### PR TITLE
feat(tetra): ACELP adaptive + algebraic codebooks

### DIFF
--- a/internal/voice/acelp/codebook.go
+++ b/internal/voice/acelp/codebook.go
@@ -1,0 +1,118 @@
+package acelp
+
+// Adaptive (pitch) and algebraic (innovation) codebooks for the TETRA ACELP
+// decoder, ETSI EN 300 395-2. Per subframe the decoder builds the excitation
+// from two contributions:
+//
+//   - the adaptive codebook (predLt): the past excitation delayed by the pitch
+//     lag T0 (+ a 1/3-sample fractional offset via a 32-tap interpolation
+//     filter), reconstructing the periodic component;
+//   - the algebraic codebook (dD4i60): a 4-pulse innovation sequence convolved
+//     with the perceptual noise filter F[], reconstructing the stochastic
+//     component.
+//
+// Clean-room ports of the reference Pred_Lt / Inter32_1_3 / Inter32_M1_3 /
+// D_D4i60. The interpolation filter taps and the sqrt(2) impulse gain are
+// numeric constants defined by the standard (see package doc for provenance).
+
+const (
+	subfrLen  = 60   // L_subfr — samples per subframe
+	q11GainI0 = 2896 // sqrt(2) in Q11 — gain of the first algebraic pulse
+)
+
+// inter32Coef1_3 / inter32Coef_M1_3 are the 32-tap fractional-delay filters for
+// the +1/3 and -1/3 sample pitch offsets (EN 300 395-2 long-term prediction).
+var inter32Coef1_3 = [32]int16{
+	-47, 59, -84, 125, -183, 263, -366, 500, -672, 893,
+	-1185, 1587, -2182, 3179, -5287, 13496, 27072, -6669, 3688, -2452,
+	1758, -1304, 981, -739, 553, -407, 294, -207, 142, -96,
+	66, -49,
+}
+
+var inter32CoefM1_3 = [32]int16{
+	-49, 66, -96, 142, -207, 294, -407, 553, -739,
+	981, -1304, 1758, -2452, 3688, -6669, 27072, 13496, -5287, 3179,
+	-2182, 1587, -1185, 893, -672, 500, -366, 263, -183, 125,
+	-84, 59, -47,
+}
+
+// inter32_1_3 interpolates the +1/3-sample value centred at exc[c], reading
+// exc[c-16 .. c+15]. Result is the interpolated excitation sample (Word16).
+func inter32_1_3(exc []int16, c int) int16 {
+	var s int32
+	for i := 0; i < 32; i++ {
+		s = lMac0(s, exc[c+i-16], inter32Coef1_3[i])
+	}
+	s = lAdd(s, s)
+	return etsiRound(s)
+}
+
+// inter32M1_3 interpolates the -1/3-sample value centred at exc[c], reading
+// exc[c-15 .. c+16].
+func inter32M1_3(exc []int16, c int) int16 {
+	var s int32
+	for i := 0; i < 32; i++ {
+		s = lMac0(s, exc[c+i-15], inter32CoefM1_3[i])
+	}
+	s = lAdd(s, s)
+	return etsiRound(s)
+}
+
+// predLt fills the adaptive-codebook excitation for one subframe: for i in
+// [0,subfr), exc[base+i] = the past excitation at delay (T0 - frac/3). frac is
+// 0, +1 or -1 (thirds of a sample). The caller guarantees exc has at least
+// pitMax+lInter samples of valid history before base. Mirrors Pred_Lt.
+func predLt(exc []int16, base int, T0, frac, subfr int) {
+	switch frac {
+	case 0:
+		for i := 0; i < subfr; i++ {
+			exc[base+i] = exc[base+i-T0]
+		}
+	case 1:
+		for i := 0; i < subfr; i++ {
+			exc[base+i] = inter32_1_3(exc, base+i-T0)
+		}
+	case -1:
+		for i := 0; i < subfr; i++ {
+			exc[base+i] = inter32M1_3(exc, base+i-T0)
+		}
+	}
+}
+
+// algebraicPulses returns the four impulse positions encoded in a 14-bit
+// algebraic codebook index (D_D4i60 pulse decoding). Positions are in
+// [0,subfrLen) and pairwise even/offset per the D4i60 grid.
+func algebraicPulses(index int16) (pos0, pos1, pos2, pos3 int) {
+	pos0 = int((index & 31) << 1)
+	pos1 = int((index&224)>>2) + 2
+	pos2 = int((index&1792)>>5) + 4
+	pos3 = int((index&14336)>>8) + 6
+	return
+}
+
+// dD4i60 decodes the 4-pulse algebraic (innovation) codeword and convolves it
+// with the noise filter F[] into cod[0:subfrLen]. F must carry 64 zero samples
+// of headroom before Fbase (F[Fbase-64 .. Fbase-1] == 0) so the negative pulse
+// offsets read valid memory. sign flips the whole codeword; shift is the 0/1
+// pulse shift. cod is Q12. Mirrors D_D4i60.
+func dD4i60(index, sign, shift int16, F []int16, Fbase int, cod []int16) {
+	pos0, pos1, pos2, pos3 := algebraicPulses(index)
+
+	// F -= shift; p0 = F - pos0; ... — all as offsets into F around Fbase.
+	b := Fbase - int(shift)
+	p0 := b - pos0
+	p1 := b - pos1
+	p2 := b - pos2
+	p3 := b - pos3
+
+	for i := 0; i < subfrLen; i++ {
+		L := lMult0(F[p0+i], q11GainI0)
+		L = subSh(L, F[p1+i], 11)
+		L = addSh(L, F[p2+i], 11)
+		L = subSh(L, F[p3+i], 11)
+		if sign != 0 {
+			L = lNegate(L)
+		}
+		cod[i] = storeHi(L, 5)
+	}
+}

