### PR TITLE
feat(p25p2): wire soft-decision demod into the live daemon config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **P25 Phase 2 soft-decision demod (`p25_phase2_soft_decision`).** A new
+  per-system opt-in knob (on/off, default off) that builds the Phase 2
+  traffic-channel receiver with soft-decision decoding: the demodulator's
+  soft symbol differentials feed a per-bit soft Viterbi on the MAC trellis,
+  recovering the ~1.5–2 dB of coding gain the hard slicer discards. On weak
+  signals this can surface the clear-MAC source RID the hard path drops; on
+  strong signals it is neutral, and with the knob off the decode is
+  byte-for-byte unchanged. Applies to the voice composer and signalling
+  follower (including Phase 1 control channels that grant Phase 2 traffic).
+  Issue #915.
 - **TETRA voice now decodes to audible audio, including up to 4 concurrent
   calls on one carrier.** The TETRA voice path recovers each traffic burst,
   channel-decodes TCH/S, and renders it with the clean-room ACELP vocoder

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -851,6 +851,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 			P25Phase2RSMode:         sys.P25Phase2RSMode,
 			P25Phase2InterleaveMode: sys.P25Phase2InterleaveMode,
 			P25Phase2ScramblerMode:  sys.P25Phase2ScramblerMode,
+			P25Phase2SoftDecision:   sys.P25Phase2SoftDecision,
 			P25Phase2ClockMode:      sys.P25Phase2ClockMode,
 			NXDNViterbiMode:         sys.NXDNViterbiMode,
 			NXDNDeviationHz:         sys.NXDNDeviationHz,

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1010,6 +1010,8 @@ trunking:
   #     # p25_phase2_interleave_mode: "on"    # per-burst block deinterleave
   #     # p25_phase2_scrambler_mode: "probe"  # blind PN44 slot probe
   #     #                              # (degrades to off without rs:on)
+  #     # p25_phase2_soft_decision: "on"      # soft-decision MAC trellis
+  #     #                              # (~1.5-2 dB; recovers weak-signal RIDs)
   #     # p25_phase2_clock_mode: "naive"      # decimate; default Gardner
   #
   #   - name: "Legacy-TETRA"

--- a/docs/opt-in-features.md
+++ b/docs/opt-in-features.md
@@ -50,6 +50,7 @@ per-system with `<key>: off`.
 | P25 Phase 2 (outer RS) | `p25_phase2_rs_mode` | `RSOff` (RS(24, 16, 9) verifier shipped per TIA-102.BAAA-A §5.9) | `on` flips RS verification on |
 | P25 Phase 2 (PN44 scrambler) | `p25_phase2_scrambler_mode` | `ScramblerOff` (PN44 descrambler shipped per TIA-102.BBAC-1 §7.2.5 with per-burst slot-offset blind probe; seed derived from per-system WACN + SystemID + NAC) | `on` flips PN44 descrambling on at the configured offset / `probe` walks the 12 Figure 7-5 slot offsets and accepts whichever RS-verifies |
 | P25 Phase 2 (block interleaver) | `p25_phase2_interleave_mode` | `off` (no deinterleave; matches synthesized-fixture expectations) | `on` flips the TIA-102.BBAC per-burst MAC block deinterleaver on, applied to the burst dibits before trellis decoding |
+| P25 Phase 2 (soft decision) | `p25_phase2_soft_decision` | `off` (hard slicer; byte-for-byte the historical behaviour) | `on` feeds the demodulator's soft symbol differentials into a per-bit soft Viterbi on the traffic-channel MAC trellis, recovering the ~1.5-2 dB of coding gain the hard slicer discards (helps surface the clear-MAC source RID on weak signals; neutral on strong ones — issue #915) |
 | NXDN | `nxdn_viterbi_mode` | `ViterbiSpec` | `off` |
 | EDACS | `edacs_bch_mode` | `BCHOn` | `off` |
 | MPT 1327 | `mpt1327_bch_mode` | `BCHOn` | `off` |

--- a/docs/user-guide-windows.md
+++ b/docs/user-guide-windows.md
@@ -962,6 +962,7 @@ OP25 fixtures, MMDVMHost / DSDcc test data) opt out per-system:
 | P25 Phase 2 trellis | `p25_phase2_trellis_mode` | `off` |
 | P25 Phase 2 RS | `p25_phase2_rs_mode` | `on` enables verification |
 | P25 Phase 2 PN44 scrambler | `p25_phase2_scrambler_mode` | `on` / `probe` |
