### PR TITLE
feat(paging): warn at startup when paging is configured without storage (#565)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **Startup warning when paging is configured without storage.** A
+  `paging.pocsag` / `paging.flex` / `paging.wideband` subsystem with no
+  `storage.path` set decodes fine and consumes live IQ, but decoded pages are
+  never persisted and `GET /api/v1/pager/messages` returns `503`, so the
+  Pagers panel shows a bare `pager/messages 503` with no hint that storage is
+  the missing piece. The daemon now surfaces this at load time as a startup
+  warning (alongside the launcher / TUI dashboard warnings) instead of leaving
+  the misconfiguration silent. (issue #565)
 - **Per-site P25 Phase 1 demod mode on wideband multi-site taps.** A single P25
   system can now mix modulation across its sites: set the system-level
   `p25_phase1_demod_mode` to the majority modulation and add a per-channel

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -629,6 +629,31 @@ func (d *Daemon) addWarning(msg string) {
 	d.startupWarnings = append(d.startupWarnings, msg)
 }
 
+// warnPagingNeedsStorage records a startup warning when a paging subsystem
+// (POCSAG / FLEX / wideband) is configured but storage.path is empty.
+// Without storage the receivers still start and consume live IQ, but decoded
+// pages are never persisted and GET /api/v1/pager/messages returns 503 — so
+// the operator sees the Pagers panel fail with a bare "pager/messages 503"
+// and no hint that the missing piece is storage.path. The 503's own body
+// carries that hint, but it never reaches an operator watching the log or the
+// GUI status code. The reporter of issue #565 hit exactly this: POCSAG
+// "not working" until they discovered on their own that adding storage: to
+// the config fixed it. Surfacing it at load time — alongside the other
+// startup warnings the launcher and TUI dashboard show — turns a silent
+// misconfiguration into an actionable one.
+func (d *Daemon) warnPagingNeedsStorage(cfg config.Config) {
+	if cfg.Storage.Path != "" {
+		return
+	}
+	if len(cfg.Paging.POCSAG)+len(cfg.Paging.FLEX)+len(cfg.Paging.Wideband) == 0 {
+		return
+	}
+	d.addWarning("paging is configured but storage.path is not set — decoded " +
+		"pages will not be persisted and the Pagers panel " +
+		"(GET /api/v1/pager/messages) returns 503; set storage.path to keep " +
+		"and view pager messages (issue #565)")
+}
+
 // newDiagCollector builds the error-diagnostics collector handed to the
 // API/gRPC servers. When the SDR pool is up, it seeds the collector
 // from the live pool snapshot so a banner never triggers a fresh USB
@@ -1939,6 +1964,11 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 			d.pagingGroups = append(d.pagingGroups, *group)
 		}
 	}
+
+	// Paging decodes only persist / surface via the API when storage is
+	// wired; warn the operator at load time if they configured paging but
+	// no storage.path (issue #565).
+	d.warnPagingNeedsStorage(cfg)
 
 	// M17 link-layer receivers — one per configured m17.channels entry.
 	// Same construction shape as the paging receivers above; decoded

