### PR TITLE
TETRA: ISSI/GSSI + frequency-offset decode, call-state fixes, soft SCH

### DIFF
--- a/internal/api/grant_individual_test.go
+++ b/internal/api/grant_individual_test.go
@@ -1,0 +1,37 @@
+package api
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TestGrantIndividualDTO verifies the Individual flag survives the
+// trunking.Grant → JSON DTO conversion, so a REST/SSE consumer can render a
+// TETRA unit-to-unit call's radio ID as an individual rather than a phantom
+// talkgroup. It is omitted from JSON for ordinary group grants.
+func TestGrantIndividualDTO(t *testing.T) {
+	indiv := trunking.Grant{
+		System: "Sys", Protocol: "tetra",
+		GroupID: 1005372, FrequencyHz: 467_912_500, Individual: true,
+	}
+	if dto := grantToDTO(indiv); !dto.Individual {
+		t.Error("grantToDTO dropped Individual=true")
+	}
+	if b, _ := json.Marshal(grantToDTO(indiv)); !strings.Contains(string(b), `"individual":true`) {
+		t.Errorf("individual grant JSON missing individual flag: %s", b)
+	}
+
+	group := trunking.Grant{
+		System: "Sys", Protocol: "tetra",
+		GroupID: 1020545, FrequencyHz: 467_912_500, // Individual defaults false
+	}
+	if dto := grantToDTO(group); dto.Individual {
+		t.Error("grantToDTO set Individual on a group grant")
+	}
+	if b, _ := json.Marshal(grantToDTO(group)); strings.Contains(string(b), "individual") {
+		t.Errorf("group grant JSON should omit the individual flag: %s", b)
+	}
+}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -470,6 +470,11 @@ type GrantDTO struct {
 	Encrypted bool  `json:"encrypted,omitempty"`
 	Emergency bool  `json:"emergency,omitempty"`
 	DataCall  bool  `json:"data_call,omitempty"`
+	// Individual marks a grant whose group_id is NOT a talkgroup but an
+	// individual destination — a unit-to-unit target radio, an interconnect
+	// target, or a TETRA subscriber ISSI — so a consumer can render the radio ID
+	// as a unit rather than a phantom talkgroup. Omitted (false) for group calls.
+	Individual bool `json:"individual,omitempty"`
 	// AlgorithmID / KeyID surface the P25 encryption parameters
 	// recovered from the in-call signalling. Zero when Encrypted is
 	// false; also zero on a Phase 1 grant until the LDU2 Encryption
@@ -490,6 +495,7 @@ func grantToDTO(g trunking.Grant) GrantDTO {
 		Timeslot:  g.Timeslot,
 		Encrypted: g.Encrypted, Emergency: g.Emergency,
 		DataCall:    g.DataCall,
+		Individual:  g.Individual,
 		AlgorithmID: g.AlgorithmID, KeyID: g.KeyID,
 	}
 }

--- a/internal/radio/tetra/channel_coding.go
+++ b/internal/radio/tetra/channel_coding.go
@@ -211,6 +211,14 @@ func DecodeSCHF(type5 []byte, colourCode uint32) ([]byte, bool) {
 	return signalingDecode(type5, framing.InterleaveKSCHF, framing.InterleaveASCHF, colourCode, 268)
 }
 
