### PR TITLE
feat(api): add GET /api/v1/grants control-channel grant log (#915)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **`GET /api/v1/grants` — a pollable log of recent control-channel grants.**
+  GopherTrunk decodes a source RID off most `GRP_VCH_GRANT` TSBKs, and already
+  streams every grant live over the `grant` SSE event; this adds the pollable
+  snapshot form so a telemetry consumer can read the source RID (plus talkgroup,
+  frequency, channel, site and encryption) straight off the grant — the way
+  SDRtrunk's control-channel grant log exposes it — without holding an SSE
+  connection. The response reuses the same stable `GrantDTO` schema the SSE
+  stream emits, with a per-row `at` timestamp; `?limit=` and `?system=` narrow
+  the result. Backed by a bounded in-memory ring (newest-first, always on), so a
+  busy system never grows the log without bound (issue #915, reporter fix #2).
 - **TETRA control-channel PDUs that span multiple MAC blocks are reassembled
   (MAC-FRAG / MAC-END).** A TM-SDU too large for one MAC block arrives as a
   start-fragment MAC-RESOURCE followed by MAC-FRAG and a MAC-END (ETSI EN 300

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -391,6 +391,7 @@ type Daemon struct {
 	voicePool    *trunking.VoicePool
 	affiliations *trunking.AffiliationTracker
 	siteTracker  *trunking.SiteTracker
+	grantTracker *trunking.GrantTracker
 	recorder     *voice.Recorder
 	// voiceDecoder is the recorder the composer decodes digital voice through
 	// and taps PCM from for the live web/gRPC stream. It equals `recorder` when
@@ -1429,6 +1430,18 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		d.siteTracker = st
 	}
 
+	// Grant tracker — always on. Subscribes to the bus and retains a
+	// bounded, most-recent-first log of decoded control-channel grants,
+	// surfaced at GET /api/v1/grants (the pollable form of the KindGrant
+	// SSE stream, issue #915).
+	{
+		gt, err := trunking.NewGrantTracker(trunking.GrantTrackerOptions{Bus: d.bus})
+		if err != nil {
+			return nil, fmt.Errorf("daemon: grant tracker: %w", err)
+		}
+		d.grantTracker = gt
+	}
+
 	// Tone-out detector — optional. Built before the composer so it can
 	// share the composer's PCM sink via fanoutSink.
 	if len(cfg.ToneOut.Profiles) > 0 {
@@ -2462,6 +2475,9 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		if d.siteTracker != nil {
 			opts.Sites = sitesProvider{d.siteTracker}
 		}
+		if d.grantTracker != nil {
+			opts.Grants = grantsProvider{d.grantTracker}
+		}
 		if d.metrics != nil {
 			opts.MetricsHandler = d.metrics.Handler()
 		}
@@ -2768,6 +2784,11 @@ func (d *Daemon) Run(ctx context.Context) error {
 	if d.affiliations != nil {
 		d.spawn(runCtx, "affiliations", false, func(ctx context.Context) error {
 			return d.affiliations.Run(ctx)
+		})
+	}
+	if d.grantTracker != nil {
+		d.spawn(runCtx, "grant-tracker", false, func(ctx context.Context) error {
+			return d.grantTracker.Run(ctx)
 		})
 	}
 	if d.p25p2Follower != nil {
@@ -3463,6 +3484,9 @@ func (d *Daemon) Close() {
 		}
 		if d.affiliations != nil {
 			_ = d.affiliations.Close()
+		}
+		if d.grantTracker != nil {
+			_ = d.grantTracker.Close()
 		}
 		if d.siteTracker != nil {
 			_ = d.siteTracker.Close()
@@ -4431,6 +4455,12 @@ func (b broadcastStatus) BroadcastStats() any { return b.mgr.Stats() }
 type affiliationProvider struct{ t *trunking.AffiliationTracker }
 
 func (a affiliationProvider) Affiliations() []trunking.UnitActivity { return a.t.Snapshot() }
+
+// grantsProvider adapts the GrantTracker into the api.GrantsProvider
+// interface (GET /api/v1/grants, issue #915).
+type grantsProvider struct{ t *trunking.GrantTracker }
+
+func (g grantsProvider) RecentGrants(limit int) []trunking.Grant { return g.t.Snapshot(limit) }
 
 // sitesProvider adapts the SiteTracker into the api.SitesProvider
 // interface.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -156,6 +156,13 @@ constructed only when its config section is present:
   table of unit→talkgroup activity built from `KindGrant`,
   `KindAffiliation` and `KindUnitRegistration` events, served at
   `GET /api/v1/affiliations`.
+- **`trunking.GrantTracker`** — a bounded, most-recent-first ring-buffer
+  log of the voice-channel grants decoded off the control channel, built
+  from `KindGrant` events and served at `GET /api/v1/grants`. It is the
+  pollable form of the live `grant` SSE stream, so a telemetry consumer can
+  read the source RID (plus talkgroup, frequency and encryption) straight
+  off the control-channel grant — the way SDRtrunk's grant log exposes it —
+  without holding an SSE connection (issue #915).
 - **`trunking.SiteTracker`** — an in-memory table of the P25 sites
   discovered from the control channel, built from `KindSiteUpdate`
   events (published on each RFSS Status Broadcast) and served at

--- a/internal/api/handlers_grants.go
+++ b/internal/api/handlers_grants.go
@@ -1,0 +1,72 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// grantsDefaultLimit is the number of recent grants returned when the caller
+// does not pass ?limit.
+const grantsDefaultLimit = 500
+
+// grantsMaxLimit caps ?limit so a single request can't ask for an unbounded
+// page; the tracker's ring is bounded anyway, but this keeps the response
+// size predictable.
+const grantsMaxLimit = 5000
+
+// GrantLogEntry is one row of GET /api/v1/grants: the stable GrantDTO the SSE
+// stream already emits for KindGrant, plus the time the grant was decoded so a
+// polling consumer can order and de-duplicate across polls. Reusing GrantDTO
+// keeps the REST snapshot and the SSE live stream on one schema.
+type GrantLogEntry struct {
+	GrantDTO
+	At time.Time `json:"at"`
+}
+
+// handleGrants answers GET /api/v1/grants with the most-recent voice-channel
+// grants decoded off the control channel, newest first — the pollable form of
+// the KindGrant stream the SSE feed carries live (issue #915). It lets a
+// telemetry consumer read the source RID (and talkgroup, frequency,
+// encryption) straight off the grant the way SDRtrunk's control-channel grant
+// log does, without holding an SSE connection.
+//
+// Query params:
+//   - limit:  max rows to return (default grantsDefaultLimit, capped at
+//     grantsMaxLimit).
+//   - system: restrict to one trunking-system name (exact match).
+//
+// Always 200; an empty list when the grant tracker is not wired.
+func (s *Server) handleGrants(w http.ResponseWriter, r *http.Request) {
+	entries := []GrantLogEntry{}
+	if s.grants != nil {
+		limit := grantsDefaultLimit
+		if v := r.URL.Query().Get("limit"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				limit = n
+			}
+		}
+		if limit > grantsMaxLimit {
+			limit = grantsMaxLimit
+		}
+		system := r.URL.Query().Get("system")
+
+		// Without a system filter, ask the tracker for exactly `limit` newest.
+		// With one, pull the full retained window and cap after filtering so a
+		// filtered query still returns up to `limit` matching rows.
+		fetch := limit
+		if system != "" {
+			fetch = 0
+		}
+		for _, g := range s.grants.RecentGrants(fetch) {
+			if system != "" && g.System != system {
+				continue
+			}
+			entries = append(entries, GrantLogEntry{GrantDTO: grantToDTO(g), At: g.At})
+			if len(entries) >= limit {
+				break
+			}
+		}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"grants": entries})
+}

--- a/internal/api/handlers_grants_test.go
+++ b/internal/api/handlers_grants_test.go
@@ -1,0 +1,122 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+type fakeGrantsProvider struct {
+	grants []trunking.Grant
+}
+
+// RecentGrants returns newest-first up to limit (0 = all), mirroring the real
+// tracker's contract so the handler's fetch/limit logic is exercised faithfully.
+func (f *fakeGrantsProvider) RecentGrants(limit int) []trunking.Grant {
+	out := append([]trunking.Grant(nil), f.grants...)
+	if limit > 0 && limit < len(out) {
+		out = out[:limit]
+	}
+	return out
+}
+
+func getGrants(t *testing.T, base, query string) []GrantLogEntry {
+	t.Helper()
+	resp, err := http.Get(base + "/api/v1/grants" + query)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	var body struct {
+		Grants []GrantLogEntry `json:"grants"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return body.Grants
+}
+
+// TestGrantsEndpointCarriesSourceRID is the API-side #915 guard: the grant log
+// endpoint surfaces the source RID (and talkgroup, frequency, encryption) off
+// the control-channel grant, newest first.
+func TestGrantsEndpointCarriesSourceRID(t *testing.T) {
+	bus := events.NewBus(4)
+	defer bus.Close()
+
+	now := time.Unix(1700, 0).UTC()
+	live := &fakeGrantsProvider{grants: []trunking.Grant{
+		// newest first, as the tracker returns
+		{System: "MMR", Protocol: "p25", GroupID: 20001, SourceID: 202419,
+			FrequencyHz: 422612500, Encrypted: true, AlgorithmID: 0x84, KeyID: 0x1234, At: now.Add(2 * time.Second)},
+		{System: "MMR", Protocol: "p25", GroupID: 20002, SourceID: 0, FrequencyHz: 422637500, At: now.Add(time.Second)},
+	}}
+
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, Grants: live})
+	defer teardown()
+
+	grants := getGrants(t, base, "")
+	if len(grants) != 2 {
+		t.Fatalf("got %d grants, want 2", len(grants))
+	}
+	g0 := grants[0]
+	if g0.SourceID != 202419 || g0.GroupID != 20001 || g0.FrequencyHz != 422612500 {
+		t.Fatalf("first grant fields wrong: %+v", g0)
+	}
+	if !g0.Encrypted || g0.AlgorithmID != 0x84 || g0.KeyID != 0x1234 {
+		t.Fatalf("encryption params lost: %+v", g0)
+	}
+	if g0.At.IsZero() {
+		t.Error("grant row missing timestamp")
+	}
+	// A source-less grant is still surfaced (coverage-truthful).
+	if grants[1].SourceID != 0 || grants[1].GroupID != 20002 {
+		t.Fatalf("second grant wrong: %+v", grants[1])
+	}
+}
+
+// TestGrantsEndpointEmptyWhenUnwired: no tracker ⇒ stable empty shape, 200.
+func TestGrantsEndpointEmptyWhenUnwired(t *testing.T) {
+	bus := events.NewBus(4)
+	defer bus.Close()
+	base, teardown := mkServer(t, ServerOptions{Bus: bus})
+	defer teardown()
+
+	if grants := getGrants(t, base, ""); len(grants) != 0 {
+		t.Fatalf("want empty list when tracker unwired, got %d", len(grants))
+	}
+}
+
+// TestGrantsEndpointLimitAndSystemFilter exercises the query params.
+func TestGrantsEndpointLimitAndSystemFilter(t *testing.T) {
+	bus := events.NewBus(4)
+	defer bus.Close()
+
+	live := &fakeGrantsProvider{grants: []trunking.Grant{
+		{System: "A", Protocol: "p25", GroupID: 1, SourceID: 10, FrequencyHz: 1},
+		{System: "B", Protocol: "p25", GroupID: 2, SourceID: 20, FrequencyHz: 2},
+		{System: "A", Protocol: "p25", GroupID: 3, SourceID: 30, FrequencyHz: 3},
+	}}
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, Grants: live})
+	defer teardown()
+
+	if g := getGrants(t, base, "?limit=1"); len(g) != 1 || g[0].SourceID != 10 {
+		t.Fatalf("?limit=1 = %+v, want single newest", g)
+	}
+	// System filter returns only matching rows, across the full window.
+	sys := getGrants(t, base, "?system=A")
+	if len(sys) != 2 {
+		t.Fatalf("?system=A returned %d rows, want 2", len(sys))
+	}
+	for _, g := range sys {
+		if g.System != "A" {
+			t.Fatalf("system filter leaked a %q row", g.System)
+		}
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -283,6 +283,7 @@ type Server struct {
 	locations    LocationQuery
 	affiliations AffiliationProvider
 	sites        SitesProvider
+	grants       GrantsProvider
 	metrics      http.Handler
 	log          *slog.Logger
 	version      string
@@ -499,6 +500,14 @@ type SitesProvider interface {
 	Sites() []trunking.SiteInfo
 }
 
+// GrantsProvider is the read side of the grant tracker, supplying the
+// most-recent voice-channel grants decoded off the control channel for
+// GET /api/v1/grants (issue #915). RecentGrants returns newest-first, up to
+// limit entries (limit <= 0 = all retained).
+type GrantsProvider interface {
+	RecentGrants(limit int) []trunking.Grant
+}
+
 // NetworkReporter is the optional capability a SitesProvider may implement to
 // render the live, human-readable network-configuration report for a system
 // (the SiteTracker does). GET /api/v1/systems/{name}/report uses it when the
@@ -595,6 +604,9 @@ type ServerOptions struct {
 	// Sites is optional. When non-nil the server exposes
 	// GET /api/v1/sites (the discovered-P25-site table, issue #698).
 	Sites SitesProvider
+	// Grants is optional. When non-nil the server exposes
+	// GET /api/v1/grants (the recent control-channel grant log, issue #915).
+	Grants GrantsProvider
 	// MetricsHandler is optional. When non-nil it is mounted at
 	// GET /metrics; the daemon passes internal/metrics.Metrics.Handler()
 	// here. Decoupling via http.Handler keeps the api package free of a
@@ -914,6 +926,7 @@ func NewServer(opts ServerOptions) (*Server, error) {
 		locations:      opts.Locations,
 		affiliations:   opts.Affiliations,
 		sites:          opts.Sites,
+		grants:         opts.Grants,
 		metrics:        opts.MetricsHandler,
 		log:            log,
 		version:        opts.Version,
@@ -1078,6 +1091,7 @@ func (s *Server) routes() *http.ServeMux {
 	mux.HandleFunc("GET /api/v1/calls/history", s.handleCallHistory)
 	mux.HandleFunc("GET /api/v1/locations", s.handleLocations)
 	mux.HandleFunc("GET /api/v1/affiliations", s.handleAffiliations)
+	mux.HandleFunc("GET /api/v1/grants", s.handleGrants)
 	mux.HandleFunc("GET /api/v1/sites", s.handleListSites)
 	mux.HandleFunc("GET /api/v1/rids", s.handleListRIDs)
 	mux.HandleFunc("GET /api/v1/rids/{id}", s.handleGetRID)

--- a/internal/trunking/grant_tracker.go
+++ b/internal/trunking/grant_tracker.go
@@ -1,0 +1,171 @@
+package trunking
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// GrantTracker keeps a bounded, most-recent-first log of the voice-channel
+// grants GopherTrunk decodes off the control channel — the same
+// events.KindGrant stream the SSE feed (/api/v1/events) carries live, made
+// available as a pollable snapshot behind GET /api/v1/grants.
+//
+// It exists for issue #915: a consumer building a telemetry database wants the
+// source RID off the control-channel grant the way SDRtrunk's grant log
+// exposes it, without holding a long-lived SSE connection. The grant carries
+// SourceID + GroupID + FrequencyHz + encryption at call-setup time for every
+// protocol, so this is a protocol-agnostic "who was granted what, when" feed —
+// distinct from the completed-call webhook, whose source RID depends on a
+// separate voice-side decode landing.
+//
+// Grants are logged exactly as decoded (no source backfill): a grant whose
+// TSBK carried src=0 is stored with src=0, mirroring what a control-channel
+// grant log actually saw. The ring buffer is fixed-capacity, so a busy system
+// (thousands of grants/hour) never grows the log without bound — the oldest
+// entries fall off. The tracker is a non-blocking bus subscriber (the bus
+// drops to a slow subscriber rather than stalling the publisher), and its
+// per-event work is a single ring append, so it cannot become the slow
+// consumer in practice.
+type GrantTracker struct {
+	bus *events.Bus
+	now func() time.Time
+
+	sub       *events.Subscription
+	runDone   chan struct{}
+	closeOnce sync.Once
+
+	mu   sync.Mutex
+	ring []Grant // fixed-capacity ring buffer
+	head int     // index of the next write
+	size int     // number of valid entries (<= len(ring))
+	seq  uint64  // total grants observed since start (monotonic)
+}
+
+// GrantTrackerOptions configure a GrantTracker.
+type GrantTrackerOptions struct {
+	// Bus is the event bus to subscribe to. Required.
+	Bus *events.Bus
+	// Capacity is how many recent grants the ring retains. Default
+	// DefaultGrantLogCapacity.
+	Capacity int
+	// Now is injectable for tests; defaults to time.Now.
+	Now func() time.Time
+}
+
+// DefaultGrantLogCapacity is the ring size when Capacity is unset. A few
+// thousand entries covers many minutes of a busy system while staying well
+// under a megabyte of retained grants.
+const DefaultGrantLogCapacity = 4096
+
+// NewGrantTracker validates opts and returns a tracker that has already
+// subscribed to the bus. Call Run to start draining.
+func NewGrantTracker(opts GrantTrackerOptions) (*GrantTracker, error) {
+	if opts.Bus == nil {
+		return nil, errors.New("trunking: GrantTracker requires an events.Bus")
+	}
+	if opts.Capacity <= 0 {
+		opts.Capacity = DefaultGrantLogCapacity
+	}
+	if opts.Now == nil {
+		opts.Now = time.Now
+	}
+	t := &GrantTracker{
+		bus:     opts.Bus,
+		now:     opts.Now,
+		runDone: make(chan struct{}),
+		ring:    make([]Grant, opts.Capacity),
+	}
+	t.sub = opts.Bus.Subscribe()
+	return t, nil
+}
+
+// Run drains grant events until ctx cancels or the bus closes.
+func (t *GrantTracker) Run(ctx context.Context) error {
+	defer close(t.runDone)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case ev, ok := <-t.sub.C:
+			if !ok {
+				return nil
+			}
+			if ev.Kind == events.KindGrant {
+				if g, ok := ev.Payload.(Grant); ok {
+					t.record(g)
+				}
+			}
+		}
+	}
+}
+
+// record appends one grant to the ring, evicting the oldest when full.
+func (t *GrantTracker) record(g Grant) {
+	// Stamp a receive time if the publisher left At zero, so the log always
+	// carries a usable timestamp. Clone PatchedGroups so a later mutation of
+	// the caller's slice can't alias into the retained entry.
+	if g.At.IsZero() {
+		g.At = t.now()
+	}
+	if len(g.PatchedGroups) > 0 {
+		g.PatchedGroups = append([]uint32(nil), g.PatchedGroups...)
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.ring[t.head] = g
+	t.head = (t.head + 1) % len(t.ring)
+	if t.size < len(t.ring) {
+		t.size++
+	}
+	t.seq++
+}
+
+// Snapshot returns up to limit of the most-recent grants, newest first. A
+// limit <= 0 returns every retained grant. The returned slice is a copy; the
+// caller may retain or mutate it freely.
+func (t *GrantTracker) Snapshot(limit int) []Grant {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	n := t.size
+	if limit > 0 && limit < n {
+		n = limit
+	}
+	out := make([]Grant, 0, n)
+	// The newest entry sits at head-1; walk backwards n entries.
+	for i := 0; i < n; i++ {
+		idx := (t.head - 1 - i + len(t.ring)) % len(t.ring)
+		out = append(out, t.ring[idx])
+	}
+	return out
+}
+
+// Len returns the number of grants currently retained in the ring.
+func (t *GrantTracker) Len() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.size
+}
+
+// Observed returns the total number of grants seen since start (including
+// those evicted from the ring) — a simple throughput counter.
+func (t *GrantTracker) Observed() uint64 {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.seq
+}
+
+// Close releases the bus subscription and waits for Run to drain.
+func (t *GrantTracker) Close() error {
+	t.closeOnce.Do(func() {
+		t.sub.Close()
+		select {
+		case <-t.runDone:
+		case <-time.After(time.Second):
+		}
+	})
+	return nil
+}

--- a/internal/trunking/grant_tracker_test.go
+++ b/internal/trunking/grant_tracker_test.go
@@ -1,0 +1,176 @@
+package trunking
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// waitForGrantLen spins until the tracker has recorded want entries or the
+// deadline passes.
+func waitForGrantLen(t *testing.T, tr *GrantTracker, want int) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if tr.Len() == want {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for grant log len %d (have %d)", want, tr.Len())
+}
+
+func startGrantTracker(t *testing.T, opts GrantTrackerOptions) *GrantTracker {
+	t.Helper()
+	tr, err := NewGrantTracker(opts)
+	if err != nil {
+		t.Fatalf("NewGrantTracker: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go tr.Run(ctx)
+	t.Cleanup(func() { cancel(); tr.Close() })
+	return tr
+}
+
+// TestGrantTrackerLogsSourceRID is the issue #915 guard for fix #2: a grant
+// carrying a source RID off the control channel is retained and surfaced with
+// that RID intact, so a consumer can read it off /api/v1/grants the way
+// SDRtrunk's grant log does.
+func TestGrantTrackerLogsSourceRID(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	tr := startGrantTracker(t, GrantTrackerOptions{Bus: bus})
+
+	bus.Publish(events.Event{Kind: events.KindGrant, Payload: Grant{
+		System: "MMR", Protocol: "p25", GroupID: 20001, SourceID: 202419,
+		FrequencyHz: 422612500, Encrypted: true,
+	}})
+	waitForGrantLen(t, tr, 1)
+
+	snap := tr.Snapshot(0)
+	if len(snap) != 1 {
+		t.Fatalf("snapshot len = %d, want 1", len(snap))
+	}
+	g := snap[0]
+	if g.SourceID != 202419 || g.GroupID != 20001 || g.FrequencyHz != 422612500 {
+		t.Fatalf("grant fields wrong: %+v", g)
+	}
+	if !g.Encrypted {
+		t.Error("encrypted flag lost — must carry through to the grant log")
+	}
+	if g.At.IsZero() {
+		t.Error("grant log entry has no timestamp")
+	}
+}
+
+// TestGrantTrackerLogsSourcelessGrant confirms the log is coverage-truthful:
+// a grant whose TSBK carried src=0 is retained as src=0, not dropped or
+// backfilled — the log records what the control channel actually decoded.
+func TestGrantTrackerLogsSourcelessGrant(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	tr := startGrantTracker(t, GrantTrackerOptions{Bus: bus})
+
+	bus.Publish(events.Event{Kind: events.KindGrant, Payload: Grant{
+		System: "MMR", Protocol: "p25", GroupID: 20001, SourceID: 0, FrequencyHz: 1,
+	}})
+	waitForGrantLen(t, tr, 1)
+	if snap := tr.Snapshot(0); len(snap) != 1 || snap[0].SourceID != 0 {
+		t.Fatalf("source-less grant not logged as src=0: %+v", snap)
+	}
+}
+
+// TestGrantTrackerNewestFirst checks ordering: the most recent grant leads.
+func TestGrantTrackerNewestFirst(t *testing.T) {
+	bus := events.NewBus(64)
+	defer bus.Close()
+	tr := startGrantTracker(t, GrantTrackerOptions{Bus: bus})
+
+	for i := uint32(1); i <= 5; i++ {
+		bus.Publish(events.Event{Kind: events.KindGrant, Payload: Grant{
+			System: "S", Protocol: "p25", GroupID: 100, SourceID: i, FrequencyHz: 1,
+		}})
+	}
+	waitForGrantLen(t, tr, 5)
+
+	snap := tr.Snapshot(0)
+	if len(snap) != 5 {
+		t.Fatalf("len = %d, want 5", len(snap))
+	}
+	// Newest (SourceID 5) first, oldest (1) last.
+	for i, want := range []uint32{5, 4, 3, 2, 1} {
+		if snap[i].SourceID != want {
+			t.Fatalf("snap[%d].SourceID = %d, want %d (order: %+v)", i, snap[i].SourceID, want, sourceIDs(snap))
+		}
+	}
+
+	// A limit returns only the newest N.
+	if lim := tr.Snapshot(2); len(lim) != 2 || lim[0].SourceID != 5 || lim[1].SourceID != 4 {
+		t.Fatalf("Snapshot(2) = %+v, want newest two [5 4]", sourceIDs(lim))
+	}
+}
+
+// TestGrantTrackerRingEviction confirms the fixed-capacity ring drops the
+// oldest grants and never grows past Capacity.
+func TestGrantTrackerRingEviction(t *testing.T) {
+	bus := events.NewBus(64)
+	defer bus.Close()
+	tr := startGrantTracker(t, GrantTrackerOptions{Bus: bus, Capacity: 3})
+
+	for i := uint32(1); i <= 7; i++ {
+		bus.Publish(events.Event{Kind: events.KindGrant, Payload: Grant{
+			System: "S", Protocol: "p25", GroupID: 1, SourceID: i, FrequencyHz: 1,
+		}})
+	}
+	// Wait until all 7 are observed; the ring holds only the last 3.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) && tr.Observed() < 7 {
+		time.Sleep(2 * time.Millisecond)
+	}
+	if tr.Observed() != 7 {
+		t.Fatalf("observed = %d, want 7", tr.Observed())
+	}
+	if tr.Len() != 3 {
+		t.Fatalf("ring len = %d, want 3 (capacity)", tr.Len())
+	}
+	snap := tr.Snapshot(0)
+	for i, want := range []uint32{7, 6, 5} {
+		if snap[i].SourceID != want {
+			t.Fatalf("after eviction snap[%d] = %d, want %d (%+v)", i, snap[i].SourceID, want, sourceIDs(snap))
+		}
+	}
+}
+
+// TestGrantTrackerIgnoresNonGrant confirms only KindGrant is logged.
+func TestGrantTrackerIgnoresNonGrant(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	tr := startGrantTracker(t, GrantTrackerOptions{Bus: bus})
+
+	bus.Publish(events.Event{Kind: events.KindAffiliation, Payload: Affiliation{
+		System: "S", SourceID: 1, GroupID: 2, Response: AffiliationAccepted,
+	}})
+	bus.Publish(events.Event{Kind: events.KindGrant, Payload: Grant{
+		System: "S", Protocol: "p25", GroupID: 2, SourceID: 9, FrequencyHz: 1,
+	}})
+	waitForGrantLen(t, tr, 1)
+	if snap := tr.Snapshot(0); len(snap) != 1 || snap[0].SourceID != 9 {
+		t.Fatalf("only the grant should be logged, got %+v", sourceIDs(snap))
+	}
+}
+
+func TestNewGrantTrackerRequiresBus(t *testing.T) {
+	if _, err := NewGrantTracker(GrantTrackerOptions{}); err == nil {
+		t.Fatal("expected error when Bus is nil")
+	}
+}
+
+func sourceIDs(gs []Grant) []uint32 {
+	out := make([]uint32, len(gs))
+	for i, g := range gs {
+		out[i] = g.SourceID
+	}
+	return out
+}


### PR DESCRIPTION
Expose the voice-channel grants decoded off the control channel as a
pollable, most-recent-first snapshot at GET /api/v1/grants — the pull
form of the `grant` SSE event stream. A telemetry consumer can now read
the source RID (plus talkgroup, frequency, channel, site and encryption)
straight off the GRP_VCH_GRANT the way SDRtrunk's control-channel grant
log exposes it, without holding an SSE connection.

This is fix #2 from issue #915 — the reporter's alternative to
backfilling the completed-call webhook's source_rid. The grant carries
the source at call-setup for every protocol, so this surfaces the grants
GT decodes off the CC even when the Phase 2 traffic-channel voice-side
source decode doesn't land. It complements, and does not replace, the
still-open Phase 2 receiver-sensitivity work.

- trunking.GrantTracker: bounded ring buffer (always on) fed by
  KindGrant; Snapshot(limit) returns newest-first. Grants are logged as
  decoded with no source backfill, so a src=0 grant stays src=0 —
  coverage-truthful.
- api: GrantsProvider + GET /api/v1/grants (handleGrants), reusing the
  stable GrantDTO the SSE stream already emits plus a per-row `at`
  timestamp; ?limit= and ?system= narrow the result.
- daemon: construct / run / close the tracker and wire it to the REST
  server, alongside the affiliation and site trackers.

Refs #915

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016dZ5HHyw1ZiArqrdAEwRjR