### PR TITLE
feat(tetra): decode voice-call grants from real air (AACH-steered NCDB + MAC demux)

### DIFF
--- a/internal/radio/tetra/downlink.go
+++ b/internal/radio/tetra/downlink.go
@@ -1,0 +1,219 @@
+package tetra
+
+// Downlink control-channel slot decode with correct Normal Continuous Downlink
+// Burst (NCDB) geometry + AACH-steered logical-channel selection + lower-MAC
+// demux. This is what lets voice-call grants decode on real air.
+//
+// The legacy normal-burst path in Process slices a fixed count of dibits
+// *after* the normal training sequence and feeds the bits straight to the L3
+// parser. That is doubly wrong for a real downlink slot: (1) an NCDB carries its
+// data in BKN1 *before* the training sequence and BKN2 *after* it (the fixed
+// forward slice misses BKN1 and starts mid-AACH), and (2) the recovered bits are
+// a MAC PDU whose header must be stripped to reach the L3 TM-SDU. downlinkNCDB
+// fixes the geometry (mirroring TrafficExtractor); decodeDownlinkSlot fixes the
+// channel/MAC demux.
+//
+// It runs additively alongside the legacy path: real bursts (with the full
+// [L-115, L+127) span) are decoded here, while the synthetic fixtures the
+// in-package tests feed — which place a single block contiguously after the
+// training sequence, with no BKN1 look-back — are ignored here and still handled
+// by the legacy path.
+
+// AACH half-block geometry relative to the normal training sequence leading
+// dibit L (ETSI EN 300 392-2 §9.4.4.3.2, matching traffic.go's BKN layout): the
+// 30-bit access-assignment is split either side of the training sequence.
+const (
+	ndbAACH1Start = -7 // AACH half 1: [L-7, L)   — 7 dibits
+	ndbAACH1Len   = 7
+	ndbAACH2Start = 11 // AACH half 2: [L+11, L+19) — 8 dibits
+	ndbAACH2Len   = 8
+)
+
+// downlinkNCDB scans the control-channel dibit stream for Normal Continuous
+// Downlink Bursts and hands each burst's BKN1, AACH halves, and BKN2 to onSlot.
+// A rolling buffer with look-back to BKN1 and look-ahead to BKN2 around each
+// detected normal training sequence — the same shape as TrafficExtractor, but
+// it also surfaces the AACH so the caller can classify the slot.
+type downlinkNCDB struct {
+	dets    []*SyncDetector
+	scratch []int
+	buf     []uint8
+	bufBase int
+	pending []int
+	onSlot  func(bkn1, aach1, aach2, bkn2 []uint8)
+}
+
+func newDownlinkNCDB(onSlot func(bkn1, aach1, aach2, bkn2 []uint8)) *downlinkNCDB {
+	d := &downlinkNCDB{onSlot: onSlot}
+	// The π/4-DQPSK stream carries a residual 0..3 dibit rotation, so correlate
+	// the normal training sequence (NTS1 + NTS2) under all four rotations.
+	for _, base := range [][]uint8{NormalSyncDibits(), NormalSyncDibits2()} {
+		for r := uint8(0); r < 4; r++ {
+			d.dets = append(d.dets, NewSyncDetector(rotateDibits(base, r), 2))
+		}
+	}
+	return d
+}
+
+// process consumes a window of dibits (baseIdx = absolute index of dibits[0],
+// monotonically non-decreasing) and emits each fully-buffered NCDB.
+func (d *downlinkNCDB) process(dibits []uint8, baseIdx int) {
+	if len(d.buf) == 0 {
+		d.bufBase = baseIdx
+	}
+	d.buf = append(d.buf, dibits...)
+
+	ntsLen := len(NormalSyncDibits())
+	for _, det := range d.dets {
+		hits, _ := det.Process(d.scratch[:0], dibits, baseIdx)
+		for _, trailing := range hits {
+			L := trailing - (ntsLen - 1)
+			dup := false
+			for _, q := range d.pending {
+				if q == L {
+					dup = true
+					break
+				}
+			}
+			if !dup {
+				d.pending = append(d.pending, L)
+			}
+		}
+	}
+
+	bufEnd := d.bufBase + len(d.buf)
+	kept := d.pending[:0:0]
+	for _, L := range d.pending {
+		needStart := L + ndbBKN1Start
+		needEnd := L + ndbBKN2Start + ndbBlockDibits
+		if needStart < d.bufBase {
+			continue // look-back trimmed away; give up on this hit
+		}
+		if needEnd > bufEnd {
+			kept = append(kept, L) // not enough look-ahead yet
+			continue
+		}
+		d.emit(L)
+	}
+	d.pending = kept
+
+	// Trim, keeping the trailing margin plus any unresolved hit's look-back.
+	keepFrom := bufEnd - ndbTrimMargin
+	for _, L := range d.pending {
+		if ns := L + ndbBKN1Start; ns < keepFrom {
+			keepFrom = ns
+		}
+	}
+	if keepFrom > d.bufBase {
+		drop := keepFrom - d.bufBase
+		if drop > len(d.buf) {
+			drop = len(d.buf)
+		}
+		d.buf = append(d.buf[:0], d.buf[drop:]...)
+		d.bufBase += drop
+	}
+}
+
+func (d *downlinkNCDB) emit(L int) {
+	slice := func(off, n int) []uint8 {
+		s := L + off - d.bufBase
+		if s < 0 || s+n > len(d.buf) {
+			return nil
+		}
+		return d.buf[s : s+n]
+	}
+	bkn1 := slice(ndbBKN1Start, ndbBlockDibits)
+	aach1 := slice(ndbAACH1Start, ndbAACH1Len)
+	aach2 := slice(ndbAACH2Start, ndbAACH2Len)
+	bkn2 := slice(ndbBKN2Start, ndbBlockDibits)
+	if bkn1 == nil || aach1 == nil || aach2 == nil || bkn2 == nil {
+		return
+	}
+	d.onSlot(bkn1, aach1, aach2, bkn2)
+}
+
+// decodeDownlinkSlot classifies and decodes one NCDB. It reads the AACH to find
+// the constellation rotation the slot decodes under, then recovers the slot's
+// signalling — SCH/F over the full slot (BKN1+BKN2) and SCH/HD over each half —
+// and hands each CRC-clean block to the MAC demux. CRC gates every decode, so
+// trying all three channel shapes never double-counts: a full-slot SCH/F slot
+// fails the half-slot SCH/HD CRC and vice versa.
+func (c *ControlChannel) decodeDownlinkSlot(bkn1, aach1, aach2, bkn2 []uint8) {
+	c.mu.Lock()
+	colour := c.colourCode
+	c.mu.Unlock()
+
+	derot := func(d []uint8, rot uint8) []byte {
+		return TetraDibitsToBits(rotateDibits(d, (4-rot)&3))
+	}
+
+	// The AACH is present in every downlink slot and decodes ~100% on a locked
+	// carrier, so it pins the rotation cheaply; fall back to trying all four
+	// only when it does not decode (e.g. a synthesised slot with no AACH).
+	rots := []uint8{0, 1, 2, 3}
+	aachDi := append(append([]uint8{}, aach1...), aach2...)
+	for r := uint8(0); r < 4; r++ {
+		rec, errs := DecodeAACH(derot(aachDi, r), colour)
+		if errs >= 0 {
+			if _, ok := ParseAccessAssign(rec); ok {
+				rots = []uint8{r}
+				break
+			}
+		}
+	}
+
+	for _, r := range rots {
+		full := append(append([]uint8{}, bkn1...), bkn2...)
+		if rec, ok := DecodeSCHF(derot(full, r), colour); ok {
+			c.ingestMAC(rec)
+		}
+		if rec, ok := DecodeSCHHD(derot(bkn1, r), colour); ok {
+			c.ingestMAC(rec)
+		}
+		if rec, ok := DecodeSCHHD(derot(bkn2, r), colour); ok {
+			c.ingestMAC(rec)
+		}
+	}
+}
+
+// ingestMAC demultiplexes a recovered logical-channel block (type-1 bits) at the
+// MAC layer: a MAC-RESOURCE PDU's channel-allocation element becomes a voice
+// grant, and its TM-SDU is handed to the L3 parser. MAC-FRAG/END reassembly and
+// broadcast (SYSINFO) handling here are follow-ups — SYSINFO identity already
+// reaches Ingest via the synchronisation-burst lock path.
+func (c *ControlChannel) ingestMAC(recovered []byte) {
+	if len(recovered) < 2 {
+		return
+	}
+	switch MACPDUType(recovered[0]<<1 | recovered[1]) {
+	case MACPDUResource:
+		m, ok := ParseMACResource(recovered, false)
+		if !ok || m.NullPDU {
+			return
+		}
+		if m.ChanAlloc != nil {
+			c.publishGrantFromMAC(m)
+		}
+		if sdu := m.tmSDU(recovered); sdu != nil {
+			if pdu, err := PDUFromBits(sdu); err == nil {
+				c.Ingest(pdu)
+			}
+		}
+	}
+}
+
+// publishGrantFromMAC turns a MAC-RESOURCE channel allocation into a voice
+// grant. The physical resource (carrier + timeslot) comes from the MAC
+// channel-allocation element; the addressed party SSI is the grant's group/dest
+// identity. Source SSI and the emergency/group flags live in the CMCE TM-SDU and
+// are filled once fragment reassembly surfaces the full CMCE PDU.
+func (c *ControlChannel) publishGrantFromMAC(m MACResource) {
+	// A grant on the CC is itself enough to declare the channel locked.
+	c.maybeLock(LockState{FrequencyHz: c.freqHz})
+	c.publishGrant(VoiceGrant{
+		DestSSI:       m.Address.SSI,
+		CarrierNumber: m.ChanAlloc.CarrierNumber,
+		Timeslot:      m.ChanAlloc.Timeslot & 0x3,
+		Encrypted:     m.Encrypted,
+	})
+}

