### PR TITLE
tetra + siglab: decode-health console debug and dashboard viz fixes

### DIFF
--- a/internal/siglab/engine.go
+++ b/internal/siglab/engine.go
@@ -537,10 +537,12 @@ func runReader(r io.Reader, source string, decode SampleDecoder, bytesPerSample 
 			res.IQTaps.SymbolCardinality = an.cardinality
 		}
 		// Per-symbol differential phase (the π/4-DQPSK rotation signal) for the
-		// rotation-tracker viz. Populated only on the CQPSK path, which is the
-		// only one that buffers complex constellation points.
+		// rotation-tracker viz, plus the 2-D symbol-decision constellation for
+		// the constellation viz's "Symbols" mode. Populated only on the CQPSK
+		// path, which is the only one that buffers complex constellation points.
 		if an != nil && len(an.constBuf) > 1 {
 			res.IQTaps.DiffPhase = diffPhaseSeries(an.constBuf, cfg.captureIQMaxPoints())
+			res.IQTaps.SymbolIQ = symbolIQSeries(an.constBuf, cfg.captureIQMaxPoints())
 		}
 	}
 

--- a/internal/siglab/iqtaps.go
+++ b/internal/siglab/iqtaps.go
@@ -56,6 +56,16 @@ type IQTaps struct {
 	// ±π/4 and ±3π/4. Populated only on the CQPSK / π4-DQPSK path (the deep
 	// constellation buffer); empty for C4FM and the 2-level paths.
 	DiffPhase []float32 `json:"diff_phase,omitempty" yaml:"diff_phase,omitempty"`
+
+	// SymbolIQ is the recovered complex symbol-decision constellation — the
+	// post-timing-recovery decision points, one per symbol, decimated to the
+	// same cap as the IQ. Unlike DecimatedIQ (the raw channelized stream, which
+	// renders as a diffuse disc), these are the actual demod outputs, so a
+	// π/4-DQPSK control channel renders as discrete decision clusters. It backs
+	// the constellation viz's "Symbols" mode. Populated only on the CQPSK /
+	// π4-DQPSK path (the deep constellation buffer); empty for C4FM and the
+	// 2-level paths, which buffer no complex constellation.
+	SymbolIQ []IQPoint `json:"symbol_iq,omitempty" yaml:"symbol_iq,omitempty"`
 }
 
 // decimateSymbolSeries stride-decimates an aligned dibit + soft stream
@@ -101,6 +111,26 @@ func diffPhaseSeries(constBuf []complex64, maxPoints int) []float32 {
 	out := make([]float32, 0, (len(d)+stride-1)/stride)
 	for i := 0; i < len(d); i += stride {
 		out = append(out, float32(d[i]))
+	}
+	return out
+}
+
+// symbolIQSeries stride-decimates a complex constellation buffer — the
+// recovered per-symbol decision points — to at most maxPoints IQPoints,
+// preserving each point's I/Q. It is the 2-D companion to diffPhaseSeries
+// (same buffer, but the whole complex point instead of the differential
+// phase). Returns nil when the buffer is empty or maxPoints ≤ 0.
+func symbolIQSeries(constBuf []complex64, maxPoints int) []IQPoint {
+	if len(constBuf) == 0 || maxPoints <= 0 {
+		return nil
+	}
+	stride := 1
+	if len(constBuf) > maxPoints {
+		stride = (len(constBuf) + maxPoints - 1) / maxPoints
+	}
+	out := make([]IQPoint, 0, (len(constBuf)+stride-1)/stride)
+	for i := 0; i < len(constBuf); i += stride {
+		out = append(out, IQPoint{I: real(constBuf[i]), Q: imag(constBuf[i])})
 	}
 	return out
 }

--- a/internal/siglab/iqtaps_test.go
+++ b/internal/siglab/iqtaps_test.go
@@ -49,3 +49,42 @@ func TestDiffPhaseSeriesTooShort(t *testing.T) {
 		t.Errorf("diffPhaseSeries(nil) = %v, want nil", got)
 	}
 }