+| P25 Phase 2 soft decision | `p25_phase2_soft_decision` | `on` (soft MAC trellis; ~1.5-2 dB) |
 | NXDN Viterbi | `nxdn_viterbi_mode` | `off` |
 | EDACS BCH | `edacs_bch_mode` | `off` |
 | MPT 1327 BCH | `mpt1327_bch_mode` | `off` |

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -141,6 +141,7 @@ type SystemDTO struct {
 	P25Phase2TrellisMode   string  `json:"p25_phase2_trellis_mode,omitempty"`
 	P25Phase2RSMode        string  `json:"p25_phase2_rs_mode,omitempty"`
 	P25Phase2ScramblerMode string  `json:"p25_phase2_scrambler_mode,omitempty"`
+	P25Phase2SoftDecision  string  `json:"p25_phase2_soft_decision,omitempty"`
 	NXDNViterbiMode        string  `json:"nxdn_viterbi_mode,omitempty"`
 	NXDNDeviationHz        float64 `json:"nxdn_deviation_hz,omitempty"`
 	EDACSBCHMode           string  `json:"edacs_bch_mode,omitempty"`
@@ -317,6 +318,7 @@ func systemToDTO(s trunking.System) SystemDTO {
 		P25Phase2TrellisMode:   s.P25Phase2TrellisMode,
 		P25Phase2RSMode:        s.P25Phase2RSMode,
 		P25Phase2ScramblerMode: s.P25Phase2ScramblerMode,
+		P25Phase2SoftDecision:  s.P25Phase2SoftDecision,
 		NXDNViterbiMode:        s.NXDNViterbiMode,
 		NXDNDeviationHz:        s.NXDNDeviationHz,
 		EDACSBCHMode:           s.EDACSBCHMode,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1483,6 +1483,16 @@ type SystemConfig struct {
 	// Color Code = NAC) per spec equation (5); the zero-seed edge
 	// case maps to (2^44 - 1). Ignored for non-P25-Phase-2 protocols.
 	P25Phase2ScramblerMode string `yaml:"p25_phase2_scrambler_mode"`
+	// P25Phase2SoftDecision enables the soft-decision demod path on the
+	// P25 Phase 2 traffic-channel receiver (issue #915). Recognised
+	// values: "" / "off" / "false" / "0" (the default — the hard
+	// slicer, byte-for-byte the historical behaviour) or "on" / "true"
+	// / "1" (feed the demodulator's soft symbol differentials into a
+	// per-bit soft Viterbi on the MAC trellis, recovering the ~1.5-2 dB
+	// of coding gain the hard slicer discards). Helps recover the
+	// clear-MAC source RID on weak signals; neutral on strong ones.
+	// Ignored for non-P25-Phase-2 protocols.
+	P25Phase2SoftDecision string `yaml:"p25_phase2_soft_decision"`
 	// P25Phase2ClockMode selects the symbol-timing-recovery strategy
 	// for the P25 Phase 2 receiver. Recognised values: "" /
 	// "gardner" / "on" (the new default — non-data-aided Gardner

--- a/internal/configbuilder/advanced.go
+++ b/internal/configbuilder/advanced.go
@@ -19,7 +19,7 @@ var AdvancedFields = map[string][]string{
 		"P25Phase1DemodMode",
 		// P25 Phase 2
 		"P25Phase2TrellisMode", "P25Phase2RSMode", "P25Phase2InterleaveMode",
-		"P25Phase2ScramblerMode", "P25Phase2ClockMode",
+		"P25Phase2ScramblerMode", "P25Phase2SoftDecision", "P25Phase2ClockMode",
 		// DMR
 		"DMRInterleavedVoice",
 		// NXDN

--- a/internal/configbuilder/fieldmeta.go
+++ b/internal/configbuilder/fieldmeta.go
@@ -185,6 +185,7 @@ var fieldMetas = map[string]FieldMeta{
 	"SystemConfig.P25Phase2RSMode":         {Label: "P25 Ph2 RS", Help: "Outer Reed-Solomon RS(24,16,9) verification. off (default) or on. P25 Phase 2 only."},
 	"SystemConfig.P25Phase2InterleaveMode": {Label: "P25 Ph2 interleave", Help: "Per-burst block deinterleave before trellis decode. off (default) or on. P25 Phase 2 only."},
 	"SystemConfig.P25Phase2ScramblerMode":  {Label: "P25 Ph2 scrambler", Help: "PN44 descrambling of the MAC PDU. on (default, all on-air) or off (unscrambled fixtures). P25 Phase 2 only."},
+	"SystemConfig.P25Phase2SoftDecision":   {Label: "P25 Ph2 soft decision", Help: "Soft-decision demod on the traffic-channel MAC trellis (~1.5-2 dB gain on weak signals; recovers clear-MAC source RIDs). off (default) or on. P25 Phase 2 only."},
 	"SystemConfig.P25Phase2ClockMode":      {Label: "P25 Ph2 clock", Help: "Symbol-timing recovery: gardner (default, live SDR) or naive (fixtures). P25 Phase 2 only."},
 	"SystemConfig.DMRInterleavedVoice":     {Label: "DMR interleaved voice", Help: "Override the 2-slot interleaved DMR voice decoder. Unset = on for DMR Tier II conventional & Tier III (single-slot only for Tier I direct-mode); set true/false to force. DMR only."},
 	"SystemConfig.NXDNViterbiMode":         {Label: "NXDN Viterbi mode", Help: "K=5 Viterbi FEC on the NXDN CAC. spec (default), on (older fixtures), or off. NXDN only."},

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -128,6 +128,10 @@ type ControlChannel struct {
 	p25Phase2RS         uint8
 	p25Phase2Interleave uint8
 	p25Phase2Scrambler  uint8
+	// p25Phase2SoftDecision is stamped onto Phase 2 TDMA voice grants so
+	// the voice composer builds a soft-decision traffic-channel receiver
+	// (issue #915). Default false keeps the hard slicer.
+	p25Phase2SoftDecision bool
 
 	// stats is the per-frame outcome counter exposed via Stats().
 	// Atomic so the daemon's API / diagnostic goroutines can read it
@@ -446,6 +450,9 @@ type Options struct {
 	P25Phase2RS         uint8
 	P25Phase2Interleave uint8
 	P25Phase2Scrambler  uint8
+	// P25Phase2SoftDecision mirrors phase2's soft-decision toggle onto
+	// hybrid Phase 2 TDMA voice grants (issue #915).
+	P25Phase2SoftDecision bool
 
 	// CarrierOffsetHz, when non-nil, reports the demodulator's current carrier
 	// offset (Hz) of the locked control carrier relative to the tuned centre.
@@ -487,25 +494,26 @@ func New(opts Options) *ControlChannel {
 		span = NIDSearchSpan
 	}
 	return &ControlChannel{
-		bus:                 opts.Bus,
-		log:                 log,
-		det:                 det,
-		systemName:          opts.SystemName,
-		freqHz:              opts.FrequencyHz,
-		bandPlan:            bp,
-		now:                 now,
-		carrierOffsetHz:     opts.CarrierOffsetHz,
-		fswTol:              fswTol,
-		aliasAsm:            NewTalkerAliasAssembler(now),
-		diagSeen:            make(map[uint32]int),
-		rotations:           resolveRotations(opts.Rotations),
-		pduSink:             opts.PDUSink,
-		nidSearchSpan:       span,
-		p25Phase1DemodMode:  opts.P25Phase1DemodMode,
-		p25Phase2Trellis:    opts.P25Phase2Trellis,
-		p25Phase2RS:         opts.P25Phase2RS,
-		p25Phase2Interleave: opts.P25Phase2Interleave,
-		p25Phase2Scrambler:  opts.P25Phase2Scrambler,
+		bus:                   opts.Bus,
+		log:                   log,
+		det:                   det,
+		systemName:            opts.SystemName,
+		freqHz:                opts.FrequencyHz,
+		bandPlan:              bp,
+		now:                   now,
+		carrierOffsetHz:       opts.CarrierOffsetHz,
+		fswTol:                fswTol,
+		aliasAsm:              NewTalkerAliasAssembler(now),
+		diagSeen:              make(map[uint32]int),
+		rotations:             resolveRotations(opts.Rotations),
+		pduSink:               opts.PDUSink,
+		nidSearchSpan:         span,
+		p25Phase1DemodMode:    opts.P25Phase1DemodMode,
+		p25Phase2Trellis:      opts.P25Phase2Trellis,
+		p25Phase2RS:           opts.P25Phase2RS,
+		p25Phase2Interleave:   opts.P25Phase2Interleave,
+		p25Phase2Scrambler:    opts.P25Phase2Scrambler,
+		p25Phase2SoftDecision: opts.P25Phase2SoftDecision,
 	}
 }
 
@@ -1658,11 +1666,12 @@ func (c *ControlChannel) publishVoiceGrant(g voiceGrant, nac uint16) {
 		protocol = "p25-phase2"
 		seed := framing.PN44SeedFromIdentity(net.WACN, net.SystemID, nac&0x0FFF)
 		p2dec = trunking.P25Phase2Decode{
-			Trellis:    c.p25Phase2Trellis,
-			RS:         c.p25Phase2RS,
-			Interleave: c.p25Phase2Interleave,
-			Scrambler:  c.p25Phase2Scrambler,
-			Seed:       seed,
+			Trellis:      c.p25Phase2Trellis,
+			RS:           c.p25Phase2RS,
+			Interleave:   c.p25Phase2Interleave,
+			Scrambler:    c.p25Phase2Scrambler,
+			Seed:         seed,
+			SoftDecision: c.p25Phase2SoftDecision,
 		}
 	}
 	c.bus.Publish(events.Event{

--- a/internal/radio/p25/phase2/control.go
+++ b/internal/radio/p25/phase2/control.go
@@ -59,6 +59,12 @@ type ControlChannel struct {
 	scramblerMode    ScramblerMode
 	scramblerSeed    uint64
 	scramblerOffset  int
+	// softDecision, when set, is stamped onto every published Phase 2
+	// voice grant (P25Phase2Decode.SoftDecision) so the voice composer /
+	// sigfollow build their traffic-channel receiver with the
+	// soft-decision demod path (issue #915). The CC's own receiver is
+	// unaffected — this field only travels to the traffic-channel decode.
+	softDecision bool
 	// bandPlan accumulates IdentifierUpdate MAC PDUs so publishGrant
 	// can resolve a voice grant's (ChannelID, ChannelNumber) into a
 	// downlink frequency. Guarded by mu.
@@ -422,6 +428,16 @@ func (c *ControlChannel) SetScramblerMode(mode ScramblerMode) {
 	c.scramblerMode = mode
 }
 
+// SetSoftDecision toggles whether published Phase 2 voice grants request
+// the soft-decision traffic-channel demod path (issue #915). It does not
+// change the CC's own receiver; it only sets the flag the composer /
+// sigfollow read off the grant to build a soft-decision receiver.
+func (c *ControlChannel) SetSoftDecision(on bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.softDecision = on
+}
+
 // ScramblerMode returns the current ScramblerMode.
 func (c *ControlChannel) ScramblerMode() ScramblerMode {
 	c.mu.Lock()
@@ -774,11 +790,12 @@ func (c *ControlChannel) publishGrant(g GroupVoiceChannelGrant, op Opcode, group
 	// the CC (see internal/voice/composer/p25p2_voice.go).
 	c.mu.Lock()
 	dec := trunking.P25Phase2Decode{
-		Trellis:    uint8(c.trellisMode),
-		RS:         uint8(c.rsMode),
-		Interleave: uint8(c.interleaveMode),
-		Scrambler:  uint8(c.scramblerMode),
-		Seed:       c.scramblerSeed,
+		Trellis:      uint8(c.trellisMode),
+		RS:           uint8(c.rsMode),
+		Interleave:   uint8(c.interleaveMode),
+		Scrambler:    uint8(c.scramblerMode),
+		Seed:         c.scramblerSeed,
+		SoftDecision: c.softDecision,
 	}
 	c.mu.Unlock()
 	rfss, site, nac := c.siteIdentity()

--- a/internal/radio/p25/phase2/receiver/receiver.go
+++ b/internal/radio/p25/phase2/receiver/receiver.go
@@ -163,6 +163,25 @@ const (
 	ClockGardner
 )
 
+// ParseSoftDecision maps a config / user-facing string into the
+// Options.SoftDecision boolean. Recognised values (case-insensitive):
+// "" / "off" / "false" / "0" → false (the default — the hard slicer,
+// byte-for-byte the historical behaviour); "on" / "true" / "1" → true
+// (feed the demodulator's soft differentials into the per-bit soft
+// Viterbi on the MAC trellis, recovering the ~1.5-2 dB of coding gain
+// the hard slicer discards; issue #915). Unknown strings return false
+// with `ok = false` so callers can warn and fall back.
+func ParseSoftDecision(s string) (on bool, ok bool) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "off", "false", "0":
+		return false, true
+	case "on", "true", "1":
+		return true, true
+	default:
+		return false, false
+	}
+}
+
 // ParseClockMode maps a config / user-facing string into a
 // ClockMode. Recognised values (case-insensitive): "" / "gardner" /
 // "on" / "true" / "1" → ClockGardner (the new default — Gardner

--- a/internal/radio/p25/phase2/receiver/receiver_test.go
+++ b/internal/radio/p25/phase2/receiver/receiver_test.go
@@ -366,3 +366,36 @@ func TestParseClockMode(t *testing.T) {
 		}
 	}
 }
+
+// TestParseSoftDecision pins the config-string contract the ccdecoder /
+// widebandt2 pipelines rely on to turn p25_phase2_soft_decision into
+// Options.SoftDecision (issue #915): empty / off-family → false (the default
+// hard slicer), on-family → true, anything else → (false, ok=false) so the
+// caller warns and falls back.
+func TestParseSoftDecision(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+		ok   bool
+	}{
+		{"", false, true},
+		{"off", false, true},
+		{"OFF", false, true},
+		{"false", false, true},
+		{"0", false, true},
+		{" off ", false, true},
+		{"on", true, true},
+		{"On", true, true},
+		{"true", true, true},
+		{"1", true, true},
+		{" on ", true, true},
+		{"nonsense", false, false},
+	}
+	for _, tc := range cases {
+		got, ok := ParseSoftDecision(tc.in)
+		if got != tc.want || ok != tc.ok {
+			t.Errorf("ParseSoftDecision(%q) = (%v, %v), want (%v, %v)",
+				tc.in, got, ok, tc.want, tc.ok)
+		}
+	}
+}

--- a/internal/radio/p25/phase2/soft_decision_grant_test.go
+++ b/internal/radio/p25/phase2/soft_decision_grant_test.go
@@ -1,0 +1,75 @@
+package phase2
+
+// Config-plumbing regression for the soft-decision front-end (issue #915):
+// the operator-facing p25_phase2_soft_decision toggle reaches the voice
+// composer / sigfollow only via the published grant's
+// P25Phase2Decode.SoftDecision. These tests pin that the CC stamps the flag
+// it was configured with (default off, on after SetSoftDecision) so a wiring
+// regression at the ControlChannel layer fails here rather than silently
+// dropping the receiver back to the hard slicer on live traffic.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// grantSoftDecision drives one grant through a CC and returns the
+// P25Phase2Decode.SoftDecision the published grant carried.
+func grantSoftDecision(t *testing.T, setSoft bool) bool {
+	t.Helper()
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	fixed := time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC)
+	cc := New(Options{
+		Bus:         bus,
+		SystemName:  "test-sys",
+		FrequencyHz: 851_012_500,
+		Now:         func() time.Time { return fixed },
+	})
+	if setSoft {
+		cc.SetSoftDecision(true)
+	}
+
+	cc.Ingest(grantPDU(0x1234, 0x00ABCD, 0x1, 0x005))
+
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind != events.KindGrant {
+				continue
+			}
+			g, ok := ev.Payload.(trunking.Grant)
+			if !ok {
+				t.Fatalf("grant payload type = %T", ev.Payload)
+			}
+			return g.P25Phase2Decode.SoftDecision
+		case <-deadline:
+			t.Fatal("no grant event")
+			return false
+		}
+	}
+}
+
+// TestGrantSoftDecisionDefaultOff: an un-configured CC stamps SoftDecision=false,
+// so live traffic keeps the historical hard-slicer path unless opted in.
+func TestGrantSoftDecisionDefaultOff(t *testing.T) {
+	if grantSoftDecision(t, false) {
+		t.Error("default grant SoftDecision = true, want false (hard slicer)")
+	}
+}
+
+// TestGrantSoftDecisionStamped: SetSoftDecision(true) reaches the grant, which
+// is the only channel by which the composer / sigfollow learn to build a
+// soft-decision receiver (issue #915).
+func TestGrantSoftDecisionStamped(t *testing.T) {
+	if !grantSoftDecision(t, true) {
+		t.Error("grant SoftDecision = false after SetSoftDecision(true)")
+	}
+}

--- a/internal/radio/p25/phase2/superframe_ingest.go
+++ b/internal/radio/p25/phase2/superframe_ingest.go
@@ -18,6 +18,17 @@ type MACDecodeConfig struct {
 	Interleave InterleaveMode
 	Scrambler  ScramblerMode
 	Seed       uint64
+	// SoftDecision requests the receiver-level soft-decision demod path
+	// (issue #915): when set, the traffic-channel receiver is built with
+	// receiver.Options.SoftDecision so it emits per-symbol soft
+	// differentials alongside the hard dibits, and the superframe decoder's
+	// ProcessSoft carries them into Subframe.Soft. The MAC-decode routines
+	// here consume Subframe.Soft automatically when it is present
+	// (DecodeSuperframeMACPDUsWithSlot), so this field is inert to the
+	// decode side itself — it exists so the flag can travel with the rest
+	// of the per-channel FEC config from the grant to the composer /
+	// sigfollow receiver setup. Default false keeps the hard slicer.
+	SoftDecision bool
 }
 
 // DecodedMACPDU pairs a decoded MAC PDU with the SlotType of the

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -296,22 +296,28 @@ func newP25Phase1Pipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 		log.Warn("ccdecoder: unrecognised p25_phase2_scrambler_mode; falling back to on",
 			"system", opts.SystemName, "value", opts.System.P25Phase2ScramblerMode)
 	}
+	p2SoftDecision, p2SoftOK := p25phase2rx.ParseSoftDecision(opts.System.P25Phase2SoftDecision)
+	if !p2SoftOK {
+		log.Warn("ccdecoder: unrecognised p25_phase2_soft_decision; falling back to off",
+			"system", opts.SystemName, "value", opts.System.P25Phase2SoftDecision)
+	}
 	// rx is forward-declared so the control channel's CarrierOffsetHz provider
 	// can close over it; the closure is only called later, at site-update
 	// publish time, well after rx is assigned below (issue #815).
 	var rx *p25phase1rx.Receiver
 	cc := p25phase1.New(p25phase1.Options{
-		Bus:                 opts.Bus,
-		Log:                 opts.Log,
-		SystemName:          opts.SystemName,
-		FrequencyHz:         opts.FrequencyHz,
-		BandPlan:            bandPlan,
-		Rotations:           rotations,
-		P25Phase1DemodMode:  opts.System.P25Phase1DemodMode,
-		P25Phase2Trellis:    uint8(p2Trellis),
-		P25Phase2RS:         uint8(p2RS),
-		P25Phase2Interleave: uint8(p2Interleave),
-		P25Phase2Scrambler:  uint8(p2Scrambler),
+		Bus:                   opts.Bus,
+		Log:                   opts.Log,
+		SystemName:            opts.SystemName,
+		FrequencyHz:           opts.FrequencyHz,
+		BandPlan:              bandPlan,
+		Rotations:             rotations,
+		P25Phase1DemodMode:    opts.System.P25Phase1DemodMode,
+		P25Phase2Trellis:      uint8(p2Trellis),
+		P25Phase2RS:           uint8(p2RS),
+		P25Phase2Interleave:   uint8(p2Interleave),
+		P25Phase2Scrambler:    uint8(p2Scrambler),
+		P25Phase2SoftDecision: p2SoftDecision,
 		// Report the TOTAL carrier offset from the configured frequency:
 		// the receiver's residual AFC plus any correction the decoder folded
 		// into the DDC (CarrierBiasHz). Residual-only would drop toward 0
@@ -475,6 +481,12 @@ func newP25Phase2Pipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 	cc.SetScramblerSeed(framing.PN44SeedFromIdentity(
 		opts.System.WACN, opts.System.SystemID, uint16(opts.System.Site),
 	))
+	softDecision, softOK := p25phase2rx.ParseSoftDecision(opts.System.P25Phase2SoftDecision)
+	if !softOK {
+		opts.Log.Warn("ccdecoder: unrecognised p25_phase2_soft_decision; falling back to off",
+			"system", opts.SystemName, "value", opts.System.P25Phase2SoftDecision)
+	}
+	cc.SetSoftDecision(softDecision)
 	clockMode, clockOK := p25phase2rx.ParseClockMode(opts.System.P25Phase2ClockMode)
 	if !clockOK {
 		opts.Log.Warn("ccdecoder: unrecognised p25_phase2_clock_mode; falling back to gardner",

--- a/internal/scanner/widebandt2/engine.go
+++ b/internal/scanner/widebandt2/engine.go
@@ -707,7 +707,7 @@ func buildChannel(sys trunking.System, ch ChannelConfig, outRateHz float64, bus 
 		// decode those grants' MAC PDUs; without it every grant carries
 		// TrellisOff / ScramblerOff / zero seed and MAC decode fails.
 		// Parse and forward the same knobs the ccdecoder pipeline does.
-		p2Trellis, p2RS, p2Interleave, p2Scrambler := parseP25Phase2FECModes(sys, log)
+		p2Trellis, p2RS, p2Interleave, p2Scrambler, p2SoftDecision := parseP25Phase2FECModes(sys, log)
 		cc := p25phase1.New(p25phase1.Options{
 			Bus:         bus,
 			Log:         log.With("system", sys.Name, "freq_hz", freqHz, "phase", 1),
@@ -721,11 +721,12 @@ func buildChannel(sys trunking.System, ch ChannelConfig, outRateHz float64, bus 
 			// too, or they lock the CC yet never decode an LDU (issue #935 /
 			// #356 follow-up). The wideband path previously left this unset,
 			// so grants always defaulted to c4fm regardless of the CC's mode.
-			P25Phase1DemodMode:  demodStr,
-			P25Phase2Trellis:    p2Trellis,
-			P25Phase2RS:         p2RS,
-			P25Phase2Interleave: p2Interleave,
-			P25Phase2Scrambler:  p2Scrambler,
+			P25Phase1DemodMode:    demodStr,
+			P25Phase2Trellis:      p2Trellis,
+			P25Phase2RS:           p2RS,
+			P25Phase2Interleave:   p2Interleave,
+			P25Phase2Scrambler:    p2Scrambler,
+			P25Phase2SoftDecision: p2SoftDecision,
 		})
 		rx := p25phase1rx.New(p25phase1rx.Options{
 			SampleRateHz: outRateHz,
@@ -799,7 +800,7 @@ func requireControlChannel(sys trunking.System, freqHz uint32, label string) err
 // their MAC PDUs (issue #882). Unrecognised values warn then fall back
 // to the same defaults the ccdecoder path uses; an empty per-system
 // value keeps the default (Trellis=on, everything else=off).
-func parseP25Phase2FECModes(sys trunking.System, log *slog.Logger) (trellis, rs, interleave, scrambler uint8) {
+func parseP25Phase2FECModes(sys trunking.System, log *slog.Logger) (trellis, rs, interleave, scrambler uint8, softDecision bool) {
 	p2Trellis, ok := p25phase2.ParseTrellisMode(sys.P25Phase2TrellisMode)
 	if !ok {
 		log.Warn("widebandt2: unrecognised p25_phase2_trellis_mode; falling back to on",
@@ -820,7 +821,12 @@ func parseP25Phase2FECModes(sys trunking.System, log *slog.Logger) (trellis, rs,
 		log.Warn("widebandt2: unrecognised p25_phase2_scrambler_mode; falling back to on",
 			"system", sys.Name, "value", sys.P25Phase2ScramblerMode)
 	}
-	return uint8(p2Trellis), uint8(p2RS), uint8(p2Interleave), uint8(p2Scrambler)
+	p2SoftDecision, ok := p25phase2rx.ParseSoftDecision(sys.P25Phase2SoftDecision)
+	if !ok {
+		log.Warn("widebandt2: unrecognised p25_phase2_soft_decision; falling back to off",
+			"system", sys.Name, "value", sys.P25Phase2SoftDecision)
+	}
+	return uint8(p2Trellis), uint8(p2RS), uint8(p2Interleave), uint8(p2Scrambler), p2SoftDecision
 }
 
 // applyP25Phase2Modes mirrors newP25Phase2Pipeline's per-system mode
@@ -858,6 +864,12 @@ func applyP25Phase2Modes(cc *p25phase2.ControlChannel, sys trunking.System, log 
 	cc.SetScramblerSeed(framing.PN44SeedFromIdentity(
 		sys.WACN, sys.SystemID, uint16(sys.Site),
 	))
+	softDecision, softOK := p25phase2rx.ParseSoftDecision(sys.P25Phase2SoftDecision)
+	if !softOK {
+		log.Warn("widebandt2: unrecognised p25_phase2_soft_decision; falling back to off",
+			"system", sys.Name, "value", sys.P25Phase2SoftDecision)
+	}
+	cc.SetSoftDecision(softDecision)
 }
 
 // Channels returns the per-channel frequencies the engine is

--- a/internal/sigfollow/manager.go
+++ b/internal/sigfollow/manager.go
@@ -209,11 +209,12 @@ func (m *Manager) follow(ctx context.Context, vt *wbvoice.VirtualTuner, g trunki
 	}
 
 	macCfg := p25p2.MACDecodeConfig{
-		Trellis:    p25p2.TrellisMode(g.P25Phase2Decode.Trellis),
-		RS:         p25p2.RSMode(g.P25Phase2Decode.RS),
-		Interleave: p25p2.InterleaveMode(g.P25Phase2Decode.Interleave),
-		Scrambler:  p25p2.ScramblerMode(g.P25Phase2Decode.Scrambler),
-		Seed:       g.P25Phase2Decode.Seed,
+		Trellis:      p25p2.TrellisMode(g.P25Phase2Decode.Trellis),
+		RS:           p25p2.RSMode(g.P25Phase2Decode.RS),
+		Interleave:   p25p2.InterleaveMode(g.P25Phase2Decode.Interleave),
+		Scrambler:    p25p2.ScramblerMode(g.P25Phase2Decode.Scrambler),
+		Seed:         g.P25Phase2Decode.Seed,
+		SoftDecision: g.P25Phase2Decode.SoftDecision,
 	}
 
 	sfDec := p25p2.NewSuperframeDecoder()
@@ -231,17 +232,31 @@ func (m *Manager) follow(ctx context.Context, vt *wbvoice.VirtualTuner, g trunki
 	var lastActivity atomic.Int64
 	lastActivity.Store(time.Now().UnixNano())
 
-	rx := p25p2rx.New(p25p2rx.Options{
+	// drainSuperframes is shared by the hard DibitSink and, when the grant
+	// requests soft-decision demod (issue #915), the soft SoftSink whose
+	// superframes carry per-symbol soft differentials in Subframe.Soft.
+	drainSuperframes := func(sfs []p25p2.Superframe) {
+		for _, sf := range sfs {
+			lastActivity.Store(time.Now().UnixNano())
+			dispatcher.Dispatch(sf, macCfg)
+		}
+	}
+	rxOpts := p25p2rx.Options{
 		SampleRateHz: rateHz,
 		ClockMode:    p25p2rx.ClockGardner,
 		GardnerGain:  gardnerGain,
-		DibitSink: func(dibits []uint8, baseIdx int) {
-			for _, sf := range sfDec.Process(dibits, baseIdx) {
-				lastActivity.Store(time.Now().UnixNano())
-				dispatcher.Dispatch(sf, macCfg)
-			}
-		},
-	})
+	}
+	if macCfg.SoftDecision {
+		rxOpts.SoftDecision = true
+		rxOpts.SoftSink = func(dibits []uint8, soft []complex64, baseIdx int) {
+			drainSuperframes(sfDec.ProcessSoft(dibits, soft, baseIdx))
+		}
+	} else {
+		rxOpts.DibitSink = func(dibits []uint8, baseIdx int) {
+			drainSuperframes(sfDec.Process(dibits, baseIdx))
+		}
+	}
+	rx := p25p2rx.New(rxOpts)
 
 	m.log.Info("sigfollow: p25p2 signalling follow started",
 		"system", g.System, "serial", vt.Serial(),

--- a/internal/siglab/metadata.go
+++ b/internal/siglab/metadata.go
@@ -139,6 +139,8 @@ func applySystemKnobs(sys *trunking.System, knobs map[string]string) {
 			sys.P25Phase2InterleaveMode = v
 		case "p25_phase2_scrambler_mode":
 			sys.P25Phase2ScramblerMode = v
+		case "p25_phase2_soft_decision":
+			sys.P25Phase2SoftDecision = v
 		case "p25_phase2_clock_mode":
 			sys.P25Phase2ClockMode = v
 		case "wacn":

--- a/internal/trunking/grant.go
+++ b/internal/trunking/grant.go
@@ -134,6 +134,13 @@ type P25Phase2Decode struct {
 	Interleave uint8
 	Scrambler  uint8
 	Seed       uint64
+	// SoftDecision mirrors phase2.MACDecodeConfig.SoftDecision: when set,
+	// the voice composer / sigfollow build the Phase 2 traffic-channel
+	// receiver with soft-decision demod (per-bit soft Viterbi on the MAC
+	// trellis) instead of the hard slicer, recovering ~1.5-2 dB of coding
+	// gain on weak signals (issue #915). Default false keeps today's hard
+	// path byte-for-byte.
+	SoftDecision bool
 }
 
 // String renders a one-line summary of a Grant for log output.

--- a/internal/trunking/site.go
+++ b/internal/trunking/site.go
@@ -306,6 +306,15 @@ type System struct {
 	// p25phase2.ControlChannel.SetScramblerMode +
 	// SetScramblerSeed by the ccdecoder connector.
 	P25Phase2ScramblerMode string
+	// P25Phase2SoftDecision enables the soft-decision demod path on the
+	// P25 Phase 2 traffic-channel receiver (issue #915). Recognised
+	// values (case-insensitive): "" / "off" / "false" / "0" → hard
+	// slicer (the default, historical behaviour); "on" / "true" / "1" →
+	// per-bit soft Viterbi on the MAC trellis (~1.5-2 dB coding gain on
+	// weak signals). Parsed via p25phase2rx.ParseSoftDecision and
+	// forwarded through the grant's P25Phase2Decode to the composer /
+	// sigfollow receiver.
+	P25Phase2SoftDecision string
 	// P25Phase2ClockMode selects the symbol-timing-recovery strategy
 	// for the P25 Phase 2 receiver. Recognised values (case-
 	// insensitive): "" / "gardner" / "on" → ClockGardner (the new

--- a/internal/tui/client/types.go
+++ b/internal/tui/client/types.go
@@ -45,6 +45,7 @@ type SystemDTO struct {
 	P25Phase2TrellisMode   string  `json:"p25_phase2_trellis_mode,omitempty"`
 	P25Phase2RSMode        string  `json:"p25_phase2_rs_mode,omitempty"`
 	P25Phase2ScramblerMode string  `json:"p25_phase2_scrambler_mode,omitempty"`
+	P25Phase2SoftDecision  string  `json:"p25_phase2_soft_decision,omitempty"`
 	NXDNViterbiMode        string  `json:"nxdn_viterbi_mode,omitempty"`
 	NXDNDeviationHz        float64 `json:"nxdn_deviation_hz,omitempty"`
 	EDACSBCHMode           string  `json:"edacs_bch_mode,omitempty"`

--- a/internal/tui/panels/settings.go
+++ b/internal/tui/panels/settings.go
@@ -194,14 +194,14 @@ fecRefresh:
 	// to) the FEC tab — the hash gate keeps the cost negligible.
 	if p.tab == tabFEC {
 		h := hashRows(s.Systems, func(sys client.SystemDTO) string {
-			return fmt.Sprintf("%s|%s|%d|%s|%s|%s|%s|%s|%s|%s|%s|%s|%.1f|%s",
+			return fmt.Sprintf("%s|%s|%d|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%.1f|%s",
 				sys.Name, sys.Protocol,
 				sys.TETRAColourCode, sys.TETRAChannel,
 				sys.TETRAChannelCoding,
 				sys.LTRFCSMode, sys.LTRManchesterMode,
 				sys.P25Phase1DemodMode,
 				sys.P25Phase2TrellisMode, sys.P25Phase2RSMode,
-				sys.P25Phase2ScramblerMode,
+				sys.P25Phase2ScramblerMode, sys.P25Phase2SoftDecision,
 				sys.NXDNViterbiMode,
 				sys.NXDNDeviationHz,
 				sys.EDACSBCHMode)
@@ -473,6 +473,7 @@ func fecSummary(s client.SystemDTO) string {
 		parts = append(parts, "trellis: "+orDefault(s.P25Phase2TrellisMode, "on"))
 		parts = append(parts, "rs: "+orDefault(s.P25Phase2RSMode, "off"))
 		parts = append(parts, "scrambler: "+orDefault(s.P25Phase2ScramblerMode, "on"))
+		parts = append(parts, "soft: "+orDefault(s.P25Phase2SoftDecision, "off"))
 	case "nxdn":
 		parts = append(parts, "viterbi: "+orDefault(s.NXDNViterbiMode, "spec"))
 		if s.NXDNDeviationHz > 0 {

--- a/internal/voice/composer/composer.go
+++ b/internal/voice/composer/composer.go
@@ -502,11 +502,12 @@ func (c *Composer) handleStart(parent context.Context, cs trunking.CallStart) {
 		go c.runDMRVoiceChain(chainCtx, cs.DeviceSerial, iqCh, rateHzF, cs.Grant.GroupID, cs.Grant.DMRInterleavedVoice, ch.done)
 	case isP25P2Voice:
 		macCfg := p25p2.MACDecodeConfig{
-			Trellis:    p25p2.TrellisMode(cs.Grant.P25Phase2Decode.Trellis),
-			RS:         p25p2.RSMode(cs.Grant.P25Phase2Decode.RS),
-			Interleave: p25p2.InterleaveMode(cs.Grant.P25Phase2Decode.Interleave),
-			Scrambler:  p25p2.ScramblerMode(cs.Grant.P25Phase2Decode.Scrambler),
-			Seed:       cs.Grant.P25Phase2Decode.Seed,
+			Trellis:      p25p2.TrellisMode(cs.Grant.P25Phase2Decode.Trellis),
+			RS:           p25p2.RSMode(cs.Grant.P25Phase2Decode.RS),
+			Interleave:   p25p2.InterleaveMode(cs.Grant.P25Phase2Decode.Interleave),
+			Scrambler:    p25p2.ScramblerMode(cs.Grant.P25Phase2Decode.Scrambler),
+			Seed:         cs.Grant.P25Phase2Decode.Seed,
+			SoftDecision: cs.Grant.P25Phase2Decode.SoftDecision,
 		}
 		go c.runP25Phase2VoiceChain(chainCtx, cs.DeviceSerial, cs.Grant.System, macCfg, iqCh, rateHzF, ch.done)
 	case isP25P1Voice:

--- a/internal/voice/composer/p25p2_voice.go
+++ b/internal/voice/composer/p25p2_voice.go
@@ -193,64 +193,86 @@ func (c *Composer) runP25Phase2VoiceChain(ctx context.Context, serial string, sy
 		macRSValid       atomic.Uint64
 		slotHist         [slotHistLen]atomic.Uint64
 	)
-	rx := p25p2rx.New(p25p2rx.Options{
+	// drainSuperframes runs the shared per-superframe voice + MAC census
+	// body. It is driven by the hard DibitSink or, when the grant requests
+	// soft-decision demod (issue #915), the soft SoftSink whose superframes
+	// carry per-symbol soft differentials in Subframe.Soft that the MAC
+	// decode path picks up automatically. The census body is identical
+	// either way, so both paths stay in lock-step.
+	drainSuperframes := func(sfs []p25p2.Superframe) {
+		for _, sf := range sfs {
+			superframesSeen.Add(1)
+			for _, sub := range sf.Subframes {
+				// Census every sub-frame's slot type — including
+				// SlotTypeUnknown and MAC types — before the voice gate,
+				// so the end-of-call census can show whether ISCH ever
+				// classified a MAC slot (#813).
+				if int(sub.SlotType) < slotHistLen {
+					slotHist[sub.SlotType].Add(1)
+				}
+				if sub.SlotType.IsMAC() {
+					macSubframesSeen.Add(1)
+				}
+				if !sub.SlotType.IsVoice() {
+					continue
+				}
+				voiceSubframes.Add(1)
+				bt.onVoice(0)
+				if rs == nil {
+					continue
+				}
+				frames, errBits, err := p25p2.ExtractVoiceFrames(sub)
+				if errBits > 0 {
+					corrErrBits.Add(uint64(errBits))
+				}
+				if err != nil {
+					uncorrectableSubframes.Add(1)
+					c.log.Debug("composer: p25p2 voice extract uncorrectable subframe",
+						"serial", serial, "err", err)
+				}
+				for _, f := range frames {
+					if f == nil {
+						continue
+					}
+					if werr := rs.WriteRawFrame(serial, f); werr != nil {
+						c.log.Warn("composer: p25p2 raw-frame write failed",
+							"serial", serial, "err", werr)
+					}
+				}
+			}
+			// The talker alias, in-call source, and encryption-sync
+			// MAC PDUs that interleave with voice are decoded by the
+			// shared dispatcher (same path the signalling follower
+			// runs off the traffic channel, #376). rsValid counts how
+			// many carried a clean outer RS(24,16,9) parity — the
+			// framing-health signal the end-of-call census reports
+			// (issue #915).
+			nDec, nRS := dispatcher.Dispatch(sf, macCfg)
+			macPDUsDecoded.Add(uint64(nDec))
+			macRSValid.Add(uint64(nRS))
+		}
+	}
+
+	// Build the receiver on the hard slicer by default; when the grant
+	// carries the soft-decision flag (issue #915) wire the soft sink so the
+	// receiver emits per-symbol soft differentials and the SuperframeDecoder
+	// carries them into Subframe.Soft via ProcessSoft.
+	rxOpts := p25p2rx.Options{
 		SampleRateHz: symbolHz,
 		ClockMode:    p25p2rx.ClockGardner,
 		GardnerGain:  p25p2VoiceGardnerGain,
-		DibitSink: func(dibits []uint8, baseIdx int) {
-			for _, sf := range sfDec.Process(dibits, baseIdx) {
-				superframesSeen.Add(1)
-				for _, sub := range sf.Subframes {
-					// Census every sub-frame's slot type — including
-					// SlotTypeUnknown and MAC types — before the voice gate,
-					// so the end-of-call census can show whether ISCH ever
-					// classified a MAC slot (#813).
-					if int(sub.SlotType) < slotHistLen {
-						slotHist[sub.SlotType].Add(1)
-					}
-					if sub.SlotType.IsMAC() {
-						macSubframesSeen.Add(1)
-					}
-					if !sub.SlotType.IsVoice() {
-						continue
-					}
-					voiceSubframes.Add(1)
-					bt.onVoice(0)
-					if rs == nil {
-						continue
-					}
-					frames, errBits, err := p25p2.ExtractVoiceFrames(sub)
-					if errBits > 0 {
-						corrErrBits.Add(uint64(errBits))
-					}
-					if err != nil {
-						uncorrectableSubframes.Add(1)
-						c.log.Debug("composer: p25p2 voice extract uncorrectable subframe",
-							"serial", serial, "err", err)
-					}
-					for _, f := range frames {
-						if f == nil {
-							continue
-						}
-						if werr := rs.WriteRawFrame(serial, f); werr != nil {
-							c.log.Warn("composer: p25p2 raw-frame write failed",
-								"serial", serial, "err", werr)
-						}
-					}
-				}
-				// The talker alias, in-call source, and encryption-sync
-				// MAC PDUs that interleave with voice are decoded by the
-				// shared dispatcher (same path the signalling follower
-				// runs off the traffic channel, #376). rsValid counts how
-				// many carried a clean outer RS(24,16,9) parity — the
-				// framing-health signal the end-of-call census reports
-				// (issue #915).
-				nDec, nRS := dispatcher.Dispatch(sf, macCfg)
-				macPDUsDecoded.Add(uint64(nDec))
-				macRSValid.Add(uint64(nRS))
-			}
-		},
-	})
+	}
+	if macCfg.SoftDecision {
+		rxOpts.SoftDecision = true
+		rxOpts.SoftSink = func(dibits []uint8, soft []complex64, baseIdx int) {
+			drainSuperframes(sfDec.ProcessSoft(dibits, soft, baseIdx))
+		}
+	} else {
+		rxOpts.DibitSink = func(dibits []uint8, baseIdx int) {
+			drainSuperframes(sfDec.Process(dibits, baseIdx))
+		}
+	}
+	rx := p25p2rx.New(rxOpts)
 
 	touchTicker := time.NewTicker(c.touchEvery)
 	defer touchTicker.Stop()

--- a/web/configbuilder/src/sections/Trunking.tsx
+++ b/web/configbuilder/src/sections/Trunking.tsx
@@ -38,7 +38,7 @@ const PROTOCOL_KNOBS: (keyof SystemConfig)[] = [
   "TETRAColourCode", "TETRAChannel", "TETRAChannelCoding", "TETRAClockMode",
   "LTRFCSMode", "LTRManchesterMode", "P25Phase1DemodMode", "DMRInterleavedVoice",
   "P25Phase2TrellisMode", "P25Phase2RSMode", "P25Phase2InterleaveMode",
-  "P25Phase2ScramblerMode", "P25Phase2ClockMode", "NXDNViterbiMode",
+  "P25Phase2ScramblerMode", "P25Phase2SoftDecision", "P25Phase2ClockMode", "NXDNViterbiMode",
   "NXDNDeviationHz", "EDACSBCHMode", "MPT1327BCHMode", "MPT1327CWSCTolerance",
   "MotorolaBCHMode", "DStarFECMode",
 ];


### PR DESCRIPTION
## Summary

Makes the soft-decision Phase 2 MAC decode path (merged in #982) operator-usable via a new per-system knob `p25_phase2_soft_decision` (on/off, default **off**), mirroring `p25_phase2_scrambler_mode`. When enabled, the Phase 2 traffic-channel receiver is built with soft-decision demod so per-symbol soft differentials reach the per-bit soft Viterbi on the MAC trellis, recovering the ~1.5–2 dB of coding gain the hard slicer discards (issue #915). Default off keeps today's hard path byte-for-byte.

## Changes

- **Config plumbing** (mirrors the scrambler knob at every hop so the flag travels via the grant to the receiver):
  - `config.SystemConfig` + `trunking.System` field + `daemon.go` copy
  - `receiver.ParseSoftDecision` (string→bool helper)
  - `grant.P25Phase2Decode.SoftDecision` + `phase2.MACDecodeConfig.SoftDecision`
  - phase2 `ControlChannel.softDecision` + `SetSoftDecision`, stamped in `publishGrant`
  - phase1 **hybrid** CC (Phase 1 control channel granting Phase 2 traffic — MMR-class topology) stamps it onto its TDMA voice grants too
  - `ccdecoder` + `widebandt2` parse the config string and call the setter
- **Receiver wiring:** the voice composer (`p25p2_voice.go`) and sigfollow (`manager.go`) select `SoftSink`→`SuperframeDecoder.ProcessSoft` when the grant requests it; otherwise the unchanged hard `DibitSink` path. Census/voice-extraction body is factored into one shared closure so both paths stay in lock-step.
- **Config surfaces:** siglab metadata key, configbuilder (advanced + fieldmeta), API/TUI DTOs + settings display, web config-builder knob list.
- **Docs:** `config.example.yaml`, `docs/opt-in-features.md`, `docs/user-guide-windows.md`, and a `CHANGELOG.md` Unreleased bullet.

## Test plan

- [x] `make vet test` is green locally — `go build ./...` + `go vet ./...` clean; all touched packages pass (`framing`, `phase2`, `receiver`, `voice/composer`, `sigfollow`, `scanner/ccdecoder`, `scanner/widebandt2`, `config`, `trunking`, `configbuilder`, `siglab`, `tui`, `api`, `phase1`).
- [ ] `make integration` — not run in this environment; change is additive/opt-in and default-off, so the hard path (which the integration suite exercises) is byte-identical.
- [x] Added or updated tests where appropriate:
  - `ParseSoftDecision` string-contract test.
  - Grant-stamping test: a Phase 2 `ControlChannel` publishes `P25Phase2Decode.SoftDecision=false` by default and `true` after `SetSoftDecision(true)` — the only channel by which the composer/sigfollow learn to build a soft receiver.
  - End-to-end receiver soft path is covered by `softdecision_test.go` from #982.
- [ ] Smoke-tested against real hardware — n/a (no SDR/USB/vocoder code changed; demod path already validated in #982).

## Breaking changes

None. New config key defaults to off; with it unset the decode is byte-for-byte the historical hard-slicer behaviour. No existing key, flag, endpoint, or default changes.

## Docs / CHANGELOG

- [x] Added a `## [Unreleased]` bullet to `CHANGELOG.md` (user-visible new config key)
- [x] Updated `docs/` (`opt-in-features.md`, `user-guide-windows.md`) and `config.example.yaml`

## Linked issues

Refs #915 — the knob makes the soft-decision front-end usable in the daemon; recovering the reporter's source RIDs still depends on a higher-SNR capture (the ground-truth capture sits ~10 dB below threshold, more than soft-decision's ~2 dB closes), so this is `Refs`, not `Closes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WDeT5T2tP4r8XbzgP8wCQV

---
_Generated by [Claude Code](https://claude.ai/code/session_01WDeT5T2tP4r8XbzgP8wCQV)_