### PR TITLE
tetra: soft-decision TCH/S decode to fix short/garbled same-carrier voice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,6 +208,18 @@ for tagged releases.
   rather than a fixed slot 1 — the building block for issue #925.
 
 ### Fixed
+- **TETRA voice recordings on a same-carrier site came out short and garbled
+  (low `audio_pct`).** The TCH/S traffic decoder was hard-decision while the
+  control channel already ran soft-decision, so on a marginal same-carrier
+  signal ~70% of a call's own speech bursts failed the class-2 CRC and were
+  dropped; the recorder concatenates only the surviving bursts, so the audio
+  played back choppy/robotic (the `recording shorter than call span` diagnostic
+  showed `audio_pct` ≈ 30%). The TCH/S channel decode now uses the receiver's
+  per-symbol soft (log-likelihood) information — a soft-input rate-1/3 Viterbi
+  mother decoder with soft depuncture and descramble, mirroring the existing
+  soft SCH path — recovering the ~2 dB of coding gain the hard path threw away.
+  Bursts with no soft info still fall back to the hard decoder, so the change is
+  never worse than before.
 - **TETRA group calls could land on the wrong talkgroup with starved audio when
   the first grant was a notification.** On a same-carrier site a group call's
   first control-channel grant is often a notification / a D-CONNECT addressed to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,9 +77,15 @@ confirmation before any close-as-completed.
   `typedef long` is 64-bit and every saturating op returns garbage. Lessons that
   cost time: the class-2 CRC is a fixed parity-check matrix (the reference's
   `TAB_CRC` tables), **not** a `G(X)` LFSR — the wrong CRC silently dropped every
-  on-air burst while synthetic round-trips passed (self-consistent bug); TCH/S is
-  hard-decision while the control SCH path is soft-decision; and the SB anchors
-  the slot grid one NDB-slot before its frame's TN1 traffic
-  (`ndbSBSlotShift` in `traffic.go`). When "voice doesn't decode" but the vocoder
+  on-air burst while synthetic round-trips passed (self-consistent bug); and the
+  SB anchors the slot grid one NDB-slot before its frame's TN1 traffic
+  (`ndbSBSlotShift` in `traffic.go`). TCH/S now decodes **soft-decision** like the
+  control SCH path (the receiver's `SoftSink` differentials → `softType5FromDiffs`
+  → soft depuncture/Viterbi in `framing.DecodeRCPCTetraMotherSoft` →
+  `tetra.DecodeTCHSSoft`); it was hard-decision until then, which failed ~70% of a
+  marginal same-carrier call's bursts and produced short/garbled recordings. The
+  traffic extractor carries the per-burst soft LLRs parallel to its dibit buffer
+  (`TrafficExtractor.StashSoft`), and the composer falls back to the hard
+  `TCHSpeechFrames` when no soft info is present. When "voice doesn't decode" but the vocoder
   unit tests pass, suspect the channel coding (CRC / interleave / reorder), not
   the vocoder — validate the whole chain against the reference, not just parts.

