### PR TITLE
tetra: stop radio IDs leaking into Talkgroups + recover single-call same-carrier bursts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,6 +208,16 @@ for tagged releases.
   rather than a fixed slot 1 — the building block for issue #925.
 
 ### Fixed
+- **A single-call same-carrier TETRA burst whose AACH usage marker miscorrected
+  was dropped instead of decoded.** The shared per-carrier voice demux routes by
+  AACH downlink usage marker; on a marginal signal the RM(30,14) AACH occasionally
+  miscorrects to a stray marker with no registered owner, so the burst was counted
+  as an `ownerless_drop` and its speech lost. When exactly one call is active the
+  demux now routes such a burst to that sole call through the class-2 CRC gate
+  (the same single-call fallback already used for an undecoded AACH) — the CRC
+  rejects a genuinely foreign burst ~255/256, and with one call there is no peer
+  to cross-talk into. With ≥2 concurrent calls the burst is still dropped, so the
+  cross-talk guarantees are unchanged.
 - **TETRA radio IDs leaked into the Talkgroups list.** A notification / D-CONNECT
   addressed to a call's calling party arrives as a bare grant before that SSI is
   known to be a radio, so it was published `Individual=false` and the engine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,6 +208,17 @@ for tagged releases.
   rather than a fixed slot 1 — the building block for issue #925.
 
 ### Fixed
+- **TETRA radio IDs leaked into the Talkgroups list.** A notification / D-CONNECT
+  addressed to a call's calling party arrives as a bare grant before that SSI is
+  known to be a radio, so it was published `Individual=false` and the engine
+  auto-catalogued the radio ID as a phantom talkgroup (e.g. `100xxxx` source IDs
+  showing up alongside real `102xxxx` talkgroups). The engine now learns which
+  SSIs are subscriber radios — any grant's calling/transmitting party (`SourceID`)
+  and any `Individual`-addressed destination — retracts a phantom talkgroup
+  already catalogued for one (`TalkgroupDB.DeleteDiscovered`, which only removes
+  auto-`Discovered` entries, never an operator-catalogued talkgroup), and refuses
+  to re-discover a known radio. GSSIs and ISSIs never overlap on a TETRA network,
+  so this is safe.
 - **TETRA voice recordings on a same-carrier site came out short and garbled
   (low `audio_pct`).** The TCH/S traffic decoder was hard-decision while the
   control channel already ran soft-decision, so on a marginal same-carrier

--- a/internal/trunking/engine.go
+++ b/internal/trunking/engine.go
@@ -76,6 +76,18 @@ type Engine struct {
 	// channel's repeated grant TSBKs and age out via runWatchdog once the call
 	// drops. Guarded by mu, like calls/synthetic.
 	observed map[string]*ActiveCall
+
+	// knownRadios is the set of subscriber SSIs a grant has revealed to be an
+	// individual radio, not a talkgroup: any grant's calling/transmitting party
+	// (SourceID) and any Individual-addressed destination. It guards talkgroup
+	// auto-discovery against the TETRA ordering race where a notification /
+	// D-CONNECT addressed to the calling party is seen before that SSI is known
+	// to be a radio (so it is published Individual=false) — which would otherwise
+	// catalogue the radio ID as a phantom talkgroup. GSSIs and ISSIs never
+	// overlap on a TETRA network, so an SSI seen as a radio is never a real
+	// talkgroup. Bounded by knownRadiosCap; guarded by radiosMu.
+	radiosMu    sync.Mutex
+	knownRadios map[uint32]struct{}
 }
 
 // observedKey identifies a logical call for the observed-call tracker:
