### PR TITLE
feat(p25p2): soft-decision MAC decode (differential per-bit soft Viterbi)

### DIFF
--- a/internal/radio/framing/p25_trellis.go
+++ b/internal/radio/framing/p25_trellis.go
@@ -155,3 +155,67 @@ func p25TrellisDibitDist(a, b uint8) int {
 		return 2
 	}
 }
+
+// DecodeP25TrellisSoftC runs true soft-decision Viterbi over the trellis using
+// per-channel-dibit complex soft samples. soft[i] is the received differential
+// for channel dibit i, rotated into the diagonal frame where the two on-air
+// bits are the signs of the real and imaginary parts: b0 = (Re < 0), b1 =
+// (Im < 0). The branch metric is the negative correlation of the received soft
+// with the expected dibit's bit signs — a magnitude-weighted log-likelihood, so
+// an ambiguous (near-zero) symbol contributes little and a strong one dominates,
+// which the scalar reliability-weighted form cannot express. len(soft) must
+// equal the channel length (2·stages). Returns the info dibits and path metric.
+func DecodeP25TrellisSoftC(soft []complex64) ([]uint8, float64) {
+	const inf = 1e30
+	if len(soft) < 2 || len(soft)%2 != 0 {
+		return nil, inf
+	}
+	stages := len(soft) / 2
+
+	// Per stage, per candidate output dibit value (0..3), the soft cost.
+	// cost(e, z) = (2*b0-1)*Re(z) + (2*b1-1)*Im(z), minimised.
+	pm := [4]float64{0, inf, inf, inf}
+	trace := make([][4]uint8, stages)
+	for s := 0; s < stages; s++ {
+		zh, zl := soft[2*s], soft[2*s+1]
+		var costHi, costLo [4]float64
+		for e := 0; e < 4; e++ {
+			sb0 := float64(2*(e&1) - 1)
+			sb1 := float64(2*((e>>1)&1) - 1)
+			costHi[e] = sb0*float64(real(zh)) + sb1*float64(imag(zh))
+			costLo[e] = sb0*float64(real(zl)) + sb1*float64(imag(zl))
+		}
+		var npm [4]float64
+		for i := range npm {
+			npm[i] = inf
+		}
+		for cur := 0; cur < 4; cur++ {
+			if pm[cur] >= inf {
+				continue
+			}
+			for next := 0; next < 4; next++ {
+				idx := p25TrellisStates[cur][next]
+				cost := pm[cur] + costHi[p25TrellisPairs[idx][0]] + costLo[p25TrellisPairs[idx][1]]
+				if cost < npm[next] {
+					npm[next] = cost
+					trace[s][next] = uint8(cur)
+				}
+			}
+		}
+		pm = npm
+	}
+	finalState := 0
+	for s := 1; s < 4; s++ {
+		if pm[s] < pm[finalState] {
+			finalState = s
+		}
+	}
+	finalMetric := pm[finalState]
+	out := make([]uint8, stages)
+	state := finalState
+	for s := stages - 1; s >= 0; s-- {
+		out[s] = uint8(state)
+		state = int(trace[s][state])
+	}
+	return out[:stages-1], finalMetric
+}

