### PR TITLE
docs(learn): add Programming in Go, DSP, and Deployment modules

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -153,6 +153,30 @@ defaults:
       learn_module: software-licensing
       nav_group: Learn
       permalink: /learn/software-licensing/:basename/
+  - scope:
+      path: "learn/programming-go"
+      type: pages
+    values:
+      layout: lesson
+      learn_module: programming-go
+      nav_group: Learn
+      permalink: /learn/programming-go/:basename/
+  - scope:
+      path: "learn/dsp"
+      type: pages
+    values:
+      layout: lesson
+      learn_module: dsp
+      nav_group: Learn
+      permalink: /learn/dsp/:basename/
+  - scope:
+      path: "learn/deployment"
+      type: pages
+    values:
+      layout: lesson
+      learn_module: deployment
+      nav_group: Learn
+      permalink: /learn/deployment/:basename/
   # Field Guide articles under /reference/ get the reference layout and nav
   # group automatically. The hub (reference/index.md) overrides to reference-hub.
   - scope:

--- a/docs/_data/learn.yml
+++ b/docs/_data/learn.yml
@@ -2956,7 +2956,7 @@ modules:
     title: "Learn Go — from your first program to reading real code"
     tagline: "The language GopherTrunk is written in — from hello world to goroutines, interfaces, and reading a real Go codebase."
     start_slug: why-go
-    workload: "PT5H"
+    workload: "PT9H"
     intro: >
       A hands-on path into Go, the language GopherTrunk itself is built in. Start
       with why Go exists and your first compiled program, learn the type system,
@@ -2986,9 +2986,9 @@ modules:
             minutes: 9
             level: beginner
             status: full
-      - id: the-language
-        label: "Unit 2 — The Language"
-        blurb: "Values, functions, errors, structs, and interfaces — the core of Go."
+      - id: language-fundamentals
+        label: "Unit 2 — Language Fundamentals"
+        blurb: "Values, control flow, functions, errors, pointers, structs, and interfaces — the core of Go."
         lessons:
           - slug: values-and-types
             title: Values, variables & types
@@ -2996,11 +2996,23 @@ modules:
             minutes: 9
             level: beginner
             status: full
+          - slug: control-flow
+            title: Control flow
+            summary: if, for, and switch — Go's deliberately small set of control structures, including the one loop keyword that does everything.
+            minutes: 9
+            level: beginner
+            status: full
           - slug: functions-and-errors
             title: Functions & error handling
-            summary: Multiple return values, the error interface, and why Go returns errors instead of throwing exceptions — the pattern you will see on every line.
+            summary: Multiple return values, the error interface, and why Go returns errors instead of throwing exceptions — the pattern you'll see on every line.
             minutes: 10
             level: beginner
+            status: full
+          - slug: pointers
+            title: Pointers
+            summary: What a pointer is, why Go has them without pointer arithmetic, and how they let functions modify values and avoid copying big structs.
+            minutes: 9
+            level: intermediate
             status: full
           - slug: structs-and-methods
             title: Structs & methods
@@ -3014,9 +3026,37 @@ modules:
             minutes: 10
             level: intermediate
             status: full
+      - id: data-and-text
+        label: "Unit 3 — Data & Text"
+        blurb: "The collections, text, files, and encodings real programs are built from."
+        lessons:
+          - slug: slices-maps-generics
+            title: Slices, maps & generics
+            summary: Go's core collections — slices and maps — how they grow and alias, plus type parameters (generics) for reusable, type-safe code.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: strings-and-runes
+            title: Strings, bytes & runes
+            summary: How Go handles text — immutable strings, byte slices, and runes — and why Unicode means a character isn't always one byte.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: json-and-serialization
+            title: JSON & serialization
+            summary: Turning Go structs into JSON and back with encoding/json, struct tags, and the marshal/unmarshal pattern behind most APIs and config.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: working-with-files
+            title: Working with files & I/O
+            summary: Reading and writing files and streams with os, io, and bufio — and the reader/writer interfaces that make it all composable.
+            minutes: 9
+            level: intermediate
+            status: full
       - id: concurrency
-        label: "Unit 3 — Concurrency"
-        blurb: "Goroutines, channels, and coordination — Go's headline feature."
+        label: "Unit 4 — Concurrency"
+        blurb: "Goroutines, channels, coordination, and the patterns that put them to work."
         lessons:
           - slug: goroutines
             title: Goroutines
@@ -3032,13 +3072,25 @@ modules:
             status: full
           - slug: select-and-sync
             title: select & synchronization
-            summary: Coordinate multiple channels with select, and use the sync package — mutexes, WaitGroups, contexts — when channels are not the right tool.
+            summary: Coordinate multiple channels with select, and use the sync package — mutexes, WaitGroups — when channels are not the right tool.
             minutes: 10
             level: advanced
             status: full
-      - id: building-real-programs
-        label: "Unit 4 — Building Real Programs"
-        blurb: "Packages, collections, generics, testing, and the standard library."
+          - slug: context-and-cancellation
+            title: Context & cancellation
+            summary: The context package — how a single cancel signal or timeout propagates through every goroutine in a call tree to shut work down cleanly.
+            minutes: 9
+            level: advanced
+            status: full
+          - slug: concurrency-patterns
+            title: Concurrency patterns
+            summary: Worker pools, pipelines, and fan-out/fan-in — the reusable shapes for structuring concurrent work, the way a real sample pipeline does.
+            minutes: 10
+            level: advanced
+            status: full
+      - id: packages-and-quality
+        label: "Unit 5 — Packages & Quality"
+        blurb: "Organizing, depending on, testing, measuring, and debugging real code."
         lessons:
           - slug: packages-and-modules
             title: Packages & modules
@@ -3046,28 +3098,64 @@ modules:
             minutes: 9
             level: intermediate
             status: full
-          - slug: slices-maps-generics
-            title: Slices, maps & generics
-            summary: Go's core collections — slices and maps — how they grow and alias, plus type parameters (generics) for reusable, type-safe code.
-            minutes: 10
+          - slug: dependency-management
+            title: Dependency management
+            summary: How go.mod and go.sum pin versions, how go get and go mod tidy manage dependencies, and why reproducible builds and few dependencies matter.
+            minutes: 9
             level: intermediate
+            status: full
+          - slug: error-handling-patterns
+            title: Error-handling patterns
+            summary: Beyond if err != nil — wrapping errors with %w, sentinel errors, errors.Is and errors.As, and custom error types for real programs.
+            minutes: 10
+            level: advanced
             status: full
           - slug: testing-in-go
             title: Testing in Go
-            summary: The built-in testing package, table-driven tests, benchmarks, and why testing is a first-class part of the language, not an add-on.
+            summary: The built-in testing package, table-driven tests, and why testing is a first-class part of the language, not an add-on.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: benchmarking-and-profiling
+            title: Benchmarking & profiling
+            summary: Measuring performance with benchmarks and pprof — finding the hot path before optimizing it, the way real-time DSP code demands.
+            minutes: 10
+            level: advanced
+            status: full
+          - slug: debugging-go
+            title: Debugging Go
+            summary: Finding bugs with print debugging, the delve debugger, the race detector, and static analysis — the toolkit for when a test goes red.
             minutes: 9
             level: intermediate
             status: full
           - slug: the-standard-library
             title: The standard library
-            summary: A tour of the batteries Go ships with — io, bytes, encoding, net, and more — and why you reach for a dependency far less often than in other ecosystems.
+            summary: A tour of the batteries Go ships with — io, bytes, encoding, net, and more — and why you reach for a dependency far less often than elsewhere.
             minutes: 9
             level: intermediate
             status: full
       - id: go-in-the-wild
-        label: "Unit 5 — Go in the Wild"
-        blurb: "Read real code, then chart your next steps as a Go developer."
+        label: "Unit 6 — Go in the Wild"
+        blurb: "Logging, project layout, idioms, and reading real code — then your next steps."
         lessons:
+          - slug: logging-and-slog
+            title: Logging with slog
+            summary: Structured logging with the standard log/slog package — levels, fields, and why a running service logs in structured form, not just printed lines.
+            minutes: 8
+            level: intermediate
+            status: full
+          - slug: project-structure
+            title: Structuring a Go project
+            summary: The cmd, internal, and package conventions that shape real Go repositories — where code goes and why, using GopherTrunk's layout as the map.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: idiomatic-go
+            title: Writing idiomatic Go
+            summary: The conventions that make Go code look and read the same everywhere — naming, accepting interfaces, handling errors, and avoiding cleverness.
+            minutes: 9
+            level: intermediate
+            status: full
           - slug: reading-real-go
             title: Reading a real Go codebase
             summary: A guided tour of how a working SDR engine like GopherTrunk is structured in Go — packages, interfaces, and goroutines you can now recognize.
@@ -3093,7 +3181,7 @@ modules:
     title: "Learn DSP — from samples to decoded bits"
     tagline: "The math and code that turn a stream of radio samples into data — filters, FFTs, mixing, and clock recovery, the way an SDR really works."
     start_slug: what-is-dsp
-    workload: "PT5H"
+    workload: "PT9H"
     intro: >
       Software-defined radio is digital signal processing wearing an antenna. This
       path takes the ideas the RF & SDR module introduces and shows how they become
@@ -3111,6 +3199,12 @@ modules:
             minutes: 8
             level: beginner
             status: full
+          - slug: what-is-a-signal
+            title: What is a signal?
+            summary: Amplitude, phase, and the sine wave that underlies everything — the vocabulary of signals before we start turning them into numbers.
+            minutes: 8
+            level: beginner
+            status: full
           - slug: sampling-and-quantization
             title: Sampling & quantization
             summary: Turning a wave into samples — sample rate, the Nyquist limit, bit depth, and the aliasing and quantization noise that come with digitizing.
@@ -3122,6 +3216,12 @@ modules:
             summary: Why SDRs carry signals as complex I/Q pairs, what the imaginary part really means, and how negative frequency becomes a useful, everyday idea.
             minutes: 10
             level: intermediate
+            status: full
+          - slug: the-decibel-in-dsp
+            title: Decibels & dynamic range
+            summary: Why signal levels are measured in decibels, how dB math turns multiplication into addition, and what dynamic range means for a sampled signal.
+            minutes: 9
+            level: beginner
             status: full
       - id: frequency-domain
         label: "Unit 2 — The Frequency Domain"
@@ -3145,6 +3245,18 @@ modules:
             minutes: 9
             level: advanced
             status: full
+          - slug: spectrograms-and-stft
+            title: Spectrograms & the STFT
+            summary: The short-time Fourier transform — sliding the FFT along a signal to see how its spectrum changes over time, the math behind a waterfall.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: the-analytic-signal
+            title: The analytic signal & Hilbert transform
+            summary: How a real signal becomes complex I/Q in the first place — the Hilbert transform, the analytic signal, and why it removes the negative-frequency mirror.
+            minutes: 10
+            level: advanced
+            status: full
       - id: filters
         label: "Unit 3 — Filters"
         blurb: "Selecting the signal you want and throwing away the rest."
@@ -3154,6 +3266,12 @@ modules:
             summary: The operation at the heart of every filter — what an impulse response is, and how sliding-and-summing in time equals multiplying in frequency.
             minutes: 10
             level: advanced
+            status: full
+          - slug: filter-design-basics
+            title: Filter design basics
+            summary: Passband, stopband, transition width, and ripple — the specification you hand a filter designer, and how those choices trade off against each other.
+            minutes: 9
+            level: intermediate
             status: full
           - slug: fir-filters
             title: FIR filters
@@ -3172,6 +3290,12 @@ modules:
             summary: Changing sample rate without aliasing — decimation, interpolation, and rational resampling — how an SDR narrows 2.4 MS/s down to a 48 kHz channel.
             minutes: 10
             level: intermediate
+            status: full
+          - slug: matched-filters-and-pulse-shaping
+            title: Matched filters & pulse shaping
+            summary: Root-raised-cosine filters, the Nyquist no-ISI criterion, and why a matched filter at the receiver maximizes SNR right where symbols are decided.
+            minutes: 10
+            level: advanced
             status: full
       - id: signal-to-bits
         label: "Unit 4 — From Signal to Bits"
@@ -3195,20 +3319,72 @@ modules:
             minutes: 11
             level: advanced
             status: full
+          - slug: carrier-and-frequency-recovery
+            title: Carrier & frequency recovery
+            summary: Correcting the frequency and phase offset between transmitter and receiver — the PLL and Costas loop that lock a carrier before symbols can be read.
+            minutes: 10
+            level: advanced
+            status: full
           - slug: gain-and-agc
             title: Gain & automatic gain control
             summary: Keeping a signal at a usable amplitude as it fades — how an AGC loop works and why the demodulator needs stable levels to decide symbols correctly.
             minutes: 9
             level: intermediate
             status: full
+          - slug: constellations-and-symbol-mapping
+            title: Constellations & symbol mapping
+            summary: Reading digital modulation as points on the I/Q plane — how PSK and QAM map bits to symbols, and what a constellation diagram tells you.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: equalization
+            title: Equalization & multipath
+            summary: Why reflections smear symbols together and how an equalizer undoes a channel's distortion — the filter that adapts to clean up inter-symbol interference.
+            minutes: 10
+            level: advanced
+            status: full
+      - id: quality-and-coding
+        label: "Unit 5 — Signal Quality & Coding"
+        blurb: "Measuring how well a decode is working, and the coding that protects the bits."
+        lessons:
+          - slug: snr-evm-and-ber
+            title: SNR, EVM & BER
+            summary: The three numbers that measure a digital link's health — signal-to-noise ratio, error-vector magnitude, and bit error rate — and how they relate.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: the-eye-diagram
+            title: The eye diagram
+            summary: Overlaying symbol periods into an "eye" — how to read timing margin, noise, and inter-symbol interference at a glance from one picture.
+            minutes: 8
+            level: intermediate
+            status: full
+          - slug: error-correction-and-framing
+            title: Error correction & framing
+            summary: How raw symbols become trustworthy data — sync words, framing, interleaving, and forward error correction that fix bit errors before decoding.
+            minutes: 10
+            level: advanced
+            status: full
+          - slug: real-time-and-buffering
+            title: Real-time processing & buffering
+            summary: Block processing, ring buffers, latency, and keeping up with the sample stream — the engineering that makes DSP run live instead of offline.
+            minutes: 9
+            level: advanced
+            status: full
       - id: dsp-in-practice
-        label: "Unit 5 — DSP in Practice"
+        label: "Unit 6 — DSP in Practice"
         blurb: "Put the whole chain together the way a real decoder does."
         lessons:
           - slug: dsp-in-gophertrunk
             title: DSP in GopherTrunk
             summary: A walkthrough of GopherTrunk's real signal path — capture, downconvert, filter, demodulate, recover symbols — mapping each stage to the lessons you just learned.
             minutes: 11
+            level: advanced
+            status: full
+          - slug: testing-and-debugging-dsp
+            title: Testing & debugging DSP
+            summary: Golden vectors, offline replay of captures, and the invariants that catch a broken signal path — how you prove a decoder actually works.
+            minutes: 10
             level: advanced
             status: full
           - slug: fixed-vs-floating-point
@@ -3230,7 +3406,7 @@ modules:
     title: "Learn deployment — from your machine to production"
     tagline: "How software actually ships and runs — containers, Docker, systemd, CI/CD, and the cloud — using GopherTrunk's own deployment as the worked example."
     start_slug: what-is-deployment
-    workload: "PT5H"
+    workload: "PT9H"
     intro: >
       Writing software is only half the job; getting it running reliably somewhere
       other than your laptop is the other half. This path covers the modern
@@ -3240,11 +3416,17 @@ modules:
     units:
       - id: foundations
         label: "Unit 1 — Foundations"
-        blurb: "What deployment means, and the artifacts and config it depends on."
+        blurb: "What deployment means, its lifecycle, and the artifacts and config it depends on."
         lessons:
           - slug: what-is-deployment
             title: What is deployment?
             summary: The journey from source code to a running service, what "it works on my machine" really costs, and the moving parts every deployment has to handle.
+            minutes: 8
+            level: beginner
+            status: full
+          - slug: the-deployment-lifecycle
+            title: The deployment lifecycle
+            summary: Build, test, release, deploy, operate — the repeating cycle every change moves through, and how the rest of this module maps onto its stages.
             minutes: 8
             level: beginner
             status: full
@@ -3260,9 +3442,15 @@ modules:
             minutes: 9
             level: beginner
             status: full
+          - slug: release-strategies
+            title: Release strategies
+            summary: Rolling, blue-green, and canary releases — the patterns for pushing a new version to users without downtime or a risky big-bang cutover.
+            minutes: 9
+            level: intermediate
+            status: full
       - id: containers
         label: "Unit 2 — Containers"
-        blurb: "Package an app with everything it needs to run, anywhere."
+        blurb: "Package an app with everything it needs to run, anywhere — safely."
         lessons:
           - slug: what-is-a-container
             title: What is a container?
@@ -3272,8 +3460,14 @@ modules:
             status: full
           - slug: writing-a-dockerfile
             title: Writing a Dockerfile
-            summary: Build an image step by step — base images, layers, multi-stage builds, and how GopherTrunk's own Dockerfile turns Go source into a small runtime image.
+            summary: Build an image step by step — base images, layers, and multi-stage builds — and how GopherTrunk's own Dockerfile turns Go source into a small runtime image.
             minutes: 11
+            level: intermediate
+            status: full
+          - slug: container-image-optimization
+            title: Optimizing container images
+            summary: Small, fast, secure images — multi-stage builds, minimal and distroless bases, layer-cache ordering, and .dockerignore — and why GopherTrunk's image is tiny.
+            minutes: 9
             level: intermediate
             status: full
           - slug: images-and-registries
@@ -3288,9 +3482,21 @@ modules:
             minutes: 10
             level: intermediate
             status: full
+          - slug: container-networking-and-volumes
+            title: Container networking & volumes
+            summary: How containers get an IP, talk to each other, publish ports, and persist data — the networking and storage model beneath a Compose file.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: container-security
+            title: Container security
+            summary: Running as non-root, dropping capabilities, read-only filesystems, and scanning images — giving a container exactly the access it needs and no more.
+            minutes: 10
+            level: advanced
+            status: full
       - id: running-in-production
         label: "Unit 3 — Running in Production"
-        blurb: "Keep a service alive, observable, and configured safely."
+        blurb: "Keep a service alive, reachable, observable, and configured safely."
         lessons:
           - slug: services-and-systemd
             title: Services & systemd
@@ -3298,9 +3504,15 @@ modules:
             minutes: 10
             level: intermediate
             status: full
+          - slug: reverse-proxies-and-tls
+            title: Reverse proxies & TLS
+            summary: Putting a service behind nginx or Caddy — terminating HTTPS, routing by host, and why the proxy, not the app, usually handles certificates.
+            minutes: 10
+            level: intermediate
+            status: full
           - slug: logging-and-health-checks
             title: Logging & health checks
-            summary: How a running service tells you it is healthy — structured logs, health endpoints, and the signals an orchestrator uses to restart what is broken.
+            summary: How a running service tells you it's healthy — structured logs, health endpoints, and the signals an orchestrator uses to restart what is broken.
             minutes: 9
             level: intermediate
             status: full
@@ -3310,14 +3522,32 @@ modules:
             minutes: 9
             level: intermediate
             status: full
+          - slug: backups-and-data
+            title: Backups & persistent data
+            summary: Where a service's data lives, how to back it up and restore it, and why stateful data needs a plan that stateless containers don't.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: production-hardening
+            title: Production hardening
+            summary: Least privilege, firewalls, updates, and the systemd sandboxing GopherTrunk ships — locking a deployment down against the threats a real host faces.
+            minutes: 10
+            level: advanced
+            status: full
       - id: automate-and-scale
         label: "Unit 4 — Automate & Scale"
-        blurb: "Ship automatically, host in the cloud, and keep it running."
+        blurb: "Ship automatically, describe infrastructure as code, and grow to meet load."
         lessons:
           - slug: ci-cd-pipelines
             title: CI/CD pipelines
             summary: Automating build, test, and release so every commit is shippable — what a pipeline does, and how GopherTrunk uses GitHub Actions to build and publish.
             minutes: 10
+            level: intermediate
+            status: full
+          - slug: infrastructure-as-code
+            title: Infrastructure as code
+            summary: Describing servers and services declaratively so environments are reproducible — the idea behind tools like Terraform and Ansible, versioned like code.
+            minutes: 9
             level: intermediate
             status: full
           - slug: deploying-to-cloud-and-vps
@@ -3326,14 +3556,60 @@ modules:
             minutes: 10
             level: intermediate
             status: full
+          - slug: container-orchestration
+            title: Container orchestration
+            summary: What Kubernetes and its cousins actually do — scheduling, self-healing, and scaling many containers — and how to tell when you truly need one.
+            minutes: 10
+            level: advanced
+            status: full
+          - slug: scaling-and-load-balancing
+            title: Scaling & load balancing
+            summary: Scaling up vs out, stateless vs stateful services, and how a load balancer spreads traffic across instances — the mechanics of handling more users.
+            minutes: 10
+            level: advanced
+            status: full
+          - slug: zero-downtime-deploys
+            title: Zero-downtime deploys
+            summary: Health-gated rollouts, draining connections, and rollback — how to replace a running version without dropping a single request.
+            minutes: 9
+            level: advanced
+            status: full
+      - id: operate
+        label: "Unit 5 — Operate"
+        blurb: "Keep a live system healthy: monitor it, get alerted, respond, and control cost."
+        lessons:
           - slug: monitoring-and-updates
             title: Monitoring & updates
             summary: Keeping a deployment healthy over time — metrics and alerts, rolling out new versions safely, and rolling back when a release goes wrong.
             minutes: 9
             level: intermediate
             status: full
+          - slug: observability
+            title: Observability — metrics, logs & traces
+            summary: The three pillars that let you understand a running system — metrics, logs, and traces — and how they answer "is it up?", "what happened?", and "why is it slow?".
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: alerting-and-oncall
+            title: Alerting & on-call
+            summary: Turning metrics into pages that matter — good alert thresholds, avoiding alert fatigue, and what being on-call for a service actually means.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: incident-response
+            title: Incident response & runbooks
+            summary: What to do when production breaks — detecting, mitigating, and communicating during an incident, and the runbooks and postmortems that prevent the next one.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: cost-and-resources
+            title: Cost & resource management
+            summary: Right-sizing CPU and memory, understanding what cloud resources cost, and keeping a deployment affordable without starving it.
+            minutes: 9
+            level: intermediate
+            status: full
       - id: deployment-applied
-        label: "Unit 5 — Applied"
+        label: "Unit 6 — Applied"
         blurb: "Deploy a real application from start to finish."
         lessons:
           - slug: deploying-gophertrunk

--- a/docs/_data/learn.yml
+++ b/docs/_data/learn.yml
@@ -84,14 +84,20 @@ learning_paths:
     modules:
       - id: rf-sdr
         note: "Start here — the RF and SDR fundamentals every signal path leans on."
+      - id: dsp
+        note: "How those signals become code — filters, FFTs, mixing, and clock recovery."
       - id: intro-software-dev
         note: "How software is designed, built, tested, and shipped."
+      - id: programming-go
+        note: "Learn Go, the language GopherTrunk itself is written in."
       - id: linux-cli
         note: "The command line where SDR tooling and servers live."
       - id: git
         note: "Version control — the backbone of any real codebase."
       - id: digital-trunking
         note: "Apply it: how trunked systems work and how software follows them."
+      - id: deployment
+        note: "Ship it — package and run your decoder as a real service."
       - id: ai-software-dev
         note: "Optional — use AI tools to accelerate your development workflow."
   - id: rf-hardware
@@ -104,6 +110,8 @@ learning_paths:
     modules:
       - id: rf-sdr
         note: "The physics of signals — waves, power, antennas, propagation."
+      - id: dsp
+        note: "The signal processing that turns captured samples into usable data."
       - id: intro-hardware
         note: "Computers and devices from the ground up, including SDR front-ends."
       - id: networking
@@ -118,12 +126,16 @@ learning_paths:
     modules:
       - id: intro-software-dev
         note: "The craft of building software."
+      - id: programming-go
+        note: "A real language, end to end — Go, from first program to concurrency."
       - id: git
         note: "Version control and collaboration."
       - id: linux-cli
         note: "The command line every developer lives in."
       - id: networking
         note: "How software talks across machines."
+      - id: deployment
+        note: "Containers, CI/CD, and getting your software running in production."
       - id: software-licensing
         note: "The legal side of shipping and reusing code."
   - id: ai-development
@@ -136,12 +148,16 @@ learning_paths:
     modules:
       - id: intro-software-dev
         note: "The software foundations AI work builds on."
+      - id: programming-go
+        note: "A concrete language to build in — Go, from basics to concurrency."
       - id: git
         note: "Version control for any real project."
       - id: ai-software-dev
         note: "Use AI tools to write and ship software faster."
       - id: building-ai
         note: "Build applications powered by AI."
+      - id: deployment
+        note: "Ship your AI feature — containers, config, and CI/CD."
   - id: security
     label: "Cybersecurity"
     title: "Learning Path — Cybersecurity"
@@ -156,6 +172,8 @@ learning_paths:
         note: "You can't secure what you don't understand — start with the network."
       - id: cybersecurity
         note: "Threats, defenses, and the security mindset."
+      - id: deployment
+        note: "Where software actually runs — containers, secrets, and hardening the deploy."
       - id: git
         note: "Track changes and collaborate safely."
   - id: trunked-radio
@@ -168,6 +186,8 @@ learning_paths:
     modules:
       - id: rf-sdr
         note: "Signals, SDR, and how digital voice is carried."
+      - id: dsp
+        note: "The signal processing that recovers bits from a noisy channel."
       - id: digital-trunking
         note: "How trunked control channels and voice calls work."
       - id: intro-hardware
@@ -2928,5 +2948,404 @@ modules:
       title: Glossary of software-licensing terms
       summary: Plain-language definitions for every term in the path — copyright, copyleft, permissive, GPL/AGPL/LGPL, dual licensing, EULA, ToS, SLA, DPA, SBOM, SPDX, indemnity, and more — cross-linked to the lessons.
       minutes: 12
+      level: beginner
+      status: full
+
+  - id: programming-go
+    label: "Programming in Go"
+    title: "Learn Go — from your first program to reading real code"
+    tagline: "The language GopherTrunk is written in — from hello world to goroutines, interfaces, and reading a real Go codebase."
+    start_slug: why-go
+    workload: "PT5H"
+    intro: >
+      A hands-on path into Go, the language GopherTrunk itself is built in. Start
+      with why Go exists and your first compiled program, learn the type system,
+      interfaces, and the concurrency model that makes Go shine, then finish by
+      reading real code from a working SDR engine. No prior Go — or compiled
+      language — experience assumed.
+    units:
+      - id: meeting-go
+        label: "Unit 1 — Meeting Go"
+        blurb: "What Go is, why it exists, and the toolchain you run every day."
+        lessons:
+          - slug: why-go
+            title: Why Go?
+            summary: Where Go came from, the problems it was built to solve, and why a fast, simple, compiled language is a great fit for systems like GopherTrunk.
+            minutes: 8
+            level: beginner
+            status: full
+          - slug: hello-go
+            title: Your first Go program
+            summary: Install Go, write hello world, and understand the difference between go run and go build — from source to a single static binary.
+            minutes: 9
+            level: beginner
+            status: full
+          - slug: the-go-toolchain
+            title: The Go toolchain
+            summary: go build, run, test, fmt, and vet — the batteries-included tools that format, check, and build your code with zero configuration.
+            minutes: 9
+            level: beginner
+            status: full
+      - id: the-language
+        label: "Unit 2 — The Language"
+        blurb: "Values, functions, errors, structs, and interfaces — the core of Go."
+        lessons:
+          - slug: values-and-types
+            title: Values, variables & types
+            summary: Go's built-in types, declarations, zero values, and static typing — why a small, strict type set makes programs easier to reason about.
+            minutes: 9
+            level: beginner
+            status: full
+          - slug: functions-and-errors
+            title: Functions & error handling
+            summary: Multiple return values, the error interface, and why Go returns errors instead of throwing exceptions — the pattern you will see on every line.
+            minutes: 10
+            level: beginner
+            status: full
+          - slug: structs-and-methods
+            title: Structs & methods
+            summary: Group data with structs, attach behaviour with methods, and understand pointer vs value receivers — Go's answer to objects.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: interfaces
+            title: Interfaces & composition
+            summary: Small interfaces, implicit satisfaction, and composition over inheritance — the idea that makes Go code flexible without class hierarchies.
+            minutes: 10
+            level: intermediate
+            status: full
+      - id: concurrency
+        label: "Unit 3 — Concurrency"
+        blurb: "Goroutines, channels, and coordination — Go's headline feature."
+        lessons:
+          - slug: goroutines
+            title: Goroutines
+            summary: Lightweight concurrency you launch with one keyword — what a goroutine is, how it differs from a thread, and why GopherTrunk runs thousands.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: channels
+            title: Channels
+            summary: Typed pipes that let goroutines communicate safely — sending, receiving, buffering, and closing — Go's "share memory by communicating" model.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: select-and-sync
+            title: select & synchronization
+            summary: Coordinate multiple channels with select, and use the sync package — mutexes, WaitGroups, contexts — when channels are not the right tool.
+            minutes: 10
+            level: advanced
+            status: full
+      - id: building-real-programs
+        label: "Unit 4 — Building Real Programs"
+        blurb: "Packages, collections, generics, testing, and the standard library."
+        lessons:
+          - slug: packages-and-modules
+            title: Packages & modules
+            summary: How Go organizes code into packages and modules, how imports and go.mod work, and how visibility is controlled by capitalization.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: slices-maps-generics
+            title: Slices, maps & generics
+            summary: Go's core collections — slices and maps — how they grow and alias, plus type parameters (generics) for reusable, type-safe code.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: testing-in-go
+            title: Testing in Go
+            summary: The built-in testing package, table-driven tests, benchmarks, and why testing is a first-class part of the language, not an add-on.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: the-standard-library
+            title: The standard library
+            summary: A tour of the batteries Go ships with — io, bytes, encoding, net, and more — and why you reach for a dependency far less often than in other ecosystems.
+            minutes: 9
+            level: intermediate
+            status: full
+      - id: go-in-the-wild
+        label: "Unit 5 — Go in the Wild"
+        blurb: "Read real code, then chart your next steps as a Go developer."
+        lessons:
+          - slug: reading-real-go
+            title: Reading a real Go codebase
+            summary: A guided tour of how a working SDR engine like GopherTrunk is structured in Go — packages, interfaces, and goroutines you can now recognize.
+            minutes: 11
+            level: advanced
+            status: full
+          - slug: next-steps-in-go
+            title: Where to go next
+            summary: Idiomatic Go, the tooling ecosystem, the community, and a short project ladder to take you from this path to shipping your own Go programs.
+            minutes: 8
+            level: beginner
+            status: full
+    glossary:
+      slug: glossary
+      title: Glossary of Go terms
+      summary: Plain-language definitions for every Go term in the path — goroutine, channel, interface, slice, struct, method, package, module, and more — cross-linked to the lessons.
+      minutes: 10
+      level: beginner
+      status: full
+
+  - id: dsp
+    label: "Digital Signal Processing"
+    title: "Learn DSP — from samples to decoded bits"
+    tagline: "The math and code that turn a stream of radio samples into data — filters, FFTs, mixing, and clock recovery, the way an SDR really works."
+    start_slug: what-is-dsp
+    workload: "PT5H"
+    intro: >
+      Software-defined radio is digital signal processing wearing an antenna. This
+      path takes the ideas the RF & SDR module introduces and shows how they become
+      code — sampling, the Fourier transform, filters, downconversion, demodulation,
+      and clock recovery — then maps every one of them onto the pipeline GopherTrunk
+      runs to decode digital trunked voice.
+    units:
+      - id: signals-as-numbers
+        label: "Unit 1 — Signals as Numbers"
+        blurb: "How a continuous wave becomes an array your code can work on."
+        lessons:
+          - slug: what-is-dsp
+            title: What is DSP?
+            summary: Why we process signals with numbers instead of analog circuits, what a digital signal processor does, and where DSP sits in a software radio.
+            minutes: 8
+            level: beginner
+            status: full
+          - slug: sampling-and-quantization
+            title: Sampling & quantization
+            summary: Turning a wave into samples — sample rate, the Nyquist limit, bit depth, and the aliasing and quantization noise that come with digitizing.
+            minutes: 10
+            level: beginner
+            status: full
+          - slug: complex-signals-and-iq
+            title: Complex signals & I/Q
+            summary: Why SDRs carry signals as complex I/Q pairs, what the imaginary part really means, and how negative frequency becomes a useful, everyday idea.
+            minutes: 10
+            level: intermediate
+            status: full
+      - id: frequency-domain
+        label: "Unit 2 — The Frequency Domain"
+        blurb: "Seeing a signal as its component frequencies — the Fourier view."
+        lessons:
+          - slug: the-fourier-transform
+            title: The Fourier transform
+            summary: The single idea that any signal is a sum of sine waves — what the transform computes, and why the frequency domain makes filtering and detection easy.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: the-fft
+            title: The FFT in practice
+            summary: How the Fast Fourier Transform makes the DFT computable in real time, bin resolution, the time-vs-frequency tradeoff, and what a waterfall really shows.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: windows-and-leakage
+            title: Windows & spectral leakage
+            summary: Why chopping a signal into blocks smears energy across bins, and how window functions trade resolution for cleaner spectra.
+            minutes: 9
+            level: advanced
+            status: full
+      - id: filters
+        label: "Unit 3 — Filters"
+        blurb: "Selecting the signal you want and throwing away the rest."
+        lessons:
+          - slug: convolution-and-impulse-response
+            title: Convolution & impulse response
+            summary: The operation at the heart of every filter — what an impulse response is, and how sliding-and-summing in time equals multiplying in frequency.
+            minutes: 10
+            level: advanced
+            status: full
+          - slug: fir-filters
+            title: FIR filters
+            summary: Finite impulse response filters — taps, linear phase, and how to design a low-pass filter to isolate one channel from a wideband capture.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: iir-filters
+            title: IIR filters
+            summary: Infinite impulse response filters — feedback, poles and zeros, far fewer taps, and the stability and phase tradeoffs that come with them.
+            minutes: 9
+            level: advanced
+            status: full
+          - slug: decimation-and-resampling
+            title: Decimation & resampling
+            summary: Changing sample rate without aliasing — decimation, interpolation, and rational resampling — how an SDR narrows 2.4 MS/s down to a 48 kHz channel.
+            minutes: 10
+            level: intermediate
+            status: full
+      - id: signal-to-bits
+        label: "Unit 4 — From Signal to Bits"
+        blurb: "Tuning, demodulating, and recovering the data hidden in the wave."
+        lessons:
+          - slug: mixing-and-downconversion
+            title: Mixing & downconversion
+            summary: Multiplying by a local oscillator to shift a signal to baseband — the digital downconverter (DDC) that centres a channel before it is decoded.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: demodulation
+            title: Demodulation in code
+            summary: Recovering the message from a carrier — AM, FM, and phase demodulation as arithmetic on I/Q samples, and how C4FM voice starts to appear.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: clock-and-symbol-recovery
+            title: Clock & symbol recovery
+            summary: Finding where each symbol begins when you have no shared clock — timing error detectors, interpolation, and the loop that locks onto the data rate.
+            minutes: 11
+            level: advanced
+            status: full
+          - slug: gain-and-agc
+            title: Gain & automatic gain control
+            summary: Keeping a signal at a usable amplitude as it fades — how an AGC loop works and why the demodulator needs stable levels to decide symbols correctly.
+            minutes: 9
+            level: intermediate
+            status: full
+      - id: dsp-in-practice
+        label: "Unit 5 — DSP in Practice"
+        blurb: "Put the whole chain together the way a real decoder does."
+        lessons:
+          - slug: dsp-in-gophertrunk
+            title: DSP in GopherTrunk
+            summary: A walkthrough of GopherTrunk's real signal path — capture, downconvert, filter, demodulate, recover symbols — mapping each stage to the lessons you just learned.
+            minutes: 11
+            level: advanced
+            status: full
+          - slug: fixed-vs-floating-point
+            title: Fixed vs floating point & performance
+            summary: Why real-time DSP cares about how numbers are stored, the tradeoffs of fixed vs floating point, and simple ways to keep a sample pipeline fast.
+            minutes: 9
+            level: advanced
+            status: full
+    glossary:
+      slug: glossary
+      title: Glossary of DSP terms
+      summary: Plain-language definitions for every DSP term in the path — sample rate, Nyquist, I/Q, FFT, FIR, IIR, decimation, mixing, AGC, symbol recovery, and more — cross-linked to the lessons.
+      minutes: 11
+      level: beginner
+      status: full
+
+  - id: deployment
+    label: "Containers & Deployment"
+    title: "Learn deployment — from your machine to production"
+    tagline: "How software actually ships and runs — containers, Docker, systemd, CI/CD, and the cloud — using GopherTrunk's own deployment as the worked example."
+    start_slug: what-is-deployment
+    workload: "PT5H"
+    intro: >
+      Writing software is only half the job; getting it running reliably somewhere
+      other than your laptop is the other half. This path covers the modern
+      deployment toolkit — build artifacts, containers and Docker, running services
+      with systemd, secrets and configuration, CI/CD pipelines, and cloud hosting —
+      and finishes by deploying a real application, GopherTrunk, end to end.
+    units:
+      - id: foundations
+        label: "Unit 1 — Foundations"
+        blurb: "What deployment means, and the artifacts and config it depends on."
+        lessons:
+          - slug: what-is-deployment
+            title: What is deployment?
+            summary: The journey from source code to a running service, what "it works on my machine" really costs, and the moving parts every deployment has to handle.
+            minutes: 8
+            level: beginner
+            status: full
+          - slug: environments-and-config
+            title: Environments & configuration
+            summary: Dev, staging, and production, why the same build must run in all of them, and how environment variables and config files keep settings out of code.
+            minutes: 9
+            level: beginner
+            status: full
+          - slug: build-artifacts-and-versioning
+            title: Build artifacts & versioning
+            summary: What a build produces, why a single reproducible artifact beats rebuilding everywhere, and how version tags let you ship and roll back with confidence.
+            minutes: 9
+            level: beginner
+            status: full
+      - id: containers
+        label: "Unit 2 — Containers"
+        blurb: "Package an app with everything it needs to run, anywhere."
+        lessons:
+          - slug: what-is-a-container
+            title: What is a container?
+            summary: Containers vs virtual machines, the isolation the kernel provides, and why "ship the whole environment" solves the works-on-my-machine problem.
+            minutes: 9
+            level: beginner
+            status: full
+          - slug: writing-a-dockerfile
+            title: Writing a Dockerfile
+            summary: Build an image step by step — base images, layers, multi-stage builds, and how GopherTrunk's own Dockerfile turns Go source into a small runtime image.
+            minutes: 11
+            level: intermediate
+            status: full
+          - slug: images-and-registries
+            title: Images & registries
+            summary: How images are named, tagged, stored, and shared through registries, and how a pull-and-run makes deploying somewhere new a one-line operation.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: docker-compose
+            title: Multi-container apps with Compose
+            summary: Describe an app and its dependencies as one file — services, networks, and volumes — and bring the whole stack up with a single command.
+            minutes: 10
+            level: intermediate
+            status: full
+      - id: running-in-production
+        label: "Unit 3 — Running in Production"
+        blurb: "Keep a service alive, observable, and configured safely."
+        lessons:
+          - slug: services-and-systemd
+            title: Services & systemd
+            summary: Turn a program into a managed service that starts on boot and restarts on failure, using the systemd unit GopherTrunk ships as the example.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: logging-and-health-checks
+            title: Logging & health checks
+            summary: How a running service tells you it is healthy — structured logs, health endpoints, and the signals an orchestrator uses to restart what is broken.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: secrets-and-configuration
+            title: Secrets & configuration management
+            summary: Keeping API keys and passwords out of images and repos — environment injection, secret stores, and the difference between config and secrets.
+            minutes: 9
+            level: intermediate
+            status: full
+      - id: automate-and-scale
+        label: "Unit 4 — Automate & Scale"
+        blurb: "Ship automatically, host in the cloud, and keep it running."
+        lessons:
+          - slug: ci-cd-pipelines
+            title: CI/CD pipelines
+            summary: Automating build, test, and release so every commit is shippable — what a pipeline does, and how GopherTrunk uses GitHub Actions to build and publish.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: deploying-to-cloud-and-vps
+            title: Deploying to the cloud & VPS
+            summary: The hosting spectrum — a VPS you manage, managed platforms, and container services — and how to choose based on control, cost, and effort.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: monitoring-and-updates
+            title: Monitoring & updates
+            summary: Keeping a deployment healthy over time — metrics and alerts, rolling out new versions safely, and rolling back when a release goes wrong.
+            minutes: 9
+            level: intermediate
+            status: full
+      - id: deployment-applied
+        label: "Unit 5 — Applied"
+        blurb: "Deploy a real application from start to finish."
+        lessons:
+          - slug: deploying-gophertrunk
+            title: Deploying GopherTrunk end to end
+            summary: A complete worked example — container image, docker-compose stack, and a systemd service — taking GopherTrunk from a repo to a running scanner on a server.
+            minutes: 12
+            level: advanced
+            status: full
+    glossary:
+      slug: glossary
+      title: Glossary of deployment terms
+      summary: Plain-language definitions for every deployment term in the path — container, image, registry, Dockerfile, Compose, systemd, CI/CD, artifact, secret, and more — cross-linked to the lessons.
+      minutes: 10
       level: beginner
       status: full

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -37,6 +37,12 @@ groups:
         url: /learn/digital-trunking/
       - title: "Module: Intro to Hardware"
         url: /learn/intro-hardware/
+      - title: "Module: Programming in Go"
+        url: /learn/programming-go/
+      - title: "Module: Digital Signal Processing"
+        url: /learn/dsp/
+      - title: "Module: Containers & Deployment"
+        url: /learn/deployment/
   - label: Field Guide
     items:
       - title: Field Guide overview

--- a/docs/learn/deployment/alerting-and-oncall.md
+++ b/docs/learn/deployment/alerting-and-oncall.md
@@ -1,0 +1,115 @@
+---
+slug: alerting-and-oncall
+title: Alerting & on-call
+description: "Turning metrics into pages that matter — good alert thresholds, avoiding alert fatigue, and what being on-call for a service actually means."
+keywords: alerting, on-call, slo, alert thresholds, alert fatigue, paging, pagerduty, symptom alerts, runbook, error budget
+level: intermediate
+status: full
+prereq:
+  - observability
+faq:
+  - q: What is alert fatigue?
+    a: "Alert fatigue is what happens when a system pages people too often, especially for things that don't need action. Responders start ignoring or silencing alerts, and eventually miss the real one buried among the noise. The cure is to alert only on symptoms that need a human right now, tune out the flappy and the harmless, and make every page actionable."
+  - q: What is an SLO and how does it drive alerts?
+    a: "A service level objective (SLO) is a target for how the service should behave from the user's view — for example, 99.9% of requests succeed. It gives you an error budget: the small fraction you're allowed to miss. You alert when you're burning that budget fast enough to breach the SLO, which ties pages to real user impact instead of arbitrary thresholds."
+---
+
+# Alerting & on-call
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+An **alert** turns a metric crossing a line into a notification — ideally a **page** only
+when a human must act now. Good alerts fire on **user-visible symptoms** (errors,
+latency, "it's down"), tie to an **SLO**, and each links a **runbook**. Too many alerts
+cause **alert fatigue** — people tune out the noise and miss the real one. **On-call**
+means being the person who responds when a page fires.
+</div>
+
+[Observability](/learn/deployment/observability/) gave you metrics; nobody watches a
+dashboard at 3 a.m. **Alerting** is how the system watches for you and wakes someone only
+when it must. The whole art is firing on the *right* things — enough to catch real
+problems, few enough that people still listen.
+
+## Alert on symptoms, not causes
+
+The most useful alerts fire on what a **user would notice**: requests failing, responses
+slow, the service unreachable. These "symptom" alerts catch every underlying cause,
+including ones you never predicted. Alerting on internal causes — high CPU, a full-ish
+disk — floods you with pages that often don't affect anyone. A Prometheus rule that
+alerts on a user-visible symptom:
+
+```yaml
+groups:
+  - name: gophertrunk
+    rules:
+      - alert: HighErrorRate
+        expr: rate(http_request_errors_total[5m]) / rate(http_requests_total[5m]) > 0.05
+        for: 10m           # sustained 10 min, not a one-second blip
+        labels:
+          severity: page
+        annotations:
+          summary: "Error rate above 5% for 10 minutes"
+          runbook: "https://runbooks.example.com/gophertrunk/high-error-rate"
+```
+
+Two details matter: `for: 10m` waits for the problem to be *sustained* so a momentary
+blip doesn't page anyone, and the `runbook` annotation links the fix.
+
+## Tie thresholds to an SLO
+
+Where do you draw the line? Anchor it to a **service level objective** — a target from the
+user's perspective, like "99.9% of requests succeed." That leaves a small **error budget**
+(the 0.1% you're allowed to miss). You page when you're burning that budget fast enough to
+breach the SLO, which means every page corresponds to real user impact. Arbitrary
+thresholds ("CPU > 80%") page you about things users never feel; SLO-based alerts page
+you about things they do.
+
+## Avoid alert fatigue
+
+The fastest way to make alerting useless is too much of it. When pages fire constantly —
+especially for things that need no action — people start silencing and ignoring them, and
+the one real page gets lost in the noise. Keep alerts trustworthy:
+
+- **Every page must be actionable** — if there's nothing to do, it's not a page.
+- **Alert on symptoms, suppress the flapping** — use `for:` durations and sensible
+  thresholds.
+- **Route by severity** — a *page* wakes someone; a *ticket* or a chat message is enough
+  for the non-urgent.
+
+| Severity | Means | Delivery |
+|----------|-------|----------|
+| Page | User impact now, act immediately | Phone/pager, wakes someone |
+| Ticket | Needs attention, not tonight | Issue tracker, next business day |
+| Info | Worth knowing, no action | Chat channel, dashboard |
+
+## What on-call actually means
+
+**On-call** is being the designated responder for a window of time — you carry the pager
+and answer when it fires. Healthy on-call has a few properties: a **rotation** so no one
+person carries it forever, a **clear escalation** path when the first responder is stuck,
+and every alert linking a **runbook** so the responder isn't debugging from a blank page.
+A page should arrive with a symptom, a severity, and a link to *what to do* — which is the
+subject of the next lesson.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — alert on user-visible symptoms so every page reflects real impact and stays actionable." markdown="0">
+  <p class="knowledge-check__q">Quick check: what should a page-level alert fire on?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Any CPU spike above 80%</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">A sustained user-visible symptom like a high error rate</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Every log line marked "warning"</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- An **alert** notifies when a metric crosses a line; a **page** should mean a human must
+  act now.
+- Alert on **user-visible symptoms**, not internal causes; use `for:` to require a
+  sustained problem.
+- Tie thresholds to an **SLO** and its error budget so pages reflect real user impact.
+- Fight **alert fatigue**: every page actionable, route by severity, link a runbook.
+- **On-call** is the responder rotation — with escalation and runbooks so pages are
+  answerable.
+
+Next up: what to do when a page fires — incident response and runbooks.

--- a/docs/learn/deployment/backups-and-data.md
+++ b/docs/learn/deployment/backups-and-data.md
@@ -1,0 +1,128 @@
+---
+slug: backups-and-data
+title: Backups & persistent data
+description: "Where a service's data lives, how to back it up and restore it, and why stateful data needs a plan that stateless containers don't."
+keywords: backups, persistent data, stateful vs stateless, backup volumes, database backup, restore testing, 3-2-1 backup rule, disaster recovery
+level: intermediate
+status: full
+prereq:
+  - container-networking-and-volumes
+faq:
+  - q: What is the 3-2-1 backup rule?
+    a: "Keep at least 3 copies of your data, on 2 different types of media or storage, with 1 copy off-site. The three copies survive a single deletion or corruption, two media types survive a whole class of failure, and the off-site copy survives fire, theft, or a compromised host. It's the minimum bar for data you'd be upset to lose."
+  - q: What's the difference between stateful and stateless?
+    a: "A stateless service keeps no important data of its own — restart it or replace it and nothing is lost, because its state lives elsewhere. A stateful service owns data that must survive, like a database or GopherTrunk's recordings and call log. Stateless parts are easy to scale and redeploy; stateful parts are the ones you must back up and restore carefully."
+---
+
+# Backups & persistent data
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Split your system into **stateless** parts (lose nothing on restart) and **stateful**
+parts (own data that must survive). Only the stateful data needs backing up — but it
+needs it seriously. Back up the **volumes and databases**, follow the **3-2-1 rule**
+(three copies, two media, one off-site), and — the step everyone skips — **test your
+restores**. A backup you've never restored is a guess, not a backup.
+</div>
+
+[Networking & volumes](/learn/deployment/container-networking-and-volumes/) showed how a
+[volume](/learn/deployment/container-networking-and-volumes/) keeps data alive when a
+container is replaced. That protects you from an *upgrade*; it does not protect you from a
+deleted volume, a corrupted database, or a dead disk. Backups do — and knowing what's
+stateful tells you exactly what to back up.
+
+## Stateless vs stateful: know what to protect
+
+The first question is *what actually holds data*. Sort every part of your system into two
+buckets:
+
+| | Stateless | Stateful |
+|---|-----------|----------|
+| Loses data on restart? | No | Yes |
+| Examples | The app binary, a reverse proxy, a stateless API | A database, GopherTrunk's `calls.db`, its recordings |
+| Recovery | Redeploy the artifact | Restore from backup |
+| Backup needed? | No — rebuild from the image | Yes — this is the data that matters |
+
+The GopherTrunk **binary** is stateless: lose the container and you just pull the image
+again. Its **`calls.db` and recordings** are stateful: lose those and the history is gone
+forever. Your backup plan targets the stateful bucket and ignores the stateless one.
+
+## Back up the volumes and databases
+
+For a file-based store like GopherTrunk's, a backup is a consistent copy of the volume.
+For a SQLite database, use the database's own backup command so you capture a coherent
+snapshot rather than a file caught mid-write:
+
+```bash
+# SQLite call database — .backup takes a consistent snapshot even while in use
+sqlite3 /var/lib/gophertrunk/calls.db ".backup '/backups/calls-$(date +%F).db'"
+
+# Recordings directory — a plain compressed archive
+tar czf /backups/recordings-$(date +%F).tar.gz -C /var/lib/gophertrunk recordings
+```
+
+For a server database like Postgres you'd use `pg_dump` instead — same idea, a
+consistent dump rather than copying live files. Schedule it with a
+[systemd timer or cron](/learn/linux-cli/services-and-systemd/) so it runs unattended.
+
+## Follow the 3-2-1 rule
+
+One copy on the same disk as the original is barely a backup — the disk that dies takes
+both. The **3-2-1 rule** is the durable minimum:
+
+- **3** copies of the data (the live one plus two backups),
+- on **2** different media or storage types,
+- with **1** copy **off-site** — another machine, another building, or object storage.
+
+```bash
+# push the local backup off-site to object storage
+aws s3 sync /backups s3://my-gophertrunk-backups/ --storage-class STANDARD_IA
+```
+
+The off-site copy is the one that survives fire, theft, ransomware, or a fat-fingered
+`rm -rf` on the host.
+
+## Test your restores — really
+
+This is the step that separates real backups from hopeful ones. A backup you have never
+restored is an untested assumption. Practice the restore on a scratch host on a schedule:
+
+```bash
+# restore into a throwaway location and confirm it opens and has data
+sqlite3 /tmp/restore-test.db ".restore '/backups/calls-2026-07-23.db'"
+sqlite3 /tmp/restore-test.db "SELECT count(*) FROM calls;"
+```
+
+If that count looks right, your backup works. If the file won't open, you just found out
+during a *drill* instead of during a *disaster*. Restore time is also worth measuring —
+knowing it takes 20 minutes shapes how you handle an [incident](/learn/deployment/incident-response/).
+
+## Retention: don't keep everything forever
+
+Backups cost storage, so decide how long to keep them. A common shape is **grandfather-
+father-son**: keep daily backups for a week, weekly for a month, monthly for a year.
+Prune older ones automatically so [cost](/learn/deployment/cost-and-resources/) stays
+bounded while you retain enough history to recover from a problem you didn't notice for a
+while.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — an untested backup is only an assumption; restoring proves it works." markdown="0">
+  <p class="knowledge-check__q">Quick check: what is the step most often skipped that makes a backup trustworthy?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Compressing the backup file</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Actually restoring it and confirming the data is intact</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Renaming it with the date</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Split the system into **stateless** (rebuild from the image) and **stateful** (must be
+  backed up) parts.
+- Back up **volumes and databases** with the store's own consistent-snapshot tool, on a
+  schedule.
+- Follow **3-2-1**: three copies, two media, one off-site.
+- **Test restores** on a schedule — an unrestored backup is a guess.
+- Set a **retention** policy so backups don't grow without bound.
+
+Next up: locking the whole host down — production hardening.

--- a/docs/learn/deployment/build-artifacts-and-versioning.md
+++ b/docs/learn/deployment/build-artifacts-and-versioning.md
@@ -1,0 +1,103 @@
+---
+slug: build-artifacts-and-versioning
+title: Build artifacts & versioning
+description: What a build produces, why one reproducible artifact beats rebuilding everywhere, and how version tags let you ship and roll back with confidence.
+keywords: build artifact, versioning, semantic versioning, semver, reproducible build, immutable artifact, rollback, release tag, deployment artifact
+level: beginner
+status: full
+prereq:
+  - what-is-deployment
+faq:
+  - q: What is a build artifact?
+    a: A build artifact is the concrete output of compiling or packaging your software — a binary, a container image, a zip file — ready to run or deploy. The idea is to build it once and deploy that exact same artifact everywhere, rather than rebuilding on each machine and risking subtle differences.
+  - q: What is semantic versioning?
+    a: Semantic versioning (SemVer) labels releases as MAJOR.MINOR.PATCH — for example 1.4.2. You bump PATCH for backward-compatible fixes, MINOR for backward-compatible new features, and MAJOR for breaking changes. The scheme lets anyone tell at a glance how risky an upgrade is.
+---
+
+# Build artifacts & versioning
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A **build artifact** is the concrete thing you deploy — a binary, a container image, a
+tarball. Build it **once** and ship that *same* immutable artifact everywhere, rather
+than rebuilding per machine. Label each with a **version** (often **SemVer**:
+MAJOR.MINOR.PATCH) so you know exactly what's running and can **roll back** to a known-
+good one instantly.
+</div>
+
+Before you can deploy something, you have to know precisely *what* that something is.
+This lesson is about the artifact you ship and how versioning keeps releases sane.
+
+## What a build produces
+
+Compiling or packaging your software yields an **artifact** — the deployable output.
+What it looks like depends on the stack:
+
+| Stack | Typical artifact |
+|-------|------------------|
+| Go (like GopherTrunk) | a single static binary |
+| Any language, containerized | a container image |
+| Python / Node | a package or a zip of files |
+
+Because Go compiles to [one self-contained binary](/learn/programming-go/hello-go/),
+GopherTrunk's artifacts are simple: a `gophertrunk` executable per platform. Its
+release process builds Linux, macOS, and Windows artifacts and publishes them with
+checksums.
+
+## Build once, deploy that exact thing
+
+The key discipline: **an artifact is immutable, and you deploy the same one
+everywhere.** Rebuilding on each server invites the "works on my machine" gremlins from
+[lesson 1](/learn/deployment/what-is-deployment/) — a slightly different compiler,
+library, or timestamp. Build the artifact a single time, test *that* artifact, and
+promote the very same bytes from staging to production. What you tested is exactly what
+you ship.
+
+## Versioning: naming what you ship
+
+Every artifact needs a **version** so you can talk about it precisely. The common
+scheme is **semantic versioning**:
+
+```text
+   1   .   4   .   2
+ MAJOR   MINOR   PATCH
+   |       |       |
+   |       |       +-- backward-compatible bug fixes
+   |       +---------- backward-compatible new features
+   +------------------ breaking changes
+```
+
+GopherTrunk stamps the version *into the binary at build time* — its build injects the
+tag via Go's linker (`-ldflags "-X …version.Version=<tag>"`), so a running instance can
+report exactly which release it is. Versions usually come from
+[Git tags](/learn/git/releases-and-tags/): tag `v1.4.2`, and the release build produces
+the `1.4.2` artifacts.
+
+## Why versioning enables rollback
+
+Immutable, versioned artifacts give you a safety net. If `v1.4.2` misbehaves in
+production, you don't debug live — you **roll back** by redeploying the previous
+known-good `v1.4.1` artifact, which still exists untouched. That ability to instantly
+return to a working version is one of the biggest reasons to build discrete, versioned
+artifacts, and it underpins the safe-update practices in
+[monitoring & updates](/learn/deployment/monitoring-and-updates/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — build one immutable artifact and deploy that same one everywhere." markdown="0">
+  <p class="knowledge-check__q">Quick check: why build an artifact once and deploy that same artifact everywhere?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">To save disk space on the build server</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">So what you tested is exactly what you ship, with no rebuild differences</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Because rebuilding is impossible</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **build artifact** is the deployable output — a binary, image, or package.
+- Build it **once** and deploy the same **immutable** artifact everywhere.
+- **Version** each artifact (often **SemVer** MAJOR.MINOR.PATCH); GopherTrunk stamps
+  the version into the binary.
+- Versioned artifacts make instant **rollback** to a known-good release possible.
+
+Next up: Unit 2 — the technology that bundles an artifact with everything it needs: containers.

--- a/docs/learn/deployment/ci-cd-pipelines.md
+++ b/docs/learn/deployment/ci-cd-pipelines.md
@@ -1,0 +1,121 @@
+---
+slug: ci-cd-pipelines
+title: CI/CD pipelines
+description: Automating build, test, and release so every commit is shippable — what a pipeline does, and how GopherTrunk uses GitHub Actions to build, test, and publish.
+keywords: ci cd, continuous integration, continuous delivery, pipeline, github actions, automated build, automated tests, release automation
+level: intermediate
+status: full
+prereq:
+  - build-artifacts-and-versioning
+faq:
+  - q: What is the difference between CI and CD?
+    a: Continuous integration (CI) automatically builds and tests every change as it's pushed, catching problems early. Continuous delivery/deployment (CD) takes a change that passed CI and automatically packages and releases it — to a registry, a release page, or straight to production. CI keeps the code always-working; CD makes shipping it automatic.
+  - q: What is a CI/CD pipeline?
+    a: A pipeline is an automated sequence of steps triggered by an event like a push or a tag — typically build, then run tests and checks, then (if all pass) produce and publish artifacts. It runs on a service like GitHub Actions, so the same steps happen identically every time, with no manual effort or forgotten steps.
+---
+
+# CI/CD pipelines
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**CI (continuous integration)** automatically **builds and tests** every change so the
+code is always working. **CD (continuous delivery)** automatically **packages and
+releases** changes that pass. Together they run as a **pipeline** triggered by pushes
+and tags. GopherTrunk uses **GitHub Actions**: every PR is built, vetted, and tested,
+and a version tag builds and publishes release artifacts.
+</div>
+
+Doing build-test-release by hand every time is slow and error-prone. **CI/CD**
+automates it, so shipping is reliable and boring — exactly what you want.
+
+## CI: keep the code always working
+
+**Continuous integration** runs your checks automatically on every change. Push a
+branch or open a pull request and a fresh machine builds the code and runs the tests —
+no "it passed on my machine," because it's an independent, identical run every time.
+(The [Git module](/learn/git/github-actions/) introduces GitHub Actions, the service
+GopherTrunk uses.)
+
+GopherTrunk's CI runs on every pull request and does the same gate a developer runs
+locally, plus more:
+
+```yaml
+# from GopherTrunk's CI workflow
+- run: go vet ./...
+- name: gofmt
+  run: |
+    unformatted=$(gofmt -l .)
+    if [ -n "$unformatted" ]; then exit 1; fi
+- run: go build ./...
+- run: go test -race -count=1 ./...
+- run: make integration
+```
+
+Vet, formatting, build, race-tested unit tests, and integration tests — all
+automatically, on every change, before it can merge. It even runs the USB backends on
+Windows and macOS runners so cross-platform code can't quietly break.
+
+## CD: automate the release
+
+**Continuous delivery** extends the pipeline past testing into *shipping*. When
+GopherTrunk gets a version tag, a separate release pipeline runs:
+
+```yaml
+on:
+  push:
+    tags:
+      - "v*.*.*"        # e.g. v1.4.2
+  workflow_dispatch:     # or trigger manually
+```
+
+That release job builds artifacts for every platform (Linux, macOS, Windows — all
+`CGO_ENABLED=0` pure-Go builds), stamps in the [version](/learn/deployment/build-artifacts-and-versioning/)
+from the tag, generates **`SHA256SUMS`** checksums, and uploads everything to a GitHub
+Release. Tag `v1.4.2`, and minutes later the downloadable binaries and installer exist —
+no manual build steps to forget.
+
+## The shape of a pipeline
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 90" role="img" aria-label="Pipeline stages: a trigger leads to build, then test and checks, then a gate, then publish artifacts." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="8.5" fill="currentColor" text-anchor="middle">
+  <rect x="6" y="32" width="74" height="30" rx="4" fill="none" stroke="currentColor"/><text x="43" y="51">push / tag</text>
+  <rect x="104" y="32" width="64" height="30" rx="4" fill="none" stroke="currentColor"/><text x="136" y="51">build</text>
+  <rect x="192" y="32" width="94" height="30" rx="4" fill="none" stroke="currentColor"/><text x="239" y="47">test + vet +</text><text x="239" y="57">gofmt</text>
+  <rect x="310" y="32" width="60" height="30" rx="4" fill="none" stroke="currentColor"/><text x="340" y="51">gate</text>
+  <rect x="394" y="32" width="116" height="30" rx="4" fill="none" stroke="currentColor" stroke-width="1.7"/><text x="452" y="51">publish artifacts</text>
+  </g>
+  <g stroke="currentColor"><line x1="80" y1="47" x2="104" y2="47"/><line x1="168" y1="47" x2="192" y2="47"/><line x1="286" y1="47" x2="310" y2="47"/><line x1="370" y1="47" x2="394" y2="47"/></g>
+</svg>
+<figcaption>A pipeline: an event triggers build and checks; only if the gate passes are artifacts published.</figcaption>
+</figure>
+
+## Why it matters
+
+CI/CD turns shipping from a careful manual ritual into an automatic, repeatable process.
+The tests always run, the artifacts are always built the same way, and a bad change is
+caught before it reaches users. It's the automation layer that ties together everything
+in this module — [artifacts](/learn/deployment/build-artifacts-and-versioning/),
+[images](/learn/deployment/images-and-registries/), and
+[versioning](/learn/deployment/build-artifacts-and-versioning/) — into a hands-off flow.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — CI builds and tests every change; CD automates packaging and releasing." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does the CI half of CI/CD do?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="correct">Automatically build and test every change as it's pushed</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Delete old releases</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Write the code for you</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **CI** automatically **builds and tests** every change; **CD** automatically
+  **packages and releases** what passes.
+- A **pipeline** is triggered by events (push, tag) and runs the same steps every time.
+- GopherTrunk's CI gates PRs on **vet, gofmt, build, race tests, and integration
+  tests**; a **version tag** builds and publishes release artifacts with checksums.
+- CI/CD makes shipping **reliable and repeatable**.
+
+Next up: where to actually run your deployment — cloud and VPS options.

--- a/docs/learn/deployment/container-image-optimization.md
+++ b/docs/learn/deployment/container-image-optimization.md
@@ -1,0 +1,136 @@
+---
+slug: container-image-optimization
+title: Optimizing container images
+description: "Small, fast, secure images — multi-stage builds, minimal and distroless bases, layer-cache ordering, and .dockerignore — and why GopherTrunk's image is tiny."
+keywords: docker image optimization, multi-stage build, distroless, scratch image, slim base image, dockerignore, layer caching, image scanning, small docker image
+level: intermediate
+status: full
+prereq:
+  - writing-a-dockerfile
+faq:
+  - q: Why should a container image be small?
+    a: "A small image builds and pushes faster, pulls faster onto every host you deploy to, and — most importantly — carries less software that could contain vulnerabilities. Every package in the image is attack surface and something to keep patched. Shipping only your binary and its bare runtime dependencies means fewer things can break or be exploited."
+  - q: What is a distroless or scratch image?
+    a: "scratch is the empty base image — nothing at all — suitable for a fully static binary that needs no operating system files. distroless images (from Google) add just the bare runtime essentials like CA certificates and timezone data but no shell or package manager. Both produce tiny images with almost no attack surface, at the cost of not being able to shell into the container to debug."
+---
+
+# Optimizing container images
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A good image is **small, fast, and secure**. A **multi-stage build** leaves the compiler
+behind and ships only the binary. A **minimal base** — slim, distroless, or scratch —
+strips the OS down to essentials. **Ordering layers** so stable steps come first keeps
+the build cache warm. A **`.dockerignore`** keeps junk out of the build. Smaller means
+less to pull, less to patch, and less to attack.
+</div>
+
+[Writing a Dockerfile](/learn/deployment/writing-a-dockerfile/) built a working image.
+This lesson makes it *good* — because a bloated image is slow to ship and full of
+software you didn't mean to run. GopherTrunk's image is deliberately tiny; here's how,
+and how to do the same to yours.
+
+## Multi-stage: leave the toolchain behind
+
+The single biggest win is a **multi-stage build**. One stage has the full Go toolchain
+and compiles the binary; a second, clean stage copies out *only* the finished binary.
+The Go compiler, the source, the module cache — none of it ships. GopherTrunk does
+exactly this:
+
+```dockerfile
+FROM golang:1.25-bookworm AS builder
+# ... compile the binary ...
+RUN go build -trimpath -ldflags "-s -w ..." -o /out/gophertrunk ./cmd/gophertrunk
+
+FROM debian:bookworm-slim AS runtime
+COPY --from=builder /out/gophertrunk /usr/local/bin/gophertrunk
+```
+
+The `golang:1.25-bookworm` builder is close to a gigabyte; the `debian:bookworm-slim`
+runtime plus the static binary is a small fraction of that. Note `-ldflags "-s -w"`,
+which strips debug symbols from the binary itself — a smaller binary in a smaller image.
+
+## Choose the smallest base you can run on
+
+The runtime base is the floor under your image size and its attack surface. The options,
+smallest first:
+
+| Base | Contains | Trade-off |
+|------|----------|-----------|
+| `scratch` | Nothing at all | Only works for a fully static binary; no shell to debug |
+| distroless | CA certs, tzdata, no shell/package manager | Tiny and locked down; harder to poke at |
+| `debian:bookworm-slim` | Minimal Debian + apt | Can shell in and add a package; a bit bigger |
+| `debian:bookworm` / `ubuntu` | Full OS | Large; lots of software you don't run |
+
+Because GopherTrunk is built `CGO_ENABLED=0` — a **pure-Go static binary** — it *could*
+run on `scratch`. It uses `debian:bookworm-slim` and adds only `ca-certificates` so an
+operator can still shell in for USB debugging, a deliberate small trade of size for
+practicality.
+
+## Order layers so the cache stays warm
+
+Each Dockerfile instruction is a cached [layer](/learn/deployment/writing-a-dockerfile/).
+Docker reuses a layer if nothing above it changed — so put the slow, rarely-changing
+steps *first*. GopherTrunk copies `go.mod`/`go.sum` and downloads dependencies **before**
+copying the source:
+
+```dockerfile
+COPY go.mod go.sum ./
+RUN go mod download        # cached until dependencies change
+COPY . .                   # changes on every code edit
+```
+
+Edit a `.go` file and only the layers below `COPY . .` rebuild; the dependency download
+is reused. Reverse the order and every code change re-downloads every dependency.
+
+## Keep junk out with .dockerignore
+
+`COPY . .` copies everything in the build context — including `.git`, local build output,
+and secrets — unless you exclude it. A `.dockerignore` file, like `.gitignore`, keeps
+that out:
+
+```text
+.git
+*.md
+bin/
+recordings/
+*.cfile
+.env
+```
+
+This shrinks the build context (faster builds), avoids busting the cache on irrelevant
+file changes, and — critically — stops a stray `.env` from being baked into the image.
+
+## Scan what you ship
+
+Small images have less to scan, but you should still scan. An **image scanner** compares
+the packages in your image against known-vulnerability databases:
+
+```bash
+docker scout cves gophertrunk:latest      # or: trivy image gophertrunk:latest
+```
+
+Run it in [CI](/learn/deployment/ci-cd-pipelines/) so a base image that picked up a new
+CVE fails the build before it reaches a server. The less you put in the image, the
+shorter this report — which is the whole point of optimizing: **small is secure**.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a multi-stage build ships only the binary, leaving the compiler and source behind." markdown="0">
+  <p class="knowledge-check__q">Quick check: what is the single biggest reason a Go container image can be tiny?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Docker compresses every image automatically</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">A multi-stage build copies only the compiled binary into a minimal base</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Go images are always small regardless of how they're built</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **multi-stage build** ships only the binary, not the compiler or source.
+- Pick the **smallest base** you can run on — scratch, distroless, or slim.
+- **Order layers** so stable steps (dependency downloads) come before code, keeping the
+  cache warm.
+- A **`.dockerignore`** keeps junk and secrets out of the build context.
+- **Scan** images in CI; **smaller means less to patch and less to attack**.
+
+Next up: naming, storing, and sharing images through registries.

--- a/docs/learn/deployment/container-networking-and-volumes.md
+++ b/docs/learn/deployment/container-networking-and-volumes.md
@@ -1,0 +1,146 @@
+---
+slug: container-networking-and-volumes
+title: Container networking & volumes
+description: "How containers get an IP, talk to each other by name, publish ports, and persist data — the networking and storage model beneath a Compose file."
+keywords: docker networking, docker volumes, bridge network, container dns, publish ports, named volume, bind mount, data persistence, docker network
+level: intermediate
+status: full
+prereq:
+  - docker-compose
+faq:
+  - q: How do containers talk to each other?
+    a: "Containers on the same Docker network can reach each other by service name — Docker runs an internal DNS so the name 'db' resolves to that container's IP. You don't hard-code IP addresses; you use the service names from your Compose file. Containers on different networks can't see each other unless you connect them, which is how you isolate a database from the outside world."
+  - q: What is the difference between a named volume and a bind mount?
+    a: "A bind mount maps a specific host directory into the container — you control the exact path, good for config files and code you edit. A named volume is managed by Docker in its own storage area, referenced by a name — better for data like databases where you don't care about the host path, just that it persists. Both survive the container being removed."
+---
+
+# Container networking & volumes
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Every container joins a **network** — usually a **bridge** — where Docker gives it an IP
+and lets containers reach each other by **service name** through built-in DNS.
+**Publishing a port** maps a container port to the host so the outside world can reach
+it. A container's own filesystem is temporary; a **volume** — named or a bind mount —
+persists data on the host so it survives the container being replaced.
+</div>
+
+The [Compose lesson](/learn/deployment/docker-compose/) showed `ports:` and `volumes:`
+lines without explaining the machinery under them. This lesson is that machinery: how
+containers get on the network, find each other, expose ports, and keep data alive.
+
+## Every container joins a network
+
+When Docker starts a container it attaches it to a **network** and hands it a private IP.
+By default that's a **bridge network** — a virtual switch on the host. Compose creates
+one network per project automatically, so all the services in a `docker-compose.yml`
+land on the same bridge and can talk to each other. Containers on *different* networks
+can't see one another, which is how you keep, say, a database off the public side.
+
+```bash
+docker network ls                    # list networks
+docker network inspect gophertrunk_default   # see who's attached
+```
+
+## Containers find each other by name
+
+The key trick: on a Docker network, you never hard-code IP addresses. Docker runs an
+internal **DNS** so a container can reach another by its **service name**. If your
+Compose file has a `db` service, the app container just connects to the host `db`:
+
+```yaml
+services:
+  app:
+    environment:
+      DATABASE_URL: "postgres://db:5432/app"   # "db" resolves to the db container
+  db:
+    image: postgres:16
+```
+
+Docker resolves `db` to that container's current IP, even if it changes on restart.
+Names are stable; IPs are not — so you always use names.
+
+## Publishing ports exposes a container to the host
+
+Container-to-container traffic stays on the internal network. To let something *outside*
+reach a container — your browser, another machine — you **publish** a port, mapping a
+host port to a container port. GopherTrunk publishes both its ports but binds them to
+localhost only:
+
+```yaml
+ports:
+  - "127.0.0.1:8080:8080"    # host 127.0.0.1:8080 -> container 8080
+  - "127.0.0.1:50051:50051"  # gRPC, localhost only
+```
+
+The `127.0.0.1:` prefix is the important detail: without it, `- "8080:8080"` binds to
+**every** host interface, exposing the API to the whole network. Binding to `127.0.0.1`
+keeps it reachable only from the host itself — you then put a
+[reverse proxy](/learn/deployment/reverse-proxies-and-tls/) in front to expose it safely.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 480 150" role="img" aria-label="A host with a published port forwarding to a container, and two containers on a bridge network talking by name." xmlns="http://www.w3.org/2000/svg">
+  <rect x="6" y="6" width="468" height="138" rx="6" fill="none" stroke="currentColor" stroke-opacity="0.4"/>
+  <text x="16" y="22" font-size="9" fill="currentColor">host</text>
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+  <rect x="20" y="55" width="90" height="28" rx="4" fill="none" stroke="currentColor"/><text x="65" y="73">127.0.0.1:8080</text>
+  <rect x="200" y="35" width="110" height="30" rx="4" fill="none" stroke="currentColor" stroke-width="1.7"/><text x="255" y="54">app</text>
+  <rect x="200" y="95" width="110" height="30" rx="4" fill="none" stroke="currentColor"/><text x="255" y="114">db</text>
+  </g>
+  <rect x="180" y="20" width="270" height="118" rx="6" fill="none" stroke="currentColor" stroke-dasharray="4 3" stroke-opacity="0.6"/>
+  <text x="440" y="34" font-size="8" fill="currentColor" text-anchor="end">bridge network</text>
+  <g stroke="currentColor" fill="none"><line x1="110" y1="69" x2="200" y2="55"/><line x1="255" y1="65" x2="255" y2="95"/></g>
+  <text x="268" y="84" font-size="8" fill="currentColor">"db"</text>
+</svg>
+<figcaption>A published port forwards from the host to a container; on the bridge network, containers reach each other by service name.</figcaption>
+</figure>
+
+## Volumes: data that outlives the container
+
+A container's writable filesystem is **ephemeral** — remove the container (which happens
+on every upgrade) and everything it wrote is gone. A **volume** maps storage that lives
+on the host, so data survives. There are two kinds:
+
+| | Bind mount | Named volume |
+|---|-----------|--------------|
+| You write | `./recordings:/var/lib/...` | `recdata:/var/lib/...` |
+| Location | A host path you choose | Docker-managed storage |
+| Best for | Config, code, files you edit | Databases, data you don't hand-edit |
+
+GopherTrunk uses **bind mounts** so the operator can see and edit the files directly:
+
+```yaml
+volumes:
+  - ./config.yaml:/etc/gophertrunk/config.yaml:ro   # read-only config
+  - ./recordings:/var/lib/gophertrunk/recordings    # recordings persist
+  - ./calls.db:/var/lib/gophertrunk/calls.db        # call database persists
+```
+
+The `:ro` on the config makes it **read-only** inside the container — the app can read
+its config but can't overwrite it. Pull a new image, recreate the container, and the
+recordings and database are still there because they live on the host, not in the
+container. That persistence is the whole subject of
+[backups & data](/learn/deployment/backups-and-data/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — Docker's internal DNS resolves service names to container IPs on the same network." markdown="0">
+  <p class="knowledge-check__q">Quick check: how does one container reach another on the same Docker network?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">By its hard-coded IP address</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">By its service name, which Docker's internal DNS resolves</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Only through the host's published ports</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Containers join a **bridge network** and get a private IP; Compose makes one per
+  project.
+- On a network, containers reach each other by **service name** via Docker's DNS — never
+  hard-code IPs.
+- **Publishing a port** maps a container port to the host; binding to `127.0.0.1` keeps
+  it off the public network.
+- A **volume** (bind mount or named) persists data on the host so it survives the
+  container being replaced; `:ro` makes a mount read-only.
+
+Next up: giving a container exactly the access it needs — container security.

--- a/docs/learn/deployment/container-orchestration.md
+++ b/docs/learn/deployment/container-orchestration.md
@@ -1,0 +1,122 @@
+---
+slug: container-orchestration
+title: Container orchestration
+description: "What Kubernetes and its cousins actually do — scheduling, self-healing, and scaling many containers — and how to tell when you truly need one."
+keywords: container orchestration, kubernetes, k8s, scheduling, self-healing, autoscaling, docker swarm, nomad, when to use kubernetes, orchestrator
+level: advanced
+status: full
+prereq:
+  - deploying-to-cloud-and-vps
+faq:
+  - q: What does a container orchestrator do?
+    a: "An orchestrator runs containers across a pool of machines for you. You declare what you want — 'run 5 copies of this image, keep them healthy, expose them on this port' — and it decides which machine each copy runs on, restarts any that die, reschedules them if a machine fails, and scales the count up or down. Kubernetes is the dominant one; Docker Swarm and Nomad are simpler alternatives."
+  - q: Do I need Kubernetes for my app?
+    a: "Usually not. Kubernetes earns its considerable complexity when you run many services across many machines, need automatic scaling and self-healing across nodes, and have a team to operate it. A single service on a single host — like one GopherTrunk instance — is far better served by docker-compose or a systemd unit. Reaching for Kubernetes too early buys you a second full-time system to run."
+---
+
+# Container orchestration
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+An **orchestrator** like **Kubernetes** runs containers across a *fleet* of machines. You
+declare the desired state — how many replicas, which ports, how much CPU — and it handles
+**scheduling** (which machine runs what), **self-healing** (restart or reschedule what
+dies), and **scaling** (add or remove replicas). It's powerful and complex — and for one
+service on one host, you almost certainly **don't need it**.
+</div>
+
+[Compose](/learn/deployment/docker-compose/) runs several containers on *one* host. When
+you outgrow one host — many services, many machines, automatic scaling — you reach for an
+**orchestrator**. This lesson explains what it does and, just as importantly, when *not*
+to reach for it.
+
+## From one host to a fleet
+
+Compose is declarative but single-host: it can't move a container to another machine when
+one dies, or spread ten replicas across five servers. An orchestrator manages a **cluster**
+of machines as one pool. You hand it a desired state and it continuously works to make
+reality match:
+
+- **Scheduling** — decide which machine has room to run each container.
+- **Self-healing** — a container crashes, the orchestrator restarts it; a whole machine
+  dies, it reschedules that machine's containers elsewhere.
+- **Scaling** — change "5 replicas" to "20" and it starts fifteen more, spread across the
+  cluster; automatic scaling ties the count to load.
+- **Service discovery & load balancing** — replicas come and go, and the orchestrator
+  keeps a stable address that spreads traffic across whichever are currently healthy.
+
+## Kubernetes in one breath
+
+Kubernetes is the dominant orchestrator. You describe workloads declaratively — much like
+IaC — and its control loop reconciles reality toward your spec:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  replicas: 5                # keep 5 copies running, always
+  template:
+    spec:
+      containers:
+        - name: web
+          image: ghcr.io/example/web:1.4.2
+          resources:
+            limits:
+              cpu: "500m"     # right-sizing, from the cost lesson
+              memory: "256Mi"
+```
+
+Apply that and Kubernetes ensures five copies exist across the cluster forever — kill
+one and a replacement appears in seconds. It's [zero-downtime
+deploys](/learn/deployment/zero-downtime-deploys/), [self-healing](/learn/deployment/logging-and-health-checks/),
+and [scaling](/learn/deployment/scaling-and-load-balancing/) built into the platform.
+
+## The cost: a whole system to operate
+
+That power isn't free. A Kubernetes cluster is itself a distributed system — a control
+plane, networking overlays, ingress controllers, storage plugins — that you must install,
+secure, upgrade, and debug. It adds concepts (pods, services, ingresses, config maps,
+operators) and failure modes you didn't have before. Run it and you've taken on a second
+full-time system alongside your app.
+
+## When you actually need one
+
+The honest test is scale and team, not fashion:
+
+| You have… | Reach for |
+|-----------|-----------|
+| One service on one host | A [systemd unit](/learn/deployment/services-and-systemd/) or [Compose](/learn/deployment/docker-compose/) |
+| A few services on one host | [Compose](/learn/deployment/docker-compose/) |
+| Many services, many machines, needing autoscaling & self-healing across nodes | Kubernetes (or a managed one) |
+| Kubernetes' model but less overhead | Docker Swarm or Nomad |
+
+A single **GopherTrunk** instance talking to a USB radio on one box is squarely in the
+top row — Compose or a systemd unit is the *right* tool, and Kubernetes would be pure
+overhead (it also can't magically share one physical SDR across nodes). Match the tool to
+the actual problem; orchestration is a solution to a fleet-sized problem, and using it on
+a single host adds cost with no benefit.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a single service on a single host is better served by Compose or systemd than by Kubernetes." markdown="0">
+  <p class="knowledge-check__q">Quick check: when does a single GopherTrunk instance on one host need Kubernetes?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Always — Kubernetes is required for any container in production</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">It doesn't — Compose or a systemd unit is the right fit</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Only when the container image is larger than 1 GB</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- An **orchestrator** runs containers across a **fleet**, handling scheduling,
+  self-healing, and scaling.
+- **Kubernetes** is the dominant one; you declare desired state and its control loop
+  reconciles reality to it.
+- It brings real **operational cost** — a distributed system you must run alongside your
+  app.
+- Reach for it only at **fleet scale with a team**; one service on one host wants
+  **Compose or systemd** instead.
+
+Next up: the mechanics of handling more users — scaling and load balancing.

--- a/docs/learn/deployment/container-security.md
+++ b/docs/learn/deployment/container-security.md
@@ -1,0 +1,144 @@
+---
+slug: container-security
+title: Container security
+description: "Running as non-root, dropping capabilities, read-only filesystems, and scanning images — giving a container exactly the access it needs and no more."
+keywords: container security, docker non-root, cap_drop, linux capabilities, read-only rootfs, image scanning, least privilege container, docker security
+level: advanced
+status: full
+prereq:
+  - container-networking-and-volumes
+faq:
+  - q: Why shouldn't containers run as root?
+    a: "By default a container process runs as root inside the container, and a container escape or a compromised app then has root-level power over mounted volumes and, in some misconfigurations, the host. Running as an unprivileged user means a break-in is confined to what that user can touch. It's the single highest-value container hardening step and costs almost nothing."
+  - q: What does cap_drop ALL do?
+    a: "Linux splits root's power into fine-grained capabilities — binding low ports, changing file ownership, loading kernel modules, and so on. cap_drop ALL removes every one of them, then cap_add grants back only the specific few the app genuinely needs. GopherTrunk drops ALL and adds back only DAC_OVERRIDE, the one capability its non-root user needs to open the USB device node."
+---
+
+# Container security
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A container is only as safe as the access you give it. Run as a **non-root user**, not
+root. **Drop all Linux capabilities** and add back only the few you truly need. Make the
+root filesystem **read-only** where you can. Keep **secrets out of the image**. And
+**scan** images for known vulnerabilities. GopherTrunk's compose file is a working
+example of every one of these.
+</div>
+
+[Networking & volumes](/learn/deployment/container-networking-and-volumes/) gave a
+container reach; this lesson takes reach *away* until only what's needed remains. The
+principle is **least privilege**: give a container exactly the access it needs and
+nothing more — the same instinct as the [systemd hardening](/learn/deployment/production-hardening/)
+on the bare-metal side, and it connects straight to
+[hardening systems](/learn/cybersecurity/hardening-systems/) in the security module.
+
+## Don't run as root
+
+By default the process inside a container runs as **root**. If the app is compromised or
+escapes its isolation, that root carries over to mounted volumes and, in bad
+configurations, toward the host. The fix is one line in the Dockerfile — create an
+unprivileged user and switch to it, which GopherTrunk does:
+
+```dockerfile
+RUN useradd --system --create-home --shell /usr/sbin/nologin gopher
+USER gopher
+```
+
+Everything after `USER gopher` runs as an ordinary user with no special powers. A
+break-in is now confined to what `gopher` can touch. This is the highest-value step for
+the least effort — always do it.
+
+## Drop capabilities to the bare minimum
+
+Linux breaks root's power into individual **capabilities**: `NET_BIND_SERVICE` to bind
+low ports, `CHOWN` to change ownership, `SYS_MODULE` to load kernel modules, and dozens
+more. A container gets a default set it almost never fully uses. Drop them all, then add
+back only what's required. GopherTrunk's compose file:
+
+```yaml
+cap_drop:
+  - ALL
+cap_add:
+  - DAC_OVERRIDE     # only to let the non-root user open the USB device node
+```
+
+That's least privilege made concrete: **every** capability removed, exactly **one**
+added back, with a comment saying why. If you can't name why a capability is on the
+list, it shouldn't be.
+
+## Make the filesystem read-only
+
+An app that never needs to write to its own program files shouldn't be able to. A
+**read-only root filesystem** stops an attacker from dropping a payload into the
+container's filesystem:
+
+```yaml
+services:
+  app:
+    read_only: true
+    tmpfs:
+      - /tmp                     # writable scratch, if the app needs it
+    volumes:
+      - ./recordings:/var/lib/gophertrunk/recordings   # the one path that must persist
+```
+
+The app can still write to its explicit [volumes](/learn/deployment/container-networking-and-volumes/)
+and any `tmpfs` scratch space — everything else is frozen. It's the container mirror of
+systemd's `ProtectSystem=strict`.
+
+## Keep secrets out of the image
+
+A [secret](/learn/deployment/secrets-and-configuration/) baked into an image — an API
+token, a password — is baked into *every layer forever*, readable by anyone who pulls it,
+even if a later layer deletes it. Never `COPY` a secrets file or hard-code a token in a
+Dockerfile. Inject secrets at **runtime** instead — an environment variable, a mounted
+file, or a secret store — so they live only in the running container, not the shipped
+artifact.
+
+## Scan images and know what you ship
+
+Even a minimal image contains packages that grow vulnerabilities over time. An **image
+scanner** flags known CVEs so you patch before an attacker exploits them:
+
+```bash
+trivy image gophertrunk:latest       # or: docker scout cves gophertrunk:latest
+```
+
+Run it in [CI](/learn/deployment/ci-cd-pipelines/) and on a schedule — a base image
+that's fine today picks up a CVE tomorrow. The smaller your
+[optimized image](/learn/deployment/container-image-optimization/), the shorter this
+report, which is why small and secure go together.
+
+## The layers of container security
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="Concentric boxes showing defense in depth: scanned image, non-root user, dropped capabilities, read-only filesystem, no secrets." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+  <rect x="10" y="10" width="440" height="110" rx="6" fill="none" stroke="currentColor" stroke-opacity="0.4"/><text x="230" y="26">scanned image (known-good packages)</text>
+  <rect x="40" y="34" width="380" height="80" rx="5" fill="none" stroke="currentColor" stroke-opacity="0.6"/><text x="230" y="49">non-root USER</text>
+  <rect x="80" y="56" width="300" height="56" rx="5" fill="none" stroke="currentColor" stroke-opacity="0.8"/><text x="230" y="70">cap_drop ALL + minimal cap_add</text>
+  <rect x="120" y="78" width="220" height="32" rx="5" fill="none" stroke="currentColor" stroke-width="1.7"/><text x="230" y="98">read-only fs, no baked secrets</text>
+  </g>
+</svg>
+<figcaption>Defense in depth: each layer removes power, so a break-in at one level still hits a wall at the next.</figcaption>
+</figure>
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — cap_drop ALL removes every capability, then cap_add grants back only what's needed." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does GopherTrunk's <code>cap_drop: ALL</code> plus <code>cap_add: DAC_OVERRIDE</code> achieve?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Grants the container every Linux capability</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Removes all capabilities, then adds back only the one needed to open the device</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Disables container networking</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Run as a **non-root user** (`USER gopher`) — the highest-value, lowest-cost step.
+- **`cap_drop: ALL`** then add back only what's needed (`DAC_OVERRIDE` for GopherTrunk).
+- Use a **read-only root filesystem** with explicit writable volumes and tmpfs.
+- Never bake **secrets** into an image; inject them at runtime.
+- **Scan** images for CVEs in CI and on a schedule; smaller images have less to scan.
+
+Next up: turning a plain binary into a managed service with systemd.

--- a/docs/learn/deployment/cost-and-resources.md
+++ b/docs/learn/deployment/cost-and-resources.md
@@ -1,0 +1,135 @@
+---
+slug: cost-and-resources
+title: Cost & resource management
+description: "Right-sizing CPU and memory, understanding what cloud resources cost, and keeping a deployment affordable without starving it."
+keywords: cloud cost, resource limits, right-sizing, cpu limits, memory limits, cloud pricing, over-provisioning, under-provisioning, reserved instances, cost management
+level: intermediate
+status: full
+prereq:
+  - deploying-to-cloud-and-vps
+faq:
+  - q: What does right-sizing mean?
+    a: "Right-sizing means matching the CPU and memory you allocate to what the workload actually uses — not far more (wasted money) and not far less (throttling and crashes). You measure real usage over time, then set requests and limits a sensible margin above the observed peak. It's the core discipline of keeping a deployment both affordable and stable."
+  - q: Why set CPU and memory limits on a container?
+    a: "Limits cap how much a container can consume so one misbehaving service can't starve everything else on the host. A memory limit also makes failures predictable — a leaking container is killed and restarted instead of taking the whole machine down. Without limits, a single runaway process can bring down every other service sharing the box."
+---
+
+# Cost & resource management
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Every deployment costs money and consumes finite CPU and memory. **Right-sizing** means
+matching what you allocate to what the workload actually uses — measure first, then set
+**limits** a margin above the real peak. **Over-provisioning** wastes money;
+**under-provisioning** causes throttling and crashes. Cloud **pricing models**
+(on-demand, reserved, spot) trade commitment for discount. Limits also protect the host:
+one greedy container can't starve the rest.
+</div>
+
+You've deployed to a [cloud or VPS](/learn/deployment/deploying-to-cloud-and-vps/) — which
+sends a bill and hands you a fixed pool of CPU and memory. This lesson keeps that bill sane
+and that pool from being exhausted, without starving the service into instability. It's the
+practical end of operating: affordable *and* stable.
+
+## Measure before you size
+
+You can't right-size what you haven't measured. Watch real usage over a representative
+period — a busy day, not an idle minute — using the [metrics](/learn/deployment/observability/)
+you already collect and basic host tools:
+
+```bash
+docker stats gophertrunk        # live CPU / memory for the container
+free -h                         # host memory headroom
+```
+
+The number that matters is the **sustained peak** under real load, plus a margin. Size to
+that, not to the average (you'll throttle at peak) and not to the worst case imaginable
+(you'll pay for headroom you never touch).
+
+## Set requests and limits
+
+Once you know the real usage, cap it. In Compose:
+
+```yaml
+services:
+  gophertrunk:
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"           # never use more than 1 core
+          memory: 512M          # killed & restarted if it exceeds this
+        reservations:
+          memory: 256M          # guaranteed this much
+```
+
+GopherTrunk's shipped [systemd unit](/learn/deployment/production-hardening/) offers the
+same as commented defaults — `MemoryMax=1G`, `TasksMax=256` — described as *conservative
+for a 2-SDR setup*. Limits do double duty: they keep cost predictable **and** they protect
+the host, since a limited container can't consume the whole machine and take its neighbours
+down with it.
+
+## Over- and under-provisioning
+
+Right-sizing lives between two failure modes:
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 470 96" role="img" aria-label="A spectrum from under-provisioned through right-sized to over-provisioned." xmlns="http://www.w3.org/2000/svg">
+  <line x1="20" y1="52" x2="450" y2="52" stroke="currentColor" stroke-opacity="0.4"/>
+  <g font-size="8.5" fill="currentColor" text-anchor="middle">
+  <circle cx="70" cy="52" r="5" fill="none" stroke="currentColor"/><text x="70" y="34">under</text><text x="70" y="76" font-size="7.5">throttles, crashes</text>
+  <circle cx="235" cy="52" r="6" fill="currentColor"/><text x="235" y="34">right-sized</text><text x="235" y="76" font-size="7.5">stable + affordable</text>
+  <circle cx="400" cy="52" r="5" fill="none" stroke="currentColor"/><text x="400" y="34">over</text><text x="400" y="76" font-size="7.5">wasted spend</text>
+  </g>
+</svg>
+<figcaption>Under-provisioning starves the service; over-provisioning burns money; right-sizing sits in the middle.</figcaption>
+</figure>
+
+- **Under-provisioning** — too little CPU throttles the service and too little memory gets
+  it killed. Cheap on paper, expensive in outages.
+- **Over-provisioning** — a giant instance running at 5% utilisation. Stable, but you're
+  paying for idle capacity every hour. It's the more common and quieter waste.
+
+## Cloud pricing models
+
+Cloud providers price the same capacity differently depending on how much you commit:
+
+| Model | You pay | Trade-off |
+|-------|---------|-----------|
+| On-demand | Full rate, no commitment | Flexible; most expensive per hour |
+| Reserved / committed | Discount for a 1–3 year commitment | Cheaper for steady, predictable load |
+| Spot / preemptible | Deep discount, can be reclaimed anytime | Cheapest; only for interruptible work |
+
+A steady service like a always-on GopherTrunk instance suits **reserved** pricing or a
+flat-rate [VPS](/learn/deployment/deploying-to-cloud-and-vps/); bursty batch jobs that can
+tolerate interruption suit **spot**. Match the pricing model to the workload's shape and
+the same compute costs far less.
+
+## Keep it honest over time
+
+Costs drift: a service grows, an instance was sized for a spike that's long gone, a forgotten
+test box bills forever. Revisit sizing periodically against fresh metrics, delete what you
+don't use, and set a billing alert so a surprise bill pages you like any other
+[symptom](/learn/deployment/alerting-and-oncall/). Cost is just another signal to observe
+and keep in bounds.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — right-sizing matches allocation to real measured usage plus a margin." markdown="0">
+  <p class="knowledge-check__q">Quick check: what is right-sizing?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Always buying the largest instance for safety</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Matching CPU and memory to real measured usage plus a sensible margin</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Removing all limits so the app can use everything</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Measure** real usage (sustained peak) before sizing anything.
+- Set **limits and reservations** to cap cost and protect the host from a greedy
+  container — GopherTrunk's unit ships conservative defaults.
+- **Under-provisioning** throttles and crashes; **over-provisioning** wastes spend —
+  right-sizing sits between.
+- Match the **pricing model** (on-demand, reserved, spot) to the workload's shape.
+- Revisit sizing over time and alert on the bill like any other signal.
+
+Next up: putting it all together — deploying GopherTrunk end to end.

--- a/docs/learn/deployment/deploying-gophertrunk.md
+++ b/docs/learn/deployment/deploying-gophertrunk.md
@@ -1,0 +1,180 @@
+---
+slug: deploying-gophertrunk
+title: Deploying GopherTrunk end to end
+description: A complete worked example — container image, docker-compose stack, and a systemd service — taking GopherTrunk from a repo to a running scanner on a server.
+keywords: deploy gophertrunk, gophertrunk docker, gophertrunk systemd, sdr deployment, end to end deployment, docker compose deploy, run gophertrunk server
+level: advanced
+status: full
+prereq:
+  - docker-compose
+  - services-and-systemd
+  - secrets-and-configuration
+faq:
+  - q: Do I need Docker to run GopherTrunk in production?
+    a: No — you can run it either way. Docker plus docker-compose is the quickest path and keeps everything contained, but GopherTrunk also ships a systemd unit so you can run the plain binary as a managed service. This lesson shows both, since which you choose is a matter of preference and environment.
+  - q: Why does deploying GopherTrunk involve USB device access?
+    a: GopherTrunk reads I/Q samples from a physical SDR dongle over USB, so the running service — whether a container or a systemd unit — needs permission to open that USB device. Both GopherTrunk's compose file and its systemd unit include the device pass-through and group settings that grant exactly that access and nothing more.
+---
+
+# Deploying GopherTrunk end to end
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+This capstone deploys GopherTrunk for real, two ways: as a **docker-compose** stack, and
+as a **systemd** service running the binary. Both pull together everything in the module
+— a versioned [artifact](/learn/deployment/build-artifacts-and-versioning/), a
+[config file](/learn/deployment/environments-and-config/), USB **device access**,
+persistent [volumes](/learn/deployment/docker-compose/), a
+[health check](/learn/deployment/logging-and-health-checks/), and
+[updates with rollback](/learn/deployment/monitoring-and-updates/).
+</div>
+
+Time to put it all together. This lesson walks GopherTrunk from a fresh repo to a
+running scanner on a server — the whole module, applied.
+
+## What we're deploying
+
+GopherTrunk is a long-running daemon that reads a USB SDR dongle, decodes trunked
+radio, and serves a web API and gRPC interface. A real deployment therefore needs: the
+binary or image, a config file, access to the USB device, somewhere to persist
+recordings and the call database, and process management so it survives crashes and
+reboots. We'll do it with containers first, then the systemd alternative.
+
+## Path A — docker-compose
+
+**1. Get the repo and build the image.** The [compose file](/learn/deployment/docker-compose/)
+builds locally from the repo [Dockerfile](/learn/deployment/writing-a-dockerfile/):
+
+```bash
+git clone https://github.com/mattcheramie/gophertrunk
+cd gophertrunk
+docker compose build          # builds the image from the Dockerfile
+```
+
+**2. Provide config and find your dongle.** Copy the example config and edit it, then
+find the USB device to pass through:
+
+```bash
+cp config.example.yaml config.yaml   # then edit device serials, talkgroups, etc.
+lsusb                                # e.g. "Bus 003 Device 002: ID 0bda:2838"
+```
+
+Set the matching `devices:` path in `docker-compose.yml` (e.g.
+`/dev/bus/usb/003/002`), and make sure `group_add` matches the group your host's udev
+rules grant (commonly `plugdev`, GID 46 on Debian).
+
+**3. Start the stack.**
+
+```bash
+docker compose up -d          # start in the background
+docker compose logs -f        # watch it come up
+```
+
+The compose file already sets `restart: unless-stopped` (survives crashes/reboots),
+maps the config read-only, persists `recordings/` and `calls.db` in
+[volumes](/learn/deployment/docker-compose/), binds the API to `127.0.0.1` only, and
+drops all Linux capabilities except `DAC_OVERRIDE` for the USB device.
+
+**4. Verify health.**
+
+```bash
+curl http://127.0.0.1:8080/api/v1/health    # -> {"status":"ok"}
+```
+
+That's the same [health endpoint](/learn/deployment/logging-and-health-checks/) Docker
+polls automatically every 30 seconds.
+
+## Path B — systemd (the binary)
+
+Prefer running the plain [binary](/learn/programming-go/hello-go/) as a
+[service](/learn/deployment/services-and-systemd/)? GopherTrunk ships a hardened unit:
+
+```bash
+# build the binary (or download a release artifact)
+go build -o bin/gophertrunk ./cmd/gophertrunk
+
+# install the unit, binary, and config
+sudo install -m 0644 docs/gophertrunk.service /etc/systemd/system/gophertrunk.service
+sudo install -m 0755 bin/gophertrunk /usr/local/bin/gophertrunk
+sudo install -d -m 0755 /etc/gophertrunk
+sudo install -m 0640 config.example.yaml /etc/gophertrunk/config.yaml
+# edit /etc/gophertrunk/config.yaml
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now gophertrunk      # start now and on every boot
+```
+
+The unit handles the rest: `Restart=on-failure` for crash resilience, `DeviceAllow` +
+`SupplementaryGroups=plugdev` for USB access, and a stack of
+[hardening](/learn/cybersecurity/hardening-systems/) directives (`DynamicUser`,
+`ProtectSystem=strict`, `NoNewPrivileges`) that sandbox the service. Tail its logs with:
+
+```bash
+journalctl -u gophertrunk -f
+```
+
+## Handling the API token (a secret)
+
+If you enable the API's auth, keep the token out of `config.yaml`. Put it in a
+locked-down file and reference it — the [secrets](/learn/deployment/secrets-and-configuration/)
+pattern GopherTrunk supports:
+
+```ini
+# in the systemd unit:
+EnvironmentFile=-/etc/gophertrunk/env
+# and in config.yaml: api.auth.token_file: /etc/gophertrunk/token
+```
+
+## Updating and rolling back
+
+To move to a new [version](/learn/deployment/build-artifacts-and-versioning/):
+
+```bash
+# containers:
+docker compose pull && docker compose up -d
+# systemd: install the new binary, then
+sudo systemctl restart gophertrunk
+```
+
+Watch the health check and logs after the update. If the new version misbehaves,
+[roll back](/learn/deployment/monitoring-and-updates/) by redeploying the previous
+image tag or reinstalling the previous binary — the old artifact still exists.
+
+## You've deployed it
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 100" role="img" aria-label="An SDR dongle connects over USB to a server running GopherTrunk as a container or systemd service, which serves an API to a user on localhost." xmlns="http://www.w3.org/2000/svg">
+  <rect x="10" y="40" width="70" height="28" rx="4" fill="none" stroke="currentColor"/><text x="45" y="58" text-anchor="middle" font-size="8.5" fill="currentColor">SDR dongle</text>
+  <line x1="80" y1="54" x2="120" y2="54" stroke="currentColor" stroke-width="1.4"/><text x="100" y="48" text-anchor="middle" font-size="7" fill="currentColor">USB</text>
+  <rect x="120" y="24" width="180" height="60" rx="5" fill="none" stroke="currentColor" stroke-width="1.7"/><text x="210" y="42" text-anchor="middle" font-size="9" fill="currentColor">server</text>
+  <rect x="140" y="50" width="140" height="24" rx="4" fill="none" stroke="currentColor"/><text x="210" y="66" text-anchor="middle" font-size="8" fill="currentColor">GopherTrunk (container/systemd)</text>
+  <line x1="300" y1="54" x2="360" y2="54" stroke="currentColor" stroke-width="1.4"/><text x="330" y="48" text-anchor="middle" font-size="7" fill="currentColor">:8080</text>
+  <rect x="360" y="40" width="70" height="28" rx="4" fill="none" stroke="currentColor"/><text x="395" y="58" text-anchor="middle" font-size="8.5" fill="currentColor">web API</text>
+</svg>
+<figcaption>The finished deployment: a dongle feeds GopherTrunk on a server, managed by Docker or systemd, serving its API.</figcaption>
+</figure>
+
+That's a complete, production-shaped deployment — build, configure, run, secure,
+monitor, update — using every idea in this module on a real application.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — GopherTrunk can run as a docker-compose stack or a systemd-managed binary." markdown="0">
+  <p class="knowledge-check__q">Quick check: what two ways does this lesson deploy GopherTrunk?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Only as a Docker container</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">As a docker-compose stack, or as a systemd-managed binary</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Only on a managed cloud platform</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- GopherTrunk deploys as a **docker-compose** stack (`build`, config, USB device,
+  volumes, health check) or a **systemd** service running the binary.
+- Both grant **least-privilege USB access** and provide **crash/reboot resilience**.
+- Keep the API token as a **secret** in a separate file, not in `config.yaml`.
+- **Update** by pulling/reinstalling the new version and watching health; **roll back**
+  to the previous artifact if needed.
+
+That's the module — from source to a running, monitored, updatable service. Keep the
+[glossary](/learn/deployment/glossary/) handy as a reference.

--- a/docs/learn/deployment/deploying-to-cloud-and-vps.md
+++ b/docs/learn/deployment/deploying-to-cloud-and-vps.md
@@ -1,0 +1,107 @@
+---
+slug: deploying-to-cloud-and-vps
+title: Deploying to the cloud & VPS
+description: The hosting spectrum — a VPS you manage, managed platforms, and container services — and how to choose based on control, cost, and effort.
+keywords: vps, cloud hosting, deploy to cloud, virtual private server, managed platform, paas, container hosting, self hosting, where to deploy
+level: intermediate
+status: full
+prereq:
+  - what-is-deployment
+faq:
+  - q: What is a VPS?
+    a: A VPS (virtual private server) is a virtual machine you rent from a hosting provider — a small Linux server in the cloud that you control fully. You install and manage everything yourself, which gives maximum control at the cost of doing the operations work. It's a common, affordable way to run a service like GopherTrunk.
+  - q: Should I use a managed platform or a plain server?
+    a: A managed platform (PaaS) handles the servers, scaling, and much of the operations for you, so you focus on the app — easier, but with less control and usually higher cost. A plain server or VPS gives full control and lower cost but you run everything yourself. Choose based on how much operations work you want to own versus how much control you need.
+---
+
+# Deploying to the cloud & VPS
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Where you run a deployment is a spectrum trading **control** against **effort**: a
+**VPS** or your own hardware gives full control but you run everything; a **managed
+platform (PaaS)** or **container service** handles the servers for you at higher cost
+and less control. Choose by how much operations work you want to own. A service like
+GopherTrunk runs happily on a cheap VPS or even a Raspberry Pi.
+</div>
+
+You've built and containerized your app. Now — *where* does it run? This lesson maps the
+hosting options and how to pick.
+
+## The hosting spectrum
+
+Every option trades how much you control against how much you have to operate:
+
+| Option | You manage | Control | Effort | Good for |
+|--------|-----------|---------|--------|----------|
+| **Own hardware / SBC** | everything, incl. the machine | total | high | home labs, GopherTrunk on a Pi |
+| **VPS** | the OS and up | high | medium | most small services |
+| **Container service** | just the container | medium | low-medium | containerized apps that scale |
+| **Managed platform (PaaS)** | just the code | low | low | teams who want zero ops |
+
+Moving down the table, the provider takes on more of the work — and charges for it —
+while you give up some control and flexibility.
+
+## The VPS: the common middle ground
+
+For most small deployments, a **VPS** — a Linux virtual machine you rent — is the
+sweet spot. You get a real server you fully control, for a few dollars a month, and you
+deploy onto it with the tools from this module: install your
+[systemd service](/learn/deployment/services-and-systemd/) or run your
+[container](/learn/deployment/docker-compose/), and you're live. You reach it over
+[SSH](/learn/linux-cli/ssh-and-remote/) to set it up and manage it.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 70" role="img" aria-label="A horizontal spectrum from more control and effort on the left to less control and effort on the right, with hardware, VPS, container service, and PaaS marked." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="40" x2="490" y2="40" stroke="currentColor" stroke-width="1.5"/>
+  <g font-size="8.5" fill="currentColor" text-anchor="middle">
+  <circle cx="60" cy="40" r="3"/><text x="60" y="28">own hardware</text><text x="60" y="58">control &#8593;</text>
+  <circle cx="200" cy="40" r="3"/><text x="200" y="28">VPS</text>
+  <circle cx="340" cy="40" r="3"/><text x="340" y="28">container svc</text>
+  <circle cx="470" cy="40" r="3"/><text x="470" y="28">PaaS</text><text x="470" y="58">effort &#8595;</text>
+  </g>
+</svg>
+<figcaption>The hosting spectrum: more control and operations work on the left, more hands-off convenience on the right.</figcaption>
+</figure>
+
+## How to choose
+
+Ask three questions:
+
+- **How much control do you need?** Special hardware (like GopherTrunk's USB radio) or
+  custom OS setup pushes you toward a VPS or your own machine — a fully managed platform
+  usually can't attach a USB dongle.
+- **How much operations work do you want?** More convenience costs money and control;
+  less costs your time.
+- **Does it need to scale?** A single small service is fine on one VPS; something that
+  must grow to many instances leans toward container services or orchestration.
+
+## GopherTrunk's angle
+
+Because GopherTrunk talks to physical radio hardware, it typically runs on a machine
+that *has* that hardware — a home server, a mini-PC, or a Raspberry Pi with the SDR
+plugged in — rather than a hands-off cloud platform. That's a useful reminder: the right
+place to deploy is driven by what the app *needs*, not by what's trendiest. Wherever it
+runs, the [Linux CLI](/learn/linux-cli/running-gophertrunk-on-linux/) and this module's
+tools are how you get it there.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a VPS gives you a full server you control, with medium operations effort." markdown="0">
+  <p class="knowledge-check__q">Quick check: what do you get with a VPS?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">A fully managed app platform with no server to run</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">A rented Linux server you fully control and operate yourself</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">A container registry</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Hosting is a spectrum trading **control** for **effort** — own hardware, VPS,
+  container service, PaaS.
+- A **VPS** is the common middle ground: a full server you control cheaply, managed over
+  SSH.
+- Choose by **control needed**, **ops effort wanted**, and whether it must **scale**.
+- Let the app's needs decide — GopherTrunk runs where its **radio hardware** is.
+
+Next up: keeping a deployment healthy over time — monitoring and updates.

--- a/docs/learn/deployment/docker-compose.md
+++ b/docs/learn/deployment/docker-compose.md
@@ -1,0 +1,115 @@
+---
+slug: docker-compose
+title: Multi-container apps with Compose
+description: Describe an app and its dependencies as one file — services, networks, and volumes — and bring the whole stack up with a single command, using GopherTrunk's real compose file.
+keywords: docker compose, docker-compose.yml, compose services, docker volumes, docker networks, multi-container, compose up, container orchestration
+level: intermediate
+status: full
+prereq:
+  - images-and-registries
+faq:
+  - q: What is Docker Compose for?
+    a: Compose describes one or more containers, plus their networks and storage, in a single YAML file, so you can start the whole set with one command instead of many long docker run lines. It's ideal for an application and its dependencies — a service, a database, a cache — running together on one host.
+  - q: What is a volume in Docker?
+    a: A container's own filesystem is temporary — delete the container and its data is gone. A volume maps a directory into the container that persists on the host, so data like a database file or recordings survives restarts and upgrades. GopherTrunk uses volumes for its config, recordings, and call database.
+---
+
+# Multi-container apps with Compose
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Docker Compose** describes an app — its **services**, **networks**, and persistent
+**volumes** — in one `docker-compose.yml` file, so `docker compose up` starts the whole
+stack. **Volumes** keep data alive across restarts. GopherTrunk ships a real compose
+file that maps its config, recordings, database, USB device, and ports.
+</div>
+
+Running one container by hand is fine; running an app with its config, storage, and
+device access every time is tedious. **Compose** captures all of it in a file.
+
+## One file for the whole stack
+
+A single `docker run` command with all its flags gets unwieldy fast. Compose moves that
+into a declarative `docker-compose.yml`, then you manage everything with:
+
+```bash
+docker compose up -d      # start the whole stack in the background
+docker compose logs -f    # follow its logs
+docker compose down       # stop and remove it
+```
+
+## GopherTrunk's compose file, annotated
+
+Here's the core of GopherTrunk's actual compose file:
+
+```yaml
+services:
+  gophertrunk:
+    image: ghcr.io/mattcheramie/gophertrunk:latest
+    build:                       # build locally from the repo Dockerfile
+      context: .
+      args:
+        VERSION: "compose-dev"
+    container_name: gophertrunk
+    restart: unless-stopped      # restart on crash or reboot
+
+    ports:
+      - "127.0.0.1:8080:8080"    # HTTP API, bound to localhost only
+      - "127.0.0.1:50051:50051"  # gRPC
+
+    volumes:
+      - ./config.yaml:/etc/gophertrunk/config.yaml:ro
+      - ./recordings:/var/lib/gophertrunk/recordings
+      - ./calls.db:/var/lib/gophertrunk/calls.db
+```
+
+Every key maps to a concept from this module:
+
+- **`image`** / **`build`** — use a [registry image](/learn/deployment/images-and-registries/)
+  or build locally from the [Dockerfile](/learn/deployment/writing-a-dockerfile/).
+- **`restart: unless-stopped`** — process management, so the container comes back after
+  a crash or reboot (the [systemd lesson](/learn/deployment/services-and-systemd/)
+  does the same for a plain binary).
+- **`ports`** — map container ports to the host; binding to `127.0.0.1` keeps them off
+  the public network (a [security](/learn/deployment/secrets-and-configuration/)
+  default).
+- **`volumes`** — persist the config (read-only), recordings, and call database on the
+  host so they survive the container being replaced.
+
+## Volumes: where your data lives
+
+The volumes line is the one to internalize. A container's own filesystem vanishes when
+the container is removed — which happens on every upgrade. **Volumes** map host
+directories into the container so the data that matters *outlives* any single container.
+GopherTrunk keeps its recordings and `calls.db` in volumes for exactly this reason: pull
+a new image, recreate the container, and your data is still there.
+
+## Hardware and permissions
+
+Because GopherTrunk talks to a USB radio, its compose file also passes the device
+through (`devices:`), grants the right group (`group_add`), and drops all Linux
+capabilities except the one needed to open the device (`cap_drop: ALL` + `cap_add:
+DAC_OVERRIDE`) — a nice example of giving a container *exactly* the access it needs and
+nothing more. You'll see this same least-privilege spirit in the
+[systemd unit](/learn/deployment/services-and-systemd/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a volume persists data on the host so it survives the container being replaced." markdown="0">
+  <p class="knowledge-check__q">Quick check: why does GopherTrunk store its recordings and database in volumes?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">To make the image smaller</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">So the data survives when the container is replaced on upgrade</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Because containers cannot write files otherwise</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Compose** describes services, networks, and volumes in one file; `docker compose
+  up` runs the stack.
+- **`restart: unless-stopped`** brings containers back after crashes and reboots.
+- **Volumes** persist data on the host so it **survives** container replacement.
+- GopherTrunk's compose maps its config, recordings, database, ports, and USB device —
+  with least-privilege capabilities.
+
+Next up: Unit 3 — running a plain binary as a managed service with systemd.

--- a/docs/learn/deployment/environments-and-config.md
+++ b/docs/learn/deployment/environments-and-config.md
@@ -1,0 +1,109 @@
+---
+slug: environments-and-config
+title: Environments & configuration
+description: Development, staging, and production, why the same build must run in all of them, and how environment variables and config files keep settings out of code.
+keywords: environments, dev staging production, configuration, environment variables, config file, twelve factor, externalized config, deployment config
+level: beginner
+status: full
+prereq:
+  - what-is-deployment
+faq:
+  - q: What are dev, staging, and production environments?
+    a: They are separate places the same software runs. Development is your machine, where you build and experiment. Staging is a production-like environment for final testing. Production is the real thing your users actually touch. Keeping them separate lets you test changes safely before they reach users.
+  - q: Should configuration go in the code or outside it?
+    a: Outside. Anything that differs between environments — ports, file paths, database URLs, feature flags — should come from configuration the program reads at startup, not values baked into the build. That way one identical build runs everywhere, and you change behaviour by changing config, not by rebuilding.
+---
+
+# Environments & configuration
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Software runs in several **environments** — **development**, **staging**,
+**production** — and the *same build* should run in all of them. What differs between
+them lives in **configuration**, supplied by **environment variables** or a **config
+file** the program reads at startup — never hard-coded. Build once, configure per
+environment.
+</div>
+
+The same program has to behave slightly differently depending on where it runs. This
+lesson is about handling that difference cleanly, without rebuilding.
+
+## The environments
+
+Most software passes through a few standard environments on its way to users:
+
+| Environment | What it's for | Who touches it |
+|-------------|---------------|----------------|
+| **Development** | building and experimenting | you |
+| **Staging** | final, production-like testing | your team |
+| **Production** | the real service | your users |
+
+They differ in the obvious ways — production has real data, real traffic, real
+consequences — so you test in dev and staging first. But the *code* should be identical
+across them. What changes is configuration.
+
+## Build once, configure per environment
+
+A cardinal rule of deployment: **the same artifact runs everywhere; only its
+configuration changes.** If dev and production run different *builds*, you can never be
+sure you tested what you shipped. So anything environment-specific gets pulled *out* of
+the code:
+
+- ports and network addresses
+- file and directory paths
+- database connection strings
+- feature flags and log levels
+- credentials (with extra care — see
+  [secrets](/learn/deployment/secrets-and-configuration/))
+
+## Two ways to supply config
+
+**Environment variables** are key/value settings the operating system hands the program
+— the standard way to inject a single value, especially in containers (they're covered
+in the [Linux CLI module](/learn/linux-cli/environment-variables/)):
+
+```bash
+export GOPHERTRUNK_CONFIG=/etc/gophertrunk/config.yaml
+gophertrunk run
+```
+
+**Config files** suit richer, structured settings. GopherTrunk uses a YAML config that
+you point it at with a flag, keeping every environment-specific choice in one editable
+file rather than in the binary:
+
+```bash
+gophertrunk run -config /etc/gophertrunk/config.yaml
+```
+
+The two combine well: a config file for the bulk of settings, environment variables to
+override a few per environment (and to inject secrets the file shouldn't contain).
+
+## Keep environments honest
+
+Two habits prevent painful surprises:
+
+- **Make staging resemble production.** The closer they are, the more bugs staging
+  catches before users do.
+- **Never edit production config by hand and forget.** Track config in version control
+  (minus secrets) so you know exactly what each environment is running — the same
+  [Git](/learn/git/) discipline you use for code.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the same build runs everywhere; configuration is what changes per environment." markdown="0">
+  <p class="knowledge-check__q">Quick check: what should differ between your development and production environments?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">The compiled build itself</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The configuration, while the build stays identical</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">The programming language</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Software runs in **development**, **staging**, and **production** — separate places,
+  same build.
+- Environment-specific settings live in **configuration**, not in code.
+- Supply config via **environment variables** and/or a **config file** read at startup.
+- Keep **staging like production** and track config in version control (secrets aside).
+
+Next up: what a build actually produces — artifacts and versioning.

--- a/docs/learn/deployment/glossary.md
+++ b/docs/learn/deployment/glossary.md
@@ -133,3 +133,76 @@ trends. See [Monitoring & updates](/learn/deployment/monitoring-and-updates/)
 
 **Rolling update** — Deploying a new version while watching its health, ready to roll
 back. See [Monitoring & updates](/learn/deployment/monitoring-and-updates/)
+
+## Lifecycle & releases
+
+**Deployment lifecycle** — The repeating loop every change moves through: build, test,
+release, deploy, operate. See [The deployment lifecycle](/learn/deployment/the-deployment-lifecycle/)
+
+**Rolling / blue-green / canary** — Release strategies that push a new version gradually,
+by switching between two environments, or to a small slice of users first. See [Release strategies](/learn/deployment/release-strategies/)
+
+## More on containers
+
+**Distroless / scratch base** — Minimal container base images with little or no OS
+userland, shrinking size and attack surface. See [Optimizing container images](/learn/deployment/container-image-optimization/)
+
+**.dockerignore** — A file listing paths to exclude from the build context, keeping images
+small and builds fast. See [Optimizing container images](/learn/deployment/container-image-optimization/)
+
+**Bridge network / port publishing** — How Docker gives containers an internal network and
+maps their ports to the host. See [Container networking & volumes](/learn/deployment/container-networking-and-volumes/)
+
+**Capability (Linux)** — A fine-grained privilege; containers drop all and add back only
+what they need. See [Container security](/learn/deployment/container-security/)
+
+**Image scanning** — Automatically checking an image for known vulnerabilities before
+deploying it. See [Container security](/learn/deployment/container-security/)
+
+## Networking, data & hardening
+
+**Reverse proxy** — A server (nginx, Caddy) in front of an app that terminates TLS and
+routes requests to it. See [Reverse proxies & TLS](/learn/deployment/reverse-proxies-and-tls/)
+
+**TLS termination** — Handling HTTPS encryption at the proxy so the app behind it can
+speak plain HTTP. See [Reverse proxies & TLS](/learn/deployment/reverse-proxies-and-tls/)
+
+**Stateful vs stateless** — Whether a service keeps important data locally; stateful data
+needs backups and a persistence plan. See [Backups & persistent data](/learn/deployment/backups-and-data/)
+
+**Least privilege** — Granting a service only the access it needs — the core idea behind
+production hardening. See [Production hardening](/learn/deployment/production-hardening/)
+
+## Automate & scale
+
+**Infrastructure as code (IaC)** — Describing servers and services in versioned,
+declarative files (Terraform, Ansible). See [Infrastructure as code](/learn/deployment/infrastructure-as-code/)
+
+**Orchestrator** — A system (like Kubernetes) that schedules, heals, and scales many
+containers across machines. See [Container orchestration](/learn/deployment/container-orchestration/)
+
+**Horizontal vs vertical scaling** — Adding more instances vs making one instance bigger;
+a load balancer spreads traffic across instances. See [Scaling & load balancing](/learn/deployment/scaling-and-load-balancing/)
+
+**Load balancer** — A component that distributes incoming requests across several service
+instances. See [Scaling & load balancing](/learn/deployment/scaling-and-load-balancing/)
+
+**Connection draining** — Letting in-flight requests finish before removing an old
+instance during a deploy. See [Zero-downtime deploys](/learn/deployment/zero-downtime-deploys/)
+
+## Operate
+
+**Observability** — Understanding a system from its outputs, via the three pillars of
+metrics, logs, and traces. See [Observability — metrics, logs & traces](/learn/deployment/observability/)
+
+**Trace** — A record following one request across services, showing where time is spent.
+See [Observability — metrics, logs & traces](/learn/deployment/observability/)
+
+**Alert / on-call** — An automatic notification when a metric crosses a threshold, and the
+rotation of who responds. See [Alerting & on-call](/learn/deployment/alerting-and-oncall/)
+
+**Runbook / postmortem** — A documented response procedure, and the blameless review that
+follows an incident. See [Incident response & runbooks](/learn/deployment/incident-response/)
+
+**Right-sizing** — Matching allocated CPU and memory to what a service actually needs, to
+control cost. See [Cost & resource management](/learn/deployment/cost-and-resources/)

--- a/docs/learn/deployment/glossary.md
+++ b/docs/learn/deployment/glossary.md
@@ -1,0 +1,135 @@
+---
+slug: glossary
+title: Glossary of deployment terms
+description: Plain-language definitions of deployment terms — container, image, registry, Dockerfile, Compose, systemd, CI/CD, artifact, secret, and more — each cross-linked to the lesson where it's explained.
+keywords: deployment glossary, docker terms, devops glossary, container image registry definition, ci cd systemd glossary, deployment dictionary
+level: beginner
+status: full
+lesson_standalone: true
+---
+
+# Glossary of deployment terms
+
+Every term used across the [deployment module](/learn/deployment/), defined in plain
+language and linked to the lesson where it's explained in full. Skim it as a refresher,
+or use your browser's find (Ctrl/Cmd-F) to jump to a word. Terms are grouped by theme.
+
+## Foundations
+
+**Deployment** — Getting software running reliably somewhere other than your own
+machine. See [What is deployment?](/learn/deployment/what-is-deployment/)
+
+**Environment** — A place software runs — development, staging, or production — each the
+same build with different configuration. See [Environments & configuration](/learn/deployment/environments-and-config/)
+
+**Configuration** — Settings that change how software behaves (ports, paths, log
+levels), supplied at startup rather than baked in. See [Environments & configuration](/learn/deployment/environments-and-config/)
+
+**Environment variable** — A key/value setting the operating system passes to a program,
+a common way to inject configuration. See [Environments & configuration](/learn/deployment/environments-and-config/)
+
+**Build artifact** — The concrete deployable output of a build — a binary, image, or
+package. See [Build artifacts & versioning](/learn/deployment/build-artifacts-and-versioning/)
+
+**Immutable artifact** — An artifact built once and never changed, deployed identically
+everywhere. See [Build artifacts & versioning](/learn/deployment/build-artifacts-and-versioning/)
+
+**Semantic versioning (SemVer)** — Labelling releases MAJOR.MINOR.PATCH to signal how
+risky an upgrade is. See [Build artifacts & versioning](/learn/deployment/build-artifacts-and-versioning/)
+
+**Rollback** — Returning to a previous known-good version by redeploying its artifact.
+See [Monitoring & updates](/learn/deployment/monitoring-and-updates/)
+
+## Containers
+
+**Container** — An application bundled with its dependencies, running isolated on a
+shared host kernel. See [What is a container?](/learn/deployment/what-is-a-container/)
+
+**Virtual machine (VM)** — An emulated computer running a full guest OS — stronger
+isolation than a container but much heavier. See [What is a container?](/learn/deployment/what-is-a-container/)
+
+**Image** — The packaged, read-only template a container runs from. See [What is a container?](/learn/deployment/what-is-a-container/)
+
+**Namespaces / cgroups** — Kernel features that isolate a container's view of the system
+and cap its resources. See [What is a container?](/learn/deployment/what-is-a-container/)
+
+**Dockerfile** — The recipe of instructions that builds a container image. See [Writing a Dockerfile](/learn/deployment/writing-a-dockerfile/)
+
+**Base image** — The starting image a Dockerfile builds on top of. See [Writing a Dockerfile](/learn/deployment/writing-a-dockerfile/)
+
+**Layer** — A cached filesystem change produced by one Dockerfile instruction. See [Writing a Dockerfile](/learn/deployment/writing-a-dockerfile/)
+
+**Multi-stage build** — A Dockerfile that compiles in one stage and copies only the
+finished binary into a small final image. See [Writing a Dockerfile](/learn/deployment/writing-a-dockerfile/)
+
+**Registry** — A server that stores and distributes images (Docker Hub, ghcr.io). See
+[Images & registries](/learn/deployment/images-and-registries/)
+
+**Tag** — A movable label on an image, like `:latest` or `:1.4.2`. See [Images & registries](/learn/deployment/images-and-registries/)
+
+**Digest** — An immutable hash identifying an image's exact contents. See [Images & registries](/learn/deployment/images-and-registries/)
+
+**Docker Compose** — A tool that describes services, networks, and volumes in one file
+and runs them together. See [Multi-container apps with Compose](/learn/deployment/docker-compose/)
+
+**Service (Compose)** — One container definition within a Compose file. See [Multi-container apps with Compose](/learn/deployment/docker-compose/)
+
+**Volume** — A host directory mapped into a container so data persists across restarts.
+See [Multi-container apps with Compose](/learn/deployment/docker-compose/)
+
+## Running in production
+
+**Service (systemd)** — A background program managed by systemd — started on boot,
+restarted on failure. See [Services & systemd](/learn/deployment/services-and-systemd/)
+
+**systemd** — The Linux init and service manager that runs and supervises services. See
+[Services & systemd](/learn/deployment/services-and-systemd/)
+
+**Unit file** — The file describing a systemd service (`ExecStart`, `Restart`, etc.).
+See [Services & systemd](/learn/deployment/services-and-systemd/)
+
+**Hardening** — Restricting a service to the least privilege it needs, via systemd
+sandboxing or dropped container capabilities. See [Services & systemd](/learn/deployment/services-and-systemd/)
+
+**Log** — A recorded narrative of a service's events, read via `journalctl` or `docker
+logs`. See [Logging & health checks](/learn/deployment/logging-and-health-checks/)
+
+**Structured logging** — Recording log events as machine-readable fields, making them
+searchable. See [Logging & health checks](/learn/deployment/logging-and-health-checks/)
+
+**Health check** — An endpoint a monitor polls to learn whether a service is working.
+See [Logging & health checks](/learn/deployment/logging-and-health-checks/)
+
+**Liveness / readiness** — Whether a service is alive (restart if not) versus ready to
+serve (hold traffic if not). See [Logging & health checks](/learn/deployment/logging-and-health-checks/)
+
+**Secret** — Confidential configuration (API key, password, token) that must never be
+committed or baked into an image. See [Secrets & configuration management](/learn/deployment/secrets-and-configuration/)
+
+**Secret store** — A dedicated service that holds secrets and hands them to authorized
+services at runtime. See [Secrets & configuration management](/learn/deployment/secrets-and-configuration/)
+
+## Automate & scale
+
+**Continuous integration (CI)** — Automatically building and testing every change as
+it's pushed. See [CI/CD pipelines](/learn/deployment/ci-cd-pipelines/)
+
+**Continuous delivery (CD)** — Automatically packaging and releasing changes that pass
+CI. See [CI/CD pipelines](/learn/deployment/ci-cd-pipelines/)
+
+**Pipeline** — An automated sequence of build/test/release steps triggered by an event.
+See [CI/CD pipelines](/learn/deployment/ci-cd-pipelines/)
+
+**VPS (virtual private server)** — A rented Linux virtual machine you fully control. See
+[Deploying to the cloud & VPS](/learn/deployment/deploying-to-cloud-and-vps/)
+
+**PaaS (managed platform)** — A host that runs your app and handles the servers for you.
+See [Deploying to the cloud & VPS](/learn/deployment/deploying-to-cloud-and-vps/)
+
+**Metrics** — Numbers measured over time (request rate, errors, memory) that reveal
+trends. See [Monitoring & updates](/learn/deployment/monitoring-and-updates/)
+
+**Alert** — An automatic notification when a metric crosses a threshold. See [Monitoring & updates](/learn/deployment/monitoring-and-updates/)
+
+**Rolling update** — Deploying a new version while watching its health, ready to roll
+back. See [Monitoring & updates](/learn/deployment/monitoring-and-updates/)

--- a/docs/learn/deployment/images-and-registries.md
+++ b/docs/learn/deployment/images-and-registries.md
@@ -1,0 +1,116 @@
+---
+slug: images-and-registries
+title: Images & registries
+description: How container images are named, tagged, stored, and shared through registries, and how a pull-and-run makes deploying somewhere new a one-line operation.
+keywords: container registry, docker image tag, docker hub, ghcr, image digest, docker pull, docker push, image naming
+level: intermediate
+status: full
+prereq:
+  - writing-a-dockerfile
+faq:
+  - q: What is a container registry?
+    a: A registry is a server that stores and distributes container images, like a package repository for containers. You push an image to it from wherever you built it, and any machine you want to deploy on pulls it back down. Docker Hub and GitHub's ghcr.io are common public registries.
+  - q: What is the difference between an image tag and a digest?
+    a: A tag is a human-friendly label like :latest or :1.4.2 that you attach to an image and can move to point at a new build. A digest is a cryptographic hash of the exact image contents — it never changes and always refers to the identical bytes. Use tags for convenience, digests when you need to pin an exact, immutable image.
+---
+
+# Images & registries
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A container **image** is named `registry/name:tag`. A **registry** (Docker Hub,
+GitHub's `ghcr.io`) stores and distributes images: you **push** from where you built,
+and any host **pulls** to deploy. A **tag** (`:latest`, `:1.4.2`) is a movable label; a
+**digest** is an immutable hash of the exact bytes. Pull-and-run makes deploying
+somewhere new a one-liner.
+</div>
+
+You've built an image. Now how do you get it onto a server? Through a **registry** —
+this lesson covers naming, storing, and sharing images.
+
+## How images are named
+
+A full image name has three parts:
+
+```text
+   ghcr.io/mattcheramie/gophertrunk : latest
+   \______/ \___________________/    \____/
+   registry        repository          tag
+```
+
+- **registry** — where it lives (`docker.io` for Docker Hub, `ghcr.io` for GitHub's
+  container registry). Omit it and Docker assumes Docker Hub.
+- **repository** — the image's name, usually `owner/project`.
+- **tag** — which version, like `latest`, `1.4.2`, or `dev`.
+
+## Tags vs digests
+
+A **tag** is a friendly, *movable* label — `:latest` points at whatever you last
+pushed as latest. That's convenient but means "latest" is a moving target. A
+**digest** (`sha256:...`) is a hash of the image's exact contents; it never moves, so
+pinning to a digest guarantees you run the *identical* bytes you tested — the
+immutability idea from [artifacts & versioning](/learn/deployment/build-artifacts-and-versioning/)
+applied to images.
+
+## Push and pull
+
+Sharing an image is two commands. From where you built it:
+
+```bash
+docker tag gophertrunk:dev ghcr.io/mattcheramie/gophertrunk:1.4.2
+docker push ghcr.io/mattcheramie/gophertrunk:1.4.2
+```
+
+And on any machine you want to deploy on:
+
+```bash
+docker pull ghcr.io/mattcheramie/gophertrunk:1.4.2
+docker run ghcr.io/mattcheramie/gophertrunk:1.4.2
+```
+
+That `pull` + `run` is the whole deploy step — no build tools, no dependencies to
+install on the target, just fetch the image and start it. This is the payoff of
+containerizing: **deploying somewhere new is a one-liner.**
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 120" role="img" aria-label="A build machine pushes an image up to a registry in the middle; two servers pull the same image down from the registry." xmlns="http://www.w3.org/2000/svg">
+  <rect x="10" y="45" width="90" height="30" rx="5" fill="none" stroke="currentColor"/><text x="55" y="64" text-anchor="middle" font-size="9" fill="currentColor">build machine</text>
+  <line x1="100" y1="55" x2="205" y2="45" stroke="currentColor" stroke-width="1.5" marker-end="url(#r1)"/><text x="150" y="40" font-size="8" fill="currentColor">push</text>
+  <rect x="205" y="35" width="110" height="42" rx="5" fill="none" stroke="currentColor" stroke-width="1.8"/><text x="260" y="60" text-anchor="middle" font-size="10" fill="currentColor">registry</text>
+  <line x1="315" y1="50" x2="420" y2="35" stroke="currentColor" stroke-width="1.5" marker-end="url(#r1)"/>
+  <line x1="315" y1="62" x2="420" y2="90" stroke="currentColor" stroke-width="1.5" marker-end="url(#r1)"/><text x="375" y="45" font-size="8" fill="currentColor">pull</text>
+  <rect x="420" y="20" width="90" height="28" rx="5" fill="none" stroke="currentColor"/><text x="465" y="38" text-anchor="middle" font-size="9" fill="currentColor">server A</text>
+  <rect x="420" y="78" width="90" height="28" rx="5" fill="none" stroke="currentColor"/><text x="465" y="96" text-anchor="middle" font-size="9" fill="currentColor">server B</text>
+  <defs><marker id="r1" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Build once, push to a registry, pull the identical image onto any number of servers.</figcaption>
+</figure>
+
+## A note on GopherTrunk
+
+GopherTrunk's [docker-compose](/learn/deployment/docker-compose/) file references the
+image name `ghcr.io/mattcheramie/gophertrunk`, but by default you **build it locally**
+from the repo Dockerfile (`docker compose build`). GopherTrunk's *official* automated
+releases are downloadable binaries and installers rather than a pushed image — a good
+reminder that "artifact" can mean a container image *or* a plain binary, and a project
+can use whichever fits.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a registry stores images so any host can pull and run them." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does a container registry let you do?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Compile source code into an image</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Store an image centrally so any machine can pull and run it</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Run tests on the image automatically</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- An image is named **`registry/repository:tag`**; omit the registry and Docker Hub is
+  assumed.
+- A **tag** is a movable label; a **digest** is an immutable hash of exact contents.
+- **`push`** to a registry, **`pull`** on any host — pull-and-run is the whole deploy.
+- GopherTrunk's compose builds the image locally; its official releases are binaries.
+
+Next up: running an app plus its dependencies together with Docker Compose.

--- a/docs/learn/deployment/incident-response.md
+++ b/docs/learn/deployment/incident-response.md
@@ -1,0 +1,124 @@
+---
+slug: incident-response
+title: Incident response & runbooks
+description: "What to do when production breaks — detecting, mitigating, and communicating during an incident, and the runbooks and postmortems that prevent the next one."
+keywords: incident response, runbook, postmortem, blameless postmortem, severity, mitigation, on-call, incident commander, mttr, production outage
+level: intermediate
+status: full
+prereq:
+  - alerting-and-oncall
+faq:
+  - q: What is a blameless postmortem?
+    a: "A blameless postmortem is a write-up after an incident that focuses on what in the system let the failure happen, not on who made a mistake. People act reasonably given the information and tools they had, so the fix is almost always a systemic one — a missing guardrail, a confusing interface, a gap in monitoring. Removing blame is what makes people honest, which is what makes the analysis useful."
+  - q: What's the difference between mitigating and resolving an incident?
+    a: "Mitigating means stopping the user impact as fast as possible — often by rolling back, failing over, or restarting — even if you don't yet understand the root cause. Resolving means actually fixing the underlying cause so it can't recur. During an incident you mitigate first to stop the bleeding; you resolve afterwards, calmly, once users are no longer affected."
+---
+
+# Incident response & runbooks
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+An **incident** is unplanned user impact. Responding to one is a repeatable flow:
+**detect** it (usually via an [alert](/learn/deployment/alerting-and-oncall/)),
+**mitigate** to stop the bleeding *before* you fully understand it, **communicate** with
+users and teammates, then **resolve** the root cause afterwards. A **runbook** is the
+pre-written playbook for a known failure; a **blameless postmortem** turns each incident
+into a systemic fix.
+</div>
+
+[Alerting](/learn/deployment/alerting-and-oncall/) wakes someone when production breaks.
+This lesson is what that someone *does*. The goal during an incident is not to be clever —
+it's to reduce user impact fast, then learn from it so the same thing can't page you
+twice.
+
+## The response flow
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 480 90" role="img" aria-label="Four stages: detect, mitigate, communicate, resolve, in sequence." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+  <rect x="8" y="30" width="96" height="30" rx="4" fill="none" stroke="currentColor"/><text x="56" y="49">detect</text>
+  <rect x="132" y="30" width="96" height="30" rx="4" fill="none" stroke="currentColor" stroke-width="1.7"/><text x="180" y="49">mitigate</text>
+  <rect x="256" y="30" width="112" height="30" rx="4" fill="none" stroke="currentColor"/><text x="312" y="49">communicate</text>
+  <rect x="396" y="30" width="80" height="30" rx="4" fill="none" stroke="currentColor"/><text x="436" y="49">resolve</text>
+  </g>
+  <g stroke="currentColor" fill="none"><line x1="104" y1="45" x2="132" y2="45"/><line x1="228" y1="45" x2="256" y2="45"/><line x1="368" y1="45" x2="396" y2="45"/></g>
+</svg>
+<figcaption>Detect the problem, mitigate to stop impact, communicate throughout, then resolve the root cause.</figcaption>
+</figure>
+
+- **Detect** — an alert fires, or a user reports it. The clock on user impact is running.
+- **Mitigate** — stop the bleeding *before* diagnosing. Roll back the recent deploy, fail
+  over, restart — whatever ends the impact fastest.
+- **Communicate** — tell affected users and teammates what's happening and when you'll
+  update next, even if the update is "still investigating."
+- **Resolve** — once users are safe, calmly find and fix the root cause.
+
+## Mitigate before you diagnose
+
+The instinct to understand *why* before acting is the wrong one mid-incident. Every minute
+spent debugging is a minute of user impact. If the incident started right after a deploy,
+your fastest mitigation is almost always a [rollback](/learn/deployment/zero-downtime-deploys/)
+to the last known-good [version](/learn/deployment/build-artifacts-and-versioning/):
+
+```bash
+# stop the bleeding first — roll back, understand later
+docker compose up -d           # recreate on the previous known-good image
+journalctl -u gophertrunk -n 200 --no-pager   # capture logs for the postmortem
+```
+
+Note the second command: grab the evidence *before* it rotates away, then move on.
+Understanding is for the postmortem; right now you're ending impact.
+
+## Severity sets the response
+
+Not every incident is all-hands. A **severity** level scales the response to the impact:
+
+| Severity | Impact | Response |
+|----------|--------|----------|
+| SEV1 | Full outage / data loss | All hands, incident commander, active comms |
+| SEV2 | Major feature broken for many | On-call + owner, regular updates |
+| SEV3 | Minor / degraded, workaround exists | On-call handles, ticket to follow up |
+
+Declaring the severity early tells everyone how hard to pull the fire alarm — and stops a
+SEV3 from consuming a team that a SEV1 will need.
+
+## Runbooks: don't improvise the known
+
+A **runbook** is a short, pre-written playbook for a *known* failure mode: the symptom,
+how to confirm it, and the exact steps to mitigate. Every [alert](/learn/deployment/alerting-and-oncall/)
+should link one, so a half-awake responder follows steps instead of inventing them. A
+runbook for GopherTrunk losing its control channel might read: *confirm via `/api/v1/health`,
+check the SDR is enumerated with `lsusb`, restart the service, escalate to the owner if it
+doesn't recover in 10 minutes.* Boring, specific, and exactly what you want at 3 a.m.
+
+## The blameless postmortem
+
+After a significant incident, write it up — timeline, impact, what happened, and what will
+stop it recurring. Make it **blameless**: focus on the *system* that let the failure
+happen, not the person at the keyboard. People act reasonably with the information they
+have, so the durable fixes are systemic — a missing health gate, a confusing config, an
+[alert](/learn/deployment/alerting-and-oncall/) that fired too late. Blame makes people
+hide facts; blamelessness makes them share the ones that prevent the next incident. Each
+postmortem's action items feed back into the [next build](/learn/deployment/the-deployment-lifecycle/)
+— closing the deployment loop.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — mitigate first to stop user impact; find the root cause afterwards." markdown="0">
+  <p class="knowledge-check__q">Quick check: what should you do first when an incident starts?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Fully diagnose the root cause before touching anything</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Mitigate to stop user impact, even before you understand the cause</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Write the postmortem</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- An **incident** is unplanned user impact; respond with **detect → mitigate →
+  communicate → resolve**.
+- **Mitigate first** — roll back or restart to stop impact before diagnosing.
+- **Severity** scales the response so effort matches impact.
+- **Runbooks** give responders pre-written steps; link one from every alert.
+- A **blameless postmortem** fixes the *system*, and its action items feed the next build.
+
+Next up: keeping a deployment affordable — cost and resource management.

--- a/docs/learn/deployment/index.md
+++ b/docs/learn/deployment/index.md
@@ -1,0 +1,36 @@
+---
+layout: learn-hub
+learn_module: deployment
+permalink: /learn/deployment/
+title: Learn deployment — from your machine to production
+description: A free, structured path through the modern deployment toolkit — build artifacts, containers and Docker, systemd, secrets, CI/CD, and cloud hosting — using GopherTrunk as the worked example.
+keywords: learn deployment, docker tutorial, containers, dockerfile, docker compose, systemd service, ci cd, github actions, deploy to vps, devops for beginners
+---
+
+Writing software is only half the job. Getting it running reliably somewhere
+other than your laptop — where it survives reboots, restarts after a crash, and
+behaves the same on a server as it did on your machine — is the other half. That
+second half has its own toolkit, and this path teaches it from the ground up.
+
+**Who this is for.** Anyone who can build a program but has never shipped one.
+No prior Docker, Linux administration, or DevOps background is assumed. If you
+have followed the [Go module](/learn/programming-go/) and know that `go build`
+produces a single binary, you already have the one prerequisite that matters.
+Comfortable with containers but fuzzy on registries, systemd, or CI/CD? Use the
+unit list to jump straight to the part you need.
+
+**How the path works.** Five units take you from "what does deploy even mean?"
+to a real application running on a real server. Unit 1 covers the foundations —
+environments, configuration, and the build artifacts everything else moves
+around. Unit 2 is containers and Docker: packaging an app with everything it
+needs to run anywhere. Unit 3 keeps a service alive and observable in
+production with systemd, logging, and secrets. Unit 4 automates the whole thing
+with CI/CD and takes it to the cloud. Unit 5 is the payoff: deploying
+GopherTrunk — a real software-defined-radio scanner — end to end, using its own
+Dockerfile, docker-compose stack, and systemd unit. There is also a
+[glossary](/learn/deployment/glossary/) you can skim any time.
+
+Every concept is grounded in files that actually ship in the GopherTrunk repo,
+so nothing here is hypothetical. Mark lessons complete as you go — your progress
+is saved in your browser. New here?
+**[Start with lesson 1: What is deployment?](/learn/deployment/what-is-deployment/)**

--- a/docs/learn/deployment/infrastructure-as-code.md
+++ b/docs/learn/deployment/infrastructure-as-code.md
@@ -1,0 +1,145 @@
+---
+slug: infrastructure-as-code
+title: Infrastructure as code
+description: "Describing servers and services declaratively so environments are reproducible — the idea behind Terraform and Ansible, versioned like code."
+keywords: infrastructure as code, iac, terraform, ansible, declarative infrastructure, idempotent, provisioning, configuration management, reproducible environments
+level: intermediate
+status: full
+prereq:
+  - ci-cd-pipelines
+faq:
+  - q: What is infrastructure as code?
+    a: "Infrastructure as code (IaC) means describing your servers, networks, and services in text files that a tool reads to create or update the real thing — instead of clicking around a console or running commands by hand. The files live in version control, get reviewed in pull requests, and can rebuild an environment identically from scratch. Your infrastructure becomes reproducible and auditable, just like your application code."
+  - q: What's the difference between Terraform and Ansible?
+    a: "Terraform provisions infrastructure — it creates the servers, networks, and cloud resources themselves, tracking their state so it knows what to add, change, or destroy. Ansible configures machines that already exist — installing packages, writing config files, starting services. In a common workflow Terraform builds the server and Ansible sets it up; they're complementary, not competitors."
+---
+
+# Infrastructure as code
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Infrastructure as code (IaC)** describes servers and services in **text files** a tool
+applies, instead of clicking a console or typing commands by hand. Good IaC is
+**declarative** (you state the desired end state) and **idempotent** (applying it twice
+changes nothing the second time). It lives in **version control** like any code.
+**Terraform** provisions the infrastructure; **Ansible** configures it.
+</div>
+
+[CI/CD](/learn/deployment/ci-cd-pipelines/) automated building and shipping your
+*artifact*. But the *server* it ships to also has to exist and be set up — and doing that
+by hand is exactly the "works on my machine" problem one level up. **IaC** solves it: the
+server's setup becomes a reviewed, versioned file you can apply anywhere.
+
+## The problem with clicking around
+
+Set a server up by hand — install packages, edit configs, open firewall ports — and you
+own a machine nobody can reproduce. The steps live only in your memory and shell history.
+Six months later you can't rebuild it, a teammate can't verify it, and the staging box
+has quietly drifted from production. IaC replaces the memory with a file.
+
+## Declarative and idempotent
+
+Two ideas make IaC trustworthy:
+
+- **Declarative** — you describe the *desired end state* ("a server with nginx installed
+  and running"), not the steps to get there. The tool figures out the difference between
+  now and desired and makes only the needed changes.
+- **Idempotent** — applying the same file twice is safe. If the server already matches,
+  the second run changes nothing. This is what lets you run IaC repeatedly and on a
+  schedule without fear.
+
+Contrast that with a shell script, which blindly re-runs every command whether or not it
+was already done — installing twice, appending config lines again. Declarative +
+idempotent means the file *is* the source of truth for what the server should be.
+
+## Terraform: provision the infrastructure
+
+**Terraform** creates the infrastructure itself — cloud servers, networks, DNS records —
+and tracks their **state** so it knows what already exists. You declare resources:
+
+```text
+resource "digitalocean_droplet" "gophertrunk" {
+  name   = "gophertrunk-prod"
+  image  = "debian-12-x64"
+  size   = "s-1vcpu-1gb"
+  region = "nyc3"
+}
+
+resource "digitalocean_firewall" "gt" {
+  droplet_ids = [digitalocean_droplet.gophertrunk.id]
+  inbound_rule {
+    protocol   = "tcp"
+    port_range = "443"        # HTTPS via the reverse proxy only
+  }
+}
+```
+
+`terraform plan` shows exactly what it *would* change; `terraform apply` makes it so.
+Change the size to `s-2vcpu-4gb`, run apply, and Terraform resizes the one droplet — it
+doesn't rebuild the world.
+
+## Ansible: configure what exists
+
+**Ansible** takes a server that already exists and brings it to a desired configuration —
+packages, files, services — over SSH, with no agent to install. You write **playbooks**:
+
+```yaml
+- hosts: gophertrunk-prod
+  become: true
+  tasks:
+    - name: Install the GopherTrunk systemd unit
+      copy:
+        src: gophertrunk.service
+        dest: /etc/systemd/system/gophertrunk.service
+
+    - name: Enable and start GopherTrunk
+      systemd:
+        name: gophertrunk
+        enabled: true
+        state: started
+```
+
+Each task is idempotent: if the unit file is already in place and the service running,
+the playbook reports "ok" and changes nothing. Run it against ten servers and they all
+end up identical — the [systemd service](/learn/deployment/services-and-systemd/) you'd
+otherwise install by hand, now reproducible.
+
+## They divide the work
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 96" role="img" aria-label="Terraform provisions a server from nothing, then Ansible configures the running server." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+  <rect x="10" y="34" width="120" height="34" rx="4" fill="none" stroke="currentColor"/><text x="70" y="48">Terraform</text><text x="70" y="60" font-size="7.5">provisions the server</text>
+  <rect x="180" y="34" width="120" height="34" rx="4" fill="none" stroke="currentColor"/><text x="240" y="48">Ansible</text><text x="240" y="60" font-size="7.5">configures the server</text>
+  <rect x="350" y="34" width="100" height="34" rx="4" fill="none" stroke="currentColor" stroke-width="1.7"/><text x="400" y="48">running</text><text x="400" y="60" font-size="7.5">GopherTrunk</text>
+  </g>
+  <g stroke="currentColor" fill="none"><line x1="130" y1="51" x2="180" y2="51"/><line x1="300" y1="51" x2="350" y2="51"/></g>
+</svg>
+<figcaption>A common flow: Terraform builds the machine, Ansible sets it up, and the service runs — all from versioned files.</figcaption>
+</figure>
+
+The whole point: your infrastructure lives in [git](/learn/git/github-actions/), gets
+reviewed in pull requests, and can be rebuilt identically from scratch. It's the same
+reproducibility CI gave your builds, extended to the servers.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — idempotent means applying the same definition twice is safe and changes nothing the second time." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does it mean that IaC is idempotent?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It can only be applied once ever</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Applying the same definition again is safe and makes no changes if nothing differs</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It runs faster each time you apply it</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **IaC** describes infrastructure in **versioned text files** a tool applies — no
+  hand-clicking.
+- Good IaC is **declarative** (state the end state) and **idempotent** (safe to reapply).
+- **Terraform** provisions infrastructure and tracks its state; **Ansible** configures
+  existing machines over SSH.
+- The payoff is **reproducible, reviewable, auditable** environments — CI's
+  reproducibility, applied to servers.
+
+Next up: where to actually run your deployment — cloud and VPS options.

--- a/docs/learn/deployment/logging-and-health-checks.md
+++ b/docs/learn/deployment/logging-and-health-checks.md
@@ -1,0 +1,123 @@
+---
+slug: logging-and-health-checks
+title: Logging & health checks
+description: How a running service tells you it's healthy — structured logs, health endpoints, and the signals an orchestrator uses to restart what's broken.
+keywords: logging, structured logs, health check, health endpoint, liveness, readiness, journald, monitoring, observability
+level: intermediate
+status: full
+prereq:
+  - services-and-systemd
+faq:
+  - q: What is a health check endpoint?
+    a: It's a small HTTP endpoint — often /health — that a service exposes to report whether it's working. A monitoring tool or orchestrator polls it periodically; a healthy response means keep running, a failure or timeout means the service is stuck and should be restarted or taken out of rotation.
+  - q: What are structured logs?
+    a: Structured logs record each event as machine-readable fields (like key/value pairs or JSON) rather than free-form text. That makes them searchable and filterable — you can pull every error for a given call or timeframe — instead of grepping unstructured lines. They're far easier to work with once a system is running at scale.
+---
+
+# Logging & health checks
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A running service has to tell you it's alive. **Logs** record what it's doing —
+**structured** logs (fields, not just text) are searchable. A **health check** endpoint
+lets a monitor poll "are you OK?"; a bad answer triggers a **restart** or removal from
+rotation. Together they're how you *know* a deployment is healthy without watching it.
+</div>
+
+Once a service runs unattended, you can't watch it by staring at a terminal. Logging
+and health checks are how it reports its own state.
+
+## Logs: the running narrative
+
+Logs are the diary of a running service — what it did, what went wrong, when. Under
+systemd, a service's output is captured by the **journal**, which you read with:
+
+```bash
+journalctl -u gophertrunk -f      # follow GopherTrunk's live logs
+```
+
+For a container, the equivalent is `docker logs -f gophertrunk`. Either way, the logs
+are your first stop when something misbehaves.
+
+**Structured** logs — events recorded as fields rather than free-form sentences — are
+much easier to work with as a system grows: you can filter for every error, every event
+on a given channel, every entry in a time window, instead of grepping prose. (The
+[Linux CLI module](/learn/linux-cli/monitoring-and-logs/) covers reading logs in depth.)
+
+## Health checks: a heartbeat you can poll
+
+A log tells you what happened; a **health check** answers "are you working *right
+now*?" The service exposes a small endpoint that returns OK when healthy:
+
+```bash
+$ curl http://127.0.0.1:8080/api/v1/health
+{"status":"ok"}
+```
+
+GopherTrunk exposes exactly this at `/api/v1/health`, and its
+[docker-compose](/learn/deployment/docker-compose/) file wires Docker to poll it:
+
+```yaml
+healthcheck:
+  test: ["CMD", "wget", "--quiet", "--spider", "http://127.0.0.1:8080/api/v1/health"]
+  interval: 30s
+  timeout: 5s
+  retries: 3
+```
+
+Every 30 seconds Docker checks the endpoint; three failures in a row mark the container
+unhealthy, and a restart policy or orchestrator can then act.
+
+## Liveness vs readiness
+
+Two subtly different questions a health check can answer:
+
+| Check | Asks | If it fails |
+|-------|------|-------------|
+| **Liveness** | Is the process alive and not stuck? | restart it |
+| **Readiness** | Is it ready to serve requests yet? | hold traffic until ready |
+
+Small deployments often use a single health endpoint for both; larger systems separate
+them so a service that's *starting up* isn't killed for not being ready yet.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 100" role="img" aria-label="A monitor repeatedly polling a service's health endpoint; a healthy reply keeps it running, a failed reply triggers a restart." xmlns="http://www.w3.org/2000/svg">
+  <rect x="20" y="35" width="90" height="30" rx="5" fill="none" stroke="currentColor"/><text x="65" y="54" text-anchor="middle" font-size="9" fill="currentColor">monitor</text>
+  <line x1="110" y1="44" x2="200" y2="44" stroke="currentColor" stroke-width="1.4" marker-end="url(#h1)"/><text x="155" y="38" font-size="8" fill="currentColor">GET /health</text>
+  <rect x="200" y="35" width="90" height="30" rx="5" fill="none" stroke="currentColor"/><text x="245" y="54" text-anchor="middle" font-size="9" fill="currentColor">service</text>
+  <line x1="200" y1="58" x2="110" y2="58" stroke="currentColor" stroke-width="1.4" marker-end="url(#h1)"/><text x="155" y="72" font-size="8" fill="currentColor">ok / fail</text>
+  <line x1="290" y1="50" x2="360" y2="35" stroke="currentColor" stroke-width="1.2" stroke-dasharray="3 2" marker-end="url(#h1)"/>
+  <text x="430" y="40" font-size="8" fill="currentColor">fail x3 &#8594; restart</text>
+  <defs><marker id="h1" markerWidth="7" markerHeight="7" refX="5" refY="3" orient="auto"><path d="M0 0 L5 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>A monitor polls the health endpoint; repeated failures trigger an automatic restart or traffic removal.</figcaption>
+</figure>
+
+## Metrics, briefly
+
+Beyond a yes/no health check, many services also expose **metrics** — numeric gauges
+and counters (requests handled, errors, memory) at an endpoint like `/metrics` for a
+tool such as Prometheus to scrape. GopherTrunk labels its compose service for exactly
+this. Metrics turn "is it up?" into "how is it *doing*?" — the subject of
+[monitoring & updates](/learn/deployment/monitoring-and-updates/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a health endpoint lets a monitor detect a stuck service and restart it." markdown="0">
+  <p class="knowledge-check__q">Quick check: what happens when a service repeatedly fails its health check?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Its logs are deleted</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">It's restarted or taken out of rotation</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Its version number increases</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Logs** are a service's running narrative — read them via `journalctl` or `docker
+  logs`; **structured** logs are searchable.
+- A **health check** endpoint lets a monitor poll "are you OK?" — GopherTrunk exposes
+  `/api/v1/health`.
+- **Liveness** (alive?) and **readiness** (ready to serve?) are distinct questions.
+- **Metrics** at `/metrics` answer "how is it doing?" beyond a simple up/down.
+
+Next up: keeping credentials safe — secrets and configuration management.

--- a/docs/learn/deployment/monitoring-and-updates.md
+++ b/docs/learn/deployment/monitoring-and-updates.md
@@ -1,0 +1,115 @@
+---
+slug: monitoring-and-updates
+title: Monitoring & updates
+description: Keeping a deployment healthy over time — metrics and alerts, rolling out new versions safely, and rolling back when a release goes wrong.
+keywords: monitoring, metrics, alerts, prometheus, rolling update, rollback, deploy new version, uptime, observability, safe deployment
+level: intermediate
+status: full
+prereq:
+  - logging-and-health-checks
+  - build-artifacts-and-versioning
+faq:
+  - q: What is the difference between logs, metrics, and alerts?
+    a: Logs are a detailed record of individual events. Metrics are numbers measured over time — request rate, error count, memory use — good for spotting trends. Alerts are automatic notifications when a metric crosses a threshold, like errors spiking or the service going down, so a human finds out without watching dashboards.
+  - q: How do you update a deployed service safely?
+    a: Deploy the new versioned artifact, watch its health check and metrics, and keep the previous version available. If the new one misbehaves, roll back by redeploying the previous artifact. Doing updates in a way that lets you quickly return to a known-good version is what makes them safe.
+---
+
+# Monitoring & updates
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A deployment isn't done when it starts — you have to keep it healthy. **Metrics** track
+trends over time and **alerts** notify you when something breaks. Ship new versions as
+**updates** while watching health, and keep the previous **versioned artifact** so you
+can **roll back** instantly if a release goes wrong. Safe updates are all about being
+able to undo them.
+</div>
+
+This lesson is about the long tail of deployment: watching a running service and
+changing it without breaking it.
+
+## From health checks to metrics and alerts
+
+A [health check](/learn/deployment/logging-and-health-checks/) tells you up or down.
+**Metrics** go further — numbers sampled over time that reveal *trends*:
+
+- request rate and error rate
+- latency (how long responses take)
+- memory and CPU use
+- app-specific gauges (for GopherTrunk, active channels, decode rate)
+
+A tool like **Prometheus** scrapes these from a `/metrics` endpoint (GopherTrunk labels
+its [compose service](/learn/deployment/docker-compose/) for exactly this) and stores
+them so you can graph them. **Alerts** sit on top: define a rule — "error rate above 5%"
+or "service down for 2 minutes" — and get notified automatically, so you learn about
+problems from a page, not from an angry user.
+
+## Rolling out a new version
+
+When a new [version](/learn/deployment/build-artifacts-and-versioning/) is ready,
+updating a container deployment is a pull-and-recreate:
+
+```bash
+docker compose pull        # fetch the new image
+docker compose up -d       # recreate the container with it
+```
+
+For a systemd binary, you install the new binary and restart the service. Either way,
+right after the update you **watch the health check and metrics** — the update isn't
+"done" until the new version proves healthy under real traffic.
+
+## Rolling back
+
+Here's why [immutable, versioned artifacts](/learn/deployment/build-artifacts-and-versioning/)
+matter so much: if the new version misbehaves, you don't debug in production under
+pressure — you **roll back** to the previous known-good version, which still exists:
+
+```bash
+docker compose pull gophertrunk:1.4.1   # the previous good version
+docker compose up -d
+```
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 90" role="img" aria-label="Version 1.4.1 running, then deploy 1.4.2, health check fails, then roll back to 1.4.1." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="8.5" fill="currentColor" text-anchor="middle">
+  <rect x="10" y="34" width="80" height="28" rx="4" fill="none" stroke="currentColor"/><text x="50" y="52">run 1.4.1</text>
+  <rect x="130" y="34" width="90" height="28" rx="4" fill="none" stroke="currentColor"/><text x="175" y="52">deploy 1.4.2</text>
+  <rect x="260" y="34" width="95" height="28" rx="4" fill="none" stroke="currentColor" stroke-dasharray="3 2"/><text x="307" y="52">health fails</text>
+  <rect x="395" y="34" width="110" height="28" rx="4" fill="none" stroke="currentColor" stroke-width="1.7"/><text x="450" y="52">roll back 1.4.1</text>
+  </g>
+  <g stroke="currentColor"><line x1="90" y1="48" x2="130" y2="48"/><line x1="220" y1="48" x2="260" y2="48"/><line x1="355" y1="48" x2="395" y2="48"/></g>
+</svg>
+<figcaption>Because the previous versioned artifact still exists, a bad release is undone by redeploying it — no live debugging.</figcaption>
+</figure>
+
+## Update safely, sleep well
+
+Good update habits:
+
+- **Update one thing at a time** so if something breaks, you know what caused it.
+- **Watch after every deploy** — health, metrics, logs — for long enough to trust it.
+- **Keep the last known-good version** ready to redeploy.
+- **Automate it** through your [CI/CD pipeline](/learn/deployment/ci-cd-pipelines/) so
+  updates are consistent, not improvised.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — keeping the previous versioned artifact lets you roll back instantly." markdown="0">
+  <p class="knowledge-check__q">Quick check: what makes rolling back a bad release possible?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Editing the running container by hand</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The previous versioned artifact still exists to redeploy</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Deleting the logs</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Keep a deployment healthy with **metrics** (trends over time) and **alerts**
+  (automatic notification).
+- Ship new versions as **updates** — pull and recreate — then **watch** health and
+  metrics.
+- Keep the previous **versioned artifact** so you can **roll back** instantly.
+- Update one thing at a time, watch after each deploy, and automate through CI/CD.
+
+Next up: Unit 5 — deploy GopherTrunk end to end, using everything you've learned.

--- a/docs/learn/deployment/observability.md
+++ b/docs/learn/deployment/observability.md
@@ -1,0 +1,134 @@
+---
+slug: observability
+title: Observability — metrics, logs & traces
+description: "The three pillars that let you understand a running system — metrics, logs, and traces — and how they answer is it up, what happened, and why is it slow."
+keywords: observability, metrics, logs, traces, three pillars, prometheus, grafana, metrics endpoint, monitoring, distributed tracing
+level: intermediate
+status: full
+prereq:
+  - logging-and-health-checks
+faq:
+  - q: What are the three pillars of observability?
+    a: "Metrics, logs, and traces. Metrics are cheap numeric time-series that answer 'is it up and how much?' — request rate, error rate, memory. Logs are timestamped event records that answer 'what exactly happened?' Traces follow one request across services to answer 'where did the time go?' Together they let you understand a system's behaviour from the outside without attaching a debugger."
+  - q: What is the difference between monitoring and observability?
+    a: "Monitoring watches for known problems — you decide in advance what to measure and alert on. Observability is the broader property of being able to ask new questions of a running system after the fact, including ones you didn't anticipate. Good metrics, logs, and traces give you observability; dashboards and alerts built on them are monitoring."
+---
+
+# Observability — metrics, logs & traces
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Observability is being able to understand a running system from the outside. It rests on
+**three pillars**: **metrics** (cheap numbers over time — "is it up?"), **logs**
+(timestamped events — "what happened?"), and **traces** (one request's path across
+services — "why is it slow?"). GopherTrunk exposes a **`/metrics`** endpoint that
+Prometheus scrapes and Grafana graphs.
+</div>
+
+[Logging & health checks](/learn/deployment/logging-and-health-checks/) gave you a service
+that can *say* it's healthy. Observability is the wider skill of *understanding* it —
+answering questions you didn't script in advance. Three kinds of signal do that, and each
+answers a different question.
+
+## The three pillars
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 470 110" role="img" aria-label="Three columns: metrics answering is it up, logs answering what happened, traces answering why is it slow." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9.5" fill="currentColor" text-anchor="middle">
+  <rect x="14" y="16" width="130" height="80" rx="5" fill="none" stroke="currentColor"/><text x="79" y="38">metrics</text><text x="79" y="60" font-size="8">numbers over time</text><text x="79" y="80" font-size="8">"is it up?"</text>
+  <rect x="170" y="16" width="130" height="80" rx="5" fill="none" stroke="currentColor"/><text x="235" y="38">logs</text><text x="235" y="60" font-size="8">event records</text><text x="235" y="80" font-size="8">"what happened?"</text>
+  <rect x="326" y="16" width="130" height="80" rx="5" fill="none" stroke="currentColor"/><text x="391" y="38">traces</text><text x="391" y="60" font-size="8">a request's path</text><text x="391" y="80" font-size="8">"why is it slow?"</text>
+  </g>
+</svg>
+<figcaption>Each pillar answers a different question; together they let you understand behaviour without a debugger.</figcaption>
+</figure>
+
+## Metrics: is it up, and how much?
+
+**Metrics** are cheap numeric measurements sampled over time — request rate, error count,
+response latency, memory in use. They're compact enough to keep for months, which makes
+them perfect for dashboards, trends, and [alerts](/learn/deployment/alerting-and-oncall/).
+GopherTrunk exposes them in Prometheus format at **`/metrics`** — its compose file even
+labels the container for a Prometheus sidecar to find:
+
+```yaml
+labels:
+  - "prometheus.scrape=true"
+  - "prometheus.port=8080"
+  - "prometheus.path=/metrics"
+```
+
+**Prometheus** periodically *scrapes* that endpoint and stores the numbers as time-series;
+**Grafana** graphs them into dashboards:
+
+```text
+# a Prometheus scrape target
+scrape_configs:
+  - job_name: gophertrunk
+    static_configs:
+      - targets: ["127.0.0.1:8080"]
+    metrics_path: /metrics
+```
+
+A metric like `http_requests_total` climbing while `http_request_errors_total` stays flat
+tells you at a glance the service is healthy under load — no log-reading required.
+
+## Logs: what exactly happened?
+
+Metrics tell you *that* errors rose; **logs** tell you *what* they were. A log line is a
+timestamped record of a discrete event, ideally [structured](/learn/deployment/logging-and-health-checks/)
+so you can filter it:
+
+```text
+{"time":"2026-07-23T14:02:11Z","level":"error","msg":"decode failed","tg":52198,"freq":851012500}
+```
+
+When a metric spikes, logs are where you go to read the story of a specific failure — the
+talkgroup, the frequency, the error. Ship them somewhere searchable (the
+[journal](/learn/linux-cli/monitoring-and-logs/), or a log aggregator) so you can query
+across time rather than tailing one file.
+
+## Traces: where did the time go?
+
+In a system of several services, a single user request hops between them, and "why is it
+slow?" means "which hop ate the time?" A **trace** follows one request end to end,
+recording how long each step took as nested **spans**. For a single-service app like a
+lone GopherTrunk instance, traces matter little — there's one process. They earn their
+keep once a request fans out across services, which is exactly the world
+[orchestration](/learn/deployment/container-orchestration/) and
+[scaling](/learn/deployment/scaling-and-load-balancing/) create.
+
+## Pick the pillar for the question
+
+| The question | The pillar |
+|--------------|-----------|
+| Is the service up? Is error rate rising? | Metrics |
+| What was *that specific* failure? | Logs |
+| Which service made this request slow? | Traces |
+| Should I get paged right now? | Metrics → [alerts](/learn/deployment/alerting-and-oncall/) |
+
+You don't need all three from day one — metrics plus good logs cover most single-service
+deployments, and GopherTrunk gives you both out of the box. Add traces when you have
+multiple services and "which one is slow?" becomes a real question.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — metrics are cheap numbers over time, ideal for dashboards and alerts on whether it's up." markdown="0">
+  <p class="knowledge-check__q">Quick check: which pillar best answers "is the service up and how much load is it under?"</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="correct">Metrics</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Traces</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">A one-off debugger session</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Observability rests on three pillars: **metrics**, **logs**, and **traces**.
+- **Metrics** are cheap numbers over time — "is it up?" — and drive dashboards and alerts;
+  GopherTrunk exposes **`/metrics`** for Prometheus, graphed by Grafana.
+- **Logs** are timestamped events — "what happened?" — best kept structured and
+  searchable.
+- **Traces** follow one request across services — "why is it slow?" — and matter most in
+  multi-service systems.
+
+Next up: turning metrics into pages that matter — alerting and on-call.

--- a/docs/learn/deployment/production-hardening.md
+++ b/docs/learn/deployment/production-hardening.md
@@ -1,0 +1,143 @@
+---
+slug: production-hardening
+title: Production hardening
+description: "Least privilege, firewalls, updates, and the systemd sandboxing GopherTrunk ships — locking a deployment down against the threats a real host faces."
+keywords: production hardening, least privilege, firewall, ufw, automatic updates, ssh keys, systemd sandbox, protectsystem, nonewprivileges, server hardening
+level: advanced
+status: full
+prereq:
+  - container-security
+faq:
+  - q: What is the principle of least privilege?
+    a: "Give every user, process, and service exactly the access it needs to do its job and nothing more. A web app doesn't need root; a scanner doesn't need to write outside its data directory; an admin doesn't need password SSH. When something is compromised, least privilege limits how far the damage spreads — the attacker inherits only the narrow access that component had."
+  - q: Should I turn on automatic security updates?
+    a: "For most servers, yes. Unattended security updates close known holes without waiting for you to log in, and known-but-unpatched vulnerabilities are how most servers get compromised. On Debian and Ubuntu, unattended-upgrades applies security patches automatically. Pair it with a reboot policy for kernel updates and you close the largest, easiest attack window."
+---
+
+# Production hardening
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Hardening is **least privilege applied to a whole host**. Close every port you don't
+serve with a **firewall**. Log in with **SSH keys**, not passwords. Turn on **automatic
+security updates**. And confine each service to a **sandbox** — GopherTrunk's systemd
+unit does this with `DynamicUser`, `ProtectSystem=strict`, `NoNewPrivileges`, and
+tightly scoped device access. Every switch removes power an attacker could otherwise
+inherit.
+</div>
+
+[Container security](/learn/deployment/container-security/) locked down one container;
+this lesson locks down the **host it runs on** and any bare-metal service beside it. The
+idea is the same — least privilege — scaled up to the machine. It leans on
+[firewalls](/learn/networking/firewalls/), [SSH](/learn/linux-cli/ssh-and-remote/), and
+[hardening systems](/learn/cybersecurity/hardening-systems/) from the other modules.
+
+## Close everything you don't serve
+
+Every open port is a door. A **firewall** shuts every door except the few you actually
+use. On Ubuntu/Debian, `ufw` makes this a few lines:
+
+```bash
+sudo ufw default deny incoming      # deny everything inbound by default
+sudo ufw default allow outgoing
+sudo ufw allow 22/tcp               # SSH
+sudo ufw allow 443/tcp              # HTTPS via the reverse proxy
+sudo ufw enable
+```
+
+Notice GopherTrunk's API port `8080` is *not* opened: it's bound to `127.0.0.1` and
+reached only through the [reverse proxy](/learn/deployment/reverse-proxies-and-tls/) on
+443. If a service doesn't need to be reachable from outside, don't open its port — the
+proxy and localhost handle the rest.
+
+## Lock down SSH
+
+SSH is the front door to the host, so harden it. Use **key authentication** and turn
+password login off entirely — a key can't be guessed the way a password can:
+
+```text
+# /etc/ssh/sshd_config
+PasswordAuthentication no
+PermitRootLogin no
+PubkeyAuthentication yes
+```
+
+No password auth means brute-force attempts against `sshd` are pointless, and
+`PermitRootLogin no` forces admins through an unprivileged account that then uses `sudo`
+— an audit trail and one less privileged door. See
+[SSH & remote access](/learn/linux-cli/ssh-and-remote/) for the key setup.
+
+## Patch automatically
+
+Most compromised servers were running software with a *known* fix that nobody applied.
+**Automatic security updates** close that gap:
+
+```bash
+sudo apt install unattended-upgrades
+sudo dpkg-reconfigure -plow unattended-upgrades   # enable security updates
+```
+
+Security patches now land without you logging in. Pair it with a reboot window for kernel
+updates and you shut the largest, cheapest attack vector — see
+[package management](/learn/linux-cli/package-management/).
+
+## Sandbox each service
+
+The [systemd lesson](/learn/deployment/services-and-systemd/) introduced GopherTrunk's
+unit; hardening is where its sandbox directives earn their place. The real unit confines
+the scanner tightly:
+
+```ini
+DynamicUser=true            # run as an ephemeral, unprivileged user
+ProtectSystem=strict        # the whole filesystem is read-only, except...
+ReadWritePaths=/var/lib/gophertrunk
+ProtectHome=true            # /home is invisible to the service
+NoNewPrivileges=true        # can never gain new privileges via setuid
+ProtectKernelModules=true   # can't load kernel modules
+ProtectKernelTunables=true  # can't rewrite /proc/sys
+RestrictRealtime=true
+RestrictNamespaces=true
+DeviceAllow=char-usb_device rwm   # only the USB device it actually needs
+```
+
+Read that as a list of powers *removed*: the scanner can't write outside its data
+directory, can't see home directories, can't escalate privileges, can't touch the kernel,
+and can reach only USB device nodes. Even if the process is fully compromised, the
+attacker inherits this tiny box — the exact mirror of the container's dropped
+capabilities, applied to a bare-metal service.
+
+## Hardening is layers, not a switch
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 470 108" role="img" aria-label="Layered defenses from outside in: firewall, SSH keys, automatic updates, service sandbox." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+  <rect x="8" y="8" width="454" height="92" rx="6" fill="none" stroke="currentColor" stroke-opacity="0.4"/><text x="235" y="24">firewall — only 22 and 443 open</text>
+  <rect x="46" y="32" width="378" height="62" rx="5" fill="none" stroke="currentColor" stroke-opacity="0.6"/><text x="235" y="47">SSH keys only, no root login</text>
+  <rect x="92" y="52" width="286" height="40" rx="5" fill="none" stroke="currentColor" stroke-opacity="0.8"/><text x="235" y="66">automatic security updates</text>
+  <rect x="132" y="70" width="206" height="22" rx="4" fill="none" stroke="currentColor" stroke-width="1.7"/><text x="235" y="85" font-size="8">systemd-sandboxed service</text>
+  </g>
+</svg>
+<figcaption>Each layer removes attacker options; a breach at the edge still meets a locked-down service in the middle.</figcaption>
+</figure>
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — ProtectSystem=strict makes the filesystem read-only except explicit ReadWritePaths." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does <code>ProtectSystem=strict</code> in GopherTrunk's unit do?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Encrypts the service's network traffic</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Makes the filesystem read-only except the explicit ReadWritePaths</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Restarts the service if it crashes</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Hardening is **least privilege applied to the whole host**, in layers.
+- A **firewall** (`ufw`) closes every port but the few you serve — GopherTrunk's 8080
+  stays on localhost.
+- Use **SSH keys**, disable password and root login.
+- Turn on **automatic security updates** to close known holes unattended.
+- **Sandbox** each service — GopherTrunk's systemd unit uses `DynamicUser`,
+  `ProtectSystem=strict`, `NoNewPrivileges`, and scoped `DeviceAllow`.
+
+Next up: automating build, test, and release with CI/CD pipelines.

--- a/docs/learn/deployment/release-strategies.md
+++ b/docs/learn/deployment/release-strategies.md
@@ -1,0 +1,123 @@
+---
+slug: release-strategies
+title: Release strategies
+description: "Recreate, rolling, blue-green, and canary releases — the patterns for pushing a new version to users without downtime or a risky big-bang cutover."
+keywords: release strategies, rolling release, blue-green deployment, canary release, recreate deployment, zero downtime release, deployment patterns
+level: intermediate
+status: full
+prereq:
+  - build-artifacts-and-versioning
+faq:
+  - q: What is a canary release?
+    a: "A canary release sends the new version to a small slice of traffic first — say 5% of users — while everyone else stays on the old version. You watch the canary's error rate and latency; if it's healthy you widen it gradually to 100%, and if it misbehaves you pull it back having exposed only a few users. The name comes from the canary miners took underground to detect danger early."
+  - q: What is the difference between blue-green and rolling?
+    a: "A rolling release replaces instances a few at a time, so old and new run side by side during the rollout. Blue-green runs two complete environments — blue (current) and green (new) — and flips all traffic at once when green is verified. Rolling is gradual and cheap; blue-green is instant to switch and instant to roll back but needs double the capacity."
+---
+
+# Release strategies
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A **release strategy** is how you swap a new version in for the old one. **Recreate**
+stops everything then starts the new version (simple, but a gap of downtime).
+**Rolling** replaces instances a few at a time. **Blue-green** runs two full
+environments and flips traffic instantly. **Canary** sends a small slice of traffic to
+the new version first and widens it as confidence grows. The tradeoff is always
+downtime and risk versus cost and complexity.
+</div>
+
+You've built a versioned [artifact](/learn/deployment/build-artifacts-and-versioning/)
+and it passed CI. Now you have to put it in front of users who are already using the old
+version. *How* you make that swap is a release strategy — and the choice decides whether
+users notice, and what happens when the new version is broken.
+
+## Recreate: stop the old, start the new
+
+The simplest strategy: shut the old version down, then start the new one.
+
+```bash
+docker compose down          # stop the old version
+docker compose up -d         # start the new one
+```
+
+Between those two commands the service is **down** — every request fails. That's fine
+for a hobby scanner, a nightly batch job, or anything where a few seconds of gap costs
+nothing. It's the wrong choice for anything users hit constantly. Recreate is honest
+about its one weakness: a visible outage window.
+
+## Rolling: replace a few at a time
+
+If you run several instances behind a
+[load balancer](/learn/networking/proxies-and-load-balancers/), you don't have to take
+them all down at once. A **rolling** release updates them in batches: drain and replace
+instance 1, wait for it to report healthy, then instance 2, and so on. Old and new
+versions serve traffic side by side during the rollout, so there's no outage — but for a
+while your users are split across two versions, which the new version must tolerate.
+
+## Blue-green: two environments, one switch
+
+**Blue-green** keeps two complete environments. *Blue* is live and serving all traffic;
+*green* is the new version, fully deployed but receiving nothing. You test green in
+place, then flip the [proxy](/learn/deployment/reverse-proxies-and-tls/) to send all
+traffic to green in one move. If green misbehaves, flip straight back to blue — rollback
+is instant because blue never went away. The cost is real: you need double the capacity
+during the switch.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A load balancer routing all traffic to a blue environment, with a green environment standing ready, and a dashed arrow showing the switch." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+  <rect x="180" y="8" width="100" height="26" rx="4" fill="none" stroke="currentColor"/><text x="230" y="25">load balancer</text>
+  <rect x="60" y="90" width="120" height="30" rx="4" fill="none" stroke="currentColor" stroke-width="1.7"/><text x="120" y="109">BLUE (live v1)</text>
+  <rect x="280" y="90" width="120" height="30" rx="4" fill="none" stroke="currentColor" stroke-dasharray="4 3"/><text x="340" y="109">GREEN (new v2)</text>
+  </g>
+  <g stroke="currentColor" fill="none"><line x1="215" y1="34" x2="120" y2="90"/><line x1="245" y1="34" x2="340" y2="90" stroke-dasharray="4 3"/></g>
+  <text x="300" y="60" font-size="8" fill="currentColor">flip</text>
+</svg>
+<figcaption>Blue-green: all traffic hits blue; when green is verified, the load balancer flips to it in one switch.</figcaption>
+</figure>
+
+## Canary: test on a slice of real traffic
+
+A **canary** release is a rolling release that pauses at the start to *measure*. You
+route a small fraction of traffic — 1%, then 5%, then 25% — to the new version while
+watching its [metrics](/learn/deployment/observability/). If error rate and latency stay
+healthy, you widen the split until the new version has 100%. If the canary looks sick,
+you pull it back, having exposed only a handful of users to the bad version. It's the
+safest strategy for high-traffic services and the one that leans hardest on good
+[observability](/learn/deployment/observability/) — you can only trust a canary you can
+measure.
+
+## Choosing one
+
+| Strategy | Downtime | Rollback | Extra capacity | Good for |
+|----------|----------|----------|----------------|----------|
+| Recreate | Yes, a gap | Redeploy old | None | Hobby apps, batch jobs, single instance |
+| Rolling | None | Slow (roll back through batches) | Small | Many stateless instances |
+| Blue-green | None | Instant (flip back) | Double | Fast rollback matters most |
+| Canary | None | Instant (stop widening) | Small | High traffic, want to limit blast radius |
+
+For a single GopherTrunk instance on one host, a brief
+[recreate](/learn/deployment/zero-downtime-deploys/) (`docker compose up -d` recreates
+the container) is entirely reasonable — the fancy strategies earn their complexity only
+once you're running many instances for many users.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a canary exposes only a small traffic slice to the new version first." markdown="0">
+  <p class="knowledge-check__q">Quick check: which strategy sends a small fraction of real traffic to the new version before widening?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Recreate</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Canary</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Blue-green</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Recreate** is simplest but has a downtime gap — fine for single instances and jobs.
+- **Rolling** replaces instances a few at a time with no outage.
+- **Blue-green** runs two environments and flips traffic instantly, at double capacity.
+- **Canary** routes a small traffic slice to the new version first, widening as metrics
+  stay healthy.
+- The tradeoff is always **downtime and risk** versus **cost and complexity**.
+
+Next up: what a container actually is, and why it solves "works on my machine".

--- a/docs/learn/deployment/reverse-proxies-and-tls.md
+++ b/docs/learn/deployment/reverse-proxies-and-tls.md
@@ -1,0 +1,140 @@
+---
+slug: reverse-proxies-and-tls
+title: Reverse proxies & TLS
+description: "Putting a service behind nginx or Caddy — terminating HTTPS, routing by host, and why the proxy, not the app, usually handles certificates."
+keywords: reverse proxy, nginx, caddy, tls termination, https, lets encrypt, acme, certificate, host routing, proxy pass
+level: intermediate
+status: full
+prereq:
+  - services-and-systemd
+faq:
+  - q: What is a reverse proxy?
+    a: "A reverse proxy is a server that sits in front of one or more backend applications and forwards client requests to them. To the outside world it looks like the whole site; behind it, it routes each request to the right backend by hostname or path. It's where you centralise HTTPS, compression, rate limiting, and routing so each app doesn't reimplement them."
+  - q: Why does the proxy handle TLS instead of the app?
+    a: "Terminating TLS at the proxy means one place holds the certificates, one place renews them, and one place gets the ciphers and protocol versions right. The app behind it can speak plain HTTP on localhost, staying simpler. GopherTrunk binds its API to 127.0.0.1 and lets a proxy add HTTPS in front — the app never has to know about certificates."
+---
+
+# Reverse proxies & TLS
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A **reverse proxy** (nginx or Caddy) sits in front of your app, taking public traffic and
+forwarding it to the app on localhost. It **terminates TLS** — holding the certificate
+and speaking HTTPS to the world — so the app behind it stays plain HTTP. It **routes by
+host** so one server can front many apps. Tools like Caddy fetch and renew Let's Encrypt
+certificates automatically over **ACME**.
+</div>
+
+The [Compose lesson](/learn/deployment/docker-compose/) bound GopherTrunk's API to
+`127.0.0.1:8080` — reachable only from the host. A **reverse proxy** is how you safely
+expose that to the world with HTTPS, without the app itself dealing in certificates. This
+builds on [TLS & HTTPS](/learn/networking/tls-and-https/) and
+[proxies & load balancers](/learn/networking/proxies-and-load-balancers/) from the
+networking module.
+
+## What a reverse proxy does
+
+A reverse proxy accepts every incoming connection and forwards it to a backend. That one
+choke point becomes the natural home for the cross-cutting concerns you don't want each
+app to reinvent:
+
+- **TLS termination** — decrypt HTTPS here, forward plain HTTP inward.
+- **Host / path routing** — send `scanner.example.com` to one app, `blog.example.com` to
+  another.
+- **Rate limiting, compression, caching, auth** — applied once, in front of everything.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 480 120" role="img" aria-label="Internet traffic over HTTPS hits a reverse proxy, which forwards plain HTTP to two backend apps on localhost." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+  <text x="45" y="64" font-size="9">internet</text>
+  <rect x="120" y="42" width="100" height="36" rx="4" fill="none" stroke="currentColor" stroke-width="1.7"/><text x="170" y="58">reverse proxy</text><text x="170" y="70" font-size="7.5">TLS ends here</text>
+  <rect x="320" y="12" width="140" height="30" rx="4" fill="none" stroke="currentColor"/><text x="390" y="31" font-size="8">127.0.0.1:8080 (app)</text>
+  <rect x="320" y="78" width="140" height="30" rx="4" fill="none" stroke="currentColor"/><text x="390" y="97" font-size="8">127.0.0.1:3000 (blog)</text>
+  </g>
+  <g stroke="currentColor" fill="none"><line x1="70" y1="60" x2="120" y2="60"/><line x1="220" y1="55" x2="320" y2="27"/><line x1="220" y1="65" x2="320" y2="93"/></g>
+  <text x="95" y="52" font-size="7.5" fill="currentColor">HTTPS</text>
+  <text x="275" y="30" font-size="7.5" fill="currentColor">HTTP</text>
+</svg>
+<figcaption>HTTPS ends at the proxy; it forwards plain HTTP to each backend on localhost, routing by hostname.</figcaption>
+</figure>
+
+## Why the app stays plain HTTP
+
+Terminating TLS at the proxy means the **certificate lives in exactly one place**. One
+process holds the private key, renews it before it expires, and keeps the TLS protocol
+versions and ciphers current. The app behind it just serves plain HTTP on localhost and
+never touches a certificate — simpler app, one thing to get right instead of many. This
+is exactly why GopherTrunk binds to `127.0.0.1`: the loopback hop is unencrypted but
+never leaves the host, and the proxy adds HTTPS on the public side.
+
+## nginx: explicit and everywhere
+
+nginx is the classic choice — a config block forwards a hostname to the backend:
+
+```text
+server {
+    listen 443 ssl;
+    server_name scanner.example.com;
+
+    ssl_certificate     /etc/letsencrypt/live/scanner.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/scanner.example.com/privkey.pem;
+
+    location / {
+        proxy_pass http://127.0.0.1:8080;   # GopherTrunk's local API
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header X-Forwarded-Proto https;
+    }
+}
+```
+
+`proxy_pass` is the forward; the `X-Forwarded-*` headers tell the app the *original*
+client's address and that the outside hop was HTTPS. You get the certificate from
+[Let's Encrypt](https://letsencrypt.org/) with `certbot`, which also installs a renewal
+timer.
+
+## Caddy: automatic HTTPS
+
+Caddy does the same job but fetches and renews certificates for you automatically over
+**ACME** — the protocol Let's Encrypt uses to prove you control a domain. The entire
+config is often two lines:
+
+```text
+scanner.example.com {
+    reverse_proxy 127.0.0.1:8080
+}
+```
+
+Point that hostname's DNS at your server, start Caddy, and it obtains a valid
+certificate on first request and renews it forever — no `certbot`, no cron job. For a
+new deployment that's the lowest-friction path to real HTTPS.
+
+## The key idea
+
+The proxy owns the edge; the app owns its logic. TLS, routing, and rate limiting live in
+front, in one place, on one team's checklist. Add a second app later and you route it
+with a few more lines — the pattern scales into the
+[load balancer](/learn/networking/proxies-and-load-balancers/) you'll meet in
+[scaling](/learn/deployment/scaling-and-load-balancing/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — terminating TLS at the proxy keeps the certificate in one place and the app plain HTTP." markdown="0">
+  <p class="knowledge-check__q">Quick check: why let the reverse proxy handle TLS instead of the app?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">The app can't serve HTTP at all</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">One place holds and renews the certificate; the app stays simple plain HTTP</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Proxies encrypt faster than any application can</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **reverse proxy** (nginx, Caddy) fronts your app and forwards requests to it.
+- It **terminates TLS** — the certificate lives in one place, and the app behind speaks
+  plain HTTP on localhost.
+- It **routes by host/path** so one server can front many apps, with `X-Forwarded-*`
+  headers passing the real client info through.
+- **Caddy** automates Let's Encrypt certificates over **ACME**; nginx + certbot does the
+  same with a bit more config.
+
+Next up: how a running service tells you it's healthy — logging and health checks.

--- a/docs/learn/deployment/scaling-and-load-balancing.md
+++ b/docs/learn/deployment/scaling-and-load-balancing.md
@@ -1,0 +1,136 @@
+---
+slug: scaling-and-load-balancing
+title: Scaling & load balancing
+description: "Scaling up vs out, stateless vs stateful services, and how a load balancer spreads traffic across instances — the mechanics of handling more users."
+keywords: scaling, load balancing, vertical scaling, horizontal scaling, stateless service, sticky sessions, round robin, load balancer algorithms, scale out
+level: advanced
+status: full
+prereq:
+  - container-orchestration
+faq:
+  - q: What's the difference between vertical and horizontal scaling?
+    a: "Vertical scaling (scaling up) means giving one machine more resources — more CPU, more memory. It's simple but capped by the biggest machine you can buy, and that machine is a single point of failure. Horizontal scaling (scaling out) means running more copies of the service behind a load balancer. It scales far further and survives one instance dying, but only works if the service is stateless."
+  - q: Why does horizontal scaling need stateless services?
+    a: "If each instance holds its own important state — a user's session in local memory, say — then which instance a request lands on matters, and you can't freely spread traffic. A stateless instance keeps no such state locally (it lives in a shared database or cache), so any instance can serve any request. That's what lets a load balancer treat all instances as interchangeable and scale them freely."
+---
+
+# Scaling & load balancing
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Two ways to handle more load: **scale up** (a bigger machine) or **scale out** (more
+copies). Scaling up is simple but capped and single-point-of-failure; scaling out goes
+far further and survives failures — but only if the service is **stateless**, so any
+instance can serve any request. A **load balancer** spreads traffic across the instances
+by an algorithm like round-robin or least-connections.
+</div>
+
+[Orchestration](/learn/deployment/container-orchestration/) can run many replicas — but
+running them only helps if traffic is *spread* across them and the service is *built* to
+be spread. This lesson is the mechanics of both: the two directions you can scale, why
+statelessness is the enabler, and how a load balancer divides the work.
+
+## Scale up or scale out
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="Scaling up shown as one growing box, scaling out shown as several identical boxes behind a load balancer." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+  <text x="80" y="16">scale up</text>
+  <rect x="55" y="26" width="50" height="26" rx="3" fill="none" stroke="currentColor"/>
+  <rect x="45" y="60" width="70" height="52" rx="3" fill="none" stroke="currentColor" stroke-width="1.7"/><text x="80" y="90" font-size="8">bigger box</text>
+  <text x="320" y="16">scale out</text>
+  <rect x="245" y="30" width="150" height="22" rx="3" fill="none" stroke="currentColor"/><text x="320" y="45" font-size="8">load balancer</text>
+  <rect x="245" y="78" width="40" height="30" rx="3" fill="none" stroke="currentColor"/>
+  <rect x="300" y="78" width="40" height="30" rx="3" fill="none" stroke="currentColor"/>
+  <rect x="355" y="78" width="40" height="30" rx="3" fill="none" stroke="currentColor"/>
+  </g>
+  <g stroke="currentColor" fill="none"><line x1="300" y1="52" x2="265" y2="78"/><line x1="320" y1="52" x2="320" y2="78"/><line x1="340" y1="52" x2="375" y2="78"/></g>
+</svg>
+<figcaption>Scaling up grows one machine; scaling out adds identical instances behind a load balancer.</figcaption>
+</figure>
+
+- **Vertical (up)** — give one machine more CPU and memory. Dead simple, no code changes,
+  but capped by the largest machine available, and that one box is a single point of
+  failure. A great *first* move.
+- **Horizontal (out)** — run more copies behind a load balancer. Scales far past any
+  single machine, and losing one instance just means the rest carry on. But it demands a
+  stateless service.
+
+Start by scaling up — it's free of architectural change. Scale out when you hit the
+ceiling of one machine or need to survive an instance dying.
+
+## Statelessness is the enabler
+
+Horizontal scaling works only if **any instance can serve any request**. That's true when
+the instance keeps no important state of its own — the state lives in a shared
+[database](/learn/deployment/backups-and-data/) or cache that all instances read. Then
+the load balancer can send request 1 to instance A and request 2 to instance B and
+nothing breaks.
+
+Put session data in one instance's local memory and you've broken that: a user's next
+request might land on a different instance that's never heard of them. The fix is to push
+state *out* of the instances into a shared store, making the instances interchangeable —
+the same [stateless-vs-stateful](/learn/deployment/backups-and-data/) split that decided
+what to back up.
+
+## The load balancer and its algorithms
+
+A **load balancer** sits in front of the instances (often the same
+[reverse proxy](/learn/deployment/reverse-proxies-and-tls/) you already run) and picks
+which one gets each request. Common algorithms:
+
+| Algorithm | Picks the instance… | Good when |
+|-----------|---------------------|-----------|
+| Round-robin | Next one in rotation | Requests are roughly equal cost |
+| Least-connections | With the fewest active requests | Request durations vary a lot |
+| IP hash | Determined by client IP | You need a client pinned to one instance |
+| Weighted | Proportional to capacity | Instances have different sizes |
+
+An nginx upstream spreading traffic across three instances:
+
+```text
+upstream app {
+    least_conn;                 # send each request to the least-busy instance
+    server 127.0.0.1:8081;
+    server 127.0.0.1:8082;
+    server 127.0.0.1:8083;
+}
+server {
+    location / { proxy_pass http://app; }
+}
+```
+
+The balancer also does **health checking**: an instance that fails its
+[health check](/learn/deployment/logging-and-health-checks/) is pulled from rotation until
+it recovers, so traffic only goes to instances that can serve it.
+
+## Sticky sessions: the escape hatch
+
+Sometimes you can't fully remove per-instance state and need a given client to keep
+hitting the same instance. **Sticky sessions** (session affinity) pin a client to one
+instance, usually via a cookie or IP hash. It's a pragmatic patch, but treat it as a
+smell: it re-introduces the coupling that statelessness removed, weakening both scaling
+and failover. Prefer shared state; use stickiness only when you must.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — stateless instances are interchangeable, so any one can serve any request." markdown="0">
+  <p class="knowledge-check__q">Quick check: what makes horizontal scaling possible?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Giving each instance more CPU and memory</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Stateless instances, so any one can serve any request</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Storing each user's session in one instance's local memory</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Scale up** (bigger machine) is simple but capped and a single point of failure;
+  **scale out** (more copies) goes further and survives failures.
+- Scaling out needs **stateless** services — state pushed to a shared store so instances
+  are interchangeable.
+- A **load balancer** spreads traffic by round-robin, least-connections, and other
+  algorithms, and drops unhealthy instances via health checks.
+- **Sticky sessions** pin a client to one instance — a pragmatic patch, but prefer shared
+  state.
+
+Next up: replacing a running version without dropping a request — zero-downtime deploys.

--- a/docs/learn/deployment/secrets-and-configuration.md
+++ b/docs/learn/deployment/secrets-and-configuration.md
@@ -1,0 +1,111 @@
+---
+slug: secrets-and-configuration
+title: Secrets & configuration management
+description: Keeping API keys and passwords out of images and repositories — environment injection, secret stores, and the difference between configuration and secrets.
+keywords: secrets management, secret store, api keys, environment variables secrets, config vs secrets, do not commit secrets, secret injection, deployment security
+level: intermediate
+status: full
+prereq:
+  - environments-and-config
+faq:
+  - q: What is the difference between configuration and a secret?
+    a: "Configuration is any setting that changes how software behaves — ports, paths, log levels — and is generally safe to store in version control. A secret is configuration that must stay confidential, like an API key, password, or token. Secrets need extra handling: never committed to a repo or baked into an image, and injected only at runtime."
+  - q: Why shouldn't I put secrets in my Docker image or Git repository?
+    a: Anything in an image or a repo is copyable and often widely shared — pushed to registries, cloned by collaborators, kept in history forever. A secret placed there leaks to everyone with access and can't be truly removed from history. Secrets must be supplied separately at runtime so the image and repo stay safe to share.
+---
+
+# Secrets & configuration management
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Configuration** (ports, paths, log levels) is safe to keep in version control;
+**secrets** (API keys, passwords, tokens) are not. Never bake secrets into an **image**
+or commit them to a **repo** — they leak and can't be un-leaked. Instead **inject** them
+at runtime via environment variables, a mounted file, or a **secret store**. GopherTrunk
+supports pulling its API token from a separate file for exactly this reason.
+</div>
+
+Some configuration must stay confidential. This lesson is about handling secrets
+without leaking them — one of the most common and costly deployment mistakes.
+
+## Config vs secrets
+
+Not all settings are equal:
+
+| | Configuration | Secret |
+|--|---------------|--------|
+| Examples | ports, paths, log level, feature flags | API keys, passwords, tokens, certificates |
+| Sensitive? | no | yes |
+| Version control? | yes — track it | **never** |
+| In the image? | fine | **never** |
+
+The line matters because they're handled differently. Ordinary
+[config](/learn/deployment/environments-and-config/) belongs in version control so you
+know what each environment runs. Secrets must be kept *out* of everything that gets
+copied around.
+
+## Why secrets can't live in images or repos
+
+Two places feel convenient and are both traps:
+
+- **In the container image** — images get pushed to
+  [registries](/learn/deployment/images-and-registries/) and pulled by many machines;
+  a secret inside travels to all of them.
+- **In the Git repo** — repositories are cloned, shared, and keep **history forever**.
+  A committed secret is exposed to everyone with access and *stays* in history even
+  after you delete it, so it must be rotated (changed) once leaked.
+
+The [cybersecurity module](/learn/cybersecurity/secrets-management/) covers this failure
+mode in depth; the deployment rule is simple: **secrets are injected at runtime, never
+built in.**
+
+## Injecting secrets safely
+
+Common ways to supply a secret only when the program runs:
+
+- **Environment variables** — set the secret in the environment the process starts in;
+  the app reads it at startup. Convenient and container-friendly.
+- **A mounted secret file** — put the secret in a file with tight permissions and point
+  the app at it. GopherTrunk's systemd unit shows this pattern: an optional
+  `EnvironmentFile` supplies a bearer token, referenced from the config as
+  `api.auth.token_file` — so the token lives in a locked-down file, not in
+  `config.yaml`.
+- **A secret store** — a dedicated service (Docker/Kubernetes secrets, a cloud secrets
+  manager, Vault) that holds secrets encrypted and hands them to authorized services at
+  runtime. This is the scalable answer for larger deployments.
+
+```ini
+# GopherTrunk's systemd unit — keep the token out of config.yaml:
+# EnvironmentFile=-/etc/gophertrunk/env
+```
+
+## A safety net: keep secrets out by default
+
+Two habits prevent most leaks:
+
+- Add secret files to [`.gitignore`](/learn/git/gitignore/) so they can't be committed
+  accidentally.
+- Reference secrets *by path or variable* in your committed config (like
+  `token_file:`), so the config is safe to share while the secret itself stays local.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — secrets are injected at runtime, never baked into images or committed to repos." markdown="0">
+  <p class="knowledge-check__q">Quick check: where should an API key be stored?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Hard-coded in the container image</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Committed to the Git repository for convenience</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Injected at runtime via an environment variable, mounted file, or secret store</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Configuration** is safe to version; **secrets** (keys, passwords, tokens) are not.
+- Never place secrets in an **image** or a **repo** — they leak widely and stay in
+  history.
+- **Inject** secrets at runtime via environment variables, a mounted file, or a
+  **secret store**.
+- GopherTrunk reads its API token from a separate file (`token_file`), keeping it out of
+  `config.yaml`.
+
+Next up: Unit 4 — automating build, test, and release with CI/CD.

--- a/docs/learn/deployment/services-and-systemd.md
+++ b/docs/learn/deployment/services-and-systemd.md
@@ -1,0 +1,127 @@
+---
+slug: services-and-systemd
+title: Services & systemd
+description: Turn a program into a managed service that starts on boot and restarts on failure, using the systemd unit GopherTrunk ships as the worked example.
+keywords: systemd, systemd service, systemd unit, service management, start on boot, restart on failure, systemctl, linux service
+level: intermediate
+status: full
+prereq:
+  - build-artifacts-and-versioning
+faq:
+  - q: What is systemd?
+    a: systemd is the init and service manager on most modern Linux systems. It starts services at boot, restarts them if they crash, manages their dependencies and ordering, and collects their logs. You describe a service in a unit file and control it with systemctl commands like start, stop, enable, and status.
+  - q: How is running under systemd different from just running a binary?
+    a: Running a binary in your terminal stops the moment you log out or the program crashes. A systemd service runs in the background, starts automatically on boot, restarts on failure, logs to the journal, and can be locked down with security settings — everything a long-running production service needs.
+---
+
+# Services & systemd
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A **service** is a program that runs in the background, starts on boot, and restarts if
+it crashes. On Linux, **systemd** manages services: you describe one in a **unit file**
+and control it with **`systemctl`**. GopherTrunk ships a real unit that starts the
+scanner on boot, restarts it on failure, and locks it down with hardening — the
+non-container way to run in production.
+</div>
+
+Containers are one way to run in production; a plain binary managed by **systemd** is
+the other. This lesson turns a binary into a proper service.
+
+## From a binary to a service
+
+Run `./gophertrunk` in your terminal and it dies when you log out or it crashes. A
+production service needs to:
+
+- start automatically **on boot**,
+- **restart** itself if it fails,
+- run in the **background** independent of any login,
+- **log** somewhere you can read later.
+
+On Linux, **systemd** provides all of this. You describe your service once in a **unit
+file** and systemd handles the rest. (The [Linux CLI module](/learn/linux-cli/services-and-systemd/)
+covers systemd basics; here we focus on deploying with it.)
+
+## GopherTrunk's unit file
+
+Here's the heart of the unit GopherTrunk ships:
+
+```ini
+[Unit]
+Description=GopherTrunk digital trunking scanner
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=exec
+ExecStart=/usr/local/bin/gophertrunk run -config /etc/gophertrunk/config.yaml
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Reading it top to bottom:
+
+- **`[Unit]`** — a description and ordering: start *after* the network is online.
+- **`ExecStart`** — the exact command to run, pointing at the installed binary and its
+  [config file](/learn/deployment/environments-and-config/).
+- **`Restart=on-failure`** with **`RestartSec=5`** — if it crashes, wait 5 seconds and
+  restart. This is your crash resilience.
+- **`WantedBy=multi-user.target`** — enable it and it starts on every boot.
+
+## Installing and controlling it
+
+Install the unit and binary, then manage the service with `systemctl`:
+
+```bash
+sudo install -m 0644 docs/gophertrunk.service /etc/systemd/system/gophertrunk.service
+sudo install -m 0755 bin/gophertrunk /usr/local/bin/gophertrunk
+sudo systemctl daemon-reload
+sudo systemctl enable --now gophertrunk   # start now AND on every boot
+sudo systemctl status gophertrunk         # check it's running
+```
+
+`enable --now` is the key line: it starts the service immediately *and* wires it to
+start on boot.
+
+## Locking it down
+
+A production service should run with the least privilege it needs. GopherTrunk's real
+unit adds a raft of **hardening** directives — a taste:
+
+```ini
+DynamicUser=true            # run as an unprivileged, ephemeral user
+ProtectSystem=strict        # the filesystem is read-only except...
+ReadWritePaths=/var/lib/gophertrunk
+NoNewPrivileges=true        # can never gain new privileges
+ProtectKernelModules=true
+RestrictRealtime=true
+```
+
+These tell the kernel to run the scanner in a tightly confined sandbox — it can't write
+outside its data directory, can't escalate privileges, can't touch kernel internals.
+It's the same least-privilege instinct as the container's dropped capabilities, applied
+to a bare-metal service, and it connects directly to the
+[cybersecurity](/learn/cybersecurity/hardening-systems/) module.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — enable --now starts the service now and on every future boot." markdown="0">
+  <p class="knowledge-check__q">Quick check: which systemd setting makes a service restart itself after it crashes?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">WantedBy=multi-user.target</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Restart=on-failure</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Description=</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **service** runs in the background, starts on boot, and restarts on failure.
+- **systemd** manages services via a **unit file**; **`systemctl`** controls them.
+- GopherTrunk's unit sets **`ExecStart`**, **`Restart=on-failure`**, and
+  **`WantedBy=multi-user.target`** — plus **hardening** for least privilege.
+- **`systemctl enable --now`** starts a service immediately and on every boot.
+
+Next up: how a running service tells you it's healthy — logging and health checks.

--- a/docs/learn/deployment/the-deployment-lifecycle.md
+++ b/docs/learn/deployment/the-deployment-lifecycle.md
@@ -1,0 +1,106 @@
+---
+slug: the-deployment-lifecycle
+title: The deployment lifecycle
+description: "Build, test, release, deploy, operate — the repeating loop every change moves through, and how the rest of this module maps onto each stage."
+keywords: deployment lifecycle, build test release deploy operate, software delivery, release cycle, deployment stages, continuous delivery loop
+level: beginner
+status: full
+prereq:
+  - what-is-deployment
+faq:
+  - q: What are the stages of the deployment lifecycle?
+    a: "A common way to name them is build, test, release, deploy, and operate. Build turns source into an artifact, test proves it works, release packages and versions it, deploy puts it where it runs, and operate keeps it healthy and feeds problems back into the next build. It's a loop, not a line — every change goes around it again."
+  - q: Is the deployment lifecycle the same as CI/CD?
+    a: "CI/CD is the automation that runs the build, test, and release stages for you on every change. The lifecycle is the bigger picture — it also includes deploying to a server and operating it in production. CI/CD automates the left-hand stages; you still design the deploy and operate ones."
+---
+
+# The deployment lifecycle
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Shipping software is a repeating **loop**, not a one-off event. A change moves through
+**build** (source to artifact), **test** (prove it works), **release** (package and
+version), **deploy** (put it where it runs), and **operate** (keep it healthy) — then
+what you learn operating feeds the next build. Every lesson in this module lives at one
+of these stages.
+</div>
+
+[What is deployment?](/learn/deployment/what-is-deployment/) framed the problem: getting
+code from your machine to a running service other people use. This lesson gives you the
+map — the five stages a change repeats forever — so the rest of the module has a place
+to hang.
+
+## Why think in a lifecycle at all?
+
+A single deploy feels like a straight line: write code, ship it, done. But real software
+is never done. You fix a bug, add a feature, patch a security hole — and each change
+retraces the same path. Naming that path as a **cycle** does two things: it makes every
+step deliberate instead of ad-hoc, and it makes the **operate** stage feed back into the
+next **build** so you actually learn from production.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 120" role="img" aria-label="A loop of five stages: build, test, release, deploy, operate, with operate feeding back to build." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+  <rect x="8" y="45" width="72" height="30" rx="4" fill="none" stroke="currentColor"/><text x="44" y="64">build</text>
+  <rect x="118" y="45" width="72" height="30" rx="4" fill="none" stroke="currentColor"/><text x="154" y="64">test</text>
+  <rect x="228" y="45" width="72" height="30" rx="4" fill="none" stroke="currentColor"/><text x="264" y="64">release</text>
+  <rect x="338" y="45" width="72" height="30" rx="4" fill="none" stroke="currentColor"/><text x="374" y="64">deploy</text>
+  <rect x="448" y="45" width="64" height="30" rx="4" fill="none" stroke="currentColor" stroke-width="1.7"/><text x="480" y="64">operate</text>
+  </g>
+  <g stroke="currentColor" fill="none"><line x1="80" y1="60" x2="118" y2="60"/><line x1="190" y1="60" x2="228" y2="60"/><line x1="300" y1="60" x2="338" y2="60"/><line x1="410" y1="60" x2="448" y2="60"/>
+  <path d="M480 45 C 480 12, 44 12, 44 45" stroke-dasharray="4 3"/></g>
+  <text x="262" y="20" text-anchor="middle" font-size="8.5" fill="currentColor">what you learn operating feeds the next build</text>
+</svg>
+<figcaption>The loop: each change goes build → test → release → deploy → operate, and operating feeds the next change.</figcaption>
+</figure>
+
+## What happens at each stage?
+
+Each stage has a clear job and a matching lesson later in this module:
+
+| Stage | The job | Where this module covers it |
+|-------|---------|------------------------------|
+| Build | Turn source into a single, reproducible artifact | [Build artifacts & versioning](/learn/deployment/build-artifacts-and-versioning/), [Writing a Dockerfile](/learn/deployment/writing-a-dockerfile/) |
+| Test | Prove the artifact works before anyone relies on it | [CI/CD pipelines](/learn/deployment/ci-cd-pipelines/) |
+| Release | Version, package, and publish it so it can be pulled | [Images & registries](/learn/deployment/images-and-registries/), [Release strategies](/learn/deployment/release-strategies/) |
+| Deploy | Put it where it runs and start it | [Cloud & VPS](/learn/deployment/deploying-to-cloud-and-vps/), [Zero-downtime deploys](/learn/deployment/zero-downtime-deploys/) |
+| Operate | Keep it healthy, watch it, fix it, feed back | [Observability](/learn/deployment/observability/), [Incident response](/learn/deployment/incident-response/) |
+
+## Where does automation fit?
+
+The first three stages — build, test, release — are exactly what a
+[CI/CD pipeline](/learn/deployment/ci-cd-pipelines/) automates. A push or a version tag
+triggers a fresh machine to build the artifact, run the tests, and publish the result,
+identically every time. GopherTrunk does this with GitHub Actions: every pull request is
+built and tested, and a version tag builds and publishes the downloadable release
+binaries. Automating the left of the loop is what makes going around it fast and boring —
+which is what you want.
+
+## Why does operate loop back to build?
+
+The last stage is the one beginners skip. Once a version is live you have to **operate**
+it: read its logs, watch its metrics, respond when it breaks. Everything you learn there
+— a slow endpoint, a crash under load, a confusing config — becomes a bug report or a
+feature request that starts the loop again with a new **build**. A deployment you can't
+observe is a loop with the feedback wire cut; you'll keep shipping the same problems.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — operate feeds what you learn back into the next build, closing the loop." markdown="0">
+  <p class="knowledge-check__q">Quick check: what makes the deployment lifecycle a loop rather than a line?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Every deploy must be undone before the next one</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">What you learn operating a release feeds the next build</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">The stages can run in any order</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Deployment is a repeating **loop**: build, test, release, deploy, operate.
+- **Build** makes an artifact, **test** proves it, **release** versions it, **deploy**
+  runs it, **operate** keeps it healthy.
+- **CI/CD** automates the build-test-release stages so going around the loop is fast.
+- **Operate** feeds what you learn back into the next **build** — that feedback is the
+  point of the loop.
+
+Next up: the environments a build runs in, and keeping config out of code.

--- a/docs/learn/deployment/what-is-a-container.md
+++ b/docs/learn/deployment/what-is-a-container.md
@@ -1,0 +1,113 @@
+---
+slug: what-is-a-container
+title: What is a container?
+description: Containers versus virtual machines, the isolation the kernel provides, and why shipping the whole environment solves the works-on-my-machine problem.
+keywords: what is a container, containers vs vms, docker container, containerization, kernel namespaces, cgroups, isolation, oci image
+level: beginner
+status: full
+prereq:
+  - what-is-deployment
+faq:
+  - q: What is the difference between a container and a virtual machine?
+    a: A virtual machine emulates a whole computer, running its own full operating system on top of a hypervisor — heavy but strongly isolated. A container shares the host's operating-system kernel and just isolates the application's files, processes, and network, making it far lighter and faster to start. For deploying most applications, containers hit the sweet spot.
+  - q: Do containers include an operating system?
+    a: A container image includes the userland files an application needs — libraries, a minimal base like Debian slim, your binary — but not a kernel. It borrows the host's kernel at runtime. That's why images are much smaller than VM disk images and why a container starts in a fraction of a second.
+---
+
+# What is a container?
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A **container** packages an application with everything it needs to run — libraries,
+files, dependencies — and runs it **isolated** on a shared host **kernel**. Unlike a
+**virtual machine**, it doesn't carry a whole operating system, so it's **light and
+fast**. Containers solve "works on my machine" by shipping the *whole environment*, not
+just the code.
+</div>
+
+Unit 1 named the "works on my machine" problem. Containers are the most popular
+solution, and this lesson explains what they actually are.
+
+## Ship the environment, not just the code
+
+The insight behind containers is simple: instead of shipping your program and *hoping*
+the target machine has the right libraries and settings, you ship your program
+**together with** its libraries, dependencies, and environment, bundled into one unit.
+That bundle — a **container** — runs the same on your laptop, a colleague's machine, and
+a cloud server, because it *brings its whole world with it*.
+
+## Containers vs virtual machines
+
+Both isolate software, but at very different weights:
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 170" role="img" aria-label="Left: virtual machines each with a full guest OS on a hypervisor. Right: containers sharing one host OS kernel via a container runtime." xmlns="http://www.w3.org/2000/svg">
+  <text x="130" y="14" text-anchor="middle" font-size="10" fill="currentColor">virtual machines</text>
+  <g font-size="8" fill="currentColor" text-anchor="middle">
+  <rect x="20" y="22" width="100" height="26" fill="none" stroke="currentColor"/><text x="70" y="39">App + Guest OS</text>
+  <rect x="140" y="22" width="100" height="26" fill="none" stroke="currentColor"/><text x="190" y="39">App + Guest OS</text>
+  <rect x="20" y="52" width="220" height="18" fill="none" stroke="currentColor"/><text x="130" y="65">Hypervisor</text>
+  <rect x="20" y="74" width="220" height="16" fill="none" stroke="currentColor"/><text x="130" y="86">Host OS + Hardware</text>
+  </g>
+  <text x="390" y="14" text-anchor="middle" font-size="10" fill="currentColor">containers</text>
+  <g font-size="8" fill="currentColor" text-anchor="middle">
+  <rect x="285" y="22" width="66" height="20" fill="none" stroke="currentColor"/><text x="318" y="35">App</text>
+  <rect x="357" y="22" width="66" height="20" fill="none" stroke="currentColor"/><text x="390" y="35">App</text>
+  <rect x="429" y="22" width="66" height="20" fill="none" stroke="currentColor"/><text x="462" y="35">App</text>
+  <rect x="285" y="46" width="210" height="18" fill="none" stroke="currentColor"/><text x="390" y="59">Container runtime</text>
+  <rect x="285" y="68" width="210" height="22" fill="none" stroke="currentColor" stroke-width="1.6"/><text x="390" y="82">Shared Host OS kernel + Hardware</text>
+  </g>
+</svg>
+<figcaption>VMs each carry a full guest OS; containers share the host kernel — so containers are far lighter and start almost instantly.</figcaption>
+</figure>
+
+| | Virtual machine | Container |
+|--|-----------------|-----------|
+| Contains | a full guest OS | just app + its dependencies |
+| Isolation | very strong (own kernel) | strong (shared kernel) |
+| Size | gigabytes | megabytes |
+| Start time | tens of seconds | fraction of a second |
+
+## How the isolation works
+
+A container shares the host's **kernel** but the kernel gives each container its own
+private view: **namespaces** make it see its own processes, filesystem, and network as
+if it were alone, and **control groups (cgroups)** cap how much CPU and memory it can
+use. So many containers safely coexist on one host without tripping over each other —
+lighter than VMs but still well isolated.
+
+## The vocabulary
+
+Two words you'll use constantly:
+
+- An **image** is the packaged, on-disk bundle — the read-only template (built from a
+  [Dockerfile](/learn/deployment/writing-a-dockerfile/), shared via a
+  [registry](/learn/deployment/images-and-registries/)).
+- A **container** is a *running instance* of an image — like a program is a running
+  instance of an executable.
+
+**Docker** is the best-known tool for building images and running containers, and the
+one we'll use. GopherTrunk ships a Dockerfile so you can run the whole scanner as a
+container — the subject of the next lesson.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a container shares the host kernel, so it's far lighter than a VM." markdown="0">
+  <p class="knowledge-check__q">Quick check: what's the main difference between a container and a virtual machine?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">A container runs faster because it uses less code</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">A container shares the host OS kernel instead of carrying its own full OS</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">A container cannot be isolated from other programs</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **container** bundles an app with its dependencies and runs it **isolated** on a
+  shared host **kernel**.
+- Versus a **VM**, it carries no guest OS — so it's **megabytes**, not gigabytes, and
+  starts almost instantly.
+- The kernel isolates each container with **namespaces** and **cgroups**.
+- An **image** is the template; a **container** is a running instance of it. Docker is
+  the common tool.
+
+Next up: writing the recipe for an image — the Dockerfile.

--- a/docs/learn/deployment/what-is-deployment.md
+++ b/docs/learn/deployment/what-is-deployment.md
@@ -1,0 +1,110 @@
+---
+slug: what-is-deployment
+title: What is deployment?
+description: The journey from source code to a running service, what "it works on my machine" really costs, and the moving parts every deployment has to handle.
+keywords: what is deployment, software deployment, deploy application, works on my machine, deployment basics, ship software, production
+level: beginner
+status: full
+faq:
+  - q: What does deploying software mean?
+    a: Deploying means taking software you've written and getting it running somewhere it can do its job — a server, a cloud host, a small computer at home — reliably and repeatably. It covers building the program, moving it to the target, configuring it for that environment, starting it, and keeping it running.
+  - q: Why is deployment considered hard?
+    a: Because the machine you develop on differs from where the software runs — different libraries, settings, file paths, and secrets. Bridging that gap so the program behaves identically everywhere, survives crashes and reboots, and can be updated safely is a discipline of its own. The tools in this module exist to make that bridge reliable.
+---
+
+# What is deployment?
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Deployment** is getting software from your machine to somewhere it runs reliably for
+real. It has to solve the same moving parts every time — a **build**, its
+**configuration**, a **runtime environment**, **process management**, **networking**,
+**secrets**, and **monitoring**. The whole point is to kill "**it works on my
+machine**" by making the software behave the same everywhere.
+</div>
+
+This is lesson 1 of the deployment path. Writing code is one half of shipping
+software; this module is the other half. By the end of it you'll be able to take a
+program like GopherTrunk and run it as a real service on a server.
+
+## From source to a running service
+
+On your machine, running a program is easy — you built it, the libraries are there,
+the config points at your files. Deployment is doing that *somewhere else*, reliably:
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 90" role="img" aria-label="Flow: source code, build, artifact, configure, run on a server as a service." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+  <rect x="6" y="30" width="70" height="32" rx="4" fill="none" stroke="currentColor"/><text x="41" y="50">source</text>
+  <rect x="100" y="30" width="70" height="32" rx="4" fill="none" stroke="currentColor"/><text x="135" y="50">build</text>
+  <rect x="194" y="30" width="78" height="32" rx="4" fill="none" stroke="currentColor"/><text x="233" y="50">artifact</text>
+  <rect x="296" y="30" width="80" height="32" rx="4" fill="none" stroke="currentColor"/><text x="336" y="50">configure</text>
+  <rect x="400" y="30" width="110" height="32" rx="4" fill="none" stroke="currentColor" stroke-width="1.8"/><text x="455" y="50">run as a service</text>
+  </g>
+  <g stroke="currentColor"><line x1="76" y1="46" x2="100" y2="46"/><line x1="170" y1="46" x2="194" y2="46"/><line x1="272" y1="46" x2="296" y2="46"/><line x1="376" y1="46" x2="400" y2="46"/></g>
+</svg>
+<figcaption>Deployment is this whole pipeline — and this module is a lesson or two on each box.</figcaption>
+</figure>
+
+## The "works on my machine" problem
+
+The classic failure is software that runs perfectly for its author and breaks
+everywhere else. The causes are always the same handful of differences:
+
+- A **library** or tool that's installed on your laptop but not the server.
+- A **setting** or file path hard-coded to your environment.
+- A **secret** (an API key, a password) that lived in your head or your shell.
+- A different **operating system** or version.
+
+Every tool in this module exists to erase one of these differences —
+[containers](/learn/deployment/what-is-a-container/) bundle the libraries,
+[configuration](/learn/deployment/environments-and-config/) externalizes the settings,
+[secret management](/learn/deployment/secrets-and-configuration/) handles the keys.
+
+## The moving parts of any deployment
+
+However you deploy, the same responsibilities show up:
+
+| Concern | The question it answers |
+|---------|-------------------------|
+| Build & artifact | What exactly are we shipping? |
+| Configuration | How does it behave in *this* environment? |
+| Runtime environment | What does it need installed to run? |
+| Process management | Who starts it, and restarts it if it crashes? |
+| Networking | How do users and other services reach it? |
+| Secrets | Where do passwords and keys come from safely? |
+| Monitoring | How do we know it's healthy? |
+
+Each has a lesson (or a few) in this module. GopherTrunk touches all of them: it's a
+long-running daemon that talks to USB radio hardware, serves a web API, records to
+disk, and must survive reboots — a realistic, complete example we'll use throughout,
+finishing with a full [end-to-end deploy](/learn/deployment/deploying-gophertrunk/).
+
+## Why get good at this
+
+Software that only runs on your laptop helps no one. The ability to reliably ship and
+operate what you build is what turns a project into a *product* — and it's a skill that
+transfers to every language and stack. Pair it with the
+[Linux command line](/learn/linux-cli/) and [Git](/learn/git/) modules and you have the
+full toolkit.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — deployment is about running software reliably somewhere other than your own machine." markdown="0">
+  <p class="knowledge-check__q">Quick check: what problem is most deployment tooling designed to solve?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Writing the code faster</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Making software behave the same everywhere, not just on the author's machine</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Reducing the number of features</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Deployment** is getting software running reliably somewhere other than your machine.
+- The enemy is "**it works on my machine**" — caused by library, config, secret, and OS
+  differences.
+- Every deployment handles the same **moving parts**: build, config, runtime, process
+  management, networking, secrets, monitoring.
+- GopherTrunk is the worked example we build toward deploying end to end.
+
+Next up: environments and configuration — running one build in many places.

--- a/docs/learn/deployment/writing-a-dockerfile.md
+++ b/docs/learn/deployment/writing-a-dockerfile.md
@@ -1,0 +1,128 @@
+---
+slug: writing-a-dockerfile
+title: Writing a Dockerfile
+description: Build a container image step by step — base images, layers, and multi-stage builds — using GopherTrunk's real Dockerfile that turns Go source into a small runtime image.
+keywords: dockerfile, docker build, base image, image layers, multi-stage build, docker from, dockerfile example, go docker
+level: intermediate
+status: full
+prereq:
+  - what-is-a-container
+faq:
+  - q: What is a multi-stage Docker build?
+    a: A multi-stage build uses one stage to compile your software (with all the heavy build tools) and a second, clean stage that copies out only the finished binary. The final image contains just what's needed to run — not the compiler or source — so it's much smaller and has less to attack or maintain.
+  - q: What are image layers?
+    a: Each instruction in a Dockerfile creates a layer — a saved filesystem change stacked on the previous one. Docker caches layers, so if nothing above a layer changed, it's reused instead of rebuilt. Ordering your Dockerfile so rarely-changing steps come first (like downloading dependencies) makes rebuilds much faster.
+---
+
+# Writing a Dockerfile
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A **Dockerfile** is the recipe for a container image: a **base image** to start from,
+then instructions that each add a cached **layer**. A **multi-stage build** compiles in
+one stage and copies only the finished binary into a small final image. GopherTrunk's
+real Dockerfile does exactly this — Go source in, a slim runtime image out.
+</div>
+
+An image doesn't appear by magic — you write a **Dockerfile** describing how to build
+it. This lesson walks through one, using GopherTrunk's actual file.
+
+## The idea: a recipe of layers
+
+A Dockerfile is a list of instructions, top to bottom. Each one — `FROM`, `COPY`, `RUN`
+— produces a **layer**, a saved filesystem change stacked on the one before. Docker
+caches layers, so an unchanged step is reused on the next build. That's why you put the
+slowest, least-changing steps (like downloading dependencies) *early*: change your code
+and only the layers below the copy rebuild.
+
+## GopherTrunk's Dockerfile, stage one
+
+GopherTrunk uses a **multi-stage** build. The first stage compiles the Go binary:
+
+```dockerfile
+FROM golang:1.25-bookworm AS builder
+WORKDIR /src
+
+# Cache deps before copying the rest of the source.
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+ARG VERSION=docker
+ENV CGO_ENABLED=0
+RUN go build -trimpath \
+        -ldflags "-s -w -X github.com/MattCheramie/GopherTrunk/internal/version.Version=${VERSION}" \
+        -o /out/gophertrunk ./cmd/gophertrunk
+```
+
+Notice the deliberate ordering: `go.mod`/`go.sum` are copied and dependencies
+downloaded *before* the full source, so editing code doesn't invalidate the cached
+dependency layer. `CGO_ENABLED=0` produces a [pure-Go static binary](/learn/programming-go/hello-go/),
+and the `-ldflags -X` stamps in the [version](/learn/deployment/build-artifacts-and-versioning/).
+
+## Stage two: a small runtime image
+
+The second stage starts fresh from a *slim* base and copies in only the finished
+binary — none of the Go compiler or source comes along:
+
+```dockerfile
+FROM debian:bookworm-slim AS runtime
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+# Non-root user for safety.
+RUN useradd --system --create-home --shell /usr/sbin/nologin gopher
+USER gopher
+WORKDIR /home/gopher
+
+COPY --from=builder /out/gophertrunk /usr/local/bin/gophertrunk
+
+EXPOSE 8080 50051
+ENTRYPOINT ["/usr/local/bin/gophertrunk"]
+CMD ["run", "-config", "/etc/gophertrunk/config.yaml"]
+```
+
+Three good practices are visible here:
+
+- **`COPY --from=builder`** pulls just the binary out of the build stage — the final
+  image is tiny and contains no toolchain to attack.
+- **`USER gopher`** runs the app as a non-root user, a security default worth copying
+  (see [secure deployment](/learn/deployment/secrets-and-configuration/)).
+- **`EXPOSE`**, **`ENTRYPOINT`**, and **`CMD`** document the ports and set what runs
+  when the container starts.
+
+## Building it
+
+With the Dockerfile in place, one command builds the image:
+
+```bash
+docker build -t gophertrunk:dev .
+```
+
+Docker runs each instruction, caching layers as it goes, and tags the result
+`gophertrunk:dev`. That image is now a portable artifact you can run anywhere Docker
+runs — and share through a [registry](/learn/deployment/images-and-registries/), the
+next lesson.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a multi-stage build keeps only the finished binary, leaving the toolchain behind." markdown="0">
+  <p class="knowledge-check__q">Quick check: why does GopherTrunk's Dockerfile use two stages?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">To build the image twice for reliability</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">To compile in one stage but ship only the small binary in the final image</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Because Go requires two Dockerfiles</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **Dockerfile** is a recipe of instructions, each producing a cached **layer**.
+- Order steps so **slow, stable ones come first** (dependencies before source) for fast
+  rebuilds.
+- A **multi-stage build** compiles in a builder stage and copies only the **binary**
+  into a slim final image.
+- Run apps as a **non-root user**; `docker build -t name .` produces the image.
+
+Next up: naming, storing, and sharing images through registries.

--- a/docs/learn/deployment/zero-downtime-deploys.md
+++ b/docs/learn/deployment/zero-downtime-deploys.md
@@ -1,0 +1,124 @@
+---
+slug: zero-downtime-deploys
+title: Zero-downtime deploys
+description: "Health-gated rollouts, draining connections, and rollback — how to replace a running version without dropping a single request."
+keywords: zero downtime deployment, connection draining, graceful shutdown, health gated rollout, rollback, rolling update, blue-green, no downtime deploy
+level: advanced
+status: full
+prereq:
+  - scaling-and-load-balancing
+faq:
+  - q: How do you deploy without downtime?
+    a: "Bring the new version up alongside the old, wait until it reports healthy before sending it traffic, then drain the old version — let its in-flight requests finish while the load balancer stops sending it new ones — and only then stop it. Rolling and blue-green strategies both do this. On a single instance you can't fully avoid a gap, but a fast graceful restart keeps it to a moment."
+  - q: What is connection draining?
+    a: "Draining means telling the load balancer to stop sending an instance new requests while letting the requests it's already handling finish. Without draining, stopping an old instance kills its in-flight requests and users see errors. With draining, the old instance quietly finishes its work and then exits cleanly, so no request is dropped during the swap."
+---
+
+# Zero-downtime deploys
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Replacing a running version without dropping requests has three moving parts: bring the
+new version up and **gate it on a health check** before it takes traffic; **drain**
+connections from the old version so its in-flight requests finish; and keep the ability
+to **roll back** instantly if the new version misbehaves. Multi-instance setups do this
+seamlessly; a single instance uses a brief graceful restart.
+</div>
+
+[Release strategies](/learn/deployment/release-strategies/) named the patterns — rolling,
+blue-green, canary. This lesson is the *mechanics* that make any of them lose zero
+requests: health gating, draining, and rollback. They lean directly on the
+[health checks](/learn/deployment/logging-and-health-checks/) and
+[load balancer](/learn/deployment/scaling-and-load-balancing/) you already have.
+
+## Gate the rollout on health
+
+The cardinal rule: **never send traffic to a version that hasn't proven it's ready.** A
+new instance starts, but it might still be loading config, opening its database, or
+warming caches. So the [load balancer](/learn/deployment/scaling-and-load-balancing/)
+waits until the instance passes its [health check](/learn/deployment/logging-and-health-checks/)
+— GopherTrunk exposes exactly this endpoint — before routing anything to it:
+
+```bash
+# poll the new instance until it's healthy, then it joins rotation
+until curl -fsS http://127.0.0.1:8081/api/v1/health >/dev/null; do sleep 1; done
+echo "new instance healthy — adding to the load balancer"
+```
+
+If the new version never goes healthy, it never gets traffic, and users stay on the good
+old version. The health check is the gate that makes a rollout safe.
+
+## Drain the old version
+
+Once the new version is serving, retire the old one *gracefully*. **Draining** tells the
+load balancer to stop sending the old instance new requests while letting its current
+ones finish. The app cooperates by handling the shutdown signal — finishing in-flight
+work before exiting rather than dying mid-request:
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 470 96" role="img" aria-label="Three phases: load balancer sends to old and new, then stops new requests to old while it finishes in-flight ones, then old exits." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="8" fill="currentColor" text-anchor="middle">
+  <text x="78" y="14">1. both serve</text>
+  <rect x="40" y="24" width="76" height="24" rx="3" fill="none" stroke="currentColor"/><text x="78" y="39">old + new</text>
+  <text x="235" y="14">2. drain old</text>
+  <rect x="190" y="24" width="90" height="24" rx="3" fill="none" stroke="currentColor" stroke-dasharray="4 3"/><text x="235" y="35">old finishes</text><text x="235" y="45" font-size="7">in-flight only</text>
+  <text x="400" y="14">3. old exits</text>
+  <rect x="360" y="24" width="80" height="24" rx="3" fill="none" stroke="currentColor" stroke-width="1.7"/><text x="400" y="39">new only</text>
+  </g>
+  <g stroke="currentColor" fill="none"><line x1="116" y1="36" x2="190" y2="36"/><line x1="280" y1="36" x2="360" y2="36"/></g>
+</svg>
+<figcaption>Draining lets the old version finish its in-flight requests before it stops, so nothing is dropped.</figcaption>
+</figure>
+
+A well-behaved server catches `SIGTERM`, stops accepting new connections, finishes what's
+in flight, then exits — "graceful shutdown." Orchestrators and load balancers give it a
+grace period to do so.
+
+## Always be able to roll back
+
+Even a health-gated, drained rollout can ship a subtle bug that only shows under real
+traffic. So keep the previous [versioned artifact](/learn/deployment/build-artifacts-and-versioning/)
+one command away:
+
+```bash
+# roll straight back to the known-good version
+docker compose pull && docker tag ghcr.io/example/app:1.4.1 ghcr.io/example/app:current
+docker compose up -d              # recreate on the previous image
+```
+
+This is why you version and keep images — rollback is just deploying the *last* good one.
+[Blue-green](/learn/deployment/release-strategies/) makes rollback instant (flip back to
+blue); rolling makes it a reverse rollout. Either way, "how do I undo this?" must have an
+answer *before* you deploy.
+
+## The single-instance reality
+
+All of the above assumes multiple instances. One GopherTrunk instance bound to one USB
+radio can't run two copies of itself — the radio is a single physical resource. So the
+honest answer for a single instance is a **brief graceful restart**: `docker compose up -d`
+recreates the container on the new image, and `systemctl restart` does the same for the
+systemd unit, each a moment's gap while the process swaps. That's a perfectly fine
+tradeoff for a single-user scanner — [recreate](/learn/deployment/release-strategies/)
+with a short, honest downtime beats pretending you have a fleet you don't.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — draining lets in-flight requests finish before the old instance stops, dropping none." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does connection draining accomplish during a deploy?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It speeds up the new version's startup</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">It lets the old instance finish in-flight requests before it stops, dropping none</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It encrypts traffic between instances</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Gate** the rollout on a [health check](/learn/deployment/logging-and-health-checks/) —
+  no traffic until the new version proves it's ready.
+- **Drain** the old version: stop new requests to it, let in-flight ones finish, then
+  exit gracefully on `SIGTERM`.
+- Keep **rollback** one command away by versioning and retaining images.
+- A **single instance** can't be truly zero-downtime; a fast graceful restart (`compose
+  up -d`, `systemctl restart`) is the honest, fine choice.
+
+Next up: keeping a deployment healthy over time — monitoring and updates.

--- a/docs/learn/dsp/carrier-and-frequency-recovery.md
+++ b/docs/learn/dsp/carrier-and-frequency-recovery.md
@@ -1,0 +1,122 @@
+---
+slug: carrier-and-frequency-recovery
+title: Carrier & frequency recovery
+description: Correcting the frequency and phase offset between transmitter and receiver — the PLL and Costas loop that lock a carrier before symbols can be read.
+keywords: carrier recovery, frequency recovery, phase offset, pll, costas loop, frequency offset correction, carrier sync, phase locked loop
+level: advanced
+status: full
+prereq:
+  - demodulation
+  - complex-signals-and-iq
+faq:
+  - q: Why is there a frequency offset between transmitter and receiver?
+    a: "The transmitter and receiver each derive their frequencies from independent crystal oscillators, and no two crystals are exactly on frequency — they differ by a few parts per million and drift with temperature. That small mismatch means the received signal arrives slightly off the tuned centre, and its phase constellation slowly rotates until a recovery loop corrects it."
+  - q: What is the difference between a PLL and a Costas loop?
+    a: "A plain phase-locked loop locks onto a signal that has an actual carrier tone present. A Costas loop is a variant designed for suppressed-carrier signals like PSK, where the modulation itself removes any steady carrier. It compares the in-phase and quadrature components to derive a phase error even though there is no discrete carrier to lock to directly."
+---
+
+# Carrier & frequency recovery
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Transmitter and receiver run on **independent oscillators**, so the signal arrives with a
+**frequency** and **phase** offset — the [constellation](/learn/dsp/constellations-and-symbol-mapping/)
+slowly **spins**. A **phase-locked loop (PLL)** measures that error and drives a local
+oscillator to cancel it. For **suppressed-carrier** PSK, where the modulation hides the
+carrier, a **Costas loop** derives the error from I and Q. Only once the carrier is locked
+can symbols be read reliably.
+</div>
+
+[Clock recovery](/learn/dsp/clock-and-symbol-recovery/) found *when* to sample; this
+lesson finds the *frequency and phase* the sampled points are referenced to. Both loops
+must lock before a decoder can trust its symbols. It builds on
+[demodulation](/learn/dsp/demodulation/) and [I/Q](/learn/dsp/complex-signals-and-iq/).
+
+## The offset problem
+
+Your receiver tuned to 851.0125 MHz, but its crystal and the transmitter's disagree by a
+few parts per million. The consequence at baseband: the signal is not sitting exactly at
+zero, and its phase reference is unknown. On the I/Q plane the whole
+[constellation](/learn/dsp/constellations-and-symbol-mapping/) **rotates** — a frequency
+offset makes it spin continuously, a phase offset holds it at a fixed wrong angle. Sample
+a spinning constellation and every symbol decision is garbage.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 150" role="img" aria-label="Left, four constellation points rotated off the axes by a frequency offset with a curved arrow showing spin; right, the same four points snapped onto the axes after carrier lock." xmlns="http://www.w3.org/2000/svg">
+  <g>
+    <line x1="20" y1="75" x2="200" y2="75" stroke="currentColor" stroke-opacity="0.3"/>
+    <line x1="110" y1="15" x2="110" y2="135" stroke="currentColor" stroke-opacity="0.3"/>
+    <circle cx="150" cy="45" r="4" fill="currentColor"/><circle cx="65" cy="40" r="4" fill="currentColor"/>
+    <circle cx="70" cy="110" r="4" fill="currentColor"/><circle cx="155" cy="105" r="4" fill="currentColor"/>
+    <path d="M175 60 A 35 35 0 0 1 150 90" fill="none" stroke="currentColor" stroke-opacity="0.7"/>
+    <text x="110" y="148" text-anchor="middle" font-size="9" fill="currentColor">offset: spinning</text>
+  </g>
+  <text x="255" y="79" text-anchor="middle" font-size="15" fill="currentColor">&#8594;</text>
+  <text x="255" y="60" text-anchor="middle" font-size="8" fill="currentColor">lock</text>
+  <g>
+    <line x1="310" y1="75" x2="500" y2="75" stroke="currentColor" stroke-opacity="0.3"/>
+    <line x1="405" y1="15" x2="405" y2="135" stroke="currentColor" stroke-opacity="0.3"/>
+    <circle cx="445" cy="40" r="4" fill="currentColor"/><circle cx="365" cy="40" r="4" fill="currentColor"/>
+    <circle cx="365" cy="110" r="4" fill="currentColor"/><circle cx="445" cy="110" r="4" fill="currentColor"/>
+    <text x="405" y="148" text-anchor="middle" font-size="9" fill="currentColor">locked: fixed</text>
+  </g>
+</svg>
+<figcaption>A frequency offset spins the constellation; carrier recovery cancels it so the points sit still where the decision logic expects them.</figcaption>
+</figure>
+
+## The phase-locked loop
+
+The workhorse is a **PLL**. It is a feedback loop with three parts:
+
+```text
+  incoming phase ->[ phase detector ]-> error ->[ loop filter ]->[ NCO ]-.
+                          ^                                              |
+                          '----------- corrected phase -----------------'
+```
+
+1. A **phase detector** compares the incoming phase to the local oscillator's phase.
+2. A **loop filter** smooths that error (setting how fast and how steadily it tracks).
+3. A **numerically controlled oscillator (NCO)** adjusts the local phase/frequency to
+   drive the error toward zero.
+
+Lock achieved, the NCO now matches the incoming carrier, and multiplying the signal by
+its conjugate de-rotates the constellation to a standstill.
+
+## Costas loops for suppressed carriers
+
+PSK and QAM are **suppressed-carrier**: the modulation is symmetric, so averaged over
+time there is no steady carrier tone for a plain PLL to grab. A **Costas loop** solves
+this by building the phase error from the *data* itself — it multiplies the in-phase and
+quadrature arms in a way that yields a usable error signal regardless of which symbol was
+sent. It is a PLL specialised for carrying no carrier, and it is what locks the phase of
+the PSK-family signals a digital scanner decodes.
+
+## Ordering with clock recovery
+
+Carrier and [clock recovery](/learn/dsp/clock-and-symbol-recovery/) are cooperating loops:
+timing recovery decides *when* to sample, carrier recovery decides the *phase reference*
+for those samples. Real receivers run them together, sometimes interacting, and only when
+**both** are locked does a clean, stationary constellation appear — ready for the
+[symbol decisions](/learn/dsp/constellations-and-symbol-mapping/) that follow. A stubborn
+frequency offset is a classic cause of a signal that shows energy but never decodes, a
+symptom the [troubleshooting](/learn/digital-trunking/troubleshooting-a-decode/) guide
+returns to.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a Costas loop recovers phase for suppressed-carrier signals like PSK." markdown="0">
+  <p class="knowledge-check__q">Quick check: which loop is designed for suppressed-carrier PSK, where no steady carrier tone exists?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">An anti-aliasing filter</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">A Costas loop</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">A decimator</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Independent oscillators leave a **frequency/phase offset** that **spins** the constellation.
+- A **PLL** — phase detector, loop filter, NCO — measures and cancels the offset.
+- **Suppressed-carrier** PSK needs a **Costas loop**, which derives phase error from I and Q.
+- Carrier recovery and **clock recovery** must both lock before symbols read cleanly.
+
+Next up: keeping the signal at a usable amplitude as it fades — gain and automatic gain control.

--- a/docs/learn/dsp/clock-and-symbol-recovery.md
+++ b/docs/learn/dsp/clock-and-symbol-recovery.md
@@ -1,0 +1,104 @@
+---
+slug: clock-and-symbol-recovery
+title: Clock & symbol recovery
+description: Finding where each symbol begins when the receiver has no shared clock — timing error detectors, interpolation, and the loop that locks onto the data rate.
+keywords: clock recovery, symbol recovery, timing recovery, symbol synchronization, gardner detector, timing error, matched filter, dsp clock recovery
+level: advanced
+status: full
+prereq:
+  - demodulation
+faq:
+  - q: Why does a receiver need clock recovery?
+    a: The transmitter sends symbols at a precise rate, but the receiver doesn't share its clock and samples on its own slightly different clock. Without correction, the receiver would read symbols at the wrong instants and drift out of step. Clock recovery continuously estimates the correct sampling instant so the decoder reads each symbol at its centre.
+  - q: What is a matched filter in this context?
+    a: A matched filter is shaped to match the transmitted pulse, and running the signal through it maximizes the signal-to-noise ratio at the symbol centres while suppressing inter-symbol interference. It's applied just before symbol decisions so each symbol is as clean and distinct as possible when the decoder samples it.
+---
+
+# Clock & symbol recovery
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+The transmitter sends symbols on a clock the receiver doesn't share, so the receiver
+must **recover** the timing — figure out where each symbol begins and sample it at its
+**centre**. A **timing error detector** measures how early or late the current guess
+is, and a feedback **loop** nudges the sampling instant until it **locks**. A
+**matched filter** first sharpens each symbol. This is what turns a demodulated wave
+into clean bits.
+</div>
+
+The demodulator gives you a wiggling signal that steps between symbol levels — but
+*when* is each symbol? Without the transmitter's clock, you have to find out. This
+lesson is that puzzle and its solution.
+
+## The problem: no shared clock
+
+The transmitter emits, say, 4800 symbols a second on its own crystal. Your receiver
+samples on a *different* crystal, a little fast or slow, and started at an arbitrary
+moment. If you just read a symbol every so-many samples, you'll gradually drift — and
+soon be sampling on the blurry transitions *between* symbols instead of their clean
+centres, where decisions go wrong.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 120" role="img" aria-label="A symbol waveform with two sets of sampling instants: some landing at the centres of symbols (good) and some landing on the transitions between them (bad)." xmlns="http://www.w3.org/2000/svg">
+  <path d="M20 80 H80 V40 H140 V90 H200 V50 H260 V80 H320 V40 H380 V90 H440" fill="none" stroke="currentColor" stroke-width="1.5" stroke-opacity="0.7"/>
+  <g fill="currentColor"><circle cx="50" cy="80" r="4"/><circle cx="110" cy="40" r="4"/><circle cx="170" cy="90" r="4"/><circle cx="230" cy="50" r="4"/></g>
+  <text x="130" y="18" text-anchor="middle" font-size="9" fill="currentColor">sampling at centres = good</text>
+  <g fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="80" cy="62" r="4"/><circle cx="140" cy="65" r="4"/><circle cx="200" cy="70" r="4"/></g>
+  <text x="360" y="18" text-anchor="middle" font-size="9" fill="currentColor">on transitions = errors</text>
+</svg>
+<figcaption>Read a symbol at its centre (filled dots) and the level is clear; read it on a transition (open dots) and the decision is ambiguous. Clock recovery keeps you on the centres.</figcaption>
+</figure>
+
+## The solution: measure the error, correct it
+
+Clock recovery is a feedback **loop**, much like the tuning loops elsewhere in DSP:
+
+1. **Guess** the symbol timing and sample there.
+2. A **timing error detector** looks at the samples around the guess and estimates
+   whether you're sampling *early* or *late*. (A classic one, the Gardner detector,
+   uses the sample halfway between two symbols — it's near zero only when timing is
+   right.)
+3. A **loop filter** smooths that error estimate and nudges the sampling instant.
+4. Repeat every symbol. Once the error settles near zero, the loop has **locked** onto
+   the transmitter's rate and tracks its drift automatically.
+
+## Interpolation: sampling between samples
+
+The correct symbol centre rarely lands exactly on one of your samples — it might be
+"37% of the way between sample 5 and sample 6." So the loop uses an **interpolator** (a
+small filter) to compute the signal's value at that fractional position. This is what
+lets timing recovery be smooth and precise rather than jumping a whole sample at a time.
+
+## The matched filter
+
+Just before the decision, the signal usually passes through a **matched filter** shaped
+to the transmitted pulse. It maximizes the signal-to-noise ratio right at the symbol
+centres and suppresses smearing between neighbouring symbols (inter-symbol
+interference), so each symbol is as crisp as possible when sampled. GopherTrunk sizes
+this matched filter and the recovery loop from the **channel rate** set by the
+[downconverter](/learn/dsp/mixing-and-downconversion/) — which is why its decoder
+behaves the same regardless of the original capture rate. The RF path's
+[clock recovery](/learn/rf-sdr/clock-recovery/) lesson covers the same loop from the
+receiver's view.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — clock recovery keeps you sampling at symbol centres despite having no shared clock." markdown="0">
+  <p class="knowledge-check__q">Quick check: why does a receiver need clock/symbol recovery?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">To increase the sample rate</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">It has no shared clock, so it must find where each symbol begins</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">To remove DC offset</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- The receiver has **no shared clock**, so it must **recover** symbol timing or drift
+  off the centres.
+- A **timing error detector** measures early/late; a **loop** corrects until it
+  **locks** and tracks drift.
+- An **interpolator** samples between samples for precise, fractional timing.
+- A **matched filter** sharpens each symbol first; GopherTrunk sizes it from the
+  channel rate.
+
+Next up: keeping the signal at a usable level as it fades — gain and AGC.

--- a/docs/learn/dsp/complex-signals-and-iq.md
+++ b/docs/learn/dsp/complex-signals-and-iq.md
@@ -1,0 +1,110 @@
+---
+slug: complex-signals-and-iq
+title: Complex signals & I/Q
+description: Why SDRs represent signals as complex I/Q pairs, what the imaginary part really means, and how negative frequency becomes a useful, everyday idea.
+keywords: iq data, i/q samples, complex signal, in-phase quadrature, negative frequency, complex baseband, analytic signal, dsp iq
+level: intermediate
+status: full
+prereq:
+  - sampling-and-quantization
+faq:
+  - q: Why does an SDR give me two numbers per sample instead of one?
+    a: The two numbers are the in-phase (I) and quadrature (Q) components — together they form one complex sample. Two numbers capture both the amplitude and the phase of the signal at that instant, which a single real number can't. This lets the radio tell a frequency above the tuned centre from one below it, something a single stream cannot do.
+  - q: What is negative frequency, physically?
+    a: With complex I/Q samples, frequency is measured relative to the tuned centre frequency. A component below the centre shows up as a negative frequency, one above as positive. It's not mystical — it just means "which side of centre, and how the phase rotates." The imaginary axis is what lets the two sides be told apart.
+---
+
+# Complex signals & I/Q
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+An SDR delivers **two numbers per sample** — **I** (in-phase) and **Q**
+(quadrature) — which together form one **complex** sample carrying both **amplitude
+and phase**. This is what lets a receiver distinguish a signal **above** the tuned
+frequency from one **below** it (positive vs **negative frequency**). I/Q is the
+native language of software radio.
+</div>
+
+Open a raw SDR capture and you'll find pairs of numbers, not single values. This
+lesson explains why — and why "complex" here means *useful*, not *complicated*.
+
+## Two numbers, one sample
+
+A single real number can tell you a wave's height right now, but not which way its
+phase is turning. SDRs solve this by recording two measurements 90° apart:
+
+- **I — in-phase**: the signal multiplied by a cosine.
+- **Q — quadrature**: the signal multiplied by a sine (a quarter-cycle offset).
+
+Treat the pair as a point on a plane — I across, Q up — and each sample becomes a
+little arrow (a **complex number**). Its **length** is the signal's amplitude; the
+**angle** is its phase; how fast the angle rotates from sample to sample is its
+frequency.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 260 160" role="img" aria-label="An I/Q plane with horizontal I axis and vertical Q axis, and an arrow from the origin whose length is amplitude and angle is phase." xmlns="http://www.w3.org/2000/svg">
+  <line x1="20" y1="80" x2="240" y2="80" stroke="currentColor" stroke-opacity="0.4"/>
+  <line x1="130" y1="10" x2="130" y2="150" stroke="currentColor" stroke-opacity="0.4"/>
+  <text x="232" y="74" font-size="11" fill="currentColor">I</text>
+  <text x="136" y="20" font-size="11" fill="currentColor">Q</text>
+  <line x1="130" y1="80" x2="200" y2="35" stroke="currentColor" stroke-width="2"/>
+  <path d="M170 80 A 40 40 0 0 0 183 57" fill="none" stroke="currentColor" stroke-width="1" stroke-opacity="0.7"/>
+  <text x="176" y="72" font-size="10" fill="currentColor">phase</text>
+  <text x="150" y="50" font-size="10" fill="currentColor">amplitude</text>
+</svg>
+<figcaption>An I/Q sample is an arrow on the complex plane: length = amplitude, angle = phase. A rotating arrow is a frequency.</figcaption>
+</figure>
+
+## Why single numbers aren't enough
+
+Imagine tuning your radio to 851.000 MHz. A signal at 851.010 MHz and one at
+850.990 MHz are both 10 kHz away from centre. With a single real number stream, they
+look *identical* — you can't tell which side of centre a signal is on. With I/Q, the
+first makes the arrow rotate one way and the second the other way. That difference is
+what we call **positive** versus **negative frequency**: not a strange idea, just
+"which side of the tuned centre."
+
+## Complex baseband
+
+Because I/Q measures everything relative to the tuned frequency, the signal is said
+to be at **complex baseband** — centred on zero, with real signals spread on both
+the positive and negative sides. Every operation later in this path —
+[mixing](/learn/dsp/mixing-and-downconversion/) to retune,
+[filtering](/learn/dsp/fir-filters/) to isolate a channel, the
+[FFT](/learn/dsp/the-fft/) to see the spectrum — is arithmetic on these complex
+samples. GopherTrunk carries them as Go `complex64` values, a pair of 32-bit floats,
+all the way down its pipeline.
+
+The RF path's [I/Q data](/learn/rf-sdr/iq-data/) lesson introduces the same idea from
+the radio side; here we care that each sample is one complex number the math treats
+as a whole.
+
+## Reading a raw capture
+
+A raw SDR file is just these pairs, interleaved: I, Q, I, Q, … If it's 8-bit, that's
+two bytes per sample. Knowing this, you can see why a few seconds of capture at
+2.4 MS/s is a large file — and why [decimating](/learn/dsp/decimation-and-resampling/)
+to a narrow channel rate as early as possible keeps the rest of the pipeline fast.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the I/Q pair encodes phase, so the receiver can tell the two sides of centre apart." markdown="0">
+  <p class="knowledge-check__q">Quick check: what can a complex I/Q stream do that a single real stream cannot?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Sample twice as fast</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Distinguish a frequency above the tuned centre from one below it</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Eliminate quantization noise</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- SDRs give **two numbers per sample** — **I** and **Q** — forming one **complex**
+  sample.
+- The pair encodes **amplitude (length)** and **phase (angle)**; a rotating arrow is
+  a frequency.
+- I/Q lets the receiver tell **positive** from **negative** frequency — which side of
+  centre a signal sits.
+- Everything downstream is arithmetic on these **complex baseband** samples
+  (`complex64` in GopherTrunk).
+
+Next up: the single most useful way to look at a signal — the frequency domain.

--- a/docs/learn/dsp/constellations-and-symbol-mapping.md
+++ b/docs/learn/dsp/constellations-and-symbol-mapping.md
@@ -1,0 +1,126 @@
+---
+slug: constellations-and-symbol-mapping
+title: Constellations & symbol mapping
+description: Reading digital modulation as points on the I/Q plane — how PSK and QAM map bits to symbols, why Gray coding matters, and what a constellation diagram tells you.
+keywords: constellation diagram, symbol mapping, psk, qpsk, qam, gray coding, iq plane symbols, bits to symbols, digital modulation constellation
+level: intermediate
+status: full
+prereq:
+  - complex-signals-and-iq
+  - demodulation
+faq:
+  - q: What is a constellation diagram?
+    a: "A constellation diagram is a scatter plot of received symbols on the I/Q plane. Each modulation scheme defines a set of ideal points — the constellation — and every received symbol lands near one of them. Tight clusters right on the ideal points mean a clean signal; a fuzzy, spread-out cloud means noise, and a rotated or warped pattern points to a specific impairment."
+  - q: Why is Gray coding used to map bits to symbols?
+    a: "Gray coding arranges the bit patterns so that adjacent constellation points differ by only a single bit. When noise nudges a symbol into a neighbouring point — the most common kind of error — only one bit flips instead of several. That keeps the bit error rate low for a given symbol error rate, which is why almost every real system uses it."
+---
+
+# Constellations & symbol mapping
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A **constellation** is the set of ideal points a modulation uses on the
+[I/Q plane](/learn/dsp/complex-signals-and-iq/). **PSK** places points around a circle
+(varying phase); **QAM** fills a grid (varying phase *and* amplitude). Each point encodes
+a group of bits; **Gray coding** ensures neighbours differ by one bit so a slip costs one
+error. Plotting received symbols against the ideal points — the **constellation diagram**
+— is the fastest read on link health.
+</div>
+
+[Demodulation](/learn/dsp/demodulation/) turned I/Q into symbols; this lesson is the map
+from those symbols to *bits*, and the picture that shows how well it's working. It
+connects to the RF path's [digital modulation](/learn/rf-sdr/digital-modulation/) lesson.
+
+## Symbols as points on a plane
+
+Each symbol period, the transmitter sends one point from a fixed set. Because a baseband
+sample is a complex I/Q value, that point has a position on the plane — a phase (angle)
+and amplitude (radius). The receiver, once [carrier-locked](/learn/dsp/carrier-and-frequency-recovery/),
+reads the incoming point and decides which ideal point it is nearest. That decision is the
+symbol; a lookup turns the symbol into its bits.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 170" role="img" aria-label="Three constellations: BPSK with two points on the I axis, QPSK with four points, and 16-QAM as a four-by-four grid of points." xmlns="http://www.w3.org/2000/svg">
+  <g>
+    <line x1="15" y1="85" x2="145" y2="85" stroke="currentColor" stroke-opacity="0.3"/>
+    <line x1="80" y1="30" x2="80" y2="140" stroke="currentColor" stroke-opacity="0.3"/>
+    <circle cx="45" cy="85" r="4" fill="currentColor"/><circle cx="115" cy="85" r="4" fill="currentColor"/>
+    <text x="80" y="158" text-anchor="middle" font-size="9" fill="currentColor">BPSK (1 bit)</text>
+  </g>
+  <g>
+    <line x1="185" y1="85" x2="315" y2="85" stroke="currentColor" stroke-opacity="0.3"/>
+    <line x1="250" y1="30" x2="250" y2="140" stroke="currentColor" stroke-opacity="0.3"/>
+    <circle cx="285" cy="55" r="4" fill="currentColor"/><circle cx="215" cy="55" r="4" fill="currentColor"/>
+    <circle cx="215" cy="115" r="4" fill="currentColor"/><circle cx="285" cy="115" r="4" fill="currentColor"/>
+    <text x="250" y="158" text-anchor="middle" font-size="9" fill="currentColor">QPSK (2 bits)</text>
+  </g>
+  <g>
+    <line x1="355" y1="85" x2="505" y2="85" stroke="currentColor" stroke-opacity="0.3"/>
+    <line x1="430" y1="30" x2="430" y2="140" stroke="currentColor" stroke-opacity="0.3"/>
+    <g fill="currentColor">
+      <circle cx="385" cy="45" r="3"/><circle cx="415" cy="45" r="3"/><circle cx="445" cy="45" r="3"/><circle cx="475" cy="45" r="3"/>
+      <circle cx="385" cy="72" r="3"/><circle cx="415" cy="72" r="3"/><circle cx="445" cy="72" r="3"/><circle cx="475" cy="72" r="3"/>
+      <circle cx="385" cy="99" r="3"/><circle cx="415" cy="99" r="3"/><circle cx="445" cy="99" r="3"/><circle cx="475" cy="99" r="3"/>
+      <circle cx="385" cy="126" r="3"/><circle cx="415" cy="126" r="3"/><circle cx="445" cy="126" r="3"/><circle cx="475" cy="126" r="3"/>
+    </g>
+    <text x="430" y="158" text-anchor="middle" font-size="9" fill="currentColor">16-QAM (4 bits)</text>
+  </g>
+</svg>
+<figcaption>More points per constellation carry more bits per symbol — but pack the points closer, so noise defeats them sooner.</figcaption>
+</figure>
+
+## PSK and QAM: two families
+
+| Scheme | Varies | Points | Bits/symbol |
+|--------|--------|--------|-------------|
+| **BPSK** | phase | 2 | 1 |
+| **QPSK** | phase | 4 | 2 |
+| **16-QAM** | phase **and** amplitude | 16 | 4 |
+
+**PSK** keeps every point at the same radius and spreads them by angle — robust, because
+amplitude carries no data. **QAM** uses a grid, squeezing more bits per symbol by using
+amplitude too, at the cost of points sitting closer together and thus being easier for
+noise to confuse. The four-level [C4FM](/learn/dsp/demodulation/) of P25 Phase 1 is a
+frequency-domain cousin of the same bits-per-symbol idea.
+
+## Gray coding: one slip, one bad bit
+
+How you *label* the points matters as much as where they sit. Noise most often bumps a
+symbol into an **adjacent** point, so the bit labels are assigned by **Gray coding** —
+neighbours differ in exactly one bit. Then the common single-step slip flips only one
+bit, keeping the [bit error rate](/learn/dsp/snr-evm-and-ber/) far below what a careless
+labelling would give.
+
+```text
+QPSK, Gray-coded:   00 | 01        a slip to any *neighbour*
+                    ----+----      changes exactly ONE bit,
+                    10 | 11        never two.
+```
+
+## The diagram as a diagnostic
+
+Plot the received symbols and the pattern *is* the diagnosis. Tight dots on the ideal
+points: healthy. A fuzzy cloud: noise — low [SNR](/learn/dsp/snr-evm-and-ber/). A pattern
+rotating or held at an angle: an uncorrected [carrier offset](/learn/dsp/carrier-and-frequency-recovery/).
+Points smeared radially: [multipath](/learn/dsp/equalization/). The spread of each cluster
+from its ideal point is measured as [EVM](/learn/dsp/snr-evm-and-ber/), the next unit's
+first metric.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — Gray coding makes adjacent points differ by one bit, so a single-step slip flips only one bit." markdown="0">
+  <p class="knowledge-check__q">Quick check: why are constellation points Gray-coded?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">To pack more points into the same space</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">So a slip to an adjacent point flips only one bit</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">To remove the carrier frequency offset</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **constellation** is the set of ideal I/Q points a modulation uses; symbols map to bits.
+- **PSK** varies phase (points on a circle); **QAM** varies phase and amplitude (a grid).
+- **Gray coding** makes neighbours differ by one bit, minimizing the bit error rate.
+- The **constellation diagram** is a fast diagnostic — its shape names the impairment.
+
+Next up: why reflections smear symbols together, and the equalizer that undoes a channel.

--- a/docs/learn/dsp/convolution-and-impulse-response.md
+++ b/docs/learn/dsp/convolution-and-impulse-response.md
@@ -1,0 +1,122 @@
+---
+slug: convolution-and-impulse-response
+title: Convolution & impulse response
+description: The operation at the heart of every filter — what an impulse response is, and how sliding-and-summing in time equals multiplying in the frequency domain.
+keywords: convolution, impulse response, filter dsp, convolution explained, time domain filtering, impulse response filter, dsp convolution
+level: advanced
+status: full
+prereq:
+  - the-fourier-transform
+faq:
+  - q: What is convolution in simple terms?
+    a: Convolution slides one short sequence (the filter) along a signal, and at each position multiplies the overlapping values and adds them up to produce one output sample. Repeat down the whole signal and you get the filtered result. It sounds abstract, but a moving average — replacing each sample with the average of it and its neighbours — is exactly a convolution.
+  - q: What is an impulse response?
+    a: A filter's impulse response is what comes out when you feed in a single spike (an impulse) and nothing else. Remarkably, that one response completely defines the filter — convolving any input with the impulse response produces the filtered output. So "the filter" and "its impulse response" are two names for the same thing.
+---
+
+# Convolution & impulse response
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Convolution** slides a short sequence along a signal, multiplying and summing the
+overlap to produce each output sample — it's how filters work in the time domain. A
+filter is fully described by its **impulse response** (what it outputs for a single
+spike). And there's a deep shortcut: **convolution in time equals multiplication in
+frequency**, tying filters back to the Fourier view.
+</div>
+
+Every filter you'll meet — FIR, IIR, the anti-alias filter in a downconverter — is
+built on one operation. This lesson demystifies it.
+
+## A moving average is a filter
+
+Start with something familiar: smoothing a noisy signal by replacing each sample with
+the average of it and its neighbours.
+
+```text
+input:   4  8  6  2  9  3
+average each with its two neighbours (÷3):
+output:     6  5.3  5.7  4.7 ...
+```
+
+You just **filtered** the signal — a low-pass filter, in fact, because averaging
+smooths out fast wiggles (high frequencies) and keeps slow trends (low ones). Slide
+the averaging window along, compute one output per position: that sliding-and-summing
+*is* convolution.
+
+## Convolution, generally
+
+A general filter doesn't weight all neighbours equally — it uses a set of weights
+called **taps** (or **coefficients**). At each position, line the taps up against the
+signal, multiply each overlapping pair, and sum:
+
+```text
+output[n] = tap0*x[n] + tap1*x[n-1] + tap2*x[n-2] + ...
+```
+
+Different taps make different filters. Choosing them to keep the frequencies you want
+and reject the rest is **filter design**, the subject of the next two lessons.
+
+## The impulse response defines the filter
+
+Here's the elegant part. Feed a filter a single **impulse** — one spike, `1, 0, 0, 0,
+…` — and whatever comes out is its **impulse response**. For a tapped filter, the
+output *is* the taps themselves.
+
+That impulse response completely characterizes the filter: convolve *any* input with
+it and you get the correctly filtered output. So the taps, the impulse response, and
+"the filter" are all the same thing seen three ways.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 120" role="img" aria-label="A single input spike on the left passes through a filter box and emerges on the right as a spread-out impulse response shape." xmlns="http://www.w3.org/2000/svg">
+  <line x1="20" y1="90" x2="120" y2="90" stroke="currentColor" stroke-opacity="0.3"/>
+  <line x1="55" y1="90" x2="55" y2="35" stroke="currentColor" stroke-width="2"/>
+  <text x="60" y="108" text-anchor="middle" font-size="9" fill="currentColor">impulse in</text>
+  <rect x="150" y="55" width="90" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="195" y="76" text-anchor="middle" font-size="11" fill="currentColor">filter</text>
+  <line x1="120" y1="72" x2="150" y2="72" stroke="currentColor" stroke-width="1.5" marker-end="url(#c1)"/>
+  <line x1="240" y1="72" x2="270" y2="72" stroke="currentColor" stroke-width="1.5" marker-end="url(#c1)"/>
+  <line x1="300" y1="90" x2="510" y2="90" stroke="currentColor" stroke-opacity="0.3"/>
+  <g stroke="currentColor" stroke-width="2">
+    <line x1="330" y1="90" x2="330" y2="70"/><line x1="355" y1="90" x2="355" y2="50"/><line x1="380" y1="90" x2="380" y2="40"/><line x1="405" y1="90" x2="405" y2="52"/><line x1="430" y1="90" x2="430" y2="72"/>
+  </g>
+  <text x="400" y="108" text-anchor="middle" font-size="9" fill="currentColor">impulse response out</text>
+  <defs><marker id="c1" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Feed a filter one spike and its output — the impulse response — fully describes what the filter does to any signal.</figcaption>
+</figure>
+
+## The great shortcut
+
+Recall from [the Fourier transform](/learn/dsp/the-fourier-transform/) that time and
+frequency are two views of a signal. There's a beautiful theorem linking them:
+
+> **Convolution in the time domain = multiplication in the frequency domain.**
+
+Filtering a signal (convolving it with the taps) is the same as multiplying its
+spectrum by the filter's frequency response. This is why filters are so often
+described by their *frequency response* — "pass below 6 kHz, reject above" — even
+though they *run* as convolution in time. It also means a filter's job is easiest to
+picture in the frequency domain and easiest to *compute* in the time domain.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — convolution in time is multiplication in frequency, the link filters rely on." markdown="0">
+  <p class="knowledge-check__q">Quick check: convolving a signal with a filter in the time domain is equivalent to what in the frequency domain?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Adding the two spectra</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Multiplying the two spectra</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Nothing — they're unrelated</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Convolution** slides a set of **taps** along a signal, multiplying and summing —
+  how filters run in time.
+- A moving average is the simplest example: a low-pass filter.
+- A filter is fully defined by its **impulse response** (its output for a single
+  spike).
+- **Convolution in time = multiplication in frequency** — filters are designed in
+  frequency, run in time.
+
+Next up: FIR filters, the workhorse for isolating a channel.

--- a/docs/learn/dsp/decimation-and-resampling.md
+++ b/docs/learn/dsp/decimation-and-resampling.md
@@ -1,0 +1,113 @@
+---
+slug: decimation-and-resampling
+title: Decimation & resampling
+description: Changing a signal's sample rate without introducing aliasing — decimation, interpolation, and rational resampling — how an SDR narrows a wideband capture down to one channel's rate.
+keywords: decimation, resampling, interpolation, sample rate conversion, downsampling, polyphase filter, anti-aliasing, dsp resampling
+level: intermediate
+status: full
+prereq:
+  - fir-filters
+faq:
+  - q: What is decimation?
+    a: Decimation lowers a signal's sample rate by keeping only every Nth sample — but you must low-pass filter first, or high frequencies alias down and corrupt the result. So decimation is really filter-then-drop-samples. Reducing the rate early, once you've isolated a narrow channel, makes all downstream processing far cheaper.
+  - q: Why not just capture at the low rate you need?
+    a: The radio has to sample fast enough to cover the whole band you're tuned across (Nyquist), which is much wider than any single channel. Once DSP isolates one narrow channel, that wide rate is wasteful, so you decimate down to just what the channel needs — often from megahertz to tens of kilohertz — before demodulating.
+---
+
+# Decimation & resampling
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Decimation** lowers the sample rate by keeping every Nth sample — but you must
+**low-pass filter first** or high frequencies **alias** in. **Interpolation** raises
+the rate. Combining them gives **rational resampling** (by a fraction). An SDR
+decimates a wide capture down to one channel's rate — from megahertz to tens of
+kilohertz — so the rest of the pipeline is cheap.
+</div>
+
+An SDR captures far more bandwidth than any single channel needs. This lesson is about
+shedding that excess safely, so downstream DSP runs on a manageable stream.
+
+## Why change the rate at all
+
+The radio must sample fast enough to cover the whole band you're watching — say
+2.4 MS/s across 2.4 MHz, as [Nyquist](/learn/dsp/sampling-and-quantization/) demands.
+But once you've [mixed](/learn/dsp/mixing-and-downconversion/) and
+[filtered](/learn/dsp/fir-filters/) down to one 12.5 kHz channel, carrying millions of
+samples a second is pure waste. Everything after — demodulation, symbol recovery — gets
+cheaper the lower the rate. So you **decimate**: reduce the rate to just what the
+channel needs.
+
+## Decimation = filter, then drop
+
+The naive idea is "keep every Nth sample, throw the rest away." Done alone, that's a
+bug: any energy above the *new* Nyquist limit folds down and **aliases** into your
+channel, exactly the corruption from the sampling lesson. So decimation is always two
+steps:
+
+```text
+1. low-pass filter  -> remove everything above the new Nyquist limit
+2. keep every Nth sample -> the rate is now 1/N
+```
+
+The filter is the **anti-aliasing** guard, and it's usually the same FIR that isolated
+the channel — one filter doing two jobs.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 90" role="img" aria-label="A fast sample stream enters an anti-alias low-pass filter, then a downsample-by-N block, and exits as a slower stream." xmlns="http://www.w3.org/2000/svg">
+  <text x="55" y="30" text-anchor="middle" font-size="9" fill="currentColor">2.4 MS/s</text>
+  <line x1="10" y1="55" x2="90" y2="55" stroke="currentColor" stroke-width="1.5"/>
+  <rect x="90" y="38" width="110" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="145" y="59" text-anchor="middle" font-size="10" fill="currentColor">low-pass (FIR)</text>
+  <line x1="200" y1="55" x2="240" y2="55" stroke="currentColor" stroke-width="1.5"/>
+  <rect x="240" y="38" width="90" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="285" y="59" text-anchor="middle" font-size="11" fill="currentColor">&#8595; by N</text>
+  <line x1="330" y1="55" x2="410" y2="55" stroke="currentColor" stroke-width="1.5"/>
+  <text x="460" y="30" text-anchor="middle" font-size="9" fill="currentColor">48 kS/s</text>
+  <text x="440" y="59" text-anchor="middle" font-size="10" fill="currentColor">to demod</text>
+</svg>
+<figcaption>Decimation is filter-then-drop: the anti-alias filter must run <em>before</em> samples are discarded.</figcaption>
+</figure>
+
+## Interpolation and rational resampling
+
+The reverse — **interpolation** — raises the rate by inserting samples between existing
+ones (then filtering to smooth them in). Combine the two and you can resample by any
+**rational** factor L/M: interpolate by L, decimate by M. That's how you convert an
+awkward capture rate to a clean channel rate — for example turning 2.4 MS/s into
+exactly 48 kS/s for a 4800-baud C4FM channel.
+
+Done efficiently, the filtering and rate change are folded together into a
+**polyphase** filter, which skips computing samples it's about to throw away.
+
+## In a real receiver
+
+This is precisely what a **digital downconverter (DDC)** does: mix the channel to
+zero, low-pass filter it, and resample to the channel rate — all in one stage.
+GopherTrunk normalizes every protocol to its channel rate this way (48 kHz for the
+4800-baud C4FM family, 144 kHz for TETRA), which is why its decode path is
+*rate-invariant*: no matter the capture rate, the demodulator always sees the same
+channel rate. You'll see that end to end in
+[DSP in GopherTrunk](/learn/dsp/dsp-in-gophertrunk/); the RF path frames the same idea
+in [filtering & decimation](/learn/rf-sdr/filtering-decimation/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — you must low-pass filter before dropping samples, or aliasing corrupts the result." markdown="0">
+  <p class="knowledge-check__q">Quick check: what must you do <em>before</em> keeping every Nth sample when decimating?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Raise the bit depth</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Low-pass filter to remove energy above the new Nyquist limit</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Apply an FFT</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Decimation** lowers the rate by keeping every Nth sample — but **filter first** or
+  suffer **aliasing**.
+- **Interpolation** raises the rate; together they give **rational resampling** (L/M).
+- Efficient implementations fold both into a **polyphase** filter.
+- A **DDC** mixes, filters, and resamples a channel to its rate — making a decoder
+  **rate-invariant**.
+
+Next up: Unit 4 — tuning a channel to zero with a mixer.

--- a/docs/learn/dsp/demodulation.md
+++ b/docs/learn/dsp/demodulation.md
@@ -1,0 +1,105 @@
+---
+slug: demodulation
+title: Demodulation in code
+description: Recovering the message from a carrier — AM, FM, and phase demodulation as arithmetic on I/Q samples, and how digital C4FM voice starts to appear.
+keywords: demodulation, fm demodulation, am demodulation, phase demodulation, c4fm, fsk, iq demodulation, dsp demod, discriminator
+level: intermediate
+status: full
+prereq:
+  - mixing-and-downconversion
+faq:
+  - q: How do you demodulate FM from I/Q samples?
+    a: FM carries information in the rate the phase changes. With complex I/Q samples the phase is the angle of each sample, so FM demodulation is measuring how much the angle rotates from one sample to the next — the change in angle per sample is proportional to the instantaneous frequency, which is the recovered signal. It's a few operations per sample.
+  - q: What is C4FM?
+    a: C4FM (compatible four-level FM) is the four-level frequency-shift modulation used by P25 Phase 1 and related systems. The transmitter shifts the frequency to one of four levels, each representing two bits, 4800 times a second. Demodulating it is FM demodulation followed by deciding which of the four levels each symbol landed on.
+---
+
+# Demodulation in code
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Demodulation** recovers the message riding on a carrier. With **I/Q** samples it's
+arithmetic: **AM** is the sample's magnitude, **FM** is the rate its **phase** rotates
+between samples, and **phase** demodulation reads the angle directly. The digital
+voice GopherTrunk decodes — like **C4FM** — is FM demodulation followed by deciding
+which symbol level each moment lands on.
+</div>
+
+You've isolated a channel at baseband. Now recover what's written on it. This lesson
+turns the modulation types from the RF path into the actual math a decoder runs.
+
+## Modulation, in reverse
+
+Recall that a transmitter encodes information by varying a carrier's
+[amplitude, frequency, or phase](/learn/rf-sdr/analog-modulation/). Demodulation
+undoes each one — and because a baseband sample is a complex I/Q value (an arrow with
+length and angle), each is a small calculation:
+
+| Modulation | Information is in | Demodulate by |
+|------------|-------------------|---------------|
+| **AM** | amplitude | taking each sample's **magnitude** (arrow length) |
+| **FM / FSK** | frequency | measuring **phase change** between samples |
+| **PM / PSK** | phase | reading each sample's **angle** |
+
+## FM demodulation: the phase-change trick
+
+FM (and its digital cousin FSK) is the workhorse for voice and much digital radio, so
+it's worth seeing concretely. Frequency *is* the rate phase changes. Since each I/Q
+sample's angle is its phase, the recovered signal is simply **how much the angle turned
+since the last sample**:
+
+```text
+sample n-1:  angle = 30 deg
+sample n:    angle = 55 deg
+-> phase advanced 25 deg -> proportional to instantaneous frequency
+```
+
+Do that every sample and the sequence of angle-changes *is* the demodulated FM — a few
+multiplies and an arctangent per sample. This block is often called a **discriminator**.
+
+## From FM to digital symbols
+
+Digital voice like **C4FM** (used by P25 Phase 1) is FM with a twist: instead of a
+continuously varying voice tone, the transmitter shifts the frequency to one of
+**four discrete levels**, 4800 times a second, each level carrying two bits. So the
+decoder:
+
+1. **FM-demodulates** to get the instantaneous frequency (as above).
+2. Watches it settle near one of four levels each symbol period.
+3. **Decides** which level — that's two bits recovered.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 120" role="img" aria-label="A demodulated signal that steps between four horizontal levels, with dashed lines marking the four decision levels the decoder chooses among." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" stroke-opacity="0.3" stroke-dasharray="3 3"><line x1="20" y1="25" x2="500" y2="25"/><line x1="20" y1="50" x2="500" y2="50"/><line x1="20" y1="75" x2="500" y2="75"/><line x1="20" y1="100" x2="500" y2="100"/></g>
+  <text x="508" y="28" font-size="8" fill="currentColor">+3</text><text x="508" y="53" font-size="8" fill="currentColor">+1</text><text x="508" y="78" font-size="8" fill="currentColor">-1</text><text x="508" y="103" font-size="8" fill="currentColor">-3</text>
+  <path d="M20 50 H70 V25 H120 V100 H170 V75 H220 V25 H270 V50 H320 V100 H370 V50 H420 V75 H470" fill="none" stroke="currentColor" stroke-width="1.5"/>
+</svg>
+<figcaption>C4FM demodulated: the frequency steps between four levels; the decoder decides which level each symbol period holds, recovering two bits each.</figcaption>
+</figure>
+
+But there's a catch: to read "each symbol period," the decoder has to know *where* each
+symbol begins — and it has no shared clock with the transmitter. Finding those symbol
+boundaries is the next lesson, [clock & symbol recovery](/learn/dsp/clock-and-symbol-recovery/).
+The RF path's [demodulation pipeline](/learn/rf-sdr/demodulation-pipeline/) walks the
+same chain from the radio side.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — FM information is the rate of phase change between I/Q samples." markdown="0">
+  <p class="knowledge-check__q">Quick check: to FM-demodulate an I/Q stream, you measure…</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">the magnitude of each sample</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">how much the phase (angle) changes between samples</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">the bit depth of each sample</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Demodulation** undoes modulation: **AM** = magnitude, **FM** = phase-change rate,
+  **PM** = angle.
+- On **I/Q** samples each is a few operations — FM demod is a **discriminator**.
+- Digital voice like **C4FM** is FM demod plus deciding which of four **symbol levels**
+  each period holds.
+- Reading symbols needs their boundaries — the job of clock recovery, next.
+
+Next up: finding where each symbol begins without a shared clock.

--- a/docs/learn/dsp/dsp-in-gophertrunk.md
+++ b/docs/learn/dsp/dsp-in-gophertrunk.md
@@ -1,0 +1,119 @@
+---
+slug: dsp-in-gophertrunk
+title: DSP in GopherTrunk
+description: A walkthrough of GopherTrunk's real signal path — capture, downconvert, filter, demodulate, recover symbols — mapping each stage to the DSP concepts you just learned.
+keywords: gophertrunk dsp, sdr pipeline, ddc, downconverter, c4fm decode, real dsp example, sdr signal chain, dsp in practice
+level: advanced
+status: full
+prereq:
+  - decimation-and-resampling
+  - demodulation
+  - clock-and-symbol-recovery
+faq:
+  - q: Does GopherTrunk use fixed-point or floating-point DSP?
+    a: GopherTrunk is pure Go and carries I/Q samples as complex64 — a pair of 32-bit floats — throughout its pipeline. Floating point keeps the DSP code simple and accurate, and modern CPUs run 32-bit float math fast enough for the channel rates involved. The next lesson explains the fixed-versus-float tradeoff in general.
+  - q: Why does GopherTrunk have two different downconverters?
+    a: The single-channel Downconverter is used by the replay/tune path to decode one channel from a capture, while the wideband DDCBank extracts many channels at once from a live stream. They are separate code paths that implement the same conceptual mix-filter-decimate DDC, so a fix to one does not automatically apply to the other — a distinction the project documents carefully.
+---
+
+# DSP in GopherTrunk
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+GopherTrunk's decode path is every concept in this module, in order: **capture**
+I/Q, **downconvert** (mix + filter + resample) to the channel rate, **demodulate**,
+then **recover symbols** into bits. Because the DDC normalizes to a fixed **channel
+rate**, the decoder is **rate-invariant** — it behaves the same whatever the capture
+rate. Samples flow as Go **`complex64`** over channels between concurrent stages.
+</div>
+
+This is where it all comes together. We'll walk GopherTrunk's real signal chain and
+label each stage with the lesson that explains it — so the pipeline stops being
+abstract and becomes something you can read in the source.
+
+## The chain, end to end
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 90" role="img" aria-label="Pipeline: capture, downconvert (mix filter decimate), demodulate, symbol and clock recovery, framing, decoded output." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="8.5" fill="currentColor" text-anchor="middle">
+  <rect x="4" y="35" width="66" height="30" rx="4" fill="none" stroke="currentColor"/><text x="37" y="53">capture</text>
+  <rect x="78" y="35" width="96" height="30" rx="4" fill="none" stroke="currentColor" stroke-width="1.8"/><text x="126" y="49">downconvert</text><text x="126" y="60">mix·filter·decim</text>
+  <rect x="182" y="35" width="80" height="30" rx="4" fill="none" stroke="currentColor"/><text x="222" y="53">demodulate</text>
+  <rect x="270" y="35" width="96" height="30" rx="4" fill="none" stroke="currentColor"/><text x="318" y="49">symbol/clock</text><text x="318" y="60">recovery</text>
+  <rect x="374" y="35" width="60" height="30" rx="4" fill="none" stroke="currentColor"/><text x="404" y="53">framing</text>
+  <rect x="442" y="35" width="74" height="30" rx="4" fill="none" stroke="currentColor"/><text x="479" y="49">decoded</text><text x="479" y="60">voice/data</text>
+  </g>
+  <g stroke="currentColor"><line x1="70" y1="50" x2="78" y2="50"/><line x1="174" y1="50" x2="182" y2="50"/><line x1="262" y1="50" x2="270" y2="50"/><line x1="366" y1="50" x2="374" y2="50"/><line x1="434" y1="50" x2="442" y2="50"/></g>
+</svg>
+<figcaption>GopherTrunk's decode path — each box is a lesson from this module.</figcaption>
+</figure>
+
+## Stage by stage
+
+**1. Capture — I/Q in.** The SDR front-end (the `sdr` package) reads samples off the
+radio and pushes them downstream as a stream of `complex64` — the
+[I/Q samples](/learn/dsp/complex-signals-and-iq/) from Unit 1. Concurrent stages hand
+this stream along over Go channels, exactly the pattern from the
+[Go concurrency lessons](/learn/programming-go/channels/).
+
+**2. Downconvert — mix, filter, decimate.** A **digital downconverter** centres the
+target channel at zero with an [NCO mix](/learn/dsp/mixing-and-downconversion/), runs a
+[FIR low-pass](/learn/dsp/fir-filters/) (a Kaiser-windowed design with a stopband more
+than 60 dB down — the [windowing](/learn/dsp/windows-and-leakage/) from Unit 2), and
+[resamples](/learn/dsp/decimation-and-resampling/) to the per-protocol channel rate —
+**48 kHz** for the 4800-baud C4FM family, **144 kHz** for TETRA. GopherTrunk has two
+DDC implementations: a single-channel `Downconverter` (used by the replay/tune path)
+and a multi-tap wideband `DDCBank` (many channels from one live capture). They're
+**separate code paths** doing the same conceptual job — a distinction the project
+documents deliberately, because a fix to one does not touch the other.
+
+**3. Demodulate.** The channel, now at baseband and at the channel rate, is
+[FM/C4FM demodulated](/learn/dsp/demodulation/) — the phase-change discriminator that
+turns I/Q into a signal stepping between symbol levels.
+
+**4. Symbol & clock recovery.** A [matched filter and timing loop](/learn/dsp/clock-and-symbol-recovery/)
+lock onto the 4800-baud symbol clock and read each symbol at its centre, with an
+[AGC](/learn/dsp/gain-and-agc/) holding the level steady. Out come bits.
+
+**5. Framing and decode.** The `scanner`/`radio` packages assemble bits into frames,
+follow the control channel, and hand voice frames to the vocoder — the boundary where
+DSP ends and the [digital trunking](/learn/digital-trunking/) module picks up.
+
+## The rate-invariance payoff
+
+Notice what the downconverter guarantees: **whatever** the capture rate — 2.4 MS/s,
+10 MS/s — everything after step 2 sees the *same* channel rate. The receiver, matched
+filter, and AGC are all sized from that channel rate, so the decoder is
+**rate-invariant**. This isn't a detail; it's a load-bearing design fact. It means a
+signal that decodes at one capture rate but not another points at the *captured data*
+(front-end overload, phase noise) rather than the steady-state DSP — a diagnosis the
+project has used to run down real field bugs.
+
+## Reading it in the source
+
+With this map, the code is navigable. Following the
+[reading-real-Go](/learn/programming-go/reading-real-go/) habits: start where samples
+enter, follow the `complex64` channel from `sdr` into the downconverter, then into the
+demodulator and symbol recovery. Each package is one box in the diagram above.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the DDC normalizes to a fixed channel rate, making the decoder rate-invariant." markdown="0">
+  <p class="knowledge-check__q">Quick check: why does GopherTrunk's decoder behave the same regardless of capture rate?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It always captures at exactly one rate</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The downconverter resamples every channel to a fixed channel rate before decoding</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It uses fixed-point math</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- GopherTrunk's chain is this module in order: **capture → downconvert → demodulate →
+  recover symbols → frame**.
+- The **DDC** (mix + FIR + resample) normalizes to a fixed **channel rate** (48 kHz
+  C4FM, 144 kHz TETRA).
+- That makes the decoder **rate-invariant** — a powerful diagnostic property.
+- Two DDCs exist — single-channel and wideband — as **separate code paths**; samples
+  flow as **`complex64`** over Go channels.
+
+Next up: the last lesson — how numbers are stored, and why it matters for performance.

--- a/docs/learn/dsp/equalization.md
+++ b/docs/learn/dsp/equalization.md
@@ -1,0 +1,118 @@
+---
+slug: equalization
+title: Equalization & multipath
+description: Why reflections smear symbols together and how an adaptive equalizer undoes a channel's distortion — the filter that cleans up inter-symbol interference.
+keywords: equalization, multipath, inter-symbol interference, adaptive equalizer, channel distortion, isi, delay spread, equalizer filter
+level: advanced
+status: full
+prereq:
+  - matched-filters-and-pulse-shaping
+  - fir-filters
+faq:
+  - q: What is multipath and why does it cause errors?
+    a: "Multipath is the arrival of a signal by several paths at once — a direct ray plus reflections off buildings and terrain — each delayed by a different amount. The delayed copies overlap the direct signal, so energy from one symbol lands on top of the next. That overlap is inter-symbol interference, and it blurs the constellation until symbols become impossible to tell apart."
+  - q: How does an equalizer fix a distorted channel?
+    a: "An equalizer is a filter whose response is the inverse of the channel's. Where the channel spread and delayed the signal, the equalizer applies an opposite correction that collapses the echoes back onto the direct path. Because the channel changes as the receiver or reflectors move, the equalizer is adaptive — it continuously adjusts its coefficients to track the channel using the recovered symbols as a reference."
+---
+
+# Equalization & multipath
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A radio signal reaches the antenna by many paths — a direct ray plus **reflections** — each
+delayed differently. Those overlapping copies spill one symbol's energy onto the next:
+**multipath-induced inter-symbol interference (ISI)**. An **equalizer** is a filter that
+applies the **inverse** of the channel, collapsing the echoes back together. Because the
+channel changes as things move, the equalizer is **adaptive**, retuning itself continuously.
+</div>
+
+[Matched filtering](/learn/dsp/matched-filters-and-pulse-shaping/) kept a clean channel
+ISI-free — but the air is not clean. This lesson is about the distortion the *channel*
+adds and the filter that undoes it. It builds on
+[FIR filters](/learn/dsp/fir-filters/) and connects to [propagation](/learn/rf-sdr/propagation/).
+
+## Multipath: many copies, many delays
+
+A transmitted signal rarely takes one path. It goes direct, and it also bounces off
+buildings, hills, and vehicles, so several delayed copies pile up at the receiver. When
+the spread of those delays approaches a symbol period, a reflection of *this* symbol
+arrives at the same time as the *next* one — inter-symbol interference, this time caused
+by the channel rather than by pulse shaping.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 150" role="img" aria-label="A transmitter and receiver with a direct path and a longer reflected path off a building, and a small plot showing the direct pulse plus a delayed echo overlapping the next symbol." xmlns="http://www.w3.org/2000/svg">
+  <circle cx="40" cy="60" r="10" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="40" y="88" text-anchor="middle" font-size="9" fill="currentColor">TX</text>
+  <circle cx="290" cy="60" r="10" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="290" y="88" text-anchor="middle" font-size="9" fill="currentColor">RX</text>
+  <line x1="50" y1="60" x2="280" y2="60" stroke="currentColor" stroke-width="1.5"/>
+  <text x="165" y="54" text-anchor="middle" font-size="8" fill="currentColor">direct</text>
+  <rect x="150" y="8" width="30" height="16" fill="none" stroke="currentColor" stroke-opacity="0.6"/>
+  <text x="165" y="20" text-anchor="middle" font-size="7" fill="currentColor">bldg</text>
+  <path d="M50 55 L160 24 L280 55" fill="none" stroke="currentColor" stroke-width="1.2" stroke-opacity="0.6"/>
+  <text x="120" y="34" text-anchor="middle" font-size="8" fill="currentColor">reflected (delayed)</text>
+  <g>
+    <line x1="360" y1="110" x2="510" y2="110" stroke="currentColor" stroke-opacity="0.3"/>
+    <path d="M370 110 L390 110 L390 60 L410 60 L410 110 L430 110" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <path d="M390 110 L410 110 L410 85 L430 85 L430 110 L450 110" fill="none" stroke="currentColor" stroke-width="1.2" stroke-opacity="0.6" stroke-dasharray="3 2"/>
+    <text x="435" y="128" text-anchor="middle" font-size="8" fill="currentColor">echo spills into next symbol</text>
+  </g>
+</svg>
+<figcaption>Multipath: a delayed reflection overlaps the following symbol, causing inter-symbol interference the equalizer must remove.</figcaption>
+</figure>
+
+On the [constellation](/learn/dsp/constellations-and-symbol-mapping/) this shows as points
+smeared and pulled off their ideal spots — not random fuzz (that's noise) but a
+structured distortion the channel imposed.
+
+## The equalizer: inverting the channel
+
+If multipath is a filter the channel applied to your signal, then undoing it is applying
+the **inverse filter**. That is an **equalizer** — usually an FIR filter whose taps are
+set so that channel-then-equalizer together look like a clean, flat, delay-only path. It
+gathers the scattered echo energy back onto the direct symbol, reopening the
+[eye](/learn/dsp/the-eye-diagram/) and tightening the constellation.
+
+```text
+distorted:  channel  ->  smeared symbols  ->  errors
+equalized:  channel  ->  EQUALIZER (inverse)  ->  clean symbols
+```
+
+## Why it must be adaptive
+
+The catch: the channel is not fixed. Move the receiver, and the reflectors, or a passing
+truck, and the set of paths changes moment to moment. A one-time inverse would be wrong
+seconds later. So the equalizer is **adaptive** — it continuously nudges its taps to keep
+the output clean, judging its own success against the recovered symbols (which sit on a
+known grid) and error-driven update rules. It is the same feedback idea as the
+[timing](/learn/dsp/clock-and-symbol-recovery/) and
+[carrier](/learn/dsp/carrier-and-frequency-recovery/) loops, applied to channel shape.
+
+## Where it fits — and where it doesn't
+
+Not every system equalizes. Narrowband voice modes with modest data rates often have a
+symbol period long enough that typical delay spread causes little ISI, so they skip an
+explicit equalizer. Higher-rate and wideband systems, where delay spread is a real
+fraction of a symbol, lean on equalization heavily. Either way, understanding multipath
+explains a signal that is strong on the meter yet decodes poorly — a hallmark the
+[troubleshooting](/learn/digital-trunking/troubleshooting-a-decode/) guide flags, since
+strength alone can't overcome a smeared channel.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — an adaptive equalizer applies the inverse of the changing channel to undo multipath ISI." markdown="0">
+  <p class="knowledge-check__q">Quick check: why must an equalizer be adaptive?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">To slowly increase the sample rate</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Because the multipath channel keeps changing as the receiver and reflectors move</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Because floating-point math drifts over time</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Multipath** delivers delayed copies of the signal; overlap causes channel **ISI**.
+- It smears the constellation in a **structured** way, distinct from random noise.
+- An **equalizer** applies the channel's **inverse**, collapsing echoes back onto the symbol.
+- The channel changes, so the equalizer is **adaptive**, retuning its taps continuously.
+
+Next up: the three numbers that measure a link's health — SNR, EVM, and BER.

--- a/docs/learn/dsp/error-correction-and-framing.md
+++ b/docs/learn/dsp/error-correction-and-framing.md
@@ -1,0 +1,119 @@
+---
+slug: error-correction-and-framing
+title: Error correction & framing
+description: How raw symbols become trustworthy data — sync words, framing, interleaving, and forward error correction that fix bit errors before decoding.
+keywords: error correction, framing, sync word, interleaving, forward error correction, fec, convolutional code, reed solomon, burst errors
+level: advanced
+status: full
+prereq:
+  - snr-evm-and-ber
+faq:
+  - q: What is a sync word and why is it needed?
+    a: "A sync word is a fixed, known bit pattern the transmitter inserts at the start of each frame. The receiver, which has been reading a continuous stream of symbols with no idea where a frame begins, slides along looking for that pattern. When it matches, the receiver knows exactly where the frame — and every field inside it — starts. Without a sync word the bits would be a meaningless stream with no structure."
+  - q: How does forward error correction fix errors without asking for a resend?
+    a: "Forward error correction adds carefully computed redundant bits before transmission. Those extra bits let the receiver detect and reconstruct a bounded number of flipped bits entirely on its own, with no return channel and no retransmission. A convolutional code plus a Viterbi decoder, or a Reed-Solomon block code, are the classic schemes — essential for one-way broadcast radio where asking for a resend is impossible."
+---
+
+# Error correction & framing
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Recovered bits are noisy and shapeless. **Framing** gives them structure — a **sync word**
+marks where each frame begins. **Interleaving** scrambles bit order so a **burst** of
+errors is spread thin. **Forward error correction (FEC)** — convolutional codes with
+Viterbi decoding, or Reed–Solomon — adds redundancy that **repairs** flipped bits with no
+retransmission. Together they turn a link with a nonzero [BER](/learn/dsp/snr-evm-and-ber/)
+into trustworthy data.
+</div>
+
+Symbol recovery gave us bits; some are wrong. This lesson is the layer that makes those
+bits *reliable* — the bridge from DSP into protocol decoding. It follows directly from
+[SNR/EVM/BER](/learn/dsp/snr-evm-and-ber/) and hands off to the digital-trunking module's
+[framing, FEC & interleaving](/learn/digital-trunking/framing-fec-interleaving/).
+
+## Framing: finding structure in a stream
+
+After symbol recovery you have an unbroken river of bits with no markers. **Framing**
+imposes structure. The transmitter groups bits into **frames** of a fixed layout and
+prefixes each with a **sync word** — a known pattern the receiver searches for by sliding
+a comparison along the stream until it matches.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 90" role="img" aria-label="A bit stream divided into frames, each beginning with a highlighted sync word followed by header and payload fields." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="30" width="70" height="30" fill="currentColor" fill-opacity="0.25" stroke="currentColor"/><text x="55" y="49">sync</text>
+    <rect x="90" y="30" width="60" height="30" fill="none" stroke="currentColor"/><text x="120" y="49">header</text>
+    <rect x="150" y="30" width="110" height="30" fill="none" stroke="currentColor"/><text x="205" y="49">payload</text>
+    <rect x="260" y="30" width="70" height="30" fill="currentColor" fill-opacity="0.25" stroke="currentColor"/><text x="295" y="49">sync</text>
+    <rect x="330" y="30" width="60" height="30" fill="none" stroke="currentColor"/><text x="360" y="49">header</text>
+    <rect x="390" y="30" width="110" height="30" fill="none" stroke="currentColor"/><text x="445" y="49">payload</text>
+  </g>
+  <text x="260" y="78" text-anchor="middle" font-size="9" fill="currentColor">one frame &#8594;| |&#8592; next frame</text>
+</svg>
+<figcaption>Framing: each frame opens with a known sync word so the receiver can lock onto frame boundaries and locate every field inside.</figcaption>
+</figure>
+
+Once aligned, the fixed layout tells the decoder where the header, addresses, and payload
+sit — the boundary where DSP ends and [protocol decoding](/learn/digital-trunking/anatomy-of-a-call/)
+begins.
+
+## Interleaving: defeating burst errors
+
+Radio errors rarely come one at a time. A fade or a burst of interference corrupts a run
+of *consecutive* bits — and a long burst can overwhelm any error-correcting code, which
+can only fix so many errors in one block. **Interleaving** is the clever countermeasure:
+shuffle the bit order before transmission and unshuffle it at the receiver.
+
+```text
+sent order (interleaved):   1 5 9 2 6 10 3 7 11 4 8 12
+a burst hits 3 in a row:        X X  X
+de-interleaved back to order: 1 2 3 4 5 6 7 8 9 10 11 12
+the 3 errors are now:             X     X        X   (spread out)
+```
+
+A tight burst becomes scattered single errors after de-interleaving — and *scattered*
+single errors are exactly what FEC handles well.
+
+## Forward error correction: repair without a resend
+
+Broadcast radio has no back-channel; the receiver can't ask "say that again." So the
+transmitter sends **redundancy up front** — **forward error correction**. Extra,
+mathematically related bits let the receiver detect *and reconstruct* a bounded number of
+flipped bits by itself. Two families dominate:
+
+| Scheme | Style | Good at |
+|--------|-------|---------|
+| **Convolutional** (Viterbi-decoded) | continuous, over a sliding window | scattered random bit errors |
+| **Reed–Solomon** | block, over groups of symbols | correcting whole bad symbols/short bursts |
+
+Systems often **stack** them — Reed–Solomon over a convolutional inner code, with
+interleaving between — so each mops up what the other misses. The payoff shows in the
+metrics: FEC lets a raw [BER](/learn/dsp/snr-evm-and-ber/) of, say, one in a thousand
+decode to *zero* errors, which is why a link can sound clean well below the SNR at which
+the raw symbols are perfect.
+
+## The pipeline in order
+
+Putting it together, the receive side is: recover symbols → find the **sync word** →
+**de-interleave** → **FEC decode** → trustworthy frame. That last output is what the
+[digital trunking](/learn/digital-trunking/) module parses into calls, talkgroups, and
+control messages.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — interleaving spreads a burst of errors into scattered single errors that FEC can fix." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does interleaving accomplish?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It marks where each frame begins</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">It spreads a burst of consecutive errors into scattered single errors FEC can correct</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It increases the raw symbol rate</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Framing** gives bits structure; a **sync word** marks where each frame begins.
+- **Interleaving** shuffles bit order so a **burst** becomes scattered single errors.
+- **FEC** (convolutional/Viterbi, Reed–Solomon) **repairs** flipped bits with no resend.
+- The chain — sync → de-interleave → FEC — turns a nonzero **BER** into trustworthy frames.
+
+Next up: making all of this run live — block processing, ring buffers, and latency.

--- a/docs/learn/dsp/filter-design-basics.md
+++ b/docs/learn/dsp/filter-design-basics.md
@@ -1,0 +1,110 @@
+---
+slug: filter-design-basics
+title: Filter design basics
+description: Passband, stopband, transition width, and ripple — the specification you hand a filter designer, and how those choices trade off against each other.
+keywords: filter design, passband stopband, transition band, ripple, filter order, filter specification, cutoff frequency, stopband attenuation
+level: intermediate
+status: full
+prereq:
+  - convolution-and-impulse-response
+faq:
+  - q: What is a filter specification?
+    a: "A filter specification is the shape you want a filter's frequency response to have, written as a handful of numbers: where the passband ends, where the stopband begins, how flat the passband must be (ripple), and how deeply the stopband must attenuate. A design tool turns that spec into actual filter coefficients."
+  - q: Why can't a filter just cut sharply at one frequency?
+    a: "A perfectly sharp cutoff would require an infinitely long filter, which is impossible to build and adds infinite delay. Every real filter needs a transition band of finite width between passband and stopband. Making that transition narrower, or the stopband deeper, always costs more taps, more computation, and more delay — that is the fundamental tradeoff."
+---
+
+# Filter design basics
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Before you build a filter you **specify** it: the **passband** (frequencies to keep),
+the **stopband** (frequencies to reject), the **transition band** between them, the
+**ripple** allowed in the passband, and the **stopband attenuation** in dB. Tightening
+any of those raises the filter's **order** (its length and cost). Design is choosing a
+sensible point in that tradeoff — the spec you hand to a tool that computes the taps.
+</div>
+
+The last lesson showed that a filter *is* its [impulse response](/learn/dsp/convolution-and-impulse-response/).
+This one is about deciding what response you want *before* you compute the taps for an
+[FIR](/learn/dsp/fir-filters/) or [IIR](/learn/dsp/iir-filters/) filter. It is the
+vocabulary of the filter specification.
+
+## The anatomy of a filter response
+
+Every frequency-selective filter has the same regions. Picture a low-pass response — keep
+the lows, reject the highs:
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 170" role="img" aria-label="A low-pass filter response showing a flat passband with small ripple, a sloping transition band, and a low stopband, with the transition width and stopband attenuation marked." xmlns="http://www.w3.org/2000/svg">
+  <line x1="40" y1="140" x2="500" y2="140" stroke="currentColor" stroke-opacity="0.3"/>
+  <line x1="40" y1="20" x2="40" y2="140" stroke="currentColor" stroke-opacity="0.3"/>
+  <text x="30" y="80" font-size="9" fill="currentColor" transform="rotate(-90 30 80)">gain</text>
+  <text x="490" y="158" text-anchor="end" font-size="10" fill="currentColor">frequency &#8594;</text>
+  <path d="M40 40 L180 40 L300 128 L500 128" fill="none" stroke="currentColor" stroke-width="2"/>
+  <path d="M40 40 q 20 -6 40 0 q 20 6 40 0 q 20 -6 40 0" fill="none" stroke="currentColor" stroke-width="1" stroke-opacity="0.6"/>
+  <text x="105" y="32" text-anchor="middle" font-size="9" fill="currentColor">passband (ripple)</text>
+  <line x1="180" y1="45" x2="300" y2="45" stroke="currentColor" stroke-dasharray="3 3" stroke-opacity="0.6"/>
+  <text x="240" y="60" text-anchor="middle" font-size="9" fill="currentColor">transition</text>
+  <text x="400" y="120" text-anchor="middle" font-size="9" fill="currentColor">stopband</text>
+  <line x1="470" y1="40" x2="470" y2="128" stroke="currentColor" stroke-dasharray="3 3" stroke-opacity="0.6"/>
+  <text x="482" y="88" font-size="9" fill="currentColor">attenuation (dB)</text>
+</svg>
+<figcaption>A filter spec in one picture: a flat passband (with bounded ripple), a finite transition band, and a stopband at some attenuation depth.</figcaption>
+</figure>
+
+## The five numbers you hand a designer
+
+| Term | What it sets |
+|------|--------------|
+| **Passband edge** | the highest frequency kept at (near) full gain |
+| **Stopband edge** | the lowest frequency that must be fully rejected |
+| **Transition width** | the gap between those two edges — narrower is harder |
+| **Passband ripple** | how much the gain may wobble in the passband (dB) |
+| **Stopband attenuation** | how far down rejected frequencies must sit (dB) |
+
+Hand those to a design method — a windowed-sinc, Parks–McClellan, or an
+[IIR](/learn/dsp/iir-filters/) prototype — and it returns the coefficients. You rarely
+choose taps by hand; you choose the *spec*.
+
+## The tradeoff you can't escape
+
+These numbers pull against each other, and the currency they all spend is **filter
+order** — the number of taps (FIR) or poles (IIR), which is compute cost and delay:
+
+- A **narrower transition** costs more order.
+- A **deeper stopband** costs more order.
+- **Less ripple** costs more order.
+
+You cannot have a razor-sharp cutoff, a 90 dB stopband, and a tiny cheap filter all at
+once. Good design is picking the *loosest* spec that still does the job. For a scanner
+channel filter, "flat across the channel, 60 dB down at the neighbour's edge, a modest
+transition" is plenty — over-specifying just burns CPU that
+[real-time processing](/learn/dsp/real-time-and-buffering/) can't spare.
+
+## FIR or IIR for this spec?
+
+The spec also steers the *type*. Need **linear phase** so a digital signal's shape
+survives? That points to [FIR](/learn/dsp/fir-filters/). Need a steep cutoff with the
+fewest operations and can tolerate nonlinear phase? An [IIR](/learn/dsp/iir-filters/)
+does it with far fewer coefficients. The specification comes first; the choice of
+structure follows from it.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a narrower transition band demands a higher-order, costlier filter." markdown="0">
+  <p class="knowledge-check__q">Quick check: making the transition band narrower requires…</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">fewer taps and less computation</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">a higher filter order — more taps and more computation</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">a lower sample rate</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A filter is **specified** by passband, stopband, transition width, ripple, and attenuation.
+- Those numbers are what you hand a design tool; it computes the **taps**.
+- Every tightening — sharper transition, deeper stopband, less ripple — raises the **order** (cost).
+- The spec also guides **FIR vs IIR**: linear phase points to FIR, minimal cost to IIR.
+
+Next up: the FIR filter — the linear-phase workhorse that carves one channel out of a capture.

--- a/docs/learn/dsp/fir-filters.md
+++ b/docs/learn/dsp/fir-filters.md
@@ -1,0 +1,110 @@
+---
+slug: fir-filters
+title: FIR filters
+description: Finite impulse response filters — taps, linear phase, and how to design a low-pass filter that isolates one channel from a wideband capture.
+keywords: fir filter, finite impulse response, filter taps, linear phase, low pass filter, channel filter, dsp fir design, kaiser window filter
+level: intermediate
+status: full
+prereq:
+  - convolution-and-impulse-response
+faq:
+  - q: What does FIR stand for and mean?
+    a: FIR is Finite Impulse Response. The filter's response to a single impulse lasts a finite number of samples — exactly the number of taps — then stops, because the output depends only on the current and past inputs, never on past outputs. This makes FIR filters stable and predictable.
+  - q: Why are FIR filters used for isolating radio channels?
+    a: FIR filters can have very sharp, precisely designed frequency responses and linear phase, meaning all frequencies are delayed equally so the signal's shape isn't distorted. That precise, distortion-free selectivity is exactly what you want to cut one narrow channel out of a wide capture before demodulating it.
+---
+
+# FIR filters
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A **FIR (finite impulse response)** filter is convolution with a fixed set of
+**taps** — its output depends only on current and past *inputs*, so its impulse
+response has a finite length and it's always **stable**. FIR filters can be designed
+with **sharp** responses and **linear phase** (no shape distortion), which makes them
+the workhorse for **isolating one channel** from a wideband capture.
+</div>
+
+FIR filters are the most common filter in software radio. This lesson shows what they
+are and how they carve one channel out of a crowded band.
+
+## What makes a filter FIR
+
+A **FIR** filter is exactly the tapped convolution from the last lesson:
+
+```text
+output[n] = tap0*x[n] + tap1*x[n-1] + ... + tapK*x[n-K]
+```
+
+The key property: the output depends only on the **input** samples, never on previous
+*outputs*. So when the input impulse passes the last tap, the output goes silent —
+the impulse response is **finite**, K+1 samples long. Because nothing feeds back, a
+FIR filter can never run away or ring forever; it is **unconditionally stable**.
+
+## Taps set the shape
+
+The taps *are* the filter. Choose them well and you get a **low-pass** filter (keep
+low frequencies, reject high), a **band-pass** (keep a middle band), or a **high-pass**.
+More taps buy a sharper transition between "keep" and "reject" — at a higher compute
+cost, since each output sample is that many multiply-adds.
+
+Designers rarely pick taps by hand. A design method (often a windowed sinc, using the
+[window functions](/learn/dsp/windows-and-leakage/) from Unit 2) turns a specification
+— "flat below 6 kHz, at least 60 dB down above 8 kHz" — into the tap values.
+GopherTrunk's channel filters, for instance, use a **Kaiser-windowed** design tuned
+for a stopband more than 60 dB below the passband.
+
+## Linear phase: keeping the shape
+
+A FIR filter whose taps are symmetric has **linear phase**: every frequency is delayed
+by the *same* amount of time. That matters because a digital signal's information is
+in its precise shape — the transitions between symbols. A filter that delayed
+different frequencies by different amounts would smear those transitions and cause
+errors. Linear phase preserves the shape, which is why FIR is preferred right before
+[demodulation](/learn/dsp/demodulation/).
+
+## Isolating a channel
+
+Here's the job FIR filters do constantly in a scanner. A capture is 2.4 MHz wide and
+full of signals; your channel is 12.5 kHz somewhere in it. After
+[mixing](/learn/dsp/mixing-and-downconversion/) that channel to zero, a low-pass FIR
+keeps only the narrow band around zero and rejects everything else:
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 130" role="img" aria-label="A wide spectrum with several peaks; a low-pass filter response shown as a box selects only the central narrow region, and the output spectrum keeps just that one channel." xmlns="http://www.w3.org/2000/svg">
+  <line x1="20" y1="60" x2="240" y2="60" stroke="currentColor" stroke-opacity="0.3"/>
+  <g stroke="currentColor" stroke-width="2"><line x1="60" y1="60" x2="60" y2="30"/><line x1="120" y1="60" x2="120" y2="20"/><line x1="180" y1="60" x2="180" y2="38"/></g>
+  <rect x="100" y="15" width="40" height="45" fill="none" stroke="currentColor" stroke-dasharray="4 3"/>
+  <text x="130" y="78" text-anchor="middle" font-size="9" fill="currentColor">keep this</text>
+  <text x="130" y="12" text-anchor="middle" font-size="9" fill="currentColor">FIR passband</text>
+  <text x="270" y="60" text-anchor="middle" font-size="16" fill="currentColor">&#8594;</text>
+  <line x1="300" y1="60" x2="510" y2="60" stroke="currentColor" stroke-opacity="0.3"/>
+  <line x1="405" y1="60" x2="405" y2="20" stroke="currentColor" stroke-width="2"/>
+  <text x="405" y="78" text-anchor="middle" font-size="9" fill="currentColor">one clean channel</text>
+</svg>
+<figcaption>A low-pass FIR keeps the narrow band around zero and rejects the rest — one channel pulled cleanly out of a crowded capture.</figcaption>
+</figure>
+
+That same filter also does double duty as the **anti-aliasing** guard before the rate
+is reduced — the subject of [decimation](/learn/dsp/decimation-and-resampling/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a FIR filter has no feedback, so it's always stable." markdown="0">
+  <p class="knowledge-check__q">Quick check: why is a FIR filter always stable?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It uses very few taps</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Its output depends only on inputs, never on past outputs — no feedback</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It runs at a low sample rate</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **FIR** filter is convolution with fixed **taps**; output depends only on inputs,
+  so it's **finite** and **stable**.
+- The **taps** set the response — low-pass, band-pass, high-pass; more taps mean a
+  sharper cutoff.
+- Symmetric taps give **linear phase**, preserving a digital signal's shape.
+- FIR filters **isolate a channel** and guard against aliasing before rate reduction.
+
+Next up: IIR filters, which trade some of that predictability for efficiency.

--- a/docs/learn/dsp/fixed-vs-floating-point.md
+++ b/docs/learn/dsp/fixed-vs-floating-point.md
@@ -1,0 +1,104 @@
+---
+slug: fixed-vs-floating-point
+title: Fixed vs floating point & performance
+description: Why real-time DSP cares how numbers are stored, the tradeoffs of fixed versus floating point, and simple ways to keep a sample pipeline fast.
+keywords: fixed point, floating point, dsp performance, real-time dsp, complex64, simd, dsp optimization, number representation
+level: advanced
+status: full
+prereq:
+  - dsp-in-gophertrunk
+faq:
+  - q: What is the difference between fixed-point and floating-point numbers?
+    a: Floating point stores a number with a mantissa and an exponent, so it covers a huge range of magnitudes with automatic scaling — easy to use but historically slower on small processors. Fixed point stores numbers as scaled integers with an implied decimal position, which is fast and compact but requires the programmer to manage scaling and guard against overflow.
+  - q: Why does performance matter so much in DSP?
+    a: DSP runs the same operations on a relentless stream of samples — millions per second — in real time. If processing can't keep up with the sample rate, buffers overflow and data is lost. So even small per-sample costs multiply enormously, and choices like number format, buffer reuse, and avoiding needless work directly decide whether a decoder keeps up.
+---
+
+# Fixed vs floating point & performance
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+DSP runs the same math on **millions of samples a second**, so how numbers are stored
+matters. **Floating point** is easy and accurate with automatic scaling;
+**fixed point** (scaled integers) is compact and fast on small hardware but needs
+manual scaling and overflow care. Beyond the format, **keeping up with the sample
+rate** — reusing buffers, decimating early, avoiding waste — is what makes a real-time
+pipeline work.
+</div>
+
+This last lesson steps back from *what* the DSP does to *how fast* it must do it — the
+practical concern that shapes real decoder code.
+
+## Two ways to store a number
+
+| | Floating point | Fixed point |
+|--|----------------|-------------|
+| Stores | mantissa + exponent | scaled integer |
+| Range | huge, auto-scaled | fixed, manual scaling |
+| Ease of use | simple, forgiving | error-prone (overflow) |
+| Speed | fast on modern CPUs/GPUs | fast on tiny/embedded hardware |
+| Typical home | desktops, servers, SDR software | DSP chips, microcontrollers, FPGAs |
+
+**Floating point** carries a scale factor with every value, so you rarely think about
+magnitudes — a filter's output just works whether the signal is tiny or huge.
+**Fixed point** stores values as integers with an agreed decimal position; it's leaner
+and was historically much faster on cheap processors, but you must scale carefully or a
+sum **overflows** and wraps into garbage.
+
+## What GopherTrunk uses
+
+GopherTrunk is **pure Go** and carries I/Q as **`complex64`** — a pair of 32-bit floats
+— through the whole pipeline. Floating point keeps the DSP code clean and accurate, and
+a modern CPU runs 32-bit float math plenty fast for the channel rates involved (tens to
+hundreds of kilohertz per channel after decimation). On a tiny embedded DSP chip you'd
+more likely see fixed point; in software radio on general-purpose CPUs, float wins on
+simplicity with no real speed penalty.
+
+## Keeping up with the stream
+
+Number format aside, the dominant performance rule in DSP is blunt: **you must process
+each sample before the next batch arrives.** Fall behind and buffers overflow and
+samples are dropped. A few habits keep a pipeline ahead:
+
+- **Decimate as early as possible.** Every stage after
+  [downconversion](/learn/dsp/decimation-and-resampling/) runs at the low channel rate,
+  not the wide capture rate — the single biggest saving.
+- **Reuse buffers.** Allocating a new slice per batch creates garbage-collection
+  pressure; reusing a fixed buffer avoids it (a real concern in
+  [Go](/learn/programming-go/slices-maps-generics/)).
+- **Do less per sample.** Precompute filter taps and NCO tables once; don't recompute
+  constants in the inner loop.
+- **Exploit the hardware.** Modern CPUs process several floats at once (SIMD); tight,
+  regular loops let the compiler use it.
+
+## The big picture
+
+You've now followed a signal from a radio wave all the way to bits, and seen the
+engineering that makes it run in real time. Pair this with the
+[RF & SDR module](/learn/rf-sdr/) for the physics, the
+[digital trunking module](/learn/digital-trunking/) for what the bits *mean*, and the
+[Go module](/learn/programming-go/) to read and write the code — together they are
+everything GopherTrunk is built from. Keep the
+[glossary](/learn/dsp/glossary/) handy as you explore the source.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — decimating early means every later stage runs at the low channel rate." markdown="0">
+  <p class="knowledge-check__q">Quick check: what's the single biggest way to keep a real-time DSP pipeline fast?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Use a higher bit depth</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Decimate to the channel rate early, so later stages run on far fewer samples</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Compute the FFT more often</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- DSP runs on **millions of samples a second**, so number storage and speed matter.
+- **Floating point** is simple and accurate; **fixed point** is compact and fast on
+  small hardware but needs manual scaling.
+- GopherTrunk uses **`complex64`** floats — simple and fast enough on modern CPUs.
+- The biggest performance lever is **decimating early**; also reuse buffers and do less
+  per sample.
+
+That's the module — from a stream of samples to decoded bits, and the code that runs it
+in real time. Keep exploring with the [glossary](/learn/dsp/glossary/).

--- a/docs/learn/dsp/gain-and-agc.md
+++ b/docs/learn/dsp/gain-and-agc.md
@@ -1,0 +1,106 @@
+---
+slug: gain-and-agc
+title: Gain & automatic gain control
+description: Keeping a signal at a usable amplitude as it fades — how an AGC loop works and why a demodulator needs stable levels to decide symbols correctly.
+keywords: agc, automatic gain control, gain, signal level, agc loop, dsp gain, level control, fading, symbol decision
+level: intermediate
+status: full
+prereq:
+  - demodulation
+faq:
+  - q: What is automatic gain control?
+    a: Automatic gain control (AGC) is a feedback loop that continuously adjusts a signal's amplitude to hold it near a target level. As the received signal fades or surges, the AGC turns its gain down or up to compensate, so downstream stages always see a roughly constant level regardless of how strong the signal arrives.
+  - q: Why does a demodulator need a stable signal level?
+    a: A symbol decision compares the signal against fixed decision levels — for C4FM, the four levels the frequency can take. If the overall amplitude drifts up or down, those comparisons shift and symbols get misread. AGC holds the level steady so the decision thresholds stay valid as the signal fades in and out.
+---
+
+# Gain & automatic gain control
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Received signals **fade and surge**, but a demodulator compares against **fixed
+decision levels**, so it needs a **stable amplitude**. **Automatic gain control (AGC)**
+is a feedback loop that measures the signal's level and adjusts **gain** to hold it near
+a target — turning gain down on strong signals, up on weak ones. It's what keeps symbol
+decisions valid as conditions change.
+</div>
+
+The last piece before bits are reliable: level. This lesson explains why amplitude
+matters to a decoder and how AGC keeps it under control.
+
+## Why level matters
+
+A [symbol decision](/learn/dsp/demodulation/) works by comparing the signal to fixed
+thresholds — for C4FM, deciding which of four frequency levels a symbol sits at. Those
+thresholds assume a known amplitude. But a real signal's strength **varies constantly**:
+a vehicle drives behind a hill, [multipath](/learn/rf-sdr/propagation/) fades in and
+out, the transmitter is near or far. If the amplitude drifts, the fixed decision levels
+no longer line up with the signal's levels, and symbols get misread.
+
+## AGC: a feedback loop for level
+
+**Automatic gain control** solves this the same way clock recovery solves timing — a
+feedback loop:
+
+```text
+1. measure the signal's current level (its power or magnitude)
+2. compare to the target level
+3. if too high, reduce gain; if too low, increase gain
+4. repeat continuously
+```
+
+The result is a signal held near a constant amplitude no matter how it arrives, so the
+demodulator's decision levels stay valid.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 120" role="img" aria-label="An input signal whose amplitude fades and surges over time, passing through an AGC block, emerging with a steady constant amplitude." xmlns="http://www.w3.org/2000/svg">
+  <path d="M10 60 q 15 -35 30 0 t 30 0 t 30 0" fill="none" stroke="currentColor" stroke-width="1.2"/>
+  <path d="M100 60 q 15 -12 30 0 t 30 0 t 30 0" fill="none" stroke="currentColor" stroke-width="1.2"/>
+  <text x="95" y="100" text-anchor="middle" font-size="9" fill="currentColor">fading input</text>
+  <rect x="210" y="42" width="90" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="255" y="63" text-anchor="middle" font-size="11" fill="currentColor">AGC</text>
+  <line x1="190" y1="59" x2="210" y2="59" stroke="currentColor" stroke-width="1.5" marker-end="url(#g1)"/>
+  <line x1="300" y1="59" x2="330" y2="59" stroke="currentColor" stroke-width="1.5" marker-end="url(#g1)"/>
+  <path d="M340 60 q 15 -22 30 0 t 30 0 t 30 0 t 30 0 t 30 0" fill="none" stroke="currentColor" stroke-width="1.4"/>
+  <text x="430" y="100" text-anchor="middle" font-size="9" fill="currentColor">steady output</text>
+  <defs><marker id="g1" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>AGC turns a fading, surging signal into one held at a steady level — so the demodulator's fixed decision thresholds keep working.</figcaption>
+</figure>
+
+## The tuning tradeoff
+
+An AGC has an **attack** and **decay** speed — how quickly it reacts. Too fast and it
+chases every noise wiggle, distorting the signal; too slow and it can't keep up with
+real fades. The loop is tuned to track genuine level changes while ignoring
+sample-to-sample noise — a balance, like every feedback loop in this unit.
+
+## Where it sits in the chain
+
+AGC typically runs on the isolated channel just before or alongside demodulation, and
+its level target is set from the **channel rate** and expected signal, so — like the
+[clock recovery loop](/learn/dsp/clock-and-symbol-recovery/) — the receiver behaves
+consistently regardless of the capture rate. The RF path frames the analog side of the
+same idea in [gain & AGC](/learn/rf-sdr/gain-and-agc/); here the point is that stable
+level is a *precondition* for reliable symbol decisions, and AGC is what guarantees it.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — AGC holds the level steady so fixed symbol-decision thresholds stay valid." markdown="0">
+  <p class="knowledge-check__q">Quick check: why does a demodulator need AGC?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">To shift the channel to zero frequency</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">To hold amplitude steady so fixed decision levels stay valid as the signal fades</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">To recover the symbol clock</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Received signals **fade and surge**, but decisions use **fixed levels** — so
+  amplitude must be **stable**.
+- **AGC** is a feedback loop: measure level, compare to target, adjust **gain**,
+  repeat.
+- Its **attack/decay** speed is tuned to track real fades without chasing noise.
+- Stable level is a **precondition** for reliable symbol decisions.
+
+Next up: Unit 5 — see the whole chain assembled in GopherTrunk's real code.

--- a/docs/learn/dsp/glossary.md
+++ b/docs/learn/dsp/glossary.md
@@ -155,3 +155,71 @@ float `complex64` throughout. See [Fixed vs floating point & performance](/learn
 
 **`complex64`** — Go's 64-bit complex type (a pair of 32-bit floats) carrying I/Q
 through GopherTrunk. See [Fixed vs floating point & performance](/learn/dsp/fixed-vs-floating-point/)
+
+## More signal fundamentals
+
+**Signal** — A quantity that varies over time carrying information; described by
+amplitude, frequency, and phase. See [What is a signal?](/learn/dsp/what-is-a-signal/)
+
+**Decibel (dB)** — A logarithmic ratio of power (10·log10) or amplitude (20·log10) that
+turns huge ranges into manageable numbers. See [Decibels & dynamic range](/learn/dsp/the-decibel-in-dsp/)
+
+**Dynamic range** — The span between the strongest and weakest signal a system can
+represent, set largely by bit depth. See [Decibels & dynamic range](/learn/dsp/the-decibel-in-dsp/)
+
+**STFT / spectrogram** — The short-time Fourier transform (FFT over sliding windows) and
+its time-frequency image. See [Spectrograms & the STFT](/learn/dsp/spectrograms-and-stft/)
+
+**Analytic signal / Hilbert transform** — The transform that turns a real signal into a
+complex one, removing the negative-frequency mirror. See [The analytic signal & Hilbert transform](/learn/dsp/the-analytic-signal/)
+
+## More on filters
+
+**Passband / stopband / transition** — The frequencies a filter keeps, the ones it
+rejects, and the ramp between them. See [Filter design basics](/learn/dsp/filter-design-basics/)
+
+**Ripple / order** — The allowed variation in a filter's response and a measure of its
+complexity. See [Filter design basics](/learn/dsp/filter-design-basics/)
+
+**Pulse shaping / RRC** — Shaping symbols (often with a root-raised-cosine filter) to
+limit bandwidth without inter-symbol interference. See [Matched filters & pulse shaping](/learn/dsp/matched-filters-and-pulse-shaping/)
+
+**Nyquist ISI criterion** — The condition under which pulses don't interfere at symbol
+sampling instants. See [Matched filters & pulse shaping](/learn/dsp/matched-filters-and-pulse-shaping/)
+
+## More on recovering data
+
+**Carrier recovery** — Correcting the frequency and phase offset between transmitter and
+receiver so symbols can be read. See [Carrier & frequency recovery](/learn/dsp/carrier-and-frequency-recovery/)
+
+**PLL / Costas loop** — Feedback loops that lock onto a carrier's phase and frequency
+(the Costas loop for suppressed-carrier PSK). See [Carrier & frequency recovery](/learn/dsp/carrier-and-frequency-recovery/)
+
+**Constellation** — The set of I/Q points a modulation uses to represent symbols (BPSK,
+QPSK, QAM). See [Constellations & symbol mapping](/learn/dsp/constellations-and-symbol-mapping/)
+
+**Equalization** — Undoing the distortion a multipath channel imposes, reducing
+inter-symbol interference. See [Equalization & multipath](/learn/dsp/equalization/)
+
+**Inter-symbol interference (ISI)** — Symbols smearing into their neighbours, caused by
+filtering or multipath. See [Equalization & multipath](/learn/dsp/equalization/)
+
+## Quality & coding
+
+**SNR / EVM / BER** — Signal-to-noise ratio, error-vector magnitude, and bit error rate —
+the three health metrics of a digital link. See [SNR, EVM & BER](/learn/dsp/snr-evm-and-ber/)
+
+**Eye diagram** — Overlapping symbol periods into an "eye" whose opening shows timing and
+noise margin. See [The eye diagram](/learn/dsp/the-eye-diagram/)
+
+**Forward error correction (FEC)** — Redundancy added before transmission that fixes bit
+errors at the receiver without retransmission. See [Error correction & framing](/learn/dsp/error-correction-and-framing/)
+
+**Interleaving / sync word / framing** — Spreading data to survive burst errors, marking
+frame starts, and grouping bits into frames. See [Error correction & framing](/learn/dsp/error-correction-and-framing/)
+
+**Ring buffer / block processing** — Processing samples in fixed blocks through a circular
+buffer to run DSP in real time. See [Real-time processing & buffering](/learn/dsp/real-time-and-buffering/)
+
+**Golden vectors / replay** — Known-good reference outputs and offline capture replay used
+to test and debug a signal path. See [Testing & debugging DSP](/learn/dsp/testing-and-debugging-dsp/)

--- a/docs/learn/dsp/glossary.md
+++ b/docs/learn/dsp/glossary.md
@@ -1,0 +1,157 @@
+---
+slug: glossary
+title: Glossary of DSP terms
+description: Plain-language definitions of digital-signal-processing terms — sample rate, Nyquist, I/Q, FFT, FIR, IIR, decimation, mixing, AGC, symbol recovery, and more — each linked to the lesson where it's explained.
+keywords: dsp glossary, signal processing terms, dsp terminology, fft fir iir definition, iq nyquist decimation glossary, dsp dictionary
+level: beginner
+status: full
+lesson_standalone: true
+---
+
+# Glossary of DSP terms
+
+Every term used across the [DSP module](/learn/dsp/), defined in plain language and
+linked to the lesson where it's explained in full. Skim it as a refresher, or use
+your browser's find (Ctrl/Cmd-F) to jump to a word. Terms are grouped by theme.
+
+## Signals as numbers
+
+**Digital signal processing (DSP)** — Manipulating a signal as a stream of numbers
+with arithmetic, in place of analog circuits. See [What is DSP?](/learn/dsp/what-is-dsp/)
+
+**Sample** — One measurement of a signal at an instant; DSP operates on sequences of
+them. See [What is DSP?](/learn/dsp/what-is-dsp/)
+
+**Sample rate** — How many samples are taken per second, setting the range of
+frequencies that can be captured. See [Sampling & quantization](/learn/dsp/sampling-and-quantization/)
+
+**Nyquist theorem** — You must sample above twice the highest frequency present, or
+higher components alias. See [Sampling & quantization](/learn/dsp/sampling-and-quantization/)
+
+**Aliasing** — The corruption where frequencies above half the sample rate fold down
+and masquerade as lower ones. See [Sampling & quantization](/learn/dsp/sampling-and-quantization/)
+
+**Quantization** — Rounding each sample to one of a fixed number of levels set by the
+bit depth, adding quantization noise. See [Sampling & quantization](/learn/dsp/sampling-and-quantization/)
+
+**Bit depth** — How many bits record each sample, setting amplitude precision. See
+[Sampling & quantization](/learn/dsp/sampling-and-quantization/)
+
+**I/Q (in-phase / quadrature)** — The two numbers per sample that form one complex
+value carrying amplitude and phase. See [Complex signals & I/Q](/learn/dsp/complex-signals-and-iq/)
+
+**Complex sample** — An I/Q pair treated as one number — an arrow whose length is
+amplitude and angle is phase. See [Complex signals & I/Q](/learn/dsp/complex-signals-and-iq/)
+
+**Baseband** — A signal centred on zero frequency, measured relative to the tuned
+centre. See [Complex signals & I/Q](/learn/dsp/complex-signals-and-iq/)
+
+**Negative frequency** — A component below the tuned centre; I/Q is what lets it be
+told apart from one above. See [Complex signals & I/Q](/learn/dsp/complex-signals-and-iq/)
+
+## The frequency domain
+
+**Fourier transform** — Re-describes a signal from time to frequency, revealing which
+sine waves it's made of. See [The Fourier transform](/learn/dsp/the-fourier-transform/)
+
+**Time / frequency domain** — Two equivalent views of a signal: amplitude over time,
+or energy over frequency. See [The Fourier transform](/learn/dsp/the-fourier-transform/)
+
+**Spectrum** — The distribution of a signal's energy across frequency. See [The Fourier transform](/learn/dsp/the-fourier-transform/)
+
+**DFT / FFT** — The Discrete Fourier Transform on sampled data, and the Fast algorithm
+that computes it in ~N·log N. See [The FFT in practice](/learn/dsp/the-fft/)
+
+**Bin** — One of the equal frequency slots an FFT divides the bandwidth into; bin width
+= sample rate ÷ FFT size. See [The FFT in practice](/learn/dsp/the-fft/)
+
+**Waterfall** — A stack of FFTs over time, showing frequency across and time down. See
+[The FFT in practice](/learn/dsp/the-fft/)
+
+**Spectral leakage** — A single tone smearing into neighbouring bins when it doesn't fit
+a whole number of cycles in the FFT block. See [Windows & spectral leakage](/learn/dsp/windows-and-leakage/)
+
+**Window function** — A taper applied to an FFT block to reduce leakage; Hann, Hamming,
+Blackman, Kaiser. See [Windows & spectral leakage](/learn/dsp/windows-and-leakage/)
+
+## Filters
+
+**Convolution** — Sliding a filter's taps along a signal, multiplying and summing to
+produce each output — how filters run in time. See [Convolution & impulse response](/learn/dsp/convolution-and-impulse-response/)
+
+**Impulse response** — A filter's output for a single spike; it fully defines the
+filter. See [Convolution & impulse response](/learn/dsp/convolution-and-impulse-response/)
+
+**Taps / coefficients** — The weights that define a filter's response. See [FIR filters](/learn/dsp/fir-filters/)
+
+**FIR (finite impulse response)** — A filter with no feedback — always stable, can have
+linear phase; the channel-isolation workhorse. See [FIR filters](/learn/dsp/fir-filters/)
+
+**Linear phase** — Delaying all frequencies equally, so a signal's shape isn't
+distorted; a property of symmetric FIR filters. See [FIR filters](/learn/dsp/fir-filters/)
+
+**IIR (infinite impulse response)** — A filter with feedback — sharp and cheap but can
+be unstable and lacks linear phase. See [IIR filters](/learn/dsp/iir-filters/)
+
+**Poles and zeros** — The feedback and feed-forward terms of an IIR filter; misplaced
+poles cause instability. See [IIR filters](/learn/dsp/iir-filters/)
+
+**Decimation** — Lowering the sample rate by filtering then keeping every Nth sample.
+See [Decimation & resampling](/learn/dsp/decimation-and-resampling/)
+
+**Interpolation** — Raising the sample rate by inserting and smoothing samples. See
+[Decimation & resampling](/learn/dsp/decimation-and-resampling/)
+
+**Resampling** — Changing the sample rate by a rational factor (interpolate then
+decimate), often via a polyphase filter. See [Decimation & resampling](/learn/dsp/decimation-and-resampling/)
+
+## From signal to bits
+
+**Mixing** — Multiplying by an oscillator's sinusoid to shift the spectrum in
+frequency. See [Mixing & downconversion](/learn/dsp/mixing-and-downconversion/)
+
+**NCO (numerically controlled oscillator)** — Software that generates a complex sine
+wave at a set frequency — the digital local oscillator. See [Mixing & downconversion](/learn/dsp/mixing-and-downconversion/)
+
+**Downconversion** — Mixing a channel down to zero (baseband). See [Mixing & downconversion](/learn/dsp/mixing-and-downconversion/)
+
+**DDC (digital downconverter)** — Mix + filter + decimate combined into one channel-
+extraction stage. See [Mixing & downconversion](/learn/dsp/mixing-and-downconversion/)
+
+**Demodulation** — Recovering the message from a carrier; AM = magnitude, FM = phase-
+change rate, PM = angle. See [Demodulation in code](/learn/dsp/demodulation/)
+
+**Discriminator** — The block that FM-demodulates by measuring phase change between
+samples. See [Demodulation in code](/learn/dsp/demodulation/)
+
+**C4FM** — The four-level FM used by P25 Phase 1; each symbol carries two bits at 4800
+symbols/second. See [Demodulation in code](/learn/dsp/demodulation/)
+
+**Symbol** — One transmitted unit carrying one or more bits, read at its centre. See
+[Clock & symbol recovery](/learn/dsp/clock-and-symbol-recovery/)
+
+**Clock / symbol recovery** — Finding where each symbol begins without a shared clock,
+via a timing loop. See [Clock & symbol recovery](/learn/dsp/clock-and-symbol-recovery/)
+
+**Timing error detector** — Measures whether the current sampling instant is early or
+late. See [Clock & symbol recovery](/learn/dsp/clock-and-symbol-recovery/)
+
+**Matched filter** — A filter shaped to the transmitted pulse that maximizes SNR at
+symbol centres. See [Clock & symbol recovery](/learn/dsp/clock-and-symbol-recovery/)
+
+**AGC (automatic gain control)** — A feedback loop that holds a signal's amplitude near
+a target as it fades. See [Gain & automatic gain control](/learn/dsp/gain-and-agc/)
+
+## In practice
+
+**Channel rate** — The fixed sample rate a DDC resamples every channel to (48 kHz C4FM,
+144 kHz TETRA in GopherTrunk). See [DSP in GopherTrunk](/learn/dsp/dsp-in-gophertrunk/)
+
+**Rate-invariance** — The property that a decoder behaves the same at any capture rate
+because the DDC normalizes to the channel rate. See [DSP in GopherTrunk](/learn/dsp/dsp-in-gophertrunk/)
+
+**Fixed point / floating point** — Two ways to store numbers; GopherTrunk uses 32-bit
+float `complex64` throughout. See [Fixed vs floating point & performance](/learn/dsp/fixed-vs-floating-point/)
+
+**`complex64`** — Go's 64-bit complex type (a pair of 32-bit floats) carrying I/Q
+through GopherTrunk. See [Fixed vs floating point & performance](/learn/dsp/fixed-vs-floating-point/)

--- a/docs/learn/dsp/iir-filters.md
+++ b/docs/learn/dsp/iir-filters.md
@@ -1,0 +1,104 @@
+---
+slug: iir-filters
+title: IIR filters
+description: Infinite impulse response filters — feedback, poles and zeros, far fewer taps than FIR, and the stability and phase tradeoffs that come with them.
+keywords: iir filter, infinite impulse response, feedback filter, biquad, poles and zeros, filter stability, iir vs fir, dsp iir
+level: advanced
+status: full
+prereq:
+  - fir-filters
+faq:
+  - q: What is the difference between FIR and IIR filters?
+    a: A FIR filter computes each output only from inputs, so it has no feedback and is always stable, but needs many taps for a sharp response. An IIR filter feeds past outputs back in, so it achieves a similar sharpness with far fewer coefficients — at the cost of possible instability and non-linear phase. FIR is safe and precise; IIR is cheap and compact.
+  - q: When would I choose an IIR filter over FIR?
+    a: Choose IIR when compute or memory is tight and you need a sharp response for few operations — for example a simple audio tone control, DC blocking, or an envelope smoother. Choose FIR when you need linear phase (to avoid distorting a digital signal's shape) or guaranteed stability, which is why channel filters before a demodulator are usually FIR.
+---
+
+# IIR filters
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+An **IIR (infinite impulse response)** filter feeds **past outputs** back into the
+computation. That feedback lets it match a FIR filter's sharpness with **far fewer
+coefficients** — cheap and compact — but it can be **unstable** if designed carelessly
+and generally lacks **linear phase**. The FIR-vs-IIR choice is precision and safety
+versus efficiency.
+</div>
+
+FIR filters are safe but can be expensive. IIR filters are the efficient alternative,
+with strings attached. This lesson covers the tradeoff.
+
+## Feedback: the defining difference
+
+A [FIR filter](/learn/dsp/fir-filters/) computes each output purely from inputs. An
+**IIR** filter also mixes in its own **previous outputs**:
+
+```text
+output[n] = b0*x[n] + b1*x[n-1] + ...        (feed-forward, like FIR)
+          - a1*output[n-1] - a2*output[n-2]  (feedback — the IIR part)
+```
+
+That feedback loop means a single input impulse can keep echoing through the output
+essentially forever — hence **infinite** impulse response. It also means an IIR filter
+can achieve a steep frequency response with only a handful of coefficients, where a FIR
+would need dozens or hundreds.
+
+## Poles, zeros, and stability
+
+IIR filters are described by **poles** and **zeros** — the feedback and feed-forward
+terms, respectively. The zeros carve notches; the poles create peaks and set the
+sharpness. But poles are dangerous: place one wrong and the feedback amplifies its own
+output each pass, and the filter **blows up** to infinity. A FIR filter can never do
+this; an IIR filter must be designed to keep its poles "inside the unit circle" to stay
+**stable**.
+
+| | FIR | IIR |
+|--|-----|-----|
+| Feedback | none | yes |
+| Stability | always stable | must be designed carefully |
+| Phase | can be linear | generally non-linear |
+| Cost for a sharp cutoff | many taps | few coefficients |
+
+## The phase cost
+
+Because of the feedback, IIR filters delay different frequencies by different amounts —
+**non-linear phase**. For audio smoothing or a DC blocker that doesn't matter. But for
+a digital signal about to be [demodulated](/learn/dsp/demodulation/), non-linear phase
+smears the symbol transitions that carry the data — which is why the selective channel
+filter in a decoder is almost always FIR, and IIR is reserved for less shape-critical
+jobs.
+
+## Where IIR earns its place
+
+Common IIR uses in a radio pipeline:
+
+- **DC blocking** — a one-pole high-pass that removes a constant offset from the I/Q
+  stream, cheaply.
+- **Envelope / power smoothing** — averaging a signal's power for an
+  [AGC](/learn/dsp/gain-and-agc/) loop.
+- **Simple tone shaping** on decoded audio.
+
+The rule of thumb: reach for **IIR when efficiency matters and phase doesn't**, and
+**FIR when phase linearity or guaranteed stability matters**.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — feedback lets IIR filters be sharp and cheap, but risks instability." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does an IIR filter use that a FIR filter does not?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="correct">Feedback from its own past outputs</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">A higher sample rate</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Complex I/Q samples</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- An **IIR** filter feeds **past outputs** back in, giving an **infinite** impulse
+  response.
+- Feedback buys a **sharp response for few coefficients** — but risks **instability**
+  (poles) and gives **non-linear phase**.
+- **FIR** is chosen for linear phase and guaranteed stability (channel filtering);
+  **IIR** for cheap jobs like DC blocking and smoothing.
+- The tradeoff: precision and safety (FIR) versus efficiency (IIR).
+
+Next up: changing a signal's sample rate safely — decimation and resampling.

--- a/docs/learn/dsp/index.md
+++ b/docs/learn/dsp/index.md
@@ -1,0 +1,32 @@
+---
+layout: learn-hub
+learn_module: dsp
+permalink: /learn/dsp/
+title: Learn DSP — from radio samples to decoded bits
+description: A free, structured path through the digital signal processing behind software radio — sampling, I/Q, the Fourier transform, filters, downconversion, demodulation, and clock recovery, mapped onto a real decoder.
+keywords: learn dsp, digital signal processing tutorial, dsp for sdr, fft tutorial, fir filter, iir filter, downconversion, demodulation, clock recovery, i/q samples
+---
+
+Software-defined radio is really just digital signal processing wearing an
+antenna. The [RF & SDR path](/learn/rf-sdr/) shows you what a radio wave *is*;
+this path shows you what your computer *does* with it once the samples start
+arriving — the arithmetic that turns a stream of numbers into voice, data, and
+trunking control messages.
+
+**Who this is for.** Anyone comfortable with the idea that an SDR hands you a
+list of numbers and curious about what happens next. No advanced maths is
+assumed — if you can follow "add these up" and "slide this along", you can
+follow every lesson here. A little from the RF & SDR path helps, and we link
+back to it constantly, but you can start cold. Already know the DFT and just
+want the applied chain? Jump to [DSP in
+GopherTrunk](/learn/dsp/dsp-in-gophertrunk/).
+
+**How the path works.** Five units build the pipeline one stage at a time.
+Unit 1 turns a wave into an array of numbers. Unit 2 shows you the frequency
+domain — the single most useful way to look at a signal. Unit 3 is filters:
+keeping the signal you want and discarding the rest. Unit 4 tunes,
+demodulates, and recovers the data hidden in the wave. Unit 5 puts the whole
+chain together the way a real decoder does and maps every stage onto
+GopherTrunk's actual code. Mark lessons complete as you go — your progress is
+saved in your browser. New here? **[Start with lesson 1: What is
+DSP?](what-is-dsp/)**

--- a/docs/learn/dsp/matched-filters-and-pulse-shaping.md
+++ b/docs/learn/dsp/matched-filters-and-pulse-shaping.md
@@ -1,0 +1,112 @@
+---
+slug: matched-filters-and-pulse-shaping
+title: Matched filters & pulse shaping
+description: Root-raised-cosine filters, the Nyquist no-ISI criterion, and why a matched filter at the receiver maximizes SNR right where each symbol is decided.
+keywords: matched filter, pulse shaping, root raised cosine, rrc filter, nyquist isi criterion, raised cosine, intersymbol interference, symbol filter
+level: advanced
+status: full
+prereq:
+  - fir-filters
+  - convolution-and-impulse-response
+faq:
+  - q: What is a matched filter and why does it maximize SNR?
+    a: "A matched filter is a filter whose impulse response is a time-reversed copy of the transmitted symbol pulse. Correlating the incoming signal against the exact pulse shape gathers all of that symbol's energy into a single peak at the decision instant, while noise, being uncorrelated with the pulse, does not add up the same way. The result is the highest possible signal-to-noise ratio at the moment the symbol is decided."
+  - q: Why split the pulse shaping into a root-raised-cosine at each end?
+    a: "The transmitter and receiver each apply a root-raised-cosine filter so that their cascade equals a full raised-cosine response. The full raised cosine satisfies the Nyquist no-ISI criterion, so symbols do not smear into their neighbours at the sampling instants, while splitting it in half also makes the receiver's filter a matched filter for the transmitted pulse — one design serves both goals at once."
+---
+
+# Matched filters & pulse shaping
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Square symbol pulses spread forever in frequency, so transmitters **shape** them. A
+**raised-cosine** pulse satisfies the **Nyquist no-ISI criterion** — it is zero at every
+*other* symbol's sampling instant, so neighbours don't smear together. Split it as a
+**root-raised-cosine (RRC)** filter at *both* transmitter and receiver: their cascade is
+a full raised cosine, and the receiver half is also a **matched filter** that maximizes
+**SNR** exactly where each symbol is decided.
+</div>
+
+The [FIR](/learn/dsp/fir-filters/) lesson built filters that select frequency bands. This
+lesson uses a filter for a different job: shaping the symbols themselves so they can be
+read cleanly. It sits right before symbol decisions in the
+[demodulation](/learn/dsp/demodulation/) chain.
+
+## The problem with square pulses
+
+The obvious way to send a symbol is a rectangular pulse — hold a level for one symbol
+period. But a sharp-edged pulse occupies an enormous bandwidth (its spectrum is a sinc
+that trails off slowly), spilling into adjacent channels. Band-limit it crudely and its
+tails ring into neighbouring symbols — **inter-symbol interference (ISI)**, where each
+symbol contaminates the ones around it.
+
+## The Nyquist no-ISI criterion
+
+Harry Nyquist's insight: a pulse can be band-limited *and* ISI-free if its shape is zero
+at every symbol instant except its own. Then, sampled at the symbol centres, each pulse
+contributes only to *its* sample and nothing to the others — even though the pulses
+overlap in between.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 150" role="img" aria-label="A raised-cosine pulse peaking at the centre symbol instant and crossing zero exactly at the neighbouring symbol instants marked by vertical dashed lines." xmlns="http://www.w3.org/2000/svg">
+  <line x1="20" y1="110" x2="500" y2="110" stroke="currentColor" stroke-opacity="0.3"/>
+  <g stroke="currentColor" stroke-opacity="0.3" stroke-dasharray="3 3">
+    <line x1="120" y1="20" x2="120" y2="120"/><line x1="200" y1="20" x2="200" y2="120"/>
+    <line x1="280" y1="20" x2="280" y2="120"/><line x1="360" y1="20" x2="360" y2="120"/><line x1="440" y1="20" x2="440" y2="120"/>
+  </g>
+  <path d="M40 108 Q 120 118 160 112 Q 200 104 220 60 Q 260 -10 300 60 Q 320 104 360 112 Q 400 118 480 108" fill="none" stroke="currentColor" stroke-width="2"/>
+  <circle cx="280" cy="35" r="3" fill="currentColor"/>
+  <text x="280" y="24" text-anchor="middle" font-size="9" fill="currentColor">its own instant (peak)</text>
+  <text x="150" y="132" text-anchor="middle" font-size="9" fill="currentColor">zero at neighbours</text>
+</svg>
+<figcaption>A raised-cosine pulse peaks at its own symbol instant and is exactly zero at every neighbour's — so overlapping pulses cause no ISI when sampled at the centres.</figcaption>
+</figure>
+
+The **raised-cosine** pulse is the classic shape that meets this criterion. A roll-off
+factor sets how gently its spectrum tapers — a small roll-off is bandwidth-tight but
+rings more; a larger one is gentler but wider.
+
+## Splitting the filter: root-raised-cosine
+
+Here is the elegant part. Rather than shaping the whole pulse at the transmitter, the
+system splits the raised cosine into two **root-raised-cosine (RRC)** halves — one at the
+transmitter, one at the receiver — so that:
+
+```text
+RRC(transmit)  *  RRC(receive)  =  full raised cosine  (no ISI)
+```
+
+That single choice buys two things at once:
+
+- The **cascade** is a full raised cosine, so the **Nyquist no-ISI** condition holds at
+  the decision instants.
+- The receiver's RRC is a **matched filter** for the transmitted pulse — its impulse
+  response is the pulse shape reversed — which maximizes SNR at the symbol centre.
+
+## Why the matched filter wins
+
+A matched filter correlates the incoming signal against the exact pulse it is looking
+for. All of a symbol's energy piles up into one peak at the sampling instant, while
+noise — uncorrelated with the pulse — does not accumulate the same way. No other linear
+filter gives a better signal-to-noise ratio at that instant, which is why the RX RRC sits
+right before the [symbol decision and timing loop](/learn/dsp/clock-and-symbol-recovery/).
+Cleaner peaks mean cleaner symbols and a lower [bit error rate](/learn/dsp/snr-evm-and-ber/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the two RRC halves cascade into a raised cosine (no ISI) and the RX half is a matched filter." markdown="0">
+  <p class="knowledge-check__q">Quick check: why is pulse shaping split into a root-raised-cosine at both ends?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">To double the data rate</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">So their cascade is a no-ISI raised cosine and the receiver half is a matched filter</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">To convert the signal to real-valued samples</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Square pulses waste bandwidth and cause **inter-symbol interference (ISI)**.
+- A **raised-cosine** pulse meets the **Nyquist no-ISI criterion** — zero at every other symbol instant.
+- Splitting it into **root-raised-cosine** halves at TX and RX yields no ISI *and* a matched filter.
+- The **matched filter** maximizes **SNR** at the decision instant, lowering the error rate.
+
+Next up: multiplying by an oscillator to shift a channel to baseband — mixing and downconversion.

--- a/docs/learn/dsp/mixing-and-downconversion.md
+++ b/docs/learn/dsp/mixing-and-downconversion.md
@@ -1,0 +1,106 @@
+---
+slug: mixing-and-downconversion
+title: Mixing & downconversion
+description: Multiplying by a local oscillator to shift a signal to baseband — the digital downconverter (DDC) that centres a channel at zero before it is decoded.
+keywords: mixing, downconversion, digital downconverter, ddc, local oscillator, nco, frequency shift, baseband, dsp mixing
+level: intermediate
+status: full
+prereq:
+  - complex-signals-and-iq
+faq:
+  - q: What does mixing do in DSP?
+    a: Mixing multiplies your signal by a complex sinusoid from a numerically controlled oscillator. Multiplying two sinusoids shifts frequencies, so this moves your chosen channel up or down the spectrum. Mixing a channel down so it sits at zero frequency is called downconversion, and it centres the channel before filtering and demodulation.
+  - q: What is a numerically controlled oscillator?
+    a: A numerically controlled oscillator (NCO) is software that generates a complex sine wave one sample at a time at a frequency you set — the digital equivalent of a local oscillator. You multiply the incoming I/Q by the NCO's output to shift the spectrum by exactly that frequency.
+---
+
+# Mixing & downconversion
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Mixing** multiplies the signal by a complex sinusoid from a **numerically
+controlled oscillator (NCO)**, which **shifts** the whole spectrum in frequency.
+**Downconversion** mixes your chosen channel down to **zero** so it sits at baseband,
+ready to be [filtered](/learn/dsp/fir-filters/) and
+[demodulated](/learn/dsp/demodulation/). Mix, filter, and resample together make a
+**digital downconverter (DDC)**.
+</div>
+
+Your channel is somewhere off-centre in a wide capture. This lesson is how you slide
+it to the middle — the first step of turning a channel into decoded data.
+
+## Multiplying shifts frequency
+
+Here's the key fact: **multiplying two sinusoids shifts frequencies**. Multiply your
+signal by a complex sine wave of frequency f and every component of the signal moves by
+f. Pick f to be *minus* your channel's offset from centre, and the channel lands
+exactly at zero.
+
+The complex sine wave comes from a **numerically controlled oscillator (NCO)** — software
+that produces a rotating I/Q value one sample at a time at whatever frequency you dial
+in. It's the digital version of the **local oscillator** in an analog radio.
+
+```text
+input channel at +200 kHz  ×  NCO at -200 kHz  =  channel now at 0 Hz
+```
+
+## Why move it to zero?
+
+Downconverting to zero (**baseband**) makes everything after it simpler:
+
+- The [low-pass filter](/learn/dsp/fir-filters/) that isolates the channel is a plain
+  filter around zero — no need to design a band-pass at some arbitrary frequency.
+- [Decimation](/learn/dsp/decimation-and-resampling/) can then shed the now-unneeded
+  bandwidth.
+- The [demodulator](/learn/dsp/demodulation/) works on a channel centred at zero,
+  where phase and frequency changes are measured relative to nothing but the channel
+  itself.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 120" role="img" aria-label="A spectrum with a channel off to the right of centre; after mixing, the same channel is centred at zero frequency." xmlns="http://www.w3.org/2000/svg">
+  <line x1="20" y1="70" x2="230" y2="70" stroke="currentColor" stroke-opacity="0.3"/>
+  <line x1="125" y1="70" x2="125" y2="60" stroke="currentColor" stroke-opacity="0.5"/>
+  <text x="125" y="88" text-anchor="middle" font-size="8" fill="currentColor">0</text>
+  <line x1="185" y1="70" x2="185" y2="30" stroke="currentColor" stroke-width="2"/>
+  <text x="185" y="24" text-anchor="middle" font-size="8" fill="currentColor">channel</text>
+  <text x="270" y="70" text-anchor="middle" font-size="14" fill="currentColor">&#8594;</text>
+  <text x="270" y="55" text-anchor="middle" font-size="8" fill="currentColor">mix</text>
+  <line x1="300" y1="70" x2="510" y2="70" stroke="currentColor" stroke-opacity="0.3"/>
+  <line x1="405" y1="70" x2="405" y2="60" stroke="currentColor" stroke-opacity="0.5"/>
+  <text x="405" y="88" text-anchor="middle" font-size="8" fill="currentColor">0</text>
+  <line x1="405" y1="70" x2="405" y2="30" stroke="currentColor" stroke-width="2"/>
+  <text x="405" y="24" text-anchor="middle" font-size="8" fill="currentColor">now centred</text>
+</svg>
+<figcaption>Mixing by the negative of the channel's offset slides it to zero, ready for filtering and decoding.</figcaption>
+</figure>
+
+## The digital downconverter (DDC)
+
+Put the three operations together — **mix** to zero, **low-pass filter** to isolate,
+**decimate** to the channel rate — and you have a **digital downconverter**, the
+front door of nearly every software decoder. GopherTrunk has two distinct DDC
+implementations for different jobs: a single-channel `Downconverter` used by the
+replay path, and a multi-tap wideband `DDCBank` that extracts many channels from one
+capture at once. They're separate code paths that happen to do the same conceptual
+thing — a distinction worth remembering when you read the
+[applied lesson](/learn/dsp/dsp-in-gophertrunk/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — mixing by the channel's negative offset shifts it to zero." markdown="0">
+  <p class="knowledge-check__q">Quick check: to bring a channel sitting at +200 kHz down to zero, you mix it with an NCO at…</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">+200 kHz</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">-200 kHz</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">+400 kHz</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Mixing** multiplies by an **NCO**'s complex sinusoid, **shifting** the spectrum.
+- **Downconversion** mixes a channel to **zero** (baseband) for simpler downstream DSP.
+- Mix + filter + decimate = a **digital downconverter (DDC)**.
+- GopherTrunk has two DDCs — a single-channel one and a wideband bank — for different
+  jobs.
+
+Next up: recovering the actual message — demodulation.

--- a/docs/learn/dsp/real-time-and-buffering.md
+++ b/docs/learn/dsp/real-time-and-buffering.md
@@ -1,0 +1,116 @@
+---
+slug: real-time-and-buffering
+title: Real-time processing & buffering
+description: Block processing, ring buffers, latency, and keeping up with the sample stream — the engineering that makes DSP run live instead of offline.
+keywords: real-time dsp, block processing, ring buffer, circular buffer, latency vs throughput, sample rate keep up, overrun, buffering
+level: advanced
+status: full
+prereq:
+  - decimation-and-resampling
+faq:
+  - q: Why is DSP done in blocks instead of one sample at a time?
+    a: "Processing a whole block of samples at once amortizes per-call overhead, keeps data in cache, and lets algorithms like the FFT work on a batch, so it is far more efficient than handling single samples. The tradeoff is latency: the system must wait to collect a full block before it can start, so bigger blocks mean higher throughput but longer delay before results appear."
+  - q: What is a ring buffer and why is it used in real-time DSP?
+    a: "A ring buffer is a fixed-size array treated as if its ends were joined, with a write pointer where new samples arrive and a read pointer where the processor consumes them. It lets a fast producer and a slower consumer run at their own paces without copying or reallocating memory, absorbing short bursts. If the producer laps the consumer the buffer overruns and samples are lost — the classic real-time failure."
+---
+
+# Real-time processing & buffering
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Live DSP must consume samples **as fast as they arrive** — forever. It does this in
+**blocks** (efficient, but each block adds **latency**), passed between producer and
+consumer through a **ring buffer** that absorbs timing jitter. The governing rule:
+**average throughput must meet or beat the sample rate**, or the buffer **overruns** and
+samples are lost. This is the engineering that turns the algorithms of this module into a
+scanner that keeps up.
+</div>
+
+Every prior lesson assumed the samples were simply *there*. This one is about the
+relentless clock behind them: an SDR delivers millions of samples per second, every
+second, and the pipeline must never fall behind. It builds on
+[decimation](/learn/dsp/decimation-and-resampling/) — the first tool for coping with the
+firehose.
+
+## The firehose problem
+
+A capture at 2.4 MS/s of [complex I/Q](/learn/dsp/complex-signals-and-iq/) is 2.4 million
+samples arriving *every second*, and they never stop. Unlike an offline file you can
+process at leisure, a live stream imposes a hard deadline: on average you must finish each
+second's work within that second. The single most important defence is to
+[decimate](/learn/dsp/decimation-and-resampling/) to a narrow channel rate as early as
+possible, shrinking the stream before the expensive stages ever see it.
+
+## Block processing
+
+You rarely process one sample at a time. Instead samples are gathered into **blocks** (a
+few hundred to a few thousand) and handled together. Blocks amortize function-call and
+loop overhead, keep data in cache, and suit batch algorithms like the
+[FFT](/learn/dsp/the-fft/). The cost is **latency**: the system must wait for a block to
+fill before it can start, so results always trail real time by at least one block.
+
+```text
+bigger blocks  -> higher throughput, higher latency
+smaller blocks -> lower latency, more per-block overhead
+```
+
+Choosing block size is choosing a point on that curve — small enough to feel responsive,
+large enough to stay efficient.
+
+## Ring buffers: decoupling producer and consumer
+
+The SDR (producer) and the DSP (consumer) don't run in perfect lockstep — the OS
+schedules them unevenly, and processing time varies block to block. A **ring buffer** (a
+circular buffer) sits between them to absorb that jitter. It's a fixed array with a
+**write pointer** where new samples land and a **read pointer** where they're consumed;
+both wrap around the end back to the start.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 300 170" role="img" aria-label="A ring buffer drawn as a circle of cells with a write pointer where a producer adds samples and a read pointer where a consumer removes them, the arc between them marked as buffered samples." xmlns="http://www.w3.org/2000/svg">
+  <circle cx="150" cy="85" r="60" fill="none" stroke="currentColor" stroke-opacity="0.4"/>
+  <g stroke="currentColor" stroke-opacity="0.3">
+    <line x1="150" y1="25" x2="150" y2="35"/><line x1="210" y1="85" x2="200" y2="85"/>
+    <line x1="150" y1="145" x2="150" y2="135"/><line x1="90" y1="85" x2="100" y2="85"/>
+  </g>
+  <path d="M150 25 A 60 60 0 0 1 210 85" fill="none" stroke="currentColor" stroke-width="4" stroke-opacity="0.5"/>
+  <line x1="150" y1="85" x2="150" y2="25" stroke="currentColor" stroke-width="1.5"/>
+  <text x="150" y="18" text-anchor="middle" font-size="9" fill="currentColor">write (producer)</text>
+  <line x1="150" y1="85" x2="210" y2="85" stroke="currentColor" stroke-width="1.5"/>
+  <text x="216" y="88" font-size="9" fill="currentColor">read</text>
+  <text x="185" y="45" font-size="8" fill="currentColor">buffered</text>
+</svg>
+<figcaption>A ring buffer: the producer writes ahead, the consumer reads behind, and the arc between them is the cushion that absorbs timing jitter.</figcaption>
+</figure>
+
+The gap between the pointers is slack that soaks up short bursts. In GopherTrunk this
+decoupling is often expressed with **Go channels** between concurrent stages — the same
+producer/consumer pattern with the buffer built in.
+
+## Overruns: the real-time failure
+
+The buffer has a limit. If the consumer is persistently too slow, the write pointer
+catches the read pointer — an **overrun** — and incoming samples are dropped. Dropped
+samples are gaps in the signal, and gaps break [symbol recovery](/learn/dsp/clock-and-symbol-recovery/)
+and [framing](/learn/dsp/error-correction-and-framing/) downstream. A buffer can hide a
+*momentary* slowness, but it cannot fix a consumer whose **average** speed is below the
+sample rate — that only ends one way. The fixes are all about average throughput: decimate
+early, keep the hot loops tight, and mind the number format, which the next lesson takes up.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a ring buffer absorbs momentary jitter, but average throughput must still meet the sample rate." markdown="0">
+  <p class="knowledge-check__q">Quick check: a ring buffer prevents dropped samples only if…</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">it is made large enough, no matter how slow the consumer is</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">the consumer's average throughput meets or beats the sample rate</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">the block size is set to exactly one sample</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Live DSP faces a hard deadline: keep up with a never-ending **sample stream**.
+- **Block processing** is efficient but adds **latency** — a throughput-vs-delay tradeoff.
+- A **ring buffer** decouples producer and consumer, absorbing timing **jitter**.
+- Buffers hide momentary slowness only; sustained under-speed causes **overruns** and lost samples.
+
+Next up: the walkthrough tying every stage together — DSP in GopherTrunk.

--- a/docs/learn/dsp/sampling-and-quantization.md
+++ b/docs/learn/dsp/sampling-and-quantization.md
@@ -1,0 +1,105 @@
+---
+slug: sampling-and-quantization
+title: Sampling & quantization
+description: Turning a continuous wave into samples — sample rate, the Nyquist limit, bit depth, and the aliasing and quantization noise that come with digitizing a signal.
+keywords: sampling, quantization, sample rate, nyquist theorem, aliasing, bit depth, analog to digital, adc, dsp sampling
+level: beginner
+status: full
+prereq:
+  - what-is-dsp
+faq:
+  - q: What is the Nyquist theorem?
+    a: The Nyquist–Shannon sampling theorem says you must sample at more than twice the highest frequency present in a signal to capture it faithfully. Sample slower and higher frequencies fold down and masquerade as lower ones — a corruption called aliasing. So to capture a 1 MHz-wide signal you need a sample rate above 2 MHz.
+  - q: What is the difference between sample rate and bit depth?
+    a: Sample rate is how often you measure the signal (samples per second), which sets the range of frequencies you can capture. Bit depth is how precisely you record each measurement (bits per sample), which sets how finely you can distinguish amplitudes and therefore the quantization noise floor. One is about time, the other about amplitude.
+---
+
+# Sampling & quantization
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Sampling** measures a wave at a fixed **sample rate**; the **Nyquist** limit says
+that rate must exceed **twice** the highest frequency, or higher components **alias**
+into false low ones. **Quantization** rounds each sample to a fixed **bit depth**,
+adding a little **quantization noise**. Together they turn a continuous wave into the
+number stream DSP works on.
+</div>
+
+Lesson 1 said DSP works on a stream of numbers. This lesson is how a real,
+continuous wave *becomes* that stream — and the two ways digitizing can go wrong.
+
+## Sampling: measuring on a clock
+
+An analog-to-digital converter measures the signal at a steady tick — the **sample
+rate**, in samples per second (often written S/s, or MS/s for millions). An SDR
+dongle might run at 2.4 MS/s: 2.4 million measurements every second.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 130" role="img" aria-label="A smooth sine wave with evenly spaced sample points marked on it as dots." xmlns="http://www.w3.org/2000/svg">
+  <line x1="10" y1="65" x2="510" y2="65" stroke="currentColor" stroke-opacity="0.3"/>
+  <path d="M10 65 C 50 5, 90 5, 130 65 S 210 125, 250 65 S 330 5, 370 65 S 450 125, 490 65" fill="none" stroke="currentColor" stroke-width="1.5" stroke-opacity="0.6"/>
+  <g fill="currentColor">
+    <circle cx="10" cy="65" r="3"/><circle cx="50" cy="25" r="3"/><circle cx="90" cy="25" r="3"/><circle cx="130" cy="65" r="3"/><circle cx="170" cy="105" r="3"/><circle cx="210" cy="105" r="3"/><circle cx="250" cy="65" r="3"/><circle cx="290" cy="25" r="3"/><circle cx="330" cy="25" r="3"/><circle cx="370" cy="65" r="3"/><circle cx="410" cy="105" r="3"/><circle cx="450" cy="105" r="3"/><circle cx="490" cy="65" r="3"/>
+  </g>
+</svg>
+<figcaption>Each dot is one sample. Take enough of them and the dots capture the wave; take too few and you lose it.</figcaption>
+</figure>
+
+## Nyquist: the speed limit
+
+How fast is fast enough? The **Nyquist–Shannon theorem** gives the rule:
+
+> Sample at **more than twice** the highest frequency in the signal.
+
+Sample a 1 MHz-wide chunk of spectrum and you need above 2 MS/s. Sample too slowly
+and a disaster called **aliasing** happens: frequencies above half the sample rate
+"fold" back down and appear as *false* lower frequencies, indistinguishable from real
+ones. It's the same effect that makes wagon wheels seem to spin backwards in film —
+too few frames per second. This is why an SDR always [filters](/learn/dsp/fir-filters/)
+before reducing its rate, a theme you'll meet again in
+[decimation](/learn/dsp/decimation-and-resampling/). The
+[sample rate & Nyquist](/learn/rf-sdr/sample-rate-nyquist/) lesson in the RF path
+covers the same limit from the radio side.
+
+## Quantization: rounding the amplitude
+
+Sampling handles *when* you measure; **quantization** handles *how precisely*. Each
+sample is rounded to one of a fixed number of levels set by the **bit depth**:
+
+| Bit depth | Levels | Typical use |
+|-----------|--------|-------------|
+| 8-bit | 256 | RTL-SDR dongles |
+| 12-bit | 4,096 | Airspy, better SDRs |
+| 16-bit | 65,536 | Audio, high-end receivers |
+
+More bits mean finer amplitude resolution and a lower noise floor. The rounding error
+you can't avoid shows up as **quantization noise** — a faint hiss set by the bit
+depth. It's one contributor to the noise floor you met in
+[noise & SNR](/learn/rf-sdr/noise-and-snr/).
+
+## The two knobs, together
+
+Digitizing a signal is these two choices: **sample rate** (sets the frequency span
+you can see) and **bit depth** (sets how finely you resolve amplitude). Get either
+wrong and information is lost before DSP even begins — which is why understanding them
+is the foundation for everything that follows.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — Nyquist requires sampling above twice the highest frequency, or aliasing occurs." markdown="0">
+  <p class="knowledge-check__q">Quick check: to capture a signal containing frequencies up to 1 MHz, your sample rate must be…</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">above 500 kHz</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">above 2 MHz</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">exactly 1 MHz</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Sampling** measures the wave at a fixed **sample rate**.
+- **Nyquist**: sample above **twice** the highest frequency, or suffer **aliasing**.
+- **Quantization** rounds each sample to a **bit depth**, adding **quantization
+  noise**.
+- Sample rate sets the frequency span; bit depth sets amplitude precision.
+
+Next up: why SDR samples come in pairs — the complex I/Q representation.

--- a/docs/learn/dsp/snr-evm-and-ber.md
+++ b/docs/learn/dsp/snr-evm-and-ber.md
@@ -1,0 +1,116 @@
+---
+slug: snr-evm-and-ber
+title: SNR, EVM & BER
+description: The three numbers that measure a digital link's health — signal-to-noise ratio, error-vector magnitude, and bit error rate — and how they relate to each other.
+keywords: snr, evm, ber, signal to noise ratio, error vector magnitude, bit error rate, link quality metrics, demod quality
+level: intermediate
+status: full
+prereq:
+  - constellations-and-symbol-mapping
+  - the-decibel-in-dsp
+faq:
+  - q: How are SNR, EVM, and BER related?
+    a: "They measure the same link health at three stages. SNR, in decibels, is how far the signal sits above the noise. That noise scatters each symbol away from its ideal constellation point, and EVM measures that scatter as a percentage. When the scatter grows large enough that symbols cross into a neighbour's decision region, bits flip — and BER counts those flips as a fraction of all bits. Lower SNR means higher EVM means higher BER."
+  - q: What EVM or SNR do I need to decode a signal?
+    a: "It depends on the modulation. A robust two- or four-level scheme tolerates a lot of scatter and decodes at fairly low SNR, while a dense QAM constellation packs points close together and needs a much cleaner signal. Forward error correction lowers the required SNR further by fixing a bounded number of bit errors, so the raw BER can be nonzero and the decoded data still be perfect."
+---
+
+# SNR, EVM & BER
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Three numbers grade a digital link, each one step downstream of the last. **SNR** (in
+[dB](/learn/dsp/the-decibel-in-dsp/)) is how far the signal sits above the noise. That
+noise scatters symbols off their ideal [constellation](/learn/dsp/constellations-and-symbol-mapping/)
+points — **EVM** measures the scatter as a percentage. When scatter pushes a symbol into
+the wrong decision region, a bit flips — **BER** counts those flips per bit. **Lower SNR →
+higher EVM → higher BER.**
+</div>
+
+You can *see* link health on a constellation; these three metrics *quantify* it. This
+lesson ties them together and builds on
+[decibels](/learn/dsp/the-decibel-in-dsp/) and
+[constellations](/learn/dsp/constellations-and-symbol-mapping/). It mirrors the RF path's
+[noise & SNR](/learn/rf-sdr/noise-and-snr/).
+
+## SNR: signal above noise
+
+**Signal-to-noise ratio** is the ratio of signal power to noise power, almost always
+quoted in **decibels**. It is the root cause metric — everything else follows from it. A
+high SNR means the wanted signal towers over the background; a low SNR means it is nearly
+buried. Because it's a power ratio it uses the 10·log₁₀ form: 20 dB SNR is 100× more
+signal power than noise.
+
+## EVM: scatter on the constellation
+
+Noise doesn't stay abstract — it knocks each received symbol *off* its ideal point.
+**Error-vector magnitude** measures exactly that: for each symbol, draw the vector from
+where it should be to where it landed; EVM is the size of that error vector, averaged and
+expressed as a **percentage** of the ideal signal amplitude.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 300 170" role="img" aria-label="One constellation point with received symbols scattered around it, and an arrow from the ideal point to a received sample labelled the error vector." xmlns="http://www.w3.org/2000/svg">
+  <line x1="20" y1="90" x2="280" y2="90" stroke="currentColor" stroke-opacity="0.25"/>
+  <line x1="150" y1="20" x2="150" y2="160" stroke="currentColor" stroke-opacity="0.25"/>
+  <circle cx="210" cy="55" r="5" fill="none" stroke="currentColor" stroke-width="2"/>
+  <text x="222" y="50" font-size="9" fill="currentColor">ideal point</text>
+  <g fill="currentColor" fill-opacity="0.6">
+    <circle cx="205" cy="62" r="2.5"/><circle cx="222" cy="50" r="2.5"/><circle cx="215" cy="70" r="2.5"/>
+    <circle cx="198" cy="52" r="2.5"/><circle cx="228" cy="63" r="2.5"/>
+  </g>
+  <line x1="210" y1="55" x2="222" y2="50" stroke="currentColor" stroke-width="1.5"/>
+  <text x="200" y="30" font-size="9" fill="currentColor">error vector</text>
+</svg>
+<figcaption>EVM is the length of the error vector from a symbol's ideal point to where it actually landed — the scatter that noise and distortion cause, as a percent.</figcaption>
+</figure>
+
+Low EVM (a few percent) is a tight cluster; high EVM is a fuzzy blob. GopherTrunk's own
+diagnostics report demod EVM — for example the project's field notes cite a channel
+locking at **EVM ≈ 7.4%** but failing at **≈ 22.5%**, a concrete threshold between decode
+and no-decode.
+
+## BER: bits that actually flipped
+
+Push EVM high enough and a symbol crosses into a **neighbour's** decision region — the
+decoder picks the wrong symbol, and (thanks to [Gray coding](/learn/dsp/constellations-and-symbol-mapping/))
+usually one bit flips. **Bit error rate** is the count of flipped bits over total bits:
+
+```text
+BER = (bits received wrong) / (total bits)
+e.g. 3 bad bits in 10,000  ->  BER = 3e-4
+```
+
+BER is the bottom-line metric — it is what actually breaks a message. And it is where
+[error correction](/learn/dsp/error-correction-and-framing/) enters: FEC can repair a
+bounded number of flips, so a link with a modest raw BER can still deliver *perfect*
+decoded data.
+
+## How they chain
+
+| Metric | Measures | Units | Position |
+|--------|----------|-------|----------|
+| **SNR** | signal vs noise power | dB | cause |
+| **EVM** | symbol scatter from ideal | % | effect on symbols |
+| **BER** | fraction of bits wrong | ratio | effect on data |
+
+Read them as one story: noise sets SNR, SNR sets how far symbols scatter (EVM), scatter
+sets how often bits flip (BER). Improve the front-end SNR and all three improve together.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — EVM measures how far received symbols scatter from their ideal constellation points." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does EVM measure?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">The fraction of bits received incorrectly</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">How far received symbols scatter from their ideal constellation points, as a percent</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">The signal power above the noise floor, in dB</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **SNR** (dB) is signal power over noise power — the root-cause quality metric.
+- **EVM** (%) is how far symbols scatter from their ideal constellation points.
+- **BER** is the fraction of bits that actually flipped — the bottom line.
+- They chain: **lower SNR → higher EVM → higher BER**; FEC can still rescue a modest BER.
+
+Next up: overlaying symbol periods into a single picture — the eye diagram.

--- a/docs/learn/dsp/spectrograms-and-stft.md
+++ b/docs/learn/dsp/spectrograms-and-stft.md
@@ -1,0 +1,115 @@
+---
+slug: spectrograms-and-stft
+title: Spectrograms & the STFT
+description: The short-time Fourier transform — sliding the FFT along a signal to see how its spectrum changes over time, the math behind every waterfall display.
+keywords: spectrogram, stft, short-time fourier transform, waterfall, time-frequency, sliding fft, spectral display, hop size overlap
+level: intermediate
+status: full
+prereq:
+  - the-fft
+  - windows-and-leakage
+faq:
+  - q: What is the difference between an FFT and an STFT?
+    a: "A single FFT gives you one spectrum for a whole block of samples, with no sense of when each frequency occurred. The short-time Fourier transform runs many FFTs, one on each short window as it slides along the signal, producing a spectrum for every moment. Stack those spectra and you can see how the signal's frequency content evolves over time."
+  - q: Is a waterfall display a spectrogram?
+    a: "Yes. A waterfall is a spectrogram drawn in real time: each new row is one FFT of the most recent block of samples, colour-mapped by magnitude and scrolled down the screen. Reading it means reading a spectrogram — bright vertical lines are steady carriers, sloping streaks are drifting or chirping signals."
+---
+
+# Spectrograms & the STFT
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A single [FFT](/learn/dsp/the-fft/) tells you *which* frequencies are present but not
+*when*. The **short-time Fourier transform (STFT)** fixes that by running an FFT on each
+short **window** as it slides along the signal, giving one spectrum per moment. Stack
+those spectra into a **spectrogram** — time on one axis, frequency on the other,
+magnitude as brightness — and you get the **waterfall** every SDR shows.
+</div>
+
+The FFT gave us a snapshot of a signal's frequencies. But radio is alive — carriers come
+and go, signals drift and chirp. To see *change*, we slide the FFT along time. This
+lesson builds on [the FFT](/learn/dsp/the-fft/) and
+[windows & leakage](/learn/dsp/windows-and-leakage/), and explains the display from
+[FFT & waterfall](/learn/rf-sdr/fft-and-waterfall/).
+
+## Why one FFT isn't enough
+
+Take an FFT of a ten-second recording and you learn every frequency that appeared —
+but a carrier that switched on for one second looks the same as one that was on the
+whole time. All timing information is smeared into a single spectrum. For a live band
+where signals appear, transmit, and vanish, that is nearly useless. We need a spectrum
+*for each moment*.
+
+## The short-time Fourier transform
+
+The fix is simple in concept: don't transform the whole signal at once. Chop it into
+short, overlapping windows and take an FFT of each one.
+
+```text
+signal:  [====================================================]
+window1: [======]                    -> FFT -> spectrum @ t1
+window2:     [======]                -> FFT -> spectrum @ t2
+window3:         [======]            -> FFT -> spectrum @ t3
+   ...   (slide by the hop size)         ...
+```
+
+Each FFT is windowed first (a Hann or Kaiser taper from the
+[leakage lesson](/learn/dsp/windows-and-leakage/)) to keep its spectrum clean. The step
+between successive windows is the **hop size**; windows usually **overlap** so nothing
+between them is missed. The result is a two-dimensional array: frequency down one axis,
+time along the other.
+
+## Reading a spectrogram
+
+Colour-map each spectrum's magnitude — dark for quiet, bright for strong — lay the
+columns side by side, and you have a **spectrogram**.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 170" role="img" aria-label="A spectrogram with time on the horizontal axis and frequency on the vertical axis, showing a steady horizontal carrier line and a diagonal chirping streak." xmlns="http://www.w3.org/2000/svg">
+  <rect x="40" y="15" width="440" height="120" fill="none" stroke="currentColor" stroke-opacity="0.4"/>
+  <text x="260" y="158" text-anchor="middle" font-size="11" fill="currentColor">time &#8594;</text>
+  <text x="24" y="78" font-size="11" fill="currentColor" transform="rotate(-90 24 78)">frequency</text>
+  <line x1="40" y1="55" x2="480" y2="55" stroke="currentColor" stroke-width="3" stroke-opacity="0.85"/>
+  <text x="130" y="49" font-size="9" fill="currentColor">steady carrier</text>
+  <line x1="90" y1="125" x2="300" y2="30" stroke="currentColor" stroke-width="2.5" stroke-opacity="0.7"/>
+  <text x="300" y="28" font-size="9" fill="currentColor">chirp / drift</text>
+  <rect x="330" y="95" width="70" height="18" fill="currentColor" fill-opacity="0.35"/>
+  <text x="365" y="128" text-anchor="middle" font-size="9" fill="currentColor">burst</text>
+</svg>
+<figcaption>A spectrogram: horizontal lines are steady carriers, sloping streaks are drifting or chirping signals, and rectangles are bursts that start and stop.</figcaption>
+</figure>
+
+A **waterfall** is exactly this, drawn live: each incoming block becomes one FFT column,
+scrolled across the display. Reading it is reading a spectrogram.
+
+## The resolution tradeoff, again
+
+The STFT can't escape the [time-vs-frequency tradeoff](/learn/dsp/the-fft/). A **long**
+window gives fine frequency resolution but blurs *when* things happened; a **short**
+window pinpoints timing but smears frequency. Choosing the window length is choosing
+where on that tradeoff you want to sit — wide for spotting a fleeting burst, narrow for
+separating two close carriers.
+
+| Window length | Frequency detail | Time detail | Good for |
+|---------------|------------------|-------------|----------|
+| Long | fine | coarse | separating nearby carriers |
+| Short | coarse | fine | catching brief bursts, fast changes |
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the STFT runs an FFT on each sliding window to show how the spectrum changes over time." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does the STFT add over a single FFT?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Higher amplitude resolution</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">A spectrum for each moment, showing how frequencies change over time</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Removal of quantization noise</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A single **FFT** shows which frequencies but not **when**.
+- The **STFT** runs an FFT on each sliding, overlapping **window** — one spectrum per moment.
+- Stacked and colour-mapped, those spectra form a **spectrogram**; drawn live it's a **waterfall**.
+- Window length sets the **time-vs-frequency** tradeoff: long for detail, short for speed.
+
+Next up: how a real signal becomes complex I/Q in the first place — the analytic signal.

--- a/docs/learn/dsp/testing-and-debugging-dsp.md
+++ b/docs/learn/dsp/testing-and-debugging-dsp.md
@@ -1,0 +1,116 @@
+---
+slug: testing-and-debugging-dsp
+title: Testing & debugging DSP
+description: Golden vectors, offline replay of captures, and the invariants that catch a broken signal path — how you prove a decoder actually works.
+keywords: testing dsp, debugging dsp, golden vectors, reference vectors, replay capture, cfile replay, dsp invariants, regression test, rate invariance
+level: advanced
+status: full
+prereq:
+  - dsp-in-gophertrunk
+faq:
+  - q: What is a golden vector in DSP testing?
+    a: "A golden vector is a saved reference: a known input and the exact output a correct implementation must produce for it. A regression test feeds the input through the code and compares against the stored output. Because DSP is deterministic arithmetic, any drift from the golden output signals a change in behaviour — it turns a subtle numeric bug into a hard test failure you can catch automatically."
+  - q: Why replay a recorded capture instead of testing with live radio?
+    a: "A live signal is never the same twice, so a bug that appears on the air is nearly impossible to reproduce or to prove fixed. A recorded capture — a .cfile of raw I/Q — is a fixed, repeatable stimulus. Replaying it runs the exact same samples through the pipeline every time, so you can reproduce a failure deterministically, bisect it, and confirm a fix by re-running the same file."
+---
+
+# Testing & debugging DSP
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+DSP is deterministic arithmetic, which makes it **testable**. **Golden vectors** pin
+known input→output pairs so any behaviour drift fails a test. **Offline replay** of a
+recorded **`.cfile`** capture turns an un-reproducible on-air bug into a repeatable one.
+And **invariants** — properties that must always hold, like GopherTrunk's
+**rate-invariance** — catch whole classes of failure. Together they let you *prove* a
+decoder works instead of hoping.
+</div>
+
+The final skill in this module isn't an algorithm — it's how you know any of them are
+correct. This lesson draws the [whole pipeline](/learn/dsp/dsp-in-gophertrunk/) together
+under the question: how do you *verify* a signal path? It reflects the practices
+GopherTrunk's own repository enforces.
+
+## Golden vectors: deterministic reference outputs
+
+Because a DSP block is pure arithmetic, the same input always yields the same output. That
+determinism is a gift for testing. A **golden vector** captures a known input and the
+correct output beside it; a regression test runs the input through the code and asserts
+the result matches.
+
+```text
+input vector   ->  [ DSP under test ]  ->  output
+                                              ||  compare
+golden output  ------------------------------ '
+mismatch => a behaviour change => test fails
+```
+
+This is exactly the project's rule for a bug fix: a regression test that **fails without
+the fix and passes with it**. If you can't write a vector that fails first, you haven't
+truly reproduced the bug — a discipline that stops "fixes" for problems that were never
+understood.
+
+## Offline replay: making the un-reproducible repeatable
+
+The hardest bugs appear on live signals that never recur. The cure is to **record** the
+raw I/Q — a **`.cfile`** of [complex samples](/learn/dsp/complex-signals-and-iq/) — once,
+then **replay** that same file through the pipeline as often as you like. GopherTrunk has a
+dedicated `replay` path for exactly this: the same samples, the same result, every run. A
+live mystery becomes a deterministic test you can bisect and, crucially, re-run to *confirm*
+a fix rather than guess at one.
+
+## Invariants: properties that must always hold
+
+Beyond specific vectors, the strongest tests assert **invariants** — statements true for
+*every* valid input. GopherTrunk's headline example is **rate-invariance**: because the
+[downconverter](/learn/dsp/dsp-in-gophertrunk/) normalizes every channel to a fixed channel
+rate, a given channel must decode to the *same* in-channel quality whether it was captured
+at 2.4 MS/s or 10 MS/s and decimated down. A test that asserts this pins the whole
+front-end's behaviour with one property.
+
+That invariant is also a **diagnostic**. Read the table:
+
+| Symptom | What the invariant tells you |
+|---------|------------------------------|
+| Fails live at high rate, **reproduces** in offline replay | the fault is in the **captured data** (front-end overload, phase noise) — not the DSP |
+| Fails live but **cannot** be reproduced offline from the same file | the DSP is fine; look upstream at capture/timing |
+| Same file decodes differently across runs | non-determinism — a real bug in the code |
+
+The project used precisely this reasoning on a field issue: a channel that locked from a
+2.4 MS/s capture but not a 10 MS/s one. Decimating the high-rate file with an *independent*
+resampler and replaying it through the proven path reproduced the **same** deficit — proving
+the ~10 dB shortfall was baked into the samples (front-end reciprocal mixing), not
+GopherTrunk's downconverter.
+
+## A workable debugging loop
+
+Putting it together, the reliable loop is:
+
+1. **Capture** the failing signal to a `.cfile`.
+2. **Replay** it to reproduce the failure deterministically.
+3. Write a **golden-vector** or **invariant** test that fails on it.
+4. Fix until the test passes — and only then claim it fixed.
+
+That last point is a hard rule in this project: a fix isn't verified until a failing-first
+test passes *and* the symptom is shown resolved. It is why the same discipline that grades
+a link — [SNR, EVM, BER](/learn/dsp/snr-evm-and-ber/) — also grades your *changes* to the
+code that decodes it.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — reproducing a high-rate failure in offline replay points at the captured data, not the steady-state DSP." markdown="0">
+  <p class="knowledge-check__q">Quick check: a bug appears only at a high capture rate but reproduces in offline replay of that file. Where is the fault?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">In the steady-state DSP algorithms</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">In the captured data itself — front-end overload or phase noise, not the DSP</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">In the display code only</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- DSP is **deterministic**, so **golden vectors** (input→output) turn numeric drift into test failures.
+- **Offline replay** of a **`.cfile`** makes an un-reproducible on-air bug repeatable.
+- **Invariants** like **rate-invariance** pin whole behaviours and double as diagnostics.
+- A fix is verified only when a **failing-first** test passes and the symptom is shown gone.
+
+Next up: the last lesson — how numbers are stored, and why it matters for performance.

--- a/docs/learn/dsp/the-analytic-signal.md
+++ b/docs/learn/dsp/the-analytic-signal.md
@@ -1,0 +1,112 @@
+---
+slug: the-analytic-signal
+title: The analytic signal & Hilbert transform
+description: How a real signal becomes complex I/Q — the Hilbert transform, the analytic signal, and why it removes the negative-frequency mirror image.
+keywords: analytic signal, hilbert transform, quadrature, negative frequency, complex baseband, real to complex, 90 degree phase shift
+level: advanced
+status: full
+prereq:
+  - complex-signals-and-iq
+  - the-fourier-transform
+faq:
+  - q: What does the Hilbert transform actually do?
+    a: "The Hilbert transform shifts every frequency component of a real signal by exactly 90 degrees. Used as the imaginary (quadrature) part alongside the original real signal, it produces the analytic signal — a complex signal whose spectrum has no negative-frequency half, so it can be represented and processed as clean I/Q."
+  - q: Why do we want to get rid of negative frequencies?
+    a: "A real signal's spectrum is always mirror-symmetric: every positive frequency has an identical negative-frequency twin carrying no new information. That mirror is what makes a real signal ambiguous about which side of a carrier it sits on. Removing it with the analytic signal leaves one clean copy, which is exactly what lets an SDR tell a signal above centre from one below."
+---
+
+# The analytic signal & Hilbert transform
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A **real** signal's spectrum is always **mirror-symmetric** — every positive frequency
+has a redundant **negative-frequency** twin. The **Hilbert transform** phase-shifts the
+signal by 90° to make the **quadrature** part; pairing it with the original gives the
+**analytic signal**, a complex signal whose negative-frequency half is **cancelled**.
+That is how a one-wire real signal becomes clean [I/Q](/learn/dsp/complex-signals-and-iq/).
+</div>
+
+The I/Q lesson took two-number samples for granted. This one answers where the second
+number *comes from* when a signal starts life as a single real stream. It builds on
+[complex signals & I/Q](/learn/dsp/complex-signals-and-iq/) and the
+[Fourier transform](/learn/dsp/the-fourier-transform/).
+
+## The mirror in every real spectrum
+
+Take the Fourier transform of any purely **real** signal and you always find the same
+thing: the spectrum is symmetric about zero. Whatever sits at +5 kHz has an identical
+mirror image at −5 kHz. That twin carries no extra information — it is a mathematical
+consequence of the signal being real — but it is what makes a lone real stream unable to
+say *which side* of a frequency a component is on.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 130" role="img" aria-label="Two spectra: a real signal with mirror-image peaks on both sides of zero, and the analytic signal with only the positive-frequency peak remaining." xmlns="http://www.w3.org/2000/svg">
+  <line x1="20" y1="60" x2="230" y2="60" stroke="currentColor" stroke-opacity="0.3"/>
+  <line x1="125" y1="60" x2="125" y2="18" stroke="currentColor" stroke-width="2"/>
+  <line x1="70" y1="60" x2="70" y2="35" stroke="currentColor" stroke-width="2"/>
+  <line x1="180" y1="60" x2="180" y2="35" stroke="currentColor" stroke-width="2"/>
+  <text x="125" y="75" text-anchor="middle" font-size="8" fill="currentColor">0</text>
+  <text x="60" y="30" font-size="8" fill="currentColor">mirror</text>
+  <text x="125" y="92" text-anchor="middle" font-size="9" fill="currentColor">real signal</text>
+  <text x="270" y="60" text-anchor="middle" font-size="15" fill="currentColor">&#8594;</text>
+  <line x1="310" y1="60" x2="500" y2="60" stroke="currentColor" stroke-opacity="0.3"/>
+  <line x1="405" y1="60" x2="405" y2="18" stroke="currentColor" stroke-width="2"/>
+  <line x1="460" y1="60" x2="460" y2="35" stroke="currentColor" stroke-width="2"/>
+  <text x="405" y="75" text-anchor="middle" font-size="8" fill="currentColor">0</text>
+  <text x="405" y="92" text-anchor="middle" font-size="9" fill="currentColor">analytic signal (mirror removed)</text>
+</svg>
+<figcaption>A real signal carries a redundant negative-frequency mirror; the analytic signal keeps only the positive half.</figcaption>
+</figure>
+
+## The Hilbert transform: a 90° phase shifter
+
+The tool that removes the mirror is the **Hilbert transform**. Think of it as a filter
+that leaves every frequency's *amplitude* untouched but shifts its *phase* by exactly
+**90°** — a quarter cycle. Feed a cosine in and a sine comes out; that is precisely the
+[quadrature](/learn/dsp/complex-signals-and-iq/) relationship between I and Q.
+
+## Building the analytic signal
+
+Now assemble the complex signal:
+
+```text
+I (in-phase)  = the original real signal
+Q (quadrature)= its Hilbert transform (90 deg shifted)
+analytic signal = I + jQ
+```
+
+Because of how the 90°-shifted copy adds and subtracts across the spectrum, the two
+mirror halves **cancel on the negative side and reinforce on the positive side**. What
+remains is a complex signal with a one-sided spectrum — the **analytic signal**. Its
+magnitude at each instant is the signal's **envelope** and its angle is the
+instantaneous **phase**, the very quantities [demodulation](/learn/dsp/demodulation/)
+reads.
+
+## Where this happens in practice
+
+Most SDRs never run a literal Hilbert transform on a real stream — their hardware
+produces I/Q directly by mixing the antenna signal against two oscillators 90° apart, a
+**quadrature downconversion** that achieves the same one-sided result in analog. The
+Hilbert view still matters: it is the theory that explains *why* two channels 90° apart
+capture everything a real signal holds, and it is exactly how you'd convert a real
+recording (say, an audio file) into I/Q in software. The result feeds the same
+[complex baseband](/learn/dsp/mixing-and-downconversion/) pipeline either way.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — pairing a signal with its 90°-shifted Hilbert transform cancels the negative-frequency mirror." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does forming the analytic signal accomplish?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It doubles the sample rate</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">It removes the redundant negative-frequency mirror, giving clean I/Q</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It eliminates all noise from the signal</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **real** signal's spectrum has a redundant **negative-frequency mirror**.
+- The **Hilbert transform** shifts every frequency by **90°** to form the quadrature part.
+- Pairing original + Hilbert gives the **analytic signal**, whose mirror half **cancels**.
+- SDR hardware reaches the same one-sided I/Q by **quadrature downconversion**.
+
+Next up: the operation at the heart of every filter — convolution and the impulse response.

--- a/docs/learn/dsp/the-decibel-in-dsp.md
+++ b/docs/learn/dsp/the-decibel-in-dsp.md
@@ -1,0 +1,118 @@
+---
+slug: the-decibel-in-dsp
+title: Decibels & dynamic range
+description: Why signal levels are measured in decibels, how dB math turns multiplication into addition, and what dynamic range means for a sampled digital signal.
+keywords: decibel dsp, dB math, dBFS, dynamic range, bit depth dynamic range, 6 dB per bit, power ratio, amplitude ratio, log scale
+level: beginner
+status: full
+prereq:
+  - sampling-and-quantization
+faq:
+  - q: Why use decibels instead of plain ratios?
+    a: "Signal strengths in radio span an enormous range — the strongest signal can be a trillion times more powerful than the weakest you can still decode. Decibels compress that range onto a manageable scale and turn multiplication into addition, so a gain of 100x becomes simply adding 20 dB. Both make signal-level bookkeeping far easier."
+  - q: What is dBFS?
+    a: "dBFS means decibels relative to full scale — the loudest level a sampled signal can represent before it clips. Full scale is 0 dBFS, and every real sample sits below it at a negative dBFS value. It is the natural yardstick for digital signals because it is referenced to the number format itself, not to any physical power."
+---
+
+# Decibels & dynamic range
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A **decibel (dB)** is a logarithmic ratio: **10·log₁₀** of a *power* ratio, or
+**20·log₁₀** of an *amplitude* ratio. Logs turn multiplication into **addition**, so
+chained gains just add. For sampled signals we measure level in **dBFS** (relative to
+full scale), and the **dynamic range** a format can hold is set by its **bit depth** —
+roughly **6 dB per bit**.
+</div>
+
+Radio spans a colossal range of signal strengths, and DSP code juggles gains at every
+stage. Decibels are how we keep that sane. This lesson builds on
+[sampling & quantization](/learn/dsp/sampling-and-quantization/) and mirrors the RF
+path's [decibels](/learn/rf-sdr/decibels/) lesson from the DSP side.
+
+## Why a logarithmic scale
+
+The weakest signal you can still decode and the strongest one the front end can handle
+differ by factors of millions to trillions. Writing those as plain numbers is unwieldy,
+and gains *multiply* as they chain through a receiver. Taking a logarithm fixes both:
+it compresses a huge range into small numbers, and it turns each multiply into an **add**.
+
+```text
+gain of 100x  -> +20 dB
+gain of 2x    -> +3 dB (approx)
+loss of 1/2   -> -3 dB
+chain them:   100x then 2x  ->  20 dB + 3 dB = 23 dB
+```
+
+## Power vs amplitude: the 10 and the 20
+
+There are two forms of the dB formula, and the difference trips people up:
+
+| Quantity | Formula | Because… |
+|----------|---------|----------|
+| **Power** ratio | dB = **10·log₁₀**(P₁/P₀) | power is the base definition |
+| **Amplitude** ratio | dB = **20·log₁₀**(A₁/A₀) | power ∝ amplitude², and log of a square doubles the factor |
+
+So doubling the *amplitude* of a signal is **+6 dB**, while doubling its *power* is
+**+3 dB**. Both describe the same physical change viewed through different quantities.
+A few values worth memorising:
+
+```text
++3 dB  ~ 2x power        +6 dB  ~ 2x amplitude
++10 dB = 10x power       +20 dB = 10x amplitude / 100x power
+ 0 dB  = no change (ratio of 1)
+```
+
+## dBFS: the digital yardstick
+
+For a signal that lives as numbers, the natural reference is the **largest value the
+format can hold** — full scale. Level measured against that is **dBFS** (dB relative to
+full scale). Full scale is **0 dBFS**; every real sample sits below it, at a negative
+value. A signal peaking at −6 dBFS is using half the available amplitude; one that
+reaches 0 dBFS is on the edge of **clipping**, where samples slam into the limit and the
+waveform is destroyed — a failure mode covered in
+[front-end overload](/learn/rf-sdr/front-end-and-overload/).
+
+## Dynamic range and bit depth
+
+**Dynamic range** is the span between the loudest signal a format can represent and the
+quantization-noise floor beneath it. It is set directly by **bit depth**: each extra bit
+doubles the number of levels, which is **~6 dB** more range.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 150" role="img" aria-label="A vertical bar from 0 dBFS at top down to a noise floor, with the span between labelled dynamic range and marked at roughly 6 dB per bit." xmlns="http://www.w3.org/2000/svg">
+  <line x1="120" y1="20" x2="120" y2="130" stroke="currentColor" stroke-width="1.5"/>
+  <line x1="112" y1="20" x2="128" y2="20" stroke="currentColor" stroke-width="2"/>
+  <text x="140" y="24" font-size="11" fill="currentColor">0 dBFS (full scale — clipping above)</text>
+  <line x1="112" y1="130" x2="128" y2="130" stroke="currentColor" stroke-width="2"/>
+  <text x="140" y="133" font-size="11" fill="currentColor">quantization noise floor</text>
+  <line x1="120" y1="24" x2="120" y2="126" stroke="currentColor" stroke-opacity="0.5" stroke-dasharray="4 3"/>
+  <text x="60" y="78" font-size="10" fill="currentColor" transform="rotate(-90 60 78)">dynamic range</text>
+  <text x="300" y="78" font-size="10" fill="currentColor">~6 dB per bit</text>
+  <text x="300" y="94" font-size="9" fill="currentColor">8-bit ≈ 48 dB · 12-bit ≈ 72 dB · 16-bit ≈ 96 dB</text>
+</svg>
+<figcaption>Dynamic range is the span from full scale down to the noise floor — about 6 dB for every bit of depth.</figcaption>
+</figure>
+
+That is why an 8-bit SDR (about 48 dB) can be swamped by a strong nearby signal that a
+12-bit unit (about 72 dB) handles, and why keeping the input well below 0 dBFS — but not
+so low it sinks into the noise floor — is the goal of [gain staging](/learn/dsp/gain-and-agc/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a decibel is 10·log₁₀ of a power ratio (or 20·log₁₀ of an amplitude ratio)." markdown="0">
+  <p class="knowledge-check__q">Quick check: how much does adding one bit of depth increase dynamic range?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">About 3 dB</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">About 6 dB</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">About 20 dB</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **decibel** is a log ratio: **10·log₁₀** of power, **20·log₁₀** of amplitude.
+- Logs turn multiplied gains into **added** dB — the reason receiver budgets are done in dB.
+- **dBFS** measures a sampled signal against full scale; 0 dBFS is the clipping edge.
+- **Dynamic range** ≈ **6 dB per bit** of depth, from full scale down to the noise floor.
+
+Next up: the single most useful way to look at a signal — its frequency content.

--- a/docs/learn/dsp/the-eye-diagram.md
+++ b/docs/learn/dsp/the-eye-diagram.md
@@ -1,0 +1,112 @@
+---
+slug: the-eye-diagram
+title: The eye diagram
+description: Overlaying symbol periods into an "eye" — how to read timing margin, noise, and inter-symbol interference at a glance from a single picture.
+keywords: eye diagram, eye pattern, eye opening, timing margin, isi, symbol quality, decision instant, signal integrity
+level: intermediate
+status: full
+prereq:
+  - clock-and-symbol-recovery
+  - snr-evm-and-ber
+faq:
+  - q: What is an eye diagram?
+    a: "An eye diagram is made by chopping a demodulated signal into single-symbol-wide slices and drawing them all on top of each other. Where the traces avoid each other an open space appears — the eye. A wide-open eye means clean, easy-to-decide symbols; a closing eye means noise, timing jitter, or inter-symbol interference is eating away the margin the decoder relies on."
+  - q: How do you read an eye diagram?
+    a: "Look at the open space in the middle. Its height is the voltage margin between symbol levels — how much noise the decoder can tolerate before mistaking one level for another. Its width is the timing margin — how much the sampling instant can drift and still land in the clear. The best moment to sample is the widest, tallest point of the opening, right at the eye's centre."
+---
+
+# The eye diagram
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+An **eye diagram** overlays many single-symbol slices of a demodulated signal on top of
+each other. The clear region that emerges — the **eye** — shows link quality at a glance:
+its **height** is the amplitude margin against noise, its **width** is the timing margin
+against jitter, and the best **sampling instant** is where the eye is most open. A wide,
+open eye decodes cleanly; a **closing** eye warns of noise, jitter, or ISI.
+</div>
+
+The last lesson gave numeric grades ([SNR/EVM/BER](/learn/dsp/snr-evm-and-ber/)); the eye
+diagram is their *picture*. It is the single most useful visual for symbol quality and
+ties directly to [clock recovery](/learn/dsp/clock-and-symbol-recovery/), which decides
+*where* in the eye to sample.
+
+## Building the eye
+
+Take the demodulated waveform — the signal stepping between symbol levels — and cut it
+into pieces exactly one (or two) symbol periods wide. Now draw every piece on the same
+axes, all starting at the same left edge. The random data means each slice takes a
+different path, but they all pass through the same **transition zones** and avoid the
+same **open centre**. That open centre is the eye.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 170" role="img" aria-label="An eye diagram: many overlaid traces forming an open lens-shaped eye in the centre, with the eye height marked as amplitude margin, eye width as timing margin, and a vertical line at the best sampling instant." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="150" x2="500" y2="150" stroke="currentColor" stroke-opacity="0.2"/>
+  <g fill="none" stroke="currentColor" stroke-opacity="0.55" stroke-width="1.3">
+    <path d="M40 40 C 140 40, 200 130, 265 130 C 330 130, 390 40, 490 40"/>
+    <path d="M40 130 C 140 130, 200 40, 265 40 C 330 40, 390 130, 490 130"/>
+    <path d="M40 40 C 150 45, 210 120, 265 120 C 320 120, 380 45, 490 40"/>
+    <path d="M40 130 C 150 125, 210 50, 265 50 C 320 50, 380 125, 490 130"/>
+  </g>
+  <line x1="265" y1="52" x2="265" y2="118" stroke="currentColor" stroke-width="1.5" stroke-dasharray="3 3"/>
+  <text x="278" y="88" font-size="9" fill="currentColor">amplitude margin (height)</text>
+  <line x1="205" y1="140" x2="325" y2="140" stroke="currentColor" stroke-width="1.5" stroke-dasharray="3 3"/>
+  <text x="265" y="165" text-anchor="middle" font-size="9" fill="currentColor">timing margin (width)</text>
+  <line x1="265" y1="30" x2="265" y2="150" stroke="currentColor" stroke-opacity="0.4"/>
+  <text x="265" y="26" text-anchor="middle" font-size="8" fill="currentColor">best sample here</text>
+</svg>
+<figcaption>An eye diagram: overlaid symbol slices leave an open eye. Its height is noise margin, its width is timing margin, and the centre is the ideal sampling instant.</figcaption>
+</figure>
+
+## Reading the two margins
+
+The eye's opening is a direct picture of decoding headroom:
+
+- **Height (vertical opening)** — the gap between symbol levels at the decision instant.
+  This is the **amplitude margin**: how much noise can push a sample before it crosses
+  into the wrong level. Noise (low [SNR](/learn/dsp/snr-evm-and-ber/)) thickens the traces
+  and shrinks the height.
+- **Width (horizontal opening)** — how long the eye stays open. This is the **timing
+  margin**: how far the sampling instant can drift and still land in the clear. Timing
+  **jitter** narrows it; [inter-symbol interference](/learn/dsp/equalization/) pulls the
+  crossings inward from both sides.
+
+The decoder wants to sample at the **widest, tallest** point — the centre of the eye —
+which is exactly the instant [clock recovery](/learn/dsp/clock-and-symbol-recovery/) hunts
+for. A well-locked timing loop parks the sampler dead-centre in the eye.
+
+## A closing eye names the problem
+
+Because each impairment attacks the eye in its own way, a glance often diagnoses the
+fault:
+
+| Symptom in the eye | Likely cause |
+|--------------------|--------------|
+| Traces thick, eye short | noise / low SNR |
+| Crossings blurred left–right | timing jitter |
+| Opening squeezed, levels pulled in | ISI / multipath |
+| Eye fully closed | any of the above, too severe to decode |
+
+More symbol levels means more, smaller eyes stacked vertically (four-level
+[C4FM](/learn/dsp/demodulation/) shows three eyes), and each must stay open. When the eye
+is shut, no sampling instant is safe and the decode fails — the visual companion to a high
+BER.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the eye's height is the amplitude (noise) margin and its width is the timing margin." markdown="0">
+  <p class="knowledge-check__q">Quick check: the vertical opening (height) of the eye represents…</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">the carrier frequency offset</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">the amplitude margin against noise before a level is misread</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">the number of taps in the channel filter</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- An **eye diagram** overlays single-symbol slices; the clear **eye** shows quality at a glance.
+- **Height** = amplitude margin against noise; **width** = timing margin against jitter.
+- The ideal **sampling instant** is the eye's centre — where clock recovery aims.
+- A **closing** eye names the fault: thick traces (noise), blurred crossings (jitter), squeezed opening (ISI).
+
+Next up: turning raw, error-prone symbols into trustworthy data — framing and error correction.

--- a/docs/learn/dsp/the-fft.md
+++ b/docs/learn/dsp/the-fft.md
@@ -1,0 +1,107 @@
+---
+slug: the-fft
+title: The FFT in practice
+description: How the Fast Fourier Transform makes the DFT computable in real time, what bin resolution means, the time-versus-frequency tradeoff, and what a waterfall display really shows.
+keywords: fft, fast fourier transform, dft, fft bins, frequency resolution, waterfall display, fft size, spectrum analyzer
+level: intermediate
+status: full
+prereq:
+  - the-fourier-transform
+faq:
+  - q: What is an FFT bin?
+    a: An FFT splits the sampled bandwidth into a fixed number of equal-width slots called bins, each reporting the energy in a small range of frequencies. The number of bins equals the FFT size. More bins over the same bandwidth means finer frequency resolution — but each FFT then needs more samples, which means it covers a longer slice of time.
+  - q: What is a waterfall display?
+    a: A waterfall stacks many FFTs computed over successive slices of time, drawing each as a horizontal line where colour or brightness shows energy per frequency bin, and scrolling downward. It lets you watch signals appear, disappear, and move across the spectrum — the standard way SDR software visualizes activity.
+---
+
+# The FFT in practice
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+The **FFT (Fast Fourier Transform)** is a fast algorithm for the DFT, quick enough to
+run live on a radio stream. It splits the bandwidth into **bins** — more bins mean
+finer **frequency resolution**, but each FFT then spans more **time**. A **waterfall**
+is just many FFTs stacked over time. The FFT is how software radio *sees* the
+spectrum.
+</div>
+
+The Fourier transform is the idea; the FFT is how you actually compute it fast enough
+to matter. This lesson covers the practical knobs and what they trade off.
+
+## Fast enough to be useful
+
+A direct DFT of N samples costs on the order of N² operations — hopeless for the
+millions of samples a second an SDR produces. The **FFT** computes the identical
+result in about N·log N operations. For a 4,096-point transform that's the difference
+between ~16 million operations and ~50 thousand — the leap that makes real-time
+spectrum analysis possible on ordinary hardware.
+
+## Bins and resolution
+
+An FFT of size N divides the sampled bandwidth into **N bins** of equal width:
+
+```text
+bin width  =  sample rate / FFT size
+```
+
+At 2.4 MS/s with a 4,096-point FFT, each bin is about 586 Hz wide. Want to resolve
+signals closer together? Use more bins. But there's a catch built into physics.
+
+## The time–frequency tradeoff
+
+To get finer frequency resolution you need a **bigger** FFT, and a bigger FFT needs
+**more samples**, which cover a **longer** stretch of time. So you can know *precisely
+what* frequency or *precisely when* — but not both at once:
+
+| FFT size (at 2.4 MS/s) | Bin width | Time span |
+|------------------------|-----------|-----------|
+| 1,024 | ~2.3 kHz | ~0.43 ms |
+| 4,096 | ~586 Hz | ~1.7 ms |
+| 16,384 | ~146 Hz | ~6.8 ms |
+
+Fine frequency detail costs time resolution, and vice versa. Choosing the FFT size is
+choosing where on that trade you want to sit — a short FFT to catch brief bursts, a
+long one to separate close carriers.
+
+## The waterfall
+
+Compute an FFT, draw its bins as a row of colours (bright = strong), drop down a line,
+compute the next FFT, and repeat. That scrolling picture is a **waterfall** — time
+running down the screen, frequency across it.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 120" role="img" aria-label="A waterfall diagram: stacked horizontal rows representing successive FFTs, with vertical streaks marking signals persisting across time and frequency." xmlns="http://www.w3.org/2000/svg">
+  <rect x="20" y="10" width="480" height="90" fill="none" stroke="currentColor" stroke-opacity="0.4"/>
+  <line x1="150" y1="10" x2="150" y2="100" stroke="currentColor" stroke-width="6" stroke-opacity="0.5"/>
+  <line x1="300" y1="10" x2="300" y2="100" stroke="currentColor" stroke-width="3" stroke-opacity="0.8"/>
+  <line x1="420" y1="40" x2="420" y2="100" stroke="currentColor" stroke-width="4" stroke-opacity="0.5"/>
+  <text x="260" y="115" text-anchor="middle" font-size="10" fill="currentColor">frequency &#8594;</text>
+  <text x="12" y="55" font-size="10" fill="currentColor" transform="rotate(-90 12 55)">time &#8595;</text>
+</svg>
+<figcaption>Each row is one FFT; each vertical streak is a signal holding a frequency over time. This is what SDR software shows you.</figcaption>
+</figure>
+
+The RF path's [FFT & waterfall](/learn/rf-sdr/fft-and-waterfall/) lesson looks at
+reading these displays; here the point is that the picture is *literally* a stack of
+FFTs, and its sharpness in frequency versus time is the tradeoff above. Windowing —
+the next lesson — cleans up how each FFT row looks.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a larger FFT gives finer frequency resolution but spans more time." markdown="0">
+  <p class="knowledge-check__q">Quick check: you double the FFT size at a fixed sample rate. What happens?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="correct">Finer frequency resolution, but each FFT covers more time</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Coarser frequency resolution and less time</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Nothing changes</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- The **FFT** computes the DFT in ~N·log N operations — fast enough for live radio.
+- It splits bandwidth into **bins**; **bin width = sample rate ÷ FFT size**.
+- Finer frequency resolution needs a **bigger FFT**, which spans **more time** — a
+  fundamental tradeoff.
+- A **waterfall** is many FFTs stacked over time — how SDR software shows the spectrum.
+
+Next up: why real FFTs smear energy, and how window functions fix it.

--- a/docs/learn/dsp/the-fourier-transform.md
+++ b/docs/learn/dsp/the-fourier-transform.md
@@ -1,0 +1,108 @@
+---
+slug: the-fourier-transform
+title: The Fourier transform
+description: The one idea that any signal is a sum of sine waves — what the Fourier transform computes, and why the frequency domain makes filtering and detection easy.
+keywords: fourier transform, frequency domain, dft, sine wave decomposition, spectrum, fourier analysis, dsp frequency
+level: intermediate
+status: full
+prereq:
+  - complex-signals-and-iq
+faq:
+  - q: What does the Fourier transform actually do?
+    a: It takes a signal described over time (a list of samples) and re-describes it over frequency — telling you how much of each frequency is present. The remarkable underlying fact is that any signal can be built by adding up sine waves of different frequencies, amplitudes, and phases, and the transform finds that recipe.
+  - q: What is the difference between the time domain and the frequency domain?
+    a: The time domain is the signal as it varies moment to moment — the raw samples. The frequency domain is the same signal expressed as its component frequencies. They contain the same information in two views; some operations (like removing an interfering tone) are trivial in one view and hard in the other.
+---
+
+# The Fourier transform
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+The **Fourier transform** re-describes a signal from the **time domain** (samples
+over time) into the **frequency domain** (how much of each frequency is present). Its
+foundation: **any signal is a sum of sine waves**. In the frequency domain, jobs like
+isolating a channel or spotting a carrier become easy — which is why the transform is
+DSP's most-used tool.
+</div>
+
+This lesson introduces the single most powerful idea in signal processing. Don't
+worry about the equations — the *concept* is what unlocks everything after it.
+
+## Any signal is a sum of sines
+
+Here's the surprising fact underneath all of it: **every signal, however complicated,
+can be built by adding together plain sine waves** of different frequencies,
+strengths, and phases. A square wave is a sum of sines; a voice is a sum of sines; a
+digital transmission is a sum of sines.
+
+The **Fourier transform** runs that idea in reverse: given the signal, it works out
+*which* sines, and *how much* of each, are in the mix. That recipe — amount of energy
+at each frequency — is the signal's **spectrum**.
+
+## Two views of the same thing
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 150" role="img" aria-label="On the left, a complicated wiggly waveform in the time domain; an arrow labelled Fourier transform points to the right, where two sharp peaks appear on a frequency axis." xmlns="http://www.w3.org/2000/svg">
+  <text x="90" y="18" text-anchor="middle" font-size="11" fill="currentColor">time domain</text>
+  <path d="M10 75 C 40 40, 55 110, 85 70 S 130 30, 160 80 S 180 110, 200 75" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <line x1="10" y1="120" x2="200" y2="120" stroke="currentColor" stroke-opacity="0.3"/>
+  <text x="105" y="135" text-anchor="middle" font-size="9" fill="currentColor">amplitude vs time</text>
+  <line x1="225" y1="75" x2="300" y2="75" stroke="currentColor" stroke-width="1.5" marker-end="url(#f1)"/>
+  <text x="262" y="66" text-anchor="middle" font-size="9" fill="currentColor">Fourier</text>
+  <text x="410" y="18" text-anchor="middle" font-size="11" fill="currentColor">frequency domain</text>
+  <line x1="320" y1="120" x2="510" y2="120" stroke="currentColor" stroke-opacity="0.3"/>
+  <line x1="370" y1="120" x2="370" y2="55" stroke="currentColor" stroke-width="2"/>
+  <line x1="450" y1="120" x2="450" y2="80" stroke="currentColor" stroke-width="2"/>
+  <text x="415" y="135" text-anchor="middle" font-size="9" fill="currentColor">energy vs frequency</text>
+  <defs><marker id="f1" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>The same signal, two views. That messy waveform on the left is just two tones — obvious as two peaks on the right.</figcaption>
+</figure>
+
+The waveform and its spectrum hold the *same information* — but some questions are
+trivial in one view and painful in the other. "Is there a carrier near 851 MHz?" is
+almost impossible to eyeball in the time domain and blindingly obvious as a peak in
+the frequency domain.
+
+## Why radio lives in the frequency domain
+
+Nearly every radio task is naturally a frequency question:
+
+- **Finding a signal** — a control channel is a peak at a known frequency.
+- **Isolating a channel** — keep a band of frequencies, discard the rest (that's
+  [filtering](/learn/dsp/fir-filters/)).
+- **Tuning** — shift the whole spectrum so your channel sits at zero (that's
+  [mixing](/learn/dsp/mixing-and-downconversion/)).
+
+There's even a deep shortcut the transform reveals: **filtering in the time domain
+(convolution) is just multiplication in the frequency domain** — the link you'll meet
+in [convolution & impulse response](/learn/dsp/convolution-and-impulse-response/).
+
+## From idea to computation
+
+The Fourier transform as pure math runs over a continuous signal. On sampled data we
+use the **Discrete Fourier Transform (DFT)**, which takes a block of samples and
+returns the energy in a set of frequency **bins**. Computed naively it's slow — but a
+clever algorithm, the **[FFT](/learn/dsp/the-fft/)**, makes it fast enough to run in
+real time on a live radio stream. That's the next lesson, and it's what powers the
+waterfall display you may have seen.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the Fourier transform converts time-domain samples into a frequency-domain spectrum." markdown="0">
+  <p class="knowledge-check__q">Quick check: the Fourier transform turns a signal described over time into one described over…</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">amplitude</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">frequency</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">distance</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Any signal is a sum of sine waves**; the **Fourier transform** finds the recipe.
+- It converts the **time domain** (samples) into the **frequency domain** (a
+  **spectrum**).
+- Radio tasks — finding, isolating, tuning — are naturally frequency questions.
+- On sampled data we use the **DFT**, made fast by the **FFT** — coming next.
+
+Next up: the FFT, and what a waterfall display is really showing you.

--- a/docs/learn/dsp/what-is-a-signal.md
+++ b/docs/learn/dsp/what-is-a-signal.md
@@ -1,0 +1,119 @@
+---
+slug: what-is-a-signal
+title: What is a signal?
+description: Amplitude, phase, and the sine wave that underlies everything — the vocabulary of signals before we turn them into numbers a computer can process.
+keywords: what is a signal, sine wave, amplitude phase frequency, phasor, signal basics dsp, sinusoid, signal vocabulary
+level: beginner
+status: full
+prereq:
+  - what-is-dsp
+faq:
+  - q: Why is the sine wave so important in signal processing?
+    a: "The sine wave is the one signal that keeps its shape through any linear filter — it comes out a sine of the same frequency, only scaled and delayed. That property makes sines the natural building blocks of every other signal, which is exactly why the Fourier transform describes any signal as a sum of them."
+  - q: What is the difference between amplitude, frequency, and phase?
+    a: "Amplitude is how tall the wave is (its strength), frequency is how many cycles it completes each second (how fast it wiggles), and phase is where in its cycle it starts (its timing offset). Those three numbers fully describe a pure sine wave, and modulation works by deliberately changing one of them."
+---
+
+# What is a signal?
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A **signal** is a value that changes over time. The **sine wave** is its fundamental
+building block, described by three numbers: **amplitude** (height/strength),
+**frequency** (cycles per second), and **phase** (timing offset). A rotating arrow —
+a **phasor** — captures all three at once, which is why signals map so neatly onto the
+complex plane you'll meet next.
+</div>
+
+Before we turn signals into numbers, we need the vocabulary for talking about them.
+This lesson is that vocabulary. It builds directly on
+[what DSP is](/learn/dsp/what-is-dsp/) and sets up
+[sampling](/learn/dsp/sampling-and-quantization/), where the wave becomes data.
+
+## What counts as a signal?
+
+A **signal** is simply any quantity that varies — usually over time. The voltage on an
+antenna, air pressure at a microphone, the brightness of a pixel down a scan line: all
+signals. In radio the signal we care about is the strength of an electromagnetic
+[radio wave](/learn/rf-sdr/radio-waves/) measured at the receiver, moment to moment.
+
+What makes a signal *useful* is that its variation carries information. A flat, unchanging
+value says nothing; the changes are the message.
+
+## The sine wave: the atom of signals
+
+The most important signal is the **sinusoid** — a smooth, repeating wave. It matters
+because it is the one shape a linear filter can never distort: a sine goes in, a sine of
+the *same frequency* comes out, only scaled and shifted. Every other signal can be built
+by adding sines together, an idea the [Fourier transform](/learn/dsp/the-fourier-transform/)
+makes exact.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 160" role="img" aria-label="A sine wave with its amplitude marked as height from the centre line and one full period marked along the axis." xmlns="http://www.w3.org/2000/svg">
+  <line x1="20" y1="80" x2="500" y2="80" stroke="currentColor" stroke-opacity="0.3"/>
+  <path d="M20 80 C 70 0, 130 0, 180 80 S 290 160, 340 80 S 450 0, 500 80" fill="none" stroke="currentColor" stroke-width="2.5"/>
+  <line x1="100" y1="80" x2="100" y2="22" stroke="currentColor" stroke-width="1.5" stroke-dasharray="4 3"/>
+  <text x="108" y="48" font-size="12" fill="currentColor">amplitude</text>
+  <line x1="180" y1="120" x2="340" y2="120" stroke="currentColor" stroke-width="1.5" stroke-dasharray="4 3"/>
+  <text x="260" y="138" text-anchor="middle" font-size="12" fill="currentColor">one period (1 / frequency)</text>
+</svg>
+<figcaption>A sine wave: amplitude is its height, one period is how long a cycle takes, and frequency is how many periods pass each second.</figcaption>
+</figure>
+
+## The three numbers that describe it
+
+A pure sine is fully pinned down by three quantities:
+
+| Property | What it means | Change it and… |
+|----------|---------------|----------------|
+| **Amplitude** | height of the wave — its strength | the signal gets louder or weaker (**AM**) |
+| **Frequency** | cycles per second, in hertz | the pitch/tuning shifts (**FM/FSK**) |
+| **Phase** | where in the cycle it starts (its timing) | the wave slides left or right (**PSK**) |
+
+Those three are exactly the properties a transmitter varies to send information —
+[modulation](/learn/rf-sdr/analog-modulation/) is nothing more than deliberately changing
+one of them in step with a message.
+
+## The phasor: one arrow for all three
+
+Here is the idea that makes everything later click. Picture the sine wave not as a
+squiggle but as an arrow spinning around a circle. The arrow's **length** is the
+amplitude, how fast it **spins** is the frequency, and the **angle** it starts at is the
+phase. That spinning arrow is called a **phasor**, and its shadow on a horizontal line
+traces out the sine wave.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 300 160" role="img" aria-label="A circle with a rotating arrow from the centre; its length is amplitude and its angle is phase, and it projects onto a sine wave to the right." xmlns="http://www.w3.org/2000/svg">
+  <circle cx="80" cy="80" r="55" fill="none" stroke="currentColor" stroke-opacity="0.35"/>
+  <line x1="80" y1="80" x2="126" y2="48" stroke="currentColor" stroke-width="2"/>
+  <path d="M110 80 A 30 30 0 0 0 122 57" fill="none" stroke="currentColor" stroke-opacity="0.7"/>
+  <text x="112" y="74" font-size="9" fill="currentColor">phase</text>
+  <text x="92" y="56" font-size="9" fill="currentColor">length = amp</text>
+  <path d="M150 80 C 175 30, 205 30, 230 80 S 275 130, 290 80" fill="none" stroke="currentColor" stroke-width="1.8" stroke-opacity="0.8"/>
+  <line x1="126" y1="48" x2="150" y2="48" stroke="currentColor" stroke-opacity="0.4" stroke-dasharray="3 3"/>
+</svg>
+<figcaption>A phasor: a spinning arrow whose length, spin rate, and starting angle are the amplitude, frequency, and phase. Its projection is the sine wave.</figcaption>
+</figure>
+
+This is the seed of complex I/Q. When the next unit represents a sample as a point on a
+plane, it is just recording where that arrow points right now — a picture that becomes
+[complex signals & I/Q](/learn/dsp/complex-signals-and-iq/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — amplitude, frequency, and phase fully describe a pure sine wave." markdown="0">
+  <p class="knowledge-check__q">Quick check: which three numbers fully describe a pure sine wave?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Bit depth, sample rate, and gain</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Amplitude, frequency, and phase</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Voltage, current, and resistance</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **signal** is a value that changes over time; its changes carry the information.
+- The **sine wave** is the fundamental building block — the one shape filters don't distort.
+- **Amplitude**, **frequency**, and **phase** fully describe a sine; modulation varies one of them.
+- A **phasor** — a spinning arrow — captures all three, and previews the complex plane.
+
+Next up: how a continuous wave becomes a stream of numbers a computer can hold.

--- a/docs/learn/dsp/what-is-dsp.md
+++ b/docs/learn/dsp/what-is-dsp.md
@@ -1,0 +1,115 @@
+---
+slug: what-is-dsp
+title: What is DSP?
+description: Why we process signals with numbers instead of analog circuits, what a digital signal processor does, and where DSP sits inside a software-defined radio.
+keywords: what is dsp, digital signal processing, dsp explained, dsp vs analog, software radio dsp, signal processing basics
+level: beginner
+status: full
+faq:
+  - q: What is digital signal processing in simple terms?
+    a: Digital signal processing is doing to a signal — with arithmetic on numbers — what used to be done with analog electronic circuits. Once a signal is a stream of numbers, filtering, tuning, and decoding all become math a computer performs. That flexibility is what makes software-defined radio possible.
+  - q: Do I need to be good at maths to learn DSP?
+    a: Not to start. The core ideas are intuitive — averaging numbers to smooth a signal, sliding one list along another, looking at a signal by its frequencies. This module keeps the maths light and visual; you can understand the whole pipeline with arithmetic and pictures, and pick up the deeper formulas later if you want them.
+---
+
+# What is DSP?
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Digital signal processing (DSP)** is manipulating a signal as a stream of
+**numbers** using arithmetic, instead of with analog circuits. Filtering, tuning,
+and demodulation all become math a computer runs. DSP is the engine inside a
+**software-defined radio**: the hardware just digitizes the airwaves, and DSP turns
+those numbers into voice, data, and control messages.
+</div>
+
+This is lesson 1 of the DSP path. Its job is to answer *what* DSP is and *why* it
+matters before we get into the how. By the end you'll see where every later lesson —
+sampling, filters, the FFT, demodulation — fits in the chain.
+
+## From circuits to numbers
+
+For most of radio's history, a signal was processed by physical circuits: a coil and
+capacitor tuned to a station, a diode recovered the audio. Each function needed
+dedicated hardware. **DSP replaces those circuits with arithmetic.** Once a signal is
+a list of numbers, "tune to this frequency" or "keep only these components" is a
+calculation, and one general-purpose processor can do the work of a rack of analog
+gear.
+
+That shift is the whole idea behind [software-defined radio](/learn/rf-sdr/what-is-sdr/):
+the radio hardware does as little as possible — just convert the antenna's signal
+into numbers — and *software* does the rest. Change the software and the same
+hardware decodes a different system.
+
+## What a signal looks like as numbers
+
+A signal is just a value that changes over time — a voltage, a pressure, a radio
+wave's amplitude. Sample it regularly and you get a sequence:
+
+```text
+time:    0    1    2    3    4    5    6   ...
+value:  0.0  0.6  0.9  0.6  0.0 -0.6 -0.9  ...   (a sampled sine wave)
+```
+
+Everything DSP does operates on sequences like this. Smoothing noise is averaging
+neighbouring values; tuning is multiplying by another sequence; detecting a tone is
+asking how much of a given frequency is present. The next lesson,
+[sampling & quantization](/learn/dsp/sampling-and-quantization/), covers exactly how
+a continuous wave becomes this list.
+
+## Where DSP sits in a software radio
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 90" role="img" aria-label="Signal chain from antenna to decoded data: antenna, analog-to-digital converter, DSP block, decoded output." xmlns="http://www.w3.org/2000/svg">
+  <rect x="6" y="30" width="80" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="46" y="51" text-anchor="middle" font-size="11" fill="currentColor">antenna</text>
+  <rect x="112" y="30" width="90" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="157" y="46" text-anchor="middle" font-size="10" fill="currentColor">ADC</text>
+  <text x="157" y="58" text-anchor="middle" font-size="9" fill="currentColor">(digitize)</text>
+  <rect x="228" y="30" width="120" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="2"/>
+  <text x="288" y="46" text-anchor="middle" font-size="11" fill="currentColor">DSP</text>
+  <text x="288" y="58" text-anchor="middle" font-size="9" fill="currentColor">filter, tune, demod</text>
+  <rect x="374" y="30" width="120" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="434" y="51" text-anchor="middle" font-size="10" fill="currentColor">decoded data</text>
+  <line x1="86" y1="47" x2="112" y2="47" stroke="currentColor" stroke-width="1.5"/>
+  <line x1="202" y1="47" x2="228" y2="47" stroke="currentColor" stroke-width="1.5"/>
+  <line x1="348" y1="47" x2="374" y2="47" stroke="currentColor" stroke-width="1.5"/>
+</svg>
+<figcaption>The radio front-end digitizes the airwaves; DSP — the whole rest of this path — turns those numbers into decoded data.</figcaption>
+</figure>
+
+Everything between "digitize" and "decoded data" is DSP, and it's what this module
+builds up stage by stage. By [the final lesson](/learn/dsp/dsp-in-gophertrunk/) you'll
+map each stage onto GopherTrunk's real code.
+
+## Why numbers win
+
+Processing in software buys you three things analog can't match easily:
+
+- **Flexibility** — a new protocol is new code, not new hardware.
+- **Precision** — arithmetic is exact and repeatable; components drift with heat and age.
+- **Complexity for free** — filters and detectors that would need dozens of parts are
+  a few lines of math.
+
+The price is that you need enough compute to keep up with the sample rate — which is
+why [performance](/learn/dsp/fixed-vs-floating-point/) is a real concern in DSP code.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — DSP works on a signal represented as a stream of numbers." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does DSP operate on?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Tuned analog circuits</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">A signal represented as a stream of numbers</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Only pre-recorded audio files</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **DSP** manipulates a signal as a stream of **numbers** with arithmetic, replacing
+  analog circuits.
+- It's the engine of **software-defined radio**: hardware digitizes, software decodes.
+- Every DSP operation is math on a **sequence of samples**.
+- Numbers buy flexibility, precision, and complexity — at the cost of needing compute.
+
+Next up: how a continuous wave actually becomes that stream of numbers.

--- a/docs/learn/dsp/windows-and-leakage.md
+++ b/docs/learn/dsp/windows-and-leakage.md
@@ -1,0 +1,110 @@
+---
+slug: windows-and-leakage
+title: Windows & spectral leakage
+description: Why chopping a signal into blocks smears its energy across FFT bins, and how window functions trade frequency resolution for cleaner, lower-leakage spectra.
+keywords: spectral leakage, window function, hann window, hamming window, fft windowing, sidelobes, dsp windows, blackman window
+level: advanced
+status: full
+prereq:
+  - the-fft
+faq:
+  - q: What causes spectral leakage?
+    a: An FFT assumes the block of samples it's given repeats forever. If the signal doesn't complete a whole number of cycles in that block, the ends don't line up, creating an artificial jump when the block "wraps". That discontinuity spreads the signal's energy into neighbouring bins — leakage — smearing a single tone across the spectrum.
+  - q: Which window function should I use?
+    a: It depends on the goal. A Hann or Hamming window is a good general default, balancing leakage suppression against resolution. A Blackman or Kaiser window suppresses leakage more strongly at the cost of a wider main peak — useful when a strong signal would otherwise drown a weak one nearby. A rectangular window (no window) gives the sharpest peak but the worst leakage.
+---
+
+# Windows & spectral leakage
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+An FFT assumes its block of samples **repeats forever**; if the signal doesn't fit a
+whole number of cycles, the mismatched ends create a jump that **leaks** energy into
+neighbouring bins. A **window function** tapers the block's edges to zero, greatly
+reducing leakage — at the cost of a slightly wider main peak. It's the standard
+cleanup applied before every FFT.
+</div>
+
+The FFT is powerful but has a sharp edge — literally. This lesson explains the
+artifact called leakage and the window functions that tame it.
+
+## The hidden assumption
+
+An FFT doesn't see your block of samples as a fragment; it treats it as **one period
+of a signal that repeats forever**. If the tone in your block completes a whole
+number of cycles, the end lines up perfectly with the start when it "wraps," and the
+FFT shows a clean, single spike.
+
+But real signals rarely land on a whole number of cycles per block. Then the end and
+the start *don't* match, and the wrap-around creates an abrupt **discontinuity** — a
+jump that was never in the real signal.
+
+## Leakage: one tone, many bins
+
+That artificial jump is sharp, and sharp edges contain lots of frequencies. So a
+single pure tone that *should* light up one bin instead **smears** its energy across
+many neighbouring bins. This is **spectral leakage**:
+
+```text
+Ideal (fits the block):   ......▁█▁......      one clean bin
+Leaky (doesn't fit):    ..▁▂▃▅█▅▃▂▁..         energy spread across bins
+```
+
+Leakage is a problem because it can bury a weak signal sitting next to a strong one:
+the strong signal's leakage floods the weak one's bins.
+
+## Windowing: taper the edges
+
+The fix is a **window function** — a smooth curve you multiply the block by before the
+FFT. It's near 1 in the middle and tapers to 0 at both ends, so the block always
+starts and ends at zero and there's no discontinuity to leak from.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 120" role="img" aria-label="A rectangular block with hard edges on the left, and the same block multiplied by a smooth bell-shaped window that tapers to zero at both ends on the right." xmlns="http://www.w3.org/2000/svg">
+  <rect x="20" y="30" width="150" height="60" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="95" y="108" text-anchor="middle" font-size="10" fill="currentColor">rectangular (hard edges)</text>
+  <text x="255" y="64" text-anchor="middle" font-size="16" fill="currentColor">&#8594;</text>
+  <path d="M320 90 C 360 90, 370 30, 415 30 C 460 30, 470 90, 510 90" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <line x1="320" y1="90" x2="510" y2="90" stroke="currentColor" stroke-opacity="0.3"/>
+  <text x="415" y="108" text-anchor="middle" font-size="10" fill="currentColor">windowed (tapered to zero)</text>
+</svg>
+<figcaption>A window tapers the block's ends to zero, removing the wrap-around jump that causes leakage.</figcaption>
+</figure>
+
+## Choosing a window
+
+Windows trade leakage suppression against how wide the main peak becomes:
+
+| Window | Leakage suppression | Main peak | Good for |
+|--------|--------------------|-----------|----------|
+| Rectangular (none) | poor | narrowest | closely spaced equal signals |
+| Hann / Hamming | good | moderate | general use — a solid default |
+| Blackman / Kaiser | excellent | widest | a weak signal beside a strong one |
+
+There's no free lunch: killing leakage widens the peak, blurring nearby frequencies a
+little. GopherTrunk's own filter and channelization design uses a **Kaiser** window
+(with a shaping parameter β) precisely because it can push leakage far below the noise
+floor when isolating one channel from a crowded band — a design choice you'll see in
+[FIR filters](/learn/dsp/fir-filters/) and again in
+[DSP in GopherTrunk](/learn/dsp/dsp-in-gophertrunk/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a window tapers the block edges to zero, removing the discontinuity that leaks." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does applying a window function to an FFT block reduce?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">The sample rate</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Spectral leakage into neighbouring bins</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Quantization noise</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- An FFT assumes its block **repeats forever**; a signal that doesn't fit creates a
+  discontinuity.
+- That jump causes **spectral leakage** — one tone smearing across many bins.
+- A **window function** tapers the block edges to zero, cutting leakage.
+- Windows trade leakage for peak width; **Hann/Hamming** are good defaults,
+  **Kaiser/Blackman** for weak-beside-strong.
+
+Next up: Unit 3 and the operation at the heart of every filter — convolution.

--- a/docs/learn/programming-go/benchmarking-and-profiling.md
+++ b/docs/learn/programming-go/benchmarking-and-profiling.md
@@ -1,0 +1,114 @@
+---
+slug: benchmarking-and-profiling
+title: Benchmarking & profiling
+description: "Measuring performance with Go benchmarks and pprof — finding the hot path before optimizing it, the discipline real-time DSP code demands."
+keywords: go benchmark, testing.B, b.N, go test -bench, pprof, go profiling, cpu profile, benchstat, performance go
+level: advanced
+status: full
+prereq:
+  - testing-in-go
+faq:
+  - q: What is b.N in a Go benchmark?
+    a: "It's the number of iterations the testing framework chooses. Your benchmark loops for i := 0; i < b.N; i++ and the runner keeps raising b.N until the timing is statistically stable, then reports nanoseconds per operation. You never set b.N yourself — you just loop over it."
+  - q: Do I need an external profiler for Go?
+    a: "No. The runtime and the pprof package ship with the toolchain. go test -cpuprofile writes a profile, and go tool pprof reads it — showing which functions burned the most time, right down to a flame graph in your browser. It's all built in."
+---
+
+# Benchmarking & profiling
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A benchmark is a **`func BenchmarkX(b *testing.B)`** that loops **`b.N`** times; run it
+with **`go test -bench=.`** to get nanoseconds and allocations per operation. To find
+*where* time goes, capture a **pprof** profile and read it with **`go tool pprof`**.
+The rule: **measure before you optimize** — profile to find the hot path, then improve
+only that.
+</div>
+
+Guessing which code is slow is usually wrong. This lesson covers Go's built-in tools
+for measuring, which sit right alongside the
+[testing package](/learn/programming-go/testing-in-go/) you already know.
+
+## Writing a benchmark
+
+A benchmark lives in a `_test.go` file and takes `*testing.B`. You loop `b.N` times;
+the framework picks `b.N` to get a stable measurement:
+
+```go
+func BenchmarkDemodulate(b *testing.B) {
+    samples := make([]complex64, 4096)
+    d := NewC4FMDemod()
+    b.ResetTimer()               // ignore setup time above
+    for i := 0; i < b.N; i++ {
+        d.Demodulate(samples)
+    }
+}
+```
+
+Run it and read the report:
+
+```
+$ go test -bench=Demodulate -benchmem
+BenchmarkDemodulate-8   32418   36907 ns/op   1024 B/op   2 allocs/op
+```
+
+That's iterations run, time per call, bytes allocated per call, and allocation count
+— the four numbers that matter for a DSP hot path.
+
+## Profiling with pprof
+
+A benchmark tells you *how slow*; a profile tells you *where*. Capture a CPU profile
+and open it:
+
+```
+$ go test -bench=Pipeline -cpuprofile cpu.out
+$ go tool pprof cpu.out
+(pprof) top          # functions by time spent
+(pprof) web          # flame graph in the browser
+```
+
+The `top` list and flame graph point straight at the function eating the cycles —
+often not the one you'd have guessed. There are memory (`-memprofile`) and block
+profiles too, read the same way.
+
+| Flag / tool | What it measures |
+|-------------|-----------------|
+| `-bench=.` | Time per operation |
+| `-benchmem` | Bytes and allocations per operation |
+| `-cpuprofile cpu.out` | Where CPU time is spent |
+| `-memprofile mem.out` | Where memory is allocated |
+| `go tool pprof` | Reads any profile — `top`, `list`, `web` |
+
+## Measure, then optimize
+
+The discipline is simple and it's the whole point:
+
+1. **Benchmark** the code so you have a baseline number.
+2. **Profile** to find the actual hot path.
+3. Change *that* — and only that.
+4. Re-run the benchmark to confirm the number improved (`benchstat` compares two runs
+   for you and flags noise).
+
+Optimizing without step 2 usually speeds up code that was never the problem. For a
+real-time SDR engine that must keep pace with incoming samples, this loop is how you
+know a change helped rather than hoped it did.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the framework sets b.N; you loop over it." markdown="0">
+  <p class="knowledge-check__q">Quick check: who decides the value of b.N in a benchmark?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">You set it to a fixed count</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The testing framework raises it until timing is stable</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It's always exactly one million</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A benchmark is **`func BenchmarkX(b *testing.B)`** looping **`b.N`** times, run with
+  **`go test -bench`**.
+- **`-benchmem`** adds bytes and allocations per operation.
+- **pprof** (`-cpuprofile` + `go tool pprof`) shows *where* time goes.
+- Always **measure, then optimize** — profile the hot path before changing it.
+
+Next up: finding bugs with the debugger, the race detector, and static analysis.

--- a/docs/learn/programming-go/channels.md
+++ b/docs/learn/programming-go/channels.md
@@ -1,0 +1,124 @@
+---
+slug: channels
+title: Channels
+description: Channels are typed pipes that let goroutines communicate safely — sending, receiving, buffering, and closing them — Go's share-memory-by-communicating model of concurrency.
+keywords: go channels, channel send receive, buffered channel, unbuffered channel, close channel, go concurrency, share memory by communicating
+level: intermediate
+status: full
+prereq:
+  - goroutines
+faq:
+  - q: What is the difference between a buffered and an unbuffered channel?
+    a: An unbuffered channel has no storage — a send blocks until another goroutine is ready to receive, so the two rendezvous. A buffered channel (`make(chan T, n)`) holds up to n values, so a send only blocks when the buffer is full. Unbuffered channels synchronize two goroutines; buffered channels let a fast producer run ahead of a slower consumer up to the buffer size.
+  - q: Do I always need channels for concurrency?
+    a: No. Channels are the idiomatic way to pass data between goroutines, but sometimes plain shared state guarded by a mutex from the sync package is simpler — for example, a counter many goroutines increment. The next lesson covers when to reach for sync instead. The guideline is to use channels to move data and ownership, and mutexes to protect small pieces of shared state.
+---
+
+# Channels
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A **channel** is a typed pipe that connects goroutines: one **sends** with `ch <- v`
+and another **receives** with `v := <-ch`. An **unbuffered** channel makes sender
+and receiver rendezvous; a **buffered** one holds a few values. Channels let
+goroutines share data **without shared-memory bugs** — the heart of Go's concurrency
+model.
+</div>
+
+Goroutines run independently; channels are how they talk. This lesson covers Go's
+central concurrency tool.
+
+## Creating and using a channel
+
+```go
+ch := make(chan int)   // a channel that carries ints
+
+go func() {
+    ch <- 42           // send 42 into the channel
+}()
+
+v := <-ch              // receive; v is 42
+```
+
+The arrow points the way the data flows: `ch <- v` sends *into* the channel,
+`<-ch` receives *out of* it. Because this channel is **unbuffered**, the send blocks
+until the receive happens — the two goroutines meet at that moment. That built-in
+synchronization is exactly why you don't need locks to hand a value from one
+goroutine to another.
+
+## Buffered channels
+
+Give `make` a size and the channel can hold values without an immediate receiver:
+
+```go
+results := make(chan []byte, 8)   // holds up to 8 before a send blocks
+```
+
+A buffered channel lets a fast producer stay ahead of a slower consumer — useful in
+a signal pipeline where samples arrive in bursts. When the buffer is full, the next
+send blocks until room opens up, which naturally applies backpressure.
+
+## Ranging and closing
+
+A sender can **close** a channel to signal "no more values," and a receiver can
+`range` over it until it's drained:
+
+```go
+go func() {
+    for _, frame := range frames {
+        out <- frame
+    }
+    close(out)          // no more frames coming
+}()
+
+for frame := range out {   // loops until out is closed and empty
+    process(frame)
+}
+```
+
+Closing is a broadcast that the stream has ended — only the sender should close, and
+only once.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 100" role="img" aria-label="Two goroutines connected by a channel: a producer sends values in one end and a consumer receives them from the other." xmlns="http://www.w3.org/2000/svg">
+  <rect x="10" y="35" width="120" height="34" rx="6" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="70" y="57" text-anchor="middle" font-size="12" fill="currentColor">producer</text>
+  <rect x="180" y="40" width="160" height="24" rx="12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-dasharray="5 3"/>
+  <text x="260" y="56" text-anchor="middle" font-size="11" fill="currentColor">channel</text>
+  <line x1="130" y1="52" x2="180" y2="52" stroke="currentColor" stroke-width="1.5" marker-end="url(#a2)"/>
+  <line x1="340" y1="52" x2="390" y2="52" stroke="currentColor" stroke-width="1.5" marker-end="url(#a2)"/>
+  <rect x="390" y="35" width="120" height="34" rx="6" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="450" y="57" text-anchor="middle" font-size="12" fill="currentColor">consumer</text>
+  <defs><marker id="a2" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>A channel decouples producer from consumer — they share data through the pipe, not through shared variables.</figcaption>
+</figure>
+
+## Why this is safer
+
+The classic concurrency bug is a **data race**: two goroutines touching the same
+variable at once, one of them writing. Channels sidestep it by passing a value's
+*ownership* along the pipe — at any moment, only one goroutine holds it. That's the
+meaning of Go's motto, *share memory by communicating*. When channels aren't the
+right fit, Go's `sync` package offers locks — the subject of the next lesson.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — an unbuffered send waits for a receiver, synchronizing the two goroutines." markdown="0">
+  <p class="knowledge-check__q">Quick check: on an <em>unbuffered</em> channel, what happens when you send a value?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It's stored until someone reads it later</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The send blocks until another goroutine receives it</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It's dropped if no one is listening</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **channel** carries typed values between goroutines: `ch <- v` sends, `<-ch`
+  receives.
+- **Unbuffered** channels synchronize sender and receiver; **buffered** ones hold a
+  few values and apply backpressure.
+- **`close`** signals the end of a stream; `range` receives until it's drained.
+- Channels prevent **data races** by passing ownership instead of sharing variables.
+
+Next up: coordinating multiple channels with select, and when to reach for locks instead.

--- a/docs/learn/programming-go/concurrency-patterns.md
+++ b/docs/learn/programming-go/concurrency-patterns.md
@@ -1,0 +1,145 @@
+---
+slug: concurrency-patterns
+title: Concurrency patterns
+description: "Worker pools, pipelines, and fan-out/fan-in — the reusable shapes for structuring concurrent Go work, the way a real streaming sample pipeline is built."
+keywords: go concurrency patterns, worker pool go, pipeline pattern go, fan-out fan-in, go channels pattern, goroutine pool, streaming pipeline go
+level: advanced
+status: full
+prereq:
+  - context-and-cancellation
+faq:
+  - q: What is a worker pool?
+    a: "A fixed number of goroutines all reading jobs from one channel and writing results to another. It caps concurrency at a chosen size so you don't spawn an unbounded number of goroutines, and it spreads work evenly because whichever worker is free grabs the next job."
+  - q: What is fan-out/fan-in?
+    a: "Fan-out starts several goroutines reading from the same input channel to parallelize a slow stage. Fan-in merges their several output channels back into one. Together they let one busy stage of a pipeline run on many cores while the rest stays a single stream."
+---
+
+# Concurrency patterns
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Three shapes cover most concurrent Go. A **pipeline** chains stages, each a goroutine
+reading one channel and writing the next. A **worker pool** runs a fixed number of
+goroutines off one job channel to cap concurrency. **Fan-out/fan-in** parallelizes a
+slow stage across many goroutines, then merges the results. All three are just
+[goroutines](/learn/programming-go/goroutines/) and
+[channels](/learn/programming-go/channels/) arranged deliberately.
+</div>
+
+Once you have goroutines, channels, and context, real programs assemble them into a
+few recurring structures. This lesson shows the shapes GopherTrunk's sample pipeline
+is built from.
+
+## The pipeline
+
+A pipeline is a chain of stages connected by channels. Each stage receives on its
+input, does one job, and sends on its output — then closes it:
+
+```go
+func demod(in <-chan complex64) <-chan byte {
+    out := make(chan byte)
+    go func() {
+        defer close(out)
+        for s := range in {
+            out <- symbol(s)
+        }
+    }()
+    return out
+}
+
+symbols := demod(samples)   // stages compose: decode(demod(samples))
+```
+
+Each stage runs concurrently, so raw samples, demodulated symbols, and decoded frames
+all flow at once — exactly how an SDR engine keeps up with a live radio.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 90" role="img" aria-label="Three pipeline stages connected by channels: samples flow into demod, then decode, then frames out." xmlns="http://www.w3.org/2000/svg">
+  <rect x="10" y="30" width="110" height="34" rx="6" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="65" y="51" text-anchor="middle" font-size="11" fill="currentColor">source</text>
+  <rect x="175" y="30" width="110" height="34" rx="6" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="230" y="51" text-anchor="middle" font-size="11" fill="currentColor">demod</text>
+  <rect x="340" y="30" width="110" height="34" rx="6" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="395" y="51" text-anchor="middle" font-size="11" fill="currentColor">decode</text>
+  <line x1="120" y1="47" x2="175" y2="47" stroke="currentColor" stroke-width="1.5" marker-end="url(#pp)"/>
+  <line x1="285" y1="47" x2="340" y2="47" stroke="currentColor" stroke-width="1.5" marker-end="url(#pp)"/>
+  <line x1="450" y1="47" x2="505" y2="47" stroke="currentColor" stroke-width="1.5" marker-end="url(#pp)"/>
+  <defs><marker id="pp" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>A pipeline: each stage is a goroutine that reads one channel and writes the next; all stages run at once.</figcaption>
+</figure>
+
+## The worker pool
+
+When one stage is the bottleneck, run several copies of it — but a *fixed* number, so
+concurrency stays bounded:
+
+```go
+jobs := make(chan Frame)
+results := make(chan Decoded)
+
+for i := 0; i < runtime.NumCPU(); i++ {   // N workers
+    go func() {
+        for f := range jobs {
+            results <- decode(f)          // whichever worker is free takes the job
+        }
+    }()
+}
+```
+
+The pool self-balances: fast jobs free a worker to grab the next one immediately. Cap
+the count at something sensible (often `runtime.NumCPU()`) rather than spawning one
+goroutine per job.
+
+## Fan-out and fan-in
+
+Fan-out is starting several workers on the *same* input channel; fan-in merges their
+outputs back into one, typically with a `sync.WaitGroup`:
+
+```go
+func fanIn(cs ...<-chan Decoded) <-chan Decoded {
+    out := make(chan Decoded)
+    var wg sync.WaitGroup
+    for _, c := range cs {
+        wg.Add(1)
+        go func(c <-chan Decoded) {
+            defer wg.Done()
+            for v := range c {
+                out <- v
+            }
+        }(c)
+    }
+    go func() { wg.Wait(); close(out) }()   // close once all inputs drain
+    return out
+}
+```
+
+| Pattern | Shape | Use it when |
+|---------|-------|-------------|
+| Pipeline | stage → channel → stage | Work is a series of transforms |
+| Worker pool | N goroutines, one job channel | You must cap concurrency |
+| Fan-out/fan-in | split to many, merge to one | One stage is the bottleneck |
+
+Thread a `context` (previous lesson) through every stage so a single cancel tears the
+whole structure down cleanly.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a pool is a fixed set of goroutines sharing one job channel." markdown="0">
+  <p class="knowledge-check__q">Quick check: what makes a worker pool different from spawning a goroutine per job?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="correct">It uses a fixed number of goroutines, bounding concurrency</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It runs jobs strictly in order</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It avoids using channels entirely</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **pipeline** chains goroutine stages with channels; each closes its output when
+  done.
+- A **worker pool** runs a fixed number of goroutines off one job channel to cap
+  concurrency.
+- **Fan-out/fan-in** parallelizes a slow stage, then merges with a `WaitGroup`.
+- Thread a **`context`** through every stage for clean shutdown.
+
+Next up: how Go organizes code into packages and modules.

--- a/docs/learn/programming-go/context-and-cancellation.md
+++ b/docs/learn/programming-go/context-and-cancellation.md
@@ -1,0 +1,133 @@
+---
+slug: context-and-cancellation
+title: Context & cancellation
+description: "The context package — how one cancel signal or timeout propagates through every goroutine in a call tree to shut work down cleanly, the first argument everywhere in Go."
+keywords: go context, context.Context, WithCancel, WithTimeout, ctx.Done, cancellation go, context first argument, graceful shutdown go
+level: advanced
+status: full
+prereq:
+  - channels
+faq:
+  - q: Why is ctx the first argument to so many Go functions?
+    a: "By convention a Context is passed as the first parameter, named ctx, so a cancel signal or deadline flows explicitly down the whole call tree. Making it the first argument means every function that might block or do I/O can be told to stop, and readers can see at a glance that a call is cancellable."
+  - q: What does ctx.Done() actually give me?
+    a: "It returns a channel that is closed when the context is cancelled or its deadline passes. You select on it: when the receive succeeds (because the channel closed), it's time to stop work and return ctx.Err(). It's the standard way a goroutine learns it should shut down."
+---
+
+# Context & cancellation
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A **`context.Context`** carries a cancellation signal and deadline down a call tree.
+**`WithCancel`** and **`WithTimeout`** derive a child context plus a `cancel`
+function; calling `cancel` (or hitting the timeout) closes **`ctx.Done()`**, a
+channel every goroutine can **`select`** on to stop cleanly. By convention `ctx` is
+the **first argument** of any cancellable function.
+</div>
+
+Long-running programs need a way to say "stop now" — on shutdown, a timeout, or a
+user's Ctrl-C. This lesson covers Go's answer, `context`, which builds directly on
+[channels](/learn/programming-go/channels/) and
+[select](/learn/programming-go/select-and-sync/).
+
+## Creating a cancellable context
+
+You start from a root (`context.Background()`) and derive children that can be
+cancelled:
+
+```go
+ctx, cancel := context.WithCancel(context.Background())
+defer cancel()          // always call cancel to release resources
+
+go scan(ctx)            // pass ctx down to the work
+// ...later, to stop everything:
+cancel()
+```
+
+`WithTimeout` and `WithDeadline` do the same but also cancel automatically after a
+duration:
+
+```go
+ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+defer cancel()
+```
+
+## Reacting to cancellation
+
+The heart of it is `ctx.Done()` — a channel that closes when the context is
+cancelled. A worker `select`s on it alongside its normal work:
+
+```go
+func scan(ctx context.Context) error {
+    for {
+        select {
+        case <-ctx.Done():
+            return ctx.Err()          // Canceled or DeadlineExceeded
+        case sample := <-samples:
+            process(sample)
+        }
+    }
+}
+```
+
+The moment `cancel()` runs (or the timeout fires), the `<-ctx.Done()` case wins and
+the goroutine returns. One signal, cleanly propagated.
+
+## One signal, a whole tree
+
+Because each derived context is a child of its parent, cancelling the parent cancels
+every descendant. A single Ctrl-C at the top can shut down every goroutine in a
+GopherTrunk pipeline — the SDR reader, the demodulators, the decoder — without any of
+them knowing about each other.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 150" role="img" aria-label="A root context cancelling and the signal propagating to three child goroutines below it." xmlns="http://www.w3.org/2000/svg">
+  <rect x="200" y="15" width="120" height="30" rx="6" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="260" y="35" text-anchor="middle" font-size="11" fill="currentColor">root ctx — cancel()</text>
+  <rect x="30" y="105" width="120" height="30" rx="6" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="90" y="125" text-anchor="middle" font-size="11" fill="currentColor">reader</text>
+  <rect x="200" y="105" width="120" height="30" rx="6" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="260" y="125" text-anchor="middle" font-size="11" fill="currentColor">demod</text>
+  <rect x="370" y="105" width="120" height="30" rx="6" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="430" y="125" text-anchor="middle" font-size="11" fill="currentColor">decoder</text>
+  <line x1="245" y1="45" x2="90" y2="105" stroke="currentColor" stroke-width="1.5" marker-end="url(#ca)"/>
+  <line x1="260" y1="45" x2="260" y2="105" stroke="currentColor" stroke-width="1.5" marker-end="url(#ca)"/>
+  <line x1="275" y1="45" x2="430" y2="105" stroke="currentColor" stroke-width="1.5" marker-end="url(#ca)"/>
+  <defs><marker id="ca" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Cancelling the root context closes Done() for every child, so one signal stops the whole tree.</figcaption>
+</figure>
+
+## Rules of the road
+
+| Do | Don't |
+|----|-------|
+| Pass `ctx` as the **first** argument | Store a Context inside a struct |
+| Always call the returned `cancel` (defer it) | Pass a `nil` context |
+| Return `ctx.Err()` when Done fires | Ignore cancellation in a long loop |
+| Use `WithTimeout` for network/I/O deadlines | Use context to pass optional arguments |
+
+Follow these and cancellation becomes a habit rather than an afterthought — essential
+for the concurrent shapes in the next lesson.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — Done() closes on cancel or timeout, and select picks it up." markdown="0">
+  <p class="knowledge-check__q">Quick check: how does a goroutine learn its context was cancelled?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It polls ctx.Canceled every loop</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The channel from ctx.Done() closes, and a select on it fires</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">The runtime kills the goroutine automatically</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **`Context`** carries a cancel signal and deadline down a call tree.
+- **`WithCancel`**/**`WithTimeout`** return a child ctx and a **`cancel`** — always
+  call cancel.
+- **`ctx.Done()`** is a channel you **`select`** on; return **`ctx.Err()`** when it
+  closes.
+- Pass **`ctx` first**; cancelling a parent cancels every child.
+
+Next up: the reusable shapes of concurrent code — worker pools, pipelines, and
+fan-out/fan-in.

--- a/docs/learn/programming-go/control-flow.md
+++ b/docs/learn/programming-go/control-flow.md
@@ -1,0 +1,147 @@
+---
+slug: control-flow
+title: Control flow
+description: "if, for, and switch — Go's deliberately small set of control structures, including the single loop keyword that replaces while, do-while, and for-each."
+keywords: go control flow, go for loop, go if statement, go switch, go while loop, go range, switch fallthrough
+level: beginner
+status: full
+prereq:
+  - values-and-types
+faq:
+  - q: Does Go have a while loop?
+    a: "No — and it doesn't need one. Go has exactly one loop keyword, for, and it covers every case: for cond {} is a while loop, for {} is an infinite loop, and for i := 0; i < n; i++ {} is the classic counted loop. One keyword, three shapes."
+  - q: Does a Go switch fall through to the next case?
+    a: "No. Unlike C, each Go case breaks automatically — there is no accidental fall-through. If you genuinely want the next case to run too, you add an explicit fallthrough statement, which is rare."
+---
+
+# Control flow
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Go keeps control flow tiny: **`if`**, **`for`**, and **`switch`**. There is no
+`while` — the single **`for`** keyword does counted loops, condition loops, infinite
+loops, and (with **`range`**) iteration over collections. A **`switch`** breaks after
+each case by default, so there is no accidental fall-through. Small set, few
+surprises.
+</div>
+
+This lesson covers every way Go changes the path a program takes. It builds on
+[Values, variables & types](/learn/programming-go/values-and-types/) and sets up
+[Functions & error handling](/learn/programming-go/functions-and-errors/), where
+`if err != nil` becomes the most-used branch in the language.
+
+## How does `if` work in Go?
+
+An `if` needs no parentheses around its condition, and the braces are always
+required:
+
+```go
+if snr < 6.0 {
+    return errNoLock
+}
+```
+
+Go adds one twist — an `if` can declare a variable scoped to the branch:
+
+```go
+if peak := findPeak(fft); peak.Power > threshold {
+    tune(peak.FreqHz)   // peak is visible here...
+}
+// ...and gone here.
+```
+
+This keeps short-lived values out of the surrounding scope, which is why you'll see
+`if err := do(); err != nil { ... }` everywhere in Go.
+
+## The one loop: `for`
+
+Go has no `while` and no `do`. Everything loops with `for`, in three shapes:
+
+```go
+for i := 0; i < 8; i++ {        // classic counted loop
+    process(taps[i])
+}
+
+for scanning {                  // condition-only — this is Go's "while"
+    scanning = step()
+}
+
+for {                           // no condition — loop forever
+    sample := <-samples
+    handle(sample)              // break or return to stop
+}
+```
+
+To walk a slice, map, or channel, add `range`:
+
+```go
+for i, s := range symbols {     // index and value
+    decode(i, s)
+}
+for freq := range channels {    // map: keys
+    tune(freq)
+}
+```
+
+`range` over a channel receives until it is closed — the pattern GopherTrunk's
+sample pipeline uses to drain a stream of `complex64` values.
+
+## What makes Go's `switch` different?
+
+A `switch` is a cleaner chain of `if`/`else`. Crucially, each case **breaks
+automatically** — no `break` needed, no accidental fall-through:
+
+```go
+switch mode {
+case "P25":
+    decodeP25(frame)
+case "DMR", "NXDN":     // one case, several values
+    decodeTDMA(frame)
+default:
+    log.Printf("unknown mode %q", mode)
+}
+```
+
+You can also omit the value and use `switch` as a tidy if-chain:
+
+```go
+switch {
+case snr > 20:
+    quality = "excellent"
+case snr > 8:
+    quality = "usable"
+default:
+    quality = "no lock"
+}
+```
+
+The table below sums up the whole toolkit.
+
+| Construct | Shape | Use it for |
+|-----------|-------|-----------|
+| `if` / `else` | `if cond { }` | A one-off branch, often `if err != nil` |
+| `for` (counted) | `for i := 0; i < n; i++` | A known number of iterations |
+| `for` (condition) | `for cond { }` | Go's `while` loop |
+| `for` (infinite) | `for { }` | Loop until `break`/`return` |
+| `for range` | `for k, v := range x` | Walking slices, maps, channels |
+| `switch` | `switch x { case … }` | Many branches on one value |
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — Go's for is its while; there is no separate while keyword." markdown="0">
+  <p class="knowledge-check__q">Quick check: how do you write a while loop in Go?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">With the while keyword</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">With for and a single condition: for cond { }</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">With a do…until block</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **`if`** needs no parentheses and can declare a branch-scoped variable.
+- **`for`** is Go's only loop — counted, condition (its `while`), infinite, or
+  `range`.
+- **`range`** walks slices, maps, and channels.
+- **`switch`** breaks after each case by default; `fallthrough` is opt-in and rare.
+
+Next up: functions, multiple return values, and Go's `error` type.

--- a/docs/learn/programming-go/debugging-go.md
+++ b/docs/learn/programming-go/debugging-go.md
@@ -1,0 +1,115 @@
+---
+slug: debugging-go
+title: Debugging Go
+description: "Finding bugs with print debugging, the delve debugger, the race detector, and static analysis — the toolkit for when a test goes red and you need to know why."
+keywords: go debugging, delve, dlv, go test -race, race detector, go vet, staticcheck, print debugging go, go debugger
+level: intermediate
+status: full
+prereq:
+  - testing-in-go
+faq:
+  - q: What is the Go race detector and when should I use it?
+    a: "It's a runtime tool you enable with go test -race (or go run -race). It instruments memory access and reports when two goroutines touch the same variable concurrently with at least one write — a data race. Run it whenever you change concurrent code; races are timing-dependent and may not show up otherwise."
+  - q: Do I need Delve, or is print debugging enough?
+    a: "Both have their place. A quick fmt.Println or log line is often the fastest way to see a value. Delve (dlv) earns its keep when you need to pause execution, step line by line, inspect goroutines, and set conditional breakpoints — especially in code that's hard to reproduce with prints alone."
+---
+
+# Debugging Go
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+When a test goes red, Go gives you a layered toolkit. **Print debugging** (`fmt` /
+`log`) is the fast first move. **Delve** (**`dlv`**) is the real debugger — breakpoints,
+stepping, inspecting goroutines. **`go test -race`** catches data races. And static
+analysis — **`go vet`** and **staticcheck** — flags whole classes of bugs before you
+ever run the code.
+</div>
+
+Every programmer spends more time finding bugs than writing them. This lesson covers
+Go's debugging tools, which pair naturally with the
+[testing](/learn/programming-go/testing-in-go/) habit of reproducing a bug as a
+failing test first.
+
+## Start with print debugging
+
+The fastest way to see what a program is doing is often to print it:
+
+```go
+log.Printf("demod: snr=%.1f symbols=%d locked=%v", snr, n, locked)
+```
+
+Use `log` over `fmt.Println` for anything you might keep — it timestamps and can be
+turned off. The `%+v` verb prints a struct with field names, and `%#v` prints it as
+Go source, both invaluable for inspecting a value:
+
+```go
+log.Printf("%+v", cfg)   // {Gain:20 FreqHz:4.60025e+08 Active:true}
+```
+
+## Delve, the real debugger
+
+When prints aren't enough, `dlv` lets you stop time. Debug a test and step through it:
+
+```
+$ dlv test ./internal/scanner
+(dlv) break Demodulate       # set a breakpoint
+(dlv) continue               # run to it
+(dlv) print snr              # inspect a variable
+(dlv) next                   # step one line
+(dlv) goroutines             # list all goroutines
+```
+
+Breakpoints, single-stepping, and goroutine inspection make it the tool for bugs you
+can't pin down with prints — a wedged goroutine, a value that's wrong only sometimes.
+
+## The race detector
+
+Concurrency bugs are the ones prints hide, because adding a print changes the timing.
+The race detector finds them properly:
+
+```
+$ go test -race ./...
+==================
+WARNING: DATA RACE
+Write at 0x00c0000b4010 by goroutine 7:
+  ...
+Previous read at 0x00c0000b4010 by goroutine 6:
+  ...
+```
+
+It reports the exact two accesses and their goroutines. Run `-race` whenever you touch
+[channels](/learn/programming-go/channels/) or shared state — it's how GopherTrunk
+keeps its multi-goroutine sample pipeline honest.
+
+## Static analysis catches bugs before you run
+
+Some bugs never need to run to be found. The table lists Go's analysis layers.
+
+| Tool | Catches |
+|------|---------|
+| `go vet` | Printf format mistakes, unreachable code, bad struct tags |
+| `go test -race` | Data races between goroutines |
+| `staticcheck` | Dead code, misused APIs, needless conversions |
+| `gofmt` / `go vet` in CI | Style and correctness gates on every push |
+
+GopherTrunk's `make vet test` gate runs `go vet` plus the full suite before any
+commit — so an entire category of mistakes is caught automatically, not in review.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — -race instruments memory access to catch concurrent read/write bugs." markdown="0">
+  <p class="knowledge-check__q">Quick check: which tool finds two goroutines touching the same variable at once?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">gofmt</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">go test -race, the race detector</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">go build</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Print debugging** with `log` and `%+v`/`%#v` is the fast first move.
+- **Delve** (`dlv`) gives breakpoints, stepping, and goroutine inspection.
+- **`go test -race`** catches data races that timing hides.
+- **`go vet`** and **staticcheck** catch bug classes before the code runs.
+
+Next up: a tour of the batteries the standard library ships with.

--- a/docs/learn/programming-go/dependency-management.md
+++ b/docs/learn/programming-go/dependency-management.md
@@ -1,0 +1,102 @@
+---
+slug: dependency-management
+title: Dependency management
+description: "How go.mod and go.sum pin versions, how go get and go mod tidy manage dependencies, and why reproducible builds and a small dependency tree matter."
+keywords: go modules, go.mod, go.sum, go get, go mod tidy, semantic versioning, go dependencies, vendoring, reproducible build
+level: intermediate
+status: full
+prereq:
+  - packages-and-modules
+faq:
+  - q: What's the difference between go.mod and go.sum?
+    a: "go.mod lists your module's path, its Go version, and the versions of the dependencies you require — it's the human-readable declaration. go.sum records a cryptographic checksum for every module version, so the toolchain can verify that what it downloads is byte-for-byte what you locked. go.mod says what; go.sum proves it hasn't changed."
+  - q: What does go mod tidy do?
+    a: "It reconciles go.mod and go.sum with what your code actually imports — adding any dependency you use but haven't declared, and removing any you declared but no longer import. Running it keeps the module files honest, which is why it's a common pre-commit step."
+---
+
+# Dependency management
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A module's dependencies live in **`go.mod`** (what versions you require) and
+**`go.sum`** (checksums that prove those versions haven't changed). **`go get`** adds
+or upgrades a dependency; **`go mod tidy`** syncs the files to what your code actually
+imports. Versions follow **semantic versioning**, and the checksums give you
+**reproducible builds** — everyone compiles the exact same code.
+</div>
+
+Every non-trivial program uses code someone else wrote. This lesson covers how Go
+tracks that code, building on
+[Packages & modules](/learn/programming-go/packages-and-modules/).
+
+## go.mod and go.sum
+
+A module is a tree of packages with a `go.mod` at its root. It declares the module
+path, the Go version, and each dependency's version:
+
+```
+module github.com/example/gophertrunk
+
+go 1.22
+
+require (
+    github.com/some/dsp v1.4.2
+    golang.org/x/sync v0.7.0
+)
+```
+
+Alongside it, `go.sum` stores a checksum for every module version the build uses.
+When the toolchain downloads a dependency, it verifies the bytes against `go.sum` —
+so a tampered or changed release fails the build instead of silently slipping in.
+
+## Adding and updating dependencies
+
+You rarely edit `go.mod` by hand. The commands do it:
+
+| Command | What it does |
+|---------|-------------|
+| `go get github.com/some/dsp@v1.5.0` | Add or move to a specific version |
+| `go get -u ./...` | Upgrade dependencies to newer minor/patch versions |
+| `go mod tidy` | Add missing and drop unused dependencies |
+| `go mod download` | Fetch everything `go.mod` lists into the cache |
+| `go mod verify` | Check the cache matches `go.sum` |
+
+Just importing a package and running `go mod tidy` is the usual way to pick up a new
+dependency — the tool finds the import, resolves a version, and records both files.
+
+## Semantic versioning
+
+Go leans hard on **semver** — `vMAJOR.MINOR.PATCH`. A patch or minor bump promises
+backward compatibility; a **major** bump (v2+) is a breaking change and, by Go's
+import-compatibility rule, even changes the import path (`.../dsp/v2`). This is what
+lets `go get -u` safely pull bug fixes without breaking your build.
+
+## Why a small dependency tree matters
+
+Every dependency is code you now ship, trust, and must keep updated. Go's culture —
+and GopherTrunk's — favours a **lean** tree: reach for the
+[standard library](/learn/programming-go/the-standard-library/) first, add a
+dependency only when it earns its place. Fewer dependencies means faster builds, a
+smaller attack surface, and less breakage when you upgrade. For fully offline or
+audited builds, `go mod vendor` copies dependencies into a `vendor/` directory that
+the build uses instead of the network.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — go.sum holds checksums that verify each dependency's bytes." markdown="0">
+  <p class="knowledge-check__q">Quick check: what is the job of the go.sum file?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It lists which packages your code imports</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">It records checksums so downloaded dependencies can be verified</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It stores your module's own version number</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **`go.mod`** declares required dependency versions; **`go.sum`** stores checksums to
+  verify them.
+- **`go get`** adds/upgrades; **`go mod tidy`** syncs the files to real imports.
+- Versions follow **semantic versioning**; a major bump changes the import path.
+- Prefer a **small** dependency tree; `go mod vendor` supports offline builds.
+
+Next up: error-handling patterns beyond the basic `if err != nil`.

--- a/docs/learn/programming-go/error-handling-patterns.md
+++ b/docs/learn/programming-go/error-handling-patterns.md
@@ -1,0 +1,130 @@
+---
+slug: error-handling-patterns
+title: Error-handling patterns
+description: "Beyond if err != nil — wrapping errors with %w, sentinel errors, errors.Is and errors.As, and custom error types for programs that fail informatively."
+keywords: go error handling, fmt.Errorf %w, errors.Is, errors.As, sentinel error, wrapped error, custom error type go, error wrapping
+level: advanced
+status: full
+prereq:
+  - functions-and-errors
+faq:
+  - q: What does %w do in fmt.Errorf?
+    a: "It wraps an underlying error inside a new one while preserving the original for later inspection. fmt.Errorf(\"open capture: %w\", err) adds context to the message and keeps err reachable, so errors.Is and errors.As can still find it further up the stack."
+  - q: When do I use errors.Is versus errors.As?
+    a: "Use errors.Is to test whether an error chain contains a specific sentinel value, like errors.Is(err, io.EOF). Use errors.As to pull a specific error type out of the chain so you can read its fields, like errors.As(err, &pathErr). Is asks which value; As asks which type."
+---
+
+# Error-handling patterns
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Go returns errors as values, and real programs add structure. **Wrap** an error with
+**`fmt.Errorf("...: %w", err)`** to add context while keeping the original. Compare
+against a **sentinel** with **`errors.Is`**, and extract a **custom error type** with
+**`errors.As`**. Define your own error types when callers need more than a message.
+These patterns turn `if err != nil` into errors that are useful, not just present.
+</div>
+
+The [functions & errors](/learn/programming-go/functions-and-errors/) lesson
+introduced the `error` interface. This one covers the patterns that make errors carry
+real information as they travel up a call stack.
+
+## Wrapping with %w
+
+As an error bubbles up, each layer should add context — where it happened — without
+discarding the cause. The `%w` verb wraps:
+
+```go
+func loadConfig(path string) (*Config, error) {
+    data, err := os.ReadFile(path)
+    if err != nil {
+        return nil, fmt.Errorf("load config %s: %w", path, err)
+    }
+    // ...
+}
+```
+
+The message becomes `load config scan.json: open scan.json: no such file or
+directory` — a breadcrumb trail — and the wrapped error stays reachable underneath.
+Use `%w` (wrap) when callers may inspect the cause; use `%v` (format) when you only
+want the text.
+
+## Sentinel errors and errors.Is
+
+A **sentinel** is a named error value that callers can test against:
+
+```go
+var ErrNoLock = errors.New("decoder: no signal lock")
+
+func decode(f Frame) error {
+    if f.SNR < 6 {
+        return ErrNoLock
+    }
+    return nil
+}
+
+if errors.Is(err, ErrNoLock) {   // matches even through wrapping
+    retry()
+}
+```
+
+`errors.Is` walks the whole wrapped chain, so a deeply wrapped `ErrNoLock` is still
+found. That is why you test with `errors.Is` rather than `err == ErrNoLock`.
+
+## Custom error types and errors.As
+
+When callers need *data* about the failure — not just its identity — define a type
+that implements `error`:
+
+```go
+type DecodeError struct {
+    FreqHz float64
+    Symbol int
+}
+
+func (e *DecodeError) Error() string {
+    return fmt.Sprintf("decode failed at %.3f MHz, symbol %d", e.FreqHz/1e6, e.Symbol)
+}
+```
+
+Pull it back out with `errors.As`, which finds the first error of that type in the
+chain and assigns it:
+
+```go
+var de *DecodeError
+if errors.As(err, &de) {
+    log.Printf("bad symbol %d at %.3f MHz", de.Symbol, de.FreqHz/1e6)
+}
+```
+
+| Tool | Question it answers | Example |
+|------|--------------------|---------|
+| `fmt.Errorf("...: %w", err)` | How do I add context? | `open capture: %w` |
+| sentinel + `errors.Is` | Is this *that* error? | `errors.Is(err, io.EOF)` |
+| custom type + `errors.As` | What are the details? | `errors.As(err, &de)` |
+
+## When to wrap, when to handle
+
+Not every error needs wrapping. A rule of thumb: **handle** an error where you can do
+something about it (retry, default, log-and-continue), and **wrap-and-return** it
+everywhere else so the layer that can act still has the context it needs. Wrapping
+once per boundary keeps messages informative without turning them into noise.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — %w wraps the cause and keeps it reachable for errors.Is/As." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does wrapping with <em>%w</em> preserve that <em>%v</em> does not?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">The stack trace</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The underlying error, so errors.Is/As can still find it</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">The line number where it occurred</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Wrap** with **`fmt.Errorf("...: %w", err)`** to add context and keep the cause.
+- Define a **sentinel** and test it with **`errors.Is`** (works through wrapping).
+- Define a **custom error type** and extract it with **`errors.As`** for details.
+- **Handle** where you can act; **wrap-and-return** everywhere else.
+
+Next up: proving your code works with Go's built-in testing package.

--- a/docs/learn/programming-go/functions-and-errors.md
+++ b/docs/learn/programming-go/functions-and-errors.md
@@ -1,0 +1,124 @@
+---
+slug: functions-and-errors
+title: Functions & error handling
+description: Go functions, multiple return values, and the error interface — why Go returns errors as ordinary values instead of throwing exceptions, and the if err != nil pattern you'll see everywhere.
+keywords: go functions, multiple return values, go error handling, error interface, if err nil, go errors, named returns, defer
+level: beginner
+status: full
+prereq:
+  - values-and-types
+faq:
+  - q: Why doesn't Go have exceptions?
+    a: Go's designers felt exceptions hide the error paths and make control flow hard to follow. Instead, a function that can fail returns an error value alongside its result, and the caller decides what to do right there. The code is more explicit — you can see every place an error is handled — at the cost of a little more typing.
+  - q: What does if err != nil mean?
+    a: It's the standard Go idiom for checking whether the function you just called failed. Functions return an `error` that is `nil` on success and non-nil on failure, so `if err != nil { ... }` means "if something went wrong, handle it here" — usually by returning the error up to the caller or logging it.
+---
+
+# Functions & error handling
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Go functions can return **multiple values**, and the idiom is to return a result
+plus an **`error`**. There are **no exceptions**: a function that can fail hands
+back an `error` that is **`nil`** on success, and the caller checks it with **`if
+err != nil`**. This makes every failure path visible in the code.
+</div>
+
+Functions are where Go's philosophy shows most clearly. This lesson covers how you
+write them and the error-handling style that pervades every Go program you'll ever
+read.
+
+## Writing a function
+
+```go
+func channelWidth(highHz, lowHz float64) float64 {
+    return highHz - lowHz
+}
+```
+
+Parameters come with their types; the return type comes after the parentheses. When
+consecutive parameters share a type you can write it once (`highHz, lowHz float64`).
+
+## Multiple return values
+
+A Go function can return several values at once — used constantly to return "the
+answer, and whether it worked":
+
+```go
+func tune(freqHz float64) (float64, error) {
+    if freqHz <= 0 {
+        return 0, fmt.Errorf("invalid frequency: %v", freqHz)
+    }
+    return freqHz, nil
+}
+```
+
+The second return value is an **`error`**. On success it is `nil`; on failure it
+carries a message.
+
+## The error pattern
+
+Because errors are just values, the caller handles them immediately:
+
+```go
+freq, err := tune(-5)
+if err != nil {
+    return err        // pass the problem up to whoever called us
+}
+// safe to use freq here — we know tune succeeded
+```
+
+You will see `if err != nil` on a huge fraction of Go lines. It can feel repetitive,
+but it means the error paths are right there in front of you — nothing is hidden in
+an invisible exception jumping up the stack.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 120" role="img" aria-label="A function returning two values, result and error, with the caller branching on whether error is nil." xmlns="http://www.w3.org/2000/svg">
+  <rect x="10" y="45" width="130" height="34" rx="6" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="75" y="67" text-anchor="middle" font-size="12" fill="currentColor">tune(freq)</text>
+  <line x1="140" y1="62" x2="210" y2="62" stroke="currentColor" stroke-width="1.5"/>
+  <text x="250" y="52" text-anchor="middle" font-size="12" fill="currentColor">result, err</text>
+  <line x1="290" y1="62" x2="350" y2="40" stroke="currentColor" stroke-width="1.5"/>
+  <line x1="290" y1="62" x2="350" y2="88" stroke="currentColor" stroke-width="1.5"/>
+  <text x="430" y="44" text-anchor="middle" font-size="12" fill="currentColor">err == nil -> use result</text>
+  <text x="430" y="94" text-anchor="middle" font-size="12" fill="currentColor">err != nil -> handle it</text>
+</svg>
+<figcaption>Every fallible call forks the same way: success uses the result; failure handles the error.</figcaption>
+</figure>
+
+## defer: cleanup that always runs
+
+`defer` schedules a call to run when the surrounding function returns, no matter how
+it returns. It's the standard way to release resources:
+
+```go
+f, err := os.Open("capture.cfile")
+if err != nil {
+    return err
+}
+defer f.Close()   // runs when this function exits, success or error
+```
+
+This keeps "open" and "close" next to each other and guarantees the file is closed
+even on an early error return.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a nil error means the call succeeded." markdown="0">
+  <p class="knowledge-check__q">Quick check: a function returns <code>(value, error)</code>. What does an <code>error</code> of <code>nil</code> mean?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="correct">The call succeeded</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">The call failed</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">The value is empty</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Go functions declare parameter and return types and can **return multiple
+  values**.
+- Fallible functions return an **`error`**; it is **`nil`** on success.
+- The **`if err != nil`** idiom handles failures explicitly — Go has **no
+  exceptions**.
+- **`defer`** guarantees cleanup runs when a function returns.
+
+Next up: bundling data together with structs and giving it behaviour with methods.

--- a/docs/learn/programming-go/glossary.md
+++ b/docs/learn/programming-go/glossary.md
@@ -1,0 +1,148 @@
+---
+slug: glossary
+title: Glossary of Go terms
+description: Plain-language definitions of Go programming terms — goroutine, channel, interface, slice, map, struct, method, package, module, and more — each cross-linked to the lesson where it's explained.
+keywords: go glossary, golang terms, go terminology, goroutine channel interface definition, go dictionary, slice map struct method
+level: beginner
+status: full
+lesson_standalone: true
+---
+
+# Glossary of Go terms
+
+Every term used across the [Go module](/learn/programming-go/), defined in plain
+language and linked to the lesson where it's explained in full. Skim it as a
+refresher, or use your browser's find (Ctrl/Cmd-F) to jump to a word. Terms are
+grouped by theme.
+
+## Language basics
+
+**Go (Golang)** — A statically typed, compiled, garbage-collected programming
+language built at Google for simple, fast systems software. See [Why Go?](/learn/programming-go/why-go/)
+
+**Compiled** — Turned into native machine code ahead of time, rather than
+interpreted as it runs. Go programs compile to a single binary. See [Why Go?](/learn/programming-go/why-go/)
+
+**Statically typed** — Every value's type is known at compile time, so type errors
+are caught before the program runs. See [Values, variables & types](/learn/programming-go/values-and-types/)
+
+**Binary** — The single self-contained executable file `go build` produces, runnable
+without Go installed. See [Your first Go program](/learn/programming-go/hello-go/)
+
+**`package main`** — The special package that produces a runnable command; it must
+contain a `func main()` entry point. See [Your first Go program](/learn/programming-go/hello-go/)
+
+**Zero value** — The default value a variable takes when declared without one: `0`,
+`false`, `""`, or `nil`. See [Values, variables & types](/learn/programming-go/values-and-types/)
+
+**`const`** — A declaration for a value that never changes. See [Values, variables & types](/learn/programming-go/values-and-types/)
+
+## The toolchain
+
+**`go build` / `go run`** — Compile to a keepable binary, or compile-and-run once.
+See [The Go toolchain](/learn/programming-go/the-go-toolchain/)
+
+**`gofmt`** — The tool that rewrites code into Go's one official style. See [The Go toolchain](/learn/programming-go/the-go-toolchain/)
+
+**`go vet`** — A tool that flags suspicious, likely-buggy code that still compiles.
+See [The Go toolchain](/learn/programming-go/the-go-toolchain/)
+
+**`go.mod`** — The file that defines a module and pins its dependency versions. See
+[Packages & modules](/learn/programming-go/packages-and-modules/)
+
+## Functions and types
+
+**Function** — A named block of code that takes parameters and can return values;
+Go functions can return **multiple** values. See [Functions & error handling](/learn/programming-go/functions-and-errors/)
+
+**`error`** — The built-in interface a fallible function returns; `nil` means
+success. See [Functions & error handling](/learn/programming-go/functions-and-errors/)
+
+**`if err != nil`** — The standard idiom for handling a failed call. See [Functions & error handling](/learn/programming-go/functions-and-errors/)
+
+**`defer`** — Schedules a call to run when the surrounding function returns, used for
+cleanup. See [Functions & error handling](/learn/programming-go/functions-and-errors/)
+
+**Struct** — A type that groups named fields together. See [Structs & methods](/learn/programming-go/structs-and-methods/)
+
+**Method** — A function attached to a type through a **receiver**. See [Structs & methods](/learn/programming-go/structs-and-methods/)
+
+**Receiver** — The type a method belongs to; a **pointer receiver** (`*T`) can modify
+the value, a **value receiver** (`T`) works on a copy. See [Structs & methods](/learn/programming-go/structs-and-methods/)
+
+**Embedding** — Placing one struct (or interface) inside another to reuse its fields
+and methods — Go's composition in place of inheritance. See [Structs & methods](/learn/programming-go/structs-and-methods/)
+
+**Interface** — A set of method signatures; a type satisfies it **implicitly** by
+having those methods. See [Interfaces & composition](/learn/programming-go/interfaces/)
+
+**`io.Reader`** — The one-method standard interface for "something you can read bytes
+from," satisfied by files, sockets, buffers, and more. See [The standard library](/learn/programming-go/the-standard-library/)
+
+## Concurrency
+
+**Concurrency** — Structuring a program as independently running tasks (distinct from
+parallelism, running them literally at once). See [Goroutines](/learn/programming-go/goroutines/)
+
+**Goroutine** — A function launched with the `go` keyword that runs concurrently;
+lightweight and scheduled by Go's runtime. See [Goroutines](/learn/programming-go/goroutines/)
+
+**Channel** — A typed pipe that passes values between goroutines; `ch <- v` sends,
+`<-ch` receives. See [Channels](/learn/programming-go/channels/)
+
+**Buffered / unbuffered channel** — Unbuffered channels make sender and receiver
+rendezvous; buffered channels hold a set number of values. See [Channels](/learn/programming-go/channels/)
+
+**Data race** — A bug where goroutines access the same variable at once with no
+synchronization; caught by `go test -race`. See [Channels](/learn/programming-go/channels/)
+
+**`select`** — A statement that waits on multiple channel operations and proceeds with
+whichever is ready first. See [select & synchronization](/learn/programming-go/select-and-sync/)
+
+**`sync.Mutex`** — A lock that guards shared state so only one goroutine enters a
+critical section at a time. See [select & synchronization](/learn/programming-go/select-and-sync/)
+
+**`sync.WaitGroup`** — A counter that lets one goroutine wait for a group of others to
+finish. See [select & synchronization](/learn/programming-go/select-and-sync/)
+
+**`context`** — A value that carries cancellation and deadlines across a call tree.
+See [select & synchronization](/learn/programming-go/select-and-sync/)
+
+## Code organization
+
+**Package** — A directory of Go files compiled together and imported as a unit. See
+[Packages & modules](/learn/programming-go/packages-and-modules/)
+
+**Module** — A versioned collection of packages defined by `go.mod`. See [Packages & modules](/learn/programming-go/packages-and-modules/)
+
+**Exported / unexported** — A capitalized name is exported (visible to other
+packages); a lowercase name is private to its package. See [Packages & modules](/learn/programming-go/packages-and-modules/)
+
+**`internal/`** — A directory whose packages can only be imported within the same
+module. See [Packages & modules](/learn/programming-go/packages-and-modules/)
+
+## Collections and generics
+
+**Slice** — A growable, ordered view into an array, extended with `append`. See [Slices, maps & generics](/learn/programming-go/slices-maps-generics/)
+
+**Map** — A key/value lookup table; the `value, ok` form reports whether a key is
+present. See [Slices, maps & generics](/learn/programming-go/slices-maps-generics/)
+
+**`append` / `make` / `copy`** — Built-ins to grow a slice, allocate a slice/map, and
+copy slice contents. See [Slices, maps & generics](/learn/programming-go/slices-maps-generics/)
+
+**Generics (type parameters)** — Writing one function or type that works across many
+types safely, added in Go 1.18. See [Slices, maps & generics](/learn/programming-go/slices-maps-generics/)
+
+## Testing
+
+**`go test`** — The command that runs tests in `_test.go` files. See [Testing in Go](/learn/programming-go/testing-in-go/)
+
+**Table-driven test** — A test that lists its cases as data and loops over them,
+Go's dominant testing style. See [Testing in Go](/learn/programming-go/testing-in-go/)
+
+**Benchmark** — A `func BenchmarkX(b *testing.B)` that measures performance with `go
+test -bench`. See [Testing in Go](/learn/programming-go/testing-in-go/)
+
+**Standard library** — The large set of packages Go ships with — `io`, `net/http`,
+`encoding/json`, and many more — reducing the need for dependencies. See [The standard library](/learn/programming-go/the-standard-library/)

--- a/docs/learn/programming-go/glossary.md
+++ b/docs/learn/programming-go/glossary.md
@@ -146,3 +146,63 @@ test -bench`. See [Testing in Go](/learn/programming-go/testing-in-go/)
 
 **Standard library** — The large set of packages Go ships with — `io`, `net/http`,
 `encoding/json`, and many more — reducing the need for dependencies. See [The standard library](/learn/programming-go/the-standard-library/)
+
+## Control flow & memory
+
+**Control flow** — Go's small set of control structures: `if`, a single `for` loop
+that covers every looping case, and `switch`. See [Control flow](/learn/programming-go/control-flow/)
+
+**Pointer** — A value holding the address of another value; Go has pointers (`*T`, `&x`)
+but no pointer arithmetic. See [Pointers](/learn/programming-go/pointers/)
+
+## Data & text
+
+**Rune** — Go's name for a Unicode code point (an `int32`); ranging over a string yields
+runes, not bytes. See [Strings, bytes & runes](/learn/programming-go/strings-and-runes/)
+
+**Struct tag** — A string annotation on a struct field (like `json:"name"`) that guides
+encoding such as JSON. See [JSON & serialization](/learn/programming-go/json-and-serialization/)
+
+**Marshal / Unmarshal** — Converting a Go value to JSON (marshal) and back (unmarshal)
+with `encoding/json`. See [JSON & serialization](/learn/programming-go/json-and-serialization/)
+
+**bufio** — Buffered wrappers around readers and writers for efficient I/O. See [Working with files & I/O](/learn/programming-go/working-with-files/)
+
+## Concurrency
+
+**Context** — A value carrying cancellation and deadlines through a call tree; passed as
+the first argument by convention. See [Context & cancellation](/learn/programming-go/context-and-cancellation/)
+
+**Worker pool** — A fixed set of goroutines pulling jobs off a channel — a core
+concurrency pattern. See [Concurrency patterns](/learn/programming-go/concurrency-patterns/)
+
+**Pipeline / fan-out / fan-in** — Composing stages connected by channels, splitting work
+across goroutines and merging results. See [Concurrency patterns](/learn/programming-go/concurrency-patterns/)
+
+## Dependencies, errors & quality
+
+**`go.sum`** — The file recording cryptographic checksums of dependencies for
+reproducible, verifiable builds. See [Dependency management](/learn/programming-go/dependency-management/)
+
+**Error wrapping** — Adding context to an error with `fmt.Errorf("...: %w", err)`,
+inspected later with `errors.Is` / `errors.As`. See [Error-handling patterns](/learn/programming-go/error-handling-patterns/)
+
+**Sentinel error** — A predefined error value (like `io.EOF`) compared against with
+`errors.Is`. See [Error-handling patterns](/learn/programming-go/error-handling-patterns/)
+
+**Benchmark / pprof** — A `func BenchmarkX(b *testing.B)` measuring performance, and the
+profiler for finding hot paths. See [Benchmarking & profiling](/learn/programming-go/benchmarking-and-profiling/)
+
+**delve** — The Go debugger (`dlv`) for stepping through code and inspecting state. See
+[Debugging Go](/learn/programming-go/debugging-go/)
+
+**`log/slog`** — The standard structured-logging package: leveled log records with
+key/value attributes. See [Logging with slog](/learn/programming-go/logging-and-slog/)
+
+## Idioms & structure
+
+**`cmd/` and `internal/`** — Conventional directories for entry points and private
+packages in a Go repository. See [Structuring a Go project](/learn/programming-go/project-structure/)
+
+**Idiomatic Go** — Code written the community way: gofmt-formatted, explicit errors,
+small interfaces, clear names. See [Writing idiomatic Go](/learn/programming-go/idiomatic-go/)

--- a/docs/learn/programming-go/goroutines.md
+++ b/docs/learn/programming-go/goroutines.md
@@ -1,0 +1,108 @@
+---
+slug: goroutines
+title: Goroutines
+description: Goroutines are Go's lightweight concurrency primitive — what they are, how they differ from operating-system threads, and why a program like GopherTrunk can run thousands of them at once.
+keywords: goroutines, go concurrency, go routine, lightweight threads, go scheduler, concurrent programming, go keyword
+level: intermediate
+status: full
+prereq:
+  - interfaces
+faq:
+  - q: What is the difference between a goroutine and a thread?
+    a: A goroutine is a function managed by Go's own runtime scheduler, not directly by the operating system. Goroutines start with a tiny stack (a few kilobytes) that grows as needed, so you can run tens of thousands of them; OS threads are heavier, so you typically have far fewer. Go multiplexes many goroutines onto a small pool of real threads for you.
+  - q: Is concurrency the same as parallelism?
+    a: No. Concurrency is structuring a program as independently running tasks; parallelism is those tasks literally executing at the same instant on multiple CPU cores. Goroutines give you concurrency; whether they run in parallel depends on how many cores are available. Go handles the mapping automatically.
+---
+
+# Goroutines
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A **goroutine** is a function launched with the **`go`** keyword that runs
+concurrently with the rest of your program. Goroutines are **lightweight** — managed
+by Go's runtime, starting at a few kilobytes — so a program can run thousands. This
+is Go's headline feature, and it's why a real-time engine like GopherTrunk can juggle
+many signal streams at once.
+</div>
+
+Everything so far has run top to bottom, one line at a time. This lesson introduces
+concurrency: doing several things at once, the Go way.
+
+## Launching a goroutine
+
+Put `go` in front of a function call and it runs concurrently — the calling code
+does not wait for it:
+
+```go
+go processSamples(stream)   // runs alongside everything below
+fmt.Println("kicked off processing")
+```
+
+`processSamples` now runs independently while `main` carries on. That one keyword is
+the entire syntax for starting concurrent work.
+
+## Why goroutines are cheap
+
+A goroutine is **not** an operating-system thread. Go's runtime keeps a small pool
+of real threads and schedules many goroutines onto them, each starting with a tiny
+stack that grows only if needed.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 150" role="img" aria-label="Many goroutines multiplexed by the Go scheduler onto a few operating-system threads." xmlns="http://www.w3.org/2000/svg">
+  <text x="60" y="20" text-anchor="middle" font-size="12" fill="currentColor">goroutines</text>
+  <circle cx="20" cy="45" r="9" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <circle cx="45" cy="45" r="9" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <circle cx="70" cy="45" r="9" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <circle cx="95" cy="45" r="9" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <circle cx="20" cy="70" r="9" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <circle cx="45" cy="70" r="9" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <rect x="200" y="45" width="120" height="34" rx="6" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="260" y="67" text-anchor="middle" font-size="12" fill="currentColor">Go scheduler</text>
+  <line x1="110" y1="57" x2="200" y2="60" stroke="currentColor" stroke-opacity="0.5" stroke-width="1"/>
+  <line x1="320" y1="62" x2="400" y2="45" stroke="currentColor" stroke-opacity="0.5" stroke-width="1"/>
+  <line x1="320" y1="62" x2="400" y2="80" stroke="currentColor" stroke-opacity="0.5" stroke-width="1"/>
+  <rect x="400" y="35" width="100" height="24" rx="4" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="450" y="51" text-anchor="middle" font-size="11" fill="currentColor">OS thread</text>
+  <rect x="400" y="70" width="100" height="24" rx="4" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="450" y="86" text-anchor="middle" font-size="11" fill="currentColor">OS thread</text>
+</svg>
+<figcaption>The runtime multiplexes many cheap goroutines onto a few real threads — so thousands of concurrent tasks cost far less than thousands of threads.</figcaption>
+</figure>
+
+Because they are so cheap, the idiomatic Go move is to launch a goroutine per unit
+of concurrent work rather than carefully pooling a scarce resource. GopherTrunk uses
+this to run capture, decoding, and per-channel processing side by side.
+
+## The catch: goroutines need coordination
+
+A goroutine runs on its own, which raises two questions this unit answers next:
+
+- **How do goroutines share results safely?** Two goroutines touching the same
+  variable at once is a *data race* — a real bug. The answer is
+  [channels](/learn/programming-go/channels/), Go's built-in way to pass data
+  between goroutines.
+- **How does `main` wait for them?** If `main` returns, the program exits and any
+  running goroutines are cut off. You need a way to coordinate — covered in
+  [select & synchronization](/learn/programming-go/select-and-sync/).
+
+Go's motto captures the philosophy: *don't communicate by sharing memory; share
+memory by communicating.* That's the channel model, and it's next.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — goroutines are managed by Go's runtime, far lighter than OS threads." markdown="0">
+  <p class="knowledge-check__q">Quick check: why can a Go program run thousands of goroutines at once?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Each goroutine is a dedicated OS thread</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">They're lightweight and multiplexed by the runtime onto a few threads</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Only one runs at a time, so they're free</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **goroutine** is launched with the **`go`** keyword and runs concurrently.
+- Goroutines are **lightweight**, scheduled by Go's runtime onto a few OS threads.
+- You can run **thousands** cheaply — the idiomatic way to structure concurrent work.
+- They need **coordination**: channels to share data, and synchronization to wait.
+
+Next up: channels, the safe way for goroutines to talk to each other.

--- a/docs/learn/programming-go/hello-go.md
+++ b/docs/learn/programming-go/hello-go.md
@@ -1,0 +1,135 @@
+---
+slug: hello-go
+title: Your first Go program
+description: Install Go, write a hello-world program, and understand the difference between go run and go build — how Go turns source code into a single static binary.
+keywords: go hello world, install go, go run, go build, first go program, package main, func main, go binary
+level: beginner
+status: full
+prereq:
+  - why-go
+faq:
+  - q: What is the difference between go run and go build?
+    a: "`go run` compiles your program to a temporary location and immediately runs it, which is handy while developing. `go build` compiles it to a permanent binary file in your current directory that you can run again later or copy to another machine. Both do the same compilation; they differ only in whether the result is thrown away or kept."
+  - q: Why does every Go program start with package main?
+    a: A Go program that produces a runnable command must live in a package named `main` and contain a function named `main`. That function is the entry point the compiler wires up as the start of the program. Packages named anything else are libraries — reusable code meant to be imported, not run directly.
+---
+
+# Your first Go program
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A runnable Go program needs a **`package main`** declaration and a **`func main()`**
+entry point. You compile-and-run it with **`go run`** while developing, or compile
+it to a permanent binary with **`go build`**. That binary is self-contained — copy
+it to another machine and it just runs.
+</div>
+
+Enough theory — let's make Go do something. This lesson gets Go installed, gets a
+program running, and explains the handful of lines every Go program starts with.
+
+## Installing Go
+
+Download the installer for your operating system from the official site
+(go.dev/dl) and follow the prompts, or use your package manager
+(`brew install go`, `apt install golang`, and so on — see the
+[Linux CLI module](/learn/linux-cli/package-management/) if package managers are
+new to you). Confirm it worked by opening a terminal and running:
+
+```text
+$ go version
+go version go1.22.0 linux/amd64
+```
+
+If you see a version number, you are ready.
+
+## The smallest useful program
+
+Create a file called `hello.go` and put this in it:
+
+```go
+package main
+
+import "fmt"
+
+func main() {
+    fmt.Println("Hello, radio!")
+}
+```
+
+Four ideas are packed into six lines:
+
+- **`package main`** — this file belongs to the special package that produces a
+  runnable command.
+- **`import "fmt"`** — pull in the standard library's *format* package, which
+  handles printing.
+- **`func main()`** — the entry point; execution starts here.
+- **`fmt.Println(...)`** — call the `Println` function from `fmt` to print a line.
+
+## Running it
+
+From the same folder, run:
+
+```text
+$ go run hello.go
+Hello, radio!
+```
+
+`go run` compiled your code and ran it in one step. Nothing was left behind — great
+for quick iteration.
+
+## Building a binary
+
+When you want a program you can keep and share, build it instead:
+
+```text
+$ go build hello.go
+$ ./hello
+Hello, radio!
+```
+
+Now there is a `hello` file (or `hello.exe` on Windows) sitting in your folder.
+That single file *is* your program — it has no dependency on Go being installed on
+the machine that runs it. This is the "single static binary" promise from lesson 1,
+and it is why distributing a Go tool is often just "here is the file."
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 120" role="img" aria-label="Flow from hello.go source through the Go compiler to a single binary that runs on any machine." xmlns="http://www.w3.org/2000/svg">
+  <rect x="10" y="40" width="120" height="40" rx="6" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="70" y="65" text-anchor="middle" font-size="13" fill="currentColor">hello.go</text>
+  <line x1="130" y1="60" x2="200" y2="60" stroke="currentColor" stroke-width="1.5" marker-end="url(#ar)"/>
+  <rect x="200" y="40" width="120" height="40" rx="6" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="260" y="65" text-anchor="middle" font-size="13" fill="currentColor">go build</text>
+  <line x1="320" y1="60" x2="390" y2="60" stroke="currentColor" stroke-width="1.5" marker-end="url(#ar)"/>
+  <rect x="390" y="40" width="120" height="40" rx="6" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="450" y="65" text-anchor="middle" font-size="13" fill="currentColor">./hello</text>
+  <defs><marker id="ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Source in, one binary out — the whole build pipeline for a simple Go program.</figcaption>
+</figure>
+
+## A note on formatting
+
+Save your file and run `gofmt -w hello.go`. It rewrites the file into Go's one
+official style — indentation, spacing, and all. Go settles formatting debates by
+having exactly one answer, and every editor can run `gofmt` for you on save. You
+will meet the rest of the toolchain in the next lesson.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Correct — go run compiles and runs without leaving a binary behind." markdown="0">
+  <p class="knowledge-check__q">Quick check: you want to test a change quickly without keeping the compiled output. Which do you use?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="correct">go run</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">go build</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">gofmt</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A runnable program needs **`package main`** and **`func main()`**.
+- **`import`** pulls in packages like `fmt` from the standard library.
+- **`go run`** compiles and runs in one step; **`go build`** produces a keepable,
+  self-contained **binary**.
+- **`gofmt`** enforces Go's single official code style.
+
+Next up: the rest of the toolchain that formats, checks, tests, and builds your code.

--- a/docs/learn/programming-go/idiomatic-go.md
+++ b/docs/learn/programming-go/idiomatic-go.md
@@ -1,0 +1,115 @@
+---
+slug: idiomatic-go
+title: Writing idiomatic Go
+description: "The conventions that make Go code read the same everywhere — gofmt, accept interfaces and return structs, handle errors explicitly, and avoid cleverness."
+keywords: idiomatic go, effective go, gofmt, accept interfaces return structs, go naming conventions, handle errors go, go best practices, go style
+level: intermediate
+status: full
+prereq:
+  - interfaces
+faq:
+  - q: What does "accept interfaces, return structs" mean?
+    a: "A function should take the smallest interface it needs as a parameter, so any type with those methods can be passed in — maximum flexibility for callers. But it should return a concrete struct, so callers get the full type with all its methods and fields, not a narrowed-down interface. Be liberal in what you accept, specific in what you return."
+  - q: Is there an official Go style guide?
+    a: "gofmt is the style guide — it settles all formatting mechanically, so there are no arguments about braces or spacing. For the deeper conventions, Effective Go and the Go Code Review Comments wiki are the canonical references the whole community follows."
+---
+
+# Writing idiomatic Go
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Idiomatic Go is remarkably uniform because so much is settled for you. **`gofmt`**
+formats every file the same way. Functions **accept interfaces and return structs**.
+Errors are **handled explicitly**, never swallowed. Names are **short in short
+scopes** and clear at package boundaries. The overriding value is **clarity over
+cleverness** — code that reads plainly. *Effective Go* is the canonical guide.
+</div>
+
+Go code from different authors looks strikingly similar, and that's by design. This
+final craft lesson gathers the conventions that make it so, drawing on everything from
+[interfaces](/learn/programming-go/interfaces/) to
+[error handling](/learn/programming-go/error-handling-patterns/).
+
+## gofmt ends the style debate
+
+There is one correct formatting, and `gofmt` (or `go fmt`) produces it — indentation,
+alignment, import grouping, all mechanical. Nobody argues about braces in Go because
+the tool decides. Run it on save; CI checks it. Formatting is simply not a thing you
+think about.
+
+## Accept interfaces, return structs
+
+The guiding shape for APIs: take the **smallest interface** you need as a parameter,
+return a **concrete type**:
+
+```go
+// Accepts any reader — file, socket, buffer.
+func Decode(r io.Reader) (*Frame, error) { ... }
+
+// Returns a concrete *Receiver, not an interface — callers get everything.
+func NewReceiver(rate int) *Receiver { ... }
+```
+
+Accepting an interface makes the function flexible for callers; returning a struct
+gives them the full type without guessing what interface to satisfy. This is the
+single most Go-shaping habit for library code.
+
+## Handle every error, explicitly
+
+Idiomatic Go never ignores an error silently. Handle it, wrap it, or return it —
+`_ = f()` on an error is a code smell:
+
+```go
+if err := cfg.Validate(); err != nil {
+    return fmt.Errorf("invalid config: %w", err)
+}
+```
+
+The verbosity is the point: every failure path is visible on the page, which is why Go
+programs tend to fail informatively rather than crash mysteriously.
+
+## Names: short scope, short name
+
+Go names scale with scope. A loop index is `i`; a receiver is one or two letters; a
+package-level exported function has a full, clear name. Long names in tiny scopes are
+noise.
+
+| Scope | Convention | Example |
+|-------|-----------|---------|
+| Loop / short block | Single letters | `i`, `r`, `s` |
+| Method receiver | 1–2 letters, consistent | `func (r *Receiver)` |
+| Package function/type | Clear, no stutter | `scanner.New`, not `scanner.NewScanner` |
+| Exported identifier | CamelCase, documented | `Demodulate`, `FreqHz` |
+
+Note the anti-stutter rule: it's `bytes.Buffer`, not `bytes.BytesBuffer` — the package
+name already carries context.
+
+## Clarity over cleverness
+
+The through-line of every rule above is that Go optimizes for the reader. Prefer the
+plain loop to the clever one-liner; prefer an obvious name to a witty one; prefer a
+few more lines to a dense trick. Code is read far more than it's written, and Go's
+culture — captured in **Effective Go** and the Go Code Review Comments — bakes that
+into how the whole community writes. That shared taste is what lets you drop into
+GopherTrunk, or any Go project, and read it in the
+[next lesson](/learn/programming-go/reading-real-go/) as if you'd written it.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — accept the smallest interface, return the concrete struct." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does "accept interfaces, return structs" advise?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Take concrete types in, return interfaces out</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Take the smallest interface you need, return the concrete type</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Never use interfaces in public APIs</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **`gofmt`** settles all formatting — style is never a debate.
+- **Accept interfaces, return structs** for flexible, honest APIs.
+- **Handle every error explicitly** — never swallow it.
+- Names are **short in short scopes**, clear at boundaries, and avoid stutter.
+- Above all, favour **clarity over cleverness** — see *Effective Go*.
+
+Next up: putting it all together by reading a real Go codebase — GopherTrunk itself.

--- a/docs/learn/programming-go/index.md
+++ b/docs/learn/programming-go/index.md
@@ -1,0 +1,28 @@
+---
+layout: learn-hub
+learn_module: programming-go
+permalink: /learn/programming-go/
+title: Learn Go — from your first program to reading real code
+description: A free, structured course in the Go programming language, from your first compiled program to goroutines, interfaces, and reading a real Go codebase — taught with examples from GopherTrunk, an SDR engine written in Go.
+keywords: learn go, golang tutorial, go for beginners, goroutines, channels, go interfaces, go concurrency, go modules, learn to program in go
+---
+
+Go has a reputation for being small, fast, and refreshingly boring — in the best
+way. There is one way to format your code, one way to build it, and a concurrency
+model you can hold in your head. That is exactly why it powers so much modern
+infrastructure, and why **GopherTrunk itself is written in Go**: a real-time SDR
+engine needs speed, safety, and easy concurrency, and Go gives you all three
+without a heavy runtime.
+
+**Who this is for.** Newcomers welcome — you do not need prior Go, and you do not
+need to have used a compiled language before. If you have written a little code in
+any language, you will move quickly. If you have not, the early lessons start from
+the very beginning.
+
+**How the module works.** Five units take you from "why does Go exist?" to reading
+real code from a working SDR decoder. The first units build the language piece by
+piece — types, functions, errors, structs, interfaces. The middle unit covers Go's
+headline feature, concurrency. The last units show how real programs are organized
+and tested, then walk through actual GopherTrunk code so the ideas land somewhere
+concrete. Mark lessons complete as you go — your progress is saved in your browser.
+New here? **[Start with lesson 1: Why Go?](why-go/)**

--- a/docs/learn/programming-go/interfaces.md
+++ b/docs/learn/programming-go/interfaces.md
@@ -1,0 +1,120 @@
+---
+slug: interfaces
+title: Interfaces & composition
+description: Small interfaces, implicit satisfaction, and composition over inheritance — the Go idea that lets unrelated types share behaviour without a class hierarchy.
+keywords: go interfaces, implicit interface, duck typing go, io reader writer, composition over inheritance, go polymorphism, empty interface
+level: intermediate
+status: full
+prereq:
+  - structs-and-methods
+faq:
+  - q: How does a type implement an interface in Go?
+    a: Implicitly. There is no "implements" keyword. If a type has all the methods an interface lists, it satisfies that interface automatically. This means you can write an interface for types that already exist — even types in libraries you don't control — as long as they have the right methods.
+  - q: Why are Go interfaces usually small?
+    a: Small interfaces (often one method, like io.Reader's Read) are easy to satisfy and easy to reuse. A one-method interface can be implemented by countless types, so functions that accept it work with all of them. Go's standard library is full of these tiny, composable interfaces, and idiomatic Go follows the same habit.
+---
+
+# Interfaces & composition
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+An **interface** is a set of method signatures. In Go a type satisfies an interface
+**implicitly** — just by having those methods, with no `implements` keyword. Small,
+one-method interfaces like **`io.Reader`** are the norm, letting unrelated types be
+used interchangeably. Interfaces are how Go gets flexibility and polymorphism
+**without inheritance**.
+</div>
+
+Interfaces are the single most important idea for reading real Go code. This lesson
+explains what they are and why Go's "implicit" twist makes them so powerful.
+
+## What an interface is
+
+An interface names behaviour, not data:
+
+```go
+type Demodulator interface {
+    Demodulate(samples []complex128) []byte
+}
+```
+
+Anything with a `Demodulate(samples []complex128) []byte` method *is* a
+`Demodulator`. A function can now accept the interface and work with any concrete
+type that fits:
+
+```go
+func decode(d Demodulator, samples []complex128) []byte {
+    return d.Demodulate(samples)
+}
+```
+
+Pass a `C4FMDemod`, an `FMDemod`, or a test fake — `decode` doesn't care, as long as
+it has the method.
+
+## Implicit satisfaction
+
+Here is the Go twist: a type never *declares* that it implements an interface. If it
+has the methods, it satisfies the interface — automatically.
+
+```go
+type C4FMDemod struct{}
+
+func (C4FMDemod) Demodulate(s []complex128) []byte { /* ... */ return nil }
+// C4FMDemod is now a Demodulator, with no extra ceremony.
+```
+
+This lets you define an interface *after the fact* to describe types you didn't
+write — including ones from libraries. It keeps packages loosely coupled: the
+demodulator doesn't need to import the interface, and the interface doesn't need to
+know about the demodulator.
+
+## Keep interfaces small
+
+The most reused interface in Go has one method:
+
+```go
+type Reader interface {
+    Read(p []byte) (n int, err error)
+}
+```
+
+`io.Reader` is satisfied by files, network connections, byte buffers, gzip streams,
+and more — so any function that reads from an `io.Reader` works with all of them,
+including an SDR sample source. The lesson from the standard library: **small
+interfaces compose**. A one-method interface is easy to satisfy and endlessly
+reusable; a giant interface is neither.
+
+## Composition, one more time
+
+Interfaces embed too. `io.ReadWriter` is simply:
+
+```go
+type ReadWriter interface {
+    Reader
+    Writer
+}
+```
+
+Between struct embedding (last lesson) and interface embedding (here), Go builds
+everything out of small parts combined — never deep inheritance trees. When you read
+GopherTrunk in [Reading a real Go codebase](/learn/programming-go/reading-real-go/),
+this pattern of small interfaces at package boundaries is everywhere.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — in Go, having the methods is enough; satisfaction is implicit." markdown="0">
+  <p class="knowledge-check__q">Quick check: how does a Go type declare that it implements an interface?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">With an "implements" keyword</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">It doesn't — having the required methods is enough</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">By registering with the interface at startup</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- An **interface** is a set of method signatures describing behaviour.
+- Go satisfies interfaces **implicitly** — no `implements`, just having the methods.
+- **Small interfaces** (like `io.Reader`) are the norm and compose beautifully.
+- Interfaces give Go **polymorphism without inheritance**.
+
+Next up: Go's headline feature — concurrency with goroutines.

--- a/docs/learn/programming-go/json-and-serialization.md
+++ b/docs/learn/programming-go/json-and-serialization.md
@@ -1,0 +1,122 @@
+---
+slug: json-and-serialization
+title: JSON & serialization
+description: "Turning Go structs into JSON and back with encoding/json — struct tags, exported fields, and the Marshal/Unmarshal pattern behind most APIs and config files."
+keywords: go json, encoding/json, json marshal unmarshal, struct tags go, json tag, go serialization, exported fields json
+level: intermediate
+status: full
+prereq:
+  - structs-and-methods
+faq:
+  - q: Why is my struct field missing from the JSON output?
+    a: "encoding/json only sees exported fields — ones that start with a capital letter. A lowercase field is unexported and invisible to the encoder, so it never appears in the output and is never filled in on decode. Capitalize it and, if you want a lowercase key, add a json struct tag."
+  - q: What does a struct tag like `json:\"freq_hz\"` do?
+    a: "It tells the encoder to use freq_hz as the JSON key for that field instead of the Go field name. Tags can also add options such as omitempty (drop the field when it's a zero value) and - (never encode this field)."
+---
+
+# JSON & serialization
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+The **`encoding/json`** package converts Go values to JSON with **`Marshal`** and
+back with **`Unmarshal`**. Only **exported** (capitalized) fields are encoded.
+**Struct tags** like `` `json:"freq_hz"` `` control the JSON key names and options
+such as **`omitempty`**. This one pattern powers config files, HTTP APIs, and saved
+state.
+</div>
+
+Serialization is how a program turns in-memory values into bytes it can store or send
+— and back again. This lesson covers Go's built-in JSON support, building on
+[Structs & methods](/learn/programming-go/structs-and-methods/).
+
+## Marshal: struct to JSON
+
+`json.Marshal` takes any value and returns its JSON bytes:
+
+```go
+type Channel struct {
+    Name   string  `json:"name"`
+    FreqHz float64 `json:"freq_hz"`
+    Active bool    `json:"active"`
+}
+
+ch := Channel{Name: "Fire Dispatch", FreqHz: 460.025e6, Active: true}
+data, err := json.Marshal(ch)
+// {"name":"Fire Dispatch","freq_hz":460025000,"active":true}
+```
+
+The **struct tags** in backticks map each Go field to a JSON key. Without a tag the
+field name is used verbatim (`FreqHz` would become `"FreqHz"`).
+
+## Unmarshal: JSON back to a struct
+
+`json.Unmarshal` fills a struct you pass by pointer:
+
+```go
+var ch Channel
+err := json.Unmarshal(data, &ch)   // note &ch — it writes through the pointer
+```
+
+Fields present in the JSON are set; anything missing keeps its zero value. Extra keys
+in the JSON that don't match a field are silently ignored, which makes forward-
+compatible config easy.
+
+## Exported fields only
+
+The encoder can only see **exported** fields — the capitalization rule from
+[Packages & modules](/learn/programming-go/packages-and-modules/). A lowercase field
+is invisible:
+
+```go
+type Config struct {
+    Gain    int    `json:"gain"`     // encoded
+    secret  string                    // never encoded — unexported
+}
+```
+
+This is the single most common JSON surprise in Go: a field "won't serialize" simply
+because it starts with a lowercase letter.
+
+## Tag options
+
+Tags carry more than a name. The table lists the ones you'll reach for most.
+
+| Tag | Effect |
+|-----|--------|
+| `json:"freq_hz"` | Use `freq_hz` as the key |
+| `json:"name,omitempty"` | Omit the field when it's a zero value |
+| `json:"-"` | Never encode or decode this field |
+| `json:",omitempty"` (no name) | Keep the field name, add omitempty |
+
+A GopherTrunk config that saves a scan list uses exactly this shape — a slice of
+tagged structs marshalled to a file and unmarshalled on startup:
+
+```go
+type ScanList struct {
+    Channels []Channel `json:"channels"`
+    StepMS   int       `json:"step_ms,omitempty"`
+}
+```
+
+For streaming large or continuous data, `json.NewEncoder(w)` and
+`json.NewDecoder(r)` work directly on the `io.Writer`/`io.Reader` interfaces you'll
+meet in the next lesson, instead of building one big byte slice.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — only exported (capitalized) fields are marshalled." markdown="0">
+  <p class="knowledge-check__q">Quick check: why might a struct field never appear in json.Marshal output?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="correct">It's unexported — its name starts with a lowercase letter</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It's a float, which JSON can't represent</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Structs must be registered before marshalling</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **`json.Marshal`** encodes a value; **`json.Unmarshal`** decodes into a pointer.
+- Only **exported** fields are serialized — capitalization matters.
+- **Struct tags** set JSON key names and options like **`omitempty`** and `-`.
+- Encoders/decoders work over **`io.Reader`/`io.Writer`** for streaming.
+
+Next up: reading and writing files and streams with os, io, and bufio.

--- a/docs/learn/programming-go/logging-and-slog.md
+++ b/docs/learn/programming-go/logging-and-slog.md
@@ -1,0 +1,110 @@
+---
+slug: logging-and-slog
+title: Logging with slog
+description: "Structured logging with the standard log/slog package — levels, key/value fields, and why a running service logs in structured form instead of plain printed lines."
+keywords: go slog, log/slog, structured logging go, slog.Info, log levels go, structured logs, json logging go, slog attributes
+level: intermediate
+status: full
+prereq:
+  - the-standard-library
+faq:
+  - q: What makes slog "structured" logging?
+    a: "Instead of baking values into a sentence, slog records them as key/value pairs: slog.Info(\"locked\", \"freq_hz\", 460025000, \"snr\", 19.7). Each field stays a separate, typed attribute, so a log system can filter, search, and aggregate on freq_hz or snr directly — something you can't reliably do with a formatted string."
+  - q: Why not just use fmt.Println or the old log package?
+    a: "For a quick script, Println is fine. But a long-running service needs log levels to control verbosity, machine-readable output for log aggregators, and consistent fields across every line. slog gives all three from the standard library, which is why it's the default choice for services."
+---
+
+# Logging with slog
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**`log/slog`** is Go's standard **structured logging** package. Instead of formatting
+values into a sentence, you attach them as **key/value attributes** —
+`slog.Info("locked", "freq_hz", f, "snr", s)`. It supports **levels** (Debug, Info,
+Warn, Error) and can emit human-readable text or **JSON** for log aggregators. A
+running service logs this way so its output can be filtered and searched, not just
+read.
+</div>
+
+A quick program can print. A service that runs for days needs logs it can query. This
+lesson covers `log/slog`, part of the
+[standard library](/learn/programming-go/the-standard-library/) since Go 1.21.
+
+## Structured, not formatted
+
+The old habit is to build a sentence:
+
+```go
+log.Printf("locked on %.4f MHz at %.1f dB SNR", freq/1e6, snr)  // one opaque string
+```
+
+`slog` records the same facts as separate, typed fields:
+
+```go
+slog.Info("signal locked",
+    "freq_hz", freq,
+    "snr", snr,
+    "protocol", "P25",
+)
+```
+
+Each key/value is preserved, so a log system can filter `protocol=P25` or graph `snr`
+over time. That is the whole point of *structured* logging: the data stays data.
+
+## Levels
+
+`slog` has four built-in levels, and a logger can be set to drop anything below a
+threshold — so you leave `Debug` lines in the code and simply raise the level in
+production.
+
+| Level | Use it for |
+|-------|-----------|
+| `slog.Debug` | Detailed tracing, off in production |
+| `slog.Info` | Normal events — startup, a lock acquired |
+| `slog.Warn` | Something unexpected but recoverable |
+| `slog.Error` | A failure that needs attention |
+
+```go
+slog.Debug("fft frame", "bins", 4096)     // hidden unless level <= Debug
+slog.Error("decode failed", "err", err)   // always shown
+```
+
+## Text or JSON output
+
+`slog` separates *what* you log from *how* it's formatted. Choose a handler:
+
+```go
+// Human-readable text (development):
+h := slog.NewTextHandler(os.Stderr, nil)
+
+// Machine-readable JSON (production / aggregators):
+h := slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})
+
+slog.SetDefault(slog.New(h))
+```
+
+The JSON handler emits one object per line — exactly what a log collector wants. You
+can also attach fields once with `logger.With("protocol", "P25")` so every subsequent
+line carries them, ideal for a per-channel logger in a scanner. You'll see the same
+structured output feed dashboards in
+[Logging & health checks](/learn/deployment/logging-and-health-checks/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — slog keeps each value as a separate key/value attribute." markdown="0">
+  <p class="knowledge-check__q">Quick check: what makes slog output "structured"?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It always writes to a database</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Values are logged as separate key/value attributes, not baked into a sentence</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It colourizes the terminal output</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **`log/slog`** logs **key/value attributes**, keeping data queryable instead of
+  formatted into a string.
+- It has four **levels** — Debug, Info, Warn, Error — with a settable threshold.
+- Swap **handlers** for text (dev) or **JSON** (production/aggregators).
+- **`logger.With(...)`** attaches persistent fields to every line.
+
+Next up: how a real Go repository is laid out — cmd, internal, and packages.

--- a/docs/learn/programming-go/next-steps-in-go.md
+++ b/docs/learn/programming-go/next-steps-in-go.md
@@ -1,0 +1,95 @@
+---
+slug: next-steps-in-go
+title: Where to go next
+description: Idiomatic Go, the tooling ecosystem, the community, and a short project ladder to take you from this module to shipping your own Go programs.
+keywords: learn go next steps, idiomatic go, effective go, go community, go projects for beginners, go tour, keep learning go
+level: beginner
+status: full
+faq:
+  - q: What should I build to practice Go?
+    a: Start small and command-line — a tool that reads a file and prints a summary, a tiny HTTP server, a program that fetches and parses some JSON. Each exercises packages, error handling, and the standard library. Then add concurrency with a program that does several things at once. Building real, small things beats reading more theory.
+  - q: What does idiomatic Go mean?
+    a: Idiomatic Go is code written the way the Go community expects — gofmt-formatted, errors handled explicitly, small interfaces, clear names, no cleverness for its own sake. The documents "Effective Go" and "Go Code Review Comments" capture the conventions. Reading real code (like the previous lesson) is the fastest way to absorb them.
+---
+
+# Where to go next
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+You now know enough Go to read and write real programs. To keep growing: write
+**idiomatic** Go (formatted, explicit errors, small interfaces), lean on the
+**tooling** and **standard library**, and **build small real things** — a CLI, a
+tiny server, a parser. The best next step is a project, not another tutorial.
+</div>
+
+This is the last lesson, and it's about momentum. You've covered the language, its
+concurrency model, and how real code is organized. Here's how to turn that into
+fluency.
+
+## Write idiomatic Go
+
+Go rewards writing code the community way:
+
+- **Let `gofmt` and `go vet` run on save** — never argue with the formatter.
+- **Handle every error explicitly** — the `if err != nil` you met in
+  [functions & errors](/learn/programming-go/functions-and-errors/) is the norm, not
+  a burden.
+- **Keep interfaces small** and accept them, return concrete types.
+- **Name things clearly and briefly** — short names for short scopes, descriptive
+  names for exported APIs.
+
+The classic references — *A Tour of Go*, *Effective Go*, and *Go Code Review
+Comments* — are short and worth reading once you've written a little.
+
+## A project ladder
+
+Fluency comes from building. A rough progression:
+
+| Step | Build | Exercises |
+|------|-------|-----------|
+| 1 | A CLI that reads a file and prints a summary | packages, `os`, `io`, errors |
+| 2 | A program that fetches and parses JSON | `net/http`, `encoding/json`, structs |
+| 3 | A tiny web server with a couple of routes | `net/http`, handlers, interfaces |
+| 4 | A worker that does several tasks at once | goroutines, channels, `sync` |
+| 5 | A contribution to an open-source Go project | reading real code, tests, review |
+
+Step 5 can be GopherTrunk itself — its
+[contribution guide](/learn/git/pull-requests/) and test-first
+[bug-fix policy](/learn/git/best-practices/) are a great place to practice.
+
+## Keep the ecosystem close
+
+- **The standard library first** — most of what you need is already there.
+- **`pkg.go.dev`** documents every public package, standard or third-party.
+- **The race detector and tests** keep concurrent code honest as it grows.
+- **The community** — the Go blog, forums, and conference talks — is welcoming and
+  unusually focused on clarity.
+
+## Where this fits
+
+Go is one skill in a bigger picture. Pair it with the
+[Linux command line](/learn/linux-cli/), [Git](/learn/git/), and
+[deployment](/learn/deployment/) modules and you can build, version, and ship a real
+service. Add the [DSP module](/learn/dsp/) and you have everything GopherTrunk is
+built from. You're ready — go build something.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — building small real programs is the fastest path to fluency." markdown="0">
+  <p class="knowledge-check__q">Quick check: what's the most effective next step after this module?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Memorize the entire standard library</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Build small, real programs of your own</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Avoid writing code until you've read every reference</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Write **idiomatic** Go: formatted, explicit errors, small interfaces, clear names.
+- Grow by **building** — climb a ladder from a CLI to a concurrent service.
+- Keep the **standard library**, **`pkg.go.dev`**, and the **race detector** close.
+- Combine Go with Linux, Git, DSP, and deployment to build something real like
+  GopherTrunk.
+
+That's the module — from your first program to reading and writing real Go. Keep the
+[glossary](/learn/programming-go/glossary/) handy as a reference.

--- a/docs/learn/programming-go/packages-and-modules.md
+++ b/docs/learn/programming-go/packages-and-modules.md
@@ -1,0 +1,112 @@
+---
+slug: packages-and-modules
+title: Packages & modules
+description: How Go organizes code into packages and modules — imports, the go.mod file, and how visibility is controlled by capitalization rather than keywords.
+keywords: go packages, go modules, go.mod, go imports, exported identifiers, package visibility, go get, dependency management
+level: intermediate
+status: full
+prereq:
+  - interfaces
+faq:
+  - q: What is the difference between a package and a module?
+    a: A package is a single directory of Go files that are compiled together and imported as a unit. A module is a collection of packages versioned together, defined by a go.mod file at its root. You import packages; you version and distribute modules. A small project is one module containing several packages.
+  - q: How does Go decide what is public?
+    a: By capitalization, not keywords. An identifier — a function, type, field, or variable — whose name starts with an uppercase letter is exported and visible to other packages. A lowercase name is private to its own package. There is no public or private keyword; the first letter says it all.
+---
+
+# Packages & modules
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A **package** is a directory of Go files compiled together; a **module** is a
+versioned collection of packages defined by a **`go.mod`** file. You **import**
+packages by path, and **capitalization controls visibility** — an `Uppercase` name
+is exported, a `lowercase` name is private to its package. No public/private
+keywords needed.
+</div>
+
+Once a program grows past one file, you need structure. This lesson covers how Go
+organizes code and manages the libraries it depends on.
+
+## Packages: the unit of code
+
+Every Go file starts with a `package` line, and all files in a directory belong to
+the same package. You pull one package into another with `import`:
+
+```go
+package scanner
+
+import (
+    "fmt"
+    "github.com/mattcheramie/gophertrunk/internal/dsp"
+)
+```
+
+Standard-library packages are imported by short name (`fmt`, `os`, `net`);
+third-party and internal packages by their full path. GopherTrunk is organized this
+way — `internal/dsp`, `internal/scanner`, and so on — each a package with a clear
+job.
+
+## Visibility by capitalization
+
+Go has no `public` or `private` keyword. Instead, the **first letter** of a name
+decides:
+
+```go
+func Decode(...)   // exported — other packages can call it
+func decode(...)   // unexported — visible only inside this package
+```
+
+The same rule applies to types, struct fields, constants, and variables. It makes
+the public surface of a package obvious at a glance: capitals are the API, lowercase
+is the implementation.
+
+## Modules: versioned dependencies
+
+A **module** is the unit you version and share. Its `go.mod` file names the module
+and pins every dependency:
+
+```text
+module github.com/mattcheramie/gophertrunk
+
+go 1.22
+
+require (
+    github.com/some/library v1.4.2
+)
+```
+
+When you import a package you don't yet have, `go get` or `go mod tidy` fetches it
+and records the exact version, and `go.sum` locks its checksum. A fresh checkout
+therefore builds with *identical* dependencies for everyone — no "works on my
+machine" surprises. That reproducibility is what makes Go projects easy to
+[build in CI](/learn/deployment/ci-cd-pipelines/) and to
+[ship as one binary](/learn/programming-go/hello-go/).
+
+## The internal directory
+
+A package under a directory named `internal/` can only be imported by code in the
+same module. GopherTrunk uses this deliberately: its guts live under `internal/`, so
+they're private implementation the rest of the world can't depend on, leaving the
+maintainers free to change them.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — an uppercase initial means the name is exported." markdown="0">
+  <p class="knowledge-check__q">Quick check: a function named <code>decode</code> (lowercase d) is…</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="correct">private to its own package</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">exported to every other package</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">a syntax error — names must be capitalized</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **package** is a directory of files compiled together; you **import** it by path.
+- A **module** (`go.mod`) versions a set of packages and pins dependencies for
+  reproducible builds.
+- **Capitalization** controls visibility — `Uppercase` is exported, `lowercase` is
+  private.
+- The **`internal/`** directory hides packages from outside the module.
+
+Next up: Go's core collections — slices and maps — plus generics.

--- a/docs/learn/programming-go/pointers.md
+++ b/docs/learn/programming-go/pointers.md
@@ -1,0 +1,125 @@
+---
+slug: pointers
+title: Pointers
+description: "What a pointer is, why Go has them without pointer arithmetic, and how they let functions modify values and avoid copying large structs — safely and simply."
+keywords: go pointers, pointer vs value, nil pointer, address of operator, dereference go, pointer to struct, go pass by value
+level: intermediate
+status: full
+prereq:
+  - values-and-types
+faq:
+  - q: Does Go have pointer arithmetic like C?
+    a: "No. You can take a pointer with & and follow it with *, but you cannot add to or subtract from an address. That single restriction removes an entire class of memory-corruption bugs while keeping the useful part of pointers: sharing and mutating a value."
+  - q: When should a function take a pointer instead of a value?
+    a: "Take a pointer when the function must modify the caller's value, or when the value is a large struct you don't want to copy on every call. For small values that only get read, passing by value is simpler and just as fast."
+---
+
+# Pointers
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A **pointer** holds the *address* of a value. `&x` takes the address; `*p`
+**dereferences** it to reach the value. Go has pointers but **no pointer
+arithmetic**, so you get sharing and mutation without the classic memory bugs. Use
+them to let a function **modify its caller's value** or to **avoid copying** a big
+struct. A pointer to nothing is **`nil`**.
+</div>
+
+Go passes everything by value — a function gets its own copy of each argument. This
+lesson explains the escape hatch: pointers, which let a function reach back and
+change the original.
+
+## What is a pointer?
+
+A pointer is a value whose contents are the memory address of another value. Two
+operators do all the work:
+
+```go
+snr := 12.5
+p := &snr        // p is a *float64 — the address of snr
+fmt.Println(*p)  // 12.5 — dereference to read the value
+*p = 9.0         // write through the pointer
+fmt.Println(snr) // 9 — snr itself changed
+```
+
+`&` means "address of"; `*` in front of a pointer means "the value it points at."
+`*float64` is read as "pointer to float64."
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 110" role="img" aria-label="A pointer variable p holding an arrow that points at a separate box holding the value 9.0." xmlns="http://www.w3.org/2000/svg">
+  <rect x="20" y="40" width="120" height="40" rx="6" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="80" y="30" text-anchor="middle" font-size="12" fill="currentColor">p (*float64)</text>
+  <text x="80" y="65" text-anchor="middle" font-size="12" fill="currentColor">0x40c0</text>
+  <rect x="300" y="40" width="120" height="40" rx="6" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="360" y="30" text-anchor="middle" font-size="12" fill="currentColor">snr (float64)</text>
+  <text x="360" y="65" text-anchor="middle" font-size="12" fill="currentColor">9.0</text>
+  <line x1="140" y1="60" x2="300" y2="60" stroke="currentColor" stroke-width="1.5" marker-end="url(#pa)"/>
+  <defs><marker id="pa" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>A pointer stores an address; dereferencing with <strong>*p</strong> follows the arrow to the value.</figcaption>
+</figure>
+
+## Why do pointers matter? Modifying the caller
+
+Because arguments are copied, a plain function can't change what the caller passed:
+
+```go
+func reset(x int)  { x = 0 }        // changes only the copy
+func clear(p *int) { *p = 0 }       // changes the caller's value
+
+n := 5
+reset(n); fmt.Println(n)   // 5 — unchanged
+clear(&n); fmt.Println(n)  // 0 — cleared through the pointer
+```
+
+This is why methods that mutate a struct use a **pointer receiver** — the subject of
+[Structs & methods](/learn/programming-go/structs-and-methods/).
+
+## Avoiding copies of big structs
+
+A `Receiver` in GopherTrunk might hold filter state, buffers, and AGC settings.
+Passing it by value copies all of that on every call. Passing `*Receiver` copies only
+the address:
+
+```go
+func (r *Receiver) Step(sample complex64) {
+    r.agc.Apply(&sample)   // mutates r's state in place
+}
+```
+
+Rule of thumb: small, read-only values go by value; things you must mutate, or large
+structs, go by pointer.
+
+## The nil pointer
+
+A pointer that points at nothing is `nil` — the zero value for any pointer type.
+Dereferencing a `nil` pointer panics, so guard it when it might be unset:
+
+```go
+if cfg.Filter != nil {
+    cfg.Filter.Apply(buf)
+}
+```
+
+Go has no pointer arithmetic, so a pointer is always either `nil` or a valid address
+of a real value — never a hand-computed offset into memory. That is what makes Go
+pointers safe to use everywhere.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — & takes an address, * follows it to the value." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does the <em>*</em> operator do in front of a pointer?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Takes the address of a value</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Dereferences it — reaches the value it points at</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Advances the pointer to the next address</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **pointer** holds a value's address; **`&`** takes it, **`*`** dereferences it.
+- Go has **no pointer arithmetic** — a pointer is always `nil` or a valid address.
+- Use pointers to **modify the caller's value** or to **avoid copying** big structs.
+- The zero pointer is **`nil`**; dereferencing `nil` panics, so guard it.
+
+Next up: grouping data with structs and attaching behaviour with methods.

--- a/docs/learn/programming-go/project-structure.md
+++ b/docs/learn/programming-go/project-structure.md
@@ -1,0 +1,121 @@
+---
+slug: project-structure
+title: Structuring a Go project
+description: "The cmd, internal, and package conventions that shape real Go repositories — where code goes and why, using GopherTrunk's own layout as the map."
+keywords: go project structure, cmd directory, internal package, go project layout, package per responsibility, go module layout, organizing go code
+level: intermediate
+status: full
+prereq:
+  - packages-and-modules
+faq:
+  - q: What is the internal directory for in a Go project?
+    a: "internal is a special directory the Go toolchain enforces: packages under internal/ can only be imported by code inside the same module. It's how a project keeps its implementation packages private, exposing a deliberate surface while forbidding outside code from depending on internals it might break."
+  - q: Why put each command under cmd/?
+    a: "A repository often ships more than one binary — the main app, a calibration tool, a test harness. Giving each its own package under cmd/ keeps every main() small and separate, while the real logic lives in importable packages under internal/ that all the commands can share."
+---
+
+# Structuring a Go project
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Real Go repositories follow a few conventions. Each executable gets a tiny `main`
+package under **`cmd/`**. Private implementation packages live under **`internal/`**,
+which the compiler forbids outside code from importing. Each package owns **one
+responsibility** and is named for it. GopherTrunk's own tree is a textbook example —
+`cmd/gophertrunk` plus `internal/dsp`, `internal/scanner`, `internal/sdr`, and more.
+</div>
+
+Where does code go? Go has strong conventions, and following them makes any project
+navigable. This lesson maps them onto GopherTrunk's real layout, extending
+[Packages & modules](/learn/programming-go/packages-and-modules/).
+
+## cmd/ — one directory per binary
+
+Every executable is a `package main` with a `main()` function, and each lives in its
+own directory under `cmd/`. GopherTrunk ships several:
+
+```
+cmd/
+  gophertrunk/      # the main scanner binary
+  voice-calibrate/  # a calibration helper
+  encodetest/       # a codec test harness
+```
+
+Each `main` stays thin — parse flags, wire things up, call into the real packages.
+`go build ./cmd/gophertrunk` builds just that one.
+
+## internal/ — enforced-private packages
+
+The bulk of the code lives under `internal/`, and the toolchain gives that name a
+superpower: **nothing outside the module can import it**. That lets the project expose
+a deliberate surface while keeping implementation free to change:
+
+```
+internal/
+  dsp/       # signal processing — filters, down-converters
+  scanner/   # control-channel decode, trunking follow
+  sdr/       # radio hardware drivers
+  config/    # loading and validating configuration
+  api/       # the HTTP/JSON surface
+```
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 170" role="img" aria-label="A tree with the module root at top, cmd and internal beneath it, and package directories under each." xmlns="http://www.w3.org/2000/svg">
+  <rect x="200" y="10" width="120" height="28" rx="6" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="260" y="29" text-anchor="middle" font-size="11" fill="currentColor">module root</text>
+  <rect x="90" y="70" width="120" height="28" rx="6" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="150" y="89" text-anchor="middle" font-size="11" fill="currentColor">cmd/</text>
+  <rect x="310" y="70" width="120" height="28" rx="6" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="370" y="89" text-anchor="middle" font-size="11" fill="currentColor">internal/</text>
+  <line x1="240" y1="38" x2="150" y2="70" stroke="currentColor" stroke-width="1.5"/>
+  <line x1="280" y1="38" x2="370" y2="70" stroke="currentColor" stroke-width="1.5"/>
+  <text x="150" y="130" text-anchor="middle" font-size="10" fill="currentColor">gophertrunk/  voice-calibrate/</text>
+  <text x="370" y="125" text-anchor="middle" font-size="10" fill="currentColor">dsp/  scanner/</text>
+  <text x="370" y="142" text-anchor="middle" font-size="10" fill="currentColor">sdr/  config/  api/</text>
+  <line x1="150" y1="98" x2="150" y2="118" stroke="currentColor" stroke-width="1.5"/>
+  <line x1="370" y1="98" x2="370" y2="113" stroke="currentColor" stroke-width="1.5"/>
+</svg>
+<figcaption>The conventional Go tree: thin binaries under cmd/, private implementation packages under internal/, each owning one concern.</figcaption>
+</figure>
+
+## One package, one responsibility
+
+Notice the pattern in those names: each package is a single concern, named for what it
+does — `dsp` does signal processing, `sdr` talks to hardware, `config` handles
+configuration. This keeps dependencies flowing one way (a command imports `scanner`,
+`scanner` imports `dsp` and `sdr`) and makes the whole tree readable.
+
+| Directory | Holds | Importable by |
+|-----------|-------|---------------|
+| `cmd/<name>/` | One `main` per binary | (it's the top; imports others) |
+| `internal/<pkg>/` | Private implementation | Only this module |
+| `pkg/` (if present) | Deliberately public API | Anyone |
+| module root | `go.mod`, `go.sum`, top-level docs | — |
+
+## Applying it
+
+When you start a project, resist one giant package. Put each binary under `cmd/`, put
+shared logic in small `internal/` packages named by responsibility, and let the
+`internal` boundary keep your public surface honest. Reading a codebase laid out this
+way — which is exactly what the
+[Reading a real Go codebase](/learn/programming-go/reading-real-go/) lesson does with
+GopherTrunk — becomes a matter of following the imports.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the compiler blocks any import of internal/ from outside the module." markdown="0">
+  <p class="knowledge-check__q">Quick check: what's special about a package under <em>internal/</em>?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It's compiled with extra optimizations</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Only code in the same module may import it</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It must contain the main function</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Each binary is a thin **`package main`** under **`cmd/<name>/`**.
+- **`internal/`** packages are private — only the same module can import them.
+- Each package owns **one responsibility** and is named for it.
+- GopherTrunk's `cmd/` + `internal/dsp`, `scanner`, `sdr`, `config` tree is the model.
+
+Next up: the conventions that make Go code idiomatic — from naming to error handling.

--- a/docs/learn/programming-go/reading-real-go.md
+++ b/docs/learn/programming-go/reading-real-go.md
@@ -1,0 +1,110 @@
+---
+slug: reading-real-go
+title: Reading a real Go codebase
+description: A guided tour of how a working SDR engine like GopherTrunk is structured in Go — packages, interfaces, and goroutines you can now recognize and read with confidence.
+keywords: reading go code, go codebase structure, go project layout, internal packages, go interfaces in practice, gophertrunk source, learn go by reading
+level: advanced
+status: full
+prereq:
+  - packages-and-modules
+  - interfaces
+  - goroutines
+faq:
+  - q: What is the best way to learn to read a large Go codebase?
+    a: "Start at the entry point (the main package under cmd/), follow the top-level flow, and lean on the fact that Gos structure is explicit — package boundaries, capitalized public APIs, and small interfaces at seams. Because every Go project is formatted and organized similarly, the skills transfer: once you can read one, you can read most."
+  - q: Why do Go projects put code under an internal directory?
+    a: A package under internal/ can only be imported within the same module, so it's private implementation the outside world can't depend on. This lets maintainers reorganize internals freely without breaking anyone. GopherTrunk keeps its engine under internal/ for exactly this reason.
+---
+
+# Reading a real Go codebase
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Real Go projects are laid out predictably: an entry point under **`cmd/`**, private
+guts under **`internal/`**, packages split by responsibility, **small interfaces** at
+the seams, and **goroutines plus channels** carrying work between stages. Everything
+in this module shows up in GopherTrunk — this lesson is where the pieces click into a
+whole you can read.
+</div>
+
+You've met every ingredient. This lesson assembles them by touring how a real Go
+program — GopherTrunk, an SDR trunking scanner — is put together, so you can open the
+source and actually follow it.
+
+## The standard project shape
+
+Most Go projects, GopherTrunk included, follow a familiar layout:
+
+```text
+cmd/            entry points — the main package(s) you build into binaries
+internal/       the engine — private packages, one per responsibility
+  dsp/          signal processing (filters, mixing, resampling)
+  scanner/      following control channels and voice
+  sdr/          talking to the radio hardware
+proto/          data definitions shared across the program
+go.mod          the module and its pinned dependencies
+```
+
+`cmd/` holds the `package main` and `func main()` from
+[lesson 2](/learn/programming-go/hello-go/); `internal/` holds the
+[packages](/learn/programming-go/packages-and-modules/) that can only be imported
+within the project. Just reading the directory names tells you where things live.
+
+## Following the flow
+
+Open the entry point and you can trace the whole program:
+
+1. **`main`** parses config and starts the engine — often launching long-running
+   work as [goroutines](/learn/programming-go/goroutines/).
+2. The **`sdr`** package reads samples off the radio and sends them down a
+   [channel](/learn/programming-go/channels/) — a stream of `complex64` I/Q values.
+3. The **`dsp`** package receives that stream, then tunes, filters, and demodulates
+   it (the whole [DSP module](/learn/dsp/) is this stage in depth).
+4. The **`scanner`** package interprets the resulting bits — control-channel
+   messages, voice frames — and drives what the user sees.
+
+Each stage is a package with a small public API; the stages hand data to each other
+over channels, exactly the *share-memory-by-communicating* model from Unit 3.
+
+## Interfaces at the seams
+
+Where two packages meet, you'll usually find a small
+[interface](/learn/programming-go/interfaces/). A demodulator, a sample source, or a
+sink is defined by the one or two methods it must have — so the scanner can be tested
+with a fake source, and a new demodulator can drop in without touching its callers.
+Spotting these interfaces is the key to understanding *why* the code is split the way
+it is.
+
+## Reading tips that always work
+
+- **Start at `main`** and follow the calls outward; don't read files alphabetically.
+- **Capitals are the API.** An exported (capitalized) name is meant to be used by
+  other packages; lowercase is internal detail you can skim.
+- **Follow the channels.** Data flowing over a channel marks the boundary between
+  concurrent stages.
+- **Run the tests.** `_test.go` files are worked examples of how each package is
+  meant to be used — often the fastest way to understand an API.
+
+Because Go is formatted and organized so consistently, these habits carry from
+GopherTrunk to almost any Go project you'll ever open.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — cmd/ holds the main package(s) you build into binaries." markdown="0">
+  <p class="knowledge-check__q">Quick check: in a typical Go project, where do you find the program's entry point?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">In the internal/ directory</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">In a main package under cmd/</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">In go.mod</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Real Go projects share a shape: **`cmd/`** entry points, **`internal/`** engine,
+  packages by responsibility.
+- Follow the program from **`main`** outward; **capitalized** names are the public
+  API.
+- Stages hand work over **channels**; **small interfaces** sit at package seams.
+- These reading habits transfer from GopherTrunk to nearly any Go codebase.
+
+Next up: where to go from here to keep growing as a Go developer.

--- a/docs/learn/programming-go/select-and-sync.md
+++ b/docs/learn/programming-go/select-and-sync.md
@@ -1,0 +1,133 @@
+---
+slug: select-and-sync
+title: select & synchronization
+description: Coordinate multiple channels with Go's select statement, and use the sync package — mutexes, WaitGroups, and context — for the times channels aren't the right tool.
+keywords: go select, select statement, sync package, mutex, waitgroup, context, goroutine coordination, data race, go concurrency patterns
+level: advanced
+status: full
+prereq:
+  - channels
+faq:
+  - q: What does the select statement do?
+    a: "`select` waits on several channel operations at once and proceeds with whichever is ready first. It's how a goroutine can, say, read from a data channel but also watch a cancellation channel — whichever fires first wins. With a `default` case, select can also try channels without blocking at all."
+  - q: What is a WaitGroup for?
+    a: A `sync.WaitGroup` lets one goroutine wait for a group of others to finish. You call Add to count the goroutines, each one calls Done as it completes, and Wait blocks until the count reaches zero. It's the standard way to make main wait for background work before the program exits.
+---
+
+# select & synchronization
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**`select`** waits on several channels at once and acts on whichever is ready —
+the key to handling multiple streams and cancellation. When channels aren't the
+right fit, the **`sync`** package provides a **`Mutex`** to guard shared state and a
+**`WaitGroup`** to wait for goroutines to finish, and **`context`** carries
+cancellation across a whole call tree.
+</div>
+
+Real concurrent programs juggle several channels and need a clean way to stop. This
+lesson covers `select` and the coordination tools that round out Go's concurrency
+model.
+
+## select: waiting on many channels
+
+`select` is like a `switch`, but its cases are channel operations. It blocks until
+one is ready, then runs that case:
+
+```go
+select {
+case frame := <-frames:
+    process(frame)          // data arrived
+case <-quit:
+    return                  // asked to stop
+}
+```
+
+This pattern — "handle data, but also watch for a stop signal" — is everywhere in
+long-running services. Add a `default` case and `select` won't block at all,
+letting you poll a channel and move on if nothing's waiting.
+
+## The sync package: when locks are simpler
+
+Channels shine for moving data, but sometimes you just have shared state many
+goroutines touch — a counter, a map, a cache. A **`sync.Mutex`** guards it:
+
+```go
+var mu sync.Mutex
+count := 0
+
+func record() {
+    mu.Lock()
+    count++          // only one goroutine in here at a time
+    mu.Unlock()
+}
+```
+
+`Lock`/`Unlock` ensure only one goroutine is in the critical section at once,
+preventing the [data race](/learn/programming-go/channels/) you'd otherwise get.
+
+## WaitGroup: waiting for goroutines to finish
+
+If `main` returns while goroutines are still running, they're cut off. A
+**`sync.WaitGroup`** waits for them:
+
+```go
+var wg sync.WaitGroup
+for _, ch := range channels {
+    wg.Add(1)
+    go func(c Channel) {
+        defer wg.Done()
+        decode(c)
+    }(ch)
+}
+wg.Wait()   // blocks until every decode finishes
+```
+
+## context: cancellation across a call tree
+
+Long-running work needs a way to be told "stop now" — a user cancels, a timeout
+fires. Go's **`context`** carries that signal down through every function and
+goroutine involved:
+
+```go
+func run(ctx context.Context) {
+    for {
+        select {
+        case <-ctx.Done():
+            return          // cancelled or timed out
+        case s := <-samples:
+            process(s)
+        }
+    }
+}
+```
+
+A single `cancel()` at the top propagates to every goroutine watching `ctx.Done()`.
+GopherTrunk uses exactly this shape to shut a scanner down cleanly.
+
+## Detecting mistakes
+
+Concurrency bugs are subtle, so Go ships a **race detector**: run your tests with
+`go test -race` and it flags any unsynchronized shared access at runtime. Make it a
+habit — it catches the bugs that are hardest to find by reading.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — select proceeds with whichever channel operation is ready first." markdown="0">
+  <p class="knowledge-check__q">Quick check: a goroutine must read incoming data but also stop when a quit channel fires. What does it use?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="correct">A select statement over both channels</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Two separate goroutines that never coordinate</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">A tight loop polling with time.Sleep</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **`select`** waits on multiple channels and acts on whichever is ready — ideal for
+  data-plus-cancellation.
+- **`sync.Mutex`** guards shared state; **`sync.WaitGroup`** waits for goroutines to
+  finish.
+- **`context`** propagates cancellation and timeouts across a whole call tree.
+- **`go test -race`** catches unsynchronized access — run it often.
+
+Next up: how Go organizes code into packages and modules.

--- a/docs/learn/programming-go/slices-maps-generics.md
+++ b/docs/learn/programming-go/slices-maps-generics.md
@@ -1,0 +1,120 @@
+---
+slug: slices-maps-generics
+title: Slices, maps & generics
+description: Go's core collections — slices and maps, how they grow and alias — plus type parameters (generics) for writing reusable, type-safe code.
+keywords: go slices, go maps, go generics, type parameters, append, make, slice aliasing, go collections
+level: intermediate
+status: full
+prereq:
+  - values-and-types
+faq:
+  - q: What is the difference between an array and a slice in Go?
+    a: An array has a fixed length that is part of its type ([4]int), so it rarely appears directly. A slice is a flexible, growable view into an underlying array — it has a length and a capacity and is what you use in practice. You create slices with literals or make, and grow them with append.
+  - q: When did Go get generics, and do I need them?
+    a: Generics arrived in Go 1.18 (2022). You don't need them for everyday code — slices and maps already work with any type — but they let you write one function or data structure that works across many types safely, instead of duplicating it per type or falling back to the empty interface. Reach for them when you'd otherwise copy-paste the same logic for int, string, and float64.
+---
+
+# Slices, maps & generics
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A **slice** is Go's growable list — a view into an array you extend with
+**`append`**. A **map** is a key/value lookup table. Both are created with **`make`**
+and are used constantly. **Generics** (type parameters) let you write one function
+that works for many types safely — added in Go 1.18.
+</div>
+
+Almost every program stores collections of things. This lesson covers Go's two core
+containers and the generics that make reusable code type-safe.
+
+## Slices: the everyday list
+
+A **slice** holds an ordered, growable sequence:
+
+```go
+var samples []float64            // an empty slice
+samples = append(samples, 0.5)   // grow it
+samples = append(samples, 0.7, 0.9)
+
+first := samples[0]              // index from 0
+window := samples[1:3]           // a sub-slice: elements 1 and 2
+```
+
+`append` returns a (possibly new) slice, so you always assign its result back. A
+slice is a lightweight view over a backing array, which is why passing one to a
+function is cheap — but also why two slices can share storage.
+
+## A slice aliasing gotcha
+
+Because a slice points into a shared array, sub-slices can *alias* each other:
+
+```go
+a := []int{1, 2, 3, 4}
+b := a[0:2]      // b shares storage with a
+b[0] = 99        // this also changes a[0]!
+```
+
+This is efficient but occasionally surprising — when you need an independent copy,
+use the built-in `copy`. Keeping this in mind matters in signal code, where large
+sample buffers are sliced constantly.
+
+## Maps: key/value lookup
+
+A **map** associates keys with values:
+
+```go
+names := make(map[int]string)
+names[101] = "Dispatch"          // talkgroup 101
+names[102] = "Fireground"
+
+n, ok := names[101]              // n = "Dispatch", ok = true
+_, ok = names[999]               // ok = false: key absent
+```
+
+The two-value form (`value, ok`) tells you whether the key was present — the idiom
+for "look it up, and tell me if it exists." Maps are unordered; range over one and
+the order is deliberately randomized.
+
+## Generics: one function, many types
+
+Before generics, a function that summed a slice had to be written once per numeric
+type or fall back to the untyped empty interface. **Type parameters** fix that:
+
+```go
+func Max[T int | float64](xs []T) T {
+    m := xs[0]
+    for _, x := range xs[1:] {
+        if x > m {
+            m = x
+        }
+    }
+    return m
+}
+
+Max([]int{3, 1, 4})        // works
+Max([]float64{2.7, 1.8})   // also works, type-safe
+```
+
+The `[T int | float64]` says "T can be either type," and the compiler checks each
+call. Use generics when you'd otherwise duplicate logic across types; for most
+day-to-day code, plain slices and maps are enough.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — append returns the grown slice, so you assign it back." markdown="0">
+  <p class="knowledge-check__q">Quick check: how do you add an element to a slice <code>s</code>?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">s.add(x)</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">s = append(s, x)</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">s[len(s)] = x</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **slice** is a growable view into an array; extend it with **`append`** and
+  assign the result back.
+- Slices can **alias** shared storage — use `copy` when you need independence.
+- A **map** is key/value lookup; the `value, ok` form reports whether a key exists.
+- **Generics** (type parameters) write one type-safe function for many types.
+
+Next up: testing, a first-class part of the language.

--- a/docs/learn/programming-go/strings-and-runes.md
+++ b/docs/learn/programming-go/strings-and-runes.md
@@ -1,0 +1,114 @@
+---
+slug: strings-and-runes
+title: Strings, bytes & runes
+description: "How Go handles text — immutable strings, byte slices, and runes — and why a character isn't always one byte once Unicode and UTF-8 enter the picture."
+keywords: go strings, go runes, go bytes, utf-8 go, immutable string, rune int32, range over string, string to byte slice
+level: intermediate
+status: full
+prereq:
+  - slices-maps-generics
+faq:
+  - q: What is a rune in Go?
+    a: "A rune is an alias for int32 and holds a single Unicode code point — one character, which may take several bytes in UTF-8. Ranging over a string yields runes, so a loop sees whole characters even when they occupy more than one byte."
+  - q: Why can't I change a character in a Go string?
+    a: "Strings are immutable — their bytes never change after creation, which makes them safe to share without copying. To edit text, convert to a []byte (or []rune), modify that, and convert back to a string."
+---
+
+# Strings, bytes & runes
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A Go **string** is an **immutable** sequence of bytes, usually holding **UTF-8**
+text. Indexing a string gives you a **byte**, not a character. A **rune** (`int32`)
+is one Unicode code point, and **`range`** over a string walks it rune by rune. To
+edit text, convert to **`[]byte`** or **`[]rune`**, change it, and convert back.
+</div>
+
+Text looks simple until non-ASCII characters arrive. This lesson untangles the three
+layers Go gives you — strings, bytes, and runes — building on
+[Slices, maps & generics](/learn/programming-go/slices-maps-generics/).
+
+## What is a Go string, really?
+
+A string is a read-only slice of bytes with a length. It is immutable: once made, its
+bytes never change, so passing a string around never copies the underlying data.
+
+```go
+s := "P25 phase 2"
+fmt.Println(len(s)) // 11 — the number of bytes
+fmt.Println(s[0])  // 80 — the byte value of 'P', not "P"
+// s[0] = 'X'      // compile error: strings are immutable
+```
+
+Note that indexing yields a **byte** (`uint8`). For pure ASCII that happens to match
+one character, but the moment text contains multi-byte characters, bytes and
+characters part ways.
+
+## Bytes vs runes
+
+UTF-8 encodes each Unicode character as one to four bytes. ASCII stays one byte; an
+accented letter or symbol takes more. A **rune** is Go's name for one code point:
+
+```go
+s := "µV"                    // micro-volts label
+fmt.Println(len(s))          // 3 — µ is two bytes, V is one
+fmt.Println(len([]rune(s)))  // 2 — two characters
+```
+
+| Type | What it is | Size | Use it for |
+|------|-----------|------|-----------|
+| `byte` | alias for `uint8` | 1 byte | Raw data, ASCII, I/O buffers |
+| `rune` | alias for `int32` | 4 bytes | One Unicode character |
+| `string` | immutable byte sequence | varies | Text you read and pass around |
+| `[]byte` | mutable byte slice | varies | Text or binary you edit |
+
+## Ranging over a string
+
+A plain index walks bytes; `range` walks **runes**, decoding UTF-8 as it goes and
+giving you each character's byte offset:
+
+```go
+for i, r := range "µVdBm" {
+    fmt.Printf("%d: %c\n", i, r)  // i jumps by the byte width of each rune
+}
+```
+
+This is the reliable way to iterate characters. Reach for the `unicode/utf8` and
+`strings` packages from the [standard library](/learn/programming-go/the-standard-library/)
+when you need counting, splitting, or case handling.
+
+## Editing text
+
+Because strings are immutable, you build new ones. For heavy concatenation use a
+`strings.Builder` instead of `+=` so you don't allocate a fresh string each time:
+
+```go
+var b strings.Builder
+for _, part := range []string{"460", ".", "025", " MHz"} {
+    b.WriteString(part)
+}
+label := b.String()   // "460.025 MHz"
+```
+
+For in-place edits, convert to `[]byte` or `[]rune`, mutate, and convert back — each
+conversion copies, which is exactly what preserves the original string's immutability.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — indexing a string gives a byte; range gives runes." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does <em>s[0]</em> return for a Go string s?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">The first character as a string</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The first byte (a uint8)</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">The first rune (a code point)</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **string** is an **immutable** sequence of bytes, usually UTF-8 text.
+- Indexing gives a **byte**; **`range`** gives **runes** (whole characters).
+- A **`rune`** is `int32`, one Unicode code point; multi-byte characters make
+  `len(string)` count bytes, not characters.
+- Edit text via **`[]byte`**/**`[]rune`** or a `strings.Builder`.
+
+Next up: turning Go values into JSON and back with the standard library.

--- a/docs/learn/programming-go/structs-and-methods.md
+++ b/docs/learn/programming-go/structs-and-methods.md
@@ -1,0 +1,122 @@
+---
+slug: structs-and-methods
+title: Structs & methods
+description: Group related data with Go structs, attach behaviour with methods, and understand pointer versus value receivers — Go's lightweight alternative to classes.
+keywords: go structs, go methods, pointer receiver, value receiver, go struct fields, composition, go objects
+level: intermediate
+status: full
+prereq:
+  - functions-and-errors
+faq:
+  - q: Does Go have classes?
+    a: No. Go has structs (bundles of named fields) and methods (functions attached to a type). Together they cover most of what classes do, but there is no inheritance. Instead, Go favours composition — embedding one struct inside another — and interfaces for shared behaviour.
+  - q: When do I use a pointer receiver versus a value receiver?
+    a: Use a pointer receiver (`func (r *Receiver)`) when the method needs to modify the struct, or when the struct is large and you want to avoid copying it. Use a value receiver when the method only reads and the struct is small. A common rule of thumb is to be consistent within a type — if any method needs a pointer receiver, use pointer receivers for all of them.
+---
+
+# Structs & methods
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A **struct** groups related fields into one type; a **method** is a function
+attached to a type via a **receiver**. A **pointer receiver** (`*T`) lets a method
+modify the struct or avoid copying it; a **value receiver** (`T`) works on a copy.
+Go has **no classes and no inheritance** — structs plus methods, composed together,
+do the job.
+</div>
+
+Real programs need to bundle data — a radio channel has a frequency, a bandwidth, a
+name. This lesson introduces structs to hold that data and methods to give it
+behaviour.
+
+## Defining a struct
+
+```go
+type Channel struct {
+    Name      string
+    FreqHz    float64
+    Bandwidth float64
+}
+```
+
+Create one and read its fields with dot notation:
+
+```go
+cc := Channel{Name: "P25 CC", FreqHz: 851.0125e6, Bandwidth: 12500}
+fmt.Println(cc.Name, cc.FreqHz)
+```
+
+Field names starting with a **capital letter** are *exported* — visible outside the
+package. Lowercase fields are private to the package (more in
+[Packages & modules](/learn/programming-go/packages-and-modules/)).
+
+## Attaching methods
+
+A method is a function with a **receiver** — the type it belongs to, written before
+the name:
+
+```go
+func (c Channel) Wavelength() float64 {
+    return 3e8 / c.FreqHz
+}
+
+fmt.Println(cc.Wavelength())
+```
+
+Here `c Channel` is a **value receiver**: the method gets a copy of the channel and
+can only read it.
+
+## Pointer vs value receivers
+
+When a method needs to *change* the struct, it takes a **pointer receiver**:
+
+```go
+func (c *Channel) Retune(freqHz float64) {
+    c.FreqHz = freqHz   // modifies the original, not a copy
+}
+```
+
+| Receiver | Written | Sees | Use when |
+|----------|---------|------|----------|
+| Value | `func (c Channel)` | a copy | read-only, small structs |
+| Pointer | `func (c *Channel)` | the original | modifying, or large structs |
+
+Call it the same way — `cc.Retune(852e6)` — Go takes the address for you. The rule
+of thumb: if any method on a type needs a pointer receiver, give them all pointer
+receivers for consistency.
+
+## Composition instead of inheritance
+
+Go has no subclasses. To reuse a struct, you **embed** it:
+
+```go
+type TrunkedChannel struct {
+    Channel        // embedded — TrunkedChannel gets Channel's fields and methods
+    SystemID int
+}
+```
+
+A `TrunkedChannel` now has `Name`, `FreqHz`, and `Wavelength()` directly, plus its
+own `SystemID`. This "has-a" composition is Go's answer to the "is-a" hierarchies of
+class-based languages — simpler, and it pairs naturally with the interfaces you'll
+meet next.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — modifying the struct requires a pointer receiver." markdown="0">
+  <p class="knowledge-check__q">Quick check: a method needs to change a field of its struct. Which receiver does it need?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">A value receiver (T)</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">A pointer receiver (*T)</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Either works identically</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **struct** bundles named **fields**; **capitalized** fields are exported.
+- A **method** attaches behaviour to a type through a **receiver**.
+- **Pointer receivers** modify the original or avoid copying; **value receivers**
+  work on a copy.
+- Go uses **composition (embedding)**, not inheritance, to reuse types.
+
+Next up: interfaces — the idea that makes Go code flexible without class hierarchies.

--- a/docs/learn/programming-go/testing-in-go.md
+++ b/docs/learn/programming-go/testing-in-go.md
@@ -1,0 +1,114 @@
+---
+slug: testing-in-go
+title: Testing in Go
+description: Go's built-in testing package, table-driven tests, and benchmarks — why testing is a first-class part of the language and how GopherTrunk gates every commit on it.
+keywords: go testing, go test, testing package, table driven tests, go benchmarks, unit tests go, testing.T, go test race
+level: intermediate
+status: full
+prereq:
+  - functions-and-errors
+faq:
+  - q: Do I need a testing framework for Go?
+    a: No. The standard library's testing package plus the go test command cover unit tests, table-driven tests, benchmarks, and coverage out of the box. Third-party assertion libraries exist, but idiomatic Go often skips them and just uses plain if checks with t.Errorf, keeping tests dependency-free.
+  - q: What is a table-driven test?
+    a: A test that lists its cases as a slice of structs — each with inputs and the expected output — then loops over them running the same assertion. It's the dominant Go testing style because adding a new case is one line, and each case can be named and reported independently with t.Run.
+---
+
+# Testing in Go
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Testing is built into Go: put tests in `_test.go` files, write functions like
+`func TestX(t *testing.T)`, and run them with **`go test`**. The idiomatic style is
+**table-driven** — a list of cases looped over. Benchmarks and the **race detector**
+come free too. GopherTrunk gates every commit on **`make vet test`**.
+</div>
+
+In Go, testing isn't an add-on you bolt on later — it's part of the toolchain from
+day one. This lesson shows the shape of a Go test and the style Go projects use.
+
+## The anatomy of a test
+
+Tests live beside the code they test, in files ending `_test.go`, and are just
+functions taking `*testing.T`:
+
+```go
+// channel_test.go
+package scanner
+
+import "testing"
+
+func TestWavelength(t *testing.T) {
+    got := Channel{FreqHz: 300e6}.Wavelength()
+    want := 1.0
+    if got != want {
+        t.Errorf("Wavelength() = %v, want %v", got, want)
+    }
+}
+```
+
+Run it with `go test ./...`. A test *fails* by calling `t.Errorf` (or `t.Fatalf` to
+stop immediately); a test that returns without complaint passes. No assertion
+library required.
+
+## Table-driven tests
+
+The dominant Go style lists cases in a table and loops:
+
+```go
+func TestChannelWidth(t *testing.T) {
+    cases := []struct {
+        name           string
+        high, low, want float64
+    }{
+        {"12.5 kHz", 851.01875e6, 851.00625e6, 12500},
+        {"zero width", 460e6, 460e6, 0},
+    }
+    for _, c := range cases {
+        t.Run(c.name, func(t *testing.T) {
+            if got := channelWidth(c.high, c.low); got != c.want {
+                t.Errorf("got %v, want %v", got, c.want)
+            }
+        })
+    }
+}
+```
+
+Adding a case is one line, and `t.Run` gives each case its own name in the output.
+This is exactly the pattern GopherTrunk uses throughout — including the regression
+tests its [contribution rules](/learn/git/pull-requests/) require for every bug fix.
+
+## Benchmarks and the race detector
+
+The same package measures performance. A `func BenchmarkX(b *testing.B)` run with
+`go test -bench=.` reports nanoseconds per operation — invaluable for DSP hot paths.
+And `go test -race` re-runs your tests watching for the concurrency bugs from
+[select & synchronization](/learn/programming-go/select-and-sync/).
+
+## Testing as a gate
+
+Because tests are so easy to run, projects wire them into a single gate. GopherTrunk's
+is `make vet test` — `go vet` plus the whole suite, green before any commit. That one
+habit is what lets a large codebase change quickly without breaking. You'll see how
+CI enforces the same gate on every push in the
+[Deployment module](/learn/deployment/ci-cd-pipelines/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — Go test files end in _test.go and use the testing package." markdown="0">
+  <p class="knowledge-check__q">Quick check: where do Go unit tests live?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">In a separate tests/ folder</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">In files ending _test.go beside the code</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Inside the main function</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Tests live in **`_test.go`** files as `func TestX(t *testing.T)`, run with **`go
+  test`**.
+- The idiomatic style is **table-driven** — a list of cases looped with `t.Run`.
+- **Benchmarks** and the **`-race`** detector come built in.
+- Projects gate commits on tests — GopherTrunk uses **`make vet test`**.
+
+Next up: a tour of the standard library that ships with Go.

--- a/docs/learn/programming-go/the-go-toolchain.md
+++ b/docs/learn/programming-go/the-go-toolchain.md
@@ -1,0 +1,100 @@
+---
+slug: the-go-toolchain
+title: The Go toolchain
+description: A tour of Go's batteries-included command-line tools — go build, run, test, fmt, and vet — the zero-configuration toolchain that formats, checks, tests, and builds your code.
+keywords: go toolchain, go build, go test, gofmt, go vet, go tools, go command, go run
+level: beginner
+status: full
+prereq:
+  - hello-go
+faq:
+  - q: Do I need a build system like Make for Go?
+    a: Usually not. The `go` command builds, tests, formats, and manages dependencies on its own, with no separate build file. Larger projects sometimes add a Makefile to bundle common commands (GopherTrunk has one), but that is a convenience wrapper around the same `go` tools, not a requirement.
+  - q: What is the difference between gofmt and go vet?
+    a: "`gofmt` is about *style* — it rewrites your code into Go's one official layout. `go vet` is about *correctness* — it inspects your code for suspicious constructs that compile but are probably bugs, like a format string that doesn't match its arguments. Formatting is cosmetic; vet catches real mistakes."
+---
+
+# The Go toolchain
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+The single **`go`** command is a whole toolchain: **`go build`** and **`go run`**
+compile, **`go test`** runs tests, **`gofmt`** enforces one official style, **`go
+vet`** flags likely bugs, and **`go mod`** manages dependencies — all with **zero
+configuration**. Learning these five commands is most of what day-to-day Go work
+needs.
+</div>
+
+Most languages leave formatting, testing, and dependency management to third-party
+tools you have to choose and configure. Go ships them in the box. This lesson is a
+quick tour so the commands feel familiar before you meet the language features
+they support.
+
+## The commands you'll use every day
+
+| Command | What it does |
+|---------|--------------|
+| `go run main.go` | Compile and immediately run — for iterating |
+| `go build` | Compile to a keepable binary |
+| `go test ./...` | Run every test in the module |
+| `gofmt -w .` | Reformat files into the one official style |
+| `go vet ./...` | Report suspicious, likely-buggy code |
+| `go mod tidy` | Add missing and remove unused dependencies |
+
+The `./...` you see on some of these means "this directory and everything below
+it" — a handy way to act on a whole project at once.
+
+## One style, settled
+
+Run `gofmt` and arguments about tabs, spaces, and brace placement simply end —
+there is one correct layout and the tool produces it. Because every Go project is
+formatted the same way, code you have never seen still reads like your own. Most
+editors run `gofmt` (or its cousin `goimports`, which also fixes import lines) every
+time you save.
+
+## Catching bugs before they run
+
+`go vet` reads your code looking for mistakes the compiler accepts but that are
+almost certainly wrong — a `Printf` whose placeholders don't match its arguments, a
+lock copied by value, an unreachable branch. It is fast and worth running
+constantly. GopherTrunk's own build gate is literally `make vet test`: vet plus the
+full test suite must pass before any commit. You will meet the testing half in
+[Testing in Go](/learn/programming-go/testing-in-go/).
+
+## Modules and dependencies
+
+A Go project is a **module**, defined by a `go.mod` file at its root that names the
+module and lists its dependencies with exact versions. When you import a package you
+don't have, `go mod tidy` fetches it and records the version, so a fresh checkout
+builds identically for everyone. You'll go deeper in
+[Packages & modules](/learn/programming-go/packages-and-modules/).
+
+```text
+$ go mod tidy      # sync dependencies with what the code imports
+$ go build ./...   # build everything
+$ go vet ./...     # check everything
+$ go test ./...    # test everything
+```
+
+Those four lines are, essentially, a full Go CI pipeline — which is why wiring Go
+into [continuous integration](/learn/deployment/ci-cd-pipelines/) is so painless.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — vet looks for likely bugs; gofmt only reformats." markdown="0">
+  <p class="knowledge-check__q">Quick check: which tool would warn you that a <code>Printf</code> call's placeholders don't match its arguments?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">gofmt</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">go vet</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">go mod tidy</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- The one **`go`** command builds, runs, tests, formats, vets, and manages
+  dependencies — **no separate build system required**.
+- **`gofmt`** gives every Go project the same style; **`go vet`** flags likely bugs.
+- A project is a **module** (`go.mod`) with pinned dependency versions.
+- `build`, `vet`, and `test` over `./...` act on the whole project at once.
+
+Next up: the values and types that Go programs are built from.

--- a/docs/learn/programming-go/the-standard-library.md
+++ b/docs/learn/programming-go/the-standard-library.md
@@ -1,0 +1,101 @@
+---
+slug: the-standard-library
+title: The standard library
+description: A tour of the batteries Go ships with — io, bytes, encoding, net, and more — and why in Go you reach for an external dependency far less often than in other ecosystems.
+keywords: go standard library, go stdlib, io reader, net http, encoding json, bufio, go packages, batteries included
+level: intermediate
+status: full
+prereq:
+  - packages-and-modules
+faq:
+  - q: Why does Go have so few dependencies compared to other languages?
+    a: Its standard library is unusually complete and stable — HTTP servers, JSON, cryptography, compression, and more are all built in and maintained alongside the language. So the common building blocks are already there, and Go projects tend to have short dependency lists. Fewer dependencies means less to audit, update, and break.
+  - q: What is io.Reader and why does it matter?
+    a: io.Reader is a one-method interface for "something you can read bytes from." Files, network connections, byte buffers, and compressed streams all satisfy it, so any function written against io.Reader works with all of them. It's the connective tissue of the standard library and the best example of Go's small-interfaces philosophy.
+---
+
+# The standard library
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Go ships a large, stable **standard library** — `io`, `bytes`, `bufio`,
+`encoding/json`, `net/http`, `os`, `time`, and much more — so you reach for an
+external dependency far less than in most ecosystems. Its small interfaces (like
+**`io.Reader`**) tie everything together. Knowing what's already there saves you
+writing — and depending on — code you don't need.
+</div>
+
+A language is only as pleasant as its libraries. Go's standard library is
+famously complete, and leaning on it is a core Go skill. This lesson maps the
+pieces you'll use most.
+
+## The packages you'll reach for constantly
+
+| Package | Gives you |
+|---------|-----------|
+| `fmt` | Formatted printing and string building |
+| `io` / `bufio` | Streaming reads and writes, buffering |
+| `bytes` / `strings` | Working with byte slices and text |
+| `os` | Files, environment, arguments |
+| `encoding/json` | Turn structs to JSON and back |
+| `net/http` | A full HTTP client *and* server |
+| `time` | Durations, timers, timestamps |
+| `errors` | Wrapping and inspecting errors |
+
+That `net/http` line is worth dwelling on: a production-grade web server is *in the
+standard library*. GopherTrunk's web interface and API build on it directly — no
+framework required.
+
+## Small interfaces, everywhere
+
+The standard library is glued together by tiny interfaces from
+[the interfaces lesson](/learn/programming-go/interfaces/). The star is `io.Reader`:
+
+```go
+func countBytes(r io.Reader) (int, error) {
+    buf := make([]byte, 4096)
+    total := 0
+    for {
+        n, err := r.Read(buf)
+        total += n
+        if err != nil {
+            return total, err   // io.EOF marks the clean end
+        }
+    }
+}
+```
+
+Because a file, a network socket, a `bytes.Buffer`, a gzip stream, and an SDR sample
+source *all* satisfy `io.Reader`, `countBytes` works with every one of them
+unchanged. Learn the handful of these interfaces — `io.Reader`, `io.Writer`,
+`io.Closer` — and huge swaths of Go code suddenly read the same way.
+
+## Fewer dependencies, on purpose
+
+Because so much is built in and kept stable across versions, Go projects typically
+have short dependency lists. That's not just tidiness: every dependency is code you
+must trust, audit, and update (see the
+[security](/learn/cybersecurity/secure-coding/) and
+[licensing](/learn/software-licensing/auditing-dependencies/) angles). Reaching for
+the standard library first is faster *and* safer.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — files, sockets, and buffers all satisfy io.Reader, so one function handles them all." markdown="0">
+  <p class="knowledge-check__q">Quick check: why can one function that takes an <code>io.Reader</code> read from files, network connections, and byte buffers alike?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Go converts them all to files first</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">They all satisfy the io.Reader interface</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It uses reflection to detect each type</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Go's **standard library** is large and stable — HTTP, JSON, crypto, and more are
+  built in.
+- Small interfaces like **`io.Reader`** let one function work across files, sockets,
+  and buffers.
+- Reaching for the stdlib first means **fewer dependencies** to audit and maintain.
+- GopherTrunk's web server and API are built on `net/http` — no framework needed.
+
+Next up: put it all together by reading a real Go codebase.

--- a/docs/learn/programming-go/values-and-types.md
+++ b/docs/learn/programming-go/values-and-types.md
@@ -1,0 +1,114 @@
+---
+slug: values-and-types
+title: Values, variables & types
+description: Go's built-in types, variable declarations, zero values, and static typing — why a small, strict set of types makes programs easier to reason about and safer to change.
+keywords: go types, go variables, go var, short variable declaration, zero value, static typing, int string bool, go constants
+level: beginner
+status: full
+prereq:
+  - hello-go
+faq:
+  - q: What is a zero value in Go?
+    a: Every variable in Go is usable the moment it is declared, even if you didn't assign it — it gets a sensible "zero value" for its type. Numbers start at 0, booleans at false, strings at "" (empty), and pointers and other reference types at nil. This removes a whole category of uninitialized-variable bugs.
+  - q: When should I use := versus var?
+    a: Use the short form `x := value` inside functions when you're declaring and assigning at once and Go can infer the type — it's the common case. Use `var x Type` when you need a variable without an initial value, want to state the type explicitly, or are declaring a package-level variable, where `:=` isn't allowed.
+---
+
+# Values, variables & types
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Go is **statically typed**: every value has a type fixed at compile time. You
+declare variables with **`var`** or the short **`:=`** form, and an unassigned
+variable starts at its type's **zero value** (0, `false`, `""`, or `nil`). The
+built-in types are few and predictable, which is exactly what makes Go code easy
+to read and safe to change.
+</div>
+
+Before functions and structs, you need the raw material: values and the types that
+describe them. This lesson covers Go's building-block types and the two ways to
+make a variable.
+
+## The built-in types
+
+Go keeps its type set small and explicit:
+
+| Type | Holds | Example |
+|------|-------|---------|
+| `bool` | true or false | `true` |
+| `int`, `int64`, `uint8` … | whole numbers (sized variants too) | `460025000` |
+| `float64` | decimal numbers | `851.0125` |
+| `string` | immutable text | `"control channel"` |
+| `byte` | one 8-bit value (alias for `uint8`) | raw sample data |
+
+Sized integer types like `uint8` and `int16` matter in signal work — a stream of
+radio samples is often bytes or 16-bit integers, and choosing the right width
+controls exactly how much memory a buffer uses.
+
+## Declaring variables
+
+Two forms cover almost everything:
+
+```go
+var frequency float64 = 851.0125   // explicit type and value
+var count int                       // no value -> zero value (0)
+
+name := "P25 control channel"       // short form: type inferred as string
+locked := true                      // inferred as bool
+```
+
+The short `:=` form only works **inside functions**, where it is the everyday
+choice. `var` is for package-level variables and for when you want a zero-valued
+variable to fill in later.
+
+## Zero values: nothing is uninitialized
+
+In many languages a variable you forget to set holds garbage. In Go it holds a
+defined **zero value**:
+
+```text
+int      -> 0
+float64  -> 0.0
+bool     -> false
+string   -> ""   (empty string)
+pointer  -> nil
+```
+
+That means you can declare `var total int` and immediately start adding to it — no
+initialization ceremony, no undefined behaviour.
+
+## Constants and readability
+
+Values that never change become **constants** with `const`. They make code
+self-documenting:
+
+```go
+const sampleRate = 2_400_000   // 2.4 MS/s; underscores are just for reading
+```
+
+## Static typing is a feature
+
+Because types are checked when you compile, a whole class of mistakes never reaches
+a running program. Assign a string to an `int`, or pass the wrong type to a
+function, and the build fails with a clear message instead of crashing later. When
+you are processing millions of samples a second, "the compiler already proved this
+is type-correct" is a comforting guarantee.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Correct — an unassigned int starts at its zero value, 0." markdown="0">
+  <p class="knowledge-check__q">Quick check: you write <code>var n int</code> and never assign it. What is <code>n</code>?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">undefined / garbage</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">0</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">nil</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Go is **statically typed** — every value's type is known at compile time.
+- Declare with **`var`** (explicit) or **`:=`** (inferred, inside functions).
+- Unassigned variables take a defined **zero value**, never garbage.
+- **`const`** names fixed values; sized integer types control memory precisely.
+
+Next up: functions, and the distinctive way Go handles errors.

--- a/docs/learn/programming-go/why-go.md
+++ b/docs/learn/programming-go/why-go.md
@@ -1,0 +1,99 @@
+---
+slug: why-go
+title: Why Go?
+description: Where the Go programming language came from, the problems it was built to solve, and why a fast, simple, statically compiled language is a great fit for systems software like GopherTrunk.
+keywords: why go, what is golang, go language history, why use go, go vs python, compiled language, go concurrency
+level: beginner
+status: full
+faq:
+  - q: Is Go hard to learn?
+    a: Go is deliberately one of the smallest mainstream languages. It has about 25 keywords, one loop construct, one way to format code, and no inheritance or exceptions to learn. Most people can read Go within a day and write useful programs within a week — the difficulty is less the language and more the ideas behind it, like concurrency, which this module builds up gradually.
+  - q: What is Go used for?
+    a: Go is used heavily for servers, networking tools, command-line programs, cloud infrastructure (Docker, Kubernetes, and much of the cloud is written in Go), and performance-sensitive systems software. GopherTrunk uses it for a real-time software-defined-radio engine, where fast concurrent processing of sample streams matters.
+  - q: Is Go faster than Python?
+    a: For CPU-bound work, yes — usually by a large margin, because Go compiles to native machine code while CPython interprets bytecode. Go also handles many simultaneous tasks efficiently through goroutines. Python is often quicker to prototype in; Go trades a little of that convenience for speed, static typing, and a single deployable binary.
+---
+
+# Why Go?
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Go** (or "Golang") is a **statically typed, compiled** language built at Google
+to make large systems software simple to write and fast to run. Its signature
+strengths are **fast compilation**, a **single static binary** as output, built-in
+**concurrency** via goroutines, and a deliberately **small** feature set. Those
+same traits are why GopherTrunk — a real-time SDR engine — is written in Go.
+</div>
+
+This is lesson 1, and its only job is to give you the *why* before the *how*. By
+the end you will understand what kind of language Go is, the trade-offs it makes,
+and why it shows up in so much of the software running the modern internet.
+
+## Where did Go come from?
+
+Go was created at Google around 2007 and released publicly in 2009. Its designers
+— including some of the people behind Unix and C — were frustrated by the same
+things every day: builds that took minutes, giant codebases that were hard to
+read, and languages that made concurrency painful. Go was their answer: keep the
+speed of a compiled language like C, but make it as pleasant to work with as a
+scripting language, and make concurrency a first-class part of the language rather
+than a library bolted on later.
+
+## What kind of language is Go?
+
+Three words describe most of what matters:
+
+| Trait | What it means | Why it helps |
+|-------|---------------|--------------|
+| **Compiled** | Your source is turned into native machine code ahead of time | Programs run fast and ship as one file with no interpreter needed |
+| **Statically typed** | Every value's type is known at compile time | Whole classes of bugs are caught before the program ever runs |
+| **Garbage-collected** | Memory is reclaimed automatically | You get C-like speed without manually freeing memory |
+
+Unlike Python or JavaScript, there is no interpreter shipping alongside your code —
+`go build` produces a **single self-contained binary** you can copy to a server and
+run. Unlike C or C++, you rarely think about memory management, and builds finish
+in seconds.
+
+## Why is Go a good fit for GopherTrunk?
+
+A software-defined-radio scanner has to do a lot at once: pull samples off the
+radio, filter and demodulate them, follow control-channel messages, and decode
+voice — all in real time, all concurrently. Go fits that shape well:
+
+- **Concurrency is built in.** Handling dozens of channels at once is natural with
+  goroutines (Unit 3), instead of wrestling with threads and locks.
+- **It is fast enough for DSP.** Native compiled code keeps up with high sample
+  rates where an interpreted language would fall behind.
+- **It deploys as one binary.** A user can download a single file and run a scanner
+  — no runtime to install (you will see how in the [Deployment module](/learn/deployment/)).
+
+## What does Go give up?
+
+Every language trades something. Go deliberately leaves out features other
+languages have — there is no class inheritance, no exceptions, and (until
+recently) no generics. That can feel spartan if you are used to a big language.
+The pay-off is that Go code tends to look the same everywhere, so you can drop into
+an unfamiliar codebase and read it. That readability is a feature, not an accident.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a single native binary is one of Go's headline benefits." markdown="0">
+  <p class="knowledge-check__q">Quick check: when you run <code>go build</code> on a Go program, what do you get?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">A folder of scripts that need an interpreter</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">A single self-contained native binary</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Bytecode that runs on a virtual machine</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Go is a **compiled, statically typed, garbage-collected** language built for
+  simple, fast systems software.
+- Its strengths are **fast builds**, a **single static binary**, **built-in
+  concurrency**, and a **small, readable** feature set.
+- Those strengths are exactly why GopherTrunk — a real-time SDR engine — is written
+  in Go.
+- Go trades away big-language features (inheritance, exceptions) for consistency
+  and readability.
+
+Next up: install Go and write your very first program.

--- a/docs/learn/programming-go/working-with-files.md
+++ b/docs/learn/programming-go/working-with-files.md
@@ -1,0 +1,140 @@
+---
+slug: working-with-files
+title: Working with files & I/O
+description: "Reading and writing files and streams with os, io, and bufio — and the reader/writer interfaces that make every source and sink in Go composable."
+keywords: go file io, os.Open, os.Create, io.Reader, io.Writer, bufio, defer close, go read file, go write file
+level: intermediate
+status: full
+prereq:
+  - interfaces
+faq:
+  - q: Why do I always see defer file.Close() in Go?
+    a: "Because an open file holds an OS resource that must be released. defer schedules Close to run when the function returns — whether it returns normally or early on an error — so the file is always closed and you never leak a handle. It's the standard Go cleanup pattern."
+  - q: What's the point of bufio?
+    a: "Raw file reads and writes each hit the operating system, which is slow when done a byte or line at a time. bufio wraps a reader or writer with an in-memory buffer, so many small operations become a few big ones. bufio.Scanner also makes line-by-line reading trivial."
+---
+
+# Working with files & I/O
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Open files with **`os.Open`** (read) and **`os.Create`** (write), and always
+**`defer f.Close()`**. The real power is the **`io.Reader`** and **`io.Writer`**
+interfaces — one-method contracts that files, network connections, and buffers all
+satisfy, so the same code works on any of them. **`bufio`** adds buffering and
+convenient line scanning.
+</div>
+
+Reading and writing data is where the [interfaces](/learn/programming-go/interfaces/)
+lesson pays off: Go models every stream through two tiny interfaces. This lesson
+shows the everyday patterns.
+
+## Opening and closing a file
+
+`os.Open` returns a `*os.File` (which is an `io.Reader`) and an error. Pair every open
+with a deferred close:
+
+```go
+f, err := os.Open("capture.cfile")
+if err != nil {
+    return fmt.Errorf("open capture: %w", err)
+}
+defer f.Close()   // runs when the function returns, even on error
+```
+
+`defer` guarantees cleanup runs no matter which path the function takes — the reason
+you see it on the line right after every successful open.
+
+## The two interfaces that tie it together
+
+Almost all of Go's I/O is built on two one-method interfaces:
+
+```go
+type Reader interface { Read(p []byte) (n int, err error) }
+type Writer interface { Write(p []byte) (n int, err error) }
+```
+
+Because a file, a network socket, a byte buffer, and a gzip stream all satisfy these,
+a function written against `io.Reader` works with every one of them. `io.Copy` is the
+classic example — it pipes any reader into any writer:
+
+```go
+n, err := io.Copy(dst, src)   // dst is any Writer, src is any Reader
+```
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 120" role="img" aria-label="A source satisfying io.Reader flows through io.Copy into a destination satisfying io.Writer." xmlns="http://www.w3.org/2000/svg">
+  <rect x="10" y="45" width="130" height="34" rx="6" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="75" y="66" text-anchor="middle" font-size="11" fill="currentColor">src (io.Reader)</text>
+  <rect x="195" y="45" width="120" height="34" rx="6" fill="none" stroke="currentColor" stroke-width="1.5" stroke-dasharray="5 3"/>
+  <text x="255" y="66" text-anchor="middle" font-size="11" fill="currentColor">io.Copy</text>
+  <rect x="380" y="45" width="130" height="34" rx="6" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="445" y="66" text-anchor="middle" font-size="11" fill="currentColor">dst (io.Writer)</text>
+  <line x1="140" y1="62" x2="195" y2="62" stroke="currentColor" stroke-width="1.5" marker-end="url(#ia)"/>
+  <line x1="315" y1="62" x2="380" y2="62" stroke="currentColor" stroke-width="1.5" marker-end="url(#ia)"/>
+  <defs><marker id="ia" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Code written against io.Reader/io.Writer works with any source and any sink — files, sockets, or in-memory buffers.</figcaption>
+</figure>
+
+## Buffering and scanning lines
+
+Reading a file line by line is a `bufio.Scanner`:
+
+```go
+f, _ := os.Open("channels.txt")
+defer f.Close()
+
+sc := bufio.NewScanner(f)
+for sc.Scan() {
+    line := sc.Text()   // one line, no trailing newline
+    addChannel(line)
+}
+if err := sc.Err(); err != nil {
+    return err
+}
+```
+
+For writing, wrap the file in a `bufio.Writer` so many small writes batch into a few
+system calls — then `Flush` before the file closes:
+
+```go
+w := bufio.NewWriter(f)
+defer w.Flush()
+fmt.Fprintf(w, "%s,%.0f\n", ch.Name, ch.FreqHz)
+```
+
+## Whole-file shortcuts
+
+When a file is small enough to hold in memory, `os.ReadFile` and `os.WriteFile`
+collapse open/read/close into one call:
+
+```go
+data, err := os.ReadFile("scanlist.json")   // []byte of the whole file
+err = os.WriteFile("out.json", data, 0o644)
+```
+
+This is how GopherTrunk loads a JSON scan list at startup — read the bytes, then
+`json.Unmarshal` them into the config struct from the
+[previous lesson](/learn/programming-go/json-and-serialization/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — defer Close releases the file whichever way the function returns." markdown="0">
+  <p class="knowledge-check__q">Quick check: why put <em>defer f.Close()</em> right after opening a file?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It makes reads faster</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">It guarantees the file is closed on every return path, including errors</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It reopens the file if a read fails</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Open with **`os.Open`**/**`os.Create`** and **`defer f.Close()`** immediately.
+- **`io.Reader`** and **`io.Writer`** are one-method interfaces every stream
+  satisfies, so I/O code composes.
+- **`bufio`** buffers reads/writes and scans lines; remember to `Flush` a buffered
+  writer.
+- **`os.ReadFile`**/**`os.WriteFile`** handle a whole small file in one call.
+
+Next up: Go's headline feature — launching concurrent work with goroutines.


### PR DESCRIPTION
Add three complementary learning modules to the /learn/ hub to fill gaps
across the six learning paths. A gap analysis showed no module taught an
actual programming language (GopherTrunk is written in Go), no module
bridged rf-sdr theory to real signal-processing code, and nothing covered
how software is shipped and operated.

New modules (all status:full, matching the existing lesson style — tl;dr
callout, SVG figures, tables, knowledge-check quiz, recap, glossary):

- programming-go (16 lessons + glossary): Go from first program to reading
  a real Go codebase — types, errors, interfaces, goroutines/channels,
  modules, testing.
- dsp (16 lessons + glossary): sampling, I/Q, the FFT, filters, mixing,
  demodulation, and clock recovery, mapped onto GopherTrunk's real pipeline.
- deployment (14 lessons + glossary): environments, containers/Docker,
  systemd, secrets, CI/CD, and cloud/VPS, with GopherTrunk's actual
  Dockerfile, docker-compose, and systemd unit as the worked example.

Wiring: register the modules in _data/learn.yml (units/lessons/glossary),
reference them across all six learning_paths so every path gains at least
one, add _config.yml lesson-scope defaults per module directory, and add
the hubs to the _data/nav.yml Learn dropdown. The chooser, path pages,
hubs, llms.txt, and both sitemaps are all data-driven from learn.yml, so
they pick up the new content automatically.

Docs-only change; no Go sources touched.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0132B8Xo6SHwE2axu3MMafqi