--- a/internal/radio/tetra/downlink_test.go
+++ b/internal/radio/tetra/downlink_test.go
@@ -1,0 +1,78 @@
+package tetra
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TestProcessDecodesGrantFromNCDB is the regression for TETRA voice grants never
+// decoding on real air (the receiver fed raw SCH/F bits to the L3 parser and
+// missed the MAC layer + used the wrong burst geometry). It lays a real captured
+// MAC-RESOURCE grant PDU (carrier 2716 / timeslot 1 / SSI 1005356, from the
+// 467.913 MHz SCBS capture) into a correctly-shaped Normal Continuous Downlink
+// Burst — BKN1 before the training sequence, BKN2 after, AACH either side — and
+// asserts Process publishes the grant. Before the NCDB + MAC wiring this
+// produced no grant.
+func TestProcessDecodesGrantFromNCDB(t *testing.T) {
+	const colour = 0x1234 // scrambler seed for the round-trip; content is in the PDU
+
+	bus := events.NewBus(16)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Sys", FrequencyHz: 467_913_000})
+	cc.SetChannelCoding(ChannelCodingOn)
+	cc.SetColourCode(colour)
+
+	// The exact MAC-RESOURCE SCH/F type-1 payload recovered from the capture.
+	info := hexToBits(t, "20760f572c3c83d538c90a1fe305009e0f92813c83d538c91e1fe301304a1eae5880")[:268]
+	type5 := EncodeSCHF(info, colour)
+	dibits := TetraBitsToDibits(type5) // 216 dibits = BKN1(108) + BKN2(108)
+	if len(dibits) != 216 {
+		t.Fatalf("SCH/F type-5 → %d dibits, want 216", len(dibits))
+	}
+	bkn1, bkn2 := dibits[:108], dibits[108:]
+
+	// Assemble the NCDB: [pad][BKN1][AACH-h1][NTS][AACH-h2][BKN2][tail]. The AACH
+	// halves are left as fill (the decoder falls back to trying all rotations
+	// when the AACH does not decode).
+	var stream []uint8
+	stream = append(stream, make([]uint8, 24)...) // priming / BKN1 look-back headroom
+	stream = append(stream, bkn1...)
+	stream = append(stream, make([]uint8, ndbAACH1Len)...)
+	stream = append(stream, NormalSyncDibits()...)
+	stream = append(stream, make([]uint8, ndbAACH2Len)...)
+	stream = append(stream, bkn2...)
+	stream = append(stream, make([]uint8, 8)...) // look-ahead tail
+
+	cc.Process(stream, 0)
+
+	var grant *trunking.Grant
+	for drained := false; !drained; {
+		select {
+		case ev := <-sub.C:
+			if g, ok := ev.Payload.(trunking.Grant); ok && ev.Kind == events.KindGrant {
+				gg := g
+				grant = &gg
+			}
+		default:
+			drained = true
+		}
+	}
+	if grant == nil {
+		t.Fatal("Process published no grant for a real MAC-RESOURCE grant in an NCDB")
+	}
+	if grant.ChannelNum != 2716 {
+		t.Errorf("grant carrier = %d, want 2716", grant.ChannelNum)
+	}
+	if grant.GroupID != 1005356 {
+		t.Errorf("grant group/dest SSI = %d, want 1005356", grant.GroupID)
+	}
+	if grant.Timeslot != 2 { // chan-alloc timeslot 1 (0-based) → 1-based 2
+		t.Errorf("grant timeslot = %d, want 2", grant.Timeslot)
+	}
+}

