### PR TITLE
feat(tetra): wire ACELP vocoder — TETRA voice to audible PCM (Stage E)

### DIFF
--- a/cmd/gophertrunk/main.go
+++ b/cmd/gophertrunk/main.go
@@ -39,6 +39,11 @@ import (
 	// PR-E wires the shared mbe synthesis pipeline. See
 	// docs/vocoders.md for the AMBE+2 patent posture.
 	_ "github.com/MattCheramie/GopherTrunk/internal/voice/ambe2"
+
+	// Blank import: pulls in the pure-Go TETRA ACELP decoder so the daemon
+	// registers the "tetra-acelp" vocoder name (TETRA full-rate voice).
+	// Clean-room from ETSI EN 300 395-2; see docs/vocoders.md.
+	_ "github.com/MattCheramie/GopherTrunk/internal/voice/acelp"
 )
 
 func main() {

--- a/docs/vocoders.md
+++ b/docs/vocoders.md
@@ -7,8 +7,8 @@ nav_group: Reference
 
 # Vocoders
 
-Digital trunked-radio voice traffic is carried by one of two
-DVSI-derived vocoders:
+Digital trunked-radio voice traffic is carried by one of three
+vocoders — two DVSI-derived, plus TETRA's own ACELP:
 
 - **IMBE** — used by P25 Phase 1 LDU1/LDU2 voice frames. Core US patents
   (filed early-to-mid-1990s, 20-year term) have **expired**. The
@@ -20,6 +20,12 @@ DVSI-derived vocoders:
   implementations (e.g. `mbelib`) implement the algorithm; the *code*
   is permissively licensed (mbelib is ISC) but the *patents* are the
   user's risk to evaluate.
+- **TETRA ACELP** — the full-rate speech codec used by TETRA voice
+  (ETSI EN 300 395-2). This is **not** a DVSI/MBE-family vocoder; it is
+  a conventional ACELP codec (LSP-quantised LPC + adaptive/algebraic
+  codebooks), specified openly by ETSI. GopherTrunk ships a pure-Go
+  decoder at `internal/voice/acelp`. See the TETRA ACELP section below
+  for the clean-room / patent posture.
 
 Re-implementing AMBE+2 in pure Go does not change the patent posture —
 the algorithm itself is what the patents cover, regardless of
@@ -275,6 +281,48 @@ or document section in the PR) can land a per-vendor preset under
 worth checking: `szechyjs/mbelib`, DSDcc, DSD-FME, OP25 — search
 the tone-decode paths for the b1 index range.
 
+## TETRA ACELP (`internal/voice/acelp`)
+
+TETRA full-rate voice uses an ACELP speech codec specified openly in
+**ETSI EN 300 395-2** (13.167 kbit/s, 137-bit frames / 30 ms → 240
+samples at 8 kHz). GopherTrunk ships a **pure-Go, clean-room** decoder.
+
+**Chain.** A granted call's traffic bursts are recovered by the
+composer's TETRA voice chain, TCH/S channel-decoded (EN 300 395-2 §5.5:
+RCPC + interleave + class-2 CRC) into 137-bit speech frames, and rendered
+to PCM by the ACELP decoder registered as the `tetra-acelp` vocoder. The
+decoder is the usual ACELP pipeline: parameter unpack → LSP split-VQ
+dequantisation → per-subframe adaptive (pitch) + algebraic (4-pulse)
+codebooks → log-energy gain dequantisation → LSP→LPC conversion →
+synthesis filter. Bit-exact fixed-point arithmetic (ITU-T-style 16/32-bit
+saturating operators) underlies every block.
+
+**Slot isolation.** The traffic extractor emits a burst for every TDMA
+timeslot on the carrier. The TCH/S class-2 CRC is used as the slot filter:
+only the granted call's TCH/S speech bursts verify, so other slots'
+signalling bursts (and encrypted TEA1-4 traffic) are dropped. This cleanly
+separates a *single* active call; two concurrent TCH/S calls on the same
+carrier would still need TDMA frame-number demux (a follow-up).
+
+**Provenance / licensing.** The decoder was ported from the *algorithmic*
+description in EN 300 395-2 and the ITU-T fixed-point operator
+definitions; the fixed quantiser tables (LSP codebooks, energy codebook,
+interpolation filters) are numeric constants sourced from the ETSI
+reference codec (via `github.com/curlyboi/libtetradec`). ACELP's core
+algebraic-CELP patents (Sherbrooke/VoiceAge, filed late-1980s to
+mid-1990s, 20-year term) have **expired**, so ACELP is far less
+patent-encumbered than the DVSI/MBE family. As with IMBE/AMBE+2, the legal
+responsibility for operating the codec falls on the deployer, not the
+project; operators in licence-restrictive jurisdictions should evaluate
+with counsel. The decoder lives behind an explicit vocoder registration
+(`tetra-acelp`) so builds can omit it.
+
+**Validation.** Each block carries unit tests validated *independently*
+of the reference where possible (e.g. the LSP→LPC conversion is checked
+against the LSP root property; log2/pow2 against `math`; the synthesis
+filter against a float recursion). Bit-exact conformance against the ETSI
+clause-4 test sequences is the remaining validation step (see Future work).
+
 ## Future work
 
 - Absolute-level calibration thresholds documented; reference data
