### PR TITLE
docs(p25): correct LSM/simulcast vs CQPSK conflation in demod-mode guidance (#935)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,18 @@ for tagged releases.
   rather than a fixed slot 1 — the building block for issue #925.
 
 ### Fixed
+- **Config guidance no longer conflates LSM/simulcast with CQPSK.** The
+  `p25_phase1_demod_mode` docs, config-builder help, `config.example.yaml`, and the
+  per-site override example (issue #942) all implied that a *simulcast* site needs the
+  `cqpsk`/`lsm` demod path — using Victoria's MMR / Melbourne CBD as the worked
+  "→ cqpsk" example. That is backwards: simulcast is a transmitter-coordination
+  technique, not a modulation, and most simulcast systems (MMR included, every site)
+  transmit C4FM — forcing CQPSK there kills the decode. Linear Simulcast Modulation
+  (LSM/CQPSK) is a *choice* some systems make, not implied by simulcast and not
+  readable from emission-designator/licensing data. All guidance now says: leave it at
+  C4FM, and switch a channel to `cqpsk` only when a strong, clean signal won't lock in
+  C4FM. The per-channel override feature itself is unchanged and still correct for
+  genuinely-CQPSK systems. (issue #935)
 - **P25 Phase 2 superframes now lock under any dibit rotation.** Real-air Phase 2
   is differentially decoded H-DQPSK, so a residual carrier offset near an odd
   multiple of ±1500 Hz (a quarter of the 6000-baud symbol rate) rotates every

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -300,10 +300,10 @@ sdr:
     #                           (frequency_hz must be in
     #                           control_channels; respects the
     #                           system's p25_phase1_demod_mode for
-    #                           C4FM vs CQPSK / LSM simulcast, or a
-    #                           per-channel p25_phase1_demod_mode
-    #                           override when sites of one system differ
-    #                           in modulation — see below, issue #935)
+    #                           C4FM vs CQPSK/LSM, or a per-channel
+    #                           p25_phase1_demod_mode override when
+    #                           sites of one system differ in
+    #                           modulation — see below, issue #935)
     #   protocol: p25-phase2  → P25 Phase 2 trunked control channel
     #                           (frequency_hz must be in
     #                           control_channels; respects the
@@ -321,16 +321,26 @@ sdr:
     # come from the system's sites: mapping (RFSS/Site → name) further down.
     #
     # PER-SITE MODULATION (issue #935): sites of one P25 system can use
-    # different modulation — an urban simulcast site on LSM (cqpsk)
-    # alongside rural single-transmitter sites on C4FM. Set the system's
-    # p25_phase1_demod_mode to the modulation MOST sites use, then add a
-    # per-channel `p25_phase1_demod_mode:` on the exceptions. A blank /
-    # absent per-channel value inherits the system default. The override
-    # drives both the control-channel decode AND the voice grants that tap
-    # issues, so a granted call on an LSM site is decoded on the LSM path
-    # too (a C4FM demod can't recover a linearly-modulated simulcast
+    # different modulation — a site that genuinely transmits linear/CQPSK
+    # (Linear Simulcast Modulation, LSM) alongside sites on C4FM. Set the
+    # system's p25_phase1_demod_mode to the modulation MOST sites use,
+    # then add a per-channel `p25_phase1_demod_mode:` on the exceptions.
+    # A blank / absent per-channel value inherits the system default. The
+    # override drives both the control-channel decode AND the voice grants
+    # that tap issues, so a granted call on a CQPSK site is decoded on the
+    # linear path too (a C4FM demod can't recover a linearly-modulated
     # signal — the CC would show control_channel_decode_quality: poor and
     # voice grants would time out without an LDU).
+    #
+    # IMPORTANT — do NOT set cqpsk just because a site is SIMULCAST.
+    # Simulcast is a transmitter-coordination technique, not a modulation:
+    # most simulcast systems transmit plain C4FM (Victoria's MMR, every
+    # site including its multi-tower CBD simulcast, is C4FM — forcing
+    # CQPSK there kills the decode). You cannot infer the modulation from
+    # the fact a site is simulcast, nor from emission-designator/licensing
+    # data (e.g. "10K1D7W" covers both C4FM and CQPSK). Determine it
+    # empirically: leave it at C4FM, and switch a channel to cqpsk only if
+    # a strong, clean signal will not lock in C4FM.
     #
     # SHARED FRONT END (issue #749): every tap on a dongle shares one
     # antenna, one centre frequency and one gain. The channelizer is
@@ -399,7 +409,7 @@ sdr:
     # P25 Phase 1 control channel on a wideband dongle. The
     # referenced system carries `protocol: p25` and the
     # channel's frequency_hz must appear in its control_channels.
-    # Honours `p25_phase1_demod_mode` (c4fm vs cqpsk / LSM) on the
+    # Honours `p25_phase1_demod_mode` (c4fm vs cqpsk/LSM) on the
     # system entry just like a dedicated CC dongle.
     #
     # MULTIPLE SITES IN PARALLEL (issue #749): a P25 system with
@@ -413,25 +423,33 @@ sdr:
     # hosted this way is automatically excluded from the sequential,
     # single-tuner cc-hunt below, so a wideband site is never starved
     # by the round-robin hunter. Example: all four sites of "MMR"
-    # decoded at once from one Airspy —
-    # Here system "MMR" defaults to p25_phase1_demod_mode: c4fm (most
-    # sites are single-TX C4FM), and the two urban simulcast sites carry a
-    # per-channel cqpsk override (issue #935):
+    # decoded at once from one Airspy. System "MMR" is C4FM on every
+    # site (including its multi-tower CBD simulcast), so it just uses the
+    # system default and needs no per-channel override:
     # - serial: "AIRSPY SN:637862DC2E8449D7"
     #   role: wideband
     #   center_freq_hz: 420_900_000
     #   voice_taps: 4
     #   channels:
-    #     - frequency_hz: 420_012_500   # Melbourne / CBD — LSM simulcast
+    #     - frequency_hz: 420_012_500   # Melbourne / CBD (C4FM simulcast)
     #       system: "MMR"
+    #     - frequency_hz: 420_037_500   # 120 Collins Street (C4FM simulcast)
+    #       system: "MMR"
+    #     - frequency_hz: 420_087_500   # Mt Anakie (C4FM)
+    #       system: "MMR"
+    #     - frequency_hz: 421_837_500   # Mt Blackwood (C4FM)
+    #       system: "MMR"
+    #
+    # The per-channel cqpsk override (issue #935) is for a DIFFERENT case:
+    # a system that actually mixes modulations — most sites C4FM, but one
+    # or two proven (empirically — C4FM won't lock a strong signal) to
+    # transmit linear/CQPSK. Then, and only then:
+    #   channels:
+    #     - frequency_hz: 460_100_000   # C4FM site — inherits system default
+    #       system: "mixed-p25"
+    #     - frequency_hz: 460_350_000   # confirmed-CQPSK site — override
+    #       system: "mixed-p25"
     #       p25_phase1_demod_mode: cqpsk
-    #     - frequency_hz: 420_037_500   # 120 Collins Street — LSM simulcast
-    #       system: "MMR"
-    #       p25_phase1_demod_mode: cqpsk
-    #     - frequency_hz: 420_087_500   # Mt Anakie — single-TX C4FM (inherits system default)
-    #       system: "MMR"
-    #     - frequency_hz: 421_837_500   # Mt Blackwood — single-TX C4FM (inherits)
-    #       system: "MMR"
     # (List every one of these frequencies in the system's
     # control_channels too — see the systems section below — and add a
     # `sites:` mapping there to give each RFSS/Site a human name.)
@@ -967,19 +985,22 @@ trunking:
   #                                     # for non-spec transmitters (see
   #                                     # samples/nxdn/README.md sweep recipe)
   #
-  #   - name: "Simulcast-P25"
+  #   - name: "Linear-CQPSK-P25"
   #     protocol: p25
   #     control_channels: [420_087_500]
-  #     p25_phase1_demod_mode: "cqpsk"  # LSM linear-CQPSK — required on
-  #                                     # P25 simulcast sites whose CC
-  #                                     # is transmitted as Linear
-  #                                     # Simulcast Modulation rather
-  #                                     # than C4FM (issue #275). Also
+  #     p25_phase1_demod_mode: "cqpsk"  # linear-CQPSK / LSM path — for a
+  #                                     # system that actually transmits
+  #                                     # Linear Simulcast Modulation
+  #                                     # rather than C4FM (issue #275).
+  #                                     # NOT triggered by a site being
+  #                                     # simulcast — most simulcast
+  #                                     # systems are C4FM; set this only
+  #                                     # when C4FM won't lock a strong,
+  #                                     # clean signal (issue #935). Also
   #                                     # routes the per-call voice chain
-  #                                     # through the LSM path; without
-  #                                     # this voice grants on simulcast
-  #                                     # sites time out with no audio
-  #                                     # (issue #356).
+  #                                     # through the linear path; without
+  #                                     # it voice grants on a CQPSK site
+  #                                     # time out with no audio (#356).
   #
   #   - name: "Legacy-P25-Phase2"
   #     protocol: p25

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -458,7 +458,7 @@ directly and needs no band plan.
 ### P25 trunked control channel on a wideband dongle
 
 A wideband dongle can also host a P25 control channel — Phase 1 (C4FM
-or CQPSK / LSM simulcast) or Phase 2 (H-DQPSK TDMA). The configuration
+or CQPSK / LSM) or Phase 2 (H-DQPSK TDMA). The configuration
 mirrors the DMR Tier III case: the wideband channel sits on the
 system's declared `control_channels`, and the engine decodes the TSBK
 (Phase 1) or MAC PDU (Phase 2) chain inline. Voice grants ride on the
@@ -479,9 +479,11 @@ trunking:
     - name: "regional-p25"
       protocol: p25                       # Phase 1
       control_channels: [851_037_500]     # MUST include the wideband channel above
-      # On a simulcast site whose CC is transmitted as Linear
-      # Simulcast Modulation rather than C4FM, opt in to the
-      # linear-CQPSK demod path:
+      # For a system that actually transmits a linear/CQPSK waveform
+      # (Linear Simulcast Modulation) rather than C4FM, opt in to the
+      # linear-CQPSK demod path. NOTE: simulcast alone does NOT require
+      # this — most simulcast systems are C4FM; set cqpsk only when a
+      # strong, clean signal won't lock in C4FM (issue #935):
       # p25_phase1_demod_mode: cqpsk
 ```
 
@@ -592,7 +594,7 @@ message that names the offending entry.
 - **DMR + P25.** Wideband supports `protocol: dmr-tier2` (Tier II
   conventional), `protocol: dmr` (Tier III trunked control channel),
   `protocol: p25` (P25 Phase 1 trunked control channel — C4FM and
-  CQPSK / LSM simulcast), and `protocol: p25-phase2` (P25 Phase 2
+  CQPSK / LSM), and `protocol: p25-phase2` (P25 Phase 2
   H-DQPSK trunked control channel). Other protocols (NXDN, TETRA,
   …) are not in scope yet.
 - **Trunked voice on the same wideband dongle.** With `voice_taps`

--- a/docs/learn/digital-trunking/digital-modulation-for-trunking.md
+++ b/docs/learn/digital-trunking/digital-modulation-for-trunking.md
@@ -12,7 +12,7 @@ faq:
   - q: What modulation does P25 Phase 1 use?
     a: P25 Phase 1 uses C4FM, a four-level frequency-shift keying. It runs at 4800 symbols per second, and because four levels carry two bits each, that yields 9600 bits per second. The same signal can also be produced with CQPSK, a linear-modulation cousin that fits the same constellation.
   - q: Why does P25 specify both C4FM and CQPSK?
-    a: They produce a compatible on-air signal but suit different transmitters. C4FM uses a constant-envelope FM-style path that works with cheap, efficient nonlinear amplifiers in handhelds. CQPSK (also called LSM) is a linear modulation that simulcast transmitters need so multiple sites can overlap cleanly, so infrastructure often uses it.
+    a: They produce a compatible on-air signal but suit different transmitters. C4FM uses a constant-envelope FM-style path that works with cheap, efficient nonlinear amplifiers in handhelds. CQPSK (also called LSM, Linear Simulcast Modulation) is a linear modulation that some simulcast systems use so overlapping copies combine more cleanly. But it is a choice, not a requirement: many simulcast systems transmit plain C4FM, so you cannot infer the modulation from the fact that a system is simulcast — you confirm it by which demodulator actually locks.
   - q: What is the difference between 4FSK and π/4-DQPSK?
     a: 4FSK shifts the carrier among four frequencies, one per symbol, and is used by DMR and NXDN as well as P25 Phase 1's C4FM. π/4-DQPSK is a phase-shift modulation used by TETRA that rotates the carrier phase in quarter-pi steps, encoding bits in the change of phase rather than its absolute value.
   - q: How can I see these modulations in GopherTrunk?
@@ -79,12 +79,12 @@ care which one transmitted it.
 
 Why bother with two ways to make the same signal? Because of **simulcast**: large
 systems broadcast the same channel from many transmitters at once over an overlapping
-area. For those overlapping signals to combine cleanly rather than smear, the
-transmitters need the tighter control that a **linear** modulation gives. C4FM's
-nonlinear path is fine for a single handheld but not for phase-precise simulcast, so
-infrastructure transmitters often use **CQPSK/LSM** while the constellation a receiver
-sees stays the same. (This is exactly why simulcast distortion is its own decoding
-challenge, covered later in the path.)
+area. A **linear** modulation gives the transmitters tighter control so those
+overlapping signals combine cleanly rather than smear, so **some** simulcast operators
+choose **CQPSK/LSM** while the constellation a receiver sees stays the same. It is not
+mandatory, though — plenty of simulcast systems still run C4FM — so simulcast alone
+doesn't tell you the modulation; the demodulator that locks does. (This is exactly why
+simulcast distortion is its own decoding challenge, covered later in the path.)
 
 ## π/4-DQPSK and 4FSK — the rest of the field
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1201,22 +1201,29 @@ type DeviceChannelConfig struct {
 	// P25Phase1DemodMode optionally overrides the parent system's
 	// p25_phase1_demod_mode for this one control-channel tap. Within a
 	// single P25 system, individual sites can transmit different
-	// modulation — e.g. an urban simulcast site on Linear Simulcast
-	// Modulation (cqpsk / lsm) alongside rural single-transmitter sites
-	// on straight C4FM (issue #935). Because a wideband dongle decodes
-	// every site's control channel in parallel and the correct demod
-	// path must be chosen before the CC locks (it is what lets it lock),
-	// the override is keyed here per control-channel frequency — the one
-	// place a site's identity is known at config time — rather than by
-	// the RFSS/Site the CC only reveals after it decodes.
+	// modulation — e.g. a site that genuinely transmits linear/CQPSK
+	// (Linear Simulcast Modulation, LSM) alongside sites on straight
+	// C4FM (issue #935). Because a wideband dongle decodes every site's
+	// control channel in parallel and the correct demod path must be
+	// chosen before the CC locks (it is what lets it lock), the override
+	// is keyed here per control-channel frequency — the one place a
+	// site's identity is known at config time — rather than by the
+	// RFSS/Site the CC only reveals after it decodes.
+	//
+	// Do NOT set this to cqpsk merely because a site is simulcast:
+	// simulcast is a transmitter-coordination technique, not a
+	// modulation, and most simulcast systems transmit C4FM (Victoria's
+	// MMR, all sites, is the worked example in #935 — forcing CQPSK
+	// there kills the decode). Override to cqpsk only for sites that a
+	// strong, clean signal proves won't lock in C4FM.
 	//
 	// Recognised values match the system-level key (case-insensitive):
 	// "" (inherit the system's p25_phase1_demod_mode) / "c4fm" / "fm"
 	// (FM discriminator + 4-level slicer) or "cqpsk" / "lsm" / "linear"
-	// (the LSM path — complex RRC + Gardner + differential QPSK).
+	// (the linear path — complex RRC + Gardner + differential QPSK).
 	// Applies to both the control-channel decoder and the voice grants
-	// this tap issues, so a granted voice call on an LSM site is decoded
-	// on the LSM path too. Ignored for non-P25-Phase-1 channels.
+	// this tap issues, so a granted voice call on a CQPSK site is decoded
+	// on the linear path too. Ignored for non-P25-Phase-1 channels.
 	P25Phase1DemodMode string `yaml:"p25_phase1_demod_mode"`
 }
 
@@ -1359,18 +1366,21 @@ type SystemConfig struct {
 
 	// P25Phase1DemodMode selects the symbol-recovery path for the
 	// P25 Phase 1 receiver. Recognised values: "" / "c4fm" / "fm"
-	// (the default — FM discriminator + 4-level slicer; matches
-	// every previously shipping config and works on conventional
-	// non-simulcast P25 transmitters) or "cqpsk" / "lsm" / "linear"
-	// (the linear / LSM path — complex RRC + Gardner + differential
-	// QPSK; required for simulcast P25 deployments whose control
-	// channel transmits Linear Simulcast Modulation rather than
-	// straight C4FM, see issue #275 and TIA-102.BAAA). Applies to
-	// both the control channel decoder and the per-call voice
-	// chain — without the voice-chain side a simulcast site would
-	// lock the CC fine but never decode an LDU on a granted voice
-	// call (issue #356 follow-up). Ignored for non-P25-Phase-1
-	// protocols.
+	// (the default — FM discriminator + 4-level slicer; matches every
+	// previously shipping config and is correct for the large majority
+	// of P25 systems, including most simulcast systems, which transmit
+	// C4FM) or "cqpsk" / "lsm" / "linear" (the linear / LSM path —
+	// complex RRC + Gardner + differential QPSK; for the minority of
+	// systems that transmit Linear Simulcast Modulation, a linear
+	// π/4-DQPSK waveform, rather than C4FM — see issue #275 and
+	// TIA-102.BAAA). The modulation is NOT implied by a system being
+	// simulcast, nor readable from emission-designator/licensing data;
+	// determine it empirically and set cqpsk only when a strong, clean
+	// signal will not lock in C4FM (issue #935). Applies to both the
+	// control channel decoder and the per-call voice chain — without
+	// the voice-chain side a CQPSK site would lock the CC fine but
+	// never decode an LDU on a granted voice call (issue #356
+	// follow-up). Ignored for non-P25-Phase-1 protocols.
 	P25Phase1DemodMode string `yaml:"p25_phase1_demod_mode"`
 	// DMRInterleavedVoice overrides the 2-slot interleaved voice decoder.
 	// A DMR carrier is 2-slot TDMA, so the demodulated stream interleaves

--- a/internal/configbuilder/fieldmeta.go
+++ b/internal/configbuilder/fieldmeta.go
@@ -120,7 +120,7 @@ var fieldMetas = map[string]FieldMeta{
 
 	"DeviceChannelConfig.FrequencyHz":        {Label: "Frequency", Hz: true, Help: "Repeater carrier frequency. Must lie inside the dongle's IQ band."},
 	"DeviceChannelConfig.System":             {Help: "Name of the trunking.systems entry this carrier belongs to."},
-	"DeviceChannelConfig.P25Phase1DemodMode": {Label: "P25 Ph1 demod mode", Help: "Per-site override of the system's demod path for this tap: blank inherits, or c4fm/fm vs cqpsk/lsm. Use when one P25 system mixes LSM simulcast and C4FM sites. P25 Phase 1 only."},
+	"DeviceChannelConfig.P25Phase1DemodMode": {Label: "P25 Ph1 demod mode", Help: "Per-site override of the system's demod path for this tap: blank inherits, or c4fm/fm vs cqpsk/lsm. Use when one P25 system mixes genuinely CQPSK/LSM sites with C4FM sites. Note: simulcast does NOT imply CQPSK — most simulcast systems are C4FM; pick cqpsk only where a strong signal won't lock in C4FM. P25 Phase 1 only."},
 
 	"RTLTCPConfig.Addr":             {Label: "Address", Help: "host:port the rtl_tcp server listens on, e.g. 192.168.1.50:1234. Required."},
 	"RTLTCPConfig.Serial":           {Help: "Virtual device serial reported by the pool. Empty derives one from the address."},
@@ -180,7 +180,7 @@ var fieldMetas = map[string]FieldMeta{
 	"SystemConfig.TETRAClockMode":          {Label: "TETRA clock mode", Help: "Symbol-timing recovery: gardner (default, live SDR) or naive (sample-aligned fixtures). TETRA only."},
 	"SystemConfig.LTRFCSMode":              {Label: "LTR FCS mode", Help: "CRC-7 FCS check on LTR Status words. on (default) or off (un-populated fixtures). LTR only."},
 	"SystemConfig.LTRManchesterMode":       {Label: "LTR Manchester mode", Help: "LTR sub-audible decode: soft (default), strict, or off/nrz. LTR only."},
-	"SystemConfig.P25Phase1DemodMode":      {Label: "P25 Ph1 demod mode", Help: "Phase 1 symbol recovery: c4fm/fm (default) or cqpsk/lsm (simulcast LSM sites). P25 Phase 1 only."},
+	"SystemConfig.P25Phase1DemodMode":      {Label: "P25 Ph1 demod mode", Help: "Phase 1 symbol recovery: c4fm/fm (default, correct for most systems including most simulcast) or cqpsk/lsm (only for systems that actually transmit linear/LSM modulation). Simulcast alone does not require cqpsk. P25 Phase 1 only."},
 	"SystemConfig.P25Phase2TrellisMode":    {Label: "P25 Ph2 trellis", Help: "½-rate trellis FEC on the Phase 2 MAC PDU. on (default) or off (pre-stripped fixtures). P25 Phase 2 only."},
 	"SystemConfig.P25Phase2RSMode":         {Label: "P25 Ph2 RS", Help: "Outer Reed-Solomon RS(24,16,9) verification. off (default) or on. P25 Phase 2 only."},
 	"SystemConfig.P25Phase2InterleaveMode": {Label: "P25 Ph2 interleave", Help: "Per-burst block deinterleave before trellis decode. off (default) or on. P25 Phase 2 only."},

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -110,8 +110,8 @@ type ControlChannel struct {
 	// p25Phase1DemodMode is the system-level operator-set demod-mode
 	// string (e.g. "cqpsk" / "c4fm"). Stamped onto every published
 	// trunking.Grant so the voice composer can route the voice IQ
-	// through the matching symbol-recovery path; without this an LSM
-	// simulcast site's voice grants would land in a hardcoded C4FM
+	// through the matching symbol-recovery path; without this a
+	// CQPSK/LSM site's voice grants would land in a hardcoded C4FM
 	// voice receiver and never decode (issue #356 follow-up). Empty
 	// string preserves the C4FM default in the voice chain.
 	p25Phase1DemodMode string

--- a/internal/radio/p25/phase1/receiver/modes.go
+++ b/internal/radio/p25/phase1/receiver/modes.go
@@ -7,18 +7,31 @@ import "strings"
 //
 //   - DemodC4FM (default) is the pre-existing path: FM
 //     discriminator → real-valued RRC matched filter → 4-level
-//     slicer. Works on conventional non-simulcast P25 Phase 1
-//     transmitters that use straight C4FM on the wire.
+//     slicer. C4FM (4-level FSK) is the standard P25 Phase 1
+//     baseband modulation and the correct choice for the large
+//     majority of systems — including most simulcast systems, which
+//     transmit C4FM across their multiple transmitters.
 //
 //   - DemodCQPSK is the linear-modulation path: complex RRC matched
 //     filter → symbol-time decimation → differential QPSK decode.
-//     This is the path operators on simulcast P25 sites need:
-//     simulcast deployments commonly transmit Linear Simulcast
-//     Modulation (LSM, TIA-102.BAAA), a CQPSK-shaped variant
-//     designed to survive multi-transmitter overlap. LSM pushed
-//     through a quadrature FM discriminator produces near-random
-//     dibits and the FSW never matches — the failure mode reported
-//     against issue #275 on the MMR system.
+//     It is for the minority of P25 Phase 1 systems that transmit a
+//     *linear* modulation on the wire — Linear Simulcast Modulation
+//     (LSM, TIA-102.BAAA), a π/4-DQPSK-family scheme, being the
+//     common one. A linear signal pushed through a quadrature FM
+//     discriminator produces near-random dibits and the FSW never
+//     matches (issue #275).
+//
+// IMPORTANT — modulation is not implied by simulcast. LSM is a linear
+// modulation that *some* operators choose (often for simulcast, because
+// a linear waveform survives multi-transmitter overlap better), but
+// simulcast does not imply LSM: many simulcast systems transmit plain
+// C4FM. The modulation also cannot be read off licensing / emission-
+// designator data (e.g. ACMA "10K1D7W" covers both C4FM and CQPSK).
+// Determine it empirically: C4FM is the default, and DemodCQPSK is
+// warranted only when a strong, clean signal will not lock in C4FM
+// (near-random dibits, no FSW). See issue #935 — Victoria's MMR is a
+// simulcast system that is C4FM on every site, and forcing CQPSK there
+// kills the decode.
 //
 // The dibit value emitted by DemodCQPSK after the LSM remap matches
 // the canonical TIA-102.BAAA convention SymbolToDibit produces from
@@ -49,7 +62,11 @@ func (m DemodMode) String() string {
 // Recognised values (case-insensitive): "" / "c4fm" / "fm" → DemodC4FM
 // (the default — matches every previously-shipping config and the
 // receiver's pre-CQPSK behaviour); "cqpsk" / "lsm" / "linear" →
-// DemodCQPSK (the simulcast / LSM path). Unknown strings return
+// DemodCQPSK (the linear-modulation path). The "lsm" alias names the
+// linear modulation itself (LSM, TIA-102.BAAA); it is *not* a "this
+// site is simulcast" switch — pick it only for systems actually
+// transmitting a linear waveform, not because a system is simulcast
+// (see the DemodMode doc and issue #935). Unknown strings return
 // DemodC4FM with ok=false so the caller can warn-log and fall back.
 func ParseDemodMode(s string) (DemodMode, bool) {
 	switch strings.ToLower(strings.TrimSpace(s)) {

--- a/internal/radio/p25/phase1/receiver/receiver.go
+++ b/internal/radio/p25/phase1/receiver/receiver.go
@@ -197,8 +197,8 @@ type Options struct {
 	// DemodC4FM (the legacy FM-discriminator → Mueller-Müller
 	// path). DemodCQPSK routes IQ through the LSM / linear-CQPSK
 	// chain (complex RRC → Gardner → π/4-DQPSK + LSM dibit remap)
-	// — required for simulcast P25 sites whose control channel is
-	// on the wire as LSM rather than C4FM. See modes.go.
+	// — for P25 sites that transmit a linear/LSM waveform rather
+	// than C4FM (not implied by simulcast; see #935). See modes.go.
 	DemodMode DemodMode
 	// GardnerGain overrides the Gardner loop step used by the
 	// CQPSK path. <=0 uses defaultGardnerGain. Ignored when

--- a/internal/scanner/widebandt2/engine.go
+++ b/internal/scanner/widebandt2/engine.go
@@ -164,12 +164,13 @@ type ChannelConfig struct {
 
 	// P25Phase1DemodMode optionally overrides the parent system's
 	// P25Phase1DemodMode for this one tap (issue #935). A P25 system can
-	// span sites of differing modulation — an LSM simulcast site and a
-	// C4FM single-transmitter site under one system name — and each tap
-	// must pick its symbol-recovery path independently before the CC
-	// locks. Empty inherits sys.P25Phase1DemodMode; any value the
-	// system-level key accepts (c4fm/fm/cqpsk/lsm/linear) is valid here.
-	// Ignored for non-P25-Phase-1 channels.
+	// span sites of differing modulation — a genuinely CQPSK/LSM site
+	// and a C4FM site under one system name — and each tap must pick its
+	// symbol-recovery path independently before the CC locks. (Simulcast
+	// alone does not imply CQPSK — most simulcast systems are C4FM.)
+	// Empty inherits sys.P25Phase1DemodMode; any value the system-level
+	// key accepts (c4fm/fm/cqpsk/lsm/linear) is valid here. Ignored for
+	// non-P25-Phase-1 channels.
 	P25Phase1DemodMode string
 }
 
@@ -664,7 +665,8 @@ func buildChannel(sys trunking.System, ch ChannelConfig, outRateHz float64, bus 
 			return nil, err
 		}
 		// Per-site demod override (issue #935): a single P25 system can
-		// span an LSM simulcast site and a C4FM single-transmitter site,
+		// span a genuinely CQPSK/LSM site and a C4FM site (simulcast
+		// alone does not imply CQPSK — most simulcast systems are C4FM),
 		// so an empty per-channel value inherits the system default while
 		// a non-empty one overrides it for this tap only. The mode must be
 		// chosen here, before the CC locks — it is what lets it lock — so

--- a/internal/scanner/widebandt2/engine_p25_persite_demod_test.go
+++ b/internal/scanner/widebandt2/engine_p25_persite_demod_test.go
@@ -10,14 +10,16 @@ import (
 
 // TestBuildChannelP25Phase1PerSiteDemodOverride is the regression test for
 // issue #935: within a single P25 system, individual sites can transmit
-// different modulation — an urban simulcast site on Linear Simulcast
-// Modulation (cqpsk / lsm) alongside rural single-transmitter sites on
-// straight C4FM. A wideband dongle decodes each site's control channel in
-// parallel, so the per-tap demod path must be selectable per control-channel
-// frequency rather than only once at the system level.
+// different modulation — a site that genuinely transmits linear/CQPSK
+// (Linear Simulcast Modulation, LSM) alongside sites on C4FM. A wideband
+// dongle decodes each site's control channel in parallel, so the per-tap
+// demod path must be selectable per control-channel frequency rather than
+// only once at the system level. (The override's trigger is real CQPSK
+// deployment, not a site being simulcast — most simulcast systems are C4FM;
+// see #935.)
 //
 // The override also has to reach the voice grants a tap publishes: without
-// it an LSM site would lock its CC yet decode no LDU on a granted call
+// it a CQPSK site would lock its CC yet decode no LDU on a granted call
 // (issue #356 follow-up), because the composer's voice chain reads the
 // grant's demod mode. The wideband path previously never stamped a demod
 // mode onto grants at all, so this pins both halves.
@@ -27,19 +29,20 @@ func TestBuildChannelP25Phase1PerSiteDemodOverride(t *testing.T) {
 	log := slog.New(slog.NewTextHandler(discardWriter{}, nil))
 
 	const (
-		lsmHz  = 420_012_500 // Melbourne / CBD — LSM simulcast
-		c4fmHz = 420_087_500 // Mt Anakie — single-TX C4FM
+		cqpskHz = 460_100_000 // a site confirmed to transmit linear/CQPSK
+		c4fmHz  = 460_350_000 // a C4FM site in the same system
 	)
 
 	// System default is c4fm (a real, non-empty value) so the inheriting
 	// tap proves inheritance rather than landing on a coincidental empty
 	// default, and the override tap proves the per-channel value wins.
-	sys := p25Phase1System("MMR", lsmHz)
-	sys.ControlChannels = []uint32{lsmHz, c4fmHz}
+	sys := p25Phase1System("mixed-p25", cqpskHz)
+	sys.ControlChannels = []uint32{cqpskHz, c4fmHz}
 	sys.P25Phase1DemodMode = "c4fm"
 
-	// Override this one tap onto the LSM path; leave the other inheriting.
-	lsmCh := ChannelConfig{FrequencyHz: lsmHz, SystemName: sys.Name, P25Phase1DemodMode: "cqpsk"}
+	// Override this one tap onto the linear/CQPSK path; leave the other
+	// inheriting the C4FM system default.
+	cqpskCh := ChannelConfig{FrequencyHz: cqpskHz, SystemName: sys.Name, P25Phase1DemodMode: "cqpsk"}
 	c4fmCh := ChannelConfig{FrequencyHz: c4fmHz, SystemName: sys.Name}
 
 	demodOf := func(t *testing.T, ch ChannelConfig) string {
@@ -55,8 +58,8 @@ func TestBuildChannelP25Phase1PerSiteDemodOverride(t *testing.T) {
 		return cc.P25Phase1DemodMode()
 	}
 
-	if got := demodOf(t, lsmCh); got != "cqpsk" {
-		t.Errorf("LSM tap demod mode = %q, want %q — per-channel override not applied to grants (issue #935)", got, "cqpsk")
+	if got := demodOf(t, cqpskCh); got != "cqpsk" {
+		t.Errorf("CQPSK tap demod mode = %q, want %q — per-channel override not applied to grants (issue #935)", got, "cqpsk")
 	}
 	if got := demodOf(t, c4fmCh); got != "c4fm" {
 		t.Errorf("inheriting tap demod mode = %q, want %q — system default not forwarded to grants", got, "c4fm")

--- a/internal/trunking/grant.go
+++ b/internal/trunking/grant.go
@@ -92,7 +92,7 @@ type Grant struct {
 	// system (C4FM vs CQPSK / LSM). The control-channel decoder
 	// already honours the setting via the ccdecoder connector; without
 	// this field every voice grant landed in a hardcoded C4FM voice
-	// receiver and never decoded on LSM-modulated simulcast sites
+	// receiver and never decoded on CQPSK/LSM-modulated sites
 	// (issue #356 follow-up). Populated by the protocol layer when it
 	// publishes the grant; ignored for non-P25-Phase-1 grants.
 	P25Phase1DemodMode string

--- a/internal/trunking/site.go
+++ b/internal/trunking/site.go
@@ -260,9 +260,10 @@ type System struct {
 	// shipping config and works on conventional non-simulcast P25
 	// transmitters); "cqpsk" / "lsm" / "linear" → DemodCQPSK (the
 	// linear / LSM path — complex RRC + Gardner + differential
-	// QPSK; required for simulcast P25 deployments whose control
-	// channel transmits Linear Simulcast Modulation rather than
-	// straight C4FM, see issue #275 and TIA-102.BAAA). Forwarded
+	// QPSK; for P25 systems that transmit Linear Simulcast
+	// Modulation, a linear/CQPSK waveform, rather than C4FM — not
+	// implied by a system being simulcast, see issues #275/#935 and
+	// TIA-102.BAAA). Forwarded
 	// into p25phase1rx.Options.DemodMode by the ccdecoder connector
 	// after parsing via p25phase1rx.ParseDemodMode.
 	P25Phase1DemodMode string

--- a/internal/voice/composer/p25p1_voice.go
+++ b/internal/voice/composer/p25p1_voice.go
@@ -90,10 +90,10 @@ func (c *Composer) resolveP25Phase1DemodMode(serial, mode string) p25p1rx.DemodM
 // demodMode is the raw system-level p25_phase1_demod_mode string from
 // the grant ("c4fm" / "cqpsk" / ""). An empty or unrecognised value
 // preserves the legacy C4FM path; "cqpsk" / "lsm" / "linear" routes
-// voice IQ through the linear-CQPSK path required for LSM simulcast
-// sites. Without this the voice chain was hardcoded to C4FM regardless
-// of the system setting and never decoded LDUs on simulcast sites
-// (issue #356 follow-up).
+// voice IQ through the linear-CQPSK path required for sites that
+// transmit a linear/LSM modulation. Without this the voice chain was
+// hardcoded to C4FM regardless of the system setting and never decoded
+// LDUs on CQPSK sites (issue #356 follow-up).
 //
 // The recorder maps protocol "p25" to the pure-Go IMBE vocoder
 // (voice.DefaultVocoderForProtocol), so WriteRawFrame here decodes each


### PR DESCRIPTION
## Summary

Issue #935's per-site `p25_phase1_demod_mode` override (shipped in #942) came with guidance that conflated **LSM / simulcast** with **CQPSK modulation** — telling operators to set `cqpsk` for "LSM simulcast" sites, and using Melbourne CBD as the worked "→ cqpsk" example. The reporter demonstrated this is backwards: CBD (and all of Victoria's MMR, a multi-tower simulcast system) transmits **C4FM**, and forcing CQPSK there *kills* the decode. Simulcast is a transmitter-coordination technique, not a modulation; LSM/CQPSK is a choice some systems make and cannot be inferred from "is it simulcast" or from emission-designator/licensing data (`10K1D7W` covers both). This corrects the guidance everywhere. **The feature itself and the `lsm`/`linear` → CQPSK alias mapping are unchanged.**

## Changes

- **`internal/radio/p25/phase1/receiver/modes.go`** (source of truth) — rewrote the `DemodMode` / `ParseDemodMode` docs: C4FM is correct for the majority of systems including *most simulcast*; CQPSK is for the minority that transmit a linear waveform; determine empirically (switch to cqpsk only when a strong, clean signal won't lock in C4FM).
- **`config.example.yaml`** — corrected the PER-SITE MODULATION section and the worked example: MMR is now correctly all-C4FM (no override), and the cqpsk override is illustrated with a clearly-hypothetical genuinely-CQPSK mixed system.
- **`internal/config/config.go`**, **`internal/configbuilder/fieldmeta.go`** (config-builder help), **`docs/hardware.md`** — same correction in field comments / UI help / operator docs.
- **`internal/voice/composer/p25p1_voice.go`**, **`internal/trunking/grant.go`**, **`internal/trunking/site.go`**, **`internal/scanner/widebandt2/engine.go`**, **`internal/radio/p25/phase1/control.go`**, **`internal/radio/p25/phase1/receiver/receiver.go`** — comment wording ("CQPSK/LSM site" not "LSM simulcast site").
- **`internal/scanner/widebandt2/engine_p25_persite_demod_test.go`** — relabelled the #942 regression test off the false CBD-as-cqpsk framing to a neutral genuinely-CQPSK example. **Assertions/behaviour unchanged.**
- **`docs/learn/digital-trunking/digital-modulation-for-trunking.md`** — softened the "simulcast needs CQPSK" overclaim.

## Test plan

- [x] `make vet test` is green locally. The #942 per-site override regression test still passes (relabelled only).
- [ ] `make integration` — n/a
- [x] Updated tests where appropriate (relabel only)
- No behaviour change: this is a guidance-correctness fix. The demod-mode alias mapping and the per-channel override plumbing are untouched.

## Breaking changes

None.

## Docs / CHANGELOG

- [x] Added a `## [Unreleased]` → `### Fixed` bullet to `CHANGELOG.md`
- [x] Updated `docs/` (`hardware.md`, the digital-modulation learn article) and `config.example.yaml`

## Linked issues

Refs #935

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015qyQePZJHVHeZmraDtMcEM)_