### PR TITLE
fix(p25p2): require RS integrity for the completed-call source RID (#915)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **P25 Phase 2 per-call MAC framing-health signal (`mac_rs_valid`).** The
+  end-of-call census line now reports how many of the decoded traffic-channel
+  MAC PDUs carried a valid outer RS(24,16,9) parity, and the per-opcode
+  `p25p2 mac pdu` debug line carries an `rs_valid` flag. `mac_pdus>0` with
+  `mac_rs_valid=0` is the built-in fingerprint of a mis-framed / mis-descrambled
+  Phase 2 superframe (random bytes parsing as MAC PDUs rather than real
+  signalling) — the objective before/after metric for a superframe-framing fix,
+  and the reason a system's clear-MAC source RID never lands (issue #915).
 - **P25 Phase 2 control-channel MAC opcode census (`--log-level debug`).** A
   new diagnostic inventories every MAC opcode seen on the control channel —
   logging a one-shot `payload_hex` sample the first time each opcode appears
@@ -27,8 +35,20 @@ for tagged releases.
   rather than a fixed slot 1 — the building block for issue #925.
 
 ### Fixed
-- **Encrypted-call `algorithm_id`/`key_id` are no longer surfaced when the
-  crypto sync mis-decodes.** On P25 Phase 2 (and Phase 1's residual-error
+- **Completed-call `source_rid` is no longer set from an unverified P25 Phase 2
+  traffic-channel MAC PDU.** The in-call source RID is backfilled from the
+  `GROUP_VOICE_CHANNEL_USER` MAC PDU decoded off the voice channel, but that
+  MAC path runs with the outer RS(24,16,9) check off by default, so any 18
+  descrambled bytes parse — and a mis-framed / mis-descrambled superframe
+  decoding random bytes occasionally lands on opcode `0x01`/`0x21` and injects
+  a plausible-but-wrong RID indistinguishable from a real one (the source-side
+  analogue of the `algorithm_id` smear above; the field report on MMR saw a
+  near-uniform 234-of-256 MAC opcode distribution, i.e. garbage passing
+  ungated). GopherTrunk now trusts a source RID only when its MAC PDU carries a
+  valid outer RS parity, so a wrong RID is never carried to the webhook or
+  `/api/v1/calls/history` — it stays omitted instead. Recovering the RIDs GT
+  never frames on such systems is a separate Phase 2 superframe-framing fix
+  (issue #915). On P25 Phase 2 (and Phase 1's residual-error
   tail) a bit-error in a traffic-channel Encryption Sync smears the decoded
   Algorithm ID roughly uniformly across `0x00-0xFF`, with a near-distinct Key
   ID per call. Those values were published straight to the completed-call

--- a/internal/radio/p25/phase2/encode.go
+++ b/internal/radio/p25/phase2/encode.go
@@ -81,6 +81,56 @@ func EncodeMACSubframe(slotType SlotType, counter uint8, pdu MACPDU, mode Trelli
 	return sub
 }
 
+// EncodeMACPDURS returns pdu with the outer RS(24, 16, 9) parity
+// (TIA-102.BAAA-A §5.9) filled in, so the assembled 18-byte MAC PDU
+// verifies under verifyMACPDURS. Real over-the-air MAC PDUs always
+// carry this parity; the plain Encode* helpers omit it (their fixtures
+// decode fine with the outer RS check off), so a fixture that must pass
+// an RS-integrity gate — the completed-call source-RID backfill, issue
+// #915 — is built by wrapping the base PDU in this helper.
+//
+// The opcode (+ MFID, for a manufacturer-specific opcode) and the
+// existing payload must fit the 12-byte / 16-hex-symbol information
+// region; the 6-byte parity tail is (re)computed from it. Because
+// EncodeRS24_16 is systematic (the 16 information symbols pass through
+// verbatim), the opcode and payload bytes are unchanged — only the
+// trailing parity is added. Panics if the content overflows the info
+// region.
+func EncodeMACPDURS(pdu MACPDU) MACPDU {
+	base := AssembleMACPDU(pdu)
+	if len(base) > 12 {
+		panic("p25/phase2: EncodeMACPDURS content exceeds the 12-byte MAC PDU info region")
+	}
+	var info18 [18]byte
+	copy(info18[:], base)
+	// Read the 16 information hex-symbols (6 bits each, MSB-first) out
+	// of bytes 0..11 — the same bit convention verifyMACPDURS uses.
+	var syms [16]byte
+	for i := 0; i < 16; i++ {
+		var s byte
+		for j := 0; j < 6; j++ {
+			bit := i*6 + j
+			s = (s << 1) | ((info18[bit>>3] >> uint(7-(bit&7))) & 1)
+		}
+		syms[i] = s
+	}
+	cw := framing.EncodeRS24_16(syms)
+	// Pack the full 24-symbol codeword back into 18 bytes: bytes 0..11
+	// reproduce the information verbatim, bytes 12..17 are the parity.
+	var full [18]byte
+	bit := 0
+	for _, sym := range cw {
+		for b := 5; b >= 0; b-- {
+			if (sym>>uint(b))&1 == 1 {
+				full[bit>>3] |= 1 << uint(7-(bit&7))
+			}
+			bit++
+		}
+	}
+	out, _ := ParseMACPDU(full[:])
+	return out
+}
+
 // EncodeEncryptionSync builds the MAC PDU form of an Encryption Sync —
 // the inverse of MACPDU.AsEncryptionSync.
 func EncodeEncryptionSync(es EncryptionSync) MACPDU {

--- a/internal/radio/p25/phase2/superframe_ingest.go
+++ b/internal/radio/p25/phase2/superframe_ingest.go
@@ -31,6 +31,21 @@ type MACDecodeConfig struct {
 type DecodedMACPDU struct {
 	SlotType SlotType
 	PDU      MACPDU
+	// RSValid reports whether the recovered 18-byte MAC PDU satisfies
+	// the outer RS(24, 16, 9) parity check (TIA-102.BAAA-A §5.9),
+	// computed regardless of the channel's RSMode. It is the per-PDU
+	// FEC-integrity signal: a real over-the-air MAC PDU that framed and
+	// descrambled correctly verifies clean, whereas a mis-framed /
+	// mis-descrambled window packs into random bytes that (almost)
+	// never satisfy the RS syndromes. The MAC path runs with the outer
+	// RS check off by default (a permissive parse for weak signals), so
+	// without this flag the caller cannot tell a genuine PDU from
+	// garbage that merely happened to parse — which lets a mis-decoded
+	// GROUP_VOICE_CHANNEL_USER inject a bogus source RID (issue #915,
+	// the source-side analogue of the #924 algid gate). Callers that
+	// backfill trust-sensitive fields (the completed-call source RID)
+	// gate on this; the framing-health census counts it.
+	RSValid bool
 }
 
 // DecodeSuperframeMACPDUsWithSlot returns every successfully decoded MAC
@@ -60,7 +75,11 @@ func DecodeSuperframeMACPDUsWithSlot(sf Superframe, cfg MACDecodeConfig) []Decod
 		offset := slotPN44Offset(sub.Index)
 		if pdu, ok := decodeMACPDUDibits(macDibits, cfg.Trellis, cfg.RS,
 			cfg.Interleave, cfg.Scrambler, cfg.Seed, offset); ok {
-			out = append(out, DecodedMACPDU{SlotType: sub.SlotType, PDU: pdu})
+			out = append(out, DecodedMACPDU{
+				SlotType: sub.SlotType,
+				PDU:      pdu,
+				RSValid:  verifyMACPDURS(AssembleMACPDU(pdu)),
+			})
 		}
 	}
 	return out

--- a/internal/radio/p25/phase2/superframe_ingest_test.go
+++ b/internal/radio/p25/phase2/superframe_ingest_test.go
@@ -154,6 +154,48 @@ func TestDecodeSuperframeMACPDUsWithSlotTagsPTT(t *testing.T) {
 	}
 }
 
+// TestDecodeSuperframeMACPDUsRSValidFlag pins the per-PDU RS-integrity
+// signal the source-RID gate + framing-health census read (issue #915):
+// a MAC PDU carrying a valid outer RS(24,16,9) parity (EncodeMACPDURS)
+// decodes with RSValid=true and its fields intact, while the same PDU
+// without parity (the plain Encode* form, standing in for a mis-framed
+// window) decodes with RSValid=false.
+func TestDecodeSuperframeMACPDUsRSValidFlag(t *testing.T) {
+	const wantSrc = 315203
+	base := GroupVoiceChannelUser{ServiceOptions: 0x40, GroupAddress: 0x4EEA, SourceID: wantSrc}
+	cfg := MACDecodeConfig{Trellis: TrellisOn}
+
+	decodeSource := func(pdu MACPDU) DecodedMACPDU {
+		t.Helper()
+		var subs [SubframesPerSuperframe][]uint8
+		for i := range subs {
+			if i == 0 {
+				subs[i] = EncodeMACSubframe(SlotTypeMACSignaling, uint8(i), pdu, TrellisOn, InterleaveOff)
+			} else {
+				subs[i] = EncodeVoiceSubframe(SlotTypeVoice4V, uint8(i), voicePayloads(Voice4VFrameCount))
+			}
+		}
+		got := DecodeSuperframeMACPDUsWithSlot(decodeOneSuperframe(t, subs), cfg)
+		if len(got) != 1 {
+			t.Fatalf("DecodeSuperframeMACPDUsWithSlot returned %d PDUs, want 1", len(got))
+		}
+		return got[0]
+	}
+
+	valid := decodeSource(EncodeMACPDURS(EncodeGroupVoiceChannelUser(base, false)))
+	if !valid.RSValid {
+		t.Error("RS-valid GROUP_VOICE_CHANNEL_USER decoded with RSValid=false")
+	}
+	if u, ok := valid.PDU.AsGroupVoiceChannelUser(); !ok || u.SourceID != wantSrc {
+		t.Errorf("RS-encoding altered the source RID: got %+v ok=%v, want SourceID=%d", u, ok, wantSrc)
+	}
+
+	raw := decodeSource(EncodeGroupVoiceChannelUser(base, false))
+	if raw.RSValid {
+		t.Error("RS-invalid (no-parity) source PDU decoded with RSValid=true")
+	}
+}
+
 // TestIngestSuperframeAllVoicePublishesNothing confirms an all-voice
 // superframe drives no control-channel events — the composer owns voice.
 func TestIngestSuperframeAllVoicePublishesNothing(t *testing.T) {

--- a/internal/sigfollow/dispatcher.go
+++ b/internal/sigfollow/dispatcher.go
@@ -106,24 +106,34 @@ func NewMACDispatcher(opts MACDispatcherOptions) *MACDispatcher {
 
 // Dispatch decodes every MAC PDU in sf under macCfg, publishing any
 // completed talker alias and invoking the source / encryption hooks. It
-// returns the number of MAC PDUs decoded so a caller can drive an
-// activity watchdog off signalling presence (0 means the superframe
-// carried only voice / idle).
-func (d *MACDispatcher) Dispatch(sf p25p2.Superframe, macCfg p25p2.MACDecodeConfig) int {
+// returns the number of MAC PDUs decoded (0 means the superframe carried
+// only voice / idle) and, of those, how many carried a valid outer
+// RS(24, 16, 9) parity — the framing-health signal a caller feeds the
+// per-call census (issue #915): on a correctly framed + descrambled
+// channel nearly every PDU is RS-valid, whereas a mis-framed traffic
+// channel decodes a stream of random bytes that (almost) never verify.
+func (d *MACDispatcher) Dispatch(sf p25p2.Superframe, macCfg p25p2.MACDecodeConfig) (decodedCount, rsValidCount int) {
 	decoded := p25p2.DecodeSuperframeMACPDUsWithSlot(sf, macCfg)
 	for _, dec := range decoded {
 		pdu := dec.PDU
+		if dec.RSValid {
+			rsValidCount++
+		}
 		// Log the first PDU seen per (slot, opcode, MFID) on this channel,
-		// with the payload bytes. If a real on-air system rides the
-		// encryption sync on a slot/opcode we don't dispatch, the hex tells
-		// the next field tester exactly what we saw — the bytes needed to
-		// confirm or correct the MAC_PTT layout (issues #376, #813).
+		// with the payload bytes and its RS-integrity flag. If a real
+		// on-air system rides the encryption sync on a slot/opcode we don't
+		// dispatch, the hex tells the next field tester exactly what we saw
+		// — the bytes needed to confirm or correct the MAC_PTT layout; and
+		// rs_valid=false across the board is the fingerprint of a mis-framed
+		// superframe rather than an unhandled-but-real opcode (issues #376,
+		// #813, #915).
 		key := uint32(dec.SlotType)<<16 | uint32(pdu.Opcode)<<8 | uint32(pdu.MFID)
 		if _, seen := d.macSeen[key]; !seen {
 			d.macSeen[key] = struct{}{}
 			d.log.Info(d.logPrefix+": p25p2 mac pdu",
 				"system", d.system, "serial", d.serial,
 				"slot", dec.SlotType, "opcode", pdu.Opcode, "mfid", pdu.MFID,
+				"rs_valid", dec.RSValid,
 				"payload_len", len(pdu.Payload),
 				"payload_hex", hex.EncodeToString(pdu.Payload))
 		}
@@ -139,7 +149,18 @@ func (d *MACDispatcher) Dispatch(sf p25p2.Superframe, macCfg p25p2.MACDecodeConf
 			}
 		}
 		if u, ok := pdu.AsGroupVoiceChannelUser(); ok {
-			if d.onCallSource != nil {
+			// Source-RID integrity gate (issue #915). The completed-call
+			// webhook's source_rid is backfilled from this in-call PDU, so a
+			// mis-decoded MAC window whose opcode byte happens to land on
+			// 0x01/0x21 would inject a plausible-but-wrong RID that is
+			// indistinguishable downstream from a real one — the source-side
+			// analogue of the #924 algid smear. The outer RS parity is the
+			// only signal that separates a genuine GROUP_VOICE_CHANNEL_USER
+			// from garbage (the opcode alone can't), so only an RS-verified
+			// PDU is trusted to set the call's source. A wrong RID is worse
+			// than an absent one; the real recovery of the ~64% missing on
+			// MMR is a Phase 2 superframe-framing fix, tracked in #915.
+			if dec.RSValid && d.onCallSource != nil {
 				d.onCallSource(u)
 			}
 			continue
@@ -176,7 +197,7 @@ func (d *MACDispatcher) Dispatch(sf p25p2.Superframe, macCfg p25p2.MACDecodeConf
 			continue
 		}
 	}
-	return len(decoded)
+	return len(decoded), rsValidCount
 }
 
 // publishTalkerAlias mirrors phase2.ControlChannel.publishTalkerAlias: a

--- a/internal/sigfollow/dispatcher_test.go
+++ b/internal/sigfollow/dispatcher_test.go
@@ -158,15 +158,13 @@ func TestDispatcherPTTSlotDrivesEncryptionHook(t *testing.T) {
 	}
 }
 
-// TestDispatcherSourceCallback verifies the in-call GROUP_VOICE_CHANNEL_USER
-// PDU routes to the OnCallSource hook (the voice composer wires this to its
-// engine-backfill publisher; the follower leaves it nil).
-func TestDispatcherSourceCallback(t *testing.T) {
-	const wantSrc = 315203
-	user := p25p2.EncodeGroupVoiceChannelUser(p25p2.GroupVoiceChannelUser{
-		ServiceOptions: 0x40, GroupAddress: 0x4EEA, SourceID: wantSrc,
-	}, false)
-
+// sourceSuperframes builds one superframe whose sub-frame 0 carries the
+// supplied GROUP_VOICE_CHANNEL_USER PDU (the rest voice), decodes the
+// dibit stream back into Superframes, and returns them — the input to
+// MACDispatcher.Dispatch. The PDU is passed in so a caller can supply an
+// RS-valid (EncodeMACPDURS) or a raw/RS-invalid form.
+func sourceSuperframes(t *testing.T, user p25p2.MACPDU) []p25p2.Superframe {
+	t.Helper()
 	dibits := make([]uint8, 50)
 	var subs [p25p2.SubframesPerSuperframe][]uint8
 	for i := range subs {
@@ -186,6 +184,19 @@ func TestDispatcherSourceCallback(t *testing.T) {
 	if len(sfs) == 0 {
 		t.Fatal("no superframes decoded")
 	}
+	return sfs
+}
+
+// TestDispatcherSourceCallback verifies the in-call GROUP_VOICE_CHANNEL_USER
+// PDU routes to the OnCallSource hook (the voice composer wires this to its
+// engine-backfill publisher; the follower leaves it nil). The PDU carries a
+// valid outer RS(24,16,9) parity, as a real over-the-air one does — the
+// dispatcher only trusts a source RID that survives the FEC check (#915).
+func TestDispatcherSourceCallback(t *testing.T) {
+	const wantSrc = 315203
+	user := p25p2.EncodeMACPDURS(p25p2.EncodeGroupVoiceChannelUser(p25p2.GroupVoiceChannelUser{
+		ServiceOptions: 0x40, GroupAddress: 0x4EEA, SourceID: wantSrc,
+	}, false))
 
 	var gotSrc uint32
 	var called int
@@ -194,7 +205,7 @@ func TestDispatcherSourceCallback(t *testing.T) {
 		OnCallSource: func(u p25p2.GroupVoiceChannelUser) { gotSrc = u.SourceID; called++ },
 	})
 	macCfg := p25p2.MACDecodeConfig{Trellis: p25p2.TrellisOn}
-	for _, sf := range sfs {
+	for _, sf := range sourceSuperframes(t, user) {
 		d.Dispatch(sf, macCfg)
 	}
 	if called == 0 {
@@ -202,5 +213,82 @@ func TestDispatcherSourceCallback(t *testing.T) {
 	}
 	if gotSrc != wantSrc {
 		t.Errorf("OnCallSource SourceID = %d, want %d", gotSrc, wantSrc)
+	}
+}
+
+// TestDispatcherSourceRequiresRSIntegrity is the #915 regression guard:
+// the completed-call webhook's source_rid is backfilled from the in-call
+// GROUP_VOICE_CHANNEL_USER PDU, and the MAC path runs with the outer RS
+// check off by default, so a mis-framed traffic channel decoding random
+// bytes will occasionally land on opcode 0x01/0x21 and — before the fix —
+// inject a plausible-but-wrong RID indistinguishable from a real one. The
+// dispatcher now trusts a source RID only when its PDU carries a valid
+// RS(24,16,9) parity.
+//
+//   - An RS-INVALID (raw Encode*, no parity) source PDU must NOT fire
+//     OnCallSource — it fails without the gate and passes with it.
+//   - An RS-VALID (EncodeMACPDURS) source PDU with the SAME opcode/RID
+//     still fires, so the gate blocks only the garbage, not real traffic.
+func TestDispatcherSourceRequiresRSIntegrity(t *testing.T) {
+	const wantSrc = 315203
+	base := p25p2.GroupVoiceChannelUser{ServiceOptions: 0x40, GroupAddress: 0x4EEA, SourceID: wantSrc}
+	macCfg := p25p2.MACDecodeConfig{Trellis: p25p2.TrellisOn}
+
+	// RS-invalid: a raw GROUP_VOICE_CHANNEL_USER with no outer parity —
+	// stands in for a mis-decoded MAC window whose opcode byte happens to
+	// be 0x01. It must be dropped.
+	garbage := p25p2.EncodeGroupVoiceChannelUser(base, false)
+	var garbageCalls int
+	dGarbage := NewMACDispatcher(MACDispatcherOptions{
+		Log: quietLog(), System: "TestSys", Serial: "tap-0",
+		OnCallSource: func(p25p2.GroupVoiceChannelUser) { garbageCalls++ },
+	})
+	for _, sf := range sourceSuperframes(t, garbage) {
+		dGarbage.Dispatch(sf, macCfg)
+	}
+	if garbageCalls != 0 {
+		t.Errorf("OnCallSource fired %d time(s) for an RS-invalid source PDU; want 0 (bogus source_rid must not reach the webhook)", garbageCalls)
+	}
+
+	// RS-valid: identical opcode + RID, but with the outer parity a real
+	// over-the-air PDU carries. It must still fire with the correct RID.
+	valid := p25p2.EncodeMACPDURS(p25p2.EncodeGroupVoiceChannelUser(base, false))
+	var gotSrc uint32
+	var validCalls int
+	dValid := NewMACDispatcher(MACDispatcherOptions{
+		Log: quietLog(), System: "TestSys", Serial: "tap-0",
+		OnCallSource: func(u p25p2.GroupVoiceChannelUser) { gotSrc = u.SourceID; validCalls++ },
+	})
+	for _, sf := range sourceSuperframes(t, valid) {
+		dValid.Dispatch(sf, macCfg)
+	}
+	if validCalls == 0 {
+		t.Fatal("OnCallSource never fired for an RS-valid source PDU")
+	}
+	if gotSrc != wantSrc {
+		t.Errorf("OnCallSource SourceID = %d, want %d", gotSrc, wantSrc)
+	}
+}
+
+// TestDispatchReturnsRSValidCount verifies Dispatch reports how many
+// decoded MAC PDUs carried a clean outer RS parity — the framing-health
+// signal the per-call census surfaces as mac_rs_valid (#915).
+func TestDispatchReturnsRSValidCount(t *testing.T) {
+	user := p25p2.EncodeMACPDURS(p25p2.EncodeGroupVoiceChannelUser(p25p2.GroupVoiceChannelUser{
+		ServiceOptions: 0x40, GroupAddress: 0x4EEA, SourceID: 315203,
+	}, false))
+	d := NewMACDispatcher(MACDispatcherOptions{Log: quietLog(), System: "TestSys", Serial: "tap-0"})
+	macCfg := p25p2.MACDecodeConfig{Trellis: p25p2.TrellisOn}
+	var totDec, totRS int
+	for _, sf := range sourceSuperframes(t, user) {
+		dec, rs := d.Dispatch(sf, macCfg)
+		totDec += dec
+		totRS += rs
+	}
+	if totDec == 0 {
+		t.Fatal("Dispatch decoded no MAC PDUs")
+	}
+	if totRS == 0 {
+		t.Errorf("Dispatch reported rsValid=0 for an RS-valid source PDU; want >=1")
 	}
 }

--- a/internal/voice/composer/p25p2_voice.go
+++ b/internal/voice/composer/p25p2_voice.go
@@ -190,6 +190,7 @@ func (c *Composer) runP25Phase2VoiceChain(ctx context.Context, serial string, sy
 		superframesSeen  atomic.Uint64
 		macSubframesSeen atomic.Uint64
 		macPDUsDecoded   atomic.Uint64
+		macRSValid       atomic.Uint64
 		slotHist         [slotHistLen]atomic.Uint64
 	)
 	rx := p25p2rx.New(p25p2rx.Options{
@@ -240,8 +241,13 @@ func (c *Composer) runP25Phase2VoiceChain(ctx context.Context, serial string, sy
 				// The talker alias, in-call source, and encryption-sync
 				// MAC PDUs that interleave with voice are decoded by the
 				// shared dispatcher (same path the signalling follower
-				// runs off the traffic channel, #376).
-				macPDUsDecoded.Add(uint64(dispatcher.Dispatch(sf, macCfg)))
+				// runs off the traffic channel, #376). rsValid counts how
+				// many carried a clean outer RS(24,16,9) parity — the
+				// framing-health signal the end-of-call census reports
+				// (issue #915).
+				nDec, nRS := dispatcher.Dispatch(sf, macCfg)
+				macPDUsDecoded.Add(uint64(nDec))
+				macRSValid.Add(uint64(nRS))
 			}
 		},
 	})
@@ -272,6 +278,13 @@ func (c *Composer) runP25Phase2VoiceChain(ctx context.Context, serial string, sy
 	//   - superframes>0, mac_subframes=0 → ISCH never classified a MAC slot
 	//                                       (inspect the slot_* histogram)
 	//   - mac_subframes>0, mac_pdus=0    → MAC FEC chain failed every slot
+	//   - mac_pdus>0, mac_rs_valid=0     → the MAC window parses but never
+	//                                       satisfies the outer RS(24,16,9)
+	//                                       parity: a mis-framed / mis-
+	//                                       descrambled superframe decoding
+	//                                       random bytes, not real signalling
+	//                                       (issue #915 — this is why the
+	//                                       clear-MAC source RID never lands)
 	// The slot_<type> buckets reuse SlotType.String() so the line is
 	// self-describing.
 	logCallCensus := func() {
@@ -281,6 +294,7 @@ func (c *Composer) runP25Phase2VoiceChain(ctx context.Context, serial string, sy
 			"voice_subframes", voiceSubframes.Load(),
 			"mac_subframes", macSubframesSeen.Load(),
 			"mac_pdus", macPDUsDecoded.Load(),
+			"mac_rs_valid", macRSValid.Load(),
 		}
 		for st := 0; st < slotHistLen; st++ {
 			if cnt := slotHist[st].Load(); cnt > 0 {

--- a/internal/voice/composer/p25p2_voice_test.go
+++ b/internal/voice/composer/p25p2_voice_test.go
@@ -318,11 +318,14 @@ func buildP25P2MetadataStream(n int) (dibits []uint8, wantSrc uint32, wantAlias 
 	wantAlgID = 0x84 // AES-256
 	wantKeyID = 0x1234
 
-	userPDU := p25p2.EncodeGroupVoiceChannelUser(p25p2.GroupVoiceChannelUser{
+	// RS-valid outer parity, as a real over-the-air PDU carries: the
+	// completed-call source_rid backfill only trusts an RS-verified
+	// GROUP_VOICE_CHANNEL_USER (issue #915).
+	userPDU := p25p2.EncodeMACPDURS(p25p2.EncodeGroupVoiceChannelUser(p25p2.GroupVoiceChannelUser{
 		ServiceOptions: 0x40, // bit 6 = encrypted
 		GroupAddress:   0x4EEA,
 		SourceID:       wantSrc,
-	}, false)
+	}, false))
 	encPDU := p25p2.EncodeEncryptionSync(p25p2.EncryptionSync{
 		AlgorithmID:      wantAlgID,
 		KeyID:            wantKeyID,


### PR DESCRIPTION
## Summary

The completed-call webhook backfills `source_rid` from the in-call `GROUP_VOICE_CHANNEL_USER` MAC PDU decoded off the P25 Phase 2 traffic channel. That MAC path runs with the outer RS(24,16,9) check **off** by default, so `decodeMACPDUDibits` returns `ok=true` for *any* 18 descrambled bytes — the opcode byte alone can't tell a genuine PDU from garbage. A mis-framed / mis-descrambled superframe therefore decodes a stream of random bytes that occasionally lands on opcode `0x01`/`0x21` and injects a **plausible-but-wrong source RID**, indistinguishable downstream from a real one. This is the source-side analogue of the #924 algid smear, and it's exactly why the field report on MMR (issue #915) sees a near-uniform 234-of-256 MAC opcode distribution: the garbage passes ungated.

This PR makes the source RID trustworthy (RS-verified or absent, never garbage) and adds a built-in framing-health signal. It does **not** attempt the actual recovery of the RIDs GT never frames on such systems — that's a Phase 2 superframe-framing fix that needs a real IQ capture, which the reporter has offered; kept open under #915.

## Changes

- **`DecodedMACPDU.RSValid`** — the shared slot-aware MAC decode now computes the outer RS(24,16,9) parity per PDU, regardless of the channel's `RSMode`. It's the per-PDU FEC-integrity signal (a genuine, correctly-framed PDU verifies clean; a mis-framed window almost never does).
- **Source-RID integrity gate** — the shared `MACDispatcher` fires `OnCallSource` only for an RS-verified `GROUP_VOICE_CHANNEL_USER`. The encryption path (already guarded by the #924 `AlgorithmKnown` gate) and the alias path are unchanged.
- **Framing-health telemetry** — `Dispatch` reports the RS-valid count; the end-of-call census gains a `mac_rs_valid` counter and the per-opcode `p25p2 mac pdu` debug line gains an `rs_valid` flag. `mac_pdus>0` with `mac_rs_valid=0` is the built-in fingerprint of a mis-framed superframe — the objective before/after metric for the framing fix.
- **`EncodeMACPDURS` helper** — fills a faithful outer RS parity onto a synthesized MAC PDU fixture (`EncodeRS24_16` is systematic, so opcode/payload pass through unchanged), so fixtures match real over-the-air PDUs, which always carry the parity.
- CHANGELOG entries (Fixed + Added).

## Test plan

- [x] `make vet test` is green locally
- [x] `make integration` is green locally
- [x] Added or updated tests where appropriate
- [ ] Smoke-tested against real hardware — n/a (no SDR/USB/vocoder change; decode-layer only). Live confirmation against MMR is requested from the reporter in #915.

New / updated tests:
- `TestDispatcherSourceRequiresRSIntegrity` — the regression guard: an RS-invalid source PDU **no longer fires** `OnCallSource` (fails before the gate, passes after), while an RS-valid one with the same opcode/RID still fires. Verified failing-first by reverting the gate.
- `TestDecodeSuperframeMACPDUsRSValidFlag` — RS-valid PDU decodes with `RSValid=true` and its RID intact; the no-parity form decodes with `RSValid=false`.
- `TestDispatchReturnsRSValidCount` — `Dispatch` surfaces the RS-valid count for the census.
- `TestDispatcherSourceCallback` and the composer's `buildP25P2MetadataStream` (#376 regression) updated to RS-valid source fixtures so they still assert recovery under the gate.

## Breaking changes

None to config/CLI/endpoints. Behavioural note: a P25 Phase 2 `source_rid` that would previously have been set from an unverified (possibly mis-decoded) MAC PDU is now omitted unless it passes the RS check. On a correctly-framed system real source PDUs are RS-valid and still surface; on a mis-framed system the raw non-zero count may drop because the values it removes were garbage — a wrong RID is worse than an absent one.

## Docs / CHANGELOG

- [x] Added `## [Unreleased]` bullets to `CHANGELOG.md` (Fixed: source-RID integrity gate; Added: `mac_rs_valid` signal)
- [ ] `README.md` / `docs/` — n/a (no operator-facing config or workflow change)

## Linked issues

Refs #915

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013n4CNgP6wu3cSFWNz2zZkn

---
_Generated by [Claude Code](https://claude.ai/code/session_013n4CNgP6wu3cSFWNz2zZkn)_