### PR TITLE
fix(tetra): decode concurrent same-carrier calls + fix TCH/S CRC so real voice decodes

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -156,6 +156,12 @@ func warnGainUnits(log *slog.Logger, serial, raw string, tenthDB int) {
 // (issue #402: 8.7 dB applied vs the 49 dB the same site decoded at, no FSW).
 const lowManualGainTenthDB = 150
 
+// tetraSameCarrierTaps is how many same-carrier voice taps are registered for a
+// TETRA system — one per TDMA timeslot, so up to four concurrent calls on the
+// control carrier each bind their own tap. The per-slot voice chain filters to
+// its granted timeslot (see internal/voice/composer/tetra_voice.go).
+const tetraSameCarrierTaps = 4
+
 // gainLooksTooLow reports whether a manual (non-auto) gain is below the
 // digital-decode floor but above the tenths-of-dB-mistake band that
 // gainLooksLikeDBMistake already covers. The two checks partition the
@@ -461,7 +467,10 @@ type Daemon struct {
 	// voice pool is built before the decoder exists. Registered after physical /
 	// wideband voice devices so a real role:voice SDR is preferred; it only ever
 	// binds a grant whose frequency equals the control channel's own carrier.
-	ccVoiceSource *ccdecoder.CCVoiceSource
+	// One tap per TDMA timeslot (up to tetraSameCarrierTaps) so up to four
+	// concurrent calls on the control carrier — one per slot — each bind their
+	// own tap; the fan-out under the control decoder copies IQ to all of them.
+	ccVoiceSources []*ccdecoder.CCVoiceSource
 	// p25p2Follower harvests P25 Phase 2 talker aliases off the traffic
 	// channel's FACCH-S signalling using standalone signalling DDC taps,
 	// independent of the voice pool — so aliases surface even when no
@@ -1113,8 +1122,15 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 	// would never bind but would mask the "no voice SDR" diagnostic, so skip it.
 	for _, sys := range cfg.Trunking.Systems {
 		if strings.EqualFold(sys.Protocol, "tetra") {
-			d.ccVoiceSource = ccdecoder.NewCCVoiceSource(
-				func() *ccdecoder.Decoder { return d.ccDecoder }, "cc:same-carrier")
+			// One tap per TDMA timeslot: a TETRA carrier has four slots, so up
+			// to four calls can run at once on the control carrier. Each tap
+			// subscribes to the control decoder's voice-IQ fan-out independently
+			// and the per-slot voice chain keeps only its granted timeslot.
+			for i := 1; i <= tetraSameCarrierTaps; i++ {
+				d.ccVoiceSources = append(d.ccVoiceSources, ccdecoder.NewCCVoiceSource(
+					func() *ccdecoder.Decoder { return d.ccDecoder },
+					fmt.Sprintf("cc:same-carrier:%d", i)))
+			}
 			break
 		}
 	}
@@ -4118,12 +4134,14 @@ func (d *Daemon) collectVoiceDevices() []*trunking.VoiceDevice {
 			Serial: vt.Serial(),
 		})
 	}
