### PR TITLE
docs(learn): fill topical content gaps with 10 new lessons

### DIFF
--- a/docs/_data/learn.yml
+++ b/docs/_data/learn.yml
@@ -75,6 +75,12 @@ paths:
             minutes: 10
             level: beginner
             status: full
+          - slug: noise-and-snr
+            title: Noise, SNR & sensitivity
+            summary: The noise floor, signal-to-noise ratio, and receiver sensitivity — why SNR, not raw signal strength, decides whether a signal decodes.
+            minutes: 9
+            level: intermediate
+            status: full
           - slug: antennas
             title: Antennas 101
             summary: Resonance, polarization, gain, SWR, and the connectors that join your antenna to your SDR.
@@ -150,6 +156,12 @@ paths:
             summary: Set gain too low and you lose weak signals; too high and you drown in distortion. Finding the sweet spot.
             minutes: 8
             level: intermediate
+            status: full
+          - slug: front-end-and-overload
+            title: Front-end filters, LNAs & overload
+            summary: Preselector filters, low-noise amplifiers, and how out-of-band signals overload the front end — the intermod and reciprocal-mixing traps behind a noisy decode.
+            minutes: 10
+            level: advanced
             status: full
           - slug: sdr-hardware
             title: SDR hardware — RTL-SDR, HackRF, Airspy
@@ -453,6 +465,12 @@ paths:
             minutes: 8
             level: advanced
             status: full
+          - slug: cli-lfs-and-security
+            title: The GitHub CLI, Git LFS & repo security
+            summary: Three power features worth knowing — the gh command-line tool, Git LFS for large files, and GitHub's security features (Dependabot, secret scanning, advisories).
+            minutes: 9
+            level: intermediate
+            status: full
 
       - id: advanced-git
         label: "Module 6 — Advanced Git & Best Practices"
@@ -624,6 +642,12 @@ paths:
             minutes: 9
             level: intermediate
             status: full
+          - slug: data-structures-algorithms
+            title: Data structures & algorithms, briefly
+            summary: The handful of data structures every developer leans on, how to pick the right one, and what Big-O notation actually tells you about speed.
+            minutes: 10
+            level: intermediate
+            status: full
 
       - id: patterns
         label: "Module 4 — Software Design Patterns"
@@ -692,6 +716,18 @@ paths:
             title: Build systems, CI/CD & automation
             summary: Turning source into a shippable artifact automatically — and catching problems the moment they're introduced.
             minutes: 9
+            level: intermediate
+            status: full
+          - slug: databases-and-persistence
+            title: Storing data — files & databases
+            summary: How programs remember things after they exit — files, relational vs. NoSQL databases, and how to choose where your data should live.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: apis-and-integration
+            title: APIs & talking to other software
+            summary: How programs talk to each other — APIs, HTTP and REST, and the integration glue that connects your software to the rest of the world.
+            minutes: 10
             level: intermediate
             status: full
           - slug: docs-and-maintenance
@@ -936,6 +972,18 @@ paths:
             minutes: 8
             level: intermediate
             status: full
+          - slug: otar-key-management
+            title: OTAR & key management
+            summary: How encrypted systems distribute and rotate keys over the air — key IDs, OTAR, and what a scanner can and can't see when the keys change.
+            minutes: 8
+            level: advanced
+            status: full
+          - slug: data-services
+            title: Data services — GPS, text & registration
+            summary: Trunked systems carry more than voice — location updates, short data, and registration traffic riding the control and data channels.
+            minutes: 8
+            level: intermediate
+            status: full
 
       - id: p25-dmr
         label: "Module 4 — P25 & DMR: The Dominant Systems"
@@ -1073,6 +1121,12 @@ paths:
             summary: The four building blocks inside every computer, from a data center to a microcontroller, and how their size and speed define what a device can do.
             minutes: 9
             level: beginner
+            status: full
+          - slug: specialized-compute
+            title: Beyond the CPU — GPUs, FPGAs & accelerators
+            summary: When a general-purpose CPU isn't the right tool — graphics cards, FPGAs, DSPs, and AI accelerators, what each is for, and where SDR and DSP work lean on them.
+            minutes: 9
+            level: intermediate
             status: full
           - slug: hardware-spectrum
             title: The hardware spectrum — cloud to microcontroller
@@ -1383,6 +1437,12 @@ paths:
             title: Agentic & command-line tools
             summary: Tools that read your repo, run commands, and edit files on their own — what an agent can do, and the guardrails you need before you let it.
             minutes: 10
+            level: intermediate
+            status: full
+          - slug: local-and-open-models
+            title: Running local & open models
+            summary: Open-weight models on your own hardware — Ollama, llama.cpp, and GPU limits — when running a model locally makes sense for coding and when it doesn't.
+            minutes: 9
             level: intermediate
             status: full
           - slug: app-vs-ide-vs-both

--- a/docs/learn/ai-software-dev/agentic-cli-tools.md
+++ b/docs/learn/ai-software-dev/agentic-cli-tools.md
@@ -134,4 +134,4 @@ And reach for something lighter when the task is small: a quick question goes to
 - **Guardrails are mandatory** — permission prompts, sandboxing, and version control turn that power into something safe to use.
 - **Always review the diff** — the agent's output is unverified until you read it, just like a colleague's pull request.
 
-Next up: now that you've met the app, the editor, and the agent, how do you decide which to use — and is it really one or the other? See [App, IDE, agent — or all three?](/learn/ai-software-dev/app-vs-ide-vs-both/).
+Next up: each of those reaches a model running on someone else's servers — or you can run one on your own hardware. See [running local & open models](/learn/ai-software-dev/local-and-open-models/).