--- a/cmd/gophertrunk/daemon_paging_storage_warn_test.go
+++ b/cmd/gophertrunk/daemon_paging_storage_warn_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/config"
+)
+
+// TestWarnPagingNeedsStorage is the regression test for issue #565: a paging
+// subsystem configured without storage.path decodes fine but persists
+// nothing, so GET /api/v1/pager/messages returns 503 and the operator sees
+// the Pagers panel "not working" with no hint that storage.path is the
+// missing piece. The daemon must surface that at load time as a startup
+// warning. Before the fix no such warning existed — paging + no storage was
+// silent.
+func TestWarnPagingNeedsStorage(t *testing.T) {
+	pocsag := config.Config{
+		Paging: config.PagingConfig{
+			POCSAG: []config.PagingPOCSAGConfig{{Serial: "00000022", FrequencyHz: 153_350_000}},
+		},
+	}
+
+	cases := []struct {
+		name      string
+		cfg       config.Config
+		wantWarn  bool
+		mustMatch []string
+	}{
+		{
+			name:      "pocsag without storage warns",
+			cfg:       pocsag,
+			wantWarn:  true,
+			mustMatch: []string{"storage.path", "paging", "565"},
+		},
+		{
+			name: "flex without storage warns",
+			cfg: config.Config{
+				Paging: config.PagingConfig{
+					FLEX: []config.PagingFLEXConfig{{Serial: "00000022", FrequencyHz: 148_000_000}},
+				},
+			},
+			wantWarn: true,
+		},
+		{
+			name: "wideband paging without storage warns",
+			cfg: config.Config{
+				Paging: config.PagingConfig{
+					Wideband: []config.PagingWidebandConfig{{Serial: "pager-sdr"}},
+				},
+			},
+			wantWarn: true,
+		},
+		{
+			name: "paging with storage set does not warn",
+			cfg: func() config.Config {
+				c := pocsag
+				c.Storage.Path = "/var/lib/gophertrunk/gt.db"
+				return c
+			}(),
+			wantWarn: false,
+		},
+		{
+			name:     "no paging configured does not warn",
+			cfg:      config.Config{},
+			wantWarn: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := &Daemon{}
+			d.warnPagingNeedsStorage(tc.cfg)
+			warns := d.StartupWarnings()
+
+			if !tc.wantWarn {
+				if len(warns) != 0 {
+					t.Fatalf("expected no warning, got %v", warns)
+				}
+				return
+			}
+
+			if len(warns) != 1 {
+				t.Fatalf("expected exactly one warning, got %d: %v", len(warns), warns)
+			}
+			for _, sub := range tc.mustMatch {
+				if !strings.Contains(warns[0], sub) {
+					t.Errorf("warning %q missing expected substring %q", warns[0], sub)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Issue #565: a Raspberry Pi 4B operator reported the POCSAG subsystem "not working" — the Pagers tab showed `pager/messages 503`. It turned out the fix was adding `storage:` to their config, which they had to discover on their own. When a paging subsystem (`paging.pocsag` / `paging.flex` / `paging.wideband`) is configured but `storage.path` is empty, the receivers still start and consume live IQ, but decoded pages are never persisted and `GET /api/v1/pager/messages` returns `503`. The 503's body does carry a "set storage.path" hint, but the web GUI only surfaces the status code, so it never reaches the operator.

## Changes

- The daemon now emits a **startup warning** at load time when paging is configured but `storage.path` is empty, printed alongside the existing launcher / TUI dashboard warnings — turning a silent misconfiguration into an actionable message.

## Test plan

- [x] `make vet test` is green locally
- [x] Added `TestWarnPagingNeedsStorage` — **fails first** (paging + no storage was silent before this change), and covers pocsag / flex / wideband triggering the warning while storage-set and no-paging stay silent.
- [ ] Not hardware-tested; the change is load-time config validation.

`make integration` not run: no daemon runtime / DSP path changed, only a load-time warning.

## Breaking changes

None. Additive load-time warning only; no config keys or behaviour change.

## Docs / CHANGELOG

- [x] `## [Unreleased]` bullet added to `CHANGELOG.md`.

## Linked issues

Refs #565

### Note on the second symptom (not addressed here)

The same reporter also saw a persistent `sdr: dropping live IQ chunks; consumer can't keep up` WARN. That's a genuine host-throughput overrun — the POCSAG front end FM-demodulates at the full SDR rate before decimating, which a Pi 4B can't always sustain; POCSAG tolerates the dropped gaps, which is why decode still works. The documented mitigation is a lower `sdr.sample_rate`. The proper cure is a decimate-before-demod front-end refactor, but that needs a capture from the reporter to verify decode parity, so it's tracked separately and intentionally out of scope for this narrow change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMnfqGiUNhnjUTeev9sdHV)_