### PR TITLE
feat(tetra): resolve grant carrier numbers to Hz from the cell's own carrier

### DIFF
--- a/internal/radio/tetra/control.go
+++ b/internal/radio/tetra/control.go
@@ -66,6 +66,12 @@ type ControlChannel struct {
 	channelType      ChannelType
 	colourCode       uint32
 	colourLearned    bool
+	// mainCarrier is the cell's own carrier number, learned from the
+	// broadcast SYSINFO. With the tuned control-channel frequency it lets a
+	// grant's carrier number resolve to Hz relative to this carrier, without a
+	// configured band plan (see publishGrant).
+	mainCarrier    uint16
+	mainCarrierSet bool
 
 	// pendingSoft holds the per-symbol complex differential (soft
 	// information) for the next Process call, stashed by StashSoft
@@ -394,6 +400,37 @@ func (c *ControlChannel) Ingest(p PDU) {
 	}
 }
 
+// tetraChannelSpacingHz is the TETRA carrier spacing (25 kHz), used to derive a
+// grant carrier's frequency relative to the cell's own carrier.
+const tetraChannelSpacingHz = 25_000
+
+// carrierFrequency derives the Hz of a TETRA carrier number relative to this
+// cell's own carrier (learned from SYSINFO) at 25 kHz spacing. Returns false
+// until both the cell's carrier and the tuned control frequency are known — so
+// an offline replay with no centre frequency simply reports 0.
+func (c *ControlChannel) carrierFrequency(carrier uint16) (uint32, bool) {
+	c.mu.Lock()
+	mc, set := c.mainCarrier, c.mainCarrierSet
+	c.mu.Unlock()
+	if !set || c.freqHz == 0 {
+		return 0, false
+	}
+	hz := int64(c.freqHz) + (int64(carrier)-int64(mc))*tetraChannelSpacingHz
+	if hz <= 0 {
+		return 0, false
+	}
+	return uint32(hz), true
+}
+
+// learnMainCarrier records the cell's own carrier number from a SYSINFO
+// broadcast, so grant carrier numbers can resolve to Hz relative to it.
+func (c *ControlChannel) learnMainCarrier(carrier uint16) {
+	c.mu.Lock()
+	c.mainCarrier = carrier
+	c.mainCarrierSet = true
+	c.mu.Unlock()
+}
+
 func (c *ControlChannel) publishGrant(g VoiceGrant) {
 	if c.bus == nil {
 		return
@@ -406,6 +443,11 @@ func (c *ControlChannel) publishGrant(g VoiceGrant) {
 			c.log.Debug("tetra: band-plan resolution failed",
 				"carrier", g.CarrierNumber, "err", err)
 		}
+	} else if hz, ok := c.carrierFrequency(g.CarrierNumber); ok {
+		// No configured band plan: derive the grant frequency relative to this
+		// cell's own carrier (learned from SYSINFO) at 25 kHz TETRA spacing.
+		// Exact for a same-carrier SCBS (carrier == mainCarrier ⇒ the CC freq).
+		freq = hz
 	}
 	c.bus.Publish(events.Event{
 		Kind: events.KindGrant,

--- a/internal/radio/tetra/downlink.go
+++ b/internal/radio/tetra/downlink.go
@@ -199,6 +199,13 @@ func (c *ControlChannel) ingestMAC(recovered []byte) {
 				c.Ingest(pdu)
 			}
 		}
+	case MACPDUBroadcast:
+		// Learn the cell's own carrier number so grant carrier numbers resolve
+		// to Hz relative to this carrier (see carrierFrequency). SYSINFO
+		// identity (MCC/MNC/LA) still reaches the lock via the sync-burst path.
+		if mc, ok := SysInfoMainCarrier(recovered); ok {
+			c.learnMainCarrier(mc)
+		}
 	}
 }
 