--- a/internal/voice/acelp/codebook_test.go
+++ b/internal/voice/acelp/codebook_test.go
@@ -1,0 +1,98 @@
+package acelp
+
+import "testing"
+
+// TestPredLtInteger checks the integer-lag (frac==0) adaptive codebook path:
+// the excitation is copied from delay T0.
+func TestPredLtInteger(t *testing.T) {
+	const base, T0 = 200, 50
+	exc := make([]int16, base+subfrLen)
+	for i := 0; i < base; i++ {
+		exc[i] = int16((i*13 + 7) % 100)
+	}
+	predLt(exc, base, T0, 0, subfrLen)
+	for i := 0; i < subfrLen; i++ {
+		if exc[base+i] != exc[base+i-T0] {
+			t.Fatalf("frac=0: exc[%d]=%d, want %d", base+i, exc[base+i], exc[base+i-T0])
+		}
+	}
+}
+
+// TestInter32DCGain checks the fractional interpolators preserve a DC signal:
+// interpolating a constant returns (approximately) that constant, i.e. the
+// filter gain is ~1.0. This validates the tap tables without re-deriving them.
+func TestInter32DCGain(t *testing.T) {
+	const c, val = 40, int16(1000)
+	exc := make([]int16, 80)
+	for i := range exc {
+		exc[i] = val
+	}
+	for name, got := range map[string]int16{
+		"+1/3": inter32_1_3(exc, c),
+		"-1/3": inter32M1_3(exc, c),
+	} {
+		if diff := int(got) - int(val); diff < -3 || diff > 3 {
+			t.Errorf("inter32 %s DC: got %d, want ~%d", name, got, val)
+		}
+	}
+}
+
+// TestAlgebraicPulses checks the pulse-position decoding for index 0 and a
+// spread index, matching the D4i60 grid.
+func TestAlgebraicPulses(t *testing.T) {
+	p0, p1, p2, p3 := algebraicPulses(0)
+	if p0 != 0 || p1 != 2 || p2 != 4 || p3 != 6 {
+		t.Errorf("index 0 pulses = %d,%d,%d,%d want 0,2,4,6", p0, p1, p2, p3)
+	}
+	// index with one bit set in each field: bit0, bit5, bit8, bit11.
+	idx := int16(1 | (1 << 5) | (1 << 8) | (1 << 11))
+	p0, p1, p2, p3 = algebraicPulses(idx)
+	if p0 != 2 || p1 != (32>>2)+2 || p2 != (256>>5)+4 || p3 != (2048>>8)+6 {
+		t.Errorf("spread pulses = %d,%d,%d,%d", p0, p1, p2, p3)
+	}
+}
+
+// TestDD4i60Impulse drives dD4i60 with an impulse noise filter so the output
+// is exactly the 4-pulse codeword: pulse 0 scaled by sqrt(2) (Q11 2896),
+// pulses 1..3 at ±2048 (=1.0 in Q11) with the +,-,+,- pattern, negated when
+// sign is set.
+func TestDD4i60Impulse(t *testing.T) {
+	const Fbase = 64
+	F := make([]int16, Fbase+subfrLen)
+	F[Fbase] = 2048 // impulse of value 1.0 in Q11 at F[0]
+
+	cod := make([]int16, subfrLen)
+	dD4i60(0, 0, 0, F, Fbase, cod) // positions 0,2,4,6; shift 0; sign +
+
+	want := map[int]int16{0: 2896, 2: -2048, 4: 2048, 6: -2048}
+	for i := 0; i < subfrLen; i++ {
+		if cod[i] != want[i] { // want[i] is 0 for unlisted positions
+			t.Errorf("cod[%d] = %d, want %d", i, cod[i], want[i])
+		}
+	}
+
+	// sign=1 negates the whole codeword.
+	dD4i60(0, 1, 0, F, Fbase, cod)
+	for i, w := range want {
+		if cod[i] != -w {
+			t.Errorf("sign=1 cod[%d] = %d, want %d", i, cod[i], -w)
+		}
+	}
+}
+
+// TestDD4i60Shift checks the pulse shift moves every pulse one sample later.
+func TestDD4i60Shift(t *testing.T) {
+	const Fbase = 64
+	F := make([]int16, Fbase+subfrLen)
+	F[Fbase] = 2048
+
+	cod := make([]int16, subfrLen)
+	dD4i60(0, 0, 1, F, Fbase, cod) // shift 1: positions 1,3,5,7
+
+	want := map[int]int16{1: 2896, 3: -2048, 5: 2048, 7: -2048}
+	for i := 0; i < subfrLen; i++ {
+		if cod[i] != want[i] {
+			t.Errorf("shifted cod[%d] = %d, want %d", i, cod[i], want[i])
+		}
+	}
+}