--- a/cmd/gophertrunk/tetra_multislot_replay_test.go
+++ b/cmd/gophertrunk/tetra_multislot_replay_test.go
@@ -81,7 +81,7 @@ func TestTETRAMultiSlotReplay(t *testing.T) {
 
 	var totalBursts, anchoredBursts, trafficMarked, trafficMarkedCRC int
 	errsHist := map[string]int{}
-	extractor := tetra.NewTrafficExtractor(colourExt, func(frame []byte, slot, mark uint8) {
+	extractor := tetra.NewTrafficExtractor(colourExt, func(frame []byte, _ []float32, slot, mark uint8) {
 		totalBursts++
 		if slot != 0 {
 			anchoredBursts++

--- a/internal/radio/framing/soft_tetra.go
+++ b/internal/radio/framing/soft_tetra.go
@@ -66,6 +66,94 @@ func DepunctureRCPCTetraSigSoft(punctured []float32, puncture []int, motherLen i
 	return out
 }
 
+// DepunctureRCPCTetraSoft is the soft-LLR analog of DepunctureRCPCTetra
+// (the rate-1/3 TCH mother code): it allocates a motherLen LLR buffer,
+// leaves punctured positions at 0 (a soft erasure — no information, zero
+// branch-metric contribution in the Viterbi), and copies received LLRs at
+// the puncture-map positions. Same (period, puncture) index map as the hard
+// version, but the erasure is 0.0 rather than the hard DepunctureMark
+// sentinel — DecodeRCPCTetraMotherSoft reads the value directly.
+func DepunctureRCPCTetraSoft(punctured []float32, period int, puncture []int, motherLen int) []float32 {
+	t := len(puncture)
+	out := make([]float32, motherLen) // zero-valued = erasure
+	for j := 1; j <= len(punctured); j++ {
+		blockIdx := (j - 1) / t
+		offset := j - t*blockIdx
+		k := period*blockIdx + puncture[offset-1]
+		if k-1 < motherLen {
+			out[k-1] = punctured[j-1]
+		}
+	}
+	return out
+}
+
+// DecodeRCPCTetraMotherSoft is the soft-decision analog of
+// DecodeRCPCTetraMother: the same 16-state K=5 rate-1/3 TCH mother-code
+// trellis (three outputs per stage, polynomials g1=in^d1^d2^d3^d4,
+// g2=in^d1^d3^d4, g3=in^d2^d4 — see EncodeRCPCTetraMother), with the hard
+// Hamming branch metric replaced by the soft correlation cost. For an
+// expected mother bit g and received LLR L, the branch cost is L·(2g-1): a
+// match lowers the path metric, a mismatch raises it, and an erasure (L=0)
+// contributes nothing. The minimum-cost path is the maximum-likelihood
+// sequence. Returns the recovered stages-bit input plus the surviving path
+// metric. The survivor is forced to state 0 (the encoder is flushed with the
+// K-1=4 zero tail bits).
+func DecodeRCPCTetraMotherSoft(channel []float32, stages int) ([]byte, float32) {
+	const numStates = 16
+	const inf = float32(1e30)
+	pm := make([]float32, numStates)
+	for i := range pm {
+		pm[i] = inf
+	}
+	pm[0] = 0
+	trace := make([][numStates]uint8, stages)
+
+	for s := 0; s < stages; s++ {
+		var npm [numStates]float32
+		for i := range npm {
+			npm[i] = inf
+		}
+		rxG1 := channel[3*s]
+		rxG2 := channel[3*s+1]
+		rxG3 := channel[3*s+2]
+		for cur := 0; cur < numStates; cur++ {
+			if pm[cur] >= inf {
+				continue
+			}
+			d1 := (cur >> 3) & 1
+			d2 := (cur >> 2) & 1
+			d3 := (cur >> 1) & 1
+			d4 := cur & 1
+			for input := 0; input < 2; input++ {
+				g1 := (input ^ d1 ^ d2 ^ d3 ^ d4) & 1
+				g2 := (input ^ d1 ^ d3 ^ d4) & 1
+				g3 := (input ^ d2 ^ d4) & 1
+				cost := pm[cur]
+				cost += rxG1 * float32(2*g1-1)
+				cost += rxG2 * float32(2*g2-1)
+				cost += rxG3 * float32(2*g3-1)
+				next := (input << 3) | (d1 << 2) | (d2 << 1) | d3
+				if cost < npm[next] {
+					npm[next] = cost
+					trace[s][next] = uint8((cur << 1) | input)
+				}
+			}
+		}
+		copy(pm, npm[:])
+	}
+
+	final := 0
+	metric := pm[final]
+	out := make([]byte, stages)
+	state := final
+	for s := stages - 1; s >= 0; s-- {
+		entry := trace[s][state]
+		out[s] = entry & 1
+		state = int(entry >> 1)
+	}
+	return out, metric
+}
+
 // DecodeRCPCTetraSigMotherSoft is the soft-decision analog of
 // DecodeRCPCTetraSigMother: the same 16-state K=5 R=1/4 mother-code
 // trellis, with the hard Hamming branch metric replaced by the soft

--- a/internal/radio/framing/soft_tetra_tch_test.go
+++ b/internal/radio/framing/soft_tetra_tch_test.go
@@ -1,0 +1,100 @@
+package framing
+
+import (
+	"math/rand"
+	"testing"
+)
+
+// bitsToLLR maps hard bits to ideal soft LLRs under the package convention
+// LLR > 0 ⇒ bit 0, LLR < 0 ⇒ bit 1.
+func bitsToLLR(bits []byte) []float32 {
+	out := make([]float32, len(bits))
+	for i, b := range bits {
+		if b&1 == 0 {
+			out[i] = 1
+		} else {
+			out[i] = -1
+		}
+	}
+	return out
+}
+
+// TestDecodeRCPCTetraMotherSoftMatchesHard: on a clean channel the soft
+// rate-1/3 TCH mother decoder recovers the same information bits as the hard
+// decoder, and a single flipped soft bit is still corrected (K=5 free distance
+// 12). This pins the soft trellis (3 outputs/stage, TCH polynomials) as a
+// faithful mirror of DecodeRCPCTetraMother.
+func TestDecodeRCPCTetraMotherSoftMatchesHard(t *testing.T) {
+	rng := rand.New(rand.NewSource(11))
+	for trial := 0; trial < 20; trial++ {
+		info := make([]byte, 40)
+		for i := range info {
+			info[i] = byte(rng.Intn(2))
+		}
+		stages := len(info) + 4 // K-1 tail bits
+		in := make([]byte, stages)
+		copy(in, info)
+		channel := EncodeRCPCTetraMother(in)
+
+		soft := bitsToLLR(channel)
+		out, _ := DecodeRCPCTetraMotherSoft(soft, stages)
+		for i, want := range in {
+			if out[i] != want {
+				t.Fatalf("trial %d clean: bit %d = %d, want %d", trial, i, out[i], want)
+			}
+		}
+		// One corrupted soft bit (sign flip) must still be corrected.
+		soft[7] = -soft[7]
+		out2, _ := DecodeRCPCTetraMotherSoft(soft, stages)
+		for i, want := range in {
+			if out2[i] != want {
+				t.Fatalf("trial %d 1-error: bit %d = %d, want %d", trial, i, out2[i], want)
+			}
+		}
+	}
+}
+
+// TestDepunctureRCPCTetraSoftMirrorsHard: the soft depuncture places received
+// LLRs at exactly the same mother-code positions the hard DepunctureRCPCTetra
+// writes bits to, and leaves every punctured position at the 0.0 soft erasure
+// (never the hard DepunctureMark). Checked for both TCH puncture schemes.
+func TestDepunctureRCPCTetraSoftMirrorsHard(t *testing.T) {
+	cases := []struct {
+		name      string
+		coded     int
+		period    int
+		puncture  []int
+		motherLen int
+	}{
+		{"rate23-class1", 168, RCPCTetraPeriod23, RCPCTetraPuncture23, 3 * 112},
+		{"rate818-class2", 162, RCPCTetraPeriod818, RCPCTetraPuncture818, 3 * (60 + 8 + 4)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			hardIn := make([]byte, tc.coded)
+			softIn := make([]float32, tc.coded)
+			for i := range hardIn {
+				hardIn[i] = byte((i % 2) ^ 1) // arbitrary 0/1 pattern
+				softIn[i] = bitsToLLR(hardIn[i : i+1])[0]
+			}
+			hard := DepunctureRCPCTetra(hardIn, tc.period, tc.puncture, tc.motherLen)
+			soft := DepunctureRCPCTetraSoft(softIn, tc.period, tc.puncture, tc.motherLen)
+			if len(soft) != len(hard) {
+				t.Fatalf("length mismatch: soft=%d hard=%d", len(soft), len(hard))
+			}
+			for i := range hard {
+				if hard[i] == DepunctureMark {
+					if soft[i] != 0 {
+						t.Errorf("pos %d: punctured, soft=%v want 0.0 erasure", i, soft[i])
+					}
+					continue
+				}
+				// A carried position: soft sign must agree with the hard bit.
+				wantNeg := hard[i] == 1
+				if (soft[i] < 0) != wantNeg {
+					t.Errorf("pos %d: hard bit %d but soft LLR %v", i, hard[i], soft[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/radio/tetra/tch.go
+++ b/internal/radio/tetra/tch.go
@@ -90,6 +90,18 @@ func tchDeinterleave(type4 []byte) []byte {
 	return out
 }
 
+// tchDeinterleaveSoft is the soft-LLR twin of tchDeinterleave: the identical
+// 24×18 inverse permutation applied to per-bit LLRs instead of hard bits.
+func tchDeinterleaveSoft(type4 []float32) []float32 {
+	out := make([]float32, tchType3Bits)
+	for i := 0; i < 18; i++ {
+		for j := 0; j < 24; j++ {
+			out[j*18+i] = type4[i*24+j]
+		}
+	}
+	return out
+}
+
 // EncodeTCHS codes two 137-bit speech frames (bit-per-byte) into a 54-byte
 // packed type-4 (descrambled type-5) traffic frame. Mirrors DecodeTCHS for the
 // round-trip test; not used in the live receive path.
@@ -172,4 +184,80 @@ func DecodeTCHS(frame []byte) (frameA, frameB []byte, crcOK bool, errs int, ok b
 		}
 	}
 	return frameA, frameB, crcOK, metric, true
+}
+
+// TCHSpeechFramesSoft is the soft-decision analog of TCHSpeechFrames: it
+// decodes one already-descrambled 432-LLR type-5 stream and, if the class-2
+// CRC verifies, returns the two 137-bit speech frames packed MSB-first (18
+// bytes each) ready for the ACELP vocoder. A frame that fails the CRC returns
+// nil, exactly like the hard gate. The soft Viterbi corrects several more bit
+// errors than the hard-decision path (the ~2 dB coding gain), so a real TCH/S
+// burst that the hard decoder drops on a marginal same-carrier signal is
+// recovered here — the fix for the short/garbled same-carrier recordings.
+// Convention (framing/soft_tetra.go): LLR > 0 ⇒ bit 0, magnitude = reliability.
+func TCHSpeechFramesSoft(type5LLR []float32) [][]byte {
+	frameA, frameB, crcOK, _, ok := DecodeTCHSSoft(type5LLR)
+	if !ok || !crcOK {
+		return nil
+	}
+	return [][]byte{framing.PackBitsMSB(frameA), framing.PackBitsMSB(frameB)}
+}
+
+// DecodeTCHSSoft is the soft-decision analog of DecodeTCHS. It mirrors the hard
+// chain step for step in the LLR domain: soft deinterleave → split
+// class0(LLR)/class-1/class-2 coded regions → soft depuncture each region into
+// the K=5 rate-1/3 mother stream (erasure = 0.0) → soft Viterbi
+// (DecodeRCPCTetraMotherSoft) → hard class-2 CRC check. class0 is uncoded, so
+// its LLRs are hard-sliced straight through. type5LLR is the already-descrambled
+// 432-LLR type-5 stream (the traffic extractor descrambles in the soft domain
+// with DescrambleTetraSoft, mirroring the hard DescrambleTetra). errs is the
+// surviving soft path metric (lower is a better fit), not a bit-error count.
+func DecodeTCHSSoft(type5LLR []float32) (frameA, frameB []byte, crcOK bool, errs float32, ok bool) {
+	if len(type5LLR) < tchType3Bits {
+		return nil, nil, false, 0, false
+	}
+	type3 := tchDeinterleaveSoft(type5LLR[:tchType3Bits])
+
+	class0 := type3[:tchClass0Bits]
+	c1 := type3[tchClass0Bits : tchClass0Bits+tchClass1Coded]
+	c2 := type3[tchClass0Bits+tchClass1Coded:]
+
+	m1 := framing.DepunctureRCPCTetraSoft(c1, framing.RCPCTetraPeriod23, framing.RCPCTetraPuncture23, 3*tchClass1Bits)
+	m2 := framing.DepunctureRCPCTetraSoft(c2, framing.RCPCTetraPeriod818, framing.RCPCTetraPuncture818, 3*(tchClass2Bits+tchCRCBits+tchTailBits))
+	mother := append(append([]float32{}, m1...), m2...)
+
+	conv, metric := framing.DecodeRCPCTetraMotherSoft(mother, tchConvIn)
+	class1 := conv[:tchClass1Bits]
+	class2 := conv[tchClass1Bits : tchClass1Bits+tchClass2Bits]
+	crc := conv[tchClass1Bits+tchClass2Bits : tchClass1Bits+tchClass2Bits+tchCRCBits]
+
+	type2 := make([]byte, 0, tchType2SpeechN)
+	type2 = append(type2, hardSliceLLR(class0)...)
+	type2 = append(type2, class1...)
+	type2 = append(type2, class2...)
+	frameA, frameB = type2ToSpeech(type2)
+
+	crcOK = true
+	want := crcTCHClass2(class2)
+	for i := range want {
+		if want[i] != (crc[i] & 1) {
+			crcOK = false
+			break
+		}
+	}
+	return frameA, frameB, crcOK, metric, true
+}
+
+// hardSliceLLR hard-decides an LLR stream into bit-per-byte bits under the
+// soft convention LLR > 0 ⇒ bit 0, LLR < 0 ⇒ bit 1 (an exact 0 erasure decides
+// bit 0). Used for the uncoded class-0 bits, which carry no FEC and so are read
+// directly off their soft values.
+func hardSliceLLR(llr []float32) []byte {
+	out := make([]byte, len(llr))
+	for i, v := range llr {
+		if v < 0 {
+			out[i] = 1
+		}
+	}
+	return out
 }

--- a/internal/radio/tetra/tch_test.go
+++ b/internal/radio/tetra/tch_test.go
@@ -57,6 +57,84 @@ func TestTCHSCorrectsSingleError(t *testing.T) {
 	}
 }
 
+// TestTCHSSoftRoundTrip proves the soft-decision TCH/S decoder recovers both
+// speech frames from a clean (noise-free) ideal-LLR type-5 stream, matching the
+// hard decoder bit-for-bit — the soft chain is a faithful mirror of the hard one.
+func TestTCHSSoftRoundTrip(t *testing.T) {
+	rng := rand.New(rand.NewSource(3))
+	for trial := 0; trial < 50; trial++ {
+		a := randBits(rng, tchSpeechFrameBits)
+		b := randBits(rng, tchSpeechFrameBits)
+		bits := framing.UnpackBitsMSB(EncodeTCHS(a, b), tchType3Bits)
+		gotA, gotB, crcOK, _, ok := DecodeTCHSSoft(idealLLR(bits, 1))
+		if !ok || !crcOK {
+			t.Fatalf("trial %d: soft decode failed on a clean frame (ok=%v crc=%v)", trial, ok, crcOK)
+		}
+		if !bitsEqual(gotA, a) || !bitsEqual(gotB, b) {
+			t.Errorf("trial %d: soft path did not recover the speech frames", trial)
+		}
+	}
+}
+
+// TestTCHSSoftCodingGain is the regression that ties the fix to the reported
+// symptom. On the SAME noisy channel, the soft-decision decoder passes the
+// class-2 CRC on far more bursts than the hard-decision decoder — the ~2 dB
+// coding gain the control channel already enjoyed but TCH/S did not. That gap is
+// why ~70% of a same-carrier call's own bursts failed CRC and the recordings
+// came out short/garbled (audio_pct ≈ 32%). Fails before the soft path exists.
+func TestTCHSSoftCodingGain(t *testing.T) {
+	rng := rand.New(rand.NewSource(20260729))
+	const trials = 300
+	const sigma = 1.0 // AWGN std-dev on unit-amplitude BPSK soft samples
+	var hardPass, softPass int
+	for i := 0; i < trials; i++ {
+		a := randBits(rng, tchSpeechFrameBits)
+		b := randBits(rng, tchSpeechFrameBits)
+		bits := framing.UnpackBitsMSB(EncodeTCHS(a, b), tchType3Bits)
+		llr := noisyLLR(rng, bits, sigma)
+		hard := make([]byte, len(llr))
+		for j, v := range llr {
+			if v < 0 {
+				hard[j] = 1
+			}
+		}
+		if len(TCHSpeechFrames(framing.PackBitsMSB(hard))) == 2 {
+			hardPass++
+		}
+		if len(TCHSpeechFramesSoft(llr)) == 2 {
+			softPass++
+		}
+	}
+	t.Logf("sigma=%.2f: hardPass=%d/%d softPass=%d/%d", sigma, hardPass, trials, softPass, trials)
+	if softPass < 2*hardPass {
+		t.Fatalf("soft coding gain too small: soft=%d hard=%d of %d (want soft >= 2x hard)", softPass, hardPass, trials)
+	}
+}
+
+func idealLLR(bits []byte, amp float32) []float32 {
+	out := make([]float32, len(bits))
+	for i, b := range bits {
+		if b&1 == 0 {
+			out[i] = amp
+		} else {
+			out[i] = -amp
+		}
+	}
+	return out
+}
+
+func noisyLLR(rng *rand.Rand, bits []byte, sigma float64) []float32 {
+	out := make([]float32, len(bits))
+	for i, b := range bits {
+		mean := 1.0
+		if b&1 == 1 {
+			mean = -1.0
+		}
+		out[i] = float32(mean + rng.NormFloat64()*sigma)
+	}
+	return out
+}
+
 func randBits(rng *rand.Rand, n int) []byte {
 	out := make([]byte, n)
 	for i := range out {

--- a/internal/radio/tetra/traffic.go
+++ b/internal/radio/tetra/traffic.go
@@ -90,7 +90,17 @@ type TrafficExtractor struct {
 	bufBase    int
 	pending    []int // training-sequence leading indices awaiting look-ahead
 	colourCode uint32
-	onBurst    func(frame []byte, slot, usage uint8)
+	onBurst    func(frame []byte, softType5 []float32, slot, usage uint8)
+
+	// softBuf holds the per-dibit complex differentials (the receiver's soft
+	// info) strictly parallel to buf, so emit can build a soft-decision type-5
+	// LLR stream for the burst. It is either empty (no soft data supplied — the
+	// hard-only path used by tests and any caller that never StashSofts) or
+	// exactly len(buf). pendingSoft carries the differentials stashed for the
+	// NEXT Process call (StashSoft), keyed by pendingSoftBase and consumed once.
+	softBuf         []complex64
+	pendingSoft     []complex64
+	pendingSoftBase int
 
 	// sbAnchor is the absolute dibit index of the most recent SB
 	// synchronisation-training-sequence leading dibit (TN1), pinning the
@@ -100,17 +110,19 @@ type TrafficExtractor struct {
 }
 
 // NewTrafficExtractor returns an extractor that calls onBurst with each
-// recovered 54-byte traffic frame, its TDMA timeslot (1..4, or 0 when the slot
-// grid is not yet anchored to a synchronisation burst), and the burst's AACH
-// downlink usage marker (§21.4.7; the per-slot call identifier, >= DLUsageTraffic
-// for a traffic slot, 0 when the AACH did not decode or the slot is not traffic).
+// recovered 54-byte traffic frame, the burst's soft-decision type-5 stream
+// (432 descrambled LLRs, or nil when no soft info was stashed — see StashSoft),
+// its TDMA timeslot (1..4, or 0 when the slot grid is not yet anchored to a
+// synchronisation burst), and the burst's AACH downlink usage marker (§21.4.7;
+// the per-slot call identifier, >= DLUsageTraffic for a traffic slot, 0 when the
+// AACH did not decode or the slot is not traffic).
 // When colourCode is non-zero the frame is descrambled with the cell's extended
 // colour code (learned from the control channel's BSCH) before onBurst, so the
 // sidecar holds descrambled type-5 — the input the TCH/S channel decoder expects.
 // The usage marker is what lets a per-call voice chain demultiplex concurrent
 // same-carrier calls reliably (the channel-allocation timeslot field does not map
 // to the physical slot on real air). onBurst must not retain the slice.
-func NewTrafficExtractor(colourCode uint32, onBurst func(frame []byte, slot, usage uint8)) *TrafficExtractor {
+func NewTrafficExtractor(colourCode uint32, onBurst func(frame []byte, softType5 []float32, slot, usage uint8)) *TrafficExtractor {
 	te := &TrafficExtractor{colourCode: colourCode, onBurst: onBurst}
 	// π/4-DQPSK leaves a constant 0..3 dibit rotation (residual CFO), so
 	// correlate the training sequence under all four rotations of the
@@ -137,6 +149,19 @@ func (te *TrafficExtractor) Process(dibits []uint8, baseIdx int) {
 	if len(te.buf) == 0 {
 		te.bufBase = baseIdx
 	}
+	// Keep softBuf strictly parallel to buf. Append the stashed differentials
+	// only when they match this dibit block (same base + length) AND softBuf is
+	// already in lockstep with buf; otherwise drop the soft path (reset to empty)
+	// rather than risk a misalignment — the burst then decodes hard-only. In the
+	// live path SoftSink stashes every call, so softBuf tracks buf from the first
+	// call and stays parallel; tests never stash, so it stays empty (hard-only).
+	if te.pendingSoft != nil && te.pendingSoftBase == baseIdx &&
+		len(te.pendingSoft) == len(dibits) && len(te.softBuf) == len(te.buf) {
+		te.softBuf = append(te.softBuf, te.pendingSoft...)
+	} else {
+		te.softBuf = te.softBuf[:0]
+	}
+	te.pendingSoft = nil
 	te.buf = append(te.buf, dibits...)
 
 	// Anchor the slot grid on the synchronisation burst. The SB's STS is
@@ -198,8 +223,26 @@ func (te *TrafficExtractor) Process(dibits []uint8, baseIdx int) {
 			drop = len(te.buf)
 		}
 		te.buf = append(te.buf[:0], te.buf[drop:]...)
+		// Trim softBuf by the same amount to keep it parallel; if it is not in
+		// lockstep (empty / short), drop the soft path rather than misalign.
+		if len(te.softBuf) >= drop {
+			te.softBuf = append(te.softBuf[:0], te.softBuf[drop:]...)
+		} else {
+			te.softBuf = te.softBuf[:0]
+		}
 		te.bufBase += drop
 	}
+}
+
+// StashSoft hands the extractor the per-dibit complex differentials (the
+// receiver's SoftSink output) for the dibits the NEXT Process call will
+// deliver, keyed by the same baseIdx. It lets the traffic path carry soft
+// (LLR) information for soft-decision TCH/S decoding without changing the hard
+// DibitSink contract — the same stash bridge the control channel uses. A caller
+// that never StashSofts leaves the extractor hard-only.
+func (te *TrafficExtractor) StashSoft(diffs []complex64, baseIdx int) {
+	te.pendingSoft = diffs
+	te.pendingSoftBase = baseIdx
 }
 
 // emit slices BKN1 and BKN2 around the training sequence leading at L and
@@ -217,7 +260,40 @@ func (te *TrafficExtractor) emit(L int) {
 	if te.colourCode != 0 {
 		bits = framing.DescrambleTetra(bits, te.colourCode)
 	}
-	te.onBurst(framing.PackBitsMSB(bits), te.slotOf(L), te.usageOf(L))
+	te.onBurst(framing.PackBitsMSB(bits), te.softFrame(L), te.slotOf(L), te.usageOf(L))
+}
+
+// softFrame builds the descrambled 432-LLR type-5 stream for the burst leading
+// at L from the parallel soft buffer, mirroring emit's hard BKN1+BKN2 slicing,
+// or nil when soft info is unavailable for this burst (hard-only fallback). The
+// receiver's AFC locks the constellation to rotation 0 (the same assumption the
+// hard BKN descramble relies on), so softType5FromDiffs is called with rot 0;
+// its hard-slice equals the emitted hard bits, and DescrambleTetraSoft applies
+// the same colour-code sign flips the hard DescrambleTetra does.
+func (te *TrafficExtractor) softFrame(L int) []float32 {
+	if len(te.softBuf) != len(te.buf) {
+		return nil
+	}
+	block := func(off int) []complex64 {
+		s := L + off - te.bufBase
+		if s < 0 || s+ndbBlockDibits > len(te.softBuf) {
+			return nil
+		}
+		return te.softBuf[s : s+ndbBlockDibits]
+	}
+	b1 := block(ndbBKN1Start)
+	b2 := block(ndbBKN2Start)
+	if b1 == nil || b2 == nil {
+		return nil
+	}
+	diffs := make([]complex64, 0, TrafficFrameDibits)
+	diffs = append(diffs, b1...)
+	diffs = append(diffs, b2...)
+	llr := softType5FromDiffs(diffs, 0)
+	if te.colourCode != 0 {
+		llr = framing.DescrambleTetraSoft(llr, te.colourCode)
+	}
+	return llr
 }
 
 // usageOf recovers the AACH downlink usage marker of the burst leading at L. The

--- a/internal/radio/tetra/traffic_test.go
+++ b/internal/radio/tetra/traffic_test.go
@@ -39,7 +39,7 @@ func TestTrafficExtractorSingleBurst(t *testing.T) {
 	buildNCDB(stream, L, bkn1, bkn2)
 
 	var frames [][]byte
-	te := NewTrafficExtractor(0, func(f []byte, _, _ uint8) {
+	te := NewTrafficExtractor(0, func(f []byte, _ []float32, _, _ uint8) {
 		frames = append(frames, append([]byte(nil), f...))
 	})
 	te.Process(stream, 0)
@@ -67,7 +67,7 @@ func TestTrafficExtractorDescrambles(t *testing.T) {
 
 	const colour = 262144876 // the reporter's cell (467.913 MHz)
 	var got []byte
-	te := NewTrafficExtractor(colour, func(f []byte, _, _ uint8) { got = append([]byte(nil), f...) })
+	te := NewTrafficExtractor(colour, func(f []byte, _ []float32, _, _ uint8) { got = append([]byte(nil), f...) })
 	te.Process(stream, 0)
 
 	rawBits := TetraDibitsToBits(append(append([]uint8{}, bkn1...), bkn2...))
@@ -88,7 +88,7 @@ func TestTrafficExtractorChunkedAcrossCalls(t *testing.T) {
 	buildNCDB(stream, L, bkn1, bkn2)
 
 	var frames [][]byte
-	te := NewTrafficExtractor(0, func(f []byte, _, _ uint8) {
+	te := NewTrafficExtractor(0, func(f []byte, _ []float32, _, _ uint8) {
 		frames = append(frames, append([]byte(nil), f...))
 	})
 	// Feed in small chunks so the training-sequence match, BKN1 look-back
@@ -118,7 +118,7 @@ func TestTrafficExtractorMultipleSlots(t *testing.T) {
 	buildNCDB(stream, 200+255, b1b, b2b)
 
 	var frames [][]byte
-	te := NewTrafficExtractor(0, func(f []byte, _, _ uint8) {
+	te := NewTrafficExtractor(0, func(f []byte, _ []float32, _, _ uint8) {
 		frames = append(frames, append([]byte(nil), f...))
 	})
 	te.Process(stream, 0)
@@ -163,7 +163,7 @@ func TestTrafficExtractorSlotTagging(t *testing.T) {
 	}
 
 	var slots []uint8
-	te := NewTrafficExtractor(0, func(_ []byte, slot, _ uint8) { slots = append(slots, slot) })
+	te := NewTrafficExtractor(0, func(_ []byte, _ []float32, slot, _ uint8) { slots = append(slots, slot) })
 	te.Process(stream, 0)
 
 	if len(slots) != len(ndbs) {
@@ -183,7 +183,7 @@ func TestTrafficExtractorSlotUnanchored(t *testing.T) {
 	stream := make([]uint8, 600)
 	buildNCDB(stream, 300, rampDibits(ndbBlockDibits, 0), rampDibits(ndbBlockDibits, 1))
 	var slots []uint8
-	te := NewTrafficExtractor(0, func(_ []byte, slot, _ uint8) { slots = append(slots, slot) })
+	te := NewTrafficExtractor(0, func(_ []byte, _ []float32, slot, _ uint8) { slots = append(slots, slot) })
 	te.Process(stream, 0)
 	if len(slots) != 1 || slots[0] != 0 {
 		t.Fatalf("unanchored slots=%v, want [0]", slots)
@@ -197,7 +197,7 @@ func TestTrafficExtractorNoFalseEmitOnNoise(t *testing.T) {
 		stream[i] = uint8((i*7 + 1) % 4) // deterministic non-sync filler
 	}
 	n := 0
-	te := NewTrafficExtractor(0, func(f []byte, _, _ uint8) { n++ })
+	te := NewTrafficExtractor(0, func(f []byte, _ []float32, _, _ uint8) { n++ })
 	te.Process(stream, 0)
 	// A rare chance correlation within tolerance is possible; assert it does
 	// not spuriously fire on structured filler.

--- a/internal/voice/composer/tetra_voice.go
+++ b/internal/voice/composer/tetra_voice.go
@@ -76,13 +76,14 @@ func (c *Composer) runTETRAVoiceChain(ctx context.Context, serial string, iqCh <
 
 	rs, _ := c.sink.(rawFrameSink)
 	var bursts, speech, offSlot atomic.Uint64
-	extractor := tetra.NewTrafficExtractor(colourExt, func(frame []byte, slot, usage uint8) {
-		c.onTETRATrafficBurst(bt, rs, serial, frame, usage, usageMarker, &bursts, &speech, &offSlot)
+	extractor := tetra.NewTrafficExtractor(colourExt, func(frame []byte, softType5 []float32, slot, usage uint8) {
+		c.onTETRATrafficBurst(bt, rs, serial, frame, softType5, usage, usageMarker, &bursts, &speech, &offSlot)
 	})
 
 	rx := tetrarx.New(tetrarx.Options{
 		SampleRateHz:        symbolHz,
 		DibitSink:           func(d []uint8, base int) { extractor.Process(d, base) },
+		SoftSink:            func(diffs []complex64, base int) { extractor.StashSoft(diffs, base) },
 		ClockMode:           tetrarx.ClockGardner,
 		GardnerGain:         0.005,
 		EnableAFC:           true,
@@ -152,7 +153,7 @@ func (c *Composer) runTETRAVoiceChain(ctx context.Context, serial string, iqCh <
 // behave like every other protocol — the call ends hangtime after its last
 // decoded speech frame (or via the no-voice startup timeout when a grant never
 // decodes any speech).
-func (c *Composer) onTETRATrafficBurst(bt *boundaryTracker, rs rawFrameSink, serial string, frame []byte, burstUsage, grantUsage uint8, bursts, speech, offSlot *atomic.Uint64) {
+func (c *Composer) onTETRATrafficBurst(bt *boundaryTracker, rs rawFrameSink, serial string, frame []byte, softType5 []float32, burstUsage, grantUsage uint8, bursts, speech, offSlot *atomic.Uint64) {
 	bursts.Add(1)
 	// Drop bursts that carry a different call's AACH usage marker. Only when both
 	// markers are known (>= DLUsageTraffic) — an unknown marker on either side
@@ -161,7 +162,7 @@ func (c *Composer) onTETRATrafficBurst(bt *boundaryTracker, rs rawFrameSink, ser
 		offSlot.Add(1)
 		return
 	}
-	c.decodeTETRASpeech(bt, rs, serial, frame, speech)
+	c.decodeTETRASpeech(bt, rs, serial, frame, softType5, speech)
 }
 
 // decodeTETRASpeech TCH/S-decodes one traffic frame for an owning call: it
@@ -170,8 +171,18 @@ func (c *Composer) onTETRATrafficBurst(bt *boundaryTracker, rs rawFrameSink, ser
 // `.raw` sidecar (the ACELP vocoder renders it to PCM downstream). A non-TCH/S
 // burst (signalling, encrypted, or corrupt) yields no frames and does not touch
 // liveness. Shared by the solo traffic tap and the same-carrier slot demux.
-func (c *Composer) decodeTETRASpeech(bt *boundaryTracker, rs rawFrameSink, serial string, frame []byte, speech *atomic.Uint64) {
-	frames := tetra.TCHSpeechFrames(frame)
+func (c *Composer) decodeTETRASpeech(bt *boundaryTracker, rs rawFrameSink, serial string, frame []byte, softType5 []float32, speech *atomic.Uint64) {
+	// Prefer soft-decision TCH/S when the extractor supplied the burst's LLRs:
+	// the soft Viterbi's ~2 dB coding gain recovers real speech bursts the
+	// hard-decision gate drops on a marginal same-carrier signal (the fix for
+	// the short/garbled recordings). Fall back to the hard gate when no soft
+	// info is available (never worse than before).
+	var frames [][]byte
+	if softType5 != nil {
+		frames = tetra.TCHSpeechFramesSoft(softType5)
+	} else {
+		frames = tetra.TCHSpeechFrames(frame)
+	}
 	if len(frames) == 0 {
 		// Not the granted call's speech — do NOT touch call liveness.
 		return
@@ -269,6 +280,7 @@ func (d *tetraSlotDemux) run(ctx context.Context, iqCh <-chan []complex64, iqHz 
 	rx := tetrarx.New(tetrarx.Options{
 		SampleRateHz:        symbolHz,
 		DibitSink:           func(di []uint8, base int) { extractor.Process(di, base) },
+		SoftSink:            func(diffs []complex64, base int) { extractor.StashSoft(diffs, base) },
 		ClockMode:           tetrarx.ClockGardner,
 		GardnerGain:         0.005,
 		EnableAFC:           true,
@@ -317,7 +329,7 @@ func (d *tetraSlotDemux) observe(iq []complex64) {
 // dropped too. When a marker has no owner but a wildcard call is waiting, the
 // oldest wildcard claims that marker. Runs on the single demux goroutine, so each
 // owner's boundary tracker has exactly one writer.
-func (d *tetraSlotDemux) onBurst(frame []byte, slot, usage uint8) {
+func (d *tetraSlotDemux) onBurst(frame []byte, softType5 []float32, slot, usage uint8) {
 	// A burst whose AACH did not decode (usage 0) or is a control slot
 	// (< DLUsageTraffic) carries no routable marker. Dropping it outright loses
 	// the granted call's own speech whenever its AACH is momentarily
@@ -345,7 +357,7 @@ func (d *tetraSlotDemux) onBurst(frame []byte, slot, usage uint8) {
 		}
 		d.crcFallbacks.Add(1)
 		sole.bursts.Add(1)
-		d.c.decodeTETRASpeech(sole.bt, sole.rs, sole.serial, frame, &sole.speech)
+		d.c.decodeTETRASpeech(sole.bt, sole.rs, sole.serial, frame, softType5, &sole.speech)
 		return
 	}
 	d.mu.Lock()
@@ -362,7 +374,7 @@ func (d *tetraSlotDemux) onBurst(frame []byte, slot, usage uint8) {
 		return
 	}
 	o.bursts.Add(1)
-	d.c.decodeTETRASpeech(o.bt, o.rs, o.serial, frame, &o.speech)
+	d.c.decodeTETRASpeech(o.bt, o.rs, o.serial, frame, softType5, &o.speech)
 }
 
 // addOwner registers o. A marker-bearing grant claims its marker (most-recent

--- a/internal/voice/composer/tetra_voice_test.go
+++ b/internal/voice/composer/tetra_voice_test.go
@@ -10,9 +10,62 @@ import (
 
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
 	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/tetra"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
+
+// idealType5LLR maps a descrambled 54-byte type-5 traffic frame to the ideal
+// soft LLR stream the soft TCH/S decoder consumes (LLR > 0 ⇒ bit 0).
+func idealType5LLR(frame []byte) []float32 {
+	bits := framing.UnpackBitsMSB(frame, tetra.TrafficFrameBytes*8)
+	out := make([]float32, len(bits))
+	for i, bit := range bits {
+		if bit&1 == 0 {
+			out[i] = 1
+		} else {
+			out[i] = -1
+		}
+	}
+	return out
+}
+
+// TestTETRADemuxSoftDecodeUsesLLRs proves the shared demux decodes a burst from
+// its soft-decision LLR stream when one is supplied, independent of the hard
+// frame bytes: a valid soft type-5 recovers the speech even though the hard
+// frame passed alongside is corrupt (all-zero → hard CRC fails). This pins the
+// soft path as wired end-to-end through onBurst → decodeTETRASpeech.
+func TestTETRADemuxSoftDecodeUsesLLRs(t *testing.T) {
+	c, _, _ := mkBoundaryComposer(t, false, 50*time.Millisecond)
+	d := mkDemux(c)
+
+	a := make([]byte, 137)
+	b := make([]byte, 137)
+	for i := range a {
+		a[i] = byte(i % 2)
+	}
+	soft := idealType5LLR(tetra.EncodeTCHS(a, b))
+	// A random hard frame that fails the class-2 CRC gate — decoding must come
+	// from the soft LLRs, not these bytes.
+	corrupt := make([]byte, tetra.TrafficFrameBytes)
+	rand.New(rand.NewSource(42)).Read(corrupt)
+	if tetra.TCHSpeechFrames(corrupt) != nil {
+		t.Fatal("precondition: corrupt frame unexpectedly passed the hard CRC gate")
+	}
+
+	o, rs := newDemuxOwner(c, "A", 19)
+	d.addOwner(o)
+	d.onBurst(corrupt, soft, 1, 19)
+	if n := len(rs.rawFrames("A")); n != 2 {
+		t.Fatalf("soft-decode path: A got %d frames, want 2 (soft LLRs must decode despite a corrupt hard frame)", n)
+	}
+	// The SAME corrupt hard frame with no soft info decodes nothing — confirming
+	// it was the soft LLRs, not the frame bytes, that produced the speech above.
+	d.onBurst(corrupt, nil, 1, 19)
+	if n := len(rs.rawFrames("A")); n != 2 {
+		t.Errorf("hard fallback on a CRC-failing frame should add no frames; total = %d, want 2", n)
+	}
+}
 
 // buildTETRATrafficDibits lays out nSlots Normal Continuous Downlink Bursts
 // (255-dibit TDMA slots) into a dibit stream, each with the normal training
@@ -146,7 +199,7 @@ func TestTETRATrafficBurstLivenessGatedByCRC(t *testing.T) {
 	if tetra.TCHSpeechFrames(junk) != nil {
 		t.Fatalf("test vector precondition: junk frame unexpectedly passed the TCH/S CRC gate")
 	}
-	c.onTETRATrafficBurst(bt, rs, "VOICE-1", junk, 0, 0, &bursts, &speech, &offSlot)
+	c.onTETRATrafficBurst(bt, rs, "VOICE-1", junk, nil, 0, 0, &bursts, &speech, &offSlot)
 	if bt.sawVoice.Load() {
 		t.Error("non-speech burst set sawVoice — liveness not gated on CRC-valid speech")
 	}
@@ -166,7 +219,7 @@ func TestTETRATrafficBurstLivenessGatedByCRC(t *testing.T) {
 	// Case B: a CRC-valid TCH/S burst carrying two 137-bit speech frames. It must
 	// mark voice activity and emit both speech frames to the recorder.
 	frame := tetra.EncodeTCHS(make([]byte, 137), make([]byte, 137))
-	c.onTETRATrafficBurst(bt, rs, "VOICE-1", frame, 0, 0, &bursts, &speech, &offSlot)
+	c.onTETRATrafficBurst(bt, rs, "VOICE-1", frame, nil, 0, 0, &bursts, &speech, &offSlot)
 	if !bt.sawVoice.Load() {
 		t.Error("CRC-valid TCH/S burst did not set sawVoice")
 	}
@@ -203,7 +256,7 @@ func TestTETRATrafficBurstUsageMarkerFilter(t *testing.T) {
 	const grantUsage uint8 = 20 // this call's downlink usage marker
 
 	// Another call's slot (marker 19 != granted 20): dropped off-call, no decode.
-	c.onTETRATrafficBurst(bt, rs, "VOICE-2", frame, 19, grantUsage, &bursts, &speech, &offSlot)
+	c.onTETRATrafficBurst(bt, rs, "VOICE-2", frame, nil, 19, grantUsage, &bursts, &speech, &offSlot)
 	if got := offSlot.Load(); got != 1 {
 		t.Errorf("foreign-call burst offSlot = %d, want 1", got)
 	}
@@ -215,7 +268,7 @@ func TestTETRATrafficBurstUsageMarkerFilter(t *testing.T) {
 	}
 
 	// Granted marker (20 == granted 20): decoded and written.
-	c.onTETRATrafficBurst(bt, rs, "VOICE-2", frame, grantUsage, grantUsage, &bursts, &speech, &offSlot)
+	c.onTETRATrafficBurst(bt, rs, "VOICE-2", frame, nil, grantUsage, grantUsage, &bursts, &speech, &offSlot)
 	if n := len(rs.rawFrames("VOICE-2")); n != 2 {
 		t.Errorf("granted-marker burst wrote %d frames, want 2", n)
 	}
@@ -225,7 +278,7 @@ func TestTETRATrafficBurstUsageMarkerFilter(t *testing.T) {
 
 	// Undecoded AACH (marker 0): CRC-gated fallback still processes it — an AACH
 	// miss must not drop the granted call's own speech.
-	c.onTETRATrafficBurst(bt, rs, "VOICE-2", frame, 0, grantUsage, &bursts, &speech, &offSlot)
+	c.onTETRATrafficBurst(bt, rs, "VOICE-2", frame, nil, 0, grantUsage, &bursts, &speech, &offSlot)
 	if n := len(rs.rawFrames("VOICE-2")); n != 4 {
 		t.Errorf("undecoded-AACH burst wrote total %d frames, want 4", n)
 	}
@@ -246,8 +299,8 @@ func TestTETRATrafficBurstNoGrantMarkerFallback(t *testing.T) {
 	frame := tetra.EncodeTCHS(make([]byte, 137), make([]byte, 137))
 
 	// Grant marker 0 (unknown): a burst with any marker is decoded, none dropped.
-	c.onTETRATrafficBurst(bt, rs, "VOICE-3", frame, 19, 0, &bursts, &speech, &offSlot)
-	c.onTETRATrafficBurst(bt, rs, "VOICE-3", frame, 0, 0, &bursts, &speech, &offSlot)
+	c.onTETRATrafficBurst(bt, rs, "VOICE-3", frame, nil, 19, 0, &bursts, &speech, &offSlot)
+	c.onTETRATrafficBurst(bt, rs, "VOICE-3", frame, nil, 0, 0, &bursts, &speech, &offSlot)
 	if n := len(rs.rawFrames("VOICE-3")); n != 4 {
 		t.Errorf("no-grant-marker fallback wrote %d frames, want 4 (accept all CRC-valid speech)", n)
 	}
@@ -283,8 +336,8 @@ func TestTETRADemuxRoutesByUsageMarker(t *testing.T) {
 	d.addOwner(oA)
 	d.addOwner(oB)
 
-	d.onBurst(frame, 1, 19) // marker 19 → A only
-	d.onBurst(frame, 2, 20) // marker 20 → B only
+	d.onBurst(frame, nil, 1, 19) // marker 19 → A only
+	d.onBurst(frame, nil, 2, 20) // marker 20 → B only
 	if n := len(rsA.rawFrames("A")); n != 2 {
 		t.Errorf("owner A got %d frames, want 2", n)
 	}
@@ -293,12 +346,12 @@ func TestTETRADemuxRoutesByUsageMarker(t *testing.T) {
 	}
 
 	// A marker with no owner is dropped (not broadcast to A or B).
-	d.onBurst(frame, 3, 21)
+	d.onBurst(frame, nil, 3, 21)
 	if n := len(rsA.rawFrames("A")) + len(rsB.rawFrames("B")); n != 4 {
 		t.Errorf("unowned marker 21 leaked: total frames now %d, want 4", n)
 	}
 	// A non-traffic AACH marker (< DLUsageTraffic, e.g. undecoded 0) is dropped.
-	d.onBurst(frame, 1, 0)
+	d.onBurst(frame, nil, 1, 0)
 	if n := len(rsA.rawFrames("A")); n != 2 {
 		t.Errorf("non-traffic marker leaked to A: %d frames, want 2", n)
 	}
@@ -315,7 +368,7 @@ func TestTETRADemuxMostRecentGrantEvicts(t *testing.T) {
 
 	oOld, rsOld := newDemuxOwner(c, "old", 19)
 	d.addOwner(oOld)
-	d.onBurst(frame, 1, 19)
+	d.onBurst(frame, nil, 1, 19)
 	if n := len(rsOld.rawFrames("old")); n != 2 {
 		t.Fatalf("old owner got %d frames before reuse, want 2", n)
 	}
@@ -323,7 +376,7 @@ func TestTETRADemuxMostRecentGrantEvicts(t *testing.T) {
 	// New call reuses marker 19 while "old" is still registered (hangtime).
 	oNew, rsNew := newDemuxOwner(c, "new", 19)
 	d.addOwner(oNew)
-	d.onBurst(frame, 1, 19)
+	d.onBurst(frame, nil, 1, 19)
 	if n := len(rsNew.rawFrames("new")); n != 2 {
 		t.Errorf("new owner got %d frames after reuse, want 2", n)
 	}
@@ -333,7 +386,7 @@ func TestTETRADemuxMostRecentGrantEvicts(t *testing.T) {
 
 	// The lingering old owner unregistering must NOT remove the new owner's marker.
 	d.removeOwner(oOld)
-	d.onBurst(frame, 1, 19)
+	d.onBurst(frame, nil, 1, 19)
 	if n := len(rsNew.rawFrames("new")); n != 4 {
 		t.Errorf("new owner lost its marker after old unregistered: %d frames, want 4", n)
 	}
@@ -354,7 +407,7 @@ func TestTETRADemuxWildcardBinding(t *testing.T) {
 	d.addOwner(oW)
 
 	// Burst on 19 goes to A, not the wildcard.
-	d.onBurst(frame, 1, 19)
+	d.onBurst(frame, nil, 1, 19)
 	if n := len(rsA.rawFrames("A")); n != 2 {
 		t.Errorf("owner A got %d frames, want 2", n)
 	}
@@ -363,13 +416,13 @@ func TestTETRADemuxWildcardBinding(t *testing.T) {
 	}
 
 	// A burst on an unclaimed marker 25 binds the wildcard to 25.
-	d.onBurst(frame, 3, 25)
-	d.onBurst(frame, 3, 25)
+	d.onBurst(frame, nil, 3, 25)
+	d.onBurst(frame, nil, 3, 25)
 	if n := len(rsW.rawFrames("W")); n != 4 {
 		t.Errorf("wildcard did not bind marker 25: %d frames, want 4", n)
 	}
 	// It must not also grab a different unclaimed marker now that it is bound.
-	d.onBurst(frame, 4, 30)
+	d.onBurst(frame, nil, 4, 30)
 	if n := len(rsW.rawFrames("W")); n != 4 {
 		t.Errorf("bound wildcard grabbed a second marker: %d frames, want 4", n)
 	}
@@ -388,7 +441,7 @@ func TestTETRADemuxCRCFallbackSingleOwner(t *testing.T) {
 	o, rs := newDemuxOwner(c, "A", 0) // wildcard: grant carried no usage marker
 	d.addOwner(o)
 
-	d.onBurst(frame, 2, 0) // undecoded AACH, single active call → CRC fallback
+	d.onBurst(frame, nil, 2, 0) // undecoded AACH, single active call → CRC fallback
 	if n := len(rs.rawFrames("A")); n != 2 {
 		t.Errorf("single-owner CRC fallback: A got %d frames, want 2", n)
 	}
@@ -411,7 +464,7 @@ func TestTETRADemuxCRCFallbackNoCrossTalkConcurrent(t *testing.T) {
 	d.addOwner(oA)
 	d.addOwner(oB)
 
-	d.onBurst(frame, 2, 0) // undecoded AACH, two active calls → drop, no cross-talk
+	d.onBurst(frame, nil, 2, 0) // undecoded AACH, two active calls → drop, no cross-talk
 	if n := len(rsA.rawFrames("A")) + len(rsB.rawFrames("B")); n != 0 {
 		t.Errorf("undecoded burst leaked to a concurrent owner: %d frames, want 0", n)
 	}
@@ -436,7 +489,7 @@ func TestTETRADemuxMarkerCollisionCounted(t *testing.T) {
 	if got := d.markerCollisions.Load(); got != 1 {
 		t.Errorf("markerCollisions = %d, want 1", got)
 	}
-	d.onBurst(frame, 1, 19) // newest owns the marker
+	d.onBurst(frame, nil, 1, 19) // newest owns the marker
 	if n := len(rsNew.rawFrames("new")); n != 2 {
 		t.Errorf("newest owner got %d frames, want 2 (most-recent-grant wins)", n)
 	}


### PR DESCRIPTION
On a TETRA same-carrier site, voice recordings came out short and garbled
(the "recording shorter than call span" diagnostic showed audio_pct ~30%).
The control channel decodes fine because SCH is soft-decision, but the TCH/S
traffic decoder was hard-decision, so on a marginal signal ~70% of a call's
own speech bursts failed the class-2 CRC and were dropped. The recorder
concatenates only the surviving bursts, so the audio played back choppy and
unintelligible.

Session-log evidence ruled out the other candidates: the "same-carrier voice
tap dropped IQ" starvation warning fired 0 times, marker_collisions=0, and all
grants were clear group voice — the loss was CRC failures, not IQ drops,
routing, or encryption.

Wire the TETRA traffic path into the soft-decision channel decode the control
channel already uses:

- framing: DecodeRCPCTetraMotherSoft (soft-input rate-1/3 K=5 TCH Viterbi) and
  DepunctureRCPCTetraSoft (soft depuncture, erasure = 0.0), mirroring the hard
  rcpc_tetra.go primitives.
- tetra/tch.go: DecodeTCHSSoft / TCHSpeechFramesSoft and tchDeinterleaveSoft —
  a step-for-step LLR mirror of DecodeTCHS (soft deinterleave -> split -> soft
  depuncture -> soft Viterbi -> hard class-2 CRC).
- tetra/traffic.go: TrafficExtractor carries the per-burst soft LLRs parallel
  to its dibit buffer (StashSoft), builds the descrambled type-5 LLR stream via
  softType5FromDiffs + DescrambleTetraSoft in emit, and delivers it through the
  extended onBurst callback.
- composer/tetra_voice.go: both the solo chain and the shared same-carrier
  demux set the receiver SoftSink; decodeTETRASpeech prefers the soft decode
  and falls back to the hard TCHSpeechFrames when no soft info is present, so
  the change is never worse than before.

Tests (fail-first): framing soft/hard parity; DecodeTCHSSoft clean round-trip;
a coding-gain regression where soft passes CRC ~8x more often than hard at the
same AWGN level; and a composer wiring test proving the demux decodes from the
soft LLRs even when the hard frame bytes fail the CRC gate.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015MRpTF8cuEe99m7am2S1SZ