--- a/internal/radio/tetra/process.go
+++ b/internal/radio/tetra/process.go
@@ -25,6 +25,10 @@ type processState struct {
 	softBuf    []complex64 // per-dibit soft differential, parallel to buf (nil ⇒ hard-only)
 	bufBase    int         // absolute dibit index of buf[0] / softBuf[0]
 	pendingSTS []int       // STS leading indices awaiting look-ahead
+
+	// ncdb decodes real downlink slots (correct NCDB geometry + AACH-steered
+	// MAC demux) under ChannelCodingOn. Lazily built. See downlink.go.
+	ncdb *downlinkNCDB
 }
 
 // Synchronisation downlink burst (SB) geometry in dibits, per ETSI
@@ -112,6 +116,14 @@ func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
 	if mode == ChannelCodingOn {
 		diffs := c.takeStashSoft(baseIdx, len(dibits))
 		c.processSB(p, dibits, diffs, baseIdx)
+		// AACH-steered NCDB decode with correct burst geometry + MAC demux —
+		// the path that recovers voice-call grants on real air. Additive
+		// alongside the legacy fixed-slice normal path below (which stays for
+		// the synthetic in-package fixtures).
+		if p.ncdb == nil {
+			p.ncdb = newDownlinkNCDB(c.decodeDownlinkSlot)
+		}
+		p.ncdb.process(dibits, baseIdx)
 	}
 
 	p.matchScratch, _ = p.det.Process(p.matchScratch[:0], dibits, baseIdx)