@@ -292,3 +340,8 @@ the tone-decode paths for the b1 index range.
   long-running archives.
 - Plain AMBE decoder for D-STAR voice (different algorithm from AMBE+2;
   same DVSI patent family).
+- TETRA ACELP: bit-exact conformance against the ETSI EN 300 395-2
+  clause-4 test sequences (add under `internal/voice/acelp/testdata/`),
+  and TDMA frame-number slot demux so concurrent same-carrier TCH/S
+  calls separate cleanly (today a single active call is isolated by the
+  TCH/S CRC).

--- a/internal/radio/tetra/tch.go
+++ b/internal/radio/tetra/tch.go
@@ -122,6 +122,22 @@ func EncodeTCHS(frameA, frameB []byte) []byte {
 	return framing.PackBitsMSB(tchInterleave(type3))
 }
 
+// TCHSpeechFrames decodes one descrambled 54-byte type-5 traffic frame and, if
+// its class-2 CRC verifies, returns the two 137-bit speech frames packed
+// MSB-first (18 bytes each) ready for the ACELP vocoder. A frame that fails the
+// CRC — a non-TCH/S burst (signalling on another timeslot) or a badly corrupted
+// slot — returns nil. On a single-call carrier this CRC gate is what isolates
+// the granted call's speech from the other TDMA timeslots' bursts: a burst that
+// is not TCH/S speech descrambles to essentially random class-2 bits and passes
+// the 8-bit CRC only ~1/256 of the time.
+func TCHSpeechFrames(traffic []byte) [][]byte {
+	frameA, frameB, crcOK, _, ok := DecodeTCHS(traffic)
+	if !ok || !crcOK {
+		return nil
+	}
+	return [][]byte{framing.PackBitsMSB(frameA), framing.PackBitsMSB(frameB)}
+}
+
 // DecodeTCHS decodes a 54-byte packed, descrambled type-5 (= type-4) traffic
 // frame into two 137-bit speech frames (bit-per-byte). crcOK reports whether
 // the class-2 CRC verified. errs is the Viterbi path metric (corrected bit

--- a/internal/radio/tetra/tch_test.go
+++ b/internal/radio/tetra/tch_test.go
@@ -76,3 +76,44 @@ func bitsEqual(x, y []byte) bool {
 	}
 	return true
 }
