### PR TITLE
tetra: parse the AACH downlink usage marker (per-slot MCCH indicator)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ for tagged releases.
   a system whose completed-call `source_rid` under-populates (issue #915). The
   raw opcode inventory + byte sample is what pins the remaining gap on a
   missing/mis-mapped grant opcode (decode-side) vs. a call-association gap.
+- **TETRA AACH downlink usage marker parsing (per-slot control/traffic
+  identification).** GopherTrunk now decodes the ACCESS-ASSIGN PDU the AACH
+  carries in the centre of every TETRA downlink slot into its downlink usage
+  marker (`unallocated` / `assigned control` / `common control` / `traffic`,
+  per ETSI EN 300 392-2 §21.4.7). This is the per-slot MCCH indicator a
+  Single Carrier Base Station running dynamic MCCH sharing relies on, where
+  any of the four TDMA slots can be the control channel at a given moment
+  rather than a fixed slot 1 — the building block for issue #925.
 
 ### Fixed
 - **Encrypted-call `algorithm_id`/`key_id` are no longer surfaced when the
@@ -31,6 +39,11 @@ for tagged releases.
   before publishing, so an out-of-set value is dropped and the fields stay
   omitted rather than carrying garbage. Clear and every registered algorithm
   pass through unchanged. Refs #813, #924.
+- **The AACH is no longer mis-routed through the CMCE/MLE Layer-3 PDU
+  parser.** The decoded AACH (a MAC-layer ACCESS-ASSIGN PDU) was being handed
+  to `ParsePDU`, which is for CMCE/MLE Layer-3 PDUs, so it was mis-parsed
+  (and could surface as a spurious grant/release). It is now parsed as the
+  ACCESS-ASSIGN PDU it actually is.
 - **A TETRA channel recorded as a narrowband slice below the 144 kHz channel
   rate (e.g. the natural 48/50 kHz SDR++/SDRTrunk record rate) now decodes
   instead of emitting a nonsense symbol rate.** The `siglab` replay/analyze

--- a/internal/radio/tetra/aach.go
+++ b/internal/radio/tetra/aach.go
@@ -1,0 +1,96 @@
+package tetra
+
+// Access-assignment header values (ETSI EN 300 392-2 §21.4.7, mirrored by
+// osmo-tetra's macpdu_decode_access_assign). The 2-bit header selects how
+// the two 6-bit access-assignment fields are interpreted. Header 0 leaves
+// the downlink as common control; the other three all carry the downlink
+// usage marker in field 1.
+const (
+	accHdrDLCommonControl uint8 = 0 // DL common control / UL common
+	// headers 1..3 (DLF1_ULCA / DLF1_ULAO / DLF1_ULF1) put the downlink
+	// usage marker in field 1; field 2's meaning is uplink-only and not
+	// needed to classify the downlink slot.
+)
+
+// Downlink usage marker values (ETSI EN 300 392-2, osmo-tetra
+// dl_usage_names). The marker is what identifies, slot by slot, whether a
+// TETRA downlink slot is currently carrying control signalling or traffic.
+// It is the basis for following a Single Carrier Base Station running
+// dynamic MCCH sharing, where any of the four TDMA slots can be acting as
+// the control channel at a given moment rather than a fixed slot 1
+// (issue #925).
+const (
+	DLUsageUnallocated     uint8 = 0
+	DLUsageAssignedControl uint8 = 1
+	DLUsageCommonControl   uint8 = 2
+	DLUsageReserved        uint8 = 3
+	// Values >= DLUsageTraffic are traffic; the marker value itself is the
+	// usage marker identifying the call occupying the slot.
+	DLUsageTraffic uint8 = 4
+)
+
+// AccessAssign is the decoded ACCESS-ASSIGN PDU carried by the AACH in the
+// centre of every TETRA downlink slot (ETSI EN 300 392-2 §21.4.7). Its
+// downlink usage marker is the per-slot control-vs-traffic indicator a
+// dynamic-MCCH-sharing SCBS relies on (issue #925): the AACH is present in
+// every slot regardless of what the slot carries, so decoding it frame by
+// frame is how a receiver maps which slot is currently the control channel.
+//
+// Field2 carries uplink access information that is not needed to classify
+// the downlink; it is retained raw for completeness.
+type AccessAssign struct {
+	Header uint8 // 2-bit access-assignment header
+	Field1 uint8 // 6-bit
+	Field2 uint8 // 6-bit
+}
+
+// DownlinkUsage returns the slot's downlink usage marker. Header 0 leaves
+// the downlink as common control by definition; every other header carries
+// the marker explicitly in field 1.
+func (a AccessAssign) DownlinkUsage() uint8 {
+	if a.Header == accHdrDLCommonControl {
+		return DLUsageCommonControl
+	}
+	return a.Field1
+}
+
+// IsControlChannel reports whether the slot's downlink is currently
+// carrying control signalling (assigned or common control) rather than
+// traffic or nothing — the per-slot MCCH indicator for dynamic sharing.
+func (a AccessAssign) IsControlChannel() bool {
+	u := a.DownlinkUsage()
+	return u == DLUsageAssignedControl || u == DLUsageCommonControl
+}
+
+// IsTraffic reports whether the slot's downlink is carrying a traffic
+// channel (a call), identified by the usage marker value.
+func (a AccessAssign) IsTraffic() bool {
+	return a.DownlinkUsage() >= DLUsageTraffic
+}
+
+// ParseAccessAssign decodes the 14 recovered type-1 bits of an AACH (the
+// DecodeAACH output — one bit per byte, MSB first) into the ACCESS-ASSIGN
+// PDU. Returns (zero, false) when fewer than 14 bits are supplied.
+//
+// Note: the header interpretation here follows the normal-frame
+// (frames 1..17) convention; frame 18 carries the broadcast block and can
+// reinterpret the fields — tracking the frame number to handle that is a
+// follow-up, and does not affect the normal-frame downlink usage marker.
+func ParseAccessAssign(type1 []byte) (AccessAssign, bool) {
+	if len(type1) < 14 {
+		return AccessAssign{}, false
+	}
+	bit := func(i int) uint8 { return type1[i] & 1 }
+	field6 := func(start int) uint8 {
+		var v uint8
+		for i := 0; i < 6; i++ {
+			v = v<<1 | bit(start+i)
+		}
+		return v
+	}
+	return AccessAssign{
+		Header: bit(0)<<1 | bit(1),
+		Field1: field6(2),
+		Field2: field6(8),
+	}, true
+}

--- a/internal/radio/tetra/aach_test.go
+++ b/internal/radio/tetra/aach_test.go
@@ -1,0 +1,91 @@
+package tetra
+
+import "testing"
+
+// aachType1 builds the 14 type-1 bits (one bit per byte, MSB first) of an
+// ACCESS-ASSIGN PDU from a 2-bit header and two 6-bit fields — the inverse
+// of ParseAccessAssign's bit packing, so tests can state fields directly.
+func aachType1(header, field1, field2 uint8) []byte {
+	bits := make([]byte, 14)
+	bits[0] = (header >> 1) & 1
+	bits[1] = header & 1
+	for i := 0; i < 6; i++ {
+		bits[2+i] = (field1 >> (5 - i)) & 1
+		bits[8+i] = (field2 >> (5 - i)) & 1
+	}
+	return bits
+}
+
+func TestParseAccessAssignDownlinkUsage(t *testing.T) {
+	cases := []struct {
+		name        string
+		header      uint8
+		field1      uint8
+		wantUsage   uint8
+		wantControl bool
+		wantTraffic bool
+	}{
+		// Header 0: downlink is common control regardless of field 1.
+		{"header0 common control", 0, 0x2A, DLUsageCommonControl, true, false},
+		// Header 1..3: field 1 is the downlink usage marker.
+		{"assigned control", 1, DLUsageAssignedControl, DLUsageAssignedControl, true, false},
+		{"common control marker", 2, DLUsageCommonControl, DLUsageCommonControl, true, false},
+		{"unallocated", 1, DLUsageUnallocated, DLUsageUnallocated, false, false},
+		{"reserved", 3, DLUsageReserved, DLUsageReserved, false, false},
+		{"traffic marker 4", 1, 4, 4, false, true},
+		{"traffic marker 63", 3, 63, 63, false, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			aa, ok := ParseAccessAssign(aachType1(tc.header, tc.field1, 0x15))
+			if !ok {
+				t.Fatal("ParseAccessAssign returned !ok for 14 bits")
+			}
+			if aa.Header != tc.header {
+				t.Errorf("Header = %d, want %d", aa.Header, tc.header)
+			}
+			if got := aa.DownlinkUsage(); got != tc.wantUsage {
+				t.Errorf("DownlinkUsage() = %d, want %d", got, tc.wantUsage)
+			}
+			if got := aa.IsControlChannel(); got != tc.wantControl {
+				t.Errorf("IsControlChannel() = %v, want %v", got, tc.wantControl)
+			}
+			if got := aa.IsTraffic(); got != tc.wantTraffic {
+				t.Errorf("IsTraffic() = %v, want %v", got, tc.wantTraffic)
+			}
+		})
+	}
+}
+
+func TestParseAccessAssignShort(t *testing.T) {
+	if _, ok := ParseAccessAssign(make([]byte, 13)); ok {
+		t.Error("ParseAccessAssign accepted fewer than 14 bits")
+	}
+}
+
+// TestAccessAssignSurvivesAACHRoundTrip runs a known ACCESS-ASSIGN through
+// GopherTrunk's own AACH FEC chain (EncodeAACH → DecodeAACH) and confirms
+// ParseAccessAssign recovers the downlink usage marker — i.e. the AACH the
+// live decoder hands to dispatchSlice yields the correct per-slot control/
+// traffic classification (issue #925).
+func TestAccessAssignSurvivesAACHRoundTrip(t *testing.T) {
+	const colour = 0x1234
+	// A voice slot: header selects DL usage marker, marker = traffic.
+	type1 := aachType1(1, 37, 0x2A)
+	type5 := EncodeAACH(type1, colour)
+	if len(type5) != 30 {
+		t.Fatalf("EncodeAACH produced %d type-5 bits, want 30", len(type5))
+	}
+	recovered, errs := DecodeAACH(type5, colour)
+	if errs != 0 {
+		t.Fatalf("DecodeAACH errs = %d, want 0 on clean round-trip", errs)
+	}
+	aa, ok := ParseAccessAssign(recovered)
+	if !ok {
+		t.Fatal("ParseAccessAssign returned !ok after round-trip")
+	}
+	if aa.DownlinkUsage() != 37 || !aa.IsTraffic() || aa.IsControlChannel() {
+		t.Errorf("round-tripped usage = %d (traffic=%v control=%v), want 37 / traffic",
+			aa.DownlinkUsage(), aa.IsTraffic(), aa.IsControlChannel())
+	}
+}

