### PR TITLE
feat(learn): add Learning Paths guidance layer; rename paths→modules, modules→units

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -53,18 +53,24 @@ defaults:
       type: pages
     values:
       layout: page
-  # Learning-path lessons under each path get the lesson layout, nav group, and
-  # their `learn_path` id automatically, so individual lessons only declare
-  # slug/title/description. Each path's hub (learn/<id>/index.md) overrides
+  # Learning-module lessons under each module get the lesson layout, nav group,
+  # and their `learn_module` id automatically, so individual lessons only declare
+  # slug/title/description. Each module's hub (learn/<id>/index.md) overrides
   # layout to `learn-hub`; the chooser (learn/index.md) overrides to
-  # `learn-index`. `learn_path` is a custom key — never `page.path`, which is a
+  # `learn-index`; the Learning Path guides (learn/paths/<id>/index.md) use
+  # `learn-path`. `learn_module` is a custom key — never `page.path`, which is a
   # Jekyll built-in used for the "Edit on GitHub" links.
+  - scope:
+      path: "learn/paths"
+      type: pages
+    values:
+      nav_group: Learn
   - scope:
       path: "learn/rf-sdr"
       type: pages
     values:
       layout: lesson
-      learn_path: rf-sdr
+      learn_module: rf-sdr
       nav_group: Learn
       permalink: /learn/rf-sdr/:basename/
   - scope:
@@ -72,15 +78,39 @@ defaults:
       type: pages
     values:
       layout: lesson
-      learn_path: git
+      learn_module: git
       nav_group: Learn
       permalink: /learn/git/:basename/
+  - scope:
+      path: "learn/linux-cli"
+      type: pages
+    values:
+      layout: lesson
+      learn_module: linux-cli
+      nav_group: Learn
+      permalink: /learn/linux-cli/:basename/
+  - scope:
+      path: "learn/networking"
+      type: pages
+    values:
+      layout: lesson
+      learn_module: networking
+      nav_group: Learn
+      permalink: /learn/networking/:basename/
+  - scope:
+      path: "learn/cybersecurity"
+      type: pages
+    values:
+      layout: lesson
+      learn_module: cybersecurity
+      nav_group: Learn
+      permalink: /learn/cybersecurity/:basename/
   - scope:
       path: "learn/intro-software-dev"
       type: pages
     values:
       layout: lesson
-      learn_path: intro-software-dev
+      learn_module: intro-software-dev
       nav_group: Learn
       permalink: /learn/intro-software-dev/:basename/
   - scope:
@@ -88,7 +118,7 @@ defaults:
       type: pages
     values:
       layout: lesson
-      learn_path: digital-trunking
+      learn_module: digital-trunking
       nav_group: Learn
       permalink: /learn/digital-trunking/:basename/
   - scope:
@@ -96,7 +126,7 @@ defaults:
       type: pages
     values:
       layout: lesson
-      learn_path: intro-hardware
+      learn_module: intro-hardware
       nav_group: Learn
       permalink: /learn/intro-hardware/:basename/
   - scope:
@@ -104,15 +134,23 @@ defaults:
       type: pages
     values:
       layout: lesson
-      learn_path: ai-software-dev
+      learn_module: ai-software-dev
       nav_group: Learn
       permalink: /learn/ai-software-dev/:basename/
+  - scope:
+      path: "learn/building-ai"
+      type: pages
+    values:
+      layout: lesson
+      learn_module: building-ai
+      nav_group: Learn
+      permalink: /learn/building-ai/:basename/
   - scope:
       path: "learn/software-licensing"
       type: pages
     values:
       layout: lesson
-      learn_path: software-licensing
+      learn_module: software-licensing
       nav_group: Learn
       permalink: /learn/software-licensing/:basename/
   # Field Guide articles under /reference/ get the reference layout and nav

--- a/docs/_data/learn.yml
+++ b/docs/_data/learn.yml
@@ -1,15 +1,41 @@
-# GopherTrunk learning paths — single source of truth.
+# GopherTrunk learning content — single source of truth.
 #
 # This file drives several things at once, so they never drift apart:
 #   1. The /learn/ chooser page          (docs/learn/index.md + learn-index.html)
-#   2. Each path's hub landing grid       (docs/learn/<id>/index.md + learn-hub.html)
-#   3. The in-lesson sidebar / module list and prev/next nav (lesson.html)
-#   4. The llms.txt export                (docs/llms.txt)
+#   2. Each Learning Path guide page      (docs/learn/paths/<id>/index.md + learn-path.html)
+#   3. Each module's hub landing grid     (docs/learn/<id>/index.md + learn-hub.html)
+#   4. The in-lesson unit list and prev/next nav (lesson.html)
+#   5. The llms.txt export                (docs/llms.txt)
 #
-# Structure: a top-level `paths:` list. Each path is one self-contained
-# curriculum (RF & SDR, Git & GitHub, …) with its own URL space /learn/<id>/.
+# Four-level hierarchy:
 #
-# Per path:
+#   Learning Path   optional, guidance-only domain track (RF Software Development,
+#                   RF Hardware, …). A curated, ordered *reading list of modules*
+#                   toward competence in a domain. NOT required to take any module.
+#     Learning Module   one self-contained curriculum (RF & SDR, Git & GitHub, …)
+#                       with its own URL space /learn/<id>/.
+#       Unit            an ordered group of lessons inside a module (display only;
+#                       does not appear in URLs).
+#         Lesson        one page at /learn/<module-id>/<slug>/.
+#
+# Two top-level lists: `learning_paths:` (the guidance layer) and `modules:` (the
+# curricula). Learning Paths reference modules by id, so a module can appear in
+# several paths. Progress is saved per (module-id, lesson-slug) — see store.js and
+# the Supabase learn_progress table — so every `id` below is APPEND-ONLY: renaming
+# one breaks lesson URLs and orphans saved progress. Path progress is derived from
+# the referenced modules' completions; it needs no storage of its own.
+#
+# Per learning_path (guidance only):
+#   id          URL segment -> /learn/paths/<id>/  (append-only)
+#   label       Short display name shown on the chooser and path card
+#   title       Full guide <h1> / page title
+#   tagline     One-line description for the chooser card
+#   intro       Folded blurb shown on the guide hero
+#   modules     Ordered list of module references: { id, note? }
+#                 id    an existing module id (see `modules:` below)
+#                 note  optional one-line "why this module / what you'll get"
+#
+# Per module (was "path"):
 #   id          URL segment -> /learn/<id>/ and /learn/<id>/<slug>/  (append-only)
 #   label       Short display name shown on the chooser and in breadcrumbs
 #   title       Full hub <h1> / page title
@@ -17,30 +43,140 @@
 #   start_slug  Slug of lesson 1 (drives the hub "Start lesson 1" CTA)
 #   workload    ISO-8601 duration estimate for Course schema (e.g. PT6H)
 #   intro       Folded blurb shown on the hub hero
-#   modules     Ordered list of modules (see below)
+#   units       Ordered list of units (see below)
 #   glossary    Optional standalone reference (no prev/next slot); keep slug: glossary
 #
-# Per module:
-#   id          Anchor id used on the hub (/learn/<path>/#<id>)
-#   label       Module heading (e.g. "Module 1 — Foundations")
-#   blurb       One-line module summary
+# Per unit (was "module"):
+#   id          Anchor id used on the hub (/learn/<module>/#<id>)
+#   label       Unit heading (e.g. "Unit 1 — Foundations")
+#   blurb       One-line unit summary
 #   lessons     Ordered list of lessons
 #
 # Per lesson:
-#   slug        URL slug -> /learn/<path>/<slug>/  (append-only; renaming breaks links)
+#   slug        URL slug -> /learn/<module>/<slug>/  (append-only; renaming breaks links)
 #   title       Lesson title (also the card heading)
 #   summary     One-line description for cards, sidebar, and llms.txt
 #   minutes     Estimated reading time (integer; shown on cards)
 #   level       beginner | intermediate | advanced  (badge + filtering)
 #   status      full | stub   (stub = outline published, body still being written)
 #
-# Lesson files live at docs/learn/<path-id>/<slug>.md. The matching `learn`
+# Lesson files live at docs/learn/<module-id>/<slug>.md. The matching `learn`
 # defaults scopes in _config.yml give them the lesson layout, nav_group, and the
-# `learn_path` key automatically, so individual lessons only declare slug/title/
+# `learn_module` key automatically, so individual lessons only declare slug/title/
 # description. Each hub overrides layout back to `learn-hub`; the chooser
 # (learn/index.md) overrides to `learn-index`.
 
-paths:
+# ---------------------------------------------------------------------------
+# Learning Paths — optional guidance. Each is an ordered recommendation of which
+# modules to work through to become competent in a broad domain. No module here
+# is required; a path only points the way.
+# ---------------------------------------------------------------------------
+learning_paths:
+  - id: rf-software-dev
+    label: "RF Software Development"
+    title: "Learning Path — RF Software Development"
+    tagline: "Write the software that turns raw radio into decoded data — the GopherTrunk skill set."
+    intro: >
+      Guidance only — nothing here is required. Work these modules in order to
+      build real competence developing SDR/RF software: understand the signal,
+      learn to build and ship software, then bring the two together to decode
+      digital trunked voice like GopherTrunk does.
+    modules:
+      - id: rf-sdr
+        note: "Start here — the RF and SDR fundamentals every signal path leans on."
+      - id: intro-software-dev
+        note: "How software is designed, built, tested, and shipped."
+      - id: linux-cli
+        note: "The command line where SDR tooling and servers live."
+      - id: git
+        note: "Version control — the backbone of any real codebase."
+      - id: digital-trunking
+        note: "Apply it: how trunked systems work and how software follows them."
+      - id: ai-software-dev
+        note: "Optional — use AI tools to accelerate your development workflow."
+  - id: rf-hardware
+    label: "RF Hardware"
+    title: "Learning Path — RF Hardware"
+    tagline: "Understand the radios, antennas, and front-ends that put signals in front of your software."
+    intro: >
+      Guidance only. For the hardware side of RF: what a signal is, the physical
+      devices that capture and move it, and how RF links are engineered.
+    modules:
+      - id: rf-sdr
+        note: "The physics of signals — waves, power, antennas, propagation."
+      - id: intro-hardware
+        note: "Computers and devices from the ground up, including SDR front-ends."
+      - id: networking
+        note: "How RF ultimately carries data across links and networks."
+  - id: software-engineering
+    label: "Software Engineering Foundations"
+    title: "Learning Path — Software Engineering Foundations"
+    tagline: "Become a well-rounded developer, from first program to shipping and licensing."
+    intro: >
+      Guidance only. A broad grounding in building software: the craft, the tools,
+      the systems it runs on, and the rules for releasing it.
+    modules:
+      - id: intro-software-dev
+        note: "The craft of building software."
+      - id: git
+        note: "Version control and collaboration."
+      - id: linux-cli
+        note: "The command line every developer lives in."
+      - id: networking
+        note: "How software talks across machines."
+      - id: software-licensing
+        note: "The legal side of shipping and reusing code."
+  - id: ai-development
+    label: "AI Software Development"
+    title: "Learning Path — AI Software Development"
+    tagline: "Build software with — and powered by — modern AI."
+    intro: >
+      Guidance only. From general software skills to building AI-assisted and
+      AI-powered applications.
+    modules:
+      - id: intro-software-dev
+        note: "The software foundations AI work builds on."
+      - id: git
+        note: "Version control for any real project."
+      - id: ai-software-dev
+        note: "Use AI tools to write and ship software faster."
+      - id: building-ai
+        note: "Build applications powered by AI."
+  - id: security
+    label: "Cybersecurity"
+    title: "Learning Path — Cybersecurity"
+    tagline: "Understand systems well enough to defend them."
+    intro: >
+      Guidance only. The systems knowledge that security rests on, then the
+      security discipline itself.
+    modules:
+      - id: linux-cli
+        note: "The environment most security work happens in."
+      - id: networking
+        note: "You can't secure what you don't understand — start with the network."
+      - id: cybersecurity
+        note: "Threats, defenses, and the security mindset."
+      - id: git
+        note: "Track changes and collaborate safely."
+  - id: trunked-radio
+    label: "Digital Trunking & Scanning"
+    title: "Learning Path — Digital Trunking & Scanning"
+    tagline: "Go from first radio wave to following live trunked voice systems."
+    intro: >
+      Guidance only. The fastest route to understanding and operating digital
+      trunked radio the way GopherTrunk decodes it.
+    modules:
+      - id: rf-sdr
+        note: "Signals, SDR, and how digital voice is carried."
+      - id: digital-trunking
+        note: "How trunked control channels and voice calls work."
+      - id: intro-hardware
+        note: "The SDR hardware that feeds a scanner."
+
+# ---------------------------------------------------------------------------
+# Learning Modules — the self-contained curricula. Each owns /learn/<id>/.
+# ---------------------------------------------------------------------------
+modules:
   - id: rf-sdr
     label: "RF & SDR"
     title: "Learn RF & SDR — from newbie to expert"