+
+// TestTCHSpeechFramesGate checks the CRC gate: a well-formed traffic frame
+// yields the two 137-bit speech frames packed to 18 bytes each, matching the
+// input; a random (non-TCH/S) frame is rejected (nil) by the class-2 CRC.
+func TestTCHSpeechFramesGate(t *testing.T) {
+	rng := rand.New(rand.NewSource(7))
+	a := randBits(rng, tchSpeechFrameBits)
+	b := randBits(rng, tchSpeechFrameBits)
+	traffic := EncodeTCHS(a, b)
+
+	frames := TCHSpeechFrames(traffic)
+	if len(frames) != 2 {
+		t.Fatalf("TCHSpeechFrames returned %d frames, want 2", len(frames))
+	}
+	wantBytes := (tchSpeechFrameBits + 7) / 8
+	for i, f := range frames {
+		if len(f) != wantBytes {
+			t.Errorf("frame %d = %d bytes, want %d", i, len(f), wantBytes)
+		}
+	}
+	if !bitsEqual(framing.UnpackBitsMSB(frames[0], tchSpeechFrameBits), a) {
+		t.Error("frame A not recovered from packed speech frame")
+	}
+	if !bitsEqual(framing.UnpackBitsMSB(frames[1], tchSpeechFrameBits), b) {
+		t.Error("frame B not recovered from packed speech frame")
+	}
+
+	// A random 54-byte frame is overwhelmingly not TCH/S: the CRC gate rejects
+	// it. Sweep a handful of seeds; none should pass.
+	passes := 0
+	for s := 0; s < 64; s++ {
+		junk := make([]byte, TrafficFrameBytes)
+		rng.Read(junk)
+		if TCHSpeechFrames(junk) != nil {
+			passes++
+		}
+	}
+	if passes > 1 { // ~1/256 chance each; >1 in 64 would be suspicious
+		t.Errorf("CRC gate let %d/64 random frames through", passes)
+	}
+}

--- a/internal/voice/acelp/vocoder.go
+++ b/internal/voice/acelp/vocoder.go
@@ -1,0 +1,50 @@
+package acelp
+
+import "github.com/MattCheramie/GopherTrunk/internal/voice"
+
+// VocoderName is the registry key for the TETRA ACELP decoder.
+const VocoderName = "tetra-acelp"
+
+// speechFrameBytes is the packed size of one 137-bit TCH/S speech frame
+// (MSB-first, last byte padded).
+const speechFrameBytes = (speechFrameBits + 7) / 8 // 18
+
+// vocoder adapts the ACELP Decoder to the voice.Vocoder interface. One input
+// frame is a packed 137-bit TCH/S speech frame; Decode returns 240 int16 PCM
+// samples at 8 kHz (30 ms). A frame shorter than 18 bytes is treated as an
+// erased frame (BFI), so the decoder runs its frame-repeat concealment.
+type vocoder struct {
+	d *Decoder
+}
+
+// NewVocoder returns a fresh TETRA ACELP vocoder.
+func NewVocoder() voice.Vocoder { return &vocoder{d: NewDecoder()} }
+
+func (v *vocoder) Name() string   { return VocoderName }
+func (v *vocoder) FrameSize() int { return speechFrameBytes }
+func (v *vocoder) Reset()         { v.d = NewDecoder() }
+func (v *vocoder) Close() error   { return nil }
+
+// Decode renders one packed 137-bit speech frame to 240 PCM samples.
+func (v *vocoder) Decode(frame []byte) ([]int16, error) {
+	bfi := len(frame) < speechFrameBytes
+	var bits []byte
+	if !bfi {
+		bits = make([]byte, speechFrameBits)
+		for i := 0; i < speechFrameBits; i++ {
+			if frame[i>>3]&(0x80>>uint(i&7)) != 0 {
+				bits[i] = 1
+			}
+		}
+	}
+	return v.d.Decode(bits, bfi), nil
+}
+
+// Compile-time check that vocoder satisfies voice.Vocoder.
+var _ voice.Vocoder = (*vocoder)(nil)
+
+func init() {
+	voice.DefaultRegistry.Register(VocoderName, func() (voice.Vocoder, error) {
+		return NewVocoder(), nil
+	})
+}