### PR DESCRIPTION
## Summary

TETRA voice-call grants never fired on a live control channel. The normal-burst path sliced a fixed count of dibits *after* the training sequence and fed them straight to the L3 parser — doubly wrong for a real downlink slot: a Normal Continuous Downlink Burst carries its data in **BKN1 before** the training sequence and **BKN2 after** it (the forward slice missed BKN1 and started mid-AACH), and the recovered bits are a **MAC PDU** whose header must be stripped to reach the L3 TM-SDU. A 90 s 467.913 MHz SCBS capture with two known calls locked but produced **zero grants**.

This wires the lower-MAC parser (merged in #950) into the live burst path so grants decode. Builds on the correct NCDB geometry + AACH-steered channel selection validated against the capture.

## Changes

- `internal/radio/tetra/downlink.go`:
  - `downlinkNCDB` — recovers each downlink slot's BKN1 + AACH + BKN2 with correct geometry (mirrors `TrafficExtractor`). Runs **additively** alongside the legacy fixed-slice path, so the synthetic in-package fixtures (which place a block contiguously after the training sequence, with no BKN1 look-back) still decode there.
  - `decodeDownlinkSlot` — reads the AACH to pin the π/4 constellation rotation, then decodes SCH/F over the full slot and SCH/HD over each half. CRC gates every decode, so trying all three channel shapes never double-counts.
  - `ingestMAC` — demuxes the MAC layer: a MAC-RESOURCE channel-allocation element becomes a voice grant (carrier + timeslot + addressed SSI), and its TM-SDU is handed to the L3 parser.
- `internal/radio/tetra/process.go` — wire the NCDB decoder into `Process` under `ChannelCodingOn`; add the lazily-built `ncdb` field.

## Test plan

- [x] `make vet test` is green locally
- [x] `make integration` is green locally (touches the daemon decode path)
- [x] Added `TestProcessDecodesGrantFromNCDB` — lays a real captured MAC-RESOURCE grant into a correctly-shaped NCDB and asserts the grant publishes. Verified it **fails without** the NCDB wiring and passes with it.
- [x] Smoke-tested via `gophertrunk replay` on the reporter's 467.913 MHz SCBS capture: grant events go **0 → 4**, decoding both calls — group 1005356 (ts 2) and 1020545 (ts 1) on carrier 2716. No hardware/USB/vocoder code changed.

## Breaking changes

None. The new decode path is additive; no config keys, CLI flags, endpoints, or default behaviour change. Existing behaviour (lock, colour code, synthetic-fixture decode) is preserved.

## Docs / CHANGELOG

- [ ] Not adding a CHANGELOG entry yet — grants now decode but the follow-ups below are needed before this is an operator-visible "TETRA voice calls" feature. Will add a bullet when the grant carries a resolved frequency + full CMCE identity.

## Linked issues

Refs #925 (same SCBS decode effort).

### Follow-ups (not in this PR)

- Band-plan frequency resolution (carrier number → Hz; grant currently reports `frequency_hz: 0`).
- Source SSI + group/emergency flags from the CMCE TM-SDU (needs MAC-FRAG/END reassembly).
- Per-slot follow filtering so the voice tap records only the granted timeslot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GVoGbXXCo3doUafoQTf3mE)_