@@ -52,9 +188,9 @@ paths:
       with what a radio wave actually is, learn how software-defined radios turn the
       airwaves into numbers, then follow the signal all the way to decoded digital
       voice — and put it to work in GopherTrunk.
-    modules:
+    units:
       - id: rf-fundamentals
-        label: "Module 1 — RF Fundamentals"
+        label: "Unit 1 — RF Fundamentals"
         blurb: "The physics every operator leans on: waves, frequency, power, antennas, and how signals travel."
         lessons:
           - slug: radio-waves
@@ -95,7 +231,7 @@ paths:
             status: full
 
       - id: signals-modulation
-        label: "Module 2 — Signals & Modulation"
+        label: "Unit 2 — Signals & Modulation"
         blurb: How information rides on a carrier — from analog AM/FM to the digital constellations GopherTrunk decodes.
         lessons:
           - slug: signal-anatomy
@@ -124,7 +260,7 @@ paths:
             status: full
 
       - id: sdr
-        label: "Module 3 — Software-Defined Radio"
+        label: "Unit 3 — Software-Defined Radio"
         blurb: What an SDR actually is, how it samples the air into IQ data, and how to set it up without overloading it.
         lessons:
           - slug: what-is-sdr
@@ -171,7 +307,7 @@ paths:
             status: full
 
       - id: dsp
-        label: "Module 4 — DSP Essentials"
+        label: "Unit 4 — DSP Essentials"
         blurb: The digital signal processing that lives between IQ samples and decoded bits — explained without the heavy math.
         lessons:
           - slug: fft-and-waterfall
@@ -200,7 +336,7 @@ paths:
             status: full
 
       - id: digital-voice-trunking
-        label: "Module 5 — Digital Voice & Trunked Radio"
+        label: "Unit 5 — Digital Voice & Trunked Radio"
         blurb: From vocoded voice to control channels — the systems GopherTrunk was built to follow.
         lessons:
           - slug: digital-voice
@@ -241,7 +377,7 @@ paths:
             status: full
 
       - id: gophertrunk
-        label: "Module 6 — Putting It Together with GopherTrunk"
+        label: "Unit 6 — Putting It Together with GopherTrunk"
         blurb: "Everything you've learned, applied: from a bare antenna to decoded calls, and how to fix it when it won't lock."
         lessons:
           - slug: antenna-to-audio
@@ -296,9 +432,9 @@ paths:
       is, build a rock-solid mental model of how Git stores your work, then learn
       branching, collaboration on GitHub, and the power tools — rebase, bisect,
       Actions — that separate confident users from the rest.
-    modules:
+    units:
       - id: git-foundations
-        label: "Module 1 — Version Control Foundations"
+        label: "Unit 1 — Version Control Foundations"
         blurb: "Why version control exists, how Git thinks, and the core loop — edit, stage, commit — you'll use every day."
         lessons:
           - slug: what-is-version-control
@@ -333,7 +469,7 @@ paths:
             status: full
 
       - id: everyday-git
-        label: "Module 2 — Everyday Git"
+        label: "Unit 2 — Everyday Git"
         blurb: The handful of commands you'll run dozens of times a day — reading state, history, and safely undoing mistakes.
         lessons:
           - slug: status-and-diffs
@@ -362,7 +498,7 @@ paths:
             status: full
 
       - id: branching-merging
-        label: "Module 3 — Branching & Merging"
+        label: "Unit 3 — Branching & Merging"
         blurb: Git's superpower — cheap branches — and how to bring lines of work back together cleanly.
         lessons:
           - slug: branches
@@ -397,7 +533,7 @@ paths:
             status: full
 
       - id: remotes-github
-        label: "Module 4 — Remotes & GitHub"
+        label: "Unit 4 — Remotes & GitHub"
         blurb: Taking Git online — pushing to GitHub, authenticating securely, and the fork-and-pull-request workflow.
         lessons:
           - slug: what-is-github
@@ -432,7 +568,7 @@ paths:
             status: full
 
       - id: github-features
-        label: "Module 5 — Collaboration & GitHub Features"
+        label: "Unit 5 — Collaboration & GitHub Features"
         blurb: The platform features that turn a code host into a place teams plan, automate, ship, and protect their work.
         lessons:
           - slug: issues-and-projects
@@ -473,7 +609,7 @@ paths:
             status: full
 
       - id: advanced-git
-        label: "Module 6 — Advanced Git & Best Practices"
+        label: "Unit 6 — Advanced Git & Best Practices"
         blurb: The power tools and habits that mark a confident operator — history surgery, debugging, and clean workflows.
         lessons:
           - slug: interactive-rebase
@@ -533,9 +669,9 @@ paths:
       and finish able to run and maintain your own services over SSH, including
       GopherTrunk itself on a Linux box or an SBC. No prior command-line experience
       required; examples use Linux (with notes for macOS and Windows/WSL).
-    modules:
+    units:
       - id: getting-started
-        label: "Module 1 — Getting Started with Linux & the Shell"
+        label: "Unit 1 — Getting Started with Linux & the Shell"
         blurb: "What Linux is, why the command line is worth your time, and how to open a shell and run your very first commands without fear."
         lessons:
           - slug: what-is-linux
@@ -570,7 +706,7 @@ paths:
             status: full
 
       - id: files
-        label: "Module 2 — Files & the Filesystem"
+        label: "Unit 2 — Files & the Filesystem"
         blurb: "Everything on Linux is a file in one big tree. Learn to navigate it, and to create, view, edit, and find files with confidence."
         lessons:
           - slug: filesystem-layout
@@ -605,7 +741,7 @@ paths:
             status: full
 
       - id: permissions-processes
-        label: "Module 3 — Permissions, Users & Processes"
+        label: "Unit 3 — Permissions, Users & Processes"
         blurb: "Who can do what, and what's running right now: the multi-user model, file permissions, root, and managing live processes."
         lessons:
           - slug: users-and-groups
@@ -640,7 +776,7 @@ paths:
             status: full
 
       - id: power-of-the-cli
-        label: "Module 4 — The Power of the Command Line"
+        label: "Unit 4 — The Power of the Command Line"
         blurb: "The real superpower: small tools that snap together. Pipes, redirection, text processing, wildcards, and the environment."
         lessons:
           - slug: pipes-and-redirection
@@ -675,7 +811,7 @@ paths:
             status: full
 
       - id: scripting
-        label: "Module 5 — Scripting & Automation"
+        label: "Unit 5 — Scripting & Automation"
         blurb: "Turn a sequence of commands into a reusable program: your first scripts, variables and input, control flow, and scheduling."
         lessons:
           - slug: first-shell-script
@@ -710,7 +846,7 @@ paths:
             status: full
 
       - id: living-on-linux
-        label: "Module 6 — Living on Linux: Servers, SBCs & GopherTrunk"
+        label: "Unit 6 — Living on Linux: Servers, SBCs & GopherTrunk"
         blurb: "Everything applied: reach a machine over SSH, run software as a managed service, watch its health, and put GopherTrunk on a Linux box."
         lessons:
           - slug: ssh-and-remote
@@ -765,9 +901,9 @@ paths:
       your own service on the network safely, including reaching GopherTrunk across
       your home network or the internet. No prior networking knowledge required;
       the Linux & the Command Line path pairs well for the hands-on parts.
-    modules:
+    units:
       - id: how-it-works
-        label: "Module 1 — How Networks & the Internet Work"
+        label: "Unit 1 — How Networks & the Internet Work"
         blurb: "The big picture: what a network is, how data is chopped into packets and routed, the layered model behind it, and one web request traced end to end."
         lessons:
           - slug: what-is-a-network
@@ -802,7 +938,7 @@ paths:
             status: full
 
       - id: addressing
-        label: "Module 2 — Addressing: IP, DNS & Ports"
+        label: "Unit 2 — Addressing: IP, DNS & Ports"
         blurb: "How machines find each other: IP addresses and subnets, the DNS name system, ports and sockets, and how home networks share one public address."
         lessons:
           - slug: ip-addresses
@@ -837,7 +973,7 @@ paths:
             status: full
 
       - id: transport-and-web
-        label: "Module 3 — The Transport & Web Protocols"
+        label: "Unit 3 — The Transport & Web Protocols"
         blurb: "The protocols you'll actually build on: TCP vs. UDP, HTTP and its methods and status codes, TLS/HTTPS, web APIs, and real-time connections."
         lessons:
           - slug: tcp-and-udp
@@ -872,7 +1008,7 @@ paths:
             status: full
 
       - id: connecting-securing
-        label: "Module 4 — Connecting & Securing Networks"
+        label: "Unit 4 — Connecting & Securing Networks"
         blurb: "The infrastructure that connects and protects real systems: firewalls, port forwarding, VPNs, proxies and load balancers, and the security basics."
         lessons:
           - slug: firewalls
@@ -907,7 +1043,7 @@ paths:
             status: full
 
       - id: cli-tools
-        label: "Module 5 — Networking from the Command Line"
+        label: "Unit 5 — Networking from the Command Line"
         blurb: "The tools that turn 'it won't connect' into an answer: inspecting your own network, testing connectivity, making requests, tunneling, and capturing packets."
         lessons:
           - slug: inspecting-your-network
@@ -942,7 +1078,7 @@ paths:
             status: full
 
       - id: your-service
-        label: "Module 6 — Putting a Service on the Network"
+        label: "Unit 6 — Putting a Service on the Network"
         blurb: "Everything applied: run a server and understand what it's bound to, expose it safely, self-host on a home network, and reach GopherTrunk across the network."
         lessons:
           - slug: running-a-server
@@ -999,9 +1135,9 @@ paths:
       the wireless-and-RF security world a scanner like GopherTrunk lives in,
       where the law and ethics matter as much as the technology. No security
       background required; the Linux and Networking paths pair well.
