### PR TITLE
fix(tetra,capture): surface the 6-bit colour code and size narrowband grabs by their slice rate

### DIFF
--- a/internal/api/capture.go
+++ b/internal/api/capture.go
@@ -123,25 +123,12 @@ func (s *Server) handleSiglabCapture(w http.ResponseWriter, r *http.Request) {
 
 	rate, centerHz := captureDeviceRateCenter(s.capture.Devices(), req.Serial)
 
-	// Reject an over-budget grab before pinning the tuner. Streaming keeps RAM
-	// bounded to one chunk, so this bounds the on-disk file size (seconds × rate ×
-	// bytes-per-sample), not memory. Skipped when the rate is unknown (device not
-	// streaming yet) — then maxCaptureSeconds is the only bound.
-	if rate > 0 {
-		estBytes := int64(req.Seconds) * int64(rate) * int64(bytesPerSample(format))
-		if estBytes > maxCaptureIQBytes {
-			s.writeError(w, http.StatusBadRequest, fmt.Sprintf(
-				"siglab: a %ds capture at %.3f MS/s would stage ~%d MiB, over the %d MiB budget — "+
-					"reduce seconds or request a narrowband slice (center_hz + bandwidth_hz)",
-				req.Seconds, float64(rate)/1e6, estBytes>>20, int64(maxCaptureIQBytes)>>20))
-			return
-		}
-	}
-
 	// Optional narrowband slice: validate the requested channel fits the tuner's
 	// current span and build a streaming down-converter up front, so an
 	// out-of-span request 400s before the tuner is pinned. The slice is carved
 	// from the live stream chunk-by-chunk during capture — no wideband buffer.
+	// Done before the budget check so a slice is sized by its decimated output
+	// rate, not the full band.
 	var ddc *siglab.StreamDownconverter
 	outRate, outCenter := rate, centerHz
 	if req.BandwidthHz > 0 {
@@ -158,6 +145,27 @@ func (s *Server) handleSiglabCapture(w http.ResponseWriter, r *http.Request) {
 		ddc = siglab.NewStreamDownconverter(float64(rate), float64(offsetHz), float64(req.BandwidthHz))
 		outRate = uint32(ddc.OutRateHz() + 0.5)
 		outCenter = center
+	}
+
+	// Reject an over-budget grab before pinning the tuner. Streaming keeps RAM
+	// bounded to one chunk, so this bounds the on-disk file size (seconds ×
+	// effective rate × bytes-per-sample), not memory. outRate is the full band
+	// for a plain grab and the decimated slice rate for a narrowband request, so
+	// a legitimate slice is not rejected on its full-band footprint. Skipped when
+	// the rate is unknown (device not streaming yet) — then maxCaptureSeconds is
+	// the only bound.
+	if rate > 0 {
+		estBytes := int64(req.Seconds) * int64(outRate) * int64(bytesPerSample(format))
+		if estBytes > maxCaptureIQBytes {
+			hint := "reduce seconds or request a narrowband slice (center_hz + bandwidth_hz)"
+			if req.BandwidthHz > 0 {
+				hint = "reduce seconds or bandwidth"
+			}
+			s.writeError(w, http.StatusBadRequest, fmt.Sprintf(
+				"siglab: a %ds capture at %.3f MS/s would stage ~%d MiB, over the %d MiB budget — %s",
+				req.Seconds, float64(outRate)/1e6, estBytes>>20, int64(maxCaptureIQBytes)>>20, hint))
+			return
+		}
 	}
 
 	// Stream encoded IQ straight to the staged file: peak memory is one chunk

--- a/internal/api/capture_test.go
+++ b/internal/api/capture_test.go
@@ -343,6 +343,47 @@ func TestSiglabCaptureRejectsOverBudget(t *testing.T) {
 	}
 }
 
+// TestSiglabCaptureNarrowbandUnderBudgetOverFullBand pins the fix for the
+// narrowband budget check. A 120s grab at 2.5 MS/s would stage ~1144 MiB as a
+// full band — over the 1 GiB budget — but a 50 kHz slice stages only ~23 MiB.
+// The budget must be sized by the decimated slice rate, not the full band, so a
+// legitimate narrowband request is accepted. Previously it 400'd, telling the
+// caller to request the very slice they already supplied.
+func TestSiglabCaptureNarrowbandUnderBudgetOverFullBand(t *testing.T) {
+	const rate = 2_500_000
+	iq := make([]complex64, rate/10) // ~0.1 s — enough for the DDC to emit samples
+	for i := range iq {
+		iq[i] = complex(float32(i%5)/5, float32(i%9)/9)
+	}
+	prov := &fakeCaptureProvider{
+		devices: []SpectrumDevice{{Serial: "SDR1", Driver: "mock"}},
+		iq:      iq,
+		rate:    rate,
+		center:  467_900_000,
+	}
+	ts := newCaptureTestServer(t, prov)
+
+	// 50 kHz slice at the tuner centre, 120 s. Full band ≈ 1144 MiB (over budget);
+	// slice ≈ 23 MiB (under). Without the fix the full-band footprint 400s here.
+	body := `{"serial":"SDR1","seconds":120,"format":"cs16","center_hz":467900000,"bandwidth_hz":50000}`
+	resp, err := http.Post(ts.URL+"/api/v1/siglab/capture", "application/json", bytes.NewBufferString(body))
+	if err != nil {
+		t.Fatalf("POST capture: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200 for a narrowband slice under budget (%s)", resp.StatusCode, b)
+	}
+	var cr captureResponse
+	if err := json.NewDecoder(resp.Body).Decode(&cr); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if cr.Capture.SampleRateHz > 60_000 {
+		t.Errorf("narrowband rate = %g, want ~50 kHz", cr.Capture.SampleRateHz)
+	}
+}
+
 // TestSiglabCaptureStreamsMultipleChunks proves the capture is streamed to disk
 // chunk-by-chunk (not buffered whole): the staged file must equal EncodeCapture
 // of the full IQ even when the provider delivers it in many small chunks.

--- a/internal/radio/tetra/control.go
+++ b/internal/radio/tetra/control.go
@@ -272,8 +272,10 @@ func (c *ControlChannel) LearnColourCode(ext uint32) bool {
 	}
 	c.colourCode = ext
 	c.colourLearned = true
+	// colour_code is the ETSI 6-bit colour code (low 6 bits); colour_ext is the
+	// full 30-bit extended value that also seeds the scrambler.
 	c.log.Info("tetra cc learned colour code from BSCH",
-		"colour_ext", ext, "system", c.systemName)
+		"colour_code", ext&0x3F, "colour_ext", ext, "system", c.systemName)
 	return true
 }
 

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -630,7 +630,10 @@ func (p *tetraPipeline) TopologySnapshot() *trunking.TopologySnapshot {
 		MCC:          t.MCC,
 		MNC:          t.MNC,
 		LocationArea: t.LocationArea,
-		ColorCode:    uint8(t.ColourCode & 0xFF),
+		// The ETSI 6-bit colour code is the low 6 bits of the 30-bit extended
+		// colour code (MCC<<20 | MNC<<6 | CC); masking 0xFF would drag in two
+		// stray MNC bits and corrupt the surfaced value.
+		ColorCode: uint8(t.ColourCode & 0x3F),
 	}
 }
 

