### PR TITLE
fix(capture): stop live capture hanging on control-channel backoff; add cs16 + narrowband slices

### DIFF
--- a/cmd/gophertrunk/capture.go
+++ b/cmd/gophertrunk/capture.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/gtbundle"
+	"github.com/MattCheramie/GopherTrunk/internal/scanner/ccdecoder"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
 	"github.com/MattCheramie/GopherTrunk/internal/siglab"
 )
@@ -36,7 +37,9 @@ func runCapture(args []string) {
 	ppm := fs.Int("ppm", 0, "frequency-correction in PPM")
 	seconds := fs.Float64("seconds", 10, "capture length in seconds (required, > 0)")
 	out := fs.String("out", "capture.cfile", "output capture path")
-	format := fs.String("format", "f32", "capture sample format: u8 | f32 (f32 = GNU Radio cfile)")
+	format := fs.String("format", "f32", "capture sample format: u8 | f32 | cs16 (f32 = GNU Radio cfile; cs16 = headerless 16-bit raw)")
+	centerHz := fs.Uint("center", 0, "narrowband slice centre in Hz (default: -freq); with -bandwidth, carves a channel from the captured wideband without retuning")
+	bandwidthHz := fs.Uint("bandwidth", 0, "narrowband slice bandwidth in Hz; when > 0 the capture is decimated to ~this rate around -center (must fit inside -freq ± sample-rate/2)")
 	protocol := fs.String("protocol", "", "protocol name written to the metadata sidecar (enables `test`; see `gophertrunk gen -list`)")
 	source := fs.String("source", "", "free-text provenance written to the metadata sidecar")
 	tune := fs.Float64("tune", 0, "fine software tune offset in Hz written to the metadata sidecar")
@@ -61,6 +64,11 @@ EXAMPLES:
   # rtl_sdr-native u8 capture from a specific dongle
   gophertrunk capture -serial 00000001 -freq 453000000 -seconds 10 \
     -format u8 -out dmr.bin
+
+  # Small 16-bit narrowband slice: carve a 50 kHz channel at 467.913 MHz out of
+  # a 2.4 MS/s grab centred there — a shareable .raw a fraction of the full size
+  gophertrunk capture -freq 467913000 -sample-rate 2400000 -seconds 30 \
+    -center 467913000 -bandwidth 50000 -format cs16 -out cc.raw
 
   # List the SDRs this binary can capture from
   gophertrunk capture -list
@@ -136,7 +144,31 @@ FLAGS:`)
 		fmt.Fprintln(os.Stderr, hint)
 	}
 
-	written, capErr := captureToFile(ctx, *out, sampleFormat, stream, uint32(*sampleRate), *seconds)
+	// Optional narrowband slice: decimate the captured wideband to a channel at
+	// -center ± -bandwidth without retuning the SDR (the same DDC the daemon and
+	// replay path use). The recorded rate + centre become the channel's.
+	var ddc *ccdecoder.Downconverter
+	recRate := float64(*sampleRate)
+	recCenter := uint32(*freq)
+	if *bandwidthHz > 0 {
+		center := uint32(*centerHz)
+		if center == 0 {
+			center = uint32(*freq)
+		}
+		offsetHz := int64(center) - int64(*freq)
+		half := int64(*sampleRate) / 2
+		if absInt64(offsetHz)+int64(*bandwidthHz)/2 > half {
+			rep.Fatalf(2, "-center %d + -bandwidth %d falls outside the captured span %d ± %d Hz",
+				center, *bandwidthHz, *freq, half)
+		}
+		ddc = ccdecoder.NewDownconverterWithOffset(float64(*sampleRate), float64(*bandwidthHz), float64(offsetHz))
+		recRate = ddc.OutRateHz()
+		recCenter = center
+		fmt.Printf("capture: narrowband slice → centre %.3f MHz, %.1f kHz channel rate\n",
+			float64(recCenter)/1e6, recRate/1e3)
+	}
+
+	written, capErr := captureToFile(ctx, *out, sampleFormat, stream, uint32(*sampleRate), *seconds, ddc)
 	if capErr != nil && !errors.Is(capErr, context.Canceled) {
 		rep.Fatal(1, fmt.Errorf("capture: %w (wrote %d samples to %s)", capErr, written, *out))
 	}
@@ -144,8 +176,8 @@ FLAGS:`)
 	meta := &siglab.Metadata{
 		Protocol:     *protocol,
 		Source:       *source,
-		SampleRateHz: float64(*sampleRate),
-		CenterFreqHz: uint32(*freq),
+		SampleRateHz: recRate,
+		CenterFreqHz: recCenter,
 		Format:       sampleFormat.String(),
 		TuneHz:       *tune,
 		AutoTune:     *autoTune,
@@ -183,8 +215,8 @@ FLAGS:`)
 			intent:       gtbundle.CaptureIntent(*bundleIntent),
 			capturePath:  *out,
 			format:       sampleFormat,
-			sampleRateHz: float64(*sampleRate),
-			centerHz:     uint32(*freq),
+			sampleRateHz: recRate,
+			centerHz:     recCenter,
 			tuneHz:       *tune,
 			protocol:     *protocol,
 			source:       *source,
@@ -237,12 +269,14 @@ func openCaptureDevice(serial string) (sdr.Device, sdr.Info, error) {
 	return dev, chosen, nil
 }
 
-// captureToFile streams complex64 chunks from src, encodes them in the
-// requested on-disk format with the shared encodeF32/encodeU8 packers, and
-// writes them to path until it has collected seconds*rate samples, the stream
-// ends, ctx cancels, or a wall-clock safety deadline elapses. Returns the
-// number of IQ samples written.
-func captureToFile(ctx context.Context, path string, format siglab.SampleFormat, src <-chan []complex64, rate uint32, seconds float64) (int64, error) {
+// captureToFile streams complex64 chunks from src, optionally decimates each
+// chunk to a narrowband channel through ddc (nil = full band), encodes the
+// result in the requested on-disk format with the shared encodeF32/encodeU8/
+// encodeS16 packers, and writes to path until it has collected seconds*rate
+// INPUT samples, the stream ends, ctx cancels, or a wall-clock safety deadline
+// elapses. Returns the number of IQ samples written (post-decimation when ddc
+// is set).
+func captureToFile(ctx context.Context, path string, format siglab.SampleFormat, src <-chan []complex64, rate uint32, seconds float64, ddc *ccdecoder.Downconverter) (int64, error) {
 	f, err := os.Create(path)
 	if err != nil {
 		return 0, fmt.Errorf("create %s: %w", path, err)
@@ -250,43 +284,64 @@ func captureToFile(ctx context.Context, path string, format siglab.SampleFormat,
 
 	encode := encodeF32
 	bytesPerSample := 8
-	if format == siglab.FormatU8 {
+	switch format {
+	case siglab.FormatU8:
 		encode = encodeU8
 		bytesPerSample = 2
+	case siglab.FormatS16:
+		encode = encodeS16
+		bytesPerSample = 4
 	}
 
+	// Stop once seconds worth of INPUT samples have been read; the written
+	// count may be far smaller when ddc decimates to a narrow channel.
 	target := int64(seconds * float64(rate))
 	// Safety deadline so a stalled/under-delivering device doesn't hang the
-	// command forever waiting to reach the sample target.
-	deadline := time.Now().Add(time.Duration(seconds*float64(time.Second)) + 5*time.Second)
+	// command forever waiting to reach the sample target. The timer is an
+	// explicit select arm (not a post-receive check) so a source that never
+	// delivers a chunk can't block the receive forever — see the same fix in
+	// captureProvider.Capture for the daemon's broker-tap path.
+	timer := time.NewTimer(time.Duration(seconds*float64(time.Second)) + 5*time.Second)
+	defer timer.Stop()
 
 	var scratch []byte
-	var written int64
+	var ddcBuf []complex64
+	var inputRead, written int64
 	var loopErr error
-	for written < target {
+loop:
+	for inputRead < target {
 		select {
 		case <-ctx.Done():
 			loopErr = ctx.Err()
+			break loop
+		case <-timer.C:
+			break loop
 		case chunk, ok := <-src:
 			if !ok {
 				loopErr = errors.New("IQ stream ended before capture finished")
-				break
+				break loop
 			}
-			n := len(chunk) * bytesPerSample
+			inputRead += int64(len(chunk))
+			samples := chunk
+			if ddc != nil {
+				ddcBuf = ddc.Process(ddcBuf, chunk)
+				samples = ddcBuf
+			}
+			if len(samples) == 0 {
+				continue
+			}
+			n := len(samples) * bytesPerSample
 			if cap(scratch) < n {
 				scratch = make([]byte, n)
 			} else {
 				scratch = scratch[:n]
 			}
-			encode(scratch, chunk)
+			encode(scratch, samples)
 			if _, werr := f.Write(scratch); werr != nil {
 				loopErr = fmt.Errorf("write: %w", werr)
-				break
+				break loop
 			}
-			written += int64(len(chunk))
-		}
-		if loopErr != nil || time.Now().After(deadline) {
-			break
+			written += int64(len(samples))
 		}
 	}
 
@@ -294,6 +349,14 @@ func captureToFile(ctx context.Context, path string, format siglab.SampleFormat,
 		loopErr = cerr
 	}
 	return written, loopErr
+}
+
+// absInt64 is the absolute value of a signed 64-bit integer.
+func absInt64(x int64) int64 {
+	if x < 0 {
+		return -x
+	}
+	return x
 }
 
 // serialsOf renders the serials of the discovered devices for a friendly hint.

--- a/cmd/gophertrunk/capture_provider.go
+++ b/cmd/gophertrunk/capture_provider.go
@@ -55,22 +55,34 @@ func (p *captureProvider) Capture(ctx context.Context, serial string, seconds in
 	defer sub.Close()
 
 	// Safety deadline so an under-delivering device can't hang the request
-	// waiting to reach the sample target.
-	deadline := time.Now().Add(time.Duration(seconds)*time.Second + 5*time.Second)
+	// waiting to reach the sample target. The timer is an explicit select arm
+	// (not a post-receive check) because the broker pauses fan-out whenever no
+	// primary StreamIQ session is running — during a control-channel hunt
+	// backoff the device delivers nothing, so a receive-then-check deadline
+	// would block forever on sub.C and wedge the HTTP request ("Capturing…"
+	// never ends). See internal/sdr/iqtap/broker.go.
+	timer := time.NewTimer(time.Duration(seconds)*time.Second + 5*time.Second)
+	defer timer.Stop()
 	out := make([]complex64, 0, target)
+loop:
 	for int64(len(out)) < target {
 		select {
 		case <-ctx.Done():
 			return out, rate, br.CenterHz(), ctx.Err()
+		case <-timer.C:
+			break loop
 		case chunk, ok := <-sub.C:
 			if !ok {
 				return out, rate, br.CenterHz(), errors.New("capture: IQ stream ended before capture finished")
 			}
 			out = append(out, chunk...)
 		}
-		if time.Now().After(deadline) {
-			break
-		}
+	}
+	if len(out) == 0 {
+		return out, rate, br.CenterHz(), fmt.Errorf(
+			"capture: device %q delivered no IQ within %ds — the tuner is not currently "+
+				"streaming (a scan may be mid-hunt / in control-channel backoff); start or "+
+				"resume a scan on this SDR, or retry", serial, seconds)
 	}
 	return out, rate, br.CenterHz(), nil
 }

--- a/cmd/gophertrunk/capture_provider_test.go
+++ b/cmd/gophertrunk/capture_provider_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/iqtap"
+)
+
+// idleDevice is a minimal sdr.Device whose StreamIQ is never called by the
+// capture path: the broker only fans IQ out to subscribers while a primary
+// StreamIQ session is active, so a broker with no primary stream (modelling a
+// control SDR whose scanner is mid-hunt / in control-channel backoff) delivers
+// nothing to a capture subscriber.
+type idleDevice struct{ rateOnlyDevice }
+
+// TestCaptureProviderTimesOutWhenBrokerIdle pins the fix for the "Capture from
+// tuner hangs forever" report: when the tuner is not streaming (no primary
+// StreamIQ session — e.g. a scan looping trying → hunt failed → backoff), a
+// capture must return a bounded error instead of blocking the request forever.
+//
+// Before the timer-arm fix the select in captureProvider.Capture blocked on
+// sub.C with no deadline arm, so this test would hang until the -timeout kills
+// the run.
+func TestCaptureProviderTimesOutWhenBrokerIdle(t *testing.T) {
+	br := iqtap.New(idleDevice{}, 0, nil)
+	if err := br.SetSampleRate(48_000); err != nil {
+		t.Fatalf("SetSampleRate: %v", err)
+	}
+	// No StreamIQ session is ever started, so the broker never delivers a
+	// chunk to a capture subscriber.
+
+	p := &captureProvider{brokers: map[string]*iqtap.Broker{"dev-a": br}}
+
+	// The capture's internal safety deadline is seconds+5s; give it generous
+	// headroom before declaring a hang so the test is not flaky under load.
+	const seconds = 1
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() {
+		_, _, _, err := p.Capture(context.Background(), "dev-a", seconds)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Capture returned nil error for an idle (non-streaming) tuner; want a bounded timeout error")
+		}
+		if elapsed := time.Since(start); elapsed > (seconds+5)*time.Second+2*time.Second {
+			t.Errorf("Capture took %v; expected it to bail near the seconds+5s safety deadline", elapsed)
+		}
+	case <-time.After((seconds+5)*time.Second + 5*time.Second):
+		t.Fatal("Capture blocked past its safety deadline — the hang is not fixed")
+	}
+}

--- a/cmd/gophertrunk/capture_test.go
+++ b/cmd/gophertrunk/capture_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/MattCheramie/GopherTrunk/internal/scanner/ccdecoder"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
 	"github.com/MattCheramie/GopherTrunk/internal/siglab"
 )
@@ -29,7 +30,7 @@ func feedChunks(n, size int) <-chan []complex64 {
 func TestCaptureToFileF32(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "cap.cfile")
 	// 1000-sample target at rate=1000, 1 s; 5×300 = 1500 ≥ 1000.
-	written, err := captureToFile(context.Background(), path, siglab.FormatF32, feedChunks(5, 300), 1000, 1.0)
+	written, err := captureToFile(context.Background(), path, siglab.FormatF32, feedChunks(5, 300), 1000, 1.0, nil)
 	if err != nil {
 		t.Fatalf("captureToFile: %v", err)
 	}
@@ -47,7 +48,7 @@ func TestCaptureToFileF32(t *testing.T) {
 
 func TestCaptureToFileU8(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "cap.bin")
-	written, err := captureToFile(context.Background(), path, siglab.FormatU8, feedChunks(4, 300), 1000, 1.0)
+	written, err := captureToFile(context.Background(), path, siglab.FormatU8, feedChunks(4, 300), 1000, 1.0, nil)
 	if err != nil {
 		t.Fatalf("captureToFile: %v", err)
 	}
@@ -60,11 +61,49 @@ func TestCaptureToFileU8(t *testing.T) {
 	}
 }
 
+func TestCaptureToFileCS16(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cap.raw")
+	written, err := captureToFile(context.Background(), path, siglab.FormatS16, feedChunks(4, 300), 1000, 1.0, nil)
+	if err != nil {
+		t.Fatalf("captureToFile: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Size() != written*4 { // cs16 = 4 bytes/sample
+		t.Errorf("file size = %d, want %d", info.Size(), written*4)
+	}
+}
+
+func TestCaptureToFileNarrowband(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nb.raw")
+	// Decimate a 48 kHz input to a ~6 kHz channel at zero offset. Feed enough
+	// input (target = 48000 input samples) so the DDC produces output.
+	ddc := ccdecoder.NewDownconverterWithOffset(48000, 6000, 0)
+	written, err := captureToFile(context.Background(), path, siglab.FormatS16, feedChunks(160, 320), 48000, 1.0, ddc)
+	if err != nil {
+		t.Fatalf("captureToFile: %v", err)
+	}
+	// 48000 input samples / 8 decimation ≈ 6000 output samples — far fewer than
+	// the input, and non-zero.
+	if written == 0 || written > 48000/4 {
+		t.Fatalf("narrowband written = %d, want a decimated (~6000) count", written)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Size() != written*4 {
+		t.Errorf("file size = %d, want %d", info.Size(), written*4)
+	}
+}
+
 func TestCaptureToFileStreamEndsEarly(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "short.cfile")
 	// Only 600 samples available but target is 1000 → returns the partial
 	// capture plus an error so the caller can report it.
-	written, err := captureToFile(context.Background(), path, siglab.FormatF32, feedChunks(2, 300), 1000, 1.0)
+	written, err := captureToFile(context.Background(), path, siglab.FormatF32, feedChunks(2, 300), 1000, 1.0, nil)
 	if err == nil {
 		t.Fatalf("expected an error when the stream ends before the target")
 	}
@@ -77,7 +116,7 @@ func TestCaptureToFileContextCancel(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "cancelled.cfile")
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancelled before the first read
-	_, err := captureToFile(ctx, path, siglab.FormatF32, feedChunks(5, 300), 1_000_000, 1.0)
+	_, err := captureToFile(ctx, path, siglab.FormatF32, feedChunks(5, 300), 1_000_000, 1.0, nil)
 	if err == nil {
 		t.Fatalf("expected ctx.Err() when the context is already cancelled")
 	}

--- a/cmd/gophertrunk/iqcapture.go
+++ b/cmd/gophertrunk/iqcapture.go
@@ -28,7 +28,7 @@ type iqCaptureSpec struct {
 	Serial  string
 	Path    string
 	Seconds int
-	Format  string // "f32" or "u8"
+	Format  string // "f32", "u8", or "cs16"
 }
 
 // parseIQCaptureSpec parses "serial=<s>,path=<file>,seconds=<n>[,format=u8|f32]".
@@ -64,10 +64,10 @@ func parseIQCaptureSpec(s string) (iqCaptureSpec, error) {
 		case "format":
 			f := strings.ToLower(v)
 			switch f {
-			case "f32", "u8":
+			case "f32", "u8", "cs16":
 				spec.Format = f
 			default:
-				return iqCaptureSpec{}, fmt.Errorf("iq-capture: format must be u8 or f32, got %q", v)
+				return iqCaptureSpec{}, fmt.Errorf("iq-capture: format must be u8, f32, or cs16, got %q", v)
 			}
 		default:
 			return iqCaptureSpec{}, fmt.Errorf("iq-capture: unknown key %q", k)
@@ -110,11 +110,21 @@ func runIQCapture(ctx context.Context, broker *iqtap.Broker, spec iqCaptureSpec,
 	var scratch []byte
 	encode := encodeF32
 	bytesPerSample := 8
-	if spec.Format == "u8" {
+	switch spec.Format {
+	case "u8":
 		encode = encodeU8
 		bytesPerSample = 2
+	case "cs16":
+		encode = encodeS16
+		bytesPerSample = 4
 	}
 
+	// Safety timer as an explicit select arm: the broker pauses fan-out when no
+	// primary StreamIQ session is running, so a receive-then-check deadline
+	// would block on sub.C forever if the primary stalls. The timer fires the
+	// normal end-of-capture path after the requested duration regardless.
+	timer := time.NewTimer(time.Duration(spec.Seconds) * time.Second)
+	defer timer.Stop()
 	deadline := time.Now().Add(time.Duration(spec.Seconds) * time.Second)
 	log.Info("iq-capture: started",
 		"serial", spec.Serial, "path", spec.Path,
@@ -125,6 +135,8 @@ func runIQCapture(ctx context.Context, broker *iqtap.Broker, spec iqCaptureSpec,
 		select {
 		case <-ctx.Done():
 			return finishIQCapture(log, spec, f, samplesWritten, bytesPerSample, sub.Dropped(), ctx.Err())
+		case <-timer.C:
+			return finishIQCapture(log, spec, f, samplesWritten, bytesPerSample, sub.Dropped(), nil)
 		case chunk, ok := <-sub.C:
 			if !ok {
 				return finishIQCapture(log, spec, f, samplesWritten, bytesPerSample, sub.Dropped(), errors.New("iq-capture: broker closed before capture finished"))
@@ -207,6 +219,28 @@ func encodeU8(dst []byte, src []complex64) {
 		dst[2*i] = clipU8(float64(real(c))*127.5 + 127.5)
 		dst[2*i+1] = clipU8(float64(imag(c))*127.5 + 127.5)
 	}
+}
+
+// encodeS16 packs complex64 samples into interleaved little-endian 16-bit
+// signed PCM (I then Q, ×32768, clamped) — the headerless "cs16" shape
+// siglab's decodeSW16 reads back. Half the size of f32 while keeping the
+// resolution of a 12–14-bit ADC.
+func encodeS16(dst []byte, src []complex64) {
+	for i, c := range src {
+		binary.LittleEndian.PutUint16(dst[4*i:], uint16(clipI16(float64(real(c))*32768)))
+		binary.LittleEndian.PutUint16(dst[4*i+2:], uint16(clipI16(float64(imag(c))*32768)))
+	}
+}
+
+func clipI16(x float64) int16 {
+	x = math.Round(x)
+	if x > 32767 {
+		return 32767
+	}
+	if x < -32768 {
+		return -32768
+	}
+	return int16(x)
 }
 
 func clipU8(x float64) byte {

--- a/cmd/gophertrunk/survey_capture.go
+++ b/cmd/gophertrunk/survey_capture.go
@@ -203,7 +203,7 @@ func captureSignalToFile(dev sdr.Device, freqHz, rateHz uint32, gain, ppm int, o
 	if err != nil {
 		return 0, fmt.Errorf("start IQ stream: %w", err)
 	}
-	return captureToFile(ctx, out, siglab.FormatF32, stream, rateHz, seconds)
+	return captureToFile(ctx, out, siglab.FormatF32, stream, rateHz, seconds, nil)
 }
 
 // routeToSigLab runs a quick in-process identify on the capture and prints the

--- a/docs/reference/wav-iq-recording.md
+++ b/docs/reference/wav-iq-recording.md
@@ -68,7 +68,12 @@ The trade-offs are the size ceiling and that not every tool honours `auxi`.
 GopherTrunk reads WAV IQ recordings through its offline engine's `-format wav` decoder (also
 accepted as `sw16`/`s16`). It parses the RIFF/WAVE header, takes the sample rate from the header —
 overriding any `-sample-rate` flag — strips the 44-byte header, and decodes the two-channel 16-bit
-PCM as I-then-Q normalised by 32768. This is the same layout GopherTrunk's own IQ writer emits and
+PCM as I-then-Q normalised by 32768. The same 16-bit sample body without the RIFF/WAVE header is the
+separate `-format cs16` (also `sc16`/`i16`/`raw`) format — a headerless complex-signed-16-bit blob
+that carries its sample rate in the metadata sidecar instead of a header. It is half the size of a
+`f32` cfile while keeping the resolution of a 12–14-bit ADC (Airspy/RSPdx/USRP), where `u8` would
+throw it away, and is the recommended small format for a capture you want to hand to an analysis
+tool. This is the same layout GopherTrunk's own IQ writer emits and
 that SDRtrunk and SDR++ produce, so a WAV captured in one of those tools replays through
 GopherTrunk's production receiver pipeline unchanged. Because a baseband WAV is already channelised
 to one signal, GopherTrunk treats it as pre-tuned: auto-tune is rejected for WAV input and a residual

--- a/internal/api/capture.go
+++ b/internal/api/capture.go
@@ -34,12 +34,21 @@ type CaptureProvider interface {
 }
 
 // captureRequest is the body of POST /api/v1/siglab/capture.
+//
+// CenterHz + BandwidthHz (both optional) request a narrowband slice carved from
+// the tuner's current wideband stream: the channel at CenterHz is shifted to DC
+// and decimated to ~BandwidthHz, so the staged file is a small baseband
+// recording instead of a full-rate wideband grab. The tuner is NOT retuned (the
+// slice is extracted from what it is already streaming), so CenterHz must fall
+// inside the tuned span. BandwidthHz == 0 keeps the legacy full-band behaviour.
 type captureRequest struct {
-	Serial   string `json:"serial"`
-	Seconds  int    `json:"seconds"`
-	Format   string `json:"format"`
-	Protocol string `json:"protocol,omitempty"`
-	Source   string `json:"source,omitempty"`
+	Serial      string `json:"serial"`
+	Seconds     int    `json:"seconds"`
+	Format      string `json:"format"`
+	Protocol    string `json:"protocol,omitempty"`
+	Source      string `json:"source,omitempty"`
+	CenterHz    uint32 `json:"center_hz,omitempty"`
+	BandwidthHz uint32 `json:"bandwidth_hz,omitempty"`
 }
 
 // captureResponse is returned by a successful capture: the staged capture
@@ -100,6 +109,17 @@ func (s *Server) handleSiglabCapture(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Optional narrowband slice: carve the channel at CenterHz down to
+	// ~BandwidthHz from the tuner's current wideband stream (no retune), so the
+	// staged file is small enough to hand to an analysis tool.
+	if req.BandwidthHz > 0 {
+		iq, sampleRateHz, centerHz, err = narrowband(iq, sampleRateHz, centerHz, req.CenterHz, req.BandwidthHz)
+		if err != nil {
+			s.writeError(w, http.StatusBadRequest, "siglab: "+err.Error())
+			return
+		}
+	}
+
 	id := randomID(16)
 	path := s.siglab.newCapturePath(id)
 	if err := os.WriteFile(path, siglab.EncodeCapture(iq, format), 0o644); err != nil {
@@ -156,14 +176,56 @@ func (s *Server) handleSiglabCaptureDownload(w http.ResponseWriter, r *http.Requ
 	defer f.Close()
 
 	ext := "cfile"
-	if c.Format == siglab.FormatU8 {
+	switch c.Format {
+	case siglab.FormatU8:
 		ext = "bin"
+	case siglab.FormatS16:
+		ext = "raw"
+	case siglab.FormatWAV:
+		ext = "wav"
 	}
 	w.Header().Set("Content-Type", "application/octet-stream")
 	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s.%s", c.ID, ext))
 	if _, err := io.Copy(w, f); err != nil {
 		s.log.Warn("api: siglab capture download failed", "err", err)
 	}
+}
+
+// narrowband carves the channel at wantCenterHz (±wantBWHz/2) out of the
+// wideband IQ the tuner is currently streaming, decimating it to a baseband
+// stream and returning the slice, its new sample rate, and its new centre
+// (== wantCenterHz, or the tuner centre when wantCenterHz is 0). The tuner is
+// not retuned — the slice is extracted from the live stream — so the requested
+// channel must fit wholly inside the tuned span [tunerCentre ± rate/2].
+func narrowband(iq []complex64, rateHz, tunerCenterHz, wantCenterHz, wantBWHz uint32) ([]complex64, uint32, uint32, error) {
+	center := wantCenterHz
+	if center == 0 {
+		center = tunerCenterHz
+	}
+	offsetHz := int64(center) - int64(tunerCenterHz)
+	half := int64(rateHz) / 2
+	if abs64(offsetHz)+int64(wantBWHz)/2 > half {
+		return nil, 0, 0, fmt.Errorf(
+			"center_hz %d + bandwidth_hz %d falls outside the tuner's current span %.3f–%.3f MHz "+
+				"(centre %.3f MHz, rate %.3f MS/s); a capture extracts a channel from the live stream "+
+				"without retuning, so pick a centre/bandwidth inside the span",
+			center, wantBWHz,
+			float64(int64(tunerCenterHz)-half)/1e6, float64(int64(tunerCenterHz)+half)/1e6,
+			float64(tunerCenterHz)/1e6, float64(rateHz)/1e6)
+	}
+	nb, outRate := siglab.Downconvert(iq, float64(rateHz), float64(offsetHz), float64(wantBWHz))
+	if len(nb) == 0 {
+		return nil, 0, 0, fmt.Errorf("bandwidth_hz %d is too small for a %d-sample capture (no output samples)", wantBWHz, len(iq))
+	}
+	return nb, uint32(outRate + 0.5), center, nil
+}
+
+// abs64 is the absolute value of a signed 64-bit integer.
+func abs64(x int64) int64 {
+	if x < 0 {
+		return -x
+	}
+	return x
 }
 
 // captureName builds a friendly staged-capture name from the device + tuning.
@@ -174,10 +236,10 @@ func captureName(serial string, centerHz uint32) string {
 	return "capture-" + serial
 }
 
-// bytesPerSample returns the on-disk size of one IQ sample in the format.
+// bytesPerSample returns the on-disk size of one IQ sample in the format. It
+// defers to the format's own decoder width (f32 → 8, cs16/wav → 4, u8 → 2) so
+// staged-capture sizes stay correct as formats are added.
 func bytesPerSample(format siglab.SampleFormat) int {
-	if format == siglab.FormatF32 {
-		return 8
-	}
-	return 2
+	_, n := format.Decoder()
+	return n
 }

--- a/internal/api/capture_test.go
+++ b/internal/api/capture_test.go
@@ -134,6 +134,119 @@ func TestSiglabCaptureStagesAndDownloads(t *testing.T) {
 	}
 }
 
+// TestSiglabCaptureCS16 stages a cs16 (headerless 16-bit) capture and checks
+// the DTO size (4 bytes/sample, half of f32) and the .raw download extension.
+func TestSiglabCaptureCS16(t *testing.T) {
+	iq := make([]complex64, 4800)
+	for i := range iq {
+		iq[i] = complex(float32(i%7)/7, float32(i%3)/3)
+	}
+	prov := &fakeCaptureProvider{
+		devices: []SpectrumDevice{{Serial: "SDR1", Driver: "mock"}},
+		iq:      iq,
+		rate:    2_400_000,
+		center:  460_000_000,
+	}
+	ts := newCaptureTestServer(t, prov)
+
+	cResp, err := http.Post(ts.URL+"/api/v1/siglab/capture", "application/json",
+		bytes.NewBufferString(`{"serial":"SDR1","seconds":2,"format":"cs16"}`))
+	if err != nil {
+		t.Fatalf("POST capture: %v", err)
+	}
+	defer cResp.Body.Close()
+	if cResp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(cResp.Body)
+		t.Fatalf("status = %d, want 200 (%s)", cResp.StatusCode, b)
+	}
+	var cr captureResponse
+	if err := json.NewDecoder(cResp.Body).Decode(&cr); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if want := int64(len(iq)) * 4; cr.Capture.Size != want {
+		t.Fatalf("cs16 size = %d, want %d (4 bytes/sample)", cr.Capture.Size, want)
+	}
+	dlResp, err := http.Get(ts.URL + cr.DownloadURL)
+	if err != nil {
+		t.Fatalf("GET download: %v", err)
+	}
+	defer dlResp.Body.Close()
+	if cd := dlResp.Header.Get("Content-Disposition"); !bytes.Contains([]byte(cd), []byte(".raw")) {
+		t.Errorf("Content-Disposition = %q, want a .raw filename", cd)
+	}
+	got, _ := io.ReadAll(dlResp.Body)
+	if want := int64(len(iq)) * 4; int64(len(got)) != want {
+		t.Errorf("downloaded %d bytes, want %d", len(got), want)
+	}
+}
+
+// TestSiglabCaptureNarrowband carves a narrow channel out of a wideband grab:
+// the staged file must be at the (much lower) channel rate and far smaller than
+// the full-band capture, and its centre must be the requested centre.
+func TestSiglabCaptureNarrowband(t *testing.T) {
+	const rate = 2_400_000
+	iq := make([]complex64, rate) // ~1 s
+	for i := range iq {
+		iq[i] = complex(float32(i%5)/5, float32(i%9)/9)
+	}
+	prov := &fakeCaptureProvider{
+		devices: []SpectrumDevice{{Serial: "SDR1", Driver: "mock"}},
+		iq:      iq,
+		rate:    rate,
+		center:  460_000_000,
+	}
+	ts := newCaptureTestServer(t, prov)
+
+	// A 50 kHz channel offset +100 kHz from the tuner centre — well inside the
+	// ±1.2 MHz span.
+	body := `{"serial":"SDR1","seconds":1,"format":"cs16","center_hz":460100000,"bandwidth_hz":50000}`
+	cResp, err := http.Post(ts.URL+"/api/v1/siglab/capture", "application/json", bytes.NewBufferString(body))
+	if err != nil {
+		t.Fatalf("POST capture: %v", err)
+	}
+	defer cResp.Body.Close()
+	if cResp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(cResp.Body)
+		t.Fatalf("status = %d, want 200 (%s)", cResp.StatusCode, b)
+	}
+	var cr captureResponse
+	if err := json.NewDecoder(cResp.Body).Decode(&cr); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if cr.Capture.SampleRateHz > 60_000 {
+		t.Errorf("narrowband rate = %g, want ~50 kHz", cr.Capture.SampleRateHz)
+	}
+	fullBytes := int64(len(iq)) * 4
+	if cr.Capture.Size >= fullBytes/10 {
+		t.Errorf("narrowband size %d not much smaller than full-band %d", cr.Capture.Size, fullBytes)
+	}
+	if cr.Metadata == nil || cr.Metadata.CenterFreqHz != 460_100_000 {
+		t.Errorf("metadata centre = %+v, want 460.1 MHz", cr.Metadata)
+	}
+}
+
+// TestSiglabCaptureNarrowbandOutOfSpan rejects a channel that does not fit the
+// tuner's current span (the capture does not retune).
+func TestSiglabCaptureNarrowbandOutOfSpan(t *testing.T) {
+	prov := &fakeCaptureProvider{
+		devices: []SpectrumDevice{{Serial: "SDR1", Driver: "mock"}},
+		iq:      make([]complex64, 2_400_000),
+		rate:    2_400_000,
+		center:  460_000_000,
+	}
+	ts := newCaptureTestServer(t, prov)
+	// +5 MHz offset is far outside the ±1.2 MHz tuned span.
+	body := `{"serial":"SDR1","seconds":1,"format":"cs16","center_hz":465000000,"bandwidth_hz":50000}`
+	resp, err := http.Post(ts.URL+"/api/v1/siglab/capture", "application/json", bytes.NewBufferString(body))
+	if err != nil {
+		t.Fatalf("POST capture: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for an out-of-span centre", resp.StatusCode)
+	}
+}
+
 func TestSiglabCaptureRejectsBadSeconds(t *testing.T) {
 	prov := &fakeCaptureProvider{iq: []complex64{complex(1, 0)}, rate: 48000}
 	ts := newCaptureTestServer(t, prov)

--- a/internal/api/handlers_siglab.go
+++ b/internal/api/handlers_siglab.go
@@ -102,7 +102,7 @@ func (s *Server) handleSiglabProtocols(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{
 		"protocols": decode,
 		"fixtures":  synth,
-		"formats":   []string{"u8", "f32"},
+		"formats":   []string{"u8", "f32", "cs16"},
 	})
 }
 

--- a/internal/siglab/cs16_test.go
+++ b/internal/siglab/cs16_test.go
@@ -1,0 +1,82 @@
+package siglab
+
+import (
+	"math"
+	"testing"
+)
+
+// TestParseSampleFormatCS16 pins the cs16 (headerless 16-bit) flag spellings
+// and the decoder shape, and guards the deliberate split from the WAV aliases:
+// s16/sw16 stay WAV (a documented, tested contract), cs16/sc16/i16/raw are the
+// new headerless format.
+func TestParseSampleFormatCS16(t *testing.T) {
+	for _, s := range []string{"cs16", "sc16", "i16", "raw", "CS16"} {
+		f, err := ParseSampleFormat(s)
+		if err != nil || f != FormatS16 {
+			t.Fatalf("ParseSampleFormat(%q) = %v, %v; want FormatS16", s, f, err)
+		}
+	}
+	// The WAV aliases must NOT be captured by the new format.
+	for _, s := range []string{"wav", "sw16", "s16"} {
+		f, err := ParseSampleFormat(s)
+		if err != nil || f != FormatWAV {
+			t.Fatalf("ParseSampleFormat(%q) = %v, %v; want FormatWAV (unchanged contract)", s, f, err)
+		}
+	}
+	if _, n := FormatS16.Decoder(); n != 4 {
+		t.Fatalf("FormatS16 bytes-per-sample = %d, want 4", n)
+	}
+	if FormatS16.String() != "cs16" {
+		t.Fatalf("FormatS16.String() = %q, want cs16", FormatS16.String())
+	}
+}
+
+// TestEncodeCaptureCS16RoundTrip encodes known IQ as cs16, decodes it back
+// through the format's own decoder, and asserts the samples survive within
+// 16-bit quantisation. It also confirms cs16 is exactly half the size of f32
+// (4 vs 8 bytes/sample) — the whole point of the format.
+func TestEncodeCaptureCS16RoundTrip(t *testing.T) {
+	in := []complex64{
+		complex(0, 0),
+		complex(0.5, -0.5),
+		complex(-0.25, 0.75),
+		complex(1, -1),
+		complex(-1, 1),
+	}
+
+	raw := EncodeCapture(in, FormatS16)
+	if got, want := len(raw), len(in)*4; got != want {
+		t.Fatalf("cs16 encoded size = %d bytes, want %d (4 bytes/sample)", got, want)
+	}
+	if f32 := EncodeCapture(in, FormatF32); len(f32) != len(raw)*2 {
+		t.Fatalf("f32 size %d should be 2× cs16 size %d", len(f32), len(raw))
+	}
+
+	decode, bps := FormatS16.Decoder()
+	out := make([]complex64, len(raw)/bps)
+	decode(raw, out)
+	if len(out) != len(in) {
+		t.Fatalf("decoded %d samples, want %d", len(out), len(in))
+	}
+
+	const tol = 1.0 / 32768 // one 16-bit LSB
+	for i := range in {
+		if d := math.Abs(float64(real(in[i]) - real(out[i]))); d > tol {
+			t.Errorf("sample %d I: in %v out %v (Δ%v > %v)", i, real(in[i]), real(out[i]), d, tol)
+		}
+		if d := math.Abs(float64(imag(in[i]) - imag(out[i]))); d > tol {
+			t.Errorf("sample %d Q: in %v out %v (Δ%v > %v)", i, imag(in[i]), imag(out[i]), d, tol)
+		}
+	}
+}
+
+// TestEncodeCaptureWAVNotU8 guards the latent-bug fix: a FormatWAV encode must
+// no longer silently downgrade to 8-bit u8 — it emits the 16-bit body (4
+// bytes/sample), the same as cs16.
+func TestEncodeCaptureWAVNotU8(t *testing.T) {
+	in := []complex64{complex(0.5, -0.5), complex(-0.25, 0.75)}
+	wav := EncodeCapture(in, FormatWAV)
+	if got, want := len(wav), len(in)*4; got != want {
+		t.Fatalf("FormatWAV encoded size = %d bytes, want %d (16-bit body, not u8's 2)", got, want)
+	}
+}

--- a/internal/siglab/decode.go
+++ b/internal/siglab/decode.go
@@ -33,6 +33,13 @@ const (
 	// WAV header, overriding -sample-rate, and the 44-byte header is skipped
 	// before decoding.
 	FormatWAV
+	// FormatS16 is headerless interleaved little-endian 16-bit signed PCM IQ
+	// (I then Q, normalised ÷32768) — the same sample layout as FormatWAV but
+	// with no RIFF/WAVE header. Half the size of f32 while keeping the
+	// resolution of a 12–14-bit ADC (Airspy/RSPdx/USRP), where u8 would throw
+	// it away. The sample rate is not carried in-band, so it comes from the
+	// metadata sidecar (or -sample-rate), like u8/f32.
+	FormatS16
 )
 
 // String renders the format as the flag value operators type.
@@ -42,6 +49,8 @@ func (f SampleFormat) String() string {
 		return "f32"
 	case FormatWAV:
 		return "wav"
+	case FormatS16:
+		return "cs16"
 	default:
 		return "u8"
 	}
@@ -50,7 +59,12 @@ func (f SampleFormat) String() string {
 // ParseSampleFormat maps a -format flag value to a SampleFormat. It accepts
 // the same spellings the replay subcommand always has (u8, f32, plus the
 // float32/cfile aliases) so existing muscle memory keeps working, plus wav
-// (aka sw16) for two-channel 16-bit baseband recordings.
+// (aka sw16/s16) for two-channel 16-bit RIFF/WAVE baseband recordings, and
+// cs16 (aka sc16/i16/raw) for the headerless interleaved 16-bit raw variant.
+//
+// NOTE: s16/sw16 remain WAV aliases (a documented, tested contract — reading a
+// WAV file as headerless would misinterpret its 44-byte header as samples).
+// The headerless format uses the unambiguous "cs16" (complex signed 16) family.
 func ParseSampleFormat(s string) (SampleFormat, error) {
 	switch strings.ToLower(strings.TrimSpace(s)) {
 	case "u8", "":
@@ -59,8 +73,10 @@ func ParseSampleFormat(s string) (SampleFormat, error) {
 		return FormatF32, nil
 	case "wav", "sw16", "s16":
 		return FormatWAV, nil
+	case "cs16", "sc16", "i16", "raw":
+		return FormatS16, nil
 	default:
-		return FormatU8, fmt.Errorf("siglab: unknown sample format %q (want u8, f32, or wav)", s)
+		return FormatU8, fmt.Errorf("siglab: unknown sample format %q (want u8, f32, cs16, or wav)", s)
 	}
 }
 
@@ -75,7 +91,11 @@ func (f SampleFormat) Decoder() (SampleDecoder, int) {
 	switch f {
 	case FormatF32:
 		return decodeF32, 8
-	case FormatWAV:
+	case FormatWAV, FormatS16:
+		// Same interleaved-16-bit decoder for both. FormatWAV's 44-byte
+		// RIFF/WAVE header is stripped upstream (prepareWAVInput in engine.go)
+		// before any bytes reach this decoder; FormatS16 is headerless, so its
+		// bytes are all IQ samples.
 		return decodeSW16, 4
 	default:
 		return decodeU8, 2

--- a/internal/siglab/downconvert.go
+++ b/internal/siglab/downconvert.go
@@ -1,0 +1,30 @@
+package siglab
+
+import "github.com/MattCheramie/GopherTrunk/internal/scanner/ccdecoder"
+
+// Downconvert frequency-shifts iq so a channel sitting at offsetHz lands at DC,
+// then decimates it to ~targetHz, returning the narrowband stream and the exact
+// achieved output rate (which equals targetHz for standard rates that reduce to
+// a sane L/M; see ccdecoder.Downconverter.OutRateHz).
+//
+// It reuses the production ccdecoder Downconverter — the same rational polyphase
+// DDC the daemon's control path and the replay engine use — so a narrowband
+// slice carved here decodes identically to an on-air lock. This is the core of
+// the live "capture a small channel around a chosen centre/bandwidth" path: a
+// fat wideband grab (hundreds of MB) is reduced to a shareable, analysable
+// baseband recording at the channel rate.
+//
+// offsetHz is the channel's offset from the wideband centre (desired centre −
+// tuner centre). A caller that wants a wider or narrower slice picks targetHz;
+// the returned rate is authoritative for sizing/metadata. The returned slice is
+// always independently owned (never aliases iq).
+func Downconvert(iq []complex64, inRateHz, offsetHz, targetHz float64) ([]complex64, float64) {
+	ddc := ccdecoder.NewDownconverterWithOffset(inRateHz, targetHz, offsetHz)
+	out := ddc.Process(nil, iq)
+	// Process returns the resampler's own buffer (or, in pass-through mode, the
+	// input slice); copy so the result's lifetime is independent of iq and of
+	// the DDC's reused scratch.
+	cp := make([]complex64, len(out))
+	copy(cp, out)
+	return cp, ddc.OutRateHz()
+}

--- a/internal/siglab/downconvert_test.go
+++ b/internal/siglab/downconvert_test.go
@@ -13,10 +13,10 @@ import (
 // phasor, so |mean| ≈ mean|·| (an off-DC tone would average toward zero).
 func TestDownconvertShiftsToneToDC(t *testing.T) {
 	const (
-		rate    = 2_400_000.0
-		offset  = 100_000.0
-		target  = 50_000.0
-		nsamp   = 240_000 // 0.1 s
+		rate   = 2_400_000.0
+		offset = 100_000.0
+		target = 50_000.0
+		nsamp  = 240_000 // 0.1 s
 	)
 	in := make([]complex64, nsamp)
 	for n := range in {

--- a/internal/siglab/downconvert_test.go
+++ b/internal/siglab/downconvert_test.go
@@ -1,0 +1,49 @@
+package siglab
+
+import (
+	"math"
+	"math/cmplx"
+	"testing"
+)
+
+// TestDownconvertShiftsToneToDC feeds a pure tone offset +100 kHz from centre
+// through Downconvert tuned to that offset and confirms two things: the output
+// rate collapses to the requested ~50 kHz channel rate (≈48× fewer samples),
+// and the tone lands at DC — i.e. the decimated stream is a near-constant
+// phasor, so |mean| ≈ mean|·| (an off-DC tone would average toward zero).
+func TestDownconvertShiftsToneToDC(t *testing.T) {
+	const (
+		rate    = 2_400_000.0
+		offset  = 100_000.0
+		target  = 50_000.0
+		nsamp   = 240_000 // 0.1 s
+	)
+	in := make([]complex64, nsamp)
+	for n := range in {
+		ph := 2 * math.Pi * offset * float64(n) / rate
+		in[n] = complex64(cmplx.Exp(complex(0, ph)))
+	}
+
+	out, outRate := Downconvert(in, rate, offset, target)
+
+	if math.Abs(outRate-target) > 1 {
+		t.Fatalf("output rate = %g, want ~%g", outRate, target)
+	}
+	if ratio := float64(len(in)) / float64(len(out)); ratio < 40 || ratio > 56 {
+		t.Fatalf("decimation ratio = %.1f, want ~48", ratio)
+	}
+
+	// Skip the filter warm-up transient, then measure the DC-ness of the tail.
+	tail := out[len(out)/2:]
+	var sum complex128
+	var mag float64
+	for _, s := range tail {
+		sum += complex128(s)
+		mag += cmplx.Abs(complex128(s))
+	}
+	meanVec := cmplx.Abs(sum) / float64(len(tail))
+	meanMag := mag / float64(len(tail))
+	if meanMag == 0 || meanVec/meanMag < 0.95 {
+		t.Fatalf("tone not at DC: |mean|/mean|·| = %.3f (want ≈1)", meanVec/meanMag)
+	}
+}

--- a/internal/siglab/synth.go
+++ b/internal/siglab/synth.go
@@ -85,14 +85,24 @@ func WriteCapture(path string, iq []complex64, format SampleFormat) error {
 	return os.WriteFile(path, EncodeCapture(iq, format), 0o644)
 }
 
-// EncodeCapture returns IQ encoded in the given on-disk format (u8 or f32).
-// It is the pure (no-I/O) core shared by WriteCapture and the in-memory
-// synth→decode bridge (SynthesizeAndAnalyze), so a synthesized signal can be
-// fed straight back into the engine via a bytes.Reader without touching disk.
+// EncodeCapture returns IQ encoded in the given on-disk format (u8, f32, or the
+// headerless 16-bit cs16). It is the pure (no-I/O) core shared by WriteCapture
+// and the in-memory synth→decode bridge (SynthesizeAndAnalyze), so a
+// synthesized signal can be fed straight back into the engine via a
+// bytes.Reader without touching disk.
+//
+// FormatWAV is encoded as the same headerless 16-bit body: a real WAV *file*
+// needs a RIFF/WAVE header carrying the sample rate, which this pure encoder
+// (iq + format only) does not have — write those through baseband.IQWriter,
+// which is rate-aware. Emitting the 16-bit body here (rather than silently
+// falling through to u8, the prior behaviour) at least preserves the sample
+// depth instead of quantising to 8 bits.
 func EncodeCapture(iq []complex64, format SampleFormat) []byte {
 	switch format {
 	case FormatF32:
 		return encodeF32(iq)
+	case FormatS16, FormatWAV:
+		return encodeSW16(iq)
 	default:
 		return encodeU8(iq)
 	}
@@ -127,6 +137,31 @@ func encodeU8(iq []complex64) []byte {
 		buf[2*i+1] = floatToU8(imag(s))
 	}
 	return buf
+}
+
+// encodeSW16 encodes interleaved little-endian 16-bit signed PCM IQ (I then Q,
+// ×32768, clamped) — the headerless body of the cs16/wav formats and the exact
+// inverse of decodeSW16.
+func encodeSW16(iq []complex64) []byte {
+	buf := make([]byte, len(iq)*4)
+	for i, s := range iq {
+		binary.LittleEndian.PutUint16(buf[4*i:], uint16(floatToI16(real(s))))
+		binary.LittleEndian.PutUint16(buf[4*i+2:], uint16(floatToI16(imag(s))))
+	}
+	return buf
+}
+
+// floatToI16 maps a normalised [-1,+1] sample to a 16-bit signed integer,
+// clamped to the int16 range. Mirrors the ÷32768 normalisation decodeSW16 uses.
+func floatToI16(v float32) int16 {
+	x := math.Round(float64(v) * 32768)
+	if x > 32767 {
+		return 32767
+	}
+	if x < -32768 {
+		return -32768
+	}
+	return int16(x)
 }
 
 func floatToU8(v float32) byte {

--- a/web/siglab/src/api/types.ts
+++ b/web/siglab/src/api/types.ts
@@ -344,13 +344,19 @@ export interface CaptureDevice {
   sample_rate_hz: number;
 }
 
-// CaptureRequest is the body of POST /api/v1/siglab/capture.
+// CaptureRequest is the body of POST /api/v1/siglab/capture. center_hz +
+// bandwidth_hz (both optional) request a small narrowband slice carved from the
+// tuner's current wideband stream: the channel at center_hz is shifted to DC and
+// decimated to ~bandwidth_hz. The tuner is not retuned, so center_hz must sit
+// inside the tuned span. Omit bandwidth_hz for a full-band capture.
 export interface CaptureRequest {
   serial: string;
   seconds: number;
   format: string;
   protocol?: string;
   source?: string;
+  center_hz?: number;
+  bandwidth_hz?: number;
 }
 
 // CaptureResponse is returned by a successful live capture.

--- a/web/siglab/src/panels/Captures.tsx
+++ b/web/siglab/src/panels/Captures.tsx
@@ -144,6 +144,8 @@ function CaptureForm() {
   const [seconds, setSeconds] = useState("10");
   const [format, setFormat] = useState("f32");
   const [protocol, setProtocol] = useState("");
+  const [centerMHz, setCenterMHz] = useState("");
+  const [bandwidthKHz, setBandwidthKHz] = useState("");
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const [downloadID, setDownloadID] = useState<string | null>(null);
@@ -171,11 +173,17 @@ function CaptureForm() {
     setErr(null);
     setDownloadID(null);
     try {
+      const bandwidthHz = bandwidthKHz.trim() ? Math.round(Number(bandwidthKHz) * 1e3) : 0;
+      const centerHz = centerMHz.trim() ? Math.round(Number(centerMHz) * 1e6) : 0;
       const res = await captureFromTuner({
         serial,
         seconds: Number(seconds) || 1,
         format,
         protocol: protocol || undefined,
+        // A narrowband slice is requested only when a bandwidth is given; the
+        // centre defaults to the tuner centre server-side when omitted.
+        bandwidth_hz: bandwidthHz > 0 ? bandwidthHz : undefined,
+        center_hz: bandwidthHz > 0 && centerHz > 0 ? centerHz : undefined,
       });
       setDownloadID(res.capture.id);
     } catch (e) {
@@ -241,6 +249,31 @@ function CaptureForm() {
           </select>
         </div>
       </div>
+      <div className="grid grid-cols-2 gap-2">
+        <div>
+          <label className="label">Center MHz (optional)</label>
+          <input
+            className="input"
+            placeholder="tuner centre"
+            value={centerMHz}
+            onChange={(e) => setCenterMHz(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="label">Bandwidth kHz (optional)</label>
+          <input
+            className="input"
+            placeholder="full band"
+            value={bandwidthKHz}
+            onChange={(e) => setBandwidthKHz(e.target.value)}
+          />
+        </div>
+      </div>
+      <p className="text-xs text-muted">
+        Set a bandwidth to save a small narrowband slice around the centre (carved from the
+        tuner&rsquo;s current span, no retune). Leave blank for a full-band grab. cs16 = 16-bit raw
+        (half the size of f32).
+      </p>
       <button className="btn" disabled={busy || !serial} onClick={onCapture}>
         {busy ? "Capturing…" : "Capture"}
       </button>
@@ -249,7 +282,7 @@ function CaptureForm() {
           className="btn-ghost block text-center"
           href={api.captureDownloadURL(config, downloadID)}
         >
-          Download .cfile
+          Download capture
         </a>
       )}
       {err && <p className="text-xs text-err">{err}</p>}

--- a/web/siglab/src/store/shared.ts
+++ b/web/siglab/src/store/shared.ts
@@ -62,7 +62,7 @@ export const useStore = create<Store>((set, get) => ({
 
   protocols: [],
   fixtures: [],
-  formats: ["u8", "f32"],
+  formats: ["u8", "f32", "cs16"],
   loadProtocols: async () => {
     const p = await api.protocols(get().config);
     set({ protocols: p.protocols, fixtures: p.fixtures, formats: p.formats });


### PR DESCRIPTION
Capture from tuner could hang forever when the scanner could not lock a
control channel. The capture taps the device's iqtap broker, which pauses
fan-out whenever no primary StreamIQ session is running; during a cc-hunt
failure the pipeline is torn down and backs off ~60s, so the broker delivers
nothing. The capture loop's select only had ctx.Done and sub.C arms and its
wall-clock deadline was checked only after a chunk arrived, so it blocked
indefinitely and the UI sat on "Capturing…".

Make the safety deadline an explicit select arm so the wait is always bounded,
and return an actionable error when no IQ arrives (the tuner is not streaming —
a scan may be mid-hunt/backoff). Apply the same timer-arm hardening to the
capture subcommand and the --iq-capture path.

Also add the capture improvements the report asked for so a failed-lock grab
can be handed off for analysis:

- cs16: a headerless interleaved 16-bit signed IQ format (aliases sc16/i16/raw),
  half the size of f32 while keeping 12–14-bit ADC resolution. s16/sw16 stay
  WAV aliases (a documented, tested contract). Fix EncodeCapture's silent u8
  downgrade for the 16-bit formats.
- Narrowband capture: optional center_hz + bandwidth_hz carve a small channel
  out of the tuner's current wideband stream (no retune) via the production
  ccdecoder DDC, so the staged file is a fraction of a full-band grab. Wired
  through the web API/UI and the capture subcommand (-center/-bandwidth).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01D8Mm1aWyrSsGVtStibDDZ7