### PR TITLE
Two open-issue fixes: #915 source RID by channel; #753 RTL V4 retune stall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ for tagged releases.
   reflects the radio actually keyed on the traffic channel — still takes
   precedence, and the republish fires only on the first fill so the repeated
   control-channel grant stream never floods the bus (issue #915).
+  Follow-up: on a heavily-compressed Phase 2 system a field test found that
+  talkgroup-keyed matching alone reached only ~12% coverage, because the
+  RID-bearing grant often arrives under a *different* talkgroup label than the
+  source-less grant that bound the call (a mis-aliased compressed grant, or a
+  super-group/patch remap). The engine now also recovers the source by physical
+  channel: a frequency + timeslot hosts exactly one in-progress transmission, so
+  a source-carrying grant landing on an active call's exact channel is folded
+  onto that call regardless of its talkgroup label — which additionally
+  suppresses the phantom duplicate call the mismatched talkgroup would otherwise
+  spawn (issue #915).
 
 ## [v0.7.1] — 2026-07-16
 

--- a/internal/trunking/engine.go
+++ b/internal/trunking/engine.go
@@ -415,6 +415,30 @@ func (e *Engine) HandleGrant(g Grant) {
 		}
 	}
 
+	// Physical-channel source backfill (#915). The talkgroup dedup above
+	// recovers a source RID only from a repeat grant that matches the bound
+	// call's (System, talkgroup, timeslot). The reporter's #916 field test
+	// showed that reaches ~12% coverage on a heavily-compressed Phase 2 system
+	// because the RID-bearing grant usually arrives under a *different*
+	// talkgroup identity than the source-less grant that bound the call, so it
+	// misses that match and — with a free device — would spawn a phantom second
+	// call from the mismatched talkgroup. A frequency + timeslot hosts exactly
+	// one in-progress transmission, so a source-carrying grant on an active
+	// call's exact channel belongs to that call: fold the RID on (only when the
+	// source is still unknown) and treat the grant as a repeat of that call,
+	// both recovering the source for the completed-call webhook and suppressing
+	// the duplicate call. Republish the source-update on the first fill only —
+	// the same path the talkgroup backfill and in-call call.source updates use.
+	if g.SourceID != 0 && g.FrequencyHz != 0 {
+		if serial, upd, filled := e.pool.BackfillSourceForChannel(g.System, g.FrequencyHz, g.Timeslot, g.SourceID); filled {
+			e.pool.Touch(serial, e.now())
+			e.republishCallSource(serial, upd)
+			e.log.Debug("grant matched active call by channel; source backfilled",
+				"grant", g.String(), "device", serial)
+			return
+		}
+	}
+
 	// 1) Free device available? Allocate. FindFreeForFrequency skips
 	// virtual voice tuners whose wideband window doesn't cover the
 	// grant — so a P25 voice grant outside the wideband band falls

--- a/internal/trunking/engine_test.go
+++ b/internal/trunking/engine_test.go
@@ -1160,6 +1160,126 @@ func TestEngineHandleGrantSourceBackfillDoesNotClobberOrReflood(t *testing.T) {
 	}
 }
 