--- a/internal/scanner/ccdecoder/pipelines_tetra_colourcode_test.go
+++ b/internal/scanner/ccdecoder/pipelines_tetra_colourcode_test.go
@@ -1,0 +1,51 @@
+package ccdecoder
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TestTETRATopologyColourCodeMasksToSixBits pins the fix for the surfaced TETRA
+// colour code. The control channel stores the 30-bit extended colour code
+// (MCC<<20 | MNC<<6 | CC) as the scrambler seed; the ETSI colour code the user
+// sees is the low 6 bits. The old display path masked 0xFF, dragging in two
+// stray MNC bits — for the reporter's two sites that produced 108 and 77 instead
+// of the real 0x2c (44) and 0x0d (13) reported by tetra-demodulator.
+func TestTETRATopologyColourCodeMasksToSixBits(t *testing.T) {
+	cases := []struct {
+		name string
+		ext  uint32
+		want uint8
+	}{
+		{"site_467_913", 262144876, 0x2c}, // colour_ext from the reporter's log → CC 44
+		{"site_469_875", 262144845, 0x0d}, // colour_ext from the reporter's log → CC 13
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bus := events.NewBus(8)
+			defer bus.Close()
+			// A non-zero TETRAColourCode makes the factory apply it via
+			// SetColourCode under the default ChannelCodingOn, so it lands in the
+			// control channel exactly as a runtime BSCH decode would.
+			p, err := newTETRAPipeline(PipelineOptions{
+				Bus: bus, SystemName: "Test", FrequencyHz: 467_913_000,
+				SampleRateHz: 144_000,
+				System: trunking.System{
+					Name: "Test", Protocol: trunking.ProtocolTETRA,
+					ControlChannels: []uint32{467_913_000},
+					TETRAColourCode: tc.ext,
+				},
+			})
+			if err != nil {
+				t.Fatalf("newTETRAPipeline: %v", err)
+			}
+			snap := p.(*tetraPipeline).TopologySnapshot()
+			if snap.ColorCode != tc.want {
+				t.Errorf("TopologySnapshot ColorCode = %d (%#x), want %d (%#x)",
+					snap.ColorCode, snap.ColorCode, tc.want, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Two operator-reported bugs while capturing TETRA control channels:

1. The surfaced/logged TETRA colour code was wrong. The control channel
   stores the 30-bit extended colour code (MCC<<20 | MNC<<6 | CC) as the
   scrambler seed; the ETSI 6-bit colour code is the low 6 bits. The
   topology snapshot masked 0xFF instead of 0x3F, dragging in two stray
   MNC bits (e.g. ext 262144876 → 108 instead of the real 0x2c/44). Fix
   the mask and also log colour_code alongside colour_ext so the learn
   line is legible.

2. POST /api/v1/siglab/capture rejected a valid narrowband slice. The
   budget check ran before the narrowband down-converter was built and
   always sized the full wideband rate, so a 120s 50 kHz slice was
   refused with "reduce seconds or request a narrowband slice" — the
   slice the caller already supplied. Build the DDC first and size the
   estimate by the effective (decimated) output rate; adapt the hint when
   a slice is already requested.

Both fixes carry failing-first regression tests reproducing the reporter's
exact values (colour codes 44/13; the 1144 MiB over-budget slice).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GVoGbXXCo3doUafoQTf3mE