--- a/docs/learn/ai-software-dev/local-and-open-models.md
+++ b/docs/learn/ai-software-dev/local-and-open-models.md
@@ -1,0 +1,121 @@
+---
+slug: local-and-open-models
+title: Running local & open models
+description: Some capable open-weight models can be downloaded and run on your own hardware — private, offline, and free of per-token bills — but you supply the compute, and there are real quality and hardware trade-offs to weigh.
+keywords: local LLM, open-weight models, Ollama, llama.cpp, LM Studio, quantization, VRAM, GPU requirements, offline AI, self-hosted model, open source models
+level: intermediate
+status: full
+prereq:
+  - the-provider-landscape
+  - agentic-cli-tools
+faq:
+  - q: "Can I run a coding model on my own computer?"
+    a: "Yes. Tools like Ollama and LM Studio download an **open-weight** model and run it entirely on your machine, exposing a local API that many editors and CLIs can point at. Whether it runs *well* depends on the model's size and your hardware — a small model is comfortable on a laptop, a large one needs a serious GPU or it runs slowly on CPU and system RAM."
+  - q: "Are local models as good as cloud models for coding?"
+    a: "For everyday completion, boilerplate and offline Q&A, a good local model is genuinely useful. But at the top end there is still a gap: the hardest agentic coding and large-context work generally favour the frontier hosted models today. That gap has been closing steadily and open-weight releases keep gaining, so treat any specific comparison as a snapshot — but don't expect a laptop model to match the best cloud model on a gnarly multi-file task just yet."
+  - q: "What hardware do I need?"
+    a: "The main limit is **memory** — specifically **VRAM** on your GPU. A model's weights have to fit in memory to run at usable speed, and bigger models need more of it. **Quantization** shrinks a model to fit in less memory at some cost to quality, which is what lets modest hardware run useful models at all. Roughly: small models fit in a laptop's RAM or a modest GPU; large ones want a high-VRAM card, or they fall back to slow CPU inference."
+  - q: "Why run a model locally at all?"
+    a: "Four common reasons: **privacy** (confidential code never leaves your machine), **offline or air-gapped** operation, **cost** (no per-token bills or rate limits once you own the hardware), and **control** (the model can't be changed or retired out from under you). It's also a great way to learn how these systems actually work."
+---
+# Running local & open models
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Open-weight** models publish their trained parameters, so you can download and run them **locally** — on your own machine, with nothing leaving it and no per-token bill. The catch is that **you** supply the compute: a model's size is measured in billions of parameters, and it has to fit in memory — mainly your GPU's **VRAM** — to run at usable speed. **Quantization** shrinks a model to fit at some quality cost. Small models run on a laptop and are fine for everyday help; the hardest agentic coding still favours frontier hosted models. See [the provider landscape](/learn/ai-software-dev/the-provider-landscape/) for where these sit in the market.
+</div>
+
+The [previous lesson](/learn/ai-software-dev/agentic-cli-tools/) reached models running on someone else's servers. This one flips that: some of the most capable models can be downloaded and run on hardware you own. That buys privacy, offline use and freedom from usage bills — but it moves the compute bill onto your desk, and there are honest trade-offs to weigh. This lesson covers what "local" means, the tools that make it easy, the hardware reality, and when running local is actually the right call.
+
+## Open-weight vs. proprietary
+
+A quick recap from [the provider landscape](/learn/ai-software-dev/the-provider-landscape/). A **proprietary** model lives only behind an API — the weights (the trained numbers that *are* the model) stay on the provider's servers and you never possess them. An **open-weight** model publishes those weights for download, so anyone can run it on their own hardware or a rented server.
+
+"Open-weight" is not the same as "open-source" in the full sense. You get the weights, but not necessarily the training data, the training code, or an unrestricted licence — some releases carry usage limits. Read the licence before you build on one.
+
+Rather than rank this week's releases, it's safer to name families generically. You'll see open-weight lineages like Llama, Qwen, Mistral, DeepSeek and gpt-oss-style releases, offered in several sizes and refreshed often. Which one leads on a given task shifts constantly, so treat any specific claim as a snapshot.
+
+## What "local" means
+
+"Local" means the model runs **on your machine**. You download the weights once, load them into memory, and every request is answered by your own hardware. Nothing is sent to a provider; no network call leaves your computer. The flip side of that independence is that **you supply the compute** — the speed and the ceiling on model size are set by your hardware, not by a data centre.
+
+## The tools
+
+You don't have to wire this up by hand. A few tools have made local models genuinely easy to run:
+
+- **Ollama** — the easiest on-ramp. One command pulls a model and runs it; it manages the download, the format and the memory for you.
+- **llama.cpp** — the efficient inference engine that sits *under* many of these tools. It's lower-level, but it's what makes running models on ordinary hardware (including CPUs) practical.
+- **LM Studio** — a graphical app for browsing, downloading and chatting with models, for people who'd rather not touch a terminal.
+
+The common thread: each one pulls a model and exposes a **local API** on your machine — typically one that mimics a familiar API shape — so many editors, [agentic CLIs](/learn/ai-software-dev/agentic-cli-tools/) and chat front-ends can be pointed straight at it instead of at a cloud provider.
+
+## The hardware reality
+
+This is where local models get honest with you. A model's size is measured in **parameters** — billions of them — and to run at usable speed, those parameters have to fit in fast memory. The single biggest limit is **VRAM**, the memory on your GPU. Fit the model in VRAM and it's quick; spill over and it falls back to system RAM and the CPU, where it still *runs* but often crawls.
+
+**Quantization** is the lever that makes modest hardware viable. It stores each parameter at lower precision — think of it as compressing the model — so a model that wouldn't otherwise fit now does, in exchange for a modest, usually acceptable quality loss. Heavier quantization means a smaller footprint and a bigger quality hit.
+
+Put together, the rule of thumb is simple:
+
+| Model size | Roughly what it needs |
+|---|---|
+| **Small** (a few billion params) | A laptop's RAM or a modest GPU — runs comfortably |
+| **Medium** | A single strong consumer GPU with plenty of VRAM |
+| **Large** (frontier-class open weights) | A high-VRAM card (or several), or slow CPU/RAM fallback |
+
+There's no way around the physics: bigger, more capable models need more memory. Quantization buys you headroom; it doesn't repeal the trade-off.
+
+## The quality gap for coding
+
+Be honest about where local models stand for coding, and durable about *why*. Small local models are genuinely good at **code completion**, **boilerplate**, explaining a snippet, and answering questions **offline** — the everyday help that doesn't need the absolute strongest model. For a lot of routine work, a local model is plenty.
+
+At the top end, though, a gap remains today. The hardest **agentic coding** — long multi-step tasks, large-context reasoning across a whole repository, subtle debugging — still generally favours the frontier hosted models. That's not a knock on open weights; it reflects the enormous compute that goes into training and serving the biggest closed models. The gap has narrowed release by release and keeps narrowing, so this is a snapshot, not a law. Match the model to the task and you'll rarely be disappointed.
+
+## Why run local
+
+Even with that gap, running local earns its place for real reasons:
+
+- **Privacy.** Confidential or proprietary code never leaves your machine — nothing to send, nothing to leak.
+- **Offline / air-gapped.** No internet, no problem. The model runs on a plane, in the field, or on a machine that's deliberately disconnected.
+- **No usage bills or rate limits.** Once you own the hardware, inference is "free" — no per-token meter, no throttling on a busy afternoon.
+- **Control and reproducibility.** The exact model stays put; no provider can change it, price it up, or retire it out from under you.
+- **Learning and experimentation.** Running a model yourself is one of the best ways to understand how these systems actually behave.
+
+## When it makes sense (and when it doesn't)
+
+A short decision guide. Choose by the task in front of you rather than by principle.
+
+**Reach for local when:**
+
+- The code is sensitive and can't leave your network (see [security, privacy & ethics](/learn/ai-software-dev/security-privacy-ethics/)).
+- You need to work offline or on an air-gapped machine.
+- The work is routine — completion, boilerplate, quick questions — and doesn't need the strongest model.
+- You want predictable cost with no per-token bill (see [understanding cost](/learn/ai-software-dev/understanding-cost/)).
+
+**Reach for a hosted frontier model when:**
+
+- The task is a hard, novel, multi-file agentic job where the top of the capability range earns its keep.
+- You don't have the hardware to run a large model at usable speed.
+
+Many developers don't choose once — they run a **hybrid** setup: a local model for private or simple work, a cloud model for the hard problems, switching by task. That's exactly the mix-and-match habit covered in [one model vs. many](/learn/ai-software-dev/one-model-vs-many/), and choosing well per task is the theme of [coding models compared](/learn/ai-software-dev/coding-models-compared/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the model's weights must fit in fast memory (ideally GPU VRAM) to run at usable speed; that's the main constraint." markdown="0">
+  <p class="knowledge-check__q">Quick check: the single biggest limit on which local model you can run at usable speed is usually…?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Which operating system you use</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">How much (V)RAM you have</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Your internet connection speed</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Open-weight** models publish their weights so you can download and run them yourself; that's not the same as an open-source licence, so check the terms.
+- **Local** means the model runs on your machine — nothing leaves it, and you supply the compute.
+- **Ollama, llama.cpp and LM Studio** pull a model and expose a local API your editors and CLIs can point at.
+- The main hardware limit is **memory, mostly GPU VRAM**; **quantization** shrinks a model to fit at some quality cost.
+- Small local models handle completion, boilerplate and offline Q&A well; the hardest agentic coding still favours frontier hosted models, though the gap keeps closing.
+- Run local for privacy, offline use, cost and control — and many people run a **hybrid** of local and cloud, choosing by task.
+
+Next up: with every option on the table, how do you actually choose — [app, IDE, agent — or all three?](/learn/ai-software-dev/app-vs-ide-vs-both/).

--- a/docs/learn/digital-trunking/data-services.md
+++ b/docs/learn/digital-trunking/data-services.md
@@ -1,0 +1,179 @@
+---
+slug: data-services
+title: Data services — GPS, text & registration
+description: How trunked radio systems carry more than voice — registration and affiliation, GPS location reporting, short data and text messaging, and packet data — and how a monitor sees it all ride on or beside the control channel.
+keywords: trunked radio data, GPS location reporting, short data service, text messaging, registration, affiliation, ARS, packet data, P25 PDU, DMR data, control channel data
+level: intermediate
+status: full
+prereq:
+  - the-control-channel
+  - talkgroups-ids-affiliation
+faq:
+  - q: Do trunked radios send more than voice?
+    a: Yes — a great deal more. Every radio registers with the system, affiliates to talkgroups, and can send location reports, status codes, short text messages, and bearer packet data. Much of this is small signaling that rides the control channel; heavier data can be granted its own channel just like a voice call. A trunked system is really a data network that also carries voice.
+  - q: Can I see the GPS locations of radios?
+    a: Sometimes you can tell that location data is being sent — the control channel or a data call will show a radio ID transferring a short payload on a schedule. Whether you can read the coordinates depends on the system. Location reporting is often carried in vendor-specific formats, and it may be encrypted, so a scanner may see that a position update happened without being able to decode where the radio is.
+  - q: What is registration and affiliation data?
+    a: Registration is a radio telling the system it is present and reachable on a site; affiliation is a radio telling the system which talkgroup it is currently listening to. Both are short data messages a radio sends without any user speaking, and they let the system route calls and manage roaming. To a monitor they appear as frequent control-channel messages from many radio IDs with no voice call attached.
+  - q: Where does data ride — the control channel or a separate channel?
+    a: Both. Small, frequent data — registration, affiliation, status, short messages — rides the control channel alongside the call grants. Heavier or sustained data, such as bulk packet transfer, is typically assigned a traffic channel the same way a voice call is granted one, so it does not clog the control channel.
+gophertrunk_links:
+  - title: CC Activity
+    url: /cc-activity.html
+    note: watch control-channel messages, including registrations and affiliations, as GopherTrunk decodes them.
+  - title: Radio IDs
+    url: /radio-ids.html
+    note: the unit IDs seen on the system, including those sending data rather than voice.
+---
+
+# Data services — GPS, text & registration
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A trunked system is a **data network that also carries voice**. Radios constantly send
+**registration/affiliation** to say who they are and which talkgroup they want; many
+also send **location/GPS** reports, **short data** and text messages, and some carry
+bearer **packet data**. Small data rides the [control channel](the-control-channel/)
+alongside call grants; heavy data gets its own channel like a voice call. Much of it a
+monitor can *see happening* even when the payload is opaque — building on
+[talkgroups, IDs & affiliation](talkgroups-ids-affiliation/).
+</div>
+
+It is easy to picture a trunked radio system as a telephone exchange for voice calls.
+That is only half the story. Beneath the calls runs a steady flow of non-voice traffic —
+the messages radios exchange with the system, and with each other, without anyone
+keying up. This lesson catalogues that traffic and shows what a scanner can and can't
+make of it.
+
+## More than voice
+
+Modern land-mobile-radio (LMR) systems move a surprising amount of non-voice data. Every
+radio on the system is a networked device: it announces itself, keeps its talkgroup
+membership current, may report where it is, can send and receive short messages, and on
+some systems can carry general packet data. Dispatchers see much of this as map pins,
+status boards, and message logs rather than as audio.
+
+For a monitor, the important shift in mindset is this: the *absence* of voice does not
+mean the system is idle. A busy control channel with no calls in progress is usually a
+system doing plenty of data work.
+
+## Registration & affiliation data
+
+You met these in [talkgroups, IDs & affiliation](talkgroups-ids-affiliation/); here they
+matter as *data traffic*. When a radio powers on or roams onto a site it **registers** —
+it tells the system "unit 12345 is here." When the user selects a talkgroup, the radio
+**affiliates** — "unit 12345 wants group 101." Neither involves speech; both are short,
+structured data messages.
+
+This is exactly the kind of traffic a monitor sees on the control channel. In the
+vocabulary of [control-channel signaling](control-channel-signaling/), registration and
+affiliation are their own message families, decoded right next to the call grants. Watch
+a control channel for a minute and most of what scrolls past is this housekeeping data,
+not voice.
+
+## Location (GPS) reporting
+
+Many systems support periodic **location reporting**: a radio sends its GPS position on a
+schedule (say every 30 seconds, or on movement) so a dispatch console can plot it on a
+map. This is the backbone of **AVL** — automatic vehicle location — used heavily by
+public-safety and fleet operators.
+
+What a scanner can infer varies. The location report is a data payload from a known radio
+ID, so you can often tell *that* a unit is reporting position and *how often*. Reading the
+coordinates is another matter: location data is frequently carried in **vendor-specific**
+formats layered on top of the standard, and it may be **encrypted**. So it is common to
+see the position updates happening — regular short data from a unit — without being able
+to decode the actual latitude and longitude.
+
+## Short data & text messaging
+
+Alongside voice, radios exchange **short data**: canned **status** codes (a button that
+means "en route," "on scene," "available") and **text messages**, both radio-to-radio and
+between radios and the dispatch console. Status messaging is popular because it is terse
+and machine-readable — a dispatcher's screen fills with unit states without a word being
+spoken. Free-text messaging is slower and less common on the air but supported by most
+standards.
+
+## Packet / IP data
+
+Some systems carry general **bearer** or **packet data** — moving arbitrary bytes rather
+than a fixed message type. P25 defines a **packet data** service (data assembled into
+PDUs, *protocol data units*); DMR carries data in its own frames. Typical uses are
+telemetry, database queries (a mobile data terminal checking a plate or a name), and
+software or configuration transfers. Sustained packet data is bandwidth-hungry, so it is
+usually run on an assigned channel rather than squeezed onto the control channel.
+
+## Control channel vs. dedicated data channel
+
+The dividing line is size and duration:
+
+- **Small, frequent data** — registration, affiliation, status, short messages, brief
+  location reports — rides the **control channel** itself, interleaved with the call
+  grants. It is cheap and needs no channel assignment.
+- **Heavy or sustained data** — bulk packet transfer, large messages — is granted a
+  **traffic/data channel**, assigned by the control channel exactly the way a voice call
+  is. The radio tunes to the granted channel, moves its data, and releases it.
+
+Which mechanism a system leans on depends on its design; the [trunking
+flavors](trunking-flavors/) lesson covers how different systems assign channels.
+
+## What it looks like to GopherTrunk
+
+GopherTrunk's control-channel decoder does not distinguish "voice systems" from "data
+systems" — it decodes the message stream as it comes. In practice that means the log
+shows **registrations**, **affiliations**, and **data-call grants** interleaved with the
+voice-call grants. The [CC Activity](/cc-activity.html) panel is where this is visible;
+the [Radio IDs](/radio-ids.html) view collects the unit IDs seen, including those that
+only ever send data.
+
+Some payloads are **opaque**. A data-call grant tells you a unit is moving data on an
+assigned channel, but the contents may be a vendor format or **encrypted** — see
+[encryption & authentication](encryption-and-authentication/) and
+[OTAR & key management](otar-key-management/). As with encrypted voice, the *metadata*
+(who, when, how often, which channel) is usually still readable even when the payload is
+not.
+
+## Per-system notes
+
+Brief and standard-specific:
+
+- **P25** — carries control-channel data in TSBKs and defines a full **packet data**
+  service built from PDUs; registration, affiliation, and status all have defined message
+  types. See [P25 Phase 1](p25-phase-1/).
+- **DMR** — Tier II and Tier III both support data; Tier III (trunked) uses CSBKs for
+  signaling. Location and registration are often handled by **vendor protocols** (for
+  example an **ARS**, *automatic registration service*, plus a GPS/telemetry protocol)
+  layered on DMR's data frames. See [DMR Tier II & III](dmr-tier-2-3/).
+- **NXDN** and others — likewise define short data and status messaging alongside voice,
+  with location and registration commonly vendor-specific. See [NXDN](nxdn/).
+
+Across all of them the pattern holds: standardized signaling for registration and
+affiliation, plus a mix of standard and vendor-specific formats for location, status, and
+bulk data.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — that constant stream of short messages from many IDs with no audio is registration, affiliation, and data traffic." markdown="0">
+  <p class="knowledge-check__q">Quick check: you see frequent short messages on the control channel from many radio IDs, but no voice call is in progress. What are you most likely watching?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">A single encrypted voice call</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Registration, affiliation, and data traffic</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Interference from an adjacent system</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A trunked system is a **data network that also carries voice** — non-voice traffic is
+  constant.
+- **Registration** and **affiliation** are short data messages that ride the control
+  channel; a monitor sees them plainly.
+- **Location/GPS** reporting drives dispatch mapping (AVL); you can often see it happening
+  even when the coordinates are vendor-specific or encrypted.
+- **Short data**, status codes, and text messaging move between radios and dispatch;
+  **packet data** carries telemetry and queries.
+- Small data rides the **control channel**; heavy data gets a **granted channel** like a
+  voice call.
+- To GopherTrunk it appears as registrations, affiliations, and data-call grants in
+  [CC Activity](/cc-activity.html), with some payloads opaque or encrypted.
+
+Next up: with the whole system understood, Module 4 takes the dominant standard in depth — [P25 Phase 1](/learn/digital-trunking/p25-phase-1/).

--- a/docs/learn/digital-trunking/encryption-and-authentication.md
+++ b/docs/learn/digital-trunking/encryption-and-authentication.md
@@ -145,5 +145,6 @@ rather than leaving you to wonder why a strong, well-locked signal produces no v
   **stun/kill**.
 - GopherTrunk shows an **encrypted indicator** but does **not** break encryption.
 
-That completes how trunking works. The next module turns to the protocols themselves,
-starting with [P25 Phase 1](p25-phase-1/) — the workhorse of North-American public safety.
+Encryption raises an obvious question: how do all those radios get — and change — their
+keys without a technician touching each one? Next up: [OTAR & key
+management](/learn/digital-trunking/otar-key-management/).

--- a/docs/learn/digital-trunking/glossary.md
+++ b/docs/learn/digital-trunking/glossary.md
@@ -237,6 +237,18 @@ before granting it service, separate from encrypting the traffic itself. See
 temporarily (stun) or permanently (kill), used when a unit is lost or stolen. See
 [Encryption & authentication](/learn/digital-trunking/encryption-and-authentication/)
 
+**OTAR (over-the-air rekeying)** — Distributing and updating encryption keys to
+radios remotely over the air, instead of touching each one with a keyloader. See
+[OTAR & key management](/learn/digital-trunking/otar-key-management/)
+
+**Key ID (KID)** — A number sent in the clear that tells radios which key a
+transmission used, without revealing the key itself. See
+[OTAR & key management](/learn/digital-trunking/otar-key-management/)
+
+**Algorithm ID (ALGID)** — A code identifying which cipher (or clear) a transmission
+uses; visible to a monitor even when the audio is not. See
+[OTAR & key management](/learn/digital-trunking/otar-key-management/)
+
 ## P25 (Project 25)
 
 **P25 (Project 25)** — A North American suite of standards for public-safety digital

--- a/docs/learn/digital-trunking/otar-key-management.md
+++ b/docs/learn/digital-trunking/otar-key-management.md
@@ -1,0 +1,195 @@
+---
+slug: otar-key-management
+title: "OTAR & key management"
+description: How encrypted trunked systems distribute and rotate keys — keyloaders and over-the-air rekeying (OTAR) from a key management facility, key IDs and algorithm IDs, crypto periods, and what a scanner can and can't see.
+keywords: OTAR, over the air rekeying, encryption key management, key ID, KID, ALGID, algorithm ID, AES-256, DES-OFB, ADP, crypto period, KMF, keyloader
+level: advanced
+status: full
+prereq:
+  - encryption-and-authentication
+faq:
+  - q: What is OTAR?
+    a: OTAR stands for over-the-air rekeying. Instead of a technician touching each radio with a keyloader, the system sends encrypted rekey messages over the air from a key management facility (KMF), so keys can be added, changed, or zeroized remotely across a whole fleet. It is standardized in P25 (TIA-102) and exists in different forms on DMR and TETRA.
+  - q: Can a scanner decode an OTAR or encrypted system?
+    a: No. A scanner can read the clear-text tags a call carries — the algorithm ID (ALGID) and key ID (KID) — so you can see which talkgroups are secure and which algorithm and key are in use. But without the actual key the voice payload stays unintelligible, and OTAR only moves keys between authorized radios; it never exposes them to a monitor.
+  - q: What is a key ID?
+    a: A key ID (KID) is a short number that names which key a call was encrypted with, without revealing the key itself. It rides in the clear alongside the algorithm ID so the receiving radio knows which stored key to apply. When a system rotates keys, the ALGID usually stays the same while the KID changes.
+  - q: How often do keys change?
+    a: On a schedule set by the operator called the crypto period — it might be daily, weekly, monthly, or tied to an event. Shorter periods limit how much traffic a single compromised key could expose. OTAR is what makes frequent rotation practical, since no one has to visit each radio to load the new key.
+gophertrunk_links:
+  - title: DMR encryption
+    url: /dmr-encryption.html
+    note: how GopherTrunk reports encryption status, algorithm, and key indicators on DMR.
+  - title: CC Activity
+    url: /cc-activity.html
+    note: watch algorithm and key-ID indicators as they appear in the control traffic.
+---
+
+# OTAR & key management
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Encryption is only as practical as its **key** distribution. A **key** is a secret
+number; each call tags — in the clear — which **algorithm ID (ALGID)** and which **key
+ID (KID)** it used, so the right radio can decrypt. Loading keys by hand with a keyloader
+doesn't scale, so big fleets use **OTAR** (over-the-air rekeying) to distribute and rotate
+keys remotely from a key management facility. Keys change on a schedule — the **crypto
+period** — which limits exposure if one leaks. None of this lets a scanner hear the audio:
+you can read the KIDs and ALGIDs, but never the key. See
+[encryption & authentication](/learn/digital-trunking/encryption-and-authentication/).
+</div>
+
+The [previous lesson](/learn/digital-trunking/encryption-and-authentication/) covered
+*how* trunked voice is encrypted and how a decoder can see that a call is protected without
+being able to hear it. This one answers the question that raises: with thousands of radios
+in a fleet, how do they all get the same secret key — and change it — without a technician
+touching every handset? That logistics problem, key *management*, is where OTAR comes in.
+
+## Keys, key IDs and algorithm IDs
+
+A **key** is just a secret number, shared between the radios allowed onto a secure
+talkgroup. The cipher mixes that number into the voice bits so only a radio with the
+matching key can recover audio. Two labels ride in the clear on every encrypted call:
+
+- the **algorithm ID (ALGID)** — *which* cipher: AES-256, DES-OFB, ADP (an RC4-based
+  option), a proprietary mode, or a value meaning **clear** (unencrypted); and
+- the **key ID (KID)** — *which* key of the several a radio may hold.
+
+These tags exist so a receiving radio knows how to handle the call — which algorithm to run
+and which stored key to apply. Because they travel unencrypted alongside the payload, a
+scanner reads them too. The crucial asymmetry: the KID *names* the key, it is **not** the
+key. Knowing that a call used key 3 under AES-256 tells you nothing about the secret itself.
+
+## Loading keys: keyloaders vs OTAR
+
+Traditionally, keys were loaded by hand. A **keyloader** — often a KVL (key variable
+loader), a small handheld device — is physically touched to each radio's connector, and the
+key is transferred over that wire. For a handful of radios this is fine. For a fleet of
+hundreds or thousands spread across a region, it is a logistics nightmare: every rekey means
+rounding up every radio, and a unit in the field or on a distant shift is easily missed.
+
+**OTAR (over-the-air rekeying)** solves this by sending keys *over the air* instead. A
+central **key management facility (KMF)** distributes and updates keys remotely, so a fleet
+can be rekeyed without anyone physically handling a radio. Keyloading and OTAR often
+coexist: a keyloader may plant an initial key-encryption key, after which OTAR handles the
+routine traffic keys.
+
+## How OTAR works (at a high level)
+
+The KMF sends **rekey messages** addressed to individual radios or to groups. These
+messages are themselves encrypted — a new traffic key is wrapped under a key the target
+radio already holds — so the new key is never exposed on the air. Through this channel the
+KMF can:
+
+- **add** a new key to a radio,
+- **change** or update an existing key, and
+- **zeroize** (erase) keys remotely — useful if a radio is lost or stolen.
+
+Radios can also acknowledge and, in some systems, request rekeys, letting the KMF track who
+is current. The mechanism is standardized in **P25 (TIA-102)**, and comparable
+over-the-air key management exists in **[DMR](/learn/digital-trunking/dmr-tier-2-3/)** and
+**[TETRA](/learn/digital-trunking/tetra/)** in their own forms. The common thread: keys move
+between authorized radios only, wrapped so that a monitor sees rekey *activity* but never
+the key material.
+
+## Crypto periods & key rotation
+
+Keys don't live forever. Operators rotate them on a schedule called the **crypto period** —
+daily, weekly, monthly, or tied to an event or shift. The reason is exposure: if a single
+key were somehow compromised, a short crypto period limits how much traffic that key ever
+protected. Rotating regularly also retires keys before they've encrypted enough material to
+be worth attacking.
+
+OTAR is precisely what makes frequent rotation practical — pushing a new key to a whole
+fleet over the air costs the operator almost nothing, whereas hand-loading every radio each
+week would be unworkable. To a monitor, a rotation is quietly visible: the **same
+talkgroup** keeps running, the **same ALGID** stays in place, but the **KID changes** to the
+new key. That's the signature of a fresh crypto period.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 540 150" role="img" aria-label="A key management facility at left sends wrapped rekey messages over the air to several radios at right; a monitor below sees only the clear key-ID and algorithm-ID tags, not the key." xmlns="http://www.w3.org/2000/svg">
+  <rect x="20" y="45" width="110" height="46" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.5"/>
+  <text x="75" y="66" text-anchor="middle" font-size="10" fill="currentColor" font-weight="600">KMF</text>
+  <text x="75" y="82" text-anchor="middle" font-size="8" fill="currentColor">key mgmt facility</text>
+  <g stroke="currentColor" stroke-width="1.3" fill="none" stroke-dasharray="5 3">
+    <line x1="130" y1="60" x2="380" y2="40"/>
+    <line x1="130" y1="68" x2="380" y2="68"/>
+    <line x1="130" y1="76" x2="380" y2="96"/>
+  </g>
+  <text x="255" y="24" text-anchor="middle" font-size="9" fill="currentColor">wrapped rekey messages (over the air)</text>
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <text x="405" y="43">radio</text>
+    <text x="405" y="71">radio</text>
+    <text x="405" y="99">radio</text>
+  </g>
+  <rect x="150" y="118" width="240" height="26" rx="5" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="270" y="135" text-anchor="middle" font-size="9" fill="currentColor">monitor sees: ALGID + KID (clear) — not the key</text>
+</svg>
+<figcaption>The KMF rekeys radios over the air with wrapped messages. A monitor can log the algorithm and key IDs the traffic advertises, but the key material itself never travels in the clear.</figcaption>
+</figure>
+
+## What a scanner can and can't see
+
+Put plainly, a scanner can:
+
+- **log KIDs and ALGIDs** per call and watch them over time,
+- **tell encrypted from clear** — the ALGID distinguishes AES-256 or DES-OFB from a clear
+  call, and
+- **map which talkgroups are secure** and spot a rotation when a KID changes.
+
+What it **cannot** do is recover audio without the key. That isn't a GopherTrunk
+limitation; it's the whole point of the design — modern ciphers like AES-256 are built to
+resist exactly that, and OTAR is engineered so keys reach authorized radios and no one else.
+
+It's worth being clear about the line this lesson stays on. Understanding the *signaling* —
+what an ALGID or KID means, what a rekey looks like from outside — is ordinary radio
+literacy and is what a decoder like GopherTrunk reports. Defeating encryption to recover
+protected audio is a different thing entirely, and it is neither the goal here nor something
+GopherTrunk attempts. See
+[encryption & authentication](/learn/digital-trunking/encryption-and-authentication/) for
+where that wall sits.
+
+## Per-system notes
+
+The idea is universal; the details differ by standard.
+
+- **P25** — key management is standardized in **TIA-102**, with a **KMF** performing OTAR:
+  rekey, key updates, and zeroize, addressed to individual radios or groups. This is the
+  most fully specified of the three. See
+  [P25 Phase 1](/learn/digital-trunking/p25-phase-1/).
+- **DMR** — ranges from **basic/enhanced privacy** (lightweight, often symmetric scrambling)
+  up to **AES**, with over-the-air key management offered largely through **vendor**
+  implementations rather than one universal scheme. See
+  [DMR Tier 2/3](/learn/digital-trunking/dmr-tier-2-3/).
+- **TETRA** — layers protection: the **TEA** air-interface encryption family secures the
+  radio link, and separate **end-to-end** encryption can protect the payload across the
+  whole path, each with its own key handling. See
+  [TETRA](/learn/digital-trunking/tetra/).
+
+Across all three, the takeaway for a monitor is the same: you'll see the algorithm and key
+identifiers in the clear, and you won't see the keys.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — same talkgroup, same algorithm, new KID is the signature of a key rotation, a fresh crypto period." markdown="0">
+  <p class="knowledge-check__q">Quick check: a talkgroup you watch suddenly shows a new key ID but the same ALGID. What happened?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">The system switched to a different encryption algorithm</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The system rotated to a new key (a new crypto period)</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Your decoder recovered the key and can now hear the call</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **key** is a secret number; every call tags its **ALGID** (which cipher) and **KID**
+  (which key) in the clear so the right radio can decrypt.
+- **Keyloaders** (a KVL touched to each radio) don't scale; **OTAR** distributes and updates
+  keys over the air from a **key management facility (KMF)**.
+- OTAR sends **wrapped rekey messages** to radios or groups, and can add, change, or
+  **zeroize** keys remotely — standardized in P25 (TIA-102), with variants in DMR and TETRA.
+- Keys rotate on a **crypto period** to limit exposure; to a monitor a rotation looks like
+  the **same talkgroup and ALGID with a new KID**.
+- A scanner can **log KIDs/ALGIDs and tell secure from clear**, but **cannot recover audio**
+  without the key — that's the design working as intended.
+
+Next up: the other things a trunked system carries besides voice — [data services: GPS, text & registration](/learn/digital-trunking/data-services/).

--- a/docs/learn/git/branch-protection.md
+++ b/docs/learn/git/branch-protection.md
@@ -163,4 +163,4 @@ or malicious — can quietly compromise it. (Unsure about "force-push," "status 
   [Actions](/learn/git/github-actions/), this makes the reviewed, tested path the only
   way into `main`.
 
-Next up: rewriting history precisely with [interactive rebase](/learn/git/interactive-rebase/).
+Next up: three power features that round out the GitHub toolkit — [the CLI, Git LFS & repo security](/learn/git/cli-lfs-and-security/).

--- a/docs/learn/git/cli-lfs-and-security.md
+++ b/docs/learn/git/cli-lfs-and-security.md
@@ -1,0 +1,188 @@
+---
+slug: cli-lfs-and-security
+title: The GitHub CLI, Git LFS & repo security
+description: Round out day-to-day GitHub with three practical features — driving GitHub from the terminal with the gh CLI, handling big binaries with Git LFS, and letting Dependabot, secret scanning and code scanning guard your repo.
+keywords: GitHub CLI, gh command, Git LFS, large file storage, Dependabot, secret scanning, push protection, security advisories, CodeQL, code scanning
+level: intermediate
+status: full
+prereq:
+  - pull-requests
+  - remotes
+faq:
+  - q: What is the gh CLI and why use it?
+    a: "gh is GitHub's official command-line tool. It lets you do GitHub-side work — open and review pull requests, manage issues, clone repos, watch Actions runs — without leaving the terminal or round-tripping through a browser. Because it's a command, it also scripts cleanly, so common chores can be automated. It complements git rather than replacing it: git handles commits and history, gh handles the GitHub platform around them."
+  - q: What is Git LFS for?
+    a: Git Large File Storage keeps big binary files (audio, video, datasets, trained models) out of your repository's history. Git normally stores every version of every file forever, so committing large binaries bloats the repo permanently. LFS replaces those files with tiny text pointers and stores the real blobs separately, so a clone only pulls the versions it needs.
+  - q: How does GitHub stop me committing a secret?
+    a: Two features work together. Secret scanning recognises the patterns of known credentials — API keys, tokens, private keys — in your commits. Push protection goes further and blocks the push outright when it spots one, before the secret ever reaches the remote. If a secret does leak, the correct fix is to rotate (revoke and reissue) it, not just delete the commit, because anyone may already have copied it.
+  - q: What is Dependabot?
+    a: Dependabot watches the dependencies your project declares and alerts you when one has a known vulnerability. It can also open pull requests that bump the affected dependency to a fixed version automatically, so keeping libraries patched becomes a review-and-merge chore rather than manual tracking.
+---
+
+# The GitHub CLI, Git LFS & repo security
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Three practical features round out day-to-day GitHub. The **gh CLI** drives the
+platform from your terminal — open [pull requests](/learn/git/pull-requests/), review,
+watch [Actions](/learn/git/github-actions/) runs — without browser round-trips, and it
+scripts cleanly. **Git LFS** keeps big binaries (audio, video, datasets, models) out of
+your history by storing tiny **pointer files** in Git and the blobs separately. And
+GitHub can **guard the repo itself**: **Dependabot** flags vulnerable dependencies,
+**secret scanning** plus push protection stop leaked credentials, and code scanning
+(CodeQL) runs static analysis in CI. All three are opt-in tools you turn on as a repo
+grows.
+</div>
+
+You've learned the everyday flow — commit, push, open a PR, run CI. This lesson covers
+three features that sit alongside that flow and make working on GitHub faster and safer:
+a command-line tool, a way to handle large files, and the platform's built-in security
+guards. None of them is essential on day one, but each earns its place as a project
+matures.
+
+## The GitHub CLI (gh)
+
+**`gh`** is GitHub's official command-line tool. Everything you'd normally click through
+the website for — pull requests, issues, releases, Actions — has a `gh` equivalent, so
+you can stay in the terminal where your code already is.
+
+First, authenticate once:
+
+```sh
+gh auth login          # interactive: pick GitHub.com, HTTPS/SSH, log in
+```
+
+After that, the common commands read almost like English:
+
+```sh
+gh repo clone owner/name       # clone without typing the full URL
+gh pr create                   # open a PR from the current branch
+gh pr checkout 42              # check out someone else's PR locally
+gh pr view --web               # jump to a PR in the browser
+gh issue list                  # browse open issues
+gh run watch                   # follow the latest Actions run live
+```
+
+Two things make `gh` worth adopting. First, it **saves round-trips**: opening a PR or
+checking a review no longer means switching to the browser, finding the tab, and
+clicking around. Second, because each command is just a command, it **scripts nicely** —
+you can wire `gh` into shell scripts or Actions to automate repetitive chores.
+
+Note that `gh` **complements git, it doesn't replace it**. `git` still handles your
+commits, branches, and history locally; `gh` handles the GitHub platform layered on top —
+the PRs, issues, and runs that live on the server.
+
+## Git LFS — large files without bloat
+
+Git was built for source code, and it stores **every version of every file forever**.
+That's exactly what you want for text: diffs are small and history is cheap. It's a
+problem for **big binaries** — audio captures, video, datasets, trained models. Commit a
+100 MB file, change it ten times, and your repository now carries a gigabyte of history
+that every clone must download, permanently, even after you delete the file.
+
+**Git LFS (Large File Storage)** fixes this. Instead of putting the binary in Git, LFS
+stores a tiny **pointer file** — a few lines of text naming the real content — and keeps
+the actual blob on a separate LFS store. Git history stays small; the heavy data is
+fetched only when a checkout needs it.
+
+You tell LFS which files to manage by pattern:
+
+```sh
+git lfs install                 # one-time setup per machine
+git lfs track "*.wav"           # manage all .wav files with LFS
+git add .gitattributes          # tracking rules live here — commit them
+git add capture.wav
+git commit -m "Add sample capture via LFS"
+```
+
+`git lfs track` writes the pattern into **`.gitattributes`**, which you commit so
+everyone on the project inherits the same rules.
+
+A few caveats:
+
+- **Quotas.** LFS storage and bandwidth have limits on GitHub's free tier; large or busy
+  repos may need a paid allowance.
+- **Everyone needs LFS installed.** A collaborator without Git LFS sees the pointer files,
+  not the real content.
+- **It's not for source code.** LFS is for large binaries; plain text belongs in normal
+  Git, where diffs and merges work.
+
+LFS is also a decision point next to your [`.gitignore`](/learn/git/gitignore/) choices:
+some big files should be tracked in LFS, but many build artifacts and generated blobs
+shouldn't be committed at all — those simply go in `.gitignore`.
+
+## Repo security features
+
+GitHub can actively watch your repository for common security problems. These are opt-in,
+found under **Settings → Security**, and cost nothing to enable on most repos.
+
+### Dependabot
+
+**Dependabot** reads the dependencies your project declares (via `package.json`,
+`go.mod`, `requirements.txt`, and the like) and cross-checks them against a database of
+known vulnerabilities. When a dependency you use has a published flaw, it raises an
+**alert**. Better still, it can open **automated pull requests** that bump the affected
+package to a fixed version — so patching becomes a matter of reviewing and merging a PR,
+not tracking advisories by hand.
+
+### Secret scanning & push protection
+
+Credentials committed by accident — an API key, a cloud token, a private key — are one
+of the most common ways secrets leak. GitHub's **secret scanning** recognises the
+patterns of hundreds of known credential types in your commits. **Push protection** takes
+it a step earlier: it **blocks the push** the moment it detects a secret, so the credential
+never reaches the remote in the first place.
+
+If a secret does get out, understand the real fix. Deleting the commit or rewriting
+history is **not enough** — anyone (or any bot scraping public pushes) may already have a
+copy. The only safe response is to **rotate the secret**: revoke the leaked key and issue
+a new one, so the exposed value becomes worthless.
+
+### Security advisories & code scanning (CodeQL)
+
+For maintainers, GitHub adds two more tools. **Security advisories** let you draft and
+discuss a vulnerability **privately**, prepare a fix, and only then publish the advisory
+and coordinate disclosure — rather than fixing a bug in the open where it tips off
+attackers. And **code scanning** with **CodeQL** runs automated static analysis over your
+code as part of [CI](/learn/git/github-actions/), flagging suspicious patterns (injection
+risks, unsafe deserialisation, and so on) directly on the pull request that introduced
+them.
+
+## When to reach for each
+
+These are tools you switch on as the need appears, not upfront:
+
+- Install **`gh`** as soon as you're opening PRs regularly — it pays for itself the first
+  day.
+- Turn on **Git LFS** the moment you need to version a large binary. Do it *before* the
+  first big commit; retrofitting LFS onto existing history is painful.
+- Enable **Dependabot** as soon as your project has real dependencies.
+- Enable **secret scanning and push protection** early — a leaked key is far cheaper to
+  prevent than to clean up.
+- Reach for **advisories and CodeQL** when the project is used by others and security
+  matters enough to formalise.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a leaked key may already be copied, so you must revoke it and issue a new one." markdown="0">
+  <p class="knowledge-check__q">Quick check: you accidentally push an API key. Besides removing it from history, what MUST you do?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Nothing — deleting the commit is enough</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Rotate/revoke the leaked key and issue a new one</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Add the key to a .gitignore file</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **`gh`** is GitHub's official CLI — PRs, issues, clones, and Actions runs from the
+  terminal; it scripts well and **complements**, not replaces, git.
+- **Git LFS** keeps large binaries out of history via small **pointer files** and a
+  `.gitattributes` tracking list; mind quotas, and remember everyone needs LFS installed.
+- **Dependabot** alerts on vulnerable dependencies and can open update PRs automatically.
+- **Secret scanning + push protection** detect and block committed credentials; the real
+  fix for a leak is to **rotate** the secret, not just delete the commit.
+- **Advisories** let you handle vulnerabilities privately, and **CodeQL code scanning**
+  runs static analysis in [CI](/learn/git/github-actions/).
+- All of these are **opt-in** — turn them on as the repo grows.
+
+Next up: Module 6 opens the power tools — rewriting history precisely with [interactive rebase](/learn/git/interactive-rebase/).

--- a/docs/learn/intro-hardware/building-blocks.md
+++ b/docs/learn/intro-hardware/building-blocks.md
@@ -134,4 +134,4 @@ Read down the columns and the scale of the difference is clear: a server can hav
 - **I/O connects to the world** — networking, USB, displays, and GPIO are how a computer senses and acts, and often the deciding factor in fit.
 - **Same parts, different scale** — a server and a microcontroller share all four blocks, separated by a factor of millions.
 
-Next up: with the parts named, we can lay every platform out on one map, ordered by power, cost, and control. See [The hardware spectrum — cloud to microcontroller](/learn/intro-hardware/hardware-spectrum/).
+Next up: those four blocks assume a general-purpose CPU — but some jobs reach for [GPUs, FPGAs & accelerators](/learn/intro-hardware/specialized-compute/) instead.

--- a/docs/learn/intro-hardware/glossary.md
+++ b/docs/learn/intro-hardware/glossary.md
@@ -26,6 +26,14 @@ This is a plain-language reference for the key terms used across the Intro to Ha
 
 **Clock speed** — How many cycles per second a CPU runs, measured in gigahertz (GHz); a rough, not absolute, guide to how fast it works. See [CPU, memory, storage & I/O](/learn/intro-hardware/building-blocks/)
 
+**GPU (graphics processing unit)** — A processor with thousands of small cores built for massively parallel math; used for graphics, scientific computing, and modern AI. See [Beyond the CPU — GPUs, FPGAs & accelerators](/learn/intro-hardware/specialized-compute/)
+
+**FPGA (field-programmable gate array)** — A chip you configure into a custom digital circuit, giving deterministic, low-latency hardware — often used in the front end of high-end SDRs. See [Beyond the CPU — GPUs, FPGAs & accelerators](/learn/intro-hardware/specialized-compute/)
+
+**DSP (digital signal processor)** — A processor specialized for signal math like filtering and transforms, common in radios, modems, and audio gear. See [Beyond the CPU — GPUs, FPGAs & accelerators](/learn/intro-hardware/specialized-compute/)
+
+**ASIC / accelerator** — Fixed-function silicon built for one job at maximum efficiency, including AI accelerators (NPUs and TPUs). See [Beyond the CPU — GPUs, FPGAs & accelerators](/learn/intro-hardware/specialized-compute/)
+
 **RAM (memory)** — Fast, temporary working storage that holds the data and programs a computer is actively using; it is cleared when power is lost. See [CPU, memory, storage & I/O](/learn/intro-hardware/building-blocks/)
 
 **Storage** — Where data is kept long-term so it survives a power cycle, such as a hard drive or solid-state drive. See [CPU, memory, storage & I/O](/learn/intro-hardware/building-blocks/)

--- a/docs/learn/intro-hardware/specialized-compute.md
+++ b/docs/learn/intro-hardware/specialized-compute.md
@@ -1,0 +1,119 @@
+---
+slug: specialized-compute
+title: Beyond the CPU — GPUs, FPGAs & accelerators
+description: The CPU can run any code, but it isn't always the best tool. Learn how GPUs, FPGAs, DSPs, and AI accelerators trade flexibility for throughput and efficiency — and when SDR work actually needs them.
+keywords: GPU, graphics processing unit, FPGA, field programmable gate array, DSP chip, ASIC, AI accelerator, NPU, TPU, parallel computing, SDR FPGA
+level: intermediate
+status: full
+prereq:
+  - building-blocks
+faq:
+  - q: "What's the difference between a CPU and a GPU?"
+    a: "A **CPU** has a few powerful cores optimised for running any kind of code fast, including branchy, decision-heavy logic. A **GPU** has thousands of small, simple cores that all do the *same* operation on different data at once. The CPU is the versatile generalist; the GPU is a specialist that wins big on wide, repetitive math — image processing, physics, and the matrix multiplications behind modern AI — but is poor at serial, branchy work."
+  - q: "What is an FPGA?"
+    a: "An **FPGA** (field-programmable gate array) is a chip you can rewire into a custom digital circuit after it's manufactured. Instead of running software on a fixed processor, you describe hardware — filters, counters, decoders — and the FPGA becomes that circuit. The payoff is deterministic, low-latency, massively parallel processing, which is why high-end SDRs use one to filter and decimate samples right at the antenna before a PC ever sees them. The cost is that FPGAs are much harder to program than ordinary computers."
+  - q: "Do I need a GPU for SDR?"
+    a: "Almost certainly not. Most SDR decoding, GopherTrunk included, runs entirely on the CPU and decodes trunked voice comfortably on an ordinary laptop or even a Raspberry Pi. GPUs and FPGAs matter only at the high end — very wide bandwidths, many channels at once, or heavy real-time DSP research. A well-written CPU pipeline covers the everyday case."
+  - q: "What is an AI accelerator or NPU?"
+    a: "An **AI accelerator** is silicon built specifically for the math machine-learning models use — mostly large matrix multiplications. An **NPU** (neural processing unit) is one built into a phone or laptop chip; a **TPU** (tensor processing unit) is Google's data-centre version. They do far less than a general CPU but run neural-network math faster and with much lower power, which is why they're increasingly baked into everyday devices."
+gophertrunk_links:
+  - title: SDR hardware
+    url: /hardware.html
+    note: the receivers GopherTrunk runs on — some do their first-stage DSP on an onboard FPGA.
+  - title: Architecture
+    url: /architecture.html
+    note: how GopherTrunk organises its DSP pipeline — and why it stays on the CPU.
+---
+
+# Beyond the CPU — GPUs, FPGAs & accelerators
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The CPU is a generalist** — a few fast cores that run *any* code, but not always the best tool for the job. When work is massively parallel or has to happen with hard timing guarantees, specialised silicon wins. A **GPU** throws thousands of small cores at wide, repetitive math (and powers modern AI). An **FPGA** becomes a custom circuit for deterministic, low-latency processing. A fixed-function **accelerator** (ASIC, NPU, TPU) trades away flexibility for maximum throughput and efficiency. The rule of thumb: reach past the CPU only when the CPU can't keep up. See [CPU, memory, storage & I/O](/learn/intro-hardware/building-blocks/).
+</div>
+
+The [last lesson](/learn/intro-hardware/building-blocks/) opened the box and found four parts in every computer: a CPU, memory, storage, and I/O. That CPU is a general-purpose processor — it will run anything you ask of it. But "will run anything" and "is the best tool for this particular job" are not the same claim. Some jobs are shaped so awkwardly for a CPU that engineers reach for a different kind of chip entirely. This lesson names those chips, explains what each is good at, and — honestly — where they do and don't matter for SDR work.
+
+## The CPU is a generalist
+
+A CPU has a handful of powerful cores, each running its fetch-execute loop very fast. Its great strength is *versatility*: it handles branchy, decision-heavy code — "if this, do that; otherwise loop back" — as easily as straight-line arithmetic. Almost all software you'll ever write runs happily on a CPU, and for most tasks nothing else is needed.
+
+Where a CPU struggles is at the extremes. Two in particular:
+
+- **Massively parallel math.** A CPU with eight cores can do eight things at once. If your job is the *same* simple operation applied to a million pieces of data, eight-at-a-time is slow.
+- **Hard real-time signal work.** A general-purpose operating system can pause your program at any moment to do something else. That's fine for a spreadsheet, but if a filter must produce a result every fixed number of nanoseconds with no exceptions, the CPU's flexibility becomes a liability.
+
+Each of the chips below exists because it answers one of those two weaknesses.
+
+## GPUs — thousands of small cores
+
+A **GPU** (graphics processing unit) attacks the first weakness. Where a CPU has a few big cores, a GPU has *thousands* of small, simple ones. They aren't independent the way CPU cores are — they mostly march in lockstep, every core running the same instruction on a different slice of data. This is called **data-parallel** or SIMD (single instruction, multiple data) work.
+
+That design was born for graphics: shading millions of pixels is exactly "do the same math to a huge grid of data." Engineers soon realised the same engine could crunch *any* wide parallel math — a use called **GPGPU** (general-purpose computing on a GPU). Today that's the engine behind modern AI: training and running neural networks is mostly enormous matrix multiplication, which maps perfectly onto thousands of cores.
+
+The trade-off is the mirror image of the CPU's. Give a GPU branchy, serial logic — lots of "if this then that" where each step depends on the last — and most of its cores sit idle. GPUs also have their own dedicated memory, **VRAM**, and a model or dataset that won't fit in VRAM simply can't run well. A GPU is a specialist: spectacular on the right shape of problem, mediocre on the wrong one.
+
+## FPGAs — reconfigurable hardware
+
+An **FPGA** (field-programmable gate array) attacks the second weakness, and it does so in a fundamentally different way. A CPU and a GPU are fixed chips that *run software*. An FPGA is a chip full of logic blocks and wires you can **reconfigure into a custom circuit** after it leaves the factory. You don't write a program that runs on a processor — you describe hardware, and the FPGA physically *becomes* that hardware.
+
+Because the result is a real circuit rather than software sharing a busy processor, an FPGA delivers **deterministic, low-latency, parallel** processing: every clock tick, the circuit does exactly what it was wired to do, on time, every time. That's precisely what high-rate signal processing wants. High-end SDRs put an FPGA right behind the antenna to **filter and decimate** the raw sample stream — throwing away the bandwidth you don't care about — before the data ever reaches a PC over USB or Ethernet. Doing that first stage in dedicated hardware is often the only way to keep up with a very wide, very fast stream.
+
+The catch is programming. You describe an FPGA's circuit in a **hardware description language** (HDL) such as VHDL or Verilog, thinking in terms of gates, clocks, and timing rather than ordinary lines of code. It's a specialised skill, and development is slower and less forgiving than writing software.
+
+## DSPs — chips built for signal math
+
+A **DSP** (digital signal processor) sits between the general CPU and the fully custom FPGA. It's a processor — it runs software — but its instruction set and hardware are tuned for the one operation signal processing does constantly: **multiply-accumulate**, multiplying pairs of numbers and adding up the results, the heart of every digital filter.
+
+DSPs powered generations of radios, modems, and audio gear, and they haven't gone away — they're still tucked inside phones, hearing aids, and countless embedded devices, quietly doing audio and radio math efficiently. On a modern PC the CPU is usually fast enough that a separate DSP chip isn't needed, but the *idea* — hardware shaped around signal math — lives on in CPU vector instructions and in FPGA and GPU pipelines alike.
+
+## ASICs, NPUs & AI accelerators
+
+At the far end of the spectrum is the **ASIC** (application-specific integrated circuit): a chip designed and manufactured to do exactly one thing, with nothing reconfigurable about it. Because every transistor is committed to the task, an ASIC is the most efficient and fastest option there is — and the least flexible. If the job ever changes, you need a new chip. ASICs make sense only when a job is fixed and the volume is huge: think the radio baseband chip in a phone, or a Bitcoin miner.
+
+Modern **AI accelerators** are ASICs (or near-ASICs) built for machine-learning math. An **NPU** (neural processing unit) is one integrated into a phone or laptop processor; a **TPU** (tensor processing unit) is Google's data-centre design. They can't do much beyond neural-network math, but they do it far faster and at far lower power than a general CPU — which is why they're increasingly standard silicon.
+
+Step back and there's a clean spectrum:
+
+| | CPU | GPU | FPGA | ASIC |
+|---|-----|-----|------|------|
+| **Flexibility** | anything | wide parallel math | any circuit you wire | one fixed job |
+| **Efficiency** | lowest | high on the right shape | high | highest |
+| **Programmed with** | ordinary code | GPU code | hardware description | not programmable |
+
+Read left to right and you're trading **flexibility for efficiency**. The CPU does anything but wrings the least throughput per watt from silicon; the ASIC does exactly one thing at maximum efficiency and nothing else. GPUs and FPGAs sit in between, each leaning one way.
+
+## Where SDR & DSP work leans on these
+
+Here's the honest framing, because it's easy to assume radio work demands exotic hardware. It usually doesn't.
+
+At the **high end** — capturing hundreds of megahertz of spectrum, monitoring dozens of channels at once, or doing heavy real-time DSP research — you do see specialised compute. The SDR itself may carry an **FPGA** to filter and decimate before the data leaves the device, and a **GPU** can accelerate wide, batch-style DSP on the host.
+
+But for the everyday task this path is about — decoding a trunked voice system — a **well-written CPU pipeline is plenty**. GopherTrunk's entire DSP chain, from down-conversion to demodulation to symbol decoding, runs on the CPU and keeps up comfortably on an ordinary laptop, and even on a [Raspberry Pi](/learn/intro-hardware/programming-an-sbc/) sitting at the antenna. The reason is that the receiver normalises the signal down to a modest per-channel rate early on, so the heavy math happens on a manageable stream — no GPU or custom silicon required. That's a deliberate design choice, and it's the opposite end of the spectrum from a [microcontroller](/learn/intro-hardware/what-is-a-microcontroller/) too small to run a general OS at all.
+
+## Choosing
+
+The heuristic is short: **reach for specialised compute only when the CPU genuinely can't keep up.** Specialised silicon is faster or more efficient on its niche, but it costs more, often draws its own power budget, and — for FPGAs and ASICs especially — takes far more effort to develop for.
+
+So weigh the same three forces every hardware decision comes down to: [cost, power, and performance](/learn/intro-hardware/cost-power-performance/), plus the development effort a harder-to-program chip demands. If a CPU meets your needs, use it — it's the cheapest to build for and the easiest to change. Move to a GPU, FPGA, or accelerator when a real bottleneck forces the trade, not before.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — an FPGA becomes a custom circuit, giving the deterministic, low-latency processing a filter at the antenna needs." markdown="0">
+  <p class="knowledge-check__q">Quick check: you need a deterministic, low-latency filter running right at the antenna before samples ever hit the PC. Which chip is the best fit?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">A faster general-purpose CPU</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">An FPGA</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">A bigger GPU with more VRAM</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **The CPU is a versatile generalist** — a few fast cores that run any code well, but struggle with massively parallel math and hard real-time timing.
+- **GPUs** bring thousands of small cores for wide, data-parallel math — graphics, general compute, and the engine of modern AI — but are poor at branchy serial logic.
+- **FPGAs** are reconfigurable hardware: you wire them into a custom circuit for deterministic, low-latency processing, at the cost of harder (HDL) development.
+- **DSPs and ASICs/NPUs/TPUs** fill out a spectrum from CPU to fixed-function silicon that trades flexibility for efficiency.
+- **SDR reality check** — the high end may use an FPGA or GPU, but a well-written CPU pipeline like GopherTrunk's decodes trunked voice on a plain laptop or a Raspberry Pi.
+- **Choosing** — reach past the CPU only when it can't keep up, weighing cost, power, and development effort.
+
+Next up: with every kind of processor named, we can lay all the platforms on one map — [the hardware spectrum, cloud to microcontroller](/learn/intro-hardware/hardware-spectrum/).

--- a/docs/learn/intro-software-dev/apis-and-integration.md
+++ b/docs/learn/intro-software-dev/apis-and-integration.md
@@ -1,0 +1,237 @@
+---
+slug: apis-and-integration
+title: APIs & talking to other software
+description: How programs talk to each other through APIs — a contract that lets one piece of software use another without knowing its internals, from in-process library calls to REST over HTTP with JSON, plus gRPC, WebSockets, and the discipline of not breaking your callers.
+keywords: API, application programming interface, REST, HTTP, JSON, web API, library API, endpoint, gRPC, WebSocket, integration, webhook
+level: intermediate
+status: full
+prereq:
+  - abstraction-coupling
+faq:
+  - q: "What is an API?"
+    a: "An API (application programming interface) is a defined set of requests one program offers to others — the inputs it accepts, the outputs it returns, and the rules for using it. It's a contract that lets you use software without knowing how it works inside, exactly like the \"program to an interface\" idea applied between programs."
+  - q: "What is REST?"
+    a: "REST is a common style for web APIs. It models things as resources, each with its own URL, and uses standard HTTP methods as verbs — GET to read, POST to create, PUT to update, DELETE to remove. It's popular because it leans on plumbing the web already has rather than inventing its own."
+  - q: "What's the difference between a library API and a web API?"
+    a: "A library API is a set of functions you call directly inside your own process — fast, in-memory, same machine. A web API is a set of requests sent over the network to another machine or service — slower, and able to fail in ways a local call can't. Same idea (a published contract), different distance."
+  - q: "What format do APIs use?"
+    a: "Web APIs most often exchange JSON over HTTP — a lightweight, human-readable text format for structured data. Other formats exist (XML, or the compact binary of gRPC), but JSON over HTTP is the everyday default for REST APIs."
+gophertrunk_links:
+  - title: Web UI
+    url: /web.html
+    note: GopherTrunk's browser UI is a client that talks to the running daemon over an API.
+---
+
+# APIs & talking to other software
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+An **API** is a contract that lets one piece of software use another **without
+knowing its internals** — you depend on the published *what*, not the *how*.
+It's the same "[program to an interface](/learn/intro-software-dev/abstraction-coupling/)"
+idea, applied *between* programs. Most web APIs are **REST**: requests over
+**HTTP**, data as **JSON**. Get the contract right and two programs written by
+two teams, in two languages, on two machines, can cooperate.
+</div>
+
+You've seen that a good [abstraction](/learn/intro-software-dev/abstraction-coupling/)
+lets one part of a program use another through a clean interface, ignoring the
+mess behind it. An API is that exact idea stretched across a boundary — between
+libraries, between programs, between whole companies. It's how your code borrows
+a mapping service, how a browser page talks to a server, and how GopherTrunk's UI
+drives the decoder running underneath it. Learn to read and design APIs and most
+of modern software stops looking like magic and starts looking like parts that
+agreed on how to talk.
+
+## What an API is
+
+An **API — application programming interface** — is a defined set of requests one
+program offers to others. It spells out what you can ask for, what inputs each
+request needs, what you'll get back, and the rules for using it. That's all a
+contract is: **inputs, outputs, and rules**, with the implementation hidden behind
+them.
+
+The worn-out analogy earns its keep here: an API is a **restaurant menu**. It lists
+what you can order and what each dish costs, and you order by name. You don't walk
+into the kitchen, and you don't need to — the menu is the interface, the kitchen is
+the hidden *how*. The chef can change recipes, swap suppliers, or rebuild the whole
+kitchen, and as long as the menu still means what it said, you never notice. Break
+the menu — rename a dish, quietly change what it contains — and every regular who
+ordered it is surprised.
+
+## Library APIs vs. web APIs
+
+The word "API" covers two distances.
+
+A **library (or module) API** is a set of functions you call **inside your own
+process**. You import the library, call `parseDate(...)` or `filter.Process(...)`,
+and control returns to you microseconds later. Same machine, same memory, no
+network. The contract is the function signatures and their documented behavior.
+
+A **web (or network) API** is a set of requests sent **over the network** to another
+machine or service. You don't call a function; you send a message — typically an
+HTTP request — and wait for a reply that has to travel there and back. Same idea, but
+the distance changes everything downstream: it's slower, and it can **fail** in ways a
+local call never does (the network drops, the other service is down, the reply is
+late). We'll come back to that under integration.
+
+Same concept, then — a published contract you program against — just separated by a
+function call in one case and a network hop in the other.
+
+## HTTP in one minute
+
+Most web APIs ride on **HTTP**, the same protocol your browser uses. HTTP is a simple
+**request/response** exchange: a client sends a request, the server sends one response.
+A request carries a few key things:
+
+- A **method** — the verb. `GET` reads, `POST` creates, `PUT`/`PATCH` update, `DELETE`
+  removes.
+- A **URL / endpoint** — the address of the thing you're acting on, e.g.
+  `/systems/42/talkgroups`.
+- Optional **headers** (metadata, like auth keys or content type) and a **body** (the
+  data you're sending, on POST/PUT).
+
+The response comes back with a **status code** that says how it went at a glance:
+**2xx** success (200 OK), **4xx** the caller got it wrong (404 Not Found, 401
+Unauthorized), **5xx** the server broke (500 Internal Server Error). Learn to read the
+status code first — it tells you whether the problem is on your side or theirs before
+you read a single line of the body.
+
+## REST & JSON
+
+**REST** is the most common style for arranging a web API. Two ideas carry most of it:
+
+- **Resources are URLs.** Every "thing" the API exposes — a system, a talkgroup, a
+  recording — gets its own address.
+- **HTTP methods are the verbs.** You `GET` a resource to read it, `POST` to create
+  one, `DELETE` to remove it. You don't invent `/getSystem` and `/deleteSystem`
+  endpoints; you use `GET /systems/42` and `DELETE /systems/42`.
+
+The data going back and forth is almost always **JSON** — JavaScript Object Notation,
+a lightweight text format of key/value pairs and lists that's readable by humans and
+trivial for any language to parse. A tiny exchange looks like this:
+
+```http
+GET /systems/42 HTTP/1.1
+Host: api.example.org
+Accept: application/json
+
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "id": 42,
+  "name": "Metro P25",
+  "type": "P25",
+  "control_channels_hz": [851000000, 851500000],
+  "active": true
+}
+```
+
+That's the whole shape of most web integration: a URL, a method, and JSON in and out.
+Nothing about it reveals whether the server is written in Go, Python, or Rust — which
+is precisely the point.
+
+## Other shapes
+
+REST-over-HTTP is the default, not the only option. A few others you'll meet:
+
+- **gRPC** — fast, strongly typed, compact binary messages defined by a shared schema.
+  Reached for in **service-to-service** communication inside a system, where speed and
+  a strict contract matter more than being human-readable in a browser.
+- **WebSockets** — a persistent, two-way connection that stays open so either side can
+  send at any time. Reached for **live/streaming** data: chat, dashboards, a UI that
+  needs a running feed of updates rather than one reply per request.
+- **GraphQL** — the client sends a query describing **exactly the fields it wants**, and
+  gets back that shape and no more. Reached for when clients have varied data needs and
+  you want to avoid a proliferation of narrow endpoints.
+
+Each is a different trade, not a strict upgrade. Pick the one whose strengths match the
+job: request/reply reads (REST), tight internal calls (gRPC), live streams (WebSockets),
+flexible client-shaped reads (GraphQL).
+
+## Integration: consuming and providing
+
+Working with APIs runs in two directions.
+
+**Consuming** — you call *someone else's* API. GopherTrunk might query an online radio
+database to turn a bare system ID into a human name. You read their docs, send requests,
+and handle the responses. Three realities come with this:
+
+- **Auth and keys.** Many APIs require an API key or token identifying you. Treat it like
+  a password — never commit it to source control.
+- **Rate limits.** Providers cap how often you may call. Exceed it and you get a 429; a
+  polite client backs off and retries later rather than hammering.
+- **Networks fail.** A remote call is not a guaranteed function return. It can time out,
+  return a 500, or hand back malformed data. Assume every call can fail and handle it —
+  this is exactly the
+  [defensive-programming](/learn/intro-software-dev/robustness-and-errors/) discipline,
+  now aimed at the network.
+
+**Providing** — you *expose* your own API for others to call. A local daemon might offer
+an API that a web UI talks to. Now you're on the menu side of the contract: you decide the
+endpoints, document them, and — crucially — keep your promises so you don't break the
+programs that came to depend on you.
+
+## Stability & versioning
+
+An API is a **promise**, and other people build on it. The moment someone calls your
+endpoint, its shape is no longer yours alone to change freely — renaming a field or
+dropping an endpoint **breaks every caller** that relied on it, often silently and at a
+distance.
+
+So published APIs are managed like releases. **Backward compatibility** — adding new
+things without breaking existing ones — is the default expectation. When a change truly
+can't stay compatible, it goes into a new **version** (`/v1/…` alongside `/v2/…`) so old
+clients keep working while new ones move over. This is the same reasoning behind
+semantic versioning: a breaking change is a big deal you signal loudly, not something you
+slip out quietly. The
+[architectural patterns](/learn/intro-software-dev/architectural-patterns/) lesson picks
+up how these contracts shape whole systems.
+
+## A worked example
+
+GopherTrunk is a small tour of both sides of this.
+
+Internally, the decoder runs as a **daemon** — a long-lived process doing the DSP and
+trunk-following. The [browser UI](/web.html) is a **separate program** that never touches
+that code directly; it's a client that talks to the daemon over an **API**. Ask the UI to
+retune, show live meters, or list active talkgroups, and under the hood it's sending
+requests to the daemon and rendering the responses. The two are loosely coupled across a
+contract — you could swap the UI for a script and the daemon wouldn't know or care.
+
+Externally, the app can reach *out* to an online database to **identify systems** — turning
+a raw system or talkgroup ID into a recognizable name. That's a web API it *consumes*, with
+someone else's keys, rate limits, and occasional outages to handle gracefully.
+
+Two APIs, then: one **internal** (UI ↔ daemon, a contract GopherTrunk provides) and one
+**external** (GopherTrunk ↔ a public database, a contract it consumes). Same idea at both
+ends — programs cooperating through a published interface instead of reaching into each
+other's internals.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a WebSocket keeps a connection open so the server can push a continuous, two-way stream of updates." markdown="0">
+  <p class="knowledge-check__q">Quick check: a browser UI needs live updates from a running local program. Which fits a continuous two-way stream best?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">A single REST GET request</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">A WebSocket connection</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Deleting the endpoint</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- An **API** is a contract — inputs, outputs, rules — that lets one program use another
+  without knowing its internals. It's "program to an interface" between programs.
+- A **library API** is functions you call in-process; a **web API** is requests over the
+  network. Same idea, different distance — and the network can fail.
+- **HTTP** is request/response with methods (GET/POST/PUT/DELETE), endpoints, and status
+  codes (2xx/4xx/5xx). It's the backbone of web APIs.
+- **REST** models resources as URLs and uses HTTP methods as verbs; **JSON** is the usual
+  data format. gRPC, WebSockets, and GraphQL suit tighter, streaming, or client-shaped needs.
+- **Integration** runs both ways — consuming others' APIs (keys, rate limits, error
+  handling) and providing your own.
+- An API is a **promise**; breaking it breaks callers, so favor backward compatibility and
+  **versioning**.
+
+Next up: the unglamorous work that keeps software alive — [documentation, tech debt & maintenance](/learn/intro-software-dev/docs-and-maintenance/).

--- a/docs/learn/intro-software-dev/build-and-ci-cd.md
+++ b/docs/learn/intro-software-dev/build-and-ci-cd.md
@@ -102,4 +102,4 @@ One toolchain, many targets. A CI pipeline can fan out across a build matrix and
 - **Pipelines & artifacts** — staged, versioned-in-code automation that produces stored, deployable, rollback-able artifacts.
 - **Reproducible & cross-compiled** — identical outputs from identical inputs, and one toolchain emitting binaries for many platforms.
 
-Next up: the work that outlasts the build — [documentation, tech debt & maintenance](/learn/intro-software-dev/docs-and-maintenance/).
+Next up: where all this software keeps what it remembers — [storing data: files & databases](/learn/intro-software-dev/databases-and-persistence/).

--- a/docs/learn/intro-software-dev/data-structures-algorithms.md
+++ b/docs/learn/intro-software-dev/data-structures-algorithms.md
@@ -1,0 +1,194 @@
+---
+slug: data-structures-algorithms
+title: Data structures & algorithms, briefly
+description: A plain-language tour of the handful of data structures worth knowing, how to pick the right container for a job, and how Big-O notation describes the way work grows as your input gets bigger.
+keywords: data structures, algorithms, Big-O notation, time complexity, array, linked list, hash map, hash table, stack, queue, binary tree, ring buffer
+level: intermediate
+status: full
+prereq:
+  - clean-code
+faq:
+  - q: "Do I need to memorize sorting algorithms?"
+    a: "No. You almost never write a sort by hand — every language ships a fast, well-tested one. What matters is knowing the *tradeoffs*: that sorting costs about O(n log n), that a sorted list lets you binary-search in O(log n), and when reaching for the standard library's sort is the right move. Understand the shape of the cost, not the line-by-line recipe."
+  - q: "What is Big-O notation?"
+    a: "Big-O is shorthand for how the work an algorithm does grows as its input grows. O(1) means constant — the size doesn't matter. O(n) means the work scales in step with the input. O(n^2) means doubling the input roughly quadruples the work. It ignores constant factors and focuses on the shape of the curve, which is what decides whether code stays fast at scale."
+  - q: "What data structure should I use?"
+    a: "Start from the operation you do most. Need fast lookup by a key? A hash map. Need order and index access? An array or list. Need to test membership? A set. Need a fixed rolling window of recent samples? A ring buffer. Pick the container whose cheap operation matches your hot path, and the rest of the code tends to fall into place."
+  - q: "Why do data structures matter if the language has built-ins?"
+    a: "Because the built-ins *are* the data structures — the language hands you arrays, maps, and sets, but it can't tell you which one fits your problem. Choosing wrong doesn't fail to compile; it just runs slowly and reads awkwardly. Knowing what each container is good at is how you pick correctly."
+gophertrunk_links:
+  - title: Architecture
+    url: /architecture.html
+    note: how GopherTrunk's real-time pipeline is organized — ring buffers carry samples between stages so no stage blocks another.
+---
+
+# Data structures & algorithms, briefly
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A **data structure** is a way to organize data so the operations you care about are
+cheap. An **algorithm** is the recipe that acts on it. **Big-O** describes how the cost
+grows as the input grows. The craft isn't implementing these from scratch — you rarely
+do — it's **choosing the right container** and knowing how its cost scales. Pick well
+and the code stays simple and fast; pick badly and it turns slow and tangled.
+</div>
+
+This is a short overview, not a computer-science course. Whole textbooks and semesters
+are devoted to this topic; the goal here is to give you a working mental model — enough
+to recognize the handful of structures you'll actually use, choose between them with
+confidence, and read the Big-O labels that libraries and colleagues throw around. Once
+you have written [readable code](/learn/intro-software-dev/clean-code/), the next lever
+on quality is making sure the shape of your data fits the work you ask of it.
+
+## What a data structure is
+
+A data structure is simply a way of organizing data in memory so that certain operations
+are cheap. That's the whole idea. Every structure makes some things fast and other things
+slow, and the trade it makes is the reason it exists.
+
+The practical consequence is that the *right* structure makes code both simple and fast,
+while the *wrong* one makes it slow and tangled. If you find yourself writing loops inside
+loops to hunt for an item, or shuffling elements around to keep something in order, that's
+often a sign the data is in the wrong container — a better-fitting structure would make the
+awkward operation disappear. Choosing well is a design decision, closely related to
+[abstraction and coupling](/learn/intro-software-dev/abstraction-coupling/): the structure
+you pick shapes the code that uses it.
+
+## The essential few
+
+You can go a long way with a small vocabulary of structures. Here are the ones worth
+knowing on sight.
+
+**Arrays and lists** hold items in order, one after another, reachable by index. Reading
+the *i*-th element is instant, and iterating in order is natural. *Reach for it when* you
+need a sequence you'll walk through or index into — the default container for "a bunch of
+things in order."
+
+**Maps and hash tables** store key→value pairs and let you look a value up by its key
+almost instantly, no matter how many entries there are. *Reach for it when* you need to
+answer "what's associated with this key?" quickly — counting occurrences, caching results,
+indexing records by ID.
+
+**Sets** store unique items and answer one question fast: "is this in here?" They're a hash
+map without the values. *Reach for it when* you need membership or de-duplication — "have I
+seen this one already?"
+
+**Stacks and queues** control the *order* things come back out. A stack is LIFO
+(last-in-first-out — like a stack of plates); a queue is FIFO (first-in-first-out — like a
+line at a counter). *Reach for a stack when* you need to undo or backtrack; *reach for a
+queue when* you need to process items in arrival order.
+
+**Trees** arrange items in a hierarchy or keep them sorted for fast search. A binary search
+tree, for instance, lets you find, insert, and remove while staying ordered, all in about
+O(log n) time. *Reach for it when* you need hierarchy (a file system, a parse tree) or an
+ordered collection you search often.
+
+**Ring buffers** (circular buffers) are fixed-size arrays that wrap around: once full, each
+new item overwrites the oldest. They never grow and never allocate after setup, which makes
+them ideal for streaming a continuous flow of data through a fixed window — exactly the job
+in an audio or IQ-sample pipeline, where a producer keeps handing samples to a consumer that
+has to keep up. *Reach for it when* you need a bounded rolling window of the most recent data.
+This is a core building block in real-time systems; see
+[concurrency and pipelines](/learn/intro-software-dev/concurrency-and-pipelines/).
+
+## Choosing the right one
+
+The trick is to start from the operation you do most often, then pick the structure that
+makes *that* operation cheap. A few concrete cases:
+
+- **Need fast lookup by key?** → a **hash map**. Retrieving a value by its key is roughly
+  constant time however large the map gets.
+- **Need order plus index access?** → an **array** (or list). You get the sequence and
+  instant access to any position.
+- **Need to test membership repeatedly?** → a **set**. "Have I seen this before?" answered
+  in near-constant time.
+- **Need a fixed rolling window of samples?** → a **ring buffer**. A bounded window of the
+  latest data with no per-item allocation.
+
+None of these are exotic. The skill is matching the shape of your problem to the container
+whose cheap operation is the one you lean on.
+
+## Algorithms & Big-O
+
+An algorithm is a recipe — a sequence of steps that turns some input into a result. Sorting
+a list, searching for a name, finding the shortest route: each is an algorithm, and each has
+a *cost* that grows as the input gets bigger. **Big-O notation** is the shorthand for that
+growth. It ignores constant factors and machine speed and focuses on the one thing that
+decides whether code survives at scale: the shape of the curve.
+
+The common shapes, from best to worst, with an everyday analogy:
+
+- **O(1) — constant.** The work is the same no matter how big the input. *Looking up a word
+  in a dictionary by flipping straight to a known page number.* A hash-map lookup is O(1).
+- **O(log n) — logarithmic.** Each step throws away half of what's left. *Guessing a number
+  between 1 and 1,000 by always halving the range — you're done in about ten guesses.* Binary
+  search over sorted data is O(log n).
+- **O(n) — linear.** The work grows in step with the input. *Reading every name on a
+  guest list once.* Scanning a list to find a match is O(n).
+- **O(n log n) — linearithmic.** A little worse than linear; the practical ceiling for good
+  sorting algorithms. *Sorting that guest list well.*
+- **O(n^2) — quadratic.** Double the input and the work roughly quadruples. *Comparing every
+  guest against every other guest.* Two nested loops over the same data is the classic O(n^2).
+
+The one to watch is O(n^2). It hides easily — a loop inside another loop, both walking the
+same collection — and stays invisible in testing because on ten items it's instant. Then the
+input grows to a hundred thousand items in production and the same code grinds to a halt. A
+lot of "why is this suddenly so slow?" turns out to be a quadratic loop that nobody noticed
+until the data got big.
+
+## You don't build these from scratch
+
+Here's the reassuring part: you almost never implement these yourself. Every mainstream
+language ships them in its standard library — Go has slices, maps, and `container` types;
+Python has lists, dicts, and sets; Java, Rust, C++ and the rest all provide the same
+essentials, tested and tuned far better than a hand-rolled version. Different
+[language families](/learn/intro-software-dev/language-families/) name and package them
+differently, but the ideas carry across all of them.
+
+Your job is not to reinvent a hash table. It's to **pick the right one** for the problem and
+**know what it costs**. That's the reusable skill: the containers change names from language
+to language, but "fast lookup by key wants a hash map" is true everywhere.
+
+## Where it shows up in real-time code
+
+The stakes rise in real-time and streaming programs. A DSP pipeline like GopherTrunk
+receives a relentless flow of samples from the radio and *cannot fall behind* — if a
+processing stage takes too long, samples pile up or get dropped and the decode fails. That
+constraint shapes the structures it uses.
+
+Ring buffers carry samples between stages so a fast producer and a slower consumer don't have
+to move in lockstep. The hot loops — the code that runs on every sample — are kept at O(n) or
+better, because anything quadratic in the per-sample path would instantly fall behind the
+incoming data. And because the samples never stop, the code has to handle overruns and gaps
+gracefully rather than crash; that's the discipline of
+[robustness and error handling](/learn/intro-software-dev/robustness-and-errors/) meeting the
+[concurrency and pipelines](/learn/intro-software-dev/concurrency-and-pipelines/) that keep a
+stream flowing. Choosing the right structure isn't academic here — it's the difference between
+keeping up with the radio and losing the signal.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a hash set (or hash map) answers 'have I seen this?' in about O(1), so it stays fast no matter how many IDs you've checked." markdown="0">
+  <p class="knowledge-check__q">Quick check: you need to check "have I seen this radio ID before?" millions of times. Best structure?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">A plain array you scan from the start each time (O(n) per check)</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">A hash set / hash map (O(1) lookup)</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">A stack, because IDs arrive in order</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **data structure** organizes data so the operations you care about are cheap; the right
+  one makes code simple and fast, the wrong one makes it slow and tangled.
+- The **essential few** — arrays/lists, maps, sets, stacks/queues, trees, and ring buffers —
+  cover most everyday needs.
+- **Choose from your hot path**: fast lookup by key → hash map; order plus index → array;
+  membership → set; rolling window of samples → ring buffer.
+- **Big-O** describes how cost grows with input size; watch for **O(n^2)** hidden in nested
+  loops — it bites only once the data gets big.
+- You **don't build these from scratch** — the standard library provides them; your job is to
+  pick correctly and know the cost.
+- **Real-time code** leans on ring buffers and O(n)-or-better hot loops because it can't fall
+  behind the incoming samples.
+
+Next up: Module 4 turns to named, reusable solutions to recurring problems — [what is a design pattern?](/learn/intro-software-dev/what-are-patterns/).

--- a/docs/learn/intro-software-dev/databases-and-persistence.md
+++ b/docs/learn/intro-software-dev/databases-and-persistence.md
@@ -1,0 +1,141 @@
+---
+slug: databases-and-persistence
+title: Storing data — files & databases
+description: Why programs write data down instead of keeping it only in memory, and how the choice runs from a plain file through embedded SQLite to full relational and NoSQL databases — with a guide to picking the simplest fit.
+keywords: data persistence, files, database, SQLite, relational database, SQL, NoSQL, key-value store, document database, time-series, ACID, transactions
+level: intermediate
+status: full
+prereq:
+  - what-is-software
+faq:
+  - q: "What's the difference between a file and a database?"
+    a: "A file is a plain stream of bytes on disk — your program decides what the bytes mean and reads or writes the whole thing. A database adds structure and machinery on top: it indexes your data so you can query it quickly, coordinates multiple writers safely, and enforces rules about what valid data looks like. A file is the raw storage; a database is storage plus a query engine and safety guarantees."
+  - q: "When should I use SQLite versus a full database server?"
+    a: "Use SQLite when the data lives with one application on one machine — a desktop app, a phone app, an embedded device. It's a database inside a single file with no server to install or run. Reach for a client-server database like PostgreSQL or MySQL when many clients need to share the same data at once, the data outgrows one machine, or you need separate access control and backups managed centrally. Most single-user tools never need more than SQLite."
+  - q: "What is SQL versus NoSQL?"
+    a: "SQL databases store data in tables of rows and columns with a fixed schema, and you query them with the SQL language; they excel when data is structured and relationships matter. \"NoSQL\" is an umbrella for everything else — key-value stores, document stores, time-series and search engines — that trade some of the relational guarantees for flexibility, scale, or a shape that fits a specific job better. Neither is strictly better; they suit different problems."
+  - q: "Do I need a database at all?"
+    a: "Often no. If your data is small, structured simply, and only one part of your program writes it, a plain file or a bit of SQLite is plenty — and far less to manage than a database server. Add a real database when you actually hit the limits: lots of data, complex queries, many simultaneous writers, or a need for transactions. Start with the simplest store that works and grow only when a concrete need appears."
+gophertrunk_links:
+  - title: Bookmarks
+    url: /bookmarks.html
+    note: GopherTrunk saves your systems and bookmarks to a small local store so they survive a restart.
+---
+
+# Storing data — files & databases
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Memory is temporary — when a program exits, everything in RAM is gone. **Persistence** means writing data down so it survives a restart. The simplest store is a **file**; the most powerful is a database. A **relational (SQL)** database organises data into tables and lets you query and update it safely; **NoSQL** stores trade some of those guarantees for flexibility or scale. Match the tool to the data — and [start simple](/learn/intro-software-dev/what-is-software/).
+</div>
+
+A running program keeps its working data in memory, which is fast but forgetful: close the program, lose the power, or crash, and it's all gone. Any software that needs to *remember* something between runs — your settings, your saved work, a log of what happened — has to write that data somewhere durable. This lesson walks from the humblest option, a plain file, up through databases, and ends on how to choose the simplest store that does the job.
+
+## Why persistence
+
+Computer memory (RAM) is **volatile**: it holds data only while the program runs and the power is on. **Persistence** is the property of data surviving beyond that — it's still there after a restart, a crash, or a reboot, because it was written to durable storage like a disk or SSD.
+
+Almost every useful program persists *something*:
+
+- **Configuration** — the settings a user picked, so they don't re-enter them every launch.
+- **User data** — documents, saved records, the actual content people create.
+- **Logs** — a record of what happened, for debugging and auditing.
+- **Recordings and captures** — larger blobs of output the program produced.
+
+The question is never *whether* to persist, but *where* and *how* — and that's a spectrum from a single file to a full database server.
+
+## Files: the simplest store
+
+A **file** is the most basic durable store: a named stream of bytes on disk. Your program writes bytes and reads them back; what those bytes mean is entirely up to you.
+
+Files come in a few flavours:
+
+- **Plain text** — human-readable notes, logs, simple lists.
+- **Structured text formats** — **JSON**, **CSV**, and **YAML** give text a shape that both people and programs can parse. A config file in YAML or a data export in CSV is readable *and* machine-friendly.
+- **Binary** — compact, non-human-readable formats for images, audio, or a program's own efficient encoding.
+
+Files are perfect for configuration and modest amounts of data. They're simple, portable, and need no extra software. But they have limits that show up as data grows:
+
+- **Concurrent writes** — if two parts of a program (or two programs) write the same file at once, they can corrupt it. Files have no built-in coordination.
+- **Querying** — to find one record you often have to read and scan the whole file; there's no index.
+- **Growth** — rewriting a large file to change one value gets slow and wasteful.
+
+When you hit those walls, it's time for a database.
+
+## Embedded databases (SQLite)
+
+An **embedded database** gives you a database's power without running a separate server. The classic example is **SQLite**: an entire relational database that lives in a **single file**, driven by a small library linked directly into your program. There's nothing to install, start, or administer — you open the file and query it.
+
+This is the sweet spot for desktop and embedded applications, and it's why SQLite is quietly one of the most deployed pieces of software on Earth. Your phone uses it. Your web browser uses it. Countless apps store their local data in a SQLite file because it offers real querying, structure, and safe concurrent access from within one program — all with the operational simplicity of "it's just a file."
+
+If a plain file is starting to feel cramped but you don't have a server-shaped problem, SQLite is very often the right next step.
+
+## Relational databases & SQL
+
+The **relational** model is the dominant way to structure data. It organises information into **tables**, each with named **columns** and any number of **rows**:
+
+- A **table** holds one kind of thing (say, `systems`).
+- Each **column** is a field with a type (a name, a frequency, a timestamp).
+- Each **row** is one record.
+- **Relationships** link tables — a row in one table can reference rows in another, so data isn't duplicated.
+- A **schema** defines this structure up front and enforces it, rejecting data that doesn't fit.
+
+You talk to a relational database with **SQL** (Structured Query Language), a declarative language for asking questions and making changes: *select* the rows that match some condition, *insert* new ones, *update* or *delete* existing ones. You describe *what* you want and the database figures out *how* to fetch it efficiently, using indexes it maintains behind the scenes.
+
+Relational databases also provide **transactions** and the **ACID** guarantees — Atomicity, Consistency, Isolation, Durability. In plain terms: a group of changes either all happen or none do (no half-finished updates), the data stays valid, concurrent users don't trip over each other, and once the database says a change is saved it really is on disk. That's what makes them trustworthy for money, records, and anything you can't afford to corrupt.
+
+**PostgreSQL** and **MySQL** are the best-known **client-server** relational databases: a database process runs somewhere and many clients connect to it over the network. That architecture is what you want when lots of users or services share the same data, when the data outgrows a single machine, or when backups and access control need central management.
+
+## NoSQL & specialized stores
+
+The relational model isn't the best fit for every problem, and **NoSQL** databases fill the gaps. It's an umbrella term — "not only SQL" — covering several families:
+
+- **Key-value stores** (like **Redis**) map a key straight to a value, extremely fast; great for caches and session data.
+- **Document stores** (like **MongoDB**) hold flexible, self-describing documents (often JSON-shaped) without a fixed schema; handy when records vary in structure.
+- **Time-series** databases are tuned for data stamped with a time — metrics, sensor readings, prices — and the queries that slice it by time.
+- **Search engines** index text so you can find documents by content rather than by exact key.
+
+The common trade is **flexibility versus guarantees**. NoSQL stores often relax the strict schema or the full ACID promises of a relational database in exchange for speed, horizontal scale, or a data shape that matches the job perfectly. That's a good deal when you genuinely need it — and an unnecessary complication when a plain relational table would have done. Choose a specialized store because your data has a specialized shape, not because it sounds modern.
+
+## Choosing where data lives
+
+There's no single right answer, but a few questions point you at the simplest fit:
+
+- **How much data?** Kilobytes → a file. Gigabytes with fast lookups → a database.
+- **How structured?** Free-form notes → a file. Rows, columns, and relationships → relational.
+- **How many writers?** One part of one program → a file or SQLite. Many clients at once → a client-server database.
+- **Do you need queries or transactions?** "Find all records where…" or all-or-nothing updates → a database earns its keep.
+- **Does it need a server?** Only if the data is genuinely shared across machines or users.
+
+The guiding principle is [YAGNI — "you aren't gonna need it"](/learn/intro-software-dev/dry-kiss-yagni/): start with the simplest store that works, and reach for something bigger only when a concrete limit forces you to. A file that becomes SQLite that one day becomes PostgreSQL is a healthy, needs-driven progression. Standing up a database cluster for a config file is over-engineering you'll have to maintain forever.
+
+## A worked example
+
+Look at how a program like GopherTrunk spreads its data across the right stores instead of forcing everything into one:
+
+- **Configuration** lives in a **file** — settings a person reads and edits, small and stable. A structured text format is perfect; no database needed.
+- **Saved systems and [bookmarks](/bookmarks.html)** go in a **small local store** — structured records you want to look up and update, tied to one installation. An embedded database like SQLite fits: queryable and safe, but still just a local file with no server to run.
+- **Recordings** are written as **files on disk** — large binary blobs of captured audio or signal data. These are big and streamed sequentially; a filesystem handles them far better than any database, so each recording is its own file and the database (if any) just stores the path.
+
+Each kind of data lands in the store that matches its shape and access pattern — the simplest thing that does the job, not one heavyweight database swallowing everything.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — SQLite is an embedded database: real querying and structure, in a single file, with no server to run." markdown="0">
+  <p class="knowledge-check__q">Quick check: a single-user desktop app needs structured, queryable local storage with no server to manage. Best first choice?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">A PostgreSQL client-server database cluster</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">SQLite (an embedded database)</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Keep everything in memory and hope it isn't lost</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Persistence** means data survives a restart — memory forgets, disk remembers, so real programs write data down.
+- **Files** are the simplest store: plain text, structured formats (JSON/CSV/YAML), or binary; great for config and modest data, but weak at concurrent writes, querying, and growth.
+- **SQLite** is a full database in a single file with no server — the sweet spot for desktop and embedded apps.
+- **Relational (SQL)** databases organise data into tables with a schema, queried with SQL and protected by ACID transactions; **PostgreSQL** and **MySQL** scale that to many shared clients.
+- **NoSQL** stores — key-value, document, time-series, search — trade some relational guarantees for flexibility, scale, or a better-fitting shape.
+- Choose by need: **start simple** (file or SQLite) and grow only when data size, queries, writers, or sharing actually demand it.
+
+Next up: how programs talk to each other and the world beyond the disk — [APIs & talking to other software](/learn/intro-software-dev/apis-and-integration/).

--- a/docs/learn/intro-software-dev/glossary.md
+++ b/docs/learn/intro-software-dev/glossary.md
@@ -217,6 +217,18 @@ This is a plain-language reference for the key terms used across the Intro to So
 
 **Idempotency** — A property where doing an operation more than once has the same effect as doing it once, which makes retries safe. See [Robustness and errors](/learn/intro-software-dev/robustness-and-errors/)
 
+## Data structures & algorithms
+
+**Data structure** — A way of organizing data in memory so the operations you need are cheap; the right choice makes code simpler and faster. See [Data structures & algorithms, briefly](/learn/intro-software-dev/data-structures-algorithms/)
+
+**Algorithm** — A step-by-step recipe for solving a problem, such as searching or sorting a collection. See [Data structures & algorithms, briefly](/learn/intro-software-dev/data-structures-algorithms/)
+
+**Big-O notation** — A shorthand for how an algorithm's work grows with input size — O(1), O(n), O(n log n), O(n²) — used to compare approaches at scale. See [Data structures & algorithms, briefly](/learn/intro-software-dev/data-structures-algorithms/)
+
+**Hash map (hash table)** — A structure that stores key→value pairs for near-instant (O(1)) lookup by key. See [Data structures & algorithms, briefly](/learn/intro-software-dev/data-structures-algorithms/)
+
+**Ring buffer** — A fixed-size circular buffer that overwrites its oldest data, ideal for streaming a continuous flow of samples. See [Data structures & algorithms, briefly](/learn/intro-software-dev/data-structures-algorithms/)
+
 ## Design patterns
 
 **Design pattern** — A reusable, named solution to a problem that recurs in software design. See [What are design patterns?](/learn/intro-software-dev/what-are-patterns/)
@@ -342,6 +354,20 @@ This is a plain-language reference for the key terms used across the Intro to So
 **Deprecation** — Marking a feature as outdated and discouraged, signalling it will be removed so users can move off it. See [Documentation and maintenance](/learn/intro-software-dev/docs-and-maintenance/)
 
 **Bus factor** — The number of people who would have to be lost before a project stalls; a bus factor of one is a warning sign. See [Documentation and maintenance](/learn/intro-software-dev/docs-and-maintenance/)
+
+## Data, storage & APIs
+
+**Persistence** — Keeping data so it survives a program exiting or the power cycling, by writing it to a file or database. See [Storing data — files & databases](/learn/intro-software-dev/databases-and-persistence/)
+
+**Database** — An organized store designed for querying and updating data reliably, from a single-file embedded engine to a networked server. See [Storing data — files & databases](/learn/intro-software-dev/databases-and-persistence/)
+
+**SQL vs NoSQL** — SQL databases store structured rows in related tables with strong guarantees; NoSQL stores (key-value, document, time-series) trade some guarantees for flexibility. See [Storing data — files & databases](/learn/intro-software-dev/databases-and-persistence/)
+
+**SQLite** — A self-contained database that lives in a single file with no server, the common choice for desktop and embedded apps. See [Storing data — files & databases](/learn/intro-software-dev/databases-and-persistence/)
+
+**API (application programming interface)** — A defined contract that lets one piece of software use another without knowing its internals. See [APIs & talking to other software](/learn/intro-software-dev/apis-and-integration/)
+
+**REST / HTTP / JSON** — The common style and formats of web APIs: resources addressed by URL, HTTP methods as verbs, and JSON as the data format. See [APIs & talking to other software](/learn/intro-software-dev/apis-and-integration/)
 
 ## Choosing a language
 

--- a/docs/learn/intro-software-dev/robustness-and-errors.md
+++ b/docs/learn/intro-software-dev/robustness-and-errors.md
@@ -120,4 +120,4 @@ This robustness is exactly what makes streaming pipelines viable — see how the
 - **Idempotency** — make retry-able operations safe to run more than once.
 - **Resilience in practice** — a radio decoder must tolerate noise, drops, and malformed frames without crashing.
 
-Next up: Module 4 begins by asking what design patterns even are — [what are patterns](/learn/intro-software-dev/what-are-patterns/).
+Next up: one more piece of everyday craft before we get to patterns — [data structures & algorithms, briefly](/learn/intro-software-dev/data-structures-algorithms/).

--- a/docs/learn/rf-sdr/decibels.md
+++ b/docs/learn/rf-sdr/decibels.md
@@ -226,5 +226,6 @@ system is worth chasing and what a better antenna or location would buy you.
   it, and decoders need a minimum.
 - Gains and losses along a path **add**, which is the whole point of decibels.
 
-Next, we'll look at how the spectrum is divided into bands — and then start putting
-information *onto* these waves with modulation.
+Next up: one more fundamental before antennas and modulation — [noise, SNR &
+sensitivity](/learn/rf-sdr/noise-and-snr/), the numbers that decide whether a signal is
+decodable at all.

--- a/docs/learn/rf-sdr/front-end-and-overload.md
+++ b/docs/learn/rf-sdr/front-end-and-overload.md
@@ -1,0 +1,214 @@
+---
+slug: front-end-and-overload
+title: Front-end filters, LNAs & overload
+description: How the analog front end — preselector filters, low-noise amplifiers, mixer and ADC — decides what reaches your decoder, and why overload, intermodulation and reciprocal mixing can ruin a clean channel even when your gain is set correctly.
+keywords: preselector filter, bandpass filter, SAW filter, LNA low noise amplifier, front-end overload, intermodulation, IMD, reciprocal mixing, phase noise, attenuator, out of band, FM broadcast filter
+level: advanced
+status: full
+prereq:
+  - gain-and-agc
+  - sdr-receiver
+faq:
+  - q: Why do I need a filter if I already have a gain control?
+    a: Gain decides how strong everything is when it reaches the ADC, but it can't tell your target apart from a strong out-of-band transmitter — it amplifies both equally. A filter rejects the unwanted energy *before* it can overload the front end, so the parts of the chain that follow only see the band you care about. Gain and filtering solve different problems; a busy RF environment usually needs both.
+  - q: What is intermodulation?
+    a: When two or more strong signals hit a stage that isn't perfectly linear (a mixer or an overdriven amplifier), the stage mixes them and produces false products at new frequencies — combinations like 2f1−f2 and 2f2−f1. These land on real channels and look like genuine signals, but they're artifacts of overload. The tell is that they appear and disappear as you change the input level with an attenuator.
+  - q: Do I put the filter or the LNA first?
+    a: It's a trade-off. A filter before the LNA protects the amplifier from strong out-of-band signals that would overload it, at the cost of the filter's insertion loss adding to the noise figure. An LNA before the filter gives the best noise figure — the first amplifier dominates system noise — but leaves that amplifier exposed to everything. In a clean location, LNA-first; in a crowded RF environment, filter-first.
+  - q: Why does a strong FM or pager signal ruin a channel far away from it?
+    a: A very strong nearby transmitter can push the mixer or ADC into overload even though it's nowhere near your frequency, spraying intermodulation products and a raised noise floor across the band. It can also degrade your channel through reciprocal mixing — the strong signal mixes with the local oscillator's phase noise and smears broadband noise onto your weak channel. The cure is to reject the offender with a filter, not to add gain.
+gophertrunk_links:
+  - title: Hardware (front-end notes)
+    url: /hardware.html
+    note: supported SDRs and notes on front-end filtering and overload behaviour.
+  - title: Tuning (receiver meters)
+    url: /tuning.html
+    note: watch level and SNR as you add a filter or attenuator — a good change lifts SNR.
+---
+
+# Front-end filters, LNAs & overload
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Gain is not the only thing that decides a clean decode — **what you let into the
+front end matters just as much**. A **preselector/filter** rejects out-of-band
+energy before it can do harm; an **LNA** lifts weak signals with minimal added
+noise; but a strong nearby transmitter can still cause **overload**,
+**intermodulation** (false ghost signals), or **reciprocal mixing** (a
+clean-looking carrier that decodes badly). The fixes are often *less* gain, an
+attenuator, or a filter — not more amplification. Builds on
+[gain & AGC](/learn/rf-sdr/gain-and-agc/) and the
+[SDR receiver](/learn/rf-sdr/sdr-receiver/).
+</div>
+
+The [gain lesson](/learn/rf-sdr/gain-and-agc/) got your signals positioned correctly
+in the ADC's range. But gain treats everything in the band the same way — it can't
+distinguish your target from the megawatt FM station down the road. This lesson is
+about the analog stages *before* digitising, and the subtle ways a strong signal you
+aren't even trying to hear can wreck the one you are.
+
+## The front end, in order
+
+The [SDR receiver lesson](/learn/rf-sdr/sdr-receiver/) walked the whole chain; here we
+zoom in on the analog stages that come before the samples exist:
+
+**antenna → (filter) → LNA → mixer → ADC**
+
+The antenna collects *everything* in its range. An optional **filter** rejects
+frequencies you don't want. The **LNA** (low-noise amplifier) boosts what's left. The
+**mixer** shifts your band down to a rate the converter can handle, and the **ADC**
+digitises it into [IQ samples](/learn/rf-sdr/iq-data/). Every stage before the ADC is
+analog and *shared* — whatever energy reaches a stage affects everything passing
+through it, not just your channel.
+
+## Preselector & bandpass filters
+
+A **preselector** is a filter placed early in the chain that passes the band you care
+about and rejects the rest. Why bother, when you're going to
+[filter digitally](/learn/rf-sdr/filtering-decimation/) later anyway? Because the analog
+front end has to survive the *total* power hitting it, and much of that power is out of
+band: **FM broadcast (88–108 MHz)**, pagers, cellular, and TV transmitters are often
+tens of dB stronger than the trunked control channel you want.
+
+- A **bandpass filter** passes a range and attenuates everything outside it.
+- A **notch filter** does the opposite — it kills one troublesome band (an
+  **FM-broadcast reject** notch is the classic first purchase).
+- **SAW filters** (surface acoustic wave) are compact fixed-frequency bandpass parts
+  common in ready-made SDR filter modules.
+
+A filter **can't add signal** — it only takes energy away, and it costs a little of
+your wanted signal too (insertion loss). What it buys you is protection: everything
+downstream now sees a much smaller total power, so the LNA, mixer and ADC are far less
+likely to overload.
+
+## Low-noise amplifiers (LNAs)
+
+An **LNA** amplifies weak signals while adding as little noise of its own as possible.
+It matters *where* it sits because **the first amplifier dominates the system
+[noise figure](/learn/rf-sdr/noise-and-snr/)** — noise added at the front is amplified by
+everything after it, so a quiet first stage sets the floor for the whole receiver. This
+is why a **masthead LNA** (mounted at the antenna) can help so much: it lifts the signal
+*before* the loss of a long feedline drags the [SNR](/learn/rf-sdr/noise-and-snr/) down.
+
+That leads straight to the classic ordering trade-off:
+
+- **Filter before LNA** — the filter protects the amplifier from strong out-of-band
+  signals that would otherwise overload it. The price is the filter's insertion loss,
+  which adds directly to the noise figure.
+- **LNA before filter** — the best possible noise figure, because nothing lossy sits
+  ahead of the amplifier. The price is that the LNA is exposed to the full band and can
+  itself be driven into overload.
+
+In a quiet rural location, LNA-first wins. In a crowded urban RF environment with
+strong nearby transmitters, filter-first is usually the safer choice — a slightly higher
+noise figure beats an amplifier that's constantly overloading.
+
+## Overload: too much total power
+
+The mixer and ADC don't see your channel in isolation — they see the **sum of
+everything in the band at once**. A strong nearby transmitter can drive them into
+compression (the stage stops responding linearly) even when your target is weak and far
+away in frequency. Once a stage is compressed, it distorts *every* signal passing
+through it, including yours.
+
+This looks similar to the too-much-gain problem from the
+[gain lesson](/learn/rf-sdr/gain-and-agc/), but the cause is different: with clipping you
+turned the gain up too far, and turning it down fixes it. With front-end overload the
+*input* is too hot — the culprit is an external signal, and the fix is to reject that
+signal or attenuate the whole input, not just to trim gain. Watch for it whenever a
+channel decodes fine at some times and falls apart when a strong local transmitter keys
+up.
+
+## Intermodulation (IMD)
+
+When a non-linear stage is fed two strong signals at f1 and f2, it doesn't just distort
+them — it **mixes** them and produces new **intermodulation products** at frequencies
+like **2f1−f2** and **2f2−f1**. These third-order products fall *close to* the original
+signals, so they can land right on top of a real channel you're trying to decode, and
+they look exactly like genuine signals on the [waterfall](/learn/rf-sdr/fft-and-waterfall/).
+
+The giveaway is how they behave with level. A real signal barely changes when you add a
+few dB of attenuation. An intermodulation product changes *much faster* — a third-order
+product drops about **3 dB for every 1 dB** you attenuate the input. So if a suspected
+ghost signal vanishes when you insert 10 dB of attenuation while your real signals only
+dip slightly, you've found IMD, not a station.
+
+## Reciprocal mixing & phase noise
+
+This is the subtle one. A real local oscillator isn't a perfect single tone — it has
+**phase noise**, a skirt of noise spread either side of its frequency. In the mixer,
+your wanted channel isn't the only thing that beats against the oscillator: a **strong
+nearby signal** does too. When that strong signal mixes with the oscillator's phase
+noise, it drags a copy of that broadband noise skirt right onto your weak channel. This
+is **reciprocal mixing**.
+
+The trap is what it looks like. On a wideband [FFT](/learn/rf-sdr/fft-and-waterfall/) the
+strong carrier looks perfectly clean, and your channel looks fine — there's no obvious
+spur, no clipping. But the *demodulated* signal is degraded: the effective noise on the
+channel is raised and the [EVM](/learn/rf-sdr/symbols-and-baud/) climbs, so it decodes
+poorly despite looking healthy on the spectrum. The strength of the offender and the
+quality of the oscillator set how bad it gets.
+
+More gain does **not** help here — it amplifies the smeared noise right along with the
+signal. The fixes are a cleaner front end (a better, lower-phase-noise oscillator) or
+**knocking the strong offender down with a filter** so it never reaches the mixer at full
+strength.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 440 150" role="img" aria-label="Two spectra. Left: a tall strong carrier and a short weak channel both sitting on a low flat noise floor, labelled looks clean. Right: the same two signals, but a noise skirt from the strong carrier has raised the floor under the weak channel, labelled reciprocal mixing." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.3">
+    <path d="M20 110 L60 110 L64 40 L68 110 L150 110 L154 80 L158 110 L200 110"/>
+    <path d="M240 110 Q260 108 270 96 L274 40 L278 96 Q300 104 320 100 L344 90 L348 80 L352 90 Q380 104 420 108"/>
+  </g>
+  <g font-size="10" fill="currentColor" text-anchor="middle">
+    <text x="64" y="30">strong</text>
+    <text x="154" y="72">weak</text>
+    <text x="110" y="130">looks clean on FFT</text>
+    <text x="330" y="130">reciprocal mixing</text>
+  </g>
+</svg>
+<figcaption>The strong carrier still looks clean, but its phase-noise skirt has raised the floor right under the weak channel — the decode suffers even though the spectrum looks fine.</figcaption>
+</figure>
+
+## Fixes: attenuators & filters
+
+The counter-intuitive part of front-end trouble is that **adding an attenuator** — or
+lowering gain, or fitting a bandpass or FM-reject filter — can *improve* your decode.
+You're trading a little signal for a large reduction in the total power abusing the
+front end, and clearing overload or IMD wins that trade easily. A practical checklist
+when a channel decodes worse than its raw strength suggests it should:
+
+1. Check the [gain](/learn/rf-sdr/gain-and-agc/) first — rule out plain ADC clipping.
+2. Insert **10 dB of attenuation**. If SNR *improves* or ghost signals vanish, you were
+   overloaded — the front end, not the channel, was the problem.
+3. Identify the strongest offender on a wide [spectrum](/learn/rf-sdr/fft-and-waterfall/)
+   (often FM broadcast or a pager); fit a **notch or bandpass filter** to reject it.
+4. In a crowded location, move the **filter ahead of the LNA**.
+5. Re-check level and SNR on the [tuning meters](/tuning.html) — a good change shows as
+   a higher, steadier SNR, not just a lower level.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — ghost signals that die faster than real ones under attenuation are intermodulation from an overloaded front end." markdown="0">
+  <p class="knowledge-check__q">Quick check: ghost signals appear across the band and vanish when you add 10 dB of attenuation, while your real signals only dip slightly. What is it?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">The antenna is too long</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Front-end overload / intermodulation</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">The sample rate is too high</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- The analog front end — **antenna → filter → LNA → mixer → ADC** — decides what even
+  reaches your decoder, and every pre-ADC stage is shared by the whole band.
+- A **preselector/filter** can't add signal, but it rejects out-of-band energy (FM,
+  pagers, cellular) and protects everything downstream from overload.
+- The **first amplifier dominates the noise figure**: LNA-first for best sensitivity,
+  filter-first to survive a crowded RF environment.
+- **Overload** (too much total input power) and **intermodulation** (false products like
+  2f1−f2) are caused by strong signals, not by your gain — an attenuator often cures them.
+- **Reciprocal mixing** raises the effective noise on a weak channel via oscillator
+  phase noise; the carrier looks clean on the FFT yet decodes badly, and more gain won't
+  help — a cleaner front end or a filter will.
+
+Next up: the dongles all of this runs on — [SDR hardware: RTL-SDR, HackRF & Airspy](/learn/rf-sdr/sdr-hardware/).

--- a/docs/learn/rf-sdr/gain-and-agc.md
+++ b/docs/learn/rf-sdr/gain-and-agc.md
@@ -150,4 +150,5 @@ weak — clearing the overload often helps more than the lost gain costs.
 - **Manual gain** is usually best for a fixed decoding setup; AGC can pump.
 - Routine: raise until SNR plateaus, check for clipping, back off for headroom.
 
-Next: choosing the hardware that all of this runs on.
+Next up: the front-end hardware that decides what even reaches the ADC —
+[filters, LNAs & overload](/learn/rf-sdr/front-end-and-overload/).

--- a/docs/learn/rf-sdr/glossary.md
+++ b/docs/learn/rf-sdr/glossary.md
@@ -75,7 +75,14 @@ noise, in dBm. A signal must rise above it to be usable. See
 receiver. See [Decibels & signal power](/learn/rf-sdr/decibels/)
 
 **SNR (signal-to-noise ratio)** — The gap in dB between a signal and the noise floor.
-Digital modes need a minimum SNR to decode. See [Decibels & signal power](/learn/rf-sdr/decibels/)
+Digital modes need a minimum SNR to decode — it, not raw signal strength, decides a
+lock. See [Noise, SNR & sensitivity](/learn/rf-sdr/noise-and-snr/)
+
+**Noise figure (NF)** — How much noise a receiver stage adds of its own; the first
+amplifier's NF dominates the whole chain. See [Noise, SNR & sensitivity](/learn/rf-sdr/noise-and-snr/)
+
+**Sensitivity / MDS** — The weakest signal a receiver can usefully detect — its
+minimum discernible signal. See [Noise, SNR & sensitivity](/learn/rf-sdr/noise-and-snr/)
 
 ## Signals & modulation
 
@@ -140,6 +147,22 @@ aligns the radio to true frequency. See [Calibration & troubleshooting](/learn/r
 **RTL-SDR / HackRF / Airspy** — Common SDR hardware. RTL-SDR is the cheap entry
 point; HackRF and Airspy add bandwidth, sensitivity, or transmit. See
 [SDR hardware](/learn/rf-sdr/sdr-hardware/) and the [Hardware guide](/hardware.html)
+
+**LNA (low-noise amplifier)** — An amplifier that boosts weak signals while adding
+very little noise of its own; placed early to set a good noise figure. See
+[Front-end filters, LNAs & overload](/learn/rf-sdr/front-end-and-overload/)
+
+**Preselector / bandpass filter** — A filter that passes your band of interest and
+rejects strong out-of-band signals before they can overload the receiver. See
+[Front-end filters, LNAs & overload](/learn/rf-sdr/front-end-and-overload/)
+
+**Intermodulation (IMD)** — False "ghost" signals created when strong signals mix in
+an overloaded, non-linear front end. See
+[Front-end filters, LNAs & overload](/learn/rf-sdr/front-end-and-overload/)
+
+**Reciprocal mixing** — Noise smeared onto a weak channel when a strong nearby signal
+mixes with an oscillator's phase noise; the carrier looks clean but the demod is
+degraded. See [Front-end filters, LNAs & overload](/learn/rf-sdr/front-end-and-overload/)
 
 ## DSP
 

--- a/docs/learn/rf-sdr/noise-and-snr.md
+++ b/docs/learn/rf-sdr/noise-and-snr.md
@@ -1,0 +1,187 @@
+---
+slug: noise-and-snr
+title: Noise, SNR & sensitivity
+description: Why signal-to-noise ratio, not raw signal strength, decides whether a transmission decodes — the receiver noise floor, thermal noise (kTB), SNR in dB, receiver sensitivity and MDS, noise figure, and why more gain isn't more SNR.
+keywords: SNR, signal to noise ratio, noise floor, receiver sensitivity, MDS, minimum discernible signal, noise figure, thermal noise, kTB, dBm, EVM, weak signal decoding
+level: intermediate
+status: full
+prereq:
+  - decibels
+  - sdr-receiver
+faq:
+  - q: What is a good SNR for decoding?
+    a: There's no single number, but digital voice systems typically need roughly 10–20 dB of signal-to-noise ratio to lock reliably, with the exact threshold depending on the protocol and how demanding its error correction is. What actually matters at the demodulator is a clean constellation and low symbol error (low EVM); SNR is the practical proxy you can read off a meter. Below the threshold you'll see intermittent locks and dropped voice; well above it, more SNR buys you little.
+  - q: What is the noise floor?
+    a: The noise floor is the background level of random energy present at the receiver even with no signal of interest — it sets the bottom of what you can hear. It comes from unavoidable thermal noise, man-made noise picked up by the antenna, and the receiver's own electronics. A signal has to rise above this floor by enough margin (its SNR) to decode.
+  - q: Does more gain improve SNR?
+    a: Only up to a point. Gain amplifies the signal and the noise together, so once a weak signal is already clear of the receiver's internal noise, adding gain doesn't change the ratio between them — it just moves both up toward the ADC ceiling. Past that point extra gain only risks overload. See the [gain lesson](/learn/rf-sdr/gain-and-agc/) for the full trade-off.
+  - q: What is receiver sensitivity, or MDS?
+    a: Sensitivity describes the weakest signal a receiver can usefully recover, often quoted as the minimum discernible signal (MDS) — the input power, in dBm, that produces a signal just detectable above the noise floor. It's set mainly by the receiver's bandwidth and its noise figure. A lower (more negative) MDS means a more sensitive receiver.
+gophertrunk_links:
+  - title: Tuning (SNR & level meters)
+    url: /tuning.html
+    note: read live SNR and level while you evaluate a signal.
+  - title: Constellation
+    url: /constellation.html
+    note: a tight constellation (low EVM) is what good SNR buys you.
+---
+
+# Noise, SNR & sensitivity
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Every receiver sits on top of a **noise floor** — a background hiss from thermal
+noise, the environment, and its own electronics. A signal decodes not because it's
+strong in absolute terms but because it clears that floor by enough margin: its
+**SNR** ([signal-to-noise ratio](/learn/rf-sdr/decibels/), measured in dB). **Sensitivity**
+is how weak a signal a receiver can still pull out of the noise. Crucially, more
+gain doesn't add SNR — see [gain & AGC](/learn/rf-sdr/gain-and-agc/).
+</div>
+
+Beginners naturally reach for "signal strength" as the thing that matters. It isn't. A
+booming signal buried in an equally booming noise floor won't decode, while a faint one
+sitting in silence will. This lesson explains the quantity that actually decides a
+decode — SNR — and the receiver properties that set the floor beneath it.
+
+## The noise floor
+
+Point an antenna at empty spectrum and the receiver still shows a level. That's the
+**noise floor**, and it has three sources.
+
+The first is **thermal noise** — the random jostling of electrons in any conductor above
+absolute zero. It's unavoidable and its power depends only on temperature and bandwidth,
+captured by the expression **kTB** (Boltzmann's constant × temperature × bandwidth). At
+room temperature this works out to roughly **−174 dBm/Hz** — the noise power in a single
+hertz of bandwidth. That figure is the floor beneath the floor: no receiver can do
+better.
+
+The second is **man-made noise** the antenna picks up — switching power supplies, LED
+lighting, chargers, motors, and general urban electrical hash. In a noisy environment
+this often dominates the thermal contribution entirely.
+
+The third is the **receiver's own noise**, added by its amplifiers and mixers (more on
+that below).
+
+Notice the bandwidth term in kTB: **the wider your receive bandwidth, the more noise
+power you collect.** Doubling bandwidth adds about 3 dB of noise. This is why narrow,
+matched filtering ahead of the [demodulator](/learn/rf-sdr/demodulation-pipeline/) helps —
+you want the noise only from the channel you care about, not the whole band.
+
+## Signal-to-noise ratio (SNR)
+
+**SNR is the gap, in dB, between your signal and the noise floor.** If a signal peaks at
+−80 dBm and the floor sits at −100 dBm, the SNR is 20 dB. That difference — not the −80
+dBm by itself — is what the demodulator has to work with.
+
+This is why absolute [dBm](/learn/rf-sdr/decibels/) is a poor predictor of success. A −40 dBm
+signal sounds strong, but if local noise or overload has pushed the floor up to −45 dBm,
+you have only 5 dB of SNR and it won't decode. Meanwhile a −95 dBm signal over a quiet
+−115 dBm floor has a healthy 20 dB and locks fine. **The ratio wins, every time.**
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 440 150" role="img" aria-label="A spectrum trace with a low wavy noise floor line and a tall narrow peak rising above it. A vertical bracket between the noise line and the top of the peak is labelled SNR." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none">
+    <path d="M20 110 q20 -6 40 0 q20 6 40 -2 q20 -4 40 2 q20 4 40 -3 q20 -3 40 2 q20 3 40 -1 q20 -4 40 2 q20 3 40 -1" stroke-width="1.2" stroke-opacity="0.7"/>
+    <path d="M210 108 l6 -78 l6 78" stroke-width="1.4"/>
+    <line x1="150" y1="112" x2="150" y2="30" stroke-dasharray="3 3" stroke-opacity="0.6"/>
+    <line x1="146" y1="112" x2="154" y2="112" stroke-opacity="0.6"/>
+    <line x1="146" y1="30" x2="154" y2="30" stroke-opacity="0.6"/>
+  </g>
+  <g font-size="10" fill="currentColor">
+    <text x="126" y="74" text-anchor="middle" transform="rotate(-90 126 74)">SNR</text>
+    <text x="300" y="126" font-size="10">noise floor</text>
+    <text x="222" y="26" text-anchor="middle" font-size="10">signal</text>
+  </g>
+</svg>
+<figcaption>What decodes a signal is its height above the noise floor (the SNR), not its absolute power.</figcaption>
+</figure>
+
+How much SNR do you need? It depends on the protocol, but as a rough guide **digital
+voice systems need on the order of 10–20 dB** to lock cleanly. The real gate at the
+receiver is the [constellation](/constellation.html) — the demodulated symbols have to land
+close enough to their ideal positions (low error vector magnitude, EVM) for the error
+correction to recover them. SNR is just the convenient meter reading that tracks it.
+
+## Sensitivity & the minimum discernible signal (MDS)
+
+**Sensitivity** is a receiver's ability to recover weak signals — how far down toward the
+noise floor it can still hear. It's often quoted as the **minimum discernible signal
+(MDS)**: the input power in dBm that produces an output just detectable above the noise,
+conventionally the point where the signal equals the noise (a few dB of SNR).
+
+MDS follows directly from the noise-floor discussion. It's roughly the thermal floor
+(−174 dBm/Hz), plus 10·log₁₀ of the bandwidth in hertz, plus the receiver's noise figure,
+plus whatever small SNR you define "discernible" to mean. Narrow the bandwidth or lower
+the noise figure and the MDS drops (improves). A receiver specified at, say, −120 dBm MDS
+in a given bandwidth is more sensitive than one at −110 dBm.
+
+The practical upshot: sensitivity is not something you fix with the volume knob. It's set
+by physics and by the front-end hardware.
+
+## Noise figure — the receiver adds its own noise
+
+No amplifier is silent. Every stage in the [receive chain](/learn/rf-sdr/sdr-receiver/) adds a
+little noise of its own, degrading the SNR that arrives at its input. **Noise figure
+(NF)** quantifies that penalty in dB — how much worse the SNR is coming out of a stage
+than going in. An ideal noiseless stage has NF = 0 dB; real ones add anywhere from a
+fraction of a dB (a good low-noise amplifier) to several dB.
+
+The subtlety is that **the first stage matters most.** Once the first amplifier has set
+the noise contribution, later stages add relatively little because the signal is already
+amplified when it reaches them. That's why a clean, low-noise-figure first amplifier —
+ideally right at the antenna — does more for weak-signal reception than anything
+downstream. The [front-end lesson](/learn/rf-sdr/front-end-and-overload/) covers where that
+amplifier belongs and how to avoid overloading it.
+
+## Why more gain isn't more SNR
+
+Here's the point that trips people up. **Gain multiplies the signal and the noise by the
+same factor**, so it doesn't change the ratio between them. If a signal enters an
+amplifier 12 dB above the noise, it leaves 12 dB above the noise — just louder.
+
+SNR is essentially fixed by the time the signal reaches the amplifiers you control: it's
+set by the antenna, the environment, and the first stage's noise figure. Turning gain up
+past the point where the signal is already clear of the receiver's *internal* noise buys
+nothing but risk — it pushes everything toward the ADC ceiling and invites
+[clipping and overload](/learn/rf-sdr/gain-and-agc/). The right amount of gain lifts weak
+signals clear of the ADC's own noise and then stops. Beyond that, SNR is what it is.
+
+## Reading SNR in practice
+
+GopherTrunk shows SNR live on its [tuning meters](/tuning.html) alongside the level in dBFS.
+When you're evaluating whether a system is decodable, watch the **SNR**, not just the
+level:
+
+- **SNR climbing as you raise gain, then flattening** — normal. Once it plateaus, you've
+  lifted the signal clear of internal noise; stop there (see the gain lesson).
+- **High level but low SNR** — the noise floor is up with the signal. Suspect local
+  interference or front-end overload, not a weak transmitter.
+- **SNR comfortably in the double digits with a tight [constellation](/constellation.html)** —
+  you're in good shape to decode.
+- **SNR hovering at the threshold** — expect intermittent locks and dropped voice; you
+  need more signal or less noise (a better antenna usually beats more gain).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a strong reading with poor SNR means the noise floor is nearly as high as the signal." markdown="0">
+  <p class="knowledge-check__q">Quick check: a signal reads a strong −40 dBm but won't decode. Most likely cause?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">The signal is too strong and needs attenuating to decode</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The noise floor is nearly as high — poor SNR</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">−40 dBm is below the receiver's sensitivity</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Every receiver has a **noise floor** from thermal noise (**kTB**, ~−174 dBm/Hz),
+  man-made noise, and its own electronics.
+- **Wider bandwidth collects more noise power** — about 3 dB per doubling.
+- **SNR** — the dB gap between signal and floor — is what decides a decode, not absolute
+  dBm.
+- Digital voice typically needs roughly **10–20 dB SNR** (low EVM) to lock.
+- **Sensitivity/MDS** is the weakest signal a receiver can hear, set by bandwidth and
+  **noise figure**; the first amplifier matters most.
+- **More gain doesn't add SNR** — it lifts signal and noise together. SNR is set before
+  the ADC.
+
+Next up: [antennas 101](/learn/rf-sdr/antennas/) — the first thing that decides how much signal, and how much noise, reaches your radio.


### PR DESCRIPTION
Adds ten lessons to close within-path coverage gaps across six of the
seven learning paths, wired into the learn.yml data model, prev/next
navigation, and the path glossaries:

- RF & SDR: "Noise, SNR & sensitivity" and "Front-end filters, LNAs &
  overload" (the receiver front end / intermod / reciprocal-mixing story).
- Digital & Trunked Radio: "OTAR & key management" and "Data services —
  GPS, text & registration".
- Intro to Hardware: "Beyond the CPU — GPUs, FPGAs & accelerators".
- Intro to Software Dev: "Data structures & algorithms, briefly",
  "Storing data — files & databases", and "APIs & talking to other
  software".
- AI in Software Dev: "Running local & open models".
- Git & GitHub: "The GitHub CLI, Git LFS & repo security".

Each lesson follows the house style (front matter, TLDR, sections,
knowledge-check, recap, prev/next). The eight preceding lessons' closing
links are updated so the reading flow is unbroken, and headline new terms
are added to the affected glossaries. Verified: learn.yml parses, every
slug maps 1:1 to a file (no missing/orphaned pages), and all internal
cross-links resolve.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LY6F93KkE871vMMoeGZuBr