+// TestEngineHandleGrantBackfillsSourceByChannelDespiteTalkgroupMismatch
+// covers the residual #915 coverage gap the repeat-grant backfill
+// (TestEngineHandleGrantBackfillsSourceFromRepeatGrant) could not reach.
+// The reporter's #916 field test on Victorian MMR (heavily Phase 2 TDMA)
+// showed source-RID coverage rising only to ~12%: the RID-bearing grant
+// "arrives after the call binds with a different talkgroup identity", so it
+// never matches the (System, talkgroup, timeslot) dedup that the repeat-grant
+// backfill keys on. A physical channel + timeslot hosts exactly one in-
+// progress transmission (Grant.Timeslot documents (FrequencyHz, Timeslot) as
+// the call identity), so a source-carrying grant landing on an active call's
+// exact channel belongs to that call even when its talkgroup label differs —
+// a mis-aliased compressed grant, or a super-group / patch remap. The engine
+// must fold that RID onto the bound call by channel, republish it for the
+// completed-call webhook, and NOT spawn a phantom second call from the
+// mismatched talkgroup.
+func TestEngineHandleGrantBackfillsSourceByChannelDespiteTalkgroupMismatch(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	pool, _ := mkPool(2) // a free second device makes the phantom-call regression observable
+	e, _ := NewEngine(EngineOptions{
+		Bus:         bus,
+		VoicePool:   pool,
+		Talkgroups:  NewTalkgroupDB(),
+		CallTimeout: 5 * time.Second,
+	})
+
+	// The call binds from a source-less compressed grant on TS1: src=0, and a
+	// talkgroup label of 20001.
+	bind := Grant{System: "MMR", Protocol: "p25-phase2", GroupID: 20001, Timeslot: 1, FrequencyHz: 422_612_500}
+	e.HandleGrant(bind)
+	actives := e.ActiveCalls()
+	if len(actives) != 1 {
+		t.Fatalf("expected 1 active call after bind, got %d", len(actives))
+	}
+	dev := actives[0].Device.Serial
+
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	// The RID-bearing grant for the SAME physical channel/timeslot arrives
+	// under a different talkgroup identity (20050) than the call bound with.
+	ridGrant := Grant{System: "MMR", Protocol: "p25-phase2", GroupID: 20050, Timeslot: 1,
+		FrequencyHz: 422_612_500, SourceID: 202419}
+	e.HandleGrant(ridGrant)
+
+	updated := e.ActiveCalls()
+	if len(updated) != 1 {
+		t.Fatalf("mismatched-talkgroup grant on an active channel must not spawn a second call: got %d active", len(updated))
+	}
+	if updated[0].Device.Serial != dev {
+		t.Fatalf("backfill rebound the call to a different device: got %q want %q", updated[0].Device.Serial, dev)
+	}
+	if updated[0].Grant.SourceID != 202419 {
+		t.Fatalf("source RID not backfilled onto the channel's bound call: got %d want 202419", updated[0].Grant.SourceID)
+	}
+	// The call keeps the talkgroup it bound under, not the RID grant's label.
+	if updated[0].Grant.GroupID != 20001 {
+		t.Errorf("channel backfill changed the call's talkgroup: got %d want 20001", updated[0].Grant.GroupID)
+	}
+
+	// The backfill must republish a source-update carrying the call's own
+	// identity (talkgroup 20001) so the recorder patches the completed-call
+	// (webhook) grant.
+	select {
+	case ev := <-sub.C:
+		if ev.Kind != events.KindCallSourceUpdate {
+			t.Fatalf("expected KindCallSourceUpdate republish, got %s", ev.Kind)
+		}
+		c, ok := ev.Payload.(CallSourceUpdate)
+		if !ok {
+			t.Fatalf("payload type = %T", ev.Payload)
+		}
+		if c.DeviceSerial != dev || c.System != "MMR" || c.GroupID != 20001 || c.SourceID != 202419 {
+			t.Errorf("enriched source-update payload = %+v", c)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("channel backfill did not republish a KindCallSourceUpdate")
+	}
+}
+
+// TestEngineChannelBackfillRespectsTimeslotAndSystem guards the physical-
+// channel key of the #915 backfill against source leakage: a DMR Tier III
+// carrier runs two independent calls on one frequency (TS1 + TS2), so a
+// source grant on TS2 must never fold its RID onto the TS1 call sharing the
+// frequency, and a grant on another system's identical frequency must never
+// match either.
+func TestEngineChannelBackfillRespectsTimeslotAndSystem(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	pool, _ := mkPool(3)
+	e, _ := NewEngine(EngineOptions{
+		Bus:         bus,
+		VoicePool:   pool,
+		Talkgroups:  NewTalkgroupDB(),
+		CallTimeout: 5 * time.Second,
+	})
+
+	// A source-less TS1 call on a shared carrier.
+	e.HandleGrant(Grant{System: "DMR3", Protocol: "dmr", GroupID: 100, Timeslot: 1, FrequencyHz: 421_000_000})
+	ts1 := e.ActiveCalls()[0].Device.Serial
+
+	// A source-carrying grant on TS2 of the SAME frequency must bind its own
+	// call, not backfill the TS1 call.
+	e.HandleGrant(Grant{System: "DMR3", Protocol: "dmr", GroupID: 200, Timeslot: 2, FrequencyHz: 421_000_000, SourceID: 555})
+	for _, ac := range e.ActiveCalls() {
+		if ac.Device.Serial == ts1 && ac.Grant.SourceID != 0 {
+			t.Fatalf("TS2 grant leaked its source onto the TS1 call: got %d", ac.Grant.SourceID)
+		}
+	}
+
+	// A source-carrying grant on another system's identical frequency+timeslot
+	// must not touch the DMR3 TS1 call either.
+	e.HandleGrant(Grant{System: "OTHER", Protocol: "dmr", GroupID: 100, Timeslot: 1, FrequencyHz: 421_000_000, SourceID: 777})
+	for _, ac := range e.ActiveCalls() {
+		if ac.Device.Serial == ts1 && ac.Grant.SourceID != 0 {
+			t.Fatalf("cross-system grant leaked its source onto the TS1 call: got %d", ac.Grant.SourceID)
+		}
+	}
+}
+
 // TestEngineHandleCallSourceUpdateUnknownDeviceDoesNotPanic guards
 // the late-arriving PDU after a call ends.
 func TestEngineHandleCallSourceUpdateUnknownDeviceDoesNotPanic(t *testing.T) {

--- a/internal/trunking/voicepool.go
+++ b/internal/trunking/voicepool.go
@@ -495,3 +495,40 @@ func (p *VoicePool) BackfillSourceFromGrant(serial string, sourceID uint32) (Gra
 	ac.Grant.SourceID = sourceID
 	return ac.Grant, true
 }
+
+// BackfillSourceForChannel folds a control-channel grant's source RID onto the
+// active call occupying a physical channel — identified by (system, frequency,
+// timeslot) — regardless of the grant's talkgroup label. It is the wider net
+// BackfillSourceFromGrant (keyed on the call's talkgroup) can't cast: on a
+// heavily-compressed Phase 2 system the RID-bearing GRP_VCH_GRANT for a call
+// frequently arrives under a *different* talkgroup than the source-less grant
+// that bound the call (a mis-aliased compressed grant, or a super-group / patch
+// remap), so it never matches the talkgroup dedup — the residual ~88% of the
+// #915 coverage gap the reporter measured. A frequency + timeslot hosts exactly
+// one in-progress transmission (see Grant.Timeslot, which documents
+// (FrequencyHz, Timeslot) as the engine's call identity), so a source-carrying
+// grant on an active call's exact channel belongs to that call.
+//
+// Fill-only-when-zero, like BackfillSourceFromGrant: an in-call
+// GROUP_VOICE_CHANNEL_USER (UpdateSource) still wins, and a later grant never
+// clobbers a known RID. Returns the bound device serial, the updated Grant, and
+// filled=true only on the first fill of a previously-zero source — so the engine
+// republishes the source-update once per call. Returns ("", zero, false) when
+// sourceID or freqHz is zero, or no channel-matching call has an unset source.
+// Issue #915.
+func (p *VoicePool) BackfillSourceForChannel(system string, freqHz uint32, timeslot uint8, sourceID uint32) (serial string, g Grant, filled bool) {
+	if sourceID == 0 || freqHz == 0 {
+		return "", Grant{}, false
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for s, ac := range p.active {
+		if ac.Grant.System != system || ac.Grant.FrequencyHz != freqHz ||
+			ac.Grant.Timeslot != timeslot || ac.Grant.SourceID != 0 {
+			continue
+		}
+		ac.Grant.SourceID = sourceID
+		return s, ac.Grant, true
+	}
+	return "", Grant{}, false
+}


### PR DESCRIPTION
Two independent open-issue fixes, one commit each on the shared review branch.

---

## Commit 1 — trunking: recover completed-call source RID by physical channel (#915)

Follow-up to #916. The completed-call `broadcast.webhook` still landed a source
RID on only ~12% of calls on a heavily-compressed P25 Phase 2 system (the
reporter's field test on Victorian MMR). #916 recovers a source RID only from a
repeat grant matching the bound call's `(System, talkgroup, timeslot)`, but on
this system the RID-bearing `GRP_VCH_GRANT` usually arrives under a **different
talkgroup label** than the source-less grant that bound the call (a mis-aliased
compressed grant, or a super-group/patch remap), so it never matches — and, with
a free voice device, would spawn a phantom second call from the mismatched
talkgroup.

A frequency + timeslot hosts exactly one in-progress transmission — the engine
already documents `(FrequencyHz, Timeslot)` as the call identity — so a
source-carrying grant landing on an active call's exact channel belongs to that
call regardless of its talkgroup label. `HandleGrant` now recovers the RID by
physical channel, filling the webhook source and suppressing the phantom call.
Fill-only-when-zero, so an in-call `call.source` still wins and a later grant
never clobbers a known RID.

- `VoicePool.BackfillSourceForChannel`
- Tests: `TestEngineHandleGrantBackfillsSourceByChannelDespiteTalkgroupMismatch`
  (fails first), `TestEngineChannelBackfillRespectsTimeslotAndSystem` (leakage guard)

Refs #915

## Commit 2 — rtlsdr: recover RTL-SDR Blog V4 retune from a control-pipe stall (#753)

The V4's R828D intermittently STALLs a demod control write mid-run — most
visibly the `SetI2CRepeater` toggle inside a `SetCenterFreq` retune — which
surfaced as a raw `EPIPE` ("broken pipe") on Linux usbdevfs (or `ErrPipeStalled`
on Windows) and aborted the whole tune, even though `rtl_test`/SDR++ tune the
same dongle cleanly (libusb recovers a control-pipe stall). GopherTrunk's native
stack recovered such stalls only on the open-time bring-up path (full device
reset) and on the tuner burst path (`writeBurstChunk` inner retry); the runtime
demod control path had none.

The demod/block register control transfers now settle and retry once on a
control-pipe stall (`EPIPE ‖ ErrPipeStalled`), mirroring the tuner burst path.
The retry is armed only after bring-up completes, so the cold-boot reset envelope
is unchanged, and a full reset is deliberately not used at runtime (it would tear
down the live IQ stream mid-tune).

- `Demod.ctrlOut`/`ctrlIn` + `EnableControlStallRetry`, armed post-bring-up
- Tests: `TestSetI2CRepeater_RecoversFromControlPipeStall` (fails first; Linux +
  Windows stall forms), `TestSetI2CRepeater_StallNotRetriedDuringBringup` and
  `TestSetI2CRepeater_PersistentStallSurfaces` (guards)

Refs #753

---

## Test plan

- [x] `make vet test` green locally (full `go test -race ./...`, exit 0)
- [ ] `make integration` — n/a (engine/pool + USB register logic; no daemon/DSP/replay path)
- [x] Failing-first regression tests for both fixes; guard tests for the invariants
- [ ] Smoke-tested against real hardware — no. #915 needs the reporter's coverage
      re-measurement + grant debug log; #753 needs the reporter (@viric) to run a
      build on the RTL-SDR Blog V4 and confirm the retune no longer aborts.

## Breaking changes

None. Both are additive recovery paths; no config/CLI/REST/gRPC/default-behaviour change.

## Docs / CHANGELOG

- [x] Two `## [Unreleased]` bullets in `CHANGELOG.md`

## Linked issues

Refs #915, Refs #753

<!-- Both kept as Refs, not Closes, per the verify-before-close policy: neither is
     confirmed against the reporters' hardware yet. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
