### PR TITLE
fix(capture): unhang 30s live capture, add export/UI fixes, and stream capture to disk

### DIFF
--- a/cmd/gophertrunk/capture_provider.go
+++ b/cmd/gophertrunk/capture_provider.go
@@ -36,19 +36,24 @@ func newCaptureProvider(pool *sdr.Pool, brokers map[string]*iqtap.Broker, log *s
 // Devices reuses the spectrum provider's broker walk.
 func (p *captureProvider) Devices() []api.SpectrumDevice { return p.sp.Devices() }
 
-// Capture records seconds worth of raw IQ from the named device's broker.
-func (p *captureProvider) Capture(ctx context.Context, serial string, seconds int) ([]complex64, uint32, uint32, error) {
+// CaptureStream records seconds worth of raw IQ from the named device's broker,
+// handing each chunk to sink as it arrives instead of buffering the whole grab.
+// The api handler's sink encodes each chunk straight to disk, so a long or
+// high-rate capture no longer holds the whole stream (and a second encoded copy)
+// in RAM.
+func (p *captureProvider) CaptureStream(ctx context.Context, serial string, seconds int, sink func([]complex64) error) (uint32, uint32, error) {
 	if p == nil {
-		return nil, 0, 0, errors.New("capture: provider not wired")
+		return 0, 0, errors.New("capture: provider not wired")
 	}
 	br, ok := p.brokers[serial]
 	if !ok {
-		return nil, 0, 0, fmt.Errorf("capture: serial %q is not a known SDR", serial)
+		return 0, 0, fmt.Errorf("capture: serial %q is not a known SDR", serial)
 	}
 	rate := br.SampleRateHz()
 	if rate == 0 {
-		return nil, 0, 0, errors.New("capture: device has no sample rate yet")
+		return 0, 0, errors.New("capture: device has no sample rate yet")
 	}
+	center := br.CenterHz()
 	target := int64(seconds) * int64(rate)
 
 	sub := br.Subscribe()
@@ -63,26 +68,29 @@ func (p *captureProvider) Capture(ctx context.Context, serial string, seconds in
 	// never ends). See internal/sdr/iqtap/broker.go.
 	timer := time.NewTimer(time.Duration(seconds)*time.Second + 5*time.Second)
 	defer timer.Stop()
-	out := make([]complex64, 0, target)
+	var got int64
 loop:
-	for int64(len(out)) < target {
+	for got < target {
 		select {
 		case <-ctx.Done():
-			return out, rate, br.CenterHz(), ctx.Err()
+			return rate, center, ctx.Err()
 		case <-timer.C:
 			break loop
 		case chunk, ok := <-sub.C:
 			if !ok {
-				return out, rate, br.CenterHz(), errors.New("capture: IQ stream ended before capture finished")
+				return rate, center, errors.New("capture: IQ stream ended before capture finished")
 			}
-			out = append(out, chunk...)
+			if err := sink(chunk); err != nil {
+				return rate, center, err
+			}
+			got += int64(len(chunk))
 		}
 	}
-	if len(out) == 0 {
-		return out, rate, br.CenterHz(), fmt.Errorf(
+	if got == 0 {
+		return rate, center, fmt.Errorf(
 			"capture: device %q delivered no IQ within %ds — the tuner is not currently "+
 				"streaming (a scan may be mid-hunt / in control-channel backoff); start or "+
 				"resume a scan on this SDR, or retry", serial, seconds)
 	}
-	return out, rate, br.CenterHz(), nil
+	return rate, center, nil
 }

--- a/cmd/gophertrunk/capture_provider_test.go
+++ b/cmd/gophertrunk/capture_provider_test.go
@@ -20,8 +20,8 @@ type idleDevice struct{ rateOnlyDevice }
 // StreamIQ session — e.g. a scan looping trying → hunt failed → backoff), a
 // capture must return a bounded error instead of blocking the request forever.
 //
-// Before the timer-arm fix the select in captureProvider.Capture blocked on
-// sub.C with no deadline arm, so this test would hang until the -timeout kills
+// Before the timer-arm fix the select in captureProvider.CaptureStream blocked
+// on sub.C with no deadline arm, so this test would hang until the -timeout kills
 // the run.
 func TestCaptureProviderTimesOutWhenBrokerIdle(t *testing.T) {
 	br := iqtap.New(idleDevice{}, 0, nil)
@@ -39,7 +39,7 @@ func TestCaptureProviderTimesOutWhenBrokerIdle(t *testing.T) {
 	done := make(chan error, 1)
 	start := time.Now()
 	go func() {
-		_, _, _, err := p.Capture(context.Background(), "dev-a", seconds)
+		_, _, err := p.CaptureStream(context.Background(), "dev-a", seconds, func([]complex64) error { return nil })
 		done <- err
 	}()
 

--- a/internal/api/capture.go
+++ b/internal/api/capture.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -15,19 +16,19 @@ import (
 )
 
 // maxCaptureSeconds bounds a single live capture so an operator can't pin a
-// tuner indefinitely with one request. The tighter real bound on memory is
-// maxCaptureIQBytes below (peak RAM scales with seconds × sample rate, which
-// varies ~5x across SDRs); this is a coarse ceiling on wall-clock duration.
+// tuner indefinitely with one request. The capture streams encoded IQ straight
+// to disk (peak RAM is one chunk, not the whole grab), so duration is bounded by
+// disk — see maxCaptureIQBytes — rather than memory; this is a coarse ceiling on
+// wall-clock duration.
 const maxCaptureSeconds = 120
 
-// maxCaptureIQBytes caps the raw wideband IQ a single capture may buffer. The
-// whole capture is collected into RAM as complex64 (8 bytes/sample) and then
-// EncodeCapture allocates a second copy, so peak resident memory is roughly
-// twice this. 1 GiB of complex64 (~134 M samples) keeps that peak to a couple
-// of GB even on a modest host. A high-rate grab that would exceed it is
-// rejected up front (before the tuner is pinned) with an actionable error
-// instead of swapping/OOM-ing the daemon. The guard is on the raw collection,
-// so it also bounds a narrowband slice (which buffers the full band first).
+// maxCaptureIQBytes caps the on-disk size a single capture may stage. Because
+// the capture now streams encoded IQ to disk one chunk at a time (see
+// siglab.CaptureWriter), memory is no longer the constraint — this bounds the
+// staged file so one request can't fill the disk. 1 GiB is ~13 s of f32 at
+// 10 MS/s or ~55 s at 2.4 MS/s; a grab that would exceed it is rejected up front
+// (before the tuner is pinned) with an actionable error suggesting a shorter
+// duration or a narrowband slice.
 const maxCaptureIQBytes = 1 << 30
 
 // CaptureProvider taps a live SDR for a fixed-length raw-IQ capture. The
@@ -39,10 +40,12 @@ const maxCaptureIQBytes = 1 << 30
 type CaptureProvider interface {
 	// Devices returns the SDRs that can be captured from.
 	Devices() []SpectrumDevice
-	// Capture records seconds worth of raw IQ from the named device and
-	// returns the complex samples plus the device's current sample rate and
-	// centre frequency. ctx cancels an in-flight capture.
-	Capture(ctx context.Context, serial string, seconds int) (iq []complex64, sampleRateHz, centerHz uint32, err error)
+	// CaptureStream records seconds worth of raw IQ from the named device,
+	// invoking sink for each chunk of complex samples as it arrives (never
+	// buffering the whole capture), and returns the device's current sample
+	// rate and centre frequency. A sink error aborts the capture and is
+	// returned. ctx cancels an in-flight capture.
+	CaptureStream(ctx context.Context, serial string, seconds int, sink func(iq []complex64) error) (sampleRateHz, centerHz uint32, err error)
 }
 
 // captureRequest is the body of POST /api/v1/siglab/capture.
@@ -118,55 +121,95 @@ func (s *Server) handleSiglabCapture(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Reject an over-budget grab before pinning the tuner. The device's current
-	// sample rate is known from the picker, so the raw-IQ footprint
-	// (seconds × rate × 8 bytes for complex64) can be estimated up front. When
-	// the rate is unknown (device not streaming yet) the estimate is skipped and
-	// maxCaptureSeconds is the only bound.
-	if rate := captureDeviceRate(s.capture.Devices(), req.Serial); rate > 0 {
-		estIQBytes := int64(req.Seconds) * int64(rate) * 8
-		if estIQBytes > maxCaptureIQBytes {
+	rate, centerHz := captureDeviceRateCenter(s.capture.Devices(), req.Serial)
+
+	// Reject an over-budget grab before pinning the tuner. Streaming keeps RAM
+	// bounded to one chunk, so this bounds the on-disk file size (seconds × rate ×
+	// bytes-per-sample), not memory. Skipped when the rate is unknown (device not
+	// streaming yet) — then maxCaptureSeconds is the only bound.
+	if rate > 0 {
+		estBytes := int64(req.Seconds) * int64(rate) * int64(bytesPerSample(format))
+		if estBytes > maxCaptureIQBytes {
 			s.writeError(w, http.StatusBadRequest, fmt.Sprintf(
-				"siglab: a %ds capture at %.3f MS/s needs ~%d MiB of IQ, over the %d MiB budget — "+
+				"siglab: a %ds capture at %.3f MS/s would stage ~%d MiB, over the %d MiB budget — "+
 					"reduce seconds or request a narrowband slice (center_hz + bandwidth_hz)",
-				req.Seconds, float64(rate)/1e6, estIQBytes>>20, int64(maxCaptureIQBytes)>>20))
+				req.Seconds, float64(rate)/1e6, estBytes>>20, int64(maxCaptureIQBytes)>>20))
 			return
 		}
 	}
 
-	iq, sampleRateHz, centerHz, err := s.capture.Capture(r.Context(), req.Serial, req.Seconds)
-	if err != nil {
-		s.writeError(w, http.StatusBadGateway, "siglab: capture: "+err.Error())
-		return
-	}
-	if len(iq) == 0 {
-		s.writeError(w, http.StatusBadGateway, "siglab: capture produced no samples")
-		return
-	}
-
-	// Optional narrowband slice: carve the channel at CenterHz down to
-	// ~BandwidthHz from the tuner's current wideband stream (no retune), so the
-	// staged file is small enough to hand to an analysis tool.
+	// Optional narrowband slice: validate the requested channel fits the tuner's
+	// current span and build a streaming down-converter up front, so an
+	// out-of-span request 400s before the tuner is pinned. The slice is carved
+	// from the live stream chunk-by-chunk during capture — no wideband buffer.
+	var ddc *siglab.StreamDownconverter
+	outRate, outCenter := rate, centerHz
 	if req.BandwidthHz > 0 {
-		iq, sampleRateHz, centerHz, err = narrowband(iq, sampleRateHz, centerHz, req.CenterHz, req.BandwidthHz)
+		if rate == 0 {
+			s.writeError(w, http.StatusBadGateway,
+				"siglab: capture: device has no sample rate yet (start or resume a scan on this SDR)")
+			return
+		}
+		offsetHz, center, err := narrowbandParams(rate, centerHz, req.CenterHz, req.BandwidthHz)
 		if err != nil {
 			s.writeError(w, http.StatusBadRequest, "siglab: "+err.Error())
 			return
 		}
+		ddc = siglab.NewStreamDownconverter(float64(rate), float64(offsetHz), float64(req.BandwidthHz))
+		outRate = uint32(ddc.OutRateHz() + 0.5)
+		outCenter = center
 	}
 
+	// Stream encoded IQ straight to the staged file: peak memory is one chunk
+	// (plus the DDC's FIR state for a narrowband slice), independent of duration.
 	id := randomID(16)
 	path := s.siglab.newCapturePath(id)
-	if err := os.WriteFile(path, siglab.EncodeCapture(iq, format), 0o644); err != nil {
+	f, err := os.Create(path)
+	if err != nil {
 		s.writeError(w, http.StatusInternalServerError, "siglab: stage capture: "+err.Error())
 		return
+	}
+	bw := bufio.NewWriterSize(f, 1<<20)
+	enc := siglab.NewCaptureWriter(bw, format)
+	sink := func(chunk []complex64) error {
+		if ddc != nil {
+			chunk = ddc.Process(chunk)
+		}
+		return enc.Write(chunk)
+	}
+
+	gotRate, gotCenter, capErr := s.capture.CaptureStream(r.Context(), req.Serial, req.Seconds, sink)
+	flushErr := bw.Flush()
+	if cerr := f.Close(); cerr != nil && flushErr == nil {
+		flushErr = cerr
+	}
+	if capErr != nil {
+		_ = os.Remove(path)
+		s.writeError(w, http.StatusBadGateway, "siglab: capture: "+capErr.Error())
+		return
+	}
+	if flushErr != nil {
+		_ = os.Remove(path)
+		s.writeError(w, http.StatusInternalServerError, "siglab: stage capture: "+flushErr.Error())
+		return
+	}
+	if enc.Samples() == 0 {
+		_ = os.Remove(path)
+		s.writeError(w, http.StatusBadGateway, "siglab: capture produced no samples")
+		return
+	}
+
+	// A full-band grab keeps the tuner's authoritative rate/centre from the
+	// stream; a narrowband slice keeps its decimated rate + requested centre.
+	if req.BandwidthHz == 0 {
+		outRate, outCenter = gotRate, gotCenter
 	}
 
 	meta := &siglab.Metadata{
 		Protocol:     req.Protocol,
 		Source:       req.Source,
-		SampleRateHz: float64(sampleRateHz),
-		CenterFreqHz: centerHz,
+		SampleRateHz: float64(outRate),
+		CenterFreqHz: outCenter,
 		Format:       format.String(),
 	}
 	// Best-effort sidecar at the path siglab.DiscoverMetadata probes
@@ -178,11 +221,11 @@ func (s *Server) handleSiglabCapture(w http.ResponseWriter, r *http.Request) {
 
 	c := &siglabCapture{
 		ID:           id,
-		Name:         captureName(req.Serial, centerHz),
+		Name:         captureName(req.Serial, outCenter),
 		Path:         path,
 		Format:       format,
-		SampleRateHz: float64(sampleRateHz),
-		Size:         int64(len(iq)) * int64(bytesPerSample(format)),
+		SampleRateHz: float64(outRate),
+		Size:         enc.Samples() * int64(bytesPerSample(format)),
 		Created:      time.Now(),
 	}
 	s.siglab.putCapture(c)
@@ -226,21 +269,20 @@ func (s *Server) handleSiglabCaptureDownload(w http.ResponseWriter, r *http.Requ
 	}
 }
 
-// narrowband carves the channel at wantCenterHz (±wantBWHz/2) out of the
-// wideband IQ the tuner is currently streaming, decimating it to a baseband
-// stream and returning the slice, its new sample rate, and its new centre
-// (== wantCenterHz, or the tuner centre when wantCenterHz is 0). The tuner is
-// not retuned — the slice is extracted from the live stream — so the requested
-// channel must fit wholly inside the tuned span [tunerCentre ± rate/2].
-func narrowband(iq []complex64, rateHz, tunerCenterHz, wantCenterHz, wantBWHz uint32) ([]complex64, uint32, uint32, error) {
-	center := wantCenterHz
+// narrowbandParams validates that the channel at wantCenterHz (±wantBWHz/2) fits
+// wholly inside the tuner's current span [tunerCentre ± rate/2] — a capture is
+// carved from the live stream without retuning — and returns the channel's
+// offset from the tuner centre and its resolved centre (== wantCenterHz, or the
+// tuner centre when wantCenterHz is 0). The offset drives the streaming DDC.
+func narrowbandParams(rateHz, tunerCenterHz, wantCenterHz, wantBWHz uint32) (offsetHz int64, center uint32, err error) {
+	center = wantCenterHz
 	if center == 0 {
 		center = tunerCenterHz
 	}
-	offsetHz := int64(center) - int64(tunerCenterHz)
+	offsetHz = int64(center) - int64(tunerCenterHz)
 	half := int64(rateHz) / 2
 	if abs64(offsetHz)+int64(wantBWHz)/2 > half {
-		return nil, 0, 0, fmt.Errorf(
+		return 0, 0, fmt.Errorf(
 			"center_hz %d + bandwidth_hz %d falls outside the tuner's current span %.3f–%.3f MHz "+
 				"(centre %.3f MHz, rate %.3f MS/s); a capture extracts a channel from the live stream "+
 				"without retuning, so pick a centre/bandwidth inside the span",
@@ -248,11 +290,7 @@ func narrowband(iq []complex64, rateHz, tunerCenterHz, wantCenterHz, wantBWHz ui
 			float64(int64(tunerCenterHz)-half)/1e6, float64(int64(tunerCenterHz)+half)/1e6,
 			float64(tunerCenterHz)/1e6, float64(rateHz)/1e6)
 	}
-	nb, outRate := siglab.Downconvert(iq, float64(rateHz), float64(offsetHz), float64(wantBWHz))
-	if len(nb) == 0 {
-		return nil, 0, 0, fmt.Errorf("bandwidth_hz %d is too small for a %d-sample capture (no output samples)", wantBWHz, len(iq))
-	}
-	return nb, uint32(outRate + 0.5), center, nil
+	return offsetHz, center, nil
 }
 
 // abs64 is the absolute value of a signed 64-bit integer.
@@ -263,16 +301,16 @@ func abs64(x int64) int64 {
 	return x
 }
 
-// captureDeviceRate returns the current sample rate of the device with the
-// given serial from the capture picker's device list, or 0 when the device is
-// unknown or has no rate yet (not streaming).
-func captureDeviceRate(devices []SpectrumDevice, serial string) uint32 {
+// captureDeviceRateCenter returns the current sample rate and centre frequency
+// of the device with the given serial from the capture picker's device list, or
+// (0, 0) when the device is unknown or has no rate yet (not streaming).
+func captureDeviceRateCenter(devices []SpectrumDevice, serial string) (rate, center uint32) {
 	for _, d := range devices {
 		if d.Serial == serial {
-			return d.SampleRateHz
+			return d.SampleRateHz, d.CenterHz
 		}
 	}
-	return 0
+	return 0, 0
 }
 
 // captureName builds a friendly staged-capture name from the device + tuning.

--- a/internal/api/capture.go
+++ b/internal/api/capture.go
@@ -15,8 +15,20 @@ import (
 )
 
 // maxCaptureSeconds bounds a single live capture so an operator can't pin a
-// tuner (and pile up hundreds of MB of staged IQ) with one request.
-const maxCaptureSeconds = 30
+// tuner indefinitely with one request. The tighter real bound on memory is
+// maxCaptureIQBytes below (peak RAM scales with seconds × sample rate, which
+// varies ~5x across SDRs); this is a coarse ceiling on wall-clock duration.
+const maxCaptureSeconds = 120
+
+// maxCaptureIQBytes caps the raw wideband IQ a single capture may buffer. The
+// whole capture is collected into RAM as complex64 (8 bytes/sample) and then
+// EncodeCapture allocates a second copy, so peak resident memory is roughly
+// twice this. 1 GiB of complex64 (~134 M samples) keeps that peak to a couple
+// of GB even on a modest host. A high-rate grab that would exceed it is
+// rejected up front (before the tuner is pinned) with an actionable error
+// instead of swapping/OOM-ing the daemon. The guard is on the raw collection,
+// so it also bounds a narrowband slice (which buffers the full band first).
+const maxCaptureIQBytes = 1 << 30
 
 // CaptureProvider taps a live SDR for a fixed-length raw-IQ capture. The
 // daemon (cmd/gophertrunk) implements it over its iqtap.Broker map; nil keeps
@@ -80,6 +92,13 @@ func (s *Server) handleSiglabCapture(w http.ResponseWriter, r *http.Request) {
 		s.writeError(w, http.StatusServiceUnavailable, "siglab: live capture not available (no SDR)")
 		return
 	}
+	// A live capture spends `seconds` of real time collecting IQ before the
+	// handler writes anything, then stages a large file — both can exceed the
+	// server-level 30s WriteTimeout (server.go), which would silently tear down
+	// the 200 mid-write and leave the UI stuck on "Capturing…". Disable the
+	// write deadline per-request, exactly as the SSE and audio-stream handlers
+	// do (see sse.go / handlers_audio_stream.go).
+	_ = http.NewResponseController(w).SetWriteDeadline(time.Time{})
 	var req captureRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		s.writeError(w, http.StatusBadRequest, "siglab: "+err.Error())
@@ -97,6 +116,22 @@ func (s *Server) handleSiglabCapture(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		s.writeError(w, http.StatusBadRequest, "siglab: "+err.Error())
 		return
+	}
+
+	// Reject an over-budget grab before pinning the tuner. The device's current
+	// sample rate is known from the picker, so the raw-IQ footprint
+	// (seconds × rate × 8 bytes for complex64) can be estimated up front. When
+	// the rate is unknown (device not streaming yet) the estimate is skipped and
+	// maxCaptureSeconds is the only bound.
+	if rate := captureDeviceRate(s.capture.Devices(), req.Serial); rate > 0 {
+		estIQBytes := int64(req.Seconds) * int64(rate) * 8
+		if estIQBytes > maxCaptureIQBytes {
+			s.writeError(w, http.StatusBadRequest, fmt.Sprintf(
+				"siglab: a %ds capture at %.3f MS/s needs ~%d MiB of IQ, over the %d MiB budget — "+
+					"reduce seconds or request a narrowband slice (center_hz + bandwidth_hz)",
+				req.Seconds, float64(rate)/1e6, estIQBytes>>20, int64(maxCaptureIQBytes)>>20))
+			return
+		}
 	}
 
 	iq, sampleRateHz, centerHz, err := s.capture.Capture(r.Context(), req.Serial, req.Seconds)
@@ -226,6 +261,18 @@ func abs64(x int64) int64 {
 		return -x
 	}
 	return x
+}
+
+// captureDeviceRate returns the current sample rate of the device with the
+// given serial from the capture picker's device list, or 0 when the device is
+// unknown or has no rate yet (not streaming).
+func captureDeviceRate(devices []SpectrumDevice, serial string) uint32 {
+	for _, d := range devices {
+		if d.Serial == serial {
+			return d.SampleRateHz
+		}
+	}
+	return 0
 }
 
 // captureName builds a friendly staged-capture name from the device + tuning.

--- a/internal/api/capture_test.go
+++ b/internal/api/capture_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
 )
 
 // fakeCaptureProvider is an in-memory CaptureProvider for handler tests.
@@ -19,16 +20,66 @@ type fakeCaptureProvider struct {
 	iq      []complex64
 	rate    uint32
 	center  uint32
+	chunks  int // number of chunks to deliver f.iq in (0 → a small default)
 	err     error
 }
 
-func (f *fakeCaptureProvider) Devices() []SpectrumDevice { return f.devices }
-
-func (f *fakeCaptureProvider) Capture(_ context.Context, _ string, _ int) ([]complex64, uint32, uint32, error) {
-	if f.err != nil {
-		return nil, 0, 0, f.err
+// Devices stamps the provider's rate/centre onto any device that doesn't carry
+// its own, so the handler's up-front rate/centre lookup (budget guard, narrowband
+// span check) sees the same values CaptureStream returns.
+func (f *fakeCaptureProvider) Devices() []SpectrumDevice {
+	out := make([]SpectrumDevice, len(f.devices))
+	copy(out, f.devices)
+	for i := range out {
+		if out[i].SampleRateHz == 0 {
+			out[i].SampleRateHz = f.rate
+		}
+		if out[i].CenterHz == 0 {
+			out[i].CenterHz = f.center
+		}
 	}
-	return f.iq, f.rate, f.center, nil
+	return out
+}
+
+func (f *fakeCaptureProvider) CaptureStream(_ context.Context, _ string, _ int, sink func([]complex64) error) (uint32, uint32, error) {
+	if f.err != nil {
+		return 0, 0, f.err
+	}
+	n := f.chunks
+	if n == 0 {
+		n = 4
+	}
+	for _, chunk := range splitChunks(f.iq, n) {
+		if err := sink(chunk); err != nil {
+			return f.rate, f.center, err
+		}
+	}
+	return f.rate, f.center, nil
+}
+
+// splitChunks splits iq into up to n roughly-equal, non-empty chunks so a fake
+// provider exercises the streaming/chunked capture path (a real broker delivers
+// IQ in many small chunks).
+func splitChunks(iq []complex64, n int) [][]complex64 {
+	if len(iq) == 0 {
+		return nil
+	}
+	if n < 1 {
+		n = 1
+	}
+	if n > len(iq) {
+		n = len(iq)
+	}
+	size := (len(iq) + n - 1) / n
+	var out [][]complex64
+	for i := 0; i < len(iq); i += size {
+		end := i + size
+		if end > len(iq) {
+			end = len(iq)
+		}
+		out = append(out, iq[i:end])
+	}
+	return out
 }
 
 func newCaptureTestServer(t *testing.T, prov CaptureProvider) *httptest.Server {
@@ -292,6 +343,52 @@ func TestSiglabCaptureRejectsOverBudget(t *testing.T) {
 	}
 }
 
+// TestSiglabCaptureStreamsMultipleChunks proves the capture is streamed to disk
+// chunk-by-chunk (not buffered whole): the staged file must equal EncodeCapture
+// of the full IQ even when the provider delivers it in many small chunks.
+func TestSiglabCaptureStreamsMultipleChunks(t *testing.T) {
+	iq := make([]complex64, 10_000)
+	for i := range iq {
+		iq[i] = complex(float32(i%11)/11, float32(i%5)/5)
+	}
+	prov := &fakeCaptureProvider{
+		devices: []SpectrumDevice{{Serial: "SDR1", Driver: "mock"}},
+		iq:      iq,
+		rate:    2_400_000,
+		center:  460_000_000,
+		chunks:  17, // many small chunks
+	}
+	ts := newCaptureTestServer(t, prov)
+
+	cResp, err := http.Post(ts.URL+"/api/v1/siglab/capture", "application/json",
+		bytes.NewBufferString(`{"serial":"SDR1","seconds":1,"format":"cs16"}`))
+	if err != nil {
+		t.Fatalf("POST capture: %v", err)
+	}
+	defer cResp.Body.Close()
+	if cResp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(cResp.Body)
+		t.Fatalf("status = %d, want 200 (%s)", cResp.StatusCode, b)
+	}
+	var cr captureResponse
+	if err := json.NewDecoder(cResp.Body).Decode(&cr); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if want := int64(len(iq)) * 4; cr.Capture.Size != want {
+		t.Fatalf("size = %d, want %d (streamed cs16)", cr.Capture.Size, want)
+	}
+
+	dlResp, err := http.Get(ts.URL + cr.DownloadURL)
+	if err != nil {
+		t.Fatalf("GET download: %v", err)
+	}
+	defer dlResp.Body.Close()
+	got, _ := io.ReadAll(dlResp.Body)
+	if want := siglab.EncodeCapture(iq, siglab.FormatS16); !bytes.Equal(got, want) {
+		t.Fatalf("streamed file (%d bytes) != EncodeCapture of the whole capture (%d bytes)", len(got), len(want))
+	}
+}
+
 // slowCaptureProvider returns IQ only after a delay, simulating a live capture
 // whose real-time collection crosses the server's WriteTimeout.
 type slowCaptureProvider struct {
@@ -305,13 +402,16 @@ func (p *slowCaptureProvider) Devices() []SpectrumDevice {
 	return []SpectrumDevice{{Serial: "SDR1", Driver: "mock"}}
 }
 
-func (p *slowCaptureProvider) Capture(ctx context.Context, _ string, _ int) ([]complex64, uint32, uint32, error) {
+func (p *slowCaptureProvider) CaptureStream(ctx context.Context, _ string, _ int, sink func([]complex64) error) (uint32, uint32, error) {
 	select {
 	case <-time.After(p.delay):
 	case <-ctx.Done():
-		return nil, 0, 0, ctx.Err()
+		return 0, 0, ctx.Err()
 	}
-	return p.iq, p.rate, p.center, nil
+	if err := sink(p.iq); err != nil {
+		return p.rate, p.center, err
+	}
+	return p.rate, p.center, nil
 }
 
 // TestSiglabCaptureSurvivesWriteTimeout is the regression test for the 30s

--- a/internal/api/capture_test.go
+++ b/internal/api/capture_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 )
@@ -252,6 +253,7 @@ func TestSiglabCaptureRejectsBadSeconds(t *testing.T) {
 	ts := newCaptureTestServer(t, prov)
 	for _, body := range []string{
 		`{"serial":"SDR1","seconds":0,"format":"f32"}`,
+		`{"serial":"SDR1","seconds":121,"format":"f32"}`, // just over the 120s ceiling
 		`{"serial":"SDR1","seconds":9999,"format":"f32"}`,
 		`{"seconds":1,"format":"f32"}`, // missing serial
 	} {
@@ -264,5 +266,108 @@ func TestSiglabCaptureRejectsBadSeconds(t *testing.T) {
 		if resp.StatusCode != http.StatusBadRequest {
 			t.Errorf("body %s → status %d, want 400", body, resp.StatusCode)
 		}
+	}
+}
+
+// TestSiglabCaptureRejectsOverBudget rejects a grab whose estimated raw-IQ
+// footprint exceeds maxCaptureIQBytes before the tuner is pinned, using the
+// device's advertised sample rate. A 120s capture at 10 MS/s is ~9.6 GiB of
+// complex64 — far over the 1 GiB budget.
+func TestSiglabCaptureRejectsOverBudget(t *testing.T) {
+	prov := &fakeCaptureProvider{
+		devices: []SpectrumDevice{{Serial: "SDR1", Driver: "mock", SampleRateHz: 10_000_000}},
+		iq:      []complex64{complex(1, 0)},
+		rate:    10_000_000,
+	}
+	ts := newCaptureTestServer(t, prov)
+	resp, err := http.Post(ts.URL+"/api/v1/siglab/capture", "application/json",
+		bytes.NewBufferString(`{"serial":"SDR1","seconds":120,"format":"f32"}`))
+	if err != nil {
+		t.Fatalf("POST capture: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 400 for an over-budget grab (%s)", resp.StatusCode, b)
+	}
+}
+
+// slowCaptureProvider returns IQ only after a delay, simulating a live capture
+// whose real-time collection crosses the server's WriteTimeout.
+type slowCaptureProvider struct {
+	delay  time.Duration
+	iq     []complex64
+	rate   uint32
+	center uint32
+}
+
+func (p *slowCaptureProvider) Devices() []SpectrumDevice {
+	return []SpectrumDevice{{Serial: "SDR1", Driver: "mock"}}
+}
+
+func (p *slowCaptureProvider) Capture(ctx context.Context, _ string, _ int) ([]complex64, uint32, uint32, error) {
+	select {
+	case <-time.After(p.delay):
+	case <-ctx.Done():
+		return nil, 0, 0, ctx.Err()
+	}
+	return p.iq, p.rate, p.center, nil
+}
+
+// TestSiglabCaptureSurvivesWriteTimeout is the regression test for the 30s
+// "Capturing…" hang: a capture that takes longer to collect than the server's
+// WriteTimeout must still deliver a complete 200 response, because the handler
+// disables the per-request write deadline. The default httptest.NewServer has
+// no WriteTimeout, so this builds an unstarted server and sets one (as
+// Server.Run does in server.go). Without the SetWriteDeadline fix the write
+// deadline fires while Capture is still collecting and the response is torn
+// down (POST error or truncated decode); with it the body decodes cleanly.
+func TestSiglabCaptureSurvivesWriteTimeout(t *testing.T) {
+	iq := make([]complex64, 4800)
+	for i := range iq {
+		iq[i] = complex(float32(i%7)/7, float32(i%3)/3)
+	}
+	prov := &slowCaptureProvider{delay: 750 * time.Millisecond, iq: iq, rate: 2_400_000, center: 460_000_000}
+
+	bus := events.NewBus(8)
+	t.Cleanup(bus.Close)
+	srv, err := NewServer(ServerOptions{
+		Addr:           "127.0.0.1:0",
+		Bus:            bus,
+		AllowMutations: true,
+		Siglab:         SiglabOptions{Enabled: true, TempDir: t.TempDir()},
+		Capture:        prov,
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	t.Cleanup(func() { _ = srv.Close() })
+
+	// Unstarted so we can set a small WriteTimeout like Server.Run does — well
+	// under the 750ms collection so a pre-fix run trips the deadline.
+	ts := httptest.NewUnstartedServer(srv.routes())
+	ts.Config.WriteTimeout = 250 * time.Millisecond
+	ts.Config.ReadTimeout = 5 * time.Second
+	ts.Start()
+	t.Cleanup(ts.Close)
+
+	// Client timeout guards the test itself (must exceed collection time).
+	cli := &http.Client{Timeout: 5 * time.Second}
+	resp, err := cli.Post(ts.URL+"/api/v1/siglab/capture", "application/json",
+		bytes.NewBufferString(`{"serial":"SDR1","seconds":1,"format":"f32"}`))
+	if err != nil {
+		t.Fatalf("POST capture (write deadline tore down the response?): %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200 (%s)", resp.StatusCode, b)
+	}
+	var cr captureResponse
+	if err := json.NewDecoder(resp.Body).Decode(&cr); err != nil {
+		t.Fatalf("decode capture response (truncated by write deadline?): %v", err)
+	}
+	if cr.Capture.ID == "" || cr.Capture.Size != int64(len(iq))*8 {
+		t.Fatalf("capture DTO = %+v, want id + %d bytes", cr.Capture, int64(len(iq))*8)
 	}
 }

--- a/internal/siglab/capture_stream.go
+++ b/internal/siglab/capture_stream.go
@@ -1,0 +1,108 @@
+package siglab
+
+import (
+	"io"
+
+	"github.com/MattCheramie/GopherTrunk/internal/scanner/ccdecoder"
+)
+
+// CaptureWriter streams IQ to an io.Writer one chunk at a time in a headerless
+// on-disk format (u8, f32, cs16). It is the streaming counterpart of
+// EncodeCapture: instead of encoding a whole capture into a fresh []byte (and
+// forcing a second full copy in RAM), it encodes each chunk into a single
+// reused scratch buffer and writes it straight out, so peak memory is one chunk
+// regardless of how long the capture runs. The bytes it emits are identical to
+// EncodeCapture of the concatenated input, so a streamed file round-trips
+// through the same decoders.
+//
+// FormatWAV is emitted as the same headerless 16-bit body EncodeCapture already
+// produces for it (a real RIFF/WAVE file needs a rate-aware header written via
+// baseband.IQWriter) — matched here so the two paths stay byte-for-byte equal.
+type CaptureWriter struct {
+	w       io.Writer
+	bpp     int // bytes per IQ sample in this format
+	format  SampleFormat
+	scratch []byte
+	samples int64
+}
+
+// NewCaptureWriter returns a CaptureWriter that encodes to format and writes to
+// w. w is typically a bufio.Writer wrapping the staged capture file.
+func NewCaptureWriter(w io.Writer, format SampleFormat) *CaptureWriter {
+	_, bpp := format.Decoder()
+	return &CaptureWriter{w: w, bpp: bpp, format: format}
+}
+
+// Write encodes one chunk of IQ and writes it to the underlying writer. An
+// empty chunk is a no-op (a decimating source can legitimately yield zero
+// output samples for a small input block).
+func (c *CaptureWriter) Write(iq []complex64) error {
+	if len(iq) == 0 {
+		return nil
+	}
+	n := len(iq) * c.bpp
+	if cap(c.scratch) < n {
+		c.scratch = make([]byte, n)
+	}
+	buf := c.scratch[:n]
+	encodeCaptureInto(buf, iq, c.format)
+	if _, err := c.w.Write(buf); err != nil {
+		return err
+	}
+	c.samples += int64(len(iq))
+	return nil
+}
+
+// Samples returns the number of IQ samples written so far.
+func (c *CaptureWriter) Samples() int64 { return c.samples }
+
+// encodeCaptureInto writes iq into dst using the same per-format layout as
+// EncodeCapture. dst must hold at least len(iq)*bytesPerSample(format) bytes.
+func encodeCaptureInto(dst []byte, iq []complex64, format SampleFormat) {
+	switch format {
+	case FormatF32:
+		encodeF32Into(dst, iq)
+	case FormatS16, FormatWAV:
+		encodeSW16Into(dst, iq)
+	default:
+		encodeU8Into(dst, iq)
+	}
+}
+
+// StreamDownconverter carves a narrowband channel out of a live wideband
+// capture chunk by chunk, retaining the down-converter's NCO + polyphase-FIR
+// state across calls. This is the streaming counterpart of the one-shot
+// Downconvert: because filter history is carried between chunks, the
+// concatenated per-chunk output is bit-equivalent to downconverting the whole
+// capture at once — but without ever holding the full wideband stream in RAM.
+//
+// Construct one per capture (a fresh capture, or a retune, needs a new one — do
+// not reuse across channels, since that is what Reset guards against in the
+// live pipeline).
+type StreamDownconverter struct {
+	ddc *ccdecoder.Downconverter
+	dst []complex64
+}
+
+// NewStreamDownconverter builds a streaming DDC that shifts the channel at
+// offsetHz (offset from the wideband centre) to DC and decimates inRateHz to
+// ~targetHz. OutRateHz reports the exact achieved rate.
+func NewStreamDownconverter(inRateHz, offsetHz, targetHz float64) *StreamDownconverter {
+	return &StreamDownconverter{ddc: ccdecoder.NewDownconverterWithOffset(inRateHz, targetHz, offsetHz)}
+}
+
+// Process decimates one wideband chunk to the narrowband rate, reusing an
+// internal buffer. The returned slice is valid only until the next Process
+// call, so callers must consume (encode/write) it before processing the next
+// chunk — which the streaming capture path does.
+func (d *StreamDownconverter) Process(chunk []complex64) []complex64 {
+	out := d.ddc.Process(d.dst, chunk)
+	// Retain the resampler's (possibly grown) output buffer to reuse next call —
+	// the standard ddc reuse idiom. The caller encodes/writes out before the
+	// next Process, so overwriting it next call is safe.
+	d.dst = out
+	return out
+}
+
+// OutRateHz returns the achieved narrowband output rate.
+func (d *StreamDownconverter) OutRateHz() float64 { return d.ddc.OutRateHz() }

--- a/internal/siglab/capture_stream_test.go
+++ b/internal/siglab/capture_stream_test.go
@@ -1,0 +1,103 @@
+package siglab
+
+import (
+	"bytes"
+	"math"
+	"testing"
+)
+
+// TestCaptureWriterMatchesEncodeCapture proves the streaming CaptureWriter emits
+// bytes identical to EncodeCapture of the whole capture, for every headerless
+// format and regardless of how the IQ is chunked. This is what lets the live
+// capture stream to disk (bounded RAM) without changing the on-disk result.
+func TestCaptureWriterMatchesEncodeCapture(t *testing.T) {
+	iq := make([]complex64, 5000)
+	for i := range iq {
+		// Include out-of-range values so the clamping paths are exercised.
+		iq[i] = complex(float32(i%13)/6-1, float32(i%7)/3-1)
+	}
+	formats := []SampleFormat{FormatU8, FormatF32, FormatS16, FormatWAV}
+	chunkings := [][]int{
+		{5000},    // single chunk
+		{1, 4999}, // tiny first chunk
+		{1000, 1000, 1000, 1000, 1000},
+		{999, 1, 2500, 0, 1500}, // includes an empty chunk
+	}
+	for _, format := range formats {
+		want := EncodeCapture(iq, format)
+		for _, sizes := range chunkings {
+			var buf bytes.Buffer
+			enc := NewCaptureWriter(&buf, format)
+			off := 0
+			var total int64
+			for _, n := range sizes {
+				if err := enc.Write(iq[off : off+n]); err != nil {
+					t.Fatalf("format %v: Write: %v", format, err)
+				}
+				off += n
+				total += int64(n)
+			}
+			if enc.Samples() != total {
+				t.Errorf("format %v chunks %v: Samples() = %d, want %d", format, sizes, enc.Samples(), total)
+			}
+			if !bytes.Equal(buf.Bytes(), want) {
+				t.Errorf("format %v chunks %v: streamed %d bytes != EncodeCapture %d bytes",
+					format, sizes, buf.Len(), len(want))
+			}
+		}
+	}
+}
+
+// TestStreamDownconverterMatchesOneShot proves the streaming narrowband DDC,
+// driven chunk-by-chunk, produces the same output as the one-shot Downconvert of
+// the whole signal — the property that lets narrowband capture stream without
+// buffering the full wideband grab.
+func TestStreamDownconverterMatchesOneShot(t *testing.T) {
+	const (
+		inRate   = 2_400_000.0
+		offset   = 100_000.0
+		targetBW = 50_000.0
+	)
+	iq := make([]complex64, 240_000) // 0.1 s
+	for i := range iq {
+		// A tone offset from DC so the mixer + decimator actually do work.
+		th := 2 * math.Pi * offset * float64(i) / inRate
+		iq[i] = complex(float32(math.Cos(th)), float32(math.Sin(th)))
+	}
+
+	want, wantRate := Downconvert(iq, inRate, offset, targetBW)
+
+	sd := NewStreamDownconverter(inRate, offset, targetBW)
+	if sd.OutRateHz() != wantRate {
+		t.Fatalf("OutRateHz = %g, want %g", sd.OutRateHz(), wantRate)
+	}
+	var got []complex64
+	for _, chunk := range chunkComplex(iq, 7) {
+		out := sd.Process(chunk)
+		got = append(got, out...) // copy out before the next Process reuses it
+	}
+	if len(got) != len(want) {
+		t.Fatalf("streamed %d samples, one-shot %d samples", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("sample %d: streamed %v != one-shot %v", i, got[i], want[i])
+		}
+	}
+}
+
+func chunkComplex(iq []complex64, n int) [][]complex64 {
+	if n < 1 {
+		n = 1
+	}
+	size := (len(iq) + n - 1) / n
+	var out [][]complex64
+	for i := 0; i < len(iq); i += size {
+		end := i + size
+		if end > len(iq) {
+			end = len(iq)
+		}
+		out = append(out, iq[i:end])
+	}
+	return out
+}

--- a/internal/siglab/synth.go
+++ b/internal/siglab/synth.go
@@ -121,22 +121,34 @@ func WriteMetadata(path string, m *Metadata) error {
 // Inverse of decodeF32.
 func encodeF32(iq []complex64) []byte {
 	buf := make([]byte, len(iq)*8)
-	for i, s := range iq {
-		binary.LittleEndian.PutUint32(buf[8*i:], math.Float32bits(real(s)))
-		binary.LittleEndian.PutUint32(buf[8*i+4:], math.Float32bits(imag(s)))
-	}
+	encodeF32Into(buf, iq)
 	return buf
+}
+
+// encodeF32Into writes the f32 encoding of iq into dst (which must be at least
+// len(iq)*8 bytes). Split out so the streaming CaptureWriter can encode chunk
+// by chunk into a reused buffer without re-implementing the byte layout.
+func encodeF32Into(dst []byte, iq []complex64) {
+	for i, s := range iq {
+		binary.LittleEndian.PutUint32(dst[8*i:], math.Float32bits(real(s)))
+		binary.LittleEndian.PutUint32(dst[8*i+4:], math.Float32bits(imag(s)))
+	}
 }
 
 // encodeU8 encodes rtl_sdr 8-bit unsigned interleaved IQ. Inverse of
 // decodeU8: maps [-1,+1] back to [0,255] centred on 127.5, clamped.
 func encodeU8(iq []complex64) []byte {
 	buf := make([]byte, len(iq)*2)
-	for i, s := range iq {
-		buf[2*i] = floatToU8(real(s))
-		buf[2*i+1] = floatToU8(imag(s))
-	}
+	encodeU8Into(buf, iq)
 	return buf
+}
+
+// encodeU8Into writes the u8 encoding of iq into dst (≥ len(iq)*2 bytes).
+func encodeU8Into(dst []byte, iq []complex64) {
+	for i, s := range iq {
+		dst[2*i] = floatToU8(real(s))
+		dst[2*i+1] = floatToU8(imag(s))
+	}
 }
 
 // encodeSW16 encodes interleaved little-endian 16-bit signed PCM IQ (I then Q,
@@ -144,11 +156,16 @@ func encodeU8(iq []complex64) []byte {
 // inverse of decodeSW16.
 func encodeSW16(iq []complex64) []byte {
 	buf := make([]byte, len(iq)*4)
-	for i, s := range iq {
-		binary.LittleEndian.PutUint16(buf[4*i:], uint16(floatToI16(real(s))))
-		binary.LittleEndian.PutUint16(buf[4*i+2:], uint16(floatToI16(imag(s))))
-	}
+	encodeSW16Into(buf, iq)
 	return buf
+}
+
+// encodeSW16Into writes the cs16 encoding of iq into dst (≥ len(iq)*4 bytes).
+func encodeSW16Into(dst []byte, iq []complex64) {
+	for i, s := range iq {
+		binary.LittleEndian.PutUint16(dst[4*i:], uint16(floatToI16(real(s))))
+		binary.LittleEndian.PutUint16(dst[4*i+2:], uint16(floatToI16(imag(s))))
+	}
 }
 
 // floatToI16 maps a normalised [-1,+1] sample to a 16-bit signed integer,

--- a/web/siglab/src/panels/CaptureRow.test.tsx
+++ b/web/siglab/src/panels/CaptureRow.test.tsx
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { CaptureRow } from "./CaptureRow";
+import type { CaptureDTO } from "../api/types";
+
+const longNamed: CaptureDTO = {
+  id: "cap123",
+  name: "capture-AIRSPY SN:256863C82B25748B-467.913MHz",
+  format: "cs16",
+  sample_rate_hz: 50_000,
+  size: 1_999_872,
+  created_at: "2026-07-18T00:00:00Z",
+};
+
+function renderRow(overrides: Partial<Parameters<typeof CaptureRow>[0]> = {}) {
+  const props = {
+    capture: longNamed,
+    selected: false,
+    inCompare: false,
+    downloadURL: "/api/v1/siglab/captures/cap123/download",
+    onSelect: vi.fn(),
+    onToggleCompare: vi.fn(),
+    onRemove: vi.fn(),
+    ...overrides,
+  };
+  return { props, ...render(<ul>{<CaptureRow {...props} />}</ul>) };
+}
+
+describe("CaptureRow", () => {
+  it("exposes a persistent per-capture download link with the right href", () => {
+    renderRow();
+    const dl = screen.getByRole("link", { name: /download capture/i });
+    expect(dl).toHaveAttribute("href", "/api/v1/siglab/captures/cap123/download");
+    expect(dl).toHaveAttribute("download");
+  });
+
+  it("truncates the name but keeps it in a title for the full value", () => {
+    renderRow();
+    const nameEl = screen.getByText(longNamed.name);
+    // The `truncate` utility plus a min-w-0 parent is what keeps a long name
+    // from pushing the cmp checkbox and controls out of the card.
+    expect(nameEl).toHaveClass("truncate");
+    expect(nameEl).toHaveAttribute("title", longNamed.name);
+  });
+
+  it("renders a clickable cmp checkbox that toggles compare", () => {
+    const { props } = renderRow();
+    const cmp = screen.getByRole("checkbox");
+    expect(cmp).not.toBeChecked();
+    fireEvent.click(cmp);
+    expect(props.onToggleCompare).toHaveBeenCalledTimes(1);
+  });
+
+  it("reflects the compare and remove wiring", () => {
+    const { props } = renderRow({ inCompare: true });
+    expect(screen.getByRole("checkbox")).toBeChecked();
+    fireEvent.click(screen.getByRole("button", { name: /remove capture/i }));
+    expect(props.onRemove).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/siglab/src/panels/CaptureRow.tsx
+++ b/web/siglab/src/panels/CaptureRow.tsx
@@ -1,0 +1,73 @@
+import type { CaptureDTO } from "../api/types";
+
+// CaptureRow is one entry in the captures list. It is a pure presentational
+// component (no store/router coupling) so it can be unit-tested directly, and
+// so the layout fixes below are self-contained:
+//
+//   - The name button is `min-w-0` so its `truncate` child can actually shrink;
+//     without it a long staged name (e.g. "capture-AIRSPY SN:…-467.913MHz")
+//     forces the flex row wider than the card and pushes the cmp checkbox and
+//     the delete button out of view (and out of reach).
+//   - The cmp label, the download link, and the delete button are `shrink-0`
+//     so they always stay inside the card and remain clickable.
+//   - A persistent per-row Download link (⭳) exports the staged .cfile via the
+//     backend download endpoint — the recorded capture is now always saveable
+//     straight from the list, not only from a transient link on the last grab.
+export function CaptureRow({
+  capture,
+  selected,
+  inCompare,
+  downloadURL,
+  onSelect,
+  onToggleCompare,
+  onRemove,
+}: {
+  capture: CaptureDTO;
+  selected: boolean;
+  inCompare: boolean;
+  downloadURL: string;
+  onSelect: () => void;
+  onToggleCompare: () => void;
+  onRemove: () => void;
+}) {
+  return (
+    <li
+      className={`flex items-center gap-2 rounded-md px-2 py-1.5 text-sm ${
+        selected ? "bg-accent/15" : "hover:bg-panel"
+      }`}
+    >
+      <button className="min-w-0 flex-1 text-left" onClick={onSelect}>
+        <div className="truncate" title={capture.name}>
+          {capture.name}
+        </div>
+        <div className="text-xs text-muted">
+          {capture.format} ·{" "}
+          {capture.sample_rate_hz ? `${capture.sample_rate_hz} Hz` : "rate?"} ·{" "}
+          {(capture.size / 1024).toFixed(0)} KiB
+        </div>
+      </button>
+      <label className="flex shrink-0 items-center gap-1 text-xs text-muted">
+        <input type="checkbox" checked={inCompare} onChange={onToggleCompare} />
+        cmp
+      </label>
+      <a
+        className="shrink-0 text-xs text-muted hover:text-fg"
+        href={downloadURL}
+        download
+        title="Download capture"
+        aria-label="Download capture"
+        onClick={(e) => e.stopPropagation()}
+      >
+        ⭳
+      </a>
+      <button
+        className="shrink-0 text-xs text-err/80 hover:text-err"
+        onClick={onRemove}
+        title="Remove capture"
+        aria-label="Remove capture"
+      >
+        ✕
+      </button>
+    </li>
+  );
+}

--- a/web/siglab/src/panels/Captures.tsx
+++ b/web/siglab/src/panels/Captures.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useStore } from "../store/shared";
 import { api } from "../api/client";
+import { CaptureRow } from "./CaptureRow";
 import type { CaptureDTO, CaptureDevice, RunConfig } from "../api/types";
 
 export function Captures() {
@@ -11,6 +12,7 @@ export function Captures() {
   const toggleCompare = useStore((s) => s.toggleCompare);
   const compareIds = useStore((s) => s.compareIds);
   const removeCapture = useStore((s) => s.removeCapture);
+  const config = useStore((s) => s.config);
   const selected = captures.find((c) => c.id === selectedId);
 
   return (
@@ -27,34 +29,16 @@ export function Captures() {
           ) : (
             <ul className="space-y-1">
               {captures.map((c) => (
-                <li
+                <CaptureRow
                   key={c.id}
-                  className={`flex items-center gap-2 rounded-md px-2 py-1.5 text-sm ${
-                    c.id === selectedId ? "bg-accent/15" : "hover:bg-panel"
-                  }`}
-                >
-                  <button className="flex-1 text-left" onClick={() => select(c.id)}>
-                    <div className="truncate">{c.name}</div>
-                    <div className="text-xs text-muted">
-                      {c.format} · {c.sample_rate_hz ? `${c.sample_rate_hz} Hz` : "rate?"} ·{" "}
-                      {(c.size / 1024).toFixed(0)} KiB
-                    </div>
-                  </button>
-                  <label className="flex items-center gap-1 text-xs text-muted">
-                    <input
-                      type="checkbox"
-                      checked={compareIds.includes(c.id)}
-                      onChange={() => toggleCompare(c.id)}
-                    />
-                    cmp
-                  </label>
-                  <button
-                    className="text-xs text-err/80 hover:text-err"
-                    onClick={() => removeCapture(c.id)}
-                  >
-                    ✕
-                  </button>
-                </li>
+                  capture={c}
+                  selected={c.id === selectedId}
+                  inCompare={compareIds.includes(c.id)}
+                  downloadURL={api.captureDownloadURL(config, c.id)}
+                  onSelect={() => select(c.id)}
+                  onToggleCompare={() => toggleCompare(c.id)}
+                  onRemove={() => removeCapture(c.id)}
+                />
               ))}
             </ul>
           )}


### PR DESCRIPTION
## Summary

A Discord tester hit a cluster of problems in the Signal-Lab **"Capture from tuner"** panel: 30s captures hung on "Capturing…" (10s worked), the staged capture name overflowed the card and pushed the `cmp` checkbox out of reach, the 30s ceiling was too small, and there was no obvious way to export a recorded capture. Root cause of the hang was the capture handler running under the server's 30s `WriteTimeout`; a capture of N seconds inherently takes ≥N seconds of real-time collection plus a large file write, so a 30s grab crossed the deadline and the response was torn down. Fixing that exposed a second problem — the whole capture was buffered in RAM twice — so this branch also streams the capture to disk to decouple max duration from memory, and then unifies the CLI capture paths on the same streaming writer.

Three cleanly-separated commits: the bug fix (with a failing-first regression test), the streaming refactor (behaviour-preserving), and a DRY follow-up + CHANGELOG.

## Changes

**Fix — 30s hang, UI, and export (`3ca92af`)**
- Disable the per-request `WriteTimeout` in `handleSiglabCapture`, mirroring the SSE and audio-stream handlers (`internal/api/sse.go`) — the actual hang fix.
- Raise `maxCaptureSeconds` 30 → 120, paired with a `maxCaptureIQBytes` budget checked up front so a high-rate grab is rejected with an actionable 400 instead of OOM-ing the daemon.
- Frontend: extract a testable `CaptureRow`; add `min-w-0`/`shrink-0` so a long name truncates and the `cmp` checkbox/controls stay in-card and clickable; add a persistent per-row **Download** link hitting the existing `GET /captures/{id}/download` endpoint (previously the only link was transient form state, so it appeared to "show up after two captures").

**Refactor — stream capture to disk (`437e43a`)**
- `siglab.CaptureWriter`: an `io.Writer` streaming encoder (reuses one scratch buffer) whose output is byte-identical to `EncodeCapture` of the whole capture.
- `siglab.StreamDownconverter`: a persistent `ccdecoder.Downconverter` driven chunk-by-chunk; NCO + polyphase-FIR state carries across calls, so narrowband streams too and stays bit-equivalent to the one-shot `Downconvert`.
- `CaptureProvider.Capture` → `CaptureStream(sink func([]complex64) error)`: the daemon provider hands each broker chunk to the sink instead of buffering; the handler validates the narrowband span + builds the DDC up front (out-of-span now 400s before pinning the tuner) and streams via `bufio` to the staged file with partial-file cleanup on error.
- `maxCaptureIQBytes` is now an on-disk size guard (RAM is no longer the constraint), estimated format-aware. Peak memory is one chunk + small FIR state regardless of capture length.

**Follow-up — unify CLI capture paths + CHANGELOG (`77821d9`)**
- Point `gophertrunk capture` (`captureToFile`) and the daemon `--iq-capture` (`runIQCapture`) at `siglab.CaptureWriter` and delete their duplicate, byte-identical streaming encoders (`encodeF32`/`encodeU8`/`encodeS16` + clip helpers, ~65 lines). All three capture paths now share one streaming encoder; on-disk bytes unchanged (round-trip/clip tests now build expected bytes from `siglab.EncodeCapture`).
- Add CHANGELOG `## [Unreleased]` entries (a `Fixed` bullet for the hang/UI/export, a `Changed` bullet for stream-to-disk).

## Test plan

- [x] `make vet test` is green locally
- [x] `make integration` is green locally (with `-race`) — the daemon capture provider/CLI paths changed
- [x] Added or updated tests where appropriate:
  - `TestSiglabCaptureSurvivesWriteTimeout` — real server with a small `WriteTimeout` + slow provider; **fails first** (response torn down → `EOF`) without the fix, passes with it.
  - `TestCaptureWriterMatchesEncodeCapture` / `TestStreamDownconverterMatchesOneShot` — prove streaming output == buffered output (byte- and sample-identical across chunkings).
  - `TestSiglabCaptureStreamsMultipleChunks` — staged file equals `EncodeCapture` of the whole when delivered in 17 chunks.
  - Web: `CaptureRow.test.tsx` (download link href/`download`, truncation, cmp toggle); `npm run test` + `npm run build` green.
  - Updated the provider-timeout, over-budget, seconds-ceiling, and CLI round-trip/clip tests.
- [ ] Smoke-tested against real hardware — n/a in this environment; the byte/sample-identity tests stand in for the on-air result, and the hang fix is covered by the WriteTimeout regression test.

## Breaking changes

None for operators. Internally, the `api.CaptureProvider` interface method changed from `Capture` (returns the whole slice) to `CaptureStream` (chunk sink); the only implementer is the daemon's `captureProvider`, updated here. The `POST /api/v1/siglab/capture` request/response shape is unchanged.

## Docs / CHANGELOG

- [x] Added `## [Unreleased]` bullets to `CHANGELOG.md` for the user-visible capture fixes and the stream-to-disk change.
- [ ] README/docs — no operator-facing doc changes needed (formats/narrowband behaviour is unchanged).

## Linked issues

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)