### PR TITLE
tetra: stop radio IDs lingering in Active Calls, and fix TETRA metrics counting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,6 +208,23 @@ for tagged releases.
   rather than a fixed slot 1 — the building block for issue #925.
 
 ### Fixed
+- **TETRA radio IDs still surfaced as talkgroups in the live Active Calls list.**
+  The engine's RadioID→TGID retraction cleaned the Talkgroups catalogue but not
+  the control-only "observed" call set, which is the other half of what the
+  Active Calls UI renders: a notification / D-CONNECT bound to the calling party
+  creates a provisional call keyed by the radio ID, and the notification-supersede
+  only released the pool-bound call, leaving the observed entry to linger as a
+  phantom "TG <radioID>". The engine now skips individual / known-radio grants when
+  recording observed calls, and retracts any observed call already tracked under an
+  SSI once that SSI is revealed to be a subscriber radio.
+- **TETRA metrics weren't counting.** `grants_total` was never defined or
+  incremented (the metrics event handler had no `KindGrant` case), so TETRA grants
+  went uncounted; TETRA voice calls were miscounted under the DMR-named
+  `dmr_voice_calls_total` (its per-timeslot increment was gated only on a non-zero
+  timeslot, which TETRA also carries); and the curated dashboards asked for a
+  `cc_locked` metric the daemon never emits (it exports `control_channel_locked`).
+  Added a protocol-labelled `grants_total`, gated `dmr_voice_calls_total` to the
+  DMR protocol, and pointed the TUI/web curated panels at `control_channel_locked`.
 - **A single-call same-carrier TETRA burst whose AACH usage marker miscorrected
   was dropped instead of decoded.** The shared per-carrier voice demux routes by
   AACH downlink usage marker; on a marginal signal the RM(30,14) AACH occasionally

--- a/internal/metrics/prom.go
+++ b/internal/metrics/prom.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
@@ -43,6 +44,7 @@ type Metrics struct {
 	callsStarted   *prometheus.CounterVec // by system,protocol,encrypted
 	activeCalls    *prometheus.GaugeVec   // by system,protocol
 	dmrSlotCalls   *prometheus.CounterVec // DMR voice calls by system,timeslot (ts1/ts2)
+	grantsTotal    *prometheus.CounterVec // control-channel voice grants by system,protocol
 	ccLockedGauge  *prometheus.GaugeVec   // by system (1 when CC locked)
 	ccFrequencyHz  *prometheus.GaugeVec   // by system; deleted on CC loss
 	ccTransitions  *prometheus.CounterVec // by system,event (locked|lost)
@@ -130,6 +132,17 @@ func New(bus *events.Bus, pool Snapshotter, version string, detailedFEC bool) (*
 		Name:      "dmr_voice_calls_total",
 		Help:      "DMR voice calls started, split by TDMA timeslot (ts1/ts2), by system.",
 	}, []string{"system", "timeslot"})
+
+	// Control-channel voice grants seen, by system and protocol. Counts every
+	// grant PDU (the CC repeats a live call's grant), so it tracks control-
+	// channel activity, not distinct calls (see calls_started_total for those).
+	// Wired for every protocol's events.KindGrant — TETRA grants were previously
+	// uncounted because observeEvent had no KindGrant case.
+	m.grantsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: namespace,
+		Name:      "grants_total",
+		Help:      "Control-channel voice grants observed, by system and protocol.",
+	}, []string{"system", "protocol"})
 
 	m.ccLockedGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: namespace,
