### PR TITLE
docs(field-guide): expand hw-foundations pages with visuals + sections

### DIFF
--- a/docs/reference/alan-turing.md
+++ b/docs/reference/alan-turing.md
@@ -4,7 +4,7 @@ title: Alan Turing
 entry_type: person
 category: hw-people
 description: Alan Turing (1912–1954) was a British mathematician and logician whose 1936 model of computation defined what a general-purpose computer is and laid the theoretical foundation for the modern stored-program machine.
-keywords: Alan Turing, Turing machine, computability, Bletchley Park, theoretical computer science, stored-program computer
+keywords: Alan Turing, Turing machine, computability, Bletchley Park, Enigma, Turing test, theoretical computer science, stored-program computer, universal machine
 aka: [Alan Turing, Turing]
 autolink: true
 infobox:
@@ -20,6 +20,33 @@ cite_urls:
 **Turing machine** defined what it means for a problem to be computable and framed the idea
 of a single machine that can run any program.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A life-and-work timeline of Alan Turing: born in 1912, he published On Computable Numbers describing the universal machine in 1936, led Enigma code-breaking at Bletchley Park from 1939 to 1945, proposed the Turing test in 1950, and died in 1954." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="66" x2="440" y2="66" stroke="currentColor" stroke-width="1.4"/>
+  <g stroke="currentColor" fill="currentColor" stroke-width="1.2">
+    <circle cx="50" cy="66" r="4" fill-opacity="0.15"/>
+    <circle cx="160" cy="66" r="6" fill="currentColor"/>
+    <circle cx="260" cy="66" r="5" fill-opacity="0.15"/>
+    <circle cx="360" cy="66" r="5" fill-opacity="0.15"/>
+    <circle cx="430" cy="66" r="4" fill-opacity="0.15"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="50" y="50" font-size="9" font-weight="600">1912</text>
+    <text x="50" y="86" font-size="8">born</text>
+    <text x="160" y="50" font-size="9" font-weight="600">1936</text>
+    <text x="160" y="86" font-size="8">universal machine</text>
+    <text x="260" y="50" font-size="9" font-weight="600">1939&#8211;45</text>
+    <text x="260" y="86" font-size="8">Bletchley Park</text>
+    <text x="360" y="50" font-size="9" font-weight="600">1950</text>
+    <text x="360" y="86" font-size="8">Turing test</text>
+    <text x="430" y="50" font-size="9" font-weight="600">1954</text>
+    <text x="430" y="86" font-size="8">died</text>
+    <text x="235" y="112" font-size="8" fill-opacity="0.9">one machine, any program &#8212; the idea underneath every general-purpose computer</text>
+  </g>
+</svg>
+<figcaption>Turing's arc from the 1936 universal machine through wartime code-breaking to the Turing test: a single thread that turned "computation" from a human activity into something a machine could, in principle, do for any task.</figcaption>
+</figure>
+
 ## Life and work
 
 In his 1936 paper "On Computable Numbers," Turing described a simple abstract device — a tape,
@@ -29,6 +56,13 @@ programmable computer.[^wiki] During the Second World War he led code-breaking w
 Bletchley Park, helping build electromechanical machines that broke the German Enigma
 cipher. After the war he contributed to early stored-program computer designs and to the
 foundations of artificial intelligence, proposing the test that bears his name.[^wiki]
+
+| Year | Milestone |
+|------|-----------|
+| 1936 | "On Computable Numbers" defines the universal machine |
+| 1939–45 | Leads Enigma code-breaking at Bletchley Park |
+| 1948–49 | Contributes to early stored-program computer design |
+| 1950 | Proposes the Turing test for machine intelligence |
 
 ## Why they matter
 
@@ -42,7 +76,9 @@ underpin all general-purpose [computer hardware](/reference/computer-hardware/).
 ## Legacy
 
 The Turing Award, computing's highest honour, is named after him, and his model remains the
-standard reference for what computers can and cannot, in principle, do.
+standard reference for what computers can and cannot, in principle, do. Every time GopherTrunk
+loads a new protocol decoder as software on the same hardware, it is exercising exactly the
+universality Turing proved possible.
 
 ## Sources
 

--- a/docs/reference/all-in-one-computer.md
+++ b/docs/reference/all-in-one-computer.md
@@ -4,12 +4,13 @@ title: All-in-one computer
 entry_type: hardware
 category: hw-personal-computers
 description: An all-in-one computer integrates the whole PC — CPU, memory, storage, and components — into the same enclosure as the display, leaving only a keyboard, mouse, and power cable on the desk.
-keywords: all-in-one, AIO computer, iMac, integrated PC, desktop replacement
+keywords: all-in-one, AIO computer, iMac, integrated PC, desktop replacement, laptop-class parts, space-saving PC
 aka: [AIO, All-in-one PC]
 infobox:
   - { label: Type, value: Personal computer }
   - { label: Form, value: PC built into the monitor }
   - { label: Internals, value: Often laptop-class parts }
+  - { label: Upgrades, value: Very limited }
   - { label: Examples, value: Apple iMac, many vendor AIOs }
 see_also: [personal-computer, desktop-computer, computer-monitor, laptop, mini-pc]
 related_lessons:
@@ -20,13 +21,53 @@ cite_urls:
 
 An **all-in-one computer** (AIO) integrates the whole computer — processor, memory, storage, and other components — into the same enclosure as the [display](/reference/computer-monitor/), so the only things on the desk are a [keyboard](/reference/keyboard/), a [mouse](/reference/mouse/), and a power cable.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 190" role="img" aria-label="An all-in-one computer shown in front profile: the display panel and the PC internals — CPU, RAM, and SSD — share a single enclosure on a stand, leaving only a keyboard, a mouse, and one power cable on the desk." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.4">
+    <rect x="120" y="22" width="220" height="120" rx="4"/>
+    <rect x="130" y="32" width="200" height="80" fill="currentColor" fill-opacity="0.08"/>
+    <rect x="130" y="118" width="200" height="16" fill="currentColor" fill-opacity="0.16"/>
+    <path d="M218 142 L218 162 M242 142 L242 162 M196 162 H264" stroke-width="1.2"/>
+  </g>
+  <g stroke="currentColor" fill="none" stroke-width="1.2">
+    <rect x="150" y="170" width="92" height="14" rx="2"/>
+    <ellipse cx="272" cy="177" rx="10" ry="8"/>
+    <path d="M340 96 C398 96 410 140 410 184"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="230" y="74" font-size="9" fill-opacity="0.75">display</text>
+    <text x="166" y="130" font-size="8">CPU</text>
+    <text x="230" y="130" font-size="8">RAM</text>
+    <text x="296" y="130" font-size="8">SSD</text>
+    <text x="196" y="181" font-size="7.5">keyboard</text>
+    <text x="272" y="164" font-size="7.5">mouse</text>
+    <text x="410" y="177" font-size="7.5">power</text>
+    <text x="230" y="14" font-size="8" fill-opacity="0.9">one enclosure holds screen &amp; computer</text>
+  </g>
+</svg>
+<figcaption>An all-in-one folds the computer behind the screen: the CPU, RAM, and storage live in the same shell as the panel, so setup is one cable and one box — at the cost of the modular internals a tower exposes.</figcaption>
+</figure>
+
 ## Overview
 
-An AIO is a [personal computer](/reference/personal-computer/) that trades the modular tower of a [desktop computer](/reference/desktop-computer/) for a single tidy unit. To fit behind the screen it usually borrows laptop-class parts: low-power [CPUs](/reference/central-processing-unit/), soldered or limited [RAM](/reference/random-access-memory/), and integrated graphics. The best-known example is Apple's iMac, but most major PC makers ship AIO models. The upside is a clean desk and easy setup; the downside is limited upgrades and the fact that a screen failure can take the whole computer with it.
+An AIO is a [personal computer](/reference/personal-computer/) that trades the modular tower of a [desktop computer](/reference/desktop-computer/) for a single tidy unit. To fit the whole machine behind the screen it usually borrows laptop-class parts: low-power [CPUs](/reference/central-processing-unit/), soldered or limited [RAM](/reference/random-access-memory/), and integrated graphics rather than a discrete card.
+
+The best-known example is Apple's iMac, but most major PC makers ship AIO models aimed at homes, offices, and public-facing counters. The upside is a clean desk and near-zero setup; the downside is limited upgrades and a shared fate — a screen failure can take the whole computer with it, and a slow CPU can't be swapped the way it can in a tower.
+
+## Form factors
+
+An AIO sits between a laptop and a tower — desktop-sized screen, laptop-grade internals, no portability:
+
+| Machine | Screen | Upgradeable | Desk footprint | Typical parts |
+|---------|--------|-------------|----------------|---------------|
+| All-in-one | Built in | Very limited | Small (one unit) | Laptop-class |
+| Desktop tower | Separate | Extensive | Large | Full desktop |
+| Mini PC | Separate | Limited | Tiny | Laptop-class |
+| Laptop | Built in | Minimal | Portable | Laptop-class |
 
 ## Where it fits
 
-An all-in-one suits reception desks, kiosks, classrooms, and homes where appearance and simplicity matter more than expandability or raw performance. If you want to upgrade parts later, a desktop tower or even a small [mini PC](/reference/mini-pc/) paired with a separate monitor gives more freedom. For a portable machine, a [laptop](/reference/laptop/) is the natural choice.
+An all-in-one suits reception desks, kiosks, classrooms, and homes where appearance and simplicity matter more than expandability or raw performance. If you want to upgrade parts later, a desktop tower or even a small [mini PC](/reference/mini-pc/) paired with a separate [monitor](/reference/computer-monitor/) gives more freedom; for a portable machine, a [laptop](/reference/laptop/) is the natural choice. For a GopherTrunk bench an AIO works as the display-and-host in one, though its soldered memory and integrated graphics leave less headroom than a tower for many-channel decoding.
 
 ## Sources
 

--- a/docs/reference/amd.md
+++ b/docs/reference/amd.md
@@ -4,7 +4,7 @@ title: AMD
 entry_type: organization
 category: hw-organizations
 description: AMD (Advanced Micro Devices) is an American semiconductor company that designs x86 CPUs and, through its Radeon line, GPUs, competing directly with Intel and NVIDIA.
-keywords: AMD, Advanced Micro Devices, Ryzen, EPYC, Radeon, x86, CPU, GPU
+keywords: AMD, Advanced Micro Devices, Ryzen, EPYC, Radeon, x86, CPU, GPU, fabless, ATI, Xilinx
 aka: [Advanced Micro Devices]
 autolink: true
 infobox:
@@ -12,7 +12,7 @@ infobox:
   - { label: Founded, value: "1969" }
   - { label: HQ, value: Santa Clara, California, USA }
   - { label: Makes, value: x86 CPUs, GPUs }
-see_also: [central-processing-unit, graphics-processing-unit, intel, x86]
+see_also: [central-processing-unit, graphics-processing-unit, intel, x86, tsmc, semiconductor]
 cite_urls:
   - https://www.amd.com/
   - https://en.wikipedia.org/wiki/AMD
@@ -21,6 +21,33 @@ cite_urls:
 **AMD** (Advanced Micro Devices) is an American semiconductor company founded in 1969 that
 designs [x86](/reference/x86/) [CPUs](/reference/central-processing-unit/) and, through its
 Radeon brand, [GPUs](/reference/graphics-processing-unit/).[^wiki]
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A timeline of AMD from its 1969 founding as an Intel-compatible second source, through the 2006 acquisition of the graphics company ATI, the 2017 launch of the Zen-based Ryzen and EPYC processors, to the 2022 acquisition of the FPGA maker Xilinx." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="64" x2="440" y2="64" stroke="currentColor" stroke-width="1.4"/>
+  <g stroke="currentColor" fill="currentColor" stroke-width="1.2">
+    <circle cx="60" cy="64" r="5" fill-opacity="0.15"/>
+    <circle cx="185" cy="64" r="5" fill-opacity="0.15"/>
+    <circle cx="310" cy="64" r="6" fill="currentColor"/>
+    <circle cx="410" cy="64" r="5" fill-opacity="0.15"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="60" y="48" font-size="9" font-weight="600">1969</text>
+    <text x="60" y="84" font-size="8">founded</text>
+    <text x="60" y="95" font-size="8">Intel 2nd source</text>
+    <text x="185" y="48" font-size="9" font-weight="600">2006</text>
+    <text x="185" y="84" font-size="8">buys ATI</text>
+    <text x="185" y="95" font-size="8">(Radeon GPUs)</text>
+    <text x="310" y="48" font-size="9" font-weight="600">2017</text>
+    <text x="310" y="84" font-size="8">Zen: Ryzen</text>
+    <text x="310" y="95" font-size="8">&amp; EPYC</text>
+    <text x="410" y="48" font-size="9" font-weight="600">2022</text>
+    <text x="410" y="84" font-size="8">buys Xilinx</text>
+    <text x="410" y="95" font-size="8">(FPGAs)</text>
+  </g>
+</svg>
+<figcaption>AMD grew from a 1969 Intel-compatible second source into a full CPU and GPU competitor, absorbing ATI's graphics in 2006, retaking the performance lead with the Zen-based Ryzen and EPYC in 2017, and adding Xilinx's programmable logic in 2022.</figcaption>
+</figure>
 
 ## Overview
 
@@ -34,12 +61,25 @@ Unlike a traditional integrated manufacturer, AMD is "fabless" — it designs ch
 contracts their fabrication to foundries such as [TSMC](/reference/tsmc/), letting it focus
 investment on design rather than building plants.
 
-## Why it matters
+## Product lines
+
+AMD's catalogue splits cleanly into a few families, each aimed at a different market:
+
+| Product line | What it is |
+|--------------|------------|
+| Ryzen | x86 CPUs for desktops and laptops |
+| EPYC | Many-core x86 CPUs for servers and data centers |
+| Radeon | GPUs for graphics and compute |
+| Instinct | Data-center GPU accelerators for AI/HPC |
+| Versal / Xilinx | FPGAs and adaptive SoCs (from the 2022 acquisition) |
+
+## Where it fits
 
 AMD keeps the x86 market competitive with [Intel](/reference/intel/), and its EPYC server
 chips and Radeon GPUs are common in workstations and data centers. For compute-heavy SDR
 work — running many decode channels or DSP on a single host — a high-core-count AMD CPU is
-a frequent choice.
+a frequent choice, and the Xilinx FPGAs it now owns are the same class of programmable logic
+found inside many software-defined radios' front ends.
 
 ## Sources
 

--- a/docs/reference/android.md
+++ b/docs/reference/android.md
@@ -4,7 +4,7 @@ title: Android
 entry_type: concept
 category: hw-mobile
 description: Android is the Linux-based, open-source mobile operating system developed by Google, running on the majority of the world's smartphones and tablets as well as watches, TVs, and embedded devices.
-keywords: Android, Google, AOSP, Linux mobile, smartphone OS, ART runtime, Kotlin, Java, app store
+keywords: Android, Google, AOSP, Linux mobile, smartphone OS, ART runtime, Kotlin, Java, app store, Wear OS
 autolink: true
 infobox:
   - { label: Type, value: Mobile operating system }
@@ -20,15 +20,56 @@ cite_urls:
   - https://en.wikipedia.org/wiki/Android_(operating_system)
 ---
 
-**Android** is the Linux-based, open-source [mobile operating system](/reference/mobile-operating-system/) developed by Google, running on most of the world's smartphones and tablets.[^wiki]
+**Android** is the Linux-based, open-source [mobile operating system](/reference/mobile-operating-system/) developed by Google, running on most of the world's smartphones and tablets as well as watches, TVs, and embedded devices.[^wiki]
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 190" role="img" aria-label="The Android software stack drawn as layers. From the bottom: the Linux kernel with device drivers, a hardware abstraction layer, native libraries beside the ART managed runtime, the Java-based application framework, and finally user apps at the top. Each layer only talks to the ones directly around it." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="currentColor" font-family="ui-sans-serif, sans-serif">
+    <g fill-opacity="0.05" stroke-width="1.2">
+      <rect x="40" y="16" width="380" height="26" rx="3"/>
+      <rect x="40" y="48" width="380" height="26" rx="3"/>
+      <rect x="40" y="80" width="185" height="26" rx="3"/>
+      <rect x="235" y="80" width="185" height="26" rx="3"/>
+      <rect x="40" y="112" width="380" height="26" rx="3"/>
+      <rect x="40" y="144" width="380" height="26" rx="3"/>
+    </g>
+    <g stroke="none" text-anchor="middle" font-size="9.5">
+      <text x="230" y="33">Apps &#183; Play Store &amp; sideloaded</text>
+      <text x="230" y="65">Java application framework (Activities, services)</text>
+      <text x="132" y="97">Native libraries</text>
+      <text x="327" y="97">ART managed runtime</text>
+      <text x="230" y="129">Hardware abstraction layer (HAL)</text>
+      <text x="230" y="161">Linux kernel &#183; drivers &#183; power &amp; security</text>
+    </g>
+  </g>
+</svg>
+<figcaption>Android is a stack of layers: a Linux kernel at the base drives the hardware, a HAL and native libraries sit above it, the ART runtime executes app bytecode, and the Java framework exposes the APIs that user apps are written against.</figcaption>
+</figure>
 
 ## Overview
 
-Android is built on the Linux kernel with a managed runtime (ART) on top; apps are written mainly in Kotlin or Java against Google's SDK. The core platform is released as open source (the Android Open Source Project, AOSP), which lets handset makers ship their own variants, while Google layers proprietary services and the Play Store on top. Beyond phones it powers watches (Wear OS), TVs, cars, and embedded gear. It runs largely on [Arm](/reference/arm-architecture/)-based [SoCs](/reference/system-on-a-chip/).
+Android is built on the Linux kernel with a managed runtime (ART) on top; apps are written mainly in Kotlin or Java against Google's SDK and compiled to bytecode that ART executes. The core platform is released as open source — the Android Open Source Project, AOSP — which lets handset makers ship their own variants, while Google layers proprietary services and the Play Store on top.
+
+Because the source is open and the kernel is Linux, Android is unusually adaptable. Beyond phones it powers watches (Wear OS), TVs, cars (Android Auto/Automotive), and embedded gear, and it runs largely on [Arm](/reference/arm-architecture/)-based [SoCs](/reference/system-on-a-chip/). That openness is also its main tension: dozens of vendors and long update tails produce *fragmentation* across versions and devices that developers must design around.
+
+## Android vs iOS
+
+The two dominant mobile platforms differ most in how open and how uniform they are:
+
+| Aspect | Android | iOS |
+|--------|---------|-----|
+| Source model | Open (AOSP) | Closed |
+| Vendors | Many | Apple only |
+| Kernel | Linux | Darwin/XNU |
+| App languages | Kotlin, Java | Swift, Objective-C |
+| Install sources | Store + sideload | App Store (curated) |
+| Fragmentation | High | Low |
+
+Android trades Apple's uniformity for reach and flexibility; iOS trades Android's variety for a single tightly controlled target.
 
 ## Where it fits
 
-Android is the open counterweight to Apple's [iOS](/reference/ios/): more device variety and more openness, at the cost of fragmentation across versions and vendors. Its Linux foundation and sideloading make it the more hackable of the two — it is at least conceivable to drive an SDR dongle and a [mobile app](/reference/mobile-app-development/) front end from a rooted Android phone, though GopherTrunk's heavy decode pipeline still prefers a dedicated capture node.
+Android is the open counterweight to Apple's [iOS](/reference/ios/): more device variety and more openness, at the cost of fragmentation across versions and vendors. Its Linux foundation and sideloading make it the more hackable of the two — it is at least conceivable to drive an SDR dongle and a [mobile app](/reference/mobile-app-development/) front end from a rooted Android phone, though GopherTrunk's heavy decode pipeline still prefers a dedicated capture node with a phone acting as a remote web console.
 
 ## Sources
 

--- a/docs/reference/arduino-company.md
+++ b/docs/reference/arduino-company.md
@@ -4,7 +4,7 @@ title: Arduino (company)
 entry_type: organization
 category: hw-organizations
 description: Arduino is an open-source hardware company that makes the Arduino microcontroller boards and development environment, popularising electronics for makers and beginners.
-keywords: Arduino, open-source hardware, microcontroller board, maker, Massimo Banzi, IDE
+keywords: Arduino, open-source hardware, microcontroller board, maker, Massimo Banzi, IDE, ATmega, shield
 aka: [Arduino LLC, Arduino SA]
 autolink: false
 infobox:
@@ -12,7 +12,7 @@ infobox:
   - { label: Founded, value: "2005" }
   - { label: HQ, value: Italy }
   - { label: Makes, value: Arduino microcontroller boards and IDE }
-see_also: [arduino, massimo-banzi, microcontroller]
+see_also: [arduino, massimo-banzi, microcontroller, avr-atmega, internet-of-things]
 related_lessons:
   - { title: "Arduino", url: /learn/intro-hardware/arduino/ }
 cite_urls:
@@ -24,25 +24,66 @@ cite_urls:
 [Arduino](/reference/arduino/) [microcontroller](/reference/microcontroller/) boards and the
 accompanying development environment.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 150" role="img" aria-label="A map of what Arduino makes. A central Arduino node connects to three things it releases as open source: the physical boards built around an ATmega microcontroller, the friendly Arduino IDE and libraries, and the open board designs, which together feed a large maker ecosystem of clones, shields, and tutorials." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.2">
+    <line x1="90" y1="75" x2="220" y2="40"/>
+    <line x1="90" y1="75" x2="220" y2="75"/>
+    <line x1="90" y1="75" x2="220" y2="110"/>
+    <line x1="300" y1="40" x2="360" y2="75"/>
+    <line x1="300" y1="75" x2="360" y2="75"/>
+    <line x1="300" y1="110" x2="360" y2="75"/>
+  </g>
+  <g stroke="currentColor" fill="currentColor" fill-opacity="0.12" stroke-width="1.2">
+    <rect x="20" y="60" width="72" height="30" rx="4"/>
+    <rect x="222" y="26" width="80" height="28" rx="4"/>
+    <rect x="222" y="61" width="80" height="28" rx="4"/>
+    <rect x="222" y="96" width="80" height="28" rx="4"/>
+    <rect x="360" y="60" width="86" height="30" rx="4"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle" font-size="9">
+    <text x="56" y="79" font-weight="600">Arduino</text>
+    <text x="262" y="44">board (ATmega)</text>
+    <text x="262" y="79">IDE &amp; libraries</text>
+    <text x="262" y="114">open designs</text>
+    <text x="403" y="79">maker ecosystem</text>
+  </g>
+  <text x="230" y="144" font-size="8" fill="currentColor" text-anchor="middle" fill-opacity="0.9">everything released open source — anyone may study, copy, and extend it</text>
+</svg>
+<figcaption>Arduino pairs a simple microcontroller board with a friendly IDE and releases both as open source, so a broad ecosystem of compatible clones, add-on shields, and tutorials could grow around it.</figcaption>
+</figure>
+
 ## Overview
 
 Arduino began around 2005 at a design school in Ivrea, Italy, from a project led by
 [Massimo Banzi](/reference/massimo-banzi/) and collaborators who wanted an easy, cheap way
 for artists and students to build interactive electronics. The result paired a simple
-microcontroller board with a friendly programming environment, and released both the board
-designs and software as open source.[^home]
+microcontroller board — early boards built around Atmel's
+[AVR ATmega](/reference/avr-atmega/) chips — with a friendly programming environment, and
+released both the board designs and software as open source.[^home]
 
 That openness let others freely study, copy, and extend the platform, fueling a huge maker
 ecosystem of compatible boards, shields, and tutorials. The company designs and sells
 official boards and maintains the Arduino IDE and libraries.
 
-## Why it matters
+## What they make
+
+The Arduino line spans a few board families plus the software that ties them together:
+
+| Product | What it is |
+|---------|------------|
+| Uno / Nano | Classic 8-bit ATmega boards for learning and small projects |
+| Mega | Larger board with many I/O pins |
+| MKR / Nano 33 | 32-bit boards with wireless for IoT |
+| Arduino IDE | The editor, compiler, and library manager |
+
+## Where it fits
 
 Arduino made microcontroller programming approachable for people without an electronics
 background, and its boards are a common starting point for sensors, automation, and small
 embedded projects. In an SDR context, an Arduino is a natural choice for the simple control
 glue around a receiver — switching an antenna relay, reading a sensor, or driving status
-LEDs.
+LEDs — while heavier signal processing happens on a host computer nearby.
 
 ## Sources
 

--- a/docs/reference/arduino.md
+++ b/docs/reference/arduino.md
@@ -3,8 +3,8 @@ slug: arduino
 title: Arduino
 entry_type: hardware
 category: hw-microcontrollers
-description: Arduino is a widely used family of beginner-friendly microcontroller boards and the open-source ecosystem of tools and code built around them.
-keywords: Arduino, sketch, Arduino IDE, shield, 8-bit microcontroller, open source hardware, AVR
+description: Arduino is a widely used family of beginner-friendly microcontroller boards and the open-source ecosystem of tools, libraries, and code built around them, centred on the simple "sketch" programming model.
+keywords: Arduino, sketch, Arduino IDE, shield, 8-bit microcontroller, open source hardware, AVR, ATmega328P, Arduino Uno, GPIO
 aka: [Arduino]
 autolink: true
 infobox:
@@ -13,7 +13,7 @@ infobox:
   - { label: Memory, value: Kilobytes of RAM and flash }
   - { label: Software, value: Arduino IDE (sketches) }
   - { label: License, value: Open source }
-see_also: [microcontroller, esp32, gpio, single-board-computer, firmware]
+see_also: [microcontroller, avr-atmega, esp32, gpio, single-board-computer, firmware]
 related_lessons:
   - { title: "Arduino", url: /learn/intro-hardware/arduino/ }
 cite_urls:
@@ -22,13 +22,52 @@ cite_urls:
 
 **Arduino** is a widely used family of beginner-friendly [microcontroller](/reference/microcontroller/) boards and the open-source ecosystem of tools and code built around them.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 180" role="img" aria-label="Top view of a classic Arduino Uno board. Along the top edge is a header of digital input and output pins; along the bottom edge are power and analog input pins. A USB port and a barrel power jack sit on the left, and the 8-bit ATmega328P microcontroller is in the centre, wired to every header pin." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.3">
+    <rect x="40" y="34" width="380" height="112" rx="6" fill-opacity="0" stroke-opacity="0.8"/>
+    <rect x="20" y="60" width="26" height="26" rx="2" fill="currentColor" fill-opacity="0.12"/>
+    <rect x="20" y="98" width="24" height="20" rx="3" fill="currentColor" fill-opacity="0.12"/>
+    <rect x="196" y="74" width="70" height="34" rx="2" fill="currentColor" fill-opacity="0.12"/>
+  </g>
+  <g stroke="currentColor" stroke-width="1.1" fill="currentColor" fill-opacity="0.18">
+    <rect x="70" y="40" width="10" height="8"/><rect x="86" y="40" width="10" height="8"/><rect x="102" y="40" width="10" height="8"/><rect x="118" y="40" width="10" height="8"/><rect x="134" y="40" width="10" height="8"/><rect x="150" y="40" width="10" height="8"/><rect x="166" y="40" width="10" height="8"/><rect x="182" y="40" width="10" height="8"/><rect x="198" y="40" width="10" height="8"/><rect x="214" y="40" width="10" height="8"/>
+    <rect x="250" y="132" width="10" height="8"/><rect x="266" y="132" width="10" height="8"/><rect x="282" y="132" width="10" height="8"/><rect x="298" y="132" width="10" height="8"/><rect x="314" y="132" width="10" height="8"/><rect x="330" y="132" width="10" height="8"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="150" y="26" font-size="8.5">DIGITAL 0&#8211;13 (GPIO / PWM)</text>
+    <text x="231" y="94" font-size="8.5" font-weight="600">ATmega328P</text>
+    <text x="231" y="105" font-size="7.5" fill-opacity="0.85">8-bit AVR core</text>
+    <text x="33" y="55" font-size="7.5">USB</text>
+    <text x="32" y="128" font-size="7.5">PWR</text>
+    <text x="290" y="152" font-size="8.5">POWER &amp; ANALOG A0&#8211;A5</text>
+  </g>
+</svg>
+<figcaption>A classic Arduino Uno: an 8-bit ATmega328P microcontroller at the centre, its pins broken out to labelled header rows. You wire sensors and actuators to those pins, write a sketch, and flash it over USB — with "shield" boards stacking onto the same headers to add features.</figcaption>
+</figure>
+
 ## Overview
 
-An Arduino program is called a *sketch*. The simple Arduino IDE, plus a huge library and "shield" ecosystem of plug-in add-on boards, is what made microcontrollers approachable to hobbyists and students. Classic Arduino boards are 8-bit and modest in speed and memory, but that is enough for sensors, motors, and small projects.
+An Arduino program is called a *sketch*. The simple Arduino IDE — with its two-function skeleton of `setup()` and `loop()` — plus a huge library and "shield" ecosystem of plug-in add-on boards, is what made microcontrollers approachable to hobbyists and students. Classic boards are 8-bit and modest in speed and memory, but that is enough for sensors, motors, and small projects.
+
+The project began in Italy in 2005 as open-source hardware: the board schematics, the IDE, and the core libraries are all freely available, which spawned countless clones and derivatives. That openness is central to Arduino's identity — the name refers as much to the software and community as to any one board.
+
+The classic lineup runs on Microchip's [AVR/ATmega](/reference/avr-atmega/) chips (the Uno's ATmega328P is the icon), while newer official boards move to 32-bit [ARM Cortex-M](/reference/arm-cortex-m/) parts and other cores for more speed and memory.
+
+## Board line-up
+
+Arduino spans a range of form factors and cores, but they share the same sketch model and IDE:
+
+| Board | Core | Clock | Flash | Notable |
+|-------|------|-------|-------|---------|
+| Uno / Nano | 8-bit AVR (ATmega328P) | 16 MHz | 32 KB | The classic beginner board |
+| Mega 2560 | 8-bit AVR (ATmega2560) | 16 MHz | 256 KB | Many I/O pins |
+| Micro / Leonardo | 8-bit AVR (ATmega32U4) | 16 MHz | 32 KB | Native USB |
+| Nano 33 / Portenta | 32-bit ARM Cortex-M | 64+ MHz | 256 KB+ | BLE, more RAM |
 
 ## Where it fits
 
-Arduino sits at the gentle end of embedded computing: you wire components to its [GPIO](/reference/gpio/) pins, write a sketch, and flash it onto the board. The ecosystem's tooling has spread well beyond the original boards — many other microcontrollers, including the [ESP32](/reference/esp32/), can be programmed with the Arduino IDE too. These tiny boards drive the kinds of small radios that fill the airwaves GopherTrunk listens to.
+Arduino sits at the gentle end of embedded computing: you wire components to its [GPIO](/reference/gpio/) pins, write a sketch, and flash it onto the board. The ecosystem's tooling has spread well beyond the original boards — many other microcontrollers, including the [ESP32](/reference/esp32/), can be programmed with the Arduino IDE too. In an SDR context an Arduino makes a handy GPIO helper — switching an antenna relay, reading a temperature [sensor](/reference/sensor/), or blinking a status light beside a capture node — while GopherTrunk itself runs on a full computer. These tiny boards also drive the kinds of small radios that fill the airwaves GopherTrunk listens to.
 
 ## Sources
 

--- a/docs/reference/arm-architecture.md
+++ b/docs/reference/arm-architecture.md
@@ -3,30 +3,78 @@ slug: arm-architecture
 title: ARM architecture
 entry_type: concept
 category: hw-foundations
-description: ARM is a family of RISC instruction set architectures licensed by Arm Holdings, prized for power efficiency and dominant in phones, tablets, and embedded devices.
-keywords: ARM architecture, RISC, Arm Holdings, AArch64, low power, mobile, embedded, Apple Silicon
+description: ARM is a family of RISC instruction set architectures licensed by Arm Holdings, prized for power efficiency and dominant in phones, tablets, embedded devices, and increasingly laptops and servers.
+keywords: ARM architecture, RISC, Arm Holdings, AArch64, ARM64, low power, mobile, embedded, Apple Silicon, SoC
 aka: [ARM, AArch64]
 autolink: true
 infobox:
   - { label: Type, value: ISA (RISC) }
   - { label: Licensed by, value: Arm Holdings }
+  - { label: 64-bit, value: "AArch64 (ARMv8, 2011)" }
   - { label: Known for, value: Power efficiency }
   - { label: Dominates, value: Mobile & embedded }
-see_also: [instruction-set-architecture, x86, risc-v, central-processing-unit, raspberry-pi, semiconductor]
+see_also: [instruction-set-architecture, x86, risc-v, central-processing-unit, raspberry-pi, system-on-a-chip]
 cite_urls:
   - https://en.wikipedia.org/wiki/ARM_architecture_family
 ---
 
-**ARM** is a family of RISC [instruction set architectures](/reference/instruction-set-architecture/) licensed by Arm Holdings, known above all for power efficiency.[^wiki]
+**ARM** is a family of RISC [instruction set architectures](/reference/instruction-set-architecture/) licensed by Arm Holdings, known above all for power efficiency and its reach across phones, embedded devices, and — increasingly — laptops and servers.[^wiki]
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 180" role="img" aria-label="Arm Holdings designs the ARM instruction set and core blueprints, then licenses them to many chip makers who each integrate ARM cores into their own systems-on-a-chip for phones, single-board computers, laptops, and servers." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.3">
+    <rect x="160" y="14" width="140" height="34" rx="4" fill="currentColor" fill-opacity="0.12"/>
+    <rect x="20" y="88" width="90" height="30" rx="4"/>
+    <rect x="130" y="88" width="90" height="30" rx="4"/>
+    <rect x="240" y="88" width="90" height="30" rx="4"/>
+    <rect x="350" y="88" width="90" height="30" rx="4"/>
+    <line x1="230" y1="48" x2="65" y2="88"/>
+    <line x1="230" y1="48" x2="175" y2="88"/>
+    <line x1="230" y1="48" x2="285" y2="88"/>
+    <line x1="230" y1="48" x2="395" y2="88"/>
+    <rect x="20" y="140" width="420" height="26" rx="4" stroke-dasharray="3 3" stroke-opacity="0.7"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="230" y="28" font-size="9" font-weight="600">Arm Holdings</text>
+    <text x="230" y="40" font-size="8" fill-opacity="0.85">designs ISA + core IP</text>
+    <text x="65" y="100" font-size="8">Qualcomm</text>
+    <text x="65" y="111" font-size="7.5" fill-opacity="0.8">phone SoC</text>
+    <text x="175" y="100" font-size="8">Apple</text>
+    <text x="175" y="111" font-size="7.5" fill-opacity="0.8">M-series</text>
+    <text x="285" y="100" font-size="8">Broadcom</text>
+    <text x="285" y="111" font-size="7.5" fill-opacity="0.8">Raspberry Pi</text>
+    <text x="395" y="100" font-size="8">Ampere</text>
+    <text x="395" y="111" font-size="7.5" fill-opacity="0.8">server CPU</text>
+    <text x="230" y="157" font-size="8">licensees integrate ARM cores into their own silicon</text>
+  </g>
+</svg>
+<figcaption>Arm Holdings sells the architecture and core blueprints but builds no chips itself; dozens of licensees drop ARM cores into their own systems-on-a-chip, which is how one efficient instruction set ended up in nearly every phone as well as single-board computers, Apple laptops, and cloud servers.</figcaption>
+</figure>
 
 ## Overview
 
-ARM follows the RISC philosophy of a small set of simple, fixed-length instructions, which keeps chips lean and power-thrifty. Arm Holdings designs the architecture and core blueprints but does not make chips itself; instead it *licenses* them to companies that build their own [SoCs](/reference/system-on-a-chip/) around ARM cores. The 64-bit variant is AArch64. This licensing model put ARM cores in nearly every smartphone, in countless embedded devices, and increasingly in laptops and servers.
+ARM follows the RISC philosophy of a small set of simple, fixed-length instructions, which keeps decode logic modest and power draw low. Arm Holdings designs the architecture and reference core blueprints but does not manufacture chips itself; instead it *licenses* them — either a ready-made core design or an architecture licence to build a custom implementation — to companies that integrate ARM cores into their own [systems-on-a-chip](/reference/system-on-a-chip/).
+
+The current 64-bit variant, introduced with ARMv8 in 2011, is called **AArch64** (or ARM64). It runs alongside the older 32-bit AArch32 mode on most application-class cores. This licensing model, combined with a strong performance-per-watt story, put ARM cores in nearly every smartphone, in vast numbers of embedded and IoT devices, in Apple's desktop and laptop Macs, and in a growing share of the server and cloud market.
+
+## How it compares
+
+The clearest way to place ARM is against the incumbent [x86](/reference/x86/) and the open [RISC-V](/reference/risc-v/):
+
+| Trait | ARM | x86 | RISC-V |
+|-------|-----|-----|--------|
+| Style | RISC | CISC | RISC |
+| Licensing | Paid licence from Arm | Intel/AMD only | Open, royalty-free |
+| Instruction length | Fixed (mostly) | Variable | Fixed |
+| Traditional stronghold | Mobile & embedded | PC & server | Research & embedded |
+| 64-bit name | AArch64 | x86-64 | RV64 |
+
+The fixed-length, load/store design shared by ARM and RISC-V is what makes their decoders simpler than x86's variable-length instructions — one reason the RISC families started in low-power niches, though ARM's reach now extends well up into high-performance computing.
 
 ## Where it fits
 
-ARM's efficiency made it the default for battery-powered and embedded computing, the opposite end of the spectrum from where [x86](/reference/x86/) grew up; [RISC-V](/reference/risc-v/) is a newer open RISC rival. The [Raspberry Pi](/reference/raspberry-pi/) and most single-board computers use ARM [CPUs](/reference/central-processing-unit/), which is exactly why a low-power GopherTrunk capture node by the antenna usually runs on ARM rather than x86.
+ARM's efficiency made it the default for battery-powered and embedded computing, the opposite end of the spectrum from where x86 grew up. The [Raspberry Pi](/reference/raspberry-pi/) and most single-board computers use ARM [CPUs](/reference/central-processing-unit/), which is exactly why a low-power GopherTrunk capture node sitting by the antenna usually runs on ARM rather than x86 — Go cross-compiles the same decoder source to an AArch64 target with no code changes.
 
 ## Sources
 
-[^wiki]: [ARM architecture family](https://en.wikipedia.org/wiki/ARM_architecture_family) — Wikipedia, on ARM, its RISC design, and licensing model.
+[^wiki]: [ARM architecture family](https://en.wikipedia.org/wiki/ARM_architecture_family) — Wikipedia, on ARM, its RISC design, the AArch64 64-bit mode, and Arm Holdings' licensing model.

--- a/docs/reference/arm-cortex-m.md
+++ b/docs/reference/arm-cortex-m.md
@@ -3,8 +3,8 @@ slug: arm-cortex-m
 title: ARM Cortex-M
 entry_type: concept
 category: hw-microcontrollers
-description: ARM Cortex-M is a family of 32-bit processor cores designed for microcontrollers, prioritizing low power, deterministic interrupt handling, and small silicon area over raw throughput.
-keywords: ARM Cortex-M, Cortex-M0, Cortex-M4, Cortex-M7, Thumb, NVIC, microcontroller core, embedded processor
+description: ARM Cortex-M is a family of 32-bit processor cores designed for microcontrollers, prioritizing low power, deterministic interrupt handling, and small silicon area over raw throughput; chip vendors license the core and wrap it in their own memory and peripherals.
+keywords: ARM Cortex-M, Cortex-M0, Cortex-M4, Cortex-M7, Thumb, NVIC, microcontroller core, embedded processor, licensed IP, ARM Holdings
 aka: [Cortex-M]
 autolink: true
 infobox:
@@ -13,7 +13,7 @@ infobox:
   - { label: Designer, value: Arm Holdings }
   - { label: Members, value: M0, M0+, M3, M4, M7, M23, M33 }
   - { label: For, value: Microcontrollers }
-see_also: [microcontroller, stm32, rp2040, teensy, real-time-operating-system, interrupt]
+see_also: [microcontroller, arm-architecture, stm32, rp2040, teensy, real-time-operating-system]
 related_lessons:
   - { title: "What is a microcontroller?", url: /learn/intro-hardware/what-is-a-microcontroller/ }
   - { title: "MCU programming and trade-offs", url: /learn/intro-hardware/mcu-programming-and-tradeoffs/ }
@@ -23,13 +23,59 @@ cite_urls:
 
 **ARM Cortex-M** is a family of 32-bit processor cores from Arm Holdings designed specifically for [microcontrollers](/reference/microcontroller/).[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 176" role="img" aria-label="Block diagram of a Cortex-M based chip. The 32-bit Cortex-M core and its nested vectored interrupt controller connect through a bus matrix to on-chip flash, SRAM, and a set of peripherals such as GPIO, timers, and analog-to-digital converters. Interrupt lines from the peripherals feed back into the interrupt controller." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.3">
+    <rect x="24" y="34" width="96" height="40" rx="4" fill="currentColor" fill-opacity="0.14"/>
+    <rect x="24" y="86" width="96" height="30" rx="4" fill="currentColor" fill-opacity="0.08"/>
+    <rect x="176" y="52" width="108" height="72" rx="4" fill="currentColor" fill-opacity="0.06"/>
+    <rect x="336" y="30" width="100" height="26" rx="4" fill="currentColor" fill-opacity="0.10"/>
+    <rect x="336" y="66" width="100" height="26" rx="4" fill="currentColor" fill-opacity="0.10"/>
+    <rect x="336" y="102" width="100" height="30" rx="4" fill="currentColor" fill-opacity="0.10"/>
+    <line x1="120" y1="54" x2="176" y2="70"/>
+    <line x1="120" y1="101" x2="176" y2="101"/>
+    <line x1="284" y1="70" x2="336" y2="43"/>
+    <line x1="284" y1="88" x2="336" y2="79"/>
+    <line x1="284" y1="106" x2="336" y2="115"/>
+  </g>
+  <path d="M336 118 C300 150 150 150 100 118 L100 76" stroke="currentColor" stroke-width="1" stroke-dasharray="3 3" fill="none" stroke-opacity="0.8"/>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="72" y="50" font-size="9" font-weight="600">Cortex-M</text>
+    <text x="72" y="63" font-size="7.5" fill-opacity="0.85">32-bit core</text>
+    <text x="72" y="104" font-size="8">NVIC</text>
+    <text x="230" y="86" font-size="8.5" font-weight="600">Bus matrix</text>
+    <text x="230" y="99" font-size="7.5" fill-opacity="0.85">AHB / APB</text>
+    <text x="386" y="46" font-size="8">Flash</text>
+    <text x="386" y="82" font-size="8">SRAM</text>
+    <text x="386" y="115" font-size="8">GPIO &#183; timers</text>
+    <text x="386" y="126" font-size="7.5" fill-opacity="0.85">ADC &#183; UART</text>
+    <text x="205" y="164" font-size="7.5" fill-opacity="0.85">dashed: peripheral interrupt lines &#8594; NVIC</text>
+  </g>
+</svg>
+<figcaption>A Cortex-M chip: the 32-bit core plus its nested vectored interrupt controller (NVIC) reach flash, SRAM, and peripherals over a bus matrix. Peripherals raise interrupts straight into the NVIC, giving the deterministic, low-latency response that defines the family. Arm designs the core; each vendor adds the memory and peripherals.</figcaption>
+</figure>
+
 ## Overview
 
-Rather than chasing raw throughput, Cortex-M cores prioritize low power, small silicon area, and predictable real-time behavior. They execute the compact Thumb instruction set and include a built-in nested vectored [interrupt](/reference/interrupt/) controller (NVIC) that makes response latency deterministic. The lineup ranges from the minimal Cortex-M0/M0+ through the DSP-capable M4 and high-performance M7, plus the security-focused M23/M33. Arm licenses the core; chip vendors wrap it in their own memory and peripherals.
+Rather than chasing raw throughput, Cortex-M cores prioritize low power, small silicon area, and predictable real-time behavior. They execute the compact Thumb instruction set and include a built-in nested vectored [interrupt](/reference/interrupt/) controller (NVIC) that makes response latency deterministic. The lineup ranges from the minimal Cortex-M0/M0+ through the DSP-capable M4 and high-performance M7, plus the security-focused M23/M33.
+
+Crucially, Arm does not sell Cortex-M chips — it licenses the core as intellectual property (part of the broader [ARM architecture](/reference/arm-architecture/)) and chip vendors wrap it in their own flash, SRAM, and peripherals. That business model is why one instruction set shows up across parts from dozens of competing manufacturers.
+
+## The lineup
+
+The family trades performance for power and area in steps, all sharing the same tools and instruction set:
+
+| Core | Tier | Highlights | Typical use |
+|------|------|-----------|-------------|
+| M0 / M0+ | Minimal | Smallest, lowest power | Cheap 32-bit MCUs, [RP2040](/reference/rp2040/) |
+| M3 | Mainstream | Full Thumb-2, good all-rounder | General embedded |
+| M4 | DSP | Single-precision FPU, DSP ops | Signal-processing MCUs |
+| M7 | High-perf | Dual-issue, fast | [Teensy](/reference/teensy/) 4.x, audio |
+| M23 / M33 | Secure | TrustZone security | Connected/secure devices |
 
 ## Where it fits
 
-Because the core is licensed rather than sold as a chip, the same Cortex-M architecture underlies products from many vendors: [STM32](/reference/stm32/) from STMicroelectronics, the [RP2040](/reference/rp2040/) from Raspberry Pi, [Teensy](/reference/teensy/) boards, and NXP, Nordic, and Microchip parts. This shared architecture means tooling, debuggers, and [RTOS](/reference/real-time-operating-system/) ports are broadly portable across the ecosystem — a major reason Cortex-M dominates 32-bit embedded design.
+Because the core is licensed rather than sold as a chip, the same Cortex-M architecture underlies products from many vendors: [STM32](/reference/stm32/) from STMicroelectronics, the [RP2040](/reference/rp2040/) from Raspberry Pi, [Teensy](/reference/teensy/) boards, and NXP, Nordic, and Microchip parts. This shared architecture means tooling, debuggers, and [RTOS](/reference/real-time-operating-system/) ports are broadly portable across the ecosystem — a major reason Cortex-M dominates 32-bit embedded design. In SDR gear, Cortex-M parts commonly run the firmware inside dongles and front ends and serve as GPIO/[sensor](/reference/sensor/) helpers around a capture node, with the heavy DSP left to a larger host.
 
 ## Sources
 

--- a/docs/reference/arm-holdings.md
+++ b/docs/reference/arm-holdings.md
@@ -4,7 +4,7 @@ title: Arm Holdings
 entry_type: organization
 category: hw-organizations
 description: Arm Holdings is a British company that designs the Arm processor architecture and licenses it to chipmakers, making it the dominant CPU design in phones and embedded devices.
-keywords: Arm, Arm Holdings, ARM architecture, processor IP, licensing, Cortex, RISC
+keywords: Arm, Arm Holdings, ARM architecture, processor IP, licensing, Cortex, RISC, fabless
 aka: [Arm, ARM Ltd, Advanced RISC Machines]
 autolink: true
 infobox:
@@ -12,7 +12,7 @@ infobox:
   - { label: Founded, value: "1990" }
   - { label: HQ, value: Cambridge, England, UK }
   - { label: Makes, value: Processor architecture and core designs (IP) }
-see_also: [arm-architecture, sophie-wilson, central-processing-unit, qualcomm]
+see_also: [arm-architecture, sophie-wilson, central-processing-unit, qualcomm, tsmc, risc-v]
 cite_urls:
   - https://www.arm.com/
   - https://en.wikipedia.org/wiki/Arm_Holdings
@@ -21,6 +21,36 @@ cite_urls:
 **Arm Holdings** is a British company that designs the
 [Arm processor architecture](/reference/arm-architecture/) and licenses it to other
 chipmakers rather than manufacturing chips itself.[^wiki]
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A diagram of Arm's licensing business model. Arm designs the architecture and Cortex cores as intellectual property, licenses that IP to chip vendors such as Apple, Qualcomm, and Samsung, who integrate it into their own systems-on-chip, which are then physically manufactured by foundries like TSMC. Arm itself builds no chips." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="currentColor" fill-opacity="0.12" stroke-width="1.2">
+    <rect x="18" y="42" width="96" height="44" rx="4"/>
+    <rect x="182" y="42" width="96" height="44" rx="4"/>
+    <rect x="346" y="42" width="96" height="44" rx="4"/>
+  </g>
+  <g stroke="currentColor" fill="none" stroke-width="1.4">
+    <line x1="114" y1="64" x2="176" y2="64"/>
+    <line x1="278" y1="64" x2="340" y2="64"/>
+    <polygon points="176,64 168,60 168,68" fill="currentColor"/>
+    <polygon points="340,64 332,60 332,68" fill="currentColor"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle" font-size="9">
+    <text x="66" y="60" font-weight="600">Arm</text>
+    <text x="66" y="74" font-size="8">designs IP / Cortex cores</text>
+    <text x="230" y="60" font-weight="600">SoC vendors</text>
+    <text x="230" y="74" font-size="8">Apple, Qualcomm, Samsung</text>
+    <text x="394" y="60" font-weight="600">foundry</text>
+    <text x="394" y="74" font-size="8">TSMC fabricates</text>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle" font-size="8" fill-opacity="0.9">
+    <text x="145" y="36">licenses</text>
+    <text x="309" y="36">makes silicon</text>
+  </g>
+  <text x="230" y="112" font-size="8" fill="currentColor" text-anchor="middle" fill-opacity="0.9">Arm never builds a chip — it sells the design that everyone else builds around</text>
+</svg>
+<figcaption>Arm's pure-IP model: it designs the architecture and Cortex cores, licenses them to SoC vendors like Apple, Qualcomm, and Samsung, who in turn have foundries such as TSMC fabricate the silicon.</figcaption>
+</figure>
 
 ## Overview
 
@@ -34,12 +64,22 @@ Because Arm cores are energy-efficient, they dominate battery-powered devices. T
 majority of smartphones, tablets, and microcontrollers — and a growing share of laptops and
 servers — run Arm-based processors.
 
-## Why it matters
+## Two ways to license
+
+Arm's business rests on two kinds of licence, which suit very different customers:
+
+| Licence type | What the customer gets |
+|--------------|------------------------|
+| Core licence | A ready-made Cortex design to drop into a chip |
+| Architecture licence | The right to design a custom core (e.g. Apple's) that runs Arm code |
+
+## Where it fits
 
 Arm's licensing model spread one CPU architecture across nearly the entire mobile and
-embedded world. The single-board computers and microcontrollers used as GopherTrunk capture
-nodes — Raspberry Pis and many MCU boards — are built around Arm cores, so the same
-instruction set runs from the antenna node up to phones in your pocket.
+embedded world, and its main open-standard rival is now the royalty-free
+[RISC-V](/reference/risc-v/). The single-board computers and microcontrollers used as
+GopherTrunk capture nodes — Raspberry Pis and many MCU boards — are built around Arm cores,
+so the same instruction set runs from the antenna node up to the phones in your pocket.
 
 ## Sources
 

--- a/docs/reference/avr-atmega.md
+++ b/docs/reference/avr-atmega.md
@@ -3,16 +3,16 @@ slug: avr-atmega
 title: AVR / ATmega
 entry_type: hardware
 category: hw-microcontrollers
-description: AVR is an 8-bit RISC microcontroller architecture from Atmel (now Microchip); its ATmega line, especially the ATmega328P, powers the classic Arduino Uno and countless hobby projects.
-keywords: AVR, ATmega, ATmega328P, ATtiny, Atmel, Microchip, Arduino Uno, 8-bit RISC, AVR-GCC
+description: AVR is an 8-bit RISC microcontroller architecture from Atmel (now Microchip) with a Harvard design; its ATmega line, especially the ATmega328P, powers the classic Arduino Uno and countless hobby projects.
+keywords: AVR, ATmega, ATmega328P, ATtiny, Atmel, Microchip, Arduino Uno, 8-bit RISC, AVR-GCC, Harvard architecture
 aka: [AVR, ATmega]
 infobox:
   - { label: Type, value: 8-bit microcontroller architecture }
-  - { label: Core, value: AVR RISC }
+  - { label: Core, value: AVR RISC (Harvard) }
   - { label: Vendor, value: Atmel (now Microchip) }
   - { label: Famous part, value: ATmega328P (Arduino Uno) }
   - { label: Language, value: C, C++, assembly }
-see_also: [arduino, microcontroller, pic-microcontroller, stm32, firmware, in-system-programming]
+see_also: [arduino, microcontroller, pic-microcontroller, arm-cortex-m, firmware, in-system-programming]
 related_lessons:
   - { title: "Arduino", url: /learn/intro-hardware/arduino/ }
   - { title: "What is a microcontroller?", url: /learn/intro-hardware/what-is-a-microcontroller/ }
@@ -22,13 +22,59 @@ cite_urls:
 
 **AVR** is an 8-bit RISC [microcontroller](/reference/microcontroller/) architecture created by Atmel and now owned by Microchip; **ATmega** is its best-known product line.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 168" role="img" aria-label="Simplified Harvard architecture of an AVR chip. The 8-bit RISC CPU with its 32 registers connects over one bus to program flash memory and over a separate bus to data SRAM and EEPROM. A peripheral bus links the CPU to GPIO ports, timers, an analog-to-digital converter, and serial interfaces." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.3">
+    <rect x="176" y="30" width="108" height="46" rx="4" fill="currentColor" fill-opacity="0.14"/>
+    <rect x="24" y="34" width="104" height="38" rx="4" fill="currentColor" fill-opacity="0.08"/>
+    <rect x="332" y="26" width="104" height="24" rx="4" fill="currentColor" fill-opacity="0.08"/>
+    <rect x="332" y="56" width="104" height="24" rx="4" fill="currentColor" fill-opacity="0.08"/>
+    <rect x="176" y="108" width="108" height="34" rx="4" fill="currentColor" fill-opacity="0.06"/>
+    <rect x="24" y="112" width="104" height="26" rx="4" fill="currentColor" fill-opacity="0.10"/>
+    <rect x="332" y="108" width="104" height="34" rx="4" fill="currentColor" fill-opacity="0.10"/>
+    <line x1="128" y1="53" x2="176" y2="53"/>
+    <line x1="284" y1="45" x2="332" y2="38"/>
+    <line x1="284" y1="60" x2="332" y2="68"/>
+    <line x1="230" y1="76" x2="230" y2="108"/>
+    <line x1="176" y1="125" x2="128" y2="125"/>
+    <line x1="284" y1="125" x2="332" y2="125"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="230" y="49" font-size="9" font-weight="600">8-bit AVR CPU</text>
+    <text x="230" y="62" font-size="7.5" fill-opacity="0.85">32 registers, RISC</text>
+    <text x="76" y="50" font-size="8" font-weight="600">Program flash</text>
+    <text x="76" y="62" font-size="7.5" fill-opacity="0.85">instruction bus</text>
+    <text x="384" y="41" font-size="8">SRAM</text>
+    <text x="384" y="71" font-size="8">EEPROM</text>
+    <text x="230" y="123" font-size="8" font-weight="600">Peripheral bus</text>
+    <text x="230" y="135" font-size="7.5" fill-opacity="0.85">timers &#183; PWM</text>
+    <text x="76" y="129" font-size="8">GPIO ports</text>
+    <text x="384" y="123" font-size="8">ADC</text>
+    <text x="384" y="135" font-size="7.5" fill-opacity="0.85">UART &#183; SPI &#183; I&#178;C</text>
+  </g>
+</svg>
+<figcaption>AVR is a Harvard design: the 8-bit RISC core fetches instructions from program flash over one bus while reading and writing data in SRAM and EEPROM over another, so a fetch and a data access can happen at once. A peripheral bus hangs GPIO, timers, the ADC, and serial ports off the same core.</figcaption>
+</figure>
+
 ## Overview
 
-The AVR design pairs a simple, fast 8-bit core with on-chip flash, SRAM, and EEPROM, plus [GPIO](/reference/gpio/), timers with [PWM](/reference/pulse-width-modulation/), an [ADC](/reference/analog-to-digital-converter/), and [UART](/reference/uart/)/[SPI](/reference/spi/)/[I²C](/reference/i2c/) peripherals. Sibling lines include the tiny ATtiny and the larger ATmega. The ATmega328P is iconic because it is the chip on the original [Arduino](/reference/arduino/) Uno, which made AVR the gateway architecture for a generation of makers.
+The AVR design pairs a simple, fast 8-bit core with on-chip flash, SRAM, and EEPROM, plus [GPIO](/reference/gpio/), timers with [PWM](/reference/pulse-width-modulation/), an [ADC](/reference/analog-to-digital-converter/), and [UART](/reference/uart/)/[SPI](/reference/spi/)/[I²C](/reference/i2c/) peripherals. It is a *Harvard* RISC architecture — separate buses for program and data — so most instructions run in a single clock cycle, giving surprisingly brisk throughput for an 8-bit part.
+
+Sibling lines include the tiny ATtiny and the larger ATmega. The ATmega328P is iconic because it is the chip on the original [Arduino](/reference/arduino/) Uno, which made AVR the gateway architecture for a generation of makers.
+
+## AVR versus the alternatives
+
+Where AVR sits among common hobby and embedded cores:
+
+| Family | Bits | Core style | Note |
+|--------|------|-----------|------|
+| AVR / ATmega | 8 | RISC, Harvard | Single-cycle, Arduino default |
+| [PIC](/reference/pic-microcontroller/) | 8/16/32 | RISC | Long supply life, rival to AVR |
+| [ARM Cortex-M](/reference/arm-cortex-m/) | 32 | RISC | More compute, richer peripherals |
 
 ## Where it fits
 
-AVR shines where 8 bits are plenty: low cost, low power, and a friendly toolchain (AVR-GCC, the Arduino IDE). Code is written in [C](/reference/c-language/) or [C++](/reference/cpp-language/) and flashed via [in-system programming](/reference/in-system-programming/) over SPI. When a project needs 32-bit performance, more memory, or built-in radios, designers step up to an [STM32](/reference/stm32/) or [ESP32](/reference/esp32/); the rival 8-bit family is the [PIC](/reference/pic-microcontroller/).
+AVR shines where 8 bits are plenty: low cost, low power, and a friendly toolchain (AVR-GCC, the Arduino IDE). Code is written in [C](/reference/c-language/) or [C++](/reference/cpp-language/) and flashed via [in-system programming](/reference/in-system-programming/) over SPI. When a project needs 32-bit performance, more memory, or built-in radios, designers step up to an [STM32](/reference/stm32/) or [ESP32](/reference/esp32/); the rival 8-bit family is the [PIC](/reference/pic-microcontroller/). Around an SDR setup, an ATmega is a tidy way to toggle relays or read a [sensor](/reference/sensor/) beside a capture node — small housekeeping jobs a decode host should not be bothered with.
 
 ## Sources
 

--- a/docs/reference/banana-pi.md
+++ b/docs/reference/banana-pi.md
@@ -4,7 +4,7 @@ title: Banana Pi
 entry_type: hardware
 category: hw-sbc
 description: Banana Pi is a brand of single-board computers in the Raspberry Pi mould, notable early on for onboard SATA and gigabit Ethernet, and later for a wide range of ARM and RISC-V boards.
-keywords: Banana Pi, SATA SBC, Allwinner, gigabit Ethernet, Raspberry Pi alternative, RISC-V board, ARM single-board computer
+keywords: Banana Pi, SATA SBC, Allwinner, gigabit Ethernet, Raspberry Pi alternative, RISC-V board, ARM single-board computer, onboard storage
 infobox:
   - { label: Type, value: Single-board computer }
   - { label: CPU, value: ARM (Allwinner / others), some RISC-V }
@@ -18,15 +18,60 @@ cite_urls:
   - https://en.wikipedia.org/wiki/Banana_Pi
 ---
 
-**Banana Pi** is a brand of [single-board computers](/reference/single-board-computer/) in the [Raspberry Pi](/reference/raspberry-pi/) mould, an early Pi alternative that stood out for onboard SATA and gigabit Ethernet.[^wiki]
+**Banana Pi** is a brand of [single-board computers](/reference/single-board-computer/) in the [Raspberry Pi](/reference/raspberry-pi/) mould — an early Pi alternative that stood out for onboard SATA and gigabit Ethernet.[^wiki]
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 170" role="img" aria-label="Top view of a Banana Pi board. Along one edge sit a gigabit Ethernet jack and USB ports; a SATA data connector and its power header sit on an adjacent edge; a 40-pin GPIO header runs along the top; the ARM system-on-chip sits in the centre. The onboard SATA and gigabit Ethernet are the features that distinguished early Banana Pi boards." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.3">
+    <rect x="40" y="24" width="380" height="120" rx="6" fill-opacity="0.05" fill="currentColor"/>
+    <rect x="196" y="66" width="64" height="46" rx="3" fill-opacity="0.14" fill="currentColor"/>
+    <g stroke-width="1.1">
+      <rect x="60" y="120" width="220" height="12" rx="2"/>
+      <line x1="66" y1="120" x2="66" y2="132"/><line x1="86" y1="120" x2="86" y2="132"/>
+      <line x1="106" y1="120" x2="106" y2="132"/><line x1="126" y1="120" x2="126" y2="132"/>
+      <line x1="146" y1="120" x2="146" y2="132"/><line x1="166" y1="120" x2="166" y2="132"/>
+      <line x1="186" y1="120" x2="186" y2="132"/><line x1="206" y1="120" x2="206" y2="132"/>
+      <line x1="226" y1="120" x2="226" y2="132"/><line x1="246" y1="120" x2="246" y2="132"/>
+    </g>
+    <rect x="384" y="34" width="30" height="24" rx="2" fill-opacity="0.12" fill="currentColor"/>
+    <rect x="384" y="66" width="30" height="18" rx="2" fill-opacity="0.12" fill="currentColor"/>
+    <rect x="384" y="90" width="30" height="18" rx="2" fill-opacity="0.12" fill="currentColor"/>
+    <rect x="46" y="34" width="14" height="34" rx="2" fill-opacity="0.18" fill="currentColor"/>
+    <rect x="46" y="76" width="10" height="20" rx="2" fill-opacity="0.12" fill="currentColor"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="8.5">
+    <text x="228" y="92" text-anchor="middle" font-size="9" font-weight="600">ARM SoC</text>
+    <text x="170" y="146" text-anchor="middle">40-pin GPIO</text>
+    <text x="399" y="30" text-anchor="middle">GbE</text>
+    <text x="399" y="79" text-anchor="middle">USB</text>
+    <text x="399" y="103" text-anchor="middle">USB</text>
+    <text x="53" y="30" text-anchor="middle" font-weight="600">SATA</text>
+    <text x="51" y="107" text-anchor="middle">pwr</text>
+  </g>
+</svg>
+<figcaption>The early Banana Pi's calling cards were a real SATA data port (plus its power header) and a gigabit Ethernet jack on a Pi-sized board — enough to build a small file server or storage-backed node without a USB disk adapter.</figcaption>
+</figure>
 
 ## Overview
 
-The first Banana Pi boards matched the Pi's size and 40-pin [GPIO](/reference/gpio/) header but added a SATA port and gigabit networking, making them attractive for small file servers. The range has since grown to cover many ARM SoCs and, more recently, [RISC-V](/reference/risc-v/) boards. As with other clones, Linux support varies by model and is generally less polished than the Raspberry Pi's.
+The first Banana Pi boards matched the Pi's size and 40-pin [GPIO](/reference/gpio/) header but added a SATA port and gigabit networking, making them attractive for small file servers and network-attached storage. Where a stock Pi of the era had to hang a disk off USB, a Banana Pi could drive a 2.5-inch drive natively, and its faster Ethernet moved data off the board without bottlenecking.
+
+The range has since grown well beyond that first board to cover many ARM system-on-chips and, more recently, [RISC-V](/reference/risc-v/) boards — an unusually wide catalogue for a single brand. As with other Pi clones, though, Linux support varies model to model and is generally less polished than the Raspberry Pi's, so a given board's usefulness depends heavily on how mature its vendor image and kernel are.
+
+## The family
+
+Banana Pi is best understood as one of several Pi-alternative brands, each with a slightly different pitch:
+
+| Brand | Maker | Typical SoC | Distinctive trait |
+|-------|-------|-------------|-------------------|
+| Banana Pi | SinoVoip | Allwinner / others, some RISC-V | Onboard SATA + gigabit Ethernet |
+| Orange Pi | Shenzhen Xunlong | Allwinner / Rockchip | Low price, many variants |
+| Rock Pi | Radxa | Rockchip (RK3588) | NVMe, fast I/O |
+| ODROID | Hardkernel | Amlogic | Performance per board |
 
 ## Where it fits
 
-Banana Pi sits among the Pi alternatives — [Orange Pi](/reference/orange-pi/), [ODROID](/reference/odroid/), [Rock Pi](/reference/rock-pi/) — and is worth a look when you want a disk and wired networking on one cheap board. For a GopherTrunk setup that both captures and serves decoded data, the built-in SATA can host the storage without a USB adapter hanging off the board.
+Banana Pi sits among the Pi alternatives — [Orange Pi](/reference/orange-pi/), [ODROID](/reference/odroid/), [Rock Pi](/reference/rock-pi/) — and is worth a look when you want a disk and wired networking on one cheap board. For a GopherTrunk setup that both captures and serves decoded data, the built-in SATA can host the storage locally without a USB adapter hanging off the board, and gigabit Ethernet keeps recorded IQ or a growing call archive moving to a collector without saturating the link.
 
 ## Sources
 

--- a/docs/reference/bare-metal-programming.md
+++ b/docs/reference/bare-metal-programming.md
@@ -3,8 +3,8 @@ slug: bare-metal-programming
 title: Bare-metal programming
 entry_type: concept
 category: hw-microcontrollers
-description: Bare-metal programming means writing software that runs directly on hardware with no operating system underneath, giving full control of the chip's registers, memory, and timing.
-keywords: bare metal, bare-metal programming, no OS, registers, super loop, embedded, firmware, direct hardware
+description: Bare-metal programming means writing software that runs directly on hardware with no operating system underneath, giving full control of the chip's registers, memory, and timing through a main "super loop" plus interrupts.
+keywords: bare metal, bare-metal programming, no OS, registers, super loop, embedded, firmware, direct hardware, interrupts, polling
 infobox:
   - { label: Type, value: Programming approach }
   - { label: OS, value: None }
@@ -20,13 +20,52 @@ cite_urls:
 
 **Bare-metal programming** means writing software that runs directly on the hardware with no operating system underneath it.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 168" role="img" aria-label="Diagram of a bare-metal super loop. A boot arrow leads into a circular main loop that repeatedly reads inputs, does work, and updates outputs. Separately, a hardware interrupt arrives on its own line, momentarily diverts the processor to a short interrupt handler, and then returns control to the loop where it left off." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.3">
+    <path d="M150 92 A70 44 0 1 1 149 92" marker-mid="none"/>
+    <path d="M212 50 L206 44 M212 50 L206 56" stroke-width="1.2"/>
+    <line x1="30" y1="118" x2="80" y2="100"/>
+    <rect x="330" y="44" width="104" height="30" rx="4" fill="currentColor" fill-opacity="0.14"/>
+    <line x1="150" y1="70" x2="150" y2="24"/>
+    <path d="M150 24 L330 24 L330 44" />
+    <path d="M330 74 L330 92 L162 92" stroke-dasharray="3 3"/>
+    <path d="M170 92 L164 86 M170 92 L164 98" stroke-width="1.2"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="150" y="70" font-size="8.5" font-weight="600">read</text>
+    <text x="208" y="96" font-size="8.5" font-weight="600">do work</text>
+    <text x="150" y="126" font-size="8.5" font-weight="600">update out</text>
+    <text x="150" y="150" font-size="8" fill-opacity="0.9">super loop (forever)</text>
+    <text x="30" y="112" font-size="8" text-anchor="start">boot</text>
+    <text x="382" y="62" font-size="8" font-weight="600">interrupt</text>
+    <text x="382" y="88" font-size="7.5" fill-opacity="0.85">handler, then return</text>
+  </g>
+</svg>
+<figcaption>Bare-metal firmware is a "super loop": after boot the processor circles forever — read inputs, do work, update outputs. Time-critical events don't wait their turn; a hardware interrupt briefly diverts the core to a short handler and then hands control back to the loop. No scheduler, no OS — just your code and the silicon.</figcaption>
+</figure>
+
 ## Overview
 
 On a [microcontroller](/reference/microcontroller/), bare-metal code is the [firmware](/reference/firmware/) itself: it configures the chip's peripheral registers by hand, manages its own memory, and typically runs as a "super loop" — an endless main loop that does work, with [interrupts](/reference/interrupt/) handling time-critical events. There is no scheduler, no driver model, and no abstraction between your code and the silicon, which means total control and minimal overhead, but also total responsibility for timing and correctness.
 
-## Trade-offs
+The two structural tools are *polling* — the loop repeatedly checking a flag or input — and *interrupts*, which let hardware pull the processor aside the instant something needs attention. Getting the balance right between them is much of the craft of bare-metal work.
 
-Bare metal is the right choice for the simplest, smallest, or most timing-sensitive [embedded systems](/reference/embedded-system/), where an OS would only add size and unpredictability. It boots instantly and wastes no resources. The cost shows up as a project grows: juggling many concurrent jobs by hand becomes error-prone, which is the point at which developers adopt a [real-time operating system](/reference/real-time-operating-system/). New firmware is loaded by [in-system programming](/reference/in-system-programming/) or a bootloader.
+## Bare metal versus an RTOS
+
+The same chip can run either way; the choice is about how many concurrent jobs the firmware must juggle:
+
+| Aspect | Bare metal | With an [RTOS](/reference/real-time-operating-system/) |
+|--------|-----------|------|
+| Structure | One super loop + interrupts | Multiple scheduled tasks |
+| Overhead | Essentially none | A few KB of code and RAM |
+| Concurrency | Hand-managed | Scheduler handles it |
+| Boot time | Instant | Near-instant |
+| Best for | Simple, tiny, timing-critical | Many competing deadlines |
+
+## Where it fits
+
+Bare metal is the right choice for the simplest, smallest, or most timing-sensitive [embedded systems](/reference/embedded-system/), where an OS would only add size and unpredictability. It boots instantly and wastes no resources. The cost shows up as a project grows: juggling many concurrent jobs by hand becomes error-prone, which is the point at which developers adopt a [real-time operating system](/reference/real-time-operating-system/). New firmware is loaded by [in-system programming](/reference/in-system-programming/) or a bootloader. The small radios and [sensors](/reference/sensor/) whose signals GopherTrunk decodes are very often bare-metal devices — a single loop is all their one job requires.
 
 ## Sources
 

--- a/docs/reference/bare-metal-server.md
+++ b/docs/reference/bare-metal-server.md
@@ -4,12 +4,13 @@ title: Bare-metal server
 entry_type: hardware
 category: hw-servers
 description: A bare-metal server is a single physical machine rented or owned entirely by one tenant, with no hypervisor or shared virtualization layer between the user and the hardware.
-keywords: bare-metal server, single-tenant, no hypervisor, dedicated hardware, bare metal cloud
+keywords: bare-metal server, single-tenant, no hypervisor, dedicated hardware, bare metal cloud, noisy neighbor, provisioning
 aka: [Bare metal]
 infobox:
   - { label: Type, value: Single-tenant physical server }
   - { label: Virtualization, value: None imposed }
   - { label: Tenancy, value: One customer }
+  - { label: Billing, value: Monthly lease or hourly cloud }
   - { label: Contrast, value: VPS / cloud instance }
 see_also: [dedicated-server, virtual-private-server, hypervisor, server, infrastructure-as-a-service, virtualization]
 related_lessons:
@@ -20,14 +21,57 @@ cite_urls:
 
 A **bare-metal server** is a single physical machine used entirely by one tenant, with no [hypervisor](/reference/hypervisor/) or shared virtualization layer sitting between the user and the hardware.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 190" role="img" aria-label="Two layer stacks compared. On a bare-metal server the operating system and workload sit directly on the hardware with a single tenant and no hypervisor. On a virtualized host a hypervisor sits above the hardware and divides it into several virtual machines shared by many tenants." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="currentColor" font-family="ui-sans-serif, sans-serif">
+    <text x="115" y="20" text-anchor="middle" font-size="9" font-weight="600" stroke="none">BARE METAL</text>
+    <rect x="30" y="70" width="170" height="34" rx="3" fill-opacity="0.14" stroke-width="1.3"/>
+    <text x="115" y="91" text-anchor="middle" font-size="8.5" stroke="none">Your OS + workload</text>
+    <rect x="30" y="120" width="170" height="34" rx="3" fill-opacity="0.06" stroke-width="1.3"/>
+    <text x="115" y="141" text-anchor="middle" font-size="8.5" stroke="none">Hardware · CPU · disk · NIC</text>
+    <text x="115" y="172" text-anchor="middle" font-size="8" stroke="none" fill-opacity="0.85">one tenant &#183; direct access</text>
+
+    <text x="345" y="20" text-anchor="middle" font-size="9" font-weight="600" stroke="none">VIRTUALIZED HOST</text>
+    <rect x="260" y="60" width="52" height="28" rx="3" fill-opacity="0.14" stroke-width="1.2"/>
+    <rect x="319" y="60" width="52" height="28" rx="3" fill-opacity="0.14" stroke-width="1.2"/>
+    <rect x="378" y="60" width="52" height="28" rx="3" fill-opacity="0.14" stroke-width="1.2"/>
+    <text x="286" y="78" text-anchor="middle" font-size="8" stroke="none">VM</text>
+    <text x="345" y="78" text-anchor="middle" font-size="8" stroke="none">VM</text>
+    <text x="404" y="78" text-anchor="middle" font-size="8" stroke="none">VM</text>
+    <rect x="260" y="94" width="170" height="22" rx="3" fill-opacity="0.20" stroke-width="1.3"/>
+    <text x="345" y="109" text-anchor="middle" font-size="8.5" stroke="none">Hypervisor</text>
+    <rect x="260" y="122" width="170" height="32" rx="3" fill-opacity="0.06" stroke-width="1.3"/>
+    <text x="345" y="142" text-anchor="middle" font-size="8.5" stroke="none">Hardware</text>
+    <text x="345" y="172" text-anchor="middle" font-size="8" stroke="none" fill-opacity="0.85">many tenants share the box</text>
+  </g>
+</svg>
+<figcaption>On bare metal your operating system runs straight on the hardware as the sole tenant; a virtualized host instead inserts a hypervisor that slices one machine among many tenants, adding isolation but also overhead and contention.</figcaption>
+</figure>
+
 ## Overview
 
-The term contrasts with virtualized cloud instances, where many tenants share one physical box through a hypervisor. On bare metal there is no virtualization overhead and no "noisy neighbor" competing for the same CPU and disk — you get the whole machine's performance and direct access to hardware features. Modern "bare-metal cloud" offerings rent such machines by the hour with cloud-style provisioning, blending dedicated hardware with on-demand billing.
+The term contrasts with virtualized cloud instances, where many tenants share one physical box through a hypervisor. On bare metal there is no virtualization overhead and no "noisy neighbor" competing for the same CPU and disk — you get the whole machine's performance and direct access to hardware features such as specific CPU instructions, NUMA layout, or an attached GPU.
+
+Modern "bare-metal cloud" offerings rent such machines by the hour with cloud-style provisioning APIs, blending dedicated hardware with on-demand billing. That gives much of the flexibility of a cloud instance while preserving the predictability of a single-tenant box. Because nothing sits between you and the silicon, bare metal is also the usual foundation for running *your own* [virtualization](/reference/virtualization/) or container stack on top.
+
+The cost is responsibility and lead time: you own the operating system and its upkeep, and physical provisioning is slower than spinning up a virtual machine — though bare-metal cloud has narrowed that gap to minutes.
 
 ## Trade-offs
 
-Bare metal is the right call when you need predictable performance, full control of the hardware, or you intend to run your own [virtualization](/reference/virtualization/) on top. A [dedicated server](/reference/dedicated-server/) is essentially a long-lease bare-metal box; a [virtual private server](/reference/virtual-private-server/) is the shared, cheaper alternative. Within [infrastructure as a service](/reference/infrastructure-as-a-service/), bare metal is the lowest-abstraction rung. GopherTrunk runs the same on bare metal as on a VPS; the deciding factor is whether you also need a real radio front end attached, which favors local hardware.
+The three common tenancy models trade performance against price and convenience:
+
+| Model | Tenancy | Virtualization | Best for |
+|-------|---------|----------------|----------|
+| Bare metal | One tenant | None imposed | Predictable performance, hardware access |
+| [VPS](/reference/virtual-private-server/) | Shared host | Hypervisor slice | Cost-sensitive, bursty workloads |
+| Shared hosting | Many per OS | None (OS-level) | Simple sites, minimal control |
+
+Bare metal is the right call when you need predictable performance, full control of the hardware, or you intend to run your own virtualization on top. A [dedicated server](/reference/dedicated-server/) is essentially a long-lease bare-metal box; a VPS is the shared, cheaper alternative.
+
+## Where it fits
+
+Within [infrastructure as a service](/reference/infrastructure-as-a-service/), bare metal is the lowest-abstraction rung — the closest a rented machine gets to one you own. GopherTrunk runs the same on bare metal as on a VPS; the deciding factor is whether you also need a real radio front end attached, which favors local hardware, or whether the box merely stores and serves decoded calls, where a shared VPS is cheaper.
 
 ## Sources
 
-[^wiki]: [Bare-metal server](https://en.wikipedia.org/wiki/Bare-metal_server) — Wikipedia, on single-tenant physical servers.
+[^wiki]: [Bare-metal server](https://en.wikipedia.org/wiki/Bare-metal_server) — Wikipedia, on single-tenant physical servers and bare-metal cloud.

--- a/docs/reference/battery-technology.md
+++ b/docs/reference/battery-technology.md
@@ -4,7 +4,7 @@ title: Battery technology
 entry_type: concept
 category: hw-mobile
 description: Battery technology covers the rechargeable chemistries — chiefly lithium-ion and lithium-polymer — that store the energy powering phones, wearables, and portable devices, defined by capacity, energy density, and cycle life.
-keywords: battery, lithium-ion, lithium-polymer, energy density, mAh, charge cycles, rechargeable, capacity, fast charging
+keywords: battery, lithium-ion, lithium-polymer, energy density, mAh, charge cycles, rechargeable, capacity, fast charging, discharge curve
 infobox:
   - { label: Type, value: Energy storage }
   - { label: Common chemistry, value: Lithium-ion / Li-polymer }
@@ -19,9 +19,49 @@ cite_urls:
 
 **Battery technology** is the set of rechargeable chemistries — most often lithium-ion and lithium-polymer — that store the electrical energy powering phones, wearables, and other portable devices.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 170" role="img" aria-label="A lithium-ion discharge curve. Voltage starts near 4.2 volts when full, holds a long, nearly flat plateau around 3.7 volts through most of the capacity, then drops steeply toward the 3.0-volt cutoff as the cell empties. This flat plateau is why a phone can report a stable voltage across most of its charge." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.2">
+    <line x1="48" y1="20" x2="48" y2="132"/>
+    <line x1="48" y1="132" x2="430" y2="132"/>
+  </g>
+  <path d="M60 34 C90 40 100 52 130 56 C200 64 300 72 360 84 C390 92 405 108 418 126" stroke="currentColor" fill="none" stroke-width="1.8"/>
+  <g stroke="currentColor" stroke-width="0.8" stroke-dasharray="3 3" fill="none">
+    <line x1="48" y1="60" x2="418" y2="60"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-family="ui-sans-serif, sans-serif" font-size="8.5">
+    <text x="20" y="37">4.2V</text>
+    <text x="20" y="63">3.7V</text>
+    <text x="20" y="135">3.0V</text>
+    <text x="60" y="148">full</text>
+    <text x="392" y="148">empty</text>
+    <text x="210" y="148" text-anchor="middle">state of charge &#8594;</text>
+    <text x="200" y="54" font-size="8">flat plateau &#8776; most of the usable charge</text>
+    <text x="392" y="104" font-size="8" text-anchor="end">steep &#8595;</text>
+  </g>
+</svg>
+<figcaption>A lithium-ion cell holds a long, nearly flat voltage plateau around 3.7 V through most of its charge, then falls sharply near empty — the shape that makes state-of-charge estimation from voltage alone tricky at the ends.</figcaption>
+</figure>
+
 ## Overview
 
-A battery is rated by capacity (milliamp-hours, mAh, or watt-hours, Wh) and judged on *energy density* — how much energy fits in a given size and weight — and *cycle life*, how many charge/discharge cycles it survives before fading. Lithium-ion dominates because it packs high energy density into a light, rechargeable cell. Lithium-polymer variants trade in a flexible pouch that can be shaped to fit thin phones and curved wearables. Charging is managed by control circuitry to balance speed, heat, and long-term wear.
+A battery is rated by capacity (milliamp-hours, mAh, or watt-hours, Wh) and judged on *energy density* — how much energy fits in a given size and weight — and *cycle life*, how many charge/discharge cycles it survives before fading. Lithium-ion dominates because it packs high energy density into a light, rechargeable cell with low self-discharge and no memory effect.
+
+Lithium-polymer variants trade the rigid metal can for a flexible pouch that can be shaped to fit thin phones and curved wearables. Charging is managed by control circuitry that balances speed, heat, and long-term wear, since fast charging and high temperatures both accelerate aging. The flat discharge curve above means most of a cell's energy is delivered at a stable voltage, with sharp knees only when nearly full or nearly empty.
+
+## Li-ion vs Li-polymer
+
+The two lithium chemistries share the same electrochemistry but differ in packaging and how that shapes a device:
+
+| Property | Lithium-ion | Lithium-polymer |
+|----------|-------------|-----------------|
+| Package | Rigid cylindrical/prismatic can | Flexible pouch |
+| Energy density | Higher per weight | Slightly lower |
+| Shape freedom | Fixed forms | Thin, curved, custom |
+| Cost | Lower | Higher |
+| Typical use | Laptops, power tools | Phones, wearables, drones |
+
+The pouch's shape freedom is why nearly every slim phone and curved smartwatch uses Li-polymer despite the cost.
 
 ## Where it fits
 

--- a/docs/reference/beaglebone.md
+++ b/docs/reference/beaglebone.md
@@ -4,13 +4,14 @@ title: BeagleBone
 entry_type: hardware
 category: hw-sbc
 description: BeagleBone is an open-source single-board computer known for strong real-time I/O, with many GPIO pins and onboard programmable real-time units, favored for industrial control.
-keywords: BeagleBone, BeagleBone Black, PRU, programmable real-time unit, real-time I/O, industrial control, open-source SBC, GPIO
+keywords: BeagleBone, BeagleBone Black, PRU, programmable real-time unit, real-time I/O, industrial control, open-source SBC, GPIO, deterministic timing
 autolink: true
 infobox:
   - { label: Type, value: Single-board computer }
   - { label: CPU, value: ARM (TI SoC) + PRUs }
   - { label: RAM, value: ~512 MB – 4 GB }
   - { label: Runs, value: Linux }
+  - { label: Noted for, value: Real-time I/O, dual expansion headers }
   - { label: Typical price, value: ~$50 – $150 }
 see_also: [single-board-computer, gpio, raspberry-pi, nvidia-jetson, input-output, microcontroller]
 related_lessons:
@@ -22,13 +23,55 @@ cite_urls:
 
 **BeagleBone** is an open-source [single-board computer](/reference/single-board-computer/) known for strong real-time I/O — many [GPIO](/reference/gpio/) pins and onboard programmable real-time units (PRUs).[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 178" role="img" aria-label="Block diagram of a BeagleBone. A central ARM CPU runs Linux, but two small programmable real-time units sit beside it on the same chip, each wired to the board's two long expansion pin headers. The PRUs execute deterministic timing-critical code independently of the Linux scheduler, driving the many GPIO pins directly." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.3">
+    <rect x="30" y="30" width="400" height="118" rx="6" fill-opacity="0.05" fill="currentColor"/>
+    <rect x="150" y="52" width="90" height="44" rx="4" fill-opacity="0.14" fill="currentColor"/>
+    <rect x="266" y="52" width="46" height="20" rx="3" fill-opacity="0.2" fill="currentColor"/>
+    <rect x="266" y="80" width="46" height="20" rx="3" fill-opacity="0.2" fill="currentColor"/>
+    <g stroke-width="1">
+      <rect x="52" y="126" width="164" height="9" rx="1.5"/>
+      <rect x="244" y="126" width="164" height="9" rx="1.5"/>
+    </g>
+    <path d="M240 62 H266" stroke-width="1.1"/>
+    <path d="M240 90 H266" stroke-width="1.1"/>
+    <path d="M289 100 V126" stroke-width="1.1"/>
+    <path d="M195 96 V126" stroke-width="1.1"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="8.5">
+    <text x="195" y="78" text-anchor="middle" font-size="9" font-weight="600">ARM CPU</text>
+    <text x="195" y="90" text-anchor="middle" font-size="7.5" fill-opacity="0.85">Linux</text>
+    <text x="289" y="66" text-anchor="middle" font-size="8" font-weight="600">PRU 0</text>
+    <text x="289" y="94" text-anchor="middle" font-size="8" font-weight="600">PRU 1</text>
+    <text x="134" y="147" text-anchor="middle">header P8</text>
+    <text x="326" y="147" text-anchor="middle">header P9</text>
+    <text x="230" y="24" text-anchor="middle" font-size="8" fill-opacity="0.9">deterministic real-time units alongside the Linux CPU</text>
+  </g>
+</svg>
+<figcaption>Beyond the Linux-running ARM CPU, a BeagleBone carries two programmable real-time units on the same chip; because they run outside the OS scheduler, they can bit-bang protocols and sample inputs with cycle-accurate timing across the board's two long expansion headers.</figcaption>
+</figure>
+
 ## Overview
 
-The PRUs are small, deterministic processors alongside the main ARM CPU, which lets a BeagleBone handle precise, timing-critical signalling that a general-purpose Linux board struggles with. Combined with its generous pin count, this makes it a favourite for industrial control and electronics-heavy projects. It runs Linux like other SBCs.
+The PRUs are small, deterministic processors alongside the main ARM CPU, which lets a BeagleBone handle precise, timing-critical signalling that a general-purpose Linux board struggles with. On an ordinary SBC the OS scheduler can preempt your code at any moment, so software-driven waveforms jitter; a PRU runs a tight loop with no operating system underneath it, so its timing is repeatable to the clock cycle.
+
+Combined with a generous pin count spread across two long expansion headers, this makes the BeagleBone a favourite for industrial control, motor drivers, and electronics-heavy projects. It runs Linux like other SBCs and is fully open-source down to the board design, which appeals to product developers who want to fork the hardware itself rather than just the software.
+
+## How it works
+
+The split of duties between the Linux CPU and the PRUs is the whole point of the board:
+
+| Job | Runs on | Why |
+|-----|---------|-----|
+| Networking, filesystem, apps | ARM CPU (Linux) | Needs a full OS and libraries |
+| Cycle-accurate pin timing | PRU | No scheduler jitter, deterministic loops |
+| Bulk GPIO / bus signalling | PRU + headers | Direct hardware access, hundreds of pins |
+| Coordination / data hand-off | Shared memory | CPU sets up work, PRU executes it |
 
 ## Where it fits
 
-The BeagleBone is the SBC alternative to the [Raspberry Pi](/reference/raspberry-pi/) when [I/O](/reference/input-output/) and determinism matter more than raw cost or community size. For general-purpose use a Pi is simpler; for GPU work at the edge see the [NVIDIA Jetson](/reference/nvidia-jetson/).
+The BeagleBone is the SBC alternative to the [Raspberry Pi](/reference/raspberry-pi/) when [I/O](/reference/input-output/) and determinism matter more than raw cost or community size. For general-purpose use a Pi is simpler and cheaper; for GPU work at the edge see the [NVIDIA Jetson](/reference/nvidia-jetson/). In a GopherTrunk context the BeagleBone is rarely the decode host itself, but its real-time pins suit the jobs *around* a capture node — precise PPS/GPS timing, antenna-relay switching, or driving a rotator — where jitter would otherwise creep in.
 
 ## Sources
 

--- a/docs/reference/bios-uefi.md
+++ b/docs/reference/bios-uefi.md
@@ -3,16 +3,17 @@ slug: bios-uefi
 title: BIOS & UEFI
 entry_type: concept
 category: hw-foundations
-description: BIOS and its modern successor UEFI are the firmware that initializes a computer's hardware at power-on and hands control to the operating system's bootloader.
-keywords: BIOS, UEFI, firmware, boot, POST, bootloader, secure boot, motherboard firmware
+description: BIOS and its modern successor UEFI are the firmware that initializes a computer's hardware at power-on, runs the power-on self-test, and hands control to the operating system's bootloader.
+keywords: BIOS, UEFI, firmware, boot, POST, power-on self-test, bootloader, secure boot, GPT, motherboard firmware
 aka: [BIOS, UEFI]
 autolink: true
 infobox:
   - { label: Type, value: Platform firmware }
   - { label: Runs, value: At power-on, before OS }
-  - { label: Does, value: Init hardware, start boot }
+  - { label: Does, value: Init hardware, POST, start boot }
+  - { label: Stored in, value: Motherboard flash chip }
   - { label: Successor, value: UEFI replaces legacy BIOS }
-see_also: [motherboard, operating-system, chipset, central-processing-unit, firmware, data-storage]
+see_also: [motherboard, operating-system, firmware, bootloader, chipset, data-storage]
 cite_urls:
   - https://en.wikipedia.org/wiki/BIOS
   - https://en.wikipedia.org/wiki/UEFI
@@ -20,15 +21,65 @@ cite_urls:
 
 **BIOS** (Basic Input/Output System) and its modern successor **UEFI** (Unified Extensible Firmware Interface) are the [firmware](/reference/firmware/) that brings a computer's hardware up at power-on and hands control to the operating system.[^bios][^uefi]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 150" role="img" aria-label="The boot sequence from left to right: power applied, the CPU runs firmware from the motherboard flash chip, the firmware performs a power-on self-test, initializes the chipset and memory, finds a bootable storage device, and launches its bootloader, which loads the operating system." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.2">
+    <rect x="8" y="46" width="66" height="40" rx="4"/>
+    <rect x="90" y="46" width="72" height="40" rx="4" fill="currentColor" fill-opacity="0.12"/>
+    <rect x="178" y="46" width="72" height="40" rx="4" fill="currentColor" fill-opacity="0.12"/>
+    <rect x="266" y="46" width="72" height="40" rx="4"/>
+    <rect x="354" y="46" width="98" height="40" rx="4"/>
+  </g>
+  <g stroke="currentColor" stroke-width="1.2" fill="currentColor">
+    <path d="M74 66 h12 m-4 -3 l4 3 l-4 3" fill="none"/>
+    <path d="M162 66 h12 m-4 -3 l4 3 l-4 3" fill="none"/>
+    <path d="M250 66 h12 m-4 -3 l4 3 l-4 3" fill="none"/>
+    <path d="M338 66 h12 m-4 -3 l4 3 l-4 3" fill="none"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="41" y="63" font-size="8.5">Power</text>
+    <text x="41" y="74" font-size="8.5">on</text>
+    <text x="126" y="60" font-size="8.5" font-weight="600">Firmware</text>
+    <text x="126" y="71" font-size="7.5" fill-opacity="0.85">POST</text>
+    <text x="126" y="80" font-size="7.5" fill-opacity="0.85">self-test</text>
+    <text x="214" y="60" font-size="8.5" font-weight="600">Init</text>
+    <text x="214" y="71" font-size="7.5" fill-opacity="0.85">chipset,</text>
+    <text x="214" y="80" font-size="7.5" fill-opacity="0.85">RAM, devices</text>
+    <text x="302" y="63" font-size="8.5">Find boot</text>
+    <text x="302" y="74" font-size="8.5">device</text>
+    <text x="403" y="60" font-size="8.5">Bootloader</text>
+    <text x="403" y="71" font-size="7.5" fill-opacity="0.85">loads the OS</text>
+    <text x="230" y="118" font-size="8" fill-opacity="0.9">legacy BIOS &#8594; UEFI: large disks (GPT), fast boot, Secure Boot</text>
+  </g>
+</svg>
+<figcaption>From the instant power is applied, the firmware self-tests the hardware, brings up the chipset and memory, locates a bootable drive, and starts its bootloader — the same job whether the firmware is legacy BIOS or the more capable UEFI.</figcaption>
+</figure>
+
 ## Overview
 
-Stored in a chip on the [motherboard](/reference/motherboard/), this firmware is the first code a [CPU](/reference/central-processing-unit/) runs when power is applied. It performs the power-on self-test (POST), initializes the [chipset](/reference/chipset/), memory, and basic devices, then locates a bootable [storage](/reference/data-storage/) device and starts its *bootloader*, which in turn loads the [operating system](/reference/operating-system/). Legacy BIOS dates to the early PC; UEFI replaced it with a more capable design supporting large disks, faster boot, and features like Secure Boot.
+Stored in a flash chip on the [motherboard](/reference/motherboard/), this firmware is the very first code a [CPU](/reference/central-processing-unit/) runs when power is applied. It performs the *power-on self-test* (POST), a quick sanity check of memory and core devices, then initializes the [chipset](/reference/chipset/), RAM, and basic peripherals so the machine is in a known, working state.
+
+Once the platform is up, the firmware consults its configured boot order, locates a bootable [storage](/reference/data-storage/) device, and starts that device's *[bootloader](/reference/bootloader/)*, which in turn loads the [operating system](/reference/operating-system/). The firmware also exposes a *setup screen* for changing boot order, clocks, and virtualization toggles, and it can itself be updated — a process called *flashing*.
+
+## BIOS versus UEFI
+
+Legacy BIOS dates to the original IBM PC of the early 1980s and carried real limitations by modern standards. UEFI replaced it with a cleaner, more capable design:
+
+| Aspect | Legacy BIOS | UEFI |
+|--------|-------------|------|
+| Era | Early 1980s | 2000s onward |
+| Disk scheme | MBR (≤ 2 TB) | GPT (very large disks) |
+| Mode | 16-bit real mode | 32-/64-bit |
+| Boot integrity | None | Secure Boot |
+| Interface | Text menus | Drivers, shell, richer UI |
+
+Most systems shipped in the last decade use UEFI, often with a *compatibility support module* (CSM) that emulates legacy BIOS for older operating systems.
 
 ## Where it fits
 
-BIOS/UEFI is the layer between bare hardware and software — without it the machine would not know how to start. It is configurable (boot order, clocks, virtualization toggles) through a setup screen, and it can be updated as *flashing* firmware. On small SDR capture boards the role is filled by an equivalent bootloader baked into the platform; conceptually the job is the same: wake the hardware, then start the OS that runs GopherTrunk.
+BIOS/UEFI is the indispensable layer between bare hardware and software — without it a machine has no idea how to start. On small SDR capture boards the role is filled by an equivalent [bootloader](/reference/bootloader/) or ROM baked into the platform rather than a PC-style setup screen, but the job is identical: wake the hardware, then start the OS that runs the GopherTrunk daemon.
 
 ## Sources
 
-[^bios]: [BIOS](https://en.wikipedia.org/wiki/BIOS) — Wikipedia, on legacy PC firmware and POST.
-[^uefi]: [UEFI](https://en.wikipedia.org/wiki/UEFI) — Wikipedia, on the modern UEFI firmware interface.
+[^bios]: [BIOS](https://en.wikipedia.org/wiki/BIOS) — Wikipedia, on legacy PC firmware, POST, and the boot handoff.
+[^uefi]: [UEFI](https://en.wikipedia.org/wiki/UEFI) — Wikipedia, on the modern UEFI firmware interface, GPT, and Secure Boot.

--- a/docs/reference/bits-and-bytes.md
+++ b/docs/reference/bits-and-bytes.md
@@ -3,13 +3,14 @@ slug: bits-and-bytes
 title: Bits & bytes
 entry_type: concept
 category: hw-foundations
-description: A bit is the smallest unit of digital information, a single 0 or 1; a byte is a group of eight bits. Together they are the units in which computers store and move all data.
-keywords: bit, byte, binary, kilobyte, megabyte, gigabyte, base-2, data units, octet
+description: A bit is the smallest unit of digital information, a single 0 or 1; a byte is a group of eight bits. Together they are the units in which computers store, address, and move all data.
+keywords: bit, byte, binary, kilobyte, megabyte, gigabyte, base-2, data units, octet, most significant bit, place value
 aka: [Bit, Byte]
 infobox:
   - { label: Bit, value: One binary digit (0 or 1) }
   - { label: Byte, value: 8 bits }
   - { label: Byte range, value: 0–255 (256 values) }
+  - { label: Bit rate unit, value: bits per second }
   - { label: Larger units, value: "KB, MB, GB, TB" }
 see_also: [logic-gate, random-access-memory, data-storage, bandwidth, central-processing-unit, transistor]
 cite_urls:
@@ -19,9 +20,68 @@ cite_urls:
 
 A **bit** is the smallest unit of digital information — a single binary digit, either 0 or 1 — and a **byte** is a group of eight bits.[^bit][^byte]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 150" role="img" aria-label="A single byte shown as eight bit cells, from the most significant bit on the left with place value 128 down to the least significant bit on the right with place value 1. The example pattern 0100 0001 sums to 65, the ASCII code for the letter A." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.2">
+    <rect x="30" y="40" width="50" height="40"/>
+    <rect x="80" y="40" width="50" height="40" fill="currentColor" fill-opacity="0.14"/>
+    <rect x="130" y="40" width="50" height="40"/>
+    <rect x="180" y="40" width="50" height="40"/>
+    <rect x="230" y="40" width="50" height="40"/>
+    <rect x="280" y="40" width="50" height="40"/>
+    <rect x="330" y="40" width="50" height="40"/>
+    <rect x="380" y="40" width="50" height="40" fill="currentColor" fill-opacity="0.14"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle" font-family="ui-monospace, monospace">
+    <text x="55" y="66" font-size="13">0</text>
+    <text x="105" y="66" font-size="13">1</text>
+    <text x="155" y="66" font-size="13">0</text>
+    <text x="205" y="66" font-size="13">0</text>
+    <text x="255" y="66" font-size="13">0</text>
+    <text x="305" y="66" font-size="13">0</text>
+    <text x="355" y="66" font-size="13">0</text>
+    <text x="405" y="66" font-size="13">1</text>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle" font-size="8" fill-opacity="0.85">
+    <text x="55" y="94">128</text>
+    <text x="105" y="94">64</text>
+    <text x="155" y="94">32</text>
+    <text x="205" y="94">16</text>
+    <text x="255" y="94">8</text>
+    <text x="305" y="94">4</text>
+    <text x="355" y="94">2</text>
+    <text x="405" y="94">1</text>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="8">
+    <text x="30" y="30">MSB</text>
+    <text x="410" y="30">LSB</text>
+  </g>
+  <text x="230" y="120" text-anchor="middle" font-size="9" fill="currentColor">64 + 1 = 65 = ASCII 'A'</text>
+  <text x="230" y="138" text-anchor="middle" font-size="8" fill="currentColor" fill-opacity="0.85">one byte holds 256 distinct values (0–255)</text>
+</svg>
+<figcaption>A byte is eight bits, each holding a place value that doubles from right to left; adding up the "on" bits gives a number from 0 to 255 — here 0100 0001 equals 65, the code for the character 'A'.</figcaption>
+</figure>
+
 ## Overview
 
-Everything a computer stores or moves is encoded in bits, physically realized as a [transistor](/reference/transistor/) switched on or off, a charge present or absent, a voltage high or low. Eight bits make a byte, which can represent 256 distinct values (0–255) — enough for one character of basic text. Larger quantities are counted in kilobytes, megabytes, gigabytes, and terabytes. Data *rates* are usually measured in **bits** per second (the unit of [bandwidth](/reference/bandwidth/)), while storage sizes are usually in **bytes** — a common source of confusion.
+Everything a computer stores or moves is encoded in bits, physically realized as a [transistor](/reference/transistor/) switched on or off, a charge present or absent, a voltage high or low. Grouping eight bits into a byte gives a convenient chunk that can represent 256 distinct values (0–255) — enough for one character of basic text, one level of a colour channel, or one small integer.
+
+Within a byte each bit carries a *place value* that doubles from the least significant bit (worth 1) on the right up to the most significant bit (worth 128) on the left, exactly like decimal place value but in base two. Larger quantities are counted in kilobytes, megabytes, gigabytes, and terabytes.
+
+A persistent source of confusion is that data *rates* are usually quoted in **bits** per second (the unit of [bandwidth](/reference/bandwidth/)) while storage *sizes* are usually quoted in **bytes** — so a "100 Mbps" link moves only about 12.5 MB each second.
+
+## Counting in bigger units
+
+Because computers address memory in powers of two, the "kilo/mega/giga" prefixes are often used to mean powers of 1024 rather than 1000; standards bodies coined the binary prefixes (KiB, MiB) to make the distinction explicit.
+
+| Unit | Bits | Bytes | Rough scale |
+|------|------|-------|-------------|
+| Bit | 1 | ⅛ | one 0 or 1 |
+| Byte | 8 | 1 | one text character |
+| Kilobyte (KB) | 8 × 10³ | 10³ | a short email |
+| Megabyte (MB) | 8 × 10⁶ | 10⁶ | a minute of music |
+| Gigabyte (GB) | 8 × 10⁹ | 10⁹ | a movie |
+| Terabyte (TB) | 8 × 10¹² | 10¹² | a large drive |
 
 ## Where it fits
 
@@ -30,4 +90,4 @@ Bits and bytes are the common currency of every other hardware idea: [memory](/r
 ## Sources
 
 [^bit]: [Bit](https://en.wikipedia.org/wiki/Bit) — Wikipedia, on the bit as the basic unit of information.
-[^byte]: [Byte](https://en.wikipedia.org/wiki/Byte) — Wikipedia, on the byte as a group of (usually eight) bits.
+[^byte]: [Byte](https://en.wikipedia.org/wiki/Byte) — Wikipedia, on the byte as a group of (usually eight) bits and the binary multiples.

--- a/docs/reference/blade-server.md
+++ b/docs/reference/blade-server.md
@@ -4,13 +4,14 @@ title: Blade server
 entry_type: hardware
 category: hw-servers
 description: A blade server is a stripped-down server module that slides into a shared enclosure, which supplies power, cooling, and networking to many blades at once for high density.
-keywords: blade server, blade enclosure, blade chassis, server density, modular server
+keywords: blade server, blade enclosure, blade chassis, server density, modular server, midplane, shared backplane
 aka: [Server blade]
 infobox:
   - { label: Type, value: Server form factor }
   - { label: Slots into, value: Blade enclosure }
   - { label: Shares, value: Power, cooling, networking }
   - { label: Optimized for, value: Density }
+  - { label: Contrast, value: Self-contained rack server }
 see_also: [rack-server, server, data-center, dedicated-server, virtualization, high-availability]
 cite_urls:
   - https://en.wikipedia.org/wiki/Blade_server
@@ -18,14 +19,62 @@ cite_urls:
 
 A **blade server** is a stripped-down [server](/reference/server/) module that slides into a shared enclosure; the enclosure supplies power, cooling, and networking to many blades at once.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 200" role="img" aria-label="A blade enclosure drawn as a tall cabinet holding eight vertical blade modules side by side. A shared backplane at the rear connects every blade to common power supplies, cooling fans, and network switch modules at the bottom of the chassis." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="currentColor" font-family="ui-sans-serif, sans-serif">
+    <rect x="40" y="20" width="300" height="120" rx="4" fill-opacity="0.04" stroke-width="1.4"/>
+    <g stroke-width="1.1">
+      <rect x="52" y="30" width="30" height="88" rx="2" fill-opacity="0.14"/>
+      <rect x="86" y="30" width="30" height="88" rx="2" fill-opacity="0.14"/>
+      <rect x="120" y="30" width="30" height="88" rx="2" fill-opacity="0.14"/>
+      <rect x="154" y="30" width="30" height="88" rx="2" fill-opacity="0.14"/>
+      <rect x="188" y="30" width="30" height="88" rx="2" fill-opacity="0.14"/>
+      <rect x="222" y="30" width="30" height="88" rx="2" fill-opacity="0.14"/>
+      <rect x="256" y="30" width="30" height="88" rx="2" fill-opacity="0.14"/>
+      <rect x="290" y="30" width="30" height="88" rx="2" fill-opacity="0.14"/>
+    </g>
+    <text x="67" y="132" text-anchor="middle" font-size="7.5" stroke="none" fill-opacity="0.9">blade</text>
+    <text x="190" y="14" text-anchor="middle" font-size="9" font-weight="600" stroke="none">Blade enclosure &#183; 8 slots</text>
+    <line x1="340" y1="30" x2="340" y2="118" stroke-width="1.3" stroke-dasharray="3 2"/>
+    <text x="392" y="60" text-anchor="middle" font-size="8" stroke="none">shared</text>
+    <text x="392" y="72" text-anchor="middle" font-size="8" stroke="none">backplane</text>
+    <text x="392" y="84" text-anchor="middle" font-size="8" stroke="none" fill-opacity="0.85">(power+data)</text>
+    <rect x="40" y="150" width="94" height="30" rx="3" fill-opacity="0.10" stroke-width="1.2"/>
+    <text x="87" y="169" text-anchor="middle" font-size="8" stroke="none">Power</text>
+    <rect x="143" y="150" width="94" height="30" rx="3" fill-opacity="0.10" stroke-width="1.2"/>
+    <text x="190" y="169" text-anchor="middle" font-size="8" stroke="none">Cooling fans</text>
+    <rect x="246" y="150" width="94" height="30" rx="3" fill-opacity="0.10" stroke-width="1.2"/>
+    <text x="293" y="169" text-anchor="middle" font-size="8" stroke="none">Network</text>
+    <text x="190" y="194" text-anchor="middle" font-size="8" stroke="none" fill-opacity="0.85">shared by every blade in the chassis</text>
+  </g>
+</svg>
+<figcaption>Each blade carries only CPU, memory, and local storage; power supplies, fans, and network switching live once in the chassis and are shared across all the slots, which is what makes blades so dense.</figcaption>
+</figure>
+
 ## Overview
 
-Where a [rack server](/reference/rack-server/) is a complete, self-contained machine, a blade keeps only the essentials — CPU, memory, and often local storage — and offloads power supplies, fans, and switching to the chassis. A single enclosure can hold a dozen or more blades, cutting cabling and power overhead and packing more compute into each [data center](/reference/data-center/) cabinet. The trade-off is vendor lock-in to that enclosure and a larger up-front cost, so blades pay off mainly at scale.
+Where a [rack server](/reference/rack-server/) is a complete, self-contained machine, a blade keeps only the essentials — CPU, memory, and often local storage — and offloads power supplies, fans, and switching to the chassis. The blades plug into a common *midplane* or backplane that carries both power and data, so inserting a blade wires it into the enclosure's shared switches and power feeds in one motion.
 
-## Trade-offs
+A single enclosure can hold a dozen or more blades, cutting cabling and power overhead and packing more compute into each [data center](/reference/data-center/) cabinet. The trade-off is vendor lock-in to that enclosure and a larger up-front cost, so blades pay off mainly at scale.
+
+## Anatomy
+
+Blades and rack servers split the same components differently — the blade pushes shared infrastructure out into the chassis:
+
+| Component | Rack server | Blade server |
+|-----------|-------------|--------------|
+| Power supply | Per server | Shared in enclosure |
+| Cooling fans | Per server | Shared in enclosure |
+| Network switch | External / top-of-rack | Module in enclosure |
+| CPU, RAM, disk | On the server | On each blade |
+| Density | Moderate | Highest |
+
+That consolidation is the whole point: fewer cables, fewer power supplies, and more servers per cabinet — at the price of committing to one vendor's enclosure.
+
+## Where it fits
 
 Blades shine when you need many similar servers in a small footprint — for example as the compute pool behind heavy [virtualization](/reference/virtualization/) or a [high-availability](/reference/high-availability/) cluster. For a handful of machines, plain rack servers are simpler and cheaper. A GopherTrunk deployment almost never needs blade density; its bottleneck is RF capture at the antenna, not raw server compute.
 
 ## Sources
 
-[^wiki]: [Blade server](https://en.wikipedia.org/wiki/Blade_server) — Wikipedia, on blade form factors and enclosures.
+[^wiki]: [Blade server](https://en.wikipedia.org/wiki/Blade_server) — Wikipedia, on blade form factors, enclosures, and shared backplanes.

--- a/docs/reference/bluetooth.md
+++ b/docs/reference/bluetooth.md
@@ -3,29 +3,76 @@ slug: bluetooth
 title: Bluetooth
 entry_type: concept
 category: hw-networking
-description: Bluetooth is a short-range wireless standard for connecting devices over the 2.4 GHz band, used for audio, peripherals, and low-power sensor links between nearby gadgets.
-keywords: Bluetooth, Bluetooth Low Energy, BLE, 2.4 GHz, wireless, PAN, pairing
+description: Bluetooth is a short-range wireless standard for connecting devices over the 2.4 GHz band, used for audio, peripherals, and low-power sensor links; its Low Energy profile (BLE) powers many battery devices and IoT sensors.
+keywords: Bluetooth, Bluetooth Low Energy, BLE, 2.4 GHz, wireless, PAN, piconet, pairing, frequency hopping, ISM band
 aka: [BT, Bluetooth Low Energy, BLE]
 infobox:
   - { label: Type, value: Short-range wireless }
   - { label: Band, value: 2.4 GHz ISM }
   - { label: Range, value: ~1–100 m (class-dependent) }
   - { label: Variants, value: Classic, Low Energy (BLE) }
-see_also: [wi-fi, near-field-communication, wireless-access-point, electromagnetic-spectrum, internet-of-things, ethernet]
+  - { label: Access, value: Frequency-hopping spread spectrum }
+see_also: [wi-fi, bluetooth-le, near-field-communication, wireless-access-point, electromagnetic-spectrum, internet-of-things, ethernet]
 cite_urls:
   - https://en.wikipedia.org/wiki/Bluetooth
 ---
 
 **Bluetooth** is a short-range wireless standard for connecting devices over the 2.4 GHz band, used for audio, peripherals, and low-power links between nearby gadgets.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 170" role="img" aria-label="A Bluetooth piconet drawn as a star: a central phone in the middle is linked by short radio hops to a headset, a keyboard, and a battery sensor arranged around it, all sharing the 2.4 GHz band by frequency hopping." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="currentColor">
+    <g stroke-width="1.2" stroke-dasharray="3 3" fill="none">
+      <line x1="230" y1="85" x2="110" y2="45"/>
+      <line x1="230" y1="85" x2="110" y2="125"/>
+      <line x1="230" y1="85" x2="350" y2="45"/>
+      <line x1="230" y1="85" x2="350" y2="125"/>
+    </g>
+    <rect x="214" y="62" width="32" height="46" rx="4" fill-opacity="0.12" stroke-width="1.4"/>
+    <rect x="86" y="30" width="48" height="30" rx="4" fill-opacity="0.12" stroke-width="1.4"/>
+    <rect x="86" y="110" width="48" height="30" rx="4" fill-opacity="0.12" stroke-width="1.4"/>
+    <rect x="326" y="30" width="48" height="30" rx="4" fill-opacity="0.12" stroke-width="1.4"/>
+    <rect x="326" y="110" width="48" height="30" rx="4" fill-opacity="0.12" stroke-width="1.4"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle" font-size="8.5">
+    <text x="230" y="89" font-weight="600">phone</text>
+    <text x="230" y="126" font-size="8">central</text>
+    <text x="110" y="49">headset</text>
+    <text x="110" y="129">keyboard</text>
+    <text x="350" y="49">sensor</text>
+    <text x="350" y="129">wearable</text>
+    <text x="230" y="150" font-size="8" fill-opacity="0.9">one piconet, 2.4 GHz ISM band, ~1600 frequency hops per second</text>
+  </g>
+</svg>
+<figcaption>A Bluetooth piconet: one central device (here a phone) holds short radio links to a handful of nearby peripherals, all hopping together across the 2.4 GHz band to dodge interference from Wi-Fi and other users of the crowded ISM spectrum.</figcaption>
+</figure>
+
 ## Overview
 
-Bluetooth forms small *personal-area networks* between paired devices — headphones to a phone, a keyboard to a laptop, a sensor to a hub — hopping rapidly across the crowded 2.4 GHz ISM band to dodge interference. **Bluetooth Low Energy** (BLE) is a separate, power-frugal profile aimed at battery devices that wake, send a short burst, and sleep, which has made it the backbone of many [IoT](/reference/internet-of-things/) sensors and wearables. Unlike [Wi-Fi](/reference/wi-fi/), it targets close-range, low-bandwidth links rather than network access; for touch-range pairing, [NFC](/reference/near-field-communication/) is closer still.
+Bluetooth forms small *personal-area networks* between paired devices — headphones to a phone, a keyboard to a laptop, a sensor to a hub — hopping rapidly across the crowded 2.4 GHz ISM band to dodge interference. The devices in one link form a *piconet*, with one central node coordinating the others, and the hopping pattern spreads their traffic thinly over the band so neighbours collide only briefly.
 
-## What it's for
+**Bluetooth Low Energy** (BLE) is a separate, power-frugal profile aimed at battery devices that wake, send a short burst, and sleep. That duty-cycled design has made it the backbone of many [IoT](/reference/internet-of-things/) sensors, beacons, and wearables, where a coin cell must last months or years. Classic Bluetooth, by contrast, keeps a continuous stream open for audio and file transfer.
 
-Bluetooth is built for convenience over short distances at low power, not throughput. It is rarely part of a GopherTrunk data path, but its dense 2.4 GHz traffic — alongside Wi-Fi — is exactly the kind of noisy [spectrum](/reference/electromagnetic-spectrum/) an SDR user learns to recognize and avoid when siting an antenna.
+Unlike [Wi-Fi](/reference/wi-fi/), Bluetooth targets close-range, low-bandwidth links rather than network access; for touch-range pairing, [NFC](/reference/near-field-communication/) is closer still. All three share the same congested unlicensed spectrum, so they are engineered to coexist rather than to reach far.
+
+## Classic vs Low Energy
+
+The two flavours share a band and a name but are built for different jobs:
+
+| Trait | Classic Bluetooth | Low Energy (BLE) |
+|-------|-------------------|------------------|
+| Aimed at | Audio, continuous streams | Sensors, bursts, beacons |
+| Power draw | Higher | Very low (sleeps between bursts) |
+| Data rate | Up to ~2–3 Mb/s | ~0.1–2 Mb/s |
+| Connection | Held open | Brief, on demand |
+| Typical use | Headphones, speakers | Wearables, IoT, tags |
+
+Modern chips implement both, so one radio can stream music and also talk to a low-power fitness band.
+
+## Where it fits
+
+Bluetooth is built for convenience over short distances at low power, not throughput, so it is rarely part of a GopherTrunk data path. Its relevance to an SDR user is as *interference*: the dense, hopping 2.4 GHz traffic from Bluetooth and [Wi-Fi](/reference/wi-fi/) is exactly the kind of noisy [spectrum](/reference/electromagnetic-spectrum/) one learns to recognize and avoid when siting an antenna, and a nearby BLE device can raise the noise floor a wideband receiver sees.
 
 ## Sources
 
-[^wiki]: [Bluetooth](https://en.wikipedia.org/wiki/Bluetooth) — Wikipedia, on the short-range wireless standard.
+[^wiki]: [Bluetooth](https://en.wikipedia.org/wiki/Bluetooth) — Wikipedia, on the short-range wireless standard, piconets, and Bluetooth Low Energy.

--- a/docs/reference/broadcom.md
+++ b/docs/reference/broadcom.md
@@ -4,7 +4,7 @@ title: Broadcom
 entry_type: organization
 category: hw-organizations
 description: Broadcom is an American semiconductor and software company that makes networking, broadband, and wireless chips, including the SoCs at the heart of the Raspberry Pi.
-keywords: Broadcom, SoC, networking chips, wireless, broadband, semiconductor
+keywords: Broadcom, SoC, networking chips, wireless, broadband, semiconductor, Avago, BCM, Wi-Fi
 aka: [Broadcom Inc, Broadcom Corporation]
 autolink: true
 infobox:
@@ -12,7 +12,7 @@ infobox:
   - { label: Founded, value: "1991" }
   - { label: HQ, value: Palo Alto, California, USA }
   - { label: Makes, value: Networking, wireless, and broadband chips; SoCs }
-see_also: [raspberry-pi, system-on-a-chip, semiconductor]
+see_also: [raspberry-pi, system-on-a-chip, semiconductor, wi-fi, tsmc]
 cite_urls:
   - https://www.broadcom.com/
   - https://en.wikipedia.org/wiki/Broadcom
@@ -22,23 +22,63 @@ cite_urls:
 networking, broadband, and wireless chips, including the systems-on-chip used in the
 [Raspberry Pi](/reference/raspberry-pi/).[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 150" role="img" aria-label="A map of Broadcom's product areas. A central Broadcom node branches to Ethernet switch silicon, Wi-Fi and Bluetooth radios, broadband and set-top-box processors, storage controllers, and the BCM systems-on-chip that power the Raspberry Pi. A separate branch shows its expansion into enterprise software." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.1">
+    <line x1="82" y1="75" x2="200" y2="30"/>
+    <line x1="82" y1="75" x2="200" y2="58"/>
+    <line x1="82" y1="75" x2="200" y2="86"/>
+    <line x1="82" y1="75" x2="200" y2="114"/>
+    <line x1="82" y1="75" x2="200" y2="142"/>
+  </g>
+  <g stroke="currentColor" fill="currentColor" fill-opacity="0.12" stroke-width="1.2">
+    <rect x="16" y="60" width="66" height="30" rx="4"/>
+    <rect x="200" y="18" width="150" height="24" rx="4"/>
+    <rect x="200" y="46" width="150" height="24" rx="4"/>
+    <rect x="200" y="74" width="150" height="24" rx="4"/>
+    <rect x="200" y="102" width="150" height="24" rx="4"/>
+    <rect x="200" y="130" width="150" height="24" rx="4"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="9">
+    <text x="49" y="79" text-anchor="middle" font-weight="600">Broadcom</text>
+    <text x="210" y="34">Ethernet switch silicon</text>
+    <text x="210" y="62">Wi-Fi &amp; Bluetooth radios</text>
+    <text x="210" y="90">BCM SoC &#8594; Raspberry Pi</text>
+    <text x="210" y="118">broadband / set-top boxes</text>
+    <text x="210" y="146">enterprise software</text>
+  </g>
+</svg>
+<figcaption>Broadcom spans networking, wireless, and broadband silicon plus enterprise software; its most visible chip to makers is the BCM system-on-chip that powers Raspberry Pi boards.</figcaption>
+</figure>
+
 ## Overview
 
 The modern Broadcom traces back to a 1991 chip company and grew through a long series of
 mergers — most notably with Avago Technologies in 2016, after which the combined firm took
-the Broadcom name. Its products span Ethernet switch silicon, Wi-Fi and Bluetooth chips,
-set-top-box and broadband processors, and storage controllers.[^home]
+the Broadcom name. Its products span Ethernet switch silicon, [Wi-Fi](/reference/wi-fi/) and
+Bluetooth chips, set-top-box and broadband processors, and storage controllers.[^home]
 
 Broadcom designs the BCM-series [SoCs](/reference/system-on-a-chip/) that power Raspberry Pi
 boards, pairing an Arm CPU with a graphics core on one chip. In recent years the company has
 also expanded heavily into enterprise software through large acquisitions.
 
-## Why it matters
+## Growth by acquisition
+
+Broadcom's scale is largely the product of serial mega-mergers, blending chips and software:
+
+| Year | Deal | What it added |
+|------|------|---------------|
+| 2016 | Avago + Broadcom | The combined chip firm and the Broadcom name |
+| 2018 | CA Technologies | Enterprise/mainframe software |
+| 2019 | Symantec (enterprise) | Cybersecurity software |
+| 2023 | VMware | Data-center virtualization software |
+
+## Where it fits
 
 Broadcom's networking and wireless chips are inside a vast amount of consumer and data-center
 equipment, often unseen. For the maker world its most visible role is the Raspberry Pi SoC —
 which means a GopherTrunk capture node running on a Pi is, at its core, running on Broadcom
-silicon.
+silicon, fabricated (like most advanced chips) by a foundry such as [TSMC](/reference/tsmc/).
 
 ## Sources
 

--- a/docs/reference/build-vs-buy.md
+++ b/docs/reference/build-vs-buy.md
@@ -4,13 +4,14 @@ title: Build vs buy a PC
 entry_type: concept
 category: hw-personal-computers
 description: Build vs buy is the decision between assembling a desktop computer from individual components and purchasing a ready-made pre-built system, trading cost, control, and effort against convenience and warranty.
-keywords: build vs buy, custom PC, pre-built PC, DIY computer, PC building, component selection
+keywords: build vs buy, custom PC, pre-built PC, DIY computer, PC building, component selection, warranty, upgradeability
 infobox:
   - { label: Type, value: Decision / trade-off }
   - { label: Build, value: Cheaper, custom, more effort }
   - { label: Buy, value: Convenient, warrantied, turnkey }
+  - { label: Shared need, value: Parts must be compatible }
   - { label: Applies to, value: Desktop PCs }
-see_also: [desktop-computer, gaming-pc, motherboard, computer-case, personal-computer]
+see_also: [desktop-computer, gaming-pc, motherboard, computer-case, personal-computer, workstation]
 related_lessons:
   - { title: "Choosing a dev machine", url: /learn/intro-hardware/choosing-a-dev-machine/ }
 cite_urls:
@@ -19,13 +20,81 @@ cite_urls:
 
 **Build vs buy** is the decision, when getting a [desktop computer](/reference/desktop-computer/), between assembling it yourself from separate components and purchasing a ready-made pre-built system.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 200" role="img" aria-label="A build-versus-buy decision split. One branch gathers separate parts — CPU, motherboard, RAM, GPU, PSU, and case — and assembles them into a PC for lower cost and full control. The other branch takes a single sealed pre-built box for convenience and one warranty." xmlns="http://www.w3.org/2000/svg">
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="230" y="16" font-size="9" font-weight="600">getting a desktop</text>
+  </g>
+  <g stroke="currentColor" fill="none" stroke-width="1.2">
+    <path d="M230 22 L120 46 M230 22 L340 46"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle" font-size="9" font-weight="600">
+    <text x="120" y="42">BUILD</text>
+    <text x="340" y="42">BUY</text>
+  </g>
+  <g stroke="currentColor" fill="none" stroke-width="1.1">
+    <rect x="30" y="56" width="42" height="20" rx="2"/>
+    <rect x="80" y="56" width="42" height="20" rx="2"/>
+    <rect x="130" y="56" width="42" height="20" rx="2"/>
+    <rect x="30" y="84" width="42" height="20" rx="2"/>
+    <rect x="80" y="84" width="42" height="20" rx="2"/>
+    <rect x="130" y="84" width="42" height="20" rx="2"/>
+    <path d="M100 108 L100 128"/>
+    <rect x="78" y="130" width="44" height="52" rx="3" fill="currentColor" fill-opacity="0.1"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle" font-size="7">
+    <text x="51" y="69">CPU</text>
+    <text x="101" y="69">board</text>
+    <text x="151" y="69">RAM</text>
+    <text x="51" y="97">GPU</text>
+    <text x="101" y="97">PSU</text>
+    <text x="151" y="97">case</text>
+    <text x="100" y="160" font-size="8">your</text>
+    <text x="100" y="172" font-size="8">PC</text>
+  </g>
+  <g stroke="currentColor" fill="none" stroke-width="1.1">
+    <rect x="318" y="70" width="44" height="34" rx="3" fill="currentColor" fill-opacity="0.16"/>
+    <path d="M340 108 L340 128"/>
+    <rect x="318" y="130" width="44" height="52" rx="3" fill="currentColor" fill-opacity="0.1"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle" font-size="7">
+    <text x="340" y="90">sealed</text>
+    <text x="340" y="99">box</text>
+    <text x="340" y="160" font-size="8">ready</text>
+    <text x="340" y="172" font-size="8">PC</text>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle" font-size="7.5" fill-opacity="0.85">
+    <text x="100" y="196">cheaper · custom · your labor</text>
+    <text x="340" y="196">turnkey · one warranty · premium</text>
+  </g>
+</svg>
+<figcaption>Building means sourcing each compatible part and assembling it yourself for lower cost and full control; buying means one tested box under a single warranty. Either way the parts must fit — board to socket, board to case, PSU to load.</figcaption>
+</figure>
+
 ## Overview
 
-Building means choosing each part — [CPU](/reference/central-processing-unit/), [motherboard](/reference/motherboard/), [RAM](/reference/random-access-memory/), [GPU](/reference/graphics-processing-unit/), [storage](/reference/solid-state-drive/), [power supply](/reference/power-supply-unit/), and [case](/reference/computer-case/) — and fitting them together yourself. Buying means a vendor delivers a complete, tested machine under a single warranty. The parts must still be compatible either way: the [motherboard form factor](/reference/motherboard-form-factor/) has to match the case, the CPU has to match the board's socket, and the power supply has to be sized for the load.
+Building means choosing each part — [CPU](/reference/central-processing-unit/), [motherboard](/reference/motherboard/), [RAM](/reference/random-access-memory/), [GPU](/reference/graphics-processing-unit/), [storage](/reference/solid-state-drive/), [power supply](/reference/power-supply-unit/), and [case](/reference/computer-case/) — and fitting them together yourself. Buying means a vendor delivers a complete, tested machine under a single warranty.
+
+The parts must still be compatible either way: the [motherboard form factor](/reference/motherboard-form-factor/) has to match the case, the CPU has to match the board's socket, and the power supply has to be sized for the load. A pre-built simply pushes those checks onto the vendor.
 
 ## Trade-offs
 
-Building usually costs less for the same performance, lets you pick exactly the parts you want, and makes future upgrades easy — at the price of your time, the learning curve, and the fact that you troubleshoot any problems yourself. Buying is faster and lower-risk, with one company on the hook for support, but you pay a premium and accept whatever components and limited upgradeability the vendor chose. Building shines for [gaming PCs](/reference/gaming-pc/) and enthusiast [workstations](/reference/workstation/); buying suits anyone who just wants a working machine. For a GopherTrunk bench either works — the radio front end is a USB dongle regardless of how the host PC was put together.
+The two paths weigh cost and control against convenience and support:
+
+| Factor | Build | Buy |
+|--------|-------|-----|
+| Cost per performance | Usually lower | Higher (assembly premium) |
+| Part choice | Exactly what you pick | Vendor's selection |
+| Setup effort | Hours + learning curve | Unbox and go |
+| Warranty | Per component | One, whole system |
+| Upgrades later | Easy | Often limited |
+| Troubleshooting | You | The vendor |
+
+Building shines for [gaming PCs](/reference/gaming-pc/) and enthusiast [workstations](/reference/workstation/); buying suits anyone who just wants a working machine.
+
+## Where it fits
+
+The choice is really about how much of the risk and effort you want to own. Build when the savings, the exact spec, or the upgrade path matter to you and you enjoy the assembly; buy when time and a single point of support matter more. For a GopherTrunk bench either works — the radio front end is a USB dongle regardless of how the host PC was put together, so a pre-built and a hand-built machine decode identically.
 
 ## Sources
 

--- a/docs/reference/cellular-modem.md
+++ b/docs/reference/cellular-modem.md
@@ -17,9 +17,57 @@ cite_urls:
 
 A **cellular modem** is the radio subsystem that connects a device to mobile networks — 4G LTE, 5G, and their predecessors — handling the RF, [modulation](/reference/modulation/), and protocols that carry calls and data over licensed cellular bands.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 150" role="img" aria-label="A cellular modem signal chain. From an antenna, signals pass through an RF front end that filters and amplifies, then a transceiver that converts between radio and baseband, then the baseband processor running the protocol stack, which connects to the main SoC. A SIM or eSIM plugs into the baseband to supply the subscriber identity." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.2" font-family="ui-sans-serif, sans-serif">
+    <path d="M40 40 l-8 -16 M40 40 l8 -16 M40 40 v46" stroke-width="1.2"/>
+    <g fill-opacity="0" >
+      <rect x="66" y="46" width="70" height="40" rx="3"/>
+      <rect x="156" y="46" width="70" height="40" rx="3"/>
+      <rect x="246" y="46" width="80" height="40" rx="3"/>
+      <rect x="346" y="46" width="76" height="40" rx="3"/>
+      <rect x="246" y="106" width="80" height="30" rx="3"/>
+    </g>
+    <line x1="48" y1="66" x2="66" y2="66"/>
+    <line x1="136" y1="66" x2="156" y2="66"/>
+    <line x1="226" y1="66" x2="246" y2="66"/>
+    <line x1="326" y1="66" x2="346" y2="66"/>
+    <line x1="286" y1="86" x2="286" y2="106"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle" font-family="ui-sans-serif, sans-serif" font-size="8.5">
+    <text x="40" y="100">antenna</text>
+    <text x="101" y="63">RF front</text>
+    <text x="101" y="74">end</text>
+    <text x="191" y="63">trans-</text>
+    <text x="191" y="74">ceiver</text>
+    <text x="286" y="63">baseband</text>
+    <text x="286" y="74">processor</text>
+    <text x="384" y="63">main</text>
+    <text x="384" y="74">SoC</text>
+    <text x="286" y="124">SIM / eSIM</text>
+  </g>
+</svg>
+<figcaption>A cellular modem chains an RF front end, a transceiver, and a baseband processor running the protocol stack; the SIM or eSIM supplies the subscriber identity, and the whole block hands data to the main SoC.</figcaption>
+</figure>
+
 ## Overview
 
-Often called the *baseband processor*, a cellular modem runs its own real-time firmware and manages the complex dance of attaching to a tower, negotiating bandwidth, and hopping between cells. It is paired with a subscriber identity from a SIM or an [eSIM](/reference/esim/). In a phone the modem is usually a block inside the main [SoC](/reference/system-on-a-chip/) (or a companion chip), wired to its own antennas separate from Wi-Fi and [GPS](/reference/gps-receiver/).
+Often called the *baseband processor*, a cellular modem runs its own real-time firmware and manages the complex dance of attaching to a tower, negotiating bandwidth, authenticating, and hopping between cells as the device moves. It is paired with a subscriber identity from a SIM or an [eSIM](/reference/esim/), which the network uses to identify and bill the account.
+
+In a phone the modem is usually a block inside the main [SoC](/reference/system-on-a-chip/) (or a companion chip), wired to its own antennas separate from Wi-Fi and [GPS](/reference/gps-receiver/). Its firmware is a large, security-sensitive body of code — effectively a second computer beside the application processor — precisely because cellular protocols are so intricate and standardized across generations.
+
+## Cellular generations
+
+Each generation raised data rates and reworked the air interface the modem must speak:
+
+| Generation | Era | Peak rate (order) | Note |
+|-----------|-----|-------------------|------|
+| 2G (GSM) | 1990s | tens of kbit/s | Digital voice, SMS |
+| 3G (UMTS) | 2000s | a few Mbit/s | Mobile data arrives |
+| 4G (LTE) | 2010s | tens–100s Mbit/s | All-IP, VoLTE |
+| 5G (NR) | 2020s | ~Gbit/s | mmWave, low latency |
+
+A modern modem is multi-mode, falling back through these as coverage allows.
 
 ## Where it fits
 

--- a/docs/reference/chromebook.md
+++ b/docs/reference/chromebook.md
@@ -4,7 +4,7 @@ title: Chromebook
 entry_type: hardware
 category: hw-personal-computers
 description: A Chromebook is a laptop or tablet running Google's ChromeOS, a lightweight operating system built around the Chrome browser and web apps, with most data stored in the cloud.
-keywords: Chromebook, ChromeOS, Chrome browser, web apps, education laptop, cloud computing
+keywords: Chromebook, ChromeOS, Chrome browser, web apps, education laptop, cloud computing, Android apps, Linux container
 aka: [ChromeOS device]
 autolink: true
 infobox:
@@ -22,13 +22,54 @@ cite_urls:
 
 A **Chromebook** is a [laptop](/reference/laptop/) or tablet that runs Google's ChromeOS, a lightweight [operating system](/reference/operating-system/) built around the Chrome web browser and cloud services.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 180" role="img" aria-label="A Chromebook leaning on the cloud: a laptop runs a browser locally with only a small SSD, while web apps, documents, and settings live on remote cloud servers reached over the network, so most compute and storage happen off the device." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.3">
+    <rect x="40" y="70" width="150" height="90" rx="4"/>
+    <rect x="52" y="82" width="126" height="52" fill="currentColor" fill-opacity="0.08"/>
+    <path d="M30 160 H200 L210 172 H20 Z" fill="currentColor" fill-opacity="0.12"/>
+    <rect x="60" y="118" width="30" height="10" rx="1"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle" font-size="7.5">
+    <text x="115" y="96" font-size="8">Chrome browser</text>
+    <text x="75" y="126" font-size="6.5">small SSD</text>
+    <text x="115" y="152" fill-opacity="0.85">local: draw the page</text>
+  </g>
+  <g stroke="currentColor" fill="none" stroke-width="1.3">
+    <path d="M300 44 a26 20 0 0 1 4 -40 a30 24 0 0 1 56 6 a22 18 0 0 1 6 34 Z" fill="currentColor" fill-opacity="0.1"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle" font-size="7.5">
+    <text x="332" y="30" font-size="8">cloud</text>
+    <text x="332" y="60">web apps · files · settings</text>
+  </g>
+  <g stroke="currentColor" fill="none" stroke-width="1.2">
+    <path d="M195 100 C250 100 250 40 300 34" stroke-dasharray="4 3"/>
+    <path d="M298 40 L300 34 L294 33" stroke-dasharray="0"/>
+  </g>
+  <text x="250" y="118" fill="currentColor" stroke="none" text-anchor="middle" font-size="7" fill-opacity="0.85">network</text>
+</svg>
+<figcaption>A Chromebook keeps the hardware light and pushes the heavy lifting to the cloud: the device runs the Chrome browser and holds little locally, while apps, documents, and settings sync to remote servers over the network.</figcaption>
+</figure>
+
 ## Overview
 
-Where a traditional [personal computer](/reference/personal-computer/) installs heavyweight desktop applications, a Chromebook leans on web apps that run inside the browser, with most documents and settings synced to the cloud. Hardware is modest by design — a low-power [CPU](/reference/central-processing-unit/), modest [RAM](/reference/random-access-memory/), and a small [SSD](/reference/solid-state-drive/) or [eMMC](/reference/emmc/) — which keeps Chromebooks cheap, fast to boot, and long on battery life. Modern models also run Android apps and an optional Linux container for development.
+Where a traditional [personal computer](/reference/personal-computer/) installs heavyweight desktop applications, a Chromebook leans on web apps that run inside the browser, with most documents and settings synced to the cloud. Hardware is modest by design — a low-power [CPU](/reference/central-processing-unit/), modest [RAM](/reference/random-access-memory/), and a small [SSD](/reference/solid-state-drive/) or [eMMC](/reference/emmc/) — which keeps Chromebooks cheap, fast to boot, and long on battery life.
+
+Modern models widen the software story beyond the browser: many run Android apps from the Play Store and an optional Linux container for development, so a Chromebook is no longer strictly a web-only device. It still assumes a network for most real work, and its automatic-update model and central management are part of why schools favor it.
+
+## How it compares
+
+A Chromebook sits between a full laptop and a pure [thin client](/reference/thin-client/):
+
+| Machine | OS | Local compute | Runs offline | Typical cost |
+|---------|----|--------------:|--------------|--------------|
+| Chromebook | ChromeOS | Low | Partly | Low |
+| Windows/Mac laptop | Full desktop OS | High | Fully | Medium–high |
+| Thin client | Minimal firmware | Very low | No | Low |
 
 ## Where it fits
 
-Chromebooks dominate classrooms and suit anyone whose work lives in a browser: email, documents, video calls, and SaaS tools. They behave somewhat like a self-contained [thin client](/reference/thin-client/), leaning on remote services rather than local power. The trade-off is limited offline software and weak local compute — heavy native workloads, including most SDR DSP, want a full laptop or desktop instead.
+Chromebooks dominate classrooms and suit anyone whose work lives in a browser: email, documents, video calls, and SaaS tools. They behave somewhat like a self-contained thin client, leaning on remote services rather than local power, but keep enough local capability to work through a brief outage. The trade-off is limited offline software and weak local compute — heavy native workloads, including most SDR DSP, want a full [laptop](/reference/laptop/) or [desktop](/reference/desktop-computer/) instead.
 
 ## Sources
 

--- a/docs/reference/colocation.md
+++ b/docs/reference/colocation.md
@@ -4,13 +4,14 @@ title: Colocation
 entry_type: concept
 category: hw-servers
 description: Colocation is renting space, power, cooling, and network connectivity in a data center for hardware you own, so you keep your own servers while outsourcing the facility.
-keywords: colocation, colo, data center space, rack space, hosting your own hardware
+keywords: colocation, colo, data center space, rack space, cage, hosting your own hardware, cross-connect
 aka: [Colo]
 infobox:
   - { label: Type, value: Hosting model }
   - { label: You provide, value: The hardware }
   - { label: Facility provides, value: Space, power, cooling, network }
   - { label: Sold by, value: Rack, cabinet, or cage }
+  - { label: Contrast, value: Cloud / managed hosting }
 see_also: [data-center, dedicated-server, rack-server, managed-hosting, cloud-computing, server]
 related_lessons:
   - { title: "Dedicated servers", url: /learn/intro-hardware/dedicated-servers/ }
@@ -20,13 +21,63 @@ cite_urls:
 
 **Colocation** (colo) is renting space, power, cooling, and network connectivity in a [data center](/reference/data-center/) for hardware you own — you keep your own [servers](/reference/server/) while outsourcing the building around them.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 190" role="img" aria-label="A data-center building outline contains a locked cage holding a customer-owned server rack. Arrows from the facility feed power, cooling, and a network uplink into the cage, while a label shows the customer owns and maintains the servers inside." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="currentColor" font-family="ui-sans-serif, sans-serif">
+    <rect x="120" y="24" width="320" height="150" rx="4" fill-opacity="0.04" stroke-width="1.4"/>
+    <text x="280" y="18" text-anchor="middle" font-size="9" font-weight="600" stroke="none">Provider's data center</text>
+    <rect x="250" y="52" width="120" height="104" rx="3" fill-opacity="0.10" stroke-width="1.3" stroke-dasharray="4 3"/>
+    <text x="310" y="66" text-anchor="middle" font-size="8" stroke="none" fill-opacity="0.9">your locked cage</text>
+    <g stroke-width="1.1">
+      <rect x="272" y="74" width="76" height="74" rx="2" fill-opacity="0.06"/>
+      <rect x="278" y="80" width="64" height="12" rx="1" fill-opacity="0.16"/>
+      <rect x="278" y="96" width="64" height="12" rx="1" fill-opacity="0.16"/>
+      <rect x="278" y="112" width="64" height="12" rx="1" fill-opacity="0.16"/>
+      <rect x="278" y="128" width="64" height="12" rx="1" fill-opacity="0.16"/>
+    </g>
+    <text x="310" y="164" text-anchor="middle" font-size="7.5" stroke="none" fill-opacity="0.85">your servers</text>
+    <g stroke-width="1.3" fill="none">
+      <line x1="150" y1="70" x2="248" y2="70"/>
+      <line x1="150" y1="104" x2="248" y2="104"/>
+      <line x1="150" y1="138" x2="248" y2="138"/>
+    </g>
+    <g stroke-width="1.3" fill="currentColor">
+      <path d="M248 70 l-8 -3 v6 z"/>
+      <path d="M248 104 l-8 -3 v6 z"/>
+      <path d="M248 138 l-8 -3 v6 z"/>
+    </g>
+    <g font-size="8" stroke="none" text-anchor="end">
+      <text x="146" y="67">Power</text>
+      <text x="146" y="101">Cooling</text>
+      <text x="146" y="135">Network uplink</text>
+    </g>
+    <text x="146" y="150" text-anchor="end" font-size="7.5" stroke="none" fill-opacity="0.7">(facility provides)</text>
+  </g>
+</svg>
+<figcaption>You buy and install the servers; the colocation provider supplies the secured space plus metered power, cooling, and network uplink around them — a split between owning the machines and outsourcing the facility.</figcaption>
+</figure>
+
 ## Overview
 
-A colocation provider sells you a slice of the facility — a few [rack-server](/reference/rack-server/) units, a full cabinet, or a locked cage — plus metered power, cooling, and uplink bandwidth. You buy, install, and maintain the machines; they guarantee the environment and uptime. This sits between running a [home server](/reference/home-server/) (you own everything, including the room) and renting compute outright.
+A colocation provider sells you a slice of the facility — a few [rack-server](/reference/rack-server/) units, a full cabinet, or a locked cage — plus metered power, cooling, and uplink bandwidth. You buy, install, and maintain the machines; they guarantee the environment and uptime, along with physical security and often a fast *cross-connect* to carriers or cloud on-ramps.
+
+This sits between running a [home server](/reference/home-server/) (you own everything, including the room) and renting compute outright. The appeal is keeping full ownership and control of the hardware while gaining a facility you could never economically build: redundant power, industrial cooling, and carrier-grade connectivity.
+
+## Tiers
+
+Colocation is usually sold at one of three granularities, trading price for isolation and control:
+
+| Unit | What you get | Typical tenant |
+|------|--------------|----------------|
+| Rack units | A few U in a shared cabinet | One or two servers |
+| Cabinet | A full lockable rack | Small business |
+| Cage | Fenced private floor space | Compliance-heavy or large fleets |
+
+Power is metered (per kilowatt or per circuit), and providers bill separately for cross-connects and extra bandwidth, so the real cost depends as much on power draw as on floor space.
 
 ## Where it fits
 
-Colocation suits organizations that have already invested in hardware, need physical control of their machines, or have compliance reasons to keep ownership, but lack a reliable facility of their own. The alternatives are a fully provider-owned [dedicated server](/reference/dedicated-server/), a [managed hosting](/reference/managed-hosting/) arrangement where the provider also runs the software, or [cloud computing](/reference/cloud-computing/) where you rent capacity with no hardware at all.
+Colocation suits organizations that have already invested in hardware, need physical control of their machines, or have compliance reasons to keep ownership, but lack a reliable facility of their own. The alternatives are a fully provider-owned [dedicated server](/reference/dedicated-server/), a [managed hosting](/reference/managed-hosting/) arrangement where the provider also runs the software, or [cloud computing](/reference/cloud-computing/) where you rent capacity with no hardware at all. A GopherTrunk back end could be colocated, but the RF capture still belongs at the antenna, not in the colo cage.
 
 ## Sources
 

--- a/docs/reference/compute-module.md
+++ b/docs/reference/compute-module.md
@@ -4,7 +4,7 @@ title: Compute Module
 entry_type: hardware
 category: hw-sbc
 description: A Compute Module is a single-board computer stripped to a small module without ports, designed to be soldered or socketed into a custom carrier board for embedded products.
-keywords: Raspberry Pi Compute Module, CM4, CM5, SO-DIMM module, carrier board, system on module, embedded SBC
+keywords: Raspberry Pi Compute Module, CM4, CM5, SO-DIMM module, carrier board, system on module, embedded SBC, custom carrier
 aka: [Raspberry Pi Compute Module, CM4]
 infobox:
   - { label: Type, value: Embeddable SBC module }
@@ -21,13 +21,54 @@ cite_urls:
 
 **A Compute Module** is a [single-board computer](/reference/single-board-computer/) stripped down to a small module — the processor, memory, and storage — without the usual ports, meant to plug into a custom carrier board.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 180" role="img" aria-label="A Compute Module plugging into a carrier board. The small module carries only the system-on-chip, RAM, and storage, and its edge connector mates into a slot on a larger custom carrier board. The carrier is where the product designer places the actual ports — USB, Ethernet, GPIO, power — laid out exactly as the product needs." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.3">
+    <rect x="30" y="96" width="400" height="70" rx="6" fill-opacity="0.05" fill="currentColor"/>
+    <rect x="150" y="120" width="160" height="10" rx="2" fill-opacity="0.2" fill="currentColor"/>
+    <rect x="150" y="22" width="160" height="66" rx="4" fill-opacity="0.1" fill="currentColor"/>
+    <rect x="164" y="34" width="30" height="24" rx="2" fill-opacity="0.2" fill="currentColor"/>
+    <rect x="204" y="34" width="20" height="24" rx="2" fill-opacity="0.16" fill="currentColor"/>
+    <rect x="234" y="34" width="20" height="24" rx="2" fill-opacity="0.16" fill="currentColor"/>
+    <path d="M175 88 V120 M285 88 V120" stroke-width="1.1"/>
+    <rect x="46" y="120" width="14" height="30" rx="2" fill-opacity="0.14" fill="currentColor"/>
+    <rect x="66" y="120" width="14" height="30" rx="2" fill-opacity="0.14" fill="currentColor"/>
+    <rect x="336" y="120" width="24" height="18" rx="2" fill-opacity="0.14" fill="currentColor"/>
+    <rect x="370" y="120" width="24" height="18" rx="2" fill-opacity="0.14" fill="currentColor"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="8.5">
+    <text x="230" y="19" text-anchor="middle" font-size="9" font-weight="600">Compute Module</text>
+    <text x="179" y="50" text-anchor="middle" font-size="7.5">SoC</text>
+    <text x="214" y="50" text-anchor="middle" font-size="7">RAM</text>
+    <text x="244" y="50" text-anchor="middle" font-size="7">eMMC</text>
+    <text x="230" y="128" text-anchor="middle" font-size="7.5" fill-opacity="0.9">edge connector</text>
+    <text x="230" y="160" text-anchor="middle" font-weight="600">custom carrier board</text>
+    <text x="63" y="143" text-anchor="middle" font-size="7">ports</text>
+    <text x="365" y="132" text-anchor="middle" font-size="7">ports</text>
+  </g>
+</svg>
+<figcaption>A Compute Module holds only the brains — SoC, RAM, and storage — and mates through an edge connector into a carrier board that the product designer lays out with exactly the ports and shape the product requires.</figcaption>
+</figure>
+
 ## Overview
 
-The best-known example is the Raspberry Pi Compute Module (CM4, CM5), but the idea is general: take the [system on a chip](/reference/system-on-a-chip/) and memory of a board like the [Raspberry Pi](/reference/raspberry-pi/) and put it on a compact, breakable-out module. A product designer then lays out a *carrier board* that routes the [GPIO](/reference/gpio/), USB, Ethernet, and power exactly as the product needs, rather than working around a fixed consumer layout.
+The best-known example is the Raspberry Pi Compute Module (CM4, CM5), but the idea is general: take the [system on a chip](/reference/system-on-a-chip/) and memory of a board like the [Raspberry Pi](/reference/raspberry-pi/) and put it on a compact module that breaks all of its signals out to an edge connector. A product designer then lays out a *carrier board* that routes the [GPIO](/reference/gpio/), USB, Ethernet, and power exactly as the product needs, rather than working around a fixed consumer layout.
+
+This separation lets one well-supported compute module serve many different products. The same module drops into a digital-signage player, an industrial gateway, or a camera, and each carrier exposes only the connectors that product uses. It also decouples the two design cadences: the module vendor handles the tricky high-speed SoC-to-memory routing, while your team designs the comparatively simple carrier.
+
+## Module vs stock board
+
+| | Stock SBC | Compute Module |
+|---|-----------|----------------|
+| Ports | Fixed, on the board | You choose, on the carrier |
+| Shape / size | Fixed | Whatever the product needs |
+| Effort to deploy | Plug in and go | Design + build a carrier |
+| Best for | Prototypes, hobby, general use | Volume embedded products |
+| Extending | [HAT](/reference/hat-add-on-board/) on the header | Integrated into the carrier |
 
 ## Where it fits
 
-A Compute Module is the choice when an [embedded system](/reference/embedded-system/) needs the brains of an SBC but its own enclosure, connectors, and shape — a step beyond bolting a [HAT](/reference/hat-add-on-board/) onto a stock board. In a GopherTrunk-style product, a Compute Module on a custom carrier could host the SDR front end and storage in a sealed, antenna-mounted capture node. The trade-off is engineering effort: you design and manufacture the carrier yourself.
+A Compute Module is the choice when an [embedded system](/reference/embedded-system/) needs the brains of an SBC but its own enclosure, connectors, and shape — a step beyond bolting a [HAT](/reference/hat-add-on-board/) onto a stock board. In a GopherTrunk-style product, a Compute Module on a custom carrier could host the SDR front end, timing, and storage in a sealed, antenna-mounted capture node with only the connectors it actually uses. The trade-off is engineering effort: you design, lay out, and manufacture the carrier yourself, which only pays off past a certain volume.
 
 ## Sources
 

--- a/docs/reference/computer-case.md
+++ b/docs/reference/computer-case.md
@@ -4,12 +4,13 @@ title: Computer case
 entry_type: hardware
 category: hw-personal-computers
 description: A computer case is the enclosure that houses and protects a desktop PC's components, providing mounting points, airflow, and cable routing for the motherboard, power supply, drives, and cards.
-keywords: computer case, PC case, chassis, tower, ATX case, airflow, form factor
+keywords: computer case, PC case, chassis, tower, ATX case, airflow, form factor, small form factor, cable management
 aka: [PC case, Chassis, Tower]
 infobox:
   - { label: Type, value: PC enclosure }
   - { label: Houses, value: Motherboard, PSU, drives, cards }
   - { label: Sizes, value: Full / mid / mini tower, SFF }
+  - { label: Job, value: Mounting + airflow + cabling }
   - { label: Matches, value: Motherboard form factor }
 see_also: [desktop-computer, motherboard, motherboard-form-factor, power-supply-unit, cooling-and-thermals]
 related_lessons:
@@ -20,13 +21,57 @@ cite_urls:
 
 A **computer case** is the enclosure that houses and protects a [desktop computer](/reference/desktop-computer/)'s components, giving each part a place to mount and a path for air and cables.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 210" role="img" aria-label="A cutaway of a tower PC case showing where the parts mount: the motherboard on the right wall, the power supply in a bottom bay, drives in a front bay, and a graphics card in a horizontal slot, with a front intake fan and a rear exhaust fan setting the airflow front to back." xmlns="http://www.w3.org/2000/svg">
+  <rect x="70" y="20" width="320" height="170" rx="4" stroke="currentColor" fill="none" stroke-width="1.5"/>
+  <g stroke="currentColor" fill="none" stroke-width="1.1">
+    <rect x="210" y="34" width="130" height="96" fill="currentColor" fill-opacity="0.07"/>
+    <rect x="230" y="52" width="34" height="34" fill="currentColor" fill-opacity="0.14"/>
+    <rect x="210" y="140" width="130" height="34" fill="currentColor" fill-opacity="0.1"/>
+    <rect x="86" y="120" width="60" height="54" fill="currentColor" fill-opacity="0.1"/>
+    <rect x="150" y="150" width="150" height="16" fill="currentColor" fill-opacity="0.14"/>
+    <circle cx="98" cy="60" r="18"/>
+    <circle cx="362" cy="60" r="14"/>
+  </g>
+  <g stroke="currentColor" fill="none" stroke-width="1.1" stroke-dasharray="4 3">
+    <path d="M118 60 H230"/>
+    <path d="M300 60 H346"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="7.5" text-anchor="middle">
+    <text x="247" y="72">CPU</text>
+    <text x="290" y="44" font-size="7">motherboard</text>
+    <text x="275" y="160">PSU</text>
+    <text x="116" y="150">drive</text>
+    <text x="116" y="162">bay</text>
+    <text x="225" y="161" font-size="7">graphics card</text>
+    <text x="98" y="62" font-size="6.5">intake</text>
+    <text x="362" y="62" font-size="6.5">exhaust</text>
+    <text x="174" y="52" font-size="7" fill-opacity="0.85">airflow &#8594;</text>
+  </g>
+</svg>
+<figcaption>The case gives every part a home and a path for air: the motherboard and CPU on one wall, the power supply in a bottom bay, drives up front, and a graphics card in a slot — with a front intake and rear exhaust fan pulling cool air across the hot parts.</figcaption>
+</figure>
+
 ## Overview
 
-The case holds the [motherboard](/reference/motherboard/), the [power supply unit](/reference/power-supply-unit/), drives, and expansion cards, with standoffs and brackets sized to standard layouts. Its job beyond mounting is *thermal*: fans and vents move air across the hot parts so [cooling](/reference/cooling-and-thermals/) keeps the CPU and GPU from throttling. Cases come in sizes — full, mid, and mini towers down to small-form-factor boxes — and each is built to accept a particular [motherboard form factor](/reference/motherboard-form-factor/) such as ATX or Mini-ITX.
+The case holds the [motherboard](/reference/motherboard/), the [power supply unit](/reference/power-supply-unit/), drives, and expansion cards, with standoffs and brackets sized to standard layouts. Its job beyond mounting is *thermal*: fans and vents move air across the hot parts so [cooling](/reference/cooling-and-thermals/) keeps the CPU and GPU from throttling. Good cases also route cables out of the airflow, which keeps the machine both tidy and cool.
+
+Cases come in a range of sizes, and each is built to accept a particular [motherboard form factor](/reference/motherboard-form-factor/) such as ATX or Mini-ITX. Bigger cases take bigger boards, more drives, and larger coolers; smaller ones save desk space but tighten every clearance.
+
+## Sizes
+
+Case size is chosen to match the board and the amount of expansion you need:
+
+| Case size | Board it fits | Drive / card room | Best for |
+|-----------|---------------|-------------------|----------|
+| Full tower | E-ATX, ATX | Most | Workstations, big cooling |
+| Mid tower | ATX, Micro-ATX | Plenty | Typical desktop / gaming |
+| Mini tower | Micro-ATX | Some | Compact desktop |
+| Small form factor | Mini-ITX | Minimal | Living room, small desk |
 
 ## Where it fits
 
-The case is the one part that does no computing yet shapes the whole build: it decides which boards fit, how many drives and cards you can add, how quiet the machine runs, and how it looks on the desk. A roomy tower eases upgrades and airflow; a small case saves space at the cost of expansion and cooling headroom. A pre-built [all-in-one computer](/reference/all-in-one-computer/) or [mini PC](/reference/mini-pc/) hides this choice inside a fixed enclosure.
+The case is the one part that does no computing yet shapes the whole build: it decides which boards fit, how many drives and cards you can add, how quiet the machine runs, and how it looks on the desk. A roomy tower eases upgrades and airflow; a small case saves space at the cost of expansion and cooling headroom. A pre-built [all-in-one computer](/reference/all-in-one-computer/) or [mini PC](/reference/mini-pc/) hides this choice inside a fixed enclosure — fine for a GopherTrunk host that never needs opening, less so for a bench you plan to grow.
 
 ## Sources
 

--- a/docs/reference/computer-hardware.md
+++ b/docs/reference/computer-hardware.md
@@ -4,11 +4,12 @@ title: Computer hardware
 entry_type: concept
 category: hw-foundations
 description: Computer hardware is the physical, touchable part of a computing device — the chips, boards, memory, and drives — as distinct from the software that runs on it.
-keywords: computer hardware, physical components, input process output, CPU memory storage I/O, hardware vs software
+keywords: computer hardware, physical components, input process output, CPU memory storage I/O, hardware vs software, building blocks
 aka: [computer hardware, hardware]
 infobox:
   - { label: Type, value: Physical computing parts }
   - { label: Opposite of, value: Software }
+  - { label: Model, value: Input → process → output }
   - { label: Building blocks, value: CPU, memory, storage, I/O }
   - { label: Range, value: Sensor chip to data-center server }
 see_also: [central-processing-unit, random-access-memory, data-storage, input-output, hardware-spectrum]
@@ -21,13 +22,58 @@ cite_urls:
 
 **Computer hardware** is the set of physical parts you can touch — the chips, circuit boards, memory modules, drives, and case — as opposed to the [software](/reference/operating-system/) that tells them what to do.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 160" role="img" aria-label="A block diagram of the input-process-output model. Input devices feed data to the central processing unit, which works with random-access memory and long-term storage to process it, and the result goes out through output devices." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.2">
+    <rect x="14" y="60" width="80" height="40" rx="4"/>
+    <rect x="180" y="60" width="100" height="40" rx="4" fill="currentColor" fill-opacity="0.14"/>
+    <rect x="366" y="60" width="80" height="40" rx="4"/>
+    <rect x="180" y="10" width="100" height="28" rx="4"/>
+    <rect x="180" y="122" width="100" height="28" rx="4"/>
+  </g>
+  <g stroke="currentColor" stroke-width="1.2" fill="none">
+    <path d="M94 80 h74 m-6 -4 l6 4 l-6 4"/>
+    <path d="M280 80 h74 m-6 -4 l6 4 l-6 4"/>
+    <path d="M230 38 v14 m-4 -6 l4 6 l4 -6"/>
+    <path d="M230 100 v14 m-4 -6 l4 6 l4 -6"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="54" y="77" font-size="9">Input</text>
+    <text x="54" y="90" font-size="7.5" fill-opacity="0.85">keyboard, sensor</text>
+    <text x="230" y="77" font-size="9" font-weight="600">Process (CPU)</text>
+    <text x="230" y="90" font-size="7.5" fill-opacity="0.85">run instructions</text>
+    <text x="406" y="77" font-size="9">Output</text>
+    <text x="406" y="90" font-size="7.5" fill-opacity="0.85">screen, radio</text>
+    <text x="230" y="28" font-size="8.5">Memory (RAM)</text>
+    <text x="230" y="140" font-size="8.5">Storage (disk)</text>
+  </g>
+</svg>
+<figcaption>Every computer, from a sensor chip to a data-center server, follows the same input-process-output model: input arrives, the CPU works with memory and storage to process it, and output goes back out — the four building blocks that hardware provides.</figcaption>
+</figure>
+
 ## Overview
+
 A computer is anything that takes **input**, follows instructions to **process** it, and produces **output**. That definition spans an enormous range: a warehouse [server](/reference/server/), the [laptop](/reference/laptop/) on your desk, and the tiny chip inside a sensor are all computers by the same rule.
 
-Nearly every one of them is built from the same four building blocks: a [central processing unit](/reference/central-processing-unit/) to run instructions, [random-access memory](/reference/random-access-memory/) for active working data, [storage](/reference/data-storage/) for data that must survive a power cycle, and [input/output](/reference/input-output/) to move data in and out.
+Nearly every one of them is built from the same four building blocks: a [central processing unit](/reference/central-processing-unit/) to run instructions, [random-access memory](/reference/random-access-memory/) for active working data, [storage](/reference/data-storage/) for data that must survive a power cycle, and [input/output](/reference/input-output/) to move data in and out. Everything else — buses, power, cooling, expansion cards — exists to connect and support those four.
+
+## The four building blocks
+
+Each block has a distinct job, and the differences in speed and persistence between them shape how software is written:
+
+| Block | Job | Speed | Keeps data without power? |
+|-------|-----|-------|---------------------------|
+| CPU | Execute instructions | Fastest | No |
+| Memory (RAM) | Hold active working data | Very fast | No |
+| Storage | Keep data long-term | Slower | Yes |
+| Input/Output | Move data in and out | Varies | — |
+
+This is why a program loads from slow, permanent storage into fast, volatile memory to run, and why losing power mid-task loses anything not yet written back to storage.
 
 ## Why it matters
-Knowing which physical resources a device has — how fast its CPU is, how much memory and storage it carries, what it can connect to — tells you what software it can realistically run. Software-defined-radio software like GopherTrunk runs across this whole range, from a full desktop down to a [single-board computer](/reference/single-board-computer/) by the antenna; the hardware sets the ceiling.
+
+Knowing which physical resources a device has — how fast its CPU is, how much memory and storage it carries, what it can connect to — tells you what software it can realistically run. Software-defined-radio software like GopherTrunk runs across this whole range, from a full desktop down to a [single-board computer](/reference/single-board-computer/) by the antenna; the hardware sets the ceiling on sample rates, channel counts, and how much decoding a node can sustain.
 
 ## Sources
+
 [^wiki]: [Computer hardware](https://en.wikipedia.org/wiki/Computer_hardware) — Wikipedia, on the physical components of a computer and the hardware/software distinction.

--- a/docs/reference/computer-monitor.md
+++ b/docs/reference/computer-monitor.md
@@ -4,26 +4,74 @@ title: Computer monitor
 entry_type: hardware
 category: hw-personal-computers
 description: A computer monitor is the display that shows a computer's visual output, characterized by its panel technology, size, resolution, and refresh rate, connected over HDMI, DisplayPort, or USB-C.
-keywords: monitor, display, LCD, LED, IPS, OLED, resolution, refresh rate, HDMI, DisplayPort
+keywords: monitor, display, LCD, LED, IPS, VA, TN, OLED, resolution, refresh rate, HDMI, DisplayPort, USB-C
 infobox:
   - { label: Type, value: Display / output device }
   - { label: Panel, value: LCD (IPS/VA/TN), OLED }
   - { label: Key specs, value: Size, resolution, refresh rate }
   - { label: Connects via, value: HDMI, DisplayPort, USB-C }
-see_also: [peripheral, personal-computer, desktop-computer, all-in-one-computer, graphics-processing-unit]
+see_also: [peripheral, personal-computer, desktop-computer, all-in-one-computer, graphics-processing-unit, waterfall-display]
 cite_urls:
   - https://en.wikipedia.org/wiki/Computer_monitor
 ---
 
 A **computer monitor** is the display that shows a computer's visual output — the screen you read and interact with, as opposed to the box that does the computing.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 190" role="img" aria-label="A computer monitor labelled with its key specifications: the diagonal measures its size, a pixel grid in the corner stands for resolution such as 1920 by 1080, a hertz label marks the refresh rate, and a row of HDMI, DisplayPort, and USB-C ports on the back carry the video signal from the GPU." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.4">
+    <rect x="60" y="24" width="230" height="130" rx="4"/>
+    <rect x="70" y="34" width="210" height="110" fill="currentColor" fill-opacity="0.07"/>
+    <path d="M150 154 L200 154 M175 154 L175 170 M150 170 H200"/>
+  </g>
+  <g stroke="currentColor" fill="none" stroke-width="1" stroke-dasharray="4 3">
+    <path d="M70 34 L280 144"/>
+  </g>
+  <g stroke="currentColor" fill="none" stroke-width="0.8">
+    <path d="M240 44 H274 M240 54 H274 M240 64 H274 M250 44 V64 M260 44 V64"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="7.5">
+    <text x="120" y="96" font-size="8" fill-opacity="0.85">size (diagonal)</text>
+    <text x="238" y="80">resolution</text>
+    <text x="238" y="90" font-size="6.5">1920&#215;1080 px</text>
+    <text x="95" y="130">refresh: 60&#8211;144 Hz</text>
+    <text x="175" y="184" text-anchor="middle" font-size="7">stand</text>
+  </g>
+  <g stroke="currentColor" fill="none" stroke-width="1.1">
+    <rect x="340" y="40" width="90" height="18" rx="2"/>
+    <rect x="340" y="66" width="90" height="18" rx="2"/>
+    <rect x="340" y="92" width="90" height="18" rx="2"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="7.5" text-anchor="middle">
+    <text x="385" y="52">HDMI</text>
+    <text x="385" y="78">DisplayPort</text>
+    <text x="385" y="104">USB-C</text>
+    <text x="385" y="128" font-size="7" fill-opacity="0.85">video in from GPU</text>
+  </g>
+</svg>
+<figcaption>A monitor is defined by three numbers — size, resolution, and refresh rate — and fed a video signal from the computer's GPU over an HDMI, DisplayPort, or USB-C input, which it turns into light.</figcaption>
+</figure>
+
 ## Overview
 
-Most monitors are flat-panel displays built on LCD technology (with IPS, VA, or TN variants) lit by LEDs, while higher-end models use OLED for deeper contrast. The main specifications are *size* (measured diagonally), *resolution* (the pixel count, such as 1920×1080 or 3840×2160), and *refresh rate* (how many times per second the image updates, in hertz). A monitor is an output [peripheral](/reference/peripheral/): it receives a video signal from the computer's [GPU](/reference/graphics-processing-unit/) over HDMI, DisplayPort, or USB-C and turns it into light.
+Most monitors are flat-panel displays built on LCD technology (with IPS, VA, or TN variants) lit by LEDs, while higher-end models use OLED for deeper contrast and true blacks. The main specifications are *size* (measured diagonally), *resolution* (the pixel count, such as 1920×1080 or 3840×2160), and *refresh rate* (how many times per second the image updates, in hertz).
+
+A monitor is an output [peripheral](/reference/peripheral/): it receives a video signal from the computer's [GPU](/reference/graphics-processing-unit/) over HDMI, DisplayPort, or USB-C and turns it into light. It does no computing of its own — swap the box behind it and the same panel shows a different machine.
+
+## Panel types
+
+The panel technology sets the trade-off between color, contrast, speed, and price:
+
+| Panel | Strength | Weakness | Typical use |
+|-------|----------|----------|-------------|
+| IPS | Wide viewing angles, color | Lower contrast | General, creative |
+| VA | High contrast | Slower pixels | Media, general |
+| TN | Fast, cheap | Poor angles/color | Budget, e-sports |
+| OLED | Deep blacks, fast | Cost, burn-in risk | Premium, HDR |
 
 ## Where it fits
 
-A monitor pairs with any [desktop computer](/reference/desktop-computer/), [mini PC](/reference/mini-pc/), or laptop, while an [all-in-one computer](/reference/all-in-one-computer/) builds the same panel into the system. Picking one is a trade-off: office and coding work reward resolution and screen area, gaming rewards high refresh rate and low latency, and photo or video work rewards color accuracy. For a GopherTrunk bench, screen area pays off — a wide or tall monitor keeps a waterfall, constellation plot, and call log all visible at once.
+A monitor pairs with any [desktop computer](/reference/desktop-computer/), [mini PC](/reference/mini-pc/), or laptop, while an [all-in-one computer](/reference/all-in-one-computer/) builds the same panel into the system. Picking one is a trade-off: office and coding work reward resolution and screen area, gaming rewards high refresh rate and low latency, and photo or video work rewards color accuracy. For a GopherTrunk bench, screen area pays off — a wide or tall monitor keeps a [waterfall](/reference/waterfall-display/), constellation plot, and call log all visible at once.
 
 ## Sources
 

--- a/docs/reference/cooling-and-thermals.md
+++ b/docs/reference/cooling-and-thermals.md
@@ -4,27 +4,77 @@ title: Cooling & thermals
 entry_type: concept
 category: hw-foundations
 description: Cooling is how a computer moves heat away from its chips to keep them within safe temperatures; thermal limits cap sustained performance through throttling when heat builds up.
-keywords: cooling, thermals, heat sink, thermal throttling, TDP, fan, liquid cooling, heat dissipation
+keywords: cooling, thermals, heat sink, thermal throttling, TDP, fan, liquid cooling, heat dissipation, thermal paste, passive cooling
 infobox:
   - { label: Goal, value: Keep chips in safe range }
   - { label: Methods, value: Heat sink, fan, liquid }
   - { label: Limit, value: TDP / thermal throttling }
   - { label: Heat source, value: Switching transistors }
-see_also: [central-processing-unit, graphics-processing-unit, power-supply-unit, clock-speed, transistor, moores-law]
+see_also: [central-processing-unit, graphics-processing-unit, power-supply-unit, clock-speed, transistor, raspberry-pi]
 cite_urls:
   - https://en.wikipedia.org/wiki/Computer_cooling
 ---
 
 **Cooling** is how a computer carries heat away from its chips, and **thermals** are the temperature limits that ultimately cap how hard those chips can run.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 170" role="img" aria-label="The heat path from a chip to the air. Heat leaves the silicon die, crosses a thin layer of thermal paste into the metal base of a heat sink, spreads up into its fins, and a fan blows cooler air through the fins to carry the heat away." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.2">
+    <rect x="150" y="128" width="120" height="18" rx="2"/>
+    <rect x="150" y="120" width="120" height="8" fill="currentColor" fill-opacity="0.10" stroke-dasharray="2 2"/>
+    <rect x="150" y="96" width="120" height="24" rx="2" fill="currentColor" fill-opacity="0.12"/>
+    <line x1="162" y1="96" x2="162" y2="52"/>
+    <line x1="180" y1="96" x2="180" y2="52"/>
+    <line x1="198" y1="96" x2="198" y2="52"/>
+    <line x1="216" y1="96" x2="216" y2="52"/>
+    <line x1="234" y1="96" x2="234" y2="52"/>
+    <line x1="252" y1="96" x2="252" y2="52"/>
+    <circle cx="360" cy="74" r="26"/>
+    <path d="M360 74 l18 -8 M360 74 l-4 19 M360 74 l-16 -12"/>
+  </g>
+  <g stroke="currentColor" stroke-width="1.1" fill="none" stroke-opacity="0.8">
+    <path d="M334 66 h-40 m8 -4 l-8 4 l8 4"/>
+    <path d="M334 82 h-40 m8 -4 l-8 4 l8 4"/>
+  </g>
+  <g stroke="currentColor" stroke-width="1.1" fill="none" stroke-opacity="0.6">
+    <path d="M170 44 v-14 m-3 6 l3 -6 l3 6"/>
+    <path d="M210 44 v-14 m-3 6 l3 -6 l3 6"/>
+    <path d="M250 44 v-14 m-3 6 l3 -6 l3 6"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="210" y="141" font-size="8">chip die (heat source)</text>
+    <text x="300" y="112" font-size="7.5" fill-opacity="0.85">thermal paste</text>
+    <text x="210" y="70" font-size="8">heat-sink fins</text>
+    <text x="360" y="112" font-size="8">fan</text>
+    <text x="210" y="24" font-size="7.5" fill-opacity="0.85">heat rises out</text>
+    <text x="300" y="60" font-size="7.5" fill-opacity="0.85">cool air in</text>
+  </g>
+</svg>
+<figcaption>Heat leaves the silicon die, crosses a thin film of thermal paste into the heat-sink base, spreads up through the fins, and a fan pushes cooler air across them to carry it away — the standard air-cooling path from chip to room.</figcaption>
+</figure>
+
 ## Overview
 
-Every switching [transistor](/reference/transistor/) dissipates a little energy as heat, and a modern processor has billions of them. That heat is moved off the die by a *heat sink* (a finned metal block), often with a fan forcing air across it, or by liquid loops in high-end systems. A chip's *thermal design power* (TDP) states how much heat the cooling must remove. When a part gets too hot, it *throttles* — lowering [clock speed](/reference/clock-speed/) to cut heat and stay safe.
+Every switching [transistor](/reference/transistor/) dissipates a little energy as heat, and a modern processor has billions of them switching billions of times a second. That heat has to leave the die or the chip cooks itself. It is moved off by a *heat sink* — a finned metal block bonded to the chip through a thin layer of thermal paste — often with a fan forcing air across the fins, or by liquid loops that carry heat to a larger radiator in high-end systems.
+
+A chip's *thermal design power* (TDP), quoted in watts, states how much sustained heat the cooling solution must be able to remove. When a part exceeds its safe temperature anyway, it protects itself by *throttling*: lowering [clock speed](/reference/clock-speed/) (and voltage) to cut heat production until it cools back down.
+
+## Ways to move heat
+
+Cooling methods trade cost, noise, and moving parts against how much heat they can shed:
+
+| Method | How it works | Typical use | Moving parts |
+|--------|--------------|-------------|--------------|
+| Passive heat sink | Fins radiate/convect to air | Low-power SoCs, fanless PCs | None |
+| Active air | Fan forces air over fins | Most desktops and laptops | Fan |
+| Liquid loop | Coolant carries heat to a radiator | High-end CPUs and GPUs | Pump + fans |
+
+Passive cooling is silent and reliable but limited; adding a fan or liquid dramatically raises the heat that can be removed at the cost of noise and parts that can fail.
 
 ## Where it fits
 
-Cooling sets the ceiling on sustained performance: a [CPU](/reference/central-processing-unit/) or [GPU](/reference/graphics-processing-unit/) can boost briefly but must back off once heat accumulates. Most of the power a [PSU](/reference/power-supply-unit/) delivers ends up as heat the cooling system has to shed. For an unattended GopherTrunk capture node baking in the sun by an antenna, passive heat sinks and good airflow keep a fanless [Raspberry Pi](/reference/raspberry-pi/) from throttling mid-decode — thermals are a real-world constraint, not an afterthought.
+Cooling sets the ceiling on sustained performance: a [CPU](/reference/central-processing-unit/) or [GPU](/reference/graphics-processing-unit/) can boost briefly but must back off once heat accumulates. Most of the power a [PSU](/reference/power-supply-unit/) delivers ultimately ends up as heat the cooling system has to shed. For an unattended GopherTrunk capture node baking in the sun by an antenna, a passive heat sink and good airflow are what keep a fanless [Raspberry Pi](/reference/raspberry-pi/) from throttling mid-decode — thermals are a real-world constraint, not an afterthought.
 
 ## Sources
 
-[^wiki]: [Computer cooling](https://en.wikipedia.org/wiki/Computer_cooling) — Wikipedia, on heat sinks, fans, liquid cooling, and thermal limits.
+[^wiki]: [Computer cooling](https://en.wikipedia.org/wiki/Computer_cooling) — Wikipedia, on heat sinks, fans, liquid cooling, TDP, and thermal throttling.

--- a/docs/reference/cuda.md
+++ b/docs/reference/cuda.md
@@ -3,8 +3,8 @@ slug: cuda
 title: CUDA
 entry_type: concept
 category: hw-accelerators
-description: CUDA is NVIDIA's parallel computing platform and programming model that lets general-purpose code run on the GPU, exposing thousands of cores through C, C++, and other languages.
-keywords: CUDA, NVIDIA, GPGPU, GPU computing, parallel computing, kernels, cuDNN, GPU programming
+description: CUDA is NVIDIA's parallel computing platform and programming model that lets general-purpose code run on the GPU, launching kernels across thousands of lightweight threads through C, C++, and other languages.
+keywords: CUDA, NVIDIA, GPGPU, GPU computing, parallel computing, kernels, threads, blocks, grid, cuBLAS, cuDNN, GPU programming
 aka: [Compute Unified Device Architecture]
 autolink: true
 infobox:
@@ -12,6 +12,7 @@ infobox:
   - { label: Vendor, value: NVIDIA }
   - { label: Introduced, value: "2007" }
   - { label: Runs on, value: NVIDIA GPUs }
+  - { label: Model, value: "Kernels over a grid of threads" }
   - { label: Languages, value: "C, C++, Fortran, Python bindings" }
 see_also: [gpgpu, graphics-processing-unit, nvidia, hardware-acceleration, vector-processor, ai-accelerator]
 cite_urls:
@@ -21,15 +22,75 @@ cite_urls:
 
 **CUDA** is [NVIDIA](/reference/nvidia/)'s parallel computing platform and programming model that lets ordinary, general-purpose code run on the [GPU](/reference/graphics-processing-unit/) instead of only the CPU.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 170" role="img" aria-label="A CUDA offload pipeline. The host CPU launches a kernel, which fans out across a grid of thread blocks on the GPU device, each block holding many lightweight threads that run in parallel, before the result is copied back to the host." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="currentColor">
+    <rect x="18" y="60" width="70" height="46" rx="4" fill-opacity="0.10" stroke-width="1.4"/>
+    <text x="53" y="80" text-anchor="middle" font-size="9" stroke="none" font-weight="600">Host</text>
+    <text x="53" y="93" text-anchor="middle" font-size="8" stroke="none">CPU</text>
+    <line x1="88" y1="83" x2="138" y2="83" stroke-width="1.3" fill="none"/>
+    <path d="M138 83 l-8 -4 v8 z" stroke="none"/>
+    <text x="113" y="76" text-anchor="middle" font-size="7.5" stroke="none" fill-opacity="0.9">launch kernel</text>
+    <rect x="140" y="26" width="220" height="118" rx="5" fill-opacity="0.05" stroke-width="1.4"/>
+    <text x="250" y="40" text-anchor="middle" font-size="8.5" stroke="none" font-weight="600">GPU device &#183; grid of blocks</text>
+  </g>
+  <g stroke="currentColor" fill="currentColor">
+    <g transform="translate(152,50)">
+      <rect x="0" y="0" width="94" height="42" rx="3" fill-opacity="0.08" stroke-width="1.1"/>
+      <text x="47" y="-4" text-anchor="middle" font-size="7" stroke="none" fill-opacity="0.9">block</text>
+    </g>
+    <g transform="translate(254,50)">
+      <rect x="0" y="0" width="94" height="42" rx="3" fill-opacity="0.08" stroke-width="1.1"/>
+      <text x="47" y="-4" text-anchor="middle" font-size="7" stroke="none" fill-opacity="0.9">block</text>
+    </g>
+    <g transform="translate(152,100)">
+      <rect x="0" y="0" width="94" height="42" rx="3" fill-opacity="0.08" stroke-width="1.1"/>
+    </g>
+    <g transform="translate(254,100)">
+      <rect x="0" y="0" width="94" height="42" rx="3" fill-opacity="0.08" stroke-width="1.1"/>
+    </g>
+  </g>
+  <g fill="currentColor" stroke="none">
+    <g font-size="0">
+      <rect x="156" y="54" width="8" height="34" fill="currentColor" fill-opacity="0.35"/>
+      <rect x="168" y="54" width="8" height="34" fill="currentColor" fill-opacity="0.35"/>
+      <rect x="180" y="54" width="8" height="34" fill="currentColor" fill-opacity="0.35"/>
+      <rect x="192" y="54" width="8" height="34" fill="currentColor" fill-opacity="0.35"/>
+      <rect x="204" y="54" width="8" height="34" fill="currentColor" fill-opacity="0.35"/>
+      <rect x="216" y="54" width="8" height="34" fill="currentColor" fill-opacity="0.35"/>
+      <rect x="228" y="54" width="8" height="34" fill="currentColor" fill-opacity="0.35"/>
+    </g>
+    <text x="250" y="160" text-anchor="middle" font-size="7.5" fill-opacity="0.9">each bar = one thread, all running the same kernel on different data</text>
+  </g>
+</svg>
+<figcaption>The host CPU launches a kernel that fans out across a grid of thread blocks on the GPU; every thread runs the same code on its own slice of data, then the result is copied back to the host.</figcaption>
+</figure>
+
 ## Overview
 
-A CUDA program splits work into a *kernel* — a small function executed in parallel by thousands of lightweight threads, each handling one element of the data. The platform exposes the GPU through extensions to C and C++ (and bindings for [Python](/reference/python-language/), Fortran, and others), plus tuned libraries such as cuBLAS for linear algebra and cuDNN for neural networks. Because it is proprietary to NVIDIA hardware, CUDA competes with the cross-vendor OpenCL and with newer portable frameworks, but its mature tooling made it the de facto standard for GPU computing.[^cuda]
+A CUDA program splits work into a *kernel* — a small function executed in parallel by thousands of lightweight threads, each handling one element of the data. Threads are organised into *blocks*, and blocks into a *grid*, so the same code scales from a small GPU to a large one without being rewritten. The platform exposes the GPU through extensions to C and C++ (and bindings for [Python](/reference/python-language/), Fortran, and others), plus tuned libraries such as cuBLAS for linear algebra and cuDNN for neural networks.
+
+Because it is proprietary to NVIDIA hardware, CUDA competes with the cross-vendor OpenCL and with newer portable frameworks, but its mature tooling, profilers, and library ecosystem made it the de facto standard for GPU computing.[^cuda] The programming model is the practical face of [GPGPU](/reference/gpgpu/): it hides the graphics pipeline entirely and presents the GPU as a general, massively parallel co-processor.
+
+## How it works
+
+CUDA divides the machine into a *host* (the CPU and its memory) and a *device* (the GPU and its memory). Work moves across that boundary in a fixed rhythm, and the thread hierarchy maps onto the hardware's execution units:
+
+| Concept | Meaning | Maps to |
+|---------|---------|---------|
+| Kernel | Function launched to run in parallel | GPU program |
+| Thread | One instance of the kernel | Single lane |
+| Block | Group of threads sharing fast memory | Streaming multiprocessor |
+| Grid | All blocks of one launch | Whole GPU |
+| Host &#8596; device copy | Moving data over PCI Express | The main overhead |
+
+The host-to-device copy is the cost that decides whether offloading pays off: if the compute per byte is low, the transfer dominates and the CPU would have been faster.
 
 ## Where it fits
 
-CUDA is the bridge that turned the GPU from a graphics device into a general accelerator (see [GPGPU](/reference/gpgpu/)), and it underpins most modern [AI accelerator](/reference/ai-accelerator/) workloads on NVIDIA hardware. For a signal-processing pipeline like GopherTrunk, a CUDA kernel can run massively parallel work — large FFTs across many channels, or batched filtering — far faster than a CPU, though for a handful of narrowband channels the data-transfer overhead to the GPU often outweighs the gain.
+CUDA is the bridge that turned the GPU from a graphics device into a general accelerator, and it underpins most modern [AI accelerator](/reference/ai-accelerator/) workloads on NVIDIA hardware. For a signal-processing pipeline like GopherTrunk, a CUDA kernel can run massively parallel work — large FFTs across many channels, batched [FIR filtering](/reference/digital-filter/), or a polyphase channelizer splitting one wide capture into hundreds of channels — far faster than a CPU. The catch is the host-device transfer: for a handful of narrowband channels the cost of shipping samples to the GPU often outweighs the gain, so CUDA earns its keep only when the channel count and sample rate are high.
 
 ## Sources
 
-[^wiki]: [CUDA](https://en.wikipedia.org/wiki/CUDA) — Wikipedia, on NVIDIA's parallel computing platform and programming model.
+[^wiki]: [CUDA](https://en.wikipedia.org/wiki/CUDA) — Wikipedia, on NVIDIA's parallel computing platform, kernels, and the thread/block/grid model.
 [^cuda]: [CUDA Zone](https://developer.nvidia.com/cuda-zone) — NVIDIA's developer site for the CUDA toolkit and libraries.

--- a/docs/reference/data-center.md
+++ b/docs/reference/data-center.md
@@ -4,13 +4,14 @@ title: Data center
 entry_type: concept
 category: hw-servers
 description: A data center is a purpose-built facility that houses computing, storage, and networking equipment with the power, cooling, and connectivity needed to run it reliably around the clock.
-keywords: data center, datacenter, server farm, colocation, power and cooling, uptime, hyperscale
+keywords: data center, datacenter, server farm, colocation, power and cooling, uptime, hyperscale, hot aisle, cold aisle, PUE
 aka: [Datacenter, Server farm]
 infobox:
   - { label: Type, value: Computing facility }
   - { label: Houses, value: Servers, storage, networking }
   - { label: Provides, value: Power, cooling, connectivity }
   - { label: Measured by, value: Uptime tier, PUE }
+  - { label: Scale, value: Room to hyperscale campus }
 see_also: [server, rack-server, colocation, cloud-computing, high-availability, data-storage]
 cite_urls:
   - https://en.wikipedia.org/wiki/Data_center
@@ -18,9 +19,59 @@ cite_urls:
 
 A **data center** is a purpose-built facility that houses computing, storage, and networking equipment together with the power, cooling, and connectivity needed to keep it running reliably around the clock.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 180" role="img" aria-label="A cross-section of two rows of server racks arranged around a cold aisle and hot aisles. Cool air rises from a raised floor into the cold aisle between the racks, is drawn front to back through the servers, and exits as hot air into the outer aisles for the cooling system to capture." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="currentColor" font-family="ui-sans-serif, sans-serif">
+    <g stroke-width="1.2">
+      <rect x="110" y="40" width="70" height="90" rx="2" fill-opacity="0.12"/>
+      <rect x="280" y="40" width="70" height="90" rx="2" fill-opacity="0.12"/>
+    </g>
+    <g stroke-width="0.8" fill-opacity="0.22">
+      <rect x="116" y="46" width="58" height="10"/><rect x="116" y="60" width="58" height="10"/>
+      <rect x="116" y="74" width="58" height="10"/><rect x="116" y="88" width="58" height="10"/>
+      <rect x="116" y="102" width="58" height="10"/><rect x="116" y="116" width="58" height="10"/>
+      <rect x="286" y="46" width="58" height="10"/><rect x="286" y="60" width="58" height="10"/>
+      <rect x="286" y="74" width="58" height="10"/><rect x="286" y="88" width="58" height="10"/>
+      <rect x="286" y="102" width="58" height="10"/><rect x="286" y="116" width="58" height="10"/>
+    </g>
+    <text x="145" y="26" text-anchor="middle" font-size="8" stroke="none">rack row</text>
+    <text x="315" y="26" text-anchor="middle" font-size="8" stroke="none">rack row</text>
+    <line x1="230" y1="132" x2="230" y2="52" stroke-width="1.4" fill="none"/>
+    <path d="M230 52 l-4 8 h8 z" stroke-width="1.2"/>
+    <text x="230" y="148" text-anchor="middle" font-size="8" stroke="none" font-weight="600">COLD aisle</text>
+    <text x="230" y="160" text-anchor="middle" font-size="7.5" stroke="none" fill-opacity="0.8">cool air up from raised floor</text>
+    <g stroke-width="1.3" fill="none">
+      <line x1="180" y1="85" x2="228" y2="85"/>
+      <line x1="352" y1="85" x2="400" y2="85"/>
+    </g>
+    <path d="M180 85 l8 -3 v6 z" stroke-width="1" fill="currentColor"/>
+    <path d="M400 85 l-8 -3 v6 z" stroke-width="1" fill="currentColor" transform="translate(0,0)"/>
+    <text x="70" y="88" text-anchor="middle" font-size="8" stroke="none">HOT aisle</text>
+    <text x="415" y="88" text-anchor="middle" font-size="8" stroke="none">HOT aisle</text>
+    <text x="230" y="14" text-anchor="middle" font-size="9" font-weight="600" stroke="none">Hot-aisle / cold-aisle airflow</text>
+  </g>
+</svg>
+<figcaption>Racks face each other across a cold aisle fed by cool air; servers pull that air front-to-back and exhaust into the hot aisles, where the cooling plant captures the heat — the airflow discipline that lets a room pack thousands of machines.</figcaption>
+</figure>
+
 ## Overview
 
-At its core a data center is a building full of [rack servers](/reference/rack-server/) and the supporting systems that keep them alive: redundant utility feeds and backup generators, uninterruptible power supplies, air or liquid cooling, fire suppression, and high-capacity network links to the outside world. Facilities are graded by uptime *tiers* (Tier I–IV) and by energy efficiency, often reported as **PUE** (power usage effectiveness — total facility power divided by IT power). Scale ranges from a single room to *hyperscale* campuses run by cloud providers.
+At its core a data center is a building full of [rack servers](/reference/rack-server/) and the supporting systems that keep them alive: redundant utility feeds and backup generators, uninterruptible power supplies, air or liquid cooling, fire suppression, and high-capacity network links to the outside world. Cabinets are arranged into *hot* and *cold* aisles so that cool supply air and hot exhaust never mix, which is the single biggest lever on cooling efficiency.
+
+Facilities are graded by uptime *tiers* (Tier I–IV) and by energy efficiency, often reported as **PUE** (power usage effectiveness — total facility power divided by IT power, where 1.0 is the unreachable ideal). Scale ranges from a single server room to *hyperscale* campuses run by cloud providers and drawing tens of megawatts.
+
+## Tiers
+
+The Uptime Institute tier system pins expected availability to how much of the facility is redundant:
+
+| Tier | Redundancy | Approx. uptime | Annual downtime |
+|------|------------|----------------|-----------------|
+| I | None (single path) | 99.671% | ~29 hours |
+| II | Redundant components | 99.741% | ~22 hours |
+| III | Concurrently maintainable | 99.982% | ~1.6 hours |
+| IV | Fault tolerant | 99.995% | ~26 minutes |
+
+Higher tiers cost more to build and run, so operators match the tier to how much an outage would actually cost them.
 
 ## Where it fits
 
@@ -28,4 +79,4 @@ A data center is where most [servers](/reference/server/) actually live. You can
 
 ## Sources
 
-[^wiki]: [Data center](https://en.wikipedia.org/wiki/Data_center) — Wikipedia, on data center facilities, tiers, and infrastructure.
+[^wiki]: [Data center](https://en.wikipedia.org/wiki/Data_center) — Wikipedia, on data center facilities, tiers, PUE, and airflow.

--- a/docs/reference/dedicated-server.md
+++ b/docs/reference/dedicated-server.md
@@ -4,14 +4,15 @@ title: Dedicated server
 entry_type: hardware
 category: hw-servers
 description: A dedicated server is a whole physical server rented for your exclusive use, with no other customers sharing the hardware.
-keywords: dedicated server, bare metal, exclusive hardware, single tenant, uncontended
+keywords: dedicated server, bare metal, exclusive hardware, single tenant, uncontended, dedicated hosting
 aka: [Dedicated server, Bare metal server]
 infobox:
   - { label: Type, value: Physical server }
   - { label: Tenancy, value: Single (exclusive) }
   - { label: Performance, value: Uncontended }
   - { label: You manage, value: The whole machine }
-see_also: [server, virtual-private-server, web-hosting, cloud-computing, home-server]
+  - { label: Contrast, value: Shared / VPS hosting }
+see_also: [server, virtual-private-server, bare-metal-server, web-hosting, cloud-computing, home-server]
 related_lessons:
   - { title: "Dedicated servers", url: /learn/intro-hardware/dedicated-servers/ }
   - { title: "Virtual private server (VPS)", url: /learn/intro-hardware/vps/ }
@@ -21,13 +22,64 @@ cite_urls:
 
 A **dedicated server** is a whole physical [server](/reference/server/) rented for your exclusive use — no other customers share the hardware.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 170" role="img" aria-label="A tenancy spectrum across three machines. Shared hosting packs many customers onto one operating system. A VPS splits one machine into a few isolated virtual servers. A dedicated server holds a single tenant who has the whole box. Contention falls and control rises from left to right." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="currentColor" font-family="ui-sans-serif, sans-serif">
+    <text x="70" y="20" text-anchor="middle" font-size="8.5" font-weight="600" stroke="none">Shared hosting</text>
+    <rect x="24" y="30" width="92" height="86" rx="3" fill-opacity="0.05" stroke-width="1.3"/>
+    <g stroke-width="0.9" fill-opacity="0.16">
+      <rect x="30" y="38" width="24" height="16" rx="1"/><rect x="58" y="38" width="24" height="16" rx="1"/><rect x="86" y="38" width="24" height="16" rx="1"/>
+      <rect x="30" y="58" width="24" height="16" rx="1"/><rect x="58" y="58" width="24" height="16" rx="1"/><rect x="86" y="58" width="24" height="16" rx="1"/>
+      <rect x="30" y="78" width="24" height="16" rx="1"/><rect x="58" y="78" width="24" height="16" rx="1"/><rect x="86" y="78" width="24" height="16" rx="1"/>
+    </g>
+    <text x="70" y="110" text-anchor="middle" font-size="7.5" stroke="none" fill-opacity="0.85">many tenants, one OS</text>
+
+    <text x="230" y="20" text-anchor="middle" font-size="8.5" font-weight="600" stroke="none">VPS</text>
+    <rect x="184" y="30" width="92" height="86" rx="3" fill-opacity="0.05" stroke-width="1.3"/>
+    <g stroke-width="1" fill-opacity="0.16">
+      <rect x="190" y="40" width="80" height="20" rx="1"/>
+      <rect x="190" y="64" width="80" height="20" rx="1"/>
+      <rect x="190" y="88" width="80" height="16" rx="1"/>
+    </g>
+    <text x="230" y="112" text-anchor="middle" font-size="7.5" stroke="none" fill-opacity="0.85">a few VMs share it</text>
+
+    <text x="390" y="20" text-anchor="middle" font-size="8.5" font-weight="600" stroke="none">Dedicated</text>
+    <rect x="344" y="30" width="92" height="86" rx="3" fill-opacity="0.05" stroke-width="1.3"/>
+    <rect x="350" y="40" width="80" height="64" rx="2" fill-opacity="0.20" stroke-width="1.1"/>
+    <text x="390" y="76" text-anchor="middle" font-size="8" stroke="none">one tenant</text>
+    <text x="390" y="112" text-anchor="middle" font-size="7.5" stroke="none" fill-opacity="0.85">the whole box is yours</text>
+
+    <line x1="24" y1="140" x2="436" y2="140" stroke-width="1.2"/>
+    <path d="M436 140 l-8 -3 v6 z" stroke-width="1"/>
+    <text x="30" y="156" font-size="7.5" stroke="none" fill-opacity="0.8">more sharing / lower cost</text>
+    <text x="430" y="156" text-anchor="end" font-size="7.5" stroke="none" fill-opacity="0.8">less contention / more control</text>
+  </g>
+</svg>
+<figcaption>Along the tenancy spectrum, shared hosting crams many customers onto one operating system and a VPS gives each tenant an isolated slice; a dedicated server hands the entire machine to a single tenant, trading cost for uncontended performance and full control.</figcaption>
+</figure>
+
 ## Overview
 
-Unlike a [virtual private server](/reference/virtual-private-server/), which carves one machine into many tenants, a dedicated server is yours alone. That means raw, uncontended performance: no neighbors competing for CPU, memory, or disk. You (or the provider, under a managed plan) handle the metal — the operating system, patching, and recovery.
+Unlike a [virtual private server](/reference/virtual-private-server/), which carves one machine into many tenants, a dedicated server is yours alone. That means raw, uncontended performance: no neighbors competing for CPU, memory, or disk, and no hypervisor tax on throughput. You (or the provider, under a managed plan) handle the metal — the operating system, patching, and recovery.
+
+In practice a dedicated server is a [bare-metal server](/reference/bare-metal-server/) offered on a rental basis, usually on a monthly lease rather than the hourly billing of bare-metal cloud. Providers rack, power, and network the box; you treat it as your own from the operating system up.
 
 ## When to choose it
 
+The decision usually comes down to how steady and heavy the workload is:
+
+| Factor | Dedicated server | VPS |
+|--------|------------------|-----|
+| Performance | Uncontended, full machine | Shared, can vary |
+| Cost | Higher, fixed | Lower, scalable |
+| Best for | Sustained heavy load | Light or bursty load |
+| Isolation | Complete | Logical (hypervisor) |
+
 Pick a dedicated server when predictable, full-machine performance is worth the higher price compared with a VPS — sustained heavy workloads, strict latency budgets, or licensing that demands a single tenant. For lighter or bursty needs, a VPS or [cloud computing](/reference/cloud-computing/) is usually the better value.
+
+## Where it fits
+
+A dedicated server sits between renting a shared slice and owning a [home server](/reference/home-server/) outright: exclusive hardware without having to house or maintain the physical box. For GopherTrunk it is a solid home for a busy back end that stores and serves decoded calls, though like any remote server it cannot capture RF — that still needs a radio front end near the antenna.
 
 ## Sources
 

--- a/docs/reference/desktop-computer.md
+++ b/docs/reference/desktop-computer.md
@@ -4,7 +4,7 @@ title: Desktop computer
 entry_type: hardware
 category: hw-personal-computers
 description: A desktop computer is a stationary personal computer that delivers the most performance per dollar and is the easiest to upgrade and expand.
-keywords: desktop computer, desktop PC, tower, workstation, upgradeable computer, stationary computer
+keywords: desktop computer, desktop PC, tower, workstation, upgradeable computer, stationary computer, thermal headroom
 aka: [Desktop computer, Desktop PC, Desktop]
 infobox:
   - { label: Type, value: Stationary personal computer }
@@ -12,7 +12,7 @@ infobox:
   - { label: Upgradeable, value: Yes, easily }
   - { label: Portability, value: None }
   - { label: Best for, value: Sustained heavy work }
-see_also: [personal-computer, laptop, central-processing-unit, random-access-memory, computer-hardware, data-storage]
+see_also: [personal-computer, laptop, central-processing-unit, random-access-memory, computer-case, computer-hardware, data-storage]
 related_lessons:
   - { title: "Desktop computers", url: /learn/intro-hardware/desktop-computers/ }
 cite_urls:
@@ -22,21 +22,74 @@ cite_urls:
 **A desktop computer** is a stationary [personal computer](/reference/personal-computer/)
 that trades portability for the most performance per dollar.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 180" role="img" aria-label="A desktop computer as a set of separate boxes: a roomy tower on the left with swappable CPU, RAM, GPU, and drive modules, wired to a monitor on the right and a keyboard and mouse in front — the modular layout that makes desktops easy to upgrade." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.4">
+    <rect x="40" y="30" width="90" height="120" rx="4"/>
+  </g>
+  <g stroke="currentColor" fill="none" stroke-width="1">
+    <rect x="52" y="42" width="66" height="16" rx="1" fill="currentColor" fill-opacity="0.14"/>
+    <rect x="52" y="66" width="66" height="12" rx="1" fill="currentColor" fill-opacity="0.1"/>
+    <rect x="52" y="86" width="66" height="22" rx="1" fill="currentColor" fill-opacity="0.1"/>
+    <rect x="52" y="116" width="66" height="24" rx="1" fill="currentColor" fill-opacity="0.1"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="7" text-anchor="middle">
+    <text x="85" y="53">CPU</text>
+    <text x="85" y="75">RAM</text>
+    <text x="85" y="100">GPU</text>
+    <text x="85" y="131">drive</text>
+    <text x="85" y="166" font-size="7.5">tower (swappable)</text>
+  </g>
+  <g stroke="currentColor" fill="none" stroke-width="1.4">
+    <rect x="270" y="34" width="150" height="94" rx="4"/>
+    <rect x="280" y="44" width="130" height="74" fill="currentColor" fill-opacity="0.07"/>
+    <path d="M330 128 V144 M310 144 H370"/>
+    <rect x="270" y="152" width="80" height="14" rx="2"/>
+    <ellipse cx="382" cy="159" rx="9" ry="7"/>
+  </g>
+  <g stroke="currentColor" fill="none" stroke-width="1.2" stroke-dasharray="4 3">
+    <path d="M130 74 H270"/>
+    <path d="M130 120 C180 120 200 158 270 158"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="7.5" text-anchor="middle">
+    <text x="345" y="88" fill-opacity="0.8">monitor</text>
+    <text x="310" y="164" font-size="7">keyboard</text>
+    <text x="382" y="146" font-size="7">mouse</text>
+  </g>
+</svg>
+<figcaption>A desktop separates the computer into a roomy tower plus its display and input devices; because the tower runs on wall power and has space to breathe, its CPU, RAM, GPU, and drives are full-size and swap out one at a time.</figcaption>
+</figure>
+
 ## Overview
 
-Because the case is roomy and runs on wall power, a desktop fits larger, faster
+Because the [case](/reference/computer-case/) is roomy and runs on wall power, a desktop fits larger, faster
 [CPUs](/reference/central-processing-unit/), more
 [RAM](/reference/random-access-memory/), and bigger
 [storage](/reference/data-storage/) than a comparable laptop — and it stays
 cool enough to run them flat out. The same roominess makes it the easiest form to
 upgrade and expand: parts swap out individually rather than being soldered down.
 
+That separation into tower, monitor, and input devices is exactly what buys the
+headroom. Nothing has to be miniaturized or battery-friendly, so a desktop reaches
+performance a laptop of the same price can't sustain — and outlives it, because you
+can replace the graphics card or double the memory instead of the whole machine.
+
 ## Trade-offs
 
-The catch is in the name: it stays on the desk. For sustained heavy work —
-compiling large projects, crunching data, running long SDR captures — a desktop's
-thermal headroom and upgrade path are hard to beat. When the work needs to travel,
-that argument flips and the [laptop](/reference/laptop/) wins.
+The catch is in the name: it stays on the desk. The choice between a desktop and a [laptop](/reference/laptop/) comes down to whether the work travels:
+
+| Factor | Desktop | Laptop |
+|--------|---------|--------|
+| Performance per dollar | Higher | Lower |
+| Sustained load | Excellent | Throttles when thin |
+| Upgradeable | Easily | Minimal |
+| Portability | None | Goes anywhere |
+
+For sustained heavy work — compiling large projects, crunching data, running long SDR captures — a desktop's thermal headroom and upgrade path are hard to beat. When the work needs to travel, that argument flips and the laptop wins.
+
+## Where it fits
+
+A desktop is the natural GopherTrunk bench machine: it can run wideband captures and many channels of DSP for hours without throttling, and its expansion slots leave room for extra storage or a capture card. Pair it with a wide [monitor](/reference/computer-monitor/) for the waterfall and it stays put while a [laptop](/reference/laptop/) handles fieldwork.
 
 ## Sources
 

--- a/docs/reference/e-reader.md
+++ b/docs/reference/e-reader.md
@@ -4,7 +4,7 @@ title: E-reader
 entry_type: hardware
 category: hw-mobile
 description: An e-reader is a portable device optimized for reading digital books, typically using a low-power electronic-paper display that mimics ink on paper and runs for weeks on a single charge.
-keywords: e-reader, e-ink, electronic paper, e-paper, Kindle, Kobo, ereader, reflective display, e-book
+keywords: e-reader, e-ink, electronic paper, e-paper, Kindle, Kobo, ereader, reflective display, e-book, microcapsule
 aka: [eReader, e-book reader]
 infobox:
   - { label: Type, value: Portable reading device }
@@ -20,13 +20,66 @@ cite_urls:
 
 An **e-reader** is a portable device built for reading digital books, using a low-power electronic-paper display that looks like ink on paper.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 170" role="img" aria-label="A cross-section of an E Ink electronic-paper display. Microcapsules sit between two electrode layers. Each capsule holds white and black pigment particles in a clear fluid. An applied voltage pulls white particles to the top to show white, or black particles up to show black, and the image stays put with no power until the next page change." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.1" font-family="ui-sans-serif, sans-serif">
+    <line x1="40" y1="34" x2="420" y2="34"/>
+    <line x1="40" y1="120" x2="420" y2="120"/>
+    <g>
+      <circle cx="95" cy="77" r="26"/>
+      <circle cx="160" cy="77" r="26"/>
+      <circle cx="225" cy="77" r="26"/>
+      <circle cx="290" cy="77" r="26"/>
+      <circle cx="355" cy="77" r="26"/>
+    </g>
+  </g>
+  <g stroke="currentColor" fill="currentColor">
+    <circle cx="88" cy="62" r="4" fill="none" stroke-width="1"/>
+    <circle cx="102" cy="60" r="4" fill="none" stroke-width="1"/>
+    <circle cx="95" cy="90" r="4" fill-opacity="1"/>
+    <circle cx="153" cy="92" r="4" fill="none" stroke-width="1"/>
+    <circle cx="167" cy="90" r="4" fill="none" stroke-width="1"/>
+    <circle cx="160" cy="63" r="4" fill-opacity="1"/>
+    <circle cx="220" cy="65" r="4" fill="none" stroke-width="1"/>
+    <circle cx="225" cy="90" r="4" fill-opacity="1"/>
+    <circle cx="285" cy="90" r="4" fill="none" stroke-width="1"/>
+    <circle cx="290" cy="63" r="4" fill-opacity="1"/>
+    <circle cx="350" cy="63" r="4" fill="none" stroke-width="1"/>
+    <circle cx="355" cy="92" r="4" fill-opacity="1"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-family="ui-sans-serif, sans-serif" font-size="8.5">
+    <text x="44" y="28">top electrode &#183; viewer side</text>
+    <text x="44" y="136">bottom electrode &#183; drives pixels</text>
+    <text x="95" y="150" text-anchor="middle" font-size="8">white up</text>
+    <text x="160" y="150" text-anchor="middle" font-size="8">black up</text>
+    <text x="290" y="150" text-anchor="middle" font-size="8">holds without power</text>
+  </g>
+</svg>
+<figcaption>Each E Ink microcapsule holds white and black pigment in clear fluid; a voltage pulses the chosen particles to the top and the image then persists with zero power until the next page turn — the root of the e-reader's weeks-long battery life.</figcaption>
+</figure>
+
 ## Overview
 
-The defining part is the *electronic-paper* (E Ink) display: a reflective screen of microcapsules that hold their image with no power once set, so the device only draws energy when the page changes. The result is paper-like readability in sunlight and [battery](/reference/battery-technology/) life measured in weeks rather than hours. E-readers run a stripped-down [mobile operating system](/reference/mobile-operating-system/) on a modest [SoC](/reference/system-on-a-chip/), often with a [touchscreen](/reference/touchscreen/) and a front light. Familiar examples include Amazon's Kindle and Rakuten's Kobo.
+The defining part is the *electronic-paper* (E Ink) display: a reflective screen of microcapsules that hold their image with no power once set, so the device only draws energy when the page changes. Because it reflects ambient light rather than emitting its own, the page stays readable in direct sunlight and is gentle on the eyes, at the cost of slow refresh and (on most models) grayscale only.
+
+The result is paper-like readability and [battery](/reference/battery-technology/) life measured in weeks rather than hours. E-readers run a stripped-down [mobile operating system](/reference/mobile-operating-system/) on a modest [SoC](/reference/system-on-a-chip/), often with a [touchscreen](/reference/touchscreen/) and a front light for reading in the dark. Familiar examples include Amazon's Kindle and Rakuten's Kobo.
+
+## E Ink vs LCD/OLED
+
+The display choice is the whole trade-off between an e-reader and a [tablet](/reference/tablet/):
+
+| Property | E Ink (e-reader) | LCD / OLED (tablet) |
+|----------|------------------|---------------------|
+| Light | Reflective (ambient) | Emissive (backlit) |
+| Power when static | ~Zero | Continuous |
+| Refresh rate | Slow (page turns) | Fast (video) |
+| Color | Mostly grayscale | Full color |
+| Sunlight | Excellent | Washes out |
+| Best for | Long-form reading | Media, apps |
 
 ## Where it fits
 
-An e-reader trades the bright, fast color of a [tablet](/reference/tablet/) for outstanding battery life and eye comfort at one task — reading. The same E Ink technology shows up on shelf labels and low-power status panels, where a display that needs power only to update is exactly the right tool for a device that mostly sits idle.
+An e-reader trades the bright, fast color of a tablet for outstanding battery life and eye comfort at one task — reading. The same E Ink technology shows up on shelf labels and low-power status panels, where a display that needs power only to update is exactly the right tool for a device that mostly sits idle — the opposite end of the power spectrum from a continuously running SDR capture node.
 
 ## Sources
 

--- a/docs/reference/eben-upton.md
+++ b/docs/reference/eben-upton.md
@@ -4,14 +4,14 @@ title: Eben Upton
 entry_type: person
 category: hw-people
 description: Eben Upton (born 1978) is a British engineer who created the Raspberry Pi single-board computer and co-founded the Raspberry Pi Foundation to make affordable computing widely accessible.
-keywords: Eben Upton, Raspberry Pi, Raspberry Pi Foundation, single-board computer, Broadcom, computing education
+keywords: Eben Upton, Raspberry Pi, Raspberry Pi Foundation, single-board computer, Broadcom, computing education, GPIO
 aka: [Eben Upton]
 autolink: true
 infobox:
   - { label: Born, value: "1978" }
   - { label: Field, value: Computer engineering }
   - { label: Known for, value: Raspberry Pi }
-see_also: [raspberry-pi, raspberry-pi-foundation, single-board-computer, broadcom]
+see_also: [raspberry-pi, raspberry-pi-foundation, single-board-computer, broadcom, gpio]
 related_lessons:
   - { title: "Raspberry Pi and family", url: /learn/intro-hardware/raspberry-pi-and-family/ }
 cite_urls:
@@ -22,6 +22,30 @@ cite_urls:
 [Raspberry Pi](/reference/raspberry-pi/) and co-founded the
 [Raspberry Pi Foundation](/reference/raspberry-pi-foundation/), aiming to give students an
 affordable, hackable computer.[^wiki]
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="A known-for card for Eben Upton: a central node labelled Eben Upton links out to the Raspberry Pi single-board computer, the Raspberry Pi Foundation he co-founded, and his chip-design background at Broadcom." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.2">
+    <rect x="170" y="46" width="120" height="30" rx="5" fill="currentColor" fill-opacity="0.1"/>
+    <rect x="20" y="16" width="120" height="26" rx="5"/>
+    <rect x="20" y="80" width="120" height="26" rx="5"/>
+    <rect x="320" y="16" width="120" height="26" rx="5"/>
+    <rect x="320" y="80" width="120" height="26" rx="5"/>
+    <line x1="170" y1="55" x2="140" y2="29"/>
+    <line x1="170" y1="67" x2="140" y2="93"/>
+    <line x1="290" y1="55" x2="320" y2="29"/>
+    <line x1="290" y1="67" x2="320" y2="93"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="230" y="65" font-size="10" font-weight="600">Eben Upton</text>
+    <text x="80" y="32" font-size="8.5">Raspberry Pi (2012)</text>
+    <text x="80" y="96" font-size="8.5">Pi Foundation</text>
+    <text x="380" y="32" font-size="8.5">Broadcom SoCs</text>
+    <text x="380" y="96" font-size="8.5">computing education</text>
+  </g>
+</svg>
+<figcaption>What Eben Upton is known for: the Raspberry Pi board itself, the Foundation that ships it, the Broadcom chip background that made it cheap, and the education mission that motivated it.</figcaption>
+</figure>
 
 ## Life and work
 
@@ -34,6 +58,13 @@ program. Working with colleagues and drawing on his chip background at
 beyond the educational market, becoming one of the best-selling computers ever and a staple of
 the maker and embedded-electronics world.[^wiki]
 
+| Year | Milestone |
+|------|-----------|
+| 2008 | Co-founds the Raspberry Pi Foundation |
+| 2012 | First Raspberry Pi board ships |
+| 2015 | Raspberry Pi passes into the tens of millions sold |
+| ongoing | Leads Raspberry Pi's commercial and foundation arms |
+
 ## Why they matter
 
 The [Raspberry Pi](/reference/raspberry-pi/) made a complete Linux computer with
@@ -45,7 +76,8 @@ continues as a leader of Raspberry Pi's commercial and foundation arms.[^wiki]
 ## Legacy
 
 Tens of millions of Raspberry Pi boards have shipped, and the platform reshaped how people
-learn hardware, prototype devices, and build low-cost embedded systems.
+learn hardware, prototype devices, and build low-cost embedded systems — including the cheap,
+always-on edge nodes that make distributed radio capture affordable.
 
 ## Sources
 

--- a/docs/reference/edge-ai.md
+++ b/docs/reference/edge-ai.md
@@ -4,7 +4,7 @@ title: Edge AI
 entry_type: concept
 category: hw-sbc
 description: Edge AI is the practice of running machine-learning models directly on local devices such as single-board computers, cameras, and sensors, rather than sending data to the cloud for inference.
-keywords: edge AI, on-device inference, edge inference, machine learning at the edge, AI accelerator, Edge TPU, low latency AI, privacy
+keywords: edge AI, on-device inference, edge inference, machine learning at the edge, AI accelerator, Edge TPU, low latency AI, privacy, quantized models
 aka: [on-device AI, edge inference]
 infobox:
   - { label: Type, value: Computing approach }
@@ -21,13 +21,59 @@ cite_urls:
 
 **Edge AI** is the practice of running machine-learning models directly on local devices — [single-board computers](/reference/single-board-computer/), cameras, sensors — instead of sending data to the cloud for inference.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 150" role="img" aria-label="Two inference paths compared. In the cloud path a sensor sends raw data over the network to a distant server and waits for a round trip. In the edge path the sensor feeds a local accelerator on the same device, which runs the model and produces a result immediately, sending only the small result onward." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.3">
+    <rect x="24" y="20" width="52" height="30" rx="4" fill-opacity="0.08" fill="currentColor"/>
+    <path d="M76 35 H150" stroke-dasharray="4 3"/>
+    <rect x="150" y="18" width="60" height="34" rx="4" fill-opacity="0.06" fill="currentColor"/>
+    <path d="M210 35 H284" stroke-dasharray="4 3"/>
+    <rect x="284" y="20" width="60" height="30" rx="4" fill-opacity="0.08" fill="currentColor"/>
+    <rect x="24" y="98" width="52" height="30" rx="4" fill-opacity="0.08" fill="currentColor"/>
+    <path d="M76 113 H150"/>
+    <rect x="150" y="96" width="70" height="34" rx="4" fill-opacity="0.16" fill="currentColor"/>
+    <path d="M220 113 H284"/>
+    <rect x="284" y="98" width="60" height="30" rx="4" fill-opacity="0.08" fill="currentColor"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="8" text-anchor="middle">
+    <text x="50" y="39" font-size="7.5">sensor</text>
+    <text x="180" y="33" font-size="7.5">cloud</text>
+    <text x="180" y="45" font-size="7.5">server</text>
+    <text x="314" y="39" font-size="7.5">result</text>
+    <text x="113" y="30" font-size="7" fill-opacity="0.85">network</text>
+    <text x="380" y="39" text-anchor="start" font-size="7.5" fill-opacity="0.9">round trip · latency</text>
+    <text x="50" y="117" font-size="7.5">sensor</text>
+    <text x="185" y="113" font-size="8" font-weight="600">accelerator</text>
+    <text x="185" y="124" font-size="7">on-device</text>
+    <text x="314" y="117" font-size="7.5">result</text>
+    <text x="380" y="117" text-anchor="start" font-size="7.5" fill-opacity="0.9">local · instant</text>
+    <text x="12" y="35" text-anchor="end" font-size="8" font-weight="600" transform="rotate(-90 12 35)">cloud</text>
+    <text x="12" y="113" text-anchor="end" font-size="8" font-weight="600" transform="rotate(-90 12 113)">edge</text>
+  </g>
+</svg>
+<figcaption>Cloud inference ships raw data to a distant server and waits for the round trip; edge AI runs the model on an accelerator right next to the sensor, returning a result immediately and sending only the small answer onward — the source of its latency, privacy, and offline advantages.</figcaption>
+</figure>
+
 ## Overview
 
-The appeal is concrete: inference next to the data is lower-latency, keeps private data on the device, and keeps working without a network. The cost is that small devices have limited compute, so edge AI leans on efficient, quantised models and on dedicated [AI accelerators](/reference/ai-accelerator/) such as [Google Coral](/reference/google-coral/)'s Edge TPU or the GPU on an [NVIDIA Jetson](/reference/nvidia-jetson/). It is a specific case of the broader move toward [edge computing](/reference/edge-computing/).
+The appeal is concrete: inference next to the data is lower-latency, keeps private data on the device, and keeps working without a network. A doorbell that recognises a face locally answers in milliseconds and never uploads the video; a cloud version has to survive a round trip and trust a remote server with the footage. Bandwidth costs drop too, because only the small result travels rather than a continuous raw stream.
+
+The cost is that small devices have limited compute, so edge AI leans on efficient, quantised models and on dedicated [AI accelerators](/reference/ai-accelerator/). Rather than run a full-precision network on a general CPU, edge deployments shrink the model — lower numeric precision, pruning, distillation — and hand the heavy math to purpose-built silicon like [Google Coral](/reference/google-coral/)'s Edge TPU or the GPU on an [NVIDIA Jetson](/reference/nvidia-jetson/). It is a specific case of the broader move toward [edge computing](/reference/edge-computing/).
+
+## Edge vs cloud inference
+
+| | Cloud inference | Edge AI |
+|---|-----------------|---------|
+| Latency | Network round trip | Immediate, local |
+| Privacy | Data leaves the device | Data stays put |
+| Offline | Fails without a link | Keeps working |
+| Compute available | Effectively unlimited | Small, power-bound |
+| Model size | Large, full precision | Quantised, compact |
+| Ongoing cost | Bandwidth + server time | One-time hardware |
 
 ## Where it fits
 
-Edge AI shows up wherever round-tripping to a server is too slow, too costly, or impossible: factory cameras, doorbells, robots, and [home automation](/reference/home-automation/). In a GopherTrunk-style deployment, edge AI could classify or flag activity in decoded data on the same node that does the radio work, sending up only the results rather than every sample.
+Edge AI shows up wherever round-tripping to a server is too slow, too costly, or impossible: factory cameras, doorbells, robots, and [home automation](/reference/home-automation/) hubs. In a GopherTrunk-style deployment, edge AI could classify or flag activity in decoded data on the same node that does the radio work — spotting a signal of interest, sorting traffic, or triggering a recording — and send up only the results rather than every sample, keeping a remote capture node useful even on a thin link.
 
 ## Sources
 

--- a/docs/reference/edge-computing.md
+++ b/docs/reference/edge-computing.md
@@ -4,12 +4,13 @@ title: Edge computing
 entry_type: concept
 category: hw-servers
 description: Edge computing processes data near where it is produced — at or close to the device or sensor — instead of sending everything to a distant data center, reducing latency and bandwidth use.
-keywords: edge computing, edge, latency, bandwidth, local processing, IoT, near the source
+keywords: edge computing, edge, latency, bandwidth, local processing, IoT, near the source, fog computing
 infobox:
   - { label: Type, value: Computing model }
   - { label: Runs, value: Near the data source }
   - { label: Reduces, value: Latency & bandwidth }
   - { label: Contrast, value: Centralized cloud }
+  - { label: Ally, value: Cloud (for heavy lifting) }
 see_also: [cloud-computing, content-delivery-network, internet-of-things, raspberry-pi, data-center, scalability]
 related_lessons:
   - { title: "Raspberry Pi and family", url: /learn/intro-hardware/raspberry-pi-and-family/ }
@@ -19,9 +20,55 @@ cite_urls:
 
 **Edge computing** processes data near where it is produced — at or close to the device or sensor — instead of shipping everything to a distant [data center](/reference/data-center/), reducing latency and bandwidth use.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 180" role="img" aria-label="A topology showing sensors on the left feeding a nearby edge node that filters and acts on data locally, then sends only small summaries upstream over a thin link to a central cloud data center on the right. A dashed baseline contrasts a purely centralized model that would send all raw data to the cloud." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="currentColor" font-family="ui-sans-serif, sans-serif">
+    <g stroke-width="1.1" fill-opacity="0.16">
+      <circle cx="34" cy="46" r="9"/><circle cx="34" cy="78" r="9"/><circle cx="34" cy="110" r="9"/>
+    </g>
+    <text x="34" y="132" text-anchor="middle" font-size="7.5" stroke="none" fill-opacity="0.85">sensors</text>
+    <g stroke-width="1.3" fill="none">
+      <line x1="44" y1="46" x2="120" y2="72"/>
+      <line x1="44" y1="78" x2="120" y2="78"/>
+      <line x1="44" y1="110" x2="120" y2="84"/>
+    </g>
+    <rect x="122" y="52" width="96" height="56" rx="4" fill-opacity="0.14" stroke-width="1.4"/>
+    <text x="170" y="76" text-anchor="middle" font-size="8.5" stroke="none" font-weight="600">Edge node</text>
+    <text x="170" y="90" text-anchor="middle" font-size="7.5" stroke="none">filter &#183; aggregate &#183; act</text>
+    <text x="170" y="126" text-anchor="middle" font-size="7.5" stroke="none" fill-opacity="0.85">close to the source</text>
+    <line x1="218" y1="80" x2="330" y2="80" stroke-width="1.6" fill="none"/>
+    <path d="M330 80 l-8 -3 v6 z" stroke-width="1"/>
+    <text x="274" y="72" text-anchor="middle" font-size="7.5" stroke="none">only summaries</text>
+    <text x="274" y="94" text-anchor="middle" font-size="7" stroke="none" fill-opacity="0.7">thin uplink</text>
+    <rect x="332" y="50" width="104" height="60" rx="4" fill-opacity="0.06" stroke-width="1.4"/>
+    <text x="384" y="76" text-anchor="middle" font-size="8.5" stroke="none" font-weight="600">Cloud</text>
+    <text x="384" y="90" text-anchor="middle" font-size="7.5" stroke="none">storage &#183; analytics</text>
+    <text x="384" y="126" text-anchor="middle" font-size="7.5" stroke="none" fill-opacity="0.85">distant data center</text>
+    <text x="230" y="160" text-anchor="middle" font-size="8" stroke="none" fill-opacity="0.85">a purely central model would push ALL raw data across the same link</text>
+  </g>
+</svg>
+<figcaption>An edge node near the sensors does the time-sensitive and high-volume work locally and forwards only compact summaries upstream, so the central cloud handles heavy storage and analytics without drowning in raw data.</figcaption>
+</figure>
+
 ## Overview
 
-In a purely centralized model, devices send raw data to the [cloud](/reference/cloud-computing/) and wait for a response. Edge computing moves some of that work outward: a small computer near the source filters, aggregates, or acts on data locally, sending only summaries or alerts upstream. This cuts round-trip latency, saves bandwidth, and keeps working when the network link is slow or down. It is closely tied to the [internet of things](/reference/internet-of-things/), where many sensors generate more data than is practical to forward whole.
+In a purely centralized model, devices send raw data to the [cloud](/reference/cloud-computing/) and wait for a response. Edge computing moves some of that work outward: a small computer near the source filters, aggregates, or acts on data locally, sending only summaries or alerts upstream. This cuts round-trip latency, saves bandwidth, and keeps working when the network link is slow or down.
+
+It is closely tied to the [internet of things](/reference/internet-of-things/), where many sensors generate more data than is practical to forward whole. The edge node may be an industrial gateway, a cell-tower micro data center, or a hobbyist single-board computer — the defining trait is proximity to where data is born, not any particular hardware.
+
+## Trade-offs
+
+Where computation happens is a balance, and edge and cloud each win on different axes:
+
+| Property | Edge | Central cloud |
+|----------|------|---------------|
+| Latency | Low (local) | Higher (round trip) |
+| Bandwidth use | Low (summaries) | High (raw data) |
+| Compute power | Modest | Effectively unlimited |
+| Works offline | Yes | No |
+| Storage & analytics | Limited | Deep |
+
+The two are complementary, not rivals: keep the reflex-fast, high-volume work at the edge and let the cloud do the heavy, long-horizon lifting.
 
 ## Where it fits
 

--- a/docs/reference/embedded-system.md
+++ b/docs/reference/embedded-system.md
@@ -3,8 +3,8 @@ slug: embedded-system
 title: Embedded system
 entry_type: concept
 category: hw-microcontrollers
-description: An embedded system is a computer built into a larger product to perform a dedicated function, usually around a microcontroller with fixed firmware rather than a general-purpose operating system.
-keywords: embedded system, dedicated function, firmware, real-time, microcontroller, appliance, deeply embedded
+description: An embedded system is a computer built into a larger product to perform a dedicated function, usually around a microcontroller with fixed firmware rather than a general-purpose operating system, sensing the world and acting on it in a closed loop.
+keywords: embedded system, dedicated function, firmware, real-time, microcontroller, appliance, deeply embedded, sensor, actuator, closed loop
 infobox:
   - { label: Type, value: Dedicated-purpose computer }
   - { label: Built around, value: Microcontroller or SoC }
@@ -20,13 +20,56 @@ cite_urls:
 
 **An embedded system** is a computer built into a larger product to carry out a dedicated function, rather than a general-purpose machine you load arbitrary programs onto.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 148" role="img" aria-label="Signal chain of an embedded system. Sensors on the left feed readings into a central microcontroller running fixed firmware. The microcontroller decides what to do and drives actuators on the right, such as a motor or relay. A feedback arrow runs from the actuators back to the sensors, closing the sense-decide-act loop." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.3">
+    <rect x="24" y="46" width="96" height="48" rx="4" fill="currentColor" fill-opacity="0.08"/>
+    <rect x="182" y="40" width="108" height="60" rx="4" fill="currentColor" fill-opacity="0.14"/>
+    <rect x="352" y="46" width="96" height="48" rx="4" fill="currentColor" fill-opacity="0.08"/>
+    <line x1="120" y1="70" x2="182" y2="70"/>
+    <path d="M182 70 L172 65 M182 70 L172 75" stroke-width="1.2"/>
+    <line x1="290" y1="70" x2="352" y2="70"/>
+    <path d="M352 70 L342 65 M352 70 L342 75" stroke-width="1.2"/>
+    <path d="M400 94 L400 126 L72 126 L72 94" stroke-dasharray="3 3"/>
+    <path d="M72 100 L67 108 M72 100 L77 108" stroke-width="1.2"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="72" y="66" font-size="8.5" font-weight="600">Sensors</text>
+    <text x="72" y="80" font-size="7.5" fill-opacity="0.85">temp, motion,</text>
+    <text x="72" y="90" font-size="7.5" fill-opacity="0.85">light&#8230;</text>
+    <text x="236" y="64" font-size="9" font-weight="600">Microcontroller</text>
+    <text x="236" y="78" font-size="7.5" fill-opacity="0.85">fixed firmware</text>
+    <text x="236" y="90" font-size="7.5" fill-opacity="0.85">sense &#8594; decide &#8594; act</text>
+    <text x="400" y="66" font-size="8.5" font-weight="600">Actuators</text>
+    <text x="400" y="80" font-size="7.5" fill-opacity="0.85">motor, relay,</text>
+    <text x="400" y="90" font-size="7.5" fill-opacity="0.85">display</text>
+    <text x="236" y="140" font-size="7.5" fill-opacity="0.85">feedback closes the loop</text>
+  </g>
+</svg>
+<figcaption>An embedded system reads the physical world through sensors, a microcontroller running fixed firmware decides what to do, and it drives actuators in response. Because the output changes the world the sensors measure, the whole thing is a closed sense-decide-act loop — one job, done cheaply and reliably.</figcaption>
+</figure>
+
 ## Overview
 
-Most embedded systems are built around a [microcontroller](/reference/microcontroller/) or system-on-chip running fixed [firmware](/reference/firmware/). They are everywhere — in appliances, cars, medical devices, industrial controllers, and radios — usually invisible to the user. Many have hard real-time constraints, met with [interrupts](/reference/interrupt/) and a [real-time operating system](/reference/real-time-operating-system/), while simpler ones run [bare metal](/reference/bare-metal-programming/). They read the physical world through [sensors](/reference/sensor/) and act on it through actuators.
+Most embedded systems are built around a [microcontroller](/reference/microcontroller/) or [system-on-chip](/reference/system-on-a-chip/) running fixed [firmware](/reference/firmware/). They are everywhere — in appliances, cars, medical devices, industrial controllers, and radios — usually invisible to the user. Many have hard real-time constraints, met with [interrupts](/reference/interrupt/) and a [real-time operating system](/reference/real-time-operating-system/), while simpler ones run [bare metal](/reference/bare-metal-programming/).
+
+They read the physical world through [sensors](/reference/sensor/) and act on it through actuators, closing the loop between measuring and doing. The term shades from "deeply embedded" 8-bit controllers with kilobytes of memory up to Linux-class systems-on-chip, but the common thread is a device dedicated to one purpose rather than a computer you install arbitrary apps onto.
+
+## Embedded versus general-purpose
+
+The distinction is specialization, not size:
+
+| Trait | Embedded system | General-purpose computer |
+|-------|-----------------|--------------------------|
+| Purpose | One dedicated function | Runs arbitrary programs |
+| Software | Fixed firmware | Installable apps + OS |
+| Resources | Kilobytes to a few MB | Gigabytes |
+| Timing | Often hard real-time | Best-effort |
+| Visible? | Usually hidden inside a product | The product itself |
 
 ## Where it fits
 
-The defining trade-off is specialization: an embedded system does one job extremely well, cheaply, and reliably, at the cost of flexibility. When a device also needs network connectivity it becomes part of the [Internet of Things](/reference/internet-of-things/). In radio terms, the small transmitters that fill the airwaves GopherTrunk listens to are embedded systems — far too small to run GopherTrunk itself, which lives on a general-purpose computer with an SDR front end.
+The defining trade-off is specialization: an embedded system does one job extremely well, cheaply, and reliably, at the cost of flexibility. When a device also needs network connectivity it becomes part of the [Internet of Things](/reference/internet-of-things/). In radio terms, the small transmitters that fill the airwaves GopherTrunk listens to are embedded systems — far too small to run GopherTrunk itself, which lives on a general-purpose computer with an SDR front end. A low-power capture node feeding IQ upstream is one honest exception: it is an embedded-style appliance built for a single job.
 
 ## Sources
 

--- a/docs/reference/emmc.md
+++ b/docs/reference/emmc.md
@@ -3,8 +3,8 @@ slug: emmc
 title: eMMC
 entry_type: hardware
 category: hw-storage
-description: eMMC is flash storage with a controller in a single chip soldered onto a board, giving embedded devices and cheaper computers built-in storage without a removable card.
-keywords: eMMC, embedded MultiMediaCard, embedded flash, soldered storage, NAND, MMC, JEDEC
+description: eMMC is flash storage with a controller in a single BGA chip soldered onto a board, giving embedded devices and cheaper computers built-in storage without a removable card.
+keywords: eMMC, embedded MultiMediaCard, embedded flash, soldered storage, NAND, MMC, JEDEC, BGA, single-board computer
 aka: [embedded MultiMediaCard]
 autolink: true
 infobox:
@@ -13,20 +13,63 @@ infobox:
   - { label: Mounting, value: Soldered to board (BGA) }
   - { label: Standard, value: JEDEC eMMC }
   - { label: Common use, value: Phones, tablets, SBCs }
-see_also: [flash-memory, sd-card, solid-state-drive, jedec, nvme, data-storage]
+see_also: [flash-memory, sd-card, solid-state-drive, jedec, nvme, data-storage, single-board-computer]
 cite_urls:
   - https://en.wikipedia.org/wiki/MultiMediaCard#eMMC
 ---
 
 **eMMC (embedded MultiMediaCard)** is a single package that combines [flash memory](/reference/flash-memory/) and its controller, soldered directly onto a device's board as built-in storage.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 150" role="img" aria-label="Cross-section of an eMMC package. A single chip package holds a stack of NAND flash dies above a small controller die that handles wear leveling; the package sits on a row of solder balls that fix it permanently to the circuit board below." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.3">
+    <rect x="120" y="24" width="220" height="66" rx="4" fill-opacity="0.06" fill="currentColor"/>
+    <rect x="140" y="34" width="180" height="16" rx="2" fill-opacity="0.14" fill="currentColor"/>
+    <rect x="146" y="40" width="180" height="16" rx="2" fill-opacity="0.14" fill="currentColor"/>
+    <rect x="152" y="46" width="180" height="16" rx="2" fill-opacity="0.14" fill="currentColor"/>
+    <rect x="150" y="68" width="120" height="14" rx="2" fill-opacity="0.22" fill="currentColor"/>
+    <line x1="90" y1="112" x2="440" y2="112" stroke-width="1.6"/>
+  </g>
+  <g fill="currentColor" stroke="currentColor" stroke-width="0.6">
+    <circle cx="150" cy="100" r="4" fill-opacity="0.5"/>
+    <circle cx="180" cy="100" r="4" fill-opacity="0.5"/>
+    <circle cx="210" cy="100" r="4" fill-opacity="0.5"/>
+    <circle cx="240" cy="100" r="4" fill-opacity="0.5"/>
+    <circle cx="270" cy="100" r="4" fill-opacity="0.5"/>
+    <circle cx="300" cy="100" r="4" fill-opacity="0.5"/>
+  </g>
+  <g fill="currentColor" stroke="none">
+    <text x="352" y="44" font-size="8.5">NAND flash</text>
+    <text x="352" y="54" font-size="8.5">dies (stacked)</text>
+    <text x="210" y="78" font-size="8.5" text-anchor="middle" font-weight="600">controller</text>
+    <text x="316" y="103" font-size="8" text-anchor="start">solder balls (BGA)</text>
+    <text x="90" y="126" font-size="8.5">circuit board — permanently mounted</text>
+  </g>
+</svg>
+<figcaption>An eMMC package stacks NAND flash dies over a controller that hides wear leveling, and a grid of solder balls fixes the whole thing to the board — one chip, no connector, no removable card.</figcaption>
+</figure>
+
 ## Overview
 
-Like an [SD card](/reference/sd-card/), eMMC bundles NAND flash with a controller that handles wear leveling and presents a simple block device — but the package is permanently mounted rather than removable. The interface and command set are standardised by [JEDEC](/reference/jedec/). Because it is fixed in place, eMMC is reliable and compact, but capacities are modest and throughput sits below a modern [NVMe](/reference/nvme/) [SSD](/reference/solid-state-drive/). It is common in phones, tablets, and the cheaper tiers of single-board computers.
+Like an [SD card](/reference/sd-card/), eMMC bundles NAND flash with a controller that handles wear leveling, bad-block management, and error correction, then presents a plain block device to the host. The difference is packaging: eMMC is a ball-grid-array (BGA) chip reflow-soldered onto the board rather than a card in a slot. The interface and command set are standardised by [JEDEC](/reference/jedec/), evolving from the older MMC standard into successive eMMC revisions.
+
+Because it is fixed in place, eMMC is mechanically reliable and compact, with no contacts to corrode or work loose. Capacities are modest — typically a handful to tens of gigabytes — and sustained throughput sits well below a modern [NVMe](/reference/nvme/) [SSD](/reference/solid-state-drive/), roughly on par with a good SD card. It is the built-in storage in most phones, tablets, and the cheaper tiers of single-board computers.
+
+## How it compares
+
+eMMC occupies the middle of the flash storage range — sturdier and usually faster than a card, far cheaper and slower than an NVMe drive:
+
+| Trait | SD card | eMMC | NVMe SSD |
+|-------|---------|------|----------|
+| Mounting | Removable slot | Soldered (BGA) | M.2 / slot |
+| Interface | SD bus | eMMC (JEDEC) | PCIe |
+| Typical speed | ~10–100 MB/s | ~100–300 MB/s | 1000+ MB/s |
+| Capacity | Up to ~1 TB | ~4–256 GB | Up to multi-TB |
+| Removable | Yes | No | Usually |
 
 ## Where it fits
 
-eMMC is the middle ground between a removable SD card and a full SSD: faster and more durable than a typical card, cheaper and smaller than a discrete drive. Some single-board computers offer an eMMC module as a sturdier alternative to booting from microSD. For a GopherTrunk node that runs unattended near an antenna, soldered or socketed eMMC avoids the wear and connection issues that plague constantly written SD cards.
+eMMC is the practical default for embedded gear that needs dependable built-in storage without the cost or size of a discrete drive. Some [single-board computers](/reference/single-board-computer/) offer an eMMC module as a sturdier alternative to booting from microSD. For a GopherTrunk node that runs unattended near an antenna, soldered or socketed eMMC avoids the wear and connection issues that plague constantly written SD cards, while staying cheaper and lower-power than fitting a full SSD.
 
 ## Sources
 

--- a/docs/reference/esim.md
+++ b/docs/reference/esim.md
@@ -19,13 +19,56 @@ cite_urls:
 
 An **eSIM** is a SIM built directly into a device as a small, reprogrammable chip, letting a user download and switch carrier profiles over the air instead of swapping a physical card.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 160" role="img" aria-label="A comparison of a physical SIM and an eSIM. On the left, a removable SIM card with a gold contact pad slides into a tray. On the right, an eSIM is a soldered chip on the board that receives one or more carrier profiles downloaded over the air from the carrier's provisioning server." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.2" font-family="ui-sans-serif, sans-serif">
+    <path d="M46 44 h70 v56 h-84 v-42 z"/>
+    <rect x="52" y="56" width="26" height="20" rx="2"/>
+    <line x1="60" y1="56" x2="60" y2="76"/>
+    <line x1="70" y1="56" x2="70" y2="76"/>
+    <line x1="52" y1="66" x2="78" y2="66"/>
+    <rect x="34" y="108" width="96" height="14" rx="2" stroke-dasharray="3 3"/>
+    <rect x="300" y="46" width="120" height="54" rx="3"/>
+    <g stroke-width="1">
+      <line x1="300" y1="58" x2="290" y2="58"/>
+      <line x1="300" y1="72" x2="290" y2="72"/>
+      <line x1="300" y1="86" x2="290" y2="86"/>
+      <line x1="420" y1="58" x2="430" y2="58"/>
+      <line x1="420" y1="72" x2="430" y2="72"/>
+      <line x1="420" y1="86" x2="430" y2="86"/>
+    </g>
+    <path d="M360 46 v-22 h-80" stroke-width="1.1"/>
+    <path d="M283 24 l6 -4 v8 z" fill="currentColor" stroke="none"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-family="ui-sans-serif, sans-serif" font-size="8.5">
+    <text x="74" y="132" text-anchor="middle">physical SIM &#183; removable</text>
+    <text x="360" y="116" text-anchor="middle">eSIM (eUICC) &#183; soldered</text>
+    <text x="220" y="20" text-anchor="middle" font-size="8">profile downloaded over the air</text>
+    <text x="360" y="130" text-anchor="middle" font-size="8">holds several profiles</text>
+  </g>
+</svg>
+<figcaption>Where a physical SIM is a removable card in a tray, an eSIM is a soldered eUICC chip that downloads carrier profiles over the air — no tray, and room for several profiles at once.</figcaption>
+</figure>
+
 ## Overview
 
-Technically an *eUICC* (embedded Universal Integrated Circuit Card) standardized by the GSMA, an eSIM solders the SIM function onto the board and holds one or more downloadable *profiles*. Activating a plan means scanning a QR code or following a carrier flow; switching networks or running a second line no longer requires opening a tray. Freeing a device from a card slot saves space and improves water resistance, and lets tiny products — [smartwatches](/reference/smartwatch/), trackers — carry cellular service at all.
+Technically an *eUICC* (embedded Universal Integrated Circuit Card) standardized by the GSMA, an eSIM solders the SIM function onto the board and holds one or more downloadable *profiles*. Activating a plan means scanning a QR code or following a carrier flow; switching networks or running a second line no longer requires opening a tray or handling a fragile nano-card.
+
+Freeing a device from a card slot saves internal space and improves water and dust resistance, and it lets tiny products — [smartwatches](/reference/smartwatch/), trackers, IoT sensors — carry cellular service at all. For manufacturers it also simplifies logistics: one hardware SKU ships worldwide and is provisioned to the right carrier after the sale.
+
+## Physical SIM vs eSIM
+
+| Aspect | Physical SIM | eSIM (eUICC) |
+|--------|--------------|--------------|
+| Form | Removable card | Soldered chip |
+| Change carrier | Swap card | Download profile |
+| Profiles held | One | Several |
+| Space & sealing | Needs tray | None; better sealed |
+| Remote fleet setup | Manual visit | Over the air |
 
 ## Where it fits
 
-The eSIM is the connectivity counterpart to a device's [cellular modem](/reference/cellular-modem/): the modem provides the radio, the eSIM the identity. For a fleet of remote GopherTrunk capture nodes on cellular backhaul, eSIM provisioning means carriers and data plans can be assigned and changed remotely, without anyone visiting each node to insert a card.
+The eSIM is the connectivity counterpart to a device's [cellular modem](/reference/cellular-modem/): the modem provides the radio, the eSIM the identity the network authenticates. For a fleet of remote GopherTrunk capture nodes on cellular backhaul, eSIM provisioning means carriers and data plans can be assigned and changed remotely, without anyone visiting each node to insert or swap a card.
 
 ## Sources
 

--- a/docs/reference/esp32.md
+++ b/docs/reference/esp32.md
@@ -3,8 +3,8 @@ slug: esp32
 title: ESP32
 entry_type: hardware
 category: hw-microcontrollers
-description: The ESP32 is a low-cost dual-core microcontroller with built-in Wi-Fi and Bluetooth, the workhorse of DIY smart-home gadgets and Internet of Things devices.
-keywords: ESP32, ESP8266, ESP-IDF, Wi-Fi, Bluetooth, dual core, IoT microcontroller, MicroPython
+description: The ESP32 is a low-cost dual-core microcontroller with built-in Wi-Fi and Bluetooth from Espressif, the workhorse of DIY smart-home gadgets and Internet of Things devices.
+keywords: ESP32, ESP8266, ESP-IDF, Wi-Fi, Bluetooth, dual core, IoT microcontroller, MicroPython, Espressif, Xtensa
 aka: [ESP32]
 autolink: true
 infobox:
@@ -13,7 +13,7 @@ infobox:
   - { label: Wireless, value: Wi-Fi + Bluetooth }
   - { label: Typical price, value: ~$2–5 }
   - { label: Language, value: C/C++ (ESP-IDF, Arduino), MicroPython }
-see_also: [microcontroller, internet-of-things, arduino, gpio, firmware]
+see_also: [microcontroller, internet-of-things, arduino, gpio, firmware, sensor]
 related_lessons:
   - { title: "ESP32", url: /learn/intro-hardware/esp32/ }
 cite_urls:
@@ -22,13 +22,58 @@ cite_urls:
 
 **The ESP32** is a low-cost, dual-core [microcontroller](/reference/microcontroller/) with built-in Wi-Fi and Bluetooth, often around a couple of dollars.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 168" role="img" aria-label="Block diagram of an ESP32 chip. Two processor cores share on-chip SRAM and connect to an integrated radio block for Wi-Fi and Bluetooth, which feeds an external antenna. A peripheral bus links the cores to GPIO pins, an analog-to-digital converter, and serial interfaces used to attach sensors." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.3">
+    <rect x="30" y="34" width="70" height="30" rx="4" fill="currentColor" fill-opacity="0.14"/>
+    <rect x="30" y="72" width="70" height="30" rx="4" fill="currentColor" fill-opacity="0.14"/>
+    <rect x="128" y="50" width="70" height="36" rx="4" fill="currentColor" fill-opacity="0.08"/>
+    <rect x="230" y="44" width="96" height="48" rx="4" fill="currentColor" fill-opacity="0.10"/>
+    <rect x="128" y="112" width="198" height="32" rx="4" fill="currentColor" fill-opacity="0.06"/>
+    <line x1="100" y1="49" x2="128" y2="60"/>
+    <line x1="100" y1="87" x2="128" y2="76"/>
+    <line x1="198" y1="68" x2="230" y2="68"/>
+    <line x1="227" y1="128" x2="128" y2="128"/>
+    <line x1="163" y1="86" x2="163" y2="112"/>
+    <path d="M326 60 L360 52 L360 44 M360 52 L392 44" stroke-width="1.1"/>
+    <line x1="360" y1="52" x2="360" y2="84"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="65" y="53" font-size="8">Core 0</text>
+    <text x="65" y="91" font-size="8">Core 1</text>
+    <text x="163" y="66" font-size="7.5" font-weight="600">SRAM</text>
+    <text x="163" y="78" font-size="7.5" fill-opacity="0.85">shared</text>
+    <text x="278" y="64" font-size="8.5" font-weight="600">Radio</text>
+    <text x="278" y="78" font-size="7.5" fill-opacity="0.85">Wi-Fi + BT</text>
+    <text x="376" y="98" font-size="7.5">antenna</text>
+    <text x="227" y="126" font-size="8" font-weight="600">Peripherals</text>
+    <text x="227" y="138" font-size="7.5" fill-opacity="0.85">GPIO &#183; ADC &#183; UART/SPI/I&#178;C &#8594; sensors</text>
+  </g>
+</svg>
+<figcaption>What sets the ESP32 apart is an integrated radio: two cores share SRAM and drive an on-chip Wi-Fi and Bluetooth block out to an antenna, while a peripheral bus wires GPIO, an ADC, and serial ports to sensors. Radio plus compute for a couple of dollars is why it dominates hobby IoT.</figcaption>
+</figure>
+
 ## Overview
 
-That combination of price and wireless connectivity makes the ESP32 the workhorse of DIY smart-home gadgets and the [Internet of Things](/reference/internet-of-things/). Common variants include the S3 and C3, alongside the older and simpler ESP8266 that preceded it.
+That combination of price and wireless connectivity makes the ESP32 the workhorse of DIY smart-home gadgets and the [Internet of Things](/reference/internet-of-things/). It comes from Espressif Systems in Shanghai, and common variants include the S3 and C3, alongside the older and simpler ESP8266 that preceded it.
+
+Under the hood the classic ESP32 pairs two 32-bit cores with a few hundred kilobytes of SRAM and, crucially, a built-in 2.4 GHz radio doing both Wi-Fi and Bluetooth — the feature that separates it from a plain [microcontroller](/reference/microcontroller/). Newer parts swap the original Xtensa cores for [RISC-V](/reference/risc-v/).
+
+## ESP32 versus its predecessor
+
+The ESP8266 put a Wi-Fi microcontroller on the map; the ESP32 broadened it:
+
+| Feature | ESP8266 | ESP32 (classic) |
+|---------|---------|-----------------|
+| Cores | Single | Dual |
+| Wireless | Wi-Fi | Wi-Fi + Bluetooth |
+| GPIO | Few usable | Many, plus ADC/DAC/touch |
+| SRAM | ~80 KB | ~520 KB |
+| Role | Cheap Wi-Fi node | General wireless MCU |
 
 ## Where it fits
 
-You can program an ESP32 in C/C++ — using either Espressif's ESP-IDF or the [Arduino](/reference/arduino/) toolchain — or in MicroPython. Wired to sensors over its [GPIO](/reference/gpio/) pins and talking over Wi-Fi, it is exactly the kind of cheap wireless node that crowds the airwaves GopherTrunk listens to, even though it is far too small to run GopherTrunk itself.
+You can program an ESP32 in C/C++ — using either Espressif's ESP-IDF or the [Arduino](/reference/arduino/) toolchain — or in MicroPython. Wired to [sensors](/reference/sensor/) over its [GPIO](/reference/gpio/) pins and talking over Wi-Fi, it is exactly the kind of cheap wireless node that crowds the airwaves GopherTrunk listens to, even though it is far too small to run GopherTrunk itself. As an SDR helper it makes a fine remote GPIO or telemetry board — reading a sensor and reporting over Wi-Fi beside a capture station.
 
 ## Sources
 

--- a/docs/reference/espressif.md
+++ b/docs/reference/espressif.md
@@ -4,7 +4,7 @@ title: Espressif Systems
 entry_type: organization
 category: hw-organizations
 description: Espressif Systems is a Chinese semiconductor company best known for its low-cost ESP8266 and ESP32 Wi-Fi and Bluetooth microcontrollers used widely in IoT projects.
-keywords: Espressif, ESP32, ESP8266, Wi-Fi microcontroller, IoT, Bluetooth
+keywords: Espressif, ESP32, ESP8266, Wi-Fi microcontroller, IoT, Bluetooth, RISC-V, SoC
 aka: [Espressif]
 autolink: true
 infobox:
@@ -12,7 +12,7 @@ infobox:
   - { label: Founded, value: "2008" }
   - { label: HQ, value: Shanghai, China }
   - { label: Makes, value: Wi-Fi/Bluetooth microcontrollers (ESP series) }
-see_also: [esp32, microcontroller, internet-of-things]
+see_also: [esp32, microcontroller, internet-of-things, wi-fi, bluetooth]
 related_lessons:
   - { title: "ESP32", url: /learn/intro-hardware/esp32/ }
 cite_urls:
@@ -21,8 +21,42 @@ cite_urls:
 ---
 
 **Espressif Systems** is a Chinese semiconductor company, founded in 2008, best known for
-its low-cost [ESP32](/reference/esp32/) family of Wi-Fi and Bluetooth
-[microcontrollers](/reference/microcontroller/).[^wiki]
+its low-cost [ESP32](/reference/esp32/) family of [Wi-Fi](/reference/wi-fi/) and
+[Bluetooth](/reference/bluetooth/) [microcontrollers](/reference/microcontroller/).[^wiki]
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 150" role="img" aria-label="A diagram of an Espressif ESP chip. A single package outline contains three integrated blocks: a microcontroller CPU core, a Wi-Fi and Bluetooth radio, and on-chip memory. Below, a short timeline notes the 2014 ESP8266 that added Wi-Fi, the 2016 ESP32 that added Bluetooth and more power, and later ESP32 variants including RISC-V cores." xmlns="http://www.w3.org/2000/svg">
+  <rect x="120" y="16" width="220" height="66" rx="6" stroke="currentColor" fill="currentColor" fill-opacity="0.06" stroke-width="1.4"/>
+  <g stroke="currentColor" fill="currentColor" fill-opacity="0.14" stroke-width="1.1">
+    <rect x="134" y="30" width="60" height="38" rx="3"/>
+    <rect x="200" y="30" width="60" height="38" rx="3"/>
+    <rect x="266" y="30" width="60" height="38" rx="3"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle" font-size="8.5">
+    <text x="164" y="46">MCU</text>
+    <text x="164" y="58">core</text>
+    <text x="230" y="46">Wi-Fi /</text>
+    <text x="230" y="58">BT radio</text>
+    <text x="296" y="46">memory</text>
+    <text x="230" y="93" font-size="8" fill-opacity="0.9">one low-cost package</text>
+  </g>
+  <line x1="40" y1="118" x2="420" y2="118" stroke="currentColor" stroke-width="1.2"/>
+  <g stroke="currentColor" fill="currentColor" stroke-width="1.1">
+    <circle cx="90" cy="118" r="4" fill-opacity="0.15"/>
+    <circle cx="230" cy="118" r="5" fill="currentColor"/>
+    <circle cx="370" cy="118" r="4" fill-opacity="0.15"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle" font-size="8">
+    <text x="90" y="108">2014 ESP8266</text>
+    <text x="90" y="140">Wi-Fi</text>
+    <text x="230" y="108" font-weight="600">2016 ESP32</text>
+    <text x="230" y="140">+ Bluetooth, more power</text>
+    <text x="370" y="108">later variants</text>
+    <text x="370" y="140">incl. RISC-V cores</text>
+  </g>
+</svg>
+<figcaption>Espressif's trick is integration: the ESP series packs a microcontroller, a Wi-Fi/Bluetooth radio, and memory into one cheap chip, evolving from the Wi-Fi-only ESP8266 to the Bluetooth-capable ESP32 and its later RISC-V variants.</figcaption>
+</figure>
 
 ## Overview
 
@@ -35,12 +69,23 @@ backs them with open development frameworks and broad community support. That co
 made the ESP series a default choice for connected sensors and devices across the
 [Internet of Things](/reference/internet-of-things/).
 
-## Why it matters
+## The ESP family
+
+A few generations trace Espressif's climb from a Wi-Fi add-on to a full IoT platform:
+
+| Chip | Year | Adds |
+|------|------|------|
+| ESP8266 | 2014 | Low-cost Wi-Fi |
+| ESP32 | 2016 | Bluetooth, dual core, more peripherals |
+| ESP32-C / -S | 2020+ | RISC-V cores, USB, security features |
+
+## Where it fits
 
 By making a wireless-capable microcontroller cheap and easy to program, Espressif helped
 make networked embedded projects routine. An ESP32 makes a tidy little wireless sensor or
 telemetry node — for example, reporting status or environmental data from a remote
-GopherTrunk antenna site back over Wi-Fi.
+GopherTrunk antenna site back over Wi-Fi — while the heavy radio decoding stays on a
+larger host.
 
 ## Sources
 

--- a/docs/reference/ethernet.md
+++ b/docs/reference/ethernet.md
@@ -3,14 +3,15 @@ slug: ethernet
 title: Ethernet
 entry_type: concept
 category: hw-networking
-description: Ethernet is the dominant family of wired local-area networking standards, defining the cables, connectors, and frame format that carry data between computers on a LAN.
-keywords: Ethernet, IEEE 802.3, twisted pair, RJ45, Gigabit Ethernet, frame, wired networking
+description: Ethernet is the dominant family of wired local-area networking standards, defining the cables, connectors, and frame format that carry data between computers on a LAN at speeds from 10 Mb/s to 400 Gb/s.
+keywords: Ethernet, IEEE 802.3, twisted pair, RJ45, Gigabit Ethernet, frame, MAC address, wired networking, speed grades
 aka: [IEEE 802.3]
 infobox:
   - { label: Type, value: Wired LAN standard }
   - { label: Standard, value: IEEE 802.3 }
   - { label: Common cabling, value: Twisted pair (RJ45), fiber }
   - { label: Speeds, value: 10 Mb/s – 400 Gb/s }
+  - { label: Addressing, value: 48-bit MAC }
 see_also: [network-switch, network-interface-card, fiber-optic, power-over-ethernet, wi-fi, lan-and-wan]
 cite_urls:
   - https://en.wikipedia.org/wiki/Ethernet
@@ -18,14 +19,69 @@ cite_urls:
 
 **Ethernet** is the dominant family of wired local-area networking standards, defining the cabling, signaling, and frame format that carry data between computers on a [LAN](/reference/lan-and-wan/).[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="The byte layout of an Ethernet frame drawn as a row of labelled fields: a 7-byte preamble and 1-byte start delimiter, a 6-byte destination MAC, a 6-byte source MAC, a 2-byte type field, the 46 to 1500-byte payload, and a 4-byte frame check sequence at the end." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="currentColor" font-family="ui-sans-serif, sans-serif">
+    <g stroke-width="1.3">
+      <rect x="14" y="40" width="44" height="30" fill-opacity="0.06"/>
+      <rect x="58" y="40" width="26" height="30" fill-opacity="0.06"/>
+      <rect x="84" y="40" width="60" height="30" fill-opacity="0.12"/>
+      <rect x="144" y="40" width="60" height="30" fill-opacity="0.12"/>
+      <rect x="204" y="40" width="40" height="30" fill-opacity="0.06"/>
+      <rect x="244" y="40" width="150" height="30" fill-opacity="0.18"/>
+      <rect x="394" y="40" width="52" height="30" fill-opacity="0.06"/>
+    </g>
+    <g stroke="none" text-anchor="middle" font-size="8">
+      <text x="36" y="58">Preamble</text>
+      <text x="71" y="58">SFD</text>
+      <text x="114" y="55" font-weight="600">Dest</text>
+      <text x="114" y="65">MAC</text>
+      <text x="174" y="55" font-weight="600">Src</text>
+      <text x="174" y="65">MAC</text>
+      <text x="224" y="58">Type</text>
+      <text x="319" y="55" font-weight="600">Payload</text>
+      <text x="319" y="65">(data)</text>
+      <text x="420" y="58">FCS</text>
+    </g>
+    <g stroke="none" text-anchor="middle" font-size="7.5" fill-opacity="0.85">
+      <text x="36" y="84">7 B</text>
+      <text x="71" y="84">1 B</text>
+      <text x="114" y="84">6 B</text>
+      <text x="174" y="84">6 B</text>
+      <text x="224" y="84">2 B</text>
+      <text x="319" y="84">46–1500 B</text>
+      <text x="420" y="84">4 B</text>
+    </g>
+  </g>
+  <text x="230" y="108" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">MAC addresses steer the frame; the FCS is a CRC that catches corruption in transit</text>
+</svg>
+<figcaption>An Ethernet frame: a preamble and start delimiter mark its beginning, destination and source MAC addresses say who it is for and from, a type field names the payload's protocol, and a frame check sequence (a CRC) at the tail lets the receiver detect corruption.</figcaption>
+</figure>
+
 ## Overview
 
-Standardized as **IEEE 802.3**, Ethernet packages data into *frames* tagged with source and destination MAC addresses and sends them over twisted-pair copper (terminated in the familiar 8-pin RJ45 plug) or over [fiber-optic](/reference/fiber-optic/) cable for longer runs and higher speeds. Speeds have climbed from the original 10 Mb/s through Fast and Gigabit Ethernet to 10, 100, and 400 Gb/s. Devices attach through a [NIC](/reference/network-interface-card/) and connect to a [switch](/reference/network-switch/); the same cabling can also carry power via [Power over Ethernet](/reference/power-over-ethernet/).
+Standardized as **IEEE 802.3**, Ethernet packages data into *frames* tagged with source and destination MAC addresses and sends them over twisted-pair copper (terminated in the familiar 8-pin RJ45 plug) or over [fiber-optic](/reference/fiber-optic/) cable for longer runs and higher speeds. Each 48-bit MAC address is globally unique to a network interface, so a [switch](/reference/network-switch/) can learn which port each device sits behind and forward frames only where they need to go.
 
-## What it's for
+Speeds have climbed from the original 10 Mb/s through Fast and Gigabit Ethernet to 10, 100, and 400 Gb/s, each grade reusing the same frame format so old and new gear interoperate. Devices attach through a [NIC](/reference/network-interface-card/) and connect to a switch; the same cabling can also carry power via [Power over Ethernet](/reference/power-over-ethernet/).
 
-Ethernet is the default for fixed, performance-sensitive connections where a cable is practical — servers, desktops, and infrastructure — while [Wi-Fi](/reference/wi-fi/) handles mobility. A wired Ethernet link gives a GopherTrunk capture node a stable, low-jitter path to stream decoded calls to a [server](/reference/server/), avoiding the contention and interference of a shared radio channel.
+A tail *frame check sequence* — a cyclic redundancy check — lets the receiver discard any frame that arrived corrupted, so upper layers see a clean byte stream or nothing at all. That reliability, plus predictable latency, is why wired Ethernet remains the default for anything that must not drop.
+
+## Speed grades
+
+The family has scaled by three orders of magnitude while keeping one frame format:
+
+| Name | Rate | Typical medium | Era |
+|------|------|----------------|-----|
+| Ethernet | 10 Mb/s | Twisted pair / coax | 1980s |
+| Fast Ethernet | 100 Mb/s | Cat 5 twisted pair | 1990s |
+| Gigabit | 1 Gb/s | Cat 5e/6 twisted pair | 2000s |
+| 10 GigE | 10 Gb/s | Cat 6a copper / fiber | 2000s–10s |
+| 100–400 GigE | 100–400 Gb/s | Fiber | Data centers |
+
+## Where it fits
+
+Ethernet is the default for fixed, performance-sensitive connections where a cable is practical — servers, desktops, and infrastructure — while [Wi-Fi](/reference/wi-fi/) handles mobility. A wired Ethernet link gives a GopherTrunk capture node a stable, low-jitter path to stream decoded calls to a [server](/reference/server/), avoiding the contention and interference of a shared radio channel; paired with [PoE](/reference/power-over-ethernet/), a single cable can both feed and power a mast-mounted node.
 
 ## Sources
 
-[^wiki]: [Ethernet](https://en.wikipedia.org/wiki/Ethernet) — Wikipedia, on the wired LAN standard family.
+[^wiki]: [Ethernet](https://en.wikipedia.org/wiki/Ethernet) — Wikipedia, on the wired LAN standard family, the 802.3 frame format, and its speed grades.

--- a/docs/reference/federico-faggin.md
+++ b/docs/reference/federico-faggin.md
@@ -4,7 +4,7 @@ title: Federico Faggin
 entry_type: person
 category: hw-people
 description: Federico Faggin (born 1941) is an Italian-American physicist who led the design of the Intel 4004, the first commercial microprocessor, and pioneered the silicon-gate technology behind modern chips.
-keywords: Federico Faggin, Intel 4004, microprocessor, silicon gate, Zilog Z80, central processing unit
+keywords: Federico Faggin, Intel 4004, microprocessor, silicon gate, Zilog Z80, Synaptics, central processing unit
 aka: [Federico Faggin]
 autolink: true
 infobox:
@@ -20,6 +20,30 @@ cite_urls:
 design of the **Intel 4004**, the first commercially available microprocessor, putting a whole
 [CPU](/reference/central-processing-unit/) on a single chip.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A career timeline of Federico Faggin: he developed the silicon-gate process at Fairchild in 1968, led the Intel 4004 microprocessor in 1971, created the Zilog Z80 in 1976, and co-founded Synaptics in 1986." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="66" x2="440" y2="66" stroke="currentColor" stroke-width="1.4"/>
+  <g stroke="currentColor" fill="currentColor" stroke-width="1.2">
+    <circle cx="60" cy="66" r="5" fill-opacity="0.15"/>
+    <circle cx="185" cy="66" r="6" fill="currentColor"/>
+    <circle cx="310" cy="66" r="5" fill-opacity="0.15"/>
+    <circle cx="420" cy="66" r="5" fill-opacity="0.15"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="60" y="50" font-size="9" font-weight="600">1968</text>
+    <text x="60" y="86" font-size="8">silicon gate</text>
+    <text x="185" y="50" font-size="9" font-weight="600">1971</text>
+    <text x="185" y="86" font-size="8">Intel 4004</text>
+    <text x="310" y="50" font-size="9" font-weight="600">1976</text>
+    <text x="310" y="86" font-size="8">Zilog Z80</text>
+    <text x="420" y="50" font-size="9" font-weight="600">1986</text>
+    <text x="420" y="86" font-size="8">Synaptics</text>
+    <text x="235" y="112" font-size="8" fill-opacity="0.9">a whole processing unit shrunk onto one slab of silicon</text>
+  </g>
+</svg>
+<figcaption>Faggin's path from the silicon-gate process to the 4004 and beyond: the manufacturing method came first, then the single-chip CPU it made possible, then the microprocessors and touch sensors that followed.</figcaption>
+</figure>
+
 ## Life and work
 
 Faggin developed the silicon-gate process for [integrated circuits](/reference/integrated-circuit/)
@@ -28,6 +52,14 @@ at Fairchild, a technique that made faster, denser chips practical. At
 project into a working microprocessor in 1971, and he later worked on the 8080.[^wiki] He then
 co-founded Zilog, where he created the influential Z80 microprocessor, and went on to found
 Synaptics, an early developer of touchpad and touchscreen technology.[^wiki]
+
+| Year | Milestone |
+|------|-----------|
+| 1968 | Develops the silicon-gate process at Fairchild |
+| 1971 | Leads the Intel 4004, first commercial microprocessor |
+| 1974 | Works on the Intel 8080 |
+| 1976 | Creates the Zilog Z80 |
+| 1986 | Co-founds Synaptics (touch sensing) |
 
 ## Why they matter
 
@@ -40,7 +72,8 @@ the 4004's layout.[^wiki]
 ## Legacy
 
 He received the U.S. National Medal of Technology and Innovation for his role in inventing the
-microprocessor, a device now embedded in nearly every electronic product.
+microprocessor, a device now embedded in nearly every electronic product — including the small
+processors that tune, sample, and decode radio in a scanner.
 
 ## Sources
 

--- a/docs/reference/fiber-optic.md
+++ b/docs/reference/fiber-optic.md
@@ -3,12 +3,13 @@ slug: fiber-optic
 title: Fiber-optic
 entry_type: concept
 category: hw-networking
-description: Fiber-optic communication sends data as pulses of light through thin glass strands, offering very high bandwidth over long distances with low loss and immunity to electrical interference.
-keywords: fiber-optic, optical fiber, fibre, single-mode, multimode, light, photonics, SFP
+description: Fiber-optic communication sends data as pulses of light guided through thin glass strands by total internal reflection, offering very high bandwidth over long distances with low loss and immunity to electrical interference.
+keywords: fiber-optic, optical fiber, fibre, single-mode, multimode, total internal reflection, light, photonics, SFP, core, cladding
 aka: [optical fiber, fibre]
 infobox:
   - { label: Type, value: Optical transmission medium }
   - { label: Carries, value: Data as light pulses }
+  - { label: Guided by, value: Total internal reflection }
   - { label: Strengths, value: High bandwidth, low loss, long reach }
   - { label: Kinds, value: Single-mode, multimode }
 see_also: [ethernet, modem, network-switch, coaxial-cable, lan-and-wan, electromagnetic-spectrum]
@@ -18,14 +19,52 @@ cite_urls:
 
 **Fiber-optic** communication sends data as pulses of light through thin strands of glass, delivering very high bandwidth over long distances with low loss.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="A cross-section of an optical fiber: a light ray enters the central glass core from a laser and zig-zags down its length, bouncing off the boundary with the surrounding cladding by total internal reflection, reaching a detector at the far end." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="currentColor">
+    <rect x="60" y="40" width="340" height="56" fill-opacity="0.06" stroke-width="1"/>
+    <rect x="60" y="56" width="340" height="24" fill-opacity="0.14" stroke-width="1.2"/>
+    <g stroke-width="1.4" fill="none">
+      <path d="M60 68 L110 58 L160 78 L210 58 L260 78 L310 58 L360 78 L400 68"/>
+    </g>
+    <circle cx="52" cy="68" r="5" fill-opacity="0.2" stroke-width="1.2"/>
+    <rect x="402" y="60" width="14" height="16" rx="2" fill-opacity="0.2" stroke-width="1.2"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="8">
+    <text x="52" y="90" text-anchor="middle">laser</text>
+    <text x="409" y="90" text-anchor="middle">det.</text>
+    <text x="230" y="52" text-anchor="middle" font-weight="600" font-size="8.5">core (high index)</text>
+    <text x="230" y="108" text-anchor="middle">cladding (lower index) — reflects the ray back in</text>
+    <text x="230" y="124" text-anchor="middle" fill-opacity="0.9" font-size="8">total internal reflection guides the light for kilometres with little loss</text>
+  </g>
+</svg>
+<figcaption>Light launched into the fiber's dense glass core strikes the boundary with the lower-index cladding at a shallow angle and reflects entirely back inward — total internal reflection — so the pulse zig-zags down the strand for kilometres before a detector recovers it.</figcaption>
+</figure>
+
 ## Overview
 
-A fiber carries a modulated beam of light by total internal reflection, so the signal travels for kilometres with little attenuation and — being optical — is immune to the electromagnetic interference that affects copper. *Single-mode* fiber uses a tiny core for long-haul, high-rate links; *multimode* fiber has a wider core for shorter runs. Fiber underpins long-distance internet backbones, data-center interconnects, and high-speed [Ethernet](/reference/ethernet/), where pluggable transceivers (SFP modules) terminate the light into a [switch](/reference/network-switch/). Compared with [coaxial cable](/reference/coaxial-cable/), it offers far more capacity and reach.
+A fiber carries a modulated beam of light by *total internal reflection*: a dense glass *core* is wrapped in a lower-index *cladding*, and light striking that boundary at a shallow angle reflects entirely back inward rather than escaping. So the signal travels for kilometres with little attenuation and — being optical — is immune to the electromagnetic interference that plagues copper.
 
-## Trade-offs
+*Single-mode* fiber uses a tiny core that supports just one light path, giving the longest reach and highest rates for long-haul links; *multimode* fiber has a wider core that admits several paths at once, which is cheaper to couple into but limits distance because the paths spread the pulse. Fiber underpins long-distance internet backbones, data-center interconnects, and high-speed [Ethernet](/reference/ethernet/), where pluggable transceivers (SFP modules) convert light to and from electrical signals at a [switch](/reference/network-switch/).
 
-Fiber's bandwidth and noise immunity come at the cost of more delicate cabling and transceivers that cost more than copper ports. For most short LAN runs, copper [Ethernet](/reference/ethernet/) is simpler; fiber earns its place over distance or in electrically noisy environments. The same physics — modulating light instead of an RF carrier — is a cousin of the modulation an SDR like GopherTrunk performs on radio waves.
+Compared with [coaxial cable](/reference/coaxial-cable/), fiber offers vastly more capacity and reach and does not radiate or pick up noise, which is why carriers have pushed it ever closer to the home.
+
+## Single-mode vs multimode
+
+The two families trade cost against reach:
+
+| Trait | Single-mode | Multimode |
+|-------|-------------|-----------|
+| Core diameter | ~9 µm (one path) | ~50–62.5 µm (many paths) |
+| Reach | Kilometres to hundreds of km | Up to a few hundred metres |
+| Source | Laser | LED or VCSEL |
+| Cost | Higher (precise coupling) | Lower |
+| Typical use | Backbones, long-haul | Within a building or rack |
+
+## Where it fits
+
+Fiber's bandwidth and noise immunity come at the cost of more delicate cabling and pricier transceivers, so for most short LAN runs copper [Ethernet](/reference/ethernet/) is simpler; fiber earns its place over distance or in electrically noisy sites. For a GopherTrunk rooftop or tower installation, a fiber backhaul can carry the decoded stream down a long run without picking up the electrical noise a copper cable would — and its immunity to interference keeps it well clear of the RF the antenna is trying to hear. The underlying idea — modulating light instead of an RF carrier — is a close cousin of the modulation an SDR performs on radio waves.
 
 ## Sources
 
-[^wiki]: [Optical fiber](https://en.wikipedia.org/wiki/Optical_fiber) — Wikipedia, on fiber-optic transmission.
+[^wiki]: [Optical fiber](https://en.wikipedia.org/wiki/Optical_fiber) — Wikipedia, on fiber-optic transmission, total internal reflection, and single-mode versus multimode fiber.

--- a/docs/reference/file-system.md
+++ b/docs/reference/file-system.md
@@ -4,14 +4,14 @@ title: File system
 entry_type: concept
 category: hw-storage
 description: A file system is the structure an operating system uses to organise data on storage into named files and directories, tracking where each file's blocks live on the device.
-keywords: file system, filesystem, ext4, NTFS, FAT, directory, inode, block, journaling, mount
+keywords: file system, filesystem, ext4, NTFS, FAT, directory, inode, block, journaling, mount, metadata
 infobox:
   - { label: Type, value: Storage organisation layer }
   - { label: Provides, value: Files and directories }
   - { label: Managed by, value: Operating system }
   - { label: Examples, value: ext4, NTFS, FAT32, APFS }
   - { label: Tracks, value: Blocks, metadata, free space }
-see_also: [data-storage, operating-system, solid-state-drive, hard-disk-drive, sd-card, flash-memory]
+see_also: [data-storage, operating-system, solid-state-drive, hard-disk-drive, sd-card, flash-memory, nvme]
 related_lessons:
   - { title: "Building blocks", url: /learn/intro-hardware/building-blocks/ }
 cite_urls:
@@ -20,9 +20,71 @@ cite_urls:
 
 A **file system** is the structure an [operating system](/reference/operating-system/) uses to organise raw storage into named files and directories, and to track where each file's data physically lives.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 176" role="img" aria-label="How a file system maps a name to data. A directory tree points to a metadata record (an inode) that stores a file's size, permissions, and timestamps, and that record holds a list of pointers to the scattered numbered blocks on the device that actually contain the file's bytes." xmlns="http://www.w3.org/2000/svg">
+  <g fill="currentColor" stroke="currentColor">
+    <g stroke-width="1.2" fill="none">
+      <path d="M40 30 V50 H70 M40 50 V78 H70 M70 78 V96 H100"/>
+    </g>
+    <g stroke="none">
+      <text x="20" y="26" font-size="9" font-weight="600">/</text>
+      <text x="74" y="42" font-size="8.5">logs/</text>
+      <text x="74" y="70" font-size="8.5">captures/</text>
+      <text x="104" y="90" font-size="8.5">iq.cfile</text>
+    </g>
+  </g>
+  <g stroke="currentColor" fill="none" stroke-width="1.2">
+    <rect x="196" y="48" width="86" height="80" rx="3" fill="currentColor" fill-opacity="0.06"/>
+    <line x1="196" y1="64" x2="282" y2="64"/>
+  </g>
+  <g fill="currentColor" stroke="none">
+    <text x="239" y="60" font-size="8.5" text-anchor="middle" font-weight="600">inode</text>
+    <text x="203" y="78" font-size="7.5">size, owner</text>
+    <text x="203" y="90" font-size="7.5">permissions</text>
+    <text x="203" y="102" font-size="7.5">timestamps</text>
+    <text x="203" y="120" font-size="7.5">block ptrs &#8595;</text>
+  </g>
+  <line x1="140" y1="88" x2="196" y2="88" stroke="currentColor" stroke-width="1.2"/>
+  <g stroke="currentColor" fill="currentColor">
+    <rect x="330" y="34" width="30" height="18" rx="2" fill-opacity="0.18" stroke="none"/>
+    <rect x="386" y="60" width="30" height="18" rx="2" fill-opacity="0.18" stroke="none"/>
+    <rect x="330" y="92" width="30" height="18" rx="2" fill-opacity="0.18" stroke="none"/>
+    <rect x="392" y="120" width="30" height="18" rx="2" fill-opacity="0.18" stroke="none"/>
+    <g stroke-width="1" fill="none">
+      <path d="M282 96 L330 43"/>
+      <path d="M282 100 L386 69"/>
+      <path d="M282 104 L330 101"/>
+      <path d="M282 108 L392 129"/>
+    </g>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="7.5">
+    <text x="345" y="46" text-anchor="middle">#12</text>
+    <text x="401" y="72" text-anchor="middle">#57</text>
+    <text x="345" y="104" text-anchor="middle">#13</text>
+    <text x="407" y="132" text-anchor="middle">#88</text>
+    <text x="373" y="162" text-anchor="middle" font-size="8">data blocks scattered across the device</text>
+  </g>
+</svg>
+<figcaption>A path name walks the directory tree to an inode — the record of a file's size, permissions, and timestamps — whose block pointers gather the scattered numbered blocks that hold the actual bytes.</figcaption>
+</figure>
+
 ## Overview
 
-A storage device on its own offers only a flat array of numbered blocks. The file system imposes order on that array: it groups blocks into files, arranges files into a directory tree, records metadata such as names, sizes, timestamps, and permissions, and keeps track of which blocks are free. Common file systems include ext4 on Linux, NTFS on Windows, APFS on macOS, and the simple FAT family used on most [SD cards](/reference/sd-card/) and USB sticks. Many modern file systems are *journaling*, logging intended changes first so the volume can recover cleanly after a crash or power loss.
+A storage device on its own offers only a flat array of numbered blocks. The file system imposes order on that array: it groups blocks into files, arranges files into a directory tree, records metadata such as names, sizes, timestamps, and permissions, and keeps track of which blocks are free. On Unix-like systems that metadata lives in a per-file *inode* that also holds the list of data blocks, while directories are just files that map names to inodes.
+
+Common file systems include ext4 on Linux, NTFS on Windows, APFS on macOS, and the simple FAT family used on most [SD cards](/reference/sd-card/) and USB sticks. They differ in maximum file size, metadata richness, and crash behaviour. Many modern file systems are *journaling*: they log intended changes first, so after a crash or power loss the volume can be replayed to a consistent state instead of needing a slow full scan.
+
+## Inside it
+
+The layers stack from the raw device up to the names a program uses:
+
+| Layer | Holds | Example |
+|-------|-------|---------|
+| Block | Smallest allocation unit | 4 KB block |
+| Inode / record | One file's metadata + block list | size, mode, mtime |
+| Directory | Names mapped to inodes | `captures/` |
+| Journal | Pending changes for crash recovery | ext4 journal |
+| Free-space map | Which blocks are unused | bitmap / extent tree |
 
 ## Where it fits
 

--- a/docs/reference/firmware.md
+++ b/docs/reference/firmware.md
@@ -3,15 +3,15 @@ slug: firmware
 title: Firmware
 entry_type: concept
 category: hw-microcontrollers
-description: Firmware is low-level software loaded onto a device's chip to control its hardware directly, sitting between pure hardware and ordinary application programs.
-keywords: firmware, bare metal, flash memory, reflashing, embedded software, non-volatile
+description: Firmware is low-level software loaded onto a device's chip to control its hardware directly, sitting between pure hardware and ordinary application programs and stored in non-volatile flash so it survives a power cycle.
+keywords: firmware, bare metal, flash memory, reflashing, embedded software, non-volatile, bootloader, firmware update
 aka: [firmware]
 infobox:
   - { label: Type, value: Low-level embedded software }
   - { label: Stored in, value: Non-volatile flash }
   - { label: Updated by, value: Reflashing }
   - { label: On an MCU, value: The whole program (no OS) }
-see_also: [microcontroller, esp32, arduino, operating-system]
+see_also: [microcontroller, bare-metal-programming, esp32, bootloader, in-system-programming, operating-system]
 related_lessons:
   - { title: "What is a microcontroller?", url: /learn/intro-hardware/what-is-a-microcontroller/ }
 cite_urls:
@@ -20,13 +20,50 @@ cite_urls:
 
 **Firmware** is low-level software loaded onto a device's chip to control its hardware directly, sitting between the pure hardware and ordinary application programs.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 176" role="img" aria-label="Two stacked software stacks compared. On a microcontroller the stack is just hardware at the bottom and firmware above it, and the firmware is the whole program. On a general-purpose computer the hardware sits under a thin firmware layer, then an operating system, then applications on top, so firmware is only a small foundation layer." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.2" text-anchor="middle">
+    <rect x="40" y="112" width="150" height="34" rx="3" fill="currentColor" fill-opacity="0.06"/>
+    <rect x="40" y="52" width="150" height="58" rx="3" fill="currentColor" fill-opacity="0.16"/>
+    <rect x="270" y="112" width="150" height="34" rx="3" fill="currentColor" fill-opacity="0.06"/>
+    <rect x="270" y="92" width="150" height="18" rx="3" fill="currentColor" fill-opacity="0.16"/>
+    <rect x="270" y="66" width="150" height="24" rx="3" fill="currentColor" fill-opacity="0.10"/>
+    <rect x="270" y="40" width="150" height="24" rx="3" fill="currentColor" fill-opacity="0.08"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="115" y="34" font-size="9" font-weight="600">Microcontroller</text>
+    <text x="115" y="86" font-size="8.5" font-weight="600">Firmware</text>
+    <text x="115" y="99" font-size="7.5" fill-opacity="0.85">= the whole program</text>
+    <text x="115" y="133" font-size="8">Hardware</text>
+    <text x="345" y="34" font-size="9" font-weight="600">General-purpose PC</text>
+    <text x="345" y="56" font-size="8">Applications</text>
+    <text x="345" y="82" font-size="8">Operating system</text>
+    <text x="345" y="104" font-size="7.5" font-weight="600">Firmware (BIOS/UEFI)</text>
+    <text x="345" y="133" font-size="8">Hardware</text>
+  </g>
+</svg>
+<figcaption>Firmware always sits directly on the hardware. On a microcontroller there is nothing above it — the firmware is the entire program. On a full computer it is a thin foundation layer beneath the operating system and applications. Either way it lives in non-volatile flash and changes only by reflashing.</figcaption>
+</figure>
+
 ## Overview
 
-On a [microcontroller](/reference/microcontroller/) there is no operating system, so the firmware *is* the whole program: it runs bare metal, owning the chip from the moment it powers on. Firmware is stored in non-volatile flash memory so it survives a power cycle, and it is changed by reflashing the chip rather than by installing software the usual way.
+On a [microcontroller](/reference/microcontroller/) there is no operating system, so the firmware *is* the whole program: it runs [bare metal](/reference/bare-metal-programming/), owning the chip from the moment it powers on. On larger machines firmware is instead a thin layer — the BIOS/UEFI of a PC, the microcode in a disk drive — that boots the hardware and hands off to an [operating system](/reference/operating-system/) above it.
+
+Firmware is stored in non-volatile flash memory so it survives a power cycle, and it is changed by *reflashing* the chip rather than by installing software the usual way. Because it runs so close to the metal, a bad firmware image can render a device unusable ("bricked") until it is reflashed through a recovery path.
+
+## How it is loaded and updated
+
+Getting firmware onto a chip, and replacing it later, follows a small set of paths:
+
+| Method | When | Note |
+|--------|------|------|
+| [In-system programming](/reference/in-system-programming/) | First flash, bring-up | Via SWD/JTAG/SPI on a blank chip |
+| [Bootloader](/reference/bootloader/) | Routine updates | A small resident loader accepts new images over USB/serial |
+| Over-the-air | Deployed IoT devices | New image pushed over the network, then reflashed |
 
 ## Where it fits
 
-Almost every embedded device runs firmware of some kind — from a thermostat to a Wi-Fi radio. Updating it means writing a new image to flash, which is why "firmware update" and "reflashing" describe the same act. The tiny radios whose signals fill the airwaves GopherTrunk listens to are all driven by firmware of this sort.
+Almost every embedded device runs firmware of some kind — from a thermostat to a Wi-Fi radio. Updating it means writing a new image to flash, which is why "firmware update" and "reflashing" describe the same act. The tiny radios whose signals fill the airwaves GopherTrunk listens to are all driven by firmware of this sort, and SDR dongles are no exception — the tuner and USB chips inside them run their own firmware, with the demodulation done in software on the host.
 
 ## Sources
 

--- a/docs/reference/foldable-phone.md
+++ b/docs/reference/foldable-phone.md
@@ -19,13 +19,53 @@ cite_urls:
 
 A **foldable phone** is a [smartphone](/reference/smartphone/) with a flexible display and a hinge, letting it fold from a pocketable size into a larger screen and back.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 170" role="img" aria-label="A cross-section of a foldable phone's hinge. The flexible OLED panel drapes over a curved teardrop gap at the fold so it bends on a radius instead of a sharp crease. Two rigid halves connect to a geared hinge mechanism at the center, which lets the panel roll into the gap as the phone closes." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.3" font-family="ui-sans-serif, sans-serif">
+    <path d="M40 60 h150 C210 60 214 78 230 92 C246 78 250 60 270 60 h150" stroke-width="2"/>
+    <line x1="40" y1="60" x2="40" y2="80"/>
+    <line x1="420" y1="60" x2="420" y2="80"/>
+    <rect x="46" y="82" width="140" height="20" rx="3"/>
+    <rect x="274" y="82" width="140" height="20" rx="3"/>
+    <circle cx="230" cy="112" r="18"/>
+    <g stroke-width="0.9">
+      <line x1="230" y1="94" x2="230" y2="130"/>
+      <line x1="212" y1="112" x2="248" y2="112"/>
+      <line x1="217" y1="99" x2="243" y2="125"/>
+      <line x1="243" y1="99" x2="217" y2="125"/>
+    </g>
+  </g>
+  <g fill="currentColor" stroke="none" font-family="ui-sans-serif, sans-serif" font-size="8.5">
+    <text x="230" y="46" text-anchor="middle">flexible OLED bends on a teardrop radius</text>
+    <text x="115" y="150" text-anchor="middle">rigid half</text>
+    <text x="345" y="150" text-anchor="middle">rigid half</text>
+    <text x="230" y="150" text-anchor="middle" font-size="8">geared hinge</text>
+  </g>
+</svg>
+<figcaption>The flexible OLED drapes into a teardrop-shaped gap at the fold so it curves on a gentle radius rather than creasing; a geared hinge links the two rigid halves and rolls the panel into that gap as the phone closes.</figcaption>
+</figure>
+
 ## Overview
 
-The enabling part is a flexible OLED [touchscreen](/reference/touchscreen/) that bends around a precision hinge without cracking. Two broad styles have emerged: *book-fold* designs that open from phone size into a small [tablet](/reference/tablet/), and *clamshell* (flip) designs that fold a full-size phone down to a compact square. Inside, the device is a normal phone — an [SoC](/reference/system-on-a-chip/), radios, and a [battery](/reference/battery-technology/) split across the two halves — running an ordinary [mobile OS](/reference/mobile-operating-system/) adapted to switch layouts as the screen folds.
+The enabling part is a flexible OLED [touchscreen](/reference/touchscreen/) that bends around a precision hinge without cracking. To avoid a sharp, panel-damaging crease, the display drops into a *teardrop* gap when folded, curving on a controlled radius; the hinge itself is a small geared mechanism engineered to survive hundreds of thousands of cycles.
+
+Two broad styles have emerged: *book-fold* designs that open from phone size into a small [tablet](/reference/tablet/), and *clamshell* (flip) designs that fold a full-size phone down to a compact square. Inside, the device is a normal phone — an [SoC](/reference/system-on-a-chip/), radios, and a [battery](/reference/battery-technology/) split across the two halves — running an ordinary [mobile OS](/reference/mobile-operating-system/) adapted to switch layouts as the screen folds.
+
+## Book-fold vs clamshell
+
+The two form factors optimize opposite priorities:
+
+| Aspect | Book-fold | Clamshell (flip) |
+|--------|-----------|-------------------|
+| Goal | Bigger screen | Smaller footprint |
+| Open size | Small tablet | Normal phone |
+| Closed size | Thick phone | Compact square |
+| Outer screen | Full cover display | Small window |
+| Typical use | Multitasking, media | Pocketability, style |
 
 ## Where it fits
 
-The foldable tries to collapse the phone-versus-tablet trade-off into one device: pocket portability when closed, more screen when open. The costs are mechanical complexity, a visible crease, added thickness, and a higher price — engineering challenges centered on durability of the hinge and the flexible panel over thousands of folds.
+The foldable tries to collapse the phone-versus-tablet trade-off into one device: pocket portability when closed, more screen when open. The costs are mechanical complexity, a visible crease, added thickness, and a higher price — engineering challenges centered on the durability of the hinge and the flexible panel over thousands of folds. For an SDR operator, the appeal is mundane but real: a larger unfolded screen makes reviewing a decoder's live web console in the field less cramped than a standard phone.
 
 ## Sources
 

--- a/docs/reference/gaming-pc.md
+++ b/docs/reference/gaming-pc.md
@@ -4,7 +4,7 @@ title: Gaming PC
 entry_type: hardware
 category: hw-personal-computers
 description: A gaming PC is a personal computer built and tuned to run video games well, centered on a powerful graphics card, a fast multi-core CPU, ample fast memory, and cooling to sustain high frame rates.
-keywords: gaming PC, gaming rig, GPU, graphics card, high refresh, overclocking, RGB build
+keywords: gaming PC, gaming rig, GPU, graphics card, high refresh, overclocking, RGB build, frame rate
 aka: [Gaming rig]
 infobox:
   - { label: Type, value: Personal computer }
@@ -20,13 +20,67 @@ cite_urls:
 
 A **gaming PC** is a [personal computer](/reference/personal-computer/) built and tuned to run video games well — usually a [desktop computer](/reference/desktop-computer/) centered on a powerful graphics card and a fast processor.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 180" role="img" aria-label="A gaming PC built around its graphics card: a large GPU sits at the center, fed by a fast CPU, quick RAM, an SSD, and strong cooling, and it renders a high frame rate that streams out to a high-refresh-rate monitor." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.5">
+    <rect x="120" y="58" width="120" height="64" rx="4" fill="currentColor" fill-opacity="0.16"/>
+  </g>
+  <text x="180" y="86" fill="currentColor" stroke="none" text-anchor="middle" font-size="10" font-weight="600">GPU</text>
+  <text x="180" y="102" fill="currentColor" stroke="none" text-anchor="middle" font-size="7" fill-opacity="0.85">graphics card</text>
+  <g stroke="currentColor" fill="none" stroke-width="1.1">
+    <rect x="30" y="24" width="60" height="20" rx="2" fill="currentColor" fill-opacity="0.08"/>
+    <rect x="30" y="54" width="60" height="20" rx="2" fill="currentColor" fill-opacity="0.08"/>
+    <rect x="30" y="84" width="60" height="20" rx="2" fill="currentColor" fill-opacity="0.08"/>
+    <rect x="30" y="114" width="60" height="20" rx="2" fill="currentColor" fill-opacity="0.08"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="7.5" text-anchor="middle">
+    <text x="60" y="38">CPU</text>
+    <text x="60" y="68">RAM</text>
+    <text x="60" y="98">SSD</text>
+    <text x="60" y="128">cooling</text>
+  </g>
+  <g stroke="currentColor" fill="none" stroke-width="1" stroke-dasharray="3 3">
+    <path d="M90 34 C110 48 110 62 120 68"/>
+    <path d="M90 64 L120 78"/>
+    <path d="M90 94 L120 96"/>
+    <path d="M90 124 C110 112 110 104 120 100"/>
+  </g>
+  <g stroke="currentColor" fill="none" stroke-width="1.4">
+    <path d="M240 90 H320" stroke-dasharray="0"/>
+    <path d="M312 84 L322 90 L312 96"/>
+    <rect x="326" y="46" width="110" height="76" rx="4"/>
+    <rect x="334" y="54" width="94" height="60" fill="currentColor" fill-opacity="0.07"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="280" y="82" font-size="7.5">frames/s</text>
+    <text x="381" y="88" font-size="8" fill-opacity="0.85">high-refresh</text>
+    <text x="381" y="100" font-size="8" fill-opacity="0.85">monitor</text>
+  </g>
+</svg>
+<figcaption>A gaming PC is organized around one part: the discrete GPU renders the 3D scene, while a fast CPU, quick RAM, an SSD, and strong cooling keep it fed so it can push a high frame rate to a high-refresh monitor.</figcaption>
+</figure>
+
 ## Overview
 
-The defining part is the discrete [GPU](/reference/graphics-processing-unit/), which renders the game's 3D scenes at high frame rates and resolutions. Around it a gaming PC pairs a fast multi-core [CPU](/reference/central-processing-unit/), plenty of quick [RAM](/reference/random-access-memory/), a [solid-state drive](/reference/solid-state-drive/) for fast loading, and enough [cooling](/reference/cooling-and-thermals/) to hold those parts at full speed without throttling. Enthusiasts often overclock the CPU or GPU and choose a [case](/reference/computer-case/) with strong airflow.
+The defining part is the discrete [GPU](/reference/graphics-processing-unit/), which renders the game's 3D scenes at high frame rates and resolutions. Around it a gaming PC pairs a fast multi-core [CPU](/reference/central-processing-unit/), plenty of quick [RAM](/reference/random-access-memory/), a [solid-state drive](/reference/solid-state-drive/) for fast loading, and enough [cooling](/reference/cooling-and-thermals/) to hold those parts at full speed without throttling.
+
+Enthusiasts often overclock the CPU or GPU for extra frames and choose a [case](/reference/computer-case/) with strong airflow (and, frequently, RGB lighting). Because the priorities are clear, a gaming PC is a common first project for people who [build their own](/reference/build-vs-buy/) — the GPU dictates most of the budget and the rest is sized to keep it busy.
+
+## Priorities
+
+Where the budget goes reflects what actually limits frame rate:
+
+| Part | Role in games | Priority |
+|------|---------------|----------|
+| GPU | Renders every frame | Highest |
+| CPU | Game logic, feeds the GPU | High |
+| RAM | Holds the working set | Medium |
+| SSD | Level and asset loading | Medium |
+| Cooling | Sustains clocks under load | Medium |
 
 ## Where it fits
 
-A gaming PC overlaps heavily with the enthusiast desktop and is a common first machine for people who [build their own](/reference/build-vs-buy/). The same GPU-heavy hardware also handles GPU compute, machine learning, and video work, which blurs the line with a [workstation](/reference/workstation/) — the difference is mostly tuning, ECC memory, and certification rather than raw parts. For GopherTrunk a gaming PC's GPU and CPU headroom make it a capable bench for replaying captures and crunching many channels of DSP at once.
+A gaming PC overlaps heavily with the enthusiast desktop, and the same GPU-heavy hardware also handles GPU compute, machine learning, and video work, which blurs the line with a [workstation](/reference/workstation/) — the difference is mostly tuning, ECC memory, and certification rather than raw parts. For GopherTrunk a gaming PC's GPU and CPU headroom make it a capable bench for replaying captures and crunching many channels of DSP at once.
 
 ## Sources
 

--- a/docs/reference/google-coral.md
+++ b/docs/reference/google-coral.md
@@ -4,7 +4,7 @@ title: Google Coral
 entry_type: hardware
 category: hw-sbc
 description: Google Coral is a hardware platform built around the Edge TPU, an AI accelerator that runs TensorFlow Lite models locally, sold as a single-board computer, a plug-in module, and a USB stick.
-keywords: Google Coral, Edge TPU, Coral Dev Board, Coral USB Accelerator, TensorFlow Lite, edge AI, machine learning accelerator
+keywords: Google Coral, Edge TPU, Coral Dev Board, Coral USB Accelerator, TensorFlow Lite, edge AI, machine learning accelerator, quantized model
 aka: [Coral, Edge TPU]
 autolink: true
 infobox:
@@ -23,13 +23,54 @@ cite_urls:
 
 **Google Coral** is a hardware platform built around the *Edge TPU*, a small [AI accelerator](/reference/ai-accelerator/) that runs machine-learning models locally rather than in the cloud.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 158" role="img" aria-label="The three forms Google Coral ships in, each containing the same Edge TPU. On the left a full Dev Board single-board computer. In the middle a small solder-down module. On the right a USB Accelerator stick that plugs into a host computer such as a Raspberry Pi. All three run the same TensorFlow Lite models." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.3">
+    <rect x="26" y="34" width="118" height="80" rx="5" fill-opacity="0.05" fill="currentColor"/>
+    <rect x="60" y="60" width="40" height="28" rx="3" fill-opacity="0.2" fill="currentColor"/>
+    <rect x="34" y="102" width="102" height="7" rx="1.5" fill-opacity="0.14" fill="currentColor"/>
+    <rect x="176" y="52" width="94" height="52" rx="4" fill-opacity="0.05" fill="currentColor"/>
+    <rect x="200" y="66" width="40" height="24" rx="3" fill-opacity="0.2" fill="currentColor"/>
+    <rect x="184" y="96" width="78" height="5" rx="1" fill-opacity="0.14" fill="currentColor"/>
+    <rect x="322" y="58" width="86" height="34" rx="4" fill-opacity="0.05" fill="currentColor"/>
+    <rect x="336" y="66" width="34" height="18" rx="3" fill-opacity="0.2" fill="currentColor"/>
+    <rect x="408" y="68" width="20" height="14" rx="2" fill-opacity="0.14" fill="currentColor"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="85" y="27" font-size="8.5" font-weight="600">Dev Board</text>
+    <text x="80" y="78" font-size="7">TPU</text>
+    <text x="85" y="126" font-size="7.5" fill-opacity="0.9">full SBC</text>
+    <text x="223" y="45" font-size="8.5" font-weight="600">Module</text>
+    <text x="220" y="82" font-size="7">TPU</text>
+    <text x="223" y="118" font-size="7.5" fill-opacity="0.9">solder-down</text>
+    <text x="365" y="51" font-size="8.5" font-weight="600">USB stick</text>
+    <text x="353" y="79" font-size="7">TPU</text>
+    <text x="365" y="106" font-size="7.5" fill-opacity="0.9">adds to a host</text>
+    <text x="230" y="146" font-size="8" fill-opacity="0.9">one Edge TPU, three packages — all run TensorFlow Lite</text>
+  </g>
+</svg>
+<figcaption>The same Edge TPU ships three ways: a full Dev Board, a solder-down module for products, and a USB Accelerator that clips the TPU onto an existing host — so you can add local inference at whatever integration level a project needs.</figcaption>
+</figure>
+
 ## Overview
 
-The Edge TPU is a cut-down [tensor processing unit](/reference/tensor-processing-unit/) that executes TensorFlow Lite models very efficiently at low power. Coral ships in several forms: a full [single-board computer](/reference/single-board-computer/) (the Coral Dev Board), a solder-down module, and a USB Accelerator stick that adds the TPU to an existing host such as a [Raspberry Pi](/reference/raspberry-pi/).[^coral]
+The Edge TPU is a cut-down [tensor processing unit](/reference/tensor-processing-unit/) that executes TensorFlow Lite models very efficiently at low power. It is not a general processor: it accelerates the tensor math at the core of neural-network inference and little else, which is exactly why it can hit high throughput on a couple of watts. Models must be quantised to 8-bit integers and compiled for the TPU before they will run on it.
 
-## What it's for
+Coral ships in several forms so the same accelerator suits different projects: a full [single-board computer](/reference/single-board-computer/) (the Coral Dev Board), a solder-down module for embedding in a product, and a USB Accelerator stick that adds the TPU to an existing host such as a [Raspberry Pi](/reference/raspberry-pi/).[^coral] The USB stick is the most common entry point, because it upgrades a board you already have rather than replacing it.
 
-Coral targets [edge AI](/reference/edge-ai/): on-device vision, audio, and sensor inference where sending data to a server is too slow, too costly, or impossible. It is a more specialised choice than an [NVIDIA Jetson](/reference/nvidia-jetson/) — the Edge TPU runs supported quantised models fast and cheap, but it is not a general GPU. In a signal-processing project, a Coral could classify or flag patterns in decoded data at the edge while a Pi handles the radio.
+## Coral vs Jetson
+
+| | Google Coral (Edge TPU) | [NVIDIA Jetson](/reference/nvidia-jetson/) |
+|---|-------------------------|--------|
+| Core | Edge TPU (fixed-function) | ARM CPU + CUDA GPU |
+| Runs | Quantised TensorFlow Lite | Broad frameworks, general GPU |
+| Power | Very low (~2 W) | Higher (5–60 W) |
+| Flexibility | Narrow, supported models only | General-purpose accelerator |
+| Best for | Cheap, fixed inference tasks | Heavier or varied ML workloads |
+
+## Where it fits
+
+Coral targets [edge AI](/reference/edge-ai/): on-device vision, audio, and sensor inference where sending data to a server is too slow, too costly, or impossible. It is a more specialised choice than an [NVIDIA Jetson](/reference/nvidia-jetson/) — the Edge TPU runs supported quantised models fast and cheap, but it is not a general GPU, so anything outside that lane belongs elsewhere. In a signal-processing project, a Coral USB Accelerator on a Pi could classify or flag patterns in decoded data at the edge while the Pi itself handles the radio, keeping inference off the CPU that is busy demodulating.
 
 ## Sources
 

--- a/docs/reference/gordon-moore.md
+++ b/docs/reference/gordon-moore.md
@@ -20,6 +20,30 @@ cite_urls:
 [Intel](/reference/intel/) and gave his name to [Moore's law](/reference/moores-law/), the
 observation that the number of transistors on a chip doubles at a steady cadence.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A career timeline of Gordon Moore: he joined the founding of Fairchild Semiconductor in 1957, published the observation later called Moore's law in 1965, co-founded Intel with Robert Noyce in 1968, and served as its chairman for decades." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="66" x2="440" y2="66" stroke="currentColor" stroke-width="1.4"/>
+  <g stroke="currentColor" fill="currentColor" stroke-width="1.2">
+    <circle cx="60" cy="66" r="5" fill-opacity="0.15"/>
+    <circle cx="185" cy="66" r="6" fill="currentColor"/>
+    <circle cx="310" cy="66" r="5" fill-opacity="0.15"/>
+    <circle cx="420" cy="66" r="5" fill-opacity="0.15"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="60" y="50" font-size="9" font-weight="600">1957</text>
+    <text x="60" y="86" font-size="8">Fairchild</text>
+    <text x="185" y="50" font-size="9" font-weight="600">1965</text>
+    <text x="185" y="86" font-size="8">Moore's law</text>
+    <text x="310" y="50" font-size="9" font-weight="600">1968</text>
+    <text x="310" y="86" font-size="8">co-founds Intel</text>
+    <text x="420" y="50" font-size="9" font-weight="600">1979&#8211;97</text>
+    <text x="420" y="86" font-size="8">Intel chairman</text>
+    <text x="235" y="112" font-size="8" fill-opacity="0.9">transistors per chip roughly double every ~2 years</text>
+  </g>
+</svg>
+<figcaption>Moore's career line: from Fairchild to the 1965 forecast that bears his name to co-founding Intel, where the doubling trend became the industry's planning clock.</figcaption>
+</figure>
+
 ## Life and work
 
 Moore began at Fairchild Semiconductor, where he worked on early silicon
@@ -28,6 +52,13 @@ Moore began at Fairchild Semiconductor, where he worked on early silicon
 revised to about every two years) and projected the trend forward — a forecast that became the
 semiconductor industry's guiding expectation.[^wiki] In 1968 he co-founded Intel with
 [Robert Noyce](/reference/robert-noyce/), where he served as a long-time executive and chairman.[^wiki]
+
+| Year | Milestone |
+|------|-----------|
+| 1957 | Helps found Fairchild Semiconductor |
+| 1965 | Publishes the observation later called Moore's law |
+| 1968 | Co-founds Intel with Robert Noyce |
+| 1975 | Revises the doubling cadence to about every two years |
 
 ## Why they matter
 
@@ -40,7 +71,8 @@ helped make the microprocessor a mass-market product.[^wiki]
 ## Legacy
 
 Though the literal doubling has slowed, "Moore's law" remains shorthand for the relentless
-improvement in computing per dollar that shaped the digital age.
+improvement in computing per dollar that shaped the digital age — and that put real-time
+multi-channel decoding within reach of hobbyist hardware.
 
 ## Sources
 

--- a/docs/reference/gpgpu.md
+++ b/docs/reference/gpgpu.md
@@ -3,14 +3,15 @@ slug: gpgpu
 title: GPGPU
 entry_type: concept
 category: hw-accelerators
-description: GPGPU is the practice of using a graphics processing unit for general-purpose computation, exploiting its thousands of parallel cores for non-graphics workloads such as math, simulation, and machine learning.
-keywords: GPGPU, general-purpose GPU, GPU computing, parallel computing, CUDA, OpenCL, compute shader
+description: GPGPU is the practice of using a graphics processing unit for general-purpose computation, exploiting its thousands of parallel cores for non-graphics workloads such as math, simulation, signal processing, and machine learning.
+keywords: GPGPU, general-purpose GPU, GPU computing, parallel computing, CUDA, OpenCL, compute shader, data parallelism, SIMD
 aka: [General-purpose computing on graphics processing units]
 autolink: true
 infobox:
   - { label: Type, value: Computing technique }
   - { label: Hardware, value: Graphics processing unit }
   - { label: Strength, value: Massively parallel data }
+  - { label: Weakness, value: Branch-heavy sequential work }
   - { label: APIs, value: "CUDA, OpenCL, compute shaders" }
 see_also: [graphics-processing-unit, cuda, hardware-acceleration, vector-processor, central-processing-unit, ai-accelerator]
 cite_urls:
@@ -19,14 +20,83 @@ cite_urls:
 
 **GPGPU** (general-purpose computing on graphics processing units) is the practice of using a [GPU](/reference/graphics-processing-unit/) to run ordinary computation rather than only rendering images.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 150" role="img" aria-label="A CPU with a few large cores beside a GPU with a dense grid of many small cores. The CPU suits sequential, branch-heavy work while the GPU applies the same operation across a large grid of data elements in parallel." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="currentColor">
+    <rect x="20" y="26" width="170" height="98" rx="5" fill-opacity="0.05" stroke-width="1.4"/>
+    <text x="105" y="20" text-anchor="middle" font-size="9" stroke="none" font-weight="600">CPU</text>
+    <rect x="34" y="40" width="66" height="34" rx="3" fill-opacity="0.14" stroke-width="1.2"/>
+    <rect x="110" y="40" width="66" height="34" rx="3" fill-opacity="0.14" stroke-width="1.2"/>
+    <rect x="34" y="82" width="66" height="34" rx="3" fill-opacity="0.14" stroke-width="1.2"/>
+    <rect x="110" y="82" width="66" height="34" rx="3" fill-opacity="0.14" stroke-width="1.2"/>
+    <text x="105" y="138" text-anchor="middle" font-size="7.5" stroke="none" fill-opacity="0.9">a few large cores &#183; sequential, branchy</text>
+  </g>
+  <g stroke="currentColor" fill="currentColor">
+    <rect x="270" y="26" width="170" height="98" rx="5" fill-opacity="0.05" stroke-width="1.4"/>
+    <text x="355" y="20" text-anchor="middle" font-size="9" stroke="none" font-weight="600">GPU</text>
+    <g stroke-width="0.8">
+      <rect x="282" y="38" width="14" height="14" fill-opacity="0.30"/>
+      <rect x="300" y="38" width="14" height="14" fill-opacity="0.30"/>
+      <rect x="318" y="38" width="14" height="14" fill-opacity="0.30"/>
+      <rect x="336" y="38" width="14" height="14" fill-opacity="0.30"/>
+      <rect x="354" y="38" width="14" height="14" fill-opacity="0.30"/>
+      <rect x="372" y="38" width="14" height="14" fill-opacity="0.30"/>
+      <rect x="390" y="38" width="14" height="14" fill-opacity="0.30"/>
+      <rect x="408" y="38" width="14" height="14" fill-opacity="0.30"/>
+      <rect x="282" y="56" width="14" height="14" fill-opacity="0.30"/>
+      <rect x="300" y="56" width="14" height="14" fill-opacity="0.30"/>
+      <rect x="318" y="56" width="14" height="14" fill-opacity="0.30"/>
+      <rect x="336" y="56" width="14" height="14" fill-opacity="0.30"/>
+      <rect x="354" y="56" width="14" height="14" fill-opacity="0.30"/>
+      <rect x="372" y="56" width="14" height="14" fill-opacity="0.30"/>
+      <rect x="390" y="56" width="14" height="14" fill-opacity="0.30"/>
+      <rect x="408" y="56" width="14" height="14" fill-opacity="0.30"/>
+      <rect x="282" y="74" width="14" height="14" fill-opacity="0.30"/>
+      <rect x="300" y="74" width="14" height="14" fill-opacity="0.30"/>
+      <rect x="318" y="74" width="14" height="14" fill-opacity="0.30"/>
+      <rect x="336" y="74" width="14" height="14" fill-opacity="0.30"/>
+      <rect x="354" y="74" width="14" height="14" fill-opacity="0.30"/>
+      <rect x="372" y="74" width="14" height="14" fill-opacity="0.30"/>
+      <rect x="390" y="74" width="14" height="14" fill-opacity="0.30"/>
+      <rect x="408" y="74" width="14" height="14" fill-opacity="0.30"/>
+      <rect x="282" y="92" width="14" height="14" fill-opacity="0.30"/>
+      <rect x="300" y="92" width="14" height="14" fill-opacity="0.30"/>
+      <rect x="318" y="92" width="14" height="14" fill-opacity="0.30"/>
+      <rect x="336" y="92" width="14" height="14" fill-opacity="0.30"/>
+      <rect x="354" y="92" width="14" height="14" fill-opacity="0.30"/>
+      <rect x="372" y="92" width="14" height="14" fill-opacity="0.30"/>
+      <rect x="390" y="92" width="14" height="14" fill-opacity="0.30"/>
+      <rect x="408" y="92" width="14" height="14" fill-opacity="0.30"/>
+    </g>
+    <text x="355" y="138" text-anchor="middle" font-size="7.5" stroke="none" fill-opacity="0.9">thousands of small cores &#183; data-parallel</text>
+  </g>
+</svg>
+<figcaption>A CPU spends its silicon on a few large cores tuned for sequential, branch-heavy code; a GPU spends its silicon on a dense grid of small cores that apply the same operation to many data elements at once — the pattern GPGPU exploits.</figcaption>
+</figure>
+
 ## Overview
 
-A GPU contains thousands of small cores built to shade pixels in parallel. When a problem can be expressed as the *same operation applied to many data elements at once* — the same SIMD/data-parallel pattern a [vector processor](/reference/vector-processor/) exploits — those cores can be redirected at it. Early GPGPU work smuggled math through the graphics pipeline; dedicated APIs like [CUDA](/reference/cuda/) and the cross-vendor OpenCL later exposed the hardware directly, making GPGPU mainstream for scientific computing, cryptography, and machine learning.
+A GPU contains thousands of small cores built to shade pixels in parallel. When a problem can be expressed as the *same operation applied to many data elements at once* — the same SIMD/data-parallel pattern a [vector processor](/reference/vector-processor/) exploits — those cores can be redirected at it. Early GPGPU work smuggled math through the graphics pipeline, dressing numbers up as textures and pixels; dedicated APIs like [CUDA](/reference/cuda/) and the cross-vendor OpenCL later exposed the hardware directly.
+
+That direct access made GPGPU mainstream for scientific computing, cryptography, and machine learning, where a single GPU can replace a rack of CPUs on the right workload. The trade-off is architectural: a GPU commits its transistors to arithmetic throughput rather than to the branch prediction and large caches that make a [CPU](/reference/central-processing-unit/) fast at irregular, sequential code.
 
 ## What it's for
 
-GPGPU shines on large, regular, parallel workloads and is the foundation of modern deep learning, where it long preceded purpose-built [AI accelerators](/reference/ai-accelerator/). It is poor at branch-heavy, sequential work, which still belongs on the [CPU](/reference/central-processing-unit/). In a software-defined radio context, GPGPU can accelerate wideband DSP — large FFTs, polyphase channelizers splitting one capture into many channels — but the cost of moving samples to and from the GPU only pays off when the channel count is high.
+The dividing line is the shape of the work, not the difficulty of the math. A workload that does the same thing to every element of a long array is ideal; one full of data-dependent branches stalls the GPU's lock-step lanes.
+
+| Suits the GPU | Suits the CPU |
+|---------------|---------------|
+| Same op over large arrays | Branchy, data-dependent logic |
+| High arithmetic per byte | Latency-sensitive single tasks |
+| Regular, predictable memory | Irregular pointer chasing |
+| FFTs, matrix math, filtering | Control flow, I/O, coordination |
+
+GPGPU is the foundation of modern deep learning, where it long preceded purpose-built [AI accelerators](/reference/ai-accelerator/).
+
+## Where it fits
+
+In a software-defined radio context, GPGPU can accelerate wideband DSP — large [FFTs](/reference/fast-fourier-transform/), polyphase [channelizers](/reference/channelizer/) splitting one capture into many channels, and batched [filtering](/reference/digital-filter/) across those channels. These are exactly the same-op-over-many-samples workloads the hardware wants. As with any [hardware acceleration](/reference/hardware-acceleration/), the cost of moving samples to and from the GPU only pays off when the channel count is high; GopherTrunk's real-time, often narrowband decoding runs comfortably on CPU vector units for the common case.
 
 ## Sources
 
-[^wiki]: [General-purpose computing on graphics processing units](https://en.wikipedia.org/wiki/General-purpose_computing_on_graphics_processing_units) — Wikipedia, on using GPUs for non-graphics computation.
+[^wiki]: [General-purpose computing on graphics processing units](https://en.wikipedia.org/wiki/General-purpose_computing_on_graphics_processing_units) — Wikipedia, on using GPUs for non-graphics computation and the data-parallel model.

--- a/docs/reference/gpio.md
+++ b/docs/reference/gpio.md
@@ -4,7 +4,7 @@ title: GPIO
 entry_type: hardware
 category: hw-sbc
 description: GPIO (general-purpose input/output) are pins on an SBC or microcontroller that code can read or switch on and off to talk to sensors, lights, motors, and other electronics.
-keywords: GPIO, general-purpose input output, pins, sensors, microcontroller, Raspberry Pi GPIO, hardware interface
+keywords: GPIO, general-purpose input output, pins, sensors, microcontroller, Raspberry Pi GPIO, hardware interface, 40-pin header, I2C, SPI
 aka: [GPIO]
 autolink: true
 infobox:
@@ -12,6 +12,7 @@ infobox:
   - { label: Found on, value: SBCs, microcontrollers }
   - { label: Controls, value: Sensors, lights, motors }
   - { label: Driven from, value: Code (Python, C, Go) }
+  - { label: Common form, value: 40-pin header }
 see_also: [single-board-computer, microcontroller, input-output, raspberry-pi, beaglebone, arduino]
 related_lessons:
   - { title: "What is an SBC?", url: /learn/intro-hardware/what-is-an-sbc/ }
@@ -22,13 +23,73 @@ cite_urls:
 
 **GPIO** (general-purpose input/output) are pins on a [single-board computer](/reference/single-board-computer/) or [microcontroller](/reference/microcontroller/) that your code can read or switch on and off to talk to sensors, lights, motors, and other electronics.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 150" role="img" aria-label="A slice of a 40-pin GPIO header showing mixed pin roles. Some pins supply power at fixed voltages, some are ground, and the rest are general-purpose I/O — several of which double as dedicated bus pins for I2C and SPI. One I/O pin is shown wired out to an LED, another to a sensor." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.2">
+    <rect x="40" y="46" width="300" height="52" rx="4" fill-opacity="0.05" fill="currentColor"/>
+    <g>
+      <circle cx="66" cy="64" r="6" fill-opacity="0.3" fill="currentColor"/>
+      <circle cx="94" cy="64" r="6" fill-opacity="0.12" fill="currentColor"/>
+      <circle cx="122" cy="64" r="6" fill-opacity="0.12" fill="currentColor"/>
+      <circle cx="150" cy="64" r="6" fill-opacity="0.5" fill="currentColor"/>
+      <circle cx="178" cy="64" r="6" fill-opacity="0.12" fill="currentColor"/>
+      <circle cx="206" cy="64" r="6" fill-opacity="0.5" fill="currentColor"/>
+      <circle cx="234" cy="64" r="6" fill-opacity="0.12" fill="currentColor"/>
+      <circle cx="262" cy="64" r="6" fill-opacity="0.12" fill="currentColor"/>
+      <circle cx="290" cy="64" r="6" fill-opacity="0.3" fill="currentColor"/>
+      <circle cx="318" cy="64" r="6" fill-opacity="0.12" fill="currentColor"/>
+      <circle cx="66" cy="82" r="6" fill-opacity="0.12" fill="currentColor"/>
+      <circle cx="94" cy="82" r="6" fill-opacity="0.3" fill="currentColor"/>
+      <circle cx="122" cy="82" r="6" fill-opacity="0.12" fill="currentColor"/>
+      <circle cx="150" cy="82" r="6" fill-opacity="0.5" fill="currentColor"/>
+      <circle cx="178" cy="82" r="6" fill-opacity="0.12" fill="currentColor"/>
+      <circle cx="206" cy="82" r="6" fill-opacity="0.12" fill="currentColor"/>
+      <circle cx="234" cy="82" r="6" fill-opacity="0.3" fill="currentColor"/>
+      <circle cx="262" cy="82" r="6" fill-opacity="0.12" fill="currentColor"/>
+      <circle cx="290" cy="82" r="6" fill-opacity="0.12" fill="currentColor"/>
+      <circle cx="318" cy="82" r="6" fill-opacity="0.12" fill="currentColor"/>
+    </g>
+    <path d="M178 76 V120 H210" stroke-width="1.1"/>
+    <circle cx="222" cy="120" r="7" fill-opacity="0.14" fill="currentColor"/>
+    <path d="M262 76 V120 H300" stroke-width="1.1"/>
+    <rect x="300" y="112" width="26" height="16" rx="2" fill-opacity="0.1" fill="currentColor"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="8" text-anchor="middle">
+    <text x="66" y="36" font-size="7">3V3</text>
+    <text x="150" y="36" font-size="7">SDA</text>
+    <text x="206" y="36" font-size="7">SCL</text>
+    <text x="290" y="36" font-size="7">GND</text>
+    <text x="222" y="140" font-size="7.5">LED (out)</text>
+    <text x="313" y="140" font-size="7.5">sensor (in)</text>
+    <text x="380" y="60" text-anchor="start" font-size="7.5" fill-opacity="0.9">power / ground</text>
+    <text x="380" y="76" text-anchor="start" font-size="7.5" fill-opacity="0.9">I2C · SPI</text>
+    <text x="380" y="92" text-anchor="start" font-size="7.5" fill-opacity="0.9">general I/O</text>
+  </g>
+</svg>
+<figcaption>A GPIO header mixes fixed power and ground pins with general-purpose I/O; some I/O pins double as dedicated bus lines (I2C's SDA/SCL, SPI), while any plain pin can be driven as an output to an LED or read as an input from a sensor.</figcaption>
+</figure>
+
 ## Overview
 
-A GPIO pin can be configured as an input (read a button or sensor) or an output (drive an LED, relay, or motor). It is the most basic form of [input/output](/reference/input-output/) a board offers, and richer interfaces are often layered on top of the same header. Code reads and writes pins through simple library calls.
+A GPIO pin can be configured as an input (read a button or sensor) or an output (drive an LED, relay, or motor). It is the most basic form of [input/output](/reference/input-output/) a board offers: at heart each pin is just a voltage the processor can either sense or force high or low. Code reads and writes pins through simple library calls, so blinking an LED or polling a switch is a few lines in [Python](/reference/python-language/), C, or [Go](/reference/go-language/).
+
+Richer interfaces are often layered on top of the same header. Certain pins are wired to hardware for standard buses — [I2C](/reference/i2c/), [SPI](/reference/spi/), UART — so instead of bit-banging a protocol by hand you can hand a whole conversation to dedicated silicon. That is why a header's pinout matters: a given pin may be plain I/O, a bus line, or a fixed power or ground rail, and only some combinations are available at once.
+
+## Pin roles
+
+A typical header pin falls into one of a few roles:
+
+| Pin role | Purpose | Example |
+|----------|---------|---------|
+| Power | Supply a fixed voltage | 3.3 V, 5 V rails |
+| Ground | Return path | GND pins |
+| General I/O | Read or drive a signal | Button in, LED out |
+| Bus (I2C / SPI / UART) | Talk to peripherals over a protocol | SDA/SCL, MOSI/MISO |
+| PWM | Timed pulses for dimming / motors | LED brightness, servo |
 
 ## Where it fits
 
-GPIO is the bridge between software and the physical world — it is what sets an SBC or MCU apart from a sealed PC or phone. The [Raspberry Pi](/reference/raspberry-pi/) header and the extensive pinout of the [BeagleBone](/reference/beaglebone/) are common examples; on the microcontroller side, boards like the [Arduino](/reference/arduino/) expose the same idea.
+GPIO is the bridge between software and the physical world — it is what sets an SBC or MCU apart from a sealed PC or phone. The [Raspberry Pi](/reference/raspberry-pi/) header and the extensive pinout of the [BeagleBone](/reference/beaglebone/) are common examples; on the microcontroller side, boards like the [Arduino](/reference/arduino/) expose the same idea. In a GopherTrunk capture node, GPIO is how the host reaches beyond the radio itself: switching an antenna relay, reading a temperature sensor in the enclosure, or wiring in a GPS pulse-per-second line for accurate timing.
 
 ## Sources
 

--- a/docs/reference/gps-receiver.md
+++ b/docs/reference/gps-receiver.md
@@ -4,7 +4,7 @@ title: GPS receiver
 entry_type: hardware
 category: hw-mobile
 description: A GPS receiver determines a device's position by timing signals from a constellation of navigation satellites, providing location, speed, and precise time to phones, wearables, and embedded systems.
-keywords: GPS receiver, GNSS, satellite navigation, GLONASS, Galileo, positioning, location, GPS chip, PPS, timing
+keywords: GPS receiver, GNSS, satellite navigation, GLONASS, Galileo, BeiDou, positioning, location, GPS chip, PPS, timing, trilateration
 aka: [GNSS receiver]
 infobox:
   - { label: Type, value: Satellite navigation receiver }
@@ -19,13 +19,62 @@ cite_urls:
 
 A **GPS receiver** determines a device's position by timing radio signals from a constellation of navigation satellites, yielding location, speed, and a very precise time reference.[^gnss]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 190" role="img" aria-label="A trilateration sketch. Three satellites near the top each broadcast a timing signal. From each satellite, the measured travel time defines a range shown as an arc. The three range arcs intersect at one point on the ground, which is the receiver's solved position. A fourth satellite is needed to also solve for the receiver's clock offset." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.2" font-family="ui-sans-serif, sans-serif">
+    <g fill-opacity="0" >
+      <rect x="70" y="20" width="26" height="16" rx="2"/>
+      <rect x="217" y="14" width="26" height="16" rx="2"/>
+      <rect x="360" y="24" width="26" height="16" rx="2"/>
+    </g>
+    <g stroke-width="0.9">
+      <line x1="64" y1="24" x2="58" y2="18"/><line x1="102" y1="24" x2="108" y2="18"/>
+      <line x1="211" y1="18" x2="205" y2="12"/><line x1="249" y1="18" x2="255" y2="12"/>
+      <line x1="354" y1="28" x2="348" y2="22"/><line x1="392" y1="28" x2="398" y2="22"/>
+    </g>
+    <path d="M120 150 A83 83 0 0 1 30 128" stroke-dasharray="4 3"/>
+    <path d="M230 150 A120 120 0 0 1 230 30" stroke-dasharray="4 3"/>
+    <path d="M140 150 A80 80 0 0 0 300 132" stroke-dasharray="4 3"/>
+    <g stroke-width="0.8" stroke-dasharray="2 3">
+      <line x1="83" y1="36" x2="205" y2="150"/>
+      <line x1="230" y1="30" x2="205" y2="150"/>
+      <line x1="373" y1="40" x2="205" y2="150"/>
+    </g>
+  </g>
+  <circle cx="205" cy="150" r="4" fill="currentColor" stroke="none"/>
+  <g fill="currentColor" stroke="none" font-family="ui-sans-serif, sans-serif" font-size="8.5" text-anchor="middle">
+    <text x="83" y="50">sat 1</text>
+    <text x="230" y="44">sat 2</text>
+    <text x="373" y="54">sat 3</text>
+    <text x="205" y="168">receiver fix</text>
+    <text x="230" y="184" font-size="8">a 4th satellite solves the clock offset</text>
+  </g>
+</svg>
+<figcaption>Each satellite's signal travel time gives a distance — a range sphere seen edge-on as an arc. Three ranges cross at the receiver's position; a fourth satellite pins down the receiver clock so the ranges are consistent.</figcaption>
+</figure>
+
 ## Overview
 
-The receiver listens for the faint signals of satellites overhead and, from the time each took to arrive, solves for its own position — needing a clear sky view and signals from at least four satellites for a 3D fix. Modern chips are *GNSS* receivers, combining the US GPS system with GLONASS, Galileo, and BeiDou for faster, more reliable fixes.[^gps] In a phone the GPS block sits in or beside the [SoC](/reference/system-on-a-chip/), with its own [antenna](/reference/antenna/), and often takes hints from the [cellular modem](/reference/cellular-modem/) (assisted GPS) to lock faster.
+The receiver listens for the faint signals of satellites overhead and, from the time each took to arrive, solves for its own position — needing a clear sky view and signals from at least four satellites: three for position and one to resolve the receiver's own clock error. Modern chips are *GNSS* receivers, combining the US GPS system with GLONASS, Galileo, and BeiDou for faster, more reliable fixes.[^gps]
+
+In a phone the GPS block sits in or beside the [SoC](/reference/system-on-a-chip/), with its own [antenna](/reference/antenna/), and often takes hints from the [cellular modem](/reference/cellular-modem/) (assisted GPS, which downloads the satellite almanac over the network) to lock far faster than from a cold start.
+
+## The GNSS constellations
+
+Four independent systems now share the sky, and a modern receiver uses several at once:
+
+| System | Operator | Note |
+|--------|----------|------|
+| GPS | United States | The original, global |
+| GLONASS | Russia | Global, aids high latitudes |
+| Galileo | European Union | Global, civil-run |
+| BeiDou | China | Global since ~2020 |
+
+More visible satellites means faster locks and better accuracy in urban canyons where sky view is limited.
 
 ## Where it fits
 
-Location is the killer feature GPS adds to phones, [smartwatches](/reference/smartwatch/), and [wearables](/reference/wearable-computer/) — maps, fitness routes, geotagging. Its precise one-pulse-per-second timing is also valuable beyond navigation: a GPS-disciplined clock can give an SDR setup like GopherTrunk an accurate frequency and time reference, useful for stable tuning and for timestamping decoded calls across distributed capture nodes.
+Location is the killer feature GPS adds to phones, [smartwatches](/reference/smartwatch/), and [wearables](/reference/wearable-computer/) — maps, fitness routes, geotagging. Its precise one-pulse-per-second timing is also valuable beyond navigation: a GPS-disciplined clock can give an SDR setup like GopherTrunk an accurate frequency and time reference, useful for stable tuning and for timestamping decoded calls consistently across distributed capture nodes.
 
 ## Sources
 

--- a/docs/reference/hardware-acceleration.md
+++ b/docs/reference/hardware-acceleration.md
@@ -3,14 +3,14 @@ slug: hardware-acceleration
 title: Hardware acceleration
 entry_type: concept
 category: hw-accelerators
-description: Hardware acceleration is offloading a task from the general-purpose CPU to specialized hardware built to do it faster or more efficiently, such as a GPU, FPGA, or fixed-function ASIC.
-keywords: hardware acceleration, offload, GPU, FPGA, ASIC, fixed-function, accelerator, throughput, efficiency
+description: Hardware acceleration is offloading a task from the general-purpose CPU to specialized hardware built to do it faster or more efficiently, such as a GPU, FPGA, or fixed-function ASIC, trading flexibility for throughput and power efficiency.
+keywords: hardware acceleration, offload, GPU, FPGA, ASIC, DSP, NPU, fixed-function, accelerator, throughput, efficiency, flexibility
 infobox:
   - { label: Type, value: Computing technique }
   - { label: Idea, value: Offload work from the CPU }
   - { label: Done by, value: "GPU, FPGA, ASIC, DSP, NPU" }
   - { label: Wins, value: Speed and power efficiency }
-  - { label: Cost, value: Less flexibility }
+  - { label: Cost, value: Less flexibility, transfer overhead }
 see_also: [graphics-processing-unit, field-programmable-gate-array, application-specific-integrated-circuit, vector-processor, ai-accelerator, soc-vs-discrete]
 cite_urls:
   - https://en.wikipedia.org/wiki/Hardware_acceleration
@@ -18,14 +18,57 @@ cite_urls:
 
 **Hardware acceleration** is the practice of offloading a task from the general-purpose [CPU](/reference/central-processing-unit/) onto specialized hardware built to do it faster, more efficiently, or both.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 150" role="img" aria-label="A spectrum of accelerators from the fully programmable CPU through the GPU and the reconfigurable FPGA to the fixed-function ASIC. Moving right, flexibility falls while speed and power efficiency rise." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="currentColor">
+    <rect x="20" y="46" width="94" height="40" rx="4" fill-opacity="0.06" stroke-width="1.3"/>
+    <text x="67" y="70" text-anchor="middle" font-size="9" stroke="none" font-weight="600">CPU</text>
+    <rect x="130" y="46" width="94" height="40" rx="4" fill-opacity="0.11" stroke-width="1.3"/>
+    <text x="177" y="70" text-anchor="middle" font-size="9" stroke="none" font-weight="600">GPU</text>
+    <rect x="240" y="46" width="94" height="40" rx="4" fill-opacity="0.18" stroke-width="1.3"/>
+    <text x="287" y="70" text-anchor="middle" font-size="9" stroke="none" font-weight="600">FPGA</text>
+    <rect x="350" y="46" width="94" height="40" rx="4" fill-opacity="0.26" stroke-width="1.3"/>
+    <text x="397" y="70" text-anchor="middle" font-size="9" stroke="none" font-weight="600">ASIC</text>
+  </g>
+  <g stroke="currentColor" fill="currentColor">
+    <line x1="20" y1="106" x2="444" y2="106" stroke-width="1.2" fill="none"/>
+    <path d="M444 106 l-8 -4 v8 z" stroke="none"/>
+    <line x1="444" y1="126" x2="20" y2="126" stroke-width="1.2" fill="none"/>
+    <path d="M20 126 l8 -4 v8 z" stroke="none"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="7.5">
+    <text x="24" y="102" fill-opacity="0.9">more flexible / programmable</text>
+    <text x="440" y="102" text-anchor="end" fill-opacity="0.9">faster &amp; more power-efficient</text>
+    <text x="24" y="138" fill-opacity="0.9">runs any code</text>
+    <text x="440" y="138" text-anchor="end" fill-opacity="0.9">does one job only</text>
+  </g>
+</svg>
+<figcaption>Accelerators sit on a spectrum: the fully programmable CPU, the massively parallel GPU, the reconfigurable FPGA, and the fixed-function ASIC — moving right trades flexibility for speed and power efficiency.</figcaption>
+</figure>
+
 ## Overview
 
 A CPU is a generalist: it can run any code, but it pays for that flexibility in speed and power. When a task is performed constantly and has a regular structure — graphics, video encoding, neural-network math, signal processing — it is often worth building hardware that does *only* that. Accelerators span a spectrum: the programmable [GPU](/reference/graphics-processing-unit/) and [vector](/reference/vector-processor/) units, the reconfigurable [FPGA](/reference/field-programmable-gate-array/), and the fixed-function [ASIC](/reference/application-specific-integrated-circuit/), with flexibility falling and efficiency rising along the way.
 
+The gains come from two sources: doing many operations at once (parallelism) and doing each with circuitry shaped exactly to the task rather than a general instruction pipeline. A dedicated video encoder or crypto block can beat a CPU by orders of magnitude in both speed and energy per operation — but it can do nothing else, and it cannot be changed once fabricated.
+
+## How it works
+
+The engineering choice is *how much to freeze in silicon*. The more a design commits to one task, the faster and leaner it runs it, and the less it can do anything else:
+
+| Accelerator | Programmability | Best at | Cost |
+|-------------|-----------------|---------|------|
+| CPU | Fully general | Anything, sequentially | Slowest per watt |
+| GPU | Software kernels | Data-parallel math | Transfer overhead |
+| FPGA | Reconfigurable logic | Custom pipelines, low latency | Hard to develop |
+| ASIC | Fixed at fabrication | One job, at scale | No changes, high NRE |
+
+Because offloading adds data-transfer and coordination overhead, it pays only when the accelerated portion is both large and regular — Amdahl's law limits how much a fast accelerator can help if most of the runtime is still ordinary CPU code.
+
 ## Where it fits
 
-The engineering question is always *what to offload*: moving work to an accelerator adds complexity and data-transfer overhead, so it pays only when the speedup is large or the CPU genuinely cannot keep up. This is a live trade-off in software-defined radio. GopherTrunk does its DSP and protocol decoding in software on the CPU, deliberately keeping the radio a simple front end; an [FPGA](/reference/field-programmable-gate-array/) doing the channelization in hardware would accelerate wideband, many-channel capture, at the cost of flexibility and a much harder development path.
+The engineering question is always *what to offload*: moving work to an accelerator adds complexity and data-transfer overhead, so it pays only when the speedup is large or the CPU genuinely cannot keep up. This is a live trade-off in software-defined radio. GopherTrunk does its DSP and protocol decoding in software on the CPU, deliberately keeping the radio a simple front end and leaning on CPU [vector units](/reference/vector-processor/) for the per-sample math; an [FPGA](/reference/field-programmable-gate-array/) doing channelization in hardware would accelerate wideband, many-channel capture, at the cost of flexibility and a much harder development path.
 
 ## Sources
 
-[^wiki]: [Hardware acceleration](https://en.wikipedia.org/wiki/Hardware_acceleration) — Wikipedia, on offloading tasks from the CPU to specialized hardware.
+[^wiki]: [Hardware acceleration](https://en.wikipedia.org/wiki/Hardware_acceleration) — Wikipedia, on offloading tasks from the CPU to specialized hardware and the flexibility-versus-efficiency spectrum.

--- a/docs/reference/hat-add-on-board.md
+++ b/docs/reference/hat-add-on-board.md
@@ -4,7 +4,7 @@ title: HAT add-on board
 entry_type: hardware
 category: hw-sbc
 description: A HAT is an add-on board that stacks onto a Raspberry Pi's GPIO header to add hardware such as displays, sensors, real-time clocks, or radios, following a standard mechanical and electrical specification.
-keywords: HAT, Hardware Attached on Top, Raspberry Pi HAT, GPIO add-on, daughterboard, expansion board, EEPROM ID
+keywords: HAT, Hardware Attached on Top, Raspberry Pi HAT, GPIO add-on, daughterboard, expansion board, EEPROM ID, 40-pin header
 aka: [HAT, Hardware Attached on Top]
 infobox:
   - { label: Type, value: SBC add-on board }
@@ -21,13 +21,56 @@ cite_urls:
 
 **A HAT** (Hardware Attached on Top) is an add-on board that stacks onto a [Raspberry Pi](/reference/raspberry-pi/)'s [GPIO](/reference/gpio/) header to add hardware.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 176" role="img" aria-label="An exploded side view of a HAT stacking onto a Raspberry Pi. The Pi board sits at the bottom with its 40-pin header standing up; the HAT board hovers above, its matching socket lining up with the header, and mounting standoffs at the corners. A small EEPROM chip on the HAT lets the Pi identify the board and auto-configure its pins." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.3">
+    <rect x="70" y="122" width="320" height="30" rx="4" fill-opacity="0.05" fill="currentColor"/>
+    <g stroke-width="1.1">
+      <line x1="150" y1="98" x2="150" y2="122"/><line x1="162" y1="98" x2="162" y2="122"/>
+      <line x1="174" y1="98" x2="174" y2="122"/><line x1="186" y1="98" x2="186" y2="122"/>
+      <line x1="198" y1="98" x2="198" y2="122"/><line x1="210" y1="98" x2="210" y2="122"/>
+      <line x1="222" y1="98" x2="222" y2="122"/><line x1="234" y1="98" x2="234" y2="122"/>
+      <line x1="246" y1="98" x2="246" y2="122"/><line x1="258" y1="98" x2="258" y2="122"/>
+    </g>
+    <rect x="70" y="44" width="320" height="28" rx="4" fill-opacity="0.1" fill="currentColor"/>
+    <rect x="144" y="72" width="122" height="12" rx="2" fill-opacity="0.2" fill="currentColor"/>
+    <rect x="330" y="52" width="22" height="14" rx="2" fill-opacity="0.24" fill="currentColor"/>
+    <line x1="82" y1="72" x2="82" y2="122" stroke-dasharray="3 3"/>
+    <line x1="378" y1="72" x2="378" y2="122" stroke-dasharray="3 3"/>
+    <circle cx="82" cy="122" r="3" fill-opacity="0.3" fill="currentColor"/>
+    <circle cx="378" cy="122" r="3" fill-opacity="0.3" fill="currentColor"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="8.5">
+    <text x="230" y="38" text-anchor="middle" font-weight="600">HAT board</text>
+    <text x="341" y="49" text-anchor="middle" font-size="6.5">EEPROM</text>
+    <text x="205" y="82" text-anchor="middle" font-size="6.5">socket</text>
+    <text x="118" y="112" text-anchor="middle" font-size="7.5">40-pin header</text>
+    <text x="230" y="168" text-anchor="middle" font-weight="600">Raspberry Pi</text>
+    <text x="60" y="98" text-anchor="end" font-size="7.5" fill-opacity="0.9">standoffs</text>
+  </g>
+</svg>
+<figcaption>A HAT drops onto the Pi's 40-pin header with corner standoffs holding it rigid; an onboard EEPROM identifies the board so the Pi can auto-configure the right pins the moment it powers up.</figcaption>
+</figure>
+
 ## Overview
 
-The HAT specification fixes the board size, mounting holes, and 40-pin connector so add-ons fit predictably, and a small EEPROM on the HAT can identify itself so the Pi auto-configures the right pins. Typical HATs add displays, [sensors](/reference/sensor/), real-time clocks, motor drivers, power management, or radios — often talking to the Pi over [I2C](/reference/i2c/) or SPI. Other SBCs use similar stackable add-ons under different names.
+The HAT specification fixes the board size, mounting-hole positions, and 40-pin connector so add-ons fit predictably, and a small EEPROM on the HAT can identify itself so the Pi auto-configures the right pins at boot. That self-identification is the part that makes a HAT more than a generic daughterboard: the Pi reads the EEPROM, learns which pins the HAT drives, and applies the correct device-tree overlay without the user editing config files.
+
+Typical HATs add displays, [sensors](/reference/sensor/), real-time clocks, motor drivers, power management, GPS, or radios — often talking to the Pi over [I2C](/reference/i2c/) or SPI so they consume only a couple of the header's pins for data. Other SBCs use similar stackable add-ons under different names (capes on the BeagleBone, for example), but the Raspberry Pi HAT is the most widely supported ecosystem.
+
+## Anatomy of the standard
+
+| Element | What the spec fixes | Why it matters |
+|---------|---------------------|----------------|
+| Form factor | Board outline, mounting holes | HATs and cases fit any Pi |
+| Connector | 40-pin GPIO header | Consistent electrical pinout |
+| EEPROM | ID + pin configuration | Pi auto-sets up the board |
+| Data link | Usually I2C / SPI | Few pins, many peripherals |
+| Power | Feeds from the Pi's rails | No separate supply needed |
 
 ## Where it fits
 
-A HAT is the quickest way to extend a board without designing your own electronics — a middle ground before committing to a custom carrier for a [Compute Module](/reference/compute-module/). For GopherTrunk, a HAT can supply the parts a bare Pi lacks at the antenna: a real-time clock for accurate timestamps, a fan and power controller, or a GPS HAT for precise timing on a capture node.
+A HAT is the quickest way to extend a board without designing your own electronics — a middle ground before committing to a custom carrier for a [Compute Module](/reference/compute-module/). For GopherTrunk, a HAT can supply the parts a bare Pi lacks at the antenna: a real-time clock for accurate timestamps when the network is down, a fan and power controller for a sealed enclosure, or a GPS HAT that feeds a pulse-per-second signal in for precise timing on a capture node. Because HATs stack, one can carry several of these at once.
 
 ## Sources
 

--- a/docs/reference/high-availability.md
+++ b/docs/reference/high-availability.md
@@ -4,13 +4,14 @@ title: High availability
 entry_type: concept
 category: hw-servers
 description: High availability is the design of systems to keep running with minimal downtime by removing single points of failure through redundancy, failover, and health monitoring.
-keywords: high availability, HA, uptime, redundancy, failover, single point of failure, nines
+keywords: high availability, HA, uptime, redundancy, failover, single point of failure, nines, active-passive
 aka: [HA]
 infobox:
   - { label: Type, value: System design goal }
   - { label: Achieved by, value: Redundancy & failover }
   - { label: Measured in, value: "Uptime (nines)" }
   - { label: Enemy, value: Single point of failure }
+  - { label: Sibling goal, value: Scalability }
 see_also: [scalability, load-balancer, raid, data-center, kubernetes, server]
 cite_urls:
   - https://en.wikipedia.org/wiki/High_availability
@@ -18,14 +19,59 @@ cite_urls:
 
 **High availability** (HA) is the practice of designing systems to keep running with minimal downtime, by removing single points of failure through redundancy, failover, and health monitoring.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 190" role="img" aria-label="A high-availability pair. Clients connect to a load balancer, which health-checks two servers and routes traffic to the active primary. A dashed standby server waits to take over. If the primary fails, the load balancer redirects to the standby, which is promoted to active." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="currentColor" font-family="ui-sans-serif, sans-serif">
+    <text x="42" y="94" text-anchor="middle" font-size="8" stroke="none">clients</text>
+    <g stroke-width="1.1" fill-opacity="0.16">
+      <circle cx="26" cy="72" r="6"/><circle cx="26" cy="98" r="6"/><circle cx="42" cy="112" r="6"/>
+    </g>
+    <line x1="52" y1="92" x2="118" y2="92" stroke-width="1.4" fill="none"/>
+    <path d="M118 92 l-8 -3 v6 z" stroke-width="1"/>
+    <rect x="120" y="70" width="80" height="44" rx="4" fill-opacity="0.18" stroke-width="1.4"/>
+    <text x="160" y="88" text-anchor="middle" font-size="8" stroke="none" font-weight="600">Load</text>
+    <text x="160" y="100" text-anchor="middle" font-size="8" stroke="none" font-weight="600">balancer</text>
+    <text x="160" y="112" text-anchor="middle" font-size="6.5" stroke="none" fill-opacity="0.8">health checks</text>
+    <line x1="200" y1="82" x2="320" y2="52" stroke-width="1.6" fill="none"/>
+    <path d="M320 52 l-8 -1 3 6 z" stroke-width="1"/>
+    <line x1="200" y1="102" x2="320" y2="132" stroke-width="1.2" stroke-dasharray="4 3" fill="none"/>
+    <rect x="322" y="34" width="96" height="40" rx="4" fill-opacity="0.16" stroke-width="1.4"/>
+    <text x="370" y="52" text-anchor="middle" font-size="8" stroke="none" font-weight="600">Primary</text>
+    <text x="370" y="65" text-anchor="middle" font-size="7" stroke="none" fill-opacity="0.85">active</text>
+    <rect x="322" y="114" width="96" height="40" rx="4" fill-opacity="0.04" stroke-width="1.3" stroke-dasharray="4 3"/>
+    <text x="370" y="132" text-anchor="middle" font-size="8" stroke="none">Standby</text>
+    <text x="370" y="145" text-anchor="middle" font-size="7" stroke="none" fill-opacity="0.85">promoted on failure</text>
+    <line x1="370" y1="74" x2="370" y2="114" stroke-width="1" stroke-dasharray="2 2" fill="none"/>
+    <text x="384" y="97" font-size="6.5" stroke="none" fill-opacity="0.7">replication</text>
+    <text x="230" y="182" text-anchor="middle" font-size="8" stroke="none" fill-opacity="0.85">no single component can take the whole service down</text>
+  </g>
+</svg>
+<figcaption>A load balancer health-checks a redundant pair and sends traffic to the active primary; when the primary fails its health check, traffic fails over to the replicated standby, which is promoted — so one dead component never means an outage.</figcaption>
+</figure>
+
 ## Overview
 
-Availability is often expressed in "nines": 99.9% uptime allows about nine hours of downtime a year, while 99.999% ("five nines") allows about five minutes. Reaching high numbers means that no single component — server, disk, network link, power feed — can take the whole system down. The toolkit includes redundant hardware, [load balancers](/reference/load-balancer/) that route around dead servers, [RAID](/reference/raid/) for disks, replicated databases, and automatic *failover* to a standby when the primary fails. The [data center](/reference/data-center/) itself contributes with redundant power and cooling.
+Availability is often expressed in "nines": 99.9% uptime allows about nine hours of downtime a year, while 99.999% ("five nines") allows about five minutes. Reaching high numbers means that no single component — server, disk, network link, power feed — can take the whole system down.
+
+The toolkit includes redundant hardware, [load balancers](/reference/load-balancer/) that route around dead servers, [RAID](/reference/raid/) for disks, replicated databases, and automatic *failover* to a standby when the primary fails. Health monitoring ties it together: the system must *detect* a failure quickly, or redundancy sits idle while users see errors. The [data center](/reference/data-center/) itself contributes with redundant power and cooling.
+
+## The nines
+
+Each additional nine cuts allowable downtime roughly tenfold — and gets sharply more expensive to guarantee:
+
+| Availability | Nickname | Downtime / year |
+|--------------|----------|-----------------|
+| 99% | Two nines | ~3.65 days |
+| 99.9% | Three nines | ~8.8 hours |
+| 99.99% | Four nines | ~53 minutes |
+| 99.999% | Five nines | ~5 minutes |
+
+The right target is an economic choice: chase only as many nines as the cost of downtime justifies, since redundancy, testing, and on-call all scale with the goal.
 
 ## Where it fits
 
-High availability is about staying *up*, while [scalability](/reference/scalability/) is about handling *more load*; the two are related but distinct, and many techniques (replication, multiple servers) serve both. Orchestrators like [Kubernetes](/reference/kubernetes/) automate failover for containerized apps. A hobby GopherTrunk node rarely justifies HA, but a monitoring site that must never miss a call would replicate capture nodes and back-end servers so any one can fail without an outage.
+High availability is about staying *up*, while [scalability](/reference/scalability/) is about handling *more load*; the two are related but distinct, and many techniques (replication, multiple servers) serve both. Orchestrators like [Kubernetes](/reference/kubernetes/) automate failover for containerized apps. A hobby GopherTrunk node rarely justifies HA, but a monitoring site that must never miss a call would replicate capture nodes and back-end [servers](/reference/server/) so any one can fail without an outage.
 
 ## Sources
 
-[^wiki]: [High availability](https://en.wikipedia.org/wiki/High_availability) — Wikipedia, on availability, redundancy, and failover.
+[^wiki]: [High availability](https://en.wikipedia.org/wiki/High_availability) — Wikipedia, on availability, redundancy, failover, and the nines.

--- a/docs/reference/home-automation.md
+++ b/docs/reference/home-automation.md
@@ -4,7 +4,7 @@ title: Home automation
 entry_type: concept
 category: hw-sbc
 description: Home automation is the control and coordination of household devices such as lights, locks, thermostats, and sensors, often run on a small always-on single-board computer acting as a local hub.
-keywords: home automation, smart home, Home Assistant, IoT hub, single-board computer, sensors, Raspberry Pi smart home, local hub
+keywords: home automation, smart home, Home Assistant, IoT hub, single-board computer, sensors, Raspberry Pi smart home, local hub, always-on
 aka: [smart home]
 infobox:
   - { label: Type, value: Application area }
@@ -21,13 +21,46 @@ cite_urls:
 
 **Home automation** is the control and coordination of household devices — lights, locks, thermostats, [sensors](/reference/sensor/) — so they run on schedules or react to conditions instead of being operated by hand.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 172" role="img" aria-label="A hub-and-spoke home automation topology. A single-board computer at the centre acts as the local hub, holding the rules and state, and connects out to household devices around it: a light, a door lock, a thermostat, and a sensor. The hub coordinates them locally and keeps working even without an internet connection." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.3">
+    <rect x="196" y="64" width="68" height="44" rx="5" fill-opacity="0.14" fill="currentColor"/>
+    <path d="M196 86 H96" /><path d="M264 86 H364"/>
+    <path d="M215 64 L150 30"/><path d="M245 64 L310 30"/>
+    <path d="M215 108 L150 142"/><path d="M245 108 L310 142"/>
+    <rect x="52" y="72" width="44" height="28" rx="4" fill-opacity="0.06" fill="currentColor"/>
+    <rect x="364" y="72" width="44" height="28" rx="4" fill-opacity="0.06" fill="currentColor"/>
+    <circle cx="140" cy="24" r="13" fill-opacity="0.06" fill="currentColor"/>
+    <rect x="298" y="12" width="26" height="24" rx="3" fill-opacity="0.06" fill="currentColor"/>
+    <rect x="128" y="130" width="26" height="24" rx="3" fill-opacity="0.06" fill="currentColor"/>
+    <circle cx="311" cy="142" r="13" fill-opacity="0.06" fill="currentColor"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="8" text-anchor="middle">
+    <text x="230" y="82" font-size="9" font-weight="600">SBC hub</text>
+    <text x="230" y="95" font-size="7">rules + state</text>
+    <text x="74" y="90" font-size="7.5">sensor</text>
+    <text x="386" y="90" font-size="7.5">sensor</text>
+    <text x="140" y="27" font-size="7.5">light</text>
+    <text x="311" y="27" font-size="7.5">lock</text>
+    <text x="141" y="146" font-size="7">climate</text>
+    <text x="311" y="146" font-size="7.5">sensor</text>
+    <text x="230" y="166" font-size="7.5" fill-opacity="0.9">coordinated locally — works with the internet down</text>
+  </g>
+</svg>
+<figcaption>A home-automation hub — typically a small always-on SBC — sits at the centre holding the rules and state, and reaches out to lights, locks, climate, and sensors, keeping the house coordinated even when the internet link is down.</figcaption>
+</figure>
+
 ## Overview
 
-A typical setup ties together many [Internet of Things](/reference/internet-of-things/) devices through a central hub that holds the rules and state. That hub is often a small, always-on [single-board computer](/reference/single-board-computer/) such as a [Raspberry Pi](/reference/raspberry-pi/) running software like Home Assistant — cheap, low-power, and able to keep everything working locally even when the internet is down.
+A typical setup ties together many [Internet of Things](/reference/internet-of-things/) devices through a central hub that holds the rules and state. That hub is often a small, always-on [single-board computer](/reference/single-board-computer/) such as a [Raspberry Pi](/reference/raspberry-pi/) running software like Home Assistant — cheap, low-power, and able to keep everything working locally even when the internet is down. Because the logic lives on the hub rather than in the cloud, a rule like "turn on the porch light at sunset" keeps firing regardless of whether a vendor's servers are reachable.
+
+The devices themselves speak a patchwork of protocols — Wi-Fi, Zigbee, Z-Wave, Bluetooth, plain [GPIO](/reference/gpio/) wiring — and part of the hub's job is to translate between them and present one consistent view. Keeping that bridge on local hardware is also what makes a smart home resilient and private: sensor readings and door-lock commands never have to leave the house.
 
 ## Where it fits
 
-Home automation is one of the most common reasons people pick up their first SBC, because the workload — talking to sensors and devices over [GPIO](/reference/gpio/), Wi-Fi, and other links, around the clock — fits the board's strengths. The same always-on, low-power profile makes such a board a natural host for other field roles, like running GopherTrunk as a quiet capture node beside the antenna.
+Home automation is one of the most common reasons people pick up their first SBC, because the workload — talking to sensors and devices over GPIO, Wi-Fi, and other links, around the clock, at a few watts — fits the board's strengths exactly. It is also a gateway to running local machine learning: pairing the hub with [edge AI](/reference/edge-ai/) lets it recognise faces at the door or sounds in a room without uploading anything.
+
+That same always-on, low-power profile makes such a board a natural host for other field roles. The Pi already sitting in a closet running the smart home is the same kind of box that can run GopherTrunk as a quiet capture node beside an antenna — a headless Linux machine that just needs to stay up and do one job well.
 
 ## Sources
 

--- a/docs/reference/home-server.md
+++ b/docs/reference/home-server.md
@@ -4,14 +4,15 @@ title: Home server & self-hosting
 entry_type: concept
 category: hw-servers
 description: A home server is a computer you run at home to host services for yourself, such as file storage, a personal site, or media — the heart of self-hosting.
-keywords: home server, self-hosting, NAS, self host, port forwarding, home lab
+keywords: home server, self-hosting, NAS, self host, port forwarding, home lab, dynamic DNS
 aka: [Home server, Self-hosting]
 infobox:
   - { label: Type, value: Home-run server }
   - { label: Common uses, value: NAS, media, personal site }
   - { label: Hidden costs, value: Power, uptime, backups }
+  - { label: Reached via, value: Port forwarding / DNS }
   - { label: Good first box, value: Raspberry Pi or old PC }
-see_also: [server, raspberry-pi, single-board-computer, dedicated-server, cloud-computing]
+see_also: [server, raspberry-pi, single-board-computer, network-attached-storage, dedicated-server, cloud-computing]
 related_lessons:
   - { title: "Home servers", url: /learn/intro-hardware/home-servers/ }
   - { title: "Combining tiers", url: /learn/intro-hardware/combining-tiers/ }
@@ -21,13 +22,58 @@ cite_urls:
 
 A **home server** is a computer you run at home to host services for yourself — file storage (a NAS), a personal site, or media you stream around the house.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 180" role="img" aria-label="A home network. A small always-on server inside the house serves files and media to a laptop, phone, and TV over the local network. A router with port forwarding connects the server to the internet cloud so it can be reached from outside." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="currentColor" font-family="ui-sans-serif, sans-serif">
+    <path d="M20 60 h230 v96 h-230 z M20 60 l115 -34 l115 34" fill-opacity="0.03" stroke-width="1.4"/>
+    <text x="135" y="50" text-anchor="middle" font-size="8" stroke="none" fill-opacity="0.85">your home</text>
+    <rect x="40" y="92" width="52" height="52" rx="4" fill-opacity="0.18" stroke-width="1.4"/>
+    <text x="66" y="114" text-anchor="middle" font-size="8" stroke="none" font-weight="600">home</text>
+    <text x="66" y="126" text-anchor="middle" font-size="8" stroke="none" font-weight="600">server</text>
+    <g stroke-width="1.2" fill="none">
+      <line x1="92" y1="104" x2="150" y2="82"/>
+      <line x1="92" y1="118" x2="150" y2="118"/>
+      <line x1="92" y1="132" x2="150" y2="150"/>
+    </g>
+    <g stroke-width="1.1" fill-opacity="0.14">
+      <rect x="152" y="72" width="30" height="20" rx="2"/>
+      <rect x="152" y="108" width="30" height="20" rx="2"/>
+      <rect x="152" y="140" width="30" height="20" rx="2"/>
+    </g>
+    <text x="200" y="86" font-size="7.5" stroke="none" fill-opacity="0.85">laptop</text>
+    <text x="200" y="122" font-size="7.5" stroke="none" fill-opacity="0.85">phone</text>
+    <text x="200" y="154" font-size="7.5" stroke="none" fill-opacity="0.85">TV</text>
+    <rect x="270" y="98" width="46" height="34" rx="3" fill-opacity="0.12" stroke-width="1.3"/>
+    <text x="293" y="112" text-anchor="middle" font-size="7.5" stroke="none">router</text>
+    <text x="293" y="124" text-anchor="middle" font-size="6.5" stroke="none" fill-opacity="0.8">port fwd</text>
+    <line x1="92" y1="118" x2="270" y2="115" stroke-width="1" stroke-dasharray="3 2" fill="none"/>
+    <line x1="316" y1="115" x2="372" y2="115" stroke-width="1.4" fill="none"/>
+    <path d="M372 115 l-8 -3 v6 z" stroke-width="1"/>
+    <path d="M392 96 a16 12 0 0 1 0 24 h-14 a13 13 0 0 1 0 -22 a17 12 0 0 1 32 -2 z" fill-opacity="0.08" stroke-width="1.3"/>
+    <text x="404" y="116" text-anchor="middle" font-size="7.5" stroke="none">internet</text>
+    <text x="230" y="174" text-anchor="middle" font-size="8" stroke="none" fill-opacity="0.85">you own the hardware &#183; you pay for power, uptime, and backups</text>
+  </g>
+</svg>
+<figcaption>A home server sits on your own network serving files and media to household devices; a router with port forwarding lets you reach it from the internet — the whole appeal being control and privacy, at the cost of running the box yourself.</figcaption>
+</figure>
+
 ## Overview
 
-Self-hosting means running those services on hardware you own instead of paying a provider. The appeal is control and privacy; the costs nobody mentions up front are electricity, keeping the box online 24/7, and a real backup plan. To reach it from outside your house you typically set up port forwarding on your router so requests find the [server](/reference/server/).
+Self-hosting means running those services on hardware you own instead of paying a provider. The appeal is control and privacy; the costs nobody mentions up front are electricity, keeping the box online 24/7, and a real backup plan. To reach it from outside your house you typically set up port forwarding on your router — often paired with dynamic DNS — so requests find the [server](/reference/server/) even as your home IP address changes.
+
+Home servers range from a single-board computer sipping a few watts to a repurposed desktop or a small rack in a closet ("home lab"). What they share is that *you* are the operator: there is no provider to page when a disk fills or a service crashes, which is both the point and the burden.
 
 ## Where it fits
 
-A [Raspberry Pi](/reference/raspberry-pi/) or other [single-board computer](/reference/single-board-computer/) — or an old PC gathering dust — makes a great first server: cheap, low-power, and enough for file shares and small sites. In GopherTrunk terms a home machine can do both jobs at once: capture RF from an attached dongle *and* store and serve the decoded data, which a remote VPS cannot.
+Choosing the first box is mostly a power-versus-capability trade:
+
+| Option | Power draw | Good for | Watch out for |
+|--------|-----------|----------|---------------|
+| [Raspberry Pi](/reference/raspberry-pi/) / SBC | ~5 W | File shares, small sites, sensors | Limited CPU & I/O |
+| Old desktop PC | 40–100 W | Media, VMs, heavier apps | Electricity, noise |
+| [NAS](/reference/network-attached-storage/) appliance | 10–30 W | Bulk storage with RAID | Less general-purpose |
+
+A [single-board computer](/reference/single-board-computer/) or an old PC gathering dust makes a great starting point: cheap, low-power, and enough for file shares and small sites. In GopherTrunk terms a home machine can do both jobs at once — capture RF from an attached dongle *and* store and serve the decoded data, which a remote VPS cannot.
 
 ## Sources
 

--- a/docs/reference/ieee.md
+++ b/docs/reference/ieee.md
@@ -4,7 +4,7 @@ title: IEEE
 entry_type: organization
 category: hw-organizations
 description: The IEEE is a global professional association for electrical and electronics engineering that publishes widely used technical standards, including those behind Ethernet and Wi-Fi.
-keywords: IEEE, Institute of Electrical and Electronics Engineers, standards, 802.11, 802.3, engineering
+keywords: IEEE, Institute of Electrical and Electronics Engineers, standards, 802.11, 802.3, 754, engineering
 aka: [Institute of Electrical and Electronics Engineers]
 autolink: true
 infobox:
@@ -12,7 +12,7 @@ infobox:
   - { label: Founded, value: "1963" }
   - { label: HQ, value: New York / Piscataway, New Jersey, USA }
   - { label: Makes, value: Technical standards, publications }
-see_also: [ethernet, wi-fi, jedec, itu]
+see_also: [ethernet, wi-fi, jedec, itu, wifi-80211]
 cite_urls:
   - https://www.ieee.org/
   - https://en.wikipedia.org/wiki/IEEE
@@ -21,6 +21,33 @@ cite_urls:
 **The IEEE** (Institute of Electrical and Electronics Engineers) is a global professional
 association for electrical, electronics, and computing engineering that publishes many of
 the technical standards the industry relies on.[^wiki]
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="A map of well-known IEEE standards. A central IEEE node branches to the 802 networking family, which splits into 802.3 Ethernet and 802.11 Wi-Fi, and separately to IEEE 754, the floating-point arithmetic standard that governs how computers represent decimal numbers." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.2">
+    <line x1="86" y1="70" x2="170" y2="45"/>
+    <line x1="86" y1="70" x2="170" y2="105"/>
+    <line x1="252" y1="45" x2="330" y2="28"/>
+    <line x1="252" y1="45" x2="330" y2="62"/>
+  </g>
+  <g stroke="currentColor" fill="currentColor" fill-opacity="0.12" stroke-width="1.2">
+    <rect x="20" y="55" width="66" height="30" rx="4"/>
+    <rect x="170" y="30" width="82" height="30" rx="4"/>
+    <rect x="170" y="90" width="82" height="30" rx="4"/>
+    <rect x="330" y="14" width="112" height="28" rx="4"/>
+    <rect x="330" y="48" width="112" height="28" rx="4"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="9">
+    <text x="53" y="74" text-anchor="middle" font-weight="600">IEEE</text>
+    <text x="211" y="49" text-anchor="middle" font-weight="600">802</text>
+    <text x="211" y="109" text-anchor="middle" font-weight="600">754</text>
+    <text x="340" y="32" font-size="8.5">802.3 &#8594; Ethernet</text>
+    <text x="340" y="66" font-size="8.5">802.11 &#8594; Wi-Fi</text>
+    <text x="211" y="121" text-anchor="middle" font-size="7.5">floating point</text>
+  </g>
+</svg>
+<figcaption>A few IEEE standards touch almost every networked computer: the 802 family gives Ethernet (802.3) and Wi-Fi (802.11), while IEEE 754 defines how machines store floating-point numbers.</figcaption>
+</figure>
 
 ## Overview
 
@@ -34,12 +61,23 @@ The IEEE 802 family is the best known: 802.3 defines [Ethernet](/reference/ether
 802.11 defines [Wi-Fi](/reference/wi-fi/). The IEEE 754 standard for floating-point
 arithmetic governs how computers represent decimal numbers.
 
-## Why it matters
+## Standards that touch SDR
+
+A handful of IEEE numbers show up directly in a capture-and-decode setup:
+
+| Standard | What it defines |
+|----------|-----------------|
+| 802.3 | Ethernet, the wired link between nodes and server |
+| 802.11 | Wi-Fi, the wireless link for remote nodes |
+| 754 | Floating-point numbers used throughout DSP math |
+
+## Where it fits
 
 IEEE standards let equipment from different vendors interoperate — the reason an Ethernet
 cable or Wi-Fi connection works between any two compliant devices. The networking that ties
 a fleet of GopherTrunk capture nodes back to a server runs on IEEE-standardized links, and
-IEEE 754 arithmetic underlies the DSP math itself.
+IEEE 754 arithmetic underlies the DSP math itself, so the floating-point samples flowing
+through the decoder obey a rule the IEEE wrote.
 
 ## Sources
 

--- a/docs/reference/in-system-programming.md
+++ b/docs/reference/in-system-programming.md
@@ -3,8 +3,8 @@ slug: in-system-programming
 title: In-system programming
 entry_type: concept
 category: hw-microcontrollers
-description: In-system programming (ISP) flashes a microcontroller's firmware while the chip stays soldered in its circuit, using a debug interface such as SWD, JTAG, or SPI instead of a chip programmer.
-keywords: in-system programming, ISP, ICSP, SWD, JTAG, debug interface, flash, programmer, ST-LINK
+description: In-system programming (ISP) flashes a microcontroller's firmware while the chip stays soldered in its circuit, using a debug interface such as SWD, JTAG, or SPI and a small programmer instead of removing the chip.
+keywords: in-system programming, ISP, ICSP, SWD, JTAG, debug interface, flash, programmer, ST-LINK, PICkit, J-Link
 aka: [ISP, ICSP]
 infobox:
   - { label: Type, value: Programming method }
@@ -20,13 +20,63 @@ cite_urls:
 
 **In-system programming (ISP)** is the practice of writing a [microcontroller's](/reference/microcontroller/) [firmware](/reference/firmware/) while the chip remains soldered into its circuit board.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 156" role="img" aria-label="Wiring of an in-system programming session. A host PC connects by USB to a small programmer such as an ST-LINK. The programmer drives a few debug pins on a header on the target board, and those pins run to the microcontroller, which stays soldered in place. Labelled lines carry clock, data, reset, and ground." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.3">
+    <rect x="20" y="54" width="72" height="44" rx="4" fill="currentColor" fill-opacity="0.06"/>
+    <rect x="140" y="54" width="80" height="44" rx="4" fill="currentColor" fill-opacity="0.12"/>
+    <rect x="300" y="34" width="150" height="94" rx="5" fill="currentColor" fill-opacity="0.04"/>
+    <rect x="360" y="66" width="70" height="42" rx="3" fill="currentColor" fill-opacity="0.16"/>
+    <rect x="306" y="54" width="16" height="60" rx="2" fill="currentColor" fill-opacity="0.10"/>
+    <line x1="92" y1="76" x2="140" y2="76"/>
+  </g>
+  <g stroke="currentColor" stroke-width="1.1" fill="none">
+    <line x1="220" y1="62" x2="306" y2="62"/>
+    <line x1="220" y1="72" x2="306" y2="72"/>
+    <line x1="220" y1="82" x2="306" y2="82"/>
+    <line x1="220" y1="92" x2="306" y2="92"/>
+    <line x1="322" y1="76" x2="360" y2="82"/>
+    <line x1="322" y1="92" x2="360" y2="92"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="56" y="79" font-size="8">Host PC</text>
+    <text x="56" y="90" font-size="7.5" fill-opacity="0.85">USB</text>
+    <text x="180" y="73" font-size="8" font-weight="600">Programmer</text>
+    <text x="180" y="85" font-size="7.5" fill-opacity="0.85">ST-LINK</text>
+    <text x="314" y="128" font-size="7.5">header</text>
+    <text x="395" y="90" font-size="8" font-weight="600">MCU</text>
+    <text x="375" y="46" font-size="7.5" fill-opacity="0.85">target board (soldered)</text>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="7" text-anchor="start">
+    <text x="236" y="60">CLK</text>
+    <text x="236" y="70">DAT</text>
+    <text x="236" y="80">RST</text>
+    <text x="236" y="90">GND</text>
+  </g>
+</svg>
+<figcaption>An ISP session: the host PC talks over USB to a small programmer (here an ST-LINK), which drives a handful of debug pins — clock, data, reset, ground — on a header wired straight to the microcontroller. The chip never leaves the board, and the same link usually allows step-debugging and memory readback.</figcaption>
+</figure>
+
 ## Overview
 
-Before ISP, a chip had to be removed and placed in a dedicated programmer. ISP instead uses a small debug interface on the board — SWD or JTAG on [ARM Cortex-M](/reference/arm-cortex-m/) parts, an [SPI](/reference/spi/)-based ICSP header on [AVR/ATmega](/reference/avr-atmega/), or vendor schemes on [PIC](/reference/pic-microcontroller/) — so a programmer like ST-LINK, J-Link, or PICkit can flash and debug the device in place. The same interface usually allows single-step debugging and reading back memory.
+Before ISP, a chip had to be removed and placed in a dedicated programmer. ISP instead uses a small debug interface on the board — SWD or JTAG on [ARM Cortex-M](/reference/arm-cortex-m/) parts, an [SPI](/reference/spi/)-based ICSP header on [AVR/ATmega](/reference/avr-atmega/), or vendor schemes on [PIC](/reference/pic-microcontroller/) — so a programmer like ST-LINK, J-Link, or PICkit can flash and debug the device in place.
+
+Only a few wires are needed: a clock, one or two data lines, reset, and ground. The same interface usually allows single-step debugging and reading memory back, which is why the ISP header is as much a debugging port as a programming one.
+
+## Common ISP interfaces
+
+Which pins you break out depends on the chip family:
+
+| Interface | Typical parts | Pins | Programmer |
+|-----------|---------------|------|-----------|
+| SWD | [ARM Cortex-M](/reference/arm-cortex-m/), [STM32](/reference/stm32/) | 2 (+ reset) | ST-LINK, J-Link |
+| JTAG | Larger ARM, FPGAs | 4–5 | J-Link, generic |
+| SPI/ICSP | [AVR/ATmega](/reference/avr-atmega/) | 3 (+ reset) | USBasp, Arduino as ISP |
+| ICSP (PIC) | [PIC](/reference/pic-microcontroller/) | 2 (+ reset) | PICkit, ICD |
 
 ## Where it fits
 
-ISP is the lowest-level way to get code onto a chip and is how a brand-new, blank MCU is first programmed — including installing a [bootloader](/reference/bootloader/), after which routine updates can happen over USB instead. On an [STM32](/reference/stm32/) board, the SWD pins broken out next to the MCU are the ISP interface. It is the standard production and bring-up workflow for [embedded systems](/reference/embedded-system/).
+ISP is the lowest-level way to get code onto a chip and is how a brand-new, blank MCU is first programmed — including installing a [bootloader](/reference/bootloader/), after which routine updates can happen over USB instead. On an [STM32](/reference/stm32/) board, the SWD pins broken out next to the MCU are the ISP interface. It is the standard production and bring-up workflow for [embedded systems](/reference/embedded-system/), including the small controllers and SDR front-end boards that surround a capture setup.
 
 ## Sources
 

--- a/docs/reference/instruction-set-architecture.md
+++ b/docs/reference/instruction-set-architecture.md
@@ -4,11 +4,12 @@ title: Instruction set architecture (ISA)
 entry_type: concept
 category: hw-foundations
 description: An instruction set architecture is the contract between hardware and software, defining the instructions, registers, and data types a processor understands, independent of how it is built.
-keywords: instruction set architecture, ISA, machine code, registers, RISC, CISC, opcode, microarchitecture
+keywords: instruction set architecture, ISA, machine code, registers, RISC, CISC, opcode, microarchitecture, fetch decode execute
 aka: [ISA]
 infobox:
   - { label: Type, value: Hardware/software contract }
-  - { label: Defines, value: Instructions, registers }
+  - { label: Defines, value: Instructions, registers, data types }
+  - { label: Separate from, value: Microarchitecture }
   - { label: Styles, value: "RISC, CISC" }
   - { label: Examples, value: "x86, ARM, RISC-V" }
 see_also: [central-processing-unit, x86, arm-architecture, risc-v, von-neumann-architecture, compiler]
@@ -18,14 +19,59 @@ cite_urls:
 
 An **instruction set architecture** (**ISA**) is the contract between hardware and software: the set of instructions, registers, and data types a [processor](/reference/central-processing-unit/) understands, separate from how any particular chip implements it.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 150" role="img" aria-label="The fetch-decode-execute cycle. The processor fetches the next instruction from memory, decodes it into a defined operation, executes it using registers and the arithmetic unit, then writes back the result and repeats. The ISA defines the instructions and registers this cycle uses." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.2">
+    <rect x="16" y="52" width="88" height="44" rx="4"/>
+    <rect x="132" y="52" width="88" height="44" rx="4" fill="currentColor" fill-opacity="0.12"/>
+    <rect x="248" y="52" width="88" height="44" rx="4" fill="currentColor" fill-opacity="0.12"/>
+    <rect x="364" y="52" width="88" height="44" rx="4"/>
+  </g>
+  <g stroke="currentColor" stroke-width="1.2" fill="none">
+    <path d="M104 74 h28 m-6 -4 l6 4 l-6 4"/>
+    <path d="M220 74 h28 m-6 -4 l6 4 l-6 4"/>
+    <path d="M336 74 h28 m-6 -4 l6 4 l-6 4"/>
+    <path d="M408 96 v18 h-350 v-18 m-4 6 l4 -6 l4 6"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="60" y="72" font-size="9" font-weight="600">Fetch</text>
+    <text x="60" y="85" font-size="7.5" fill-opacity="0.85">read instruction</text>
+    <text x="176" y="72" font-size="9" font-weight="600">Decode</text>
+    <text x="176" y="85" font-size="7.5" fill-opacity="0.85">read opcode</text>
+    <text x="292" y="72" font-size="9" font-weight="600">Execute</text>
+    <text x="292" y="85" font-size="7.5" fill-opacity="0.85">registers + ALU</text>
+    <text x="408" y="72" font-size="9" font-weight="600">Write back</text>
+    <text x="408" y="85" font-size="7.5" fill-opacity="0.85">store result</text>
+    <text x="230" y="132" font-size="8" fill-opacity="0.9">ISA defines the opcodes and registers · microarchitecture decides how the cycle is built</text>
+  </g>
+</svg>
+<figcaption>The processor repeats a fetch-decode-execute-write-back cycle; the ISA is the fixed vocabulary of opcodes and registers that this cycle operates on, while the microarchitecture is the separate engineering of how fast and how cleverly the cycle runs.</figcaption>
+</figure>
+
 ## Overview
 
-The ISA defines what a program *can ask the CPU to do* — the opcodes, the registers, how memory is addressed — so that machine code written for an ISA runs on any chip that implements it. The *microarchitecture* is the separate question of how a given chip carries those instructions out (pipelines, caches, execution units). ISAs split loosely into **RISC** (few, simple, fixed-length instructions) and **CISC** (more, richer instructions); the major families today are [x86](/reference/x86/), [ARM](/reference/arm-architecture/), and the open [RISC-V](/reference/risc-v/).
+The ISA defines what a program *can ask the CPU to do* — the opcodes, the registers, how memory is addressed, what data types exist — so that machine code written for an ISA runs on any chip that implements it. It is a stable interface: a binary compiled for x86-64 in 2010 still runs on an x86-64 chip made today, because both honour the same contract.
+
+The *microarchitecture* is the separate question of how a given chip carries those instructions out — its pipeline depth, caches, branch predictors, and execution units. Two chips can share an ISA yet differ wildly in speed and power because their microarchitectures differ. This split is what lets Intel and AMD both build x86 chips, or dozens of vendors all build ARM chips, that run the same software.
+
+## RISC versus CISC
+
+ISAs split loosely into two philosophies, though modern designs blur the line internally:
+
+| Trait | RISC | CISC |
+|-------|------|------|
+| Instruction count | Few, simple | Many, complex |
+| Instruction length | Fixed | Variable |
+| Work per instruction | Small, uniform | Can be large |
+| Memory access | Load/store only | Many ops touch memory |
+| Examples | ARM, RISC-V | x86 |
+
+The major families today are the CISC [x86](/reference/x86/) and the RISC [ARM](/reference/arm-architecture/) and open [RISC-V](/reference/risc-v/). In practice even x86 chips decode their complex instructions into simple RISC-like internal operations, so the distinction is now more about the external contract than the silicon.
 
 ## Where it fits
 
-The ISA is why a [compiler](/reference/compiler/) must *target* a specific architecture, and why a binary built for x86 will not run on an ARM chip without recompilation or emulation. It builds on the [von Neumann](/reference/von-neumann-architecture/) idea of a stored program the processor fetches and executes. For GopherTrunk this is a daily reality: Go cross-compiles the same source to x86 servers and to the ARM CPU in a [Raspberry Pi](/reference/raspberry-pi/) capture node.
+The ISA is why a [compiler](/reference/compiler/) must *target* a specific architecture, and why a binary built for x86 will not run on an ARM chip without recompilation or emulation. It builds on the [von Neumann](/reference/von-neumann-architecture/) idea of a stored program the processor fetches and executes. For GopherTrunk this is a daily reality: Go cross-compiles the same source to x86 servers and to the ARM CPU in a [Raspberry Pi](/reference/raspberry-pi/) capture node, each producing native machine code for that ISA.
 
 ## Sources
 
-[^wiki]: [Instruction set architecture](https://en.wikipedia.org/wiki/Instruction_set_architecture) — Wikipedia, on the ISA as the hardware/software interface.
+[^wiki]: [Instruction set architecture](https://en.wikipedia.org/wiki/Instruction_set_architecture) — Wikipedia, on the ISA as the hardware/software interface and its separation from microarchitecture.

--- a/docs/reference/intel.md
+++ b/docs/reference/intel.md
@@ -4,7 +4,7 @@ title: Intel
 entry_type: organization
 category: hw-organizations
 description: Intel is an American semiconductor company, the inventor of the commercial microprocessor and long the dominant maker of x86 CPUs for PCs, servers, and data centers.
-keywords: Intel, x86, microprocessor, CPU, semiconductor, Core, Xeon, fab
+keywords: Intel, x86, microprocessor, CPU, semiconductor, Core, Xeon, fab, 4004, 8086
 aka: [Intel Corporation]
 autolink: true
 infobox:
@@ -12,7 +12,7 @@ infobox:
   - { label: Founded, value: "1968" }
   - { label: HQ, value: Santa Clara, California, USA }
   - { label: Makes, value: x86 CPUs, chipsets, FPGAs }
-see_also: [central-processing-unit, x86, gordon-moore, robert-noyce, amd]
+see_also: [central-processing-unit, x86, gordon-moore, robert-noyce, amd, moores-law, semiconductor]
 cite_urls:
   - https://www.intel.com/
   - https://en.wikipedia.org/wiki/Intel
@@ -21,6 +21,32 @@ cite_urls:
 **Intel** is an American semiconductor company founded in 1968 that produced the first
 commercial microprocessor and became the dominant supplier of
 [x86](/reference/x86/) [CPUs](/reference/central-processing-unit/).[^wiki]
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A timeline of Intel milestones. It is founded in 1968 by Noyce and Moore, ships the 4004, the first commercial single-chip microprocessor, in 1971, launches the 8086 that starts the x86 line in 1978, and reaches the modern era of Core processors for PCs and Xeon processors for servers." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="66" x2="440" y2="66" stroke="currentColor" stroke-width="1.4"/>
+  <g stroke="currentColor" fill="currentColor" stroke-width="1.2">
+    <circle cx="60" cy="66" r="5" fill-opacity="0.15"/>
+    <circle cx="180" cy="66" r="5" fill-opacity="0.15"/>
+    <circle cx="300" cy="66" r="6" fill="currentColor"/>
+    <circle cx="410" cy="66" r="5" fill-opacity="0.15"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="60" y="50" font-size="9" font-weight="600">1968</text>
+    <text x="60" y="86" font-size="8">founded</text>
+    <text x="60" y="97" font-size="8">Noyce &amp; Moore</text>
+    <text x="180" y="50" font-size="9" font-weight="600">1971</text>
+    <text x="180" y="86" font-size="8">4004</text>
+    <text x="180" y="97" font-size="8">1st microprocessor</text>
+    <text x="300" y="50" font-size="9" font-weight="600">1978</text>
+    <text x="300" y="86" font-size="8">8086</text>
+    <text x="300" y="97" font-size="8">starts x86</text>
+    <text x="410" y="50" font-size="9" font-weight="600">now</text>
+    <text x="410" y="86" font-size="8">Core / Xeon</text>
+  </g>
+</svg>
+<figcaption>Intel's arc runs from its 1968 founding by Noyce and Moore, through the 4004 — the first single-chip microprocessor — and the 8086 that launched x86, to today's Core and Xeon lines.</figcaption>
+</figure>
 
 ## Overview
 
@@ -31,12 +57,24 @@ the 1978 8086 launched the x86 instruction set that still underpins most desktop
 and server processors today.[^wiki]
 
 For decades Intel built both the chip designs and the fabrication plants ("fabs") that
-made them, a vertically integrated model summarised by Moore's prediction that transistor
-counts would roughly double every two years. Its modern lines include Core processors for
-PCs and Xeon processors for servers and data centers; it has also produced chipsets,
-network controllers, and FPGAs.[^home]
+made them, a vertically integrated model summarised by
+[Moore's law](/reference/moores-law/) — his prediction that transistor counts would roughly
+double every two years. Its modern lines include Core processors for PCs and Xeon
+processors for servers and data centers; it has also produced chipsets, network controllers,
+and FPGAs.[^home]
 
-## Why it matters
+## Landmark chips
+
+A few products mark the turns in Intel's history:
+
+| Year | Chip | Why it mattered |
+|------|------|-----------------|
+| 1971 | 4004 | First commercial single-chip microprocessor |
+| 1978 | 8086 | Started the x86 architecture |
+| 1993 | Pentium | Brought x86 into the mainstream PC boom |
+| 2006+ | Core / Xeon | Modern PC and server processor families |
+
+## Where it fits
 
 The PC era was largely built on Intel x86 CPUs running Windows and Linux, and most
 general-purpose servers — including the machines that host an SDR decoder pipeline or a

--- a/docs/reference/internet-of-things.md
+++ b/docs/reference/internet-of-things.md
@@ -3,16 +3,16 @@ slug: internet-of-things
 title: Internet of Things (IoT)
 entry_type: concept
 category: hw-microcontrollers
-description: The Internet of Things is the network of everyday physical objects with embedded computing and connectivity that send and receive data, often over cheap wireless microcontrollers.
-keywords: Internet of Things, IoT, smart home, embedded, wireless sensors, ESP32, connected devices
+description: The Internet of Things is the network of everyday physical objects with embedded computing and connectivity that send and receive data, typically built on cheap wireless microcontrollers reporting through a gateway to a server or the cloud.
+keywords: Internet of Things, IoT, smart home, embedded, wireless sensors, ESP32, connected devices, gateway, cloud
 aka: [IoT, Internet of Things]
 autolink: true
 infobox:
   - { label: Type, value: Networked embedded devices }
   - { label: Typical node, value: Cheap wireless microcontroller }
   - { label: Connectivity, value: Wi-Fi, Bluetooth, cellular }
-  - { label: Reports to, value: Server or cloud }
-see_also: [esp32, microcontroller, cloud-computing, firmware, server]
+  - { label: Reports to, value: Gateway, server, or cloud }
+see_also: [esp32, microcontroller, sensor, cloud-computing, firmware, server]
 related_lessons:
   - { title: "ESP32", url: /learn/intro-hardware/esp32/ }
 cite_urls:
@@ -21,13 +21,58 @@ cite_urls:
 
 **The Internet of Things (IoT)** is the network of everyday physical objects — sensors, appliances, wearables — with embedded computing and connectivity that lets them send and receive data.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 156" role="img" aria-label="Data flow of an Internet of Things system. On the left several small sensor nodes send wireless readings to a local gateway. The gateway forwards the data over the internet to a cloud service in the centre-right, which stores and analyses it. A dashboard on a phone reads results back from the cloud, and control commands flow back down to the nodes." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.2">
+    <rect x="24" y="34" width="52" height="22" rx="3" fill="currentColor" fill-opacity="0.12"/>
+    <rect x="24" y="66" width="52" height="22" rx="3" fill="currentColor" fill-opacity="0.12"/>
+    <rect x="24" y="98" width="52" height="22" rx="3" fill="currentColor" fill-opacity="0.12"/>
+    <rect x="150" y="62" width="66" height="30" rx="4" fill="currentColor" fill-opacity="0.10"/>
+    <path d="M286 60 q10 -20 32 -14 q6 -18 30 -12 q22 -4 22 16 q18 4 8 22 q4 16 -20 14 l-62 0 q-24 2 -22 -18 q-12 -8 -0 -18 z" fill="currentColor" fill-opacity="0.08"/>
+    <rect x="392" y="96" width="44" height="30" rx="4" fill="currentColor" fill-opacity="0.10"/>
+  </g>
+  <g stroke="currentColor" stroke-width="1.1" fill="none">
+    <line x1="76" y1="45" x2="150" y2="72"/>
+    <line x1="76" y1="77" x2="150" y2="77"/>
+    <line x1="76" y1="109" x2="150" y2="82"/>
+    <line x1="216" y1="77" x2="300" y2="70"/>
+    <path d="M336 100 L336 111 L392 111" stroke-dasharray="3 3"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="50" y="49" font-size="7.5">node</text>
+    <text x="50" y="81" font-size="7.5">node</text>
+    <text x="50" y="113" font-size="7.5">node</text>
+    <text x="10" y="132" font-size="7.5" text-anchor="start">cheap wireless MCUs + sensors</text>
+    <text x="183" y="74" font-size="8" font-weight="600">Gateway</text>
+    <text x="183" y="85" font-size="7" fill-opacity="0.85">local hub</text>
+    <text x="332" y="66" font-size="8.5" font-weight="600">Cloud</text>
+    <text x="332" y="78" font-size="7" fill-opacity="0.85">store + analyse</text>
+    <text x="414" y="115" font-size="7.5">app</text>
+  </g>
+</svg>
+<figcaption>A typical IoT path: cheap wireless sensor nodes report to a local gateway, which forwards the data over the internet to a cloud service that stores and analyses it; a phone app reads results back and control commands flow back down to the nodes. Each node is tiny, but collectively they number in the billions.</figcaption>
+</figure>
+
 ## Overview
 
-IoT devices are typically built on cheap wireless [microcontrollers](/reference/microcontroller/) like the [ESP32](/reference/esp32/), each reporting its readings to a [server](/reference/server/) or the [cloud](/reference/cloud-computing/). Individually each node is tiny; collectively they number in the billions.
+IoT devices are typically built on cheap wireless [microcontrollers](/reference/microcontroller/) like the [ESP32](/reference/esp32/), each reading the world through [sensors](/reference/sensor/) and reporting to a [server](/reference/server/) or the [cloud](/reference/cloud-computing/). Individually each node is tiny; collectively they number in the billions.
+
+Most systems follow a tiered shape: constrained nodes at the edge, a gateway that aggregates and relays their traffic, and a backend that stores, analyses, and visualises the data. That structure keeps the per-node hardware — and its power draw — as small as possible.
+
+## Connectivity choices
+
+Nodes reach the network in different ways depending on range, power, and data rate:
+
+| Link | Range | Power | Typical use |
+|------|-------|-------|-------------|
+| Wi-Fi | Home / building | Higher | Smart-home gadgets |
+| Bluetooth LE | Room | Low | Wearables, beacons |
+| [LoRa](/reference/lora/) / LPWAN | Kilometres | Very low | Rural/field sensors |
+| Cellular (NB-IoT/LTE-M) | Wide-area | Medium | Trackers, metering |
 
 ## Where it fits
 
-The appeal of IoT is putting just enough computing into ordinary objects to make them measurable and controllable from afar. Those same low-power wireless nodes are part of the radio landscape: their transmissions are among the signals filling the airwaves GopherTrunk listens to, though the devices themselves are far too small to run it.
+The appeal of IoT is putting just enough computing into ordinary objects to make them measurable and controllable from afar. Those same low-power wireless nodes are part of the radio landscape: their transmissions are among the signals filling the airwaves GopherTrunk listens to, though the devices themselves are far too small to run it. The tiered node-gateway-cloud pattern also mirrors a distributed SDR setup, where small capture nodes feed a central decode server.
 
 ## Sources
 

--- a/docs/reference/ios.md
+++ b/docs/reference/ios.md
@@ -4,7 +4,7 @@ title: iOS
 entry_type: concept
 category: hw-mobile
 description: iOS is Apple's mobile operating system, running on the iPhone and underpinning iPadOS and watchOS, known for tight hardware-software integration, a curated app store, and a strong security model.
-keywords: iOS, Apple, iPhone, iPadOS, Swift, App Store, Apple Silicon, mobile OS, walled garden
+keywords: iOS, Apple, iPhone, iPadOS, watchOS, Swift, App Store, Apple Silicon, mobile OS, walled garden, Secure Enclave
 autolink: true
 infobox:
   - { label: Type, value: Mobile operating system }
@@ -22,9 +22,50 @@ cite_urls:
 
 **iOS** is Apple's [mobile operating system](/reference/mobile-operating-system/), introduced with the first iPhone in 2007 and known for tight integration between Apple's hardware and software.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 180" role="img" aria-label="The iOS software stack as concentric layers. At the center is the Apple Silicon SoC with its Secure Enclave. Around it, the Darwin XNU kernel; then core services and Cocoa Touch frameworks; then the sandbox that isolates each app; and on the outside, apps installed only through the curated App Store." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" font-family="ui-sans-serif, sans-serif">
+    <circle cx="150" cy="90" r="76" stroke-width="1.2"/>
+    <circle cx="150" cy="90" r="58" stroke-width="1.2"/>
+    <circle cx="150" cy="90" r="40" stroke-width="1.2"/>
+    <circle cx="150" cy="90" r="20" stroke-width="1.2" fill-opacity="0.08" fill="currentColor"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-family="ui-sans-serif, sans-serif" font-size="8.5" text-anchor="middle">
+    <text x="150" y="93">SoC</text>
+    <text x="150" y="140">XNU kernel</text>
+    <text x="150" y="160">core services / Cocoa Touch</text>
+    <text x="150" y="24">App Store apps (curated)</text>
+  </g>
+  <g fill="currentColor" stroke="none" font-family="ui-sans-serif, sans-serif" font-size="8.5">
+    <text x="270" y="60">Apple controls both the</text>
+    <text x="270" y="74">silicon and the software,</text>
+    <text x="270" y="88">so each ring is tuned to</text>
+    <text x="270" y="102">the one inside it &#8212; a</text>
+    <text x="270" y="116">tightly sealed &#8220;walled</text>
+    <text x="270" y="130">garden.&#8221;</text>
+  </g>
+</svg>
+<figcaption>iOS wraps Apple's own silicon in concentric layers — kernel, frameworks, per-app sandbox, and a curated App Store on the outside — with Apple controlling every ring, the integration that defines its "walled garden."</figcaption>
+</figure>
+
 ## Overview
 
-iOS runs only on Apple's own devices, atop Apple Silicon [SoCs](/reference/system-on-a-chip/) descended from the [Arm architecture](/reference/arm-architecture/). Apps are written in Swift or Objective-C and distributed through a curated App Store, with a strong sandbox and hardware-backed security (Secure Enclave, code signing). The same foundation underpins iPadOS and watchOS. Because Apple controls both silicon and software, it can tune power and performance closely — a "walled garden" that trades openness for consistency.
+iOS runs only on Apple's own devices, atop Apple Silicon [SoCs](/reference/system-on-a-chip/) descended from the [Arm architecture](/reference/arm-architecture/). Apps are written in Swift or Objective-C and distributed through a curated App Store, with a strong sandbox and hardware-backed security such as the Secure Enclave and mandatory code signing.
+
+The same foundation underpins iPadOS and watchOS, so a developer's skills and much of the code carry across Apple's device line. Because Apple controls both silicon and software, it can tune power and performance closely and push updates to nearly all devices at once — a "walled garden" that trades openness for consistency and a long, uniform support window.
+
+## The Apple OS family
+
+iOS is one member of a family sharing the same core:
+
+| OS | Device | Shared core | Distinct trait |
+|----|--------|-------------|----------------|
+| iOS | iPhone | Darwin/XNU | Touch-first phone UI |
+| iPadOS | iPad | Darwin/XNU | Multitasking, pointer |
+| watchOS | Apple Watch | Darwin/XNU | Glanceable, tiny screen |
+| macOS | Mac | Darwin/XNU | Full desktop, open files |
+
+The common core is why features and frameworks propagate quickly across Apple's lineup.
 
 ## Where it fits
 

--- a/docs/reference/ip-address.md
+++ b/docs/reference/ip-address.md
@@ -3,14 +3,15 @@ slug: ip-address
 title: IP address
 entry_type: concept
 category: hw-networking
-description: An IP address is a numeric label assigned to each device on a network running the Internet Protocol, identifying the host and letting packets be routed to it.
-keywords: IP address, IPv4, IPv6, Internet Protocol, subnet, DHCP, NAT, host address
+description: An IP address is a numeric label assigned to each device on a network running the Internet Protocol, identifying the host and letting packets be routed to it; IPv4 uses 32 bits, IPv6 uses 128.
+keywords: IP address, IPv4, IPv6, Internet Protocol, subnet, subnet mask, DHCP, NAT, dotted quad, host address
 aka: [Internet Protocol address]
 infobox:
   - { label: Type, value: Network address }
   - { label: Identifies, value: A host on an IP network }
   - { label: Versions, value: IPv4 (32-bit), IPv6 (128-bit) }
   - { label: Assigned by, value: DHCP or statically }
+  - { label: Split by, value: Subnet mask (network / host) }
 see_also: [router, gateway, lan-and-wan, network-interface-card, network-switch, ethernet]
 cite_urls:
   - https://en.wikipedia.org/wiki/IP_address
@@ -18,14 +19,61 @@ cite_urls:
 
 An **IP address** is a numeric label assigned to each device on a network that uses the Internet Protocol, identifying the host so that packets can be routed to it.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 150" role="img" aria-label="An IPv4 address 192.168.1.10 broken into its four octets. Each dotted number is shown as an 8-bit binary group, and a subnet mask marks the first three octets as the network portion and the last as the host portion." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="currentColor">
+    <g stroke-width="1.3">
+      <rect x="24" y="30" width="92" height="30" fill-opacity="0.12"/>
+      <rect x="124" y="30" width="92" height="30" fill-opacity="0.12"/>
+      <rect x="224" y="30" width="92" height="30" fill-opacity="0.12"/>
+      <rect x="332" y="30" width="92" height="30" fill-opacity="0.20"/>
+    </g>
+    <g stroke="none" text-anchor="middle" font-family="ui-monospace, monospace">
+      <text x="70" y="50" font-size="12" font-weight="600">192</text>
+      <text x="170" y="50" font-size="12" font-weight="600">168</text>
+      <text x="270" y="50" font-size="12" font-weight="600">1</text>
+      <text x="378" y="50" font-size="12" font-weight="600">10</text>
+      <text x="70" y="78" font-size="8" fill-opacity="0.85">11000000</text>
+      <text x="170" y="78" font-size="8" fill-opacity="0.85">10101000</text>
+      <text x="270" y="78" font-size="8" fill-opacity="0.85">00000001</text>
+      <text x="378" y="78" font-size="8" fill-opacity="0.85">00001010</text>
+    </g>
+    <line x1="24" y1="96" x2="316" y2="96" stroke-width="1.4"/>
+    <line x1="332" y1="96" x2="424" y2="96" stroke-width="1.4"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle" font-size="8.5">
+    <text x="170" y="112" font-weight="600">network (mask 255.255.255.0)</text>
+    <text x="378" y="112" font-weight="600">host</text>
+    <text x="230" y="138" fill-opacity="0.9">four 8-bit octets = 32 bits · the subnet mask says where network ends and host begins</text>
+  </g>
+</svg>
+<figcaption>An IPv4 address is 32 bits written as four dotted octets. The subnet mask splits it into a network portion — shared by every host on the same LAN — and a host portion that uniquely names the device within that network.</figcaption>
+</figure>
+
 ## Overview
 
-IP addresses come in two versions: **IPv4**, a 32-bit value written as four dotted numbers (like `192.168.1.10`), and **IPv6**, a 128-bit form created because IPv4 addresses ran short. An address is bound to a device's [NIC](/reference/network-interface-card/) and is paired with a *subnet mask* that says which part identifies the network and which the host. Addresses are usually handed out automatically by DHCP, and on home networks private addresses are shared to the internet through a [router](/reference/router/) performing address translation (NAT).
+IP addresses come in two versions: **IPv4**, a 32-bit value written as four dotted numbers (like `192.168.1.10`), and **IPv6**, a 128-bit form created because the pool of IPv4 addresses ran short. An address is bound to a device's [NIC](/reference/network-interface-card/) and is paired with a *subnet mask* that says which leading bits identify the network and which the individual host.
+
+Addresses are usually handed out automatically by *DHCP* when a device joins a network, though servers and infrastructure often get *static* addresses that never change. On home and office networks, a block of *private* addresses is reused behind a [router](/reference/router/) that performs *network address translation* (NAT), sharing one public address among many internal devices.
+
+Routing works entirely on these numbers: every [router](/reference/router/) between source and destination looks only at the destination address to decide the next hop, which is what lets a packet cross the world without any single device knowing the whole path.
+
+## IPv4 vs IPv6
+
+The jump to IPv6 was driven by exhaustion of the older, smaller address space:
+
+| Trait | IPv4 | IPv6 |
+|-------|------|------|
+| Size | 32 bits | 128 bits |
+| Notation | Dotted decimal `192.168.1.10` | Hex groups `2001:db8::1` |
+| Address count | ~4.3 billion | ~3.4 × 10³⁸ |
+| Typical assignment | DHCP + NAT | DHCP / autoconfiguration |
+| Why it exists | Original design | Relieve IPv4 exhaustion |
 
 ## Where it fits
 
-The IP address is how a [router](/reference/router/) and [gateway](/reference/gateway/) decide where a packet should go, both within a [LAN and across a WAN](/reference/lan-and-wan/). To reach a GopherTrunk capture node — to stream its decoded calls or open its web view — you connect to its IP address on the local network, so giving such nodes stable, known addresses makes a multi-node site far easier to manage.
+The IP address is how a [router](/reference/router/) and [gateway](/reference/gateway/) decide where a packet should go, both within a [LAN and across a WAN](/reference/lan-and-wan/). To reach a GopherTrunk capture node — to stream its decoded calls or open the daemon's web console — you connect to its IP address on the local network, so giving each node a stable, known address (static, or a DHCP reservation) makes a multi-node site far easier to manage and script against.
 
 ## Sources
 
-[^wiki]: [IP address](https://en.wikipedia.org/wiki/IP_address) — Wikipedia, on the numeric label that identifies a host on an IP network.
+[^wiki]: [IP address](https://en.wikipedia.org/wiki/IP_address) — Wikipedia, on the numeric label that identifies a host, subnet masks, and IPv4 versus IPv6.

--- a/docs/reference/jack-kilby.md
+++ b/docs/reference/jack-kilby.md
@@ -4,7 +4,7 @@ title: Jack Kilby
 entry_type: person
 category: hw-people
 description: Jack Kilby (1923–2005) was an American electrical engineer at Texas Instruments who built the first working integrated circuit in 1958, later sharing the Nobel Prize in Physics for the achievement.
-keywords: Jack Kilby, integrated circuit, Texas Instruments, microchip, Nobel Prize, semiconductor
+keywords: Jack Kilby, integrated circuit, Texas Instruments, microchip, Nobel Prize, pocket calculator, semiconductor
 aka: [Jack Kilby, Jack St. Clair Kilby]
 autolink: true
 infobox:
@@ -20,6 +20,27 @@ cite_urls:
 [integrated circuit](/reference/integrated-circuit/) at Texas Instruments in 1958, a
 breakthrough that earned him a share of the 2000 Nobel Prize in Physics.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A career timeline of Jack Kilby: he joined Texas Instruments in 1958, demonstrated the first working integrated circuit that same year, co-invented the handheld electronic calculator in 1967, and shared the Nobel Prize in Physics in 2000." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="66" x2="440" y2="66" stroke="currentColor" stroke-width="1.4"/>
+  <g stroke="currentColor" fill="currentColor" stroke-width="1.2">
+    <circle cx="90" cy="66" r="6" fill="currentColor"/>
+    <circle cx="250" cy="66" r="5" fill-opacity="0.15"/>
+    <circle cx="400" cy="66" r="5" fill-opacity="0.15"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="90" y="50" font-size="9" font-weight="600">1958</text>
+    <text x="90" y="86" font-size="8">first integrated circuit</text>
+    <text x="250" y="50" font-size="9" font-weight="600">1967</text>
+    <text x="250" y="86" font-size="8">handheld calculator</text>
+    <text x="400" y="50" font-size="9" font-weight="600">2000</text>
+    <text x="400" y="86" font-size="8">Nobel Prize</text>
+    <text x="235" y="112" font-size="8" fill-opacity="0.9">a whole circuit on one slab, not wired from discrete parts</text>
+  </g>
+</svg>
+<figcaption>Kilby's line runs from a single summer's demonstration in 1958 — a complete circuit on one piece of semiconductor — to the Nobel Prize that recognised it as a foundation of modern electronics.</figcaption>
+</figure>
+
 ## Life and work
 
 In the summer of 1958, newly hired and with no vacation yet earned, Kilby stayed in a quiet
@@ -29,6 +50,13 @@ material rather than wired together from discrete parts.[^wiki] Months later
 [Robert Noyce](/reference/robert-noyce/) developed the planar silicon version that became the
 manufacturable standard; the two are recognised as independent co-inventors of the
 integrated circuit.[^wiki]
+
+| Year | Milestone |
+|------|-----------|
+| 1958 | Builds the first working integrated circuit at TI |
+| 1967 | Co-invents the handheld electronic calculator |
+| 1970 | Awarded the National Medal of Science |
+| 2000 | Shares the Nobel Prize in Physics |
 
 ## Why they matter
 
@@ -41,7 +69,8 @@ a compact SDR scanner. Kilby also co-invented the handheld electronic calculator
 ## Legacy
 
 The Nobel committee cited his "part in the invention of the integrated circuit," recognising it
-as a foundation of modern information technology.
+as a foundation of modern information technology — the manufacturing idea every chip in a radio
+receiver still descends from.
 
 ## Sources
 

--- a/docs/reference/jedec.md
+++ b/docs/reference/jedec.md
@@ -4,7 +4,7 @@ title: JEDEC
 entry_type: organization
 category: hw-organizations
 description: JEDEC is the semiconductor industry's standards body, best known for defining the memory standards such as the DDR and LPDDR specifications used in computer RAM.
-keywords: JEDEC, memory standards, DDR, LPDDR, DRAM, semiconductor standards, RAM
+keywords: JEDEC, memory standards, DDR, LPDDR, DRAM, semiconductor standards, RAM, flash
 aka: [JEDEC Solid State Technology Association]
 autolink: true
 infobox:
@@ -12,7 +12,7 @@ infobox:
   - { label: Founded, value: "1958" }
   - { label: HQ, value: Arlington, Virginia, USA }
   - { label: Makes, value: Semiconductor and memory standards }
-see_also: [random-access-memory, semiconductor, ieee]
+see_also: [random-access-memory, semiconductor, ieee, flash-memory]
 cite_urls:
   - https://www.jedec.org/
   - https://en.wikipedia.org/wiki/JEDEC
@@ -22,6 +22,30 @@ cite_urls:
 standards body, best known for defining the memory standards used in computer
 [RAM](/reference/random-access-memory/).[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="A timeline of JEDEC's DDR memory generations. Starting from the first DDR standard around 2000, each successive generation — DDR2, DDR3, DDR4, and DDR5 around 2020 — roughly doubles the peak data rate while keeping a common, vendor-neutral interface so parts stay interchangeable." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="60" x2="440" y2="60" stroke="currentColor" stroke-width="1.4"/>
+  <g stroke="currentColor" fill="currentColor" stroke-width="1.1">
+    <circle cx="55" cy="60" r="4" fill-opacity="0.15"/>
+    <circle cx="150" cy="60" r="4" fill-opacity="0.15"/>
+    <circle cx="245" cy="60" r="4" fill-opacity="0.15"/>
+    <circle cx="340" cy="60" r="5" fill-opacity="0.4"/>
+    <circle cx="415" cy="60" r="6" fill="currentColor"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="55" y="45" font-size="9" font-weight="600">DDR</text>
+    <text x="55" y="78" font-size="8">~2000</text>
+    <text x="150" y="45" font-size="9" font-weight="600">DDR2</text>
+    <text x="245" y="45" font-size="9" font-weight="600">DDR3</text>
+    <text x="340" y="45" font-size="9" font-weight="600">DDR4</text>
+    <text x="415" y="45" font-size="9" font-weight="600">DDR5</text>
+    <text x="415" y="78" font-size="8">~2020</text>
+    <text x="235" y="102" font-size="8" fill-opacity="0.9">each generation roughly doubles peak data rate — same open, vendor-neutral interface</text>
+  </g>
+</svg>
+<figcaption>JEDEC's DDR standards advance in lockstep generations — DDR through DDR5 — each roughly doubling bandwidth while holding to one open interface, so memory from any member maker stays interchangeable.</figcaption>
+</figure>
+
 ## Overview
 
 JEDEC began in 1958 as a joint standards effort within the electronics industry and is now
@@ -30,15 +54,28 @@ develops open standards through committees of competing manufacturers, ensuring 
 from different vendors are compatible.[^home]
 
 Its most visible work is the DDR (Double Data Rate) and LPDDR memory specifications that
-define the DRAM modules in PCs, servers, and phones. JEDEC also standardizes flash memory
-interfaces, packaging, and reliability test methods used across the industry.
+define the DRAM modules in PCs, servers, and phones. JEDEC also standardizes
+[flash memory](/reference/flash-memory/) interfaces, packaging, and reliability test methods
+used across the industry.
 
-## Why it matters
+## What JEDEC standardizes
+
+The association's committees cover far more than desktop RAM:
+
+| Standard family | Where it is used |
+|-----------------|------------------|
+| DDR | Main memory in PCs and servers |
+| LPDDR | Low-power memory in phones and tablets |
+| eMMC / UFS | Managed flash storage in mobile devices |
+| Packaging / JESD tests | Physical formats and reliability methods |
+
+## Where it fits
 
 Because JEDEC sets the memory standards, a DDR module from one maker works in a board
 designed for that standard, regardless of brand. Every computer that runs a GopherTrunk
 decoder — from a server holding hours of IQ data in RAM to a single-board capture node —
-depends on JEDEC-standardized memory to do it.
+depends on JEDEC-standardized memory to do it, and the sample buffers streaming through the
+DSP live in exactly that DRAM.
 
 ## Sources
 

--- a/docs/reference/jensen-huang.md
+++ b/docs/reference/jensen-huang.md
@@ -4,7 +4,7 @@ title: Jensen Huang
 entry_type: person
 category: hw-people
 description: Jensen Huang (born 1963) is a Taiwanese-American engineer who co-founded NVIDIA and led its transformation from a graphics-chip maker into the dominant supplier of GPUs for gaming, AI, and high-performance computing.
-keywords: Jensen Huang, NVIDIA, GPU, graphics processing unit, CUDA, AI accelerator
+keywords: Jensen Huang, NVIDIA, GPU, graphics processing unit, CUDA, AI accelerator, deep learning
 aka: [Jensen Huang, Jen-Hsun Huang]
 autolink: true
 infobox:
@@ -20,6 +20,30 @@ cite_urls:
 [NVIDIA](/reference/nvidia/) in 1993 and built it into the leading maker of the
 [graphics processing unit](/reference/graphics-processing-unit/), or GPU.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A timeline of Jensen Huang and NVIDIA: he co-founded the company in 1993, it coined the term GPU with the GeForce 256 in 1999, launched the CUDA parallel-computing platform in 2006, and rose to lead the AI-accelerator boom in the 2020s." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="66" x2="440" y2="66" stroke="currentColor" stroke-width="1.4"/>
+  <g stroke="currentColor" fill="currentColor" stroke-width="1.2">
+    <circle cx="60" cy="66" r="5" fill-opacity="0.15"/>
+    <circle cx="185" cy="66" r="5" fill-opacity="0.15"/>
+    <circle cx="310" cy="66" r="6" fill="currentColor"/>
+    <circle cx="420" cy="66" r="5" fill-opacity="0.15"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="60" y="50" font-size="9" font-weight="600">1993</text>
+    <text x="60" y="86" font-size="8">co-founds NVIDIA</text>
+    <text x="185" y="50" font-size="9" font-weight="600">1999</text>
+    <text x="185" y="86" font-size="8">coins "GPU"</text>
+    <text x="310" y="50" font-size="9" font-weight="600">2006</text>
+    <text x="310" y="86" font-size="8">CUDA</text>
+    <text x="420" y="50" font-size="9" font-weight="600">2020s</text>
+    <text x="420" y="86" font-size="8">AI boom</text>
+    <text x="235" y="112" font-size="8" fill-opacity="0.9">parallel math for graphics turned out to fit neural nets &#38; DSP</text>
+  </g>
+</svg>
+<figcaption>Huang's NVIDIA timeline: a graphics-card startup that named the GPU, opened it to general computing with CUDA, and rode that bet into the center of the AI era.</figcaption>
+</figure>
+
 ## Life and work
 
 Huang trained as an electrical engineer and worked in the chip industry before co-founding
@@ -28,6 +52,13 @@ executive, the company popularised the term "GPU" and steadily widened the chip'
 gaming.[^wiki] With the [CUDA](/reference/cuda/) platform, NVIDIA made the GPU's massive
 parallelism usable for general computation, positioning the company at the centre of the
 deep-learning boom and the rise of [AI accelerators](/reference/ai-accelerator/).[^wiki]
+
+| Year | Milestone |
+|------|-----------|
+| 1993 | Co-founds NVIDIA |
+| 1999 | GeForce 256 marketed as the first "GPU" |
+| 2006 | Launches the CUDA general-purpose computing platform |
+| 2020s | NVIDIA becomes a defining company of the AI era |
 
 ## Why they matter
 
@@ -40,7 +71,8 @@ through the FFTs and filtering that wideband SDR demands. Huang's bet on
 ## Legacy
 
 Under Huang, NVIDIA grew from a graphics-card startup into one of the most valuable technology
-companies in the world, with its GPUs underpinning much of modern AI infrastructure.
+companies in the world, with its GPUs underpinning much of modern AI infrastructure and much of
+the GPU-accelerated DSP that large-scale radio work increasingly leans on.
 
 ## Sources
 

--- a/docs/reference/john-von-neumann.md
+++ b/docs/reference/john-von-neumann.md
@@ -4,7 +4,7 @@ title: John von Neumann
 entry_type: person
 category: hw-people
 description: John von Neumann (1903–1957) was a Hungarian-American mathematician who described the stored-program computer architecture that bears his name and still organizes nearly every general-purpose computer.
-keywords: John von Neumann, von Neumann architecture, stored-program computer, EDVAC, computer science, mathematics
+keywords: John von Neumann, von Neumann architecture, stored-program computer, EDVAC, fetch-decode-execute, computer science, mathematics
 aka: [John von Neumann, von Neumann]
 autolink: true
 infobox:
@@ -21,6 +21,33 @@ described the stored-program computer design — the
 [von Neumann architecture](/reference/von-neumann-architecture/) — that still organises
 nearly every general-purpose machine.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A life-and-work timeline of John von Neumann: born in 1903, he formalized game theory in 1928, wrote the First Draft of a Report on the EDVAC describing the stored-program computer in 1945, built the IAS machine around 1951, and died in 1957." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="66" x2="440" y2="66" stroke="currentColor" stroke-width="1.4"/>
+  <g stroke="currentColor" fill="currentColor" stroke-width="1.2">
+    <circle cx="50" cy="66" r="4" fill-opacity="0.15"/>
+    <circle cx="150" cy="66" r="5" fill-opacity="0.15"/>
+    <circle cx="270" cy="66" r="6" fill="currentColor"/>
+    <circle cx="370" cy="66" r="5" fill-opacity="0.15"/>
+    <circle cx="430" cy="66" r="4" fill-opacity="0.15"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="50" y="50" font-size="9" font-weight="600">1903</text>
+    <text x="50" y="86" font-size="8">born</text>
+    <text x="150" y="50" font-size="9" font-weight="600">1928</text>
+    <text x="150" y="86" font-size="8">game theory</text>
+    <text x="270" y="50" font-size="9" font-weight="600">1945</text>
+    <text x="270" y="86" font-size="8">EDVAC report</text>
+    <text x="370" y="50" font-size="9" font-weight="600">1951</text>
+    <text x="370" y="86" font-size="8">IAS machine</text>
+    <text x="430" y="50" font-size="9" font-weight="600">1957</text>
+    <text x="430" y="86" font-size="8">died</text>
+    <text x="235" y="112" font-size="8" fill-opacity="0.9">program and data share one memory &#8212; software becomes soft</text>
+  </g>
+</svg>
+<figcaption>Von Neumann's arc from mathematics to computing peaks at the 1945 EDVAC report, whose single idea — storing the program in the same memory as the data — still names the architecture almost every computer follows.</figcaption>
+</figure>
+
 ## Life and work
 
 Von Neumann made foundational contributions across mathematics, physics, game theory, and
@@ -29,6 +56,13 @@ on the EDVAC" set out a machine in which program instructions and data share the
 fetched and executed by a single processing unit. That single insight — that a computer
 should store its own program — separated software from wiring and made the
 programmable computer practical.[^wiki]
+
+| Year | Milestone |
+|------|-----------|
+| 1928 | Formalises minimax game theory |
+| 1945 | "First Draft of a Report on the EDVAC" |
+| 1946 | Joins the IAS computer project |
+| 1951 | IAS machine, a widely copied stored-program design |
 
 ## Why they matter
 

--- a/docs/reference/keyboard.md
+++ b/docs/reference/keyboard.md
@@ -4,7 +4,7 @@ title: Keyboard
 entry_type: hardware
 category: hw-personal-computers
 description: A keyboard is the primary text-input peripheral for a computer, a grid of keys that send character and command codes, available in membrane and mechanical types and many layouts.
-keywords: keyboard, mechanical keyboard, membrane keyboard, QWERTY, key switch, input device
+keywords: keyboard, mechanical keyboard, membrane keyboard, QWERTY, key switch, rubber dome, input device, keycap
 infobox:
   - { label: Type, value: Input peripheral }
   - { label: Switches, value: Membrane or mechanical }
@@ -17,9 +17,58 @@ cite_urls:
 
 A **keyboard** is the primary text-input device for a computer: a grid of keys that, when pressed, send character and command codes to the machine.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 175" role="img" aria-label="A cutaway comparing two key switches. On the left a membrane key presses a keycap onto a rubber dome that collapses to close a contact on a printed sheet. On the right a mechanical key uses a spring-loaded plastic stem in a housing that snaps a metal contact closed, giving a distinct tactile press." xmlns="http://www.w3.org/2000/svg">
+  <text x="115" y="20" fill="currentColor" stroke="none" text-anchor="middle" font-size="9" font-weight="600">membrane</text>
+  <text x="345" y="20" fill="currentColor" stroke="none" text-anchor="middle" font-size="9" font-weight="600">mechanical</text>
+  <g stroke="currentColor" fill="none" stroke-width="1.3">
+    <path d="M70 40 H160 L150 58 H80 Z" fill="currentColor" fill-opacity="0.14"/>
+    <path d="M92 58 Q115 92 138 58" fill="currentColor" fill-opacity="0.08"/>
+    <path d="M60 118 H170"/>
+    <path d="M60 126 H170"/>
+    <circle cx="115" cy="118" r="3" fill="currentColor"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="7.5">
+    <text x="163" y="50">keycap</text>
+    <text x="145" y="82">rubber dome</text>
+    <text x="120" y="140">contact sheets</text>
+  </g>
+  <g stroke="currentColor" fill="none" stroke-width="1.3">
+    <path d="M300 36 H390 L380 54 H310 Z" fill="currentColor" fill-opacity="0.14"/>
+    <rect x="322" y="56" width="46" height="54" fill="currentColor" fill-opacity="0.06"/>
+    <path d="M330 58 V104 M340 58 V104" stroke-width="1"/>
+    <path d="M348 60 q6 8 0 16 q-6 8 0 16 q6 8 0 16" stroke-width="1"/>
+    <path d="M300 118 H390"/>
+    <circle cx="345" cy="118" r="3" fill="currentColor"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="7.5">
+    <text x="393" y="46">keycap</text>
+    <text x="286" y="86" text-anchor="end">stem</text>
+    <text x="360" y="86">spring</text>
+    <text x="345" y="140" text-anchor="middle">metal contact</text>
+  </g>
+  <text x="230" y="168" fill="currentColor" stroke="none" text-anchor="middle" font-size="7.5" fill-opacity="0.85">both close a switch on each keypress and report a code over USB or Bluetooth</text>
+</svg>
+<figcaption>Under every key is a switch. A membrane key collapses a rubber dome to bridge two printed contact sheets — cheap and quiet; a mechanical key uses a sprung stem that snaps a metal contact closed — pricier, but crisper and longer-lived.</figcaption>
+</figure>
+
 ## Overview
 
-A keyboard is an input [peripheral](/reference/peripheral/). Each keypress is detected and translated into a code the [operating system](/reference/operating-system/) interprets as a letter, number, or command. Two switch technologies dominate: cheap, quiet *membrane* keyboards that press a contact through a rubber dome, and *mechanical* keyboards with an individual spring-loaded switch under each key that many typists prefer for feel and durability. Layouts vary by language and preference — QWERTY is most common, with AZERTY, Dvorak, and others in use. Keyboards connect over [USB](/reference/usb/) or wirelessly via Bluetooth.
+A keyboard is an input [peripheral](/reference/peripheral/). Each keypress is detected and translated into a code the [operating system](/reference/operating-system/) interprets as a letter, number, or command. Two switch technologies dominate: cheap, quiet *membrane* keyboards that press a contact through a rubber dome, and *mechanical* keyboards with an individual spring-loaded switch under each key that many typists prefer for feel and durability.
+
+Layouts vary by language and preference — QWERTY is most common, with AZERTY, Dvorak, and others in use — and boards come in sizes from full (with a numeric pad) down to compact tenkeyless and 60% designs. Keyboards connect over [USB](/reference/usb/) or wirelessly via Bluetooth.
+
+## Membrane vs mechanical
+
+The switch type sets most of what a keyboard feels like and costs:
+
+| Trait | Membrane | Mechanical |
+|-------|----------|-----------|
+| Under each key | Shared rubber dome | Individual switch |
+| Feel | Soft, mushy | Distinct, tactile/clicky |
+| Noise | Quiet | Often louder |
+| Durability | Lower | Very high |
+| Cost | Low | Higher |
 
 ## Where it fits
 

--- a/docs/reference/lan-and-wan.md
+++ b/docs/reference/lan-and-wan.md
@@ -3,13 +3,14 @@ slug: lan-and-wan
 title: LAN & WAN
 entry_type: concept
 category: hw-networking
-description: A LAN is a network covering a small area such as a home or office, while a WAN spans long distances connecting many networks; the internet is the largest WAN.
-keywords: LAN, WAN, local area network, wide area network, internet, network scope, subnet
+description: A LAN is a network covering a small area such as a home or office, while a WAN spans long distances connecting many networks; a router joins the two, and the internet is the largest WAN.
+keywords: LAN, WAN, local area network, wide area network, internet, network scope, subnet, router, gateway, backhaul
 aka: [local area network, wide area network]
 infobox:
   - { label: LAN, value: Local area network (one site) }
   - { label: WAN, value: Wide area network (many sites) }
   - { label: Joined by, value: Router / gateway }
+  - { label: LAN reach, value: One building or campus }
   - { label: Largest WAN, value: The internet }
 see_also: [router, gateway, network-switch, ip-address, ethernet, wi-fi]
 cite_urls:
@@ -19,13 +20,61 @@ cite_urls:
 
 A **LAN** (local area network) covers a small area such as a home, office, or building, while a **WAN** (wide area network) spans long distances and ties many networks together — the internet being the largest WAN of all.[^lan][^wan]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 150" role="img" aria-label="A network topology: three local devices connect to a switch, the switch to a router, and the router reaches out across a wide-area cloud to the internet. A dashed box groups the devices and switch as the local-area network, with the router straddling the boundary to the wide-area side." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="currentColor">
+    <rect x="10" y="18" width="250" height="114" rx="6" fill="none" stroke-width="1" stroke-dasharray="4 3" stroke-opacity="0.7"/>
+    <g stroke-width="1.3">
+      <rect x="24" y="30" width="34" height="22" rx="3" fill-opacity="0.1"/>
+      <rect x="24" y="62" width="34" height="22" rx="3" fill-opacity="0.1"/>
+      <rect x="24" y="94" width="34" height="22" rx="3" fill-opacity="0.1"/>
+      <rect x="110" y="58" width="46" height="30" rx="3" fill-opacity="0.16"/>
+      <rect x="196" y="58" width="46" height="30" rx="3" fill-opacity="0.16"/>
+    </g>
+    <g stroke-width="1.2" fill="none">
+      <line x1="58" y1="41" x2="110" y2="70"/>
+      <line x1="58" y1="73" x2="110" y2="73"/>
+      <line x1="58" y1="105" x2="110" y2="76"/>
+      <line x1="156" y1="73" x2="196" y2="73"/>
+      <line x1="242" y1="73" x2="300" y2="73"/>
+    </g>
+    <path d="M312 62 q-14 0 -14 12 q-14 2 -10 14 q2 10 16 8 h58 q18 2 20 -12 q2 -14 -14 -16 q-2 -12 -18 -8 q-8 -8 -20 -2 q-10 -2 -18 4 Z" fill-opacity="0.1" stroke-width="1.3"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle" font-size="8">
+    <text x="41" y="128" font-size="8">devices</text>
+    <text x="133" y="77" font-weight="600">switch</text>
+    <text x="219" y="77" font-weight="600">router</text>
+    <text x="356" y="80" font-weight="600">internet</text>
+    <text x="135" y="16" font-size="8.5" font-weight="600">LAN (one site)</text>
+    <text x="356" y="112" font-size="8.5" font-weight="600">WAN</text>
+  </g>
+</svg>
+<figcaption>Within one site, devices reach a switch and share a single subnet — that is the LAN. The router at the edge is the gateway: its inside face joins the LAN, its outside face reaches across the WAN to other networks and the internet.</figcaption>
+</figure>
+
 ## Overview
 
-A LAN connects nearby devices over [Ethernet](/reference/ethernet/) and [Wi-Fi](/reference/wi-fi/), usually through a [switch](/reference/network-switch/) and a single [IP](/reference/ip-address/) subnet, giving high speed and low latency within one site. A WAN links such sites across cities or continents over leased lines, fiber, or the public internet, at greater distance but typically lower speed and higher latency. The boundary between them is a [router](/reference/router/) acting as the [gateway](/reference/gateway/): the LAN side faces inward, the WAN side faces out.
+A LAN connects nearby devices over [Ethernet](/reference/ethernet/) and [Wi-Fi](/reference/wi-fi/), usually through a [switch](/reference/network-switch/) and a single [IP](/reference/ip-address/) subnet, giving high speed and low latency within one site. Because every device is close and under one administration, a LAN can run fast and cheap, and traffic between two local machines never has to leave the building.
+
+A WAN links such sites across cities or continents over leased lines, fiber, or the public internet, at greater distance but typically lower speed and higher latency than a LAN. The boundary between them is a [router](/reference/router/) acting as the [gateway](/reference/gateway/): the LAN side faces inward toward local devices, the WAN side faces out toward the wider network.
+
+The distinction is one of *scope*, not of any single technology — the same Ethernet and IP that run a LAN also carry WAN traffic — and it governs where you put fast local links versus slower, costlier long-haul ones.
+
+## LAN vs WAN
+
+The two differ mainly in reach, and everything else follows from that:
+
+| Trait | LAN | WAN |
+|-------|-----|-----|
+| Span | One site or building | Cities to continents |
+| Speed | High (1–100 Gb/s) | Often lower, varies |
+| Latency | Very low | Higher |
+| Owned by | You / one organization | Carriers, shared |
+| Example | Office network | The internet |
 
 ## Where it fits
 
-The LAN-versus-WAN distinction is mostly about *scope*, and it shapes how a distributed system is laid out. A GopherTrunk site keeps its capture nodes and storage [server](/reference/server/) on a fast local LAN, then reaches across the WAN only to publish results or pull in remote feeds — keeping the bandwidth-heavy raw data local and sending just the decoded output over the slower wide-area link.
+The LAN-versus-WAN distinction shapes how a distributed system is laid out. A GopherTrunk site keeps its capture nodes and storage [server](/reference/server/) on a fast local LAN, then reaches across the WAN only to publish results or pull in remote feeds — keeping the bandwidth-heavy raw IQ data local and sending just the compact decoded output over the slower, costlier wide-area link. Getting that split right is the difference between a responsive multi-node site and one that saturates its uplink.
 
 ## Sources
 

--- a/docs/reference/laptop.md
+++ b/docs/reference/laptop.md
@@ -4,7 +4,7 @@ title: Laptop
 entry_type: hardware
 category: hw-personal-computers
 description: A laptop is a complete portable personal computer with screen, keyboard, and battery built in, trading some performance and expandability for mobility.
-keywords: laptop, notebook computer, portable computer, ultrabook, thermal throttling, mobile development machine
+keywords: laptop, notebook computer, portable computer, ultrabook, thermal throttling, mobile development machine, clamshell
 aka: [Laptop, Notebook, Notebook computer]
 infobox:
   - { label: Type, value: Portable personal computer }
@@ -22,6 +22,34 @@ cite_urls:
 **A laptop** is a complete, portable [personal computer](/reference/personal-computer/)
 with screen, keyboard, and battery built into one folding shell.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 175" role="img" aria-label="A side cutaway of an open laptop clamshell: the upper half is the display panel, and the thin lower half packs the keyboard on top of the motherboard, a large flat battery, and a small heat pipe and fan — the cramped cooling that forces the CPU to throttle under sustained load." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.4">
+    <path d="M110 24 L250 24 L250 96 L110 108 Z"/>
+    <path d="M122 34 L240 34 L240 92 L122 100 Z" fill="currentColor" fill-opacity="0.07"/>
+    <path d="M110 108 L400 108 L392 140 L102 140 Z" fill="currentColor" fill-opacity="0.05"/>
+  </g>
+  <g stroke="currentColor" fill="none" stroke-width="1">
+    <rect x="118" y="112" width="180" height="8" rx="1" fill="currentColor" fill-opacity="0.14"/>
+    <rect x="120" y="126" width="150" height="9" rx="1" fill="currentColor" fill-opacity="0.1"/>
+    <rect x="285" y="124" width="95" height="11" rx="1" fill="currentColor" fill-opacity="0.12"/>
+    <rect x="300" y="112" width="26" height="9" rx="1" fill="currentColor" fill-opacity="0.16"/>
+    <path d="M330 116 h34" stroke-dasharray="2 2"/>
+    <circle cx="372" cy="116" r="6"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="7.5">
+    <text x="180" y="66" text-anchor="middle" font-size="8" fill-opacity="0.8">display</text>
+    <text x="160" y="118" text-anchor="middle" font-size="7">keyboard</text>
+    <text x="185" y="133" text-anchor="middle" font-size="7">board</text>
+    <text x="333" y="133" text-anchor="middle" font-size="7">battery</text>
+    <text x="313" y="119" text-anchor="middle" font-size="6">CPU</text>
+    <text x="372" y="106" text-anchor="middle" font-size="6">fan</text>
+  </g>
+  <text x="230" y="165" fill="currentColor" stroke="none" text-anchor="middle" font-size="7.5" fill-opacity="0.85">everything folds into one thin battery-powered shell &#8212; little room to cool or expand</text>
+</svg>
+<figcaption>A laptop packs the whole computer into a folding shell: display in the lid, and beneath the keyboard a motherboard, a large flat battery, and a slim heat pipe and fan. The tight space limits cooling and expansion — the price of portability.</figcaption>
+</figure>
+
 ## Overview
 
 A laptop runs the same full [operating system](/reference/operating-system/) and
@@ -32,13 +60,27 @@ a thin, battery-powered case. The packaging costs something: less room to expand
 and in thin models the cooling can't keep up, so the CPU slows itself down under
 load — thermal throttling — capping sustained performance.
 
+What it buys in return is self-containment. Screen, keyboard, trackpad, battery,
+and wireless are all built in, so a laptop needs nothing but itself to be a working
+computer — the reason it has become the default machine for most people.
+
 ## Trade-offs
 
-Against the [desktop](/reference/desktop-computer/)'s power and upgrade path, the
-laptop offers one decisive thing: it goes where you go. For most developers that
-mobility outweighs the lost headroom, which is why the laptop is the default
-development machine. SDR capture work still runs fine on one; phones and tablets,
-by contrast, are screens to view the data on rather than machines to capture it.
+Against the [desktop](/reference/desktop-computer/), the laptop offers one decisive thing — it goes where you go:
+
+| Factor | Laptop | Desktop |
+|--------|--------|---------|
+| Portability | Goes anywhere | Stays put |
+| Sustained performance | Throttles when thin | Full speed |
+| Expandability | Minimal | Extensive |
+| Power source | Battery or wall | Wall only |
+| Everything built in | Yes | Separate parts |
+
+For most developers that mobility outweighs the lost headroom, which is why the laptop is the default development machine.
+
+## Where it fits
+
+A laptop is the natural field machine for GopherTrunk: SDR capture work runs fine on one, and it can go to the antenna, the car, or the site while the heavy replay and wideband DSP wait for a desktop bench. Phones and tablets, by contrast, are screens to view the data on rather than machines to capture it.
 
 ## Sources
 

--- a/docs/reference/libre-computer.md
+++ b/docs/reference/libre-computer.md
@@ -4,7 +4,7 @@ title: Libre Computer
 entry_type: hardware
 category: hw-sbc
 description: Libre Computer is a maker of single-board computers that emphasise open, mainline software support and Raspberry Pi compatibility, with boards such as Le Potato and Renegade built on Amlogic and Rockchip chips.
-keywords: Libre Computer, Le Potato, AML-S905X-CC, Renegade, open source SBC, mainline Linux, Raspberry Pi compatible, ARM single-board computer
+keywords: Libre Computer, Le Potato, AML-S905X-CC, Renegade, open source SBC, mainline Linux, Raspberry Pi compatible, ARM single-board computer, upstream drivers
 infobox:
   - { label: Type, value: Single-board computer }
   - { label: Emphasis, value: Open, mainline software }
@@ -21,13 +21,44 @@ cite_urls:
 
 **Libre Computer** is a maker of [single-board computers](/reference/single-board-computer/) that emphasise open, mainline software support and broad [Raspberry Pi](/reference/raspberry-pi/) compatibility.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 168" role="img" aria-label="Two software stacks compared as layers. The vendor-image path stacks your app on top of a frozen vendor kernel and a one-off board patch, which strands the board when the OS moves on. The Libre Computer path stacks your app on a standard OS on the mainline Linux kernel with upstreamed drivers, so ordinary current software keeps running." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.2">
+    <rect x="34" y="30" width="170" height="24" rx="3" fill-opacity="0.06" fill="currentColor"/>
+    <rect x="34" y="58" width="170" height="24" rx="3" fill-opacity="0.06" fill="currentColor"/>
+    <rect x="34" y="86" width="170" height="24" rx="3" fill-opacity="0.16" fill="currentColor" stroke-dasharray="4 3"/>
+    <rect x="34" y="114" width="170" height="24" rx="3" fill-opacity="0.06" fill="currentColor"/>
+    <rect x="256" y="30" width="170" height="24" rx="3" fill-opacity="0.06" fill="currentColor"/>
+    <rect x="256" y="58" width="170" height="24" rx="3" fill-opacity="0.06" fill="currentColor"/>
+    <rect x="256" y="86" width="170" height="52" rx="3" fill-opacity="0.16" fill="currentColor"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="8" text-anchor="middle">
+    <text x="119" y="21" font-weight="600" font-size="8.5">vendor image</text>
+    <text x="119" y="46">your app</text>
+    <text x="119" y="74">frozen vendor OS</text>
+    <text x="119" y="102" font-size="7.5">one-off board patch</text>
+    <text x="119" y="130">hardware</text>
+    <text x="341" y="21" font-weight="600" font-size="8.5">Libre Computer</text>
+    <text x="341" y="46">your app</text>
+    <text x="341" y="74">standard current OS</text>
+    <text x="341" y="108" font-weight="600">mainline Linux kernel</text>
+    <text x="341" y="122" font-size="7.5">upstreamed drivers + hardware</text>
+    <text x="119" y="156" font-size="7.5" fill-opacity="0.9">strands when the OS moves on</text>
+    <text x="341" y="156" font-size="7.5" fill-opacity="0.9">keeps working with current software</text>
+  </g>
+</svg>
+<figcaption>Many cheap boards ship a frozen vendor image with a one-off patch that strands them when the OS moves on; Libre Computer's pitch is upstream support — drivers merged into the mainline Linux kernel so standard, current software keeps running.</figcaption>
+</figure>
+
 ## Overview
 
-Boards such as Le Potato (AML-S905X-CC) and the Renegade use Amlogic and Rockchip ARM chips and copy the Pi's footprint and 40-pin [GPIO](/reference/gpio/) header. The project's distinguishing goal is upstream support: getting drivers into the mainline Linux kernel and standard bootloaders so the hardware keeps working with ordinary, current software rather than a vendor's frozen image.[^libre]
+Boards such as Le Potato (AML-S905X-CC) and the Renegade use Amlogic and Rockchip ARM chips and copy the Pi's footprint and 40-pin [GPIO](/reference/gpio/) header, so existing cases and add-ons often fit. On paper they look like any other Pi alternative — the difference is in how the software is delivered.
+
+The project's distinguishing goal is upstream support: getting drivers into the mainline Linux kernel and standard bootloaders so the hardware keeps working with ordinary, current software rather than a vendor's frozen image.[^libre] Many low-cost boards ship a one-off kernel fork that works the day you buy it but never gets updated, so a few years on the board is stuck on an old, insecure OS. Mainlined support avoids that trap because the board rides along with every new kernel release.
 
 ## Where it fits
 
-Among Pi alternatives like [Orange Pi](/reference/orange-pi/), [ODROID](/reference/odroid/), and [Rock Pi](/reference/rock-pi/), Libre Computer's pitch is longevity and trust in the software stack rather than raw specs. For an always-on GopherTrunk capture node you intend to leave in place for years, mainline support means OS updates are less likely to strand the board.
+Among Pi alternatives like [Orange Pi](/reference/orange-pi/), [ODROID](/reference/odroid/), and [Rock Pi](/reference/rock-pi/), Libre Computer's pitch is longevity and trust in the software stack rather than raw specs — you may give up a little performance per dollar in exchange for a board that stays current. For an always-on GopherTrunk capture node you intend to leave in place for years, that trade favours Libre: mainline support means OS and security updates are far less likely to strand the board, so a decode node bolted up near an antenna keeps receiving patches without a risky vendor-image migration.
 
 ## Sources
 

--- a/docs/reference/linus-torvalds.md
+++ b/docs/reference/linus-torvalds.md
@@ -4,7 +4,7 @@ title: Linus Torvalds
 entry_type: person
 category: hw-people
 description: Linus Torvalds (born 1969) is a Finnish-American software engineer who created the Linux kernel and the Git version-control system, two pillars of modern computing infrastructure.
-keywords: Linus Torvalds, Linux, kernel, Git, open source, operating system
+keywords: Linus Torvalds, Linux, kernel, Git, open source, operating system, version control
 aka: [Linus Torvalds]
 autolink: true
 infobox:
@@ -21,6 +21,30 @@ kernel — the core of an [operating system](/reference/operating-system/) now r
 everything from supercomputers to phones — and later the Git
 [version-control](/reference/version-control/) system.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A career timeline of Linus Torvalds: born in 1969, he announced the Linux kernel in 1991, released version 1.0 in 1994, wrote the Git version-control system in 2005, and continues to coordinate Linux kernel development." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="66" x2="440" y2="66" stroke="currentColor" stroke-width="1.4"/>
+  <g stroke="currentColor" fill="currentColor" stroke-width="1.2">
+    <circle cx="55" cy="66" r="4" fill-opacity="0.15"/>
+    <circle cx="175" cy="66" r="6" fill="currentColor"/>
+    <circle cx="275" cy="66" r="5" fill-opacity="0.15"/>
+    <circle cx="390" cy="66" r="5" fill-opacity="0.15"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="55" y="50" font-size="9" font-weight="600">1969</text>
+    <text x="55" y="86" font-size="8">born</text>
+    <text x="175" y="50" font-size="9" font-weight="600">1991</text>
+    <text x="175" y="86" font-size="8">Linux announced</text>
+    <text x="275" y="50" font-size="9" font-weight="600">1994</text>
+    <text x="275" y="86" font-size="8">Linux 1.0</text>
+    <text x="390" y="50" font-size="9" font-weight="600">2005</text>
+    <text x="390" y="86" font-size="8">writes Git</text>
+    <text x="235" y="112" font-size="8" fill-opacity="0.9">"just a hobby" kernel &#8594; the OS under most of the internet</text>
+  </g>
+</svg>
+<figcaption>Torvalds' timeline: a student's 1991 hobby kernel that grew into Linux, and the Git tool he later built to manage it — two projects that now sit under a large share of the world's computers.</figcaption>
+</figure>
+
 ## Life and work
 
 In 1991, as a student in Helsinki, Torvalds announced a free Unix-like kernel he was writing
@@ -29,6 +53,13 @@ into a full [operating system](/reference/operating-system/) that today powers m
 Android phones, and embedded devices.[^wiki] In 2005 he wrote Git to manage the kernel's own
 development, and it became the dominant tool for tracking source code.[^wiki] He continues to
 coordinate Linux kernel development.
+
+| Year | Milestone |
+|------|-----------|
+| 1991 | Announces the Linux kernel |
+| 1994 | Releases Linux 1.0 |
+| 2005 | Writes Git to manage kernel development |
+| ongoing | Coordinates mainline Linux kernel releases |
 
 ## Why they matter
 
@@ -41,7 +72,8 @@ source lives in a Git repository descended from Torvalds' tools.[^wiki]
 ## Legacy
 
 Linux and Git underpin a large share of the internet and of open-source software, making
-Torvalds one of the most influential figures in modern computing infrastructure.
+Torvalds one of the most influential figures in modern computing infrastructure — including the
+everyday plumbing that lets an open-source SDR project like GopherTrunk build, ship, and run.
 
 ## Sources
 

--- a/docs/reference/managed-hosting.md
+++ b/docs/reference/managed-hosting.md
@@ -4,12 +4,13 @@ title: Managed hosting
 entry_type: concept
 category: hw-servers
 description: Managed hosting is a service where the provider not only supplies the server but also handles its operating system, updates, security, and monitoring, so the customer manages only their application.
-keywords: managed hosting, fully managed, server administration, patching, monitoring, unmanaged hosting
+keywords: managed hosting, fully managed, server administration, patching, monitoring, unmanaged hosting, SLA
 aka: [Fully managed hosting]
 infobox:
   - { label: Type, value: Hosting model }
   - { label: Provider runs, value: OS, patching, security, monitoring }
   - { label: You run, value: Your application }
+  - { label: Often includes, value: Response-time SLA }
   - { label: Contrast, value: Unmanaged / self-managed }
 see_also: [web-hosting, dedicated-server, colocation, cloud-computing, software-as-a-service, server]
 related_lessons:
@@ -20,13 +21,50 @@ cite_urls:
 
 **Managed hosting** is a service in which the provider supplies the [server](/reference/server/) and also runs it for you — handling the operating system, updates, security, backups, and monitoring — so you manage only your own application.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 190" role="img" aria-label="Two responsibility stacks compared. Under unmanaged hosting the customer owns everything above the bare hardware: the operating system, patching, security, and the application. Under managed hosting the provider owns the hardware, operating system, patching, security, and monitoring, leaving the customer only the application on top." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="currentColor" font-family="ui-sans-serif, sans-serif">
+    <text x="115" y="18" text-anchor="middle" font-size="9" font-weight="600" stroke="none">UNMANAGED</text>
+    <text x="345" y="18" text-anchor="middle" font-size="9" font-weight="600" stroke="none">MANAGED</text>
+    <g stroke-width="1.2" font-size="8">
+      <rect x="30" y="28" width="170" height="24" rx="2" fill-opacity="0.20"/><text x="115" y="44" text-anchor="middle" stroke="none">Application</text>
+      <rect x="30" y="54" width="170" height="24" rx="2" fill-opacity="0.20"/><text x="115" y="70" text-anchor="middle" stroke="none">Security</text>
+      <rect x="30" y="80" width="170" height="24" rx="2" fill-opacity="0.20"/><text x="115" y="96" text-anchor="middle" stroke="none">Patching &amp; updates</text>
+      <rect x="30" y="106" width="170" height="24" rx="2" fill-opacity="0.20"/><text x="115" y="122" text-anchor="middle" stroke="none">Operating system</text>
+      <rect x="30" y="132" width="170" height="24" rx="2" fill-opacity="0.06"/><text x="115" y="148" text-anchor="middle" stroke="none">Hardware</text>
+
+      <rect x="260" y="28" width="170" height="24" rx="2" fill-opacity="0.20"/><text x="345" y="44" text-anchor="middle" stroke="none">Application</text>
+      <rect x="260" y="54" width="170" height="24" rx="2" fill-opacity="0.06"/><text x="345" y="70" text-anchor="middle" stroke="none">Security</text>
+      <rect x="260" y="80" width="170" height="24" rx="2" fill-opacity="0.06"/><text x="345" y="96" text-anchor="middle" stroke="none">Patching &amp; monitoring</text>
+      <rect x="260" y="106" width="170" height="24" rx="2" fill-opacity="0.06"/><text x="345" y="122" text-anchor="middle" stroke="none">Operating system</text>
+      <rect x="260" y="132" width="170" height="24" rx="2" fill-opacity="0.06"/><text x="345" y="148" text-anchor="middle" stroke="none">Hardware</text>
+    </g>
+    <text x="115" y="174" text-anchor="middle" font-size="7.5" stroke="none" fill-opacity="0.85">you manage all but the metal</text>
+    <text x="345" y="170" text-anchor="middle" font-size="7.5" stroke="none" fill-opacity="0.85">shaded = provider runs it</text>
+    <text x="345" y="181" text-anchor="middle" font-size="7.5" stroke="none" fill-opacity="0.85">you manage only the app</text>
+  </g>
+</svg>
+<figcaption>The line between unmanaged and managed hosting is who keeps the machine healthy: unmanaged leaves everything above the hardware to you, while managed hands the operating system, patching, security, and monitoring to the provider so you tend only your application.</figcaption>
+</figure>
+
 ## Overview
 
-The line between *managed* and *unmanaged* hosting is who keeps the machine healthy. With unmanaged hosting (the typical [dedicated server](/reference/dedicated-server/) or plain [VPS](/reference/virtual-private-server/)), the provider hands you a server and you are responsible for patching the [operating system](/reference/operating-system/), configuring services, and responding to incidents. With managed hosting, the provider does that operational work — often with guaranteed response times — and you pay a premium for it.
+The line between *managed* and *unmanaged* hosting is who keeps the machine healthy. With unmanaged hosting (the typical [dedicated server](/reference/dedicated-server/) or plain [VPS](/reference/virtual-private-server/)), the provider hands you a server and you are responsible for patching the [operating system](/reference/operating-system/), configuring services, and responding to incidents.
+
+With managed hosting, the provider does that operational work — often under a service-level agreement with guaranteed response times — and you pay a premium for it. The premium buys back time and expertise: no 3 a.m. patching, no scramble when a disk fails, and someone accountable for uptime. What you give up is some control, since you no longer touch the layers the provider now owns.
 
 ## Where it fits
 
-Managed hosting suits teams without dedicated system administrators, or those who would rather spend effort on their product than on server upkeep. It is more hands-off than [colocation](/reference/colocation/) but less abstract than [software as a service](/reference/software-as-a-service/), where even the application is run for you. For a hobbyist running GopherTrunk, managed hosting is rarely needed — the capture node is yours to tend — but it can simplify a back end that stores and serves decoded data.
+Managed and unmanaged are two ends of one axis; where a model sits determines how much operations work lands on you:
+
+| Model | Provider handles | You handle |
+|-------|------------------|------------|
+| [Colocation](/reference/colocation/) | Facility only | Hardware + all software |
+| Unmanaged server | Hardware | OS, security, app |
+| Managed hosting | Hardware, OS, security, monitoring | Application |
+| [SaaS](/reference/software-as-a-service/) | Everything, incl. the app | Just using it |
+
+Managed hosting suits teams without dedicated system administrators, or those who would rather spend effort on their product than on server upkeep. It is more hands-off than colocation but less abstract than [software as a service](/reference/software-as-a-service/), where even the application is run for you. For a hobbyist running GopherTrunk, managed hosting is rarely needed — the capture node is yours to tend — but it can simplify a back end that stores and serves decoded data.
 
 ## Sources
 

--- a/docs/reference/massimo-banzi.md
+++ b/docs/reference/massimo-banzi.md
@@ -4,7 +4,7 @@ title: Massimo Banzi
 entry_type: person
 category: hw-people
 description: Massimo Banzi (born 1968) is an Italian engineer and designer who co-founded Arduino, the open-source electronics platform that made microcontroller programming accessible to artists, students, and makers.
-keywords: Massimo Banzi, Arduino, microcontroller, open-source hardware, physical computing, electronics prototyping
+keywords: Massimo Banzi, Arduino, microcontroller, open-source hardware, physical computing, electronics prototyping, GPIO
 aka: [Massimo Banzi]
 autolink: true
 infobox:
@@ -23,6 +23,30 @@ cite_urls:
 [microcontroller](/reference/microcontroller/) programming approachable for people without an
 electronics background.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="A known-for card for Massimo Banzi: a central node labelled Massimo Banzi links out to the Arduino board, the friendly IDE and programming environment, the open-source hardware licensing model, and the microcontroller GPIO pins that connect to sensors." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.2">
+    <rect x="170" y="46" width="120" height="30" rx="5" fill="currentColor" fill-opacity="0.1"/>
+    <rect x="20" y="16" width="120" height="26" rx="5"/>
+    <rect x="20" y="80" width="120" height="26" rx="5"/>
+    <rect x="320" y="16" width="120" height="26" rx="5"/>
+    <rect x="320" y="80" width="120" height="26" rx="5"/>
+    <line x1="170" y1="55" x2="140" y2="29"/>
+    <line x1="170" y1="67" x2="140" y2="93"/>
+    <line x1="290" y1="55" x2="320" y2="29"/>
+    <line x1="290" y1="67" x2="320" y2="93"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="230" y="65" font-size="10" font-weight="600">Massimo Banzi</text>
+    <text x="80" y="32" font-size="8.5">Arduino board</text>
+    <text x="80" y="96" font-size="8.5">friendly IDE</text>
+    <text x="380" y="32" font-size="8.5">open-source HW</text>
+    <text x="380" y="96" font-size="8.5">GPIO to sensors</text>
+  </g>
+</svg>
+<figcaption>What Massimo Banzi is known for: the Arduino board, the beginner-friendly programming environment, the open-source hardware licence, and the GPIO pins that let a newcomer wire a microcontroller to the physical world.</figcaption>
+</figure>
+
 ## Life and work
 
 While teaching interaction design in Italy in the mid-2000s, Banzi and collaborators wanted a
@@ -31,6 +55,13 @@ cheap, simple board their students could use for physical-computing projects. Th
 programming environment, released as open-source hardware so anyone could copy, modify, or
 build on it.[^wiki] He went on to help lead the [Arduino company](/reference/arduino-company/)
 that grew around the platform and to champion open hardware broadly.[^wiki]
+
+| Year | Milestone |
+|------|-----------|
+| ~2005 | Co-creates Arduino at the Interaction Design Institute Ivrea |
+| 2005 | First Arduino boards released as open-source hardware |
+| 2010s | Arduino becomes a de facto standard for electronics education |
+| ongoing | Leads the Arduino company and champions open hardware |
 
 ## Why they matter
 
@@ -43,7 +74,8 @@ embedded radio projects.[^wiki]
 ## Legacy
 
 The open-source approach Banzi promoted made Arduino a de facto standard for electronics
-education and rapid prototyping, spawning countless compatible boards and shields.
+education and rapid prototyping, spawning countless compatible boards and shields — the kind of
+approachable hardware that leads many hobbyists toward embedded radio and SDR in the first place.
 
 ## Sources
 

--- a/docs/reference/microcontroller.md
+++ b/docs/reference/microcontroller.md
@@ -3,8 +3,8 @@ slug: microcontroller
 title: Microcontroller (MCU)
 entry_type: hardware
 category: hw-microcontrollers
-description: A microcontroller is a tiny, low-power computer on a single chip that combines a processor, memory, and I/O to control one device or task without an operating system.
-keywords: microcontroller, MCU, embedded, bare metal, flash memory, single chip computer, low power
+description: A microcontroller is a tiny, low-power computer on a single chip that combines a processor, memory, and I/O to control one device or task without an operating system, running its program as firmware straight from on-chip flash.
+keywords: microcontroller, MCU, embedded, bare metal, flash memory, single chip computer, low power, GPIO, on-chip peripherals
 aka: [MCU, microcontroller]
 autolink: true
 infobox:
@@ -13,7 +13,7 @@ infobox:
   - { label: Memory, value: Kilobytes of RAM, on-chip flash }
   - { label: OS, value: None (bare metal) }
   - { label: Language, value: C, C++, Rust, MicroPython }
-see_also: [arduino, esp32, gpio, firmware, single-board-computer, internet-of-things]
+see_also: [arduino, esp32, gpio, firmware, single-board-computer, sensor]
 related_lessons:
   - { title: "What is a microcontroller?", url: /learn/intro-hardware/what-is-a-microcontroller/ }
 cite_urls:
@@ -22,13 +22,64 @@ cite_urls:
 
 **A microcontroller (MCU)** is a tiny, low-power computer on a single chip that combines a processor, memory, and input/output, dedicated to controlling one device or task.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 176" role="img" aria-label="Block diagram inside a microcontroller chip. A central processor core connects over one internal bus to on-chip flash holding the program and to SRAM for working data. The same bus links a set of built-in peripherals: general-purpose I/O pins, timers with pulse-width modulation, an analog-to-digital converter, and serial interfaces. Everything is on one piece of silicon." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.3">
+    <rect x="30" y="30" width="400" height="120" rx="6" stroke-dasharray="4 3" stroke-opacity="0.7"/>
+    <rect x="60" y="52" width="86" height="40" rx="4" fill="currentColor" fill-opacity="0.14"/>
+    <rect x="60" y="104" width="86" height="26" rx="4" fill="currentColor" fill-opacity="0.08"/>
+    <rect x="170" y="104" width="86" height="26" rx="4" fill="currentColor" fill-opacity="0.08"/>
+    <rect x="280" y="46" width="66" height="24" rx="4" fill="currentColor" fill-opacity="0.10"/>
+    <rect x="356" y="46" width="66" height="24" rx="4" fill="currentColor" fill-opacity="0.10"/>
+    <rect x="280" y="104" width="66" height="26" rx="4" fill="currentColor" fill-opacity="0.10"/>
+    <rect x="356" y="104" width="66" height="26" rx="4" fill="currentColor" fill-opacity="0.10"/>
+    <line x1="70" y1="98" x2="410" y2="98" stroke-width="1.6"/>
+    <line x1="103" y1="92" x2="103" y2="98"/>
+    <line x1="103" y1="98" x2="103" y2="104"/>
+    <line x1="213" y1="98" x2="213" y2="104"/>
+    <line x1="313" y1="70" x2="313" y2="98"/>
+    <line x1="389" y1="70" x2="389" y2="98"/>
+    <line x1="313" y1="98" x2="313" y2="104"/>
+    <line x1="389" y1="98" x2="389" y2="104"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="103" y="76" font-size="9" font-weight="600">CPU core</text>
+    <text x="103" y="121" font-size="7.5">Flash</text>
+    <text x="213" y="121" font-size="7.5">SRAM</text>
+    <text x="313" y="61" font-size="7.5">GPIO</text>
+    <text x="389" y="61" font-size="7.5">Timers/PWM</text>
+    <text x="313" y="121" font-size="7.5">ADC</text>
+    <text x="389" y="121" font-size="7.5">UART/SPI/I&#178;C</text>
+    <text x="245" y="92" font-size="7.5" fill-opacity="0.85">internal bus</text>
+    <text x="230" y="166" font-size="8" fill-opacity="0.9">all on one chip &#183; no external memory or OS needed</text>
+  </g>
+</svg>
+<figcaption>Inside a microcontroller: a CPU core, program flash, and SRAM, plus built-in peripherals — GPIO, timers, an ADC, and serial ports — all sharing one internal bus on a single chip. That integration is the whole point: a complete little computer that needs no external memory and no operating system.</figcaption>
+</figure>
+
 ## Overview
 
 Unlike a full computer, a microcontroller has no operating system: your code runs bare metal as the device's [firmware](/reference/firmware/). It boots in milliseconds and can run for years on a small battery, working with only kilobytes of RAM and a modest amount of on-chip flash. That frugality is the point — an MCU does one job reliably and cheaply.
 
+The defining trait is *integration*: processor, memory, and I/O all live on one chip. Where a desktop CPU needs external RAM, storage, and support chips, a microcontroller packs enough of each to stand alone, exposing its pins as [GPIO](/reference/gpio/), an [ADC](/reference/analog-to-digital-converter/), timers, and serial buses for wiring up the outside world.
+
 ## How it differs from a single-board computer
 
-A [single-board computer](/reference/single-board-computer/) like a Raspberry Pi runs a real OS and behaves like a small PC; a microcontroller does not. MCUs are programmed in [C](/reference/c-language/), [C++](/reference/cpp-language/), and sometimes [Rust](/reference/rust-language/) or MicroPython, then flashed onto the chip. Popular families include [Arduino](/reference/arduino/) boards and the Wi-Fi-equipped [ESP32](/reference/esp32/), and most expose their pins as [GPIO](/reference/gpio/) for wiring up sensors and radios. These are the small radios that populate the airwaves GopherTrunk listens to, even though they are far too small to run GopherTrunk itself.
+A [single-board computer](/reference/single-board-computer/) like a Raspberry Pi runs a real OS and behaves like a small PC; a microcontroller does not:
+
+| Aspect | Microcontroller | Single-board computer |
+|--------|-----------------|-----------------------|
+| Memory | Kilobytes of RAM | Gigabytes |
+| Storage | On-chip flash | SD card / eMMC |
+| Software | Firmware, bare metal | Full OS (Linux) |
+| Boot | Milliseconds | Seconds |
+| Power | Milliwatts | Watts |
+
+MCUs are programmed in [C](/reference/c-language/), [C++](/reference/cpp-language/), and sometimes [Rust](/reference/rust-language/) or MicroPython, then flashed onto the chip. Popular families include [Arduino](/reference/arduino/) boards and the Wi-Fi-equipped [ESP32](/reference/esp32/).
+
+## Where it fits
+
+Microcontrollers are the small radios and controllers that populate the airwaves GopherTrunk listens to, even though they are far too small to run GopherTrunk itself. Around an SDR rig they earn their keep as helpers — reading a [sensor](/reference/sensor/), switching an antenna relay, or driving a status display over GPIO — leaving the demodulation and decoding to a general-purpose host.
 
 ## Sources
 

--- a/docs/reference/mini-pc.md
+++ b/docs/reference/mini-pc.md
@@ -4,7 +4,7 @@ title: Mini PC
 entry_type: hardware
 category: hw-personal-computers
 description: A mini PC is a small-form-factor desktop computer, often the size of a paperback, that uses low-power laptop-class parts to deliver a full PC in a fraction of the space and power of a tower.
-keywords: mini PC, small form factor, NUC, SFF PC, low-power desktop, fanless PC
+keywords: mini PC, small form factor, NUC, SFF PC, low-power desktop, fanless PC, always-on node
 aka: [Mini PC, SFF PC, NUC]
 infobox:
   - { label: Type, value: Small-form-factor PC }
@@ -20,9 +20,56 @@ cite_urls:
 
 A **mini PC** is a small-form-factor [desktop computer](/reference/desktop-computer/) — often about the size of a paperback book — that packs a full PC into a fraction of the volume and power of a conventional tower.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 175" role="img" aria-label="A mini PC drawn to scale beside a full tower: a small paperback-sized box holding a laptop-class CPU, compact RAM, and an M.2 SSD, drawing only tens of watts, next to a much larger tower for comparison, with a row of USB, HDMI, and Ethernet ports on the mini PC's back." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.2">
+    <rect x="40" y="28" width="70" height="118" rx="3" fill="currentColor" fill-opacity="0.05"/>
+  </g>
+  <text x="75" y="160" fill="currentColor" stroke="none" text-anchor="middle" font-size="7.5" fill-opacity="0.8">full tower</text>
+  <g stroke="currentColor" fill="none" stroke-width="1.5">
+    <rect x="180" y="86" width="96" height="60" rx="4" fill="currentColor" fill-opacity="0.1"/>
+  </g>
+  <g stroke="currentColor" fill="none" stroke-width="0.9">
+    <rect x="190" y="98" width="34" height="12" rx="1" fill="currentColor" fill-opacity="0.16"/>
+    <rect x="232" y="98" width="34" height="12" rx="1" fill="currentColor" fill-opacity="0.12"/>
+    <rect x="190" y="118" width="76" height="14" rx="1" fill="currentColor" fill-opacity="0.12"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle" font-size="6.5">
+    <text x="207" y="107">CPU</text>
+    <text x="249" y="107">RAM</text>
+    <text x="228" y="128">M.2 SSD</text>
+    <text x="228" y="160" font-size="7.5" fill-opacity="0.8">mini PC (~paperback)</text>
+  </g>
+  <g stroke="currentColor" fill="none" stroke-width="1.1">
+    <rect x="326" y="42" width="18" height="12" rx="1"/>
+    <rect x="326" y="60" width="18" height="12" rx="1"/>
+    <rect x="326" y="78" width="18" height="12" rx="1"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="7.5">
+    <text x="350" y="52">USB</text>
+    <text x="350" y="70">HDMI</text>
+    <text x="350" y="88">Ethernet</text>
+    <text x="380" y="112" text-anchor="middle" font-size="7.5" fill-opacity="0.85">10&#8211;65 W</text>
+  </g>
+</svg>
+<figcaption>A mini PC shrinks a full desktop to roughly the size of a paperback by using laptop-class parts — an efficient CPU, compact RAM, and an M.2 SSD — while keeping standard USB, HDMI, and Ethernet ports and sipping only tens of watts.</figcaption>
+</figure>
+
 ## Overview
 
-To shrink the box, a mini PC uses low-power laptop-class parts: an efficient [CPU](/reference/central-processing-unit/) with integrated graphics, soldered or compact [RAM](/reference/random-access-memory/), and an M.2 [SSD](/reference/solid-state-drive/). It still runs a full desktop [operating system](/reference/operating-system/) and connects to an external [monitor](/reference/computer-monitor/), [keyboard](/reference/keyboard/), and [mouse](/reference/mouse/). Intel's NUC line popularized the format; many vendors now ship similar units, some fanless and silent.
+To shrink the box, a mini PC uses low-power laptop-class parts: an efficient [CPU](/reference/central-processing-unit/) with integrated graphics, soldered or compact [RAM](/reference/random-access-memory/), and an M.2 [SSD](/reference/solid-state-drive/). It still runs a full desktop [operating system](/reference/operating-system/) and connects to an external [monitor](/reference/computer-monitor/), [keyboard](/reference/keyboard/), and [mouse](/reference/mouse/).
+
+Intel's NUC line popularized the format; many vendors now ship similar units, some fanless and silent. Because they draw so little power, mini PCs make natural always-on machines — left running a service in a corner where a tower would be too big or too loud.
+
+## How it compares
+
+A mini PC lands between a hobbyist board and a full tower:
+
+| Machine | Size | Internals | Runs desktop OS | Expansion |
+|---------|------|-----------|-----------------|-----------|
+| Single-board computer | Credit-card | ARM SoC | Sometimes | Headers/HATs |
+| Mini PC | Paperback | Laptop-class x86 | Yes | Limited |
+| Desktop tower | Large | Full desktop | Yes | Extensive |
 
 ## Where it fits
 

--- a/docs/reference/mobile-app-development.md
+++ b/docs/reference/mobile-app-development.md
@@ -23,6 +23,29 @@ cite_urls:
 [smartphones](/reference/smartphone/) and [tablets](/reference/tablet/), and it
 comes in three broad flavors.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 170" role="img" aria-label="Three approaches to mobile app development converging on the same two devices. Native code is written separately for iOS and Android. A cross-platform framework compiles one shared codebase to both. A progressive web app runs inside the browser on either. All three ultimately deliver to a phone and a tablet." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.2" font-family="ui-sans-serif, sans-serif">
+    <rect x="30" y="24" width="120" height="28" rx="3"/>
+    <rect x="30" y="70" width="120" height="28" rx="3"/>
+    <rect x="30" y="116" width="120" height="28" rx="3"/>
+    <rect x="330" y="52" width="46" height="66" rx="4"/>
+    <rect x="390" y="60" width="52" height="50" rx="4"/>
+    <line x1="150" y1="38" x2="330" y2="70"/>
+    <line x1="150" y1="84" x2="330" y2="84"/>
+    <line x1="150" y1="130" x2="330" y2="100"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-family="ui-sans-serif, sans-serif" font-size="8.5" text-anchor="middle">
+    <text x="90" y="42">native (Swift / Kotlin)</text>
+    <text x="90" y="88">cross-platform</text>
+    <text x="90" y="134">PWA (web)</text>
+    <text x="353" y="128">phone</text>
+    <text x="416" y="120">tablet</text>
+  </g>
+</svg>
+<figcaption>Native, cross-platform, and web (PWA) are three routes to the same destination — a phone and a tablet — trading how much they share against how deeply they reach the hardware.</figcaption>
+</figure>
+
 ## Overview
 
 The first is **native**: code written for one platform alone, with full hardware
@@ -33,15 +56,33 @@ such as Flutter or React Native (the latter built on
 [JavaScript](/reference/javascript-language/)). The third is the **PWA**, or
 progressive web app — a website that behaves like an installed app.
 
-## Trade-offs
+Which flavor a team picks turns on how much they value reach against depth, and
+how much duplicated work they can afford. The build work itself always happens on
+a [personal computer](/reference/personal-computer/); the phone or tablet is only
+the deployment target, tested against emulators and physical devices.
 
-The three trade off reach against depth. Native gives the deepest hardware access
-and smoothest performance but doubles the work to cover both platforms.
-Cross-platform writes once and ships everywhere at some cost in polish and
-native-feature access. A PWA is the lightest to build and needs no app store, but
-runs inside the browser's limits. The build work itself happens on a
-[personal computer](/reference/personal-computer/); the phone or tablet is the
-target.
+## Comparing the approaches
+
+The three trade reach against depth in a fairly clean way:
+
+| Approach | Codebases | Hardware access | Performance | App store |
+|----------|-----------|-----------------|-------------|-----------|
+| Native | One per platform | Full | Best | Yes |
+| Cross-platform | One shared | Most | Very good | Yes |
+| PWA | One (web) | Limited | Good | Not required |
+
+Native gives the deepest access and smoothest feel but doubles the work; a PWA
+is lightest and store-free but lives inside the browser's limits; cross-platform
+sits in between.
+
+## Where it fits
+
+Mobile app development is how the client side of a mobile experience gets built —
+including a lightweight front end for viewing data a server produces. A GopherTrunk
+decoder typically exposes a web console, so the simplest "app" for checking it from
+a phone is a PWA pointed at that console; a native or cross-platform app would only
+be worth the effort if it needed deeper device features like background
+notifications. The heavy decoding stays on the capture node, not the handset.
 
 ## Sources
 

--- a/docs/reference/mobile-operating-system.md
+++ b/docs/reference/mobile-operating-system.md
@@ -19,13 +19,55 @@ cite_urls:
 
 A **mobile operating system** is the system software that runs a phone or tablet — managing the touchscreen, radios, applications, and battery on hardware that is portable, always connected, and tightly power-constrained.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 165" role="img" aria-label="A mobile operating system shown as the middle layer between hardware and apps. At the bottom sits the SoC, radios, and sensors. In the middle, the mobile OS, whose three central jobs are labeled: a touch-first user interface, aggressive power management, and a per-app security sandbox. At the top are the user's apps, isolated from one another." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.2" font-family="ui-sans-serif, sans-serif">
+    <rect x="40" y="16" width="380" height="26" rx="3"/>
+    <rect x="40" y="56" width="380" height="52" rx="3" fill="currentColor" fill-opacity="0.05"/>
+    <rect x="40" y="122" width="380" height="26" rx="3"/>
+    <line x1="230" y1="42" x2="230" y2="56" stroke-width="0.9"/>
+    <line x1="230" y1="108" x2="230" y2="122" stroke-width="0.9"/>
+    <g stroke-width="0.9">
+      <rect x="60" y="70" width="100" height="26" rx="3"/>
+      <rect x="180" y="70" width="100" height="26" rx="3"/>
+      <rect x="300" y="70" width="100" height="26" rx="3"/>
+    </g>
+  </g>
+  <g fill="currentColor" stroke="none" font-family="ui-sans-serif, sans-serif" font-size="8.5" text-anchor="middle">
+    <text x="230" y="33">apps (isolated from one another)</text>
+    <text x="230" y="53">mobile OS</text>
+    <text x="110" y="86">touch UI</text>
+    <text x="230" y="86">power mgmt</text>
+    <text x="350" y="86">app sandbox</text>
+    <text x="230" y="139">SoC &#183; radios &#183; sensors</text>
+  </g>
+</svg>
+<figcaption>A mobile OS is the layer between the hardware and the user's apps; its three defining jobs are a touch-first interface, aggressive power management, and a sandbox that isolates every app from the rest of the device.</figcaption>
+</figure>
+
 ## Overview
 
-Like any [operating system](/reference/operating-system/), a mobile OS schedules processes, manages memory, and brokers access to hardware. What distinguishes it is the emphasis: a [touchscreen](/reference/touchscreen/)-first interface, aggressive power management to stretch [battery](/reference/battery-technology/) life, and a strict per-app sandbox so untrusted code from an app store cannot reach the rest of the device. Two platforms dominate: [Android](/reference/android/) and [iOS](/reference/ios/). Apps are built with [mobile app development](/reference/mobile-app-development/) tools specific to each.
+Like any [operating system](/reference/operating-system/), a mobile OS schedules processes, manages memory, and brokers access to hardware. What distinguishes it is the emphasis: a [touchscreen](/reference/touchscreen/)-first interface, aggressive power management to stretch [battery](/reference/battery-technology/) life, and a strict per-app sandbox so untrusted code from an app store cannot reach the rest of the device.
+
+Two platforms dominate: [Android](/reference/android/) and [iOS](/reference/ios/). Both descend from established kernels (Linux and Darwin) but reshape everything above the kernel around touch, mobility, and battery. Apps are built with [mobile app development](/reference/mobile-app-development/) tools specific to each, and both platforms curate distribution to keep the sandbox meaningful.
+
+## Mobile OS vs desktop OS
+
+The same fundamentals, tuned for very different constraints:
+
+| Concern | Mobile OS | Desktop OS |
+|---------|-----------|------------|
+| Primary input | Touchscreen | Keyboard & mouse |
+| Power | Battery-critical | Mains, relaxed |
+| App model | Sandboxed, curated | Mostly open install |
+| Background work | Tightly limited | Freely allowed |
+| Updates | Whole-OS images | Piecemeal packages |
+
+The restrictions that make a mobile OS efficient and secure are exactly what make it an awkward host for open-ended background workloads.
 
 ## Where it fits
 
-The mobile OS is the layer between the [SoC](/reference/system-on-a-chip/) and the apps a user sees. It decides which background work runs, when the cellular and Wi-Fi radios wake, and how quickly the screen sleeps — choices that directly govern how long a charge lasts. Running a full SDR decode pipeline like GopherTrunk on such a device is unusual: the power budget and locked-down background limits favor a small Linux board near the antenna instead.
+The mobile OS is the layer between the [SoC](/reference/system-on-a-chip/) and the apps a user sees. It decides which background work runs, when the cellular and Wi-Fi radios wake, and how quickly the screen sleeps — choices that directly govern how long a charge lasts. Running a full SDR decode pipeline like GopherTrunk on such a device is unusual: the power budget and locked-down background limits favor a small Linux board near the antenna, with the phone used only as a client onto it.
 
 ## Sources
 

--- a/docs/reference/modem.md
+++ b/docs/reference/modem.md
@@ -3,14 +3,15 @@ slug: modem
 title: Modem
 entry_type: hardware
 category: hw-networking
-description: A modem is a device that modulates and demodulates signals so digital data can travel over a medium not designed for it, such as a phone line, cable, or radio link.
-keywords: modem, modulator demodulator, cable modem, DSL, fiber modem, broadband
+description: A modem modulates and demodulates signals so digital data can travel over a medium not designed for it — a phone line, coax, fiber, or radio link — terminating an internet provider's line and handing clean Ethernet to a router.
+keywords: modem, modulator demodulator, cable modem, DSL, fiber modem, ONT, cellular modem, broadband, carrier
 aka: [modulator-demodulator]
 infobox:
   - { label: Type, value: Networking device }
   - { label: Job, value: Modulate / demodulate data }
   - { label: Bridges, value: Carrier medium to digital network }
   - { label: Kinds, value: Cable, DSL, fiber, cellular }
+  - { label: Hands off, value: Ethernet to a router }
 see_also: [router, cellular-modem, gateway, fiber-optic, ethernet, network-interface-card]
 cite_urls:
   - https://en.wikipedia.org/wiki/Modem
@@ -18,14 +19,61 @@ cite_urls:
 
 A **modem** (modulator–demodulator) is a device that encodes digital data onto a carrier signal for transmission over a medium not built for it, and decodes it again at the far end.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 150" role="img" aria-label="A modem's two-way signal flow: on the outbound path digital bits enter a modulator that impresses them onto a wavy carrier sent down the line; on the return path an incoming carrier enters a demodulator that recovers the original bits." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="currentColor">
+    <g stroke-width="1.3">
+      <rect x="150" y="24" width="90" height="34" rx="4" fill-opacity="0.14"/>
+      <rect x="150" y="92" width="90" height="34" rx="4" fill-opacity="0.14"/>
+    </g>
+    <g stroke-width="1.4" fill="none">
+      <line x1="20" y1="41" x2="150" y2="41"/>
+      <path d="M240 41 q10 -8 20 0 t20 0 t20 0 t20 0 t20 0 t20 0" />
+      <path d="M20 109 q10 -8 20 0 t20 0 t20 0 t20 0 t20 0 t20 0 t20 0" />
+      <line x1="240" y1="109" x2="440" y2="109"/>
+    </g>
+    <g stroke-width="1.2">
+      <path d="M143 41 l-8 -4 v8 Z" fill="currentColor"/>
+      <path d="M433 41 l8 -4 v8 Z" fill="currentColor" transform="translate(0,0)"/>
+      <path d="M247 109 l-8 -4 v8 Z" fill="currentColor"/>
+    </g>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="8.5">
+    <text x="20" y="34">digital bits</text>
+    <text x="195" y="45" text-anchor="middle" font-weight="600">modulate</text>
+    <text x="360" y="34" text-anchor="middle">carrier out (to line)</text>
+    <text x="100" y="102" text-anchor="middle">carrier in (from line)</text>
+    <text x="195" y="113" text-anchor="middle" font-weight="600">demodulate</text>
+    <text x="360" y="102" text-anchor="middle">digital bits</text>
+    <text x="230" y="142" text-anchor="middle" fill-opacity="0.9">same box, two directions: bits ⇄ a signal the medium can carry</text>
+  </g>
+</svg>
+<figcaption>A modem works both ways at once: a modulator impresses outgoing bits onto a carrier the line can carry, while a demodulator recovers incoming bits from the carrier arriving from the far end — the two halves that give the device its name.</figcaption>
+</figure>
+
 ## Overview
 
-The name describes the job: *modulate* outgoing data onto a carrier — a tone on a phone line, an RF channel on a coax cable, light on a [fiber](/reference/fiber-optic/) strand — and *demodulate* the incoming signal back into bits. A modem is what terminates the link from an internet provider and hands clean [Ethernet](/reference/ethernet/) to a [router](/reference/router/). Variants include cable, DSL, fiber (ONT), and [cellular modems](/reference/cellular-modem/) that ride a mobile network. In consumer gear the modem and router are often combined in one box.
+The name describes the job: *modulate* outgoing data onto a carrier — a tone on a phone line, an RF channel on a coax cable, light on a [fiber](/reference/fiber-optic/) strand — and *demodulate* the incoming signal back into bits. Because each medium has its own physics, the modulation scheme differs, but the role is always the same: turn a stream of bits into something the line can carry, and back again.
+
+A modem is what terminates the link from an internet provider and hands clean [Ethernet](/reference/ethernet/) to a [router](/reference/router/). It speaks the provider's line protocol on one side and standard local networking on the other, so everything downstream can ignore how the last mile actually works.
+
+Variants include cable, DSL, fiber (an ONT, or optical network terminal), and [cellular modems](/reference/cellular-modem/) that ride a mobile network. In consumer gear the modem and router are frequently combined into one box, which blurs the boundary but not the two distinct jobs inside.
+
+## Kinds of modem
+
+Each type is matched to the medium the provider runs to the premises:
+
+| Kind | Carrier medium | Modulates onto |
+|------|----------------|----------------|
+| DSL | Telephone twisted pair | High-frequency tones |
+| Cable | Coaxial cable (DOCSIS) | RF channels |
+| Fiber (ONT) | Optical fiber | Pulses of light |
+| Cellular | Radio (LTE / 5G) | RF carrier over the air |
 
 ## Where it fits
 
-The modem is the boundary between a private network and the provider's carrier medium; downstream of it the [router](/reference/router/) acts as the [gateway](/reference/gateway/) to the local [LAN](/reference/lan-and-wan/). The modulation/demodulation idea is the same one at the heart of an SDR — a GopherTrunk decoder demodulates an RF carrier into symbols, just as a modem recovers bits from a line signal.
+The modem is the boundary between a private network and the provider's carrier medium; downstream of it the [router](/reference/router/) acts as the [gateway](/reference/gateway/) to the local [LAN](/reference/lan-and-wan/). The modulation/demodulation idea is the very same one at the heart of an SDR — a GopherTrunk decoder demodulates an RF carrier into symbols exactly as a modem recovers bits from a line signal, which is why the two fields share so much vocabulary.
 
 ## Sources
 
-[^wiki]: [Modem](https://en.wikipedia.org/wiki/Modem) — Wikipedia, on the modulator-demodulator and its variants.
+[^wiki]: [Modem](https://en.wikipedia.org/wiki/Modem) — Wikipedia, on the modulator-demodulator and its cable, DSL, fiber, and cellular variants.

--- a/docs/reference/motherboard-form-factor.md
+++ b/docs/reference/motherboard-form-factor.md
@@ -4,7 +4,7 @@ title: Motherboard form factor
 entry_type: concept
 category: hw-personal-computers
 description: A motherboard form factor is a standardized specification for a motherboard's size, shape, mounting holes, and connector placement, so boards, cases, and power supplies from different makers fit together.
-keywords: form factor, ATX, Micro-ATX, Mini-ITX, E-ATX, motherboard size, mounting holes, expansion slots
+keywords: form factor, ATX, Micro-ATX, Mini-ITX, E-ATX, motherboard size, mounting holes, expansion slots, rear I/O
 aka: [Form factor]
 infobox:
   - { label: Type, value: Hardware standard }
@@ -20,9 +20,55 @@ cite_urls:
 
 A **motherboard form factor** is a standardized specification for a [motherboard](/reference/motherboard/)'s physical size, shape, mounting-hole positions, and connector placement, so that boards, cases, and power supplies from different makers fit and work together.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 200" role="img" aria-label="Three common motherboard form factors drawn to scale from a shared corner: full-size ATX at 305 by 244 millimeters, smaller Micro-ATX at 244 by 244, and tiny Mini-ITX at 170 by 170, each with corner mounting holes, showing how smaller boards trade expansion slots for a smaller footprint." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none">
+    <rect x="50" y="34" width="128" height="102" stroke-width="1.5" fill="currentColor" fill-opacity="0.04"/>
+    <rect x="50" y="34" width="102" height="102" stroke-width="1.4" fill="currentColor" fill-opacity="0.06"/>
+    <rect x="50" y="34" width="71" height="71" stroke-width="1.4" fill="currentColor" fill-opacity="0.1"/>
+  </g>
+  <g stroke="currentColor" fill="none" stroke-width="1">
+    <circle cx="56" cy="40" r="2.4"/>
+    <circle cx="172" cy="40" r="2.4"/>
+    <circle cx="56" cy="130" r="2.4"/>
+    <circle cx="172" cy="130" r="2.4"/>
+    <circle cx="115" cy="99" r="2.4"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="8">
+    <text x="126" y="126" font-weight="600">ATX</text>
+    <text x="104" y="98" font-weight="600" font-size="7.5">mATX</text>
+    <text x="76" y="66" font-weight="600" font-size="7">ITX</text>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="8">
+    <text x="250" y="46" font-weight="600">ATX</text>
+    <text x="250" y="58" font-size="7">305 &#215; 244 mm · most slots</text>
+    <text x="250" y="88" font-weight="600">Micro-ATX</text>
+    <text x="250" y="100" font-size="7">244 &#215; 244 mm · compact</text>
+    <text x="250" y="130" font-weight="600">Mini-ITX</text>
+    <text x="250" y="142" font-size="7">170 &#215; 170 mm · one slot, SFF</text>
+    <text x="250" y="176" font-size="7" fill-opacity="0.85">bigger board &#8594; more PCIe &amp; RAM slots</text>
+    <text x="250" y="188" font-size="7" fill-opacity="0.85">smaller board &#8594; smaller case</text>
+  </g>
+</svg>
+<figcaption>The common desktop form factors nest inside one another: full ATX has the most expansion, Micro-ATX trims it for a compact build, and Mini-ITX shrinks to a single slot for small-form-factor machines — all sharing the same mounting-hole and port conventions so cases and power supplies fit.</figcaption>
+</figure>
+
 ## Overview
 
-By fixing dimensions and the location of mounting holes, the rear I/O panel, expansion slots, and the power connector, a form factor turns PC parts into interchangeable building blocks. The common desktop standards descend from Intel's ATX: full-size **ATX** (~305 × 244 mm) with the most slots and ports, smaller **Micro-ATX** for compact builds, and tiny **Mini-ITX** (170 × 170 mm) for small-form-factor machines. Larger **E-ATX** boards serve high-end [workstations](/reference/workstation/). A given [computer case](/reference/computer-case/) lists which form factors it accepts, and a [power supply unit](/reference/power-supply-unit/) follows matching standards.
+By fixing dimensions and the location of mounting holes, the rear I/O panel, expansion slots, and the power connector, a form factor turns PC parts into interchangeable building blocks. Because the standards share conventions, a case advertised for ATX also accepts the smaller Micro-ATX and Mini-ITX boards that mount on the same holes.
+
+The common desktop standards descend from Intel's ATX. A given [computer case](/reference/computer-case/) lists which form factors it accepts, and a [power supply unit](/reference/power-supply-unit/) follows matching standards so the connectors line up regardless of who made each part.
+
+## Common sizes
+
+The size you pick caps how much you can add later:
+
+| Form factor | Size (mm) | PCIe slots (typ.) | RAM slots | Best for |
+|-------------|-----------|-------------------|-----------|----------|
+| E-ATX | 305 × 330 | 4–7 | 8 | High-end workstations |
+| ATX | 305 × 244 | 4–7 | 4 | Standard desktop |
+| Micro-ATX | 244 × 244 | 1–4 | 2–4 | Compact builds |
+| Mini-ITX | 170 × 170 | 1 | 2 | Small-form-factor |
 
 ## Where it fits
 

--- a/docs/reference/mouse.md
+++ b/docs/reference/mouse.md
@@ -4,7 +4,7 @@ title: Mouse
 entry_type: hardware
 category: hw-personal-computers
 description: A mouse is a hand-held pointing device that tracks motion on a surface to move an on-screen cursor, with buttons and a scroll wheel for selecting and navigating.
-keywords: mouse, pointing device, optical mouse, trackball, cursor, scroll wheel, input device
+keywords: mouse, pointing device, optical mouse, trackball, cursor, scroll wheel, input device, trackpad
 infobox:
   - { label: Type, value: Input peripheral }
   - { label: Sensing, value: Optical / laser }
@@ -17,9 +17,57 @@ cite_urls:
 
 A **mouse** is a hand-held pointing device that tracks motion across a surface to move a cursor on screen, with buttons and usually a scroll wheel for selecting and navigating.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 175" role="img" aria-label="A mouse and how it works: a top view shows the left and right buttons and a scroll wheel, a bottom callout shows the optical sensor — an LED or laser plus a tiny camera reading the surface — and an arrow maps that motion to the cursor moving on a screen." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.4">
+    <path d="M70 40 Q70 24 100 24 Q130 24 130 40 L130 120 Q130 140 100 140 Q70 140 70 120 Z" fill="currentColor" fill-opacity="0.05"/>
+    <path d="M100 24 L100 78"/>
+    <rect x="94" y="40" width="12" height="20" rx="3" fill="currentColor" fill-opacity="0.16"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="7.5">
+    <text x="55" y="48" text-anchor="end">left</text>
+    <text x="145" y="48">right</text>
+    <text x="118" y="52">wheel</text>
+  </g>
+  <g stroke="currentColor" fill="none" stroke-width="1.2">
+    <circle cx="100" cy="150" r="6"/>
+    <path d="M100 140 L100 156" stroke-dasharray="0"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="7" text-anchor="middle">
+    <text x="100" y="170">optical sensor (LED + camera)</text>
+  </g>
+  <g stroke="currentColor" fill="none" stroke-width="1.4">
+    <path d="M155 82 H250" stroke-dasharray="4 3"/>
+    <path d="M242 76 L252 82 L242 88" stroke-dasharray="0"/>
+    <rect x="270" y="34" width="160" height="96" rx="4"/>
+    <rect x="278" y="42" width="144" height="80" fill="currentColor" fill-opacity="0.06"/>
+    <path d="M330 66 L330 100 L340 92 L346 104 L352 100 L344 90 L356 88 Z" fill="currentColor" fill-opacity="0.9"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle" font-size="7.5">
+    <text x="200" y="76">motion</text>
+    <text x="350" y="118" fill-opacity="0.85">cursor on screen</text>
+  </g>
+</svg>
+<figcaption>Move the mouse and its optical sensor reads how far it has traveled across the surface; that motion drives the on-screen cursor, while the buttons and scroll wheel send their own click and scroll events to the operating system.</figcaption>
+</figure>
+
 ## Overview
 
-A mouse is an input [peripheral](/reference/peripheral/). Modern mice sense movement optically — an LED or laser plus a tiny camera reads the surface and reports how far the device has moved — replacing the old mechanical rolling ball. The position data drives the on-screen cursor, while button clicks and wheel scrolls send their own events to the [operating system](/reference/operating-system/). Variants include the trackball (a stationary ball you spin), the trackpad built into laptops, and ergonomic or high-precision gaming mice. Connection is over [USB](/reference/usb/) or Bluetooth.
+A mouse is an input [peripheral](/reference/peripheral/). Modern mice sense movement optically — an LED or laser plus a tiny camera reads the surface and reports how far the device has moved — replacing the old mechanical rolling ball. The position data drives the on-screen cursor, while button clicks and wheel scrolls send their own events to the [operating system](/reference/operating-system/).
+
+Variants trade off precision, ergonomics, and space. Connection is over [USB](/reference/usb/) or Bluetooth, and a wireless mouse adds a battery and a receiver dongle or a direct radio link.
+
+## Types
+
+The pointing job can be done several ways:
+
+| Type | How it senses | Notes |
+|------|---------------|-------|
+| Optical mouse | LED + camera on surface | Standard, cheap |
+| Laser mouse | Laser + camera | Works on more surfaces |
+| Trackball | You spin a fixed ball | Stays in one spot |
+| Trackpad | Finger on a touch surface | Built into laptops |
+| Gaming mouse | High-precision sensor, extra buttons | Tunable sensitivity |
 
 ## Where it fits
 

--- a/docs/reference/near-field-communication.md
+++ b/docs/reference/near-field-communication.md
@@ -4,7 +4,7 @@ title: Near-field communication (NFC)
 entry_type: concept
 category: hw-mobile
 description: Near-field communication (NFC) is a short-range wireless technology that lets devices exchange small amounts of data over a few centimeters, used for contactless payments, transit cards, and tap-to-pair.
-keywords: NFC, near-field communication, contactless, tap to pay, RFID, 13.56 MHz, contactless payment, tag, tap to pair
+keywords: NFC, near-field communication, contactless, tap to pay, RFID, 13.56 MHz, contactless payment, tag, tap to pair, inductive coupling
 autolink: true
 aka: [NFC]
 infobox:
@@ -19,9 +19,50 @@ cite_urls:
 
 **Near-field communication (NFC)** is a short-range wireless technology that lets two devices exchange small amounts of data when held within a few centimeters of each other.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 155" role="img" aria-label="An NFC tap shown as inductive coupling. A phone on the left carries an antenna coil driven by its NFC controller, generating a 13.56 megahertz magnetic field. A passive tag or card on the right has its own coil. When the two coils are within a few centimeters, the phone's field induces current in the tag's coil, powering it and carrying data both ways." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.2" font-family="ui-sans-serif, sans-serif">
+    <rect x="40" y="34" width="70" height="86" rx="8"/>
+    <ellipse cx="94" cy="77" rx="9" ry="26"/>
+    <ellipse cx="88" cy="77" rx="9" ry="20"/>
+    <rect x="350" y="46" width="70" height="62" rx="6"/>
+    <ellipse cx="366" cy="77" rx="9" ry="22"/>
+    <ellipse cx="372" cy="77" rx="9" ry="16"/>
+    <g stroke-width="0.9">
+      <path d="M120 60 C170 48 210 48 250 60" stroke-dasharray="4 3"/>
+      <path d="M120 77 C180 70 260 70 340 77" stroke-dasharray="4 3"/>
+      <path d="M120 94 C170 106 210 106 250 94" stroke-dasharray="4 3"/>
+    </g>
+  </g>
+  <g fill="currentColor" stroke="none" font-family="ui-sans-serif, sans-serif" font-size="8.5" text-anchor="middle">
+    <text x="75" y="136">phone &#183; NFC coil</text>
+    <text x="385" y="124">passive tag / card</text>
+    <text x="230" y="42" font-size="8">13.56 MHz magnetic field</text>
+    <text x="230" y="128" font-size="8">&#8804; ~4 cm &#183; field powers the tag</text>
+  </g>
+</svg>
+<figcaption>NFC works by inductive coupling: the phone's coil radiates a 13.56 MHz magnetic field that, within a few centimeters, induces current in a passive tag's coil — powering it and carrying data both ways without the tag needing its own battery.</figcaption>
+</figure>
+
 ## Overview
 
-NFC operates at 13.56 MHz and grew out of [RFID](/reference/radio-wave/). Its very short range is a feature: a tap is deliberate and hard to eavesdrop on. A device can act as a reader (scanning a tag or card), a tag (presenting credentials), or in peer-to-peer mode. An NFC controller in the [SoC](/reference/system-on-a-chip/), wired to a small loop antenna, can even power a passive tag through its field, so unpowered stickers and cards work. The [mobile OS](/reference/mobile-operating-system/) exposes it to apps for payments and pairing.
+NFC operates at 13.56 MHz and grew out of [RFID](/reference/radio-wave/). Its very short range is a feature, not a limit: a tap is deliberate and hard to eavesdrop on. A device can act as a reader (scanning a tag or card), a tag (presenting credentials), or in peer-to-peer mode.
+
+An NFC controller in the [SoC](/reference/system-on-a-chip/), wired to a small loop antenna, can even power a passive tag through its magnetic field, so unpowered stickers and cards work with no battery of their own. The [mobile OS](/reference/mobile-operating-system/) exposes the controller to apps for payments and pairing, usually behind a secure element that holds payment credentials.
+
+## NFC vs other short-range radios
+
+NFC deliberately trades range and speed for intimacy and simplicity:
+
+| Property | NFC | Bluetooth | Wi-Fi |
+|----------|-----|-----------|-------|
+| Range | ~4 cm | ~10 m | ~30 m+ |
+| Data rate | ~424 kbit/s | 1–3 Mbit/s | 100s Mbit/s |
+| Pairing | Instant tap | Discovery/pair | Join network |
+| Powers passive device | Yes | No | No |
+| Typical use | Pay, ticket, tap-pair | Audio, peripherals | Internet, streaming |
+
+Its slowness barely matters, because NFC carries only tiny payloads — a token, an ID, or a handoff that then continues over a faster radio.
 
 ## Where it fits
 

--- a/docs/reference/network-attached-storage.md
+++ b/docs/reference/network-attached-storage.md
@@ -4,13 +4,14 @@ title: Network-attached storage (NAS)
 entry_type: hardware
 category: hw-servers
 description: Network-attached storage (NAS) is a dedicated file-storage device that connects to a network and lets multiple clients read and write shared files over standard protocols.
-keywords: NAS, network-attached storage, file server, SMB, NFS, shared storage, RAID
+keywords: NAS, network-attached storage, file server, SMB, NFS, shared storage, RAID, SAN
 aka: [NAS]
 infobox:
   - { label: Type, value: Networked file storage }
   - { label: Serves, value: Files to many clients }
   - { label: Protocols, value: SMB, NFS, AFP }
   - { label: Often uses, value: RAID arrays }
+  - { label: Contrast, value: SAN (block storage) }
 see_also: [data-storage, raid, server, home-server, hard-disk-drive, data-center]
 related_lessons:
   - { title: "Home servers", url: /learn/intro-hardware/home-servers/ }
@@ -20,14 +21,60 @@ cite_urls:
 
 **Network-attached storage** (**NAS**) is a dedicated file-storage device that connects to a network and lets multiple clients read and write shared files over standard protocols.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 180" role="img" aria-label="A network-attached storage box in the center holds four disk drives combined into a RAID array. Three clients — a desktop, a laptop, and a phone — connect to it over the network and read and write shared files using the SMB and NFS protocols." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="currentColor" font-family="ui-sans-serif, sans-serif">
+    <rect x="185" y="52" width="90" height="76" rx="4" fill-opacity="0.10" stroke-width="1.4"/>
+    <text x="230" y="44" text-anchor="middle" font-size="9" font-weight="600" stroke="none">NAS</text>
+    <g stroke-width="1.1" fill-opacity="0.18">
+      <rect x="194" y="62" width="72" height="12" rx="1"/>
+      <rect x="194" y="78" width="72" height="12" rx="1"/>
+      <rect x="194" y="94" width="72" height="12" rx="1"/>
+      <rect x="194" y="110" width="72" height="12" rx="1"/>
+    </g>
+    <text x="230" y="140" text-anchor="middle" font-size="7" stroke="none" fill-opacity="0.85">4 disks in a RAID array</text>
+    <g stroke-width="1.3" fill="none">
+      <line x1="185" y1="72" x2="96" y2="46"/>
+      <line x1="185" y1="90" x2="96" y2="118"/>
+      <line x1="275" y1="90" x2="364" y2="80"/>
+    </g>
+    <rect x="46" y="32" width="46" height="30" rx="2" fill-opacity="0.14" stroke-width="1.1"/>
+    <text x="69" y="51" text-anchor="middle" font-size="7.5" stroke="none">desktop</text>
+    <rect x="46" y="104" width="46" height="30" rx="2" fill-opacity="0.14" stroke-width="1.1"/>
+    <text x="69" y="123" text-anchor="middle" font-size="7.5" stroke="none">laptop</text>
+    <rect x="368" y="64" width="34" height="34" rx="2" fill-opacity="0.14" stroke-width="1.1"/>
+    <text x="385" y="84" text-anchor="middle" font-size="7.5" stroke="none">phone</text>
+    <text x="140" y="70" text-anchor="middle" font-size="7" stroke="none" fill-opacity="0.8">SMB</text>
+    <text x="140" y="112" text-anchor="middle" font-size="7" stroke="none" fill-opacity="0.8">NFS</text>
+    <text x="320" y="76" text-anchor="middle" font-size="7" stroke="none" fill-opacity="0.8">SMB</text>
+    <text x="230" y="166" text-anchor="middle" font-size="8" stroke="none" fill-opacity="0.85">one shared file store many clients read and write over the network</text>
+  </g>
+</svg>
+<figcaption>A NAS combines several disks into a redundant RAID array and serves the resulting shared files to many clients at once over standard protocols like SMB and NFS — a single storage pool the whole network can reach.</figcaption>
+</figure>
+
 ## Overview
 
-A NAS is a small, specialized [server](/reference/server/) whose job is storage: a handful of drive bays, a modest CPU, and an operating system tuned for serving files over protocols such as SMB and NFS. Drives are usually combined into a [RAID](/reference/raid/) array for capacity and redundancy, so a single disk failure does not lose data. This contrasts with *storage-area network* (SAN) hardware, which serves raw block devices rather than files. Consumer NAS boxes from vendors like Synology and QNAP have made the form factor common in homes and small offices.
+A NAS is a small, specialized [server](/reference/server/) whose job is storage: a handful of drive bays, a modest CPU, and an operating system tuned for serving files over protocols such as SMB and NFS. Drives are usually combined into a [RAID](/reference/raid/) array for capacity and redundancy, so a single disk failure does not lose data.
+
+This contrasts with *storage-area network* (SAN) hardware, which serves raw block devices rather than files, and with direct-attached storage, which is wired to one machine and cannot be shared. Consumer NAS boxes from vendors like Synology and QNAP have made the form factor common in homes and small offices, while enterprise units scale to dozens of bays.
+
+## How it compares
+
+NAS is one of three ways to attach storage, distinguished by *what* they serve and *who* can reach it:
+
+| Type | Serves | Shared? | Typical use |
+|------|--------|---------|-------------|
+| NAS | Files (SMB/NFS) | Many clients | Shared documents, media, backups |
+| SAN | Raw blocks | Servers (via fabric) | Databases, virtualization |
+| Direct-attached | Blocks | One host | A single server's own disks |
+
+For most homes and small offices the file-level, network-shared NAS is the natural fit; SANs earn their complexity only when applications need raw block devices at scale.
 
 ## Where it fits
 
-A NAS is the natural shared-storage tier behind a [home server](/reference/home-server/) or in a [data center](/reference/data-center/) rack, built on ordinary [hard disk drives](/reference/hard-disk-drive/). It is a good home for GopherTrunk's bulk output — days of decoded calls and recordings can sit on a redundant NAS volume rather than the capture node's local disk, keeping the node lean.
+A NAS is the natural shared-storage tier behind a [home server](/reference/home-server/) or in a [data center](/reference/data-center/) rack, built on ordinary [hard disk drives](/reference/hard-disk-drive/). It is a good home for GopherTrunk's bulk output — days of decoded calls and IQ recordings can sit on a redundant NAS volume rather than the capture node's local disk, keeping the node lean and its storage safe from a single drive failure.
 
 ## Sources
 
-[^wiki]: [Network-attached storage](https://en.wikipedia.org/wiki/Network-attached_storage) — Wikipedia, on NAS devices and protocols.
+[^wiki]: [Network-attached storage](https://en.wikipedia.org/wiki/Network-attached_storage) — Wikipedia, on NAS devices, protocols, and RAID.

--- a/docs/reference/nvidia-jetson.md
+++ b/docs/reference/nvidia-jetson.md
@@ -4,7 +4,7 @@ title: NVIDIA Jetson
 entry_type: hardware
 category: hw-sbc
 description: NVIDIA Jetson is a family of single-board computers with a powerful onboard GPU, aimed at on-device AI and computer vision such as edge inference and robotics.
-keywords: NVIDIA Jetson, Jetson Nano, Jetson Orin, edge AI, GPU SBC, computer vision, edge inference, robotics
+keywords: NVIDIA Jetson, Jetson Nano, Jetson Orin, edge AI, GPU SBC, computer vision, edge inference, robotics, CUDA, JetPack
 autolink: true
 infobox:
   - { label: Type, value: Single-board computer (GPU) }
@@ -12,7 +12,7 @@ infobox:
   - { label: RAM, value: ~4 GB – 64 GB }
   - { label: Runs, value: Linux (JetPack) }
   - { label: Typical price, value: ~$100 – $2000+ }
-see_also: [single-board-computer, raspberry-pi, beaglebone, gpio, central-processing-unit, cloud-computing]
+see_also: [single-board-computer, raspberry-pi, beaglebone, gpio, central-processing-unit, edge-ai]
 related_lessons:
   - { title: "Raspberry Pi and family", url: /learn/intro-hardware/raspberry-pi-and-family/ }
   - { title: "SBC use cases and limits", url: /learn/intro-hardware/sbc-use-cases-and-limits/ }
@@ -22,13 +22,69 @@ cite_urls:
 
 **NVIDIA Jetson** is a family of [single-board computers](/reference/single-board-computer/) with a powerful onboard GPU, aimed at on-device AI and computer vision.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 156" role="img" aria-label="An edge inference pipeline on a Jetson. A camera feeds frames into the module, where an ARM CPU handles the operating system and a large array of GPU cores runs the neural-network math in parallel; the result — a detection or classification — comes straight back out on-device, with no cloud round trip." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.3">
+    <rect x="26" y="56" width="46" height="34" rx="4" fill-opacity="0.06" fill="currentColor"/>
+    <path d="M72 73 H104"/>
+    <rect x="104" y="30" width="220" height="90" rx="6" fill-opacity="0.05" fill="currentColor"/>
+    <rect x="120" y="48" width="60" height="54" rx="4" fill-opacity="0.12" fill="currentColor"/>
+    <g stroke-width="0.9">
+      <rect x="196" y="48" width="112" height="54" rx="4" fill-opacity="0.05" fill="currentColor"/>
+      <rect x="204" y="56" width="10" height="10" rx="1.5" fill-opacity="0.35" fill="currentColor"/>
+      <rect x="220" y="56" width="10" height="10" rx="1.5" fill-opacity="0.35" fill="currentColor"/>
+      <rect x="236" y="56" width="10" height="10" rx="1.5" fill-opacity="0.35" fill="currentColor"/>
+      <rect x="252" y="56" width="10" height="10" rx="1.5" fill-opacity="0.35" fill="currentColor"/>
+      <rect x="268" y="56" width="10" height="10" rx="1.5" fill-opacity="0.35" fill="currentColor"/>
+      <rect x="284" y="56" width="10" height="10" rx="1.5" fill-opacity="0.35" fill="currentColor"/>
+      <rect x="204" y="72" width="10" height="10" rx="1.5" fill-opacity="0.35" fill="currentColor"/>
+      <rect x="220" y="72" width="10" height="10" rx="1.5" fill-opacity="0.35" fill="currentColor"/>
+      <rect x="236" y="72" width="10" height="10" rx="1.5" fill-opacity="0.35" fill="currentColor"/>
+      <rect x="252" y="72" width="10" height="10" rx="1.5" fill-opacity="0.35" fill="currentColor"/>
+      <rect x="268" y="72" width="10" height="10" rx="1.5" fill-opacity="0.35" fill="currentColor"/>
+      <rect x="284" y="72" width="10" height="10" rx="1.5" fill-opacity="0.35" fill="currentColor"/>
+      <rect x="204" y="88" width="10" height="10" rx="1.5" fill-opacity="0.35" fill="currentColor"/>
+      <rect x="220" y="88" width="10" height="10" rx="1.5" fill-opacity="0.35" fill="currentColor"/>
+      <rect x="236" y="88" width="10" height="10" rx="1.5" fill-opacity="0.35" fill="currentColor"/>
+      <rect x="252" y="88" width="10" height="10" rx="1.5" fill-opacity="0.35" fill="currentColor"/>
+      <rect x="268" y="88" width="10" height="10" rx="1.5" fill-opacity="0.35" fill="currentColor"/>
+      <rect x="284" y="88" width="10" height="10" rx="1.5" fill-opacity="0.35" fill="currentColor"/>
+    </g>
+    <path d="M324 73 H356"/>
+    <rect x="356" y="56" width="80" height="34" rx="4" fill-opacity="0.06" fill="currentColor"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="8" text-anchor="middle">
+    <text x="49" y="77" font-size="7.5">camera</text>
+    <text x="150" y="79" font-size="8" font-weight="600">ARM</text>
+    <text x="150" y="90" font-size="6.5">OS</text>
+    <text x="252" y="40" font-size="8" font-weight="600">GPU cores</text>
+    <text x="396" y="72" font-size="7.5">detection</text>
+    <text x="396" y="84" font-size="7">on-device</text>
+    <text x="230" y="140" font-size="7.5" fill-opacity="0.9">CPU + many parallel GPU cores run inference locally — no cloud</text>
+  </g>
+</svg>
+<figcaption>A Jetson pairs a conventional ARM CPU with a large array of GPU cores; frames from a camera are classified by the neural network running across those cores and the result comes straight back on-device, without a cloud round trip.</figcaption>
+</figure>
+
 ## Overview
 
-Where a general-purpose board leans on its [CPU](/reference/central-processing-unit/), a Jetson pairs an ARM CPU with an NVIDIA GPU so that machine-learning inference can run locally — useful for robotics, cameras, and other edge devices that cannot rely on the cloud. Jetsons run Linux (NVIDIA's JetPack distribution).
+Where a general-purpose board leans on its [CPU](/reference/central-processing-unit/), a Jetson pairs an ARM CPU with an NVIDIA GPU so that machine-learning inference can run locally. Neural-network math is overwhelmingly parallel — the same operation across thousands of values — which is precisely what a GPU's many cores are built for, so a model that would crawl on a CPU runs in real time on the Jetson's silicon. This makes it a fit for robotics, cameras, and other edge devices that cannot rely on the cloud.
+
+Jetsons run Linux through NVIDIA's JetPack distribution, which bundles the CUDA and TensorRT libraries that let frameworks reach the GPU. The family spans a wide range, from the modest Jetson Nano to the far more capable Orin modules, so "a Jetson" can mean anything from a hobby board to a several-thousand-dollar module driving an autonomous machine.
+
+## How it compares
+
+| | [Raspberry Pi](/reference/raspberry-pi/) | NVIDIA Jetson | [Google Coral](/reference/google-coral/) |
+|---|-------------|---------------|--------|
+| Accelerator | None (CPU only) | CUDA GPU | Edge TPU |
+| ML flexibility | Light CPU inference | Broad, general GPU | Quantised TF Lite only |
+| Power draw | ~2–8 W | ~5–60 W | ~2 W |
+| Price | ~$15–80 | ~$100–2000+ | ~$60–150 |
+| Best role | General-purpose node | Heavy edge AI / vision | Cheap fixed inference |
 
 ## Where it fits
 
-A Jetson is more expensive and more power-hungry than a [Raspberry Pi](/reference/raspberry-pi/), so it is the SBC you reach for specifically when you need GPU compute at the edge rather than a general-purpose board. For lighter, always-on roles a Pi is usually the better fit.
+A Jetson is more expensive and more power-hungry than a [Raspberry Pi](/reference/raspberry-pi/), so it is the SBC you reach for specifically when you need GPU compute at the edge — [edge AI](/reference/edge-ai/), computer vision, robotics — rather than a general-purpose board. For lighter, always-on roles a Pi is usually the better fit; when real-time I/O matters more than compute, look at the [BeagleBone](/reference/beaglebone/). In a GopherTrunk context a Jetson is overkill for plain decoding, but its GPU could accelerate signal-classification or machine-learning analysis of decoded traffic on the same node.
 
 ## Sources
 

--- a/docs/reference/nvidia.md
+++ b/docs/reference/nvidia.md
@@ -4,7 +4,7 @@ title: NVIDIA
 entry_type: organization
 category: hw-organizations
 description: NVIDIA is an American company that designs GPUs and the CUDA platform, and is the leading supplier of accelerators for graphics, AI, and high-performance computing.
-keywords: NVIDIA, GPU, CUDA, Jetson, GeForce, AI accelerator, Jensen Huang
+keywords: NVIDIA, GPU, CUDA, Jetson, GeForce, AI accelerator, Jensen Huang, Tegra
 aka: [NVIDIA Corporation]
 autolink: true
 infobox:
@@ -12,7 +12,7 @@ infobox:
   - { label: Founded, value: "1993" }
   - { label: HQ, value: Santa Clara, California, USA }
   - { label: Makes, value: GPUs, AI accelerators, SoCs }
-see_also: [graphics-processing-unit, cuda, nvidia-jetson, jensen-huang]
+see_also: [graphics-processing-unit, cuda, nvidia-jetson, jensen-huang, tsmc, ai-accelerator]
 cite_urls:
   - https://www.nvidia.com/
   - https://en.wikipedia.org/wiki/Nvidia
@@ -21,6 +21,32 @@ cite_urls:
 **NVIDIA** is an American company founded in 1993 that designs
 [GPUs](/reference/graphics-processing-unit/) and the
 [CUDA](/reference/cuda/) software platform for general-purpose GPU computing.[^wiki]
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A timeline of NVIDIA. Founded in 1993, it popularizes the term GPU with the 1999 GeForce, turns the GPU into a general parallel processor by releasing CUDA in 2007, and in the modern era becomes the leading supplier of AI and high-performance computing accelerators." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="66" x2="440" y2="66" stroke="currentColor" stroke-width="1.4"/>
+  <g stroke="currentColor" fill="currentColor" stroke-width="1.2">
+    <circle cx="58" cy="66" r="5" fill-opacity="0.15"/>
+    <circle cx="178" cy="66" r="5" fill-opacity="0.15"/>
+    <circle cx="300" cy="66" r="6" fill="currentColor"/>
+    <circle cx="412" cy="66" r="5" fill-opacity="0.4"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="58" y="50" font-size="9" font-weight="600">1993</text>
+    <text x="58" y="86" font-size="8">founded</text>
+    <text x="178" y="50" font-size="9" font-weight="600">1999</text>
+    <text x="178" y="86" font-size="8">GeForce</text>
+    <text x="178" y="97" font-size="8">coins "GPU"</text>
+    <text x="300" y="50" font-size="9" font-weight="600">2007</text>
+    <text x="300" y="86" font-size="8">CUDA</text>
+    <text x="300" y="97" font-size="8">GPU compute</text>
+    <text x="412" y="50" font-size="9" font-weight="600">now</text>
+    <text x="412" y="86" font-size="8">AI / HPC</text>
+    <text x="412" y="97" font-size="8">accelerators</text>
+  </g>
+</svg>
+<figcaption>NVIDIA moved from graphics to general compute: the 1999 GeForce popularized the term GPU, CUDA in 2007 turned that GPU into a programmable parallel processor, and the same hardware now leads the AI and HPC accelerator market.</figcaption>
+</figure>
 
 ## Overview
 
@@ -34,12 +60,25 @@ Beyond add-in cards, NVIDIA designs Tegra systems-on-chip and the
 [Jetson](/reference/nvidia-jetson/) line of embedded AI modules, bringing GPU-accelerated
 computing to robotics, cameras, and edge devices.
 
-## Why it matters
+## Product lines
+
+NVIDIA's silicon now spans from gaming cards to data-center accelerators and edge modules:
+
+| Product line | What it is |
+|--------------|------------|
+| GeForce | Consumer GPUs for gaming and graphics |
+| Data-center GPUs | Accelerators for AI training and HPC |
+| Jetson | Embedded GPU modules for edge AI |
+| CUDA | The software platform that unlocks GPU compute |
+
+## Where it fits
 
 GPUs excel at the massively parallel arithmetic that DSP and machine learning both demand.
 An NVIDIA card can accelerate heavy SDR signal processing or run on-device classification,
-and a Jetson module can do GPU-accelerated work at the edge — for example, near an antenna
-where sending raw IQ back to a server would be impractical.
+and a Jetson [AI accelerator](/reference/ai-accelerator/) can do GPU-accelerated work at the
+edge — for example, near an antenna where sending raw IQ back to a server would be
+impractical. Like most leading-edge designs, NVIDIA's chips are fabricated by a foundry such
+as [TSMC](/reference/tsmc/).
 
 ## Sources
 

--- a/docs/reference/nvme.md
+++ b/docs/reference/nvme.md
@@ -4,7 +4,7 @@ title: NVMe
 entry_type: concept
 category: hw-storage
 description: NVMe is a high-speed protocol for accessing solid-state storage directly over a PCI Express link, replacing older disk interfaces designed for slow mechanical drives.
-keywords: NVMe, Non-Volatile Memory Express, PCIe storage, M.2, NVMe SSD, queue depth, storage protocol
+keywords: NVMe, Non-Volatile Memory Express, PCIe storage, M.2, NVMe SSD, queue depth, storage protocol, AHCI, SATA
 aka: [Non-Volatile Memory Express]
 autolink: true
 infobox:
@@ -13,20 +13,57 @@ infobox:
   - { label: Replaces, value: AHCI / SATA for SSDs }
   - { label: Form factors, value: M.2, U.2, add-in card }
   - { label: Strength, value: Low latency, deep parallelism }
-see_also: [solid-state-drive, flash-memory, pci-express, hard-disk-drive, data-storage, memory-hierarchy]
+see_also: [solid-state-drive, flash-memory, pci-express, hard-disk-drive, data-storage, memory-hierarchy, emmc]
 cite_urls:
   - https://en.wikipedia.org/wiki/NVM_Express
 ---
 
 **NVMe (Non-Volatile Memory Express)** is a protocol for talking to fast solid-state storage directly over a [PCI Express](/reference/pci-express/) link, designed from the start for flash rather than spinning disks.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 150" role="img" aria-label="Bar chart comparing peak sequential bandwidth of three storage interfaces. SATA III tops out near 550 megabytes per second, NVMe over four lanes of PCIe generation 3 reaches roughly 3500, and NVMe over four lanes of PCIe generation 4 reaches roughly 7000, drawn to scale as horizontal bars." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="currentColor">
+    <line x1="118" y1="20" x2="118" y2="122" stroke-width="1.2"/>
+    <rect x="118" y="30" width="31" height="18" fill-opacity="0.2" stroke="none"/>
+    <rect x="118" y="66" width="200" height="18" fill-opacity="0.32" stroke="none"/>
+    <rect x="118" y="102" width="400" height="18" fill-opacity="0.5" stroke="none"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="8.5">
+    <text x="112" y="43" text-anchor="end">SATA III</text>
+    <text x="112" y="79" text-anchor="end">NVMe PCIe 3.0 x4</text>
+    <text x="112" y="115" text-anchor="end">NVMe PCIe 4.0 x4</text>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="8" font-family="ui-monospace, monospace">
+    <text x="154" y="43">~550 MB/s</text>
+    <text x="323" y="79">~3500 MB/s</text>
+    <text x="405" y="115" text-anchor="end" fill-opacity="0.85">~7000 MB/s</text>
+  </g>
+  <text x="118" y="140" font-size="8" fill="currentColor" fill-opacity="0.9">peak sequential read — bars drawn to scale; the interface, not the flash, is the ceiling</text>
+</svg>
+<figcaption>SATA was built for mechanical disks and caps near 550 MB/s; NVMe rides PCI Express lanes directly, so bandwidth scales with lane count and generation instead of a legacy disk bus.</figcaption>
+</figure>
+
 ## Overview
 
-Older interfaces such as SATA used the AHCI command set, which assumed the slow seek times of a [hard disk drive](/reference/hard-disk-drive/) and offered a single shallow command queue. NVMe instead exposes many deep queues that a [flash](/reference/flash-memory/)-based [SSD](/reference/solid-state-drive/) can service in parallel, with far lower per-command overhead. Drives commonly appear as an M.2 stick plugged straight into the board's PCIe lanes, so the [CPU](/reference/central-processing-unit/) reaches the flash without a legacy disk controller in the path.
+Older interfaces such as SATA used the AHCI command set, which assumed the slow seek times of a [hard disk drive](/reference/hard-disk-drive/) and offered a single shallow command queue. NVMe instead exposes thousands of deep queues that a [flash](/reference/flash-memory/)-based [SSD](/reference/solid-state-drive/) can service in parallel, with far lower per-command overhead and no translation to a disk-era protocol. Drives commonly appear as an M.2 stick plugged straight into the board's PCIe lanes, so the [CPU](/reference/central-processing-unit/) reaches the flash without a legacy disk controller in the path.
 
-## What it's for
+Because it rides PCI Express, NVMe's ceiling rises with the link: a four-lane PCIe 3.0 slot delivers several gigabytes per second, and PCIe 4.0 and 5.0 roughly double it each generation. Latency drops too, since a command need not wait behind others in a one-deep queue. That parallelism is exactly what a busy SSD wants, since its many NAND chips can be read and written at once.
 
-NVMe exists to stop the interface from being the bottleneck once the medium is flash. A SATA SSD tops out around 550 MB/s; an NVMe drive on a few PCIe lanes runs several times that, with much lower latency under load. For a GopherTrunk node decoding many talkgroups at once, an NVMe SSD ensures that writing decoded frames and IQ snapshots never stalls the pipeline — though for a simple capture node a plain SD card or SATA SSD is usually plenty.
+## SATA vs NVMe
+
+The two interfaces target the same flash but differ in everything around it:
+
+| Aspect | SATA (AHCI) | NVMe |
+|--------|-------------|------|
+| Designed for | Mechanical disks | Flash / solid state |
+| Physical link | SATA cable | PCI Express lanes |
+| Command queues | 1 queue, 32 deep | 64K queues, 64K deep |
+| Peak bandwidth | ~550 MB/s | Several GB/s and up |
+| Latency overhead | Higher (legacy stack) | Lower |
+
+## Where it fits
+
+NVMe exists to stop the interface from being the bottleneck once the medium is flash. For a GopherTrunk node decoding many talkgroups at once, an NVMe SSD ensures that writing decoded frames and high-rate IQ snapshots never stalls the pipeline — sustained multi-gigabyte-per-second capture files land without back-pressure. For a simple single-channel capture node, though, a plain SD card, [eMMC](/reference/emmc/), or SATA SSD is usually plenty, and NVMe is worth the cost mainly when the write rate genuinely climbs.
 
 ## Sources
 

--- a/docs/reference/odroid.md
+++ b/docs/reference/odroid.md
@@ -4,7 +4,7 @@ title: ODROID
 entry_type: hardware
 category: hw-sbc
 description: ODROID is a line of single-board computers from Hardkernel of South Korea, known for higher performance than the Raspberry Pi and unusual models such as big.LITTLE and x86 boards.
-keywords: ODROID, Hardkernel, ODROID-N2, ODROID-XU4, Amlogic, big.LITTLE, high-performance SBC, Raspberry Pi alternative
+keywords: ODROID, Hardkernel, ODROID-N2, ODROID-XU4, Amlogic, big.LITTLE, high-performance SBC, Raspberry Pi alternative, heterogeneous cores
 infobox:
   - { label: Type, value: Single-board computer }
   - { label: Maker, value: Hardkernel (South Korea) }
@@ -21,13 +21,60 @@ cite_urls:
 
 **ODROID** is a line of [single-board computers](/reference/single-board-computer/) from Hardkernel of South Korea, known for offering more performance than the [Raspberry Pi](/reference/raspberry-pi/) and for some unusual designs.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 158" role="img" aria-label="A big.LITTLE core layout as used on boards like the ODROID-XU4. Four large high-performance cores sit in one cluster and four small energy-efficient cores in another, sharing memory. Light background tasks run on the little cores to save power, and heavy work spills onto the big cores for speed." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.3">
+    <rect x="30" y="34" width="180" height="70" rx="6" fill-opacity="0.05" fill="currentColor"/>
+    <rect x="44" y="50" width="34" height="34" rx="3" fill-opacity="0.22" fill="currentColor"/>
+    <rect x="84" y="50" width="34" height="34" rx="3" fill-opacity="0.22" fill="currentColor"/>
+    <rect x="124" y="50" width="34" height="34" rx="3" fill-opacity="0.22" fill="currentColor"/>
+    <rect x="164" y="50" width="34" height="34" rx="3" fill-opacity="0.22" fill="currentColor"/>
+    <rect x="250" y="34" width="180" height="70" rx="6" fill-opacity="0.05" fill="currentColor"/>
+    <rect x="264" y="58" width="20" height="20" rx="2" fill-opacity="0.1" fill="currentColor"/>
+    <rect x="292" y="58" width="20" height="20" rx="2" fill-opacity="0.1" fill="currentColor"/>
+    <rect x="320" y="58" width="20" height="20" rx="2" fill-opacity="0.1" fill="currentColor"/>
+    <rect x="348" y="58" width="20" height="20" rx="2" fill-opacity="0.1" fill="currentColor"/>
+    <path d="M210 69 H250" stroke-dasharray="4 3"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="8" text-anchor="middle">
+    <text x="120" y="26" font-size="8.5" font-weight="600">big cluster</text>
+    <text x="61" y="71" font-size="7.5">A15</text>
+    <text x="101" y="71" font-size="7.5">A15</text>
+    <text x="141" y="71" font-size="7.5">A15</text>
+    <text x="181" y="71" font-size="7.5">A15</text>
+    <text x="120" y="98" font-size="7" fill-opacity="0.9">heavy work — fast</text>
+    <text x="340" y="26" font-size="8.5" font-weight="600">LITTLE cluster</text>
+    <text x="274" y="72" font-size="6.5">A7</text>
+    <text x="302" y="72" font-size="6.5">A7</text>
+    <text x="330" y="72" font-size="6.5">A7</text>
+    <text x="358" y="72" font-size="6.5">A7</text>
+    <text x="340" y="98" font-size="7" fill-opacity="0.9">idle tasks — efficient</text>
+    <text x="230" y="132" font-size="7.5" fill-opacity="0.9">shared memory · scheduler moves work between clusters</text>
+  </g>
+</svg>
+<figcaption>Boards like the ODROID-XU4 use a big.LITTLE layout: a cluster of large high-performance cores paired with a cluster of small efficient ones, letting the scheduler run background work cheaply and burst onto the big cores when load demands.</figcaption>
+</figure>
+
 ## Overview
 
-ODROID boards mostly use Amlogic ARM chips, and over the years the line has included big.LITTLE designs (the ODROID-XU4), strong general-purpose boards (the ODROID-N2+), and even x86 models. Most run Linux or Android and expose [GPIO](/reference/gpio/) headers, though pinouts and accessories differ from the Pi's, so cases and add-ons are less universally compatible.
+ODROID boards mostly use Amlogic ARM chips, and over the years the line has included big.LITTLE designs (the ODROID-XU4), strong general-purpose boards (the ODROID-N2+), and even x86 models. The big.LITTLE arrangement pairs a cluster of fast cores with a cluster of efficient ones so the scheduler can keep light background work on the small cores and only spin up the power-hungry cores when a burst of load arrives — more sustained throughput without a proportional jump in power.
+
+Most run Linux or Android and expose [GPIO](/reference/gpio/) headers, though pinouts and accessories differ from the Pi's, so cases and add-ons are less universally compatible. Hardkernel's reputation is for squeezing genuinely higher performance out of a board at a modest price premium, which is the main reason to choose one over a stock Pi.
+
+## The family
+
+A representative slice of the ODROID line shows the range of designs:
+
+| Board | CPU | Notable trait |
+|-------|-----|---------------|
+| ODROID-XU4 | 8-core big.LITTLE (A15 + A7) | Heterogeneous cores, high throughput |
+| ODROID-N2+ | 6-core Amlogic (A73 + A53) | Strong general-purpose performance |
+| ODROID-H series | x86 (Intel) | Runs standard PC software |
+| ODROID-C | Amlogic quad-core | Lower-cost Pi-class board |
 
 ## Where it fits
 
-ODROID is the alternative you reach for when a [Raspberry Pi](/reference/raspberry-pi/) is not fast enough but a [Jetson](/reference/nvidia-jetson/) is overkill — more CPU and memory bandwidth without a price jump into GPU territory. It competes with [Rock Pi](/reference/rock-pi/) and [Orange Pi](/reference/orange-pi/). For a GopherTrunk node decoding several busy trunked systems at once, an ODROID's extra cores can keep the demodulators fed where a smaller board would fall behind.
+ODROID is the alternative you reach for when a [Raspberry Pi](/reference/raspberry-pi/) is not fast enough but a [Jetson](/reference/nvidia-jetson/) is overkill — more CPU and memory bandwidth without a price jump into GPU territory. It competes with [Rock Pi](/reference/rock-pi/) and [Orange Pi](/reference/orange-pi/). For a GopherTrunk node decoding several busy trunked systems at once, an ODROID's extra cores can keep the demodulators fed where a smaller board would fall behind, and the big.LITTLE scheduling means the board still idles efficiently between bursts of traffic.
 
 ## Sources
 

--- a/docs/reference/operating-system.md
+++ b/docs/reference/operating-system.md
@@ -3,12 +3,13 @@ slug: operating-system
 title: Operating system
 entry_type: concept
 category: hw-foundations
-description: An operating system is the software that manages a device's hardware and resources and gives other programs a consistent way to run.
-keywords: operating system, OS, Linux, Windows, macOS, Android, iOS, bare metal, kernel
+description: An operating system is the software that manages a device's hardware and resources and gives other programs a consistent, shared way to run.
+keywords: operating system, OS, kernel, Linux, Windows, macOS, Android, iOS, bare metal, scheduler, resource management
 aka: [operating system, OS]
 infobox:
   - { label: Type, value: System software }
-  - { label: Manages, value: Hardware and resources }
+  - { label: Core, value: The kernel }
+  - { label: Manages, value: CPU, memory, I/O, files }
   - { label: Examples, value: Linux, Windows, macOS, Android, iOS }
   - { label: Small devices, value: Often none (bare metal) }
 see_also: [computer-hardware, firmware, microcontroller, single-board-computer, input-output]
@@ -20,11 +21,57 @@ cite_urls:
 
 **An operating system (OS)** is the software that manages a device's hardware and resources and gives other programs a consistent, shared way to run.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 160" role="img" aria-label="A layered stack. At the bottom is computer hardware; above it the operating system kernel manages the CPU, memory, and input-output; on top run the applications, which reach the hardware only by asking the kernel through system calls." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.2">
+    <rect x="40" y="18" width="380" height="30" rx="4"/>
+    <rect x="40" y="62" width="380" height="46" rx="4" fill="currentColor" fill-opacity="0.12"/>
+    <rect x="40" y="122" width="380" height="28" rx="4"/>
+    <line x1="150" y1="62" x2="150" y2="108" stroke-opacity="0.6"/>
+    <line x1="270" y1="62" x2="270" y2="108" stroke-opacity="0.6"/>
+  </g>
+  <g stroke="currentColor" stroke-width="1.1" fill="none" stroke-opacity="0.75">
+    <path d="M120 48 v14 m-3 -6 l3 6 l3 -6"/>
+    <path d="M230 48 v14 m-3 -6 l3 6 l3 -6"/>
+    <path d="M340 48 v14 m-3 -6 l3 6 l3 -6"/>
+    <path d="M230 108 v14 m-3 -6 l3 6 l3 -6"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="230" y="37" font-size="9">Applications</text>
+    <text x="230" y="80" font-size="9" font-weight="600">Operating system (kernel)</text>
+    <text x="95" y="98" font-size="7.5" fill-opacity="0.85">schedule CPU</text>
+    <text x="210" y="98" font-size="7.5" fill-opacity="0.85">manage memory</text>
+    <text x="345" y="98" font-size="7.5" fill-opacity="0.85">handle I/O</text>
+    <text x="230" y="140" font-size="9">Computer hardware</text>
+    <text x="365" y="58" font-size="7" fill-opacity="0.8">system calls</text>
+  </g>
+</svg>
+<figcaption>Applications sit on top, hardware at the bottom, and the OS kernel in the middle — programs reach the CPU, memory, and devices only by asking the kernel, which shares those resources fairly among everything running.</figcaption>
+</figure>
+
 ## Overview
-The OS sits between [computer hardware](/reference/computer-hardware/) and the applications on top of it. It decides which program gets the [CPU](/reference/central-processing-unit/) and how much memory each one holds, handles [input/output](/reference/input-output/), and presents a uniform interface so an app need not know the exact details of the chips underneath. Common examples are Linux, Windows, and macOS on larger machines, and Android and iOS on phones.
+
+The OS sits between [computer hardware](/reference/computer-hardware/) and the applications on top of it. Its core is the *kernel*, the always-resident code that decides which program gets the [CPU](/reference/central-processing-unit/) and for how long (scheduling), how much memory each one holds and how they are kept from stepping on each other, and how requests to devices are handled through [input/output](/reference/input-output/).
+
+Just as important, the OS presents a *uniform interface* — a file system, network sockets, a way to start and stop programs — so an application need not know the exact model of disk or network card underneath. Programs ask for services through *system calls* rather than touching hardware directly, which is what lets the same app run on very different machines. Common examples are Linux, Windows, and macOS on larger computers, and Android and iOS on phones.
+
+## What an OS manages
+
+The kernel's job is really the disciplined sharing of a handful of scarce hardware resources:
+
+| Resource | What the OS does | Without it |
+|----------|------------------|-----------|
+| CPU time | Schedules which program runs when | One program could hog the machine |
+| Memory | Allocates and isolates each program's RAM | Programs corrupt each other |
+| Storage | Presents files and directories | Raw block numbers, no structure |
+| Devices | Drivers + a common I/O interface | Every app needs its own driver |
+
+By owning these, the OS lets many programs share one computer safely and lets developers write against a stable interface instead of bare metal.
 
 ## Where it fits
-Not every device has an OS. A [microcontroller](/reference/microcontroller/) often runs **bare metal** — a single program written straight to the chip as [firmware](/reference/firmware/), with no operating system in between. The larger and more general-purpose a device is, the more it leans on an OS to juggle many programs at once. (This entry is the hardware-tier view; the software-development guide covers operating systems from the programming side.)
+
+Not every device has an OS. A [microcontroller](/reference/microcontroller/) often runs **bare metal** — a single program written straight to the chip as [firmware](/reference/firmware/), with no operating system in between. The larger and more general-purpose a device is, the more it leans on an OS to juggle many programs at once. A GopherTrunk decode node typically runs Linux, whether on an x86 box or a [single-board computer](/reference/single-board-computer/) by the antenna, and relies on the OS to schedule the daemon and stream data off the SDR. (This entry is the hardware-tier view; the software-development guide covers operating systems from the programming side.)
 
 ## Sources
-[^wiki]: [Operating system](https://en.wikipedia.org/wiki/Operating_system) — Wikipedia, on OS resource management and examples.
+
+[^wiki]: [Operating system](https://en.wikipedia.org/wiki/Operating_system) — Wikipedia, on OS resource management, the kernel, scheduling, and examples.

--- a/docs/reference/optical-disc.md
+++ b/docs/reference/optical-disc.md
@@ -4,7 +4,7 @@ title: Optical disc
 entry_type: hardware
 category: hw-storage
 description: An optical disc stores data as pits read by a laser, in formats such as CD, DVD, and Blu-ray, once dominant for software and media distribution and still useful for archival.
-keywords: optical disc, CD, DVD, Blu-ray, laser, pits and lands, optical storage, archival
+keywords: optical disc, CD, DVD, Blu-ray, laser, pits and lands, optical storage, archival, wavelength
 aka: [CD, DVD, Blu-ray]
 infobox:
   - { label: Type, value: Optical non-volatile storage }
@@ -17,11 +17,57 @@ cite_urls:
   - https://en.wikipedia.org/wiki/Optical_disc
 ---
 
-An **optical disc** stores data as microscopic pits and flat lands on a reflective surface, read by a focused laser.[^wiki]
+An **optical disc** stores data as microscopic pits and flat lands on a reflective spiral track, read by a focused laser.[^wiki]
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 160" role="img" aria-label="How a laser reads an optical disc. A laser beam focuses up through the disc onto a spiral track of pits and flat lands; light reflecting from a land returns strongly while light from a pit is scattered and dimmed, and a photodetector turns that changing brightness into a bit stream." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.2">
+    <line x1="40" y1="52" x2="440" y2="52"/>
+    <line x1="40" y1="66" x2="440" y2="66"/>
+  </g>
+  <g stroke="currentColor" fill="currentColor" fill-opacity="0.22" stroke-width="1">
+    <rect x="70" y="52" width="34" height="14"/>
+    <rect x="150" y="52" width="20" height="14"/>
+    <rect x="230" y="52" width="46" height="14"/>
+    <rect x="322" y="52" width="24" height="14"/>
+    <rect x="392" y="52" width="30" height="14"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="8">
+    <text x="40" y="46" fill-opacity="0.9">reflective spiral track (unrolled): raised pits and flat lands</text>
+    <text x="126" y="46" text-anchor="middle" font-size="7.5">land</text>
+    <text x="253" y="79" text-anchor="middle" font-size="7.5">pit</text>
+  </g>
+  <g stroke="currentColor" fill="none" stroke-width="1.1">
+    <path d="M180 128 L200 66"/>
+    <path d="M220 128 L200 66"/>
+    <path d="M200 66 L200 120" stroke-dasharray="2 3" stroke-opacity="0.6"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="8">
+    <text x="200" y="140" text-anchor="middle" font-weight="600">laser + lens</text>
+    <text x="200" y="150" text-anchor="middle" font-size="7.5" fill-opacity="0.9">reads brightness &#8594; 1s and 0s</text>
+  </g>
+  <text x="345" y="140" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.85">shorter wavelength &#8594; smaller pits &#8594; more data</text>
+</svg>
+<figcaption>Data rides a single spiral of pits and lands; a focused laser reflects brightly off a land and weakly off a pit, and each generation shrank the laser's wavelength to pack smaller pits and hold more.</figcaption>
+</figure>
 
 ## Overview
 
-A laser shines on the spinning disc and a photodetector senses how the reflected light changes between pits and lands, recovering the bit stream. Successive generations shortened the laser's wavelength to pack data more tightly: the infrared CD (~700 MB), the red-laser DVD (4.7 GB and up), and the blue-violet Blu-ray (25 GB per layer and beyond). Discs come as read-only pressed media, write-once recordable, and rewritable types. Data is laid out under standard file systems so any drive can read it.
+A laser shines on the spinning disc and a photodetector senses how the reflected light changes between pits and lands, recovering the bit stream from one long spiral track. Successive generations shortened the laser's wavelength to pack data more tightly: the infrared CD, the red-laser DVD, and the blue-violet Blu-ray, whose shorter beam focuses to a smaller spot and reads finer pits. Discs come as read-only pressed media, write-once recordable, and rewritable types, and data is laid out under standard file systems so any compatible drive can read it.
+
+Optical storage is cheap to press in volume, physically robust, and needs no power to hold data, but it is slow to read and write compared with flash, and mechanical drives to spin it are increasingly rare on new machines.
+
+## DVD vs Blu-ray
+
+The jump from red to blue-violet lasers is what multiplied capacity across generations:
+
+| Format | Laser | Wavelength | Capacity (single layer) |
+|--------|-------|-----------|-------------------------|
+| CD | Infrared | 780 nm | ~700 MB |
+| DVD | Red | 650 nm | 4.7 GB |
+| Blu-ray | Blue-violet | 405 nm | 25 GB |
+
+Shorter wavelengths focus to a smaller spot, so pits shrink and the spiral packs more turns into the same disc.
 
 ## Where it fits
 

--- a/docs/reference/orange-pi.md
+++ b/docs/reference/orange-pi.md
@@ -4,7 +4,7 @@ title: Orange Pi
 entry_type: hardware
 category: hw-sbc
 description: Orange Pi is a family of low-cost single-board computers from China that mimic the Raspberry Pi form factor, often offering more cores or ports per dollar with less mature software support.
-keywords: Orange Pi, Allwinner, Rockchip, Raspberry Pi alternative, low-cost SBC, ARM single-board computer
+keywords: Orange Pi, Allwinner, Rockchip, Raspberry Pi alternative, low-cost SBC, ARM single-board computer, value SBC, vendor image
 infobox:
   - { label: Type, value: Single-board computer }
   - { label: Maker, value: Shenzhen Xunlong (China) }
@@ -20,13 +20,45 @@ cite_urls:
 
 **Orange Pi** is a family of low-cost [single-board computers](/reference/single-board-computer/) made in China that copy the [Raspberry Pi](/reference/raspberry-pi/) form factor while often packing more cores or ports per dollar.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 156" role="img" aria-label="The value trade-off of an Orange Pi shown as two facing bars. The hardware bar is long — more cores, ports, and RAM per dollar than a comparable Raspberry Pi. The software-support bar is shorter — drivers and community maturity trail the Pi, so the same hardware can take more effort to get fully working." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.2">
+    <rect x="150" y="34" width="260" height="26" rx="3" fill-opacity="0.2" fill="currentColor"/>
+    <rect x="150" y="34" width="260" height="26" rx="3"/>
+    <rect x="150" y="76" width="120" height="26" rx="3" fill-opacity="0.1" fill="currentColor"/>
+    <rect x="150" y="76" width="120" height="26" rx="3" stroke-dasharray="4 3"/>
+    <line x1="150" y1="24" x2="150" y2="118" stroke-width="1"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="8.5">
+    <text x="142" y="51" text-anchor="end">hardware / $</text>
+    <text x="142" y="93" text-anchor="end">software support</text>
+    <text x="280" y="51" text-anchor="middle" font-size="7.5">more cores · ports · RAM</text>
+    <text x="278" y="93" text-anchor="middle" font-size="7.5">trails the Pi</text>
+    <text x="280" y="138" text-anchor="middle" font-size="7.5" fill-opacity="0.9">cheap and capable — but more setup effort to get fully running</text>
+  </g>
+</svg>
+<figcaption>Orange Pi's bargain is asymmetric: you get more hardware per dollar than a comparable Raspberry Pi, but driver maturity and community support trail it, so the same board can take more effort to bring fully to life.</figcaption>
+</figure>
+
 ## Overview
 
-Orange Pi boards are built around Allwinner and Rockchip ARM chips and run Linux or Android. Many keep a Pi-style layout and a compatible 40-pin [GPIO](/reference/gpio/) header, so existing add-ons and cases often fit. The catch is software: drivers and community support are usually less mature than the Raspberry Pi's, so the same hardware can be more work to get fully running.
+Orange Pi boards are built around Allwinner and Rockchip ARM chips and run Linux or Android. Many keep a Pi-style layout and a compatible 40-pin [GPIO](/reference/gpio/) header, so existing add-ons and cases often fit — the physical compatibility is close enough that swapping an Orange Pi in for a Pi is frequently mechanical, not just electrical.
+
+The catch is software: drivers and community support are usually less mature than the Raspberry Pi's, so the same hardware can be more work to get fully running. A vendor image may be pinned to an older kernel, some peripherals may lack polished drivers, and troubleshooting leans on a smaller forum base. That gap is the price of the lower price, and how much it matters depends on whether you are running a well-trodden setup or something off the beaten path.
+
+## Value vs polish
+
+| | [Raspberry Pi](/reference/raspberry-pi/) | Orange Pi |
+|---|-------------|-----------|
+| Hardware per dollar | Baseline | Often more (cores, ports, RAM) |
+| Software maturity | Excellent, huge community | Trails, smaller community |
+| OS images | Well maintained, current | Vendor images, sometimes dated |
+| Accessory fit | Universal | Usually Pi-compatible |
+| Best when | You want it to just work | You want specs on a budget |
 
 ## Where it fits
 
-Orange Pi sits alongside [Banana Pi](/reference/banana-pi/), [Rock Pi](/reference/rock-pi/), and [Libre Computer](/reference/libre-computer/) as a Raspberry Pi alternative chosen on price or specs. For a GopherTrunk capture node where you control the OS image and just need a cheap Linux box near the antenna, an Orange Pi can be a good value — provided you accept the extra setup time over a Pi.
+Orange Pi sits alongside [Banana Pi](/reference/banana-pi/), [Rock Pi](/reference/rock-pi/), and [Libre Computer](/reference/libre-computer/) as a Raspberry Pi alternative chosen on price or specs. For a GopherTrunk capture node where you control the OS image and just need a cheap Linux box near the antenna, an Orange Pi can be good value — provided you accept the extra setup time over a Pi. It is a natural pick when you are deploying several capture nodes and the per-board saving adds up, and less attractive for a one-off build where the Pi's smooth software would save you an afternoon.
 
 ## Sources
 

--- a/docs/reference/peripheral.md
+++ b/docs/reference/peripheral.md
@@ -4,7 +4,7 @@ title: Peripheral
 entry_type: concept
 category: hw-personal-computers
 description: A peripheral is any device connected to a computer that extends its capabilities — input, output, or storage — sitting outside the core CPU and memory and communicating over a bus such as USB.
-keywords: peripheral, input device, output device, I/O device, USB device, external device
+keywords: peripheral, input device, output device, I/O device, USB device, external device, storage peripheral
 infobox:
   - { label: Type, value: Connected device class }
   - { label: Categories, value: Input, output, storage }
@@ -17,9 +17,63 @@ cite_urls:
 
 A **peripheral** is any device connected to a computer that extends what it can do, sitting outside the core [CPU](/reference/central-processing-unit/) and memory and communicating with them over a bus.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 200" role="img" aria-label="A hub-and-spoke map of peripherals around a computer. The computer sits at the center; input peripherals like a keyboard, mouse, and webcam feed data in on the left, output peripherals like a monitor, printer, and speakers send results out on the right, and a storage peripheral hangs below — all connected over buses such as USB, Bluetooth, or PCIe." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.5">
+    <rect x="190" y="82" width="80" height="42" rx="4" fill="currentColor" fill-opacity="0.12"/>
+  </g>
+  <text x="230" y="100" fill="currentColor" stroke="none" text-anchor="middle" font-size="8" font-weight="600">computer</text>
+  <text x="230" y="113" fill="currentColor" stroke="none" text-anchor="middle" font-size="6.5" fill-opacity="0.85">CPU + memory</text>
+  <g stroke="currentColor" fill="none" stroke-width="1.1">
+    <rect x="30" y="26" width="66" height="20" rx="3"/>
+    <rect x="30" y="64" width="66" height="20" rx="3"/>
+    <rect x="30" y="102" width="66" height="20" rx="3"/>
+    <rect x="364" y="26" width="70" height="20" rx="3"/>
+    <rect x="364" y="64" width="70" height="20" rx="3"/>
+    <rect x="364" y="102" width="70" height="20" rx="3"/>
+    <rect x="197" y="156" width="66" height="20" rx="3"/>
+  </g>
+  <g stroke="currentColor" fill="none" stroke-width="1" stroke-dasharray="4 3">
+    <path d="M96 36 C150 40 160 90 190 96"/>
+    <path d="M96 74 C150 78 165 96 190 100"/>
+    <path d="M96 112 C150 108 170 106 190 106"/>
+    <path d="M364 36 C310 40 300 90 270 96"/>
+    <path d="M364 74 C310 78 295 96 270 100"/>
+    <path d="M364 112 C310 108 290 108 270 108"/>
+    <path d="M230 124 V156"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="7.5" text-anchor="middle">
+    <text x="63" y="39">keyboard</text>
+    <text x="63" y="77">mouse</text>
+    <text x="63" y="115">webcam</text>
+    <text x="399" y="39">monitor</text>
+    <text x="399" y="77">printer</text>
+    <text x="399" y="115">speakers</text>
+    <text x="230" y="169">external drive</text>
+    <text x="63" y="17" font-weight="600" fill-opacity="0.85">INPUT</text>
+    <text x="399" y="17" font-weight="600" fill-opacity="0.85">OUTPUT</text>
+    <text x="230" y="192" font-size="7" fill-opacity="0.85">bus: USB · Bluetooth · PCIe</text>
+  </g>
+</svg>
+<figcaption>Peripherals ring the computer and fall into three groups — input devices feed data in, output devices send results out, and storage devices hold data — each attaching over a bus such as USB, Bluetooth, or PCIe.</figcaption>
+</figure>
+
 ## Overview
 
-Peripherals are how a computer talks to the world, and they fall into three rough groups. *Input* peripherals feed data in — the [keyboard](/reference/keyboard/), [mouse](/reference/mouse/), [webcam](/reference/webcam/), and scanners. *Output* peripherals send results out — the [monitor](/reference/computer-monitor/), [printer](/reference/printer/), and speakers. *Storage* peripherals hold data, like external drives. All of them attach to the machine through an [input/output](/reference/input-output/) interface such as [USB](/reference/usb/), Bluetooth, or an expansion slot, and rely on driver software so the [operating system](/reference/operating-system/) can use them.
+Peripherals are how a computer talks to the world, and they fall into three rough groups. *Input* peripherals feed data in — the [keyboard](/reference/keyboard/), [mouse](/reference/mouse/), [webcam](/reference/webcam/), and scanners. *Output* peripherals send results out — the [monitor](/reference/computer-monitor/), [printer](/reference/printer/), and speakers. *Storage* peripherals hold data, like external drives.
+
+All of them attach to the machine through an [input/output](/reference/input-output/) interface such as [USB](/reference/usb/), Bluetooth, or an expansion slot, and rely on driver software so the [operating system](/reference/operating-system/) can use them.
+
+## Categories
+
+The same bus carries devices from every category; what differs is the direction data flows:
+
+| Category | Data direction | Examples |
+|----------|----------------|----------|
+| Input | Into the computer | Keyboard, mouse, webcam, scanner |
+| Output | Out of the computer | Monitor, printer, speakers |
+| Storage | Both ways | External drive, USB stick |
+| Combined | Both ways | Touchscreen, all-in-one printer |
 
 ## Where it fits
 

--- a/docs/reference/personal-computer.md
+++ b/docs/reference/personal-computer.md
@@ -4,7 +4,7 @@ title: Personal computer
 entry_type: hardware
 category: hw-personal-computers
 description: A personal computer is a general-purpose computer sized and priced for a single user, built from a CPU, RAM, storage, and I/O and running a full operating system.
-keywords: personal computer, PC, development machine, desktop, laptop, general-purpose computer
+keywords: personal computer, PC, development machine, desktop, laptop, general-purpose computer, building blocks
 aka: [Personal computer, PC]
 infobox:
   - { label: Type, value: General-purpose computer }
@@ -23,6 +23,38 @@ cite_urls:
 user, in two main forms — the [desktop](/reference/desktop-computer/) and the
 [laptop](/reference/laptop/).[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 190" role="img" aria-label="A personal computer built from four building blocks — CPU, RAM, storage, and input/output — all linked by a system bus and running one operating system, then packaged into either of two forms: a desktop tower or a folding laptop." xmlns="http://www.w3.org/2000/svg">
+  <line x1="40" y1="70" x2="420" y2="70" stroke="currentColor" stroke-width="1.5"/>
+  <g stroke="currentColor" fill="none" stroke-width="1.2">
+    <rect x="46" y="30" width="76" height="26" rx="3" fill="currentColor" fill-opacity="0.12"/>
+    <rect x="140" y="30" width="76" height="26" rx="3" fill="currentColor" fill-opacity="0.1"/>
+    <rect x="234" y="30" width="76" height="26" rx="3" fill="currentColor" fill-opacity="0.1"/>
+    <rect x="328" y="30" width="76" height="26" rx="3" fill="currentColor" fill-opacity="0.1"/>
+    <path d="M84 56 V70 M178 56 V70 M272 56 V70 M366 56 V70"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle" font-size="8">
+    <text x="84" y="47">CPU</text>
+    <text x="178" y="47">RAM</text>
+    <text x="272" y="47">storage</text>
+    <text x="366" y="47">I/O</text>
+    <text x="230" y="86" font-size="7" fill-opacity="0.85">system bus &#183; one operating system</text>
+  </g>
+  <g stroke="currentColor" fill="none" stroke-width="1.1">
+    <path d="M160 70 L120 108 M300 70 L340 108" stroke-dasharray="4 3"/>
+    <rect x="90" y="112" width="30" height="50" rx="3"/>
+    <path d="M300 118 L370 118 L370 150 L292 150 Z" fill="currentColor" fill-opacity="0.06"/>
+    <path d="M300 118 L316 106 L386 106 L370 118 Z" fill="currentColor" fill-opacity="0.1"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle" font-size="7.5">
+    <text x="105" y="176">desktop</text>
+    <text x="338" y="168">laptop</text>
+    <text x="230" y="182" font-size="7" fill-opacity="0.85">same blocks, two packages</text>
+  </g>
+</svg>
+<figcaption>Whatever its shape, a personal computer is the same four building blocks — CPU, RAM, storage, and I/O — wired to a system bus under one operating system, then packaged as either a stationary desktop or a portable laptop.</figcaption>
+</figure>
+
 ## Overview
 
 Whatever the form factor, a personal computer is built from the same four
@@ -33,13 +65,28 @@ What sets it apart from smaller devices is headroom: a full
 [operating system](/reference/operating-system/) and gigabytes of memory, enough
 to run essentially the whole programming-language landscape without compromise.
 
+The two main packages simply arrange those blocks differently — a desktop spreads
+them across a roomy case for power and upgrades, a laptop folds them into one
+portable shell — but the computing model underneath is identical.
+
+## Main forms
+
+The category splits mainly on whether the machine moves:
+
+| Form | Portability | Performance | Upgradeable | Typical use |
+|------|-------------|-------------|-------------|-------------|
+| Desktop | Stationary | Highest per dollar | Easily | Bench, heavy work |
+| Laptop | Goes anywhere | Good, may throttle | Minimal | Everyday, mobile |
+| All-in-one | Stationary | Moderate | Limited | Tidy home/office |
+| Mini PC | Movable-ish | Moderate | Limited | Always-on node |
+
 ## Where it fits
 
 The personal computer is the machine most developers write and test code on — the
 "development machine." Because it has the OS, memory, and storage to host
 compilers, editors, and full toolchains, SDR software and decoders like
 GopherTrunk run comfortably on one. This entry is the umbrella for the
-desktop-vs-laptop category; the two sub-entries cover the trade-offs.
+[desktop](/reference/desktop-computer/)-vs-[laptop](/reference/laptop/) category; the two sub-entries cover the trade-offs.
 
 ## Sources
 

--- a/docs/reference/pic-microcontroller.md
+++ b/docs/reference/pic-microcontroller.md
@@ -4,7 +4,7 @@ title: PIC microcontroller
 entry_type: hardware
 category: hw-microcontrollers
 description: PIC is a long-running family of low-cost microcontrollers from Microchip Technology, spanning 8-, 16-, and 32-bit cores and prized for simplicity, ruggedness, and very long supply lifetimes.
-keywords: PIC, PIC microcontroller, Microchip, PIC16, PIC18, PICkit, MPLAB, 8-bit MCU
+keywords: PIC, PIC microcontroller, Microchip, PIC16, PIC18, PIC24, dsPIC, PIC32, PICkit, MPLAB, 8-bit MCU
 aka: [PIC]
 infobox:
   - { label: Type, value: Microcontroller family }
@@ -22,13 +22,48 @@ cite_urls:
 
 **PIC** is a long-running family of low-cost [microcontrollers](/reference/microcontroller/) from Microchip Technology, originally introduced as "Peripheral Interface Controller" parts.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 168" role="img" aria-label="A tier chart of the PIC microcontroller family arranged as three rising steps. The lowest and widest step is the 8-bit PIC10, 12, 16, and 18 lines. The middle step is the 16-bit PIC24 and dsPIC digital-signal parts. The tallest step is the 32-bit PIC32 line. An arrow along the bottom marks increasing performance from left to right." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.3">
+    <rect x="30" y="94" width="130" height="40" rx="4" fill="currentColor" fill-opacity="0.08"/>
+    <rect x="168" y="66" width="130" height="68" rx="4" fill="currentColor" fill-opacity="0.11"/>
+    <rect x="306" y="38" width="130" height="96" rx="4" fill="currentColor" fill-opacity="0.15"/>
+    <line x1="30" y1="150" x2="430" y2="150" stroke-width="1.2"/>
+    <path d="M430 150 L420 145 M430 150 L420 155" stroke-width="1.2"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="95" y="112" font-size="8.5" font-weight="600">8-bit</text>
+    <text x="95" y="125" font-size="7.5" fill-opacity="0.85">PIC10/12/16/18</text>
+    <text x="233" y="88" font-size="8.5" font-weight="600">16-bit</text>
+    <text x="233" y="101" font-size="7.5" fill-opacity="0.85">PIC24 &#183; dsPIC</text>
+    <text x="371" y="60" font-size="8.5" font-weight="600">32-bit</text>
+    <text x="371" y="73" font-size="7.5" fill-opacity="0.85">PIC32</text>
+    <text x="230" y="164" font-size="7.5" fill-opacity="0.9">increasing performance &#8594;</text>
+  </g>
+</svg>
+<figcaption>The PIC family climbs in steps: cheap, rugged 8-bit PIC10/12/16/18 parts at the base, 16-bit PIC24 and DSP-capable dsPIC in the middle, and 32-bit PIC32 at the top. One vendor, one tool suite (MPLAB), one programming workflow spanning the whole range.</figcaption>
+</figure>
+
 ## Overview
 
-The range stretches from simple 8-bit PIC10/PIC16/PIC18 chips through 16-bit PIC24/dsPIC up to 32-bit PIC32 parts. PICs are known for a small, regular instruction set, robust [GPIO](/reference/gpio/), and decades-long availability that makes them a staple of industrial and consumer products. They are programmed in [C](/reference/c-language/) or assembly with Microchip's MPLAB tools and flashed via [in-system programming](/reference/in-system-programming/) using a PICkit or ICD programmer.
+The range stretches from simple 8-bit PIC10/PIC16/PIC18 chips through 16-bit PIC24/dsPIC up to 32-bit PIC32 parts. PICs are known for a small, regular instruction set, robust [GPIO](/reference/gpio/), and decades-long availability that makes them a staple of industrial and consumer products.
+
+That longevity is a genuine selling point: a design built around a PIC can often buy the same part years later, which matters for equipment with long service lives. They are programmed in [C](/reference/c-language/) or assembly with Microchip's MPLAB tools and flashed via [in-system programming](/reference/in-system-programming/) using a PICkit or ICD programmer.
+
+## The PIC tiers
+
+One family, three levels of capability:
+
+| Tier | Lines | Bits | Typical role |
+|------|-------|------|--------------|
+| Entry | PIC10 / PIC12 / PIC16 | 8 | Cheapest, tiny control tasks |
+| Enhanced 8-bit | PIC18 | 8 | More memory and peripherals |
+| Digital signal | PIC24 / dsPIC | 16 | DSP maths, motor control |
+| High-end | PIC32 | 32 | MIPS core, heavier compute |
 
 ## Trade-offs
 
-PICs compete head-to-head with [AVR/ATmega](/reference/avr-atmega/) in the 8-bit space; the choice often comes down to ecosystem familiarity rather than capability. For more compute or richer peripherals, designers reach for an ARM part such as the [STM32](/reference/stm32/). Like all small [MCUs](/reference/microcontroller/), a PIC runs your code as [firmware](/reference/firmware/) with no operating system, so it boots instantly and sips power.
+PICs compete head-to-head with [AVR/ATmega](/reference/avr-atmega/) in the 8-bit space; the choice often comes down to ecosystem familiarity rather than capability. For more compute or richer peripherals, designers reach for an ARM part such as the [STM32](/reference/stm32/). Like all small [MCUs](/reference/microcontroller/), a PIC runs your code as [firmware](/reference/firmware/) with no operating system, so it boots instantly and sips power — the profile of the small controllers and [sensors](/reference/sensor/) that surround an SDR capture setup rather than the host that runs GopherTrunk.
 
 ## Sources
 

--- a/docs/reference/power-over-ethernet.md
+++ b/docs/reference/power-over-ethernet.md
@@ -3,29 +3,74 @@ slug: power-over-ethernet
 title: Power over Ethernet (PoE)
 entry_type: concept
 category: hw-networking
-description: Power over Ethernet delivers electrical power to a device over the same twisted-pair cable that carries its network data, removing the need for a separate power supply at the device.
-keywords: Power over Ethernet, PoE, PoE+, 802.3af, 802.3at, 802.3bt, powered device, injector
+description: Power over Ethernet delivers electrical power to a device over the same twisted-pair cable that carries its network data, removing the need for a separate power supply at the device and easing mast- or ceiling-mounted installs.
+keywords: Power over Ethernet, PoE, PoE+, PoE++, 802.3af, 802.3at, 802.3bt, powered device, PSE, injector, power class
 aka: [PoE]
 infobox:
   - { label: Type, value: Power-and-data over twisted pair }
   - { label: Standard, value: IEEE 802.3af / at / bt }
   - { label: Delivers, value: ~13 W up to ~90 W }
-  - { label: Source, value: PoE switch or injector }
-see_also: [ethernet, network-switch, wireless-access-point, network-interface-card, lan-and-wan, router]
+  - { label: Source, value: PoE switch or injector (PSE) }
+  - { label: Load, value: Powered device (PD) }
+see_also: [ethernet, network-switch, wireless-access-point, network-interface-card, lan-and-wan, raspberry-pi]
 cite_urls:
   - https://en.wikipedia.org/wiki/Power_over_Ethernet
 ---
 
 **Power over Ethernet** (**PoE**) delivers electrical power to a device over the same twisted-pair cable that carries its [Ethernet](/reference/ethernet/) data, so the device needs no separate power supply.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="A PoE link: a power sourcing equipment switch on the left injects DC power onto the same Ethernet cable that carries data, and a single cable runs to a powered device on the right — such as an access point on a mast — that draws both data and power from it." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="currentColor">
+    <g stroke-width="1.3">
+      <rect x="18" y="50" width="92" height="40" rx="4" fill-opacity="0.14"/>
+      <rect x="350" y="50" width="92" height="40" rx="4" fill-opacity="0.14"/>
+    </g>
+    <g stroke-width="1.5" fill="none">
+      <path d="M110 64 H350"/>
+      <path d="M110 76 H350"/>
+    </g>
+    <g stroke-width="1.2">
+      <path d="M344 64 l8 -4 v8 Z" fill="currentColor"/>
+      <path d="M344 76 l8 -4 v8 Z" fill="currentColor"/>
+    </g>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle" font-size="8.5">
+    <text x="64" y="66" font-weight="600">PoE switch</text>
+    <text x="64" y="80" font-size="8">(PSE)</text>
+    <text x="396" y="66" font-weight="600">access point</text>
+    <text x="396" y="80" font-size="8">(powered device)</text>
+    <text x="230" y="58" font-size="8" fill-opacity="0.95">data ⇄</text>
+    <text x="230" y="90" font-size="8" fill-opacity="0.95">+ DC power →</text>
+    <text x="230" y="120" font-size="8" fill-opacity="0.9">one cable carries both — no outlet needed at the device</text>
+  </g>
+</svg>
+<figcaption>PoE runs power and data down the same cable: a power sourcing equipment switch (the PSE) injects DC alongside the Ethernet signal, and a single run reaches a powered device — here a mast-mounted access point — that needs no mains outlet of its own.</figcaption>
+</figure>
+
 ## Overview
 
-Standardized in IEEE 802.3 (af, at/PoE+, and bt), PoE lets a *power sourcing equipment* device — a PoE [switch](/reference/network-switch/) or an inline injector — feed a *powered device* anywhere from about 13 W up to roughly 90 W, negotiating the level so it never over-drives a device that can't accept it. This is ideal for gear mounted where a power outlet is awkward: [wireless access points](/reference/wireless-access-point/), IP cameras, and small computers all run on a single cable.
+Standardized in IEEE 802.3 (af, at/PoE+, and bt/PoE++), PoE lets a *power sourcing equipment* (PSE) device — a PoE [switch](/reference/network-switch/) or an inline injector — feed a *powered device* (PD) anywhere from about 13 W up to roughly 90 W over the twisted pairs. The two ends first *negotiate*: the PSE detects a compliant device and its power class before applying full voltage, so it never over-drives gear that cannot accept power or damages a plain Ethernet device.
 
-## What it's for
+That single-cable delivery is ideal for equipment mounted where a power outlet is awkward: [wireless access points](/reference/wireless-access-point/) on ceilings, IP cameras on walls, VoIP phones, and small computers all run on one cable that carries both data and power. Because the power rides the same infrastructure, a centralized PoE switch can also power-cycle or monitor its attached devices remotely.
 
-PoE collapses two cables into one, which is exactly the appeal for an antenna-side node. A GopherTrunk capture box built on a PoE-capable [Raspberry Pi](/reference/raspberry-pi/) HAT can sit on a mast or in an attic with only a network cable run to it — data down, power up — instead of needing mains wiring at the antenna.
+Later standards raised the ceiling — from the original ~13 W to ~90 W — to feed hungrier devices like pan-tilt-zoom cameras and multi-radio access points that early PoE could not support.
+
+## Power classes
+
+Successive standards lifted the wattage available at the device:
+
+| Standard | Name | At the device | Typical loads |
+|----------|------|---------------|---------------|
+| 802.3af | PoE | ~12.95 W | VoIP phones, basic APs |
+| 802.3at | PoE+ | ~25.5 W | PTZ cameras, dual-radio APs |
+| 802.3bt Type 3 | PoE++ | ~51 W | Multi-radio APs, small PCs |
+| 802.3bt Type 4 | PoE++ | ~71–90 W | Displays, high-power devices |
+
+## Where it fits
+
+PoE collapses two cables into one, which is exactly the appeal for an antenna-side node. A GopherTrunk capture box built on a PoE-capable [Raspberry Pi](/reference/raspberry-pi/) HAT can sit on a mast or in an attic with only a single network cable run to it — data down, power up — instead of needing mains wiring at the antenna. That keeps the install clean, removes a mains supply from near the front end, and lets the whole node be power-cycled from the switch in the rack below.
 
 ## Sources
 
-[^wiki]: [Power over Ethernet](https://en.wikipedia.org/wiki/Power_over_Ethernet) — Wikipedia, on carrying power alongside data on Ethernet cabling.
+[^wiki]: [Power over Ethernet](https://en.wikipedia.org/wiki/Power_over_Ethernet) — Wikipedia, on carrying power alongside data on Ethernet cabling and the 802.3af/at/bt power classes.

--- a/docs/reference/power-supply-unit.md
+++ b/docs/reference/power-supply-unit.md
@@ -4,13 +4,14 @@ title: Power supply unit (PSU)
 entry_type: hardware
 category: hw-foundations
 description: A power supply unit converts AC mains electricity into the regulated low-voltage DC rails a computer's components need, and is rated by wattage and conversion efficiency.
-keywords: power supply unit, PSU, SMPS, switched-mode power supply, voltage rails, wattage, efficiency, 80 PLUS
+keywords: power supply unit, PSU, SMPS, switched-mode power supply, voltage rails, 12V 5V 3.3V, wattage, efficiency, 80 PLUS
 aka: [PSU, Power supply]
 infobox:
   - { label: Type, value: AC-to-DC converter }
   - { label: Outputs, value: "+12 V, +5 V, +3.3 V rails" }
   - { label: Rated by, value: Wattage & efficiency }
   - { label: Tech, value: Switched-mode (SMPS) }
+  - { label: Efficiency mark, value: 80 PLUS }
 see_also: [motherboard, cooling-and-thermals, central-processing-unit, graphics-processing-unit, computer-hardware]
 cite_urls:
   - https://en.wikipedia.org/wiki/Power_supply_unit_(computer)
@@ -18,14 +19,54 @@ cite_urls:
 
 A **power supply unit** (**PSU**) converts alternating-current mains electricity into the regulated low-voltage direct current that a computer's components run on.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 160" role="img" aria-label="A power supply takes AC mains on the left, rectifies and switches it, and outputs three regulated DC rails on the right: plus twelve volts feeding the CPU and GPU, plus five volts feeding drives and USB, and plus three point three volts feeding the chipset and memory." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.2">
+    <rect x="120" y="52" width="90" height="56" rx="4" fill="currentColor" fill-opacity="0.12"/>
+    <path d="M18 80 q10 -14 20 0 t20 0 t20 0 t20 0"/>
+    <line x1="210" y1="66" x2="300" y2="66"/>
+    <line x1="210" y1="80" x2="300" y2="80"/>
+    <line x1="210" y1="94" x2="300" y2="94"/>
+  </g>
+  <g fill="currentColor" stroke="none">
+    <text x="18" y="100" font-size="8">AC mains</text>
+    <text x="165" y="76" font-size="8.5" text-anchor="middle" font-weight="600">SMPS</text>
+    <text x="165" y="88" font-size="7" text-anchor="middle" fill-opacity="0.85">rectify +</text>
+    <text x="165" y="97" font-size="7" text-anchor="middle" fill-opacity="0.85">switch</text>
+    <text x="306" y="69" font-size="8.5">+12 V</text>
+    <text x="360" y="69" font-size="7.5" fill-opacity="0.85">CPU, GPU</text>
+    <text x="306" y="83" font-size="8.5">+5 V</text>
+    <text x="360" y="83" font-size="7.5" fill-opacity="0.85">drives, USB</text>
+    <text x="306" y="97" font-size="8.5">+3.3 V</text>
+    <text x="360" y="97" font-size="7.5" fill-opacity="0.85">chipset, RAM</text>
+    <text x="230" y="135" font-size="8" text-anchor="middle" fill-opacity="0.9">rated by total wattage · efficiency wasted as heat (80 PLUS marks the good ones)</text>
+  </g>
+</svg>
+<figcaption>A switched-mode supply rectifies and chops the AC mains, then delivers three steady DC rails — +12 V, +5 V, and +3.3 V — each feeding the parts of the machine that expect that voltage.</figcaption>
+</figure>
+
 ## Overview
 
-Most PCs use a *switched-mode* power supply (SMPS), which is small and efficient compared with older linear designs. It delivers several DC *rails* — typically +12 V, +5 V, and +3.3 V — to the [motherboard](/reference/motherboard/), drives, and add-in cards through standardized connectors. A unit is rated by total **wattage** (how much it can deliver) and by conversion **efficiency** (how little it wastes as heat), with schemes like 80 PLUS certifying the latter.
+Most PCs use a *switched-mode* power supply (SMPS), which rapidly switches the incoming power at high frequency to regulate its output; this makes it far smaller and more efficient than the older linear designs it replaced. It first rectifies the AC mains to a high DC voltage, then switches and steps it down to the low voltages the machine needs.
+
+The output is delivered as several DC *rails* — typically +12 V, +5 V, and +3.3 V — routed to the [motherboard](/reference/motherboard/), drives, and add-in cards through standardized connectors. A unit is rated by total **wattage** (how much power it can deliver at once) and by conversion **efficiency** (how little it wastes as heat), with certification schemes such as 80 PLUS grading the latter.
+
+## The rails
+
+Different components expect different voltages, so the PSU provides each on its own rail:
+
+| Rail | Typical loads | Notes |
+|------|---------------|-------|
+| +12 V | CPU, GPU, fans, motors | Carries most of the power in a modern PC |
+| +5 V | Drives, USB, some logic | The traditional workhorse rail |
+| +3.3 V | Chipset, memory, low-voltage logic | Lowest of the three |
+
+Modern designs put nearly all the power on the +12 V rail and derive the lower voltages from it on the board, because high-current parts like the CPU and GPU dominate the budget.
 
 ## Where it fits
 
-The PSU sizes the whole machine: a power-hungry [GPU](/reference/graphics-processing-unit/) and [CPU](/reference/central-processing-unit/) demand more headroom, and wasted power becomes heat the [cooling](/reference/cooling-and-thermals/) system must remove. Small computers skip a full PSU — a [Raspberry Pi](/reference/raspberry-pi/) running a GopherTrunk capture node takes regulated 5 V straight from a USB adapter — but the job is identical: turn wall power into the clean, steady rails the chips expect.
+The PSU sizes the whole machine: a power-hungry [GPU](/reference/graphics-processing-unit/) and [CPU](/reference/central-processing-unit/) demand more wattage headroom, and whatever power is wasted becomes heat the [cooling](/reference/cooling-and-thermals/) system must remove. Small computers skip a full PSU — a [Raspberry Pi](/reference/raspberry-pi/) running a GopherTrunk capture node takes regulated 5 V straight from a USB adapter — but the job is identical: turn wall power into the clean, steady rails the chips expect, and a noisy or undersized supply can quietly corrupt an SDR capture.
 
 ## Sources
 
-[^wiki]: [Power supply unit (computer)](https://en.wikipedia.org/wiki/Power_supply_unit_(computer)) — Wikipedia, on PC power supplies, rails, and efficiency.
+[^wiki]: [Power supply unit (computer)](https://en.wikipedia.org/wiki/Power_supply_unit_(computer)) — Wikipedia, on PC power supplies, switched-mode design, voltage rails, and efficiency ratings.

--- a/docs/reference/printer.md
+++ b/docs/reference/printer.md
@@ -4,7 +4,7 @@ title: Printer
 entry_type: hardware
 category: hw-personal-computers
 description: A printer is an output peripheral that puts a computer's text and images onto paper, the two main consumer types being inkjet and laser, connected over USB, Wi-Fi, or a network.
-keywords: printer, inkjet, laser printer, all-in-one printer, output device, USB printer, network printer
+keywords: printer, inkjet, laser printer, all-in-one printer, output device, USB printer, network printer, toner
 infobox:
   - { label: Type, value: Output peripheral }
   - { label: Common types, value: Inkjet, laser }
@@ -17,9 +17,55 @@ cite_urls:
 
 A **printer** is an output [peripheral](/reference/peripheral/) that puts a computer's text and images onto paper, turning a digital document into a physical page.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 175" role="img" aria-label="A comparison of the two main printer types. An inkjet on the left moves a printhead across the page and sprays tiny droplets of liquid ink. A laser on the right charges a rotating drum, coats it with powdered toner, and fuses the toner onto the page with heat." xmlns="http://www.w3.org/2000/svg">
+  <text x="115" y="20" fill="currentColor" stroke="none" text-anchor="middle" font-size="9" font-weight="600">inkjet</text>
+  <text x="345" y="20" fill="currentColor" stroke="none" text-anchor="middle" font-size="9" font-weight="600">laser</text>
+  <g stroke="currentColor" fill="none" stroke-width="1.3">
+    <rect x="70" y="34" width="46" height="18" rx="2" fill="currentColor" fill-opacity="0.14"/>
+    <path d="M116 52 H150" stroke-dasharray="3 2"/>
+    <path d="M93 52 L90 70 M99 52 L97 70 M105 52 L104 70"/>
+    <rect x="50" y="86" width="130" height="54" rx="2" fill="currentColor" fill-opacity="0.05"/>
+    <path d="M62 100 H120 M62 110 H140 M62 120 H108"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="7">
+    <text x="123" y="47">printhead</text>
+    <text x="128" y="72">droplets</text>
+    <text x="115" y="156" text-anchor="middle" fill-opacity="0.85">sprays liquid ink</text>
+  </g>
+  <g stroke="currentColor" fill="none" stroke-width="1.3">
+    <circle cx="320" cy="52" r="18" fill="currentColor" fill-opacity="0.08"/>
+    <path d="M320 70 L320 86" stroke-dasharray="3 2"/>
+    <rect x="360" y="42" width="24" height="20" rx="2" fill="currentColor" fill-opacity="0.14"/>
+    <rect x="280" y="90" width="130" height="50" rx="2" fill="currentColor" fill-opacity="0.05"/>
+    <path d="M292 104 H352 M292 114 H372 M292 124 H340"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="7">
+    <text x="320" y="55" text-anchor="middle">drum</text>
+    <text x="372" y="55" text-anchor="middle">toner</text>
+    <text x="345" y="156" text-anchor="middle" fill-opacity="0.85">fuses powder with heat</text>
+  </g>
+</svg>
+<figcaption>The two dominant printer types work very differently: an inkjet sweeps a printhead over the page and sprays liquid-ink droplets, while a laser charges a drum, coats it with toner powder, and fuses that powder onto the paper with heat.</figcaption>
+</figure>
+
 ## Overview
 
-Two technologies dominate the consumer and office market. *Inkjet* printers spray tiny droplets of liquid ink and excel at color and photos; *laser* printers fuse powdered toner onto the page and are faster, cheaper per page, and crisper for plain text. Many units are *all-in-one* devices that also scan and copy. A printer is a pure output device, receiving a print job from the [operating system](/reference/operating-system/) via a driver, and connects over [USB](/reference/usb/), [Wi-Fi](/reference/wi-fi/), or a wired network so it can be shared.
+Two technologies dominate the consumer and office market. *Inkjet* printers spray tiny droplets of liquid ink and excel at color and photos; *laser* printers fuse powdered toner onto the page and are faster, cheaper per page, and crisper for plain text. Many units are *all-in-one* devices that also scan and copy.
+
+A printer is a pure output device, receiving a print job from the [operating system](/reference/operating-system/) via a driver, and connects over [USB](/reference/usb/), [Wi-Fi](/reference/wi-fi/), or a wired network so it can be shared among several machines.
+
+## Inkjet vs laser
+
+The choice usually comes down to what and how much you print:
+
+| Trait | Inkjet | Laser |
+|-------|--------|-------|
+| Marks with | Liquid ink droplets | Fused toner powder |
+| Best at | Color, photos | Fast, crisp text |
+| Speed | Slower | Faster |
+| Cost per page | Higher | Lower |
+| Up-front cost | Lower | Higher |
 
 ## Where it fits
 

--- a/docs/reference/qualcomm.md
+++ b/docs/reference/qualcomm.md
@@ -4,7 +4,7 @@ title: Qualcomm
 entry_type: organization
 category: hw-organizations
 description: Qualcomm is an American company known for cellular modem technology and its Snapdragon system-on-chip processors that power a large share of smartphones.
-keywords: Qualcomm, Snapdragon, modem, cellular, SoC, baseband, wireless
+keywords: Qualcomm, Snapdragon, modem, cellular, SoC, baseband, wireless, CDMA
 aka: [Qualcomm Incorporated]
 autolink: true
 infobox:
@@ -12,7 +12,7 @@ infobox:
   - { label: Founded, value: "1985" }
   - { label: HQ, value: San Diego, California, USA }
   - { label: Makes, value: Mobile SoCs, cellular modems, wireless chips }
-see_also: [system-on-a-chip, arm-holdings, arm-architecture]
+see_also: [system-on-a-chip, arm-holdings, arm-architecture, cellular-modem, tsmc]
 cite_urls:
   - https://www.qualcomm.com/
   - https://en.wikipedia.org/wiki/Qualcomm
@@ -22,24 +22,60 @@ cite_urls:
 technology and its Snapdragon [systems-on-chip](/reference/system-on-a-chip/) that power a
 large share of the world's smartphones.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A diagram of a Qualcomm Snapdragon system-on-chip. A single package outline contains four integrated blocks: Arm-based CPU cores, a GPU, an AI accelerator, and an integrated cellular modem, showing how a whole phone's processing and radio front end are packed onto one power-efficient chip." xmlns="http://www.w3.org/2000/svg">
+  <rect x="70" y="20" width="320" height="72" rx="6" stroke="currentColor" fill="currentColor" fill-opacity="0.06" stroke-width="1.4"/>
+  <text x="230" y="14" text-anchor="middle" font-size="9" fill="currentColor" font-weight="600">Snapdragon SoC</text>
+  <g stroke="currentColor" fill="currentColor" fill-opacity="0.14" stroke-width="1.1">
+    <rect x="82" y="34" width="70" height="44" rx="3"/>
+    <rect x="158" y="34" width="70" height="44" rx="3"/>
+    <rect x="234" y="34" width="70" height="44" rx="3"/>
+    <rect x="310" y="34" width="70" height="44" rx="3"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle" font-size="8.5">
+    <text x="117" y="52">Arm</text>
+    <text x="117" y="64">CPU cores</text>
+    <text x="193" y="58">GPU</text>
+    <text x="269" y="52">AI</text>
+    <text x="269" y="64">accel.</text>
+    <text x="345" y="52">cellular</text>
+    <text x="345" y="64">modem</text>
+  </g>
+  <text x="230" y="110" font-size="8" fill="currentColor" text-anchor="middle" fill-opacity="0.9">compute and the radio front end on one power-efficient chip</text>
+</svg>
+<figcaption>A Snapdragon system-on-chip fuses Arm CPU cores, a GPU, an AI accelerator, and a cellular modem onto one die — the same radio-plus-processor integration that lets a whole phone fit in a pocket.</figcaption>
+</figure>
+
 ## Overview
 
 Qualcomm built its early business on CDMA cellular technology and the patents around it,
 becoming a major licensor of mobile wireless intellectual property. Its Snapdragon
 SoCs combine [Arm](/reference/arm-holdings/)-based CPU cores, a GPU, an AI accelerator, and
-an integrated cellular modem on one chip, and are widely used in Android phones, tablets,
-and increasingly in laptops.[^home]
+an integrated [cellular modem](/reference/cellular-modem/) on one chip, and are widely used
+in Android phones, tablets, and increasingly in laptops.[^home]
 
 The company is largely fabless, designing its chips and outsourcing manufacturing to
-foundries. It also supplies Wi-Fi, Bluetooth, and GPS components used across the mobile and
-embedded industry.
+foundries such as [TSMC](/reference/tsmc/). It also supplies Wi-Fi, Bluetooth, and GPS
+components used across the mobile and embedded industry.
 
-## Why it matters
+## What Qualcomm sells
+
+Qualcomm earns money from both silicon and the patent portfolio behind it:
+
+| Business | What it is |
+|----------|------------|
+| Snapdragon SoCs | Integrated CPU + GPU + modem chips for phones |
+| Standalone modems | Cellular baseband chips for other makers' devices |
+| Connectivity | Wi-Fi, Bluetooth, and GPS components |
+| Licensing | Patents on CDMA and later cellular standards |
+
+## Where it fits
 
 Qualcomm's modems and SoCs sit inside a huge fraction of the mobile devices in use, making
 it central to how phones connect to networks. Its baseband and RF expertise illustrates how
 a complete radio front end and digital processor can be packed into a single power-efficient
-chip — the same integration trend that puts capable SDR-adjacent radios into small devices.
+chip — the same integration trend that puts capable SDR-adjacent radios into small devices,
+and that a GopherTrunk decoder ultimately mirrors in software.
 
 ## Sources
 

--- a/docs/reference/rack-server.md
+++ b/docs/reference/rack-server.md
@@ -4,13 +4,14 @@ title: Rack server
 entry_type: hardware
 category: hw-servers
 description: A rack server is a server built in a flat, standardized chassis that bolts into a 19-inch equipment rack, letting many machines be stacked densely in a data center.
-keywords: rack server, rack-mount, 19-inch rack, rack unit, 1U, 2U, server chassis
+keywords: rack server, rack-mount, 19-inch rack, rack unit, 1U, 2U, 4U, server chassis, cold aisle
 aka: [Rack-mount server]
 infobox:
   - { label: Type, value: Server form factor }
   - { label: Mounts in, value: 19-inch rack }
   - { label: Height unit, value: "U (1.75 in / 44.45 mm)" }
   - { label: Common sizes, value: 1U, 2U, 4U }
+  - { label: Airflow, value: Front-to-back }
 see_also: [server, blade-server, data-center, dedicated-server, network-attached-storage, colocation]
 related_lessons:
   - { title: "Dedicated servers", url: /learn/intro-hardware/dedicated-servers/ }
@@ -21,9 +22,50 @@ cite_urls:
 
 A **rack server** is a [server](/reference/server/) built in a flat, standardized chassis that bolts into a 19-inch equipment rack, so many machines can be stacked densely in a cabinet.[^rack]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 210" role="img" aria-label="A 19-inch equipment rack shown from the front. Rack unit numbers run up the left side. The rack holds a network switch at top, several 1U slim servers, a 2U server that occupies two units, a 4U server, and network-attached storage near the bottom, illustrating how different chassis heights stack in the same frame." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="currentColor" font-family="ui-sans-serif, sans-serif">
+    <rect x="150" y="16" width="200" height="184" rx="3" fill-opacity="0.03" stroke-width="1.5"/>
+    <g font-size="7" stroke="none" text-anchor="end" fill-opacity="0.75">
+      <text x="144" y="30">12U</text><text x="144" y="46">10U</text><text x="144" y="70">8U</text>
+      <text x="144" y="110">6U</text><text x="144" y="150">3U</text><text x="144" y="182">1U</text>
+    </g>
+    <g stroke-width="1.1">
+      <rect x="158" y="22" width="184" height="14" rx="1" fill-opacity="0.10"/><text x="250" y="32" text-anchor="middle" font-size="7" stroke="none">Network switch &#183; 1U</text>
+      <rect x="158" y="38" width="184" height="14" rx="1" fill-opacity="0.16"/><text x="250" y="48" text-anchor="middle" font-size="7" stroke="none">1U server</text>
+      <rect x="158" y="54" width="184" height="14" rx="1" fill-opacity="0.16"/><text x="250" y="64" text-anchor="middle" font-size="7" stroke="none">1U server</text>
+      <rect x="158" y="70" width="184" height="30" rx="1" fill-opacity="0.20"/><text x="250" y="88" text-anchor="middle" font-size="7" stroke="none">2U server</text>
+      <rect x="158" y="102" width="184" height="58" rx="1" fill-opacity="0.24"/><text x="250" y="134" text-anchor="middle" font-size="7" stroke="none">4U server &#183; more bays &amp; cooling</text>
+      <rect x="158" y="162" width="184" height="32" rx="1" fill-opacity="0.12"/><text x="250" y="181" text-anchor="middle" font-size="7" stroke="none">NAS storage</text>
+    </g>
+    <g stroke-width="1.3" fill="none">
+      <line x1="380" y1="120" x2="356" y2="120"/><path d="M356 120 l8 -3 v6 z" stroke-width="1" fill="currentColor"/>
+    </g>
+    <text x="384" y="116" font-size="7.5" stroke="none">cold-aisle</text>
+    <text x="384" y="126" font-size="7.5" stroke="none">air in</text>
+    <text x="250" y="208" text-anchor="middle" font-size="7.5" stroke="none" fill-opacity="0.85">1U = 1.75 in (44.45 mm) &#183; taller chassis = more drives &amp; slots</text>
+  </g>
+</svg>
+<figcaption>A 19-inch rack stacks chassis measured in units (U): slim 1U "pizza boxes", taller 2U and 4U servers with more bays and cooling, plus switches and storage — all sharing the same rails, power, and front-to-back airflow.</figcaption>
+</figure>
+
 ## Overview
 
-Height is measured in *rack units* (**U**), each 1.75 in (44.45 mm) tall.[^ru] A 1U "pizza box" is the slimmest common server; 2U and 4U chassis trade density for more drive bays, expansion slots, and cooling. The 19-inch rack standard means servers, switches, and storage from different vendors share the same rails, power distribution, and cable management. Rack servers fill the cabinets of a [data center](/reference/data-center/), where airflow runs front-to-back through cold and hot aisles.
+Height is measured in *rack units* (**U**), each 1.75 in (44.45 mm) tall.[^ru] A 1U "pizza box" is the slimmest common server; 2U and 4U chassis trade density for more drive bays, expansion slots, and cooling. The 19-inch rack standard means servers, switches, and storage from different vendors share the same rails, power distribution, and cable management.
+
+Rack servers fill the cabinets of a [data center](/reference/data-center/), where airflow runs front-to-back through cold and hot aisles. The standardization is the quiet superpower here: because every vendor builds to the same 19-inch width and U increment, an operator can mix machines, switches, and storage in one frame and cable them predictably.
+
+## Form factors
+
+Chassis height is the main dial, trading density against expandability:
+
+| Size | Height | Trade-off | Typical role |
+|------|--------|-----------|--------------|
+| 1U | 1.75 in | Densest, limited bays/cooling | Web & app servers |
+| 2U | 3.5 in | Balance of density and expansion | General workhorse |
+| 4U | 7 in | Most drives, slots, and cooling | Storage, GPU, database |
+
+The taller the chassis, the fewer fit per rack — so operators pick the smallest U count that still holds the drives, cards, and cooling a workload needs.
 
 ## Where it fits
 

--- a/docs/reference/raspberry-pi-foundation.md
+++ b/docs/reference/raspberry-pi-foundation.md
@@ -4,7 +4,7 @@ title: Raspberry Pi Foundation
 entry_type: organization
 category: hw-organizations
 description: The Raspberry Pi Foundation is a UK charity that created the Raspberry Pi single-board computer to make computing education affordable and accessible.
-keywords: Raspberry Pi Foundation, Raspberry Pi, single-board computer, education, charity, Eben Upton
+keywords: Raspberry Pi Foundation, Raspberry Pi, single-board computer, education, charity, Eben Upton, Broadcom
 aka: [Raspberry Pi]
 autolink: false
 infobox:
@@ -12,7 +12,7 @@ infobox:
   - { label: Founded, value: "2009" }
   - { label: HQ, value: Cambridge, England, UK }
   - { label: Makes, value: Raspberry Pi single-board computers }
-see_also: [raspberry-pi, eben-upton, single-board-computer]
+see_also: [raspberry-pi, eben-upton, single-board-computer, broadcom, compute-module]
 related_lessons:
   - { title: "Raspberry Pi and family", url: /learn/intro-hardware/raspberry-pi-and-family/ }
 cite_urls:
@@ -24,6 +24,29 @@ cite_urls:
 [Raspberry Pi](/reference/raspberry-pi/) [single-board computer](/reference/single-board-computer/)
 to make computing affordable and accessible for education.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 125" role="img" aria-label="A timeline of the Raspberry Pi Foundation. The charity is founded in 2009 to improve computing education, ships the first low-cost Raspberry Pi board in 2012 which sells far beyond the classroom, and later separates engineering and sales into a trading subsidiary, Raspberry Pi Ltd, while the charity continues educational work." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="62" x2="440" y2="62" stroke="currentColor" stroke-width="1.4"/>
+  <g stroke="currentColor" fill="currentColor" stroke-width="1.2">
+    <circle cx="70" cy="62" r="5" fill-opacity="0.15"/>
+    <circle cx="220" cy="62" r="6" fill="currentColor"/>
+    <circle cx="380" cy="62" r="5" fill-opacity="0.15"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="70" y="46" font-size="9" font-weight="600">2009</text>
+    <text x="70" y="82" font-size="8">charity founded</text>
+    <text x="70" y="93" font-size="8">for CS education</text>
+    <text x="220" y="46" font-size="9" font-weight="600">2012</text>
+    <text x="220" y="82" font-size="8">first Pi ships</text>
+    <text x="220" y="93" font-size="8">sells beyond class</text>
+    <text x="380" y="46" font-size="9" font-weight="600">later</text>
+    <text x="380" y="82" font-size="8">Raspberry Pi Ltd</text>
+    <text x="380" y="93" font-size="8">trades; charity teaches</text>
+  </g>
+</svg>
+<figcaption>The Foundation set out in 2009 to fix a decline in hands-on computing, shipped its first cheap board in 2012, and later split off Raspberry Pi Ltd for engineering and sales while the charity kept its educational mission.</figcaption>
+</figure>
+
 ## Overview
 
 The Foundation was started by a group including [Eben Upton](/reference/eben-upton/), who
@@ -34,14 +57,26 @@ computer that could be bought for tens of dollars and freely tinkered with.[^hom
 The first Raspberry Pi shipped in 2012 and sold far beyond the classroom, becoming a staple
 for hobbyists, makers, and industry. Engineering and sales now run through a trading
 subsidiary (Raspberry Pi Ltd), while the charity continues educational programs and
-curriculum work.
+curriculum work. The boards are built around [Broadcom](/reference/broadcom/) systems-on-chip.
 
-## Why it matters
+## The Raspberry Pi range
+
+From one educational board, the line has grown to cover several form factors:
+
+| Model | What it is |
+|-------|------------|
+| Model B | The flagship full-size board with ports |
+| Zero | A tiny, cheaper cut-down board |
+| Compute Module | A board-to-embed version for products |
+| Pico | An RP2040 microcontroller board (not a full computer) |
+
+## Where it fits
 
 The Raspberry Pi turned the cheap, capable single-board computer into a mainstream tool.
 For a project like GopherTrunk, a Pi by the antenna makes a practical capture node — small,
 low-power, and inexpensive enough to deploy several — and the Foundation's mission is why
-that hardware exists at the price it does.
+that hardware exists at the price it does. A [Compute Module](/reference/compute-module/) can
+carry the same idea into a purpose-built receiver enclosure.
 
 ## Sources
 

--- a/docs/reference/raspberry-pi-pico.md
+++ b/docs/reference/raspberry-pi-pico.md
@@ -4,7 +4,7 @@ title: Raspberry Pi Pico
 entry_type: hardware
 category: hw-microcontrollers
 description: The Raspberry Pi Pico is a tiny, low-cost microcontroller board built on the RP2040 chip; the Pico W variant adds Wi-Fi, making it a popular entry point for embedded and IoT projects.
-keywords: Raspberry Pi Pico, Pico W, RP2040, microcontroller board, MicroPython, Pico SDK, Wi-Fi
+keywords: Raspberry Pi Pico, Pico W, RP2040, RP2350, microcontroller board, MicroPython, Pico SDK, Wi-Fi, castellated pins
 aka: [Pico, Pico W]
 autolink: true
 infobox:
@@ -13,7 +13,7 @@ infobox:
   - { label: Wireless, value: Wi-Fi on Pico W / 2 W }
   - { label: Typical price, value: ~$4–6 }
   - { label: Language, value: C/C++, MicroPython }
-see_also: [rp2040, raspberry-pi, microcontroller, esp32, gpio, internet-of-things]
+see_also: [rp2040, raspberry-pi, microcontroller, esp32, gpio, sensor]
 related_lessons:
   - { title: "What is a microcontroller?", url: /learn/intro-hardware/what-is-a-microcontroller/ }
   - { title: "MCU programming and trade-offs", url: /learn/intro-hardware/mcu-programming-and-tradeoffs/ }
@@ -23,13 +23,51 @@ cite_urls:
 
 **The Raspberry Pi Pico** is a tiny, low-cost [microcontroller](/reference/microcontroller/) board built around the [RP2040](/reference/rp2040/) chip.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 176" role="img" aria-label="Top view of a Raspberry Pi Pico board. A micro-USB port sits at the top edge, the square RP2040 chip is in the centre, and rows of castellated pads line both long edges, most of them general-purpose I/O pins that also carry serial, PWM, and analog-to-digital functions." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.3">
+    <rect x="140" y="20" width="180" height="140" rx="10" stroke-opacity="0.8"/>
+    <rect x="206" y="14" width="48" height="16" rx="3" fill="currentColor" fill-opacity="0.12"/>
+    <rect x="196" y="70" width="68" height="46" rx="3" fill="currentColor" fill-opacity="0.16"/>
+  </g>
+  <g stroke="currentColor" stroke-width="1" fill="currentColor" fill-opacity="0.18">
+    <rect x="130" y="34" width="12" height="9"/><rect x="130" y="50" width="12" height="9"/><rect x="130" y="66" width="12" height="9"/><rect x="130" y="82" width="12" height="9"/><rect x="130" y="98" width="12" height="9"/><rect x="130" y="114" width="12" height="9"/><rect x="130" y="130" width="12" height="9"/>
+    <rect x="318" y="34" width="12" height="9"/><rect x="318" y="50" width="12" height="9"/><rect x="318" y="66" width="12" height="9"/><rect x="318" y="82" width="12" height="9"/><rect x="318" y="98" width="12" height="9"/><rect x="318" y="114" width="12" height="9"/><rect x="318" y="130" width="12" height="9"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="230" y="10" font-size="8">micro-USB (power + flashing)</text>
+    <text x="230" y="90" font-size="8.5" font-weight="600">RP2040</text>
+    <text x="230" y="102" font-size="7.5" fill-opacity="0.85">dual Cortex-M0+</text>
+    <text x="86" y="88" font-size="7.5" text-anchor="middle">GPIO</text>
+    <text x="86" y="99" font-size="7.5" text-anchor="middle">edge</text>
+    <text x="374" y="88" font-size="7.5" text-anchor="middle">GPIO</text>
+    <text x="374" y="99" font-size="7.5" text-anchor="middle">edge</text>
+    <text x="230" y="172" font-size="7.5" fill-opacity="0.9">castellated pads: solder as a header or reflow like a module</text>
+  </g>
+</svg>
+<figcaption>The Pico's layout: a micro-USB port for power and drag-and-drop programming, the RP2040 in the middle, and castellated pads down both edges — most of them GPIO that double as serial, PWM, and ADC lines. The castellations let you solder headers or reflow the whole board onto another PCB like a module.</figcaption>
+</figure>
+
 ## Overview
 
-Unlike the Linux-running [Raspberry Pi](/reference/raspberry-pi/) single-board computers, the Pico is a bare-metal MCU board: castellated edges for soldering, a row of [GPIO](/reference/gpio/) pins, and a USB port that doubles as power and a drag-and-drop programming interface. It is written in C/C++ with the Pico SDK or in MicroPython. The **Pico W** adds Wi-Fi (and Bluetooth), turning it into a cheap connected node for the [Internet of Things](/reference/internet-of-things/); the Pico 2 and 2 W move to the newer RP2350.
+Unlike the Linux-running [Raspberry Pi](/reference/raspberry-pi/) single-board computers, the Pico is a bare-metal MCU board: castellated edges for soldering, a row of [GPIO](/reference/gpio/) pins, and a USB port that doubles as power and a drag-and-drop programming interface. It is written in C/C++ with the Pico SDK or in MicroPython.
+
+The **Pico W** adds Wi-Fi (and Bluetooth), turning it into a cheap connected node for the [Internet of Things](/reference/internet-of-things/); the Pico 2 and 2 W move to the newer RP2350 chip with faster cores and more memory.
+
+## The Pico lineup
+
+Several variants share the same board footprint:
+
+| Board | Chip | Wireless | Note |
+|-------|------|----------|------|
+| Pico | RP2040 | — | The original |
+| Pico W | RP2040 | Wi-Fi + BLE | Connected projects |
+| Pico 2 | RP2350 | — | Faster, more RAM |
+| Pico 2 W | RP2350 | Wi-Fi + BLE | Newest connected board |
 
 ## Where it fits
 
-The Pico is a common first board for learning embedded programming, competing with [Arduino](/reference/arduino/) and [ESP32](/reference/esp32/) boards. It is well suited to reading [sensors](/reference/sensor/), driving displays, and bit-banging protocols via the RP2040's programmable I/O. Like any MCU it is far too small to run GopherTrunk, but it is exactly the sort of device that crowds the airwaves GopherTrunk listens to.
+The Pico is a common first board for learning embedded programming, competing with [Arduino](/reference/arduino/) and [ESP32](/reference/esp32/) boards. It is well suited to reading [sensors](/reference/sensor/), driving displays, and bit-banging protocols via the RP2040's programmable I/O. Like any MCU it is far too small to run GopherTrunk, but it is exactly the sort of device that crowds the airwaves GopherTrunk listens to — and its PIO blocks make it a capable GPIO/timing helper alongside a capture node.
 
 ## Sources
 

--- a/docs/reference/raspberry-pi.md
+++ b/docs/reference/raspberry-pi.md
@@ -4,7 +4,7 @@ title: Raspberry Pi
 entry_type: hardware
 category: hw-sbc
 description: Raspberry Pi is a popular, low-cost single-board computer used for learning, hobby projects, home servers, and edge devices, running Linux and programmed in Python, C, or Go.
-keywords: Raspberry Pi, Pi Zero 2 W, Pi 4, Pi 5, Compute Module, HAT, Raspberry Pi OS, single-board computer
+keywords: Raspberry Pi, Pi Zero 2 W, Pi 4, Pi 5, Compute Module, HAT, Raspberry Pi OS, single-board computer, 40-pin header, SDR host
 autolink: true
 infobox:
   - { label: Type, value: Single-board computer }
@@ -22,13 +22,59 @@ cite_urls:
 
 **Raspberry Pi** is the popular, low-cost [single-board computer](/reference/single-board-computer/) that defined the category — used for learning, hobby projects, home servers, and edge devices.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 176" role="img" aria-label="Top view of a Raspberry Pi board. The 40-pin GPIO header runs along the top edge, the Broadcom system-on-chip sits in the centre with RAM beside it, USB and Ethernet jacks line the right edge, HDMI and power connectors line the bottom, and a microSD card slot sits on the left. This layout is the de-facto template that most Pi-compatible boards copy." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.3">
+    <rect x="36" y="30" width="388" height="116" rx="7" fill-opacity="0.05" fill="currentColor"/>
+    <g stroke-width="1">
+      <rect x="70" y="36" width="230" height="11" rx="2"/>
+      <line x1="78" y1="36" x2="78" y2="47"/><line x1="90" y1="36" x2="90" y2="47"/>
+      <line x1="102" y1="36" x2="102" y2="47"/><line x1="114" y1="36" x2="114" y2="47"/>
+      <line x1="126" y1="36" x2="126" y2="47"/><line x1="138" y1="36" x2="138" y2="47"/>
+      <line x1="150" y1="36" x2="150" y2="47"/><line x1="162" y1="36" x2="162" y2="47"/>
+      <line x1="174" y1="36" x2="174" y2="47"/><line x1="186" y1="36" x2="186" y2="47"/>
+      <line x1="198" y1="36" x2="198" y2="47"/><line x1="210" y1="36" x2="210" y2="47"/>
+    </g>
+    <rect x="150" y="72" width="56" height="46" rx="4" fill-opacity="0.16" fill="currentColor"/>
+    <rect x="220" y="80" width="30" height="30" rx="3" fill-opacity="0.1" fill="currentColor"/>
+    <rect x="392" y="52" width="32" height="26" rx="2" fill-opacity="0.14" fill="currentColor"/>
+    <rect x="392" y="90" width="32" height="26" rx="2" fill-opacity="0.14" fill="currentColor"/>
+    <rect x="70" y="118" width="34" height="20" rx="2" fill-opacity="0.12" fill="currentColor"/>
+    <rect x="120" y="118" width="26" height="20" rx="2" fill-opacity="0.12" fill="currentColor"/>
+    <rect x="30" y="86" width="10" height="24" rx="2" fill-opacity="0.18" fill="currentColor"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="8.5">
+    <text x="185" y="26" text-anchor="middle" font-size="7.5">40-pin GPIO header</text>
+    <text x="178" y="99" text-anchor="middle" font-size="9" font-weight="600">SoC</text>
+    <text x="235" y="98" text-anchor="middle" font-size="6.5">RAM</text>
+    <text x="408" y="46" text-anchor="middle" font-size="7.5">USB</text>
+    <text x="408" y="122" text-anchor="middle" font-size="7">Ethernet</text>
+    <text x="87" y="132" text-anchor="middle" font-size="6.5">HDMI</text>
+    <text x="133" y="132" text-anchor="middle" font-size="6.5">pwr</text>
+    <text x="35" y="80" text-anchor="middle" font-size="6.5">SD</text>
+  </g>
+</svg>
+<figcaption>The Raspberry Pi's layout — a 40-pin GPIO header along one edge, a Broadcom SoC and RAM in the middle, and USB, Ethernet, HDMI, power, and a microSD slot around the sides — became the de-facto template that most Pi-compatible boards copy.</figcaption>
+</figure>
+
 ## Overview
 
-The range runs from the tiny Pi Zero 2 W through the Pi 4 and Pi 5 to the Compute Module for embedding in custom hardware. A Raspberry Pi runs Raspberry Pi OS (a Linux distribution) and is programmed in ordinary languages such as [Python](/reference/python-language/), [C](/reference/c-language/), and [Go](/reference/go-language/). A *HAT* is an add-on board that stacks onto its [GPIO](/reference/gpio/) header to add hardware.
+The range runs from the tiny Pi Zero 2 W through the Pi 4 and Pi 5 to the [Compute Module](/reference/compute-module/) for embedding in custom hardware. A Raspberry Pi runs Raspberry Pi OS (a Linux distribution) and is programmed in ordinary languages such as [Python](/reference/python-language/), [C](/reference/c-language/), and [Go](/reference/go-language/) — the same tools and workflow as a desktop Linux machine, which is a large part of why it became the default teaching board.
+
+What sets it apart from a sealed PC is the 40-pin [GPIO](/reference/gpio/) header, which lets code talk directly to electronics, and the *HAT* — an add-on board that stacks onto that header to add hardware. Its real advantage over faster rivals, though, is the ecosystem: an enormous body of documentation, a huge community, and well-maintained OS images mean most projects "just work," which is worth more than raw specs for a board you want to set up once and leave running.
+
+## The lineup
+
+| Model | Rough role | RAM | Notable |
+|-------|-----------|-----|---------|
+| Pi Zero 2 W | Tiny, low-power | 512 MB | Smallest, cheapest, Wi-Fi |
+| Pi 4 | General-purpose | 1–8 GB | Dual HDMI, USB 3, gigabit |
+| Pi 5 | Fastest flagship | 2–16 GB | PCIe, much higher performance |
+| Compute Module | Embedded module | 1–16 GB | Needs a custom carrier board |
 
 ## Where it fits
 
-For most projects the Pi is the default choice: cheap, well documented, and broadly supported. A Raspberry Pi by the antenna can run GopherTrunk as a small, low-power SDR capture node. When you need GPU compute at the edge, the [NVIDIA Jetson](/reference/nvidia-jetson/) is an alternative; when you need stronger real-time I/O, look at the [BeagleBone](/reference/beaglebone/).
+For most projects the Pi is the default choice: cheap, well documented, and broadly supported. A Raspberry Pi by the antenna can run GopherTrunk as a small, low-power [SDR](/reference/software-defined-radio/) capture node, hosting an RTL-SDR or similar dongle and decoding locally while drawing only a few watts — headless, fanless, and easy to leave in place. When you need GPU compute at the edge, the [NVIDIA Jetson](/reference/nvidia-jetson/) is an alternative; when you need stronger real-time I/O, look at the [BeagleBone](/reference/beaglebone/); and when you want more of it as a [home server](/reference/home-server/), the Pi handles that too.
 
 ## Sources
 

--- a/docs/reference/real-time-operating-system.md
+++ b/docs/reference/real-time-operating-system.md
@@ -3,8 +3,8 @@ slug: real-time-operating-system
 title: Real-time operating system (RTOS)
 entry_type: concept
 category: hw-microcontrollers
-description: A real-time operating system is a small OS that schedules tasks with guaranteed, bounded timing, used on microcontrollers where responses must happen within strict deadlines.
-keywords: RTOS, real-time operating system, FreeRTOS, Zephyr, task scheduling, deadline, preemptive, deterministic
+description: A real-time operating system is a small OS that schedules tasks with guaranteed, bounded timing, used on microcontrollers where responses must happen within strict deadlines; its priority-based preemptive scheduler makes worst-case latency predictable.
+keywords: RTOS, real-time operating system, FreeRTOS, Zephyr, ThreadX, task scheduling, deadline, preemptive, deterministic, priority
 aka: [RTOS]
 infobox:
   - { label: Type, value: Operating system class }
@@ -21,13 +21,59 @@ cite_urls:
 
 **A real-time operating system (RTOS)** is a small operating system that schedules tasks with guaranteed, bounded timing, so a response is delivered within a known deadline.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 168" role="img" aria-label="A preemptive scheduling timeline with three task priority lanes over time. A low-priority task runs until a medium-priority task becomes ready and preempts it; partway through, a high-priority task becomes ready, preempts the medium task, runs to completion, and then control falls back down to the medium task and finally the low task, which resumes where it left off." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" stroke-width="1" fill="none" stroke-opacity="0.5">
+    <line x1="70" y1="44" x2="440" y2="44"/>
+    <line x1="70" y1="80" x2="440" y2="80"/>
+    <line x1="70" y1="116" x2="440" y2="116"/>
+    <line x1="70" y1="132" x2="440" y2="132"/>
+  </g>
+  <g stroke="currentColor" fill="currentColor" fill-opacity="0.16" stroke-width="1.1">
+    <rect x="200" y="32" width="70" height="18"/>
+    <rect x="130" y="68" width="70" height="18"/>
+    <rect x="270" y="68" width="60" height="18"/>
+    <rect x="70" y="104" width="60" height="18"/>
+    <rect x="330" y="104" width="110" height="18"/>
+  </g>
+  <g stroke="currentColor" stroke-width="0.9" stroke-dasharray="2 2" stroke-opacity="0.6">
+    <line x1="130" y1="122" x2="130" y2="68"/>
+    <line x1="200" y1="86" x2="200" y2="32"/>
+    <line x1="270" y1="50" x2="270" y2="86"/>
+    <line x1="330" y1="86" x2="330" y2="104"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="8">
+    <text x="10" y="45" text-anchor="start">High</text>
+    <text x="10" y="81" text-anchor="start">Medium</text>
+    <text x="10" y="117" text-anchor="start">Low</text>
+    <text x="235" y="45" text-anchor="middle" fill-opacity="0.9">runs</text>
+    <text x="255" y="150" text-anchor="middle" font-size="7.5" fill-opacity="0.85">time &#8594; &#183; higher priority always preempts lower</text>
+  </g>
+</svg>
+<figcaption>Preemptive priority scheduling: the low task runs until a medium task becomes ready and preempts it, then a high-priority task preempts in turn, finishes, and control falls back down — the low task resuming only once nothing higher is waiting. Because the highest-priority ready task always runs, worst-case response time is bounded and predictable.</figcaption>
+</figure>
+
 ## Overview
 
-What makes an OS "real-time" is not raw speed but *determinism*: the worst-case time to react to an event is predictable and small. An RTOS provides a priority-based, usually preemptive scheduler, plus primitives like tasks, queues, semaphores, and timers, all in a footprint of a few kilobytes. On a [microcontroller](/reference/microcontroller/) it sits between your application and the hardware, multiplexing several jobs onto one core while honoring deadlines. Popular examples include FreeRTOS, Zephyr, and ThreadX.
+What makes an OS "real-time" is not raw speed but *determinism*: the worst-case time to react to an event is predictable and small. An RTOS provides a priority-based, usually preemptive scheduler, plus primitives like tasks, queues, semaphores, and timers, all in a footprint of a few kilobytes.
+
+On a [microcontroller](/reference/microcontroller/) it sits between your application and the hardware, multiplexing several jobs onto one core while honoring deadlines. The scheduler guarantees that the highest-priority ready task is the one running, so a time-critical job is never left waiting behind less important work. Popular examples include FreeRTOS, Zephyr, and ThreadX.
+
+## RTOS versus bare metal
+
+The same chip can run either way; the trade is structure and guarantees against overhead:
+
+| Aspect | Bare metal | RTOS |
+|--------|-----------|------|
+| Concurrency | Hand-coded super loop | Scheduled tasks |
+| Timing guarantee | Ad hoc | Bounded worst case |
+| Overhead | None | A few KB code + RAM |
+| Primitives | You build them | Tasks, queues, semaphores |
+| Sweet spot | 1–2 jobs | Many competing deadlines |
 
 ## Where it fits
 
-Simple firmware often runs [bare metal](/reference/bare-metal-programming/) — a single loop plus [interrupts](/reference/interrupt/) — which is enough when there are only a couple of jobs. An RTOS earns its keep once an [embedded system](/reference/embedded-system/) juggles many concurrent tasks (reading [sensors](/reference/sensor/), driving a radio, servicing a network stack) with competing deadlines. It ports easily across [ARM Cortex-M](/reference/arm-cortex-m/) parts, so the same code runs on many chips.
+Simple firmware often runs [bare metal](/reference/bare-metal-programming/) — a single loop plus [interrupts](/reference/interrupt/) — which is enough when there are only a couple of jobs. An RTOS earns its keep once an [embedded system](/reference/embedded-system/) juggles many concurrent tasks (reading [sensors](/reference/sensor/), driving a radio, servicing a network stack) with competing deadlines. It ports easily across [ARM Cortex-M](/reference/arm-cortex-m/) parts, so the same code runs on many chips. The same determinism argument scales up: a busy SDR decode host leans on its general-purpose OS scheduler to keep real-time sample streams flowing without dropouts.
 
 ## Sources
 

--- a/docs/reference/risc-v.md
+++ b/docs/reference/risc-v.md
@@ -3,8 +3,8 @@ slug: risc-v
 title: RISC-V
 entry_type: concept
 category: hw-foundations
-description: RISC-V is an open, royalty-free RISC instruction set architecture that anyone can implement freely, used in research, embedded systems, and a growing range of processors.
-keywords: RISC-V, open ISA, RISC, royalty-free, open standard, extensions, embedded
+description: RISC-V is an open, royalty-free RISC instruction set architecture that anyone can implement freely, built as a small base plus optional extensions, used in research, embedded systems, and a growing range of processors.
+keywords: RISC-V, open ISA, RISC, royalty-free, open standard, extensions, base integer, embedded, RV32, RV64
 aka: [RISC-V, RISCV]
 autolink: true
 infobox:
@@ -12,21 +12,74 @@ infobox:
   - { label: Licensing, value: Open, royalty-free }
   - { label: Steward, value: RISC-V International }
   - { label: Design, value: Small base + extensions }
+  - { label: Base widths, value: "RV32, RV64, RV128" }
 see_also: [instruction-set-architecture, arm-architecture, x86, central-processing-unit, microcontroller, semiconductor]
 cite_urls:
   - https://en.wikipedia.org/wiki/RISC-V
 ---
 
-**RISC-V** is an open, royalty-free RISC [instruction set architecture](/reference/instruction-set-architecture/) that anyone can implement without a license fee.[^wiki]
+**RISC-V** is an open, royalty-free RISC [instruction set architecture](/reference/instruction-set-architecture/) that anyone can implement without a license fee, built as a small mandatory base plus optional extensions.[^wiki]
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 160" role="img" aria-label="RISC-V is built as a small mandatory base integer instruction set at the center, surrounded by optional extensions a designer can add: M for multiply and divide, A for atomics, F and D for floating point, C for compressed instructions, and V for vectors." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.2">
+    <circle cx="140" cy="80" r="42" fill="currentColor" fill-opacity="0.14"/>
+    <rect x="270" y="18" width="60" height="24" rx="4"/>
+    <rect x="340" y="18" width="60" height="24" rx="4"/>
+    <rect x="270" y="54" width="60" height="24" rx="4"/>
+    <rect x="340" y="54" width="60" height="24" rx="4"/>
+    <rect x="270" y="90" width="60" height="24" rx="4"/>
+    <rect x="340" y="90" width="60" height="24" rx="4"/>
+  </g>
+  <g stroke="currentColor" stroke-width="1" fill="none" stroke-opacity="0.6">
+    <line x1="182" y1="70" x2="270" y2="30"/>
+    <line x1="182" y1="72" x2="340" y2="30"/>
+    <line x1="182" y1="80" x2="270" y2="66"/>
+    <line x1="182" y1="80" x2="340" y2="66"/>
+    <line x1="182" y1="90" x2="270" y2="102"/>
+    <line x1="182" y1="92" x2="340" y2="102"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="140" y="76" font-size="9" font-weight="600">Base</text>
+    <text x="140" y="88" font-size="8">integer (I)</text>
+    <text x="140" y="99" font-size="7" fill-opacity="0.85">mandatory</text>
+    <text x="300" y="34" font-size="8">M · mul/div</text>
+    <text x="370" y="34" font-size="8">A · atomics</text>
+    <text x="300" y="70" font-size="8">F · float</text>
+    <text x="370" y="70" font-size="8">D · double</text>
+    <text x="300" y="106" font-size="8">C · compressed</text>
+    <text x="370" y="106" font-size="8">V · vectors</text>
+    <text x="230" y="145" font-size="8" fill-opacity="0.9">pick only the extensions a chip needs</text>
+  </g>
+</svg>
+<figcaption>Every RISC-V chip starts from the same small mandatory base integer instruction set, then adds only the optional extensions it needs — multiply, atomics, floating point, compressed encodings, vectors — so a tiny microcontroller and a big application core share one open foundation.</figcaption>
+</figure>
 
 ## Overview
 
-Where [x86](/reference/x86/) and [ARM](/reference/arm-architecture/) are owned and licensed, RISC-V is a free and open standard stewarded by RISC-V International. It is built as a small mandatory *base* integer instruction set plus optional *extensions* (for multiplication, floating point, vectors, and more), so a designer picks only what a chip needs. This modular, open model lets universities, startups, and large vendors build compatible processors from tiny [microcontrollers](/reference/microcontroller/) up to application cores without royalties.
+Where [x86](/reference/x86/) and [ARM](/reference/arm-architecture/) are owned and licensed, RISC-V is a free and open standard stewarded by the non-profit RISC-V International. Anyone — a student, a startup, or a large vendor — can implement it, extend it, and ship silicon without paying royalties or signing an architecture licence.
+
+Its defining feature is *modularity*. A small mandatory **base** integer instruction set (in 32-, 64-, or 128-bit register widths, named RV32/RV64/RV128) does the essentials; everything else lives in optional **extensions** that a designer bolts on only when needed. A minimal embedded core might implement just the base, while an application processor adds multiply, floating point, and vector extensions.
+
+## The base-plus-extensions model
+
+Standard extension letters name the optional pieces, and a chip's supported set is written as a string like "RV64GC":
+
+| Letter | Adds | Typical need |
+|--------|------|--------------|
+| I | Base integer ops | Always (mandatory) |
+| M | Integer multiply/divide | General compute |
+| A | Atomic operations | Multi-core, OS support |
+| F / D | Single-/double-precision float | Math-heavy workloads |
+| C | Compressed 16-bit encodings | Smaller code, embedded |
+| V | Vector operations | DSP, ML, signal work |
+
+The common shorthand "G" bundles the I, M, A, F, and D set as a general-purpose baseline. This pick-what-you-need design keeps the smallest [microcontrollers](/reference/microcontroller/) lean while letting the same ISA scale up to full application cores.
 
 ## Where it fits
 
-RISC-V's appeal is freedom from licensing and the ability to customize the ISA, which has made it popular in research, education, and embedded designs, with broader adoption growing. It competes with ARM in efficiency-focused niches and offers an open alternative to both incumbents. For a toolchain like GopherTrunk's, supporting a new ISA is mostly a matter of the [compiler](/reference/compiler/) gaining a target — the open ISA lowers the barrier to that happening.
+RISC-V's appeal is freedom from licensing and the ability to customize the ISA, which has made it popular in research, education, and embedded designs, with broader commercial adoption growing steadily. It competes with ARM in efficiency-focused niches and offers an open alternative to both incumbents. For a toolchain like GopherTrunk's, supporting a new ISA is mostly a matter of the [compiler](/reference/compiler/) gaining a target — and the open, extensible nature of RISC-V, including its vector extension for signal work, lowers the barrier to that happening.
 
 ## Sources
 
-[^wiki]: [RISC-V](https://en.wikipedia.org/wiki/RISC-V) — Wikipedia, on the open RISC-V ISA and its extension model.
+[^wiki]: [RISC-V](https://en.wikipedia.org/wiki/RISC-V) — Wikipedia, on the open RISC-V ISA, its base-plus-extensions model, and RISC-V International.

--- a/docs/reference/robert-noyce.md
+++ b/docs/reference/robert-noyce.md
@@ -4,7 +4,7 @@ title: Robert Noyce
 entry_type: person
 category: hw-people
 description: Robert Noyce (1927–1990) was an American physicist who co-invented the practical silicon integrated circuit and co-founded Intel, earning the nickname "the Mayor of Silicon Valley."
-keywords: Robert Noyce, integrated circuit, Intel, Fairchild Semiconductor, silicon, Silicon Valley
+keywords: Robert Noyce, integrated circuit, Intel, Fairchild Semiconductor, planar process, silicon, Silicon Valley
 aka: [Robert Noyce, Bob Noyce]
 autolink: true
 infobox:
@@ -20,6 +20,30 @@ cite_urls:
 silicon [integrated circuit](/reference/integrated-circuit/) and co-founded
 [Intel](/reference/intel/), becoming a central figure of Silicon Valley.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A career timeline of Robert Noyce: he co-founded Fairchild Semiconductor in 1957, devised the manufacturable planar silicon integrated circuit in 1959, co-founded Intel with Gordon Moore in 1968, and later helped launch the Sematech consortium in 1987." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="66" x2="440" y2="66" stroke="currentColor" stroke-width="1.4"/>
+  <g stroke="currentColor" fill="currentColor" stroke-width="1.2">
+    <circle cx="60" cy="66" r="5" fill-opacity="0.15"/>
+    <circle cx="185" cy="66" r="6" fill="currentColor"/>
+    <circle cx="310" cy="66" r="5" fill-opacity="0.15"/>
+    <circle cx="420" cy="66" r="5" fill-opacity="0.15"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="60" y="50" font-size="9" font-weight="600">1957</text>
+    <text x="60" y="86" font-size="8">Fairchild</text>
+    <text x="185" y="50" font-size="9" font-weight="600">1959</text>
+    <text x="185" y="86" font-size="8">planar IC</text>
+    <text x="310" y="50" font-size="9" font-weight="600">1968</text>
+    <text x="310" y="86" font-size="8">co-founds Intel</text>
+    <text x="420" y="50" font-size="9" font-weight="600">1987</text>
+    <text x="420" y="86" font-size="8">Sematech</text>
+    <text x="235" y="112" font-size="8" fill-opacity="0.9">wiring laid on the chip itself &#8212; mass-manufacturable silicon</text>
+  </g>
+</svg>
+<figcaption>Noyce's line from Fairchild's planar integrated circuit to co-founding Intel: the manufacturable form of the chip, and the company that turned it into the microprocessor industry.</figcaption>
+</figure>
+
 ## Life and work
 
 At Fairchild Semiconductor in 1959, Noyce devised a way to build many interconnected
@@ -28,6 +52,13 @@ chip itself — the form of [integrated circuit](/reference/integrated-circuit/)
 manufacturable at scale. [Jack Kilby](/reference/jack-kilby/) had demonstrated the integrated
 circuit concept months earlier, and the two are credited as independent co-inventors.[^wiki] In
 1968 Noyce and [Gordon Moore](/reference/gordon-moore/) left Fairchild to found Intel.[^wiki]
+
+| Year | Milestone |
+|------|-----------|
+| 1957 | Co-founds Fairchild Semiconductor |
+| 1959 | Devises the manufacturable planar silicon IC |
+| 1968 | Co-founds Intel with Gordon Moore |
+| 1987 | Helps launch the Sematech industry consortium |
 
 ## Why they matter
 
@@ -40,7 +71,8 @@ shaped the company that brought the microprocessor to the world.[^wiki]
 ## Legacy
 
 Known as "the Mayor of Silicon Valley," Noyce mentored a generation of entrepreneurs and
-helped define the region's culture before his death in 1990.
+helped define the region's culture before his death in 1990 — and the planar process he
+pioneered is still, in refined form, how the chips inside every SDR are made.
 
 ## Sources
 

--- a/docs/reference/rock-pi.md
+++ b/docs/reference/rock-pi.md
@@ -4,7 +4,7 @@ title: Rock Pi (Radxa)
 entry_type: hardware
 category: hw-sbc
 description: Rock Pi is a family of single-board computers from Radxa of China, built mainly on Rockchip processors and often offering NVMe, faster networking, or more RAM than a comparably priced Raspberry Pi.
-keywords: Rock Pi, Radxa, Rockchip, RK3588, ROCK 5, NVMe SBC, Raspberry Pi alternative, ARM single-board computer
+keywords: Rock Pi, Radxa, Rockchip, RK3588, ROCK 5, NVMe SBC, Raspberry Pi alternative, ARM single-board computer, fast storage
 aka: [Radxa Rock]
 infobox:
   - { label: Type, value: Single-board computer }
@@ -21,13 +21,50 @@ cite_urls:
 
 **Rock Pi** is a family of [single-board computers](/reference/single-board-computer/) from Radxa of China, built mainly on Rockchip chips and often offering faster I/O than a similarly priced [Raspberry Pi](/reference/raspberry-pi/).[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 150" role="img" aria-label="A storage comparison. A Raspberry Pi routes its filesystem over a slow microSD card path, shown as a thin pipe. A Rock Pi adds an NVMe solid-state drive on a PCIe lane, shown as a much wider pipe, so recording raw IQ or keeping a large call archive runs far faster." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.3">
+    <rect x="30" y="28" width="70" height="34" rx="4" fill-opacity="0.06" fill="currentColor"/>
+    <rect x="30" y="92" width="70" height="34" rx="4" fill-opacity="0.06" fill="currentColor"/>
+    <path d="M100 45 H320" stroke-width="1.6"/>
+    <path d="M100 103 L320 103 L320 121 L100 121 Z" fill-opacity="0.14" fill="currentColor"/>
+    <rect x="340" y="30" width="86" height="30" rx="3" fill-opacity="0.1" fill="currentColor"/>
+    <rect x="340" y="92" width="86" height="34" rx="3" fill-opacity="0.2" fill="currentColor"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="8" text-anchor="middle">
+    <text x="65" y="42" font-size="8" font-weight="600">Rock Pi</text>
+    <text x="65" y="54" font-size="6.5">RK3588</text>
+    <text x="65" y="106" font-size="8" font-weight="600">Rasp. Pi</text>
+    <text x="65" y="118" font-size="6.5">Pi 4</text>
+    <text x="210" y="40" font-size="7">PCIe lane — wide, fast</text>
+    <text x="210" y="115" font-size="7">microSD — narrow, slow</text>
+    <text x="383" y="49" font-size="8" font-weight="600">NVMe SSD</text>
+    <text x="383" y="106" font-size="7.5">microSD</text>
+    <text x="383" y="118" font-size="7.5">card</text>
+  </g>
+</svg>
+<figcaption>The Rock Pi's edge is I/O: an NVMe SSD on a PCIe lane moves data far faster than the microSD card a stock Pi of the same price relies on — the difference that matters when a node records raw IQ or keeps a large archive.</figcaption>
+</figure>
+
 ## Overview
 
-The line is built around Rockchip SoCs — the powerful RK3588 powers the higher-end ROCK 5 boards — and frequently adds features the Pi lacks at the same price, such as an [NVMe](/reference/nvme/) slot, faster Ethernet, or more RAM. Boards run Linux or Android and keep a Pi-style [GPIO](/reference/gpio/) header. As with most Pi alternatives, software polish trails the Raspberry Pi.
+The line is built around Rockchip SoCs — the powerful RK3588 powers the higher-end ROCK 5 boards — and frequently adds features the Pi lacks at the same price, such as an [NVMe](/reference/nvme/) slot, faster Ethernet, or more RAM. The NVMe slot is the headline: instead of running the whole system off a microSD card, a Rock Pi can boot and store data on a proper solid-state drive over PCIe, which transforms any workload that reads or writes a lot of data.
+
+Boards run Linux or Android and keep a Pi-style [GPIO](/reference/gpio/) header, so much of the Pi accessory ecosystem carries over mechanically. As with most Pi alternatives, software polish trails the Raspberry Pi — vendor images and community depth are not quite at Pi levels — but Radxa's boards are generally among the better-supported of the alternatives.
+
+## Rock Pi vs a stock Pi
+
+| | [Raspberry Pi](/reference/raspberry-pi/) 4 | Rock Pi / ROCK 5 |
+|---|-------------|------------------|
+| SoC | Broadcom quad-core | Rockchip (RK3588, 8-core) |
+| Fast storage | microSD (optional USB SSD) | Native NVMe over PCIe |
+| RAM ceiling | Up to 8 GB | Up to 16–32 GB |
+| Networking | Gigabit | Gigabit / 2.5 GbE on some |
+| Software polish | Excellent | Good, trails the Pi |
 
 ## Where it fits
 
-Rock Pi competes with [ODROID](/reference/odroid/), [Orange Pi](/reference/orange-pi/), and [Banana Pi](/reference/banana-pi/), and is a natural pick when fast local storage matters. A GopherTrunk node that records raw IQ or keeps days of decoded calls benefits from NVMe rather than an SD card, which is where a Rock Pi can edge out a stock Pi.
+Rock Pi competes with [ODROID](/reference/odroid/), [Orange Pi](/reference/orange-pi/), and [Banana Pi](/reference/banana-pi/), and is a natural pick when fast local storage matters. A GopherTrunk node that records raw IQ or keeps days of decoded calls benefits from NVMe rather than an SD card, which is where a Rock Pi can clearly edge out a stock Pi: SD cards are both slow and prone to wear out under continuous writes, while an NVMe drive sustains the throughput a busy capture-and-archive node generates. The extra RAM and cores also give more headroom for decoding several channels at once.
 
 ## Sources
 

--- a/docs/reference/rp2040.md
+++ b/docs/reference/rp2040.md
@@ -3,8 +3,8 @@ slug: rp2040
 title: RP2040
 entry_type: hardware
 category: hw-microcontrollers
-description: The RP2040 is a low-cost dual-core ARM Cortex-M0+ microcontroller designed by Raspberry Pi, notable for its programmable I/O (PIO) blocks and use in the Raspberry Pi Pico.
-keywords: RP2040, Raspberry Pi Pico, PIO, programmable IO, dual core, Cortex-M0+, MicroPython, C SDK
+description: The RP2040 is a low-cost dual-core ARM Cortex-M0+ microcontroller designed by Raspberry Pi, notable for its programmable I/O (PIO) blocks and its use in the Raspberry Pi Pico.
+keywords: RP2040, Raspberry Pi Pico, PIO, programmable IO, dual core, Cortex-M0+, MicroPython, C SDK, state machine
 aka: [RP2040]
 autolink: true
 infobox:
@@ -23,13 +23,62 @@ cite_urls:
 
 **RP2040** is a low-cost, dual-core [microcontroller](/reference/microcontroller/) designed in-house by Raspberry Pi, built on two [ARM Cortex-M0+](/reference/arm-cortex-m/) cores.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 176" role="img" aria-label="Block diagram of the RP2040 chip. Two ARM Cortex-M0+ cores share 264 kilobytes of on-chip SRAM and connect to external QSPI flash. A bus links them to standard peripherals, and to two programmable I/O blocks, each containing state machines that drive the GPIO pins to bit-bang custom digital protocols without loading the cores." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.3">
+    <rect x="28" y="30" width="72" height="28" rx="4" fill="currentColor" fill-opacity="0.14"/>
+    <rect x="28" y="66" width="72" height="28" rx="4" fill="currentColor" fill-opacity="0.14"/>
+    <rect x="128" y="44" width="70" height="36" rx="4" fill="currentColor" fill-opacity="0.08"/>
+    <rect x="128" y="100" width="70" height="26" rx="4" fill="currentColor" fill-opacity="0.06"/>
+    <rect x="226" y="42" width="96" height="40" rx="4" fill="currentColor" fill-opacity="0.06"/>
+    <rect x="226" y="96" width="96" height="46" rx="4" fill="currentColor" fill-opacity="0.16"/>
+    <rect x="352" y="96" width="84" height="46" rx="4" fill="currentColor" fill-opacity="0.06"/>
+    <line x1="100" y1="44" x2="128" y2="56"/>
+    <line x1="100" y1="80" x2="128" y2="68"/>
+    <line x1="198" y1="62" x2="226" y2="62"/>
+    <line x1="163" y1="80" x2="163" y2="100"/>
+    <line x1="274" y1="82" x2="274" y2="96"/>
+    <line x1="322" y1="119" x2="352" y2="119"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="64" y="48" font-size="8">Core 0</text>
+    <text x="64" y="84" font-size="8">Core 1</text>
+    <text x="163" y="60" font-size="7.5" font-weight="600">SRAM</text>
+    <text x="163" y="72" font-size="7" fill-opacity="0.85">264 KB</text>
+    <text x="163" y="117" font-size="7.5">QSPI flash</text>
+    <text x="274" y="58" font-size="7.5">Peripherals</text>
+    <text x="274" y="70" font-size="7" fill-opacity="0.85">UART/SPI/I&#178;C/ADC</text>
+    <text x="274" y="116" font-size="8" font-weight="600">PIO blocks</text>
+    <text x="274" y="128" font-size="7" fill-opacity="0.85">state machines</text>
+    <text x="394" y="116" font-size="8">GPIO</text>
+    <text x="394" y="128" font-size="7" fill-opacity="0.85">bit-banged</text>
+  </g>
+</svg>
+<figcaption>The RP2040's twist is the PIO block: alongside two Cortex-M0+ cores, shared SRAM, and the usual peripherals sit programmable state machines that drive the GPIO pins directly, generating or capturing custom digital protocols at high speed without stealing core cycles.</figcaption>
+</figure>
+
 ## Overview
 
 Its signature feature is **PIO** (programmable I/O): small state machines that can be programmed to bit-bang custom digital protocols at high speed, freeing the main cores from timing-critical work. The chip pairs 264 KB of on-chip SRAM with external QSPI flash and offers the usual [GPIO](/reference/gpio/), [UART](/reference/uart/), [SPI](/reference/spi/), [I²C](/reference/i2c/), [PWM](/reference/pulse-width-modulation/), and [ADC](/reference/analog-to-digital-converter/) peripherals. It is programmed in C/C++ via the Pico SDK, in MicroPython, or in Rust.
 
+Notably, Raspberry Pi designed the RP2040 itself rather than licensing a ready-made microcontroller — the first silicon from the foundation — while still building on Arm's licensed Cortex-M0+ core.
+
+## Key specifications
+
+The headline numbers behind the chip:
+
+| Spec | RP2040 |
+|------|--------|
+| Cores | 2 × ARM Cortex-M0+ |
+| Clock | Up to 133 MHz |
+| SRAM | 264 KB on-chip |
+| Flash | External QSPI (none on-chip) |
+| Standout | 2 × PIO blocks (8 state machines) |
+| GPIO | 30 pins |
+
 ## Where it fits
 
-The RP2040 first shipped on the [Raspberry Pi Pico](/reference/raspberry-pi-pico/) board, but it is sold as a bare chip and now appears in boards from many vendors and in the wireless Pico W. PIO makes it unusually good at driving LED strips, generating waveforms, or implementing odd interfaces — work that would otherwise need an [STM32](/reference/stm32/) or external logic.
+The RP2040 first shipped on the [Raspberry Pi Pico](/reference/raspberry-pi-pico/) board, but it is sold as a bare chip and now appears in boards from many vendors and in the wireless Pico W. PIO makes it unusually good at driving LED strips, generating waveforms, or implementing odd interfaces — work that would otherwise need an [STM32](/reference/stm32/) or external logic. That same PIO flexibility makes it a handy timing-and-GPIO helper beside an SDR capture node, handling protocol chores the decode host would rather not.
 
 ## Sources
 

--- a/docs/reference/sbc-cluster.md
+++ b/docs/reference/sbc-cluster.md
@@ -4,7 +4,7 @@ title: SBC cluster
 entry_type: concept
 category: hw-sbc
 description: An SBC cluster is several single-board computers networked together to share work, used to learn distributed computing, build cheap low-power compute, or run lightweight container orchestration at home.
-keywords: SBC cluster, Raspberry Pi cluster, Pi cluster, Kubernetes cluster, distributed computing, parallel computing, home lab, low-power cluster
+keywords: SBC cluster, Raspberry Pi cluster, Pi cluster, Kubernetes cluster, distributed computing, parallel computing, home lab, low-power cluster, edge nodes
 aka: [Pi cluster]
 infobox:
   - { label: Type, value: Computing arrangement }
@@ -21,13 +21,48 @@ cite_urls:
 
 **An SBC cluster** is several [single-board computers](/reference/single-board-computer/) networked together so they share work — a small computer cluster built from boards like the [Raspberry Pi](/reference/raspberry-pi/).[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 168" role="img" aria-label="A cluster topology. A central network switch connects up to four single-board computer nodes over Ethernet. One node is marked as the controller that schedules work, and the other three are workers that run it; a job can be spread across the workers and a failed board replaced without taking the cluster down." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.3">
+    <rect x="176" y="66" width="108" height="30" rx="4" fill-opacity="0.14" fill="currentColor"/>
+    <path d="M110 66 L200 42 M230 96 L230 130 M320 66 L260 42 M150 96 L150 130 M310 96 L310 130"/>
+    <rect x="70" y="20" width="80" height="26" rx="4" fill-opacity="0.16" fill="currentColor"/>
+    <rect x="210" y="20" width="80" height="26" rx="4" fill-opacity="0.06" fill="currentColor"/>
+    <rect x="110" y="130" width="80" height="26" rx="4" fill-opacity="0.06" fill="currentColor"/>
+    <rect x="270" y="130" width="80" height="26" rx="4" fill-opacity="0.06" fill="currentColor"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="8" text-anchor="middle">
+    <text x="230" y="85" font-size="9" font-weight="600">network switch</text>
+    <text x="110" y="37" font-size="7.5" font-weight="600">controller</text>
+    <text x="250" y="37" font-size="7.5">worker</text>
+    <text x="150" y="147" font-size="7.5">worker</text>
+    <text x="310" y="147" font-size="7.5">worker</text>
+    <text x="230" y="164" font-size="7.5" fill-opacity="0.9">controller schedules · workers run · a dead node is just replaced</text>
+  </g>
+</svg>
+<figcaption>An SBC cluster wires several boards to a switch: a controller node schedules work across the worker nodes, and because the work is spread rather than pinned, a failed board can be swapped out without bringing the whole system down.</figcaption>
+</figure>
+
 ## Overview
 
-The boards are linked over Ethernet through a switch and coordinated by software, frequently Kubernetes or another container orchestrator, so jobs can be spread across nodes and a failed board can be replaced without taking the whole system down. People build them to learn distributed computing hands-on, to assemble cheap and low-power compute, or to run a resilient home lab.
+The boards are linked over Ethernet through a switch and coordinated by software, frequently Kubernetes or another container orchestrator, so jobs can be spread across nodes and a failed board can be replaced without taking the whole system down. One board usually acts as the controller that decides what runs where, and the rest are workers that carry it out; the orchestrator watches for a node dropping out and reschedules its work elsewhere.
+
+People build them to learn distributed computing hands-on, to assemble cheap and low-power compute, or to run a resilient home lab. A rack of small boards is a tangible way to see scheduling, networking, and failover work — everything a cloud does invisibly is here on a shelf, blinking, and cheap enough that a mistake costs a board, not a bill.
+
+## Why build one
+
+| Motive | What the cluster gives | Honest limit |
+|--------|------------------------|--------------|
+| Learning | Real distributed-systems practice | A single PC is faster |
+| Redundancy | Survives one node failing | More parts to fail overall |
+| Low-power compute | Many watts-scale nodes | Poor throughput per dollar |
+| Physical distribution | Nodes near different locations | Coordination overhead |
 
 ## Trade-offs
 
-A cluster of small boards rarely beats one capable machine on raw throughput per dollar or watt, so the payoff is usually learning, redundancy, or physical distribution rather than peak performance. In GopherTrunk terms, the natural reason to spread work across boards is geography, not horsepower: separate capture nodes near different antennas, each decoding locally and feeding a shared collector — closer to [edge computing](/reference/edge-computing/) than to a number-crunching cluster.
+A cluster of small boards rarely beats one capable machine on raw throughput per dollar or watt, so the payoff is usually learning, redundancy, or physical distribution rather than peak performance. Splitting a single heavy job across weak nodes and a slow network often runs slower than the same job on one strong box, once the coordination cost is counted.
+
+In GopherTrunk terms, the natural reason to spread work across boards is geography, not horsepower: separate capture nodes near different antennas, each decoding locally and feeding a shared collector — closer to [edge computing](/reference/edge-computing/) than to a number-crunching cluster. Each node does the radio work where the signal is strong, and only compact decoded results travel back over the network, which is exactly the case where distribution earns its keep.
 
 ## Sources
 

--- a/docs/reference/scalability.md
+++ b/docs/reference/scalability.md
@@ -4,12 +4,13 @@ title: Scalability
 entry_type: concept
 category: hw-servers
 description: Scalability is a system's ability to handle growing load by adding resources, either by using bigger machines (vertical) or by adding more machines (horizontal).
-keywords: scalability, scaling, vertical scaling, horizontal scaling, scale up, scale out, elasticity
+keywords: scalability, scaling, vertical scaling, horizontal scaling, scale up, scale out, elasticity, stateless
 infobox:
   - { label: Type, value: System property }
   - { label: Vertical, value: Bigger machine (scale up) }
   - { label: Horizontal, value: More machines (scale out) }
   - { label: Related, value: Elasticity }
+  - { label: Sibling goal, value: High availability }
 see_also: [high-availability, load-balancer, cloud-computing, kubernetes, serverless-computing, server]
 cite_urls:
   - https://en.wikipedia.org/wiki/Scalability
@@ -17,9 +18,60 @@ cite_urls:
 
 **Scalability** is a system's ability to handle growing load by adding resources — either by using a bigger machine (vertical scaling) or by adding more machines (horizontal scaling).[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 180" role="img" aria-label="Two scaling strategies. Scaling up replaces one server with a single larger, more powerful server. Scaling out keeps modest servers but adds more of them side by side behind a load balancer that spreads the work across all of them." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="currentColor" font-family="ui-sans-serif, sans-serif">
+    <text x="115" y="18" text-anchor="middle" font-size="9" font-weight="600" stroke="none">SCALE UP (vertical)</text>
+    <rect x="60" y="112" width="34" height="30" rx="2" fill-opacity="0.14" stroke-width="1.2"/>
+    <text x="77" y="131" text-anchor="middle" font-size="7" stroke="none">1x</text>
+    <line x1="104" y1="127" x2="128" y2="127" stroke-width="1.3" fill="none"/>
+    <path d="M128 127 l-8 -3 v6 z" stroke-width="1"/>
+    <rect x="134" y="60" width="56" height="82" rx="3" fill-opacity="0.22" stroke-width="1.4"/>
+    <text x="162" y="104" text-anchor="middle" font-size="8" stroke="none">4x</text>
+    <text x="115" y="160" text-anchor="middle" font-size="7.5" stroke="none" fill-opacity="0.85">one bigger machine</text>
+    <text x="115" y="171" text-anchor="middle" font-size="7" stroke="none" fill-opacity="0.7">simple, but has a ceiling</text>
+
+    <text x="345" y="18" text-anchor="middle" font-size="9" font-weight="600" stroke="none">SCALE OUT (horizontal)</text>
+    <rect x="300" y="34" width="90" height="20" rx="3" fill-opacity="0.18" stroke-width="1.3"/>
+    <text x="345" y="48" text-anchor="middle" font-size="7.5" stroke="none">load balancer</text>
+    <g stroke-width="1.2" fill-opacity="0.14">
+      <rect x="278" y="96" width="30" height="30" rx="2"/>
+      <rect x="314" y="96" width="30" height="30" rx="2"/>
+      <rect x="350" y="96" width="30" height="30" rx="2"/>
+      <rect x="386" y="96" width="30" height="30" rx="2"/>
+    </g>
+    <g stroke-width="1" fill="none">
+      <line x1="330" y1="54" x2="293" y2="96"/>
+      <line x1="340" y1="54" x2="329" y2="96"/>
+      <line x1="350" y1="54" x2="365" y2="96"/>
+      <line x1="360" y1="54" x2="401" y2="96"/>
+    </g>
+    <text x="345" y="145" text-anchor="middle" font-size="7.5" stroke="none" fill-opacity="0.85">more modest machines</text>
+    <text x="345" y="156" text-anchor="middle" font-size="7" stroke="none" fill-opacity="0.7">no hard ceiling; needs stateless design</text>
+  </g>
+</svg>
+<figcaption>Scaling up swaps in a single larger server — simple but bounded by the biggest box you can buy; scaling out adds more modest servers behind a load balancer, which has no hard ceiling but requires software built to spread across many machines.</figcaption>
+</figure>
+
 ## Overview
 
-*Vertical* scaling, or scaling up, means giving one server more CPU, memory, or faster disks. It is simple but bounded by the largest machine you can buy and leaves a single point of failure. *Horizontal* scaling, or scaling out, means running many servers behind a [load balancer](/reference/load-balancer/) and dividing the work among them. Scaling out has no hard ceiling and pairs naturally with redundancy, but the software must be designed for it — stateless services and shared data stores scale out far more easily than monoliths. *Elasticity* is the related ability to add and remove capacity automatically as demand changes.
+*Vertical* scaling, or scaling up, means giving one server more CPU, memory, or faster disks. It is simple but bounded by the largest machine you can buy and leaves a single point of failure. *Horizontal* scaling, or scaling out, means running many servers behind a [load balancer](/reference/load-balancer/) and dividing the work among them.
+
+Scaling out has no hard ceiling and pairs naturally with redundancy, but the software must be designed for it — *stateless* services and shared data stores scale out far more easily than monoliths that keep session state in local memory. *Elasticity* is the related ability to add and remove capacity automatically as demand changes, adding servers under load and releasing them when the spike passes.
+
+## Trade-offs
+
+The two directions have opposite strengths, and real systems often scale up first, then out:
+
+| Aspect | Scale up (vertical) | Scale out (horizontal) |
+|--------|--------------------|------------------------|
+| How | Bigger single machine | More machines |
+| Ceiling | Largest box available | Effectively none |
+| Complexity | Low | Higher (distribution) |
+| Fault tolerance | Single point of failure | Survives node loss |
+| App requirement | Runs as-is | Must be stateless-friendly |
+
+Scaling up is the quick win for a single overloaded server; scaling out is what carries a system past the limits of any one machine — and, done right, improves availability along the way.
 
 ## Where it fits
 
@@ -27,4 +79,4 @@ Scalability is about handling *more*, while [high availability](/reference/high-
 
 ## Sources
 
-[^wiki]: [Scalability](https://en.wikipedia.org/wiki/Scalability) — Wikipedia, on vertical and horizontal scaling.
+[^wiki]: [Scalability](https://en.wikipedia.org/wiki/Scalability) — Wikipedia, on vertical and horizontal scaling and elasticity.

--- a/docs/reference/sd-card.md
+++ b/docs/reference/sd-card.md
@@ -4,7 +4,7 @@ title: SD card
 entry_type: hardware
 category: hw-storage
 description: An SD card is a small removable flash-memory card used for storage in cameras, phones, and single-board computers, available in SD, microSD, and high-capacity variants.
-keywords: SD card, microSD, SDHC, SDXC, flash card, memory card, speed class, removable storage
+keywords: SD card, microSD, SDHC, SDXC, flash card, memory card, speed class, removable storage, UHS, V30
 aka: [Secure Digital, microSD]
 infobox:
   - { label: Type, value: Removable flash storage }
@@ -12,20 +12,67 @@ infobox:
   - { label: Sizes, value: SD, miniSD, microSD }
   - { label: Capacity tiers, value: SD, SDHC, SDXC, SDUC }
   - { label: Common use, value: Cameras, phones, SBCs }
-see_also: [flash-memory, emmc, solid-state-drive, data-storage, raspberry-pi, file-system]
+see_also: [flash-memory, emmc, solid-state-drive, data-storage, raspberry-pi, file-system, single-board-computer]
 cite_urls:
   - https://en.wikipedia.org/wiki/SD_card
 ---
 
 An **SD card** (Secure Digital) is a small removable storage card built around [flash memory](/reference/flash-memory/), widely used in cameras, phones, and small computers.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 150" role="img" aria-label="A stylised SD card showing its notched corner, a row of gold contact pads along the bottom edge, and a speed-class rating printed on the face. A callout explains that the class number, such as V30, states the minimum sustained write speed the card guarantees for recording." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.3">
+    <path d="M120 24 H300 V126 H120 V44 L140 24 Z" fill="currentColor" fill-opacity="0.05"/>
+  </g>
+  <g stroke="currentColor" fill="currentColor" fill-opacity="0.3" stroke-width="0.6">
+    <rect x="132" y="104" width="12" height="16" rx="1"/>
+    <rect x="150" y="104" width="12" height="16" rx="1"/>
+    <rect x="168" y="104" width="12" height="16" rx="1"/>
+    <rect x="186" y="104" width="12" height="16" rx="1"/>
+    <rect x="204" y="104" width="12" height="16" rx="1"/>
+    <rect x="222" y="104" width="12" height="16" rx="1"/>
+    <rect x="240" y="104" width="12" height="16" rx="1"/>
+    <rect x="258" y="104" width="12" height="16" rx="1"/>
+  </g>
+  <g fill="currentColor" stroke="none">
+    <text x="210" y="58" font-size="10" text-anchor="middle" font-weight="600">32 GB</text>
+    <text x="210" y="82" font-size="9" text-anchor="middle">V30 &#183; UHS-I</text>
+    <text x="195" y="138" font-size="7.5" text-anchor="middle" fill-opacity="0.9">gold contact pads</text>
+  </g>
+  <g stroke="currentColor" fill="none" stroke-width="1">
+    <path d="M300 70 H340" stroke-dasharray="2 3" stroke-opacity="0.6"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="8">
+    <text x="346" y="60">speed class</text>
+    <text x="346" y="72">(here V30):</text>
+    <text x="346" y="84">min sustained</text>
+    <text x="346" y="96">write &#8805; 30 MB/s</text>
+  </g>
+  <text x="141" y="20" font-size="7.5" fill="currentColor" fill-opacity="0.85">notched corner</text>
+</svg>
+<figcaption>A row of gold pads carries the SD bus, the notched corner keys the card into its slot, and the printed speed class (here V30) promises a minimum sustained write rate — the number that matters for continuous recording.</figcaption>
+</figure>
+
 ## Overview
 
-The standard defines several physical sizes — full-size SD, miniSD, and the tiny microSD — and capacity tiers that grew over time: SDHC, SDXC, and SDUC. A small controller inside the card handles wear leveling and presents a simple block device, so the host just sees storage formatted with a [file system](/reference/file-system/). Speed classes (Class 10, UHS, V30, and so on) rate sustained write performance, which matters for high-bitrate recording.
+The standard defines several physical sizes — full-size SD, miniSD, and the tiny microSD — and capacity tiers that grew over time: SDHC, SDXC, and SDUC. A small controller inside the card handles wear leveling, bad-block remapping, and error correction, then presents a simple block device, so the host just sees storage formatted with a [file system](/reference/file-system/) (usually FAT or exFAT).
+
+Ratings on the card describe two different things. The *capacity tier* (SDHC, SDXC) sets how large the card can be and which addressing the host must support. The *speed class* (Class 10, UHS Speed Class, and the video V-classes) rates the minimum sustained write performance — the guaranteed floor under continuous recording, which matters far more than the flashy peak read numbers on the label.
+
+## Speed classes
+
+The class marking states the slowest write the card is allowed to sustain, so a recorder never outruns it:
+
+| Class mark | Min sustained write | Typical use |
+|------------|---------------------|-------------|
+| Class 10 / U1 | 10 MB/s | HD video, general |
+| U3 / V30 | 30 MB/s | 4K video capture |
+| V60 | 60 MB/s | High-bitrate 4K/8K |
+| V90 | 90 MB/s | Professional 8K |
 
 ## Where it fits
 
-The SD card is the default boot and storage medium for many single-board computers, including the [Raspberry Pi](/reference/raspberry-pi/), which boots from a microSD card by default. It is cheap and removable, but cards vary in quality and endurance, and a low-end card can wear out under constant logging. A GopherTrunk capture node can run from an SD card, though for heavy continuous writes an [eMMC](/reference/emmc/) module or an [SSD](/reference/solid-state-drive/) lasts longer.
+The SD card is the default boot and storage medium for many [single-board computers](/reference/single-board-computer/), including the [Raspberry Pi](/reference/raspberry-pi/), which boots from a microSD card by default. It is cheap and removable, but cards vary widely in quality and endurance, and a low-end card can wear out under constant logging. A GopherTrunk capture node can run from an SD card — a well-rated card easily keeps up with decoded-call logs — though for heavy continuous IQ writes an [eMMC](/reference/emmc/) module or an [SSD](/reference/solid-state-drive/) lasts longer.
 
 ## Sources
 

--- a/docs/reference/semiconductor.md
+++ b/docs/reference/semiconductor.md
@@ -3,13 +3,14 @@ slug: semiconductor
 title: Semiconductor
 entry_type: concept
 category: hw-foundations
-description: A semiconductor is a material whose electrical conductivity sits between a conductor and an insulator and can be precisely controlled, making it the basis of transistors and chips.
-keywords: semiconductor, silicon, doping, conductivity, transistor, p-type, n-type, fabrication
+description: A semiconductor is a material whose electrical conductivity sits between a conductor and an insulator and can be precisely controlled by doping, making it the basis of transistors and chips.
+keywords: semiconductor, silicon, doping, conductivity, transistor, p-type, n-type, pn junction, fabrication, band gap
 infobox:
   - { label: Type, value: Material class }
   - { label: Conductivity, value: Between conductor & insulator }
   - { label: Key material, value: Silicon }
-  - { label: Tuned by, value: Doping }
+  - { label: Tuned by, value: Doping (n-type / p-type) }
+  - { label: Key structure, value: The p–n junction }
 see_also: [transistor, integrated-circuit, logic-gate, moores-law, central-processing-unit, x86]
 cite_urls:
   - https://en.wikipedia.org/wiki/Semiconductor
@@ -17,14 +18,55 @@ cite_urls:
 
 A **semiconductor** is a material whose electrical conductivity falls between that of a conductor and an insulator and — crucially — can be precisely controlled.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 160" role="img" aria-label="A p-n junction. On the left, n-type silicon doped to have extra free electrons shown as minus signs; on the right, p-type silicon doped to have holes shown as plus signs. Where they meet, a depletion region forms, and this junction conducts current in only one direction." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.2">
+    <rect x="60" y="40" width="150" height="64" fill="currentColor" fill-opacity="0.06"/>
+    <rect x="250" y="40" width="150" height="64" fill="currentColor" fill-opacity="0.16"/>
+    <line x1="210" y1="40" x2="210" y2="104"/>
+    <line x1="250" y1="40" x2="250" y2="104"/>
+    <rect x="210" y="40" width="40" height="64" fill="currentColor" fill-opacity="0.02" stroke-dasharray="3 3"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="10" text-anchor="middle">
+    <text x="90" y="64">&#8722;</text><text x="120" y="64">&#8722;</text><text x="150" y="64">&#8722;</text><text x="180" y="64">&#8722;</text>
+    <text x="90" y="90">&#8722;</text><text x="120" y="90">&#8722;</text><text x="150" y="90">&#8722;</text><text x="180" y="90">&#8722;</text>
+    <text x="280" y="64">+</text><text x="310" y="64">+</text><text x="340" y="64">+</text><text x="370" y="64">+</text>
+    <text x="280" y="90">+</text><text x="310" y="90">+</text><text x="340" y="90">+</text><text x="370" y="90">+</text>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="135" y="30" font-size="8.5" font-weight="600">n-type</text>
+    <text x="135" y="122" font-size="7.5" fill-opacity="0.85">extra electrons</text>
+    <text x="325" y="30" font-size="8.5" font-weight="600">p-type</text>
+    <text x="325" y="122" font-size="7.5" fill-opacity="0.85">holes</text>
+    <text x="230" y="122" font-size="7" fill-opacity="0.8">depletion</text>
+    <text x="230" y="150" font-size="8" fill-opacity="0.9">the p–n junction conducts one way — the seed of the diode and transistor</text>
+  </g>
+</svg>
+<figcaption>Doping one side of silicon to have spare electrons (n-type) and the other to have holes (p-type) creates a p–n junction that passes current in only one direction — the fundamental structure from which diodes and transistors are built.</figcaption>
+</figure>
+
 ## Overview
 
-Silicon is the workhorse semiconductor. By *doping* it with tiny amounts of other elements, makers create regions that carry charge differently (*n-type* and *p-type*), and the junctions between them behave in controllable ways. That controllability is what makes a [transistor](/reference/transistor/) possible: a small signal can switch or modulate a larger current. Many such structures are then fabricated together on one die to form an [integrated circuit](/reference/integrated-circuit/).
+Silicon is the workhorse semiconductor. In its pure form it barely conducts, but by *doping* it with tiny amounts of other elements, makers create regions that carry charge differently: *n-type* silicon has spare mobile electrons (negative carriers), while *p-type* has "holes" that behave as positive carriers. Neither alone is remarkable — the magic is at the boundary.
+
+Where an n-type region meets a p-type region, a *p–n junction* forms that conducts current freely in one direction and blocks it in the other. That one-way behaviour is a diode; layering junctions so that a small signal controls a larger current gives a [transistor](/reference/transistor/). Many such structures are then fabricated together on one die to form an [integrated circuit](/reference/integrated-circuit/).
+
+## Where materials sit
+
+A material's conductivity is what places it in one of three broad classes, and the semiconductor's value is that it can be pushed toward either extreme on demand:
+
+| Class | Conductivity | Example | Role |
+|-------|--------------|---------|------|
+| Conductor | High | Copper | Wires, contacts |
+| Semiconductor | Controllable | Silicon | Switches, chips |
+| Insulator | Very low | Glass, rubber | Isolation |
+
+Because doping and applied voltage can swing a semiconductor between conducting and blocking, it can act as a controllable switch — exactly what digital logic needs.
 
 ## Where it fits
 
-Semiconductors are the physical foundation under all of digital computing: without a material you can switch on and off reliably, there are no [logic gates](/reference/logic-gate/), no [CPUs](/reference/central-processing-unit/), no chips at all. The decades-long ability to shrink semiconductor features is what powered [Moore's law](/reference/moores-law/). The same physics serves radio too — the diodes, amplifiers, and mixers in an SDR front end are semiconductor devices handling the RF before GopherTrunk decodes it.
+Semiconductors are the physical foundation under all of digital computing: without a material you can switch on and off reliably, there are no [logic gates](/reference/logic-gate/), no [CPUs](/reference/central-processing-unit/), no chips at all. The decades-long ability to shrink semiconductor features is what powered [Moore's law](/reference/moores-law/). The same physics serves radio too — the diodes, amplifiers, and mixers in an SDR front end are semiconductor devices handling the RF before GopherTrunk ever sees a sample.
 
 ## Sources
 
-[^wiki]: [Semiconductor](https://en.wikipedia.org/wiki/Semiconductor) — Wikipedia, on semiconductor materials, doping, and conductivity.
+[^wiki]: [Semiconductor](https://en.wikipedia.org/wiki/Semiconductor) — Wikipedia, on semiconductor materials, doping, n-type and p-type, and the p–n junction.

--- a/docs/reference/sensor.md
+++ b/docs/reference/sensor.md
@@ -3,8 +3,8 @@ slug: sensor
 title: Sensor
 entry_type: hardware
 category: hw-microcontrollers
-description: A sensor is a device that detects a physical quantity — temperature, light, motion, pressure — and converts it into an electrical signal a microcontroller can read and act on.
-keywords: sensor, transducer, temperature, accelerometer, light, pressure, analog, digital, I2C sensor
+description: A sensor is a device that detects a physical quantity — temperature, light, motion, pressure — and converts it into an electrical signal a microcontroller can read and act on, either as a raw analog voltage or as a digital reading over a bus.
+keywords: sensor, transducer, temperature, accelerometer, light, pressure, gas, analog, digital, I2C sensor, ADC
 infobox:
   - { label: Type, value: Input transducer }
   - { label: Senses, value: Heat, light, motion, pressure, gas }
@@ -19,13 +19,55 @@ cite_urls:
 
 **A sensor** is a device that detects a physical quantity — temperature, light, motion, pressure, gas — and converts it into an electrical signal a computer can read.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 156" role="img" aria-label="Two signal chains from the physical world into a microcontroller. In the top path, a physical quantity drives a transducer to a raw analog voltage, which an analog-to-digital converter turns into numbers the microcontroller reads. In the bottom path, a smart sensor with built-in electronics outputs an already-digital reading over an I-squared-C or SPI bus straight to the microcontroller." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.2">
+    <rect x="22" y="30" width="70" height="30" rx="4" fill="currentColor" fill-opacity="0.10"/>
+    <rect x="132" y="30" width="70" height="30" rx="4" fill="currentColor" fill-opacity="0.08"/>
+    <rect x="22" y="96" width="120" height="30" rx="4" fill="currentColor" fill-opacity="0.10"/>
+    <rect x="330" y="58" width="108" height="40" rx="4" fill="currentColor" fill-opacity="0.16"/>
+    <line x1="92" y1="45" x2="132" y2="45"/>
+    <path d="M132 45 L122 40 M132 45 L122 50" stroke-width="1.1"/>
+    <line x1="202" y1="45" x2="330" y2="66"/>
+    <path d="M330 66 L319 63 M330 66 L322 72" stroke-width="1.1"/>
+    <line x1="142" y1="111" x2="330" y2="90"/>
+    <path d="M330 90 L319 89 M330 90 L321 96" stroke-width="1.1"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="57" y="42" font-size="7.5" font-weight="600">Transducer</text>
+    <text x="57" y="53" font-size="7" fill-opacity="0.85">analog volts</text>
+    <text x="167" y="42" font-size="7.5" font-weight="600">ADC</text>
+    <text x="167" y="53" font-size="7" fill-opacity="0.85">to numbers</text>
+    <text x="82" y="108" font-size="7.5" font-weight="600">Smart sensor</text>
+    <text x="82" y="119" font-size="7" fill-opacity="0.85">digital over I&#178;C / SPI</text>
+    <text x="384" y="76" font-size="8.5" font-weight="600">Microcontroller</text>
+    <text x="384" y="88" font-size="7" fill-opacity="0.85">reads &amp; acts</text>
+    <text x="235" y="146" font-size="7.5" fill-opacity="0.9">analog path digitizes; digital sensors skip the ADC</text>
+  </g>
+</svg>
+<figcaption>Two ways a reading reaches the chip: a plain transducer outputs an analog voltage that the microcontroller's ADC turns into numbers, while a "smart" sensor with its own electronics hands over an already-digital value over I²C or SPI. Either way the sensor is the input side of the sense-decide-act loop.</figcaption>
+</figure>
+
 ## Overview
 
 Sensors are the input side of nearly every embedded device. Some output a raw analog voltage that a [microcontroller](/reference/microcontroller/) digitizes with its [ADC](/reference/analog-to-digital-converter/); many modern sensors include their own electronics and present a clean digital reading over [I²C](/reference/i2c/) or [SPI](/reference/spi/), or as a simple [GPIO](/reference/gpio/) signal. Common examples include thermistors, accelerometers and gyroscopes, photodiodes, microphones, and pressure and gas sensors.
 
+Technically a sensor is a *transducer* — it converts energy from one form (heat, light, motion) into an electrical signal. Whether that signal needs the extra analog-to-digital step or arrives ready-made as data is the main practical distinction between an analog sensor and a digital one.
+
+## Analog versus digital sensors
+
+The output format shapes how the microcontroller reads it:
+
+| Trait | Analog sensor | Digital sensor |
+|-------|---------------|----------------|
+| Output | Continuous voltage | Numbers over a bus |
+| MCU reads via | On-chip [ADC](/reference/analog-to-digital-converter/) | [I²C](/reference/i2c/) / [SPI](/reference/spi/) / GPIO |
+| Extra circuitry | Often needs conditioning | Built into the sensor |
+| Example | Thermistor, photocell | BME280, MPU-6050 |
+
 ## Where it fits
 
-Sensors give an [embedded system](/reference/embedded-system/) awareness of the physical world; paired with network connectivity they are the data source behind the [Internet of Things](/reference/internet-of-things/). The microcontroller reads the sensor, decides what to do, and drives an output — closing the loop between sensing and action. A weather station node reporting temperature and humidity over a radio link is a textbook sensor-plus-MCU device.
+Sensors give an [embedded system](/reference/embedded-system/) awareness of the physical world; paired with network connectivity they are the data source behind the [Internet of Things](/reference/internet-of-things/). The microcontroller reads the sensor, decides what to do, and drives an output — closing the loop between sensing and action. A weather-station node reporting temperature and humidity over a radio link is a textbook sensor-plus-MCU device — and precisely the kind of small transmitter whose signals GopherTrunk decodes.
 
 ## Sources
 

--- a/docs/reference/server.md
+++ b/docs/reference/server.md
@@ -4,14 +4,15 @@ title: Server
 entry_type: hardware
 category: hw-servers
 description: A server is a computer that provides services or data to other machines over a network, built for uptime and many simultaneous clients.
-keywords: server, network server, web server, application server, uptime, clients
+keywords: server, network server, web server, application server, uptime, clients, request response
 aka: [Server]
 infobox:
   - { label: Type, value: Networked computer }
   - { label: Role, value: Serves clients }
   - { label: Built for, value: Uptime & concurrency }
   - { label: Building blocks, value: CPU, RAM, storage, I/O }
-see_also: [web-hosting, virtual-private-server, dedicated-server, home-server, cloud-computing]
+  - { label: Obtained as, value: Web host, VPS, dedicated, cloud }
+see_also: [web-hosting, virtual-private-server, dedicated-server, home-server, cloud-computing, network-attached-storage]
 related_lessons:
   - { title: "Web & shared hosting", url: /learn/intro-hardware/web-hosting/ }
 cite_urls:
@@ -20,13 +21,63 @@ cite_urls:
 
 A **server** is a computer that provides services or data to other machines over a network — serving web pages, running an application, or storing files for clients to fetch.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 180" role="img" aria-label="Several client devices on the left send requests over a network to a single server on the right, which sends responses back. The server box is opened to show its four building blocks: CPU, RAM, storage, and input-output, and a note that it is built for uptime and many simultaneous clients." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="currentColor" font-family="ui-sans-serif, sans-serif">
+    <g stroke-width="1.1" fill-opacity="0.14">
+      <rect x="26" y="40" width="40" height="26" rx="2"/>
+      <rect x="26" y="78" width="40" height="26" rx="2"/>
+      <rect x="26" y="116" width="40" height="26" rx="2"/>
+    </g>
+    <text x="46" y="156" text-anchor="middle" font-size="7.5" stroke="none" fill-opacity="0.85">clients</text>
+    <g fill="none" stroke-width="1.3">
+      <line x1="70" y1="53" x2="150" y2="80"/>
+      <line x1="70" y1="91" x2="150" y2="91"/>
+      <line x1="70" y1="129" x2="150" y2="102"/>
+    </g>
+    <path d="M150 80 l-8 0 3 -5 z" stroke-width="1"/>
+    <text x="108" y="66" text-anchor="middle" font-size="7" stroke="none" fill-opacity="0.8">request</text>
+    <text x="108" y="120" text-anchor="middle" font-size="7" stroke="none" fill-opacity="0.8">response</text>
+    <rect x="152" y="40" width="150" height="104" rx="4" fill-opacity="0.06" stroke-width="1.5"/>
+    <text x="227" y="34" text-anchor="middle" font-size="9" font-weight="600" stroke="none">Server</text>
+    <g stroke-width="1.1" font-size="7.5">
+      <rect x="162" y="50" width="64" height="26" rx="2" fill-opacity="0.16"/><text x="194" y="66" text-anchor="middle" stroke="none">CPU</text>
+      <rect x="230" y="50" width="64" height="26" rx="2" fill-opacity="0.16"/><text x="262" y="66" text-anchor="middle" stroke="none">RAM</text>
+      <rect x="162" y="80" width="64" height="26" rx="2" fill-opacity="0.16"/><text x="194" y="96" text-anchor="middle" stroke="none">storage</text>
+      <rect x="230" y="80" width="64" height="26" rx="2" fill-opacity="0.16"/><text x="262" y="96" text-anchor="middle" stroke="none">I/O</text>
+    </g>
+    <text x="227" y="124" text-anchor="middle" font-size="7" stroke="none" fill-opacity="0.8">built for uptime &amp; concurrency</text>
+    <text x="378" y="60" text-anchor="middle" font-size="8" stroke="none" font-weight="600">Same blocks,</text>
+    <text x="378" y="72" text-anchor="middle" font-size="8" stroke="none" font-weight="600">different upkeep:</text>
+    <g font-size="7.5" stroke="none" text-anchor="middle" fill-opacity="0.9">
+      <text x="378" y="90">runs 24/7</text>
+      <text x="378" y="104">many clients at once</text>
+      <text x="378" y="118">redundant parts</text>
+    </g>
+  </g>
+</svg>
+<figcaption>A server answers requests from many clients at once over the network; inside it holds the same four building blocks as any computer — CPU, RAM, storage, and I/O — but is built and operated for long uptime and heavy concurrency.</figcaption>
+</figure>
+
 ## Overview
 
-Under the hood a server has the same four building blocks as any computer: a [CPU](/reference/central-processing-unit/), [RAM](/reference/random-access-memory/), [storage](/reference/data-storage/), and [I/O](/reference/input-output/). What sets it apart is how it is built and run: for long uptime and to handle many simultaneous clients without falling over. A "server" can be a rack machine in a data center, a virtual slice of one, or an old box in a closet.
+Under the hood a server has the same four building blocks as any computer: a [CPU](/reference/central-processing-unit/), [RAM](/reference/random-access-memory/), [storage](/reference/data-storage/), and [I/O](/reference/input-output/). What sets it apart is how it is built and run: for long uptime and to handle many simultaneous clients without falling over, often with redundant power supplies, error-correcting memory, and hot-swappable disks.
+
+The word describes a *role* as much as a machine. The same box can be a web server, an application server, a file server, or all three at once, depending on the software it runs. A "server" can be a rack machine in a data center, a virtual slice of one, or an old box in a closet — what makes it a server is that other machines depend on it.
 
 ## Where it fits
 
-This is the umbrella entry for the category. You usually do not buy a bare server so much as choose *how* you get one: [web hosting](/reference/web-hosting/) for the simplest sites, a [virtual private server](/reference/virtual-private-server/) for more control, a [dedicated server](/reference/dedicated-server/) for the whole machine, a [home server](/reference/home-server/) you run yourself, or [cloud computing](/reference/cloud-computing/) on demand. In GopherTrunk terms a server can store and serve decoded data, but it cannot capture RF — that still needs an antenna and a dongle on a machine with a radio front end.
+This is the umbrella entry for the category. You usually do not buy a bare server so much as choose *how* you get one:
+
+| Way to get one | You manage | Best for |
+|----------------|-----------|----------|
+| [Web hosting](/reference/web-hosting/) | Just your site | Simple sites |
+| [VPS](/reference/virtual-private-server/) | OS and up | Custom stacks, control |
+| [Dedicated server](/reference/dedicated-server/) | The whole machine | Heavy, steady load |
+| [Home server](/reference/home-server/) | Everything, incl. hardware | Self-hosting, learning |
+| [Cloud computing](/reference/cloud-computing/) | Varies by service | On-demand, elastic |
+
+In GopherTrunk terms a server can store and serve decoded data, run the web console, and archive recordings to [network-attached storage](/reference/network-attached-storage/), but it cannot capture RF — that still needs an antenna and a dongle on a machine with a radio front end.
 
 ## Sources
 

--- a/docs/reference/serverless-computing.md
+++ b/docs/reference/serverless-computing.md
@@ -4,13 +4,14 @@ title: Serverless computing
 entry_type: concept
 category: hw-servers
 description: Serverless computing is a cloud model where code runs in short-lived, provider-managed containers triggered by events, scaling automatically and billing only for actual execution, with no servers to provision.
-keywords: serverless, functions as a service, FaaS, lambda, event-driven, autoscaling, pay per use
+keywords: serverless, functions as a service, FaaS, lambda, event-driven, autoscaling, pay per use, cold start
 aka: [FaaS, Functions as a service]
 infobox:
   - { label: Type, value: Cloud execution model }
   - { label: Unit, value: Function / event handler }
   - { label: Scaling, value: Automatic, to zero }
   - { label: Billing, value: Per execution }
+  - { label: Weakness, value: Cold starts, time limits }
 see_also: [platform-as-a-service, cloud-computing, container, infrastructure-as-a-service, scalability, software-as-a-service]
 cite_urls:
   - https://en.wikipedia.org/wiki/Serverless_computing
@@ -18,9 +19,60 @@ cite_urls:
 
 **Serverless computing** is a [cloud computing](/reference/cloud-computing/) model in which code runs in short-lived, provider-managed environments triggered by events; it scales automatically and bills only for actual execution, with no servers to provision.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 170" role="img" aria-label="An event-driven flow. Events such as an HTTP request, a queue message, and a timer arrive on the left. Each fires a function that the platform runs in a freshly spun-up container. Under a burst of events several containers run in parallel, and when events stop the platform scales back to zero so nothing is billed while idle." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="currentColor" font-family="ui-sans-serif, sans-serif">
+    <g font-size="7.5" stroke="none" text-anchor="middle">
+      <rect x="20" y="34" width="72" height="20" rx="3" fill-opacity="0.12" stroke="currentColor" stroke-width="1.1"/><text x="56" y="48">HTTP request</text>
+      <rect x="20" y="72" width="72" height="20" rx="3" fill-opacity="0.12" stroke="currentColor" stroke-width="1.1"/><text x="56" y="86">queue msg</text>
+      <rect x="20" y="110" width="72" height="20" rx="3" fill-opacity="0.12" stroke="currentColor" stroke-width="1.1"/><text x="56" y="124">timer</text>
+    </g>
+    <text x="56" y="24" text-anchor="middle" font-size="8" stroke="none" font-weight="600">events</text>
+    <g stroke-width="1.3" fill="none">
+      <line x1="92" y1="44" x2="180" y2="60"/>
+      <line x1="92" y1="82" x2="180" y2="82"/>
+      <line x1="92" y1="120" x2="180" y2="104"/>
+    </g>
+    <text x="255" y="24" text-anchor="middle" font-size="8" stroke="none" font-weight="600">functions spun up on demand</text>
+    <g stroke-width="1.2" fill-opacity="0.16">
+      <rect x="182" y="46" width="46" height="30" rx="3"/>
+      <rect x="234" y="46" width="46" height="30" rx="3"/>
+      <rect x="182" y="84" width="46" height="30" rx="3"/>
+      <rect x="234" y="84" width="46" height="30" rx="3"/>
+    </g>
+    <g font-size="7" stroke="none" text-anchor="middle" fill-opacity="0.9">
+      <text x="205" y="65">fn</text><text x="257" y="65">fn</text><text x="205" y="103">fn</text><text x="257" y="103">fn</text>
+    </g>
+    <line x1="288" y1="80" x2="344" y2="80" stroke-width="1.3" fill="none"/>
+    <path d="M344 80 l-8 -3 v6 z" stroke-width="1"/>
+    <text x="316" y="72" text-anchor="middle" font-size="6.5" stroke="none" fill-opacity="0.75">idle</text>
+    <rect x="346" y="66" width="96" height="28" rx="3" fill-opacity="0.04" stroke-width="1.3" stroke-dasharray="4 3"/>
+    <text x="394" y="84" text-anchor="middle" font-size="8" stroke="none">scale to zero</text>
+    <text x="255" y="150" text-anchor="middle" font-size="8" stroke="none" fill-opacity="0.85">you pay only while a function is actually running</text>
+  </g>
+</svg>
+<figcaption>Each event fires a function that the platform runs in a freshly created container; a burst spins up many in parallel, and when events stop the platform scales to zero — so idle time costs nothing.</figcaption>
+</figure>
+
 ## Overview
 
-The name is a slight misnomer — servers still exist, but the developer never sees or manages them. You upload a function; the platform runs it on demand when an event fires (an HTTP request, a queue message, a timer), spins up [containers](/reference/container/) to handle load, and tears them down afterward. Because idle functions cost nothing, serverless can scale to zero between bursts. The trade-offs are cold-start latency, execution time limits, and statelessness — long-running or stateful work fits poorly.
+The name is a slight misnomer — servers still exist, but the developer never sees or manages them. You upload a function; the platform runs it on demand when an event fires (an HTTP request, a queue message, a timer), spins up [containers](/reference/container/) to handle load, and tears them down afterward. Because idle functions cost nothing, serverless can scale to zero between bursts.
+
+The trade-offs are real: a *cold start* delay when a new container must be created for the first request, hard limits on how long a single invocation may run, and statelessness — each call starts fresh, so anything that must persist lives in an external store. Long-running or stateful work fits poorly, but bursty, event-driven tasks fit beautifully.
+
+## Trade-offs
+
+Serverless sits at the top of the cloud abstraction ladder, giving up control for convenience:
+
+| Property | Serverless | Traditional server |
+|----------|-----------|--------------------|
+| Provisioning | None | You size the machine |
+| Scaling | Automatic, to zero | Manual or scripted |
+| Billing | Per execution | Per hour, even idle |
+| Startup latency | Cold-start delay | Always warm |
+| Long / stateful jobs | Poor fit | Fine |
+
+Where the workload is spiky and stateless, paying only for execution is a big win; where it is continuous, a server that stays warm is both simpler and cheaper.
 
 ## Where it fits
 

--- a/docs/reference/single-board-computer.md
+++ b/docs/reference/single-board-computer.md
@@ -4,7 +4,7 @@ title: Single-board computer (SBC)
 entry_type: hardware
 category: hw-sbc
 description: A single-board computer (SBC) is a complete computer built on one small circuit board, with CPU, memory, storage, and ports, capable of running a full operating system.
-keywords: single-board computer, SBC, Raspberry Pi, embedded Linux, GPIO, edge device, low power computer
+keywords: single-board computer, SBC, Raspberry Pi, embedded Linux, GPIO, edge device, low power computer, capture node
 aka: [SBC]
 autolink: true
 infobox:
@@ -23,13 +23,53 @@ cite_urls:
 
 **A single-board computer (SBC)** is a complete computer built on one small circuit board — [CPU](/reference/central-processing-unit/), [memory](/reference/random-access-memory/), [storage](/reference/data-storage/), and ports — capable of running a full [operating system](/reference/operating-system/), usually Linux.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 150" role="img" aria-label="A spectrum placing the single-board computer between a microcontroller and a personal computer. The microcontroller runs bare firmware with pins but no operating system; the SBC in the middle runs a full Linux operating system yet still exposes GPIO pins; the personal computer runs a full OS but is sealed with no direct pin access." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.3">
+    <line x1="30" y1="46" x2="430" y2="46" stroke-width="1.2"/>
+    <rect x="34" y="60" width="104" height="52" rx="5" fill-opacity="0.05" fill="currentColor"/>
+    <rect x="178" y="56" width="104" height="60" rx="5" fill-opacity="0.16" fill="currentColor"/>
+    <rect x="322" y="60" width="104" height="52" rx="5" fill-opacity="0.05" fill="currentColor"/>
+    <circle cx="52" cy="46" r="4" fill-opacity="0.2" fill="currentColor"/>
+    <circle cx="230" cy="46" r="5" fill="currentColor" fill-opacity="0.5"/>
+    <circle cx="408" cy="46" r="4" fill-opacity="0.2" fill="currentColor"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="86" y="38" font-size="8.5" font-weight="600">microcontroller</text>
+    <text x="86" y="82" font-size="7.5">firmware only</text>
+    <text x="86" y="96" font-size="7.5">pins, no OS</text>
+    <text x="230" y="34" font-size="9" font-weight="600">SBC</text>
+    <text x="230" y="80" font-size="7.5">full Linux OS</text>
+    <text x="230" y="94" font-size="7.5">and GPIO pins</text>
+    <text x="230" y="108" font-size="7.5" fill-opacity="0.9">a few watts</text>
+    <text x="374" y="38" font-size="8.5" font-weight="600">personal computer</text>
+    <text x="374" y="82" font-size="7.5">full OS</text>
+    <text x="374" y="96" font-size="7.5">sealed, no pins</text>
+    <text x="230" y="138" font-size="7.5" fill-opacity="0.9">runs a real OS like a PC — but exposes pins like a microcontroller</text>
+  </g>
+</svg>
+<figcaption>An SBC occupies the middle ground: it runs a full operating system the way a PC does, yet still breaks out GPIO pins to the physical world the way a microcontroller does — all on one small, few-watt board.</figcaption>
+</figure>
+
 ## Overview
 
-An SBC sits between a [personal computer](/reference/personal-computer/) and a [microcontroller](/reference/microcontroller/). Unlike a microcontroller, it runs a real OS and ordinary languages and tools; unlike a sealed PC or phone, it exposes [GPIO](/reference/gpio/) pins that let your code talk directly to electronics. Most are credit-card sized and draw only a few watts.
+An SBC sits between a [personal computer](/reference/personal-computer/) and a [microcontroller](/reference/microcontroller/). Unlike a microcontroller, it runs a real OS and ordinary languages and tools; unlike a sealed PC or phone, it exposes [GPIO](/reference/gpio/) pins that let your code talk directly to electronics. That combination — a familiar Linux environment plus direct hardware access — is what makes SBCs so widely used for tinkering, prototyping, and embedding.
+
+Most are credit-card sized and draw only a few watts, so they can run continuously without a fan or a meaningful power bill and fit inside small enclosures. Nearly all are built around an ARM [system-on-a-chip](/reference/system-on-a-chip/) that packs the CPU, GPU, and I/O onto one die, with RAM, storage (a microSD card, eMMC, or increasingly NVMe), and the ports all soldered to the single board.
+
+## SBC vs its neighbours
+
+| | Microcontroller | Single-board computer | Personal computer |
+|---|-----------------|------------------------|-------------------|
+| Runs an OS | No, bare firmware | Yes, full Linux | Yes, full OS |
+| GPIO pins | Yes | Yes | No (sealed) |
+| Typical power | Milliwatts | A few watts | Tens–hundreds of watts |
+| Multitasking | Very limited | Yes | Yes |
+| Best at | Tight real-time control | Embedded, always-on jobs | Heavy general compute |
 
 ## Where it fits
 
-The category is broad: the [Raspberry Pi](/reference/raspberry-pi/) is the best-known general-purpose board, the [NVIDIA Jetson](/reference/nvidia-jetson/) adds a GPU for edge AI, and the [BeagleBone](/reference/beaglebone/) emphasises real-time I/O. Their low power and small size make them well suited to always-on, embedded, and field roles — for example, a Raspberry Pi by the antenna can run GopherTrunk as a small, low-power SDR capture node.
+The category is broad: the [Raspberry Pi](/reference/raspberry-pi/) is the best-known general-purpose board, the [NVIDIA Jetson](/reference/nvidia-jetson/) adds a GPU for edge AI, and the [BeagleBone](/reference/beaglebone/) emphasises real-time I/O. Their low power and small size make them well suited to always-on, embedded, and field roles. For GopherTrunk this is a genuine fit rather than a stretch: a Raspberry Pi or similar board by the antenna can run the software as a small, low-power headless SDR capture-and-decode node, and several such nodes can be spread across sites to feed one collector.
 
 ## Sources
 

--- a/docs/reference/smartphone.md
+++ b/docs/reference/smartphone.md
@@ -4,7 +4,7 @@ title: Smartphone
 entry_type: hardware
 category: hw-mobile
 description: A smartphone is a pocket-sized touchscreen computer with a cellular connection, sensors, and a battery that runs apps, making it the most widespread computer on earth.
-keywords: smartphone, mobile phone, iOS, Android, app, touchscreen computer, cellular
+keywords: smartphone, mobile phone, iOS, Android, app, touchscreen computer, cellular, SoC, sensors
 aka: [Smartphone, Smart phone, Mobile phone]
 infobox:
   - { label: Type, value: Pocket touchscreen computer }
@@ -12,7 +12,7 @@ infobox:
   - { label: Platforms, value: iOS, Android }
   - { label: Runs, value: Apps }
   - { label: Role, value: Deployment target }
-see_also: [tablet, mobile-app-development, personal-computer, laptop, operating-system]
+see_also: [tablet, mobile-app-development, cellular-modem, smartwatch, system-on-a-chip, operating-system]
 related_lessons:
   - { title: "Smartphones", url: /learn/intro-hardware/smartphones/ }
 cite_urls:
@@ -23,14 +23,62 @@ cite_urls:
 connection, sensors, and a battery, running apps — the most widespread computer
 on earth.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 175" role="img" aria-label="A block diagram of a smartphone's internals. A central system-on-a-chip connects to five surrounding blocks: the cellular and Wi-Fi modem, the battery and power management, a cluster of sensors, the touchscreen display, and storage with memory. The SoC sits at the hub with lines to each." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.2" font-family="ui-sans-serif, sans-serif">
+    <rect x="185" y="66" width="90" height="42" rx="4" fill="currentColor" fill-opacity="0.06"/>
+    <rect x="30" y="20" width="96" height="30" rx="3"/>
+    <rect x="334" y="20" width="96" height="30" rx="3"/>
+    <rect x="20" y="124" width="96" height="30" rx="3"/>
+    <rect x="182" y="130" width="96" height="30" rx="3"/>
+    <rect x="344" y="124" width="96" height="30" rx="3"/>
+    <g stroke-width="0.9">
+      <line x1="185" y1="74" x2="126" y2="42"/>
+      <line x1="275" y1="74" x2="334" y2="42"/>
+      <line x1="192" y1="108" x2="110" y2="124"/>
+      <line x1="230" y1="108" x2="230" y2="130"/>
+      <line x1="268" y1="108" x2="360" y2="124"/>
+    </g>
+  </g>
+  <g fill="currentColor" stroke="none" font-family="ui-sans-serif, sans-serif" font-size="8.5" text-anchor="middle">
+    <text x="230" y="90">SoC (CPU/GPU)</text>
+    <text x="78" y="39">modem &#183; Wi-Fi</text>
+    <text x="382" y="39">battery / power</text>
+    <text x="68" y="143">sensors</text>
+    <text x="230" y="149">touchscreen</text>
+    <text x="392" y="143">memory &amp; storage</text>
+  </g>
+</svg>
+<figcaption>Inside a phone, a system-on-a-chip is the hub: it drives the touchscreen, talks to the cellular and Wi-Fi modem, reads a cluster of sensors, and runs off a tightly managed battery, with memory and storage close by.</figcaption>
+</figure>
+
 ## Overview
 
 Inside, a smartphone has the same building blocks as any computer — a
 [CPU](/reference/central-processing-unit/), [RAM](/reference/random-access-memory/),
-and [storage](/reference/data-storage/) — paired with a touchscreen, a radio, and
-a dense cluster of sensors. It runs a mobile
-[operating system](/reference/operating-system/), almost always Apple's iOS or
-Google's Android, and the software it runs comes packaged as apps.
+and [storage](/reference/data-storage/) — most of them integrated into a single
+[system-on-a-chip](/reference/system-on-a-chip/). Around that hub sit a
+touchscreen, a [cellular modem](/reference/cellular-modem/) and Wi-Fi radio, and a
+dense cluster of sensors: accelerometer, gyroscope, magnetometer, GPS, and more.
+
+It runs a mobile [operating system](/reference/operating-system/), almost always
+Apple's iOS or Google's Android, and the software it runs comes packaged as apps.
+The whole design is a negotiation with the battery: performance, screen
+brightness, and radio use are all traded against how long a single charge lasts.
+
+## Phone vs tablet vs wearable
+
+The mobile tiers differ mostly in size, screen, and power budget:
+
+| Trait | Smartphone | Tablet | Wearable |
+|-------|-----------|--------|----------|
+| Screen | ~6 in | ~10 in | ~1–2 in / none |
+| Cellular | Standard | Optional | Optional (eSIM) |
+| Battery | A day+ | Days | Hours–a day |
+| Primary role | Do-everything | Media, light work | Sensing, notify |
+| Standalone | Yes | Yes | Often tethered |
+
+The phone is the anchor of the group; tablets scale it up, wearables shrink it down.
 
 ## Where it fits
 
@@ -40,7 +88,8 @@ you write and build the software on a [laptop](/reference/laptop/) or
 with platform languages — [Swift](/reference/swift-language/) for iOS,
 [Kotlin](/reference/kotlin-language/) or [Java](/reference/java-language/) for
 Android — covered under [mobile app development](/reference/mobile-app-development/).
-In an SDR setup a phone is somewhere to view decoded data, not a capture machine.
+In an SDR setup a phone is somewhere to view decoded data over the capture node's
+web console, not the machine doing the decoding.
 
 ## Sources
 

--- a/docs/reference/smartwatch.md
+++ b/docs/reference/smartwatch.md
@@ -4,7 +4,7 @@ title: Smartwatch
 entry_type: hardware
 category: hw-mobile
 description: A smartwatch is a wrist-worn computer that pairs with or extends a smartphone, combining a small touchscreen, sensors, and radios to show notifications, track fitness, and run lightweight apps.
-keywords: smartwatch, wearable, Apple Watch, Wear OS, fitness tracker, wrist computer, heart rate sensor, smart watch
+keywords: smartwatch, wearable, Apple Watch, Wear OS, fitness tracker, wrist computer, heart rate sensor, smart watch, SpO2, accelerometer
 infobox:
   - { label: Type, value: Wrist-worn computer }
   - { label: Display, value: Small touchscreen }
@@ -19,13 +19,57 @@ cite_urls:
 
 A **smartwatch** is a wrist-worn computer that pairs with or extends a [smartphone](/reference/smartphone/), packing a small [touchscreen](/reference/touchscreen/), sensors, and radios into a watch-sized case.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 175" role="img" aria-label="A smartwatch and its sensor array. On the left, the watch body with a small touchscreen and a strap. On the right, callouts list what the watch senses and connects with: a touchscreen display and low-power SoC on the front, and on the back against the skin an optical heart-rate sensor, an accelerometer and gyroscope, a GPS receiver, and Bluetooth and Wi-Fi radios, all fed by a tiny battery." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.2" font-family="ui-sans-serif, sans-serif">
+    <path d="M108 30 h44 l6 18 v78 l-6 18 h-44 l-6 -18 v-78 z"/>
+    <rect x="104" y="52" width="52" height="70" rx="6" fill="currentColor" fill-opacity="0.05"/>
+    <circle cx="130" cy="145" r="7"/>
+    <circle cx="126" cy="141" r="1.6" fill="currentColor"/>
+    <circle cx="134" cy="141" r="1.6" fill="currentColor"/>
+    <circle cx="130" cy="149" r="1.6" fill="currentColor"/>
+    <g stroke-width="0.8">
+      <line x1="158" y1="60" x2="250" y2="46"/>
+      <line x1="158" y1="80" x2="250" y2="72"/>
+      <line x1="158" y1="100" x2="250" y2="98"/>
+      <line x1="137" y1="145" x2="250" y2="124"/>
+      <line x1="158" y1="115" x2="250" y2="150"/>
+    </g>
+  </g>
+  <g fill="currentColor" stroke="none" font-family="ui-sans-serif, sans-serif" font-size="8.5">
+    <text x="256" y="49">touchscreen + low-power SoC</text>
+    <text x="256" y="75">accelerometer / gyroscope</text>
+    <text x="256" y="101">GPS receiver</text>
+    <text x="256" y="127">optical heart-rate sensor</text>
+    <text x="256" y="153">Bluetooth / Wi-Fi radios</text>
+  </g>
+</svg>
+<figcaption>A smartwatch crams a display, a low-power SoC, motion and heart-rate sensors, GPS, and short-range radios into a watch case — the whole array kept alive by a battery a fraction the size of a phone's.</figcaption>
+</figure>
+
 ## Overview
 
-A smartwatch is a tightly constrained [wearable computer](/reference/wearable-computer/): a low-power [SoC](/reference/system-on-a-chip/), a small display, Bluetooth and often Wi-Fi or cellular, and sensors such as a heart-rate monitor, accelerometer, and [GPS receiver](/reference/gps-receiver/). It runs a purpose-built [mobile OS](/reference/mobile-operating-system/) — for example watchOS or Wear OS — surfacing notifications, fitness tracking, payments, and small apps. Everything is shaped by a tiny [battery](/reference/battery-technology/), forcing aggressive power management and, on many models, a daily charge.
+A smartwatch is a tightly constrained [wearable computer](/reference/wearable-computer/): a low-power [SoC](/reference/system-on-a-chip/), a small display, Bluetooth and often Wi-Fi or cellular, and sensors such as an optical heart-rate monitor, accelerometer, gyroscope, and [GPS receiver](/reference/gps-receiver/). It runs a purpose-built [mobile OS](/reference/mobile-operating-system/) — for example watchOS or Wear OS — surfacing notifications, fitness tracking, payments, and small apps.
+
+Everything is shaped by a tiny [battery](/reference/battery-technology/), forcing aggressive power management and, on many models, a daily charge. Much of the heavy work is offloaded to a paired phone over Bluetooth; the watch handles glanceable interaction and continuous sensing against the skin, which the phone in a pocket cannot do.
+
+## Smartwatch vs band vs phone
+
+The wrist tier trades capability for size at each step down from the phone:
+
+| Trait | Smartwatch | Fitness band | Smartphone |
+|-------|-----------|--------------|------------|
+| Display | Full touchscreen | Small or none | Large |
+| Apps | Yes | Fixed functions | Full stores |
+| Sensors | Rich (HR, GPS…) | Basic (HR, steps) | Rich |
+| Battery | ~1 day | Days–week | ~1 day |
+| Standalone | Some (cellular) | No | Yes |
+
+A band strips the smartwatch down to sensing and battery life; the phone is the full computer both lean on.
 
 ## Where it fits
 
-The smartwatch sits at the smallest, most personal end of the mobile spectrum: not a replacement for a phone but a glanceable extension of it, and a hub for health sensors worn against the skin. Its sealed, battery-limited design makes it purely a consumer endpoint — useful as a remote notifier, not as a place to run real compute like an SDR pipeline.
+The smartwatch sits at the smallest, most personal end of the mobile spectrum: not a replacement for a phone but a glanceable extension of it, and a hub for health sensors worn against the skin. Its sealed, battery-limited design makes it purely a consumer endpoint — useful as a remote notifier for an alert, not as a place to run real compute like an SDR pipeline.
 
 ## Sources
 

--- a/docs/reference/soc-vs-discrete.md
+++ b/docs/reference/soc-vs-discrete.md
@@ -3,8 +3,8 @@ slug: soc-vs-discrete
 title: SoC vs discrete
 entry_type: concept
 category: hw-accelerators
-description: SoC vs discrete is the design trade-off between integrating processors and accelerators onto one system-on-a-chip versus using separate dedicated chips connected on a board.
-keywords: SoC, system on a chip, discrete, integrated GPU, dedicated GPU, integration, accelerator, trade-off, edge, data center
+description: SoC vs discrete is the design trade-off between integrating processors and accelerators onto one system-on-a-chip with shared memory versus using separate dedicated chips, each with its own memory, connected on a board.
+keywords: SoC, system on a chip, discrete, integrated GPU, dedicated GPU, shared memory, PCI Express, integration, accelerator, trade-off, edge, data center
 infobox:
   - { label: Type, value: Design trade-off }
   - { label: SoC, value: One chip, shared memory, low power }
@@ -18,14 +18,66 @@ cite_urls:
 
 **SoC vs discrete** is the design trade-off between integrating the processor and its accelerators onto a single [system-on-a-chip](/reference/system-on-a-chip/) versus using separate, dedicated chips wired together on a board.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 168" role="img" aria-label="On the left, a single system-on-a-chip die holds the CPU, GPU, NPU, and modem sharing one memory pool. On the right, separate CPU and GPU chips each have their own memory and connect over a PCI Express bus on a board." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="currentColor">
+    <text x="105" y="20" text-anchor="middle" font-size="9" stroke="none" font-weight="600">SoC (integrated)</text>
+    <rect x="20" y="30" width="170" height="86" rx="6" fill-opacity="0.06" stroke-width="1.5"/>
+    <rect x="32" y="42" width="52" height="26" rx="3" fill-opacity="0.16" stroke-width="1"/>
+    <text x="58" y="59" text-anchor="middle" font-size="7.5" stroke="none">CPU</text>
+    <rect x="92" y="42" width="52" height="26" rx="3" fill-opacity="0.16" stroke-width="1"/>
+    <text x="118" y="59" text-anchor="middle" font-size="7.5" stroke="none">GPU</text>
+    <rect x="32" y="74" width="52" height="26" rx="3" fill-opacity="0.16" stroke-width="1"/>
+    <text x="58" y="91" text-anchor="middle" font-size="7.5" stroke="none">NPU</text>
+    <rect x="92" y="74" width="52" height="26" rx="3" fill-opacity="0.16" stroke-width="1"/>
+    <text x="118" y="91" text-anchor="middle" font-size="7.5" stroke="none">modem</text>
+    <rect x="150" y="42" width="30" height="58" rx="3" fill-opacity="0.10" stroke-width="1"/>
+    <text x="165" y="86" text-anchor="middle" font-size="7" stroke="none" transform="rotate(-90 165 74)">shared RAM</text>
+    <text x="105" y="130" text-anchor="middle" font-size="7.5" stroke="none" fill-opacity="0.9">one die &#183; low power &#183; small</text>
+  </g>
+  <g stroke="currentColor" fill="currentColor">
+    <text x="352" y="20" text-anchor="middle" font-size="9" stroke="none" font-weight="600">Discrete (separate)</text>
+    <rect x="256" y="30" width="192" height="86" rx="6" fill-opacity="0.03" stroke-width="1.4" stroke-dasharray="4 3"/>
+    <rect x="268" y="46" width="60" height="30" rx="3" fill-opacity="0.16" stroke-width="1"/>
+    <text x="298" y="65" text-anchor="middle" font-size="7.5" stroke="none">CPU</text>
+    <rect x="268" y="82" width="60" height="18" rx="2" fill-opacity="0.08" stroke-width="0.9"/>
+    <text x="298" y="94" text-anchor="middle" font-size="6.5" stroke="none">RAM</text>
+    <rect x="376" y="46" width="60" height="30" rx="3" fill-opacity="0.16" stroke-width="1"/>
+    <text x="406" y="65" text-anchor="middle" font-size="7.5" stroke="none">GPU</text>
+    <rect x="376" y="82" width="60" height="18" rx="2" fill-opacity="0.08" stroke-width="0.9"/>
+    <text x="406" y="94" text-anchor="middle" font-size="6.5" stroke="none">VRAM</text>
+    <line x1="328" y1="61" x2="376" y2="61" stroke-width="1.3" fill="none"/>
+    <text x="352" y="56" text-anchor="middle" font-size="6.5" stroke="none" fill-opacity="0.9">PCIe</text>
+    <text x="352" y="130" text-anchor="middle" font-size="7.5" stroke="none" fill-opacity="0.9">own memory each &#183; peak performance</text>
+  </g>
+  <text x="230" y="158" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.9">integration cuts the distance data travels; separation lets each part grow as large as its own package</text>
+</svg>
+<figcaption>An SoC packs the CPU, GPU, NPU, and modem onto one die sharing a single memory pool; a discrete design gives each chip its own memory and connects them over a bus like PCI Express — trading power and size against peak performance.</figcaption>
+</figure>
+
 ## Overview
 
 An integrated approach puts the CPU, [GPU](/reference/graphics-processing-unit/), [NPU](/reference/neural-processing-unit/), memory controller, and I/O on one die that shares a single pool of memory. A discrete approach gives an accelerator its own chip and its own high-bandwidth memory, connected over a bus such as PCI Express. Integration shortens the distance data has to travel, cutting power and latency; separation lets each part be made as large and fast as its own package allows.
 
+Shared memory is the pivotal difference. On an SoC the CPU and its accelerators read the same RAM, so passing data between them can be nearly free — no copy across a bus. A discrete accelerator has its own dedicated memory that is faster and larger than what an SoC can share, but every hand-off means copying data across the interconnect, which costs both time and energy.
+
 ## Trade-offs
 
-The SoC wins on power, physical size, and cost — which is why phones, single-board computers, and edge devices use integrated [accelerators](/reference/ai-accelerator/). The discrete part wins on peak performance and upgradability, which is why data-center training rigs and gaming PCs bolt on standalone GPUs with dedicated memory. The choice mirrors the broader [hardware-acceleration](/reference/hardware-acceleration/) question of where compute should live. For a GopherTrunk capture node, an integrated SoC board by the antenna is the natural pick: low power and small, with the radio front end doing the heavy RF work.
+The two designs optimise for opposite ends of the power-and-performance curve, and the right pick follows the device it lives in:
+
+| Aspect | SoC (integrated) | Discrete (separate) |
+|--------|------------------|---------------------|
+| Memory | Shared pool | Own dedicated memory |
+| Power &amp; size | Low, compact | High, bulky |
+| Peak performance | Limited by die area | As large as its package |
+| Data movement | Nearly free on-die | Copy across the bus |
+| Upgradability | Fixed | Swap the card |
+| Typical home | Phones, SBCs, edge | Data centers, gaming PCs |
+
+## Where it fits
+
+The SoC wins on power, physical size, and cost — which is why phones, single-board computers, and edge devices use integrated [accelerators](/reference/ai-accelerator/). The discrete part wins on peak performance and upgradability, which is why data-center training rigs and gaming PCs bolt on standalone GPUs with dedicated memory. The choice mirrors the broader [hardware-acceleration](/reference/hardware-acceleration/) question of where compute should live. For a GopherTrunk capture node, an integrated SoC board by the antenna is the natural pick: low power and small, with the radio front end doing the heavy RF work, while a rack-mounted decode server can justify a discrete GPU for many-channel processing.
 
 ## Sources
 
-[^wiki]: [System on a chip](https://en.wikipedia.org/wiki/System_on_a_chip) — Wikipedia, on integrating components onto a single chip versus discrete designs.
+[^wiki]: [System on a chip](https://en.wikipedia.org/wiki/System_on_a_chip) — Wikipedia, on integrating components onto a single chip versus discrete designs and shared versus dedicated memory.

--- a/docs/reference/solid-state-drive.md
+++ b/docs/reference/solid-state-drive.md
@@ -4,7 +4,7 @@ title: Solid-state drive (SSD)
 entry_type: hardware
 category: hw-storage
 description: A solid-state drive stores data in non-volatile flash memory with no moving parts, giving much faster access and better durability than a spinning hard disk.
-keywords: solid-state drive, SSD, flash storage, NAND, SATA SSD, NVMe SSD, wear leveling, TBW
+keywords: solid-state drive, SSD, flash storage, NAND, SATA SSD, NVMe SSD, wear leveling, TBW, random access
 aka: [SSD]
 infobox:
   - { label: Type, value: Flash non-volatile storage }
@@ -12,16 +12,64 @@ infobox:
   - { label: Interfaces, value: SATA, NVMe (PCIe) }
   - { label: Moving parts, value: None }
   - { label: Strength, value: Fast random access }
-see_also: [hard-disk-drive, flash-memory, nvme, data-storage, memory-hierarchy, file-system]
+see_also: [hard-disk-drive, flash-memory, nvme, data-storage, memory-hierarchy, file-system, emmc]
 cite_urls:
   - https://en.wikipedia.org/wiki/Solid-state_drive
 ---
 
 A **solid-state drive (SSD)** is a storage device that keeps data in non-volatile [flash memory](/reference/flash-memory/) with no moving parts, delivering far faster access than a mechanical disk.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 160" role="img" aria-label="Side-by-side comparison of an SSD and a hard disk drive. The SSD is drawn as a controller chip wired to a bank of NAND flash chips with no moving parts, so any block is reached electronically. The hard disk is drawn as a spinning platter with a seek arm that must physically swing to the right track, making random access much slower." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.2">
+    <rect x="24" y="30" width="196" height="96" rx="4" fill="currentColor" fill-opacity="0.04"/>
+    <rect x="40" y="70" width="30" height="22" rx="2" fill="currentColor" fill-opacity="0.22" stroke="none"/>
+    <rect x="96" y="46" width="26" height="18" rx="2" fill="currentColor" fill-opacity="0.15" stroke="none"/>
+    <rect x="130" y="46" width="26" height="18" rx="2" fill="currentColor" fill-opacity="0.15" stroke="none"/>
+    <rect x="164" y="46" width="26" height="18" rx="2" fill="currentColor" fill-opacity="0.15" stroke="none"/>
+    <rect x="96" y="94" width="26" height="18" rx="2" fill="currentColor" fill-opacity="0.15" stroke="none"/>
+    <rect x="130" y="94" width="26" height="18" rx="2" fill="currentColor" fill-opacity="0.15" stroke="none"/>
+    <rect x="164" y="94" width="26" height="18" rx="2" fill="currentColor" fill-opacity="0.15" stroke="none"/>
+    <path d="M70 74 H96 M70 82 H96 M70 90 H130 M122 55 H96 M122 103 H96" stroke-width="0.8"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="8">
+    <text x="55" y="84" text-anchor="middle" font-size="7.5">ctrl</text>
+    <text x="122" y="22" text-anchor="middle" font-weight="600">SSD &#8212; NAND flash chips</text>
+    <text x="122" y="142" text-anchor="middle" font-size="7.5" fill-opacity="0.9">any block reached electronically &#183; no moving parts</text>
+  </g>
+  <g stroke="currentColor" fill="none" stroke-width="1.2">
+    <rect x="240" y="30" width="196" height="96" rx="4" fill="currentColor" fill-opacity="0.04"/>
+    <circle cx="320" cy="78" r="34" fill="currentColor" fill-opacity="0.06"/>
+    <circle cx="320" cy="78" r="6" fill="currentColor" fill-opacity="0.3" stroke="none"/>
+    <line x1="410" y1="44" x2="332" y2="72" stroke-width="1.4"/>
+    <circle cx="410" cy="44" r="3" fill="currentColor" stroke="none"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="8">
+    <text x="338" y="22" text-anchor="middle" font-weight="600">HDD &#8212; spinning platter</text>
+    <text x="338" y="142" text-anchor="middle" font-size="7.5" fill-opacity="0.9">seek arm must swing to the track &#183; slower random access</text>
+  </g>
+</svg>
+<figcaption>An SSD is a controller wired to NAND flash chips, so any block is reached electronically; a hard disk must physically swing a seek arm to the right track on a spinning platter, which is why the SSD wins decisively on random access.</figcaption>
+</figure>
+
 ## Overview
 
-Where a [hard disk drive](/reference/hard-disk-drive/) seeks a head across spinning platters, an SSD reads any block electronically, so random access is orders of magnitude quicker and there is no mechanical latency or noise. A controller manages the underlying NAND, spreading writes across cells (wear leveling) because flash cells endure a limited number of erase cycles. SSDs connect over the older SATA interface or, for much higher throughput, over [NVMe](/reference/nvme/) on a [PCI Express](/reference/pci-express/) link.
+Where a [hard disk drive](/reference/hard-disk-drive/) seeks a head across spinning platters, an SSD reads any block electronically, so random access is orders of magnitude quicker and there is no mechanical latency, noise, or vibration sensitivity. A controller manages the underlying NAND, spreading writes across cells (wear leveling) because each flash cell endures only a limited number of erase cycles, and remapping cells that wear out. Endurance is often quoted as *TBW* — total bytes that can be written over the drive's life.
+
+SSDs connect over the older SATA interface, which caps around 550 MB/s, or over [NVMe](/reference/nvme/) on a [PCI Express](/reference/pci-express/) link for several times that throughput and much lower latency. Either way the medium is the same NAND flash; the interface just sets how fast the host can reach it.
+
+## SSD vs HDD
+
+The two fill the same role but trade off very differently:
+
+| Trait | SSD | HDD |
+|-------|-----|-----|
+| Moving parts | None | Platters + heads |
+| Random access | Very fast | Slow (seek + rotate) |
+| Sequential speed | High | Moderate |
+| Cost per TB | Higher | Lower |
+| Durability | Shock-resistant | Sensitive to shock |
+| Wear limit | Erase cycles (TBW) | Mechanical wear |
 
 ## Where it fits
 

--- a/docs/reference/sophie-wilson.md
+++ b/docs/reference/sophie-wilson.md
@@ -4,7 +4,7 @@ title: Sophie Wilson
 entry_type: person
 category: hw-people
 description: Sophie Wilson (born 1957) is a British computer scientist who designed the BBC Micro's BASIC and the original ARM instruction set, the architecture now found in most of the world's mobile and embedded processors.
-keywords: Sophie Wilson, ARM, ARM architecture, BBC Micro, Acorn, instruction set, RISC
+keywords: Sophie Wilson, ARM, ARM architecture, BBC Micro, BBC BASIC, Acorn, instruction set, RISC
 aka: [Sophie Wilson]
 autolink: true
 infobox:
@@ -20,6 +20,30 @@ cite_urls:
 [ARM](/reference/arm-architecture/) instruction set, the processor architecture now at the
 heart of most smartphones and a vast range of embedded devices.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A career timeline of Sophie Wilson: she wrote BBC BASIC for the BBC Micro at Acorn in 1981, designed the original ARM instruction set in 1983, saw the first ARM silicon run in 1985, and the architecture was spun out into Arm Holdings in 1990." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="66" x2="440" y2="66" stroke="currentColor" stroke-width="1.4"/>
+  <g stroke="currentColor" fill="currentColor" stroke-width="1.2">
+    <circle cx="60" cy="66" r="5" fill-opacity="0.15"/>
+    <circle cx="185" cy="66" r="6" fill="currentColor"/>
+    <circle cx="310" cy="66" r="5" fill-opacity="0.15"/>
+    <circle cx="420" cy="66" r="5" fill-opacity="0.15"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="60" y="50" font-size="9" font-weight="600">1981</text>
+    <text x="60" y="86" font-size="8">BBC BASIC</text>
+    <text x="185" y="50" font-size="9" font-weight="600">1983</text>
+    <text x="185" y="86" font-size="8">ARM ISA</text>
+    <text x="310" y="50" font-size="9" font-weight="600">1985</text>
+    <text x="310" y="86" font-size="8">first ARM silicon</text>
+    <text x="420" y="50" font-size="9" font-weight="600">1990</text>
+    <text x="420" y="86" font-size="8">Arm spun out</text>
+    <text x="235" y="112" font-size="8" fill-opacity="0.9">a simple, low-power RISC design &#8212; now tens of billions of cores a year</text>
+  </g>
+</svg>
+<figcaption>Wilson's line runs from BBC BASIC to the compact ARM instruction set she designed at Acorn — a low-power RISC idea that grew into the most widely shipped processor architecture in the world.</figcaption>
+</figure>
+
 ## Life and work
 
 At Acorn Computers, Wilson wrote the BBC BASIC language for the BBC Micro, a hugely influential
@@ -29,6 +53,13 @@ Machine — ARM — while colleague Steve Furber led the chip implementation. Th
 simple, efficient, low-power [CPU](/reference/central-processing-unit/), and the resulting RISC
 design was remarkably compact.[^wiki] The architecture was later spun out into what became
 [Arm Holdings](/reference/arm-holdings/).[^wiki]
+
+| Year | Milestone |
+|------|-----------|
+| 1981 | Writes BBC BASIC for the BBC Micro |
+| 1983 | Designs the original ARM instruction set |
+| 1985 | First ARM silicon runs |
+| 1990 | ARM spun out into Arm Holdings |
 
 ## Why they matter
 
@@ -40,7 +71,8 @@ controllers — including many of the small boards used to run SDR capture and d
 ## Legacy
 
 The instruction set she created decades ago still underlies the dominant mobile and embedded
-processor family, making it one of the most widely used designs in computing history.
+processor family, making it one of the most widely used designs in computing history — and the
+same ISA that runs GopherTrunk when it is cross-compiled for a low-power ARM capture node.
 
 ## Sources
 

--- a/docs/reference/steve-wozniak.md
+++ b/docs/reference/steve-wozniak.md
@@ -4,7 +4,7 @@ title: Steve Wozniak
 entry_type: person
 category: hw-people
 description: Steve Wozniak (born 1950) is an American engineer who designed the Apple I and Apple II computers, single-handedly engineering machines that helped launch the personal computer industry.
-keywords: Steve Wozniak, Apple I, Apple II, personal computer, Apple Computer, hardware design
+keywords: Steve Wozniak, Apple I, Apple II, personal computer, Apple Computer, floppy controller, hardware design
 aka: [Steve Wozniak, Woz, Stephen Wozniak]
 autolink: true
 infobox:
@@ -20,6 +20,27 @@ cite_urls:
 hardware that helped turn the [personal computer](/reference/personal-computer/) from a
 hobbyist kit into a consumer product.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A career timeline of Steve Wozniak: he designed the single-board Apple I in 1976, co-founded Apple Computer that same year, released the mass-market Apple II in 1977, and added a chip-efficient floppy-disk controller in 1978." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="66" x2="440" y2="66" stroke="currentColor" stroke-width="1.4"/>
+  <g stroke="currentColor" fill="currentColor" stroke-width="1.2">
+    <circle cx="70" cy="66" r="5" fill-opacity="0.15"/>
+    <circle cx="200" cy="66" r="6" fill="currentColor"/>
+    <circle cx="360" cy="66" r="5" fill-opacity="0.15"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="70" y="50" font-size="9" font-weight="600">1976</text>
+    <text x="70" y="86" font-size="8">Apple I &#38; Apple Computer</text>
+    <text x="200" y="50" font-size="9" font-weight="600">1977</text>
+    <text x="200" y="86" font-size="8">Apple II</text>
+    <text x="360" y="50" font-size="9" font-weight="600">1978</text>
+    <text x="360" y="86" font-size="8">Disk II controller</text>
+    <text x="235" y="112" font-size="8" fill-opacity="0.9">maximum capability from a minimum of chips</text>
+  </g>
+</svg>
+<figcaption>Wozniak's short, dense burst of design work: the Apple I, the mass-market Apple II, and the famously chip-efficient Disk II controller — each squeezing more from fewer parts.</figcaption>
+</figure>
+
 ## Life and work
 
 Wozniak built the Apple I as a single-board machine and, with Steve Jobs, co-founded Apple
@@ -28,6 +49,12 @@ and clever economical use of [integrated circuits](/reference/integrated-circuit
 one of the first highly successful mass-produced [personal computers](/reference/personal-computer/).[^wiki]
 He was known for tight, elegant circuit designs that squeezed maximum capability from minimal
 parts, including a floppy-disk controller built from a handful of chips.[^wiki]
+
+| Year | Milestone |
+|------|-----------|
+| 1976 | Designs the Apple I; co-founds Apple Computer |
+| 1977 | Releases the mass-market Apple II |
+| 1978 | Designs the chip-efficient Disk II controller |
 
 ## Why they matter
 
@@ -40,7 +67,8 @@ maker projects.[^wiki]
 ## Legacy
 
 Widely known as "Woz," he remains an icon of hands-on engineering and helped define the early
-personal-computer era before stepping back from day-to-day work at Apple.
+personal-computer era before stepping back from day-to-day work at Apple. The clever
+do-more-with-less circuit style he embodied still describes good embedded and SDR design today.
 
 ## Sources
 

--- a/docs/reference/stm32.md
+++ b/docs/reference/stm32.md
@@ -3,8 +3,8 @@ slug: stm32
 title: STM32
 entry_type: hardware
 category: hw-microcontrollers
-description: STM32 is STMicroelectronics' broad family of 32-bit ARM Cortex-M microcontrollers, spanning ultra-low-power to high-performance parts widely used in industrial, consumer, and hobby embedded designs.
-keywords: STM32, STMicroelectronics, ARM Cortex-M, STM32F4, STM32 Nucleo, Blue Pill, HAL, STM32CubeIDE
+description: STM32 is STMicroelectronics' broad family of 32-bit ARM Cortex-M microcontrollers, spanning ultra-low-power to high-performance parts widely used in industrial, consumer, and hobby embedded designs, all sharing one HAL and toolchain.
+keywords: STM32, STMicroelectronics, ARM Cortex-M, STM32F4, STM32H7, STM32L0, STM32 Nucleo, Blue Pill, HAL, STM32CubeIDE
 aka: [STM32]
 autolink: true
 infobox:
@@ -13,7 +13,7 @@ infobox:
   - { label: Vendor, value: STMicroelectronics }
   - { label: Tooling, value: STM32Cube, HAL, ST-LINK }
   - { label: Language, value: C, C++, Rust }
-see_also: [arm-cortex-m, microcontroller, rp2040, avr-atmega, bare-metal-programming, firmware]
+see_also: [arm-cortex-m, microcontroller, rp2040, avr-atmega, in-system-programming, real-time-operating-system]
 related_lessons:
   - { title: "What is a microcontroller?", url: /learn/intro-hardware/what-is-a-microcontroller/ }
   - { title: "MCU programming and trade-offs", url: /learn/intro-hardware/mcu-programming-and-tradeoffs/ }
@@ -23,13 +23,59 @@ cite_urls:
 
 **STM32** is STMicroelectronics' broad family of 32-bit [microcontrollers](/reference/microcontroller/) built around [ARM Cortex-M](/reference/arm-cortex-m/) cores.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 172" role="img" aria-label="A positioning chart of STM32 series on two axes. The horizontal axis is increasing performance and the vertical axis is increasing low-power focus. The low-power STM32L0 sits high on the power axis but low on performance; the value-line F0 is low on both; the mainstream F1 and F4 sit in the middle; and the high-performance F7 and H7 sit far right for performance. All share one Cortex-M core family." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.2">
+    <line x1="50" y1="26" x2="50" y2="140"/>
+    <line x1="50" y1="140" x2="440" y2="140"/>
+    <path d="M50 26 L46 34 M50 26 L54 34" stroke-width="1.1"/>
+    <path d="M440 140 L432 136 M440 140 L432 144" stroke-width="1.1"/>
+  </g>
+  <g stroke="currentColor" fill="currentColor" fill-opacity="0.18" stroke-width="1.1">
+    <circle cx="96" cy="46" r="6"/>
+    <circle cx="104" cy="118" r="6"/>
+    <circle cx="196" cy="96" r="6"/>
+    <circle cx="270" cy="72" r="7"/>
+    <circle cx="356" cy="58" r="7"/>
+    <circle cx="412" cy="44" r="8"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="8" text-anchor="middle">
+    <text x="96" y="36" font-weight="600">L0</text>
+    <text x="104" y="134" font-weight="600">F0</text>
+    <text x="196" y="86" font-weight="600">F1</text>
+    <text x="270" y="62" font-weight="600">F4</text>
+    <text x="356" y="48" font-weight="600">F7</text>
+    <text x="412" y="32" font-weight="600">H7</text>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="7.5" fill-opacity="0.9">
+    <text x="60" y="22" text-anchor="start">low-power focus &#8593;</text>
+    <text x="250" y="158" text-anchor="middle">performance &#8594;</text>
+  </g>
+</svg>
+<figcaption>One family, many trade-offs: the ultra-low-power STM32L0 favours battery life, the value-line F0 minimises cost, the mainstream F1/F4 balance both, and the F7/H7 chase raw performance. Because they all share the same Cortex-M lineage, HAL, and tools, code moves across the map with little friction.</figcaption>
+</figure>
+
 ## Overview
 
-The line spans dozens of series, from the tiny low-power STM32L0 and value-line STM32F0 up to the high-performance STM32F7 and STM32H7. All share a common peripheral set — [UART](/reference/uart/), [SPI](/reference/spi/), [I²C](/reference/i2c/), timers with [PWM](/reference/pulse-width-modulation/), and on-chip [ADCs](/reference/analog-to-digital-converter/) — and a shared HAL (hardware abstraction layer) so code ports across the family. Parts are programmed in [C](/reference/c-language/), [C++](/reference/cpp-language/), or [Rust](/reference/rust-language/) and flashed over the ST-LINK debugger using [in-system programming](/reference/in-system-programming/).
+The line spans dozens of series, from the tiny low-power STM32L0 and value-line STM32F0 up to the high-performance STM32F7 and STM32H7. All share a common peripheral set — [UART](/reference/uart/), [SPI](/reference/spi/), [I²C](/reference/i2c/), timers with [PWM](/reference/pulse-width-modulation/), and on-chip [ADCs](/reference/analog-to-digital-converter/) — and a shared HAL (hardware abstraction layer) so code ports across the family.
+
+That breadth-plus-consistency is the family's whole appeal: pick the series that fits a project's power and performance budget, and reuse most of the same code and tooling if requirements change. Parts are programmed in [C](/reference/c-language/), [C++](/reference/cpp-language/), or [Rust](/reference/rust-language/) and flashed over the ST-LINK debugger using [in-system programming](/reference/in-system-programming/).
+
+## Series at a glance
+
+A slice across the range shows the spread of cores and priorities:
+
+| Series | Core | Focus | Typical part |
+|--------|------|-------|--------------|
+| STM32L0 | Cortex-M0+ | Ultra-low power | Battery sensors |
+| STM32F0 | Cortex-M0 | Low cost | Value designs |
+| STM32F1 | Cortex-M3 | Mainstream | "Blue Pill" boards |
+| STM32F4 | Cortex-M4 | Balanced + DSP | Popular all-rounder |
+| STM32H7 | Cortex-M7 | High performance | Demanding compute |
 
 ## Where it fits
 
-STM32 is the default choice when a project outgrows an 8-bit [AVR/ATmega](/reference/avr-atmega/) but does not need a full [single-board computer](/reference/single-board-computer/). The cheap "Blue Pill" board and the official Nucleo and Discovery kits make it popular with hobbyists, while its rich peripherals and long supply lifetimes keep it common in industrial and automotive products. Many designs run [bare metal](/reference/bare-metal-programming/) or under a small [RTOS](/reference/real-time-operating-system/).
+STM32 is the default choice when a project outgrows an 8-bit [AVR/ATmega](/reference/avr-atmega/) but does not need a full [single-board computer](/reference/single-board-computer/). The cheap "Blue Pill" board and the official Nucleo and Discovery kits make it popular with hobbyists, while its rich peripherals and long supply lifetimes keep it common in industrial and automotive products. Many designs run [bare metal](/reference/bare-metal-programming/) or under a small [RTOS](/reference/real-time-operating-system/). In SDR gear an STM32 often handles front-end control — tuning, gain, and GPIO housekeeping — beside the host that does the actual decoding.
 
 ## Sources
 

--- a/docs/reference/tablet.md
+++ b/docs/reference/tablet.md
@@ -4,7 +4,7 @@ title: Tablet
 entry_type: hardware
 category: hw-mobile
 description: A tablet is a larger touchscreen device sitting between a phone and a laptop, sharing the phone operating system and app model and sometimes paired with a keyboard.
-keywords: tablet, iPad, Android tablet, touchscreen device, detachable keyboard, mobile device
+keywords: tablet, iPad, Android tablet, touchscreen device, detachable keyboard, mobile device, iPadOS
 aka: [Tablet, Tablet computer]
 infobox:
   - { label: Type, value: Large touchscreen device }
@@ -12,7 +12,7 @@ infobox:
   - { label: Platforms, value: iPadOS, Android }
   - { label: Runs, value: Apps }
   - { label: Optional, value: Detachable keyboard }
-see_also: [smartphone, mobile-app-development, laptop, personal-computer, operating-system]
+see_also: [smartphone, mobile-app-development, touchscreen, mobile-operating-system, laptop, personal-computer]
 related_lessons:
   - { title: "Tablets", url: /learn/intro-hardware/tablets/ }
 cite_urls:
@@ -22,12 +22,51 @@ cite_urls:
 **A tablet** is a larger touchscreen device that sits between a
 [smartphone](/reference/smartphone/) and a [laptop](/reference/laptop/).[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 150" role="img" aria-label="A size spectrum of three devices. On the left, a small phone held in portrait. In the middle, a larger tablet. On the right, a laptop with a hinged screen and keyboard. An arrow beneath runs from the phone's pocket portability toward the laptop's full productivity, with the tablet sitting in the middle of that range." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.2" font-family="ui-sans-serif, sans-serif">
+    <rect x="46" y="46" width="34" height="58" rx="5"/>
+    <rect x="150" y="34" width="74" height="82" rx="6" fill="currentColor" fill-opacity="0.05"/>
+    <path d="M320 42 h84 v54 h-84 z"/>
+    <path d="M310 110 h104 l-10 -14 h-84 z"/>
+    <line x1="46" y1="132" x2="410" y2="132" stroke-width="0.9"/>
+    <path d="M410 132 l-8 -4 v8 z" fill="currentColor" stroke="none"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-family="ui-sans-serif, sans-serif" font-size="8.5" text-anchor="middle">
+    <text x="63" y="120">phone</text>
+    <text x="187" y="130">tablet</text>
+    <text x="362" y="126">laptop</text>
+    <text x="120" y="146" font-size="8">pocket portability</text>
+    <text x="360" y="146" font-size="8">full productivity</text>
+  </g>
+</svg>
+<figcaption>The tablet sits midway on the size spectrum: bigger and more capable than a phone for reading and media, but lighter and more portable than a laptop — closest to the phone in software, closest to the laptop in screen.</figcaption>
+</figure>
+
 ## Overview
 
-A tablet shares the phone's mobile [operating system](/reference/operating-system/)
-and its app model, just on a bigger screen. That extra screen makes it well
-suited to media — reading, video, drawing — and to light productivity, especially
-when paired with a detachable keyboard that nudges it toward laptop territory.
+A tablet shares the phone's mobile [operating system](/reference/mobile-operating-system/)
+and its app model, just on a bigger [touchscreen](/reference/touchscreen/). That
+extra screen makes it well suited to media — reading, video, drawing — and to
+light productivity, especially when paired with a detachable keyboard that nudges
+it toward laptop territory.
+
+Under the glass it is essentially a large phone without the phone: the same class
+of [SoC](/reference/system-on-a-chip/), the same app stores, often the same OS
+(iPadOS is a tablet-tuned sibling of iOS). Cellular is usually optional rather than
+standard, and the larger body leaves room for a bigger battery and better speakers.
+
+## Phone vs tablet vs laptop
+
+The three form a ladder from most portable to most capable:
+
+| Trait | Phone | Tablet | Laptop |
+|-------|-------|--------|--------|
+| Screen | ~6 in | ~10 in | ~13–16 in |
+| Input | Touch | Touch (+ keyboard) | Keyboard & trackpad |
+| OS | Mobile | Mobile | Desktop |
+| Best for | On-the-go | Media, light work | Real work, dev |
+| Portability | Pocket | Bag | Bag, heavier |
 
 ## Where it fits
 
@@ -36,7 +75,8 @@ view and interact with data, not a development machine, and apps are still built
 on a [personal computer](/reference/personal-computer/) under
 [mobile app development](/reference/mobile-app-development/). The extra screen
 pays off wherever a phone feels cramped but a full laptop is more than the task
-needs — including reading decoded SDR output in the field.
+needs — including reading a GopherTrunk decoder's web console at the bench or in
+the field.
 
 ## Sources
 

--- a/docs/reference/teensy.md
+++ b/docs/reference/teensy.md
@@ -3,8 +3,8 @@ slug: teensy
 title: Teensy
 entry_type: hardware
 category: hw-microcontrollers
-description: Teensy is a line of compact, high-performance ARM Cortex-M microcontroller boards from PJRC, Arduino-compatible and popular for audio, USB, and demanding real-time projects.
-keywords: Teensy, PJRC, Teensy 4.0, Teensy 4.1, Cortex-M7, Arduino compatible, Teensyduino, audio library
+description: Teensy is a line of compact, high-performance ARM Cortex-M microcontroller boards from PJRC, Arduino-compatible and popular for audio, USB, and demanding real-time projects, headlined by the 600 MHz Cortex-M7 Teensy 4.x.
+keywords: Teensy, PJRC, Teensy 4.0, Teensy 4.1, Cortex-M7, Arduino compatible, Teensyduino, audio library, 600 MHz
 aka: [Teensy]
 infobox:
   - { label: Type, value: Microcontroller board }
@@ -12,7 +12,7 @@ infobox:
   - { label: Vendor, value: PJRC }
   - { label: Compatible, value: Arduino (via Teensyduino) }
   - { label: Strengths, value: USB, audio, real-time I/O }
-see_also: [arm-cortex-m, microcontroller, arduino, stm32, rp2040, firmware]
+see_also: [arm-cortex-m, microcontroller, arduino, stm32, rp2040, sensor]
 related_lessons:
   - { title: "What is a microcontroller?", url: /learn/intro-hardware/what-is-a-microcontroller/ }
   - { title: "MCU programming and trade-offs", url: /learn/intro-hardware/mcu-programming-and-tradeoffs/ }
@@ -22,13 +22,55 @@ cite_urls:
 
 **Teensy** is a line of compact, high-performance [microcontroller](/reference/microcontroller/) boards made by PJRC, built on [ARM Cortex-M](/reference/arm-cortex-m/) cores.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 156" role="img" aria-label="A bar chart comparing microcontroller clock speeds. An 8-bit Arduino Uno runs at 16 megahertz, shown as a very short bar. A 133 megahertz RP2040 is a short bar. An STM32F4 at 168 megahertz is a little longer. The 600 megahertz Cortex-M7 Teensy 4.0 towers over them all with by far the longest bar." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.1">
+    <line x1="118" y1="24" x2="118" y2="132"/>
+  </g>
+  <g stroke="currentColor" fill="currentColor" fill-opacity="0.16" stroke-width="1.1">
+    <rect x="118" y="30" width="9" height="16"/>
+    <rect x="118" y="58" width="72" height="16"/>
+    <rect x="118" y="86" width="91" height="16"/>
+    <rect x="118" y="114" width="324" height="16"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="8">
+    <text x="112" y="42" text-anchor="end">Uno (AVR)</text>
+    <text x="112" y="70" text-anchor="end">RP2040</text>
+    <text x="112" y="98" text-anchor="end">STM32F4</text>
+    <text x="112" y="126" text-anchor="end" font-weight="600">Teensy 4.0</text>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="7.5" fill-opacity="0.9">
+    <text x="133" y="42" text-anchor="start">16 MHz</text>
+    <text x="196" y="70" text-anchor="start">133 MHz</text>
+    <text x="215" y="98" text-anchor="start">168 MHz</text>
+    <text x="436" y="126" text-anchor="end">600 MHz &#183; Cortex-M7</text>
+    <text x="118" y="148" text-anchor="start" fill-opacity="0.85">clock speed (bars roughly to scale)</text>
+  </g>
+</svg>
+<figcaption>Teensy's calling card is horsepower: the Teensy 4.0's 600 MHz Cortex-M7 dwarfs a classic 16 MHz Arduino Uno and comfortably outruns typical hobby MCUs — all in a board the size of a postage stamp, still driven from the familiar Arduino IDE.</figcaption>
+</figure>
+
 ## Overview
 
 The flagship Teensy 4.0 and 4.1 run a 600 MHz Cortex-M7 — far faster than a typical hobby MCU — in a board barely larger than a postage stamp. Teensy boards are [Arduino](/reference/arduino/)-compatible through the Teensyduino add-on, so they use familiar libraries and the Arduino IDE, but they also expose deep hardware features: many [GPIO](/reference/gpio/) pins, several [UART](/reference/uart/)/[SPI](/reference/spi/)/[I²C](/reference/i2c/) buses, [PWM](/reference/pulse-width-modulation/), and strong USB support.
 
+PJRC, the small Oregon company behind Teensy, is also known for a polished audio library that turns the boards into capable real-time signal processors — a large part of their following.
+
+## Teensy 4.x versus a classic board
+
+The gap in raw capability is stark:
+
+| Spec | Arduino Uno | Teensy 4.0 |
+|------|-------------|------------|
+| Core | 8-bit AVR | 32-bit Cortex-M7 |
+| Clock | 16 MHz | 600 MHz |
+| Flash | 32 KB | 2 MB |
+| RAM | 2 KB | 1 MB |
+| FPU / DSP | No | Yes |
+
 ## Where it fits
 
-Teensy is the go-to when an Arduino-style workflow needs serious horsepower or precise timing. Its well-known audio library makes it a favorite for synthesizers and effects, and its fast cores suit MIDI controllers, data loggers, and other real-time work. Where a project wants the same class of compute with vendor tooling instead of the Arduino layer, an [STM32](/reference/stm32/) is the usual alternative.
+Teensy is the go-to when an Arduino-style workflow needs serious horsepower or precise timing. Its well-known audio library makes it a favorite for synthesizers and effects, and its fast cores suit MIDI controllers, data loggers, and other real-time work. Where a project wants the same class of compute with vendor tooling instead of the Arduino layer, an [STM32](/reference/stm32/) is the usual alternative. Its DSP-capable core and audio pipeline also make it a plausible front-end for light real-time signal work near an SDR setup — though full trunking decode still belongs on a general-purpose host.
 
 ## Sources
 

--- a/docs/reference/thin-client.md
+++ b/docs/reference/thin-client.md
@@ -4,7 +4,7 @@ title: Thin client
 entry_type: hardware
 category: hw-personal-computers
 description: A thin client is a minimal computer that does little work itself, instead connecting to a server or virtual desktop that runs the applications and stores the data centrally.
-keywords: thin client, zero client, VDI, remote desktop, virtual desktop, terminal
+keywords: thin client, zero client, VDI, remote desktop, virtual desktop, terminal, central server
 aka: [Thin client, Zero client]
 infobox:
   - { label: Type, value: Minimal networked PC }
@@ -18,13 +18,60 @@ cite_urls:
 
 A **thin client** is a minimal computer that does little processing on its own, instead connecting over a network to a [server](/reference/server/) or virtual desktop that runs the applications and holds the data.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 185" role="img" aria-label="A thin-client topology: three small thin clients on the left, each just a screen with minimal hardware, connect over a network to one central server on the right that runs the virtual desktops and stores all the data. Screen images flow back to the clients while keystrokes flow to the server." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.2">
+    <rect x="30" y="26" width="60" height="40" rx="3" fill="currentColor" fill-opacity="0.06"/>
+    <rect x="30" y="74" width="60" height="40" rx="3" fill="currentColor" fill-opacity="0.06"/>
+    <rect x="30" y="122" width="60" height="40" rx="3" fill="currentColor" fill-opacity="0.06"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle" font-size="7">
+    <text x="60" y="49">thin</text>
+    <text x="60" y="59">client</text>
+    <text x="60" y="97">thin</text>
+    <text x="60" y="107">client</text>
+    <text x="60" y="145">thin</text>
+    <text x="60" y="155">client</text>
+  </g>
+  <g stroke="currentColor" fill="none" stroke-width="1.1" stroke-dasharray="4 3">
+    <path d="M90 46 L210 90"/>
+    <path d="M90 94 L210 94"/>
+    <path d="M90 142 L210 98"/>
+  </g>
+  <text x="150" y="80" fill="currentColor" stroke="none" text-anchor="middle" font-size="7" fill-opacity="0.85">network</text>
+  <g stroke="currentColor" fill="none" stroke-width="1.4">
+    <rect x="330" y="46" width="100" height="96" rx="4" fill="currentColor" fill-opacity="0.1"/>
+    <path d="M340 66 H420 M340 82 H420 M340 98 H420 M340 114 H420"/>
+    <circle cx="348" cy="58" r="2" fill="currentColor"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="380" y="158" font-size="8" font-weight="600">server / VDI</text>
+    <text x="380" y="172" font-size="7" fill-opacity="0.85">runs the apps · holds the data</text>
+    <text x="255" y="112" font-size="6.5" fill-opacity="0.85">screen &#8592; · keys &#8594;</text>
+  </g>
+</svg>
+<figcaption>A thin client is little more than a screen on the network: many of them share one central server that runs the actual applications and stores the data, streaming each user a picture back while sending keystrokes and clicks the other way.</figcaption>
+</figure>
+
 ## Overview
 
-A thin client is essentially a screen, [keyboard](/reference/keyboard/), and [mouse](/reference/mouse/) bolted to just enough hardware to draw a remote session — a low-power [CPU](/reference/central-processing-unit/), a little [RAM](/reference/random-access-memory/), and a network port, with no spinning disk and often no local [storage](/reference/data-storage/) at all. The real computing happens centrally, frequently on a [virtualized](/reference/virtualization/) desktop infrastructure (VDI), and the thin client simply streams the picture back and forth. A *zero client* takes this further, with firmware fixed to a single remote protocol.
+A thin client is essentially a screen, [keyboard](/reference/keyboard/), and [mouse](/reference/mouse/) bolted to just enough hardware to draw a remote session — a low-power [CPU](/reference/central-processing-unit/), a little [RAM](/reference/random-access-memory/), and a network port, with no spinning disk and often no local [storage](/reference/data-storage/) at all. The real computing happens centrally, frequently on a [virtualized](/reference/virtualization/) desktop infrastructure (VDI), and the thin client simply streams the picture back and forth.
+
+A *zero client* takes this further, with firmware fixed to a single remote protocol and essentially nothing to configure. The appeal in both cases is that the valuable state lives on the server, not the device on the desk.
+
+## How it compares
+
+Where the computing and the data actually live is the whole distinction:
+
+| Machine | Runs apps | Stores data | Works standalone |
+|---------|-----------|-------------|------------------|
+| Thin client | On the server | On the server | No |
+| Chromebook | Browser + cloud | Mostly cloud | Partly |
+| Full PC | Locally | Locally | Yes |
 
 ## Where it fits
 
-Thin clients suit large organizations — call centers, hospitals, schools — where central management, security, and low per-seat cost matter more than local flexibility. Because nothing important lives on the device, a failed unit is swapped in minutes and stolen hardware leaks no data. A [Chromebook](/reference/chromebook/) is a consumer cousin of the idea. The limits are the same as that idea's: take away the network or the server and a thin client can do almost nothing, so it is a poor fit for standalone or offline compute like local SDR processing.
+Thin clients suit large organizations — call centers, hospitals, schools — where central management, security, and low per-seat cost matter more than local flexibility. Because nothing important lives on the device, a failed unit is swapped in minutes and stolen hardware leaks no data. A [Chromebook](/reference/chromebook/) is a consumer cousin of the idea. The limits are the same: take away the network or the server and a thin client can do almost nothing, so it is a poor fit for standalone or offline compute like local SDR processing.
 
 ## Sources
 

--- a/docs/reference/touchscreen.md
+++ b/docs/reference/touchscreen.md
@@ -4,7 +4,7 @@ title: Touchscreen
 entry_type: hardware
 category: hw-mobile
 description: A touchscreen is a display that also serves as an input device, sensing the position of fingers or a stylus on its surface — the primary interface for phones, tablets, and many embedded devices.
-keywords: touchscreen, capacitive, resistive, multitouch, touch panel, display input, stylus, touch sensor
+keywords: touchscreen, capacitive, resistive, multitouch, touch panel, display input, stylus, touch sensor, projected capacitive
 infobox:
   - { label: Type, value: Display + input device }
   - { label: Common tech, value: Capacitive (projected) }
@@ -19,9 +19,55 @@ cite_urls:
 
 A **touchscreen** is a display that doubles as an input device, sensing where a finger or stylus touches its surface — the defining interface of modern phones and tablets.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 160" role="img" aria-label="A projected-capacitive touchscreen sensing a fingertip. A grid of transparent horizontal and vertical electrodes is laid over the display. A fingertip touching the glass draws off a tiny amount of charge at the electrodes it covers, changing the capacitance at that crossing. The controller reads which row and column changed to find the touch coordinates." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="0.9" font-family="ui-sans-serif, sans-serif">
+    <g stroke-opacity="0.55">
+      <line x1="60" y1="44" x2="360" y2="44"/>
+      <line x1="60" y1="68" x2="360" y2="68"/>
+      <line x1="60" y1="92" x2="360" y2="92"/>
+      <line x1="60" y1="116" x2="360" y2="116"/>
+      <line x1="96" y1="30" x2="96" y2="128"/>
+      <line x1="156" y1="30" x2="156" y2="128"/>
+      <line x1="216" y1="30" x2="216" y2="128"/>
+      <line x1="276" y1="30" x2="276" y2="128"/>
+      <line x1="336" y1="30" x2="336" y2="128"/>
+    </g>
+    <rect x="46" y="132" width="328" height="12" rx="2" stroke-width="1.1"/>
+    <circle cx="216" cy="68" r="16" stroke-width="1.4"/>
+    <path d="M216 40 v-16 M216 24 a10 14 0 0 1 10 14" stroke-width="1.4"/>
+    <circle cx="216" cy="68" r="3" fill="currentColor"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-family="ui-sans-serif, sans-serif" font-size="8.5" text-anchor="middle">
+    <text x="410" y="47">rows</text>
+    <text x="216" y="20">fingertip</text>
+    <text x="210" y="142">LCD / OLED display beneath</text>
+    <text x="216" y="156" font-size="8">capacitance drops where the finger crosses the grid</text>
+  </g>
+</svg>
+<figcaption>A projected-capacitive panel is a grid of transparent electrodes over the display; a fingertip perturbs the capacitance at the row and column it covers, and the controller reads that crossing as a touch coordinate — enabling fast, accurate multitouch.</figcaption>
+</figure>
+
 ## Overview
 
-Most modern touchscreens are *projected capacitive*: a grid of transparent electrodes detects the tiny change in capacitance a fingertip causes, enabling fast, accurate *multitouch* (pinch, swipe, two-finger gestures). Older *resistive* panels sense pressure where two conductive layers meet — cheaper and usable with gloves or any stylus, but single-touch and less responsive. The panel is laminated over an LCD or OLED display, and a controller reports touch coordinates to the [mobile OS](/reference/mobile-operating-system/).
+Most modern touchscreens are *projected capacitive*: a grid of transparent electrodes detects the tiny change in capacitance a fingertip causes, enabling fast, accurate *multitouch* (pinch, swipe, two-finger gestures). Because it senses charge rather than pressure, the glass can be smooth and rigid and the surface can stay sealed.
+
+Older *resistive* panels sense pressure where two conductive layers physically meet — cheaper and usable with gloves or any stylus, but single-touch and less responsive. In both cases the sensing layer is laminated over an LCD or OLED display, and a dedicated controller reports touch coordinates to the [mobile OS](/reference/mobile-operating-system/) many times a second.
+
+## Capacitive vs resistive
+
+The two families trade responsiveness against cost and glove-friendliness:
+
+| Property | Capacitive | Resistive |
+|----------|------------|-----------|
+| Senses | Charge (finger) | Pressure |
+| Multitouch | Yes | No (typically) |
+| Clarity | High | Lower |
+| Works with gloves | No (usually) | Yes |
+| Cost | Higher | Lower |
+| Typical use | Phones, tablets | Kiosks, industrial |
+
+Capacitive won the phone era because multitouch gestures need it; resistive survives where cost or glove use matters more than finesse.
 
 ## Where it fits
 

--- a/docs/reference/tsmc.md
+++ b/docs/reference/tsmc.md
@@ -4,7 +4,7 @@ title: TSMC
 entry_type: organization
 category: hw-organizations
 description: TSMC (Taiwan Semiconductor Manufacturing Company) is the world's largest dedicated chip foundry, manufacturing integrated circuits designed by other companies on contract.
-keywords: TSMC, foundry, semiconductor manufacturing, fab, integrated circuit, fabless
+keywords: TSMC, foundry, semiconductor manufacturing, fab, integrated circuit, fabless, process node
 aka: [Taiwan Semiconductor Manufacturing Company]
 autolink: true
 infobox:
@@ -12,7 +12,7 @@ infobox:
   - { label: Founded, value: "1987" }
   - { label: HQ, value: Hsinchu, Taiwan }
   - { label: Makes, value: Integrated circuits (contract manufacturing) }
-see_also: [semiconductor, integrated-circuit, amd, nvidia]
+see_also: [semiconductor, integrated-circuit, amd, nvidia, qualcomm, moores-law]
 cite_urls:
   - https://www.tsmc.com/
   - https://en.wikipedia.org/wiki/TSMC
@@ -22,24 +22,71 @@ cite_urls:
 foundry, manufacturing [integrated circuits](/reference/integrated-circuit/) designed by
 other companies on contract.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="A diagram of the pure-play foundry model. Several fabless design houses — AMD, NVIDIA, Apple, and Qualcomm — send their chip designs to TSMC, which owns the fabrication plants and manufactures the physical silicon that is returned to each customer as finished chips. TSMC designs no branded chips of its own." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="currentColor" fill-opacity="0.12" stroke-width="1.1">
+    <rect x="16" y="14" width="96" height="22" rx="3"/>
+    <rect x="16" y="44" width="96" height="22" rx="3"/>
+    <rect x="16" y="74" width="96" height="22" rx="3"/>
+    <rect x="16" y="104" width="96" height="22" rx="3"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="8.5" text-anchor="middle">
+    <text x="64" y="29">AMD</text>
+    <text x="64" y="59">NVIDIA</text>
+    <text x="64" y="89">Apple</text>
+    <text x="64" y="119">Qualcomm</text>
+  </g>
+  <g stroke="currentColor" fill="none" stroke-width="1.1">
+    <line x1="112" y1="25" x2="196" y2="60"/>
+    <line x1="112" y1="55" x2="196" y2="66"/>
+    <line x1="112" y1="85" x2="196" y2="74"/>
+    <line x1="112" y1="115" x2="196" y2="80"/>
+    <line x1="304" y1="70" x2="356" y2="70"/>
+    <polygon points="356,70 348,66 348,74" fill="currentColor"/>
+  </g>
+  <rect x="196" y="46" width="108" height="48" rx="5" stroke="currentColor" fill="currentColor" fill-opacity="0.12" stroke-width="1.4"/>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="250" y="66" font-size="9" font-weight="600">TSMC</text>
+    <text x="250" y="80" font-size="8">owns the fabs</text>
+    <rect x="356" y="56" width="88" height="28" rx="4" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/>
+    <text x="400" y="74" font-size="8.5">finished chips</text>
+  </g>
+  <text x="240" y="112" font-size="8" fill="currentColor" text-anchor="middle" fill-opacity="0.9">fabless designers bring the design; TSMC makes the silicon</text>
+</svg>
+<figcaption>The pure-play foundry model in one picture: fabless firms like AMD, NVIDIA, Apple, and Qualcomm send designs to TSMC, which owns the fabrication plants and returns finished silicon — TSMC sells no branded chips of its own.</figcaption>
+</figure>
+
 ## Overview
 
 Founded in 1987, TSMC pioneered the "pure-play foundry" model: it does not design or sell
 its own branded chips, but instead fabricates designs supplied by customers. That model
 enabled the rise of "fabless" companies — firms like [AMD](/reference/amd/),
-[NVIDIA](/reference/nvidia/), Apple, and Qualcomm that design chips but own no factories.[^home]
+[NVIDIA](/reference/nvidia/), Apple, and [Qualcomm](/reference/qualcomm/) that design chips
+but own no factories.[^home]
 
 TSMC operates some of the most advanced [semiconductor](/reference/semiconductor/)
-fabrication plants in the world, repeatedly leading the industry to smaller process nodes.
-Because so many top chip designs are made there, its plants are a critical link in the
-global electronics supply chain.
+fabrication plants in the world, repeatedly leading the industry to smaller process nodes —
+the steady shrink that keeps [Moore's law](/reference/moores-law/) alive. Because so many top
+chip designs are made there, its plants are a critical link in the global electronics supply
+chain.
 
-## Why it matters
+## Why the model won
+
+Splitting design from manufacturing gave each side an advantage that reshaped the industry:
+
+| Party | What they gain |
+|-------|----------------|
+| Fabless designer | No multi-billion-dollar fab to build or fill |
+| TSMC (foundry) | Volume from many customers funds leading-edge fabs |
+| The industry | Faster process advances, more chip-design startups |
+
+## Where it fits
 
 Almost any modern device — a phone, a GPU, a server CPU, the SoC in a single-board computer
 running a GopherTrunk node — is likely built on silicon fabricated by TSMC. By separating
 chip design from manufacturing, TSMC reshaped the industry and concentrated a large share of
-advanced production capacity in one company.
+advanced production capacity in one company, so the RTL-SDR dongle, the Pi, and the decode
+server on a GopherTrunk bench very probably all contain TSMC-made chips.
 
 ## Sources
 

--- a/docs/reference/vector-processor.md
+++ b/docs/reference/vector-processor.md
@@ -3,13 +3,14 @@ slug: vector-processor
 title: Vector processor
 entry_type: concept
 category: hw-accelerators
-description: A vector processor is a design that applies one instruction to a whole array of data elements at once, exploiting data parallelism for high throughput in numeric and signal-processing workloads.
-keywords: vector processor, SIMD, array processor, data parallelism, SSE, AVX, NEON, supercomputer, DSP
+description: A vector processor applies one instruction to a whole array of data elements at once, exploiting data parallelism for high throughput in numeric and signal-processing workloads; the SIMD model survives in modern CPU vector units and GPUs.
+keywords: vector processor, SIMD, array processor, data parallelism, lanes, SSE, AVX, NEON, supercomputer, Cray, DSP
 aka: [Array processor]
 infobox:
   - { label: Type, value: Processor architecture }
   - { label: Model, value: "SIMD (single instruction, many data)" }
   - { label: Strength, value: Data-parallel numeric throughput }
+  - { label: Origin, value: "Cray supercomputers, 1970s" }
   - { label: Modern form, value: "SIMD units (AVX, NEON), GPUs" }
 see_also: [central-processing-unit, graphics-processing-unit, gpgpu, hardware-acceleration, digital-filter, fast-fourier-transform]
 cite_urls:
@@ -18,14 +19,74 @@ cite_urls:
 
 A **vector processor** is a processor designed to apply a single instruction to a whole array of data elements at once, rather than one element per instruction.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 170" role="img" aria-label="A scalar add processes one pair of numbers per instruction, needing four instructions for a four-element array. A vector or SIMD add processes all four lanes with a single instruction." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="currentColor">
+    <text x="20" y="20" font-size="9" stroke="none" font-weight="600">Scalar &#183; one add per instruction</text>
+    <g font-family="ui-monospace, monospace" font-size="8.5" stroke="none">
+      <rect x="20" y="30" width="26" height="18" rx="2" fill-opacity="0.12" stroke="currentColor" stroke-width="1"/>
+      <text x="33" y="43" text-anchor="middle">a0</text>
+      <text x="54" y="43" text-anchor="middle" stroke="none">+</text>
+      <rect x="62" y="30" width="26" height="18" rx="2" fill-opacity="0.12" stroke="currentColor" stroke-width="1"/>
+      <text x="75" y="43" text-anchor="middle">b0</text>
+      <text x="96" y="43" text-anchor="middle" stroke="none">=</text>
+      <rect x="104" y="30" width="26" height="18" rx="2" fill-opacity="0.22" stroke="currentColor" stroke-width="1"/>
+      <text x="117" y="43" text-anchor="middle">c0</text>
+      <text x="150" y="43" stroke="none" fill-opacity="0.85">&#8592; instruction 1</text>
+    </g>
+    <text x="20" y="66" font-size="7.5" stroke="none" fill-opacity="0.85">... then a1+b1, a2+b2, a3+b3 &#8212; four separate instructions</text>
+  </g>
+  <g stroke="currentColor" fill="currentColor">
+    <text x="20" y="94" font-size="9" stroke="none" font-weight="600">Vector / SIMD &#183; one add, four lanes</text>
+    <g font-family="ui-monospace, monospace" font-size="8.5" stroke="none">
+      <rect x="20" y="104" width="70" height="52" rx="3" fill-opacity="0.08" stroke="currentColor" stroke-width="1.1"/>
+      <text x="55" y="118" text-anchor="middle">a0</text>
+      <text x="55" y="131" text-anchor="middle">a1</text>
+      <text x="55" y="144" text-anchor="middle">a2</text>
+      <text x="55" y="156" text-anchor="middle">a3</text>
+      <text x="104" y="134" text-anchor="middle" stroke="none">+</text>
+      <rect x="118" y="104" width="70" height="52" rx="3" fill-opacity="0.08" stroke="currentColor" stroke-width="1.1"/>
+      <text x="153" y="118" text-anchor="middle">b0</text>
+      <text x="153" y="131" text-anchor="middle">b1</text>
+      <text x="153" y="144" text-anchor="middle">b2</text>
+      <text x="153" y="156" text-anchor="middle">b3</text>
+      <text x="202" y="134" text-anchor="middle" stroke="none">=</text>
+      <rect x="216" y="104" width="70" height="52" rx="3" fill-opacity="0.20" stroke="currentColor" stroke-width="1.1"/>
+      <text x="251" y="118" text-anchor="middle">c0</text>
+      <text x="251" y="131" text-anchor="middle">c1</text>
+      <text x="251" y="144" text-anchor="middle">c2</text>
+      <text x="251" y="156" text-anchor="middle">c3</text>
+      <text x="304" y="134" stroke="none" fill-opacity="0.85">&#8592; one instruction</text>
+    </g>
+  </g>
+</svg>
+<figcaption>A scalar processor adds one pair of numbers per instruction, so a four-element array costs four instructions; a vector (SIMD) unit adds all four lanes with a single instruction, amortizing the overhead across the whole array.</figcaption>
+</figure>
+
 ## Overview
 
 The model is *SIMD* — single instruction, multiple data. Where a scalar processor adds two numbers per add instruction, a vector unit adds two arrays of numbers in one go, amortizing instruction overhead and keeping wide arithmetic pipelines full. The idea powered the early Cray supercomputers and survives today as the SIMD extensions built into ordinary CPUs (Intel's SSE/AVX, ARM's NEON) and, taken to an extreme, in the thousands-of-lanes design of the [GPU](/reference/graphics-processing-unit/).
 
+The win is twofold: fewer instructions are fetched and decoded for the same work, and the hardware can lay out identical arithmetic units side by side as *lanes* that all fire together. The limit is that every lane must do the same operation in lock-step, so vector code favours long, regular arrays with no per-element branching — the further the data strays from that shape, the less the vector unit helps.
+
+## Anatomy
+
+A vector unit is defined by how wide it is and how it handles data that does not fill its lanes cleanly:
+
+| Property | Scalar | Vector / SIMD |
+|----------|--------|---------------|
+| Elements per instruction | One | Many (a full register width) |
+| Instruction overhead | Per element | Amortized over the lanes |
+| Best-case shape | Any | Long, regular arrays |
+| Branch handling | Free | Costly (predication or masks) |
+| Examples | Plain add | AVX, NEON, GPU warps |
+
+Because all lanes share one instruction stream, a vector unit spends far less silicon on control and far more on arithmetic than a scalar core — the same bargain a [GPU](/reference/graphics-processing-unit/) takes to its extreme.
+
 ## Where it fits
 
-Vector processing is the foundation of [GPGPU](/reference/gpgpu/) and of most numeric [hardware acceleration](/reference/hardware-acceleration/): any workload that does the same math across long, regular arrays benefits. Digital signal processing is a prime example — a [FIR digital filter](/reference/digital-filter/) or an [FFT](/reference/fast-fourier-transform/) multiplies and sums across streams of samples, exactly the data-parallel shape SIMD exploits. GopherTrunk's per-sample DSP on the [CPU](/reference/central-processing-unit/) leans on these vector units to keep up with high sample rates.
+Vector processing is the foundation of [GPGPU](/reference/gpgpu/) and of most numeric [hardware acceleration](/reference/hardware-acceleration/): any workload that does the same math across long, regular arrays benefits. Digital signal processing is a prime example — a [FIR digital filter](/reference/digital-filter/) or an [FFT](/reference/fast-fourier-transform/) multiplies and sums across streams of samples, exactly the data-parallel shape SIMD exploits. GopherTrunk's per-sample DSP on the [CPU](/reference/central-processing-unit/) leans on these vector units to keep up with high sample rates, processing many IQ samples per instruction rather than one at a time.
 
 ## Sources
 
-[^wiki]: [Vector processor](https://en.wikipedia.org/wiki/Vector_processor) — Wikipedia, on SIMD/array processor architectures.
+[^wiki]: [Vector processor](https://en.wikipedia.org/wiki/Vector_processor) — Wikipedia, on SIMD/array processor architectures, lanes, and the scalar-versus-vector distinction.

--- a/docs/reference/virtual-private-server.md
+++ b/docs/reference/virtual-private-server.md
@@ -4,15 +4,16 @@ title: Virtual private server (VPS)
 entry_type: concept
 category: hw-servers
 description: A virtual private server is a slice of a physical server that behaves like your own machine with root access, created by virtualization via a hypervisor.
-keywords: VPS, virtual private server, hypervisor, root access, DigitalOcean, Linode, Hetzner
+keywords: VPS, virtual private server, hypervisor, root access, DigitalOcean, Linode, Hetzner, virtual machine
 aka: [VPS]
 autolink: true
 infobox:
   - { label: Type, value: Virtual server }
   - { label: Access, value: Root / full control }
   - { label: Created by, value: Virtualization }
+  - { label: Neighbors, value: Isolated by hypervisor }
   - { label: Providers, value: DigitalOcean, Linode, Hetzner }
-see_also: [server, web-hosting, dedicated-server, virtualization, cloud-computing]
+see_also: [server, web-hosting, dedicated-server, bare-metal-server, virtualization, cloud-computing]
 related_lessons:
   - { title: "Virtual private server (VPS)", url: /learn/intro-hardware/vps/ }
   - { title: "Web & shared hosting", url: /learn/intro-hardware/web-hosting/ }
@@ -22,13 +23,55 @@ cite_urls:
 
 A **virtual private server (VPS)** is a slice of a physical [server](/reference/server/) that behaves like your own machine, complete with root access.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 180" role="img" aria-label="A client on the left connects over the network to one virtual private server, which is a highlighted virtual machine among three sharing a single physical host through a hypervisor. That VPS reads and writes an attached storage volume on the right. The other virtual machines are isolated neighbors on the same host." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="currentColor" font-family="ui-sans-serif, sans-serif">
+    <rect x="20" y="74" width="46" height="30" rx="2" fill-opacity="0.14" stroke-width="1.1"/>
+    <text x="43" y="93" text-anchor="middle" font-size="7.5" stroke="none">client</text>
+    <line x1="66" y1="89" x2="126" y2="89" stroke-width="1.4" fill="none"/>
+    <path d="M126 89 l-8 -3 v6 z" stroke-width="1"/>
+    <rect x="128" y="34" width="180" height="112" rx="4" fill-opacity="0.04" stroke-width="1.5"/>
+    <text x="218" y="28" text-anchor="middle" font-size="8.5" font-weight="600" stroke="none">one physical host</text>
+    <rect x="138" y="44" width="160" height="26" rx="2" fill-opacity="0.06" stroke-width="1"/>
+    <text x="218" y="60" text-anchor="middle" font-size="7.5" stroke="none" fill-opacity="0.85">neighbor VM (isolated)</text>
+    <rect x="138" y="74" width="160" height="32" rx="2" fill-opacity="0.24" stroke-width="1.5"/>
+    <text x="218" y="90" text-anchor="middle" font-size="8" stroke="none" font-weight="600">your VPS</text>
+    <text x="218" y="101" text-anchor="middle" font-size="6.5" stroke="none">own OS &#183; root access</text>
+    <rect x="138" y="110" width="160" height="18" rx="2" fill-opacity="0.20" stroke-width="1.1"/>
+    <text x="218" y="122" text-anchor="middle" font-size="7.5" stroke="none">Hypervisor</text>
+    <rect x="138" y="130" width="160" height="10" rx="1" fill-opacity="0.06" stroke-width="1"/>
+    <line x1="298" y1="90" x2="358" y2="90" stroke-width="1.4" fill="none"/>
+    <path d="M358 90 l-8 -3 v6 z" stroke-width="1"/>
+    <path d="M366 76 a20 6 0 0 1 40 0 v28 a20 6 0 0 1 -40 0 z" fill-opacity="0.12" stroke-width="1.3"/>
+    <path d="M366 76 a20 6 0 0 0 40 0" fill="none" stroke-width="1.1"/>
+    <text x="386" y="118" text-anchor="middle" font-size="7.5" stroke="none">storage</text>
+    <text x="230" y="166" text-anchor="middle" font-size="8" stroke="none" fill-opacity="0.85">a hypervisor divides one host into isolated virtual machines</text>
+  </g>
+</svg>
+<figcaption>A hypervisor splits one physical host into several isolated virtual machines; your VPS is one such slice with its own operating system and root access, reachable by clients and backed by its own storage — cheaper than a whole machine, more capable than shared hosting.</figcaption>
+</figure>
+
 ## Overview
 
-A VPS sits between shared [web hosting](/reference/web-hosting/) and a whole [dedicated server](/reference/dedicated-server/): more control than the former, far cheaper than the latter. It is created by [virtualization](/reference/virtualization/) — a hypervisor divides one physical host into several isolated virtual machines, each with its own operating system. Providers like DigitalOcean, Linode, and Hetzner rent these by the month.
+A VPS sits between shared [web hosting](/reference/web-hosting/) and a whole [dedicated server](/reference/dedicated-server/): more control than the former, far cheaper than the latter. It is created by [virtualization](/reference/virtualization/) — a hypervisor divides one physical host into several isolated virtual machines, each with its own operating system, kernel, and root account.
+
+The isolation is logical rather than physical: neighbors share the same silicon, so a very busy tenant can in principle contend for CPU or disk (the "noisy neighbor" effect), though providers cap and balance resources to limit it. Providers like DigitalOcean, Linode, and Hetzner rent these by the month, and can resize or snapshot them far faster than any physical box.
 
 ## When to choose it
 
-Reach for a VPS when shared hosting stops being enough: you need root access, custom services, or a specific software stack. The trade-off is responsibility — you manage the operating system, security updates, and backups yourself. For GopherTrunk this is a fine place to store and serve decoded data, though it still cannot capture RF.
+The VPS is the middle rung of the hosting ladder, and the choice is usually against its neighbors:
+
+| Option | Control | Cost | Performance |
+|--------|---------|------|-------------|
+| Shared hosting | Low (no root) | Lowest | Shared, variable |
+| **VPS** | Root, own OS | Moderate | Good, mostly isolated |
+| [Dedicated](/reference/dedicated-server/) / [bare metal](/reference/bare-metal-server/) | Full machine | Highest | Uncontended |
+
+Reach for a VPS when shared hosting stops being enough: you need root access, custom services, or a specific software stack. The trade-off is responsibility — you manage the operating system, security updates, and backups yourself.
+
+## Where it fits
+
+A VPS is the default first "real server" for most projects — enough control to run anything, cheap enough to leave on 24/7. For GopherTrunk this is a fine place to host the web console and store and serve decoded data, though like any virtual or remote server it still cannot capture RF, which needs a radio front end near the antenna.
 
 ## Sources
 

--- a/docs/reference/volatile-memory.md
+++ b/docs/reference/volatile-memory.md
@@ -4,7 +4,7 @@ title: Volatile vs non-volatile memory
 entry_type: concept
 category: hw-storage
 description: Volatile memory loses its contents when power is removed, while non-volatile memory retains them; the distinction explains why computers separate fast working memory from persistent storage.
-keywords: volatile memory, non-volatile memory, RAM, ROM, flash, persistence, data retention, DRAM
+keywords: volatile memory, non-volatile memory, RAM, ROM, flash, persistence, data retention, DRAM, power-off
 aka: [non-volatile memory]
 infobox:
   - { label: Volatile, value: Loses data without power (RAM) }
@@ -12,7 +12,7 @@ infobox:
   - { label: Volatile trait, value: Fast, used as working memory }
   - { label: Non-volatile trait, value: Persistent storage }
   - { label: Key question, value: "Does it survive power-off?" }
-see_also: [random-access-memory, read-only-memory, flash-memory, memory-hierarchy, data-storage, cache-memory]
+see_also: [random-access-memory, read-only-memory, flash-memory, memory-hierarchy, data-storage, cache-memory, solid-state-drive]
 cite_urls:
   - https://en.wikipedia.org/wiki/Volatile_memory
   - https://en.wikipedia.org/wiki/Non-volatile_memory
@@ -20,9 +20,50 @@ cite_urls:
 
 **Volatile memory** loses its contents the moment power is removed, while **non-volatile memory** keeps them — a distinction that shapes how every computer divides fast working memory from lasting storage.[^vol][^nonvol]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 168" role="img" aria-label="Two panels showing what survives power-off. With power on, both a RAM chip and a flash chip hold their data. After power is removed, the RAM chip is blank because it is volatile, while the flash chip still holds the same data because it is non-volatile." xmlns="http://www.w3.org/2000/svg">
+  <text x="115" y="22" font-size="9" text-anchor="middle" fill="currentColor" font-weight="600">power ON</text>
+  <text x="345" y="22" font-size="9" text-anchor="middle" fill="currentColor" font-weight="600">power OFF</text>
+  <line x1="230" y1="30" x2="230" y2="150" stroke="currentColor" stroke-width="0.8" stroke-dasharray="3 3" stroke-opacity="0.5"/>
+  <g stroke="currentColor" fill="none" stroke-width="1.2">
+    <rect x="40" y="40" width="150" height="42" rx="3" fill="currentColor" fill-opacity="0.05"/>
+    <rect x="40" y="98" width="150" height="42" rx="3" fill="currentColor" fill-opacity="0.05"/>
+    <rect x="270" y="40" width="150" height="42" rx="3" fill="currentColor" fill-opacity="0.05"/>
+    <rect x="270" y="98" width="150" height="42" rx="3" fill="currentColor" fill-opacity="0.05"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-family="ui-monospace, monospace" font-size="9">
+    <text x="52" y="66">RAM  1011 0110</text>
+    <text x="52" y="124">flash 1011 0110</text>
+    <text x="282" y="66" fill-opacity="0.35">RAM  &#8212;&#8212;&#8212;&#8212; &#8212;&#8212;&#8212;&#8212;</text>
+    <text x="282" y="124">flash 1011 0110</text>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="7.5">
+    <text x="115" y="94" text-anchor="middle" fill-opacity="0.85">volatile: needs power to hold bits</text>
+    <text x="115" y="152" text-anchor="middle" fill-opacity="0.85">non-volatile: bits stay put</text>
+    <text x="345" y="94" text-anchor="middle" fill-opacity="0.85">contents lost</text>
+    <text x="345" y="152" text-anchor="middle" fill-opacity="0.85">contents retained</text>
+  </g>
+</svg>
+<figcaption>Cut the power and volatile RAM forgets everything, while non-volatile flash keeps the same bits — the single test that sorts working memory from persistent storage.</figcaption>
+</figure>
+
 ## Overview
 
-[RAM](/reference/random-access-memory/) is the archetypal volatile memory: it is fast and freely rewritable, which makes it ideal as the place a running program keeps its data, but everything in it vanishes at power-off. Non-volatile memory — [flash](/reference/flash-memory/), [ROM](/reference/read-only-memory/), hard disks, tape — gives up some speed or flexibility in exchange for retaining data without power. [Cache memory](/reference/cache-memory/) is also volatile. The trade-off is fundamental: the fastest memories tend to be volatile, and persistence tends to cost speed or write endurance.
+[RAM](/reference/random-access-memory/) is the archetypal volatile memory: it is fast and freely rewritable, which makes it ideal as the place a running program keeps its data, but everything in it vanishes at power-off. Dynamic RAM even needs constant refreshing to hold its charge while powered. Non-volatile memory — [flash](/reference/flash-memory/), [ROM](/reference/read-only-memory/), hard disks, tape — gives up some speed or flexibility in exchange for retaining data without power.
+
+[Cache memory](/reference/cache-memory/) is also volatile, as are the CPU's registers. The trade-off is fundamental: the fastest memories tend to be volatile, and persistence tends to cost speed or write endurance. That is why systems layer them rather than picking one.
+
+## Volatile vs non-volatile
+
+The dividing line is simple, but it drives where each technology is used:
+
+| Trait | Volatile | Non-volatile |
+|-------|----------|--------------|
+| Survives power-off | No | Yes |
+| Examples | DRAM, SRAM, cache | Flash, ROM, disk, tape |
+| Typical speed | Fastest | Slower |
+| Typical role | Working memory | Persistent storage |
+| Rewrites | Effectively unlimited | Often limited (flash wear) |
 
 ## Where it fits
 

--- a/docs/reference/wearable-computer.md
+++ b/docs/reference/wearable-computer.md
@@ -20,13 +20,57 @@ cite_urls:
 
 A **wearable computer** is a small computing device worn on the body — on the wrist, head, ear, or clothing — built to provide hands-free, always-available computing.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 160" role="img" aria-label="Four wearable form factors around a simple human figure. Smart glasses on the head, a smart earbud at the ear, a smartwatch on the wrist, and a fitness band or clip on the body. Each is labeled, showing that wearables are defined by where on the body they are worn." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.2" font-family="ui-sans-serif, sans-serif">
+    <circle cx="150" cy="46" r="20"/>
+    <path d="M150 66 v46 M150 78 l-30 18 M150 78 l30 18 M150 112 l-18 30 M150 112 l18 30"/>
+    <path d="M132 44 h36" stroke-width="1.4"/>
+    <circle cx="127" cy="44" r="4"/>
+    <circle cx="173" cy="44" r="4"/>
+    <ellipse cx="171" cy="52" rx="4" ry="5"/>
+    <rect x="114" y="90" width="14" height="12" rx="2"/>
+    <rect x="164" y="126" width="16" height="12" rx="3"/>
+    <g stroke-width="0.8">
+      <line x1="180" y1="40" x2="250" y2="32"/>
+      <line x1="178" y1="54" x2="250" y2="66"/>
+      <line x1="114" y1="96" x2="60" y2="96"/>
+      <line x1="180" y1="132" x2="250" y2="132"/>
+    </g>
+  </g>
+  <g fill="currentColor" stroke="none" font-family="ui-sans-serif, sans-serif" font-size="8.5">
+    <text x="256" y="35">smart glasses (head)</text>
+    <text x="256" y="69">hearable (ear)</text>
+    <text x="56" y="99" text-anchor="end">smartwatch (wrist)</text>
+    <text x="256" y="135">fitness band / clip (body)</text>
+  </g>
+</svg>
+<figcaption>Wearables are grouped by where they sit on the body — glasses on the head, hearables at the ear, a smartwatch on the wrist, a band or clip on the torso — each a small sensor-and-radio package under tight size and battery limits.</figcaption>
+</figure>
+
 ## Overview
 
-Wearables span [smartwatches](/reference/smartwatch/) and fitness bands, smart glasses and AR headsets, and "hearables" such as smart earbuds. All share the same constraints: a tiny [SoC](/reference/system-on-a-chip/), a small or absent display, low-power radios like Bluetooth and [NFC](/reference/near-field-communication/), and a [battery](/reference/battery-technology/) measured in fractions of a phone's. Many lean on a paired [smartphone](/reference/smartphone/) for heavy lifting and connectivity, acting as a sensor-rich satellite rather than a standalone computer.
+Wearables span [smartwatches](/reference/smartwatch/) and fitness bands, smart glasses and AR headsets, and "hearables" such as smart earbuds. All share the same constraints: a tiny [SoC](/reference/system-on-a-chip/), a small or absent display, low-power radios like Bluetooth and [NFC](/reference/near-field-communication/), and a [battery](/reference/battery-technology/) measured in fractions of a phone's.
+
+Many lean on a paired [smartphone](/reference/smartphone/) for heavy lifting and connectivity, acting as a sensor-rich satellite rather than a standalone computer. The design pressure is relentless: every added feature costs volume, weight, and battery on a device that must be comfortable to wear all day, so wearables sense and relay far more than they compute.
+
+## Wearable form factors
+
+The category spans several body positions, each suited to different jobs:
+
+| Form | Worn on | Typical job |
+|------|---------|-------------|
+| Smartwatch | Wrist | Notify, sensors, apps |
+| Fitness band | Wrist | Step & heart tracking |
+| Smart glasses | Head | Display, camera, AR |
+| Hearable | Ear | Audio, voice assistant |
+| Smart clothing | Body | Biometrics, motion |
+
+What unites them is not a screen or a chip but the fact of being worn — placement on the body is the defining trait.
 
 ## Where it fits
 
-The category is defined by being *on* the body rather than in a pocket, which favors continuous sensing — motion, heart rate, location via [GPS](/reference/gps-receiver/) — over raw performance. The extreme size and power limits make wearables the most constrained tier of personal computing, suited to capturing and relaying data, not to running compute-heavy workloads on their own.
+The category is defined by being *on* the body rather than in a pocket, which favors continuous sensing — motion, heart rate, location via [GPS](/reference/gps-receiver/) — over raw performance. The extreme size and power limits make wearables the most constrained tier of personal computing, suited to capturing and relaying data, not to running compute-heavy workloads like an SDR decode pipeline on their own.
 
 ## Sources
 

--- a/docs/reference/webcam.md
+++ b/docs/reference/webcam.md
@@ -4,7 +4,7 @@ title: Webcam
 entry_type: hardware
 category: hw-personal-computers
 description: A webcam is a small camera peripheral that captures video and stills for a computer, used for video calls, streaming, and recording, connected over USB or built into a laptop or monitor.
-keywords: webcam, web camera, video conferencing, USB camera, streaming camera, image sensor
+keywords: webcam, web camera, video conferencing, USB camera, streaming camera, image sensor, resolution, frame rate
 infobox:
   - { label: Type, value: Input peripheral (camera) }
   - { label: Captures, value: Video and stills }
@@ -17,9 +17,51 @@ cite_urls:
 
 A **webcam** is a small camera [peripheral](/reference/peripheral/) that captures video and still images for a computer, used for video calls, streaming, and recording.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 165" role="img" aria-label="How a webcam works: light from the scene passes through a lens onto an image sensor, a small processor encodes the picture into a compressed video stream, and that stream travels over USB into the computer as a camera source that applications can read." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.2">
+    <path d="M30 50 L30 110 M40 46 L40 114 M50 42 L50 118"/>
+  </g>
+  <g stroke="currentColor" fill="none" stroke-width="1" stroke-dasharray="3 3">
+    <path d="M52 54 L96 76 M52 80 L96 80 M52 106 L96 84"/>
+  </g>
+  <g stroke="currentColor" fill="none" stroke-width="1.4">
+    <path d="M100 60 Q118 80 100 100 Q126 92 126 80 Q126 68 100 60 Z" fill="currentColor" fill-opacity="0.12"/>
+    <rect x="140" y="60" width="34" height="40" rx="2" fill="currentColor" fill-opacity="0.1"/>
+    <rect x="196" y="60" width="46" height="40" rx="2" fill="currentColor" fill-opacity="0.06"/>
+    <path d="M242 80 H300"/>
+    <path d="M292 74 L302 80 L292 86"/>
+    <rect x="312" y="52" width="120" height="56" rx="4"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="7.5" text-anchor="middle">
+    <text x="40" y="34">scene</text>
+    <text x="113" y="120">lens</text>
+    <text x="157" y="114">sensor</text>
+    <text x="219" y="114">encode</text>
+    <text x="272" y="72">USB</text>
+    <text x="372" y="78" font-size="8">computer</text>
+    <text x="372" y="92" font-size="7" fill-opacity="0.85">camera source</text>
+  </g>
+</svg>
+<figcaption>A webcam turns a scene into a data stream: light passes through a lens onto an image sensor, a small processor encodes the frames, and the compressed video travels over USB into the computer as a camera source applications can tap.</figcaption>
+</figure>
+
 ## Overview
 
-A webcam pairs an image [sensor](/reference/sensor/) and a lens with a small processor that encodes the picture into a video stream the computer can read. It is an input device: the [operating system](/reference/operating-system/) sees it as a camera source that applications tap into. The specs that matter are *resolution* (1080p and 4K are common), *frame rate* (frames per second), and *field of view* (how wide a scene it captures). Webcams connect over [USB](/reference/usb/) or come built into a [laptop](/reference/laptop/) bezel or a [monitor](/reference/computer-monitor/).
+A webcam pairs an image [sensor](/reference/sensor/) and a lens with a small processor that encodes the picture into a video stream the computer can read. It is an input device: the [operating system](/reference/operating-system/) sees it as a camera source that applications tap into.
+
+The specs that matter are *resolution* (1080p and 4K are common), *frame rate* (frames per second), and *field of view* (how wide a scene it captures). Webcams connect over [USB](/reference/usb/) or come built into a [laptop](/reference/laptop/) bezel or a [monitor](/reference/computer-monitor/).
+
+## Key specs
+
+A handful of numbers describe most of what a webcam can do:
+
+| Spec | What it sets | Common values |
+|------|--------------|---------------|
+| Resolution | Image detail | 720p, 1080p, 4K |
+| Frame rate | Motion smoothness | 30 or 60 fps |
+| Field of view | How wide it sees | 65°–90°+ |
+| Connection | How it attaches | USB, or built-in |
 
 ## Where it fits
 

--- a/docs/reference/wi-fi.md
+++ b/docs/reference/wi-fi.md
@@ -3,29 +3,74 @@ slug: wi-fi
 title: Wi-Fi
 entry_type: concept
 category: hw-networking
-description: Wi-Fi is the family of wireless local-area networking standards that let devices connect to a network over radio in the 2.4, 5, and 6 GHz bands instead of a cable.
-keywords: Wi-Fi, IEEE 802.11, WLAN, wireless networking, 2.4 GHz, 5 GHz, Wi-Fi 6, access point
+description: Wi-Fi is the family of wireless local-area networking standards that let devices join a network over radio in the 2.4, 5, and 6 GHz bands instead of a cable, bridging clients onto a wired LAN through an access point.
+keywords: Wi-Fi, IEEE 802.11, WLAN, wireless networking, 2.4 GHz, 5 GHz, 6 GHz, Wi-Fi 6, Wi-Fi 7, access point, generations
 aka: [WiFi, IEEE 802.11, WLAN]
 infobox:
   - { label: Type, value: Wireless LAN standard }
   - { label: Standard, value: IEEE 802.11 }
   - { label: Bands, value: 2.4, 5, 6 GHz }
   - { label: Reach, value: Tens of metres indoors }
-see_also: [wireless-access-point, ethernet, bluetooth, network-interface-card, router, electromagnetic-spectrum]
+  - { label: Bridges via, value: Wireless access point }
+see_also: [wireless-access-point, wifi-80211, ethernet, bluetooth, network-interface-card, router, electromagnetic-spectrum]
 cite_urls:
   - https://en.wikipedia.org/wiki/Wi-Fi
 ---
 
 **Wi-Fi** is the family of wireless local-area networking standards that let devices join a network over radio, in the 2.4, 5, and 6 GHz bands, instead of a wired connection.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 150" role="img" aria-label="A Wi-Fi link: a wired access point radiates arcs of radio signal to a laptop and a phone over the air, and connects by an Ethernet cable to a switch that reaches the wider network. The clients reach the LAN wirelessly through the access point." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="currentColor">
+    <rect x="206" y="24" width="48" height="26" rx="4" fill-opacity="0.16" stroke-width="1.3"/>
+    <g stroke-width="1.3" fill="none" stroke-opacity="0.85">
+      <path d="M198 40 a18 18 0 0 0 -18 18"/>
+      <path d="M190 40 a26 26 0 0 0 -26 26"/>
+      <path d="M262 40 a18 18 0 0 1 18 18"/>
+      <path d="M270 40 a26 26 0 0 1 26 26"/>
+    </g>
+    <g stroke-width="1.3">
+      <rect x="128" y="90" width="52" height="34" rx="3" fill-opacity="0.1"/>
+      <rect x="286" y="94" width="26" height="38" rx="4" fill-opacity="0.1"/>
+      <rect x="360" y="30" width="46" height="26" rx="3" fill-opacity="0.14"/>
+    </g>
+    <line x1="254" y1="37" x2="360" y2="43" stroke-width="1.3"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle" font-size="8.5">
+    <text x="230" y="41" font-weight="600" font-size="8">AP</text>
+    <text x="154" y="110" font-size="8">laptop</text>
+    <text x="299" y="118" font-size="8">phone</text>
+    <text x="383" y="47" font-size="8">switch</text>
+    <text x="312" y="40" font-size="7.5" fill-opacity="0.9">wired to LAN</text>
+    <text x="230" y="142" fill-opacity="0.9">clients reach the LAN over the air through the access point</text>
+  </g>
+</svg>
+<figcaption>A wireless access point radiates a shared radio channel that client devices — a laptop, a phone — associate with, while its wired uplink bridges that traffic onto the Ethernet LAN. The air link is convenient but shared, so all nearby clients compete for the same channel.</figcaption>
+</figure>
+
 ## Overview
 
-Built on the **IEEE 802.11** standards, Wi-Fi connects client devices to a [wireless access point](/reference/wireless-access-point/), which bridges them onto the wired [LAN](/reference/lan-and-wan/). Successive generations — now labelled Wi-Fi 4, 5, 6, and 7 — have raised throughput and efficiency using wider channels and smarter modulation, though real-world range and speed depend on interference and walls. Because it shares unlicensed [spectrum](/reference/electromagnetic-spectrum/), Wi-Fi competes with [Bluetooth](/reference/bluetooth/), microwaves, and neighbouring networks for airtime.
+Built on the **IEEE 802.11** standards, Wi-Fi connects client devices to a [wireless access point](/reference/wireless-access-point/), which bridges them onto the wired [LAN](/reference/lan-and-wan/). A client *associates* with the access point and then shares its radio channel with every other client, taking turns to transmit — so raw link speed and real throughput can differ sharply when the air is busy.
 
-## What it's for
+Successive generations — now labelled Wi-Fi 4, 5, 6, and 7 — have raised throughput and efficiency using wider channels, more spatial streams (MIMO), and smarter modulation, and the newest add the roomy 6 GHz band. Real-world range and speed still depend heavily on interference, walls, and how many devices share the channel.
 
-Wi-Fi trades the raw stability of [Ethernet](/reference/ethernet/) for mobility and easy deployment, making it the default for laptops, phones, and IoT devices. A GopherTrunk node can report over Wi-Fi where running a cable is impractical, but the 2.4 GHz band is busy and can desensitize a nearby receiver, so a wired link or careful placement is wiser when the antenna and the radio share a roof.
+Because it uses *unlicensed* [spectrum](/reference/electromagnetic-spectrum/), Wi-Fi competes with [Bluetooth](/reference/bluetooth/), microwave ovens, and neighbouring networks for airtime, and has no exclusive claim to any frequency — coexistence, not isolation, is the design premise.
+
+## Generations
+
+Each generation added bandwidth and efficiency while staying backward compatible:
+
+| Generation | 802.11 | Bands | Peak rate (order of) |
+|------------|--------|-------|----------------------|
+| Wi-Fi 4 | n | 2.4 / 5 GHz | Hundreds of Mb/s |
+| Wi-Fi 5 | ac | 5 GHz | ~1 Gb/s |
+| Wi-Fi 6 / 6E | ax | 2.4 / 5 / 6 GHz | Several Gb/s |
+| Wi-Fi 7 | be | 2.4 / 5 / 6 GHz | Tens of Gb/s |
+
+## Where it fits
+
+Wi-Fi trades the raw stability of [Ethernet](/reference/ethernet/) for mobility and easy deployment, making it the default for laptops, phones, and IoT devices. A GopherTrunk node can report over Wi-Fi where running a cable is impractical, and pointing a phone or laptop at the daemon's web console over the house Wi-Fi is a natural way to check on it. But the 2.4 GHz band is busy and can desensitize a nearby receiver, so a wired link or careful placement is wiser when the antenna and the radio share a roof.
 
 ## Sources
 
-[^wiki]: [Wi-Fi](https://en.wikipedia.org/wiki/Wi-Fi) — Wikipedia, on the IEEE 802.11 wireless networking family.
+[^wiki]: [Wi-Fi](https://en.wikipedia.org/wiki/Wi-Fi) — Wikipedia, on the IEEE 802.11 wireless networking family, its bands, and its generations.

--- a/docs/reference/workstation.md
+++ b/docs/reference/workstation.md
@@ -4,7 +4,7 @@ title: Workstation
 entry_type: hardware
 category: hw-personal-computers
 description: A workstation is a high-end personal computer built for demanding professional work — CAD, video, simulation, software builds — with powerful CPUs, lots of memory, and often error-correcting RAM.
-keywords: workstation, professional PC, ECC memory, Xeon, Threadripper, CAD, render workstation, ISV certified
+keywords: workstation, professional PC, ECC memory, Xeon, Threadripper, CAD, render workstation, ISV certified, many-core
 aka: [Pro workstation]
 infobox:
   - { label: Type, value: High-end personal computer }
@@ -21,9 +21,53 @@ cite_urls:
 
 A **workstation** is a high-end [personal computer](/reference/personal-computer/) built for demanding professional work — engineering, content creation, scientific computing, and large software builds — rather than ordinary office or home use.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 180" role="img" aria-label="What distinguishes a workstation: a tower whose four differentiators are called out — a many-core CPU shown as a grid of cores, large error-correcting ECC memory, a professional GPU, and vendor ISV certification — all specified for sustained heavy load rather than gaming." xmlns="http://www.w3.org/2000/svg">
+  <rect x="40" y="24" width="120" height="132" rx="4" stroke="currentColor" fill="none" stroke-width="1.5"/>
+  <g stroke="currentColor" fill="none" stroke-width="0.9">
+    <rect x="58" y="40" width="46" height="46" rx="2" fill="currentColor" fill-opacity="0.1"/>
+    <path d="M69 40 V86 M81 40 V86 M93 40 V86 M58 51 H104 M58 63 H104 M58 75 H104"/>
+    <rect x="118" y="40" width="30" height="46" rx="2" fill="currentColor" fill-opacity="0.08"/>
+    <rect x="58" y="100" width="90" height="18" rx="2" fill="currentColor" fill-opacity="0.12"/>
+    <rect x="58" y="126" width="90" height="18" rx="2" fill="currentColor" fill-opacity="0.08"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="6.5" text-anchor="middle">
+    <text x="81" y="97">many cores</text>
+    <text x="133" y="66">cool</text>
+    <text x="103" y="112">pro GPU</text>
+    <text x="103" y="138">ECC RAM</text>
+  </g>
+  <g stroke="currentColor" fill="none" stroke-width="1" stroke-dasharray="4 3">
+    <path d="M104 60 H210 M148 109 H210 M148 135 H250"/>
+  </g>
+  <g fill="currentColor" stroke="none" font-size="8">
+    <text x="216" y="42" font-weight="600">Many-core CPU</text>
+    <text x="216" y="54" font-size="7" fill-opacity="0.85">Xeon / Threadripper class</text>
+    <text x="216" y="88" font-weight="600">ECC memory</text>
+    <text x="216" y="100" font-size="7" fill-opacity="0.85">large, catches bit errors</text>
+    <text x="216" y="130" font-weight="600">Pro GPU + ISV cert</text>
+    <text x="216" y="142" font-size="7" fill-opacity="0.85">validated for pro software</text>
+  </g>
+  <text x="230" y="170" fill="currentColor" stroke="none" text-anchor="middle" font-size="7.5" fill-opacity="0.85">specified for sustained heavy load, not just peak frame rate</text>
+</svg>
+<figcaption>A workstation looks like a desktop but is specified differently: a many-core CPU, large error-correcting memory, a professional GPU, and vendor certification for specific applications — all aimed at reliable, sustained heavy load.</figcaption>
+</figure>
+
 ## Overview
 
-A workstation looks like a [desktop computer](/reference/desktop-computer/) but is specified for sustained heavy load: a many-core [CPU](/reference/central-processing-unit/) (Intel Xeon or AMD Threadripper class), large amounts of [RAM](/reference/random-access-memory/) — frequently error-correcting (ECC) memory to catch bit errors — and a professional [GPU](/reference/graphics-processing-unit/) tuned for compute or certified rendering. Vendors often "certify" workstations against specific professional applications (ISV certification) so the hardware and drivers are validated for that software.
+A workstation looks like a [desktop computer](/reference/desktop-computer/) but is specified for sustained heavy load: a many-core [CPU](/reference/central-processing-unit/) (Intel Xeon or AMD Threadripper class), large amounts of [RAM](/reference/random-access-memory/) — frequently error-correcting (ECC) memory to catch bit errors — and a professional [GPU](/reference/graphics-processing-unit/) tuned for compute or certified rendering.
+
+Vendors often "certify" workstations against specific professional applications (ISV certification) so the hardware and drivers are validated for that software. The premium buys reliability and correctness under long, heavy runs rather than the peak frame rate a gaming machine chases.
+
+## Workstation vs gaming PC vs server
+
+The parts overlap, but each class optimizes for a different goal:
+
+| Machine | Optimized for | ECC memory | GPU emphasis |
+|---------|---------------|------------|--------------|
+| Workstation | Sustained pro compute | Common | Compute / certified |
+| Gaming PC | Peak frame rate | Rare | Consumer, high-clock |
+| Server | Serving many clients | Standard | Often headless |
 
 ## Where it fits
 

--- a/docs/reference/x86.md
+++ b/docs/reference/x86.md
@@ -3,13 +3,14 @@ slug: x86
 title: x86
 entry_type: concept
 category: hw-foundations
-description: x86 is the dominant CISC instruction set architecture for desktops, laptops, and servers, originated by Intel and extended to 64 bits as x86-64 by AMD.
-keywords: x86, x86-64, amd64, CISC, Intel, AMD, instruction set, IA-32
+description: x86 is the dominant CISC instruction set architecture for desktops, laptops, and servers, originated by Intel with the 8086 and extended to 64 bits as x86-64 by AMD.
+keywords: x86, x86-64, amd64, CISC, Intel, AMD, instruction set, IA-32, 8086, backward compatible
 aka: [x86-64, amd64, IA-32]
 autolink: true
 infobox:
   - { label: Type, value: ISA (CISC) }
-  - { label: Origin, value: "Intel, 1978" }
+  - { label: Origin, value: "Intel 8086, 1978" }
+  - { label: 32-bit, value: "IA-32 (80386, 1985)" }
   - { label: 64-bit, value: "x86-64 (AMD, 2003)" }
   - { label: Dominates, value: PCs & servers }
 see_also: [instruction-set-architecture, arm-architecture, risc-v, central-processing-unit, semiconductor, von-neumann-architecture]
@@ -19,14 +20,50 @@ cite_urls:
 
 **x86** is the long-dominant [instruction set architecture](/reference/instruction-set-architecture/) for desktops, laptops, and servers — a CISC design originated by Intel and extended to 64 bits as x86-64.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="A timeline of the x86 architecture. It begins with Intel's 16-bit 8086 in 1978, widens to 32-bit with the 80386 in 1985, and is extended to 64-bit as x86-64 by AMD in 2003, each step adding instructions while staying backward compatible." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="70" x2="440" y2="70" stroke="currentColor" stroke-width="1.4"/>
+  <g stroke="currentColor" fill="currentColor" stroke-width="1.2">
+    <circle cx="70" cy="70" r="5" fill-opacity="0.15"/>
+    <circle cx="200" cy="70" r="5" fill-opacity="0.15"/>
+    <circle cx="360" cy="70" r="6" fill="currentColor"/>
+  </g>
+  <g fill="currentColor" stroke="none" text-anchor="middle">
+    <text x="70" y="52" font-size="9" font-weight="600">8086</text>
+    <text x="70" y="92" font-size="8">1978 · 16-bit</text>
+    <text x="200" y="52" font-size="9" font-weight="600">80386</text>
+    <text x="200" y="92" font-size="8">1985 · 32-bit (IA-32)</text>
+    <text x="360" y="52" font-size="9" font-weight="600">x86-64</text>
+    <text x="360" y="92" font-size="8">2003 · 64-bit (AMD)</text>
+    <text x="235" y="122" font-size="8" fill-opacity="0.9">each step adds instructions but still runs the old code — backward compatible</text>
+  </g>
+</svg>
+<figcaption>x86 grew by accretion: the 16-bit 8086, the 32-bit 80386, and AMD's 64-bit x86-64, each generation adding richer instructions while still running software written for its predecessors — the compatibility that made the family hard to displace.</figcaption>
+</figure>
+
 ## Overview
 
-The family began with Intel's 8086 in 1978 and grew by accreting new instructions while staying backward compatible, the hallmark of a CISC design with many rich, variable-length instructions. In 2003 AMD added 64-bit addressing as *x86-64* (also called amd64), which Intel adopted, and that variant is what almost every modern PC and server [CPU](/reference/central-processing-unit/) runs. Intel and AMD are the two main x86 chip makers.
+The family began with Intel's 8086 in 1978 and grew by *accreting* new instructions while preserving backward compatibility — the hallmark of a CISC design with many rich, variable-length instructions. The 80386 widened it to 32 bits (the IA-32 generation) in 1985, and successive chips added floating-point, SIMD (MMX, SSE, AVX), and virtualization instructions without ever breaking older code.
+
+In 2003 AMD added 64-bit addressing as *x86-64* (also called amd64), which Intel adopted, and that variant is what almost every modern PC and server [CPU](/reference/central-processing-unit/) runs today. Intel and AMD remain the two principal x86 chip makers. Internally, modern x86 chips decode their complex instructions into simpler RISC-like micro-operations, so the CISC label now describes the external contract more than the silicon.
+
+## Milestones
+
+The through-line of x86 history is that each widening kept the last one's software working:
+
+| Year | Milestone | Width | Brought |
+|------|-----------|-------|---------|
+| 1978 | 8086 | 16-bit | The original ISA |
+| 1985 | 80386 | 32-bit | IA-32, protected mode |
+| 1997+ | MMX / SSE / AVX | — | SIMD vector instructions |
+| 2003 | x86-64 (AMD) | 64-bit | Large address space, more registers |
+
+This relentless backward compatibility is both x86's great strength — an enormous body of existing software just runs — and the source of its complexity.
 
 ## Where it fits
 
-x86 owns the PC and most of the server and cloud market, so the great majority of compiled binaries and operating systems assume it. Its main challenger is [ARM](/reference/arm-architecture/), which leads in mobile and is rising in laptops and servers on efficiency, while [RISC-V](/reference/risc-v/) offers an open alternative. A GopherTrunk decode server is typically an x86-64 box; the same Go source also cross-compiles to ARM for edge capture nodes.
+x86 owns the PC and most of the server and cloud market, so the great majority of compiled binaries and operating systems assume it. Its main challenger is [ARM](/reference/arm-architecture/), which leads in mobile and is rising in laptops and servers on efficiency, while the open [RISC-V](/reference/risc-v/) offers a royalty-free alternative. A GopherTrunk decode server is typically an x86-64 box, where abundant CPU headroom makes many-channel decoding comfortable; the same Go source also cross-compiles to ARM for low-power edge capture nodes.
 
 ## Sources
 
-[^wiki]: [x86](https://en.wikipedia.org/wiki/X86) — Wikipedia, on the x86 instruction set family and x86-64.
+[^wiki]: [x86](https://en.wikipedia.org/wiki/X86) — Wikipedia, on the x86 instruction set family, the 8086 origin, IA-32, and x86-64.


### PR DESCRIPTION
Bring the 11 hardware-foundations Field Guide entries up to the site's
rich format: each gains an inline theme-aware SVG figure and expanded
Overview / middle section (with a comparison table) / "Where it fits",
matching the RF/SDR and Software-Dev domains.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MZArYWwxodqnyhTUV1LVvs