### PR TITLE
feat(tetra): ACELP fixed-point log2/pow2 math kernel

### DIFF
--- a/internal/voice/acelp/mathfp.go
+++ b/internal/voice/acelp/mathfp.go
@@ -1,0 +1,90 @@
+package acelp
+
+// Fixed-point log2 / pow2 / double-precision-split helpers for the TETRA ACELP
+// decoder's gain-dequantisation energy arithmetic (EN 300 395-2). log2 and
+// pow2 are piecewise-linear table interpolations over a 33-point grid; the
+// decoder works in the log-energy domain, so a gain is recovered as
+// pow2(energy - reference_energy). L_extract splits a 32-bit value into a
+// high/low fixed-point pair.
+//
+// These are the standard ITU-T fixed-point kernels (the TETRA reference reuses
+// them, with log2.tab/pow2.tab identical to the G.729 tables). Clean-room from
+// the algorithm (normalise, table lookup, linear interpolation); the 33-entry
+// tables are numeric constants (see package doc for provenance).
+
+// tabLog2[i] = round(2^15 * log2(1 + i/32)), i in [0,32].
+var tabLog2 = [33]int16{
+	0, 1455, 2866, 4236, 5568, 6863, 8124, 9352, 10549, 11716,
+	12855, 13967, 15054, 16117, 17156, 18172, 19167, 20142, 21097, 22033,
+	22951, 23852, 24735, 25603, 26455, 27291, 28113, 28922, 29716, 30497,
+	31266, 32023, 32767,
+}
+
+// tabPow2[i] = round(2^14 * 2^(i/32)), i in [0,32].
+var tabPow2 = [33]int16{
+	16384, 16743, 17109, 17484, 17867, 18258, 18658, 19066, 19484, 19911,
+	20347, 20792, 21247, 21713, 22188, 22674, 23170, 23678, 24196, 24726,
+	25268, 25821, 26386, 26964, 27554, 28158, 28774, 29405, 30048, 30706,
+	31379, 32066, 32767,
+}
+
+// log2fp computes log2(L_x) as an integer exponent and a Q15 fraction, so that
+// L_x ≈ 2^(exponent + fraction/2^15). Returns (0,0) for L_x <= 0.
+func log2fp(x int32) (exponent, fraction int16) {
+	if x <= 0 {
+		return 0, 0
+	}
+	exp := normL(x)
+	x = lShl(x, exp)
+	exponent = subOp(30, exp)
+
+	x = lShr(x, 9)
+	i := extractH(x) // integer table index in [32,63]
+	x = lShr(x, 1)
+	a := extractL(x) & 0x7fff // interpolation fraction
+	i = subOp(i, 32)
+
+	L := lDepositH(tabLog2[i])
+	tmp := subOp(tabLog2[i], tabLog2[i+1])
+	L = lMsu(L, tmp, a)
+	fraction = extractH(L)
+	return exponent, fraction
+}
+
+// pow2fp computes 2^(exponent + fraction/2^15) as a Q0..Q31 value (the shift is
+// implied by exponent), inverse of log2fp. Mirrors the standard Pow2.
+func pow2fp(exponent, fraction int16) int32 {
+	L := lMult(fraction, 32)
+	i := extractH(L) // integer table index in [0,31]
+	L = lShr(L, 1)
+	a := extractL(L) & 0x7fff
+
+	L = lDepositH(tabPow2[i])
+	tmp := subOp(tabPow2[i], tabPow2[i+1])
+	L = lMsu(L, tmp, a)
+
+	exp := subOp(30, exponent)
+	return lShrR(L, exp)
+}
+
+// lExtract splits a 32-bit value into a high word and a low word in the
+// double-precision format used by the LPC routines: hi = L>>16, and lo carries
+// the residual so that L ≈ (hi<<16) + (lo<<1). Mirrors L_Extract.
+func lExtract(l int32) (hi, lo int16) {
+	hi = extractH(l)
+	lo = extractL(lMsu(lShr(l, 1), hi, 16384))
+	return hi, lo
+}
+
+// lComp reconstructs a 32-bit value from the double-precision (hi,lo) pair,
+// inverse of lExtract. Mirrors L_Comp.
+func lComp(hi, lo int16) int32 {
+	return lMac(lDepositH(hi), lo, 1)
+}
+
+// load_sh16 / add_sh16 / sub_sh16 are the shift-by-16 specialisations of the
+// shift-accumulate operators (Load_sh16/add_sh16/sub_sh16): they place a 16-bit
+// value in the high half of the accumulator.
+func loadSh16(v int16) int32           { return lDepositH(v) }
+func addSh16(acc int32, v int16) int32 { return lAdd(acc, lDepositH(v)) }
+func subSh16(acc int32, v int16) int32 { return lSub(acc, lDepositH(v)) }

