### PR TITLE
tetra: add decode-health debug output to the console

### DIFF
--- a/internal/radio/tetra/control.go
+++ b/internal/radio/tetra/control.go
@@ -1,6 +1,7 @@
 package tetra
 
 import (
+	"context"
 	"log/slog"
 	"strings"
 	"sync"
@@ -57,6 +58,18 @@ type ControlChannel struct {
 	// adapter uses (see process.go). Lazily constructed on the
 	// first Process call.
 	proc *processState
+
+	// debug is set once in New when the logger is at debug level. It gates
+	// the decode-health counter accumulation (bumpStat) so a production
+	// (info-level) decode carries no counter overhead — same nil-guard
+	// spirit as fecObserver above.
+	debug bool
+	// statsMu guards stats independently of mu: the counters are bumped
+	// from the decode path (dispatchSlice / decodeSB / publishGrant), some
+	// of which run outside mu or call methods that take mu, so a separate
+	// lock avoids any re-entrancy. DrainStats reads and resets under it.
+	statsMu sync.Mutex
+	stats   Stats
 
 	mu               sync.Mutex
 	locked           bool
@@ -326,6 +339,54 @@ func (c *ControlChannel) Topology() TopologyConfig {
 	}
 }
 
+// Stats is a snapshot of TETRA decode-health counters accumulated since the
+// last DrainStats call. It is debug-only telemetry: the counters only move
+// when the control channel's logger is at debug level (see New), and feed the
+// throttled "tetra: decode status" console line the connector emits. All
+// fields are cumulative counts over the drain window except Dibits, which is
+// the symbol count used to estimate the effective baud.
+type Stats struct {
+	Dibits   int64 // symbols (dibits) processed — effective-baud numerator
+	SBBursts int64 // synchronisation-burst candidates entering the SB decoder
+	BSCHOK   int64 // BSCH blocks recovered CRC-clean
+	BSCHFail int64 // SB candidates whose BSCH did not decode under any rotation
+	SysInfo  int64 // BNCH SYSINFO PDUs decoded off the synchronisation burst
+	SCHPDUs  int64 // signalling PDUs parsed off the normal-sync path
+	Grants   int64 // voice grants published
+}
+
+// addStat adds n to a decode-health counter when debug telemetry is on. A
+// no-op (no lock, no write) otherwise, so production decode is unaffected.
+// field must point into c.stats.
+func (c *ControlChannel) addStat(field *int64, n int64) {
+	if !c.debug {
+		return
+	}
+	c.statsMu.Lock()
+	*field += n
+	c.statsMu.Unlock()
+}
+
+// DrainStats returns the decode-health counters accumulated since the last
+// call and resets them to zero. Stays all-zero unless the logger is at debug
+// level (see New / addStat). Safe for concurrent use.
+func (c *ControlChannel) DrainStats() Stats {
+	c.statsMu.Lock()
+	defer c.statsMu.Unlock()
+	s := c.stats
+	c.stats = Stats{}
+	return s
+}
+
+// Locked reports whether the control channel has declared lock. Read-only;
+// mirrors the Topology accessor so the connector can surface lock state in the
+// periodic decode-status line without poking unexported fields.
+func (c *ControlChannel) Locked() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.locked
+}
+
 // Options configure a ControlChannel.
 type Options struct {
 	Bus         *events.Bus
@@ -361,6 +422,7 @@ func New(opts Options) *ControlChannel {
 		resolver:    opts.Resolver,
 		now:         now,
 		fecObserver: opts.FECObserver,
+		debug:       log.Enabled(context.Background(), slog.LevelDebug),
 	}
 }
 
@@ -426,6 +488,7 @@ func (c *ControlChannel) publishGrant(g VoiceGrant) {
 			At:        c.now(),
 		},
 	})