--- a/internal/voice/acelp/vocoder_test.go
+++ b/internal/voice/acelp/vocoder_test.go
@@ -1,0 +1,70 @@
+package acelp
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/voice"
+)
+
+// TestVocoderRegistered checks the tetra-acelp vocoder is in the default
+// registry and builds through it.
+func TestVocoderRegistered(t *testing.T) {
+	v, err := voice.DefaultRegistry.New(VocoderName)
+	if err != nil {
+		t.Fatalf("registry.New(%q): %v", VocoderName, err)
+	}
+	if v.Name() != VocoderName {
+		t.Errorf("Name() = %q, want %q", v.Name(), VocoderName)
+	}
+	if v.FrameSize() != speechFrameBytes {
+		t.Errorf("FrameSize() = %d, want %d", v.FrameSize(), speechFrameBytes)
+	}
+	if err := v.Close(); err != nil {
+		t.Errorf("Close(): %v", err)
+	}
+}
+
+// TestVocoderDecode checks a full packed frame decodes to 240 samples and a
+// short/nil frame is handled as an erased frame (still 240 samples).
+func TestVocoderDecode(t *testing.T) {
+	v := NewVocoder()
+	frame := make([]byte, speechFrameBytes)
+	for i := range frame {
+		frame[i] = byte(i * 17)
+	}
+	pcm, err := v.Decode(frame)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if len(pcm) != frameLen {
+		t.Fatalf("Decode returned %d samples, want %d", len(pcm), frameLen)
+	}
+
+	// erased frame (too short) still yields a concealed frame
+	pcm, err = v.Decode(nil)
+	if err != nil || len(pcm) != frameLen {
+		t.Fatalf("erased decode: %d samples, err %v", len(pcm), err)
+	}
+}
+
+// TestVocoderResetDeterministic checks Reset restores the decoder so the same
+// frame sequence reproduces identical output.
+func TestVocoderResetDeterministic(t *testing.T) {
+	v := NewVocoder()
+	frame := make([]byte, speechFrameBytes)
+	for i := range frame {
+		frame[i] = byte(i*29 + 3)
+	}
+	a, _ := v.Decode(frame)
+	b, _ := v.Decode(frame)
+
+	v.Reset()
+	a2, _ := v.Decode(frame)
+	b2, _ := v.Decode(frame)
+
+	for i := range a {
+		if a[i] != a2[i] || b[i] != b2[i] {
+			t.Fatalf("Reset did not restore decoder state at sample %d", i)
+		}
+	}
+}

--- a/internal/voice/composer/tetra_voice.go
+++ b/internal/voice/composer/tetra_voice.go
@@ -43,22 +43,22 @@ func newTETRAVoiceFrontEnd(iqHz float64, bw uint32) *decimatingFIR {
 }
 
 // runTETRAVoiceChain consumes IQ for one TETRA traffic-channel call. It
-// decimates the tap IQ to the TETRA symbol rate, recovers the π/4-DQPSK
-// dibit stream with the shared TETRA receiver, extracts each Normal
-// Continuous Downlink Burst's two data blocks (tetra.TrafficExtractor), and
-// appends them to the recorder's `.raw` sidecar as raw full-slot traffic
-// frames.
+// decimates the tap IQ to the TETRA symbol rate, recovers the π/4-DQPSK dibit
+// stream with the shared TETRA receiver, extracts each Normal Continuous
+// Downlink Burst's two data blocks (tetra.TrafficExtractor), TCH/S-decodes each
+// burst, and emits the recovered 137-bit speech frames to the recorder — which
+// renders them to PCM with the clean-room ACELP vocoder ("tetra-acelp") and
+// writes both the decoded WAV and a `.raw` sidecar of the speech frames. This
+// mirrors the DMR/P25 shape (post-FEC frames in `.raw` + decoded WAV).
 //