+
+func TestSymbolIQSeriesPreservesPoints(t *testing.T) {
+	// Below the cap, every complex point is passed through unchanged as an
+	// IQPoint — this is the 2-D symbol-decision constellation the viz plots.
+	pts := []complex64{complex(1, 0), complex(0, 1), complex(-1, 0), complex(0, -1)}
+	got := symbolIQSeries(pts, 1000)
+	if len(got) != len(pts) {
+		t.Fatalf("len = %d, want %d", len(got), len(pts))
+	}
+	for i, p := range pts {
+		if got[i].I != real(p) || got[i].Q != imag(p) {
+			t.Errorf("point[%d] = (%v,%v), want (%v,%v)", i, got[i].I, got[i].Q, real(p), imag(p))
+		}
+	}
+}
+
+func TestSymbolIQSeriesDecimationCap(t *testing.T) {
+	pts := make([]complex64, 5000)
+	for i := range pts {
+		pts[i] = complex64(cmplx.Exp(complex(0, 0.3*float64(i))))
+	}
+	const cap = 500
+	got := symbolIQSeries(pts, cap)
+	if len(got) == 0 {
+		t.Fatal("expected a decimated symbol-IQ series")
+	}
+	if len(got) > cap {
+		t.Errorf("symbol-IQ series exceeds cap: %d > %d", len(got), cap)
+	}
+}
+
+func TestSymbolIQSeriesEmpty(t *testing.T) {
+	if got := symbolIQSeries(nil, 100); got != nil {
+		t.Errorf("symbolIQSeries(nil) = %v, want nil", got)
+	}
+	if got := symbolIQSeries([]complex64{complex(1, 0)}, 0); got != nil {
+		t.Errorf("symbolIQSeries(maxPoints=0) = %v, want nil", got)
+	}
+}

--- a/web/siglab/src/api/types.ts
+++ b/web/siglab/src/api/types.ts
@@ -20,6 +20,10 @@ export interface IQTaps {
   // Per-symbol differential phase (radians) of the complex constellation —
   // the π/4-DQPSK rotation signal. Present only on the CQPSK path.
   diff_phase?: number[];
+  // Recovered complex symbol-decision points (the true constellation). Unlike
+  // decimated_iq (the raw disc), these render as discrete decision clusters.
+  // Present only on the CQPSK / π4-DQPSK path.
+  symbol_iq?: IQPoint[];
 }
 
 // PSDResult is the server-computed Welch power spectrum from

