### PR TITLE
p25: gate ALGID/KID surfacing on the TIA-102 algorithm set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ for tagged releases.
 ## [Unreleased]
 
 ### Fixed
+- **Encrypted-call `algorithm_id`/`key_id` are no longer surfaced when the
+  crypto sync mis-decodes.** On P25 Phase 2 (and Phase 1's residual-error
+  tail) a bit-error in a traffic-channel Encryption Sync smears the decoded
+  Algorithm ID roughly uniformly across `0x00-0xFF`, with a near-distinct Key
+  ID per call. Those values were published straight to the completed-call
+  webhook and `/api/v1/calls/history`, where they were indistinguishable from
+  a real key (a 7-day MMR sample showed the real AES-256 `0x84` alongside a
+  flat ~4-22 calls at *every* other algid). The composer now validates the
+  decoded Algorithm ID against the TIA-102 registry (`p25.AlgorithmKnown`)
+  before publishing, so an out-of-set value is dropped and the fields stay
+  omitted rather than carrying garbage. Clear and every registered algorithm
+  pass through unchanged. Refs #813, #924.
 - **A TETRA channel recorded as a narrowband slice below the 144 kHz channel
   rate (e.g. the natural 48/50 kHz SDR++/SDRTrunk record rate) now decodes
   instead of emitting a nonsense symbol rate.** The `siglab` replay/analyze

--- a/internal/radio/p25/algorithm.go
+++ b/internal/radio/p25/algorithm.go
@@ -42,6 +42,20 @@ func AlgorithmName(id uint8) string {
 	return "unknown"
 }
 
+// AlgorithmKnown reports whether id is a registered TIA-102 Algorithm ID
+// (i.e. AlgorithmName has a mnemonic for it, clear included). It exists so
+// the call path can gate crypto metadata before surfacing it: a bit-error
+// in a traffic-channel Encryption Sync smears the Algorithm ID roughly
+// uniformly across 0x00-0xFF (with a near-distinct Key ID per call), so an
+// out-of-set value is provably a mis-decode and, surfaced, is downstream
+// indistinguishable from a real key. Callers omit algorithm_id/key_id when
+// this returns false rather than emit plausible-looking garbage. The set
+// tracks AlgorithmName, so a genuinely new algorithm is admitted the moment
+// it is added there. Issues #813, #924.
+func AlgorithmKnown(id uint8) bool {
+	return AlgorithmName(id) != "unknown"
+}
+
 // FormatAlgorithm renders id as "0x84 (AES-256)" for human-readable
 // log lines and UI tooltips. Unknown values render as "0xNN (unknown)"
 // so an operator can still cross-reference the raw ID with SDRtrunk

--- a/internal/radio/p25/algorithm_test.go
+++ b/internal/radio/p25/algorithm_test.go
@@ -22,6 +22,35 @@ func TestAlgorithmName(t *testing.T) {
 	}
 }
 
