### PR TITLE
fix(tetra): fast DSP re-acquire on CC sync drought

### DIFF
--- a/internal/radio/tetra/control.go
+++ b/internal/radio/tetra/control.go
@@ -618,6 +618,28 @@ func (c *ControlChannel) CheckStale(now time.Time, timeout time.Duration) {
 	c.MarkLost()
 }
 
+// NeedsResync reports whether the control-channel heartbeat is older than
+// timeout, i.e. no sync burst / SYSINFO / grant has decoded for that long. It is
+// the trigger the pipeline uses to force a fast DSP re-acquire (reset the symbol
+// timing to centre) after a noise burst wanders the loops off-lock — the
+// steady-state Gardner loop at the production gain re-converges only very slowly,
+// so from-centre reacquisition (~one AFC block) is far faster than waiting it
+// out.
+//
+// Like CheckStale it is a lock-free atomic read of the heartbeat and is a no-op
+// before the first decode (lastActivity==0). Deliberately independent of the
+// locked flag: MarkLost never clears the heartbeat, so a stale locked OR
+// already-lost channel both keep asking for a reacquire until the carrier
+// returns — bounding the recovery tail the cchunt same-frequency guard would
+// otherwise leave running for tens of seconds.
+func (c *ControlChannel) NeedsResync(now time.Time, timeout time.Duration) bool {
+	last := c.lastActivityNano.Load()
+	if last == 0 {
+		return false
+	}
+	return now.Sub(time.Unix(0, last)) > timeout
+}
+
 func (c *ControlChannel) maybeLock(s LockState) {
 	c.noteActivity()
 	c.mu.Lock()
@@ -654,4 +676,31 @@ func (c *ControlChannel) MarkLost() {
 	}
 	c.locked = false
 	c.bus.Publish(events.Event{Kind: events.KindCCLost, Payload: c.last})
+}
+
+// ResyncReset drops the dibit-domain synchronisation state so the next Process
+// call rebuilds it from a fresh baseline. It is called immediately after the
+// receiver's Reset (which restarts its dibit index at 0) so the two stay in
+// step: processState indexes its rolling SB buffer by ABSOLUTE dibit index
+// (bufBase, pendingSTS), so a receiver whose index jumped back to 0 while proc
+// held a large bufBase would drive every future SB look-back into the
+// "already trimmed" branch and never decode another sync burst. Nil-ing proc
+// forces a clean lazy rebuild with the new baseIdx.
+//
+// Everything that makes re-lock fast is PRESERVED: the learned/confirmed colour
+// code, the lock flag and cell identity, the channel configuration, the activity
+// heartbeat, and the decode-health stats. Only the throwaway dibit-sync scratch
+// (proc) and the soft-differential stash are cleared.
+//
+// Precondition: called on the same goroutine as Process (from
+// tetraPipeline.Process, after rx.Process returns), so the unlocked proc read in
+// Process never races this write; the mutex here guards proc and the pendingSoft
+// stash against the other lock-holding accessors.
+func (c *ControlChannel) ResyncReset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.proc = nil
+	c.pendingSoft = c.pendingSoft[:0]
+	c.pendingSoftBase = 0
+	c.pendingSoftSet = false
 }

