### PR TITLE
feat(tetra): decode the lower-MAC layer (MAC-RESOURCE + channel allocation)

### DIFF
--- a/internal/radio/tetra/mac.go
+++ b/internal/radio/tetra/mac.go
@@ -1,0 +1,289 @@
+package tetra
+
+// TETRA lower-MAC PDU parsing (ETSI EN 300 392-2 §21). The physical layer
+// recovers type-1 bits for a logical channel (SCH/F, SCH/HD); those bits are a
+// MAC PDU, not a Layer-3 PDU. The MAC PDU frames the TM-SDU (the LLC/L3 PDU) and
+// — for MAC-RESOURCE — carries the channel-allocation element that assigns a
+// call's traffic carrier + timeslot. A CMCE voice grant is therefore reached
+// only by parsing the MAC header, extracting the TM-SDU, and (for the physical
+// resource) reading the MAC channel-allocation element.
+//
+// Field widths follow EN 300 392-2 §21.4.3.1 (MAC-RESOURCE) and §21.5.2
+// (channel allocation), cross-checked against osmo-tetra's decoder. Bits are
+// carried one-per-byte, MSB first — the shape DecodeSCHF / DecodeSCHHD return.
+
+// MACPDUType is the 2-bit MAC PDU type that opens every downlink MAC PDU
+// (§21.4.1).
+type MACPDUType uint8
+
+const (
+	MACPDUResource  MACPDUType = 0 // MAC-RESOURCE — carries a TM-SDU + optional grant
+	MACPDUFragEnd   MACPDUType = 1 // MAC-FRAG (subtype 0) / MAC-END (subtype 1)
+	MACPDUBroadcast MACPDUType = 2 // SYSINFO / ACCESS-DEFINE
+	MACPDUSuppl     MACPDUType = 3 // MAC-U-SIGNAL / supplementary
+)
+
+// MAC-FRAG/END subtype (the bit following the 2-bit MAC PDU type when
+// MACPDUType == MACFragEnd).
+const (
+	macFrag uint8 = 0
+	macEnd  uint8 = 1
+)
+
+// Address types (§21.4.3.1). addrLenBits gives the address element width for
+// each; NULL carries no address (and the PDU no TM-SDU).
+const (
+	addrNull     uint8 = 0
+	addrSSI      uint8 = 1
+	addrEventLbl uint8 = 2
+	addrUSSI     uint8 = 3
+	addrSMI      uint8 = 4
+	addrSSIEvent uint8 = 5
+	addrSSIUsage uint8 = 6
+	addrSMIEvent uint8 = 7
+)
+
+var addrLenBits = [8]int{
+	addrNull:     0,
+	addrSSI:      24,
+	addrEventLbl: 10,
+	addrUSSI:     24,
+	addrSMI:      24,
+	addrSSIEvent: 34, // 24 + 10
+	addrSSIUsage: 30, // 24 + 6
+	addrSMIEvent: 34, // 24 + 10
+}
+
+// macLenStartFragment / macLenSecondStolen are the reserved length-indication
+// values (§21.4.3.1): a start fragment continues the TM-SDU in a following
+// MAC-FRAG/MAC-END; the second-stolen marker flags a stolen half-slot.
+const (
+	macLenStartFragment uint8 = 0x3f
+	macLenSecondStolen  uint8 = 0x3e
+)
+
+// bitReader walks a one-bit-per-byte slice MSB-first.
+type bitReader struct {
+	bits []byte
+	pos  int
+}
+
+func (r *bitReader) remaining() int { return len(r.bits) - r.pos }
+
+// u reads n bits as an unsigned integer, MSB first. A read past the end
+// returns whatever bits are available shifted into place and marks the reader
+// exhausted by advancing pos past the end.
+func (r *bitReader) u(n int) uint32 {
+	var v uint32
+	for i := 0; i < n; i++ {
+		v <<= 1
+		if r.pos < len(r.bits) {
+			v |= uint32(r.bits[r.pos] & 1)
+		}
+		r.pos++
+	}
+	return v
+}
+
+func (r *bitReader) bit() uint8 { return uint8(r.u(1)) }
+
+// MACAddress is the addressed party of a MAC-RESOURCE PDU (§21.4.3.1).
+type MACAddress struct {
+	Type        uint8
+	SSI         uint32 // 24-bit short subscriber identity (individual or group)
+	EventLabel  uint16 // 10-bit
+	UsageMarker uint8  // 6-bit (addrSSIUsage)
+}
+
+// ChannelAllocation is the MAC channel-allocation element (§21.5.2): the
+// physical traffic resource assigned to a call. CarrierNumber resolves to Hz
+// via the band plan; Timeslot is the assigned downlink slot.
+type ChannelAllocation struct {
+	AllocationType uint8
+	Timeslot       uint8 // 4-bit assigned-timeslot field
+	ULDL           uint8 // 2-bit up/downlink assignment
+	CLCHPermission bool
+	CellChange     bool
+	CarrierNumber  uint16 // 12-bit main carrier number
+	ExtCarrier     bool
+	FreqBand       uint8 // 4-bit (ext carrier)
+	FreqOffset     uint8 // 2-bit (ext carrier)
+	DuplexSpacing  uint8 // 3-bit (ext carrier)
+	ReverseOper    bool  // (ext carrier)
+	MonitPattern   uint8 // 2-bit
+}
+
+// MACResource is a decoded downlink MAC-RESOURCE PDU. TMSDUBitOffset is the bit
+// index (into the type-1 bit slice passed to ParseMACResource) at which the
+// TM-SDU (Layer-3 PDU) begins.
+type MACResource struct {
+	FillBits       bool
+	GrantPosition  bool
+	EncryptionMode uint8
+	Encrypted      bool
+	RandomAccess   bool
+	LengthInd      uint8
+	NullPDU        bool // address type NULL — no TM-SDU
+	StartFragment  bool // TM-SDU continues in a following MAC-FRAG/MAC-END
+	Address        MACAddress
+	SlotGranting   bool
+	ChanAlloc      *ChannelAllocation // nil when no allocation present
+	TMSDUBitOffset int
+}
+
+// parseChanAlloc reads the channel-allocation element at the reader's cursor
+// (§21.5.2). Mirrors osmo-tetra's macpdu_decode_chan_alloc, including the
+// extended-carrier and augmented (ul_dl==0) branches so the cursor lands
+// correctly past the element.
+func parseChanAlloc(r *bitReader) ChannelAllocation {
+	ca := ChannelAllocation{
+		AllocationType: uint8(r.u(2)),
+		Timeslot:       uint8(r.u(4)),
+		ULDL:           uint8(r.u(2)),
+		CLCHPermission: r.bit() == 1,
+		CellChange:     r.bit() == 1,
+		CarrierNumber:  uint16(r.u(12)),
+	}
+	if r.bit() == 1 {
+		ca.ExtCarrier = true
+		ca.FreqBand = uint8(r.u(4))
+		ca.FreqOffset = uint8(r.u(2))
+		ca.DuplexSpacing = uint8(r.u(3))
+		ca.ReverseOper = r.bit() == 1
+	}
+	ca.MonitPattern = uint8(r.u(2))
+	if ca.MonitPattern == 0 {
+		r.u(2) // monitoring pattern for frame 18
+	}
+	if ca.ULDL == 0 {
+		// Augmented channel-allocation element (§21.5.2a).
+		r.u(2) // up/downlink assigned
+		r.u(3) // bandwidth
+		r.u(3) // modulation
+		r.u(3) // max uplink QAM modulation
+		r.u(3) // reserved
+		r.u(3) // conforming channel status
+		r.u(4) // BS link imbalance
+		r.u(5) // BS transmit power relative to main carrier
+		nap := r.u(2)
+		if nap == 1 {
+			r.u(11) // napping information (§21.5.2c)
+		}
+		r.u(4) // reserved
+		if r.bit() == 1 {
+			r.u(16)
+		}
+		if r.bit() == 1 {
+			r.u(16)
+		}
+		r.u(1)
+	}
+	return ca
+}
+
+// ParseMACResource decodes a downlink MAC-RESOURCE PDU from type-1 bits
+// (one-per-byte, MSB first). Returns (zero, false) if the leading MAC PDU type
+// is not MAC-RESOURCE or the header is truncated. A NULL-address PDU returns
+// with NullPDU set and no TM-SDU. isDecrypted lets the caller assert a payload
+// has already been deciphered so a channel-allocation element behind an
+// encryption flag is still parsed.
+func ParseMACResource(bits []byte, isDecrypted bool) (MACResource, bool) {
+	if len(bits) < 16 {
+		return MACResource{}, false
+	}
+	r := &bitReader{bits: bits}
+	if MACPDUType(r.u(2)) != MACPDUResource {
+		return MACResource{}, false
+	}
+	m := MACResource{
+		FillBits:      r.bit() == 1,
+		GrantPosition: r.bit() == 1,
+	}
+	m.EncryptionMode = uint8(r.u(2))
+	m.Encrypted = m.EncryptionMode > 0 && !isDecrypted
+	m.RandomAccess = r.bit() == 1
+	m.LengthInd = uint8(r.u(6))
+	m.StartFragment = m.LengthInd == macLenStartFragment
+	m.Address.Type = uint8(r.u(3))
+	if m.Address.Type == addrNull {
+		m.NullPDU = true
+		m.TMSDUBitOffset = r.pos
+		return m, true
+	}
+	// Read the address fields, then advance the cursor by the type's full width.
+	addrStart := r.pos
+	switch m.Address.Type {
+	case addrSSI, addrUSSI, addrSMI:
+		m.Address.SSI = r.u(24)
+	case addrEventLbl:
+		m.Address.EventLabel = uint16(r.u(10))
+	case addrSSIEvent, addrSMIEvent:
+		m.Address.SSI = r.u(24)
+		m.Address.EventLabel = uint16(r.u(10))
+	case addrSSIUsage:
+		m.Address.SSI = r.u(24)
+		m.Address.UsageMarker = uint8(r.u(6))
+	default:
+		return MACResource{}, false
+	}
+	r.pos = addrStart + addrLenBits[m.Address.Type]
+
+	if r.bit() == 1 { // power control present
+		r.u(4)
+	}
+	if r.bit() == 1 { // slot granting present
+		m.SlotGranting = true
+		r.u(4) // number of slots granted
+		r.u(4) // delay
+	}
+	if r.bit() == 1 && !m.Encrypted { // channel allocation present
+		ca := parseChanAlloc(r)
+		m.ChanAlloc = &ca
+	}
+	m.TMSDUBitOffset = r.pos
+	return m, true
+}
+
+// tmSDU returns the TM-SDU (Layer-3 PDU) bits following the MAC header, as a
+// one-bit-per-byte slice. Returns nil when the offset runs past the block or
+// the PDU carries no TM-SDU (null / start-fragment-with-nothing).
+func (m MACResource) tmSDU(bits []byte) []byte {
+	if m.NullPDU || m.TMSDUBitOffset >= len(bits) {
+		return nil
+	}
+	return bits[m.TMSDUBitOffset:]
+}
+
+// macFragmentSubtype reports the MAC-FRAG/MAC-END subtype for a PDU whose
+// leading MAC PDU type is MACFragEnd.
+func macFragmentSubtype(bits []byte) (uint8, bool) {
+	if len(bits) < 3 {
+		return 0, false
+	}
+	r := &bitReader{bits: bits}
+	if MACPDUType(r.u(2)) != MACPDUFragEnd {
+		return 0, false
+	}
+	return r.bit(), true
+}
+
+// macFragmentPayload returns the fragment payload bits of a MAC-FRAG/MAC-END
+// PDU. MAC-FRAG (§21.4.3.3): 2-bit type + 1-bit subtype, then the fragment.
+// MAC-END additionally carries a fill-bit flag + length indication before the
+// fragment (§21.4.3.4).
+func macFragmentPayload(bits []byte) []byte {
+	sub, ok := macFragmentSubtype(bits)
+	if !ok {
+		return nil
+	}
+	r := &bitReader{bits: bits}
+	r.u(3) // MAC PDU type + subtype
+	if sub == macEnd {
+		r.bit() // fill-bit indication
+		r.u(6)  // length indication
+	}
+	if r.pos >= len(bits) {
+		return nil
+	}
+	return bits[r.pos:]
+}

