### PR TITLE
TETRA: D-DISCONNECT teardown, MAC-FRAG reassembly, uplink reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **TETRA control-channel PDUs that span multiple MAC blocks are reassembled
+  (MAC-FRAG / MAC-END).** A TM-SDU too large for one MAC block arrives as a
+  start-fragment MAC-RESOURCE followed by MAC-FRAG and a MAC-END (ETSI EN 300
+  392-2 §21.4.3.3/.4); those continuation PDUs were previously dropped, losing
+  the L3 CMCE PDU carried across them (a large D-SETUP's call-identifier→group
+  mapping, calling-party SSI, and emergency flag). The channel allocation is
+  complete on the start fragment, so the voice grant still publishes immediately;
+  the reassembled MAC-END now recovers the full call-control PDU and enriches the
+  call with its source and emergency state.
+- **TETRA network-configuration report now shows the control channel's uplink.**
+  The cell's uplink carrier, derived from the SYSINFO duplex spacing and the
+  frequency offset (§21.4.4.1), was computed but dropped before the report; the
+  primary control channel now renders its `UPLINK:` frequency alongside the
+  downlink.
+- **Soft-decision decode on the TETRA grant (SCH/F + SCH/HD) path.** The
+  signalling-channel decode on the grant-bearing blocks now uses the per-symbol
+  soft (log-likelihood) information when available, falling back to the
+  hard-decision Viterbi path, recovering grants on marginal control channels that
+  a hard decision drops.
 - **P25 Phase 2 blind CMA equalizer on the traffic-channel receiver
   (`p25_phase2_equalizer: on`).** A new opt-in adds a blind constant-modulus
   (CMA) adaptive equalizer on the Phase 2 symbol stream, after carrier
@@ -185,6 +204,35 @@ for tagged releases.
   log line always showed `drops=0` — the drop count was only surfaced in a
   separate fan-out warning. The capture now reports the real subscriber drop
   count, matching the wideband tap, so a gappy grab is visible in its own result.
+- **TETRA subscriber/talkgroup identities (ISSI/GSSI) were corrupted on a live
+  single-carrier site.** The MAC TM-SDU is an LLC PDU (§21.2); its basic-link
+  header was not stripped before the L3 CMCE PDU was parsed, so the 3-bit MLE
+  discriminator and every address field were misframed and the decoded radio /
+  talkgroup IDs were wrong. GopherTrunk now parses the LLC sublayer (`ParseLLC`)
+  before CMCE, recovering the correct ISSI/GSSI.
+- **TETRA grant frequencies ignored the SYSINFO frequency offset.** The broadcast
+  frequency-offset field (0 / ±6.25 / +12.5 kHz, §21.4.4.1) was dropped, so a
+  cell whose carrier actually sits at e.g. 469.88125 MHz resolved to 469.875 MHz.
+  The offset (with the frequency band, duplex spacing, and reverse-operation
+  flags) is now parsed and applied, so grant carriers resolve to their true
+  absolute downlink/uplink frequencies.
+- **Ghost TETRA recordings from teardown PDUs.** A MAC-RESOURCE whose CMCE PDU is
+  a call teardown (D-RELEASE, and now D-DISCONNECT, EN 300 392-2 Table 14.9)
+  carries a channel-allocation element for the resource being *reclaimed*, not a
+  new call; publishing a grant for it spawned a zero-byte phantom recording. Such
+  grants are now suppressed, and D-DISCONNECT is modelled so it tears the call
+  down instead of leaking a ghost.
+- **Individual (unit-to-unit) TETRA calls were surfaced as phantom talkgroups.** A
+  grant addressed to a subscriber ISSI showed the radio ID as if it were a
+  talkgroup. Calls are now classified individual-vs-group (any SSI seen as a CMCE
+  calling/transmitting party is an individual radio), and an individual-addressed
+  grant is flagged as such (`GrantDTO.individual`) instead of being listed as a
+  talkgroup.
+- **TETRA active-call tracking thrashed on a busy carrier (marker collisions,
+  starved audio).** Grants for the same call on one carrier could be keyed as
+  separate calls, colliding on the voice tap and starving audio. Same-carrier
+  TETRA grants that share a (system, frequency, timeslot) are now folded into one
+  call, backfilling the source onto the existing recording.
 - **TETRA colour code locked on the first sync burst, so a single mis-decoded
   BSCH could poison a whole session.** The extended colour code (the scrambler
   seed for every BNCH/SCH/TCH block) was learned from the first BSCH and never

--- a/internal/radio/tetra/cmce.go
+++ b/internal/radio/tetra/cmce.go
@@ -51,20 +51,12 @@ func (p PDU) TypeString() string {
 	return fmt.Sprintf("%s/Type(%X)", p.Disc, p.Type)
 }
 