@@ -262,7 +274,7 @@ func (e *Engine) Run(ctx context.Context) error {
 func (e *Engine) discoverTalkgroup(g Grant) *TalkGroup {
 	tg := &TalkGroup{
 		ID:     g.GroupID,
-		Tag:    "Discovered",
+		Tag:    discoveredTag,
 		Mode:   "D",
 		Scan:   e.ScanMode() != ScanModeList,
 		Stream: true,
@@ -274,6 +286,52 @@ func (e *Engine) discoverTalkgroup(g Grant) *TalkGroup {
 	return tg
 }
 
+// knownRadiosCap bounds the learned-radios set so a long-running busy site
+// cannot grow it without bound. Past the cap the set stops learning new SSIs
+// (existing ones still guard discovery, and retraction still fires whenever a
+// radio is seen), mirroring the tetra decoder's individualsCap.
+const knownRadiosCap = 16384
+
+// noteRadio records that ssi is a subscriber radio (an individual unit) rather
+// than a talkgroup, and retracts any talkgroup previously auto-discovered for
+// it. A radio is revealed by any grant that carries it as a calling /
+// transmitting party (SourceID) or addresses it individually; GSSIs and ISSIs
+// never overlap on a TETRA network, so an SSI seen as a radio is never a real
+// talkgroup. Only auto-"Discovered" entries are retracted (DeleteDiscovered) —
+// an operator-catalogued talkgroup is authoritative and left untouched. No-op
+// for ssi 0. Retraction is what fixes the leaked radio IDs already sitting in
+// the Talkgroups list; the knownRadios guard in HandleGrant then keeps a later
+// notification for the same radio from re-discovering it.
+func (e *Engine) noteRadio(ssi uint32, system string) {
+	if ssi == 0 {
+		return
+	}
+	e.radiosMu.Lock()
+	if e.knownRadios == nil {
+		e.knownRadios = make(map[uint32]struct{})
+	}
+	_, known := e.knownRadios[ssi]
+	if !known && len(e.knownRadios) < knownRadiosCap {
+		e.knownRadios[ssi] = struct{}{}
+	}
+	e.radiosMu.Unlock()
+	if known {
+		return // already learned — any phantom was retracted on first sighting
+	}
+	if e.talkgroups.DeleteDiscovered(ssi) {
+		e.log.Info("retracted auto-discovered talkgroup — SSI is a subscriber radio, not a talkgroup",
+			"tg", ssi, "system", system)
+	}
+}
+
+// isKnownRadio reports whether ssi has been revealed as a subscriber radio.
+func (e *Engine) isKnownRadio(ssi uint32) bool {
+	e.radiosMu.Lock()
+	defer e.radiosMu.Unlock()
+	_, ok := e.knownRadios[ssi]
+	return ok
+}
+
 func (e *Engine) HandleGrant(g Grant) {
 	if g.At.IsZero() {
 		g.At = e.now()
@@ -282,13 +340,24 @@ func (e *Engine) HandleGrant(g Grant) {
 		e.log.Warn("dropping grant with zero frequency", "grant", g.String())
 		return
 	}
+	// Learn subscriber radios this grant reveals and retract any phantom
+	// talkgroup previously catalogued for one. A calling/transmitting party is
+	// always a radio; an Individual grant's destination is a subscriber address.
+	// This both cleans up radio IDs already leaked into the Talkgroups list and
+	// primes the discovery guard below.
+	e.noteRadio(g.SourceID, g.System)
+	if g.Individual {
+		e.noteRadio(g.GroupID, g.System)
+	}
 	tg := e.talkgroups.Lookup(g.GroupID)
-	if tg == nil && g.GroupID != 0 && !g.Individual {
+	if tg == nil && g.GroupID != 0 && !g.Individual && !e.isKnownRadio(g.GroupID) {
 		// First time this talkgroup has been heard: catalogue it so
 		// Database → Talkgroups fills in from the air (the trunk-recorder
 		// behaviour the operator asked for). Individual (unit-to-unit /
 		// interconnect) grants are skipped — their 24-bit destination is a
-		// subscriber address, not a talkgroup.
+		// subscriber address, not a talkgroup — as are SSIs already known to be
+		// radios (the notification/D-CONNECT ordering race that leaked radio IDs
+		// into the talkgroup list).
 		tg = e.discoverTalkgroup(g)
 	}
 	if tg != nil && tg.Lockout && !g.Emergency {

--- a/internal/trunking/engine_test.go
+++ b/internal/trunking/engine_test.go
@@ -128,6 +128,54 @@ func TestEngineDiscoversTalkgroupFromGrant(t *testing.T) {
 	}
 }
 
+// TestEngineRetractsRadioIDLeakedAsTalkgroup pins the RadioID→TGID leak fix.
+// A TETRA notification / D-CONNECT addressed to the calling party arrives as a
+// group grant (Individual=false) before that SSI is known to be a radio, so the
+// engine phantom-catalogues the radio ID as a talkgroup. Once a later grant
+// reveals the SSI is a radio — either as a calling party (SourceID) or via an
+// Individual-addressed grant — the phantom must be retracted, and a subsequent
+// notification for the same radio must not re-discover it.
+func TestEngineRetractsRadioIDLeakedAsTalkgroup(t *testing.T) {
+	e, _, bus, _ := mkEngine(t, 1)
+	defer bus.Close()
+
+	// Ordering A — phantom first, then the SSI is seen as a calling party.
+	// A bare notification addressed to radio 1005387 (src unknown) leaks it in.
+	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: 1005387, FrequencyHz: 467_912_500})
+	if tg := e.talkgroups.Lookup(1005387); tg == nil || tg.Tag != discoveredTag {
+		t.Fatalf("precondition: radio 1005387 should be leaked as a Discovered TG, got %+v", tg)
+	}
+	// A real group call where 1005387 is the calling party reveals it as a radio.
+	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: 1020529, SourceID: 1005387, FrequencyHz: 467_912_500})
+	if e.talkgroups.Lookup(1005387) != nil {
+		t.Errorf("radio 1005387 was not retracted after being seen as a calling party")
+	}
+	if e.talkgroups.Lookup(1020529) == nil {
+		t.Errorf("real group TG 1020529 should still be discovered")
+	}
+	// A later notification for the same radio must NOT re-discover it.
+	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: 1005387, FrequencyHz: 467_912_500})
+	if e.talkgroups.Lookup(1005387) != nil {
+		t.Errorf("radio 1005387 re-discovered as a TG after being known as a radio")
+	}
+
+	// Ordering B — the SSI is known as a radio first (Individual grant), so a
+	// later bare notification for it is never catalogued.
+	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: 1005574, FrequencyHz: 467_912_500, Individual: true})
+	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: 1005574, FrequencyHz: 467_912_500})
+	if e.talkgroups.Lookup(1005574) != nil {
+		t.Errorf("radio 1005574 (known individual) must not be discovered as a TG")
+	}
+
+	// An operator-catalogued talkgroup that happens to share an id with a radio
+	// sighting must NEVER be retracted — only auto-"Discovered" entries are.
+	e.talkgroups.Add(&TalkGroup{ID: 4242, Tag: "Ops", AlphaTag: "Dispatch"})
+	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: 1020529, SourceID: 4242, FrequencyHz: 467_912_500})
+	if tg := e.talkgroups.Lookup(4242); tg == nil {
+		t.Errorf("operator-catalogued TG 4242 was wrongly retracted")
+	}
+}
+
 // TestEngineSkipsOutOfBandVirtualTunerInFavorOfPhysical covers the
 // Phase B fallback: when a wideband virtual voice tuner can't serve
 // a grant (frequency outside its IQ window) and a physical voice