--- a/internal/radio/tetra/control_resync_test.go
+++ b/internal/radio/tetra/control_resync_test.go
@@ -1,0 +1,106 @@
+package tetra
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// TestResyncResetRestoresDecodeAfterBaseIdxRestart is the regression for the
+// slow TETRA CC recovery after a noise burst. The recovery fix resets the
+// receiver's DSP loops to centre so they reacquire fast — but rx.Reset restarts
+// the receiver's dibit index at 0, and the control channel's SB decoder indexes
+// its rolling buffer by ABSOLUTE dibit index. Without a paired ResyncReset the
+// stale bufBase drives every future sync burst into the "look-back already
+// trimmed" branch and the channel never decodes another SB (the exact
+// zero-sb_bursts stall seen in the field debug.log). This asserts: a baseIdx
+// restart WITHOUT ResyncReset stops decoding, and ResyncReset restores it while
+// preserving the learned identity so re-lock stays fast.
+func TestResyncResetRestoresDecodeAfterBaseIdxRestart(t *testing.T) {
+	cc, bus := debugCC(t, io.Discard, slog.LevelDebug)
+	defer bus.Close()
+
+	stream := buildCleanSBStream(t, 0x2D, 3, 5, cleanSysinfoPDU())
+
+	// Phase 1: decode a clean SB at a large absolute baseIdx (as on a
+	// long-running live stream). The channel locks and learns the colour code.
+	cc.Process(stream, 1_000_000)
+	if got := cc.DrainStats().BSCHOK; got < 1 {
+		t.Fatalf("phase 1 BSCHOK = %d, want >= 1 (clean SB should decode)", got)
+	}
+	wantColour := cc.ColourCode()
+	wantTopo := cc.Topology()
+
+	// Phase 2: the receiver reset restarts the dibit index at 0, but WITHOUT the
+	// paired ResyncReset the proc's absolute bufBase is still ~1e6, so the SB
+	// look-back is judged already-trimmed and nothing decodes. This captures the
+	// corruption as a passing assertion.
+	cc.Process(stream, 0)
+	if got := cc.DrainStats().BSCHOK; got != 0 {
+		t.Fatalf("phase 2 BSCHOK = %d, want 0 (stale bufBase must strand the SB decode)", got)
+	}
+
+	// Phase 3: ResyncReset drops the dibit-sync scratch so the next Process
+	// rebuilds it from the fresh baseIdx and decoding resumes immediately.
+	cc.ResyncReset()
+	cc.Process(stream, 0)
+	if got := cc.DrainStats().BSCHOK; got < 1 {
+		t.Fatalf("phase 3 BSCHOK = %d, want >= 1 (ResyncReset must restore decode)", got)
+	}
+
+	// Identity that makes re-lock fast must survive the reset.
+	if got := cc.ColourCode(); got != wantColour {
+		t.Errorf("colour code after ResyncReset = %#x, want %#x (must be preserved)", got, wantColour)
+	}
+	if got := cc.Topology(); got.MCC != wantTopo.MCC || got.MNC != wantTopo.MNC {
+		t.Errorf("identity after ResyncReset = MCC %d/MNC %d, want %d/%d",
+			got.MCC, got.MNC, wantTopo.MCC, wantTopo.MNC)
+	}
+}
+
+// TestNeedsResyncPredicate pins the heartbeat-age predicate the pipeline uses to
+// trigger a DSP reacquire: no-op before the first decode, false while activity is
+// fresh, true once the heartbeat is older than the timeout — and, crucially,
+// still true after MarkLost (MarkLost does not clear the heartbeat), so the
+// reacquire keeps firing to bound the post-loss recovery tail.
+func TestNeedsResyncPredicate(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+
+	base := time.Unix(1_000, 0)
+	now := base
+	cc := New(Options{
+		Bus: bus, Log: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		SystemName: "Sys", FrequencyHz: 412_000_000,
+		Now: func() time.Time { return now },
+	})
+	const timeout = 500 * time.Millisecond
+
+	// Cold: no decode yet ⇒ never needs resync.
+	if cc.NeedsResync(now.Add(time.Hour), timeout) {
+		t.Fatal("NeedsResync true before the first decode, want false")
+	}
+
+	// A lock stamps the heartbeat at t=base.
+	cc.maybeLock(LockState{FrequencyHz: 412_000_000})
+
+	if cc.NeedsResync(base.Add(300*time.Millisecond), timeout) {
+		t.Error("NeedsResync true while activity is fresh (300ms < 500ms), want false")
+	}
+	if !cc.NeedsResync(base.Add(600*time.Millisecond), timeout) {
+		t.Error("NeedsResync false after the heartbeat went stale (600ms > 500ms), want true")
+	}
+
+	// After MarkLost the heartbeat is preserved, so a stale channel still asks to
+	// reacquire — this is what bounds the recovery tail past cc.lost.
+	cc.MarkLost()
+	if cc.Locked() {
+		t.Fatal("channel still locked after MarkLost")
+	}
+	if !cc.NeedsResync(base.Add(600*time.Millisecond), timeout) {
+		t.Error("NeedsResync false after MarkLost, want true (heartbeat must survive loss)")
+	}
+}

