### PR TITLE
feat(tetra): ACELP LSP-to-LPC conversion + bandwidth expansion

### DIFF
--- a/internal/voice/acelp/lpc.go
+++ b/internal/voice/acelp/lpc.go
@@ -1,0 +1,120 @@
+package acelp
+
+// LSP → LPC conversion and spectral (bandwidth) expansion for the TETRA ACELP
+// decoder, ETSI EN 300 395-2. Once the frame's 10 line spectral pairs are
+// dequantised (in the cosine domain), the decoder converts them to LPC filter
+// coefficients A(z), interpolating across the four subframes, and derives the
+// bandwidth-expanded weighting filters used to build the perceptual noise
+// filter. Clean-room ports of the reference Fac_Pond / Get_Lsp_Pol / Lsp_Az /
+// Int_Lpc4 / Pond_Ai.
+
+// mpyMix multiplies a double-precision (hi,lo) value by a 16-bit n, in DPF
+// (Mpy_32_16): result ≈ (hi<<16 + lo<<1) * n >> 15.
+func mpyMix(hi, lo, n int16) int32 {
+	L := lMult(hi, n)
+	L = lMac(L, mult(lo, n), 1)
+	return L
+}
+
+// facPond builds the spectral-expansion factor vector for a bandwidth-expansion
+// coefficient gamma (Q15): fac[i] = gamma^(i+1). Mirrors Fac_Pond (length p).
+func facPond(gamma int16) [lpcOrder]int16 {
+	var fac [lpcOrder]int16
+	fac[0] = gamma
+	for i := 1; i < lpcOrder; i++ {
+		fac[i] = etsiRound(lMult(fac[i-1], gamma))
+	}
+	return fac
+}
+
+// getLspPol builds the (half) LSP polynomial F1(z) or F2(z) from five
+// cosine-domain LSPs read with stride 2 from lsp (Q24 coefficients f[0..5]).
+// Mirrors Get_Lsp_Pol. lsp must have at least 9 elements from the base.
+func getLspPol(lsp []int16) [6]int32 {
+	var f [6]int32
+	fi := 0
+	li := 0
+
+	f[fi] = loadSh(4096, 12) // f[0] = 1.0 in Q24
+	fi++
+	f[fi] = 0
+	f[fi] = subSh(f[fi], lsp[li], 10) // f[1] = -2*lsp[0]
+	fi++
+	li += 2
+
+	for i := 2; i <= 5; i++ {
+		f[fi] = f[fi-2]
+		for j := 1; j < i; j++ {
+			hi, lo := lExtract(f[fi-1])
+			t0 := mpyMix(hi, lo, lsp[li])
+			t0 = lShl(t0, 1)
+			f[fi] = lAdd(f[fi], f[fi-2])
+			f[fi] = lSub(f[fi], t0)
+			fi--
+		}
+		f[fi] = subSh(f[fi], lsp[li], 10)
+		fi += i
+		li += 2
+	}
+	return f
+}
+
+// lspAz converts 10 cosine-domain LSPs to 11 LPC coefficients a[0..10] in Q12
+// (a[0] = 4096 = 1.0). Mirrors Lsp_Az.
+func lspAz(lsp []int16) [lpcOrder + 1]int16 {
+	var a [lpcOrder + 1]int16
+	f1 := getLspPol(lsp[0:]) // even-indexed LSPs
+	f2 := getLspPol(lsp[1:]) // odd-indexed LSPs
+
+	for i := 5; i > 0; i-- {
+		f1[i] = lAdd(f1[i], f1[i-1]) // F1 *= (1 + z^-1)
+		f2[i] = lSub(f2[i], f2[i-1]) // F2 *= (1 - z^-1)
+	}
+
+	a[0] = 4096
+	for i, j := 1, 10; i <= 5; i, j = i+1, j-1 {
+		t0 := lAdd(f1[i], f2[i])
+		a[i] = extractL(lShrR(t0, 13)) // Q24 -> Q12, *0.5
+		t0 = lSub(f1[i], f2[i])
+		a[j] = extractL(lShrR(t0, 13))
+	}
+	return a
+}
+
+// intLpc4 interpolates the LPC coefficients for the four subframes from the
+// previous and current frame's LSPs, converting each interpolated LSP set to
+// LPC via lspAz. Returns the 44 coefficients (4 × 11) laid out subframe by
+// subframe. Interpolation weights (old,new) are (3/4,1/4),(1/2,1/2),(1/4,3/4),
+// (0,1). Mirrors Int_Lpc4.
+func intLpc4(lspOld, lspNew [lpcOrder]int16) [(lpcOrder + 1) * numSubfr]int16 {
+	var a [(lpcOrder + 1) * numSubfr]int16
+	facNew := int16(8192)  // 1/4 in Q15
+	facOld := int16(24576) // 3/4 in Q15
+	var lsp [lpcOrder]int16
+
+	for j := 0; j < 33; j += 11 {
+		for i := 0; i < lpcOrder; i++ {
+			t0 := lMult(lspOld[i], facOld)
+			t0 = lMac(t0, lspNew[i], facNew)
+			lsp[i] = extractH(t0)
+		}
+		sub := lspAz(lsp[:])
+		copy(a[j:j+lpcOrder+1], sub[:])
+		facOld = subOp(facOld, 8192)
+		facNew = addOp(facNew, 8192)
+	}
+	last := lspAz(lspNew[:])
+	copy(a[33:33+lpcOrder+1], last[:])
+	return a
+}
+
+// pondAi applies spectral (bandwidth) expansion to LPC coefficients:
+// aExp[i] = a[i] * fac[i-1]. aExp[0] = a[0]. Mirrors Pond_Ai.
+func pondAi(a []int16, fac [lpcOrder]int16) [lpcOrder + 1]int16 {
+	var aExp [lpcOrder + 1]int16
+	aExp[0] = a[0]
+	for i := 1; i <= lpcOrder; i++ {
+		aExp[i] = etsiRound(lMult(a[i], fac[i-1]))
+	}
+	return aExp
+}

