### PR TITLE
ccdecoder: bounded ratio search for the DDC cap-exceeded fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ for tagged releases.
 ## [Unreleased]
 
 ### Fixed
+- **The narrowband down-converter no longer shifts the channel rate on SDR
+  sample rates that don't divide cleanly into the channel target.** When a
+  capture rate reduced to a ratio past the resampler's L/M caps, `ccdecoder`'s
+  DDC fell back to a crude integer decimator that missed the target rate by up
+  to a few percent — e.g. a 3.019 MS/s stream landed the 144 kHz TETRA channel
+  at 143762 Hz, i.e. 17970 sym/s instead of 18000 (−0.165%), a decode-breaking
+  symbol-clock error. It now falls back to the closest L/M under the caps (the
+  bounded search already used in the wideband `internal/dsp/tuner` path for
+  issue #550), landing the same stream at 143998 Hz (17999.8 sym/s). Standard
+  SDR rates (2.4/2.5/10 MS/s) reduce cleanly and are unaffected.
 - **Completed-call webhook now carries the source RID on nearly every call,
   not just the ~18% whose voice-side `call.source` decoded.** The per-call
   `broadcast.webhook` sink read the source RID off the grant that *bound* the

--- a/internal/scanner/ccdecoder/ddc.go
+++ b/internal/scanner/ccdecoder/ddc.go
@@ -176,21 +176,51 @@ func (d *Downconverter) Reset() {
 	}
 }
 
-// ddcRatio reduces target/in to its lowest L/M terms. A non-standard
-// SDR rate can reduce to a pathologically large ratio; since the
-// output rate only needs to be *roughly* 48 kHz, those fall back to
-// a pure integer decimator (L=1).
+// ddcRatio reduces target/in to its lowest L/M terms so the resampler
+// lands the output rate exactly on target. A non-standard SDR rate can
+// reduce to a pathologically large ratio (L>64 branches or M>8192);
+// rather than a crude integer decimator (L=1, M=round(in/target)) —
+// which silently shifts the achieved rate, and therefore the recovered
+// symbol rate, by up to a few percent — it falls back to the closest
+// L/M under the caps. For a 3.019 MS/s capture the old fallback landed
+// the 144 kHz TETRA channel at 143762 Hz (17970 baud, −0.165% — the
+// "baud drift" signature); the bounded search lands it at 143998 Hz
+// (17999.8 baud, −0.001%).
+//
+// This is the issue #550 fix already proven in internal/dsp/tuner
+// (bestRatioUnderCaps); porting it here closes the "two separate DDC
+// paths" divergence CLAUDE.md #764/#771 warns about. Standard SDR rates
+// (2.4/2.5/10 MS/s, common USRP rates) reduce cleanly and never reach
+// the fallback, so they are unaffected.
 func ddcRatio(target, in int) (l, m int) {
 	g := gcd(target, in)
 	l, m = target/g, in/g
 	if l > 64 || m > 8192 {
-		l = 1
-		m = int(math.Round(float64(in) / float64(target)))
-		if m < 1 {
-			m = 1
-		}
+		l, m = bestRatioUnderCaps(float64(target) / float64(in))
 	}
 	return l, m
+}
+
+// bestRatioUnderCaps returns the L/M (L in 1..64, M in 1..8192) whose ratio is
+// closest to r. O(64) and reached only on the cap-exceeded fallback, so it has
+// no per-sample cost. Mirrors internal/dsp/tuner.bestRatioUnderCaps (issue
+// #550) so both down-converter paths reduce a pathological rate the same way
+// instead of the old integer decimator that shifted the achieved rate.
+func bestRatioUnderCaps(r float64) (l, m int) {
+	bestL, bestM := 1, 1
+	bestErr := math.Inf(1)
+	for li := 1; li <= 64; li++ {
+		mi := int(math.Round(float64(li) / r))
+		if mi < 1 {
+			mi = 1
+		} else if mi > 8192 {
+			mi = 8192
+		}
+		if e := math.Abs(float64(li)/float64(mi) - r); e < bestErr {
+			bestErr, bestL, bestM = e, li, mi
+		}
+	}
+	return bestL, bestM
 }
 
 func gcd(a, b int) int {

--- a/internal/scanner/ccdecoder/ddc_test.go
+++ b/internal/scanner/ccdecoder/ddc_test.go
@@ -110,6 +110,37 @@ func TestDownconverterDecimationRate(t *testing.T) {
 	}
 }
 
