### PR TITLE
fix(tetra): supersede notification-bound calls + reject foreign-band ghost grants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,29 @@ for tagged releases.
   rather than a fixed slot 1 — the building block for issue #925.
 
 ### Fixed
+- **TETRA group calls could land on the wrong talkgroup with starved audio when
+  the first grant was a notification.** On a same-carrier site a group call's
+  first control-channel grant is often a notification / a D-CONNECT addressed to
+  the calling party, which arrives before that party is known as a radio ID — so
+  it is labelled with the individual's SSI (a phantom talkgroup), carries no
+  source, and follows the notification's own downlink usage marker rather than
+  the traffic channel's. The recording bound to that provisional identity, and
+  when the authoritative group grant for the same physical channel arrived, the
+  physical-channel source backfill folded it on as a mere source update — so the
+  recording stayed on the wrong talkgroup and kept following the wrong usage
+  marker, starving the voice demux (a few percent of the call decoded). The
+  engine now supersedes a still-unfinalised, notification-bound TETRA call when
+  the authoritative group grant (real GSSI, calling-party source, traffic usage
+  marker) lands on its channel, so the recording follows the correct talkgroup
+  and marker from the outset. TETRA-gated; P25 same-channel grants are unchanged.
+- **TETRA: a corrupt control-channel block whose CRC happened to pass could
+  surface a ghost grant on a foreign frequency band.** A false-positive SCH CRC
+  (or a slipped bit cursor) produced a bogus voice grant whose carrier resolved
+  tens of MHz from the site — e.g. `carrier 6 → 400 MHz` on a 467 MHz cell —
+  spawning a phantom call on a band the site does not operate. Grants whose
+  resolved carrier sits more than 10 MHz from the control channel are now
+  dropped as bit-alignment / CRC artefacts (a site's downlink carriers span at
+  most a few MHz).
 - **`auto_record` with `tap: ddc` reported `drops=0` even when the DDC grab had
   gaps.** A triggered narrowband capture that fell behind the voice fan-out
   dropped IQ chunks (time gaps that break downstream decode), but the "captured"