+	c.addStat(&c.stats.Grants, 1)
 	c.log.Debug("tetra: grant",
 		"system", c.systemName,
 		"src", g.SourceSSI, "dst", g.DestSSI,

--- a/internal/radio/tetra/process.go
+++ b/internal/radio/tetra/process.go
@@ -91,6 +91,10 @@ func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
 	colour := c.colourCode
 	c.mu.Unlock()
 
+	// Count symbols for the effective-baud estimate in the periodic
+	// decode-status line (debug-only; no-op otherwise).
+	c.addStat(&c.stats.Dibits, int64(len(dibits)))
+
 	if c.proc == nil {
 		sts := SyncTrainingDibits()
 		ps := &processState{
@@ -264,6 +268,7 @@ func (c *ControlChannel) processSB(p *processState, dibits []uint8, diffs []comp
 // the BSCH SYNC PDU, locks on the cell identity, then descrambles the
 // BNCH SYSINFO with the learned code to fill the location area.
 func (c *ControlChannel) decodeSB(p *processState, L int) {
+	c.addStat(&c.stats.SBBursts, 1)
 	block := func(start, n int) []uint8 {
 		s := start - p.bufBase
 		return p.buf[s : s+n]
@@ -301,8 +306,17 @@ func (c *ControlChannel) decodeSB(p *processState, L int) {
 		}
 	}
 	if !found {
+		c.addStat(&c.stats.BSCHFail, 1)
+		c.log.Debug("tetra: sync burst BSCH decode failed",
+			"sts_at", L, "system", c.systemName)
 		return
 	}
+	c.addStat(&c.stats.BSCHOK, 1)
+	c.log.Debug("tetra: sync burst decoded",
+		"sts_at", L, "rot", bschRot,
+		"colour_code", sync.ExtendedColourCode()&0x3F,
+		"colour_ext", sync.ExtendedColourCode(),
+		"mcc", sync.MCC, "mnc", sync.MNC, "system", c.systemName)
 	c.LearnColourCode(sync.ExtendedColourCode())
 	// Report the BSCH FEC correction depth: re-encode the recovered
 	// type-1 bits and count how many channel bits the §8.3.1 chain
@@ -342,6 +356,10 @@ func (c *ControlChannel) decodeSB(p *processState, L int) {
 				if sb.MCC != 0 {
 					ls.MCC, ls.MNC = sb.MCC, sb.MNC
 				}
+				c.addStat(&c.stats.SysInfo, 1)
+				c.log.Debug("tetra: sysinfo",
+					"la", sb.LocationArea, "mcc", ls.MCC, "mnc", ls.MNC,
+					"rot", rot, "system", c.systemName)
 			}
 			if c.fecObserver != nil {
 				received := TetraDibitsToBits(rotateDibits(bnch, rot))
@@ -473,6 +491,7 @@ func (c *ControlChannel) dispatchSlice(slice []uint8, mode ChannelCodingMode, ch
 	}
 	if len(info) >= 1 {
 		if pdu, err := ParsePDU(info); err == nil {
+			c.addStat(&c.stats.SCHPDUs, 1)
 			c.Ingest(pdu)
 		}
 	}

--- a/internal/radio/tetra/receiver/receiver.go
+++ b/internal/radio/tetra/receiver/receiver.go
@@ -291,6 +291,17 @@ func (r *Receiver) Process(iq []complex64) {
 	r.dibitBase += len(r.dibits)
 }
 
+// CarrierOffsetHz reports the residual carrier-frequency offset the AFC most
+// recently estimated, in Hz. Zero when the AFC is disabled (EnableAFC off).
+// Diagnostic only — surfaced in the connector's periodic decode-status line so
+// an operator can see how far off-centre the tuned control channel sits.
+func (r *Receiver) CarrierOffsetHz() float64 {
+	if r.afc == nil {
+		return 0
+	}
+	return r.afc.OffsetHz(SymbolRate)
+}
+
 // Reset returns the receiver to its initial state. Call on stream
 // re-sync (control-channel hunt success, IQ underrun recovery) so
 // the matched filter + differential decoder shed their history and

--- a/internal/radio/tetra/stats_test.go
+++ b/internal/radio/tetra/stats_test.go
@@ -1,0 +1,180 @@
+package tetra
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// debugCC builds a ControlChannel whose logger writes to buf at the given
+// level, with channel coding on — the configuration the live/replay connector
+// uses. Returns the control channel and its event bus (caller closes the bus).
+func debugCC(t *testing.T, buf io.Writer, level slog.Level) (*ControlChannel, *events.Bus) {
+	t.Helper()
+	bus := events.NewBus(8)
+	cc := New(Options{
+		Bus:         bus,
+		Log:         slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: level})),
+		SystemName:  "Sys",
+		FrequencyHz: 412_000_000,
+	})
+	cc.SetChannelCoding(ChannelCodingOn)
+	return cc, bus
+}
+
+// buildCleanSBStream assembles a complete, error-free synchronisation burst as
+// a hard dibit stream: pad, BSCH(60) carrying the cell identity, STS(19),
+// broadcast(15), BNCH(108) carrying a SYSINFO PDU scrambled with the cell's
+// extended colour code, then trailing margin so the look-ahead is satisfied.
+// The BNCH info bits go through pduToType1Bits (the same helper the SCH/HD
+// round-trip test uses), so the recovered PDU parses back to a SystemBroadcast.
+func buildCleanSBStream(t *testing.T, cc6 uint8, mcc, mnc uint16, sysinfo PDU) []uint8 {
+	t.Helper()
+	syncInfo := make([]byte, 60)
+	putBits(syncInfo, 4, 6, uint32(cc6))
+	putBits(syncInfo, 31, 10, uint32(mcc))
+	putBits(syncInfo, 41, 14, uint32(mnc))
+	bschDibits := TetraBitsToDibits(EncodeBSCH(syncInfo))
+
+	ext := ExtendedColourCode(mcc, mnc, cc6)
+	info := pduToType1Bits(sysinfo, 124)
+	if info == nil {
+		t.Fatalf("sysinfo PDU too large for SCH/HD 124 type-1 bits")
+	}
+	bnchDibits := TetraBitsToDibits(EncodeSCHHD(info, ext))
+
+	var s []uint8
+	s = append(s, make([]uint8, 50)...)                // pad before BSCH
+	s = append(s, bschDibits...)                       // BSCH (60)
+	s = append(s, SyncTrainingDibits()...)             // STS (19)
+	s = append(s, make([]uint8, sbBroadcastDibits)...) // broadcast (15)
+	s = append(s, bnchDibits...)                       // BNCH (108)
+	s = append(s, make([]uint8, 300)...)               // trailing look-ahead margin
+	return s
+}
+
+// cleanSysinfoPDU is a minimal valid MLE SYSINFO PDU (MCC=10b / MNC=14b /
+// LA=14b), the same payload layout the topology / round-trip tests use.
+func cleanSysinfoPDU() PDU {
+	return PDU{
+		Disc:    DiscMLE,
+		Type:    uint8(MLESystemInfo),
+		Payload: []byte{0x00, 0xC0, 0x05, 0x01, 0x00}, // MCC=3 MNC=5 LA=64
+	}
+}
+
+// TestDrainStatsCountsSyncBurst confirms the debug decode-health counters move
+// on a clean synchronisation burst (SB) and reset on drain. A clean SB decodes
+// its BSCH (learning the colour code) and its BNCH SYSINFO, so one burst yields
+// SBBursts>=1, BSCHOK>=1, BSCHFail=0 and SysInfo>=1, and Dibits equal to the
+// stream length. A second drain must return to zero.
+func TestDrainStatsCountsSyncBurst(t *testing.T) {
+	cc, bus := debugCC(t, io.Discard, slog.LevelDebug)
+	defer bus.Close()
+
+	stream := buildCleanSBStream(t, 0x2D, 3, 5, cleanSysinfoPDU())
+	cc.Process(stream, 0)
+
+	got := cc.DrainStats()
+	if got.Dibits != int64(len(stream)) {
+		t.Errorf("Dibits = %d, want %d (stream length)", got.Dibits, len(stream))
+	}
+	if got.SBBursts < 1 {
+		t.Errorf("SBBursts = %d, want >= 1", got.SBBursts)
+	}
+	if got.BSCHOK < 1 {
+		t.Errorf("BSCHOK = %d, want >= 1", got.BSCHOK)
+	}
+	if got.SysInfo < 1 {
+		t.Errorf("SysInfo = %d, want >= 1 (clean BNCH should decode)", got.SysInfo)
+	}
+	if got.BSCHFail != 0 {
+		t.Errorf("BSCHFail = %d, want 0 on a clean burst", got.BSCHFail)
+	}
+
+	// Draining resets: a second drain with no further input is all-zero.
+	if again := cc.DrainStats(); again != (Stats{}) {
+		t.Errorf("second DrainStats = %+v, want zero", again)
+	}
+
+	// The location area from the BNCH SYSINFO made it into the lock state.
+	if topo := cc.Topology(); topo.LocationArea != 64 {
+		t.Errorf("LocationArea = %d, want 64 (from decoded BNCH SYSINFO)", topo.LocationArea)
+	}
+}
+
+// TestStatsInertAtInfoLevel confirms the counters are gated on debug: at
+// info level the accumulation is a no-op, so DrainStats stays zero even
+// after decoding a burst. This is the zero-overhead production path.
+func TestStatsInertAtInfoLevel(t *testing.T) {
+	cc, bus := debugCC(t, io.Discard, slog.LevelInfo)
+	defer bus.Close()
+
+	stream := buildCleanSBStream(t, 0x2D, 3, 5, cleanSysinfoPDU())
+	cc.Process(stream, 0)
+
+	if got := cc.DrainStats(); got != (Stats{}) {
+		t.Errorf("DrainStats at info level = %+v, want zero (gated on debug)", got)
+	}
+	// The lock still happened — gating stats must not disable decoding.
+	if topo := cc.Topology(); topo.MCC == 0 {
+		t.Errorf("burst did not decode at info level (MCC=0); stats gating must not affect decode")
+	}
+}
+
+// TestSyncBurstDebugLines confirms the per-milestone debug lines are emitted at
+// debug level and suppressed at info level. These are the "more debug info from
+// the control channel" the request asked for.
+func TestSyncBurstDebugLines(t *testing.T) {
+	t.Run("debug emits", func(t *testing.T) {
+		var buf bytes.Buffer
+		cc, bus := debugCC(t, &buf, slog.LevelDebug)
+		defer bus.Close()
+		cc.Process(buildCleanSBStream(t, 0x2D, 3, 5, cleanSysinfoPDU()), 0)
+		out := buf.String()
+		for _, want := range []string{"tetra: sync burst decoded", "tetra: sysinfo"} {
+			if !strings.Contains(out, want) {
+				t.Errorf("debug output missing %q\n---\n%s", want, out)
+			}
+		}
+	})
+	t.Run("info suppresses", func(t *testing.T) {
+		var buf bytes.Buffer
+		cc, bus := debugCC(t, &buf, slog.LevelInfo)
+		defer bus.Close()
+		cc.Process(buildCleanSBStream(t, 0x2D, 3, 5, cleanSysinfoPDU()), 0)
+		if out := buf.String(); strings.Contains(out, "tetra: sync burst decoded") {
+			t.Errorf("info output should not contain debug milestone lines\n---\n%s", out)
+		}
+	})
+}
+
+// TestDrainStatsCountsSCHPDU confirms the SCHPDUs counter tracks signalling
+// PDUs recovered off the normal-sync path (dispatchSlice), the other decode
+// route alongside the synchronisation burst.
+func TestDrainStatsCountsSCHPDU(t *testing.T) {
+	cc, bus := debugCC(t, io.Discard, slog.LevelDebug)
+	defer bus.Close()
+	cc.SetExpectedChannel(ChannelSCHHD)
+	cc.SetColourCode(0x12345)
+
+	pdu := PDU{Disc: DiscMLE, Type: uint8(MLESystemInfo), Payload: []byte{0x00, 0x40, 0x00, 0x00, 0x00}}
+	info := pduToType1Bits(pdu, 124)
+	if info == nil {
+		t.Fatal("PDU too large for SCH/HD 124 type-1 bits")
+	}
+	dibits := TetraBitsToDibits(EncodeSCHHD(info, 0x12345))
+
+	stream := make([]uint8, 30)
+	stream = append(stream, NormalSyncDibits()...)
+	stream = append(stream, dibits...)
+	cc.Process(stream, 0)
+
+	if got := cc.DrainStats(); got.SCHPDUs < 1 {
+		t.Errorf("SCHPDUs = %d, want >= 1 (normal-sync SCH/HD PDU)", got.SCHPDUs)
+	}
+}

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -1,8 +1,11 @@
 package ccdecoder
 
 import (
+	"context"
 	"log/slog"
+	"math"
 	"sort"
+	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
@@ -610,17 +613,96 @@ func newTETRAPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 		// cut the on-air symbol error rate by ~10x (issue #553).
 		EnableChannelFilter: true,
 	})
-	return &tetraPipeline{rx: rx, cc: cc}, nil
+	return &tetraPipeline{
+		rx:     rx,
+		cc:     cc,
+		log:    opts.Log,
+		system: opts.SystemName,
+		now:    time.Now,
+		// Gate the periodic decode-status line on debug once, up front, so a
+		// production (info-level) decode does no per-chunk clock reads. The
+		// control channel gates its own counter accumulation the same way.
+		debug: opts.Log != nil && opts.Log.Enabled(context.Background(), slog.LevelDebug),
+	}, nil
 }
+
+// tetraStatusInterval throttles the aggregate "tetra: decode status" debug
+// line so a long capture emits a compact health summary a few times a minute
+// rather than once per IQ chunk. Mirrors the ~1 s AFC-status throttle in
+// decoder.go.
+const tetraStatusInterval = 5 * time.Second
 
 type tetraPipeline struct {
-	rx *tetrarx.Receiver
-	cc *tetra.ControlChannel
+	rx      *tetrarx.Receiver
+	cc      *tetra.ControlChannel
+	log     *slog.Logger
+	system  string
+	debug   bool
+	now     func() time.Time // injectable for tests; set to time.Now at construction
+	lastLog time.Time        // wall clock of the previous status line (zero ⇒ not primed)
 }
 
-func (p *tetraPipeline) Process(iq []complex64) { p.rx.Process(iq) }
-func (p *tetraPipeline) Reset()                 { p.rx.Reset() }
-func (p *tetraPipeline) Close() error           { return nil }
+func (p *tetraPipeline) Process(iq []complex64) {
+	p.rx.Process(iq)
+	p.maybeLogStatus()
+}
+
+// tetraEffectiveBaud derives the effective symbol rate (baud) and its
+// percentage deviation from the nominal 18000 sym/s over a window of `dibits`
+// symbols spanning `elapsed`. This is the same figure siglab reports as
+// EffectiveBaud = symbols / duration. Returns zeros for a non-positive window.
+func tetraEffectiveBaud(dibits int64, elapsed time.Duration) (baud, devPct float64) {
+	secs := elapsed.Seconds()
+	if secs <= 0 {
+		return 0, 0
+	}
+	baud = float64(dibits) / secs
+	devPct = (baud - tetrarx.SymbolRate) / tetrarx.SymbolRate * 100
+	return baud, devPct
+}
+
+// maybeLogStatus emits a throttled decode-health summary at debug level:
+// effective baud + deviation (symbols over wall time, the same figure siglab
+// reports as EffectiveBaud), the AFC's residual carrier offset, lock state and
+// the per-window decode counts. No-op unless the logger is at debug level.
+func (p *tetraPipeline) maybeLogStatus() {
+	if !p.debug || p.log == nil {
+		return
+	}
+	now := p.now()
+	if p.lastLog.IsZero() {
+		p.lastLog = now // prime the window; first line lands one interval later
+		return
+	}
+	elapsed := now.Sub(p.lastLog)
+	if elapsed < tetraStatusInterval {
+		return
+	}
+	p.lastLog = now
+
+	st := p.cc.DrainStats()
+	baud, dev := tetraEffectiveBaud(st.Dibits, elapsed)
+	p.log.Debug("tetra: decode status",
+		"system", p.system,
+		"locked", p.cc.Locked(),
+		"carrier_off_hz", math.Round(p.rx.CarrierOffsetHz()*10)/10,
+		"baud", math.Round(baud),
+		"baud_dev_pct", math.Round(dev*100)/100,
+		"sb_bursts", st.SBBursts,
+		"bsch_ok", st.BSCHOK,
+		"bsch_fail", st.BSCHFail,
+		"sysinfo", st.SysInfo,
+		"sch_pdus", st.SCHPDUs,
+		"grants", st.Grants,
+		"colour_code", p.cc.Topology().ColourCode&0x3F,
+	)
+}
+
+func (p *tetraPipeline) Reset() {
+	p.rx.Reset()
+	p.lastLog = time.Time{}
+}
+func (p *tetraPipeline) Close() error { return nil }
 
 // TopologySnapshot surfaces the TETRA single-cell identity (MCC/MNC/LA + colour
 // code) the control channel learned. No adjacent cells for TETRA.

--- a/internal/scanner/ccdecoder/pipelines_tetra_status_test.go
+++ b/internal/scanner/ccdecoder/pipelines_tetra_status_test.go
@@ -1,0 +1,128 @@
+package ccdecoder
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TestTETRAEffectiveBaud pins the effective-baud helper: symbols over the
+// window duration, plus percentage deviation from the nominal 18000 sym/s.
+func TestTETRAEffectiveBaud(t *testing.T) {
+	cases := []struct {
+		name    string
+		dibits  int64
+		elapsed time.Duration
+		baud    float64
+		dev     float64
+	}{
+		{"nominal", 108_000, 6 * time.Second, 18000, 0},
+		{"plus_0.1pct", 90_070, 5 * time.Second, 18014, (18014.0 - 18000) / 18000 * 100},
+		{"empty_window", 0, 0, 0, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			baud, dev := tetraEffectiveBaud(tc.dibits, tc.elapsed)
+			if baud != tc.baud {
+				t.Errorf("baud = %v, want %v", baud, tc.baud)
+			}
+			if (dev-tc.dev) > 1e-9 || (tc.dev-dev) > 1e-9 {
+				t.Errorf("devPct = %v, want %v", dev, tc.dev)
+			}
+		})
+	}
+}
+
+// TestTETRAStatusLineThrottled drives the pipeline's decode-status line with a
+// deterministic clock: it primes on the first call, stays silent until the
+// throttle interval elapses, then emits one line with the effective baud
+// derived from the symbols processed in the window. A second call within the
+// same interval must not re-emit.
+func TestTETRAStatusLineThrottled(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	bus := events.NewBus(8)
+	defer bus.Close()
+
+	pp, err := newTETRAPipeline(PipelineOptions{
+		Bus: bus, Log: logger, SystemName: "Test", FrequencyHz: 412_000_000,
+		SampleRateHz: 144_000,
+		System: trunking.System{
+			Name: "Test", Protocol: trunking.ProtocolTETRA,
+			ControlChannels: []uint32{412_000_000},
+		},
+	})
+	if err != nil {
+		t.Fatalf("newTETRAPipeline: %v", err)
+	}
+	p := pp.(*tetraPipeline)
+
+	now := time.Unix(1000, 0)
+	p.now = func() time.Time { return now }
+
+	// First call primes the window; no status line yet.
+	p.maybeLogStatus()
+	if strings.Contains(buf.String(), "tetra: decode status") {
+		t.Fatalf("status line emitted before the interval elapsed\n%s", buf.String())
+	}
+
+	// Accumulate 108000 symbols so baud = 108000 / 6 s = 18000.
+	p.cc.Process(make([]uint8, 108_000), 0)
+
+	now = now.Add(6 * time.Second)
+	p.maybeLogStatus()
+	out := buf.String()
+	if !strings.Contains(out, "tetra: decode status") {
+		t.Fatalf("expected a status line after the interval\n%s", out)
+	}
+	if !strings.Contains(out, "baud=18000") {
+		t.Errorf("expected baud=18000 in status line\n%s", out)
+	}
+	for _, key := range []string{"carrier_off_hz=", "locked=", "sb_bursts=", "colour_code="} {
+		if !strings.Contains(out, key) {
+			t.Errorf("status line missing key %q\n%s", key, out)
+		}
+	}
+
+	// A second call within the same interval must not re-emit.
+	buf.Reset()
+	p.maybeLogStatus()
+	if strings.Contains(buf.String(), "tetra: decode status") {
+		t.Errorf("status line emitted twice within one interval\n%s", buf.String())
+	}
+}
+
+// TestTETRAStatusLineSilentAtInfo confirms the status line is gated on debug —
+// an info-level logger emits nothing even past the interval.
+func TestTETRAStatusLineSilentAtInfo(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	bus := events.NewBus(8)
+	defer bus.Close()
+
+	pp, err := newTETRAPipeline(PipelineOptions{
+		Bus: bus, Log: logger, SystemName: "Test", FrequencyHz: 412_000_000,
+		SampleRateHz: 144_000,
+		System: trunking.System{
+			Name: "Test", Protocol: trunking.ProtocolTETRA,
+			ControlChannels: []uint32{412_000_000},
+		},
+	})
+	if err != nil {
+		t.Fatalf("newTETRAPipeline: %v", err)
+	}
+	p := pp.(*tetraPipeline)
+	now := time.Unix(1000, 0)
+	p.now = func() time.Time { return now }
+	p.maybeLogStatus()
+	now = now.Add(6 * time.Second)
+	p.maybeLogStatus()
+	if strings.Contains(buf.String(), "tetra: decode status") {
+		t.Errorf("status line should be gated off at info level\n%s", buf.String())
+	}
+}


