### PR TITLE
fix(tetra): end voice calls on decoded speech, not raw carrier bursts

### DIFF
--- a/internal/voice/acelp/replay_capture_test.go
+++ b/internal/voice/acelp/replay_capture_test.go
@@ -1,0 +1,116 @@
+package acelp
+
+import (
+	"encoding/binary"
+	"math"
+	"os"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/tetra"
+)
+
+// TestReplayCapture is an offline validation harness (skipped unless
+// GT_TETRA_RAW points at a `.raw` sidecar of descrambled 54-byte type-4 TETRA
+// traffic frames, e.g. an old-build recorder sidecar). It TCH/S-decodes each
+// frame, renders the CRC-valid speech frames through the ACELP vocoder, and
+// writes an 8 kHz mono WAV (GT_TETRA_WAV, default /tmp/tetra_replay.wav). It
+// reports the CRC-pass rate and coarse PCM stats so the decoded audio can be
+// listened to / inspected. Not a CI test — a manual real-air acceptance check.
+func TestReplayCapture(t *testing.T) {
+	rawPath := os.Getenv("GT_TETRA_RAW")
+	if rawPath == "" {
+		t.Skip("set GT_TETRA_RAW to a .raw capture to run the offline ACELP replay")
+	}
+	data, err := os.ReadFile(rawPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const frameBytes = tetra.TrafficFrameBytes // 54
+	if len(data)%frameBytes != 0 {
+		t.Logf("warning: %d bytes is not a multiple of %d; trailing bytes ignored", len(data), frameBytes)
+	}
+	nFrames := len(data) / frameBytes
+
+	voc := NewVocoder()
+	var pcm []int16
+	crcPass, speechFrames := 0, 0
+	for i := 0; i < nFrames; i++ {
+		frame := data[i*frameBytes : (i+1)*frameBytes]
+		sfs := tetra.TCHSpeechFrames(frame)
+		if len(sfs) == 0 {
+			continue
+		}
+		crcPass++
+		for _, sf := range sfs {
+			speechFrames++
+			out, _ := voc.Decode(sf)
+			pcm = append(pcm, out...)
+		}
+	}
+
+	// Coarse PCM stats.
+	var sumSq float64
+	var peak int16
+	for _, s := range pcm {
+		sumSq += float64(s) * float64(s)
+		if a := abs16(s); a > peak {
+			peak = a
+		}
+	}
+	rms := 0.0
+	if len(pcm) > 0 {
+		rms = math.Sqrt(sumSq / float64(len(pcm)))
+	}
+	durSec := float64(len(pcm)) / 8000.0
+	t.Logf("frames=%d crc_pass_slots=%d (%.1f%%) speech_frames=%d pcm_samples=%d dur=%.2fs rms=%.0f peak=%d",
+		nFrames, crcPass, 100*float64(crcPass)/float64(max(nFrames, 1)), speechFrames, len(pcm), durSec, rms, peak)
+
+	wavPath := os.Getenv("GT_TETRA_WAV")
+	if wavPath == "" {
+		wavPath = "/tmp/tetra_replay.wav"
+	}
+	if err := writeWAV8k(wavPath, pcm); err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("wrote %s", wavPath)
+}
+
+func abs16(x int16) int16 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func writeWAV8k(path string, pcm []int16) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	const rate = 8000
+	dataLen := len(pcm) * 2
+	h := make([]byte, 44)
+	copy(h[0:], "RIFF")
+	binary.LittleEndian.PutUint32(h[4:], uint32(36+dataLen))
+	copy(h[8:], "WAVE")
+	copy(h[12:], "fmt ")
+	binary.LittleEndian.PutUint32(h[16:], 16)
+	binary.LittleEndian.PutUint16(h[20:], 1) // PCM
+	binary.LittleEndian.PutUint16(h[22:], 1) // mono
+	binary.LittleEndian.PutUint32(h[24:], rate)
+	binary.LittleEndian.PutUint32(h[28:], rate*2)
+	binary.LittleEndian.PutUint16(h[32:], 2)
+	binary.LittleEndian.PutUint16(h[34:], 16)
+	copy(h[36:], "data")
+	binary.LittleEndian.PutUint32(h[40:], uint32(dataLen))
+	if _, err := f.Write(h); err != nil {
+		return err
+	}
+	buf := make([]byte, dataLen)
+	for i, s := range pcm {
+		binary.LittleEndian.PutUint16(buf[i*2:], uint16(s))
+	}
+	_, err = f.Write(buf)
+	return err
+}