-// VoiceGrant is the structured shape of a CMCE D-CONNECT PDU. The
-// fields surface what a trunking follower needs to retune a Voice
-// device to the assigned slot:
-//
-//	bytes 0-1  Call Identifier (14 bits) + flags
-//	bytes 2-4  Source SSI (24 bits)
-//	bytes 5-7  Destination SSI (24 bits)
-//	byte  8    Communication type / flags
-//	bytes 9-10 Carrier Number (12 bits) + Timeslot (2 bits) + flags
-//
-// The exact bit positions follow the most-cited public reference for
-// CMCE D-CONNECT; vendor extensions repurpose the high bits of
-// byte 8 and the trailing bytes. Cross-check before trusting live
-// captures.
+// VoiceGrant is the grant a trunking follower needs to retune a Voice device to
+// the assigned traffic slot. It is filled field-by-field from the bit-accurate
+// MAC layer (see downlink.go publishGrantFromMAC / classifyParties): the
+// physical resource (carrier + timeslot + usage marker) from the MAC-RESOURCE
+// channel-allocation element, and the party SSIs / emergency flag from the CMCE
+// TM-SDU riding in the same PDU.
 type VoiceGrant struct {
 	CallIdentifier uint16 // 14-bit
 	SourceSSI      uint32 // 24-bit
@@ -72,7 +64,6 @@ type VoiceGrant struct {
 	CarrierNumber  uint16 // 12-bit
 	Timeslot       uint8  // 2-bit (0..3)
 	UsageMarker    uint8  // downlink usage marker (AACH §21.4.7); 0 = none
-	Group          bool
 	// Individual marks a grant whose DestSSI is an individual subscriber ISSI
 	// (a unit-to-unit / individual-addressed call), not a talkgroup GSSI — so the
 	// engine and UI do not surface the radio ID as a phantom talkgroup. Set by

--- a/internal/radio/tetra/cmce_parse.go
+++ b/internal/radio/tetra/cmce_parse.go
@@ -24,21 +24,23 @@ package tetra
 type CMCEType uint8
 
 const (
-	CMCETypeDConnect   CMCEType = 0x02 // D-CONNECT
-	CMCETypeDRelease   CMCEType = 0x06 // D-RELEASE
-	CMCETypeDSetup     CMCEType = 0x07 // D-SETUP
-	CMCETypeDTxCeased  CMCEType = 0x09 // D-TX CEASED
-	CMCETypeDTxGranted CMCEType = 0x0B // D-TX GRANTED
+	CMCETypeDConnect    CMCEType = 0x02 // D-CONNECT
+	CMCETypeDDisconnect CMCEType = 0x04 // D-DISCONNECT
+	CMCETypeDRelease    CMCEType = 0x06 // D-RELEASE
+	CMCETypeDSetup      CMCEType = 0x07 // D-SETUP
+	CMCETypeDTxCeased   CMCEType = 0x09 // D-TX CEASED
+	CMCETypeDTxGranted  CMCEType = 0x0B // D-TX GRANTED
 )
 
 // isCMCETeardown reports whether a CMCE PDU type tears a call down rather than
 // establishing or maintaining it. A channel-allocation element that accompanies
 // a teardown PDU refers to the traffic resource being *reclaimed*, not a new
 // voice grant — so ingestMAC must not publish a grant for it, which would spawn a
-// zero-byte ghost call that the release then immediately ends. D-DISCONNECT is
-// not yet modelled by ParseCMCE; add it here when it is.
+// zero-byte ghost call that the release then immediately ends. Both the
+// infrastructure-initiated D-RELEASE and D-DISCONNECT (EN 300 392-2
+// §14.5.1.3.3) reclaim the resource this way.
 func isCMCETeardown(t CMCEType) bool {
-	return t == CMCETypeDRelease
+	return t == CMCETypeDRelease || t == CMCETypeDDisconnect
 }
 
 // cmceMLEPD is the 3-bit MLE protocol discriminator value that selects the CMCE
@@ -130,6 +132,15 @@ func ParseCMCE(bits []byte) (CMCEMessage, bool) {
 			optSkip(r, 8)              // basic service information
 			msg.GroupSSI = optU(r, 24) // temporary address (GSSI)
 		}
+
+	case CMCETypeDDisconnect:
+		// CallId(14) DisconnectCause(5) — mandatory (Table 14.9). Same shape as
+		// D-RELEASE; the infrastructure sends it to disconnect an established call.
+		if r.remaining() < 14+5 {
+			return CMCEMessage{}, false
+		}
+		msg.CallIdentifier = uint16(r.u(14))
+		msg.DisconnectCause = uint8(r.u(5))
 
 	case CMCETypeDRelease:
 		// CallId(14) DisconnectCause(5) — mandatory (Table 14.12).

--- a/internal/radio/tetra/cmce_parse_test.go
+++ b/internal/radio/tetra/cmce_parse_test.go
@@ -207,6 +207,31 @@ func TestParseCMCE_NoOptionalChain(t *testing.T) {
 	}
 }
 
+func TestParseCMCE_DDisconnect(t *testing.T) {
+	// D-DISCONNECT (Table 14.9) is CallId(14) + DisconnectCause(5), the same
+	// mandatory shape as D-RELEASE, and must parse and read as a teardown.
+	w := &cmceBitWriter{}
+	w.header(CMCETypeDDisconnect)
+	w.u(0x1ABC&0x3FFF, 14) // call id
+	w.u(0x0A, 5)           // disconnect cause
+	msg, ok := ParseCMCE(w.bits)
+	if !ok {
+		t.Fatal("ParseCMCE ok=false on a valid D-DISCONNECT")
+	}
+	if msg.Type != CMCETypeDDisconnect {
+		t.Errorf("Type = %#x, want D-DISCONNECT (%#x)", msg.Type, CMCETypeDDisconnect)
+	}
+	if msg.CallIdentifier != (0x1ABC & 0x3FFF) {
+		t.Errorf("CallIdentifier = %#x, want %#x", msg.CallIdentifier, 0x1ABC&0x3FFF)
+	}
+	if msg.DisconnectCause != 0x0A {
+		t.Errorf("DisconnectCause = %#x, want 0x0A", msg.DisconnectCause)
+	}
+	if !isCMCETeardown(msg.Type) {
+		t.Error("D-DISCONNECT should be classified as a teardown")
+	}
+}
+
 func TestParseCMCE_RejectsNonCMCE(t *testing.T) {
 	w := &cmceBitWriter{}
 	w.u(0x1, 3) // MLE PD = 001 (MM), not CMCE

--- a/internal/radio/tetra/control.go
+++ b/internal/radio/tetra/control.go
@@ -119,6 +119,18 @@ type ControlChannel struct {
 	// dropped on release. Guarded by mu.
 	callGroups map[uint16]uint32
 
+	// fragTMSDU accumulates a TM-SDU that spans a start-fragment MAC-RESOURCE and
+	// one or more following MAC-FRAG / MAC-END PDUs (§21.4.3.3/.4). fragResource
+	// is the start fragment's MAC-RESOURCE context (address + channel allocation),
+	// needed to act on the reassembled L3 CMCE PDU because MAC-FRAG/MAC-END carry
+	// no address of their own. fragActive marks a reassembly in progress. A single
+	// TM-SDU is in flight at a time (a new start fragment replaces an incomplete
+	// one); bounded by fragMaxBits and cleared on reassembly or resync. Guarded by
+	// mu.
+	fragTMSDU    []byte
+	fragResource MACResource
+	fragActive   bool
+
 	// pendingSoft holds the per-symbol complex differential (soft
 	// information) for the next Process call, stashed by StashSoft
 	// immediately before the matching dibit chunk arrives (see
@@ -755,6 +767,60 @@ func (c *ControlChannel) isIndividual(ssi uint32) bool {
 	return ok
 }
 
+// fragMaxBits bounds the reassembly buffer (one-bit-per-byte). A control-channel
+// TM-SDU is well under this; the cap only stops a runaway MAC-FRAG stream that
+// never delivers a MAC-END from growing the buffer without limit.
+const fragMaxBits = 2048
+
+// stashFragment records a start-fragment MAC-RESOURCE's partial TM-SDU and its
+// resource context so a following MAC-END can reassemble the complete L3 PDU. A
+// new start fragment replaces any incomplete one (single TM-SDU in flight).
+func (c *ControlChannel) stashFragment(m MACResource, partial []byte) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.fragResource = m
+	c.fragTMSDU = append(c.fragTMSDU[:0], partial...)
+	c.fragActive = true
+}
+
+// appendFragment appends a MAC-FRAG continuation to the in-progress TM-SDU. A
+// no-op when no start fragment is in progress; a stream that would exceed
+// fragMaxBits is dropped rather than accumulated.
+func (c *ControlChannel) appendFragment(payload []byte) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.fragActive {
+		return
+	}
+	if len(c.fragTMSDU)+len(payload) > fragMaxBits {
+		c.fragActive = false
+		c.fragTMSDU = c.fragTMSDU[:0]
+		return
+	}
+	c.fragTMSDU = append(c.fragTMSDU, payload...)
+}
+
+// takeFragment appends a MAC-END payload, returns the reassembled TM-SDU (a
+// fresh slice) plus the start fragment's MAC-RESOURCE context, and clears the
+// buffer. ok is false for a stray MAC-END with no start fragment in progress or
+// an over-length reassembly.
+func (c *ControlChannel) takeFragment(payload []byte) (MACResource, []byte, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	defer func() {
+		c.fragActive = false
+		c.fragTMSDU = c.fragTMSDU[:0]
+		c.fragResource = MACResource{}
+	}()
+	if !c.fragActive || len(c.fragTMSDU)+len(payload) > fragMaxBits {
+		return MACResource{}, nil, false
+	}
+	sdu := make([]byte, 0, len(c.fragTMSDU)+len(payload))
+	sdu = append(sdu, c.fragTMSDU...)
+	sdu = append(sdu, payload...)
+	return c.fragResource, sdu, true
+}
+
 // publishRelease emits a KindCallRelease so the engine ends the active call for
 // this talkgroup at once, rather than waiting out the voice hangtime/no-voice
 // timers. No-op without a bus or a resolvable group.
@@ -906,4 +972,10 @@ func (c *ControlChannel) ResyncReset() {
 	c.pendingSoft = c.pendingSoft[:0]
 	c.pendingSoftBase = 0
 	c.pendingSoftSet = false
+	// A stream re-sync abandons any half-reassembled TM-SDU: its continuation
+	// belonged to the pre-resync bit index and must not splice onto a fragment
+	// decoded after the baseline jump.
+	c.fragActive = false
+	c.fragTMSDU = c.fragTMSDU[:0]
+	c.fragResource = MACResource{}
 }

--- a/internal/radio/tetra/control_resync_test.go
+++ b/internal/radio/tetra/control_resync_test.go
@@ -104,3 +104,34 @@ func TestNeedsResyncPredicate(t *testing.T) {
 		t.Error("NeedsResync false after MarkLost, want true (heartbeat must survive loss)")
 	}
 }
