### PR TITLE
siglab/ccdecoder: normalise sub-target captures up to the channel rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ for tagged releases.
 ## [Unreleased]
 
 ### Fixed
+- **A TETRA channel recorded as a narrowband slice below the 144 kHz channel
+  rate (e.g. the natural 48/50 kHz SDR++/SDRTrunk record rate) now decodes
+  instead of emitting a nonsense symbol rate.** The `siglab` replay/analyze
+  engine only ever *decimated* to the per-protocol channel rate — a capture
+  already at or below the target was fed to the receiver raw. For TETRA (144 kHz
+  target) that left a 50 kHz recording at 50000/18000 ≈ 2.78 samples/symbol,
+  which the receiver rounded to 3 and handed the Gardner loop as a 3.0 nominal:
+  an ~8% clock error it can't pull in, so it produced 50000/3 ≈ 16667 sym/s
+  (−7.4%) and never locked. The down-converter now *normalises* to the channel
+  rate in both directions — a sub-target capture is interpolated **up** to
+  144 kHz (`dsp.Resampler` already supports L>M), restoring the receiver's
+  designed 8 samples/symbol. A 50 kHz capture now recovers 18004.9 sym/s (+0.0%)
+  and the training sequences correlate; the committed 48 kHz `samples/tetra`
+  reference likewise normalises to exactly 144000 Hz. Only sub-target replays
+  change; every wideband SDR rate reduces exactly as before.
 - **The narrowband down-converter no longer shifts the channel rate on SDR
   sample rates that don't divide cleanly into the channel target.** When a
   capture rate reduced to a ratio past the resampler's L/M caps, `ccdecoder`'s

--- a/internal/scanner/ccdecoder/ddc.go
+++ b/internal/scanner/ccdecoder/ddc.go
@@ -74,12 +74,16 @@ const ddcKaiserBeta = 7.0
 // Downconverter decimates a wideband SDR IQ stream to a narrowband
 // channel rate.
 //
-// Decimation is a rational polyphase resample (dsp.Resampler) whose
+// Rate conversion is a rational polyphase resample (dsp.Resampler) whose
 // L/M ratio is chosen so the output rate lands exactly on the
 // requested target for every standard SDR rate. When the SDR already
-// streams at (or below) the target the resampler is skipped and the
-// chunk passes straight through — keeping the rate==target unit
-// tests (and any future low-rate SDR) on a no-op path.
+// streams at the target the resampler is skipped and the chunk passes
+// straight through — keeping the rate==target unit tests on a no-op path.
+// A wider capture is decimated to the target; a narrowband capture recorded
+// BELOW the target (e.g. a 50 kHz or 48 kHz TETRA slice, whose 144 kHz
+// channel target the live path always delivers) is interpolated UP to it, so
+// the receiver always runs at its designed samples-per-symbol rather than a
+// rounded, decode-breaking one.
 //
 // It deliberately does NOT remove the front-end DC offset: a C4FM /
 // FM control channel carries real signal energy at 0 Hz (the FM
@@ -104,10 +108,11 @@ type Downconverter struct {
 	outRateHz float64
 }
 
-// NewDownconverter builds a down-converter that decimates inRateHz to
-// ~targetHz. The exact achieved output rate is reported by
-// OutRateHz (it equals targetHz for every SDR rate that reduces to
-// a sane L/M, and equals inRateHz in pass-through mode).
+// NewDownconverter builds a down-converter that resamples inRateHz to
+// ~targetHz (decimating a wider capture, interpolating a sub-target one).
+// The exact achieved output rate is reported by OutRateHz (it equals
+// targetHz for every SDR rate that reduces to a sane L/M, and equals
+// inRateHz in the rate==target pass-through mode).
 func NewDownconverter(inRateHz, targetHz float64) *Downconverter {
 	return NewDownconverterWithOffset(inRateHz, targetHz, 0)
 }
@@ -126,8 +131,8 @@ func NewDownconverterWithOffset(inRateHz, targetHz, offsetHz float64) *Downconve
 	}
 	in := int(math.Round(inRateHz))
 	target := int(math.Round(targetHz))