+// DecodeSCHFSoft is the soft-decision analog of DecodeSCHF: 432 type-5 LLRs →
+// 268 type-1 bits + CRC-pass flag. The soft-input Viterbi recovers ~1.5–2 dB the
+// hard slicer discards, which matters on the longer SCH/F block where a marginal
+// constellation accumulates more symbol errors before the CRC gate.
+func DecodeSCHFSoft(type5LLR []float32, colourCode uint32) ([]byte, bool) {
+	return signalingDecodeSoft(type5LLR, framing.InterleaveKSCHF, framing.InterleaveASCHF, colourCode, 268)
+}
+
 // EncodeSCHHU runs 92 type-1 bits through the SCH/HU chain per
 // §8.3.1.4.3. Returns 168 type-5 bits.
 func EncodeSCHHU(type1 []byte, colourCode uint32) []byte {

--- a/internal/radio/tetra/classify_test.go
+++ b/internal/radio/tetra/classify_test.go
@@ -1,0 +1,70 @@
+package tetra
+
+import "testing"
+
+// TestClassifyPartiesGroupAndIndividual pins the individual-vs-group
+// classification. On real air a CMCE calling/transmitting party SSI is always an
+// individual radio, and a grant carrying one is addressed under the group's GSSI;
+// a later grant addressed to that radio (a D-CONNECT to the calling party, which
+// has no party field) is individual-addressed, not a talkgroup grant.
+func TestClassifyPartiesGroupAndIndividual(t *testing.T) {
+	cc := New(Options{FrequencyHz: 467_913_000})
+	const (
+		gssi = 1020545 // talkgroup
+		issi = 1005372 // radio ID
+		call = 8675
+	)
+
+	// 1. Group D-SETUP: addressed under the GSSI, calling party present. GroupID is
+	//    the GSSI, source is the party; the party is learned as an individual.
+	var group VoiceGrant
+	cc.classifyParties(&group,
+		MACResource{Address: MACAddress{Type: addrSSI, SSI: gssi}},
+		CMCEMessage{Type: CMCETypeDSetup, CallIdentifier: call, PartySSI: issi}, true)
+	if group.DestSSI != gssi || group.SourceSSI != issi || group.Individual {
+		t.Errorf("group grant = {dst:%d src:%d indiv:%v}, want {dst:%d src:%d indiv:false}",
+			group.DestSSI, group.SourceSSI, group.Individual, gssi, issi)
+	}
+	if !cc.isIndividual(issi) {
+		t.Errorf("party %d not learned as an individual", issi)
+	}
+
+	// 2. D-CONNECT addressed to the now-known individual, no party, no group mapped
+	//    yet: flagged Individual so it is not surfaced as a talkgroup.
+	var indiv VoiceGrant
+	cc.classifyParties(&indiv,
+		MACResource{Address: MACAddress{Type: addrSSI, SSI: issi}},
+		CMCEMessage{Type: CMCETypeDConnect, CallIdentifier: 999}, true)
+	if indiv.DestSSI != issi || !indiv.Individual {
+		t.Errorf("individual-addressed grant = {dst:%d indiv:%v}, want {dst:%d indiv:true}",
+			indiv.DestSSI, indiv.Individual, issi)
+	}
+
+	// 3. Once the call is mapped to its group, an individual-addressed grant for
+	//    that call folds onto the group instead of standing alone.
+	cc.rememberCall(call, gssi)
+	var folded VoiceGrant
+	cc.classifyParties(&folded,
+		MACResource{Address: MACAddress{Type: addrSSI, SSI: issi}},
+		CMCEMessage{Type: CMCETypeDConnect, CallIdentifier: call}, true)
+	if folded.DestSSI != gssi || folded.SourceSSI != issi || folded.Individual {
+		t.Errorf("folded grant = {dst:%d src:%d indiv:%v}, want {dst:%d src:%d indiv:false}",
+			folded.DestSSI, folded.SourceSSI, folded.Individual, gssi, issi)
+	}
+}
+
+// TestClassifyPartiesUnknownStaysGroup guards the conservative default: an SSI
+// never seen as a party (and no CMCE party on this PDU) is left as a talkgroup —
+// the MAC address type cannot distinguish a GSSI from an ISSI, so we never guess
+// Individual without positive evidence.
+func TestClassifyPartiesUnknownStaysGroup(t *testing.T) {
+	cc := New(Options{FrequencyHz: 467_913_000})
+	var g VoiceGrant
+	cc.classifyParties(&g,
+		MACResource{Address: MACAddress{Type: addrSSI, SSI: 1234567}},
+		CMCEMessage{Type: CMCETypeDConnect, CallIdentifier: 1}, true)
+	if g.DestSSI != 1234567 || g.Individual || g.SourceSSI != 0 {
+		t.Errorf("unknown grant = {dst:%d src:%d indiv:%v}, want {dst:1234567 src:0 indiv:false}",
+			g.DestSSI, g.SourceSSI, g.Individual)
+	}
+}

--- a/internal/radio/tetra/cmce.go
+++ b/internal/radio/tetra/cmce.go
@@ -73,8 +73,13 @@ type VoiceGrant struct {
 	Timeslot       uint8  // 2-bit (0..3)
 	UsageMarker    uint8  // downlink usage marker (AACH §21.4.7); 0 = none
 	Group          bool
-	Emergency      bool
-	Encrypted      bool
+	// Individual marks a grant whose DestSSI is an individual subscriber ISSI
+	// (a unit-to-unit / individual-addressed call), not a talkgroup GSSI — so the
+	// engine and UI do not surface the radio ID as a phantom talkgroup. Set by
+	// classifyParties.
+	Individual bool
+	Emergency  bool
+	Encrypted  bool
 }
 
 // Voice grants and call teardown are decoded bit-accurately from the MAC layer

--- a/internal/radio/tetra/cmce_parse.go
+++ b/internal/radio/tetra/cmce_parse.go
@@ -31,6 +31,16 @@ const (
 	CMCETypeDTxGranted CMCEType = 0x0B // D-TX GRANTED
 )
 
+// isCMCETeardown reports whether a CMCE PDU type tears a call down rather than
+// establishing or maintaining it. A channel-allocation element that accompanies
+// a teardown PDU refers to the traffic resource being *reclaimed*, not a new
+// voice grant — so ingestMAC must not publish a grant for it, which would spawn a
+// zero-byte ghost call that the release then immediately ends. D-DISCONNECT is
+// not yet modelled by ParseCMCE; add it here when it is.
+func isCMCETeardown(t CMCEType) bool {
+	return t == CMCETypeDRelease
+}
+
 // cmceMLEPD is the 3-bit MLE protocol discriminator value that selects the CMCE
 // SDU (Table 18.1: 010 = CMCE; 001 = MM, 100 = SNDCP, 101 = MLE).
 const cmceMLEPD uint32 = 0x2

--- a/internal/radio/tetra/control.go
+++ b/internal/radio/tetra/control.go
@@ -104,6 +104,14 @@ type ControlChannel struct {
 	sysInfo    SysInfo
 	sysInfoSet bool
 
+	// individuals is the set of SSIs observed acting as a CMCE calling /
+	// transmitting party (msg.PartySSI). A party is always an individual radio, so
+	// this lets classifyParties recognise a grant addressed to a subscriber ISSI
+	// (e.g. a D-CONNECT to the calling party, which carries no party field of its
+	// own) and flag it Individual instead of surfacing it as a talkgroup. Bounded
+	// by individualsCap; guarded by mu.
+	individuals map[uint32]struct{}
+
 	// callGroups maps a CMCE 14-bit call identifier to the group SSI (GSSI) the
 	// call is addressed to, learned from D-SETUP/D-CONNECT. A D-RELEASE /
 	// D-TX-GRANTED carries only the call identifier, so this resolves it back to
@@ -666,6 +674,7 @@ func (c *ControlChannel) publishGrant(g VoiceGrant) {
 			Timeslot:         g.Timeslot + 1,
 			Encrypted:        g.Encrypted,
 			Emergency:        g.Emergency,
+			Individual:       g.Individual,
 			TETRAColourExt:   colourExt,
 			TETRAUsageMarker: g.UsageMarker,
 			At:               c.now(),
@@ -676,7 +685,7 @@ func (c *ControlChannel) publishGrant(g VoiceGrant) {
 		"system", c.systemName,
 		"src", g.SourceSSI, "dst", g.DestSSI,
 		"carrier", g.CarrierNumber, "slot", g.Timeslot, "freq_hz", freq,
-		"group", g.Group, "enc", g.Encrypted, "emer", g.Emergency)
+		"individual", g.Individual, "enc", g.Encrypted, "emer", g.Emergency)
 }
 
 // rememberCall records the call-identifier → group-SSI mapping learned from a
@@ -714,6 +723,36 @@ func (c *ControlChannel) forgetCall(callID uint16) {
 	c.mu.Lock()
 	delete(c.callGroups, callID)
 	c.mu.Unlock()
+}
+
+// individualsCap bounds the learned-individuals set so a long-running site cannot
+// grow it without limit. A cell's active subscriber set is far smaller; once full
+// the set stops learning new individuals (existing ones still classify).
+const individualsCap = 8192
+
+// noteIndividual records an SSI seen acting as a CMCE calling/transmitting party
+// — always an individual radio. No-op for 0 or once the set is at capacity.
+func (c *ControlChannel) noteIndividual(ssi uint32) {
+	if ssi == 0 {
+		return
+	}
+	c.mu.Lock()
+	if c.individuals == nil {
+		c.individuals = make(map[uint32]struct{})
+	}
+	if _, ok := c.individuals[ssi]; !ok && len(c.individuals) < individualsCap {
+		c.individuals[ssi] = struct{}{}
+	}
+	c.mu.Unlock()
+}
+
+// isIndividual reports whether an SSI has been seen acting as a party (and is
+// therefore an individual radio rather than a talkgroup GSSI).
+func (c *ControlChannel) isIndividual(ssi uint32) bool {
+	c.mu.Lock()
+	_, ok := c.individuals[ssi]
+	c.mu.Unlock()
+	return ok
 }
 
 // publishRelease emits a KindCallRelease so the engine ends the active call for

--- a/internal/radio/tetra/downlink.go
+++ b/internal/radio/tetra/downlink.go
@@ -211,7 +211,12 @@ func (c *ControlChannel) ingestMAC(recovered []byte) {
 				}
 			}
 		}
