### PR TITLE
Event-driven raw-IQ auto-recording, siglab capture timestamps, and TETRA short-recording diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **Event-driven raw-IQ auto-recording (`baseband.auto_record`).** The daemon
+  can now capture a short slice of the control SDR's raw IQ whenever a
+  classified event fires — `on_concurrent_calls: N` (N+ calls active at once),
+  `on_no_voice_device` (a grant arrived but every voice tuner was busy),
+  `on_encrypted`, or `on_emergency` — plus a manual
+  `POST /api/v1/siglab/autorecord/trigger`. Each capture lands in the
+  configured `dir` with a self-describing name
+  (`<system>_<UTC>_<reason>_<freqHz>_<rateHz>hz.<ext>`) and a `.metadata.json`
+  sidecar, so it drops straight into `gophertrunk replay` / siglab. A cooldown
+  and an in-flight cap keep a burst of grants from spawning a capture storm.
+  This is the event-based debugging hook for capturing hard-to-decode moments
+  (concurrent grants, unknown packets) as they happen.
+- **siglab capture start time in the capture list.** Each capture row now shows
+  its recording start time, so otherwise-identical grabs of the same carrier
+  (e.g. three `capture-AIRSPY SN:…` captures) can be told apart at a glance.
 - **Startup warning when paging is configured without storage.** A
   `paging.pocsag` / `paging.flex` / `paging.wideband` subsystem with no
   `storage.path` set decodes fine and consumes live IQ, but decoded pages are
@@ -234,6 +249,17 @@ for tagged releases.
   spawn (issue #915).
 
 ### Changed
+- **Short digital recordings now report their frame yield.** The recorder's
+  `recording shorter than call span` diagnostic gained `frames`, `audio_pct`
+  (the fraction of the call span that decoded to audio), and `vocoder`, so a
+  sparse-decode recording (few TCH/S bursts passing CRC — the TETRA
+  short-recording symptom) is diagnosable from one log line instead of by
+  diffing the WAV against the call record.
+- **Same-carrier voice-tap IQ drops are no longer silent.** When the control
+  decoder's voice tap drops IQ to a lagging voice consumer (still dropping to
+  protect the decode hot path), the dropped chunks are now counted and surfaced
+  as a single warning at call end with the remedy — so starved voice decode
+  (the short/gappy-recording symptom) is visible instead of silent (issue #402).
 - **Live captures stream straight to disk instead of buffering the whole grab in
   RAM.** The Signal-Lab capture path (and the `gophertrunk capture` / daemon
   `--iq-capture` subcommands) previously held the entire capture in memory as

--- a/internal/scanner/ccdecoder/decoder.go
+++ b/internal/scanner/ccdecoder/decoder.go
@@ -502,7 +502,7 @@ func New(opts Options) (*Decoder, error) {
 		metrics:      opts.Metrics,
 		fec:          opts.FEC,
 		autotune:     opts.Autotune,
-		voiceFan:     newVoiceFanout(),
+		voiceFan:     newVoiceFanout(log),
 	}
 	empty := ""
 	d.activeSystem.Store(&empty)

--- a/internal/scanner/ccdecoder/voicetap.go
+++ b/internal/scanner/ccdecoder/voicetap.go
@@ -3,7 +3,9 @@ package ccdecoder
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"sync"
+	"sync/atomic"
 )
 
 // Same-carrier voice tap. A TETRA Single Carrier Base Station keeps voice calls
