### PR TITLE
fix(p25p2): make ScramblerProbe self-align to the intra-slot PN44 offset (#915)

### DIFF
--- a/internal/radio/p25/phase2/mac_probe_pin.go
+++ b/internal/radio/p25/phase2/mac_probe_pin.go
@@ -1,0 +1,141 @@
+package phase2
+
+import "github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+
+// probeSweepInterval bounds how often the self-aligning ScramblerProbe
+// re-runs its full-sequence phase sweep while it has not yet pinned a
+// channel's PN44 phase. Sweeping the whole 4320-bit sequence on every MAC
+// burst of an undecodable channel is expensive — the FEC-heavy work,
+// multiplied across the concurrent voice + signalling follows a busy
+// multi-site Phase 2 system runs, starves the live IQ consumer, which is why
+// the reporter saw probe collapse superframe sync entirely ("probe →
+// superframes=0", issue #915). Once a channel decodes, the phase pins on the
+// first RS-valid burst and the sweep never runs again; between misses it is
+// amortised to one full sweep per this many MAC bursts. Counted in MAC
+// bursts, not superframes.
+const probeSweepInterval = 24
+
+// ScramblerPin caches the PN44 channel-bit sequence phase that
+// ScramblerProbe discovers for one P25 Phase 2 traffic channel, so the
+// self-aligning sweep runs once (then O(1) per burst) instead of on every
+// MAC PDU.
+//
+// Why the pin exists (issue #915, Finding B). The completed-call source RID
+// rides an in-call MAC PDU that is PN44-scrambled on the coded channel bits
+// (TIA-102.BBAC-1 §7.2.5). Descrambling needs the burst's phase into the
+// continuous 4320-bit superframe sequence. GopherTrunk derives that phase
+// from its superframe grid (slotChannelPN44Offset = slot·360 + 64, where 64
+// is MACPayloadOffset·2), but the intra-slot offset is a working assumption —
+// the reference decoders place the MAC payload at slot·360 + 20 — so the
+// fixed offset can be wrong by a constant, and then the burst never satisfies
+// the outer RS(24,16,9) parity for any seed (the reporter's mac_rs_valid=0).
+//
+// ScramblerProbe resolves this by trying candidate phases against the RS
+// gate: a wrong phase packs into random bytes that satisfy the 8-symbol
+// syndrome with probability ≈2^-48, so the first RS-valid phase is the true
+// one. The pre-existing probe swept only the 12 slot BASES while holding the
+// intra-slot offset fixed at the (possibly wrong) grid assumption, so it
+// could never recover a channel whose true intra-slot offset differs — this
+// pin sweeps the full sequence phase, which does, and remembers it.
+//
+// Not safe for concurrent use: construct one per call / follow and drive it
+// from the single receiver goroutine (MACDispatcher owns one).
+type ScramblerPin struct {
+	seq  []byte // precomputed pn44SuperframeBits keystream for seed
+	seed uint64
+
+	have  bool
+	phase int // pinned sequence-phase offset (0..pn44SuperframeBits-1)
+
+	sweptOnce  bool
+	sinceSweep int
+}
+
+// keystream returns the cached PN44 keystream for seed, recomputing it (and
+// dropping any pinned phase) when the seed changes.
+func (p *ScramblerPin) keystream(seed uint64) []byte {
+	if p.seq != nil && p.seed == seed {
+		return p.seq
+	}
+	seq := make([]byte, pn44SuperframeBits)
+	s := framing.NewPN44Scrambler(seed)
+	for i := range seq {
+		seq[i] = s.Next()
+	}
+	p.seq = seq
+	p.seed = seed
+	p.have = false
+	p.sweptOnce = false
+	p.sinceSweep = 0
+	return seq
+}
+
+// descrambleWithSeq XORs bits in place with the precomputed keystream
+// starting at offset (folded into the sequence period). It is the O(1)-per-
+// bit equivalent of descrambleAtOffset's Advance-then-Apply, so the phase
+// sweep does not re-clock the LFSR from zero on every candidate.
+func descrambleWithSeq(bits, seq []byte, offset int) {
+	n := len(seq)
+	offset %= n
+	if offset < 0 {
+		offset += n
+	}
+	for i := range bits {
+		bits[i] ^= seq[offset]
+		offset++
+		if offset == n {
+			offset = 0
+		}
+	}
+}
+
+// decodeAtPhase descrambles macDibits at the given channel-bit phase using
+// the precomputed keystream and runs the RS-gated FEC + parse chain. The RS
+// gate is what lets the probe tell the true phase from a wrong one, so it is
+// always on here regardless of the channel's RSMode.
+func decodeAtPhase(macDibits []uint8, mode TrellisMode, interleave InterleaveMode, seq []byte, phase int) (MACPDU, bool) {
+	bits := framing.DibitsToBits(macDibits)
+	descrambleWithSeq(bits, seq, phase)
+	return decodeMACChannelAndParse(framing.BitsToDibits(bits), mode, interleave, RSOn)
+}
+
+// probeSubframe recovers the MAC PDU from one MAC sub-frame under the
+// self-aligning ScramblerProbe, using and updating the pin. slotIndex is the
+// sub-frame's 0..11 position within the superframe (known once superframe
+// sync has locked), so the candidate phase is slotIndex·360 + phase. Because
+// the intra-slot offset is constant across the 12 slots, a phase discovered
+// on one slot applies to all of them, so the pin generalises after the first
+// RS-valid burst.
+func (p *ScramblerPin) probeSubframe(macDibits []uint8, mode TrellisMode, interleave InterleaveMode, seed uint64, slotIndex int) (MACPDU, bool) {
+	seq := p.keystream(seed)
+	base := slotIndex * DibitsPerSubframe * 2 // slot base, in channel bits
+
+	// Fast path: a pinned channel decodes at its known phase directly.
+	if p.have {
+		if pdu, ok := decodeAtPhase(macDibits, mode, interleave, seq, base+p.phase); ok {
+			return pdu, true
+		}
+		// The pinned phase stopped validating (a re-tune, or a fluke lock) —
+		// drop it and re-sweep.
+		p.have = false
+	}
+
+	// Backoff: while unpinned, sweep the first burst immediately, then at most
+	// once per probeSweepInterval bursts, so an undecodable channel can't
+	// starve the IQ consumer with a full-sequence sweep on every PDU.
+	p.sinceSweep++
+	if p.sweptOnce && p.sinceSweep < probeSweepInterval {
+		return MACPDU{}, false
+	}
+	p.sweptOnce = true
+	p.sinceSweep = 0
+
+	for c := 0; c < pn44SuperframeBits; c++ {
+		if pdu, ok := decodeAtPhase(macDibits, mode, interleave, seq, base+c); ok {
+			p.have = true
+			p.phase = c
+			return pdu, true
+		}
+	}
+	return MACPDU{}, false
+}

--- a/internal/radio/p25/phase2/mac_probe_pin_test.go
+++ b/internal/radio/p25/phase2/mac_probe_pin_test.go
@@ -1,0 +1,117 @@
+package phase2
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
+
+// scrambleMACRegionAt scrambles the MAC payload region of a MAC sub-frame in
+// place at an arbitrary channel-bit phase, standing in for a real downlink
+// whose intra-slot PN44 offset differs from GopherTrunk's superframe-grid
+// assumption (slotChannelPN44Offset). It mirrors EncodeMACSubframeScrambled
+// but takes the phase explicitly. XOR is symmetric, so descrambleAtOffset
+// scrambles here.
+func scrambleMACRegionAt(sub []uint8, seed uint64, phase int) {
+	region := sub[MACPayloadOffset : MACPayloadOffset+macPDUDibitsTrellis]
+	bits := framing.DibitsToBits(region)
+	descrambleAtOffset(bits, seed, phase)
+	copy(region, framing.BitsToDibits(bits))
+}
+
+// TestScramblerProbePinsUnknownIntraSlotOffset is the issue-#915 regression
+// for the self-aligning probe (the second half of Finding B). A real
+// Victorian MMR (WACN 0xBEE00) downlink scrambles the MAC channel bits at
+// slot·360 + 20 (the reference decoders' intra-slot offset), but
+// GopherTrunk's grid assumes slot·360 + 64 (MACPayloadOffset·2). The
+// slot-base-only probe (DecodeSuperframeMACPDUsWithSlot) holds that +64 fixed
+// while it sweeps the 12 slot bases, so it can never descramble a channel
+// whose true intra-slot offset is +20 — which is the mac_rs_valid=0 the
+// reporter measured. The pinned probe sweeps the full sequence phase,
+// discovers +20 from the RS gate, and pins it for the rest of the call.
+//
+// This is a synthetic round-trip (GopherTrunk is receive-only and the
+// reporter's raw IQ capture is not reachable from this build environment): it
+// proves the probe now resolves the intra-slot phase degree of freedom that
+// the fixed-offset descramble cannot. The exact real-air offset is confirmed
+// separately by the reporter's live mac_rs_valid metric, per the
+// verify-before-close policy.
+func TestScramblerProbePinsUnknownIntraSlotOffset(t *testing.T) {
+	const (
+		wacn      = 0xBEE00
+		sysID     = 0x164
+		nac       = 0x161
+		wantSrc   = 0x0A1B2C
+		realIntra = 20 // reference intra-slot channel-bit offset, != MACPayloadOffset*2
+	)
+	if MACPayloadOffset*2 == realIntra {
+		t.Fatal("test premise broken: realIntra must differ from MACPayloadOffset*2 so the fixed offset is wrong")
+	}
+	seed := framing.PN44SeedFromIdentity(wacn, sysID, nac)
+	user := GroupVoiceChannelUser{ServiceOptions: 0x40, GroupAddress: 32202, SourceID: wantSrc}
+	pdu := EncodeMACPDURS(EncodeGroupVoiceChannelUser(user, false))
+
+	// A MAC sub-frame for the given slot, scrambled at the *reference*
+	// intra-slot offset (slot·360 + realIntra), not GopherTrunk's assumed one.
+	build := func(slot int) []uint8 {
+		sub := EncodeMACSubframe(SlotTypeMACSignaling, uint8(slot), pdu, TrellisOn, InterleaveOff)
+		scrambleMACRegionAt(sub, seed, slot*DibitsPerSubframe*2+realIntra)
+		return sub
+	}
+
+	var subs [SubframesPerSuperframe][]uint8
+	for i := range subs {
+		if i == 0 {
+			subs[i] = build(0)
+		} else {
+			subs[i] = EncodeVoiceSubframe(SlotTypeVoice4V, uint8(i), voicePayloads(Voice4VFrameCount))
+		}
+	}
+	sf := decodeOneSuperframe(t, subs)
+	// ScramblerProbe gates on RS to pick the true phase, so it is used with
+	// RSOn (the composer warns when it is not); with RSOn the slot-base probe
+	// does its real RS-gated sweep instead of degrading to a permissive parse.
+	cfg := MACDecodeConfig{Trellis: TrellisOn, RS: RSOn, Scrambler: ScramblerProbe, Seed: seed}
+
+	// Fails-first: the slot-base-only probe (fixed +64 intra-slot) is blind to
+	// the intra-slot degree of freedom and recovers nothing.
+	if got := DecodeSuperframeMACPDUsWithSlot(sf, cfg); len(got) != 0 {
+		t.Fatalf("slot-base probe unexpectedly decoded %d PDUs; it should be blind to the intra-slot offset", len(got))
+	}
+
+	// The fix: the pinned full-phase probe self-aligns to +20.
+	pin := &ScramblerPin{}
+	got := DecodeSuperframeMACPDUsWithSlotPinned(sf, cfg, pin)
+	if len(got) != 1 {
+		t.Fatalf("pinned probe decoded %d PDUs, want 1", len(got))
+	}
+	if !got[0].RSValid {
+		t.Error("pinned probe returned a non-RS-valid PDU; probe must only surface RS-verified PDUs")
+	}
+	u, ok := got[0].PDU.AsGroupVoiceChannelUser()
+	if !ok || u.SourceID != wantSrc {
+		t.Fatalf("recovered PDU = %+v ok=%v, want SourceID=%#x", u, ok, wantSrc)
+	}
+	if !pin.have {
+		t.Fatal("probe did not pin the discovered channel phase")
+	}
+
+	// Cross-slot generalisation: a later sub-frame on a *different* slot with
+	// the same constant offset decodes via the pinned phase — the pin applies
+	// slot·360 + phase across the superframe's 12 slots.
+	var subs2 [SubframesPerSuperframe][]uint8
+	for i := range subs2 {
+		if i == 4 {
+			subs2[i] = build(4)
+		} else {
+			subs2[i] = EncodeVoiceSubframe(SlotTypeVoice4V, uint8(i), voicePayloads(Voice4VFrameCount))
+		}
+	}
+	got2 := DecodeSuperframeMACPDUsWithSlotPinned(decodeOneSuperframe(t, subs2), cfg, pin)
+	if len(got2) != 1 || !got2[0].RSValid {
+		t.Fatalf("pinned probe failed to decode a different slot via the pinned phase: got %d PDUs", len(got2))
+	}
+	if u2, ok := got2[0].PDU.AsGroupVoiceChannelUser(); !ok || u2.SourceID != wantSrc {
+		t.Fatalf("cross-slot recovered PDU = %+v ok=%v, want SourceID=%#x", u2, ok, wantSrc)
+	}
+}

--- a/internal/radio/p25/phase2/superframe_ingest.go
+++ b/internal/radio/p25/phase2/superframe_ingest.go
@@ -84,6 +84,44 @@ func DecodeSuperframeMACPDUsWithSlot(sf Superframe, cfg MACDecodeConfig) []Decod
 	return out
 }
 
