### PR TITLE
docs(tetra): correct stale voice/vocoder docs now that TETRA voice decodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **TETRA voice now decodes to audible audio, including up to 4 concurrent
+  calls on one carrier.** The TETRA voice path recovers each traffic burst,
+  channel-decodes TCH/S, and renders it with the clean-room ACELP vocoder
+  (`tetra-acelp`), now bit-exact to the ETSI EN 300 395-2 reference. Each burst
+  is tagged with its TDMA timeslot (anchored to the synchronisation burst), and
+  the daemon registers up to four `cc:same-carrier:N` taps, so up to four
+  simultaneous calls on one control carrier — one per slot — record into their
+  own files instead of only one binding and the rest being dropped with
+  "no voice device available for grant". The same-carrier voice device serial
+  changes from `cc:same-carrier` to `cc:same-carrier:1..4`.
 - **Startup warning when paging is configured without storage.** A
   `paging.pocsag` / `paging.flex` / `paging.wideband` subsystem with no
   `storage.path` set decodes fine and consumes live IQ, but decoded pages are
@@ -72,6 +82,15 @@ for tagged releases.
   rather than a fixed slot 1 — the building block for issue #925.
 
 ### Fixed
+- **TETRA TCH/S class-2 CRC was computed wrong, so no on-air voice ever
+  decoded.** The 8-bit CRC was a `G(X)=1+X³+X⁷` LFSR; the TETRA CRC
+  (EN 300 395-2 §5.5.1) is a fixed parity-check matrix, so every received TCH/S
+  burst failed the check and was dropped (recordings held only spurious frames).
+  Reimplemented from the ETSI reference tap tables — real voice now decodes.
+- **TETRA voice calls could hang forever, monopolising the same-carrier tap.**
+  Call liveness is now driven by CRC-valid decoded speech rather than every raw
+  carrier burst, so a call ends on hangtime when its transmission stops and the
+  tap is freed for the next grant.
 - **Config guidance no longer conflates LSM/simulcast with CQPSK.** The
   `p25_phase1_demod_mode` docs, config-builder help, `config.example.yaml`, and the
   per-site override example (issue #942) all implied that a *simulcast* site needs the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,3 +65,21 @@ confirmation before any close-as-completed.
   at the Airspy's native 10 MS/s clock. `TestDownconverterSNRInvariantAcrossRate`
   in the file above pins this: a noisy channel reaches the receiver at the same
   in-channel SNR whether decoded natively at 10 MS/s or decimated to 2.5 MS/s.
+- **TETRA voice** decodes end-to-end: traffic burst → TCH/S channel decode
+  (`internal/radio/tetra/tch.go`) → clean-room ACELP vocoder
+  (`internal/voice/acelp`) → PCM. Two independent conformance passes against the
+  **ETSI EN 300 395-2 reference C codec** underpin it, and both are reproducible
+  via skip-guarded harnesses: `internal/voice/acelp/etsi_reference_test.go`
+  (feed both the same 137-bit bitstream → bit-identical PCM) and
+  `cmd/gophertrunk/tetra_multislot_replay_test.go` (replay a real cs16 IQ capture
+  → per-slot audio, correlated against the control channel's grant timeslots).
+  Build the ETSI tools with `Word32` as a 32-bit `int` — on LP64 the default
+  `typedef long` is 64-bit and every saturating op returns garbage. Lessons that
+  cost time: the class-2 CRC is a fixed parity-check matrix (the reference's
+  `TAB_CRC` tables), **not** a `G(X)` LFSR — the wrong CRC silently dropped every
+  on-air burst while synthetic round-trips passed (self-consistent bug); TCH/S is
+  hard-decision while the control SCH path is soft-decision; and the SB anchors
+  the slot grid one NDB-slot before its frame's TN1 traffic
+  (`ndbSBSlotShift` in `traffic.go`). When "voice doesn't decode" but the vocoder
+  unit tests pass, suspect the channel coding (CRC / interleave / reorder), not
+  the vocoder — validate the whole chain against the reference, not just parts.

--- a/docs/vocoders.md
+++ b/docs/vocoders.md
@@ -76,7 +76,7 @@ Default mapping (see `voice.DefaultVocoderForProtocol`):
 | `dmr-tier3`    | `ambe2` | DMR Tier III trunked             |
 | `nxdn`         | `ambe2` |                                  |
 | `dpmr`         | `ambe2` | dPMR Mode 3                      |
-| `tetra`        | `ambe2` |                                  |
+| `tetra`        | `tetra-acelp` | full-rate ACELP; up to 4 concurrent same-carrier timeslots |
 
 Analog protocols (`motorola`, `edacs`, `ltr`, `mpt1327`, etc.)
 have no entry — for those, the composer's FM chain feeds
@@ -298,11 +298,15 @@ synthesis filter. Bit-exact fixed-point arithmetic (ITU-T-style 16/32-bit
 saturating operators) underlies every block.
 
 **Slot isolation.** The traffic extractor emits a burst for every TDMA
-timeslot on the carrier. The TCH/S class-2 CRC is used as the slot filter:
-only the granted call's TCH/S speech bursts verify, so other slots'
-signalling bursts (and encrypted TEA1-4 traffic) are dropped. This cleanly
-separates a *single* active call; two concurrent TCH/S calls on the same
-carrier would still need TDMA frame-number demux (a follow-up).
+timeslot on the carrier and tags each with its TDMA timeslot (1..4),
+numbered from the synchronisation burst that anchors the 255-dibit slot
+grid. The composer's TETRA chain keeps only bursts on its granted timeslot,
+so up to four concurrent calls on one carrier — one per slot, each on its
+own `cc:same-carrier:N` tap — decode into four independent recordings. The
+TCH/S class-2 CRC still gates what counts as speech (signalling bursts and
+encrypted TEA1-4 traffic fail it); until the slot grid anchors, or on a
+traffic-only carrier with no synchronisation burst, the chain falls back to
+CRC-gated single-call isolation.
 
 **Provenance / licensing.** The decoder was ported from the *algorithmic*
 description in EN 300 395-2 and the ITU-T fixed-point operator
@@ -317,11 +321,19 @@ project; operators in licence-restrictive jurisdictions should evaluate
 with counsel. The decoder lives behind an explicit vocoder registration
 (`tetra-acelp`) so builds can omit it.
 
-**Validation.** Each block carries unit tests validated *independently*
-of the reference where possible (e.g. the LSP→LPC conversion is checked
-against the LSP root property; log2/pow2 against `math`; the synthesis
-filter against a float recursion). Bit-exact conformance against the ETSI
-clause-4 test sequences is the remaining validation step (see Future work).
+**Validation.** Each block carries unit tests validated *independently* of
+the reference where possible (e.g. the LSP→LPC conversion is checked against
+the LSP root property; log2/pow2 against `math`; the synthesis filter against
+a float recursion). Beyond that, the decoder is **bit-exact** to the ETSI
+EN 300 395-2 reference codec: feeding both the same 137-bit bitstream yields
+identical PCM sample-for-sample (0 / 96000 mismatches over 400 frames,
+including erasure/BFI frames). The TCH/S channel decode was validated the
+same way against the ETSI reference *channel* codec — GT's type-3 frame is
+bit-identical, which is how the class-2 CRC error that had been dropping
+every on-air burst was found and fixed. The ACELP check is reproducible via the
+skip-guarded harness `internal/voice/acelp/etsi_reference_test.go`; the class-2
+CRC is guarded in-tree by `TestTCHClass2CRCMatchesETSI` (two reference-verified
+vectors). The ETSI sources/vectors themselves are copyrighted and not committed.
 
 ## Future work
 
@@ -340,8 +352,9 @@ clause-4 test sequences is the remaining validation step (see Future work).
   long-running archives.
 - Plain AMBE decoder for D-STAR voice (different algorithm from AMBE+2;
   same DVSI patent family).
-- TETRA ACELP: bit-exact conformance against the ETSI EN 300 395-2
-  clause-4 test sequences (add under `internal/voice/acelp/testdata/`),
-  and TDMA frame-number slot demux so concurrent same-carrier TCH/S
-  calls separate cleanly (today a single active call is isolated by the
-  TCH/S CRC).
+- TETRA ACELP concurrent-call decoding runs four independent TETRA
+  receivers (one per same-carrier tap) over the same IQ; sharing one
+  receiver's slot-tagged bursts across the per-slot chains would cut that
+  CPU. Per-burst talkgroup gating is also still disabled for TETRA (the
+  boundary tracker uses grantTG 0) because TCH/S carries no in-band
+  talkgroup identity.

--- a/internal/radio/tetra/tetra.go
+++ b/internal/radio/tetra/tetra.go
@@ -35,23 +35,19 @@
 //   - The π/4-DQPSK demodulator + symbol-clock recovery for TETRA's
 //     18 ksym/sec air interface. internal/dsp/demod/dqpsk.go is the
 //     closest fit; matched-filter parameters differ from P25 Phase 2.
-//   - TDMA timing recovery + slot demarcation. The 4-slot frame +
-//     18-frame multiframe + 60-multiframe hyperframe scheduling
-//     belongs in a separate sync stage.
-//   - Lower-layer FEC: RCPC convolutional + reed-muller block coding
-//     across the various logical channels (BSCH, AACH, SCH/F,
-//     SCH/HD, BNCH). Parsing here assumes upstream FEC has corrected
-//     errors.
 //   - End-to-end air-interface encryption (TEA1/2/3/4) — TETRA voice
 //     traffic on most operational networks is encrypted; the
-//     `Encrypted` flag on a grant just records what the CC said.
-//   - TCH/S traffic-channel FEC (§8.4 unequal error protection) and the
-//     TETRA ACELP speech decoder that would turn recovered speech frames
-//     into PCM. The voice-follow path (traffic.go + the composer's TETRA
-//     chain) already retunes to the granted carrier, demodulates it, and
-//     extracts each Normal Continuous Downlink Burst's data blocks to the
-//     recorder's `.raw` sidecar for out-of-band decode; the FEC + vocoder
-//     are the remaining steps to intelligible audio.
+//     `Encrypted` flag on a grant just records what the CC said. Encrypted
+//     TCH/S fails the class-2 CRC and produces no decoded audio.
+//
+// Now wired (voice path): the composer's TETRA chain retunes to the granted
+// carrier, demodulates it, and — via traffic.go — recovers each Normal
+// Continuous Downlink Burst tagged with its TDMA timeslot (numbered from the
+// synchronisation burst). TCH/S channel decode (§5.5: RCPC + interleave +
+// class-2 CRC) turns each burst into 137-bit speech frames, which the
+// clean-room ACELP vocoder (internal/voice/acelp, bit-exact to ETSI
+// EN 300 395-2) renders to PCM. Per-slot filtering lets up to four concurrent
+// same-carrier calls decode into independent recordings.
 //
 // As with the other trunking packages: ship a clean structured
 // surface now, leave the analogue / FEC / encryption pieces as named

--- a/internal/radio/tetra/traffic.go
+++ b/internal/radio/tetra/traffic.go
@@ -25,14 +25,13 @@ import (
 // sequence and emits them concatenated as one 432-bit (54-byte) full-slot
 // traffic frame.
 //
-// The emitted frame is the raw, still-scrambled type-5 payload. TCH/S
-// channel decoding (the unequal-error-protection scheme of §8.4) and the
-// TETRA ACELP vocoder are deliberately NOT applied here — they are the
-// labelled follow-ups. The raw frames go to the recorder's `.raw` sidecar
-// for out-of-band decode, exactly as the DMR / P25 / EDACS-ProVoice voice
-// paths write their post-FEC or raw frames. Being scrambled, a consumer
-// descrambles with the cell's extended colour code (learned from the
-// control channel's BSCH) before TCH/S FEC.
+// The emitted frame is the raw, still-scrambled type-5 payload; TCH/S channel
+// decoding (§5.5) and the ACELP vocoder run downstream in the composer's TETRA
+// chain (tch.go + internal/voice/acelp), which descrambles with the cell's
+// extended colour code (learned from the control channel's BSCH), TCH/S-decodes
+// each burst into 137-bit speech frames, and renders them to PCM. The raw frames
+// are also written to the recorder's `.raw` sidecar, exactly as the DMR / P25 /
+// EDACS-ProVoice voice paths write their post-FEC or raw frames.
 //
 // Slot demultiplexing: the extractor emits a frame for every NCDB it sees
 // on the carrier — all four TDMA timeslots — and tags each with its TDMA


### PR DESCRIPTION
## Summary

Follow-up to the TETRA voice work merged in #975. That PR made TETRA voice decode end-to-end (TCH/S class-2 CRC fix + ACELP + per-timeslot demux for up to 4 concurrent same-carrier calls), but several docs still described the old, pre-working state. This corrects them (docs/comments only — no code behaviour change). The doc commit was written against #975 but landed after that PR merged, so it wasn't included; this brings it onto current `main`.

## Changes

- **`docs/vocoders.md`** — the protocol→vocoder table listed `tetra → ambe2`; it is `tetra-acelp`. Rewrote the TETRA ACELP "slot isolation" (per-timeslot demux is done, not a follow-up — concurrent same-carrier calls decode into separate recordings), "validation" (the decoder is bit-exact to the ETSI EN 300 395-2 reference; the class-2 CRC is guarded by `TestTCHClass2CRCMatchesETSI`), and future-work notes (remaining items are the CPU cost of four receivers and per-burst talkgroup gating, which TCH/S can't provide).
- **`internal/radio/tetra/tetra.go` + `traffic.go`** — the package "honest deferrals" and the extractor doc still called TCH/S FEC, the ACELP vocoder, and slot demarcation unwired follow-ups. They're implemented — the comments now describe the real path.
- **`CHANGELOG.md`** — `[Unreleased]` entries: Added (TETRA voice decodes on-air + up to 4 concurrent same-carrier calls), Fixed (the class-2 CRC bug + the never-ending-call fix).
- **`CLAUDE.md`** — a DSP note so the next investigation starts ahead: the two ETSI conformance harnesses, the LP64 `Word32` build gotcha, the CRC-is-a-parity-matrix (not a `G(X)` LFSR) lesson, hard- vs soft-decision, and the SB slot anchor.

## Test plan

- [x] `make vet test` is green locally
- [x] `make integration` is green locally (unchanged from #975 — no code touched)
- [x] Added or updated tests where appropriate — n/a (docs/comments only)
- [ ] Smoke-tested against real hardware — n/a (no code change)

`go build ./...` and the tetra package tests pass; the diff is comments + Markdown only.

## Breaking changes

None.

## Docs / CHANGELOG

- [x] Added a `## [Unreleased]` bullet to `CHANGELOG.md`
- [x] Updated `docs/` (this PR is the docs update)

## Linked issues

n/a — follow-up to #975.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmkZyhNfZnLVhxxx7miXPv

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmkZyhNfZnLVhxxx7miXPv)_