### PR TITLE
docs(p25): finish LSM/simulcast vs CQPSK correction on the surfaces #958 missed (#935)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,9 @@ for tagged releases.
   readable from emission-designator/licensing data. All guidance now says: leave it at
   C4FM, and switch a channel to `cqpsk` only when a strong, clean signal won't lock in
   C4FM. The per-channel override feature itself is unchanged and still correct for
-  genuinely-CQPSK systems. (issue #935)
+  genuinely-CQPSK systems. A follow-up completes the same correction on the surfaces the
+  first pass missed — the opt-in-features reference, the web config-builder's per-channel
+  demod-override help, and the system-identification learn article. (issue #935)
 - **P25 Phase 2 superframes now lock under any dibit rotation.** Real-air Phase 2
   is differentially decoded H-DQPSK, so a residual carrier offset near an odd
   multiple of ±1500 Hz (a quarter of the 6000-baud symbol rate) rotates every

--- a/docs/learn/digital-trunking/identifying-the-system.md
+++ b/docs/learn/digital-trunking/identifying-the-system.md
@@ -76,8 +76,8 @@ closes, and the *shape* reveals the modulation family:
   peaks.
 - **A ring of phase points** — **π/4-DQPSK** (TETRA): the constellation rotates in
   quarter-pi steps and traces a rosette rather than fixed levels.
-- **A tight four-corner QPSK box** — **CQPSK/LSM**, the linear cousin P25 simulcast
-  transmitters use.
+- **A tight four-corner QPSK box** — **CQPSK/LSM**, a linear P25 modulation some
+  systems transmit (simulcast alone does not imply it — most simulcast is C4FM).
 
 A clean lock draws tight clusters and a wide-open eye; smearing means you're close to
 the noise floor — useful information, but don't mistake a weak-signal smear for the
@@ -98,11 +98,11 @@ peaks, and a two-versus-four-level question answers itself.
     <g fill="currentColor"><circle cx="270" cy="55" r="3.5"/><circle cx="300" cy="68" r="3.5"/><circle cx="313" cy="98" r="3.5"/><circle cx="300" cy="128" r="3.5"/><circle cx="270" cy="141" r="3.5"/><circle cx="240" cy="128" r="3.5"/><circle cx="227" cy="98" r="3.5"/><circle cx="240" cy="68" r="3.5"/></g>
     <!-- CQPSK -->
     <text x="450" y="22" font-weight="600">CQPSK / LSM</text>
-    <text x="450" y="36" font-size="8.5">P25 simulcast — QPSK box</text>
+    <text x="450" y="36" font-size="8.5">P25 linear/LSM — QPSK box</text>
     <g fill="currentColor"><circle cx="420" cy="68" r="4"/><circle cx="480" cy="68" r="4"/><circle cx="420" cy="128" r="4"/><circle cx="480" cy="128" r="4"/></g>
   </g>
 </svg>
-<figcaption>The constellation gives away the modulation family at a glance: four levels for FSK systems, a rosette ring for TETRA's π/4-DQPSK, a four-corner box for CQPSK simulcast.</figcaption>
+<figcaption>The constellation gives away the modulation family at a glance: four levels for FSK systems, a rosette ring for TETRA's π/4-DQPSK, a four-corner box for CQPSK/LSM.</figcaption>
 </figure>
 
 ## Clue 3 — audio and burst cadence
@@ -121,7 +121,7 @@ recognition table as a field guide:
 
 | System | Channel bandwidth | Modulation | Access | Telltale |
 |--------|-------------------|------------|--------|----------|
-| **P25 Phase 1** | 12.5 kHz | C4FM (or CQPSK simulcast) | FDMA | Four levels, continuous trace, 4800 sym/s |
+| **P25 Phase 1** | 12.5 kHz | C4FM (or CQPSK/LSM on some systems) | FDMA | Four levels, continuous trace, 4800 sym/s |
 | **P25 Phase 2** | 6.25 kHz equiv. | H-CPM / TDMA | TDMA (2-slot) | Narrow channel, pulsing bursts |
 | **DMR** | 12.5 kHz | 4FSK | TDMA (2-slot) | Four levels *and* slotting on one 12.5 kHz carrier |
 | **NXDN** | 6.25 / 12.5 kHz | 4FSK | FDMA | Very narrow carrier, four levels, continuous |

--- a/docs/opt-in-features.md
+++ b/docs/opt-in-features.md
@@ -100,18 +100,27 @@ decimator per system.
 
 ## 2a. P25 Phase 1 demodulator selection
 
-**C4FM on by default; opt into CQPSK/LSM per system.** Conventional
-P25 Phase 1 sites transmit C4FM on the air — the FM-discriminator +
-4-level slicer the receiver ships with handles them. P25 simulcast
-deployments commonly transmit the control channel as
+**C4FM on by default; opt into CQPSK/LSM only when a site genuinely
+transmits it.** Almost all P25 Phase 1 sites transmit C4FM on the air —
+**including most simulcast systems** — and the FM-discriminator +
+4-level slicer the receiver ships with handles them. Some systems
+instead transmit
 [Linear Simulcast Modulation](https://www.dsheirer.com/linear-simulcast-modulation/)
-(LSM, TIA-102.BAAA), a CQPSK-shaped variant designed to survive the
-multi-transmitter overlap that destroys pure C4FM. LSM pushed through
+(LSM, TIA-102.BAAA), a CQPSK-shaped linear waveform. LSM pushed through
 an FM discriminator produces near-random dibits and the FSW never
 matches — the failure mode reported against
 [issue #275](https://github.com/MattCheramie/GopherTrunk/issues/275).
 
-Operators on simulcast sites opt into the CQPSK path per system:
+**Simulcast does not imply CQPSK.** Simulcast is a transmitter-
+coordination technique, not a modulation — most simulcast systems
+(Victoria's MMR, its multi-tower Melbourne CBD included) transmit plain
+C4FM, and forcing CQPSK there kills the decode. You cannot read the
+modulation off the fact a site is simulcast, nor off emission-designator
+/ licensing data (`10K1D7W` covers both C4FM and CQPSK). Determine it
+empirically: leave it at C4FM, and switch a system — or a single site,
+via the per-channel `p25_phase1_demod_mode` override
+([issue #935](https://github.com/MattCheramie/GopherTrunk/issues/935)) —
+to CQPSK only when a strong, clean signal will not lock in C4FM:
 
 | Receiver | YAML key | Default | Opt-in string |
 | --- | --- | --- | --- |

--- a/web/configbuilder/src/sections/SDR.tsx
+++ b/web/configbuilder/src/sections/SDR.tsx
@@ -232,9 +232,9 @@ function DeviceEditor(props: {
                   options={[
                     { value: "", label: "Inherit system default" },
                     { value: "c4fm", label: "C4FM / FM" },
-                    { value: "cqpsk", label: "CQPSK / LSM (simulcast)" },
+                    { value: "cqpsk", label: "CQPSK / LSM (linear)" },
                   ]}
-                  help="Override the system's demod path for this site only. Use when one P25 system mixes LSM simulcast and C4FM sites (issue #935). P25 Phase 1 only."
+                  help="Override the system's demod path for this site only. Use when one P25 system genuinely mixes CQPSK/linear (LSM) sites and C4FM sites — decided empirically (a strong signal won't lock in C4FM), NOT just because a site is simulcast (most simulcast is C4FM). Issue #935. P25 Phase 1 only."
                 />
               </div>
             )}


### PR DESCRIPTION
## Summary

The #935 feature (per-channel `p25_phase1_demod_mode` override, #942) and the guidance correction (#958) both landed, but the reporter's core correction — **simulcast does not imply CQPSK; most simulcast is C4FM; set `cqpsk` only empirically** — was not applied to three user-facing surfaces #958 didn't reach. They still told operators the backwards thing. This finishes the correction so the docs speak with one voice.

## Changes

- **`docs/opt-in-features.md` §2a** — still said *"P25 simulcast deployments commonly transmit … LSM"* and *"Operators on simulcast sites opt into the CQPSK path per system"* (the exact backwards advice). Reworded to: C4FM is correct for almost all sites **including most simulcast**; LSM/CQPSK is a linear waveform *some* systems transmit, not implied by simulcast and not readable off emission-designator data (`10K1D7W` covers both); switch to `cqpsk` — system-wide or per-channel — only empirically, when a strong, clean signal won't lock in C4FM.
- **`web/configbuilder/src/sections/SDR.tsx`** — the React config-builder's per-channel demod-override option label (`"CQPSK / LSM (simulcast)"` → `"CQPSK / LSM (linear)"`) and help text reframed off *simulcast* onto *genuinely-CQPSK/linear, decided empirically*. (#958 corrected the Go-side `fieldmeta.go` but not this web builder.)
- **`docs/learn/digital-trunking/identifying-the-system.md`** — softened *"CQPSK/LSM, the linear cousin P25 simulcast transmitters use"* and the *"CQPSK simulcast"* constellation labels so the modulation-identification guidance no longer implies simulcast ⟹ CQPSK.
- **`CHANGELOG.md`** — extended the existing (Unreleased) #958 bullet to note these follow-up surfaces, rather than adding a redundant entry.

## Test plan

- [x] Docs/UI wording only — **no behaviour change**. No Go files touched, so the Go build/test state is identical to `main`; the per-channel override feature (#942) and the `lsm`/`linear`→`cqpsk` alias are untouched.
- [ ] `make vet test` — not re-run: zero Go changes (nothing for it to exercise beyond `main`).
- [ ] Web config-builder typecheck — the change is pure string content inside existing JSX props (no structural/type change); the build toolchain isn't provisioned in this environment, so it wasn't run.

## Breaking changes

None.

## Docs / CHANGELOG

- [x] Extended the existing `## [Unreleased]` CHANGELOG bullet for #935.
- [x] `README.md` — n/a (no operator-facing behaviour change).

## Linked issues

Refs #935

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RagXANPJKfd2qPUcrEhEC1

---
_Generated by [Claude Code](https://claude.ai/code/session_01RagXANPJKfd2qPUcrEhEC1)_