+// DecodeSuperframeMACPDUsWithSlotPinned is DecodeSuperframeMACPDUsWithSlot
+// with a self-aligning ScramblerProbe. When cfg.Scrambler is ScramblerProbe
+// and pin is non-nil, each MAC sub-frame is descrambled at the channel phase
+// the pin has discovered (or, until one is found, an RS-gated sweep of the
+// full 4320-bit sequence), so probe recovers a channel whose true intra-slot
+// PN44 offset differs from GopherTrunk's superframe-grid assumption
+// (slotChannelPN44Offset) — the mac_rs_valid=0 case in issue #915, Finding B.
+// The slot-base-only sweep in DecodeSuperframeMACPDUsWithSlot holds that
+// intra-slot offset fixed, so it cannot. For any other scrambler mode, or a
+// nil pin, this is identical to DecodeSuperframeMACPDUsWithSlot.
+func DecodeSuperframeMACPDUsWithSlotPinned(sf Superframe, cfg MACDecodeConfig, pin *ScramblerPin) []DecodedMACPDU {
+	if pin == nil || cfg.Scrambler != ScramblerProbe {
+		return DecodeSuperframeMACPDUsWithSlot(sf, cfg)
+	}
+	macLen := macPDUDibits
+	if cfg.Trellis == TrellisOn {
+		macLen = macPDUDibitsTrellis
+	}
+	var out []DecodedMACPDU
+	for _, sub := range sf.Subframes {
+		if !sub.SlotType.IsMAC() {
+			continue
+		}
+		if len(sub.Dibits) < MACPayloadOffset+macLen {
+			continue
+		}
+		macDibits := sub.Dibits[MACPayloadOffset : MACPayloadOffset+macLen]
+		if pdu, ok := pin.probeSubframe(macDibits, cfg.Trellis, cfg.Interleave, cfg.Seed, sub.Index); ok {
+			out = append(out, DecodedMACPDU{
+				SlotType: sub.SlotType,
+				PDU:      pdu,
+				RSValid:  verifyMACPDURS(AssembleMACPDU(pdu)),
+			})
+		}
+	}
+	return out
+}
+
 // DecodeSuperframeMACPDUs returns every successfully decoded MAC PDU
 // found in sf's MAC-typed sub-frames, in sub-frame order. Voice
 // sub-frames are skipped. Both the control-channel ingest path and the

