### PR TITLE
p25/phase2: control-channel MAC opcode census for the #915 source-RID gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Added
+- **P25 Phase 2 control-channel MAC opcode census (`--log-level debug`).** A
+  new diagnostic inventories every MAC opcode seen on the control channel —
+  logging a one-shot `payload_hex` sample the first time each opcode appears
+  plus a periodic `opcode:count` summary. Unlike the existing per-grant DEBUG
+  line, it has no survivorship bias: it also surfaces opcodes GT does not
+  currently parse as a grant, which is where a RID-bearing grant would hide on
+  a system whose completed-call `source_rid` under-populates (issue #915). The
+  raw opcode inventory + byte sample is what pins the remaining gap on a
+  missing/mis-mapped grant opcode (decode-side) vs. a call-association gap.
+
 ### Fixed
 - **A TETRA channel recorded as a narrowband slice below the 144 kHz channel
   rate (e.g. the natural 48/50 kHz SDR++/SDRTrunk record rate) now decodes

--- a/internal/radio/p25/phase2/control.go
+++ b/internal/radio/p25/phase2/control.go
@@ -1,7 +1,10 @@
 package phase2
 
 import (
+	"encoding/hex"
+	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -86,12 +89,96 @@ type ControlChannel struct {
 	// gate reads via DecodedFrames; bumped from the IQ-pump goroutine but
 	// exported as an atomic so other goroutines can sample it lock-free.
 	macDecoded atomic.Uint64
+
+	// macCensus counts, per MAC opcode, every PDU that reached Ingest.
+	// It backs the control-channel opcode census (issue #915): the
+	// per-grant DEBUG line only fires for opcodes GT already parses as a
+	// grant, so it can't reveal a RID-bearing grant arriving under an
+	// opcode GT drops or mis-maps — the leading suspect for the calls
+	// whose source RID never populates. The census has no such blind
+	// spot: it inventories the raw opcode set with a one-shot byte sample
+	// so a source-less-call log pins the remaining gap on a missing/
+	// mis-mapped opcode (decode-side) vs. an association gap. Guarded by mu.
+	macCensus map[Opcode]uint64
 }
 
 // DecodedFrames reports the cumulative count of MAC PDUs that cleared
 // FEC + CRC on this channel. It is the protocol-agnostic decode-activity
 // counter the wideband engine polls to gate per-channel power logging.
 func (c *ControlChannel) DecodedFrames() uint64 { return c.macDecoded.Load() }
+
+// MACCensus returns a snapshot of the per-opcode PDU counts observed on
+// this control channel since start. Used by tests and available for the
+// daemon/metrics to surface the opcode inventory that disambiguates the
+// #915 remaining-gap fork (missing/mis-mapped grant opcode vs association).
+func (c *ControlChannel) MACCensus() map[Opcode]uint64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make(map[Opcode]uint64, len(c.macCensus))
+	for op, n := range c.macCensus {
+		out[op] = n
+	}
+	return out
+}
+
+// censusObserve records p's opcode in the running census and logs a
+// one-shot sample (opcode + name + known-flag + payload hex) the first
+// time each distinct opcode is seen, plus a full opcode:count summary at a
+// coarse cadence. Pure telemetry — it changes no decode or dispatch
+// behaviour. See macCensus for why this exists (issue #915).
+func (c *ControlChannel) censusObserve(p MACPDU) {
+	c.mu.Lock()
+	if c.macCensus == nil {
+		c.macCensus = make(map[Opcode]uint64)
+	}
+	first := c.macCensus[p.Opcode] == 0
+	c.macCensus[p.Opcode]++
+	c.mu.Unlock()
+
+	if first {
+		c.log.Debug("p25/phase2 cc mac census: opcode seen",
+			"system", c.systemName, "freq", c.freqHz,
+			"opcode", fmt.Sprintf("0x%02X", uint8(p.Opcode)),
+			"name", p.Opcode.String(), "known", p.Opcode.IsKnown(),
+			"len", len(p.Payload), "payload_hex", hex.EncodeToString(p.Payload))
+	}
+	// Rolling frequency table, throttled to keep the log quiet. The
+	// distribution (which opcodes dominate, and whether a RID-bearing
+	// grant opcode is present at all) is what characterises a system.
+	if n := c.macDecoded.Load(); n != 0 && n%censusSummaryEvery == 0 {
+		c.log.Debug("p25/phase2 cc mac census: summary",
+			"system", c.systemName, "freq", c.freqHz,
+			"pdus", n, "opcodes", c.censusSummary())
+	}
+}
+
+// censusSummary renders the per-opcode counts as a stable, opcode-sorted
+// "0xNN(name)=count" list for a single log field.
+func (c *ControlChannel) censusSummary() string {
+	c.mu.Lock()
+	ops := make([]Opcode, 0, len(c.macCensus))
+	for op := range c.macCensus {
+		ops = append(ops, op)
+	}
+	counts := make(map[Opcode]uint64, len(c.macCensus))
+	for op, n := range c.macCensus {
+		counts[op] = n
+	}
+	c.mu.Unlock()
+	sort.Slice(ops, func(i, j int) bool { return ops[i] < ops[j] })
+	var b strings.Builder
+	for i, op := range ops {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		fmt.Fprintf(&b, "0x%02X(%s)=%d", uint8(op), op.String(), counts[op])
+	}
+	return b.String()
+}
+
+// censusSummaryEvery is how many Ingested MAC PDUs elapse between rolling
+// census-summary log lines. Coarse enough to stay quiet on a busy CC.
+const censusSummaryEvery = 2048
 
 // TrellisMode selects how the Process adapter interprets the MAC
 // PDU dibit window inside the Phase 2 traffic channel.
@@ -472,6 +559,7 @@ func New(opts Options) *ControlChannel {
 // against the very first PDUs.
 func (c *ControlChannel) Ingest(p MACPDU) {
 	c.macDecoded.Add(1)
+	c.censusObserve(p)
 	c.mu.Lock()
 	strict := c.strictValidation
 	c.mu.Unlock()

--- a/internal/radio/p25/phase2/control_census_test.go
+++ b/internal/radio/p25/phase2/control_census_test.go
@@ -1,0 +1,50 @@
+package phase2
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// TestControlChannelMACCensus verifies the control-channel opcode census
+// (issue #915) counts every MAC PDU by opcode — crucially including
+// opcodes GT does NOT parse as a grant. The per-grant DEBUG line has
+// survivorship bias (it only fires on opcodes already recognised as
+// grants), so a RID-bearing grant arriving under a dropped/mis-mapped
+// opcode is invisible there; the census is what surfaces it.
+func TestControlChannelMACCensus(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Sys"})
+
+	if got := cc.MACCensus(); len(got) != 0 {
+		t.Fatalf("fresh MACCensus() = %v, want empty", got)
+	}
+
+	grant := []byte{0x00, 0x10, 0x07, 0xCA, 0xFE, 0x12, 0x34, 0x56}
+	cc.Ingest(MACPDU{Opcode: OpGroupVoiceChannelGrant, Payload: grant})
+	cc.Ingest(MACPDU{Opcode: OpGroupVoiceChannelGrant, Payload: grant})
+	// 0x43 is not in GT's parsed-grant set: it must still be inventoried,
+	// because "an opcode GT ignores" is exactly where a missing RID-bearing
+	// grant would hide on a system whose source RIDs never populate.
+	cc.Ingest(MACPDU{Opcode: Opcode(0x43), Payload: make([]byte, 8)})
+
+	census := cc.MACCensus()
+	if census[OpGroupVoiceChannelGrant] != 2 {
+		t.Errorf("census[0x%02X] = %d, want 2", uint8(OpGroupVoiceChannelGrant), census[OpGroupVoiceChannelGrant])
+	}
+	if census[Opcode(0x43)] != 1 {
+		t.Errorf("census[0x43] = %d, want 1 — an unparsed opcode must still be counted", census[Opcode(0x43)])
+	}
+	if len(census) != 2 {
+		t.Errorf("census tracks %d opcodes, want 2: %v", len(census), census)
+	}
+
+	// The snapshot must be a copy — mutating it can't corrupt the channel's
+	// running census.
+	census[Opcode(0x43)] = 999
+	if again := cc.MACCensus(); again[Opcode(0x43)] != 1 {
+		t.Errorf("MACCensus() returned a live map, not a snapshot: %v", again)
+	}
+}


### PR DESCRIPTION
## Summary

Completed-call `source_rid` coverage on a heavily-compressed P25 Phase 2 system plateaued at **~36%** after the #916/#922 grant-association fixes. The open fork is **(a)** an association gap — GT decodes a RID-bearing grant but doesn't fold it onto the call — vs **(b)** decode-side — GT never decodes the RID-bearing grant's opcode/layout at all.

The existing `p25/phase2 grant` DEBUG line can't tell them apart: it only fires for opcodes GT already parses as a grant (`AsGroupVoiceChannelGrant`), so a RID-bearing grant arriving under an opcode GT drops or mis-maps is invisible there.

Cross-checking GT's Phase 2 grant opcode table against the authoritative TIA-102 / SDRtrunk MAC reference shows a **real divergence in the group-grant family** (GT: `0x40`=Update / `0x44`=Grant; SDRtrunk/TIA: `0x40`=Grant-with-source / `0x42`=Update / `0x44`=UnitToUnit), which makes **(b)** a live suspect. But GT still decodes ~36% and produces thousands of Phase 2 calls, so its table isn't simply "all wrong" — and per the repo's verify-before-fix policy I won't rewrite a decode-layer table blind against synthetic assumptions and risk regressing the working path. That needs real off-air Phase 2 control-channel bytes.

## Changes

- Add a **control-channel MAC opcode census** to `phase2.ControlChannel` (pure telemetry, no decode/dispatch change):
  - one-shot `opcode seen` log per distinct opcode with `name` / `known` / `payload_hex`;
  - a throttled `summary` line with the full `opcode:count` distribution;
  - a `MACCensus()` snapshot accessor (for tests / future metrics).
- Emitted at `--log-level debug`. It inventories **every** opcode — including ones GT doesn't parse as a grant — so a source-less-call log pins the remaining gap on a missing/mis-mapped grant opcode vs. an association gap. Same "produce data instead of silence" approach that resolved #813.

## Test plan

- [x] `make vet test` green locally
- [x] `make integration` green locally
- [x] Added test — `TestControlChannelMACCensus`: counts every opcode including ones GT doesn't parse as a grant; the returned snapshot is a copy.
- [ ] Smoke-tested against real hardware — n/a; the reporter's live-air census output is what characterises the system.

## Breaking changes

None. DEBUG-level telemetry only; no decode, dispatch, or API behaviour changes.

## Docs / CHANGELOG

- [x] `## [Unreleased]` bullet added to `CHANGELOG.md` (under `### Added`)

## Linked issues

Refs #915 — left **open** per the verify-before-close policy; this is the instrument to gather the data that settles the remaining-gap fork, not the fix itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016MamFURz8QqFmCeqUR4cpL)_