--- a/internal/radio/tetra/mac_test.go
+++ b/internal/radio/tetra/mac_test.go
@@ -1,0 +1,79 @@
+package tetra
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+// hexToBits expands packed MSB-first bytes into a one-bit-per-byte slice — the
+// type-1 bit shape DecodeSCHF / DecodeSCHHD emit and ParseMACResource consumes.
+func hexToBits(t *testing.T, s string) []byte {
+	t.Helper()
+	packed, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatalf("bad hex: %v", err)
+	}
+	bits := make([]byte, len(packed)*8)
+	for i := range bits {
+		if packed[i>>3]&(1<<uint(7-(i&7))) != 0 {
+			bits[i] = 1
+		}
+	}
+	return bits
+}
+
+// TestParseMACResourceRealGrant parses a real MAC-RESOURCE PDU recovered from
+// the 467.913 MHz SCBS capture (issue: TETRA voice grants never decoded because
+// the MAC header was fed straight to the L3 parser). This SCH/F block carries a
+// channel-allocation element granting a call onto the cell's own carrier 2716
+// (= 467.913 MHz), timeslot 1, for individual SSI 1005356 — one of the two
+// calls in the capture. The bytes are the exact type-1 payload the receiver
+// recovered (burst at dibit L=270183).
+func TestParseMACResourceRealGrant(t *testing.T) {
+	const pdu = "20760f572c3c83d538c90a1fe305009e0f92813c83d538c91e1fe301304a1eae5880"
+	bits := hexToBits(t, pdu)
+
+	m, ok := ParseMACResource(bits, false)
+	if !ok {
+		t.Fatal("ParseMACResource returned !ok on a real MAC-RESOURCE PDU")
+	}
+	if m.NullPDU {
+		t.Fatal("real grant PDU wrongly parsed as a NULL PDU")
+	}
+	if m.Address.SSI != 1005356 {
+		t.Errorf("Address.SSI = %d, want 1005356", m.Address.SSI)
+	}
+	if m.ChanAlloc == nil {
+		t.Fatal("ChanAlloc = nil, want a channel-allocation grant")
+	}
+	if m.ChanAlloc.CarrierNumber != 2716 {
+		t.Errorf("grant carrier = %d, want 2716 (467.913 MHz, the cell's own carrier)", m.ChanAlloc.CarrierNumber)
+	}
+	if m.ChanAlloc.Timeslot != 1 {
+		t.Errorf("grant timeslot = %d, want 1", m.ChanAlloc.Timeslot)
+	}
+}
+
+// TestParseMACResourceRejectsNonResource ensures a MAC broadcast PDU (SYSINFO,
+// leading MAC PDU type 10) is not mistaken for a MAC-RESOURCE.
+func TestParseMACResourceRejectsNonResource(t *testing.T) {
+	// SYSINFO broadcast from the same capture; main carrier 2716 sits in the
+	// 12 bits after the 2-bit MAC type + 2-bit broadcast type.
+	const sysinfo = "8a9c4c0e928eec8bd0c0041cffffd700"
+	bits := hexToBits(t, sysinfo)
+	if MACPDUType(bits[0]<<1|bits[1]) != MACPDUBroadcast {
+		t.Fatalf("leading MAC PDU type = %d, want broadcast (2)", bits[0]<<1|bits[1])
+	}
+	if _, ok := ParseMACResource(bits, false); ok {
+		t.Error("ParseMACResource accepted a MAC broadcast PDU")
+	}
+	// The cell's own main carrier decodes to 2716.
+	r := &bitReader{bits: bits}
+	r.u(2) // MAC PDU type
+	if r.u(2) != 0 {
+		t.Fatal("broadcast subtype != SYSINFO")
+	}
+	if mc := uint16(r.u(12)); mc != 2716 {
+		t.Errorf("SYSINFO main carrier = %d, want 2716", mc)
+	}
+}


