### PR TITLE
docs(field-guide): add pages for RF/tech acronyms and autolink them

### DIFF
--- a/docs/_data/reference.yml
+++ b/docs/_data/reference.yml
@@ -217,6 +217,8 @@ domains:
           - { slug: intersymbol-interference, title: Intersymbol interference (ISI), type: term }
           - { slug: roll-off-factor, title: Roll-off factor, type: term }
           - { slug: bit-rate-vs-baud, title: Bit rate vs baud, type: term }
+          - { slug: amplitude-phase-shift-keying, title: Amplitude and phase-shift keying (APSK), type: technology }
+          - { slug: modulation-and-coding-scheme, title: Modulation and coding scheme (MCS), type: concept }
 
       - id: sdr-dsp
         label: SDR & DSP
@@ -480,6 +482,7 @@ domains:
           - { slug: mpt-1327, title: MPT 1327, type: protocol }
           - { slug: iden, title: iDEN, type: protocol }
           - { slug: provoice, title: ProVoice, type: protocol }
+          - { slug: direct-mode-operation, title: Direct mode operation (DMO), type: concept }
 
       - id: cellular
         label: Cellular
@@ -499,6 +502,10 @@ domains:
           - { slug: imsi-imei, title: IMSI & IMEI, type: term }
           - { slug: cellular-handover, title: Handover, type: term }
           - { slug: base-station-enodeb-gnodeb, title: Base station (eNodeB / gNodeB), type: term }
+          - { slug: frequency-division-duplex, title: Frequency-division duplex (FDD), type: concept }
+          - { slug: time-division-duplex, title: Time-division duplex (TDD), type: concept }
+          - { slug: discontinuous-reception, title: Discontinuous reception (DRX), type: concept }
+          - { slug: imt, title: International Mobile Telecommunications (IMT), type: technology }
 
       - id: wireless-data-iot
         label: Wireless data & IoT
@@ -561,6 +568,7 @@ domains:
           - { slug: atsc-1, title: ATSC 1.0, type: protocol }
           - { slug: atsc-3, title: ATSC 3.0 (NextGen TV), type: protocol }
           - { slug: isdb-t, title: ISDB-T, type: protocol }
+          - { slug: single-frequency-network, title: Single-frequency network (SFN), type: technology }
 
       - id: aviation-marine
         label: Aviation & marine
@@ -587,6 +595,9 @@ domains:
           - { slug: navtex, title: NAVTEX, type: protocol }
           - { slug: epirb-406, title: EPIRB (406 MHz), type: protocol }
           - { slug: marine-vhf, title: Marine VHF, type: technology }
+          - { slug: identification-friend-or-foe, title: Identification friend or foe (IFF), type: technology }
+          - { slug: sitor, title: SITOR, type: protocol }
+          - { slug: solas, title: SOLAS, type: concept }
 
       - id: paging-data
         label: Paging & data
@@ -651,6 +662,7 @@ domains:
           - { slug: ralcwi, title: RALCWI, type: technology }
           - { slug: evrc, title: EVRC, type: technology }
           - { slug: gsm-fr-hr-efr, title: GSM FR / HR / EFR, type: technology }
+          - { slug: advanced-audio-coding, title: Advanced Audio Coding (AAC), type: technology }
 
       - id: sdr-devices
         label: SDR devices
@@ -904,6 +916,12 @@ domains:
           - { slug: connectivity-standards-alliance, title: Connectivity Standards Alliance, type: organization }
           - { slug: rsgb, title: RSGB, type: organization }
           - { slug: dmr-association, title: DMR Association, type: organization }
+          - { slug: faa, title: Federal Aviation Administration (FAA), type: organization }
+          - { slug: imo, title: International Maritime Organization (IMO), type: organization }
+          - { slug: iec, title: International Electrotechnical Commission (IEC), type: organization }
+          - { slug: tapr, title: Tucson Amateur Packet Radio (TAPR), type: organization }
+          - { slug: nrsc, title: National Radio Systems Committee (NRSC), type: organization }
+          - { slug: ccitt, title: CCITT, type: organization }
   - id: software-dev
     label: "Software Development"
     blurb: Programming languages and the concepts, paradigms, and practices of building software — the craft behind GopherTrunk itself.
@@ -1036,6 +1054,7 @@ domains:
           - { slug: clock-speed, title: Clock speed, type: concept }
           - { slug: bios-uefi, title: BIOS & UEFI, type: concept }
           - { slug: chipset, title: Chipset, type: hardware }
+          - { slug: binary-coded-decimal, title: Binary-coded decimal (BCD), type: concept }
 
       - id: hw-servers
         label: Servers & hosting

--- a/docs/reference/5g-nr.md
+++ b/docs/reference/5g-nr.md
@@ -5,7 +5,7 @@ entry_type: protocol
 category: cellular
 description: 5G NR is the 3GPP fifth-generation air interface using scalable OFDM numerologies, LDPC and polar coding, massive MIMO, and mmWave bands for high-throughput, low-latency service.
 keywords: 5G NR, New Radio, 3GPP, OFDM numerology, flexible subcarrier spacing, LDPC code, polar code, massive MIMO, beamforming, mmWave, FR1, FR2, sub-6, standalone, non-standalone
-aka: [5G NR, New Radio, 5G]
+aka: [5G NR, New Radio, 5G, RedCap]
 autolink: true
 infobox:
   - { label: Type, value: 5G cellular air interface }