--- a/internal/radio/tetra/process.go
+++ b/internal/radio/tetra/process.go
@@ -29,6 +29,19 @@ type processState struct {
 	// ncdb decodes real downlink slots (correct NCDB geometry + AACH-steered
 	// MAC demux) under ChannelCodingOn. Lazily built. See downlink.go.
 	ncdb *downlinkNCDB
+
+	// Sync-continuity tracking for the higher-level (multiframe-keyed) sync log.
+	// TETRA numbers time in a 4-slot frame / 18-frame multiframe / 60-multiframe
+	// hyperframe hierarchy (ETSI EN 300 392-2 §4.5.2); the BSCH SYNC PDU carries
+	// the current multiframe number (MN). Rather than log every sync burst
+	// (thousands of lines), the decoder logs once per multiframe on an MN change
+	// and flags multiframe gaps. lastMN is the previous decoded MN; haveMN gates
+	// the first-burst "acquired" line; mfCount counts multiframes seen since
+	// acquisition. Cleared with the rest of processState on ResyncReset, so a
+	// post-noise reacquire re-emits the "acquired" marker.
+	lastMN  uint8
+	haveMN  bool
+	mfCount uint64
 }
 
 // Synchronisation downlink burst (SB) geometry in dibits, per ETSI
@@ -318,20 +331,17 @@ func (c *ControlChannel) decodeSB(p *processState, L int) {
 		}
 	}
 	if !found {
+		// A failed BSCH decode is one bad/false sync candidate among the many the
+		// four-rotation correlator throws off on noise; it is counted (BSCHFail)
+		// and surfaced in aggregate by the throttled decode-status line, not
+		// logged per burst (that was tens of thousands of lines per capture).
 		c.addStat(&c.stats.BSCHFail, 1)
-		c.log.Debug("tetra: sync burst BSCH decode failed",
-			"sts_at", L, "system", c.systemName)
 		return
 	}
 	c.addStat(&c.stats.BSCHOK, 1)
-	// Heartbeat: a CRC-clean sync burst is the ~1 s cadence that proves the
-	// carrier is still live, independent of voice traffic. Feeds CheckStale.
+	// Heartbeat: a CRC-clean sync burst proves the carrier is still live,
+	// independent of voice traffic. Feeds CheckStale / NeedsResync.
 	c.noteActivity()
-	c.log.Debug("tetra: sync burst decoded",
-		"sts_at", L, "rot", bschRot,
-		"colour_code", sync.ExtendedColourCode()&0x3F,
-		"colour_ext", sync.ExtendedColourCode(),
-		"mcc", sync.MCC, "mnc", sync.MNC, "system", c.systemName)
 	c.LearnColourCode(sync.ExtendedColourCode())
 	// Report the BSCH FEC correction depth: re-encode the recovered
 	// type-1 bits and count how many channel bits the §8.3.1 chain
@@ -372,9 +382,6 @@ func (c *ControlChannel) decodeSB(p *processState, L int) {
 					ls.MCC, ls.MNC = sb.MCC, sb.MNC
 				}
 				c.addStat(&c.stats.SysInfo, 1)
-				c.log.Debug("tetra: sysinfo",
-					"la", sb.LocationArea, "mcc", ls.MCC, "mnc", ls.MNC,
-					"rot", rot, "system", c.systemName)
 			}
 			if c.fecObserver != nil {
 				received := TetraDibitsToBits(rotateDibits(bnch, rot))
@@ -384,6 +391,51 @@ func (c *ControlChannel) decodeSB(p *processState, L int) {
 		}
 	}
 	c.maybeLock(ls)