--- a/web/siglab/src/panels/Results.tsx
+++ b/web/siglab/src/panels/Results.tsx
@@ -128,7 +128,7 @@ function VizGrid({ r, iq, jobId }: { r: Result; iq?: Result["iq_taps"]; jobId?: 
     <div className="grid gap-4 lg:grid-cols-2">
       {r.signal && <SymbolHistogram signal={r.signal} />}
       {r.signal?.demod && <VSAMetrics demod={r.signal.demod} />}
-      {hasIQ && <Constellation points={iq!.decimated_iq} />}
+      {hasIQ && <Constellation points={iq!.decimated_iq} symbols={iq!.symbol_iq} />}
       {hasIQ && jobId && <PSD jobId={jobId} />}
       {hasIQ && jobId && <Spectrogram jobId={jobId} />}
       {(soft.length > 1 || detail.soft_eye) && (

--- a/web/siglab/src/viz/Constellation.tsx
+++ b/web/siglab/src/viz/Constellation.tsx
@@ -1,25 +1,37 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import * as d3 from "d3";
 import type { IQPoint } from "../api/types";
 
-// Constellation renders the decimated channelized IQ as a 2D scatter using
-// D3. PSK/QPSK shows clusters; C4FM shows four arcs; noise shows a diffuse
-// disc; DC bias shows an offset blob.
-export function Constellation({ points }: { points: IQPoint[] }) {
+// Constellation renders a 2D I/Q scatter using D3. Two modes:
+//   - "raw": the decimated channelized IQ (decimated_iq). PSK/QPSK shows
+//     clusters, C4FM shows four arcs, noise shows a diffuse disc — for
+//     π/4-DQPSK the raw stream is a filled disc because it is sampled off the
+//     symbol instants.
+//   - "symbols": the recovered per-symbol decision points (symbol_iq), which
+//     render as discrete decision clusters (8 for a healthy π/4-DQPSK control
+//     channel). Only available on the CQPSK / π4-DQPSK path.
+// The mode toggle appears only when symbol points are present; it defaults to
+// "symbols" so the cleaner view shows by default when we have it.
+export function Constellation({ points, symbols }: { points: IQPoint[]; symbols?: IQPoint[] }) {
   const ref = useRef<SVGSVGElement | null>(null);
+  const hasSymbols = !!symbols && symbols.length > 0;
+  const [mode, setMode] = useState<"raw" | "symbols">(hasSymbols ? "symbols" : "raw");
+
+  const showSymbols = mode === "symbols" && hasSymbols;
+  const active: IQPoint[] = showSymbols ? symbols! : points;
 
   useEffect(() => {
     const svg = d3.select(ref.current);
     svg.selectAll("*").remove();
-    if (points.length === 0) return;
+    if (active.length === 0) return;
 
     const size = 320;
     const m = 24;
     // Subsample for render performance; the density still reads clearly.
     const max = 6000;
-    const step = Math.max(1, Math.floor(points.length / max));
+    const step = Math.max(1, Math.floor(active.length / max));
     const pts: IQPoint[] = [];
-    for (let i = 0; i < points.length; i += step) pts.push(points[i]);
+    for (let i = 0; i < active.length; i += step) pts.push(active[i]);
 
     const extent = d3.max(pts, (p) => Math.max(Math.abs(p.i), Math.abs(p.q))) ?? 1;
     const scale = d3.scaleLinear().domain([-extent, extent]).range([m, size - m]);
@@ -36,6 +48,11 @@ export function Constellation({ points }: { points: IQPoint[] }) {
       .attr("y1", m).attr("y2", size - m).attr("x1", scale(0)).attr("x2", scale(0))
       .attr("stroke", "rgba(255,255,255,0.12)");
 
+    // Decision points are sparser and want to read as clusters, so draw them a
+    // touch larger and more opaque than the dense raw cloud.
+    const r = showSymbols ? 1.6 : 1.1;
+    const fill = showSymbols ? "rgba(56,189,248,0.7)" : "rgba(56,189,248,0.45)";
+
     svg
       .append("g")
       .selectAll("circle")
@@ -43,16 +60,28 @@ export function Constellation({ points }: { points: IQPoint[] }) {
       .join("circle")
       .attr("cx", (p) => scale(p.i))
       .attr("cy", (p) => scale(-p.q))
-      .attr("r", 1.1)
-      .attr("fill", "rgba(56,189,248,0.45)");
-  }, [points]);
+      .attr("r", r)
+      .attr("fill", fill);
+  }, [active, showSymbols]);
 
   return (
     <div className="card">
-      <h3 className="mb-2 text-sm font-semibold">Constellation (I/Q)</h3>
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <h3 className="text-sm font-semibold">Constellation (I/Q)</h3>
+        {hasSymbols && (
+          <label className="flex items-center gap-1 text-xs text-muted">
+            <input
+              type="checkbox"
+              checked={mode === "symbols"}
+              onChange={(e) => setMode(e.target.checked ? "symbols" : "raw")}
+            />
+            Symbol decisions
+          </label>
+        )}
+      </div>
       <svg ref={ref} className="mx-auto block" />
       <p className="mt-1 text-center text-xs text-muted">
-        {points.length.toLocaleString()} decimated samples
+        {active.length.toLocaleString()} {showSymbols ? "symbol decisions" : "decimated samples"}
       </p>
     </div>
   );

--- a/web/siglab/src/viz/PSD.tsx
+++ b/web/siglab/src/viz/PSD.tsx
@@ -42,6 +42,10 @@ export function PSD({ jobId }: { jobId: string }) {
   const n = psd?.bins.length ?? 0;
   const base = psd ? -psd.sample_rate_hz / 2 : 0;
   const step = psd && n > 0 ? psd.sample_rate_hz / n : 0;
+  // Symmetric baseband span in kHz — the spectrum is centered on DC, so a
+  // linear ±rate/2 axis gives round, symmetric ticks (a "mean" view) instead
+  // of the ragged category-index labels Chart.js would otherwise pick.
+  const halfKHz = psd ? psd.sample_rate_hz / 2 / 1000 : 0;
 
   return (
     <div className="card">
@@ -50,11 +54,12 @@ export function PSD({ jobId }: { jobId: string }) {
       {psd && n > 0 ? (
         <Line
           data={{
-            labels: psd.bins.map((_, i) => ((base + i * step) / 1000).toFixed(1)),
             datasets: [
               {
                 label: "PSD (dBFS)",
-                data: psd.bins,
+                // {x,y} points on a linear kHz axis: x is the bin's baseband
+                // frequency, so the axis is symmetric about DC.
+                data: psd.bins.map((y, i) => ({ x: (base + i * step) / 1000, y })),
                 borderColor: "#38bdf8",
                 pointRadius: 0,
                 borderWidth: 1,
@@ -65,7 +70,13 @@ export function PSD({ jobId }: { jobId: string }) {
             responsive: true,
             plugins: { legend: { display: false } },
             scales: {
-              x: { title: { display: true, text: "kHz" }, ticks: { maxTicksLimit: 12 } },
+              x: {
+                type: "linear",
+                min: -halfKHz,
+                max: halfKHz,
+                title: { display: true, text: "kHz" },
+                ticks: { maxTicksLimit: 13 },
+              },
               y: { title: { display: true, text: "dBFS" } },
             },
           }}


### PR DESCRIPTION
## Summary

Two related observability improvements for TETRA. The live decode path was
nearly silent, and the siglab dashboard's PSD axis and constellation panel were
hard to read. This adds debug-level console telemetry when decoding TETRA and
fixes the two dashboard panels. Pure observability — no decode behaviour change.

## Changes

- **TETRA console debug** (`internal/radio/tetra`, `internal/scanner/ccdecoder`):
  debug-gated decode-health counters on `ControlChannel` (sync bursts, BSCH
  ok/fail, SYSINFO, SCH PDUs, grants) exposed via `DrainStats()`, plus a
  `Locked()` accessor; per-milestone debug lines at the previously-silent points
  (`tetra: sync burst decoded`, `tetra: sysinfo`, `sync burst BSCH decode
  failed`); `Receiver.CarrierOffsetHz()` surfacing the AFC estimate that was
  computed but never reachable; and a throttled `tetra: decode status` line
  (effective baud + deviation, carrier offset, lock state, per-window decode
  counts). Gated on the global `-log-level debug`; zero overhead otherwise.
  Surfaces in both the daemon and `gophertrunk replay`.
- **siglab PSD axis** (`web/siglab/src/viz/PSD.tsx`): the panel rendered on a
  Chart.js category axis and labelled FFT bins by index, so `maxTicksLimit`
  produced ragged, off-centre ticks (`-11.5 / +12.7`). Replaced with a linear
  kHz axis fed `{x,y}` points, symmetric about DC (`min/max = ±sample_rate/2`) —
  round, symmetric ticks.
- **siglab constellation** (`internal/siglab`, `web/siglab`): the panel plotted
  only raw decimated channelized IQ (a filled disc for π/4-DQPSK). Surface the
  recovered complex symbol-decision points already buffered server-side —
  `IQTaps.SymbolIQ` + a `symbolIQSeries` helper (the 2-D companion to the
  existing `diffPhaseSeries`), populated on the CQPSK / π4-DQPSK path and shipped
  over the existing `GET .../iq`. The constellation viz gains a "Symbol
  decisions" toggle (shown only when present, on by default) that renders
  discrete decision clusters instead of the disc. C4FM has no complex
  constellation, so it stays on the raw view.

## Test plan

- [x] `make vet test` is green locally
- [x] `make integration` is green locally (TETRA console-debug commit touches the
      daemon/replay path)
- [x] Added or updated tests where appropriate — TETRA: `DrainStats` counter /
      reset / debug-gating, the milestone debug lines, the effective-baud helper,
      and the throttled status line (injected clock); siglab: `symbolIQSeries`
      decimation-cap / passthrough / empty cases
- [x] Frontend `tsc --noEmit` + `vite build` green (siglab SPA)
- [ ] Smoke-tested against real hardware — n/a: no SDR / USB / vocoder code
      changed; this is decode-side observability and dashboard rendering (a TETRA
      radio capture is en route for a later live check)

## Breaking changes

None. The console output is additive and gated behind `-log-level debug`. The
new `symbol_iq` field on the `/iq` response is additive and `omitempty`.

## Docs / CHANGELOG

- [ ] CHANGELOG — the symmetric PSD axis and constellation "Symbol decisions"
      toggle are user-visible; can add an `## [Unreleased]` bullet on request.
- [ ] README / docs — n/a (no operator-facing config/CLI/endpoint change)

## Linked issues

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015mC2ZV5guQTFf5iuQ9Nctt)_