### PR TITLE
follow-up: surface DDC auto-record drop count; drop stale demod deferral

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,12 @@ for tagged releases.
   rather than a fixed slot 1 — the building block for issue #925.
 
 ### Fixed
+- **`auto_record` with `tap: ddc` reported `drops=0` even when the DDC grab had
+  gaps.** A triggered narrowband capture that fell behind the voice fan-out
+  dropped IQ chunks (time gaps that break downstream decode), but the "captured"
+  log line always showed `drops=0` — the drop count was only surfaced in a
+  separate fan-out warning. The capture now reports the real subscriber drop
+  count, matching the wideband tap, so a gappy grab is visible in its own result.
 - **TETRA colour code locked on the first sync burst, so a single mis-decoded
   BSCH could poison a whole session.** The extended colour code (the scrambler
   seed for every BNCH/SCH/TCH block) was learned from the first BSCH and never

--- a/cmd/gophertrunk/iqautorecord.go
+++ b/cmd/gophertrunk/iqautorecord.go
@@ -23,7 +23,7 @@ import (
 // voice taps read) plus its pipeline rate and centre. *ccdecoder.Decoder
 // satisfies it; tests supply a fake. Used only when auto_record's tap is "ddc".
 type ddcVoiceTap interface {
-	SubscribeVoiceIQ() (<-chan []complex64, func())
+	SubscribeVoiceIQ() (<-chan []complex64, func() uint64)
 	PipelineRateHz() float64
 	CenterFreqHz() uint32
 }
@@ -176,7 +176,6 @@ func captureDDCToFile(ctx context.Context, tap ddcVoiceTap, path string, format 
 		return 0, 0, fmt.Errorf("iq-autorecord: create %s: %w", path, err)
 	}
 	ch, unsub := tap.SubscribeVoiceIQ()
-	defer unsub()
 	enc := siglab.NewCaptureWriter(f, format)
 
 	// The DDC fan-out only broadcasts while the control pipeline is locked/active;
@@ -208,13 +207,17 @@ func captureDDCToFile(ctx context.Context, tap ddcVoiceTap, path string, format 
 		}
 	}()
 
+	// Unsubscribe and read the fan-out's drop count for this capture: dropped IQ
+	// chunks are time gaps in the grab that break downstream decode, exactly like
+	// the wideband path's subscriber drops. runCapture surfaces the count (and the
+	// fan-out logs its own warning at unsubscribe).
+	drops = unsub()
+
 	closeErr := f.Close()
 	if streamErr == nil && closeErr != nil && !errors.Is(closeErr, os.ErrClosed) {
 		streamErr = closeErr
 	}
-	// Subscriber drops are logged by the fan-out itself at unsubscribe; the DDC
-	// tap exposes no per-capture drop count, so report 0.
-	return samples, 0, streamErr
+	return samples, drops, streamErr
 }
 
 // Run drains the event subscription until ctx is cancelled. sub is an

--- a/cmd/gophertrunk/iqautorecord_test.go
+++ b/cmd/gophertrunk/iqautorecord_test.go
@@ -23,14 +23,15 @@ type fakeDDCTap struct {
 	rate   float64
 	center uint32
 	chunks [][]complex64
+	drops  uint64 // reported by the unsubscribe func, mirroring the fan-out
 }
 
-func (f *fakeDDCTap) SubscribeVoiceIQ() (<-chan []complex64, func()) {
+func (f *fakeDDCTap) SubscribeVoiceIQ() (<-chan []complex64, func() uint64) {
 	ch := make(chan []complex64, len(f.chunks)+1)
 	for _, c := range f.chunks {
 		ch <- c
 	}
-	return ch, func() {}
+	return ch, func() uint64 { return f.drops }
 }
 
 func (f *fakeDDCTap) PipelineRateHz() float64 { return f.rate }
@@ -57,6 +58,22 @@ func TestCaptureDDCToFile(t *testing.T) {
 	}
 	if fi.Size() != 384*4 {
 		t.Errorf("file size = %d, want %d (384 samples × 4 bytes cs16)", fi.Size(), 384*4)
+	}
+}
+
+// TestCaptureDDCToFileReportsDrops confirms the capture surfaces the fan-out's
+// subscriber drop count (a gappy grab) instead of always reporting 0.
+func TestCaptureDDCToFileReportsDrops(t *testing.T) {
+	tap := &fakeDDCTap{rate: 144000, center: 467913000, drops: 7, chunks: [][]complex64{
+		make([]complex64, 64),
+	}}
+	path := filepath.Join(t.TempDir(), "ddc.cs16")
+	_, drops, err := captureDDCToFile(context.Background(), tap, path, siglab.FormatS16, 1)
+	if err != nil {
+		t.Fatalf("captureDDCToFile: %v", err)
+	}
+	if drops != 7 {
+		t.Errorf("drops = %d, want 7 (the fan-out drop count must be surfaced, not hard-coded 0)", drops)
 	}
 }
 

--- a/internal/radio/tetra/tetra.go
+++ b/internal/radio/tetra/tetra.go
@@ -32,9 +32,6 @@
 //
 // What's NOT yet wired (honest deferrals):
 //