-    modules:
+    units:
       - id: foundations
-        label: "Module 1 — Security Foundations"
+        label: "Unit 1 — Security Foundations"
         blurb: "The mindset and vocabulary of security: what it protects, the goals it aims for, how threats and risk are described, who attacks, and how a defender thinks."
         lessons:
           - slug: what-is-cybersecurity
@@ -1036,7 +1172,7 @@ paths:
             status: full
 
       - id: crypto
-        label: "Module 2 — Cryptography Essentials"
+        label: "Unit 2 — Cryptography Essentials"
         blurb: "The math-free version of the cryptography that underpins everything secure: encryption, keys, hashing, signatures, and where each shows up in real life."
         lessons:
           - slug: what-is-cryptography
@@ -1071,7 +1207,7 @@ paths:
             status: full
 
       - id: identity-access
-        label: "Module 3 — Identity, Authentication & Access"
+        label: "Unit 3 — Identity, Authentication & Access"
         blurb: "Proving who you are and controlling what you can do: authentication, passwords and MFA, authorization, managing secrets, and the human layer attackers love."
         lessons:
           - slug: authentication-basics
@@ -1106,7 +1242,7 @@ paths:
             status: full
 
       - id: attacks-defenses
-        label: "Module 4 — Attacks & Defenses"
+        label: "Unit 4 — Attacks & Defenses"
         blurb: "The attacks every developer should recognise — explained so you can defend against them — and the layered defenses that stop them."
         lessons:
           - slug: common-attacks
@@ -1141,7 +1277,7 @@ paths:
             status: full
 
       - id: securing
-        label: "Module 5 — Securing Systems & Software"
+        label: "Unit 5 — Securing Systems & Software"
         blurb: "Applying the defenses: hardening a machine, writing secure code, protecting networks and services, watching for trouble, and safeguarding data."
         lessons:
           - slug: hardening-systems
@@ -1176,7 +1312,7 @@ paths:
             status: full
 
       - id: in-practice
-        label: "Module 6 — Security in Practice"
+        label: "Unit 6 — Security in Practice"
         blurb: "Everything applied: a developer's security checklist, staying safe as an individual, the wireless-and-RF security world, and where to keep learning."
         lessons:
           - slug: security-for-developers
@@ -1229,9 +1365,9 @@ paths:
       finally how to assemble your own solo development stack, workflow, and
       distribution strategy. Examples lean on real-time and radio software — the
       kind of streaming, signal-crunching code behind GopherTrunk.
-    modules:
+    units:
       - id: history
-        label: "Module 1 — A Brief History of Software"
+        label: "Unit 1 — A Brief History of Software"
         blurb: "Where software came from: the hardware, the first languages, the pioneers, and the cheap compute that put a radio receiver inside a program."
         lessons:
           - slug: what-is-software
@@ -1266,7 +1402,7 @@ paths:
             status: full
 
       - id: languages
-        label: "Module 2 — Modern Programming Languages"
+        label: "Unit 2 — Modern Programming Languages"
         blurb: "The families languages fall into, how they run, and the capabilities, trade-offs, and security properties that set them apart."
         lessons:
           - slug: language-families
@@ -1307,7 +1443,7 @@ paths:
             status: full
 
       - id: principles
-        label: "Module 3 — Software Development Principles"
+        label: "Unit 3 — Software Development Principles"
         blurb: "The timeless, language-agnostic ideas that make code readable, changeable, and robust instead of a tangle nobody dares touch."
         lessons:
           - slug: clean-code
@@ -1348,7 +1484,7 @@ paths:
             status: full
 
       - id: patterns
-        label: "Module 4 — Software Design Patterns"
+        label: "Unit 4 — Software Design Patterns"
         blurb: "Named, reusable solutions to problems that come up again and again — including the streaming and plugin shapes signal software lives on."
         lessons:
           - slug: what-are-patterns
@@ -1389,7 +1525,7 @@ paths:
             status: full
 
       - id: process
-        label: "Module 5 — Development Systems & Strategies"
+        label: "Unit 5 — Development Systems & Strategies"
         blurb: "How software actually gets built and kept alive: life cycles, version control, testing, automation, and fighting technical debt."
         lessons:
           - slug: sdlc-and-methodologies
@@ -1436,7 +1572,7 @@ paths:
             status: full
 
       - id: choosing-a-language
-        label: "Module 6 — Choosing the Right Language"
+        label: "Unit 6 — Choosing the Right Language"
         blurb: "A full toolkit for the question every project starts with: which language? Driven by requirements, trade-offs, and the domain you're in."
         lessons:
           - slug: why-language-choice-matters
@@ -1477,7 +1613,7 @@ paths:
             status: full
 
       - id: solo-stack
-        label: "Module 7 — Build Your Solo Developer Stack"
+        label: "Unit 7 — Build Your Solo Developer Stack"
         blurb: "Putting it all together as a team of one: pick your stack, set up your workflow, and ship and distribute software you build alone."
         lessons:
           - slug: solo-developer-mindset
@@ -1547,9 +1683,9 @@ paths:
       finish able to recognise a system on the waterfall and follow it in
       GopherTrunk. New to radio? Skim the RF & SDR path first; this one assumes
       only the basics.
-    modules:
+    units:
       - id: history
-        label: "Module 1 — A Brief History of Trunked & Digital Radio"
+        label: "Unit 1 — A Brief History of Trunked & Digital Radio"
         blurb: "How we got here: from one-frequency-per-fleet, to shared trunked channels, to the digital standards that run public safety today."
         lessons:
           - slug: why-radio-went-digital
@@ -1584,7 +1720,7 @@ paths:
             status: full
 
       - id: digital-radio
-        label: "Module 2 — Digital Radio End-to-End"
+        label: "Unit 2 — Digital Radio End-to-End"
         blurb: "The complete digital chain: turning a voice into bits, putting bits on a carrier, protecting them from errors, and packing many calls onto one channel."
         lessons:
           - slug: analog-vs-digital-voice
@@ -1625,7 +1761,7 @@ paths:
             status: full
 
       - id: how-trunking-works
-        label: "Module 3 — How Trunking Works"
+        label: "Unit 3 — How Trunking Works"
         blurb: "The mechanics every trunked system shares: talkgroups, affiliation, the request-grant-release dance, multi-site coverage, and encryption."
         lessons:
           - slug: conventional-vs-trunked
@@ -1684,7 +1820,7 @@ paths:
             status: full
 
       - id: p25-dmr
-        label: "Module 4 — P25 & DMR: The Dominant Systems"
+        label: "Unit 4 — P25 & DMR: The Dominant Systems"
         blurb: "The two digital trunking standards you'll meet most — examined in depth, from frame structure to the way GopherTrunk follows them."
         lessons:
           - slug: p25-phase-1
@@ -1707,7 +1843,7 @@ paths:
             status: full
 
       - id: other-systems
-        label: "Module 5 — Other Digital Systems You'll Meet"
+        label: "Unit 5 — Other Digital Systems You'll Meet"
         blurb: "The rest of the landscape GopherTrunk decodes — from European TETRA to legacy LTR, and the amateur digital voice modes in between."
         lessons:
           - slug: tetra
@@ -1742,7 +1878,7 @@ paths:
             status: full
 
       - id: gophertrunk
-        label: "Module 6 — Decoding Digital Trunking with GopherTrunk"
+        label: "Unit 6 — Decoding Digital Trunking with GopherTrunk"
         blurb: "Everything applied: spot a system on the waterfall, find its control channel, follow every call, and fix it when the lock won't hold."
         lessons:
           - slug: identifying-the-system
@@ -1803,9 +1939,9 @@ paths:
       is right for your project. Examples lean on GopherTrunk, the kind of
       software-defined-radio software that can live on anything from a laptop to a
       Raspberry Pi by the antenna.
-    modules:
+    units:
       - id: foundations
-        label: "Module 1 — Hardware Foundations"
+        label: "Unit 1 — Hardware Foundations"
         blurb: "The ideas every later module leans on: what hardware is, the parts inside every computer, the spectrum from cloud to microcontroller, and the trade-offs that drive every choice."
         lessons:
           - slug: what-is-hardware
@@ -1846,7 +1982,7 @@ paths:
             status: full
 
       - id: servers
-        label: "Module 2 — Servers & Hosting"
+        label: "Unit 2 — Servers & Hosting"
         blurb: "Where software runs for other people: the ladder from cheap shared web hosting, through VPSes and dedicated servers, to a server humming in your own home."
         lessons:
           - slug: web-hosting
@@ -1875,7 +2011,7 @@ paths:
             status: full
 
       - id: personal-computers
-        label: "Module 3 — Personal Computers"
+        label: "Unit 3 — Personal Computers"
         blurb: "The machines you build software on: the trade between a fixed, powerful desktop and a portable laptop, and how to choose the one you'll work on every day."
         lessons:
           - slug: desktop-computers
@@ -1898,7 +2034,7 @@ paths:
             status: full
 
       - id: mobile
-        label: "Module 4 — Mobile Devices"
+        label: "Unit 4 — Mobile Devices"
         blurb: "The computers in everyone's pocket and bag: what smartphones and tablets are good at, what they're not, and what it takes to build software for them."
         lessons:
           - slug: smartphones
@@ -1921,7 +2057,7 @@ paths:
             status: full
 
       - id: single-board-computers
-        label: "Module 5 — Single-Board Computers"
+        label: "Unit 5 — Single-Board Computers"
         blurb: "A complete computer on one small board: what an SBC like the Raspberry Pi is, what it's brilliant at, how you program it, and where its limits begin."
         lessons:
           - slug: what-is-an-sbc
@@ -1950,7 +2086,7 @@ paths:
             status: full
 
       - id: microcontrollers
-        label: "Module 6 — Microcontrollers"
+        label: "Unit 6 — Microcontrollers"
         blurb: "The tiny chips that run the physical world: what a microcontroller is, the Arduino that made them approachable, the wireless ESP32, and how you program them."
         lessons:
           - slug: what-is-a-microcontroller
@@ -1979,7 +2115,7 @@ paths:
             status: full
 
       - id: choosing-hardware
-        label: "Module 7 — Choosing the Right Hardware"
+        label: "Unit 7 — Choosing the Right Hardware"
         blurb: "Everything applied: turn a project's needs into the platform — or, more often, the combination of platforms — that fits it best, with a repeatable framework and worked examples."
         lessons:
           - slug: start-with-requirements
@@ -2044,9 +2180,9 @@ paths:
       to work in a real project. No coding background required, though the
       Intro to Software Development path pairs well; examples lean on real
       software, including the kind of signal-crunching code behind GopherTrunk.
-    modules:
+    units:
       - id: how-models-work
-        label: "Module 1 — How AI Models Actually Work"
+        label: "Unit 1 — How AI Models Actually Work"
         blurb: "Under the hood before the hype: what an AI model is, how it's trained, how it decides what to write, how context works, and which kinds of models write code."
         lessons:
           - slug: what-is-ai-for-coding
@@ -2081,7 +2217,7 @@ paths:
             status: full
 
       - id: providers-and-cost
-        label: "Module 2 — Providers, Models & What They Cost"
+        label: "Unit 2 — Providers, Models & What They Cost"
         blurb: "The market you're choosing from: the major providers and models for coding, their strengths and weaknesses, the interfaces you reach them through, and how limits and cost work."
         lessons:
           - slug: the-provider-landscape