--- a/internal/radio/tetra/control.go
+++ b/internal/radio/tetra/control.go
@@ -548,6 +548,17 @@ func (c *ControlChannel) Ingest(p PDU) {
 // grant carrier's frequency relative to the cell's own carrier.
 const tetraChannelSpacingHz = 25_000
 
+// maxGrantCarrierOffsetHz bounds how far a grant's resolved traffic frequency may
+// sit from the control channel before it is treated as a bit-alignment / false-CRC
+// parsing artefact rather than a real allocation. Every traffic carrier a control
+// channel grants lives in the same operator allocation as the CC itself — TETRA
+// site downlink carriers span at most a few MHz — so a resolved frequency tens of
+// MHz away (e.g. carrier 6 → 400 MHz on a 467 MHz cell) can only be a corrupt
+// block whose 16-bit SCH CRC happened to pass, or a slipped bit cursor. 10 MHz is
+// comfortably wider than any real single-site carrier spread yet rejects such
+// foreign-band garbage outright.
+const maxGrantCarrierOffsetHz = 10_000_000
+
 // carrierFrequency derives the Hz of a TETRA carrier number for this cell.
 //
 // When the full SYSINFO frequency parameters are known (frequency band +
@@ -657,6 +668,26 @@ func (c *ControlChannel) publishGrant(g VoiceGrant) {
 		// cell's own carrier (learned from SYSINFO) at 25 kHz TETRA spacing.
 		// Exact for a same-carrier SCBS (carrier == mainCarrier ⇒ the CC freq).
 		freq = hz
+	}
+	// Structural sanity guard against a bit-alignment slip or a false-positive SCH
+	// CRC: a grant whose carrier resolves to a band foreign to this cell cannot be
+	// real (see maxGrantCarrierOffsetHz). Drop it rather than log a ghost call and
+	// spawn a phantom recording on a frequency the site does not operate. Only
+	// enforced once both the CC frequency and a resolved grant frequency are known;
+	// an offline replay with neither (freq == 0) simply skips the guard.
+	if freq != 0 && c.freqHz != 0 {
+		off := int64(freq) - int64(c.freqHz)
+		if off < 0 {
+			off = -off
+		}
+		if off > maxGrantCarrierOffsetHz {
+			c.log.Warn("tetra: dropping grant — carrier resolves to a foreign band (bit-alignment/CRC artefact)",
+				"system", c.systemName,
+				"src", g.SourceSSI, "dst", g.DestSSI,
+				"carrier", g.CarrierNumber, "resolved_hz", freq,
+				"cc_hz", c.freqHz, "offset_hz", off)
+			return
+		}
 	}
 	c.bus.Publish(events.Event{
 		Kind: events.KindGrant,

--- a/internal/radio/tetra/downlink_test.go
+++ b/internal/radio/tetra/downlink_test.go
@@ -86,6 +86,48 @@ func TestProcessDecodesGrantFromNCDB(t *testing.T) {
 	}
 }
 
+// TestGrantForeignCarrierRejected is the regression for the parser bit-alignment
+// bug report: a corrupt block whose SCH CRC happened to pass surfaced a grant
+// dst=4603484 carrier=6 slot=2 on a 467.9125 MHz (carrier 2716) cell, resolving to
+// 400.1625 MHz — a foreign band. The structural sanity guard in publishGrant must
+// drop such a grant (its carrier resolves tens of MHz from the CC) while a
+// legitimate same-cell grant still publishes. Before the guard both grants
+// published, spawning a ghost call on a band the site does not operate.
+func TestGrantForeignCarrierRejected(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Sys", FrequencyHz: 467_912_500})
+	cc.learnMainCarrier(2716) // the cell's own carrier
+
+	// carrier 6 → 467.9125 MHz + (6-2716)×25 kHz = 400.1625 MHz — a bit-alignment /
+	// false-CRC artefact 67.75 MHz from the CC. Must be dropped.
+	cc.publishGrant(VoiceGrant{DestSSI: 4603484, CarrierNumber: 6, Timeslot: 2})
+	// A legitimate same-carrier grant must still publish.
+	cc.publishGrant(VoiceGrant{DestSSI: 1020543, CarrierNumber: 2716, Timeslot: 1})
+
+	var grants []trunking.Grant
+	for drained := false; !drained; {
+		select {
+		case ev := <-sub.C:
+			if g, ok := ev.Payload.(trunking.Grant); ok && ev.Kind == events.KindGrant {
+				grants = append(grants, g)
+			}
+		default:
+			drained = true
+		}
+	}
+	if len(grants) != 1 {
+		t.Fatalf("published %d grants, want 1 (foreign-band carrier 6 must be dropped)", len(grants))
+	}
+	if grants[0].GroupID != 1020543 || grants[0].ChannelNum != 2716 {
+		t.Errorf("published grant = tg %d carrier %d, want tg 1020543 carrier 2716",
+			grants[0].GroupID, grants[0].ChannelNum)
+	}
+}
+
 // TestCarrierFrequencyDerivation checks that a grant carrier number resolves to
 // Hz relative to the cell's own carrier (learned from SYSINFO) at 25 kHz
 // spacing, with no configured band plan.

--- a/internal/trunking/engine.go
+++ b/internal/trunking/engine.go
@@ -423,6 +423,40 @@ func (e *Engine) HandleGrant(g Grant) {
 		}
 	}
 
+	// TETRA notification supersede. A call can be bound from a *provisional* grant:
+	// a group-call notification, or a D-CONNECT addressed to the calling party that
+	// arrives before that party is known as a radio ID — so it is labelled with the
+	// individual's SSI (or a phantom talkgroup), carries no source, and, worst,
+	// carries the notification's own downlink usage marker rather than the traffic
+	// channel's. When the authoritative group grant for the same physical channel
+	// then arrives — the real GSSI, the calling party as source, and the traffic
+	// slot's usage marker — the #915 source backfill below would fold it onto the
+	// provisional call as a mere source update, leaving the recording on the wrong
+	// talkgroup AND following the notification's usage marker instead of the traffic
+	// marker, which starves the vocoder (the reporter saw 4 speech frames / 1.7%
+	// audio over a 7 s call). Instead, end the provisional call and let the
+	// authoritative grant start a fresh one below, so the composer's slot demux
+	// registers the correct usage marker from the outset. The provisional call has
+	// decoded no traffic — its marker never matched the voice slot — so no real
+	// audio is lost. Gated on TETRA and on a still-unfinalised (source-less)
+	// provisional call whose talkgroup differs, so P25's legitimate same-channel
+	// different-talkgroup grants (#915) and ordinary same-call repeats are untouched.
+	if g.Protocol == "tetra" && g.GroupID != 0 && g.SourceID != 0 && g.FrequencyHz != 0 {
+		for _, ac := range e.pool.Active() {
+			if ac.Grant.System != g.System || ac.Grant.FrequencyHz != g.FrequencyHz ||
+				ac.Grant.Timeslot != g.Timeslot {
+				continue
+			}
+			if ac.Grant.SourceID != 0 || ac.Grant.GroupID == g.GroupID {
+				continue // finalised, or the same talkgroup — an ordinary repeat (handled below)
+			}
+			e.log.Info("tetra: superseding notification-bound call with the authoritative group grant",
+				"provisional", ac.Grant.String(), "authoritative", g.String(), "device", ac.Device.Serial)
+			e.endCall(ac, EndReasonNormal)
+			break
+		}
+	}
+
 	// Physical-channel source backfill (#915). The talkgroup dedup above
 	// recovers a source RID only from a repeat grant that matches the bound
 	// call's (System, talkgroup, timeslot). The reporter's #916 field test

--- a/internal/trunking/engine_tetra_test.go
+++ b/internal/trunking/engine_tetra_test.go
@@ -32,6 +32,48 @@ func TestEngineTETRAFoldsGrantsByChannel(t *testing.T) {
 	}
 }
 
