### PR TITLE
feat(tetra): ACELP decoder foundation — fixed-point basic operators

### DIFF
--- a/internal/voice/acelp/ops.go
+++ b/internal/voice/acelp/ops.go
@@ -1,0 +1,275 @@
+// Package acelp is a Go port of the ETSI EN 300 395-2 TETRA ACELP speech
+// decoder — the codec that turns TCH/S-decoded 137-bit speech frames into
+// 8 kHz PCM, the final stage of TETRA voice.
+//
+// PROVENANCE / LICENSING: this port derives from the ETSI reference codec
+// (fixed-point ANSI C), obtained via github.com/curlyboi/libtetradec. The ETSI
+// reference implementation is copyrighted by ETSI and distributed under ETSI's
+// terms; the codec is also historically patent-encumbered (algebraic CELP,
+// though the core patents are largely expired). Before shipping enabled by
+// default, confirm the intended posture in docs/vocoders.md. This is why the
+// decoder lives in its own package behind an explicit vocoder registration.
+package acelp
+
+// Fixed-point basic operators — a faithful port of the ITU-T G.191 STL / ETSI
+// TETRA reference tetra_op.c. Bit-exact 16/32-bit saturating arithmetic; every
+// higher-level codec block is built from these, so their exact overflow and
+// rounding behaviour is what makes the decoder bit-exact.
+
+const (
+	maxWord16 = int16(0x7fff)      // 32767
+	minWord16 = int16(-0x8000)     // -32768
+	maxWord32 = int32(0x7fffffff)  //  2147483647
+	minWord32 = int32(-0x80000000) // -2147483648
+)
+
+// overflow / carry mirror the reference codec's global flags. A few blocks read
+// overflow after a shift/normalise; carry is retained for completeness.
+var overflow, carry bool
+
+// sature clamps a 32-bit value into the 16-bit range, setting overflow.
+func sature(l int32) int16 {
+	switch {
+	case l > int32(maxWord16):
+		overflow = true
+		return maxWord16
+	case l < int32(minWord16):
+		overflow = true
+		return minWord16
+	default:
+		overflow = false
+		return int16(l)
+	}
+}
+
+func absS(v int16) int16 {
+	if v == minWord16 {
+		return maxWord16
+	}
+	if v < 0 {
+		return -v
+	}
+	return v
+}
+
+func addOp(a, b int16) int16 { return sature(int32(a) + int32(b)) }
+func subOp(a, b int16) int16 { return sature(int32(a) - int32(b)) }
+
+func negate(v int16) int16 {
+	if v == minWord16 {
+		return maxWord16
+	}
+	return -v
+}
+
+func extractH(l int32) int16 { return int16(l >> 16) }
+func extractL(l int32) int16 { return int16(l) } // low 16 bits
+
+// etsiRound rounds a 32-bit accumulator to the 16 MSBs.
+func etsiRound(l int32) int16 { return extractH(lAdd(l, 0x00008000)) }
+
+func mult(a, b int16) int16 {
+	p := (int32(a) * int32(b)) & int32(-0x8000) >> 15 // (a*b & 0xffff8000) >> 15
+	if p&0x00010000 != 0 {
+		p |= int32(-0x10000) // sign extend (0xffff0000)
+	}
+	return sature(p)
+}
+
+func multR(a, b int16) int16 {
+	p := int32(a)*int32(b) + 0x00004000
+	p = (p & int32(-0x8000)) >> 15
+	if p&0x00010000 != 0 {
+		p |= int32(-0x10000)
+	}
+	return sature(p)
+}
+
+func lMult(a, b int16) int32 {
+	l := int32(a) * int32(b)
+	if l != 0x40000000 {
+		return l * 2
+	}
+	overflow = true
+	return maxWord32
+}
+
+func lAdd(a, b int32) int32 {
+	out := a + b
+	if (a^b)&minWord32 == 0 && (out^a)&minWord32 != 0 {
+		overflow = true
+		if a < 0 {
+			return minWord32
+		}
+		return maxWord32
+	}
+	return out
+}
+
+func lSub(a, b int32) int32 {
+	out := a - b
+	if (a^b)&minWord32 != 0 && (out^a)&minWord32 != 0 {
+		overflow = true
+		if a < 0 {
+			return minWord32
+		}
+		return maxWord32
+	}
+	return out
+}
+
+func lMac(acc int32, a, b int16) int32 { return lAdd(acc, lMult(a, b)) }
+func lMsu(acc int32, a, b int16) int32 { return lSub(acc, lMult(a, b)) }
+
+func lNegate(l int32) int32 {
+	if l == minWord32 {
+		return maxWord32
+	}
+	return -l
+}
+
+func lAbs(l int32) int32 {
+	if l == minWord32 {
+		return maxWord32
+	}
+	if l < 0 {
+		return -l
+	}
+	return l
+}
+
+func lDepositH(v int16) int32 { return int32(v) << 16 }
+func lDepositL(v int16) int32 { return int32(v) }
+
+func shl(v, n int16) int16 {
+	if n < 0 {
+		return shr(v, -n)
+	}
+	l := int32(v) << uint(n)
+	if l != int32(int16(l)) {
+		overflow = true
+		if v > 0 {
+			return maxWord16
+		}
+		return minWord16
+	}
+	return int16(l)
+}
+
+func shr(v, n int16) int16 {
+	if n < 0 {
+		return shl(v, -n)
+	}
+	if n >= 15 {
+		if v < 0 {
+			return -1
+		}
+		return 0
+	}
+	if v < 0 {
+		return ^((^v) >> uint(n))
+	}
+	return v >> uint(n)
+}
+
+func lShl(l int32, n int16) int32 {
+	if n < 0 {
+		return lShr(l, -n)
+	}
+	for ; n > 0; n-- {
+		if l > 0x3fffffff {
+			overflow = true
+			return maxWord32
+		}
+		if l < int32(-0x40000000) {
+			overflow = true
+			return minWord32
+		}
+		l *= 2
+	}
+	return l
+}
+
+func lShr(l int32, n int16) int32 {
+	if n < 0 {
+		return lShl(l, -n)
+	}
+	if n >= 31 {
+		if l < 0 {
+			return -1
+		}
+		return 0
+	}
+	if l < 0 {
+		return ^((^l) >> uint(n))
+	}
+	return l >> uint(n)
+}
+
+// lShrR is lShr with rounding of the last shifted-out bit.
+func lShrR(l int32, n int16) int32 {
+	if n > 31 {
+		return 0
+	}
+	out := lShr(l, n)
+	if n > 0 && (lShr(l, n-1)&1) != 0 {
+		out = lAdd(out, 1)
+	}
+	return out
+}
+
+func normS(v int16) int16 {
+	if v == 0 {
+		return 0
+	}
+	if v == -1 {
+		return 15
+	}
+	if v < 0 {
+		v = ^v
+	}
+	var n int16
+	for ; v < 0x4000; n++ {
+		v <<= 1
+	}
+	return n
+}
+
+func normL(l int32) int16 {
+	if l == 0 {
+		return 0
+	}
+	if l == -1 {
+		return 31
+	}
+	if l < 0 {
+		l = ^l
+	}
+	var n int16
+	for ; l < 0x40000000; n++ {
+		l <<= 1
+	}
+	return n
+}
+
+// divS is the fractional integer division var1/var2 (Q15), 0 <= var1 <= var2.
+func divS(a, b int16) int16 {
+	if a == 0 {
+		return 0
+	}
+	if a == b {
+		return maxWord16
+	}
+	num := lDepositL(a)
+	den := lDepositL(b)
+	var out int16
+	for i := 0; i < 15; i++ {
+		out <<= 1
+		num <<= 1
+		if num >= den {
+			num = lSub(num, den)
+			out = addOp(out, 1)
+		}
+	}
+	return out
+}