--- a/internal/radio/tetra/downlink_test.go
+++ b/internal/radio/tetra/downlink_test.go
@@ -76,3 +76,57 @@ func TestProcessDecodesGrantFromNCDB(t *testing.T) {
 		t.Errorf("grant timeslot = %d, want 2", grant.Timeslot)
 	}
 }
+
+// TestCarrierFrequencyDerivation checks that a grant carrier number resolves to
+// Hz relative to the cell's own carrier (learned from SYSINFO) at 25 kHz
+// spacing, with no configured band plan.
+func TestCarrierFrequencyDerivation(t *testing.T) {
+	cc := New(Options{Log: slog.Default(), FrequencyHz: 467_913_000})
+	if _, ok := cc.carrierFrequency(2716); ok {
+		t.Error("carrierFrequency resolved before the main carrier was learned")
+	}
+	cc.learnMainCarrier(2716)
+	for carrier, want := range map[uint16]uint32{
+		2716: 467_913_000, // same carrier ⇒ the control frequency
+		2717: 467_938_000, // +25 kHz
+		2715: 467_888_000, // −25 kHz
+	} {
+		hz, ok := cc.carrierFrequency(carrier)
+		if !ok || hz != want {
+			t.Errorf("carrier %d → %d (ok=%v), want %d", carrier, hz, ok, want)
+		}
+	}
+}
+
+// TestGrantPublishesResolvedFrequency drives the MAC ingest end to end: a real
+// SYSINFO broadcast teaches the cell's carrier, then a real MAC-RESOURCE grant
+// publishes with the traffic frequency resolved (same-carrier SCBS ⇒ 467.913).
+func TestGrantPublishesResolvedFrequency(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Sys", FrequencyHz: 467_913_000})
+	cc.ingestMAC(hexToBits(t, "8a9c4c0e928eec8bd0c0041cffffd700"))                                     // SYSINFO → carrier 2716
+	cc.ingestMAC(hexToBits(t, "20760f572c3c83d538c90a1fe305009e0f92813c83d538c91e1fe301304a1eae5880")) // grant
+
+	var grant *trunking.Grant
+	for drained := false; !drained; {
+		select {
+		case ev := <-sub.C:
+			if g, ok := ev.Payload.(trunking.Grant); ok && ev.Kind == events.KindGrant {
+				gg := g
+				grant = &gg
+			}
+		default:
+			drained = true
+		}
+	}
+	if grant == nil {
+		t.Fatal("no grant published")
+	}
+	if grant.FrequencyHz != 467_913_000 {
+		t.Errorf("grant frequency = %d, want 467913000 (carrier 2716 resolved)", grant.FrequencyHz)
+	}
+}

--- a/internal/radio/tetra/mac.go
+++ b/internal/radio/tetra/mac.go
@@ -30,6 +30,13 @@ const (
 	macEnd  uint8 = 1
 )
 
+// Broadcast sub-types (the 2 bits following the MAC PDU type when
+// MACPDUType == MACPDUBroadcast), EN 300 392-2 §21.4.4.
+const (
+	TETRAMACBcastSysInfo      uint8 = 0 // SYSINFO
+	TETRAMACBcastAccessDefine uint8 = 1 // ACCESS-DEFINE
+)
+
 // Address types (§21.4.3.1). addrLenBits gives the address element width for
 // each; NULL carries no address (and the PDU no TM-SDU).
 const (
@@ -242,6 +249,24 @@ func ParseMACResource(bits []byte, isDecrypted bool) (MACResource, bool) {
 	}
 	m.TMSDUBitOffset = r.pos
 	return m, true
+}
+
+// SysInfoMainCarrier extracts the cell's own main carrier number from a MAC
+// broadcast SYSINFO PDU (type-1 bits, one-per-byte MSB first): MAC PDU type (2)
+// + broadcast type (2) + main carrier (12), per EN 300 392-2 §21.4.4.1. Returns
+// (0, false) unless the PDU is a broadcast whose subtype is SYSINFO.
+func SysInfoMainCarrier(bits []byte) (uint16, bool) {
+	if len(bits) < 16 {
+		return 0, false
+	}
+	r := &bitReader{bits: bits}
+	if MACPDUType(r.u(2)) != MACPDUBroadcast {
+		return 0, false
+	}
+	if r.u(2) != uint32(TETRAMACBcastSysInfo) {
+		return 0, false
+	}
+	return uint16(r.u(12)), true
 }
 
 // tmSDU returns the TM-SDU (Layer-3 PDU) bits following the MAC header, as a

