### PR TITLE
fix(p25p2): descramble MAC in the coded-channel-bit domain (#915)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,21 @@ for tagged releases.
   real Victorian MMR (WACN 0xBEE00) Phase 2 voice capture: 0 superframes before,
   ~430 after. (issue #915; the traffic-channel MAC descramble mapping that keeps
   `mac_rs_valid=0` even on a locked superframe is a separate, still-open blocker.)
+- **P25 Phase 2 MAC descramble moved to the coded-channel-bit domain.** The PN44
+  scrambler (TIA-102.BBAC-1 §7.2.5) wraps the burst "between demodulation and
+  FEC", i.e. over the coded channel bits — but GopherTrunk XORed the recovered
+  144 *information* bits *after* the trellis decode. The trellis code does not
+  commute with the XOR, so a genuinely scrambled burst could never satisfy the
+  outer RS(24,16,9) check regardless of seed — the `mac_rs_valid=0` blocker that
+  suppresses the Phase 2 source RID (and talker alias). The descramble now runs
+  on the raw channel dibits before deinterleave/trellis, at each sub-frame's
+  channel-bit offset into the continuous 4320-bit superframe sequence, matching
+  the reference decoders (SDRtrunk `Timeslot.xor()`, OP25 `handle_packet()`).
+  `ScramblerProbe` self-aligns the slot phase against the RS gate. Regression
+  tests build a channel-scrambled burst from the reporter's confirmed MMR
+  identity (WACN 0xBEE00 / System ID 0x164 / NAC 0x161) and recover the source
+  RID through the full FEC chain; live-air confirmation of the per-slot offset is
+  pending the reporter's `mac_rs_valid` re-pull. (issue #915, Finding B)
 - **TETRA control channels now lock on real air (§8.2.5 scrambler).** The
   scrambling LFSR shifted its register the wrong direction relative to the tap
   convention, so the generated sequence diverged from ETSI EN 300 392-2 §8.2.5

--- a/internal/radio/p25/phase2/control.go
+++ b/internal/radio/p25/phase2/control.go
@@ -377,34 +377,35 @@ func ParseInterleaveMode(s string) (InterleaveMode, bool) {
 //     scrambled, so the config default (ParseScramblerMode) is
 //     ScramblerOn.
 //
-//   - ScramblerOn (config default): the trellis-decoded 144-bit MAC PDU is XORed
-//     with the leading 144 bits of the PN44 scrambling sequence
-//     derived from the configured (WACN_ID, System_ID, Color_Code)
-//     seed before ParseMACPDU runs. SetScramblerSeed must be
-//     called first so the LFSR has a real seed to clock from; a
-//     zero seed maps to (2^44 - 1) per spec, which is unlikely to
-//     produce useful decoding against on-air traffic.
+//   - ScramblerOn (config default): the CODED MAC channel bits are XORed
+//     with the PN44 scrambling sequence — derived from the configured
+//     (WACN_ID, System_ID, NAC) seed — BEFORE deinterleave/trellis, per
+//     TIA-102.BBAC-1 §7.2.5 (the scrambler wraps the burst "between
+//     demodulation and FEC"). SetScramblerSeed must be called first so
+//     the LFSR has a real seed to clock from; a zero seed maps to
+//     (2^44 - 1) per spec, which is unlikely to produce useful decoding
+//     against on-air traffic. Descrambling in the channel domain is the
+//     issue-#915 fix: the pre-fix code XORed the post-trellis info bits,
+//     a domain the trellis code cannot commute with, so RS(24,16,9)
+//     could never converge on a scrambled burst (mac_rs_valid=0).
 //
-//     ScramblerOn descrambles from the per-burst slot offset
-//     installed via SetScramblerOffset (default 0). Operators
-//     with superframe tracking can update the offset before each
-//     burst arrives; operators without superframe tracking should
-//     use ScramblerProbe instead.
+//     ScramblerOn descrambles from the channel-bit offset installed via
+//     SetScramblerOffset (default 0); the superframe-structured path
+//     supplies each sub-frame's slotChannelPN44Offset automatically.
+//     Operators without superframe tracking should use ScramblerProbe.
 //
-//   - ScramblerProbe: the Process adapter walks each of the 12
-//     spec-defined slot offsets in
-//     framing.PN44SlotOffsetsOutbound (Figure 7-5), descrambles
-//     with each, and accepts the first candidate whose outer
-//     RS(24, 16, 9) syndromes are zero. This is the blind-probe
-//     form for receivers without superframe synchronization — it
-//     locks onto any of the 12 slots without external timing
-//     context.
+//   - ScramblerProbe: descrambles the channel bits at each candidate
+//     offset in the continuous 4320-bit superframe sequence and accepts
+//     the first whose outer RS(24, 16, 9) syndromes are zero. This is the
+//     self-aligning form for a receiver whose slot-to-sequence phase is
+//     not yet pinned; the RS gate makes the sweep safe (a wrong offset
+//     satisfies the syndromes with probability ≈2^-48, so garbage is
+//     never accepted).
 //
 //     ScramblerProbe requires RSMode to be RSOn — without RS
-//     verification there is no way to tell which of the 12
-//     descrambled candidates is the true PDU. When RSMode is
-//     RSOff, ScramblerProbe degrades silently to ScramblerOn
-//     behaviour (the leading offset wins).
+//     verification there is no way to tell which descrambled candidate
+//     is the true PDU. When RSMode is RSOff, ScramblerProbe degrades
+//     silently to ScramblerOn behaviour at the configured offset.
 type ScramblerMode uint8
 
 const (

--- a/internal/radio/p25/phase2/encode.go
+++ b/internal/radio/p25/phase2/encode.go
@@ -81,6 +81,32 @@ func EncodeMACSubframe(slotType SlotType, counter uint8, pdu MACPDU, mode Trelli
 	return sub
 }
 
+// EncodeMACSubframeScrambled builds a MAC sub-frame exactly like
+// EncodeMACSubframe and then applies the PN44 channel-bit scrambling that
+// a real P25 Phase 2 downlink carries (TIA-102.BBAC-1 §7.2.5): the coded
+// MAC channel bits are XORed with the superframe scrambling sequence at
+// the sub-frame's channel-bit offset (slotChannelPN44Offset). It is the
+// transmit-side inverse of the ScramblerOn descramble in
+// decodeMACPDUDibits, and exists so tests can build a realistically
+// scrambled burst without a real over-the-air capture (issue #915).
+//
+// slotIndex is the sub-frame's 0..11 position within the superframe; seed
+// is the 44-bit PN44 seed (framing.PN44SeedFromIdentity). Only the MAC
+// payload region is scrambled — the ISCH is outside the scrambled window.
+func EncodeMACSubframeScrambled(slotType SlotType, counter uint8, pdu MACPDU, mode TrellisMode, interleave InterleaveMode, slotIndex int, seed uint64) []uint8 {
+	sub := EncodeMACSubframe(slotType, counter, pdu, mode, interleave)
+	macLen := macPDUDibits
+	if mode == TrellisOn {
+		macLen = macPDUDibitsTrellis
+	}
+	region := sub[MACPayloadOffset : MACPayloadOffset+macLen]
+	bits := framing.DibitsToBits(region)
+	// XOR is symmetric, so the descramble primitive scrambles too.
+	descrambleAtOffset(bits, seed, slotChannelPN44Offset(slotIndex))
+	copy(region, framing.BitsToDibits(bits))
+	return sub
+}
+
 // EncodeMACPDURS returns pdu with the outer RS(24, 16, 9) parity
 // (TIA-102.BAAA-A §5.9) filled in, so the assembled 18-byte MAC PDU
 // verifies under verifyMACPDURS. Real over-the-air MAC PDUs always

--- a/internal/radio/p25/phase2/mac_descramble_channel_test.go
+++ b/internal/radio/p25/phase2/mac_descramble_channel_test.go
@@ -1,0 +1,135 @@
+package phase2
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
+
+// TestMACDescrambleChannelDomain is the issue-#915 "Finding B" regression:
+// P25 Phase 2 PN44 scrambling (TIA-102.BBAC-1 §7.2.5) wraps the CODED channel
+// bits between demodulation and FEC, so the descramble must run on the raw
+// channel dibits BEFORE the trellis/deinterleave — not on the 144 information
+// bits recovered AFTER the trellis, the way GopherTrunk did before this fix.
+// The trellis code does not commute with the XOR, so descrambling in the info
+// domain can never satisfy the outer RS(24,16,9) check on a genuinely
+// scrambled burst: real Victorian MMR (WACN 0xBEE00) Phase 2 traffic decoded
+// with mac_rs_valid=0 for every seed, which is exactly what this test pins.
+//
+// The fixture is built with the reporter's confirmed MMR identity (WACN
+// 0xBEE00, System ID 0x164, NAC 0x161) and a channel-scrambled TrellisOn MAC
+// sub-frame carrying a GROUP_VOICE_CHANNEL_USER with a known source RID.
+//
+// This is a synthetic round-trip (GopherTrunk is receive-only, and the
+// reporter's raw IQ capture is not reachable from CI): it proves the
+// descramble DOMAIN is correct and self-consistent with the transmit side.
+// The exact per-slot channel offset onto real air is confirmed separately by
+// the reporter's live mac_rs_valid metric.
+func TestMACDescrambleChannelDomain(t *testing.T) {
+	const (
+		wacn    = 0xBEE00
+		sysID   = 0x164
+		nac     = 0x161
+		slot    = 0
+		wantSrc = 0x00ABCD
+		wantTG  = 32202 // TG 32202 / "NE DISP 2", the reporter's capture channel.
+	)
+	seed := framing.PN44SeedFromIdentity(wacn, sysID, nac)
+	offset := slotChannelPN44Offset(slot)
+
+	user := GroupVoiceChannelUser{ServiceOptions: 0x40, GroupAddress: wantTG, SourceID: wantSrc}
+	pdu := EncodeMACPDURS(EncodeGroupVoiceChannelUser(user, false))
+
+	// A realistically channel-scrambled MAC sub-frame, then the exact 146-dibit
+	// channel window the decoder lifts out of it.
+	sub := EncodeMACSubframeScrambled(SlotTypeMACSignaling, uint8(slot), pdu,
+		TrellisOn, InterleaveOff, slot, seed)
+	macDibits := sub[MACPayloadOffset : MACPayloadOffset+macPDUDibitsTrellis]
+
+	// 1. The fix: channel-domain descramble recovers the PDU and passes RS.
+	got, ok := decodeMACPDUDibits(macDibits, TrellisOn, RSOn, InterleaveOff,
+		ScramblerOn, seed, offset)
+	if !ok {
+		t.Fatal("channel-domain descramble failed to decode the scrambled MAC PDU")
+	}
+	u, ok := got.AsGroupVoiceChannelUser()
+	if !ok || u.SourceID != wantSrc {
+		t.Fatalf("recovered PDU = %+v ok=%v, want SourceID=%#x", u, ok, wantSrc)
+	}
+
+	// 2. The fixture really is scrambled: decoding with the scrambler off does
+	// not satisfy RS, so passing in step 1 means the descramble did the work.
+	if _, ok := decodeMACPDUDibits(macDibits, TrellisOn, RSOn, InterleaveOff,
+		ScramblerOff, seed, offset); ok {
+		t.Fatal("scrambled burst decoded with the scrambler OFF; fixture is not actually scrambled")
+	}
+
+	// 3. Domain guard (the regression itself): replicate the pre-#915 path —
+	// trellis-decode first, then descramble the INFO bits — and confirm it can
+	// NOT recover the PDU. This is the mac_rs_valid=0 failure the fix corrects;
+	// if a future change moved the descramble back after the trellis, this
+	// assertion would fail.
+	infoDibits, _ := framing.DecodeP25Trellis(macDibits)
+	infoBits := framing.DibitsToBits(infoDibits)
+	descrambleAtOffset(infoBits, seed, offset)
+	if info := framing.PackBitsMSB(infoBits); len(info) >= 18 && verifyMACPDURS(info[:18]) {
+		t.Fatal("info-domain (post-trellis) descramble unexpectedly passed RS; the domain fix is untested")
+	}
+
+	// 4. A wrong seed must not spuriously validate.
+	if _, ok := decodeMACPDUDibits(macDibits, TrellisOn, RSOn, InterleaveOff,
+		ScramblerOn, seed^0xFFF, offset); ok {
+		t.Fatal("channel-domain descramble validated under the wrong seed")
+	}
+
+	// 5. ScramblerProbe self-aligns: handed offset 0, the RS-gated sweep finds
+	// the true channel phase on its own — the path a receiver uses when its
+	// slot-to-sequence offset is not yet pinned.
+	probed, ok := decodeMACPDUDibits(macDibits, TrellisOn, RSOn, InterleaveOff,
+		ScramblerProbe, seed, 0)
+	if !ok {
+		t.Fatal("ScramblerProbe failed to self-align to the channel offset")
+	}
+	if pu, ok := probed.AsGroupVoiceChannelUser(); !ok || pu.SourceID != wantSrc {
+		t.Fatalf("probe recovered wrong PDU: %+v ok=%v, want SourceID=%#x", pu, ok, wantSrc)
+	}
+}
+
+// TestDecodeSuperframeMACPDUsChannelScrambled drives the whole
+// superframe-structured path (slice → ISCH slot-type → channel descramble →
+// FEC → RS) over a scrambled superframe, confirming the ControlChannel's own
+// MACDecodeConfig (ScramblerOn + identity seed) recovers a source RID from a
+// channel-scrambled MAC sub-frame end to end (issue #915).
+func TestDecodeSuperframeMACPDUsChannelScrambled(t *testing.T) {
+	const (
+		wacn    = 0xBEE00
+		sysID   = 0x164
+		nac     = 0x161
+		wantSrc = 315203
+	)
+	seed := framing.PN44SeedFromIdentity(wacn, sysID, nac)
+	user := GroupVoiceChannelUser{ServiceOptions: 0x40, GroupAddress: 0x4EEA, SourceID: wantSrc}
+	pdu := EncodeMACPDURS(EncodeGroupVoiceChannelUser(user, false))
+
+	var subs [SubframesPerSuperframe][]uint8
+	for i := range subs {
+		if i == 0 {
+			subs[i] = EncodeMACSubframeScrambled(SlotTypeMACSignaling, uint8(i), pdu,
+				TrellisOn, InterleaveOff, i, seed)
+		} else {
+			subs[i] = EncodeVoiceSubframe(SlotTypeVoice4V, uint8(i), voicePayloads(Voice4VFrameCount))
+		}
+	}
+	cfg := MACDecodeConfig{Trellis: TrellisOn, Scrambler: ScramblerOn, Seed: seed}
+	got := DecodeSuperframeMACPDUsWithSlot(decodeOneSuperframe(t, subs), cfg)
+	if len(got) != 1 {
+		t.Fatalf("DecodeSuperframeMACPDUsWithSlot returned %d PDUs, want 1", len(got))
+	}
+	if !got[0].RSValid {
+		t.Error("channel-scrambled source PDU decoded with RSValid=false")
+	}
+	u, ok := got[0].PDU.AsGroupVoiceChannelUser()
+	if !ok || u.SourceID != wantSrc {
+		t.Errorf("recovered PDU = %+v ok=%v, want SourceID=%d", u, ok, wantSrc)
+	}
+}

--- a/internal/radio/p25/phase2/process.go
+++ b/internal/radio/p25/phase2/process.go
@@ -135,26 +135,77 @@ func (c *ControlChannel) tryIngestMACPDU(macDibits []uint8, mode TrellisMode, rs
 //     dibits + 1 finisher transition. DecodeP25Trellis recovers
 //     the 72 information dibits.
 //
-// When interleaveMode is InterleaveOn the per-burst block
-// interleaver (TIA-102.BBAC) is undone before trellis decoding.
+// Pipeline order (issue #915). Per TIA-102.BBAC-1 §7.2.5 the PN44
+// scrambler wraps the CODED channel bits "between demodulation and
+// FEC", so the descramble runs FIRST — on the raw channel dibits —
+// and only then does the FEC chain (deinterleave, then trellis) run.
+// This matches the reference decoders (SDRtrunk's Timeslot.xor() and
+// OP25's handle_packet() both XOR the mask over the coded burst before
+// deinterleave/trellis/RS). GopherTrunk previously descrambled the
+// recovered 144 INFORMATION bits AFTER the trellis; because the trellis
+// code does not commute with the XOR, that domain can never satisfy the
+// outer RS(24, 16, 9) check on a genuinely scrambled burst, which is
+// why real Phase 2 traffic decoded with mac_rs_valid = 0 regardless of
+// seed (issue #915, Finding B).
 //
-// When scramblerMode is ScramblerOn the recovered 144 info bits
-// are XORed with 144 bits of the PN44 sequence starting at
-// scramblerOffset (per TIA-102.BBAC-1 §7.2.5) before RS check or
-// MAC parse runs.
+// When scramblerMode is ScramblerOn the channel bits are XORed with the
+// PN44 sequence starting at scramblerOffset — the caller passes the
+// slot's channel-bit offset into the continuous 4320-bit superframe
+// sequence (slotChannelPN44Offset); the sequence runs continuously
+// across the 360 ms superframe rather than restarting per burst.
 //
-// When scramblerMode is ScramblerProbe each of the 12 spec-defined
-// slot offsets in framing.PN44SlotOffsetsOutbound (Figure 7-5) is
-// tried and the first candidate whose outer RS(24, 16, 9) syndromes
-// are zero is accepted — the blind-probe form for receivers without
-// superframe synchronization. ScramblerProbe requires rsMode == RSOn;
-// otherwise it degrades to ScramblerOn behaviour at scramblerOffset.
+// When scramblerMode is ScramblerProbe each of the 12 slot channel-bit
+// phases (slotChannelPN44Offset) is tried and the first candidate whose
+// outer RS(24, 16, 9) syndromes are zero is accepted — the self-aligning
+// form for a receiver without superframe synchronization, where the
+// sub-frame's slot within the superframe (hence its phase into the
+// continuous 4320-bit sequence) is not yet pinned. The RS gate makes the
+// sweep safe: a wrong offset packs into random bytes that satisfy the
+// 8-parity-symbol syndrome with probability ≈2^-48, so the sweep never
+// accepts garbage. ScramblerProbe requires rsMode == RSOn; otherwise it
+// degrades to ScramblerOn at scramblerOffset.
 //
-// When rsMode is RSOn the (post-descramble) 18-byte MAC PDU is
-// re-grouped into 24 hex symbols and verified against the
-// RS(24, 16, 9) outer code per TIA-102.BAAA-A §5.9; PDUs whose
-// syndromes are non-zero are rejected.
+// When rsMode is RSOn the (descrambled, FEC-decoded) 18-byte MAC PDU is
+// re-grouped into 24 hex symbols and verified against the RS(24, 16, 9)
+// outer code per TIA-102.BAAA-A §5.9; PDUs whose syndromes are non-zero
+// are rejected.
 func decodeMACPDUDibits(macDibits []uint8, mode TrellisMode, rsMode RSMode, interleaveMode InterleaveMode, scramblerMode ScramblerMode, scramblerSeed uint64, scramblerOffset int) (MACPDU, bool) {
+	switch scramblerMode {
+	case ScramblerProbe:
+		if rsMode != RSOn {
+			// Without the RS gate there is no way to tell a correct
+			// offset from a wrong one, so fall back to the fixed offset.
+			return descrambleChannelAndParse(macDibits, mode, interleaveMode, rsMode, scramblerSeed, scramblerOffset)
+		}
+		for slot := 0; slot < SubframesPerSuperframe; slot++ {
+			off := slotChannelPN44Offset(slot)
+			if pdu, ok := descrambleChannelAndParse(macDibits, mode, interleaveMode, RSOn, scramblerSeed, off); ok {
+				return pdu, true
+			}
+		}
+		return MACPDU{}, false
+	case ScramblerOn:
+		return descrambleChannelAndParse(macDibits, mode, interleaveMode, rsMode, scramblerSeed, scramblerOffset)
+	default: // ScramblerOff
+		return decodeMACChannelAndParse(macDibits, mode, interleaveMode, rsMode)
+	}
+}
+
+// descrambleChannelAndParse XOR-descrambles the coded channel bits of
+// macDibits at channelOffset (per TIA-102.BBAC-1 §7.2.5 — the scrambler
+// domain is the channel bits, not the post-FEC info bits) and then runs
+// the FEC + parse chain over the descrambled burst. The input slice is
+// left untouched.
+func descrambleChannelAndParse(macDibits []uint8, mode TrellisMode, interleaveMode InterleaveMode, rsMode RSMode, seed uint64, channelOffset int) (MACPDU, bool) {
+	bits := framing.DibitsToBits(macDibits)
+	descrambleAtOffset(bits, seed, channelOffset)
+	return decodeMACChannelAndParse(framing.BitsToDibits(bits), mode, interleaveMode, rsMode)
+}
+
+// decodeMACChannelAndParse runs the FEC chain (deinterleave, then
+// trellis) over channel dibits, re-groups the recovered 144 information
+// bits into the 18-byte MAC PDU, optionally RS-verifies, and parses.
+func decodeMACChannelAndParse(macDibits []uint8, mode TrellisMode, interleaveMode InterleaveMode, rsMode RSMode) (MACPDU, bool) {
 	// Undo the per-burst block interleaver before trellis decoding,
 	// when enabled. DeinterleaveMACBurst returns a fresh slice so the
 	// caller's buffer is untouched.
@@ -178,48 +229,7 @@ func decodeMACPDUDibits(macDibits []uint8, mode TrellisMode, rsMode RSMode, inte
 		}
 		infoDibits = macDibits
 	}
-	rawBits := framing.DibitsToBits(infoDibits)
-
-	switch scramblerMode {
-	case ScramblerProbe:
-		if rsMode != RSOn {
-			return descrambleAndParse(rawBits, scramblerSeed, scramblerOffset, rsMode)
-		}
-		for _, off := range framing.PN44SlotOffsetsOutbound {
-			candidate := append([]byte(nil), rawBits...)
-			descrambleAtOffset(candidate, scramblerSeed, off)
-			info := framing.PackBitsMSB(candidate)
-			if len(info) < 18 || !verifyMACPDURS(info[:18]) {
-				continue
-			}
-			if pdu, err := ParseMACPDU(info[:18]); err == nil {
-				return pdu, true
-			}
-			return MACPDU{}, false
-		}
-		return MACPDU{}, false
-	case ScramblerOn:
-		return descrambleAndParse(rawBits, scramblerSeed, scramblerOffset, rsMode)
-	default:
-		info := framing.PackBitsMSB(rawBits)
-		if len(info) < 18 {
-			return MACPDU{}, false
-		}
-		if rsMode == RSOn && !verifyMACPDURS(info[:18]) {
-			return MACPDU{}, false
-		}
-		if pdu, err := ParseMACPDU(info[:18]); err == nil {
-			return pdu, true
-		}
-		return MACPDU{}, false
-	}
-}
-
-// descrambleAndParse descrambles bits in-place at the supplied offset,
-// RS-verifies (when rsMode == RSOn), and returns the parsed PDU.
-func descrambleAndParse(bits []byte, seed uint64, offset int, rsMode RSMode) (MACPDU, bool) {
-	descrambleAtOffset(bits, seed, offset)
-	info := framing.PackBitsMSB(bits)
+	info := framing.PackBitsMSB(framing.DibitsToBits(infoDibits))
 	if len(info) < 18 {
 		return MACPDU{}, false
 	}
@@ -232,15 +242,20 @@ func descrambleAndParse(bits []byte, seed uint64, offset int, rsMode RSMode) (MA
 	return MACPDU{}, false
 }
 
+// pn44SuperframeBits is the length in channel bits of one 360 ms P25
+// Phase 2 superframe (12 sub-frames × 180 dibits × 2 bits) — the period
+// of the PN44 scrambling sequence per TIA-102.BBAC-1 §7.2.5. Channel-bit
+// offsets fold into this period.
+const pn44SuperframeBits = DibitsPerSuperframe * 2
+
 // descrambleAtOffset XOR-descrambles bits in-place with the PN44
 // sequence starting at offset (folded into the 4320-bit
 // superframe period).
 func descrambleAtOffset(bits []byte, seed uint64, offset int) {
 	s := framing.NewPN44Scrambler(seed)
-	const superframeBits = 4320
-	offset = offset % superframeBits
+	offset = offset % pn44SuperframeBits
 	if offset < 0 {
-		offset += superframeBits
+		offset += pn44SuperframeBits
 	}
 	if offset > 0 {
 		s.Advance(offset)

--- a/internal/radio/p25/phase2/process_scrambler_test.go
+++ b/internal/radio/p25/phase2/process_scrambler_test.go
@@ -187,7 +187,10 @@ func TestProcessDescramblerProbeFindsOffset(t *testing.T) {
 		slotIndex  = 5
 		opGrpGrant = byte(0x40)
 	)
-	offset := framing.PN44SlotOffsetsOutbound[slotIndex]
+	// Channel-domain descramble (issue #915): the probe sweeps each slot's
+	// channel-bit offset (slotChannelPN44Offset), so the fixture is scrambled
+	// at that same offset rather than the bare slot-start offset.
+	offset := slotChannelPN44Offset(slotIndex)
 
 	// Build a MAC PDU whose first 16 hex symbols (96 bits = 12
 	// bytes) carry the payload, then RS-encode to fill the trailing
@@ -271,7 +274,10 @@ func TestProcessDescramblerProbeRejectsWrongSeed(t *testing.T) {
 		differentSeed = uint64(0x1234567890A)
 		slotIndex     = 3
 	)
-	offset := framing.PN44SlotOffsetsOutbound[slotIndex]
+	// Channel-domain descramble (issue #915): the probe sweeps each slot's
+	// channel-bit offset (slotChannelPN44Offset), so the fixture is scrambled
+	// at that same offset rather than the bare slot-start offset.
+	offset := slotChannelPN44Offset(slotIndex)
 
 	// Build any RS-encoded MAC PDU.
 	var info [16]byte

--- a/internal/radio/p25/phase2/superframe_ingest.go
+++ b/internal/radio/p25/phase2/superframe_ingest.go
@@ -1,7 +1,5 @@
 package phase2
 
-import "github.com/MattCheramie/GopherTrunk/internal/radio/framing"
-
 // MACPayloadOffset is the dibit offset of the MAC PDU within a
 // 180-dibit sub-frame: it follows the SyncDibits-wide region and the
 // ISCH, sharing the same start as a voice sub-frame's first voice
@@ -55,9 +53,10 @@ type DecodedMACPDU struct {
 // DecodeSuperframeMACPDUs; callers that route on the PTT slot
 // (encryption sync) use this one.
 //
-// The PN44 descrambler is handed the spec's per-slot offset
-// (slotPN44Offset) because superframe sync pins which of the 12 TDMA
-// slots each sub-frame occupies.
+// The PN44 descrambler is handed the sub-frame's channel-bit offset
+// (slotChannelPN44Offset) because superframe sync pins which of the 12
+// TDMA slots each sub-frame occupies, and the descramble runs on the
+// coded channel bits before FEC (issue #915).
 func DecodeSuperframeMACPDUsWithSlot(sf Superframe, cfg MACDecodeConfig) []DecodedMACPDU {
 	macLen := macPDUDibits
 	if cfg.Trellis == TrellisOn {
@@ -72,7 +71,7 @@ func DecodeSuperframeMACPDUsWithSlot(sf Superframe, cfg MACDecodeConfig) []Decod
 			continue
 		}
 		macDibits := sub.Dibits[MACPayloadOffset : MACPayloadOffset+macLen]
-		offset := slotPN44Offset(sub.Index)
+		offset := slotChannelPN44Offset(sub.Index)
 		if pdu, ok := decodeMACPDUDibits(macDibits, cfg.Trellis, cfg.RS,
 			cfg.Interleave, cfg.Scrambler, cfg.Seed, offset); ok {
 			out = append(out, DecodedMACPDU{
@@ -129,14 +128,24 @@ func (c *ControlChannel) IngestSuperframe(sf Superframe) {
 	}
 }
 
-// slotPN44Offset returns the PN44 sequence offset for sub-frame index
-// (0..11) — the spec-defined per-slot offset, known here because
-// superframe sync pins which slot a sub-frame occupies. Out-of-range
-// indices fall back to offset 0.
-func slotPN44Offset(index int) int {
-	offs := framing.PN44SlotOffsetsOutbound
-	if index < 0 || index >= len(offs) {
+// slotChannelPN44Offset returns the PN44 sequence offset, in CHANNEL
+// bits, at which sub-frame index's MAC payload begins within the
+// continuous 4320-bit superframe scrambling sequence (TIA-102.BBAC-1
+// §7.2.5). Because the descramble is applied to the coded channel bits
+// before FEC (issue #915), the offset is the absolute channel-bit
+// position of the MAC payload: the sub-frame's start in the superframe
+// (index × DibitsPerSubframe × 2 bits) plus the MAC payload's offset
+// within the sub-frame (MACPayloadOffset × 2 bits), which follows the
+// sync + ISCH region.
+//
+// GopherTrunk's superframe grid (sync width, ISCH placement) is a
+// documented working assumption, so this offset is the principled
+// default for ScramblerOn; ScramblerProbe confirms the true phase
+// against the RS gate rather than trusting it. Out-of-range indices
+// fall back to offset 0.
+func slotChannelPN44Offset(index int) int {
+	if index < 0 || index >= SubframesPerSuperframe {
 		return 0
 	}
-	return offs[index]
+	return (index*DibitsPerSubframe + MACPayloadOffset) * 2
 }


### PR DESCRIPTION
## Summary

GopherTrunk's P25 Phase 2 MAC descramble ran in the wrong bit domain — it XORed the recovered 144 *information* bits *after* the trellis decode. Per TIA-102.BBAC-1 §7.2.5 (and the reference decoders SDRtrunk/OP25, which hit ~100% source coverage on this same air) the PN44 scrambler wraps the **coded channel bits between demodulation and FEC**. Because the trellis code does not commute with the XOR, no seed could ever make a genuinely scrambled burst pass the outer RS(24,16,9) check — the `mac_rs_valid=0` blocker that suppresses the Phase 2 source RID and talker alias (issue #915, "Finding B").

_(The #935 demod-mode doc correction that briefly shared this branch now lives in its own PR #958; this PR is #915-only again.)_

## Changes

- **Descramble in the channel-bit domain.** `decodeMACPDUDibits` now XOR-descrambles the raw channel dibits *before* deinterleave/trellis, at each sub-frame's channel-bit offset into the continuous 4320-bit superframe sequence (`slotChannelPN44Offset` = `slot·360 + MACPayloadOffset·2`). Previously it descrambled the post-trellis info bits.
- **Self-aligning probe.** `ScramblerProbe` sweeps the 12 slot channel-bit phases, RS-gated — a receiver whose slot→sequence phase isn't pinned self-aligns. A wrong offset satisfies the RS syndromes with probability ≈2⁻⁴⁸, so the sweep never accepts garbage.
- Refactored `decodeMACPDUDibits` into `descrambleChannelAndParse` + `decodeMACChannelAndParse`; added `EncodeMACSubframeScrambled` transmit-side scaffolding for tests.
- Corrected the now-stale scrambler docs in `control.go` / `process.go` / `superframe_ingest.go`, and added a CHANGELOG entry.

## Test plan

- New `mac_descramble_channel_test.go`:
  - Builds a channel-scrambled TrellisOn MAC sub-frame from the reporter's confirmed MMR identity (WACN `0xBEE00` / System ID `0x164` / NAC `0x161`) and recovers the source RID through the full FEC chain with `RSValid=true`.
  - A domain-guard assertion replicates the old post-trellis descramble and confirms it fails RS — the failing-first proof that the domain is the fix.
  - End-to-end recovery through `DecodeSuperframeMACPDUsWithSlot`, plus wrong-seed rejection and `ScramblerProbe` self-alignment.
- [x] `make vet test` is green locally
- [ ] `make integration` — n/a (no daemon/replay change)
- [x] Added tests
- [ ] **Not** smoke-tested against the reporter's raw IQ capture: it is hosted on a host this build environment's network policy blocks, so the per-slot channel offset onto real air is confirmed by the reporter's live `mac_rs_valid` re-pull — the same way every prior PR on this issue was verified. `scrambler=probe` sweeps the slot phases if the fixed offset needs a small adjustment.

## Breaking changes

None. The live default is already `ScramblerOn`; this only corrects the *domain* of an already-active (but ineffective) descramble. Existing synthetic fixtures decode unchanged.

## Docs / CHANGELOG

- [x] Added a `## [Unreleased]` → `### Fixed` bullet to `CHANGELOG.md`
- [ ] README/docs — n/a

## Linked issues

Refs #915

🤖 Generated with [Claude Code](https://claude.com/claude-code)