@@ -286,6 +299,7 @@ func New(bus *events.Bus, pool Snapshotter, version string, detailedFEC bool) (*
 		m.callsStarted,
 		m.activeCalls,
 		m.dmrSlotCalls,
+		m.grantsTotal,
 		m.ccLockedGauge,
 		m.ccFrequencyHz,
 		m.ccTransitions,
@@ -377,9 +391,17 @@ func (m *Metrics) observeEvent(ev events.Event) {
 			sys, proto, enc := callLabels(cs.Grant)
 			m.activeCalls.WithLabelValues(sys, proto).Inc()
 			m.callsStarted.WithLabelValues(sys, proto, enc).Inc()
-			if cs.Grant.Timeslot != 0 {
+			// dmr_voice_calls_total is a DMR-specific per-timeslot counter; gate
+			// it on the DMR protocol so a slotted non-DMR call (TETRA carries a
+			// 1..4 timeslot too) is not miscounted under the DMR-named metric.
+			if strings.HasPrefix(cs.Grant.Protocol, "dmr") && cs.Grant.Timeslot != 0 {
 				m.dmrSlotCalls.WithLabelValues(sys, fmt.Sprintf("ts%d", cs.Grant.Timeslot)).Inc()
 			}
+		}
+	case events.KindGrant:
+		if g, ok := ev.Payload.(trunking.Grant); ok {
+			sys, proto, _ := callLabels(g)
+			m.grantsTotal.WithLabelValues(sys, proto).Inc()
 		}
 	case events.KindCallEnd:
 		if ce, ok := ev.Payload.(trunking.CallEnd); ok {

--- a/internal/metrics/prom_test.go
+++ b/internal/metrics/prom_test.go
@@ -153,6 +153,48 @@ func TestDMRSlotCallsCounter(t *testing.T) {
 	}
 }
 
+// TestTETRAMetricsGrantsAndNoDMRMislabel pins the TETRA metrics fixes: a TETRA
+// KindGrant increments grants_total{tetra} (previously observeEvent had no
+// KindGrant case, so it was always zero), and a slotted TETRA voice call does
+// NOT increment the DMR-named dmr_voice_calls_total (previously any Timeslot!=0
+// grant was miscounted there).
+func TestTETRAMetricsGrantsAndNoDMRMislabel(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	m, _ := New(bus, nil, "test", false)
+	defer m.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go m.Run(ctx)
+
+	// A TETRA voice call on timeslot 3 (must not touch the DMR slot counter).
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: trunking.CallStart{
+		Grant:        trunking.Grant{System: "TSys", Protocol: "tetra", GroupID: 1020529, FrequencyHz: 467912500, Timeslot: 3},
+		DeviceSerial: "D0", StartedAt: time.Now(),
+	}})
+	// Two TETRA grants (the CC repeats a live call's grant).
+	for i := 0; i < 2; i++ {
+		bus.Publish(events.Event{Kind: events.KindGrant, Payload: trunking.Grant{
+			System: "TSys", Protocol: "tetra", GroupID: 1020529, SourceID: 1005746, FrequencyHz: 467912500, Timeslot: 3,
+		}})
+	}
+
+	grants := m.grantsTotal.WithLabelValues("TSys", "tetra")
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if testutil.ToFloat64(grants) == 2 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := testutil.ToFloat64(grants); got != 2 {
+		t.Errorf("grants_total{TSys,tetra} = %v, want 2 (TETRA grants must be counted)", got)
+	}
+	if got := testutil.CollectAndCount(m.dmrSlotCalls); got != 0 {
+		t.Errorf("dmr_voice_calls_total has %d series, want 0 (TETRA must not increment the DMR counter)", got)
+	}
+}
+
 func TestDecodeErrorEventIncrementsCounter(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()

--- a/internal/trunking/engine.go
+++ b/internal/trunking/engine.go
@@ -322,6 +322,34 @@ func (e *Engine) noteRadio(ssi uint32, system string) {
 		e.log.Info("retracted auto-discovered talkgroup — SSI is a subscriber radio, not a talkgroup",
 			"tg", ssi, "system", system)
 	}
+	// Drop any live control-only "observed" call provisionally tracked under this
+	// radio ID. A TETRA notification / D-CONNECT to the calling party creates one
+	// (keyed by the radio ID as GroupID) before the authoritative group grant
+	// supersedes the pool-bound call; the supersede only released the bound call,
+	// leaving this observed entry to linger in the Active Calls list as a phantom
+	// "TG <radioID>". Retracting it here propagates the correction to the other
+	// half of the Active Calls set.
+	if e.purgeObservedForGroup(ssi) {
+		e.log.Info("retracted observed call — SSI is a subscriber radio, not a talkgroup",
+			"tg", ssi, "system", system)
+	}
+}
+
+// purgeObservedForGroup removes every control-only "observed" call whose grant
+// GroupID equals ssi, returning true if any were removed. Called when ssi is
+// revealed to be a subscriber radio so a phantom call provisionally tracked
+// under the radio ID stops appearing in the Active Calls list. Guarded by e.mu.
+func (e *Engine) purgeObservedForGroup(ssi uint32) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	removed := false
+	for key, ac := range e.observed {
+		if ac.Grant.GroupID == ssi {
+			delete(e.observed, key)
+			removed = true
+		}
+	}
+	return removed
 }
 
 // isKnownRadio reports whether ssi has been revealed as a subscriber radio.