-		if m.ChanAlloc != nil {
+		// Publish a voice grant for the allocated resource — unless the CMCE PDU
+		// riding in this MAC-RESOURCE is a teardown (D-RELEASE): its
+		// channel-allocation element is the resource being reclaimed, not a new
+		// call, and publishing it spawns a zero-byte ghost call that handleCMCE's
+		// release then immediately ends.
+		if m.ChanAlloc != nil && !(haveCMCE && isCMCETeardown(msg.Type)) {
 			c.publishGrantFromMAC(m, msg, haveCMCE)
 		}
 		if haveCMCE {

--- a/internal/radio/tetra/downlink.go
+++ b/internal/radio/tetra/downlink.go
@@ -257,11 +257,49 @@ func (c *ControlChannel) publishGrantFromMAC(m MACResource, msg CMCEMessage, hav
 	}
 	if haveCMCE {
 		g.Emergency = msg.Emergency
-		if msg.PartySSI != 0 {
-			g.SourceSSI = msg.PartySSI
-		}
 	}
+	c.classifyParties(&g, m, msg, haveCMCE)
 	c.publishGrant(g)
+}
+
+// classifyParties fills a grant's GroupID (DestSSI), SourceID (SourceSSI) and
+// Individual flag from the MAC address and the decoded CMCE, so a unit-to-unit
+// call's subscriber ISSI is not surfaced as a talkgroup.
+//
+// The reliable on-air signal (confirmed against real captures): a CMCE
+// calling/transmitting party SSI (msg.PartySSI) is always an *individual* radio,
+// and a grant that carries one is addressed under the group's GSSI (the MAC
+// address) with that party as the source. Any SSI ever seen as a party is
+// therefore an individual; a later grant addressed to it (e.g. a D-CONNECT to the
+// calling party, which has no party field of its own) is an individual-addressed
+// PDU, not a talkgroup grant.
+func (c *ControlChannel) classifyParties(g *VoiceGrant, m MACResource, msg CMCEMessage, haveCMCE bool) {
+	addr := m.Address.SSI
+	g.DestSSI = addr
+	g.SourceSSI = 0
+	g.Individual = false
+
+	if haveCMCE && msg.PartySSI != 0 {
+		// Group call addressed under the GSSI, with the calling/transmitting party
+		// as the source. Definitive — no history needed. Learn the party as an
+		// individual so a later PDU addressed to it is classified correctly.
+		g.SourceSSI = msg.PartySSI
+		c.noteIndividual(msg.PartySSI)
+		return
+	}
+
+	// No party field on this PDU. If the addressed SSI is one we have seen act as
+	// a party, it is an individual radio: mark the grant Individual so discovery /
+	// the UI do not treat the subscriber ISSI as a talkgroup. Fold onto the real
+	// group when a prior setup mapped this call to one.
+	if c.isIndividual(addr) {
+		if resolved := c.resolveGroup(msg.CallIdentifier, addr); resolved != 0 && resolved != addr && !c.isIndividual(resolved) {
+			g.DestSSI = resolved
+			g.SourceSSI = addr
+			return
+		}
+		g.Individual = true
+	}
 }
 
 // handleCMCE acts on a decoded CMCE call-control PDU that rode in a MAC-RESOURCE
@@ -272,15 +310,19 @@ func (c *ControlChannel) publishGrantFromMAC(m MACResource, msg CMCEMessage, hav
 func (c *ControlChannel) handleCMCE(m MACResource, msg CMCEMessage) {
 	switch msg.Type {
 	case CMCETypeDSetup, CMCETypeDConnect:
-		// Map to the MAC-RESOURCE address SSI — the exact value publishGrantFromMAC
-		// uses as the grant's group id, so a later release/talker resolves to the
-		// same key the engine tracks the call by. Fall back to the CMCE temporary
-		// address only when the MAC address is not an SSI (0).
+		// Map the call identifier to the group SSI — the MAC address a group setup
+		// is addressed under — so a later release/talker resolves to the talkgroup
+		// the engine tracks the call by. Fall back to the CMCE temporary address
+		// only when the MAC address is not an SSI (0). Skip a known individual: a
+		// D-CONNECT addressed to the calling party must not overwrite the mapping
+		// with the radio ID (which would misattribute the release/talker).
 		gssi := m.Address.SSI
 		if gssi == 0 {
 			gssi = msg.GroupSSI
 		}
-		c.rememberCall(msg.CallIdentifier, gssi)
+		if !c.isIndividual(gssi) {
+			c.rememberCall(msg.CallIdentifier, gssi)
+		}
 	case CMCETypeDRelease:
 		gssi := c.resolveGroup(msg.CallIdentifier, m.Address.SSI)
 		c.publishRelease(gssi, msg.DisconnectCause)

--- a/internal/radio/tetra/downlink.go
+++ b/internal/radio/tetra/downlink.go
@@ -38,12 +38,13 @@ type downlinkNCDB struct {
 	dets    []*SyncDetector
 	scratch []int
 	buf     []uint8
+	softBuf []complex64 // per-symbol differentials, strictly parallel to buf (or empty)
 	bufBase int
 	pending []int
-	onSlot  func(bkn1, aach1, aach2, bkn2 []uint8)
+	onSlot  func(bkn1, aach1, aach2, bkn2 []uint8, bkn1Diffs, bkn2Diffs []complex64)
 }
 
-func newDownlinkNCDB(onSlot func(bkn1, aach1, aach2, bkn2 []uint8)) *downlinkNCDB {
+func newDownlinkNCDB(onSlot func(bkn1, aach1, aach2, bkn2 []uint8, bkn1Diffs, bkn2Diffs []complex64)) *downlinkNCDB {
 	d := &downlinkNCDB{onSlot: onSlot}
 	// The π/4-DQPSK stream carries a residual 0..3 dibit rotation, so correlate
 	// the normal training sequence (NTS1 + NTS2) under all four rotations.
@@ -57,11 +58,19 @@ func newDownlinkNCDB(onSlot func(bkn1, aach1, aach2, bkn2 []uint8)) *downlinkNCD
 
 // process consumes a window of dibits (baseIdx = absolute index of dibits[0],
 // monotonically non-decreasing) and emits each fully-buffered NCDB.
-func (d *downlinkNCDB) process(dibits []uint8, baseIdx int) {
+func (d *downlinkNCDB) process(dibits []uint8, diffs []complex64, baseIdx int) {
 	if len(d.buf) == 0 {
 		d.bufBase = baseIdx
 	}
 	d.buf = append(d.buf, dibits...)
+	// Keep the soft buffer strictly parallel to buf (same discipline as
+	// processSB): append only while soft data is supplied every call, else drop
+	// the soft path rather than misalign. Empty softBuf ⇒ hard-only decode.
+	if diffs != nil && len(diffs) == len(dibits) && len(d.softBuf) == len(d.buf)-len(dibits) {
+		d.softBuf = append(d.softBuf, diffs...)
+	} else if len(d.softBuf) != len(d.buf) {
+		d.softBuf = d.softBuf[:0]
+	}
 
 	ntsLen := len(NormalSyncDibits())
 	for _, det := range d.dets {
@@ -109,6 +118,9 @@ func (d *downlinkNCDB) process(dibits []uint8, baseIdx int) {
 		if drop > len(d.buf) {
 			drop = len(d.buf)
 		}
+		if len(d.softBuf) == len(d.buf) {
+			d.softBuf = append(d.softBuf[:0], d.softBuf[drop:]...)
+		}
 		d.buf = append(d.buf[:0], d.buf[drop:]...)
 		d.bufBase += drop
 	}
@@ -122,6 +134,18 @@ func (d *downlinkNCDB) emit(L int) {
 		}
 		return d.buf[s : s+n]
 	}
+	// softSlice returns the per-symbol differentials for the same span, or nil
+	// when soft data is not available/aligned (hard-only decode downstream).
+	softSlice := func(off, n int) []complex64 {
+		if len(d.softBuf) != len(d.buf) {
+			return nil
+		}
+		s := L + off - d.bufBase
+		if s < 0 || s+n > len(d.softBuf) {
+			return nil
+		}
+		return d.softBuf[s : s+n]
+	}
 	bkn1 := slice(ndbBKN1Start, ndbBlockDibits)
 	aach1 := slice(ndbAACH1Start, ndbAACH1Len)
 	aach2 := slice(ndbAACH2Start, ndbAACH2Len)
@@ -129,7 +153,7 @@ func (d *downlinkNCDB) emit(L int) {
 	if bkn1 == nil || aach1 == nil || aach2 == nil || bkn2 == nil {
 		return
 	}
-	d.onSlot(bkn1, aach1, aach2, bkn2)
+	d.onSlot(bkn1, aach1, aach2, bkn2, softSlice(ndbBKN1Start, ndbBlockDibits), softSlice(ndbBKN2Start, ndbBlockDibits))
 }
 
 // decodeDownlinkSlot classifies and decodes one NCDB. It reads the AACH to find
@@ -138,7 +162,7 @@ func (d *downlinkNCDB) emit(L int) {
 // and hands each CRC-clean block to the MAC demux. CRC gates every decode, so
 // trying all three channel shapes never double-counts: a full-slot SCH/F slot
 // fails the half-slot SCH/HD CRC and vice versa.
-func (c *ControlChannel) decodeDownlinkSlot(bkn1, aach1, aach2, bkn2 []uint8) {
+func (c *ControlChannel) decodeDownlinkSlot(bkn1, aach1, aach2, bkn2 []uint8, bkn1Diffs, bkn2Diffs []complex64) {
 	c.mu.Lock()
 	colour := c.colourCode
 	c.mu.Unlock()
@@ -162,17 +186,41 @@ func (c *ControlChannel) decodeDownlinkSlot(bkn1, aach1, aach2, bkn2 []uint8) {
 		}
 	}
 
+	// Soft data (the per-symbol differentials) lets the longer SCH/F and SCH/HD
+	// blocks decode ~1.5–2 dB deeper on a marginal constellation — the same soft
+	// path the BSCH/BNCH already use. Try soft first, fall back to the hard slice.
+	// softType5FromDiffs(diffs, (4-r)&3) hard-slices to derot(dibits, r), so soft
+	// and hard use the identical rotation. CRC gates both, so no double-count.
+	haveF := bkn1Diffs != nil && bkn2Diffs != nil && len(bkn1Diffs) == len(bkn1) && len(bkn2Diffs) == len(bkn2)
+
 	for _, r := range rots {
 		full := append(append([]uint8{}, bkn1...), bkn2...)
-		if rec, ok := DecodeSCHF(derot(full, r), colour); ok {
+		if haveF {
+			fullDiffs := append(append([]complex64{}, bkn1Diffs...), bkn2Diffs...)
+			if rec, ok := DecodeSCHFSoft(softType5FromDiffs(fullDiffs, (4-r)&3), colour); ok {
+				c.ingestMAC(rec)
+			} else if rec, ok := DecodeSCHF(derot(full, r), colour); ok {
+				c.ingestMAC(rec)
+			}
+		} else if rec, ok := DecodeSCHF(derot(full, r), colour); ok {
 			c.ingestMAC(rec)
 		}
-		if rec, ok := DecodeSCHHD(derot(bkn1, r), colour); ok {
+		c.decodeDownlinkHalf(bkn1, bkn1Diffs, r, derot, colour)
+		c.decodeDownlinkHalf(bkn2, bkn2Diffs, r, derot, colour)
+	}
+}
+
+// decodeDownlinkHalf decodes one SCH/HD half-slot under rotation r, soft-first
+// (when the per-symbol differentials are available and aligned) then hard.
+func (c *ControlChannel) decodeDownlinkHalf(bkn []uint8, diffs []complex64, r uint8, derot func([]uint8, uint8) []byte, colour uint32) {
+	if diffs != nil && len(diffs) == len(bkn) {
+		if rec, ok := DecodeSCHHDSoft(softType5FromDiffs(diffs, (4-r)&3), colour); ok {
 			c.ingestMAC(rec)
+			return
 		}
-		if rec, ok := DecodeSCHHD(derot(bkn2, r), colour); ok {
-			c.ingestMAC(rec)
-		}
+	}
+	if rec, ok := DecodeSCHHD(derot(bkn, r), colour); ok {
+		c.ingestMAC(rec)
 	}
 }
 

--- a/internal/radio/tetra/ghost_grant_test.go
+++ b/internal/radio/tetra/ghost_grant_test.go
@@ -1,0 +1,126 @@
+package tetra
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// macResourceGrant builds a MAC-RESOURCE type-1 block addressed by SSI, carrying
+// a channel-allocation element (carrier/timeslot) and the given TM-SDU (an LLC
+// PDU) — the exact layout ParseMACResource reads (EN 300 392-2 §21.4.3.1 /
+// §21.5.2). ULDL=1 and monitoring-pattern=1 keep parseChanAlloc out of its
+// augmented / frame-18 branches so the TM-SDU begins right after the element.
+func macResourceGrant(ssi uint32, carrier uint16, timeslot uint8, tmsdu []byte) []byte {
+	w := &cmceBitWriter{}
+	w.u(uint64(MACPDUResource), 2) // MAC PDU type
+	w.u(0, 1)                      // fill bit
+	w.u(0, 1)                      // grant position
+	w.u(0, 2)                      // encryption mode (0 = clear)
+	w.u(0, 1)                      // random access
+	w.u(1, 6)                      // length indication (not 0x3f/0x3e)
+	w.u(uint64(addrSSI), 3)        // address type = SSI
+	w.u(uint64(ssi), 24)           // SSI
+	w.u(0, 1)                      // power control absent
+	w.u(0, 1)                      // slot granting absent
+	w.u(1, 1)                      // channel allocation present
+	w.u(0, 2)                      // allocation type
+	w.u(uint64(timeslot), 4)       // assigned timeslot
+	w.u(1, 2)                      // up/downlink (nonzero → skip augmented branch)
+	w.u(0, 1)                      // CLCH permission
+	w.u(0, 1)                      // cell change
+	w.u(uint64(carrier), 12)       // main carrier number
+	w.u(0, 1)                      // extended carrier absent
+	w.u(1, 2)                      // monitoring pattern (nonzero → no frame-18 field)
+	return append(w.bits, tmsdu...)
+}
+
+// cmceReleaseTMSDU / cmceSetupTMSDU wrap a CMCE PDU in a BL-UDATA LLC PDU — the
+// TM-SDU shape a real MAC-RESOURCE delivers.
+func cmceReleaseTMSDU(callID uint16, cause uint8) []byte {
+	c := &cmceBitWriter{}
+	c.header(CMCETypeDRelease)
+	c.u(uint64(callID), 14)
+	c.u(uint64(cause), 5)
+	return append(bl(llcBLUDATA, 0), c.bits...)
+}
+
+func cmceSetupTMSDU(callID uint16) []byte {
+	c := &cmceBitWriter{}
+	c.header(CMCETypeDSetup)
+	c.u(uint64(callID), 14)
+	c.u(0, 4+1+1+8+2+1) // mandatory fields through transmission-request permission
+	c.u(1, 4)           // call priority (non-emergency)
+	c.u(0, 1)           // O-bit clear (no optional elements)
+	return append(bl(llcBLUDATA, 0), c.bits...)
+}
+
+func drainKinds(sub *events.Subscription) map[events.Kind]int {
+	counts := map[events.Kind]int{}
+	for {
+		select {
+		case ev := <-sub.C:
+			counts[ev.Kind]++
+		default:
+			return counts
+		}
+	}
+}
+
+// TestIngestMACSuppressesGrantOnRelease is the ghost-call regression. A single
+// MAC-RESOURCE that carries both a channel-allocation element and a CMCE
+// D-RELEASE must NOT publish a voice grant (which spawns a zero-byte ghost call)
+// — only the release. Before the teardown gate, ingestMAC published a grant for
+// every ChanAlloc regardless of the CMCE type.
+func TestIngestMACSuppressesGrantOnRelease(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "Sys", FrequencyHz: 467_913_000})
+	block := macResourceGrant(0x0F5670, 2716, 1, cmceReleaseTMSDU(0x1234, 13))
+	cc.ingestMAC(block)
+
+	counts := drainKinds(sub)
+	if counts[events.KindGrant] != 0 {
+		t.Errorf("published %d grant(s) for a D-RELEASE-bearing MAC-RESOURCE, want 0 (ghost call)", counts[events.KindGrant])
+	}
+	if counts[events.KindCallRelease] == 0 {
+		t.Error("did not publish the D-RELEASE")
+	}
+}
+
+// TestIngestMACPublishesGrantOnSetup guards that the teardown gate is
+// teardown-only: a MAC-RESOURCE carrying a channel allocation and a CMCE D-SETUP
+// still publishes a voice grant.
+func TestIngestMACPublishesGrantOnSetup(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "Sys", FrequencyHz: 467_913_000})
+	block := macResourceGrant(0x0F5670, 2716, 1, cmceSetupTMSDU(0x1234))
+	cc.ingestMAC(block)
+
+	var grant *trunking.Grant
+	for drained := false; !drained; {
+		select {
+		case ev := <-sub.C:
+			if g, ok := ev.Payload.(trunking.Grant); ok && ev.Kind == events.KindGrant {
+				gg := g
+				grant = &gg
+			}
+		default:
+			drained = true
+		}
+	}
+	if grant == nil {
+		t.Fatal("no grant published for a D-SETUP-bearing MAC-RESOURCE")
+	}
+	if grant.GroupID != 0x0F5670 {
+		t.Errorf("grant GroupID = %#x, want 0x0F5670", grant.GroupID)
+	}
+}

--- a/internal/radio/tetra/process.go
+++ b/internal/radio/tetra/process.go
@@ -140,7 +140,7 @@ func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
 		if p.ncdb == nil {
 			p.ncdb = newDownlinkNCDB(c.decodeDownlinkSlot)
 		}
-		p.ncdb.process(dibits, baseIdx)
+		p.ncdb.process(dibits, diffs, baseIdx)
 	}
 
 	p.matchScratch, _ = p.det.Process(p.matchScratch[:0], dibits, baseIdx)

--- a/internal/radio/tetra/soft_test.go
+++ b/internal/radio/tetra/soft_test.go
@@ -127,6 +127,68 @@ func TestSoftSCHHDOutperformsHardUnderNoise(t *testing.T) {
 	}
 }
 
+// TestSoftSCHFRoundTripClean: soft SCH/F recovers the exact 268 info bits on a
+// clean channel (the grant-carrying full-slot channel; no soft variant existed
+// before the fat-tetra work).
+func TestSoftSCHFRoundTripClean(t *testing.T) {
+	info := make([]byte, 268)
+	for i := range info {
+		info[i] = byte((i*7 + 3) & 1)
+	}
+	const colour = 0x12345
+	type5 := EncodeSCHF(info, colour)
+	llr, hard := bitsToLLR(type5, 0, rand.New(rand.NewSource(3)))
+	got, ok := DecodeSCHFSoft(llr, colour)
+	if !ok {
+		t.Fatal("soft SCH/F failed CRC on a clean channel")
+	}
+	for i := range info {
+		if got[i] != info[i] {
+			t.Fatalf("soft SCH/F recovered bit %d = %d, want %d", i, got[i], info[i])
+		}
+	}
+	if _, ok := DecodeSCHF(hard, colour); !ok {
+		t.Fatal("hard SCH/F failed CRC on a clean channel (sanity)")
+	}
+}
+
+// TestSoftSCHFOutperformsHardUnderNoise: at a noise level where the hard SCH/F
+// decoder mostly fails, the soft decoder mostly succeeds — the ~2 dB soft gain
+// now available on the grant path (previously hard-only), which is what lets
+// marginal-constellation grants clear the CRC.
+func TestSoftSCHFOutperformsHardUnderNoise(t *testing.T) {
+	info := make([]byte, 268)
+	for i := range info {
+		info[i] = byte((i*5 + 1) & 1)
+	}
+	const colour = 0x12345
+	type5 := EncodeSCHF(info, colour)
+	rng := rand.New(rand.NewSource(7))
+	const (
+		sigma  = 0.7
+		trials = 200
+	)
+	hardPass, softPass := 0, 0
+	for tr := 0; tr < trials; tr++ {
+		llr, hard := bitsToLLR(type5, sigma, rng)
+		if _, ok := DecodeSCHF(hard, colour); ok {
+			hardPass++
+		}
+		if got, ok := DecodeSCHFSoft(llr, colour); ok {
+			softPass++
+			for i := range info {
+				if got[i] != info[i] {
+					t.Fatalf("soft CRC passed but bit %d wrong", i)
+				}
+			}
+		}
+	}
+	t.Logf("sigma=%.2f: hard %d/%d, soft %d/%d", sigma, hardPass, trials, softPass, trials)
+	if softPass < 2*hardPass || softPass <= hardPass {
+		t.Errorf("soft SCH/F gain insufficient: hard %d, soft %d of %d", hardPass, softPass, trials)
+	}
+}
+
 // TestSoftBSCHOutperformsHardUnderNoise: same gain on the colour-0 BSCH
 // (the cold-start lock chain).
 func TestSoftBSCHOutperformsHardUnderNoise(t *testing.T) {

--- a/internal/trunking/engine.go
+++ b/internal/trunking/engine.go
@@ -447,6 +447,34 @@ func (e *Engine) HandleGrant(g Grant) {
 		}
 	}
 
+	// TETRA: a physical channel + timeslot hosts exactly one call, but the SwMI
+	// grants that one call under several SSIs — the group GSSI in a D-SETUP, the
+	// calling party's individual ISSI in a D-CONNECT addressed to the caller. Those
+	// grants carry different GroupIDs, so the (System, GroupID, Timeslot) dedup and
+	// the source-backfill above both miss them and a free device would spawn a
+	// duplicate call that then collides with the first on their shared usage marker
+	// and starves its recording. Fold any TETRA grant on an active call's exact
+	// (System, frequency, timeslot) onto that call. Gated on TETRA so P25 — whose
+	// compressed/patch grants legitimately reuse a channel under different
+	// talkgroups (#915) — is unchanged.
+	if g.Protocol == "tetra" && g.FrequencyHz != 0 {
+		for _, ac := range e.pool.Active() {
+			if ac.Grant.System != g.System || ac.Grant.FrequencyHz != g.FrequencyHz ||
+				ac.Grant.Timeslot != g.Timeslot {
+				continue
+			}
+			e.pool.Touch(ac.Device.Serial, e.now())
+			if g.SourceID != 0 {
+				if upd, filled := e.pool.BackfillSourceFromGrant(ac.Device.Serial, g.SourceID); filled {
+					e.republishCallSource(ac.Device.Serial, upd)
+				}
+			}
+			e.log.Debug("tetra grant on an active channel; treated as a repeat",
+				"grant", g.String(), "device", ac.Device.Serial)
+			return
+		}
+	}
+
 	// 1) Free device available? Allocate. FindFreeForFrequency skips
 	// virtual voice tuners whose wideband window doesn't cover the
 	// grant — so a P25 voice grant outside the wideband band falls

--- a/internal/trunking/engine_tetra_test.go
+++ b/internal/trunking/engine_tetra_test.go
@@ -1,0 +1,66 @@
+package trunking
+
+import "testing"
+
+// TestEngineTETRAFoldsGrantsByChannel: a TETRA physical channel + timeslot hosts
+// one call, but the SwMI grants it under several SSIs — the calling party's
+// individual ISSI (a D-CONNECT) and the group GSSI (a D-SETUP). Those grants
+// carry different GroupIDs; without the channel fold, a later group grant whose
+// source is already known spawns a duplicate call that collides with the first on
+// the shared usage marker. Assert the three grants collapse to one active call.
+func TestEngineTETRAFoldsGrantsByChannel(t *testing.T) {
+	e, pool, bus, _ := mkEngine(t, 2)
+	defer bus.Close()
+
+	const (
+		freq = uint32(467_912_500)
+		ts   = uint8(2)
+		gssi = uint32(1020545) // talkgroup
+		issi = uint32(1005372) // radio ID
+	)
+	// D-CONNECT to the individual binds the call; group D-SETUP grants for the same
+	// channel + timeslot follow under the GSSI. All one physical call.
+	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: issi, FrequencyHz: freq, Timeslot: ts, Individual: true})
+	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: gssi, SourceID: issi, FrequencyHz: freq, Timeslot: ts})
+	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: gssi, SourceID: issi, FrequencyHz: freq, Timeslot: ts})
+
+	if n := len(pool.Active()); n != 1 {
+		t.Fatalf("active calls = %d, want 1 (TETRA grants on one channel+slot must not duplicate)", n)
+	}
+	if src := pool.Active()[0].Grant.SourceID; src != issi {
+		t.Errorf("call source = %d, want %d (backfilled onto the folded call)", src, issi)
+	}
+}
+
+// TestEngineTETRAConcurrentSlotsStayDistinct guards that the channel fold keys on
+// timeslot: two TETRA calls on the same carrier but different timeslots are
+// distinct calls and must not be folded.
+func TestEngineTETRAConcurrentSlotsStayDistinct(t *testing.T) {
+	e, pool, bus, _ := mkEngine(t, 2)
+	defer bus.Close()
+
+	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: 100, FrequencyHz: 467_912_500, Timeslot: 1})
+	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: 200, FrequencyHz: 467_912_500, Timeslot: 2})
+
+	if n := len(pool.Active()); n != 2 {
+		t.Fatalf("active calls = %d, want 2 (distinct timeslots are distinct calls)", n)
+	}
+}
+
+// TestEngineP25ChannelFoldGated proves the channel fold is TETRA-only: two P25
+// grants with different talkgroups on the same frequency are not folded by it
+// (P25 compressed/patch grants legitimately reuse a channel under different
+// talkgroups, #915), so they remain two calls — the pre-existing behaviour.
+func TestEngineP25ChannelFoldGated(t *testing.T) {
+	e, pool, bus, _ := mkEngine(t, 2)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	e.HandleGrant(Grant{System: "X", Protocol: "p25", GroupID: 100, FrequencyHz: 851_000_000})
+	e.HandleGrant(Grant{System: "X", Protocol: "p25", GroupID: 200, FrequencyHz: 851_000_000})
+
+	if n := len(pool.Active()); n != 2 {
+		t.Fatalf("active P25 calls = %d, want 2 (the TETRA channel fold must not affect P25)", n)
+	}
+}


