### PR TITLE
feat(tetra): CMCE call-control (emergency, D-RELEASE, talker) + voice slot-loss fix

### DIFF
--- a/cmd/gophertrunk/tetra_multislot_replay_test.go
+++ b/cmd/gophertrunk/tetra_multislot_replay_test.go
@@ -79,12 +79,18 @@ func TestTETRAMultiSlotReplay(t *testing.T) {
 	}
 	usage := map[uint8]*usageAcc{}
 
-	var totalBursts, anchoredBursts int
+	var totalBursts, anchoredBursts, trafficMarked, trafficMarkedCRC int
 	errsHist := map[string]int{}
 	extractor := tetra.NewTrafficExtractor(colourExt, func(frame []byte, slot, mark uint8) {
 		totalBursts++
 		if slot != 0 {
 			anchoredBursts++
+		}
+		if mark >= tetra.DLUsageTraffic {
+			trafficMarked++
+			if len(tetra.TCHSpeechFrames(frame)) > 0 {
+				trafficMarkedCRC++
+			}
 		}
 		if _, _, _, errs, ok := tetra.DecodeTCHS(frame); ok {
 			switch {
@@ -153,7 +159,7 @@ func TestTETRAMultiSlotReplay(t *testing.T) {
 	}
 
 	t.Logf("in=%.0fHz out=%.0fHz samples=%d dur=%.1fs", inRate, outRate, len(iq), float64(len(iq))/inRate)
-	t.Logf("total_bursts=%d anchored=%d errs_hist=%v", totalBursts, anchoredBursts, errsHist)
+	t.Logf("total_bursts=%d anchored=%d traffic_marked=%d traffic_marked_crc=%d errs_hist=%v", totalBursts, anchoredBursts, trafficMarked, trafficMarkedCRC, errsHist)
 	outDir := os.Getenv("GT_TETRA_OUT")
 	for tn := 1; tn <= 4; tn++ {
 		s := slots[tn]

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -144,6 +144,19 @@ const (
 	// source ID + encrypted state at grant time do not need this
 	// event — the values are already on the Grant.
 	KindCallSourceUpdate Kind = "call.source"
+	// KindCallRelease fires when a protocol control-channel decoder sees an
+	// explicit call-teardown message (e.g. a TETRA CMCE D-RELEASE) rather than
+	// inferring the end from a silence timeout. Payload is a
+	// trunking.CallRelease keyed by (System, GroupID); the engine ends the
+	// matching active call at once instead of waiting out the hangtime/no-voice
+	// timers.
+	KindCallRelease Kind = "call.release"
+	// KindCallTalker fires when a control-channel decoder resolves the current
+	// transmitting party of an active call (e.g. a TETRA CMCE D-TX-GRANTED
+	// carrying the transmitting party SSI). Payload is a trunking.CallTalker
+	// keyed by (System, GroupID); the engine backfills the bound call's source
+	// via the same path as KindCallSourceUpdate.
+	KindCallTalker Kind = "call.talker"
 	// KindSiteUpdate fires when the P25 control-channel decoder parses
 	// an RFSS Status Broadcast (TSBK 0x3A), naming the site it is
 	// camped on and the control-channel frequency it was heard on.

--- a/internal/radio/tetra/cmce.go
+++ b/internal/radio/tetra/cmce.go
@@ -1,7 +1,6 @@
 package tetra
 
 import (
-	"encoding/binary"
 	"fmt"
 )
 
@@ -78,61 +77,11 @@ type VoiceGrant struct {
 	Encrypted      bool
 }
 
-// AsVoiceGrant returns the structured grant if the PDU is a CMCE
-// D-CONNECT (or D-TX-GRANTED), otherwise (zero, false). Both PDUs
-// carry the same channel-allocation sub-element layout.
-func (p PDU) AsVoiceGrant() (VoiceGrant, bool) {
-	if !p.IsCMCE() {
-		return VoiceGrant{}, false
-	}
-	switch PDUType(p.Type) {
-	case CMCEDConnect, CMCEDTxGranted:
-	default:
-		return VoiceGrant{}, false
-	}
-	if len(p.Payload) < 11 {
-		return VoiceGrant{}, false
-	}
-	cidAndFlags := binary.BigEndian.Uint16(p.Payload[0:2])
-	flagsByte := p.Payload[8]
-	carrierAndSlot := binary.BigEndian.Uint16(p.Payload[9:11])
-	return VoiceGrant{
-		CallIdentifier: cidAndFlags >> 2, // upper 14 bits
-		SourceSSI: uint32(p.Payload[2])<<16 |
-			uint32(p.Payload[3])<<8 | uint32(p.Payload[4]),
-		DestSSI: uint32(p.Payload[5])<<16 |
-			uint32(p.Payload[6])<<8 | uint32(p.Payload[7]),
-		CarrierNumber: carrierAndSlot >> 4, // upper 12 bits
-		Timeslot:      uint8((carrierAndSlot >> 2) & 0x3),
-		Group:         flagsByte&0x80 != 0,
-		Emergency:     flagsByte&0x40 != 0,
-		Encrypted:     flagsByte&0x20 != 0,
-	}, true
-}
-
-// CallRelease is the structured shape of a CMCE D-RELEASE PDU. We
-// surface the call identifier so a higher-layer state machine can
-// match the release to a previously-seen D-CONNECT.
-type CallRelease struct {
-	CallIdentifier  uint16
-	DisconnectCause uint8
-}
-
-// AsRelease returns the structured release if the PDU is a CMCE
-// D-RELEASE, otherwise (zero, false).
-func (p PDU) AsRelease() (CallRelease, bool) {
-	if !p.IsCMCE() || PDUType(p.Type) != CMCEDRelease {
-		return CallRelease{}, false
-	}
-	if len(p.Payload) < 3 {
-		return CallRelease{}, false
-	}
-	cid := binary.BigEndian.Uint16(p.Payload[0:2]) >> 2
-	return CallRelease{
-		CallIdentifier:  cid,
-		DisconnectCause: p.Payload[2],
-	}, true
-}
+// Voice grants and call teardown are decoded bit-accurately from the MAC layer
+// (see downlink.go ingestMAC / ParseCMCE), not from this byte-aligned PDU view:
+// a real CMCE TM-SDU is bit-packed (3-bit MLE discriminator + 5-bit PDU type),
+// which the byte-oriented ParsePDU cannot frame. The VoiceGrant struct below is
+// retained as the grant carrier the MAC path fills.
 
 // SystemBroadcast is the structured shape of an MLE SYSINFO PDU. The
 // network identifiers (MCC + MNC) uniquely tag a TETRA system; the

--- a/internal/radio/tetra/cmce_parse.go
+++ b/internal/radio/tetra/cmce_parse.go
@@ -1,0 +1,238 @@
+package tetra
+
+// Bit-accurate CMCE (Circuit-Mode Control Entity) downlink PDU parsing, per
+// ETSI EN 300 392-2 V3.8.1 §14. This replaces the byte-aligned ParsePDU +
+// AsVoiceGrant/AsRelease guesswork: a real control-channel TM-SDU is
+// bit-packed, not byte-aligned, so the L3 PDU must be read one field at a time
+// with the MSB-first bitReader (the same reader mac.go uses for MAC-RESOURCE).
+//
+// The TM-SDU delivered by the MAC layer (MACResource.tmSDU) is an MLE service
+// PDU: a 3-bit MLE protocol discriminator (Table 18.1) followed by the SDU. When
+// the discriminator selects CMCE, the SDU opens with a 5-bit CMCE PDU type
+// (Table 14.66) and the type's information elements. Type-1 (mandatory) elements
+// are always present in a fixed order; the optional type-2 elements that follow
+// are introduced by a single O-bit and then, one per element in table order, a
+// presence (P-)bit — see §14 / the general PDU layout (the "Optional bit" +
+// "Presence bit" scheme). We walk only as far as the type-2 elements we need
+// (the group/temporary address and the calling/transmitting party SSI); the
+// type-3/4 (M-bit) chain that would follow is never entered, so trailing
+// SS/facility elements can never mis-frame the fields we read.
+
+// CMCEType is the 5-bit downlink CMCE PDU type (EN 300 392-2 Table 14.66).
+type CMCEType uint8
+
+const (
+	CMCETypeDConnect   CMCEType = 0x02 // D-CONNECT
+	CMCETypeDRelease   CMCEType = 0x06 // D-RELEASE
+	CMCETypeDSetup     CMCEType = 0x07 // D-SETUP
+	CMCETypeDTxCeased  CMCEType = 0x09 // D-TX CEASED
+	CMCETypeDTxGranted CMCEType = 0x0B // D-TX GRANTED
+)
+
+// cmceMLEPD is the 3-bit MLE protocol discriminator value that selects the CMCE
+// SDU (Table 18.1: 010 = CMCE; 001 = MM, 100 = SNDCP, 101 = MLE).
+const cmceMLEPD uint32 = 0x2
+
+// callPriorityEmergency is the 4-bit Call priority value that marks an emergency
+// call: 1111 = "Pre-emptive priority 4 (Emergency)" (Table 14.46).
+const callPriorityEmergency uint8 = 0xF
+
+// CMCEMessage is a decoded downlink CMCE PDU, tagged by Type. Absent optional
+// fields are left zero: GroupSSI/PartySSI == 0 means the element was not present,
+// and HasPriority == false means no Call priority element was decoded.
+type CMCEMessage struct {
+	Type           CMCEType
+	CallIdentifier uint16 // 14-bit
+
+	HasPriority bool
+	Priority    uint8 // 4-bit Call priority (Table 14.46)
+	Emergency   bool  // Priority == 1111 (Pre-emptive priority 4 / Emergency)
+
+	GroupSSI uint32 // Temporary address (24-bit GSSI); 0 = absent
+	PartySSI uint32 // Calling / Transmitting party SSI (24-bit); 0 = absent
+
+	DisconnectCause uint8 // D-RELEASE only (5-bit)
+}
+
+// ParseCMCE decodes a downlink CMCE PDU from the TM-SDU bit slice
+// (one-bit-per-byte, MSB first) returned by MACResource.tmSDU — i.e. BEFORE any
+// byte packing. It reads the 3-bit MLE protocol discriminator (must be CMCE),
+// the 5-bit CMCE PDU type, the mandatory type-1 fields, then the optional type-2
+// chain far enough to reach the Temporary address (GSSI) and the
+// calling/transmitting party SSI. Returns (zero, false) when the MLE
+// discriminator is not CMCE, the PDU type is not one we model, or the slice is
+// truncated inside a mandatory field.
+func ParseCMCE(bits []byte) (CMCEMessage, bool) {
+	r := &bitReader{bits: bits}
+	// MLE protocol discriminator (3) + CMCE PDU type (5) = the opening byte.
+	if r.remaining() < 8 {
+		return CMCEMessage{}, false
+	}
+	if r.u(3) != cmceMLEPD {
+		return CMCEMessage{}, false
+	}
+	msg := CMCEMessage{Type: CMCEType(r.u(5))}
+
+	switch msg.Type {
+	case CMCETypeDSetup:
+		// CallId(14) CallTimeout(4) Hook(1) Simplex/duplex(1) BasicSvc(8)
+		// TxGrant(2) TxReqPerm(1) CallPriority(4) — all mandatory (Table 14.15).
+		if r.remaining() < 14+4+1+1+8+2+1+4 {
+			return CMCEMessage{}, false
+		}
+		msg.CallIdentifier = uint16(r.u(14))
+		r.u(4) // call time-out
+		r.u(1) // hook method
+		r.u(1) // simplex/duplex
+		r.u(8) // basic service information
+		r.u(2) // transmission grant
+		r.u(1) // transmission request permission
+		msg.setPriority(uint8(r.u(4)))
+		// Optional type-2 chain: Notification indicator(6), Temporary address(24),
+		// Calling party type identifier(2) + conditional Calling party SSI.
+		if optElementsPresent(r) {
+			optSkip(r, 6)              // notification indicator
+			msg.GroupSSI = optU(r, 24) // temporary address (GSSI)
+			msg.readPartySSI(r)        // calling party type id + conditional SSI
+		}
+
+	case CMCETypeDConnect:
+		// CallId(14) CallTimeout(4) Hook(1) Simplex/duplex(1) TxGrant(2)
+		// TxReqPerm(1) CallOwnership(1) — mandatory (Table 14.7).
+		if r.remaining() < 14+4+1+1+2+1+1 {
+			return CMCEMessage{}, false
+		}
+		msg.CallIdentifier = uint16(r.u(14))
+		r.u(4) // call time-out
+		r.u(1) // hook method
+		r.u(1) // simplex/duplex
+		r.u(2) // transmission grant
+		r.u(1) // transmission request permission
+		r.u(1) // call ownership
+		// Optional type-2 chain: Call priority(4), Basic service(8),
+		// Temporary address(24).
+		if optElementsPresent(r) {
+			if v, ok := optField(r, 4); ok {
+				msg.setPriority(uint8(v))
+			}
+			optSkip(r, 8)              // basic service information
+			msg.GroupSSI = optU(r, 24) // temporary address (GSSI)
+		}
+
+	case CMCETypeDRelease:
+		// CallId(14) DisconnectCause(5) — mandatory (Table 14.12).
+		if r.remaining() < 14+5 {
+			return CMCEMessage{}, false
+		}
+		msg.CallIdentifier = uint16(r.u(14))
+		msg.DisconnectCause = uint8(r.u(5))
+
+	case CMCETypeDTxCeased:
+		// CallId(14) TxReqPerm(1) — mandatory (Table 14.16).
+		if r.remaining() < 14+1 {
+			return CMCEMessage{}, false
+		}
+		msg.CallIdentifier = uint16(r.u(14))
+		r.u(1) // transmission request permission
+
+	case CMCETypeDTxGranted:
+		// CallId(14) TxGrant(2) TxReqPerm(1) EncControl(1) Reserved(1) —
+		// mandatory (Table 14.18).
+		if r.remaining() < 14+2+1+1+1 {
+			return CMCEMessage{}, false
+		}
+		msg.CallIdentifier = uint16(r.u(14))
+		r.u(2) // transmission grant
+		r.u(1) // transmission request permission
+		r.u(1) // encryption control
+		r.u(1) // reserved
+		// Optional type-2: Notification indicator(6), Transmitting party type
+		// identifier(2) + conditional Transmitting party SSI.
+		if optElementsPresent(r) {
+			optSkip(r, 6)       // notification indicator
+			msg.readPartySSI(r) // transmitting party type id + conditional SSI
+		}
+
+	default:
+		return CMCEMessage{}, false
+	}
+	return msg, true
+}
+
+// setPriority records the 4-bit Call priority and derives the emergency flag.
+func (m *CMCEMessage) setPriority(p uint8) {
+	m.HasPriority = true
+	m.Priority = p & 0xF
+	m.Emergency = m.Priority == callPriorityEmergency
+}
+
+// readPartySSI reads a "party type identifier" type-2 element and its
+// conditional address SSI (Calling party in D-SETUP, Transmitting party in
+// D-TX-GRANTED). The identifier is a type-2 element (P-bit gated); when present
+// its 2-bit value conditions the SSI: 1 ⇒ SSI(24); 2 ⇒ SSI(24) + extension(24,
+// skipped). 0 ⇒ no SSI.
+func (m *CMCEMessage) readPartySSI(r *bitReader) {
+	present, ok := optPBit(r)
+	if !ok || !present {
+		return
+	}
+	if r.remaining() < 2 {
+		return
+	}
+	cpti := r.u(2)
+	// CPTI 1 ⇒ SSI(24); CPTI 2 ⇒ SSI(24) + extension(24). The SSI and extension
+	// are conditional elements (gated by the CPTI value, no P-bit of their own).
+	if cpti == 1 || cpti == 2 {
+		if r.remaining() < 24 {
+			return
+		}
+		m.PartySSI = r.u(24)
+	}
+	if cpti == 2 && r.remaining() >= 24 {
+		r.u(24) // calling/transmitting party extension (skipped)
+	}
+}
+
+// optElementsPresent reads the O-bit that introduces the optional type-2 /
+// type-3-4 element chain. Returns false when absent (no bits left, or O == 0).
+func optElementsPresent(r *bitReader) bool {
+	if r.remaining() < 1 {
+		return false
+	}
+	return r.bit() == 1
+}
+
+// optPBit reads a type-2 element presence bit. ok is false when the stream is
+// exhausted (the chain simply ends — remaining type-2 elements are absent).
+func optPBit(r *bitReader) (present bool, ok bool) {
+	if r.remaining() < 1 {
+		return false, false
+	}
+	return r.bit() == 1, true
+}
+
+// optField reads a fixed-width type-2 element: its P-bit, then n bits of content
+// if present. Returns (value, true) only when the element is present and fully
+// available.
+func optField(r *bitReader, n int) (uint32, bool) {
+	present, ok := optPBit(r)
+	if !ok || !present {
+		return 0, false
+	}
+	if r.remaining() < n {
+		return 0, false
+	}
+	return r.u(n), true
+}
+
+// optU is optField that returns just the value (0 when absent).
+func optU(r *bitReader, n int) uint32 {
+	v, _ := optField(r, n)
+	return v
+}
+
+// optSkip advances past a fixed-width type-2 element (P-bit + n content bits when
+// present), discarding its value.
+func optSkip(r *bitReader, n int) {
+	optField(r, n)
+}

--- a/internal/radio/tetra/cmce_parse_test.go
+++ b/internal/radio/tetra/cmce_parse_test.go
@@ -1,0 +1,239 @@
+package tetra
+
+import "testing"
+
+// cmceBitWriter emits an MSB-first one-bit-per-byte stream — the same convention
+// bitReader consumes — so tests can hand-assemble bit-packed CMCE PDUs. A single
+// fixture is round-tripped through the reader in TestCMCEBitWriterRoundTrip to
+// guarantee the two conventions match (a mismatch would make every fixture
+// self-consistently wrong).
+type cmceBitWriter struct{ bits []byte }
+
+func (w *cmceBitWriter) u(v uint64, n int) {
+	for i := n - 1; i >= 0; i-- {
+		w.bits = append(w.bits, byte((v>>uint(i))&1))
+	}
+}
+
+// opt appends a type-2 element: a presence bit, then n content bits if present.
+func (w *cmceBitWriter) opt(present bool, v uint64, n int) {
+	if present {
+		w.u(1, 1)
+		w.u(v, n)
+	} else {
+		w.u(0, 1)
+	}
+}
+
+// pbit appends a bare presence bit (for elements whose content width varies).
+func (w *cmceBitWriter) pbit(present bool) {
+	if present {
+		w.u(1, 1)
+	} else {
+		w.u(0, 1)
+	}
+}
+
+// cmceHeader writes the 3-bit CMCE MLE discriminator + 5-bit PDU type.
+func (w *cmceBitWriter) header(t CMCEType) {
+	w.u(uint64(cmceMLEPD), 3)
+	w.u(uint64(t), 5)
+}
+
+func TestCMCEBitWriterRoundTrip(t *testing.T) {
+	// A D-RELEASE with known fields must read back exactly what was written —
+	// proves the writer and bitReader share the MSB-first convention.
+	w := &cmceBitWriter{}
+	w.header(CMCETypeDRelease)
+	w.u(0x1ABC&0x3FFF, 14) // call id
+	w.u(0x0A, 5)           // disconnect cause
+	msg, ok := ParseCMCE(w.bits)
+	if !ok {
+		t.Fatal("ParseCMCE returned ok=false on a valid D-RELEASE")
+	}
+	if msg.CallIdentifier != (0x1ABC & 0x3FFF) {
+		t.Errorf("CallIdentifier = %#x, want %#x", msg.CallIdentifier, 0x1ABC&0x3FFF)
+	}
+	if msg.DisconnectCause != 0x0A {
+		t.Errorf("DisconnectCause = %#x, want 0x0A", msg.DisconnectCause)
+	}
+}
+
+func TestParseCMCE_DSetupEmergency(t *testing.T) {
+	const (
+		callID = 0x0123
+		gssi   = 0x0F5670 // 24-bit GSSI
+		src    = 0x0123AB // 24-bit calling party SSI
+	)
+	w := &cmceBitWriter{}
+	w.header(CMCETypeDSetup)
+	w.u(callID, 14)                       // call identifier
+	w.u(0, 4)                             // call time-out
+	w.u(0, 1)                             // hook
+	w.u(0, 1)                             // simplex/duplex
+	w.u(0, 8)                             // basic service info
+	w.u(0, 2)                             // transmission grant
+	w.u(0, 1)                             // transmission request permission
+	w.u(uint64(callPriorityEmergency), 4) // call priority = emergency
+	w.u(1, 1)                             // O-bit: optional elements present
+	w.opt(false, 0, 6)                    // notification indicator absent
+	w.opt(true, gssi, 24)                 // temporary address (GSSI) present
+	w.pbit(true)                          // calling party type identifier present
+	w.u(1, 2)                             // CPTI = 1 (SSI present)
+	w.u(src, 24)                          // calling party SSI
+
+	msg, ok := ParseCMCE(w.bits)
+	if !ok {
+		t.Fatal("ParseCMCE ok=false on a valid D-SETUP")
+	}
+	if msg.Type != CMCETypeDSetup {
+		t.Errorf("Type = %#x, want D-SETUP", msg.Type)
+	}
+	if !msg.Emergency {
+		t.Error("Emergency = false, want true (call priority 1111)")
+	}
+	if msg.CallIdentifier != callID {
+		t.Errorf("CallIdentifier = %#x, want %#x", msg.CallIdentifier, callID)
+	}
+	if msg.GroupSSI != gssi {
+		t.Errorf("GroupSSI = %#x, want %#x", msg.GroupSSI, gssi)
+	}
+	if msg.PartySSI != src {
+		t.Errorf("PartySSI = %#x, want %#x", msg.PartySSI, src)
+	}
+}
+
+func TestParseCMCE_DSetupNonEmergency(t *testing.T) {
+	w := &cmceBitWriter{}
+	w.header(CMCETypeDSetup)
+	w.u(1, 14)          // call id
+	w.u(0, 4+1+1+8+2+1) // timeout..txreqperm
+	w.u(0x1, 4)         // call priority = 1 (lowest), not emergency
+	w.u(0, 1)           // O-bit clear
+	msg, ok := ParseCMCE(w.bits)
+	if !ok {
+		t.Fatal("ok=false")
+	}
+	if msg.Emergency {
+		t.Error("Emergency = true, want false (priority 0001)")
+	}
+	if !msg.HasPriority || msg.Priority != 1 {
+		t.Errorf("Priority = %d (has=%v), want 1", msg.Priority, msg.HasPriority)
+	}
+	if msg.GroupSSI != 0 || msg.PartySSI != 0 {
+		t.Errorf("expected no optional SSIs, got group=%#x party=%#x", msg.GroupSSI, msg.PartySSI)
+	}
+}
+
+func TestParseCMCE_DConnectOptionalPriorityAndGSSI(t *testing.T) {
+	const gssi = 0x0ABCDE
+	w := &cmceBitWriter{}
+	w.header(CMCETypeDConnect)
+	w.u(0x2A, 14)                                 // call id
+	w.u(0, 4+1+1+2+1+1)                           // timeout..call ownership
+	w.u(1, 1)                                     // O-bit
+	w.opt(true, uint64(callPriorityEmergency), 4) // call priority = emergency
+	w.opt(false, 0, 8)                            // basic service absent
+	w.opt(true, gssi, 24)                         // temporary address present
+	msg, ok := ParseCMCE(w.bits)
+	if !ok {
+		t.Fatal("ok=false")
+	}
+	if !msg.Emergency {
+		t.Error("Emergency = false, want true")
+	}
+	if msg.GroupSSI != gssi {
+		t.Errorf("GroupSSI = %#x, want %#x", msg.GroupSSI, gssi)
+	}
+	if msg.CallIdentifier != 0x2A {
+		t.Errorf("CallIdentifier = %#x, want 0x2A", msg.CallIdentifier)
+	}
+}
+
+func TestParseCMCE_DTxGrantedTalker(t *testing.T) {
+	const talker = 0x00CAFE
+	w := &cmceBitWriter{}
+	w.header(CMCETypeDTxGranted)
+	w.u(0x3F, 14)      // call id
+	w.u(0, 2+1+1+1)    // tx grant..reserved
+	w.u(1, 1)          // O-bit
+	w.opt(false, 0, 6) // notification indicator absent
+	w.pbit(true)       // transmitting party type identifier present
+	w.u(1, 2)          // TPTI = 1
+	w.u(talker, 24)    // transmitting party SSI
+	msg, ok := ParseCMCE(w.bits)
+	if !ok {
+		t.Fatal("ok=false")
+	}
+	if msg.Type != CMCETypeDTxGranted {
+		t.Errorf("Type = %#x, want D-TX-GRANTED", msg.Type)
+	}
+	if msg.PartySSI != talker {
+		t.Errorf("PartySSI = %#x, want %#x", msg.PartySSI, talker)
+	}
+}
+
+func TestParseCMCE_DTxCeased(t *testing.T) {
+	w := &cmceBitWriter{}
+	w.header(CMCETypeDTxCeased)
+	w.u(0x1BCD&0x3FFF, 14)
+	w.u(0, 1)
+	msg, ok := ParseCMCE(w.bits)
+	if !ok {
+		t.Fatal("ok=false")
+	}
+	if msg.Type != CMCETypeDTxCeased || msg.CallIdentifier != (0x1BCD&0x3FFF) {
+		t.Errorf("got Type=%#x CallId=%#x", msg.Type, msg.CallIdentifier)
+	}
+}
+
+func TestParseCMCE_NoOptionalChain(t *testing.T) {
+	// O-bit clear: mandatory fields still parse; optionals stay zero.
+	w := &cmceBitWriter{}
+	w.header(CMCETypeDSetup)
+	w.u(0x2B, 14)
+	w.u(0, 4+1+1+8+2+1)
+	w.u(0x3, 4) // priority 3
+	w.u(0, 1)   // O-bit clear
+	msg, ok := ParseCMCE(w.bits)
+	if !ok {
+		t.Fatal("ok=false")
+	}
+	if msg.GroupSSI != 0 || msg.PartySSI != 0 {
+		t.Error("optional SSIs should be absent with O-bit clear")
+	}
+	if msg.CallIdentifier != 0x2B || msg.Priority != 3 {
+		t.Errorf("mandatory fields wrong: callid=%#x prio=%d", msg.CallIdentifier, msg.Priority)
+	}
+}
+
+func TestParseCMCE_RejectsNonCMCE(t *testing.T) {
+	w := &cmceBitWriter{}
+	w.u(0x1, 3) // MLE PD = 001 (MM), not CMCE
+	w.u(uint64(CMCETypeDSetup), 5)
+	w.u(0, 40)
+	if _, ok := ParseCMCE(w.bits); ok {
+		t.Error("ParseCMCE accepted a non-CMCE MLE discriminator")
+	}
+}
+
+func TestParseCMCE_RejectsUnmodelledType(t *testing.T) {
+	w := &cmceBitWriter{}
+	w.u(uint64(cmceMLEPD), 3)
+	w.u(0x00, 5) // D-ALERT — not modelled
+	w.u(0, 40)
+	if _, ok := ParseCMCE(w.bits); ok {
+		t.Error("ParseCMCE accepted an unmodelled PDU type")
+	}
+}
+
+func TestParseCMCE_Truncated(t *testing.T) {
+	// Header says D-SETUP but the slice ends inside the mandatory block.
+	w := &cmceBitWriter{}
+	w.header(CMCETypeDSetup)
+	w.u(0x2B, 14)
+	w.u(0, 5) // far short of the mandatory field count
+	if _, ok := ParseCMCE(w.bits); ok {
+		t.Error("ParseCMCE accepted a truncated mandatory block")
+	}
+}

--- a/internal/radio/tetra/control.go
+++ b/internal/radio/tetra/control.go
@@ -94,6 +94,13 @@ type ControlChannel struct {
 	mainCarrier    uint16
 	mainCarrierSet bool
 
+	// callGroups maps a CMCE 14-bit call identifier to the group SSI (GSSI) the
+	// call is addressed to, learned from D-SETUP/D-CONNECT. A D-RELEASE /
+	// D-TX-GRANTED carries only the call identifier, so this resolves it back to
+	// the talkgroup the engine keys active calls by. Lazily built; entries are
+	// dropped on release. Guarded by mu.
+	callGroups map[uint16]uint32
+
 	// pendingSoft holds the per-symbol complex differential (soft
 	// information) for the next Process call, stashed by StashSoft
 	// immediately before the matching dibit chunk arrives (see
@@ -500,14 +507,12 @@ func (c *ControlChannel) Ingest(p PDU) {
 			MNC:          sb.MNC,
 			LocationArea: sb.LocationArea,
 		})
-		return
 	}
-	if g, ok := p.AsVoiceGrant(); ok {
-		// Even without a prior SYSINFO, a voice grant on the CC is
-		// enough to declare the channel locked.
-		c.maybeLock(LockState{FrequencyHz: c.freqHz})
-		c.publishGrant(g)
-	}
+	// Voice grants and call teardown are NOT parsed here: on real air they ride
+	// in a bit-packed CMCE TM-SDU that the byte-aligned ParsePDU cannot frame
+	// (a 3-bit MLE discriminator + 5-bit type, not 4+4). They are decoded
+	// bit-accurately from the MAC layer instead — see downlink.go handleCMCE,
+	// where the MAC-RESOURCE address already gives the reliable GSSI.
 }
 
 // tetraChannelSpacingHz is the TETRA carrier spacing (25 kHz), used to derive a
@@ -589,6 +594,82 @@ func (c *ControlChannel) publishGrant(g VoiceGrant) {
 		"src", g.SourceSSI, "dst", g.DestSSI,
 		"carrier", g.CarrierNumber, "slot", g.Timeslot, "freq_hz", freq,
 		"group", g.Group, "enc", g.Encrypted, "emer", g.Emergency)
+}
+
+// rememberCall records the call-identifier → group-SSI mapping learned from a
+// D-SETUP/D-CONNECT, so a later D-RELEASE/D-TX-GRANTED (which carries only the
+// call identifier) can be resolved back to the talkgroup. No-op for a zero
+// group.
+func (c *ControlChannel) rememberCall(callID uint16, gssi uint32) {
+	if gssi == 0 {
+		return
+	}
+	c.mu.Lock()
+	if c.callGroups == nil {
+		c.callGroups = make(map[uint16]uint32)
+	}
+	c.callGroups[callID] = gssi
+	c.mu.Unlock()
+}
+
+// resolveGroup maps a CMCE call identifier to its group SSI, preferring the
+// learned D-SETUP/D-CONNECT mapping and falling back to the MAC-RESOURCE address
+// SSI the PDU was addressed under (which for a group call is the GSSI). Returns
+// 0 when neither is known.
+func (c *ControlChannel) resolveGroup(callID uint16, addrSSI uint32) uint32 {
+	c.mu.Lock()
+	gssi := c.callGroups[callID]
+	c.mu.Unlock()
+	if gssi != 0 {
+		return gssi
+	}
+	return addrSSI
+}
+
+// forgetCall drops a call-identifier mapping once its call has been released.
+func (c *ControlChannel) forgetCall(callID uint16) {
+	c.mu.Lock()
+	delete(c.callGroups, callID)
+	c.mu.Unlock()
+}
+
+// publishRelease emits a KindCallRelease so the engine ends the active call for
+// this talkgroup at once, rather than waiting out the voice hangtime/no-voice
+// timers. No-op without a bus or a resolvable group.
+func (c *ControlChannel) publishRelease(gssi uint32, cause uint8) {
+	if c.bus == nil || gssi == 0 {
+		return
+	}
+	c.bus.Publish(events.Event{
+		Kind: events.KindCallRelease,
+		Payload: trunking.CallRelease{
+			System:  c.systemName,
+			GroupID: gssi,
+			Reason:  trunking.EndReasonReleased,
+			At:      c.now(),
+		},
+	})
+	c.log.Debug("tetra: call release",
+		"system", c.systemName, "group", gssi, "cause", cause)
+}
+
+// publishTalker emits a KindCallTalker so the engine backfills the current
+// transmitting party's SSI onto the active call for this talkgroup.
+func (c *ControlChannel) publishTalker(gssi, src uint32) {
+	if c.bus == nil || gssi == 0 || src == 0 {
+		return
+	}
+	c.bus.Publish(events.Event{
+		Kind: events.KindCallTalker,
+		Payload: trunking.CallTalker{
+			System:   c.systemName,
+			GroupID:  gssi,
+			SourceID: src,
+			At:       c.now(),
+		},
+	})
+	c.log.Debug("tetra: call talker",
+		"system", c.systemName, "group", gssi, "src", src)
 }
 
 // noteActivity stamps the control-channel heartbeat with the current time.

--- a/internal/radio/tetra/downlink.go
+++ b/internal/radio/tetra/downlink.go
@@ -191,13 +191,25 @@ func (c *ControlChannel) ingestMAC(recovered []byte) {
 		if !ok || m.NullPDU {
 			return
 		}
-		if m.ChanAlloc != nil {
-			c.publishGrantFromMAC(m)
-		}
+		// Parse the L3 CMCE PDU first (bit-accurate, from the raw TM-SDU bits) so
+		// a grant can be enriched with its emergency flag + source SSI, and so a
+		// D-RELEASE / D-TX change can act on the same MAC-RESOURCE's address.
+		var (
+			msg      CMCEMessage
+			haveCMCE bool
+		)
 		if sdu := m.tmSDU(recovered); sdu != nil {
+			msg, haveCMCE = ParseCMCE(sdu)
+			// Keep the broadcast/SYSINFO L3 path (Ingest no longer emits grants).
 			if pdu, err := PDUFromBits(sdu); err == nil {
 				c.Ingest(pdu)
 			}
+		}
+		if m.ChanAlloc != nil {
+			c.publishGrantFromMAC(m, msg, haveCMCE)
+		}
+		if haveCMCE {
+			c.handleCMCE(m, msg)
 		}
 	case MACPDUBroadcast:
 		// Learn the cell's own carrier number so grant carrier numbers resolve
@@ -210,14 +222,14 @@ func (c *ControlChannel) ingestMAC(recovered []byte) {
 }
 
 // publishGrantFromMAC turns a MAC-RESOURCE channel allocation into a voice
-// grant. The physical resource (carrier + timeslot) comes from the MAC
-// channel-allocation element; the addressed party SSI is the grant's group/dest
-// identity. Source SSI and the emergency/group flags live in the CMCE TM-SDU and
-// are filled once fragment reassembly surfaces the full CMCE PDU.
-func (c *ControlChannel) publishGrantFromMAC(m MACResource) {
+// grant. The physical resource (carrier + timeslot) and the addressed group SSI
+// come from the MAC layer (reliable, bit-accurate). When the same MAC-RESOURCE's
+// CMCE TM-SDU decoded (haveCMCE), the grant is enriched with the correctly
+// decoded emergency flag and — when present — the calling party's source SSI.
+func (c *ControlChannel) publishGrantFromMAC(m MACResource, msg CMCEMessage, haveCMCE bool) {
 	// A grant on the CC is itself enough to declare the channel locked.
 	c.maybeLock(LockState{FrequencyHz: c.freqHz})
-	c.publishGrant(VoiceGrant{
+	g := VoiceGrant{
 		DestSSI:       m.Address.SSI,
 		CarrierNumber: m.ChanAlloc.CarrierNumber,
 		Timeslot:      m.ChanAlloc.Timeslot & 0x3,
@@ -228,5 +240,45 @@ func (c *ControlChannel) publishGrantFromMAC(m MACResource) {
 		// plain-SSI grant, which falls the voice chain back to CRC-gated isolation.
 		UsageMarker: m.Address.UsageMarker,
 		Encrypted:   m.Encrypted,
-	})
+	}
+	if haveCMCE {
+		g.Emergency = msg.Emergency
+		if msg.PartySSI != 0 {
+			g.SourceSSI = msg.PartySSI
+		}
+	}
+	c.publishGrant(g)
+}
+
+// handleCMCE acts on a decoded CMCE call-control PDU that rode in a MAC-RESOURCE
+// addressed to m.Address.SSI (the GSSI for a group call). It learns the
+// call-identifier → group mapping from setup PDUs so a later release/talker PDU
+// resolves to the talkgroup the engine keys calls by, ends a call on D-RELEASE,
+// and surfaces the transmitting party on D-TX-GRANTED.
+func (c *ControlChannel) handleCMCE(m MACResource, msg CMCEMessage) {
+	switch msg.Type {
+	case CMCETypeDSetup, CMCETypeDConnect:
+		// Map to the MAC-RESOURCE address SSI — the exact value publishGrantFromMAC
+		// uses as the grant's group id, so a later release/talker resolves to the
+		// same key the engine tracks the call by. Fall back to the CMCE temporary
+		// address only when the MAC address is not an SSI (0).
+		gssi := m.Address.SSI
+		if gssi == 0 {
+			gssi = msg.GroupSSI
+		}
+		c.rememberCall(msg.CallIdentifier, gssi)
+	case CMCETypeDRelease:
+		gssi := c.resolveGroup(msg.CallIdentifier, m.Address.SSI)
+		c.publishRelease(gssi, msg.DisconnectCause)
+		c.forgetCall(msg.CallIdentifier)
+	case CMCETypeDTxGranted:
+		if msg.PartySSI != 0 {
+			gssi := c.resolveGroup(msg.CallIdentifier, m.Address.SSI)
+			c.publishTalker(gssi, msg.PartySSI)
+		}
+	case CMCETypeDTxCeased:
+		// Transmission boundary within a call; no engine action today (a
+		// CallSourceUpdate cannot represent "talker stopped"). Hook for a future
+		// KindCallSegment emission.
+	}
 }

--- a/internal/radio/tetra/ingest_cmce_test.go
+++ b/internal/radio/tetra/ingest_cmce_test.go
@@ -1,0 +1,114 @@
+package tetra
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TestHandleCMCEReleaseResolvesViaSetupMap: a D-SETUP teaches the call
+// identifier → group mapping, so a later D-RELEASE (which carries only the call
+// identifier) publishes a KindCallRelease keyed to that group — even when the
+// release PDU's own MAC address is not the group.
+func TestHandleCMCEReleaseResolvesViaSetupMap(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "Sys", FrequencyHz: 467_913_000})
+
+	const (
+		callID = 0x1234
+		gssi   = 0x0F5670
+	)
+	// D-SETUP addressed to the GSSI (via the MAC address) learns the mapping.
+	cc.handleCMCE(
+		MACResource{Address: MACAddress{Type: addrSSI, SSI: gssi}},
+		CMCEMessage{Type: CMCETypeDSetup, CallIdentifier: callID, GroupSSI: gssi},
+	)
+	// D-RELEASE whose MAC address is an individual, not the group: the map
+	// resolves it back to the group.
+	cc.handleCMCE(
+		MACResource{Address: MACAddress{Type: addrSSI, SSI: 0x999999}},
+		CMCEMessage{Type: CMCETypeDRelease, CallIdentifier: callID, DisconnectCause: 3},
+	)
+
+	rel := waitForRelease(t, sub)
+	if rel.System != "Sys" || rel.GroupID != gssi {
+		t.Errorf("CallRelease = %+v, want System=Sys GroupID=%#x", rel, gssi)
+	}
+	if rel.Reason != trunking.EndReasonReleased {
+		t.Errorf("release reason = %v, want released", rel.Reason)
+	}
+}
+
+// TestHandleCMCEReleaseFallsBackToMACAddress: with no prior D-SETUP, a D-RELEASE
+// resolves its group from the MAC-RESOURCE address it was carried under (a group
+// call's downlink signalling is addressed to the GSSI).
+func TestHandleCMCEReleaseFallsBackToMACAddress(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "Sys", FrequencyHz: 467_913_000})
+	const gssi = 0x0ABCDE
+	cc.handleCMCE(
+		MACResource{Address: MACAddress{Type: addrSSI, SSI: gssi}},
+		CMCEMessage{Type: CMCETypeDRelease, CallIdentifier: 0x55},
+	)
+	if rel := waitForRelease(t, sub); rel.GroupID != gssi {
+		t.Errorf("fallback release GroupID = %#x, want %#x", rel.GroupID, gssi)
+	}
+}
+
+// TestHandleCMCETxGrantedPublishesTalker: a D-TX-GRANTED carrying the
+// transmitting party SSI publishes a KindCallTalker for the call's group.
+func TestHandleCMCETxGrantedPublishesTalker(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "Sys", FrequencyHz: 467_913_000})
+	const (
+		gssi   = 0x0ABCDE
+		talker = 0x00CAFE
+	)
+	cc.handleCMCE(
+		MACResource{Address: MACAddress{Type: addrSSI, SSI: gssi}},
+		CMCEMessage{Type: CMCETypeDTxGranted, CallIdentifier: 0x66, PartySSI: talker},
+	)
+
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindCallTalker {
+				tk := ev.Payload.(trunking.CallTalker)
+				if tk.GroupID != gssi || tk.SourceID != talker {
+					t.Errorf("CallTalker = %+v, want group %#x src %#x", tk, gssi, talker)
+				}
+				return
+			}
+		default:
+			t.Fatal("no KindCallTalker published for D-TX-GRANTED")
+		}
+	}
+}
+
+func waitForRelease(t *testing.T, sub *events.Subscription) trunking.CallRelease {
+	t.Helper()
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindCallRelease {
+				return ev.Payload.(trunking.CallRelease)
+			}
+		default:
+			t.Fatal("no KindCallRelease published")
+			return trunking.CallRelease{}
+		}
+	}
+}

