### PR TITLE
feat(tetra): ACELP LPC synthesis filter + impulse-response energy

### DIFF
--- a/internal/voice/acelp/syn.go
+++ b/internal/voice/acelp/syn.go
@@ -1,0 +1,57 @@
+package acelp
+
+// LPC synthesis filter and impulse-response energy for the TETRA ACELP decoder,
+// ETSI EN 300 395-2. synFilt runs 1/A(z): it turns an excitation (or any input)
+// into the synthesised signal, carrying the last p output samples as filter
+// memory between subframes. It is used both to build the perceptual noise
+// filter F[] and to produce the final speech samples. lpcGain returns the energy
+// of the 1/A(z) impulse response, which the gain dequantiser uses to normalise
+// the pitch/code energies. Clean-room ports of Syn_Filt / Lpc_Gain.
+
+const lpcGainLen = 60 // impulse-response length for the LPC gain (llg)
+
+// lMsu0 is the no-shift multiply-subtract (L_msu0): acc - a*b.
+func lMsu0(acc int32, a, b int16) int32 { return lSub(acc, lMult0(a, b)) }
+
+// synFilt applies the LPC synthesis filter 1/A(z) to x[0:lg], writing y[0:lg].
+// a holds the p+1 Q12 coefficients (a[0]=4096). mem carries the p previous
+// output samples (updated in place when update is true). x and y may alias the
+// same slice. Mirrors Syn_Filt.
+func synFilt(a, x, y []int16, lg int, mem []int16, update bool) {
+	tmp := make([]int16, lg+lpcOrder)
+	copy(tmp[:lpcOrder], mem[:lpcOrder])
+
+	for i := 0; i < lg; i++ {
+		s := loadSh(x[i], 12) // a[] is Q12
+		yi := lpcOrder + i
+		for j := 1; j <= lpcOrder; j++ {
+			s = lMsu0(s, a[j], tmp[yi-j])
+		}
+		s = addSh(s, 1, 11) // rounding
+		tmp[yi] = extractH(lShl(s, 4))
+	}
+
+	for i := 0; i < lg; i++ {
+		y[i] = tmp[i+lpcOrder]
+	}
+	if update {
+		for i := 0; i < lpcOrder; i++ {
+			mem[i] = y[lg-lpcOrder+i]
+		}
+	}
+}
+
+// lpcGain computes the energy of the impulse response of 1/A(z) over 60 samples
+// (Q20). Mirrors Lpc_Gain. a holds the p+1 Q12 LPC coefficients.
+func lpcGain(a []int16) int32 {
+	h := make([]int16, lpcGainLen)
+	h[0] = 1024 // 1.0 in Q10
+	mem := make([]int16, lpcOrder)
+	synFilt(a, h, h, lpcGainLen, mem, false)
+
+	var ener int32
+	for i := 0; i < lpcGainLen; i++ {
+		ener = lMac0(ener, h[i], h[i])
+	}
+	return ener
+}