### PR DESCRIPTION
## Summary

TETRA voice grants never decode on real air. The receiver feeds the recovered SCH/F / SCH/HD type-1 bits straight to the Layer-3 PDU parser, but on air those bits are a **MAC-RESOURCE PDU** whose header the L3 parser misreads as the CMCE discriminator. The channel/timeslot allocation for a call is a **MAC element** (§21.5.2), not a CMCE field, so it is never reachable — verified against a real 467.913 MHz SCBS capture, which locks and reads the cell identity but produces **zero grants over 90 s** despite two known voice calls.

This PR adds the lower-MAC parser that is the prerequisite to reaching a grant. It is a self-contained decoder building block; wiring it into the live burst path (AACH-steered slot demux + grant publish) is the next PR.

## Changes

- `internal/radio/tetra/mac.go` — lower-MAC PDU parsing (ETSI EN 300 392-2 §21.4.3.1 / §21.5.2):
  - MAC PDU type discriminator (MAC-RESOURCE / MAC-FRAG-END / broadcast / supplementary).
  - `ParseMACResource`: header (fill / grant-position / encryption / random-access / length-indication), the address element (all address types + widths), the optional power-control / slot-granting / channel-allocation flags, and the resulting **TM-SDU bit offset** so the nested L3 PDU can be extracted.
  - `ChannelAllocation` (§21.5.2): allocation type, timeslot, carrier number, extended-carrier and augmented (ul/dl==0) branches, so the cursor lands correctly past the element.