--- a/docs/reference/advanced-audio-coding.md
+++ b/docs/reference/advanced-audio-coding.md
@@ -1,0 +1,89 @@
+---
+slug: advanced-audio-coding
+title: Advanced Audio Coding (AAC)
+entry_type: technology
+category: voice-coding
+description: Advanced Audio Coding is the MPEG perceptual audio codec that succeeded MP3, using the MDCT and a psychoacoustic model to code full-band audio at low bitrates; DAB+ and DRM carry HE-AAC.
+keywords: AAC, Advanced Audio Coding, HE-AAC, AAC-LC, MDCT, psychoacoustic model, SBR, parametric stereo, DAB+, perceptual codec, MPEG-4
+aka: [AAC, Advanced Audio Coding, HE-AAC, AAC-LC]
+autolink: true
+infobox:
+  - { label: Type, value: Perceptual audio codec }
+  - { label: Family, value: MPEG-2 / MPEG-4 }
+  - { label: Core tools, value: "MDCT + psychoacoustic model" }
+  - { label: Used by, value: "DAB+, DRM, ATSC/DVB" }
+see_also: [vocoder, opus-codec, pulse-code-modulation, dab, drm-broadcast, hd-radio, spectral-efficiency]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Advanced_Audio_Coding
+  - https://www.iso.org/standard/76383.html
+---
+
+**Advanced Audio Coding** (**AAC**) is the MPEG-2/MPEG-4 perceptual audio codec that
+succeeded MP3, delivering better quality at the same bitrate.[^wiki] Unlike a speech
+[vocoder](/reference/vocoder/), which models the human voice, AAC codes full-band music
+and general audio; it works by transforming blocks of
+[PCM](/reference/pulse-code-modulation/) samples and discarding detail a listener cannot
+hear, in the same perceptual-coding family as the [Opus codec](/reference/opus-codec/).
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 470 130" role="img" aria-label="Signal chain: PCM audio enters a modified discrete cosine transform, then a psychoacoustic model drives quantization, then entropy coding produces a compressed bitstream." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="12" y="50" width="86" height="34" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="55" y="64">PCM audio</text><text x="55" y="76" font-size="7.5">samples</text>
+    <rect x="128" y="50" width="86" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="171" y="64">MDCT</text><text x="171" y="76" font-size="7.5">time → freq</text>
+    <rect x="244" y="50" width="96" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="292" y="61">quantize</text><text x="292" y="73" font-size="7.5">psychoacoustic</text>
+    <rect x="370" y="50" width="88" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="414" y="64">entropy</text><text x="414" y="76" font-size="7.5">bitstream</text>
+    <g stroke="currentColor" stroke-width="1.1"><line x1="98" y1="67" x2="127" y2="67" marker-end="url(#rel_aac)"/><line x1="214" y1="67" x2="243" y2="67" marker-end="url(#rel_aac)"/><line x1="340" y1="67" x2="369" y2="67" marker-end="url(#rel_aac)"/></g>
+    <text x="292" y="34" font-size="7.5" fill="currentColor" fill-opacity="0.85">masking curve hides inaudible detail</text>
+    <line x1="292" y1="38" x2="292" y2="49" stroke="currentColor" stroke-width="1" stroke-opacity="0.6"/>
+  </g>
+  <defs><marker id="rel_aac" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>AAC transforms PCM audio with the MDCT, quantizes each frequency band according to a psychoacoustic masking model, then entropy-codes the result into a compact bitstream.</figcaption>
+</figure>
+
+## How it works
+
+AAC splits the audio into overlapping blocks and applies a **modified discrete cosine
+transform (MDCT)** to move each block from the time domain into a set of frequency
+coefficients. A **psychoacoustic model** then estimates, band by band, how much noise the
+ear will mask behind louder nearby tones, and the encoder quantizes each band only as
+finely as audibility requires — spending bits where the ear is sensitive and coarsening
+or dropping detail where it is not. The quantized coefficients are finally packed with
+entropy (Huffman) coding, so the output bitstream is both perceptually transparent and
+small. Because it is a *lossy transform* codec rather than a source model of speech, AAC
+handles music, applause, and mixed program material that a low-rate voice coder cannot.
+
+Several **profiles** trade complexity for efficiency. **AAC-LC** (Low Complexity) is the
+baseline. **HE-AAC** — where "HE" is High-Efficiency — adds **Spectral Band Replication
+(SBR)**, which reconstructs high frequencies from a compact parametric description instead
+of coding them outright. **HE-AAC v2** adds **Parametric Stereo (PS)**, describing the
+stereo image with a few side parameters, and reaches broadcast-usable quality near 24–48
+kbps — a fraction of what MP3 needs for the same result.
+
+## In practice
+
+AAC's low-bitrate strength made it the audio codec of choice for constrained broadcast
+links. **[DAB+](/reference/dab/)** carries HE-AAC v2, which let it pack many more stations
+into a multiplex than the original DAB's MP2. **[DRM](/reference/drm-broadcast/)** (Digital
+Radio Mondiale) also uses AAC-family coding for shortwave and mediumwave digital audio, and
+digital television (ATSC and DVB) uses AAC for audio. One notable exception: US
+**[HD Radio](/reference/hd-radio/)** does *not* use AAC — it carries its own proprietary
+**HDC** codec, a perceptually similar but separate design. Choosing AAC over an outright PCM
+stream is a large gain in
+[spectral efficiency](/reference/spectral-efficiency/): the same channel carries far more
+program content.
+
+## Relevance to SDR
+
+An SDR listener tuning a digital broadcast multiplex is, after demodulation and
+error-correction, left with an AAC (or HDC) elementary stream that a software decoder turns
+back into audio. Knowing which codec a mode uses tells you which decoder library to reach
+for — welle.io and similar DAB+ receivers embed an HE-AAC decoder, while HD Radio tools need
+the HDC path. GopherTrunk's own decode targets are land-mobile trunking voice (P25, DMR,
+NXDN, TETRA) that use low-rate speech vocoders, not AAC; AAC is documented here as the
+broadcast-audio counterpart an SDR user meets outside the trunking world.
+
+## Sources
+
+[^wiki]: [Advanced Audio Coding](https://en.wikipedia.org/wiki/Advanced_Audio_Coding) — Wikipedia, for AAC's history as the MP3 successor, the MDCT and psychoacoustic model, and the AAC-LC / HE-AAC / HE-AAC v2 profiles.
+[^iso]: [ISO/IEC 14496-3 (MPEG-4 Audio)](https://www.iso.org/standard/76383.html) — the standard that defines the AAC profiles, SBR, and Parametric Stereo tools.

--- a/docs/reference/ais.md
+++ b/docs/reference/ais.md
@@ -5,7 +5,7 @@ entry_type: protocol
 category: aviation-marine
 description: AIS (Automatic Identification System) is a maritime VHF data system in which ships broadcast identity, position, course, and speed using GMSK in a self-organising TDMA scheme.
 keywords: AIS, Automatic Identification System, marine tracking, GMSK, SOTDMA, 161.975 162.025, AIS channel A B, vessel position, MMSI, NMEA, AIVDM, satellite AIS
-aka: [AIS]
+aka: [AIS, CSTDMA]
 autolink: true
 infobox:
   - { label: Type, value: Maritime data broadcast }

--- a/docs/reference/amplitude-phase-shift-keying.md
+++ b/docs/reference/amplitude-phase-shift-keying.md
@@ -1,0 +1,85 @@
+---
+slug: amplitude-phase-shift-keying
+title: Amplitude and phase-shift keying (APSK)
+entry_type: technology
+category: modulation
+description: APSK places constellation points on concentric rings — amplitude sets the ring, phase sets the position — giving a near-constant envelope that suits satellite power amplifiers; DVB-S2/S2X use 16APSK and 32APSK.
+keywords: APSK, amplitude and phase-shift keying, 16APSK, 32APSK, concentric rings, DVB-S2, DVB-S2X, travelling-wave tube, constellation, satellite modulation
+aka: [APSK, Amplitude and phase-shift keying, 16APSK, 32APSK]
+autolink: true
+infobox:
+  - { label: Type, value: Digital modulation (amplitude + phase) }
+  - { label: Constellation, value: Concentric rings }
+  - { label: Common orders, value: "16APSK (4+12), 32APSK (4+12+16)" }
+  - { label: Used by, value: DVB-S2 / DVB-S2X }
+see_also: [phase-shift-keying, 8psk, qpsk, quadrature-amplitude-modulation, constellation-diagram, dvb-s, spectral-efficiency]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Amplitude_and_phase-shift_keying
+  - https://en.wikipedia.org/wiki/DVB-S2
+---
+
+**Amplitude and phase-shift keying** (**APSK**) arranges its
+[constellation](/reference/constellation-diagram/) points on several **concentric rings**:
+the signal amplitude selects which ring a symbol lands on, and its phase selects the
+position around that ring.[^wiki] It is a deliberate compromise between pure
+[phase-shift keying](/reference/phase-shift-keying/) — a single ring, as in
+[QPSK](/reference/qpsk/) or [8PSK](/reference/8psk/) — and
+[quadrature amplitude modulation](/reference/quadrature-amplitude-modulation/), whose
+rectangular grid spends more amplitude levels.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 300 240" role="img" aria-label="A 16APSK constellation on the IQ plane: an inner ring of four points and an outer ring of twelve points, both centred on the origin." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="120" x2="270" y2="120" stroke="currentColor" stroke-opacity="0.4"/>
+  <line x1="150" y1="20" x2="150" y2="210" stroke="currentColor" stroke-opacity="0.4"/>
+  <text x="262" y="134" font-size="10" fill="currentColor">I</text><text x="136" y="30" font-size="10" fill="currentColor">Q</text>
+  <circle cx="150" cy="120" r="38" fill="none" stroke="currentColor" stroke-opacity="0.3" stroke-dasharray="3 3"/>
+  <circle cx="150" cy="120" r="88" fill="none" stroke="currentColor" stroke-opacity="0.3" stroke-dasharray="3 3"/>
+  <g fill="currentColor">
+    <circle cx="177" cy="93" r="3.4"/><circle cx="123" cy="93" r="3.4"/><circle cx="123" cy="147" r="3.4"/><circle cx="177" cy="147" r="3.4"/>
+    <circle cx="238" cy="120" r="3.4"/><circle cx="226" cy="76" r="3.4"/><circle cx="194" cy="44" r="3.4"/><circle cx="150" cy="32" r="3.4"/><circle cx="106" cy="44" r="3.4"/><circle cx="74" cy="76" r="3.4"/><circle cx="62" cy="120" r="3.4"/><circle cx="74" cy="164" r="3.4"/><circle cx="106" cy="196" r="3.4"/><circle cx="150" cy="208" r="3.4"/><circle cx="194" cy="196" r="3.4"/><circle cx="226" cy="164" r="3.4"/>
+  </g>
+  <text x="150" y="230" text-anchor="middle" font-size="8" fill="currentColor">16APSK: inner ring of 4, outer ring of 12</text>
+</svg>
+<figcaption>16APSK places 4 points on an inner ring and 12 on an outer ring; amplitude picks the ring and phase the position, keeping only two amplitude levels.</figcaption>
+</figure>
+
+## How it works
+
+Each APSK order is described by how its points split across rings. **16APSK** uses a **4+12**
+layout — four points on the inner ring, twelve on the outer — carrying four bits per symbol.
+**32APSK** adds a third ring for a **4+12+16** layout, carrying five bits per symbol. Because
+almost every symbol sits at one of just two or three radii, the transmitted envelope stays
+close to constant. That matters for the **travelling-wave-tube amplifiers (TWTAs)** aboard
+satellites: those amplifiers are run near saturation for efficiency, where they are strongly
+nonlinear and compress amplitude. A many-level QAM grid, with its wide spread of amplitudes,
+suffers badly under that compression; APSK's few tight rings pass through with far less
+distortion.
+
+The cost is noise margin. Splitting power across rings and phases packs the points more
+closely than a robust QPSK constellation, so APSK needs a higher
+[signal-to-noise ratio](/reference/signal-to-noise-ratio/) than QPSK or 8PSK to hit the same
+error rate. It buys extra [spectral efficiency](/reference/spectral-efficiency/) only when the
+link budget can spare the SNR.
+
+## In practice
+
+APSK is the workhorse of modern satellite transmission. **[DVB-S2](/reference/dvb-s/)** and its
+extension DVB-S2X adopt 16APSK and 32APSK (and, in S2X, higher orders up to 256APSK) for their
+higher-throughput modes, selected by adaptive coding and modulation when the measured link can
+support them; the more robust QPSK and 8PSK modes are used when it cannot. The ring radii and
+the pairing with a specific forward-error-correction code rate are jointly optimised so the
+constellation performs well through the satellite's nonlinear amplifier.
+
+## Relevance to SDR
+
+On a constellation display APSK is unmistakable: instead of PSK's single ring or QAM's square
+grid, it shows two or three clean rings of points. A software receiver locking a DVB-S2 carrier
+must know the exact APSK order and ring-ratio to demap symbols correctly. APSK falls outside
+GopherTrunk's land-mobile trunking focus — those modes use C4FM and π/4-DQPSK — so it is
+documented here to complete the modulation family and to mark where satellite links move beyond
+phase-only keying.
+
+## Sources
+
+[^wiki]: [Amplitude and phase-shift keying](https://en.wikipedia.org/wiki/Amplitude_and_phase-shift_keying) — Wikipedia, for the concentric-ring constellations, the 16APSK/32APSK layouts, and the nonlinear-amplifier motivation.
+[^s2]: [DVB-S2](https://en.wikipedia.org/wiki/DVB-S2) — Wikipedia, for the adoption of 16APSK and 32APSK in the DVB-S2/S2X higher-throughput modes.

--- a/docs/reference/binary-coded-decimal.md
+++ b/docs/reference/binary-coded-decimal.md
@@ -1,0 +1,84 @@
+---
+slug: binary-coded-decimal
+title: Binary-coded decimal (BCD)
+entry_type: concept
+category: hw-foundations
+description: Binary-coded decimal stores each decimal digit 0-9 in its own 4-bit nibble, leaving six codes unused; it trades range for trivial decimal display and appears in POCSAG, DSC, RDS, and clock chips.
+keywords: BCD, binary-coded decimal, packed BCD, unpacked BCD, nibble, decimal digit, POCSAG, DSC, RDS, real-time clock
+aka: [BCD, Binary-coded decimal, packed BCD]
+autolink: true
+infobox:
+  - { label: Type, value: Numeric encoding }
+  - { label: Unit, value: "One decimal digit per 4-bit nibble" }
+  - { label: Unused codes, value: "1010–1111 (six of sixteen)" }
+  - { label: Used by, value: "POCSAG, DSC, RDS, RTC chips" }
+see_also: [bits-and-bytes, pocsag, dsc]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Binary-coded_decimal
+  - https://www.itu.int/rec/R-REC-M.493/en
+---
+
+**Binary-coded decimal** (**BCD**) stores each decimal digit 0–9 in its own 4-bit
+[nibble](/reference/bits-and-bytes/), from `0000` to `1001`.[^wiki] Because a nibble can
+express sixteen values but only ten digits are used, the six codes `1010`–`1111` go unused —
+so BCD wastes about 17% of the available range in exchange for a direct, conversion-free
+mapping between stored bits and the decimal digits a human reads.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 420 150" role="img" aria-label="The decimal number one nine seven mapped to three 4-bit nibbles: 0001, 1001, 0111, each digit in its own nibble." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="12" fill="currentColor" text-anchor="middle">
+    <text x="70" y="34">1</text><text x="210" y="34">9</text><text x="350" y="34">7</text>
+  </g>
+  <g stroke="currentColor" stroke-width="1.1"><line x1="70" y1="42" x2="70" y2="60" marker-end="url(#rel_bcd)"/><line x1="210" y1="42" x2="210" y2="60" marker-end="url(#rel_bcd)"/><line x1="350" y1="42" x2="350" y2="60" marker-end="url(#rel_bcd)"/></g>
+  <g font-size="13" fill="currentColor" text-anchor="middle" font-family="monospace">
+    <rect x="20" y="66" width="100" height="34" rx="4" fill="currentColor" fill-opacity="0.10" stroke="currentColor" stroke-width="1.2"/><text x="70" y="88">0001</text>
+    <rect x="160" y="66" width="100" height="34" rx="4" fill="currentColor" fill-opacity="0.13" stroke="currentColor" stroke-width="1.2"/><text x="210" y="88">1001</text>
+    <rect x="300" y="66" width="100" height="34" rx="4" fill="currentColor" fill-opacity="0.16" stroke="currentColor" stroke-width="1.2"/><text x="350" y="88">0111</text>
+  </g>
+  <g font-size="8" fill="currentColor" text-anchor="middle">
+    <text x="70" y="118">nibble</text><text x="210" y="118">nibble</text><text x="350" y="118">nibble</text>
+    <text x="210" y="140" fill-opacity="0.85">each decimal digit occupies its own 4 bits</text>
+  </g>
+  <defs><marker id="rel_bcd" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>The decimal number 197 in BCD: each digit maps straight to its own nibble — 1→0001, 9→1001, 7→0111 — with no binary-to-decimal arithmetic needed.</figcaption>
+</figure>
+
+## How it works
+
+In pure binary the number 197 is `11000101`, and recovering its decimal digits takes repeated
+division. BCD skips that: each digit is encoded independently, so `197` is simply `0001 1001
+0111`. Reading a digit out to a seven-segment display, rounding to a decimal place, or
+transmitting a digit string becomes a lookup with no conversion. The trade is density — BCD
+needs four bits per digit where binary would pack the same value more tightly, and a quarter of
+each nibble's codes are illegal.
+
+BCD comes in two layouts. **Packed BCD** stores two digits per byte, one in each nibble, which
+is the compact form used in most protocols and storage. **Unpacked BCD** stores a single digit
+per byte, wasting the high nibble but simplifying byte-at-a-time processing. Arithmetic on BCD
+requires a decimal-adjust step whenever a nibble would exceed `1001`, which is why processors
+historically included a decimal-adjust instruction.
+
+## In practice
+
+BCD is favoured wherever decimal digits are displayed or transmitted directly and a
+binary-to-decimal conversion would be a nuisance. Numeric **[POCSAG](/reference/pocsag/)** pages
+carry their digits as BCD, as do the maritime identities and call fields of
+**[DSC](/reference/dsc/)** (Digital Selective Calling). The Radio Data System (**RDS**) uses BCD
+for time and date, and real-time-clock chips store the seconds, minutes, hours, and calendar in
+BCD so firmware can read the time out digit by digit. In each case the payload is meant to be
+read as decimal, so encoding it as decimal from the start is simpler than repeatedly converting.
+
+## Relevance to SDR
+
+A decoder that pulls a numeric page or a DSC identity off the air must know the field is BCD,
+not binary — misreading a packed BCD byte as an ordinary integer yields nonsense. Recognising the
+`1010`–`1111` codes as invalid also serves as a cheap sanity check on a recovered bitstream.
+GopherTrunk's trunking focus centres on P25/DMR/NXDN/TETRA control data, but BCD is exactly the
+kind of low-level digit encoding a paging or maritime decoder built alongside it must parse
+correctly.
+
+## Sources
+
+[^wiki]: [Binary-coded decimal](https://en.wikipedia.org/wiki/Binary-coded_decimal) — Wikipedia, for the nibble-per-digit encoding, unused codes, and the packed vs unpacked forms.
+[^dsc]: [ITU-R M.493, Digital Selective-Calling system](https://www.itu.int/rec/R-REC-M.493/en) — the recommendation defining the DSC message format that carries maritime identities as decimal digits.

--- a/docs/reference/bluetooth-rf.md
+++ b/docs/reference/bluetooth-rf.md
@@ -5,7 +5,7 @@ entry_type: protocol
 category: wireless-data-iot
 description: "Bluetooth's RF layer is a 2.4 GHz frequency-hopping spread-spectrum air interface using GFSK across 79 (Classic) or 40 (LE) channels for short-range personal-area links."
 keywords: Bluetooth, Bluetooth RF, Bluetooth Classic, BR/EDR, FHSS, frequency hopping, GFSK, 2.4 GHz ISM, adaptive frequency hopping, personal area network, piconet
-aka: [Bluetooth Classic PHY, BR/EDR, Bluetooth radio]
+aka: [Bluetooth Classic PHY, BR/EDR, Bluetooth radio, EDR, "Enhanced Data Rate"]
 autolink: true
 infobox:
   - { label: Type, value: Short-range wireless PHY }

--- a/docs/reference/ccitt.md
+++ b/docs/reference/ccitt.md
@@ -1,0 +1,82 @@
+---
+slug: ccitt
+title: CCITT
+entry_type: organization
+category: organizations
+description: CCITT, the International Telegraph and Telephone Consultative Committee, was the ITU body renamed ITU-T in 1993; its names still label standards such as ITA2/Baudot, the V-series modems, and the G-series codecs.
+keywords: CCITT, ITU-T, International Telegraph and Telephone Consultative Committee, ITA2, Baudot, V-series, G-series, G.711, telegraph alphabet
+aka: [CCITT, International Telegraph and Telephone Consultative Committee]
+autolink: true
+infobox:
+  - { label: Type, value: Former ITU standards body }
+  - { label: Focus, value: Telegraph & telephone standards }
+  - { label: Renamed, value: "ITU-T (1993)" }
+  - { label: Standards, value: "ITA2, V-series, G-series" }
+see_also: [itu, itu-r, g711, rtty, modem]
+cite_urls:
+  - https://www.itu.int/en/ITU-T/
+  - https://en.wikipedia.org/wiki/ITU-T
+---
+
+**CCITT** (the **International Telegraph and Telephone Consultative Committee**, French
+*Comité Consultatif International Téléphonique et Télégraphique*) was the
+[ITU](/reference/itu/) body renamed **ITU-T** in 1993. Its names still label standards behind
+**[RTTY](/reference/rtty/)**, telephone **[modems](/reference/modem/)**, and speech
+codecs.[^wiki]
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="A lineage arrow from CCITT, active until 1993, to ITU-T from 1993 to the present, with example standards each produced." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="30" y="40" width="150" height="36" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="105" y="56">CCITT</text><text x="105" y="68" font-size="7.5">to 1993</text>
+    <rect x="280" y="40" width="150" height="36" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="355" y="56">ITU-T</text><text x="355" y="68" font-size="7.5">1993 – present</text>
+    <line x1="180" y1="58" x2="279" y2="58" stroke="currentColor" stroke-width="1.4" marker-end="url(#rel_ccitt)"/>
+    <text x="230" y="50" font-size="7.5">renamed</text>
+    <text x="105" y="98" font-size="7.5" fill-opacity="0.85">ITA2 · V-series · G.711</text>
+    <text x="355" y="98" font-size="7.5" fill-opacity="0.85">continues the numbering</text>
+  </g>
+  <defs><marker id="rel_ccitt" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>CCITT became ITU-T in 1993; standards it issued are still cited under their CCITT names.</figcaption>
+</figure>
+
+## Overview
+
+The CCITT was, for most of the 20th century, the standards arm of the
+[ITU](/reference/itu/) responsible for telegraphy and telephony. Meeting in study groups and
+plenary assemblies, it produced the "Recommendations" that made national telephone and
+telegraph networks interconnect across borders. In the 1992–1993 ITU reorganisation the CCITT
+was renamed the **ITU Telecommunication Standardization Sector (ITU-T)**, which carries on the
+same work and the same Recommendation numbering; its sister sector, [ITU-R](/reference/itu-r/),
+handles radiocommunication. Because the renaming preserved the numbering, a great many
+standards are still known and cited by their original CCITT names.
+
+Several of those touch signals an SDR user meets. The **CCITT No. 2 telegraph alphabet** —
+also called **ITA2** or Baudot — is the 5-bit character code that underlies
+**[RTTY](/reference/rtty/)** (radioteletype), still heard on the HF bands. The **V-series**
+Recommendations defined the telephone-line **[modem](/reference/modem/)** standards (V.21,
+V.22, V.32, V.34, and beyond) whose modulation and handshaking ideas echo through modern data
+modes. And the **G-series** defined the digital speech codecs of the telephone network, most
+famously **[G.711](/reference/g711/)** pulse-code modulation and its relatives, which set the
+template for how voice is digitised. Presenting CCITT as the historical predecessor of ITU-T is
+the accurate framing: the organisation did not disappear so much as change its name and keep
+publishing.
+
+## Relevance to SDR
+
+CCITT-lineage standards describe the letters and tones of some of the oldest decodable digital
+signals on the air. When an SDR user copies **[RTTY](/reference/rtty/)**, the decoder is
+mapping mark/space tones back into ITA2 characters exactly as the CCITT No. 2 alphabet defines
+them. Older HF and phone-patch data modes trace their modulation lineage to the V-series, and
+the G-series codecs describe how sampled voice is represented in countless digital systems.
+Knowing that these carry CCITT names — now formally ITU-T — helps a listener follow
+documentation that predates the 1993 rename.
+
+These legacy modes sit outside GopherTrunk's land-mobile trunking focus, so GopherTrunk does
+not itself decode RTTY or telephone modems; dedicated tools handle those. The reference stands
+as context for the wider RF landscape an SDR user explores, and it resolves the common
+confusion between the historical CCITT name and today's ITU-T.
+
+## Sources
+
+[^home]: [ITU Telecommunication Standardization Sector (ITU-T)](https://www.itu.int/en/ITU-T/) — the official site of the sector that continues the CCITT's work and Recommendation numbering.
+[^wiki]: [ITU-T](https://en.wikipedia.org/wiki/ITU-T) — Wikipedia, for the CCITT's history and its 1993 renaming to ITU-T.

--- a/docs/reference/d-star.md
+++ b/docs/reference/d-star.md
@@ -5,7 +5,7 @@ entry_type: protocol
 category: amateur-digital
 description: D-STAR is an amateur digital-voice and data standard developed by the JARL and popularised by Icom, using GMSK modulation and an AMBE-family vocoder.
 keywords: D-STAR, amateur digital voice, JARL, Icom, GMSK, AMBE, DV, DD mode, reflectors, G2 routing, DPlus, DExtra, DCS
-aka: [D-STAR, DSTAR]
+aka: [D-STAR, DSTAR, DPlus, DExtra]
 autolink: true
 infobox:
   - { label: Type, value: Amateur digital voice + data }

--- a/docs/reference/direct-mode-operation.md
+++ b/docs/reference/direct-mode-operation.md
@@ -1,0 +1,108 @@
+---
+slug: direct-mode-operation
+title: Direct mode operation (DMO)
+entry_type: concept
+category: land-mobile-trunking
+description: Direct mode operation lets radios talk peer-to-peer without any repeater or base station, trading trunking features for line-of-sight simplex range.
+keywords: DMO, direct mode operation, talkaround, simplex, TMO, TETRA direct mode, DMR direct mode, peer to peer radio, off network
+aka: [DMO, Direct mode operation, talkaround, simplex operation]
+autolink: true
+infobox:
+  - { label: Type, value: Peer-to-peer radio mode }
+  - { label: Also called, value: Talkaround, simplex }
+  - { label: Opposite of, value: Trunked mode (TMO) }
+see_also: [tetra, dmr, trunked-radio, talkgroup, conventional-radio, failsoft, channel-grant]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Terrestrial_Trunked_Radio
+  - https://en.wikipedia.org/wiki/Talkaround
+---
+
+**Direct mode operation** (**DMO**) is a mode in which radios talk **peer-to-peer**,
+handset to handset, bypassing the infrastructure entirely — no repeater and no base
+station in the path.[^wiki] It is the counterpart to normal
+[trunked](/reference/trunked-radio/) operation, where every call is routed through a
+network of sites; in DMO the radios simply transmit and receive on a shared channel the
+way a walkie-talkie does. The same idea is called **talkaround** or **simplex** in
+conventional land-mobile parlance.[^talk]
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 180" role="img" aria-label="On the left, two handsets talk directly to each other in direct mode. On the right, two handsets each link through a central tower in trunked mode." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle" stroke="none">
+    <text x="115" y="20" font-size="10">Direct mode (DMO)</text>
+    <text x="345" y="20" font-size="10">Trunked mode (TMO)</text>
+  </g>
+  <g stroke="currentColor" stroke-width="1.3" fill="none">
+    <rect x="40" y="90" width="20" height="40" rx="3"/>
+    <rect x="170" y="90" width="20" height="40" rx="3"/>
+    <line x1="62" y1="100" x2="168" y2="100" stroke-dasharray="4 3"/>
+    <line x1="168" y1="120" x2="62" y2="120" stroke-dasharray="4 3"/>
+  </g>
+  <text x="115" y="150" font-size="8" fill="currentColor" text-anchor="middle">peer-to-peer, line of sight</text>
+  <g stroke="currentColor" stroke-width="1.3" fill="none">
+    <rect x="280" y="95" width="20" height="40" rx="3"/>
+    <rect x="390" y="95" width="20" height="40" rx="3"/>
+    <line x1="345" y1="45" x2="345" y2="80"/>
+    <path d="M336 80 L345 45 L354 80 Z" fill="currentColor" fill-opacity="0.2"/>
+    <line x1="302" y1="105" x2="340" y2="70"/>
+    <line x1="388" y1="105" x2="350" y2="70"/>
+  </g>
+  <text x="345" y="150" font-size="8" fill="currentColor" text-anchor="middle">every call through the site</text>
+</svg>
+<figcaption>DMO keeps traffic between the two radios; trunked mode routes every call through the network's tower.</figcaption>
+</figure>
+
+## How it works
+
+In DMO the two (or more) radios agree on a single simplex frequency and share it: one
+transmits while the others listen, keyed by push-to-talk, with no repeater retransmitting
+the signal on a second frequency. Because nothing amplifies or re-radiates the
+transmission from a tall site, range is strictly **radio-to-radio line of sight** —
+typically a few kilometres on the ground, far less than the wide-area coverage a trunked
+site provides. The trade is deliberate: DMO keeps working when the network cannot.
+
+Different standards give the mode different names but the concept is identical.
+[TETRA](/reference/tetra/) draws the sharpest line, contrasting **DMO** with **TMO**
+(trunked mode operation) as two formally specified modes a radio switches between.
+[DMR](/reference/dmr/) calls it **direct mode**, where two radios share a channel using
+the same two-slot TDMA structure without a repeater. P25 and analog conventional systems
+call it **direct** or **talkaround** — a button that drops the repeater and transmits on
+the output frequency directly.
+
+Switching to DMO means giving up the trunking machinery. There is no control channel, so
+there are no [channel grants](/reference/channel-grant/) assigning a traffic frequency per
+call, no wide-area roaming between sites, and no centralised affiliation of a
+[talkgroup](/reference/talkgroup/). Users pick a channel manually and stay on it. This
+makes DMO closer in spirit to [conventional radio](/reference/conventional-radio/) than to
+trunking, even on a radio that is otherwise a trunked subscriber unit.
+
+## Where it is used
+
+DMO is the fallback and the local-work mode. It is used when radios are **out of network
+coverage** — inside a building, down in a valley, or beyond the last site — and for
+**on-scene traffic** where a crew working together does not need to burden the network,
+such as firefighters on a fireground talking among themselves. It is distinct from
+[failsoft](/reference/failsoft/), the degraded mode a trunked *site* falls back to when it
+loses its controller; DMO removes the infrastructure from the path entirely rather than
+running a crippled version of it.
+
+Many systems allow a **DMO gateway** or **DMO repeater**: a radio or fixed unit that
+bridges direct-mode traffic back into the trunked network, so a crew working simplex on
+scene can still reach dispatch. The gateway listens on the direct channel and relays onto
+the infrastructure, extending DMO's short range without every handset needing a network
+link.
+
+## Relevance to SDR
+
+For an SDR listener, DMO traffic looks different from trunked traffic on the waterfall:
+there is no control channel to follow and no grant to chase, so calls appear as
+intermittent simplex transmissions on fixed frequencies rather than as a managed hop
+across a site's channel pool. GopherTrunk's trunking follower keys on the control channel
+and channel grants, so purely direct-mode conversations fall outside that flow and are
+monitored like conventional channels — parked on the known simplex frequency. Recognising
+that a system has dropped to DMO explains why expected grant activity on the control
+channel goes quiet while voice is still on the air nearby.
+
+## Sources
+
+[^wiki]: [Terrestrial Trunked Radio](https://en.wikipedia.org/wiki/Terrestrial_Trunked_Radio) — Wikipedia, for TETRA's DMO versus TMO distinction and the loss of trunking features off-network.
+[^talk]: [Talkaround](https://en.wikipedia.org/wiki/Talkaround) — Wikipedia, for the conventional/simplex "talkaround" equivalent of direct mode.

--- a/docs/reference/discontinuous-reception.md
+++ b/docs/reference/discontinuous-reception.md
@@ -1,0 +1,94 @@
+---
+slug: discontinuous-reception
+title: Discontinuous reception (DRX)
+entry_type: concept
+category: cellular
+description: Discontinuous reception is a power-saving mechanism that lets an idle device sleep between scheduled paging occasions and wake briefly to check for a page, trading a little latency for large battery savings; extended DRX stretches the cycle to minutes for IoT.
+keywords: DRX, discontinuous reception, eDRX, extended DRX, paging occasion, sleep cycle, battery saving, duty cycle, NB-IoT, LTE-M
+aka: [DRX, Discontinuous reception, eDRX, extended DRX]
+autolink: true
+infobox:
+  - { label: Type, value: Power-saving mechanism }
+  - { label: Idea, value: Receiver duty-cycles between pages }
+  - { label: Extended, value: eDRX (cycle up to minutes) }
+see_also: [nb-iot, lte-m, 5g-nr, registration, lte]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Discontinuous_reception
+  - https://en.wikipedia.org/wiki/Paging_(telecommunications)
+---
+
+**Discontinuous reception** (**DRX**) is a power-saving mechanism in which an idle device's
+receiver **sleeps** between scheduled *paging occasions* and **wakes** only briefly to check
+whether the network is trying to reach it.[^wiki] By keeping the receiver off most of the
+time, DRX trades a little latency — the network may have to wait for the next wake window to
+deliver a page — for large battery savings. It is present in GSM, [LTE](/reference/lte/), and
+[5G NR](/reference/5g-nr/), and its extended form (**eDRX**) stretches the cycle to minutes
+for low-power IoT such as [NB-IoT](/reference/nb-iot/) and [LTE-M](/reference/lte-m/).
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="A timeline of a receiver duty cycle showing long sleep stretches punctuated by short wake windows where the device listens for a paging message." xmlns="http://www.w3.org/2000/svg">
+  <line x1="20" y1="100" x2="440" y2="100" stroke="currentColor" stroke-opacity="0.5"/>
+  <text x="405" y="120" font-size="9" fill="currentColor">time →</text>
+  <g stroke="currentColor" stroke-width="1.4" fill="none">
+    <path d="M20 100 L60 100 L60 55 L78 55 L78 100 L170 100 L170 55 L188 55 L188 100 L280 100 L280 55 L298 55 L298 100 L390 100 L390 55 L408 55 L408 100 L440 100"/>
+  </g>
+  <g font-size="8" fill="currentColor" text-anchor="middle">
+    <text x="115" y="115">sleep</text>
+    <text x="225" y="115">sleep</text>
+    <text x="335" y="115">sleep</text>
+    <text x="69" y="48">wake</text>
+    <text x="179" y="48">wake</text>
+    <text x="289" y="48">wake</text>
+    <text x="399" y="48">wake</text>
+  </g>
+  <text x="230" y="36" text-anchor="middle" font-size="9" fill="currentColor">short "listen for page" windows on a fixed cycle</text>
+</svg>
+<figcaption>DRX duty-cycles the receiver: it stays asleep through long stretches and powers up only at the agreed paging occasions to listen for a page, then sleeps again.</figcaption>
+</figure>
+
+## How it works
+
+When a device registers with the network but has no active data, it enters an idle state and
+negotiates a **DRX cycle** — a repeating period whose length both sides know. Within each
+cycle the device computes, from its own identity, a specific *paging occasion*: a short
+window in which it turns its receiver on and listens for a paging message addressed to it.
+If nothing is there, it powers the receiver back down until the next cycle. Because the
+network knows the device's schedule too, it holds any incoming page until that window and
+transmits it then. The whole scheme rests on both ends agreeing, at
+[registration](/reference/registration/) time, on the cycle length and how the paging
+occasion is derived.
+
+The trade-off is **latency for power**. A longer DRX cycle means the receiver is off a
+greater fraction of the time — dramatically less energy — but an incoming call, message, or
+data push can wait up to one cycle before the device notices it. Ordinary phones use cycles
+of a fraction of a second to a couple of seconds, short enough that the added delay is
+imperceptible while still cutting idle drain sharply. The receiver hardware, not the display,
+is often the dominant idle consumer, so switching it off between pages is one of the largest
+levers on standby battery life.
+
+## Extended DRX and IoT
+
+For devices that must run years on a small battery, standard DRX does not sleep long enough.
+**Extended DRX (eDRX)** stretches the cycle far beyond the normal range — up to minutes, and
+in some configurations longer — so an [NB-IoT](/reference/nb-iot/) or
+[LTE-M](/reference/lte-m/) sensor can stay asleep for a very long interval and still be
+reachable, at the cost of the network tolerating that much delay before a downlink reaches
+it. A related mechanism, Power Saving Mode, goes further still by letting the device become
+essentially unreachable between its own transmissions. Conceptually none of this is new:
+it is the same **duty-cycling** that battery-powered paging receivers have always used —
+listen briefly on a known schedule, sleep the rest of the time.
+
+## Relevance to SDR
+
+DRX is why a monitored idle cellular device is silent on the air most of the time and only
+briefly active: its receiver, and any uplink it sends, follow the negotiated cycle rather
+than a continuous stream. An observer sees traffic clustered around paging occasions rather
+than spread evenly. GopherTrunk decodes land-mobile trunking rather than cellular paging, but
+the same idea — a receiver that duty-cycles to catch a control-channel page and otherwise
+stays idle — describes how battery-powered trunking subscribers conserve power while waiting
+for a call, making DRX useful background for reasoning about intermittent RF activity.
+
+## Sources
+
+[^wiki]: [Discontinuous reception](https://en.wikipedia.org/wiki/Discontinuous_reception) — Wikipedia, for the DRX cycle, paging occasions, and the extended-DRX variant.
+[^paging]: [Paging (telecommunications)](https://en.wikipedia.org/wiki/Paging_(telecommunications)) — Wikipedia, for how networks page idle devices and the duty-cycling that DRX builds on.

--- a/docs/reference/faa.md
+++ b/docs/reference/faa.md
@@ -1,0 +1,82 @@
+---
+slug: faa
+title: Federal Aviation Administration (FAA)
+entry_type: organization
+category: organizations
+description: The FAA, the Federal Aviation Administration, is the US agency that runs the National Airspace System and drove the ADS-B mandate on 1090 MHz and UAT 978.
+keywords: FAA, Federal Aviation Administration, NextGen, ADS-B, UAT, TIS-B, FIS-B, air traffic control, 1090 MHz, 978 MHz
+aka: [FAA, Federal Aviation Administration]
+autolink: true
+infobox:
+  - { label: Type, value: US government agency (DOT) }
+  - { label: Focus, value: Civil aviation, air traffic control }
+  - { label: Founded, value: 1958 }
+  - { label: Standards, value: ADS-B, UAT, TIS-B, FIS-B }
+see_also: [ads-b, uat-978, tis-b, fis-b, mode-s, rtca, icao]
+cite_urls:
+  - https://www.faa.gov/
+  - https://en.wikipedia.org/wiki/Federal_Aviation_Administration
+---
+
+**FAA** (the **Federal Aviation Administration**) is the United States Department of
+Transportation agency that regulates civil aviation and operates the National Airspace
+System, including air traffic control. Its NextGen modernisation drove the US
+**[ADS-B](/reference/ads-b/)** mandate, carried on [Mode S](/reference/mode-s/) at
+1090 MHz and on the **[UAT 978](/reference/uat-978/)** link.[^wiki]
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 150" role="img" aria-label="The FAA's NextGen programme feeds four surveillance and data services: ADS-B on 1090 MHz, UAT on 978 MHz, TIS-B traffic, and FIS-B weather." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="55" width="90" height="34" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="65" y="70">FAA</text><text x="65" y="82" font-size="7.5">NextGen</text>
+    <rect x="300" y="10" width="140" height="26" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="370" y="27">ADS-B · 1090 MHz</text>
+    <rect x="300" y="44" width="140" height="26" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="370" y="61">UAT · 978 MHz</text>
+    <rect x="300" y="78" width="140" height="26" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="370" y="95">TIS-B · traffic</text>
+    <rect x="300" y="112" width="140" height="26" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="370" y="129">FIS-B · weather</text>
+    <g stroke="currentColor" stroke-width="1.1"><line x1="110" y1="72" x2="299" y2="23" marker-end="url(#rel_faa)"/><line x1="110" y1="72" x2="299" y2="57" marker-end="url(#rel_faa)"/><line x1="110" y1="72" x2="299" y2="91" marker-end="url(#rel_faa)"/><line x1="110" y1="72" x2="299" y2="125" marker-end="url(#rel_faa)"/></g>
+  </g>
+  <defs><marker id="rel_faa" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>NextGen ties together the surveillance and data-link services the FAA broadcasts to and from equipped aircraft.</figcaption>
+</figure>
+
+## Overview
+
+The FAA was created in 1958 and is responsible for the safety and regulation of US civil
+aviation: it certifies aircraft and airmen, writes the Federal Aviation Regulations, and runs
+the air traffic control system that keeps the National Airspace System orderly. Over the past
+two decades its defining programme has been **NextGen**, a shift from ground radar to
+satellite-based surveillance, of which **[ADS-B](/reference/ads-b/)** (Automatic Dependent
+Surveillance – Broadcast) is the centrepiece. A rule effective January 2020 mandated ADS-B Out
+in most controlled US airspace.
+
+The FAA specifies two physical links. Air carriers and most turbine aircraft use 1090 MHz
+Extended Squitter, riding on the [Mode S](/reference/mode-s/) transponder, while general
+aviation may instead use the **[UAT 978](/reference/uat-978/)** (Universal Access Transceiver)
+data link at 978 MHz. Because UAT is a two-way link, the FAA's ground infrastructure also
+broadcasts two free services to equipped aircraft: **[TIS-B](/reference/tis-b/)**
+(Traffic Information Service – Broadcast), which relays nearby traffic including non-ADS-B
+targets seen by radar, and **[FIS-B](/reference/fis-b/)** (Flight Information Service –
+Broadcast), which sends weather, NOTAMs, and other advisories. The FAA sets US operational
+requirements but does not write the detailed signal standards alone: it works with
+[RTCA](/reference/rtca/), whose DO-260 series defines the ADS-B message performance, while the
+global framework above the FAA is set by [ICAO](/reference/icao/).
+
+## Relevance to SDR
+
+The FAA's mandates are why the airwaves over the United States are full of decodable aircraft
+data. Because ADS-B, UAT, TIS-B, and FIS-B are open, unencrypted broadcasts designed for
+interoperability, an inexpensive SDR and a dedicated decoder can receive them: 1090 MHz for
+airliners with tools like `dump1090`, and 978 MHz to pull in the traffic and weather pictures
+that TIS-B and FIS-B paint for general aviation. The FAA effectively turned a regulatory
+requirement into one of the most popular SDR hobbies, and crowdsourced feeder networks now
+depend on thousands of these receivers.
+
+Aircraft surveillance sits outside GopherTrunk's land-mobile trunking focus, so GopherTrunk
+does not itself decode these links; dedicated 978/1090 MHz tools handle them. The reference
+stands as context for the wider RF landscape an SDR user explores, and it explains why US
+aviation signals are so uniform and abundant: a single national authority mandated them.
+
+## Sources
+
+[^home]: [Federal Aviation Administration](https://www.faa.gov/) — the FAA's official site, for NextGen, the ADS-B rule, and the UAT/TIS-B/FIS-B services.
+[^wiki]: [Federal Aviation Administration](https://en.wikipedia.org/wiki/Federal_Aviation_Administration) — Wikipedia, for the FAA's history, structure, and role in US aviation.

--- a/docs/reference/flex.md
+++ b/docs/reference/flex.md
@@ -5,7 +5,7 @@ entry_type: protocol
 category: paging-data
 description: "FLEX is a high-speed one-way paging protocol developed by Motorola, using 4-level FSK at up to 6400 bps with strong synchronisation and error correction for reliable wide-area paging."
 keywords: FLEX paging, Motorola FLEX, 4-FSK, high-speed pager, 1600 3200 6400 bps, simulcast paging, ReFLEX, frame phase, time synchronised
-aka: [FLEX]
+aka: [FLEX, ReFLEX]
 autolink: true
 infobox:
   - { label: Type, value: One-way paging protocol }

--- a/docs/reference/frequency-division-duplex.md
+++ b/docs/reference/frequency-division-duplex.md
@@ -1,0 +1,89 @@
+---
+slug: frequency-division-duplex
+title: Frequency-division duplex (FDD)
+entry_type: concept
+category: cellular
+description: Frequency-division duplex carries uplink and downlink at the same time on two separate paired frequency bands kept apart by a duplex gap, the classic scheme for GSM, UMTS, and macro LTE.
+keywords: FDD, frequency division duplex, paired spectrum, duplex gap, uplink downlink, duplexer, GSM, UMTS, LTE
+aka: [FDD, Frequency-division duplex, paired spectrum]
+autolink: true
+infobox:
+  - { label: Type, value: Duplexing scheme }
+  - { label: Separation, value: By frequency (paired bands) }
+  - { label: Traffic, value: Simultaneous both directions }
+see_also: [time-division-duplex, duplexer, fdma, lte, frequency-bands, guard-band]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Duplex_(telecommunications)
+  - https://en.wikipedia.org/wiki/Frequency-division_duplexing
+---
+
+**Frequency-division duplex** (**FDD**) is a two-way radio scheme in which the uplink and
+downlink run **simultaneously** on two **separate, paired frequency bands**.[^wiki] The two
+bands are held apart by a *duplex gap* — a slice of unused spectrum — so a
+[duplexer](/reference/duplexer/) can let a device transmit and receive at the same instant
+without its own transmitter deafening its receiver. FDD is the classic arrangement for
+GSM, UMTS, and most macro-cell [LTE](/reference/lte/) bands, and it stands in contrast to
+[time-division duplex](/reference/time-division-duplex/).
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 150" role="img" aria-label="A frequency axis showing an uplink band on the left, a duplex gap in the middle, and a downlink band on the right, both bands active at the same time." xmlns="http://www.w3.org/2000/svg">
+  <line x1="20" y1="110" x2="440" y2="110" stroke="currentColor" stroke-opacity="0.5"/>
+  <text x="410" y="128" font-size="9" fill="currentColor">frequency →</text>
+  <rect x="40" y="50" width="120" height="60" rx="3" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.3"/>
+  <text x="100" y="44" text-anchor="middle" font-size="10" fill="currentColor">uplink band</text>
+  <text x="100" y="84" text-anchor="middle" font-size="8" fill="currentColor">device → tower</text>
+  <rect x="300" y="50" width="120" height="60" rx="3" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.3"/>
+  <text x="360" y="44" text-anchor="middle" font-size="10" fill="currentColor">downlink band</text>
+  <text x="360" y="84" text-anchor="middle" font-size="8" fill="currentColor">tower → device</text>
+  <line x1="160" y1="70" x2="300" y2="70" stroke="currentColor" stroke-dasharray="4 3" stroke-opacity="0.6"/>
+  <text x="230" y="64" text-anchor="middle" font-size="9" fill="currentColor">duplex gap</text>
+  <text x="230" y="136" text-anchor="middle" font-size="8" fill="currentColor" fill-opacity="0.85">both bands carry traffic at the same time</text>
+</svg>
+<figcaption>FDD splits uplink and downlink onto two paired bands separated by a duplex gap; both are active simultaneously, so the link is continuous in each direction.</figcaption>
+</figure>
+
+## How it works
+
+An FDD deployment allocates two blocks of spectrum a fixed distance apart. The lower block
+usually carries the uplink (device to tower) and the upper the downlink (tower to device),
+with the *duplex spacing* between their centre frequencies fixed by the band plan. Because
+transmit and receive sit on different frequencies, the device's [duplexer](/reference/duplexer/)
+— a pair of sharp filters — passes the receive band to the receiver while blocking the
+device's own transmit energy from swamping it. The duplex gap gives those filters room to
+roll off; a [guard band](/reference/guard-band/) at the edge of each block keeps adjacent
+operators from interfering.
+
+The defining property is **continuity**: since each direction owns its own frequency full
+time, data flows both ways without interruption and with low, constant latency. There is no
+switching overhead and no need to reserve time for turning the link around. The cost is
+**paired spectrum** — a regulator must hand out two matched blocks, and the duplex gap
+between them cannot be used for traffic, so some spectrum is spent purely on separation.
+FDD is naturally symmetric: uplink and downlink get equal bandwidth whether or not the
+traffic is balanced.
+
+## Band plans and paired spectrum
+
+Cellular [frequency bands](/reference/frequency-bands/) are numbered, and each FDD band
+specifies both halves of the pair plus the spacing between them — for example, LTE Band 1
+pairs a 1920–1980 MHz uplink with a 2110–2170 MHz downlink, 190 MHz apart. Multiple users
+share each band through [FDMA](/reference/fdma/) and other multiplexing on top of the
+duplex split. Because download traffic now dominates, the rigid symmetry of FDD is
+sometimes a poor fit for data-heavy use, which is one reason newer mid-band allocations
+lean on time-division duplex instead. Established FDD bands remain the backbone of wide-area
+macro coverage, where their simplicity, range, and predictable latency are assets.
+
+## Relevance to SDR
+
+FDD is why a cellular signal you find on an SDR spectrum display appears as two mirror
+blocks of activity separated by a quiet gap: the busy tower downlink is the one an
+uncoordinated receiver hears strongly, while the uplink sits in its own band far below the
+noise unless a handset is nearby. Recognising the paired structure — and the fixed duplex
+spacing of each band — helps identify which cellular technology and band a signal belongs
+to. GopherTrunk targets land-mobile trunking rather than cellular, but the same duplexing
+concepts describe how trunked repeaters separate their inbound and outbound paths, so FDD
+is useful background for reading any two-way RF spectrum.
+
+## Sources
+
+[^wiki]: [Frequency-division duplexing](https://en.wikipedia.org/wiki/Frequency-division_duplexing) — Wikipedia, for the definition of FDD, paired bands, and the duplex gap.
+[^duplex]: [Duplex (telecommunications)](https://en.wikipedia.org/wiki/Duplex_(telecommunications)) — Wikipedia, for full-duplex operation and the contrast between frequency- and time-division duplexing.

--- a/docs/reference/identification-friend-or-foe.md
+++ b/docs/reference/identification-friend-or-foe.md
@@ -1,0 +1,101 @@
+---
+slug: identification-friend-or-foe
+title: Identification friend or foe (IFF)
+entry_type: technology
+category: aviation-marine
+description: IFF is a military challenge-and-reply transponder system from WWII, using 1030 MHz interrogations and 1090 MHz replies; civil secondary surveillance radar descends from it.
+keywords: IFF, identification friend or foe, secondary surveillance radar, SSR, transponder, interrogator, 1030 MHz, 1090 MHz, Mode 5, challenge reply
+aka: [IFF, Identification friend or foe, secondary surveillance radar]
+autolink: true
+infobox:
+  - { label: Type, value: Military transponder system }
+  - { label: Frequencies, value: "1030 MHz challenge / 1090 MHz reply" }
+  - { label: Origin, value: World War II }
+see_also: [mode-ac, mode-s, ads-b, tcas, encryption]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Identification_friend_or_foe
+  - https://en.wikipedia.org/wiki/Secondary_surveillance_radar
+---
+
+**Identification friend or foe** (**IFF**) is a military transponder-and-interrogator
+system, born in World War II, that answers a single question: is this radar contact a
+friend?[^wiki] A ground or airborne **interrogator** transmits a coded challenge on
+**1030 MHz**, and a friendly **transponder** aboard the target replies on **1090 MHz**
+with a coded answer. Civil **secondary surveillance radar** (SSR) — the
+[Mode A/C](/reference/mode-ac/) and [Mode S](/reference/mode-s/) systems that track
+airliners — descends directly from IFF and shares the very same frequency pair.[^ssr]
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 190" role="img" aria-label="A ground interrogator transmits a challenge at 1030 megahertz to an aircraft transponder, which replies at 1090 megahertz." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" stroke-width="1.3" fill="none">
+    <path d="M40 150 L60 110 L80 150 Z" fill="currentColor" fill-opacity="0.15"/>
+    <line x1="60" y1="110" x2="60" y2="95"/>
+    <path d="M380 55 L420 45 L400 65 Z" fill="currentColor" fill-opacity="0.15"/>
+    <line x1="360" y1="60" x2="400" y2="52"/>
+  </g>
+  <g stroke="currentColor" stroke-width="1.2" fill="none">
+    <path d="M75 100 Q220 40 375 55" marker-end="url(#iff_arrow)"/>
+    <path d="M375 80 Q220 120 80 130" marker-end="url(#iff_arrow)"/>
+  </g>
+  <g font-size="9" fill="currentColor">
+    <text x="55" y="168" text-anchor="middle">interrogator</text>
+    <text x="400" y="38" text-anchor="middle">transponder</text>
+    <text x="200" y="62" text-anchor="middle">challenge → 1030 MHz</text>
+    <text x="210" y="140" text-anchor="middle">← reply 1090 MHz</text>
+  </g>
+  <defs><marker id="iff_arrow" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>The interrogator challenges on 1030 MHz; a friendly transponder replies on 1090 MHz. No reply is not proof of a foe.</figcaption>
+</figure>
+
+## How it works
+
+IFF is a **cooperative** system: it works only because the friendly aircraft carries a
+transponder that recognises the challenge and answers correctly. The interrogator sends a
+pulse-coded challenge in one of several **modes**, and a valid transponder replies with a
+coded response after a fixed delay. Matching the reply to the interrogation confirms the
+contact is equipped and responding as a friend. This is fundamentally different from
+primary radar, which merely bounces energy off a target and reports a blip with no
+identity attached.
+
+The wartime lineage runs straight into today's civil airspace. The military "modes" of
+early IFF were opened for air-traffic use as **SSR Modes A and C** — Mode A returns a
+four-digit squawk code, Mode C adds pressure altitude — and later
+[Mode S](/reference/mode-s/) added selective, addressed interrogation and the data link
+that [ADS-B](/reference/ads-b/) rides on. All of them still use the 1030/1090 MHz pair
+inherited from IFF, which is why a single antenna and receiver band covers both military
+and civil secondary surveillance.
+
+Modern military IFF has moved well beyond those open modes. **Mode 5** uses
+[encryption](/reference/encryption/) and spread-spectrum techniques so that challenges and
+replies cannot be spoofed or exploited by an adversary, replacing the older Mode 4. The
+civil and military systems coexist on the same frequencies but the secure military modes
+are cryptographically protected.
+
+## What it can and cannot do
+
+The name is precise and slightly misleading. IFF identifies **friends** — it cannot mark
+**foes**. A correct reply positively confirms a friend; the *absence* of a reply means
+only that the contact is not a responding friend. It could be an enemy, or it could be a
+friendly aircraft with a broken, switched-off, or wrongly keyed transponder. For this
+reason IFF is one input to identification, never a standalone weapons-release
+authority. The same cooperative-only limitation applies to civil SSR: an aircraft with no
+working transponder is invisible to secondary radar even though it is plainly a friend,
+which is part of why [TCAS](/reference/tcas/) collision avoidance and primary radar exist
+alongside it.
+
+## Relevance to SDR
+
+For the SDR hobbyist, IFF's civil descendants are the accessible part: the 1090 MHz replies
+that carry Mode A/C squawks, Mode S addresses, and ADS-B position reports are unencrypted
+and decodable with a cheap receiver and software like `dump1090`. The military secure modes
+are not. Understanding IFF explains *why* the aviation surveillance band is arranged the way
+it is — a challenge-and-reply architecture from the 1940s, still built on 1030 MHz up and
+1090 MHz down. Aircraft surveillance sits outside GopherTrunk's land-mobile trunking focus,
+so it does not decode 1090 MHz itself; the reference stands as context for the wider RF
+landscape.
+
+## Sources
+
+[^wiki]: [Identification friend or foe](https://en.wikipedia.org/wiki/Identification_friend_or_foe) — Wikipedia, for IFF's WWII origin, the 1030/1090 MHz challenge-reply pair, modes, and Mode 5.
+[^ssr]: [Secondary surveillance radar](https://en.wikipedia.org/wiki/Secondary_surveillance_radar) — Wikipedia, for how civil SSR Modes A/C and S descend from IFF and share its frequencies.

--- a/docs/reference/iec.md
+++ b/docs/reference/iec.md
@@ -1,0 +1,83 @@
+---
+slug: iec
+title: International Electrotechnical Commission (IEC)
+entry_type: organization
+category: organizations
+description: The IEC, the International Electrotechnical Commission, is the international standards body for electrical and electronic technologies, co-running ISO/IEC JTC 1 and publishing standards such as IEC 61162 behind AIS.
+keywords: IEC, International Electrotechnical Commission, ISO/IEC JTC 1, IEC 61162, NMEA, electrical standards, electronic standards, Geneva
+aka: [IEC, International Electrotechnical Commission]
+autolink: true
+infobox:
+  - { label: Type, value: International standards body }
+  - { label: Focus, value: Electrical & electronic technologies }
+  - { label: Founded, value: 1906 }
+  - { label: Standards, value: "IEC 61162, ISO/IEC JTC 1" }
+see_also: [itu, nist, etsi, ieee, ais]
+cite_urls:
+  - https://www.iec.ch/
+  - https://en.wikipedia.org/wiki/International_Electrotechnical_Commission
+---
+
+**IEC** (the **International Electrotechnical Commission**) is the international standards
+organisation for electrical, electronic, and related technologies. It partners with ISO in the
+joint committee **ISO/IEC JTC 1** for information technology, and it publishes standards that
+reach radio and data gear — including IEC 61162, the interface behind
+**[AIS](/reference/ais/)** data.[^wiki]
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="The IEC and ISO jointly run the ISO/IEC JTC 1 committee for IT standards, while the IEC separately publishes electrical, electronic, and interface standards." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="20" width="90" height="30" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="65" y="39">IEC</text>
+    <rect x="20" y="88" width="90" height="30" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="65" y="107">ISO</text>
+    <rect x="200" y="54" width="110" height="30" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="255" y="69">ISO/IEC JTC 1</text><text x="255" y="80" font-size="7.5">IT standards</text>
+    <rect x="355" y="18" width="95" height="26" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="402" y="35" font-size="7.5">electrical / safety</text>
+    <rect x="355" y="94" width="95" height="26" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="402" y="111" font-size="7.5">IEC 61162 · AIS</text>
+    <g stroke="currentColor" stroke-width="1.1"><line x1="110" y1="40" x2="199" y2="64" marker-end="url(#rel_iec)"/><line x1="110" y1="100" x2="199" y2="74" marker-end="url(#rel_iec)"/><line x1="110" y1="32" x2="354" y2="30" marker-end="url(#rel_iec)"/><line x1="110" y1="45" x2="354" y2="106" marker-end="url(#rel_iec)"/></g>
+  </g>
+  <defs><marker id="rel_iec" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>The IEC co-runs JTC 1 with ISO for IT standards and separately publishes the electrical and interface standards that touch radio hardware.</figcaption>
+</figure>
+
+## Overview
+
+The IEC was founded in 1906 and, from its headquarters in Geneva, prepares and publishes
+international standards for all electrical, electronic, and related technologies — collectively
+"electrotechnology." Its national committees represent member countries, and its standards
+range from the fundamentals of quantities and units to product safety, connectors, and
+electromagnetic compatibility. The IEC also administers conformity-assessment schemes that let
+equipment certified in one country be accepted in others.
+
+Where the IEC's work meets the SDR world is twofold. First, it partners with ISO in the joint
+technical committee **ISO/IEC JTC 1**, which develops information-technology standards — from
+character encodings to coding and interconnection — that underpin the digital systems radios
+increasingly embed. Second, the IEC publishes standards that directly touch radio and
+navigation data: connector and safety standards for the hardware, and maritime interface
+standards such as **IEC 61162**, the internationally standardised counterpart of the NMEA 0183
+serial protocol used to move **[AIS](/reference/ais/)**, GPS, and other navigation data between
+shipboard equipment. It is worth distinguishing the IEC from three neighbours it is easily
+confused with: the [ITU](/reference/itu/) governs spectrum and telecommunications, the US-based
+[NIST](/reference/nist/) maintains measurement standards, and the [IEEE](/reference/ieee/) is a
+US-based professional body whose engineering standards (such as the 802 networking series) are
+distinct from the IEC's, while in Europe [ETSI](/reference/etsi/) handles telecommunications
+standards.
+
+## Relevance to SDR
+
+The IEC rarely defines an over-the-air waveform directly — that is the province of the ITU,
+ETSI, and industry bodies — but its standards shape the gear and the data around a receiver.
+The IEC 61162 / NMEA interface is the format in which a decoded **[AIS](/reference/ais/)** or
+GNSS stream is passed from a receiver into charting and logging software, so an SDR user who
+feeds AIS sentences into a plotter is handling IEC-standardised data. IEC safety, connector,
+and electromagnetic-compatibility standards also govern the physical hardware — power supplies,
+cabling, and shielding — that determines how clean a receive chain is.
+
+Those standards sit alongside rather than inside GopherTrunk's trunking decode path, so
+GopherTrunk does not implement IEC standards directly. The reference stands as context for the
+wider ecosystem of standards bodies whose work an SDR user encounters, and it clarifies where
+the IEC fits relative to the ITU, IEEE, and ETSI.
+
+## Sources
+
+[^home]: [International Electrotechnical Commission](https://www.iec.ch/) — the IEC's official site, for its standards catalogue, JTC 1 role, and conformity schemes.
+[^wiki]: [International Electrotechnical Commission](https://en.wikipedia.org/wiki/International_Electrotechnical_Commission) — Wikipedia, for the IEC's history, structure, and standards role.

--- a/docs/reference/imo.md
+++ b/docs/reference/imo.md
@@ -1,0 +1,83 @@
+---
+slug: imo
+title: International Maritime Organization (IMO)
+entry_type: organization
+category: organizations
+description: The IMO, the International Maritime Organization, is the UN agency for maritime safety that adopts SOLAS and, through it, mandates the GMDSS radio systems including AIS and DSC.
+keywords: IMO, International Maritime Organization, SOLAS, GMDSS, AIS, DSC, EPIRB, NAVTEX, MMSI, maritime safety
+aka: [IMO, International Maritime Organization]
+autolink: true
+infobox:
+  - { label: Type, value: UN specialised agency }
+  - { label: Focus, value: Maritime safety, pollution prevention }
+  - { label: Founded, value: 1948 }
+  - { label: Standards, value: SOLAS, GMDSS }
+see_also: [ais, dsc, navtex, epirb-406, solas, cospas-sarsat, itu]
+cite_urls:
+  - https://www.imo.org/
+  - https://en.wikipedia.org/wiki/International_Maritime_Organization
+---
+
+**IMO** (the **International Maritime Organization**) is the United Nations agency for
+maritime safety and the prevention of marine pollution. It adopts the
+**[SOLAS](/reference/solas/)** convention and, through it, mandates the radio systems that
+keep ships safe — including **[AIS](/reference/ais/)** position reporting and
+**[DSC](/reference/dsc/)** digital distress alerting.[^wiki]
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 150" role="img" aria-label="The IMO adopts the SOLAS convention, whose GMDSS chapter mandates four radio systems: AIS, DSC, EPIRB, and NAVTEX." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="15" y="58" width="90" height="34" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="60" y="79">IMO</text>
+    <rect x="150" y="58" width="100" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="200" y="73">SOLAS</text><text x="200" y="85" font-size="7.5">GMDSS</text>
+    <rect x="315" y="10" width="130" height="26" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="380" y="27">AIS · position</text>
+    <rect x="315" y="44" width="130" height="26" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="380" y="61">DSC · distress</text>
+    <rect x="315" y="78" width="130" height="26" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="380" y="95">EPIRB · beacon</text>
+    <rect x="315" y="112" width="130" height="26" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="380" y="129">NAVTEX · safety</text>
+    <g stroke="currentColor" stroke-width="1.1"><line x1="105" y1="75" x2="149" y2="75" marker-end="url(#rel_imo)"/><line x1="250" y1="75" x2="314" y2="23" marker-end="url(#rel_imo)"/><line x1="250" y1="75" x2="314" y2="57" marker-end="url(#rel_imo)"/><line x1="250" y1="75" x2="314" y2="91" marker-end="url(#rel_imo)"/><line x1="250" y1="75" x2="314" y2="125" marker-end="url(#rel_imo)"/></g>
+  </g>
+  <defs><marker id="rel_imo" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>The IMO adopts SOLAS, whose GMDSS provisions mandate the maritime radio systems an SDR listener meets on the VHF and HF bands.</figcaption>
+</figure>
+
+## Overview
+
+The IMO was established in 1948 (as the Inter-Governmental Maritime Consultative Organization,
+renamed in 1982) and is the UN specialised agency responsible for the safety and security of
+shipping and the prevention of pollution by ships. It works largely by adopting international
+conventions that member states then bring into national law. Its flagship instrument is the
+**[SOLAS](/reference/solas/)** convention (Safety of Life at Sea), whose radio chapter defines
+the **Global Maritime Distress and Safety System (GMDSS)** — the mandatory suite of automated
+alerting and safety-communication equipment carried by SOLAS-class ships.
+
+Several of the GMDSS components are radio systems an SDR user will recognise.
+**[DSC](/reference/dsc/)** (Digital Selective Calling) sends digital distress and calling
+alerts on dedicated channels; **[NAVTEX](/reference/navtex/)** broadcasts navigational and
+meteorological safety messages as narrow-band direct printing on 518 kHz;
+**[EPIRB](/reference/epirb-406/)** beacons transmit distress alerts on 406 MHz to the
+[Cospas-Sarsat](/reference/cospas-sarsat/) satellite system; and **[AIS](/reference/ais/)**
+(Automatic Identification System) continuously reports each ship's identity, position, course,
+and speed on VHF. The IMO also issues the permanent **IMO ship identification number**, and
+together with the [ITU](/reference/itu/) it underpins the **MMSI** (Maritime Mobile Service
+Identity) numbers that identify vessels in DSC and AIS traffic. The ITU allocates the spectrum
+and specifies the technical radio characteristics; the IMO mandates that ships carry and use
+the equipment.
+
+## Relevance to SDR
+
+The IMO's mandates are why coastal VHF is full of decodable maritime data. Because AIS is an
+open, unencrypted broadcast on 161.975 and 162.025 MHz, a modest SDR and an AIS decoder can
+plot ships in real time, and the same receivers feed crowdsourced vessel-tracking networks.
+NAVTEX on 518 kHz and DSC on the VHF and HF distress channels are likewise receivable and
+decodable with common SDR tools, letting a listener read the safety-broadcast and alerting
+layer the IMO built into GMDSS.
+
+Maritime signals sit outside GopherTrunk's land-mobile trunking focus, so GopherTrunk does not
+itself decode AIS or NAVTEX; dedicated tools handle those. The reference stands as context for
+the wider RF landscape an SDR user explores, and it explains why maritime radio is so uniform
+worldwide: a single UN body, through SOLAS, harmonised it.
+
+## Sources
+
+[^home]: [International Maritime Organization](https://www.imo.org/) — the IMO's official site, for SOLAS, the GMDSS, and the maritime identity schemes.
+[^wiki]: [International Maritime Organization](https://en.wikipedia.org/wiki/International_Maritime_Organization) — Wikipedia, for the IMO's history, structure, and conventions.

--- a/docs/reference/imt.md
+++ b/docs/reference/imt.md
@@ -1,0 +1,96 @@
+---
+slug: imt
+title: International Mobile Telecommunications (IMT)
+entry_type: technology
+category: cellular
+description: IMT is the ITU-R umbrella under which each mobile generation is defined by minimum requirements a technology must meet to be badged — IMT-2000 for 3G, IMT-Advanced for 4G, and IMT-2020 for 5G.
+keywords: IMT, International Mobile Telecommunications, IMT-2000, IMT-Advanced, IMT-2020, 3G, 4G, 5G, ITU-R, mobile generation, IMT spectrum
+aka: [IMT, International Mobile Telecommunications, IMT-2000, IMT-Advanced, IMT-2020]
+autolink: true
+infobox:
+  - { label: Type, value: ITU-R requirement framework }
+  - { label: Sets, value: Minimum targets per generation }
+  - { label: Milestones, value: "IMT-2000 (3G), -Advanced (4G), -2020 (5G)" }
+see_also: [itu-r, lte, lte-advanced, 5g-nr, umts-wcdma, wrc, cellular-handover]
+cite_urls:
+  - https://www.itu.int/en/ITU-R/study-groups/rsg5/rwp5d/imt/Pages/default.aspx
+  - https://en.wikipedia.org/wiki/International_Mobile_Telecommunications
+---
+
+**International Mobile Telecommunications** (**IMT**) is the [ITU-R](/reference/itu-r/)
+umbrella under which each mobile **generation** is defined by the minimum requirements a
+technology must meet to be badged with it.[^itu] IMT does not itself design radios: it sets
+targets — peak data rate, latency, mobility, spectral efficiency — and any radio standard
+that meets them qualifies as an IMT technology. The milestones map onto the familiar
+generations: **IMT-2000** is 3G, **IMT-Advanced** is 4G, and **IMT-2020** is 5G.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 160" role="img" aria-label="A timeline from IMT-2000 for 3G to IMT-Advanced for 4G to IMT-2020 for 5G, with the qualifying 3GPP technologies listed under each milestone." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="55" x2="430" y2="55" stroke="currentColor" stroke-opacity="0.5"/>
+  <g fill="currentColor"><circle cx="90" cy="55" r="4"/><circle cx="230" cy="55" r="4"/><circle cx="370" cy="55" r="4"/></g>
+  <g font-size="10" fill="currentColor" text-anchor="middle">
+    <text x="90" y="40">IMT-2000</text>
+    <text x="230" y="40">IMT-Advanced</text>
+    <text x="370" y="40">IMT-2020</text>
+  </g>
+  <g font-size="8" fill="currentColor" text-anchor="middle" fill-opacity="0.85">
+    <text x="90" y="78">3G</text>
+    <text x="230" y="78">4G</text>
+    <text x="370" y="78">5G</text>
+  </g>
+  <g font-size="8" fill="currentColor" text-anchor="middle">
+    <rect x="52" y="92" width="76" height="20" rx="3" fill="none" stroke="currentColor" stroke-width="1"/><text x="90" y="105">UMTS / WCDMA</text>
+    <rect x="188" y="92" width="84" height="20" rx="3" fill="none" stroke="currentColor" stroke-width="1"/><text x="230" y="105">LTE-Advanced</text>
+    <rect x="336" y="92" width="68" height="20" rx="3" fill="none" stroke="currentColor" stroke-width="1"/><text x="370" y="105">5G NR</text>
+  </g>
+  <text x="230" y="140" text-anchor="middle" font-size="8" fill="currentColor" fill-opacity="0.85">ITU-R sets the targets; 3GPP standards are the radios that qualify</text>
+</svg>
+<figcaption>Each IMT milestone names a generation by requirement; the boxes below are the 3GPP radio technologies that met the targets and earned the badge.</figcaption>
+</figure>
+
+## How it works
+
+IMT is a framework maintained by the ITU Radiocommunication Sector, ITU-R, working through
+its study groups. For each generation, ITU-R publishes a set of **minimum technical
+requirements**: quantities such as peak and user-experienced data rate, control- and
+user-plane latency, mobility (the speed at which a link must hold up), connection density,
+and spectral efficiency. A candidate radio technology is then evaluated against those
+numbers, and if it passes it is accepted into the IMT family for that generation. The scheme
+deliberately separates **requirements** from **implementation**: the ITU says what a
+generation must achieve, and industry decides how.
+
+The radios that actually meet the targets come almost entirely from **3GPP**, the standards
+partnership that authors the mobile air interfaces. [UMTS/WCDMA](/reference/umts-wcdma/)
+qualified under IMT-2000; [LTE-Advanced](/reference/lte-advanced/) — the enhanced release of
+[LTE](/reference/lte/) — met the IMT-Advanced bar for 4G; and [5G NR](/reference/5g-nr/)
+satisfies IMT-2020. (Baseline LTE was marketed as 4G before it fully met IMT-Advanced, a
+common gap between the marketing label and the formal badge.) Because the requirement is what
+defines the generation, the same milestone can admit more than one qualifying technology, and
+a technology is a "true" member of a generation only once ITU-R accepts it.
+
+## Spectrum and the WRC
+
+A generation needs spectrum as well as a standard. The **[World Radiocommunication
+Conference](/reference/wrc/)** (WRC), the ITU treaty conference held every few years,
+identifies bands as **"IMT spectrum"** — the frequency ranges administrations agree to make
+available for IMT systems. These identifications, recorded in the international Radio
+Regulations, are what let the same 3G/4G/5G bands be reused across borders, so a device and
+its [handovers](/reference/cellular-handover/) work internationally. IMT thus ties together
+three ITU workstreams: the *requirements* (IMT framework), the *evaluation* of candidate
+radios, and the *spectrum* identifications made at the WRC.
+
+## Relevance to SDR
+
+IMT is the vocabulary behind the generation labels an SDR user meets constantly — "3G",
+"4G", "5G" are shorthand for IMT-2000, IMT-Advanced, and IMT-2020 — and the WRC's IMT-band
+identifications explain why cellular signals appear in the same frequency ranges worldwide.
+Knowing that a badge is a *requirement*, not a single radio, clarifies why several
+technologies can share a generation. GopherTrunk decodes land-mobile trunking rather than
+IMT cellular systems, but IMT frames the wider mobile-spectrum landscape an SDR listener
+navigates, and the ITU's role here mirrors its role in allocating the land-mobile spectrum
+GopherTrunk does target.
+
+## Sources
+
+[^itu]: [IMT — ITU-R Working Party 5D](https://www.itu.int/en/ITU-R/study-groups/rsg5/rwp5d/imt/Pages/default.aspx) — the ITU-R group responsible for the IMT framework and the minimum requirements for each generation.
+[^wiki]: [International Mobile Telecommunications](https://en.wikipedia.org/wiki/International_Mobile_Telecommunications) — Wikipedia, for the IMT-2000, IMT-Advanced, and IMT-2020 milestones and their qualifying technologies.

--- a/docs/reference/ip-address.md
+++ b/docs/reference/ip-address.md
@@ -5,7 +5,8 @@ entry_type: concept
 category: hw-networking
 description: An IP address is a numeric label assigned to each device on a network running the Internet Protocol, identifying the host and letting packets be routed to it; IPv4 uses 32 bits, IPv6 uses 128.
 keywords: IP address, IPv4, IPv6, Internet Protocol, subnet, subnet mask, DHCP, NAT, dotted quad, host address
-aka: [Internet Protocol address]
+aka: [Internet Protocol address, IPv4, IPv6]
+autolink: true
 infobox:
   - { label: Type, value: Network address }
   - { label: Identifies, value: A host on an IP network }

--- a/docs/reference/modulation-and-coding-scheme.md
+++ b/docs/reference/modulation-and-coding-scheme.md
@@ -1,0 +1,85 @@
+---
+slug: modulation-and-coding-scheme
+title: Modulation and coding scheme (MCS)
+entry_type: concept
+category: modulation
+description: A modulation and coding scheme is an index that jointly selects a modulation order and a forward-error-correction code rate; link adaptation picks the highest MCS the channel's SNR can carry.
+keywords: MCS, modulation and coding scheme, modulation and coding index, link adaptation, adaptive modulation and coding, AMC, CQI, LTE, 5G NR, Wi-Fi, throughput
+aka: [MCS, Modulation and coding scheme, modulation and coding index]
+autolink: true
+infobox:
+  - { label: Type, value: Link-adaptation index }
+  - { label: Selects, value: "Modulation order + FEC code rate" }
+  - { label: Driven by, value: "Measured SNR / CQI" }
+  - { label: Used by, value: "LTE, 5G NR, Wi-Fi" }
+see_also: [quadrature-amplitude-modulation, forward-error-correction, signal-to-noise-ratio, spectral-efficiency, lte, wifi-80211, shannon-capacity]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Link_adaptation
+  - https://en.wikipedia.org/wiki/Adaptive_modulation_and_coding
+---
+
+A **modulation and coding scheme** (**MCS**) is an index that *jointly* selects a
+modulation order — [QPSK](/reference/qpsk/), 16-, 64-, or 256-level
+[QAM](/reference/quadrature-amplitude-modulation/) — and a
+[forward-error-correction](/reference/forward-error-correction/) code rate.[^link] One MCS
+number therefore pins down both how many bits ride on each symbol and how much redundancy
+protects them, so a transmitter can trade robustness for throughput with a single choice.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 200" role="img" aria-label="A ladder in which rising SNR selects a higher MCS index, mapping to a higher modulation order and code rate and thus higher throughput." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" stroke-width="1.2"><line x1="40" y1="175" x2="40" y2="20" marker-end="url(#rel_mcs)"/><line x1="40" y1="175" x2="440" y2="175" marker-end="url(#rel_mcs)"/></g>
+  <text x="18" y="100" font-size="9" fill="currentColor" transform="rotate(-90 18 100)" text-anchor="middle">throughput →</text>
+  <text x="240" y="195" font-size="9" fill="currentColor" text-anchor="middle">measured SNR / CQI →</text>
+  <g font-size="8" fill="currentColor" text-anchor="middle">
+    <rect x="60" y="140" width="96" height="26" rx="4" fill="currentColor" fill-opacity="0.10" stroke="currentColor" stroke-width="1.1"/><text x="108" y="151">MCS low</text><text x="108" y="161" font-size="7">QPSK, rate 1/3</text>
+    <rect x="182" y="104" width="96" height="26" rx="4" fill="currentColor" fill-opacity="0.13" stroke="currentColor" stroke-width="1.1"/><text x="230" y="115">MCS mid</text><text x="230" y="125" font-size="7">16QAM, rate 1/2</text>
+    <rect x="304" y="68" width="96" height="26" rx="4" fill="currentColor" fill-opacity="0.16" stroke="currentColor" stroke-width="1.1"/><text x="352" y="79">MCS high</text><text x="352" y="89" font-size="7">64QAM, rate 3/4</text>
+    <rect x="340" y="30" width="96" height="26" rx="4" fill="currentColor" fill-opacity="0.20" stroke="currentColor" stroke-width="1.1"/><text x="388" y="41">MCS top</text><text x="388" y="51" font-size="7">256QAM, rate 5/6</text>
+  </g>
+</svg>
+<figcaption>Link adaptation climbs the ladder: the better the measured channel, the higher the MCS index — a higher modulation order and lighter coding — and the more bits per second the link carries.</figcaption>
+</figure>
+
+## How it works
+
+The point of an MCS table is **link adaptation**, also called **adaptive modulation and
+coding (AMC)**.[^amc] The receiver measures channel quality — a
+[signal-to-noise ratio](/reference/signal-to-noise-ratio/) estimate, reported in cellular
+systems as a Channel Quality Indicator (CQI) — and the transmitter selects the *highest* MCS
+index that the channel can still decode reliably. When the link is strong, a high MCS packs
+many bits per symbol with light coding, maximising
+[spectral efficiency](/reference/spectral-efficiency/). As the channel degrades — the user
+moves away, fades, or picks up interference — the scheduler steps down to a lower MCS: a
+smaller modulation order and a stronger code, fewer bits per symbol but a lower error rate.
+The system is, in effect, chasing the [Shannon capacity](/reference/shannon-capacity/) of the
+instantaneous channel, holding the error rate roughly constant while throughput floats up and
+down with conditions.
+
+Each MCS index is a fixed row in a standard's table, so both ends agree on exactly what
+modulation and code rate an index means. Higher index means more bits per symbol but demands
+higher SNR to decode; there is no free lunch — the ladder simply lets the link ride as high as
+the moment allows.
+
+## In practice
+
+MCS tables are central to modern wireless. **[LTE](/reference/lte/)** defines an MCS index
+(0–28) that the eNodeB assigns per user per subframe based on reported CQI. **5G NR** extends
+the idea with multiple MCS tables, including a 256QAM table for strong links and a
+low-spectral-efficiency table for coverage edges. **[Wi-Fi](/reference/wifi-80211/)** (802.11n
+onward) has its own MCS index spanning BPSK through 256QAM/1024QAM and several code rates, with
+the rate-control algorithm picking an index per frame. In every case the same principle holds:
+one index, jointly chosen, tracking the channel.
+
+## Relevance to SDR
+
+For an SDR observer, the MCS carried in a system's control signalling is a live readout of link
+quality — a high index means the base station judges the channel excellent, a low index means it
+is fighting fades or range. Decoding those control fields reveals how a network is adapting
+without ever touching the payload. GopherTrunk's land-mobile trunking targets (P25, DMR, NXDN,
+TETRA) use fixed modulation rather than a per-burst MCS ladder, so MCS is documented here as the
+adaptive-link concept an SDR user meets in cellular and Wi-Fi monitoring.
+
+## Sources
+
+[^link]: [Link adaptation](https://en.wikipedia.org/wiki/Link_adaptation) — Wikipedia, for the joint selection of modulation and code rate by an MCS index and its role in matching the channel.
+[^amc]: [Adaptive modulation and coding](https://en.wikipedia.org/wiki/Adaptive_modulation_and_coding) — Wikipedia, for AMC, CQI feedback, and the MCS tables used in LTE, 5G NR, and Wi-Fi.

--- a/docs/reference/nrsc.md
+++ b/docs/reference/nrsc.md
@@ -1,0 +1,79 @@
+---
+slug: nrsc
+title: National Radio Systems Committee (NRSC)
+entry_type: organization
+category: organizations
+description: The NRSC, the National Radio Systems Committee, is a joint NAB/CTA body that sets US terrestrial broadcast standards, including NRSC-5 for HD Radio and the RBDS variant of RDS.
+keywords: NRSC, National Radio Systems Committee, NRSC-5, HD Radio, IBOC, NRSC-4, RBDS, RDS, NAB, CTA, broadcast standards
+aka: [NRSC, National Radio Systems Committee]
+autolink: true
+infobox:
+  - { label: Type, value: US broadcast standards committee }
+  - { label: Focus, value: Terrestrial AM/FM broadcasting }
+  - { label: Sponsors, value: "NAB and CTA" }
+  - { label: Standards, value: "NRSC-5, NRSC-4, RBDS" }
+see_also: [hd-radio, rds, broadcast-am, broadcast-fm, fcc]
+cite_urls:
+  - https://www.nrscstandards.org/
+  - https://en.wikipedia.org/wiki/National_Radio_Systems_Committee
+---
+
+**NRSC** (the **National Radio Systems Committee**) is a joint committee of the US National
+Association of Broadcasters (NAB) and the Consumer Technology Association (CTA) that sets
+standards for terrestrial radio broadcasting — including **[HD Radio](/reference/hd-radio/)**
+and the **[RBDS](/reference/rds/)** data system on
+**[FM](/reference/broadcast-fm/)** and **[AM](/reference/broadcast-am/)**.[^wiki]
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="The NRSC, sponsored by NAB and CTA, publishes three broadcast standards: NRSC-5 HD Radio, NRSC-4 the AM emission mask, and RBDS." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="55" width="100" height="34" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="70" y="70">NRSC</text><text x="70" y="82" font-size="7.5">NAB + CTA</text>
+    <rect x="300" y="12" width="150" height="28" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="375" y="30" font-size="8">NRSC-5 · HD Radio (IBOC)</text>
+    <rect x="300" y="58" width="150" height="28" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="375" y="76" font-size="8">NRSC-4 · AM mask</text>
+    <rect x="300" y="104" width="150" height="28" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="375" y="122" font-size="8">RBDS · US RDS</text>
+    <g stroke="currentColor" stroke-width="1.1"><line x1="120" y1="66" x2="299" y2="26" marker-end="url(#rel_nrsc)"/><line x1="120" y1="72" x2="299" y2="72" marker-end="url(#rel_nrsc)"/><line x1="120" y1="78" x2="299" y2="118" marker-end="url(#rel_nrsc)"/></g>
+  </g>
+  <defs><marker id="rel_nrsc" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>The NRSC's standards define US digital radio (NRSC-5), the AM emission mask (NRSC-4), and the RBDS data layer on FM and AM.</figcaption>
+</figure>
+
+## Overview
+
+The NRSC is a technical standards-setting body jointly sponsored by the **National Association
+of Broadcasters (NAB)** and the **Consumer Technology Association (CTA)**. It brings
+broadcasters and equipment makers together to write voluntary standards that keep US
+terrestrial AM and FM radio — and the receivers built for it — interoperable. Its standards are
+frequently referenced by the [FCC](/reference/fcc/) in rulemaking, giving them practical force
+even though the committee itself is an industry body rather than a regulator.
+
+Three of its standards matter most to a radio listener. **NRSC-5** defines
+**[HD Radio](/reference/hd-radio/)**, the **in-band on-channel (IBOC)** system that lets a
+station broadcast digital audio and data in the sidebands of its existing analog AM or FM
+channel, so a single assignment carries both analog and digital services. **NRSC-4** specifies
+the **AM emission mask** — the limits on an AM station's occupied bandwidth and spectral
+splatter that keep adjacent channels clean. And the committee standardised **RBDS** (the Radio
+Broadcast Data System), the US variant of Europe's **[RDS](/reference/rds/)**, which carries
+station name, program type, song text, and traffic flags in a low-rate subcarrier on
+**[FM](/reference/broadcast-fm/)**. Together these define how US **[AM](/reference/broadcast-am/)**
+and FM broadcasting delivers digital audio and data alongside the legacy analog signal.
+
+## Relevance to SDR
+
+The NRSC's standards describe signals an SDR user routinely encounters across the broadcast
+band. The RBDS/RDS subcarrier on an FM station is openly decodable — many SDR programs display
+the station name and now-playing text pulled straight from that data group — and the structure
+they parse is the one the NRSC standardised. HD Radio's IBOC sidebands are visible on a
+waterfall as the digital "shoulders" flanking an analog FM or AM carrier, and open decoders
+exist that recover the NRSC-5 digital audio and program-service data. Knowing which standard
+defines a given feature helps a listener interpret what appears on the spectrum.
+
+Broadcast radio sits outside GopherTrunk's land-mobile trunking focus, so GopherTrunk does not
+itself decode HD Radio or RBDS; dedicated tools handle those. The reference stands as context
+for the wider RF landscape an SDR user explores, and it identifies the body that makes US AM
+and FM digital and data services consistent from one station and receiver to the next.
+
+## Sources
+
+[^home]: [NRSC Standards](https://www.nrscstandards.org/) — the NRSC's official standards site, for NRSC-5, NRSC-4, and RBDS documents.
+[^wiki]: [National Radio Systems Committee](https://en.wikipedia.org/wiki/National_Radio_Systems_Committee) — Wikipedia, for the committee's sponsors, history, and standards.

--- a/docs/reference/rtty.md
+++ b/docs/reference/rtty.md
@@ -5,7 +5,7 @@ entry_type: protocol
 category: amateur-digital
 description: "RTTY (Radioteletype) is a classic digital mode that sends text as 5-bit Baudot characters over frequency-shift keying, historically at 45.45 baud with a 170 Hz shift."
 keywords: RTTY, radioteletype, Baudot, ITA2, FSK, frequency shift keying, mark, space, 45.45 baud, 170 Hz shift, amateur radio, teletype
-aka: [RTTY, Radioteletype]
+aka: [RTTY, Radioteletype, LTRS, FIGS]
 autolink: true
 infobox:
   - { label: Type, value: Text-over-radio digital mode }

--- a/docs/reference/single-frequency-network.md
+++ b/docs/reference/single-frequency-network.md
@@ -1,0 +1,91 @@
+---
+slug: single-frequency-network
+title: Single-frequency network (SFN)
+entry_type: technology
+category: broadcast
+description: A single-frequency network has many transmitters broadcast the identical signal on the same frequency, tightly time-synchronised so OFDM's guard interval turns the overlapping copies into constructive multipath; used by DAB, DVB-T, and ATSC 3.0.
+keywords: SFN, single-frequency network, multi-frequency network, MFN, OFDM, guard interval, GPS synchronisation, DAB, DVB-T, ISDB-T, ATSC 3.0, simulcast
+aka: [SFN, Single-frequency network]
+autolink: true
+infobox:
+  - { label: Type, value: Broadcast transmitter network }
+  - { label: Key enabler, value: "OFDM guard interval" }
+  - { label: Synchronisation, value: GPS-disciplined timing }
+  - { label: Used by, value: "DAB, DVB-T/T2, ISDB-T, ATSC 3.0" }
+see_also: [ofdm, dab, dvb-t, atsc-3, isdb-t, simulcast, guard-band, multipath-propagation]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Single-frequency_network
+  - https://en.wikipedia.org/wiki/Orthogonal_frequency-division_multiplexing
+---
+
+A **single-frequency network** (**SFN**) has multiple transmitters broadcast the
+*identical* signal on the **same frequency**, tightly synchronised in time so their
+overlapping coverage reinforces rather than clashes.[^wiki] It is made possible by
+[OFDM](/reference/ofdm/): the modulation's guard interval absorbs the delayed copies
+arriving from neighbouring transmitters as constructive
+[multipath](/reference/multipath-propagation/) instead of interference.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 420 220" role="img" aria-label="Three transmitter towers, all labelled frequency f-zero, with overlapping coverage circles and a receiver sitting in the region where all three overlap." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" stroke-width="1.2" fill="none" stroke-opacity="0.45">
+    <circle cx="120" cy="90" r="80"/><circle cx="290" cy="90" r="80"/><circle cx="205" cy="160" r="80"/>
+  </g>
+  <g stroke="currentColor" stroke-width="1.4" fill="currentColor">
+    <g><line x1="120" y1="90" x2="120" y2="55"/><path d="M120 55 L112 40 M120 55 L128 40" fill="none"/><circle cx="120" cy="90" r="3"/></g>
+    <g><line x1="290" y1="90" x2="290" y2="55"/><path d="M290 55 L282 40 M290 55 L298 40" fill="none"/><circle cx="290" cy="90" r="3"/></g>
+    <g><line x1="205" y1="160" x2="205" y2="125"/><path d="M205 125 L197 110 M205 125 L213 110" fill="none"/><circle cx="205" cy="160" r="3"/></g>
+  </g>
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <text x="120" y="36">f₀</text><text x="290" y="36">f₀</text><text x="205" y="106">f₀</text>
+  </g>
+  <g><path d="M205 120 l-7 -12 h14 z" fill="currentColor"/><circle cx="205" cy="112" r="4" fill="none" stroke="currentColor" stroke-width="1.3"/></g>
+  <text x="205" y="200" text-anchor="middle" font-size="9" fill="currentColor">receiver in the overlap hears all three as constructive multipath</text>
+</svg>
+<figcaption>Every tower radiates the identical signal on the same frequency f₀; a receiver in the overlap combines the time-aligned copies as reinforcement, not interference.</figcaption>
+</figure>
+
+## How it works
+
+In an ordinary network, two transmitters on the same channel would jam each other wherever their
+coverage met. OFDM changes the arithmetic. It divides the signal across many narrow subcarriers
+and prepends each symbol with a **guard interval** — a short copy of the symbol's tail. Any echo
+that arrives within that guard window, whether it is a reflection off terrain or a copy from a
+second transmitter, lands inside the same symbol period and adds coherently at the receiver.
+Provided every transmitter radiates bit-for-bit the same waveform at the same instant, a distant
+transmitter is indistinguishable from a natural echo, and the receiver treats the sum as
+constructive [multipath](/reference/multipath-propagation/).
+
+Two conditions make this work. The transmitters must be **frequency- and time-locked**, which in
+practice means GPS-disciplined references so their clocks and symbol timing agree to a fraction
+of the guard interval. And the network's inter-transmitter spacing must keep differential delays
+within that guard window — a longer guard interval permits wider spacing at the cost of some
+throughput. Get either wrong and the delayed copies fall outside the guard window and become
+inter-symbol interference instead of reinforcement.
+
+## In practice
+
+SFNs save spectrum. A **multi-frequency network (MFN)** gives each transmitter its own channel to
+avoid mutual interference, consuming several channels to cover a region; an SFN covers the same
+region on a single channel, freeing the rest for other services. Digital broadcasting adopted the
+technique widely: **[DAB](/reference/dab/)** digital radio, **[DVB-T](/reference/dvb-t/)** and
+DVB-T2 television, Japan's **[ISDB-T](/reference/isdb-t/)**, and
+**[ATSC 3.0](/reference/atsc-3/)** all run SFNs, and HD Radio uses on-channel boosters on the same
+principle. The SFN is the digital-broadcast cousin of analog land-mobile
+[simulcast](/reference/simulcast/), which likewise keys several transmitters together on one
+frequency — but where analog simulcast must carefully manage overlap distortion, OFDM's guard
+interval handles it by design.
+
+## Relevance to SDR
+
+An SDR receiving a digital-broadcast multiplex in an SFN region is, without any special handling,
+demodulating the coherent sum of several transmitters — one reason OFDM broadcasts stay robust
+indoors and in cluttered terrain. Understanding SFNs explains why a strong digital signal can
+originate from more than one tower at once, and why signal-quality metrics behave differently from
+a single-transmitter link. SFN broadcasting sits outside GopherTrunk's land-mobile trunking scope,
+but it is documented here as the OFDM network architecture behind the digital-radio and television
+signals an SDR user encounters alongside trunked voice.
+
+## Sources
+
+[^wiki]: [Single-frequency network](https://en.wikipedia.org/wiki/Single-frequency_network) — Wikipedia, for the identical-signal same-frequency design, GPS synchronisation, and the SFN-versus-MFN spectrum trade.
+[^ofdm]: [Orthogonal frequency-division multiplexing](https://en.wikipedia.org/wiki/Orthogonal_frequency-division_multiplexing) — Wikipedia, for the guard interval that lets an OFDM receiver absorb delayed copies as constructive multipath.

--- a/docs/reference/sitor.md
+++ b/docs/reference/sitor.md
@@ -1,0 +1,106 @@
+---
+slug: sitor
+title: SITOR
+entry_type: protocol
+category: aviation-marine
+description: SITOR is an HF maritime radiotelex mode with error correction, built on the CCIR 476 code; SITOR-A uses ARQ handshaking and SITOR-B uses one-way FEC, as in NAVTEX.
+keywords: SITOR, simplex teleprinting over radio, radiotelex, CCIR 476, SITOR-A, SITOR-B, ARQ, FEC, NAVTEX, AMTOR, HF maritime
+aka: [SITOR, Simplex teleprinting over radio, NAVTEX mode, AMTOR]
+autolink: true
+infobox:
+  - { label: Full name, value: Simplex Teleprinting Over Radio }
+  - { label: Code, value: CCIR 476 (7-bit, 4:3 ratio) }
+  - { label: Modes, value: "SITOR-A (ARQ), SITOR-B (FEC)" }
+see_also: [navtex, rtty, forward-error-correction, marine-vhf, dsc, frequency-shift-keying]
+cite_urls:
+  - https://en.wikipedia.org/wiki/SITOR
+  - https://en.wikipedia.org/wiki/Telex#Radioteletype
+---
+
+**SITOR** — **Simplex Teleprinting Over Radio** — is an HF maritime radiotelex mode that
+adds **error correction** to teleprinter traffic over shortwave.[^wiki] Where plain
+[RTTY](/reference/rtty/) sends characters with no way to catch a corrupted bit, SITOR is
+built on the 7-bit **CCIR 476** code, a *constant-ratio* code in which every valid
+character has exactly **four mark bits and three space bits** — so any bit flipped in
+transit breaks the 4:3 ratio and is instantly flagged as an error. It is transmitted as
+[frequency-shift keying](/reference/frequency-shift-keying/) on HF.[^telex]
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 200" role="img" aria-label="SITOR-A on the left shows two stations exchanging request and acknowledge handshake arrows; SITOR-B on the right shows one transmitter broadcasting repeated time-diverse blocks one way." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="10" fill="currentColor" text-anchor="middle" stroke="none">
+    <text x="115" y="18">SITOR-A (ARQ)</text>
+    <text x="345" y="18">SITOR-B (FEC)</text>
+  </g>
+  <g stroke="currentColor" stroke-width="1.3" fill="none">
+    <rect x="35" y="70" width="22" height="42" rx="3"/>
+    <rect x="175" y="70" width="22" height="42" rx="3"/>
+    <path d="M58 80 L173 80" marker-end="url(#st_arrow)"/>
+    <path d="M173 102 L58 102" marker-end="url(#st_arrow)"/>
+  </g>
+  <g font-size="8" fill="currentColor" text-anchor="middle" stroke="none">
+    <text x="115" y="76">block →</text>
+    <text x="115" y="116">← acknowledge / repeat</text>
+    <text x="115" y="150" font-size="8">two-way handshake</text>
+  </g>
+  <g stroke="currentColor" stroke-width="1.3" fill="none">
+    <rect x="290" y="70" width="22" height="42" rx="3"/>
+    <path d="M313 78 L430 78" marker-end="url(#st_arrow)"/>
+    <path d="M313 91 L430 91" marker-end="url(#st_arrow)"/>
+    <path d="M313 104 L430 104" marker-end="url(#st_arrow)"/>
+  </g>
+  <g font-size="8" fill="currentColor" text-anchor="middle" stroke="none">
+    <text x="372" y="128">same block sent twice,</text>
+    <text x="372" y="140">time-spaced (diversity)</text>
+    <text x="372" y="162" font-size="8">one-way broadcast</text>
+  </g>
+  <defs><marker id="st_arrow" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>SITOR-A handshakes between two stations and re-requests bad blocks; SITOR-B broadcasts one way, repeating each block time-spaced so a receiver can recover it.</figcaption>
+</figure>
+
+## How it works
+
+The foundation is the constant-ratio **CCIR 476** alphabet. By fixing the number of marks
+and spaces in every symbol, the code turns simple bit errors into detectable violations:
+a receiver that gets a character with the wrong mark/space count knows it is corrupt
+without needing a checksum. SITOR then uses that detection differently in its two modes.
+
+**SITOR-A** is an **ARQ** (Automatic Repeat reQuest) mode for a two-way link between a
+specific pair of stations. The sender transmits short blocks of characters and pauses; the
+receiver checks each block and sends back a brief acknowledgement, and any block that fails
+the ratio test is **re-requested** and sent again. The two stations alternate in a tight
+handshake, so throughput drops on a poor channel but the delivered text is essentially
+error-free. This is the mode used for point-to-point radiotelex traffic.
+
+**SITOR-B** is a **[forward-error-correction](/reference/forward-error-correction/)** mode
+for **one-way broadcast**, where there is no return path to request repeats. Instead of
+asking again, the transmitter sends **each character twice, separated in time** — a form of
+time diversity. A receiver that gets a corrupt copy of a character can fall back on the
+delayed second copy, so short fades and noise bursts rarely take out both. Because it needs
+no acknowledgement, one transmitter can serve any number of listeners at once.
+
+## Family and relatives
+
+SITOR spawned a family. **[NAVTEX](/reference/navtex/)**, the international maritime safety
+broadcast service on **518 kHz**, is simply SITOR-B carrying navigational warnings, weather,
+and search-and-rescue notices to any ship in range. **AMTOR** (Amateur Teleprinting Over
+Radio) is the amateur-radio adaptation of SITOR, using the same CCIR 476 code and the same
+ARQ/FEC pair of modes. All of them descend from the commercial and maritime radiotelex
+networks that carried teleprinter traffic over HF before satellite links, and they remain
+in service for the robustness that constant-ratio coding gives on a noisy shortwave channel.
+
+## Decoding it with GopherTrunk
+
+SITOR is an HF, narrowband FSK mode, well outside GopherTrunk's VHF/UHF land-mobile
+trunking focus, so GopherTrunk does not decode it. It is documented here because an SDR
+listener sweeping the marine HF bands will encounter its distinctive sound — the
+chirping, paused "chirp-chirp-pause" of SITOR-A's handshake, or the steady stream of
+SITOR-B/NAVTEX — and because decoding it needs only a general-coverage receiver and a
+soundcard decoder such as those that read NAVTEX on 518 kHz. Recognising SITOR's two modes
+by ear (handshaking pauses versus continuous broadcast) tells you immediately whether you
+are hearing a two-station radiotelex link or a one-way safety broadcast.
+
+## Sources
+
+[^wiki]: [SITOR](https://en.wikipedia.org/wiki/SITOR) — Wikipedia, for the CCIR 476 constant-ratio code, the SITOR-A ARQ and SITOR-B FEC modes, and the NAVTEX/AMTOR relationships.
+[^telex]: [Radioteletype](https://en.wikipedia.org/wiki/Telex#Radioteletype) — Wikipedia, for HF radiotelex context and how error-corrected teleprinter modes work over shortwave.

--- a/docs/reference/solas.md
+++ b/docs/reference/solas.md
@@ -1,0 +1,105 @@
+---
+slug: solas
+title: SOLAS
+entry_type: concept
+category: aviation-marine
+description: SOLAS is the IMO's core maritime safety treaty; it mandates the GMDSS, which is why the DSC, NAVTEX, EPIRB, and AIS signals an SDR listener hears exist and are standardized.
+keywords: SOLAS, Safety of Life at Sea, GMDSS, IMO, maritime safety convention, DSC, NAVTEX, EPIRB, AIS, distress alerting
+aka: [SOLAS, Safety of Life at Sea, GMDSS]
+autolink: true
+infobox:
+  - { label: Full name, value: "Int'l Convention for the Safety of Life at Sea" }
+  - { label: Adopted by, value: "IMO" }
+  - { label: Mandates, value: GMDSS radio systems }
+see_also: [ais, dsc, navtex, epirb-406, cospas-sarsat, imo, marine-vhf]
+cite_urls:
+  - https://en.wikipedia.org/wiki/SOLAS_Convention
+  - https://en.wikipedia.org/wiki/Global_Maritime_Distress_and_Safety_System
+---
+
+**SOLAS** — the **International Convention for the Safety of Life at Sea** — is the core
+maritime safety treaty, adopted and maintained by the [IMO](/reference/imo/).[^wiki] For an
+SDR listener its importance is indirect but decisive: SOLAS is the regulation that *requires*
+ships to carry particular radio equipment, so the maritime signals you hear on the bands exist
+and are standardized because a treaty says they must. Above set tonnage thresholds, SOLAS
+mandates the **Global Maritime Distress and Safety System** (**GMDSS**) — the coordinated suite
+of radio systems that handles distress alerting, safety broadcasts, and position reporting at
+sea.[^gmdss]
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 210" role="img" aria-label="A ship carrying the GMDSS radio systems SOLAS mandates: AIS for position reporting, DSC for digital distress alerting, a NAVTEX receiver for safety broadcasts, and an EPIRB satellite distress beacon." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" stroke-width="1.4" fill="none">
+    <path d="M120 150 L340 150 L320 178 L140 178 Z" fill="currentColor" fill-opacity="0.1"/>
+    <line x1="230" y1="150" x2="230" y2="95"/>
+    <line x1="210" y1="120" x2="250" y2="120"/>
+  </g>
+  <g font-size="8.5" fill="currentColor" text-anchor="middle" stroke="none">
+    <text x="230" y="168">SOLAS ship — GMDSS fit</text>
+  </g>
+  <g stroke="currentColor" stroke-width="1.1" fill="none">
+    <line x1="150" y1="150" x2="70" y2="60" marker-end="url(#so_a)"/>
+    <line x1="200" y1="150" x2="175" y2="55" marker-end="url(#so_a)"/>
+    <line x1="270" y1="150" x2="300" y2="55" marker-end="url(#so_a)"/>
+    <line x1="320" y1="150" x2="400" y2="60" marker-end="url(#so_a)"/>
+  </g>
+  <g font-size="8" fill="currentColor" text-anchor="middle" stroke="none">
+    <text x="60" y="48">AIS</text><text x="60" y="38" font-size="7">position</text>
+    <text x="172" y="48">DSC</text><text x="172" y="38" font-size="7">distress alert</text>
+    <text x="303" y="48">NAVTEX</text><text x="303" y="38" font-size="7">safety info</text>
+    <text x="405" y="48">EPIRB</text><text x="405" y="38" font-size="7">sat beacon</text>
+  </g>
+  <defs><marker id="so_a" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>SOLAS obliges ships to carry a GMDSS fit; each mandated system is a signal an SDR user can receive.</figcaption>
+</figure>
+
+## What SOLAS requires
+
+SOLAS is organised into chapters covering construction, fire protection, life-saving
+appliances, and — the part that matters here — **radiocommunications**. Its radio chapter
+requires ships on international voyages, above defined tonnages, to carry GMDSS equipment
+appropriate to the sea areas they operate in. Rather than specify one radio, GMDSS layers
+several systems so that a distress can always be raised and safety information always
+received, whether a ship is near shore or mid-ocean. The treaty sets the *requirement*; the
+technical formats are standardized internationally so that equipment from any
+manufacturer interoperates worldwide.
+
+That mandate is why a handful of maritime signals are so consistent and widespread:
+
+- **[Digital Selective Calling](/reference/dsc/)** (DSC) — the digital distress-alerting layer
+  on [marine VHF](/reference/marine-vhf/) channel 70 and on MF/HF, used to send an automated,
+  addressed distress or safety call that includes the ship's identity and position.
+- **[NAVTEX](/reference/navtex/)** — the 518 kHz maritime safety broadcast service delivering
+  navigational warnings, weather, and search-and-rescue notices to a printer or screen aboard.
+- **[EPIRB](/reference/epirb-406/)** — the 406 MHz emergency position-indicating radio beacon
+  that, when a vessel sinks, transmits a distress signal to the
+  [Cospas-Sarsat](/reference/cospas-sarsat/) satellite network.
+- **[AIS](/reference/ais/)** — the Automatic Identification System, broadcasting each ship's
+  identity, position, course, and speed on VHF for collision avoidance and traffic monitoring.
+
+Larger ships also carry satellite terminals for long-range distress and communications, closing
+the coverage gap beyond terrestrial range.
+
+## Why it matters to the listener
+
+The practical takeaway is that SOLAS is the **regulatory driver** behind nearly everything an
+SDR user hears on the marine bands. AIS is dense and continuous precisely because every SOLAS
+ship must transmit it; DSC calls appear on channel 70 because the treaty requires the watch;
+NAVTEX runs on schedule on 518 kHz because ships must be able to receive safety broadcasts.
+These are open, standardized, unencrypted signals — designed for interoperability and safety —
+which is exactly what makes them so accessible to a hobbyist receiver.
+
+## Relevance to SDR
+
+Maritime signals fall outside GopherTrunk's land-mobile trunking focus, so GopherTrunk does not
+decode AIS, DSC, NAVTEX, or EPIRB itself; dedicated tools and a general-coverage or VHF receiver
+handle those. SOLAS is documented here as the *why* behind them: it explains why the maritime RF
+landscape looks the way it does and why its systems are so uniform across the world's oceans — a
+single treaty, administered by the [IMO](/reference/imo/), obliges every qualifying ship to carry
+the same standardized GMDSS radios. Understanding that connection turns a scattered set of marine
+signals into a coherent, purpose-built safety network.
+
+## Sources
+
+[^wiki]: [SOLAS Convention](https://en.wikipedia.org/wiki/SOLAS_Convention) — Wikipedia, for SOLAS's status as the core maritime safety treaty and its radiocommunications requirements.
+[^gmdss]: [Global Maritime Distress and Safety System](https://en.wikipedia.org/wiki/Global_Maritime_Distress_and_Safety_System) — Wikipedia, for the GMDSS systems (DSC, NAVTEX, EPIRB, AIS, satellite) SOLAS mandates.

--- a/docs/reference/system-fusion-ysf.md
+++ b/docs/reference/system-fusion-ysf.md
@@ -5,7 +5,7 @@ entry_type: protocol
 category: amateur-digital
 description: "System Fusion (Yaesu System Fusion, YSF) is Yaesu's amateur C4FM digital-voice system, supporting digital and analog modes with an AMBE-family vocoder and internet-linked rooms."
 keywords: System Fusion, YSF, Yaesu, C4FM, amateur digital voice, Fusion, Wires-X, AMBE, AMS, DN VW mode, digital narrow, voice full rate
-aka: [System Fusion, Yaesu System Fusion, YSF, Fusion]
+aka: [System Fusion, Yaesu System Fusion, YSF, Fusion, WIRES-X]
 autolink: true
 infobox:
   - { label: Type, value: Amateur digital voice }

--- a/docs/reference/tapr.md
+++ b/docs/reference/tapr.md
@@ -1,0 +1,80 @@
+---
+slug: tapr
+title: Tucson Amateur Packet Radio (TAPR)
+entry_type: organization
+category: organizations
+description: TAPR, Tucson Amateur Packet Radio, is a US amateur-radio non-profit that pioneered digital communications, building the early TNCs behind AX.25 packet radio and co-defining the KISS protocol.
+keywords: TAPR, Tucson Amateur Packet Radio, TNC, TNC-2, AX.25, KISS, packet radio, open hardware, DCC, amateur radio
+aka: [TAPR, Tucson Amateur Packet Radio]
+autolink: true
+infobox:
+  - { label: Type, value: Amateur-radio non-profit R&D }
+  - { label: Focus, value: Amateur digital communications }
+  - { label: Founded, value: 1982 }
+  - { label: Standards, value: "TNC hardware, KISS" }
+see_also: [packet-radio, ax25, kiss-tnc, arrl, aprs]
+cite_urls:
+  - https://tapr.org/
+  - https://en.wikipedia.org/wiki/Tucson_Amateur_Packet_Radio
+---
+
+**TAPR** (**Tucson Amateur Packet Radio**) is a US amateur-radio non-profit that pioneered
+amateur digital communications. It developed the early terminal node controllers that put
+**[AX.25](/reference/ax25/)** **[packet radio](/reference/packet-radio/)** on the air and
+co-defined the **[KISS](/reference/kiss-tnc/)** host-to-TNC protocol.[^wiki]
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 110" role="img" aria-label="A TAPR milestone timeline from the TNC-1 and TNC-2 controllers, through the KISS protocol, to later open hardware and software-defined radio projects." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="60" x2="430" y2="60" stroke="currentColor" stroke-width="1.2"/>
+  <g font-size="8.5" fill="currentColor" text-anchor="middle">
+    <circle cx="70" cy="60" r="4" fill="currentColor"/><text x="70" y="44">TNC-1 / TNC-2</text><text x="70" y="82" font-size="7.5">AX.25 on air</text>
+    <circle cx="200" cy="60" r="4" fill="currentColor"/><text x="200" y="44">KISS</text><text x="200" y="82" font-size="7.5">host ↔ TNC</text>
+    <circle cx="330" cy="60" r="4" fill="currentColor"/><text x="330" y="44">open hardware</text><text x="330" y="82" font-size="7.5">GPSDO · SDR</text>
+    <text x="405" y="52" font-size="9">→</text>
+  </g>
+</svg>
+<figcaption>From the first packet TNCs to open hardware, TAPR has driven amateur digital-radio experimentation for four decades.</figcaption>
+</figure>
+
+## Overview
+
+TAPR was founded in 1982 in Tucson, Arizona, and quickly became the focal point of the amateur
+packet-radio movement. Its defining early achievement was the **terminal node controller**
+(TNC) — the modem-and-protocol box that sits between a radio and a computer. The
+**TAPR TNC-1** and, especially, the widely cloned **TNC-2** made **[packet
+radio](/reference/packet-radio/)** affordable and interoperable, letting hams exchange data
+over VHF using the **[AX.25](/reference/ax25/)** link-layer protocol. TAPR later helped define
+**[KISS](/reference/kiss-tnc/)** ("Keep It Simple, Stupid"), the minimal framing protocol that
+lets a host computer drive a TNC directly, moving the protocol intelligence into software — a
+design that endures in modern soundcard and SDR-based packet setups.
+
+Beyond packet, TAPR has long championed **open hardware** and experimentation. Over the years
+its projects and kits have spanned GPS-disciplined oscillators for precise frequency and
+timing references, digital signal processing, and software-defined radio, and it developed an
+early open-hardware licence to keep such designs freely shareable. TAPR also co-hosts, with the
+**[ARRL](/reference/arrl/)**, the annual **Digital Communications Conference (DCC)**, a long-
+running venue for papers and demonstrations on amateur digital modes. That community and its
+tooling fed directly into modern systems such as **[APRS](/reference/aprs/)** (the Automatic
+Packet Reporting System), which rides on the same AX.25 packet foundation TAPR helped
+establish.
+
+## Relevance to SDR
+
+TAPR's legacy is everywhere a hobbyist decodes amateur data. The AX.25 framing and KISS
+interface it helped standardise are exactly what a modern SDR-plus-software packet station
+speaks: a soundcard modem or SDR replaces the old hardware TNC, but the on-air protocol and the
+KISS link to the host are unchanged, which is why decades-old packet gear and new SDR setups
+interoperate. APRS position and telemetry beacons, widely received with cheap SDRs, are built
+on that same lineage. TAPR's open-hardware ethos also seeded much of the culture — shared
+designs, GPSDO references, and community conferences — that the wider SDR world now takes for
+granted.
+
+Amateur packet sits outside GopherTrunk's land-mobile trunking focus, so GopherTrunk does not
+itself decode AX.25 or APRS; dedicated tools handle those. The reference stands as context for
+the wider RF landscape an SDR user explores, and it credits the organisation whose early work
+made amateur digital radio open and interoperable in the first place.
+
+## Sources
+
+[^home]: [Tucson Amateur Packet Radio](https://tapr.org/) — TAPR's official site, for its projects, kits, open-hardware work, and the DCC.
+[^wiki]: [Tucson Amateur Packet Radio](https://en.wikipedia.org/wiki/Tucson_Amateur_Packet_Radio) — Wikipedia, for TAPR's history, the TNC-2, and its role in packet radio.

--- a/docs/reference/tetra.md
+++ b/docs/reference/tetra.md
@@ -5,7 +5,7 @@ entry_type: protocol
 category: land-mobile-trunking
 description: TETRA (Terrestrial Trunked Radio) is an ETSI digital trunked-radio standard using four-slot TDMA and π/4-DQPSK, widely used by public safety and transport outside North America.
 keywords: TETRA, Terrestrial Trunked Radio, ETSI, four-slot TDMA, pi/4-DQPSK, ACELP, public safety Europe, TETRA 2, TEDS, direct mode
-aka: [TETRA, Terrestrial Trunked Radio]
+aka: [TETRA, Terrestrial Trunked Radio, MCCH]
 autolink: true
 infobox:
   - { label: Type, value: Digital trunked radio }

--- a/docs/reference/time-division-duplex.md
+++ b/docs/reference/time-division-duplex.md
@@ -1,0 +1,94 @@
+---
+slug: time-division-duplex
+title: Time-division duplex (TDD)
+entry_type: concept
+category: cellular
+description: Time-division duplex shares one frequency for uplink and downlink by alternating them in time slots separated by a guard period, needing no paired spectrum and allowing an asymmetric split, used by TD-LTE and much of 5G NR.
+keywords: TDD, time division duplex, unpaired spectrum, guard period, uplink downlink, TD-LTE, 5G NR, asymmetric traffic
+aka: [TDD, Time-division duplex]
+autolink: true
+infobox:
+  - { label: Type, value: Duplexing scheme }
+  - { label: Separation, value: By time (one shared band) }
+  - { label: Traffic, value: Alternating, splittable ratio }
+see_also: [frequency-division-duplex, tdma, lte, 5g-nr, guard-band]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Time-division_duplex
+  - https://en.wikipedia.org/wiki/Duplex_(telecommunications)
+---
+
+**Time-division duplex** (**TDD**) is a two-way radio scheme in which the uplink and
+downlink **share one frequency**, taking turns in **time slots** separated by a short
+*guard period*.[^wiki] Because both directions use the same channel, TDD needs no paired
+spectrum, and the split between uplink and downlink time can be tuned to match asymmetric,
+download-heavy traffic. It powers TD-LTE and much of [5G NR](/reference/5g-nr/) in the
+mid-band and mmWave ranges, and it stands in contrast to
+[frequency-division duplex](/reference/frequency-division-duplex/).
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 150" role="img" aria-label="A single frequency shown over a time axis, alternating downlink and uplink slots with a small guard gap between each transmission." xmlns="http://www.w3.org/2000/svg">
+  <line x1="20" y1="120" x2="440" y2="120" stroke="currentColor" stroke-opacity="0.5"/>
+  <text x="405" y="138" font-size="9" fill="currentColor">time →</text>
+  <text x="20" y="40" font-size="9" fill="currentColor">one frequency</text>
+  <g stroke="currentColor" stroke-width="1.3">
+    <rect x="40" y="50" width="90" height="60" rx="3" fill="currentColor" fill-opacity="0.22"/>
+    <rect x="150" y="50" width="40" height="60" rx="3" fill="currentColor" fill-opacity="0.08"/>
+    <rect x="210" y="50" width="90" height="60" rx="3" fill="currentColor" fill-opacity="0.22"/>
+    <rect x="320" y="50" width="40" height="60" rx="3" fill="currentColor" fill-opacity="0.08"/>
+    <rect x="380" y="50" width="55" height="60" rx="3" fill="currentColor" fill-opacity="0.22"/>
+  </g>
+  <text x="85" y="84" text-anchor="middle" font-size="9" fill="currentColor">DL</text>
+  <text x="170" y="84" text-anchor="middle" font-size="7" fill="currentColor">UL</text>
+  <text x="255" y="84" text-anchor="middle" font-size="9" fill="currentColor">DL</text>
+  <text x="340" y="84" text-anchor="middle" font-size="7" fill="currentColor">UL</text>
+  <text x="407" y="84" text-anchor="middle" font-size="9" fill="currentColor">DL</text>
+  <text x="170" y="44" text-anchor="middle" font-size="7" fill="currentColor">guard</text>
+</svg>
+<figcaption>TDD keeps a single frequency and alternates downlink and uplink in time; a small guard period between them lets one side stop before the other starts. The DL/UL ratio can be skewed toward download.</figcaption>
+</figure>
+
+## How it works
+
+A TDD frame is divided into slots that are assigned to the downlink or the uplink on a
+repeating schedule. At any instant only one direction is transmitting on the channel, so
+transmit and receive never overlap and no [duplexer](/reference/duplexer/) filter pair is
+required — the radio simply switches between transmitting and receiving. Between a downlink
+burst and the following uplink burst the network inserts a **guard period**: a brief silence
+that lets the previous transmission's signal clear the air (accounting for propagation delay
+across the cell) before the other end begins, preventing the two directions from colliding.
+This is the same time-sharing idea as [TDMA](/reference/tdma/) applied to the duplex
+direction rather than to separating users.
+
+The two big advantages are **unpaired spectrum** and an **adjustable split**. A regulator
+can allocate a single contiguous block, and the operator decides how many slots go to
+download versus upload — a natural fit for modern traffic, which is heavily download-biased.
+The costs are **tight synchronization** (every cell must agree on the frame timing, or one
+cell's uplink will clash with a neighbour's downlink) and the **guard time** itself, which is
+spectrum-efficiency lost to the turnaround and grows with cell size.
+
+## TDD in cellular
+
+TD-LTE (the TDD variant of [LTE](/reference/lte/)) and the majority of
+[5G NR](/reference/5g-nr/) mid-band and millimetre-wave deployments use TDD, because the
+prime new spectrum for those systems came in large unpaired blocks and because massive-MIMO
+beamforming benefits from channel *reciprocity* — the uplink and downlink share the same
+frequency, so the base station can infer the downlink channel from what it measured on the
+uplink. The [guard band](/reference/guard-band/) at the block edges still separates operators
+in frequency, while the guard period separates the directions in time. The trade-off against
+FDD is fundamental: TDD wins flexibility and unpaired-spectrum use, FDD wins continuous
+low-latency symmetric links.
+
+## Relevance to SDR
+
+On a spectrum display a TDD signal looks different from an FDD pair: instead of two mirrored
+bands, a single block pulses on and off as the frame alternates direction, and a waterfall
+shows the busy downlink slots interleaved with quieter uplink ones on the *same* centre
+frequency. Recognising that on/off, single-band pattern is the quickest way to tell TDD from
+FDD when surveying spectrum. GopherTrunk decodes land-mobile trunking rather than cellular,
+but the time-sharing principle behind TDD is the same one that lets a single trunked channel
+carry alternating inbound and outbound traffic, so it is useful context for reading two-way RF.
+
+## Sources
+
+[^wiki]: [Time-division duplex](https://en.wikipedia.org/wiki/Time-division_duplex) — Wikipedia, for the definition of TDD, the guard period, and the adjustable uplink/downlink split.
+[^duplex]: [Duplex (telecommunications)](https://en.wikipedia.org/wiki/Duplex_(telecommunications)) — Wikipedia, for full-duplex operation and the contrast between time- and frequency-division duplexing.

--- a/docs/reference/wifi-80211.md
+++ b/docs/reference/wifi-80211.md
@@ -5,7 +5,7 @@ entry_type: protocol
 category: wireless-data-iot
 description: "Wi-Fi (IEEE 802.11) is the wireless-LAN air interface using OFDM/OFDMA and MIMO in the 2.4, 5, and 6 GHz bands across the a/b/g/n/ac/ax/be generations."
 keywords: Wi-Fi, IEEE 802.11, WLAN, OFDM, OFDMA, MIMO, 802.11a, 802.11b, 802.11g, 802.11n, 802.11ac, 802.11ax, 802.11be, Wi-Fi 6, Wi-Fi 7, 2.4 GHz, 5 GHz, 6 GHz
-aka: [802.11, IEEE 802.11, WLAN PHY, Wi-Fi PHY]
+aka: [802.11, IEEE 802.11, WLAN PHY, Wi-Fi PHY, "Wi-Fi 6", 802.11ax]
 autolink: true
 infobox:
   - { label: Type, value: Wireless LAN air interface }


### PR DESCRIPTION
Reviewed every Field Guide article for acronyms used in prose that had no
page of their own, and gave the genuine RF/tech ones a full rich page in
the existing format (front matter, theme-aware inline SVG, sourced prose).

New pages (19), registered in _data/reference.yml:
- Modulation/DSP/broadcast/data: AAC, APSK, MCS, BCD, SFN
- Cellular: FDD, TDD, DRX, IMT
- Trunked/aviation/marine: DMO, IFF, SITOR, SOLAS
- Organizations: FAA, IMO, IEC, TAPR, NRSC, CCITT

Acronyms bound to a single existing topic are folded into that parent's
aka list (so mentions autolink to where they're explained) rather than
getting a thin standalone page: MCCH→TETRA, IPv4/IPv6→IP address,
CSTDMA→AIS, ReFLEX→FLEX, WIRES-X→System Fusion, D-Plus/D-Extra→D-STAR,
LTRS/FIGS→RTTY, RedCap→5G NR, EDR→Bluetooth, Wi-Fi 6/802.11ax→Wi-Fi.

Common non-technical acronyms (ASAP, FAQ, …) are intentionally skipped.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01S72j4QsoX9x9vsddXhLHHy