### PR TITLE
feat(api): add duration_ms to call.end; confirm+pin nac on P25 grant events (#268)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **`call.end` real-time event now carries `duration_ms`.** The SSE/WebSocket
+  event stream's call-completion event (`event: call.end` on `/api/v1/events`
+  and the WS stream) now includes the call length in milliseconds alongside
+  `started_at`/`ended_at`, matching the completed-call webhook's `duration_ms`,
+  so an SSE/WS-only consumer (a Prometheus exporter, a Grafana feed) reads a
+  call's duration off the completion event without pairing it back to
+  `call.start` and subtracting timestamps itself. Also confirmed and pinned by
+  a regression test that the P25 control-channel `nac` — site identity
+  alongside `rfss_id`/`site_id` — is present on every P25 grant / affiliation /
+  registration event (threaded from the decoded NID; omitted only for non-P25
+  protocols where NAC does not apply). (issue #268)
 - **TETRA voice now decodes to audible audio, including up to 4 concurrent
   calls on one carrier.** The TETRA voice path recovers each traffic burst,
   channel-decodes TCH/S, and renders it with the clean-room ACELP vocoder

--- a/internal/api/sse_test.go
+++ b/internal/api/sse_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
@@ -111,6 +112,84 @@ func TestEventToDTOUnitRegistrationSiteJSON(t *testing.T) {
 	want := `{"system":"MMR","protocol":"p25","source_id":1122867,"wacn":781832,"system_id":1332,"response":"accepted","rfss_id":2,"site_id":9,"nac":659}`
 	if got != want {
 		t.Errorf("registration+site JSON =\n  %s\nwant\n  %s", got, want)
+	}
+}
+
+// TestEventToDTOGrantCarriesNAC pins that a P25 grant event surfaces the
+// control channel's NAC on the wire (issue #268). NAC is threaded from the
+// decoded NID, so it is present on every P25 grant; downstream site-identity
+// dashboards read it alongside rfss_id/site_id. The `omitempty` tag only drops
+// it for non-P25 protocols (DMR/TETRA/…) where NAC does not apply — so a
+// consumer can treat "nac absent" as "not a P25 grant", never as "P25 grant
+// that silently lost its NAC".
+func TestEventToDTOGrantCarriesNAC(t *testing.T) {
+	dto := eventToDTO(events.Event{
+		Kind: events.KindGrant,
+		Payload: trunking.Grant{
+			System: "MMR", Protocol: "p25", GroupID: 0x1234, SourceID: 0xABCDEF,
+			FrequencyHz: 851_000_000, RFSSID: 1, SiteID: 9, NAC: 0x293,
+		},
+	})
+	body, err := json.Marshal(dto.Payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(body, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	nac, ok := m["nac"]
+	if !ok {
+		t.Fatalf("P25 grant JSON is missing `nac`: %s", body)
+	}
+	if nac.(float64) != 659 {
+		t.Errorf("nac = %v, want 659", nac)
+	}
+
+	// Contract: a grant with no NAC (non-P25, NAC unset) omits the field rather
+	// than surfacing a misleading nac:0.
+	body2, _ := json.Marshal(grantToDTO(trunking.Grant{System: "DMR-T3", Protocol: "dmr", GroupID: 1001}))
+	var m2 map[string]any
+	if err := json.Unmarshal(body2, &m2); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, present := m2["nac"]; present {
+		t.Errorf("non-P25 grant should omit nac, got: %s", body2)
+	}
+}
+
+// TestEventToDTOCallEndDuration pins that the call.end event carries
+// duration_ms (issue #268), so an SSE/WS-only consumer reads a call's length
+// off the completion event — matching the completed-call webhook's duration_ms
+// — instead of pairing call.end back to call.start and subtracting itself.
+func TestEventToDTOCallEndDuration(t *testing.T) {
+	start := time.Date(2026, 7, 24, 10, 0, 0, 0, time.UTC)
+	end := start.Add(3200 * time.Millisecond)
+	dto := eventToDTO(events.Event{
+		Kind: events.KindCallEnd,
+		Payload: trunking.CallEnd{
+			Grant:        trunking.Grant{System: "MMR", Protocol: "p25", NAC: 0x293},
+			DeviceSerial: "VOICE-1",
+			StartedAt:    start,
+			EndedAt:      end,
+			Reason:       trunking.EndReasonNormal,
+		},
+	})
+	body, err := json.Marshal(dto.Payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(body, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if d, _ := m["duration_ms"].(float64); d != 3200 {
+		t.Errorf("duration_ms = %v, want 3200 (json=%s)", m["duration_ms"], body)
+	}
+	// A zero StartedAt (watchdog/shutdown teardown) yields duration 0, not a
+	// garbage value from subtracting the zero time.
+	if z := callEndToDTO(trunking.CallEnd{EndedAt: end, Reason: trunking.EndReasonNormal}); z.DurationMs != 0 {
+		t.Errorf("zero-start duration = %d, want 0", z.DurationMs)
 	}
 }
 

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -809,7 +809,13 @@ type CallEndDTO struct {
 	DeviceSerial string        `json:"device_serial"`
 	StartedAt    time.Time     `json:"started_at"`
 	EndedAt      time.Time     `json:"ended_at"`
-	Reason       string        `json:"reason"`
+	// DurationMs is the call's length in milliseconds (ended − started). It
+	// mirrors the completed-call webhook's duration_ms so an SSE/WS-only
+	// consumer (a Prometheus exporter, a Grafana feed) can read a call's
+	// duration off the completion event without pairing it back to the
+	// call.start and subtracting timestamps itself (issue #268).
+	DurationMs int64 `json:"duration_ms"`
+	Reason     string `json:"reason"`
 }
 
 func callStartToDTO(cs trunking.CallStart) CallStartDTO {
@@ -822,12 +828,19 @@ func callStartToDTO(cs trunking.CallStart) CallStartDTO {
 }
 
 func callEndToDTO(ce trunking.CallEnd) CallEndDTO {
+	// Duration only when both timestamps are sane; a watchdog/shutdown teardown
+	// can leave StartedAt zero, and clock skew must not surface a negative.
+	var durMs int64
+	if !ce.StartedAt.IsZero() && ce.EndedAt.After(ce.StartedAt) {
+		durMs = ce.EndedAt.Sub(ce.StartedAt).Milliseconds()
+	}
 	return CallEndDTO{
 		Grant:        grantToDTO(ce.Grant),
 		Talkgroup:    talkgroupToDTO(ce.Talkgroup),
 		DeviceSerial: ce.DeviceSerial,
 		StartedAt:    ce.StartedAt,
 		EndedAt:      ce.EndedAt,
+		DurationMs:   durMs,
 		Reason:       ce.Reason.String(),
 	}
 }

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -816,7 +816,7 @@ type CallEndDTO struct {
 	// consumer (a Prometheus exporter, a Grafana feed) can read a call's
 	// duration off the completion event without pairing it back to the
 	// call.start and subtracting timestamps itself (issue #268).
-	DurationMs int64 `json:"duration_ms"`
+	DurationMs int64  `json:"duration_ms"`
 	Reason     string `json:"reason"`
 }
 


### PR DESCRIPTION
## Summary

Closes the two gaps the reporter flagged on the real-time telemetry tracking issue (building against the SSE stream for a Grafana pipeline):

1. **`call.end` carried no duration.** The SSE/WS `call.end` event already fires (the engine publishes `KindCallEnd`; `handleSSE` forwards every bus kind) with `started_at`/`ended_at`, but not the call length — so an SSE/WS-only consumer (a Prometheus exporter, a Grafana feed) had to pair each `call.end` back to its `call.start` and subtract timestamps. Now it carries `duration_ms` directly.
2. **`nac` reliability on grant/affiliation events.** Audited + pinned.

## Changes

- **`call.end` → `duration_ms`.** Add `duration_ms` to `CallEndDTO` (`internal/api/types.go`), computed as `ended − started` and named to match the completed-call webhook's `duration_ms` so both transports agree. Guarded so a watchdog/shutdown teardown with a zero `StartedAt` (or any clock skew) yields `0`, never a garbage or negative value.
- **`nac` audit + guarantee.** On P25 the NAC is threaded from the decoded NID (`best.nid.NAC`) onto every grant / affiliation / unit-registration event, and preserved through the call lifecycle (the #915/#922 source/encryption backfill mutates the bound grant's fields in place; `call.end` embeds that grant). The `omitempty` tag only drops `nac` for **non-P25** protocols where NAC doesn't apply — so a consumer reads "`nac` absent" as "not a P25 grant", never as "P25 grant that silently lost its NAC". No behaviour change; pinned with a regression test.

## Test plan

- [x] `make vet test` green (the one failure in a full run, `internal/hunt`'s `TestManager_RunHistoryAndExportRun`, is a pre-existing timing flake unrelated to this change — it passes on isolated re-run; `internal/api` is clean).
- [x] `TestEventToDTOCallEndDuration` — asserts `duration_ms` on the `call.end` payload (fails without the new field) and that a zero-`StartedAt` teardown yields `0`.
- [x] `TestEventToDTOGrantCarriesNAC` — asserts `nac` is present with the decoded value on a P25 grant DTO and omitted on a non-P25 grant.

## Breaking changes

None — `duration_ms` is an additive field on `call.end`; existing consumers ignore it.

## Docs / CHANGELOG

- [x] Added an `## [Unreleased]` bullet documenting the new `call.end` `duration_ms` field and the confirmed `nac` guarantee.
- No dedicated event-schema doc exists yet (`docs/api-events.md` is still an open item on #268); `docs/cc-activity.md` only lists event kinds, so nothing there to update field-wise.

## Linked issues

Refs #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RagXANPJKfd2qPUcrEhEC1

---
_Generated by [Claude Code](https://claude.ai/code/session_01RagXANPJKfd2qPUcrEhEC1)_