--- a/internal/trunking/talkgroup.go
+++ b/internal/trunking/talkgroup.go
@@ -106,6 +106,28 @@ func (d *TalkgroupDB) Delete(id uint32) bool {
 	return true
 }
 
+// discoveredTag is the Tag stamped on auto-learned talkgroups (see
+// Engine.discoverTalkgroup), distinguishing them from operator-catalogued
+// entries so retraction never removes a curated record.
+const discoveredTag = "Discovered"
+
+// DeleteDiscovered removes an auto-discovered talkgroup (Tag == discoveredTag)
+// by id, returning true only if such an entry was present and removed. An
+// operator-catalogued talkgroup (any other Tag) is left untouched. The Tag check
+// and the delete run under one write lock so a concurrent UpdateFields cannot
+// race the read. Used to retract a phantom talkgroup once its id is revealed to
+// be a subscriber radio (the TETRA notification/D-CONNECT ordering race).
+func (d *TalkgroupDB) DeleteDiscovered(id uint32) bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	tg, ok := d.tgs[id]
+	if !ok || tg.Tag != discoveredTag {
+		return false
+	}
+	delete(d.tgs, id)
+	return true
+}
+
 // All returns a snapshot of every talkgroup in the DB.
 func (d *TalkgroupDB) All() []*TalkGroup {
 	d.mu.RLock()

--- a/internal/voice/composer/tetra_voice.go
+++ b/internal/voice/composer/tetra_voice.go
@@ -324,11 +324,14 @@ func (d *tetraSlotDemux) observe(iq []complex64) {
 }
 
 // onBurst routes one extracted traffic frame to the call that owns its AACH usage
-// marker. Non-traffic bursts (usage < DLUsageTraffic, including an undecoded AACH
-// reported as 0) carry no speech and are dropped; a marker with no live owner is
-// dropped too. When a marker has no owner but a wildcard call is waiting, the
-// oldest wildcard claims that marker. Runs on the single demux goroutine, so each
-// owner's boundary tracker has exactly one writer.
+// marker. When a marker has no owner but a wildcard call is waiting, the oldest
+// wildcard claims that marker. A burst that cannot be routed by marker — an
+// undecoded/control AACH (usage < DLUsageTraffic) or a decoded marker with no
+// registered owner — is handed to the CRC gate of the sole active call when
+// exactly one call is up (a stray/undecoded AACH on that call's own burst), and
+// dropped (counted) only when ≥2 calls are concurrent, where cross-talk would be
+// possible. Runs on the single demux goroutine, so each owner's boundary tracker
+// has exactly one writer.
 func (d *tetraSlotDemux) onBurst(frame []byte, softType5 []float32, slot, usage uint8) {
 	// A burst whose AACH did not decode (usage 0) or is a control slot
 	// (< DLUsageTraffic) carries no routable marker. Dropping it outright loses
@@ -368,8 +371,27 @@ func (d *tetraSlotDemux) onBurst(frame []byte, softType5 []float32, slot, usage 
 		o.marker = usage
 		d.owners[usage] = o
 	}
+	// No owner for this decoded marker and no wildcard to claim it. When exactly
+	// one call is active, this is that call's own burst whose AACH usage marker
+	// miscorrected to a stray value (a common RM(30,14) miss on a marginal AACH):
+	// capture the sole owner so it goes through the CRC gate below instead of
+	// being dropped. Safe for the same reason as the usage-0 fallback — with a
+	// single active call there is no peer to cross-talk into, and the class-2 CRC
+	// still rejects a non-matching burst ~255/256.
+	var sole *tetraSlotOwner
+	if o == nil && len(d.owners) == 1 && len(d.wildcards) == 0 {
+		for _, only := range d.owners {
+			sole = only
+		}
+	}
 	d.mu.Unlock()
 	if o == nil {
+		if sole != nil {
+			d.crcFallbacks.Add(1)
+			sole.bursts.Add(1)
+			d.c.decodeTETRASpeech(sole.bt, sole.rs, sole.serial, frame, softType5, &sole.speech)
+			return
+		}
 		d.ownerlessDrops.Add(1)
 		return
 	}

--- a/internal/voice/composer/tetra_voice_test.go
+++ b/internal/voice/composer/tetra_voice_test.go
@@ -473,6 +473,44 @@ func TestTETRADemuxCRCFallbackNoCrossTalkConcurrent(t *testing.T) {
 	}
 }
 
+// TestTETRADemuxOwnerlessMarkerSingleOwnerCRCFallback: a burst that decodes a
+// traffic marker with no registered owner is the sole active call's own burst
+// whose AACH usage marker miscorrected. With one call active it must be routed
+// to that call through the CRC gate (recovering speech a strict marker match
+// would drop as ownerless), and with two concurrent calls it must still be
+// dropped as ownerless (no cross-talk). Regression for the same-carrier
+// ownerless-drop audio loss.
+func TestTETRADemuxOwnerlessMarkerSingleOwnerCRCFallback(t *testing.T) {
+	c, _, _ := mkBoundaryComposer(t, false, 50*time.Millisecond)
+	frame := tetra.EncodeTCHS(make([]byte, 137), make([]byte, 137))
+
+	// One active call (marker 24); a CRC-valid burst carries a stray marker 25.
+	d := mkDemux(c)
+	o, rs := newDemuxOwner(c, "A", 24)
+	d.addOwner(o)
+	d.onBurst(frame, nil, 1, 25) // decoded marker 25, no owner, single call → CRC fallback
+	if n := len(rs.rawFrames("A")); n != 2 {
+		t.Errorf("ownerless single-owner fallback: A got %d frames, want 2", n)
+	}
+	if got := d.ownerlessDrops.Load(); got != 0 {
+		t.Errorf("ownerlessDrops = %d, want 0 (burst was recovered, not dropped)", got)
+	}
+
+	// Two concurrent calls: a stray-marker burst has no safe owner and must drop.
+	d2 := mkDemux(c)
+	oA, rsA := newDemuxOwner(c, "A", 24)
+	oB, rsB := newDemuxOwner(c, "B", 26)
+	d2.addOwner(oA)
+	d2.addOwner(oB)
+	d2.onBurst(frame, nil, 1, 25) // stray marker 25, two calls → drop, no cross-talk
+	if n := len(rsA.rawFrames("A")) + len(rsB.rawFrames("B")); n != 0 {
+		t.Errorf("ownerless burst leaked to a concurrent owner: %d frames, want 0", n)
+	}
+	if got := d2.ownerlessDrops.Load(); got != 1 {
+		t.Errorf("ownerlessDrops = %d, want 1", got)
+	}
+}
+
 // TestTETRADemuxMarkerCollisionCounted: two calls registering the same usage
 // marker is now counted + warned (previously a silent orphan). Most-recent-grant
 // still wins the marker (existing eviction semantics preserved).

--- a/internal/voice/recorder.go
+++ b/internal/voice/recorder.go
@@ -958,10 +958,14 @@ func (r *Recorder) finalizeLocked(s *recordingSession, serial string, endedAt ti
 		if wallSec > 1 && audioSec < 0.75*wallSec {
 			// audio_pct is the frame yield: how much of the call span actually
 			// decoded to audio. A very low value (e.g. 0.1 s / 5.4 s = ~2%) with
-			// a small frames count is the fingerprint of upstream frame loss
-			// (few TCH/S bursts passing CRC on a starved same-carrier tap), not
-			// a genuinely short over. Surfacing frames + pct makes that
-			// diagnosable from this one line.
+			// a small frames count is the fingerprint of upstream frame loss —
+			// on TETRA, few TCH/S bursts passing the class-2 CRC (a marginal
+			// same-carrier signal without soft-decision coding gain) or bursts
+			// mis-routed away from the call by the usage-marker demux — rather
+			// than a genuinely short over. (IQ starvation of the tap is a distinct
+			// cause, surfaced separately by the ccdecoder "dropped IQ to a lagging
+			// voice consumer" warning; a zero there rules it out.) Surfacing
+			// frames + pct makes this diagnosable from this one line.
 			r.log.Debug("recorder: recording shorter than call span",
 				"device", serial, "wav", s.wavPath, "vocoder", s.vocoderName,
 				"audio_seconds", round1(audioSec), "wall_seconds", round1(wallSec),


### PR DESCRIPTION
## Summary

Two TETRA follow-up fixes on the same branch (the RadioID→TGID leak plus a same-carrier voice-decode follow-up deferred from the soft-decision work in #999). They're independent logical changes committed separately; happy to split into two PRs if preferred, but the working branch is shared.

## Changes

**1. Radio IDs leaking into the Talkgroups list (`internal/trunking/…`)**
- A notification / D-CONNECT addressed to a call's calling party arrives as a bare grant *before* that SSI is learned to be a radio, so it is published `Individual=false` and the engine auto-catalogues the radio ID as a phantom talkgroup (`100xxxx` source IDs appearing next to real `102xxxx` talkgroups). Discovery was gated on `!Individual`, but the flag is decided once at grant time and there was no retraction path.
- The engine now learns which SSIs a grant reveals to be subscriber radios (any calling/transmitting party `SourceID`, any `Individual`-addressed destination), retracts a phantom talkgroup already catalogued for one, and refuses to re-discover a known radio.
- New `TalkgroupDB.DeleteDiscovered(id)` removes **only** auto-`Discovered` entries (tag check + delete under one write lock), so an operator-catalogued talkgroup is never touched. GSSIs and ISSIs never overlap on TETRA, so this is safe.

**2. Recover single-call same-carrier bursts on a miscorrected AACH marker (`internal/voice/composer/tetra_voice.go`)**
- The shared per-carrier voice demux routes by AACH usage marker; on a marginal signal the RM(30,14) AACH occasionally miscorrects to a stray marker with no owner, so the burst was dropped (`ownerless_drop`) and its speech lost.
- When exactly one call is active, the demux now routes such a decoded-but-ownerless burst to the sole owner through the class-2 CRC gate (mirrors the existing usage-0 fallback). With ≥2 concurrent calls it is still dropped — cross-talk guarantees unchanged.
- Also corrects the recorder's `recording shorter than call span` comment (the "starved tap" attribution was disproved by the session logs' zero IQ-drop warnings).

## Test plan

- [x] `make vet test` is green locally
- [ ] `make integration` — n/a (no daemon/replay wiring changed)
- [x] Added regression tests: `TestEngineRetractsRadioIDLeakedAsTalkgroup` (both orderings + operator-TG protection) and `TestTETRADemuxOwnerlessMarkerSingleOwnerCRCFallback` (single-call recovery + two-call no-cross-talk). Both fail without their fix.
- [x] Change #2 additionally validated by replaying the reporter's six 144 kHz `.cs16` captures through the real control decoder (colour code `262144876`); the merged soft-decision path plus this routing fix recover materially more CRC-valid bursts on the degraded concurrent-load captures.

## Breaking changes

None. In-memory behaviour only; no config keys, flags, endpoints, or schemas change.

## Docs / CHANGELOG

- [x] Added `## [Unreleased]` → Fixed bullets to `CHANGELOG.md` for both changes
- [ ] `README.md` / `docs/` — n/a

## Linked issues

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MRpTF8cuEe99m7am2S1SZ