--- a/internal/voice/composer/tetra_voice.go
+++ b/internal/voice/composer/tetra_voice.go
@@ -75,24 +75,7 @@ func (c *Composer) runTETRAVoiceChain(ctx context.Context, serial string, iqCh <
 	rs, _ := c.sink.(rawFrameSink)
 	var bursts, speech atomic.Uint64
 	extractor := tetra.NewTrafficExtractor(colourExt, func(frame []byte) {
-		bursts.Add(1)
-		// Each recovered burst counts as traffic activity: keep the call
-		// alive and reset the hangtime timer.
-		bt.onVoice(0)
-		if rs == nil {
-			return
-		}
-		// TCH/S-decode the burst. Only bursts whose class-2 CRC verifies are
-		// TCH/S speech for the granted call (other TDMA timeslots' bursts fail
-		// the CRC); emit each recovered 137-bit speech frame to the recorder,
-		// which renders it with the ACELP vocoder and appends it to the `.raw`
-		// sidecar.
-		for _, sf := range tetra.TCHSpeechFrames(frame) {
-			speech.Add(1)
-			if err := rs.WriteRawFrame(serial, sf); err != nil {
-				c.log.Warn("composer: TETRA speech-frame write failed", "serial", serial, "err", err)
-			}
-		}
+		c.onTETRATrafficBurst(bt, rs, serial, frame, &bursts, &speech)
 	})
 
 	rx := tetrarx.New(tetrarx.Options{
@@ -127,6 +110,47 @@ func (c *Composer) runTETRAVoiceChain(ctx context.Context, serial string, iqCh <
 			}
 			bt.observe(iq)
 			rx.Process(fe.Process(nil, iq))
+		}
+	}
+}
+
+// onTETRATrafficBurst handles one Normal Continuous Downlink Burst recovered by
+// the TrafficExtractor. Call liveness (the hangtime end-of-call) is driven ONLY
+// by CRC-valid TCH/S speech for the granted call — not by every raw burst.
+//
+// This matters because the extractor emits a burst for all four TDMA timeslots
+// on the carrier, continuously, whether or not it is the granted call's speech.
+// Refreshing the boundary tracker on every raw burst (the previous behaviour)
+// kept lastVoiceNano perpetually fresh while the carrier was up, so the hangtime
+// never elapsed and the (single, same-carrier) voice device was held forever —
+// every later grant was then dropped with "no voice device available for grant".
+//
+// The class-2 CRC gate (tetra.TCHSpeechFrames) already isolates the granted
+// call's speech: a non-TCH/S burst (signalling on another timeslot, an encrypted
+// call, or a badly corrupted slot) returns no frames. Gating onVoice on that
+// same result makes TETRA teardown behave like every other protocol — the call
+// ends hangtime after its last decoded speech frame (or via the no-voice
+// startup timeout when a grant never decodes any speech).
+func (c *Composer) onTETRATrafficBurst(bt *boundaryTracker, rs rawFrameSink, serial string, frame []byte, bursts, speech *atomic.Uint64) {
+	bursts.Add(1)
+	// TCH/S-decode the burst. Only bursts whose class-2 CRC verifies are TCH/S
+	// speech for the granted call; everything else yields no frames.
+	frames := tetra.TCHSpeechFrames(frame)
+	if len(frames) == 0 {
+		// Not the granted call's speech — do NOT touch call liveness.
+		return
+	}
+	// CRC-valid speech: keep the call alive and reset the hangtime timer.
+	bt.onVoice(0)
+	if rs == nil {
+		return
+	}
+	// Emit each recovered 137-bit speech frame to the recorder, which renders it
+	// with the ACELP vocoder and appends it to the `.raw` sidecar.
+	for _, sf := range frames {
+		speech.Add(1)
+		if err := rs.WriteRawFrame(serial, sf); err != nil {
+			c.log.Warn("composer: TETRA speech-frame write failed", "serial", serial, "err", err)
 		}
 	}
 }

