### PR TITLE
blog: add 'Recording, Composition & Streaming' deep-dive series (14 parts)

### DIFF
--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -125,6 +125,8 @@ groups:
         url: /blog/series/protocol-decoders/
       - title: "Series: Voice Coding"
         url: /blog/series/voice-coding/
+      - title: "Series: Recording, Composition & Streaming"
+        url: /blog/series/recording-streaming/
       - title: Tutorials
         url: /blog/category/tutorials/
       - title: "Series: Signal Lab"

--- a/docs/_posts/2026-05-27-welcome-to-the-gophertrunk-blog.md
+++ b/docs/_posts/2026-05-27-welcome-to-the-gophertrunk-blog.md
@@ -29,6 +29,35 @@ The blog is organized into four categories:
   step-by-step guides for getting things done: building a control-channel
   hunt, importing PDFs of frequency lists, setting up the web console.
 
+<figure class="lab-figure">
+<svg viewBox="0 0 640 172" width="640" height="172" role="img" aria-label="A map of the GopherTrunk blog: one hub labeled 'the blog' branches to four category boxes — Announcements (project news and milestones), Releases (version write-ups), Deep dives (protocol and DSP internals), and Tutorials (step-by-step guides).">
+  <rect x="16" y="66" width="120" height="42" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="76" y="85" text-anchor="middle" fill="var(--accent)" font-size="11">the blog</text>
+  <text x="76" y="99" text-anchor="middle" fill="var(--fg-muted)" font-size="9">four categories</text>
+  <line x1="136" y1="80" x2="180" y2="30" stroke="currentColor"/><polygon points="176,26 186,28 180,37" fill="currentColor"/>
+  <line x1="136" y1="84" x2="180" y2="66" stroke="currentColor"/><polygon points="176,62 186,66 176,71" fill="currentColor"/>
+  <line x1="136" y1="90" x2="180" y2="102" stroke="currentColor"/><polygon points="176,97 186,104 176,107" fill="currentColor"/>
+  <line x1="136" y1="94" x2="180" y2="140" stroke="currentColor"/><polygon points="177,133 186,142 173,142" fill="currentColor"/>
+  <rect x="186" y="12" width="230" height="30" rx="5" fill="none" stroke="currentColor"/>
+  <text x="200" y="27" fill="currentColor" font-size="10">Announcements</text>
+  <text x="200" y="38" fill="var(--fg-muted)" font-size="8">project news · milestones</text>
+  <rect x="186" y="50" width="230" height="30" rx="5" fill="none" stroke="currentColor"/>
+  <text x="200" y="65" fill="currentColor" font-size="10">Releases</text>
+  <text x="200" y="76" fill="var(--fg-muted)" font-size="8">per-version write-ups</text>
+  <rect x="186" y="88" width="230" height="30" rx="5" fill="none" stroke="currentColor"/>
+  <text x="200" y="103" fill="currentColor" font-size="10">Deep dives</text>
+  <text x="200" y="114" fill="var(--fg-muted)" font-size="8">protocols · DSP · internals</text>
+  <rect x="186" y="126" width="230" height="30" rx="5" fill="none" stroke="currentColor"/>
+  <text x="200" y="141" fill="currentColor" font-size="10">Tutorials</text>
+  <text x="200" y="152" fill="var(--fg-muted)" font-size="8">step-by-step guides</text>
+  <rect x="440" y="50" width="184" height="68" rx="6" fill="none" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <text x="532" y="80" text-anchor="middle" fill="var(--fg-muted)" font-size="9">RSS feed · check back</text>
+  <text x="532" y="94" text-anchor="middle" fill="var(--fg-muted)" font-size="9">new posts show up</text>
+  <line x1="416" y1="84" x2="440" y2="84" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+</svg>
+<figcaption>What's on this blog: one home, four categories — Announcements, Releases, Deep dives, and Tutorials — each reachable from the index and the RSS feed.</figcaption>
+</figure>
+
 ## How to follow along
 
 The blog has an [RSS feed]({{ '/feed.xml' | relative_url }}) — point

--- a/docs/_posts/2026-06-03-sdr-internals-01-what-is-software-defined-radio.md
+++ b/docs/_posts/2026-06-03-sdr-internals-01-what-is-software-defined-radio.md
@@ -40,6 +40,33 @@ program." That is the whole premise of GopherTrunk: a P25, DMR, TETRA, NXDN and
 multi-protocol trunking scanner where every block — from the USB driver to the
 voice codec — is Go code.
 
+<figure class="lab-figure">
+<svg viewBox="0 0 660 150" width="660" height="150" role="img" aria-label="A software-defined radio block diagram split into a hardware half and a software half. The hardware dongle chain is antenna, then RF front-end, then ADC; a dashed boundary separates it from the software half, where the ADC output becomes IQ samples fed into software DSP and finally audio.">
+  <text x="144" y="26" text-anchor="middle" fill="var(--fg-muted)" font-size="10">hardware (the dongle)</text>
+  <text x="467" y="26" text-anchor="middle" fill="var(--fg-muted)" font-size="10">software (a program)</text>
+  <rect x="10" y="58" width="64" height="40" rx="6" fill="none" stroke="currentColor"/>
+  <text x="42" y="82" text-anchor="middle" fill="currentColor" font-size="10">antenna</text>
+  <line x1="74" y1="78" x2="88" y2="78" stroke="currentColor"/><polygon points="88,74 96,78 88,82" fill="currentColor"/>
+  <rect x="96" y="58" width="96" height="40" rx="6" fill="none" stroke="currentColor"/>
+  <text x="144" y="82" text-anchor="middle" fill="currentColor" font-size="10">RF front-end</text>
+  <line x1="192" y1="78" x2="206" y2="78" stroke="currentColor"/><polygon points="206,74 214,78 206,82" fill="currentColor"/>
+  <rect x="214" y="58" width="64" height="40" rx="6" fill="none" stroke="currentColor"/>
+  <text x="246" y="82" text-anchor="middle" fill="currentColor" font-size="10">ADC</text>
+  <line x1="289" y1="18" x2="289" y2="132" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <line x1="278" y1="78" x2="292" y2="78" stroke="currentColor"/><polygon points="292,74 300,78 292,82" fill="currentColor"/>
+  <rect x="300" y="58" width="104" height="40" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="352" y="76" text-anchor="middle" fill="var(--accent)" font-size="10">IQ samples</text>
+  <text x="352" y="90" text-anchor="middle" fill="var(--fg-muted)" font-size="8">[]complex64</text>
+  <line x1="404" y1="78" x2="418" y2="78" stroke="currentColor"/><polygon points="418,74 426,78 418,82" fill="currentColor"/>
+  <rect x="426" y="58" width="110" height="40" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="481" y="82" text-anchor="middle" fill="var(--accent)" font-size="10">software DSP</text>
+  <line x1="536" y1="78" x2="550" y2="78" stroke="currentColor"/><polygon points="550,74 558,78 550,82" fill="currentColor"/>
+  <rect x="558" y="58" width="76" height="40" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="596" y="82" text-anchor="middle" fill="var(--fg-muted)" font-size="10">audio</text>
+</svg>
+<figcaption>Software-defined radio digitizes the spectrum as early as possible: the dongle only carries the signal to the ADC, and everything after the IQ samples — tuning, filtering, demodulation — is just a program.</figcaption>
+</figure>
+
 > New to the fundamentals? See the reference entries on
 > [software-defined radio]({{ '/reference/software-defined-radio/' | relative_url }})
 > and [IQ data]({{ '/reference/iq-data/' | relative_url }}), or the learn-path
@@ -73,6 +100,31 @@ The single most important architectural decision in GopherTrunk is that
 DSP knows nothing about protocols, protocols know nothing about the trunking
 engine, and the engine knows nothing about the API, storage, or UI that consume
 its output.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 470 240" width="470" height="240" role="img" aria-label="The GopherTrunk layered architecture as a five-level stack. From bottom to top: internal/sdr producing IQ samples, internal/dsp producing symbols, internal/radio doing protocol decode, internal/trunking plus internal/events publishing domain events, and internal/api plus internal/voice emitting audio. Data flows upward through typed channels, while all package dependencies point one way, downward.">
+  <rect x="40" y="14" width="300" height="34" rx="6" fill="none" stroke="currentColor"/>
+  <text x="190" y="30" text-anchor="middle" fill="currentColor" font-size="10">internal/api · internal/voice</text>
+  <text x="190" y="42" text-anchor="middle" fill="var(--fg-muted)" font-size="8">audio out</text>
+  <rect x="40" y="58" width="300" height="34" rx="6" fill="none" stroke="currentColor"/>
+  <text x="190" y="74" text-anchor="middle" fill="currentColor" font-size="10">internal/trunking · internal/events</text>
+  <text x="190" y="86" text-anchor="middle" fill="var(--fg-muted)" font-size="8">domain events</text>
+  <rect x="40" y="102" width="300" height="34" rx="6" fill="none" stroke="currentColor"/>
+  <text x="190" y="118" text-anchor="middle" fill="currentColor" font-size="10">internal/radio</text>
+  <text x="190" y="130" text-anchor="middle" fill="var(--fg-muted)" font-size="8">protocol decode</text>
+  <rect x="40" y="146" width="300" height="34" rx="6" fill="none" stroke="currentColor"/>
+  <text x="190" y="162" text-anchor="middle" fill="currentColor" font-size="10">internal/dsp</text>
+  <text x="190" y="174" text-anchor="middle" fill="var(--fg-muted)" font-size="8">symbols</text>
+  <rect x="40" y="190" width="300" height="34" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="190" y="206" text-anchor="middle" fill="var(--accent)" font-size="10">internal/sdr</text>
+  <text x="190" y="218" text-anchor="middle" fill="var(--fg-muted)" font-size="8">IQ samples</text>
+  <line x1="20" y1="224" x2="20" y2="18" stroke="currentColor"/><polygon points="16,26 20,14 24,26" fill="currentColor"/>
+  <text x="12" y="120" text-anchor="middle" fill="var(--fg-muted)" font-size="9" transform="rotate(-90 12 120)">data flows up (channels)</text>
+  <line x1="360" y1="18" x2="360" y2="224" stroke="var(--fg-muted)"/><polygon points="356,216 360,228 364,216" fill="var(--fg-muted)"/>
+  <text x="378" y="120" text-anchor="middle" fill="var(--fg-muted)" font-size="9" transform="rotate(90 378 120)">dependencies point down</text>
+</svg>
+<figcaption>Every layer depends only downward — the SDR layer knows nothing about DSP, DSP nothing about protocols — while IQ data flows up through typed channels from <code>internal/sdr</code> to <code>internal/api</code>.</figcaption>
+</figure>
 
 ### How that principle shaped the Go code
 

--- a/docs/_posts/2026-06-04-sdr-internals-02-sdr-device-driver-registry.md
+++ b/docs/_posts/2026-06-04-sdr-internals-02-sdr-device-driver-registry.md
@@ -90,6 +90,30 @@ This is **dependency inversion**: the high-level engine depends on the abstract
 contracts by registering themselves. The arrow points the "wrong" way on
 purpose.
 
+<figure class="lab-figure">
+<svg viewBox="0 0 520 180" width="520" height="180" role="img" aria-label="Four SDR driver packages — rtlsdr/purego, hackrf, airspy, and airspyhf — each call sdr.Register from their init function at import time, populating a single process-global registry that is a map from driver name to Driver.">
+  <text x="85" y="14" text-anchor="middle" fill="var(--fg-muted)" font-size="10">init() at import</text>
+  <rect x="10" y="22" width="150" height="26" rx="6" fill="none" stroke="currentColor"/>
+  <text x="85" y="39" text-anchor="middle" fill="currentColor" font-size="10">rtlsdr/purego</text>
+  <rect x="10" y="54" width="150" height="26" rx="6" fill="none" stroke="currentColor"/>
+  <text x="85" y="71" text-anchor="middle" fill="currentColor" font-size="10">hackrf</text>
+  <rect x="10" y="86" width="150" height="26" rx="6" fill="none" stroke="currentColor"/>
+  <text x="85" y="103" text-anchor="middle" fill="currentColor" font-size="10">airspy</text>
+  <rect x="10" y="118" width="150" height="26" rx="6" fill="none" stroke="currentColor"/>
+  <text x="85" y="135" text-anchor="middle" fill="currentColor" font-size="10">airspyhf</text>
+  <line x1="160" y1="35" x2="290" y2="55" stroke="currentColor"/><polygon points="290,51 300,55 290,59" fill="currentColor"/>
+  <line x1="160" y1="67" x2="290" y2="75" stroke="currentColor"/><polygon points="290,71 300,75 290,79" fill="currentColor"/>
+  <line x1="160" y1="99" x2="290" y2="95" stroke="currentColor"/><polygon points="290,91 300,95 290,99" fill="currentColor"/>
+  <line x1="160" y1="131" x2="290" y2="115" stroke="currentColor"/><polygon points="290,111 300,115 290,119" fill="currentColor"/>
+  <rect x="300" y="30" width="200" height="110" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="400" y="52" text-anchor="middle" fill="var(--fg-muted)" font-size="8">internal/sdr/registry.go</text>
+  <text x="400" y="82" text-anchor="middle" fill="var(--accent)" font-size="12">registry</text>
+  <text x="400" y="102" text-anchor="middle" fill="var(--accent)" font-size="11">map[string]Driver</text>
+  <text x="400" y="124" text-anchor="middle" fill="var(--fg-muted)" font-size="9">sdr.Register(d)</text>
+</svg>
+<figcaption>Each driver package calls <code>sdr.Register</code> from its <code>init()</code>, so the binary's blank-import set — not a switch statement — decides which hardware the registry knows about.</figcaption>
+</figure>
+
 ### How that principle shaped the Go code
 
 - **Blank imports choose the hardware.** `cmd/gophertrunk` blank-imports the
@@ -103,6 +127,30 @@ purpose.
   that satisfies `Device` and calls `Register` — no existing file changes. The
   same hook is how the baseband-replay "virtual tuner" mounts recorded WAVs as
   if they were real dongles.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 130" width="680" height="130" role="img" aria-label="The runtime lookup flow: the engine calls sdr.DriverByName to enumerate and pick a driver, calls Open on that Driver to get a Device, and calls StreamIQ on the Device interface to obtain a receive-only channel of complex64 IQ chunks.">
+  <rect x="8" y="50" width="68" height="40" rx="6" fill="none" stroke="currentColor"/>
+  <text x="42" y="74" text-anchor="middle" fill="currentColor" font-size="10">engine</text>
+  <line x1="76" y1="70" x2="90" y2="70" stroke="currentColor"/><polygon points="90,66 98,70 90,74" fill="currentColor"/>
+  <rect x="98" y="50" width="138" height="40" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="167" y="68" text-anchor="middle" fill="var(--accent)" font-size="10">sdr.DriverByName()</text>
+  <text x="167" y="82" text-anchor="middle" fill="var(--fg-muted)" font-size="8">enumerate → pick</text>
+  <line x1="236" y1="70" x2="250" y2="70" stroke="currentColor"/><polygon points="250,66 258,70 250,74" fill="currentColor"/>
+  <rect x="258" y="50" width="84" height="40" rx="6" fill="none" stroke="currentColor"/>
+  <text x="300" y="68" text-anchor="middle" fill="currentColor" font-size="10">Driver</text>
+  <text x="300" y="82" text-anchor="middle" fill="var(--fg-muted)" font-size="8">Open(serial)</text>
+  <line x1="342" y1="70" x2="356" y2="70" stroke="currentColor"/><polygon points="356,66 364,70 356,74" fill="currentColor"/>
+  <rect x="364" y="50" width="84" height="40" rx="6" fill="none" stroke="currentColor"/>
+  <text x="406" y="68" text-anchor="middle" fill="currentColor" font-size="10">Device</text>
+  <text x="406" y="82" text-anchor="middle" fill="var(--fg-muted)" font-size="8">one interface</text>
+  <line x1="448" y1="70" x2="462" y2="70" stroke="currentColor"/><polygon points="462,66 470,70 462,74" fill="currentColor"/>
+  <rect x="470" y="50" width="200" height="40" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="570" y="68" text-anchor="middle" fill="var(--accent)" font-size="10">StreamIQ(ctx)</text>
+  <text x="570" y="82" text-anchor="middle" fill="var(--fg-muted)" font-size="8">&lt;-chan []complex64</text>
+</svg>
+<figcaption>Enumerate, open, stream: the engine names a driver, opens it into a <code>Device</code>, and only ever touches the <code>Device</code> interface — it never imports <code>rtlsdr</code>, <code>hackrf</code>, or <code>airspy</code>.</figcaption>
+</figure>
 
 The registry pattern is one of the most reused ideas in the codebase — you'll
 see it again for vocoders in

--- a/docs/_posts/2026-06-05-sdr-internals-03-sdr-pool-streaming-concurrency.md
+++ b/docs/_posts/2026-06-05-sdr-internals-03-sdr-pool-streaming-concurrency.md
@@ -70,6 +70,31 @@ const (
 )
 ```
 
+<figure class="lab-figure">
+<svg viewBox="0 0 560 190" width="560" height="190" role="img" aria-label="The SDR pool enumerates and opens several USB dongles, then hands the engine role-tagged devices. Three dongles feed one internal/sdr Pool, which assigns roles and runs a watchdog that re-enumerates on disconnect, and exposes RoleControl, RoleVoice, and RoleWideband handles.">
+  <text x="58" y="14" text-anchor="middle" fill="var(--fg-muted)" font-size="10">USB dongles</text>
+  <text x="485" y="14" text-anchor="middle" fill="var(--fg-muted)" font-size="10">roles</text>
+  <rect x="10" y="20" width="96" height="28" rx="6" fill="none" stroke="currentColor"/><text x="58" y="38" text-anchor="middle" fill="currentColor" font-size="10">dongle A</text>
+  <rect x="10" y="64" width="96" height="28" rx="6" fill="none" stroke="currentColor"/><text x="58" y="82" text-anchor="middle" fill="currentColor" font-size="10">dongle B</text>
+  <rect x="10" y="108" width="96" height="28" rx="6" fill="none" stroke="currentColor"/><text x="58" y="126" text-anchor="middle" fill="currentColor" font-size="10">dongle C</text>
+  <line x1="106" y1="34" x2="140" y2="60" stroke="currentColor"/><polygon points="140,56 150,60 140,64" fill="currentColor"/>
+  <line x1="106" y1="78" x2="140" y2="90" stroke="currentColor"/><polygon points="140,86 150,90 140,94" fill="currentColor"/>
+  <line x1="106" y1="122" x2="140" y2="120" stroke="currentColor"/><polygon points="140,116 150,120 140,124" fill="currentColor"/>
+  <rect x="150" y="40" width="150" height="100" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="225" y="70" text-anchor="middle" fill="var(--fg-muted)" font-size="8">internal/sdr/pool.go</text>
+  <text x="225" y="90" text-anchor="middle" fill="var(--accent)" font-size="13">Pool</text>
+  <text x="225" y="108" text-anchor="middle" fill="var(--fg-muted)" font-size="9">assign roles</text>
+  <text x="225" y="122" text-anchor="middle" fill="var(--fg-muted)" font-size="9">watchdog re-enumerates</text>
+  <line x1="300" y1="60" x2="410" y2="34" stroke="currentColor"/><polygon points="410,30 420,34 410,38" fill="currentColor"/>
+  <line x1="300" y1="90" x2="410" y2="78" stroke="currentColor"/><polygon points="410,74 420,78 410,82" fill="currentColor"/>
+  <line x1="300" y1="120" x2="410" y2="122" stroke="currentColor"/><polygon points="410,118 420,122 410,126" fill="currentColor"/>
+  <rect x="420" y="20" width="130" height="28" rx="6" fill="none" stroke="currentColor"/><text x="485" y="38" text-anchor="middle" fill="currentColor" font-size="10">RoleControl</text>
+  <rect x="420" y="64" width="130" height="28" rx="6" fill="none" stroke="currentColor"/><text x="485" y="82" text-anchor="middle" fill="currentColor" font-size="10">RoleVoice</text>
+  <rect x="420" y="108" width="130" height="28" rx="6" fill="none" stroke="currentColor"/><text x="485" y="126" text-anchor="middle" fill="currentColor" font-size="10">RoleWideband</text>
+</svg>
+<figcaption>The <code>Pool</code> herds a fleet of dongles: it enumerates and opens each device through the registry, tags them by role, and a watchdog re-enumerates a bumped cable so the engine asks for "a voice device" instead of juggling serial numbers.</figcaption>
+</figure>
+
 ### The IQ tap: one stream, many readers
 
 Several subsystems want the *same* IQ at once — the decoder, the live spectrum
@@ -81,6 +106,34 @@ primary consumer reads the stream untouched, while secondary subscribers receive
 
 This is fan-out with a deliberate asymmetry: the decoder gets guaranteed
 delivery; observers get best-effort.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 640 200" width="640" height="200" role="img" aria-label="The internal/sdr/iqtap broker fans one IQ stream to many readers. The USB reader goroutine produces chunks into the broker; the broker delivers guaranteed copies to the decoder while sending best-effort copies to the spectrum display and diagnostics, whose frames are dropped and counted if they fall behind.">
+  <rect x="8" y="80" width="120" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="68" y="100" text-anchor="middle" fill="currentColor" font-size="10">USB reader</text>
+  <text x="68" y="114" text-anchor="middle" fill="var(--fg-muted)" font-size="8">StreamIQ chunk</text>
+  <line x1="128" y1="102" x2="158" y2="102" stroke="currentColor"/><polygon points="158,98 168,102 158,106" fill="currentColor"/>
+  <rect x="170" y="76" width="110" height="52" rx="6" fill="none" stroke="currentColor"/>
+  <text x="225" y="98" text-anchor="middle" fill="currentColor" font-size="10">iqtap broker</text>
+  <text x="225" y="112" text-anchor="middle" fill="var(--fg-muted)" font-size="8">fan-out / copy</text>
+  <line x1="280" y1="98" x2="322" y2="34" stroke="currentColor"/><polygon points="318,30 328,32 322,41" fill="currentColor"/>
+  <line x1="280" y1="104" x2="322" y2="106" stroke="currentColor"/><polygon points="322,101 330,105 322,109" fill="currentColor"/>
+  <line x1="280" y1="112" x2="322" y2="168" stroke="currentColor"/><polygon points="318,161 328,170 316,170" fill="currentColor"/>
+  <rect x="330" y="16" width="200" height="34" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="430" y="33" text-anchor="middle" fill="var(--accent)" font-size="10">decoder</text>
+  <text x="430" y="45" text-anchor="middle" fill="var(--fg-muted)" font-size="8">guaranteed delivery</text>
+  <rect x="330" y="88" width="200" height="34" rx="6" fill="none" stroke="currentColor"/>
+  <text x="430" y="105" text-anchor="middle" fill="currentColor" font-size="10">spectrum display</text>
+  <text x="430" y="117" text-anchor="middle" fill="var(--fg-muted)" font-size="8">best-effort</text>
+  <rect x="330" y="150" width="200" height="34" rx="6" fill="none" stroke="currentColor"/>
+  <text x="430" y="167" text-anchor="middle" fill="currentColor" font-size="10">diagnostics</text>
+  <text x="430" y="179" text-anchor="middle" fill="var(--fg-muted)" font-size="8">best-effort</text>
+  <text x="590" y="140" text-anchor="middle" fill="var(--fg-muted)" font-size="9">slow →</text>
+  <text x="590" y="152" text-anchor="middle" fill="var(--fg-muted)" font-size="9">dropped</text>
+  <text x="590" y="164" text-anchor="middle" fill="var(--fg-muted)" font-size="9">&amp; counted</text>
+</svg>
+<figcaption>The tap broker breaks the back-pressure rule on purpose: the decoder is guaranteed every chunk, while a slow spectrum or diagnostics subscriber has its copies dropped and counted so it can never stall the decode path.</figcaption>
+</figure>
 
 ## The design principle: pipes-and-filters with bounded channels
 

--- a/docs/_posts/2026-06-06-sdr-internals-04-dsp-foundations-filters-nco-agc.md
+++ b/docs/_posts/2026-06-06-sdr-internals-04-dsp-foundations-filters-nco-agc.md
@@ -40,6 +40,34 @@ the band. Four primitives fix that:
   dongle's rate and a protocol's symbol clock.
   ([reference]({{ '/reference/resampler/' | relative_url }}))
 
+<figure class="lab-figure">
+<svg viewBox="0 0 680 150" width="680" height="150" role="img" aria-label="The four DSP primitives compose left to right into one signal chain: wideband IQ enters an NCO or mixer that shifts it to baseband, then FIR or CIC filters that filter and decimate, then AGC that levels amplitude to a target, then a resampler that converts to the protocol symbol clock, emitting symbols. Every stage uses the same Process destination-source buffer-reuse convention.">
+  <text x="340" y="20" text-anchor="middle" fill="var(--fg-muted)" font-size="10">Process(dst, src) — buffers reused every chunk</text>
+  <rect x="8" y="52" width="86" height="44" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="51" y="78" text-anchor="middle" fill="var(--fg-muted)" font-size="10">wideband IQ</text>
+  <line x1="94" y1="74" x2="108" y2="74" stroke="currentColor"/><polygon points="108,70 116,74 108,78" fill="currentColor"/>
+  <rect x="116" y="52" width="96" height="44" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="164" y="72" text-anchor="middle" fill="var(--accent)" font-size="10">NCO / mixer</text>
+  <text x="164" y="86" text-anchor="middle" fill="var(--fg-muted)" font-size="8">shift to baseband</text>
+  <line x1="212" y1="74" x2="226" y2="74" stroke="currentColor"/><polygon points="226,70 234,74 226,78" fill="currentColor"/>
+  <rect x="234" y="52" width="96" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="282" y="72" text-anchor="middle" fill="currentColor" font-size="10">FIR / CIC</text>
+  <text x="282" y="86" text-anchor="middle" fill="var(--fg-muted)" font-size="8">filter + decimate</text>
+  <line x1="330" y1="74" x2="344" y2="74" stroke="currentColor"/><polygon points="344,70 352,74 344,78" fill="currentColor"/>
+  <rect x="352" y="52" width="96" height="44" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="400" y="72" text-anchor="middle" fill="var(--accent)" font-size="10">AGC</text>
+  <text x="400" y="86" text-anchor="middle" fill="var(--fg-muted)" font-size="8">level to target</text>
+  <line x1="448" y1="74" x2="462" y2="74" stroke="currentColor"/><polygon points="462,70 470,74 462,78" fill="currentColor"/>
+  <rect x="470" y="52" width="120" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="530" y="72" text-anchor="middle" fill="currentColor" font-size="10">resampler</text>
+  <text x="530" y="86" text-anchor="middle" fill="var(--fg-muted)" font-size="8">L/M to symbol clock</text>
+  <line x1="590" y1="74" x2="604" y2="74" stroke="currentColor"/><polygon points="604,70 612,74 604,78" fill="currentColor"/>
+  <rect x="612" y="52" width="62" height="44" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="643" y="78" text-anchor="middle" fill="var(--fg-muted)" font-size="10">symbols</text>
+</svg>
+<figcaption>The four primitives compose into one chain — mix, filter, level, resample — each a stateful struct driven through the same <code>Process(dst, src)</code> signature so the hot path never allocates.</figcaption>
+</figure>
+
 The learn-path lesson
 [Filtering & decimation]({{ '/learn/rf-sdr/filtering-decimation/' | relative_url }})
 covers the theory; this post is about the code.
@@ -67,6 +95,24 @@ advanced sample by sample so the phasor stays continuous across chunk
 boundaries. The AGC tracks a running magnitude estimate (an exponential moving
 average) and scales toward a target level. The resampler keeps its polyphase
 filter state between calls.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 620 170" width="620" height="170" role="img" aria-label="A signal-level-over-time timeline showing what AGC does. The raw input amplitude sits at noise level, jumps sharply when a transmitter keys up, and later fades. The AGC output is held near a constant target level throughout, with only a brief transient at key-up and at the fade.">
+  <line x1="40" y1="20" x2="40" y2="140" stroke="currentColor"/>
+  <line x1="40" y1="140" x2="600" y2="140" stroke="currentColor"/>
+  <text x="16" y="84" text-anchor="middle" fill="var(--fg-muted)" font-size="9" transform="rotate(-90 16 84)">level</text>
+  <text x="576" y="156" text-anchor="middle" fill="var(--fg-muted)" font-size="9">time →</text>
+  <line x1="40" y1="70" x2="600" y2="70" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <text x="80" y="64" fill="var(--fg-muted)" font-size="9">target level</text>
+  <polyline points="50,120 170,120 180,45 300,50 420,48 432,96 590,102" fill="none" stroke="currentColor"/>
+  <polyline points="50,74 178,74 188,52 214,72 420,72 432,86 462,72 590,72" fill="none" stroke="var(--accent)"/>
+  <text x="185" y="36" text-anchor="middle" fill="var(--fg-muted)" font-size="9">key-up</text>
+  <text x="470" y="118" text-anchor="middle" fill="var(--fg-muted)" font-size="9">fade</text>
+  <text x="120" y="112" fill="currentColor" font-size="9">input amplitude</text>
+  <text x="500" y="64" fill="var(--accent)" font-size="9">AGC output</text>
+</svg>
+<figcaption>AGC tracks a running magnitude estimate and scales toward a target: the input amplitude swings as a transmitter keys up and fades, but downstream slicers see a level held steady near the target.</figcaption>
+</figure>
 
 Factory functions handle the math-heavy design step once, up front:
 `LowpassKaiser(n, fc, beta)`, `RootRaisedCosine(sps, span, alpha)`, and

--- a/docs/_posts/2026-06-07-sdr-internals-05-tuning-channelization.md
+++ b/docs/_posts/2026-06-07-sdr-internals-05-tuning-channelization.md
@@ -32,6 +32,31 @@ shift the channel to baseband with an NCO, low-pass filter it, and
 [decimate]({{ '/reference/decimation/' | relative_url }}) to a manageable rate
 (~48 kHz, the symbol clock for 4800-baud protocols).
 
+<figure class="lab-figure">
+<svg viewBox="0 0 660 150" width="660" height="150" role="img" aria-label="The digital down-converter pipeline for one channel: a wideband IQ capture at 2.4 mega-samples per second is shifted so the wanted channel sits at baseband by an NCO, low-pass filtered to reject the neighbors, then decimated by M, producing a narrowband channel at about 48 kilohertz, the symbol clock.">
+  <rect x="8" y="52" width="110" height="44" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="63" y="72" text-anchor="middle" fill="var(--fg-muted)" font-size="10">wideband IQ</text>
+  <text x="63" y="86" text-anchor="middle" fill="var(--fg-muted)" font-size="8">2.4 MS/s</text>
+  <line x1="118" y1="74" x2="132" y2="74" stroke="currentColor"/><polygon points="132,70 140,74 132,78" fill="currentColor"/>
+  <rect x="142" y="52" width="100" height="44" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="192" y="72" text-anchor="middle" fill="var(--accent)" font-size="10">NCO shift</text>
+  <text x="192" y="86" text-anchor="middle" fill="var(--fg-muted)" font-size="8">channel → baseband</text>
+  <line x1="242" y1="74" x2="256" y2="74" stroke="currentColor"/><polygon points="256,70 264,74 256,78" fill="currentColor"/>
+  <rect x="266" y="52" width="100" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="316" y="72" text-anchor="middle" fill="currentColor" font-size="10">low-pass FIR</text>
+  <text x="316" y="86" text-anchor="middle" fill="var(--fg-muted)" font-size="8">reject neighbors</text>
+  <line x1="366" y1="74" x2="380" y2="74" stroke="currentColor"/><polygon points="380,70 388,74 380,78" fill="currentColor"/>
+  <rect x="390" y="52" width="100" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="440" y="72" text-anchor="middle" fill="currentColor" font-size="10">decimate ↓M</text>
+  <text x="440" y="86" text-anchor="middle" fill="var(--fg-muted)" font-size="8">drop the rate</text>
+  <line x1="490" y1="74" x2="504" y2="74" stroke="currentColor"/><polygon points="504,70 512,74 504,78" fill="currentColor"/>
+  <rect x="514" y="52" width="140" height="44" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="584" y="72" text-anchor="middle" fill="var(--accent)" font-size="10">narrowband channel</text>
+  <text x="584" y="86" text-anchor="middle" fill="var(--fg-muted)" font-size="8">~48 kHz symbol clock</text>
+</svg>
+<figcaption>A digital down-converter tunes "inside the samples": shift the wanted channel to baseband with an NCO, low-pass filter it, and decimate down to the ~48 kHz symbol clock — no extra hardware.</figcaption>
+</figure>
+
 There are two ways to do this for *many* channels at once, and they have
 opposite cost profiles:
 
@@ -66,6 +91,40 @@ type Bank interface {
   input samples, then fine-tunes each bin with a small DDC. Shared cost,
   grid-aligned — ideal when you want many evenly-spaced channels (for example, a
   P25 Phase 1 control channel and its voice channels on one dongle).
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 200" width="660" height="200" role="img" aria-label="One wideband chunk of complex64 samples enters a Bank, whose interface has two interchangeable implementations — DDCBank for arbitrary offsets and ChannelizerBank for grid-aligned channels. The Bank emits several narrowband outputs at once: a P25 Phase 1 control channel and three voice channels, each around 48 kHz, all from the single capture.">
+  <rect x="8" y="84" width="110" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="63" y="104" text-anchor="middle" fill="currentColor" font-size="10">wideband chunk</text>
+  <text x="63" y="118" text-anchor="middle" fill="var(--fg-muted)" font-size="8">[]complex64</text>
+  <line x1="118" y1="106" x2="160" y2="106" stroke="currentColor"/><polygon points="160,102 168,106 160,110" fill="currentColor"/>
+  <rect x="170" y="40" width="180" height="132" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="260" y="56" text-anchor="middle" fill="var(--accent)" font-size="10">Bank.Process()</text>
+  <rect x="182" y="66" width="156" height="42" rx="5" fill="none" stroke="currentColor"/>
+  <text x="260" y="84" text-anchor="middle" fill="currentColor" font-size="10">DDCBank</text>
+  <text x="260" y="98" text-anchor="middle" fill="var(--fg-muted)" font-size="8">any offset</text>
+  <rect x="182" y="116" width="156" height="42" rx="5" fill="none" stroke="currentColor"/>
+  <text x="260" y="134" text-anchor="middle" fill="currentColor" font-size="10">ChannelizerBank</text>
+  <text x="260" y="148" text-anchor="middle" fill="var(--fg-muted)" font-size="8">grid-aligned</text>
+  <line x1="350" y1="92" x2="422" y2="30" stroke="currentColor"/><polygon points="422,26 430,30 422,34" fill="currentColor"/>
+  <line x1="350" y1="100" x2="422" y2="74" stroke="currentColor"/><polygon points="422,70 430,74 422,78" fill="currentColor"/>
+  <line x1="350" y1="112" x2="422" y2="118" stroke="currentColor"/><polygon points="422,114 430,118 422,122" fill="currentColor"/>
+  <line x1="350" y1="120" x2="422" y2="162" stroke="currentColor"/><polygon points="422,158 430,162 422,166" fill="currentColor"/>
+  <rect x="430" y="14" width="210" height="32" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="535" y="30" text-anchor="middle" fill="var(--accent)" font-size="10">control channel</text>
+  <text x="535" y="41" text-anchor="middle" fill="var(--fg-muted)" font-size="8">P25 Phase 1</text>
+  <rect x="430" y="58" width="210" height="32" rx="6" fill="none" stroke="currentColor"/>
+  <text x="535" y="74" text-anchor="middle" fill="currentColor" font-size="10">voice ch A</text>
+  <text x="535" y="85" text-anchor="middle" fill="var(--fg-muted)" font-size="8">~48 kHz</text>
+  <rect x="430" y="102" width="210" height="32" rx="6" fill="none" stroke="currentColor"/>
+  <text x="535" y="118" text-anchor="middle" fill="currentColor" font-size="10">voice ch B</text>
+  <text x="535" y="129" text-anchor="middle" fill="var(--fg-muted)" font-size="8">~48 kHz</text>
+  <rect x="430" y="146" width="210" height="32" rx="6" fill="none" stroke="currentColor"/>
+  <text x="535" y="162" text-anchor="middle" fill="currentColor" font-size="10">voice ch C</text>
+  <text x="535" y="173" text-anchor="middle" fill="var(--fg-muted)" font-size="8">~48 kHz</text>
+</svg>
+<figcaption>One capture, many channels: the <code>Bank</code> interface fronts two strategies — <code>DDCBank</code> for irregular offsets, <code>ChannelizerBank</code> for a regular grid — and pulls a control channel and its voice channels out of a single wideband chunk.</figcaption>
+</figure>
 
 The caller — the wideband voice tuner in `internal/sdr/wbvoice`, or the control
 decoder — picks the implementation based on how many channels it needs and how

--- a/docs/_posts/2026-06-08-sdr-internals-06-demodulation.md
+++ b/docs/_posts/2026-06-08-sdr-internals-06-demodulation.md
@@ -42,6 +42,31 @@ The learn-path lesson
 [The demodulation pipeline]({{ '/learn/rf-sdr/demodulation-pipeline/' | relative_url }})
 gives the visual intuition.
 
+<figure class="lab-figure">
+<svg viewBox="0 0 650 110" width="650" height="110" role="img" aria-label="The shared demodulation pipeline: baseband IQ enters an FM discriminator front-end, whose discriminated signal passes through a matched filter, then a 4-level slicer, producing soft symbols on the plus or minus three, plus or minus one alphabet.">
+  <rect x="8" y="34" width="108" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="62" y="54" text-anchor="middle" fill="currentColor" font-size="11">IQ samples</text>
+  <text x="62" y="68" text-anchor="middle" fill="var(--fg-muted)" font-size="8">baseband</text>
+  <line x1="116" y1="56" x2="134" y2="56" stroke="currentColor"/><polygon points="134,52 144,56 134,60" fill="currentColor"/>
+  <rect x="136" y="34" width="108" height="44" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="190" y="54" text-anchor="middle" fill="var(--accent)" font-size="11">FM discriminator</text>
+  <text x="190" y="68" text-anchor="middle" fill="var(--fg-muted)" font-size="8">shared front-end</text>
+  <line x1="244" y1="56" x2="262" y2="56" stroke="currentColor"/><polygon points="262,52 272,56 262,60" fill="currentColor"/>
+  <rect x="264" y="34" width="108" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="318" y="54" text-anchor="middle" fill="currentColor" font-size="11">matched filter</text>
+  <text x="318" y="68" text-anchor="middle" fill="var(--fg-muted)" font-size="8">RRC / Gaussian</text>
+  <line x1="372" y1="56" x2="390" y2="56" stroke="currentColor"/><polygon points="390,52 400,56 390,60" fill="currentColor"/>
+  <rect x="392" y="34" width="108" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="446" y="54" text-anchor="middle" fill="currentColor" font-size="11">4-level slicer</text>
+  <text x="446" y="68" text-anchor="middle" fill="var(--fg-muted)" font-size="8">to symbol alphabet</text>
+  <line x1="500" y1="56" x2="518" y2="56" stroke="currentColor"/><polygon points="518,52 528,56 518,60" fill="currentColor"/>
+  <rect x="530" y="34" width="112" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="586" y="54" text-anchor="middle" fill="currentColor" font-size="11">soft symbols</text>
+  <text x="586" y="68" text-anchor="middle" fill="var(--fg-muted)" font-size="8">&#177;3, &#177;1</text>
+</svg>
+<figcaption>The C4FM demod pipeline: IQ through the shared FM discriminator, a root-raised-cosine matched filter, and a 4-level slicer to soft symbols &#8212; each stage a Part 4 primitive.</figcaption>
+</figure>
+
 ## How GopherTrunk implements it in Go
 
 Each demodulator is a self-contained stateful struct that takes IQ (or a
@@ -69,6 +94,30 @@ There's also an `AdaptiveC4FM` that adds automatic frequency correction to track
 transmitter drift. Each type is a few dozen lines because the hard work — the
 filters, the oscillator — was already built in
 [Part 4]({{ '/blog/deep-dives/sdr-internals-04-dsp-foundations-filters-nco-agc/' | relative_url }}).
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 196" width="660" height="196" role="img" aria-label="One shared FM discriminator front-end fans out to four matched-filter-and-slicer variants: C4FM with a root-raised-cosine filter and 4-level slicer, GFSK with a Gaussian matched filter, FFSK for audio-band signaling, and pi-over-4 DQPSK for TETRA.">
+  <rect x="8" y="80" width="70" height="36" rx="6" fill="none" stroke="currentColor"/>
+  <text x="43" y="102" text-anchor="middle" fill="currentColor" font-size="10">IQ</text>
+  <line x1="78" y1="98" x2="96" y2="98" stroke="currentColor"/><polygon points="96,94 106,98 96,102" fill="currentColor"/>
+  <rect x="106" y="74" width="120" height="48" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="166" y="94" text-anchor="middle" fill="var(--accent)" font-size="11">FM discriminator</text>
+  <text x="166" y="110" text-anchor="middle" fill="var(--fg-muted)" font-size="8">shared front-end</text>
+  <line x1="226" y1="90" x2="300" y2="30" stroke="currentColor"/><polygon points="296,26 306,29 300,38" fill="currentColor"/>
+  <line x1="226" y1="96" x2="300" y2="76" stroke="currentColor"/><polygon points="296,72 306,75 299,84" fill="currentColor"/>
+  <line x1="226" y1="104" x2="300" y2="122" stroke="currentColor"/><polygon points="299,116 306,124 296,125" fill="currentColor"/>
+  <line x1="226" y1="110" x2="300" y2="168" stroke="currentColor"/><polygon points="298,161 306,170 294,169" fill="currentColor"/>
+  <rect x="306" y="14" width="340" height="32" rx="5" fill="none" stroke="currentColor"/>
+  <text x="318" y="34" fill="currentColor" font-size="10">C4FM &#8212; RRC matched filter + 4-level slicer (P25/DMR/NXDN)</text>
+  <rect x="306" y="60" width="340" height="32" rx="5" fill="none" stroke="currentColor"/>
+  <text x="318" y="80" fill="currentColor" font-size="10">GFSK &#8212; Gaussian matched filter (EDACS)</text>
+  <rect x="306" y="106" width="340" height="32" rx="5" fill="none" stroke="currentColor"/>
+  <text x="318" y="126" fill="currentColor" font-size="10">FFSK &#8212; audio-band FSK (MPT 1327, POCSAG)</text>
+  <rect x="306" y="152" width="340" height="32" rx="5" fill="none" stroke="currentColor"/>
+  <text x="318" y="172" fill="currentColor" font-size="10">&#960;/4-DQPSK &#8212; differential QPSK (TETRA)</text>
+</svg>
+<figcaption>The demod family: one FM discriminator feeds four matched-filter-and-slicer variants, each a small single-responsibility type composed from shared primitives.</figcaption>
+</figure>
 
 ## The design principle: single responsibility
 

--- a/docs/_posts/2026-06-09-sdr-internals-07-symbol-timing-sync-recovery.md
+++ b/docs/_posts/2026-06-09-sdr-internals-07-symbol-timing-sync-recovery.md
@@ -29,6 +29,36 @@ feedback loop that tracks that optimal instant and outputs exactly one sample pe
 symbol. ([clock recovery]({{ '/reference/clock-recovery/' | relative_url }}),
 [eye diagram]({{ '/reference/eye-diagram/' | relative_url }}))
 
+<figure class="lab-figure">
+<svg viewBox="0 0 660 180" width="660" height="180" role="img" aria-label="The Mueller-Muller symbol-timing recovery loop: oversampled input feeds an interpolator, whose output goes to a timing-error detector, then a loop filter; the filtered error drives an NCO phase accumulator that feeds the fractional sample phase mu back into the interpolator, and one symbol per period is emitted.">
+  <rect x="8" y="30" width="96" height="42" rx="6" fill="none" stroke="currentColor"/>
+  <text x="56" y="48" text-anchor="middle" fill="currentColor" font-size="10">oversampled</text>
+  <text x="56" y="62" text-anchor="middle" fill="var(--fg-muted)" font-size="8">~10 sps</text>
+  <line x1="104" y1="51" x2="122" y2="51" stroke="currentColor"/><polygon points="122,47 132,51 122,55" fill="currentColor"/>
+  <rect x="132" y="30" width="96" height="42" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="180" y="48" text-anchor="middle" fill="var(--accent)" font-size="11">interpolator</text>
+  <text x="180" y="62" text-anchor="middle" fill="var(--fg-muted)" font-size="8">reads at mu</text>
+  <line x1="228" y1="51" x2="246" y2="51" stroke="currentColor"/><polygon points="246,47 256,51 246,55" fill="currentColor"/>
+  <rect x="256" y="30" width="124" height="42" rx="6" fill="none" stroke="currentColor"/>
+  <text x="318" y="48" text-anchor="middle" fill="currentColor" font-size="10">timing-error detector</text>
+  <text x="318" y="62" text-anchor="middle" fill="var(--fg-muted)" font-size="8">Mueller-Muller</text>
+  <line x1="380" y1="51" x2="398" y2="51" stroke="currentColor"/><polygon points="398,47 408,51 398,55" fill="currentColor"/>
+  <rect x="408" y="30" width="96" height="42" rx="6" fill="none" stroke="currentColor"/>
+  <text x="456" y="55" text-anchor="middle" fill="currentColor" font-size="10">loop filter</text>
+  <line x1="504" y1="51" x2="522" y2="51" stroke="currentColor"/><polygon points="522,47 532,51 522,55" fill="currentColor"/>
+  <rect x="532" y="30" width="112" height="42" rx="6" fill="none" stroke="currentColor"/>
+  <text x="588" y="48" text-anchor="middle" fill="currentColor" font-size="10">one symbol</text>
+  <text x="588" y="62" text-anchor="middle" fill="var(--fg-muted)" font-size="8">per period</text>
+  <rect x="256" y="118" width="124" height="40" rx="6" fill="none" stroke="currentColor"/>
+  <text x="318" y="136" text-anchor="middle" fill="currentColor" font-size="10">NCO / phase acc.</text>
+  <text x="318" y="150" text-anchor="middle" fill="var(--fg-muted)" font-size="8">carries mu across chunks</text>
+  <line x1="456" y1="72" x2="456" y2="138" stroke="currentColor"/><line x1="456" y1="138" x2="382" y2="138" stroke="currentColor"/><polygon points="386,134 380,138 386,142" fill="currentColor"/>
+  <line x1="256" y1="138" x2="180" y2="138" stroke="currentColor"/><line x1="180" y1="138" x2="180" y2="72" stroke="currentColor"/><polygon points="176,80 180,72 184,80" fill="currentColor"/>
+  <text x="205" y="106" text-anchor="middle" fill="var(--fg-muted)" font-size="9">mu feedback</text>
+</svg>
+<figcaption>The timing loop as feedback state machine: interpolate &#8594; timing-error detector &#8594; loop filter &#8594; NCO, with the fractional phase <code>mu</code> fed back and carried across every chunk.</figcaption>
+</figure>
+
 Even with perfect symbols you still don't know where a *frame* begins. **Sync
 recovery** slides a known pattern (a sync word) across the symbol stream and
 fires when it correlates strongly — that's your frame boundary.
@@ -70,6 +100,32 @@ NID, the DMR burst sync, and the NXDN frame sync — only the pattern changes.
 A typical receiver chains them: `FM → matched filter → MuellerMuller → slicer →
 correlator → dibits`, exactly as the NXDN receiver does in
 `internal/radio/nxdn/receiver`.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 190" width="660" height="190" role="img" aria-label="An eye diagram: overlaid symbol transitions form an open eye; a dashed vertical accent line marks the optimal sampling instant at mu where the eye is widest, with decision dots at the high and low symbol levels and a muted horizontal decision threshold.">
+  <line x1="40" y1="25" x2="40" y2="160" stroke="var(--fg-muted)"/>
+  <line x1="40" y1="160" x2="620" y2="160" stroke="var(--fg-muted)"/>
+  <line x1="40" y1="85" x2="620" y2="85" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <text x="34" y="48" text-anchor="end" fill="var(--fg-muted)" font-size="9">+sym</text>
+  <text x="34" y="132" text-anchor="end" fill="var(--fg-muted)" font-size="9">&#8722;sym</text>
+  <text x="34" y="89" text-anchor="end" fill="var(--fg-muted)" font-size="8">thr</text>
+  <path d="M40,85 Q80,55 120,85" fill="none" stroke="currentColor"/>
+  <path d="M120,85 Q210,42 300,85" fill="none" stroke="currentColor"/>
+  <path d="M120,85 Q210,128 300,85" fill="none" stroke="currentColor"/>
+  <path d="M300,85 Q390,42 480,85" fill="none" stroke="currentColor"/>
+  <path d="M300,85 Q390,128 480,85" fill="none" stroke="currentColor"/>
+  <path d="M480,85 Q560,55 600,85" fill="none" stroke="currentColor"/>
+  <line x1="210" y1="28" x2="210" y2="150" stroke="var(--accent)" stroke-dasharray="5 3"/>
+  <circle cx="210" cy="52" r="4" fill="var(--accent)"/>
+  <circle cx="210" cy="118" r="4" fill="var(--accent)"/>
+  <text x="210" y="20" text-anchor="middle" fill="var(--accent)" font-size="10">sample at mu</text>
+  <line x1="120" y1="172" x2="300" y2="172" stroke="var(--fg-muted)"/>
+  <line x1="120" y1="168" x2="120" y2="176" stroke="var(--fg-muted)"/>
+  <line x1="300" y1="168" x2="300" y2="176" stroke="var(--fg-muted)"/>
+  <text x="210" y="186" text-anchor="middle" fill="var(--fg-muted)" font-size="9">one symbol period</text>
+</svg>
+<figcaption>The eye diagram the loop is chasing: the timing-error detector nudges <code>mu</code> toward the instant of maximum eye opening, where the margin between symbol levels is greatest.</figcaption>
+</figure>
 
 ## The design principle: feedback state machines
 

--- a/docs/_posts/2026-06-10-sdr-internals-08-equalization-diversity-fft.md
+++ b/docs/_posts/2026-06-10-sdr-internals-08-equalization-diversity-fft.md
@@ -48,6 +48,31 @@ equalizer **wraps** the demod chain — it sits between decimation and the
 discriminator and improves the symbols without the demodulator knowing it's
 there.
 
+<figure class="lab-figure">
+<svg viewBox="0 0 660 180" width="660" height="180" role="img" aria-label="An adaptive equalizer inserted as a decorator between decimation and the discriminator: decimated IQ passes through the equalizer's adaptive FIR taps to the discriminator and out as soft symbols; an error signal drives an LMS or CMA update that adjusts the tap weights each sample.">
+  <rect x="8" y="30" width="104" height="42" rx="6" fill="none" stroke="currentColor"/>
+  <text x="60" y="55" text-anchor="middle" fill="currentColor" font-size="10">decimation</text>
+  <line x1="112" y1="51" x2="130" y2="51" stroke="currentColor"/><polygon points="130,47 140,51 130,55" fill="currentColor"/>
+  <rect x="140" y="24" width="170" height="54" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="225" y="45" text-anchor="middle" fill="var(--accent)" font-size="11">equalizer</text>
+  <text x="225" y="60" text-anchor="middle" fill="var(--fg-muted)" font-size="8">adaptive FIR: w0 w1 w2 w3</text>
+  <line x1="310" y1="51" x2="328" y2="51" stroke="currentColor"/><polygon points="328,47 338,51 328,55" fill="currentColor"/>
+  <rect x="338" y="30" width="120" height="42" rx="6" fill="none" stroke="currentColor"/>
+  <text x="398" y="55" text-anchor="middle" fill="currentColor" font-size="10">discriminator</text>
+  <line x1="458" y1="51" x2="476" y2="51" stroke="currentColor"/><polygon points="476,47 486,51 476,55" fill="currentColor"/>
+  <rect x="486" y="30" width="120" height="42" rx="6" fill="none" stroke="currentColor"/>
+  <text x="546" y="55" text-anchor="middle" fill="currentColor" font-size="10">soft symbols</text>
+  <rect x="140" y="120" width="170" height="38" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="225" y="139" text-anchor="middle" fill="var(--accent)" font-size="10">adapt taps</text>
+  <text x="225" y="152" text-anchor="middle" fill="var(--fg-muted)" font-size="8">LMS / CMA (SGD)</text>
+  <line x1="546" y1="72" x2="546" y2="139" stroke="currentColor"/><line x1="546" y1="139" x2="312" y2="139" stroke="currentColor"/><polygon points="316,135 310,139 316,143" fill="currentColor"/>
+  <text x="430" y="133" text-anchor="middle" fill="var(--fg-muted)" font-size="9">error signal</text>
+  <line x1="225" y1="120" x2="225" y2="78" stroke="currentColor"/><polygon points="221,86 225,78 229,86" fill="currentColor"/>
+  <text x="262" y="102" text-anchor="middle" fill="var(--fg-muted)" font-size="9">new weights</text>
+</svg>
+<figcaption>The equalizer as a decorator: it wraps the chain between decimation and the discriminator, and a per-sample LMS/CMA update adapts its FIR taps to reverse the channel &#8212; transparent to the demodulator.</figcaption>
+</figure>
+
 **Diversity** lives in `internal/dsp/diversity`: `MRC` (weighted sum by per-branch
 SNR) and `Selection` (pick the strongest branch).
 
@@ -69,6 +94,42 @@ func (p *Producer) Push(iq []complex64) (*Frame, bool) {
     // returns a dBFS Frame only when the next frame is due
 }
 ```
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 180" width="660" height="180" role="img" aria-label="A power spectrum from the rate-limited FFT producer: dBFS on the vertical axis, frequency bins across the bottom, a flat muted noise floor of short bars, and one tall accent bar marking a detected carrier peak; a label notes the ten frames per second cap.">
+  <line x1="56" y1="24" x2="56" y2="150" stroke="var(--fg-muted)"/>
+  <line x1="56" y1="150" x2="612" y2="150" stroke="var(--fg-muted)"/>
+  <text x="50" y="30" text-anchor="end" fill="var(--fg-muted)" font-size="8">0 dBFS</text>
+  <text x="50" y="150" text-anchor="end" fill="var(--fg-muted)" font-size="8">&#8722;80</text>
+  <text x="334" y="170" text-anchor="middle" fill="var(--fg-muted)" font-size="9">frequency bins &#8594;</text>
+  <rect x="66" y="136" width="16" height="14" fill="var(--fg-muted)"/>
+  <rect x="90" y="130" width="16" height="20" fill="var(--fg-muted)"/>
+  <rect x="114" y="138" width="16" height="12" fill="var(--fg-muted)"/>
+  <rect x="138" y="128" width="16" height="22" fill="var(--fg-muted)"/>
+  <rect x="162" y="134" width="16" height="16" fill="var(--fg-muted)"/>
+  <rect x="186" y="126" width="16" height="24" fill="var(--fg-muted)"/>
+  <rect x="210" y="132" width="16" height="18" fill="var(--fg-muted)"/>
+  <rect x="234" y="122" width="16" height="28" fill="var(--fg-muted)"/>
+  <rect x="258" y="112" width="16" height="38" fill="var(--fg-muted)"/>
+  <rect x="282" y="44" width="16" height="106" fill="var(--accent)"/>
+  <rect x="306" y="108" width="16" height="42" fill="var(--fg-muted)"/>
+  <rect x="330" y="130" width="16" height="20" fill="var(--fg-muted)"/>
+  <rect x="354" y="136" width="16" height="14" fill="var(--fg-muted)"/>
+  <rect x="378" y="128" width="16" height="22" fill="var(--fg-muted)"/>
+  <rect x="402" y="134" width="16" height="16" fill="var(--fg-muted)"/>
+  <rect x="426" y="138" width="16" height="12" fill="var(--fg-muted)"/>
+  <rect x="450" y="130" width="16" height="20" fill="var(--fg-muted)"/>
+  <rect x="474" y="135" width="16" height="15" fill="var(--fg-muted)"/>
+  <rect x="498" y="132" width="16" height="18" fill="var(--fg-muted)"/>
+  <rect x="522" y="138" width="16" height="12" fill="var(--fg-muted)"/>
+  <rect x="546" y="134" width="16" height="16" fill="var(--fg-muted)"/>
+  <rect x="570" y="139" width="16" height="11" fill="var(--fg-muted)"/>
+  <line x1="290" y1="44" x2="290" y2="30" stroke="var(--accent)"/>
+  <text x="290" y="24" text-anchor="middle" fill="var(--accent)" font-size="10">carrier</text>
+  <text x="604" y="34" text-anchor="end" fill="var(--fg-muted)" font-size="9">10 fps cap</text>
+</svg>
+<figcaption>One dBFS <code>Frame</code> from the rate-limited spectrum producer: a flat noise floor with a single accent carrier peak &#8212; the same frames that feed the waterfall, TUI panel, and carrier detector.</figcaption>
+</figure>
 
 ## The design principle: decorator + interface segregation
 

--- a/docs/_posts/2026-06-11-sdr-internals-09-framing-fec.md
+++ b/docs/_posts/2026-06-11-sdr-internals-09-framing-fec.md
@@ -29,6 +29,29 @@ survives this by adding **forward error correction**: structured redundancy that
 lets the receiver detect *and repair* errors without asking for a retransmission.
 ([reference]({{ '/reference/forward-error-correction/' | relative_url }}))
 
+<figure class="lab-figure">
+<svg viewBox="0 0 660 116" width="660" height="116" role="img" aria-label="The framing and FEC stack: a symbol stream is scanned for a sync word that marks the frame boundary, the framed bits are assembled, the FEC decoder detects and repairs errors, and a clean payload emerges.">
+  <rect x="8" y="36" width="112" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="64" y="56" text-anchor="middle" fill="currentColor" font-size="10">symbol stream</text>
+  <text x="64" y="70" text-anchor="middle" fill="var(--fg-muted)" font-size="8">dibits, with errors</text>
+  <line x1="120" y1="58" x2="138" y2="58" stroke="currentColor"/><polygon points="138,54 148,58 138,62" fill="currentColor"/>
+  <rect x="148" y="36" width="104" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="200" y="56" text-anchor="middle" fill="currentColor" font-size="10">sync word</text>
+  <text x="200" y="70" text-anchor="middle" fill="var(--fg-muted)" font-size="8">frame boundary</text>
+  <line x1="252" y1="58" x2="270" y2="58" stroke="currentColor"/><polygon points="270,54 280,58 270,62" fill="currentColor"/>
+  <rect x="280" y="36" width="104" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="332" y="60" text-anchor="middle" fill="currentColor" font-size="10">frame</text>
+  <line x1="384" y1="58" x2="402" y2="58" stroke="currentColor"/><polygon points="402,54 412,58 402,62" fill="currentColor"/>
+  <rect x="412" y="36" width="118" height="44" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="471" y="56" text-anchor="middle" fill="var(--accent)" font-size="10">FEC decode</text>
+  <text x="471" y="70" text-anchor="middle" fill="var(--fg-muted)" font-size="8">detect + repair</text>
+  <line x1="530" y1="58" x2="548" y2="58" stroke="currentColor"/><polygon points="548,54 558,58 548,62" fill="currentColor"/>
+  <rect x="558" y="36" width="94" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="605" y="60" text-anchor="middle" fill="currentColor" font-size="10">payload</text>
+</svg>
+<figcaption>The framing stack: sync word &#8594; frame &#8594; FEC decode &#8594; clean payload &#8212; every protocol draws its codes from the shared <code>internal/radio/framing</code> toolbox.</figcaption>
+</figure>
+
 Each protocol layers several codes, plus
 [interleaving]({{ '/reference/interleaving/' | relative_url }}) (spreads burst
 errors out so the codes can handle them) and
@@ -69,6 +92,34 @@ pattern, flip the bad bits. Where a code is small, the error patterns are
 not a search. The Viterbi decoder walks a trellis and traces back the
 most-likely path; soft-decision variants take symbol confidences (LLRs) when the
 demodulator can supply them.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 170" width="660" height="170" role="img" aria-label="The syndrome-decoding flow for a Golay codeword: a noisy 24-bit word has its syndrome computed; the syndrome indexes a precomputed error-pattern table built at package init; the matching pattern is XORed to flip the bad bits, yielding 12 clean data bits and an ok flag.">
+  <rect x="8" y="30" width="120" height="46" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="68" y="50" text-anchor="middle" fill="var(--accent)" font-size="10">noisy codeword</text>
+  <text x="68" y="64" text-anchor="middle" fill="var(--fg-muted)" font-size="8">24 bits</text>
+  <line x1="128" y1="53" x2="146" y2="53" stroke="currentColor"/><polygon points="146,49 156,53 146,57" fill="currentColor"/>
+  <rect x="156" y="30" width="118" height="46" rx="6" fill="none" stroke="currentColor"/>
+  <text x="215" y="57" text-anchor="middle" fill="currentColor" font-size="10">compute syndrome</text>
+  <line x1="274" y1="53" x2="292" y2="53" stroke="currentColor"/><polygon points="292,49 302,53 292,57" fill="currentColor"/>
+  <rect x="302" y="30" width="126" height="46" rx="6" fill="none" stroke="currentColor"/>
+  <text x="365" y="52" text-anchor="middle" fill="currentColor" font-size="10">lookup error</text>
+  <text x="365" y="66" text-anchor="middle" fill="var(--fg-muted)" font-size="8">pattern (O(1))</text>
+  <line x1="428" y1="53" x2="446" y2="53" stroke="currentColor"/><polygon points="446,49 456,53 446,57" fill="currentColor"/>
+  <rect x="456" y="30" width="110" height="46" rx="6" fill="none" stroke="currentColor"/>
+  <text x="511" y="52" text-anchor="middle" fill="currentColor" font-size="10">XOR flip</text>
+  <text x="511" y="66" text-anchor="middle" fill="var(--fg-muted)" font-size="8">bad bits</text>
+  <line x1="566" y1="53" x2="584" y2="53" stroke="currentColor"/><polygon points="584,49 594,53 584,57" fill="currentColor"/>
+  <rect x="594" y="30" width="58" height="46" rx="6" fill="none" stroke="currentColor"/>
+  <text x="623" y="50" text-anchor="middle" fill="currentColor" font-size="9">data</text>
+  <text x="623" y="64" text-anchor="middle" fill="var(--fg-muted)" font-size="8">12b &#183; ok</text>
+  <rect x="302" y="118" width="126" height="34" rx="6" fill="none" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <text x="365" y="134" text-anchor="middle" fill="var(--fg-muted)" font-size="9">syndrome&#8594;pattern</text>
+  <text x="365" y="146" text-anchor="middle" fill="var(--fg-muted)" font-size="8">table built in init()</text>
+  <line x1="365" y1="118" x2="365" y2="78" stroke="var(--fg-muted)"/><polygon points="361,86 365,78 369,86" fill="var(--fg-muted)"/>
+</svg>
+<figcaption>Syndrome decoding as a pure function: <code>GolayDecode</code> computes a syndrome, looks up the error pattern in a table precomputed at <code>init()</code>, and XORs it away &#8212; a lookup on the hot path, not a search.</figcaption>
+</figure>
 
 These pieces compose into a protocol's framer. A P25 Phase 1 voice frame, for
 example, runs deinterleave → trellis/Viterbi → Hamming on the link-control words —

--- a/docs/_posts/2026-06-12-sdr-internals-10-protocol-decoders-state-machines.md
+++ b/docs/_posts/2026-06-12-sdr-internals-10-protocol-decoders-state-machines.md
@@ -70,6 +70,32 @@ However different P25 and DMR look inside, they converge on the **same output**:
 unit, and an encrypted flag. That uniform result is the contract the rest of the
 system relies on.
 
+<figure class="lab-figure">
+<svg viewBox="0 0 660 170" width="660" height="170" role="img" aria-label="A control-channel decoder state machine with four states left to right: hunting, synced, parsing, and grant emitted. Correlator over threshold advances hunting to synced, FEC ok advances to parsing, a decoded signaling message emits a grant, and losing sync returns any state to hunting.">
+  <rect x="8" y="46" width="140" height="48" rx="10" fill="none" stroke="var(--accent)"/>
+  <text x="78" y="66" text-anchor="middle" fill="var(--accent)" font-size="11">hunting</text>
+  <text x="78" y="80" text-anchor="middle" fill="var(--fg-muted)" font-size="8">scan for sync</text>
+  <line x1="148" y1="70" x2="170" y2="70" stroke="currentColor"/><polygon points="170,66 180,70 170,74" fill="currentColor"/>
+  <text x="164" y="40" text-anchor="middle" fill="var(--fg-muted)" font-size="8">corr &gt; thr</text>
+  <rect x="180" y="46" width="140" height="48" rx="10" fill="none" stroke="currentColor"/>
+  <text x="250" y="66" text-anchor="middle" fill="currentColor" font-size="11">synced</text>
+  <text x="250" y="80" text-anchor="middle" fill="var(--fg-muted)" font-size="8">frame locked</text>
+  <line x1="320" y1="70" x2="342" y2="70" stroke="currentColor"/><polygon points="342,66 352,70 342,74" fill="currentColor"/>
+  <text x="336" y="40" text-anchor="middle" fill="var(--fg-muted)" font-size="8">FEC ok</text>
+  <rect x="352" y="46" width="140" height="48" rx="10" fill="none" stroke="currentColor"/>
+  <text x="422" y="66" text-anchor="middle" fill="currentColor" font-size="11">parsing</text>
+  <text x="422" y="80" text-anchor="middle" fill="var(--fg-muted)" font-size="8">signaling msgs</text>
+  <line x1="492" y1="70" x2="514" y2="70" stroke="currentColor"/><polygon points="514,66 524,70 514,74" fill="currentColor"/>
+  <text x="508" y="40" text-anchor="middle" fill="var(--fg-muted)" font-size="8">grant</text>
+  <rect x="524" y="46" width="128" height="48" rx="10" fill="none" stroke="var(--accent)"/>
+  <text x="588" y="66" text-anchor="middle" fill="var(--accent)" font-size="11">grant emitted</text>
+  <text x="588" y="80" text-anchor="middle" fill="var(--fg-muted)" font-size="8">TG on freq</text>
+  <line x1="588" y1="94" x2="588" y2="134" stroke="currentColor"/><line x1="588" y1="134" x2="78" y2="134" stroke="currentColor"/><line x1="78" y1="134" x2="78" y2="94" stroke="currentColor"/><polygon points="74,102 78,94 82,102" fill="currentColor"/>
+  <text x="333" y="150" text-anchor="middle" fill="var(--fg-muted)" font-size="9">sync lost &#8594; re-hunt</text>
+</svg>
+<figcaption>Each <code>internal/radio</code> receiver is an explicit state machine &#8212; hunting &#8594; synced &#8594; parsing &#8594; grant &#8212; with a single back edge when sync is lost, making lock, loss, and re-sync readable and testable.</figcaption>
+</figure>
+
 ## The design principle: adapter + a uniform contract
 
 Each decoder is an **adapter**: it translates one protocol's idiosyncratic
@@ -77,6 +103,31 @@ signaling into a single, shared vocabulary of events. The trunking engine in
 [Part 11]({{ '/blog/deep-dives/sdr-internals-11-trunking-engine-event-bus/' | relative_url }})
 consumes only that vocabulary — it has no idea whether a grant came from a P25
 TSBK or a DMR CSBK.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 200" width="660" height="200" role="img" aria-label="The adapter pattern: four protocol receivers on the left, P25 TSBK, DMR CSBK, NXDN, and TETRA, each translate their own signaling into a single uniform Grant value in the middle, which the protocol-agnostic trunking engine on the right consumes.">
+  <rect x="8" y="18" width="150" height="32" rx="6" fill="none" stroke="currentColor"/>
+  <text x="83" y="38" text-anchor="middle" fill="currentColor" font-size="10">P25 &#183; TSBK / MAC</text>
+  <rect x="8" y="62" width="150" height="32" rx="6" fill="none" stroke="currentColor"/>
+  <text x="83" y="82" text-anchor="middle" fill="currentColor" font-size="10">DMR &#183; CSBK</text>
+  <rect x="8" y="106" width="150" height="32" rx="6" fill="none" stroke="currentColor"/>
+  <text x="83" y="126" text-anchor="middle" fill="currentColor" font-size="10">NXDN receiver</text>
+  <rect x="8" y="150" width="150" height="32" rx="6" fill="none" stroke="currentColor"/>
+  <text x="83" y="170" text-anchor="middle" fill="currentColor" font-size="10">TETRA receiver</text>
+  <line x1="158" y1="34" x2="300" y2="90" stroke="currentColor"/><polygon points="294,84 302,92 290,93" fill="currentColor"/>
+  <line x1="158" y1="78" x2="300" y2="96" stroke="currentColor"/><polygon points="293,90 302,98 292,100" fill="currentColor"/>
+  <line x1="158" y1="122" x2="300" y2="104" stroke="currentColor"/><polygon points="292,100 302,102 293,110" fill="currentColor"/>
+  <line x1="158" y1="166" x2="300" y2="110" stroke="currentColor"/><polygon points="290,107 302,108 294,116" fill="currentColor"/>
+  <rect x="302" y="72" width="150" height="56" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="377" y="96" text-anchor="middle" fill="var(--accent)" font-size="11">Grant</text>
+  <text x="377" y="112" text-anchor="middle" fill="var(--fg-muted)" font-size="8">freq &#183; TG &#183; slot &#183; enc</text>
+  <line x1="452" y1="100" x2="490" y2="100" stroke="currentColor"/><polygon points="490,96 500,100 490,104" fill="currentColor"/>
+  <rect x="500" y="72" width="152" height="56" rx="6" fill="none" stroke="currentColor"/>
+  <text x="576" y="96" text-anchor="middle" fill="currentColor" font-size="11">trunking engine</text>
+  <text x="576" y="112" text-anchor="middle" fill="var(--fg-muted)" font-size="8">protocol-agnostic (Part 11)</text>
+</svg>
+<figcaption>Every decoder is an adapter: however different P25, DMR, NXDN, and TETRA look inside, they converge on one uniform <code>Grant</code> contract, so the engine is written once and never changes when a protocol is added.</figcaption>
+</figure>
 
 ### How that principle shaped the Go code
 

--- a/docs/_posts/2026-06-13-sdr-internals-11-trunking-engine-event-bus.md
+++ b/docs/_posts/2026-06-13-sdr-internals-11-trunking-engine-event-bus.md
@@ -36,6 +36,35 @@ the web UI, the call-log database, the Prometheus metrics, the Broadcastify
 uploader. Rather than have the engine call each of them, it publishes to an
 **event bus** (`internal/events`) and they subscribe.
 
+<figure class="lab-figure">
+<svg viewBox="0 0 660 190" width="660" height="190" role="img" aria-label="A protocol decoder publishes a grant onto the in-process event bus; the bus fans domain events out to five independent subscribers — the trunking engine, the recorder, the SQLite call log, the web UI over WebSocket, and the Broadcastify uploader — none of which the engine ever calls directly.">
+  <rect x="8" y="76" width="112" height="44" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="64" y="96" text-anchor="middle" fill="var(--accent)" font-size="11">decoder</text>
+  <text x="64" y="111" text-anchor="middle" fill="var(--fg-muted)" font-size="9">publishes grant</text>
+  <line x1="120" y1="98" x2="158" y2="98" stroke="currentColor"/><polygon points="158,94 168,98 158,102" fill="currentColor"/>
+  <rect x="168" y="66" width="98" height="64" rx="6" fill="none" stroke="currentColor"/>
+  <text x="217" y="90" text-anchor="middle" fill="currentColor" font-size="11">event bus</text>
+  <text x="217" y="105" text-anchor="middle" fill="var(--fg-muted)" font-size="9">internal/events</text>
+  <text x="217" y="118" text-anchor="middle" fill="var(--fg-muted)" font-size="9">Kind + payload</text>
+  <line x1="266" y1="90" x2="300" y2="26" stroke="currentColor"/><polygon points="296,22 306,24 300,33" fill="currentColor"/>
+  <line x1="266" y1="94" x2="300" y2="62" stroke="currentColor"/><polygon points="296,58 306,60 299,69" fill="currentColor"/>
+  <line x1="266" y1="98" x2="300" y2="98" stroke="currentColor"/><polygon points="300,94 310,98 300,102" fill="currentColor"/>
+  <line x1="266" y1="102" x2="300" y2="134" stroke="currentColor"/><polygon points="299,127 306,136 296,138" fill="currentColor"/>
+  <line x1="266" y1="106" x2="300" y2="170" stroke="currentColor"/><polygon points="298,163 306,172 294,172" fill="currentColor"/>
+  <rect x="310" y="12" width="180" height="28" rx="5" fill="none" stroke="var(--accent)"/>
+  <text x="400" y="30" text-anchor="middle" fill="var(--accent)" font-size="10">engine · HandleGrant</text>
+  <rect x="310" y="48" width="180" height="28" rx="5" fill="none" stroke="currentColor"/>
+  <text x="400" y="66" text-anchor="middle" fill="currentColor" font-size="10">recorder</text>
+  <rect x="310" y="84" width="180" height="28" rx="5" fill="none" stroke="currentColor"/>
+  <text x="400" y="102" text-anchor="middle" fill="currentColor" font-size="10">call log · SQLite</text>
+  <rect x="310" y="120" width="180" height="28" rx="5" fill="none" stroke="currentColor"/>
+  <text x="400" y="138" text-anchor="middle" fill="currentColor" font-size="10">web UI · WebSocket</text>
+  <rect x="310" y="156" width="180" height="28" rx="5" fill="none" stroke="currentColor"/>
+  <text x="400" y="174" text-anchor="middle" fill="currentColor" font-size="10">Broadcastify uploader</text>
+</svg>
+<figcaption>A grant published by the decoder fans out through the bus; the engine, recorder, call log, web UI, and uploader each subscribe independently — the engine never calls them.</figcaption>
+</figure>
+
 ## How GopherTrunk implements it in Go
 
 The engine is a single goroutine running a `select` loop — the classic Go event
@@ -66,6 +95,32 @@ The bus is a typed pub/sub fanout. Events are tagged with a `Kind` —
 `KindAffiliation`, and dozens more — and carry a payload. Subscribers register a
 channel and receive the kinds they care about. Delivery is asynchronous with
 overflow protection, so a slow subscriber can't stall the engine.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 120" width="680" height="120" role="img" aria-label="The engine's grant-to-call state flow: a KindGrant event triggers HandleGrant, which allocates a voice SDR and publishes KindCallStart; the call stays active while voice frames arrive; the 500-millisecond watchdog reaps a silent call and it ends as KindCallComplete.">
+  <rect x="8" y="40" width="92" height="42" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="54" y="60" text-anchor="middle" fill="var(--accent)" font-size="10">KindGrant</text>
+  <text x="54" y="73" text-anchor="middle" fill="var(--fg-muted)" font-size="8">tg + freq</text>
+  <line x1="100" y1="61" x2="118" y2="61" stroke="currentColor"/><polygon points="118,57 128,61 118,65" fill="currentColor"/>
+  <rect x="128" y="40" width="118" height="42" rx="6" fill="none" stroke="currentColor"/>
+  <text x="187" y="60" text-anchor="middle" fill="currentColor" font-size="10">HandleGrant</text>
+  <text x="187" y="73" text-anchor="middle" fill="var(--fg-muted)" font-size="8">allocate voice SDR</text>
+  <line x1="246" y1="61" x2="264" y2="61" stroke="currentColor"/><polygon points="264,57 274,61 264,65" fill="currentColor"/>
+  <rect x="274" y="40" width="104" height="42" rx="6" fill="none" stroke="currentColor"/>
+  <text x="326" y="60" text-anchor="middle" fill="currentColor" font-size="10">KindCallStart</text>
+  <text x="326" y="73" text-anchor="middle" fill="var(--fg-muted)" font-size="8">retune + record</text>
+  <line x1="378" y1="61" x2="396" y2="61" stroke="currentColor"/><polygon points="396,57 406,61 396,65" fill="currentColor"/>
+  <rect x="406" y="40" width="104" height="42" rx="6" fill="none" stroke="currentColor"/>
+  <text x="458" y="60" text-anchor="middle" fill="currentColor" font-size="10">active call</text>
+  <text x="458" y="73" text-anchor="middle" fill="var(--fg-muted)" font-size="8">voice frames</text>
+  <line x1="510" y1="61" x2="528" y2="61" stroke="currentColor"/><polygon points="528,57 538,61 528,65" fill="currentColor"/>
+  <text x="605" y="34" text-anchor="middle" fill="var(--fg-muted)" font-size="8">watchdog: silent</text>
+  <rect x="538" y="40" width="134" height="42" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="605" y="60" text-anchor="middle" fill="var(--accent)" font-size="10">KindCallComplete</text>
+  <text x="605" y="73" text-anchor="middle" fill="var(--fg-muted)" font-size="8">reaped after 500ms</text>
+</svg>
+<figcaption>Inside the engine's <code>select</code> loop, one grant becomes a call: allocate a radio, start recording, then let the 500&nbsp;ms watchdog reap the call once its frames stop.</figcaption>
+</figure>
 
 ```go
 // internal/events — kinds (excerpt)

--- a/docs/_posts/2026-06-14-sdr-internals-12-voice-coding-vocoders.md
+++ b/docs/_posts/2026-06-14-sdr-internals-12-voice-coding-vocoders.md
@@ -41,6 +41,32 @@ Both belong to the
 [Multi-Band Excitation]({{ '/reference/multi-band-excitation/' | relative_url }})
 family — and that shared lineage is the key to the design.
 
+<figure class="lab-figure">
+<svg viewBox="0 0 680 140" width="680" height="140" role="img" aria-label="The MBE vocoder model as a pipeline: a few-kilobit voice frame is unpacked and error-corrected into MBE parameters — pitch, voicing, and a spectral envelope — which the MBE synthesis core turns into 8 kilohertz PCM speech.">
+  <rect x="8" y="46" width="98" height="48" rx="6" fill="none" stroke="currentColor"/>
+  <text x="57" y="67" text-anchor="middle" fill="currentColor" font-size="10">frame bits</text>
+  <text x="57" y="81" text-anchor="middle" fill="var(--fg-muted)" font-size="8">2.4–4.4 kbps</text>
+  <line x1="106" y1="70" x2="126" y2="70" stroke="currentColor"/><polygon points="126,66 136,70 126,74" fill="currentColor"/>
+  <rect x="136" y="46" width="104" height="48" rx="6" fill="none" stroke="currentColor"/>
+  <text x="188" y="67" text-anchor="middle" fill="currentColor" font-size="10">unpack + FEC</text>
+  <text x="188" y="81" text-anchor="middle" fill="var(--fg-muted)" font-size="8">de-interleave</text>
+  <line x1="240" y1="70" x2="260" y2="70" stroke="currentColor"/><polygon points="260,66 270,70 260,74" fill="currentColor"/>
+  <rect x="270" y="40" width="150" height="60" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="345" y="60" text-anchor="middle" fill="var(--accent)" font-size="10">MBE parameters</text>
+  <text x="345" y="76" text-anchor="middle" fill="var(--fg-muted)" font-size="8">pitch · voicing</text>
+  <text x="345" y="89" text-anchor="middle" fill="var(--fg-muted)" font-size="8">spectral envelope</text>
+  <line x1="420" y1="70" x2="440" y2="70" stroke="currentColor"/><polygon points="440,66 450,70 440,74" fill="currentColor"/>
+  <rect x="450" y="46" width="118" height="48" rx="6" fill="none" stroke="currentColor"/>
+  <text x="509" y="67" text-anchor="middle" fill="currentColor" font-size="10">MBE synthesis</text>
+  <text x="509" y="81" text-anchor="middle" fill="var(--fg-muted)" font-size="8">harmonics + FFT</text>
+  <line x1="568" y1="70" x2="588" y2="70" stroke="currentColor"/><polygon points="588,66 598,70 588,74" fill="currentColor"/>
+  <rect x="598" y="46" width="74" height="48" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="635" y="67" text-anchor="middle" fill="var(--accent)" font-size="10">8 kHz</text>
+  <text x="635" y="81" text-anchor="middle" fill="var(--fg-muted)" font-size="8">PCM</text>
+</svg>
+<figcaption>A vocoder models how speech is produced, not the waveform: the radio ships MBE parameters and the receiver resynthesizes speech from pitch, voicing, and a spectral envelope.</figcaption>
+</figure>
+
 ## How GopherTrunk implements it in Go
 
 IMBE and AMBE+2 differ in how they *unpack and error-correct* their on-air bits,
@@ -56,6 +82,34 @@ front-ends:
 - `internal/voice/mbe` — takes those parameters and synthesizes 8 kHz PCM:
   voiced-harmonic generation, unvoiced FFT excitation with overlap-add, spectral
   enhancement, and per-frame AGC.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 180" width="680" height="180" role="img" aria-label="Per-protocol vocoder selection: P25 Phase 1 uses the IMBE front-end, while P25 Phase 2, DMR and NXDN use the AMBE+2 front-end; both front-ends reduce their frames to MBE parameters and feed the shared internal/voice/mbe synthesis core, which emits 8 kilohertz PCM.">
+  <rect x="8" y="26" width="132" height="42" rx="6" fill="none" stroke="currentColor"/>
+  <text x="74" y="51" text-anchor="middle" fill="currentColor" font-size="10">P25 Phase 1</text>
+  <rect x="8" y="110" width="132" height="46" rx="6" fill="none" stroke="currentColor"/>
+  <text x="74" y="131" text-anchor="middle" fill="currentColor" font-size="10">P25 Phase 2</text>
+  <text x="74" y="146" text-anchor="middle" fill="var(--fg-muted)" font-size="9">DMR · NXDN</text>
+  <line x1="140" y1="47" x2="178" y2="47" stroke="currentColor"/><polygon points="178,43 188,47 178,51" fill="currentColor"/>
+  <line x1="140" y1="133" x2="178" y2="133" stroke="currentColor"/><polygon points="178,129 188,133 178,137" fill="currentColor"/>
+  <rect x="188" y="26" width="158" height="42" rx="6" fill="none" stroke="currentColor"/>
+  <text x="267" y="47" text-anchor="middle" fill="currentColor" font-size="10">internal/voice/imbe</text>
+  <text x="267" y="60" text-anchor="middle" fill="var(--fg-muted)" font-size="8">Golay/Hamming FEC</text>
+  <rect x="188" y="110" width="158" height="46" rx="6" fill="none" stroke="currentColor"/>
+  <text x="267" y="131" text-anchor="middle" fill="currentColor" font-size="10">internal/voice/ambe2</text>
+  <text x="267" y="145" text-anchor="middle" fill="var(--fg-muted)" font-size="8">BPTC + codebook</text>
+  <line x1="346" y1="47" x2="392" y2="80" stroke="currentColor"/><polygon points="386,74 396,82 384,84" fill="currentColor"/>
+  <line x1="346" y1="133" x2="392" y2="100" stroke="currentColor"/><polygon points="384,96 396,98 386,106" fill="currentColor"/>
+  <rect x="398" y="60" width="160" height="60" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="478" y="84" text-anchor="middle" fill="var(--accent)" font-size="10">internal/voice/mbe</text>
+  <text x="478" y="100" text-anchor="middle" fill="var(--fg-muted)" font-size="9">shared synthesis core</text>
+  <line x1="558" y1="90" x2="588" y2="90" stroke="currentColor"/><polygon points="588,86 598,90 588,94" fill="currentColor"/>
+  <rect x="598" y="68" width="74" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="635" y="88" text-anchor="middle" fill="currentColor" font-size="10">8 kHz</text>
+  <text x="635" y="101" text-anchor="middle" fill="var(--fg-muted)" font-size="8">PCM</text>
+</svg>
+<figcaption>The <code>Vocoder</code> registry hands the decoder "imbe" or "ambe2" by name; the two front-ends differ only in bit-unpacking and FEC, then share the single <code>internal/voice/mbe</code> synthesis core.</figcaption>
+</figure>
 
 Every vocoder satisfies one interface:
 

--- a/docs/_posts/2026-06-15-sdr-internals-13-recording-composition-streaming.md
+++ b/docs/_posts/2026-06-15-sdr-internals-13-recording-composition-streaming.md
@@ -97,8 +97,10 @@ The daemon constructs the dependency graph from configuration at startup.
 
 The recording and streaming path has plenty worth its own series — call
 segmentation heuristics, the pure-Go MP3 encoder, and the quirks of each upload
-backend's API. A future deep dive can trace one call from PCM to a Broadcastify
-upload. Next, the finale: how all of this is exposed, observed, and tested.
+backend's API. That series now exists:
+[Recording, Composition & Streaming]({{ '/blog/series/recording-streaming/' | relative_url }})
+traces one call from PCM to a Broadcastify upload across 14 parts. Next here, the
+finale: how all of this is exposed, observed, and tested.
 
 ## FAQ
 

--- a/docs/_posts/2026-06-15-sdr-internals-13-recording-composition-streaming.md
+++ b/docs/_posts/2026-06-15-sdr-internals-13-recording-composition-streaming.md
@@ -38,6 +38,33 @@ starts a call, three things have to happen on the output side:
 These are the
 [antenna-to-audio]({{ '/learn/rf-sdr/antenna-to-audio/' | relative_url }}) last mile.
 
+<figure class="lab-figure">
+<svg viewBox="0 0 680 120" width="680" height="120" role="img" aria-label="The composer's per-call demodulation chain: a voice-device IQ stream passes through an FM or protocol receiver, an audio low-pass filter, an optional AGC stage, and a resampler, emerging as 16-bit PCM handed to the recorder.">
+  <rect x="6" y="42" width="84" height="44" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="48" y="62" text-anchor="middle" fill="var(--accent)" font-size="10">IQ stream</text>
+  <text x="48" y="76" text-anchor="middle" fill="var(--fg-muted)" font-size="8">StreamIQ</text>
+  <line x1="90" y1="64" x2="102" y2="64" stroke="currentColor"/><polygon points="102,60 112,64 102,68" fill="currentColor"/>
+  <rect x="112" y="42" width="104" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="164" y="62" text-anchor="middle" fill="currentColor" font-size="10">FM / proto RX</text>
+  <text x="164" y="76" text-anchor="middle" fill="var(--fg-muted)" font-size="8">demod</text>
+  <line x1="216" y1="64" x2="228" y2="64" stroke="currentColor"/><polygon points="228,60 238,64 228,68" fill="currentColor"/>
+  <rect x="238" y="42" width="90" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="283" y="66" text-anchor="middle" fill="currentColor" font-size="10">audio LPF</text>
+  <line x1="328" y1="64" x2="340" y2="64" stroke="currentColor"/><polygon points="340,60 350,64 340,68" fill="currentColor"/>
+  <rect x="350" y="42" width="94" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="397" y="62" text-anchor="middle" fill="currentColor" font-size="10">AGC</text>
+  <text x="397" y="76" text-anchor="middle" fill="var(--fg-muted)" font-size="8">optional</text>
+  <line x1="444" y1="64" x2="456" y2="64" stroke="currentColor"/><polygon points="456,60 466,64 456,68" fill="currentColor"/>
+  <rect x="466" y="42" width="90" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="511" y="66" text-anchor="middle" fill="currentColor" font-size="10">resample</text>
+  <line x1="556" y1="64" x2="568" y2="64" stroke="currentColor"/><polygon points="568,60 578,64 568,68" fill="currentColor"/>
+  <rect x="578" y="42" width="96" height="44" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="626" y="62" text-anchor="middle" fill="var(--accent)" font-size="10">16-bit PCM</text>
+  <text x="626" y="76" text-anchor="middle" fill="var(--fg-muted)" font-size="8">to recorder</text>
+</svg>
+<figcaption>The composer (<code>internal/voice/composer</code>) runs this chain per call over consumer-owned <code>IQSource</code>/<code>PCMSink</code> interfaces, so it never imports the whole SDR or recorder packages.</figcaption>
+</figure>
+
 ## How GopherTrunk implements it in Go
 
 The **composer** (`internal/voice/composer`) bridges call events to a demod
@@ -67,6 +94,36 @@ The **broadcaster** (`internal/broadcast`) is a `Manager` that subscribes to
 `internal/voice/mp3` package, and fans it out to the configured backends
 (`broadcastify`, `rdioscanner`, `openmhz`, `icecast`) with bounded
 exponential-backoff retry.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 180" width="680" height="180" role="img" aria-label="Output fan-out on the streaming side: the recorder writes a WAV then publishes KindCallComplete; the broadcast Manager subscribes to it, encodes MP3 once with internal/voice/mp3, and pushes to four backends — Broadcastify, RdioScanner, OpenMHz and Icecast — with bounded exponential-backoff retry.">
+  <rect x="8" y="68" width="120" height="46" rx="6" fill="none" stroke="currentColor"/>
+  <text x="68" y="88" text-anchor="middle" fill="currentColor" font-size="10">recorder</text>
+  <text x="68" y="103" text-anchor="middle" fill="var(--fg-muted)" font-size="8">writes .wav</text>
+  <text x="154" y="82" text-anchor="middle" fill="var(--fg-muted)" font-size="8">KindCallComplete</text>
+  <line x1="128" y1="91" x2="178" y2="91" stroke="currentColor"/><polygon points="178,87 188,91 178,95" fill="currentColor"/>
+  <rect x="188" y="64" width="140" height="54" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="258" y="86" text-anchor="middle" fill="var(--accent)" font-size="10">broadcast.Manager</text>
+  <text x="258" y="101" text-anchor="middle" fill="var(--fg-muted)" font-size="8">subscribes complete</text>
+  <line x1="328" y1="91" x2="360" y2="91" stroke="currentColor"/><polygon points="360,87 370,91 360,95" fill="currentColor"/>
+  <rect x="370" y="68" width="108" height="46" rx="6" fill="none" stroke="currentColor"/>
+  <text x="424" y="88" text-anchor="middle" fill="currentColor" font-size="10">MP3 encode</text>
+  <text x="424" y="103" text-anchor="middle" fill="var(--fg-muted)" font-size="8">voice/mp3</text>
+  <line x1="478" y1="82" x2="540" y2="26" stroke="currentColor"/><polygon points="536,22 546,24 540,33" fill="currentColor"/>
+  <line x1="478" y1="88" x2="540" y2="70" stroke="currentColor"/><polygon points="536,66 546,68 539,77" fill="currentColor"/>
+  <line x1="478" y1="94" x2="540" y2="112" stroke="currentColor"/><polygon points="539,105 546,114 536,116" fill="currentColor"/>
+  <line x1="478" y1="100" x2="540" y2="156" stroke="currentColor"/><polygon points="538,149 546,158 534,158" fill="currentColor"/>
+  <rect x="548" y="12" width="126" height="28" rx="5" fill="none" stroke="currentColor"/>
+  <text x="611" y="30" text-anchor="middle" fill="currentColor" font-size="10">broadcastify</text>
+  <rect x="548" y="56" width="126" height="28" rx="5" fill="none" stroke="currentColor"/>
+  <text x="611" y="74" text-anchor="middle" fill="currentColor" font-size="10">rdioscanner</text>
+  <rect x="548" y="100" width="126" height="28" rx="5" fill="none" stroke="currentColor"/>
+  <text x="611" y="118" text-anchor="middle" fill="currentColor" font-size="10">openmhz</text>
+  <rect x="548" y="144" width="126" height="28" rx="5" fill="none" stroke="currentColor"/>
+  <text x="611" y="162" text-anchor="middle" fill="currentColor" font-size="10">icecast</text>
+</svg>
+<figcaption>The broadcaster is a bus subscriber, not something the recorder calls: it waits for <code>KindCallComplete</code>, encodes MP3 once, and fans the file out to each configured backend with bounded retry.</figcaption>
+</figure>
 
 ## The design principle: config-driven lazy initialization
 

--- a/docs/_posts/2026-06-16-sdr-internals-14-apis-testing-pure-go.md
+++ b/docs/_posts/2026-06-16-sdr-internals-14-apis-testing-pure-go.md
@@ -39,6 +39,30 @@ Every one of them subscribes to the event bus from
 [Part 11]({{ '/blog/deep-dives/sdr-internals-11-trunking-engine-event-bus/' | relative_url }}).
 None of them calls into the engine.
 
+<figure class="lab-figure">
+<svg viewBox="0 0 660 190" width="660" height="190" role="img" aria-label="Ports-and-adapters output surface: the engine core and its event bus sit on the left, and five adapters — internal/api for gRPC, REST and WebSocket; internal/tui; internal/metrics; internal/storage; and the web single-page console — each subscribe to the bus, while the engine imports none of them.">
+  <rect x="8" y="68" width="140" height="52" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="78" y="90" text-anchor="middle" fill="var(--accent)" font-size="11">engine core</text>
+  <text x="78" y="106" text-anchor="middle" fill="var(--fg-muted)" font-size="9">event bus (Part 11)</text>
+  <line x1="148" y1="94" x2="290" y2="22" stroke="currentColor"/><polygon points="286,18 296,20 290,29" fill="currentColor"/>
+  <line x1="148" y1="94" x2="290" y2="58" stroke="currentColor"/><polygon points="286,54 296,56 289,65" fill="currentColor"/>
+  <line x1="148" y1="94" x2="290" y2="94" stroke="currentColor"/><polygon points="290,90 300,94 290,98" fill="currentColor"/>
+  <line x1="148" y1="94" x2="290" y2="130" stroke="currentColor"/><polygon points="289,123 296,132 286,134" fill="currentColor"/>
+  <line x1="148" y1="94" x2="290" y2="166" stroke="currentColor"/><polygon points="288,159 296,168 284,168" fill="currentColor"/>
+  <rect x="300" y="8" width="340" height="28" rx="5" fill="none" stroke="currentColor"/>
+  <text x="470" y="26" text-anchor="middle" fill="currentColor" font-size="10">internal/api · gRPC / REST / WebSocket · SSE</text>
+  <rect x="300" y="44" width="340" height="28" rx="5" fill="none" stroke="currentColor"/>
+  <text x="470" y="62" text-anchor="middle" fill="currentColor" font-size="10">internal/tui · Bubbletea cockpit</text>
+  <rect x="300" y="80" width="340" height="28" rx="5" fill="none" stroke="currentColor"/>
+  <text x="470" y="98" text-anchor="middle" fill="currentColor" font-size="10">internal/metrics · Prometheus /metrics</text>
+  <rect x="300" y="116" width="340" height="28" rx="5" fill="none" stroke="currentColor"/>
+  <text x="470" y="134" text-anchor="middle" fill="currentColor" font-size="10">internal/storage · SQLite call log</text>
+  <rect x="300" y="152" width="340" height="28" rx="5" fill="none" stroke="currentColor"/>
+  <text x="470" y="170" text-anchor="middle" fill="currentColor" font-size="10">web/ · React SPA console</text>
+</svg>
+<figcaption>Every output is an adapter over one event stream. Adapters depend on the core through the bus and the core depends on none of them, so any surface can be added, removed, or tested alone.</figcaption>
+</figure>
+
 ## How GopherTrunk implements it in Go
 
 This is **ports and adapters** (a.k.a. hexagonal architecture): the engine is the
@@ -65,6 +89,27 @@ iq := demod.ModulateC4FM(dibits, sps, span, alpha, sampleRateHz, deviationHz)
 These run under `-tags integration` so they're separate from fast unit tests,
 which are table-driven (the DSP and FEC suites inject known inputs and assert
 exact outputs).
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 130" width="680" height="130" role="img" aria-label="The synthesized-IQ integration test path: a modulator and mock SDR are the only fake — the sample source — feeding real demodulator, receiver and FEC code, then the engine and event bus, ending in assertions that KindCCLocked appears and the metrics agree.">
+  <rect x="8" y="42" width="152" height="52" rx="6" fill="none" stroke="var(--accent)" stroke-dasharray="4 3"/>
+  <text x="84" y="64" text-anchor="middle" fill="var(--accent)" font-size="10">synth IQ · mock SDR</text>
+  <text x="84" y="80" text-anchor="middle" fill="var(--fg-muted)" font-size="9">the only fake</text>
+  <line x1="160" y1="68" x2="180" y2="68" stroke="currentColor"/><polygon points="180,64 190,68 180,72" fill="currentColor"/>
+  <rect x="190" y="42" width="172" height="52" rx="6" fill="none" stroke="currentColor"/>
+  <text x="276" y="64" text-anchor="middle" fill="currentColor" font-size="10">demod → receiver → FEC</text>
+  <text x="276" y="80" text-anchor="middle" fill="var(--fg-muted)" font-size="9">production code</text>
+  <line x1="362" y1="68" x2="382" y2="68" stroke="currentColor"/><polygon points="382,64 392,68 382,72" fill="currentColor"/>
+  <rect x="392" y="42" width="120" height="52" rx="6" fill="none" stroke="currentColor"/>
+  <text x="452" y="64" text-anchor="middle" fill="currentColor" font-size="10">engine + bus</text>
+  <text x="452" y="80" text-anchor="middle" fill="var(--fg-muted)" font-size="9">real path</text>
+  <line x1="512" y1="68" x2="532" y2="68" stroke="currentColor"/><polygon points="532,64 542,68 532,72" fill="currentColor"/>
+  <rect x="542" y="42" width="130" height="52" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="607" y="64" text-anchor="middle" fill="var(--accent)" font-size="10">assert CCLocked</text>
+  <text x="607" y="80" text-anchor="middle" fill="var(--fg-muted)" font-size="9">+ metrics agree</text>
+</svg>
+<figcaption>Under <code>-tags integration</code>, only the sample source is faked: the test synthesizes spec-correct IQ and runs the genuine DSP, protocol, engine, and bus code end to end.</figcaption>
+</figure>
 
 ## The design principle: ports & adapters + testability
 

--- a/docs/_posts/2026-06-18-build-in-the-open-01-picking-what-to-build.md
+++ b/docs/_posts/2026-06-18-build-in-the-open-01-picking-what-to-build.md
@@ -61,6 +61,27 @@ mentioning your solution?** "I want to build a React dashboard" is a solution.
 "I can't see all my home-lab services' health in one place" is a problem. Lead
 with the second kind.
 
+<figure class="lab-figure">
+<svg viewBox="0 0 664 130" width="664" height="130" role="img" aria-label="A funnel that narrows a raw idea into a shippable first version in four stages: many candidate ideas, then a one-sentence problem statement, then validated shared demand, then a walking-skeleton first milestone of only the Must features.">
+  <rect x="10" y="46" width="120" height="40" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="70" y="63" text-anchor="middle" fill="var(--fg-muted)" font-size="10">many ideas</text>
+  <text x="70" y="77" text-anchor="middle" fill="var(--fg-muted)" font-size="8">"a cool app"</text>
+  <line x1="130" y1="66" x2="160" y2="66" stroke="currentColor"/><polygon points="160,62 170,66 160,70" fill="currentColor"/>
+  <rect x="170" y="44" width="130" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="235" y="61" text-anchor="middle" fill="currentColor" font-size="10">problem statement</text>
+  <text x="235" y="76" text-anchor="middle" fill="var(--fg-muted)" font-size="8">one sentence, no solution</text>
+  <line x1="300" y1="66" x2="330" y2="66" stroke="currentColor"/><polygon points="330,62 340,66 330,70" fill="currentColor"/>
+  <rect x="340" y="46" width="120" height="40" rx="6" fill="none" stroke="currentColor"/>
+  <text x="400" y="63" text-anchor="middle" fill="currentColor" font-size="10">validated demand</text>
+  <text x="400" y="77" text-anchor="middle" fill="var(--fg-muted)" font-size="8">others share the pain</text>
+  <line x1="460" y1="66" x2="490" y2="66" stroke="currentColor"/><polygon points="490,62 500,66 490,70" fill="currentColor"/>
+  <rect x="500" y="48" width="154" height="38" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="577" y="64" text-anchor="middle" fill="var(--accent)" font-size="10">walking skeleton</text>
+  <text x="577" y="78" text-anchor="middle" fill="var(--fg-muted)" font-size="8">Musts only — ship in weeks</text>
+</svg>
+<figcaption>The funnel from Part 1: a raw idea narrows to a one-sentence problem, then to validated demand, then to a walking skeleton of only the Must features.</figcaption>
+</figure>
+
 ## Validate that the problem is real (and shared)
 
 Scratching your own itch gets you a user of one. Before you sink months in, do a
@@ -101,6 +122,41 @@ The walking skeleton matters because it forces every layer of the system to
 exist, even if each is minimal. That flushes out the hard integration problems
 early, when they're cheap to fix, instead of after you've polished a feature
 nobody can reach yet.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 176" width="660" height="176" role="img" aria-label="A build-versus-skip decision tree: ask whether you feel the itch personally, whether others share the pain, and whether a first version fits in a few weeks. A no on any question routes to shelve, reassess, or narrow the idea; three yeses route to build it.">
+  <rect x="8" y="20" width="140" height="46" rx="6" fill="none" stroke="currentColor"/>
+  <text x="78" y="40" text-anchor="middle" fill="currentColor" font-size="10">feel the itch</text>
+  <text x="78" y="54" text-anchor="middle" fill="currentColor" font-size="10">yourself?</text>
+  <line x1="148" y1="43" x2="188" y2="43" stroke="currentColor"/><polygon points="188,39 198,43 188,47" fill="currentColor"/>
+  <text x="168" y="36" text-anchor="middle" fill="var(--fg-muted)" font-size="8">yes</text>
+  <rect x="198" y="20" width="140" height="46" rx="6" fill="none" stroke="currentColor"/>
+  <text x="268" y="40" text-anchor="middle" fill="currentColor" font-size="10">others share</text>
+  <text x="268" y="54" text-anchor="middle" fill="currentColor" font-size="10">the pain?</text>
+  <line x1="338" y1="43" x2="378" y2="43" stroke="currentColor"/><polygon points="378,39 388,43 378,47" fill="currentColor"/>
+  <text x="358" y="36" text-anchor="middle" fill="var(--fg-muted)" font-size="8">yes</text>
+  <rect x="388" y="20" width="150" height="46" rx="6" fill="none" stroke="currentColor"/>
+  <text x="463" y="40" text-anchor="middle" fill="currentColor" font-size="10">v1 fits in</text>
+  <text x="463" y="54" text-anchor="middle" fill="currentColor" font-size="10">a few weeks?</text>
+  <line x1="538" y1="43" x2="578" y2="43" stroke="var(--accent)"/><polygon points="578,39 588,43 578,47" fill="var(--accent)"/>
+  <text x="558" y="36" text-anchor="middle" fill="var(--fg-muted)" font-size="8">yes</text>
+  <rect x="588" y="24" width="64" height="38" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="620" y="47" text-anchor="middle" fill="var(--accent)" font-size="11">BUILD</text>
+  <line x1="78" y1="66" x2="78" y2="130" stroke="var(--fg-muted)"/><polygon points="74,130 78,140 82,130" fill="var(--fg-muted)"/>
+  <text x="90" y="102" text-anchor="middle" fill="var(--fg-muted)" font-size="8">no</text>
+  <line x1="268" y1="66" x2="268" y2="130" stroke="var(--fg-muted)"/><polygon points="264,130 268,140 272,130" fill="var(--fg-muted)"/>
+  <text x="280" y="102" text-anchor="middle" fill="var(--fg-muted)" font-size="8">no</text>
+  <line x1="463" y1="66" x2="463" y2="130" stroke="var(--fg-muted)"/><polygon points="459,130 463,140 467,130" fill="var(--fg-muted)"/>
+  <text x="475" y="102" text-anchor="middle" fill="var(--fg-muted)" font-size="8">no</text>
+  <rect x="18" y="140" width="120" height="28" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="78" y="158" text-anchor="middle" fill="var(--fg-muted)" font-size="9">shelve it</text>
+  <rect x="208" y="140" width="120" height="28" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="268" y="158" text-anchor="middle" fill="var(--fg-muted)" font-size="9">user of one — reassess</text>
+  <rect x="403" y="140" width="120" height="28" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="463" y="158" text-anchor="middle" fill="var(--fg-muted)" font-size="9">narrow the scope</text>
+</svg>
+<figcaption>The build-versus-skip test: a personal itch, shared pain, and a few-weeks scope all have to hold; a no on any one sends the idea back to shelve, reassess, or narrow before you write code.</figcaption>
+</figure>
 
 ## Write it down before you write code
 

--- a/docs/_posts/2026-06-18-rf-front-end-01-why-pure-go-drivers.md
+++ b/docs/_posts/2026-06-18-rf-front-end-01-why-pure-go-drivers.md
@@ -120,6 +120,31 @@ directly — USBDEVFS on Linux, WinUSB on Windows, IOKit on macOS — instead of
 linking a C USB stack. The build stays `CGO_ENABLED=0`, and `go build` keeps
 cross-compiling to every target with no toolchain gymnastics.
 
+<figure class="lab-figure">
+<svg viewBox="0 0 660 220" width="660" height="220" role="img" aria-label="Two USB stacks compared. The conventional CGO stack routes the scanner through librtlsdr and libusb, both C shared libraries, before reaching the kernel USB interface. GopherTrunk's pure-Go stack calls the same kernel USB interface directly with no C libraries in between.">
+  <text x="150" y="18" text-anchor="middle" fill="var(--fg-muted)" font-size="10">conventional (CGO)</text>
+  <text x="510" y="18" text-anchor="middle" fill="var(--accent)" font-size="10">GopherTrunk (pure Go)</text>
+  <rect x="60" y="30" width="180" height="30" rx="6" fill="none" stroke="currentColor"/>
+  <text x="150" y="49" text-anchor="middle" fill="currentColor" font-size="10">scanner (Go)</text>
+  <line x1="150" y1="60" x2="150" y2="76" stroke="currentColor"/><polygon points="146,76 150,84 154,76" fill="currentColor"/>
+  <rect x="60" y="84" width="180" height="30" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="150" y="103" text-anchor="middle" fill="var(--fg-muted)" font-size="10">librtlsdr / libhackrf (C)</text>
+  <line x1="150" y1="114" x2="150" y2="130" stroke="currentColor"/><polygon points="146,130 150,138 154,130" fill="currentColor"/>
+  <rect x="60" y="138" width="180" height="30" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="150" y="157" text-anchor="middle" fill="var(--fg-muted)" font-size="10">libusb (C)</text>
+  <line x1="150" y1="168" x2="150" y2="184" stroke="currentColor"/><polygon points="146,184 150,192 154,184" fill="currentColor"/>
+  <rect x="60" y="192" width="180" height="26" rx="6" fill="none" stroke="currentColor"/>
+  <text x="150" y="209" text-anchor="middle" fill="currentColor" font-size="10">kernel USB interface</text>
+  <rect x="420" y="30" width="180" height="30" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="510" y="49" text-anchor="middle" fill="var(--accent)" font-size="10">scanner + Go USB driver</text>
+  <line x1="510" y1="60" x2="510" y2="184" stroke="var(--accent)"/><polygon points="506,184 510,192 514,184" fill="var(--accent)"/>
+  <text x="524" y="128" fill="var(--fg-muted)" font-size="9">no C libraries</text>
+  <rect x="420" y="192" width="180" height="26" rx="6" fill="none" stroke="currentColor"/>
+  <text x="510" y="209" text-anchor="middle" fill="currentColor" font-size="10">kernel USB interface</text>
+</svg>
+<figcaption>The CGO path drags in <code>librtlsdr</code> and <code>libusb</code> as C shared libraries that must be present and version-matched; GopherTrunk's pure-Go driver reaches the same kernel USB interface directly, so the build stays <code>CGO_ENABLED=0</code>.</figcaption>
+</figure>
+
 The cost of refusing the tax is that we have to *write* the USB transport and the
 chip protocols ourselves. That cost is exactly what this series documents.
 
@@ -134,6 +159,28 @@ out to a C toolchain. For a daemon that is meant to run unattended at the antenn
 often on a Raspberry Pi or a small ARM box — "one static binary with no shared
 libraries to drift out from under it" is a reliability feature, not just a
 packaging convenience.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 190" width="660" height="190" role="img" aria-label="One Go source tree cross-compiles with GOOS and GOARCH to a single static binary for Linux, macOS, and Windows, each talking to that platform's native USB API: USBDEVFS, IOKit, and WinUSB respectively.">
+  <rect x="8" y="72" width="150" height="46" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="83" y="92" text-anchor="middle" fill="var(--accent)" font-size="11">one Go source tree</text>
+  <text x="83" y="108" text-anchor="middle" fill="var(--fg-muted)" font-size="9">CGO_ENABLED=0</text>
+  <text x="250" y="88" text-anchor="middle" fill="var(--fg-muted)" font-size="9">go build GOOS/GOARCH</text>
+  <line x1="158" y1="95" x2="360" y2="36" stroke="currentColor"/><polygon points="352,32 362,36 352,40" fill="currentColor"/>
+  <line x1="158" y1="95" x2="360" y2="95" stroke="currentColor"/><polygon points="360,91 370,95 360,99" fill="currentColor"/>
+  <line x1="158" y1="95" x2="360" y2="154" stroke="currentColor"/><polygon points="352,150 362,154 352,158" fill="currentColor"/>
+  <rect x="370" y="16" width="270" height="40" rx="6" fill="none" stroke="currentColor"/>
+  <text x="505" y="34" text-anchor="middle" fill="currentColor" font-size="10">Linux binary → USBDEVFS</text>
+  <text x="505" y="48" text-anchor="middle" fill="var(--fg-muted)" font-size="9">single static binary</text>
+  <rect x="370" y="75" width="270" height="40" rx="6" fill="none" stroke="currentColor"/>
+  <text x="505" y="93" text-anchor="middle" fill="currentColor" font-size="10">macOS binary → IOKit</text>
+  <text x="505" y="107" text-anchor="middle" fill="var(--fg-muted)" font-size="9">single static binary</text>
+  <rect x="370" y="134" width="270" height="40" rx="6" fill="none" stroke="currentColor"/>
+  <text x="505" y="152" text-anchor="middle" fill="currentColor" font-size="10">Windows binary → WinUSB</text>
+  <text x="505" y="166" text-anchor="middle" fill="var(--fg-muted)" font-size="9">single static binary</text>
+</svg>
+<figcaption>The same source tree cross-compiles with <code>GOOS</code>/<code>GOARCH</code> to one static binary per OS, each speaking that platform's native USB interface — no C toolchain and no shared libraries to drift out from under the operator.</figcaption>
+</figure>
 
 The other half of the payoff is on *our* side of the build. Because every byte
 from the USB endpoint to the `complex64` is Go, the whole RF front end is in scope

--- a/docs/_posts/2026-06-19-build-in-the-open-02-choosing-language-platforms-stack.md
+++ b/docs/_posts/2026-06-19-build-in-the-open-02-choosing-language-platforms-stack.md
@@ -69,6 +69,33 @@ Notice that "which language is best" isn't on the list. There's no best
 language, only a best *fit* for a specific set of constraints. The same problem
 can have different right answers for a solo hobbyist and a ten-person team.
 
+<figure class="lab-figure">
+<svg viewBox="0 0 660 184" width="660" height="184" role="img" aria-label="A constraint-driven stack decision map: five constraints — where it runs, performance, distribution, ecosystem, and existing skills — feed a language choice, which makes a single static binary that cross-compiles to the target operating systems Linux, macOS, and Windows.">
+  <rect x="8" y="20" width="150" height="144" rx="6" fill="none" stroke="currentColor"/>
+  <text x="83" y="38" text-anchor="middle" fill="var(--fg-muted)" font-size="9">constraints</text>
+  <text x="83" y="60" text-anchor="middle" fill="currentColor" font-size="10">where it runs</text>
+  <text x="83" y="80" text-anchor="middle" fill="currentColor" font-size="10">performance</text>
+  <text x="83" y="100" text-anchor="middle" fill="currentColor" font-size="10">distribution</text>
+  <text x="83" y="120" text-anchor="middle" fill="currentColor" font-size="10">ecosystem</text>
+  <text x="83" y="140" text-anchor="middle" fill="currentColor" font-size="10">skills you have</text>
+  <line x1="158" y1="92" x2="200" y2="92" stroke="currentColor"/><polygon points="200,88 210,92 200,96" fill="currentColor"/>
+  <rect x="210" y="66" width="150" height="52" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="285" y="88" text-anchor="middle" fill="var(--accent)" font-size="11">language choice</text>
+  <text x="285" y="104" text-anchor="middle" fill="var(--fg-muted)" font-size="8">best fit, not best</text>
+  <line x1="360" y1="92" x2="402" y2="92" stroke="currentColor"/><polygon points="402,88 412,92 402,96" fill="currentColor"/>
+  <rect x="412" y="66" width="150" height="52" rx="6" fill="none" stroke="currentColor"/>
+  <text x="487" y="88" text-anchor="middle" fill="currentColor" font-size="10">single static binary</text>
+  <text x="487" y="104" text-anchor="middle" fill="var(--fg-muted)" font-size="8">download &amp; run</text>
+  <line x1="562" y1="80" x2="600" y2="46" stroke="currentColor"/><polygon points="596,42 606,44 600,53" fill="currentColor"/>
+  <line x1="562" y1="92" x2="600" y2="92" stroke="currentColor"/><polygon points="600,88 610,92 600,96" fill="currentColor"/>
+  <line x1="562" y1="104" x2="600" y2="138" stroke="currentColor"/><polygon points="596,131 606,140 594,140" fill="currentColor"/>
+  <rect x="600" y="32" width="54" height="24" rx="5" fill="none" stroke="var(--fg-muted)"/><text x="627" y="48" text-anchor="middle" fill="var(--fg-muted)" font-size="9">Linux</text>
+  <rect x="600" y="80" width="54" height="24" rx="5" fill="none" stroke="var(--fg-muted)"/><text x="627" y="96" text-anchor="middle" fill="var(--fg-muted)" font-size="9">macOS</text>
+  <rect x="600" y="128" width="54" height="24" rx="5" fill="none" stroke="var(--fg-muted)"/><text x="627" y="144" text-anchor="middle" fill="var(--fg-muted)" font-size="8">Windows</text>
+</svg>
+<figcaption>Constraints, not taste, pick the stack: five questions select a language, the language makes "download and run" real via a single static binary, and that binary cross-compiles to Linux, macOS, and Windows.</figcaption>
+</figure>
+
 ## Why boring technology usually wins
 
 Once a few candidates survive the constraint checklist, prefer the **boring**
@@ -135,6 +162,26 @@ a fix or feature you need lands. Your future self and your CI both thank you.
 
 [GopherTrunk](https://github.com/MattCheramie/GopherTrunk) is a digital-trunking
 SDR scanner, and every stack decision traces straight back to a constraint.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 176" width="660" height="176" role="img" aria-label="How each GopherTrunk stack choice traces to a constraint: needing no C dependencies and a single binary selects pure Go with CGO disabled; needing a database selects the pure-Go modernc.org/sqlite driver; needing a browser console selects a prebuilt React and Vite bundle; needing reproducible patched builds pins the Go 1.25.11 toolchain.">
+  <text x="150" y="22" text-anchor="middle" fill="var(--fg-muted)" font-size="10">constraint</text>
+  <text x="501" y="22" text-anchor="middle" fill="var(--fg-muted)" font-size="10">GopherTrunk choice</text>
+  <rect x="20" y="34" width="260" height="28" rx="5" fill="none" stroke="currentColor"/><text x="150" y="52" text-anchor="middle" fill="currentColor" font-size="10">no C deps · single binary</text>
+  <line x1="280" y1="48" x2="352" y2="48" stroke="currentColor"/><polygon points="352,44 362,48 352,52" fill="currentColor"/>
+  <rect x="362" y="34" width="278" height="28" rx="5" fill="none" stroke="var(--accent)"/><text x="501" y="52" text-anchor="middle" fill="var(--accent)" font-size="10">pure Go · CGO_ENABLED=0</text>
+  <rect x="20" y="70" width="260" height="28" rx="5" fill="none" stroke="currentColor"/><text x="150" y="88" text-anchor="middle" fill="currentColor" font-size="10">needs a database</text>
+  <line x1="280" y1="84" x2="352" y2="84" stroke="currentColor"/><polygon points="352,80 362,84 352,88" fill="currentColor"/>
+  <rect x="362" y="70" width="278" height="28" rx="5" fill="none" stroke="currentColor"/><text x="501" y="88" text-anchor="middle" fill="currentColor" font-size="10">modernc.org/sqlite (pure Go)</text>
+  <rect x="20" y="106" width="260" height="28" rx="5" fill="none" stroke="currentColor"/><text x="150" y="124" text-anchor="middle" fill="currentColor" font-size="10">browser operator console</text>
+  <line x1="280" y1="120" x2="352" y2="120" stroke="currentColor"/><polygon points="352,116 362,120 352,124" fill="currentColor"/>
+  <rect x="362" y="106" width="278" height="28" rx="5" fill="none" stroke="currentColor"/><text x="501" y="124" text-anchor="middle" fill="currentColor" font-size="10">React 18 + Vite static bundle</text>
+  <rect x="20" y="142" width="260" height="28" rx="5" fill="none" stroke="currentColor"/><text x="150" y="160" text-anchor="middle" fill="currentColor" font-size="10">reproducible, patched builds</text>
+  <line x1="280" y1="156" x2="352" y2="156" stroke="currentColor"/><polygon points="352,152 362,156 352,160" fill="currentColor"/>
+  <rect x="362" y="142" width="278" height="28" rx="5" fill="none" stroke="currentColor"/><text x="501" y="160" text-anchor="middle" fill="currentColor" font-size="10">toolchain go1.25.11</text>
+</svg>
+<figcaption>Every GopherTrunk stack choice traces to a constraint — the no-C-dependencies, single-binary goal is why Go, <code>modernc.org/sqlite</code>, a prebuilt web bundle, and a pinned toolchain were all chosen.</figcaption>
+</figure>
 
 - **Language: pure Go, with `CGO_ENABLED=0`.** The problem statement from Part 1
   was essentially "there's no SDR scanner that installs as a single,

--- a/docs/_posts/2026-06-19-rf-front-end-02-the-device-contract.md
+++ b/docs/_posts/2026-06-19-rf-front-end-02-the-device-contract.md
@@ -69,6 +69,35 @@ close. Anything one radio can do that another cannot is, by definition, *not* in
 discipline to keep it that way is what lets a recorded WAV file or a network
 socket satisfy the same eight methods as a $25 dongle.
 
+<figure class="lab-figure">
+<svg viewBox="0 0 660 210" width="660" height="210" role="img" aria-label="The trunking engine depends only on the eight-method Device interface — Info, SetCenterFreq, SetSampleRate, SetGain, SetPPM, SetBiasTee, StreamIQ, Close. Five backends implement it: RTL-SDR, Airspy R2 or Mini, Airspy HF+, HackRF One, and the rtltcp and mock drivers.">
+  <rect x="8" y="88" width="120" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="68" y="114" text-anchor="middle" fill="currentColor" font-size="10">trunking engine</text>
+  <line x1="128" y1="110" x2="170" y2="110" stroke="currentColor"/><polygon points="170,106 180,110 170,114" fill="currentColor"/>
+  <rect x="180" y="22" width="180" height="168" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="270" y="40" text-anchor="middle" fill="var(--accent)" font-size="11">Device interface</text>
+  <text x="270" y="60" text-anchor="middle" fill="currentColor" font-size="10">Info()</text>
+  <text x="270" y="78" text-anchor="middle" fill="currentColor" font-size="10">SetCenterFreq</text>
+  <text x="270" y="96" text-anchor="middle" fill="currentColor" font-size="10">SetSampleRate</text>
+  <text x="270" y="114" text-anchor="middle" fill="currentColor" font-size="10">SetGain (-1 = AGC)</text>
+  <text x="270" y="132" text-anchor="middle" fill="currentColor" font-size="10">SetPPM</text>
+  <text x="270" y="150" text-anchor="middle" fill="currentColor" font-size="10">SetBiasTee</text>
+  <text x="270" y="168" text-anchor="middle" fill="currentColor" font-size="10">StreamIQ</text>
+  <text x="270" y="184" text-anchor="middle" fill="currentColor" font-size="10">Close</text>
+  <line x1="470" y1="30" x2="372" y2="30" stroke="currentColor"/><polygon points="372,26 362,30 372,34" fill="currentColor"/>
+  <line x1="470" y1="66" x2="372" y2="66" stroke="currentColor"/><polygon points="372,62 362,66 372,70" fill="currentColor"/>
+  <line x1="470" y1="102" x2="372" y2="102" stroke="currentColor"/><polygon points="372,98 362,102 372,106" fill="currentColor"/>
+  <line x1="470" y1="138" x2="372" y2="138" stroke="currentColor"/><polygon points="372,134 362,138 372,142" fill="currentColor"/>
+  <line x1="470" y1="174" x2="372" y2="174" stroke="currentColor"/><polygon points="372,170 362,174 372,178" fill="currentColor"/>
+  <rect x="472" y="16" width="180" height="28" rx="6" fill="none" stroke="currentColor"/><text x="562" y="34" text-anchor="middle" fill="currentColor" font-size="10">RTL-SDR (R820T)</text>
+  <rect x="472" y="52" width="180" height="28" rx="6" fill="none" stroke="currentColor"/><text x="562" y="70" text-anchor="middle" fill="currentColor" font-size="10">Airspy R2 / Mini</text>
+  <rect x="472" y="88" width="180" height="28" rx="6" fill="none" stroke="currentColor"/><text x="562" y="106" text-anchor="middle" fill="currentColor" font-size="10">Airspy HF+</text>
+  <rect x="472" y="124" width="180" height="28" rx="6" fill="none" stroke="currentColor"/><text x="562" y="142" text-anchor="middle" fill="currentColor" font-size="10">HackRF One</text>
+  <rect x="472" y="160" width="180" height="28" rx="6" fill="none" stroke="var(--fg-muted)"/><text x="562" y="178" text-anchor="middle" fill="var(--fg-muted)" font-size="10">rtltcp · mock</text>
+</svg>
+<figcaption>The engine only ever sees the eight-method <code>Device</code> contract; every backend — three USB radio families plus the network and mock drivers — implements it, so nothing chip-specific leaks upward.</figcaption>
+</figure>
+
 ## How GopherTrunk implements it in Go
 
 ### Identity: `Info`
@@ -199,7 +228,29 @@ if d, ok := dev.(sdr.BlogV4Forcer); ok {
 The type assertion succeeds for the RTL-SDR driver and fails — cleanly, with `ok
 == false` — for every other backend. The Blog V4 fix reaches exactly the hardware
 that needs it, and the Airspy and HackRF drivers never hear about a 28.8 MHz
-crystal. The doc comments on both interfaces even encode the failure signature:
+crystal.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 190" width="660" height="190" role="img" aria-label="A caller type-asserts a Device value to the BlogV4Forcer interface. The assertion returns ok equals true only for the RTL-SDR driver, which then calls SetBlogV4, and returns ok equals false for the Airspy and HackRF drivers, which are skipped, leaving the Device contract untouched.">
+  <rect x="8" y="72" width="100" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="58" y="98" text-anchor="middle" fill="currentColor" font-size="10">dev (Device)</text>
+  <line x1="108" y1="94" x2="148" y2="94" stroke="currentColor"/><polygon points="148,90 158,94 148,98" fill="currentColor"/>
+  <rect x="160" y="66" width="200" height="56" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="260" y="90" text-anchor="middle" fill="var(--fg-muted)" font-size="9">type assertion</text>
+  <text x="260" y="108" text-anchor="middle" fill="var(--accent)" font-size="10">dev.(sdr.BlogV4Forcer)</text>
+  <line x1="360" y1="80" x2="430" y2="40" stroke="currentColor"/><polygon points="422,36 432,40 422,44" fill="currentColor"/>
+  <line x1="360" y1="108" x2="430" y2="150" stroke="currentColor"/><polygon points="422,146 432,150 422,154" fill="currentColor"/>
+  <rect x="430" y="18" width="222" height="44" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="541" y="36" text-anchor="middle" fill="var(--accent)" font-size="10">ok == true → RTL-SDR</text>
+  <text x="541" y="52" text-anchor="middle" fill="currentColor" font-size="10">d.SetBlogV4(lite)</text>
+  <rect x="430" y="128" width="222" height="44" rx="6" fill="none" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <text x="541" y="146" text-anchor="middle" fill="var(--fg-muted)" font-size="10">ok == false → Airspy, HackRF</text>
+  <text x="541" y="162" text-anchor="middle" fill="var(--fg-muted)" font-size="10">skip · Device untouched</text>
+</svg>
+<figcaption>The optional quirk is discovered, not assumed: <code>dev.(sdr.BlogV4Forcer)</code> succeeds only for the RTL-SDR driver, so the Blog V4 fix reaches exactly that hardware while every other radio falls through with <code>ok == false</code>.</figcaption>
+</figure>
+
+The doc comments on both interfaces even encode the failure signature:
 "`xtalHz` of 16 MHz on an R828D is the signature that RTL-SDR Blog V4
 auto-detection missed and the LO is mistuned by ~1.8×."
 

--- a/docs/_posts/2026-06-20-build-in-the-open-03-brainstorm-with-claude-readme-roadmap.md
+++ b/docs/_posts/2026-06-20-build-in-the-open-03-brainstorm-with-claude-readme-roadmap.md
@@ -73,6 +73,32 @@ Two habits make this trustworthy. First, **ask for sources or reasoning**, not
 just conclusions, so you can sanity-check. Second, remember Claude is generating
 candidates — the *judgment* about what's actually worth building is yours.
 
+<figure class="lab-figure">
+<svg viewBox="0 0 640 190" width="640" height="190" role="img" aria-label="An AI-assisted planning loop: your problem statement feeds Claude Code, which proposes a domain map, a competitor scan, and a candidate feature list; you prioritize those candidates into Must, Should, Could and Won't; and a refined prompt loops back to Claude. A CLAUDE.md file supplies standing rules to every pass.">
+  <rect x="16" y="76" width="130" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="81" y="94" text-anchor="middle" fill="currentColor" font-size="10">problem</text>
+  <text x="81" y="108" text-anchor="middle" fill="currentColor" font-size="10">statement</text>
+  <line x1="146" y1="98" x2="182" y2="98" stroke="currentColor"/><polygon points="182,94 192,98 182,102" fill="currentColor"/>
+  <rect x="192" y="70" width="170" height="56" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="277" y="90" text-anchor="middle" fill="var(--accent)" font-size="10">Claude proposes</text>
+  <text x="277" y="104" text-anchor="middle" fill="var(--fg-muted)" font-size="8">domain map · competitor scan</text>
+  <text x="277" y="116" text-anchor="middle" fill="var(--fg-muted)" font-size="8">candidate feature list</text>
+  <line x1="362" y1="98" x2="398" y2="98" stroke="currentColor"/><polygon points="398,94 408,98 398,102" fill="currentColor"/>
+  <rect x="408" y="70" width="170" height="56" rx="6" fill="none" stroke="currentColor"/>
+  <text x="493" y="90" text-anchor="middle" fill="currentColor" font-size="10">you prioritize</text>
+  <text x="493" y="104" text-anchor="middle" fill="var(--fg-muted)" font-size="8">Must · Should</text>
+  <text x="493" y="116" text-anchor="middle" fill="var(--fg-muted)" font-size="8">Could · Won't</text>
+  <line x1="493" y1="126" x2="493" y2="158" stroke="currentColor"/>
+  <line x1="493" y1="158" x2="277" y2="158" stroke="currentColor"/>
+  <line x1="277" y1="158" x2="277" y2="126" stroke="currentColor"/><polygon points="273,134 277,124 281,134" fill="currentColor"/>
+  <text x="385" y="153" text-anchor="middle" fill="var(--fg-muted)" font-size="8">refine the prompt, repeat</text>
+  <rect x="192" y="16" width="170" height="26" rx="6" fill="none" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <text x="277" y="33" text-anchor="middle" fill="var(--fg-muted)" font-size="9">CLAUDE.md · standing rules</text>
+  <line x1="277" y1="42" x2="277" y2="68" stroke="var(--fg-muted)" stroke-dasharray="4 3"/><polygon points="273,60 277,70 281,60" fill="var(--fg-muted)"/>
+</svg>
+<figcaption>The AI-assisted planning loop: Claude proposes candidates, you prioritize with MoSCoW, and a refined prompt loops back — with <code>CLAUDE.md</code> supplying standing rules to every pass.</figcaption>
+</figure>
+
 ## From brainstorm to a prioritized list
 
 A brainstorm gives you breadth; a project needs a spine. Converge the long list
@@ -125,6 +151,27 @@ Keep the README's snapshot short and link out to deeper planning documents — a
 and a `CHANGELOG.md` for what's already shipped. The README summarizes; those
 docs carry the detail. Update the snapshot whenever reality changes, and it stays
 trustworthy.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 168" width="660" height="168" role="img" aria-label="The flow from a prioritized feature list into a README that doubles as a roadmap: the list becomes the README's what-is-this, quick start, features, and status snapshot; the status snapshot links out to roadmap.md, status.md, and CHANGELOG.md; and a build step synthesizes the website landing page from the same README.">
+  <rect x="12" y="60" width="120" height="48" rx="6" fill="none" stroke="currentColor"/>
+  <text x="72" y="80" text-anchor="middle" fill="currentColor" font-size="10">prioritized</text>
+  <text x="72" y="94" text-anchor="middle" fill="currentColor" font-size="10">feature list</text>
+  <line x1="132" y1="84" x2="164" y2="84" stroke="currentColor"/><polygon points="164,80 174,84 164,88" fill="currentColor"/>
+  <rect x="174" y="46" width="150" height="76" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="249" y="64" text-anchor="middle" fill="var(--accent)" font-size="11">README.md</text>
+  <text x="249" y="80" text-anchor="middle" fill="var(--fg-muted)" font-size="8">what is this? · quick start</text>
+  <text x="249" y="92" text-anchor="middle" fill="var(--fg-muted)" font-size="8">features</text>
+  <text x="249" y="110" text-anchor="middle" fill="currentColor" font-size="9">status snapshot</text>
+  <line x1="324" y1="84" x2="356" y2="84" stroke="currentColor"/><polygon points="356,80 366,84 356,88" fill="currentColor"/>
+  <rect x="366" y="40" width="150" height="26" rx="5" fill="none" stroke="var(--fg-muted)"/><text x="441" y="57" text-anchor="middle" fill="var(--fg-muted)" font-size="9">docs/roadmap.md</text>
+  <rect x="366" y="71" width="150" height="26" rx="5" fill="none" stroke="var(--fg-muted)"/><text x="441" y="88" text-anchor="middle" fill="var(--fg-muted)" font-size="9">docs/status.md</text>
+  <rect x="366" y="102" width="150" height="26" rx="5" fill="none" stroke="var(--fg-muted)"/><text x="441" y="119" text-anchor="middle" fill="var(--fg-muted)" font-size="9">CHANGELOG.md</text>
+  <line x1="249" y1="122" x2="249" y2="140" stroke="currentColor"/><polygon points="245,132 249,142 253,132" fill="currentColor"/>
+  <rect x="150" y="140" width="198" height="22" rx="5" fill="none" stroke="currentColor"/><text x="249" y="155" text-anchor="middle" fill="currentColor" font-size="9">pages.yml → website landing page</text>
+</svg>
+<figcaption>The prioritized list becomes a README that doubles as a roadmap; its status snapshot links out to <code>roadmap.md</code>, <code>status.md</code>, and <code>CHANGELOG.md</code>, and the same README is synthesized into the website landing page.</figcaption>
+</figure>
 
 ## What CLAUDE.md is
 

--- a/docs/_posts/2026-06-20-rf-front-end-03-driver-registry-enumeration.md
+++ b/docs/_posts/2026-06-20-rf-front-end-03-driver-registry-enumeration.md
@@ -117,6 +117,32 @@ import (
 That import block *is* the hardware-support list. Want a build that only talks to
 RTL-SDR? Drop three lines. The engine doesn't change; the binary's import set does.
 
+<figure class="lab-figure">
+<svg viewBox="0 0 660 200" width="660" height="200" role="img" aria-label="The blank imports in cmd/gophertrunk trigger each driver package's init function, which calls sdr.Register to populate the process-global registry, a map from driver name to Driver.">
+  <rect x="8" y="50" width="160" height="100" rx="6" fill="none" stroke="currentColor"/>
+  <text x="88" y="68" text-anchor="middle" fill="currentColor" font-size="10">cmd/gophertrunk (main)</text>
+  <text x="88" y="88" text-anchor="middle" fill="var(--fg-muted)" font-size="9">_ import airspy</text>
+  <text x="88" y="104" text-anchor="middle" fill="var(--fg-muted)" font-size="9">_ import airspyhf</text>
+  <text x="88" y="120" text-anchor="middle" fill="var(--fg-muted)" font-size="9">_ import hackrf</text>
+  <text x="88" y="136" text-anchor="middle" fill="var(--fg-muted)" font-size="9">_ import rtlsdr/purego</text>
+  <line x1="168" y1="100" x2="200" y2="100" stroke="currentColor"/><polygon points="200,96 210,100 200,104" fill="currentColor"/>
+  <rect x="210" y="78" width="90" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="255" y="104" text-anchor="middle" fill="currentColor" font-size="10">init()</text>
+  <line x1="300" y1="100" x2="332" y2="100" stroke="currentColor"/><polygon points="332,96 342,100 332,104" fill="currentColor"/>
+  <rect x="342" y="74" width="140" height="52" rx="6" fill="none" stroke="currentColor"/>
+  <text x="412" y="96" text-anchor="middle" fill="currentColor" font-size="10">sdr.Register</text>
+  <text x="412" y="112" text-anchor="middle" fill="currentColor" font-size="10">(&amp;Driver{})</text>
+  <line x1="482" y1="100" x2="514" y2="100" stroke="currentColor"/><polygon points="514,96 524,100 514,104" fill="currentColor"/>
+  <rect x="524" y="50" width="128" height="100" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="588" y="70" text-anchor="middle" fill="var(--accent)" font-size="11">registry</text>
+  <text x="588" y="88" text-anchor="middle" fill="var(--fg-muted)" font-size="9">map[string]Driver</text>
+  <text x="588" y="108" text-anchor="middle" fill="currentColor" font-size="9">"airspy" →</text>
+  <text x="588" y="123" text-anchor="middle" fill="currentColor" font-size="9">"hackrf" →</text>
+  <text x="588" y="138" text-anchor="middle" fill="currentColor" font-size="9">"rtlsdr" →</text>
+</svg>
+<figcaption>Registration is a side effect of importing: a blank import pulls a driver package in, its <code>init()</code> calls <code>sdr.Register</code>, and the driver lands in the process-global <code>map[string]Driver</code> — the core never names a concrete type.</figcaption>
+</figure>
+
 This is more than a tidy trick — it is the mechanism by which the engine stays
 genuinely ignorant of its drivers. The `internal/sdr` package, which defines
 `Device`, `Driver`, and the registry, does *not* import the driver sub-packages;
@@ -190,6 +216,31 @@ The `continue` is the whole fix: a driver that errors contributes an entry to
 device list plus one error per driver that failed to enumerate, so callers can
 surface the failure instead of silently reporting an empty list." The operator now
 sees their RTL-SDR *and* a precise note about which backend failed and why.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 200" width="660" height="200" role="img" aria-label="EnumerateAll walks each driver returned by Drivers, sorted by name, and calls Enumerate. On success it appends the driver's devices to the out list; on error it appends one error and continues. Both paths feed the returned out and errs pair, so one failing backend cannot blank out the others.">
+  <rect x="8" y="78" width="120" height="48" rx="6" fill="none" stroke="currentColor"/>
+  <text x="68" y="98" text-anchor="middle" fill="currentColor" font-size="10">Drivers()</text>
+  <text x="68" y="114" text-anchor="middle" fill="var(--fg-muted)" font-size="9">sorted by name</text>
+  <line x1="128" y1="102" x2="160" y2="102" stroke="currentColor"/><polygon points="160,98 170,102 160,106" fill="currentColor"/>
+  <rect x="170" y="78" width="130" height="48" rx="6" fill="none" stroke="currentColor"/>
+  <text x="235" y="106" text-anchor="middle" fill="currentColor" font-size="10">d.Enumerate()</text>
+  <line x1="300" y1="90" x2="320" y2="42" stroke="currentColor"/><polygon points="312,38 322,42 312,46" fill="currentColor"/>
+  <line x1="300" y1="114" x2="320" y2="154" stroke="currentColor"/><polygon points="312,150 322,154 312,158" fill="currentColor"/>
+  <rect x="320" y="20" width="210" height="44" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="425" y="38" text-anchor="middle" fill="var(--accent)" font-size="10">success</text>
+  <text x="425" y="54" text-anchor="middle" fill="currentColor" font-size="10">out += infos</text>
+  <rect x="320" y="132" width="210" height="44" rx="6" fill="none" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <text x="425" y="150" text-anchor="middle" fill="var(--fg-muted)" font-size="10">error</text>
+  <text x="425" y="166" text-anchor="middle" fill="var(--fg-muted)" font-size="10">errs += err · continue</text>
+  <line x1="530" y1="42" x2="560" y2="88" stroke="currentColor"/><polygon points="552,84 562,88 552,92" fill="currentColor"/>
+  <line x1="530" y1="154" x2="560" y2="116" stroke="currentColor"/><polygon points="552,112 562,116 552,120" fill="currentColor"/>
+  <rect x="560" y="80" width="92" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="606" y="99" text-anchor="middle" fill="currentColor" font-size="10">returns</text>
+  <text x="606" y="114" text-anchor="middle" fill="currentColor" font-size="9">(out, errs)</text>
+</svg>
+<figcaption>The <code>continue</code> is the whole fix: a driver that errors adds one entry to <code>errs</code> and is skipped, while every other driver still appends its devices to <code>out</code> — so a single flaky backend can no longer hide every dongle.</figcaption>
+</figure>
 
 `Drivers()` itself returns the backends sorted by name, so enumeration order — and
 the device list the operator sees — is deterministic across runs rather than

--- a/docs/_posts/2026-06-21-build-in-the-open-04-git-github-fundamentals-web-interface.md
+++ b/docs/_posts/2026-06-21-build-in-the-open-04-git-github-fundamentals-web-interface.md
@@ -100,6 +100,29 @@ separate push/pull step. That's exactly why the web interface is such a friendly
 on-ramp: you get commits, branches, and pull requests without yet installing Git
 or learning the command line.
 
+<figure class="lab-figure">
+<svg viewBox="0 0 640 176" width="640" height="176" role="img" aria-label="The local repository and the GitHub remote as two synced copies. Locally, edited working files are staged and then committed into the repo's history. Push sends local commits up to the GitHub remote; pull brings the remote's new commits down; clone makes the first local copy from the remote.">
+  <rect x="14" y="40" width="270" height="120" rx="8" fill="none" stroke="currentColor"/>
+  <text x="149" y="58" text-anchor="middle" fill="var(--fg-muted)" font-size="9">local repo · your laptop</text>
+  <rect x="30" y="70" width="72" height="34" rx="5" fill="none" stroke="currentColor"/><text x="66" y="90" text-anchor="middle" fill="currentColor" font-size="9">working files</text>
+  <line x1="102" y1="87" x2="126" y2="87" stroke="currentColor"/><polygon points="126,83 136,87 126,91" fill="currentColor"/>
+  <rect x="136" y="70" width="60" height="34" rx="5" fill="none" stroke="currentColor"/><text x="166" y="86" text-anchor="middle" fill="currentColor" font-size="9">staging</text><text x="166" y="98" text-anchor="middle" fill="var(--fg-muted)" font-size="8">area</text>
+  <line x1="196" y1="87" x2="220" y2="87" stroke="currentColor"/><polygon points="220,83 230,87 220,91" fill="currentColor"/>
+  <rect x="230" y="70" width="42" height="34" rx="5" fill="none" stroke="currentColor"/><text x="251" y="90" text-anchor="middle" fill="currentColor" font-size="9">commit</text>
+  <text x="149" y="132" text-anchor="middle" fill="var(--fg-muted)" font-size="8">history of snapshots</text>
+  <rect x="430" y="40" width="196" height="120" rx="8" fill="none" stroke="var(--accent)"/>
+  <text x="528" y="58" text-anchor="middle" fill="var(--accent)" font-size="10">GitHub remote (origin)</text>
+  <text x="528" y="104" text-anchor="middle" fill="var(--fg-muted)" font-size="9">the shared copy</text>
+  <line x1="288" y1="76" x2="426" y2="76" stroke="var(--accent)"/><polygon points="426,72 436,76 426,80" fill="var(--accent)"/>
+  <text x="358" y="70" text-anchor="middle" fill="var(--accent)" font-size="9">push</text>
+  <line x1="426" y1="106" x2="288" y2="106" stroke="currentColor"/><polygon points="288,102 278,106 288,110" fill="currentColor"/>
+  <text x="358" y="120" text-anchor="middle" fill="var(--fg-muted)" font-size="9">pull</text>
+  <line x1="426" y1="142" x2="288" y2="142" stroke="var(--fg-muted)" stroke-dasharray="4 3"/><polygon points="288,138 278,142 288,146" fill="var(--fg-muted)"/>
+  <text x="358" y="155" text-anchor="middle" fill="var(--fg-muted)" font-size="8">clone (first copy)</text>
+</svg>
+<figcaption>The local repo and the GitHub remote are two synced copies: you stage and commit locally, then <code>push</code> commits up and <code>pull</code> new ones down, while <code>clone</code> makes the first local copy. Working purely in the web UI, the remote is the only copy you touch.</figcaption>
+</figure>
+
 ## The whole loop in the GitHub web interface
 
 Here's the complete beginner workflow, no terminal required.
@@ -133,6 +156,20 @@ heart of collaborating on GitHub, and we'll dig into merge strategies in
 
 That's the entire loop: **edit → commit → branch → pull request**, all from a
 web browser.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 150" width="660" height="150" role="img" aria-label="The beginner GitHub web loop, all in the browser: edit a file with the pencil icon, commit the change with a message, create a branch to work off to the side while main stays safe, and open a pull request proposing the branch be merged into main. Every step happens directly on the remote.">
+  <rect x="14" y="52" width="112" height="44" rx="6" fill="none" stroke="currentColor"/><text x="70" y="72" text-anchor="middle" fill="currentColor" font-size="10">edit file</text><text x="70" y="86" text-anchor="middle" fill="var(--fg-muted)" font-size="8">pencil icon</text>
+  <line x1="126" y1="74" x2="158" y2="74" stroke="currentColor"/><polygon points="158,70 168,74 158,78" fill="currentColor"/>
+  <rect x="168" y="52" width="112" height="44" rx="6" fill="none" stroke="currentColor"/><text x="224" y="72" text-anchor="middle" fill="currentColor" font-size="10">commit</text><text x="224" y="86" text-anchor="middle" fill="var(--fg-muted)" font-size="8">with a message</text>
+  <line x1="280" y1="74" x2="312" y2="74" stroke="currentColor"/><polygon points="312,70 322,74 312,78" fill="currentColor"/>
+  <rect x="322" y="52" width="112" height="44" rx="6" fill="none" stroke="currentColor"/><text x="378" y="72" text-anchor="middle" fill="currentColor" font-size="10">new branch</text><text x="378" y="86" text-anchor="middle" fill="var(--fg-muted)" font-size="8">main stays safe</text>
+  <line x1="434" y1="74" x2="466" y2="74" stroke="var(--accent)"/><polygon points="466,70 476,74 466,78" fill="var(--accent)"/>
+  <rect x="476" y="52" width="130" height="44" rx="6" fill="none" stroke="var(--accent)"/><text x="541" y="72" text-anchor="middle" fill="var(--accent)" font-size="10">pull request</text><text x="541" y="86" text-anchor="middle" fill="var(--fg-muted)" font-size="8">propose merge → main</text>
+  <text x="310" y="28" text-anchor="middle" fill="var(--fg-muted)" font-size="9">all in the browser — the remote is the only copy</text>
+</svg>
+<figcaption>The whole beginner loop in the browser: edit → commit → new branch → pull request, every step happening directly on the GitHub remote.</figcaption>
+</figure>
 
 ## .gitignore essentials
 

--- a/docs/_posts/2026-06-21-rebuild-gophertrunk-from-source-with-git-and-github.md
+++ b/docs/_posts/2026-06-21-rebuild-gophertrunk-from-source-with-git-and-github.md
@@ -71,6 +71,22 @@ and Windows on any of those hosts without a cross-toolchain. The rest of this
 post is the detailed version of those five steps, plus how to keep your clone
 current and a few build knobs worth knowing.
 
+<figure class="lab-figure">
+<svg viewBox="0 0 660 132" width="660" height="132" role="img" aria-label="The five-step build pipeline: git clone the repository, git checkout the version you want (main, a tag, or a branch), make build to compile cmd/gophertrunk into bin/gophertrunk, verify with gophertrunk version and sdr list, and optionally install the binary onto your PATH.">
+  <rect x="10" y="42" width="112" height="46" rx="6" fill="none" stroke="currentColor"/><text x="66" y="62" text-anchor="middle" fill="currentColor" font-size="10">clone</text><text x="66" y="76" text-anchor="middle" fill="var(--fg-muted)" font-size="8">git clone</text>
+  <line x1="122" y1="65" x2="146" y2="65" stroke="currentColor"/><polygon points="146,61 156,65 146,69" fill="currentColor"/>
+  <rect x="156" y="42" width="112" height="46" rx="6" fill="none" stroke="currentColor"/><text x="212" y="62" text-anchor="middle" fill="currentColor" font-size="10">checkout</text><text x="212" y="76" text-anchor="middle" fill="var(--fg-muted)" font-size="8">main · tag · branch</text>
+  <line x1="268" y1="65" x2="292" y2="65" stroke="currentColor"/><polygon points="292,61 302,65 292,69" fill="currentColor"/>
+  <rect x="302" y="42" width="112" height="46" rx="6" fill="none" stroke="var(--accent)"/><text x="358" y="62" text-anchor="middle" fill="var(--accent)" font-size="10">make build</text><text x="358" y="76" text-anchor="middle" fill="var(--fg-muted)" font-size="8">bin/gophertrunk</text>
+  <line x1="414" y1="65" x2="438" y2="65" stroke="currentColor"/><polygon points="438,61 448,65 438,69" fill="currentColor"/>
+  <rect x="448" y="42" width="112" height="46" rx="6" fill="none" stroke="currentColor"/><text x="504" y="62" text-anchor="middle" fill="currentColor" font-size="10">verify</text><text x="504" y="76" text-anchor="middle" fill="var(--fg-muted)" font-size="8">version · sdr list</text>
+  <line x1="560" y1="65" x2="584" y2="65" stroke="currentColor"/><polygon points="584,61 594,65 584,69" fill="currentColor"/>
+  <rect x="594" y="42" width="60" height="46" rx="6" fill="none" stroke="var(--fg-muted)"/><text x="624" y="66" text-anchor="middle" fill="var(--fg-muted)" font-size="9" transform="rotate(-90 624 66)">install PATH</text>
+  <text x="358" y="112" text-anchor="middle" fill="var(--fg-muted)" font-size="9">compiles ./cmd/gophertrunk with version, commit &amp; build time stamped in</text>
+</svg>
+<figcaption>The whole loop, five steps: clone the repo, check out the version you want, <code>make build</code> the binary, verify it runs and sees your SDR, then optionally install it on your <code>PATH</code>.</figcaption>
+</figure>
+
 > New to Git itself? This post assumes you can run `git clone` and
 > `git checkout`. If those aren't second nature yet, the free
 > [**Git & GitHub learning path**]({{ '/learn/git/' | relative_url }}) starts from
@@ -92,6 +108,25 @@ That is the entire list. GopherTrunk uses `purego` for every system call it make
 `CGO_ENABLED=0` and ships as one
 [static binary]({{ '/reference/static-binary/' | relative_url }}). There is no
 `libusb`, no `librtlsdr`, no compiler toolchain to install.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 620 196" width="620" height="196" role="img" aria-label="The build toolchain dependency stack, bottom to top: the Go 1.25-plus toolchain building with CGO_ENABLED=0 sits at the base; make sits above it wrapping a plain go build; git supplies the source at cmd/gophertrunk; and the top layer is the single static binary bin/gophertrunk with no C libraries — no libusb, librtlsdr, or compiler toolchain.">
+  <rect x="120" y="12" width="380" height="34" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="310" y="30" text-anchor="middle" fill="var(--accent)" font-size="11">bin/gophertrunk — one static binary</text>
+  <text x="310" y="42" text-anchor="middle" fill="var(--fg-muted)" font-size="8">no C libs · no libusb · no librtlsdr</text>
+  <line x1="310" y1="46" x2="310" y2="58" stroke="currentColor"/><polygon points="306,48 310,58 314,48" fill="currentColor"/>
+  <rect x="120" y="60" width="380" height="30" rx="6" fill="none" stroke="currentColor"/>
+  <text x="310" y="79" text-anchor="middle" fill="currentColor" font-size="10">make build  →  wraps  go build ./cmd/gophertrunk</text>
+  <line x1="310" y1="90" x2="310" y2="102" stroke="currentColor"/><polygon points="306,92 310,102 314,92" fill="currentColor"/>
+  <rect x="120" y="104" width="380" height="30" rx="6" fill="none" stroke="currentColor"/>
+  <text x="310" y="123" text-anchor="middle" fill="currentColor" font-size="10">Go 1.25+ toolchain  ·  CGO_ENABLED=0</text>
+  <line x1="310" y1="134" x2="310" y2="146" stroke="currentColor"/><polygon points="306,136 310,146 314,136" fill="currentColor"/>
+  <rect x="120" y="148" width="380" height="30" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="310" y="167" text-anchor="middle" fill="var(--fg-muted)" font-size="10">git  ·  source at ./cmd/gophertrunk</text>
+  <text x="60" y="97" text-anchor="middle" fill="var(--fg-muted)" font-size="9" transform="rotate(-90 60 97)">the three required tools</text>
+</svg>
+<figcaption>The toolchain is a short stack: git fetches the source, the Go 1.25+ toolchain compiles it with <code>CGO_ENABLED=0</code>, <code>make</code> wraps <code>go build</code>, and the top of the stack is a single static binary with no C libraries underneath.</figcaption>
+</figure>
 
 > **On Linux and want to actually receive with an SDR after building?** USB
 > device permissions are a separate, one-time setup step. See

--- a/docs/_posts/2026-06-21-rf-front-end-04-usb-without-libusb.md
+++ b/docs/_posts/2026-06-21-rf-front-end-04-usb-without-libusb.md
@@ -58,6 +58,33 @@ on Windows, **IOKit** on macOS. GopherTrunk speaks to those directly. The cost i
 that we write three backends by hand; the payoff is a pure-Go, CGO-free,
 `go build`-and-ship binary on every target.
 
+<figure class="lab-figure">
+<svg viewBox="0 0 660 190" width="660" height="190" role="img" aria-label="The RTL2832U driver calls the Transport port, which exposes only vendor control-out 0x40, vendor control-in 0xC0, and a bulk-IN endpoint 0x81. Below the OS boundary, a per-OS adapter turns those calls into USBDEVFS, WinUSB, or IOKit to reach the RTL2832U's endpoint 0x81.">
+  <text x="230" y="14" text-anchor="middle" fill="var(--fg-muted)" font-size="9">pure-Go driver</text>
+  <text x="500" y="14" text-anchor="middle" fill="var(--fg-muted)" font-size="9">OS USB stack</text>
+  <rect x="8" y="66" width="110" height="48" rx="6" fill="none" stroke="currentColor"/>
+  <text x="63" y="94" text-anchor="middle" fill="currentColor" font-size="10">RTL2832U driver</text>
+  <line x1="118" y1="90" x2="146" y2="90" stroke="currentColor"/><polygon points="146,86 156,90 146,94" fill="currentColor"/>
+  <rect x="158" y="30" width="180" height="120" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="248" y="50" text-anchor="middle" fill="var(--accent)" font-size="11">Transport · usb.go</text>
+  <text x="248" y="72" text-anchor="middle" fill="currentColor" font-size="9">ControlOut  0x40</text>
+  <text x="248" y="90" text-anchor="middle" fill="currentColor" font-size="9">ControlIn   0xC0</text>
+  <text x="248" y="108" text-anchor="middle" fill="currentColor" font-size="9">StartBulkIn ep 0x81</text>
+  <text x="248" y="128" text-anchor="middle" fill="var(--fg-muted)" font-size="9">Claim · Reset · Close</text>
+  <line x1="358" y1="22" x2="358" y2="168" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <text x="358" y="182" text-anchor="middle" fill="var(--fg-muted)" font-size="9">OS boundary</text>
+  <line x1="338" y1="90" x2="378" y2="90" stroke="currentColor"/><polygon points="378,86 388,90 378,94" fill="currentColor"/>
+  <rect x="390" y="66" width="160" height="48" rx="6" fill="none" stroke="currentColor"/>
+  <text x="470" y="87" text-anchor="middle" fill="currentColor" font-size="10">USBDEVFS · WinUSB</text>
+  <text x="470" y="102" text-anchor="middle" fill="currentColor" font-size="10">· IOKit</text>
+  <line x1="550" y1="90" x2="578" y2="90" stroke="currentColor"/><polygon points="578,86 588,90 578,94" fill="currentColor"/>
+  <rect x="590" y="66" width="62" height="48" rx="6" fill="none" stroke="currentColor"/>
+  <text x="621" y="87" text-anchor="middle" fill="currentColor" font-size="9">RTL2832U</text>
+  <text x="621" y="102" text-anchor="middle" fill="var(--fg-muted)" font-size="9">ep 0x81</text>
+</svg>
+<figcaption>The <code>Transport</code> port exposes only the slice of USB the RTL2832U needs — vendor control in/out and one bulk-IN endpoint (<code>0x81</code>) — and a per-OS adapter below the boundary turns those calls into USBDEVFS, WinUSB, or IOKit.</figcaption>
+</figure>
+
 ## How GopherTrunk implements it in Go
 
 **Everything funnels through two interfaces.** The first, `Enumerator`, discovers and
@@ -244,6 +271,35 @@ owned by the application's needs. `linuxTransport`, `winTransport`, and
 `darwinTransport` are the *adapters* — concrete implementations that translate
 those needs into one specific OS's USB ABI. The RTL2832U driver lives entirely on
 the port side and is, by construction, ignorant of which adapter it's talking to.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 200" width="660" height="200" role="img" aria-label="One Transport port defined in usb.go is satisfied by several adapters selected by go:build tags: usb_linux.go for USBDEVFS, usb_darwin.go for IOKit, usb_windows.go for WinUSB, usb_other.go as the unsupported null adapter, and usb_mock.go for tests. Exactly one real backend is compiled into each binary.">
+  <rect x="230" y="16" width="200" height="44" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="330" y="43" text-anchor="middle" fill="var(--accent)" font-size="11">Transport port · usb.go</text>
+  <text x="330" y="84" text-anchor="middle" fill="var(--fg-muted)" font-size="9">//go:build selects one adapter</text>
+  <line x1="330" y1="60" x2="67" y2="100" stroke="currentColor"/><polygon points="63,96 67,106 71,98" fill="currentColor"/>
+  <line x1="330" y1="60" x2="197" y2="100" stroke="currentColor"/><polygon points="193,96 197,106 201,98" fill="currentColor"/>
+  <line x1="330" y1="60" x2="327" y2="100" stroke="currentColor"/><polygon points="323,97 327,106 331,97" fill="currentColor"/>
+  <line x1="330" y1="60" x2="457" y2="100" stroke="currentColor"/><polygon points="453,98 457,106 461,96" fill="currentColor"/>
+  <line x1="330" y1="60" x2="587" y2="100" stroke="currentColor"/><polygon points="583,98 587,106 591,96" fill="currentColor"/>
+  <rect x="8" y="106" width="118" height="62" rx="6" fill="none" stroke="currentColor"/>
+  <text x="67" y="134" text-anchor="middle" fill="currentColor" font-size="9">usb_linux.go</text>
+  <text x="67" y="150" text-anchor="middle" fill="var(--fg-muted)" font-size="9">USBDEVFS</text>
+  <rect x="138" y="106" width="118" height="62" rx="6" fill="none" stroke="currentColor"/>
+  <text x="197" y="134" text-anchor="middle" fill="currentColor" font-size="9">usb_darwin.go</text>
+  <text x="197" y="150" text-anchor="middle" fill="var(--fg-muted)" font-size="9">IOKit</text>
+  <rect x="268" y="106" width="118" height="62" rx="6" fill="none" stroke="currentColor"/>
+  <text x="327" y="134" text-anchor="middle" fill="currentColor" font-size="9">usb_windows.go</text>
+  <text x="327" y="150" text-anchor="middle" fill="var(--fg-muted)" font-size="9">WinUSB</text>
+  <rect x="398" y="106" width="118" height="62" rx="6" fill="none" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <text x="457" y="134" text-anchor="middle" fill="var(--fg-muted)" font-size="9">usb_other.go</text>
+  <text x="457" y="150" text-anchor="middle" fill="var(--fg-muted)" font-size="9">unsupported</text>
+  <rect x="528" y="106" width="118" height="62" rx="6" fill="none" stroke="currentColor"/>
+  <text x="587" y="134" text-anchor="middle" fill="currentColor" font-size="9">usb_mock.go</text>
+  <text x="587" y="150" text-anchor="middle" fill="var(--fg-muted)" font-size="9">tests</text>
+</svg>
+<figcaption>One port, several adapters: <code>//go:build</code> tags compile exactly one real OS backend into each binary, while <code>usb_other.go</code> keeps exotic targets building and <code>MockTransport</code> plugs into the same port for hardware-free tests.</figcaption>
+</figure>
 
 ### How that principle shaped the Go code
 

--- a/docs/_posts/2026-06-22-build-in-the-open-05-three-ways-to-merge-to-main.md
+++ b/docs/_posts/2026-06-22-build-in-the-open-05-three-ways-to-merge-to-main.md
@@ -82,10 +82,72 @@ three safety mechanisms live:
 Crucially, the *shape* of the commits inside your branch and the *merge button*
 you press are two different decisions. The next sections connect them.
 
+<figure class="lab-figure">
+<svg viewBox="0 0 660 176" width="660" height="176" role="img" aria-label="The pull request as a merge gate: a feature branch opens a pull request, which must pass the required status checks build-test, usb-windows, and usb-macos and have review threads resolved before the merge gate unlocks and the change lands on main.">
+  <rect x="14" y="62" width="104" height="46" rx="6" fill="none" stroke="currentColor"/>
+  <text x="66" y="82" text-anchor="middle" fill="currentColor" font-size="10">feature</text>
+  <text x="66" y="96" text-anchor="middle" fill="currentColor" font-size="10">branch</text>
+  <line x1="118" y1="85" x2="150" y2="85" stroke="currentColor"/><polygon points="150,81 160,85 150,89" fill="currentColor"/>
+  <rect x="160" y="62" width="104" height="46" rx="6" fill="none" stroke="currentColor"/>
+  <text x="212" y="82" text-anchor="middle" fill="currentColor" font-size="10">pull</text>
+  <text x="212" y="96" text-anchor="middle" fill="currentColor" font-size="10">request</text>
+  <line x1="264" y1="85" x2="296" y2="85" stroke="currentColor"/><polygon points="296,81 306,85 296,89" fill="currentColor"/>
+  <rect x="306" y="30" width="168" height="110" rx="6" fill="none" stroke="currentColor"/>
+  <text x="390" y="47" text-anchor="middle" fill="var(--fg-muted)" font-size="9">required to merge</text>
+  <text x="390" y="66" text-anchor="middle" fill="currentColor" font-size="10">build-test</text>
+  <text x="390" y="84" text-anchor="middle" fill="currentColor" font-size="10">usb-windows</text>
+  <text x="390" y="102" text-anchor="middle" fill="currentColor" font-size="10">usb-macos</text>
+  <text x="390" y="124" text-anchor="middle" fill="currentColor" font-size="10">review resolved</text>
+  <line x1="474" y1="85" x2="506" y2="85" stroke="var(--accent)"/><polygon points="506,81 516,85 506,89" fill="var(--accent)"/>
+  <rect x="516" y="62" width="130" height="46" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="581" y="82" text-anchor="middle" fill="var(--accent)" font-size="10">merge to main</text>
+  <text x="581" y="96" text-anchor="middle" fill="var(--fg-muted)" font-size="8">gate unlocks when green</text>
+</svg>
+<figcaption>The pull request is the gate: GopherTrunk requires the <code>build-test</code>, <code>usb-windows</code>, and <code>usb-macos</code> checks to pass and review threads resolved before the merge button to <code>main</code> unlocks.</figcaption>
+</figure>
+
 ## The three ways to merge to main
 
 There are three honest ways to land a branch, defined by how many commits you
 want to appear on `main`. GitHub exposes each as a merge-button option.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 188" width="660" height="188" role="img" aria-label="The three GitHub merge strategies drawn as branch graphs. Merge commit: the feature branch commits are kept and joined to main by a merge commit, forming a bubble. Squash and merge: the branch's commits collapse into a single new commit on main. Rebase and merge: the branch commits are replayed onto main as a straight line with no merge commit.">
+  <line x1="215" y1="30" x2="215" y2="150" stroke="var(--fg-muted)" stroke-dasharray="2 4"/>
+  <line x1="445" y1="30" x2="445" y2="150" stroke="var(--fg-muted)" stroke-dasharray="2 4"/>
+  <text x="100" y="20" text-anchor="middle" fill="currentColor" font-size="10">merge commit</text>
+  <line x1="20" y1="78" x2="185" y2="78" stroke="currentColor"/>
+  <circle cx="38" cy="78" r="5" fill="currentColor"/>
+  <circle cx="66" cy="78" r="5" fill="currentColor"/>
+  <line x1="66" y1="78" x2="98" y2="128" stroke="currentColor"/>
+  <line x1="98" y1="128" x2="132" y2="128" stroke="currentColor"/>
+  <circle cx="98" cy="128" r="5" fill="currentColor"/>
+  <circle cx="132" cy="128" r="5" fill="currentColor"/>
+  <line x1="132" y1="128" x2="168" y2="78" stroke="var(--accent)"/>
+  <circle cx="168" cy="78" r="6" fill="var(--accent)"/>
+  <text x="100" y="160" text-anchor="middle" fill="var(--fg-muted)" font-size="8">all commits + a bubble</text>
+  <text x="330" y="20" text-anchor="middle" fill="currentColor" font-size="10">squash &amp; merge</text>
+  <line x1="245" y1="78" x2="415" y2="78" stroke="currentColor"/>
+  <circle cx="262" cy="78" r="5" fill="currentColor"/>
+  <circle cx="290" cy="78" r="5" fill="currentColor"/>
+  <circle cx="400" cy="78" r="6" fill="var(--accent)"/>
+  <line x1="305" y1="128" x2="360" y2="128" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <circle cx="305" cy="128" r="4" fill="var(--fg-muted)"/>
+  <circle cx="333" cy="128" r="4" fill="var(--fg-muted)"/>
+  <circle cx="360" cy="128" r="4" fill="var(--fg-muted)"/>
+  <line x1="360" y1="128" x2="396" y2="86" stroke="var(--fg-muted)" stroke-dasharray="4 3"/><polygon points="391,88 400,80 396,91" fill="var(--fg-muted)"/>
+  <text x="330" y="160" text-anchor="middle" fill="var(--fg-muted)" font-size="8">3 commits collapse to 1</text>
+  <text x="558" y="20" text-anchor="middle" fill="currentColor" font-size="10">rebase &amp; merge</text>
+  <line x1="460" y1="78" x2="648" y2="78" stroke="currentColor"/>
+  <circle cx="478" cy="78" r="5" fill="currentColor"/>
+  <circle cx="508" cy="78" r="5" fill="currentColor"/>
+  <circle cx="558" cy="78" r="6" fill="var(--accent)"/>
+  <circle cx="588" cy="78" r="6" fill="var(--accent)"/>
+  <circle cx="618" cy="78" r="6" fill="var(--accent)"/>
+  <text x="558" y="160" text-anchor="middle" fill="var(--fg-muted)" font-size="8">commits replayed, linear</text>
+</svg>
+<figcaption>The three merge buttons as branch graphs: a merge commit keeps every branch commit and joins with a bubble, squash collapses them into one commit on <code>main</code>, and rebase replays them as a straight line.</figcaption>
+</figure>
 
 ### 1. Many small commits → one PR
 

--- a/docs/_posts/2026-06-22-rf-front-end-05-usb-on-linux-usbdevfs.md
+++ b/docs/_posts/2026-06-22-rf-front-end-05-usb-on-linux-usbdevfs.md
@@ -53,6 +53,31 @@ func (l *linuxEnumerator) Name() string { return "usbdevfs" }
 and wraps the file descriptor in a `linuxTransport`. Everything after that is
 ioctls on that one fd.
 
+<figure class="lab-figure">
+<svg viewBox="0 0 660 180" width="660" height="180" role="img" aria-label="The linuxTransport in userspace opens the device node under /dev/bus/usb with O_RDWR and drives it with ioctl(2) across the OS boundary into the kernel usbfs layer, which reaches the RTL2832U dongle. Enumeration separately reads VID, PID, and serial from sysfs without opening anything.">
+  <text x="200" y="14" text-anchor="middle" fill="var(--fg-muted)" font-size="9">userspace (Go)</text>
+  <text x="520" y="14" text-anchor="middle" fill="var(--fg-muted)" font-size="9">kernel</text>
+  <rect x="8" y="60" width="120" height="48" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="68" y="82" text-anchor="middle" fill="var(--accent)" font-size="10">linuxTransport</text>
+  <text x="68" y="98" text-anchor="middle" fill="var(--fg-muted)" font-size="9">(Go)</text>
+  <line x1="128" y1="84" x2="158" y2="84" stroke="currentColor"/><polygon points="158,80 168,84 158,88" fill="currentColor"/>
+  <rect x="170" y="60" width="150" height="48" rx="6" fill="none" stroke="currentColor"/>
+  <text x="245" y="82" text-anchor="middle" fill="currentColor" font-size="10">/dev/bus/usb/</text>
+  <text x="245" y="98" text-anchor="middle" fill="var(--fg-muted)" font-size="9">BBB/DDD · O_RDWR</text>
+  <text x="352" y="76" text-anchor="middle" fill="var(--fg-muted)" font-size="9">ioctl(2)</text>
+  <line x1="320" y1="84" x2="360" y2="84" stroke="currentColor"/><polygon points="360,80 370,84 360,88" fill="currentColor"/>
+  <line x1="376" y1="24" x2="376" y2="140" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <rect x="388" y="60" width="130" height="48" rx="6" fill="none" stroke="currentColor"/>
+  <text x="453" y="82" text-anchor="middle" fill="currentColor" font-size="10">kernel usbfs</text>
+  <text x="453" y="98" text-anchor="middle" fill="var(--fg-muted)" font-size="9">(usbdevfs)</text>
+  <line x1="518" y1="84" x2="548" y2="84" stroke="currentColor"/><polygon points="548,80 558,84 548,88" fill="currentColor"/>
+  <rect x="560" y="60" width="92" height="48" rx="6" fill="none" stroke="currentColor"/>
+  <text x="606" y="88" text-anchor="middle" fill="currentColor" font-size="9">RTL2832U</text>
+  <text x="330" y="158" text-anchor="middle" fill="var(--fg-muted)" font-size="9">enumerate: /sys/bus/usb/devices (sysfs) — VID/PID/serial, no open</text>
+</svg>
+<figcaption>The Linux backend opens the node under <code>/dev/bus/usb</code> and drives it entirely with <code>ioctl(2)</code> into the kernel's usbfs — nothing between userspace and the kernel — while enumeration reads identity from sysfs without opening anything.</figcaption>
+</figure>
+
 ## How GopherTrunk implements it in Go
 
 **The first thing the backend needs is the ioctl request numbers, and Go gives us no
@@ -155,6 +180,29 @@ for i := 0; i < ringBufs; i++ {
 The driver's default geometry is **32 buffers of 16 KiB** — `DefaultRingBuffers`
 and `DefaultBufferLen` in `usb.go`. With 32 URBs queued, the kernel can keep the
 bus saturated even if the consumer stalls for several milliseconds.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 200" width="660" height="200" role="img" aria-label="StartBulkIn submits a ring of 32 URBs of 16 KiB each. The kernel fills each URB asynchronously; a single reaper goroutine pinned with LockOSThread reaps a completion with REAPURB, hands the bytes to onPacket, and immediately resubmits the same URB to keep the ring full.">
+  <rect x="20" y="28" width="170" height="48" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="105" y="48" text-anchor="middle" fill="var(--accent)" font-size="10">SUBMITURB ×32</text>
+  <text x="105" y="64" text-anchor="middle" fill="var(--fg-muted)" font-size="9">16 KiB each</text>
+  <line x1="190" y1="52" x2="248" y2="52" stroke="currentColor"/><polygon points="248,48 258,52 248,56" fill="currentColor"/>
+  <rect x="250" y="28" width="150" height="48" rx="6" fill="none" stroke="currentColor"/>
+  <text x="325" y="48" text-anchor="middle" fill="currentColor" font-size="10">kernel fills</text>
+  <text x="325" y="64" text-anchor="middle" fill="var(--fg-muted)" font-size="9">URB (async)</text>
+  <line x1="400" y1="52" x2="458" y2="52" stroke="currentColor"/><polygon points="458,48 468,52 458,56" fill="currentColor"/>
+  <rect x="460" y="28" width="180" height="48" rx="6" fill="none" stroke="currentColor"/>
+  <text x="550" y="48" text-anchor="middle" fill="currentColor" font-size="10">REAPURB</text>
+  <text x="550" y="64" text-anchor="middle" fill="var(--fg-muted)" font-size="9">reaper · LockOSThread</text>
+  <line x1="550" y1="76" x2="550" y2="116" stroke="currentColor"/><polygon points="546,116 550,124 554,116" fill="currentColor"/>
+  <rect x="460" y="124" width="180" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="550" y="151" text-anchor="middle" fill="currentColor" font-size="10">onPacket(buf[:n])</text>
+  <line x1="460" y1="146" x2="105" y2="146" stroke="currentColor"/>
+  <line x1="105" y1="146" x2="105" y2="76" stroke="currentColor"/><polygon points="101,84 105,76 109,84" fill="currentColor"/>
+  <text x="282" y="140" text-anchor="middle" fill="var(--fg-muted)" font-size="9">resubmit same URB</text>
+</svg>
+<figcaption>A ring of 32 URBs stays in flight: the kernel fills them asynchronously while one OS-thread-pinned reaper reaps each completion, feeds <code>onPacket</code>, and immediately resubmits that URB — so the bus never runs dry.</figcaption>
+</figure>
 
 Once the ring is submitted, a **single reaper goroutine** owns the completion
 loop. It pins itself to its OS thread, reaps one URB at a time, hands the bytes to

--- a/docs/_posts/2026-06-23-build-in-the-open-06-issues-planning-inviting-contributors.md
+++ b/docs/_posts/2026-06-23-build-in-the-open-06-issues-planning-inviting-contributors.md
@@ -106,6 +106,31 @@ This is the highest-leverage habit on this whole list: it ties the *why* (the
 issue) to the *what* (the PR) permanently, and it keeps your issue tracker
 honest by closing work as it lands instead of leaving stale tickets.
 
+<figure class="lab-figure">
+<svg viewBox="0 0 660 100" width="660" height="100" role="img" aria-label="The issue lifecycle as a left-to-right pipeline: an issue is opened, then triaged and labeled by type, area and signal, then attached to a milestone and assigned, then linked from a pull request with Closes hash-N, and finally auto-closed when that pull request merges.">
+  <rect x="6" y="30" width="116" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="64" y="52" text-anchor="middle" fill="currentColor" font-size="11">opened</text>
+  <text x="64" y="66" text-anchor="middle" fill="var(--fg-muted)" font-size="9">bug / feature</text>
+  <line x1="122" y1="52" x2="132" y2="52" stroke="currentColor"/><polygon points="132,48 138,52 132,56" fill="currentColor"/>
+  <rect x="138" y="30" width="116" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="196" y="52" text-anchor="middle" fill="currentColor" font-size="11">triaged</text>
+  <text x="196" y="66" text-anchor="middle" fill="var(--fg-muted)" font-size="9">type · area · signal</text>
+  <line x1="254" y1="52" x2="264" y2="52" stroke="currentColor"/><polygon points="264,48 270,52 264,56" fill="currentColor"/>
+  <rect x="270" y="30" width="116" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="328" y="52" text-anchor="middle" fill="currentColor" font-size="11">milestone</text>
+  <text x="328" y="66" text-anchor="middle" fill="var(--fg-muted)" font-size="9">+ assignee</text>
+  <line x1="386" y1="52" x2="396" y2="52" stroke="currentColor"/><polygon points="396,48 402,52 396,56" fill="currentColor"/>
+  <rect x="402" y="30" width="116" height="44" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="460" y="52" text-anchor="middle" fill="var(--accent)" font-size="11">pull request</text>
+  <text x="460" y="66" text-anchor="middle" fill="var(--fg-muted)" font-size="9">Closes #N</text>
+  <line x1="518" y1="52" x2="528" y2="52" stroke="currentColor"/><polygon points="528,48 534,52 528,56" fill="currentColor"/>
+  <rect x="534" y="30" width="116" height="44" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="592" y="52" text-anchor="middle" fill="var(--accent)" font-size="11">merged</text>
+  <text x="592" y="66" text-anchor="middle" fill="var(--fg-muted)" font-size="9">auto-closed</text>
+</svg>
+<figcaption>An issue's path on GopherTrunk: opened, triaged with the type·area·signal labels, milestoned, then closed automatically when a <code>Closes #N</code> pull request merges to <code>main</code>.</figcaption>
+</figure>
+
 ## How do I invite contributors?
 
 People help projects where helping is *easy*. Think of it as a funnel — every
@@ -126,6 +151,29 @@ friction point loses people — and reduce friction at each step:
 
 You don't need all of these on day one. A `CONTRIBUTING.md` and a couple of
 good-first-issues are the highest-value starting pair.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 640 208" width="640" height="208" role="img" aria-label="The contributor funnel: each step from finding the repository to a merged pull request is paired with the file that lowers its friction. Find the repo maps to README and topics; want to help maps to CONTRIBUTING.md; pick a task maps to the good first issue label; submit maps to the issue and PR templates; get reviewed maps to CODEOWNERS.">
+  <text x="120" y="22" text-anchor="middle" fill="var(--fg-muted)" font-size="10">contributor step</text>
+  <text x="491" y="22" text-anchor="middle" fill="var(--fg-muted)" font-size="10">what lowers the friction</text>
+  <rect x="24" y="34" width="192" height="26" rx="5" fill="none" stroke="currentColor"/><text x="120" y="51" text-anchor="middle" fill="currentColor" font-size="11">find the repo</text>
+  <line x1="216" y1="47" x2="356" y2="47" stroke="currentColor"/><polygon points="356,43 366,47 356,51" fill="currentColor"/>
+  <rect x="366" y="34" width="250" height="26" rx="5" fill="none" stroke="currentColor"/><text x="491" y="51" text-anchor="middle" fill="currentColor" font-size="11">README + topics</text>
+  <rect x="24" y="68" width="192" height="26" rx="5" fill="none" stroke="currentColor"/><text x="120" y="85" text-anchor="middle" fill="currentColor" font-size="11">want to help</text>
+  <line x1="216" y1="81" x2="356" y2="81" stroke="currentColor"/><polygon points="356,77 366,81 356,85" fill="currentColor"/>
+  <rect x="366" y="68" width="250" height="26" rx="5" fill="none" stroke="currentColor"/><text x="491" y="85" text-anchor="middle" fill="currentColor" font-size="11">CONTRIBUTING.md</text>
+  <rect x="24" y="102" width="192" height="26" rx="5" fill="none" stroke="var(--accent)"/><text x="120" y="119" text-anchor="middle" fill="var(--accent)" font-size="11">pick a task</text>
+  <line x1="216" y1="115" x2="356" y2="115" stroke="currentColor"/><polygon points="356,111 366,115 356,119" fill="currentColor"/>
+  <rect x="366" y="102" width="250" height="26" rx="5" fill="none" stroke="var(--accent)"/><text x="491" y="119" text-anchor="middle" fill="var(--accent)" font-size="11">good first issue</text>
+  <rect x="24" y="136" width="192" height="26" rx="5" fill="none" stroke="currentColor"/><text x="120" y="153" text-anchor="middle" fill="currentColor" font-size="11">submit a PR</text>
+  <line x1="216" y1="149" x2="356" y2="149" stroke="currentColor"/><polygon points="356,145 366,149 356,153" fill="currentColor"/>
+  <rect x="366" y="136" width="250" height="26" rx="5" fill="none" stroke="currentColor"/><text x="491" y="153" text-anchor="middle" fill="currentColor" font-size="11">issue + PR templates</text>
+  <rect x="24" y="170" width="192" height="26" rx="5" fill="none" stroke="currentColor"/><text x="120" y="187" text-anchor="middle" fill="currentColor" font-size="11">get reviewed</text>
+  <line x1="216" y1="183" x2="356" y2="183" stroke="currentColor"/><polygon points="356,179 366,183 356,187" fill="currentColor"/>
+  <rect x="366" y="170" width="250" height="26" rx="5" fill="none" stroke="currentColor"/><text x="491" y="187" text-anchor="middle" fill="currentColor" font-size="11">CODEOWNERS</text>
+</svg>
+<figcaption>Every step of the funnel is backed by a file that removes a question: the pair a project should ship first is <code>CONTRIBUTING.md</code> plus a few <code>good first issue</code> tickets.</figcaption>
+</figure>
 
 ## How much access should I give collaborators?
 

--- a/docs/_posts/2026-06-23-rf-front-end-06-usb-on-macos-windows.md
+++ b/docs/_posts/2026-06-23-rf-front-end-06-usb-on-macos-windows.md
@@ -49,6 +49,30 @@ from `setupapi.dll`. Both are normally consumed from C. GopherTrunk consumes the
 from pure Go — purego on macOS, lazy DLL procs on Windows — to keep the
 CGO-free, single-static-binary promise intact on every OS.
 
+<figure class="lab-figure">
+<svg viewBox="0 0 660 210" width="660" height="210" role="img" aria-label="The RTL2832U driver talks to one eight-method Transport port, which is satisfied by three interchangeable operating-system adapters underneath: Linux USBDEVFS ioctls with an async URB ring, macOS IOKit vtables via purego with N pinned reader threads, and Windows WinUSB procs with overlapped I/O.">
+  <rect x="230" y="12" width="200" height="30" rx="6" fill="none" stroke="currentColor"/>
+  <text x="330" y="31" text-anchor="middle" fill="currentColor" font-size="11">RTL2832U driver</text>
+  <line x1="330" y1="42" x2="330" y2="64" stroke="currentColor"/><polygon points="326,56 330,66 334,56" fill="currentColor"/>
+  <rect x="168" y="66" width="324" height="38" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="330" y="84" text-anchor="middle" fill="var(--accent)" font-size="11">Transport port · eight methods</text>
+  <text x="330" y="98" text-anchor="middle" fill="var(--fg-muted)" font-size="8">ControlIn · ControlOut · ClaimInterface · StartBulkIn / StopBulkIn</text>
+  <line x1="250" y1="104" x2="132" y2="146" stroke="currentColor"/><polygon points="136,137 126,148 140,148" fill="currentColor"/>
+  <line x1="330" y1="104" x2="330" y2="146" stroke="currentColor"/><polygon points="326,138 330,148 334,138" fill="currentColor"/>
+  <line x1="410" y1="104" x2="528" y2="146" stroke="currentColor"/><polygon points="520,148 534,148 524,137" fill="currentColor"/>
+  <rect x="20" y="150" width="200" height="48" rx="6" fill="none" stroke="currentColor"/>
+  <text x="120" y="170" text-anchor="middle" fill="currentColor" font-size="10">Linux — USBDEVFS</text>
+  <text x="120" y="184" text-anchor="middle" fill="var(--fg-muted)" font-size="8">ioctls · URB ring · 1 reaper</text>
+  <rect x="230" y="150" width="200" height="48" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="330" y="170" text-anchor="middle" fill="var(--accent)" font-size="10">macOS — IOKit (purego)</text>
+  <text x="330" y="184" text-anchor="middle" fill="var(--fg-muted)" font-size="8">vtables · sync ReadPipe · N pinned</text>
+  <rect x="440" y="150" width="200" height="48" rx="6" fill="none" stroke="currentColor"/>
+  <text x="540" y="170" text-anchor="middle" fill="currentColor" font-size="10">Windows — WinUSB</text>
+  <text x="540" y="184" text-anchor="middle" fill="var(--fg-muted)" font-size="8">procs · overlapped · 1 + N events</text>
+</svg>
+<figcaption>All three USB backends satisfy the identical eight-method <code>Transport</code> port; the RTL2832U driver above can't tell which OS adapter — or which threading model — is underneath it.</figcaption>
+</figure>
+
 ## How GopherTrunk implements it in Go
 
 ### macOS: IOKit through purego
@@ -244,6 +268,37 @@ aborts vanished. This is also why the macOS design uses **one OS thread per slot
 in the first place: pinning makes the synchronous-`ReadPipe`-per-thread model the
 *natural* one, and lets us skip CFRunLoop callbacks entirely. The threading rule
 isn't an implementation detail we tolerated — it dictated the whole bulk-IN shape.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 190" width="660" height="190" role="img" aria-label="Before and after the macOS threading fix. Before: one reader goroutine issues ReadPipe on OS thread A but the Go scheduler resumes it on thread B, so two threads reach the same IOKit user client concurrently and the process aborts. After: runtime.LockOSThread welds the bulkLoop goroutine to a single OS thread that owns the slot, so IOKit sees a single owner and the aborts vanish.">
+  <text x="166" y="16" text-anchor="middle" fill="var(--fg-muted)" font-size="10">before — one goroutine, two threads</text>
+  <rect x="22" y="34" width="128" height="34" rx="6" fill="none" stroke="currentColor"/>
+  <text x="86" y="50" text-anchor="middle" fill="currentColor" font-size="9">thread A</text>
+  <text x="86" y="62" text-anchor="middle" fill="var(--fg-muted)" font-size="8">issues ReadPipe</text>
+  <rect x="182" y="34" width="128" height="34" rx="6" fill="none" stroke="currentColor"/>
+  <text x="246" y="50" text-anchor="middle" fill="currentColor" font-size="9">thread B</text>
+  <text x="246" y="62" text-anchor="middle" fill="var(--fg-muted)" font-size="8">resumes goroutine</text>
+  <line x1="150" y1="51" x2="178" y2="51" stroke="currentColor" stroke-dasharray="4 3"/><polygon points="178,47 188,51 178,55" fill="currentColor"/>
+  <text x="164" y="30" text-anchor="middle" fill="var(--fg-muted)" font-size="7">migrate</text>
+  <line x1="86" y1="68" x2="140" y2="118" stroke="currentColor"/><polygon points="132,110 143,120 129,118" fill="currentColor"/>
+  <line x1="246" y1="68" x2="192" y2="118" stroke="currentColor"/><polygon points="203,118 189,120 200,110" fill="currentColor"/>
+  <rect x="80" y="120" width="172" height="42" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="166" y="138" text-anchor="middle" fill="var(--accent)" font-size="9">IOKit user client</text>
+  <text x="166" y="152" text-anchor="middle" fill="var(--fg-muted)" font-size="8">cross-thread access → process abort</text>
+  <line x1="330" y1="14" x2="330" y2="172" stroke="var(--fg-muted)" stroke-dasharray="3 4"/>
+  <text x="496" y="16" text-anchor="middle" fill="var(--fg-muted)" font-size="10">after — runtime.LockOSThread</text>
+  <rect x="416" y="34" width="160" height="34" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="496" y="50" text-anchor="middle" fill="var(--accent)" font-size="9">bulkLoop goroutine</text>
+  <text x="496" y="62" text-anchor="middle" fill="var(--fg-muted)" font-size="8">LockOSThread on entry</text>
+  <line x1="496" y1="68" x2="496" y2="90" stroke="currentColor"/><polygon points="492,82 496,92 500,82" fill="currentColor"/>
+  <rect x="416" y="92" width="160" height="28" rx="6" fill="none" stroke="currentColor"/>
+  <text x="496" y="110" text-anchor="middle" fill="currentColor" font-size="9">one OS thread · owns slot</text>
+  <line x1="496" y1="120" x2="496" y2="142" stroke="currentColor"/><polygon points="492,134 496,144 500,134" fill="currentColor"/>
+  <rect x="408" y="144" width="176" height="32" rx="6" fill="none" stroke="currentColor"/>
+  <text x="496" y="164" text-anchor="middle" fill="currentColor" font-size="9">IOKit user client · single owner</text>
+</svg>
+<figcaption>Pinning each per-slot reader to its own OS thread gives IOKit the single-owner model it demands — which is exactly why the macOS backend runs one pinned thread per ring slot rather than one shared reaper.</figcaption>
+</figure>
 
 (The same `runtime.LockOSThread` shows up in the Linux and Windows reapers too, but
 for a milder reason: keeping a long-blocking syscall loop off the threads serving

--- a/docs/_posts/2026-06-24-build-in-the-open-07-github-actions-which-workflows.md
+++ b/docs/_posts/2026-06-24-build-in-the-open-07-github-actions-which-workflows.md
@@ -58,6 +58,35 @@ define *jobs* (groups of *steps*) and the *events* that trigger them
 `workflow_dispatch`). The mental model: *an event happens → a workflow runs →
 jobs report success or failure.*
 
+<figure class="lab-figure">
+<svg viewBox="0 0 680 100" width="680" height="100" role="img" aria-label="A continuous-integration pipeline drawn as ordered stages that a pull request passes through: go vet for static checks, a gofmt format check, go build to compile, go test with the race detector, make integration, and finally the required status check that gates the merge.">
+  <rect x="10" y="30" width="102" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="61" y="52" text-anchor="middle" fill="currentColor" font-size="11">go vet</text>
+  <text x="61" y="66" text-anchor="middle" fill="var(--fg-muted)" font-size="8">static check</text>
+  <line x1="112" y1="52" x2="118" y2="52" stroke="currentColor"/><polygon points="117,48 121,52 117,56" fill="currentColor"/>
+  <rect x="121" y="30" width="102" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="172" y="52" text-anchor="middle" fill="currentColor" font-size="11">gofmt</text>
+  <text x="172" y="66" text-anchor="middle" fill="var(--fg-muted)" font-size="8">format check</text>
+  <line x1="223" y1="52" x2="229" y2="52" stroke="currentColor"/><polygon points="228,48 232,52 228,56" fill="currentColor"/>
+  <rect x="232" y="30" width="102" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="283" y="52" text-anchor="middle" fill="currentColor" font-size="11">go build</text>
+  <text x="283" y="66" text-anchor="middle" fill="var(--fg-muted)" font-size="8">compile</text>
+  <line x1="334" y1="52" x2="340" y2="52" stroke="currentColor"/><polygon points="339,48 343,52 339,56" fill="currentColor"/>
+  <rect x="343" y="30" width="102" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="394" y="52" text-anchor="middle" fill="currentColor" font-size="11">go test</text>
+  <text x="394" y="66" text-anchor="middle" fill="var(--fg-muted)" font-size="8">-race -count=1</text>
+  <line x1="445" y1="52" x2="451" y2="52" stroke="currentColor"/><polygon points="450,48 454,52 450,56" fill="currentColor"/>
+  <rect x="454" y="30" width="102" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="505" y="52" text-anchor="middle" fill="currentColor" font-size="11">integration</text>
+  <text x="505" y="66" text-anchor="middle" fill="var(--fg-muted)" font-size="8">make integration</text>
+  <line x1="556" y1="52" x2="562" y2="52" stroke="currentColor"/><polygon points="561,48 565,52 561,56" fill="currentColor"/>
+  <rect x="565" y="30" width="102" height="44" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="616" y="52" text-anchor="middle" fill="var(--accent)" font-size="11">merge gate</text>
+  <text x="616" y="66" text-anchor="middle" fill="var(--fg-muted)" font-size="8">required ✓</text>
+</svg>
+<figcaption>The <code>build-test</code> job of <code>ci.yml</code> as a stage pipeline: vet, format, build, race-tested, integrated — and only a green run clears the required-status-check merge gate.</figcaption>
+</figure>
+
 ## Which workflows should most projects have?
 
 You don't need everything on day one, but here's the menu and why each item
@@ -140,6 +169,29 @@ to cut wasted runner minutes on active PRs. (For deploys, you usually set
 workflows in
 [`.github/workflows/`](https://github.com/MattCheramie/GopherTrunk/tree/main/.github/workflows),
 one for each need above.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 208" width="660" height="208" role="img" aria-label="The trigger matrix mapping each GitHub event to the workflow it starts: pull request and push to main start ci.yml, a version tag starts release.yml, a pull request starts installer.yml, a push to docs plus a daily cron start pages.yml, and a manual workflow_dispatch starts cleanup-branches.yml.">
+  <text x="125" y="22" text-anchor="middle" fill="var(--fg-muted)" font-size="10">trigger event</text>
+  <text x="520" y="22" text-anchor="middle" fill="var(--fg-muted)" font-size="10">workflow (.github/workflows/)</text>
+  <rect x="20" y="34" width="210" height="26" rx="5" fill="none" stroke="currentColor"/><text x="125" y="51" text-anchor="middle" fill="currentColor" font-size="10">pull_request · push main</text>
+  <line x1="230" y1="47" x2="380" y2="47" stroke="currentColor"/><polygon points="380,43 390,47 380,51" fill="currentColor"/>
+  <rect x="390" y="34" width="260" height="26" rx="5" fill="none" stroke="var(--accent)"/><text x="520" y="51" text-anchor="middle" fill="var(--accent)" font-size="11">ci.yml — merge gate</text>
+  <rect x="20" y="68" width="210" height="26" rx="5" fill="none" stroke="currentColor"/><text x="125" y="85" text-anchor="middle" fill="currentColor" font-size="10">tag v*.*.*</text>
+  <line x1="230" y1="81" x2="380" y2="81" stroke="currentColor"/><polygon points="380,77 390,81 380,85" fill="currentColor"/>
+  <rect x="390" y="68" width="260" height="26" rx="5" fill="none" stroke="currentColor"/><text x="520" y="85" text-anchor="middle" fill="currentColor" font-size="11">release.yml</text>
+  <rect x="20" y="102" width="210" height="26" rx="5" fill="none" stroke="currentColor"/><text x="125" y="119" text-anchor="middle" fill="currentColor" font-size="10">pull_request (not docs)</text>
+  <line x1="230" y1="115" x2="380" y2="115" stroke="currentColor"/><polygon points="380,111 390,115 380,119" fill="currentColor"/>
+  <rect x="390" y="102" width="260" height="26" rx="5" fill="none" stroke="currentColor"/><text x="520" y="119" text-anchor="middle" fill="currentColor" font-size="11">installer.yml — PR-only</text>
+  <rect x="20" y="136" width="210" height="26" rx="5" fill="none" stroke="currentColor"/><text x="125" y="153" text-anchor="middle" fill="currentColor" font-size="10">push docs/** · daily cron</text>
+  <line x1="230" y1="149" x2="380" y2="149" stroke="currentColor"/><polygon points="380,145 390,149 380,153" fill="currentColor"/>
+  <rect x="390" y="136" width="260" height="26" rx="5" fill="none" stroke="currentColor"/><text x="520" y="153" text-anchor="middle" fill="currentColor" font-size="11">pages.yml</text>
+  <rect x="20" y="170" width="210" height="26" rx="5" fill="none" stroke="currentColor"/><text x="125" y="187" text-anchor="middle" fill="currentColor" font-size="10">workflow_dispatch</text>
+  <line x1="230" y1="183" x2="380" y2="183" stroke="currentColor"/><polygon points="380,179 390,183 380,187" fill="currentColor"/>
+  <rect x="390" y="170" width="260" height="26" rx="5" fill="none" stroke="currentColor"/><text x="520" y="187" text-anchor="middle" fill="currentColor" font-size="11">cleanup-branches.yml</text>
+</svg>
+<figcaption>GopherTrunk's five workflows, each bound to the event that should start it — the trigger, not the workflow, is what makes a release deliberate and a chore scheduled.</figcaption>
+</figure>
 
 ### `ci.yml` — the merge gate
 

--- a/docs/_posts/2026-06-24-rf-front-end-07-rtlsdr-rtl2832u-bringup.md
+++ b/docs/_posts/2026-06-24-rf-front-end-07-rtlsdr-rtl2832u-bringup.md
@@ -61,6 +61,34 @@ files in `internal/sdr/rtlsdr/rtl2832u`:
 This post is the bring-up; the tuner that rides on top of the I2C bridge is
 Part 8, and sustained streaming through the USB FIFO is Part 9.
 
+<figure class="lab-figure">
+<svg viewBox="0 0 660 150" width="660" height="150" role="img" aria-label="The RTL-SDR signal path: the antenna feeds the R82xx tuner, which mixes RF down to a 3.57 MHz IF and hands it to the RTL2832U acting as a raw 8-bit ADC clocked at 28.8 MHz; the RTL2832U streams unsigned IQ out the USB bulk-IN endpoint to the host, and separately reaches the tuner as an I2C master through its bridge repeater.">
+  <rect x="150" y="14" width="210" height="28" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="255" y="31" text-anchor="middle" fill="var(--fg-muted)" font-size="9">I2C bridge · repeater bit (control)</text>
+  <line x1="321" y1="68" x2="321" y2="42" stroke="var(--fg-muted)"/>
+  <line x1="200" y1="42" x2="162" y2="66" stroke="var(--fg-muted)"/><polygon points="171,60 158,68 172,71" fill="var(--fg-muted)"/>
+  <rect x="8" y="68" width="70" height="46" rx="6" fill="none" stroke="currentColor"/>
+  <text x="43" y="94" text-anchor="middle" fill="currentColor" font-size="9">antenna</text>
+  <line x1="78" y1="91" x2="92" y2="91" stroke="currentColor"/><polygon points="92,87 102,91 92,95" fill="currentColor"/>
+  <rect x="102" y="68" width="130" height="46" rx="6" fill="none" stroke="currentColor"/>
+  <text x="167" y="88" text-anchor="middle" fill="currentColor" font-size="10">R82xx tuner</text>
+  <text x="167" y="102" text-anchor="middle" fill="var(--fg-muted)" font-size="8">RF → 3.57 MHz IF</text>
+  <line x1="232" y1="91" x2="246" y2="91" stroke="currentColor"/><polygon points="246,87 256,91 246,95" fill="currentColor"/>
+  <rect x="256" y="68" width="158" height="46" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="335" y="88" text-anchor="middle" fill="var(--accent)" font-size="10">RTL2832U</text>
+  <text x="335" y="102" text-anchor="middle" fill="var(--fg-muted)" font-size="8">raw 8-bit ADC · 28.8 MHz</text>
+  <line x1="414" y1="91" x2="428" y2="91" stroke="currentColor"/><polygon points="428,87 438,91 428,95" fill="currentColor"/>
+  <rect x="438" y="68" width="104" height="46" rx="6" fill="none" stroke="currentColor"/>
+  <text x="490" y="88" text-anchor="middle" fill="currentColor" font-size="9">USB bulk-IN</text>
+  <text x="490" y="102" text-anchor="middle" fill="var(--fg-muted)" font-size="8">FIFO endpoint</text>
+  <line x1="542" y1="91" x2="556" y2="91" stroke="currentColor"/><polygon points="556,87 566,91 556,95" fill="currentColor"/>
+  <rect x="566" y="68" width="86" height="46" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="609" y="88" text-anchor="middle" fill="var(--fg-muted)" font-size="9">host</text>
+  <text x="609" y="102" text-anchor="middle" fill="var(--fg-muted)" font-size="8">unsigned IQ</text>
+</svg>
+<figcaption>All the tuning happens in the R82xx; the RTL2832U is only a raw ADC with a USB FIFO, and the same chip reaches its tuner as an I2C master through the bridge the bring-up layer opens.</figcaption>
+</figure>
+
 ## How GopherTrunk implements it in Go
 
 ### The register transport
@@ -177,7 +205,32 @@ func (d *Demod) InitBaseband() error {
 The FIR upload sits *inside* the sequence — after the demod soft-reset (bit 3)
 and the DDC/IF-register clear, but before SDR mode is enabled and zero-IF gets
 turned on. That placement is what the table's comment means by "order is
-load-bearing." The 20-tap FIR filter itself is the DAB/FM-tuned coefficient set
+load-bearing."
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 150" width="660" height="150" role="img" aria-label="The InitBaseband sequence as a timeline: steps 0 to 14 configure the USB endpoints, power the demod, soft-reset it and clear the DDC/IF registers; then the 20-tap FIR is uploaded to page 1, addresses 0x1C to 0x2F; then steps 15 to the end enable SDR mode, zero-IF, and DC and IQ compensation. The FIR upload sits inside the sequence, and every demod write must be followed by a commit read of page 0x0A register 0x01 or it never latches.">
+  <text x="330" y="20" text-anchor="middle" fill="var(--fg-muted)" font-size="10">InitBaseband() — order is load-bearing</text>
+  <rect x="16" y="36" width="190" height="52" rx="6" fill="none" stroke="currentColor"/>
+  <text x="111" y="58" text-anchor="middle" fill="currentColor" font-size="10">steps 0–14</text>
+  <text x="111" y="72" text-anchor="middle" fill="var(--fg-muted)" font-size="8">USB EP cfg · demod power</text>
+  <text x="111" y="83" text-anchor="middle" fill="var(--fg-muted)" font-size="8">soft-reset · clear DDC/IF</text>
+  <line x1="206" y1="62" x2="234" y2="62" stroke="currentColor"/><polygon points="234,58 244,62 234,66" fill="currentColor"/>
+  <rect x="244" y="36" width="172" height="52" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="330" y="58" text-anchor="middle" fill="var(--accent)" font-size="10">FIR upload</text>
+  <text x="330" y="72" text-anchor="middle" fill="var(--fg-muted)" font-size="8">20 taps · page 1</text>
+  <text x="330" y="83" text-anchor="middle" fill="var(--fg-muted)" font-size="8">addr 0x1C–0x2F</text>
+  <line x1="416" y1="62" x2="444" y2="62" stroke="currentColor"/><polygon points="444,58 454,62 444,66" fill="currentColor"/>
+  <rect x="454" y="36" width="190" height="52" rx="6" fill="none" stroke="currentColor"/>
+  <text x="549" y="58" text-anchor="middle" fill="currentColor" font-size="10">steps 15–end</text>
+  <text x="549" y="72" text-anchor="middle" fill="var(--fg-muted)" font-size="8">SDR mode · zero-IF</text>
+  <text x="549" y="83" text-anchor="middle" fill="var(--fg-muted)" font-size="8">DC + IQ compensation</text>
+  <rect x="120" y="106" width="420" height="30" rx="6" fill="none" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <text x="330" y="125" text-anchor="middle" fill="var(--fg-muted)" font-size="9">every demod write → commit read (page 0x0A, reg 0x01) or it never latches</text>
+</svg>
+<figcaption>The FIR upload is split into the middle of the flood — after the soft-reset and DDC/IF clear, before SDR mode — which is the "order is load-bearing" boundary the <code>initBasebandSteps</code> table pins as code.</figcaption>
+</figure>
+
+The 20-tap FIR filter itself is the DAB/FM-tuned coefficient set
 librtlsdr ships, packed with a fiddly layout — the first 8 taps are 8-bit signed
 (one byte each), and taps 8–15 are 12-bit signed and pack three nibbles per pair
 into 12 bytes:

--- a/docs/_posts/2026-06-25-build-in-the-open-08-testing-how-to-write-tests.md
+++ b/docs/_posts/2026-06-25-build-in-the-open-08-testing-how-to-write-tests.md
@@ -80,6 +80,27 @@ Most pain in real projects comes from an *inverted* pyramid — a few brittle
 end-to-end tests and no unit tests underneath. Push the bulk of your coverage
 down to the fast layer, where a failure points straight at the broken function.
 
+<figure class="lab-figure">
+<svg viewBox="0 0 660 210" width="660" height="210" role="img" aria-label="The testing pyramid: a wide base of many fast unit tests, a narrower middle band of fewer integration tests, and a small tip of a handful of slow end-to-end tests. GopherTrunk's make test is the unit base, make integration the middle, and the per-protocol lights-up checks the tip.">
+  <polygon points="170,20 40,185 300,185" fill="none" stroke="currentColor"/>
+  <line x1="127" y1="75" x2="213" y2="75" stroke="currentColor"/>
+  <line x1="83" y1="130" x2="257" y2="130" stroke="currentColor"/>
+  <text x="170" y="56" text-anchor="middle" fill="var(--fg-muted)" font-size="10">e2e</text>
+  <text x="170" y="107" text-anchor="middle" fill="currentColor" font-size="11">integration</text>
+  <text x="170" y="162" text-anchor="middle" fill="var(--accent)" font-size="12">unit</text>
+  <line x1="220" y1="50" x2="330" y2="50" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <text x="336" y="46" fill="var(--fg-muted)" font-size="10">a handful, slowest</text>
+  <text x="336" y="60" fill="var(--fg-muted)" font-size="9">per-protocol lights-up</text>
+  <line x1="262" y1="103" x2="330" y2="103" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <text x="336" y="99" fill="currentColor" font-size="10">fewer — make integration</text>
+  <text x="336" y="113" fill="var(--fg-muted)" font-size="9">wired daemon, no SDR</text>
+  <line x1="305" y1="158" x2="330" y2="158" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <text x="336" y="154" fill="var(--accent)" font-size="10">thousands — make test</text>
+  <text x="336" y="168" fill="var(--fg-muted)" font-size="9">go test -race, &lt;30s, the CI gate</text>
+</svg>
+<figcaption>Push the bulk of coverage to the wide base: GopherTrunk's <code>make test</code> unit layer is the gate CI enforces, with tagged integration tests and per-protocol end-to-end checks above it.</figcaption>
+</figure>
+
 ## How do you write a good test?
 
 A few techniques transfer to any language and test runner.
@@ -151,6 +172,27 @@ work is structured and the right answer is checkable:
 - **Write the regression test for a bug.** Describe the bug (or paste the stack
   trace), and ask for a test that fails *before* the fix and passes *after*. Land
   that test in the same PR as the fix — exactly the discipline good projects use.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 540 170" width="540" height="170" role="img" aria-label="The red, green, refactor loop: first write a failing test that is red, then write just enough code to make it pass and go green, then refactor while keeping the tests green, and repeat. For a bug fix the failing test comes first and ships in the same pull request as the fix.">
+  <rect x="20" y="30" width="150" height="44" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="95" y="49" text-anchor="middle" fill="var(--accent)" font-size="11">1 · red</text>
+  <text x="95" y="64" text-anchor="middle" fill="var(--fg-muted)" font-size="9">write a failing test</text>
+  <line x1="170" y1="52" x2="187" y2="52" stroke="currentColor"/><polygon points="187,48 193,52 187,56" fill="currentColor"/>
+  <rect x="195" y="30" width="150" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="270" y="49" text-anchor="middle" fill="currentColor" font-size="11">2 · green</text>
+  <text x="270" y="64" text-anchor="middle" fill="var(--fg-muted)" font-size="9">make it pass</text>
+  <line x1="345" y1="52" x2="362" y2="52" stroke="currentColor"/><polygon points="362,48 368,52 362,56" fill="currentColor"/>
+  <rect x="370" y="30" width="150" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="445" y="49" text-anchor="middle" fill="currentColor" font-size="11">3 · refactor</text>
+  <text x="445" y="64" text-anchor="middle" fill="var(--fg-muted)" font-size="9">clean up, stay green</text>
+  <line x1="445" y1="74" x2="445" y2="140" stroke="currentColor"/>
+  <line x1="445" y1="140" x2="95" y2="140" stroke="currentColor"/>
+  <line x1="95" y1="140" x2="95" y2="80" stroke="currentColor"/><polygon points="91,80 95,74 99,80" fill="currentColor"/>
+  <text x="270" y="135" text-anchor="middle" fill="var(--fg-muted)" font-size="9">repeat — for a bug fix, the red test lands in the same PR</text>
+</svg>
+<figcaption>The red→green→refactor loop, and the rule GopherTrunk enforces: a bug fix ships with a regression test that fails before the fix and passes after it, in the same PR.</figcaption>
+</figure>
 
 Always read what it produces. Claude is great at breadth; you supply the
 judgment about which cases actually matter and whether the assertions are real.

--- a/docs/_posts/2026-06-25-rf-front-end-08-rtlsdr-r82xx-blog-v4.md
+++ b/docs/_posts/2026-06-25-rf-front-end-08-rtlsdr-r82xx-blog-v4.md
@@ -46,6 +46,36 @@ tuner's PLL doesn't target 154 MHz — it targets 154 MHz + 3.57 MHz, and the
 RTL2832U is configured (back in `PrepareDemod`) to expect signal at that IF
 offset.
 
+<figure class="lab-figure">
+<svg viewBox="0 0 660 165" width="660" height="165" role="img" aria-label="The R82xx tuner block: the antenna's RF passes through an LNA with RF gain, then a mixer that subtracts a PLL-driven local oscillator to translate the signal down to a fixed 3.57 MHz intermediate frequency with VGA gain, which the RTL2832U's ADC then samples. The PLL and its local oscillator are clocked from the reference crystal.">
+  <rect x="8" y="40" width="60" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="38" y="66" text-anchor="middle" fill="currentColor" font-size="9">antenna</text>
+  <line x1="68" y1="62" x2="82" y2="62" stroke="currentColor"/><polygon points="82,58 92,62 82,66" fill="currentColor"/>
+  <rect x="92" y="40" width="96" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="140" y="60" text-anchor="middle" fill="currentColor" font-size="10">LNA</text>
+  <text x="140" y="73" text-anchor="middle" fill="var(--fg-muted)" font-size="8">RF gain</text>
+  <line x1="188" y1="62" x2="202" y2="62" stroke="currentColor"/><polygon points="202,58 212,62 202,66" fill="currentColor"/>
+  <rect x="212" y="40" width="96" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="260" y="60" text-anchor="middle" fill="currentColor" font-size="10">mixer</text>
+  <text x="260" y="73" text-anchor="middle" fill="var(--fg-muted)" font-size="8">RF − LO</text>
+  <line x1="308" y1="62" x2="322" y2="62" stroke="currentColor"/><polygon points="322,58 332,62 322,66" fill="currentColor"/>
+  <rect x="332" y="40" width="120" height="44" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="392" y="60" text-anchor="middle" fill="var(--accent)" font-size="10">3.57 MHz IF</text>
+  <text x="392" y="73" text-anchor="middle" fill="var(--fg-muted)" font-size="8">VGA gain</text>
+  <line x1="452" y1="62" x2="466" y2="62" stroke="currentColor"/><polygon points="466,58 476,62 466,66" fill="currentColor"/>
+  <rect x="476" y="40" width="176" height="44" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="564" y="60" text-anchor="middle" fill="var(--fg-muted)" font-size="10">RTL2832U ADC</text>
+  <text x="564" y="73" text-anchor="middle" fill="var(--fg-muted)" font-size="8">samples the IF</text>
+  <rect x="212" y="112" width="96" height="34" rx="6" fill="none" stroke="currentColor"/>
+  <text x="260" y="133" text-anchor="middle" fill="currentColor" font-size="9">PLL · LO</text>
+  <line x1="260" y1="112" x2="260" y2="86" stroke="currentColor"/><polygon points="256,94 260,84 264,94" fill="currentColor"/>
+  <rect x="92" y="112" width="96" height="34" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="140" y="133" text-anchor="middle" fill="var(--fg-muted)" font-size="9">xtal ref</text>
+  <line x1="188" y1="129" x2="202" y2="129" stroke="currentColor"/><polygon points="202,125 212,129 202,133" fill="currentColor"/>
+</svg>
+<figcaption>The R82xx mixes RF down to a fixed 3.57 MHz IF, so the RTL2832U only ever samples an intermediate frequency; every PLL division that sets the LO is computed off the reference crystal.</figcaption>
+</figure>
+
 The driver is a straight port of osmocom librtlsdr's `tuner_r82xx.c` — register
 addresses, the init flood, the PLL math, and the frequency-range mux table are
 all kept byte-identical so real-hardware captures replay-validate against the
@@ -120,6 +150,33 @@ vcoFra := uint32((vcoFreq - 2*pllRef*uint64(nint)) / 1000)
 Notice `effectiveXtalHz()`. *Every* PLL division is computed off the reference
 crystal. If the driver believes the crystal is 16 MHz when it's actually 28.8
 MHz, every tune is wrong by the ratio 28.8/16 = **1.8×**. Hold that thought.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 140" width="660" height="140" role="img" aria-label="Two tuning paths through the same setPLL math. With the R828D default crystal of 16 MHz, setPLL puts the local oscillator off target by the ratio 28.8 over 16, which is 1.8 times, leaving the Blog V4 deaf and receiving noise. With the SetBlogV4 override supplying 28.8 MHz, the same setPLL lands the local oscillator on target and the Blog V4 locks.">
+  <text x="330" y="16" text-anchor="middle" fill="var(--fg-muted)" font-size="9">every tune divides off the crystal:  nint, vcoFra = vcoFreq / (2 · effectiveXtalHz)</text>
+  <rect x="14" y="26" width="176" height="40" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="102" y="44" text-anchor="middle" fill="var(--fg-muted)" font-size="9">R828D default</text>
+  <text x="102" y="57" text-anchor="middle" fill="var(--fg-muted)" font-size="9">xtal = 16 MHz</text>
+  <line x1="190" y1="46" x2="216" y2="46" stroke="currentColor"/><polygon points="216,42 226,46 216,50" fill="currentColor"/>
+  <rect x="226" y="26" width="150" height="40" rx="6" fill="none" stroke="currentColor"/>
+  <text x="301" y="50" text-anchor="middle" fill="currentColor" font-size="10">setPLL</text>
+  <line x1="376" y1="46" x2="402" y2="46" stroke="currentColor"/><polygon points="402,42 412,46 402,50" fill="currentColor"/>
+  <rect x="412" y="26" width="234" height="40" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="529" y="44" text-anchor="middle" fill="var(--fg-muted)" font-size="9">LO off by 28.8 / 16 = 1.8×</text>
+  <text x="529" y="57" text-anchor="middle" fill="var(--fg-muted)" font-size="9">deaf — receives noise</text>
+  <rect x="14" y="86" width="176" height="40" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="102" y="104" text-anchor="middle" fill="var(--accent)" font-size="9">SetBlogV4 override</text>
+  <text x="102" y="117" text-anchor="middle" fill="var(--accent)" font-size="9">xtal = 28.8 MHz</text>
+  <line x1="190" y1="106" x2="216" y2="106" stroke="currentColor"/><polygon points="216,102 226,106 216,110" fill="currentColor"/>
+  <rect x="226" y="86" width="150" height="40" rx="6" fill="none" stroke="currentColor"/>
+  <text x="301" y="110" text-anchor="middle" fill="currentColor" font-size="10">setPLL</text>
+  <line x1="376" y1="106" x2="402" y2="106" stroke="currentColor"/><polygon points="402,102 412,106 402,110" fill="currentColor"/>
+  <rect x="412" y="86" width="234" height="40" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="529" y="104" text-anchor="middle" fill="var(--accent)" font-size="9">LO on target</text>
+  <text x="529" y="117" text-anchor="middle" fill="var(--accent)" font-size="9">Blog V4 locks</text>
+</svg>
+<figcaption>Same PLL math, different crystal: the wrong 16 MHz reference mistunes every Blog V4 by 1.8×, and <code>SetBlogV4</code> restoring the 28.8 MHz crystal is what puts the LO back on target.</figcaption>
+</figure>
 
 ### Tuner auto-detection
 

--- a/docs/_posts/2026-06-26-build-in-the-open-09-documentation-done-right.md
+++ b/docs/_posts/2026-06-26-build-in-the-open-09-documentation-done-right.md
@@ -98,6 +98,27 @@ trying to be two of these at once. A tutorial bloated with reference detail
 loses the beginner; a reference padded with tutorial hand-holding annoys the
 expert. Split them, and each gets clearer.
 
+<figure class="lab-figure">
+<svg viewBox="0 0 520 236" width="520" height="236" role="img" aria-label="The Diátaxis framework as four quadrants: tutorials are learning-oriented, how-to guides are task-oriented, explanation is understanding-oriented and reference is information-oriented. The top row is practical and the bottom row is theoretical; the left column serves study and the right column serves work.">
+  <text x="245" y="20" text-anchor="middle" fill="var(--fg-muted)" font-size="9">practical — steps you follow</text>
+  <rect x="50" y="30" width="190" height="82" rx="6" fill="none" stroke="currentColor"/>
+  <text x="145" y="66" text-anchor="middle" fill="var(--accent)" font-size="12">Tutorials</text>
+  <text x="145" y="84" text-anchor="middle" fill="var(--fg-muted)" font-size="9">learning-oriented</text>
+  <rect x="250" y="30" width="190" height="82" rx="6" fill="none" stroke="currentColor"/>
+  <text x="345" y="66" text-anchor="middle" fill="currentColor" font-size="12">How-to guides</text>
+  <text x="345" y="84" text-anchor="middle" fill="var(--fg-muted)" font-size="9">task-oriented</text>
+  <rect x="50" y="120" width="190" height="82" rx="6" fill="none" stroke="currentColor"/>
+  <text x="145" y="156" text-anchor="middle" fill="currentColor" font-size="12">Explanation</text>
+  <text x="145" y="174" text-anchor="middle" fill="var(--fg-muted)" font-size="9">understanding-oriented</text>
+  <rect x="250" y="120" width="190" height="82" rx="6" fill="none" stroke="currentColor"/>
+  <text x="345" y="156" text-anchor="middle" fill="currentColor" font-size="12">Reference</text>
+  <text x="345" y="174" text-anchor="middle" fill="var(--fg-muted)" font-size="9">information-oriented</text>
+  <text x="245" y="216" text-anchor="middle" fill="var(--fg-muted)" font-size="9">theoretical — knowledge you absorb</text>
+  <text x="16" y="145" fill="var(--fg-muted)" font-size="9" transform="rotate(-90 16 145)">study ← → work</text>
+</svg>
+<figcaption>Diátaxis names four kinds of doc so each stays pure; a page that feels muddled is usually two quadrants at once and should be split.</figcaption>
+</figure>
+
 ## Keep docs next to the code
 
 Wherever it's reasonable, keep documentation **in the repository**, in a `/docs`
@@ -124,6 +145,30 @@ first-class part of the repo, and the layout maps cleanly onto everything above:
   [Pages landing page]({{ '/' | relative_url }}) is *synthesized from the README
   at build time* (see Part 10), so the front door and the homepage never drift
   apart. The README links out to the deeper docs rather than absorbing them.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 640 120" width="640" height="120" role="img" aria-label="The source-to-site build flow: README.md is synthesized into docs/index.md, which sits alongside the docs folder of learn, reference and guides pages; Jekyll builds those Markdown sources; and GitHub Pages serves the result at gophertrunk.org.">
+  <rect x="10" y="34" width="120" height="52" rx="6" fill="none" stroke="currentColor"/>
+  <text x="70" y="58" text-anchor="middle" fill="currentColor" font-size="11">README.md</text>
+  <text x="70" y="73" text-anchor="middle" fill="var(--fg-muted)" font-size="9">the front door</text>
+  <text x="149" y="52" text-anchor="middle" fill="var(--fg-muted)" font-size="8">synthesize</text>
+  <line x1="130" y1="60" x2="162" y2="60" stroke="currentColor"/><polygon points="162,56 168,60 162,64" fill="currentColor"/>
+  <rect x="168" y="34" width="150" height="52" rx="6" fill="none" stroke="currentColor"/>
+  <text x="243" y="55" text-anchor="middle" fill="currentColor" font-size="11">docs/</text>
+  <text x="243" y="69" text-anchor="middle" fill="var(--fg-muted)" font-size="8">index.md · learn</text>
+  <text x="243" y="80" text-anchor="middle" fill="var(--fg-muted)" font-size="8">reference · guides</text>
+  <line x1="318" y1="60" x2="350" y2="60" stroke="currentColor"/><polygon points="350,56 356,60 350,64" fill="currentColor"/>
+  <rect x="356" y="34" width="110" height="52" rx="6" fill="none" stroke="currentColor"/>
+  <text x="411" y="58" text-anchor="middle" fill="currentColor" font-size="11">Jekyll</text>
+  <text x="411" y="73" text-anchor="middle" fill="var(--fg-muted)" font-size="9">build</text>
+  <line x1="466" y1="60" x2="498" y2="60" stroke="currentColor"/><polygon points="498,56 504,60 498,64" fill="currentColor"/>
+  <rect x="504" y="34" width="126" height="52" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="567" y="58" text-anchor="middle" fill="var(--accent)" font-size="11">gophertrunk.org</text>
+  <text x="567" y="73" text-anchor="middle" fill="var(--fg-muted)" font-size="9">GitHub Pages</text>
+</svg>
+<figcaption>One source of truth: the README is synthesized into <code>docs/index.md</code> at build time, so the homepage and the front door can never drift apart.</figcaption>
+</figure>
+
 - **The standard files are all present.** `CONTRIBUTING.md` documents the build,
   test, branch, and PR conventions (including the table of `make` targets and the
   opt-in hardware-test env vars); `SECURITY.md` carries the threat model and

--- a/docs/_posts/2026-06-26-rf-front-end-09-rtlsdr-streaming-gc-churn.md
+++ b/docs/_posts/2026-06-26-rf-front-end-09-rtlsdr-streaming-gc-churn.md
@@ -48,6 +48,32 @@ dropping samples when the consumer hiccups.
 The whole thing lives in `internal/sdr/rtlsdr/purego/stream.go`, with the device
 state machine in `device.go`.
 
+<figure class="lab-figure">
+<svg viewBox="0 0 660 130" width="660" height="130" role="img" aria-label="The RTL2832U streaming pipeline: the bulk-IN endpoint fills a ring of 32 async USB buffers of 16 KiB each, about 6 ms of headroom; each completed URB calls deliver, which converts unsigned-8-bit IQ into complex64 through a 256-entry lookup table and enqueues the chunk on a consumer channel 32 chunks deep, about 110 ms of slack, which a control-channel decoder drains.">
+  <text x="330" y="20" text-anchor="middle" fill="var(--fg-muted)" font-size="10">2.4 MS/s · 4.8 MB/s continuous</text>
+  <rect x="8" y="44" width="112" height="50" rx="6" fill="none" stroke="currentColor"/>
+  <text x="64" y="66" text-anchor="middle" fill="currentColor" font-size="9">RTL2832U</text>
+  <text x="64" y="80" text-anchor="middle" fill="var(--fg-muted)" font-size="8">bulk-IN 0x81</text>
+  <line x1="120" y1="69" x2="134" y2="69" stroke="currentColor"/><polygon points="134,65 144,69 134,73" fill="currentColor"/>
+  <rect x="144" y="44" width="128" height="50" rx="6" fill="none" stroke="currentColor"/>
+  <text x="208" y="66" text-anchor="middle" fill="currentColor" font-size="9">32 async buffers</text>
+  <text x="208" y="80" text-anchor="middle" fill="var(--fg-muted)" font-size="8">16 KiB · ~6 ms headroom</text>
+  <line x1="272" y1="69" x2="286" y2="69" stroke="currentColor"/><polygon points="286,65 296,69 286,73" fill="currentColor"/>
+  <rect x="296" y="44" width="108" height="50" rx="6" fill="none" stroke="currentColor"/>
+  <text x="350" y="66" text-anchor="middle" fill="currentColor" font-size="9">deliver()</text>
+  <text x="350" y="80" text-anchor="middle" fill="var(--fg-muted)" font-size="8">U8→c64 LUT</text>
+  <line x1="404" y1="69" x2="418" y2="69" stroke="currentColor"/><polygon points="418,65 428,69 418,73" fill="currentColor"/>
+  <rect x="428" y="44" width="112" height="50" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="484" y="66" text-anchor="middle" fill="var(--accent)" font-size="9">chan depth 32</text>
+  <text x="484" y="80" text-anchor="middle" fill="var(--fg-muted)" font-size="8">~110 ms slack</text>
+  <line x1="540" y1="69" x2="554" y2="69" stroke="currentColor"/><polygon points="554,65 564,69 554,73" fill="currentColor"/>
+  <rect x="564" y="44" width="88" height="50" rx="6" fill="none" stroke="currentColor"/>
+  <text x="608" y="66" text-anchor="middle" fill="currentColor" font-size="9">consumer</text>
+  <text x="608" y="80" text-anchor="middle" fill="var(--fg-muted)" font-size="8">CC decoder</text>
+</svg>
+<figcaption>The bulk-IN flood crosses 32 async USB buffers, a lookup-table conversion in <code>deliver</code>, and a 32-deep consumer channel — the geometry the GC-churn bug systematically defeated.</figcaption>
+</figure>
+
 ## How GopherTrunk implements it in Go
 
 ### The geometry
@@ -214,6 +240,33 @@ With the ring in place the steady state allocates **nothing** per chunk, the GC
 went quiet, the consumer kept its budget, and the drop rate fell to zero. The
 deeper channel depth from earlier is slack on top of this — not a substitute for
 it.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 145" width="660" height="145" role="img" aria-label="Before and after the issue 489 fix. Before: deliver allocates a fresh 64 KiB complex64 slice per chunk, which drives GC churn whose pauses land on the consumer goroutine, so the pipeline sheds 25 to 48 percent of live IQ. After: a reuse ring of streamChanDepth plus 2 slots that advances only on a successful send means zero allocation in steady state, the GC stays quiet, and the drop rate falls to zero.">
+  <text x="330" y="18" text-anchor="middle" fill="var(--fg-muted)" font-size="10">issue #489 — per-chunk allocation vs buffer reuse</text>
+  <rect x="14" y="28" width="182" height="42" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="105" y="46" text-anchor="middle" fill="var(--fg-muted)" font-size="9">make([]complex64)</text>
+  <text x="105" y="60" text-anchor="middle" fill="var(--fg-muted)" font-size="8">fresh ~64 KiB per chunk</text>
+  <line x1="196" y1="49" x2="222" y2="49" stroke="currentColor"/><polygon points="222,45 232,49 222,53" fill="currentColor"/>
+  <rect x="232" y="28" width="160" height="42" rx="6" fill="none" stroke="currentColor"/>
+  <text x="312" y="46" text-anchor="middle" fill="currentColor" font-size="9">GC churn</text>
+  <text x="312" y="60" text-anchor="middle" fill="var(--fg-muted)" font-size="8">pauses hit consumer</text>
+  <line x1="392" y1="49" x2="418" y2="49" stroke="currentColor"/><polygon points="418,45 428,49 418,53" fill="currentColor"/>
+  <rect x="428" y="28" width="218" height="42" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="537" y="53" text-anchor="middle" fill="var(--fg-muted)" font-size="9">sheds 25–48% of live IQ</text>
+  <rect x="14" y="92" width="182" height="42" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="105" y="110" text-anchor="middle" fill="var(--accent)" font-size="9">reuse ring</text>
+  <text x="105" y="124" text-anchor="middle" fill="var(--fg-muted)" font-size="8">streamChanDepth + 2 slots</text>
+  <line x1="196" y1="113" x2="222" y2="113" stroke="currentColor"/><polygon points="222,109 232,113 222,117" fill="currentColor"/>
+  <rect x="232" y="92" width="160" height="42" rx="6" fill="none" stroke="currentColor"/>
+  <text x="312" y="110" text-anchor="middle" fill="currentColor" font-size="9">0 alloc steady state</text>
+  <text x="312" y="124" text-anchor="middle" fill="var(--fg-muted)" font-size="8">advances only on send</text>
+  <line x1="392" y1="113" x2="418" y2="113" stroke="currentColor"/><polygon points="418,109 428,113 418,117" fill="currentColor"/>
+  <rect x="428" y="92" width="218" height="42" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="537" y="117" text-anchor="middle" fill="var(--accent)" font-size="9">GC quiet · drop rate → 0</text>
+</svg>
+<figcaption>The fix wasn't cleverer code, it was <em>no</em> code in the allocator: reusing <code>streamChanDepth + 2</code> preallocated buffers took the GC out of the consumer's real-time budget and dropped the loss rate to zero.</figcaption>
+</figure>
 
 ## The second problem: silent live IQ loss (issue #402)
 

--- a/docs/_posts/2026-06-27-build-in-the-open-10-websites-support-pages-github-pages.md
+++ b/docs/_posts/2026-06-27-build-in-the-open-10-websites-support-pages-github-pages.md
@@ -53,6 +53,27 @@ JavaScript — there's nothing to run, nothing to patch, and nothing to pay for.
 marketing sites are all static by nature, and a static site is the fastest and
 most secure thing you can ship.
 
+<figure class="lab-figure">
+<svg viewBox="0 0 660 120" width="660" height="120" role="img" aria-label="The GitHub Pages deploy flow: a push to docs or the daily cron triggers the pages.yml workflow, which runs a Jekyll build, which deploys to GitHub Pages on a CDN over HTTPS, which serves the custom domain gophertrunk.org named in the CNAME file.">
+  <rect x="10" y="34" width="130" height="52" rx="6" fill="none" stroke="currentColor"/>
+  <text x="75" y="58" text-anchor="middle" fill="currentColor" font-size="11">git push</text>
+  <text x="75" y="73" text-anchor="middle" fill="var(--fg-muted)" font-size="9">docs/** or cron</text>
+  <line x1="140" y1="60" x2="172" y2="60" stroke="currentColor"/><polygon points="172,56 178,60 172,64" fill="currentColor"/>
+  <rect x="178" y="34" width="160" height="52" rx="6" fill="none" stroke="currentColor"/>
+  <text x="258" y="58" text-anchor="middle" fill="currentColor" font-size="11">pages.yml</text>
+  <text x="258" y="73" text-anchor="middle" fill="var(--fg-muted)" font-size="9">Actions · Jekyll build</text>
+  <line x1="338" y1="60" x2="370" y2="60" stroke="currentColor"/><polygon points="370,56 376,60 370,64" fill="currentColor"/>
+  <rect x="376" y="34" width="130" height="52" rx="6" fill="none" stroke="currentColor"/>
+  <text x="441" y="58" text-anchor="middle" fill="currentColor" font-size="11">GitHub Pages</text>
+  <text x="441" y="73" text-anchor="middle" fill="var(--fg-muted)" font-size="9">CDN · HTTPS</text>
+  <line x1="506" y1="60" x2="538" y2="60" stroke="currentColor"/><polygon points="538,56 544,60 538,64" fill="currentColor"/>
+  <rect x="544" y="34" width="110" height="52" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="599" y="58" text-anchor="middle" fill="var(--accent)" font-size="11">gophertrunk.org</text>
+  <text x="599" y="73" text-anchor="middle" fill="var(--fg-muted)" font-size="9">CNAME</text>
+</svg>
+<figcaption>Every push (or the daily <code>cron</code>) runs <code>pages.yml</code>, which builds the Jekyll site and deploys it to GitHub Pages — served over HTTPS on the domain in <code>docs/CNAME</code>.</figcaption>
+</figure>
+
 ## Why use a static-site generator?
 
 Writing raw HTML for every page gets old fast. A **static-site generator** lets
@@ -101,6 +122,25 @@ Beyond the docs, a few pages do real work:
   more.
 - **A blog.** For release notes, tutorials, and build-in-the-open posts like this
   one — which doubles as SEO and a reason for people to come back.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 540 210" width="540" height="210" role="img" aria-label="The site page structure fanning out from the repository root: a landing page synthesized from the README, the docs folder of guides, reference and learning pages, a support page, a self-drip-releasing blog, and a FUNDING.yml that renders the Sponsor button.">
+  <rect x="20" y="80" width="120" height="48" rx="6" fill="none" stroke="currentColor"/>
+  <text x="80" y="102" text-anchor="middle" fill="currentColor" font-size="11">site root</text>
+  <text x="80" y="117" text-anchor="middle" fill="var(--fg-muted)" font-size="9">docs/ folder</text>
+  <line x1="140" y1="104" x2="242" y2="29" stroke="currentColor"/><polygon points="243,25 250,29 240,35" fill="currentColor"/>
+  <line x1="140" y1="104" x2="242" y2="67" stroke="currentColor"/><polygon points="242,63 250,67 241,73" fill="currentColor"/>
+  <line x1="140" y1="104" x2="242" y2="105" stroke="currentColor"/><polygon points="242,101 250,105 242,109" fill="currentColor"/>
+  <line x1="140" y1="104" x2="242" y2="143" stroke="currentColor"/><polygon points="242,139 250,143 241,149" fill="currentColor"/>
+  <line x1="140" y1="104" x2="242" y2="181" stroke="currentColor"/><polygon points="243,177 250,181 240,187" fill="currentColor"/>
+  <rect x="250" y="14" width="260" height="30" rx="5" fill="none" stroke="currentColor"/><text x="380" y="33" text-anchor="middle" fill="currentColor" font-size="10">landing page — index.md (from README)</text>
+  <rect x="250" y="52" width="260" height="30" rx="5" fill="none" stroke="currentColor"/><text x="380" y="71" text-anchor="middle" fill="currentColor" font-size="10">docs/ — learn · reference · guides</text>
+  <rect x="250" y="90" width="260" height="30" rx="5" fill="none" stroke="currentColor"/><text x="380" y="109" text-anchor="middle" fill="currentColor" font-size="10">support.md — get help</text>
+  <rect x="250" y="128" width="260" height="30" rx="5" fill="none" stroke="var(--accent)"/><text x="380" y="147" text-anchor="middle" fill="var(--accent)" font-size="10">blog — _posts, drip-released</text>
+  <rect x="250" y="166" width="260" height="30" rx="5" fill="none" stroke="currentColor"/><text x="380" y="185" text-anchor="middle" fill="currentColor" font-size="10">FUNDING.yml — Sponsor button</text>
+</svg>
+<figcaption>The pages a real project ships, all from one repo: a landing page synthesized from the README, the <code>docs/</code> tree, a support page, a <code>FUNDING.yml</code> sponsor button, and a blog that drip-releases itself.</figcaption>
+</figure>
 
 ## Running a blog (and drip-releasing posts)
 

--- a/docs/_posts/2026-06-27-rf-front-end-10-airspy-real-to-complex.md
+++ b/docs/_posts/2026-06-27-rf-front-end-10-airspy-real-to-complex.md
@@ -73,6 +73,32 @@ device contract; here we build the converter that justifies it.
 one method per USB packet. Its job, top to bottom: decode `uint16` reals,
 remove DC, mix by `Fs/4`, run the half-band pair, emit `complex64`.**
 
+<figure class="lab-figure">
+<svg viewBox="0 0 660 130" width="660" height="130" role="img" aria-label="The Airspy R2/Mini real-to-complex pipeline in iqconverter.go: bare 12-bit uint16 real ADC samples with DC at 2048 pass through a leaky high-pass DC blocker, then a multiplier-free Fs over 4 mix, then a 47-tap half-band Hilbert pair, then decimation by two, producing complex64 IQ at half the input rate.">
+  <rect x="8" y="46" width="96" height="48" rx="6" fill="none" stroke="currentColor"/>
+  <text x="56" y="66" text-anchor="middle" fill="currentColor" font-size="9">uint16 reals</text>
+  <text x="56" y="80" text-anchor="middle" fill="var(--fg-muted)" font-size="8">12-bit · DC 2048</text>
+  <line x1="104" y1="70" x2="118" y2="70" stroke="currentColor"/><polygon points="118,66 128,70 118,74" fill="currentColor"/>
+  <rect x="128" y="46" width="104" height="48" rx="6" fill="none" stroke="currentColor"/>
+  <text x="180" y="66" text-anchor="middle" fill="currentColor" font-size="9">DC blocker</text>
+  <text x="180" y="80" text-anchor="middle" fill="var(--fg-muted)" font-size="8">leaky HPF</text>
+  <line x1="232" y1="70" x2="246" y2="70" stroke="currentColor"/><polygon points="246,66 256,70 246,74" fill="currentColor"/>
+  <rect x="256" y="46" width="104" height="48" rx="6" fill="none" stroke="currentColor"/>
+  <text x="308" y="66" text-anchor="middle" fill="currentColor" font-size="9">Fs/4 mix</text>
+  <text x="308" y="80" text-anchor="middle" fill="var(--fg-muted)" font-size="8">sign flip · no ×</text>
+  <line x1="360" y1="70" x2="374" y2="70" stroke="currentColor"/><polygon points="374,66 384,70 374,74" fill="currentColor"/>
+  <rect x="384" y="46" width="120" height="48" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="444" y="66" text-anchor="middle" fill="var(--accent)" font-size="9">half-band pair</text>
+  <text x="444" y="80" text-anchor="middle" fill="var(--fg-muted)" font-size="8">47-tap Hilbert</text>
+  <line x1="504" y1="70" x2="518" y2="70" stroke="currentColor"/><polygon points="518,66 528,70 518,74" fill="currentColor"/>
+  <rect x="528" y="46" width="124" height="48" rx="6" fill="none" stroke="currentColor"/>
+  <text x="590" y="66" text-anchor="middle" fill="currentColor" font-size="9">÷2 → complex64</text>
+  <text x="590" y="80" text-anchor="middle" fill="var(--fg-muted)" font-size="8">N reals → N/2 IQ</text>
+  <text x="330" y="22" text-anchor="middle" fill="var(--fg-muted)" font-size="10">processRaw() — one call per USB packet, state carried across boundaries</text>
+</svg>
+<figcaption>The Airspy R2/Mini hand the host bare real samples, so the driver synthesizes complex baseband in four stages — DC removal, a free Fs/4 mix, a half-band Hilbert pair, and decimate-by-two — entirely in <code>iqconverter.go</code>.</figcaption>
+</figure>
+
 ### Stage 1 — leaky-HPF DC removal
 
 The ADC parks DC at 2048 and the front end adds its own slow bias drift. Left
@@ -199,6 +225,29 @@ func (c *iqConverter) processRaw(buf []byte) []complex64 {
 
 One bulk-IN payload of `N` real bytes-as-uint16 yields `N/2` real samples and
 `N/4` complex samples, at exactly the configured IQ rate.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 165" width="660" height="165" role="img" aria-label="How the persistent phase counter routes each real sample. The phase cycles 0,1,2,3 and carries across USB packets. Even phases 0 and 2 take the in-phase lane: a sign flip feeds the 24-tap half-band FIR to produce lastI. Odd phases 1 and 3 take the quadrature lane: a 0.5-scaled sign-flipped sample runs through a matched delay to produce qOut. On the odd phases the converter emits complex of lastI and qOut, giving an implicit decimate-by-two into complex64.">
+  <text x="330" y="14" text-anchor="middle" fill="var(--fg-muted)" font-size="10">the Fs/4 phase counter routes each real sample into one lane</text>
+  <rect x="12" y="58" width="120" height="54" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="72" y="82" text-anchor="middle" fill="var(--accent)" font-size="10">phase 0→1→2→3</text>
+  <text x="72" y="96" text-anchor="middle" fill="var(--fg-muted)" font-size="8">persists across packets</text>
+  <line x1="132" y1="74" x2="176" y2="44" stroke="currentColor"/><polygon points="167,41 179,37 175,49" fill="currentColor"/>
+  <line x1="132" y1="96" x2="176" y2="128" stroke="currentColor"/><polygon points="167,123 179,127 172,135" fill="currentColor"/>
+  <rect x="180" y="22" width="236" height="40" rx="6" fill="none" stroke="currentColor"/>
+  <text x="298" y="40" text-anchor="middle" fill="currentColor" font-size="9">I lane · phases 0,2</text>
+  <text x="298" y="53" text-anchor="middle" fill="var(--fg-muted)" font-size="8">sign-flip → half-band FIR (24 taps) → lastI</text>
+  <rect x="180" y="110" width="236" height="40" rx="6" fill="none" stroke="currentColor"/>
+  <text x="298" y="128" text-anchor="middle" fill="currentColor" font-size="9">Q lane · phases 1,3</text>
+  <text x="298" y="141" text-anchor="middle" fill="var(--fg-muted)" font-size="8">0.5·x sign-flip → matched delay → qOut</text>
+  <line x1="416" y1="42" x2="462" y2="74" stroke="currentColor"/><polygon points="453,69 465,73 456,81" fill="currentColor"/>
+  <line x1="416" y1="130" x2="462" y2="96" stroke="currentColor"/><polygon points="453,89 465,95 457,101" fill="currentColor"/>
+  <rect x="464" y="58" width="184" height="54" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="556" y="82" text-anchor="middle" fill="var(--accent)" font-size="9">emit complex(lastI, qOut)</text>
+  <text x="556" y="96" text-anchor="middle" fill="var(--fg-muted)" font-size="8">÷2 decimate → complex64</text>
+</svg>
+<figcaption>Emitting only on the odd (quadrature) phases makes the decimate-by-two implicit: every four real samples collapse to one <code>complex64</code>, with the phase counter carried across packet boundaries so the rotation never glitches.</figcaption>
+</figure>
 
 ## The problem we hit: a half-band Hilbert that joined packets seamlessly (#454)
 

--- a/docs/_posts/2026-06-28-build-in-the-open-11-releases-prerelease-semver-changelogs.md
+++ b/docs/_posts/2026-06-28-build-in-the-open-11-releases-prerelease-semver-changelogs.md
@@ -78,6 +78,30 @@ the number is lying and your users stop trusting it. When in doubt about whether
 something is a feature or a fix, ask: *could this surprise someone who upgrades
 without reading?* If yes, it's at least a MINOR.
 
+<figure class="lab-figure">
+<svg viewBox="0 0 660 168" width="660" height="168" role="img" aria-label="The three SemVer bump rules applied to version 1.2.3: a breaking change bumps MAJOR to 2.0.0 and resets minor and patch; a backward-compatible feature bumps MINOR to 1.3.0 and resets patch; a bug fix bumps PATCH to 1.2.4.">
+  <rect x="270" y="12" width="120" height="34" rx="6" fill="none" stroke="currentColor"/>
+  <text x="330" y="27" text-anchor="middle" fill="currentColor" font-size="13">1.2.3</text>
+  <text x="330" y="40" text-anchor="middle" fill="var(--fg-muted)" font-size="8">current version</text>
+  <line x1="300" y1="46" x2="150" y2="84" stroke="currentColor"/><polygon points="153,79 143,86 156,88" fill="currentColor"/>
+  <line x1="330" y1="46" x2="330" y2="84" stroke="currentColor"/><polygon points="326,84 330,94 334,84" fill="currentColor"/>
+  <line x1="360" y1="46" x2="510" y2="84" stroke="currentColor"/><polygon points="504,79 517,86 507,88" fill="currentColor"/>
+  <rect x="26" y="96" width="196" height="58" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="124" y="114" text-anchor="middle" fill="var(--accent)" font-size="11">MAJOR → 2.0.0</text>
+  <text x="124" y="130" text-anchor="middle" fill="currentColor" font-size="9">breaking change</text>
+  <text x="124" y="144" text-anchor="middle" fill="var(--fg-muted)" font-size="8">read notes before upgrade</text>
+  <rect x="232" y="96" width="196" height="58" rx="6" fill="none" stroke="currentColor"/>
+  <text x="330" y="114" text-anchor="middle" fill="currentColor" font-size="11">MINOR → 1.3.0</text>
+  <text x="330" y="130" text-anchor="middle" fill="currentColor" font-size="9">new feature, compatible</text>
+  <text x="330" y="144" text-anchor="middle" fill="var(--fg-muted)" font-size="8">safe to upgrade</text>
+  <rect x="438" y="96" width="196" height="58" rx="6" fill="none" stroke="currentColor"/>
+  <text x="536" y="114" text-anchor="middle" fill="currentColor" font-size="11">PATCH → 1.2.4</text>
+  <text x="536" y="130" text-anchor="middle" fill="currentColor" font-size="9">bug fix, no API change</text>
+  <text x="536" y="144" text-anchor="middle" fill="var(--fg-muted)" font-size="8">always safe</text>
+</svg>
+<figcaption>What each number promises: bump MAJOR for a breaking change, MINOR for a backward-compatible feature, PATCH for a fix — and reset the lower fields to zero.</figcaption>
+</figure>
+
 A subtle but important rule: **everything below `1.0.0` is a free-for-all.**
 SemVer §4 says the public API should not be considered stable until `1.0.0`. A
 `0.x` version is itself a signal — "I'm still figuring out the shape of this,
@@ -145,6 +169,34 @@ the binary can report exactly which release and commit it came from. In Go this
 is `-ldflags "-X pkg.Version=..."`; other ecosystems have equivalents. And always
 publish a `SHA256SUMS` file so anyone can verify the download wasn't corrupted or
 tampered with.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 176" width="660" height="176" role="img" aria-label="The release timeline: an Unreleased changelog section fills up as PRs merge; pushing a v-prefixed tag triggers CI to build artifacts and checksums; a 0.x or -rc tag publishes as a pre-release, while a clean v1.0.0-plus tag publishes as the latest stable release, and the Unreleased heading is renamed to the dated version.">
+  <line x1="24" y1="40" x2="636" y2="40" stroke="var(--fg-muted)"/><polygon points="636,36 646,40 636,44" fill="var(--fg-muted)"/>
+  <rect x="24" y="52" width="150" height="46" rx="6" fill="none" stroke="currentColor"/>
+  <text x="99" y="70" text-anchor="middle" fill="currentColor" font-size="10">## [Unreleased]</text>
+  <text x="99" y="84" text-anchor="middle" fill="var(--fg-muted)" font-size="8">filled as PRs merge</text>
+  <text x="99" y="94" text-anchor="middle" fill="var(--fg-muted)" font-size="8">Added · Fixed · Changed</text>
+  <line x1="174" y1="75" x2="206" y2="75" stroke="currentColor"/><polygon points="206,71 216,75 206,79" fill="currentColor"/>
+  <rect x="216" y="52" width="150" height="46" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="291" y="70" text-anchor="middle" fill="var(--accent)" font-size="10">git tag vX.Y.Z</text>
+  <text x="291" y="84" text-anchor="middle" fill="var(--fg-muted)" font-size="8">on: push tags v*.*.*</text>
+  <text x="291" y="94" text-anchor="middle" fill="var(--fg-muted)" font-size="8">triggers release.yml</text>
+  <line x1="366" y1="75" x2="398" y2="75" stroke="currentColor"/><polygon points="398,71 408,75 398,79" fill="currentColor"/>
+  <rect x="408" y="52" width="150" height="46" rx="6" fill="none" stroke="currentColor"/>
+  <text x="483" y="70" text-anchor="middle" fill="currentColor" font-size="10">CI build matrix</text>
+  <text x="483" y="84" text-anchor="middle" fill="var(--fg-muted)" font-size="8">ldflags version stamp</text>
+  <text x="483" y="94" text-anchor="middle" fill="var(--fg-muted)" font-size="8">+ SHA256SUMS</text>
+  <line x1="483" y1="98" x2="483" y2="120" stroke="currentColor"/><polygon points="479,120 483,130 487,120" fill="currentColor"/>
+  <rect x="330" y="132" width="146" height="34" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="403" y="148" text-anchor="middle" fill="var(--fg-muted)" font-size="10">v0.x / -rc.1</text>
+  <text x="403" y="160" text-anchor="middle" fill="var(--fg-muted)" font-size="8">prerelease: true</text>
+  <rect x="490" y="132" width="146" height="34" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="563" y="148" text-anchor="middle" fill="var(--accent)" font-size="10">v1.0.0+</text>
+  <text x="563" y="160" text-anchor="middle" fill="var(--fg-muted)" font-size="8">latest stable release</text>
+</svg>
+<figcaption>One tag drives the whole timeline: the <code>[Unreleased]</code> changelog fills as PRs merge, a pushed <code>v*.*.*</code> tag triggers the build, and the version pattern decides pre-release versus latest.</figcaption>
+</figure>
 
 ## How GopherTrunk does it
 

--- a/docs/_posts/2026-06-28-rf-front-end-11-hackrf-one.md
+++ b/docs/_posts/2026-06-28-rf-front-end-11-hackrf-one.md
@@ -43,6 +43,26 @@ was the Airspy R2/Mini in
 [Part 10]({{ '/blog/deep-dives/rf-front-end-10-airspy-real-to-complex/' | relative_url }}))
 and no 16-bit unpacking; just two signed bytes per complex sample.
 
+<figure class="lab-figure">
+<svg viewBox="0 0 660 140" width="660" height="140" role="img" aria-label="The HackRF receive sample path: the firmware delivers signed 8-bit interleaved I,Q bytes on bulk endpoint 0x81, decodeInt8IQ reinterprets each byte as int8 and divides by 128, producing normalised complex64 samples in the range minus one to one, which feed the DSP chain.">
+  <rect x="8" y="46" width="160" height="48" rx="6" fill="none" stroke="currentColor"/>
+  <text x="88" y="68" text-anchor="middle" fill="currentColor" font-size="11">bulk-IN 0x81</text>
+  <text x="88" y="82" text-anchor="middle" fill="var(--fg-muted)" font-size="9">I, Q, I, Q · signed 8-bit</text>
+  <line x1="168" y1="70" x2="206" y2="70" stroke="currentColor"/><polygon points="206,66 216,70 206,74" fill="currentColor"/>
+  <rect x="216" y="46" width="160" height="48" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="296" y="68" text-anchor="middle" fill="var(--accent)" font-size="11">decodeInt8IQ</text>
+  <text x="296" y="82" text-anchor="middle" fill="var(--fg-muted)" font-size="9">int8(b) / 128</text>
+  <line x1="376" y1="70" x2="414" y2="70" stroke="currentColor"/><polygon points="414,66 424,70 414,74" fill="currentColor"/>
+  <rect x="424" y="46" width="150" height="48" rx="6" fill="none" stroke="currentColor"/>
+  <text x="499" y="68" text-anchor="middle" fill="currentColor" font-size="11">complex64</text>
+  <text x="499" y="82" text-anchor="middle" fill="var(--fg-muted)" font-size="9">[-1, 1]</text>
+  <line x1="574" y1="70" x2="604" y2="70" stroke="currentColor"/><polygon points="604,66 614,70 604,74" fill="currentColor"/>
+  <rect x="614" y="46" width="40" height="48" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="634" y="73" text-anchor="middle" fill="var(--fg-muted)" font-size="9">DSP</text>
+</svg>
+<figcaption>The HackRF's receive path is the friendliest of the three: signed 8-bit interleaved bytes on bulk endpoint <code>0x81</code>, reinterpreted as <code>int8</code> and divided by 128 into <code>complex64</code> in <code>[-1, 1]</code>.</figcaption>
+</figure>
+
 ## How GopherTrunk implements it in Go
 
 ### Decoding the samples
@@ -92,6 +112,22 @@ func (d *Device) setMode(mode uint16) error {
 `StreamIQ` flips to receive, starts the bulk-IN reaper, and a detached goroutine
 flips back to off on either context cancellation or an unrecoverable URB death —
 the same teardown shape every driver in this series shares.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 620 150" width="620" height="150" role="img" aria-label="The HackRF half-duplex transceiver state machine over SET_TRANSCEIVER_MODE: StreamIQ moves the device from transceiver mode off, value zero, to receive, value one, where bulk-IN samples flow; a context cancellation or an unrecoverable URB death flips it back to off.">
+  <rect x="30" y="52" width="200" height="52" rx="6" fill="none" stroke="currentColor"/>
+  <text x="130" y="76" text-anchor="middle" fill="currentColor" font-size="11">transceiverModeOff</text>
+  <text x="130" y="92" text-anchor="middle" fill="var(--fg-muted)" font-size="9">mode 0 · no stream</text>
+  <rect x="390" y="52" width="200" height="52" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="490" y="76" text-anchor="middle" fill="var(--accent)" font-size="11">transceiverModeReceive</text>
+  <text x="490" y="92" text-anchor="middle" fill="var(--fg-muted)" font-size="9">mode 1 · bulk-IN flowing</text>
+  <line x1="230" y1="68" x2="388" y2="68" stroke="currentColor"/><polygon points="388,64 398,68 388,72" fill="currentColor"/>
+  <text x="309" y="60" text-anchor="middle" fill="var(--fg-muted)" font-size="9">StreamIQ</text>
+  <line x1="390" y1="90" x2="232" y2="90" stroke="currentColor"/><polygon points="232,86 222,90 232,94" fill="currentColor"/>
+  <text x="311" y="104" text-anchor="middle" fill="var(--fg-muted)" font-size="9">ctx cancel / URB death</text>
+</svg>
+<figcaption>Half-duplex: the HackRF streams only in receive mode. <code>StreamIQ</code> flips <code>SET_TRANSCEIVER_MODE</code> to receive (1); context cancellation or an unrecoverable URB death flips it back to off (0).</figcaption>
+</figure>
 
 ### Tuning and the tracking baseband filter
 

--- a/docs/_posts/2026-06-29-build-in-the-open-12-optimizing-securing-your-repository.md
+++ b/docs/_posts/2026-06-29-build-in-the-open-12-optimizing-securing-your-repository.md
@@ -92,6 +92,36 @@ contributors.
 Optimization gets people in the door. Security keeps the door from being kicked
 off its hinges.
 
+<figure class="lab-figure">
+<svg viewBox="0 0 660 190" width="660" height="190" role="img" aria-label="A defense-in-depth stack guarding the main branch: an incoming change passes through four hardening layers in turn — branch protection with required checks, secret scanning with push protection, Dependabot and CVE scanning, and least-privilege Actions tokens — before it can reach a protected main.">
+  <rect x="16" y="78" width="96" height="36" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="64" y="100" text-anchor="middle" fill="var(--fg-muted)" font-size="10">a change</text>
+  <line x1="112" y1="96" x2="140" y2="96" stroke="currentColor"/><polygon points="140,92 150,96 140,100" fill="currentColor"/>
+  <rect x="150" y="20" width="118" height="150" rx="6" fill="none" stroke="currentColor"/>
+  <text x="209" y="40" text-anchor="middle" fill="currentColor" font-size="10">branch</text>
+  <text x="209" y="53" text-anchor="middle" fill="currentColor" font-size="10">protection</text>
+  <text x="209" y="70" text-anchor="middle" fill="var(--fg-muted)" font-size="8">PR required</text>
+  <text x="209" y="82" text-anchor="middle" fill="var(--fg-muted)" font-size="8">status checks</text>
+  <text x="209" y="94" text-anchor="middle" fill="var(--fg-muted)" font-size="8">no force-push</text>
+  <rect x="274" y="20" width="118" height="150" rx="6" fill="none" stroke="currentColor"/>
+  <text x="333" y="40" text-anchor="middle" fill="currentColor" font-size="10">secret</text>
+  <text x="333" y="53" text-anchor="middle" fill="currentColor" font-size="10">scanning</text>
+  <text x="333" y="70" text-anchor="middle" fill="var(--fg-muted)" font-size="8">push protection</text>
+  <text x="333" y="82" text-anchor="middle" fill="var(--fg-muted)" font-size="8">blocks the commit</text>
+  <rect x="398" y="20" width="118" height="150" rx="6" fill="none" stroke="currentColor"/>
+  <text x="457" y="40" text-anchor="middle" fill="currentColor" font-size="10">Dependabot</text>
+  <text x="457" y="53" text-anchor="middle" fill="currentColor" font-size="10">+ CVE scan</text>
+  <text x="457" y="70" text-anchor="middle" fill="var(--fg-muted)" font-size="8">govulncheck</text>
+  <text x="457" y="82" text-anchor="middle" fill="var(--fg-muted)" font-size="8">fails the build</text>
+  <rect x="522" y="20" width="60" height="150" rx="6" fill="none" stroke="currentColor"/>
+  <text x="552" y="86" text-anchor="middle" fill="currentColor" font-size="10" transform="rotate(-90 552 86)">least-priv tokens</text>
+  <line x1="582" y1="95" x2="606" y2="95" stroke="currentColor"/><polygon points="606,91 616,95 606,99" fill="currentColor"/>
+  <rect x="600" y="60" width="52" height="70" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="626" y="98" text-anchor="middle" fill="var(--accent)" font-size="11" transform="rotate(-90 626 98)">main</text>
+</svg>
+<figcaption>Hardening is layered, not a single wall: a change must clear branch protection, secret scanning, dependency-CVE gates, and least-privilege token scope before it touches the protected <code>main</code>.</figcaption>
+</figure>
+
 ### Branch protection and required checks
 
 Protect `main` so nobody (including you on a bad day) can push broken code or
@@ -172,6 +202,34 @@ graph. Because `build-test` and the USB jobs are required, a failing security
 scan keeps a PR from merging. There's also a `licenses` job that regenerates the
 third-party license inventory with `go-licenses`, backstopping the hand-curated
 table.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 640 188" width="640" height="188" role="img" aria-label="A pull request fans out to four CI jobs — build-test, usb-windows, usb-macos, and vulncheck running govulncheck — that all report back to a required-checks gate; only when every required check passes does the PR merge to main, and any failure blocks the merge.">
+  <rect x="14" y="76" width="96" height="42" rx="6" fill="none" stroke="currentColor"/>
+  <text x="62" y="94" text-anchor="middle" fill="currentColor" font-size="11">pull request</text>
+  <text x="62" y="108" text-anchor="middle" fill="var(--fg-muted)" font-size="8">into main</text>
+  <line x1="110" y1="88" x2="150" y2="34" stroke="currentColor"/><polygon points="146,30 156,32 150,41" fill="currentColor"/>
+  <line x1="110" y1="94" x2="150" y2="74" stroke="currentColor"/><polygon points="146,70 156,74 146,79" fill="currentColor"/>
+  <line x1="110" y1="100" x2="150" y2="114" stroke="currentColor"/><polygon points="146,109 156,116 146,119" fill="currentColor"/>
+  <line x1="110" y1="106" x2="150" y2="160" stroke="currentColor"/><polygon points="147,153 156,162 143,162" fill="currentColor"/>
+  <rect x="156" y="18" width="150" height="28" rx="5" fill="none" stroke="currentColor"/><text x="231" y="36" text-anchor="middle" fill="currentColor" font-size="10">build-test</text>
+  <rect x="156" y="60" width="150" height="28" rx="5" fill="none" stroke="currentColor"/><text x="231" y="78" text-anchor="middle" fill="currentColor" font-size="10">usb-windows</text>
+  <rect x="156" y="102" width="150" height="28" rx="5" fill="none" stroke="currentColor"/><text x="231" y="120" text-anchor="middle" fill="currentColor" font-size="10">usb-macos</text>
+  <rect x="156" y="144" width="150" height="30" rx="5" fill="none" stroke="var(--accent)"/><text x="231" y="159" text-anchor="middle" fill="var(--accent)" font-size="10">vulncheck</text><text x="231" y="170" text-anchor="middle" fill="var(--fg-muted)" font-size="8">govulncheck ./...</text>
+  <line x1="306" y1="32" x2="410" y2="86" stroke="currentColor"/><polygon points="405,81 414,90 401,90" fill="currentColor"/>
+  <line x1="306" y1="74" x2="410" y2="90" stroke="currentColor"/><polygon points="404,85 414,92 403,95" fill="currentColor"/>
+  <line x1="306" y1="116" x2="410" y2="96" stroke="currentColor"/><polygon points="404,91 414,94 405,101" fill="currentColor"/>
+  <line x1="306" y1="158" x2="410" y2="100" stroke="currentColor"/><polygon points="401,100 414,100 405,109" fill="currentColor"/>
+  <rect x="414" y="70" width="106" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="467" y="90" text-anchor="middle" fill="currentColor" font-size="10">required-</text>
+  <text x="467" y="103" text-anchor="middle" fill="currentColor" font-size="10">checks gate</text>
+  <line x1="520" y1="80" x2="556" y2="52" stroke="var(--accent)"/><polygon points="552,48 562,50 556,59" fill="var(--accent)"/>
+  <line x1="520" y1="104" x2="556" y2="132" stroke="var(--fg-muted)"/><polygon points="556,125 562,135 549,133" fill="var(--fg-muted)"/>
+  <rect x="562" y="34" width="72" height="32" rx="6" fill="none" stroke="var(--accent)"/><text x="598" y="50" text-anchor="middle" fill="var(--accent)" font-size="10">all green</text><text x="598" y="61" text-anchor="middle" fill="var(--fg-muted)" font-size="8">→ merge</text>
+  <rect x="562" y="118" width="72" height="32" rx="6" fill="none" stroke="var(--fg-muted)"/><text x="598" y="134" text-anchor="middle" fill="var(--fg-muted)" font-size="10">any red</text><text x="598" y="145" text-anchor="middle" fill="var(--fg-muted)" font-size="8">blocked</text>
+</svg>
+<figcaption>Required checks are the gate: <code>build-test</code>, the two USB jobs, and the <code>vulncheck</code> CVE scan must all pass before a PR can merge to <code>main</code> — a failing security scan blocks the merge like any other check.</figcaption>
+</figure>
 
 **A real disclosure policy.** `SECURITY.md` is not boilerplate — it opens with a
 *threat model* (an operator running the daemon on a private network or single

--- a/docs/_posts/2026-06-29-rf-front-end-12-sdr-pool-usb-watchdog.md
+++ b/docs/_posts/2026-06-29-rf-front-end-12-sdr-pool-usb-watchdog.md
@@ -48,6 +48,28 @@ to find a `RoleVoice` device by serial when the engine binds a call. That
 indirection is what lets the same code run on a one-stick hobby setup and a
 four-stick site without a branch anywhere in the engine.
 
+<figure class="lab-figure">
+<svg viewBox="0 0 660 176" width="660" height="176" role="img" aria-label="The SDR pool owns a slice of opened PoolEntry devices, each carrying a Driver, Device, Info, and a Role. The engine never names a specific dongle; it asks the pool for a device by role — RoleControl for the control-channel decoder, RoleVoice for call audio, and RoleWideband for a whole-site Airspy.">
+  <rect x="8" y="66" width="120" height="46" rx="6" fill="none" stroke="currentColor"/>
+  <text x="68" y="86" text-anchor="middle" fill="currentColor" font-size="10">engine</text>
+  <text x="68" y="100" text-anchor="middle" fill="var(--fg-muted)" font-size="9">"give me role X"</text>
+  <line x1="128" y1="89" x2="166" y2="89" stroke="currentColor"/><polygon points="166,85 176,89 166,93" fill="currentColor"/>
+  <rect x="176" y="60" width="120" height="58" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="236" y="84" text-anchor="middle" fill="var(--accent)" font-size="11">Pool</text>
+  <text x="236" y="99" text-anchor="middle" fill="var(--fg-muted)" font-size="9">entries + mutex</text>
+  <line x1="296" y1="72" x2="330" y2="41" stroke="currentColor"/><polygon points="326,37 336,39 331,48" fill="currentColor"/>
+  <line x1="296" y1="89" x2="330" y2="89" stroke="currentColor"/><polygon points="330,85 340,89 330,93" fill="currentColor"/>
+  <line x1="296" y1="106" x2="330" y2="137" stroke="currentColor"/><polygon points="331,130 336,139 326,141" fill="currentColor"/>
+  <rect x="340" y="22" width="300" height="30" rx="5" fill="none" stroke="currentColor"/>
+  <text x="490" y="41" text-anchor="middle" fill="currentColor" font-size="10">RoleControl · decodes grants</text>
+  <rect x="340" y="74" width="300" height="30" rx="5" fill="none" stroke="currentColor"/>
+  <text x="490" y="93" text-anchor="middle" fill="currentColor" font-size="10">RoleVoice · follows to call audio</text>
+  <rect x="340" y="126" width="300" height="30" rx="5" fill="none" stroke="currentColor"/>
+  <text x="490" y="145" text-anchor="middle" fill="currentColor" font-size="10">RoleWideband · whole-site Airspy</text>
+</svg>
+<figcaption>The pool owns every opened dongle as a <code>PoolEntry</code> and answers one question — give me the device with role X — so the engine never names a specific stick.</figcaption>
+</figure>
+
 ## How GopherTrunk implements it in Go
 
 A `Pool` is a slice of opened entries behind a mutex, plus an optional event bus:
@@ -195,6 +217,29 @@ Crucially it swaps the `Device` **in place** on the existing `PoolEntry` —
 `Info.Index` updates to the new enumeration. `TestPoolReacquireSwapsDeviceHandleInPlace`
 asserts exactly that: same `PoolEntry`, new `*fakeDevice`, stale handle closed,
 bias-tee re-applied, index refreshed to 7.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 160" width="660" height="160" role="img" aria-label="The USB watchdog state machine keyed on each serial: a present device that the 30-second enumerate stops seeing flips to missing and emits KindSDRDetached; when the same serial reappears under a new bus address the watchdog calls Reacquire, which swaps the Device in place on the existing PoolEntry and returns the serial to present.">
+  <rect x="20" y="52" width="150" height="50" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="95" y="74" text-anchor="middle" fill="var(--accent)" font-size="11">present</text>
+  <text x="95" y="90" text-anchor="middle" fill="var(--fg-muted)" font-size="9">enumerate sees serial</text>
+  <line x1="170" y1="65" x2="253" y2="65" stroke="currentColor"/><polygon points="253,61 263,65 253,69" fill="currentColor"/>
+  <text x="211" y="57" text-anchor="middle" fill="var(--fg-muted)" font-size="9">stops seeing</text>
+  <rect x="263" y="52" width="150" height="50" rx="6" fill="none" stroke="currentColor"/>
+  <text x="338" y="74" text-anchor="middle" fill="currentColor" font-size="11">missing</text>
+  <text x="338" y="90" text-anchor="middle" fill="var(--fg-muted)" font-size="9">KindSDRDetached</text>
+  <line x1="413" y1="65" x2="496" y2="65" stroke="currentColor"/><polygon points="496,61 506,65 496,69" fill="currentColor"/>
+  <text x="454" y="57" text-anchor="middle" fill="var(--fg-muted)" font-size="9">serial reappears</text>
+  <rect x="506" y="52" width="140" height="50" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="576" y="74" text-anchor="middle" fill="var(--accent)" font-size="11">Reacquire</text>
+  <text x="576" y="90" text-anchor="middle" fill="var(--fg-muted)" font-size="9">swap Device in place</text>
+  <line x1="576" y1="102" x2="576" y2="130" stroke="currentColor"/>
+  <line x1="576" y1="130" x2="95" y2="130" stroke="currentColor"/>
+  <line x1="95" y1="130" x2="95" y2="104" stroke="currentColor"/><polygon points="91,112 95,102 99,112" fill="currentColor"/>
+  <text x="335" y="145" text-anchor="middle" fill="var(--fg-muted)" font-size="9">new bus address · same PoolEntry, Role and serial survive</text>
+</svg>
+<figcaption>The watchdog keys a state machine on each serial: a device the 30-second enumerate stops seeing goes <code>missing</code> (<code>KindSDRDetached</code>); when it reappears under a new bus address, <code>Reacquire</code> swaps the <code>Device</code> in place on the same <code>PoolEntry</code>.</figcaption>
+</figure>
 
 ## The problem we hit: the retune-vs-teardown re-open race (issue #686)
 

--- a/docs/_posts/2026-06-30-build-in-the-open-13-advanced-git-and-github-features.md
+++ b/docs/_posts/2026-06-30-build-in-the-open-13-advanced-git-and-github-features.md
@@ -82,6 +82,30 @@ time for you to test. You can even automate it: `git bisect run ./test.sh` lets
 the test suite find the culprit hands-free across hundreds of commits in a dozen
 steps.
 
+<figure class="lab-figure">
+<svg viewBox="0 0 660 150" width="660" height="150" role="img" aria-label="A commit graph illustrating git bisect: a linear chain of eight commits runs from a known-good commit on the left to a known-bad commit on the right; bisect checks out the midpoint, marks it good, halves the range, checks the next midpoint, marks it bad, and converges on the single first-bad commit.">
+  <line x1="30" y1="40" x2="630" y2="40" stroke="currentColor"/>
+  <circle cx="40" cy="40" r="7" fill="none" stroke="var(--accent)"/>
+  <circle cx="124" cy="40" r="7" fill="none" stroke="currentColor"/>
+  <circle cx="208" cy="40" r="7" fill="none" stroke="currentColor"/>
+  <circle cx="292" cy="40" r="7" fill="none" stroke="currentColor"/>
+  <circle cx="376" cy="40" r="7" fill="none" stroke="currentColor"/>
+  <circle cx="460" cy="40" r="7" fill="var(--accent)" stroke="var(--accent)"/>
+  <circle cx="544" cy="40" r="7" fill="none" stroke="currentColor"/>
+  <circle cx="628" cy="40" r="7" fill="none" stroke="var(--accent)"/>
+  <text x="40" y="24" text-anchor="middle" fill="var(--accent)" font-size="9">good</text>
+  <text x="628" y="24" text-anchor="middle" fill="var(--accent)" font-size="9">bad</text>
+  <text x="460" y="24" text-anchor="middle" fill="var(--accent)" font-size="9">first bad</text>
+  <line x1="292" y1="66" x2="292" y2="48" stroke="var(--fg-muted)"/><polygon points="288,50 292,42 296,50" fill="var(--fg-muted)"/>
+  <text x="292" y="80" text-anchor="middle" fill="var(--fg-muted)" font-size="9">1. midpoint → test good</text>
+  <line x1="460" y1="112" x2="460" y2="50" stroke="var(--fg-muted)"/><polygon points="456,52 460,44 464,52" fill="var(--fg-muted)"/>
+  <text x="460" y="100" text-anchor="middle" fill="var(--fg-muted)" font-size="9">2. new midpoint → test bad</text>
+  <text x="460" y="126" text-anchor="middle" fill="currentColor" font-size="9">3. range = one commit → culprit found</text>
+  <text x="330" y="146" text-anchor="middle" fill="var(--fg-muted)" font-size="8">git bisect run ./test.sh — ~10 tests over 1000 commits</text>
+</svg>
+<figcaption>Bisect binary-searches the history between a known-good and known-bad commit, halving the suspect range each test until one commit remains — the change that introduced the bug.</figcaption>
+</figure>
+
 ### Reflog: undo almost anything
 
 `git reflog` records *every* move of `HEAD` — including after a bad reset, a
@@ -128,6 +152,32 @@ The platform layered on top of Git is deep. The high-value pieces:
 
 You won't use all of these on day one, but knowing they exist means you reach for
 the right tool when the need shows up.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 200" width="660" height="200" role="img" aria-label="A two-column feature map. The left column, Git power tools operating on local history, lists interactive rebase, cherry-pick, stash, bisect, reflog, and worktrees. The right column, the GitHub platform layered on the same repo, lists Discussions, code search, Codespaces, GHCR packages, Environments, and the GraphQL API.">
+  <rect x="16" y="14" width="300" height="176" rx="6" fill="none" stroke="currentColor"/>
+  <text x="166" y="34" text-anchor="middle" fill="currentColor" font-size="11">Git power tools</text>
+  <text x="166" y="47" text-anchor="middle" fill="var(--fg-muted)" font-size="8">operate on local history</text>
+  <rect x="34" y="58" width="128" height="26" rx="5" fill="none" stroke="var(--accent)"/><text x="98" y="75" text-anchor="middle" fill="var(--accent)" font-size="10">rebase -i</text>
+  <rect x="170" y="58" width="128" height="26" rx="5" fill="none" stroke="currentColor"/><text x="234" y="75" text-anchor="middle" fill="currentColor" font-size="10">cherry-pick</text>
+  <rect x="34" y="90" width="128" height="26" rx="5" fill="none" stroke="currentColor"/><text x="98" y="107" text-anchor="middle" fill="currentColor" font-size="10">stash</text>
+  <rect x="170" y="90" width="128" height="26" rx="5" fill="none" stroke="var(--accent)"/><text x="234" y="107" text-anchor="middle" fill="var(--accent)" font-size="10">bisect</text>
+  <rect x="34" y="122" width="128" height="26" rx="5" fill="none" stroke="var(--accent)"/><text x="98" y="139" text-anchor="middle" fill="var(--accent)" font-size="10">reflog</text>
+  <rect x="170" y="122" width="128" height="26" rx="5" fill="none" stroke="currentColor"/><text x="234" y="139" text-anchor="middle" fill="currentColor" font-size="10">worktree</text>
+  <rect x="34" y="154" width="264" height="26" rx="5" fill="none" stroke="currentColor"/><text x="166" y="171" text-anchor="middle" fill="currentColor" font-size="10">resolve conflicts deliberately</text>
+  <rect x="344" y="14" width="300" height="176" rx="6" fill="none" stroke="currentColor"/>
+  <text x="494" y="34" text-anchor="middle" fill="currentColor" font-size="11">GitHub platform</text>
+  <text x="494" y="47" text-anchor="middle" fill="var(--fg-muted)" font-size="8">layered on the same repo</text>
+  <rect x="362" y="58" width="128" height="26" rx="5" fill="none" stroke="currentColor"/><text x="426" y="75" text-anchor="middle" fill="currentColor" font-size="10">Discussions</text>
+  <rect x="498" y="58" width="128" height="26" rx="5" fill="none" stroke="currentColor"/><text x="562" y="75" text-anchor="middle" fill="currentColor" font-size="10">code search</text>
+  <rect x="362" y="90" width="128" height="26" rx="5" fill="none" stroke="currentColor"/><text x="426" y="107" text-anchor="middle" fill="currentColor" font-size="10">Codespaces</text>
+  <rect x="498" y="90" width="128" height="26" rx="5" fill="none" stroke="var(--accent)"/><text x="562" y="107" text-anchor="middle" fill="var(--accent)" font-size="10">GHCR</text>
+  <rect x="362" y="122" width="128" height="26" rx="5" fill="none" stroke="currentColor"/><text x="426" y="139" text-anchor="middle" fill="currentColor" font-size="10">Environments</text>
+  <rect x="498" y="122" width="128" height="26" rx="5" fill="none" stroke="currentColor"/><text x="562" y="139" text-anchor="middle" fill="currentColor" font-size="10">GraphQL API</text>
+  <rect x="362" y="154" width="264" height="26" rx="5" fill="none" stroke="var(--fg-muted)"/><text x="494" y="171" text-anchor="middle" fill="var(--fg-muted)" font-size="9">Insights · saved replies · shortcuts</text>
+</svg>
+<figcaption>The second tier at a glance: Git power tools that reshape local history on the left, and the GitHub platform features that layer on the same repo on the right — GopherTrunk uses the highlighted ones for real.</figcaption>
+</figure>
 
 ## How GopherTrunk does it
 

--- a/docs/_posts/2026-06-30-rf-front-end-13-testing-radios-without-radios.md
+++ b/docs/_posts/2026-06-30-rf-front-end-13-testing-radios-without-radios.md
@@ -47,6 +47,27 @@ so the protocol logic is exercised, **a golden-master conversion test** so the
 DSP-facing output is byte-for-byte correct, and **an opt-in real-hardware tier**
 that smoke-tests against actual silicon when you have it plugged in.
 
+<figure class="lab-figure">
+<svg viewBox="0 0 650 170" width="650" height="170" role="img" aria-label="Every driver depends on the Transport interface, not on the OS USB stack. At that seam two peers are interchangeable: the real platform transport backed by USBDEVFS, WinUSB, or IOKit talking to silicon, and MockTransport, which replays a captured control-transfer Script with no hardware present. The driver cannot tell them apart.">
+  <rect x="8" y="66" width="130" height="46" rx="6" fill="none" stroke="currentColor"/>
+  <text x="73" y="86" text-anchor="middle" fill="currentColor" font-size="11">driver</text>
+  <text x="73" y="100" text-anchor="middle" fill="var(--fg-muted)" font-size="9">rtl2832u · tuners</text>
+  <line x1="138" y1="89" x2="184" y2="89" stroke="currentColor"/><polygon points="184,85 194,89 184,93" fill="currentColor"/>
+  <rect x="194" y="64" width="140" height="50" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="264" y="86" text-anchor="middle" fill="var(--accent)" font-size="11">Transport</text>
+  <text x="264" y="101" text-anchor="middle" fill="var(--fg-muted)" font-size="9">interface (the seam)</text>
+  <line x1="334" y1="78" x2="388" y2="46" stroke="currentColor"/><polygon points="384,42 394,44 389,53" fill="currentColor"/>
+  <line x1="334" y1="100" x2="388" y2="132" stroke="currentColor"/><polygon points="389,125 394,135 384,137" fill="currentColor"/>
+  <rect x="394" y="24" width="248" height="42" rx="6" fill="none" stroke="currentColor"/>
+  <text x="518" y="43" text-anchor="middle" fill="currentColor" font-size="10">real transport → silicon</text>
+  <text x="518" y="57" text-anchor="middle" fill="var(--fg-muted)" font-size="9">USBDEVFS · WinUSB · IOKit</text>
+  <rect x="394" y="112" width="248" height="42" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="518" y="131" text-anchor="middle" fill="var(--accent)" font-size="10">MockTransport → Script</text>
+  <text x="518" y="145" text-anchor="middle" fill="var(--fg-muted)" font-size="9">replays captured transfers · no hardware</text>
+</svg>
+<figcaption>The <code>Transport</code> interface is the seam: the real platform transport and <code>MockTransport</code> are interchangeable peers, so the driver runs its full bring-up against a replayed <code>Script</code> with no hardware present.</figcaption>
+</figure>
+
 ## How GopherTrunk implements it in Go
 
 ### The scripted mock transport
@@ -95,6 +116,32 @@ happened, in order, with the right bytes.** The mock even models the messy parts
 path ran, `ClaimErr` injects an `EBUSY` so the claim-failure branch is exercised,
 and `BulkSimulateDeath` fires `onStreamDead` after delivering its packets so the
 issue #345 reaper-death path is covered without unplugging anything.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 176" width="660" height="176" role="img" aria-label="How MockTransport verifies a bring-up: the driver issues a ControlOut, the mock pops the next CtrlExchange from its ordered Script and compares direction, bRequest, wValue, wIndex, and the exact payload bytes; a match advances the step, a mismatch records a descriptive error, and after bring-up the test asserts Remaining equals zero, proving every expected transfer happened in order.">
+  <rect x="8" y="62" width="140" height="46" rx="6" fill="none" stroke="currentColor"/>
+  <text x="78" y="82" text-anchor="middle" fill="currentColor" font-size="10">driver ControlOut</text>
+  <text x="78" y="96" text-anchor="middle" fill="var(--fg-muted)" font-size="9">req · val · idx · data</text>
+  <line x1="148" y1="85" x2="184" y2="85" stroke="currentColor"/><polygon points="184,81 194,85 184,89" fill="currentColor"/>
+  <rect x="194" y="62" width="140" height="46" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="264" y="82" text-anchor="middle" fill="var(--accent)" font-size="10">pop CtrlExchange</text>
+  <text x="264" y="96" text-anchor="middle" fill="var(--fg-muted)" font-size="9">next Script step</text>
+  <line x1="334" y1="85" x2="370" y2="85" stroke="currentColor"/><polygon points="370,81 380,85 370,89" fill="currentColor"/>
+  <rect x="380" y="62" width="140" height="46" rx="6" fill="none" stroke="currentColor"/>
+  <text x="450" y="82" text-anchor="middle" fill="currentColor" font-size="10">compare fields</text>
+  <text x="450" y="96" text-anchor="middle" fill="var(--fg-muted)" font-size="9">+ exact bytes</text>
+  <line x1="520" y1="74" x2="566" y2="42" stroke="currentColor"/><polygon points="562,38 572,40 567,49" fill="currentColor"/>
+  <text x="548" y="30" text-anchor="middle" fill="var(--fg-muted)" font-size="9">match</text>
+  <rect x="566" y="24" width="86" height="30" rx="5" fill="none" stroke="var(--accent)"/>
+  <text x="609" y="43" text-anchor="middle" fill="var(--accent)" font-size="10">advance</text>
+  <line x1="520" y1="96" x2="566" y2="128" stroke="currentColor"/><polygon points="567,121 572,131 562,133" fill="currentColor"/>
+  <text x="546" y="150" text-anchor="middle" fill="var(--fg-muted)" font-size="9">mismatch</text>
+  <rect x="566" y="116" width="86" height="30" rx="5" fill="none" stroke="var(--fg-muted)"/>
+  <text x="609" y="135" text-anchor="middle" fill="var(--fg-muted)" font-size="10">recordErr</text>
+  <text x="264" y="130" text-anchor="middle" fill="var(--fg-muted)" font-size="9">after bring-up: assert Remaining() == 0</text>
+</svg>
+<figcaption><code>MockTransport</code> replays a captured <code>Script</code>: each driver transfer is matched against the next <code>CtrlExchange</code> — direction, request, value, index, and exact bytes — and <code>Remaining() == 0</code> proves every expected transfer happened in order.</figcaption>
+</figure>
 
 The same file ships a `MockEnumerator` so even discovery is fakeable — it returns
 a fixed set of descriptors and opens each as a `MockTransport`, which is how the

--- a/docs/_posts/2026-07-01-build-in-the-open-14-cli-workflow-claude-code-daily-driver.md
+++ b/docs/_posts/2026-07-01-build-in-the-open-14-cli-workflow-claude-code-daily-driver.md
@@ -81,6 +81,25 @@ intent ("add a `/api/v1/sites` endpoint and a regression test"), and the agent
 does the multi-step work: explore the code, make the change, run the tests, and
 prepare a commit.
 
+<figure class="lab-figure">
+<svg viewBox="0 0 660 156" width="660" height="156" role="img" aria-label="The Claude Code daily-driver loop as a cycle: a plain-English prompt leads the agent to explore the code, edit it, run the tests, commit, and open a PR; from the PR the loop returns to the next prompt, with review feeding back in.">
+  <rect x="14" y="52" width="92" height="40" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="60" y="70" text-anchor="middle" fill="var(--accent)" font-size="10">prompt</text>
+  <text x="60" y="83" text-anchor="middle" fill="var(--fg-muted)" font-size="8">plain intent</text>
+  <line x1="106" y1="72" x2="132" y2="72" stroke="currentColor"/><polygon points="132,68 142,72 132,76" fill="currentColor"/>
+  <rect x="142" y="52" width="92" height="40" rx="6" fill="none" stroke="currentColor"/><text x="188" y="70" text-anchor="middle" fill="currentColor" font-size="10">explore</text><text x="188" y="83" text-anchor="middle" fill="var(--fg-muted)" font-size="8">read files</text>
+  <line x1="234" y1="72" x2="260" y2="72" stroke="currentColor"/><polygon points="260,68 270,72 260,76" fill="currentColor"/>
+  <rect x="270" y="52" width="92" height="40" rx="6" fill="none" stroke="currentColor"/><text x="316" y="70" text-anchor="middle" fill="currentColor" font-size="10">edit</text><text x="316" y="83" text-anchor="middle" fill="var(--fg-muted)" font-size="8">make change</text>
+  <line x1="362" y1="72" x2="388" y2="72" stroke="currentColor"/><polygon points="388,68 398,72 388,76" fill="currentColor"/>
+  <rect x="398" y="52" width="92" height="40" rx="6" fill="none" stroke="currentColor"/><text x="444" y="70" text-anchor="middle" fill="currentColor" font-size="10">test</text><text x="444" y="83" text-anchor="middle" fill="var(--fg-muted)" font-size="8">run suite</text>
+  <line x1="490" y1="72" x2="516" y2="72" stroke="currentColor"/><polygon points="516,68 526,72 516,76" fill="currentColor"/>
+  <rect x="526" y="52" width="118" height="40" rx="6" fill="none" stroke="var(--accent)"/><text x="585" y="70" text-anchor="middle" fill="var(--accent)" font-size="10">commit → PR</text><text x="585" y="83" text-anchor="middle" fill="var(--fg-muted)" font-size="8">gh pr create</text>
+  <line x1="585" y1="92" x2="585" y2="122" stroke="currentColor"/><line x1="585" y1="122" x2="60" y2="122" stroke="currentColor"/><line x1="60" y1="122" x2="60" y2="92" stroke="currentColor"/><polygon points="56,100 60,90 64,100" fill="currentColor"/>
+  <text x="322" y="138" text-anchor="middle" fill="var(--fg-muted)" font-size="9">review the result → next prompt</text>
+</svg>
+<figcaption>Delegate, don't copy-paste: one prompt drives the agent through explore, edit, test, and commit to an opened PR — then you review and start the loop again.</figcaption>
+</figure>
+
 It comes in two forms that share the same setup:
 
 - **The CLI** — `claude` in your terminal, right next to `gh` and `git`.
@@ -131,6 +150,27 @@ any project, in any language:
 
 Then back to step 2. That loop, run consistently, is how a blank idea becomes a
 released, maintained project.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 176" width="660" height="176" role="img" aria-label="The full daily loop as a cycle of seven stages: capture an idea as an issue, branch off main, build with Claude Code, open a PR, let CI run required checks, merge to main, and release when there is something worth shipping — then the arrow returns from release to the next issue.">
+  <rect x="16" y="20" width="118" height="38" rx="6" fill="none" stroke="var(--accent)"/><text x="75" y="38" text-anchor="middle" fill="var(--accent)" font-size="10">idea → issue</text><text x="75" y="51" text-anchor="middle" fill="var(--fg-muted)" font-size="8">scoped w/ Claude</text>
+  <line x1="134" y1="39" x2="176" y2="39" stroke="currentColor"/><polygon points="176,35 186,39 176,43" fill="currentColor"/>
+  <rect x="186" y="20" width="118" height="38" rx="6" fill="none" stroke="currentColor"/><text x="245" y="38" text-anchor="middle" fill="currentColor" font-size="10">branch</text><text x="245" y="51" text-anchor="middle" fill="var(--fg-muted)" font-size="8">claude/issue-NNN</text>
+  <line x1="304" y1="39" x2="346" y2="39" stroke="currentColor"/><polygon points="346,35 356,39 346,43" fill="currentColor"/>
+  <rect x="356" y="20" width="118" height="38" rx="6" fill="none" stroke="var(--accent)"/><text x="415" y="38" text-anchor="middle" fill="var(--accent)" font-size="10">build w/ Claude</text><text x="415" y="51" text-anchor="middle" fill="var(--fg-muted)" font-size="8">CLAUDE.md · tests</text>
+  <line x1="474" y1="39" x2="516" y2="39" stroke="currentColor"/><polygon points="516,35 526,39 516,43" fill="currentColor"/>
+  <rect x="526" y="20" width="118" height="38" rx="6" fill="none" stroke="currentColor"/><text x="585" y="38" text-anchor="middle" fill="currentColor" font-size="10">open PR</text><text x="585" y="51" text-anchor="middle" fill="var(--fg-muted)" font-size="8">gh pr create</text>
+  <line x1="585" y1="58" x2="585" y2="88" stroke="currentColor"/><polygon points="581,88 585,98 589,88" fill="currentColor"/>
+  <rect x="526" y="98" width="118" height="38" rx="6" fill="none" stroke="currentColor"/><text x="585" y="116" text-anchor="middle" fill="currentColor" font-size="10">CI checks</text><text x="585" y="129" text-anchor="middle" fill="var(--fg-muted)" font-size="8">required gates</text>
+  <line x1="526" y1="117" x2="484" y2="117" stroke="currentColor"/><polygon points="484,113 474,117 484,121" fill="currentColor"/>
+  <rect x="356" y="98" width="118" height="38" rx="6" fill="none" stroke="currentColor"/><text x="415" y="116" text-anchor="middle" fill="currentColor" font-size="10">merge</text><text x="415" y="129" text-anchor="middle" fill="var(--fg-muted)" font-size="8">squash to main</text>
+  <line x1="356" y1="117" x2="314" y2="117" stroke="currentColor"/><polygon points="314,113 304,117 314,121" fill="currentColor"/>
+  <rect x="186" y="98" width="118" height="38" rx="6" fill="none" stroke="var(--accent)"/><text x="245" y="116" text-anchor="middle" fill="var(--accent)" font-size="10">release</text><text x="245" y="129" text-anchor="middle" fill="var(--fg-muted)" font-size="8">push vX.Y.Z</text>
+  <line x1="186" y1="117" x2="75" y2="117" stroke="currentColor"/><line x1="75" y1="117" x2="75" y2="58" stroke="currentColor"/><polygon points="71,68 75,58 79,68" fill="currentColor"/>
+  <text x="130" y="90" text-anchor="middle" fill="var(--fg-muted)" font-size="9">back to the next issue</text>
+</svg>
+<figcaption>Parts 1–13 collapse into one repeatable cycle: issue → branch → build with Claude → PR → CI → merge → release, then round again — the loop GopherTrunk's own history runs on.</figcaption>
+</figure>
 
 ## How GopherTrunk does it
 

--- a/docs/_posts/2026-07-01-rf-front-end-14-diagnostics-metrics-payoff.md
+++ b/docs/_posts/2026-07-01-rf-front-end-14-diagnostics-metrics-payoff.md
@@ -144,6 +144,30 @@ There's a sibling counter, `ccdecoder_decode_overruns_total`, that distinguishes
 says "the machine can't sustain this decode," while a climbing `iq_underruns`
 says "the USB transport hiccuped." Two counters, one diagnosis.
 
+<figure class="lab-figure">
+<svg viewBox="0 0 664 132" width="664" height="132" role="img" aria-label="The IQ-drop metric flow: a driver's reaper goroutine hits an overrun and calls NotifyIQDrop with its Info; the daemon's installed atomic-pointer observer increments the iq_underruns_total counter labelled by driver and serial; Prometheus scrapes the slash-metrics endpoint, which an operator dashboard or alert watches.">
+  <rect x="6" y="44" width="116" height="48" rx="6" fill="none" stroke="currentColor"/>
+  <text x="64" y="65" text-anchor="middle" fill="currentColor" font-size="10">reaper overrun</text>
+  <text x="64" y="79" text-anchor="middle" fill="var(--fg-muted)" font-size="9">driver goroutine</text>
+  <line x1="122" y1="68" x2="150" y2="68" stroke="currentColor"/><polygon points="150,64 160,68 150,72" fill="currentColor"/>
+  <rect x="160" y="44" width="120" height="48" rx="6" fill="none" stroke="currentColor"/>
+  <text x="220" y="65" text-anchor="middle" fill="currentColor" font-size="10">NotifyIQDrop</text>
+  <text x="220" y="79" text-anchor="middle" fill="var(--fg-muted)" font-size="9">atomic observer</text>
+  <line x1="280" y1="68" x2="308" y2="68" stroke="currentColor"/><polygon points="308,64 318,68 308,72" fill="currentColor"/>
+  <rect x="318" y="44" width="140" height="48" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="388" y="65" text-anchor="middle" fill="var(--accent)" font-size="10">iq_underruns_total</text>
+  <text x="388" y="79" text-anchor="middle" fill="var(--fg-muted)" font-size="9">{driver, serial}</text>
+  <line x1="458" y1="68" x2="486" y2="68" stroke="currentColor"/><polygon points="486,64 496,68 486,72" fill="currentColor"/>
+  <rect x="496" y="44" width="92" height="48" rx="6" fill="none" stroke="currentColor"/>
+  <text x="542" y="65" text-anchor="middle" fill="currentColor" font-size="10">/metrics</text>
+  <text x="542" y="79" text-anchor="middle" fill="var(--fg-muted)" font-size="9">scrape</text>
+  <line x1="588" y1="68" x2="616" y2="68" stroke="currentColor"/><polygon points="616,64 626,68 616,72" fill="currentColor"/>
+  <rect x="626" y="44" width="32" height="48" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="642" y="71" text-anchor="middle" fill="var(--fg-muted)" font-size="8">dash</text>
+</svg>
+<figcaption>The IQ-drop flow: a driver's reaper calls <code>NotifyIQDrop</code>, the daemon's atomic-pointer observer increments <code>iq_underruns_total{driver,serial}</code>, and Prometheus scrapes <code>/metrics</code> for an operator dashboard.</figcaption>
+</figure>
+
 ## The problem we hit: silent IQ loss looked exactly like an RF problem
 
 This is the bug that drove the entire issue #402 investigation, and it's worth
@@ -172,6 +196,27 @@ on purpose: you can't fix what you can't see, and you certainly can't tell an
 operator "this is a CPU problem, not an antenna problem" without a number to point
 at. Once `iq_underruns_total` was climbing in front of them, the diagnosis became
 a glance instead of an afternoon.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 190" width="660" height="190" role="img" aria-label="What the counters reveal, starting from a no-decode symptom: if iq_underruns_total is climbing the USB transport hiccuped; if ccdecoder_decode_overruns_total climbs while iq_underruns stays flat the host cannot sustain the decode; if both drop counters are flat but iq_power_dbfs is weak the problem is RF — a bad antenna or gain.">
+  <rect x="8" y="72" width="130" height="46" rx="6" fill="none" stroke="currentColor"/>
+  <text x="73" y="92" text-anchor="middle" fill="currentColor" font-size="11">no decode</text>
+  <text x="73" y="106" text-anchor="middle" fill="var(--fg-muted)" font-size="9">which layer?</text>
+  <line x1="138" y1="88" x2="356" y2="37" stroke="currentColor"/><polygon points="352,33 362,35 357,44" fill="currentColor"/>
+  <text x="248" y="44" text-anchor="middle" fill="var(--fg-muted)" font-size="9">iq_underruns_total climbing</text>
+  <rect x="362" y="18" width="290" height="34" rx="5" fill="none" stroke="var(--accent)"/>
+  <text x="507" y="39" text-anchor="middle" fill="var(--accent)" font-size="10">USB transport hiccup</text>
+  <line x1="138" y1="95" x2="356" y2="95" stroke="currentColor"/><polygon points="356,91 366,95 356,99" fill="currentColor"/>
+  <text x="248" y="88" text-anchor="middle" fill="var(--fg-muted)" font-size="9">decode_overruns up · underruns flat</text>
+  <rect x="362" y="78" width="290" height="34" rx="5" fill="none" stroke="currentColor"/>
+  <text x="507" y="99" text-anchor="middle" fill="currentColor" font-size="10">host can't sustain decode</text>
+  <line x1="138" y1="102" x2="356" y2="153" stroke="currentColor"/><polygon points="352,146 362,149 356,158" fill="currentColor"/>
+  <text x="248" y="150" text-anchor="middle" fill="var(--fg-muted)" font-size="9">drops flat · iq_power_dbfs weak</text>
+  <rect x="362" y="138" width="290" height="34" rx="5" fill="none" stroke="currentColor"/>
+  <text x="507" y="159" text-anchor="middle" fill="currentColor" font-size="10">RF: antenna / gain</text>
+</svg>
+<figcaption>What the counters reveal: a climbing <code>iq_underruns_total</code> means the USB transport hiccuped, a climbing decode-overruns with flat underruns means the host can't keep up, and flat drops with weak <code>iq_power_dbfs</code> means the problem is RF.</figcaption>
+</figure>
 
 ## The design principle: observability is a feature — and the pure-Go thesis, vindicated
 

--- a/docs/_posts/2026-07-15-rf-scope-10-advanced-tuning-pipelines.md
+++ b/docs/_posts/2026-07-15-rf-scope-10-advanced-tuning-pipelines.md
@@ -98,6 +98,27 @@ underneath it, in the right order. Skipping the analyzers you do not need is the
 cheapest speed-up on a big capture: `-analyzers hierarchy` alone skips all the
 per-emitter demodulation entropy and topology do.
 
+<figure class="lab-figure">
+<svg viewBox="0 0 660 190" width="660" height="190" role="img" aria-label="The rfscope analyzer dependency graph. Hierarchy stands alone. Topology feeds entropy; timeline feeds timing. Expert depends on topology, timeline, and entropy. Requesting expert transparently pulls topology, timeline, and entropy in, topologically sorted so each runs after what it depends on.">
+  <text x="90" y="18" text-anchor="middle" fill="var(--fg-muted)" font-size="9">roots</text>
+  <text x="330" y="18" text-anchor="middle" fill="var(--fg-muted)" font-size="9">dependents</text>
+  <text x="566" y="18" text-anchor="middle" fill="var(--fg-muted)" font-size="9">requested</text>
+  <rect x="24" y="30" width="132" height="28" rx="5" fill="none" stroke="currentColor"/><text x="90" y="48" text-anchor="middle" fill="currentColor" font-size="10">topology</text>
+  <rect x="24" y="70" width="132" height="28" rx="5" fill="none" stroke="currentColor"/><text x="90" y="88" text-anchor="middle" fill="currentColor" font-size="10">timeline</text>
+  <rect x="24" y="130" width="132" height="28" rx="5" fill="none" stroke="var(--fg-muted)" stroke-dasharray="4 3"/><text x="90" y="148" text-anchor="middle" fill="var(--fg-muted)" font-size="10">hierarchy (standalone)</text>
+  <rect x="266" y="30" width="132" height="28" rx="5" fill="none" stroke="currentColor"/><text x="332" y="48" text-anchor="middle" fill="currentColor" font-size="10">entropy</text>
+  <rect x="266" y="70" width="132" height="28" rx="5" fill="none" stroke="currentColor"/><text x="332" y="88" text-anchor="middle" fill="currentColor" font-size="10">timing</text>
+  <rect x="500" y="50" width="132" height="30" rx="5" fill="none" stroke="var(--accent)"/><text x="566" y="69" text-anchor="middle" fill="var(--accent)" font-size="11">expert</text>
+  <line x1="156" y1="44" x2="262" y2="44" stroke="currentColor"/><polygon points="262,40 272,44 262,48" fill="currentColor"/>
+  <line x1="156" y1="84" x2="262" y2="84" stroke="currentColor"/><polygon points="262,80 272,84 262,88" fill="currentColor"/>
+  <line x1="398" y1="46" x2="496" y2="60" stroke="currentColor"/><polygon points="490,55 500,62 487,63" fill="currentColor"/>
+  <line x1="156" y1="40" x2="496" y2="58" stroke="var(--fg-muted)"/><polygon points="490,52 500,59 487,61" fill="var(--fg-muted)"/>
+  <line x1="156" y1="78" x2="496" y2="66" stroke="var(--fg-muted)"/><polygon points="488,62 500,66 489,71" fill="var(--fg-muted)"/>
+  <text x="330" y="182" text-anchor="middle" fill="var(--fg-muted)" font-size="9">-analyzers expert → topology · timeline · entropy pulled in, topologically sorted</text>
+</svg>
+<figcaption>The registry resolves <code>DependsOn</code> into a topological order: asking for <code>expert</code> transparently runs topology, timeline, and entropy first, each after the analyzers it depends on — no central list to edit.</figcaption>
+</figure>
+
 ## Tuning segmentation for weird bands
 
 When the defaults miss something, the fix is almost always in segmentation (Part 2),
@@ -198,6 +219,34 @@ gophertrunk cryptolab ks reuse -in frames.jsonl             # if IVs/MIs repeat
 7), and RF Scope even prints a `cryptolab ks reuse` suggestion when it detects frames
 sharing an IV. Detection lives in RF Scope; the byte-level attack lives in Crypto Lab;
 the frames file is the seam between them.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 176" width="660" height="176" role="img" aria-label="The RF Scope tuning and reverse-engineering pipeline: a wideband capture file is segmented into carriers, each carrier is retuned to baseband one at a time by the single-tap ccdecoder downconverter, the analyzer chain runs, and unknown payloads are emitted to a frames JSONL file that hands off to the separate cryptolab toolkit.">
+  <rect x="14" y="60" width="104" height="46" rx="6" fill="none" stroke="currentColor"/>
+  <text x="66" y="80" text-anchor="middle" fill="currentColor" font-size="10">wide.cfile</text>
+  <text x="66" y="94" text-anchor="middle" fill="var(--fg-muted)" font-size="8">wideband capture</text>
+  <line x1="118" y1="83" x2="146" y2="83" stroke="currentColor"/><polygon points="146,79 156,83 146,87" fill="currentColor"/>
+  <rect x="156" y="52" width="120" height="62" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="216" y="72" text-anchor="middle" fill="var(--accent)" font-size="10">segmentation</text>
+  <text x="216" y="86" text-anchor="middle" fill="var(--fg-muted)" font-size="8">single-tap ccdecoder</text>
+  <text x="216" y="97" text-anchor="middle" fill="var(--fg-muted)" font-size="8">retune each carrier</text>
+  <text x="216" y="108" text-anchor="middle" fill="var(--fg-muted)" font-size="8">to baseband, one at a time</text>
+  <line x1="276" y1="83" x2="304" y2="83" stroke="currentColor"/><polygon points="304,79 314,83 304,87" fill="currentColor"/>
+  <rect x="314" y="60" width="104" height="46" rx="6" fill="none" stroke="currentColor"/>
+  <text x="366" y="80" text-anchor="middle" fill="currentColor" font-size="10">analyzers</text>
+  <text x="366" y="94" text-anchor="middle" fill="var(--fg-muted)" font-size="8">registry chain</text>
+  <line x1="418" y1="83" x2="446" y2="83" stroke="currentColor"/><polygon points="446,79 456,83 446,87" fill="currentColor"/>
+  <rect x="456" y="60" width="104" height="46" rx="6" fill="none" stroke="currentColor"/>
+  <text x="508" y="80" text-anchor="middle" fill="currentColor" font-size="10">-frames-out</text>
+  <text x="508" y="94" text-anchor="middle" fill="var(--fg-muted)" font-size="8">frames.jsonl</text>
+  <line x1="560" y1="83" x2="588" y2="83" stroke="var(--accent)"/><polygon points="588,79 598,83 588,87" fill="var(--accent)"/>
+  <rect x="588" y="52" width="60" height="62" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="618" y="86" text-anchor="middle" fill="var(--accent)" font-size="10" transform="rotate(-90 618 86)">cryptolab</text>
+  <text x="216" y="140" text-anchor="middle" fill="var(--fg-muted)" font-size="8">not the wideband DDCBank / channelizer</text>
+  <text x="508" y="140" text-anchor="middle" fill="var(--fg-muted)" font-size="8">the seam: detection hands off bytes</text>
+</svg>
+<figcaption>One carrier at a time: segmentation retunes each discovered carrier to baseband with the single-tap <code>ccdecoder</code> downconverter, runs the analyzer chain, and emits unknown payloads to <code>frames.jsonl</code> — the seam Crypto Lab picks up.</figcaption>
+</figure>
 
 <aside class="lab-note">
 <p><strong>Sidebar — which downconverter?</strong> RF Scope's segmentation shifts each

--- a/docs/_posts/2026-07-31-voice-coding-12-calibration-testing.md
+++ b/docs/_posts/2026-07-31-voice-coding-12-calibration-testing.md
@@ -256,8 +256,11 @@ is a vocoder you can't trust, so the last thing the series built was the ruler.
 Voice frames arrive from the
 [Protocol Decoders]({{ '/blog/series/protocol-decoders/' | relative_url }}) series;
 calls come from the
-[Trunking Engine]({{ '/blog/series/trunking-engine/' | relative_url }}) series. If
-you want the rest of the pipeline, those are where to go next.
+[Trunking Engine]({{ '/blog/series/trunking-engine/' | relative_url }}) series. And
+once the vocoder has produced PCM, the
+[Recording, Composition & Streaming]({{ '/blog/series/recording-streaming/' | relative_url }})
+series picks up the *output* half — turning that audio into crash-safe files, a
+searchable call log, live streams, and uploads to the public call aggregators.
 
 ## FAQ
 

--- a/docs/_posts/2026-08-01-recording-streaming-01-the-output-half.md
+++ b/docs/_posts/2026-08-01-recording-streaming-01-the-output-half.md
@@ -1,0 +1,329 @@
+---
+title: "Recording, Composition & Streaming, Part 1: The Output Half"
+description: How GopherTrunk turns a decoded call into files, feeds, and uploads — four independent, config-gated subsystems that subscribe to a handful of bus events instead of calling each other, so recording, persistence, live audio, and streaming never block one another.
+category: deep-dives
+keywords: sdr call recording architecture, event bus subscriber, call start end complete events, config driven lazy init, recorder call log broadcast, audio publisher, gophertrunk recording composition streaming, pure go scanner output
+tags: [recording, streaming, architecture, events, go, software-design]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Recording, Composition & Streaming"
+series_part: 1
+---
+
+*Part 1 of **Recording, Composition & Streaming**, a 14-part deep dive into
+GopherTrunk's output half — everything that happens after the vocoders in the
+[Voice Coding]({{ '/blog/series/voice-coding/' | relative_url }}) series produce
+PCM. This opener is the map: the four subsystems that turn a decoded call into a
+file, a database row, a live feed, and an upload, and the one design rule that
+lets them coexist without ever calling each other. We'll follow a single call —
+call it the 3 p.m. dispatch on talkgroup 101 — from the moment its audio exists
+to the moment it lands in a Broadcastify feed, across the whole series.*
+
+> **TL;DR:** Once a call is decoded, four **independent, optional** subsystems
+> react to it — the **recorder** (WAV on disk), the **call log** (a SQLite row),
+> the **audio publisher** (live browser/gRPC audio), and the **broadcast
+> manager** (uploads to aggregators). None of them calls the others; they all
+> **subscribe** to the same four bus events — `KindCallStart`, `KindCallSegment`,
+> `KindCallEnd`, `KindCallComplete`. The unifying rule is **config-driven lazy
+> init**: a subsystem exists only if its YAML section is present, so a disabled
+> feature isn't flag-gated dead code — it is never constructed and costs nothing.
+
+**Key takeaways**
+
+- The output half is **four subscribers on one bus**, not a call chain. Slow
+  uploads can't back-pressure recording; a missing database can't stop live audio.
+- Four events carry a call's whole life: **start**, **segment** (a
+  transmission boundary), **end**, and **complete** (the WAV is flushed and
+  closed). Each subsystem cares about a different subset.
+- **`KindCallEnd` ≠ `KindCallComplete`.** End fires the instant the engine tears
+  the call down; complete fires later, once the recorder has a finished file to
+  hand to the uploader. That gap is the seam the whole series hangs on.
+- **Optional means absent, not idle.** No broadcast section → no manager, no MP3
+  encoder, no goroutines. The daemon builds the dependency graph from config.
+
+## Cheat sheet
+
+| Subsystem | Constructed by | Subscribes to | Produces |
+|---|---|---|---|
+| Recorder | `voice.NewRecorder` (`internal/voice/recorder.go`) | start · segment · end · encryption | `.wav` (+ `.raw`), then `KindCallComplete` |
+| Call log | `storage.NewCallLog` (`internal/storage/calllog.go`) | start · end | a `call_log` row |
+| Audio publisher | `api.NewAudioPublisher` (`internal/api/audio_publisher.go`) | decoded PCM tap | live HTTP/gRPC audio |
+| Broadcast manager | `buildBroadcastManager` (`cmd/gophertrunk/broadcast.go`) | `KindCallComplete` | uploads to aggregators |
+| Retention | `storage.NewRetention` (`internal/storage/retention.go`) | timer, not events | deletes old rows/files |
+
+## In this post
+
+- **The four events** that describe a call's life, and why there are four.
+- **The four subscribers**, and which events each one wants.
+- **Why a bus** instead of the recorder calling the uploader directly.
+- **Config-driven lazy init** — the rule that makes every subsystem optional.
+- **The thread we'll pull** — one call, PCM to Broadcastify, over 14 posts.
+
+## Where a call arrives
+
+By the time this series begins, the hard part is done. The
+[Trunking Engine]({{ '/blog/series/trunking-engine/' | relative_url }}) has
+turned a control-channel grant into a call and retuned a voice SDR to its
+frequency; the [Voice Coding]({{ '/blog/series/voice-coding/' | relative_url }})
+vocoders are turning that channel's IQ into 8 kHz PCM. What we have, in other
+words, is a stream of audio samples and some metadata about whose call it is. The
+output half's job is to do something durable and useful with them.
+
+There are four things a scanner operator might want from a call, and GopherTrunk
+treats each as a separate concern:
+
+- **Keep it** — write a playable audio file that survives a crash.
+- **Index it** — record who/what/when so the call is searchable later.
+- **Hear it now** — stream the audio live to a browser or the host speakers.
+- **Share it** — upload it to Broadcastify, RdioScanner, OpenMHz, or an Icecast feed.
+
+The tempting design is a straight line: recorder writes the file, then calls the
+indexer, then calls the uploader. GopherTrunk deliberately does not do that.
+Instead, all four hang off the event bus introduced in
+[Trunking Engine Part 2]({{ '/blog/series/trunking-engine/' | relative_url }}).
+
+## The four events of a call's life
+
+The engine and the composer publish a small, fixed vocabulary. Four kinds
+describe a call from cradle to grave:
+
+```go
+// internal/events/bus.go (shape)
+const (
+    KindCallStart    Kind = "call.start"    // voice SDR retuned; audio incoming
+    KindCallSegment  Kind = "call.segment"  // a transmission boundary mid-call
+    KindCallEnd      Kind = "call.end"      // engine tore the call down
+    KindCallComplete Kind = "call.complete" // recorder flushed & closed the WAV
+)
+```
+
+The payloads are equally small, and they live with the engine in
+`internal/trunking/grant.go`. `CallStart` says a device has been pointed at a
+call; `CallEnd` says it's over and carries the quality figures the composer
+measured; `CallComplete` adds the one thing the engine can't know — the path to
+the finished file:
+
+```go
+// internal/trunking/grant.go (shape)
+type CallComplete struct {
+    Grant        Grant
+    Talkgroup    *TalkGroup
+    DeviceSerial string
+    StartedAt    time.Time
+    EndedAt      time.Time
+    Reason       EndReason
+    AudioPath    string // the .wav the recorder wrote
+    SampleRate   uint32 // its PCM rate in Hz
+}
+```
+
+The reason there are **two** end-of-call events is the single most important
+thing in this post. `KindCallEnd` fires the instant the engine decides the call
+is over — the hangtime expired, or a higher-priority grant preempted the voice
+SDR. At that moment there is no finished file yet: the recorder still has to
+flush its buffer, patch the WAV header, and close the handle. Only when that's
+done does the recorder publish `KindCallComplete` with a real `AudioPath`. Any
+subsystem that needs the *file* (the uploader) waits for complete; any subsystem
+that only needs the *metadata* (the call log) can act on end. Collapsing the two
+would mean either uploading a half-written file or blocking the engine on disk
+I/O. Keeping them separate is what lets the engine move on immediately.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 190" width="660" height="190" role="img" aria-label="One decoded call publishes four events on the bus; four independent subsystems each subscribe to the subset they need: the recorder to start, segment and end; the call log to start and end; the audio publisher to the live PCM tap; and the broadcast manager to call-complete only.">
+  <rect x="8" y="80" width="120" height="46" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="68" y="100" text-anchor="middle" fill="var(--accent)" font-size="11">decoded call</text>
+  <text x="68" y="116" text-anchor="middle" fill="var(--fg-muted)" font-size="9">PCM + metadata</text>
+  <line x1="128" y1="103" x2="160" y2="103" stroke="currentColor"/><polygon points="160,99 170,103 160,107" fill="currentColor"/>
+  <rect x="170" y="72" width="90" height="62" rx="6" fill="none" stroke="currentColor"/>
+  <text x="215" y="97" text-anchor="middle" fill="currentColor" font-size="11">event bus</text>
+  <text x="215" y="112" text-anchor="middle" fill="var(--fg-muted)" font-size="9">start · segment</text>
+  <text x="215" y="124" text-anchor="middle" fill="var(--fg-muted)" font-size="9">end · complete</text>
+  <line x1="260" y1="90" x2="300" y2="34" stroke="currentColor"/><polygon points="296,30 306,32 300,41" fill="currentColor"/>
+  <line x1="260" y1="98" x2="300" y2="74" stroke="currentColor"/><polygon points="296,70 306,74 299,82" fill="currentColor"/>
+  <line x1="260" y1="110" x2="300" y2="118" stroke="currentColor"/><polygon points="299,113 306,120 296,122" fill="currentColor"/>
+  <line x1="260" y1="120" x2="300" y2="162" stroke="currentColor"/><polygon points="298,155 306,164 294,164" fill="currentColor"/>
+  <rect x="306" y="16" width="150" height="30" rx="5" fill="none" stroke="currentColor"/>
+  <text x="381" y="31" text-anchor="middle" fill="currentColor" font-size="10">recorder</text>
+  <text x="381" y="42" text-anchor="middle" fill="var(--fg-muted)" font-size="8">start·segment·end</text>
+  <rect x="306" y="60" width="150" height="28" rx="5" fill="none" stroke="currentColor"/>
+  <text x="381" y="78" text-anchor="middle" fill="currentColor" font-size="10">call log · start·end</text>
+  <rect x="306" y="104" width="150" height="28" rx="5" fill="none" stroke="currentColor"/>
+  <text x="381" y="122" text-anchor="middle" fill="currentColor" font-size="10">audio publisher · live</text>
+  <rect x="306" y="148" width="150" height="30" rx="5" fill="none" stroke="var(--accent)"/>
+  <text x="381" y="163" text-anchor="middle" fill="var(--accent)" font-size="10">broadcast manager</text>
+  <text x="381" y="174" text-anchor="middle" fill="var(--fg-muted)" font-size="8">call.complete only</text>
+  <line x1="456" y1="163" x2="500" y2="163" stroke="currentColor"/><polygon points="500,159 510,163 500,167" fill="currentColor"/>
+  <rect x="510" y="148" width="140" height="30" rx="5" fill="none" stroke="var(--fg-muted)"/>
+  <text x="580" y="167" text-anchor="middle" fill="var(--fg-muted)" font-size="9">Broadcastify · RdioScanner</text>
+  <text x="330" y="196" text-anchor="middle" fill="var(--fg-muted)" font-size="9"></text>
+</svg>
+<figcaption>Four subsystems, one bus. Each subscribes only to the events it needs; the broadcast manager waits for <code>call.complete</code> because it needs the finished file, not just the metadata.</figcaption>
+</figure>
+
+## The four subscribers
+
+Each subsystem is a long-lived object that the daemon constructs at startup and
+wires to the bus. None of them imports the others.
+
+- **The recorder** (`voice.NewRecorder`) is the busiest. It subscribes to
+  `KindCallStart` to open a session, `KindCallSegment` to roll to a new file at a
+  transmission boundary, and `KindCallEnd` to finalize. It is also the *lone
+  decoder*: the same decode that fills the WAV feeds the live tap, so audio is
+  decoded once and fanned out (Part 2). When it closes a file it publishes
+  `KindCallComplete`.
+- **The call log** (`storage.NewCallLog`) subscribes to `KindCallStart` (INSERT a
+  row with a null end time) and `KindCallEnd` (UPDATE it with duration, end
+  reason, and the quality figures). It never touches the audio (Part 10).
+- **The audio publisher** (`api.NewAudioPublisher`) isn't event-driven in the
+  same way — it receives decoded PCM through a sink the recorder feeds, and fans
+  it to any connected HTTP or gRPC listener (Part 12).
+- **The broadcast manager** (`buildBroadcastManager`) subscribes to
+  `KindCallComplete` alone, reads the finished WAV, encodes MP3 once, and pushes
+  to each configured backend with bounded retry (Parts 13–14).
+
+The daemon holds them as plain fields and builds each behind a config check:
+
+```go
+// cmd/gophertrunk/daemon.go (shape)
+type daemon struct {
+    recorder  *voice.Recorder
+    audioPub  *api.AudioPublisher
+    callLog   *storage.CallLog   // nil unless a database is configured
+    retention *storage.Retention // nil unless a retention window is set
+    // …broadcast manager built and Run() only when a feed is enabled
+}
+```
+
+## Why a bus, not a call chain
+
+Making these four subscribers rather than a pipeline buys three properties that a
+straight call chain can't.
+
+First, **isolation of failure.** A Broadcastify upload that hangs for thirty
+seconds on a bad network is a problem contained entirely inside the broadcast
+manager's worker goroutine. Because it reacts to an event rather than being
+called by the recorder, it can never back-pressure the decode or the file write.
+The recorder published `KindCallComplete` and moved on; whether the upload
+succeeds, retries, or is dropped is the manager's business.
+
+Second, **independent lifecycles.** You can run the recorder with no database,
+the database with no recordings directory (decode-only, for live audio), or the
+broadcaster with neither — each is wired only if its config asks for it. There is
+no "recording implies logging implies uploading" coupling to unpick.
+
+Third, **testability.** Each subsystem can be exercised by publishing synthetic
+events onto a bus and asserting on its output — no need to stand up the whole
+daemon. That's the same observer discipline the
+[Trunking Engine]({{ '/blog/series/trunking-engine/' | relative_url }}) series
+leans on, extended to the output side.
+
+### How that principle shaped the Go code
+
+- **The recorder never imports `internal/broadcast`.** The seam between them is a
+  `KindCallComplete` event carrying a file path — a string and some metadata, not
+  a Go call. Either side can be tested, replaced, or disabled without touching
+  the other.
+- **One decode, many sinks.** Rather than the recorder and the live-audio path
+  each decoding the channel, the recorder decodes once and writes to a
+  `fanoutSink` — a slice of PCM sinks. Recording and live listening share a
+  single vocoder pass (Part 2).
+- **Metadata and audio travel separately.** The call log acts on `KindCallEnd`
+  (metadata is ready immediately); the uploader waits for `KindCallComplete` (the
+  file isn't). Splitting the events lets each consumer act as early as it safely can.
+
+## Config-driven lazy init
+
+The rule that ties the output half together: **a subsystem exists only if its
+config section is present.** This is not a feature flag that skips a code path at
+runtime — it's the absence of an object.
+
+```go
+// cmd/gophertrunk/broadcast.go (shape)
+func buildBroadcastManager(cfg BroadcastConfig, /* … */) (*broadcast.Manager, error) {
+    if !cfg.anyBackendEnabled() {
+        return nil, nil // no feed configured → no Manager at all
+    }
+    // …build backends, construct Manager, which subscribes to the bus
+}
+```
+
+The daemon does the same for the call log (built only when a database path is
+configured) and for retention (constructed only when at least one of
+`retention.call_log_days`, `retention.log_days`, or `retention.files_days` is
+set). A GopherTrunk instance streaming live audio with no recordings, no
+database, and no uploads allocates none of the recording, persistence, or
+broadcast machinery. Disabled features aren't idle — they're not there.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 640 200" width="640" height="200" role="img" aria-label="A vertical mapping from YAML config sections to the subsystems each one instantiates: the recordings section builds the recorder, the database section builds the call log, the retention section builds the retention sweeper, the api section builds the audio publisher, and the broadcast section builds the broadcast manager. Absent sections build nothing.">
+  <text x="120" y="24" text-anchor="middle" fill="var(--fg-muted)" font-size="10">config.yaml section</text>
+  <text x="470" y="24" text-anchor="middle" fill="var(--fg-muted)" font-size="10">instantiated subsystem</text>
+  <rect x="24" y="36" width="180" height="26" rx="5" fill="none" stroke="currentColor"/><text x="114" y="53" text-anchor="middle" fill="currentColor" font-size="11">recordings:</text>
+  <line x1="204" y1="49" x2="356" y2="49" stroke="currentColor"/><polygon points="356,45 366,49 356,53" fill="currentColor"/>
+  <rect x="366" y="36" width="250" height="26" rx="5" fill="none" stroke="var(--accent)"/><text x="491" y="53" text-anchor="middle" fill="var(--accent)" font-size="11">voice.Recorder</text>
+  <rect x="24" y="70" width="180" height="26" rx="5" fill="none" stroke="currentColor"/><text x="114" y="87" text-anchor="middle" fill="currentColor" font-size="11">database:</text>
+  <line x1="204" y1="83" x2="356" y2="83" stroke="currentColor"/><polygon points="356,79 366,83 356,87" fill="currentColor"/>
+  <rect x="366" y="70" width="250" height="26" rx="5" fill="none" stroke="var(--accent)"/><text x="491" y="87" text-anchor="middle" fill="var(--accent)" font-size="11">storage.CallLog</text>
+  <rect x="24" y="104" width="180" height="26" rx="5" fill="none" stroke="currentColor"/><text x="114" y="121" text-anchor="middle" fill="currentColor" font-size="11">retention:</text>
+  <line x1="204" y1="117" x2="356" y2="117" stroke="currentColor"/><polygon points="356,113 366,117 356,121" fill="currentColor"/>
+  <rect x="366" y="104" width="250" height="26" rx="5" fill="none" stroke="var(--accent)"/><text x="491" y="121" text-anchor="middle" fill="var(--accent)" font-size="11">storage.Retention</text>
+  <rect x="24" y="138" width="180" height="26" rx="5" fill="none" stroke="currentColor"/><text x="114" y="155" text-anchor="middle" fill="currentColor" font-size="11">broadcast:</text>
+  <line x1="204" y1="151" x2="356" y2="151" stroke="currentColor"/><polygon points="356,147 366,151 356,155" fill="currentColor"/>
+  <rect x="366" y="138" width="250" height="26" rx="5" fill="none" stroke="var(--accent)"/><text x="491" y="155" text-anchor="middle" fill="var(--accent)" font-size="11">broadcast.Manager</text>
+  <rect x="24" y="172" width="180" height="22" rx="5" fill="none" stroke="var(--fg-muted)" stroke-dasharray="4 3"/><text x="114" y="187" text-anchor="middle" fill="var(--fg-muted)" font-size="10">(section absent)</text>
+  <line x1="204" y1="183" x2="356" y2="183" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <rect x="366" y="172" width="250" height="22" rx="5" fill="none" stroke="var(--fg-muted)" stroke-dasharray="4 3"/><text x="491" y="187" text-anchor="middle" fill="var(--fg-muted)" font-size="10">nothing built — zero cost</text>
+</svg>
+<figcaption>The daemon builds the output-half dependency graph from configuration. Each subsystem's presence is decided once, at startup, by whether its YAML section exists.</figcaption>
+</figure>
+
+## The thread we'll pull
+
+Over the next thirteen posts we follow one call end to end. Part 2 is the
+**contract** that carries its composed audio into the recorder without the two
+packages knowing each other's types. Part 3 is **composition** proper — how a
+burst of overs becomes one call, and how a transmission boundary becomes a
+`KindCallSegment`. Parts 4–7 are the **recorder**: session lifecycle, the
+crash-safe WAV, file naming and raw sidecars, and the subtle guards that stop one
+call's audio from bleeding into the next. Part 8 places **loudness** at the right
+seam. Part 9 is the `CallComplete` **handoff**. Parts 10–11 are **persistence and
+retention**. Part 12 is **live listening**. Parts 13–14 are the **broadcast
+manager** and the five aggregator **backends** — the last step, where our 3 p.m.
+dispatch finally becomes a row in a Broadcastify feed.
+
+## Where this goes next
+
+[Part 2]({{ '/blog/deep-dives/recording-streaming-02-composition-contract/' | relative_url }})
+opens the seam between composition and recording: the narrow, consumer-owned
+interfaces (`IQSource`, `PCMSink`, `RawFrameSink`) that let the composer hand off
+audio without importing the recorder — and why the recorder, not the composer, is
+the one place a call is decoded.
+
+## FAQ
+
+**What's the difference between `KindCallEnd` and `KindCallComplete`?**
+`KindCallEnd` fires the instant the engine tears the call down — before any file
+is finished. `KindCallComplete` fires later, once the recorder has flushed and
+closed the WAV, and it carries the on-disk `AudioPath`. Subsystems that need the
+file (the uploader) wait for complete; subsystems that need only metadata (the
+call log) act on end.
+
+**Why don't the recorder, logger, and uploader just call each other?**
+So a slow or failing step can't block the others. They're independent bus
+subscribers: the recorder publishes an event and moves on, and a thirty-second
+upload stall stays contained in the broadcast manager's own goroutine, never
+back-pressuring decode or disk writes.
+
+**Can I record without uploading, or stream live without recording?**
+Yes. Every subsystem is independent and config-gated. Omit the `broadcast:`
+section for local-only recording; run with an empty recordings directory for
+decode-only live audio with no files on disk.
+
+**Does enabling a feature I don't use cost anything?**
+No. "Optional means absent, not idle" — a subsystem with no config section is
+never constructed, so it allocates no goroutines, buffers, or encoders.
+
+## Series navigation
+
+**Part 1 of 14** · Next →
+[Part 2: The Composition Contract]({{ '/blog/deep-dives/recording-streaming-02-composition-contract/' | relative_url }})

--- a/docs/_posts/2026-08-02-recording-streaming-02-composition-contract.md
+++ b/docs/_posts/2026-08-02-recording-streaming-02-composition-contract.md
@@ -1,0 +1,403 @@
+---
+title: "Recording, Composition & Streaming, Part 2: The Composition Contract"
+description: How composed audio crosses from GopherTrunk's demod composer into its recorder through three consumer-owned interfaces, why the recorder is the one place a call is decoded, and how the PCM path and the raw-vocoder-frame path differ.
+category: deep-dives
+keywords: consumer owned interface go, dependency inversion audio pipeline, pcm sink raw frame sink, vocoder decode fanout, recorder lone decoder, iqsource pcmsink enginehooks, digital voice raw frame, gophertrunk composer recorder contract
+tags: [recording, architecture, interfaces, go, vocoder, software-design]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Recording, Composition & Streaming"
+series_part: 2
+---
+
+*Part 2 of **Recording, Composition & Streaming**, tracing the seam between the
+demod composer and the recorder. In [Part 1]({{ '/blog/deep-dives/recording-streaming-01-the-output-half/' | relative_url }})
+we followed our 3 p.m. dispatch on talkgroup 101 through four bus-subscribing
+subsystems. Now we zoom into the one hop that carries the call's actual audio:
+how the composer hands samples to the recorder without either package importing
+the other's concrete types, and why the recorder — not the composer — is the
+single place a digital call gets decoded.*
+
+> **TL;DR:** The composer knows the recorder only through three tiny,
+> **consumer-declared** interfaces — `IQSource`, `PCMSink`, `EngineHooks`. It
+> never imports `voice.Recorder`. Analog FM chains demodulate to PCM in the
+> composer and push it via `WritePCM`; **digital** chains emit undecoded vocoder
+> frames via `WriteRawFrame`, and the **recorder** decodes them. That makes the
+> recorder the *lone decoder*: one vocoder pass fills the WAV and fans the same
+> PCM to every live listener, so a call is never decoded twice.
+
+**Key takeaways**
+
+- The composer package depends on **interfaces it defines itself**
+  (`PCMSink` is `WritePCM(serial, samples)` and nothing more), not on the
+  recorder. Dependency arrows point *into* the composer, not out of it.
+- **Two paths cross the seam.** Analog FM → real PCM via `WritePCM`. Digital
+  (P25/DMR/…) → raw IMBE/AMBE frames via `WriteRawFrame`, which the recorder
+  decodes with a per-call vocoder.
+- The recorder is the **lone decoder** for digital voice. `writeRawFrame`
+  decodes once, then fans out: `.raw` sidecar, live raw tap, WAV, and the
+  decoded-PCM live tap all come from that single pass.
+- The daemon glues the two packages together with a `fanoutSink` — one object
+  that satisfies `PCMSink` for the composer while multiplexing to the recorder,
+  the host player, and the tone-out detector.
+
+## Cheat sheet
+
+| Thing | What it is | Where in code |
+|---|---|---|
+| `IQSource` | The slice of an SDR the composer needs (`StreamIQ` + `SampleRateHz`) | `internal/voice/composer/composer.go` |
+| `PCMSink` | `WritePCM(serial, []int16)` — the composer's whole view of the recorder | `internal/voice/composer/composer.go` |
+| `EngineHooks` | `Touch` / `EndCall` / `UpdateSignal` / `UpdateDemod` back to the engine | `internal/voice/composer/composer.go` |
+| `WritePCM` | Recorder entry for analog PCM; appends to the open WAV | `internal/voice/recorder.go` |
+| `WriteRawFrame` | Recorder entry for a digital vocoder frame; decode-and-fan | `internal/voice/recorder.go` |
+| `DecodedPCMSink` / `RawFrameSink` | Live taps the recorder feeds after decode | `internal/voice/recorder.go` |
+| `fanoutSink` | Daemon glue: one `PCMSink` that multiplexes to many | `cmd/gophertrunk/daemon.go` |
+
+## In this post
+
+- **Consumer-owned interfaces** — why `PCMSink` lives in the composer, not the recorder.
+- **The two crossings** — the analog PCM path versus the digital raw-frame path.
+- **The lone decoder** — how `writeRawFrame` decodes once and fans out four ways.
+- **The daemon glue** — `fanoutSink`, `playerSink`, and how the wiring is assembled.
+- Where the *shape* of a call (overs, hangtime, segments) comes from — the teaser for Part 3.
+
+## Who imports whom
+
+The interesting fact about the composer package is what it does **not** import.
+It builds per-call demod chains that end by handing audio to the recorder, yet it
+has no compile-time knowledge of `voice.Recorder` at all. Instead it declares the
+narrow slice of behaviour it needs and accepts anything that satisfies it. This
+is the classic Go move — **interfaces belong to the consumer** — and the composer
+uses it three times.
+
+```go
+// internal/voice/composer/composer.go (shape)
+
+// The subset of an SDR device the composer consumes.
+type IQSource interface {
+    StreamIQ(ctx context.Context) (<-chan []complex64, error)
+    SampleRateHz() uint32
+}
+
+// The subset of voice.Recorder we touch. WritePCM matches it exactly.
+type PCMSink interface {
+    WritePCM(deviceSerial string, samples []int16) error
+}
+
+// The engine calls the chain uses to keep the engine in sync.
+type EngineHooks interface {
+    Touch(deviceSerial string)
+    EndCall(deviceSerial string, reason trunking.EndReason) bool
+    UpdateSignal(deviceSerial string, dbfs float64)
+    UpdateDemod(deviceSerial string, evmPct, snrDB float64)
+}
+```
+
+`PCMSink` is the whole of the composer's view of the recorder: a single method
+that takes a device serial and a slice of `int16`. The doc comment is blunt about
+it — "`Recorder.WritePCM` matches this signature exactly" — but the point is that
+the composer doesn't *know* that. It knows `PCMSink`. The recorder could be
+swapped for a test double, a null sink, or a `fanoutSink` (below) and the composer
+would neither notice nor need recompiling.
+
+The `Options` struct the daemon fills in is entirely interface-typed on these
+seams:
+
+```go
+// internal/voice/composer/composer.go (shape)
+type Options struct {
+    Bus     *events.Bus
+    Devices Devices     // resolves an IQSource by serial
+    Sink    PCMSink     // typically *voice.Recorder, via a fanoutSink
+    Engine  EngineHooks // typically *trunking.Engine
+    // …IQSampleRate, PCMSampleRate, VoiceHangtime, SplitPerTransmission, DSP knobs
+}
+```
+
+`Devices` is a second consumer interface — `FindBySerial(serial) IQSource` — so
+even the SDR pool reaches the composer through an abstraction. The concrete
+`sdr.Pool`, the concrete `trunking.Engine`, and the concrete `voice.Recorder` all
+live in other packages; the composer holds only their shadows. That is why the
+whole demod pipeline can be exercised in a unit test with an in-memory IQ channel
+and a map-backed `Devices` — no SDR, no daemon.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 210" width="660" height="210" role="img" aria-label="Dependency-inversion diagram: the composer package sits in the centre and declares three interfaces it owns — IQSource, PCMSink and EngineHooks. The SDR pool, the recorder and the trunking engine live in other packages and satisfy those interfaces, so every dependency arrow points inward toward the composer rather than the composer importing any concrete type.">
+  <rect x="230" y="70" width="200" height="70" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="330" y="94" text-anchor="middle" fill="var(--accent)" font-size="11">composer package</text>
+  <text x="330" y="110" text-anchor="middle" fill="var(--fg-muted)" font-size="8">declares IQSource · PCMSink</text>
+  <text x="330" y="122" text-anchor="middle" fill="var(--fg-muted)" font-size="8">EngineHooks · Devices</text>
+  <rect x="20" y="24" width="160" height="34" rx="5" fill="none" stroke="currentColor"/>
+  <text x="100" y="44" text-anchor="middle" fill="currentColor" font-size="10">sdr.Pool</text>
+  <rect x="20" y="90" width="160" height="34" rx="5" fill="none" stroke="currentColor"/>
+  <text x="100" y="105" text-anchor="middle" fill="currentColor" font-size="10">voice.Recorder</text>
+  <text x="100" y="117" text-anchor="middle" fill="var(--fg-muted)" font-size="8">satisfies PCMSink</text>
+  <rect x="20" y="152" width="160" height="34" rx="5" fill="none" stroke="currentColor"/>
+  <text x="100" y="172" text-anchor="middle" fill="currentColor" font-size="10">trunking.Engine</text>
+  <line x1="180" y1="41" x2="228" y2="88" stroke="currentColor"/><polygon points="222,82 230,90 219,90" fill="currentColor"/>
+  <line x1="180" y1="107" x2="228" y2="105" stroke="currentColor"/><polygon points="221,101 230,105 221,109" fill="currentColor"/>
+  <line x1="180" y1="169" x2="228" y2="122" stroke="currentColor"/><polygon points="219,120 230,120 224,128" fill="currentColor"/>
+  <text x="205" y="70" text-anchor="middle" fill="var(--fg-muted)" font-size="8">implements ↗</text>
+  <rect x="470" y="86" width="170" height="38" rx="5" fill="none" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <text x="555" y="102" text-anchor="middle" fill="var(--fg-muted)" font-size="9">composer imports</text>
+  <text x="555" y="115" text-anchor="middle" fill="var(--fg-muted)" font-size="9">NO concrete type ↑</text>
+  <line x1="470" y1="105" x2="432" y2="105" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+</svg>
+<figcaption>Dependency inversion at the composition seam: concrete packages satisfy interfaces the composer owns, so every arrow points inward and the composer imports no recorder type.</figcaption>
+</figure>
+
+## Two ways audio crosses the seam
+
+Once a chain is running, how audio reaches the recorder depends on whether the
+protocol is analog or digital — and the difference is the reason there are two
+recorder entry points.
+
+**Analog FM** (Motorola Type II, EDACS clear, LTR, MPT-1327, conventional FM)
+carries voice as plain narrowband FM. The composer's `runFMChain` does the whole
+job: low-pass the IQ, decimate, quadrature-demodulate, convert to `int16`, and
+call `WritePCM`. By the time audio crosses the seam it is finished PCM — the
+recorder just appends it to the WAV. There is nothing left to decode.
+
+**Digital** protocols (P25 Phase 1/2, DMR, TETRA, …) are the opposite. Their
+chains do the DSP — carrier recovery, symbol timing, FEC — and produce not audio
+but **vocoder frames**: 88-bit IMBE codewords for P25 Phase 1, AMBE+2 for DMR and
+Phase 2, and so on. Those chains never call `WritePCM`. They call `WriteRawFrame`
+with the raw codec bytes, and the *recorder* runs the vocoder. (How each chain is
+selected and clocked — C4FM vs CQPSK, the FIR decimation, the boundary tracker —
+is the subject of [Voice Coding Part 9]({{ '/blog/deep-dives/voice-coding-09-the-composer/' | relative_url }});
+here we care only about which recorder method the chain calls and what the
+recorder does with it.)
+
+The recorder exposes a small family of raw-frame entry points, differing only in
+how much side information the chain can supply:
+
+```go
+// internal/voice/recorder.go (shape)
+func (r *Recorder) WriteRawFrame(serial string, frame []byte) error
+func (r *Recorder) WriteRawFrameWithErrors(serial string, frame []byte, correctedBits int) error
+func (r *Recorder) WriteRawFrameForCall(serial string, callID uint64, frame []byte, correctedBits int) error
+```
+
+All three funnel into one unexported `writeRawFrame`. `WriteRawFrameWithErrors`
+adds the channel-FEC corrected-bit count, which the pure-Go IMBE decoder folds
+into its adaptive smoothing. `WriteRawFrameForCall` adds the `Grant.CallID`, which
+lets the recorder **fence a stale frame** from a call that previously held a
+reused voice-tap serial — the cross-call audio-bleed guard we'll return to in
+Part 7. A P25 Phase 1 chain that knows all of this calls the richest variant; a
+simple test harness calls plain `WriteRawFrame`.
+
+## The lone decoder
+
+Here is the design decision the whole series leans on: **a digital call is decoded
+in exactly one place.** Not once for the recording and again for live audio — once,
+in the recorder, with the result fanned to every consumer. The `writeRawFrame` hot
+path is where that fan-out happens.
+
+```go
+// internal/voice/recorder.go (shape)
+func (r *Recorder) writeRawFrame(serial string, callID uint64, frame []byte,
+    correctedBits int, haveErrs bool) error {
+
+    s := r.sessionForWrite(serial, callID) // nil ⇒ no session (or CallID fenced)
+    if s == nil {
+        return nil
+    }
+    if s.raw != nil {
+        s.raw.Write(frame) // (1) verbatim to the .raw sidecar
+    }
+    if r.rawTap != nil {   // (2) verbatim to the live raw tap (gRPC include_raw)
+        // prefers RawFrameCallSink (CallID-fenced) over plain WriteRawFrame
+    }
+    if s.vocoder != nil {
+        if haveErrs { /* hand correctedBits to an ErrorAware vocoder */ }
+        samples, err := s.vocoder.Decode(frame) // the one decode
+        if err != nil { return nil }            // log + drop from PCM, keep sidecar
+        if s.wav != nil {
+            s.wav.WriteSamples(samples)          // (3) into the WAV
+        }
+        if r.decodedTap != nil {                 // (4) to the live decoded-PCM tap
+            // prefers DecodedPCMCallSink (CallID-fenced) over plain WritePCM
+        }
+    }
+    return nil
+}
+```
+
+One frame in, four things out. The raw bytes go to disk **and** to the raw live
+tap *before* any decode, because they exist even for protocols with no in-process
+vocoder (ProVoice, or an encrypted call) — the raw sidecar is often the only
+capture of such a call. Then, if a vocoder exists for the protocol, the single
+`Decode` call produces PCM that is written to the WAV *and* handed to the decoded
+live tap. Recording and live listening therefore share one vocoder pass; a
+decode error drops the frame from PCM but keeps the sidecar intact.
+
+The two live taps are themselves consumer-owned interfaces, declared in the
+recorder for the same reason the composer declares `PCMSink` — to avoid an import
+cycle back to the packages that consume the audio:
+
+```go
+// internal/voice/recorder.go (shape)
+type DecodedPCMSink interface {
+    WritePCM(deviceSerial string, samples []int16) error
+}
+type RawFrameSink interface {
+    WriteRawFrame(deviceSerial, vocoder string, frame []byte) error
+}
+
+func (r *Recorder) SetDecodedPCMSink(s DecodedPCMSink) { r.decodedTap = s }
+func (r *Recorder) SetRawFrameSink(s RawFrameSink)     { r.rawTap = s }
+```
+
+Both are wired **once**, at daemon construction, before `Run` starts — so the hot
+path reads `r.decodedTap` and `r.rawTap` without locking. Each has a call-aware
+sibling (`DecodedPCMCallSink.WritePCMForCall`, `RawFrameCallSink.WriteRawFrameForCall`)
+that carries the `CallID`; `writeRawFrame` prefers the call-aware form via a type
+assertion so the live stream is fenced by the same identity the WAV uses.
+
+Why does this matter enough to build a whole discipline around? Because the
+composer's digital chains emit **only** raw frames — they never produce PCM. If
+the recorder weren't the one to decode them, the live-audio path would be silent
+for every digital call while the recordings played back fine. That was a real
+bug (issue #598): decoded audio reached the WAV but never reached the
+`WritePCM`-only live sinks, because nothing decoded on their behalf. Making the
+recorder the lone decoder and fanning its output is what fixed it.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 220" width="660" height="220" role="img" aria-label="One raw vocoder frame enters the recorder's writeRawFrame method and fans four ways: verbatim to the dot-raw sidecar on disk, verbatim to the live raw tap, and — after a single vocoder Decode pass — as PCM into the WAV file and to the live decoded-PCM tap. The single Decode box is highlighted to show recording and live listening share one decode.">
+  <rect x="10" y="92" width="120" height="36" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="70" y="110" text-anchor="middle" fill="var(--accent)" font-size="10">raw frame</text>
+  <text x="70" y="122" text-anchor="middle" fill="var(--fg-muted)" font-size="8">IMBE / AMBE bytes</text>
+  <line x1="130" y1="110" x2="168" y2="110" stroke="currentColor"/><polygon points="168,106 178,110 168,114" fill="currentColor"/>
+  <rect x="178" y="86" width="110" height="48" rx="6" fill="none" stroke="currentColor"/>
+  <text x="233" y="106" text-anchor="middle" fill="currentColor" font-size="10">writeRawFrame</text>
+  <text x="233" y="120" text-anchor="middle" fill="var(--fg-muted)" font-size="8">fan-out</text>
+  <line x1="288" y1="98" x2="470" y2="26" stroke="currentColor"/><polygon points="464,22 474,24 468,33" fill="currentColor"/>
+  <rect x="474" y="12" width="176" height="28" rx="5" fill="none" stroke="currentColor"/>
+  <text x="562" y="30" text-anchor="middle" fill="currentColor" font-size="9">.raw sidecar (verbatim)</text>
+  <line x1="288" y1="104" x2="470" y2="70" stroke="currentColor"/><polygon points="464,66 474,68 467,77" fill="currentColor"/>
+  <rect x="474" y="54" width="176" height="28" rx="5" fill="none" stroke="currentColor"/>
+  <text x="562" y="72" text-anchor="middle" fill="currentColor" font-size="9">live raw tap (gRPC)</text>
+  <line x1="288" y1="118" x2="326" y2="130" stroke="var(--accent)"/><polygon points="320,126 330,131 319,134" fill="var(--accent)"/>
+  <rect x="330" y="112" width="120" height="40" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="390" y="130" text-anchor="middle" fill="var(--accent)" font-size="10">vocoder.Decode</text>
+  <text x="390" y="144" text-anchor="middle" fill="var(--fg-muted)" font-size="8">one pass → PCM</text>
+  <line x1="450" y1="126" x2="470" y2="112" stroke="currentColor"/><polygon points="464,108 474,110 468,118" fill="currentColor"/>
+  <rect x="474" y="96" width="176" height="28" rx="5" fill="none" stroke="var(--accent)"/>
+  <text x="562" y="114" text-anchor="middle" fill="var(--accent)" font-size="9">WAV (WriteSamples)</text>
+  <line x1="450" y1="140" x2="470" y2="150" stroke="currentColor"/><polygon points="464,146 474,151 463,154" fill="currentColor"/>
+  <rect x="474" y="138" width="176" height="28" rx="5" fill="none" stroke="currentColor"/>
+  <text x="562" y="156" text-anchor="middle" fill="currentColor" font-size="9">decoded-PCM live tap</text>
+  <text x="330" y="196" fill="var(--fg-muted)" font-size="9">Analog FM skips all this: runFMChain calls WritePCM with finished PCM directly.</text>
+</svg>
+<figcaption>The decode-and-fan hot path: one digital frame becomes the sidecar, the raw tap, the WAV, and the decoded live tap — with a single vocoder pass shared by the recording and the live listeners.</figcaption>
+</figure>
+
+## The daemon glue
+
+The composer wants one `PCMSink`. The daemon has several things that want the
+audio — the recorder, the host speaker player, the tone-out detector. It reconciles
+the two with a tiny adapter, `fanoutSink`, which *is* a slice of `PCMSink` and
+satisfies `PCMSink` itself:
+
+```go
+// cmd/gophertrunk/daemon.go (shape)
+type fanoutSink []composer.PCMSink
+
+func (f fanoutSink) WritePCM(serial string, samples []int16) error {
+    for _, s := range f {
+        _ = s.WritePCM(serial, samples)
+    }
+    return nil
+}
+```
+
+That is the whole trick behind "one composer, many consumers." The composer holds
+a `fanoutSink` as its `Sink` and calls `WritePCM` once; the fan-out loops. But
+`fanoutSink` also implements the richer shapes — `WritePCMForCall` (CallID-fenced
+for the reused voice taps), and crucially the raw-frame methods `WriteRawFrame`,
+`WriteRawFrameWithErrors`, and `WriteRawFrameForCall`. Each uses a type assertion
+to forward only to the contained sinks that understand that shape: raw frames
+reach the recorder (which understands them) and are silently skipped for the
+player and tone-out (which don't).
+
+> ⚠ That raw-frame forwarding is not optional politeness. Before it existed
+> (issue #356), the digital chains' `c.sink.(rawFrameSink)` assertion failed
+> against a `fanoutSink`, so every IMBE/AMBE frame was dropped before reaching
+> disk — while the activity counter still ticked, producing healthy-looking call
+> logs next to 0-byte `.raw` files and 44-byte header-only WAVs. The daemon glue
+> must implement every shape the chains might assert, or the fence and the frames
+> both go silently inert.
+
+The other adapter, `playerSink`, wraps the host audio player and adds a
+per-talkgroup mute check before writing to the speakers — a call for a muted
+talkgroup is still recorded and streamed, just not played aloud:
+
+```go
+// cmd/gophertrunk/daemon.go (shape)
+type playerSink struct {
+    p      *player.Player
+    engine *trunking.Engine
+}
+func (s playerSink) WritePCM(serial string, samples []int16) error {
+    if s.engine != nil {
+        if tg := s.engine.TalkgroupForDevice(serial); tg != nil && tg.Mute {
+            return nil // muted for the speakers only
+        }
+    }
+    return s.p.WritePCM(serial, samples)
+}
+```
+
+So for our 3 p.m. dispatch: if it's a P25 call, the composer's Phase 1 chain
+demodulates the IQ into IMBE frames and calls `WriteRawFrameForCall`. The daemon's
+`fanoutSink` forwards each frame to the recorder, which decodes it once, writes
+PCM to talkgroup 101's WAV, and simultaneously feeds the browser stream and the
+host player. If it were an analog Motorola call instead, the composer would have
+FM-demodulated to PCM itself and called `WritePCM` — same fan-out, no vocoder.
+
+## Where this goes next
+
+[Part 3]({{ '/blog/deep-dives/recording-streaming-03-assembling-a-call/' | relative_url }})
+answers a question this post skipped: audio crosses the seam frame by frame, but
+what decides where one *call* — one continuous recording — begins and ends? That's
+the "composition" in the series title: how a burst of overs separated by silence
+becomes one file (or many), how hangtime and talkgroup gating draw the
+boundaries, and how a transmission boundary becomes the `KindCallSegment` event
+that rolls the recorder to a new file.
+
+## FAQ
+
+**Why does the composer define `PCMSink` instead of importing `voice.Recorder`?**
+Because the interface belongs to the consumer. The composer needs exactly one
+method — `WritePCM(serial, samples)` — so it declares that and accepts anything
+satisfying it. This keeps the composer free of a hard dependency on the recorder,
+avoids an import cycle, and lets tests drive the demod pipeline with an in-memory
+sink instead of a real recorder.
+
+**What's the difference between `WritePCM` and `WriteRawFrame`?**
+`WritePCM` takes finished PCM and appends it to the WAV — analog FM chains produce
+audio directly and use it. `WriteRawFrame` takes an undecoded vocoder frame
+(IMBE/AMBE) from a digital chain; the recorder runs the vocoder to turn it into
+PCM. Analog calls never touch `WriteRawFrame`; digital calls never call `WritePCM`
+from the composer.
+
+**Why is the recorder the "lone decoder" rather than decoding in the composer?**
+So a digital call is decoded exactly once. `writeRawFrame` runs the vocoder a
+single time and fans the resulting PCM to both the WAV and every live listener. If
+the composer decoded instead, the live `WritePCM`-only sinks would never see
+digital audio (they don't handle raw frames) — the exact silence bug #598 fixed by
+centralising decode in the recorder.
+
+**What does `fanoutSink` do that a plain slice couldn't?**
+It implements every sink shape the composer's chains might assert for —
+`WritePCM`, `WritePCMForCall`, and the three raw-frame methods — and forwards each
+call only to the contained sinks that understand it. A missing method there
+doesn't fail loudly; the chain's type assertion just falls back and silently drops
+frames, which is how issue #356 produced empty recordings.
+
+## Series navigation
+
+**Part 2 of 14** · ←
+[Part 1: The Output Half]({{ '/blog/deep-dives/recording-streaming-01-the-output-half/' | relative_url }})
+· Next →
+[Part 3: Assembling a Call]({{ '/blog/deep-dives/recording-streaming-03-assembling-a-call/' | relative_url }})

--- a/docs/_posts/2026-08-03-recording-streaming-03-assembling-a-call.md
+++ b/docs/_posts/2026-08-03-recording-streaming-03-assembling-a-call.md
@@ -1,0 +1,373 @@
+---
+title: "Recording, Composition & Streaming, Part 3: Assembling a Call"
+description: How GopherTrunk turns a burst of separate overs into one continuous call — hangtime, talkgroup gating and per-transmission splitting surfacing as segment events that roll the recorder's files, from the output side rather than the DSP.
+category: deep-dives
+keywords: call boundary hangtime, per transmission recording, callsegment event, voice call grouping conversation, transmission splitting scanner, file roll recorder, gophertrunk composition, talkgroup gating boundary
+tags: [recording, composition, events, hangtime, go, software-design]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Recording, Composition & Streaming"
+series_part: 3
+---
+
+*Part 3 of **Recording, Composition & Streaming** — the "composition" the series
+is named for. [Part 2]({{ '/blog/deep-dives/recording-streaming-02-composition-contract/' | relative_url }})
+carried audio across the seam one frame at a time. Now we ask what decides where a
+call begins and ends. Our 3 p.m. dispatch on talkgroup 101 isn't one continuous
+transmission — it's a dispatcher's over, a two-second gap, a unit's reply, another
+gap. This post is about how those separate overs become one call (or a tidy run of
+per-over files), and how a transmission boundary turns into a file roll on disk.*
+
+> **TL;DR:** A voice chain feeds a shared **boundary tracker** two facts —
+> "a voice frame decoded" and "a transmission ended." The tracker applies
+> **hangtime** (end the call `VoiceHangtime` after the last frame) and
+> **talkgroup gating** (drop, and eventually end on, a foreign talkgroup on a
+> shared frequency). In per-transmission mode it publishes a **`KindCallSegment`**
+> at each over boundary; the recorder finalizes the current file, emits its
+> `CallComplete`, and parks a dormant session so the next over opens a fresh file.
+> The `voice_call_grouping` config picks per-over or per-conversation files.
+
+**Key takeaways**
+
+- The unit of *composition* is the call; the unit of *transmission* is the over.
+  `VoiceCallGrouping` decides whether one call is one file or one file per over.
+- **Hangtime**, not a channel-release message, ends most calls. The tracker ends
+  the call `VoiceHangtime` after the last matching voice frame.
+- A **`CallSegment`** event is the composer telling the recorder to *roll the
+  file* without ending the engine's call — a same-talkgroup re-key stays captured.
+- On a segment the recorder **finalizes and parks a dormant session**: identity is
+  carried forward, but no empty trailing file is created until real audio arrives.
+
+## Cheat sheet
+
+| Concept | What it does | Where in code |
+|---|---|---|
+| `boundaryTracker` | Per-call controller: hangtime, TG gating, split | `internal/voice/composer/boundary.go` |
+| `onVoice(tg)` | Records a decoded frame; returns whether to write it | `internal/voice/composer/boundary.go` |
+| `onTransmissionEnd()` | Emits a `KindCallSegment` in split mode | `internal/voice/composer/boundary.go` |
+| `CallSegment` | Payload telling the recorder to roll the file | `internal/trunking/grant.go` |
+| `handleSegment` | Recorder: finalize current file, park dormant session | `internal/voice/recorder.go` |
+| `voice_call_grouping` | `"transmission"` (per over) vs `"conversation"` | `internal/config/config.go` |
+
+## In this post
+
+- **Overs vs calls** — the two units, and the config knob that maps between them.
+- **The boundary tracker** — the three facts it turns into decisions (at the event level).
+- **Hangtime** — why silence, not a message, ends most calls.
+- **The segment roll** — how `CallSegment` becomes a new file without ending the call.
+- **The dormant park** — how the recorder carries identity forward across a roll.
+
+## Two clocks: the over and the call
+
+A trunked conversation is a sequence of **overs** — each keying of a radio's PTT,
+separated by short silences while people take turns. GopherTrunk has to decide how
+those map onto files. There are two sensible answers and it supports both, via one
+config field:
+
+```go
+// internal/config/config.go (shape)
+// VoiceCallGrouping controls how voice recordings are split, for EVERY
+// voice protocol. "transmission" (default) writes one file per over —
+// the recording rolls at each end-of-transmission boundary.
+// "conversation" keeps consecutive overs of the same talkgroup in one
+// file, splitting only when a different talkgroup takes the (shared)
+// frequency or the channel goes idle past VoiceHangtimeMs.
+VoiceCallGrouping string `yaml:"voice_call_grouping"`
+```
+
+The daemon reduces this to a single boolean it hands the composer:
+
+```go
+// cmd/gophertrunk/daemon.go (shape)
+SplitPerTransmission: cfg.Trunking.VoiceCallGrouping != "conversation",
+```
+
+In `"transmission"` mode (the default), every over becomes its own file with its
+own timestamp — the Trunk-Recorder style, tidy for one-line-per-over browsing. In
+`"conversation"` mode, consecutive overs of the same talkgroup accumulate into one
+file, and the recording only splits when a *different* talkgroup seizes the shared
+frequency or the channel goes quiet past hangtime. Same audio, different file
+granularity. The choice is made once, at startup, and threaded through every voice
+chain identically — the boundary logic is protocol-agnostic on purpose.
+
+## The boundary tracker, from the outside
+
+Every voice chain — FM, DMR, P25 Phase 1, P25 Phase 2 — shares one small
+controller, the `boundaryTracker`. Its *internals* (the demod-quality accumulators,
+the C4FM soft-symbol buffers, the SNR/EVM estimator) belong to
+[Voice Coding Part 9]({{ '/blog/deep-dives/voice-coding-09-the-composer/' | relative_url }})
+and we treat them as given. What matters here is its **event surface**: a chain
+feeds it two facts and it turns them into three decisions.
+
+```go
+// internal/voice/composer/boundary.go (shape)
+// onVoice records one decoded voice frame and returns whether its audio
+// should be written. tg is the in-band talkgroup, or 0 when the frame
+// carries none (P25 LDU2, FM) — then the previous match is inherited.
+func (bt *boundaryTracker) onVoice(tg uint32) bool
+
+// onTransmissionEnd marks an over boundary; rolls the file in split mode.
+func (bt *boundaryTracker) onTransmissionEnd()
+
+// run drives the hangtime timer + throttled Touch heartbeat until ctx ends.
+func (bt *boundaryTracker) run(ctx context.Context)
+```
+
+The three decisions those produce are:
+
+1. **Write or drop this frame.** `onVoice` returns a bool. When the grant carries
+   a talkgroup and the frame's in-band talkgroup differs from it (and isn't a
+   patched member), the frame is *foreign* — its audio is dropped, so a second
+   talkgroup sharing the frequency can't append its speech to this call.
+2. **End the call on a sustained foreign talkgroup.** A couple of consecutive
+   frames of the *same* foreign talkgroup (`foreignRunToEnd`) end the call — the
+   frequency has been taken over, and the engine will start the other talkgroup's
+   call on its own tuner. A lone mis-decode is debounced away.
+3. **Roll the file at an over boundary.** `onTransmissionEnd` publishes a segment
+   (below) — but only in split mode, and only when audio was actually written
+   since the last roll, so a run of terminators can't spawn empty files.
+
+For our dispatch on talkgroup 101, `onVoice(101)` matches the grant and returns
+true for every frame of the dispatcher's over. If a unit on talkgroup 250 briefly
+keyed up on the same voice channel, those frames would return false and be dropped;
+two in a row and the call ends cleanly.
+
+## Hangtime: silence ends the call
+
+The most important thing the tracker does is decide when a call is *over*. On many
+systems there is no explicit channel-release message — P25 in particular rarely
+sends one — so the call ends when the audio simply stops. That's **hangtime**:
+
+```go
+// internal/voice/composer/boundary.go (shape)
+func (bt *boundaryTracker) run(ctx context.Context) {
+    // …ticker…
+    for {
+        select {
+        case <-ctx.Done():
+            return
+        case <-t.C:
+            if !bt.sawVoice.Load() {
+                // Never decoded a matching frame: end on the no-voice
+                // startup window so a phantom grant frees its tap.
+                if time.Since(start) > bt.noVoiceTimeout {
+                    bt.end(trunking.EndReasonTimeout)
+                    return
+                }
+                continue
+            }
+            last := bt.lastVoiceNano.Load()
+            // Keep the engine's LastHeardAt fresh, gated on progress.
+            if bt.c.engine != nil && last != bt.lastTouchNano {
+                bt.c.engine.Touch(bt.serial)
+                bt.lastTouchNano = last
+            }
+            if time.Since(lastFrame) > bt.hangtime {
+                bt.end(trunking.EndReasonNormal)
+                return
+            }
+        }
+    }
+}
+```
+
+Two windows live here. Once voice *has* been decoding, the call ends
+`VoiceHangtime` (default 3.5 s) after the **last matching frame** — tightly
+bounding the recording to the actual transmission instead of waiting out the
+engine's much longer call-timeout watchdog. If voice *never* decodes at all — a
+stale control-channel grant, a mis-tuned tap — the call is torn down after a
+short no-voice startup window with `EndReasonTimeout`, so a phantom grant frees
+its voice SDR promptly rather than hanging idle. The distinction between the two
+end reasons (`EndReasonNormal` vs `EndReasonTimeout`) is exactly the "radio
+stopped transmitting" versus "we never decoded a thing" split the call log later
+surfaces.
+
+When the tracker decides to end, it calls `end(reason)` exactly once, which stamps
+the measured signal and demod-quality figures onto the bound call and calls
+`EngineHooks.EndCall`. The engine publishes `KindCallEnd`; the composer cancels
+the chain. The recorder's response to that — finalize and publish `CallComplete`
+— is Part 4's territory. What's new *here* is the third decision: rolling the file
+mid-call, without ending it.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 200" width="660" height="200" role="img" aria-label="A timeline of one call on talkgroup 101: a first over of decoded voice frames, a short silence gap shorter than hangtime, a second over, and a final silence. In per-transmission mode a CallSegment marker at the end of the first over rolls the recording to a new file. After the last over, once the silence exceeds the hangtime window, a CallEnd fires. The hangtime window is drawn as a bracket after the final over.">
+  <line x1="20" y1="120" x2="640" y2="120" stroke="var(--fg-muted)"/>
+  <text x="20" y="150" fill="var(--fg-muted)" font-size="9">t →</text>
+  <rect x="40" y="96" width="150" height="24" rx="4" fill="none" stroke="var(--accent)"/>
+  <text x="115" y="112" text-anchor="middle" fill="var(--accent)" font-size="9">over 1 · tg 101</text>
+  <text x="230" y="112" text-anchor="middle" fill="var(--fg-muted)" font-size="8">gap &lt; hangtime</text>
+  <rect x="290" y="96" width="150" height="24" rx="4" fill="none" stroke="var(--accent)"/>
+  <text x="365" y="112" text-anchor="middle" fill="var(--accent)" font-size="9">over 2 · tg 101</text>
+  <line x1="190" y1="120" x2="190" y2="70" stroke="currentColor"/>
+  <polygon points="186,74 190,66 194,74" fill="currentColor"/>
+  <text x="190" y="60" text-anchor="middle" fill="currentColor" font-size="8">CallSegment</text>
+  <text x="190" y="50" text-anchor="middle" fill="var(--fg-muted)" font-size="8">roll → new file</text>
+  <text x="115" y="88" text-anchor="middle" fill="var(--fg-muted)" font-size="8">file A</text>
+  <text x="365" y="88" text-anchor="middle" fill="var(--fg-muted)" font-size="8">file B</text>
+  <line x1="440" y1="128" x2="560" y2="128" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <line x1="440" y1="124" x2="440" y2="132" stroke="var(--fg-muted)"/>
+  <line x1="560" y1="124" x2="560" y2="132" stroke="var(--fg-muted)"/>
+  <text x="500" y="144" text-anchor="middle" fill="var(--fg-muted)" font-size="8">VoiceHangtime</text>
+  <line x1="560" y1="120" x2="560" y2="70" stroke="currentColor"/>
+  <polygon points="556,74 560,66 564,74" fill="currentColor"/>
+  <text x="560" y="60" text-anchor="middle" fill="currentColor" font-size="8">CallEnd</text>
+  <text x="560" y="50" text-anchor="middle" fill="var(--fg-muted)" font-size="8">reason: normal</text>
+</svg>
+<figcaption>Per-transmission mode: a segment marker rolls the recording to a new file at each over boundary, while the call itself ends only once silence outlasts the hangtime window.</figcaption>
+</figure>
+
+## The segment roll
+
+When the split mode is on, an over boundary publishes a small event rather than
+ending the call:
+
+```go
+// internal/voice/composer/boundary.go (shape)
+func (bt *boundaryTracker) onTransmissionEnd() {
+    if !bt.c.splitTx || !bt.voiceSinceRoll {
+        return // conversation mode, or nothing written since last roll
+    }
+    bt.voiceSinceRoll = false
+    bt.c.bus.Publish(events.Event{
+        Kind: events.KindCallSegment,
+        Payload: trunking.CallSegment{
+            DeviceSerial: bt.serial,
+            At:           time.Now(),
+        },
+    })
+}
+```
+
+The payload is deliberately minimal — a device serial and the boundary instant:
+
+```go
+// internal/trunking/grant.go (shape)
+// CallSegment is published at an end-of-transmission boundary when
+// per-transmission recording is enabled, so the recorder closes the
+// current file and starts a fresh one for the next over. At marks the
+// boundary instant; the recorder uses it as the new segment's start
+// timestamp.
+type CallSegment struct {
+    DeviceSerial string
+    At           time.Time
+}
+```
+
+The crucial property is what a segment is *not*: it is **not** a call end. The
+engine's call keeps running — the voice SDR stays tuned, the `CallID` is unchanged
+— so a same-talkgroup re-key that never triggers a fresh control-channel grant is
+still captured on the same tuner. The segment only tells the recorder to close one
+file and open the next. That's the difference the bus vocabulary from Part 1 buys:
+`KindCallSegment` is a file-roll instruction, `KindCallEnd` is a call teardown, and
+they travel independently.
+
+## The dormant park
+
+On the recorder side, a segment is handled by finalizing the current file and
+parking a **dormant session**:
+
+```go
+// internal/voice/recorder.go (shape)
+func (r *Recorder) handleSegment(seg trunking.CallSegment) {
+    r.mu.Lock()
+    s, ok := r.sessions[seg.DeviceSerial]
+    if !ok || s.wav == nil {
+        r.mu.Unlock()
+        return // nothing open to roll (already dormant, or decode-only)
+    }
+    cc := r.finalizeLocked(s, seg.DeviceSerial, seg.At, trunking.EndReasonNormal)
+    // Park a dormant session: keeps the call's identity so the next
+    // write opens the next segment file, without creating an empty
+    // trailing file if no further audio arrives.
+    r.sessions[seg.DeviceSerial] = &recordingSession{cs: s.cs, callID: s.callID}
+    r.mu.Unlock()
+    if cc != nil {
+        r.normalizeIfEnabled(cc.AudioPath)
+        r.bus.Publish(events.Event{Kind: events.KindCallComplete, Payload: *cc})
+    }
+}
+```
+
+Three things happen, in order. First, `finalizeLocked` closes the current WAV
+(and `.raw`), producing a `CallComplete` for the over that just finished — so each
+over rolls out to the uploader as its own completed file. Second, the recorder
+replaces the session in its map with a **dormant** one: a `recordingSession`
+carrying only the originating `CallStart` and the `CallID`, with **no open files**.
+Third, after releasing the lock, it publishes `CallComplete` for the finished
+over.
+
+The dormant park is what makes per-over splitting leave a clean recordings tree.
+The parked session has no WAV path and no open handle; it exists only to carry the
+call's identity forward. If the next over arrives, the first write reopens files
+lazily under a fresh timestamp (the mechanism Part 4 details). If the call instead
+ends during the silence — no further audio — the dormant session is simply closed
+with nothing to finalize, and **no empty trailing file** is ever created. That is
+why a chatty channel of short overs doesn't litter the disk with 44-byte WAVs
+between transmissions.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 190" width="660" height="190" role="img" aria-label="A state machine for one recording session across a segment roll: it starts active with an open WAV file, a CallSegment finalizes it and publishes CallComplete, moving to a dormant state with no open files, which carries only the call identity forward. From dormant, the next write reopens a fresh file back to active; alternatively a CallEnd during the silence closes the dormant session with nothing to finalize, reaching ended without leaving a trailing file.">
+  <rect x="30" y="76" width="130" height="44" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="95" y="96" text-anchor="middle" fill="var(--accent)" font-size="10">active</text>
+  <text x="95" y="110" text-anchor="middle" fill="var(--fg-muted)" font-size="8">WAV open, writing</text>
+  <line x1="160" y1="98" x2="255" y2="98" stroke="currentColor"/><polygon points="255,94 265,98 255,102" fill="currentColor"/>
+  <text x="212" y="90" text-anchor="middle" fill="var(--fg-muted)" font-size="8">CallSegment</text>
+  <text x="212" y="112" text-anchor="middle" fill="var(--fg-muted)" font-size="8">finalize + Complete</text>
+  <rect x="265" y="76" width="140" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="335" y="96" text-anchor="middle" fill="currentColor" font-size="10">dormant</text>
+  <text x="335" y="110" text-anchor="middle" fill="var(--fg-muted)" font-size="8">no files, keeps id</text>
+  <path d="M 335 76 C 300 30, 130 30, 95 74" fill="none" stroke="currentColor"/>
+  <polygon points="99,68 93,76 104,74" fill="currentColor"/>
+  <text x="215" y="34" text-anchor="middle" fill="var(--fg-muted)" font-size="8">next write → reopen fresh file</text>
+  <line x1="405" y1="98" x2="500" y2="98" stroke="currentColor"/><polygon points="500,94 510,98 500,102" fill="currentColor"/>
+  <text x="455" y="90" text-anchor="middle" fill="var(--fg-muted)" font-size="8">CallEnd in silence</text>
+  <text x="455" y="112" text-anchor="middle" fill="var(--fg-muted)" font-size="8">close, nothing to finalize</text>
+  <rect x="510" y="76" width="120" height="44" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="570" y="96" text-anchor="middle" fill="var(--fg-muted)" font-size="10">ended</text>
+  <text x="570" y="110" text-anchor="middle" fill="var(--fg-muted)" font-size="8">no trailing file</text>
+</svg>
+<figcaption>A session's life across a roll: a segment parks it dormant with its identity intact; the next write reopens a fresh file, while a call end during the silence closes it cleanly with no empty file left behind.</figcaption>
+</figure>
+
+## Where this goes next
+
+[Part 4]({{ '/blog/deep-dives/recording-streaming-04-recording-session/' | relative_url }})
+opens up the `recordingSession` state machine that this post kept treating as a
+black box: why files open **lazily** on the first write (so a dead-key leaves
+nothing on disk), how the dormant park carries a call's identity across a segment
+roll, and how an empty recordings directory turns the whole recorder into a
+decode-only live-audio feed that still writes no files.
+
+## FAQ
+
+**What's the difference between a transmission and a call?**
+A transmission (an "over") is one keying of a radio's PTT; a call is the whole
+conversation. `voice_call_grouping` maps between them: `"transmission"` writes one
+file per over, `"conversation"` keeps consecutive same-talkgroup overs in one file.
+The boundary tracker detects overs; the config decides whether each one becomes a
+separate file.
+
+**Why does hangtime end the call instead of a channel-release message?**
+Because many trunked systems — P25 especially — rarely send an explicit release.
+The tracker ends the call `VoiceHangtime` (default 3.5 s) after the last decoded
+voice frame, which bounds the recording tightly to the actual transmission rather
+than waiting out the engine's much longer call-timeout watchdog.
+
+**Does a `CallSegment` end the call?**
+No. A segment tells the recorder to close the current file and open a fresh one,
+but the engine's call keeps running — same tuner, same `CallID`. That's what lets a
+same-talkgroup re-key that never re-grants stay captured. Only `CallEnd` tears the
+call down.
+
+**Why doesn't per-over splitting fill my disk with tiny files between overs?**
+Because a segment parks a *dormant* session with no open files, and the next file
+is opened lazily on the first write. If the call ends during the silence after an
+over, the dormant session closes with nothing to finalize — so no empty trailing
+WAV is ever created.
+
+## Series navigation
+
+**Part 3 of 14** · ←
+[Part 2: The Composition Contract]({{ '/blog/deep-dives/recording-streaming-02-composition-contract/' | relative_url }})
+· Next →
+[Part 4: The Recording Session]({{ '/blog/deep-dives/recording-streaming-04-recording-session/' | relative_url }})

--- a/docs/_posts/2026-08-04-recording-streaming-04-recording-session.md
+++ b/docs/_posts/2026-08-04-recording-streaming-04-recording-session.md
@@ -1,0 +1,389 @@
+---
+title: "Recording, Composition & Streaming, Part 4: The Recording Session"
+description: How GopherTrunk's per-call recording session opens files lazily on the first write so dead-keys leave nothing on disk, carries identity forward through dormant post-segment parks, and runs decode-only when no recordings directory is configured.
+category: deep-dives
+keywords: lazy file open recorder, dead key no file, decode only mode, recording session state machine, dormant session park, gophertrunk recorder session, build session vocoder, empty outdir live audio
+tags: [recording, session, state-machine, go, lazy-init, software-design]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Recording, Composition & Streaming"
+series_part: 4
+---
+
+*Part 4 of **Recording, Composition & Streaming**, opening the black box the last
+two posts leaned on: the `recordingSession`. [Part 3]({{ '/blog/deep-dives/recording-streaming-03-assembling-a-call/' | relative_url }})
+showed segments parking a session dormant; this post is the whole state machine
+behind that. Our 3 p.m. dispatch on talkgroup 101 gets a session the instant its
+grant lands — but not a file. If the transmitter keys and unkeys without a word,
+we want nothing on disk. This is how the recorder threads that needle.*
+
+> **TL;DR:** A `recordingSession` is **prepared** on `CallStart` but its files are
+> **not opened** — `buildSession` resolves paths and builds the vocoder, and
+> `openSessionFiles` runs only on the first actual write. A dead-key therefore
+> leaves no WAV, no `.raw`, and no empty talkgroup folder. A post-segment
+> **dormant** session carries the call's identity with no open files, reopening
+> lazily on the next over. And an **empty `OutDir`** flips the recorder into
+> **decode-only** mode: every call still builds a vocoder and feeds live audio, it
+> just never writes a file.
+
+**Key takeaways**
+
+- **Files open lazily.** `buildSession` prepares paths and a vocoder; the WAV and
+  `.raw` are created by `openSessionFiles` on the first sample or frame — so a
+  call with no audio touches disk zero times.
+- **The talkgroup directory is lazy too.** It's `MkdirAll`'d just before the first
+  file, so a followed-but-silent grant leaves no empty `<system>/<tg>` folder.
+- **Dormant sessions carry identity.** After a segment, the parked session holds
+  only the `CallStart` and `CallID`; `sessionForWrite` rebuilds it under a fresh
+  timestamp when the next write arrives.
+- **Decode-only mode** (empty `OutDir`) decodes and fans live audio with no files —
+  how live browser audio works without a configured recordings directory.
+
+## Cheat sheet
+
+| Thing | What it does | Where in code |
+|---|---|---|
+| `recordingSession` | Per-call state: files, vocoder, paths, `CallID` | `internal/voice/recorder.go` |
+| `buildSession` | Prepare paths + vocoder; open **no** files | `internal/voice/recorder.go` |
+| `openSessionFiles` | Lazily create the WAV / `.raw` on first write | `internal/voice/recorder.go` |
+| `sessionForWrite` | Resolve/reopen the session for a write; `CallID` fence | `internal/voice/recorder.go` |
+| `handleStart` | Gate the `CallStart`, then build + register a session | `internal/voice/recorder.go` |
+| `decodeOnly` | Empty `OutDir` → decode + live audio, no files | `internal/voice/recorder.go` |
+
+## In this post
+
+- **The session struct** — what one call's state actually holds.
+- **Prepare, don't open** — `buildSession` versus `openSessionFiles`.
+- **The write path** — how `sessionForWrite` reopens a dormant session lazily.
+- **The gates** — what `handleStart` checks before a session ever exists.
+- **Decode-only mode** — the recorder as a pure live-audio decoder.
+
+## One call's state
+
+Everything the recorder knows about an in-flight call lives in one struct, keyed
+by device serial in the recorder's `sessions` map:
+
+```go
+// internal/voice/recorder.go (shape)
+type recordingSession struct {
+    wav         *WavWriter   // nil until the first write (or in decode-only)
+    wavPath     string       // resolved at buildSession; "" for a dormant park
+    raw         *os.File     // the .raw sidecar, likewise lazy
+    rawPath     string
+    vocoder     Vocoder      // per-protocol; nil for analog
+    vocoderName string
+    sampleRate  uint32       // WAV header rate (8 kHz for vocoded calls)
+    lastSample  int16        // for the end-of-call fade
+    rawWanted   bool         // should a .raw be opened on first frame?
+    startedAt   time.Time
+    callID      uint64       // Grant.CallID — the cross-call fence key
+    cs          trunking.CallStart // retained so a segment roll can reopen
+}
+```
+
+The two fields that make the whole state machine work are `wav` and `cs`. A `wav`
+of `nil` means "no file is open" — which is true in three distinct situations: a
+freshly prepared session that hasn't been written yet, a dormant post-segment park,
+and a decode-only session that will never open a file. `cs` (the originating
+`CallStart`) is retained so a segment roll can open the *next* file with the same
+grant and talkgroup under a new timestamp. The struct is small on purpose: it is
+the identity of a call plus a few handles that may or may not be live.
+
+## Prepare, don't open
+
+`handleStart` builds a session; `buildSession` prepares it *without* touching disk.
+This is the design's central move, and its doc comment is explicit that it "does
+NOT open the files":
+
+```go
+// internal/voice/recorder.go (shape)
+func (r *Recorder) buildSession(cs trunking.CallStart, startedAt time.Time) *recordingSession {
+    dir := r.directoryFor(cs)          // path only — NOT created here
+    base := r.basenameFor(withStart(cs, startedAt))
+    s := &recordingSession{startedAt: startedAt, cs: cs, callID: cs.Grant.CallID}
+
+    // Instantiate the per-protocol vocoder if one is mapped, before the
+    // WAV is opened (its header rate tracks the vocoder's native rate).
+    if name, ok := r.vocoderForProtocol[cs.Grant.Protocol]; ok && name != "" {
+        if v, err := DefaultRegistry.New(name); err == nil {
+            // opt-in enhancement + startup squelch installed here
+            s.vocoder, s.vocoderName = v, name
+        }
+    }
+    s.sampleRate = r.sampleRate
+    if s.vocoder != nil {
+        s.sampleRate = pcmHzDefault // vocoder output is always 8 kHz
+    }
+    s.wavPath = filepath.Join(dir, base+".wav")
+    if r.writeRaw || cs.Grant.ProVoice ||
+        dmrVoiceProtocol(cs.Grant.Protocol) || tetraVoiceProtocol(cs.Grant.Protocol) {
+        s.rawPath = filepath.Join(dir, base+".raw")
+        s.rawWanted = true
+    }
+    // Files are NOT opened here — see openSessionFiles.
+    return s
+}
+```
+
+So after `buildSession`, a session has a vocoder, a chosen sample rate, and two
+resolved paths — but nothing on disk. The talkgroup directory itself isn't even
+created yet. That is deliberate: a grant that is *followed* but never yields audio
+— a dead-key, an immediately-aborted encrypted call, a voice tap left
+off-frequency while a hunt borrows the SDR — leaves neither a header-only WAV nor
+an empty `<system>/<talkgroup>` folder behind. The WAV header rate is worth one
+note: a *vocoded* call is forced to 8 kHz regardless of `recordings.sample_rate`,
+because the vocoder's output is always 8 kHz and appending it under a different
+header rate would play back garbled; `recordings.sample_rate` applies only to
+analog PCM fed via `WritePCM`.
+
+The actual disk work is quarantined in `openSessionFiles`, called from the write
+path on the first sample or frame:
+
+```go
+// internal/voice/recorder.go (shape)
+func (r *Recorder) openSessionFiles(s *recordingSession) error {
+    if s.wav != nil {
+        return nil // idempotent: already open
+    }
+    if dir := filepath.Dir(s.wavPath); dir != "" {
+        if err := os.MkdirAll(dir, 0o755); err != nil { // lazy dir creation
+            return err
+        }
+    }
+    wav, err := NewWavFile(s.wavPath, s.sampleRate)
+    if err != nil {
+        if s.vocoder != nil { s.vocoder.Close(); s.vocoder = nil }
+        return err
+    }
+    s.wav = wav
+    if s.rawWanted && s.raw == nil {
+        if raw, err := os.Create(s.rawPath); err == nil {
+            s.raw = raw
+        }
+    }
+    return nil
+}
+```
+
+`TestRecorderNoAudioLeavesNoFiles` and `TestRecorderNoAudioLeavesNoDir` in
+`recorder_idle_test.go` pin this behaviour: a `CallStart` with no following write
+produces no files *and* no directory.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 190" width="660" height="190" role="img" aria-label="A state machine for a recording session: CallStart builds a prepared session that has a vocoder and resolved paths but no open files. On the first write, openSessionFiles lazily creates the WAV and dot-raw and the session becomes files-open. A CallSegment finalizes and parks it dormant, from which the next write reopens fresh files back to files-open. A CallEnd from either the prepared or dormant state, with no audio ever written, closes to ended leaving nothing on disk; a CallEnd from files-open closes and publishes CallComplete.">
+  <rect x="20" y="76" width="120" height="46" rx="6" fill="none" stroke="currentColor"/>
+  <text x="80" y="96" text-anchor="middle" fill="currentColor" font-size="10">prepared</text>
+  <text x="80" y="110" text-anchor="middle" fill="var(--fg-muted)" font-size="8">paths+vocoder</text>
+  <text x="80" y="66" text-anchor="middle" fill="var(--fg-muted)" font-size="8">CallStart</text>
+  <line x1="140" y1="99" x2="228" y2="99" stroke="var(--accent)"/><polygon points="228,95 238,99 228,103" fill="var(--accent)"/>
+  <text x="184" y="92" text-anchor="middle" fill="var(--accent)" font-size="8">first write</text>
+  <text x="184" y="114" text-anchor="middle" fill="var(--fg-muted)" font-size="8">openSessionFiles</text>
+  <rect x="238" y="76" width="130" height="46" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="303" y="96" text-anchor="middle" fill="var(--accent)" font-size="10">files-open</text>
+  <text x="303" y="110" text-anchor="middle" fill="var(--fg-muted)" font-size="8">WAV + .raw</text>
+  <line x1="368" y1="99" x2="452" y2="99" stroke="currentColor"/><polygon points="452,95 462,99 452,103" fill="currentColor"/>
+  <text x="410" y="92" text-anchor="middle" fill="var(--fg-muted)" font-size="8">CallSegment</text>
+  <rect x="462" y="76" width="120" height="46" rx="6" fill="none" stroke="currentColor"/>
+  <text x="522" y="96" text-anchor="middle" fill="currentColor" font-size="10">dormant</text>
+  <text x="522" y="110" text-anchor="middle" fill="var(--fg-muted)" font-size="8">keeps identity</text>
+  <path d="M 462 84 C 400 44, 360 44, 303 74" fill="none" stroke="currentColor"/>
+  <polygon points="307,68 301,76 312,74" fill="currentColor"/>
+  <text x="383" y="46" text-anchor="middle" fill="var(--fg-muted)" font-size="8">next write → reopen</text>
+  <line x1="80" y1="122" x2="80" y2="164" stroke="var(--fg-muted)"/><polygon points="76,158 80,168 84,158" fill="var(--fg-muted)"/>
+  <line x1="522" y1="122" x2="522" y2="164" stroke="var(--fg-muted)"/><polygon points="518,158 522,168 526,158" fill="var(--fg-muted)"/>
+  <rect x="250" y="152" width="120" height="28" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="310" y="170" text-anchor="middle" fill="var(--fg-muted)" font-size="9">ended · no file</text>
+  <line x1="140" y1="164" x2="248" y2="167" stroke="var(--fg-muted)"/>
+  <line x1="462" y1="164" x2="372" y2="167" stroke="var(--fg-muted)"/>
+  <text x="310" y="146" text-anchor="middle" fill="var(--fg-muted)" font-size="8">CallEnd with no audio written</text>
+</svg>
+<figcaption>The session state machine: prepared on CallStart, files opened lazily on the first write, parked dormant across a segment, and — when no audio ever arrives — ended without ever touching disk.</figcaption>
+</figure>
+
+## The write path reopens lazily
+
+Every write — `WritePCM` and the `WriteRawFrame` family — first resolves the
+session through `sessionForWrite`, which is where the lazy reopen lives:
+
+```go
+// internal/voice/recorder.go (shape)
+func (r *Recorder) sessionForWrite(serial string, callID uint64) *recordingSession {
+    r.mu.Lock()
+    defer r.mu.Unlock()
+    s, ok := r.sessions[serial]
+    if !ok {
+        return nil // no session (the composer can race ahead of CallStart)
+    }
+    if callID != 0 && s.callID != 0 && callID != s.callID {
+        return nil // cross-call fence: a stale frame from a reused tap serial
+    }
+    if r.decodeOnly {
+        return s // no files ever; the vocoder is enough to fan live audio
+    }
+    if s.wav == nil {
+        if s.wavPath == "" {
+            // A dormant park carries only cs+callID: build a fresh session
+            // under a new timestamp before opening its files.
+            ns := r.buildSession(s.cs, time.Now().UTC())
+            if ns == nil { return nil }
+            r.sessions[serial] = ns
+            s = ns
+        }
+        if err := r.openSessionFiles(s); err != nil {
+            delete(r.sessions, serial) // don't retry on every frame
+            return nil
+        }
+    }
+    return s
+}
+```
+
+This one function reconciles all three `wav == nil` cases. A **prepared** session
+(has a `wavPath`, no files) just needs `openSessionFiles`. A **dormant** park (no
+`wavPath` at all) is first rebuilt via `buildSession` under a fresh `time.Now()`
+timestamp — that's how the second over of a per-transmission call gets a new
+filename while keeping the same grant and `CallID`. A **decode-only** session is
+handed straight back with `wav == nil`, because it will never open a file. And the
+`CallID` fence sits right at the top: a frame whose call identity doesn't match the
+open session is rejected *without* reopening a dormant session, so a mismatched
+frame can't even spawn an empty file. `TestRecorderCallIDFenceDropsStaleFrames`
+covers that path. (The dormant `recordingSession` can also just be closed with no
+open files — `TestDormantSessionCloseNoPanic` and `TestWavWriterNilClose` in
+`recordingsession_close_test.go` guard against the nil-writer panic that would
+otherwise lurk there.)
+
+## The gates before a session exists
+
+`handleStart` is the decision that decides whether a session is built at all. It
+runs a short sequence of gates, each of which can drop the `CallStart` before any
+session is registered:
+
+```go
+// internal/voice/recorder.go (shape)
+func (r *Recorder) handleStart(cs trunking.CallStart) {
+    if r.recordDisabled.Load() {
+        return // operator toggled recording off at runtime
+    }
+    if !r.decodeOnly && cs.Talkgroup != nil && !cs.Talkgroup.Record {
+        return // talkgroup record=false: follow + play live, write nothing
+    }
+    if r.skipEncrypted && cs.Grant.Encrypted {
+        return // opted out of recording encrypted calls
+    }
+    r.mu.Lock()
+    defer r.mu.Unlock()
+    // …replace any stale session on this serial…
+    s := r.buildSession(cs, cs.StartedAt)
+    if s == nil {
+        return
+    }
+    r.sessions[cs.DeviceSerial] = s
+}
+```
+
+The ordering has one subtlety worth calling out. The `record=false` gate is
+skipped when `decodeOnly` is set — a decode-only recorder writes nothing to disk
+*regardless*, so if it also dropped `record=false` talkgroups here, those
+talkgroups would be silent on the *live* feed too. The whole point of decode-only
+mode is live audio; dropping the call at the gate would defeat it. The
+`recordDisabled` gate, by contrast, applies to everyone and is the runtime "stop
+laying down WAVs" switch — and it deliberately leaves in-flight sessions alone, so
+flipping it mid-conversation doesn't truncate the head of a call.
+
+## Decode-only mode
+
+The `decodeOnly` flag is set once, in `NewRecorder`, purely from whether an output
+directory was configured:
+
+```go
+// internal/voice/recorder.go (shape)
+func NewRecorder(opts RecorderOptions) (*Recorder, error) {
+    // An empty OutDir runs the recorder in decode-only mode: it still
+    // decodes each call and feeds the live-audio tap, it just never
+    // writes files. This is how live browser audio works without a
+    // configured recordings dir.
+    decodeOnly := opts.OutDir == ""
+    if !decodeOnly {
+        os.MkdirAll(opts.OutDir, 0o755)
+    }
+    // …vocoder map, normalize/enhance defaults, displayLoc…
+}
+```
+
+In this mode the recorder is a pure decoder. `buildSession` still constructs the
+per-protocol vocoder, so `writeRawFrame` can decode each frame; `sessionForWrite`
+hands back the session with `wav == nil`; the decode result skips the WAV write but
+still fans to the decoded-PCM live tap (Part 2's fan-out). The result is that a
+GopherTrunk instance with no `recordings:` directory configured *still* streams
+live digital audio to the browser — it decodes every call, it just persists none.
+This is the recorder's contribution to the "optional means absent, not idle"
+principle from Part 1: with no `OutDir`, there is no persistence, but the live
+path is fully alive. `TestRecorderSuppressesAllIdleRecording` and the idle-suite
+neighbours in `recorder_idle_test.go` validate the "still decodes, writes nothing"
+contract.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 210" width="660" height="210" role="img" aria-label="A decision flow for a CallStart entering the recorder: it first checks recordDisabled — if recording is off at runtime, the call is dropped. Otherwise, if the talkgroup is flagged record=false and the recorder is not in decode-only mode, it drops. Otherwise, if skipEncrypted is set and the grant is encrypted, it drops. Passing all gates, it builds a session. A separate branch shows that when OutDir is empty the recorder is in decode-only mode, which builds a vocoder and feeds live audio but writes no files.">
+  <rect x="20" y="90" width="110" height="34" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="75" y="111" text-anchor="middle" fill="var(--accent)" font-size="10">CallStart</text>
+  <line x1="130" y1="107" x2="158" y2="107" stroke="currentColor"/><polygon points="158,103 168,107 158,111" fill="currentColor"/>
+  <rect x="168" y="88" width="96" height="38" rx="5" fill="none" stroke="currentColor"/>
+  <text x="216" y="104" text-anchor="middle" fill="currentColor" font-size="9">recordDisabled?</text>
+  <text x="216" y="118" text-anchor="middle" fill="var(--fg-muted)" font-size="8">record=false? enc?</text>
+  <line x1="216" y1="126" x2="216" y2="168" stroke="var(--fg-muted)"/><polygon points="212,162 216,172 220,162" fill="var(--fg-muted)"/>
+  <text x="216" y="186" text-anchor="middle" fill="var(--fg-muted)" font-size="9">yes → drop, no session</text>
+  <line x1="264" y1="107" x2="330" y2="107" stroke="currentColor"/><polygon points="330,103 340,107 330,111" fill="currentColor"/>
+  <text x="300" y="100" text-anchor="middle" fill="var(--fg-muted)" font-size="8">pass</text>
+  <rect x="340" y="88" width="110" height="38" rx="5" fill="none" stroke="var(--accent)"/>
+  <text x="395" y="104" text-anchor="middle" fill="var(--accent)" font-size="9">buildSession</text>
+  <text x="395" y="118" text-anchor="middle" fill="var(--fg-muted)" font-size="8">vocoder + paths</text>
+  <line x1="450" y1="107" x2="500" y2="107" stroke="currentColor"/><polygon points="500,103 510,107 500,111" fill="currentColor"/>
+  <rect x="510" y="72" width="130" height="30" rx="5" fill="none" stroke="currentColor"/>
+  <text x="575" y="91" text-anchor="middle" fill="currentColor" font-size="9">OutDir set → files</text>
+  <rect x="510" y="112" width="130" height="34" rx="5" fill="none" stroke="var(--fg-muted)"/>
+  <text x="575" y="128" text-anchor="middle" fill="var(--fg-muted)" font-size="9">OutDir empty →</text>
+  <text x="575" y="140" text-anchor="middle" fill="var(--fg-muted)" font-size="9">decode-only, live only</text>
+  <line x1="450" y1="120" x2="508" y2="128" stroke="var(--fg-muted)" stroke-dasharray="3 3"/>
+</svg>
+<figcaption>From CallStart to a session: three gates can drop the call before any state exists; passing them builds a session whose files open only when OutDir is set — an empty OutDir yields a decode-only, live-audio-only recorder.</figcaption>
+</figure>
+
+## Where this goes next
+
+[Part 5]({{ '/blog/deep-dives/recording-streaming-05-wav-on-disk/' | relative_url }})
+follows the file that `openSessionFiles` finally creates: the crash-safe WAV. Once
+a session opens its `WavWriter`, how does GopherTrunk keep the on-disk file valid
+even if the daemon dies mid-call — the streaming header, the length-field patch on
+close, and why a half-written recording is still playable.
+
+## FAQ
+
+**Why open files lazily instead of on `CallStart`?**
+Because a grant that yields no audio — a dead-key, an aborted encrypted call, a tap
+left off-frequency — should leave nothing behind. `buildSession` resolves paths and
+builds the vocoder but opens no files; `openSessionFiles` runs on the first write.
+No audio, no WAV, no `.raw`, and not even an empty talkgroup directory.
+
+**What is a dormant session?**
+After a per-transmission segment roll, the recorder parks a session that holds only
+the originating `CallStart` and `CallID` with no open files. It carries the call's
+identity forward so the next over reopens a fresh file under a new timestamp — and
+if the call ends first, it closes cleanly without leaving an empty trailing file.
+
+**What does decode-only mode do?**
+When `OutDir` is empty, the recorder builds each call's vocoder and decodes every
+frame but never opens a file. The decoded PCM still fans to the live-audio tap, so
+browser and host audio work with no recordings directory configured. It's how you
+run GopherTrunk as a pure live scanner with nothing written to disk.
+
+**Does disabling recording at runtime truncate the call I'm hearing?**
+No. The `recordDisabled` gate stops *new* sessions from opening files, but leaves
+in-flight sessions alone — they finish naturally on `CallEnd`. Flipping the switch
+mid-conversation won't cut the head off the call already being recorded.
+
+## Series navigation
+
+**Part 4 of 14** · ←
+[Part 3: Assembling a Call]({{ '/blog/deep-dives/recording-streaming-03-assembling-a-call/' | relative_url }})
+· Next →
+[Part 5: The WAV on Disk]({{ '/blog/deep-dives/recording-streaming-05-wav-on-disk/' | relative_url }})

--- a/docs/_posts/2026-08-05-recording-streaming-05-wav-on-disk.md
+++ b/docs/_posts/2026-08-05-recording-streaming-05-wav-on-disk.md
@@ -1,0 +1,373 @@
+---
+title: "Recording, Composition & Streaming, Part 5: WAV on Disk — Crash-Safety, the Tolerant Reader & Clean Cuts"
+description: How GopherTrunk's recorder turns decoded PCM into a WAV that survives a crash — placeholder-then-patch RIFF headers, a chunk-walking reader that clamps a truncated final chunk, an end-of-call fade tail, and dead-key suppression that removes empty files.
+category: deep-dives
+keywords: wav file crash safety, riff header patch, tolerant wav reader, truncated chunk clamp, end of call fade, dead key suppression, empty recording removal, gophertrunk recorder, 16-bit pcm mono wav, sdr call recording
+tags: [recording, wav, file-integrity, dsp, go, software-design]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Recording, Composition & Streaming"
+series_part: 5
+---
+
+*Part 5 of **Recording, Composition & Streaming**, a 14-part deep dive into
+GopherTrunk's output half. Parts 2–4 got a call's composed audio into a
+[recording session]({{ '/blog/deep-dives/recording-streaming-04-recording-session/' | relative_url }})
+and started its WAV. This post is about the file itself: what the recorder does
+so that our 3 p.m. dispatch on talkgroup 101 lands as a playable file even if the
+daemon is killed mid-write — and what it decides NOT to keep. The
+[Voice Coding]({{ '/blog/deep-dives/voice-coding-11-recording-encoding/' | relative_url }})
+series already dissected the header-patch trick at the byte level; here we care
+about the recorder's use of it and the finalize decisions layered on top.*
+
+> **TL;DR:** `WavWriter` writes a 44-byte header with **zero placeholders** for
+> the two length fields and patches them in `Close()`, so a crash leaves a file
+> whose worst case is a readable, length-zero recording rather than one media
+> players reject. `ReadWAVSamples` **walks the RIFF chunks** and clamps a
+> truncated final `data` chunk to the bytes that actually exist, so even an
+> un-patched file reads back. On finalize the recorder appends a short **linear
+> fade** to zero (killing the end-of-call click), and **removes** a WAV that
+> captured no real speech instead of leaving dead-key spam on disk.
+
+**Key takeaways**
+
+- The WAV is written **length-last**: two fields (RIFF size at byte 4, data size
+  at byte 40) start as zeros and are back-patched on `Close()`. A crash before
+  the patch costs the length fields, not the audio.
+- The reader is **deliberately tolerant** — a chunk walk that accepts extra
+  chunks before `data` and clamps a final chunk whose declared size runs past
+  end-of-file, so an un-patched or truncated capture still yields samples.
+- Finalize is where the recorder **shapes the cut**: `fadeTail` ramps the last
+  decoded sample down to zero over ~10 ms so a short over doesn't end on a click.
+- **Empty and dead-key calls are removed, not kept.** No PCM, or a vocoder that
+  decoded zero voiced/unvoiced frames, means the WAV is deleted and no
+  `CallComplete` is published — nothing to upload, no tiny-file spam.
+
+## Cheat sheet
+
+| Thing | What it does | Where in code |
+|---|---|---|
+| `WavWriter.writeHeader` | Emits 44 bytes with zeroed length fields | `internal/voice/wav.go` |
+| `WavWriter.Close` → `patchHeader` | Seeks to byte 4 and byte 40, writes real lengths | `internal/voice/wav.go` |
+| `WavWriter.DataBytes` | Payload byte count; readable after Close | `internal/voice/wav.go` |
+| `ReadWAVSamples` | Chunk-walking, truncation-clamping tolerant reader | `internal/voice/wav.go` |
+| `finalizeLocked` | Fade, empty check, CallComplete-or-nil decision | `internal/voice/recorder.go` |
+| `fadeTail` | Linear ramp from last sample to zero | `internal/voice/recorder.go` |
+| `removeSessionFiles` | Deletes WAV + `.raw` for a worthless call | `internal/voice/recorder.go` |
+
+## In this post
+
+- **Length-last WAV** — why the header is written with holes and patched on close.
+- **The tolerant reader** — the chunk walk and the truncated-chunk clamp.
+- **The fade tail** — smoothing an abrupt digital cut without touching the DSP.
+- **Empty and dead-key removal** — the finalize decisions that keep the tree clean.
+- **The audio-vs-wall-clock check** — a diagnostic that catches lost voice frames.
+
+## Length-last, because you can't know the length yet
+
+A canonical PCM WAV is a RIFF container: a 12-byte `RIFF … WAVE` preamble, a
+`fmt ` chunk describing the format, and a `data` chunk holding the samples. Two
+of those fields are byte counts that can't be known until the file is done — the
+overall RIFF size and the `data` chunk size. A call is a live stream; the
+recorder is appending samples for as long as the radio holds the channel. It has
+no idea how long the file will be when it opens it.
+
+`WavWriter` resolves this the standard way — **write the header with zeros in the
+length slots, patch them when you close** — but the reason GopherTrunk leans on
+it is durability. `writeHeader` lays down all 44 bytes up front with placeholders
+for the two lengths:
+
+```go
+// internal/voice/wav.go (shape)
+func (w *WavWriter) writeHeader() error {
+    header := make([]byte, wavHeaderSize) // 44
+    copy(header[0:4], "RIFF")
+    // header[4:8]  RIFF size — patched in Close()
+    copy(header[8:12], "WAVE")
+    copy(header[12:16], "fmt ")
+    binary.LittleEndian.PutUint32(header[16:20], 16) // fmt chunk size
+    binary.LittleEndian.PutUint16(header[20:22], 1)  // PCM
+    // …channels, sampleRate, byteRate, blockAlign, bitsPerSample…
+    copy(header[36:40], "data")
+    // header[40:44] data size — patched in Close()
+    _, err := w.w.Write(header)
+    return err
+}
+```
+
+Every `WriteSamples` call appends little-endian `int16` payload and bumps
+`bytesWritten`. Nothing seeks; the file grows monotonically. Only `Close()` goes
+back and fills the holes:
+
+```go
+// internal/voice/wav.go (shape)
+func (w *WavWriter) patchHeader() error {
+    w.w.Seek(4, io.SeekStart)
+    binary.Write(w.w, binary.LittleEndian, uint32(36+w.bytesWritten)) // RIFF size
+    w.w.Seek(40, io.SeekStart)
+    binary.Write(w.w, binary.LittleEndian, w.bytesWritten)            // data size
+    w.w.Seek(0, io.SeekEnd)
+    return nil
+}
+```
+
+The payoff is the crash story. If the daemon is `SIGKILL`ed mid-call — OOM,
+power loss, a panic elsewhere — the file on disk is a valid header (with zero
+lengths) followed by however many samples were flushed. Byte 4 and byte 40 still
+read zero, so a strict player sees a length-zero recording, but the container is
+structurally intact and the samples are physically present. Contrast the naive
+alternative, where you'd buffer the whole call and write the header once at the
+end: a crash there loses *everything*. Length-last trades a strict-reader edge
+case for never losing the audio you already captured. `TestWavHeaderShape` pins
+the patched offsets — data size at `[40:44]`, RIFF size at `[4:8]` — and
+`TestWavCloseTwice` confirms `Close()` is idempotent, which matters because the
+recorder's session teardown can reach a writer more than once.
+
+`Close()` is also nil-safe and closed-safe on purpose. A dormant session parked
+between overs holds a nil writer; closing it must be a no-op, not a panic:
+
+```go
+// internal/voice/wav.go (shape)
+func (w *WavWriter) Close() error {
+    if w == nil || w.closed {
+        return nil
+    }
+    w.closed = true
+    if err := w.patchHeader(); err != nil {
+        if w.closeFn != nil {
+            _ = w.closeFn() // still release the fd; chain the error
+        }
+        return err
+    }
+    // …closeFn()…
+}
+```
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 150" width="660" height="150" role="img" aria-label="Byte layout of the 44-byte WAV header. The RIFF chunk id occupies bytes 0 to 4, the RIFF size field at byte 4 is highlighted as patched-on-close, WAVE and fmt and format fields fill the middle, the data chunk id sits at byte 36, and the data size field at byte 40 is highlighted as patched-on-close, followed by the PCM payload starting at byte 44.">
+  <rect x="8" y="40" width="70" height="34" rx="6" fill="none" stroke="currentColor"/>
+  <text x="43" y="60" text-anchor="middle" fill="currentColor" font-size="10">RIFF</text>
+  <text x="43" y="72" text-anchor="middle" fill="var(--fg-muted)" font-size="8">0..4</text>
+  <rect x="78" y="40" width="80" height="34" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="118" y="57" text-anchor="middle" fill="var(--accent)" font-size="10">RIFF size</text>
+  <text x="118" y="69" text-anchor="middle" fill="var(--accent)" font-size="8">byte 4 · patched</text>
+  <rect x="158" y="40" width="60" height="34" rx="6" fill="none" stroke="currentColor"/>
+  <text x="188" y="60" text-anchor="middle" fill="currentColor" font-size="10">WAVE</text>
+  <text x="188" y="72" text-anchor="middle" fill="var(--fg-muted)" font-size="8">8..12</text>
+  <rect x="218" y="40" width="140" height="34" rx="6" fill="none" stroke="currentColor"/>
+  <text x="288" y="60" text-anchor="middle" fill="currentColor" font-size="10">fmt · PCM · rate</text>
+  <text x="288" y="72" text-anchor="middle" fill="var(--fg-muted)" font-size="8">12..36</text>
+  <rect x="358" y="40" width="66" height="34" rx="6" fill="none" stroke="currentColor"/>
+  <text x="391" y="60" text-anchor="middle" fill="currentColor" font-size="10">data</text>
+  <text x="391" y="72" text-anchor="middle" fill="var(--fg-muted)" font-size="8">36..40</text>
+  <rect x="424" y="40" width="82" height="34" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="465" y="57" text-anchor="middle" fill="var(--accent)" font-size="10">data size</text>
+  <text x="465" y="69" text-anchor="middle" fill="var(--accent)" font-size="8">byte 40 · patched</text>
+  <rect x="506" y="40" width="146" height="34" rx="6" fill="none" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <text x="579" y="57" text-anchor="middle" fill="var(--fg-muted)" font-size="10">int16 PCM payload</text>
+  <text x="579" y="69" text-anchor="middle" fill="var(--fg-muted)" font-size="8">byte 44 →</text>
+  <text x="330" y="24" text-anchor="middle" fill="var(--fg-muted)" font-size="10">44-byte header — two fields written last</text>
+  <text x="330" y="104" text-anchor="middle" fill="var(--fg-muted)" font-size="9">A crash before Close() leaves both accent fields at zero — the payload is still physically present.</text>
+</svg>
+<figcaption>The two highlighted fields are the only ones written after the audio. Everything else is fixed at open; a crash costs the lengths, never the samples.</figcaption>
+</figure>
+
+## The tolerant reader
+
+Writing crash-safe files is only half the contract — something has to read them
+back, including the ones a crash left un-patched. `ReadWAVSamples` is that reader,
+and it is written to tolerate exactly the damage the writer's crash story
+produces. GopherTrunk uses it in the normalize pass (measuring a finished WAV
+before rewriting it) and anywhere a recording is re-opened, so its tolerance is
+load-bearing, not decorative.
+
+Two design choices make it robust. First, it **walks the RIFF chunks** rather
+than assuming the canonical fixed layout. It steps chunk-by-chunk from byte 12,
+reading each `id`+`size`, and only acts on `fmt ` and `data` — so an extra chunk
+some other encoder slipped in before `data` is skipped, not fatal. Second, and
+this is the one that matters for our crash: when a chunk's declared size runs
+past the end of the file, it **clamps to what's actually present** instead of
+indexing out of bounds:
+
+```go
+// internal/voice/wav.go (shape)
+for pos := 12; pos+8 <= len(b); {
+    id := string(b[pos : pos+4])
+    size := int(binary.LittleEndian.Uint32(b[pos+4 : pos+8]))
+    body := pos + 8
+    if size < 0 || body+size > len(b) {
+        // Truncated final chunk (e.g. a crash before patchHeader):
+        // clamp to the bytes that actually exist.
+        size = len(b) - body
+    }
+    switch id {
+    case "fmt ":
+        // …parse format, channels, sampleRate, bits…
+    case "data":
+        dataStart, dataLen = body, size
+    }
+    pos = body + size + (size & 1) // chunks are word-aligned
+}
+```
+
+That clamp is the reader's half of the length-last bargain. A crashed file has a
+`data` size field of zero — but the *bytes are there*, past the header. Because
+the walk clamps `size` to `len(b) - body`, the reader recovers every sample that
+was flushed, regardless of what the (un-patched, zero) length field claims. The
+`size < 0` guard catches a garbage length that overflows `int`; the `size & 1`
+step keeps the walk word-aligned across padded chunks.
+
+The tolerance has limits, and they are deliberate: after the walk it insists on
+16-bit mono PCM (`channels == 1`, `bits == 16`, `format == 1`) — the recorder's
+own output contract — and errors out otherwise. It will forgive a truncated file
+it wrote; it will not silently misread a stereo or float WAV as if it were the
+format it expects. Tolerant about damage, strict about type.
+
+## Shaping the cut: the fade tail
+
+Everything above is about *not losing* audio. `finalizeLocked` is where the
+recorder decides how the audio *ends*. A decoded digital over that stops
+mid-waveform leaves a non-zero final sample, and a hard jump from that value to
+silence is a step discontinuity — an audible click or scratch on playback, most
+obvious on short overs where the tail is a big fraction of the call.
+
+The fix is a short linear ramp appended at finalize, the digital counterpart of
+the squelch-tail fade the analog FM chain already applies in the composer (owned
+by [Voice Coding Part 9]({{ '/blog/deep-dives/voice-coding-09-the-composer/' | relative_url }})).
+The recorder tracks `lastSample` — the most recent decoded PCM value — and on
+close builds a ~10 ms ramp from it down to zero:
+
+```go
+// internal/voice/recorder.go (shape)
+func fadeTail(from int16, n int) []int16 {
+    if from == 0 || n <= 0 {
+        return nil // already at silence, or nothing to ramp
+    }
+    out := make([]int16, n)
+    start := float64(from)
+    for i := range out {
+        out[i] = int16(start * (1.0 - float64(i)/float64(n)))
+    }
+    return out
+}
+```
+
+Finalize sizes `n` as `sampleRate/100` (≈10 ms, floored at 8 samples), writes the
+ramp to the WAV, and — importantly — fans the same tail to the live decoded-PCM
+sink so the browser stream ends as cleanly as the file does. The guards keep it
+honest: it runs only for vocoder-decoded calls (`s.vocoder != nil`) with real
+audio (`dataBytes > 0`), and a dead-key call has `lastSample == 0`, so `fadeTail`
+returns `nil` and appends nothing. `TestRecorderFadesDigitalTailToZero` and
+`TestFadeTail` pin the ramp's first sample to `from` (seamless continuation) and
+its shape down to zero.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 180" width="660" height="180" role="img" aria-label="Timeline of a short over. Decoded PCM samples run flat then stop abruptly at a non-zero level; the recorder appends a roughly ten millisecond linear fade ramp from that last sample value down to zero, so the file ends at silence instead of a step discontinuity that would click on playback.">
+  <line x1="30" y1="150" x2="640" y2="150" stroke="var(--fg-muted)"/>
+  <line x1="30" y1="30" x2="30" y2="150" stroke="var(--fg-muted)"/>
+  <text x="20" y="34" text-anchor="end" fill="var(--fg-muted)" font-size="8">+</text>
+  <text x="20" y="92" text-anchor="end" fill="var(--fg-muted)" font-size="8">0</text>
+  <polyline points="30,92 70,70 110,105 150,72 190,108 230,74 270,104 310,70 350,100 390,78 430,96" fill="none" stroke="currentColor"/>
+  <text x="230" y="128" text-anchor="middle" fill="var(--fg-muted)" font-size="9">decoded PCM (the over)</text>
+  <circle cx="430" cy="96" r="3" fill="var(--accent)"/>
+  <text x="430" y="88" text-anchor="middle" fill="var(--accent)" font-size="8">lastSample</text>
+  <line x1="430" y1="96" x2="520" y2="92" stroke="var(--accent)" stroke-width="1.5"/>
+  <text x="475" y="120" text-anchor="middle" fill="var(--accent)" font-size="9">~10 ms fade → 0</text>
+  <line x1="430" y1="150" x2="430" y2="60" stroke="var(--fg-muted)" stroke-dasharray="3 3"/>
+  <line x1="520" y1="92" x2="640" y2="92" stroke="var(--fg-muted)" stroke-dasharray="3 3"/>
+  <text x="580" y="86" text-anchor="middle" fill="var(--fg-muted)" font-size="9">silence</text>
+  <text x="335" y="172" text-anchor="middle" fill="var(--fg-muted)" font-size="9">Without the ramp, the jump from lastSample to zero is a step discontinuity — an audible click.</text>
+</svg>
+<figcaption>The fade is appended at finalize, not computed in the DSP: the last decoded sample is ramped to zero over ~10 ms on both the WAV and the live stream.</figcaption>
+</figure>
+
+## What the recorder refuses to keep
+
+The last set of finalize decisions is about *suppression* — the calls whose files
+should never survive. Two cases produce no `CallComplete` and, in the worse case,
+delete what was written.
+
+**Empty files.** If `dataBytes == 0` — no PCM was ever decoded into the WAV —
+there is nothing to stream. `finalizeLocked` returns `nil` (no `CallComplete`, so
+no upload). A digital call keeps its `.raw` sidecar as the only capture; an analog
+call simply produced nothing. Because the recorder opens files lazily on the
+first write (covered in
+[Part 4]({{ '/blog/deep-dives/recording-streaming-04-recording-session/' | relative_url }})),
+a truly silent grant usually never creates a file at all —
+`TestRecorderNoAudioLeavesNoFiles` and `TestRecorderNoAudioLeavesNoDir` confirm
+it leaves not even an empty talkgroup directory.
+
+**Dead-key / idle carriers.** Subtler is a call that *did* write PCM but is
+worthless: a vocoder that decoded frames, all of which were idle, silent, or bad —
+`Voiced + Unvoiced == 0`. The WAV holds only muted silence. In per-transmission
+mode these are the dominant source of tiny-file spam. When the session's vocoder
+implements `StatProvider` (the pure-Go IMBE decoder) and reports zero voiced and
+unvoiced frames, `removeSessionFiles` deletes both the WAV and the `.raw`
+sidecar, and finalize returns `nil`:
+
+```go
+// internal/voice/recorder.go (shape)
+if haveStats && vs.Voiced+vs.Unvoiced == 0 {
+    r.removeSessionFiles(s) // dead-key: delete WAV + .raw
+    return nil              // no CallComplete
+}
+if dataBytes == 0 {
+    return nil // empty: nothing to stream, keep any .raw
+}
+return &trunking.CallComplete{ /* Grant, AudioPath, SampleRate, … */ }
+```
+
+Alongside these, finalize runs a **diagnostic** that changes nothing on disk but
+catches a real bug class: the audio-vs-wall-clock check. For a decoded call it
+compares the WAV's audio seconds (`dataBytes / (sampleRate * 2)`) against the
+call's wall-clock span. When the audio is under 75% of the wall time on a call
+longer than a second, it logs at DEBUG — the self-evident "16 s call, 9 s
+recording" symptom that means voice frames were lost upstream (talkgroup gating,
+undecoded windows) rather than a genuinely short over. It's DEBUG, not WARN,
+because a legitimate multi-over call drops the silent gaps between overs; this is
+an investigation aid, not an alarm.
+
+## Where this goes next
+
+[Part 6]({{ '/blog/deep-dives/recording-streaming-06-segmentation-naming-sidecars/' | relative_url }})
+zooms out from one file to the filesystem: how a call maps to a
+`<system>/<talkgroup>/<timestamp>_freq_src` path, how per-transmission recording
+rolls each over into its own file, and why DMR, ProVoice, and TETRA always get a
+`.raw` sidecar written alongside — the on-air frames that must survive even when
+no playable WAV can be produced.
+
+## FAQ
+
+**What happens to a WAV if GopherTrunk crashes mid-call?**
+The file on disk is a valid 44-byte header followed by every sample that was
+flushed, with the two length fields (RIFF size at byte 4, data size at byte 40)
+still zero because `Close()` never ran to patch them. GopherTrunk's own
+`ReadWAVSamples` clamps the truncated `data` chunk and reads every recovered
+sample; a strict third-party player may see a length-zero file but the audio is
+physically intact.
+
+**Why patch the header on close instead of writing it correctly up front?**
+Because the recorder can't know the call's length until the call ends — it's a
+live stream. Writing the header last (with zeroed length placeholders) means a
+crash costs only the length fields, whereas buffering the whole call to write one
+correct header would lose the entire recording on a crash.
+
+**Why does a short over need a fade at the end?**
+A decoded over that stops mid-waveform leaves a non-zero final sample; jumping
+straight to silence is a step discontinuity that clicks on playback.
+`fadeTail` appends a ~10 ms linear ramp from that last sample to zero, on both the
+WAV and the live stream. A silent/dead-key call has a zero last sample, so no
+ramp is added.
+
+**Why does the recorder delete some recordings instead of keeping them?**
+A call that decoded no voiced or unvoiced frames (a dead-key or idle carrier)
+produced only muted silence — worthless audio and, in per-transmission mode, the
+main source of tiny-file spam. The recorder removes the WAV and `.raw` and
+publishes no `CallComplete`, so nothing downstream tries to upload an empty call.
+
+## Series navigation
+
+**Part 5 of 14** · ←
+[Part 4: The Recording Session]({{ '/blog/deep-dives/recording-streaming-04-recording-session/' | relative_url }})
+· Next →
+[Part 6: Segmentation, Naming & Raw Sidecars]({{ '/blog/deep-dives/recording-streaming-06-segmentation-naming-sidecars/' | relative_url }})

--- a/docs/_posts/2026-08-06-recording-streaming-06-segmentation-naming-sidecars.md
+++ b/docs/_posts/2026-08-06-recording-streaming-06-segmentation-naming-sidecars.md
@@ -1,0 +1,344 @@
+---
+title: "Recording, Composition & Streaming, Part 6: Segmentation, Naming & Raw Sidecars"
+description: How a trunked call maps to the filesystem in GopherTrunk — the system/talkgroup directory scheme, timezone-aware timestamped filenames tagged with frequency, source and timeslot, per-transmission file rolls, and the .raw sidecar written for DMR, ProVoice and TETRA.
+category: deep-dives
+keywords: sdr recording filename scheme, trunk recorder directory layout, per transmission recording, dmr timeslot recording, raw vocoder sidecar, ambe frame capture, talkgroup directory, timezone aware timestamp, gophertrunk recorder, provoice tetra raw
+tags: [recording, filesystem, dmr, sidecar, go, software-design]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Recording, Composition & Streaming"
+series_part: 6
+---
+
+*Part 6 of **Recording, Composition & Streaming**, a 14-part deep dive into
+GopherTrunk's output half.
+[Part 5]({{ '/blog/deep-dives/recording-streaming-05-wav-on-disk/' | relative_url }})
+was about one file's integrity; this post is about where that file lives and what
+it's named. When our 3 p.m. dispatch on talkgroup 101 hits disk, its path encodes
+the system, the talkgroup, the wall-clock instant, the RF frequency, the source
+radio, and — on a slotted protocol — the timeslot. And for protocols whose voice
+GopherTrunk can't render to a WAV, a `.raw` sidecar of on-air frames is written so
+the call is never lost.*
+
+> **TL;DR:** The recorder lays calls out Trunk-Recorder-style:
+> `<OutDir>/<system>/<talkgroup>/<timestamp>_freq<Hz>_src<src>[_ts<slot>].wav`.
+> The timestamp renders in the configured **display timezone**, the frequency and
+> source tags make a shared voice channel legible, and the `_ts` tag keeps DMR's
+> two concurrent slots from colliding. In **per-transmission** mode every over
+> rolls to a fresh file. DMR voice, EDACS ProVoice, and TETRA voice always get a
+> **`.raw` sidecar** — a flat concatenation of on-air vocoder frames — because
+> their audio either has no in-process decoder or must survive for out-of-band
+> tools regardless.
+
+**Key takeaways**
+
+- A call's directory is `<system>/<talkgroup>`, both **sanitized** for
+  cross-OS-safe paths; the talkgroup folder is the alpha tag when known, else the
+  decimal group ID.
+- The basename is a **timezone-aware timestamp** plus `_freq`, `_src`, and
+  optional `_ts` tags — enough to identify the physical channel and originator
+  from the filename alone.
+- **Per-transmission recording** rolls each over into its own file via a segment
+  event; a DMR carrier running two slots produces two independent session streams.
+- The **`.raw` sidecar** is a raw dump of vocoder frames with no surrounding
+  metadata, written for DMR/ProVoice/TETRA so an external decoder can consume it.
+
+## Cheat sheet
+
+| Thing | What it does | Where in code |
+|---|---|---|
+| `directoryFor` | Builds `<OutDir>/<system>/<talkgroup>` | `internal/voice/recorder.go` |
+| `basenameFor` | `<stamp>_freq<Hz>_src<src>[_ts<slot>]`, display-tz stamp | `internal/voice/recorder.go` |
+| `sanitize` | Maps unsafe runes to `_` for cross-OS paths | `internal/voice/recorder.go` |
+| `handleSegment` | Rolls the current over, parks a dormant session | `internal/voice/recorder.go` |
+| `rawWanted` | Marks a session for a `.raw` sidecar | `internal/voice/recorder.go` |
+| `dmrVoiceProtocol` / `tetraVoiceProtocol` | Force `.raw` even when `WriteRaw` is off | `internal/voice/recorder.go` |
+| `writeRawFrame` | Appends verbatim frames to `.raw` | `internal/voice/recorder.go` |
+
+## In this post
+
+- **The directory scheme** — system and talkgroup, and how each is chosen.
+- **The basename** — timestamp, timezone, and the `_freq`/`_src`/`_ts` tags.
+- **Per-transmission rolls** — one over, one file, via `handleSegment`.
+- **Raw sidecars** — who gets one, and why the format is deliberately bare.
+- **DMR's two slots** — one carrier, two concurrent sessions, distinct files.
+
+## The directory: system, then talkgroup
+
+Every recording lands under a two-level tree beneath the recordings directory:
+`<OutDir>/<system>/<talkgroup>`. `directoryFor` builds it from the call's grant:
+
+```go
+// internal/voice/recorder.go (shape)
+func (r *Recorder) directoryFor(cs trunking.CallStart) string {
+    system := sanitize(cs.Grant.System)
+    if system == "" {
+        system = "unknown-system"
+    }
+    tgDir := fmt.Sprintf("%d", cs.Grant.GroupID)
+    if cs.Talkgroup != nil && cs.Talkgroup.AlphaTag != "" {
+        tgDir = sanitize(cs.Talkgroup.AlphaTag)
+    }
+    return filepath.Join(r.outDir, system, tgDir)
+}
+```
+
+Two choices are worth calling out. First, the talkgroup folder prefers the
+human-readable **alpha tag** when the engine resolved one (`Talkgroup != nil` and
+a non-empty `AlphaTag`), falling back to the raw decimal `GroupID` when it didn't.
+So a configured system browses as `PD Dispatch/` and `Fire Tac 2/`, while an
+unlabelled talkgroup on an unconfigured system still records cleanly as `1234/`.
+Second, everything user-derived passes through `sanitize`, which maps anything
+outside `[A-Za-z0-9._-]` to an underscore — a system named `Metro (North)` becomes
+`Metro__North_`, safe on every filesystem GopherTrunk targets.
+
+Crucially, `directoryFor` only *computes* the path. The directory is **not
+created here** — it's made lazily in `openSessionFiles`, just before the first
+file is opened, which is on the first write. A grant that's followed but never
+yields audio (a dead-key, an aborted encrypted call, a tap parked off-frequency
+while a hunt borrows the SDR) therefore leaves **no empty `<system>/<talkgroup>`
+folder** behind. The tree only ever contains directories that hold a real
+recording.
+
+## The basename: a self-documenting filename
+
+`basenameFor` builds the filename stem. It starts from a timestamp and appends
+tags until the name uniquely and legibly identifies the call:
+
+```go
+// internal/voice/recorder.go (shape)
+func (r *Recorder) basenameFor(cs trunking.CallStart) string {
+    stamp := t.In(r.displayLoc).Format("20060102T150405Z0700")
+    base := stamp
+    if cs.Grant.FrequencyHz != 0 {
+        base = fmt.Sprintf("%s_freq%d", base, cs.Grant.FrequencyHz)
+    }
+    base = fmt.Sprintf("%s_src%d", base, cs.Grant.SourceID)
+    if cs.Grant.Timeslot != 0 {
+        base = fmt.Sprintf("%s_ts%d", base, cs.Grant.Timeslot)
+    }
+    return base
+}
+```
+
+Each piece earns its place:
+
+- **The timestamp renders in the display timezone.** `displayLoc` comes from
+  `display.timezone` (via `DisplayConfig.Location()`); it defaults to UTC when
+  unset. Formatting in local wall-clock time means the filename matches the
+  timestamps the rest of the UI and logs already show — no mental UTC conversion
+  when you're scrubbing through a directory listing. The `Z0700` zone token keeps
+  the stamp self-documenting and **filename-safe** (no colon): UTC formats as a
+  literal `Z`, other zones as a numeric offset like `+1000`.
+  `TestRecorderBasenameTimezone` locks this in.
+- **`_freq<Hz>`** tags the RF voice-channel frequency. On a trunked system the
+  voice frequencies are a shared pool — many talkgroups cycle through the same
+  physical channels — so stamping the frequency on each file tells you which
+  channel a recording came from. Omitted when the grant frequency is unknown (0).
+  `TestRecorderFrequencyInFilename` covers it.
+- **`_src<src>`** is the source radio ID (the originating subscriber unit),
+  always present.
+- **`_ts<slot>`** is appended only for slotted protocols (`Timeslot != 0`). This
+  is the collision-breaker described below; `TestRecorderTimeslotInWavName`
+  asserts it lands in the name.
+
+The WAV path is then `filepath.Join(dir, base+".wav")`, and — for the protocols
+below — the sidecar is `base+".raw"` in the same directory.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 620 210" width="620" height="210" role="img" aria-label="A directory tree. The recordings root contains a system folder named Metro P25, which contains two talkgroup folders: PD Dispatch and Fire Tac 2. PD Dispatch holds one WAV file with a timestamp, frequency and source tag. Fire Tac 2 holds two files sharing a timestamp but distinguished by timeslot tags ts1 and ts2, each paired with a matching raw sidecar file.">
+  <text x="20" y="24" fill="var(--fg-muted)" font-size="10">recordings/</text>
+  <line x1="26" y1="30" x2="26" y2="188" stroke="var(--fg-muted)"/>
+  <rect x="40" y="34" width="120" height="24" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="100" y="50" text-anchor="middle" fill="var(--accent)" font-size="10">Metro_P25/</text>
+  <line x1="52" y1="58" x2="52" y2="176" stroke="var(--fg-muted)"/>
+  <rect x="66" y="66" width="120" height="22" rx="6" fill="none" stroke="currentColor"/>
+  <text x="126" y="81" text-anchor="middle" fill="currentColor" font-size="10">PD_Dispatch/</text>
+  <line x1="78" y1="88" x2="78" y2="104" stroke="var(--fg-muted)"/>
+  <rect x="92" y="98" width="300" height="20" rx="5" fill="none" stroke="var(--fg-muted)"/>
+  <text x="102" y="112" fill="var(--fg-muted)" font-size="8.5">20260722T150000-0500_freq851012500_src4021.wav</text>
+  <rect x="66" y="126" width="120" height="22" rx="6" fill="none" stroke="currentColor"/>
+  <text x="126" y="141" text-anchor="middle" fill="currentColor" font-size="10">Fire_Tac_2/</text>
+  <line x1="78" y1="148" x2="78" y2="200" stroke="var(--fg-muted)"/>
+  <rect x="92" y="152" width="330" height="18" rx="5" fill="none" stroke="var(--accent)"/>
+  <text x="100" y="165" fill="var(--accent)" font-size="8.5">…T151233-0500_freq851262500_src310_ts1.wav + .raw</text>
+  <rect x="92" y="176" width="330" height="18" rx="5" fill="none" stroke="var(--accent)"/>
+  <text x="100" y="189" fill="var(--accent)" font-size="8.5">…T151233-0500_freq851262500_src512_ts2.wav + .raw</text>
+  <text x="470" y="162" fill="var(--fg-muted)" font-size="9">same second,</text>
+  <text x="470" y="176" fill="var(--fg-muted)" font-size="9">split by _ts</text>
+</svg>
+<figcaption>Two talkgroups under one system. Fire Tac 2 is a DMR carrier: two concurrent slots share a timestamp but are kept distinct by the <code>_ts1</code>/<code>_ts2</code> tag, each with its own <code>.raw</code> sidecar.</figcaption>
+</figure>
+
+## Per-transmission rolls
+
+By default a call is one continuous recording. But in **transmission** grouping
+mode the composer publishes a `KindCallSegment` at each end-of-over boundary, and
+the recorder rolls to a new file. `handleSegment` finalizes the current file and
+parks a dormant session that carries the call's identity forward:
+
+```go
+// internal/voice/recorder.go (shape)
+func (r *Recorder) handleSegment(seg trunking.CallSegment) {
+    s, ok := r.sessions[seg.DeviceSerial]
+    if !ok || s.wav == nil {
+        return // nothing open to roll
+    }
+    cc := r.finalizeLocked(s, seg.DeviceSerial, seg.At, trunking.EndReasonNormal)
+    // Park a dormant session: same cs + callID, no open files yet.
+    r.sessions[seg.DeviceSerial] = &recordingSession{cs: s.cs, callID: s.callID}
+    // …publish CallComplete for the finished over…
+}
+```
+
+The parked session has `wav == nil` and no paths. The next write on that serial
+finds it dormant and opens a **fresh file under a new timestamp** — reusing the
+same grant and talkgroup but with `basenameFor` stamping the roll's own start
+time. This is why segmentation never leaves a trailing empty file: the next over's
+file isn't created until audio actually arrives for it. Each finished over is a
+complete, closed, `CallComplete`-published recording in its own right.
+`TestRecorderSegmentRollsToNewFile` walks exactly this: one call, a segment event,
+two distinct files.
+
+## The raw sidecar
+
+For some protocols the WAV isn't enough — or isn't possible. The `.raw` sidecar
+is a **flat concatenation of on-air vocoder frames**, written verbatim with no
+surrounding metadata, so an operator can bring their own decoder (external libmbe,
+DVSI hardware, DSD-FME) and consume the file directly. `buildSession` decides
+whether a call wants one:
+
+```go
+// internal/voice/recorder.go (shape)
+if r.writeRaw || cs.Grant.ProVoice ||
+    dmrVoiceProtocol(cs.Grant.Protocol) ||
+    tetraVoiceProtocol(cs.Grant.Protocol) {
+    s.rawPath = filepath.Join(dir, base+".raw")
+    s.rawWanted = true
+}
+```
+
+Four ways to earn a sidecar, and the reasons differ:
+
+- **`recordings.write_raw` is on** (`r.writeRaw`) — the operator wants raw frames
+  for every digital call, alongside the decoded WAV.
+- **EDACS ProVoice** (`cs.Grant.ProVoice`) — the ProVoice vocoder is patent- and
+  trade-secret-encumbered, so GopherTrunk ships **no** built-in decoder. The
+  sidecar is the *only* capture of the call; without it, a ProVoice grant would
+  produce nothing usable.
+- **DMR voice** (`dmr-tier1/2/3`) — DMR *does* have an in-process AMBE+2 decoder,
+  so it gets a playable WAV, but it *also* always gets a sidecar so the on-air
+  AMBE frames remain available for out-of-band tools.
+- **TETRA voice** — no in-process vocoder yet (TCH/S FEC + ACELP are follow-ups),
+  so like ProVoice the `.raw` of full-slot traffic frames is the only capture.
+
+`rawWanted` is recorded at session-build time, but — like the WAV — the file is
+opened **lazily** in `openSessionFiles`, so a call that never emits a frame leaves
+no 0-byte `.raw` behind. Once open, every `writeRawFrame` appends the frame bytes
+directly to it:
+
+```go
+// internal/voice/recorder.go (shape)
+func (r *Recorder) writeRawFrame(deviceSerial string, callID uint64, frame []byte, /*…*/) error {
+    s := r.sessionForWrite(deviceSerial, callID)
+    if s == nil {
+        return nil
+    }
+    if s.raw != nil {
+        if _, err := s.raw.Write(frame); err != nil {
+            return err
+        }
+    }
+    // …then fan to the live raw tap, and decode into the WAV if a vocoder exists…
+}
+```
+
+The sidecar and the WAV are independent outputs of the same frame stream: the raw
+write happens first and unconditionally (for any open session with a sidecar),
+then the frame is decoded into PCM for the WAV if a vocoder was instantiated.
+`TestRecorderRawFrameSidecar`, `TestRecorderProVoiceForcesRawSidecar`, and
+`TestRecorderNonProVoiceSkipsRawWhenDisabled` pin the who-gets-one matrix.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 640 200" width="640" height="200" role="img" aria-label="A single DMR carrier feeds two concurrent recording sessions, one per timeslot. Timeslot 1's frames flow to a session that writes both a ts1 WAV and a ts1 raw sidecar; timeslot 2's frames flow to a separate session that writes a ts2 WAV and a ts2 raw sidecar. The two sessions are keyed by distinct device serials and never share a file.">
+  <rect x="16" y="80" width="110" height="40" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="71" y="98" text-anchor="middle" fill="var(--accent)" font-size="10">DMR carrier</text>
+  <text x="71" y="112" text-anchor="middle" fill="var(--fg-muted)" font-size="8">TS1 + TS2 slots</text>
+  <line x1="126" y1="94" x2="176" y2="58" stroke="currentColor"/><polygon points="172,54 182,56 176,64" fill="currentColor"/>
+  <line x1="126" y1="106" x2="176" y2="146" stroke="currentColor"/><polygon points="176,140 182,150 170,149" fill="currentColor"/>
+  <rect x="182" y="36" width="130" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="247" y="55" text-anchor="middle" fill="currentColor" font-size="10">session (serial A)</text>
+  <text x="247" y="69" text-anchor="middle" fill="var(--fg-muted)" font-size="8">callID 1 · ts1</text>
+  <rect x="182" y="126" width="130" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="247" y="145" text-anchor="middle" fill="currentColor" font-size="10">session (serial B)</text>
+  <text x="247" y="159" text-anchor="middle" fill="var(--fg-muted)" font-size="8">callID 2 · ts2</text>
+  <line x1="312" y1="50" x2="356" y2="42" stroke="currentColor"/><polygon points="356,38 366,42 355,46" fill="currentColor"/>
+  <line x1="312" y1="66" x2="356" y2="76" stroke="currentColor"/><polygon points="355,72 366,76 354,80" fill="currentColor"/>
+  <rect x="366" y="30" width="150" height="22" rx="5" fill="none" stroke="var(--accent)"/><text x="441" y="45" text-anchor="middle" fill="var(--accent)" font-size="9">…_ts1.wav</text>
+  <rect x="366" y="60" width="150" height="22" rx="5" fill="none" stroke="var(--fg-muted)"/><text x="441" y="75" text-anchor="middle" fill="var(--fg-muted)" font-size="9">…_ts1.raw</text>
+  <line x1="312" y1="140" x2="356" y2="132" stroke="currentColor"/><polygon points="356,128 366,132 355,136" fill="currentColor"/>
+  <line x1="312" y1="156" x2="356" y2="166" stroke="currentColor"/><polygon points="355,162 366,166 354,170" fill="currentColor"/>
+  <rect x="366" y="120" width="150" height="22" rx="5" fill="none" stroke="var(--accent)"/><text x="441" y="135" text-anchor="middle" fill="var(--accent)" font-size="9">…_ts2.wav</text>
+  <rect x="366" y="150" width="150" height="22" rx="5" fill="none" stroke="var(--fg-muted)"/><text x="441" y="165" text-anchor="middle" fill="var(--fg-muted)" font-size="9">…_ts2.raw</text>
+  <text x="558" y="98" text-anchor="middle" fill="var(--fg-muted)" font-size="9">distinct files</text>
+  <text x="558" y="112" text-anchor="middle" fill="var(--fg-muted)" font-size="9">per slot</text>
+</svg>
+<figcaption>One DMR carrier, two concurrent calls. Each slot is a separate session keyed by its own device serial and CallID, producing its own <code>_ts</code>-tagged WAV plus a matching <code>.raw</code> sidecar.</figcaption>
+</figure>
+
+## Why DMR's two slots don't collide
+
+DMR Tier III runs **two concurrent calls on one physical carrier** — TS1 and TS2.
+If those two calls happen to share a talkgroup (same directory) and start in the
+same wall-clock second, their `stamp_freq_src` basenames would be identical and
+one would clobber the other. The `_ts<slot>` tag exists precisely to break that
+tie: each slot's file is distinct and self-labelling. And because each slot is
+followed by its own voice tap with its own device serial, the recorder already
+holds them as two independent sessions — the naming tag is the on-disk half of a
+separation the session map enforces in memory. (That per-serial identity, and the
+CallID that fences one slot's frames from the other's, is the subject of
+[Part 7]({{ '/blog/deep-dives/recording-streaming-07-correctness-guards/' | relative_url }}).)
+
+## Where this goes next
+
+[Part 7]({{ '/blog/deep-dives/recording-streaming-07-correctness-guards/' | relative_url }})
+turns to the subtle safety machinery that keeps all this honest: the CallID fence
+that stops a reused voice-tap serial from bleeding one call's tail into the next,
+mid-stream encryption abort-and-delete, grant backfill for late-resolving IDs, and
+runtime record on/off that never drops an in-flight call.
+
+## FAQ
+
+**How is a recording's filename structured?**
+`<OutDir>/<system>/<talkgroup>/<timestamp>_freq<Hz>_src<src>[_ts<slot>].wav`. The
+timestamp is the call's start rendered in the configured display timezone (a
+filename-safe `Z0700` stamp), `_freq` is the RF voice-channel frequency, `_src` is
+the originating radio ID, and `_ts` is appended only for slotted protocols like
+DMR. The talkgroup folder is the alpha tag when known, else the decimal group ID.
+
+**What is the `.raw` sidecar and which calls get one?**
+It's a flat, metadata-free concatenation of on-air vocoder frames written next to
+the WAV, so you can decode it with external tools. It's written when
+`recordings.write_raw` is on, and always for EDACS ProVoice, DMR voice, and TETRA
+voice — protocols whose audio either has no in-process decoder (ProVoice, TETRA)
+or must remain available as raw AMBE regardless (DMR).
+
+**Does per-transmission recording create a separate file per over?**
+Yes. In transmission grouping the composer emits a `KindCallSegment` at each
+end-of-over boundary; the recorder finalizes the current file, publishes its
+`CallComplete`, and parks a dormant session that opens a fresh file — under a new
+timestamp — when the next over's audio arrives. No trailing empty file is left if
+the call ends first.
+
+**Why do DMR TS1 and TS2 recordings not overwrite each other?**
+The `_ts<slot>` tag makes each slot's filename unique even when both calls share a
+talkgroup and start in the same second, and internally the two slots are separate
+recording sessions keyed by distinct voice-tap serials. The naming tag is the
+on-disk expression of a separation the recorder already maintains in memory.
+
+## Series navigation
+
+**Part 6 of 14** · ←
+[Part 5: WAV on Disk]({{ '/blog/deep-dives/recording-streaming-05-wav-on-disk/' | relative_url }})
+· Next →
+[Part 7: Correctness Guards]({{ '/blog/deep-dives/recording-streaming-07-correctness-guards/' | relative_url }})

--- a/docs/_posts/2026-08-07-recording-streaming-07-correctness-guards.md
+++ b/docs/_posts/2026-08-07-recording-streaming-07-correctness-guards.md
@@ -1,0 +1,372 @@
+---
+title: "Recording, Composition & Streaming, Part 7: Correctness Guards — Cross-Call Fencing, Encryption Skip & Runtime Toggles"
+description: The subtle safety machinery in GopherTrunk's recorder and audio publisher — a CallID fence that stops a reused voice-tap serial bleeding one call's tail into the next, mid-stream encryption abort-and-delete, grant backfill for late-resolving IDs, and runtime record on/off that never drops an in-flight call.
+category: deep-dives
+keywords: cross call audio bleed, callid fence, voice tap serial reuse, mid call encryption abort, encrypted call skip, grant backfill, runtime recording toggle, talkgroup record gate, gophertrunk recorder guards, live audio fencing
+tags: [recording, correctness, encryption, concurrency, go, software-design]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Recording, Composition & Streaming"
+series_part: 7
+---
+
+*Part 7 of **Recording, Composition & Streaming**, a 14-part deep dive into
+GopherTrunk's output half. Parts 4–6 built the recording session, the crash-safe
+WAV, and the on-disk naming. This post is about the guards that keep them correct
+under adversarial timing: a voice tap whose serial gets reused before the old
+call drained, a call that turns out to be encrypted halfway through, IDs that
+resolve late, and an operator flipping recording off mid-conversation. None of
+these is visible in a happy-path recording of our 3 p.m. dispatch — they're the
+machinery that makes sure the file you get is *that* call's audio and nothing
+else's.*
+
+> **TL;DR:** Wideband voice taps reuse a small pool of device serials, so a frame
+> from a just-ended call can arrive after the next call has claimed the same
+> serial. GopherTrunk fences this with the **CallID**: `sessionForWrite` rejects a
+> frame whose `callID` doesn't match the open session, and the live
+> `AudioPublisher` applies the **same fence** on `WritePCMForCall`/`WriteRawFrameForCall`.
+> When `skip_encrypted` is set and a call is discovered encrypted mid-stream, the
+> recorder **closes and deletes** the partial and publishes no `CallComplete`.
+> Late-resolving RID/ALG/KID are **backfilled** onto the session's grant so the
+> eventual `CallComplete` is accurate, and recording can be toggled at runtime
+> **without truncating** in-flight calls.
+
+**Key takeaways**
+
+- The **CallID fence** is enforced in two independent places — the recorder's
+  `sessionForWrite` (the WAV/`.raw` side) and the audio publisher's `writePCM`/
+  `writeRaw` (the live side) — because a reused serial can bleed audio into
+  *either* sink.
+- **Encryption is handled at two moments**: a grant that already signals
+  encryption never opens a file; encryption discovered mid-call closes and
+  `os.Remove`s the partial and suppresses `CallComplete`.
+- **Backfill** mirrors late-resolved source ID and encryption facts onto the
+  session's stored grant, so a Phase 2 compressed grant that resolves on the
+  traffic channel doesn't broadcast as `encrypted=false`.
+- **Runtime toggles are graceful**: disabling recording drops *new* `CallStart`s
+  but lets in-flight sessions finish; the per-talkgroup `Record` flag gates files
+  without silencing live audio.
+
+## Cheat sheet
+
+| Guard | What it stops | Where in code |
+|---|---|---|
+| CallID fence (recorder) | Stale frame → wrong WAV/`.raw` | `sessionForWrite` (`internal/voice/recorder.go`) |
+| CallID fence (live) | Stale frame → wrong live stream | `writePCM`/`writeRaw` (`internal/api/audio_publisher.go`) |
+| Mid-call encryption abort | Encrypted partial reaching uploads | `handleEncryptionUpdate` (`internal/voice/recorder.go`) |
+| Grant backfill | Inaccurate `CallComplete` metadata | `backfillSessionGrant` (`internal/voice/recorder.go`) |
+| Runtime record gate | Losing the head of a mid-call disable | `SetRecordingEnabled` / `recordDisabled` |
+| Talkgroup `Record` gate | Writing files for no-record talkgroups | `handleStart` (`internal/voice/recorder.go`) |
+
+## In this post
+
+- **The reused-serial problem** — why a valid frame can belong to the wrong call.
+- **The CallID fence**, enforced twice: on disk and on the live stream.
+- **Encryption**, at grant time and mid-stream — abort, delete, suppress.
+- **Backfill** — making the finished-call metadata match what the engine learned late.
+- **Runtime toggles** — record on/off and per-talkgroup gating without collateral.
+
+## The reused-serial problem
+
+A recording session is keyed by **device serial** — which voice SDR (or wideband
+voice tap) is following the call. That key is stable and cheap, but it has a sharp
+edge: wideband taps draw from a **fixed pool** of serials. When one call ends and
+the next grant reuses the same tap, the recorder's `sessions[serial]` is
+re-pointed at the new call — while the *previous* call's decode chain may still be
+draining a few final frames. Those frames are valid audio; they just belong to a
+call that's over. Delivered naively, they'd be appended to the new call's WAV, and
+fanned to live subscribers **filtered on the new call's talkgroup** — one call's
+tail bleeding into another's stream, mislabelled.
+
+The engine already carries the thing needed to tell them apart: `Grant.CallID`, a
+process-monotonic identifier the voice pool assigns per call. The guard is to
+stamp each session with its `CallID` and reject any frame that arrives claiming a
+different one.
+
+## The CallID fence, on disk
+
+Every write path funnels through `sessionForWrite`, which does the matching under
+the recorder's lock:
+
+```go
+// internal/voice/recorder.go (shape)
+func (r *Recorder) sessionForWrite(serial string, callID uint64) *recordingSession {
+    r.mu.Lock()
+    defer r.mu.Unlock()
+    s, ok := r.sessions[serial]
+    if !ok {
+        return nil
+    }
+    if callID != 0 && s.callID != 0 && callID != s.callID {
+        return nil // stale frame from the call that previously held this serial
+    }
+    // …lazily open files / return the live session…
+}
+```
+
+The rule is deliberately permissive at the edges: a **zero on either side
+matches**. A zero incoming `callID` (an analog or synthetic call that doesn't
+stamp one) or a zero session `callID` preserves the old behaviour for callers that
+never opted in. Only when *both* are non-zero and they differ is the frame
+rejected — and it's rejected **without reopening a dormant session**, so a
+mismatched frame can't even spawn an empty file. Digital voice chains that know
+their call's identity call `WriteRawFrameForCall(serial, callID, …)` in preference
+to the plain form; the fence is invisible to everyone else.
+`TestRecorderCallIDFenceDropsStaleFrames` reproduces the reuse and asserts the
+stale frame lands nowhere.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 200" width="660" height="200" role="img" aria-label="A timeline of one voice-tap serial reused across two calls. Call A holds the serial and is stamped CallID 1; near its end the tap is reassigned to Call B, stamped CallID 2, so the session map now points at Call B. A few of Call A's final decoded frames, still stamped CallID 1, arrive after the flip; the fence compares their CallID 1 against the session's CallID 2, they mismatch, and the frames are dropped instead of being written to Call B's file or stream.">
+  <line x1="30" y1="60" x2="630" y2="60" stroke="currentColor"/>
+  <text x="30" y="48" fill="var(--fg-muted)" font-size="9">tap serial "voice-0"</text>
+  <line x1="150" y1="52" x2="150" y2="150" stroke="var(--fg-muted)" stroke-dasharray="3 3"/>
+  <text x="150" y="166" text-anchor="middle" fill="var(--fg-muted)" font-size="8">serial reassigned</text>
+  <rect x="40" y="66" width="200" height="26" rx="6" fill="none" stroke="currentColor"/>
+  <text x="140" y="83" text-anchor="middle" fill="currentColor" font-size="10">Call A · CallID 1</text>
+  <rect x="150" y="100" width="300" height="26" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="300" y="117" text-anchor="middle" fill="var(--accent)" font-size="10">Call B · CallID 2 (session now)</text>
+  <circle cx="200" cy="60" r="4" fill="currentColor"/>
+  <circle cx="230" cy="60" r="4" fill="currentColor"/>
+  <text x="215" y="34" text-anchor="middle" fill="var(--fg-muted)" font-size="8">A's draining frames</text>
+  <text x="215" y="44" text-anchor="middle" fill="var(--fg-muted)" font-size="8">(still CallID 1)</text>
+  <line x1="200" y1="64" x2="230" y2="98" stroke="var(--fg-muted)" stroke-dasharray="2 2"/>
+  <line x1="230" y1="64" x2="255" y2="98" stroke="var(--fg-muted)" stroke-dasharray="2 2"/>
+  <rect x="470" y="96" width="170" height="34" rx="6" fill="none" stroke="currentColor"/>
+  <text x="555" y="112" text-anchor="middle" fill="currentColor" font-size="9">fence: 1 ≠ 2 → drop</text>
+  <text x="555" y="124" text-anchor="middle" fill="var(--fg-muted)" font-size="8">no WAV, no live stream</text>
+  <line x1="450" y1="113" x2="470" y2="113" stroke="currentColor"/><polygon points="470,109 480,113 470,117" fill="currentColor"/>
+  <text x="335" y="192" text-anchor="middle" fill="var(--fg-muted)" font-size="9">A zero CallID on either side matches — the fence only fires when both are known and differ.</text>
+</svg>
+<figcaption>The reused serial points the session at Call B, but Call A's late frames still carry CallID 1. The fence compares against the session's CallID 2 and drops them.</figcaption>
+</figure>
+
+## The same fence, on the live stream
+
+The WAV isn't the only sink a stale frame can poison. The live
+[audio publisher]({{ '/blog/deep-dives/recording-streaming-12-live-listening/' | relative_url }})
+fans decoded PCM (and, for opted-in subscribers, raw frames) to gRPC/HTTP
+listeners — and it filters by talkgroup. A stale frame fanned out here would be
+labelled with, and leaked to subscribers filtered on, the *new* call's talkgroup.
+So the publisher enforces a **matching fence**, keyed the same way, against the
+grant map its own bus subscription maintains:
+
+```go
+// internal/api/audio_publisher.go (shape)
+func (p *AudioPublisher) writePCM(deviceSerial string, callID uint64, samples []int16) error {
+    p.mu.RLock()
+    defer p.mu.RUnlock()
+    grant, haveGrant := p.grants[deviceSerial]
+    // The serial's live grant has moved to a different call — drop the old tail.
+    if haveGrant && callID != 0 && grant.CallID != 0 && callID != grant.CallID {
+        return nil
+    }
+    // …fan to matching subscribers…
+}
+```
+
+`writeRaw` carries the identical check. The recorder hands its session's CallID to
+whichever sink implements the call-aware interface (`DecodedPCMCallSink` /
+`RawFrameCallSink`); a sink that doesn't still gets the plain `WritePCM`. The two
+fences are **independent implementations of one invariant** because the two sinks
+learn "the call has moved on" through different channels — the recorder from its
+`sessions` map, the publisher from its bus-fed `grants` map — and either could
+still hold the old identity for a beat.
+`TestAudioPublisher_WritePCMForCallFencesStaleCall` and its raw twin drive exactly
+the reuse the recorder test does, one layer out.
+
+## Encryption, at two moments
+
+GopherTrunk can be told (`recordings.skip_encrypted`) to refuse encrypted calls.
+Encryption is known at two very different times, so the guard has two halves.
+
+**At grant time**, if the control-channel grant already flags encryption,
+`handleStart` never opens a session — the file simply never exists:
+
+```go
+// internal/voice/recorder.go (shape)
+if r.skipEncrypted && cs.Grant.Encrypted {
+    r.log.Debug("recorder: skipping encrypted call", /*…*/)
+    return
+}
+```
+
+**Mid-stream** is the harder case. P25 Phase 1 carries its Encryption Sync in
+LDU2, and a Phase 2 compressed grant only resolves encryption on the traffic
+channel — so a call can be *recording clear-looking audio* before it announces
+it's encrypted. When that arrives (a `KindCallEncryption` or `KindCallSourceUpdate`
+event whose flag resolves to encrypted), `handleEncryptionUpdate` aborts: it drops
+the session, closes the open files, and **deletes them from disk**, publishing no
+`CallComplete` so no partial ever reaches the upload feeds:
+
+```go
+// internal/voice/recorder.go (shape)
+func (r *Recorder) handleEncryptionUpdate(deviceSerial string, encrypted bool) {
+    if !r.skipEncrypted || !encrypted {
+        return
+    }
+    s, ok := r.sessions[deviceSerial]
+    if !ok {
+        return
+    }
+    delete(r.sessions, deviceSerial)
+    if s.wav == nil {
+        return // dormant post-segment park — no open files
+    }
+    _ = s.close()
+    for _, p := range []string{s.wavPath, s.rawPath} {
+        if p != "" {
+            _ = os.Remove(p) // tolerate os.IsNotExist
+        }
+    }
+    // …no CallComplete published…
+}
+```
+
+Suppressing `CallComplete` is the load-bearing part: as
+[Part 1]({{ '/blog/deep-dives/recording-streaming-01-the-output-half/' | relative_url }})
+established, the broadcast manager only acts on `CallComplete`. No event, no
+upload — the encrypted partial can't leak even though it briefly existed on disk.
+`TestRecorderAbortsOnEncryptionSync` and
+`TestRecorderAbortsMidCallEncryptedSourceUpdate` cover both trigger events;
+`TestRecorderRecordsEncryptedWhenSkipDisabled` confirms it's opt-in.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 620 190" width="620" height="190" role="img" aria-label="A decision flow for a call discovered encrypted mid-stream. An in-progress recording receives an encryption update; if skip_encrypted is off or the call is clear, recording continues normally. Otherwise the session is dropped from the map, its open WAV and raw files are closed and removed with os.Remove, and no CallComplete is published, so downstream upload feeds never see the partial.">
+  <rect x="20" y="80" width="120" height="40" rx="6" fill="none" stroke="currentColor"/>
+  <text x="80" y="98" text-anchor="middle" fill="currentColor" font-size="10">recording…</text>
+  <text x="80" y="112" text-anchor="middle" fill="var(--fg-muted)" font-size="8">encryption update</text>
+  <line x1="140" y1="100" x2="180" y2="100" stroke="currentColor"/><polygon points="180,96 190,100 180,104" fill="currentColor"/>
+  <polygon points="190,100 250,74 310,100 250,126" fill="none" stroke="currentColor"/>
+  <text x="250" y="96" text-anchor="middle" fill="currentColor" font-size="9">skip &amp;&amp;</text>
+  <text x="250" y="108" text-anchor="middle" fill="currentColor" font-size="9">encrypted?</text>
+  <line x1="250" y1="126" x2="250" y2="160" stroke="currentColor"/><polygon points="246,160 250,170 254,160" fill="currentColor"/>
+  <text x="285" y="150" fill="var(--fg-muted)" font-size="9">no</text>
+  <rect x="160" y="168" width="180" height="20" rx="5" fill="none" stroke="var(--fg-muted)"/>
+  <text x="250" y="182" text-anchor="middle" fill="var(--fg-muted)" font-size="9">keep recording (unchanged)</text>
+  <line x1="310" y1="100" x2="352" y2="100" stroke="var(--accent)"/><polygon points="352,96 362,100 352,104" fill="var(--accent)"/>
+  <text x="332" y="92" fill="var(--accent)" font-size="9">yes</text>
+  <rect x="362" y="42" width="240" height="24" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="482" y="58" text-anchor="middle" fill="var(--accent)" font-size="9">delete session from map</text>
+  <rect x="362" y="72" width="240" height="24" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="482" y="88" text-anchor="middle" fill="var(--accent)" font-size="9">close + os.Remove(wav, raw)</text>
+  <rect x="362" y="102" width="240" height="24" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="482" y="118" text-anchor="middle" fill="var(--accent)" font-size="9">suppress CallComplete</text>
+  <line x1="482" y1="66" x2="482" y2="72" stroke="var(--accent)"/>
+  <line x1="482" y1="96" x2="482" y2="102" stroke="var(--accent)"/>
+  <text x="482" y="142" text-anchor="middle" fill="var(--fg-muted)" font-size="9">→ upload feeds never see the partial</text>
+</svg>
+<figcaption>Mid-call encryption: when opted in, the session is dropped, its files are closed and removed, and no <code>CallComplete</code> is published — so the broadcast manager, which acts only on that event, never touches the partial.</figcaption>
+</figure>
+
+## Backfill: making the metadata match
+
+Deleting the partial is one response to late-resolved encryption. But when the
+operator *isn't* skipping encrypted calls — or when the late fact is a source
+radio ID rather than encryption — the call keeps recording, and the concern flips:
+the eventual `CallComplete` must carry the truth. That `CallComplete` is built
+from the session's *stored* grant (a snapshot taken at `CallStart`), so
+`backfillSessionGrant` mirrors the engine's late discoveries onto it:
+
+```go
+// internal/voice/recorder.go (shape)
+func (r *Recorder) backfillSessionGrant(serial string, encrypted bool, algID uint8, keyID uint16, sourceID uint32) {
+    s, ok := r.sessions[serial]
+    if !ok {
+        return
+    }
+    if encrypted {
+        s.cs.Grant.Encrypted = true
+        if algID != 0 { s.cs.Grant.AlgorithmID = algID }
+        if keyID != 0 { s.cs.Grant.KeyID = keyID }
+    }
+    if sourceID != 0 {
+        s.cs.Grant.SourceID = sourceID
+    }
+}
+```
+
+The update rules are conservative on purpose. Encryption is **sticky-true** — set,
+never cleared here — so a later clear-looking update can't un-mark a call the
+engine already saw encrypted. A **zero source is ignored**, so a subsequent
+clear-source update can't erase a RID that was already resolved. Without this, a
+Phase 2 compressed grant whose encryption resolves only on the traffic channel
+would broadcast as `encrypted=false` even though the call log — fed from the
+engine-backfilled `CallEnd` grant — correctly shows it encrypted (the exact split
+of issue #897). `TestRecorderBackfillsMidCallEncryptionIntoCallComplete` pins the
+two records back into agreement.
+
+## Runtime toggles without collateral
+
+The last guards are about operator actions mid-stream not damaging calls in
+flight.
+
+**Runtime record on/off.** `SetRecordingEnabled(false)` flips an atomic
+`recordDisabled` that `handleStart` checks: subsequent `CallStart`s are dropped
+silently, laying down no files. But **in-flight sessions are left alone** — they
+finish naturally on `CallEnd` — so flipping the switch mid-conversation doesn't
+truncate the call that's already recording. The gate stops *new* work; it never
+severs *existing* work. `TestRecorderGateBlocksNewSessions` covers the block;
+the atomic makes the read lock-free on the hot path.
+
+**Per-talkgroup gating.** Independently, a talkgroup flagged `Record = false` is
+followed and played live but written to no file. The check in `handleStart` is
+careful about a subtlety: it must *not* drop the call outright, or the talkgroup
+would go silent live too. Instead it skips only file creation, and only when the
+recorder is actually persisting (`!r.decodeOnly`):
+
+```go
+// internal/voice/recorder.go (shape)
+if !r.decodeOnly && cs.Talkgroup != nil && !cs.Talkgroup.Record {
+    return // follow + play live, but write no files
+}
+```
+
+A decode-only recorder writes nothing regardless, so it deliberately falls through
+here — dropping the call would silence a talkgroup that's supposed to be audible.
+`TestRecorderSkipsRecordFalseTalkgroup` locks the file-skip; the live path stays
+open. Two toggles, one principle: change what's recorded going forward, never
+damage what's already in flight or what's meant to stay audible.
+
+## Where this goes next
+
+[Part 8]({{ '/blog/deep-dives/recording-streaming-08-loudness-output-stage/' | relative_url }})
+moves from correctness to polish: where and when the optional loudness
+normalization runs — after the WAV is finalized and *before* `CallComplete` is
+published, so every downstream consumer reads leveled audio — and why that seam,
+not the DSP, is where GopherTrunk places it.
+
+## FAQ
+
+**What is the CallID fence and why is it needed?**
+Wideband voice taps reuse a small pool of device serials, so a frame from a
+just-ended call can arrive after the next call has claimed the same serial.
+Each session and grant is stamped with the call's monotonic `CallID`; a frame
+whose CallID doesn't match the current session (both non-zero and different) is
+dropped, so one call's draining tail can't be written to — or streamed as — the
+next call's audio.
+
+**Why is the fence implemented in two places?**
+Because a stale frame can poison two independent sinks: the recorder's WAV/`.raw`
+files and the live audio publisher's stream. The recorder learns a call has ended
+through its `sessions` map; the publisher learns through its own bus-fed `grants`
+map. Each enforces the same CallID check against its own view, so neither sink
+mislabels a reused-serial frame.
+
+**What happens if a call is found to be encrypted after recording starts?**
+With `skip_encrypted` on, the recorder closes and `os.Remove`s the in-progress WAV
+and `.raw`, drops the session, and publishes no `CallComplete`. Because the
+broadcast manager acts only on `CallComplete`, the encrypted partial that briefly
+existed on disk never reaches any upload feed.
+
+**Can I turn recording off without losing the call that's currently recording?**
+Yes. The runtime record toggle only blocks *new* `CallStart` events; sessions
+already open finish normally on `CallEnd`. Likewise a talkgroup marked
+`Record = false` is still followed and played live — only its file writing is
+skipped — so gating never silences live audio.
+
+## Series navigation
+
+**Part 7 of 14** · ←
+[Part 6: Segmentation, Naming & Raw Sidecars]({{ '/blog/deep-dives/recording-streaming-06-segmentation-naming-sidecars/' | relative_url }})
+· Next →
+[Part 8: The Loudness Output Stage]({{ '/blog/deep-dives/recording-streaming-08-loudness-output-stage/' | relative_url }})

--- a/docs/_posts/2026-08-08-recording-streaming-08-loudness-output-stage.md
+++ b/docs/_posts/2026-08-08-recording-streaming-08-loudness-output-stage.md
@@ -1,0 +1,389 @@
+---
+title: "Recording, Composition & Streaming, Part 8: Loudness at the Output Stage"
+description: Where and when GopherTrunk applies loudness leveling to a finished call — an atomic per-call rewrite of the on-disk WAV, an independent in-memory gain on the distributed MP3 copy, and an optional real-time AGC on the live browser stream — each a separate config switch, none re-deriving the BS.1770 math.
+category: deep-dives
+keywords: ebu r128 loudness normalization placement, bs.1770 per call leveling, atomic wav rewrite temp rename, in-memory mp3 gain broadcast, live loudness agc stream parity, apply_to recording distributed both, gophertrunk normalize config, output-stage audio leveling
+tags: [loudness, normalization, recording, streaming, go, audio]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Recording, Composition & Streaming"
+series_part: 8
+---
+
+*Part 8 of **Recording, Composition & Streaming**. Our 3 p.m. dispatch on
+talkgroup 101 has been decoded, written to a crash-safe WAV, named, and
+guarded against cross-call bleed (Parts 4–7). Before the recorder announces
+the finished file to the uploader, one optional step can level its loudness so
+it matches every other call in the feed. This post is about **placement**: not
+how the loudness measurement works — the [Voice Coding]({{ '/blog/series/voice-coding/' | relative_url }})
+series owns that — but exactly **where** and **when** a gain is applied, and why
+GopherTrunk offers three independent places to apply it.*
+
+> **TL;DR:** Loudness leveling in GopherTrunk lives at **three separate seams**,
+> each its own config switch. `AppliesToRecording()` rewrites the **on-disk WAV**
+> in place — atomically, temp-file-plus-rename — so every downstream consumer
+> inherits normalized audio. `AppliesToDistributed()` applies the gain **in
+> memory** while encoding the outbound MP3, leaving the WAV pristine. And the
+> optional `audio.live_loudness` sink runs a real-time envelope AGC on the
+> **live browser stream** so what you hear now tracks the normalized files. The
+> BS.1770/R128 math itself is a black box called `loudness.NormalizeGain` — this
+> post is only about which of those three seams you enable.
+
+**Key takeaways**
+
+- **Leveling is placement, not math.** GopherTrunk calls one shared function,
+  `loudness.NormalizeGain`, from three different sites. Choosing a site — WAV,
+  MP3, live stream — is the entire configuration surface an operator touches.
+- **The on-disk rewrite is atomic.** `rewriteWAV` writes a `.tmp` next to the
+  file and `os.Rename`s it over the original, so a crash mid-normalize can never
+  truncate a good recording.
+- **The distributed MP3 gain is non-destructive.** `encodeNormalizedMP3` levels
+  the samples in memory and encodes; the WAV on `AudioPath` is never touched. A
+  call can therefore ship loud to Broadcastify while staying faithful on disk.
+- **The live AGC is an approximation, by necessity.** R128 *integrated*
+  loudness needs the whole call; the live stream doesn't have the whole call
+  yet. So `liveLoudnessSink` runs an envelope-follower AGC that matches
+  *perceived* loudness in real time rather than reproducing the offline result.
+
+## Cheat sheet
+
+| Seam | Enabled by | Applied where | Function | Touches the WAV? |
+|---|---|---|---|---|
+| On-disk WAV rewrite | `NormalizeConfig.AppliesToRecording()` | recorder, after finalize | `normalizeWAVFile` → `rewriteWAV` | Yes — atomic temp+rename |
+| Distributed MP3 gain | `NormalizeConfig.AppliesToDistributed()` | broadcast Manager, at encode | `encodeNormalizedMP3` | No — in memory only |
+| Live-stream loudness | `audio.live_loudness` | daemon, decoded-PCM tap | `newLiveLoudnessSink` (`liveLoudnessSink`) | No — real-time AGC |
+| Voice enhancement | `recordings.enhance` | recorder, at **decode** | `SetVoiceEnhance` on the vocoder | (decode stage, not output) |
+| The gain calculation | (shared) | all three call it | `loudness.NormalizeGain` | — |
+
+## In this post
+
+- **Three seams, one gain function** — the shape of the leveling surface.
+- **The on-disk rewrite** — where it sits in the recorder, and why it's atomic.
+- **The distributed copy** — an independent switch that leaves the WAV alone.
+- **The live AGC** — keeping the browser stream matched to normalized files.
+- **What isn't here** — the BS.1770 math and the decode-stage enhance chain.
+
+## Three seams, one gain function
+
+Every leveling site in GopherTrunk ends up calling the same function. It lives
+in `internal/dsp/loudness` and the [Voice Coding Part 10]({{ '/blog/deep-dives/voice-coding-10-enhancement-loudness/' | relative_url }})
+post documents its internals; from the output half's point of view it is a black
+box with one signature:
+
+```go
+// internal/dsp/loudness (shape) — documented in Voice Coding Part 10
+func NormalizeGain(samples []float64, sampleRate int, p NormalizeParams) (gain float64, ok bool)
+```
+
+It measures a whole call's integrated loudness, returns the single linear gain
+that moves it toward the target (true-peak limited), and reports `ok == false`
+when the audio is too short or quiet to measure. **Pure gain, no compression** —
+the within-call dynamics the vocoder AGC produced are preserved. The knobs are
+carried by `NormalizeConfig` (target LUFS, true-peak ceiling, max boost); the
+`WithDefaults` path fills any zero field with the package defaults (−16 LUFS,
+−1.5 dBTP, ±12 dB).
+
+The interesting part is that there are **three** callers, and which ones fire is
+decided entirely by config. The YAML `NormalizeConfig` carries an `ApplyTo`
+string, and two predicate methods read it:
+
+```go
+// internal/config/config.go (shape)
+func (n NormalizeConfig) AppliesToRecording() bool {
+    return n.Enabled && (n.ApplyTo == "" || n.ApplyTo == "recording" || n.ApplyTo == "both")
+}
+func (n NormalizeConfig) AppliesToDistributed() bool {
+    return n.Enabled && (n.ApplyTo == "distributed" || n.ApplyTo == "both")
+}
+```
+
+`apply_to: recording` (the default when normalize is enabled) rewrites the WAV.
+`apply_to: distributed` leaves the WAV pristine and levels only the outbound
+MP3. `apply_to: both` does both. These are **not mutually exclusive settings on
+a dial** — they are two independent booleans, and the third seam (the live AGC)
+is a completely separate config key. An operator can archive faithful WAVs while
+shipping loud MP3s, or normalize the archive while keeping distribution
+verbatim, or level everything, or nothing.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 220" width="660" height="220" role="img" aria-label="One finished call fans into three independent loudness switches: AppliesToRecording rewrites the on-disk WAV atomically, AppliesToDistributed applies an in-memory gain to the outbound MP3 while leaving the WAV pristine, and audio.live_loudness runs a real-time AGC on the live browser stream. All three call the same loudness.NormalizeGain function.">
+  <rect x="8" y="90" width="120" height="46" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="68" y="110" text-anchor="middle" fill="var(--accent)" font-size="11">finished call</text>
+  <text x="68" y="126" text-anchor="middle" fill="var(--fg-muted)" font-size="9">WAV on AudioPath</text>
+  <line x1="128" y1="100" x2="176" y2="34" stroke="currentColor"/><polygon points="172,30 182,32 176,41" fill="currentColor"/>
+  <line x1="128" y1="113" x2="176" y2="110" stroke="currentColor"/><polygon points="176,106 186,110 176,114" fill="currentColor"/>
+  <line x1="128" y1="126" x2="176" y2="186" stroke="currentColor"/><polygon points="176,178 184,188 172,188" fill="currentColor"/>
+  <rect x="186" y="16" width="210" height="40" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="291" y="33" text-anchor="middle" fill="var(--accent)" font-size="10">AppliesToRecording()</text>
+  <text x="291" y="48" text-anchor="middle" fill="var(--fg-muted)" font-size="8">rewrite WAV — atomic temp+rename</text>
+  <rect x="186" y="90" width="210" height="40" rx="6" fill="none" stroke="currentColor"/>
+  <text x="291" y="107" text-anchor="middle" fill="currentColor" font-size="10">AppliesToDistributed()</text>
+  <text x="291" y="122" text-anchor="middle" fill="var(--fg-muted)" font-size="8">in-memory gain — WAV pristine</text>
+  <rect x="186" y="166" width="210" height="40" rx="6" fill="none" stroke="currentColor"/>
+  <text x="291" y="183" text-anchor="middle" fill="currentColor" font-size="10">audio.live_loudness</text>
+  <text x="291" y="198" text-anchor="middle" fill="var(--fg-muted)" font-size="8">real-time AGC — live stream</text>
+  <line x1="396" y1="36" x2="470" y2="105" stroke="var(--fg-muted)"/><polygon points="466,99 474,109 461,107" fill="var(--fg-muted)"/>
+  <line x1="396" y1="110" x2="470" y2="110" stroke="var(--fg-muted)"/><polygon points="470,106 480,110 470,114" fill="var(--fg-muted)"/>
+  <line x1="396" y1="186" x2="470" y2="116" stroke="var(--fg-muted)"/><polygon points="466,113 474,111 470,122" fill="var(--fg-muted)"/>
+  <rect x="480" y="92" width="170" height="36" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="565" y="108" text-anchor="middle" fill="var(--accent)" font-size="10">loudness.NormalizeGain</text>
+  <text x="565" y="122" text-anchor="middle" fill="var(--fg-muted)" font-size="8">shared — Voice Coding Part 10</text>
+</svg>
+<figcaption>Three independent config switches, one shared gain calculation. Enabling one seam says nothing about the others; the WAV, the MP3, and the live stream are leveled — or not — on their own.</figcaption>
+</figure>
+
+## The on-disk rewrite
+
+The first seam lives inside the recorder, at the exact point a call becomes a
+finished file. When `finalizeLocked` closes a session's WAV and returns a
+`*CallComplete` (the subject of [Part 9]({{ '/blog/deep-dives/recording-streaming-09-call-complete-seam/' | relative_url }})),
+the recorder does one thing before it publishes the completion event:
+
+```go
+// internal/voice/recorder.go (shape)
+cc := r.finalizeLocked(s, ce.DeviceSerial, ce.EndedAt, ce.Reason)
+r.mu.Unlock()
+if cc != nil {
+    r.normalizeIfEnabled(cc.AudioPath) // rewrite the WAV before anyone sees it
+    r.bus.Publish(events.Event{Kind: events.KindCallComplete, Payload: *cc})
+}
+```
+
+Two placement decisions are baked into those three lines. First, normalization
+runs **after `r.mu` is released** — whole-file measure-and-rewrite I/O must not
+block other recording sessions, so `normalizeIfEnabled` is deliberately outside
+the recorder's lock. Second, it runs **before the `KindCallComplete` publish**,
+so by the time the uploader, the web player, or the MP3 encoder ever touches the
+file, the audio is already at target. There is no window in which a downstream
+consumer reads the un-normalized version.
+
+`normalizeIfEnabled` is a thin guard — it checks the switch and never lets a
+failure drop a call:
+
+```go
+// internal/voice/recorder.go (shape)
+func (r *Recorder) normalizeIfEnabled(wavPath string) {
+    if !r.normalize.Enabled || wavPath == "" {
+        return
+    }
+    if err := normalizeWAVFile(wavPath, r.normalize); err != nil {
+        r.log.Warn("recorder: loudness normalize failed", "wav", wavPath, "err", err)
+    }
+}
+```
+
+`normalizeWAVFile` reads the samples, converts to float, asks
+`loudness.NormalizeGain` for the gain, applies it, and — critically — calls
+`rewriteWAV` to put the result back. It returns `nil` without touching the file
+when the gain isn't measurable (silent or too short). The rewrite is where the
+crash-safety lives:
+
+```go
+// internal/voice/normalize.go (shape)
+func rewriteWAV(path string, samples []int16, sampleRate uint32) error {
+    tmp := path + ".tmp"
+    w, err := NewWavFile(tmp, sampleRate)
+    // …WriteSamples, Close…
+    return os.Rename(tmp, path) // atomic replace over the original
+}
+```
+
+Write to a sibling temp file, close it, then `os.Rename` it over the original.
+On any POSIX filesystem the rename is atomic, so a crash mid-write leaves either
+the old good WAV or the new good WAV — never a truncated one. This is the same
+discipline the crash-safe WAV writer used in [Part 5]({{ '/blog/deep-dives/recording-streaming-05-wav-on-disk/' | relative_url }}),
+applied a second time to the rewrite.
+
+Because this seam edits the file every consumer reads, its effect is **global**:
+web playback, the MP3 encode, and every upload backend all inherit the
+normalized audio for free. That is exactly why the default `apply_to` is
+`recording` — one rewrite, and the whole output half is consistent.
+
+There is also an exported entry point, `NormalizeWAVFile`, that the offline
+tooling (`gophertrunk decode -normalize`) calls; it wraps the same internal path
+with `withDefaults()` applied first, since the recorder backfills defaults at
+construction but a one-shot CLI invocation has not.
+
+## The distributed copy
+
+The second seam lives in a completely different package —
+`internal/broadcast` — and it never writes to disk. When the broadcast Manager
+turns a `CallComplete` into an outbound `Call`, it stamps the call with its own
+`NormalizeConfig`. The MP3 is encoded lazily, at most once, the first time any
+backend asks for it:
+
+```go
+// internal/broadcast/broadcast.go (shape)
+func (c *Call) MP3() ([]byte, error) {
+    // …once-only guard…
+    if c.normalize.Enabled {
+        c.mp3Data, c.mp3Err = encodeNormalizedMP3(c.AudioPath, c.normalize.Params)
+    } else {
+        c.mp3Data, _, c.mp3Err = mp3.EncodeWAVFile(c.AudioPath)
+    }
+    return c.mp3Data, c.mp3Err
+}
+```
+
+`encodeNormalizedMP3` reads the WAV, converts to float, applies
+`loudness.NormalizeGain` **in memory**, and hands the leveled samples to the MP3
+encoder. The comment on the function says it plainly: it applies the gain
+"leaving the file untouched." The on-disk WAV on `AudioPath` stays exactly as
+the recorder wrote it. The gain lives only in the byte slice that becomes the
+MP3.
+
+This is what makes the two switches genuinely independent. `apply_to:
+distributed` gives you a faithful archive and a loud feed. It exists because the
+two audiences want different things: an operator's local archive should be
+byte-faithful to what came off the air, while Broadcastify listeners want every
+call at a consistent volume regardless of how hot the transmitter was.
+
+The wiring that connects config to this seam is in `cmd/gophertrunk/broadcast.go`.
+`buildBroadcastManager` takes the daemon's `config.NormalizeConfig` and, only
+when `AppliesToDistributed()` is true, translates it into the broadcast
+package's own `NormalizeConfig` with defaults resolved:
+
+```go
+// cmd/gophertrunk/broadcast.go (shape)
+var normalize broadcast.NormalizeConfig
+if normCfg.AppliesToDistributed() {
+    normalize = broadcast.NormalizeConfig{
+        Enabled: true,
+        Params:  loudness.NormalizeParams{ /* target, true-peak, max-boost */ }.WithDefaults(),
+    }
+}
+return broadcast.NewManager(broadcast.Options{ /* …, */ Normalize: normalize })
+```
+
+If the operator chose `apply_to: recording`, `AppliesToDistributed()` is false,
+`normalize` stays its zero value, and the Manager encodes the WAV verbatim —
+because the WAV was *already* normalized on disk by the first seam. The two
+predicates make sure the gain is applied exactly once for any given `apply_to`
+choice, never twice.
+
+## The live AGC
+
+The third seam is the odd one out, and its constraints are worth stating
+because they explain why it can't just reuse the offline path. The live browser
+stream needs to sound as loud as the normalized recordings **while the call is
+still in progress** — but R128 *integrated* loudness is a whole-call
+measurement, and mid-call there is no whole call to measure. So the live path
+uses a different tool: a real-time envelope-follower AGC.
+
+The daemon builds it only when `audio.live_loudness` is set, wrapping the
+decoded-PCM tap that feeds the network stream:
+
+```go
+// cmd/gophertrunk/daemon.go (shape)
+var liveStreamSink composer.PCMSink = d.audioPub
+if cfg.Audio.LiveLoudness {
+    lls := newLiveLoudnessSink(d.audioPub, 8000, d.bus, log)
+    d.liveLoudness = lls
+    liveStreamSink = lls // AGC now sits in front of the publisher
+}
+```
+
+`liveLoudnessSink` is a `composer.PCMSink` decorator: it levels each block of
+decoded digital PCM with a per-serial `dsp.AudioAGC`, then forwards to the real
+publisher. It subscribes to the bus so it can `Reset()` a serial's envelope at
+`KindCallStart` (a loud prior call shouldn't under-amplify the next call's
+onset) and drop the entry at `KindCallEnd`. Deliberately, it wraps **only the
+digital decoded tap** — the on-disk WAV is untouched (the recorder does its own
+per-call R128), and analog FM live audio is untouched (the composer already
+shapes its loudness upstream), so nothing is double-processed.
+
+The result isn't bit-identical to the offline rewrite, and the code says so: the
+envelope AGC "is the real-time approximation that matches what the listener
+actually perceives." Perceptual parity, not numerical identity, is the goal — a
+live listener toggling between the stream and a just-recorded file shouldn't
+reach for the volume knob.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 200" width="660" height="200" role="img" aria-label="A timeline of one call showing where each leveling seam acts: the live-loudness AGC levels the decoded PCM in real time as the call streams; the recorder finalizes and, if AppliesToRecording, rewrites the WAV atomically before publishing CallComplete; and only afterward, on demand, the broadcast Manager applies its in-memory gain while encoding the MP3 if AppliesToDistributed.">
+  <line x1="20" y1="40" x2="640" y2="40" stroke="currentColor"/><polygon points="640,36 650,40 640,44" fill="currentColor"/>
+  <text x="20" y="26" fill="var(--fg-muted)" font-size="9">call in progress</text>
+  <text x="330" y="26" fill="var(--fg-muted)" font-size="9">call ends</text>
+  <text x="560" y="26" fill="var(--fg-muted)" font-size="9">on upload</text>
+  <line x1="330" y1="30" x2="330" y2="50" stroke="var(--fg-muted)" stroke-dasharray="3 3"/>
+  <rect x="24" y="60" width="280" height="34" rx="6" fill="none" stroke="currentColor"/>
+  <text x="164" y="77" text-anchor="middle" fill="currentColor" font-size="10">live-loudness AGC (real time)</text>
+  <text x="164" y="89" text-anchor="middle" fill="var(--fg-muted)" font-size="8">levels decoded PCM as it streams</text>
+  <rect x="340" y="60" width="180" height="34" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="430" y="77" text-anchor="middle" fill="var(--accent)" font-size="10">finalizeLocked</text>
+  <text x="430" y="89" text-anchor="middle" fill="var(--fg-muted)" font-size="8">close WAV → *CallComplete</text>
+  <rect x="340" y="108" width="180" height="34" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="430" y="125" text-anchor="middle" fill="var(--accent)" font-size="10">normalizeIfEnabled</text>
+  <text x="430" y="137" text-anchor="middle" fill="var(--fg-muted)" font-size="8">atomic WAV rewrite (recording)</text>
+  <rect x="340" y="156" width="180" height="30" rx="6" fill="none" stroke="currentColor"/>
+  <text x="430" y="175" text-anchor="middle" fill="currentColor" font-size="10">publish CallComplete</text>
+  <line x1="430" y1="94" x2="430" y2="108" stroke="var(--accent)"/><polygon points="426,108 430,116 434,108" fill="var(--accent)"/>
+  <line x1="430" y1="142" x2="430" y2="156" stroke="currentColor"/><polygon points="426,156 430,164 434,156" fill="currentColor"/>
+  <rect x="536" y="108" width="112" height="42" rx="6" fill="none" stroke="currentColor"/>
+  <text x="592" y="125" text-anchor="middle" fill="currentColor" font-size="9">Call.MP3()</text>
+  <text x="592" y="138" text-anchor="middle" fill="var(--fg-muted)" font-size="8">in-memory gain</text>
+  <text x="592" y="147" text-anchor="middle" fill="var(--fg-muted)" font-size="8">(distributed)</text>
+  <line x1="520" y1="171" x2="580" y2="150" stroke="var(--fg-muted)" stroke-dasharray="3 3"/><polygon points="576,145 584,149 573,153" fill="var(--fg-muted)"/>
+</svg>
+<figcaption>The three seams act at different times. The live AGC runs while the call streams; the WAV rewrite sits between <code>finalizeLocked</code> and the <code>CallComplete</code> publish; the MP3 gain runs only later, on demand, when a backend asks for the encoded copy.</figcaption>
+</figure>
+
+## What isn't here
+
+Two things this post deliberately does **not** cover.
+
+The **BS.1770/R128 measurement and the AGC control law** belong to
+[Voice Coding Part 10]({{ '/blog/deep-dives/voice-coding-10-enhancement-loudness/' | relative_url }}).
+`loudness.NormalizeGain` and `dsp.AudioAGC` are black boxes here; how they gate,
+window, and true-peak-limit is the codec series' subject. This post is only about
+which of the three call sites you switch on.
+
+The **voice enhancement chain** (`recordings.enhance`, toggled live by
+`SetVoiceEnhance`) is a related but distinct feature that lives at a different
+stage. Enhancement — band-limit, warmth shelf, louder AGC — is installed on the
+per-call vocoder at **decode** time, so it shapes the WAV and the live fan-out
+identically because both come from that one decode. Loudness normalization, by
+contrast, is an **output-stage** operation applied to already-decoded audio. If
+you find yourself asking "does this shape the sound before or after the file
+exists?", enhancement is before (at decode) and the three seams above are after
+(at output). They compose cleanly precisely because they sit at different stages.
+
+## Where this goes next
+
+[Part 9]({{ '/blog/deep-dives/recording-streaming-09-call-complete-seam/' | relative_url }})
+opens the event those first two seams bracket: `CallComplete`. We'll see exactly
+how `finalizeLocked` builds it, what identity and metadata it carries, and how it
+becomes the single decoupling seam between recording and everything downstream —
+the point where the loudness-normalized WAV we just produced is handed off to the
+rest of the world.
+
+## FAQ
+
+**Does enabling normalization overwrite my original recordings?**
+Only if `apply_to` includes `recording` (the default when normalize is on). That
+path rewrites the WAV in place — atomically, via a temp file and rename, so a
+crash never truncates it. Choose `apply_to: distributed` to keep the on-disk WAV
+byte-faithful and level only the outbound MP3.
+
+**Can I keep faithful archives but still send loud audio to Broadcastify?**
+Yes — that's exactly `apply_to: distributed`. The recorder leaves the WAV
+untouched, and `encodeNormalizedMP3` applies the gain in memory while encoding
+the outbound copy, so the archive and the feed diverge on purpose.
+
+**Why doesn't the live stream sound bit-identical to the recorded file?**
+Integrated R128 loudness needs the whole call, which the live path doesn't have
+yet. The `audio.live_loudness` sink uses a real-time envelope AGC instead — a
+perceptual approximation that matches what a listener hears, not a reproduction
+of the offline measurement.
+
+**Where in the pipeline is loudness applied?**
+For the WAV, between `finalizeLocked` and the `CallComplete` publish, so every
+downstream reader sees normalized audio. For the MP3, later and on demand, inside
+`Call.MP3()` when a backend requests the encoded bytes. For the live stream,
+continuously, as decoded PCM passes through the sink on its way to the publisher.
+
+## Series navigation
+
+**Part 8 of 14** · ←
+[Part 7: Correctness Guards]({{ '/blog/deep-dives/recording-streaming-07-correctness-guards/' | relative_url }})
+· Next →
+[Part 9: CallComplete — The Seam to Everything Downstream]({{ '/blog/deep-dives/recording-streaming-09-call-complete-seam/' | relative_url }})

--- a/docs/_posts/2026-08-09-recording-streaming-09-call-complete-seam.md
+++ b/docs/_posts/2026-08-09-recording-streaming-09-call-complete-seam.md
@@ -1,0 +1,359 @@
+---
+title: "Recording, Composition & Streaming, Part 9: CallComplete — The Seam to Everything Downstream"
+description: How GopherTrunk's single CallComplete event decouples recording from streaming and persistence — what finalizeLocked builds, the identity and file metadata it carries, the per-call VoiceStats quality log emitted alongside it, and why the demod signal, EVM, and SNR figures ride the earlier CallEnd instead.
+category: deep-dives
+keywords: callcomplete event seam, finalizelocked callcomplete payload, decouple recording streaming persistence, per call voicestats quality log, callend evm snr signal dbfs, audiopath sample rate grant identity, gophertrunk event bus handoff, one event fan out subscribers
+tags: [events, recording, streaming, architecture, go, audio]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Recording, Composition & Streaming"
+series_part: 9
+---
+
+*Part 9 of **Recording, Composition & Streaming**. Our 3 p.m. dispatch on
+talkgroup 101 is now a finished, loudness-normalized WAV on disk. The recorder is
+done with it. Everything else the scanner does with that call — upload it, index
+it, show it in a UI — hangs off one event the recorder publishes at exactly this
+moment: `KindCallComplete`. This post is about that seam: what `finalizeLocked`
+puts into the payload, what it pointedly leaves out, and why that single event is
+the reason recording and streaming never have to know each other's types.*
+
+> **TL;DR:** `CallComplete` is the one event that decouples recording from
+> everything downstream. `finalizeLocked` builds it after it closes a call's WAV,
+> and it carries just enough to act on a **finished file**: the grant identity,
+> the resolved talkgroup, start/end timestamps, the end reason, and — the two
+> fields the engine could never know — the on-disk `AudioPath` and its
+> `SampleRate`. The per-call audio-quality picture (`VoiceStats`: pitch, AGC gain,
+> clip %) is *logged* at finalize but not carried on the event, and the demod
+> figures (`SignalDbFS`, `EVMPct`, `SNRDb`) ride the earlier `CallEnd` instead.
+> Knowing which figure lives on which event is knowing this seam.
+
+**Key takeaways**
+
+- **One event, many subscribers.** The recorder publishes `CallComplete` and
+  moves on; the broadcast Manager (and any future subscriber) reacts. No
+  subsystem calls another — the seam is a struct on a bus, not a function call.
+- **`CallComplete` carries the file; `CallEnd` carries the demod quality.** The
+  engine emits `CallEnd` with `SignalDbFS` / `EVMPct` / `SNRDb` the instant the
+  call tears down; the recorder emits `CallComplete` later, once a real
+  `AudioPath` exists. The split is deliberate.
+- **`finalizeLocked` is the sole constructor.** It's the only place a
+  `*CallComplete` is built, and it returns `nil` — publishing nothing — for a
+  call that captured no usable audio, so downstream never sees a phantom file.
+- **`VoiceStats` is a log, not a payload.** The audio-layer quality summary is
+  emitted to the operator's log at finalize; it isn't threaded onto the event,
+  because its consumer is a human triaging "robotic" audio, not the uploader.
+
+## Cheat sheet
+
+| Thing | Type / function | Where | Role |
+|---|---|---|---|
+| The completion event | `trunking.CallComplete` | `internal/trunking/grant.go` | Payload of `KindCallComplete` — the downstream seam |
+| Its builder | `finalizeLocked` | `internal/voice/recorder.go` | Closes the WAV, returns `*CallComplete` or `nil` |
+| The demod figures | `CallEnd.SignalDbFS` / `EVMPct` / `SNRDb` | `internal/trunking/grant.go` | Ride `CallEnd`, feed the call log |
+| Per-call quality log | `VoiceStats`, `logVoiceStats`, `voiceStatsFor` | `internal/voice/stats.go`, `recorder.go` | Audio-layer triage summary, logged not carried |
+| Clip-warn threshold | `voiceClipWarnPct` | `internal/voice/recorder.go` | Escalates the quality log to WARN |
+| Stats capability | `StatProvider`, `ErrorAware` | `internal/voice/stats.go` | Interfaces a vocoder opts into |
+
+## In this post
+
+- **Why the seam exists** — recording and streaming that never import each other.
+- **What `finalizeLocked` builds** — the two fields only the recorder knows.
+- **The two-event split** — file metadata on complete, demod quality on end.
+- **The `VoiceStats` quality log** — why it's logged and not carried.
+- **The nil case** — the calls that finish but complete nothing.
+
+## Why the seam exists
+
+Part 1 of this series made the argument in the abstract: the output half is four
+independent subscribers on one bus, not a call chain. `CallComplete` is where
+that argument becomes concrete. The recorder produces a file; the broadcast
+Manager consumes it; and the *only* thing connecting them is a struct carrying a
+path. The recorder does not import `internal/broadcast`; the broadcast package
+does not import the recorder. Either can be tested, replaced, or disabled without
+touching the other, because the seam between them is data.
+
+That matters most when a downstream step is slow or absent. A Broadcastify upload
+that stalls for thirty seconds is contained entirely inside the Manager's worker
+goroutine — the recorder published `CallComplete` and returned. If no broadcast
+section is configured, the Manager doesn't exist and the event simply has one
+fewer subscriber. Recording never blocks on, or even knows about, what happens
+after the file is written.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 200" width="660" height="200" role="img" aria-label="The recorder's finalizeLocked closes a WAV and publishes one KindCallComplete event onto the bus, which fans out to independent subscribers: the broadcast Manager, which reads AudioPath to encode and upload, and any other future subscriber. The recorder does not call any of them directly.">
+  <rect x="8" y="76" width="130" height="50" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="73" y="97" text-anchor="middle" fill="var(--accent)" font-size="11">finalizeLocked</text>
+  <text x="73" y="112" text-anchor="middle" fill="var(--fg-muted)" font-size="9">close WAV → *CallComplete</text>
+  <line x1="138" y1="101" x2="176" y2="101" stroke="currentColor"/><polygon points="176,97 186,101 176,105" fill="currentColor"/>
+  <rect x="186" y="80" width="120" height="42" rx="6" fill="none" stroke="currentColor"/>
+  <text x="246" y="98" text-anchor="middle" fill="currentColor" font-size="11">event bus</text>
+  <text x="246" y="112" text-anchor="middle" fill="var(--fg-muted)" font-size="9">KindCallComplete</text>
+  <line x1="306" y1="92" x2="352" y2="48" stroke="currentColor"/><polygon points="348,44 358,46 352,55" fill="currentColor"/>
+  <line x1="306" y1="104" x2="352" y2="104" stroke="currentColor"/><polygon points="352,100 362,104 352,108" fill="currentColor"/>
+  <line x1="306" y1="114" x2="352" y2="158" stroke="currentColor"/><polygon points="350,151 358,161 346,160" fill="currentColor"/>
+  <rect x="358" y="30" width="180" height="38" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="448" y="46" text-anchor="middle" fill="var(--accent)" font-size="10">broadcast Manager</text>
+  <text x="448" y="60" text-anchor="middle" fill="var(--fg-muted)" font-size="8">reads AudioPath → MP3 → upload</text>
+  <rect x="358" y="86" width="180" height="36" rx="6" fill="none" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <text x="448" y="102" text-anchor="middle" fill="var(--fg-muted)" font-size="10">any future subscriber</text>
+  <text x="448" y="115" text-anchor="middle" fill="var(--fg-muted)" font-size="8">same event, no recorder change</text>
+  <rect x="358" y="140" width="180" height="36" rx="6" fill="none" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <text x="448" y="156" text-anchor="middle" fill="var(--fg-muted)" font-size="10">(disabled → absent)</text>
+  <text x="448" y="169" text-anchor="middle" fill="var(--fg-muted)" font-size="8">one fewer subscriber</text>
+  <line x1="538" y1="49" x2="590" y2="49" stroke="currentColor"/><polygon points="590,45 600,49 590,53" fill="currentColor"/>
+  <rect x="600" y="34" width="52" height="30" rx="5" fill="none" stroke="var(--fg-muted)"/>
+  <text x="626" y="53" text-anchor="middle" fill="var(--fg-muted)" font-size="9">feeds</text>
+</svg>
+<figcaption>One <code>CallComplete</code> fans out. The recorder publishes and returns; each subscriber reads the fields it needs. Adding or removing a consumer never touches the recorder.</figcaption>
+</figure>
+
+## What finalizeLocked builds
+
+`finalizeLocked` is the sole constructor of a `*CallComplete`. It runs under the
+recorder's lock at the moment a session's WAV is closed — on a normal call end
+(`handleEnd`) or at a per-transmission segment boundary (`handleSegment`). Its job
+is to turn a live `recordingSession` into either a completion payload or a
+decision to publish nothing.
+
+When it does build one, the payload is small and deliberately file-centric:
+
+```go
+// internal/trunking/grant.go (shape)
+type CallComplete struct {
+    Grant        Grant      // full grant identity: system, protocol, TG, source, freq…
+    Talkgroup    *TalkGroup // resolved label, or nil if unknown
+    DeviceSerial string     // which voice SDR followed the call
+    StartedAt    time.Time
+    EndedAt      time.Time
+    Reason       EndReason
+    AudioPath    string     // the .wav the recorder wrote — only the recorder knows this
+    SampleRate   uint32     // its PCM rate in Hz
+}
+```
+
+The two fields that justify the event's existence are `AudioPath` and
+`SampleRate`. Everything else — the grant, the talkgroup, the timestamps, the
+reason — the engine already had at `CallEnd`. What the engine could *never* know
+is where the finished file landed on disk and at what rate it was written, because
+those are decided inside the recorder (see [Part 6]({{ '/blog/deep-dives/recording-streaming-06-segmentation-naming-sidecars/' | relative_url }})
+on naming and [Part 5]({{ '/blog/deep-dives/recording-streaming-05-wav-on-disk/' | relative_url }})
+on the WAV rate). `CallComplete` exists precisely to carry those two facts to the
+consumer that needs a real file, the uploader.
+
+The build itself is the tail of `finalizeLocked`:
+
+```go
+// internal/voice/recorder.go (shape)
+return &trunking.CallComplete{
+    Grant:        s.cs.Grant,
+    Talkgroup:    s.cs.Talkgroup,
+    DeviceSerial: serial,
+    StartedAt:    s.startedAt,
+    EndedAt:      endedAt,
+    Reason:       reason,
+    AudioPath:    s.wavPath,
+    SampleRate:   s.sampleRate,
+}
+```
+
+Note it copies the grant off the *session* (`s.cs.Grant`), not off the incoming
+`CallEnd`. That's what lets the recorder's in-call backfills — a source ID or
+encryption flag recovered on the traffic channel and stitched onto `s.cs.Grant`
+mid-call — reach the uploader with the identity the call actually turned out to
+have, rather than the grant-time snapshot.
+
+## The two-event split
+
+The single most useful thing to internalize about this seam is which quality
+figures live on which event — because they are split, on purpose, across two
+events that fire at different times.
+
+The demod-quality figures ride **`CallEnd`**, the event the engine publishes the
+instant the call tears down:
+
+```go
+// internal/trunking/grant.go (shape)
+type CallEnd struct {
+    Grant        Grant
+    Talkgroup    *TalkGroup
+    DeviceSerial string
+    StartedAt    time.Time
+    EndedAt      time.Time
+    Reason       EndReason
+    SignalDbFS   *float64 // mean received channel power (dBFS), RSSI-style
+    EVMPct       *float64 // RMS error-vector magnitude (%) over the settled decode
+    SNRDb        *float64 // estimated symbol SNR (dB)
+}
+```
+
+All three are pointers because they're optional — the composer measures them over
+the settled decode (currently only the P25 Phase 1 chains feed the demod taps
+that populate `EVMPct` / `SNRDb`), and they're `nil` on any call ended by the
+watchdog, a preemption, or shutdown. Critically, `SignalDbFS` is a channel-power
+figure and *not* SNR/EVM — they answer different questions and the struct keeps
+them separate.
+
+These figures do **not** appear on `CallComplete`. The reason is the same one
+that motivated splitting `CallEnd` from `CallComplete` in the first place
+([Part 1]({{ '/blog/deep-dives/recording-streaming-01-the-output-half/' | relative_url }})):
+the demod quality is known *immediately*, before any file is finished, and its
+consumer — the call log — acts on `CallEnd` so it can persist that quality the
+moment the call ends. Making the uploader wait on `CallComplete` for a *file* it
+needs, while letting the logger act on `CallEnd` for *metadata* it already has, is
+the whole point of having two events. Duplicating the demod figures onto
+`CallComplete` would blur that line for no consumer that needs them there.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 250" width="660" height="250" role="img" aria-label="An annotated split of a call's two end-of-life events. CallEnd fires first at teardown and carries Grant, timestamps, Reason, and the optional demod figures SignalDbFS, EVMPct and SNRDb, read by the call log. CallComplete fires later once the WAV is closed and carries Grant, Talkgroup, timestamps, Reason, plus AudioPath and SampleRate, read by the broadcast Manager. VoiceStats is logged at finalize but rides neither event.">
+  <text x="20" y="24" fill="var(--fg-muted)" font-size="10">at teardown →</text>
+  <rect x="20" y="34" width="280" height="120" rx="6" fill="none" stroke="currentColor"/>
+  <text x="34" y="52" fill="currentColor" font-size="11">CallEnd</text>
+  <text x="34" y="70" fill="var(--fg-muted)" font-size="9">Grant · StartedAt · EndedAt · Reason</text>
+  <text x="34" y="88" fill="var(--accent)" font-size="9">SignalDbFS *float64  — channel power</text>
+  <text x="34" y="103" fill="var(--accent)" font-size="9">EVMPct *float64  — error-vector %</text>
+  <text x="34" y="118" fill="var(--accent)" font-size="9">SNRDb *float64  — symbol SNR</text>
+  <text x="34" y="140" fill="var(--fg-muted)" font-size="9">→ read by the call log (Part 10)</text>
+  <text x="360" y="24" fill="var(--fg-muted)" font-size="10">after WAV closed →</text>
+  <rect x="360" y="34" width="280" height="120" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="374" y="52" fill="var(--accent)" font-size="11">CallComplete</text>
+  <text x="374" y="70" fill="var(--fg-muted)" font-size="9">Grant · Talkgroup · timestamps · Reason</text>
+  <text x="374" y="88" fill="var(--accent)" font-size="9">AudioPath string  — where the .wav is</text>
+  <text x="374" y="103" fill="var(--accent)" font-size="9">SampleRate uint32  — its PCM rate</text>
+  <text x="374" y="125" fill="var(--fg-muted)" font-size="9">(only the recorder knows these two)</text>
+  <text x="374" y="142" fill="var(--fg-muted)" font-size="9">→ read by the broadcast Manager (Part 13)</text>
+  <line x1="300" y1="94" x2="360" y2="94" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <text x="330" y="88" text-anchor="middle" fill="var(--fg-muted)" font-size="8">later</text>
+  <rect x="120" y="184" width="420" height="52" rx="6" fill="none" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <text x="330" y="204" text-anchor="middle" fill="var(--fg-muted)" font-size="10">VoiceStats — pitch · AGC gain · clip%</text>
+  <text x="330" y="220" text-anchor="middle" fill="var(--fg-muted)" font-size="9">logged at finalize (logVoiceStats), carried on NEITHER event</text>
+</svg>
+<figcaption>Which figure lives where. Demod quality rides <code>CallEnd</code> for the logger; file metadata rides <code>CallComplete</code> for the uploader; the audio-layer <code>VoiceStats</code> summary is written to the log and travels on no event at all.</figcaption>
+</figure>
+
+## The VoiceStats quality log
+
+There is a third body of quality information about our call, and it goes to a
+third place: the operator's log. Where `CallEnd`'s figures describe the *channel*
+(how clean the RF and the symbols were), `VoiceStats` describes the *audio* — the
+layer the FEC counters can't see:
+
+```go
+// internal/voice/stats.go (shape)
+type VoiceStats struct {
+    Frames, Voiced, Unvoiced, Silent, Bad, Repeated int // frame-class counts
+    MeanF0Hz, MeanL, MeanVoicedFrac                 float64 // pitch / spectral
+    MeanAGCGain, MinAGCGain, MaxAGCGain             float64 // AGC behaviour
+    MaxPreClipPeak, OutputRMS, CrestFactor          float64 // amplitude health
+    ClipSamples, TotalSamples                       int
+    // …b_0 range + FirstFrameHex for dead-key diagnostics…
+}
+
+func (s VoiceStats) ClipPct() float64 { /* 100 * ClipSamples / TotalSamples */ }
+```
+
+`finalizeLocked` calls `logVoiceStats` for every call that finalizes. It obtains
+the stats through `voiceStatsFor`, which type-asserts the session's vocoder to
+the optional `StatProvider` interface — currently only the pure-Go IMBE decoder
+implements it, so a vocoder that doesn't track stats simply produces no summary,
+and the recorder carries on. When stats exist, the line reports pitch, harmonic
+count, AGC gain range, peak, RMS, crest factor, and clip percentage. It's logged
+at DEBUG normally, but escalates to WARN when the output is clipping past
+`voiceClipWarnPct` (0.5%) — the signature of an over-hot vocoder AGC slamming
+speech into the int16 rail:
+
+```go
+// internal/voice/recorder.go (shape)
+const voiceClipWarnPct = 0.5
+
+if vs.ClipPct() > voiceClipWarnPct {
+    r.log.Warn("recorder: voice audio quality — output clipping (vocoder gain too hot)", args...)
+    return
+}
+r.log.Debug("recorder: voice audio quality", args...)
+```
+
+The design point for this series: `VoiceStats` is **logged, not carried**. It
+rides neither `CallEnd` nor `CallComplete`, because its consumer is a human
+triaging a "robotic" or "too loud" field report — not a subsystem making a
+routing decision. Threading it onto an event would put diagnostic detail on the
+wire that no automated subscriber reads. (The related interface, `ErrorAware`,
+lets the same decoder *consume* the per-frame FEC corrected-bit count from the
+recorder before it decodes — the input side of the same quality story.)
+
+## The nil case
+
+`finalizeLocked` doesn't always build a `CallComplete`. It returns `nil` — and
+the caller publishes nothing — whenever there is no real file to hand
+downstream. Two cases matter. A vocoder-decoded call whose every frame was
+idle, silent, or bad (`vs.Voiced + vs.Unvoiced == 0`) is a dead-key or idle
+carrier: `finalizeLocked` removes the empty outputs and returns `nil`. And a
+call that decoded no PCM at all (`dataBytes == 0`) returns `nil` too — though a
+digital call keeps its `.raw` sidecar as the only capture even when the WAV is
+empty.
+
+This is the seam's quiet correctness guarantee: because the *only* constructor of
+a `CallComplete` refuses to build one for a call with no usable audio, no
+downstream subscriber ever receives a completion event pointing at a file that
+isn't worth uploading. The uploader never has to defend against a phantom path;
+if it got a `CallComplete`, there is a real, non-empty WAV at `AudioPath`. The
+publish sites make this explicit — they null-check before touching the bus:
+
+```go
+// internal/voice/recorder.go (shape)
+cc := r.finalizeLocked(s, ce.DeviceSerial, ce.EndedAt, ce.Reason)
+r.mu.Unlock()
+if cc != nil {
+    r.normalizeIfEnabled(cc.AudioPath) // Part 8 — level before anyone reads it
+    r.bus.Publish(events.Event{Kind: events.KindCallComplete, Payload: *cc})
+}
+```
+
+That `cc != nil` guard is the same at both publish sites (`handleEnd` and
+`handleSegment`), and it's the reason the rest of the output half can treat a
+`CallComplete` as a promise: the file exists, it's finished, and — after the
+loudness step from [Part 8]({{ '/blog/deep-dives/recording-streaming-08-loudness-output-stage/' | relative_url }}) —
+it's ready to read.
+
+## Where this goes next
+
+[Part 10]({{ '/blog/deep-dives/recording-streaming-10-call-log-sqlite/' | relative_url }})
+follows the *other* branch of the split we drew here: the call log, which acts on
+`CallStart` and `CallEnd` — not `CallComplete` — to write a searchable SQLite row
+carrying exactly the demod figures (`SignalDbFS`, `EVMPct`, `SNRDb`) this post
+kept off the completion event. It's the persistence half of the same two-event
+design.
+
+## FAQ
+
+**What's the difference between `CallEnd` and `CallComplete` again?**
+`CallEnd` fires the instant the engine tears the call down and carries the demod
+figures (`SignalDbFS`, `EVMPct`, `SNRDb`) — no file yet. `CallComplete` fires
+later, once the recorder has closed the WAV, and carries the on-disk `AudioPath`
+and `SampleRate`. Consumers needing the file wait for complete; consumers needing
+only metadata act on end.
+
+**Which quality numbers are on `CallComplete`?**
+None of the demod figures. `CallComplete` is file-centric: grant identity,
+talkgroup, timestamps, reason, `AudioPath`, and `SampleRate`. The demod quality
+rides `CallEnd`, and the audio-layer `VoiceStats` is written to the log rather
+than carried on any event.
+
+**Why isn't `VoiceStats` attached to the completion event?**
+Its consumer is a human triaging audio quality, not a subsystem making a routing
+decision. `logVoiceStats` emits it at finalize — DEBUG normally, WARN when the
+output clips past 0.5% — so operators can diagnose "robotic" or over-loud calls
+without diffing the WAV, and no event has to carry diagnostic detail nothing reads.
+
+**Does every finished call publish a `CallComplete`?**
+No. `finalizeLocked` returns `nil` — and nothing is published — for a dead-key or
+idle-only call (it deletes the empty outputs) and for a call that decoded no PCM.
+So a `CallComplete` is a guarantee that a real, non-empty file exists at
+`AudioPath`, and downstream never receives a phantom path.
+
+## Series navigation
+
+**Part 9 of 14** · ←
+[Part 8: Loudness at the Output Stage]({{ '/blog/deep-dives/recording-streaming-08-loudness-output-stage/' | relative_url }})
+· Next →
+[Part 10: The Call Log in SQLite]({{ '/blog/deep-dives/recording-streaming-10-call-log-sqlite/' | relative_url }})

--- a/docs/_posts/2026-08-10-recording-streaming-10-call-log-sqlite.md
+++ b/docs/_posts/2026-08-10-recording-streaming-10-call-log-sqlite.md
@@ -1,0 +1,415 @@
+---
+title: "Recording, Composition & Streaming, Part 10: The Call Log — SQLite Persistence & Never-Downgrade Updates"
+description: How GopherTrunk indexes every call into a CGO-free SQLite call_log by subscribing to the bus — an INSERT on start, an UPDATE on end keyed by device and timestamp, and a COALESCE/NULLIF discipline that backfills late RID and encryption without ever clobbering a value it already knew.
+category: deep-dives
+keywords: sqlite call log persistence, modernc pure go sqlite, coalesce nullif never downgrade, call history rest api, insert on start update on end, p25 rid backfill, event bus subscriber storage, gophertrunk call_log schema
+tags: [storage, sqlite, persistence, events, go, database]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Recording, Composition & Streaming"
+series_part: 10
+---
+
+*Part 10 of **Recording, Composition & Streaming**, following one call — the
+3 p.m. dispatch on talkgroup 101 — from PCM to a Broadcastify upload. The
+[recorder]({{ '/blog/deep-dives/recording-streaming-04-recording-session/' | relative_url }})
+is busy turning that call into a WAV; this post is about the other subscriber
+that woke up when the call started. While the audio path writes bytes to disk,
+the **call log** writes one row to SQLite so the dispatch is searchable months
+later — and it has to write that row before anyone knows who was talking. This
+is the story of how a row that starts life half-blank gets filled in without
+ever being made worse.*
+
+> **TL;DR:** The call log is a bus subscriber that keeps `call_log` in sync with
+> live calls. `KindCallStart` does an INSERT with a null `ended_at`;
+> `KindCallEnd` does an UPDATE keyed by `(device_serial, started_at)` that fills
+> duration, end reason, and quality. The catch is that a P25 caller's RID and
+> encryption often arrive *after* the call started, so the UPDATE uses
+> `COALESCE(NULLIF(?, 0), col)` to backfill late values while **never** letting a
+> blank end-grant overwrite an identity the start already captured. Reads go
+> through `DB.History`, which is what the REST `/api/v1/calls/history` endpoint
+> serves.
+
+**Key takeaways**
+
+- The call log is **two SQL statements**: INSERT on `KindCallStart`, UPDATE on
+  `KindCallEnd`, both keyed by `(device_serial, started_at)`. A unique index makes
+  duplicate starts idempotent.
+- **Never downgrade.** `COALESCE(NULLIF(?, 0), col)` backfills a late RID / ALGID
+  / KID but keeps a known value when the end grant is zero; encryption only ever
+  goes clear→encrypted, never back.
+- **Unset is not zero.** `signal_dbfs`, `evm_pct`, and `snr_db` are nullable and
+  bound as `sql.NullFloat64`, so a non-composer end (a watchdog timeout) writes
+  NULL and leaves an earlier measurement intact.
+- The store is **pure-Go SQLite** (`modernc.org/sqlite`), so `CGO_ENABLED=0`
+  holds across the daemon and it cross-compiles to `linux/arm64` with no toolchain.
+
+## Cheat sheet
+
+| Thing | What it does | Where |
+|---|---|---|
+| `CallLog` | Bus subscriber that keeps `call_log` current | `internal/storage/calllog.go` |
+| `NewCallLog` | Subscribes to the bus immediately; `Run` drains later | `internal/storage/calllog.go` |
+| `recordStart` | `INSERT OR REPLACE` on `KindCallStart`, `ended_at` NULL | `internal/storage/calllog.go` |
+| `recordEnd` | Never-downgrade `UPDATE` on `KindCallEnd` | `internal/storage/calllog.go` |
+| `call_log` table | Schema + idempotency index, migrated on Open | `internal/storage/sqlite.go` |
+| `HistoryFilter` / `CallRow` | Read query shape + row DTO | `internal/storage/calllog.go` |
+| `DB.History` | Newest-first read behind the REST history endpoint | `internal/storage/calllog.go` |
+
+## In this post
+
+- **Two writes, one key** — the INSERT/UPDATE split and why the row starts blank.
+- **The never-downgrade SQL** — `COALESCE`, `NULLIF`, and the encryption `CASE`.
+- **Unset ≠ zero** — nullable quality columns and why a watchdog end writes NULL.
+- **The schema** — pure-Go SQLite, the idempotency index, and forward migrations.
+- **The read path** — `HistoryFilter` → `DB.History` → the REST endpoint.
+
+## A row that starts blank
+
+When the engine grants the 3 p.m. dispatch and retunes a voice SDR, it publishes
+`KindCallStart` on the same bus the recorder listens to (see
+[Part 1]({{ '/blog/deep-dives/recording-streaming-01-the-output-half/' | relative_url }})).
+The `CallLog` subscriber is one of the objects that wakes up. Its whole job is to
+keep the `call_log` table tracking the live call, and it does that with exactly
+two SQL statements.
+
+`NewCallLog` subscribes to the bus **immediately**, in the constructor, so a
+caller can publish events before `Run` is even scheduled — the subscription
+buffers them:
+
+```go
+// internal/storage/calllog.go (shape)
+type CallLog struct {
+    db  *DB
+    bus *events.Bus
+    sub *events.Subscription
+    // …
+}
+
+func NewCallLog(db *DB, bus *events.Bus, logger *slog.Logger) (*CallLog, error) {
+    // …validate db + bus…
+    cl := &CallLog{db: db, bus: bus, /* … */}
+    cl.sub = bus.Subscribe() // subscribe now; drain in Run
+    return cl, nil
+}
+```
+
+`Run` is a plain select loop over the subscription channel. It cares about
+exactly two of the four call events — start and end — and ignores segment and
+complete entirely (those belong to the recorder and the uploader):
+
+```go
+// internal/storage/calllog.go (shape)
+func (c *CallLog) Run(ctx context.Context) error {
+    for {
+        select {
+        case <-ctx.Done():
+            return ctx.Err()
+        case ev := <-c.sub.C:
+            switch ev.Kind {
+            case events.KindCallStart:
+                cs := ev.Payload.(trunking.CallStart)
+                c.recordStart(cs) // INSERT, ended_at NULL
+            case events.KindCallEnd:
+                ce := ev.Payload.(trunking.CallEnd)
+                c.recordEnd(ce)   // UPDATE, fill the rest
+            }
+        }
+    }
+}
+```
+
+`recordStart` writes what the grant knows at grant time — system, protocol,
+group, frequency, the device serial, and the start timestamp in Unix
+nanoseconds. It does *not* know how long the call ran, why it ended, or how loud
+it was, so those columns stay null:
+
+```go
+// internal/storage/calllog.go (shape)
+func (c *CallLog) recordStart(cs trunking.CallStart) error {
+    const q = `
+INSERT OR REPLACE INTO call_log (
+    system, protocol, group_id, source_id, frequency_hz,
+    encrypted, algorithm_id, key_id, emergency, data_call, timeslot,
+    device_serial, started_at, talkgroup_alpha
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    // …bind grant fields; started_at = cs.StartedAt.UnixNano()…
+}
+```
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 210" width="660" height="210" role="img" aria-label="A sequence: the engine publishes call.start, which the call log turns into an INSERT with ended_at NULL; the call runs; then the engine publishes call.end, which the call log turns into an UPDATE keyed by device serial and started_at that fills duration, end reason, and quality figures into the same row.">
+  <rect x="10" y="16" width="130" height="30" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="75" y="35" text-anchor="middle" fill="var(--accent)" font-size="11">trunking engine</text>
+  <rect x="270" y="16" width="120" height="30" rx="6" fill="none" stroke="currentColor"/>
+  <text x="330" y="35" text-anchor="middle" fill="currentColor" font-size="11">CallLog.Run</text>
+  <rect x="520" y="16" width="130" height="30" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="585" y="35" text-anchor="middle" fill="var(--accent)" font-size="11">call_log row</text>
+  <line x1="75" y1="46" x2="75" y2="200" stroke="var(--fg-muted)" stroke-dasharray="3 3"/>
+  <line x1="330" y1="46" x2="330" y2="200" stroke="var(--fg-muted)" stroke-dasharray="3 3"/>
+  <line x1="585" y1="46" x2="585" y2="200" stroke="var(--fg-muted)" stroke-dasharray="3 3"/>
+  <line x1="75" y1="66" x2="326" y2="66" stroke="currentColor"/><polygon points="326,62 336,66 326,70" fill="currentColor"/>
+  <text x="200" y="61" text-anchor="middle" fill="currentColor" font-size="9">KindCallStart</text>
+  <line x1="330" y1="86" x2="581" y2="86" stroke="var(--accent)"/><polygon points="581,82 591,86 581,90" fill="var(--accent)"/>
+  <text x="458" y="81" text-anchor="middle" fill="var(--accent)" font-size="9">INSERT · ended_at = NULL</text>
+  <text x="585" y="108" text-anchor="middle" fill="var(--fg-muted)" font-size="8">(active call — searchable now)</text>
+  <line x1="75" y1="140" x2="326" y2="140" stroke="currentColor"/><polygon points="326,136 336,140 326,144" fill="currentColor"/>
+  <text x="200" y="135" text-anchor="middle" fill="currentColor" font-size="9">KindCallEnd</text>
+  <line x1="330" y1="164" x2="581" y2="164" stroke="var(--accent)"/><polygon points="581,160 591,164 581,168" fill="var(--accent)"/>
+  <text x="458" y="159" text-anchor="middle" fill="var(--accent)" font-size="9">UPDATE WHERE device_serial, started_at</text>
+  <text x="458" y="184" text-anchor="middle" fill="var(--fg-muted)" font-size="8">fill duration · reason · signal · evm · snr</text>
+</svg>
+<figcaption>Two writes, one row. Start inserts an active call the instant the SDR retunes; end updates the same row by its natural key once the call is over.</figcaption>
+</figure>
+
+The pair `(device_serial, started_at)` is the row's natural key: one physical
+voice SDR can only carry one call at a time, so the serial plus the start
+timestamp uniquely names a call. That is exactly the unique index the schema
+declares, which is why `recordStart` can use `INSERT OR REPLACE` and stay
+idempotent — three duplicate `KindCallStart` events (a real possibility on a
+noisy control channel) collapse to a single row, as
+`TestCallLogIdempotentStart` pins.
+
+## The never-downgrade UPDATE
+
+Here is the subtlety that makes this post worth writing. On a P25 Phase 2
+compressed grant, the caller's **radio ID (RID)** is not on the control channel
+at grant time — `source_id` starts at 0. It surfaces mid-call on the traffic
+channel. Encryption is the same: the algorithm ID and key ID often arrive
+mid-call (P25 Phase 1 LDU2, Phase 2 EncryptionSync). The engine backfills these
+onto the bound grant, so by `KindCallEnd` the grant carries the *real* values —
+and if `recordEnd` did a naive `SET source_id = ?`, it would finally record the
+RID that `recordStart` couldn't. That much is issue #696, and
+`TestCallLogBackfillsSourceOnEnd` covers it: start with `source_id = 0`, end with
+`source_id = 778899`, and the row must end up at `778899`.
+
+But the reverse must **not** happen. A later end grant can arrive *blanker* than
+the start — a compressed-form update that dropped the RID, a preemption whose
+grant snapshot lost the encryption fields. A naive `SET` would clobber a good
+value with zero. The fix is a single guarded UPDATE:
+
+```go
+// internal/storage/calllog.go (shape)
+const q = `
+UPDATE call_log
+   SET ended_at     = ?,
+       duration_ms  = ?,
+       end_reason   = ?,
+       source_id    = COALESCE(NULLIF(?, 0), source_id),
+       encrypted    = CASE WHEN ? != 0 THEN 1 ELSE encrypted END,
+       algorithm_id = COALESCE(NULLIF(?, 0), algorithm_id),
+       key_id       = COALESCE(NULLIF(?, 0), key_id),
+       signal_dbfs  = COALESCE(?, signal_dbfs),
+       evm_pct      = COALESCE(?, evm_pct),
+       snr_db       = COALESCE(?, snr_db)
+ WHERE device_serial = ? AND started_at = ?`
+```
+
+Read `COALESCE(NULLIF(?, 0), source_id)` inside-out. `NULLIF(?, 0)` turns a bound
+value of `0` into SQL NULL; a real RID passes through unchanged. `COALESCE(…,
+source_id)` then falls back to the column's current value when the first argument
+is NULL. So a genuine mid-call RID overwrites the placeholder, and a zero end
+grant leaves whatever the row already had. `algorithm_id` and `key_id` follow the
+identical pattern.
+
+Encryption uses a `CASE` instead of `COALESCE` because it is a one-way latch:
+`CASE WHEN ? != 0 THEN 1 ELSE encrypted END` only ever flips clear→encrypted. The
+protocol defines no mid-call *decryption*, so once a call is known encrypted it
+stays that way even if a later grant reports clear.
+`TestCallLogEndDoesNotDowngrade` is the guard: a call that starts with RID 5150,
+ALG `0x84`, KID 3 survives a completely blank end grant with all three intact.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 220" width="660" height="220" role="img" aria-label="A which-write-wins table for the never-downgrade rules. For source_id, algorithm_id and key_id, a nonzero end value wins and a zero end value keeps the existing column. For encrypted, an encrypted end latches to encrypted and a clear end keeps whatever was there. For signal_dbfs, evm_pct and snr_db, a measured value wins and a NULL bind keeps the existing column.">
+  <text x="70" y="24" text-anchor="middle" fill="var(--fg-muted)" font-size="10">column</text>
+  <text x="300" y="24" text-anchor="middle" fill="var(--fg-muted)" font-size="10">end value present</text>
+  <text x="520" y="24" text-anchor="middle" fill="var(--fg-muted)" font-size="10">end value blank / NULL</text>
+  <line x1="20" y1="32" x2="640" y2="32" stroke="var(--fg-muted)"/>
+  <rect x="20" y="42" width="180" height="30" rx="5" fill="none" stroke="currentColor"/>
+  <text x="110" y="61" text-anchor="middle" fill="currentColor" font-size="10">source_id · alg · key</text>
+  <rect x="212" y="42" width="196" height="30" rx="5" fill="none" stroke="var(--accent)"/>
+  <text x="310" y="61" text-anchor="middle" fill="var(--accent)" font-size="9">NULLIF(?,0) → new wins</text>
+  <rect x="420" y="42" width="220" height="30" rx="5" fill="none" stroke="currentColor"/>
+  <text x="530" y="61" text-anchor="middle" fill="currentColor" font-size="9">COALESCE → keep column</text>
+  <rect x="20" y="80" width="180" height="30" rx="5" fill="none" stroke="currentColor"/>
+  <text x="110" y="99" text-anchor="middle" fill="currentColor" font-size="10">encrypted</text>
+  <rect x="212" y="80" width="196" height="30" rx="5" fill="none" stroke="var(--accent)"/>
+  <text x="310" y="99" text-anchor="middle" fill="var(--accent)" font-size="9">CASE → latch to 1</text>
+  <rect x="420" y="80" width="220" height="30" rx="5" fill="none" stroke="currentColor"/>
+  <text x="530" y="99" text-anchor="middle" fill="currentColor" font-size="9">keep column (no downgrade)</text>
+  <rect x="20" y="118" width="180" height="30" rx="5" fill="none" stroke="currentColor"/>
+  <text x="110" y="137" text-anchor="middle" fill="currentColor" font-size="10">signal · evm · snr</text>
+  <rect x="212" y="118" width="196" height="30" rx="5" fill="none" stroke="var(--accent)"/>
+  <text x="310" y="137" text-anchor="middle" fill="var(--accent)" font-size="9">COALESCE(?,…) → new wins</text>
+  <rect x="420" y="118" width="220" height="30" rx="5" fill="none" stroke="currentColor"/>
+  <text x="530" y="137" text-anchor="middle" fill="currentColor" font-size="9">NULL bind → keep column</text>
+  <text x="330" y="180" text-anchor="middle" fill="var(--fg-muted)" font-size="9">Rule: a known value is never replaced by zero or NULL.</text>
+  <text x="330" y="198" text-anchor="middle" fill="var(--fg-muted)" font-size="9">The end write can only add information, never remove it.</text>
+</svg>
+<figcaption>Which write wins. Every column's UPDATE is a one-way ratchet: the end event can enrich the row but can never downgrade a value the start already established.</figcaption>
+</figure>
+
+## Unset is not zero
+
+The last three columns — `signal_dbfs`, `evm_pct`, `snr_db` — are the call's
+measured quality, and they carry a distinction the integer columns don't: **the
+difference between "measured as 0" and "never measured."** Only some ends carry a
+measurement. A clean composer teardown stamps the received channel power and, on
+a P25 Phase 1 chain, the demod EVM and SNR. A *non-composer* end — a watchdog
+timeout, a preemption, a shutdown — carries nothing.
+
+The code models "nothing" as a NULL bind rather than a zero. `recordEnd` reads
+the pointer fields on `CallEnd` and only marks the `sql.NullFloat64` valid when
+the pointer is non-nil:
+
+```go
+// internal/storage/calllog.go (shape)
+var sig sql.NullFloat64
+if ce.SignalDbFS != nil {
+    sig = sql.NullFloat64{Float64: *ce.SignalDbFS, Valid: true}
+}
+// evm_pct / snr_db bound the same way from ce.EVMPct / ce.SNRDb
+```
+
+An invalid `sql.NullFloat64` binds as SQL NULL, so `COALESCE(?, signal_dbfs)`
+keeps whatever the column already held — the same never-clobber discipline as the
+RID guard, applied to floats. That is why the columns have no `DEFAULT` in the
+schema: a fresh call with no reading must read back as `nil`, distinct from a
+legitimate `0.0 dBFS`. `TestCallLogPersistsSignalDbFS` and
+`TestCallLogPersistsDemodMetrics` assert both halves — a measured call round-trips
+its value, an unmeasured call reads back `nil`.
+
+> ⚠ These figures are for *your* records, not cross-decoder comparison across the
+> board. `signal_dbfs` is channel power in dBFS, not calibrated RSSI or SNR; only
+> the `evm_pct` / `snr_db` pair (populated by P25 Phase 1 chains) is a true demod-
+> quality measure. The `CallRow` doc comments spell this out so a history consumer
+> doesn't read too much into a raw power figure.
+
+The DSP behind these numbers — how the composer measures EVM and SNR — belongs to
+[Voice Coding Part 10]({{ '/blog/deep-dives/voice-coding-10-enhancement-loudness/' | relative_url }}).
+Here they are just three more columns the call log persists faithfully.
+
+## The schema and why it's pure Go
+
+The table lives in `internal/storage/sqlite.go`, applied once at `Open` time. The
+driver is `modernc.org/sqlite` — a pure-Go SQLite with no CGO. As the package doc
+in `internal/storage/storage.go` puts it, that keeps `CGO_ENABLED=0` true across
+the whole daemon so it cross-compiles to `linux/arm64` without toolchain
+gymnastics — a real concern for a scanner that runs on a Raspberry Pi.
+
+```sql
+-- internal/storage/sqlite.go (shape)
+CREATE TABLE IF NOT EXISTS call_log (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    system        TEXT    NOT NULL,
+    group_id      INTEGER NOT NULL,
+    source_id     INTEGER NOT NULL DEFAULT 0,
+    -- …encrypted, algorithm_id, key_id, emergency, timeslot…
+    device_serial TEXT    NOT NULL,
+    started_at    INTEGER NOT NULL,  -- unix nanoseconds
+    ended_at      INTEGER,           -- NULL while the call is active
+    duration_ms   INTEGER,
+    signal_dbfs   REAL,  -- NULL = unmeasured (no DEFAULT)
+    evm_pct       REAL,  -- NULL = unmeasured
+    snr_db        REAL   -- NULL = unmeasured
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_call_log_active
+    ON call_log(device_serial, started_at);
+```
+
+That last unique index is the one enforcing idempotent starts, and the plain
+indexes on `started_at`, `(system, started_at)`, and `(group_id, started_at)`
+serve the history filters below. Because `CREATE TABLE IF NOT EXISTS` never alters
+an existing table, a database from an older GopherTrunk keeps its old column set;
+`ensureCallLogColumns` inspects `PRAGMA table_info` and `ALTER TABLE`s in any
+missing columns (`algorithm_id`, `key_id`, `timeslot`, and the three nullable
+quality columns). It is idempotent, so it needs no schema-version gate —
+`TestMigrationAddsEncryptionColumns` builds a pre-migration table and confirms an
+old row still reads back with sensible defaults after `Open`.
+
+## The read path
+
+Writes are only half the story; the row exists to be read back. `HistoryFilter`
+describes a query and `CallRow` is the row DTO:
+
+```go
+// internal/storage/calllog.go (shape)
+type HistoryFilter struct {
+    System    string
+    GroupID   uint32    // 0 = no filter
+    SourceID  uint32    // 0 = no filter (filters on RID)
+    Since     time.Time
+    Until     time.Time
+    Limit     int
+    OnlyEnded bool
+}
+```
+
+`DB.History` builds a parameterised `WHERE` incrementally — each non-zero filter
+appends one `AND` clause and one bound arg — and always orders `started_at DESC`
+so results are newest-first. `OnlyEnded` adds `ended_at IS NOT NULL` to hide calls
+still in progress; `Limit` caps the result. The scan is where the nullable columns
+pay off: `ended_at`, `duration_ms`, and the three quality floats scan into
+`sql.Null*` locals and only populate the `CallRow` pointer fields when valid, so a
+JSON consumer sees `null`, not a fabricated zero.
+
+```go
+// internal/storage/calllog.go (shape)
+func (d *DB) History(ctx context.Context, f HistoryFilter) ([]CallRow, error) {
+    q := `SELECT … FROM call_log WHERE 1=1`
+    // append " AND system = ?", " AND group_id = ?", " AND source_id = ?",
+    //        " AND started_at >= ?", " AND started_at < ?", " AND ended_at IS NOT NULL"
+    q += " ORDER BY started_at DESC"
+    // …scan rows; nullable columns → pointer fields…
+}
+```
+
+This is the single read helper behind the REST `/api/v1/calls/history` endpoint —
+the storage package doc notes there is no gRPC call-log service; history is REST
+only. `TestHistoryFilters` exercises every clause, including the `SourceID` filter
+that the `/rids` history view uses to pull every call from one radio across
+systems — the exact query that only works because the never-downgrade UPDATE got
+the RID into the row in the first place.
+
+## Where this goes next
+
+The call log grows one row per call forever, and the recorder grows one WAV per
+call forever. Something has to bound both.
+[Part 11]({{ '/blog/deep-dives/recording-streaming-11-retention-housekeeping/' | relative_url }})
+covers the retention sweeper — the background job that ages out old `call_log`
+rows, the decoder-log tables, and (opt-in) the `.wav` / `.raw` files on disk,
+each gated by its own configurable cutoff.
+
+## FAQ
+
+**Why key the row on `(device_serial, started_at)` instead of an ID?**
+Because the writer needs a *natural* key it can compute at both start and end
+without carrying state between events. One physical voice SDR carries one call at
+a time, so its serial plus the start timestamp names the call uniquely. That pair
+is a unique index, which also makes duplicate `KindCallStart` events idempotent.
+
+**What does `COALESCE(NULLIF(?, 0), col)` actually do?**
+`NULLIF(?, 0)` converts a bound `0` to SQL NULL; `COALESCE` then falls back to the
+existing column value when the argument is NULL. Net effect: a real mid-call RID
+(or ALGID/KID) overwrites the grant-time placeholder, but a zero end grant leaves
+the known value untouched. It is a one-way ratchet that only ever adds information.
+
+**Why can a call's RID be missing at start but present at end?**
+On P25 Phase 2 compressed grants the radio ID isn't on the control channel; it
+surfaces mid-call on the traffic channel. The engine backfills it onto the bound
+grant, so `KindCallEnd` carries the real RID. Without the never-downgrade UPDATE
+(issue #696) the history row would keep `source_id = 0` and the caller would never
+appear in call history.
+
+**Does the call log need CGO or a native SQLite library?**
+No. It uses `modernc.org/sqlite`, a pure-Go SQLite driver, so `CGO_ENABLED=0`
+holds across the daemon and it cross-compiles to targets like `linux/arm64` with
+no C toolchain — which matters when the scanner runs on a Raspberry Pi.
+
+## Series navigation
+
+**Part 10 of 14** · ←
+[Part 9: The Call-Complete Seam]({{ '/blog/deep-dives/recording-streaming-09-call-complete-seam/' | relative_url }})
+· Next →
+[Part 11: Retention & Housekeeping]({{ '/blog/deep-dives/recording-streaming-11-retention-housekeeping/' | relative_url }})

--- a/docs/_posts/2026-08-11-recording-streaming-11-retention-housekeeping.md
+++ b/docs/_posts/2026-08-11-recording-streaming-11-retention-housekeeping.md
@@ -1,0 +1,365 @@
+---
+title: "Recording, Composition & Streaming, Part 11: Retention & Housekeeping"
+description: How GopherTrunk bounds disk and database growth with one idempotent background sweeper — call-row age, an allow-listed set of decoder-log tables, and mtime-based deletion of only .wav and .raw artifacts under an opt-in files root, each lane gated independently by config.
+category: deep-dives
+keywords: sdr recording retention, disk housekeeping sweeper, sqlite row retention, mtime file deletion, opt-in config gating, idempotent background job, decoder log table allow-list, gophertrunk retention
+tags: [storage, retention, housekeeping, sqlite, go, filesystem]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Recording, Composition & Streaming"
+series_part: 11
+---
+
+*Part 11 of **Recording, Composition & Streaming**, following the 3 p.m.
+dispatch on talkgroup 101 from PCM to a Broadcastify upload. By now that call is
+two artifacts: a WAV the
+[recorder]({{ '/blog/deep-dives/recording-streaming-04-recording-session/' | relative_url }})
+wrote and a
+[call_log row]({{ '/blog/deep-dives/recording-streaming-10-call-log-sqlite/' | relative_url }})
+the persistence layer wrote. Multiply that by every call, every day, and a
+scanner left running fills its disk. This post is about the janitor — the one
+background job whose entire purpose is to make sure that yesterday's dispatch
+doesn't outlive its welcome, without ever touching a file it wasn't told to.*
+
+> **TL;DR:** `storage.Retention` is a single idempotent sweeper that runs at
+> startup and then every `Interval`. It has three independent lanes — old
+> `call_log` rows, old rows in an allow-listed set of decoder-log tables, and old
+> `.wav` / `.raw` files under a `FilesRoot` — and **each lane runs only if its own
+> max-age is set**. File deletion is doubly opt-in: it needs both a `FilesRoot` and
+> a non-zero `FilesMaxAge`, and it deletes *only* recording artifacts by extension,
+> never a config or CSV parked nearby. The daemon builds the sweeper at all only
+> when at least one retention window is configured.
+
+**Key takeaways**
+
+- **Three lanes, three gates.** Call rows, decoder-log tables, and files are each
+  swept only when their respective max-age is greater than zero. A zero age is a
+  disabled lane, not "delete everything."
+- **Opt-in by config.** No `retention:` window in the YAML → the daemon never
+  constructs a `Retention` at all. File deletion additionally requires an explicit
+  `FilesRoot`.
+- **Deletes only recording artifacts.** The filesystem walk removes a file only if
+  its extension is `.wav` or `.raw` *and* its mtime is past the cutoff — configs
+  and talkgroup CSVs in the same tree are left alone.
+- **Idempotent and crash-tolerant.** Every sweep recomputes cutoffs from
+  `time.Now()`; errors are logged and swallowed so a transient FS or DB hiccup
+  never kills the loop.
+
+## Cheat sheet
+
+| Thing | What it does | Where |
+|---|---|---|
+| `Retention` | The sweeper: three age-gated deletion lanes | `internal/storage/retention.go` |
+| `RetentionOptions` | Per-lane max-ages, `FilesRoot`, `Interval` | `internal/storage/retention.go` |
+| `SweepOnce` | Runs the configured deletions once | `internal/storage/retention.go` |
+| `deleteOldRows` | `DELETE FROM call_log WHERE started_at < cutoff` | `internal/storage/retention.go` |
+| `deleteOldLogRows` / `deleteOldByColumn` | Age-out one decoder-log table by its timestamp column | `internal/storage/retention.go` |
+| `deleteOldFiles` / `isRecordingArtifact` | `filepath.Walk` + extension + mtime check | `internal/storage/retention.go` |
+| `decoderLogTables` | The allow-list of sweepable log tables | `internal/storage/retention.go` |
+| daemon wiring | Builds `Retention` only if a window is set | `cmd/gophertrunk/daemon.go` |
+
+## In this post
+
+- **The shape of a sweeper** — `Run`, `SweepOnce`, and the three gated lanes.
+- **Aging out rows** — the call-log lane and the decoder-log allow-list.
+- **Aging out files** — the walk, the extension guard, and the mtime cutoff.
+- **Opt-in by config** — how the daemon decides whether a sweeper exists at all.
+- **Idempotence** — why re-running the sweep is always safe.
+
+## A janitor, not a pipeline
+
+Retention is the one subsystem in this series that isn't a bus subscriber. It
+reacts to a **timer**, not to call events — nothing about a call's life triggers
+a sweep. `Run` does one sweep immediately at startup (so a daemon that was down
+over a retention boundary catches up on boot) and then ticks on `Interval`:
+
+```go
+// internal/storage/retention.go (shape)
+func (r *Retention) Run(ctx context.Context) error {
+    r.SweepOnce(ctx)
+    tick := time.NewTicker(r.interval)
+    defer tick.Stop()
+    for {
+        select {
+        case <-ctx.Done():
+            return ctx.Err()
+        case <-tick.C:
+            r.SweepOnce(ctx)
+        }
+    }
+}
+```
+
+`SweepOnce` is the whole policy in one function. It has three lanes, and each is
+guarded by a two-part check: the relevant backend must exist (`r.db != nil`, or a
+non-empty `r.files`) **and** that lane's max-age must be positive. A zero age
+means the lane is off:
+
+```go
+// internal/storage/retention.go (shape)
+func (r *Retention) SweepOnce(ctx context.Context) {
+    if r.db != nil && r.dbAge > 0 {
+        r.deleteOldRows(ctx) // call_log rows
+    }
+    if r.db != nil && r.logAge > 0 {
+        for _, table := range decoderLogTables {
+            r.deleteOldLogRows(ctx, table) // pager_log, aprs_log, …
+        }
+    }
+    if r.files != "" && r.filesAge > 0 {
+        r.deleteOldFiles() // .wav / .raw under FilesRoot
+    }
+}
+```
+
+That two-part gate is the design's spine: **presence of a backend is not consent
+to delete.** A daemon with a database attached but no `CallRowMaxAge` sweeps zero
+rows. Errors inside each lane are logged and swallowed — a locked file or a
+transient DB error must not tear down the ticker — so the sweeper self-heals on
+the next tick.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 210" width="660" height="210" role="img" aria-label="Three independent sweep lanes fan out from SweepOnce. The first lane deletes call_log rows older than CallRowMaxAge and is gated by that age being greater than zero. The second lane iterates the decoder-log table allow-list, deleting rows older than LogRowMaxAge, gated by that age. The third lane walks FilesRoot deleting .wav and .raw files older than FilesMaxAge, gated by both a non-empty FilesRoot and that age. Each gate is independent.">
+  <rect x="250" y="14" width="160" height="34" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="330" y="30" text-anchor="middle" fill="var(--accent)" font-size="11">SweepOnce</text>
+  <text x="330" y="43" text-anchor="middle" fill="var(--fg-muted)" font-size="8">timer-driven, not events</text>
+  <line x1="290" y1="48" x2="130" y2="86" stroke="currentColor"/><polygon points="130,82 122,90 138,90" fill="currentColor"/>
+  <line x1="330" y1="48" x2="330" y2="86" stroke="currentColor"/><polygon points="326,86 330,94 334,86" fill="currentColor"/>
+  <line x1="370" y1="48" x2="530" y2="86" stroke="currentColor"/><polygon points="530,82 538,90 522,90" fill="currentColor"/>
+  <rect x="30" y="94" width="200" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="130" y="112" text-anchor="middle" fill="currentColor" font-size="10">call_log rows</text>
+  <text x="130" y="128" text-anchor="middle" fill="var(--fg-muted)" font-size="8">gate: dbAge &gt; 0</text>
+  <rect x="230" y="94" width="200" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="330" y="112" text-anchor="middle" fill="currentColor" font-size="10">decoder-log tables</text>
+  <text x="330" y="128" text-anchor="middle" fill="var(--fg-muted)" font-size="8">gate: logAge &gt; 0 · allow-list</text>
+  <rect x="430" y="94" width="200" height="44" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="530" y="112" text-anchor="middle" fill="var(--accent)" font-size="10">.wav / .raw files</text>
+  <text x="530" y="128" text-anchor="middle" fill="var(--fg-muted)" font-size="8">gate: FilesRoot ≠ "" &amp; filesAge &gt; 0</text>
+  <text x="130" y="160" text-anchor="middle" fill="var(--fg-muted)" font-size="9">started_at &lt; cutoff</text>
+  <text x="330" y="160" text-anchor="middle" fill="var(--fg-muted)" font-size="9">received_at &lt; cutoff</text>
+  <text x="530" y="160" text-anchor="middle" fill="var(--fg-muted)" font-size="9">mtime &lt; cutoff</text>
+  <text x="330" y="192" text-anchor="middle" fill="var(--fg-muted)" font-size="9">Each lane is independent — a zero max-age disables just that lane.</text>
+</svg>
+<figcaption>Three sweep lanes, three independent gates. A missing max-age silences one lane without affecting the others; nothing here is all-or-nothing.</figcaption>
+</figure>
+
+## Aging out rows
+
+The database lanes are almost too simple to describe, which is the point. The
+call-log lane computes a cutoff from *now* on every sweep and deletes anything
+older:
+
+```go
+// internal/storage/retention.go (shape)
+func (r *Retention) deleteOldRows(ctx context.Context) (int64, error) {
+    cutoff := time.Now().Add(-r.dbAge).UnixNano()
+    res, err := r.db.sql.ExecContext(ctx,
+        `DELETE FROM call_log WHERE started_at < ?`, cutoff)
+    // …return RowsAffected…
+}
+```
+
+`TestRetentionDeletesOldRows` pins the boundary: with a 24-hour age, a 25-hour-old
+row is deleted while 10-hour and 1-hour rows survive.
+
+The decoder-log lane is where the allow-list matters. GopherTrunk decodes far
+more than trunked voice — POCSAG pagers, APRS, AIS vessels, DSC, ADS-B aircraft,
+MDC1200, M17 — and each writes an append-only log table keyed by a `received_at`
+nanosecond column. The sweeper knows exactly which tables it may touch:
+
+```go
+// internal/storage/retention.go (shape)
+var decoderLogTables = []string{
+    "pager_log", "aprs_log", "vessel_log", "dsc_log",
+    "aircraft_log", "mdc1200_log", "m17_log",
+}
+```
+
+`deleteOldLogRows` is a thin wrapper over `deleteOldByColumn(ctx, table,
+"received_at")`, which interpolates the table and column names directly into the
+`DELETE`. That string-building is safe *precisely because* the inputs are
+in-code constants — the allow-list slice or a literal — never user input. The
+comment in the source says so explicitly, and it's the reason `location_log`
+(which keys on `reported_at`, not `received_at`) is swept by a separate call
+rather than being bolted into the loop. `TestRetentionLogSweepEveryTable` runs the
+delete against every allow-listed table plus the `location_log` special case, so a
+typo or a table missing its timestamp column would fail the build's tests.
+
+Note the two log lanes share one `logAge`: every decoder-log table ages out on the
+same window. `TestRetentionLogSweepDisabledByDefault` confirms the gate — with
+`CallRowMaxAge` set but `LogRowMaxAge` zero, a 100-day-old `m17_log` row survives
+untouched.
+
+## Aging out files
+
+The filesystem lane is the one that needs the most care, because a wrong deletion
+here is unrecoverable and the recordings directory is a place operators park other
+things. `deleteOldFiles` walks `FilesRoot` and applies two filters to every file
+it finds — an extension check and an mtime check — deleting only when *both* pass:
+
+```go
+// internal/storage/retention.go (shape)
+func (r *Retention) deleteOldFiles() (int, error) {
+    cutoff := time.Now().Add(-r.filesAge)
+    return filepath.Walk(r.files, func(path string, info os.FileInfo, err error) error {
+        if err != nil { return nil }        // tolerate transient FS errors
+        if info.IsDir() { return nil }
+        if !isRecordingArtifact(path) { return nil } // only .wav / .raw
+        if info.ModTime().After(cutoff) { return nil } // still fresh
+        os.Remove(path)
+        return nil
+    })
+}
+
+func isRecordingArtifact(path string) bool {
+    switch strings.ToLower(filepath.Ext(path)) {
+    case ".wav", ".raw":
+        return true
+    }
+    return false
+}
+```
+
+The extension guard is deliberate defensive coding. As the source comment notes,
+it's there so the sweep doesn't clobber configs or talkgroup CSVs an operator
+parked near the recordings. `TestRetentionDeletesOldFiles` makes the point
+concretely: in a tree containing an old `.wav`, an old `.raw`, a fresh `.wav`, and
+an old `config.yaml`, the sweep removes the two old artifacts, keeps the fresh
+one, and leaves the `config.yaml` alone even though it's well past the cutoff — the
+extension check saves it.
+
+Two more details worth noting. The walk swallows per-entry errors by returning
+`nil` from the walk function, so one unreadable directory doesn't abort the whole
+sweep. And the mtime comparison uses the file's own modification time, not any
+database record — the file lane needs no DB at all, which is why `NewRetention`
+accepts a `FilesRoot`-only configuration with no `DB`.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 640 250" width="640" height="250" role="img" aria-label="A decision tree for one file encountered during the filesystem walk. First: is it a directory? If yes, skip. Otherwise: is the extension .wav or .raw? If no, skip and preserve the file. Otherwise: is the modification time newer than the cutoff? If yes, skip because it is still fresh. Otherwise remove the file.">
+  <rect x="240" y="12" width="160" height="30" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="320" y="31" text-anchor="middle" fill="var(--accent)" font-size="10">walk entry</text>
+  <line x1="320" y1="42" x2="320" y2="60" stroke="currentColor"/><polygon points="316,60 320,68 324,60" fill="currentColor"/>
+  <rect x="230" y="68" width="180" height="30" rx="6" fill="none" stroke="currentColor"/>
+  <text x="320" y="87" text-anchor="middle" fill="currentColor" font-size="10">IsDir?</text>
+  <line x1="410" y1="83" x2="500" y2="83" stroke="currentColor"/><polygon points="500,79 508,83 500,87" fill="currentColor"/>
+  <text x="455" y="78" text-anchor="middle" fill="var(--fg-muted)" font-size="8">yes</text>
+  <rect x="508" y="68" width="110" height="30" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="563" y="87" text-anchor="middle" fill="var(--fg-muted)" font-size="9">skip</text>
+  <line x1="320" y1="98" x2="320" y2="116" stroke="currentColor"/><polygon points="316,116 320,124 324,116" fill="currentColor"/>
+  <text x="336" y="112" text-anchor="middle" fill="var(--fg-muted)" font-size="8">no</text>
+  <rect x="220" y="124" width="200" height="30" rx="6" fill="none" stroke="currentColor"/>
+  <text x="320" y="143" text-anchor="middle" fill="currentColor" font-size="10">ext .wav / .raw?</text>
+  <line x1="420" y1="139" x2="500" y2="139" stroke="currentColor"/><polygon points="500,135 508,139 500,143" fill="currentColor"/>
+  <text x="460" y="134" text-anchor="middle" fill="var(--fg-muted)" font-size="8">no</text>
+  <rect x="508" y="124" width="120" height="30" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="568" y="143" text-anchor="middle" fill="var(--fg-muted)" font-size="9">preserve</text>
+  <line x1="320" y1="154" x2="320" y2="172" stroke="currentColor"/><polygon points="316,172 320,180 324,172" fill="currentColor"/>
+  <text x="336" y="168" text-anchor="middle" fill="var(--fg-muted)" font-size="8">yes</text>
+  <rect x="220" y="180" width="200" height="30" rx="6" fill="none" stroke="currentColor"/>
+  <text x="320" y="199" text-anchor="middle" fill="currentColor" font-size="10">mtime &gt; cutoff?</text>
+  <line x1="420" y1="195" x2="500" y2="195" stroke="currentColor"/><polygon points="500,191 508,195 500,199" fill="currentColor"/>
+  <text x="458" y="190" text-anchor="middle" fill="var(--fg-muted)" font-size="8">yes (fresh)</text>
+  <rect x="508" y="180" width="120" height="30" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="568" y="199" text-anchor="middle" fill="var(--fg-muted)" font-size="9">skip</text>
+  <line x1="320" y1="210" x2="320" y2="226" stroke="var(--accent)"/><polygon points="316,226 320,234 324,226" fill="var(--accent)"/>
+  <text x="336" y="223" text-anchor="middle" fill="var(--fg-muted)" font-size="8">no (old)</text>
+  <rect x="250" y="226" width="140" height="24" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="320" y="242" text-anchor="middle" fill="var(--accent)" font-size="10">os.Remove</text>
+</svg>
+<figcaption>The per-file decision tree. A file is deleted only after passing both the extension guard and the mtime cutoff; every other path preserves it.</figcaption>
+</figure>
+
+## Opt-in by config
+
+None of this exists unless the operator asks for it. In
+`cmd/gophertrunk/daemon.go`, the sweeper is constructed only when at least one
+retention window is set:
+
+```go
+// cmd/gophertrunk/daemon.go (shape)
+if cfg.Retention.CallLogDays > 0 ||
+    cfg.Retention.LogDays > 0 ||
+    cfg.Retention.FilesDays > 0 {
+    interval, _ := retentionInterval(cfg.Retention.Interval)
+    r, _ := storage.NewRetention(storage.RetentionOptions{
+        DB:            db,
+        FilesRoot:     cfg.Recordings.Dir,
+        CallRowMaxAge: time.Duration(cfg.Retention.CallLogDays) * 24 * time.Hour,
+        FilesMaxAge:   time.Duration(cfg.Retention.FilesDays) * 24 * time.Hour,
+        Interval:      interval,
+    })
+    d.retention = r
+}
+```
+
+This is the same **config-driven lazy init** rule that runs through the whole
+output half (see
+[Part 1]({{ '/blog/deep-dives/recording-streaming-01-the-output-half/' | relative_url }})):
+with no retention days configured, `d.retention` stays nil and the daemon never
+spawns the sweep goroutine. The `FilesRoot` is wired from the recordings directory,
+so file deletion piggybacks on wherever the recorder is already writing — but only
+takes effect when `FilesDays` (hence `FilesMaxAge`) is non-zero, keeping file
+deletion doubly opt-in. `retentionInterval` parses the optional interval string,
+defaulting to one hour when it's empty, mirroring `NewRetention`'s own default.
+
+`NewRetention` itself refuses a pointless configuration:
+`TestRetentionRequiresAtLeastOne` confirms it errors when neither a `DB` nor a
+`FilesRoot` is supplied — there'd be nothing to sweep.
+
+## Idempotence
+
+The reason this sweeper can run at startup, on every tick, and even concurrently
+with the writers is that it holds no state between runs. Every lane recomputes its
+cutoff from `time.Now()` at the moment it executes; a `DELETE ... WHERE ts <
+cutoff` that finds nothing to delete is a no-op, and re-deleting an already-deleted
+row or file simply affects zero rows or is skipped by the walk. There is no
+"mark-then-sweep" bookkeeping to get out of sync.
+
+Concurrency with the [call log]({{ '/blog/deep-dives/recording-streaming-10-call-log-sqlite/' | relative_url }})
+writer is safe because SQLite serialises writers — the store caps the pool to a
+single connection, so the sweeper's `DELETE` and the call log's `UPDATE` take
+turns rather than racing. `TestRetentionRunStopsOnContextCancel` confirms the loop
+exits cleanly on context cancellation, returning the cancellation error like every
+other long-lived subsystem in the daemon.
+
+## Where this goes next
+
+That's the persistence and housekeeping pair complete — the call is now recorded,
+indexed, and destined to be cleaned up on schedule. The next posts turn to the
+*live* side of the output half.
+[Part 12]({{ '/blog/deep-dives/recording-streaming-12-live-listening/' | relative_url }})
+covers live listening: how the same decoded PCM that fills the WAV is fanned out
+to a browser or gRPC listener in real time, with no file and no database involved.
+
+## FAQ
+
+**Does GopherTrunk delete my recordings by default?**
+No. File deletion is doubly opt-in: it needs both a recordings directory
+(`FilesRoot`) and a non-zero `retention.files_days`. With no `retention:` window
+configured at all, the daemon never even constructs the sweeper, so nothing is
+ever deleted.
+
+**Will the sweeper remove non-recording files in the recordings folder?**
+No. `isRecordingArtifact` only matches `.wav` and `.raw` extensions. A
+`config.yaml`, a talkgroup CSV, or any other file in the same tree is skipped
+regardless of age — the extension guard exists specifically to protect files
+operators park nearby.
+
+**How do the three retention lanes relate?**
+They're independent. Call-row age (`call_log_days`), decoder-log age
+(`log_days`), and file age (`files_days`) each gate their own lane; setting one
+does nothing to the others, and a zero value disables just that lane rather than
+meaning "delete everything."
+
+**Is it safe to run retention while calls are being logged?**
+Yes. The sweep is idempotent — it recomputes cutoffs from the current time each
+run and re-running deletes nothing already gone — and SQLite serialises writers
+against a single connection, so the sweeper's deletes and the call log's writes
+take turns instead of racing.
+
+## Series navigation
+
+**Part 11 of 14** · ←
+[Part 10: The Call Log — SQLite Persistence & Never-Downgrade Updates]({{ '/blog/deep-dives/recording-streaming-10-call-log-sqlite/' | relative_url }})
+· Next →
+[Part 12: Live Listening]({{ '/blog/deep-dives/recording-streaming-12-live-listening/' | relative_url }})

--- a/docs/_posts/2026-08-12-recording-streaming-12-live-listening.md
+++ b/docs/_posts/2026-08-12-recording-streaming-12-live-listening.md
@@ -1,0 +1,395 @@
+---
+title: "Recording, Composition & Streaming, Part 12: Live Listening — The Local Audio Path"
+description: How GopherTrunk lets you hear a call the instant it decodes — a lock-free AudioPublisher fan-out, an open-ended WAV HTTP stream that even Safari will play, a gRPC StreamAudio path, and a host speaker player that deliberately refuses digital PCM to avoid an echo.
+category: deep-dives
+keywords: live audio streaming sdr, browser wav stream, safari range request 206, grpc streamaudio, audio publisher fan-out, drop on full backpressure, host speaker player oto, gophertrunk live listening, decoded pcm tap, comb filter echo
+tags: [streaming, audio, http, grpc, go, real-time]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Recording, Composition & Streaming"
+series_part: 12
+---
+
+*Part 12 of **Recording, Composition & Streaming**, following one call — the 3
+p.m. dispatch on talkgroup 101 — through GopherTrunk's output half. In
+[Part 5]({{ '/blog/deep-dives/recording-streaming-05-wav-on-disk/' | relative_url }})
+we watched its PCM land in a crash-safe WAV on disk. But an operator staring at
+the scanner doesn't want to open a file thirty seconds later — they want to hear
+the dispatcher **now**, while it's still keyed up. This post is the live path:
+the same decoded PCM that fills the WAV is teed to a fan-out point that feeds a
+browser stream, a gRPC subscriber, and the tone-out detector — and, for analog
+FM only, the machine's own speakers.*
+
+> **TL;DR:** The recorder decodes each call exactly once and taps that PCM into
+> the **`AudioPublisher`** (`internal/api/audio_publisher.go`), a lock-free
+> fan-out that copies frames to every connected subscriber over a **bounded
+> channel** and **drops on full** rather than letting one slow client stall the
+> composer. Browsers play an **open-ended WAV** whose header lies about its
+> length so playback never stops; Safari additionally demands a `Range`/`206`
+> handshake, which `handleAudioStream` answers. gRPC clients get the same frames
+> via `StreamAudio`. The host-speaker **`Player`** is wired separately and is fed
+> **analog FM only** — routing decoded digital PCM there too would play the call
+> twice on one box and comb-filter into an echo (issue #598 follow-up).
+
+**Key takeaways**
+
+- **One decode, many ears.** The recorder is the lone decoder; its decoded PCM
+  is fanned to the publisher, the tone-out detector, and (for analog) the
+  speakers. Nobody decodes the channel twice.
+- **Drop-on-full, never block.** Every subscriber owns a 256-frame channel. A
+  stalled network write drops frames and counts the loss — it never back-pressures
+  the composer goroutine that produced them.
+- **The WAV header is a polite lie.** `streamingWAVHeader` declares a ~2 GiB data
+  chunk so a browser `<audio>` element keeps reading until the socket closes.
+- **The host speaker gets analog only.** Digital PCM is excluded from the local
+  `Player` on purpose: it already streams to the WebUI, and playing it locally
+  too produces two offset copies that comb-filter into an echo.
+
+## Cheat sheet
+
+| Thing | What it does | Where in code |
+|---|---|---|
+| `AudioPublisher` | Lock-free fan-out of decoded PCM to N subscribers | `internal/api/audio_publisher.go` |
+| `WritePCM` / `WritePCMForCall` | Satisfies `composer.PCMSink`; the second fences cross-call bleed by `CallID` | `audio_publisher.go` |
+| `WriteRawFrame` | Fans un-decoded IMBE/AMBE bytes to `IncludeRaw` subscribers | `audio_publisher.go` |
+| `Subscribe` / `Unsubscribe` | Registers/removes one wire-side stream + its bounded channel | `audio_publisher.go` |
+| `audioSubChanCap` | Per-subscriber channel depth (256 frames) | `audio_publisher.go` |
+| `handleAudioStream` | Open-ended WAV over HTTP for `<audio src=…>` | `internal/api/handlers_audio_stream.go` |
+| `streamingWAVHeader` / `parseRange` | 44-byte oversized WAV header; Safari `Range` parser | `handlers_audio_stream.go` |
+| `StreamAudio` | gRPC server-stream of `AudioFrame`s | `internal/api/grpc.go` |
+| `player.Player` | Host-speaker sink (oto → ALSA/CoreAudio/WASAPI) | `internal/voice/player/player.go` |
+| `liveSinks` wiring | Assembles the live tap; excludes digital from the speaker | `cmd/gophertrunk/daemon.go` |
+
+## In this post
+
+- **The fan-out point** — why `AudioPublisher` implements the same `WritePCM`
+  contract the recorder does, and how drop-on-full keeps a slow client harmless.
+- **The browser stream** — an open-ended WAV, and the Safari `Range`/`206` dance
+  `handleAudioStream` performs to satisfy WebKit's media element.
+- **The gRPC path** — the same frames, structured, for non-browser consumers.
+- **The host speaker** — the `Player`, and the deliberate rule that keeps
+  **digital PCM off the local speakers** so you don't get an echo.
+
+## The fan-out point
+
+By the time our 3 p.m. dispatch is audible, the
+[Voice Coding composer]({{ '/blog/deep-dives/voice-coding-09-the-composer/' | relative_url }})
+has turned the voice channel's IQ into 8 kHz PCM, and — as
+[Part 4]({{ '/blog/deep-dives/recording-streaming-04-recording-session/' | relative_url }})
+described — the recorder is the one component that decodes it. The trick that
+makes live listening cheap is that the recorder doesn't keep that PCM to itself.
+It exposes a **decoded-PCM tap**, and the daemon points that tap at a fan-out
+sink whose members all speak the same tiny interface the recorder itself
+satisfies:
+
+```go
+// internal/composer/sink.go (shape)
+type PCMSink interface {
+    WritePCM(deviceSerial string, samples []int16) error
+}
+```
+
+The `AudioPublisher` implements exactly this, which is why the daemon can drop it
+into the fan-out beside every other sink without any of them knowing the others
+exist. Its whole reason to live is to copy each PCM chunk to any number of
+connected listeners:
+
+```go
+// internal/api/audio_publisher.go (shape)
+func (p *AudioPublisher) WritePCM(deviceSerial string, samples []int16) error {
+    p.mu.RLock()
+    defer p.mu.RUnlock()
+    if len(p.subs) == 0 {
+        return nil // no listeners: allocate nothing, copy nothing
+    }
+    var frame *apiv1.AudioFrame // built lazily on first match
+    for sub := range p.subs {
+        if !sub.filter.matches(deviceSerial, grant.GroupID) {
+            continue
+        }
+        if frame == nil {
+            frame = buildPCMFrame(grant, deviceSerial, samples)
+        }
+        select {
+        case sub.ch <- frame:            // fast consumer: delivered
+        default:                          // slow consumer: drop, count, move on
+            sub.dropped.Add(uint64(len(samples)))
+            p.dropped.Add(uint64(len(samples)))
+        }
+    }
+    return nil
+}
+```
+
+Two design choices in that loop carry the whole post. First, the frame is built
+**lazily** — `buildPCMFrame` runs only once a subscriber actually matches, so the
+common "nobody is listening" case copies nothing. Second, the send is a
+**non-blocking** `select` with a `default` arm. Each subscriber owns a channel of
+`audioSubChanCap` (256) frames — a few seconds of slack at typical chunk sizes.
+If a client's network write stalls and its channel backs up, the publisher
+**drops the frame and increments a counter** rather than blocking. That is the
+single most important property here: the composer goroutine that produced the PCM
+is the same one draining the vocoder, and if a dead browser tab could stall it,
+one wedged listener would freeze decoding for everyone. Drop-on-full makes a slow
+consumer its own problem.
+
+**Subscribers register and deregister** through `Subscribe`/`Unsubscribe`. A
+subscriber carries a `filter` (device serials and/or talkgroup IDs; empty matches
+everything) and its bounded channel. `Unsubscribe` is idempotent and **closes the
+channel**, so the reader side sees a clean end-of-stream. The publisher also
+keeps a per-device-serial `Grant` map, fed by its own events-bus subscription, so
+each `buildPCMFrame` can stamp the wire frame with talkgroup/system context.
+
+One subtlety worth pinning: the grant cache is best-effort. The bus can drop the
+`CallStart` event under load, and gating audio on a known grant once left the
+WebUI silent while disk recordings kept working (issue #598). So `WritePCM` emits
+the PCM **even when the grant is unknown**, with a zero `Grant`; only
+talkgroup-*filtered* subscribers are skipped in that case, because their
+predicate can't be proven without a `GroupID` and we must never leak another
+talkgroup's audio to them. There is also a stricter sibling, `WritePCMForCall`,
+that carries the `CallID`: when a voice-tap serial has already been reused by a
+newer call, PCM still draining from the older one is **dropped rather than
+mislabelled** with the new call's talkgroup — closing a cross-call audio-bleed
+window. A parallel pair, `WriteRawFrame`/`WriteRawFrameForCall`, does the same for
+verbatim un-decoded vocoder bytes (IMBE/AMBE+2), fanned only to subscribers that
+set `IncludeRaw`.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 220" width="660" height="220" role="img" aria-label="The recorder decodes a call once and taps its PCM into the AudioPublisher, which fans copies to the HTTP WAV stream, the gRPC StreamAudio path, and the tone-out detector, each over its own bounded drop-on-full channel; the host speaker player is fed on a separate path by analog FM only, not by the digital decoded PCM.">
+  <rect x="8" y="86" width="120" height="46" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="68" y="106" text-anchor="middle" fill="var(--accent)" font-size="11">recorder</text>
+  <text x="68" y="122" text-anchor="middle" fill="var(--fg-muted)" font-size="9">lone decoder</text>
+  <line x1="128" y1="109" x2="162" y2="109" stroke="currentColor"/><polygon points="162,105 172,109 162,113" fill="currentColor"/>
+  <text x="150" y="101" text-anchor="middle" fill="var(--fg-muted)" font-size="8">decoded PCM tap</text>
+  <rect x="172" y="88" width="100" height="42" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="222" y="108" text-anchor="middle" fill="var(--accent)" font-size="11">AudioPublisher</text>
+  <text x="222" y="122" text-anchor="middle" fill="var(--fg-muted)" font-size="8">fan-out · drop-on-full</text>
+  <line x1="272" y1="98" x2="312" y2="34" stroke="currentColor"/><polygon points="308,30 318,32 312,41" fill="currentColor"/>
+  <line x1="272" y1="106" x2="312" y2="82" stroke="currentColor"/><polygon points="308,78 318,82 311,90" fill="currentColor"/>
+  <line x1="272" y1="118" x2="312" y2="130" stroke="currentColor"/><polygon points="311,125 318,132 308,134" fill="currentColor"/>
+  <rect x="318" y="18" width="170" height="30" rx="5" fill="none" stroke="currentColor"/>
+  <text x="403" y="33" text-anchor="middle" fill="currentColor" font-size="10">HTTP WAV stream</text>
+  <text x="403" y="44" text-anchor="middle" fill="var(--fg-muted)" font-size="8">&lt;audio src=…&gt; · Safari-safe</text>
+  <rect x="318" y="66" width="170" height="30" rx="5" fill="none" stroke="currentColor"/>
+  <text x="403" y="81" text-anchor="middle" fill="currentColor" font-size="10">gRPC StreamAudio</text>
+  <text x="403" y="92" text-anchor="middle" fill="var(--fg-muted)" font-size="8">structured AudioFrame</text>
+  <rect x="318" y="114" width="170" height="30" rx="5" fill="none" stroke="currentColor"/>
+  <text x="403" y="129" text-anchor="middle" fill="currentColor" font-size="10">tone-out detector</text>
+  <text x="403" y="140" text-anchor="middle" fill="var(--fg-muted)" font-size="8">Goertzel on raw PCM</text>
+  <line x1="128" y1="180" x2="312" y2="180" stroke="var(--fg-muted)" stroke-dasharray="4 3"/><polygon points="312,176 322,180 312,184" fill="var(--fg-muted)"/>
+  <text x="215" y="173" text-anchor="middle" fill="var(--fg-muted)" font-size="8">analog FM only (composer main fanout)</text>
+  <rect x="322" y="166" width="170" height="30" rx="5" fill="none" stroke="var(--fg-muted)"/>
+  <text x="407" y="181" text-anchor="middle" fill="var(--fg-muted)" font-size="10">host speaker Player</text>
+  <text x="407" y="192" text-anchor="middle" fill="var(--fg-muted)" font-size="8">digital excluded (no echo)</text>
+</svg>
+<figcaption>One decode, several ears. The publisher fans decoded PCM to the network stream and tone-out; the host speaker is on a separate arm fed by analog FM only, so a digital call is never played locally and streamed at the same time.</figcaption>
+</figure>
+
+## The browser stream: an open-ended WAV
+
+The most convenient live sink needs no client software at all — an
+`<audio src="/api/v1/audio/stream">` element in the WebUI. `handleAudioStream`
+serves that URL as a **single, never-ending WAV file**. The mechanism is delightfully
+blunt: a WAV file begins with a 44-byte RIFF/WAVE header whose `data` chunk
+declares how many sample bytes follow. `streamingWAVHeader` fills that field with
+`0x7FFFFFFF` — almost 2 GiB — so a browser believes it has an enormous file ahead
+of it and keeps reading PCM off the socket until the connection closes:
+
+```go
+// internal/api/handlers_audio_stream.go (shape)
+const (
+    wavHeaderSize  = 44
+    wavMaxDataSize = uint32(0x7FFFFFFF) // declared data-chunk size (a lie)
+    wavTotalSize   = int64(wavHeaderSize) + int64(wavMaxDataSize)
+)
+```
+
+After emitting the header the handler subscribes to the publisher, then loops:
+every matching `AudioFrame` is already 16-bit little-endian mono per
+`buildPCMFrame`, so it writes the sample bytes straight through and `Flush`es.
+Because the response is long-lived, the handler first clears the server's
+`WriteTimeout` via `http.NewResponseController` so a quiet channel between overs
+doesn't get the socket torn down mid-call. For Chrome, Firefox, and `curl`, that
+plain `200` chunked stream is the whole story.
+
+### The Safari Range dance
+
+Safari (macOS and iOS) is the exception, and it's the reason `parseRange` exists.
+WebKit's media element **refuses to play from a server that doesn't advertise
+byte-range support.** It will not accept a bare `200`; instead it opens with a
+tiny probe — typically `Range: bytes=0-1` — to learn the resource size, and only
+then issues the real `Range: bytes=0-` for the body. `handleAudioStream` answers
+both:
+
+- **The probe** (`bytes=0-1`, entirely inside the 44-byte header) is served
+  without ever subscribing to live audio. The handler slices those exact header
+  bytes, sets `Accept-Ranges: bytes` and a `Content-Range` citing the ~2 GiB
+  total, and returns `206 Partial Content`. Safari now knows the "size."
+- **The bulk request** (`bytes=0-`, open-ended) subscribes for real, replies
+  `206` with a `Content-Range` of `bytes 0-<total-1>/<total>`, writes the header
+  from the requested offset, and then streams live frames exactly as the `200`
+  path does.
+
+`parseRange` is deliberately narrow: it accepts a single `bytes=start-end` or
+`bytes=start-`, and returns `ok=false` for suffix ranges (`bytes=-N`), multi-range
+requests, or anything malformed — in which case the handler falls back to the
+plain `200` stream, which is safe for every non-Safari client. The upshot is that
+a **live** stream, which has no real seekable length, satisfies a media element
+that was designed around seekable files.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 640 210" width="640" height="210" role="img" aria-label="A sequence diagram of Safari's handshake with the audio stream endpoint: Safari first sends a Range request for bytes 0 to 1, the server replies 206 Partial Content with the WAV header bytes and a Content-Range citing the near-2-gigabyte total; Safari then sends an open-ended Range request for bytes 0 onward, and the server replies 206 and streams the live WAV body until the connection closes.">
+  <text x="150" y="22" text-anchor="middle" fill="var(--accent)" font-size="11">Safari media element</text>
+  <text x="490" y="22" text-anchor="middle" fill="var(--accent)" font-size="11">/api/v1/audio/stream</text>
+  <line x1="150" y1="32" x2="150" y2="196" stroke="var(--fg-muted)" stroke-dasharray="3 3"/>
+  <line x1="490" y1="32" x2="490" y2="196" stroke="var(--fg-muted)" stroke-dasharray="3 3"/>
+  <line x1="150" y1="52" x2="486" y2="52" stroke="currentColor"/><polygon points="486,48 496,52 486,56" fill="currentColor"/>
+  <text x="318" y="46" text-anchor="middle" fill="currentColor" font-size="9">GET · Range: bytes=0-1  (size probe)</text>
+  <line x1="490" y1="82" x2="154" y2="82" stroke="var(--accent)"/><polygon points="154,78 144,82 154,86" fill="var(--accent)"/>
+  <text x="318" y="76" text-anchor="middle" fill="var(--accent)" font-size="9">206 · Content-Range bytes 0-1/2147483691 · header bytes</text>
+  <line x1="150" y1="122" x2="486" y2="122" stroke="currentColor"/><polygon points="486,118 496,122 486,126" fill="currentColor"/>
+  <text x="318" y="116" text-anchor="middle" fill="currentColor" font-size="9">GET · Range: bytes=0-  (open-ended body)</text>
+  <line x1="490" y1="152" x2="154" y2="152" stroke="var(--accent)"/><polygon points="154,148 144,152 154,156" fill="var(--accent)"/>
+  <text x="318" y="146" text-anchor="middle" fill="var(--accent)" font-size="9">206 · WAV header, then live PCM frames…</text>
+  <line x1="490" y1="180" x2="154" y2="180" stroke="var(--fg-muted)"/><polygon points="154,176 144,180 154,184" fill="var(--fg-muted)"/>
+  <text x="318" y="174" text-anchor="middle" fill="var(--fg-muted)" font-size="9">…flushed per over until the socket closes</text>
+</svg>
+<figcaption>Safari won't play a bare 200. It probes for a size, then requests the body — and <code>handleAudioStream</code> answers both with a 206, serving the header from cache for the probe and streaming live for the body.</figcaption>
+</figure>
+
+## The gRPC path: the same frames, structured
+
+Not every consumer is a browser. A companion app, a transcription bridge, or a
+CLI wants **structured** frames, not a raw byte river. That's `StreamAudio`, a
+server-streaming RPC that reuses the *identical* publisher plumbing:
+
+```go
+// internal/api/grpc.go (shape)
+func (g *GRPCServer) StreamAudio(req *apiv1.StreamAudioRequest,
+    srv apiv1.AudioService_StreamAudioServer) error {
+    sub := g.audio.Subscribe(AudioSubFilter{
+        DeviceSerials: req.GetDeviceSerials(),
+        TalkgroupIDs:  req.GetTalkgroupIds(),
+        IncludeRaw:    req.GetIncludeRaw(),
+    })
+    defer g.audio.Unsubscribe(sub)
+    for {
+        select {
+        case <-srv.Context().Done():
+            return nil
+        case frame, ok := <-sub.ch:
+            if !ok {
+                return nil
+            }
+            if err := srv.Send(frame); err != nil {
+                return err
+            }
+        }
+    }
+}
+```
+
+It is the HTTP loop with the framing swapped: `Subscribe`, drain the bounded
+channel, `Send`, and clean up on `Unsubscribe`. Because a gRPC subscriber can set
+`IncludeRaw`, this is the path that carries **un-decoded vocoder frames** — the
+verbatim IMBE/AMBE bytes the recorder also writes to the `.raw` sidecar from
+[Part 6]({{ '/blog/deep-dives/recording-streaming-06-segmentation-naming-sidecars/' | relative_url }})
+— to a client that wants to run its own decoder. HTTP browser clients never opt
+into raw, so they only ever see PCM.
+
+## The host speaker, and why digital PCM stays off it
+
+The last live sink is the machine's own speakers: `player.Player`. It, too,
+implements `WritePCM`, so it drops into the fan-out like everything else. Its
+backend is `github.com/ebitengine/oto/v3` — ALSA on Linux, CoreAudio on macOS,
+WASAPI on Windows — with a **software gain/mute stage** applied at `WritePCM`
+time so volume changes are instant, and the same **drop-on-full** discipline: a
+bounded queue and a non-blocking send, so a stalled audio device never
+back-pressures the composer. When `audio.enabled` is false, the device is
+`"null"`, or the backend won't open on a headless box, `New` returns a **no-op
+player** and the rest of the daemon runs identically — a dead speaker surfaces as
+`Stats().BackendError`, not as a crash.
+
+Here is the rule that trips people up. The host speaker is **not** on the same
+tap as the network stream. Look at the daemon's live wiring:
+
+```go
+// cmd/gophertrunk/daemon.go (shape)
+// The host speaker player is deliberately EXCLUDED from this tap:
+// routing decoded digital PCM there plays the call on the local
+// speaker while the WebUI streams the same PCM, and on one machine
+// the two offset playbacks echo / comb-filter (issue #598 follow-up).
+var liveSinks []composer.PCMSink
+if d.toneout != nil {
+    liveSinks = append(liveSinks, d.toneout)
+}
+liveSinks = append(liveSinks, liveStreamSink) // the AudioPublisher
+d.voiceDecoder.SetDecodedPCMSink(fanoutSink(liveSinks))
+```
+
+The `liveSinks` fan-out — the decoded-digital tap — contains the publisher and
+the tone-out detector, but **not** the `Player`. Digital protocols (P25, DMR,
+NXDN, …) reach the WebUI live, and if the same box is running the browser, the
+operator hears the call there. Feeding the speaker the same decoded PCM would
+play the call **twice on one machine**, a few tens of milliseconds apart, and the
+two offset copies comb-filter into a hollow echo. Analog FM, by contrast, still
+reaches the speaker — but through the composer's *main* sink fanout, wired via a
+`playerSink` adapter that also honours the per-talkgroup `Mute` flag. So the
+`Player` gets analog only; digital host-speaker playback is intentionally out of
+scope.
+
+> **⚠ If your live browser stream is silent but recordings are fine**, the usual
+> cause is grant-gating, not the audio path — which is exactly issue #598. The
+> publisher now emits PCM with a zero grant when `CallStart` was dropped, so
+> unfiltered and device-only subscribers still hear audio; only talkgroup-filtered
+> subscribers are skipped without a known grant.
+
+The `TestDaemonWiresLiveAudioWithoutRecordings` integration test
+(`cmd/gophertrunk/daemon_live_audio_test.go`) pins the other half of this:
+configuring **no** recordings directory must still build a decode-only voice
+decoder, a composer, and a live `audioPub`, so a DMR user who never wanted files
+still hears calls in the browser.
+
+## Where this goes next
+
+Live listening is the ephemeral output — heard once, kept nowhere. The durable,
+shared output is next.
+[Part 13]({{ '/blog/deep-dives/recording-streaming-13-broadcast-manager/' | relative_url }})
+opens the **broadcast manager**: the subsystem that waits on `KindCallComplete`,
+reads the finished WAV, encodes it to MP3 once, and pushes it to aggregator feeds
+with bounded retry — the step that finally turns our 3 p.m. dispatch into a row
+in a Broadcastify feed.
+
+## FAQ
+
+**Why does the browser stream never end?** `streamingWAVHeader` writes a 44-byte
+WAV header whose `data` chunk claims ~2 GiB of samples follow. A browser `<audio>`
+element trusts that length and keeps reading PCM off the socket until the
+connection closes, so a single request plays live audio indefinitely rather than
+stopping at a real file boundary.
+
+**Why the special handling for Safari?** WebKit's media element refuses to play
+from a server that doesn't support byte ranges. Safari sends a small `Range:
+bytes=0-1` probe to learn the size, then an open-ended `bytes=0-` for the body;
+`handleAudioStream` answers both with `206 Partial Content` and an `Accept-Ranges`
+header. Chrome, Firefox, and curl send no `Range` and take the plain `200`
+streaming path.
+
+**What happens if a listener is too slow?** Each subscriber owns a bounded
+256-frame channel (`audioSubChanCap`). When it fills, the publisher drops the
+frame and increments both a per-subscriber and a global counter instead of
+blocking. This keeps one wedged client from back-pressuring the composer goroutine
+that decodes audio for everyone.
+
+**Why can't I hear digital calls on the host's speakers?** By design. Digital PCM
+is excluded from the local `Player` because it already streams to the WebUI;
+playing it locally too would produce two offset copies on one machine that
+comb-filter into an echo (issue #598 follow-up). Analog FM still reaches the
+speakers through the composer's main fan-out.
+
+## Series navigation
+
+**Part 12 of 14** · ←
+[Part 11: Retention & Housekeeping]({{ '/blog/deep-dives/recording-streaming-11-retention-housekeeping/' | relative_url }})
+· Next →
+[Part 13: The Broadcast Manager]({{ '/blog/deep-dives/recording-streaming-13-broadcast-manager/' | relative_url }})

--- a/docs/_posts/2026-08-13-recording-streaming-13-broadcast-manager.md
+++ b/docs/_posts/2026-08-13-recording-streaming-13-broadcast-manager.md
@@ -1,0 +1,440 @@
+---
+title: "Recording, Composition & Streaming, Part 13: Outbound Streaming — The Broadcast Manager"
+description: How GopherTrunk ships a finished call to the outside world — one bus subscriber that gates on stream/duration, encodes MP3 exactly once, and fans out through a bounded worker pool with drop-on-full and exponential-backoff retry so a wedged aggregator can never back-pressure the decode path.
+category: deep-dives
+keywords: broadcast manager gophertrunk, call complete subscriber, bounded worker pool go, drop on full queue, exponential backoff retry, lazy mp3 encode once, stream gate min duration, aggregator upload fanout, non blocking event loop
+tags: [streaming, broadcast, concurrency, go, backpressure, events]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Recording, Composition & Streaming"
+series_part: 13
+---
+
+*Part 13 of **Recording, Composition & Streaming**, following one call — the 3
+p.m. dispatch on talkgroup 101 — from PCM to a Broadcastify upload. By now the
+recorder has flushed its WAV, the call log has its row, and the engine has moved
+on. The last durable thing left to do is **share** the call: push it to
+Broadcastify, RdioScanner, OpenMHz, a webhook, or a live Icecast feed. This post
+is the machine that does the pushing — the **broadcast Manager**. Part 14 tours
+each destination's wire protocol; here we build the pump that feeds all of them.*
+
+> **TL;DR:** The `broadcast.Manager` is a single `KindCallComplete` subscriber.
+> On each completed call it applies two filters — the talkgroup **stream gate**
+> and a **minimum-duration** floor — then enqueues the call onto a bounded
+> channel. A fixed pool of **worker goroutines** drains that channel, encodes the
+> MP3 **once** (lazily, shared across all backends), and calls each backend's
+> `Send` with **exponential-backoff** retry. If the queue is full, the call is
+> **dropped**, never blocked — the decode path is sacred and the Manager will
+> lose an upload before it ever back-pressures the recorder.
+
+**Key takeaways**
+
+- The Manager's event loop does almost nothing: filter, then a **non-blocking
+  send** onto a buffered `jobs` channel. A wedged backend fills the queue and the
+  next call is dropped — the loop never stalls.
+- MP3 encoding is **lazy and once-per-call**. `Call.MP3()` memoises the encoded
+  bytes behind a mutex, so five backends streaming the same call pay for **one**
+  encode, and a metadata-only webhook pays for **zero**.
+- Retry is **per-backend**, bounded by `MaxRetries`, with a delay that starts at
+  `RetryBase` (2s) and **doubles** each attempt. After the budget is spent the
+  call is abandoned and counted as failed — it is never retried forever.
+- Two independent gates decide whether a call streams at all: the talkgroup's
+  `Stream` flag (operator opt-out) and `MinDuration` (kerchunk filter). Both live
+  in `dispatch`, before anything touches the network.
+
+## Cheat sheet
+
+| Thing | What it does | Where in code |
+|---|---|---|
+| `broadcast.Manager` | Subscribes to `KindCallComplete`, filters, fans out | `internal/broadcast/manager.go` |
+| `Options` | Bus, backends, `MinDuration`, `Workers`, `MaxRetries`, `RetryBase` | `internal/broadcast/manager.go` |
+| `Manager.dispatch` | Stream gate + min-duration filter + non-blocking enqueue | `internal/broadcast/manager.go` |
+| `Manager.worker` | Drains `jobs`, calls `sendWithRetry` per accepting backend | `internal/broadcast/manager.go` |
+| `Manager.sendWithRetry` | `MaxRetries+1` attempts, backoff doubles from `RetryBase` | `internal/broadcast/manager.go` |
+| `Call` / `Call.MP3()` | Completed call + lazy, memoised MP3 accessor | `internal/broadcast/broadcast.go` |
+| `Backend` | `Name` / `Accepts` / `Send` — one outbound destination | `internal/broadcast/broadcast.go` |
+| `buildBroadcastManager` | Builds the Manager from config; returns `nil` when no feed | `cmd/gophertrunk/broadcast.go` |
+
+## In this post
+
+- **The event seam** — why the Manager subscribes rather than being called.
+- **The two gates** in `dispatch` — stream opt-out and minimum duration.
+- **Drop-on-full** — the one decision that keeps the decode path unblockable.
+- **Encode once** — how `Call.MP3()` shares a single encode across N backends.
+- **Bounded backoff retry** — the `sendWithRetry` timeline, and when to give up.
+
+## The seam: one subscriber, nothing calls it
+
+[Part 1]({{ '/blog/deep-dives/recording-streaming-01-the-output-half/' | relative_url }})
+established the rule the whole output half lives by: subsystems **subscribe**,
+they don't call each other. The broadcast Manager is the purest example. It
+imports neither the recorder nor the call log; its only tie to the rest of the
+daemon is a subscription to one event kind.
+
+```go
+// internal/broadcast/manager.go (shape)
+func (m *Manager) Run(ctx context.Context) error {
+    defer close(m.runDone)
+    for {
+        select {
+        case <-ctx.Done():
+            return ctx.Err()
+        case ev, ok := <-m.sub.C:
+            if !ok {
+                return nil
+            }
+            if ev.Kind != events.KindCallComplete {
+                continue
+            }
+            cc, ok := ev.Payload.(trunking.CallComplete)
+            if !ok {
+                continue
+            }
+            m.dispatch(cc)
+        }
+    }
+}
+```
+
+`Run` is a plain event loop. It filters the bus down to `KindCallComplete`,
+type-asserts the payload to a `trunking.CallComplete` (the struct from
+[Part 9]({{ '/blog/deep-dives/recording-streaming-09-call-complete-seam/' | relative_url }})
+that carries `AudioPath`, `StartedAt`, `EndedAt`, and the grant), and hands it to
+`dispatch`. One subtle guarantee lives in the constructor: `NewManager`
+**subscribes to the bus before it returns**, and starts the workers immediately —
+so a call that completes in the window between construction and the first `Run`
+iteration is buffered in the subscription, not lost.
+
+The important property is what `Run` does *not* do: it never blocks on a network
+socket. Everything after `dispatch` happens on a separate goroutine, so a
+Broadcastify server that takes thirty seconds to answer stalls a worker, not the
+event loop — and never the recorder that published the event.
+
+## Two gates in `dispatch`
+
+`dispatch` is where a completed call earns — or fails to earn — a spot in the
+upload queue. It applies two independent filters before it does any work:
+
+```go
+// internal/broadcast/manager.go (shape)
+func (m *Manager) dispatch(cc trunking.CallComplete) {
+    if len(m.backends) == 0 {
+        return
+    }
+    if cc.Talkgroup != nil && !cc.Talkgroup.Stream {
+        return // talkgroup opted out of all feeds
+    }
+    if m.minDuration > 0 && cc.Duration() < m.minDuration {
+        return // too short — a kerchunk, not a real transmission
+    }
+    call := callFromEvent(cc)
+    call.normalize = m.normalize
+    // …enqueue (below)
+}
+```
+
+The **stream gate** is the operator's opt-out. Every `TalkGroup` carries a
+`Stream bool` (`internal/trunking/talkgroup.go`) that defaults to `true` — legacy
+CSV/JSON talkgroup files without a `Stream` column keep streaming everything, so
+the gate is backward-compatible. Flag a sensitive talkgroup `Stream=false` and
+its completed calls are dropped here, before any backend sees them. It is a
+single decision point covering **all** feeds at once.
+
+The **minimum-duration** floor drops calls shorter than `MinDuration`. This is
+the kerchunk filter: a 300 ms key-up with no real audio is noise on an
+aggregator feed, and `MinDuration` (set from `broadcast.min_duration_ms` in
+config) lets an operator suppress them. Zero means "stream calls of any length".
+Both gates run *before* `callFromEvent`, so a rejected call costs nothing beyond
+two comparisons.
+
+Once a call passes both gates, `callFromEvent` (`internal/broadcast/broadcast.go`)
+projects the `CallComplete` payload into a `*Call` — the Manager's own value type
+carrying system, protocol, talkgroup, source, frequency, the P25 site identity,
+timestamps, and the on-disk `AudioPath`. The recorder's engine types never cross
+into the backends; the `Call` is the Manager's stable interface to them.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 220" width="660" height="220" role="img" aria-label="Pipeline: a call-complete event enters the Manager's Run loop, passes through the stream gate and minimum-duration filter in dispatch, then either drops when the bounded jobs channel is full or enqueues onto it; a pool of N worker goroutines drains the channel and runs a per-backend retry loop that ends at Broadcastify, RdioScanner, and other destinations.">
+  <rect x="8" y="88" width="104" height="44" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="60" y="108" text-anchor="middle" fill="var(--accent)" font-size="10">call.complete</text>
+  <text x="60" y="122" text-anchor="middle" fill="var(--fg-muted)" font-size="8">bus event</text>
+  <line x1="112" y1="110" x2="140" y2="110" stroke="currentColor"/><polygon points="140,106 150,110 140,114" fill="currentColor"/>
+  <rect x="150" y="82" width="118" height="56" rx="6" fill="none" stroke="currentColor"/>
+  <text x="209" y="102" text-anchor="middle" fill="currentColor" font-size="10">dispatch</text>
+  <text x="209" y="116" text-anchor="middle" fill="var(--fg-muted)" font-size="8">Stream gate ·</text>
+  <text x="209" y="127" text-anchor="middle" fill="var(--fg-muted)" font-size="8">MinDuration</text>
+  <line x1="268" y1="110" x2="296" y2="110" stroke="currentColor"/><polygon points="296,106 306,110 296,114" fill="currentColor"/>
+  <line x1="209" y1="138" x2="209" y2="196" stroke="var(--fg-muted)" stroke-dasharray="4 3"/><polygon points="205,196 209,206 213,196" fill="var(--fg-muted)"/>
+  <text x="209" y="200" text-anchor="middle" fill="var(--fg-muted)" font-size="8">rejected → return</text>
+  <rect x="306" y="86" width="96" height="48" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="354" y="104" text-anchor="middle" fill="var(--accent)" font-size="10">jobs chan</text>
+  <text x="354" y="117" text-anchor="middle" fill="var(--fg-muted)" font-size="8">buffered (64)</text>
+  <text x="354" y="128" text-anchor="middle" fill="var(--fg-muted)" font-size="8">full → drop</text>
+  <line x1="402" y1="110" x2="430" y2="110" stroke="currentColor"/><polygon points="430,106 440,110 430,114" fill="currentColor"/>
+  <rect x="440" y="70" width="96" height="26" rx="5" fill="none" stroke="currentColor"/>
+  <text x="488" y="87" text-anchor="middle" fill="currentColor" font-size="9">worker 1</text>
+  <rect x="440" y="102" width="96" height="26" rx="5" fill="none" stroke="currentColor"/>
+  <text x="488" y="119" text-anchor="middle" fill="currentColor" font-size="9">worker N</text>
+  <text x="488" y="142" text-anchor="middle" fill="var(--fg-muted)" font-size="8">sendWithRetry</text>
+  <line x1="536" y1="90" x2="566" y2="90" stroke="currentColor"/><polygon points="566,86 576,90 566,94" fill="currentColor"/>
+  <line x1="536" y1="114" x2="566" y2="114" stroke="currentColor"/><polygon points="566,110 576,114 566,118" fill="currentColor"/>
+  <rect x="576" y="76" width="80" height="26" rx="5" fill="none" stroke="var(--fg-muted)"/>
+  <text x="616" y="93" text-anchor="middle" fill="var(--fg-muted)" font-size="8">Broadcastify</text>
+  <rect x="576" y="106" width="80" height="26" rx="5" fill="none" stroke="var(--fg-muted)"/>
+  <text x="616" y="123" text-anchor="middle" fill="var(--fg-muted)" font-size="8">RdioScanner…</text>
+</svg>
+<figcaption>The Manager's event loop only filters and enqueues; the network work happens on worker goroutines, so a slow backend can never stall <code>dispatch</code>.</figcaption>
+</figure>
+
+## Drop-on-full: the decision that protects decode
+
+Here is the single most important line in the subsystem — the enqueue:
+
+```go
+// internal/broadcast/manager.go (shape)
+select {
+case m.jobs <- call:
+    m.mu.Lock(); m.queued++; m.mu.Unlock()
+default:
+    // Queue full — a backend is wedged. Drop rather than block the
+    // event loop (and the recorder behind it).
+    m.mu.Lock(); m.dropped++; m.mu.Unlock()
+    m.log.Warn("broadcast: upload queue full, dropping call",
+        "system", call.System, "tg", call.Talkgroup)
+}
+```
+
+The `jobs` channel is buffered (depth 64). The `select` with a `default` case is
+a **non-blocking send**: if there is room, the call is queued; if the buffer is
+full, the `default` fires and the call is **dropped** and counted. There is no
+third option where `dispatch` waits.
+
+This is deliberate and it is the whole reason the broadcast path is safe to run
+in production. Imagine Broadcastify goes down for a minute. Each worker blocks
+inside `Send` waiting on a dead socket; the `jobs` channel fills to 64; and then
+`dispatch` starts dropping. What it does **not** do is block — which means the
+`Run` loop keeps draining the bus, the bus never fills, and the recorder that
+publishes `KindCallComplete` never waits on the broadcaster. **A downstream
+outage costs you some uploads; it never costs you a recording.** The dropped
+counter surfaces the loss in `Stats()` so an operator can see it happened.
+
+> ⚠ Drop-on-full is a design choice, not a bug. If your feed is losing calls,
+> the fix is more `Workers` or a faster network — not an unbounded queue, which
+> would trade dropped uploads for unbounded memory growth and, eventually, the
+> exact back-pressure this design exists to prevent.
+
+## Encode the MP3 once
+
+A completed call might go to five backends. Encoding its WAV to MP3 five times
+would be wasteful — MP3 encoding is the most expensive thing the Manager does.
+`Call.MP3()` solves this with lazy, memoised, mutex-guarded encoding:
+
+```go
+// internal/broadcast/broadcast.go (shape)
+func (c *Call) MP3() ([]byte, error) {
+    c.mu.Lock()
+    defer c.mu.Unlock()
+    if c.mp3Done {
+        return c.mp3Data, c.mp3Err // cached bytes (or cached error)
+    }
+    c.mp3Done = true
+    if c.normalize.Enabled {
+        c.mp3Data, c.mp3Err = encodeNormalizedMP3(c.AudioPath, c.normalize.Params)
+    } else {
+        c.mp3Data, _, c.mp3Err = mp3.EncodeWAVFile(c.AudioPath)
+    }
+    return c.mp3Data, c.mp3Err
+}
+```
+
+The first backend to call `MP3()` runs the encode; every later caller — including
+retries — gets the cached slice back. The mutex makes it safe across the several
+worker goroutines that might touch the same call. Two consequences fall out of
+this shape:
+
+- **Metadata-only feeds pay nothing.** The webhook backend, unless
+  `IncludeAudio` is set, never calls `MP3()`, so a call streamed only to a
+  metadata webhook is never encoded at all.
+- **Encoding is a black box here.** The Shine MP3 encoder, the Xing/LAME header,
+  and the WAV read all live in the voice package and are covered in
+  [Voice Coding Part 11]({{ '/blog/deep-dives/voice-coding-11-recording-encoding/' | relative_url }}).
+  The Manager treats `mp3.EncodeWAVFile` as a function that turns a path into
+  bytes; that boundary is exactly why the two subsystems can evolve independently.
+
+The one wrinkle is optional loudness normalization. When
+`normalize.Enabled`, `encodeNormalizedMP3` reads the WAV, applies a single gain
+**in memory**, and encodes the adjusted samples — the on-disk file the recorder
+wrote is left pristine. The *math* of that gain (BS.1770/R128) belongs to
+[Voice Coding Part 10]({{ '/blog/deep-dives/voice-coding-10-enhancement-loudness/' | relative_url }});
+what matters here is only *where* it is applied: on the distributed copy, once,
+behind the same memoisation.
+
+## The worker and its retry loop
+
+Workers are trivial: each drains `jobs` and, for every backend that `Accepts`
+the call's system, runs `sendWithRetry`.
+
+```go
+// internal/broadcast/manager.go (shape)
+func (m *Manager) worker() {
+    defer m.wg.Done()
+    for call := range m.jobs {
+        for _, b := range m.backends {
+            if !b.Accepts(call.System) {
+                continue // this backend filters out this system
+            }
+            m.sendWithRetry(b, call)
+        }
+    }
+}
+```
+
+`Accepts` is the per-backend `systemFilter` from
+[Part 14]({{ '/blog/deep-dives/recording-streaming-14-aggregator-backends/' | relative_url }}):
+a backend configured with a `Systems` list only takes calls from those trunking
+systems; an unfiltered backend takes everything. So one Manager can feed
+"Metro" calls to one Broadcastify system and "County" calls to another.
+
+`sendWithRetry` is the backoff engine:
+
+```go
+// internal/broadcast/manager.go (shape)
+func (m *Manager) sendWithRetry(b Backend, call *Call) {
+    backoff := m.retryBase // 2s by default
+    for attempt := 0; attempt <= m.maxRetries; attempt++ {
+        ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+        err := b.Send(ctx, call)
+        cancel()
+        if err == nil {
+            m.mu.Lock(); m.sent[b.Name()]++; m.mu.Unlock()
+            return // delivered
+        }
+        m.log.Warn("broadcast: upload failed", "backend", b.Name(),
+            "attempt", attempt+1, "of", m.maxRetries+1, "err", err)
+        if attempt < m.maxRetries {
+            time.Sleep(backoff)
+            backoff *= 2 // 2s → 4s → 8s …
+        }
+    }
+    m.mu.Lock(); m.failed[b.Name()]++; m.mu.Unlock()
+    m.log.Error("broadcast: giving up on call", "backend", b.Name())
+}
+```
+
+The loop runs `MaxRetries+1` attempts total (the first try plus the retry
+budget). Each `Send` gets a fresh 60-second context, so a hung request can't wedge
+a worker forever. Between attempts the worker **sleeps** for `backoff`, then
+**doubles** it: 2s, 4s, 8s with the defaults. That doubling is what turns a
+transient blip (a 502, a dropped TCP connection) into a recovered upload while
+keeping a persistent outage from hammering a dead server. When the budget is
+spent, the call is counted as `failed` for that backend and abandoned — the
+Manager never retries a call forever, and a failure on one backend never affects
+the others, because each gets its own independent `sendWithRetry` call.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 176" width="660" height="176" role="img" aria-label="Timeline for sendWithRetry with three retries: attempt 1 fails, wait 2 seconds; attempt 2 fails, wait 4 seconds; attempt 3 fails, wait 8 seconds; attempt 4 fails and the Manager gives up and counts the call as failed. A green branch shows any attempt succeeding leads to sent and an immediate return.">
+  <line x1="20" y1="70" x2="600" y2="70" stroke="var(--fg-muted)"/>
+  <polygon points="600,66 610,70 600,74" fill="var(--fg-muted)"/>
+  <text x="610" y="60" fill="var(--fg-muted)" font-size="8">time</text>
+  <rect x="24" y="56" width="70" height="28" rx="5" fill="none" stroke="currentColor"/>
+  <text x="59" y="74" text-anchor="middle" fill="currentColor" font-size="9">attempt 1</text>
+  <text x="120" y="60" text-anchor="middle" fill="var(--fg-muted)" font-size="8">wait 2s</text>
+  <line x1="94" y1="70" x2="146" y2="70" stroke="currentColor" stroke-dasharray="3 2"/>
+  <rect x="146" y="56" width="70" height="28" rx="5" fill="none" stroke="currentColor"/>
+  <text x="181" y="74" text-anchor="middle" fill="currentColor" font-size="9">attempt 2</text>
+  <text x="248" y="60" text-anchor="middle" fill="var(--fg-muted)" font-size="8">wait 4s</text>
+  <line x1="216" y1="70" x2="290" y2="70" stroke="currentColor" stroke-dasharray="3 2"/>
+  <rect x="290" y="56" width="70" height="28" rx="5" fill="none" stroke="currentColor"/>
+  <text x="325" y="74" text-anchor="middle" fill="currentColor" font-size="9">attempt 3</text>
+  <text x="404" y="60" text-anchor="middle" fill="var(--fg-muted)" font-size="8">wait 8s</text>
+  <line x1="360" y1="70" x2="458" y2="70" stroke="currentColor" stroke-dasharray="3 2"/>
+  <rect x="458" y="56" width="70" height="28" rx="5" fill="none" stroke="currentColor"/>
+  <text x="493" y="74" text-anchor="middle" fill="currentColor" font-size="9">attempt 4</text>
+  <line x1="528" y1="70" x2="556" y2="70" stroke="currentColor"/><polygon points="556,66 566,70 556,74" fill="currentColor"/>
+  <rect x="566" y="54" width="80" height="32" rx="5" fill="none" stroke="var(--fg-muted)"/>
+  <text x="606" y="70" text-anchor="middle" fill="var(--fg-muted)" font-size="8">give up</text>
+  <text x="606" y="80" text-anchor="middle" fill="var(--fg-muted)" font-size="8">failed++</text>
+  <line x1="325" y1="84" x2="325" y2="128" stroke="var(--accent)"/><polygon points="321,128 325,138 329,128" fill="var(--accent)"/>
+  <text x="325" y="118" text-anchor="middle" fill="var(--accent)" font-size="8">Send err == nil</text>
+  <rect x="270" y="138" width="110" height="28" rx="5" fill="none" stroke="var(--accent)"/>
+  <text x="325" y="156" text-anchor="middle" fill="var(--accent)" font-size="9">sent++ · return</text>
+</svg>
+<figcaption>Per-backend backoff: the delay doubles from <code>RetryBase</code> each attempt, capped by <code>MaxRetries</code>; any successful <code>Send</code> records the delivery and returns immediately.</figcaption>
+</figure>
+
+## Where the Manager comes from
+
+The daemon never constructs a `Manager` unconditionally. `buildBroadcastManager`
+(`cmd/gophertrunk/broadcast.go`) walks each backend config section, builds the
+enabled ones, and — critically — **returns `nil, nil` when the backend list is
+empty**:
+
+```go
+// cmd/gophertrunk/broadcast.go (shape)
+func buildBroadcastManager(cfg config.BroadcastConfig, /* … */) (*broadcast.Manager, error) {
+    var backends []broadcast.Backend
+    // …append one Backend per enabled Broadcastify/RdioScanner/OpenMHz/Webhook/Icecast entry
+    if len(backends) == 0 {
+        return nil, nil // no feed configured → no Manager, no workers, no encoder
+    }
+    return broadcast.NewManager(broadcast.Options{
+        Bus: bus, Log: log, Backends: backends,
+        MinDuration: time.Duration(cfg.MinDurationMs) * time.Millisecond,
+        Workers:     cfg.Workers,
+        Normalize:   normalize,
+    })
+}
+```
+
+This is the config-driven lazy init rule from
+[Part 1]({{ '/blog/deep-dives/recording-streaming-01-the-output-half/' | relative_url }})
+applied to the broadcaster: a scanner with no feed configured allocates no
+worker goroutines, no MP3 encoder, and no bus subscription. The subsystem isn't
+disabled at runtime — it doesn't exist. And because `Workers` and `MinDurationMs`
+flow straight from config, the pool size and kerchunk floor are the operator's to
+tune without touching code.
+
+## Where this goes next
+
+The Manager fans a `*Call` out to a set of `Backend`s, but it treats every
+backend as an opaque `Send(ctx, call) error`.
+[Part 14]({{ '/blog/deep-dives/recording-streaming-14-aggregator-backends/' | relative_url }}),
+the finale, opens each of those boxes: Broadcastify's two-step metadata-then-PUT
+upload, the multipart POSTs for RdioScanner and OpenMHz, Icecast's paced source
+connection topped up with pre-encoded silence, and the generic JSON webhook — and
+it finally lands our 3 p.m. dispatch in a real Broadcastify feed.
+
+## FAQ
+
+**What happens to a call when every upload worker is busy?**
+`dispatch` does a non-blocking send onto the buffered `jobs` channel. If the
+buffer (depth 64) is full because the workers are wedged on a slow backend, the
+`default` branch of the `select` fires and the call is **dropped** and counted in
+`Stats().Dropped`. The event loop never blocks, so the recorder is never
+back-pressured.
+
+**Is the MP3 encoded once or once per backend?**
+Once per call. `Call.MP3()` memoises the encoded bytes behind a mutex, so the
+first backend that needs audio pays for the encode and all others — including
+retries and additional backends — reuse the cached slice. A metadata-only webhook
+that never requests audio triggers no encode at all.
+
+**How long does the Manager keep retrying a failed upload?**
+`MaxRetries+1` attempts per backend (default 4 total), sleeping `RetryBase`
+between attempts and doubling it each time — 2s, 4s, 8s by default. After the
+budget is exhausted the call is counted as failed for that backend and abandoned.
+It is never retried indefinitely, and a failure on one backend doesn't affect the
+others.
+
+**Can I stop a specific talkgroup from ever being uploaded?**
+Yes. Set `Stream=false` on the talkgroup (a column in the CSV/JSON talkgroup file
+or the `stream` field in JSON). `dispatch` checks `cc.Talkgroup.Stream` before
+enqueuing, so a `Stream=false` talkgroup's calls are dropped ahead of every
+backend at once. The flag defaults to `true` for backward compatibility.
+
+## Series navigation
+
+**Part 13 of 14** · ←
+[Part 12: Live Listening]({{ '/blog/deep-dives/recording-streaming-12-live-listening/' | relative_url }})
+· Next →
+[Part 14: The Aggregator Backends]({{ '/blog/deep-dives/recording-streaming-14-aggregator-backends/' | relative_url }})

--- a/docs/_posts/2026-08-14-recording-streaming-14-aggregator-backends.md
+++ b/docs/_posts/2026-08-14-recording-streaming-14-aggregator-backends.md
@@ -1,0 +1,428 @@
+---
+title: "Recording, Composition & Streaming, Part 14: The Aggregator Backends — Broadcastify, RdioScanner, OpenMHz, Icecast & Webhook"
+description: A closing tour of every outbound destination's real wire protocol — Broadcastify's two-step metadata-then-PUT upload, the multipart POSTs for RdioScanner and OpenMHz, Icecast's paced silence-topped source connection, and the generic JSON webhook — capped by the pure-Go, zero-CGO testing story that verifies them all.
+category: deep-dives
+keywords: broadcastify calls api, rdioscanner call upload, openmhz upload multipart, icecast source protocol go, webhook json call feed, two step upload, pure go sdr testing, httptest backend, zero cgo scanner, gophertrunk aggregators
+tags: [streaming, broadcast, http, icecast, testing, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Recording, Composition & Streaming"
+series_part: 14
+---
+
+*Part 14 — the finale — of **Recording, Composition & Streaming**. Thirteen posts
+ago our 3 p.m. dispatch on talkgroup 101 was raw IQ; twelve posts ago it was PCM;
+last post the broadcast Manager fanned it out to a set of opaque `Backend`s. This
+post opens each box — the actual HTTP and TCP conversations that carry a call to
+Broadcastify, RdioScanner, OpenMHz, an Icecast server, and a generic webhook —
+and then closes the series with the thing that makes all of it trustworthy: a
+pure-Go, zero-CGO test suite that stands the whole path up in memory.*
+
+> **TL;DR:** Five backends, five wire protocols behind one `Send(ctx, *Call)
+> error` interface. **Broadcastify** is a two-step handshake: POST metadata, get a
+> one-time upload URL, PUT the MP3 to it. **RdioScanner** and **OpenMHz** are
+> single multipart/form-data POSTs built by a shared `buildMultipart` helper.
+> **Icecast** is different in kind — a persistent, paced source socket topped up
+> with pre-encoded silence so it never starves. The **webhook** is a stable JSON
+> schema, audio opt-in. All five are verified end to end with `httptest` servers,
+> in-memory WAVs, and a temp SQLite call log — no CGO, no network, no fixtures.
+
+**Key takeaways**
+
+- **Broadcastify uploads in two steps** because the audio never touches the API
+  host: the metadata POST returns a one-time URL (often on object storage) that
+  the MP3 is `PUT` to directly.
+- **RdioScanner and OpenMHz share the multipart machinery** but not the field
+  names — `buildMultipart` writes the body, each backend supplies its own field
+  set (RdioScanner's `key`/`system`/`dateTime`, OpenMHz's `source_list`/`patch_list`).
+- **Icecast is a live stream, not an upload.** A background goroutine holds a
+  source connection open and a ticker writes paced chunks; between calls it cycles
+  one second of pre-encoded silence so the server never times the source out.
+- **The whole system is pure Go.** MP3 encode, WAV I/O, and SQLite are all
+  CGO-free, so the tests run the real encode/decode/persist path in memory against
+  `httptest` backends — the strongest possible evidence the wire formats are right.
+
+## Cheat sheet
+
+| Backend | Wire shape | Key functions / fields |
+|---|---|---|
+| Broadcastify | POST metadata → one-time URL → PUT audio | `requestUploadURL` · `parseBroadcastifyUploadURL` · `putAudio` |
+| RdioScanner | one multipart POST to `/api/call-upload` | `buildMultipart` · `key`/`system`/`dateTime` fields |
+| OpenMHz | one multipart POST to `/<shortName>/upload` | `source_list` · `patch_list` JSON parts |
+| Icecast | persistent paced source socket | `runStream` · `handshake` · `takeChunk` (silence) |
+| Webhook | one `application/json` POST | `webhookPayload` · `callType` · `rfc3339In` · `IncludeAudio` |
+| Shared | multipart body + filenames + timestamps | `buildMultipart` · `audioFilename` · `rfc3339In` |
+
+## In this post
+
+- **Broadcastify** — why one upload is two HTTP round trips.
+- **RdioScanner & OpenMHz** — one multipart helper, two field vocabularies.
+- **Icecast** — a paced source connection kept alive with cycled silence.
+- **The webhook** — a stable JSON schema and a call-type classifier.
+- **The pure-Go coda** — how zero-CGO makes the whole path testable in memory.
+
+## Broadcastify: two round trips for one upload
+
+Every other audio backend POSTs the MP3 in a single request. Broadcastify Calls
+splits the upload in two, and the reason is architectural: the API host answers
+metadata, but the *audio* goes somewhere else — typically object storage behind a
+signed, one-time URL. So `Send` does a metadata POST first, reads back a URL, and
+PUTs the audio to it:
+
+```go
+// internal/broadcast/broadcastify.go (shape)
+func (b *broadcastifyBackend) Send(ctx context.Context, c *Call) error {
+    audio, err := c.MP3()
+    if err != nil {
+        return fmt.Errorf("%s: encode mp3: %w", b.name, err)
+    }
+    uploadURL, err := b.requestUploadURL(ctx, c) // step 1: metadata POST
+    if err != nil {
+        return err
+    }
+    return b.putAudio(ctx, uploadURL, audio) // step 2: PUT to the one-time URL
+}
+```
+
+Step one, `requestUploadURL`, is a `application/x-www-form-urlencoded` POST
+carrying `apiKey`, `systemId`, `callDuration`, `ts` (the Unix start time), `tg`,
+`src`, and `freq`. The API answers with a small text body, and
+`parseBroadcastifyUploadURL` teases the URL out of it:
+
+```go
+// internal/broadcast/broadcastify.go (shape)
+func parseBroadcastifyUploadURL(body string) (string, error) {
+    fields := strings.Fields(strings.TrimSpace(body))
+    if len(fields) == 0 {
+        return "", errors.New("broadcastify: empty metadata response")
+    }
+    if fields[0] == "0" && len(fields) >= 2 {
+        return fields[1], nil // "0 <url>" — success + the upload URL
+    }
+    if strings.HasPrefix(fields[0], "http") {
+        return fields[0], nil // bare URL
+    }
+    return "", fmt.Errorf("broadcastify: metadata response rejected: %s", body)
+}
+```
+
+The `"0 <url>"` convention — a `0` status token, whitespace, then the URL — is the
+Broadcastify Calls protocol's success shape; anything else is treated as a
+rejection and surfaced as an error (which the Manager will then retry). Step two,
+`putAudio`, is a plain `PUT` of the MP3 bytes with `Content-Type: audio/mpeg` and
+an explicit `ContentLength`, to the URL step one handed back. A non-2xx on either
+leg returns an error, and the Manager's `sendWithRetry` handles the backoff.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 640 210" width="640" height="210" role="img" aria-label="Sequence diagram of the Broadcastify two-step upload. GopherTrunk POSTs form-encoded metadata to the Calls API, which replies with a status zero and a one-time upload URL. GopherTrunk then PUTs the MP3 audio bytes directly to that upload URL, which replies 200 OK.">
+  <line x1="70" y1="30" x2="70" y2="190" stroke="var(--fg-muted)"/>
+  <text x="70" y="22" text-anchor="middle" fill="var(--accent)" font-size="9">GopherTrunk</text>
+  <line x1="330" y1="30" x2="330" y2="190" stroke="var(--fg-muted)"/>
+  <text x="330" y="22" text-anchor="middle" fill="currentColor" font-size="9">Calls API</text>
+  <line x1="560" y1="30" x2="560" y2="190" stroke="var(--fg-muted)"/>
+  <text x="560" y="22" text-anchor="middle" fill="currentColor" font-size="9">upload URL</text>
+  <line x1="70" y1="54" x2="330" y2="54" stroke="currentColor"/><polygon points="330,50 340,54 330,58" fill="currentColor"/>
+  <text x="200" y="48" text-anchor="middle" fill="currentColor" font-size="8">POST metadata (apiKey, systemId, tg, ts…)</text>
+  <line x1="330" y1="86" x2="70" y2="86" stroke="var(--accent)" stroke-dasharray="4 3"/><polygon points="80,82 70,86 80,90" fill="var(--accent)"/>
+  <text x="200" y="80" text-anchor="middle" fill="var(--accent)" font-size="8">"0 &lt;upload-url&gt;"</text>
+  <line x1="70" y1="130" x2="560" y2="130" stroke="currentColor"/><polygon points="560,126 570,130 560,134" fill="currentColor"/>
+  <text x="315" y="124" text-anchor="middle" fill="currentColor" font-size="8">PUT audio/mpeg (the MP3 bytes)</text>
+  <line x1="560" y1="162" x2="70" y2="162" stroke="var(--accent)" stroke-dasharray="4 3"/><polygon points="80,158 70,162 80,166" fill="var(--accent)"/>
+  <text x="315" y="156" text-anchor="middle" fill="var(--accent)" font-size="8">200 OK</text>
+  <text x="315" y="184" text-anchor="middle" fill="var(--fg-muted)" font-size="8">audio never transits the API host — it goes straight to storage</text>
+</svg>
+<figcaption>Broadcastify Calls: the metadata POST returns a one-time URL, and the MP3 is PUT to that URL directly — two round trips, one logical upload.</figcaption>
+</figure>
+
+## RdioScanner and OpenMHz: one multipart helper, two vocabularies
+
+Both of these are single `multipart/form-data` POSTs, and both build the body
+with the same tiny helper. `buildMultipart` (`internal/broadcast/multipart.go`)
+takes a slice of `multipartField` — a text field carries `Value`, a file part
+carries `Filename` + `Data` — and returns the encoded buffer plus the
+`Content-Type` header with its generated boundary:
+
+```go
+// internal/broadcast/multipart.go (shape)
+type multipartField struct {
+    Name     string
+    Value    string // text field
+    Filename string // set → written as a file part
+    Data     []byte // the file bytes
+}
+
+func buildMultipart(fields []multipartField) (*bytes.Buffer, string, error) {
+    // …CreateFormFile for parts with a Filename, WriteField otherwise
+}
+```
+
+What differs is the **field vocabulary** each service expects. RdioScanner wants
+`key`, `system`, `dateTime`, `talkgroup`, `source`, `frequency`, and the audio as
+`audio`; OpenMHz wants `api_key`, `freq`, `start_time`, `stop_time`,
+`call_length`, `talkgroup_num`, and — the interesting ones —
+`source_list` and `patch_list`:
+
+```go
+// internal/broadcast/openmhz.go (shape)
+sourceList := fmt.Sprintf(`[{"src":%d,"time":%d,"pos":0}]`, c.Source, c.StartedAt.Unix())
+patchList := "[]"
+if len(c.PatchedGroups) > 0 {
+    // "[201,212]" — the patched talkgroups on this call
+}
+fields := []multipartField{
+    {Name: "api_key", Value: b.apiKey},
+    {Name: "talkgroup_num", Value: strconv.FormatUint(uint64(c.Talkgroup), 10)},
+    {Name: "source_list", Value: sourceList},
+    {Name: "patch_list", Value: patchList},
+    {Name: "call", Filename: audioFilename(c, "mp3"), Data: audio},
+    // …freq, start_time, stop_time, call_length, emergency
+}
+```
+
+`source_list` is a JSON array OpenMHz expects even when there is only the single
+granting unit to report — GopherTrunk sends the one source it knows with `pos:0`.
+`patch_list` carries the patched talkgroups when the call is a patch, `[]`
+otherwise. Both backends name their audio part with the shared `audioFilename`
+helper (`<talkgroup>-<unixstart>.mp3`), and RdioScanner stamps its `dateTime`
+with `rfc3339In` so the timestamp renders in the operator's configured display
+timezone with an explicit offset — the same helper the webhook uses, so a call
+carries one consistent wall-clock time across every feed.
+
+## Icecast: a live stream that never starves
+
+Icecast is the odd one out. The other four backends *upload a finished call*;
+Icecast maintains a *continuous live audio stream* that a listener can tune into
+at any moment. That changes everything about its shape. There is no per-call
+request — instead, `NewIcecast` starts a background goroutine that holds a source
+connection open, and `Send` just **appends** the call's MP3 onto a shared queue:
+
+```go
+// internal/broadcast/icecast.go (shape)
+func (b *icecastBackend) Send(_ context.Context, c *Call) error {
+    audio, err := c.MP3()
+    if err != nil {
+        return fmt.Errorf("%s: encode mp3: %w", b.name, err)
+    }
+    b.mu.Lock()
+    defer b.mu.Unlock()
+    if len(b.queue)+len(audio) > b.maxQueue {
+        b.log.Warn("broadcast: icecast queue full, dropping call", "tg", c.Talkgroup)
+        return nil // best-effort: drop, don't fail (no pointless Manager retry)
+    }
+    b.queue = append(b.queue, audio...)
+    return nil
+}
+```
+
+Note `Send` returns `nil` even when it drops — a live feed is best-effort, and
+returning an error would trigger Manager retries that make no sense for streaming
+audio. The real work is in `runStream`, which dials the server, does the Icecast
+source `handshake` (a `SOURCE <mount> HTTP/1.0` request with basic auth and
+`Ice-*` headers), then loops on a ticker writing paced chunks:
+
+```go
+// internal/broadcast/icecast.go (shape)
+ticker := time.NewTicker(icecastTick) // 200ms
+chunk := b.bytesPerSec * int(icecastTick) / int(time.Second)
+silenceOff := 0
+for {
+    select {
+    case <-ctx.Done():
+        return nil
+    case <-ticker.C:
+    }
+    payload := b.takeChunk(chunk, &silenceOff)
+    conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
+    if _, err := conn.Write(payload); err != nil {
+        return err // triggers reconnect in run()
+    }
+}
+```
+
+The pacing is the point. Icecast expects a source to feed audio at roughly its
+real byte rate; feed too fast and buffers bloat, too slow and the server times
+the source out. So each tick writes exactly `bytesPerSec * tick` bytes. When there
+is real call audio queued, `takeChunk` serves it; when the queue is empty — the
+gap between calls — it **pads the chunk with pre-encoded silence**, cycling
+through one second of MP3-encoded digital silence over and over:
+
+```go
+// internal/broadcast/icecast.go (shape)
+func (b *icecastBackend) takeChunk(n int, silenceOff *int) []byte {
+    out := make([]byte, 0, n)
+    // …drain up to n bytes of real queued call audio under the lock
+    for len(out) < n { // shortfall → top up with cycled silence
+        if *silenceOff >= len(b.silence) {
+            *silenceOff = 0 // wrap around the one-second silence buffer
+        }
+        // …append b.silence[silenceOff:end], advance silenceOff
+    }
+    return out
+}
+```
+
+The silence is encoded once at construction (`mp3.Encode(make([]int16, rate),
+rate)`) and reused forever, so the pacer costs nothing between calls. If the
+connection drops, `run` reconnects after a fixed backoff and re-handshakes —
+the source stays up across network blips without dropping the listener's stream.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 640 210" width="640" height="210" role="img" aria-label="The Icecast pacer. Send appends call MP3 onto a shared queue. A ticker fires every 200 milliseconds; takeChunk pulls a fixed-size chunk, draining real call audio from the queue first and topping any shortfall up from a cycling one-second silence buffer, then writes the chunk to the source socket connected to the Icecast server.">
+  <rect x="16" y="30" width="120" height="30" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="76" y="49" text-anchor="middle" fill="var(--accent)" font-size="9">Send(call)</text>
+  <line x1="76" y1="60" x2="76" y2="86" stroke="currentColor"/><polygon points="72,86 76,96 80,86" fill="currentColor"/>
+  <rect x="16" y="96" width="120" height="34" rx="6" fill="none" stroke="currentColor"/>
+  <text x="76" y="112" text-anchor="middle" fill="currentColor" font-size="9">queue []byte</text>
+  <text x="76" y="124" text-anchor="middle" fill="var(--fg-muted)" font-size="8">MP3 of each call</text>
+  <rect x="16" y="150" width="120" height="34" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="76" y="166" text-anchor="middle" fill="var(--fg-muted)" font-size="9">silence buffer</text>
+  <text x="76" y="178" text-anchor="middle" fill="var(--fg-muted)" font-size="8">1s, cycled</text>
+  <line x1="136" y1="113" x2="250" y2="105" stroke="currentColor"/><polygon points="250,101 260,105 250,109" fill="currentColor"/>
+  <line x1="136" y1="167" x2="250" y2="120" stroke="var(--fg-muted)" stroke-dasharray="4 3"/><polygon points="250,116 260,120 249,124" fill="var(--fg-muted)"/>
+  <rect x="260" y="86" width="130" height="52" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="325" y="106" text-anchor="middle" fill="var(--accent)" font-size="9">takeChunk(n)</text>
+  <text x="325" y="119" text-anchor="middle" fill="var(--fg-muted)" font-size="8">real audio first,</text>
+  <text x="325" y="130" text-anchor="middle" fill="var(--fg-muted)" font-size="8">pad with silence</text>
+  <text x="325" y="72" text-anchor="middle" fill="var(--fg-muted)" font-size="8">ticker · every 200ms</text>
+  <line x1="325" y1="80" x2="325" y2="86" stroke="var(--fg-muted)"/>
+  <line x1="390" y1="112" x2="440" y2="112" stroke="currentColor"/><polygon points="440,108 450,112 440,116" fill="currentColor"/>
+  <rect x="450" y="90" width="80" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="490" y="110" text-anchor="middle" fill="currentColor" font-size="9">source</text>
+  <text x="490" y="122" text-anchor="middle" fill="currentColor" font-size="9">socket</text>
+  <line x1="530" y1="112" x2="566" y2="112" stroke="currentColor"/><polygon points="566,108 576,112 566,116" fill="currentColor"/>
+  <rect x="576" y="90" width="56" height="44" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="604" y="110" text-anchor="middle" fill="var(--fg-muted)" font-size="8">Icecast</text>
+  <text x="604" y="122" text-anchor="middle" fill="var(--fg-muted)" font-size="8">server</text>
+</svg>
+<figcaption>The Icecast pacer writes a fixed-size chunk every tick, draining real call audio when there is any and topping up the shortfall with cycled silence so the source connection never starves.</figcaption>
+</figure>
+
+## The webhook: a stable schema, audio opt-in
+
+The generic webhook is the escape hatch — the backend for everyone whose sink
+isn't one of the four named services. It POSTs one `application/json` object per
+call against a documented, stable schema (`webhookPayload`) so a downstream
+consumer can rely on it:
+
+```go
+// internal/broadcast/webhook.go (shape)
+type webhookPayload struct {
+    Event       string   `json:"event"` // always "call"
+    System      string   `json:"system"`
+    Protocol    string   `json:"protocol"`
+    CallType    string   `json:"call_type"` // "group" | "unit" | "data"
+    Talkgroup   uint32   `json:"talkgroup"`
+    Source      uint32   `json:"source,omitempty"`
+    FrequencyHz uint32   `json:"frequency_hz"`
+    // …P25 site identity (channel_id, rfss_id, site_id, nac), encryption,
+    //   emergency, patched_groups — all omitempty so presence means "known"
+    StartedAt   string   `json:"started_at"` // rfc3339In
+    EndedAt     string   `json:"ended_at"`
+    DurationMs  int64    `json:"duration_ms"`
+    AudioBase64 string   `json:"audio_base64,omitempty"` // only when opted in
+}
+```
+
+Two design details are worth calling out. `callType` classifies the call so a
+consumer never mistakes a unit-to-unit call's destination radio ID for a
+talkgroup — a group call reads `"group"`, an individual call `"unit"`, a data
+grant `"data"`. And audio is **opt-in**: unless `IncludeAudio` is set, `Send`
+never calls `c.MP3()`, so a metadata-only webhook pays no encode cost and the
+payload stays lightweight. When it *is* set, the MP3 is base64-encoded into
+`audio_base64` alongside an `audio_format`. Fields that don't apply to a given
+call — site identity on non-P25, encryption params on a clear call — are dropped
+via `omitempty`, so a consumer can treat presence as "this value is known".
+
+## The coda: pure Go is what makes it testable
+
+The reason this series could describe each wire format with confidence is that
+every one of them is exercised by a real test — and those tests run because
+GopherTrunk's entire output half is **pure Go, zero CGO**. The MP3 encoder
+(Shine), the WAV reader/writer, and the SQLite call log are all CGO-free, so a
+test can stand up the real encode → upload → persist path entirely in memory with
+nothing mocked but the network endpoint.
+
+The pattern repeats across the suite:
+
+- **In-memory WAV.** `internal/voice/wav_test.go` writes and header-patches a WAV
+  through an in-memory `io.WriteSeeker` — no tempfile, no disk. The broadcast
+  tests' `writeWAV` helper (`internal/broadcast/broadcast_test.go`) makes a real
+  short WAV that the real encoder turns into real MP3 bytes.
+- **`httptest` backends.** `internal/broadcast/backends_test.go` stands up
+  `httptest.NewServer` handlers that assert on exactly what this post described —
+  `TestBroadcastifyTwoStepUpload` checks the metadata form *and* that the second
+  leg is a `PUT` whose body begins with the MP3 frame sync `0xFF`;
+  `TestRdioScannerUpload` and `TestOpenMHzUpload` parse the multipart body and
+  check the field names; `TestIcecastSourceHandshakeAndStream` speaks the raw
+  source protocol over a `net.Listener`.
+- **Behavioural Manager tests.** `internal/broadcast/manager_test.go` drives the
+  full Part 13 machine with a `fakeBackend`: `TestManagerSkipsStreamFalseTalkgroup`
+  and `TestManagerDropsShortCalls` pin the two gates,
+  `TestManagerRetriesTransientFailure` and `TestManagerGivesUpAfterMaxRetries`
+  pin the backoff budget.
+- **Timezone and schema.** `internal/broadcast/timezone_test.go` pins `rfc3339In`
+  to a fixed offset; `internal/broadcast/webhook_test.go` decodes the posted JSON
+  back into a `webhookPayload` and checks the site identity and `call_type`.
+- **Temp SQLite.** `internal/storage/calllog_test.go` opens a real database at
+  `t.TempDir()/calls.db` and asserts the start/end rows — the same pure-Go SQLite
+  the daemon uses, no external server.
+
+That is the quiet payoff of the whole architecture. Because nothing links C,
+`go test ./...` builds and runs the real recording, encoding, and streaming code
+on any machine with a Go toolchain — no libsndfile, no lame, no sqlite3 dev
+package. The wire formats in this post aren't described from a spec; they're
+described from tests that send the real bytes and check what a real server
+receives.
+
+## The 3 p.m. dispatch, delivered
+
+Fourteen posts ago we picked up one call — the 3 p.m. dispatch on talkgroup 101 —
+as it arrived from the vocoders as PCM. The recorder wrote its crash-safe WAV; the
+call log indexed it; loudness leveled the distributed copy; the `CallComplete`
+event carried its path to the broadcast Manager; the Manager gated it on
+`Stream` and `MinDuration`, encoded it to MP3 once, and handed it to a worker.
+That worker calls `broadcastifyBackend.Send`. A form POST goes out with the
+talkgroup, the source, the frequency, and the start time; Broadcastify answers
+`"0 <url>"`; the MP3 bytes `PUT` to that URL; a `200` comes back; `sent["broadcastify"]`
+ticks to one. The call is live in the feed. That is the whole output half, end to
+end — four independent subsystems, one bus, and a call that made it all the way
+out.
+
+## FAQ
+
+**Why does Broadcastify need two requests when everyone else uses one?**
+Because the audio doesn't go to the API host. The metadata POST returns a
+one-time upload URL — usually pointing at object storage — and the MP3 is `PUT`
+directly to it. `parseBroadcastifyUploadURL` reads the `"0 <url>"` success
+response; a rejection returns an error the Manager retries.
+
+**Do RdioScanner and OpenMHz share code?**
+They share `buildMultipart` and `audioFilename` but not their field sets. Each
+backend assembles its own `[]multipartField` — RdioScanner's `key`/`system`/
+`dateTime`, OpenMHz's `source_list`/`patch_list`/`talkgroup_num` — and hands it to
+the same encoder. The helper writes the body; the backend owns the vocabulary.
+
+**Why does the Icecast backend send silence between calls?**
+An Icecast source connection must feed audio continuously or the server times it
+out and drops the mount. Between calls there is no audio, so the pacer tops each
+timed chunk up from a one-second buffer of pre-encoded silence, cycling it. This
+keeps the source alive and the listener's stream unbroken without re-encoding.
+
+**How can the tests be sure the uploads are correct without hitting real servers?**
+They stand up `httptest` servers that assert on the exact bytes each backend
+sends — the two-step Broadcastify handshake, the multipart field names, the raw
+Icecast source protocol — while the encode and WAV paths run for real in memory.
+Because the whole stack is pure Go with zero CGO, `go test ./...` exercises the
+genuine code path on any machine with a Go toolchain.
+
+## Series navigation
+
+**Part 14 of 14** · ←
+[Part 13: Outbound Streaming — The Broadcast Manager]({{ '/blog/deep-dives/recording-streaming-13-broadcast-manager/' | relative_url }})
+· This is the finale — back to the
+[series index]({{ '/blog/series/recording-streaming/' | relative_url }}).
+
+*Where to next? The pure-Go, zero-CGO story that made this series' tests possible
+runs deeper in the SDR Internals series — see
+[SDR Internals]({{ '/blog/series/sdr-internals/' | relative_url }}) ch. 14,
+"APIs, Testing & the Pure-Go Story."*

--- a/docs/blog/series/recording-streaming.md
+++ b/docs/blog/series/recording-streaming.md
@@ -1,0 +1,61 @@
+---
+layout: page
+title: "Recording, Composition & Streaming: turning decoded calls into files, feeds & uploads"
+description: A 14-part deep dive into GopherTrunk's output half — how a decoded call becomes a crash-safe WAV, a row in the call log, a live browser stream, and an upload to Broadcastify, RdioScanner, OpenMHz and Icecast, all from optional, event-driven, config-gated subsystems in pure Go.
+keywords: sdr call recording, wav recorder, broadcastify calls upload, rdioscanner openmhz, icecast streaming, call log sqlite, recording retention, live audio stream, event bus subscriber, gophertrunk recording composition streaming
+nav_group: Blog
+permalink: /blog/series/recording-streaming/
+---
+
+**Recording, Composition & Streaming** is a 14-part deep dive into the *output
+half* of [GopherTrunk](https://github.com/MattCheramie/GopherTrunk) — everything
+that happens after the vocoders produce PCM. A decoded call has to become a
+**crash-safe WAV** on disk, a **row in the call log**, a **live stream** a
+browser can play, and an **upload** to the public call aggregators — and each of
+those is an independent, optional subsystem that reacts to a handful of bus
+events instead of calling its neighbours.
+
+Where [SDR Internals]({{ '/blog/series/sdr-internals/' | relative_url }}) gave
+this whole area one survey episode, and
+[Voice Coding]({{ '/blog/series/voice-coding/' | relative_url }}) covered the
+*codec* that produces the PCM, this series takes the **subsystem/plumbing** view:
+the event contracts, the session lifecycle, file-integrity guarantees, metadata
+and persistence, retention, the live-listen path, the fan-out manager, and the
+real API quirks of each aggregator backend. One thread runs the length of the
+series — the life of a single call, from the instant its PCM exists to the moment
+it lands in a Broadcastify feed.
+
+Every post reads three ways: a **TL;DR + cheat-sheet** for skimmers, **bold
+headers, tables, and diagrams** for the medium read, and full prose with real
+code for the deep read.
+
+New here? Start with the
+[antenna-to-audio]({{ '/learn/rf-sdr/antenna-to-audio/' | relative_url }}) lesson
+for the last mile, then come back for the implementation.
+
+{%- assign parts = site.posts | where: "series", "Recording, Composition & Streaming" | sort: "series_part" -%}
+{%- if parts and parts.size > 0 -%}
+<ol class="post-list series-list">
+  {%- for post in parts -%}
+    <li class="post-card">
+      <a class="post-card__link" href="{{ post.url | relative_url }}">
+        <h2 class="post-card__title">{{ post.title }}</h2>
+      </a>
+      <p class="post-card__meta">
+        <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%B %-d, %Y" }}</time>
+        <span class="category-chip">Deep dives</span>
+      </p>
+      {%- if post.description -%}
+        <p class="post-card__desc">{{ post.description }}</p>
+      {%- endif -%}
+    </li>
+  {%- endfor -%}
+</ol>
+{%- else -%}
+<p class="post-list__empty">No posts in this series yet — check back soon.</p>
+{%- endif -%}
+
+<p class="blog-feed-link">
+  See all <a href="{{ '/blog/category/deep-dives/' | relative_url }}">deep dives</a>
+  or subscribe via <a href="{{ '/feed.xml' | relative_url }}">RSS</a>.
+</p>


### PR DESCRIPTION
Start the next per-component deep-dive series after Voice Coding, covering the
output half of the pipeline — everything after the vocoders produce PCM. The
series traces one call from decoded audio to a Broadcastify upload across 14
future-dated posts (Aug 1-14) that drip one per day via the existing Jekyll
schedule mechanism.

Parts: (1) the output half & config-driven event subscribers, (2) the
composition contract, (3) assembling a call from overs, (4) the recording
session state machine, (5) crash-safe WAV on disk, (6) segmentation/naming/raw
sidecars, (7) cross-call & encryption correctness guards, (8) loudness
placement, (9) the CallComplete seam, (10) the SQLite call log, (11) retention,
(12) live listening, (13) the broadcast Manager, (14) the aggregator backends
(finale).

Each post follows the house style: SEO/AISO front matter, a three-ways-readable
body (TL;DR + cheat sheet + FAQ), and two theme-aware inline SVG figures. Every
post is grounded in real code (internal/voice, internal/storage,
internal/broadcast, internal/api, cmd/gophertrunk) and links out to the Voice
Coding series rather than re-deriving its DSP/codec material.

Also adds the series index page, a nav entry, and forward-links from the SDR
Internals ch.13 overview and the Voice Coding finale.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AiebAV9ACyZiFMHJcF34Zm