--- a/internal/voice/acelp/mathfp_test.go
+++ b/internal/voice/acelp/mathfp_test.go
@@ -1,0 +1,92 @@
+package acelp
+
+import (
+	"math"
+	"testing"
+)
+
+// TestLog2Known checks log2fp against exact powers of two: log2(2^k) must have
+// integer exponent k and ~zero fraction.
+func TestLog2Known(t *testing.T) {
+	for _, k := range []int16{1, 5, 10, 15, 20, 25, 30} {
+		exp, frac := log2fp(int32(1) << uint(k))
+		if exp != k {
+			t.Errorf("log2(2^%d): exponent %d, want %d", k, exp, k)
+		}
+		if frac < -4 || frac > 4 {
+			t.Errorf("log2(2^%d): fraction %d, want ~0", k, frac)
+		}
+	}
+	if e, f := log2fp(0); e != 0 || f != 0 {
+		t.Errorf("log2(0) = %d,%d want 0,0", e, f)
+	}
+}
+
+// TestLog2Value checks the numeric accuracy of log2fp against math.Log2 for a
+// spread of magnitudes.
+func TestLog2Value(t *testing.T) {
+	for _, x := range []int32{3, 100, 1000, 12345, 1 << 20, 3 << 24, 0x7fffffff} {
+		exp, frac := log2fp(x)
+		got := float64(exp) + float64(frac)/32768.0
+		want := math.Log2(float64(x))
+		if math.Abs(got-want) > 0.01 {
+			t.Errorf("log2fp(%d) = %.4f, want %.4f", x, got, want)
+		}
+	}
+}
+
+// TestPow2Log2RoundTrip checks that pow2fp inverts log2fp within a small
+// relative error over a range of inputs.
+func TestPow2LogRoundTrip(t *testing.T) {
+	for _, x := range []int32{5, 97, 1000, 50000, 1 << 18, 1 << 24, 1 << 28} {
+		exp, frac := log2fp(x)
+		got := pow2fp(exp, frac)
+		rel := math.Abs(float64(got-x)) / float64(x)
+		if rel > 0.001 {
+			t.Errorf("pow2(log2(%d)) = %d, rel err %.4f", x, got, rel)
+		}
+	}
+}
+
+// TestPow2Value checks pow2fp for known fractional exponents. pow2fp(k, 0) with
+// exponent k returns 2^k as an integer.
+func TestPow2Value(t *testing.T) {
+	for _, k := range []int16{4, 8, 12, 16, 20} {
+		got := pow2fp(k, 0)
+		want := int32(1) << uint(k)
+		if d := got - want; d < -1 || d > 1 {
+			t.Errorf("pow2(%d,0) = %d, want %d", k, got, want)
+		}
+	}
+	// half-fraction: 2^(10 + 0.5) = 2^10 * sqrt(2)
+	got := pow2fp(10, 1<<14) // 0.5 in Q15
+	want := int32(math.Round(1024 * math.Sqrt2))
+	if d := got - want; d < -2 || d > 2 {
+		t.Errorf("pow2(10, .5) = %d, want ~%d", got, want)
+	}
+}
+
+// TestLExtractComp checks the double-precision split/recombine round-trips
+// within the 1-LSB precision of the format.
+func TestLExtractComp(t *testing.T) {
+	for _, l := range []int32{0, 1, 2, 0x12345678, -0x12345678, maxWord32, minWord32 + 2} {
+		hi, lo := lExtract(l)
+		got := lComp(hi, lo)
+		if d := got - l; d < -2 || d > 2 {
+			t.Errorf("lComp(lExtract(%#x)) = %#x, off by %d", l, got, d)
+		}
+	}
+}
+
+// TestShift16Ops checks the shift-by-16 accumulate helpers.
+func TestShift16Ops(t *testing.T) {
+	if loadSh16(3) != 3<<16 {
+		t.Errorf("loadSh16(3) = %#x, want %#x", loadSh16(3), 3<<16)
+	}
+	if addSh16(0x10000, 2) != 0x30000 {
+		t.Errorf("addSh16 failed: %#x", addSh16(0x10000, 2))
+	}
+	if subSh16(0x30000, 1) != 0x20000 {
+		t.Errorf("subSh16 failed: %#x", subSh16(0x30000, 1))
+	}
+}


### PR DESCRIPTION
## Summary

Fourth Stage-D increment for the clean-room TETRA ACELP speech decoder
(`internal/voice/acelp/`). Adds the fixed-point math kernel the gain
dequantiser operates in: the decoder recovers pitch/code gains in the
log-energy domain (gain = `pow2(energy − reference_energy)`), so it needs
fixed-point log2 and 2ˣ plus the double-precision split used by the LPC energy
arithmetic. Self-contained; wired into nothing yet.

## Changes

- **`log2fp` / `pow2fp`** (`mathfp.go`): piecewise-linear table interpolations
  of log₂ and 2ˣ over a 33-point grid (EN 300 395-2 energy arithmetic).
- **`lExtract` / `lComp`**: the double-precision high/low split and recombine
  used by the LPC routines.
- **`loadSh16` / `addSh16` / `subSh16`**: shift-by-16 accumulate
  specialisations.

`log2.tab`/`pow2.tab` are the standard ITU-T fixed-point tables (byte-identical
to the widely-published G.729 tables); implemented from the algorithm
(normalise → table lookup → linear interpolation), not transcribed from
reference C. Provenance/licensing recorded in the package doc.

## Test plan

- [x] `make vet test` green locally (`go test ./internal/voice/acelp/...`,
      `go vet`, `gofmt -l` all clean)
- [ ] `make integration` — n/a (no daemon/DSP path touched)
- [x] Added tests: log₂ of exact powers of two; log₂ numeric accuracy vs
      `math.Log2`; `pow2∘log2` round-trip (<0.1% error); `pow2` of known
      fractional exponents (incl. 2^0.5 = √2); and the double-precision
      split/recombine round-trip
- [ ] Smoke-tested against real hardware — n/a (codec-internal)

## Breaking changes

none — new package-internal code.

## Docs / CHANGELOG

- [ ] n/a — not user-visible yet; the ACELP posture note in `docs/vocoders.md`
      lands with the vocoder registration (Stage E).

## Linked issues

n/a — part of the ongoing TETRA voice work tracked in this branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GVoGbXXCo3doUafoQTf3mE)_