-	if in <= 0 || target <= 0 || in <= target {
-		return d // pass-through decimation: the NCO mix (if any) still runs
+	if in <= 0 || target <= 0 || in == target {
+		return d // pass-through: the NCO mix (if any) still runs, no resample
 	}
 	l, m := ddcRatio(target, in)
 	tapsPerBranch := (ddcStopbandTaps*m + l - 1) / l
@@ -141,7 +146,8 @@ func NewDownconverterWithOffset(inRateHz, targetHz, offsetHz float64) *Downconve
 
 // OutRateHz returns the achieved narrowband output rate (equals the
 // requested target for standard SDR rates that reduce to a sane L/M;
-// equals inRateHz in pass-through mode). Callers building a receiver
+// equals inRateHz only when the capture is already at the target).
+// Callers building a receiver
 // against the downconverter's output should use this value for
 // SampleRateHz so matched-filter sizing matches the actual stream.
 func (d *Downconverter) OutRateHz() float64 { return d.outRateHz }

--- a/internal/scanner/ccdecoder/ddc_test.go
+++ b/internal/scanner/ccdecoder/ddc_test.go
@@ -141,6 +141,58 @@ func TestDownconverterCapFallbackRate(t *testing.T) {
 	}
 }
 
+// TestDownconverterUpsampleRate: a narrowband capture recorded BELOW the
+// channel target must be interpolated UP to the target so the receiver runs
+// at its designed samples-per-symbol, not fed raw. The motivating case is a
+// TETRA channel recorded at 50 kHz (or the natural 48 kHz SDR++/SDRTrunk
+// narrowband rate): the receiver rounds 50000/18000 = 2.78 → 3 sps and the
+// Gardner loop, told a 3.0 nominal against a 2.78 true rate, never locks —
+// emitting 50000/3 ≈ 16667 baud (−7.4%). Normalising the input to 144 kHz
+// restores 8 sps. Equality with the target must still short-circuit to the
+// byte-exact pass-through (no resampler).
+func TestDownconverterUpsampleRate(t *testing.T) {
+	const tetra = 144_000.0
+	// The narrowband rates SDR++/SDRTrunk actually record a TETRA slice at
+	// must land within 0.1% of the channel target.
+	for _, in := range []float64{50_000, 48_000} {
+		d := NewDownconverter(in, tetra)
+		if d.resampler == nil {
+			t.Errorf("in=%.0f→%.0f: expected an interpolating resampler, got pass-through", in, tetra)
+			continue
+		}
+		if rel := math.Abs(d.OutRateHz()-tetra) / tetra; rel > 0.001 {
+			t.Errorf("in=%.0f: OutRateHz = %.1f, want within 0.1%% of %.0f (got %.3f%%)",
+				in, d.OutRateHz(), tetra, rel*100)
+		}
+		// Output must grow by ~L/M (interpolation lengthens the stream).
+		out := d.Process(nil, make([]complex64, 5_000))
+		want := int(5_000 * d.OutRateHz() / in)
+		if diff := len(out) - want; diff < -16 || diff > 16 {
+			t.Errorf("in=%.0f: len(out) = %d, want %d ± 16", in, len(out), want)
+		}
+	}
+	// Equality with the target must remain a pass-through (nil resampler),
+	// guarding the in==target predicate against regressing to in<target.
+	if d := NewDownconverter(tetra, tetra); d.resampler != nil {
+		t.Errorf("rate == target must pass through (nil resampler), got a resampler")
+	}
+}
+
+// TestDownconverterUpsampleIsolatesChannel: interpolating a sub-target capture
+// up to the channel rate must preserve the in-band signal at ~unity gain and
+// not raise spectral images into the band. A +8 kHz tone (well inside a 25 kHz
+// TETRA channel) recorded at 50 kHz survives the upsample to 144 kHz.
+func TestDownconverterUpsampleIsolatesChannel(t *testing.T) {
+	const inRate, target = 50_000.0, 144_000.0
+	const n = 131_072
+	up := NewDownconverter(inRate, target).
+		Process(nil, complexTone(8_000, inRate, n, 1.0))
+	got := rms(up[200:]) // skip the interpolation start-up transient
+	if got < 0.7 || got > 1.3 {
+		t.Errorf("in-band tone after upsample: rms = %v, want ~1.0", got)
+	}
+}
+
 // TestDownconverterIsolatesChannel: an in-channel tone survives the
 // decimation at ~unity gain while an out-of-band interferer (which
 // would otherwise alias straight into the passband) is rejected by

