### PR TITLE
fix(tetra): extend AFC carrier acquisition range to ~±6 kHz (#940)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,16 @@ for tagged releases.
   rather than a fixed slot 1 — the building block for issue #925.
 
 ### Fixed
+- **TETRA AFC now acquires carriers several kHz off-centre.** The carrier AFC
+  estimated the offset from the 4×Δφ differential mean, which wraps into
+  ±f_sym/8 ≈ ±2250 Hz — so a control channel more than 2250 Hz off-frequency
+  aliased into that window and left a multi-kHz constellation spin that broke
+  Gardner timing, and the receiver never locked even on a clean, strong signal.
+  Real SDR front-ends (RTL-SDR, Airspy, HackRF, non-GPSDO USRP) routinely sit
+  several kHz off, so this was a real acquisition gap. A coarse mean-frequency
+  stage (the angle of the pre-matched-filter block's lag-1 autocorrelation)
+  now picks the alias bucket before the existing fine estimator refines it,
+  extending acquisition to roughly ±6 kHz. (issue #940)
 - **TETRA control channels now lock on real air (§8.2.5 scrambler).** The
   scrambling LFSR shifted its register the wrong direction relative to the tap
   convention, so the generated sequence diverged from ETSI EN 300 392-2 §8.2.5

--- a/internal/radio/tetra/receiver/afc.go
+++ b/internal/radio/tetra/receiver/afc.go
@@ -22,10 +22,10 @@ import "math"
 // and locks. Re-estimating per block tracks slow clock/thermal drift; a
 // single whole-stream estimate would leave a growing residual.
 type carrierAFC struct {
-	sps   int
-	theta float64     // derotation phase within the current block
-	omega float64     // most recent per-symbol offset estimate (for OffsetHz)
-	buf   []complex64 // oversampled samples awaiting a full block
+	sps     int
+	omega   float64     // most recent per-symbol offset estimate (for OffsetHz)
+	buf     []complex64 // oversampled matched-filter samples awaiting a full block
+	wideBuf []complex64 // parallel pre-matched (channel-filtered) samples for the coarse stage
 }
 
 // afcBlockSymbols is the feed-forward re-estimation window in symbols.
@@ -37,7 +37,48 @@ func newCarrierAFC(sps int) *carrierAFC {
 	if sps < 1 {
 		sps = 1
 	}
-	return &carrierAFC{sps: sps, buf: make([]complex64, 0, afcBlockSymbols*sps)}
+	return &carrierAFC{
+		sps:     sps,
+		buf:     make([]complex64, 0, afcBlockSymbols*sps),
+		wideBuf: make([]complex64, 0, afcBlockSymbols*sps),
+	}
+}
+
+// coarseOmega estimates the mean carrier offset over a block as the angle of
+// its lag-1 autocorrelation — the power-weighted spectral centroid of a
+// symmetric π/4-DQPSK spectrum — scaled to rad/symbol. Unlike the 4×Δφ
+// differential estimator (estimateOmega), it has no ±π/4-per-symbol wrap: its
+// unambiguous range spans the whole passband, so it fixes which
+// π/2-per-symbol (f_sym/4 Hz) alias bucket the fine estimator's result sits
+// in. It must be read from the *pre-matched-filter* (channel-filtered) stream:
+// the matched filter is centred at 0 Hz and pulls a spectral estimate of an
+// off-centre carrier back toward 0, which would defeat the point. The channel
+// filter bounds the usable acquisition range to roughly ±(cutoff − signal
+// half-bandwidth) ≈ ±6 kHz at the production 15 kHz cutoff.
+func coarseOmega(block []complex64, sps int) float64 {
+	var sr, si float64
+	for k := 1; k < len(block); k++ {
+		d := block[k] * conjf(block[k-1])
+		sr += float64(real(d))
+		si += float64(imag(d))
+	}
+	if sr == 0 && si == 0 {
+		return 0
+	}
+	// atan2 is the mean phase advance per sample (rad/sample); ×sps → rad/symbol.
+	return math.Atan2(si, sr) * float64(sps)
+}
+
+// derotate multiplies each sample of block by e^{-jωk/sps}, k counting from 0
+// at the block start — a per-block absolute derotation by ω rad/symbol.
+func (a *carrierAFC) derotate(block []complex64, omega float64) {
+	perSample := omega / float64(a.sps)
+	theta := 0.0
+	for i := range block {
+		rot := complex(float32(math.Cos(-theta)), float32(math.Sin(-theta)))
+		block[i] *= rot
+		theta += perSample
+	}
 }
 
 // estimateOmega returns the mean per-symbol phase offset over an
@@ -70,22 +111,50 @@ func estimateOmega(block []complex64, sps int) float64 {
 // estimate errors don't accumulate into a drifting phase). Samples that
 // do not yet fill a block are buffered for the next call; the trailing
 // partial block at end-of-stream is not emitted.
-func (a *carrierAFC) Process(dst, src []complex64) []complex64 {
+//
+// Each block is corrected in two stages. A coarse mean-frequency estimate on
+// the parallel pre-matched-filter (channel-filtered) block picks the alias
+// bucket — extending the acquisition range past the differential estimator's
+// ±f_sym/8 ≈ ±2250 Hz wrap to roughly ±6 kHz — and the existing 4×Δφ
+// estimator then refines the residual on the coarse-derotated matched block.
+// wide is that pre-matched stream (parallel to matched, same length); pass nil
+// to disable the coarse stage and fall back to fine-only (the historical
+// behaviour), which the receiver does when no channel filter is active and the
+// wideband stream would still carry adjacent carriers.
+func (a *carrierAFC) Process(dst, matched, wide []complex64) []complex64 {
 	dst = dst[:0]
-	a.buf = append(a.buf, src...)
+	a.buf = append(a.buf, matched...)
+	// Keep wideBuf strictly parallel to buf, but only while the pre-matched
+	// stream is supplied every call at the matching length; otherwise drop the
+	// coarse stage rather than risk a misaligned read (matches the soft-buffer
+	// discipline in the control-channel SB path).
+	if wide != nil && len(wide) == len(matched) && len(a.wideBuf) == len(a.buf)-len(matched) {
+		a.wideBuf = append(a.wideBuf, wide...)
+	} else if len(a.wideBuf) != len(a.buf) {
+		a.wideBuf = a.wideBuf[:0]
+	}
 	blockSamples := afcBlockSymbols * a.sps
 	for len(a.buf) >= blockSamples {
 		block := a.buf[:blockSamples]
-		a.omega = estimateOmega(block, a.sps)
-		perSample := a.omega / float64(a.sps)
-		a.theta = 0
-		for i := range block {
-			rot := complex(float32(math.Cos(-a.theta)), float32(math.Sin(-a.theta)))
-			block[i] *= rot
-			a.theta += perSample
+
+		var coarse float64
+		haveWide := len(a.wideBuf) >= blockSamples
+		if haveWide {
+			coarse = coarseOmega(a.wideBuf[:blockSamples], a.sps)
 		}
+		// Bring the block within the fine estimator's unambiguous window, then
+		// refine. Total offset = coarse + fine; both derotations are absolute
+		// from phase 0, so per-block errors never accumulate.
+		a.derotate(block, coarse)
+		fine := estimateOmega(block, a.sps)
+		a.derotate(block, fine)
+		a.omega = coarse + fine
+
 		dst = append(dst, block...)
 		a.buf = append(a.buf[:0], a.buf[blockSamples:]...)
+		if haveWide {
+			a.wideBuf = append(a.wideBuf[:0], a.wideBuf[blockSamples:]...)
+		}
 	}
 	return dst
 }
@@ -94,9 +163,9 @@ func (a *carrierAFC) Process(dst, src []complex64) []complex64 {
 func (a *carrierAFC) OffsetHz(symRate float64) float64 { return a.omega * symRate / (2 * math.Pi) }
 
 func (a *carrierAFC) Reset() {
-	a.theta = 0
 	a.omega = 0
 	a.buf = a.buf[:0]
+	a.wideBuf = a.wideBuf[:0]
 }
 
 func conjf(c complex64) complex64 { return complex(real(c), -imag(c)) }

--- a/internal/radio/tetra/receiver/afc_range_test.go
+++ b/internal/radio/tetra/receiver/afc_range_test.go
@@ -1,0 +1,126 @@
+package receiver
+
+import (
+	"io"
+	"log/slog"
+	"math"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/tetra"
+)
+
+// TestReceiverAFCLocksWithLargeCarrierOffset drives the production 144 kHz /
+// Gardner / AFC path with a synthesized TETRA control channel shifted by a
+// carrier-frequency offset well beyond the differential AFC's ±f_sym/8 =
+// ±2250 Hz acquisition window, and asserts a real lock at each offset.
+//
+// This is the regression guard for issue #940. The original AFC estimated the
+// offset from the 4×Δφ differential mean, which wraps into (−π/4, π/4] rad/
+// symbol, so any carrier more than 2250 Hz off-centre aliased into that window
+// and left a multi-kHz constellation spin that broke Gardner timing — the
+// receiver never locked even on a clean, strong signal. Real SDR front-ends
+// routinely sit several kHz off-frequency, so this was a real acquisition gap.
+// The two-stage AFC (coarse mean-frequency on the pre-matched-filter block +
+// the existing fine estimator) extends acquisition to roughly ±6 kHz.
+//
+// Before the fix this fails at every offset here; after it, all lock.
+func TestReceiverAFCLocksWithLargeCarrierOffset(t *testing.T) {
+	const (
+		controlFreqHz        = 412_062_500
+		colourCode           = uint32(0x12345)
+		locationArea  uint16 = 0x42
+		sps                  = 8
+		span                 = 8
+		alpha                = 0.35
+		gardnerGain          = 0.005
+		sampleRateHz         = 144_000.0
+	)
+
+	dibits := buildTETRASCHHDDibits(120, colourCode, locationArea)
+	baseIQ := demod.ModulatePiOver4DQPSK(dibits, sps, span, alpha, math.Pi/4)
+
+	// Offsets chosen to straddle the old ±2250 Hz cliff, both signs, out to the
+	// ~±6 kHz range the two-stage AFC targets.
+	for _, cfoHz := range []float64{-5500, -4000, 3000, 4000, 5500} {
+		t.Run(offsetName(cfoHz), func(t *testing.T) {
+			iq := make([]complex64, len(baseIQ))
+			for i, s := range baseIQ {
+				ph := 2 * math.Pi * cfoHz * float64(i) / sampleRateHz
+				iq[i] = s * complex(float32(math.Cos(ph)), float32(math.Sin(ph)))
+			}
+
+			bus := events.NewBus(64)
+			defer bus.Close()
+			sub := bus.Subscribe()
+			defer sub.Close()
+
+			cc := tetra.New(tetra.Options{
+				Bus:         bus,
+				Log:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+				SystemName:  "TETRASite",
+				FrequencyHz: controlFreqHz,
+			})
+			cc.SetChannelCoding(tetra.ChannelCodingOn)
+			cc.SetExpectedChannel(tetra.ChannelSCHHD)
+			cc.SetColourCode(colourCode)
+
+			rx := New(Options{
+				SampleRateHz:        sampleRateHz,
+				ClockMode:           ClockGardner,
+				GardnerGain:         gardnerGain,
+				EnableAFC:           true,
+				EnableChannelFilter: true,
+				DibitSink:           func(d []uint8, b int) { cc.Process(d, b) },
+				SoftSink:            func(diffs []complex64, b int) { cc.StashSoft(diffs, b) },
+			})
+
+			const chunk = 4096
+			for i := 0; i < len(iq); i += chunk {
+				end := i + chunk
+				if end > len(iq) {
+					end = len(iq)
+				}
+				rx.Process(iq[i:end])
+			}
+
+			locked := false
+		drain:
+			for {
+				select {
+				case ev := <-sub.C:
+					if ev.Kind == events.KindCCLocked {
+						locked = true
+					}
+				default:
+					break drain
+				}
+			}
+			if !locked {
+				t.Fatalf("no cc.locked at CFO=%.0f Hz (afc reported %.0f Hz): the AFC failed "+
+					"to acquire a carrier beyond ±2250 Hz (regression for issue #940)",
+					cfoHz, rx.afc.OffsetHz(SymbolRate))
+			}
+		})
+	}
+}
+
+func offsetName(hz float64) string {
+	sign := "+"
+	if hz < 0 {
+		sign = "-"
+		hz = -hz
+	}
+	// small hand-formatter to avoid importing fmt/strconv for a label
+	whole := int(hz + 0.5)
+	digits := []byte{}
+	if whole == 0 {
+		digits = []byte{'0'}
+	}
+	for whole > 0 {
+		digits = append([]byte{byte('0' + whole%10)}, digits...)
+		whole /= 10
+	}
+	return "CFO" + sign + string(digits) + "Hz"
+}

--- a/internal/radio/tetra/receiver/receiver.go
+++ b/internal/radio/tetra/receiver/receiver.go
@@ -245,7 +245,17 @@ func (r *Receiver) Process(iq []complex64) {
 	// matched samples than it consumed.
 	matched := r.matched
 	if r.afc != nil {
-		r.derotated = r.afc.Process(r.derotated, r.matched)
+		// The AFC's coarse (wide-range) stage reads the pre-matched-filter
+		// stream, which is only free of adjacent carriers when the channel
+		// filter ran; without it, pass nil so the AFC stays fine-only rather
+		// than risk locking the coarse estimate onto a neighbour. When the
+		// filter is on, iq still holds that channel-filtered stream here,
+		// sample-aligned with r.matched.
+		var wide []complex64
+		if r.chanFilt != nil {
+			wide = iq
+		}
+		r.derotated = r.afc.Process(r.derotated, r.matched, wide)
 		matched = r.derotated
 		if len(matched) == 0 {
 			return


### PR DESCRIPTION
The carrier AFC estimated the residual offset from the 4×Δφ differential
mean, which wraps into (−π/4, π/4] rad/symbol — an acquisition range of only
±f_sym/8 ≈ ±2250 Hz. A control channel more than 2250 Hz off-centre aliased
into that window; the AFC then de-rotated by the wrong (aliased) estimate and
left a residual that is a non-zero multiple of f_sym/4 = 4500 Hz — a fast
constellation spin that corrupts the Gardner timing-error metric — so the
receiver never locked even on a clean, strong signal. Real SDR front-ends
(RTL-SDR, Airspy, HackRF, non-GPSDO USRP) routinely sit several kHz off, so
this was a genuine acquisition gap (found while investigating #925).

Fix: a two-stage per-block estimate. A coarse mean-frequency stage — the angle
of the block's lag-1 autocorrelation, i.e. the power-weighted spectral
centroid of the symmetric π/4-DQPSK spectrum — has no ±π/4 wrap, so it fixes
which f_sym/4 alias bucket the offset sits in; the existing 4×Δφ estimator
then refines the residual on the coarse-de-rotated block. The coarse stage
reads the pre-matched-filter (channel-filtered) block, because the matched
filter is centred at 0 Hz and biases a spectral estimate of an off-centre
carrier back toward 0; the receiver passes that stream only when the channel
filter is active (otherwise the coarse stage stays off and the AFC is
fine-only, unchanged). Reliable acquisition extends to ~±6 kHz, bounded by the
15 kHz channel-filter cutoff.

Regression test (fails before, passes after): TestReceiverAFCLocksWithLarge-
CarrierOffset drives the production 144 kHz / Gardner / AFC path with ±3–5.5
kHz offsets and asserts lock at each. The existing 144 kHz centred-lock test,
the AFC unit tests, and the #925 real-capture lock test stay green.

Refs #940

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Lb3PkYm1YzgB4BcVxz3315