### PR DESCRIPTION
## Summary

Field-reported TETRA decoding defects on a live single-carrier site (MCC 250 / MNC 013): decoded subscriber/talkgroup identities were corrupted, the broadcast frequency-offset field was ignored, active-call tracking thrashed (zero-byte ghost recordings, radio IDs shown as talkgroups, starved audio), and marginal control-channel signals dropped grants. This PR fixes the decode and call-state bugs and adds soft-decision on the grant path. Every fix is validated against the reporter's own IQ captures.

## Changes

- **ISSI/GSSI decode via the LLC sublayer.** The MAC TM-SDU on real air is an LLC PDU (EN 300 392-2 §21.2), not the MLE PDU — GT parsed CMCE straight off it, misframing every L3 address (the calling-party ISSI came out as 0). Add `ParseLLC` (strip the basic-link header + any FCS) before CMCE, recovering the calling-party ISSI and the D-TX-GRANTED talker.
- **SYSINFO frequency offset.** Parse the Frequency band / Offset / Duplex spacing / Reverse fields that `SysInfoMainCarrier` was dropping, and compute the true offset-corrected downlink (and uplink) carrier — a cell broadcasting 469.875 MHz actually sits at 469.88125 (offset `01` = +6.25 kHz).
- **Ghost recordings.** Suppress a voice grant when its MAC-RESOURCE carries a CMCE D-RELEASE (the channel-allocation is the resource being *reclaimed*, not a new call), which was spawning a call the release immediately ended.
- **Individual vs group.** Classify a grant addressed to a subscriber ISSI as `Individual` (any SSI ever seen as a CMCE calling/transmitting party is a radio, not a talkgroup), so a radio ID is no longer surfaced as a phantom talkgroup. Surfaced via the additive `GrantDTO.individual` field.
- **Marker collision / starved audio.** Fold TETRA grants that land on one physical `(system, frequency, timeslot)` into a single call (gated on `Protocol == "tetra"` so P25 compressed/patch grants are unchanged), eliminating the duplicate calls that collided on the shared usage marker and starved each other's recording.
- **Soft-decision SCH grant path.** Add `DecodeSCHFSoft` and route the receiver's per-symbol differentials through the NCDB path (soft-first, hard fallback) — ~2 dB gain on marginal signals (soft 65/200 vs hard 3/200 in test).
- **chore:** bump `google.golang.org/grpc` to v1.82.1 (GO-2026-6061) to clear the vulncheck CI gate.