@@ -2116,7 +2252,7 @@ paths:
             status: full
 
       - id: ways-to-use
-        label: "Module 3 — Ways to Use AI in Your Workflow"
+        label: "Unit 3 — Ways to Use AI in Your Workflow"
         blurb: "Where the AI actually lives while you work: the provider's app, your IDE, an agent in the terminal, or a deliberate blend — with the honest pluses and drawbacks of each."
         lessons:
           - slug: the-provider-app
@@ -2151,7 +2287,7 @@ paths:
             status: full
 
       - id: coding-modes
-        label: "Module 4 — Modes of AI-Assisted Coding"
+        label: "Unit 4 — Modes of AI-Assisted Coding"
         blurb: "The full spectrum, from a model finishing your line to a model building a feature unattended — what each mode is good for, and where it bites."
         lessons:
           - slug: code-completion
@@ -2180,7 +2316,7 @@ paths:
             status: full
 
       - id: directing-behavior
-        label: "Module 5 — Directing How the Model Writes Code"
+        label: "Unit 5 — Directing How the Model Writes Code"
         blurb: "Going from random results to reliable ones: prompting well, steering behavior with skills and config files, feeding the right context, and deciding between one model and many."
         lessons:
           - slug: prompting-for-code
@@ -2209,7 +2345,7 @@ paths:
             status: full
 
       - id: putting-it-together
-        label: "Module 6 — Putting AI to Work in Your Projects"
+        label: "Unit 6 — Putting AI to Work in Your Projects"
         blurb: "Everything applied: choose your model and provider, pick your method, keep the output trustworthy and safe, and start using AI in a real project today."
         lessons:
           - slug: choosing-model-and-provider
@@ -2270,9 +2406,9 @@ paths:
       production. Examples lean on real software, including AI features you might
       add to a project like GopherTrunk. Pairs with the AI in Software Dev path; no
       AI background beyond it required.
-    modules:
+    units:
       - id: foundations
-        label: "Module 1 — From Using AI to Building With It"
+        label: "Unit 1 — From Using AI to Building With It"
         blurb: "The shift from chatting with AI to calling it from your own code: what an AI feature is, the model as a component, how the API works, your first call, and the cost it carries."
         lessons:
           - slug: building-vs-using-ai
@@ -2307,7 +2443,7 @@ paths:
             status: full
 
       - id: prompting-in-code
-        label: "Module 2 — Prompting in Code"
+        label: "Unit 2 — Prompting in Code"
         blurb: "Turning prompts from throwaway chat messages into reliable, versioned parts of your program that produce output consistent enough to build on."
         lessons:
           - slug: prompts-as-code
@@ -2336,7 +2472,7 @@ paths:
             status: full
 
       - id: structured-tools-streaming
-        label: "Module 3 — Structured Output, Tools & Streaming"
+        label: "Unit 3 — Structured Output, Tools & Streaming"
         blurb: "The features that turn a text generator into a programmable component: JSON output, tool and function calling, streaming, and multimodal inputs."
         lessons:
           - slug: structured-output
@@ -2365,7 +2501,7 @@ paths:
             status: full
 
       - id: rag
-        label: "Module 4 — Retrieval-Augmented Generation (RAG)"
+        label: "Unit 4 — Retrieval-Augmented Generation (RAG)"
         blurb: "Grounding the model in your own data so it answers from your documents and facts instead of only its training — the most common way to build a genuinely useful AI feature."
         lessons:
           - slug: grounding-and-retrieval
@@ -2400,7 +2536,7 @@ paths:
             status: full
 
       - id: agents-eval-safety
-        label: "Module 5 — Agents, Evaluation & Safety"
+        label: "Unit 5 — Agents, Evaluation & Safety"
         blurb: "Letting the model act, then making sure it acts well: agent loops and tools, evaluating a probabilistic feature, handling failure, and defending against prompt injection."
         lessons:
           - slug: what-is-an-ai-agent
@@ -2435,7 +2571,7 @@ paths:
             status: full
 
       - id: shipping
-        label: "Module 6 — Shipping & Operating AI Features"
+        label: "Unit 6 — Shipping & Operating AI Features"
         blurb: "Everything applied: choose a model, control cost and latency, protect user data, watch it in production, and ship your first AI feature end to end."
         lessons:
           - slug: choosing-a-model-for-a-feature
@@ -2504,9 +2640,9 @@ paths:
       educational material, not legal advice. No legal background required;
       examples lean on real software, including GopherTrunk's own Apache-2.0
       license and dependency notices.
-    modules:
+    units:
       - id: foundations
-        label: "Module 1 — Licensing & IP Foundations"
+        label: "Unit 1 — Licensing & IP Foundations"
         blurb: "What a software license actually is, how copyright and other IP make code ownable, license versus contract, the full spectrum of license types, and how the law differs around the world."
         lessons:
           - slug: what-is-a-software-license
@@ -2547,7 +2683,7 @@ paths:
             status: full
 
       - id: open-source-in-depth
-        label: "Module 2 — Open Source Licenses in Depth"
+        label: "Unit 2 — Open Source Licenses in Depth"
         blurb: "What 'open source' really means, the permissive-versus-copyleft divide, and a detailed look at every common license — MIT, BSD, Apache, GPL, AGPL, the weak-copyleft licenses, and public domain — with the real strengths and weaknesses of each."
         lessons:
           - slug: what-is-open-source
@@ -2600,7 +2736,7 @@ paths:
             status: full
 
       - id: choosing-and-combining
-        label: "Module 3 — Choosing & Combining Open Source"
+        label: "Unit 3 — Choosing & Combining Open Source"
         blurb: "Putting the licenses to work: how they combine and where they conflict, how to pick one for your own project, contributor agreements, dual licensing, and the long-term risks of depending on open source."
         lessons:
           - slug: license-compatibility
@@ -2635,7 +2771,7 @@ paths:
             status: full
 
       - id: proprietary-and-commercial
-        label: "Module 4 — Proprietary & Commercial Licensing"
+        label: "Unit 4 — Proprietary & Commercial Licensing"
         blurb: "The paid side of the spectrum: how proprietary licensing works, the commercial pricing models, source-available licenses, and how to write and price a custom license to sell your own software — plus where to get real help."
         lessons:
           - slug: proprietary-licensing
@@ -2676,7 +2812,7 @@ paths:
             status: full
 
       - id: oss-in-products
-        label: "Module 5 — Using Open Source in Software You Sell"
+        label: "Unit 5 — Using Open Source in Software You Sell"
         blurb: "You can absolutely build a paid product on open source — if you follow the rules. Meeting permissive obligations, handling copyleft and the 'viral' question, and auditing your dependencies so compliance is continuous, not a fire drill."
         lessons:
           - slug: using-oss-in-products
@@ -2705,7 +2841,7 @@ paths:
             status: full
 
       - id: reading-agreements
-        label: "Module 6 — Reading Agreements & Other User Agreements"
+        label: "Unit 6 — Reading Agreements & Other User Agreements"
         blurb: "How to actually read a software agreement and understand it before you sign — the main clauses, the risk clauses, and the red flags — then a tour of the other agreements software needs: EULAs, terms of service, privacy policies, DPAs, SLAs, and NDAs."
         lessons:
           - slug: how-to-read-an-agreement
@@ -2758,7 +2894,7 @@ paths:
             status: full
 
       - id: putting-it-together
-        label: "Module 7 — Choosing Your License & Agreements"
+        label: "Unit 7 — Choosing Your License & Agreements"
         blurb: "Everything applied: a repeatable framework that turns your goals into a license choice, a step-by-step walkthrough to pick yours, a way to determine which other agreements your software needs, and a full worked example end to end."
         lessons:
           - slug: the-decision-framework

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -13,17 +13,29 @@ groups:
         url: /guide-advanced.html
   - label: Learn
     items:
-      - title: All learning paths
+      - title: All learning
         url: /learn/
-      - title: "RF & SDR"
+      - title: "Path: RF Software Development"
+        url: /learn/paths/rf-software-dev/
+      - title: "Path: RF Hardware"
+        url: /learn/paths/rf-hardware/
+      - title: "Path: Software Engineering"
+        url: /learn/paths/software-engineering/
+      - title: "Path: AI Software Development"
+        url: /learn/paths/ai-development/
+      - title: "Path: Cybersecurity"
+        url: /learn/paths/security/
+      - title: "Path: Digital Trunking & Scanning"
+        url: /learn/paths/trunked-radio/
+      - title: "Module: RF & SDR"
         url: /learn/rf-sdr/
-      - title: "Git & GitHub"
+      - title: "Module: Git & GitHub"
         url: /learn/git/
-      - title: "Intro to Software Dev"
+      - title: "Module: Intro to Software Dev"
         url: /learn/intro-software-dev/
-      - title: "Digital Trunking"
+      - title: "Module: Digital Trunking"
         url: /learn/digital-trunking/
-      - title: "Intro to Hardware"
+      - title: "Module: Intro to Hardware"
         url: /learn/intro-hardware/
   - label: Field Guide
     items:

--- a/docs/_includes/learn-path-nav.html
+++ b/docs/_includes/learn-path-nav.html
@@ -1,16 +1,16 @@
 {%- comment -%}
-  Prev / next navigation for a learning path. Expects:
+  Prev / next navigation for a learning module. Expects:
     all_lessons — flat ordered array of lesson objects (slug, title)
-    idx         — index of the current lesson, or -1 if not in the path
-    total       — number of lessons in the path
-    base        — the path's base URL, e.g. /learn/git/
-    has_glossary — truthy if the path has a glossary (for the finish link)
+    idx         — index of the current lesson, or -1 if not in the module
+    total       — number of lessons in the module
+    base        — the module's base URL, e.g. /learn/git/
+    has_glossary — truthy if the module has a glossary (for the finish link)
   Wired up by _layouts/lesson.html.
 {%- endcomment -%}
 {%- if include.idx >= 0 -%}
   {%- assign prev_i = include.idx | minus: 1 -%}
   {%- assign next_i = include.idx | plus: 1 -%}
-  <nav class="path-nav" aria-label="Learning path">
+  <nav class="path-nav" aria-label="Lessons in this module">
     {%- if include.idx > 0 -%}
       {%- assign prev = include.all_lessons[prev_i] -%}
       <a class="path-nav__link path-nav__link--prev" href="{{ include.base | append: prev.slug | append: '/' | relative_url }}">
@@ -19,8 +19,8 @@
       </a>
     {%- else -%}
       <a class="path-nav__link path-nav__link--prev" href="{{ include.base | relative_url }}">
-        <span class="path-nav__dir">&larr; Path overview</span>
-        <span class="path-nav__title">Start of the path</span>
+        <span class="path-nav__dir">&larr; Module overview</span>
+        <span class="path-nav__title">Start of the module</span>
       </a>
     {%- endif -%}
 
@@ -39,7 +39,7 @@
     {%- else -%}
       <a class="path-nav__link path-nav__link--next" href="{{ include.base | relative_url }}">
         <span class="path-nav__dir">You finished! &rarr;</span>
-        <span class="path-nav__title">Back to the path overview</span>
+        <span class="path-nav__title">Back to the module overview</span>
       </a>
     {%- endif -%}
   </nav>

--- a/docs/_includes/learn-schema.html
+++ b/docs/_includes/learn-schema.html
@@ -1,5 +1,5 @@
 {%- comment -%}
