### PR TITLE
fix(tetra): stop CC lock-flap + same-carrier audio leaks; add tap: ddc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,13 @@ for tagged releases.
   byte-for-byte unchanged. Applies to the voice composer and signalling
   follower (including Phase 1 control channels that grant Phase 2 traffic).
   Issue #915.
+- **`baseband.auto_record.tap: ddc`** — event-triggered auto-captures can now
+  record the control decoder's narrowband post-DDC stream (the pipeline rate,
+  144 kHz for TETRA) instead of the full-rate wideband SDR IQ. Files are orders of
+  magnitude smaller (a few MB vs ~95 MB) and directly replayable; for a
+  same-carrier TETRA site the DDC tap holds all four voice timeslots of the
+  control carrier. `tap: wideband` (default) is unchanged. Triggered captures also
+  create their target directory if missing.
 - **TETRA voice now decodes to audible audio, including up to 4 concurrent
   calls on one carrier.** The TETRA voice path recovers each traffic burst,
   channel-decodes TCH/S, and renders it with the clean-room ACELP vocoder
@@ -129,6 +136,20 @@ for tagged releases.
   rather than a fixed slot 1 — the building block for issue #925.
 
 ### Fixed
+- **Concurrent same-carrier TETRA calls could still leak audio between each
+  other** — a long conversation would pick up a second slot's speech mid-stream.
+  The per-call demux ran one receiver per call and routed by the AACH usage
+  marker, but could not evict a peer: when a call ended and the network reused its
+  usage marker for a new call while the old one lingered in hangtime, both matched
+  and the old recording absorbed the new call's audio. Concurrent same-carrier
+  calls now share ONE per-carrier voice demux (its sync/AACH state stays warm
+  across calls) with a single owner per usage marker and most-recent-grant-wins
+  eviction, so a reused marker immediately displaces the lingering call. Routing by
+  the AACH usage marker (not the physical TDMA slot) is what makes this reliable:
+  on real captures a single call's bursts jitter across adjacent decoded slot
+  numbers, so slot-keyed routing mis-delivers them — the usage marker is stable
+  per call. Grants addressed without a usage marker bind to the first unclaimed
+  marker instead of accept-all-mixing.
 - **A locked TETRA control channel flapped "CC hunt failed · candidates
   exhausted" every ~30–60 s while it was decoding calls fine.** Two coupled gaps:
   the control-channel hunter's success test needs a fresh `cc.locked` event within

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,20 @@ for tagged releases.
   rather than a fixed slot 1 — the building block for issue #925.
 
 ### Fixed