--- a/internal/voice/acelp/lpc_test.go
+++ b/internal/voice/acelp/lpc_test.go
@@ -1,0 +1,131 @@
+package acelp
+
+import (
+	"math"
+	"math/cmplx"
+	"testing"
+)
+
+// orderedLSPs is a valid strictly-decreasing cosine-domain LSP set (the
+// reference decoder's reset value).
+var orderedLSPs = [lpcOrder]int16{30000, 26000, 21000, 15000, 8000, 0, -8000, -15000, -21000, -26000}
+
+// evalPoly evaluates sum coef[m]*e^{-j m w} at frequency w.
+func evalPoly(coef []float64, w float64) complex128 {
+	var s complex128
+	for m, c := range coef {
+		s += complex(c, 0) * cmplx.Exp(complex(0, -float64(m)*w))
+	}
+	return s
+}
+
+// TestLspAzRootProperty is an independent correctness check of the LSP→LPC
+// conversion: reconstruct A(z) from the LSPs, form the symmetric/antisymmetric
+// LSP polynomials F1(z)=A(z)+z^-(p+1)A(1/z) and F2(z)=A(z)-z^-(p+1)A(1/z), and
+// verify that every LSP frequency ω_i = acos(lsp_i) is a root of one of them
+// (min(|F1|,|F2|) ≈ 0). This validates the algorithm without re-deriving it.
+func TestLspAzRootProperty(t *testing.T) {
+	a := lspAz(orderedLSPs[:])
+
+	// af[0..10] = a[i]/4096 (Q12 -> float), af[11] = 0.
+	af := make([]float64, 12)
+	for i := 0; i <= lpcOrder; i++ {
+		af[i] = float64(a[i]) / 4096.0
+	}
+	// c(z) = z^-(p+1) A(1/z): c[m] = af[11-m], m=1..11.
+	f1 := make([]float64, 12)
+	f2 := make([]float64, 12)
+	for m := 0; m <= 11; m++ {
+		c := 0.0
+		if m >= 1 {
+			c = af[11-m]
+		}
+		f1[m] = af[m] + c
+		f2[m] = af[m] - c
+	}
+
+	for i, q := range orderedLSPs {
+		w := math.Acos(float64(q) / 32768.0)
+		m1 := cmplx.Abs(evalPoly(f1, w))
+		m2 := cmplx.Abs(evalPoly(f2, w))
+		if min := math.Min(m1, m2); min > 0.02 {
+			t.Errorf("LSP %d (ω=%.3f): min(|F1|,|F2|)=%.4f, not a root", i, w, min)
+		}
+	}
+}
+
+// TestLspAzHeader checks the fixed leading coefficient.
+func TestLspAzHeader(t *testing.T) {
+	a := lspAz(orderedLSPs[:])
+	if a[0] != 4096 {
+		t.Errorf("a[0] = %d, want 4096 (1.0 in Q12)", a[0])
+	}
+}
+
+// TestFacPond checks the spectral-expansion factors are gamma^(i+1).
+func TestFacPond(t *testing.T) {
+	const gamma = 24576 // 0.75 in Q15
+	fac := facPond(gamma)
+	for i := 0; i < lpcOrder; i++ {
+		want := math.Pow(0.75, float64(i+1))
+		got := float64(fac[i]) / 32768.0
+		if math.Abs(got-want) > 0.001 {
+			t.Errorf("fac[%d] = %.4f, want %.4f", i, got, want)
+		}
+	}
+}
+
+// TestPondAi checks bandwidth-expanded coefficients equal a[i]*fac[i-1].
+func TestPondAi(t *testing.T) {
+	a := lspAz(orderedLSPs[:])
+	fac := facPond(24576)
+	aExp := pondAi(a[:], fac)
+	if aExp[0] != a[0] {
+		t.Errorf("aExp[0] = %d, want %d", aExp[0], a[0])
+	}
+	for i := 1; i <= lpcOrder; i++ {
+		want := etsiRound(lMult(a[i], fac[i-1]))
+		if aExp[i] != want {
+			t.Errorf("aExp[%d] = %d, want %d", i, aExp[i], want)
+		}
+		// magnitude should shrink (expansion pulls poles inward)
+		if absS(aExp[i]) > absS(a[i]) {
+			t.Errorf("aExp[%d]=%d larger than a[%d]=%d", i, aExp[i], i, a[i])
+		}
+	}
+}
+
+// TestIntLpc4 checks the four-subframe interpolation endpoints: the last
+// subframe uses the new LSPs exactly, and all four coefficient sets start with
+// 4096.
+func TestIntLpc4(t *testing.T) {
+	lspOld := orderedLSPs
+	lspNew := [lpcOrder]int16{31000, 25000, 20000, 14000, 7000, -1000, -9000, -16000, -22000, -27000}
+	a := intLpc4(lspOld, lspNew)
+
+	last := lspAz(lspNew[:])
+	for i := 0; i <= lpcOrder; i++ {
+		if a[33+i] != last[i] {
+			t.Errorf("last subframe a[33+%d]=%d, want %d (lspAz(new))", i, a[33+i], last[i])
+		}
+	}
+	for s := 0; s < numSubfr; s++ {
+		if a[s*(lpcOrder+1)] != 4096 {
+			t.Errorf("subframe %d: leading coef %d, want 4096", s, a[s*(lpcOrder+1)])
+		}
+	}
+
+	// First subframe should equal lspAz of the 3/4-old + 1/4-new interpolation.
+	var lsp0 [lpcOrder]int16
+	for i := 0; i < lpcOrder; i++ {
+		t0 := lMult(lspOld[i], 24576)
+		t0 = lMac(t0, lspNew[i], 8192)
+		lsp0[i] = extractH(t0)
+	}
+	first := lspAz(lsp0[:])
+	for i := 0; i <= lpcOrder; i++ {
+		if a[i] != first[i] {
+			t.Errorf("first subframe a[%d]=%d, want %d", i, a[i], first[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fifth Stage-D increment for the clean-room TETRA ACELP speech decoder
(`internal/voice/acelp/`). Converts the frame's dequantised line spectral pairs
(from the LSP dequantiser, #959) into the per-subframe LPC synthesis filter
A(z) and its bandwidth-expanded weighting variants — the coefficients the
synthesis filter and the perceptual noise filter both run on. Codec-internal;
not wired in yet.

## Changes

- **`getLspPol` / `lspAz`** (`lpc.go`): build the F1/F2 LSP polynomials from the
  cosine-domain LSPs and combine them into 11 LPC coefficients A(z) in Q12
  (mirrors `Get_Lsp_Pol` / `Lsp_Az`).
- **`intLpc4`**: interpolate A(z) across the four subframes from the previous
  and current frame's LSPs — weights (old,new) = (3/4,1/4), (1/2,1/2),
  (1/4,3/4), (0,1) (mirrors `Int_Lpc4`).
- **`facPond` / `pondAi`**: spectral (bandwidth) expansion —
  `fac[i]=gamma^(i+1)`, `aExp[i]=a[i]*fac[i-1]` — for the perceptual noise
  filter (mirrors `Fac_Pond` / `Pond_Ai`).
- **`mpyMix`**: the DPF (double-precision-format) multiply the polynomial
  recursion needs.

## Test plan

- [x] `make vet test` green locally (`go test ./internal/voice/acelp/...`,
      `go vet`, `gofmt -l` all clean)
- [ ] `make integration` — n/a (no daemon/DSP path touched)
- [x] Added tests, notably an **independent** correctness check: reconstruct
      A(z), form the symmetric/antisymmetric LSP polynomials
      F1=A(z)+z⁻⁽ᵖ⁺¹⁾A(1/z) and F2=A(z)−z⁻⁽ᵖ⁺¹⁾A(1/z), and verify every LSP
      frequency ωᵢ=acos(lspᵢ) is a root of one of them — validates the
      conversion without re-deriving it. Plus γⁿ expansion factors, the
      `aExp=a·fac` relation with pole-inward magnitude shrink, and `intLpc4`
      endpoint interpolation.
- [ ] Smoke-tested against real hardware — n/a (codec-internal)

## Breaking changes

none — new package-internal code.

## Docs / CHANGELOG

- [ ] n/a — not user-visible yet; the ACELP posture note in `docs/vocoders.md`
      lands with the vocoder registration (Stage E).

## Linked issues

n/a — part of the ongoing TETRA voice work tracked in this branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GVoGbXXCo3doUafoQTf3mE)_