@@ -20,28 +22,52 @@ import (
 // consumer can never stall the decode hot path.
 type voiceFanout struct {
 	mu   sync.Mutex
-	subs map[int]chan []complex64
+	subs map[int]*voiceSub
 	next int
+	log  *slog.Logger
 }
 
-func newVoiceFanout() *voiceFanout { return &voiceFanout{subs: map[int]chan []complex64{}} }
+// voiceSub is one subscriber's channel plus its dropped-chunk counter. A drop
+// is a gap of missing IQ delivered to the followed call's voice chain, which
+// breaks the receiver's symbol timing / lock — the mechanism behind starved,
+// short/gappy TETRA recordings (issue #402). Counting them turns that silent
+// loss into an actionable log line at call end.
+type voiceSub struct {
+	ch    chan []complex64
+	drops atomic.Uint64
+}
+
+func newVoiceFanout(log *slog.Logger) *voiceFanout {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &voiceFanout{subs: map[int]*voiceSub{}, log: log}
+}
 
 func (f *voiceFanout) subscribe() (<-chan []complex64, func()) {
-	ch := make(chan []complex64, 64)
+	sub := &voiceSub{ch: make(chan []complex64, 64)}
 	f.mu.Lock()
 	id := f.next
 	f.next++
-	f.subs[id] = ch
+	f.subs[id] = sub
 	f.mu.Unlock()
 	var once sync.Once
-	return ch, func() {
+	return sub.ch, func() {
 		once.Do(func() {
 			f.mu.Lock()
-			if c, ok := f.subs[id]; ok {
+			if s, ok := f.subs[id]; ok {
 				delete(f.subs, id)
-				close(c)
+				close(s.ch)
 			}
 			f.mu.Unlock()
+			// After the delete-under-lock no further broadcast can increment
+			// this sub's counter, so the load sees the final total. Surface a
+			// non-zero drop count once at unsubscribe (call end) with the
+			// remedy, mirroring the --iq-capture drop warning.
+			if d := sub.drops.Load(); d > 0 {
+				f.log.Warn("ccdecoder: same-carrier voice tap dropped IQ to a lagging voice consumer — the followed call's decode was starved (expect short/gappy recordings); reduce CPU load or lower sdr.sample_rate (issue #402)",
+					"dropped_chunks", d)
+			}
 		})
 	}
 }
@@ -49,18 +75,21 @@ func (f *voiceFanout) subscribe() (<-chan []complex64, func()) {
 // broadcast copies chunk to every subscriber. The caller's slice is reused
 // across chunks, so each subscriber receives its own copy. A no-op (and no
 // allocation) when nothing is subscribed — the production hot-path default.
+// A full subscriber buffer drops the chunk (protecting the decode path) and
+// bumps that subscriber's drop counter so the loss is not silent.
 func (f *voiceFanout) broadcast(chunk []complex64) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if len(f.subs) == 0 {
 		return
 	}
-	for _, ch := range f.subs {
+	for _, s := range f.subs {
 		cp := make([]complex64, len(chunk))
 		copy(cp, chunk)
 		select {
-		case ch <- cp:
+		case s.ch <- cp:
 		default: // subscriber lagging; drop to protect the decode path
+			s.drops.Add(1)
 		}
 	}
 }

--- a/internal/scanner/ccdecoder/voicetap_test.go
+++ b/internal/scanner/ccdecoder/voicetap_test.go
@@ -1,7 +1,10 @@
 package ccdecoder
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
+	"strings"
 	"testing"
 	"time"
 )
@@ -9,7 +12,7 @@ import (
 // TestVoiceFanoutDeliversCopies verifies subscribers get their own copy of each
 // broadcast chunk and that a broadcast with no subscribers is a no-op.
 func TestVoiceFanoutDeliversCopies(t *testing.T) {
-	f := newVoiceFanout()
+	f := newVoiceFanout(nil)
 	f.broadcast([]complex64{1, 2, 3}) // no subscribers: must not panic/block
 
 	ch, unsub := f.subscribe()
@@ -34,20 +37,55 @@ func TestVoiceFanoutDeliversCopies(t *testing.T) {
 }
 
 // TestVoiceFanoutDropsWhenFull proves a lagging subscriber can't stall the
-// broadcaster (drop-on-full), protecting the decode hot path.
+// broadcaster (drop-on-full), protecting the decode hot path, and that the
+// dropped IQ is counted and surfaced as a warning at unsubscribe (issue #402
+// starvation diagnostic) rather than lost silently.
 func TestVoiceFanoutDropsWhenFull(t *testing.T) {
-	f := newVoiceFanout()
+	var logs bytes.Buffer
+	f := newVoiceFanout(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn})))
 	_, unsub := f.subscribe()
-	defer unsub()
 	for i := 0; i < 1000; i++ {
 		f.broadcast([]complex64{complex(float32(i), 0)}) // never blocks despite full buffer
+	}
+	unsub() // call-end: drops must be reported
+
+	out := logs.String()
+	if !strings.Contains(out, "same-carrier voice tap dropped IQ") {
+		t.Fatalf("expected a dropped-IQ warning at unsubscribe; log was:\n%s", out)
+	}
+	// The 64-chunk buffer soaks the first 64; the rest (≥ 900) are counted drops.
+	if !strings.Contains(out, "dropped_chunks=") {
+		t.Errorf("warning missing dropped_chunks count; log: %s", out)
+	}
+}
+
+// TestVoiceFanoutNoDropWarningWhenDrained verifies a subscriber that keeps up
+// logs nothing at unsubscribe (no false starvation warnings).
+func TestVoiceFanoutNoDropWarningWhenDrained(t *testing.T) {
+	var logs bytes.Buffer
+	f := newVoiceFanout(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	ch, unsub := f.subscribe()
+	done := make(chan struct{})
+	go func() {
+		for range ch { // drain promptly so nothing drops
+		}
+		close(done)
+	}()
+	for i := 0; i < 200; i++ {
+		f.broadcast([]complex64{complex(float32(i), 0)})
+		time.Sleep(time.Millisecond)
+	}
+	unsub()
+	<-done
+	if strings.Contains(logs.String(), "dropped IQ") {
+		t.Fatalf("unexpected drop warning for a keeping-up subscriber:\n%s", logs.String())
 	}
 }
 
 // TestCCVoiceSourceSameCarrierGate checks the tap binds only the CC's current
 // carrier and streams until the context ends.
 func TestCCVoiceSourceSameCarrierGate(t *testing.T) {
-	d := &Decoder{voiceFan: newVoiceFanout(), activeFreqHz: 467_913_000, pipelineRateHz: 144_000}
+	d := &Decoder{voiceFan: newVoiceFanout(nil), activeFreqHz: 467_913_000, pipelineRateHz: 144_000}
 	src := NewCCVoiceSource(func() *Decoder { return d }, "cc:SDR1")
 
 	// A nil decoder (before startup / after teardown) stays inert.


### PR DESCRIPTION
## Summary

Follows up the TETRA "voice-like decoding works, but calls are too short" report. It adds the operator's requested **event-based raw-IQ recording** hook (so hard-to-decode moments can be captured for offline analysis), makes siglab captures **identifiable by start time**, and lands **diagnostics that pinpoint why short recordings happen** — without shipping an unverified DSP fix.

The short-recording symptom itself is **investigated, not blindly patched** (per CONTRIBUTING's no-unverified-fix rule): the recorder faithfully writes every decoded frame, so "too short" means few TCH/S bursts pass CRC on the `cc:same-carrier` tap. Replaying the reporter's `467_913_cs16_bw50_3` capture offline decodes the control channel **cleanly** (locked, 0.076% baud deviation, 21 grants, zero errors) while the live session logged `#402 "decode can't keep up; dropping IQ"` — clean-offline + starved-live points at **real-time IQ starvation on the same-carrier voice tap**, not a steady-state DSP defect. The actual DSP fix (sharing the CC decoder's lock / backpressure) is left for a separate, reproduced-and-verified change; this PR makes that starvation observable and gives us the capture tooling to reproduce it.

## Changes

- **Event-driven raw-IQ auto-recorder (`baseband.auto_record`).** New config section: `enabled`, `dir`, `format` (cs16/f32/u8), `seconds`, `cooldown`, and triggers `on_concurrent_calls: N`, `on_no_voice_device`, `on_encrypted`, `on_emergency`. A new daemon bus subscriber (`cmd/gophertrunk/iqautorecord.go`) tracks concurrency and actuates captures of the control SDR, reusing a shared `captureIQToFile` helper extracted from the `--iq-capture` path. Files are named `<system>_<UTC>_<reason>_<freqHz>_<rateHz>hz.<ext>` with a `.metadata.json` sidecar so they load into `replay`/siglab directly. A cooldown + in-flight cap prevent capture storms.
- **Manual trigger:** `POST /api/v1/siglab/autorecord/trigger` fires a capture on demand (bypasses the cooldown), 503 when auto-record is disabled.
- **Engine signal:** new `events.KindGrantUnserved`, published where the engine logs `no voice device available for grant`, drives the `on_no_voice_device` trigger.
- **siglab capture start time** is now rendered per capture row (the `created_at` field was already plumbed end-to-end, just unshown) so identical-looking captures are distinguishable.
- **Recorder diagnostic** `recording shorter than call span` now reports `frames`, `audio_pct` (frame yield), and `vocoder`.
- **Same-carrier voice-tap IQ drops are counted and reported** at call end instead of being silently discarded (behaviour unchanged — still drops to protect the decode hot path).
- CHANGELOG + `config.example.yaml` + config-builder fieldmeta updated.

## Test plan

- [x] `make vet test` is green locally (full `-race ./...`)
- [x] `make integration` is green locally
- [x] Added or updated tests where appropriate — config validation; auto-recorder trigger classification / cooldown / in-flight cap / manual trigger; the manual API endpoint; the recorder short-span diagnostic (locks `frames`/`audio_pct`/`vocoder`); the voice-tap drop counter + warning; and the siglab `CaptureRow` timestamp (vitest + tsc)
- [ ] Smoke-tested against real hardware — n/a (no SDR in CI). Verified offline against the reporter's `467_913_cs16_bw50_3` cs16 capture via `gophertrunk replay -protocol tetra`

## Breaking changes

None. `baseband.auto_record` is a new, opt-in (`enabled: false` by default) config section; the new API route and event kind are additive.

## Docs / CHANGELOG

- [x] Added `## [Unreleased]` bullets to `CHANGELOG.md`
- [x] Updated `config.example.yaml` with a documented `auto_record` block

## Linked issues

Refs #402 (real-time IQ starvation / drop visibility). No tracked issue for the auto-recorder feature or the TETRA short-recording report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M6mk2A6YUsjDNSZLoDdaAA)_