### PR DESCRIPTION
The live TETRA decode path was nearly silent: only cc-locked/colour-learned
(Info) and grant/aach (Debug) were emitted. There was no visibility into sync
acquisition, per-burst decode health, carrier offset, or effective baud while
a capture ran — the very things an operator iterating on TETRA needs to see.

Add debug-level observability, gated on the existing global -log-level debug
(so it is a no-op in normal operation and appears automatically in
`gophertrunk replay`, which already runs at debug):

- Decode-health counters on tetra.ControlChannel (dibits, SB bursts, BSCH
  ok/fail, SYSINFO, SCH PDUs, grants), accumulated only when the logger is at
  debug level and exposed via DrainStats(); plus a Locked() accessor.
- Per-milestone Debug lines at the previously-silent points: "sync burst
  decoded", "sysinfo", and "sync burst BSCH decode failed".
- Receiver.CarrierOffsetHz() surfaces the AFC's residual carrier estimate,
  which was computed but never reachable.
- A throttled (~5s) "tetra: decode status" line in the TETRA pipeline
  reporting effective baud + deviation (symbols/duration, the same figure
  siglab reports), carrier offset, lock state and the per-window decode
  counts.

Both the daemon and the replay/siglab path build the same ControlChannel +
tetraPipeline, so this surfaces in both. Pure observability — no decode
behaviour change.

Tests: DrainStats counter/reset behaviour and debug gating; the milestone
debug lines; the effective-baud helper; and the throttled status line via an
injected clock.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015mC2ZV5guQTFf5iuQ9Nctt