--- a/internal/voice/acelp/syn_test.go
+++ b/internal/voice/acelp/syn_test.go
@@ -1,0 +1,104 @@
+package acelp
+
+import "testing"
+
+// unitA is the trivial LPC filter A(z)=1 (1/A(z) is identity).
+func unitA() []int16 {
+	a := make([]int16, lpcOrder+1)
+	a[0] = 4096
+	return a
+}
+
+// synFiltFloat is an independent float reference of the synthesis recursion
+// y[i] = x[i] - sum_{j=1}^{p} (a[j]/4096) * y[i-j], with zero initial memory.
+func synFiltFloat(a []int16, x []int16) []float64 {
+	y := make([]float64, len(x))
+	for i := range x {
+		s := float64(x[i])
+		for j := 1; j <= lpcOrder; j++ {
+			if i-j >= 0 {
+				s -= float64(a[j]) / 4096.0 * y[i-j]
+			}
+		}
+		y[i] = s
+	}
+	return y
+}
+
+// TestSynFiltIdentity checks 1/A(z) with A(z)=1 passes the input through.
+func TestSynFiltIdentity(t *testing.T) {
+	x := []int16{100, -200, 300, -50, 1234, -1000, 7, 0, -9, 500}
+	y := make([]int16, len(x))
+	mem := make([]int16, lpcOrder)
+	synFilt(unitA(), x, y, len(x), mem, false)
+	for i := range x {
+		if y[i] != x[i] {
+			t.Errorf("identity: y[%d]=%d, want %d", i, y[i], x[i])
+		}
+	}
+}
+
+// TestSynFiltVsFloat checks the fixed-point synthesis filter tracks the float
+// recursion within a small tolerance for a real (stable) LPC filter.
+func TestSynFiltVsFloat(t *testing.T) {
+	a := lspAz(orderedLSPs[:]) // a real, stable A(z)
+	x := make([]int16, 60)
+	for i := range x {
+		x[i] = int16(((i*37+11)%400 - 200)) // deterministic pseudo-signal
+	}
+	y := make([]int16, len(x))
+	mem := make([]int16, lpcOrder)
+	synFilt(a[:], x, y, len(x), mem, false)
+
+	ref := synFiltFloat(a[:], x)
+	for i := range x {
+		if d := float64(y[i]) - ref[i]; d < -8 || d > 8 {
+			t.Errorf("y[%d]=%d, float ref %.1f (diff %.1f)", i, y[i], ref[i], d)
+		}
+	}
+}
+
+// TestSynFiltMemoryContinuity checks that filtering in two calls with memory
+// update matches filtering the whole signal in one call.
+func TestSynFiltMemoryContinuity(t *testing.T) {
+	a := lspAz(orderedLSPs[:])
+	x := make([]int16, 40)
+	for i := range x {
+		x[i] = int16((i*13+5)%200 - 100)
+	}
+
+	whole := make([]int16, len(x))
+	mem := make([]int16, lpcOrder)
+	synFilt(a[:], x, whole, len(x), mem, false)
+
+	split := make([]int16, len(x))
+	mem2 := make([]int16, lpcOrder)
+	synFilt(a[:], x[:20], split[:20], 20, mem2, true)
+	synFilt(a[:], x[20:], split[20:], 20, mem2, true)
+
+	for i := range x {
+		if whole[i] != split[i] {
+			t.Errorf("continuity mismatch at %d: whole %d, split %d", i, whole[i], split[i])
+		}
+	}
+}
+
+// TestLpcGainUnit checks the impulse-response energy for A(z)=1: the response is
+// just the input impulse (1024 in Q10), so energy = 1024^2.
+func TestLpcGainUnit(t *testing.T) {
+	got := lpcGain(unitA())
+	want := int32(1024 * 1024)
+	if got != want {
+		t.Errorf("lpcGain(unit) = %d, want %d", got, want)
+	}
+}
+
+// TestLpcGainResonant checks a real LPC filter has larger impulse-response
+// energy than the flat filter (resonances amplify).
+func TestLpcGainResonant(t *testing.T) {
+	a := lspAz(orderedLSPs[:])
+	got := lpcGain(a[:])
+	if got <= 1024*1024 {
+		t.Errorf("resonant lpcGain = %d, expected > %d", got, 1024*1024)
+	}
+}


### PR DESCRIPTION
## Summary

Sixth Stage-D increment for the clean-room TETRA ACELP speech decoder
(`internal/voice/acelp/`). Adds the LPC synthesis filter — the block that turns
an excitation into synthesised speech — and the impulse-response energy the gain
dequantiser needs. This unblocks the gain dequantiser (`Dec_Ener`, next), whose
last dependency was `Lpc_Gain`. Codec-internal; not wired in yet.

## Changes

- **`synFilt`** (`syn.go`): the synthesis filter 1/A(z), carrying the last p
  output samples as filter memory between subframes. Used both to build the
  perceptual noise filter F[] and to produce the final speech samples (mirrors
  `Syn_Filt`).
- **`lpcGain`**: energy of the 60-sample 1/A(z) impulse response (Q20), the
  normalising term the energy dequantiser uses (mirrors `Lpc_Gain`).
- **`lMsu0`**: the no-shift multiply-subtract the filter recursion uses.

## Test plan

- [x] `make vet test` green locally (`go test ./internal/voice/acelp/...`,
      `go vet`, `gofmt -l` all clean)
- [ ] `make integration` — n/a (no daemon/DSP path touched)
- [x] Added tests, independent of the reference: identity pass-through for
      A(z)=1; agreement with a float reference of the synthesis recursion for a
      real stable A(z); memory continuity (two calls carrying state == one
      whole-signal call); and impulse-response energy (exact 1024² for the flat
      filter, larger for a resonant one)
- [ ] Smoke-tested against real hardware — n/a (codec-internal)

## Breaking changes

none — new package-internal code.

## Docs / CHANGELOG

- [ ] n/a — not user-visible yet; the ACELP posture note in `docs/vocoders.md`
      lands with the vocoder registration (Stage E).

## Linked issues

n/a — part of the ongoing TETRA voice work tracked in this branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GVoGbXXCo3doUafoQTf3mE)_