-//   - The π/4-DQPSK demodulator + symbol-clock recovery for TETRA's
-//     18 ksym/sec air interface. internal/dsp/demod/dqpsk.go is the
-//     closest fit; matched-filter parameters differ from P25 Phase 2.
 //   - End-to-end air-interface encryption (TEA1/2/3/4) — TETRA voice
 //     traffic on most operational networks is encrypted; the
 //     `Encrypted` flag on a grant just records what the CC said. Encrypted

--- a/internal/scanner/ccdecoder/voicetap.go
+++ b/internal/scanner/ccdecoder/voicetap.go
@@ -45,7 +45,12 @@ func newVoiceFanout(log *slog.Logger) *voiceFanout {
 	return &voiceFanout{subs: map[int]*voiceSub{}, log: log}
 }
 
-func (f *voiceFanout) subscribe() (<-chan []complex64, func()) {
+// subscribe registers a voice subscriber and returns its IQ channel plus an
+// unsubscribe func. The unsubscribe func returns the number of chunks that were
+// dropped to this subscriber over its lifetime (0 when it kept up), so a consumer
+// that wants the count — e.g. a triggered DDC capture reporting whether the grab
+// has gaps — can read it; callers that don't care simply ignore the return.
+func (f *voiceFanout) subscribe() (<-chan []complex64, func() uint64) {
 	sub := &voiceSub{ch: make(chan []complex64, 64)}
 	f.mu.Lock()
 	id := f.next
@@ -53,7 +58,7 @@ func (f *voiceFanout) subscribe() (<-chan []complex64, func()) {
 	f.subs[id] = sub
 	f.mu.Unlock()
 	var once sync.Once
-	return sub.ch, func() {
+	return sub.ch, func() uint64 {
 		once.Do(func() {
 			f.mu.Lock()
 			if s, ok := f.subs[id]; ok {
@@ -70,6 +75,9 @@ func (f *voiceFanout) subscribe() (<-chan []complex64, func()) {
 					"dropped_chunks", d)
 			}
 		})
+		// The counter is final once the delete above ran; safe to read on any
+		// call (a second unsubscribe is a no-op that still reports the total).
+		return sub.drops.Load()
 	}
 }
 
@@ -97,8 +105,10 @@ func (f *voiceFanout) broadcast(chunk []complex64) {
 
 // SubscribeVoiceIQ returns a channel of channelised (post-DDC) IQ at the
 // pipeline rate plus an unsubscribe func. The same-carrier voice tap consumes
-// it for the life of a followed call.
-func (d *Decoder) SubscribeVoiceIQ() (<-chan []complex64, func()) {
+// it for the life of a followed call. The unsubscribe func returns the number of
+// IQ chunks dropped to this subscriber (0 when it kept up); callers that don't
+// need the count ignore it.
+func (d *Decoder) SubscribeVoiceIQ() (<-chan []complex64, func() uint64) {
 	return d.voiceFan.subscribe()
 }
 


### PR DESCRIPTION
## Summary

Two small loose ends left over from the same-carrier TETRA voice / `tap: ddc` work that's already in `main`. A triggered `tap: ddc` capture that fell behind the voice fan-out reported `drops=0` in its result even when it dropped IQ chunks (time gaps that break downstream decode), so a gappy grab looked clean; and the `tetra` package's honest-deferrals list still claimed the π/4-DQPSK demodulator was unwired, which the voice path fixed long ago.

## Changes

- **Surface the DDC capture drop count.** `voiceFanout.subscribe` / `Decoder.SubscribeVoiceIQ` now return an unsubscribe func that reports the subscriber's dropped-chunk total (`func() uint64`); `captureDDCToFile` reports it instead of a hard-coded `0`, so `iq-autorecord: captured … drops=N` is accurate for the DDC tap, matching the wideband path. Callers that don't need the count ignore the return.
- **Drop the stale deferral.** Remove "π/4-DQPSK demodulator + symbol-clock recovery … NOT yet wired" from `internal/radio/tetra/tetra.go` — the shared TETRA receiver demodulates control and traffic (the package's own "Now wired" paragraph already says so). TEA1–4 encryption remains the one real deferral.

## Test plan

- [x] `make vet test` is green locally (`-race ./...`, exit 0)
- [ ] `make integration` — n/a (no daemon/DSP behaviour change; capture path covered by unit tests)
- [x] Added `TestCaptureDDCToFileReportsDrops` (fails on the old hard-coded `0`); existing `voiceFanout` / DDC-capture tests still pass
- [ ] Smoke-tested against real hardware — n/a (drop count is exercised deterministically via a fake tap)

## Breaking changes

None. `SubscribeVoiceIQ`'s unsubscribe return type widens from `func()` to `func() uint64`; every existing caller that just invokes `unsub()` compiles unchanged.

## Docs / CHANGELOG

- [x] Added an `## [Unreleased]` bullet to `CHANGELOG.md`
- [ ] README/docs — n/a (the stale note lived in a package doc comment, updated in this PR)

## Linked issues

n/a

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tw8qnPNaittdGKiqo2iZxC)_