-  Structured data for learning-path pages. Emits:
+  Structured data for lesson pages. Emits:
     - TechArticle           (the lesson itself, with learning metadata)
     - BreadcrumbList        (Home › Learn › Lesson)
     - FAQPage               (only when the page defines a `faq:` list)
@@ -7,7 +7,7 @@
   Expects include.idx / include.total from the lesson layout.
 {%- endcomment -%}
 {%- assign page_url = page.url | absolute_url -%}
-{%- assign p = site.data.learn.paths | where: "id", page.learn_path | first -%}
+{%- assign p = site.data.learn.modules | where: "id", page.learn_module | first -%}
 {%- assign path_base = '/learn/' | append: p.id | append: '/' -%}
 <script type="application/ld+json">
 {

--- a/docs/_layouts/learn-hub.html
+++ b/docs/_layouts/learn-hub.html
@@ -2,15 +2,21 @@
 layout: default
 ---
 {%- comment -%}
-  Hub landing page for one learning path. The page selects its path with
-  `learn_path:` in front matter. Renders the module/lesson grid from
+  Hub landing page for one learning module. The page selects its module with
+  `learn_module:` in front matter. Renders the unit/lesson grid from
   _data/learn.yml and a localStorage-backed progress bar (progressively
   enhanced by assets/js/learn.js). Emits Course + ItemList structured data.
 {%- endcomment -%}
-{%- assign p = site.data.learn.paths | where: "id", page.learn_path | first -%}
+{%- assign p = site.data.learn.modules | where: "id", page.learn_module | first -%}
 {%- assign base = '/learn/' | append: p.id | append: '/' -%}
 {%- assign total = 0 -%}
-{%- for mod in p.modules -%}{%- assign total = total | plus: mod.lessons.size -%}{%- endfor -%}
+{%- for unit in p.units -%}{%- assign total = total | plus: unit.lessons.size -%}{%- endfor -%}
+{%- comment -%} Learning Paths that recommend this module (guidance backlinks) {%- endcomment -%}
+{%- assign in_paths = "" | split: "" -%}
+{%- for lp in site.data.learn.learning_paths -%}
+  {%- assign lp_match = lp.modules | where: "id", p.id | first -%}
+  {%- if lp_match -%}{%- assign in_paths = in_paths | push: lp -%}{%- endif -%}
+{%- endfor -%}
 
 <main id="content" class="page" role="main">
   <div class="container" data-cta-host>
@@ -42,15 +48,26 @@ layout: default
       {{ content }}
     </article>
 
+    {%- if in_paths.size > 0 -%}
+      <aside class="learn-inpaths" aria-label="Learning paths that include this module">
+        <span class="learn-inpaths__label">Part of these Learning Paths:</span>
+        <ul class="learn-inpaths__list">
+          {%- for lp in in_paths -%}
+            <li><a href="{{ '/learn/paths/' | append: lp.id | append: '/' | relative_url }}">{{ lp.label }}</a></li>
+          {%- endfor -%}
+        </ul>
+      </aside>
+    {%- endif -%}
+
     <div class="learn-modules">
-      {%- for mod in p.modules -%}
-        <section class="learn-module" id="{{ mod.id }}">
+      {%- for unit in p.units -%}
+        <section class="learn-module" id="{{ unit.id }}">
           <div class="learn-module__head">
-            <h2 class="learn-module__title">{{ mod.label }}</h2>
-            <p class="learn-module__blurb">{{ mod.blurb }}</p>
+            <h2 class="learn-module__title">{{ unit.label }}</h2>
+            <p class="learn-module__blurb">{{ unit.blurb }}</p>
           </div>
           <ol class="learn-grid">
-            {%- for lesson in mod.lessons -%}
+            {%- for lesson in unit.lessons -%}
               {%- assign lesson_url = base | append: lesson.slug | append: '/' -%}
               <li class="learn-card{% if lesson.status == 'stub' %} learn-card--stub{% endif %}" data-lesson="{{ p.id }}/{{ lesson.slug }}">
                 <a class="learn-card__link" href="{{ lesson_url | relative_url }}">
@@ -118,8 +135,8 @@ layout: default
   "name": {{ page.title | append: ' lessons' | jsonify }},
   "itemListElement": [
     {%- assign n = 0 -%}
-    {%- for mod in p.modules -%}
-      {%- for lesson in mod.lessons -%}
+    {%- for unit in p.units -%}
+      {%- for lesson in unit.lessons -%}
         {%- assign n = n | plus: 1 -%}
         {
           "@type": "ListItem",

--- a/docs/_layouts/learn-index.html
+++ b/docs/_layouts/learn-index.html
@@ -2,21 +2,27 @@
 layout: default
 ---
 {%- comment -%}
-  The /learn/ chooser. The hub's front door: it explains the overall goal
-  (work from first principles up to shipping a real project like GopherTrunk),
-  shows the visitor's progress across every path, and lets them resume or reset
-  any path. Every path in _data/learn.yml becomes a card linking to its hub.
+  The /learn/ chooser. The hub's front door: it introduces the optional
+  Learning Paths (guided routes toward a domain), shows the visitor's progress
+  across every module, and lets them resume or reset any module. Every module in
+  _data/learn.yml becomes a card linking to its hub; every Learning Path becomes
+  a card linking to its guide.
 
   Progressive enhancement: the page is fully usable with JS off — every card
-  links to its hub, the journey stepper is a static numbered list, and the
+  links to its target, the journey stepper is a static numbered list, and the
   mission copy and ItemList schema are server-rendered. The progress dashboard,
   per-card rings, "continue" targets and reset buttons are populated by
   assets/js/learn.js from localStorage, and stay hidden/empty without it.
+
+  learn.js reads the `learn-paths-data` JSON blob and the data-* hooks below,
+  all keyed on the module `id`. Those identifiers are intentionally left as
+  "path" (data.paths, data-path-card, …) to match the JS; only the visible copy
+  speaks of "modules".
 {%- endcomment -%}
-{%- assign paths = site.data.learn.paths -%}
+{%- assign modules = site.data.learn.modules -%}
 {%- assign grand_total = 0 -%}
-{%- for p in paths -%}
-  {%- for mod in p.modules -%}{%- assign grand_total = grand_total | plus: mod.lessons.size -%}{%- endfor -%}
+{%- for p in modules -%}
+  {%- for unit in p.units -%}{%- assign grand_total = grand_total | plus: unit.lessons.size -%}{%- endfor -%}
 {%- endfor -%}
 
 <main id="content" class="page" role="main">
@@ -37,16 +43,43 @@ layout: default
       {{ content }}
     </article>
 
-    {%- comment -%} ---- Journey stepper: the 6 paths leading to "ship it" ---- {%- endcomment -%}
+    {%- comment -%} ---- Learning Paths: optional domain guides ---- {%- endcomment -%}
+    <section class="learn-paths" aria-labelledby="paths-h">
+      <h2 id="paths-h" class="learn-journey__title">Learning Paths</h2>
+      <p class="learn-journey__lede">
+        Not sure where to start? A <strong>Learning Path</strong> is a guided,
+        ordered route through several modules toward competence in a bigger area —
+        like RF software or hardware. They are guidance only: nothing here is
+        required, and every module can be taken on its own.
+      </p>
+      <ol class="learn-grid">
+        {%- for lp in site.data.learn.learning_paths -%}
+          <li class="learn-card learn-card--path">
+            <a class="learn-card__link" href="{{ '/learn/paths/' | append: lp.id | append: '/' | relative_url }}">
+              <span class="learn-card__body">
+                <span class="learn-card__title">{{ lp.label }}</span>
+                <span class="learn-card__summary">{{ lp.tagline }}</span>
+                <span class="learn-card__meta">
+                  <span class="learn-card__tag">{{ lp.modules.size }} modules</span>
+                </span>
+              </span>
+            </a>
+          </li>
+        {%- endfor -%}
+      </ol>
+    </section>
+
+    {%- comment -%} ---- Journey stepper: the modules leading to "ship it" ---- {%- endcomment -%}
     <section class="learn-journey" aria-labelledby="journey-h">
       <h2 id="journey-h" class="learn-journey__title">Your journey to shipping a project</h2>
       <p class="learn-journey__lede">
-        {{ paths.size }} paths take you from first principles to a real, shipping
-        application like GopherTrunk — an SDR trunking scanner. Follow them in
-        order, or jump straight to what you need. Your progress fills in as you go.
+        {{ modules.size }} modules take you from first principles to a real,
+        shipping application like GopherTrunk — an SDR trunking scanner. Follow
+        them in order, or jump straight to what you need. Your progress fills in
+        as you go.
       </p>
       <ol class="journey" role="list">
-        {%- for p in paths -%}
+        {%- for p in modules -%}
           <li class="journey__step" data-journey-path="{{ p.id }}">
             <a class="journey__link" href="{{ '/learn/' | append: p.id | append: '/' | relative_url }}">
               <span class="journey__marker">
@@ -74,7 +107,7 @@ layout: default
     <section class="learn-dashboard" aria-labelledby="dash-h" hidden data-learn-dashboard>
       <h2 id="dash-h" class="learn-dashboard__title">Your progress</h2>
       <div class="learn-dashboard__grid">
-        <figure class="learn-donut" role="img" aria-label="Overall progress across all learning paths" data-donut-figure>
+        <figure class="learn-donut" role="img" aria-label="Overall progress across all learning modules" data-donut-figure>
           <svg class="learn-donut__svg" viewBox="0 0 120 120" focusable="false" aria-hidden="true">
             <circle class="learn-donut__track" cx="60" cy="60" r="52" />
             <circle class="learn-donut__fill" cx="60" cy="60" r="52"
@@ -87,14 +120,14 @@ layout: default
 
         <ul class="learn-stats" data-learn-stats>
           <li><span class="learn-stats__num" data-stat-lessons>0</span><span class="learn-stats__lbl">lessons done</span></li>
-          <li><span class="learn-stats__num" data-stat-started>0</span><span class="learn-stats__lbl">of {{ paths.size }} paths started</span></li>
-          <li><span class="learn-stats__num" data-stat-completed>0</span><span class="learn-stats__lbl">paths completed</span></li>
+          <li><span class="learn-stats__num" data-stat-started>0</span><span class="learn-stats__lbl">of {{ modules.size }} modules started</span></li>
+          <li><span class="learn-stats__num" data-stat-completed>0</span><span class="learn-stats__lbl">modules completed</span></li>
         </ul>
 
-        <ul class="learn-cluster" data-learn-cluster aria-label="Progress by path">
-          {%- for p in paths -%}
+        <ul class="learn-cluster" data-learn-cluster aria-label="Progress by module">
+          {%- for p in modules -%}
             {%- assign t = 0 -%}
-            {%- for mod in p.modules -%}{%- assign t = t | plus: mod.lessons.size -%}{%- endfor -%}
+            {%- for unit in p.units -%}{%- assign t = t | plus: unit.lessons.size -%}{%- endfor -%}
             <li class="learn-cluster__row" data-cluster-path="{{ p.id }}" data-cluster-total="{{ t }}">
               <span class="learn-cluster__name">{{ p.label }}</span>
               <span class="learn-cluster__track"><span class="learn-cluster__bar" data-cluster-bar></span></span>
@@ -105,14 +138,14 @@ layout: default
       </div>
     </section>
 
-    {%- comment -%} ---- Enhanced path cards ---- {%- endcomment -%}
+    {%- comment -%} ---- Enhanced module cards ---- {%- endcomment -%}
     <div class="learn-modules">
       <section class="learn-module">
-        <h2 class="learn-module__title">Pick a path</h2>
+        <h2 class="learn-module__title">Browse all modules</h2>
         <ol class="learn-grid">
-          {%- for p in paths -%}
+          {%- for p in modules -%}
             {%- assign count = 0 -%}
-            {%- for mod in p.modules -%}{%- assign count = count | plus: mod.lessons.size -%}{%- endfor -%}
+            {%- for unit in p.units -%}{%- assign count = count | plus: unit.lessons.size -%}{%- endfor -%}
             {%- assign base = '/learn/' | append: p.id | append: '/' -%}
             <li class="learn-card learn-card--path" data-path-card="{{ p.id }}" data-path-total="{{ count }}">
               <a class="learn-card__link" href="{{ base | relative_url }}">
@@ -129,7 +162,7 @@ layout: default
                   <span class="learn-card__summary">{{ p.tagline }}</span>
                   <span class="learn-card__meta">
                     <span class="learn-card__time" data-card-count>{{ count }} lessons</span>
-                    <span class="learn-card__tag">{{ p.modules.size }} modules</span>
+                    <span class="learn-card__tag">{{ p.units.size }} units</span>
                   </span>
                 </span>
               </a>
@@ -150,10 +183,10 @@ layout: default
 <script type="application/json" id="learn-paths-data">
 {
   "paths": [
-    {%- for p in paths -%}
+    {%- for p in modules -%}
     {%- assign base = '/learn/' | append: p.id | append: '/' -%}
     {%- assign t = 0 -%}
-    {%- for mod in p.modules -%}{%- assign t = t | plus: mod.lessons.size -%}{%- endfor -%}
+    {%- for unit in p.units -%}{%- assign t = t | plus: unit.lessons.size -%}{%- endfor -%}
     {
       "id": {{ p.id | jsonify }},
       "label": {{ p.label | jsonify }},
@@ -161,8 +194,8 @@ layout: default
       "hubUrl": {{ base | relative_url | jsonify }},
       "lessons": [
         {%- assign k = 0 -%}
-        {%- for mod in p.modules -%}
-          {%- for lesson in mod.lessons -%}
+        {%- for unit in p.units -%}
+          {%- for lesson in unit.lessons -%}
             {%- assign k = k | plus: 1 -%}
             {"slug": {{ lesson.slug | jsonify }}, "title": {{ lesson.title | jsonify }}, "url": {{ base | append: lesson.slug | append: '/' | relative_url | jsonify }}}{%- unless k == t -%},{%- endunless -%}
           {%- endfor -%}
@@ -182,7 +215,7 @@ layout: default
   "@type": "ItemList",
   "name": {{ page.title | jsonify }},
   "itemListElement": [
-    {%- for p in paths -%}
+    {%- for p in modules -%}
     {
       "@type": "ListItem",
       "position": {{ forloop.index }},

--- a/docs/_layouts/learn-path.html
+++ b/docs/_layouts/learn-path.html
@@ -1,0 +1,171 @@
+---
+layout: default
+---
+{%- comment -%}
+  Learning Path guide — one optional, guidance-only domain track. Selects its
+  path with `learn_path_id:` in front matter, resolves each referenced module id
+  against site.data.learn.modules, and renders an ordered list of module cards
+  plus a derived progress dashboard. Nothing here is required — a path only
+  recommends an order for otherwise-independent modules.
+
+  Progress reuse: this page emits the same `learn-paths-data` blob and data-*
+  hooks the chooser uses, scoped to this path's modules, so assets/js/learn.js
+  paints per-module rings, the continue button, and the overall donut straight
+  from the learner's saved (Supabase-synced) progress — no path-specific JS and
+  no path-specific storage. Path progress is purely derived from the modules'
+  completions.
+{%- endcomment -%}
+{%- assign lp = site.data.learn.learning_paths | where: "id", page.learn_path_id | first -%}
+
+{%- comment -%} Resolve module references to full module objects, preserving order. {%- endcomment -%}
+{%- assign lp_modules = "" | split: "" -%}
+{%- assign lp_notes = "" | split: "" -%}
+{%- for ref in lp.modules -%}
+  {%- assign m = site.data.learn.modules | where: "id", ref.id | first -%}
+  {%- if m -%}
+    {%- assign lp_modules = lp_modules | push: m -%}
+    {%- assign lp_notes = lp_notes | push: ref.note -%}
+  {%- endif -%}
+{%- endfor -%}
+{%- assign grand_total = 0 -%}
+{%- for m in lp_modules -%}
+  {%- for unit in m.units -%}{%- assign grand_total = grand_total | plus: unit.lessons.size -%}{%- endfor -%}
+{%- endfor -%}
+
+<main id="content" class="page" role="main">
+  <div class="container" data-cta-host>
+    <nav class="breadcrumb" aria-label="Breadcrumb">
+      <ol>
+        <li><a href="{{ '/' | relative_url }}">Home</a></li>
+        <li><a href="{{ '/learn/' | relative_url }}">Learn</a></li>
+        <li><span aria-current="page">{{ lp.label }}</span></li>
+      </ol>
+    </nav>
+
+    <header class="learn-hero">
+      <h1 class="learn-hero__title">{{ lp.title }}</h1>
+      <p class="learn-hero__lede">{{ lp.intro }}</p>
+    </header>
+
+    <p class="learn-pathnote" role="note">
+      <strong>This is a guide, not a requirement.</strong> A Learning Path only
+      recommends an order for working through otherwise-independent modules toward
+      competence in this area. Take them all, or pick just the ones you need —
+      your progress is tracked per module either way.
+    </p>
+
+    <article class="prose prose--wide learn-intro">
+      {{ content }}
+    </article>
+
+    {%- comment -%} ---- Derived progress dashboard (hidden until learn.js runs) ---- {%- endcomment -%}
+    <section class="learn-dashboard" aria-labelledby="dash-h" hidden data-learn-dashboard>
+      <h2 id="dash-h" class="learn-dashboard__title">Your progress on this path</h2>
+      <div class="learn-dashboard__grid">
+        <figure class="learn-donut" role="img" aria-label="Overall progress across this learning path" data-donut-figure>
+          <svg class="learn-donut__svg" viewBox="0 0 120 120" focusable="false" aria-hidden="true">
+            <circle class="learn-donut__track" cx="60" cy="60" r="52" />
+            <circle class="learn-donut__fill" cx="60" cy="60" r="52"
+                    data-donut-fill stroke-dasharray="326.726" stroke-dashoffset="326.726"
+                    transform="rotate(-90 60 60)" />
+            <text class="learn-donut__pct" x="60" y="67" text-anchor="middle" data-donut-pct>0%</text>
+          </svg>
+          <figcaption class="learn-donut__caption" data-donut-caption>0 of {{ grand_total }} lessons complete</figcaption>
+        </figure>
+        <ul class="learn-stats" data-learn-stats>
+          <li><span class="learn-stats__num" data-stat-lessons>0</span><span class="learn-stats__lbl">lessons done</span></li>
+          <li><span class="learn-stats__num" data-stat-started>0</span><span class="learn-stats__lbl">of {{ lp_modules.size }} modules started</span></li>
+          <li><span class="learn-stats__num" data-stat-completed>0</span><span class="learn-stats__lbl">modules completed</span></li>
+        </ul>
+      </div>
+    </section>
+
+    {%- comment -%} ---- Ordered module recommendations ---- {%- endcomment -%}
+    <div class="learn-modules">
+      <section class="learn-module">
+        <h2 class="learn-module__title">Recommended order</h2>
+        <ol class="learn-grid">
+          {%- for m in lp_modules -%}
+            {%- assign count = 0 -%}
+            {%- for unit in m.units -%}{%- assign count = count | plus: unit.lessons.size -%}{%- endfor -%}
+            {%- assign base = '/learn/' | append: m.id | append: '/' -%}
+            <li class="learn-card learn-card--path" data-path-card="{{ m.id }}" data-path-total="{{ count }}">
+              <a class="learn-card__link" href="{{ base | relative_url }}">
+                <span class="learn-card__ring" aria-hidden="true">
+                  <svg viewBox="0 0 44 44" focusable="false">
+                    <circle class="learn-card__ring-track" cx="22" cy="22" r="19" />
+                    <circle class="learn-card__ring-fill" cx="22" cy="22" r="19"
+                            data-card-ring stroke-dasharray="119.38" stroke-dashoffset="119.38"
+                            transform="rotate(-90 22 22)" />
+                  </svg>
+                </span>
+                <span class="learn-card__body">
+                  <span class="learn-card__title">{{ forloop.index }}. {{ m.label }}</span>
+                  <span class="learn-card__summary">{% if lp_notes[forloop.index0] %}{{ lp_notes[forloop.index0] }}{% else %}{{ m.tagline }}{% endif %}</span>
+                  <span class="learn-card__meta">
+                    <span class="learn-card__time" data-card-count>{{ count }} lessons</span>
+                    <span class="learn-card__tag">{{ m.units.size }} units</span>
+                  </span>
+                </span>
+              </a>
+              <div class="learn-card__actions" data-card-actions hidden>
+                <a class="btn btn--secondary learn-card__continue" data-card-continue href="{{ base | append: m.start_slug | append: '/' | relative_url }}">Start lesson 1 &rarr;</a>
+                <button type="button" class="learn-card__reset" data-card-reset hidden>reset</button>
+              </div>
+            </li>
+          {%- endfor -%}
+        </ol>
+      </section>
+    </div>
+
+    {%- include page-ctas.html -%}
+  </div>
+</main>
+
+<script type="application/json" id="learn-paths-data">
+{
+  "paths": [
+    {%- for m in lp_modules -%}
+    {%- assign base = '/learn/' | append: m.id | append: '/' -%}
+    {%- assign t = 0 -%}
+    {%- for unit in m.units -%}{%- assign t = t | plus: unit.lessons.size -%}{%- endfor -%}
+    {
+      "id": {{ m.id | jsonify }},
+      "label": {{ m.label | jsonify }},
+      "total": {{ t }},
+      "hubUrl": {{ base | relative_url | jsonify }},
+      "lessons": [
+        {%- assign k = 0 -%}
+        {%- for unit in m.units -%}
+          {%- for lesson in unit.lessons -%}
+            {%- assign k = k | plus: 1 -%}
+            {"slug": {{ lesson.slug | jsonify }}, "title": {{ lesson.title | jsonify }}, "url": {{ base | append: lesson.slug | append: '/' | relative_url | jsonify }}}{%- unless k == t -%},{%- endunless -%}
+          {%- endfor -%}
+        {%- endfor -%}
+      ]
+    }{%- unless forloop.last -%},{%- endunless -%}
+    {%- endfor -%}
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ItemList",
+  "name": {{ lp.title | jsonify }},
+  "description": {{ lp.tagline | jsonify }},
+  "itemListElement": [
+    {%- for m in lp_modules -%}
+    {
+      "@type": "ListItem",
+      "position": {{ forloop.index }},
+      "name": {{ m.title | jsonify }},
+      "url": {{ '/learn/' | append: m.id | append: '/' | absolute_url | jsonify }}
+    }{%- unless forloop.last -%},{%- endunless -%}
+    {%- endfor -%}
+  ]
+}
+</script>
+<script defer src="{{ '/assets/js/store.js' | relative_url }}"></script>
+<script defer src="{{ '/assets/js/learn.js' | relative_url }}"></script>

--- a/docs/_layouts/lesson.html
+++ b/docs/_layouts/lesson.html
@@ -2,23 +2,23 @@
 layout: default
 ---
 {%- comment -%}
-  Lesson layout for any learning path.
+  Lesson layout for any learning module.
 
-  The lesson selects its path with `learn_path:` (set per-directory in
-  _config.yml). Flattens that path's modules into one ordered list so it can
-  compute the lesson's position, its module, and prev/next links from a single
+  The lesson selects its module with `learn_module:` (set per-directory in
+  _config.yml). Flattens that module's units into one ordered list so it can
+  compute the lesson's position, its unit, and prev/next links from a single
   source (_data/learn.yml). The page identifies itself with `slug:` in front
-  matter. The glossary (page.lesson_standalone) skips path nav.
+  matter. The glossary (page.lesson_standalone) skips lesson nav.
 {%- endcomment -%}
 
-{%- assign p = site.data.learn.paths | where: "id", page.learn_path | first -%}
+{%- assign p = site.data.learn.modules | where: "id", page.learn_module | first -%}
 {%- assign base = '/learn/' | append: p.id | append: '/' -%}
 {%- assign all_lessons = "" | split: "" -%}
-{%- assign module_labels = "" | split: "" -%}
-{%- for mod in p.modules -%}
-  {%- for lesson in mod.lessons -%}
+{%- assign unit_labels = "" | split: "" -%}
+{%- for unit in p.units -%}
+  {%- for lesson in unit.lessons -%}
     {%- assign all_lessons = all_lessons | push: lesson -%}
-    {%- assign module_labels = module_labels | push: mod.label -%}
+    {%- assign unit_labels = unit_labels | push: unit.label -%}
   {%- endfor -%}
 {%- endfor -%}
 {%- assign total = all_lessons | size -%}
@@ -39,7 +39,7 @@ layout: default
         <li><a href="{{ '/learn/' | relative_url }}">Learn</a></li>
         <li><a href="{{ base | relative_url }}">{{ p.label }}</a></li>
         {%- if idx >= 0 -%}
-          <li><span class="breadcrumb__group">{{ module_labels[idx] }}</span></li>
+          <li><span class="breadcrumb__group">{{ unit_labels[idx] }}</span></li>
         {%- endif -%}
         <li><span aria-current="page">{{ page.title }}</span></li>
       </ol>
@@ -70,8 +70,8 @@ layout: default
         {%- if page.prereq and page.prereq.size > 0 -%}
           <p class="lesson__prereq"><span class="lesson__prereq-label">Before this:</span>
             {%- for slug in page.prereq -%}
-              {%- assign p = all_lessons | where: "slug", slug | first -%}
-              {%- if p -%}<a class="lesson__chip" href="{{ '/learn/' | append: slug | append: '/' | relative_url }}">{{ p.title }}</a>{%- endif -%}
+              {%- assign pl = all_lessons | where: "slug", slug | first -%}
+              {%- if pl -%}<a class="lesson__chip" href="{{ base | append: slug | append: '/' | relative_url }}">{{ pl.title }}</a>{%- endif -%}
             {%- endfor -%}
           </p>
         {%- endif -%}

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -952,6 +952,46 @@ a.category-chip:hover {
 .learn-journey__title { font-size: 1.4rem; font-weight: 600; margin: 0 0 0.3rem; }
 .learn-journey__lede { margin: 0 0 1.5rem; color: var(--fg-muted); max-width: 48rem; }
 
+/* Learning Paths (optional guidance layer) */
+.learn-paths { margin: 0 0 2.75rem; }
+
+.learn-pathnote {
+  border-left: 3px solid var(--accent);
+  background: var(--accent-soft);
+  padding: 0.7rem 1rem;
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  font-size: 0.92rem;
+  margin: 0 0 1.75rem;
+  max-width: 48rem;
+}
+
+/* "Part of these Learning Paths" backlinks on a module hub */
+.learn-inpaths {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0 0 1.75rem;
+  font-size: 0.9rem;
+}
+.learn-inpaths__label { color: var(--fg-muted); }
+.learn-inpaths__list {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin: 0;
+  padding: 0;
+}
+.learn-inpaths__list a {
+  display: inline-block;
+  padding: 0.2rem 0.6rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  text-decoration: none;
+}
+.learn-inpaths__list a:hover { border-color: var(--accent); }
+
 .journey {
   list-style: none;
   margin: 0;

--- a/docs/learn/ai-software-dev/index.md
+++ b/docs/learn/ai-software-dev/index.md
@@ -1,6 +1,6 @@
 ---
 layout: learn-hub
-learn_path: ai-software-dev
+learn_module: ai-software-dev
 permalink: /learn/ai-software-dev/
 title: Intro to Using AI in Software Development — from how models work to shipping with them
 description: A free, structured learning path on using AI to write software — how large language models work and are trained, how context windows work, the providers and models for coding and what they cost, the ways to use AI (app, IDE, agent), prompting and config files, and how to choose your own stack and start today.

--- a/docs/learn/building-ai/index.md
+++ b/docs/learn/building-ai/index.md
@@ -1,6 +1,6 @@
 ---
 layout: learn-hub
-learn_path: building-ai
+learn_module: building-ai
 permalink: /learn/building-ai/
 title: Building AI Into Your Software — from your first API call to a feature you ship
 description: A free, structured path to building AI-powered features into your own software — model APIs, prompts in code, structured output and tools, retrieval (RAG), agents, evaluation, security, and shipping to production.

--- a/docs/learn/cybersecurity/index.md
+++ b/docs/learn/cybersecurity/index.md
@@ -1,6 +1,6 @@
 ---
 layout: learn-hub
-learn_path: cybersecurity
+learn_module: cybersecurity
 permalink: /learn/cybersecurity/
 title: Cybersecurity Fundamentals — from threats and crypto to defending real systems
 description: A free, structured, defender-focused path through cybersecurity — the CIA triad, cryptography, authentication and access, the common attacks explained so you can defend against them, hardening, secure coding, and the ethics of wireless and RF monitoring.

--- a/docs/learn/digital-trunking/index.md
+++ b/docs/learn/digital-trunking/index.md
@@ -1,6 +1,6 @@
 ---
 layout: learn-hub
-learn_path: digital-trunking
+learn_module: digital-trunking
 permalink: /learn/digital-trunking/
 title: Learn Digital & Trunked Radio — from analog roots to decoding every system
 description: A free, structured learning path on digital and digital-trunking radio systems — the history of trunking and digital voice, the end-to-end digital signal chain, and every trunked system GopherTrunk decodes (P25, DMR, TETRA, NXDN, Motorola, EDACS, LTR, MPT-1327).

--- a/docs/learn/git/index.md
+++ b/docs/learn/git/index.md
@@ -1,6 +1,6 @@
 ---
 layout: learn-hub
-learn_path: git
+learn_module: git
 permalink: /learn/git/
 title: Learn Git & GitHub — from first commit to advanced workflows
 description: A free, structured learning path covering Git and GitHub from the absolute basics to advanced workflows — commits, branching, merging, remotes, pull requests, GitHub Actions, and the best practices professional teams rely on.

--- a/docs/learn/index.md
+++ b/docs/learn/index.md
@@ -1,7 +1,7 @@
 ---
 layout: learn-index
 title: Learn
-lede: Free, structured learning paths that take you from complete beginner to confident practitioner — one short, self-contained lesson at a time.
+lede: Free, structured modules that take you from complete beginner to confident practitioner — with optional Learning Paths to guide your route, one short lesson at a time.
 description: Free, structured GopherTrunk learning paths — radio & SDR fundamentals, a complete Git & GitHub course, the Linux command line, computer networking & the internet, cybersecurity fundamentals, an intro to software development, digital & trunked radio, an intro to hardware, using AI in software development, and building AI features into your own software — taking you from beginner to expert one short lesson at a time.
 keywords: GopherTrunk learn, SDR tutorial, learn git, github tutorial, learn linux, command line tutorial, bash, learn networking, how the internet works, TCP IP, DNS, learn cybersecurity, security fundamentals, encryption, radio fundamentals, learn software development, programming for beginners, learn computer hardware, hardware for developers, using AI for coding, AI software development, build AI features, LLM app development, learn LLMs, free courses
 permalink: /learn/
@@ -13,12 +13,15 @@ itself: a software-defined-radio trunking scanner built in Go. Getting there
 touches a lot of ground — how radio works, how signals become numbers, how
 software is designed and version-controlled, the hardware it runs on, how
 modern AI tools fit into the workflow, and how to build AI features into your
-own software. Each path below covers one of those pieces, in plain language, one
-short lesson at a time.
+own software. Each **module** below covers one of those pieces, in plain
+language, one short lesson at a time. Not sure what order to take them in? A
+**Learning Path** is an optional guide that recommends a route through several
+modules toward competence in a bigger area, like RF software or hardware.
 
-You don't have to take them in order, and you don't have to finish them all to
+You don't have to follow a path, take modules in order, or finish them all to
 build something. Start where you're weakest, follow the **journey** from first
 principles to a finished application, and watch your **progress** fill in as you
-go. Everything is saved in your browser — pick up any path exactly where you
-left off, or reset one to start over. Lessons are self-contained and
+go. Your progress is saved in your browser — and to your account when you're
+signed in, so it follows you across devices. Pick up any module exactly where
+you left off, or reset one to start over. Lessons are self-contained and
 cross-linked, so you can read straight through or jump to just what you need.

--- a/docs/learn/intro-hardware/index.md
+++ b/docs/learn/intro-hardware/index.md
@@ -1,6 +1,6 @@
 ---
 layout: learn-hub
-learn_path: intro-hardware
+learn_module: intro-hardware
 permalink: /learn/intro-hardware/
 title: Intro to Hardware — from the cloud to the microcontroller
 description: A free, structured learning path covering the hardware a developer chooses between — web hosting, VPSes, dedicated and home servers, desktops, laptops, smartphones, tablets, single-board computers like the Raspberry Pi, and microcontrollers like the Arduino and ESP32 — with the use cases, programming languages, and trade-offs of each, plus how to pick the right platform for your project.

--- a/docs/learn/intro-software-dev/index.md
+++ b/docs/learn/intro-software-dev/index.md
@@ -1,6 +1,6 @@
 ---
 layout: learn-hub
-learn_path: intro-software-dev
+learn_module: intro-software-dev
 permalink: /learn/intro-software-dev/
 title: Intro to Software Development — from punch cards to your own solo stack
 description: A free, structured learning path covering software development from the ground up — its history, modern programming languages and their trade-offs, design principles and patterns, how teams ship, how to choose the right language, and how to build and distribute your own software solo.

--- a/docs/learn/linux-cli/index.md
+++ b/docs/learn/linux-cli/index.md
@@ -1,6 +1,6 @@
 ---
 layout: learn-hub
-learn_path: linux-cli
+learn_module: linux-cli
 permalink: /learn/linux-cli/
 title: Linux & the Command Line — from first command to confident operator
 description: A free, structured path from your first terminal command to running your own Linux services — the shell, filesystem, permissions, processes, pipes, scripting, SSH, and systemd, with a Raspberry Pi and GopherTrunk as the payoff.

--- a/docs/learn/networking/index.md
+++ b/docs/learn/networking/index.md
@@ -1,6 +1,6 @@
 ---
 layout: learn-hub
-learn_path: networking
+learn_module: networking
 permalink: /learn/networking/
 title: Networking & the Internet — from your first packet to a service on the open web
 description: A free, structured path through how data actually moves — packets, IP, DNS, ports, TCP, UDP, HTTP, and TLS — plus firewalls, NAT, VPNs, proxies, the command-line tools to debug a connection, and how to put your own service safely online.

--- a/docs/learn/paths/ai-development/index.md
+++ b/docs/learn/paths/ai-development/index.md
@@ -1,0 +1,13 @@
+---
+layout: learn-path
+learn_path_id: ai-development
+permalink: /learn/paths/ai-development/
+title: "Learning Path — AI Software Development"
+description: A guided, optional route through the learning modules for building software with and powered by modern AI — from software foundations to shipping AI-powered applications.
+keywords: AI software development, build AI applications, AI-assisted coding, learn AI development
+---
+
+Modern AI shows up in software two ways: as a tool that helps you build, and as
+the engine inside the product. These modules take you from solid software
+foundations to doing both. Follow them in order, or jump to what you need — none
+is a prerequisite for the others here.

--- a/docs/learn/paths/rf-hardware/index.md
+++ b/docs/learn/paths/rf-hardware/index.md
@@ -1,0 +1,13 @@
+---
+layout: learn-path
+learn_path_id: rf-hardware
+permalink: /learn/paths/rf-hardware/
+title: "Learning Path — RF Hardware"
+description: A guided, optional route through the learning modules that build RF hardware competence — signals, the physical devices that capture and move them, and how RF links carry data.
+keywords: RF hardware, SDR front end, antennas, radio hardware, learn RF hardware
+---
+
+The hardware side of RF is about the physical chain that puts a signal in front
+of your software: what a signal is, the devices that capture and move it, and how
+RF ultimately carries data. Work the modules below in order, or dip into the ones
+you need.

--- a/docs/learn/paths/rf-software-dev/index.md
+++ b/docs/learn/paths/rf-software-dev/index.md
@@ -1,0 +1,14 @@
+---
+layout: learn-path
+learn_path_id: rf-software-dev
+permalink: /learn/paths/rf-software-dev/
+title: "Learning Path — RF Software Development"
+description: A guided, optional route through GopherTrunk's learning modules toward competence in RF and SDR software development — from radio fundamentals to decoding digital trunked voice in code.
+keywords: RF software development, SDR programming, learn to build SDR software, digital trunking decoder, GopherTrunk learning path
+---
+
+Building software that turns raw radio into decoded data pulls together several
+skills: the physics of the signal, the craft of writing and shipping code, and
+the specifics of how trunked systems work. The modules below are ordered to take
+you through all of it. None is required on its own — this path just points the
+way.

--- a/docs/learn/paths/security/index.md
+++ b/docs/learn/paths/security/index.md
@@ -1,0 +1,13 @@
+---
+layout: learn-path
+learn_path_id: security
+permalink: /learn/paths/security/
+title: "Learning Path — Cybersecurity"
+description: A guided, optional route through the learning modules that build toward security competence — the systems and network knowledge defense rests on, then the security discipline itself.
+keywords: cybersecurity learning path, learn security, network security, linux security, security fundamentals
+---
+
+You can't defend what you don't understand. This path builds the systems and
+network knowledge that security rests on, then moves into the security discipline
+itself. The order below is a recommendation — take the modules in whatever
+sequence fits what you already know.

--- a/docs/learn/paths/software-engineering/index.md
+++ b/docs/learn/paths/software-engineering/index.md
@@ -1,0 +1,12 @@
+---
+layout: learn-path
+learn_path_id: software-engineering
+permalink: /learn/paths/software-engineering/
+title: "Learning Path — Software Engineering Foundations"
+description: A guided, optional route through the learning modules that make a well-rounded developer — the craft of building software, version control, the command line, networking, and licensing.
+keywords: software engineering foundations, learn to code, git, linux command line, software licensing
+---
+
+Becoming a well-rounded developer means more than writing code: it's the tools,
+the systems your code runs on, and the rules for shipping it. These modules give
+you that grounding. This is a suggested order — every module also stands alone.

--- a/docs/learn/paths/trunked-radio/index.md
+++ b/docs/learn/paths/trunked-radio/index.md
@@ -1,0 +1,13 @@
+---
+layout: learn-path
+learn_path_id: trunked-radio
+permalink: /learn/paths/trunked-radio/
+title: "Learning Path — Digital Trunking & Scanning"
+description: A guided, optional route through the learning modules that take you from your first radio wave to following live digital trunked voice systems the way GopherTrunk decodes them.
+keywords: digital trunking, trunked radio scanning, P25 DMR trunking, learn trunked radio, GopherTrunk
+---
+
+This is the fastest route from "what is a radio wave?" to following live trunked
+voice systems. The modules below cover the signal, how trunked control and voice
+channels work, and the hardware that feeds a scanner. Guidance only — start
+wherever makes sense for you.

--- a/docs/learn/rf-sdr/index.md
+++ b/docs/learn/rf-sdr/index.md
@@ -1,6 +1,6 @@
 ---
 layout: learn-hub
-learn_path: rf-sdr
+learn_module: rf-sdr
 permalink: /learn/rf-sdr/
 title: Learn RF & SDR — from newbie to expert
 description: A free, structured learning path covering radio and software-defined-radio (SDR) fundamentals — frequency, modulation, IQ data, DSP, and digital trunked radio — taking you from complete beginner to confident GopherTrunk operator.

--- a/docs/learn/software-licensing/index.md
+++ b/docs/learn/software-licensing/index.md
@@ -1,6 +1,6 @@
 ---
 layout: learn-hub
-learn_path: software-licensing
+learn_module: software-licensing
 permalink: /learn/software-licensing/
 title: Software Licensing & Agreements — from open source to selling your own
 description: A free, structured learning path on software licensing and agreements — every license type from open source to proprietary, the open-source licenses in depth, writing a commercial license, using open source in software you sell, how to read an agreement, EULAs, terms of service, privacy and SLA terms, and choosing the right license and agreements for your own software.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -11,19 +11,26 @@ sitemap: false
 > The site also hosts a free, structured learning path that teaches radio and SDR
 > fundamentals from beginner to expert.
 
-## Learn (learning paths)
+## Learn
 
 Free, structured curricula taking a complete newcomer to a confident
 practitioner. Browse: {{ '/learn/' | absolute_url }}
-{% for path in site.data.learn.paths %}{% assign base = '/learn/' | append: path.id | append: '/' %}
-## Learn {{ path.label }} (learning path)
+
+### Learning paths (optional guides)
+
+Each Learning Path recommends an ordered set of modules toward competence in a
+broad domain. Guidance only — no module is required.
+{% for lp in site.data.learn.learning_paths %}- [{{ lp.label }}]({{ '/learn/paths/' | append: lp.id | append: '/' | absolute_url }}): {{ lp.tagline }}
+{% endfor %}
+{% for path in site.data.learn.modules %}{% assign base = '/learn/' | append: path.id | append: '/' %}
+## Learn {{ path.label }} (learning module)
 
 {{ path.intro }}
 Start: {{ base | absolute_url }}
-{% for mod in path.modules %}
-### {{ mod.label }}
-{{ mod.blurb }}
-{% for lesson in mod.lessons %}- [{{ lesson.title }}]({{ base | append: lesson.slug | append: '/' | absolute_url }}): {{ lesson.summary }}
+{% for unit in path.units %}
+### {{ unit.label }}
+{{ unit.blurb }}
+{% for lesson in unit.lessons %}- [{{ lesson.title }}]({{ base | append: lesson.slug | append: '/' | absolute_url }}): {{ lesson.summary }}
 {% endfor %}{% endfor %}{% if path.glossary %}### Glossary
 - [{{ path.glossary.title }}]({{ base | append: 'glossary/' | absolute_url }}): {{ path.glossary.summary }}
 {% endif %}{% endfor %}

--- a/docs/sitemap-page.md
+++ b/docs/sitemap-page.md
@@ -28,9 +28,19 @@ Google Search Console.
 
 ## Learn
 
-Structured learning paths. See [all learning paths]({{ '/learn/' | relative_url }}).
+Structured learning content. See [all learning]({{ '/learn/' | relative_url }}).
 
-{%- for path in site.data.learn.paths %}
+### Learning paths
+
+Optional guided routes through several modules toward competence in a domain.
+
+<ul>
+{%- for lp in site.data.learn.learning_paths -%}
+  <li><a href="{{ '/learn/paths/' | append: lp.id | append: '/' | relative_url }}">{{ lp.title }}</a></li>
+{%- endfor -%}
+</ul>
+
+{%- for path in site.data.learn.modules %}
 ### {{ path.title }}
 
 <ul>

--- a/supabase/migrations/20260718155556_initial_schema.sql
+++ b/supabase/migrations/20260718155556_initial_schema.sql
@@ -90,11 +90,15 @@ create trigger on_auth_user_created
 
 -- ---------------------------------------------------------------------------
 -- learn_progress — one row per completed lesson, private to the user.
--- Matches the client store: key is (user_id, path_id, slug).
+-- Matches the client store: key is (user_id, path_id, slug). `path_id` holds a
+-- learning-MODULE id (e.g. "rf-sdr"). The site's "learning paths" are an optional
+-- guidance layer with no rows of their own — path progress is derived from the
+-- referenced modules' completions. Module ids are append-only, so these rows
+-- stay valid across learning-content restructures.
 -- ---------------------------------------------------------------------------
 create table if not exists public.learn_progress (
   user_id      uuid not null references auth.users (id) on delete cascade,
-  path_id      text not null,
+  path_id      text not null,  -- learning-module id (append-only); not a "learning path"
   slug         text not null,
   completed_at timestamptz not null default now(),
   primary key (user_id, path_id, slug)


### PR DESCRIPTION
Restructure the learning section into a 4-level hierarchy:
Learning Path → Learning Module → Unit → Lesson.

- New optional, guidance-only Learning Paths (RF Software Development, RF
  Hardware, Software Engineering Foundations, AI Software Development,
  Cybersecurity, Digital Trunking & Scanning) that recommend an ordered set of
  modules toward competence in a broad domain. They reference modules by id
  (so a module can appear in several paths) and require nothing. New
  learn-path layout + /learn/paths/<id>/ guide pages, plus "Part of these
  Learning Paths" backlinks on each module hub.
- Rename the former "paths" to Learning Modules and their internal "Module N"
  groupings to Units across data, templates, config, llms.txt, sitemap, nav.
- All module ids/URLs are unchanged, so lesson URLs stay stable and the
  Supabase learn_progress table (keyed on module id + slug) is preserved with
  no migration. Path progress is derived client-side from the modules'
  already-synced completions — no new storage, reusing the existing learn.js
  data hooks.
- Add lesson-layout config scopes for linux-cli, networking, cybersecurity,
  and building-ai, which previously had none (their lessons rendered without
  the lesson layout or nav).
- Fix a pre-existing variable-shadowing bug in the lesson.html prereq loop.

Verified locally: Jekyll build is clean (no Liquid errors) and the
check_site_pages sitemap guard passes.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HLLxBdo8yiniSg2ymuARJm