### PR TITLE
fix(tetra): demux concurrent same-carrier voice by AACH usage marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,13 @@ for tagged releases.
   calls on one carrier.** The TETRA voice path recovers each traffic burst,
   channel-decodes TCH/S, and renders it with the clean-room ACELP vocoder
   (`tetra-acelp`), now bit-exact to the ETSI EN 300 395-2 reference. Each burst
-  is tagged with its TDMA timeslot (anchored to the synchronisation burst), and
-  the daemon registers up to four `cc:same-carrier:N` taps, so up to four
-  simultaneous calls on one control carrier — one per slot — record into their
-  own files instead of only one binding and the rest being dropped with
-  "no voice device available for grant". The same-carrier voice device serial
-  changes from `cc:same-carrier` to `cc:same-carrier:1..4`.
+  is tagged with its AACH downlink usage marker (the per-slot call identifier),
+  and the daemon registers up to four `cc:same-carrier:N` taps, so up to four
+  simultaneous calls on one control carrier — demultiplexed by matching each
+  call's grant usage marker — record into their own files instead of only one
+  binding and the rest being dropped with "no voice device available for grant".
+  The same-carrier voice device serial changes from `cc:same-carrier` to
+  `cc:same-carrier:1..4`.
 - **Event-driven raw-IQ auto-recording (`baseband.auto_record`).** The daemon
   can now capture a short slice of the control SDR's raw IQ whenever a
   classified event fires — `on_concurrent_calls: N` (N+ calls active at once),
@@ -97,6 +98,21 @@ for tagged releases.
   rather than a fixed slot 1 — the building block for issue #925.
 
 ### Fixed