+	c.logSyncProgress(p, sync, ls.LocationArea)
+}
+
+// logSyncProgress emits the higher-level, multiframe-keyed sync log in place of
+// the old per-burst spam. TETRA numbers time as 4-slot frames / 18-frame
+// multiframes / 60-multiframe hyperframes (ETSI EN 300 392-2 §4.5.2), and the
+// BSCH SYNC PDU carries the current multiframe number (MN). A healthy carrier
+// throws off a decodable sync burst roughly every frame, so keying the log on MN
+// collapses it to about one line per multiframe:
+//
+//   - the first burst after (re)acquisition logs "tetra sync acquired";
+//   - further bursts within the same multiframe are silent (also folds away the
+//     duplicate hits the four-rotation correlator produces for one SB);
+//   - a new multiframe logs "tetra sync", and a non-consecutive MN logs
+//     "tetra sync gap" with the number of multiframes missed — the compact
+//     signal that sync briefly dropped.
+//
+// All at debug level; production (info) decode logs nothing here.
+func (c *ControlChannel) logSyncProgress(p *processState, sync SyncPDU, la uint16) {
+	if !p.haveMN {
+		p.haveMN = true
+		p.lastMN = sync.MN
+		p.mfCount = 1
+		c.log.Debug("tetra sync acquired",
+			"mn", sync.MN, "fn", sync.FN,
+			"colour_code", sync.ExtendedColourCode()&0x3F,
+			"mcc", sync.MCC, "mnc", sync.MNC, "la", la, "system", c.systemName)
+		return
+	}
+	if sync.MN == p.lastMN {
+		return // same multiframe — already logged
+	}
+	// Multiframe advanced. Wrapped modulo 60 (0..59); a gap > 1 means one or more
+	// multiframes went undecoded (a brief sync dropout).
+	gap := (int(sync.MN) - int(p.lastMN) + 60) % 60
+	p.lastMN = sync.MN
+	p.mfCount++
+	if gap > 1 {
+		c.log.Debug("tetra sync gap",
+			"mn", sync.MN, "missed", gap-1, "mf_count", p.mfCount, "system", c.systemName)
+		return
+	}
+	c.log.Debug("tetra sync",
+		"mn", sync.MN, "fn", sync.FN, "mf_count", p.mfCount,
+		"colour_code", sync.ExtendedColourCode()&0x3F, "la", la, "system", c.systemName)
 }
 
 // hammingBits counts the positions where two 0/1 bit slices differ, over

--- a/internal/radio/tetra/stats_test.go
+++ b/internal/radio/tetra/stats_test.go
@@ -57,6 +57,35 @@ func buildCleanSBStream(t *testing.T, cc6 uint8, mcc, mnc uint16, sysinfo PDU) [
 	return s
 }
 
+// buildCleanSBStreamMN is buildCleanSBStream with the BSCH SYNC PDU's multiframe
+// number (MN, bits 17..22) set, so tests can drive the multiframe-keyed sync log
+// across multiframe boundaries and gaps.
+func buildCleanSBStreamMN(t *testing.T, cc6 uint8, mcc, mnc uint16, mn uint8, sysinfo PDU) []uint8 {
+	t.Helper()
+	syncInfo := make([]byte, 60)
+	putBits(syncInfo, 4, 6, uint32(cc6))
+	putBits(syncInfo, 17, 6, uint32(mn))
+	putBits(syncInfo, 31, 10, uint32(mcc))
+	putBits(syncInfo, 41, 14, uint32(mnc))
+	bschDibits := TetraBitsToDibits(EncodeBSCH(syncInfo))
+
+	ext := ExtendedColourCode(mcc, mnc, cc6)
+	info := pduToType1Bits(sysinfo, 124)
+	if info == nil {
+		t.Fatalf("sysinfo PDU too large for SCH/HD 124 type-1 bits")
+	}
+	bnchDibits := TetraBitsToDibits(EncodeSCHHD(info, ext))
+
+	var s []uint8
+	s = append(s, make([]uint8, 50)...)
+	s = append(s, bschDibits...)
+	s = append(s, SyncTrainingDibits()...)
+	s = append(s, make([]uint8, sbBroadcastDibits)...)
+	s = append(s, bnchDibits...)
+	s = append(s, make([]uint8, 300)...)
+	return s
+}
+
 // cleanSysinfoPDU is a minimal valid MLE SYSINFO PDU (MCC=10b / MNC=14b /
 // LA=14b), the same payload layout the topology / round-trip tests use.
 func cleanSysinfoPDU() PDU {
@@ -126,29 +155,58 @@ func TestStatsInertAtInfoLevel(t *testing.T) {
 	}
 }
 