@@ -412,7 +440,13 @@ func (e *Engine) HandleGrant(g Grant) {
 	// talkgroup" report). Repeated grant TSBKs for a live call refresh the
 	// entry; data grants are not voice calls and are skipped. ObservedCalls
 	// filters out whichever of these a tuner ends up following.
-	if !g.DataCall {
+	if !g.DataCall && !g.Individual && !e.isKnownRadio(g.GroupID) {
+		// Skip individual (unit-to-unit) grants and grants addressed to a known
+		// subscriber radio — their destination is a radio ID, not a talkgroup, so
+		// tracking them here would surface the radio ID as a phantom talkgroup in
+		// the Active Calls list (the same notification/D-CONNECT ordering race the
+		// discovery gate above guards). A radio only learned to be one AFTER a
+		// provisional entry was made is retracted by noteRadio's observed purge.
 		e.observeCall(g, tg)
 	}
 

--- a/internal/trunking/engine_test.go
+++ b/internal/trunking/engine_test.go
@@ -176,6 +176,51 @@ func TestEngineRetractsRadioIDLeakedAsTalkgroup(t *testing.T) {
 	}
 }
 
+// engineHasCallForTG reports whether any active (pool-bound) or observed
+// (control-only) call is labelled with talkgroup tg — the union the Active Calls
+// UI renders.
+func engineHasCallForTG(e *Engine, tg uint32) bool {
+	for _, ac := range e.ActiveCalls() {
+		if ac.Grant.GroupID == tg {
+			return true
+		}
+	}
+	for _, ac := range e.ObservedCalls() {
+		if ac.Grant.GroupID == tg {
+			return true
+		}
+	}
+	return false
+}
+
+// TestEngineRetractsRadioIDFromActiveCalls pins the Active-Calls half of the
+// RadioID→TGID leak: a TETRA notification bound to the calling party's radio ID
+// creates a provisional call labelled "TG <radioID>". When the authoritative
+// group grant reveals that SSI is the calling party (a radio), the provisional
+// must vanish from the Active Calls list — not just the Talkgroups catalogue.
+// Before the fix the supersede only released the pool-bound call and left the
+// control-only "observed" entry lingering (the reporter's "not passed anywhere
+// else").
+func TestEngineRetractsRadioIDFromActiveCalls(t *testing.T) {
+	e, _, bus, _ := mkEngine(t, 1)
+	defer bus.Close()
+	const freq = 467_912_500
+
+	// Provisional notification addressed to radio 1005399 (source unknown).
+	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: 1005399, FrequencyHz: freq, Timeslot: 3})
+	if !engineHasCallForTG(e, 1005399) {
+		t.Fatalf("precondition: a provisional call for radio 1005399 should exist")
+	}
+	// Authoritative group grant: 1005399 is the calling party, real TG is 1020545.
+	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: 1020545, SourceID: 1005399, FrequencyHz: freq, Timeslot: 3})
+	if engineHasCallForTG(e, 1005399) {
+		t.Errorf("radio 1005399 still shown as a call after the authoritative grant superseded it")
+	}
+	if !engineHasCallForTG(e, 1020545) {
+		t.Errorf("authoritative group call 1020545 should be active")
+	}
+}
+
 // TestEngineSkipsOutOfBandVirtualTunerInFavorOfPhysical covers the
 // Phase B fallback: when a wideband virtual voice tuner can't serve
 // a grant (frequency outside its IQ window) and a physical voice