--- a/internal/radio/tetra/process_channel_coding_test.go
+++ b/internal/radio/tetra/process_channel_coding_test.go
@@ -93,9 +93,11 @@ func TestProcessChannelCodingOnSCHHDRoundTrip(t *testing.T) {
 	}
 }
 
-// TestProcessChannelCodingOnSCHFRoundTrip: same idea but with a
-// full-slot signaling channel (432 type-5 bits / 216 dibits) and
-// a CMCE D-CONNECT (voice grant) PDU.
+// TestProcessChannelCodingOnSCHFRoundTrip: same idea but with a full-slot
+// signaling channel (432 type-5 bits / 216 dibits). It carries an MLE SYSINFO
+// (the L3 PDU the legacy Process/Ingest path still surfaces — grants are decoded
+// from the MAC layer, not this path) and asserts cc.locked, exercising the
+// SCH/F FEC round-trip end to end.
 func TestProcessChannelCodingOnSCHFRoundTrip(t *testing.T) {
 	bus := events.NewBus(16)
 	defer bus.Close()
@@ -120,15 +122,10 @@ func TestProcessChannelCodingOnSCHFRoundTrip(t *testing.T) {
 	// exercises the intended decode path.
 	cc.SetColourCode(0x1234)
 
-	// CMCE D-CONNECT carrying a VoiceGrant for talkgroup 0xCAFE,
-	// source 0xAAAAAA, dest 0xBBBBBB, carrier 7, group flag set.
-	payload := make([]byte, 11)
-	payload[0], payload[1] = 0x00, 0x04 // CID = 1
-	payload[2], payload[3], payload[4] = 0xAA, 0xAA, 0xAA
-	payload[5], payload[6], payload[7] = 0xBB, 0xBB, 0xBB
-	payload[8] = 0x80                    // group flag
-	payload[9], payload[10] = 0x00, 0x70 // carrier 7
-	pdu := PDU{Disc: DiscCMCE, Type: uint8(CMCEDConnect), Payload: payload}
+	// An MLE SYSINFO PDU carried over SCH/F; the legacy Process/Ingest path
+	// surfaces it as cc.locked. (Grants are decoded from the MAC layer, covered
+	// by downlink_test.go.)
+	pdu := PDU{Disc: DiscMLE, Type: uint8(MLESystemInfo), Payload: buildSysInfoPayload(206, 1, 5)}
 	info := pduToType1Bits(pdu, 268)
 	if info == nil {
 		t.Fatalf("PDU too large for SCH/F 268 type-1 bits")
@@ -145,16 +142,16 @@ func TestProcessChannelCodingOnSCHFRoundTrip(t *testing.T) {
 
 	cc.Process(stream, 0)
 
-	var sawGrant bool
+	var sawLock bool
 	for {
 		select {
 		case ev := <-sub.C:
-			if ev.Kind == events.KindGrant {
-				sawGrant = true
+			if ev.Kind == events.KindCCLocked {
+				sawLock = true
 			}
 		default:
-			if !sawGrant {
-				t.Errorf("ChannelCodingOn Process did not publish KindGrant for a CMCE D-CONNECT encoded via SCH/F")
+			if !sawLock {
+				t.Errorf("ChannelCodingOn Process did not publish cc.locked for an MLE SYSINFO encoded via SCH/F")
 			}
 			return
 		}

--- a/internal/radio/tetra/strict_test.go
+++ b/internal/radio/tetra/strict_test.go
@@ -52,37 +52,34 @@ func TestStrictValidationDropsUnknownDiscriminator(t *testing.T) {
 }
 
 // TestStrictValidationKeepsKnownPDU: a PDU with a recognised
-// (Discriminator, Type) pair must still publish its event under
-// strict mode. Uses a D-CONNECT carrying a voice grant.
+// (Discriminator, Type) pair must still publish its event under strict mode.
+// Uses an MLE SYSINFO, the L3 PDU Ingest still surfaces (grants/teardown are
+// decoded from the MAC layer, not Ingest — see downlink.go).
 func TestStrictValidationKeepsKnownPDU(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()
 	sub := bus.Subscribe()
 	defer sub.Close()
 
-	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Sys"})
+	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Sys", FrequencyHz: 410_000_000})
 	cc.SetStrictValidation(true)
 
-	// Build a minimal D-CONNECT payload: 14-bit CID + flags, source SSI,
-	// dest SSI, flags byte, carrier+slot. Channel 7, slot 0, group call.
-	payload := make([]byte, 11)
-	payload[0], payload[1] = 0x00, 0x04 // CID = 1 in upper 14 bits
-	payload[2], payload[3], payload[4] = 0xAA, 0xAA, 0xAA
-	payload[5], payload[6], payload[7] = 0xBB, 0xBB, 0xBB
-	payload[8] = 0x80                    // group flag set
-	payload[9], payload[10] = 0x00, 0x70 // carrier 7 in upper 12 bits, slot 0
-	cc.Ingest(PDU{Disc: DiscCMCE, Type: uint8(CMCEDConnect), Payload: payload})
+	cc.Ingest(PDU{
+		Disc:    DiscMLE,
+		Type:    uint8(MLESystemInfo),
+		Payload: buildSysInfoPayload(206, 1, 5),
+	})
 
 	got := 0
 	for {
 		select {
 		case ev := <-sub.C:
-			if ev.Kind == events.KindGrant {
+			if ev.Kind == events.KindCCLocked {
 				got++
 			}
 		default:
 			if got == 0 {
-				t.Errorf("strict-mode D-CONNECT did not publish a Grant")
+				t.Errorf("strict-mode MLE SYSINFO did not publish cc.locked")
 			}
 			return
 		}

--- a/internal/radio/tetra/tetra_test.go
+++ b/internal/radio/tetra/tetra_test.go
@@ -78,109 +78,16 @@ func TestDiscriminatorClassification(t *testing.T) {
 	}
 }
 
-// buildVoiceGrantPayload constructs the 11-byte D-CONNECT payload
-// that AsVoiceGrant decodes.
-func buildVoiceGrantPayload(cid uint16, src, dst uint32, carrier uint16, slot uint8, group, emer, enc bool) []byte {
-	out := make([]byte, 11)
-	cidField := (cid & 0x3FFF) << 2
-	out[0] = byte(cidField >> 8)
-	out[1] = byte(cidField & 0xFF)
-	out[2] = byte((src >> 16) & 0xFF)
-	out[3] = byte((src >> 8) & 0xFF)
-	out[4] = byte(src & 0xFF)
-	out[5] = byte((dst >> 16) & 0xFF)
-	out[6] = byte((dst >> 8) & 0xFF)
-	out[7] = byte(dst & 0xFF)
-	var flags byte
-	if group {
-		flags |= 0x80
-	}
-	if emer {
-		flags |= 0x40
-	}
-	if enc {
-		flags |= 0x20
-	}
-	out[8] = flags
-	carrierField := ((carrier & 0xFFF) << 4) | (uint16(slot&0x3) << 2)
-	out[9] = byte(carrierField >> 8)
-	out[10] = byte(carrierField & 0xFF)
-	return out
-}
-
-func TestAsVoiceGrantExtractsFields(t *testing.T) {
-	payload := buildVoiceGrantPayload(
-		0x1234, 0x100200, 0x300400, 0x0ABC, 2,
-		true, true, false,
-	)
-	pdu := PDU{Disc: DiscCMCE, Type: uint8(CMCEDConnect), Payload: payload}
-	g, ok := pdu.AsVoiceGrant()
-	if !ok {
-		t.Fatal("AsVoiceGrant returned !ok")
-	}
-	if g.CallIdentifier != 0x1234 {
-		t.Errorf("CallIdentifier = %X, want 1234", g.CallIdentifier)
-	}
-	if g.SourceSSI != 0x100200 || g.DestSSI != 0x300400 {
-		t.Errorf("SSIs = %X / %X", g.SourceSSI, g.DestSSI)
-	}
-	if g.CarrierNumber != 0x0ABC {
-		t.Errorf("CarrierNumber = %X, want ABC", g.CarrierNumber)
-	}
-	if g.Timeslot != 2 {
-		t.Errorf("Timeslot = %d", g.Timeslot)
-	}
-	if !g.Group || !g.Emergency || g.Encrypted {
-		t.Errorf("flags = %+v", g)
-	}
-}
-
-func TestAsVoiceGrantTxGrantedAlsoMatches(t *testing.T) {
-	payload := buildVoiceGrantPayload(0x10, 1, 2, 0x100, 0, false, false, true)
-	pdu := PDU{Disc: DiscCMCE, Type: uint8(CMCEDTxGranted), Payload: payload}
-	g, ok := pdu.AsVoiceGrant()
-	if !ok || !g.Encrypted || g.CarrierNumber != 0x100 {
-		t.Errorf("D-TX-GRANTED grant = %+v ok=%v", g, ok)
-	}
-}
-
-func TestAsVoiceGrantWrongType(t *testing.T) {
-	pdu := PDU{Disc: DiscCMCE, Type: uint8(CMCEDRelease), Payload: make([]byte, 11)}
-	if _, ok := pdu.AsVoiceGrant(); ok {
-		t.Error("AsVoiceGrant returned ok for D-RELEASE")
-	}
-}
-
-func TestAsVoiceGrantWrongDisc(t *testing.T) {
-	pdu := PDU{Disc: DiscMM, Type: uint8(CMCEDConnect), Payload: make([]byte, 11)}
-	if _, ok := pdu.AsVoiceGrant(); ok {
-		t.Error("AsVoiceGrant returned ok for non-CMCE Disc")
-	}
-}
-
-func TestAsVoiceGrantShortPayload(t *testing.T) {
-	pdu := PDU{Disc: DiscCMCE, Type: uint8(CMCEDConnect), Payload: make([]byte, 8)}
-	if _, ok := pdu.AsVoiceGrant(); ok {
-		t.Error("AsVoiceGrant returned ok for short payload")
-	}
-}
-
-func TestAsRelease(t *testing.T) {
-	payload := []byte{0x12, 0x38, 0x05} // CID = 0x048E (after >>2), cause = 5
-	pdu := PDU{Disc: DiscCMCE, Type: uint8(CMCEDRelease), Payload: payload}
-	r, ok := pdu.AsRelease()
-	if !ok {
-		t.Fatal("AsRelease returned !ok")
-	}
-	if r.CallIdentifier != 0x048E {
-		t.Errorf("CallIdentifier = %X, want 048E", r.CallIdentifier)
-	}
-	if r.DisconnectCause != 5 {
-		t.Errorf("DisconnectCause = %d", r.DisconnectCause)
-	}
-	other := PDU{Disc: DiscCMCE, Type: uint8(CMCEDConnect)}
-	if _, ok := other.AsRelease(); ok {
-		t.Error("AsRelease returned ok for non-RELEASE")
+// grantMAC builds the MACResource that publishGrantFromMAC turns into a voice
+// grant — the real on-air grant carrier (a MAC-RESOURCE channel allocation
+// addressed to the group SSI), replacing the byte-aligned D-CONNECT the deleted
+// AsVoiceGrant used to parse. The bit-accurate CMCE parse itself is covered by
+// cmce_parse_test.go and the end-to-end MAC path by downlink_test.go.
+func grantMAC(dst uint32, carrier uint16, slot uint8, enc bool) MACResource {
+	return MACResource{
+		Encrypted: enc,
+		Address:   MACAddress{Type: addrSSI, SSI: dst},
+		ChanAlloc: &ChannelAllocation{CarrierNumber: carrier, Timeslot: slot},
 	}
 }
 
@@ -401,14 +308,13 @@ func TestControlChannelEmitsGrant(t *testing.T) {
 		Now:         func() time.Time { return fixed },
 	})
 
-	cc.Ingest(PDU{
-		Disc: DiscCMCE,
-		Type: uint8(CMCEDConnect),
-		Payload: buildVoiceGrantPayload(
-			0x55, 0x000123, 0x00ABCD, 200, 1,
-			true, false, true,
-		),
-	})
+	// A MAC-RESOURCE grant for dest 0x00ABCD on carrier 200 / slot 1, encrypted,
+	// with a D-SETUP CMCE PDU supplying the source SSI (0x000123), non-emergency.
+	cc.publishGrantFromMAC(
+		grantMAC(0x00ABCD, 200, 1, true),
+		CMCEMessage{Type: CMCETypeDSetup, PartySSI: 0x000123},
+		true,
+	)
 
 	// First event: cc.locked synthesized when grant arrives.
 	select {
@@ -460,11 +366,7 @@ func TestControlChannelGrantWithoutResolver(t *testing.T) {
 	defer sub.Close()
 
 	cc := New(Options{Bus: bus, FrequencyHz: 380_500_000})
-	cc.Ingest(PDU{
-		Disc:    DiscCMCE,
-		Type:    uint8(CMCEDConnect),
-		Payload: buildVoiceGrantPayload(1, 2, 3, 42, 0, false, false, false),
-	})
+	cc.publishGrantFromMAC(grantMAC(3, 42, 0, false), CMCEMessage{}, false)
 
 	<-sub.C // cc.locked
 	ev := <-sub.C

--- a/internal/trunking/engine.go
+++ b/internal/trunking/engine.go
@@ -229,6 +229,14 @@ func (e *Engine) Run(ctx context.Context) error {
 				if c, ok := ev.Payload.(CallSourceUpdate); ok {
 					e.handleCallSourceUpdate(c)
 				}
+			case events.KindCallRelease:
+				if r, ok := ev.Payload.(CallRelease); ok {
+					e.handleCallRelease(r)
+				}
+			case events.KindCallTalker:
+				if t, ok := ev.Payload.(CallTalker); ok {
+					e.handleCallTalker(t)
+				}
 			case events.KindTalkerAlias:
 				if a, ok := ev.Payload.(TalkerAlias); ok {
 					e.handleTalkerAlias(a)
@@ -609,6 +617,54 @@ func (e *Engine) handleCallSourceUpdate(c CallSourceUpdate) {
 		"src", enriched.SourceID,
 		"enc", enriched.Encrypted)
 	e.applyEncryptedPolicy(c.DeviceSerial, g, g.Encrypted)
+}
+
+// callsBySystemGroup returns the active calls bound to a given system +
+// talkgroup. A TETRA release/talker event is keyed by (System, GroupID) because
+// the CMCE PDU that produced it is addressed to the GSSI and carries no device
+// serial. Snapshots pool.Active(), so callers may end/mutate the results without
+// holding a lock (endCall re-checks via the idempotent pool.Release).
+func (e *Engine) callsBySystemGroup(system string, group uint32) []*ActiveCall {
+	var out []*ActiveCall
+	for _, ac := range e.pool.Active() {
+		if ac.Grant.System == system && ac.Grant.GroupID == group {
+			out = append(out, ac)
+		}
+	}
+	return out
+}
+
+// handleCallRelease ends every active call matching the released (System,
+// GroupID) at once — the decoded-teardown path that replaces waiting out the
+// composer's hangtime/no-voice timers. A no-match release is a harmless no-op
+// (the call may have already ended, or was never followed). endCall is
+// idempotent (pool.Release returns nil if already released), so a release racing
+// the hangtime end still publishes exactly one CallEnd.
+func (e *Engine) handleCallRelease(r CallRelease) {
+	reason := r.Reason
+	if reason == EndReasonUnknown {
+		reason = EndReasonReleased
+	}
+	for _, ac := range e.callsBySystemGroup(r.System, r.GroupID) {
+		e.endCall(ac, reason)
+	}
+}
+
+// handleCallTalker backfills the current transmitting party onto the active
+// call(s) for (System, GroupID), reusing the KindCallSourceUpdate path (keyed by
+// the resolved device serial). A talker update for an unfollowed call resolves
+// to no serials and is a no-op.
+func (e *Engine) handleCallTalker(t CallTalker) {
+	if t.SourceID == 0 {
+		return
+	}
+	for _, ac := range e.callsBySystemGroup(t.System, t.GroupID) {
+		e.handleCallSourceUpdate(CallSourceUpdate{
+			DeviceSerial: ac.Device.Serial,
+			SourceID:     t.SourceID,
+			At:           t.At,
+		})
+	}
 }
 
 // republishCallSource emits an enriched KindCallSourceUpdate for a source

--- a/internal/trunking/engine_test.go
+++ b/internal/trunking/engine_test.go
@@ -1473,3 +1473,113 @@ func TestEngineHandleCallEncryptionEnrichedRepublishDoesNotLoop(t *testing.T) {
 		// pass
 	}
 }
+
+// TestEngineHandleCallReleaseEndsCall: a decoded call-teardown (e.g. TETRA CMCE
+// D-RELEASE) ends the active call for that (System, GroupID) at once — the fix
+// for TETRA calls that otherwise only ended on the ~7 s no-voice timeout. A
+// zero Reason defaults to EndReasonReleased.
+func TestEngineHandleCallReleaseEndsCall(t *testing.T) {
+	e, pool, bus, _ := mkEngine(t, 1)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: 100, FrequencyHz: 851_000_000})
+	if len(pool.Active()) != 1 {
+		t.Fatalf("precondition: want 1 active call, got %d", len(pool.Active()))
+	}
+
+	e.handleCallRelease(CallRelease{System: "X", GroupID: 100})
+
+	c := &testBusCollector{}
+	evs := c.drain(sub, 2, 500*time.Millisecond)
+	var end *CallEnd
+	for _, ev := range evs {
+		if ev.Kind == events.KindCallEnd {
+			ce := ev.Payload.(CallEnd)
+			end = &ce
+		}
+	}
+	if end == nil {
+		t.Fatal("no call.end published after release")
+	}
+	if end.Reason != EndReasonReleased {
+		t.Errorf("end reason = %v, want released", end.Reason)
+	}
+	if end.Grant.GroupID != 100 {
+		t.Errorf("ended call GroupID = %d, want 100", end.Grant.GroupID)
+	}
+	if len(pool.Active()) != 0 {
+		t.Errorf("call still active after release: %d", len(pool.Active()))
+	}
+}
+
+// TestEngineHandleCallReleaseNoMatchNoop: a release for a group with no active
+// call is harmless.
+func TestEngineHandleCallReleaseNoMatchNoop(t *testing.T) {
+	e, pool, bus, _ := mkEngine(t, 1)
+	defer bus.Close()
+
+	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: 100, FrequencyHz: 851_000_000})
+	e.handleCallRelease(CallRelease{System: "X", GroupID: 999}) // different group
+	if len(pool.Active()) != 1 {
+		t.Errorf("unrelated release ended the call: active=%d", len(pool.Active()))
+	}
+}
+
+// TestEngineHandleCallReleaseIdempotent: two releases for the same call publish
+// exactly one call.end (the pool release is idempotent), so a release racing the
+// hangtime end can't double-end.
+func TestEngineHandleCallReleaseIdempotent(t *testing.T) {
+	e, _, bus, _ := mkEngine(t, 1)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: 100, FrequencyHz: 851_000_000})
+	e.handleCallRelease(CallRelease{System: "X", GroupID: 100})
+	e.handleCallRelease(CallRelease{System: "X", GroupID: 100})
+
+	c := &testBusCollector{}
+	evs := c.drain(sub, 3, 300*time.Millisecond)
+	ends := 0
+	for _, ev := range evs {
+		if ev.Kind == events.KindCallEnd {
+			ends++
+		}
+	}
+	if ends != 1 {
+		t.Errorf("call.end published %d times, want exactly 1", ends)
+	}
+}
+
+// TestEngineHandleCallTalkerUpdatesSource: a decoded transmitting party (TETRA
+// CMCE D-TX-GRANTED) backfills the active call's source via the source-update
+// path.
+func TestEngineHandleCallTalkerUpdatesSource(t *testing.T) {
+	e, _, bus, _ := mkEngine(t, 1)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: 100, FrequencyHz: 851_000_000})
+	e.handleCallTalker(CallTalker{System: "X", GroupID: 100, SourceID: 4242})
+
+	c := &testBusCollector{}
+	evs := c.drain(sub, 3, 500*time.Millisecond)
+	var upd *CallSourceUpdate
+	for _, ev := range evs {
+		if ev.Kind == events.KindCallSourceUpdate {
+			u := ev.Payload.(CallSourceUpdate)
+			if u.System != "" { // the engine's enriched republish
+				upd = &u
+			}
+		}
+	}
+	if upd == nil {
+		t.Fatal("no enriched call.source published after talker update")
+	}
+	if upd.SourceID != 4242 || upd.GroupID != 100 {
+		t.Errorf("source update = %+v, want src 4242 group 100", *upd)
+	}
+}

--- a/internal/trunking/grant.go
+++ b/internal/trunking/grant.go
@@ -215,6 +215,12 @@ const (
 	// tuner was freed by policy, not by a decode problem or a higher-
 	// priority preemption. Issue #711.
 	EndReasonEncrypted
+	// EndReasonReleased is an explicit, decoded call-teardown end: the
+	// control-channel decoder saw a channel-release message (e.g. a TETRA CMCE
+	// D-RELEASE) and ended the call at once. Distinct from EndReasonNormal (a
+	// hangtime/carrier-drop inference) and EndReasonTimeout (silent from start)
+	// so operators can see the call ended because the network said so.
+	EndReasonReleased
 )
 
 func (r EndReason) String() string {
@@ -235,6 +241,8 @@ func (r EndReason) String() string {
 		return "manual"
 	case EndReasonEncrypted:
 		return "encrypted"
+	case EndReasonReleased:
+		return "released"
 	default:
 		return "unknown"
 	}
@@ -350,6 +358,31 @@ type CallSourceUpdate struct {
 	SourceID     uint32
 	Encrypted    bool
 	At           time.Time
+}
+
+// CallRelease is the payload of an events.KindCallRelease event. A
+// control-channel decoder publishes one when it decodes an explicit
+// call-teardown message (e.g. a TETRA CMCE D-RELEASE). The engine ends every
+// active call matching (System, GroupID) at once, instead of waiting out the
+// hangtime/no-voice timers. Keyed by talkgroup because a TETRA release rides in
+// a MAC-RESOURCE addressed to the GSSI and carries no device/serial notion.
+type CallRelease struct {
+	System  string
+	GroupID uint32
+	Reason  EndReason
+	At      time.Time
+}
+
+// CallTalker is the payload of an events.KindCallTalker event. A control-channel
+// decoder publishes one when it resolves the current transmitting party of an
+// active call (e.g. a TETRA CMCE D-TX-GRANTED carrying the transmitting party
+// SSI). The engine resolves (System, GroupID) to the bound device and backfills
+// the source via the KindCallSourceUpdate path.
+type CallTalker struct {
+	System   string
+	GroupID  uint32
+	SourceID uint32
+	At       time.Time
 }
 
 // SiteUpdate is the payload of an events.KindSiteUpdate event. The P25

--- a/internal/voice/composer/tetra_voice.go
+++ b/internal/voice/composer/tetra_voice.go
@@ -230,6 +230,18 @@ type tetraSlotDemux struct {
 	// registration order, so concurrent marker-less calls still separate instead of
 	// falling back to accept-all/mix. Best-effort; verified against real DDC IQ.
 	wildcards []*tetraSlotOwner
+
+	// Drop/fallback counters — the demux's routing was previously a telemetry
+	// blind spot (a slot-loss showed up only as an empty recording). Logged at
+	// demux teardown so a "gappy recordings" report is self-triaging: undecoded =
+	// bursts with no routable AACH marker dropped (no single owner to fall back
+	// to), ownerless = decoded traffic markers with no registered call, crcFallback
+	// = undecoded bursts routed to the sole active call via the CRC gate,
+	// collisions = two calls contending for one marker.
+	undecodedDrops   atomic.Uint64
+	ownerlessDrops   atomic.Uint64
+	crcFallbacks     atomic.Uint64
+	markerCollisions atomic.Uint64
 }
 
 // tetraSlotOwner is one call's registration with the carrier demux: the usage
@@ -264,7 +276,13 @@ func (d *tetraSlotDemux) run(ctx context.Context, iqCh <-chan []complex64, iqHz 
 	})
 	d.c.log.Info("composer: tetra shared voice demux started (usage-marker routing)",
 		"key", d.key, "colour_code", d.colour&0x3F, "rate_hz", symbolHz)
-	defer d.c.log.Info("composer: tetra shared voice demux ended", "key", d.key)
+	defer func() {
+		d.c.log.Info("composer: tetra shared voice demux ended", "key", d.key,
+			"undecoded_drops", d.undecodedDrops.Load(),
+			"ownerless_drops", d.ownerlessDrops.Load(),
+			"crc_fallbacks", d.crcFallbacks.Load(),
+			"marker_collisions", d.markerCollisions.Load())
+	}()
 
 	for {
 		select {
@@ -300,7 +318,34 @@ func (d *tetraSlotDemux) observe(iq []complex64) {
 // oldest wildcard claims that marker. Runs on the single demux goroutine, so each
 // owner's boundary tracker has exactly one writer.
 func (d *tetraSlotDemux) onBurst(frame []byte, slot, usage uint8) {
+	// A burst whose AACH did not decode (usage 0) or is a control slot
+	// (< DLUsageTraffic) carries no routable marker. Dropping it outright loses
+	// the granted call's own speech whenever its AACH is momentarily
+	// un-decodable — the shared-demux gap the solo tap did not have. Fall back to
+	// the CRC gate, but ONLY when exactly one call is active (one owner and no
+	// waiting wildcard, or one waiting wildcard and no owner): with a single call
+	// there is no concurrent call to cross-talk into, so this matches the solo
+	// tap's burstUsage==0 behaviour. With ≥2 active calls an unrouteable burst is
+	// dropped (and counted) rather than mixed into an arbitrary recording.
 	if usage < tetra.DLUsageTraffic {
+		d.mu.Lock()
+		var sole *tetraSlotOwner
+		switch {
+		case len(d.owners) == 1 && len(d.wildcards) == 0:
+			for _, o := range d.owners {
+				sole = o
+			}
+		case len(d.owners) == 0 && len(d.wildcards) == 1:
+			sole = d.wildcards[0]
+		}
+		d.mu.Unlock()
+		if sole == nil {
+			d.undecodedDrops.Add(1)
+			return
+		}
+		d.crcFallbacks.Add(1)
+		sole.bursts.Add(1)
+		d.c.decodeTETRASpeech(sole.bt, sole.rs, sole.serial, frame, &sole.speech)
 		return
 	}
 	d.mu.Lock()
@@ -313,6 +358,7 @@ func (d *tetraSlotDemux) onBurst(frame []byte, slot, usage uint8) {
 	}
 	d.mu.Unlock()
 	if o == nil {
+		d.ownerlessDrops.Add(1)
 		return
 	}
 	o.bursts.Add(1)
@@ -325,6 +371,15 @@ func (d *tetraSlotDemux) onBurst(frame []byte, slot, usage uint8) {
 func (d *tetraSlotDemux) addOwner(o *tetraSlotOwner) {
 	d.mu.Lock()
 	if o.marker >= tetra.DLUsageTraffic {
+		if prev := d.owners[o.marker]; prev != nil && prev != o {
+			// Two live calls contending for one on-air marker: most-recent-grant
+			// wins (a reused marker must displace a hangtime-lingering call), but
+			// if these are genuinely concurrent the prior call now starves. Count
+			// + warn so the case is visible rather than a silent empty recording.
+			d.markerCollisions.Add(1)
+			d.c.log.Warn("composer: tetra usage-marker collision — newest call takes the marker, prior call starves",
+				"key", d.key, "marker", o.marker, "prev", prev.serial, "new", o.serial)
+		}
 		d.owners[o.marker] = o
 	} else {
 		d.wildcards = append(d.wildcards, o)

--- a/internal/voice/composer/tetra_voice_test.go
+++ b/internal/voice/composer/tetra_voice_test.go
@@ -374,3 +374,73 @@ func TestTETRADemuxWildcardBinding(t *testing.T) {
 		t.Errorf("bound wildcard grabbed a second marker: %d frames, want 4", n)
 	}
 }
+
+// TestTETRADemuxCRCFallbackSingleOwner: when only one call is active and a burst
+// arrives with an undecoded/non-traffic AACH marker (usage 0), the demux falls
+// back to the CRC gate and routes it to that sole owner — parity with the solo
+// tap. Before this fallback the shared demux dropped every usage-0 burst, so a
+// single marker-less (plain-SSI grant) call decoded no speech.
+func TestTETRADemuxCRCFallbackSingleOwner(t *testing.T) {
+	c, _, _ := mkBoundaryComposer(t, false, 50*time.Millisecond)
+	d := mkDemux(c)
+	frame := tetra.EncodeTCHS(make([]byte, 137), make([]byte, 137))
+
+	o, rs := newDemuxOwner(c, "A", 0) // wildcard: grant carried no usage marker
+	d.addOwner(o)
+
+	d.onBurst(frame, 2, 0) // undecoded AACH, single active call → CRC fallback
+	if n := len(rs.rawFrames("A")); n != 2 {
+		t.Errorf("single-owner CRC fallback: A got %d frames, want 2", n)
+	}
+	if got := d.crcFallbacks.Load(); got != 1 {
+		t.Errorf("crcFallbacks = %d, want 1", got)
+	}
+}
+
+// TestTETRADemuxCRCFallbackNoCrossTalkConcurrent is the cross-talk guard: with
+// two concurrent calls active, a burst whose AACH did not decode (usage 0) is
+// NOT routed to either — there is no way to tell which call it belongs to, so
+// mixing it into an arbitrary recording is worse than dropping. It is counted.
+func TestTETRADemuxCRCFallbackNoCrossTalkConcurrent(t *testing.T) {
+	c, _, _ := mkBoundaryComposer(t, false, 50*time.Millisecond)
+	d := mkDemux(c)
+	frame := tetra.EncodeTCHS(make([]byte, 137), make([]byte, 137))
+
+	oA, rsA := newDemuxOwner(c, "A", 19)
+	oB, rsB := newDemuxOwner(c, "B", 20)
+	d.addOwner(oA)
+	d.addOwner(oB)
+
+	d.onBurst(frame, 2, 0) // undecoded AACH, two active calls → drop, no cross-talk
+	if n := len(rsA.rawFrames("A")) + len(rsB.rawFrames("B")); n != 0 {
+		t.Errorf("undecoded burst leaked to a concurrent owner: %d frames, want 0", n)
+	}
+	if got := d.undecodedDrops.Load(); got != 1 {
+		t.Errorf("undecodedDrops = %d, want 1", got)
+	}
+}
+
+// TestTETRADemuxMarkerCollisionCounted: two calls registering the same usage
+// marker is now counted + warned (previously a silent orphan). Most-recent-grant
+// still wins the marker (existing eviction semantics preserved).
+func TestTETRADemuxMarkerCollisionCounted(t *testing.T) {
+	c, _, _ := mkBoundaryComposer(t, false, 50*time.Millisecond)
+	d := mkDemux(c)
+	frame := tetra.EncodeTCHS(make([]byte, 137), make([]byte, 137))
+
+	oOld, rsOld := newDemuxOwner(c, "old", 19)
+	oNew, rsNew := newDemuxOwner(c, "new", 19)
+	d.addOwner(oOld)
+	d.addOwner(oNew) // collision on marker 19
+
+	if got := d.markerCollisions.Load(); got != 1 {
+		t.Errorf("markerCollisions = %d, want 1", got)
+	}
+	d.onBurst(frame, 1, 19) // newest owns the marker
+	if n := len(rsNew.rawFrames("new")); n != 2 {
+		t.Errorf("newest owner got %d frames, want 2 (most-recent-grant wins)", n)
+	}
+	if n := len(rsOld.rawFrames("old")); n != 0 {
+		t.Errorf("displaced owner got %d frames, want 0 (starved by collision)", n)
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #989 (CC sync-recovery + multiframe logging, already merged) on the
same live single-carrier TETRA site. This PR fixes call start/end and the
emergency flag, and recovers voice that was being lost on the same-carrier demux.
The CMCE decode was byte-aligned and never matched real (bit-packed) PDUs, so
calls only ended on a ~7 s timeout, `src` was always 0, and an auto-record was
spuriously tagged emergency; concurrent same-carrier calls also produced
gappy/empty recordings.

## Changes

Three self-contained commits:

- **bit-accurate CMCE downlink PDU parser** (`ParseCMCE`) — decode the TM-SDU as
  actually framed per ETSI EN 300 392-2 §14 (3-bit MLE discriminator + 5-bit CMCE
  type + bit-packed mandatory fields + the O-bit/P-bit type-2 optional chain),
  reusing the existing `bitReader`. Replaces the byte-aligned `Disc(4)+Type(4)`
  guess that never lined up with real CMCE PDUs.
- **CMCE call-control wiring** — fed from the MAC layer where the GSSI is known:
  grants now carry the correctly-decoded emergency flag (from the 4-bit Call
  priority, `1111` = emergency) and the source SSI; `D-RELEASE` ends the matching
  call at once (new `EndReasonReleased`) instead of the ~7 s timeout;
  `D-TX-GRANTED` backfills the talker (new `call.release` / `call.talker` events).
  The misaligned byte-aligned `AsVoiceGrant`/`AsRelease` path is removed — grants
  come solely from the reliable MAC-RESOURCE layer.
- **voice slot-loss: single-call CRC fallback + demux observability** — the shared
  same-carrier demux now CRC-gates an undecoded/marker-less burst when a single
  call is active (parity with the solo tap; drops rather than cross-talks with ≥2
  active calls), counts marker collisions instead of silently orphaning a call,
  and logs undecoded / ownerless / CRC-fallback / collision counters at teardown
  so slot drops are diagnosable.

## Test plan

- [x] `make vet test` is green locally
- [ ] `make integration` — not run in this environment
- [x] Added or updated tests (fail-first): CMCE parser (10 cases incl. a
  writer/reader round-trip), CMCE ingest→release/talker wiring, engine
  release-ends-call / idempotent / talker-source, demux single-owner CRC fallback
  + concurrent no-cross-talk guard + collision counter. Migrated the tests that
  drove grants through the removed byte-aligned path onto the MAC path.
- [x] Smoke-tested against real captures: the voice path was validated by
  replaying the reporter's 144 kHz ddc-tap cs16 through `TestTETRAMultiSlotReplay`
  — per-slot TCH/S decodes 72–75% of traffic-marked bursts on a clean capture,
  confirming the loss was demux routing, not channel decode. The emergency /
  D-RELEASE decode is unit-tested here; the reporter validates on-air (live
  traffic).

## Breaking changes

None operator-facing (no config keys, CLI flags, REST/gRPC changes). Internal
only: the byte-aligned `PDU.AsVoiceGrant` / `PDU.AsRelease` accessors are removed
(superseded by `ParseCMCE` off the MAC layer); two new event kinds
(`call.release`, `call.talker`) and one new `EndReason` (`released`) are added.

## Docs / CHANGELOG

- [ ] CHANGELOG `## [Unreleased]` bullet — not added yet (happy to add on request)
- [ ] README/docs — n/a (no operator-facing behaviour change)

## Linked issues

n/a

## Known follow-ups

- Concurrent marker-less / marker-collision voice cases are now *surfaced* by the
  new counters but not fully resolved — a raw wideband capture of a bad concurrent
  moment (or the new field counters) is needed to choose slot-disambiguation vs a
  grant-attribution fix.
- The traffic extractor assumes AFC rotation 0 while the control path tries all 4
  rotations; a no-op on the provided captures (all at rotation 0), left as a
  data-driven follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P8UJSRRr1i1N3MS133YQXe

---
_Generated by [Claude Code](https://claude.ai/code/session_01P8UJSRRr1i1N3MS133YQXe)_