-// This is the traffic-following + capture half of TETRA voice support. TCH/S
-// channel decoding (§8.4) and the TETRA ACELP vocoder that would turn the
-// raw frames into PCM are the labelled follow-ups; until they land the `.raw`
-// sidecar is the capture, exactly as for DMR/P25 (post-FEC frames) and EDACS
-// ProVoice (raw frames). Encrypted calls (TEA1-4) still capture raw — the
-// bytes exist even when no in-process decode does.
-//
-// The extractor emits a frame for every burst on the carrier (all four TDMA
-// timeslots), not just the granted one; groupID/timeslot are threaded
-// through for a future per-slot filter and logging only.
+// The extractor emits a burst for every timeslot on the carrier (all four TDMA
+// slots), not just the granted one. Slot isolation is done by the TCH/S CRC:
+// only the granted call's TCH/S bursts pass, so the other slots' signalling
+// bursts are dropped (tetra.TCHSpeechFrames). This cleanly separates a single
+// active call; concurrent TCH/S calls on the same carrier would still mix and
+// need TDMA frame-number demux (a follow-up). groupID/timeslot are threaded
+// through for logging and that future demux. Encrypted calls (TEA1-4) fail the
+// CRC and produce no decoded audio (their raw bursts still exist upstream).
 func (c *Composer) runTETRAVoiceChain(ctx context.Context, serial string, iqCh <-chan []complex64, iqHz float64, groupID uint32, timeslot uint8, colourExt uint32, done chan<- struct{}) {
 	defer close(done)
 	defer gtlog.Recover(c.log, "voice-chain-tetra:"+serial, nil)
@@ -73,7 +73,7 @@ func (c *Composer) runTETRAVoiceChain(ctx context.Context, serial string, iqCh <
 	symbolHz := fe.OutRateHz()
 
 	rs, _ := c.sink.(rawFrameSink)
-	var bursts atomic.Uint64
+	var bursts, speech atomic.Uint64
 	extractor := tetra.NewTrafficExtractor(colourExt, func(frame []byte) {
 		bursts.Add(1)
 		// Each recovered burst counts as traffic activity: keep the call
@@ -82,8 +82,16 @@ func (c *Composer) runTETRAVoiceChain(ctx context.Context, serial string, iqCh <
 		if rs == nil {
 			return
 		}
-		if err := rs.WriteRawFrame(serial, frame); err != nil {
-			c.log.Warn("composer: TETRA raw-frame write failed", "serial", serial, "err", err)
+		// TCH/S-decode the burst. Only bursts whose class-2 CRC verifies are
+		// TCH/S speech for the granted call (other TDMA timeslots' bursts fail
+		// the CRC); emit each recovered 137-bit speech frame to the recorder,
+		// which renders it with the ACELP vocoder and appends it to the `.raw`
+		// sidecar.
+		for _, sf := range tetra.TCHSpeechFrames(frame) {
+			speech.Add(1)
+			if err := rs.WriteRawFrame(serial, sf); err != nil {
+				c.log.Warn("composer: TETRA speech-frame write failed", "serial", serial, "err", err)
+			}
 		}
 	})
 
@@ -96,9 +104,14 @@ func (c *Composer) runTETRAVoiceChain(ctx context.Context, serial string, iqCh <
 		EnableChannelFilter: true,
 	})
 
-	c.log.Info("composer: tetra voice follow started — descrambled traffic sidecar (TCH/S FEC + ACELP vocoder are follow-ups)",
+	c.log.Info("composer: tetra voice follow started — TCH/S decode + ACELP vocoder",
 		"serial", serial, "group", groupID, "timeslot", timeslot,
 		"colour_code", colourExt&0x3F, "rate_hz", symbolHz)
+
+	defer func() {
+		c.log.Info("composer: tetra voice follow ended",
+			"serial", serial, "bursts", bursts.Load(), "speech_frames", speech.Load())
+	}()
 
 	touchTicker := time.NewTicker(c.touchEvery)
 	defer touchTicker.Stop()

--- a/internal/voice/composer/tetra_voice_test.go
+++ b/internal/voice/composer/tetra_voice_test.go
@@ -15,9 +15,11 @@ import (
 // buildTETRATrafficDibits lays out nSlots Normal Continuous Downlink Bursts
 // (255-dibit TDMA slots) into a dibit stream, each with the normal training
 // sequence at its §9.4.4.3.2 intra-slot position (bit 244 → dibit 122). The
-// data blocks are deterministic filler — the chain test asserts the raw
-// full-slot frames flow and drive the call lifecycle, not their payload
-// (the payload round-trip is TrafficExtractor's own unit test).
+// data blocks are deterministic filler — the chain test asserts that bursts
+// are recovered and drive the call lifecycle, not their payload. (Payload
+// round-trips are covered by TrafficExtractor and TCHSpeechFrames unit tests;
+// the CRC gate legitimately drops these filler bursts, so no decoded speech is
+// asserted here.)
 func buildTETRATrafficDibits(nSlots int) []uint8 {
 	const (
 		slot   = 255
@@ -36,11 +38,14 @@ func buildTETRATrafficDibits(nSlots int) []uint8 {
 	return stream
 }
 
-// TestComposerTETRAVoiceChainWritesRawFrames drives the composer's TETRA
+// TestComposerTETRAVoiceChainLifecycle drives the composer's TETRA
 // traffic-follow path end to end: modulated π/4-DQPSK IQ → TETRA receiver →
-// TrafficExtractor → recorder .raw sidecar, and confirms full-slot traffic
-// frames flow, the engine is kept alive, and the call ends on hangtime.
-func TestComposerTETRAVoiceChainWritesRawFrames(t *testing.T) {
+// TrafficExtractor → TCH/S decode, and confirms the chain starts, recovered
+// bursts keep the engine's call alive, and the call ends on hangtime once the
+// IQ stops. The filler bursts do not carry valid TCH/S, so the CRC gate emits
+// no speech frames — speech-frame decoding is covered by the tetra package's
+// TCHSpeechFrames test and the ACELP vocoder tests.
+func TestComposerTETRAVoiceChainLifecycle(t *testing.T) {
 	const (
 		sps   = 8 // 18000 baud × 8 = 144 kHz intermediate rate
 		span  = 8
@@ -95,20 +100,8 @@ func TestComposerTETRAVoiceChainWritesRawFrames(t *testing.T) {
 	waitFor(t, 10*time.Second, func() bool { return len(c.ActiveChains()) == 1 })
 	src.SendIQ(iq)
 
-	// Full-slot traffic frames must reach the sidecar.
-	waitFor(t, 20*time.Second, func() bool { return len(sink.rawFrames("VOICE-1")) >= 5 })
-	got := sink.rawFrames("VOICE-1")
-	if len(got) == 0 {
-		t.Fatal("no raw traffic frames written")
-	}
-	for i, f := range got {
-		if len(f) != tetra.TrafficFrameBytes {
-			t.Fatalf("frame %d is %d bytes, want %d (BKN1+BKN2 type-5)", i, len(f), tetra.TrafficFrameBytes)
-		}
-	}
-
-	// The chain keeps the engine's call alive while traffic flows.
-	waitFor(t, 5*time.Second, func() bool { return eng.touched.Load() > 0 })
+	// Recovered bursts keep the engine's call alive while traffic flows.
+	waitFor(t, 20*time.Second, func() bool { return eng.touched.Load() > 0 })
 
 	// After the IQ stops, the boundary tracker ends the call on hangtime
 	// (VoiceHangtime after the last decoded burst).

--- a/internal/voice/recorder.go
+++ b/internal/voice/recorder.go
@@ -274,8 +274,8 @@ func DefaultVocoderForProtocol() map[string]string {
 		"dmr-tier2":  "ambe2-dmr", // DMR Tier II — AMBE+2 3600x2450
 		"dmr-tier3":  "ambe2-dmr", // DMR Tier III — AMBE+2 3600x2450
 		"nxdn":       "ambe2",
-		"dpmr":       "ambe2", // dPMR Mode 3 (digital)
-		"tetra":      "ambe2", // TETRA voice
+		"dpmr":       "ambe2",       // dPMR Mode 3 (digital)
+		"tetra":      "tetra-acelp", // TETRA full-rate voice — clean-room ACELP (EN 300 395-2)
 	}
 }
 
@@ -287,10 +287,12 @@ func dmrVoiceProtocol(protocol string) bool {
 	return protocol == "dmr-tier1" || protocol == "dmr-tier2" || protocol == "dmr-tier3"
 }
 
-// tetraVoiceProtocol reports whether a call is TETRA voice. TETRA has no
-// in-process vocoder yet (TCH/S FEC + ACELP are follow-ups), so — like
-// ProVoice — its `.raw` sidecar of raw full-slot traffic frames is the only
-// capture of the call and is always written.
+// tetraVoiceProtocol reports whether a call is TETRA voice. The composer's
+// TETRA chain now TCH/S-decodes each traffic burst and emits post-FEC 137-bit
+// speech frames, which the clean-room ACELP vocoder ("tetra-acelp") renders to
+// PCM — the same post-FEC-frames-in-`.raw` + decoded-WAV shape as DMR. The
+// `.raw` sidecar is always written so the speech frames remain available for
+// out-of-band tools.
 func tetraVoiceProtocol(protocol string) bool {
 	return protocol == "tetra"
 }

--- a/internal/voice/recorder_test.go
+++ b/internal/voice/recorder_test.go
@@ -1153,7 +1153,7 @@ func TestDefaultVocoderForProtocolMappings(t *testing.T) {
 		"dmr-tier3":  "ambe2-dmr",
 		"nxdn":       "ambe2",
 		"dpmr":       "ambe2",
-		"tetra":      "ambe2",
+		"tetra":      "tetra-acelp",
 	}
 	if len(got) != len(want) {
 		t.Errorf("len = %d, want %d", len(got), len(want))


### PR DESCRIPTION
## Summary

Final stage of TETRA voice: this closes the loop from a decoded control-channel
grant to an **audible 8 kHz WAV**. The clean-room ACELP decoder built across the
previous PRs is registered as a vocoder, the `"tetra"` protocol is remapped onto
it (off the wrong `ambe2` that produced garbage WAVs), and the composer's TETRA
voice chain now TCH/S-decodes each recovered burst and feeds the resulting
speech frames through it.

## Changes

- **`acelp` vocoder** (`internal/voice/acelp/vocoder.go`): registers the decoder
  as the `voice.Vocoder` named `"tetra-acelp"` — one packed 137-bit TCH/S speech
  frame → 240 PCM samples (30 ms); a short/nil frame → erased-frame concealment.
  Blank-imported by `cmd/gophertrunk` so the name registers in default builds.
- **`recorder`**: `DefaultVocoderForProtocol` maps `"tetra"` → `"tetra-acelp"`
  (was `"ambe2"`).
- **`composer`** (`tetra_voice.go`): the TETRA chain now TCH/S-decodes each
  recovered burst and emits post-FEC 137-bit speech frames (instead of raw
  type-5 blocks). **Slot isolation is by the TCH/S class-2 CRC** — only the
  granted call's TCH/S speech bursts verify, so the other TDMA timeslots'
  signalling bursts are dropped. This cleanly separates a *single* active call;
  concurrent same-carrier TCH/S calls would still need TDMA frame-number demux
  (documented follow-up).
- **`tetra.TCHSpeechFrames`**: CRC-gated helper turning one descrambled traffic
  frame into the two packed speech frames the vocoder consumes.
- **`docs/vocoders.md`**: new TETRA ACELP section — chain, slot isolation,
  clean-room / patent posture (core algebraic-CELP patents expired), and the
  remaining ETSI clause-4 bit-exact validation step.

## Test plan

- [x] `make vet test` green locally (full `-race` suite; the pre-existing
      `internal/voice` + `composer` tests updated for the new mapping/semantics)
- [ ] `make integration` — not run here; no daemon/DSP path changed, only the
      composer frame emission + recorder protocol map. Worth a run in CI.
- [x] Added tests: vocoder registration + decode + `Reset` determinism; the CRC
      gate (valid frame → 2 packed speech frames matching input, random frames
      rejected ~1/256); the recorder protocol-map update; and the composer chain
      lifecycle (recovered bursts keep the call alive, ends on hangtime). The
      old raw-frame composer assertion was refocused on lifecycle since the CRC
      gate legitimately drops the test's non-TCH/S filler bursts.
- [ ] Bit-exact conformance vs the ETSI EN 300 395-2 clause-4 sequences — the
      remaining validation step (noted in docs Future work).
- [ ] Manual: listen to the produced WAVs for the two calls on the 467.913
      capture — the intended end-to-end acceptance check.

## Breaking changes

`.raw` sidecar content for TETRA voice changes from raw type-5 traffic blocks to
post-FEC 137-bit speech frames (matching the DMR/P25 "post-FEC frames in `.raw`"
convention). No config/API/schema change.

## Docs / CHANGELOG

- [x] `docs/vocoders.md` updated (TETRA ACELP section + Future work).
- [ ] No `CHANGELOG.md` entry added — defer to maintainer preference for how to
      phrase the user-visible "TETRA voice now decodes to audio" line.

## Linked issues

n/a — part of the ongoing TETRA voice work tracked in this branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GVoGbXXCo3doUafoQTf3mE)_