+- **Concurrent same-carrier TETRA calls decoded as "DJ scratches" — most calls
+  produced only brief garbled fragments.** The per-slot demux dropped a burst
+  whose decoded TDMA timeslot did not match the call's *granted* timeslot, but on
+  real air the grant timeslot does not identify the physical slot (distinct calls
+  collide on one value; the synchronisation-burst slot anchor also jitters a
+  call's bursts across adjacent slot numbers), so most calls had their own speech
+  discarded as "off-slot" and recorded only the handful of frames decoded before
+  the slot grid anchored. The voice chain now demultiplexes concurrent calls by
+  the **AACH downlink usage marker** — the per-slot call identifier the AACH
+  broadcasts in every downlink slot, matched against the usage marker carried in
+  the call's grant — which cleanly separates simultaneous calls on one carrier.
+  A grant addressed without a usage marker, or a burst whose AACH does not decode,
+  falls back to CRC-gated single-call decoding so a call's speech is never dropped
+  on a guess. Verified against a real 5-capture same-carrier IQ set: the two
+  concurrent calls that the timeslot filter starved now recover their full audio.
 - **TETRA TCH/S class-2 CRC was computed wrong, so no on-air voice ever
   decoded.** The 8-bit CRC was a `G(X)=1+X³+X⁷` LFSR; the TETRA CRC
   (EN 300 395-2 §5.5.1) is a fixed parity-check matrix, so every received TCH/S

--- a/cmd/gophertrunk/tetra_multislot_replay_test.go
+++ b/cmd/gophertrunk/tetra_multislot_replay_test.go
@@ -68,9 +68,20 @@ func TestTETRAMultiSlotReplay(t *testing.T) {
 	var dibitsFed int
 	dibitRate := tetrarx.SymbolRate // 18000 symbols(=dibits)/sec
 
+	// Per-usage-marker accumulator: the AACH downlink usage marker is the demux
+	// key the live voice chain routes by (concurrent same-carrier calls each carry
+	// a distinct marker). Cross-check that CRC-valid speech clusters cleanly by
+	// marker, and that each marker maps to a single physical slot.
+	type usageAcc struct {
+		speechFrames [][]byte
+		crcBursts    int
+		slotHits     map[uint8]int
+	}
+	usage := map[uint8]*usageAcc{}
+
 	var totalBursts, anchoredBursts int
 	errsHist := map[string]int{}
-	extractor := tetra.NewTrafficExtractor(colourExt, func(frame []byte, slot uint8) {
+	extractor := tetra.NewTrafficExtractor(colourExt, func(frame []byte, slot, mark uint8) {
 		totalBursts++
 		if slot != 0 {
 			anchoredBursts++
@@ -87,11 +98,21 @@ func TestTETRAMultiSlotReplay(t *testing.T) {
 				errsHist["31+"]++
 			}
 		}
-		if slot < 1 || slot > 4 {
-			return
-		}
 		sfs := tetra.TCHSpeechFrames(frame)
 		if len(sfs) == 0 {
+			return
+		}
+		if mark >= tetra.DLUsageTraffic {
+			u := usage[mark]
+			if u == nil {
+				u = &usageAcc{slotHits: map[uint8]int{}}
+				usage[mark] = u
+			}
+			u.crcBursts++
+			u.speechFrames = append(u.speechFrames, sfs...)
+			u.slotHits[slot]++
+		}
+		if slot < 1 || slot > 4 {
 			return
 		}
 		s := &slots[slot]
@@ -167,6 +188,19 @@ func TestTETRAMultiSlotReplay(t *testing.T) {
 		if outDir != "" {
 			writeWav8kLocal(outDir+"/slot"+string(rune('0'+tn))+".wav", pcm)
 		}
+	}
+
+	// Per-usage-marker view: the live demux key. Each traffic marker should
+	// cluster on a single physical slot (one call = one marker = one slot).
+	var marks []int
+	for m := range usage {
+		marks = append(marks, int(m))
+	}
+	sort.Ints(marks)
+	for _, mi := range marks {
+		u := usage[uint8(mi)]
+		t.Logf("usage_marker %d: crc_bursts=%d speech_frames=%d slot_hits=%v",
+			mi, u.crcBursts, len(u.speechFrames), u.slotHits)
 	}
 }
 

--- a/internal/radio/tetra/cmce.go
+++ b/internal/radio/tetra/cmce.go
@@ -72,6 +72,7 @@ type VoiceGrant struct {
 	DestSSI        uint32 // 24-bit
 	CarrierNumber  uint16 // 12-bit
 	Timeslot       uint8  // 2-bit (0..3)
+	UsageMarker    uint8  // downlink usage marker (AACH §21.4.7); 0 = none
 	Group          bool
 	Emergency      bool
 	Encrypted      bool

--- a/internal/radio/tetra/control.go
+++ b/internal/radio/tetra/control.go
@@ -527,11 +527,12 @@ func (c *ControlChannel) publishGrant(g VoiceGrant) {
 			// trunking engine's Timeslot is 1-based with 0 reserved for
 			// "not applicable", so map 0..3 → 1..4. The voice tap uses it
 			// to pick the granted slot out of the 4-slot TDMA frame.
-			Timeslot:       g.Timeslot + 1,
-			Encrypted:      g.Encrypted,
-			Emergency:      g.Emergency,
-			TETRAColourExt: colourExt,
-			At:             c.now(),
+			Timeslot:         g.Timeslot + 1,
+			Encrypted:        g.Encrypted,
+			Emergency:        g.Emergency,
+			TETRAColourExt:   colourExt,
+			TETRAUsageMarker: g.UsageMarker,
+			At:               c.now(),
 		},
 	})
 	c.addStat(&c.stats.Grants, 1)

--- a/internal/radio/tetra/downlink.go
+++ b/internal/radio/tetra/downlink.go
@@ -221,6 +221,12 @@ func (c *ControlChannel) publishGrantFromMAC(m MACResource) {
 		DestSSI:       m.Address.SSI,
 		CarrierNumber: m.ChanAlloc.CarrierNumber,
 		Timeslot:      m.ChanAlloc.Timeslot & 0x3,
-		Encrypted:     m.Encrypted,
+		// The MAC address usage marker (present when the party is addressed by
+		// SSI+usage, §21.4.3.1) is the call's downlink usage marker — the reliable
+		// key the voice chain uses to demultiplex concurrent same-carrier calls by
+		// matching it against each traffic slot's AACH marker. Absent (0) on a
+		// plain-SSI grant, which falls the voice chain back to CRC-gated isolation.
+		UsageMarker: m.Address.UsageMarker,
+		Encrypted:   m.Encrypted,
 	})
 }

--- a/internal/radio/tetra/downlink_test.go
+++ b/internal/radio/tetra/downlink_test.go
@@ -75,6 +75,15 @@ func TestProcessDecodesGrantFromNCDB(t *testing.T) {
 	if grant.Timeslot != 2 { // chan-alloc timeslot 1 (0-based) → 1-based 2
 		t.Errorf("grant timeslot = %d, want 2", grant.Timeslot)
 	}
+	// The grant is addressed by SSI+usage (address type 6), so it carries the
+	// call's downlink usage marker — the reliable key the voice chain uses to
+	// demultiplex concurrent same-carrier calls (the channel-allocation timeslot
+	// field does not map to the physical slot on real air). It must survive the
+	// MAC → VoiceGrant → trunking.Grant plumbing so the voice chain can match it
+	// against each burst's AACH marker.
+	if grant.TETRAUsageMarker != 15 {
+		t.Errorf("grant usage marker = %d, want 15 (from the addrSSIUsage grant)", grant.TETRAUsageMarker)
+	}
 }
 
 // TestCarrierFrequencyDerivation checks that a grant carrier number resolves to

--- a/internal/radio/tetra/tetra.go
+++ b/internal/radio/tetra/tetra.go
@@ -46,8 +46,10 @@
 // synchronisation burst). TCH/S channel decode (§5.5: RCPC + interleave +
 // class-2 CRC) turns each burst into 137-bit speech frames, which the
 // clean-room ACELP vocoder (internal/voice/acelp, bit-exact to ETSI
-// EN 300 395-2) renders to PCM. Per-slot filtering lets up to four concurrent
-// same-carrier calls decode into independent recordings.
+// EN 300 395-2) renders to PCM. Each burst also carries its AACH downlink usage
+// marker; the voice chain routes bursts by matching that marker to the granted
+// call's, so up to four concurrent same-carrier calls decode into independent
+// recordings.
 //
 // As with the other trunking packages: ship a clean structured
 // surface now, leave the analogue / FEC / encryption pieces as named

--- a/internal/radio/tetra/traffic.go
+++ b/internal/radio/tetra/traffic.go
@@ -34,18 +34,22 @@ import (
 // EDACS-ProVoice voice paths write their post-FEC or raw frames.
 //
 // Slot demultiplexing: the extractor emits a frame for every NCDB it sees
-// on the carrier — all four TDMA timeslots — and tags each with its TDMA
-// timeslot (TN, 1..4) so a per-slot voice chain can keep only its granted
-// slot and up to four calls on one carrier decode independently. The slot is
-// numbered from the synchronisation burst (SB), which the same detector
-// correlates: the SB's synchronisation training sequence is transmitted in
-// slot 1 (TN1) of frame 18, so it anchors the 255-dibit slot grid. A burst
-// leading at dibit L is then in slot ((round((L - sbAnchor)/255)) mod 4) + 1;
-// the ~15-dibit intra-slot offset between the normal and synchronisation
-// training sequences is far below the half-slot (127-dibit) rounding margin,
-// so it need not be modelled exactly. Until an SB is seen the slot is reported
-// as 0 (unknown) and the consumer falls back to CRC-gated single-call
-// behaviour. On a traffic-only carrier with no SB the slot stays 0.
+// on the carrier — all four TDMA timeslots — tagged with both its AACH downlink
+// usage marker (the reliable per-slot call identifier, ETSI §21.4.7) and its TDMA
+// timeslot number, so concurrent calls on one carrier decode independently.
+//
+// The usage marker is the demux key the voice chain routes by: the AACH is
+// present and decodes in every downlink slot, and a call's marker matches the
+// usage marker carried in its grant. The TDMA timeslot number is retained for
+// telemetry, but on real air it is NOT a reliable demux key — the SB anchor's
+// intra-slot rounding jitters a call's bursts across adjacent slot numbers, and
+// the channel-allocation grant timeslot field does not map to the physical slot.
+//
+// The slot number is derived from the synchronisation burst (SB): the SB's
+// synchronisation training sequence is transmitted in slot 1 (TN1) of frame 18,
+// so it anchors the 255-dibit slot grid. A burst leading at dibit L is then in
+// slot ((round((L - sbAnchor)/255)) mod 4) + 1. Until an SB is seen the slot is
+// reported as 0 (unknown). On a traffic-only carrier with no SB the slot stays 0.
 const (
 	// ndbSlotDibits is the dibit span of one TDMA timeslot (510 bits): four
 	// slots make a 1020-dibit TDMA frame. The slot grid the SB anchor pins.
@@ -86,7 +90,7 @@ type TrafficExtractor struct {
 	bufBase    int
 	pending    []int // training-sequence leading indices awaiting look-ahead
 	colourCode uint32
-	onBurst    func(frame []byte, slot uint8)
+	onBurst    func(frame []byte, slot, usage uint8)
 
 	// sbAnchor is the absolute dibit index of the most recent SB
 	// synchronisation-training-sequence leading dibit (TN1), pinning the
@@ -96,13 +100,17 @@ type TrafficExtractor struct {
 }
 
 // NewTrafficExtractor returns an extractor that calls onBurst with each
-// recovered 54-byte traffic frame and its TDMA timeslot (1..4, or 0 when the
-// slot grid is not yet anchored to a synchronisation burst). When colourCode is
-// non-zero the frame is descrambled with the cell's extended colour code
-// (learned from the control channel's BSCH) before onBurst, so the sidecar
-// holds descrambled type-5 — the input the TCH/S channel decoder expects.
-// onBurst must not retain the slice.
-func NewTrafficExtractor(colourCode uint32, onBurst func(frame []byte, slot uint8)) *TrafficExtractor {
+// recovered 54-byte traffic frame, its TDMA timeslot (1..4, or 0 when the slot
+// grid is not yet anchored to a synchronisation burst), and the burst's AACH
+// downlink usage marker (§21.4.7; the per-slot call identifier, >= DLUsageTraffic
+// for a traffic slot, 0 when the AACH did not decode or the slot is not traffic).
+// When colourCode is non-zero the frame is descrambled with the cell's extended
+// colour code (learned from the control channel's BSCH) before onBurst, so the
+// sidecar holds descrambled type-5 — the input the TCH/S channel decoder expects.
+// The usage marker is what lets a per-call voice chain demultiplex concurrent
+// same-carrier calls reliably (the channel-allocation timeslot field does not map
+// to the physical slot on real air). onBurst must not retain the slice.
+func NewTrafficExtractor(colourCode uint32, onBurst func(frame []byte, slot, usage uint8)) *TrafficExtractor {
 	te := &TrafficExtractor{colourCode: colourCode, onBurst: onBurst}
 	// π/4-DQPSK leaves a constant 0..3 dibit rotation (residual CFO), so
 	// correlate the training sequence under all four rotations of the
@@ -195,7 +203,8 @@ func (te *TrafficExtractor) Process(dibits []uint8, baseIdx int) {
 }
 
 // emit slices BKN1 and BKN2 around the training sequence leading at L and
-// forwards the concatenated raw type-5 frame.
+// forwards the concatenated raw type-5 frame, tagged with the burst's TDMA slot
+// and its AACH downlink usage marker.
 func (te *TrafficExtractor) emit(L int) {
 	block := func(off int) []uint8 {
 		s := L + off - te.bufBase
@@ -208,7 +217,45 @@ func (te *TrafficExtractor) emit(L int) {
 	if te.colourCode != 0 {
 		bits = framing.DescrambleTetra(bits, te.colourCode)
 	}
-	te.onBurst(framing.PackBitsMSB(bits), te.slotOf(L))
+	te.onBurst(framing.PackBitsMSB(bits), te.slotOf(L), te.usageOf(L))
+}
+
+// usageOf recovers the AACH downlink usage marker of the burst leading at L. The
+// 30-bit access-assignment sits in two halves either side of the normal training
+// sequence (same geometry as the control-channel downlinkNCDB); it is scrambled
+// with the cell colour code and RM(30,14)-coded. Returns 0 when the AACH is not
+// buffered, does not decode, or the slot is not carrying traffic — callers treat
+// 0 as "unknown" and fall back to CRC-gated isolation. The receiver's AFC locks
+// the constellation to rotation 0 (the same assumption the BKN descramble above
+// relies on), so no rotation search is needed here.
+func (te *TrafficExtractor) usageOf(L int) uint8 {
+	half := func(off, n int) []uint8 {
+		s := L + off - te.bufBase
+		if s < 0 || s+n > len(te.buf) {
+			return nil
+		}
+		return te.buf[s : s+n]
+	}
+	a1 := half(ndbAACH1Start, ndbAACH1Len)
+	a2 := half(ndbAACH2Start, ndbAACH2Len)
+	if a1 == nil || a2 == nil {
+		return 0
+	}
+	di := make([]uint8, 0, ndbAACH1Len+ndbAACH2Len)
+	di = append(di, a1...)
+	di = append(di, a2...)
+	rec, errs := DecodeAACH(TetraDibitsToBits(di), te.colourCode)
+	if errs < 0 {
+		return 0
+	}
+	aa, ok := ParseAccessAssign(rec)
+	if !ok {
+		return 0
+	}
+	if u := aa.DownlinkUsage(); u >= DLUsageTraffic {
+		return u
+	}
+	return 0
 }
 
 // ndbSBSlotShift aligns the synchronisation-burst anchor to the NDB slot grid.

--- a/internal/radio/tetra/traffic_test.go
+++ b/internal/radio/tetra/traffic_test.go
@@ -39,7 +39,7 @@ func TestTrafficExtractorSingleBurst(t *testing.T) {
 	buildNCDB(stream, L, bkn1, bkn2)
 
 	var frames [][]byte
-	te := NewTrafficExtractor(0, func(f []byte, _ uint8) {
+	te := NewTrafficExtractor(0, func(f []byte, _, _ uint8) {
 		frames = append(frames, append([]byte(nil), f...))
 	})
 	te.Process(stream, 0)
@@ -67,7 +67,7 @@ func TestTrafficExtractorDescrambles(t *testing.T) {
 
 	const colour = 262144876 // the reporter's cell (467.913 MHz)
 	var got []byte
-	te := NewTrafficExtractor(colour, func(f []byte, _ uint8) { got = append([]byte(nil), f...) })
+	te := NewTrafficExtractor(colour, func(f []byte, _, _ uint8) { got = append([]byte(nil), f...) })
 	te.Process(stream, 0)
 
 	rawBits := TetraDibitsToBits(append(append([]uint8{}, bkn1...), bkn2...))
@@ -88,7 +88,7 @@ func TestTrafficExtractorChunkedAcrossCalls(t *testing.T) {
 	buildNCDB(stream, L, bkn1, bkn2)
 
 	var frames [][]byte
-	te := NewTrafficExtractor(0, func(f []byte, _ uint8) {
+	te := NewTrafficExtractor(0, func(f []byte, _, _ uint8) {
 		frames = append(frames, append([]byte(nil), f...))
 	})
 	// Feed in small chunks so the training-sequence match, BKN1 look-back
@@ -118,7 +118,7 @@ func TestTrafficExtractorMultipleSlots(t *testing.T) {
 	buildNCDB(stream, 200+255, b1b, b2b)
 
 	var frames [][]byte
-	te := NewTrafficExtractor(0, func(f []byte, _ uint8) {
+	te := NewTrafficExtractor(0, func(f []byte, _, _ uint8) {
 		frames = append(frames, append([]byte(nil), f...))
 	})
 	te.Process(stream, 0)
@@ -163,7 +163,7 @@ func TestTrafficExtractorSlotTagging(t *testing.T) {
 	}
 
 	var slots []uint8
-	te := NewTrafficExtractor(0, func(_ []byte, slot uint8) { slots = append(slots, slot) })
+	te := NewTrafficExtractor(0, func(_ []byte, slot, _ uint8) { slots = append(slots, slot) })
 	te.Process(stream, 0)
 
 	if len(slots) != len(ndbs) {
@@ -183,7 +183,7 @@ func TestTrafficExtractorSlotUnanchored(t *testing.T) {
 	stream := make([]uint8, 600)
 	buildNCDB(stream, 300, rampDibits(ndbBlockDibits, 0), rampDibits(ndbBlockDibits, 1))
 	var slots []uint8
-	te := NewTrafficExtractor(0, func(_ []byte, slot uint8) { slots = append(slots, slot) })
+	te := NewTrafficExtractor(0, func(_ []byte, slot, _ uint8) { slots = append(slots, slot) })
 	te.Process(stream, 0)
 	if len(slots) != 1 || slots[0] != 0 {
 		t.Fatalf("unanchored slots=%v, want [0]", slots)
@@ -197,7 +197,7 @@ func TestTrafficExtractorNoFalseEmitOnNoise(t *testing.T) {
 		stream[i] = uint8((i*7 + 1) % 4) // deterministic non-sync filler
 	}
 	n := 0
-	te := NewTrafficExtractor(0, func(f []byte, _ uint8) { n++ })
+	te := NewTrafficExtractor(0, func(f []byte, _, _ uint8) { n++ })
 	te.Process(stream, 0)
 	// A rare chance correlation within tolerance is possible; assert it does
 	// not spuriously fire on structured filler.

--- a/internal/trunking/grant.go
+++ b/internal/trunking/grant.go
@@ -60,6 +60,16 @@ type Grant struct {
 	// the scrambler seed the voice chain descrambles the granted call's traffic
 	// frames with. Zero on non-TETRA grants and until the colour code is learned.
 	TETRAColourExt uint32
+	// TETRAUsageMarker is the call's downlink usage marker (ETSI EN 300 392-2
+	// §21.4.7), the per-slot control-vs-traffic identifier the AACH broadcasts in
+	// every downlink slot. On a same-carrier SCBS it — not the unreliable
+	// channel-allocation timeslot field — is what maps a granted call to the
+	// physical TDMA slot carrying its speech, so the voice chain demultiplexes
+	// concurrent calls by matching this against each burst's AACH marker. Traffic
+	// markers are >= 4 (DLUsageTraffic); 0 means "unknown" (grant addressed by SSI
+	// without a usage marker), which falls the voice chain back to CRC-gated
+	// single-call isolation. Zero on non-TETRA grants.
+	TETRAUsageMarker uint8
 	// AlgorithmID and KeyID carry the encryption parameters the
 	// protocol's privacy header advertises (the DMR PI header, etc.).
 	// They are meaningful only when Encrypted is true and stay zero

--- a/internal/voice/composer/composer.go
+++ b/internal/voice/composer/composer.go
@@ -512,7 +512,7 @@ func (c *Composer) handleStart(parent context.Context, cs trunking.CallStart) {
 	case isP25P1Voice:
 		go c.runP25Phase1VoiceChain(chainCtx, cs.DeviceSerial, cs.Grant.System, iqCh, rateHzF, cs.Grant.P25Phase1DemodMode, cs.Grant.GroupID, cs.Grant.CallID, cs.Grant.PatchedGroups, ch.done)
 	case isTETRAVoice:
-		go c.runTETRAVoiceChain(chainCtx, cs.DeviceSerial, iqCh, rateHzF, cs.Grant.GroupID, cs.Grant.Timeslot, cs.Grant.TETRAColourExt, ch.done)
+		go c.runTETRAVoiceChain(chainCtx, cs.DeviceSerial, iqCh, rateHzF, cs.Grant.GroupID, cs.Grant.Timeslot, cs.Grant.TETRAColourExt, cs.Grant.TETRAUsageMarker, ch.done)
 	default:
 		// Analog FM has no symbol clock to drift, so the rounded integer
 		// rate is fine; keep its uint32 signature unchanged.

--- a/internal/voice/composer/tetra_voice.go
+++ b/internal/voice/composer/tetra_voice.go
@@ -52,15 +52,19 @@ func newTETRAVoiceFrontEnd(iqHz float64, bw uint32) *decimatingFIR {
 // mirrors the DMR/P25 shape (post-FEC frames in `.raw` + decoded WAV).
 //
 // The extractor emits a burst for every timeslot on the carrier (all four TDMA
-// slots), each tagged with its timeslot (anchored to the synchronisation burst,
-// TN1). This chain keeps only bursts on its granted timeslot and drops the rest
-// (onTETRATrafficBurst), so up to four concurrent calls on one carrier — one per
-// slot, each on its own same-carrier tap — decode into four independent
-// recordings instead of mixing. Until the slot grid anchors (or on a traffic
-// carrier with no synchronisation burst) the slot is unknown and the chain falls
-// back to the TCH/S-CRC single-call isolation. Encrypted calls (TEA1-4) fail the
-// CRC and produce no decoded audio (their raw bursts still exist upstream).
-func (c *Composer) runTETRAVoiceChain(ctx context.Context, serial string, iqCh <-chan []complex64, iqHz float64, groupID uint32, timeslot uint8, colourExt uint32, done chan<- struct{}) {
+// slots), each tagged with the AACH downlink usage marker of the slot it came
+// from. This chain keeps only bursts whose marker matches the granted call's
+// usage marker and drops the rest (onTETRATrafficBurst), so up to four concurrent
+// calls on one carrier — one per slot, each on its own same-carrier tap — decode
+// into four independent recordings instead of mixing. The AACH usage marker, not
+// the channel-allocation timeslot field, is the demux key: on real air the grant
+// timeslot does not map to the physical slot (distinct calls collide on one
+// value), which silently starved every mis-mapped call. When the grant carries no
+// usage marker, or a burst's AACH does not decode, the chain falls back to
+// TCH/S-CRC single-call isolation so a call's own speech is never dropped on a
+// guess. Encrypted calls (TEA1-4) fail the CRC and produce no decoded audio
+// (their raw bursts still exist upstream).
+func (c *Composer) runTETRAVoiceChain(ctx context.Context, serial string, iqCh <-chan []complex64, iqHz float64, groupID uint32, timeslot uint8, colourExt uint32, usageMarker uint8, done chan<- struct{}) {
 	defer close(done)
 	defer gtlog.Recover(c.log, "voice-chain-tetra:"+serial, nil)
 
@@ -75,8 +79,8 @@ func (c *Composer) runTETRAVoiceChain(ctx context.Context, serial string, iqCh <
 
 	rs, _ := c.sink.(rawFrameSink)
 	var bursts, speech, offSlot atomic.Uint64
-	extractor := tetra.NewTrafficExtractor(colourExt, func(frame []byte, slot uint8) {
-		c.onTETRATrafficBurst(bt, rs, serial, frame, slot, timeslot, &bursts, &speech, &offSlot)
+	extractor := tetra.NewTrafficExtractor(colourExt, func(frame []byte, slot, usage uint8) {
+		c.onTETRATrafficBurst(bt, rs, serial, frame, usage, usageMarker, &bursts, &speech, &offSlot)
 	})
 
 	rx := tetrarx.New(tetrarx.Options{
@@ -90,12 +94,12 @@ func (c *Composer) runTETRAVoiceChain(ctx context.Context, serial string, iqCh <
 
 	c.log.Info("composer: tetra voice follow started — TCH/S decode + ACELP vocoder",
 		"serial", serial, "group", groupID, "timeslot", timeslot,
-		"colour_code", colourExt&0x3F, "rate_hz", symbolHz)
+		"usage_marker", usageMarker, "colour_code", colourExt&0x3F, "rate_hz", symbolHz)
 
 	defer func() {
 		c.log.Info("composer: tetra voice follow ended",
 			"serial", serial, "bursts", bursts.Load(), "speech_frames", speech.Load(),
-			"other_slot_bursts", offSlot.Load())
+			"other_call_bursts", offSlot.Load())
 	}()
 
 	touchTicker := time.NewTicker(c.touchEvery)
@@ -127,27 +131,36 @@ func (c *Composer) runTETRAVoiceChain(ctx context.Context, serial string, iqCh <
 // never elapsed and the (single, same-carrier) voice device was held forever —
 // every later grant was then dropped with "no voice device available for grant".
 //
-// Slot demultiplexing: the extractor tags each burst with its TDMA timeslot
-// (slot, 1..4; 0 = not yet anchored to a synchronisation burst). When the slot
-// is known and does NOT match this chain's granted timeslot, the burst belongs
-// to another call sharing the carrier and is dropped here — this is what lets up
-// to four concurrent calls on one carrier decode into four independent
-// recordings. Until the grid anchors (slot 0), the chain falls back to the
-// CRC-gated single-call behaviour (a non-same-carrier traffic tap has no SB, so
-// slot stays 0 and every chain behaves as before).
+// Usage-marker demultiplexing: the extractor tags each burst with the AACH
+// downlink usage marker of the slot it came from (burstUsage, >= DLUsageTraffic
+// for a traffic slot, 0 when the AACH did not decode or the slot is not traffic).
+// The grant carries the call's usage marker (grantUsage). When both are present
+// and differ, the burst belongs to another call sharing the carrier and is
+// dropped — this is what lets up to four concurrent same-carrier calls decode
+// into independent recordings. The channel-allocation timeslot field is NOT used:
+// on real air it does not map to the physical slot (distinct calls collide on one
+// value), which silently starved every mis-mapped call; the AACH usage marker is
+// the reliable per-slot call identifier.
+//
+// Fallbacks (never discard the granted call's own speech on a guess):
+//   - grantUsage == 0 (the grant was addressed by plain SSI, no usage marker):
+//     accept every CRC-valid burst — the pre-demux single-call behaviour. Audio
+//     is preserved; true concurrency without markers may mix (rare).
+//   - burstUsage == 0 (this burst's AACH did not decode): let the CRC gate decide
+//     rather than dropping, so an occasional AACH miss does not drop own speech.
 //
 // The class-2 CRC gate (tetra.TCHSpeechFrames) then isolates the granted call's
-// speech: a non-TCH/S burst (signalling on another timeslot, an encrypted call,
-// or a badly corrupted slot) returns no frames. Gating onVoice on that result
-// makes TETRA teardown behave like every other protocol — the call ends hangtime
-// after its last decoded speech frame (or via the no-voice startup timeout when
-// a grant never decodes any speech).
-func (c *Composer) onTETRATrafficBurst(bt *boundaryTracker, rs rawFrameSink, serial string, frame []byte, slot, grantSlot uint8, bursts, speech, offSlot *atomic.Uint64) {
+// speech: a non-TCH/S burst (signalling, an encrypted call, or a badly corrupted
+// slot) returns no frames. Gating onVoice on that result makes TETRA teardown
+// behave like every other protocol — the call ends hangtime after its last
+// decoded speech frame (or via the no-voice startup timeout when a grant never
+// decodes any speech).
+func (c *Composer) onTETRATrafficBurst(bt *boundaryTracker, rs rawFrameSink, serial string, frame []byte, burstUsage, grantUsage uint8, bursts, speech, offSlot *atomic.Uint64) {
 	bursts.Add(1)
-	// Drop bursts from another timeslot once the slot grid is anchored and the
-	// grant names a slot. slot==0 (unanchored) or grantSlot==0 (unknown) falls
-	// through to the CRC-gated single-call path.
-	if slot != 0 && grantSlot != 0 && slot != grantSlot {
+	// Drop bursts that carry a different call's AACH usage marker. Only when both
+	// markers are known (>= DLUsageTraffic) — an unknown marker on either side
+	// falls through to the CRC gate so we never drop the granted call's own speech.
+	if grantUsage >= tetra.DLUsageTraffic && burstUsage >= tetra.DLUsageTraffic && burstUsage != grantUsage {
 		offSlot.Add(1)
 		return
 	}

--- a/internal/voice/composer/tetra_voice_test.go
+++ b/internal/voice/composer/tetra_voice_test.go
@@ -184,49 +184,74 @@ func TestTETRATrafficBurstLivenessGatedByCRC(t *testing.T) {
 	}
 }
 
-// TestTETRATrafficBurstSlotFilter is the regression for concurrent same-carrier
-// calls: once the slot grid is anchored, a burst whose timeslot differs from the
-// chain's granted timeslot must be dropped (counted as off-slot) and never
-// decoded — even if it is a CRC-valid TCH/S frame for the OTHER call. A burst on
-// the granted slot, and any burst while the grid is unanchored (slot 0), must
-// still be processed.
-func TestTETRATrafficBurstSlotFilter(t *testing.T) {
+// TestTETRATrafficBurstUsageMarkerFilter is the regression for concurrent
+// same-carrier calls: a burst whose AACH downlink usage marker differs from the
+// chain's granted usage marker belongs to another call sharing the carrier and
+// must be dropped (counted off-call) and never decoded — even if it is a
+// CRC-valid TCH/S frame for the OTHER call. A burst carrying the granted marker
+// must be decoded; a burst whose AACH did not decode (marker 0) must fall through
+// to the CRC gate rather than being dropped, so an occasional AACH miss never
+// drops the granted call's own speech.
+func TestTETRATrafficBurstUsageMarkerFilter(t *testing.T) {
 	c, _, _ := mkBoundaryComposer(t, false, 50*time.Millisecond)
 	bt := c.newBoundaryTracker("VOICE-2", 0, nil)
 	rs := &recordingSink{}
 	var bursts, speech, offSlot atomic.Uint64
 
-	// A CRC-valid TCH/S frame (belongs to whichever slot it arrives on).
+	// A CRC-valid TCH/S frame (belongs to whichever call it arrives on).
 	frame := tetra.EncodeTCHS(make([]byte, 137), make([]byte, 137))
-	const grantSlot uint8 = 2
+	const grantUsage uint8 = 20 // this call's downlink usage marker
 
-	// Foreign slot (3 != granted 2), anchored: dropped as off-slot, no decode.
-	c.onTETRATrafficBurst(bt, rs, "VOICE-2", frame, 3, grantSlot, &bursts, &speech, &offSlot)
+	// Another call's slot (marker 19 != granted 20): dropped off-call, no decode.
+	c.onTETRATrafficBurst(bt, rs, "VOICE-2", frame, 19, grantUsage, &bursts, &speech, &offSlot)
 	if got := offSlot.Load(); got != 1 {
-		t.Errorf("foreign-slot burst offSlot = %d, want 1", got)
+		t.Errorf("foreign-call burst offSlot = %d, want 1", got)
 	}
 	if n := len(rs.rawFrames("VOICE-2")); n != 0 {
-		t.Errorf("foreign-slot burst wrote %d frames, want 0 (must not decode another call's slot)", n)
+		t.Errorf("foreign-call burst wrote %d frames, want 0 (must not decode another call's slot)", n)
 	}
 	if bt.sawVoice.Load() {
-		t.Error("foreign-slot burst set sawVoice — a concurrent call would keep this call alive")
+		t.Error("foreign-call burst set sawVoice — a concurrent call would keep this call alive")
 	}
 
-	// Granted slot (2 == granted 2): decoded and written.
-	c.onTETRATrafficBurst(bt, rs, "VOICE-2", frame, grantSlot, grantSlot, &bursts, &speech, &offSlot)
+	// Granted marker (20 == granted 20): decoded and written.
+	c.onTETRATrafficBurst(bt, rs, "VOICE-2", frame, grantUsage, grantUsage, &bursts, &speech, &offSlot)
 	if n := len(rs.rawFrames("VOICE-2")); n != 2 {
-		t.Errorf("granted-slot burst wrote %d frames, want 2", n)
+		t.Errorf("granted-marker burst wrote %d frames, want 2", n)
 	}
 	if !bt.sawVoice.Load() {
-		t.Error("granted-slot burst did not mark voice activity")
+		t.Error("granted-marker burst did not mark voice activity")
 	}
 
-	// Unanchored (slot 0): single-call fallback still processes it.
-	c.onTETRATrafficBurst(bt, rs, "VOICE-2", frame, 0, grantSlot, &bursts, &speech, &offSlot)
+	// Undecoded AACH (marker 0): CRC-gated fallback still processes it — an AACH
+	// miss must not drop the granted call's own speech.
+	c.onTETRATrafficBurst(bt, rs, "VOICE-2", frame, 0, grantUsage, &bursts, &speech, &offSlot)
 	if n := len(rs.rawFrames("VOICE-2")); n != 4 {
-		t.Errorf("unanchored burst wrote total %d frames, want 4", n)
+		t.Errorf("undecoded-AACH burst wrote total %d frames, want 4", n)
 	}
 	if got := offSlot.Load(); got != 1 {
-		t.Errorf("offSlot = %d after one foreign + one granted + one unanchored, want 1", got)
+		t.Errorf("offSlot = %d after one foreign + one granted + one undecoded-AACH, want 1", got)
+	}
+}
+
+// TestTETRATrafficBurstNoGrantMarkerFallback pins the safety net: when the grant
+// carries no usage marker (0 — addressed by plain SSI), every CRC-valid burst is
+// accepted regardless of the burst's own marker, so a call's speech is never
+// silently discarded on a guess (the pre-demux single-call behaviour).
+func TestTETRATrafficBurstNoGrantMarkerFallback(t *testing.T) {
+	c, _, _ := mkBoundaryComposer(t, false, 50*time.Millisecond)
+	bt := c.newBoundaryTracker("VOICE-3", 0, nil)
+	rs := &recordingSink{}
+	var bursts, speech, offSlot atomic.Uint64
+	frame := tetra.EncodeTCHS(make([]byte, 137), make([]byte, 137))
+
+	// Grant marker 0 (unknown): a burst with any marker is decoded, none dropped.
+	c.onTETRATrafficBurst(bt, rs, "VOICE-3", frame, 19, 0, &bursts, &speech, &offSlot)
+	c.onTETRATrafficBurst(bt, rs, "VOICE-3", frame, 0, 0, &bursts, &speech, &offSlot)
+	if n := len(rs.rawFrames("VOICE-3")); n != 4 {
+		t.Errorf("no-grant-marker fallback wrote %d frames, want 4 (accept all CRC-valid speech)", n)
+	}
+	if got := offSlot.Load(); got != 0 {
+		t.Errorf("offSlot = %d, want 0 (no dropping without a grant marker)", got)
 	}
 }


### PR DESCRIPTION
Concurrent same-carrier TETRA calls decoded as "DJ scratches" — most calls
produced only a brief garbled fragment, only calls that were alone on the
carrier came through cleanly.

Root cause: the per-slot voice demux dropped a burst whose decoded TDMA
timeslot did not match the call's *granted* timeslot. On real air the grant
timeslot does not identify the physical slot — distinct calls collide on one
value and slot 4 never appears — and the synchronisation-burst slot anchor
also jitters a call's bursts across adjacent slot numbers. So most calls had
their own speech discarded as "off-slot" and recorded only the handful of
frames decoded before the slot grid anchored.

Diagnosed from the reporter's 5-capture same-carrier IQ set: offline per-slot
decode recovers clean multi-second audio (DDC / receiver / TCH-S / ACELP are
all correct), and the control channel's own AACH downlink usage marker matches
the usage marker carried in each grant (verified: markers 19/20 in one
capture, one per concurrent call).

Fix: demultiplex by the AACH downlink usage marker instead of the timeslot.
The TrafficExtractor now decodes each burst's AACH and surfaces its usage
marker; the grant carries the call's usage marker (plumbed from the MAC
addrSSIUsage element through VoiceGrant → trunking.Grant); the voice chain
keeps only bursts whose marker matches. A grant addressed without a usage
marker, or a burst whose AACH does not decode, falls back to CRC-gated
single-call decoding so a call's own speech is never dropped on a guess.

- internal/radio/tetra/traffic.go: TrafficExtractor decodes AACH per burst,
  onBurst gains the usage marker
- internal/radio/tetra/{cmce,downlink,control}.go: plumb the usage marker
- internal/trunking/grant.go: Grant.TETRAUsageMarker
- internal/voice/composer/tetra_voice.go: route by usage marker + fallbacks
- tests: usage-marker filter + no-marker fallback unit tests; real-PDU
  plumbing assertion (downlink_test); replay harness per-marker accounting

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0143FCU48ecrifc2csT8PFXX