--- a/internal/tui/panels/metrics.go
+++ b/internal/tui/panels/metrics.go
@@ -27,7 +27,7 @@ var curatedMetrics = []string{
 	"gophertrunk_calls_active",
 	"gophertrunk_calls_total",
 	"gophertrunk_grants_total",
-	"gophertrunk_cc_locked",
+	"gophertrunk_control_channel_locked",
 	"gophertrunk_sse_clients",
 	"gophertrunk_devices_attached",
 	"gophertrunk_tone_alerts_total",

--- a/web/src/panels/Metrics.tsx
+++ b/web/src/panels/Metrics.tsx
@@ -30,7 +30,7 @@ const CURATED = [
   "gophertrunk_calls_active",
   "gophertrunk_calls_total",
   "gophertrunk_grants_total",
-  "gophertrunk_cc_locked",
+  "gophertrunk_control_channel_locked",
   "gophertrunk_sse_clients",
   "gophertrunk_devices_attached",
   "gophertrunk_tone_alerts_total",
@@ -132,7 +132,7 @@ export function Metrics() {
         },
         {
           label: "cc_locked",
-          data: hist.map((s) => s.values.get("gophertrunk_cc_locked") ?? 0),
+          data: hist.map((s) => s.values.get("gophertrunk_control_channel_locked") ?? 0),
           borderColor: "rgb(234, 179, 8)",
           backgroundColor: "rgba(234, 179, 8, 0.15)",
           fill: true,


### PR DESCRIPTION
## Summary

Two TETRA telemetry/UI bugs a reporter hit while monitoring a live system: a radio ID still showing as a talkgroup in the live Active Calls list, and TETRA metrics not counting.

## Changes

**1. Radio ID lingering in the Active Calls list (`internal/trunking/engine.go`)**
- The earlier RadioID→TGID retraction cleaned the Talkgroups *catalogue* but not the control-only "observed" call set — the other half of what the Active Calls UI renders. A TETRA notification / D-CONNECT addressed to the calling party creates a provisional call keyed by the radio ID as its `GroupID`; the notification-supersede only released the *pool-bound* call, leaving the observed entry to linger as a phantom `TG <radioID>` (the reporter's "this message is not passed anywhere else").
- `observeCall` now skips individual and known-radio grants, and `noteRadio` retracts any observed call already tracked under an SSI once that SSI is revealed to be a subscriber radio.

**2. TETRA metrics not counting (`internal/metrics/prom.go`, dashboards)**
- `grants_total` was never defined or incremented — the metrics event handler had no `KindGrant` case, so TETRA grants went uncounted. Added a protocol-labelled `grants_total{system,protocol}` wired to `events.KindGrant`.
- TETRA voice calls were miscounted under the DMR-named `dmr_voice_calls_total` (its per-timeslot increment was gated only on a non-zero timeslot, which TETRA carries 1..4). Gated it to the DMR protocol.
- The curated TUI/web dashboards requested a `gophertrunk_cc_locked` metric the daemon never emits (it exports `gophertrunk_control_channel_locked`); pointed both panels at the real name.

## Test plan

- [x] `make vet test` is green locally
- [ ] `make integration` — n/a (no daemon/DSP/replay wiring changed)
- [x] Added regression tests: `TestEngineRetractsRadioIDFromActiveCalls` (radio ID gone from Active Calls after the authoritative grant supersedes it) and `TestTETRAMetricsGrantsAndNoDMRMislabel` (a TETRA grant increments `grants_total`; a slotted TETRA call does not touch the DMR counter).
- [ ] Smoke-tested against real hardware — n/a (engine/metrics logic); verified against the reporter's Active-Calls screenshot and metrics dashboard.

## Breaking changes

None. `dmr_voice_calls_total` is now DMR-only as its name/help always documented (TETRA previously polluted it — a bug, not an interface guarantee). The new `grants_total` and the corrected `control_channel_locked` dashboard reference are additive/fixes; no config keys, flags, or endpoints change.

## Docs / CHANGELOG

- [x] Added `## [Unreleased]` → Fixed bullets to `CHANGELOG.md` for both changes
- [ ] `README.md` / `docs/` — n/a

## Linked issues

n/a (follow-up bug reports; the concurrent-load garble equalizer work is tracked in #1001)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MRpTF8cuEe99m7am2S1SZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015MRpTF8cuEe99m7am2S1SZ)_