-// TestSyncBurstDebugLines confirms the per-milestone debug lines are emitted at
-// debug level and suppressed at info level. These are the "more debug info from
-// the control channel" the request asked for.
+// TestSyncBurstDebugLines confirms the higher-level, multiframe-keyed sync log
+// (ETSI EN 300 392-2 §4.5.2) replaces the old per-burst spam: the first burst
+// logs "tetra sync acquired", further bursts in the same multiframe are silent,
+// a new multiframe logs "tetra sync", a non-consecutive multiframe logs
+// "tetra sync gap", and all of it is suppressed at info level. Streams are fed at
+// consecutive baseIdx to keep the SB decoder's absolute-index buffer monotonic.
 func TestSyncBurstDebugLines(t *testing.T) {
-	t.Run("debug emits", func(t *testing.T) {
+	t.Run("debug emits multiframe-keyed lines, not per-burst spam", func(t *testing.T) {
 		var buf bytes.Buffer
 		cc, bus := debugCC(t, &buf, slog.LevelDebug)
 		defer bus.Close()
-		cc.Process(buildCleanSBStream(t, 0x2D, 3, 5, cleanSysinfoPDU()), 0)
+
+		base := 0
+		feed := func(mn uint8) {
+			s := buildCleanSBStreamMN(t, 0x2D, 3, 5, mn, cleanSysinfoPDU())
+			cc.Process(s, base)
+			base += len(s)
+		}
+
+		feed(1) // first burst → acquired
+		feed(1) // same multiframe → silent
+		feed(2) // next multiframe → sync
+		feed(5) // skipped MN 3,4 → gap (missed 2)
+
 		out := buf.String()
-		for _, want := range []string{"tetra: sync burst decoded", "tetra: sysinfo"} {
+		for _, want := range []string{"tetra sync acquired", "tetra sync gap"} {
 			if !strings.Contains(out, want) {
 				t.Errorf("debug output missing %q\n---\n%s", want, out)
 			}
+		}
+		// The old per-burst spam must be gone.
+		for _, gone := range []string{"tetra: sync burst decoded", "tetra: sysinfo", "BSCH decode failed"} {
+			if strings.Contains(out, gone) {
+				t.Errorf("debug output still contains removed per-burst line %q\n---\n%s", gone, out)
+			}
+		}
+		// Exactly one "acquired" line (same-MN second burst did not re-acquire).
+		if n := strings.Count(out, "tetra sync acquired"); n != 1 {
+			t.Errorf("acquired lines = %d, want 1 (same-MN burst must not re-log)\n%s", n, out)
+		}
+		// The gap collapses the missed multiframes into one "gap" line reporting 2.
+		if !strings.Contains(out, "missed=2") {
+			t.Errorf("gap line should report missed=2\n---\n%s", out)
 		}
 	})
 	t.Run("info suppresses", func(t *testing.T) {
 		var buf bytes.Buffer
 		cc, bus := debugCC(t, &buf, slog.LevelInfo)
 		defer bus.Close()
-		cc.Process(buildCleanSBStream(t, 0x2D, 3, 5, cleanSysinfoPDU()), 0)
-		if out := buf.String(); strings.Contains(out, "tetra: sync burst decoded") {
-			t.Errorf("info output should not contain debug milestone lines\n---\n%s", out)
+		cc.Process(buildCleanSBStreamMN(t, 0x2D, 3, 5, 1, cleanSysinfoPDU()), 0)
+		if out := buf.String(); strings.Contains(out, "tetra sync") {
+			t.Errorf("info output should not contain debug sync lines\n---\n%s", out)
 		}
 	})
 }

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -656,21 +656,67 @@ const (
 	tetraStaleCheckInterval = 1 * time.Second
 )
 
+// tetraResyncTimeout is how long the control channel may decode nothing before
+// the pipeline forces a fast DSP re-acquire (reset the receiver's symbol-timing
+// and AFC loops to centre, then rebuild the CC's dibit-sync scratch). A noise
+// burst wanders the Gardner timing phase off-lock and, at the production
+// GardnerGain, it re-converges only very slowly — the field symptom was a
+// control channel taking tens of seconds to re-lock after brief wideband noise
+// while a from-cold receiver acquires in ~one AFC block. Resetting to centre on
+// a short heartbeat drought reacquires in that same ~one-block time.
+//
+// A healthy carrier decodes a CRC-clean sync burst roughly every frame (~57 ms),
+// thinning to ~130 ms only on a marginal-but-still-locked signal, so 500 ms
+// leaves a comfortable margin against a false reset (which is cheap anyway — it
+// costs ~one block of reacquisition and self-heals within a frame). It fires
+// well before the 5 s tetraLockStaleTimeout, so transient noise is absorbed
+// without ever declaring cc.lost.
+const tetraResyncTimeout = 500 * time.Millisecond
+
 type tetraPipeline struct {
-	rx        *tetrarx.Receiver
-	cc        *tetra.ControlChannel
-	log       *slog.Logger
-	system    string
-	debug     bool
-	now       func() time.Time // injectable for tests; set to time.Now at construction
-	lastLog   time.Time        // wall clock of the previous status line (zero ⇒ not primed)
-	lastStale time.Time        // wall clock of the previous lock-staleness check
+	rx         *tetrarx.Receiver
+	cc         *tetra.ControlChannel
+	log        *slog.Logger
+	system     string
+	debug      bool
+	now        func() time.Time // injectable for tests; set to time.Now at construction
+	lastLog    time.Time        // wall clock of the previous status line (zero ⇒ not primed)
+	lastStale  time.Time        // wall clock of the previous lock-staleness check
+	lastResync time.Time        // wall clock of the previous DSP resync (throttle)
 }
 
 func (p *tetraPipeline) Process(iq []complex64) {
 	p.rx.Process(iq)
+	p.checkResync()
 	p.checkLockStale()
 	p.maybeLogStatus()
+}
+
+// checkResync forces a fast DSP re-acquire when the control-channel heartbeat has
+// gone stale (see tetraResyncTimeout). It resets the receiver's timing/AFC loops
+// to centre and drops the CC's dibit-sync scratch (kept in lock-step because
+// rx.Reset restarts the dibit index at 0), so a channel knocked off-lock by a
+// noise burst reacquires in ~one AFC block instead of waiting for the slow
+// steady-state Gardner loop to drift back. Throttled to one attempt per timeout
+// window so a genuinely dead carrier reacquires at most once per window rather
+// than every chunk. Unlike maybeLogStatus this runs in production (not
+// debug-gated): the reacquire itself must happen regardless of log level; only
+// the diagnostic line is level-filtered.
+func (p *tetraPipeline) checkResync() {
+	now := p.now()
+	if !p.cc.NeedsResync(now, tetraResyncTimeout) {
+		return
+	}
+	if now.Sub(p.lastResync) < tetraResyncTimeout {
+		return
+	}
+	p.lastResync = now
+	p.rx.Reset()
+	p.cc.ResyncReset()
+	if p.log != nil {
+		p.log.Debug("tetra: dsp resync (heartbeat stale; reacquiring symbol timing from centre)",
+			"system", p.system)
+	}
 }
 
 // checkLockStale runs the control-channel lock watchdog on a light throttle.
@@ -738,8 +784,13 @@ func (p *tetraPipeline) maybeLogStatus() {
 
 func (p *tetraPipeline) Reset() {
 	p.rx.Reset()
+	// rx.Reset restarts the receiver's dibit index at 0; keep the CC's
+	// absolute-indexed sync scratch in step so a post-reset stream can
+	// reacquire (see ControlChannel.ResyncReset).
+	p.cc.ResyncReset()
 	p.lastLog = time.Time{}
 	p.lastStale = time.Time{}
+	p.lastResync = time.Time{}
 }
 func (p *tetraPipeline) Close() error { return nil }
 

--- a/internal/scanner/ccdecoder/pipelines_tetra_resync_test.go
+++ b/internal/scanner/ccdecoder/pipelines_tetra_resync_test.go
@@ -1,0 +1,100 @@
+package ccdecoder
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/tetra"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// buildArmingSBStream assembles a clean TETRA synchronisation burst as a hard
+// dibit stream — enough for the control channel to decode the BSCH and stamp its
+// activity heartbeat, so NeedsResync/checkResync have a live heartbeat to age
+// out. Mirrors the in-package tetra buildCleanSBStream but only needs the BSCH to
+// decode (the BNCH may be idle), built here from exported tetra symbols.
+func buildArmingSBStream() []uint8 {
+	setBits := func(bits []byte, off, n int, v uint32) {
+		for i := 0; i < n; i++ {
+			bits[off+i] = byte((v >> uint(n-1-i)) & 1)
+		}
+	}
+	syncInfo := make([]byte, 60)
+	setBits(syncInfo, 4, 6, 0x2D) // colour code
+	setBits(syncInfo, 31, 10, 3)  // MCC
+	setBits(syncInfo, 41, 14, 5)  // MNC
+	bschDibits := tetra.TetraBitsToDibits(tetra.EncodeBSCH(syncInfo))
+
+	var s []uint8
+	s = append(s, make([]uint8, 50)...)          // pad before BSCH (look-back)
+	s = append(s, bschDibits...)                 // BSCH (60)
+	s = append(s, tetra.SyncTrainingDibits()...) // STS (19)
+	s = append(s, make([]uint8, 15)...)          // broadcast (15)
+	s = append(s, make([]uint8, 108)...)         // BNCH (108; idle, need not decode)
+	s = append(s, make([]uint8, 300)...)         // trailing look-ahead margin
+	return s
+}
+
+// TestTETRAResyncTriggerAndThrottle drives the pipeline's fast DSP re-acquire on
+// a deterministic clock: a fresh heartbeat produces no resync, a heartbeat aged
+// past tetraResyncTimeout produces exactly one "tetra: dsp resync" line, and a
+// second call in the same window is throttled. This is the fail-first guard for
+// the recovery fix — reverting the single p.checkResync() call in Process turns
+// it red.
+func TestTETRAResyncTriggerAndThrottle(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	bus := events.NewBus(8)
+	defer bus.Close()
+
+	pp, err := newTETRAPipeline(PipelineOptions{
+		Bus: bus, Log: logger, SystemName: "Test", FrequencyHz: 412_000_000,
+		SampleRateHz: 144_000,
+		System: trunking.System{
+			Name: "Test", Protocol: trunking.ProtocolTETRA,
+			ControlChannels: []uint32{412_000_000},
+		},
+	})
+	if err != nil {
+		t.Fatalf("newTETRAPipeline: %v", err)
+	}
+	p := pp.(*tetraPipeline)
+
+	// Fixed pipeline clock, anchored just before arming so the freshly-stamped
+	// heartbeat (real-time, stamped inside cc.Process) reads as ~0 age at t0.
+	t0 := time.Now()
+	cur := t0
+	p.now = func() time.Time { return cur }
+
+	// Arm the heartbeat with a clean BSCH decode.
+	p.cc.Process(buildArmingSBStream(), 0)
+	if !p.cc.Locked() {
+		t.Fatal("control channel did not lock on the clean arming burst")
+	}
+
+	// Drive the real Process path (empty IQ ⇒ rx is a no-op) so the test also
+	// guards the p.checkResync() wiring in Process, not just checkResync itself.
+	// Fresh heartbeat: no resync.
+	p.Process(nil)
+	if strings.Contains(buf.String(), "tetra: dsp resync") {
+		t.Fatalf("resync fired while heartbeat was fresh\n%s", buf.String())
+	}
+
+	// Age the heartbeat past the timeout: exactly one resync.
+	cur = t0.Add(tetraResyncTimeout + 100*time.Millisecond)
+	p.Process(nil)
+	if !strings.Contains(buf.String(), "tetra: dsp resync") {
+		t.Fatalf("expected a resync after the heartbeat went stale\n%s", buf.String())
+	}
+
+	// A second call within the same window is throttled (no second line).
+	buf.Reset()
+	p.Process(nil)
+	if strings.Contains(buf.String(), "tetra: dsp resync") {
+		t.Errorf("resync fired twice within one timeout window (throttle failed)\n%s", buf.String())
+	}
+}


### PR DESCRIPTION
After a burst of wideband noise the TETRA control channel could take tens
of seconds to re-lock, while a cold receiver acquires in ~one AFC block.
The receiver's Gardner symbol-timing loop tracks continuously at the
production gain with no lock detector, so once noise wanders its timing
phase off-lock it re-converges only very slowly (the sync correlator finds
nothing — the sb_bursts=0 stall seen in the field debug.log). On a
single-control-channel system the cc-hunt supervisor's same-frequency guard
never rebuilds the pipeline, so the wandered DSP state persists across the
whole outage, even past cc.lost.

Reset the receiver's timing/AFC loops to centre when the control-channel
activity heartbeat goes stale past a short window (tetraResyncTimeout,
500ms) so it reacquires from the fast cold-start condition instead of
crawling back. The trigger is independent of the locked flag (the heartbeat
survives MarkLost) so it also bounds the post-loss recovery tail, and it
fires well before the 5s cc.lost watchdog so transient noise is absorbed
without ever declaring loss.

rx.Reset restarts the receiver's dibit index at 0, but the control
channel's SB decoder indexes its rolling buffer by absolute dibit index, so
the reset is paired with a new ControlChannel.ResyncReset that drops the
dibit-sync scratch while preserving the learned colour code, lock flag,
cell identity and heartbeat — keeping re-lock fast. Without it the stale
bufBase strands every future sync burst in the "look-back already trimmed"
branch and the channel never decodes another SB.

Regression tests: ResyncReset restores decode after a baseIdx restart (and
preserves identity); the NeedsResync predicate; and the pipeline
trigger/throttle path.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01P8UJSRRr1i1N3MS133YQXe