- `internal/radio/tetra/mac_test.go` — unit tests using **real captured PDUs** as fixtures.

## Test plan

- [x] `make vet test` is green locally
- [ ] `make integration` — n/a; this PR does not touch the daemon/live path (parser only, not yet wired)
- [x] Added tests. Validated against the reporter's 467.913 MHz SCBS capture: a real MAC-RESOURCE block decodes a channel-allocation grant onto the cell's own carrier **2716 (= 467.913 MHz), timeslot 1, SSI 1005356** — one of the two calls present. Cross-checked: the cell's own SYSINFO main carrier also decodes to 2716, and 2716 → 467.913 MHz on the band plan.
- [x] Smoke-tested against a real capture (headerless 50 kHz cs16 slice of the SCBS control channel); no hardware/USB/vocoder code changed.

## Breaking changes

None. Adds new decoder surface; no config keys, CLI flags, endpoints, or default behaviour change (the parser is not yet wired into the live decode path).

## Docs / CHANGELOG

- [ ] Not user-visible yet — this is an internal decoder building block with no operator-facing behaviour change. A CHANGELOG entry will accompany the PR that wires it in and surfaces grant/call events.

## Linked issues

Refs #925 (same SCBS / dynamic-MCCH-sharing decode effort).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GVoGbXXCo3doUafoQTf3mE)_