--- a/internal/radio/framing/p25_trellis_soft_test.go
+++ b/internal/radio/framing/p25_trellis_soft_test.go
@@ -1,0 +1,94 @@
+package framing
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+)
+
+// dibitToDiag maps a canonical channel dibit to its ideal soft point in the
+// diagonal frame DecodeP25TrellisSoftC expects: b0 = Re<0, b1 = Im<0.
+func dibitToDiag(v uint8) complex64 {
+	b0 := float64(v & 1)
+	b1 := float64((v >> 1) & 1)
+	return complex(float32((1-2*b0)/math.Sqrt2), float32((1-2*b1)/math.Sqrt2))
+}
+
+// TestDecodeP25TrellisSoftCClean: on ideal (noiseless) soft points the soft
+// Viterbi recovers exactly the transmitted info dibits — anchors the bit
+// convention against the hard encoder/decoder.
+func TestDecodeP25TrellisSoftCClean(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+	for trial := 0; trial < 300; trial++ {
+		n := 8 + rng.Intn(40)
+		info := make([]uint8, n)
+		for i := range info {
+			info[i] = uint8(rng.Intn(4))
+		}
+		ch := EncodeP25Trellis(info)
+		soft := make([]complex64, len(ch))
+		for i, v := range ch {
+			soft[i] = dibitToDiag(v)
+		}
+		got, _ := DecodeP25TrellisSoftC(soft)
+		if len(got) != len(info) {
+			t.Fatalf("len %d != %d", len(got), len(info))
+		}
+		for i := range info {
+			if got[i] != info[i] {
+				t.Fatalf("trial %d: soft-C decode wrong at %d (got %d want %d)", trial, i, got[i], info[i])
+			}
+		}
+	}
+}
+
+// TestDecodeP25TrellisSoftCBeatsHard: over an AWGN diagonal channel the true
+// soft Viterbi has a strictly lower info-dibit error rate than the hard decoder.
+func TestDecodeP25TrellisSoftCBeatsHard(t *testing.T) {
+	const infoLen = 72
+	for _, sigma := range []float64{0.5, 0.6, 0.7} {
+		rng := rand.New(rand.NewSource(9))
+		var hardErr, softErr, total int
+		for trial := 0; trial < 400; trial++ {
+			info := make([]uint8, infoLen)
+			for i := range info {
+				info[i] = uint8(rng.Intn(4))
+			}
+			ch := EncodeP25Trellis(info)
+			hardCh := make([]uint8, len(ch))
+			soft := make([]complex64, len(ch))
+			for i, v := range ch {
+				ideal := dibitToDiag(v)
+				re := float64(real(ideal)) + rng.NormFloat64()*sigma
+				im := float64(imag(ideal)) + rng.NormFloat64()*sigma
+				soft[i] = complex(float32(re), float32(im))
+				var b0, b1 uint8
+				if re < 0 {
+					b0 = 1
+				}
+				if im < 0 {
+					b1 = 1
+				}
+				hardCh[i] = 2*b1 + b0
+			}
+			hard, _ := DecodeP25Trellis(hardCh)
+			sft, _ := DecodeP25TrellisSoftC(soft)
+			for i := 0; i < infoLen; i++ {
+				if hard[i] != info[i] {
+					hardErr++
+				}
+				if sft[i] != info[i] {
+					softErr++
+				}
+				total++
+			}
+		}
+		hBER := float64(hardErr) / float64(total)
+		sBER := float64(softErr) / float64(total)
+		t.Logf("sigma=%.2f  hard BER=%.4f  soft BER=%.4f  (%.1f%% reduction)",
+			sigma, hBER, sBER, 100*(hBER-sBER)/hBER)
+		if sBER >= hBER {
+			t.Errorf("sigma=%.2f: soft BER %.4f not better than hard %.4f", sigma, sBER, hBER)
+		}
+	}
+}

--- a/internal/radio/framing/p25p2_interleave.go
+++ b/internal/radio/framing/p25p2_interleave.go
@@ -36,6 +36,26 @@ func InterleaveMACBurst(in []uint8) []uint8 {
 	return out
 }
 