+
+// TestResyncResetPreservesLearnedIndividuals pins the invariant that a resync
+// keeps the learned individual/group classification: ResyncReset clears only the
+// dibit-sync scratch (proc) and the transient soft / fragment stashes, never the
+// individuals set. If a resync dropped it, every noise burst would regress a
+// subscriber ISSI back to being surfaced as a phantom talkgroup until it was
+// seen as a party again. The reassembly buffer, by contrast, MUST be cleared —
+// its continuation belonged to the pre-resync bit index.
+func TestResyncResetPreservesLearnedIndividuals(t *testing.T) {
+	cc := New(Options{SystemName: "Sys", FrequencyHz: 412_000_000})
+
+	cc.noteIndividual(0x0123AB)
+	if !cc.isIndividual(0x0123AB) {
+		t.Fatal("noteIndividual did not record the SSI")
+	}
+
+	// Seed an in-flight fragment reassembly to prove the resync abandons it.
+	cc.stashFragment(MACResource{}, []byte{1, 0, 1})
+
+	cc.ResyncReset()
+
+	if !cc.isIndividual(0x0123AB) {
+		t.Error("ResyncReset dropped a learned individual — classification would regress after every resync")
+	}
+	cc.mu.Lock()
+	fragActive := cc.fragActive
+	cc.mu.Unlock()
+	if fragActive {
+		t.Error("ResyncReset left a half-reassembled TM-SDU active; it must abandon the pre-resync fragment")
+	}
+}

