### PR TITLE
fix(tetra): bit-reverse the §8.2.5 scrambler seed so real bursts descramble

### DIFF
--- a/cmd/gophertrunk/capture.go
+++ b/cmd/gophertrunk/capture.go
@@ -1,13 +1,16 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/gtbundle"
@@ -132,6 +135,17 @@ FLAGS:`)
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 
+	// Count IQ chunks the driver drops while this capture runs. A dropped
+	// chunk is a contiguous time gap in the recording — enough to slip a
+	// downstream decoder's symbol clock and make the carrier appear to
+	// "jump". The daemon's --iq-capture path already surfaces its drops
+	// (iqcapture.go); this standalone path did not, so a corrupt capture was
+	// silent to the operator. Install a device-scoped counter and warn at the
+	// end if any dropped.
+	drops := &captureDropCounter{serial: info.Serial}
+	sdr.SetIQDropObserver(drops.observe)
+	defer sdr.SetIQDropObserver(nil)
+
 	stream, err := dev.StreamIQ(ctx)
 	if err != nil {
 		rep.Fatal(1, fmt.Errorf("start IQ stream: %w", err))
@@ -171,6 +185,18 @@ FLAGS:`)
 	written, capErr := captureToFile(ctx, *out, sampleFormat, stream, uint32(*sampleRate), *seconds, ddc)
 	if capErr != nil && !errors.Is(capErr, context.Canceled) {
 		rep.Fatal(1, fmt.Errorf("capture: %w (wrote %d samples to %s)", capErr, written, *out))
+	}
+	if d := drops.count(); d > 0 {
+		// Loud + actionable: a dropped-chunk capture looks fine on disk but
+		// decodes as a clock-slipping, carrier-jumping mess. The bottleneck is
+		// almost always the drain not keeping up with the native rate — the DDC
+		// (-bandwidth) decimation cost or slow storage — so the driver sheds
+		// whole chunks.
+		fmt.Fprintf(os.Stderr,
+			"capture: WARNING — the SDR dropped %d IQ chunk(s) during this capture. "+
+				"Each is a time gap that corrupts downstream decode (symbol-clock slip / carrier jumps). "+
+				"Remedy: lower -sample-rate, drop or widen -bandwidth (the DDC decimation is CPU-heavy), "+
+				"or write to faster storage; then re-capture.\n", d)
 	}
 
 	meta := &siglab.Metadata{
@@ -269,6 +295,31 @@ func openCaptureDevice(serial string) (sdr.Device, sdr.Info, error) {
 	return dev, chosen, nil
 }
 
+// captureWriterDepth is how many encoded chunks captureStream buffers between
+// the IQ-drain goroutine and the disk-writer goroutine. A storage-latency
+// spike up to this many chunks is absorbed here instead of stalling the drain
+// — which, on a live SDR, would make the driver shed whole IQ chunks
+// (NotifyIQDrop), punching time gaps into the capture that slip a downstream
+// decoder's symbol clock. Each entry is one post-DDC encoded chunk (a few KB
+// for a narrowband slice), so this is trivial memory.
+const captureWriterDepth = 256
+
+// captureBufWriter is the disk write-buffer size. Batching many small chunk
+// writes into one syscall keeps the writer goroutine from falling behind.
+const captureBufWriter = 1 << 20 // 1 MiB
+
+// encoderFor returns the byte packer and per-sample size for a capture format.
+func encoderFor(format siglab.SampleFormat) (func(dst []byte, src []complex64), int) {
+	switch format {
+	case siglab.FormatU8:
+		return encodeU8, 2
+	case siglab.FormatS16:
+		return encodeS16, 4
+	default:
+		return encodeF32, 8
+	}
+}
+
 // captureToFile streams complex64 chunks from src, optionally decimates each
 // chunk to a narrowband channel through ddc (nil = full band), encodes the
 // result in the requested on-disk format with the shared encodeF32/encodeU8/
@@ -281,17 +332,32 @@ func captureToFile(ctx context.Context, path string, format siglab.SampleFormat,
 	if err != nil {
 		return 0, fmt.Errorf("create %s: %w", path, err)
 	}
-
-	encode := encodeF32
-	bytesPerSample := 8
-	switch format {
-	case siglab.FormatU8:
-		encode = encodeU8
-		bytesPerSample = 2
-	case siglab.FormatS16:
-		encode = encodeS16
-		bytesPerSample = 4
+	bw := bufio.NewWriterSize(f, captureBufWriter)
+	written, loopErr := captureStream(ctx, bw, format, src, rate, seconds, ddc)
+	// captureStream has joined its writer goroutine before returning, so bw is
+	// no longer touched concurrently — flush + close on this goroutine.
+	if ferr := bw.Flush(); ferr != nil && loopErr == nil {
+		loopErr = fmt.Errorf("flush: %w", ferr)
 	}
+	if cerr := f.Close(); cerr != nil && loopErr == nil {
+		loopErr = cerr
+	}
+	return written, loopErr
+}
+
+// captureStream is the format-encode + write loop behind captureToFile,
+// decoupled from the file so it is testable with any io.Writer.
+//
+// The disk write runs on its own goroutine fed by a deep buffered channel, so
+// a slow/stalling writer never stalls the goroutine draining src. That
+// matters because src is the SDR driver's bounded delivery channel: if this
+// goroutine blocks on a disk write, the driver's channel backs up and the
+// driver drops whole IQ chunks (non-blocking, silent), corrupting the capture.
+// Decoupling keeps the drain running so a transient stall costs latency, not
+// samples. The stateful DDC stays on the drain goroutine (it must run in
+// order); only the encoded bytes cross to the writer.
+func captureStream(ctx context.Context, w io.Writer, format siglab.SampleFormat, src <-chan []complex64, rate uint32, seconds float64, ddc *ccdecoder.Downconverter) (int64, error) {
+	encode, bytesPerSample := encoderFor(format)
 
 	// Stop once seconds worth of INPUT samples have been read; the written
 	// count may be far smaller when ddc decimates to a narrow channel.
@@ -299,12 +365,30 @@ func captureToFile(ctx context.Context, path string, format siglab.SampleFormat,
 	// Safety deadline so a stalled/under-delivering device doesn't hang the
 	// command forever waiting to reach the sample target. The timer is an
 	// explicit select arm (not a post-receive check) so a source that never
-	// delivers a chunk can't block the receive forever — see the same fix in
-	// captureProvider.Capture for the daemon's broker-tap path.
+	// delivers a chunk can't block the receive forever.
 	timer := time.NewTimer(time.Duration(seconds*float64(time.Second)) + 5*time.Second)
 	defer timer.Stop()
 
-	var scratch []byte
+	writerCh := make(chan []byte, captureWriterDepth)
+	writeErrCh := make(chan error, 1)
+	writerDone := make(chan struct{})
+	go func() {
+		defer close(writerDone)
+		for b := range writerCh {
+			if _, werr := w.Write(b); werr != nil {
+				select {
+				case writeErrCh <- werr:
+				default:
+				}
+				// Keep draining so the producer never blocks on a full channel
+				// after a write failure; stop writing.
+				for range writerCh {
+				}
+				return
+			}
+		}
+	}()
+
 	var ddcBuf []complex64
 	var inputRead, written int64
 	var loopErr error
@@ -315,6 +399,9 @@ loop:
 			loopErr = ctx.Err()
 			break loop
 		case <-timer.C:
+			break loop
+		case werr := <-writeErrCh:
+			loopErr = fmt.Errorf("write: %w", werr)
 			break loop
 		case chunk, ok := <-src:
 			if !ok {
@@ -330,26 +417,56 @@ loop:
 			if len(samples) == 0 {
 				continue
 			}
-			n := len(samples) * bytesPerSample
-			if cap(scratch) < n {
-				scratch = make([]byte, n)
-			} else {
-				scratch = scratch[:n]
-			}
-			encode(scratch, samples)
-			if _, werr := f.Write(scratch); werr != nil {
+			// Fresh buffer per chunk: it is handed to the writer goroutine, so
+			// it must not alias the reused ddcBuf.
+			buf := make([]byte, len(samples)*bytesPerSample)
+			encode(buf, samples)
+			select {
+			case writerCh <- buf:
+			case werr := <-writeErrCh:
 				loopErr = fmt.Errorf("write: %w", werr)
+				break loop
+			case <-ctx.Done():
+				loopErr = ctx.Err()
 				break loop
 			}
 			written += int64(len(samples))
 		}
 	}
 
-	if cerr := f.Close(); cerr != nil && loopErr == nil {
-		loopErr = cerr
+	close(writerCh)
+	<-writerDone
+	// A write error that landed as the loop was exiting (or during the final
+	// drain) still counts.
+	if loopErr == nil {
+		select {
+		case werr := <-writeErrCh:
+			loopErr = fmt.Errorf("write: %w", werr)
+		default:
+		}
 	}
 	return written, loopErr
 }
+
+// captureDropCounter counts SDR IQ-chunk drops for one device during a
+// capture, via the process-wide sdr IQ-drop observer. It turns a silently
+// corrupt capture (dropped chunks = time gaps) into a count the command can
+// warn about.
+type captureDropCounter struct {
+	serial string
+	n      atomic.Uint64
+}
+
+// observe is the sdr.SetIQDropObserver callback; it counts drops for the
+// capture's device and ignores any other device's.
+func (c *captureDropCounter) observe(info sdr.Info) {
+	if info.Serial == c.serial {
+		c.n.Add(1)
+	}
+}
+
+// count returns the number of dropped chunks observed so far.
+func (c *captureDropCounter) count() uint64 { return c.n.Load() }
 
 // absInt64 is the absolute value of a signed 64-bit integer.
 func absInt64(x int64) int64 {

--- a/cmd/gophertrunk/capture.go
+++ b/cmd/gophertrunk/capture.go
@@ -182,9 +182,14 @@ FLAGS:`)
 			float64(recCenter)/1e6, recRate/1e3)
 	}
 
-	written, capErr := captureToFile(ctx, *out, sampleFormat, stream, uint32(*sampleRate), *seconds, ddc)
+	written, probe, capErr := captureToFile(ctx, *out, sampleFormat, stream, uint32(*sampleRate), *seconds, ddc)
 	if capErr != nil && !errors.Is(capErr, context.Canceled) {
 		rep.Fatal(1, fmt.Errorf("capture: %w (wrote %d samples to %s)", capErr, written, *out))
+	}
+	// Warn if a ppm error has pulled the recorded carrier off centre — the
+	// other half of the "capture won't lock" story alongside dropped chunks.
+	if w := carrierOffsetWarning(probe, recRate, recCenter); w != "" {
+		fmt.Fprintln(os.Stderr, w)
 	}
 	if d := drops.count(); d > 0 {
 		// Loud + actionable: a dropped-chunk capture looks fine on disk but
@@ -327,13 +332,16 @@ func encoderFor(format siglab.SampleFormat) (func(dst []byte, src []complex64), 
 // INPUT samples, the stream ends, ctx cancels, or a wall-clock safety deadline
 // elapses. Returns the number of IQ samples written (post-decimation when ddc
 // is set).
-func captureToFile(ctx context.Context, path string, format siglab.SampleFormat, src <-chan []complex64, rate uint32, seconds float64, ddc *ccdecoder.Downconverter) (int64, error) {
+// captureToFile returns the samples written plus the first captureProbeSamples
+// of recorded (post-DDC) IQ, which the caller FFTs for the carrier-offset
+// warning.
+func captureToFile(ctx context.Context, path string, format siglab.SampleFormat, src <-chan []complex64, rate uint32, seconds float64, ddc *ccdecoder.Downconverter) (int64, []complex64, error) {
 	f, err := os.Create(path)
 	if err != nil {
-		return 0, fmt.Errorf("create %s: %w", path, err)
+		return 0, nil, fmt.Errorf("create %s: %w", path, err)
 	}
 	bw := bufio.NewWriterSize(f, captureBufWriter)
-	written, loopErr := captureStream(ctx, bw, format, src, rate, seconds, ddc)
+	written, probe, loopErr := captureStream(ctx, bw, format, src, rate, seconds, ddc)
 	// captureStream has joined its writer goroutine before returning, so bw is
 	// no longer touched concurrently — flush + close on this goroutine.
 	if ferr := bw.Flush(); ferr != nil && loopErr == nil {
@@ -342,7 +350,7 @@ func captureToFile(ctx context.Context, path string, format siglab.SampleFormat,
 	if cerr := f.Close(); cerr != nil && loopErr == nil {
 		loopErr = cerr
 	}
-	return written, loopErr
+	return written, probe, loopErr
 }
 
 // captureStream is the format-encode + write loop behind captureToFile,
@@ -356,8 +364,9 @@ func captureToFile(ctx context.Context, path string, format siglab.SampleFormat,
 // Decoupling keeps the drain running so a transient stall costs latency, not
 // samples. The stateful DDC stays on the drain goroutine (it must run in
 // order); only the encoded bytes cross to the writer.
-func captureStream(ctx context.Context, w io.Writer, format siglab.SampleFormat, src <-chan []complex64, rate uint32, seconds float64, ddc *ccdecoder.Downconverter) (int64, error) {
+func captureStream(ctx context.Context, w io.Writer, format siglab.SampleFormat, src <-chan []complex64, rate uint32, seconds float64, ddc *ccdecoder.Downconverter) (int64, []complex64, error) {
 	encode, bytesPerSample := encoderFor(format)
+	probe := make([]complex64, 0, captureProbeSamples)
 
 	// Stop once seconds worth of INPUT samples have been read; the written
 	// count may be far smaller when ddc decimates to a narrow channel.
@@ -417,6 +426,16 @@ loop:
 			if len(samples) == 0 {
 				continue
 			}
+			// Collect the first window of recorded samples for the caller's
+			// carrier-offset probe (append copies, so it's safe against the
+			// reused ddcBuf / the src-owned chunk).
+			if len(probe) < captureProbeSamples {
+				take := samples
+				if n := captureProbeSamples - len(probe); len(take) > n {
+					take = take[:n]
+				}
+				probe = append(probe, take...)
+			}
 			// Fresh buffer per chunk: it is handed to the writer goroutine, so
 			// it must not alias the reused ddcBuf.
 			buf := make([]byte, len(samples)*bytesPerSample)
@@ -445,7 +464,7 @@ loop:
 		default:
 		}
 	}
-	return written, loopErr
+	return written, probe, loopErr
 }
 
 // captureDropCounter counts SDR IQ-chunk drops for one device during a

--- a/cmd/gophertrunk/capture_carrier.go
+++ b/cmd/gophertrunk/capture_carrier.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/fft"
+)
+
+// captureProbeSamples is how many recorded (post-DDC) IQ samples the capture
+// collects for the carrier-offset probe. A power-of-two window keeps the FFT
+// cheap; 32768 bins give sub-100 Hz resolution even at multi-MS/s rates and a
+// fraction of a second at a narrowband slice rate.
+const captureProbeSamples = 1 << 15
+
+// carrierOffsetWarnHz is the |offset| above which the capture warns. Small
+// offsets are pulled in by every decoder's AFC; a multi-kHz offset (a real
+// ppm error) is what prevents lock, which is what we want to flag.
+const carrierOffsetWarnHz = 2000.0
+
+// captureCarrierOffsetHz estimates the dominant signal's frequency offset from
+// baseband centre (DC) over iq, sampled at rate Hz. A ppm-mistuned capture
+// puts the whole channel off centre by a fixed number of Hz; this recovers
+// that.
+//
+// A modulated channel has no sharp carrier line — its power is spread across
+// the occupied band and (being noisy and roughly symmetric) a simple centroid
+// is pulled toward DC by the noise. Instead this smooths the power spectrum
+// with a moving average about a channel-fraction wide, collapsing the
+// modulation ripple into a single hump, and returns the peak of that hump —
+// the channel's centre. It returns ok=false when the window is too short or no
+// hump stands clearly above the mean (a noise-only capture), so a featureless
+// capture never produces a spurious warning.
+func captureCarrierOffsetHz(iq []complex64, rate float64) (float64, bool) {
+	// Largest power of two we have, capped at the probe size.
+	n := 1
+	for n*2 <= len(iq) && n*2 <= captureProbeSamples {
+		n *= 2
+	}
+	if n < 1024 || rate <= 0 {
+		return 0, false
+	}
+	in := fft.Cmplx64ToCmplx128(nil, iq[:n])
+	spec := fft.New(n).Forward(nil, in)
+
+	power := make([]float64, n)
+	var total float64
+	for k := 0; k < n; k++ {
+		re, im := real(spec[k]), imag(spec[k])
+		power[k] = re*re + im*im
+		total += power[k]
+	}
+	if total <= 0 {
+		return 0, false
+	}
+
+	// Circular moving-average sum over a window ~n/64 bins wide. The spectrum
+	// wraps at DC (bin n-1 is adjacent to bin 0), so the window is circular.
+	win := n / 64
+	if win < 8 {
+		win = 8
+	}
+	half := win / 2
+	win = 2*half + 1 // actual window width
+
+	smoothed := make([]float64, n)
+	var sum float64
+	for j := -half; j <= half; j++ {
+		sum += power[((j%n)+n)%n]
+	}
+	smoothed[0] = sum
+	best, bestK := sum, 0
+	for k := 1; k < n; k++ {
+		sum -= power[(((k-1-half)%n)+n)%n]
+		sum += power[(((k+half)%n)+n)%n]
+		smoothed[k] = sum
+		if sum > best {
+			best, bestK = sum, k
+		}
+	}
+
+	// Require the peak window to hold clearly more energy than an average
+	// window — otherwise there is no channel, just noise.
+	meanWindow := total / float64(n) * float64(win)
+	const peakMargin = 3.0
+	if best < meanWindow*peakMargin {
+		return 0, false
+	}
+
+	// The argmax is the FIRST bin reaching the peak, which for a flat-topped
+	// channel (or a sharp tone) sits at the leading edge of the plateau —
+	// biased low by ~half the smoothing window. Expand the plateau (circularly)
+	// and take its centre so the estimate lands on the channel's middle.
+	thr := best * 0.999
+	l, r := bestK, bestK
+	for i := 0; i < n; i++ {
+		p := ((l-1)%n + n) % n
+		if smoothed[p] < thr {
+			break
+		}
+		l = p
+	}
+	for i := 0; i < n; i++ {
+		q := (r + 1) % n
+		if smoothed[q] < thr {
+			break
+		}
+		r = q
+	}
+	width := ((r - l) % n + n) % n
+	centerK := (l + width/2) % n
+
+	// Map the centre bin to a signed baseband frequency (fftshift): the upper
+	// half of the spectrum is the negative frequencies.
+	f := float64(centerK)
+	if centerK >= n/2 {
+		f -= float64(n)
+	}
+	return f * rate / float64(n), true
+}
+
+// carrierOffsetWarning returns an operator-facing warning when a recorded
+// capture's carrier sits far enough off centre to matter, or "" when it is
+// close enough (or couldn't be estimated). freqHz is the tuned RF centre, used
+// to translate the offset into an approximate ppm figure.
+func carrierOffsetWarning(iq []complex64, rate float64, freqHz uint32) string {
+	offset, ok := captureCarrierOffsetHz(iq, rate)
+	if !ok || math.Abs(offset) < carrierOffsetWarnHz {
+		return ""
+	}
+	ppm := 0.0
+	if freqHz > 0 {
+		ppm = offset / float64(freqHz) * 1e6
+	}
+	return formatCarrierOffsetWarning(offset, ppm)
+}
+
+// formatCarrierOffsetWarning renders the warning string. Split out so the
+// wording is unit-testable without synthesising IQ.
+func formatCarrierOffsetWarning(offsetHz, ppm float64) string {
+	// The sign convention of -ppm is driver-specific, so quote the magnitude
+	// and tell the operator which way to nudge rather than risk a wrong sign.
+	dir := "below"
+	if offsetHz > 0 {
+		dir = "above"
+	}
+	msg := fmt.Sprintf("capture: WARNING — the recorded carrier sits %.1f kHz %s centre",
+		math.Abs(offsetHz)/1000, dir)
+	if ppm != 0 {
+		msg += fmt.Sprintf(" (≈%.1f ppm at this frequency)", math.Abs(ppm))
+	}
+	msg += fmt.Sprintf(". If unintended this is an uncorrected tuner error: set -ppm to "+
+		"pull the carrier back to centre (try ±%.0f and keep the sign that shrinks the "+
+		"offset). If you offset -center on purpose, ignore this.", math.Abs(ppm))
+	return msg
+}

--- a/cmd/gophertrunk/capture_carrier.go
+++ b/cmd/gophertrunk/capture_carrier.go
@@ -107,7 +107,7 @@ func captureCarrierOffsetHz(iq []complex64, rate float64) (float64, bool) {
 		}
 		r = q
 	}
-	width := ((r - l) % n + n) % n
+	width := ((r-l)%n + n) % n
 	centerK := (l + width/2) % n
 
 	// Map the centre bin to a signed baseband frequency (fftshift): the upper

--- a/cmd/gophertrunk/capture_carrier_test.go
+++ b/cmd/gophertrunk/capture_carrier_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"math"
+	"strings"
+	"testing"
+)
+
+// synthTone builds n IQ samples of a complex exponential at offsetHz plus a
+// little deterministic noise, so the noise floor is non-zero (no math/rand, so
+// it's reproducible without seeding concerns).
+func synthTone(n int, offsetHz, rate, noise float64) []complex64 {
+	iq := make([]complex64, n)
+	x := uint32(0x9E3779B9)
+	nz := func() float64 {
+		x = x*1664525 + 1013904223
+		return (float64(x>>8)/float64(1<<24) - 0.5) * noise
+	}
+	for i := 0; i < n; i++ {
+		th := 2 * math.Pi * offsetHz * float64(i) / rate
+		iq[i] = complex(float32(math.Cos(th)+nz()), float32(math.Sin(th)+nz()))
+	}
+	return iq
+}
+
+func TestCaptureCarrierOffsetHz(t *testing.T) {
+	const rate = 50000.0
+	for _, off := range []float64{0, 5000, -8700, 12000} {
+		got, ok := captureCarrierOffsetHz(synthTone(1<<15, off, rate, 0.1), rate)
+		if !ok {
+			t.Fatalf("off=%.0f: estimate not ok", off)
+		}
+		if math.Abs(got-off) > 200 {
+			t.Errorf("off=%.0f Hz: got %.0f Hz, want within 200 Hz", off, got)
+		}
+	}
+}
+
+func TestCaptureCarrierOffsetHzTooShort(t *testing.T) {
+	if _, ok := captureCarrierOffsetHz(make([]complex64, 500), 50000); ok {
+		t.Error("expected ok=false for a window shorter than the minimum FFT size")
+	}
+	if _, ok := captureCarrierOffsetHz(synthTone(4096, 0, 50000, 0.1), 0); ok {
+		t.Error("expected ok=false for a zero sample rate")
+	}
+}
+
+func TestCarrierOffsetWarning(t *testing.T) {
+	const rate = 50000.0
+	const freq = 467_913_000
+
+	// A small offset is pulled in by the decoder's AFC — stay silent.
+	if w := carrierOffsetWarning(synthTone(1<<15, 500, rate, 0.1), rate, freq); w != "" {
+		t.Errorf("500 Hz offset should not warn, got: %s", w)
+	}
+
+	// A multi-kHz offset fires and names the fix.
+	w := carrierOffsetWarning(synthTone(1<<15, -8700, rate, 0.1), rate, freq)
+	if w == "" {
+		t.Fatal("an 8.7 kHz offset should warn")
+	}
+	for _, sub := range []string{"centre", "ppm", "-ppm", "below"} {
+		if !strings.Contains(w, sub) {
+			t.Errorf("warning missing %q: %s", sub, w)
+		}
+	}
+}
+
+func TestFormatCarrierOffsetWarning(t *testing.T) {
+	below := formatCarrierOffsetWarning(-8700, -18.6)
+	if !strings.Contains(below, "8.7 kHz below centre") {
+		t.Errorf("below-centre wording wrong: %s", below)
+	}
+	if !strings.Contains(below, "18.6 ppm") {
+		t.Errorf("missing ppm figure: %s", below)
+	}
+	above := formatCarrierOffsetWarning(3200, 6.8)
+	if !strings.Contains(above, "3.2 kHz above centre") {
+		t.Errorf("above-centre wording wrong: %s", above)
+	}
+}

--- a/cmd/gophertrunk/capture_test.go
+++ b/cmd/gophertrunk/capture_test.go
@@ -33,7 +33,7 @@ func feedChunks(n, size int) <-chan []complex64 {
 func TestCaptureToFileF32(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "cap.cfile")
 	// 1000-sample target at rate=1000, 1 s; 5×300 = 1500 ≥ 1000.
-	written, err := captureToFile(context.Background(), path, siglab.FormatF32, feedChunks(5, 300), 1000, 1.0, nil)
+	written, _, err := captureToFile(context.Background(), path, siglab.FormatF32, feedChunks(5, 300), 1000, 1.0, nil)
 	if err != nil {
 		t.Fatalf("captureToFile: %v", err)
 	}
@@ -51,7 +51,7 @@ func TestCaptureToFileF32(t *testing.T) {
 
 func TestCaptureToFileU8(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "cap.bin")
-	written, err := captureToFile(context.Background(), path, siglab.FormatU8, feedChunks(4, 300), 1000, 1.0, nil)
+	written, _, err := captureToFile(context.Background(), path, siglab.FormatU8, feedChunks(4, 300), 1000, 1.0, nil)
 	if err != nil {
 		t.Fatalf("captureToFile: %v", err)
 	}
@@ -66,7 +66,7 @@ func TestCaptureToFileU8(t *testing.T) {
 
 func TestCaptureToFileCS16(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "cap.raw")
-	written, err := captureToFile(context.Background(), path, siglab.FormatS16, feedChunks(4, 300), 1000, 1.0, nil)
+	written, _, err := captureToFile(context.Background(), path, siglab.FormatS16, feedChunks(4, 300), 1000, 1.0, nil)
 	if err != nil {
 		t.Fatalf("captureToFile: %v", err)
 	}
@@ -84,7 +84,7 @@ func TestCaptureToFileNarrowband(t *testing.T) {
 	// Decimate a 48 kHz input to a ~6 kHz channel at zero offset. Feed enough
 	// input (target = 48000 input samples) so the DDC produces output.
 	ddc := ccdecoder.NewDownconverterWithOffset(48000, 6000, 0)
-	written, err := captureToFile(context.Background(), path, siglab.FormatS16, feedChunks(160, 320), 48000, 1.0, ddc)
+	written, _, err := captureToFile(context.Background(), path, siglab.FormatS16, feedChunks(160, 320), 48000, 1.0, ddc)
 	if err != nil {
 		t.Fatalf("captureToFile: %v", err)
 	}
@@ -106,7 +106,7 @@ func TestCaptureToFileStreamEndsEarly(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "short.cfile")
 	// Only 600 samples available but target is 1000 → returns the partial
 	// capture plus an error so the caller can report it.
-	written, err := captureToFile(context.Background(), path, siglab.FormatF32, feedChunks(2, 300), 1000, 1.0, nil)
+	written, _, err := captureToFile(context.Background(), path, siglab.FormatF32, feedChunks(2, 300), 1000, 1.0, nil)
 	if err == nil {
 		t.Fatalf("expected an error when the stream ends before the target")
 	}
@@ -119,7 +119,7 @@ func TestCaptureToFileContextCancel(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "cancelled.cfile")
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancelled before the first read
-	_, err := captureToFile(ctx, path, siglab.FormatF32, feedChunks(5, 300), 1_000_000, 1.0, nil)
+	_, _, err := captureToFile(ctx, path, siglab.FormatF32, feedChunks(5, 300), 1_000_000, 1.0, nil)
 	if err == nil {
 		t.Fatalf("expected ctx.Err() when the context is already cancelled")
 	}
@@ -202,7 +202,7 @@ func TestCaptureStreamDrainsDespiteBlockedWriter(t *testing.T) {
 	}
 	done := make(chan res, 1)
 	go func() {
-		wr, err := captureStream(context.Background(), w, siglab.FormatF32, src, uint32(n*size), 1.0, nil)
+		wr, _, err := captureStream(context.Background(), w, siglab.FormatF32, src, uint32(n*size), 1.0, nil)
 		done <- res{wr, err}
 	}()
 
@@ -244,7 +244,7 @@ func (w errWriter) Write(p []byte) (int, error) { return 0, w.err }
 
 func TestCaptureStreamSurfacesWriteError(t *testing.T) {
 	src := feedChunks(10, 50)
-	_, err := captureStream(context.Background(), errWriter{err: errors.New("disk full")}, siglab.FormatF32, src, 500, 1.0, nil)
+	_, _, err := captureStream(context.Background(), errWriter{err: errors.New("disk full")}, siglab.FormatF32, src, 500, 1.0, nil)
 	if err == nil || !strings.Contains(err.Error(), "disk full") {
 		t.Fatalf("want a surfaced write error, got %v", err)
 	}

--- a/cmd/gophertrunk/capture_test.go
+++ b/cmd/gophertrunk/capture_test.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/scanner/ccdecoder"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
@@ -157,6 +160,103 @@ func TestCaptureSampleRateHint(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// gatedWriter blocks every Write until release is closed, then records the
+// bytes. It models a stalled disk so a test can prove the capture drain is
+// decoupled from the write.
+type gatedWriter struct {
+	release chan struct{}
+	mu      sync.Mutex
+	buf     []byte
+}
+
+func (w *gatedWriter) Write(p []byte) (int, error) {
+	<-w.release
+	w.mu.Lock()
+	w.buf = append(w.buf, p...)
+	w.mu.Unlock()
+	return len(p), nil
+}
+
+func (w *gatedWriter) len() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return len(w.buf)
+}
+
+// TestCaptureStreamDrainsDespiteBlockedWriter proves the fix: even when every
+// disk write is blocked, the goroutine draining src keeps running and empties
+// the source into the deep write buffer. On a live SDR that is what stops the
+// driver from dropping chunks when storage stalls. Fails first: a synchronous
+// write in the drain goroutine would leave src full until the writer unblocks.
+func TestCaptureStreamDrainsDespiteBlockedWriter(t *testing.T) {
+	const n, size = 100, 50 // fits captureWriterDepth
+	w := &gatedWriter{release: make(chan struct{})}
+	src := feedChunks(n, size)
+
+	type res struct {
+		written int64
+		err     error
+	}
+	done := make(chan res, 1)
+	go func() {
+		wr, err := captureStream(context.Background(), w, siglab.FormatF32, src, uint32(n*size), 1.0, nil)
+		done <- res{wr, err}
+	}()
+
+	// src must drain while the writer is still blocked.
+	deadline := time.After(2 * time.Second)
+	for len(src) > 0 {
+		select {
+		case <-deadline:
+			t.Fatalf("src still has %d chunks while the writer is blocked — the write is not decoupled from the drain", len(src))
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+	if w.len() != 0 {
+		t.Fatalf("writer wrote %d bytes while gated — it should be blocked", w.len())
+	}
+
+	close(w.release)
+	select {
+	case r := <-done:
+		if r.err != nil {
+			t.Fatalf("captureStream: %v", r.err)
+		}
+		if r.written != int64(n*size) {
+			t.Errorf("written = %d, want %d", r.written, n*size)
+		}
+		if got := w.len(); got != n*size*8 {
+			t.Errorf("wrote %d bytes, want %d (f32)", got, n*size*8)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("captureStream did not finish after releasing the writer")
+	}
+}
+
+// errWriter fails every write.
+type errWriter struct{ err error }
+
+func (w errWriter) Write(p []byte) (int, error) { return 0, w.err }
+
+func TestCaptureStreamSurfacesWriteError(t *testing.T) {
+	src := feedChunks(10, 50)
+	_, err := captureStream(context.Background(), errWriter{err: errors.New("disk full")}, siglab.FormatF32, src, 500, 1.0, nil)
+	if err == nil || !strings.Contains(err.Error(), "disk full") {
+		t.Fatalf("want a surfaced write error, got %v", err)
+	}
+}
+
+func TestCaptureDropCounter(t *testing.T) {
+	c := &captureDropCounter{serial: "ABC"}
+	c.observe(sdr.Info{Serial: "ABC"})
+	c.observe(sdr.Info{Serial: "OTHER"}) // different device: ignored
+	c.observe(sdr.Info{Serial: "ABC"})
+	if got := c.count(); got != 2 {
+		t.Errorf("count = %d, want 2 (drops for OTHER must not be counted)", got)
 	}
 }
 

--- a/cmd/gophertrunk/survey_capture.go
+++ b/cmd/gophertrunk/survey_capture.go
@@ -203,7 +203,8 @@ func captureSignalToFile(dev sdr.Device, freqHz, rateHz uint32, gain, ppm int, o
 	if err != nil {
 		return 0, fmt.Errorf("start IQ stream: %w", err)
 	}
-	return captureToFile(ctx, out, siglab.FormatF32, stream, rateHz, seconds, nil)
+	written, _, err := captureToFile(ctx, out, siglab.FormatF32, stream, rateHz, seconds, nil)
+	return written, err
 }
 
 // routeToSigLab runs a quick in-process identify on the capture and prints the

--- a/internal/radio/framing/scramble_tetra.go
+++ b/internal/radio/framing/scramble_tetra.go
@@ -39,13 +39,38 @@ type ScramblerTetra struct {
 	state uint32
 }
 
-// NewScramblerTetra constructs a fresh scrambler seeded by the
-// 30-bit extended colour code. The low 30 bits of colourCode hold
-// e(1)..e(30) with bit i = e(i+1). Pass 0 for BSCH / BSCH-Q.
+// NewScramblerTetra constructs a fresh scrambler seeded by the 30-bit
+// extended colour code. colourCode carries the extended colour code as a
+// value — MCC (10) || MNC (14) || colour (6), MSB first (§8.2.5.3, the
+// packing tetra.ExtendedColourCode produces) — so its most-significant
+// bit (bit 29) is e(1) and its least-significant bit is e(30). Pass 0 for
+// BSCH / BSCH-Q.
+//
+// The LFSR init (§8.2.5.2 eq. 8.42) requires state bit i = e(i+1), i.e.
+// e(1) in state bit 0. Since the value carries e(1) in bit 29, the low 30
+// bits are bit-reversed on the way into the register. Getting this wrong
+// is invisible to BSCH (extended colour 0, a bit-reversal fixed point) and
+// to every scramble/descramble round-trip (both sides share the reversed
+// seed), yet leaves every real (externally scrambled) BNCH/SCH burst
+// undecodable — lock succeeds off the unscrambled BSCH while no message
+// ever decodes.
 func NewScramblerTetra(colourCode uint32) *ScramblerTetra {
 	return &ScramblerTetra{
-		state: (colourCode & 0x3FFFFFFF) | 0xC0000000,
+		state: reverseLow30(colourCode) | 0xC0000000,
 	}
+}
+
+// reverseLow30 bit-reverses the low 30 bits of v (bit i ↔ bit 29-i),
+// mapping the extended-colour-code value's e(1)-in-MSB layout onto the
+// LFSR's e(i+1)-in-state-bit-i initialisation.
+func reverseLow30(v uint32) uint32 {
+	var out uint32
+	for i := 0; i < 30; i++ {
+		if v&(1<<uint(i)) != 0 {
+			out |= 1 << uint(29-i)
+		}
+	}
+	return out
 }
 
 // Next advances the LFSR by one step and returns the next bit

--- a/internal/radio/framing/scramble_tetra_test.go
+++ b/internal/radio/framing/scramble_tetra_test.go
@@ -115,7 +115,14 @@ func TestScrambleTetraRandomRoundTrip(t *testing.T) {
 //	p(k) = Σ_{i∈taps} p(k-i)                    (eq. 8.41, mod 2)
 //	taps = {1,2,4,5,7,8,10,11,12,16,22,23,26,32}
 //	init: p(-31)=p(-30)=1, p(-29)=e(30), …, p(0)=e(1)   (eq. 8.42)
-//	      e(m) = bit (m-1) of the 30-bit extended colour code (e(1)=LSB)
+//
+// The extended colour code is MCC || MNC || colour, MSB first
+// (§8.2.5.3, the packing tetra.ExtendedColourCode produces), so e(1) is
+// its most-significant (bit 29) bit and e(30) its least-significant
+// (bit 0): e(m) = bit (30-m) of ext. Getting this endianness wrong (e(1)
+// as the LSB) still round-trips and still passes BSCH, but does not match
+// the sequence a real base station scrambles with, so no BNCH/SCH burst
+// decodes.
 //
 // Output is p(1), p(2), … For BSCH the extended colour code is 0.
 func refScrambleTetraETSI(n int, ext uint32) []byte {
@@ -124,8 +131,8 @@ func refScrambleTetraETSI(n int, ext uint32) []byte {
 	p := make([]byte, n+32)
 	p[0], p[1] = 1, 1 // p(-31), p(-30)
 	for j := 0; j < 30; j++ {
-		m := 30 - j // p(-29+j) = e(m)
-		p[2+j] = byte((ext >> uint(m-1)) & 1)
+		// p(-29+j) = e(30-j); e(m) = bit (30-m) of ext, so e(30-j) = bit j.
+		p[2+j] = byte((ext >> uint(j)) & 1)
 	}
 	out := make([]byte, n)
 	for k := 1; k <= n; k++ {

--- a/internal/radio/tetra/control.go
+++ b/internal/radio/tetra/control.go
@@ -418,10 +418,10 @@ func (c *ControlChannel) publishGrant(g VoiceGrant) {
 			// trunking engine's Timeslot is 1-based with 0 reserved for
 			// "not applicable", so map 0..3 → 1..4. The voice tap uses it
 			// to pick the granted slot out of the 4-slot TDMA frame.
-			Timeslot:    g.Timeslot + 1,
-			Encrypted:   g.Encrypted,
-			Emergency:   g.Emergency,
-			At:          c.now(),
+			Timeslot:  g.Timeslot + 1,
+			Encrypted: g.Encrypted,
+			Emergency: g.Emergency,
+			At:        c.now(),
 		},
 	})
 	c.log.Debug("tetra: grant",

--- a/internal/radio/tetra/control.go
+++ b/internal/radio/tetra/control.go
@@ -414,6 +414,11 @@ func (c *ControlChannel) publishGrant(g VoiceGrant) {
 			SourceID:    g.SourceSSI,
 			FrequencyHz: freq,
 			ChannelNum:  g.CarrierNumber,
+			// TETRA carries a 0-based (0..3) timeslot on the grant; the
+			// trunking engine's Timeslot is 1-based with 0 reserved for
+			// "not applicable", so map 0..3 → 1..4. The voice tap uses it
+			// to pick the granted slot out of the 4-slot TDMA frame.
+			Timeslot:    g.Timeslot + 1,
 			Encrypted:   g.Encrypted,
 			Emergency:   g.Emergency,
 			At:          c.now(),

--- a/internal/radio/tetra/scrambler_realair_test.go
+++ b/internal/radio/tetra/scrambler_realair_test.go
@@ -1,0 +1,43 @@
+package tetra
+
+import (
+	"encoding/base64"
+	"testing"
+)
+
+// realBNCHBlock is a single SCH/HD type-5 block (108 dibits, one dibit per
+// byte, MSB-first bit convention) recovered off-air from the BNCH of a live
+// TETRA TMO downlink — the MCCH of a cell with MCC 250 / MNC 13, extended
+// colour code 262144845 (base colour 13). It was captured through the
+// production IQ → π/4-DQPSK receiver, so it carries the exact scrambling a
+// real base station applied.
+//
+// A real base station seeds the §8.2.5 scrambler with the extended colour
+// code bit-reversed into the LFSR (e(1) = the code's MSB). The pre-fix
+// GopherTrunk scrambler seeded the raw value instead; that is a no-op for
+// the BSCH (extended colour 0) so cold-start lock still worked, but it left
+// every non-zero-colour burst — BNCH SYSINFO and all SCH signalling —
+// uncorrectable, which is why a locked TETRA control channel decoded no
+// messages. This block only descrambles CRC-clean under the corrected seed,
+// so it is the on-air regression guard for that fix.
+const realBNCHBlock = "AwABAAABAAABAAIBAgICAgMDAgEAAAMDAwMDAAEAAwEDAQMDAAMBAwMCAwMDAQEDAQMDAgABAQMDAgABAwIAAQECAAEBAQADAAEDAQACAgECAAACAwEDAgMAAQEAAwMDAQAAAgAAAQEBAQEA"
+
+const realBNCHColour = 262144845
+
+// TestDescrambleRealBNCHBlock pins the §8.2.5 scrambler seed to real air:
+// the captured BNCH block descrambles + FEC-decodes CRC-clean only when the
+// extended colour code is bit-reversed into the LFSR. It fails with the
+// pre-fix (raw-value) seed.
+func TestDescrambleRealBNCHBlock(t *testing.T) {
+	dibits, err := base64.StdEncoding.DecodeString(realBNCHBlock)
+	if err != nil {
+		t.Fatalf("decode fixture: %v", err)
+	}
+	if len(dibits) != 108 {
+		t.Fatalf("fixture has %d dibits, want 108 (one SCH/HD block)", len(dibits))
+	}
+	if _, ok := DecodeSCHHD(TetraDibitsToBits(dibits), realBNCHColour); !ok {
+		t.Fatal("real BNCH block failed to descramble/decode CRC-clean — " +
+			"the §8.2.5 scrambler seed must bit-reverse the extended colour code")
+	}
+}

--- a/internal/radio/tetra/tetra.go
+++ b/internal/radio/tetra/tetra.go
@@ -45,8 +45,13 @@
 //   - End-to-end air-interface encryption (TEA1/2/3/4) — TETRA voice
 //     traffic on most operational networks is encrypted; the
 //     `Encrypted` flag on a grant just records what the CC said.
-//   - Voice frame extraction → AMBE+2 vocoder. The vocoder lives
-//     in internal/voice/ambe2 (pure-Go, default-on).
+//   - TCH/S traffic-channel FEC (§8.4 unequal error protection) and the
+//     TETRA ACELP speech decoder that would turn recovered speech frames
+//     into PCM. The voice-follow path (traffic.go + the composer's TETRA
+//     chain) already retunes to the granted carrier, demodulates it, and
+//     extracts each Normal Continuous Downlink Burst's data blocks to the
+//     recorder's `.raw` sidecar for out-of-band decode; the FEC + vocoder
+//     are the remaining steps to intelligible audio.
 //
 // As with the other trunking packages: ship a clean structured
 // surface now, leave the analogue / FEC / encryption pieces as named

--- a/internal/radio/tetra/traffic.go
+++ b/internal/radio/tetra/traffic.go
@@ -1,0 +1,162 @@
+package tetra
+
+import "github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+
+// Traffic-channel burst extraction for the voice-follow path.
+//
+// Once the control channel grants a call onto a traffic carrier, a voice
+// tap retunes to that carrier and demodulates it to the same π/4-DQPSK
+// dibit stream the control channel uses. Each downlink timeslot on the
+// carrier is a Normal Continuous Downlink Burst (NCDB), whose layout is
+// (ETSI EN 300 392-2 §9.4.4.3.2, matching osmo-tetra), in dibits relative
+// to the normal training sequence leading dibit L:
+//
+//	BKN1 (block 1) : [L-115, L-7)   108 dibits (216 type-5 bits)
+//	AACH half 1    : [L-7,   L)       7 dibits ( 14 bits)
+//	training seq   : [L,     L+11)   11 dibits ( 22 bits)
+//	AACH half 2    : [L+11,  L+19)    8 dibits ( 16 bits)
+//	BKN2 (block 2) : [L+19,  L+127)  108 dibits (216 type-5 bits)
+//
+// TrafficExtractor recovers BKN1 and BKN2 around each detected training
+// sequence and emits them concatenated as one 432-bit (54-byte) full-slot
+// traffic frame.
+//
+// The emitted frame is the raw, still-scrambled type-5 payload. TCH/S
+// channel decoding (the unequal-error-protection scheme of §8.4) and the
+// TETRA ACELP vocoder are deliberately NOT applied here — they are the
+// labelled follow-ups. The raw frames go to the recorder's `.raw` sidecar
+// for out-of-band decode, exactly as the DMR / P25 / EDACS-ProVoice voice
+// paths write their post-FEC or raw frames. Being scrambled, a consumer
+// descrambles with the cell's extended colour code (learned from the
+// control channel's BSCH) before TCH/S FEC.
+//
+// Slot demultiplexing: the extractor emits a frame for every NCDB it sees
+// on the carrier — all four TDMA timeslots, not just the granted one —
+// because absolute slot alignment needs frame-number tracking the tap does
+// not yet have. That is an honest first-pass limitation; the granted
+// Timeslot is carried on the grant for a future per-slot filter.
+const (
+	// ndbBKN1Start / ndbBKN2Start are the leading dibit of each data block
+	// relative to the training-sequence leading dibit L.
+	ndbBKN1Start = -115
+	ndbBKN2Start = 19
+	// ndbBlockDibits is the dibit count of one NCDB data block (216 type-5
+	// bits) — the SCH/HD / traffic half-slot size.
+	ndbBlockDibits = 108
+	// ndbTrimMargin is how many trailing dibits the rolling buffer keeps so
+	// a training-sequence hit near the end still has its BKN1 look-back.
+	ndbTrimMargin = 256
+)
+
+// TrafficFrameDibits is the number of dibits in one emitted full-slot
+// traffic frame (BKN1 + BKN2).
+const TrafficFrameDibits = 2 * ndbBlockDibits // 216
+
+// TrafficFrameBytes is the packed size of one emitted traffic frame
+// (432 type-5 bits, MSB-first).
+const TrafficFrameBytes = (2 * ndbBlockDibits * 2) / 8 // 54
+
+// TrafficExtractor scans a π/4-DQPSK dibit stream for Normal Continuous
+// Downlink Bursts and emits each burst's BKN1+BKN2 as a raw 54-byte
+// full-slot traffic frame. It is the traffic-channel analog of the control
+// channel's processSB: a rolling buffer with look-back to BKN1 and
+// look-ahead to BKN2 around each detected normal training sequence.
+//
+// Not safe for concurrent use; construct one per followed call.
+type TrafficExtractor struct {
+	dets    []*SyncDetector // NTS1 + NTS2, each under all four constellation rotations
+	scratch []int
+	buf     []uint8
+	bufBase int
+	pending []int // training-sequence leading indices awaiting look-ahead
+	onBurst func(frame []byte)
+}
+
+// NewTrafficExtractor returns an extractor that calls onBurst with each
+// recovered 54-byte traffic frame. onBurst must not retain the slice.
+func NewTrafficExtractor(onBurst func(frame []byte)) *TrafficExtractor {
+	te := &TrafficExtractor{onBurst: onBurst}
+	// π/4-DQPSK leaves a constant 0..3 dibit rotation (residual CFO), so
+	// correlate the training sequence under all four rotations of the
+	// pattern — the same trick processSB uses for the sync burst.
+	for _, base := range [][]uint8{NormalSyncDibits(), NormalSyncDibits2()} {
+		for r := uint8(0); r < 4; r++ {
+			te.dets = append(te.dets, NewSyncDetector(rotateDibits(base, r), 2))
+		}
+	}
+	return te
+}
+
+// Process consumes a window of dibits from the traffic-channel receiver.
+// baseIdx is the absolute dibit index of dibits[0]; it must be
+// monotonically non-decreasing across calls (Receiver.Reset restarts it).
+func (te *TrafficExtractor) Process(dibits []uint8, baseIdx int) {
+	if len(te.buf) == 0 {
+		te.bufBase = baseIdx
+	}
+	te.buf = append(te.buf, dibits...)
+
+	ntsLen := len(NormalSyncDibits()) // 11
+	for _, det := range te.dets {
+		var hits []int
+		hits, _ = det.Process(te.scratch[:0], dibits, baseIdx)
+		for _, trailing := range hits {
+			L := trailing - (ntsLen - 1)
+			dup := false
+			for _, q := range te.pending {
+				if q == L {
+					dup = true
+					break
+				}
+			}
+			if !dup {
+				te.pending = append(te.pending, L)
+			}
+		}
+	}
+
+	bufEnd := te.bufBase + len(te.buf)
+	kept := make([]int, 0, len(te.pending))
+	for _, L := range te.pending {
+		needStart := L + ndbBKN1Start
+		needEnd := L + ndbBKN2Start + ndbBlockDibits
+		if needStart < te.bufBase {
+			continue // look-back already trimmed; give up on this hit
+		}
+		if needEnd > bufEnd {
+			kept = append(kept, L) // not enough look-ahead yet
+			continue
+		}
+		te.emit(L)
+	}
+	te.pending = kept
+
+	// Trim, keeping the trailing margin plus any unresolved hit's look-back.
+	keepFrom := bufEnd - ndbTrimMargin
+	for _, L := range te.pending {
+		if ns := L + ndbBKN1Start; ns < keepFrom {
+			keepFrom = ns
+		}
+	}
+	if keepFrom > te.bufBase {
+		drop := keepFrom - te.bufBase
+		if drop > len(te.buf) {
+			drop = len(te.buf)
+		}
+		te.buf = append(te.buf[:0], te.buf[drop:]...)
+		te.bufBase += drop
+	}
+}
+
+// emit slices BKN1 and BKN2 around the training sequence leading at L and
+// forwards the concatenated raw type-5 frame.
+func (te *TrafficExtractor) emit(L int) {
+	block := func(off int) []uint8 {
+		s := L + off - te.bufBase
+		return te.buf[s : s+ndbBlockDibits]
+	}
+	d := make([]uint8, 0, TrafficFrameDibits)
+	d = append(d, block(ndbBKN1Start)...)
+	d = append(d, block(ndbBKN2Start)...)
+	te.onBurst(framing.PackBitsMSB(TetraDibitsToBits(d)))
+}

--- a/internal/radio/tetra/traffic_test.go
+++ b/internal/radio/tetra/traffic_test.go
@@ -1,0 +1,122 @@
+package tetra
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
+
+// buildNCDB lays out one Normal Continuous Downlink Burst into a dibit
+// stream: BKN1 and BKN2 at the §9.4.4.3.2 offsets around the normal
+// training sequence leading at absolute index L. Positions outside the
+// blocks/TS are filler.
+func buildNCDB(stream []uint8, L int, bkn1, bkn2 []uint8) {
+	nts := NormalSyncDibits()
+	copy(stream[L:], nts)
+	copy(stream[L+ndbBKN1Start:], bkn1)
+	copy(stream[L+ndbBKN2Start:], bkn2)
+}
+
+func rampDibits(n int, seed uint8) []uint8 {
+	out := make([]uint8, n)
+	for i := range out {
+		out[i] = (uint8(i) + seed) & 3
+	}
+	return out
+}
+
+func wantFrame(bkn1, bkn2 []uint8) []byte {
+	d := append(append([]uint8{}, bkn1...), bkn2...)
+	return framing.PackBitsMSB(TetraDibitsToBits(d))
+}
+
+func TestTrafficExtractorSingleBurst(t *testing.T) {
+	bkn1 := rampDibits(ndbBlockDibits, 0)
+	bkn2 := rampDibits(ndbBlockDibits, 2)
+	stream := make([]uint8, 600)
+	L := 200
+	buildNCDB(stream, L, bkn1, bkn2)
+
+	var frames [][]byte
+	te := NewTrafficExtractor(func(f []byte) {
+		frames = append(frames, append([]byte(nil), f...))
+	})
+	te.Process(stream, 0)
+
+	if len(frames) != 1 {
+		t.Fatalf("emitted %d frames, want 1", len(frames))
+	}
+	if len(frames[0]) != TrafficFrameBytes {
+		t.Errorf("frame is %d bytes, want %d", len(frames[0]), TrafficFrameBytes)
+	}
+	if !bytes.Equal(frames[0], wantFrame(bkn1, bkn2)) {
+		t.Errorf("frame payload mismatch")
+	}
+}
+
+func TestTrafficExtractorChunkedAcrossCalls(t *testing.T) {
+	bkn1 := rampDibits(ndbBlockDibits, 1)
+	bkn2 := rampDibits(ndbBlockDibits, 3)
+	stream := make([]uint8, 600)
+	L := 300
+	buildNCDB(stream, L, bkn1, bkn2)
+
+	var frames [][]byte
+	te := NewTrafficExtractor(func(f []byte) {
+		frames = append(frames, append([]byte(nil), f...))
+	})
+	// Feed in small chunks so the training-sequence match, BKN1 look-back
+	// and BKN2 look-ahead land in different Process calls.
+	const chunk = 37
+	for i := 0; i < len(stream); i += chunk {
+		e := i + chunk
+		if e > len(stream) {
+			e = len(stream)
+		}
+		te.Process(stream[i:e], i)
+	}
+	if len(frames) != 1 {
+		t.Fatalf("emitted %d frames across chunks, want 1", len(frames))
+	}
+	if !bytes.Equal(frames[0], wantFrame(bkn1, bkn2)) {
+		t.Errorf("chunked frame payload mismatch")
+	}
+}
+
+func TestTrafficExtractorMultipleSlots(t *testing.T) {
+	// Two consecutive timeslots (255 dibits apart) both carrying an NCDB.
+	stream := make([]uint8, 1000)
+	b1a, b2a := rampDibits(ndbBlockDibits, 0), rampDibits(ndbBlockDibits, 1)
+	b1b, b2b := rampDibits(ndbBlockDibits, 2), rampDibits(ndbBlockDibits, 3)
+	buildNCDB(stream, 200, b1a, b2a)
+	buildNCDB(stream, 200+255, b1b, b2b)
+
+	var frames [][]byte
+	te := NewTrafficExtractor(func(f []byte) {
+		frames = append(frames, append([]byte(nil), f...))
+	})
+	te.Process(stream, 0)
+	if len(frames) != 2 {
+		t.Fatalf("emitted %d frames, want 2", len(frames))
+	}
+	if !bytes.Equal(frames[0], wantFrame(b1a, b2a)) || !bytes.Equal(frames[1], wantFrame(b1b, b2b)) {
+		t.Errorf("multi-slot frame payloads mismatch")
+	}
+}
+
+func TestTrafficExtractorNoFalseEmitOnNoise(t *testing.T) {
+	// A stream with no training sequence must emit nothing.
+	stream := make([]uint8, 2000)
+	for i := range stream {
+		stream[i] = uint8((i*7 + 1) % 4) // deterministic non-sync filler
+	}
+	n := 0
+	te := NewTrafficExtractor(func(f []byte) { n++ })
+	te.Process(stream, 0)
+	// A rare chance correlation within tolerance is possible; assert it does
+	// not spuriously fire on structured filler.
+	if n > 0 {
+		t.Errorf("emitted %d frames on noise, want 0", n)
+	}
+}

--- a/internal/voice/composer/composer.go
+++ b/internal/voice/composer/composer.go
@@ -15,9 +15,12 @@
 //
 // DMR voice grants run a dedicated chain (see dmr_voice.go): IQ →
 // DMR receiver → voice superframe decoder → on-air AMBE frames
-// appended to the recorder's .raw sidecar. Other digital protocols
-// (P25, NXDN, ...) have no composer chain yet — their grants are
-// logged and bypassed.
+// appended to the recorder's .raw sidecar. P25 Phase 1 / Phase 2 have
+// their own chains; TETRA follows the traffic channel and lays down a
+// raw full-slot sidecar (see tetra_voice.go — TCH/S FEC + ACELP are
+// follow-ups). The remaining digital protocols (NXDN, dPMR, YSF,
+// D-STAR, EDACS ProVoice) have no composer chain yet — their grants
+// are logged and bypassed.
 package composer
 
 import (
@@ -425,10 +428,14 @@ func (c *Composer) handleStart(parent context.Context, cs trunking.CallStart) {
 	isDMRVoice := proto == "dmr-tier1" || proto == "dmr-tier2" || proto == "dmr-tier3"
 	isP25P2Voice := proto == "p25-phase2"
 	isP25P1Voice := proto == "p25"
-	if !isFM && !isDMRVoice && !isP25P2Voice && !isP25P1Voice {
-		// Remaining digital protocols (NXDN, dPMR, TETRA, YSF, D-STAR,
-		// EDACS ProVoice) have no composer voice chain yet — their
-		// voice bursts are not decoded into PCM here.
+	// TETRA follows the traffic channel and lays down a raw full-slot
+	// sidecar (TCH/S FEC + ACELP vocoder are follow-ups — see
+	// runTETRAVoiceChain), like the DMR/P25 raw-frame paths.
+	isTETRAVoice := proto == "tetra"
+	if !isFM && !isDMRVoice && !isP25P2Voice && !isP25P1Voice && !isTETRAVoice {
+		// Remaining digital protocols (NXDN, dPMR, YSF, D-STAR, EDACS
+		// ProVoice) have no composer voice chain yet — their voice bursts
+		// are not decoded into PCM here.
 		c.log.Info("composer: digital protocol not yet decoded; chain bypassed",
 			"device", cs.DeviceSerial, "protocol", proto,
 			"group", cs.Grant.GroupID)
@@ -504,6 +511,8 @@ func (c *Composer) handleStart(parent context.Context, cs trunking.CallStart) {
 		go c.runP25Phase2VoiceChain(chainCtx, cs.DeviceSerial, cs.Grant.System, macCfg, iqCh, rateHzF, ch.done)
 	case isP25P1Voice:
 		go c.runP25Phase1VoiceChain(chainCtx, cs.DeviceSerial, cs.Grant.System, iqCh, rateHzF, cs.Grant.P25Phase1DemodMode, cs.Grant.GroupID, cs.Grant.CallID, cs.Grant.PatchedGroups, ch.done)
+	case isTETRAVoice:
+		go c.runTETRAVoiceChain(chainCtx, cs.DeviceSerial, iqCh, rateHzF, cs.Grant.GroupID, cs.Grant.Timeslot, ch.done)
 	default:
 		// Analog FM has no symbol clock to drift, so the rounded integer
 		// rate is fine; keep its uint32 signature unchanged.

--- a/internal/voice/composer/tetra_voice.go
+++ b/internal/voice/composer/tetra_voice.go
@@ -1,0 +1,118 @@
+package composer
+
+import (
+	"context"
+	"math"
+	"sync/atomic"
+	"time"
+
+	gtlog "github.com/MattCheramie/GopherTrunk/internal/log"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/tetra"
+	tetrarx "github.com/MattCheramie/GopherTrunk/internal/radio/tetra/receiver"
+)
+
+// tetraVoiceIntermediateHz is the rate the wideband voice-tap IQ is
+// decimated to before the TETRA receiver runs. It matches the per-protocol
+// channel rate the control-channel DDC normalises to (144 kHz), giving the
+// 18000-baud π/4-DQPSK stream 8 samples/symbol — the rate the receiver's
+// Gardner loop, AFC and channel filter are tuned for. A tap already at or
+// below this rate is used as-is (the receiver needs only ≥ 2×18 kHz).
+const tetraVoiceIntermediateHz = 144_000
+
+// tetraVoiceChannelSelectHz caps the voice front-end channel filter at half
+// the 25 kHz TETRA channel spacing when the tap already streams at the
+// intermediate rate (so the front end still band-limits to one carrier
+// before the receiver). Mirrors dmrVoiceChannelSelectHz.
+const tetraVoiceChannelSelectHz = 12_500.0
+
+// newTETRAVoiceFrontEnd builds the channel-select + decimation front end for
+// the TETRA voice chain, mirroring newDMRVoiceFrontEnd: a wideband DDC tap
+// already at the intermediate rate (decim==1) is band-limited to a single
+// 25 kHz channel; a higher-rate tap is decimated with the anti-alias FIR.
+func newTETRAVoiceFrontEnd(iqHz float64, bw uint32) *decimatingFIR {
+	chanBW := float64(bw)
+	decim := int(math.Round(iqHz)) / tetraVoiceIntermediateHz
+	filterAtUnity := false
+	if decim <= 1 {
+		filterAtUnity = true
+		if chanBW > tetraVoiceChannelSelectHz {
+			chanBW = tetraVoiceChannelSelectHz
+		}
+	}
+	return newDecimatingFIR(iqHz, tetraVoiceIntermediateHz, chanBW, filterAtUnity)
+}
+
+// runTETRAVoiceChain consumes IQ for one TETRA traffic-channel call. It
+// decimates the tap IQ to the TETRA symbol rate, recovers the π/4-DQPSK
+// dibit stream with the shared TETRA receiver, extracts each Normal
+// Continuous Downlink Burst's two data blocks (tetra.TrafficExtractor), and
+// appends them to the recorder's `.raw` sidecar as raw full-slot traffic
+// frames.
+//
+// This is the traffic-following + capture half of TETRA voice support. TCH/S
+// channel decoding (§8.4) and the TETRA ACELP vocoder that would turn the
+// raw frames into PCM are the labelled follow-ups; until they land the `.raw`
+// sidecar is the capture, exactly as for DMR/P25 (post-FEC frames) and EDACS
+// ProVoice (raw frames). Encrypted calls (TEA1-4) still capture raw — the
+// bytes exist even when no in-process decode does.
+//
+// The extractor emits a frame for every burst on the carrier (all four TDMA
+// timeslots), not just the granted one; groupID/timeslot are threaded
+// through for a future per-slot filter and logging only.
+func (c *Composer) runTETRAVoiceChain(ctx context.Context, serial string, iqCh <-chan []complex64, iqHz float64, groupID uint32, timeslot uint8, done chan<- struct{}) {
+	defer close(done)
+	defer gtlog.Recover(c.log, "voice-chain-tetra:"+serial, nil)
+
+	// Shared boundary controller: hangtime end-of-call + Touch heartbeat.
+	// Talkgroup gating is disabled (grantTG 0) until the chain surfaces a
+	// per-burst in-band identity.
+	bt := c.newBoundaryTracker(serial, 0, nil)
+	go bt.run(ctx)
+
+	fe := newTETRAVoiceFrontEnd(iqHz, c.bw)
+	symbolHz := fe.OutRateHz()
+
+	rs, _ := c.sink.(rawFrameSink)
+	var bursts atomic.Uint64
+	extractor := tetra.NewTrafficExtractor(func(frame []byte) {
+		bursts.Add(1)
+		// Each recovered burst counts as traffic activity: keep the call
+		// alive and reset the hangtime timer.
+		bt.onVoice(0)
+		if rs == nil {
+			return
+		}
+		if err := rs.WriteRawFrame(serial, frame); err != nil {
+			c.log.Warn("composer: TETRA raw-frame write failed", "serial", serial, "err", err)
+		}
+	})
+
+	rx := tetrarx.New(tetrarx.Options{
+		SampleRateHz:        symbolHz,
+		DibitSink:           func(d []uint8, base int) { extractor.Process(d, base) },
+		ClockMode:           tetrarx.ClockGardner,
+		GardnerGain:         0.005,
+		EnableAFC:           true,
+		EnableChannelFilter: true,
+	})
+
+	c.log.Info("composer: tetra voice follow started — raw traffic sidecar (TCH/S FEC + ACELP vocoder are follow-ups)",
+		"serial", serial, "group", groupID, "timeslot", timeslot, "rate_hz", symbolHz)
+
+	touchTicker := time.NewTicker(c.touchEvery)
+	defer touchTicker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-touchTicker.C:
+			// Touch + hangtime end-of-call are driven by the boundary tracker.
+		case iq, ok := <-iqCh:
+			if !ok {
+				return
+			}
+			bt.observe(iq)
+			rx.Process(fe.Process(nil, iq))
+		}
+	}
+}

--- a/internal/voice/composer/tetra_voice_test.go
+++ b/internal/voice/composer/tetra_voice_test.go
@@ -62,7 +62,12 @@ func TestComposerTETRAVoiceChainWritesRawFrames(t *testing.T) {
 		IQSampleRate:  uint32(sps * 18000), // 144 kHz tap
 		PCMSampleRate: 8000,
 		TouchInterval: 30 * time.Millisecond,
-		VoiceHangtime: 300 * time.Millisecond,
+		// Generous hangtime: the no-voice teardown fires at 2×hangtime, and the
+		// heavy TETRA receiver processing the whole IQ chunk must emit its first
+		// burst before then — otherwise, under a saturated CI running the whole
+		// suite under -race, the call would end as a no-voice Timeout instead of
+		// decoding traffic. 2 s → 4 s no-voice window is ample.
+		VoiceHangtime: 2 * time.Second,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -85,11 +90,13 @@ func TestComposerTETRAVoiceChainWritesRawFrames(t *testing.T) {
 		},
 	})
 
-	waitFor(t, 2*time.Second, func() bool { return len(c.ActiveChains()) == 1 })
+	// Generous timeouts throughout: this test runs in the full `-race` suite on
+	// shared CI, where the TETRA receiver DSP is CPU-heavy and slow to schedule.
+	waitFor(t, 10*time.Second, func() bool { return len(c.ActiveChains()) == 1 })
 	src.SendIQ(iq)
 
 	// Full-slot traffic frames must reach the sidecar.
-	waitFor(t, 5*time.Second, func() bool { return len(sink.rawFrames("VOICE-1")) >= 5 })
+	waitFor(t, 20*time.Second, func() bool { return len(sink.rawFrames("VOICE-1")) >= 5 })
 	got := sink.rawFrames("VOICE-1")
 	if len(got) == 0 {
 		t.Fatal("no raw traffic frames written")
@@ -101,8 +108,9 @@ func TestComposerTETRAVoiceChainWritesRawFrames(t *testing.T) {
 	}
 
 	// The chain keeps the engine's call alive while traffic flows.
-	waitFor(t, time.Second, func() bool { return eng.touched.Load() > 0 })
+	waitFor(t, 5*time.Second, func() bool { return eng.touched.Load() > 0 })
 
-	// After the IQ stops, the boundary tracker ends the call on hangtime.
-	waitFor(t, 3*time.Second, func() bool { return eng.endReason("VOICE-1") == trunking.EndReasonNormal })
+	// After the IQ stops, the boundary tracker ends the call on hangtime
+	// (VoiceHangtime after the last decoded burst).
+	waitFor(t, 15*time.Second, func() bool { return eng.endReason("VOICE-1") == trunking.EndReasonNormal })
 }

--- a/internal/voice/composer/tetra_voice_test.go
+++ b/internal/voice/composer/tetra_voice_test.go
@@ -1,0 +1,108 @@
+package composer
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/tetra"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// buildTETRATrafficDibits lays out nSlots Normal Continuous Downlink Bursts
+// (255-dibit TDMA slots) into a dibit stream, each with the normal training
+// sequence at its §9.4.4.3.2 intra-slot position (bit 244 → dibit 122). The
+// data blocks are deterministic filler — the chain test asserts the raw
+// full-slot frames flow and drive the call lifecycle, not their payload
+// (the payload round-trip is TrafficExtractor's own unit test).
+func buildTETRATrafficDibits(nSlots int) []uint8 {
+	const (
+		slot   = 255
+		leadIn = 512 // receiver clock/AFC warm-up
+		ntsAt  = 122 // dibit offset of the NTS within the slot
+	)
+	nts := tetra.NormalSyncDibits()
+	stream := make([]uint8, leadIn+nSlots*slot+slot)
+	for i := range stream {
+		stream[i] = uint8((i*3 + 1) % 4) // non-sync filler
+	}
+	for s := 0; s < nSlots; s++ {
+		L := leadIn + s*slot + ntsAt
+		copy(stream[L:], nts)
+	}
+	return stream
+}
+
+// TestComposerTETRAVoiceChainWritesRawFrames drives the composer's TETRA
+// traffic-follow path end to end: modulated π/4-DQPSK IQ → TETRA receiver →
+// TrafficExtractor → recorder .raw sidecar, and confirms full-slot traffic
+// frames flow, the engine is kept alive, and the call ends on hangtime.
+func TestComposerTETRAVoiceChainWritesRawFrames(t *testing.T) {
+	const (
+		sps   = 8 // 18000 baud × 8 = 144 kHz intermediate rate
+		span  = 8
+		alpha = 0.35
+		slots = 24
+	)
+	dibits := buildTETRATrafficDibits(slots)
+	iq := demod.ModulatePiOver4DQPSK(dibits, sps, span, alpha, math.Pi/4)
+
+	src := newFakeSource()
+	bus := events.NewBus(8)
+	sink := &recordingSink{}
+	eng := &fakeEngine{}
+	c, err := New(Options{
+		Bus:           bus,
+		Devices:       &fakeDevices{src: map[string]IQSource{"VOICE-1": src}},
+		Sink:          sink,
+		Engine:        eng,
+		IQSampleRate:  uint32(sps * 18000), // 144 kHz tap
+		PCMSampleRate: 8000,
+		TouchInterval: 30 * time.Millisecond,
+		VoiceHangtime: 300 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go c.Run(ctx)
+	defer c.Close()
+	defer bus.Close()
+
+	bus.Publish(events.Event{
+		Kind: events.KindCallStart,
+		Payload: trunking.CallStart{
+			Grant: trunking.Grant{
+				System: "TETRASite", Protocol: "tetra",
+				GroupID: 1234, FrequencyHz: 390_000_000, Timeslot: 1,
+			},
+			DeviceSerial: "VOICE-1",
+			StartedAt:    time.Now().UTC(),
+		},
+	})
+
+	waitFor(t, 2*time.Second, func() bool { return len(c.ActiveChains()) == 1 })
+	src.SendIQ(iq)
+
+	// Full-slot traffic frames must reach the sidecar.
+	waitFor(t, 5*time.Second, func() bool { return len(sink.rawFrames("VOICE-1")) >= 5 })
+	got := sink.rawFrames("VOICE-1")
+	if len(got) == 0 {
+		t.Fatal("no raw traffic frames written")
+	}
+	for i, f := range got {
+		if len(f) != tetra.TrafficFrameBytes {
+			t.Fatalf("frame %d is %d bytes, want %d (BKN1+BKN2 type-5)", i, len(f), tetra.TrafficFrameBytes)
+		}
+	}
+
+	// The chain keeps the engine's call alive while traffic flows.
+	waitFor(t, time.Second, func() bool { return eng.touched.Load() > 0 })
+
+	// After the IQ stops, the boundary tracker ends the call on hangtime.
+	waitFor(t, 3*time.Second, func() bool { return eng.endReason("VOICE-1") == trunking.EndReasonNormal })
+}

--- a/internal/voice/recorder.go
+++ b/internal/voice/recorder.go
@@ -287,6 +287,14 @@ func dmrVoiceProtocol(protocol string) bool {
 	return protocol == "dmr-tier1" || protocol == "dmr-tier2" || protocol == "dmr-tier3"
 }
 
+// tetraVoiceProtocol reports whether a call is TETRA voice. TETRA has no
+// in-process vocoder yet (TCH/S FEC + ACELP are follow-ups), so — like
+// ProVoice — its `.raw` sidecar of raw full-slot traffic frames is the only
+// capture of the call and is always written.
+func tetraVoiceProtocol(protocol string) bool {
+	return protocol == "tetra"
+}
+
 // NewRecorder validates options and returns a recorder ready to Run.
 // Like the engine, the recorder subscribes to the bus at construction
 // so that CallStart events published before Run starts are not lost.
@@ -833,7 +841,7 @@ func (r *Recorder) buildSession(cs trunking.CallStart, startedAt time.Time) *rec
 	// ProVoice and DMR voice grants always get a sidecar — neither has
 	// an in-process vocoder, so the .raw file is the only capture of
 	// the call.
-	if r.writeRaw || cs.Grant.ProVoice || dmrVoiceProtocol(cs.Grant.Protocol) {
+	if r.writeRaw || cs.Grant.ProVoice || dmrVoiceProtocol(cs.Grant.Protocol) || tetraVoiceProtocol(cs.Grant.Protocol) {
 		s.rawPath = filepath.Join(dir, base+".raw")
 		s.rawWanted = true
 	}


### PR DESCRIPTION
The TETRA scrambler seeded its LFSR with the extended colour code value as
stored — MCC || MNC || colour, MSB first — but §8.2.5.2 eq. 8.42 requires
state bit i = e(i+1), i.e. e(1) (the code's MSB) in state bit 0. The two
orderings agree only when the extended colour code is zero, which is exactly
the BSCH case, so cold-start lock kept working while every non-zero-colour
burst — BNCH SYSINFO and all SCH signalling — stayed uncorrectable. The
symptom on real air is a control channel that locks (off the unscrambled
BSCH) yet decodes no messages.

Reverse the low 30 bits of the extended colour code into the LFSR seed. The
prior "independent" ETSI reference in the scrambler test encoded the same
e(1)=LSB endianness, so it agreed with the buggy generator; correct it to the
spec's MSB-first convention. Add a real-air regression: a BNCH SCH/HD block
captured off a live MCC 250 / MNC 13 cell that descrambles CRC-clean only
under the corrected seed.

Both regressions fail without the fix and pass with it.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TeAqNCZjJpBHfs2dUGLgFY