+// TestEngineTETRANotificationSuperseded is the regression for the group
+// notification vs channel grant bug (Discord report, log 01753d5b): a call bound
+// from a provisional notification grant — labelled with the calling party's own
+// SSI (the temporal race: the party is not yet known as a radio ID), no source,
+// and the notification's usage marker (8) — must yield to the authoritative group
+// grant for the same physical channel, which carries the real GSSI, the calling
+// party as source, and the traffic slot's usage marker (23). Before the supersede
+// the #915 channel backfill folded the group grant on as a source update, so the
+// call stayed on the wrong talkgroup and followed marker 8, starving the vocoder.
+func TestEngineTETRANotificationSuperseded(t *testing.T) {
+	e, pool, bus, _ := mkEngine(t, 2)
+	defer bus.Close()
+
+	const (
+		freq = uint32(467_912_500)
+		ts   = uint8(2)
+		issi = uint32(1005724) // calling party radio ID (also the notification address)
+		gssi = uint32(1020543) // the real talkgroup
+	)
+	// Grant 1: the provisional notification — addressed to the individual's SSI
+	// (surfaced as a phantom talkgroup because the ISSI is not yet known), no
+	// source, the notification's usage marker.
+	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: issi, FrequencyHz: freq, Timeslot: ts, TETRAUsageMarker: 8})
+	// Grant 2: the authoritative group grant — real GSSI, the calling party as
+	// source, and the traffic channel's downlink usage marker.
+	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: gssi, SourceID: issi, FrequencyHz: freq, Timeslot: ts, TETRAUsageMarker: 23})
+
+	act := pool.Active()
+	if len(act) != 1 {
+		t.Fatalf("active calls = %d, want 1", len(act))
+	}
+	if got := act[0].Grant.GroupID; got != gssi {
+		t.Errorf("call talkgroup = %d, want %d (the authoritative GSSI must supersede the notification)", got, gssi)
+	}
+	if got := act[0].Grant.TETRAUsageMarker; got != 23 {
+		t.Errorf("call usage marker = %d, want 23 (the traffic marker must supersede the notification marker)", got)
+	}
+	if got := act[0].Grant.SourceID; got != issi {
+		t.Errorf("call source = %d, want %d", got, issi)
+	}
+}
+
 // TestEngineTETRAConcurrentSlotsStayDistinct guards that the channel fold keys on
 // timeslot: two TETRA calls on the same carrier but different timeslots are
 // distinct calls and must not be folded.


### PR DESCRIPTION
## Summary

Two TETRA control-channel grant-handling bugs from an operator field report on a
same-carrier 467.9125 MHz (carrier 2716) site: (1) a group call recorded on the
wrong talkgroup with starved audio when its first grant was a notification rather
than the real channel grant, and (2) a corrupt block whose CRC happened to pass
surfaced a ghost grant on a foreign frequency band.