--- a/internal/voice/acelp/ops_test.go
+++ b/internal/voice/acelp/ops_test.go
@@ -1,0 +1,92 @@
+package acelp
+
+import "testing"
+
+// TestBasicOperators checks the documented edge cases of the fixed-point
+// operators (from the ETSI/ITU-T definitions) that make the decoder bit-exact.
+func TestBasicOperators(t *testing.T) {
+	if absS(minWord16) != maxWord16 {
+		t.Errorf("absS(-32768) = %d, want 32767", absS(minWord16))
+	}
+	if addOp(maxWord16, 1) != maxWord16 {
+		t.Errorf("addOp saturate high failed")
+	}
+	if addOp(minWord16, -1) != minWord16 {
+		t.Errorf("addOp saturate low failed")
+	}
+	if subOp(minWord16, 1) != minWord16 {
+		t.Errorf("subOp saturate low failed")
+	}
+	if negate(minWord16) != maxWord16 {
+		t.Errorf("negate(-32768) = %d, want 32767", negate(minWord16))
+	}
+	if mult(minWord16, minWord16) != maxWord16 {
+		t.Errorf("mult(-32768,-32768) = %d, want 32767", mult(minWord16, minWord16))
+	}
+	if multR(minWord16, minWord16) != maxWord16 {
+		t.Errorf("multR(-32768,-32768) = %d, want 32767", multR(minWord16, minWord16))
+	}
+	if got := mult(16384, 16384); got != 8192 { // 0.5 * 0.5 = 0.25 in Q15
+		t.Errorf("mult(16384,16384) = %d, want 8192", got)
+	}
+	if lMult(minWord16, minWord16) != maxWord32 {
+		t.Errorf("lMult(-32768,-32768) = %d, want MAX_32", lMult(minWord16, minWord16))
+	}
+	if got := lMult(16384, 16384); got != 0x20000000 { // (0.5*0.5)<<1 in Q31
+		t.Errorf("lMult(16384,16384) = %#x, want 0x20000000", got)
+	}
+	if lAdd(maxWord32, 1) != maxWord32 {
+		t.Errorf("lAdd saturate high failed")
+	}
+	if lSub(minWord32, 1) != minWord32 {
+		t.Errorf("lSub saturate low failed")
+	}
+	if got := etsiRound(0x00018000); got != 2 { // round 1.5 -> 2 at the 16-MSB point
+		t.Errorf("etsiRound(0x00018000) = %d, want 2", got)
+	}
+	if got := extractH(0x12345678); got != 0x1234 {
+		t.Errorf("extractH = %#x, want 0x1234", got)
+	}
+}
+
+// TestShiftsAndNorm checks the shift and normalisation operators, including the
+// shl(v, norm_s(v)) normalisation identity.
+func TestShiftsAndNorm(t *testing.T) {
+	if got := shl(1, 3); got != 8 {
+		t.Errorf("shl(1,3) = %d, want 8", got)
+	}
+	if got := shl(16384, 2); got != maxWord16 { // overflow saturates positive
+		t.Errorf("shl overflow = %d, want 32767", got)
+	}
+	if got := shr(-8, 2); got != -2 { // arithmetic right shift
+		t.Errorf("shr(-8,2) = %d, want -2", got)
+	}
+	if got := shr(v16(1), -3); got != 8 { // negative count = left shift
+		t.Errorf("shr(1,-3) = %d, want 8", got)
+	}
+	if got := lShr(-8, 2); got != -2 {
+		t.Errorf("lShr(-8,2) = %d, want -2", got)
+	}
+	if got := lShl(1, 4); got != 16 {
+		t.Errorf("lShl(1,4) = %d, want 16", got)
+	}
+	// normalisation identity: shl(v, normS(v)) lands in [0x4000,0x7fff] magnitude.
+	for _, v := range []int16{1, 100, -100, 0x0123, -0x0123, 0x4000} {
+		n := normS(v)
+		norm := shl(v, n)
+		if v > 0 && (norm < 0x4000 || norm > 0x7fff) {
+			t.Errorf("normS(%d): shl gave %#x, not normalised", v, norm)
+		}
+	}
+	if normL(0) != 0 || normL(-1) != 31 {
+		t.Errorf("normL edge cases failed")
+	}
+	if got := divS(16384, 32767); got <= 0 || got >= maxWord16 {
+		t.Errorf("divS(16384,32767) = %d, out of range", got)
+	}
+	if divS(100, 100) != maxWord16 {
+		t.Errorf("divS(a,a) should be 32767")
+	}
+}
+
+func v16(x int16) int16 { return x }