+- **A locked TETRA control channel flapped "CC hunt failed · candidates
+  exhausted" every ~30–60 s while it was decoding calls fine.** Two coupled gaps:
+  the control-channel hunter's success test needs a fresh `cc.locked` event within
+  its dwell (default 3 s), but TETRA emits the lock only once (edge-triggered), so
+  when cold acquisition (BSCH sync + colour code) outlasts the dwell the first hunt
+  fails and every same-frequency re-hunt then exhausts the dwell against an
+  already-locked, silent-on-the-wire pipeline; and there was no TETRA lock-loss
+  watchdog (`MarkLost` had no callers), so the scanner could never leave the locked
+  state on a genuine outage. Now the supervisor parks a system it already knows is
+  locked instead of re-hunting it, and a new control-channel watchdog publishes
+  `cc.lost` when a locked carrier decodes nothing for ~5 s (≈5 missed
+  multiframes), so a genuinely dead carrier still re-hunts and recovers. (The
+  ±6 kHz AFC acquisition range, #940, was already merged and is unrelated — a
+  ~1.5 kHz carrier offset sits well inside it.)
 - **Concurrent same-carrier TETRA calls decoded as "DJ scratches" — most calls
   produced only brief garbled fragments.** The per-slot demux dropped a burst
   whose decoded TDMA timeslot did not match the call's *granted* timeslot, but on

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -2404,7 +2404,15 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		if cfg.Baseband.AutoRecord.Enabled && d.controlSerial != "" {
 			if br := d.iqBrokers[d.controlSerial]; br != nil {
 				sysName, proto := primaryControlSystem(cfg)
-				d.iqAutoRec = newIQAutoRecorder(cfg.Baseband.AutoRecord, sysName, proto, d.controlSerial, br, log)
+				// Lazy control-decoder accessor for the "ddc" tap (nil interface
+				// until the decoder is built, mirroring the same-carrier voice tap).
+				ddcTap := func() ddcVoiceTap {
+					if d.ccDecoder == nil {
+						return nil
+					}
+					return d.ccDecoder
+				}
+				d.iqAutoRec = newIQAutoRecorder(cfg.Baseband.AutoRecord, sysName, proto, d.controlSerial, br, ddcTap, log)
 				if d.iqAutoRec != nil {
 					d.iqAutoRecSub = d.bus.Subscribe()
 					opts.AutoRecord = autoRecordTrigger{rec: d.iqAutoRec}

--- a/cmd/gophertrunk/iqautorecord.go
+++ b/cmd/gophertrunk/iqautorecord.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -15,6 +17,16 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/siglab"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
+
+// ddcVoiceTap is the subset of the control-channel decoder the DDC-tap capture
+// consumes: the post-DDC channelised IQ fan-out (the same stream the same-carrier
+// voice taps read) plus its pipeline rate and centre. *ccdecoder.Decoder
+// satisfies it; tests supply a fake. Used only when auto_record's tap is "ddc".
+type ddcVoiceTap interface {
+	SubscribeVoiceIQ() (<-chan []complex64, func())
+	PipelineRateHz() float64
+	CenterFreqHz() uint32
+}
 
 // autoRecordConcurrencyWindow is how long a granted call is counted as
 // "active" for the on_concurrent_calls trigger. The control channel repeats a
@@ -58,6 +70,10 @@ type iqAutoRecorder struct {
 	seconds  int
 	log      *slog.Logger
 
+	// ddc lazily resolves the control decoder for the "ddc" tap (nil when the
+	// decoder is not yet built / not applicable). Nil for the wideband tap.
+	ddc func() ddcVoiceTap
+
 	// capture actuates a capture; defaults to captureIQToFile over broker.
 	capture captureFunc
 	// now is the clock (injectable for tests).
@@ -74,7 +90,7 @@ type iqAutoRecorder struct {
 // Returns nil when disabled, so the daemon can skip wiring it entirely. cfg is
 // assumed already validated (config.Validate); format/cooldown fall back to
 // their documented defaults.
-func newIQAutoRecorder(cfg config.BasebandAutoRecordConfig, system, protocol, serial string, broker *iqtap.Broker, log *slog.Logger) *iqAutoRecorder {
+func newIQAutoRecorder(cfg config.BasebandAutoRecordConfig, system, protocol, serial string, broker *iqtap.Broker, ddc func() ddcVoiceTap, log *slog.Logger) *iqAutoRecorder {
 	if !cfg.Enabled {
 		return nil
 	}
@@ -106,6 +122,7 @@ func newIQAutoRecorder(cfg config.BasebandAutoRecordConfig, system, protocol, se
 		cooldown: cooldown,
 		dir:      cfg.Dir,
 		seconds:  cfg.Seconds,
+		ddc:      ddc,
 		log:      log.With("component", "iq-autorecord", "serial", serial),
 		now:      time.Now,
 		baseCtx:  context.Background(),
@@ -128,13 +145,76 @@ func (a *iqAutoRecorder) inFlightCount() int {
 	return a.inFlight
 }
 
-// defaultCapture writes the capture through the shared captureIQToFile helper.
+// defaultCapture writes the capture: the narrowband post-DDC channel stream when
+// tap: ddc, otherwise the wideband broker via the shared captureIQToFile helper.
 func (a *iqAutoRecorder) defaultCapture(ctx context.Context, path string, format siglab.SampleFormat, seconds int) (int64, uint64, error) {
+	if a.cfg.TapDDC() {
+		var tap ddcVoiceTap
+		if a.ddc != nil {
+			tap = a.ddc()
+		}
+		return captureDDCToFile(ctx, tap, path, format, seconds)
+	}
 	if a.broker == nil {
 		return 0, 0, fmt.Errorf("iq-autorecord: no broker")
 	}
 	samples, _, drops, err := captureIQToFile(ctx, a.broker, path, format, seconds)
 	return samples, drops, err
+}
+
+// captureDDCToFile records `seconds` of the control decoder's post-DDC channelised
+// IQ (the pipeline-rate stream: 144 kHz for TETRA, ~48 kHz for the C4FM family) to
+// path in the chosen format, reusing siglab.CaptureWriter so the bytes are
+// identical to a wideband capture at that rate. Orders of magnitude smaller than
+// the wideband broker capture, and directly replayable. ctx cancels early.
+func captureDDCToFile(ctx context.Context, tap ddcVoiceTap, path string, format siglab.SampleFormat, seconds int) (samples int64, drops uint64, err error) {
+	if tap == nil {
+		return 0, 0, fmt.Errorf("iq-autorecord: no control decoder for ddc tap")
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return 0, 0, fmt.Errorf("iq-autorecord: create %s: %w", path, err)
+	}
+	ch, unsub := tap.SubscribeVoiceIQ()
+	defer unsub()
+	enc := siglab.NewCaptureWriter(f, format)
+
+	// The DDC fan-out only broadcasts while the control pipeline is locked/active;
+	// a timer arm ends the capture after the requested duration even if the stream
+	// stalls (mirrors captureIQToFile's safety timer).
+	timer := time.NewTimer(time.Duration(seconds) * time.Second)
+	defer timer.Stop()
+	deadline := time.Now().Add(time.Duration(seconds) * time.Second)
+
+	streamErr := func() error {
+		for {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-timer.C:
+				return nil
+			case chunk, ok := <-ch:
+				if !ok {
+					return errors.New("iq-autorecord: voice tap closed before capture finished")
+				}
+				if werr := enc.Write(chunk); werr != nil {
+					return fmt.Errorf("write: %w", werr)
+				}
+				samples += int64(len(chunk))
+				if time.Now().After(deadline) {
+					return nil
+				}
+			}
+		}
+	}()
+
+	closeErr := f.Close()
+	if streamErr == nil && closeErr != nil && !errors.Is(closeErr, os.ErrClosed) {
+		streamErr = closeErr
+	}
+	// Subscriber drops are logged by the fan-out itself at unsubscribe; the DDC
+	// tap exposes no per-capture drop count, so report 0.
+	return samples, 0, streamErr
 }
 
 // Run drains the event subscription until ctx is cancelled. sub is an
@@ -269,7 +349,16 @@ func (a *iqAutoRecorder) runCapture(ctx context.Context, reason, system, protoco
 	}()
 
 	var centerHz, rateHz uint32
-	if a.broker != nil {
+	if a.cfg.TapDDC() {
+		// DDC tap: centre + rate come from the control decoder's channelised
+		// pipeline (≈144 kHz for TETRA), not the wideband SDR.
+		if a.ddc != nil {
+			if tap := a.ddc(); tap != nil {
+				centerHz = tap.CenterFreqHz()
+				rateHz = uint32(tap.PipelineRateHz() + 0.5)
+			}
+		}
+	} else if a.broker != nil {
 		centerHz = a.broker.CenterHz()
 		rateHz = a.broker.SampleRateHz()
 	}
@@ -278,6 +367,12 @@ func (a *iqAutoRecorder) runCapture(ctx context.Context, reason, system, protoco
 	}
 	if protocol == "" {
 		protocol = a.protocol
+	}
+	// Ensure the capture directory exists — a missing dir was the operator's
+	// "no such file or directory" capture failure. Cheap and idempotent.
+	if err := os.MkdirAll(a.dir, 0o755); err != nil {
+		a.log.Warn("iq-autorecord: could not create capture dir", "reason", reason, "dir", a.dir, "err", err)
+		return
 	}
 	path := filepath.Join(a.dir, autoRecordFilename(system, reason, at, centerHz, rateHz, a.format))
 

--- a/cmd/gophertrunk/iqautorecord_test.go
+++ b/cmd/gophertrunk/iqautorecord_test.go
@@ -2,6 +2,10 @@ package main
 
 import (
 	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -11,6 +15,119 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/siglab"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
+
+// fakeDDCTap is a stub ddcVoiceTap: SubscribeVoiceIQ pre-loads a buffered channel
+// with the configured chunks (then blocks, so the capture ends on its timer),
+// letting the DDC-tap capture path be exercised without a live decoder.
+type fakeDDCTap struct {
+	rate   float64
+	center uint32
+	chunks [][]complex64
+}
+
+func (f *fakeDDCTap) SubscribeVoiceIQ() (<-chan []complex64, func()) {
+	ch := make(chan []complex64, len(f.chunks)+1)
+	for _, c := range f.chunks {
+		ch <- c
+	}
+	return ch, func() {}
+}
+
+func (f *fakeDDCTap) PipelineRateHz() float64 { return f.rate }
+func (f *fakeDDCTap) CenterFreqHz() uint32    { return f.center }
+
+// TestCaptureDDCToFile checks the narrowband DDC capture writes every delivered
+// sample in the chosen format (cs16 = 4 bytes/sample) and ends cleanly on the
+// duration timer.
+func TestCaptureDDCToFile(t *testing.T) {
+	tap := &fakeDDCTap{rate: 144000, center: 467913000, chunks: [][]complex64{
+		make([]complex64, 128), make([]complex64, 128), make([]complex64, 128),
+	}}
+	path := filepath.Join(t.TempDir(), "ddc.cs16")
+	samples, _, err := captureDDCToFile(context.Background(), tap, path, siglab.FormatS16, 1)
+	if err != nil {
+		t.Fatalf("captureDDCToFile: %v", err)
+	}
+	if samples != 384 {
+		t.Errorf("samples = %d, want 384", samples)
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Size() != 384*4 {
+		t.Errorf("file size = %d, want %d (384 samples × 4 bytes cs16)", fi.Size(), 384*4)
+	}
+}
+
+// TestCaptureDDCToFileNilTap errors clearly when the control decoder is absent.
+func TestCaptureDDCToFileNilTap(t *testing.T) {
+	if _, _, err := captureDDCToFile(context.Background(), nil, filepath.Join(t.TempDir(), "x.cs16"), siglab.FormatS16, 1); err == nil {
+		t.Error("captureDDCToFile(nil tap) = nil error, want an error")
+	}
+}
+
+// TestAutoRecordDDCTapMetadata drives a full triggered capture with tap: ddc and
+// confirms the file + metadata carry the DDC pipeline rate (144 kHz) and control
+// centre, not the wideband SDR rate — and that a missing dir is created.
+func TestAutoRecordDDCTapMetadata(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "made", "on", "demand") // exercises MkdirAll
+	cfg := config.BasebandAutoRecordConfig{
+		Enabled: true, Dir: dir, Seconds: 1, Format: "cs16", Tap: "ddc",
+	}
+	tap := &fakeDDCTap{rate: 144000, center: 467913000, chunks: [][]complex64{make([]complex64, 144)}}
+	a := newIQAutoRecorder(cfg, "TETRA_Site_1", "tetra", "cc:same-carrier", nil, func() ddcVoiceTap { return tap }, nil)
+	if a == nil {
+		t.Fatal("newIQAutoRecorder returned nil")
+	}
+	now := time.Date(2026, 7, 24, 8, 0, 0, 0, time.UTC)
+	a.now = func() time.Time { return now }
+	a.runCapture(context.Background(), "concurrent", "TETRA_Site_1", "tetra", now)
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	var cs16, meta string
+	for _, e := range entries {
+		switch {
+		case strings.HasSuffix(e.Name(), ".cs16"):
+			cs16 = e.Name()
+		case strings.HasSuffix(e.Name(), ".metadata.json"):
+			meta = filepath.Join(dir, e.Name())
+		}
+	}
+	if cs16 == "" {
+		t.Fatalf("no .cs16 capture written; dir has %v", entries)
+	}
+	if !strings.Contains(cs16, "144000hz") {
+		t.Errorf("filename %q does not carry the DDC rate 144000hz", cs16)
+	}
+	if !strings.Contains(cs16, "467913000") {
+		t.Errorf("filename %q does not carry the control centre 467913000", cs16)
+	}
+	b, err := os.ReadFile(meta)
+	if err != nil {
+		t.Fatalf("read metadata: %v", err)
+	}
+	var m struct {
+		SampleRateHz float64 `json:"sample_rate_hz"`
+		CenterFreqHz uint32  `json:"center_freq_hz"`
+		Format       string  `json:"format"`
+	}
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("parse metadata: %v", err)
+	}
+	if m.SampleRateHz != 144000 {
+		t.Errorf("metadata sample_rate_hz = %v, want 144000 (DDC pipeline rate)", m.SampleRateHz)
+	}
+	if m.CenterFreqHz != 467913000 {
+		t.Errorf("metadata center_freq_hz = %d, want 467913000", m.CenterFreqHz)
+	}
+	if m.Format != "cs16" {
+		t.Errorf("metadata format = %q, want cs16", m.Format)
+	}
+}
 
 // fakeClock is a manually-advanced clock for deterministic cooldown tests.
 type fakeClock struct {
@@ -65,7 +182,7 @@ func newTestAutoRecorder(t *testing.T, cfg config.BasebandAutoRecordConfig) (*iq
 	if cfg.Seconds == 0 {
 		cfg.Seconds = 4
 	}
-	a := newIQAutoRecorder(cfg, "TETRA_Site_1", "tetra", "cc:same-carrier", nil, nil)
+	a := newIQAutoRecorder(cfg, "TETRA_Site_1", "tetra", "cc:same-carrier", nil, nil, nil)
 	if a == nil {
 		t.Fatal("newIQAutoRecorder returned nil for enabled config")
 	}
@@ -115,7 +232,7 @@ func grant(system string, tg uint32, ts uint8) trunking.Grant {
 }
 
 func TestAutoRecordDisabledReturnsNil(t *testing.T) {
-	if a := newIQAutoRecorder(config.BasebandAutoRecordConfig{Enabled: false}, "s", "tetra", "x", nil, nil); a != nil {
+	if a := newIQAutoRecorder(config.BasebandAutoRecordConfig{Enabled: false}, "s", "tetra", "x", nil, nil, nil); a != nil {
 		t.Fatal("expected nil for disabled config")
 	}
 }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1314,6 +1314,12 @@ broadcast:
 #     enabled: true
 #     dir: "../iq/auto/"
 #     format: cs16               # cs16 (default) | f32 (GNU Radio cfile) | u8
+#     tap: wideband              # wideband (default, full-rate SDR — large files)
+#                                # | ddc (narrowband channelised stream at the
+#                                #   pipeline rate, e.g. 144 kHz for TETRA — far
+#                                #   smaller and directly replayable). For a
+#                                #   same-carrier TETRA site the ddc tap holds all
+#                                #   four voice timeslots of the control carrier.
 #     seconds: 8                 # capture length per trigger
 #     cooldown: 10s              # min gap between automatic triggers
 #     on_concurrent_calls: 2     # fire at N+ concurrent calls (0 = off)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -533,6 +533,22 @@ type BasebandAutoRecordConfig struct {
 	OnEncrypted bool `yaml:"on_encrypted"`
 	// OnEmergency fires on an emergency-flagged grant.
 	OnEmergency bool `yaml:"on_emergency"`
+	// Tap selects what IQ is captured, mirroring BasebandRecordConfig.Tap:
+	//   "wideband" (default) — the control SDR's full-rate raw IQ (the historical
+	//     behaviour; large files, e.g. ~50 MB per 30 s at 2.5 MS/s).
+	//   "ddc" — the control decoder's narrowband digital-down-converter output
+	//     (the channelised stream at the pipeline rate: 144 kHz for TETRA, ~48 kHz
+	//     for the C4FM family). Orders of magnitude smaller and directly replayable
+	//     with `replay -format wav` / siglab. For a same-carrier TETRA site the DDC
+	//     tap holds all four voice timeslots of the control carrier — exactly the
+	//     channel worth sharing when a hard-to-decode call fires a trigger.
+	Tap string `yaml:"tap"`
+}
+
+// TapDDC reports whether triggered captures tap the narrowband DDC output rather
+// than the wideband SDR stream. Mirrors BasebandRecordConfig.TapDDC.
+func (a BasebandAutoRecordConfig) TapDDC() bool {
+	return strings.EqualFold(strings.TrimSpace(a.Tap), "ddc")
 }
 
 // autoRecordDefaultCooldown is used when Cooldown is empty.
@@ -2539,6 +2555,11 @@ func (c Config) validateBaseband() []error {
 		}
 		if a.OnConcurrentCalls < 0 {
 			errs = append(errs, fmt.Errorf("baseband.auto_record: on_concurrent_calls must not be negative"))
+		}
+		switch strings.ToLower(strings.TrimSpace(a.Tap)) {
+		case "", "wideband", "ddc":
+		default:
+			errs = append(errs, fmt.Errorf("baseband.auto_record: tap must be wideband|ddc, got %q", a.Tap))
 		}
 		if _, err := a.CooldownDuration(); err != nil {
 			errs = append(errs, fmt.Errorf("baseband.auto_record: cooldown %q: %w", a.Cooldown, err))

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -363,6 +363,9 @@ func TestValidate(t *testing.T) {
 		{"auto_record missing dir", Config{Baseband: BasebandConfig{AutoRecord: BasebandAutoRecordConfig{Enabled: true, Seconds: 8, OnNoVoiceDevice: true}}}, true},
 		{"auto_record zero seconds", Config{Baseband: BasebandConfig{AutoRecord: BasebandAutoRecordConfig{Enabled: true, Dir: "iq", OnConcurrentCalls: 2}}}, true},
 		{"auto_record bad format", Config{Baseband: BasebandConfig{AutoRecord: BasebandAutoRecordConfig{Enabled: true, Dir: "iq", Seconds: 8, Format: "flac", OnEncrypted: true}}}, true},
+		{"auto_record tap ddc ok", Config{Baseband: BasebandConfig{AutoRecord: BasebandAutoRecordConfig{Enabled: true, Dir: "iq", Seconds: 8, Tap: "ddc", OnConcurrentCalls: 2}}}, false},
+		{"auto_record tap wideband ok", Config{Baseband: BasebandConfig{AutoRecord: BasebandAutoRecordConfig{Enabled: true, Dir: "iq", Seconds: 8, Tap: "wideband"}}}, false},
+		{"auto_record bad tap", Config{Baseband: BasebandConfig{AutoRecord: BasebandAutoRecordConfig{Enabled: true, Dir: "iq", Seconds: 8, Tap: "narrowband"}}}, true},
 		{"auto_record bad cooldown", Config{Baseband: BasebandConfig{AutoRecord: BasebandAutoRecordConfig{Enabled: true, Dir: "iq", Seconds: 8, Cooldown: "soon", OnEncrypted: true}}}, true},
 		{"auto_record negative concurrent", Config{Baseband: BasebandConfig{AutoRecord: BasebandAutoRecordConfig{Enabled: true, Dir: "iq", Seconds: 8, OnConcurrentCalls: -1}}}, true},
 	}

--- a/internal/configbuilder/fieldmeta.go
+++ b/internal/configbuilder/fieldmeta.go
@@ -393,6 +393,7 @@ var fieldMetas = map[string]FieldMeta{
 	"BasebandAutoRecordConfig.OnNoVoiceDevice":   {Label: "On no voice device", Help: "Fire when a grant arrives but every voice tuner is busy."},
 	"BasebandAutoRecordConfig.OnEncrypted":       {Label: "On encrypted", Help: "Fire on a grant flagged encrypted."},
 	"BasebandAutoRecordConfig.OnEmergency":       {Label: "On emergency", Help: "Fire on an emergency-flagged grant."},
+	"BasebandAutoRecordConfig.Tap":               {Help: "What IQ to capture: wideband (default, full-rate SDR — large files) or ddc (narrowband channelised stream at the pipeline rate, e.g. 144 kHz for TETRA — far smaller and directly replayable).", Options: opts("", "wideband (default)", "ddc", "ddc")},
 
 	// ---- Paging ------------------------------------------------------------
 	"PagingConfig.POCSAG":               {Label: "POCSAG", Help: "POCSAG channels, each pinning one SDR to a paging frequency."},

--- a/internal/radio/tetra/control.go
+++ b/internal/radio/tetra/control.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
@@ -93,6 +94,13 @@ type ControlChannel struct {
 	pendingSoft     []complex64
 	pendingSoftBase int
 	pendingSoftSet  bool
+
+	// lastActivityNano is the Unix-nanos timestamp of the most recent
+	// successful control-channel decode (a synchronisation burst, SYSINFO,
+	// or grant). It is the heartbeat CheckStale watches to declare the lock
+	// lost when the carrier goes silent. Atomic so the decode hot path
+	// (noteActivity) never contends on mu. Zero until the first decode.
+	lastActivityNano atomic.Int64
 }
 
 // StashSoft records the soft per-symbol differentials for the dibit
@@ -543,7 +551,35 @@ func (c *ControlChannel) publishGrant(g VoiceGrant) {
 		"group", g.Group, "enc", g.Encrypted, "emer", g.Emergency)
 }
 
+// noteActivity stamps the control-channel heartbeat with the current time.
+// Called from the decode path on every successful CC recovery (sync burst,
+// SYSINFO, grant) so CheckStale can tell a live carrier from a silent one.
+// Lock-free (atomic) so it adds no contention to the hot path.
+func (c *ControlChannel) noteActivity() {
+	c.lastActivityNano.Store(c.now().UnixNano())
+}
+
+// CheckStale declares the control channel lost (publishes cc.lost via MarkLost)
+// when it is locked but has decoded nothing for longer than timeout. This is the
+// watchdog the cchunt supervisor needs to leave StateLocked and re-hunt when the
+// carrier genuinely goes silent — TETRA's maybeLock is edge-triggered and never
+// re-affirms a steady lock, so without this a dead carrier would never surface a
+// cc.lost. A no-op until the first decode (lastActivity==0), while unlocked, or
+// while activity is fresh, so a healthy carrier (sync burst every ~1 s) never
+// trips it.
+func (c *ControlChannel) CheckStale(now time.Time, timeout time.Duration) {
+	last := c.lastActivityNano.Load()
+	if last == 0 {
+		return
+	}
+	if now.Sub(time.Unix(0, last)) <= timeout {
+		return
+	}
+	c.MarkLost()
+}
+
 func (c *ControlChannel) maybeLock(s LockState) {
+	c.noteActivity()
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.locked && c.last == s {
@@ -566,8 +602,10 @@ func (c *ControlChannel) maybeLock(s LockState) {
 		"la", s.LocationArea, "system", c.systemName)
 }
 
-// MarkLost publishes cc.lost and resets the locked flag. The trunking
-// engine's hunter calls this when the control channel goes silent.
+// MarkLost publishes cc.lost and resets the locked flag. CheckStale calls this
+// when a locked control channel has gone silent past the staleness timeout, so
+// the cchunt supervisor leaves StateLocked and re-hunts. Idempotent while
+// already unlocked.
 func (c *ControlChannel) MarkLost() {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/internal/radio/tetra/control_watchdog_test.go
+++ b/internal/radio/tetra/control_watchdog_test.go
@@ -1,0 +1,109 @@
+package tetra
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TestControlChannelStaleLockPublishesLost is the regression for the flapping
+// "CC hunt failed · candidates exhausted" seen while a TETRA control channel is
+// still decoding: TETRA's maybeLock is edge-triggered, so a steady lock never
+// re-affirms and the cchunt supervisor could never leave StateLocked. CheckStale
+// is the watchdog that turns a genuinely silent carrier into a cc.lost so the
+// supervisor re-hunts. This asserts: a fresh lock does NOT publish cc.lost, and a
+// lock that has decoded nothing for longer than the timeout DOES.
+func TestControlChannelStaleLockPublishesLost(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	now := time.Unix(1_000, 0)
+	cc := New(Options{
+		Bus:         bus,
+		Log:         slog.Default(),
+		SystemName:  "Sys",
+		FrequencyHz: 467_913_000,
+		Now:         func() time.Time { return now },
+	})
+
+	// Lock the control channel. maybeLock stamps the activity heartbeat.
+	cc.maybeLock(LockState{FrequencyHz: 467_913_000})
+	if !cc.Locked() {
+		t.Fatal("control channel did not lock")
+	}
+
+	countLost := func() int {
+		n := 0
+		for {
+			select {
+			case ev := <-sub.C:
+				if ev.Kind == events.KindCCLost {
+					if lp, ok := ev.Payload.(trunking.LockedPayload); ok && lp.LockedFrequencyHz() == 467_913_000 {
+						n++
+					}
+				}
+			default:
+				return n
+			}
+		}
+	}
+	countLost() // drain the cc.locked (and anything else) so far
+
+	// Fresh activity (3 s < 5 s timeout): no cc.lost.
+	now = now.Add(3 * time.Second)
+	cc.CheckStale(now, 5*time.Second)
+	if got := countLost(); got != 0 {
+		t.Errorf("cc.lost published %d times while activity is fresh, want 0", got)
+	}
+	if !cc.Locked() {
+		t.Error("control channel unlocked while activity was still fresh")
+	}
+
+	// A further sync burst refreshes the heartbeat; the clock advancing past the
+	// timeout relative to the ORIGINAL lock must not trip it once refreshed.
+	cc.noteActivity()              // simulates a decodeSB heartbeat at t=1003
+	now = now.Add(4 * time.Second) // t=1007, 4 s since the refresh
+	cc.CheckStale(now, 5*time.Second)
+	if got := countLost(); got != 0 {
+		t.Errorf("cc.lost published %d times after a heartbeat refresh, want 0", got)
+	}
+
+	// Now go silent past the timeout: cc.lost fires and the lock drops.
+	now = now.Add(6 * time.Second) // 6 s since the last heartbeat
+	cc.CheckStale(now, 5*time.Second)
+	if got := countLost(); got != 1 {
+		t.Errorf("cc.lost published %d times after going silent, want 1", got)
+	}
+	if cc.Locked() {
+		t.Error("control channel still locked after the staleness watchdog fired")
+	}
+}
+
+// TestControlChannelCheckStaleNoopBeforeFirstDecode guards the startup case:
+// CheckStale must do nothing until the channel has actually decoded something
+// (lastActivity==0), so a freshly-constructed channel is never declared lost.
+func TestControlChannelCheckStaleNoopBeforeFirstDecode(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	now := time.Unix(2_000, 0)
+	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Sys", FrequencyHz: 1, Now: func() time.Time { return now }})
+
+	now = now.Add(time.Hour)
+	cc.CheckStale(now, 5*time.Second)
+
+	select {
+	case ev := <-sub.C:
+		if ev.Kind == events.KindCCLost {
+			t.Error("cc.lost published before the channel ever decoded anything")
+		}
+	default:
+	}
+}

--- a/internal/radio/tetra/process.go
+++ b/internal/radio/tetra/process.go
@@ -324,6 +324,9 @@ func (c *ControlChannel) decodeSB(p *processState, L int) {
 		return
 	}
 	c.addStat(&c.stats.BSCHOK, 1)
+	// Heartbeat: a CRC-clean sync burst is the ~1 s cadence that proves the
+	// carrier is still live, independent of voice traffic. Feeds CheckStale.
+	c.noteActivity()
 	c.log.Debug("tetra: sync burst decoded",
 		"sts_at", L, "rot", bschRot,
 		"colour_code", sync.ExtendedColourCode()&0x3F,

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -644,19 +644,45 @@ func newTETRAPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 // decoder.go.
 const tetraStatusInterval = 5 * time.Second
 
+// tetraLockStaleTimeout is how long a locked TETRA control channel may decode
+// nothing before the watchdog (ControlChannel.CheckStale) declares it lost and
+// publishes cc.lost, so the cchunt supervisor leaves StateLocked and re-hunts.
+// Generous (~5 missed multiframes at the ~1 s BSCH cadence) so brief fades or a
+// momentarily busy carrier never trip it, while a genuinely dead carrier is
+// surfaced within a few seconds. tetraStaleCheckInterval throttles how often
+// Process runs the (cheap) check.
+const (
+	tetraLockStaleTimeout   = 5 * time.Second
+	tetraStaleCheckInterval = 1 * time.Second
+)
+
 type tetraPipeline struct {
-	rx      *tetrarx.Receiver
-	cc      *tetra.ControlChannel
-	log     *slog.Logger
-	system  string
-	debug   bool
-	now     func() time.Time // injectable for tests; set to time.Now at construction
-	lastLog time.Time        // wall clock of the previous status line (zero ⇒ not primed)
+	rx        *tetrarx.Receiver
+	cc        *tetra.ControlChannel
+	log       *slog.Logger
+	system    string
+	debug     bool
+	now       func() time.Time // injectable for tests; set to time.Now at construction
+	lastLog   time.Time        // wall clock of the previous status line (zero ⇒ not primed)
+	lastStale time.Time        // wall clock of the previous lock-staleness check
 }
 
 func (p *tetraPipeline) Process(iq []complex64) {
 	p.rx.Process(iq)
+	p.checkLockStale()
 	p.maybeLogStatus()
+}
+
+// checkLockStale runs the control-channel lock watchdog on a light throttle.
+// Unlike maybeLogStatus it is NOT debug-gated — the watchdog must run in
+// production so a silent carrier surfaces cc.lost and the supervisor re-hunts.
+func (p *tetraPipeline) checkLockStale() {
+	now := p.now()
+	if now.Sub(p.lastStale) < tetraStaleCheckInterval {
+		return
+	}
+	p.lastStale = now
+	p.cc.CheckStale(now, tetraLockStaleTimeout)
 }
 
 // tetraEffectiveBaud derives the effective symbol rate (baud) and its
@@ -713,6 +739,7 @@ func (p *tetraPipeline) maybeLogStatus() {
 func (p *tetraPipeline) Reset() {
 	p.rx.Reset()
 	p.lastLog = time.Time{}
+	p.lastStale = time.Time{}
 }
 func (p *tetraPipeline) Close() error { return nil }
 

--- a/internal/scanner/ccdecoder/voicetap.go
+++ b/internal/scanner/ccdecoder/voicetap.go
@@ -3,6 +3,7 @@ package ccdecoder
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"sync"
 	"sync/atomic"
@@ -140,6 +141,20 @@ func NewCCVoiceSource(get func() *Decoder, serial string) *CCVoiceSource {
 }
 
 func (s *CCVoiceSource) Serial() string { return s.serial }
+
+// CarrierKey returns a stable identifier for the control carrier this tap shares
+// with the other same-carrier taps. Every cc:same-carrier:N source backed by the
+// same control decoder returns the same key, so the voice composer groups them
+// under one shared per-carrier TETRA voice demux (one receiver + demux for the
+// whole carrier, instead of one per concurrent call). Empty while the control
+// decoder is not yet constructed (the source never binds then anyway).
+func (s *CCVoiceSource) CarrierKey() string {
+	dec := s.get()
+	if dec == nil {
+		return ""
+	}
+	return fmt.Sprintf("cc-same-carrier:%p", dec)
+}
 
 // SetCenterFreq is a no-op: the carrier is already tuned by the control decoder.
 func (s *CCVoiceSource) SetCenterFreq(uint32) error { return nil }

--- a/internal/scanner/cchunt/supervisor.go
+++ b/internal/scanner/cchunt/supervisor.go
@@ -194,6 +194,20 @@ func (s *Supervisor) Run(ctx context.Context) error {
 			s.waitOrSleep(ctx, minDur(remaining, 500*time.Millisecond))
 			continue
 		}
+		// Park an already-locked system instead of re-hunting it. A cc.locked
+		// edge (recordLock → StateLocked) can land AFTER a hunt round already
+		// failed and backed off — e.g. a TETRA control channel whose cold
+		// acquisition (BSCH sync + colour code) took longer than the dwell.
+		// Without this the loop re-hunts a system it already knows is locked,
+		// and because an edge-triggered decoder (TETRA) never re-emits cc.locked
+		// on the same locked pipeline, every such re-hunt exhausts the dwell and
+		// reports "candidates exhausted" while the decoder keeps decoding calls.
+		// parkUntilUnlocked returns as soon as the state leaves StateLocked,
+		// which the protocol's lock-loss watchdog (cc.lost) drives on real loss.
+		if s.isLocked(name) {
+			s.parkUntilUnlocked(ctx, name)
+			continue
+		}
 
 		s.startRound(name)
 		hunter, err := trunking.NewHunter(trunking.HunterOptions{
@@ -543,6 +557,15 @@ func (s *Supervisor) isHeld(name string) bool {
 	defer s.mu.RUnlock()
 	rt := s.states[name]
 	return rt != nil && rt.heldByOp
+}
+
+// isLocked reports whether the system is already in StateLocked (a cc.locked
+// edge was observed), so the Run loop parks it instead of re-hunting.
+func (s *Supervisor) isLocked(name string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	rt := s.states[name]
+	return rt != nil && rt.state == StateLocked && !rt.heldByOp
 }
 
 // --- operator mutation surface ---

--- a/internal/scanner/cchunt/supervisor_test.go
+++ b/internal/scanner/cchunt/supervisor_test.go
@@ -215,6 +215,105 @@ func TestSupervisorPauseAllResumeAll(t *testing.T) {
 	}
 }
 
+// TestSupervisorParksAfterLateLock is the regression for the flapping
+// "CC hunt failed · candidates exhausted" a TETRA system shows while it is
+// actually locked and decoding. A cc.locked edge can land AFTER a hunt round has
+// already failed and backed off (TETRA cold acquisition outlasting the dwell);
+// an edge-triggered decoder then never re-emits cc.locked, so every subsequent
+// re-hunt exhausts the dwell. The supervisor must PARK a system it already knows
+// is StateLocked instead of re-hunting it — and a later cc.lost (from the
+// protocol's lock-loss watchdog) must un-park it so a genuinely dead carrier
+// still recovers.
+func TestSupervisorParksAfterLateLock(t *testing.T) {
+	bus := events.NewBus(128)
+	defer bus.Close()
+	tuner := &fakeTuner{}
+	sys := trunking.System{
+		Name:            "Late",
+		Protocol:        trunking.ProtocolP25,
+		ControlChannels: []uint32{851_000_000}, // single candidate
+	}
+	sup, err := New(Options{
+		Bus:            bus,
+		Tuner:          tuner,
+		Systems:        []trunking.System{sys},
+		Dwell:          40 * time.Millisecond,
+		InitialBackoff: 120 * time.Millisecond,
+		MaxBackoff:     120 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sub := bus.Subscribe()
+	defer sub.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = sup.Run(ctx) }()
+
+	waitKind := func(kind events.Kind, within time.Duration) bool {
+		deadline := time.After(within)
+		for {
+			select {
+			case ev := <-sub.C:
+				if ev.Kind == kind {
+					return true
+				}
+			case <-deadline:
+				return false
+			}
+		}
+	}
+	countKind := func(kind events.Kind, window time.Duration) int {
+		n := 0
+		deadline := time.After(window)
+		for {
+			select {
+			case ev := <-sub.C:
+				if ev.Kind == kind {
+					n++
+				}
+			case <-deadline:
+				return n
+			}
+		}
+	}
+
+	// The first hunt fails (nothing locks within the dwell) — the scenario the
+	// fix targets: a failure BEFORE any lock is observed.
+	if !waitKind(events.KindHuntFailed, 2*time.Second) {
+		t.Fatal("never saw the initial HuntFailed")
+	}
+	// A late lock lands during the ensuing backoff (no hunt in flight).
+	bus.Publish(events.Event{Kind: events.KindCCLocked, Payload: fakeLock{freq: 851_000_000}})
+
+	// The supervisor must reach StateLocked and stay parked there.
+	lockedDeadline := time.Now().Add(time.Second)
+	for {
+		if sup.Snapshot()[0].State == StateLocked {
+			break
+		}
+		if time.Now().After(lockedDeadline) {
+			t.Fatalf("never reached StateLocked: %+v", sup.Snapshot())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Parked: no further HuntFailed across several would-be backoff rounds.
+	if got := countKind(events.KindHuntFailed, 500*time.Millisecond); got != 0 {
+		t.Errorf("saw %d HuntFailed after the lock — the supervisor re-hunts an already-locked system instead of parking", got)
+	}
+	if st := sup.Snapshot()[0].State; st != StateLocked {
+		t.Errorf("state after parking = %q, want locked", st)
+	}
+
+	// A cc.lost un-parks the system and a fresh hunt begins (recovery).
+	bus.Publish(events.Event{Kind: events.KindCCLost, Payload: fakeLock{freq: 851_000_000}})
+	if !waitKind(events.KindHuntProgress, time.Second) {
+		t.Error("no new hunt round after cc.lost — a dead carrier would never recover")
+	}
+}
+
 func TestSupervisorForceRetuneClearsBackoff(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()

--- a/internal/voice/composer/composer.go
+++ b/internal/voice/composer/composer.go
@@ -268,6 +268,21 @@ type Composer struct {
 
 	mu     sync.Mutex
 	chains map[string]*chain
+	// tetraDemuxes holds one shared voice demultiplexer per same-carrier TETRA
+	// control carrier (keyed by sameCarrierSource.CarrierKey). It decodes the
+	// carrier once and routes each burst to the single call that owns its AACH
+	// usage marker, so concurrent same-carrier calls decode independently without
+	// the per-call pre-anchor / hangtime-reuse cross-slot leaks. See tetra_voice.go.
+	tetraDemuxes map[string]*tetraSlotDemux
+}
+
+// sameCarrierSource is the optional capability a voice IQ source implements when
+// it is a shared same-carrier tap: several such taps on one control carrier
+// deliver the same post-DDC stream, so they must share ONE TETRA voice demux
+// rather than each running its own receiver. CarrierKey groups the taps that
+// belong to the same physical carrier. Implemented by ccdecoder.CCVoiceSource.
+type sameCarrierSource interface {
+	CarrierKey() string
 }
 
 type chain struct {
@@ -334,26 +349,27 @@ func New(opts Options) (*Composer, error) {
 		log = slog.Default()
 	}
 	c := &Composer{
-		bus:        opts.Bus,
-		dev:        opts.Devices,
-		sink:       opts.Sink,
-		engine:     opts.Engine,
-		log:        log,
-		iqHz:       opts.IQSampleRate,
-		pcmHz:      opts.PCMSampleRate,
-		bw:         opts.VoiceBandwidthHz,
-		touchEvery: opts.TouchInterval,
-		hangtime:   opts.VoiceHangtime,
-		splitTx:    opts.SplitPerTransmission,
-		eqCfg:      opts.Equalizer,
-		deemphCfg:  opts.DeEmphasis,
-		lpfCfg:     opts.AudioLPF,
-		agcCfg:     opts.AudioAGC,
-		resampCfg:  opts.AudioResampler,
-		autotune:   opts.Autotune,
-		cryptoSink: opts.CryptoSink,
-		chains:     make(map[string]*chain),
-		runDone:    make(chan struct{}),
+		bus:          opts.Bus,
+		dev:          opts.Devices,
+		sink:         opts.Sink,
+		engine:       opts.Engine,
+		log:          log,
+		iqHz:         opts.IQSampleRate,
+		pcmHz:        opts.PCMSampleRate,
+		bw:           opts.VoiceBandwidthHz,
+		touchEvery:   opts.TouchInterval,
+		hangtime:     opts.VoiceHangtime,
+		splitTx:      opts.SplitPerTransmission,
+		eqCfg:        opts.Equalizer,
+		deemphCfg:    opts.DeEmphasis,
+		lpfCfg:       opts.AudioLPF,
+		agcCfg:       opts.AudioAGC,
+		resampCfg:    opts.AudioResampler,
+		autotune:     opts.Autotune,
+		cryptoSink:   opts.CryptoSink,
+		chains:       make(map[string]*chain),
+		tetraDemuxes: make(map[string]*tetraSlotDemux),
+		runDone:      make(chan struct{}),
 	}
 	c.sub = opts.Bus.Subscribe()
 	return c, nil
@@ -455,6 +471,22 @@ func (c *Composer) handleStart(parent context.Context, cs trunking.CallStart) {
 	}
 	c.mu.Unlock()
 
+	// Same-carrier TETRA: route through the shared per-carrier voice demux instead
+	// of opening a per-call IQ subscription + receiver. One demux decodes the
+	// carrier and delivers each burst only to the call that currently owns that
+	// burst's AACH usage marker, eliminating the per-call pre-anchor accept-all and
+	// hangtime marker-reuse leaks. Non-same-carrier TETRA (a dedicated retuned voice
+	// SDR — one call per tap) and every other protocol fall through to the per-call
+	// StreamIQ path below.
+	if isTETRAVoice {
+		if scs, ok := src.(sameCarrierSource); ok {
+			if key := scs.CarrierKey(); key != "" {
+				c.followTETRASameCarrier(parent, src, key, cs)
+				return
+			}
+		}
+	}
+
 	chainCtx, cancel := context.WithCancel(parent)
 	iqCh, err := src.StreamIQ(chainCtx)
 	if err != nil {
@@ -537,11 +569,95 @@ func (c *Composer) cancelAll() {
 	c.mu.Lock()
 	chains := c.chains
 	c.chains = make(map[string]*chain)
+	demuxes := c.tetraDemuxes
+	c.tetraDemuxes = make(map[string]*tetraSlotDemux)
 	c.mu.Unlock()
+	// Cancel the per-call chains first so their owners unregister from the
+	// demuxes, then tear the demuxes down.
 	for _, ch := range chains {
 		ch.cancel()
 		<-ch.done
 	}
+	for _, d := range demuxes {
+		d.cancel()
+		<-d.done
+	}
+}
+
+// followTETRASameCarrier binds one same-carrier TETRA call to the carrier's
+// shared voice demux: it ensures the demux exists, then spawns a thin chain
+// goroutine that registers this call as the owner of its granted AACH usage
+// marker and unregisters on call end. The chain does no IQ work of its own — the
+// demux delivers its marker's decoded speech frames.
+func (c *Composer) followTETRASameCarrier(parent context.Context, src IQSource, key string, cs trunking.CallStart) {
+	d := c.ensureTETRADemux(parent, key, src, cs.Grant.TETRAColourExt)
+	if d == nil {
+		c.log.Warn("composer: could not start TETRA voice demux", "serial", cs.DeviceSerial, "key", key)
+		return
+	}
+	chainCtx, cancel := context.WithCancel(parent)
+	ch := &chain{cancel: cancel, done: make(chan struct{})}
+	c.mu.Lock()
+	c.chains[cs.DeviceSerial] = ch
+	c.mu.Unlock()
+	go c.runTETRASameCarrierChain(chainCtx, d, cs.DeviceSerial, cs.Grant.GroupID, cs.Grant.Timeslot, cs.Grant.TETRAUsageMarker, ch.done)
+}
+
+// ensureTETRADemux returns the shared voice demux for a control carrier, creating
+// and starting it on first use. The demux lives for the composer's lifetime (its
+// SB anchor + AACH state stay warm across calls, so a new call never re-anchors
+// from scratch) until Close/cancelAll or the control decoder's IQ stream closes.
+// Only ever called from the single Run goroutine, so the create is race-free.
+func (c *Composer) ensureTETRADemux(parent context.Context, key string, src IQSource, colourExt uint32) *tetraSlotDemux {
+	c.mu.Lock()
+	if d := c.tetraDemuxes[key]; d != nil {
+		c.mu.Unlock()
+		return d
+	}
+	d := &tetraSlotDemux{
+		c:      c,
+		key:    key,
+		colour: colourExt,
+		owners: make(map[uint8]*tetraSlotOwner),
+		done:   make(chan struct{}),
+	}
+	c.tetraDemuxes[key] = d
+	c.mu.Unlock()
+
+	demuxCtx, cancel := context.WithCancel(parent)
+	d.cancel = cancel
+	iqCh, err := src.StreamIQ(demuxCtx)
+	if err != nil {
+		cancel()
+		c.mu.Lock()
+		delete(c.tetraDemuxes, key)
+		c.mu.Unlock()
+		close(d.done)
+		c.log.Warn("composer: TETRA voice demux StreamIQ failed", "key", key, "err", err)
+		return nil
+	}
+	rateHzF := float64(src.SampleRateHz())
+	if rateHzF == 0 {
+		rateHzF = float64(c.iqHz)
+	}
+	if exact, ok := src.(exactRateSource); ok {
+		if r := exact.SampleRateExactHz(); r > 0 {
+			rateHzF = r
+		}
+	}
+	go d.run(demuxCtx, iqCh, rateHzF)
+	return d
+}
+
+// removeTETRADemux drops a demux from the registry once its IQ stream has ended
+// (self-called from the demux goroutine), so the next same-carrier grant builds a
+// fresh one (e.g. after a control-SDR reacquire swaps the decoder).
+func (c *Composer) removeTETRADemux(key string, d *tetraSlotDemux) {
+	c.mu.Lock()
+	if c.tetraDemuxes[key] == d {
+		delete(c.tetraDemuxes, key)
+	}
+	c.mu.Unlock()
 }
 
 // runFMChain consumes IQ for one call. The chain is intentionally

--- a/internal/voice/composer/tetra_voice.go
+++ b/internal/voice/composer/tetra_voice.go
@@ -3,6 +3,7 @@ package composer
 import (
 	"context"
 	"math"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -42,28 +43,24 @@ func newTETRAVoiceFrontEnd(iqHz float64, bw uint32) *decimatingFIR {
 	return newDecimatingFIR(iqHz, tetraVoiceIntermediateHz, chanBW, filterAtUnity)
 }
 
-// runTETRAVoiceChain consumes IQ for one TETRA traffic-channel call. It
+// runTETRAVoiceChain consumes IQ for one TETRA traffic-channel call on a SOLO tap
+// — a dedicated retuned voice SDR carrying a single call (one call per traffic
+// carrier), NOT a same-carrier SCBS. (Concurrent same-carrier calls go through the
+// shared per-carrier tetraSlotDemux instead — see followTETRASameCarrier.) It
 // decimates the tap IQ to the TETRA symbol rate, recovers the π/4-DQPSK dibit
-// stream with the shared TETRA receiver, extracts each Normal Continuous
-// Downlink Burst's two data blocks (tetra.TrafficExtractor), TCH/S-decodes each
-// burst, and emits the recovered 137-bit speech frames to the recorder — which
-// renders them to PCM with the clean-room ACELP vocoder ("tetra-acelp") and
-// writes both the decoded WAV and a `.raw` sidecar of the speech frames. This
-// mirrors the DMR/P25 shape (post-FEC frames in `.raw` + decoded WAV).
+// stream with the shared TETRA receiver, extracts each Normal Continuous Downlink
+// Burst's two data blocks (tetra.TrafficExtractor), TCH/S-decodes each burst, and
+// emits the recovered 137-bit speech frames to the recorder — which renders them
+// to PCM with the clean-room ACELP vocoder ("tetra-acelp") and writes both the
+// decoded WAV and a `.raw` sidecar. This mirrors the DMR/P25 shape.
 //
-// The extractor emits a burst for every timeslot on the carrier (all four TDMA
-// slots), each tagged with the AACH downlink usage marker of the slot it came
-// from. This chain keeps only bursts whose marker matches the granted call's
-// usage marker and drops the rest (onTETRATrafficBurst), so up to four concurrent
-// calls on one carrier — one per slot, each on its own same-carrier tap — decode
-// into four independent recordings instead of mixing. The AACH usage marker, not
-// the channel-allocation timeslot field, is the demux key: on real air the grant
-// timeslot does not map to the physical slot (distinct calls collide on one
-// value), which silently starved every mis-mapped call. When the grant carries no
-// usage marker, or a burst's AACH does not decode, the chain falls back to
-// TCH/S-CRC single-call isolation so a call's own speech is never dropped on a
-// guess. Encrypted calls (TEA1-4) fail the CRC and produce no decoded audio
-// (their raw bursts still exist upstream).
+// Each burst is tagged with the AACH downlink usage marker of the slot it came
+// from; the chain keeps only bursts whose marker matches the granted call's
+// (onTETRATrafficBurst). When the grant carries no usage marker, or a burst's AACH
+// does not decode, the chain falls back to TCH/S-CRC single-call isolation so a
+// call's own speech is never dropped on a guess — which is the common case on a
+// solo tap (one call present). Encrypted calls (TEA1-4) fail the CRC and produce
+// no decoded audio (their raw bursts still exist upstream).
 func (c *Composer) runTETRAVoiceChain(ctx context.Context, serial string, iqCh <-chan []complex64, iqHz float64, groupID uint32, timeslot uint8, colourExt uint32, usageMarker uint8, done chan<- struct{}) {
 	defer close(done)
 	defer gtlog.Recover(c.log, "voice-chain-tetra:"+serial, nil)
@@ -164,8 +161,16 @@ func (c *Composer) onTETRATrafficBurst(bt *boundaryTracker, rs rawFrameSink, ser
 		offSlot.Add(1)
 		return
 	}
-	// TCH/S-decode the burst. Only bursts whose class-2 CRC verifies are TCH/S
-	// speech for the granted call; everything else yields no frames.
+	c.decodeTETRASpeech(bt, rs, serial, frame, speech)
+}
+
+// decodeTETRASpeech TCH/S-decodes one traffic frame for an owning call: it
+// recovers the CRC-valid 137-bit speech frames, refreshes call liveness (only on
+// real speech, never on raw bursts) and appends each frame to the recorder's
+// `.raw` sidecar (the ACELP vocoder renders it to PCM downstream). A non-TCH/S
+// burst (signalling, encrypted, or corrupt) yields no frames and does not touch
+// liveness. Shared by the solo traffic tap and the same-carrier slot demux.
+func (c *Composer) decodeTETRASpeech(bt *boundaryTracker, rs rawFrameSink, serial string, frame []byte, speech *atomic.Uint64) {
 	frames := tetra.TCHSpeechFrames(frame)
 	if len(frames) == 0 {
 		// Not the granted call's speech — do NOT touch call liveness.
@@ -179,9 +184,196 @@ func (c *Composer) onTETRATrafficBurst(bt *boundaryTracker, rs rawFrameSink, ser
 	// Emit each recovered 137-bit speech frame to the recorder, which renders it
 	// with the ACELP vocoder and appends it to the `.raw` sidecar.
 	for _, sf := range frames {
-		speech.Add(1)
+		if speech != nil {
+			speech.Add(1)
+		}
 		if err := rs.WriteRawFrame(serial, sf); err != nil {
 			c.log.Warn("composer: TETRA speech-frame write failed", "serial", serial, "err", err)
 		}
 	}
+}
+
+// --- Shared per-carrier TETRA voice demultiplexer --------------------------
+//
+// On a TETRA single-carrier base station every concurrent call rides a different
+// TDMA timeslot of the SAME control carrier, and all same-carrier voice taps see
+// the SAME post-DDC IQ (the control decoder's voice fan-out, ccdecoder/voicetap.go).
+// Running a fresh receiver + TrafficExtractor per call caused cross-slot audio
+// leaks:
+//
+//   - pre-anchor accept-all: a fresh per-call extractor had no reference frame yet,
+//     so it could not tell one call's speech from another's for the first second.
+//   - hangtime marker reuse: a call lingers in hangtime after its speech stops; if
+//     the network reuses its usage marker for a new call, a per-call chain (which
+//     cannot evict a peer) kept decoding it into the old call's recording.
+//
+// tetraSlotDemux replaces the per-call extractors with ONE receiver + extractor
+// for the whole carrier whose AACH/SB state stays warm across calls. It routes
+// each decoded burst to the single call that owns that burst's AACH downlink
+// usage marker (the reliable per-call identifier — the channel-allocation timeslot
+// does not map to the physical slot on real air, and the SB slot index jitters
+// across adjacent slots). owners is keyed by usage marker with most-recent-grant-
+// wins, so a new call for a reused marker immediately displaces the lingering one.
+// One demux exists per carrier for the composer's lifetime; per-call chains are
+// thin owners that register/unregister a marker.
+type tetraSlotDemux struct {
+	c      *Composer
+	key    string
+	colour uint32
+	cancel context.CancelFunc
+	done   chan struct{}
+
+	mu     sync.Mutex
+	owners map[uint8]*tetraSlotOwner // usage marker (>=DLUsageTraffic) -> current owner
+	// wildcards are owners whose grant carried no usage marker (addressed by plain
+	// SSI). Each claims the first unclaimed traffic marker the demux observes, in
+	// registration order, so concurrent marker-less calls still separate instead of
+	// falling back to accept-all/mix. Best-effort; verified against real DDC IQ.
+	wildcards []*tetraSlotOwner
+}
+
+// tetraSlotOwner is one call's registration with the carrier demux: the usage
+// marker it follows (0 until a wildcard claims one) plus the boundary tracker +
+// recorder sink its decoded speech drives. bursts/speech feed the ended log line.
+type tetraSlotOwner struct {
+	serial         string
+	marker         uint8 // grant usage marker; 0 = wildcard until it claims one
+	bt             *boundaryTracker
+	rs             rawFrameSink
+	bursts, speech atomic.Uint64
+}
+
+// run streams the carrier's post-DDC IQ through one front end + receiver +
+// TrafficExtractor, feeding every burst to onBurst. It self-removes from the
+// composer's registry when the IQ stream ends so a later grant rebuilds it.
+func (d *tetraSlotDemux) run(ctx context.Context, iqCh <-chan []complex64, iqHz float64) {
+	defer close(d.done)
+	defer d.c.removeTETRADemux(d.key, d)
+	defer gtlog.Recover(d.c.log, "tetra-voice-demux:"+d.key, nil)
+
+	fe := newTETRAVoiceFrontEnd(iqHz, d.c.bw)
+	symbolHz := fe.OutRateHz()
+	extractor := tetra.NewTrafficExtractor(d.colour, d.onBurst)
+	rx := tetrarx.New(tetrarx.Options{
+		SampleRateHz:        symbolHz,
+		DibitSink:           func(di []uint8, base int) { extractor.Process(di, base) },
+		ClockMode:           tetrarx.ClockGardner,
+		GardnerGain:         0.005,
+		EnableAFC:           true,
+		EnableChannelFilter: true,
+	})
+	d.c.log.Info("composer: tetra shared voice demux started (usage-marker routing)",
+		"key", d.key, "colour_code", d.colour&0x3F, "rate_hz", symbolHz)
+	defer d.c.log.Info("composer: tetra shared voice demux ended", "key", d.key)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case iq, ok := <-iqCh:
+			if !ok {
+				return
+			}
+			d.observe(iq)
+			rx.Process(fe.Process(nil, iq))
+		}
+	}
+}
+
+// observe folds the carrier's channel power into every current owner's signal
+// meter. All calls share one carrier, so its post-DDC power is each call's RSSI.
+func (d *tetraSlotDemux) observe(iq []complex64) {
+	d.mu.Lock()
+	for _, o := range d.owners {
+		o.bt.observe(iq)
+	}
+	for _, o := range d.wildcards {
+		o.bt.observe(iq)
+	}
+	d.mu.Unlock()
+}
+
+// onBurst routes one extracted traffic frame to the call that owns its AACH usage
+// marker. Non-traffic bursts (usage < DLUsageTraffic, including an undecoded AACH
+// reported as 0) carry no speech and are dropped; a marker with no live owner is
+// dropped too. When a marker has no owner but a wildcard call is waiting, the
+// oldest wildcard claims that marker. Runs on the single demux goroutine, so each
+// owner's boundary tracker has exactly one writer.
+func (d *tetraSlotDemux) onBurst(frame []byte, slot, usage uint8) {
+	if usage < tetra.DLUsageTraffic {
+		return
+	}
+	d.mu.Lock()
+	o := d.owners[usage]
+	if o == nil && len(d.wildcards) > 0 {
+		o = d.wildcards[0]
+		d.wildcards = d.wildcards[1:]
+		o.marker = usage
+		d.owners[usage] = o
+	}
+	d.mu.Unlock()
+	if o == nil {
+		return
+	}
+	o.bursts.Add(1)
+	d.c.decodeTETRASpeech(o.bt, o.rs, o.serial, frame, &o.speech)
+}
+
+// addOwner registers o. A marker-bearing grant claims its marker (most-recent
+// grant wins, so a new call reusing a marker displaces a hangtime-lingering one);
+// a marker-less (wildcard) grant queues to claim the first unowned marker seen.
+func (d *tetraSlotDemux) addOwner(o *tetraSlotOwner) {
+	d.mu.Lock()
+	if o.marker >= tetra.DLUsageTraffic {
+		d.owners[o.marker] = o
+	} else {
+		d.wildcards = append(d.wildcards, o)
+	}
+	d.mu.Unlock()
+}
+
+// removeOwner releases o's marker (only if o still owns it — a newer call that
+// already displaced it keeps it) and drops it from the wildcard queue if it never
+// claimed a marker.
+func (d *tetraSlotDemux) removeOwner(o *tetraSlotOwner) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if o.marker >= tetra.DLUsageTraffic && d.owners[o.marker] == o {
+		delete(d.owners, o.marker)
+	}
+	for i, w := range d.wildcards {
+		if w == o {
+			d.wildcards = append(d.wildcards[:i], d.wildcards[i+1:]...)
+			break
+		}
+	}
+}
+
+// runTETRASameCarrierChain is the thin per-call goroutine for a same-carrier
+// TETRA call. It owns the call's boundary tracker (hangtime end-of-call + Touch
+// heartbeat) and registers itself as the owner of its granted AACH usage marker
+// with the carrier's shared demux; the demux delivers that marker's decoded
+// speech. It does no IQ work of its own. On ctx cancel (call end) it releases the
+// marker.
+func (c *Composer) runTETRASameCarrierChain(ctx context.Context, d *tetraSlotDemux, serial string, groupID uint32, grantSlot, usageMarker uint8, done chan<- struct{}) {
+	defer close(done)
+	defer gtlog.Recover(c.log, "voice-chain-tetra-sc:"+serial, nil)
+
+	// Talkgroup gating disabled (grantTG 0): the chain surfaces no per-burst
+	// in-band identity, so liveness is driven purely by CRC-valid speech.
+	bt := c.newBoundaryTracker(serial, 0, nil)
+	go bt.run(ctx)
+	rs, _ := c.sink.(rawFrameSink)
+
+	o := &tetraSlotOwner{serial: serial, marker: usageMarker, bt: bt, rs: rs}
+	d.addOwner(o)
+	c.log.Info("composer: tetra voice follow started (shared demux) — TCH/S decode + ACELP vocoder",
+		"serial", serial, "group", groupID, "timeslot", grantSlot, "usage_marker", usageMarker)
+	defer func() {
+		d.removeOwner(o)
+		c.log.Info("composer: tetra voice follow ended",
+			"serial", serial, "bursts", o.bursts.Load(), "speech_frames", o.speech.Load())
+	}()
+
+	<-ctx.Done()
 }

--- a/internal/voice/composer/tetra_voice_test.go
+++ b/internal/voice/composer/tetra_voice_test.go
@@ -255,3 +255,122 @@ func TestTETRATrafficBurstNoGrantMarkerFallback(t *testing.T) {
 		t.Errorf("offSlot = %d, want 0 (no dropping without a grant marker)", got)
 	}
 }
+
+// --- shared per-carrier usage-marker demux regressions ---------------------
+
+// newDemuxOwner builds a tetraSlotOwner with its own recorder sink + boundary
+// tracker for the demux tests.
+func newDemuxOwner(c *Composer, serial string, marker uint8) (*tetraSlotOwner, *recordingSink) {
+	rs := &recordingSink{}
+	bt := c.newBoundaryTracker(serial, 0, nil)
+	return &tetraSlotOwner{serial: serial, marker: marker, bt: bt, rs: rs}, rs
+}
+
+func mkDemux(c *Composer) *tetraSlotDemux {
+	return &tetraSlotDemux{c: c, key: "test", owners: make(map[uint8]*tetraSlotOwner)}
+}
+
+// TestTETRADemuxRoutesByUsageMarker is the core regression for cross-slot audio
+// leaks: each concurrent same-carrier call is keyed by its AACH usage marker, so
+// a burst is delivered only to the call whose marker it carries — never to a peer.
+func TestTETRADemuxRoutesByUsageMarker(t *testing.T) {
+	c, _, _ := mkBoundaryComposer(t, false, 50*time.Millisecond)
+	d := mkDemux(c)
+	frame := tetra.EncodeTCHS(make([]byte, 137), make([]byte, 137))
+
+	oA, rsA := newDemuxOwner(c, "A", 19)
+	oB, rsB := newDemuxOwner(c, "B", 20)
+	d.addOwner(oA)
+	d.addOwner(oB)
+
+	d.onBurst(frame, 1, 19) // marker 19 → A only
+	d.onBurst(frame, 2, 20) // marker 20 → B only
+	if n := len(rsA.rawFrames("A")); n != 2 {
+		t.Errorf("owner A got %d frames, want 2", n)
+	}
+	if n := len(rsB.rawFrames("B")); n != 2 {
+		t.Errorf("owner B got %d frames, want 2", n)
+	}
+
+	// A marker with no owner is dropped (not broadcast to A or B).
+	d.onBurst(frame, 3, 21)
+	if n := len(rsA.rawFrames("A")) + len(rsB.rawFrames("B")); n != 4 {
+		t.Errorf("unowned marker 21 leaked: total frames now %d, want 4", n)
+	}
+	// A non-traffic AACH marker (< DLUsageTraffic, e.g. undecoded 0) is dropped.
+	d.onBurst(frame, 1, 0)
+	if n := len(rsA.rawFrames("A")); n != 2 {
+		t.Errorf("non-traffic marker leaked to A: %d frames, want 2", n)
+	}
+}
+
+// TestTETRADemuxMostRecentGrantEvicts is the hangtime-reuse (R2) regression: when
+// the network reuses a usage marker for a new call while the old one lingers in
+// hangtime, the newest grant owns the marker and the old recording stops — no
+// leak of the new call's audio into the old file.
+func TestTETRADemuxMostRecentGrantEvicts(t *testing.T) {
+	c, _, _ := mkBoundaryComposer(t, false, 50*time.Millisecond)
+	d := mkDemux(c)
+	frame := tetra.EncodeTCHS(make([]byte, 137), make([]byte, 137))
+
+	oOld, rsOld := newDemuxOwner(c, "old", 19)
+	d.addOwner(oOld)
+	d.onBurst(frame, 1, 19)
+	if n := len(rsOld.rawFrames("old")); n != 2 {
+		t.Fatalf("old owner got %d frames before reuse, want 2", n)
+	}
+
+	// New call reuses marker 19 while "old" is still registered (hangtime).
+	oNew, rsNew := newDemuxOwner(c, "new", 19)
+	d.addOwner(oNew)
+	d.onBurst(frame, 1, 19)
+	if n := len(rsNew.rawFrames("new")); n != 2 {
+		t.Errorf("new owner got %d frames after reuse, want 2", n)
+	}
+	if n := len(rsOld.rawFrames("old")); n != 2 {
+		t.Errorf("old owner leaked new call's audio: %d frames, want 2 (frozen at eviction)", n)
+	}
+
+	// The lingering old owner unregistering must NOT remove the new owner's marker.
+	d.removeOwner(oOld)
+	d.onBurst(frame, 1, 19)
+	if n := len(rsNew.rawFrames("new")); n != 4 {
+		t.Errorf("new owner lost its marker after old unregistered: %d frames, want 4", n)
+	}
+}
+
+// TestTETRADemuxWildcardBinding pins the type-1 (no-usage-marker) grant handling:
+// a wildcard owner claims the first unclaimed traffic marker it sees, and must not
+// steal a marker a marker-bearing call already owns.
+func TestTETRADemuxWildcardBinding(t *testing.T) {
+	c, _, _ := mkBoundaryComposer(t, false, 50*time.Millisecond)
+	d := mkDemux(c)
+	frame := tetra.EncodeTCHS(make([]byte, 137), make([]byte, 137))
+
+	// A marker-bearing call owns 19; a wildcard (marker 0) is also waiting.
+	oA, rsA := newDemuxOwner(c, "A", 19)
+	oW, rsW := newDemuxOwner(c, "W", 0)
+	d.addOwner(oA)
+	d.addOwner(oW)
+
+	// Burst on 19 goes to A, not the wildcard.
+	d.onBurst(frame, 1, 19)
+	if n := len(rsA.rawFrames("A")); n != 2 {
+		t.Errorf("owner A got %d frames, want 2", n)
+	}
+	if n := len(rsW.rawFrames("W")); n != 0 {
+		t.Errorf("wildcard stole a claimed marker: %d frames, want 0", n)
+	}
+
+	// A burst on an unclaimed marker 25 binds the wildcard to 25.
+	d.onBurst(frame, 3, 25)
+	d.onBurst(frame, 3, 25)
+	if n := len(rsW.rawFrames("W")); n != 4 {
+		t.Errorf("wildcard did not bind marker 25: %d frames, want 4", n)
+	}
+	// It must not also grab a different unclaimed marker now that it is bound.
+	d.onBurst(frame, 4, 30)
+	if n := len(rsW.rawFrames("W")); n != 4 {
+		t.Errorf("bound wildcard grabbed a second marker: %d frames, want 4", n)
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #985 (usage-marker voice demux, now merged). Two more same-carrier TETRA fixes plus the DDC auto-record tap that unblocks sharing small IQ captures for offline debugging.

## Changes

- **CC lock/hunt no longer flaps "CC hunt failed · candidates exhausted" while a control channel is decoding.** TETRA's `maybeLock` is edge-triggered, so a steady lock never re-emits `cc.locked`; when cold acquisition (BSCH sync + colour code) outlasts the hunter's 3 s dwell, the first hunt fails and every same-frequency re-hunt then exhausts the dwell against an already-locked pipeline. The supervisor now parks a system it already knows is locked, and a new control-channel lock-loss watchdog (`ControlChannel.CheckStale` → `MarkLost`, which previously had no callers) publishes `cc.lost` when a locked carrier decodes nothing for ~5 s, so a genuinely dead carrier still re-hunts and recovers.
- **Concurrent same-carrier calls no longer leak audio into each other.** The per-call usage-marker demux from #985 could not evict a peer: when a call ended in hangtime and the network reused its AACH usage marker for a new call, both matched and the old recording absorbed the new call's audio. Concurrent same-carrier calls now share ONE per-carrier voice demux (its sync/AACH state stays warm across calls) with a single owner per usage marker and most-recent-grant-wins eviction. Routing by the AACH **usage marker** rather than the physical TDMA slot is what makes it reliable — on real captures a single call's bursts jitter across adjacent decoded slot numbers, so slot-keyed routing mis-delivers them. Grants addressed without a usage marker bind to the first unclaimed marker instead of accept-all-mixing.
- **`baseband.auto_record.tap: ddc`** — event-triggered auto-captures can now record the control decoder's narrowband post-DDC stream (144 kHz for TETRA, holding all four voice timeslots) instead of the full-rate wideband SDR IQ — a few MB vs ~95 MB, directly replayable with `replay -format wav` / siglab. The config field existed but the capture path did not, so `tap: ddc` was silently ignored. Triggered captures also create their target directory if missing.

## Test plan

- [x] `make vet test` is green locally
- [x] `make integration` is green locally
- [x] Added or updated tests where appropriate — supervisor park-on-late-lock + cc.lost recovery; control-channel staleness watchdog; shared-demux usage-marker routing / most-recent-grant eviction / marker-less wildcard binding; DDC capture rate + filename/metadata
- [ ] Smoke-tested against real hardware — the demux + watchdog are verified against the reporter's earlier 5-capture 144 kHz `cs16` set (both usage-marker types + 2-slot concurrency) via the skip-guarded replay harnesses; the specific leaking conversation in the latest report had no IQ (that's what `tap: ddc` unblocks), so a re-capture is pending to confirm that exact case

## Breaking changes

none — `baseband.auto_record.tap` defaults to `wideband` (unchanged); `cc.lost` is an internal bus event.

## Docs / CHANGELOG

- [x] Added `## [Unreleased]` bullets to `CHANGELOG.md` (one Added, two Fixed)
- [ ] No operator-facing README/docs change beyond the new config key

## Linked issues

Refs #402 (same-carrier voice tap). Follow-up to #985.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0143FCU48ecrifc2csT8PFXX

---
_Generated by [Claude Code](https://claude.ai/code/session_0143FCU48ecrifc2csT8PFXX)_