--- a/internal/radio/tetra/downlink.go
+++ b/internal/radio/tetra/downlink.go
@@ -371,7 +371,9 @@ func (c *ControlChannel) handleCMCE(m MACResource, msg CMCEMessage) {
 		if !c.isIndividual(gssi) {
 			c.rememberCall(msg.CallIdentifier, gssi)
 		}
-	case CMCETypeDRelease:
+	case CMCETypeDRelease, CMCETypeDDisconnect:
+		// Both end the call: D-RELEASE from the SwMI, D-DISCONNECT the
+		// infrastructure-initiated disconnect (EN 300 392-2 §14.5.1.3.3).
 		gssi := c.resolveGroup(msg.CallIdentifier, m.Address.SSI)
 		c.publishRelease(gssi, msg.DisconnectCause)
 		c.forgetCall(msg.CallIdentifier)

--- a/internal/radio/tetra/downlink.go
+++ b/internal/radio/tetra/downlink.go
@@ -226,9 +226,10 @@ func (c *ControlChannel) decodeDownlinkHalf(bkn []uint8, diffs []complex64, r ui
 
 // ingestMAC demultiplexes a recovered logical-channel block (type-1 bits) at the
 // MAC layer: a MAC-RESOURCE PDU's channel-allocation element becomes a voice
-// grant, and its TM-SDU is handed to the L3 parser. MAC-FRAG/END reassembly and
-// broadcast (SYSINFO) handling here are follow-ups — SYSINFO identity already
-// reaches Ingest via the synchronisation-burst lock path.
+// grant, and its TM-SDU is handed to the L3 parser. A TM-SDU too large for one
+// block arrives as a start-fragment MAC-RESOURCE plus following MAC-FRAG /
+// MAC-END PDUs, reassembled here. Broadcast (SYSINFO) frequency parameters are
+// learned; SYSINFO identity already reaches Ingest via the sync-burst lock path.
 func (c *ControlChannel) ingestMAC(recovered []byte) {
 	if len(recovered) < 2 {
 		return
@@ -239,36 +240,38 @@ func (c *ControlChannel) ingestMAC(recovered []byte) {
 		if !ok || m.NullPDU {
 			return
 		}
-		// Parse the L3 CMCE PDU first (bit-accurate, from the raw TM-SDU bits) so
-		// a grant can be enriched with its emergency flag + source SSI, and so a
-		// D-RELEASE / D-TX change can act on the same MAC-RESOURCE's address.
-		var (
-			msg      CMCEMessage
-			haveCMCE bool
-		)
-		if sdu := m.tmSDU(recovered); sdu != nil {
-			// The MAC TM-SDU is an LLC PDU (§21.2): strip the basic-link header
-			// (and any FCS trailer) to reach the TL-SDU — the MLE PDU — before the
-			// 3-bit MLE discriminator + CMCE fields line up. Feeding the raw TM-SDU
-			// into ParseCMCE misframes every L3 address (corrupts ISSI/GSSI).
-			if tl, ok := ParseLLC(sdu); ok {
-				msg, haveCMCE = ParseCMCE(tl)
-				// Keep the broadcast/SYSINFO L3 path (Ingest no longer emits grants).
-				if pdu, err := PDUFromBits(tl); err == nil {
-					c.Ingest(pdu)
-				}
+		if m.StartFragment {
+			// The TM-SDU is truncated here and continues in following
+			// MAC-FRAG/MAC-END PDUs. The physical resource (carrier/timeslot/GSSI)
+			// is fully known from this MAC header, so publish the grant now — no
+			// latency cost, and robust to a lost MAC-END — and stash the partial
+			// TM-SDU so the MAC-END can recover the complete L3 CMCE PDU (the
+			// call-id→group mapping / release / talker a single block can't carry).
+			if m.ChanAlloc != nil {
+				c.publishGrantFromMAC(m, CMCEMessage{}, false)
 			}
+			if sdu := m.tmSDU(recovered); sdu != nil {
+				c.stashFragment(m, sdu)
+			}
+			return
 		}
-		// Publish a voice grant for the allocated resource — unless the CMCE PDU
-		// riding in this MAC-RESOURCE is a teardown (D-RELEASE): its
-		// channel-allocation element is the resource being reclaimed, not a new
-		// call, and publishing it spawns a zero-byte ghost call that handleCMCE's
-		// release then immediately ends.
-		if m.ChanAlloc != nil && !(haveCMCE && isCMCETeardown(msg.Type)) {
-			c.publishGrantFromMAC(m, msg, haveCMCE)
+		c.ingestResourceTMSDU(m, m.tmSDU(recovered))
+	case MACPDUFragEnd:
+		// Continuation of a start-fragment TM-SDU (§21.4.3.3/.4). MAC-FRAG appends;
+		// MAC-END completes the reassembly and runs the same L3 handling as a
+		// single-block MAC-RESOURCE, keyed by the stashed start-fragment context.
+		sub, ok := macFragmentSubtype(recovered)
+		if !ok {
+			return
 		}
-		if haveCMCE {
-			c.handleCMCE(m, msg)
+		payload := macFragmentPayload(recovered)
+		switch sub {
+		case macFrag:
+			c.appendFragment(payload)
+		case macEnd:
+			if m, sdu, ok := c.takeFragment(payload); ok {
+				c.ingestResourceTMSDU(m, sdu)
+			}
 		}
 	case MACPDUBroadcast:
 		// Learn the cell's full SYSINFO frequency parameters (main carrier +
@@ -280,6 +283,40 @@ func (c *ControlChannel) ingestMAC(recovered []byte) {
 		if si, ok := ParseSysInfo(recovered); ok {
 			c.learnSysInfo(si)
 		}
+	}
+}
+
+// ingestResourceTMSDU runs the L3 handling for a MAC-RESOURCE whose TM-SDU is
+// complete — either delivered in a single block or reassembled from a
+// start-fragment + MAC-FRAG/MAC-END chain. sdu is the TM-SDU bits (nil for a
+// bare grant with no TM-SDU). It decodes the CMCE PDU (to enrich the grant with
+// its emergency flag + source SSI and to drive call-state), publishes a voice
+// grant for any channel allocation — unless the CMCE is a teardown (D-RELEASE /
+// D-DISCONNECT) whose allocation is the resource being reclaimed, which would
+// otherwise spawn a zero-byte ghost call — and acts on the call-control PDU.
+func (c *ControlChannel) ingestResourceTMSDU(m MACResource, sdu []byte) {
+	var (
+		msg      CMCEMessage
+		haveCMCE bool
+	)
+	if sdu != nil {
+		// The MAC TM-SDU is an LLC PDU (§21.2): strip the basic-link header (and
+		// any FCS trailer) to reach the TL-SDU — the MLE PDU — before the 3-bit MLE
+		// discriminator + CMCE fields line up. Feeding the raw TM-SDU into
+		// ParseCMCE misframes every L3 address (corrupts ISSI/GSSI).
+		if tl, ok := ParseLLC(sdu); ok {
+			msg, haveCMCE = ParseCMCE(tl)
+			// Keep the broadcast/SYSINFO L3 path (Ingest no longer emits grants).
+			if pdu, err := PDUFromBits(tl); err == nil {
+				c.Ingest(pdu)
+			}
+		}
+	}
+	if m.ChanAlloc != nil && !(haveCMCE && isCMCETeardown(msg.Type)) {
+		c.publishGrantFromMAC(m, msg, haveCMCE)
+	}
+	if haveCMCE {
+		c.handleCMCE(m, msg)
 	}
 }
 

--- a/internal/radio/tetra/frag_reassembly_test.go
+++ b/internal/radio/tetra/frag_reassembly_test.go
@@ -1,0 +1,159 @@
+package tetra
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// macResourceStartFragment builds a MAC-RESOURCE whose length indication is the
+// reserved start-fragment marker (0x3f, §21.4.3.1): the MAC header — including
+// the channel-allocation element — is complete, but the TM-SDU is truncated and
+// continues in a following MAC-FRAG/MAC-END. It is macResourceGrant with the
+// length field swapped for the marker.
+func macResourceStartFragment(ssi uint32, carrier uint16, timeslot uint8, partial []byte) []byte {
+	w := &cmceBitWriter{}
+	w.u(uint64(MACPDUResource), 2)      // MAC PDU type
+	w.u(0, 1)                           // fill bit
+	w.u(0, 1)                           // grant position
+	w.u(0, 2)                           // encryption mode (0 = clear)
+	w.u(0, 1)                           // random access
+	w.u(uint64(macLenStartFragment), 6) // length indication = start-fragment marker
+	w.u(uint64(addrSSI), 3)             // address type = SSI
+	w.u(uint64(ssi), 24)                // SSI
+	w.u(0, 1)                           // power control absent
+	w.u(0, 1)                           // slot granting absent
+	w.u(1, 1)                           // channel allocation present
+	w.u(0, 2)                           // allocation type
+	w.u(uint64(timeslot), 4)            // assigned timeslot
+	w.u(1, 2)                           // up/downlink (nonzero → skip augmented branch)
+	w.u(0, 1)                           // CLCH permission
+	w.u(0, 1)                           // cell change
+	w.u(uint64(carrier), 12)            // main carrier number
+	w.u(0, 1)                           // extended carrier absent
+	w.u(1, 2)                           // monitoring pattern (nonzero → no frame-18 field)
+	return append(w.bits, partial...)
+}
+
+// macEndPDU wraps continuation bits in a MAC-END PDU (§21.4.3.4): MAC PDU
+// type = MACPDUFragEnd, subtype = macEnd, then a fill-bit flag + 6-bit length
+// indication before the fragment — the exact header macFragmentPayload skips.
+func macEndPDU(payload []byte) []byte {
+	w := &cmceBitWriter{}
+	w.u(uint64(MACPDUFragEnd), 2)
+	w.u(uint64(macEnd), 1)
+	w.u(0, 1) // fill-bit indication
+	w.u(0, 6) // length indication
+	return append(w.bits, payload...)
+}
+
+// cmceSetupEmergencyParty builds a D-SETUP TM-SDU (LLC BL-UDATA + CMCE) marked
+// emergency and carrying a calling-party SSI, so a published grant enriches to
+// Emergency=true with SourceSSI=party. Long enough to be a realistic fragmented
+// TM-SDU.
+func cmceSetupEmergencyParty(callID uint16, party uint32) []byte {
+	c := &cmceBitWriter{}
+	c.header(CMCETypeDSetup)
+	c.u(uint64(callID), 14)               // call identifier
+	c.u(0, 4+1+1+8+2+1)                   // through transmission-request permission
+	c.u(uint64(callPriorityEmergency), 4) // call priority = emergency
+	c.u(1, 1)                             // O-bit: optional elements present
+	c.opt(false, 0, 6)                    // notification indicator absent
+	c.opt(false, 0, 24)                   // temporary address (GSSI) absent
+	c.pbit(true)                          // calling party type identifier present
+	c.u(1, 2)                             // CPTI = 1 (SSI present)
+	c.u(uint64(party), 24)                // calling party SSI
+	return append(bl(llcBLUDATA, 0), c.bits...)
+}
+
+func collectGrants(sub *events.Subscription) []trunking.Grant {
+	var grants []trunking.Grant
+	for {
+		select {
+		case ev := <-sub.C:
+			if g, ok := ev.Payload.(trunking.Grant); ok && ev.Kind == events.KindGrant {
+				grants = append(grants, g)
+			}
+		default:
+			return grants
+		}
+	}
+}
+
+// TestIngestMACReassemblesFragmentedTMSDU is the MAC-FRAG/MAC-END regression. A
+// TM-SDU too large for one MAC block arrives as a start-fragment MAC-RESOURCE
+// (carrying the complete channel allocation) plus a MAC-END carrying the rest of
+// the L3 CMCE PDU. The reassembled D-SETUP must enrich the grant with the same
+// Emergency flag + calling-party SourceID that the identical unfragmented TM-SDU
+// produces. Before reassembly the MAC-END was dropped, so the fragmented case
+// only ever published the un-enriched start-fragment grant.
+func TestIngestMACReassemblesFragmentedTMSDU(t *testing.T) {
+	const (
+		gssi     = 0x0F5670
+		party    = 0x0123AB
+		callID   = 0x1234
+		carrier  = 2716
+		timeslot = 1
+	)
+	full := cmceSetupEmergencyParty(callID, party)
+
+	// Reference: the same TM-SDU delivered in one block.
+	wantG, wantSrc, wantEmerg := ingestOneGrant(t, func(cc *ControlChannel) {
+		cc.ingestMAC(macResourceGrant(gssi, carrier, timeslot, full))
+	})
+	if wantG != gssi || wantSrc != party || !wantEmerg {
+		t.Fatalf("reference grant wrong: group=%#x src=%#x emergency=%v", wantG, wantSrc, wantEmerg)
+	}
+
+	// Split the TM-SDU early (inside the CMCE mandatory block, so the truncated
+	// start fragment cannot itself parse a CMCE PDU) and deliver it fragmented.
+	split := 24 // bits: past the LLC header, well short of the D-SETUP mandatory fields
+	if split >= len(full) {
+		t.Fatal("test TM-SDU shorter than the split point")
+	}
+	bus := events.NewBus(32)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "Sys", FrequencyHz: 467_913_000})
+	cc.ingestMAC(macResourceStartFragment(gssi, carrier, timeslot, full[:split]))
+	cc.ingestMAC(macEndPDU(full[split:]))
+
+	grants := collectGrants(sub)
+	if len(grants) == 0 {
+		t.Fatal("no grant published for a fragmented D-SETUP")
+	}
+	var enriched *trunking.Grant
+	for i := range grants {
+		if grants[i].SourceID == party && grants[i].Emergency {
+			enriched = &grants[i]
+		}
+	}
+	if enriched == nil {
+		t.Fatalf("fragmented grant not enriched from the reassembled MAC-END: got %+v (want group=%#x src=%#x emergency=true)",
+			grants, uint32(gssi), uint32(party))
+	}
+	if enriched.GroupID != gssi {
+		t.Errorf("reassembled grant GroupID = %#x, want %#x", enriched.GroupID, uint32(gssi))
+	}
+}
+
+// ingestOneGrant runs feed against a fresh ControlChannel and returns the fields
+// of the last grant it published.
+func ingestOneGrant(t *testing.T, feed func(*ControlChannel)) (group, src uint32, emergency bool) {
+	t.Helper()
+	bus := events.NewBus(32)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+	cc := New(Options{Bus: bus, SystemName: "Sys", FrequencyHz: 467_913_000})
+	feed(cc)
+	grants := collectGrants(sub)
+	if len(grants) == 0 {
+		t.Fatal("no grant published")
+	}
+	last := grants[len(grants)-1]
+	return last.GroupID, last.SourceID, last.Emergency
+}

--- a/internal/radio/tetra/ghost_grant_test.go
+++ b/internal/radio/tetra/ghost_grant_test.go
@@ -46,6 +46,14 @@ func cmceReleaseTMSDU(callID uint16, cause uint8) []byte {
 	return append(bl(llcBLUDATA, 0), c.bits...)
 }
 
+func cmceDisconnectTMSDU(callID uint16, cause uint8) []byte {
+	c := &cmceBitWriter{}
+	c.header(CMCETypeDDisconnect)
+	c.u(uint64(callID), 14)
+	c.u(uint64(cause), 5)
+	return append(bl(llcBLUDATA, 0), c.bits...)
+}
+
 func cmceSetupTMSDU(callID uint16) []byte {
 	c := &cmceBitWriter{}
 	c.header(CMCETypeDSetup)
@@ -89,6 +97,32 @@ func TestIngestMACSuppressesGrantOnRelease(t *testing.T) {
 	}
 	if counts[events.KindCallRelease] == 0 {
 		t.Error("did not publish the D-RELEASE")
+	}
+}
+
+// TestIngestMACSuppressesGrantOnDisconnect is the ghost-call regression for
+// D-DISCONNECT (EN 300 392-2 Table 14.9). A MAC-RESOURCE carrying both a
+// channel-allocation element and a CMCE D-DISCONNECT must NOT publish a voice
+// grant — the allocation is the resource being reclaimed — and must emit the
+// release. Before D-DISCONNECT was modelled, ParseCMCE returned ok=false for
+// it, so haveCMCE was false, the teardown gate never fired, and a zero-byte
+// ghost call was published (that nothing then tore down).
+func TestIngestMACSuppressesGrantOnDisconnect(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "Sys", FrequencyHz: 467_913_000})
+	block := macResourceGrant(0x0F5670, 2716, 1, cmceDisconnectTMSDU(0x1234, 13))
+	cc.ingestMAC(block)
+
+	counts := drainKinds(sub)
+	if counts[events.KindGrant] != 0 {
+		t.Errorf("published %d grant(s) for a D-DISCONNECT-bearing MAC-RESOURCE, want 0 (ghost call)", counts[events.KindGrant])
+	}
+	if counts[events.KindCallRelease] == 0 {
+		t.Error("did not publish the D-DISCONNECT as a release")
 	}
 }
 

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -826,6 +826,9 @@ func (p *tetraPipeline) TopologySnapshot() *trunking.TopologySnapshot {
 		snap.PrimaryCC = &trunking.TopoChannelRef{
 			ChannelNumber: t.MainCarrier,
 			FrequencyHz:   t.DownlinkHz,
+			// The uplink is the offset-corrected duplex pair (§21.4.4.1), derived
+			// directly from the SYSINFO duplex spacing rather than a band plan.
+			UplinkHz: t.UplinkHz,
 		}
 	}
 	return snap

--- a/internal/trunking/network_report.go
+++ b/internal/trunking/network_report.go
@@ -232,9 +232,14 @@ func ReportFromTopology(t *TopologySnapshot) NetworkReport {
 	for _, b := range t.BandPlan {
 		offsets[b.ChannelID] = b.TxOffsetHz
 	}
-	conv := func(id uint8, num uint16, downHz uint32) ReportChannel {
+	conv := func(id uint8, num uint16, downHz, upHz uint32) ReportChannel {
 		c := ReportChannel{ChannelID: id, ChannelNumber: num, DownlinkHz: downHz}
-		if downHz != 0 {
+		switch {
+		case upHz != 0:
+			// The protocol resolved the uplink directly (TETRA duplex spacing).
+			c.UplinkHz = upHz
+		case downHz != 0:
+			// Otherwise derive it from the band-plan transmit offset (P25).
 			if off, ok := offsets[id]; ok && off != 0 {
 				if up := int64(downHz) + off; up > 0 {
 					c.UplinkHz = uint32(up)
@@ -254,16 +259,17 @@ func ReportFromTopology(t *TopologySnapshot) NetworkReport {
 	}
 	site := ReportSite{RFSS: t.RFSS, Site: t.Site, LRA: t.LRA}
 	if t.PrimaryCC != nil {
-		site.PrimaryCC = conv(t.PrimaryCC.ChannelID, t.PrimaryCC.ChannelNumber, t.PrimaryCC.FrequencyHz)
+		site.PrimaryCC = conv(t.PrimaryCC.ChannelID, t.PrimaryCC.ChannelNumber, t.PrimaryCC.FrequencyHz, t.PrimaryCC.UplinkHz)
 	}
 	for _, s := range t.Secondary {
-		site.SecondaryCC = append(site.SecondaryCC, conv(s.ChannelID, s.ChannelNumber, s.FrequencyHz))
+		site.SecondaryCC = append(site.SecondaryCC, conv(s.ChannelID, s.ChannelNumber, s.FrequencyHz, s.UplinkHz))
 	}
 	for _, n := range t.Neighbors {
 		site.Neighbors = append(site.Neighbors, ReportNeighbor{
-			RFSS:    n.RFSS,
-			Site:    n.Site,
-			Channel: conv(n.ChannelID, n.ChannelNumber, n.FrequencyHz),
+			RFSS: n.RFSS,
+			Site: n.Site,
+			// TopoNeighborRef carries no explicit uplink; it comes from the band plan.
+			Channel: conv(n.ChannelID, n.ChannelNumber, n.FrequencyHz, 0),
 		})
 	}
 	r.Sites = []ReportSite{site}

--- a/internal/trunking/network_report_test.go
+++ b/internal/trunking/network_report_test.go
@@ -111,3 +111,28 @@ func TestReportFromTopologyMapsFieldsAndUplink(t *testing.T) {
 		t.Errorf("neighbour uplink not derived: %+v", site.Neighbors)
 	}
 }
+
+// TestReportFromTopologyDirectUplink covers a protocol (TETRA) that resolves the
+// uplink directly from its own duplex spacing, with no band plan: the explicit
+// TopoChannelRef.UplinkHz must flow through to the report and the rendered
+// UPLINK line, not be dropped for want of a band-plan transmit offset.
+func TestReportFromTopologyDirectUplink(t *testing.T) {
+	snap := &TopologySnapshot{
+		SystemName: "TETRA Cell",
+		Protocol:   "tetra",
+		// Offset-corrected duplex pair (§21.4.4.1): 469.88125 MHz DL / 459.88125 UL.
+		PrimaryCC: &TopoChannelRef{ChannelNumber: 3595, FrequencyHz: 469881250, UplinkHz: 459881250},
+	}
+	r := ReportFromTopology(snap)
+	if len(r.Sites) != 1 {
+		t.Fatalf("Sites = %d, want 1", len(r.Sites))
+	}
+	if got := r.Sites[0].PrimaryCC.UplinkHz; got != 459881250 {
+		t.Errorf("primary uplink = %d, want 459881250 (direct, no band plan)", got)
+	}
+	var buf strings.Builder
+	RenderNetworkReport(&buf, r)
+	if !strings.Contains(buf.String(), "UPLINK:459.881250 MHz") {
+		t.Errorf("rendered report missing direct TETRA uplink:\n%s", buf.String())
+	}
+}

--- a/internal/trunking/topology.go
+++ b/internal/trunking/topology.go
@@ -61,6 +61,11 @@ type TopoChannelRef struct {
 	ChannelID     uint8  `json:"channel_id" yaml:"channel_id"`
 	ChannelNumber uint16 `json:"channel_number" yaml:"channel_number"`
 	FrequencyHz   uint32 `json:"frequency_hz,omitempty" yaml:"frequency_hz,omitempty"`
+	// UplinkHz is the channel's uplink (MS transmit) frequency when the protocol
+	// resolves it directly rather than via a band-plan transmit offset — TETRA
+	// derives it from the SYSINFO duplex spacing (§21.4.4.1). Zero when unknown or
+	// when the uplink is instead computed from a band plan (P25).
+	UplinkHz uint32 `json:"uplink_hz,omitempty" yaml:"uplink_hz,omitempty"`
 }
 
 // TopoNeighborRef is an adjacent site advertised by the control channel.


### PR DESCRIPTION
## Summary

Follow-up to the merged #994 TETRA control-channel work, implementing the items deferred there. Fixes a ghost-recording leak on D-DISCONNECT, reassembles control PDUs that span multiple MAC blocks, and surfaces the cell's uplink in the network-configuration report.

## Changes

- **D-DISCONNECT modelled** (ETSI EN 300 392-2 Table 14.9, PDU-type `00100₂` = 0x04). A MAC-RESOURCE whose CMCE PDU is a D-DISCONNECT carries a channel-allocation element for the resource being *reclaimed*, not a new call. Because the type was unmodelled, `ParseCMCE` returned `ok=false`, the teardown gate in `ingestMAC` never fired, and a zero-byte ghost recording was published that nothing then ended. It now parses (Call identifier + Disconnect cause) and routes through the same release path as D-RELEASE.
- **MAC-FRAG / MAC-END reassembly** (§21.4.3.3/.4). A TM-SDU too large for one MAC block arrives as a start-fragment MAC-RESOURCE followed by MAC-FRAG and a MAC-END; those continuation PDUs were dropped, losing the L3 CMCE PDU carried across them (a large D-SETUP's call-id→group mapping, calling-party SSI, emergency flag). The channel allocation is complete on the start fragment, so the voice grant still publishes immediately; the reassembled MAC-END now recovers the full call-control PDU and enriches the call. The single-block path is factored into `ingestResourceTMSDU` and is byte-for-byte unchanged; the reassembly buffer is bounded and cleared on resync.
- **TETRA uplink in the network report.** The cell's uplink carrier, derived from the SYSINFO duplex spacing + frequency offset (§21.4.4.1), was computed but dropped before the report. An additive `TopoChannelRef.UplinkHz` now carries it through to the report's `UPLINK:` line; the P25 band-plan transmit-offset path is unchanged.
- **Cleanup.** Remove the dead `VoiceGrant.Group` field (never read or written) and the stale byte-offset doc comment left over from the deleted byte-aligned parser; add a regression test pinning that `ResyncReset` preserves the learned-individuals set (so individual/group classification never regresses on a resync).
- **Docs.** Record the branch's user-visible TETRA changes in `CHANGELOG.md`.

## Test plan

- [x] `make vet test` is green locally
- [x] `make integration` is green locally
- [x] Added tests, each demonstrated failing-first where it guards a bug: D-DISCONNECT teardown (no grant + a release), a fragmented D-SETUP reassembles to the same `Emergency` + calling-party `SourceID` as the identical unfragmented TM-SDU, the direct-uplink report renders its `UPLINK:` line, and learned individuals survive a resync.

## Breaking changes

None. `TopoChannelRef.UplinkHz` is additive (`omitempty`); the removed `VoiceGrant.Group` was internal and unused.

## Docs / CHANGELOG

Added `## [Unreleased]` bullets for the user-visible changes.

## Linked issues

n/a — Discord field reports; the base fixes landed in #994.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFGjw2moTZbAyhp78sWgqw

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFGjw2moTZbAyhp78sWgqw)_