### PR DESCRIPTION
## Summary

Starts **Stage D** — the TETRA ACELP speech decoder (ETSI EN 300 395-2), the final stage that turns the TCH/S-decoded 137-bit speech frames (merged in #954) into 8 kHz PCM. The decoder is a bit-exact fixed-point algorithm, so the first, foundational piece is the ITU-T G.191 STL / ETSI reference **basic operators** — every higher-level block composes them, and their exact overflow/rounding behaviour is what makes the port bit-exact.

## Changes

- New package `internal/voice/acelp`:
  - `ops.go` — 28 fixed-point operators (saturating `add`/`sub`/`mult`/`mult_r`/`L_mult`/`L_mac`/`L_msu`, `L_add`/`L_sub`, shifts `shl`/`shr`/`L_shl`/`L_shr`/`L_shr_r`, `round`, `norm_s`/`norm_l`, `div_s`, deposits/extracts, abs/negate), a faithful port of the reference `tetra_op.c`.
  - `ops_test.go` — the documented edge cases: `abs_s(-32768)=32767`, saturating add/sub, `mult(-32768,-32768)=32767`, `L_mult`, rounding, the `shl(v, norm_s(v))` normalisation identity, fractional division.

## Provenance / licensing (please review)

This port derives from the **ETSI reference codec** (fixed-point ANSI C), obtained via `github.com/curlyboi/libtetradec`. The ETSI reference implementation is ETSI-copyrighted and the codec is historically patent-encumbered (algebraic CELP; core patents largely expired). The package doc records this, and the codec will sit behind an **explicit vocoder registration** (off by default) so the licensing posture can be set in `docs/vocoders.md` before it ships enabled. Flagging for a maintainer decision.

## Test plan

- [x] `go vet` + package tests green (`-run` all in `internal/voice/acelp`)
- [x] `go build ./...` green
- [ ] `make integration` — n/a (isolated new package, not yet wired)

## Breaking changes

None — new isolated package, not yet referenced by any build path.

## Follow-ups (the remaining decoder blocks)

LSP dequantisation + the codebook tables (`clsp_334.tab`, `ener_qua.tab`, …), adaptive + algebraic codebooks, gain dequant, LPC synthesis filter, adaptive post-filter, then the vocoder registration + WAV output (Stage E). Each lands as its own tested PR.

## Linked issues

Refs #925.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GVoGbXXCo3doUafoQTf3mE)_