## Changes

- **Supersede a notification-bound TETRA call with the authoritative group grant**
  (`internal/trunking/engine.go`). On a same-carrier site a group call's first
  grant is often a notification / a D-CONNECT addressed to the calling party,
  which arrives before that party is known as a radio ID — so it is labelled with
  the individual's SSI (a phantom talkgroup), carries no source, and follows the
  notification's own downlink usage marker rather than the traffic channel's. The
  recording bound to that provisional identity; when the authoritative group grant
  for the same physical channel arrived ~0.16 s later, the #915 physical-channel
  source backfill folded it on as a mere source update, so the recording stayed on
  the wrong talkgroup and kept following the wrong usage marker — starving the
  voice demux (reporter saw 4 speech frames / 1.7% audio over a 7 s call vs. 218 /
  59.5% for a call whose first grant was the group grant). `HandleGrant` now, ahead
  of the #915 backfill, ends a still-unfinalised (source-less) provisional call
  when a grant with a real source and a different talkgroup lands on its exact
  (system, frequency, timeslot), and lets the authoritative grant start fresh so
  the composer registers the correct usage marker from the outset. TETRA-gated and
  scoped to source-less, different-talkgroup provisional calls, so P25's legitimate
  same-channel different-talkgroup grants (#915) and ordinary same-call repeats are
  untouched.
- **Reject grants whose carrier resolves to a foreign band**
  (`internal/radio/tetra/control.go`). A false-positive SCH CRC (16-bit) or a
  slipped bit cursor produced a bogus grant (`dst=4603484 carrier=6 slot=2 →
  400.1625 MHz`) on a 467.9125 MHz cell, spawning a phantom call on a band the site
  does not operate. `publishGrant` now drops any grant whose resolved carrier sits
  more than 10 MHz from the control channel (a site's downlink carriers span at most
  a few MHz), once both frequencies are known. Offline replay with no CC frequency
  skips the guard.
- **CHANGELOG**: two `[Unreleased]` bullets under `### Fixed`.

## Test plan

- [x] `make vet test` is green locally (`-race ./...`, exit 0; includes
      `voice/composer`, which consumes the engine's call events)
- [ ] `make integration` — n/a (engine grant-routing + grant-publish guard; both
      covered by unit tests, no daemon/DSP behaviour change)
- [x] Added regression tests that fail before the fix:
  - `TestEngineTETRANotificationSuperseded` (`internal/trunking/engine_tetra_test.go`)
    replays the reported grant sequence and asserts the active call ends up on the
    authoritative GSSI with the traffic usage marker and calling-party source.
  - `TestGrantForeignCarrierRejected` (`internal/radio/tetra/downlink_test.go`)
    feeds the reported carrier-6 garbage plus a legitimate same-carrier grant and
    asserts only the legitimate grant publishes.
- [ ] Smoke-tested against real hardware — not this round. The notification fix is
      validated at the engine level against the reported grant sequence; validating
      the recovered audio end-to-end needs the call's IQ capture (`.cs16`/`.cfile`).

## Breaking changes

None.

## Docs / CHANGELOG

- [x] Added `## [Unreleased]` bullets to `CHANGELOG.md` (both fixes are
      user-visible)
- [ ] README / `docs/` — n/a (no operator-facing config or CLI change)

## Linked issues

n/a — reported via Discord field logs (`01753d5b`, `5fd537f6`, `574946a6`), no
tracked issue.

### Note on the notification fix

The report also suggested a mid-call *retarget* that renames the in-progress `.wav`
to the true talkgroup directory without ending the call. There is no existing rail
for that (no event carries a live GroupID change; the recorder never renames an
open file; the composer's usage-marker owner is registered once at call start), so
it would be a new event + a mid-write `os.Rename` + a composer marker hot-swap —
none of it validatable without the call's IQ capture. This PR takes the
end-and-restart path instead, which fixes both the wrong-talkgroup and the starved
audio on well-tested rails; the provisional call decoded no traffic (its marker
never matched the voice slot) so no real audio is discarded, and the recorder
already drops the near-empty stub. The in-place reroute remains a sensible
follow-up once a capture is available to validate the recovered audio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tw8qnPNaittdGKiqo2iZxC)_