--- a/internal/voice/acelp/ops_ext.go
+++ b/internal/voice/acelp/ops_ext.go
@@ -1,0 +1,30 @@
+package acelp
+
+// Additional fixed-point operators used by the codebook and synthesis blocks:
+// the no-shift long multiply/accumulate (L_mult0/L_mac0) and the shift-and-
+// accumulate helpers (Load_sh/add_sh/sub_sh/store_hi). Faithful ports of the
+// ETSI TETRA reference operators (see package doc for provenance); built from
+// the base operators in ops.go so their saturation behaviour matches.
+
+// lMult0 is the 32-bit product without the Q15 left shift (L_mult0). The only
+// overflow case, -32768 × -32768 = 0x40000000, fits in Word32, so no saturation
+// is applied — matching the reference.
+func lMult0(a, b int16) int32 { return int32(a) * int32(b) }
+
+// lMac0 accumulates a no-shift product with saturating 32-bit add (L_mac0).
+func lMac0(acc int32, a, b int16) int32 { return lAdd(acc, lMult0(a, b)) }
+
+// loadSh loads a 16-bit value into a 32-bit accumulator shifted left by sh
+// (Load_sh).
+func loadSh(v int16, sh int16) int32 { return lShl(lDepositL(v), sh) }
+
+// addSh adds v<<sh to the accumulator with saturation (add_sh).
+func addSh(acc int32, v, sh int16) int32 { return lAdd(acc, loadSh(v, sh)) }
+
+// subSh subtracts v<<sh from the accumulator with saturation (sub_sh).
+func subSh(acc int32, v, sh int16) int32 { return lSub(acc, loadSh(v, sh)) }
+
+// storeHi shifts the accumulator left by sh and returns its high 16 bits
+// (store_hi) — the standard way the reference rescales a 32-bit result down to
+// a fixed-point Word16.
+func storeHi(l int32, sh int16) int16 { return extractH(lShl(l, sh)) }


### PR DESCRIPTION
## Summary

Third Stage-D increment for the clean-room TETRA ACELP speech decoder
(`internal/voice/acelp/`). Following the operators (#957) and LSP dequant
(#959), this adds the two per-subframe excitation codebooks — the periodic
(pitch) and stochastic (innovation) sources whose sum drives the LPC synthesis
filter. Still codec-internal; not yet wired into the receive path.

## Changes

- **Adaptive (pitch) codebook** (`predLt`, `inter32_1_3`/`inter32M1_3`,
  `codebook.go`): reconstructs the periodic excitation from the past excitation
  delayed by the pitch lag T0, with the two 32-tap fractional-delay
  interpolation filters for the ±1/3-sample offsets (mirrors `Pred_Lt`).
- **Algebraic (innovation) codebook** (`dD4i60`, `algebraicPulses`): decodes
  the 14-bit 4-pulse codeword, places pulses on the D4i60 grid, and convolves
  them with the perceptual noise filter F[] — first pulse scaled by sqrt(2)
  (Q11 2896), the +,-,+,- pattern, whole-codeword sign flip and 0/1 pulse shift
  (mirrors `D_D4i60`).
- **Extra fixed-point operators** (`ops_ext.go`): no-shift long multiply/
  accumulate (`lMult0`/`lMac0`) and shift-and-accumulate helpers
  (`loadSh`/`addSh`/`subSh`/`storeHi`), composed from the base operators so
  saturation matches the reference.

The interpolation taps and the sqrt(2) pulse gain are numeric constants defined
by EN 300 395-2 (provenance/licensing recorded in the package doc, as with the
LSP tables).

## Test plan

- [x] `make vet test` green locally (`go test ./internal/voice/acelp/...`,
      `go vet`, `gofmt -l` all clean)
- [ ] `make integration` — n/a (no daemon/DSP path touched)
- [x] Added tests: integer-lag copy; DC-gain preservation through both
      fractional interpolators (validates the tap tables without re-deriving
      them); pulse-position decoding; and an impulse-response check that pins
      the exact pulse amplitudes, signs, and shift behaviour
- [ ] Smoke-tested against real hardware — n/a (codec-internal, no live decode
      wired yet)

## Breaking changes

none — new package-internal code, not yet registered as a vocoder or wired in.

## Docs / CHANGELOG

- [ ] n/a — not user-visible yet; the ACELP posture note in `docs/vocoders.md`
      lands with the vocoder registration (Stage E).

## Linked issues

n/a — part of the ongoing TETRA voice work tracked in this branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GVoGbXXCo3doUafoQTf3mE)_