--- a/internal/siglab/engine.go
+++ b/internal/siglab/engine.go
@@ -264,18 +264,22 @@ func ccYield(r *Result) int64 {
 func runReader(r io.Reader, source string, decode SampleDecoder, bytesPerSample int, tuneHz float64, cfg Config, onEvent func(EventRecord), mon *monitorHook) (*Result, error) {
 	logger := cfg.logger()
 
-	// Mirror the production ccdecoder DDC: decimate to the per-protocol
-	// channel rate (TETRA → 144 kHz, else 48 kHz) whenever the input is
-	// wider, and apply the tuning shift. An already-channelized capture
-	// (rate ≤ target) with no tuning passes straight through.
+	// Mirror the production ccdecoder DDC: normalise to the per-protocol
+	// channel rate (TETRA → 144 kHz, else 48 kHz) and apply the tuning shift.
+	// A wider capture is decimated; a narrowband capture recorded BELOW the
+	// target — e.g. a TETRA slice grabbed at the natural 48/50 kHz SDR++ rate,
+	// far under the 144 kHz TETRA channel target — is interpolated UP to it, so
+	// the receiver runs at its designed samples-per-symbol instead of a rounded,
+	// decode-breaking one. Only a capture already exactly at the target (no
+	// tuning) passes straight through.
 	target := ccdecoder.DDCTargetForProtocol(cfg.Protocol)
 	ddcTarget := cfg.SampleRateHz
-	if cfg.SampleRateHz > target {
+	if cfg.SampleRateHz != target {
 		ddcTarget = target
 	}
 	var ddc *ccdecoder.Downconverter
 	receiverRate := cfg.SampleRateHz
-	if tuneHz != 0 || ddcTarget < cfg.SampleRateHz {
+	if tuneHz != 0 || ddcTarget != cfg.SampleRateHz {
 		ddc = ccdecoder.NewDownconverterWithOffset(cfg.SampleRateHz, ddcTarget, tuneHz)
 		receiverRate = ddc.OutRateHz()
 	}

--- a/internal/siglab/subtarget_tetra_test.go
+++ b/internal/siglab/subtarget_tetra_test.go
@@ -1,0 +1,70 @@
+package siglab
+
+import (
+	"bytes"
+	"math"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TestReplaySubTargetTETRALocks is the end-to-end reproduction of the field
+// report: a TETRA control channel recorded as a narrowband slice BELOW the
+// 144 kHz channel target (the natural 48/50 kHz rate SDR++/SDRTrunk pick) must
+// still lock. Before the fix, the engine fed the sub-target stream to the
+// receiver raw; the receiver rounded 50000/18000 = 2.78 → 3 samples/symbol and
+// the Gardner loop — told a 3.0 nominal against a 2.78 true rate — never locked,
+// emitting 50000/3 ≈ 16667 baud (−7.4%). Normalising the input up to the
+// channel rate restores 8 sps and the lock.
+//
+// The capture is derived from the in-tree 144 kHz TETRA synth fixture by
+// decimating it to 50 kHz through the (already-working) in>target DDC path, so
+// the test needs no committed binary and exercises exactly the sub-target
+// upsample the field capture requires.
+func TestReplaySubTargetTETRALocks(t *testing.T) {
+	const captureRate = 50_000.0
+
+	iq, meta, err := Synthesize(SynthOptions{Protocol: trunking.ProtocolTETRA, Format: FormatS16})
+	if err != nil {
+		t.Fatalf("Synthesize TETRA: %v", err)
+	}
+	if meta.SampleRateHz <= captureRate {
+		t.Fatalf("fixture rate %.0f must exceed the sub-target capture rate", meta.SampleRateHz)
+	}
+
+	// Decimate the 144 kHz fixture down to a 50 kHz narrowband slice — the
+	// shape of the operator's SDR++ recording. This uses the in>target path,
+	// which already works; the fix is on the way back up.
+	slice, sliceRate := Downconvert(iq, meta.SampleRateHz, 0, captureRate)
+	if math.Abs(sliceRate-captureRate) > 1 {
+		t.Fatalf("slice rate = %.1f, want ~%.0f", sliceRate, captureRate)
+	}
+
+	sys := trunking.System{Name: "siglab", Protocol: trunking.ProtocolTETRA}
+	applySystemKnobs(&sys, meta.System)
+
+	cfg := Config{
+		Protocol:      trunking.ProtocolTETRA,
+		System:        sys,
+		SystemName:    "siglab",
+		SampleRateHz:  captureRate,
+		Format:        FormatS16,
+		CollectIQDiag: true,
+	}
+	data := EncodeCapture(slice, FormatS16)
+	res, err := RunReader(bytes.NewReader(data), "subtarget-tetra", cfg)
+	if err != nil {
+		t.Fatalf("RunReader: %v", err)
+	}
+
+	if !res.Locked {
+		t.Errorf("sub-target (%.0f Hz) TETRA did not lock; NoLockReason=%q, EffectiveBaud=%.1f (%.2f%%)",
+			captureRate, res.NoLockReason, res.EffectiveBaud, res.BaudDeviationPct)
+	}
+	// The recovered symbol rate must be ~18000, not the ~16667 the un-normalised
+	// path produced. Allow 1% for the fixture's residual clock error.
+	if math.Abs(res.BaudDeviationPct) > 1.0 {
+		t.Errorf("EffectiveBaud = %.1f (%.2f%% off 18000), want within 1%%",
+			res.EffectiveBaud, res.BaudDeviationPct)
+	}
+}


### PR DESCRIPTION
A TETRA control channel recorded as a narrowband slice below the 144 kHz
channel target — the natural 48/50 kHz rate SDR++/SDRTrunk pick for a
narrowband grab — reported a nonsense symbol rate and never locked.

The siglab replay/analyze engine only ever *decimated* to the per-protocol
channel rate: a capture already at or below the target was fed to the
receiver raw. For TETRA (144 kHz target) a 50 kHz recording arrives at
50000/18000 ~= 2.78 samples/symbol, which the receiver rounds to 3 and hands
the Gardner loop as a 3.0 nominal — an ~8% clock error it can't pull in. It
emitted 50000/3 ~= 16667 sym/s (-7.4%) and produced a garbage constellation,
exactly the field report ("16657 baud, -7.5%, NOT LOCKED"). At the production
144 kHz rate 144000/18000 = 8.0 exactly, so the rounding is a no-op and the
bug only bit sub-144 kHz captures — including the committed 48 kHz
samples/tetra reference, which is very likely why it never decoded CRC-clean.

Fix: extend ccdecoder.Downconverter from "decimate to target" to "normalise
to target (up or down)". Its resampler pass-through predicate changes from
`in <= target` to `in == target`, so a sub-target rate now builds an
interpolating resampler instead of passing through raw; dsp.Resampler already
supports L>M interpolation (cutoff = 0.5/max(L,M), gain-compensated) and
ddcRatio/bestRatioUnderCaps already handle ratios > 1. The siglab engine now
selects the channel rate as the DDC target in both directions and builds the
DDC whenever the capture rate differs from it. Keeping the change in the
shared down-converter (rather than a siglab-local upsampler) avoids the
"two separate DDC paths" divergence CLAUDE.md #764/#771 warns about and fixes
the same latent gap in the symbolscope / rfscope single-channel paths.

Only sub-target replays change; every wideband SDR rate (2.4/2.5/10 MS/s, …)
still reduces exactly as before, and a capture already at the target keeps
its byte-exact pass-through.

Verified end to end: the 50 kHz field capture now upsamples to 144118 Hz and
recovers 18004.9 sym/s (+0.0%) with the TETRA training sequences correlating
at Hamming distance 0 (previously impossible); the 48 kHz reference
normalises to exactly 144000 Hz. TestDownconverterUpsampleRate /
TestDownconverterUpsampleIsolatesChannel pin the DDC behaviour and
TestReplaySubTargetTETRALocks reproduces the field lock end to end — both
fail on the pre-fix tree and pass after.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KzMQokdtNRXdPFuykagohe