--- a/internal/sigfollow/dispatcher.go
+++ b/internal/sigfollow/dispatcher.go
@@ -52,6 +52,11 @@ type MACDispatcher struct {
 	motorolaAliasAsm *p25p2.MotorolaAliasAssembler
 	macSeen          map[uint32]struct{}
 
+	// scramblerPin lets ScramblerProbe self-align to this channel's PN44
+	// phase once and reuse it, instead of sweeping on every MAC burst (issue
+	// #915). One per dispatcher, driven single-threaded from Dispatch.
+	scramblerPin *p25p2.ScramblerPin
+
 	onCallSource     func(p25p2.GroupVoiceChannelUser)
 	onCallEncryption func(p25p2.EncryptionSync)
 }
@@ -99,6 +104,7 @@ func NewMACDispatcher(opts MACDispatcherOptions) *MACDispatcher {
 		aliasAsm:         p25p2.NewTalkerAliasAssembler(nil),
 		motorolaAliasAsm: p25p2.NewMotorolaAliasAssembler(nil),
 		macSeen:          make(map[uint32]struct{}),
+		scramblerPin:     &p25p2.ScramblerPin{},
 		onCallSource:     opts.OnCallSource,
 		onCallEncryption: opts.OnCallEncryption,
 	}
@@ -113,7 +119,7 @@ func NewMACDispatcher(opts MACDispatcherOptions) *MACDispatcher {
 // channel nearly every PDU is RS-valid, whereas a mis-framed traffic
 // channel decodes a stream of random bytes that (almost) never verify.
 func (d *MACDispatcher) Dispatch(sf p25p2.Superframe, macCfg p25p2.MACDecodeConfig) (decodedCount, rsValidCount int) {
-	decoded := p25p2.DecodeSuperframeMACPDUsWithSlot(sf, macCfg)
+	decoded := p25p2.DecodeSuperframeMACPDUsWithSlotPinned(sf, macCfg, d.scramblerPin)
 	for _, dec := range decoded {
 		pdu := dec.PDU
 		if dec.RSValid {


### PR DESCRIPTION
## Summary

On the reporter's Victorian MMR Phase 2 air, `mac_rs_valid=0` on every locked superframe (issue #915, Finding B): the completed-call source RID rides an in-call MAC PDU that is PN44-scrambled on the coded channel bits, and GopherTrunk's descramble phase (`slotChannelPN44Offset = slot·360 + 64`, where `64 = MACPayloadOffset·2`) is a superframe-grid *working assumption*. The reference decoders place the MAC payload at `slot·360 + 20`, so when the true intra-slot offset differs by a constant, the burst never satisfies the outer RS(24,16,9) parity for any seed. `ScramblerProbe` was meant to resolve this against the RS gate, but it swept only the 12 slot **bases** while holding the intra-slot offset fixed at the (possibly wrong) assumption — so it could never recover such a channel, and its full FEC-heavy sweep on *every* MAC burst starved the live IQ consumer (the reporter's "probe → superframes=0").

## Changes

- Add `ScramblerPin` (`internal/radio/p25/phase2/mac_probe_pin.go`): a per-channel cache that sweeps the **full 4320-bit sequence phase** against the RS gate once, pins the discovered phase, then descrambles at `slot·360 + phase` directly (O(1) per burst). The intra-slot offset is constant across the 12 slots, so a phase found on one slot generalises to all of them.
  - While unpinned the sweep is amortised (`probeSweepInterval`) so it can no longer starve superframe acquisition, and it uses a precomputed keystream instead of re-clocking the LFSR from zero per candidate.
  - Probe surfaces **only RS-verified PDUs** regardless of the channel's `RSMode`, preserving the #915/#924 source-RID integrity gate (a wrong RID is worse than an absent one).
- Add `DecodeSuperframeMACPDUsWithSlotPinned` (`superframe_ingest.go`): identical to `DecodeSuperframeMACPDUsWithSlot` for every mode except probe-with-a-pin. Existing callers/behaviour unchanged (nil pin → old path).
- Wire the pin into `MACDispatcher` (`internal/sigfollow/dispatcher.go`), the single choke point shared by the voice composer and the signalling follower, so both real-air Phase 2 paths get the self-aligning probe.

## Test plan

- [x] `make vet test` is green locally
- [ ] `make integration` — n/a (no daemon/DSP wiring change; pure decode-layer)
- [x] Added a regression test: `TestScramblerProbePinsUnknownIntraSlotOffset` scrambles a MAC sub-frame at `slot·360 + 20` (≠ the assumed `+64`) — the slot-base probe (`DecodeSuperframeMACPDUsWithSlot`) recovers **0** PDUs, the pinned probe self-aligns and recovers the source RID (RS-valid), and a *different* slot then decodes via the pinned phase. Fails against the old path, passes with the fix.
- [ ] Real hardware: **not reachable from this build environment** — the reporter's raw IQ capture host (`eri.com.au`) is blocked by the network policy, so this is a synthetic round-trip that proves the probe resolves the intra-slot phase *degree of freedom*, not the exact real-air offset.

## Breaking changes

None. Default behaviour (`ScramblerOn` with the fixed offset) is untouched; the change only affects `ScramblerProbe`, and only makes it strictly more capable (self-aligns to an unknown constant offset) and cheaper (pinned, amortised).

## Docs / CHANGELOG

- [ ] n/a — deliberately no "fixed" CHANGELOG bullet yet: the real-air offset is confirmed separately by the reporter's live `mac_rs_valid` metric (verify-before-close), so this is **Refs #915**, not Closes.

## Linked issues

Refs #915

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RagXANPJKfd2qPUcrEhEC1

---
_Generated by [Claude Code](https://claude.ai/code/session_01RagXANPJKfd2qPUcrEhEC1)_