### PR TITLE
feat(p25): surface Motorola FACCH-S alias ciphertext as cryptanalysis ground truth (#773)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **Motorola P25 talker-alias ciphertext is logged as cryptanalysis ground
+  truth.** When a Motorola FACCH-S talker alias reassembles on a Phase 2
+  traffic channel, GopherTrunk now emits a `p25p2 alias ciphertext` log line
+  carrying the source RID, talkgroup, and the reassembled encoded-alias bytes
+  (`encoded_hex`) — the `rid,talkgroup,encoded_hex,alias` record the alias
+  cipher analysis consumes. The proprietary alias cipher is still gated
+  (unsolved, so the decoded name stays blank), but this lets an operator
+  harvest the chosen-plaintext / known-RID corpus needed to finish it
+  (`research/p25-talker-alias-chosen-plaintext.md`) using GopherTrunk alone
+  instead of SDRTrunk (#773).
 - **TETRA voice now decodes to audible audio, including up to 4 concurrent
   calls on one carrier.** The TETRA voice path recovers each traffic burst,
   channel-decodes TCH/S, and renders it with the clean-room ACELP vocoder

--- a/internal/radio/p25/motorola/alias.go
+++ b/internal/radio/p25/motorola/alias.go
@@ -193,6 +193,14 @@ type Message struct {
 	SystemID uint16
 	RadioID  uint32
 	Alias    string
+	// Encoded is the reassembled per-byte-cipher region — the exactly
+	// 2n encoded-alias bytes, with the trailing CRC-16 stripped. It is
+	// the *ciphertext* the proprietary cipher operates on, independent of
+	// whether that cipher is solved (CipherVerified), so callers can log
+	// it as chosen-plaintext / known-RID ground truth to finish the
+	// cryptanalysis (#773). This is the same shape the cryptolab `alias
+	// sweep` solver consumes (pure cipher output, no CRC).
+	Encoded []byte
 	// AliasReliable reports whether the decoded alias can be trusted as a
 	// confirmed name. It is true only when the decode is all printable
 	// ASCII (no bit-error corruption hallmarks, #711) AND the cipher
@@ -249,6 +257,7 @@ func DecodeMessage(msg []byte) (Message, bool) {
 		SystemID:      sysID,
 		RadioID:       rid,
 		Alias:         alias,
+		Encoded:       append([]byte(nil), encoded...),
 		AliasReliable: aliasReliable,
 		CRCOK:         crcOK,
 	}, true

--- a/internal/radio/p25/motorola/alias_test.go
+++ b/internal/radio/p25/motorola/alias_test.go
@@ -192,6 +192,44 @@ func TestRealSampleYieldsRIDButNoConfidentAlias(t *testing.T) {
 	}
 }
 
+// TestDecodeMessageExposesEncodedCiphertext pins the reassembled cipher
+// region on the decoded message (#773). Message.Encoded must be exactly
+// the 2n encoded-alias bytes — the SUID prefix and the trailing CRC-16
+// stripped — so a caller can surface it as chosen-plaintext / known-RID
+// ground truth for the cipher cryptanalysis regardless of whether the
+// cipher itself decodes. Uses the real #376 reassembled stream for RID
+// 200062 (24 cipher bytes between the 7-byte SUID and the 2-byte CRC).
+func TestDecodeMessageExposesEncodedCiphertext(t *testing.T) {
+	msg := []byte{
+		0xBE, 0xE0, 0x01, 0x64, 0x03, 0x0D, 0x7E, // SUID (RID 200062)
+		0x24, 0x44, 0xF6, 0xFF, 0x2F, 0xA9, 0xAC, 0x3E, 0xC3, 0x44,
+		0x32, 0xFA, 0x63, 0xCC, 0x81, 0xC3, 0xC5, 0xD9, 0x6A, 0x96, // encoded alias
+		0x00, 0x00, 0x00, 0x00, // cipher tail
+		0x00, 0x00, // CRC-16
+	}
+	m, ok := DecodeMessage(msg)
+	if !ok {
+		t.Fatal("DecodeMessage returned ok=false")
+	}
+	want := msg[7:31] // between the 7-byte SUID and the 2-byte CRC tail
+	if len(m.Encoded) != len(want) {
+		t.Fatalf("Encoded len = %d, want %d", len(m.Encoded), len(want))
+	}
+	for i := range want {
+		if m.Encoded[i] != want[i] {
+			t.Fatalf("Encoded[%d] = %02X, want %02X\n got % X\nwant % X",
+				i, m.Encoded[i], want[i], m.Encoded, want)
+		}
+	}
+	// Must be an independent copy, not an alias into the caller's buffer.
+	if len(m.Encoded) > 0 {
+		m.Encoded[0] ^= 0xFF
+		if msg[7] == m.Encoded[0] {
+			t.Error("Encoded aliases the input slice; want an independent copy")
+		}
+	}
+}
+
 func TestDecodeMessageTooShort(t *testing.T) {
 	if _, ok := DecodeMessage([]byte{0x00, 0x01}); ok {
 		t.Error("expected ok=false for too-short input")

--- a/internal/radio/p25/phase2/talker_alias.go
+++ b/internal/radio/p25/phase2/talker_alias.go
@@ -273,19 +273,50 @@ func (p MACPDU) AsMotorolaAliasData() (MotorolaAliasData, bool) {
 	}, true
 }
 
+// MotorolaAliasResult is the outcome of feeding a fragment to a
+// MotorolaAliasAssembler. Complete is true once the header and every
+// data block of the same sequence have arrived and the message
+// reassembled; the other fields are meaningful only then.
+type MotorolaAliasResult struct {
+	// Alias is the decoded talker-alias string (best-effort printable
+	// ASCII). While the proprietary cipher is unverified it is typically
+	// empty or garbage — see Reliable.
+	Alias string
+	// SourceID is the radio (subscriber) ID the alias belongs to,
+	// recovered from the byte-aligned message prefix.
+	SourceID uint32
+	// TalkgroupID is the talkgroup carried in the alias header PDU.
+	TalkgroupID uint16
+	// Encoded is the reassembled cipher region (the 2n encoded-alias
+	// bytes, CRC stripped) — chosen-plaintext / known-RID ground truth
+	// for the cipher cryptanalysis (#773), surfaced regardless of whether
+	// the cipher decodes.
+	Encoded []byte
+	// CRCOK reports whether the reassembled message's trailing CRC-16
+	// matched. Advisory (#376).
+	CRCOK bool
+	// Reliable is true only when the decode is clean printable ASCII AND
+	// the cipher is verified; false while the cipher is gated (#773).
+	Reliable bool
+	// Complete is true once a full alias message reassembled.
+	Complete bool
+}
+
 // MotorolaAliasAssembler reassembles the real Motorola FACCH-S talker
 // alias for one active call. Construct one per voice chain; it is
 // single-goroutine like phase1.MotorolaTalkerAliasBuf. AddHeader /
-// AddData return (alias, sourceRID, reliable, true) once the header and
-// every data block of the same sequence have arrived. reliable is false
-// when the decoded alias holds non-ASCII-printable characters (bit-error
-// corruption surviving the CRC, #711).
+// AddData return a MotorolaAliasResult whose Complete is true once the
+// header and every data block of the same sequence have arrived. Reliable
+// is false when the decoded alias holds non-ASCII-printable characters
+// (bit-error corruption surviving the CRC, #711) or the cipher is still
+// gated (#773).
 type MotorolaAliasAssembler struct {
 	now func() time.Time
 
 	haveHeader bool
 	sequence   uint8
 	blockCount uint8
+	talkgroup  uint16
 	header     []byte
 	blocks     map[uint8][]byte
 	leads      map[uint8]uint8 // per-block leading cipher nibble
@@ -307,10 +338,10 @@ func NewMotorolaAliasAssembler(now func() time.Time) *MotorolaAliasAssembler {
 
 // AddHeader feeds a decoded alias header. A header with a new sequence
 // resets any in-flight data blocks.
-func (a *MotorolaAliasAssembler) AddHeader(h MotorolaAliasHeader) (string, uint32, bool, bool) {
+func (a *MotorolaAliasAssembler) AddHeader(h MotorolaAliasHeader) MotorolaAliasResult {
 	a.evictStale()
 	if h.BlockCount == 0 || h.BlockCount > aliasMaxBlocks {
-		return "", 0, false, false
+		return MotorolaAliasResult{}
 	}
 	if !a.haveHeader || h.Sequence != a.sequence {
 		a.blocks = make(map[uint8][]byte)
@@ -319,6 +350,7 @@ func (a *MotorolaAliasAssembler) AddHeader(h MotorolaAliasHeader) (string, uint3
 	a.haveHeader = true
 	a.sequence = h.Sequence
 	a.blockCount = h.BlockCount
+	a.talkgroup = h.TalkgroupID
 	a.header = append([]byte(nil), h.Fragment...)
 	a.updated = a.now()
 	return a.tryComplete()
@@ -326,11 +358,11 @@ func (a *MotorolaAliasAssembler) AddHeader(h MotorolaAliasHeader) (string, uint3
 
 // AddData feeds a decoded alias data block. Blocks whose sequence
 // doesn't match the current header are ignored.
-func (a *MotorolaAliasAssembler) AddData(d MotorolaAliasData) (string, uint32, bool, bool) {
+func (a *MotorolaAliasAssembler) AddData(d MotorolaAliasData) MotorolaAliasResult {
 	a.evictStale()
 	if !a.haveHeader || d.Sequence != a.sequence || d.BlockNumber == 0 ||
 		d.BlockNumber > a.blockCount {
-		return "", 0, false, false
+		return MotorolaAliasResult{}
 	}
 	a.blocks[d.BlockNumber] = append([]byte(nil), d.Fragment...)
 	a.leads[d.BlockNumber] = d.LeadNibble
@@ -340,28 +372,39 @@ func (a *MotorolaAliasAssembler) AddData(d MotorolaAliasData) (string, uint32, b
 
 // tryComplete reassembles and decodes once the header and every data
 // block are present.
-func (a *MotorolaAliasAssembler) tryComplete() (string, uint32, bool, bool) {
+func (a *MotorolaAliasAssembler) tryComplete() MotorolaAliasResult {
 	if !a.haveHeader || len(a.blocks) < int(a.blockCount) {
-		return "", 0, false, false
+		return MotorolaAliasResult{}
 	}
 	blocks := make([][]byte, 0, a.blockCount)
 	leads := make([]uint8, 0, a.blockCount)
 	for i := uint8(1); i <= a.blockCount; i++ {
 		b, ok := a.blocks[i]
 		if !ok {
-			return "", 0, false, false
+			return MotorolaAliasResult{}
 		}
 		blocks = append(blocks, b)
 		leads = append(leads, a.leads[i])
 	}
+	talkgroup := a.talkgroup
 	decoded, ok := motorola.DecodeMessage(assembleMotorolaAliasMessage(a.header, blocks, leads))
 	if !ok {
-		return "", 0, false, false
+		return MotorolaAliasResult{}
 	}
 	a.reset()
 	// An empty alias (all-non-printable decode) still completes so the
-	// source RID is reported; the publish path drops the empty alias.
-	return decoded.Alias, decoded.RadioID, decoded.AliasReliable, true
+	// source RID and the reassembled ciphertext are reported; the publish
+	// path drops the empty alias string, but the ciphertext is surfaced as
+	// cryptanalysis ground truth regardless (#773).
+	return MotorolaAliasResult{
+		Alias:       decoded.Alias,
+		SourceID:    decoded.RadioID,
+		TalkgroupID: talkgroup,
+		Encoded:     decoded.Encoded,
+		CRCOK:       decoded.CRCOK,
+		Reliable:    decoded.AliasReliable,
+		Complete:    true,
+	}
 }
 
 // assembleMotorolaAliasMessage rebuilds the packed Motorola alias message
@@ -420,6 +463,7 @@ func (a *MotorolaAliasAssembler) reset() {
 	a.haveHeader = false
 	a.sequence = 0
 	a.blockCount = 0
+	a.talkgroup = 0
 	a.header = nil
 	a.blocks = make(map[uint8][]byte)
 	a.leads = make(map[uint8]uint8)

--- a/internal/radio/p25/phase2/talker_alias_test.go
+++ b/internal/radio/p25/phase2/talker_alias_test.go
@@ -1,6 +1,7 @@
 package phase2
 
 import (
+	"encoding/hex"
 	"testing"
 	"time"
 
@@ -137,20 +138,58 @@ func TestMotorolaAliasAssemblerYieldsRID(t *testing.T) {
 	a := NewMotorolaAliasAssembler(nil)
 
 	h, _ := macPDU(t, aliasHeaderMSG...).AsMotorolaAliasHeader()
-	if _, _, _, done := a.AddHeader(h); done {
+	if a.AddHeader(h).Complete {
 		t.Fatal("header alone (2 blocks pending) must not complete")
 	}
 	d1, _ := macPDU(t, aliasData1MSG...).AsMotorolaAliasData()
-	if _, _, _, done := a.AddData(d1); done {
+	if a.AddData(d1).Complete {
 		t.Fatal("1 of 2 blocks must not complete")
 	}
 	d2, _ := macPDU(t, aliasData2MSG...).AsMotorolaAliasData()
-	_, rid, _, done := a.AddData(d2)
-	if !done {
+	res := a.AddData(d2)
+	if !res.Complete {
 		t.Fatal("both blocks present should complete the alias")
 	}
-	if rid != 200062 {
-		t.Errorf("source RID = %d, want 200062", rid)
+	if res.SourceID != 200062 {
+		t.Errorf("source RID = %d, want 200062", res.SourceID)
+	}
+}
+
+// TestMotorolaAliasAssemblerExposesCiphertext pins the chosen-plaintext /
+// known-RID ground-truth record surfaced on completion (#773). The
+// proprietary alias cipher is gated (motorola.CipherVerified == false), so
+// the decoded alias string is unreliable and typically empty — but the
+// reassembled *ciphertext* (the 2n encoded-alias bytes, CRC stripped)
+// paired with the RID and talkgroup is exactly the corpus row the cipher
+// cryptanalysis consumes, and must be surfaced regardless of decode
+// success so an operator can capture it with GopherTrunk alone rather than
+// SDRTrunk. Before this change the completion result carried no ciphertext
+// at all.
+func TestMotorolaAliasAssemblerExposesCiphertext(t *testing.T) {
+	a := NewMotorolaAliasAssembler(nil)
+
+	h, _ := macPDU(t, aliasHeaderMSG...).AsMotorolaAliasHeader()
+	a.AddHeader(h)
+	d1, _ := macPDU(t, aliasData1MSG...).AsMotorolaAliasData()
+	a.AddData(d1)
+	d2, _ := macPDU(t, aliasData2MSG...).AsMotorolaAliasData()
+	res := a.AddData(d2)
+
+	if !res.Complete {
+		t.Fatal("both blocks present should complete the alias")
+	}
+	if res.SourceID != 200062 {
+		t.Errorf("source RID = %d, want 200062", res.SourceID)
+	}
+	if res.TalkgroupID != 20208 {
+		t.Errorf("talkgroup = %d, want 20208", res.TalkgroupID)
+	}
+	// The 2n-byte cipher region of the reassembled SDRTrunk ground-truth
+	// stream (bytes after the 7-byte SUID, before the 2-byte CRC tail).
+	wantHex := "2444f6ff2fa9ac3ec34432fa63cc81c3c5d96a9600000000"
+	gotHex := hex.EncodeToString(res.Encoded)
+	if gotHex != wantHex {
+		t.Errorf("encoded ciphertext = %s, want %s", gotHex, wantHex)
 	}
 }
 
@@ -208,7 +247,7 @@ func TestMotorolaAliasAssemblerWrongOpcodeRejected(t *testing.T) {
 	// A 0x95 PDU before any header must not complete or panic.
 	d, _ := macPDU(t, aliasData1MSG...).AsMotorolaAliasData()
 	a := NewMotorolaAliasAssembler(nil)
-	if _, _, _, done := a.AddData(d); done {
+	if a.AddData(d).Complete {
 		t.Error("data before header must not complete")
 	}
 }

--- a/internal/sigfollow/dispatcher.go
+++ b/internal/sigfollow/dispatcher.go
@@ -191,19 +191,48 @@ func (d *MACDispatcher) Dispatch(sf p25p2.Superframe, macCfg p25p2.MACDecodeConf
 		// reassembler, data blocks (0x95) complete it, and the source RID
 		// falls out of the decoded message prefix (#376).
 		if h, ok := pdu.AsMotorolaAliasHeader(); ok {
-			if alias, src, reliable, complete := d.motorolaAliasAsm.AddHeader(h); complete {
-				d.publishTalkerAlias(src, alias, reliable)
+			if res := d.motorolaAliasAsm.AddHeader(h); res.Complete {
+				d.completeMotorolaAlias(res)
 			}
 			continue
 		}
 		if dat, ok := pdu.AsMotorolaAliasData(); ok {
-			if alias, src, reliable, complete := d.motorolaAliasAsm.AddData(dat); complete {
-				d.publishTalkerAlias(src, alias, reliable)
+			if res := d.motorolaAliasAsm.AddData(dat); res.Complete {
+				d.completeMotorolaAlias(res)
 			}
 			continue
 		}
 	}
 	return len(decoded), rsValidCount
+}
+
+// completeMotorolaAlias handles a fully reassembled Motorola FACCH-S
+// alias. It publishes the decoded alias (when non-empty) and always emits
+// the reassembled ciphertext as cryptanalysis ground truth.
+//
+// The proprietary alias cipher is still gated (motorola.CipherVerified is
+// false), so the decoded Alias is typically empty on real traffic and the
+// alias card shows nothing (#773). But the reassembled *ciphertext* — the
+// 2n encoded-alias bytes paired with the known source RID and talkgroup —
+// is exactly the record the cipher cryptanalysis needs, and the
+// chosen-plaintext capture procedure (research/p25-talker-alias-chosen-
+// plaintext.md) names GopherTrunk as a valid capture receiver. Surfacing
+// it here lets an operator harvest the `rid,talkgroup,encoded_hex,alias`
+// corpus from live air with GopherTrunk alone, instead of falling back to
+// SDRTrunk — the dependency #773 is trying to retire. It is logged for
+// every completed alias regardless of decode success; multiple identical
+// lines across keyups are expected and let the capturer confirm the
+// ciphertext is stable (deterministic), as the procedure's sanity check
+// requires.
+func (d *MACDispatcher) completeMotorolaAlias(res p25p2.MotorolaAliasResult) {
+	if len(res.Encoded) > 0 {
+		d.log.Info(d.logPrefix+": p25p2 alias ciphertext",
+			"system", d.system, "serial", d.serial,
+			"rid", res.SourceID, "talkgroup", res.TalkgroupID,
+			"encoded_hex", hex.EncodeToString(res.Encoded),
+			"crc_ok", res.CRCOK, "reliable", res.Reliable)
+	}
+	d.publishTalkerAlias(res.SourceID, res.Alias, res.Reliable)
 }
 
 // publishTalkerAlias mirrors phase2.ControlChannel.publishTalkerAlias: a

--- a/research/p25-talker-alias-chosen-plaintext.md
+++ b/research/p25-talker-alias-chosen-plaintext.md
@@ -41,6 +41,13 @@ equipment.
   3,607-pair dataset**. For each transmission we need the **reassembled
   encoded-alias bytes (the ciphertext hex)** paired with the alias string you
   programmed.
+  - **GopherTrunk emits this natively.** When a Motorola FACCH-S alias
+    reassembles on a followed Phase 2 traffic channel, GopherTrunk logs a
+    `p25p2 alias ciphertext` line with `rid`, `talkgroup`, and `encoded_hex`
+    — the ciphertext hex this procedure needs. Grep the daemon log for
+    `alias ciphertext` while capturing; each keyup produces one line, and the
+    `encoded_hex` must be byte-identical across the 2–3 keyups (the sanity
+    check below). No SDRTrunk required.
 
 ## Core procedure (repeat per alias)
 1. In CPS, set the radio's talker alias to the next string from the list below.


### PR DESCRIPTION
## Summary

The Motorola P25 talker-alias cipher (#773) is an unsolved, clean-room-gated research problem: reassembly, framing, live wiring, and the analysis tooling are all already in place, but the cipher itself **cannot be verified from the data on hand** — the accumulator low-byte update has *zero* observed transitions in every corpus captured so far, an observability floor rather than an effort limit (see `research/p25-talker-alias-cryptanalysis.md`). So the decoded alias stays blank on real traffic and `motorola.CipherVerified` stays `false`.

The documented way forward is a **chosen-plaintext capture** from a programmable Motorola radio (`research/p25-talker-alias-chosen-plaintext.md`), which names GopherTrunk as a valid capture receiver — except GT couldn't actually produce the record it needs. On completion the dispatcher only published the (empty, gated) alias string and **dropped the reassembled ciphertext**, so a field tester had to fall back to SDRTrunk to read the encoded bytes. That's exactly the SDRTrunk dependency #773 is trying to retire.

This PR closes that gap: it surfaces the `rid,talkgroup,encoded_hex,alias` ground-truth record for every completed FACCH-S alias, so an operator can harvest the corpus that finishes the cryptanalysis using GopherTrunk alone. **It does not touch the cipher, `CipherVerified`, or the reliability gate** — a possibly-wrong table still never surfaces a fabricated name.

## Changes

- **`internal/radio/p25/motorola/alias.go`** — `Message` gains an `Encoded []byte` field: the reassembled `2n`-byte cipher region with the SUID prefix and trailing CRC-16 stripped, the exact shape the cryptolab `alias sweep` solver consumes. Additive; `DecodeMessage` populates it with an independent copy.
- **`internal/radio/p25/phase2/talker_alias.go`** — `MotorolaAliasAssembler.AddHeader`/`AddData`/`tryComplete` now return a `MotorolaAliasResult` struct (alias, source RID, talkgroup, ciphertext, CRC, reliable, complete) instead of a bare `(string, uint32, bool, bool)` tuple, threading the talkgroup from the header and the ciphertext from the decode.
- **`internal/sigfollow/dispatcher.go`** — a new `completeMotorolaAlias` helper emits a `p25p2 alias ciphertext` log line — `rid`, `talkgroup`, `encoded_hex`, `crc_ok` — for every completed alias, regardless of whether the gated cipher decodes. Repeated identical lines across keyups are intentional (they let the capturer confirm the ciphertext is stable, the procedure's sanity check).
- **`research/p25-talker-alias-chosen-plaintext.md`** — documents that GT now emits this natively (grep the log for `alias ciphertext`).
- **`CHANGELOG.md`** — `[Unreleased]` / Added bullet.

## Test plan

- [x] `make vet test` is green locally.
- [ ] `make integration` — n/a (no daemon/DSP path changed; this is a decode-side data-surfacing change).
- [x] Added tests (failing-first — they assert a capability that did not exist before):
  - `motorola.TestDecodeMessageExposesEncodedCiphertext` pins `Message.Encoded` to the 24-byte cipher region of the real #376 RID-200062 stream, and that it's an independent copy, not an alias into the caller's buffer.
  - `phase2.TestMotorolaAliasAssemblerExposesCiphertext` pins the same ciphertext plus RID `200062` and talkgroup `20208` reassembled from the golden header + data PDUs.
  - Existing assembler tests updated to the new `MotorolaAliasResult` return type.
- [ ] Smoke-tested against real hardware — n/a (no SDR/USB/vocoder code changed). End-to-end validation is a live chosen-plaintext capture, which is the follow-up this change enables.

## Breaking changes

None for operators. Internal API: `MotorolaAliasAssembler.AddHeader`/`AddData` now return `MotorolaAliasResult` instead of a 4-tuple — both call sites (the sigfollow dispatcher and the package tests) are updated in this PR. `motorola.Message` gains a field (additive). No config keys, CLI flags, endpoints, or default behaviour change.

## Docs / CHANGELOG

- [x] Added a `## [Unreleased]` bullet to `CHANGELOG.md`.
- [x] Updated `research/p25-talker-alias-chosen-plaintext.md`.

## Linked issues

Refs #773 — this unblocks the chosen-plaintext capture path that the cipher solve depends on; it deliberately does **not** claim to decode the alias, so it is `Refs`, not `Closes`. The cipher stays gated until an alias round-trips against ground truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019zPnpZBhjESXPo4DETCgMx

---
_Generated by [Claude Code](https://claude.ai/code/session_019zPnpZBhjESXPo4DETCgMx)_