### PR TITLE
test(mpt1327): assert the FM+FFSK receiver recovers the correct bits

### DIFF
--- a/internal/radio/mpt1327/receiver/receiver_test.go
+++ b/internal/radio/mpt1327/receiver/receiver_test.go
@@ -144,6 +144,72 @@ func TestReceiverBitSinkBaseIdxMonotonic(t *testing.T) {
 	}
 }
 
+// bestBitMatch slides want over got and returns the largest number of
+// bit-exact matches at any alignment — the metric for "did the FM+FFSK
+// receiver recover the transmitted bits", independent of clock-recovery
+// warm-up latency at the front of the stream.
+func bestBitMatch(got []byte, want []int) (best, at int) {
+	for off := 0; off+len(want) <= len(got); off++ {
+		n := 0
+		for i, w := range want {
+			if int(got[off+i]) == w {
+				n++
+			}
+		}
+		if n > best {
+			best, at = n, off
+		}
+	}
+	return best, at
+}
+
+// TestReceiverRecoversTransmittedBits is the bit-correctness guard the
+// older TestReceiverEmitsBitsFromFMFFSK lacked: it asserts the FM →
+// FFSK-discriminator → clock-recovery → slicer chain recovers the actual
+// transmitted bit values, not merely that it emits some symbols. A demod
+// that produced a plausible-but-wrong 2-level stream (the failure mode
+// reported in issue #927) would emit bits but never align to the payload.
+func TestReceiverRecoversTransmittedBits(t *testing.T) {
+	// A 1010… preamble lets the Mueller-Müller loop settle before the
+	// distinctive payload, whose recovery is what the assertion checks.
+	var bits []int
+	for i := 0; i < 48; i++ {
+		bits = append(bits, i%2)
+	}
+	payload := []int{1, 1, 0, 1, 0, 0, 1, 0, 1, 1, 1, 0, 0, 0, 1, 0,
+		1, 0, 1, 1, 0, 0, 1, 1, 0, 1, 0, 0, 0, 1, 1, 1, 0, 1, 1, 0}
+	bits = append(bits, payload...)
+	// Trailing flush so the payload sits comfortably inside the recovered
+	// stream rather than at its truncated edge (clock recovery can drop/add
+	// a symbol at the very start/end as it warms up and drains).
+	for i := 0; i < 16; i++ {
+		bits = append(bits, i%2)
+	}
+
+	var got []byte
+	r := New(Options{
+		SampleRateHz: 48_000,
+		BitSink:      func(b []byte, baseIdx int) { got = append(got, b...) },
+	})
+	iq := makeFMFFSKIQ(bits)
+	const chunk = 4096
+	for i := 0; i < len(iq); i += chunk {
+		end := i + chunk
+		if end > len(iq) {
+			end = len(iq)
+		}
+		r.Process(iq[i:end])
+	}
+
+	best, at := bestBitMatch(got, payload)
+	// Allow one slip at the very edges of clock recovery, but the payload
+	// must otherwise come through bit-exact.
+	if best < len(payload)-1 {
+		t.Errorf("recovered %d/%d payload bits at best alignment (offset %d); got=%v",
+			best, len(payload), at, got)
+	}
+}
+
 func TestReceiverEmittedBitsAreBinary(t *testing.T) {
 	var bad int
 	r := New(Options{


### PR DESCRIPTION
## Summary

Investigating #927 ("MPT-1327 NOT LOCKED; GopherTrunk routes raw complex I/Q into a phase-quadrature slicer instead of FM-demodulating") — the reporter's proposed fix is an FM demod → FFSK tone discriminator (1200/1800 Hz) → bit slicer. **GopherTrunk's MPT-1327 receiver already *is* exactly that pipeline** (`internal/radio/mpt1327/receiver`):

```
IQ → FM discriminator (demod.FM) → audio → FFSK tone discriminator (demod.FFSK) → Mueller-Müller clock recovery → bit slicer
```

There is no phase-quadrature slicing anywhere in the MPT-1327 path, in the daemon or in siglab (which routes through the same `ccdecoder` pipeline). The "circular ring" the reporter saw on the I/Q constellation is the *expected* appearance of a constant-envelope FFSK/FM signal on an I/Q plot — a raw-baseband diagnostic view, not the decode path.

So the premise of the report is inverted. But the investigation did surface a **real test gap**: the existing end-to-end test (`TestReceiverEmitsBitsFromFMFFSK`) only asserted the chain emitted *some* batches — never that the recovered **bit values** were correct. A demod that produced a plausible-but-wrong 2-level stream (the reported failure mode) would have passed it.

## Changes

- Add `TestReceiverRecoversTransmittedBits`: modulate a known preamble+payload bit sequence to FM+FFSK IQ, run it through the production receiver, and assert the payload is recovered **bit-exact** at the best stream alignment (tolerating a single clock-recovery warm-up slip). Closes the coverage gap and pins the demod's correctness.

**No production change.** The receiver already decodes clean synthetic MPT-1327 correctly (this test proves it), so the live-capture lock failure is capture-specific.

## Test plan

- [x] `make vet test` green locally
- [x] New test passes; verified it is meaningful by construction (a wrong 2-level stream fails to align to the payload)
- [ ] Real hardware — n/a; the reporter's raw IQ capture is what's needed to diagnose the actual on-air lock failure (see the issue thread).

## Breaking changes

None — test-only.

## Docs / CHANGELOG

- n/a (not user-visible).

## Linked issues

Refs #927 — left **open**; this pins the receiver's correctness and the issue awaits a raw IQ capture to diagnose the capture-specific lock failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016MamFURz8QqFmCeqUR4cpL)_