+// TestDownconverterCapFallbackRate: a wideband SDR rate whose exact
+// reduction to the channel target exceeds the L/M caps must fall back to
+// the closest representable ratio (issue #550 bounded search), not the
+// old integer decimator that shifted the achieved rate by up to a few
+// percent. A 3.019 MS/s capture landed the 144 kHz TETRA channel at
+// 143762 Hz (17970 baud, −0.165%) under the old fallback; the bounded
+// search must keep it within 0.1% of target, and standard rates that
+// never trip the caps must still land exactly.
+func TestDownconverterCapFallbackRate(t *testing.T) {
+	const tetra = 144_000.0
+	// Rates whose exact target/in reduction trips the L>64 / M>8192 caps.
+	for _, in := range []float64{3_019_000, 2_999_999, 1_500_001} {
+		got := NewDownconverter(in, tetra).OutRateHz()
+		if rel := math.Abs(got-tetra) / tetra; rel > 0.001 {
+			t.Errorf("in=%.0f: OutRateHz = %.1f, want within 0.1%% of %.0f (got %.3f%%)",
+				in, got, tetra, rel*100)
+		}
+	}
+	// Standard rates reduce cleanly and must remain exact for both the
+	// 48 kHz C4FM target and the 144 kHz TETRA target — the fallback must
+	// not perturb rates that never trip the caps.
+	for _, tc := range []struct{ in, target float64 }{
+		{2_048_000, 48_000}, {2_400_000, 48_000},
+		{2_400_000, 144_000}, {2_500_000, 144_000}, {10_000_000, 144_000},
+	} {
+		if got := NewDownconverter(tc.in, tc.target).OutRateHz(); math.Abs(got-tc.target) > 1e-6 {
+			t.Errorf("in=%.0f→%.0f: OutRateHz = %.3f, want exact", tc.in, tc.target, got)
+		}
+	}
+}
+
 // TestDownconverterIsolatesChannel: an in-channel tone survives the
 // decimation at ~unity gain while an out-of-band interferer (which
 // would otherwise alias straight into the passband) is rejected by


### PR DESCRIPTION
## Summary

Investigating a "TETRA baud drifts to 17970" report, I found a real symbol-clock
error in `ccdecoder`'s down-converter: when a capture rate reduces to an L/M
ratio past the resampler caps, the DDC fell back to a crude integer decimator
(`L=1, M=round(in/target)`) that misses the channel target by up to a few
percent. A 3.019 MS/s stream lands the 144 kHz TETRA channel at 143762 Hz — i.e.
17970 sym/s instead of 18000 (−0.165%), the exact "baud drift" signature — and
the wrong rate breaks decode. The wideband `internal/dsp/tuner` path already
fixed this (issue #550) with a bounded closest-ratio search; this ports the same
fix to the single-channel `ccdecoder` path so both down-converters agree.

Context / caveat: this is **not** a full fix for the original off-air TETRA
captures that prompted the report. Those captures (36/50/100 kHz slices) don't
trip this fallback, and diagnosis showed they fail later in BSCH/SCH-HD channel
decode — sync correlates at `best_dist=0` with the right 255-symbol framing, but
every frame fails CRC, so the colour code is never acquired. That's a separate,
deeper decoder-robustness problem (the receiver decodes an ideal synthesized
signal fine but not real off-air ones). This PR lands the one genuine,
self-contained bug the investigation surfaced; the channel-decode work is
intended follow-up.

Note: an earlier revision of this branch also normalised narrowband captures up
to the channel rate (interpolating a sub-target slice to 8 sps). That was
dropped — it regressed `TestDaemonCCDecodesTETRA` (a 72 kHz decode that worked
via pass-through) and showed no demonstrated benefit (an ideal 36 kHz synth
already locked at 2 sps, and the real captures fail at CRC regardless of rate).

## Changes

- `internal/scanner/ccdecoder/ddc.go`: replace `ddcRatio`'s integer-decimator
  fallback with `bestRatioUnderCaps` (L∈1..64, M∈1..8192, closest ratio),
  mirroring `internal/dsp/tuner.bestRatioUnderCaps`. Only the cap-exceeded path
  changes; clean reductions and every standard SDR rate are untouched.
- `internal/scanner/ccdecoder/ddc_test.go`: `TestDownconverterCapFallbackRate`
  pins cap-tripping rates within 0.1% of target (144 kHz TETRA and 48 kHz C4FM)
  and confirms standard rates stay exact.
- `CHANGELOG.md`: `## [Unreleased]` bullet.

## Test plan

- [x] `make vet test` is green locally
- [x] `make integration` is green locally (touches the shared DDC the daemon uses)
- [x] Added or updated tests where appropriate
- [ ] Smoke-tested against real hardware — n/a (no SDR available; verified with
      the 3.019/2.999/1.500 MS/s rates that trip the fallback and standard
      2.4/2.5/10 MS/s rates that don't)

## Breaking changes

None. Standard SDR rates never reach the fallback, so their L/M and achieved
output rate are byte-for-byte unchanged; only rates that previously landed on a
*wrong* rate change — to a more-correct one.

## Docs / CHANGELOG

- [x] Added a `## [Unreleased]` bullet to `CHANGELOG.md`
- [ ] Updated `README.md` / `docs/` — n/a (no operator-facing behaviour change)

## Linked issues

n/a (reported via Discord; no tracked issue). The deeper off-air TETRA
channel-decode gap is intended follow-up, not closed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)