--- a/internal/voice/composer/tetra_voice_test.go
+++ b/internal/voice/composer/tetra_voice_test.go
@@ -3,6 +3,8 @@ package composer
 import (
 	"context"
 	"math"
+	"math/rand"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -40,11 +42,19 @@ func buildTETRATrafficDibits(nSlots int) []uint8 {
 
 // TestComposerTETRAVoiceChainLifecycle drives the composer's TETRA
 // traffic-follow path end to end: modulated π/4-DQPSK IQ → TETRA receiver →
-// TrafficExtractor → TCH/S decode, and confirms the chain starts, recovered
-// bursts keep the engine's call alive, and the call ends on hangtime once the
-// IQ stops. The filler bursts do not carry valid TCH/S, so the CRC gate emits
-// no speech frames — speech-frame decoding is covered by the tetra package's
-// TCHSpeechFrames test and the ACELP vocoder tests.
+// TrafficExtractor → TCH/S decode, and confirms the chain starts and — because
+// the filler bursts carry no valid TCH/S speech (the CRC gate rejects them) —
+// the call is NOT kept alive by raw carrier activity and tears down via the
+// no-voice startup timeout instead of hanging on the carrier forever. This is
+// the regression guard for the "active call never ends" bug: before the fix,
+// every recovered burst refreshed the hangtime timer, so a continuous carrier
+// held the single voice device indefinitely.
+//
+// The speech-keeps-the-call-alive / ends-on-hangtime path is covered
+// deterministically by TestTETRATrafficBurstLivenessGatedByCRC (a clean
+// EncodeTCHS→TCHSpeechFrames round trip, no DSP), which avoids depending on the
+// class-2 CRC surviving the full modulate→demod round trip under a loaded
+// -race CI.
 func TestComposerTETRAVoiceChainLifecycle(t *testing.T) {
 	const (
 		sps   = 8 // 18000 baud × 8 = 144 kHz intermediate rate
@@ -100,10 +110,75 @@ func TestComposerTETRAVoiceChainLifecycle(t *testing.T) {
 	waitFor(t, 10*time.Second, func() bool { return len(c.ActiveChains()) == 1 })
 	src.SendIQ(iq)
 
-	// Recovered bursts keep the engine's call alive while traffic flows.
-	waitFor(t, 20*time.Second, func() bool { return eng.touched.Load() > 0 })
+	// The filler bursts carry no valid TCH/S speech, so no matching voice frame
+	// ever decodes. The boundary tracker must therefore end the call via the
+	// no-voice startup timeout (2×VoiceHangtime) — NOT keep it alive off raw
+	// carrier activity. Reason timeout matches the "silent-from-start" teardown.
+	waitFor(t, 15*time.Second, func() bool { return eng.endReason("VOICE-1") == trunking.EndReasonTimeout })
+}
 
-	// After the IQ stops, the boundary tracker ends the call on hangtime
-	// (VoiceHangtime after the last decoded burst).
-	waitFor(t, 15*time.Second, func() bool { return eng.endReason("VOICE-1") == trunking.EndReasonNormal })
+// TestTETRATrafficBurstLivenessGatedByCRC is the direct regression for the
+// "active call never ends" bug. It exercises onTETRATrafficBurst without any DSP
+// and asserts that call liveness is driven ONLY by CRC-valid TCH/S speech:
+//
+//   - a non-TCH/S (junk) burst must NOT touch the boundary tracker — no onVoice,
+//     no sawVoice, no lastVoiceNano advance, no speech frame written; and
+//   - a CRC-valid TCH/S burst (EncodeTCHS) must mark voice activity and emit the
+//     two 137-bit speech frames.
+//
+// Before the fix, onVoice fired on every raw burst, so the junk case would set
+// sawVoice / advance lastVoiceNano — and a continuous carrier of such bursts
+// held the voice device forever. This test fails on that code and passes once
+// liveness is gated on TCHSpeechFrames.
+func TestTETRATrafficBurstLivenessGatedByCRC(t *testing.T) {
+	c, _, _ := mkBoundaryComposer(t, false, 50*time.Millisecond)
+	bt := c.newBoundaryTracker("VOICE-1", 0, nil)
+	rs := &recordingSink{}
+	var bursts, speech atomic.Uint64
+
+	// Case A: a deterministic non-TCH/S 54-byte burst. Guard that the CRC gate
+	// rejects it (it does for this fixed vector), then confirm it leaves the
+	// call-liveness state completely untouched.
+	junk := make([]byte, tetra.TrafficFrameBytes)
+	rng := rand.New(rand.NewSource(42))
+	rng.Read(junk)
+	if tetra.TCHSpeechFrames(junk) != nil {
+		t.Fatalf("test vector precondition: junk frame unexpectedly passed the TCH/S CRC gate")
+	}
+	c.onTETRATrafficBurst(bt, rs, "VOICE-1", junk, &bursts, &speech)
+	if bt.sawVoice.Load() {
+		t.Error("non-speech burst set sawVoice — liveness not gated on CRC-valid speech")
+	}
+	if got := bt.lastVoiceNano.Load(); got != 0 {
+		t.Errorf("non-speech burst advanced lastVoiceNano to %d, want 0", got)
+	}
+	if n := len(rs.rawFrames("VOICE-1")); n != 0 {
+		t.Errorf("non-speech burst wrote %d raw frames, want 0", n)
+	}
+	if got := speech.Load(); got != 0 {
+		t.Errorf("non-speech burst counted %d speech frames, want 0", got)
+	}
+	if got := bursts.Load(); got != 1 {
+		t.Errorf("bursts = %d after one call, want 1", got)
+	}
+
+	// Case B: a CRC-valid TCH/S burst carrying two 137-bit speech frames. It must
+	// mark voice activity and emit both speech frames to the recorder.
+	frame := tetra.EncodeTCHS(make([]byte, 137), make([]byte, 137))
+	c.onTETRATrafficBurst(bt, rs, "VOICE-1", frame, &bursts, &speech)
+	if !bt.sawVoice.Load() {
+		t.Error("CRC-valid TCH/S burst did not set sawVoice")
+	}
+	if bt.lastVoiceNano.Load() == 0 {
+		t.Error("CRC-valid TCH/S burst did not advance lastVoiceNano")
+	}
+	if n := len(rs.rawFrames("VOICE-1")); n != 2 {
+		t.Errorf("CRC-valid burst wrote %d raw frames, want 2", n)
+	}
+	if got := speech.Load(); got != 2 {
+		t.Errorf("speech frames = %d, want 2", got)
+	}
+	if got := bursts.Load(); got != 2 {
+		t.Errorf("bursts = %d after two calls, want 2", got)
+	}
 }


### PR DESCRIPTION
A TETRA voice call never ended: the traffic-follow chain refreshed the
boundary tracker on every recovered NCDB burst, before the CRC gate. The
TrafficExtractor emits a burst for all four TDMA timeslots continuously, so
while the carrier was up the hangtime timer was reset forever. The single
cc:same-carrier virtual voice device stayed held by the first call and every
later grant was dropped with "no voice device available for grant" — the
operator got only one voice call.

Drive call liveness from CRC-valid TCH/S speech instead (like P25 LDUs / DMR
voice superframes): onVoice is now called only when tetra.TCHSpeechFrames
recovers a speech frame for the granted call. When the transmission ends,
speech stops, hangtime elapses, the call ends and frees the device for the
next grant; a grant that never decodes speech ends via the no-voice timeout.

The burst-handling closure is extracted to Composer.onTETRATrafficBurst so the
gate is unit-testable without the DSP path. TestTETRATrafficBurstLivenessGatedByCRC
is the failing-first regression (a non-speech burst must not touch liveness; a
CRC-valid burst must). TestComposerTETRAVoiceChainLifecycle is updated to assert
non-speech filler tears down via the no-voice timeout rather than being kept
alive.

acelp/replay_capture_test.go adds a skip-guarded offline harness
(GT_TETRA_RAW) that renders a descrambled traffic .raw through
TCHSpeechFrames -> ACELP to a WAV for real-air acceptance checks.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HmkZyhNfZnLVhxxx7miXPv