Also included: the 469.875 "fat" site was investigated and found to be a **signal-quality wall** (on-air constellation distortion). A per-symbol carrier-tracking loop was implemented and tested but did not recover it and was reverted as unproven; CMA would not help a phase-domain skew. Documented, no risky DSP shipped.

## Test plan

- [x] `make vet test` green locally
- [x] `make integration` green locally
- [x] Added/updated tests: LLC framing + CMCE realignment, SYSINFO frequency math, ghost-grant suppression, individual/group classification, `GrantDTO` round-trip, TETRA channel-fold dedup, soft SCH/F vs hard under noise
- [x] Validated against the reporter's real IQ captures: the calling-party ISSI now decodes (was `source_id=0` on every call), grant frequency is offset-corrected, and replay shows **0 usage-marker collisions / 0 ghost recordings** (previously 3–28% starved recordings)

## Breaking changes

None. The `individual` JSON field is additive (`omitempty`); the call-fold behaviour change is TETRA-only; the grpc change is a patch bump.

## Docs / CHANGELOG

n/a — no `CHANGELOG.md` entry added; happy to add an `## [Unreleased]` bullet if the project wants one for the operator-visible identity/frequency changes.

## Linked issues

n/a — Discord field reports (no tracked GitHub issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFGjw2moTZbAyhp78sWgqw

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFGjw2moTZbAyhp78sWgqw)_