### PR TITLE
docs(recordings): note skip_encrypted suppresses the webhook for encrypted calls (#897)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -203,7 +203,10 @@ recordings:
       release_ms: 80     # envelope release (default 80)
       makeup_db: 0       # fixed post-compression gain (default 0)
   write_raw: true   # also append a .raw sidecar with the vocoder frames
-  skip_encrypted: false  # don't write files for calls flagged encrypted
+  skip_encrypted: false  # don't write files for calls flagged encrypted.
+                         # NOTE: true also suppresses the completed-call
+                         # broadcast backends (webhook/rdioscanner) for
+                         # encrypted calls — keep false to deliver them.
   warm_dmr_audio: false  # opt-in: warmer DMR vocoder (gentle high-shelf, softens the bright software-AMBE+2 timbre; superseded by enhance, DMR only)
   equalizer:
     enabled: false  # CMA blind equalizer in the FM voice chain (simulcast mitigation)
@@ -1217,9 +1220,13 @@ broadcast:
   # Generic JSON webhook: POST one JSON object per completed call to your
   # own endpoint (analytics DB, Grafana pipeline, Discord/Slack relay,
   # custom uploader). The payload carries the call metadata — system,
-  # talkgroup, source RID, frequency, P25 site identity (rfss_id/site_id/
-  # nac/channel_id), encryption + emergency flags, patched groups, and
+  # talkgroup, source RID, call_type (group/unit/data), frequency, P25 site
+  # identity (rfss_id/site_id/nac/channel_id), encryption + emergency flags
+  # (with algorithm_id/key_id on encrypted calls), patched groups, and
   # start/stop timestamps. Set include_audio to also embed the base64 MP3.
+  # NOTE: recordings.skip_encrypted: true suppresses the webhook for
+  # encrypted calls (the call ends before the recorder lifecycle completes);
+  # keep skip_encrypted: false to receive them. See issue #897.
   # webhook:
   #   - enabled: true
   #     name: "analytics"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1667,6 +1667,13 @@ type RecordingsConfig struct {
 	// opened; a call whose encryption is only discovered mid-stream has
 	// its in-progress WAV/raw files closed and deleted. Live follow /
 	// playback is unaffected. Default false (record everything).
+	//
+	// Note it also suppresses the completed-call broadcast backends
+	// (webhook, rdioscanner, …) for encrypted calls: because the recorder
+	// discards the call without publishing a CallComplete, no completed-call
+	// event reaches those backends. Set skip_encrypted: false to deliver
+	// encrypted calls (with their backfilled encryption / alg / key
+	// metadata) to them. See issue #897.
 	SkipEncrypted bool `yaml:"skip_encrypted"`
 	// CryptoCapturePath, when set, opts into the cryptolab crypto-frame
 	// bridge: for each encrypted P25 Phase 1 superframe the voice composer


### PR DESCRIPTION
## Summary

Issue #897's two webhook problems — `encrypted` always `false`, and unit-call RIDs landing in `talkgroup` with no `call_type` — were fixed in #899 and confirmed end-to-end by the reporter (`ENCRYPTED='Y'`, `ALGORITHM_ID`/`KEY_ID` populated, `CALL_TYPE='group'`). During that confirmation they flagged a config gotcha worth documenting, and the earlier close-out comment said it had been documented — but that documentation never actually landed on `main`. This PR lands it, so the issue can close honestly.

The gotcha: with `recordings.skip_encrypted: true`, the recorder discards an encrypted call **without publishing a `CallComplete`** (confirmed in `recorder.go` — files are deleted and "no CallComplete is published so downstream upload feeds never see the partial"), so the completed-call broadcast backends (webhook, rdioscanner, …) never fire for encrypted calls. From the operator's side this looks like the webhook silently dropping encrypted traffic. Setting `skip_encrypted: false` delivers those calls — now with the backfilled encryption/alg/key metadata #899 added.

## Changes

- `internal/config/config.go` — `SkipEncrypted` field comment now notes the completed-call-broadcast suppression and points to `skip_encrypted: false`.
- `config.example.yaml` — the `recordings.skip_encrypted` line and the `broadcast`/webhook section both call out the interaction; the webhook payload description also now lists the `call_type` and `algorithm_id`/`key_id` fields #899 added.

No behaviour change — documentation only.

## Test plan

- [x] `make vet test` scope: `go build ./internal/config/...` + `go test ./internal/config/...` green (the config-example validity test parses the edited YAML)
- [x] `gofmt` clean
- [ ] Hardware smoke test — n/a (docs only)

## Breaking changes

None.

## Docs / CHANGELOG

- Documentation-only clarification of existing behaviour; the #897 fix itself was changelogged with #899. No new `## [Unreleased]` bullet.

## Linked issues

Refs #897 — lands the `skip_encrypted`/webhook documentation the close-out referenced; the core fix is already merged (#899) and reporter-confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013n4CNgP6wu3cSFWNz2zZkn

---
_Generated by [Claude Code](https://claude.ai/code/session_013n4CNgP6wu3cSFWNz2zZkn)_