+func TestAlgorithmKnown(t *testing.T) {
+	cases := []struct {
+		id   uint8
+		want bool
+	}{
+		// Registered TIA-102 algorithms (clear included) are known.
+		{0x80, true}, // CLEAR
+		{0x81, true}, // DES-OFB
+		{0x83, true}, // TDES-2
+		{0x84, true}, // AES-256
+		{0x85, true}, // AES-128
+		{0x89, true}, // AES-256-OFB
+		{0x9F, true}, // DES-XL
+		{0xAA, true}, // ADP/RC4
+		// Bit-error smear values that a mis-decoded Encryption Sync emits
+		// must be rejected so they are never surfaced as a real key (#924).
+		{0x00, false},
+		{0x01, false},
+		{0x37, false},
+		{0x82, false},
+		{0xFF, false},
+	}
+	for _, c := range cases {
+		if got := AlgorithmKnown(c.id); got != c.want {
+			t.Errorf("AlgorithmKnown(0x%02X) = %v, want %v", c.id, got, c.want)
+		}
+	}
+}
+
 func TestFormatAlgorithm(t *testing.T) {
 	cases := []struct {
 		id   uint8

--- a/internal/voice/composer/p25p1_voice.go
+++ b/internal/voice/composer/p25p1_voice.go
@@ -10,6 +10,7 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/dsp"
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	gtlog "github.com/MattCheramie/GopherTrunk/internal/log"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/p25"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
 	p25p1rx "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1/receiver"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
@@ -403,7 +404,15 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial, system st
 					// garbage algorithm/key as a real encryption change.
 					essRSUncorrectable.Add(1)
 				}
-				if lerr == nil && es.Encrypted() {
+				if lerr == nil && es.Encrypted() && !p25.AlgorithmKnown(es.AlgorithmID) {
+					// The outer RS reported success but "corrected" to an
+					// Algorithm ID outside the TIA-102 set — a residual-error
+					// mis-decode. Surfacing it is worse than omitting it
+					// (downstream it's indistinguishable from a real key), and
+					// its MI would pollute cryptolab too, so drop it. Issue #924.
+					c.log.Debug("composer: p25p1 dropping out-of-set encryption sync",
+						"serial", serial, "alg", p25.FormatAlgorithm(es.AlgorithmID), "key", es.KeyID)
+				} else if lerr == nil && es.Encrypted() {
 					c.log.Debug("composer: p25p1 encryption sync",
 						"serial", serial, "alg", es.AlgorithmID, "key", es.KeyID)
 					// cryptolab crypto-frame bridge: hand this superframe's

--- a/internal/voice/composer/p25p2_voice.go
+++ b/internal/voice/composer/p25p2_voice.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	gtlog "github.com/MattCheramie/GopherTrunk/internal/log"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/p25"
 	p25p2 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase2"
 	p25p2rx "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase2/receiver"
 	"github.com/MattCheramie/GopherTrunk/internal/sigfollow"
@@ -338,6 +339,15 @@ func (c *Composer) publishP25Phase2CallSource(serial string, u p25p2.GroupVoiceC
 // Grant and republishes with the call's identity.
 func (c *Composer) publishP25Phase2CallEncryption(serial string, es p25p2.EncryptionSync) {
 	if c.bus == nil {
+		return
+	}
+	// Validity gate: a mis-decoded MAC Encryption Sync yields an Algorithm
+	// ID outside the TIA-102 set (the field-observed smear across 0x00-0xFF,
+	// one Key ID per call). Drop it rather than surface a plausible-but-wrong
+	// algid+key that downstream can't tell from a real key. Issue #924.
+	if !p25.AlgorithmKnown(es.AlgorithmID) {
+		c.log.Debug("composer: p25p2 dropping out-of-set encryption sync",
+			"serial", serial, "alg", p25.FormatAlgorithm(es.AlgorithmID), "key", es.KeyID)
 		return
 	}
 	c.bus.Publish(events.Event{

--- a/internal/voice/composer/p25p2_voice_test.go
+++ b/internal/voice/composer/p25p2_voice_test.go
@@ -483,6 +483,48 @@ func TestComposerP25Phase2InCallMetadataFires(t *testing.T) {
 	}
 }
 
+// TestComposerP25Phase2DropsOutOfSetEncryptionSync pins the #924 validity
+// gate: a MAC Encryption Sync whose Algorithm ID is not a registered TIA-102
+// value is a bit-error mis-decode and must not be surfaced. Before the gate
+// both syncs published, so the completed-call webhook carried a plausible
+// algid+key that downstream couldn't tell from a real one.
+func TestComposerP25Phase2DropsOutOfSetEncryptionSync(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+	c := &Composer{bus: bus, log: discardLogger()}
+
+	// Out-of-set algid (bit-error smear) — must be dropped.
+	c.publishP25Phase2CallEncryption("VOICE-1", p25p2.EncryptionSync{AlgorithmID: 0x37, KeyID: 0xABCD})
+	// Valid AES-256 — must publish.
+	c.publishP25Phase2CallEncryption("VOICE-1", p25p2.EncryptionSync{AlgorithmID: 0x84, KeyID: 0x1234})
+
+	var got []trunking.CallEncryption
+	deadline := time.After(500 * time.Millisecond)
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind != events.KindCallEncryption {
+				continue
+			}
+			ce, ok := ev.Payload.(trunking.CallEncryption)
+			if !ok {
+				t.Fatalf("KindCallEncryption payload type = %T", ev.Payload)
+			}
+			got = append(got, ce)
+		case <-deadline:
+			if len(got) != 1 {
+				t.Fatalf("published %d CallEncryption events, want 1 — the out-of-set algid must be dropped: %+v", len(got), got)
+			}
+			if got[0].AlgorithmID != 0x84 || got[0].KeyID != 0x1234 {
+				t.Fatalf("surfaced alg/key = 0x%X/0x%X, want 0x84/0x1234", got[0].AlgorithmID, got[0].KeyID)
+			}
+			return
+		}
+	}
+}
+
 // TestComposerP25Phase2VoiceChainWarnsTrellisOff confirms the chain-entry
 // diagnostic fires a warning when the grant carries TrellisOff — the
 // inconsistent FEC profile (trellis off while RS/interleave/scrambler are


### PR DESCRIPTION
## Summary

On P25 Phase 2 (and Phase 1's residual-error tail) a bit-error in a traffic-channel Encryption Sync smears the decoded Algorithm ID roughly uniformly across `0x00–0xFF`, with a near-distinct Key ID per call. Those values were surfaced straight to the completed-call webhook and `/api/v1/calls/history`, where they are **indistinguishable downstream from a real key**. er-imagery's 7-day MMR sample (#924) shows the real AES-256 (`0x84`) sitting alongside a flat ~4–22 calls at *every* other algid value — provably decode error, not signalling.

This is the concrete, verifiable half of #813: the deep Phase 2 decode-reliability question needs the reporter's real captures (network-blocked from the automation environment), but the *surfacing* of garbage crypto metadata can be fixed and unit-tested in isolation, which is exactly what #924 asks for.

## Changes

- Add `p25.AlgorithmKnown(id)` — reports whether an Algorithm ID is in the existing TIA-102 `AlgorithmName` registry (clear + registered encrypted algorithms). Single source of truth; a genuinely new algorithm is admitted the moment it's added to `AlgorithmName`.
- Gate **both** composer Encryption-Sync publish sites (`p25p1_voice.go`, `p25p2_voice.go`) on it. The composer is the single source both the recorder (→ webhook / history) and the engine (→ SSE / TUI) draw from, so one gate covers every consumer. An out-of-set algid is dropped (debug-logged), leaving `algorithm_id`/`key_id` omitted rather than emitting a plausible-but-wrong value. On Phase 1 the dropped sync is also withheld from cryptolab, whose MI would otherwise be polluted.
- Clear and every registered algorithm pass through unchanged — the gate is the sole change to the surfaced value; no protocol/FEC/DSP logic is touched.

## Test plan

- [x] `make vet test` is green locally
- [x] `make integration` is green locally
- [x] Added tests — **failing-first**:
  - `TestAlgorithmKnown` pins the valid set vs. the bit-error smear values.
  - `TestComposerP25Phase2DropsOutOfSetEncryptionSync` asserts an out-of-set algid never reaches the bus while a valid AES-256 sync still does — **2 published events before the gate, 1 after**.
- [ ] Smoke-tested against real hardware — n/a in the automation environment; the reporter's live-air verification is what confirms end-to-end.

## Breaking changes

None. `algorithm_id`/`key_id` are already `omitempty`; this only changes *which* values appear — real algids are unaffected, out-of-set garbage stops appearing.

## Docs / CHANGELOG

- [x] Added an `## [Unreleased]` bullet to `CHANGELOG.md`

## Linked issues

Refs #813, Refs #924 (left open per the verify-before-close policy).

> Note: the Phase 2 control-channel MAC opcode census for #915, which briefly shared this branch, now lives in its own PR (#929).

🤖 Generated with [Claude Code](https://claude.com/claude-code)