### PR TITLE
fix(tetra): end voice calls on decoded speech + make ACELP bit-exact to the ETSI reference

### DIFF
--- a/internal/voice/acelp/etsi_reference_test.go
+++ b/internal/voice/acelp/etsi_reference_test.go
@@ -15,9 +15,12 @@ import (
 //	sdecoder serial.bin ref_out.pcm                   # ETSI reference decoder
 //
 // GT_ETSI_SERIAL = serial.bin : shared bitstream, int16 LE, 138 words/frame
+//
 //	(word 0 = BFI, words 1..137 = the 137 coded speech bits 0/1) — exactly the
 //	format ETSI sdecoder reads (Bits2prm_Tetra) and GT's Decoder.Decode consumes.
+//
 // GT_ETSI_REF = ref_out.pcm : reference decoder output, int16 LE, 240 samples/
+//
 //	frame, INCLUDING the reference Post_Process (saturating x2 after Decod_Tetra).
 //	GT omits that x2, so the harness applies postProcessX2 to GT's output first.
 //

--- a/internal/voice/acelp/etsi_reference_test.go
+++ b/internal/voice/acelp/etsi_reference_test.go
@@ -1,0 +1,127 @@
+package acelp
+
+import (
+	"encoding/binary"
+	"os"
+	"testing"
+)
+
+// TestETSIReferenceConformance is the authoritative bit-exact conformance check
+// for the clean-room TETRA ACELP decoder against the ETSI EN 300 395-2 reference
+// C codec. It is skipped unless GT_ETSI_SERIAL and GT_ETSI_REF point at files
+// produced by the reference tools:
+//
+//	scoder   in.pcm     serial.bin  synth_local.pcm   # ETSI reference encoder
+//	sdecoder serial.bin ref_out.pcm                   # ETSI reference decoder
+//
+// GT_ETSI_SERIAL = serial.bin : shared bitstream, int16 LE, 138 words/frame
+//	(word 0 = BFI, words 1..137 = the 137 coded speech bits 0/1) — exactly the
+//	format ETSI sdecoder reads (Bits2prm_Tetra) and GT's Decoder.Decode consumes.
+// GT_ETSI_REF = ref_out.pcm : reference decoder output, int16 LE, 240 samples/
+//	frame, INCLUDING the reference Post_Process (saturating x2 after Decod_Tetra).
+//	GT omits that x2, so the harness applies postProcessX2 to GT's output first.
+//
+// The decoder is fixed-point integer maths, so a faithful port matches the
+// reference sample-for-sample (0 mismatches). The ETSI sources/vectors are
+// copyrighted and are NOT committed.
+//
+// Reference build note (64-bit hosts): the ETSI basic-op saturation assumes a
+// 32-bit Word32 (`typedef long`, 32-bit under ILP32). On LP64 `long` is 64-bit
+// and every saturating op returns garbage — build with Word32 as 32-bit int
+// (edit the typedef, or -m32).
+func TestETSIReferenceConformance(t *testing.T) {
+	serialPath := os.Getenv("GT_ETSI_SERIAL")
+	refPath := os.Getenv("GT_ETSI_REF")
+	if serialPath == "" || refPath == "" {
+		t.Skip("set GT_ETSI_SERIAL and GT_ETSI_REF to the ETSI reference vectors to run the conformance check")
+	}
+
+	serial := readI16LE(t, serialPath)
+	ref := readI16LE(t, refPath)
+
+	const serialPerFrame = 138 // 1 BFI + 137 bits
+	const pcmPerFrame = 240
+	if len(serial)%serialPerFrame != 0 {
+		t.Fatalf("serial length %d is not a multiple of %d", len(serial), serialPerFrame)
+	}
+	nFrames := len(serial) / serialPerFrame
+	if got := len(ref) / pcmPerFrame; got != nFrames {
+		t.Fatalf("frame count mismatch: serial has %d frames, ref has %d", nFrames, got)
+	}
+
+	dec := NewDecoder()
+	bits := make([]byte, speechFrameBits)
+
+	mismatches, maxAbs, bfiFrames := 0, 0, 0
+	firstBadFrame := -1
+	for f := 0; f < nFrames; f++ {
+		base := f * serialPerFrame
+		bfi := serial[base] != 0
+		if bfi {
+			bfiFrames++
+		}
+		for i := 0; i < speechFrameBits; i++ {
+			bits[i] = byte(serial[base+1+i] & 1)
+		}
+		out := dec.Decode(bits, bfi)
+		if len(out) != pcmPerFrame {
+			t.Fatalf("frame %d: decoder returned %d samples, want %d", f, len(out), pcmPerFrame)
+		}
+		for i, s := range out {
+			got := postProcessX2(s)
+			want := ref[f*pcmPerFrame+i]
+			if got != want {
+				mismatches++
+				if d := absDiff(int(got), int(want)); d > maxAbs {
+					maxAbs = d
+				}
+				if firstBadFrame < 0 {
+					firstBadFrame = f
+				}
+			}
+		}
+	}
+
+	t.Logf("frames=%d (bfi=%d) samples=%d mismatches=%d maxAbsDiff=%d firstBadFrame=%d",
+		nFrames, bfiFrames, nFrames*pcmPerFrame, mismatches, maxAbs, firstBadFrame)
+	if mismatches != 0 {
+		t.Errorf("ACELP decode diverges from the ETSI reference: %d/%d samples differ (max abs %d, first at frame %d)",
+			mismatches, nFrames*pcmPerFrame, maxAbs, firstBadFrame)
+	}
+}
+
+// postProcessX2 mirrors the reference Post_Process: a saturating multiply-by-two
+// (add(x, x)) applied to each output sample after Decod_Tetra.
+func postProcessX2(s int16) int16 {
+	v := int32(s) * 2
+	if v > 32767 {
+		return 32767
+	}
+	if v < -32768 {
+		return -32768
+	}
+	return int16(v)
+}
+
+func absDiff(a, b int) int {
+	if a < b {
+		return b - a
+	}
+	return a - b
+}
+
+func readI16LE(t *testing.T, path string) []int16 {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(raw)%2 != 0 {
+		t.Fatalf("%s: odd byte length %d", path, len(raw))
+	}
+	out := make([]int16, len(raw)/2)
+	for i := range out {
+		out[i] = int16(binary.LittleEndian.Uint16(raw[i*2:]))
+	}
+	return out
+}

--- a/internal/voice/acelp/gain.go
+++ b/internal/voice/acelp/gain.go
@@ -103,7 +103,7 @@ func (e *enerPredictor) decEner(index int16, bfi bool, a, prdLt, code []int16, s
 	L = loadSh(e.lastEnerPit, 6)
 	L = subSh(L, enerPlt, 6)
 	L = addSh(L, 12, 15) // gain in Q12
-	exp, frac = lExtract(L)
+	exp, frac = lExtractLog(L)
 	L = pow2fp(exp, frac)
 	if lSub(L, 4915) > 0 { // 1.2 in Q12
 		L = 4915
@@ -113,7 +113,7 @@ func (e *enerPredictor) decEner(index int16, bfi bool, a, prdLt, code []int16, s
 	// Code gain = pow2(0.5*(last_ener_cod - ener_c)).
 	L = loadSh(e.lastEnerCod, 6)
 	L = subSh(L, enerC, 6)
-	exp, frac = lExtract(L)
+	exp, frac = lExtractLog(L)
 	L = pow2fp(exp, frac)
 	gainCod = extractL(L)
 

--- a/internal/voice/acelp/lpc.go
+++ b/internal/voice/acelp/lpc.go
@@ -8,12 +8,16 @@ package acelp
 // filter. Clean-room ports of the reference Fac_Pond / Get_Lsp_Pol / Lsp_Az /
 // Int_Lpc4 / Pond_Ai.
 
-// mpyMix multiplies a double-precision (hi,lo) value by a 16-bit n, in DPF
-// (Mpy_32_16): result ≈ (hi<<16 + lo<<1) * n >> 15.
+// mpyMix multiplies a value split by lExtractLog (hi = L>>15, lo = low 15 bits)
+// by a 16-bit n: hi*n + 2*((lo*n)>>16). Faithful port of the reference mpy_mix
+// (FEXP_TET.C) — it pairs with lExtractLog's L>>15 split, NOT the DPF lExtract.
+// Using the DPF pair here rounds differently and left occasional 1-LSB errors in
+// the interpolated LPC coefficients, which the synthesis filter then grew into a
+// small drift on a handful of frames.
 func mpyMix(hi, lo, n int16) int32 {
-	L := lMult(hi, n)
-	L = lMac(L, mult(lo, n), 1)
-	return L
+	p1 := extractH(lMult0(lo, n))
+	L := lMult0(hi, n)
+	return addSh(L, p1, 1)
 }
 
 // facPond builds the spectral-expansion factor vector for a bandwidth-expansion
@@ -45,7 +49,7 @@ func getLspPol(lsp []int16) [6]int32 {
 	for i := 2; i <= 5; i++ {
 		f[fi] = f[fi-2]
 		for j := 1; j < i; j++ {
-			hi, lo := lExtract(f[fi-1])
+			hi, lo := lExtractLog(f[fi-1])
 			t0 := mpyMix(hi, lo, lsp[li])
 			t0 = lShl(t0, 1)
 			f[fi] = lAdd(f[fi], f[fi-2])

--- a/internal/voice/acelp/mathfp.go
+++ b/internal/voice/acelp/mathfp.go
@@ -69,11 +69,29 @@ func pow2fp(exponent, fraction int16) int32 {
 
 // lExtract splits a 32-bit value into a high word and a low word in the
 // double-precision format used by the LPC routines: hi = L>>16, and lo carries
-// the residual so that L ≈ (hi<<16) + (lo<<1). Mirrors L_Extract.
+// the residual so that L ≈ (hi<<16) + (lo<<1). Mirrors the standard ITU-T
+// L_Extract; pairs with lComp.
 func lExtract(l int32) (hi, lo int16) {
 	hi = extractH(l)
 	lo = extractL(lMsu(lShr(l, 1), hi, 16384))
 	return hi, lo
+}
+
+// lExtractLog splits a Q15 log-domain value into its integer exponent and Q15
+// fraction for pow2fp: exp = L>>15, frac = L - (exp<<15) (the low 15 bits). This
+// is a faithful port of the TETRA reference L_extract (FEXP_TET.C):
+//
+//	hi = extract_h(L_shl(L, 1))          // L>>15, with L_shl saturation
+//	lo = extract_l(sub_sh(L, hi, 15))    // low 15 bits
+//
+// Dec_Ener feeds L_extract's output straight to pow2 as an (integer, fraction)
+// pair, so the split MUST use this L>>15 convention — distinct from the DPF
+// lExtract (L>>16) the LPC path uses. Mixing the two is what made the recovered
+// gains 2^N too small (the whole call decoded at a fraction of its true level).
+func lExtractLog(l int32) (exp, frac int16) {
+	exp = extractH(lShl(l, 1))
+	frac = extractL(subSh(l, exp, 15))
+	return exp, frac
 }
 
 // lComp reconstructs a 32-bit value from the double-precision (hi,lo) pair,

--- a/internal/voice/acelp/vocoder.go
+++ b/internal/voice/acelp/vocoder.go
@@ -25,7 +25,10 @@ func (v *vocoder) FrameSize() int { return speechFrameBytes }
 func (v *vocoder) Reset()         { v.d = NewDecoder() }
 func (v *vocoder) Close() error   { return nil }
 
-// Decode renders one packed 137-bit speech frame to 240 PCM samples.
+// Decode renders one packed 137-bit speech frame to 240 PCM samples. The raw
+// Decod_Tetra synthesis is post-processed by the reference's saturating x2
+// (Post_Process, EN 300 395-2) so the output level matches the ETSI reference
+// decoder sample-for-sample; without it GT's audio is 6 dB below reference.
 func (v *vocoder) Decode(frame []byte) ([]int16, error) {
 	bfi := len(frame) < speechFrameBytes
 	var bits []byte
@@ -37,7 +40,11 @@ func (v *vocoder) Decode(frame []byte) ([]int16, error) {
 			}
 		}
 	}
-	return v.d.Decode(bits, bfi), nil
+	pcm := v.d.Decode(bits, bfi)
+	for i, sfin := range pcm {
+		pcm[i] = addOp(sfin, sfin) // Post_Process: saturating x2
+	}
+	return pcm, nil
 }
 
 // Compile-time check that vocoder satisfies voice.Vocoder.


### PR DESCRIPTION
## Summary

Two TETRA voice defects reported from a live capture. First, a TETRA call **never ended** — the single `cc:same-carrier` voice device stayed held forever, so every later grant was dropped with `no voice device available for grant` and the operator got only one voice call. Second, validating the clean-room ACELP decoder against the ETSI EN 300 395-2 reference revealed the decoder was **not bit-exact** — recovered gains were ~2^N too small, so a decoded call came out ~18 dB low with the wrong spectral shape (i.e. garbled/near-silent audio).

## Changes

**Call teardown (`6875de6`)**
- Drive TETRA call liveness from CRC-valid TCH/S speech, not raw carrier bursts. The traffic extractor emits a burst for all four TDMA timeslots continuously, and the old code refreshed the hangtime timer on every burst, so a live carrier held the voice device forever. Now `onVoice` fires only when `tetra.TCHSpeechFrames` recovers a speech frame — so the call ends hangtime after the last decoded speech (or via the no-voice timeout), freeing the device for the next grant.
- Extracted the burst callback into `Composer.onTETRATrafficBurst` so the gate is unit-testable without the DSP path.

**ACELP bit-exactness (`65f63e2`)**
- Two porting bugs, both from reusing the double-precision `L_Extract` convention (`hi = L>>16`) where the TETRA reference's `L_extract` (`hi = L>>15`) is required:
  - **Gain dequantiser** fed `pow2` the wrong exponent split → gains ~2^N too small → whole call ~18 dB low. Added `lExtractLog` (faithful port of the reference `L_extract`) and used it in `decEner`.
  - **LSP→LPC (`Get_Lsp_Pol`)** used the DPF split + an `lMult`-based `mpyMix`, rounding differently from the reference `L_extract` + `mpy_mix` (`L_mult0`-based), leaving 1-LSB LPC errors the synthesis filter grew into drift on a handful of frames. Ported `mpy_mix` faithfully.
  - Applied the reference `Post_Process` (saturating ×2 after `Decod_Tetra`) in the vocoder so GT's decoded level matches the reference (was 6 dB low).

## Test plan

- [x] `make vet test` is green locally
- [x] `make integration` is green locally (composer voice chain touched)
- [x] Added or updated tests where appropriate
- [x] Smoke-tested against real hardware / captures — described below

Regression + validation:
- `TestTETRATrafficBurstLivenessGatedByCRC` (composer): failing-first regression — a non-speech burst must not touch call liveness; a CRC-valid burst must. Verified it fails on the pre-fix per-burst logic and passes after. `TestComposerTETRAVoiceChainLifecycle` updated to assert non-speech traffic tears down via the no-voice timeout.
- `TestETSIReferenceConformance` (acelp, skip-guarded by `GT_ETSI_SERIAL`/`GT_ETSI_REF`): after building the ETSI reference decoder and sharing a bitstream, GT decodes it **sample-for-sample — 0 / 96 000 mismatches across 400 frames, including 30 BFI/erasure frames** (concealment path). The ETSI sources/vectors are copyrighted and are **not** committed; the harness skips in CI unless the env vars point at locally-provided vectors. (Reference build note captured in the test: its `Word32 = long` assumes 32-bit; build with `Word32 = int` on LP64 or the saturating ops return garbage.)
- Real-capture smoke test: replaying the reporter's `1020545` `.raw` through the fixed vocoder went from rms 28 / peak 258 (silence-garbage) to rms 2176 / peak 32767 (proper speech-level audio).

## Breaking changes

None. The vocoder ×2 raises raw decoded level to match the reference, but the downstream `normalize`/`enhance` chain already targets loudness, so audible output is unaffected.

## Docs / CHANGELOG

- [ ] Added a `## [Unreleased]` bullet to `CHANGELOG.md` if this is user-visible
- [ ] Updated `README.md` or `docs/` if operator-facing behaviour changed

n/a — no operator-facing config/CLI/endpoint changes. Happy to add a CHANGELOG bullet if you'd like one for the TETRA voice improvement.

## Linked issues

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmkZyhNfZnLVhxxx7miXPv

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmkZyhNfZnLVhxxx7miXPv)_