+// DeinterleaveMACBurstC applies the exact same de-interleave permutation as
+// DeinterleaveMACBurst to a parallel complex64 slice (the soft-decision
+// per-dibit differential, issue #915), keeping the soft sample aligned with its
+// dibit through the block interleaver. Lengths not a multiple of
+// macInterleaveRows are returned unchanged, matching the dibit path.
+func DeinterleaveMACBurstC(in []complex64) []complex64 {
+	n := len(in)
+	if n == 0 || n%macInterleaveRows != 0 {
+		return append([]complex64(nil), in...)
+	}
+	cols := n / macInterleaveRows
+	out := make([]complex64, n)
+	for r := 0; r < macInterleaveRows; r++ {
+		for c := 0; c < cols; c++ {
+			out[r*cols+c] = in[c*macInterleaveRows+r]
+		}
+	}
+	return out
+}
+
 // DeinterleaveMACBurst is the exact inverse of InterleaveMACBurst: it
 // recovers the original dibit order from a block-interleaved MAC burst.
 func DeinterleaveMACBurst(in []uint8) []uint8 {

--- a/internal/radio/p25/phase2/process.go
+++ b/internal/radio/p25/phase2/process.go
@@ -242,6 +242,81 @@ func decodeMACChannelAndParse(macDibits []uint8, mode TrellisMode, interleaveMod
 	return MACPDU{}, false
 }
 
+// decodeMACPDUDibitsSoftC is the soft-decision counterpart of
+// decodeMACPDUDibits: it drives the true per-bit soft Viterbi
+// (framing.DecodeP25TrellisSoftC) off the diagonal-frame differential samples
+// carried alongside the hard dibits. It mirrors the scrambler dispatch exactly.
+// soft must be the same length as macDibits; a nil / mismatched soft degrades to
+// the hard path. Issue #915.
+func decodeMACPDUDibitsSoftC(macDibits []uint8, soft []complex64, mode TrellisMode, rsMode RSMode, interleaveMode InterleaveMode, scramblerMode ScramblerMode, scramblerSeed uint64, scramblerOffset int) (MACPDU, bool) {
+	if len(soft) != len(macDibits) || mode != TrellisOn {
+		return decodeMACPDUDibits(macDibits, mode, rsMode, interleaveMode, scramblerMode, scramblerSeed, scramblerOffset)
+	}
+	switch scramblerMode {
+	case ScramblerProbe:
+		if rsMode != RSOn {
+			return descrambleAndParseSoftC(soft, interleaveMode, rsMode, scramblerSeed, scramblerOffset)
+		}
+		for slot := 0; slot < SubframesPerSuperframe; slot++ {
+			off := slotChannelPN44Offset(slot)
+			if pdu, ok := descrambleAndParseSoftC(soft, interleaveMode, RSOn, scramblerSeed, off); ok {
+				return pdu, true
+			}
+		}
+		return MACPDU{}, false
+	case ScramblerOn:
+		return descrambleAndParseSoftC(soft, interleaveMode, rsMode, scramblerSeed, scramblerOffset)
+	default: // ScramblerOff
+		return decodeMACChannelAndParseSoftC(soft, interleaveMode, rsMode)
+	}
+}
+
+// descrambleAndParseSoftC descrambles the diagonal-frame soft samples (a set
+// PN44 channel bit flips the sign of the matching soft component: bit b1 → Im,
+// bit b0 → Re) at channelOffset, then runs the soft FEC chain. The input slice
+// is left untouched.
+func descrambleAndParseSoftC(soft []complex64, interleaveMode InterleaveMode, rsMode RSMode, seed uint64, channelOffset int) (MACPDU, bool) {
+	ds := make([]complex64, len(soft))
+	copy(ds, soft)
+	seq := make([]byte, len(soft)*2)
+	descrambleAtOffset(seq, seed, channelOffset) // XOR into zeros ⇒ seq = PN44 bits
+	for i := range ds {
+		if seq[2*i] == 1 { // b1 (Im)
+			ds[i] = complex(real(ds[i]), -imag(ds[i]))
+		}
+		if seq[2*i+1] == 1 { // b0 (Re)
+			ds[i] = complex(-real(ds[i]), imag(ds[i]))
+		}
+	}
+	return decodeMACChannelAndParseSoftC(ds, interleaveMode, rsMode)
+}
+
+// decodeMACChannelAndParseSoftC deinterleaves the soft samples (same permutation
+// as the dibits), runs the soft Viterbi, then RS-verifies and parses.
+func decodeMACChannelAndParseSoftC(soft []complex64, interleaveMode InterleaveMode, rsMode RSMode) (MACPDU, bool) {
+	if len(soft) != macPDUDibitsTrellis {
+		return MACPDU{}, false
+	}
+	if interleaveMode == InterleaveOn {
+		soft = framing.DeinterleaveMACBurstC(soft)
+	}
+	decoded, _ := framing.DecodeP25TrellisSoftC(soft)
+	if len(decoded) != macPDUDibits {
+		return MACPDU{}, false
+	}
+	info := framing.PackBitsMSB(framing.DibitsToBits(decoded))
+	if len(info) < 18 {
+		return MACPDU{}, false
+	}
+	if rsMode == RSOn && !verifyMACPDURS(info[:18]) {
+		return MACPDU{}, false
+	}
+	if pdu, err := ParseMACPDU(info[:18]); err == nil {
+		return pdu, true
+	}
+	return MACPDU{}, false
+}
+
 // pn44SuperframeBits is the length in channel bits of one 360 ms P25
 // Phase 2 superframe (12 sub-frames × 180 dibits × 2 bits) — the period
 // of the PN44 scrambling sequence per TIA-102.BBAC-1 §7.2.5. Channel-bit

--- a/internal/radio/p25/phase2/receiver/receiver.go
+++ b/internal/radio/p25/phase2/receiver/receiver.go
@@ -121,6 +121,17 @@ type Options struct {
 	// GardnerGain overrides the Gardner loop step (default 0.03,
 	// applied only when ClockMode is ClockGardner).
 	GardnerGain float64
+	// SoftDecision enables soft-decision output: alongside the hard dibits the
+	// receiver emits, per dibit, the complex differential in the diagonal frame
+	// (b0 = Re<0, b1 = Im<0) via SoftSink, so the Phase 2 MAC path can run a
+	// true per-bit soft Viterbi (~1.5-2 dB of coding gain the hard slicer
+	// discards; issue #915). Requires SoftSink; the hard DibitSink is not
+	// called on the soft path. Default false ⇒ the hard path runs
+	// byte-identically. ClockGardner only.
+	SoftDecision bool
+	// SoftSink receives the (dibits, soft, baseIdx) stream when SoftDecision is
+	// set. Required in that case.
+	SoftSink phase2.SoftDibitSink
 }
 
 // ClockMode selects how the receiver decimates the matched-filter
@@ -174,10 +185,12 @@ func ParseClockMode(s string) (ClockMode, bool) {
 
 // Receiver is the composed IQ → dibit pipeline.
 type Receiver struct {
-	dq        *demod.PiOver4DQPSK
-	sps       int
-	dibitSink phase2.DibitSink
-	dibitBase int
+	dq           *demod.PiOver4DQPSK
+	sps          int
+	dibitSink    phase2.DibitSink
+	softSink     phase2.SoftDibitSink
+	softDecision bool
+	dibitBase    int
 	// rxOffset is the absolute sample index where the next symbol
 	// centre should be picked from the matched-filter output. It
 	// advances by sps each time we emit a dibit, and wraps when the
@@ -203,6 +216,8 @@ type Receiver struct {
 	rotated []complex64 // NCO-de-rotated IQ, fed to the matched filter
 	matched []complex64
 	dibits  []uint8
+	diffs   []complex64 // soft path: per-symbol differential from DecodeBoth
+	soft    []complex64 // soft path: differential rotated into the diagonal frame
 	symbols []complex64
 	// pending holds matched-filter samples from prior Process calls
 	// that didn't align with a symbol centre and are needed for the
@@ -217,7 +232,11 @@ func New(opts Options) *Receiver {
 	if opts.SampleRateHz <= 0 {
 		panic("receiver: SampleRateHz is required")
 	}
-	if opts.DibitSink == nil {
+	if opts.SoftDecision {
+		if opts.SoftSink == nil {
+			panic("receiver: SoftSink is required when SoftDecision is set")
+		}
+	} else if opts.DibitSink == nil {
 		panic("receiver: DibitSink is required")
 	}
 	sps := opts.SampleRateHz / SymbolRate
@@ -233,10 +252,12 @@ func New(opts Options) *Receiver {
 		alpha = RolloffAlpha
 	}
 	r := &Receiver{
-		dq:        demod.NewPiOver4DQPSK(int(sps+0.5), span, alpha, Rotation),
-		sps:       int(sps + 0.5),
-		dibitSink: opts.DibitSink,
-		clockMode: opts.ClockMode,
+		dq:           demod.NewPiOver4DQPSK(int(sps+0.5), span, alpha, Rotation),
+		sps:          int(sps + 0.5),
+		dibitSink:    opts.DibitSink,
+		softSink:     opts.SoftSink,
+		softDecision: opts.SoftDecision,
+		clockMode:    opts.ClockMode,
 	}
 	if r.clockMode == ClockGardner {
 		gain := opts.GardnerGain
@@ -336,6 +357,27 @@ func (r *Receiver) Process(iq []complex64) {
 		}
 	}
 	if len(r.symbols) == 0 {
+		return
+	}
+	if r.softDecision {
+		// Soft path: recover the hard dibit AND the complex differential
+		// (DecodeBoth, as the TETRA receiver does). The differential's ideal
+		// points sit at π/8 + k·π/2; rotating by +π/8 puts them on the
+		// diagonals, so the two on-air bits become the signs of Re and Im —
+		// the frame framing.DecodeP25TrellisSoftC expects (issue #915).
+		r.dibits, r.diffs = r.dq.DecodeBoth(r.dibits, r.diffs, r.symbols)
+		if cap(r.soft) < len(r.diffs) {
+			r.soft = make([]complex64, len(r.diffs))
+		}
+		r.soft = r.soft[:len(r.diffs)]
+		const c, s = float32(0.9238795325112867), float32(0.3826834323650898) // cos/sin(π/8)
+		for i, d := range r.dibits {
+			r.dibits[i] = canonicalDibitRemap[d&3]
+			re, im := real(r.diffs[i]), imag(r.diffs[i])
+			r.soft[i] = complex(re*c-im*s, re*s+im*c)
+		}
+		r.softSink(r.dibits, r.soft, r.dibitBase)
+		r.dibitBase += len(r.dibits)
 		return
 	}
 	r.dibits = r.dq.Decode(r.dibits, r.symbols)

--- a/internal/radio/p25/phase2/receiver/softdecision_test.go
+++ b/internal/radio/p25/phase2/receiver/softdecision_test.go
@@ -1,0 +1,139 @@
+package receiver_test
+
+// End-to-end soft-decision test for issue #915: modulate real-shaped P25 Phase 2
+// superframes carrying a MAC_PTT (ALGID/KID) payload, add AWGN, and drive them
+// through the production receiver with SoftDecision off vs on. True per-bit soft
+// Viterbi on the MAC trellis must recover the payload at noise levels where the
+// hard slicer cannot, and must be byte-identical on a clean signal.
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase2"
+	rx "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase2/receiver"
+)
+
+const (
+	sdWantAlg = 0x84
+	sdWantKey = 0x1234
+)
+
+func sdStream(t *testing.T, nSF int) []complex64 {
+	t.Helper()
+	const sps, span, alpha = 8, 8, 0.20
+	es := phase2.EncryptionSync{AlgorithmID: sdWantAlg, KeyID: sdWantKey,
+		MessageIndicator: [9]byte{9, 8, 7, 6, 5, 4, 3, 2, 1}}
+	ptt := phase2.EncodePushToTalk(es)
+	if b := phase2.AssembleMACPDU(ptt); len(b) < 18 {
+		ptt.Payload = append(ptt.Payload, make([]byte, 18-len(b))...)
+	}
+	vpay := make([][]byte, phase2.VoiceFrameCount(phase2.SlotTypeVoice4V))
+	for i := range vpay {
+		vpay[i] = make([]byte, phase2.VoiceFrameBytes)
+	}
+	var subs [phase2.SubframesPerSuperframe][]uint8
+	for i := range subs {
+		if i == 0 {
+			subs[i] = phase2.EncodeMACSubframe(phase2.SlotTypeMACPTT, uint8(i), ptt,
+				phase2.TrellisOn, phase2.InterleaveOff)
+		} else {
+			subs[i] = phase2.EncodeVoiceSubframe(phase2.SlotTypeVoice4V, uint8(i), vpay)
+		}
+	}
+	superframe := phase2.EncodeSuperframe(subs)
+	base := phase2.SyncSubframeIndex * phase2.DibitsPerSubframe
+	copy(superframe[base:base+phase2.SyncDibits], hexToDibitsMSB(specSyncHex, phase2.SyncDibits))
+
+	dibits := leadInDibits(600, 0xB915)
+	for n := 0; n < nSF; n++ {
+		dibits = append(dibits, superframe...)
+	}
+	return demod.ModulateHDQPSKSpec(dibits, sps, span, alpha)
+}
+
+func sdDecode(iq []complex64, soft bool) int {
+	sfDec := phase2.NewSuperframeDecoder()
+	var sfs []phase2.Superframe
+	opts := rx.Options{SampleRateHz: 8 * rx.SymbolRate, ClockMode: rx.ClockGardner, GardnerGain: 0.005}
+	if soft {
+		opts.SoftDecision = true
+		opts.SoftSink = func(d []uint8, s []complex64, base int) {
+			sfs = append(sfs, sfDec.ProcessSoft(d, s, base)...)
+		}
+	} else {
+		opts.DibitSink = func(d []uint8, base int) {
+			sfs = append(sfs, sfDec.Process(d, base)...)
+		}
+	}
+	r := rx.New(opts)
+	for off := 0; off < len(iq); off += 192 {
+		end := off + 192
+		if end > len(iq) {
+			end = len(iq)
+		}
+		r.Process(iq[off:end])
+	}
+	cfg := phase2.MACDecodeConfig{Trellis: phase2.TrellisOn}
+	got := 0
+	for _, sf := range sfs {
+		for _, tagged := range phase2.DecodeSuperframeMACPDUsWithSlot(sf, cfg) {
+			if tagged.SlotType != phase2.SlotTypeMACPTT {
+				continue
+			}
+			if es, ok := tagged.PDU.AsPushToTalk(); ok &&
+				int(es.AlgorithmID) == sdWantAlg && int(es.KeyID) == sdWantKey {
+				got++
+			}
+		}
+	}
+	return got
+}
+
+func sdAddNoise(iq []complex64, sigma float64, seed int64) []complex64 {
+	rng := rand.New(rand.NewSource(seed))
+	out := make([]complex64, len(iq))
+	for i, s := range iq {
+		out[i] = s + complex(float32(rng.NormFloat64()*sigma), float32(rng.NormFloat64()*sigma))
+	}
+	return out
+}
+
+// TestSoftDecisionNoiseless: clean signal ⇒ soft and hard recover the same.
+func TestSoftDecisionNoiseless(t *testing.T) {
+	iq := sdStream(t, 6)
+	hard := sdDecode(iq, false)
+	soft := sdDecode(iq, true)
+	if hard == 0 {
+		t.Fatalf("hard recovered 0 payloads on clean signal")
+	}
+	if soft != hard {
+		t.Fatalf("clean signal: soft recovered %d, hard %d — must match", soft, hard)
+	}
+}
+
+// TestSoftDecisionBeatsHard: true soft-decision recovers more MAC payloads than
+// hard across the noisy sweep, and never fewer.
+func TestSoftDecisionBeatsHard(t *testing.T) {
+	base := sdStream(t, 40)
+	totalHard, totalSoft := 0, 0
+	for _, sigma := range []float64{0.35, 0.45, 0.55} {
+		var hSum, sSum int
+		for seed := int64(1); seed <= 4; seed++ {
+			iq := sdAddNoise(base, sigma, seed)
+			hSum += sdDecode(iq, false)
+			sSum += sdDecode(iq, true)
+		}
+		t.Logf("sigma=%.2f  hard=%d  soft=%d  (of 40 superframes × 4 seeds)", sigma, hSum, sSum)
+		if sSum < hSum {
+			t.Errorf("sigma=%.2f: soft %d recovered FEWER than hard %d", sigma, sSum, hSum)
+		}
+		totalHard += hSum
+		totalSoft += sSum
+	}
+	t.Logf("TOTAL hard=%d soft=%d", totalHard, totalSoft)
+	if totalSoft <= totalHard {
+		t.Errorf("soft-decision did not improve payload recovery (hard=%d soft=%d)", totalHard, totalSoft)
+	}
+}

--- a/internal/radio/p25/phase2/superframe_decoder.go
+++ b/internal/radio/p25/phase2/superframe_decoder.go
@@ -30,6 +30,11 @@ type Subframe struct {
 	SlotType SlotType
 	// Dibits holds the DibitsPerSubframe raw dibits of the sub-frame.
 	Dibits []uint8
+	// Soft holds the per-dibit complex differential (diagonal frame) parallel
+	// to Dibits when the superframe was assembled via ProcessSoft (soft path,
+	// issue #915); nil on the hard path. It is de-rotated in step with Dibits
+	// so it stays in the canonical decision frame.
+	Soft []complex64
 }
 
 // Superframe is one decoded 360 ms P25 Phase 2 superframe.
@@ -70,6 +75,7 @@ type syncAnchor struct {
 type SuperframeDecoder struct {
 	dets     [4]*SyncDetector // one per constant dibit rotation (issue #915)
 	buf      []uint8
+	softBuf  []complex64  // parallel per-dibit soft samples (soft path; nil-len on hard)
 	bufStart int          // absolute dibit index of buf[0]
 	pending  []syncAnchor // sync anchors awaiting a full superframe
 }
@@ -113,6 +119,7 @@ func (d *SuperframeDecoder) initDetectors() {
 // anchor does not slice across the discontinuity.
 func (d *SuperframeDecoder) Reset() {
 	d.buf = d.buf[:0]
+	d.softBuf = d.softBuf[:0]
 	d.bufStart = 0
 	d.pending = d.pending[:0]
 	d.initDetectors()
@@ -123,10 +130,26 @@ func (d *SuperframeDecoder) Reset() {
 // dibits[0]; it must be monotonically non-decreasing across calls.
 // Superframes are returned in stream order.
 func (d *SuperframeDecoder) Process(dibits []uint8, baseIdx int) []Superframe {
+	return d.process(dibits, nil, baseIdx)
+}
+
+// ProcessSoft is Process with a parallel per-dibit soft stream (soft path,
+// issue #915). soft must have the same length as dibits; the soft samples ride
+// through slicing + de-rotation so each MAC sub-frame carries a Subframe.Soft
+// the soft Viterbi can use. It returns exactly the superframes Process would
+// for the identical dibit stream — soft never changes sync locking or slicing.
+func (d *SuperframeDecoder) ProcessSoft(dibits []uint8, soft []complex64, baseIdx int) []Superframe {
+	return d.process(dibits, soft, baseIdx)
+}
+
+func (d *SuperframeDecoder) process(dibits []uint8, soft []complex64, baseIdx int) []Superframe {
 	if len(d.buf) == 0 {
 		d.bufStart = baseIdx
 	}
 	d.buf = append(d.buf, dibits...)
+	if soft != nil && len(soft) == len(dibits) {
+		d.softBuf = append(d.softBuf, soft...)
+	}
 
 	// Detect the outbound sync under each of the four constant dibit
 	// rotations; only the rotation that matches the stream's residual-carrier
@@ -180,6 +203,10 @@ func (d *SuperframeDecoder) trim() {
 	drop := len(d.buf) - superframeBufKeep
 	copy(d.buf, d.buf[drop:])
 	d.buf = d.buf[:superframeBufKeep]
+	if len(d.softBuf) == len(d.buf)+drop {
+		copy(d.softBuf, d.softBuf[drop:])
+		d.softBuf = d.softBuf[:superframeBufKeep]
+	}
 	d.bufStart += drop
 }
 
@@ -194,12 +221,21 @@ func (d *SuperframeDecoder) sliceSuperframe(start int, rot uint8) Superframe {
 	sf := Superframe{StartDibit: start}
 	off := start - d.bufStart
 	derot := (4 - rot) & 3
+	haveSoft := len(d.softBuf) >= off+SubframesPerSuperframe*DibitsPerSubframe
 	for i := 0; i < SubframesPerSuperframe; i++ {
 		sub := make([]uint8, DibitsPerSubframe)
 		copy(sub, d.buf[off+i*DibitsPerSubframe:off+(i+1)*DibitsPerSubframe])
+		var soft []complex64
+		if haveSoft {
+			soft = make([]complex64, DibitsPerSubframe)
+			copy(soft, d.softBuf[off+i*DibitsPerSubframe:off+(i+1)*DibitsPerSubframe])
+		}
 		if derot != 0 {
 			for j := range sub {
 				sub[j] = (sub[j] + derot) & 3
+			}
+			for j := range soft {
+				soft[j] = derotSoft(soft[j], derot)
 			}
 		}
 		slot := SlotTypeUnknown
@@ -211,7 +247,33 @@ func (d *SuperframeDecoder) sliceSuperframe(start int, rot uint8) Superframe {
 			Timeslot: i & 1,
 			SlotType: slot,
 			Dibits:   sub,
+			Soft:     soft,
 		}
 	}
 	return sf
+}
+
+// derotSoft applies to a diagonal-frame soft sample the geometric transform
+// that (dibit + k) & 3 applies to the hard dibit value it encodes (b0 = Re<0,
+// b1 = Im<0, canonical value = 2·b1 + b0). Adding k mod 4 to the value is a
+// carry-coupled bit permutation; the k=1,3 cases flip Im conditioned on the
+// sign of Re (a soft "controlled-NOT"), so the soft stays in the canonical
+// decision frame after de-rotation. Issue #915.
+func derotSoft(z complex64, k uint8) complex64 {
+	re, im := real(z), imag(z)
+	switch k & 3 {
+	case 1:
+		if re >= 0 {
+			return complex(-re, im)
+		}
+		return complex(-re, -im)
+	case 2:
+		return complex(re, -im)
+	case 3:
+		if re >= 0 {
+			return complex(-re, -im)
+		}
+		return complex(-re, im)
+	}
+	return z
 }

--- a/internal/radio/p25/phase2/superframe_ingest.go
+++ b/internal/radio/p25/phase2/superframe_ingest.go
@@ -72,8 +72,20 @@ func DecodeSuperframeMACPDUsWithSlot(sf Superframe, cfg MACDecodeConfig) []Decod
 		}
 		macDibits := sub.Dibits[MACPayloadOffset : MACPayloadOffset+macLen]
 		offset := slotChannelPN44Offset(sub.Index)
-		if pdu, ok := decodeMACPDUDibits(macDibits, cfg.Trellis, cfg.RS,
-			cfg.Interleave, cfg.Scrambler, cfg.Seed, offset); ok {
+		var pdu MACPDU
+		var ok bool
+		if len(sub.Soft) >= MACPayloadOffset+macLen {
+			// Soft-decision path (issue #915): true per-bit soft Viterbi over
+			// the diagonal-frame differential. Byte-identical to the hard path
+			// on a clean signal; recovers ~1.5-2 dB otherwise.
+			soft := sub.Soft[MACPayloadOffset : MACPayloadOffset+macLen]
+			pdu, ok = decodeMACPDUDibitsSoftC(macDibits, soft, cfg.Trellis, cfg.RS,
+				cfg.Interleave, cfg.Scrambler, cfg.Seed, offset)
+		} else {
+			pdu, ok = decodeMACPDUDibits(macDibits, cfg.Trellis, cfg.RS,
+				cfg.Interleave, cfg.Scrambler, cfg.Seed, offset)
+		}
+		if ok {
 			out = append(out, DecodedMACPDU{
 				SlotType: sub.SlotType,
 				PDU:      pdu,

--- a/internal/radio/p25/phase2/sync.go
+++ b/internal/radio/p25/phase2/sync.go
@@ -11,6 +11,16 @@ package phase2
 // Phase 2 CC state machine on live IQ.
 type DibitSink func(dibits []uint8, baseIdx int)
 
+// SoftDibitSink is the soft-decision counterpart of DibitSink: alongside the
+// hard dibits it carries, per dibit, the complex differential rotated into the
+// diagonal frame where the two on-air bits are the signs of the real and
+// imaginary parts (b0 = Re<0, b1 = Im<0). This is the true per-bit soft
+// information the MAC trellis's soft Viterbi (framing.DecodeP25TrellisSoftC)
+// needs — a magnitude-weighted log-likelihood, which recovers ~1.5-2 dB the
+// hard slicer discards. soft has the same length as dibits. Used only when the
+// receiver's Options.SoftDecision is set (issue #915).
+type SoftDibitSink func(dibits []uint8, soft []complex64, baseIdx int)
+
 // Phase 2 sync words. Outbound (BS → MS) and inbound (MS → BS) carry distinct
 // patterns so a receiver can lock onto the appropriate side of the link.
 // hexToDibits materialises SyncDibits (20) dibits MSB-first from the low 40 bits


### PR DESCRIPTION
## Summary

Adds **opt-in soft-decision decoding** for the P25 Phase 2 MAC path (issue #915). The receiver's hard slicer throws away ~1.5–2 dB of coding gain; this recovers it by feeding true per-bit soft information into the MAC trellis's Viterbi. It's the "more sensitive front-end" work — done *through* differential detection, not requiring coherent lock.

The enabling insight (measured, not assumed): the receiver's differential constellation sits at **π/8 + k·π/2**, so rotating by +π/8 lands the four points on the diagonals and the two on-air bits become the **signs of Re and Im**. In that frame the branch metric is the magnitude-weighted correlation of the received soft with each candidate dibit's bit signs — so an ambiguous (near-zero) symbol contributes little and a strong one dominates, which a *scalar* reliability weight cannot express (an earlier scalar-weighted attempt regressed; this true per-bit form does not).

## Changes

- `framing.DecodeP25TrellisSoftC` — soft-input Viterbi reusing the existing trellis engine; `framing.DeinterleaveMACBurstC` for the parallel soft slice.
- Receiver `Options.SoftDecision` / `SoftSink`, `phase2.SoftDibitSink`, `Subframe.Soft`, `SuperframeDecoder.ProcessSoft` + `derotSoft`, and the soft MAC decode chain in `process.go` / `superframe_ingest.go`.
- The soft sample rides the **descramble** (a sign flip per set PN44 bit), the **deinterleave** (same permutation), and the **superframe de-rotation** (a soft controlled-NOT for the carry-coupled ±1/±3 cases) so it stays in the canonical decision frame.
- All gated behind `Options.SoftDecision` (default false) ⇒ the hard path is **byte-identical**; no other protocol, clean-signal fixture, or the shared DDC is touched.

## Test plan

- [x] `go build ./...` + `go vet ./...` clean; hard-path tests in `framing`, `phase2`, `receiver`, plus consumers (`voice/composer`, `widebandt2`) all green.
- [x] `framing`: soft trellis anchors clean-decode exactly and cuts info-dibit BER **~88%** at the operating SNR.
- [x] `receiver` (end-to-end through the production path): clean signal decodes identically to hard; under AWGN soft recovers **~43% more MAC payloads**, including payloads where the hard path recovers **zero**.
- [x] Ground-truth capture (`#981` harness): **neutral** — `rs_valid` unchanged. That capture sits ~10 dB below threshold, more than soft-decision's ~2 dB closes; a higher-SNR capture (already requested on #915) is needed to convert the gain into recovered source RIDs.

## Breaking changes

None. Opt-in, additive, default-off; hard path byte-identical.

## Docs / CHANGELOG

- n/a — internal receiver capability; not user-facing until wired into config in a follow-up.

## Linked issues

Refs #915

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WDeT5T2tP4r8XbzgP8wCQV

---
_Generated by [Claude Code](https://claude.ai/code/session_01WDeT5T2tP4r8XbzgP8wCQV)_