--- a/internal/radio/tetra/mac_test.go
+++ b/internal/radio/tetra/mac_test.go
@@ -77,3 +77,21 @@ func TestParseMACResourceRejectsNonResource(t *testing.T) {
 		t.Errorf("SYSINFO main carrier = %d, want 2716", mc)
 	}
 }
+
+// TestSysInfoMainCarrier decodes the cell's own carrier number from a real
+// SYSINFO broadcast recovered from the 467.913 MHz capture — carrier 2716,
+// which resolves to 467.913 MHz on the band plan.
+func TestSysInfoMainCarrier(t *testing.T) {
+	bits := hexToBits(t, "8a9c4c0e928eec8bd0c0041cffffd700")
+	mc, ok := SysInfoMainCarrier(bits)
+	if !ok {
+		t.Fatal("SysInfoMainCarrier returned !ok on a real SYSINFO broadcast")
+	}
+	if mc != 2716 {
+		t.Errorf("main carrier = %d, want 2716", mc)
+	}
+	// A MAC-RESOURCE PDU is not a SYSINFO broadcast.
+	if _, ok := SysInfoMainCarrier(hexToBits(t, "20760f572c3c83d538c90a1fe305009e")); ok {
+		t.Error("SysInfoMainCarrier accepted a non-broadcast PDU")
+	}
+}


### PR DESCRIPTION
## Summary

A decoded TETRA voice grant carried a carrier number but no frequency (`frequency_hz: 0`), so the trunking engine could not retune a voice tap to the call. TETRA's carrier-number → Hz mapping is network-specific, but the cell broadcasts its own carrier number in SYSINFO and the control channel is tuned to a known frequency — together those pin the band plan without any operator config.

## Changes

- `internal/radio/tetra/mac.go` — `SysInfoMainCarrier`: decode the cell's own carrier number from a MAC broadcast SYSINFO PDU (§21.4.4.1). Add the broadcast sub-type constants.
- `internal/radio/tetra/downlink.go` — `ingestMAC` learns the main carrier from SYSINFO broadcasts during MAC demux.
- `internal/radio/tetra/control.go` — `carrierFrequency` derives a grant carrier's Hz relative to the cell's own carrier at 25 kHz spacing: `grant_hz = control_hz + (grant_carrier − main_carrier) × 25 kHz`. `publishGrant` uses it when no explicit `Options.Resolver` is configured. Exact for a same-carrier SCBS (grant carrier == main carrier ⇒ the control frequency) and correct for adjacent carriers.

## Test plan

- [x] `make vet test` is green locally
- [x] `make integration` is green locally (decode path)
- [x] Added tests: `SysInfoMainCarrier` decode (real SYSINFO fixture → carrier 2716), the derivation formula (`carrierFrequency` for same / ±25 kHz carriers), and end-to-end (`ingestMAC` SYSINFO + grant ⇒ grant frequency resolved).
- [x] Smoke-tested via `gophertrunk replay … -freq 467913000` on the reporter's capture: both calls' grants now resolve to **467.913 MHz** (carrier 2716), timeslots 1 and 2. No hardware/USB/vocoder code changed.

## Breaking changes

None. Adds a derivation used only when no band-plan `Resolver` is configured; an offline replay with no centre frequency still reports 0.

## Docs / CHANGELOG

- [ ] n/a — still below the "operator-visible TETRA voice" bar; deferred until grants carry full CMCE identity and the tap follows.

## Linked issues

Refs #925.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GVoGbXXCo3doUafoQTf3mE)_