-	// The same-carrier CC tap goes last so a physical role:voice SDR or a
-	// wideband tap is preferred; it binds only a grant on the CC's own carrier.
-	if d.ccVoiceSource != nil {
+	// The same-carrier CC taps go last so a physical role:voice SDR or a
+	// wideband tap is preferred; each binds only a grant on the CC's own carrier
+	// and the engine keys concurrent calls by timeslot, so up to four slots bind
+	// their own tap.
+	for _, cc := range d.ccVoiceSources {
 		voices = append(voices, &trunking.VoiceDevice{
-			Tuner:  d.ccVoiceSource,
-			Serial: d.ccVoiceSource.Serial(),
+			Tuner:  cc,
+			Serial: cc.Serial(),
 		})
 	}
 	return voices
@@ -4133,15 +4151,15 @@ func (d *Daemon) collectVoiceDevices() []*trunking.VoiceDevice {
 // poolDevices uses to resolve a virtual tuner. Returns nil when no
 // virtual tuners are configured so the lookup is a no-op.
 func (d *Daemon) virtualVoiceMap() map[string]composer.IQSource {
-	if len(d.virtualVoiceTuners) == 0 && d.ccVoiceSource == nil {
+	if len(d.virtualVoiceTuners) == 0 && len(d.ccVoiceSources) == 0 {
 		return nil
 	}
-	out := make(map[string]composer.IQSource, len(d.virtualVoiceTuners)+1)
+	out := make(map[string]composer.IQSource, len(d.virtualVoiceTuners)+len(d.ccVoiceSources))
 	for _, vt := range d.virtualVoiceTuners {
 		out[vt.Serial()] = vt
 	}
-	if d.ccVoiceSource != nil {
-		out[d.ccVoiceSource.Serial()] = d.ccVoiceSource
+	for _, cc := range d.ccVoiceSources {
+		out[cc.Serial()] = cc
 	}
 	return out
 }

--- a/cmd/gophertrunk/tetra_multislot_replay_test.go
+++ b/cmd/gophertrunk/tetra_multislot_replay_test.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"encoding/binary"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/tetra"
+	tetrarx "github.com/MattCheramie/GopherTrunk/internal/radio/tetra/receiver"
+	"github.com/MattCheramie/GopherTrunk/internal/scanner/ccdecoder"
+	"github.com/MattCheramie/GopherTrunk/internal/voice/acelp"
+)
+
+// TestTETRAMultiSlotReplay is a real-air validation harness for the per-timeslot
+// demux. Skip unless GT_TETRA_IQ points at a cs16 (interleaved int16) IQ file
+// and GT_TETRA_IQ_RATE gives its sample rate (GT_TETRA_OUT optionally names a
+// dir for per-slot WAVs). It resamples to the 144 kHz TETRA channel rate, runs
+// the receiver + slot-tagging TrafficExtractor, and for each TDMA timeslot
+// decodes the CRC-valid TCH/S speech, printing a per-slot activity timeline to
+// cross-check against the control channel's grant timeslots.
+//
+// It confirms the slot-tagging mechanism on real air (every burst anchors to the
+// synchronisation burst and is tagged 1..4). It also surfaces a separate,
+// pre-existing limitation: on a clean same-carrier capture the TCH/S channel
+// decode (tch.go) passes the class-2 CRC only at the ~1/256 chance floor, so
+// almost no real speech is recovered — the recovered bursts are spurious and
+// scattered, not clustered on the grants. That is a tch.go channel-coding issue,
+// not a demux one, and blocks audible output until fixed.
+func TestTETRAMultiSlotReplay(t *testing.T) {
+	path := os.Getenv("GT_TETRA_IQ")
+	if path == "" {
+		t.Skip("set GT_TETRA_IQ (cs16 IQ) + GT_TETRA_IQ_RATE to run the multi-slot replay")
+	}
+	inRate := 50000.0
+	if v := os.Getenv("GT_TETRA_IQ_RATE"); v != "" {
+		f, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			t.Fatalf("bad GT_TETRA_IQ_RATE: %v", err)
+		}
+		inRate = f
+	}
+	const colourExt = 262144876 // the reporter's cell
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	iq := make([]complex64, len(raw)/4)
+	for i := range iq {
+		re := int16(binary.LittleEndian.Uint16(raw[i*4:]))
+		im := int16(binary.LittleEndian.Uint16(raw[i*4+2:]))
+		iq[i] = complex(float32(re)/32768, float32(im)/32768)
+	}
+
+	ddc := ccdecoder.NewDownconverter(inRate, 144000)
+	outRate := ddc.OutRateHz()
+
+	// Per-slot accumulators.
+	type slotAcc struct {
+		speechFrames  [][]byte
+		crcBursts     int
+		firstT, lastT float64
+	}
+	var slots [5]slotAcc // index 1..4
+	var dibitsFed int
+	dibitRate := tetrarx.SymbolRate // 18000 symbols(=dibits)/sec
+
+	var totalBursts, anchoredBursts int
+	errsHist := map[string]int{}
+	extractor := tetra.NewTrafficExtractor(colourExt, func(frame []byte, slot uint8) {
+		totalBursts++
+		if slot != 0 {
+			anchoredBursts++
+		}
+		if _, _, _, errs, ok := tetra.DecodeTCHS(frame); ok {
+			switch {
+			case errs <= 5:
+				errsHist["00-05"]++
+			case errs <= 15:
+				errsHist["06-15"]++
+			case errs <= 30:
+				errsHist["16-30"]++
+			default:
+				errsHist["31+"]++
+			}
+		}
+		if slot < 1 || slot > 4 {
+			return
+		}
+		sfs := tetra.TCHSpeechFrames(frame)
+		if len(sfs) == 0 {
+			return
+		}
+		s := &slots[slot]
+		tSec := float64(dibitsFed) / dibitRate
+		if s.crcBursts == 0 {
+			s.firstT = tSec
+		}
+		s.lastT = tSec
+		s.crcBursts++
+		s.speechFrames = append(s.speechFrames, sfs...)
+	})
+
+	rx := tetrarx.New(tetrarx.Options{
+		SampleRateHz: outRate,
+		DibitSink: func(d []uint8, base int) {
+			dibitsFed = base + len(d)
+			extractor.Process(d, base)
+		},
+		ClockMode:           tetrarx.ClockGardner,
+		GardnerGain:         0.005,
+		EnableAFC:           true,
+		EnableChannelFilter: true,
+	})
+
+	const chunk = 65536
+	var scratch []complex64
+	for i := 0; i < len(iq); i += chunk {
+		e := i + chunk
+		if e > len(iq) {
+			e = len(iq)
+		}
+		scratch = ddc.Process(scratch[:0], iq[i:e])
+		rx.Process(scratch)
+	}
+
+	t.Logf("in=%.0fHz out=%.0fHz samples=%d dur=%.1fs", inRate, outRate, len(iq), float64(len(iq))/inRate)
+	t.Logf("total_bursts=%d anchored=%d errs_hist=%v", totalBursts, anchoredBursts, errsHist)
+	outDir := os.Getenv("GT_TETRA_OUT")
+	for tn := 1; tn <= 4; tn++ {
+		s := slots[tn]
+		if s.crcBursts == 0 {
+			t.Logf("slot %d: no TCH/S speech", tn)
+			continue
+		}
+		// Decode this slot's speech frames to PCM with a fresh ACELP vocoder.
+		voc := acelp.NewVocoder()
+		var pcm []int16
+		for _, sf := range s.speechFrames {
+			out, _ := voc.Decode(sf)
+			pcm = append(pcm, out...)
+		}
+		var peak int16
+		for _, v := range pcm {
+			if v > peak {
+				peak = v
+			} else if -v > peak {
+				peak = -v
+			}
+		}
+		t.Logf("slot %d: crc_bursts=%d speech_frames=%d active=%.1f..%.1fs pcm=%.1fs peak=%d",
+			tn, s.crcBursts, len(s.speechFrames), s.firstT, s.lastT, float64(len(pcm))/8000, peak)
+		if outDir != "" {
+			writeWav8kLocal(outDir+"/slot"+string(rune('0'+tn))+".wav", pcm)
+		}
+	}
+}
+
+func writeWav8kLocal(path string, pcm []int16) {
+	f, err := os.Create(path)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	const rate = 8000
+	dataLen := len(pcm) * 2
+	h := make([]byte, 44)
+	copy(h[0:], "RIFF")
+	binary.LittleEndian.PutUint32(h[4:], uint32(36+dataLen))
+	copy(h[8:], "WAVE")
+	copy(h[12:], "fmt ")
+	binary.LittleEndian.PutUint32(h[16:], 16)
+	binary.LittleEndian.PutUint16(h[20:], 1)
+	binary.LittleEndian.PutUint16(h[22:], 1)
+	binary.LittleEndian.PutUint32(h[24:], rate)
+	binary.LittleEndian.PutUint32(h[28:], rate*2)
+	binary.LittleEndian.PutUint16(h[32:], 2)
+	binary.LittleEndian.PutUint16(h[34:], 16)
+	copy(h[36:], "data")
+	binary.LittleEndian.PutUint32(h[40:], uint32(dataLen))
+	f.Write(h)
+	buf := make([]byte, dataLen)
+	for i, s := range pcm {
+		binary.LittleEndian.PutUint16(buf[i*2:], uint16(s))
+	}
+	f.Write(buf)
+}

--- a/cmd/gophertrunk/tetra_multislot_replay_test.go
+++ b/cmd/gophertrunk/tetra_multislot_replay_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/binary"
 	"os"
+	"sort"
 	"strconv"
 	"testing"
 
@@ -61,6 +62,7 @@ func TestTETRAMultiSlotReplay(t *testing.T) {
 		speechFrames  [][]byte
 		crcBursts     int
 		firstT, lastT float64
+		activeSec     map[int]int
 	}
 	var slots [5]slotAcc // index 1..4
 	var dibitsFed int
@@ -100,6 +102,10 @@ func TestTETRAMultiSlotReplay(t *testing.T) {
 		s.lastT = tSec
 		s.crcBursts++
 		s.speechFrames = append(s.speechFrames, sfs...)
+		if s.activeSec == nil {
+			s.activeSec = map[int]int{}
+		}
+		s.activeSec[int(tSec)]++
 	})
 
 	rx := tetrarx.New(tetrarx.Options{
@@ -149,8 +155,15 @@ func TestTETRAMultiSlotReplay(t *testing.T) {
 				peak = -v
 			}
 		}
-		t.Logf("slot %d: crc_bursts=%d speech_frames=%d active=%.1f..%.1fs pcm=%.1fs peak=%d",
-			tn, s.crcBursts, len(s.speechFrames), s.firstT, s.lastT, float64(len(pcm))/8000, peak)
+		var secs []int
+		for k := range s.activeSec {
+			if s.activeSec[k] >= 2 { // >=2 bursts in the second = real activity, not a lone spurious
+				secs = append(secs, k)
+			}
+		}
+		sort.Ints(secs)
+		t.Logf("slot %d: crc_bursts=%d speech_frames=%d pcm=%.1fs peak=%d active_secs(>=2)=%v",
+			tn, s.crcBursts, len(s.speechFrames), float64(len(pcm))/8000, peak, secs)
 		if outDir != "" {
 			writeWav8kLocal(outDir+"/slot"+string(rune('0'+tn))+".wav", pcm)
 		}

--- a/internal/radio/tetra/tch.go
+++ b/internal/radio/tetra/tch.go
@@ -24,24 +24,19 @@ const (
 )
 
 // crcTCHClass2 computes the 8 CRC bits protecting the 60 class-2 bits
-// (§5.5.1): 7 parity bits from G(X)=1+X³+X⁷, then an 8th overall even-parity
-// bit over the class-2 bits plus the 7 parity bits. class2 is 60 bit-per-byte.
+// (EN 300 395-2 §5.5.1). Each CRC bit is the even parity (XOR) of the class-2
+// bits at the ranks in tchCRCTaps — the ETSI reference's fixed parity-check
+// matrix. class2 is 60 bit-per-byte. This must match the on-air CRC exactly:
+// any deviation makes every received TCH/S burst fail the check and be dropped.
 func crcTCHClass2(class2 []byte) []byte {
-	var reg [7]byte // reg[k] holds the x^k coefficient
-	for _, b := range class2 {
-		fb := (b & 1) ^ reg[6]
-		reg = [7]byte{fb, reg[0], reg[1], reg[2] ^ fb, reg[3], reg[4], reg[5]}
-	}
 	out := make([]byte, tchCRCBits)
-	var parity byte
-	for k := 0; k < 7; k++ {
-		out[k] = reg[k]
-		parity ^= reg[k]
+	for k := range tchCRCTaps {
+		var parity byte
+		for _, rank := range tchCRCTaps[k] {
+			parity ^= class2[rank-1] & 1 // ranks are 1-based
+		}
+		out[k] = parity
 	}
-	for _, b := range class2 {
-		parity ^= b & 1
-	}
-	out[7] = parity
 	return out
 }
 

--- a/internal/radio/tetra/tch_tables.go
+++ b/internal/radio/tetra/tch_tables.go
@@ -57,6 +57,22 @@ const (
 	tchClass0Bits = 102 // 2 frames x 51
 	tchClass1Bits = 112 // 2 frames x 56
 	tchClass2Bits = 60  // 2 frames x 30
-	tchCRCBits    = 8   // 7 CRC (G=1+X^3+X^7) + 1 overall parity
+	tchCRCBits    = 8   // 8-bit CRC over the class-2 bits (ETSI EN 300 395-2 §5.5)
 	tchTailBits   = 4   // convolutional flush
 )
+
+// tchCRCTaps defines the TETRA TCH/S 8-bit CRC (EN 300 395-2 §5.5.1): CRC bit k
+// is the XOR (even parity) of the class-2 bits at these 1-based ranks. Verbatim
+// from the ETSI reference codec's TAB_CRC1..8 (the CRC is a fixed parity-check
+// matrix, NOT a cyclic G(X) LFSR — an earlier G(X)=1+X³+X⁷ approximation did not
+// match on-air frames, so every real TCH/S burst failed the CRC and was dropped).
+var tchCRCTaps = [tchCRCBits][]uint8{
+	{1, 5, 8, 9, 13, 15, 16, 17, 19, 21, 22, 24, 25, 31, 32, 35, 36, 38, 40, 43, 44, 45, 48, 49, 50, 51, 53, 54, 56},
+	{2, 6, 9, 10, 14, 16, 17, 18, 20, 22, 23, 25, 26, 32, 33, 36, 37, 39, 41, 44, 45, 46, 49, 50, 51, 52, 54, 55, 57},
+	{3, 7, 10, 11, 15, 17, 18, 19, 21, 23, 24, 26, 27, 33, 34, 37, 38, 40, 42, 45, 46, 47, 50, 51, 52, 53, 55, 56, 58},
+	{1, 4, 5, 9, 11, 12, 13, 15, 17, 18, 20, 21, 27, 28, 31, 32, 34, 36, 39, 40, 41, 44, 45, 46, 47, 49, 50, 52, 57, 59},
+	{2, 5, 6, 10, 12, 13, 14, 16, 18, 19, 21, 22, 28, 29, 32, 33, 35, 37, 40, 41, 42, 45, 46, 47, 48, 50, 51, 53, 58, 60},
+	{3, 6, 7, 11, 13, 14, 15, 17, 19, 20, 22, 23, 29, 30, 33, 34, 36, 38, 41, 42, 43, 46, 47, 48, 49, 51, 52, 54, 59},
+	{4, 7, 8, 12, 14, 15, 16, 18, 20, 21, 23, 24, 30, 31, 34, 35, 37, 39, 42, 43, 44, 47, 48, 49, 50, 52, 53, 55, 60},
+	{1, 2, 3, 4, 8, 13, 14, 16, 19, 20, 22, 23, 25, 26, 27, 28, 29, 30, 32, 33, 34, 36, 37, 40, 41, 42, 44, 48, 50, 53, 56, 57, 58, 59, 60},
+}

--- a/internal/radio/tetra/tch_test.go
+++ b/internal/radio/tetra/tch_test.go
@@ -77,6 +77,34 @@ func bitsEqual(x, y []byte) bool {
 	return true
 }
 
+// TestTCHClass2CRCMatchesETSI pins the class-2 CRC to the ETSI EN 300 395-2
+// reference (its TAB_CRC parity matrix). The two vectors' expected outputs were
+// produced by the reference codec's Build_Crc; an earlier G(X)=1+X³+X⁷ LFSR
+// approximation produced different bits, so every real on-air TCH/S burst failed
+// the CRC and was dropped (no decoded voice). This guards against regressing to
+// any CRC that disagrees with real air.
+func TestTCHClass2CRCMatchesETSI(t *testing.T) {
+	cases := []struct {
+		class2 []byte
+		want   []byte
+	}{
+		{
+			class2: []byte{1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 1, 0, 1},
+			want:   []byte{1, 0, 1, 1, 0, 0, 1, 1},
+		},
+		{
+			class2: []byte{1, 1, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 0, 1, 0, 1, 1, 0, 0, 1, 0, 1, 0, 0, 1, 1, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 1, 0, 1, 1, 0},
+			want:   []byte{1, 1, 1, 0, 0, 1, 1, 1},
+		},
+	}
+	for i, c := range cases {
+		got := crcTCHClass2(c.class2)
+		if !bitsEqual(got, c.want) {
+			t.Errorf("case %d: crcTCHClass2 = %v, want %v (ETSI reference)", i, got, c.want)
+		}
+	}
+}
+
 // TestTCHSpeechFramesGate checks the CRC gate: a well-formed traffic frame
 // yields the two 137-bit speech frames packed to 18 bytes each, matching the
 // input; a random (non-TCH/S) frame is rejected (nil) by the class-2 CRC.

--- a/internal/radio/tetra/traffic.go
+++ b/internal/radio/tetra/traffic.go
@@ -212,16 +212,26 @@ func (te *TrafficExtractor) emit(L int) {
 	te.onBurst(framing.PackBitsMSB(bits), te.slotOf(L))
 }
 
+// ndbSBSlotShift aligns the synchronisation-burst anchor to the NDB slot grid.
+// The SB is transmitted in TN1, but its synchronisation training sequence sits
+// late in the SB burst (after the frequency-correction + BSCH preamble), so the
+// detected STS leading dibit lands one NDB slot before the TN1 traffic burst's
+// normal-training-sequence position. Adding 3 (= −1 mod 4) makes a burst one
+// slot after the anchor read as TN1, matching the control channel's granted
+// timeslots — verified against the reporter's real same-carrier capture
+// (grant ts1↔decoded slot, ts2↔decoded slot line up once shifted).
+const ndbSBSlotShift = 3
+
 // slotOf returns the TDMA timeslot (1..4) of a burst whose training sequence
-// leads at absolute dibit L, or 0 when no synchronisation burst has anchored
-// the slot grid yet. The SB anchors TN1; each further slot is 255 dibits on.
-// Rounding to the nearest slot absorbs the small intra-slot offset between the
-// normal and synchronisation training sequences.
+// leads at absolute dibit L, or 0 when no synchronisation burst has anchored the
+// slot grid yet. The SB anchors the grid (see ndbSBSlotShift); each further slot
+// is 255 dibits on, and rounding to the nearest slot absorbs the small intra-slot
+// offset between the normal and synchronisation training sequences.
 func (te *TrafficExtractor) slotOf(L int) uint8 {
 	if !te.haveAnchor {
 		return 0
 	}
-	si := int(math.Round(float64(L-te.sbAnchor)/float64(ndbSlotDibits))) % 4
+	si := (int(math.Round(float64(L-te.sbAnchor)/float64(ndbSlotDibits))) + ndbSBSlotShift) % 4
 	if si < 0 {
 		si += 4
 	}

--- a/internal/radio/tetra/traffic.go
+++ b/internal/radio/tetra/traffic.go
@@ -1,6 +1,10 @@
 package tetra
 
-import "github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+import (
+	"math"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
 
 // Traffic-channel burst extraction for the voice-follow path.
 //
@@ -31,11 +35,22 @@ import "github.com/MattCheramie/GopherTrunk/internal/radio/framing"
 // control channel's BSCH) before TCH/S FEC.
 //
 // Slot demultiplexing: the extractor emits a frame for every NCDB it sees
-// on the carrier — all four TDMA timeslots, not just the granted one —
-// because absolute slot alignment needs frame-number tracking the tap does
-// not yet have. That is an honest first-pass limitation; the granted
-// Timeslot is carried on the grant for a future per-slot filter.
+// on the carrier — all four TDMA timeslots — and tags each with its TDMA
+// timeslot (TN, 1..4) so a per-slot voice chain can keep only its granted
+// slot and up to four calls on one carrier decode independently. The slot is
+// numbered from the synchronisation burst (SB), which the same detector
+// correlates: the SB's synchronisation training sequence is transmitted in
+// slot 1 (TN1) of frame 18, so it anchors the 255-dibit slot grid. A burst
+// leading at dibit L is then in slot ((round((L - sbAnchor)/255)) mod 4) + 1;
+// the ~15-dibit intra-slot offset between the normal and synchronisation
+// training sequences is far below the half-slot (127-dibit) rounding margin,
+// so it need not be modelled exactly. Until an SB is seen the slot is reported
+// as 0 (unknown) and the consumer falls back to CRC-gated single-call
+// behaviour. On a traffic-only carrier with no SB the slot stays 0.
 const (
+	// ndbSlotDibits is the dibit span of one TDMA timeslot (510 bits): four
+	// slots make a 1020-dibit TDMA frame. The slot grid the SB anchor pins.
+	ndbSlotDibits = 255
 	// ndbBKN1Start / ndbBKN2Start are the leading dibit of each data block
 	// relative to the training-sequence leading dibit L.
 	ndbBKN1Start = -115
@@ -65,20 +80,30 @@ const TrafficFrameBytes = (2 * ndbBlockDibits * 2) / 8 // 54
 // Not safe for concurrent use; construct one per followed call.
 type TrafficExtractor struct {
 	dets       []*SyncDetector // NTS1 + NTS2, each under all four constellation rotations
+	stsDets    []*SyncDetector // synchronisation training sequence, all four rotations (slot-1 anchor)
 	scratch    []int
+	stsScratch []int
 	buf        []uint8
 	bufBase    int
 	pending    []int // training-sequence leading indices awaiting look-ahead
 	colourCode uint32
-	onBurst    func(frame []byte)
+	onBurst    func(frame []byte, slot uint8)
+
+	// sbAnchor is the absolute dibit index of the most recent SB
+	// synchronisation-training-sequence leading dibit (TN1), pinning the
+	// 255-dibit slot grid; haveAnchor is false until the first SB is seen.
+	sbAnchor   int
+	haveAnchor bool
 }
 
 // NewTrafficExtractor returns an extractor that calls onBurst with each
-// recovered 54-byte traffic frame. When colourCode is non-zero the frame is
-// descrambled with the cell's extended colour code (learned from the control
-// channel's BSCH) before onBurst, so the sidecar holds descrambled type-5 —
-// the input the TCH/S channel decoder expects. onBurst must not retain the slice.
-func NewTrafficExtractor(colourCode uint32, onBurst func(frame []byte)) *TrafficExtractor {
+// recovered 54-byte traffic frame and its TDMA timeslot (1..4, or 0 when the
+// slot grid is not yet anchored to a synchronisation burst). When colourCode is
+// non-zero the frame is descrambled with the cell's extended colour code
+// (learned from the control channel's BSCH) before onBurst, so the sidecar
+// holds descrambled type-5 — the input the TCH/S channel decoder expects.
+// onBurst must not retain the slice.
+func NewTrafficExtractor(colourCode uint32, onBurst func(frame []byte, slot uint8)) *TrafficExtractor {
 	te := &TrafficExtractor{colourCode: colourCode, onBurst: onBurst}
 	// π/4-DQPSK leaves a constant 0..3 dibit rotation (residual CFO), so
 	// correlate the training sequence under all four rotations of the
@@ -87,6 +112,13 @@ func NewTrafficExtractor(colourCode uint32, onBurst func(frame []byte)) *Traffic
 		for r := uint8(0); r < 4; r++ {
 			te.dets = append(te.dets, NewSyncDetector(rotateDibits(base, r), 2))
 		}
+	}
+	// Synchronisation-training-sequence detectors (all four rotations) pin
+	// the slot grid: the SB is transmitted in TN1, so its STS leading dibit
+	// anchors slot 1. Threshold 3 matches the control channel's processSB.
+	sts := SyncTrainingDibits()
+	for r := uint8(0); r < 4; r++ {
+		te.stsDets = append(te.stsDets, NewSyncDetector(rotateDibits(sts, r), 3))
 	}
 	return te
 }
@@ -99,6 +131,17 @@ func (te *TrafficExtractor) Process(dibits []uint8, baseIdx int) {
 		te.bufBase = baseIdx
 	}
 	te.buf = append(te.buf, dibits...)
+
+	// Anchor the slot grid on the synchronisation burst. The SB's STS is
+	// transmitted in TN1, so its leading dibit pins slot 1; refresh on every
+	// SB (once per multiframe) so the anchor tracks any slow clock drift.
+	for _, det := range te.stsDets {
+		hits, _ := det.Process(te.stsScratch[:0], dibits, baseIdx)
+		for _, trailing := range hits {
+			te.sbAnchor = trailing - (stsDibits - 1)
+			te.haveAnchor = true
+		}
+	}
 
 	ntsLen := len(NormalSyncDibits()) // 11
 	for _, det := range te.dets {
@@ -166,5 +209,21 @@ func (te *TrafficExtractor) emit(L int) {
 	if te.colourCode != 0 {
 		bits = framing.DescrambleTetra(bits, te.colourCode)
 	}
-	te.onBurst(framing.PackBitsMSB(bits))
+	te.onBurst(framing.PackBitsMSB(bits), te.slotOf(L))
+}
+
+// slotOf returns the TDMA timeslot (1..4) of a burst whose training sequence
+// leads at absolute dibit L, or 0 when no synchronisation burst has anchored
+// the slot grid yet. The SB anchors TN1; each further slot is 255 dibits on.
+// Rounding to the nearest slot absorbs the small intra-slot offset between the
+// normal and synchronisation training sequences.
+func (te *TrafficExtractor) slotOf(L int) uint8 {
+	if !te.haveAnchor {
+		return 0
+	}
+	si := int(math.Round(float64(L-te.sbAnchor)/float64(ndbSlotDibits))) % 4
+	if si < 0 {
+		si += 4
+	}
+	return uint8(si) + 1
 }

--- a/internal/radio/tetra/traffic_test.go
+++ b/internal/radio/tetra/traffic_test.go
@@ -39,7 +39,7 @@ func TestTrafficExtractorSingleBurst(t *testing.T) {
 	buildNCDB(stream, L, bkn1, bkn2)
 
 	var frames [][]byte
-	te := NewTrafficExtractor(0, func(f []byte) {
+	te := NewTrafficExtractor(0, func(f []byte, _ uint8) {
 		frames = append(frames, append([]byte(nil), f...))
 	})
 	te.Process(stream, 0)
@@ -67,7 +67,7 @@ func TestTrafficExtractorDescrambles(t *testing.T) {
 
 	const colour = 262144876 // the reporter's cell (467.913 MHz)
 	var got []byte
-	te := NewTrafficExtractor(colour, func(f []byte) { got = append([]byte(nil), f...) })
+	te := NewTrafficExtractor(colour, func(f []byte, _ uint8) { got = append([]byte(nil), f...) })
 	te.Process(stream, 0)
 
 	rawBits := TetraDibitsToBits(append(append([]uint8{}, bkn1...), bkn2...))
@@ -88,7 +88,7 @@ func TestTrafficExtractorChunkedAcrossCalls(t *testing.T) {
 	buildNCDB(stream, L, bkn1, bkn2)
 
 	var frames [][]byte
-	te := NewTrafficExtractor(0, func(f []byte) {
+	te := NewTrafficExtractor(0, func(f []byte, _ uint8) {
 		frames = append(frames, append([]byte(nil), f...))
 	})
 	// Feed in small chunks so the training-sequence match, BKN1 look-back
@@ -118,7 +118,7 @@ func TestTrafficExtractorMultipleSlots(t *testing.T) {
 	buildNCDB(stream, 200+255, b1b, b2b)
 
 	var frames [][]byte
-	te := NewTrafficExtractor(0, func(f []byte) {
+	te := NewTrafficExtractor(0, func(f []byte, _ uint8) {
 		frames = append(frames, append([]byte(nil), f...))
 	})
 	te.Process(stream, 0)
@@ -130,6 +130,64 @@ func TestTrafficExtractorMultipleSlots(t *testing.T) {
 	}
 }
 
+// TestTrafficExtractorSlotTagging pins the SB-anchored slot numbering: a
+// synchronisation burst (STS) anchors slot 1 (TN1), and each subsequent NCDB is
+// tagged with its TDMA timeslot by rounding its 255-dibit offset from the
+// anchor. The small (+30-dibit) offsets prove the rounding absorbs the intra-
+// slot NTS↔STS displacement (< half a slot).
+func TestTrafficExtractorSlotTagging(t *testing.T) {
+	const sbL = 200
+	stream := make([]uint8, 1500)
+	for i := range stream {
+		stream[i] = uint8((i*7 + 1) % 4) // filler
+	}
+	// Synchronisation burst: STS leading at sbL anchors slot 1.
+	copy(stream[sbL:], SyncTrainingDibits())
+
+	// NCDBs at slots 2, 3, 4, then slot 1 of the next frame — each offset +30
+	// dibits from the exact grid to exercise the rounding tolerance.
+	type ndb struct {
+		L        int
+		wantSlot uint8
+	}
+	ndbs := []ndb{
+		{sbL + 1*255 + 30, 2},
+		{sbL + 2*255 + 30, 3},
+		{sbL + 3*255 + 30, 4},
+		{sbL + 4*255 + 30, 1}, // wraps mod 4 back to TN1
+	}
+	for i, n := range ndbs {
+		buildNCDB(stream, n.L, rampDibits(ndbBlockDibits, uint8(i)), rampDibits(ndbBlockDibits, uint8(i+1)))
+	}
+
+	var slots []uint8
+	te := NewTrafficExtractor(0, func(_ []byte, slot uint8) { slots = append(slots, slot) })
+	te.Process(stream, 0)
+
+	if len(slots) != len(ndbs) {
+		t.Fatalf("emitted %d frames, want %d (slots=%v)", len(slots), len(ndbs), slots)
+	}
+	for i, n := range ndbs {
+		if slots[i] != n.wantSlot {
+			t.Errorf("burst %d (L=%d): slot=%d, want %d", i, n.L, slots[i], n.wantSlot)
+		}
+	}
+}
+
+// TestTrafficExtractorSlotUnanchored checks that without a synchronisation burst
+// the slot is reported as 0 (unknown) — the single-call / traffic-only-carrier
+// fallback.
+func TestTrafficExtractorSlotUnanchored(t *testing.T) {
+	stream := make([]uint8, 600)
+	buildNCDB(stream, 300, rampDibits(ndbBlockDibits, 0), rampDibits(ndbBlockDibits, 1))
+	var slots []uint8
+	te := NewTrafficExtractor(0, func(_ []byte, slot uint8) { slots = append(slots, slot) })
+	te.Process(stream, 0)
+	if len(slots) != 1 || slots[0] != 0 {
+		t.Fatalf("unanchored slots=%v, want [0]", slots)
+	}
+}
+
 func TestTrafficExtractorNoFalseEmitOnNoise(t *testing.T) {
 	// A stream with no training sequence must emit nothing.
 	stream := make([]uint8, 2000)
@@ -137,7 +195,7 @@ func TestTrafficExtractorNoFalseEmitOnNoise(t *testing.T) {
 		stream[i] = uint8((i*7 + 1) % 4) // deterministic non-sync filler
 	}
 	n := 0
-	te := NewTrafficExtractor(0, func(f []byte) { n++ })
+	te := NewTrafficExtractor(0, func(f []byte, _ uint8) { n++ })
 	te.Process(stream, 0)
 	// A rare chance correlation within tolerance is possible; assert it does
 	// not spuriously fire on structured filler.

--- a/internal/radio/tetra/traffic_test.go
+++ b/internal/radio/tetra/traffic_test.go
@@ -150,11 +150,13 @@ func TestTrafficExtractorSlotTagging(t *testing.T) {
 		L        int
 		wantSlot uint8
 	}
+	// The SB's STS anchors the grid one NDB-slot before its frame's TN1 traffic
+	// (ndbSBSlotShift), so the first NDB after the SB is TN1, then 2, 3, 4.
 	ndbs := []ndb{
-		{sbL + 1*255 + 30, 2},
-		{sbL + 2*255 + 30, 3},
-		{sbL + 3*255 + 30, 4},
-		{sbL + 4*255 + 30, 1}, // wraps mod 4 back to TN1
+		{sbL + 1*255 + 30, 1},
+		{sbL + 2*255 + 30, 2},
+		{sbL + 3*255 + 30, 3},
+		{sbL + 4*255 + 30, 4},
 	}
 	for i, n := range ndbs {
 		buildNCDB(stream, n.L, rampDibits(ndbBlockDibits, uint8(i)), rampDibits(ndbBlockDibits, uint8(i+1)))

--- a/internal/voice/composer/tetra_voice.go
+++ b/internal/voice/composer/tetra_voice.go
@@ -52,12 +52,13 @@ func newTETRAVoiceFrontEnd(iqHz float64, bw uint32) *decimatingFIR {
 // mirrors the DMR/P25 shape (post-FEC frames in `.raw` + decoded WAV).
 //
 // The extractor emits a burst for every timeslot on the carrier (all four TDMA
-// slots), not just the granted one. Slot isolation is done by the TCH/S CRC:
-// only the granted call's TCH/S bursts pass, so the other slots' signalling
-// bursts are dropped (tetra.TCHSpeechFrames). This cleanly separates a single
-// active call; concurrent TCH/S calls on the same carrier would still mix and
-// need TDMA frame-number demux (a follow-up). groupID/timeslot are threaded
-// through for logging and that future demux. Encrypted calls (TEA1-4) fail the
+// slots), each tagged with its timeslot (anchored to the synchronisation burst,
+// TN1). This chain keeps only bursts on its granted timeslot and drops the rest
+// (onTETRATrafficBurst), so up to four concurrent calls on one carrier — one per
+// slot, each on its own same-carrier tap — decode into four independent
+// recordings instead of mixing. Until the slot grid anchors (or on a traffic
+// carrier with no synchronisation burst) the slot is unknown and the chain falls
+// back to the TCH/S-CRC single-call isolation. Encrypted calls (TEA1-4) fail the
 // CRC and produce no decoded audio (their raw bursts still exist upstream).
 func (c *Composer) runTETRAVoiceChain(ctx context.Context, serial string, iqCh <-chan []complex64, iqHz float64, groupID uint32, timeslot uint8, colourExt uint32, done chan<- struct{}) {
 	defer close(done)
@@ -73,9 +74,9 @@ func (c *Composer) runTETRAVoiceChain(ctx context.Context, serial string, iqCh <
 	symbolHz := fe.OutRateHz()
 
 	rs, _ := c.sink.(rawFrameSink)
-	var bursts, speech atomic.Uint64
-	extractor := tetra.NewTrafficExtractor(colourExt, func(frame []byte) {
-		c.onTETRATrafficBurst(bt, rs, serial, frame, &bursts, &speech)
+	var bursts, speech, offSlot atomic.Uint64
+	extractor := tetra.NewTrafficExtractor(colourExt, func(frame []byte, slot uint8) {
+		c.onTETRATrafficBurst(bt, rs, serial, frame, slot, timeslot, &bursts, &speech, &offSlot)
 	})
 
 	rx := tetrarx.New(tetrarx.Options{
@@ -93,7 +94,8 @@ func (c *Composer) runTETRAVoiceChain(ctx context.Context, serial string, iqCh <
 
 	defer func() {
 		c.log.Info("composer: tetra voice follow ended",
-			"serial", serial, "bursts", bursts.Load(), "speech_frames", speech.Load())
+			"serial", serial, "bursts", bursts.Load(), "speech_frames", speech.Load(),
+			"other_slot_bursts", offSlot.Load())
 	}()
 
 	touchTicker := time.NewTicker(c.touchEvery)
@@ -125,14 +127,30 @@ func (c *Composer) runTETRAVoiceChain(ctx context.Context, serial string, iqCh <
 // never elapsed and the (single, same-carrier) voice device was held forever —
 // every later grant was then dropped with "no voice device available for grant".
 //
-// The class-2 CRC gate (tetra.TCHSpeechFrames) already isolates the granted
-// call's speech: a non-TCH/S burst (signalling on another timeslot, an encrypted
-// call, or a badly corrupted slot) returns no frames. Gating onVoice on that
-// same result makes TETRA teardown behave like every other protocol — the call
-// ends hangtime after its last decoded speech frame (or via the no-voice
-// startup timeout when a grant never decodes any speech).
-func (c *Composer) onTETRATrafficBurst(bt *boundaryTracker, rs rawFrameSink, serial string, frame []byte, bursts, speech *atomic.Uint64) {
+// Slot demultiplexing: the extractor tags each burst with its TDMA timeslot
+// (slot, 1..4; 0 = not yet anchored to a synchronisation burst). When the slot
+// is known and does NOT match this chain's granted timeslot, the burst belongs
+// to another call sharing the carrier and is dropped here — this is what lets up
+// to four concurrent calls on one carrier decode into four independent
+// recordings. Until the grid anchors (slot 0), the chain falls back to the
+// CRC-gated single-call behaviour (a non-same-carrier traffic tap has no SB, so
+// slot stays 0 and every chain behaves as before).
+//
+// The class-2 CRC gate (tetra.TCHSpeechFrames) then isolates the granted call's
+// speech: a non-TCH/S burst (signalling on another timeslot, an encrypted call,
+// or a badly corrupted slot) returns no frames. Gating onVoice on that result
+// makes TETRA teardown behave like every other protocol — the call ends hangtime
+// after its last decoded speech frame (or via the no-voice startup timeout when
+// a grant never decodes any speech).
+func (c *Composer) onTETRATrafficBurst(bt *boundaryTracker, rs rawFrameSink, serial string, frame []byte, slot, grantSlot uint8, bursts, speech, offSlot *atomic.Uint64) {
 	bursts.Add(1)
+	// Drop bursts from another timeslot once the slot grid is anchored and the
+	// grant names a slot. slot==0 (unanchored) or grantSlot==0 (unknown) falls
+	// through to the CRC-gated single-call path.
+	if slot != 0 && grantSlot != 0 && slot != grantSlot {
+		offSlot.Add(1)
+		return
+	}
 	// TCH/S-decode the burst. Only bursts whose class-2 CRC verifies are TCH/S
 	// speech for the granted call; everything else yields no frames.
 	frames := tetra.TCHSpeechFrames(frame)

--- a/internal/voice/composer/tetra_voice_test.go
+++ b/internal/voice/composer/tetra_voice_test.go
@@ -134,18 +134,19 @@ func TestTETRATrafficBurstLivenessGatedByCRC(t *testing.T) {
 	c, _, _ := mkBoundaryComposer(t, false, 50*time.Millisecond)
 	bt := c.newBoundaryTracker("VOICE-1", 0, nil)
 	rs := &recordingSink{}
-	var bursts, speech atomic.Uint64
+	var bursts, speech, offSlot atomic.Uint64
 
 	// Case A: a deterministic non-TCH/S 54-byte burst. Guard that the CRC gate
 	// rejects it (it does for this fixed vector), then confirm it leaves the
-	// call-liveness state completely untouched.
+	// call-liveness state completely untouched. slot 0 = unanchored (the
+	// single-call fallback), grantSlot 0 = no per-slot filter.
 	junk := make([]byte, tetra.TrafficFrameBytes)
 	rng := rand.New(rand.NewSource(42))
 	rng.Read(junk)
 	if tetra.TCHSpeechFrames(junk) != nil {
 		t.Fatalf("test vector precondition: junk frame unexpectedly passed the TCH/S CRC gate")
 	}
-	c.onTETRATrafficBurst(bt, rs, "VOICE-1", junk, &bursts, &speech)
+	c.onTETRATrafficBurst(bt, rs, "VOICE-1", junk, 0, 0, &bursts, &speech, &offSlot)
 	if bt.sawVoice.Load() {
 		t.Error("non-speech burst set sawVoice — liveness not gated on CRC-valid speech")
 	}
@@ -165,7 +166,7 @@ func TestTETRATrafficBurstLivenessGatedByCRC(t *testing.T) {
 	// Case B: a CRC-valid TCH/S burst carrying two 137-bit speech frames. It must
 	// mark voice activity and emit both speech frames to the recorder.
 	frame := tetra.EncodeTCHS(make([]byte, 137), make([]byte, 137))
-	c.onTETRATrafficBurst(bt, rs, "VOICE-1", frame, &bursts, &speech)
+	c.onTETRATrafficBurst(bt, rs, "VOICE-1", frame, 0, 0, &bursts, &speech, &offSlot)
 	if !bt.sawVoice.Load() {
 		t.Error("CRC-valid TCH/S burst did not set sawVoice")
 	}
@@ -180,5 +181,52 @@ func TestTETRATrafficBurstLivenessGatedByCRC(t *testing.T) {
 	}
 	if got := bursts.Load(); got != 2 {
 		t.Errorf("bursts = %d after two calls, want 2", got)
+	}
+}
+
+// TestTETRATrafficBurstSlotFilter is the regression for concurrent same-carrier
+// calls: once the slot grid is anchored, a burst whose timeslot differs from the
+// chain's granted timeslot must be dropped (counted as off-slot) and never
+// decoded — even if it is a CRC-valid TCH/S frame for the OTHER call. A burst on
+// the granted slot, and any burst while the grid is unanchored (slot 0), must
+// still be processed.
+func TestTETRATrafficBurstSlotFilter(t *testing.T) {
+	c, _, _ := mkBoundaryComposer(t, false, 50*time.Millisecond)
+	bt := c.newBoundaryTracker("VOICE-2", 0, nil)
+	rs := &recordingSink{}
+	var bursts, speech, offSlot atomic.Uint64
+
+	// A CRC-valid TCH/S frame (belongs to whichever slot it arrives on).
+	frame := tetra.EncodeTCHS(make([]byte, 137), make([]byte, 137))
+	const grantSlot uint8 = 2
+
+	// Foreign slot (3 != granted 2), anchored: dropped as off-slot, no decode.
+	c.onTETRATrafficBurst(bt, rs, "VOICE-2", frame, 3, grantSlot, &bursts, &speech, &offSlot)
+	if got := offSlot.Load(); got != 1 {
+		t.Errorf("foreign-slot burst offSlot = %d, want 1", got)
+	}
+	if n := len(rs.rawFrames("VOICE-2")); n != 0 {
+		t.Errorf("foreign-slot burst wrote %d frames, want 0 (must not decode another call's slot)", n)
+	}
+	if bt.sawVoice.Load() {
+		t.Error("foreign-slot burst set sawVoice — a concurrent call would keep this call alive")
+	}
+
+	// Granted slot (2 == granted 2): decoded and written.
+	c.onTETRATrafficBurst(bt, rs, "VOICE-2", frame, grantSlot, grantSlot, &bursts, &speech, &offSlot)
+	if n := len(rs.rawFrames("VOICE-2")); n != 2 {
+		t.Errorf("granted-slot burst wrote %d frames, want 2", n)
+	}
+	if !bt.sawVoice.Load() {
+		t.Error("granted-slot burst did not mark voice activity")
+	}
+
+	// Unanchored (slot 0): single-call fallback still processes it.
+	c.onTETRATrafficBurst(bt, rs, "VOICE-2", frame, 0, grantSlot, &bursts, &speech, &offSlot)
+	if n := len(rs.rawFrames("VOICE-2")); n != 4 {
+		t.Errorf("unanchored burst wrote total %d frames, want 4", n)
+	}
+	if got := offSlot.Load(); got != 1 {
+		t.Errorf("offSlot = %d after one foreign + one granted + one unanchored, want 1", got)
 	}
 }


### PR DESCRIPTION
## Summary

TETRA has 4 TDMA slots per carrier, so up to 4 calls can run at once on one frequency — but GT had a single `cc:same-carrier` voice tap, so only one bound (others were dropped with `no voice device available for grant`), and traffic bursts weren't tagged by timeslot so concurrent calls would mix. Validating against real captures then exposed a deeper, pre-existing problem: the TCH/S class-2 CRC was computed wrong, so **every real on-air voice burst failed the CRC and was dropped** — TETRA voice never actually decoded on air (recordings held only spurious frames), despite the ACELP vocoder being bit-exact. This PR fixes both, so real TETRA voice decodes for the first time and up to 4 simultaneous same-carrier calls are separated into their own recordings.

## Changes

- **TCH/S class-2 CRC corrected (the unlock).** `tch.go` computed the 8-bit CRC as a `G(X)=1+X³+X⁷` LFSR; the TETRA CRC (EN 300 395-2 §5.5.1) is a fixed parity-check matrix (the ETSI reference's `TAB_CRC1..8`). They disagree, so every received TCH/S burst failed the check. `crcTCHClass2` is reimplemented from the reference tap tables; GT's type-3 frame is now bit-for-bit identical to the ETSI channel coder. A regression test pins two reference-verified CRC vectors.
- **Per-timeslot demux.** The `TrafficExtractor` now correlates the synchronisation training sequence and tags each NCDB with its TDMA timeslot (1..4) — the SB anchors the 255-dibit slot grid, with `ndbSBSlotShift` accounting for the STS's late position in the SB burst so the absolute TN mapping matches the control channel's grants. The voice chain drops bursts off its granted timeslot; slot 0 (unanchored / no-SB traffic carrier) falls back to the prior CRC-gated single-call path.
- **Up to 4 same-carrier taps.** The daemon registers `cc:same-carrier:1..4` over the control decoder's existing 1-to-N IQ fan-out; the engine already keys concurrent calls by `(system, talkgroup, timeslot)`, so four slots bind four taps. Each chain filters by its own grant's timeslot, so tap↔slot assignment is irrelevant.
- **Call teardown / ACELP** (earlier commits on this branch, already covered): calls end on decoded speech rather than raw carrier bursts, and the ACELP vocoder was made bit-exact to the ETSI reference.

## Test plan

- [x] `make vet test` is green locally
- [x] `make integration` is green locally (daemon/composer voice path touched)
- [x] Added or updated tests where appropriate
- [x] Smoke-tested against real captures — described below

- Unit tests: slot-tagging geometry (SB anchor, TN1..TN4, unanchored=0), per-slot filter regression (a foreign-slot CRC-valid burst is dropped and doesn't keep the call alive), and `TestTCHClass2CRCMatchesETSI` pinning two ETSI-reference CRC vectors (the old LFSR produced different bits).
- Real-air validation on the reporter's clean 467.913 MHz same-carrier capture (`cmd/gophertrunk/tetra_multislot_replay_test.go`, skip-guarded by `GT_TETRA_IQ`): control locks with 0.00 decode-errors, 21 grants on ts1/ts2. After the CRC fix, CRC-passing bursts jump **18 → 431** (~15 s + ~9 s of real speech on the two active slots). Decoded slot-1 activity aligns with the ts1 grants and slot-2 with ts2, including a window where two calls decode concurrently into separate recordings.
- The TCH/S decode was validated against the ETSI EN 300 395-2 reference **channel** codec (built from the ETSI C sources); GT's type-3 is now bit-identical. ETSI sources/vectors are copyrighted and are NOT committed.

## Breaking changes

Minor operator-visible change: the same-carrier voice device serial changes from `cc:same-carrier` to `cc:same-carrier:1..4` (this is what distinguishes concurrent calls in the UI/logs). No config/CLI/endpoint changes.

## Docs / CHANGELOG

- [ ] Added a `## [Unreleased]` bullet to `CHANGELOG.md` if this is user-visible
- [ ] Updated `README.md` or `docs/` if operator-facing behaviour changed

n/a for now — happy to add a CHANGELOG entry for "TETRA voice now decodes on-air + up to 4 concurrent same-carrier calls" if you'd like one.

## Linked issues

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmkZyhNfZnLVhxxx7miXPv

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmkZyhNfZnLVhxxx7miXPv)_