--- a/internal/radio/tetra/process.go
+++ b/internal/radio/tetra/process.go
@@ -434,7 +434,18 @@ func (c *ControlChannel) dispatchSlice(slice []uint8, mode ChannelCodingMode, ch
 		if errs < 0 {
 			return
 		}
-		info = framing.PackBitsMSB(recovered)
+		// The AACH carries an ACCESS-ASSIGN PDU — a MAC-layer per-slot usage
+		// marker — NOT a CMCE/MLE Layer-3 PDU, so it must not go through
+		// ParsePDU (which would mis-parse it, occasionally as a spurious
+		// grant/release). Parse the downlink usage marker instead: it is what
+		// identifies, slot by slot, whether the slot is currently control or
+		// traffic — the signal a dynamic-MCCH-sharing SCBS needs (issue #925).
+		if aa, ok := ParseAccessAssign(recovered); ok {
+			c.log.Debug("tetra aach access-assign",
+				"header", aa.Header, "dl_usage", aa.DownlinkUsage(),
+				"control", aa.IsControlChannel(), "traffic", aa.IsTraffic())
+		}
+		return
 	case channel == ChannelBSCH:
 		recovered, ok := DecodeBSCH(bits)
 		if !ok {


### PR DESCRIPTION
## Summary

Groundwork for following a TETRA **Single Carrier Base Station running dynamic MCCH sharing** (#925), where any of the four TDMA slots can be acting as the control channel at a given moment rather than a fixed slot 1. The per-slot control-vs-traffic state is carried by the **ACCESS-ASSIGN PDU in the AACH**, which sits in the centre of every downlink slot regardless of what the slot carries — so decoding it is the mechanism the issue's proposal #3 ("dynamic channel handling via AACH parsing") calls for.

GopherTrunk already had the AACH FEC decode (`EncodeAACH`/`DecodeAACH`) but **no parser for its content** — and the decode path actually fed the recovered AACH bits to `ParsePDU`, the CMCE/MLE **Layer-3** parser, which is a category error that mis-parses them (occasionally as a spurious grant/release).

## Changes

- Add `AccessAssign` + `ParseAccessAssign` decoding the 14-bit ACCESS-ASSIGN PDU (2-bit header + two 6-bit fields) into the **downlink usage marker**, with `IsControlChannel()` / `IsTraffic()` helpers. Values and header interpretation follow ETSI EN 300 392-2 §21.4.7, cross-checked against osmo-tetra's `macpdu_decode_access_assign` / `dl_usage_names` (`0`=unallocated, `1`=assigned control, `2`=common control, `3`=reserved, `4+`=traffic).
- Route the decoded AACH to `ParseAccessAssign` (debug-logged) instead of `ParsePDU`, fixing the mis-routing.

## Test plan

- [x] `make vet test` green locally
- [x] `make integration` green locally
- [x] Added tests: `TestParseAccessAssignDownlinkUsage` (every usage class → correct control/traffic classification), `TestParseAccessAssignShort`, and `TestAccessAssignSurvivesAACHRoundTrip` (a known ACCESS-ASSIGN survives GT's own `EncodeAACH`→`DecodeAACH`→`ParseAccessAssign` to the right marker).
- [ ] Smoke-tested against real hardware — n/a; see scope note below.

## Scope — please read

This is the **protocol building block only**, and deliberately so. Two larger pieces the issue implies are **out of scope here because they can't be verified without a raw IQ capture** of an SCBS carrier (per the repo's verify-before-fix policy):

1. **Wiring per-slot AACH extraction into the live receive flow.** GT's control decoder currently locates PDUs by training-sequence correlation and doesn't pull the mid-slot AACH out of every burst; adding that touches the framing hot path and needs real bytes to validate slot geometry.
2. **The reported CC-lock failure itself.** The issue attributes it to "continuous phase tracking" blowing up at voice-slot boundaries — but GT's TETRA receiver is **differential π/4-DQPSK + a block-based AFC**, not a continuous carrier PLL, so that specific premise doesn't match GT's architecture. The plausible real weak point (a per-block AFC estimate corrupted by a mid-block discontinuity) can only be diagnosed/fixed against a capture.

## Breaking changes

None. Adds a parser + corrects where the AACH is routed; no config, API, or grant-behaviour changes.

## Docs / CHANGELOG

- [x] `## [Unreleased]` bullets added (`### Added` for the parser, `### Fixed` for the mis-routing).

## Linked issues

Refs #925 — left **open**; this lands the verifiable protocol piece, and the issue awaits a raw IQ capture for the live-wiring and lock-failure halves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016MamFURz8QqFmCeqUR4cpL)_