### PR TITLE
feat(p25): per-site Phase 1 demod mode on wideband multi-site taps (#935)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **Per-site P25 Phase 1 demod mode on wideband multi-site taps.** A single P25
+  system can now mix modulation across its sites: set the system-level
+  `p25_phase1_demod_mode` to the majority modulation and add a per-channel
+  `p25_phase1_demod_mode:` override on the wideband dongle's `channels:` entries
+  for the exceptions (blank inherits the system default). Recognised values
+  match the system-level key (`c4fm`/`fm` vs `cqpsk`/`lsm`/`linear`). The
+  override is keyed per control-channel frequency — the one place a site's
+  identity is known before its CC locks — and drives both the control-channel
+  decode and the voice grants that tap issues, so a granted call on an LSM
+  simulcast site is decoded on the LSM path instead of timing out with no LDU
+  (a C4FM demodulator can't recover a linearly-modulated simulcast signal —
+  the symptom was `control_channel_decode_quality: poor` on urban simulcast
+  sites regardless of hardware). This also closes a latent gap where the
+  wideband path never stamped a demod mode onto its grants at all, so wideband
+  P25 voice always ran the C4FM chain regardless of the system setting.
+  (issue #935)
 - **LoRa Low Data Rate Optimization (LDRO).** The LoRa PHY now decodes the
   reduced-rate payload mode LoRa uses at high spreading factors, where the long
   symbol lets clock drift smear the dechirp peak across the two least-significant

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -1796,8 +1796,9 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 			channels := make([]widebandt2.ChannelConfig, 0, len(devCfg.Channels))
 			for _, ch := range devCfg.Channels {
 				channels = append(channels, widebandt2.ChannelConfig{
-					FrequencyHz: ch.FrequencyHz,
-					SystemName:  ch.System,
+					FrequencyHz:        ch.FrequencyHz,
+					SystemName:         ch.System,
+					P25Phase1DemodMode: ch.P25Phase1DemodMode,
 				})
 			}
 			// Route IQ + tuning through the iqtap broker so the live

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -300,7 +300,10 @@ sdr:
     #                           (frequency_hz must be in
     #                           control_channels; respects the
     #                           system's p25_phase1_demod_mode for
-    #                           C4FM vs CQPSK / LSM simulcast)
+    #                           C4FM vs CQPSK / LSM simulcast, or a
+    #                           per-channel p25_phase1_demod_mode
+    #                           override when sites of one system differ
+    #                           in modulation — see below, issue #935)
     #   protocol: p25-phase2  → P25 Phase 2 trunked control channel
     #                           (frequency_hz must be in
     #                           control_channels; respects the
@@ -316,6 +319,18 @@ sdr:
     # pointing at the same system). Every tap decodes in parallel out of
     # the one capture — they are NOT hunted one-at-a-time. Per-site names
     # come from the system's sites: mapping (RFSS/Site → name) further down.
+    #
+    # PER-SITE MODULATION (issue #935): sites of one P25 system can use
+    # different modulation — an urban simulcast site on LSM (cqpsk)
+    # alongside rural single-transmitter sites on C4FM. Set the system's
+    # p25_phase1_demod_mode to the modulation MOST sites use, then add a
+    # per-channel `p25_phase1_demod_mode:` on the exceptions. A blank /
+    # absent per-channel value inherits the system default. The override
+    # drives both the control-channel decode AND the voice grants that tap
+    # issues, so a granted call on an LSM site is decoded on the LSM path
+    # too (a C4FM demod can't recover a linearly-modulated simulcast
+    # signal — the CC would show control_channel_decode_quality: poor and
+    # voice grants would time out without an LDU).
     #
     # SHARED FRONT END (issue #749): every tap on a dongle shares one
     # antenna, one centre frequency and one gain. The channelizer is
@@ -399,18 +414,23 @@ sdr:
     # single-tuner cc-hunt below, so a wideband site is never starved
     # by the round-robin hunter. Example: all four sites of "MMR"
     # decoded at once from one Airspy —
+    # Here system "MMR" defaults to p25_phase1_demod_mode: c4fm (most
+    # sites are single-TX C4FM), and the two urban simulcast sites carry a
+    # per-channel cqpsk override (issue #935):
     # - serial: "AIRSPY SN:637862DC2E8449D7"
     #   role: wideband
     #   center_freq_hz: 420_900_000
     #   voice_taps: 4
     #   channels:
-    #     - frequency_hz: 420_012_500   # Melbourne / CBD
+    #     - frequency_hz: 420_012_500   # Melbourne / CBD — LSM simulcast
     #       system: "MMR"
-    #     - frequency_hz: 420_037_500   # 120 Collins Street
+    #       p25_phase1_demod_mode: cqpsk
+    #     - frequency_hz: 420_037_500   # 120 Collins Street — LSM simulcast
     #       system: "MMR"
-    #     - frequency_hz: 420_087_500   # Mt Anakie
+    #       p25_phase1_demod_mode: cqpsk
+    #     - frequency_hz: 420_087_500   # Mt Anakie — single-TX C4FM (inherits system default)
     #       system: "MMR"
-    #     - frequency_hz: 421_837_500   # Mt Blackwood
+    #     - frequency_hz: 421_837_500   # Mt Blackwood — single-TX C4FM (inherits)
     #       system: "MMR"
     # (List every one of these frequencies in the system's
     # control_channels too — see the systems section below — and add a

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1197,6 +1197,27 @@ type DeviceConfig struct {
 type DeviceChannelConfig struct {
 	FrequencyHz uint32 `yaml:"frequency_hz"`
 	System      string `yaml:"system"`
+
+	// P25Phase1DemodMode optionally overrides the parent system's
+	// p25_phase1_demod_mode for this one control-channel tap. Within a
+	// single P25 system, individual sites can transmit different
+	// modulation — e.g. an urban simulcast site on Linear Simulcast
+	// Modulation (cqpsk / lsm) alongside rural single-transmitter sites
+	// on straight C4FM (issue #935). Because a wideband dongle decodes
+	// every site's control channel in parallel and the correct demod
+	// path must be chosen before the CC locks (it is what lets it lock),
+	// the override is keyed here per control-channel frequency — the one
+	// place a site's identity is known at config time — rather than by
+	// the RFSS/Site the CC only reveals after it decodes.
+	//
+	// Recognised values match the system-level key (case-insensitive):
+	// "" (inherit the system's p25_phase1_demod_mode) / "c4fm" / "fm"
+	// (FM discriminator + 4-level slicer) or "cqpsk" / "lsm" / "linear"
+	// (the LSM path — complex RRC + Gardner + differential QPSK).
+	// Applies to both the control-channel decoder and the voice grants
+	// this tap issues, so a granted voice call on an LSM site is decoded
+	// on the LSM path too. Ignored for non-P25-Phase-1 channels.
+	P25Phase1DemodMode string `yaml:"p25_phase1_demod_mode"`
 }
 
 type TrunkingConfig struct {

--- a/internal/configbuilder/fieldmeta.go
+++ b/internal/configbuilder/fieldmeta.go
@@ -118,8 +118,9 @@ var fieldMetas = map[string]FieldMeta{
 	"DeviceConfig.DCAvoid":         {Label: "DC-spike avoid", Help: "Tune a control SDR's LO off-channel and mix the channel back to baseband, off the front-end DC spur and its I/Q-image (the offset tuning SDRTrunk/OP25 use). Helps marginal sites; off by default (issue #402)."},
 	"DeviceConfig.DCAvoidOffsetHz": {Label: "DC-avoid offset", Hz: true, Help: "LO offset in Hz when DC-spike avoid is on. 0 = auto (sample_rate/4). Must be < sample_rate/2."},
 
-	"DeviceChannelConfig.FrequencyHz": {Label: "Frequency", Hz: true, Help: "Repeater carrier frequency. Must lie inside the dongle's IQ band."},
-	"DeviceChannelConfig.System":      {Help: "Name of the trunking.systems entry this carrier belongs to."},
+	"DeviceChannelConfig.FrequencyHz":        {Label: "Frequency", Hz: true, Help: "Repeater carrier frequency. Must lie inside the dongle's IQ band."},
+	"DeviceChannelConfig.System":             {Help: "Name of the trunking.systems entry this carrier belongs to."},
+	"DeviceChannelConfig.P25Phase1DemodMode": {Label: "P25 Ph1 demod mode", Help: "Per-site override of the system's demod path for this tap: blank inherits, or c4fm/fm vs cqpsk/lsm. Use when one P25 system mixes LSM simulcast and C4FM sites. P25 Phase 1 only."},
 
 	"RTLTCPConfig.Addr":             {Label: "Address", Help: "host:port the rtl_tcp server listens on, e.g. 192.168.1.50:1234. Required."},
 	"RTLTCPConfig.Serial":           {Help: "Virtual device serial reported by the pool. Empty derives one from the address."},

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -241,6 +241,14 @@ func (c *ControlChannel) P25Phase2FEC() (trellis, rs, interleave, scrambler uint
 	return c.p25Phase2Trellis, c.p25Phase2RS, c.p25Phase2Interleave, c.p25Phase2Scrambler
 }
 
+// P25Phase1DemodMode reports the raw demod-mode string this CC stamps
+// onto the voice grants it publishes (issue #935). Empty means the
+// composer falls back to its own default (c4fm). Exposed read-only so
+// tests can confirm a per-site override reached the grant path — the
+// wideband multi-site fix relied on this to prove an LSM tap's grants
+// carry the LSM mode rather than defaulting to c4fm.
+func (c *ControlChannel) P25Phase1DemodMode() string { return c.p25Phase1DemodMode }
+
 // TopologySnapshot builds the protocol-neutral topology snapshot for this
 // control channel: identity, primary/secondary control channels, neighbours,
 // and band plan, with every channel's downlink frequency resolved through the

--- a/internal/scanner/widebandt2/engine.go
+++ b/internal/scanner/widebandt2/engine.go
@@ -161,6 +161,16 @@ const channelizerCleanResidualFrac = 0.40
 type ChannelConfig struct {
 	FrequencyHz uint32
 	SystemName  string
+
+	// P25Phase1DemodMode optionally overrides the parent system's
+	// P25Phase1DemodMode for this one tap (issue #935). A P25 system can
+	// span sites of differing modulation — an LSM simulcast site and a
+	// C4FM single-transmitter site under one system name — and each tap
+	// must pick its symbol-recovery path independently before the CC
+	// locks. Empty inherits sys.P25Phase1DemodMode; any value the
+	// system-level key accepts (c4fm/fm/cqpsk/lsm/linear) is valid here.
+	// Ignored for non-P25-Phase-1 channels.
+	P25Phase1DemodMode string
 }
 
 // IQPowerObserver is the minimal metrics surface the engine uses to
@@ -653,10 +663,21 @@ func buildChannel(sys trunking.System, ch ChannelConfig, outRateHz float64, bus 
 		if err := requireControlChannel(sys, freqHz, "p25 / Phase 1"); err != nil {
 			return nil, err
 		}
-		demodMode, ok := p25phase1rx.ParseDemodMode(sys.P25Phase1DemodMode)
+		// Per-site demod override (issue #935): a single P25 system can
+		// span an LSM simulcast site and a C4FM single-transmitter site,
+		// so an empty per-channel value inherits the system default while
+		// a non-empty one overrides it for this tap only. The mode must be
+		// chosen here, before the CC locks — it is what lets it lock — so
+		// it is keyed per control-channel frequency, not by the RFSS/Site
+		// the CC only reveals once decoded.
+		demodStr := sys.P25Phase1DemodMode
+		if ch.P25Phase1DemodMode != "" {
+			demodStr = ch.P25Phase1DemodMode
+		}
+		demodMode, ok := p25phase1rx.ParseDemodMode(demodStr)
 		if !ok {
 			log.Warn("widebandt2: unrecognised p25_phase1_demod_mode; falling back to c4fm",
-				"system", sys.Name, "value", sys.P25Phase1DemodMode)
+				"system", sys.Name, "freq_hz", freqHz, "value", demodStr)
 		}
 		// C4FM has only two physical rotations (identity, polarity
 		// flip); the CQPSK / LSM path has the full four-fold QPSK
@@ -686,12 +707,19 @@ func buildChannel(sys trunking.System, ch ChannelConfig, outRateHz float64, bus 
 		// Parse and forward the same knobs the ccdecoder pipeline does.
 		p2Trellis, p2RS, p2Interleave, p2Scrambler := parseP25Phase2FECModes(sys, log)
 		cc := p25phase1.New(p25phase1.Options{
-			Bus:                 bus,
-			Log:                 log.With("system", sys.Name, "freq_hz", freqHz, "phase", 1),
-			SystemName:          sys.Name,
-			FrequencyHz:         freqHz,
-			BandPlan:            bandPlan,
-			Rotations:           rotations,
+			Bus:         bus,
+			Log:         log.With("system", sys.Name, "freq_hz", freqHz, "phase", 1),
+			SystemName:  sys.Name,
+			FrequencyHz: freqHz,
+			BandPlan:    bandPlan,
+			Rotations:   rotations,
+			// Stamp the resolved demod mode onto every voice grant this CC
+			// publishes so the composer decodes the traffic channel on the
+			// same path — an LSM site's grants must run the LSM voice chain
+			// too, or they lock the CC yet never decode an LDU (issue #935 /
+			// #356 follow-up). The wideband path previously left this unset,
+			// so grants always defaulted to c4fm regardless of the CC's mode.
+			P25Phase1DemodMode:  demodStr,
 			P25Phase2Trellis:    p2Trellis,
 			P25Phase2RS:         p2RS,
 			P25Phase2Interleave: p2Interleave,

--- a/internal/scanner/widebandt2/engine_p25_persite_demod_test.go
+++ b/internal/scanner/widebandt2/engine_p25_persite_demod_test.go
@@ -1,0 +1,64 @@
+package widebandt2
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	p25phase1 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
+)
+
+// TestBuildChannelP25Phase1PerSiteDemodOverride is the regression test for
+// issue #935: within a single P25 system, individual sites can transmit
+// different modulation — an urban simulcast site on Linear Simulcast
+// Modulation (cqpsk / lsm) alongside rural single-transmitter sites on
+// straight C4FM. A wideband dongle decodes each site's control channel in
+// parallel, so the per-tap demod path must be selectable per control-channel
+// frequency rather than only once at the system level.
+//
+// The override also has to reach the voice grants a tap publishes: without
+// it an LSM site would lock its CC yet decode no LDU on a granted call
+// (issue #356 follow-up), because the composer's voice chain reads the
+// grant's demod mode. The wideband path previously never stamped a demod
+// mode onto grants at all, so this pins both halves.
+func TestBuildChannelP25Phase1PerSiteDemodOverride(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	log := slog.New(slog.NewTextHandler(discardWriter{}, nil))
+
+	const (
+		lsmHz  = 420_012_500 // Melbourne / CBD — LSM simulcast
+		c4fmHz = 420_087_500 // Mt Anakie — single-TX C4FM
+	)
+
+	// System default is c4fm (a real, non-empty value) so the inheriting
+	// tap proves inheritance rather than landing on a coincidental empty
+	// default, and the override tap proves the per-channel value wins.
+	sys := p25Phase1System("MMR", lsmHz)
+	sys.ControlChannels = []uint32{lsmHz, c4fmHz}
+	sys.P25Phase1DemodMode = "c4fm"
+
+	// Override this one tap onto the LSM path; leave the other inheriting.
+	lsmCh := ChannelConfig{FrequencyHz: lsmHz, SystemName: sys.Name, P25Phase1DemodMode: "cqpsk"}
+	c4fmCh := ChannelConfig{FrequencyHz: c4fmHz, SystemName: sys.Name}
+
+	demodOf := func(t *testing.T, ch ChannelConfig) string {
+		t.Helper()
+		ec, err := buildChannel(sys, ch, narrowbandRateHz, bus, log, nil)
+		if err != nil {
+			t.Fatalf("buildChannel(%d): %v", ch.FrequencyHz, err)
+		}
+		cc, ok := ec.processor.(*p25phase1.ControlChannel)
+		if !ok {
+			t.Fatalf("processor type = %T, want *p25phase1.ControlChannel", ec.processor)
+		}
+		return cc.P25Phase1DemodMode()
+	}
+
+	if got := demodOf(t, lsmCh); got != "cqpsk" {
+		t.Errorf("LSM tap demod mode = %q, want %q — per-channel override not applied to grants (issue #935)", got, "cqpsk")
+	}
+	if got := demodOf(t, c4fmCh); got != "c4fm" {
+		t.Errorf("inheriting tap demod mode = %q, want %q — system default not forwarded to grants", got, "c4fm")
+	}
+}

--- a/web/configbuilder/src/api/types.ts
+++ b/web/configbuilder/src/api/types.ts
@@ -68,6 +68,10 @@ export interface APIConfig {
 export interface DeviceChannelConfig {
   FrequencyHz: number;
   System: string;
+  // Optional per-site P25 Phase 1 demod override for this tap (issue #935):
+  // "" inherits the system's p25_phase1_demod_mode, else "c4fm"/"fm" or
+  // "cqpsk"/"lsm"/"linear". Ignored for non-P25-Phase-1 channels.
+  P25Phase1DemodMode?: string;
 }
 
 export interface DeviceConfig {

--- a/web/configbuilder/src/sections/SDR.tsx
+++ b/web/configbuilder/src/sections/SDR.tsx
@@ -225,6 +225,17 @@ function DeviceEditor(props: {
                 ) : (
                   <TextField label="System" value={c.System} onChange={(v) => set({ ...c, System: v })} help="Must match a trunking system name." />
                 )}
+                <SelectField
+                  label="P25 Ph1 demod override"
+                  value={c.P25Phase1DemodMode ?? ""}
+                  onChange={(v) => set({ ...c, P25Phase1DemodMode: v })}
+                  options={[
+                    { value: "", label: "Inherit system default" },
+                    { value: "c4fm", label: "C4FM / FM" },
+                    { value: "cqpsk", label: "CQPSK / LSM (simulcast)" },
+                  ]}
+                  help="Override the system's demod path for this site only. Use when one P25 system mixes LSM simulcast and C4FM sites (issue #935). P25 Phase 1 only."
+                />
               </div>
             )}
           />


### PR DESCRIPTION
## Summary

Within a single P25 system, individual sites can transmit different modulation — e.g. an urban simulcast site on Linear Simulcast Modulation (`cqpsk`/`lsm`) alongside rural single-transmitter sites on straight `c4fm`. Today `p25_phase1_demod_mode` is a system-level setting only, so a wideband multi-site config can't decode an LSM site and a C4FM site under one system: the LSM sites show `control_channel_decode_quality: poor` regardless of hardware because a C4FM demodulator can't recover a linearly-modulated simulcast signal. This adds a per-site override.

_(The #565 paging-storage fix that was briefly stacked here now lives in its own PR, #944.)_

## Changes

- **New per-channel config key** `p25_phase1_demod_mode` on the wideband device's `sdr.devices[].channels[]` entries (`config.DeviceChannelConfig`). Empty inherits the system-level default; accepts the same values as the system key (`c4fm`/`fm` vs `cqpsk`/`lsm`/`linear`).
- **Keyed per control-channel frequency, not RFSS/Site.** The demod path must be chosen *before* a CC locks — it's what lets it lock — so it can't be keyed by the RFSS/Site the CC only reveals after decoding. The wideband `channels:` entry is the one place a site's identity is known at config time.
- **`widebandt2.buildChannel`** resolves the effective mode (per-channel override → system default) and applies it to both the receiver's `DemodMode` and the control channel, so the voice grants that tap issues are stamped with the same mode and the composer runs the LSM voice chain for LSM sites.
- **Latent-gap fix:** the wideband `buildChannel` path previously never set `p25phase1.Options.P25Phase1DemodMode` at all, so wideband P25 voice grants always defaulted to the C4FM chain regardless of the system setting. Now forwarded (mirrors the single-CC `ccdecoder` pipeline).
- Read-only `ControlChannel.P25Phase1DemodMode()` accessor (mirrors the existing `P25Phase2FEC()`), plus daemon plumbing, `configbuilder` field metadata, and the web Config Builder typed field + editor.
- `config.example.yaml`: the existing MMR multi-site example now shows the mix — CBD/Collins St on `cqpsk`, Mt Anakie/Blackwood inheriting `c4fm`.

## Test plan

- [x] `make vet test` is green locally
- [x] Added a regression test — `TestBuildChannelP25Phase1PerSiteDemodOverride` in `internal/scanner/widebandt2`. It **fails first** (demod mode `""` on both taps) on both the missing override *and* the pre-existing grant-propagation gap, and passes with the fix.
- [ ] Smoke-tested against real hardware — not possible here; needs the reporter to confirm CBD/Geelong now lock and decode voice with `p25_phase1_demod_mode: cqpsk`.

`make integration` not run: the change is config plumbing into `buildChannel`, covered by the unit test; no DSP/replay path changed.

## Breaking changes

None. The new key is optional and defaults to inheriting the existing system-level `p25_phase1_demod_mode`, so existing configs are unchanged.

## Docs / CHANGELOG

- [x] Added a `## [Unreleased]` bullet to `CHANGELOG.md`
- [x] Updated `config.example.yaml` (per-site modulation notes + worked MMR example)

## Linked issues

Refs #935

<!-- Refs, not Closes: the fix can't be verified without the reporter's hardware confirming an LSM site now locks and decodes voice. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)