### PR TITLE
fix(web): Eye diagram follows the locked channel like the other scopes (#557)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,15 @@ for tagged releases.
   rather than a fixed slot 1 — the building block for issue #925.
 
 ### Fixed
+- **Eye diagram panel now follows the locked channel like the other Plots
+  scopes.** The Eye diagram carried the offset/frequency tuning controls from
+  the constellation work (issue #557) but, unlike the Constellation and Symbol
+  scope panels, never refreshed the active-call snapshot — so its "follow the
+  newest call" offset froze on a stale call the moment the panel was opened
+  directly, and re-checking Hold left the view on that stale call frequency
+  instead of parking it on the control channel. The panel now polls active
+  calls while mounted and parks on the configured control channel on Hold,
+  matching the sibling scopes.
 - **Completed-call `source_rid` is no longer set from an unverified P25 Phase 2
   traffic-channel MAC PDU.** The in-call source RID is backfilled from the
   `GROUP_VOICE_CHANNEL_USER` MAC PDU decoded off the voice channel, but that

--- a/web/src/panels/EyeDiagram.test.tsx
+++ b/web/src/panels/EyeDiagram.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 
 vi.mock("../api/spectrum", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../api/spectrum")>()),
@@ -84,6 +84,115 @@ describe("EyeDiagram panel", () => {
     render(<EyeDiagram />);
     await waitFor(() => {
       expect(screen.getByText("live")).toBeInTheDocument();
+    });
+  });
+
+  it("rests on the control channel by default when no call is active (#557)", async () => {
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue([
+      {
+        serial: "rtl-1",
+        driver: "rtlsdr",
+        role: "control",
+        center_hz: 851_000_000,
+        sample_rate_hz: 2_048_000,
+        control_channel_hz: 851_025_000,
+      },
+    ] as never);
+
+    render(<EyeDiagram />);
+    await waitFor(() => {
+      const last = vi.mocked(openSymbolStream).mock.calls.at(-1)?.[1];
+      // CC is 25 kHz above the 851.000 MHz centre.
+      expect(last?.offset).toBe(25_000);
+    });
+  });
+
+  it("prefers an active call over the control channel (#557)", async () => {
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue([
+      {
+        serial: "rtl-1",
+        driver: "rtlsdr",
+        role: "control",
+        center_hz: 851_000_000,
+        sample_rate_hz: 2_048_000,
+        control_channel_hz: 851_025_000,
+      },
+    ] as never);
+
+    useShared.setState({
+      activeCalls: [
+        {
+          grant: {
+            system: "sys",
+            protocol: "p25",
+            group_id: 1,
+            frequency_hz: 851_050_000,
+          },
+          device_serial: "rtl-1",
+          started_at: "2026-06-07T00:00:00Z",
+        },
+      ] as never,
+    });
+
+    render(<EyeDiagram />);
+    await waitFor(() => {
+      const last = vi.mocked(openSymbolStream).mock.calls.at(-1)?.[1];
+      // Follows the call (50 kHz), not the CC (25 kHz).
+      expect(last?.offset).toBe(50_000);
+    });
+  });
+
+  it("stays at centre when the device reports no control channel (#557)", async () => {
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue(ONE_DEVICE as never);
+
+    render(<EyeDiagram />);
+    await waitFor(() => {
+      expect(openSymbolStream).toHaveBeenCalled();
+    });
+    expect(vi.mocked(openSymbolStream).mock.calls.at(-1)?.[1]?.offset).toBe(0);
+  });
+
+  it("parks the view on the control channel when Hold is re-checked (#557)", async () => {
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue([
+      {
+        serial: "rtl-1",
+        driver: "rtlsdr",
+        role: "control",
+        center_hz: 851_000_000,
+        sample_rate_hz: 2_048_000,
+        control_channel_hz: 851_025_000,
+      },
+    ] as never);
+    // Hold off + an active call → the view follows the call (50 kHz).
+    useShared.setState({
+      activeCalls: [
+        {
+          grant: {
+            system: "sys",
+            protocol: "p25",
+            group_id: 1,
+            frequency_hz: 851_050_000,
+          },
+          device_serial: "rtl-1",
+          started_at: "2026-06-07T00:00:00Z",
+        },
+      ] as never,
+    });
+
+    render(<EyeDiagram />);
+    await waitFor(() => {
+      expect(vi.mocked(openSymbolStream).mock.calls.at(-1)?.[1]?.offset).toBe(
+        50_000,
+      );
+    });
+
+    // Re-checking Hold must jump the view to the control channel (25 kHz),
+    // not freeze on the (possibly stale) call frequency.
+    fireEvent.click(screen.getByRole("checkbox"));
+    await waitFor(() => {
+      expect(vi.mocked(openSymbolStream).mock.calls.at(-1)?.[1]?.offset).toBe(
+        25_000,
+      );
     });
   });
 

--- a/web/src/panels/EyeDiagram.tsx
+++ b/web/src/panels/EyeDiagram.tsx
@@ -11,6 +11,7 @@ import { selectClientConfig, useShared } from "../store/shared";
 import { prefs } from "../store/prefs";
 import { EyeDiagramChart } from "../components/EyeDiagramChart";
 import { TuningControls } from "../components/TuningControls";
+import { useActiveCallsPoll } from "../hooks/useActiveCallsPoll";
 
 // Eye diagram panel — GopherTrunk's take on OP25's "datascope". The
 // daemon runs a parallel P25 C4FM receiver on the selected channel and
@@ -30,6 +31,11 @@ type ConnState = "connecting" | "open" | "closed";
 export function EyeDiagram() {
   const cfg = useShared(selectClientConfig);
   const activeCalls = useShared((s) => s.activeCalls);
+  // Keep the follow logic live: this panel reads activeCalls but, unlike
+  // Active/Dashboard, didn't refresh it — so the view froze on a stale
+  // call ("following call" forever, single freq) when opened directly.
+  // Matches the Constellation and Symbol scope panels (#557).
+  useActiveCallsPoll();
   const [devices, setDevices] = useState<SpectrumDevice[]>([]);
   const [selected, setSelected] = useState<string | null>(null);
   const [conn, setConn] = useState<ConnState>("closed");
@@ -196,7 +202,14 @@ export function EyeDiagram() {
             setOffsetKHz(khz);
           }}
           hold={hold}
-          onHoldChange={setHold}
+          onHoldChange={(next) => {
+            // Re-checking Hold parks the view on the control channel (a
+            // stable, known reference) rather than freezing on a call
+            // frequency that may already be stale — matching the
+            // Constellation and Symbol scope panels (#557).
+            if (next && controlOffsetKHz != null) setOffsetKHz(controlOffsetKHz);
+            setHold(next);
+          }}
           following={
             followOffsetKHz != null
               ? "call"


### PR DESCRIPTION
## Summary

Reviewing the constellation improvement (#557) end-to-end, all four of the reporter's follow-ups are already implemented and merged (see the issue comment). The one gap left was the **Eye diagram** panel: it received the same offset/frequency `TuningControls` as the Constellation and Symbol scope panels, but two behaviours diverged from those siblings.

- It read the shared active-calls snapshot but never refreshed it (no `useActiveCallsPoll`), so a panel opened directly froze its "follow the newest active call" offset on whatever stale snapshot happened to be in the store — the exact bug the other two panels fixed.
- Re-checking **Hold** just froze the view at the current (possibly stale call) offset instead of parking it on the configured control channel, unlike the sibling panels.

This brings the Eye diagram to parity so all three Plots scopes behave identically.

## Changes

- `EyeDiagram.tsx`: call `useActiveCallsPoll()` while mounted; park the view on the control channel when Hold is re-checked (mirrors Constellation / Symbol scope).
- `EyeDiagram.test.tsx`: add the `#557` tuning-behaviour tests the Eye panel was missing — rests on the control channel by default, prefers an active call over the CC, stays centred when the device reports no CC — plus a **failing-first** regression test for the Hold-park behaviour.
- CHANGELOG.

## Test plan

- [x] `npm run typecheck` clean
- [x] Panel tests green (`EyeDiagram` / `Constellation` / `SymbolScope`, 34 tests); full web suite 287 passing
- [x] Verified the Hold-park test fails without the fix and passes with it
- [ ] Manual hardware smoke test — n/a (frontend-only; behaviour mirrors the already-shipped sibling panels)

## Breaking changes

None — frontend behaviour only, bringing the Eye panel in line with the other Plots scopes.

## Docs / CHANGELOG

- [x] Added an `## [Unreleased]` `### Fixed` bullet to `CHANGELOG.md`

## Linked issues

Refs #557 — the four explicit follow-ups (Symbol scope frequency view, fine 6.25/12.5 kHz offset entry, larger constellation dot zoom, config-CC default) are already merged; this closes the remaining Eye-panel consistency gap in the same feature family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013n4CNgP6wu3cSFWNz2zZkn

---
_Generated by [Claude Code](https://claude.ai/code/session_013n4CNgP6wu3cSFWNz2zZkn)_