### PR TITLE
recordings: cross-site duplicate-recording suppression (recordings.dedup)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **Cross-site duplicate-recording suppression (`recordings.dedup`).** When
+  monitoring several networked / simulcast sites where the same talkgroup carries
+  the same traffic, a call heard on more than one system is now saved once
+  instead of once per site. Enable with `recordings.dedup.enabled: true`
+  (`window_seconds` defaults to 60): a call whose `(talkgroup, source)` was
+  already recorded from a *different* system within the window is skipped. Keying
+  on the calling-radio RID (globally unique in a network) means two genuinely
+  different calls that share a talkgroup number across systems still both record
+  when their sources are known; a re-key on the same system is never suppressed;
+  and live monitoring is unaffected (recording-only). Off by default.
 - **`GET /api/v1/grants` — a pollable log of recent control-channel grants.**
   GopherTrunk decodes a source RID off most `GRP_VCH_GRANT` TSBKs, and already
   streams every grant live over the `grant` SSE event; this adds the pollable

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -1287,6 +1287,10 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 				MaxBoostDB:   cfg.Recordings.Normalize.MaxBoostDB,
 			},
 			Enhance: enhancerConfigFromYAML(cfg.Recordings.Enhance),
+			Dedup: voice.DedupConfig{
+				Enabled: cfg.Recordings.Dedup.Enabled,
+				Window:  cfg.Recordings.Dedup.Window(),
+			},
 		})
 		if err != nil {
 			return nil, fmt.Errorf("daemon: recorder: %w", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1826,6 +1826,11 @@ type RecordingsConfig struct {
 	// consistent level. Off by default. This is post-processing of the
 	// recorded WAV only; live monitoring/playback is unaffected.
 	Normalize NormalizeConfig `yaml:"normalize"`
+	// Dedup suppresses near-simultaneous duplicate recordings of the same call
+	// heard on more than one monitored system — networked / simulcast sites
+	// where the same talkgroup carries the same traffic, so a call is saved once
+	// instead of once per site. Off by default. See DedupConfig.
+	Dedup DedupConfig `yaml:"dedup"`
 	// WarmDMRAudio selects the opt-in "ambe2-dmr-warm" vocoder for DMR
 	// voice instead of the default "ambe2-dmr". It applies a gentle
 	// output high-shelf that trims ~2 dB above ~1.5 kHz, softening the
@@ -1871,6 +1876,31 @@ func (n NormalizeConfig) AppliesToRecording() bool {
 // copy should be normalized in the broadcast subsystem.
 func (n NormalizeConfig) AppliesToDistributed() bool {
 	return n.Enabled && (n.ApplyTo == "distributed" || n.ApplyTo == "both")
+}
+
+// DedupConfig is the YAML shape of cross-site duplicate-recording suppression.
+// When enabled, a call whose (talkgroup, source) was already recorded from a
+// DIFFERENT monitored system within the window is skipped — so a call heard on
+// several networked / simulcast sites is saved once instead of once per site. A
+// re-key on the SAME system is always recorded. Keying on the source RID (which
+// is globally unique in a network) means two genuinely different calls that
+// happen to share a talkgroup number across systems still both record whenever
+// their sources are known and differ.
+type DedupConfig struct {
+	Enabled bool `yaml:"enabled"`
+	// WindowSeconds is how long a recorded call suppresses another system's copy
+	// of the same (talkgroup, source); it should cover a typical over plus
+	// inter-site skew. Default 60 when enabled.
+	WindowSeconds int `yaml:"window_seconds"`
+}
+
+// Window returns the dedup suppression window, applying the 60 s default when
+// enabled with an unset/invalid WindowSeconds.
+func (d DedupConfig) Window() time.Duration {
+	if d.WindowSeconds <= 0 {
+		return 60 * time.Second
+	}
+	return time.Duration(d.WindowSeconds) * time.Second
 }
 
 // EnhanceConfig is the YAML shape of the opt-in voice enhancement chain

--- a/internal/configbuilder/fieldmeta.go
+++ b/internal/configbuilder/fieldmeta.go
@@ -262,6 +262,10 @@ var fieldMetas = map[string]FieldMeta{
 	"NormalizeConfig.TruePeakDBTP":       {Label: "True peak (dBTP)", Help: "True-peak ceiling in dBTP. Default -1.5 when enabled."},
 	"NormalizeConfig.MaxBoostDB":         {Label: "Max gain (dB)", Help: "Cap on applied gain in either direction so quiet calls don't amplify hiss. Default 12 when enabled."},
 
+	"RecordingsConfig.Dedup":       {Help: "Cross-site duplicate suppression — when monitoring networked/simulcast sites that share talkgroups, save a call once instead of once per site."},
+	"DedupConfig.Enabled":          {Help: "Skip recording a call already being recorded from another monitored system (same talkgroup + source)."},
+	"DedupConfig.WindowSeconds":    {Label: "Window (seconds)", Help: "How long a recorded call suppresses another system's copy of it. Default 60 when enabled."},
+
 	// ---- Recordings ▸ Voice enhancement (sound-good chain) -----------------
 	"RecordingsConfig.Enhance":   {Label: "Voice enhancement", Help: "Opt-in \"sound-good\" chain for decoded digital voice: band-limits to the telephone band, warms the bright software-AMBE+2 timbre, runs the AGC to a louder target, and (optionally) compresses. Shapes BOTH recordings and live monitoring. Trades a little faithfulness for a cleaner/louder sound like OP25 / Trunk Recorder / DSDPlus. Off by default."},
 	"EnhanceConfig.Enabled":      {Help: "Turn the voice enhancement chain on. When off, decoded audio is byte-identical to the faithful path."},

--- a/internal/configbuilder/fieldmeta.go
+++ b/internal/configbuilder/fieldmeta.go
@@ -262,9 +262,9 @@ var fieldMetas = map[string]FieldMeta{
 	"NormalizeConfig.TruePeakDBTP":       {Label: "True peak (dBTP)", Help: "True-peak ceiling in dBTP. Default -1.5 when enabled."},
 	"NormalizeConfig.MaxBoostDB":         {Label: "Max gain (dB)", Help: "Cap on applied gain in either direction so quiet calls don't amplify hiss. Default 12 when enabled."},
 
-	"RecordingsConfig.Dedup":       {Help: "Cross-site duplicate suppression — when monitoring networked/simulcast sites that share talkgroups, save a call once instead of once per site."},
-	"DedupConfig.Enabled":          {Help: "Skip recording a call already being recorded from another monitored system (same talkgroup + source)."},
-	"DedupConfig.WindowSeconds":    {Label: "Window (seconds)", Help: "How long a recorded call suppresses another system's copy of it. Default 60 when enabled."},
+	"RecordingsConfig.Dedup":    {Help: "Cross-site duplicate suppression — when monitoring networked/simulcast sites that share talkgroups, save a call once instead of once per site."},
+	"DedupConfig.Enabled":       {Help: "Skip recording a call already being recorded from another monitored system (same talkgroup + source)."},
+	"DedupConfig.WindowSeconds": {Label: "Window (seconds)", Help: "How long a recorded call suppresses another system's copy of it. Default 60 when enabled."},
 
 	// ---- Recordings ▸ Voice enhancement (sound-good chain) -----------------
 	"RecordingsConfig.Enhance":   {Label: "Voice enhancement", Help: "Opt-in \"sound-good\" chain for decoded digital voice: band-limits to the telephone band, warms the bright software-AMBE+2 timbre, runs the AGC to a louder target, and (optionally) compresses. Shapes BOTH recordings and live monitoring. Trades a little faithfulness for a cleaner/louder sound like OP25 / Trunk Recorder / DSDPlus. Off by default."},

--- a/internal/configbuilder/webschema_test.go
+++ b/internal/configbuilder/webschema_test.go
@@ -42,10 +42,12 @@ var webRoundTripAllow = map[string][]string{
 	"SystemConfig": {"Sites"},
 	"SiteConfig":   {"RFSS", "Site", "Name"},
 
-	// Research/offline cryptolab crypto-frame capture path. Round-trips via the
-	// RecordingsConfig index signature; editable in the TUI and raw YAML. A
-	// bespoke web editor for this niche knob is intentionally omitted.
-	"RecordingsConfig": {"CryptoCapturePath"},
+	// Research/offline cryptolab crypto-frame capture path, and cross-site
+	// duplicate-recording suppression (recordings.dedup) — both round-trip via
+	// the RecordingsConfig index signature; editable in the TUI, raw YAML, and
+	// the web builder's generic editor. A bespoke web editor is a follow-up.
+	"RecordingsConfig": {"CryptoCapturePath", "Dedup"},
+	"DedupConfig":      {"Enabled", "WindowSeconds"},
 
 	// Event-driven raw-IQ auto-record (baseband.auto_record) — a debug/research
 	// capture hook. Round-trips through the BasebandConfig index signature;

--- a/internal/voice/recorder.go
+++ b/internal/voice/recorder.go
@@ -137,7 +137,36 @@ type Recorder struct {
 	// timestamps (display.timezone). Never nil after NewRecorder; defaults
 	// to time.UTC when the caller leaves it unset (the prior behaviour).
 	displayLoc *time.Location
+
+	// dedup configures cross-site duplicate-recording suppression; dedupSeen is
+	// the recently-recorded (talkgroup, source) → (system, time) index it keys
+	// on, guarded by dedupMu. Only consulted for file-writing recorders (a
+	// decode-only recorder writes nothing, so there is no duplicate to suppress).
+	dedup     DedupConfig
+	dedupMu   sync.Mutex
+	dedupSeen map[dedupKey]dedupEntry
 }
+
+// DedupConfig configures cross-site duplicate-recording suppression. When
+// Enabled, a call whose (talkgroup, source) was already recorded from a
+// DIFFERENT system within Window is skipped — one copy of a call heard on
+// several networked/simulcast sites instead of one per site.
+type DedupConfig struct {
+	Enabled bool
+	Window  time.Duration
+}
+
+type dedupKey struct{ group, source uint32 }
+
+type dedupEntry struct {
+	system string
+	at     time.Time
+}
+
+// dedupMaxKeys bounds the recently-recorded index so a long-running busy
+// multi-system deployment cannot grow it without bound; stale keys are pruned
+// once it is exceeded.
+const dedupMaxKeys = 4096
 
 // DecodedPCMSink receives PCM the recorder decodes from digital
 // vocoder frames, so live consumers (web stream, host player,
@@ -250,6 +279,10 @@ type RecorderOptions struct {
 	// match the local wall-clock the rest of the UI/logs already show,
 	// instead of always UTC.
 	DisplayLoc *time.Location
+
+	// Dedup opts into cross-site duplicate-recording suppression (off by
+	// default). See DedupConfig / Recorder.dedupSuppress.
+	Dedup DedupConfig
 }
 
 // DefaultVocoderForProtocol returns the Protocol → vocoder-name
@@ -345,11 +378,46 @@ func NewRecorder(opts RecorderOptions) (*Recorder, error) {
 		vocoderForProtocol: vocoderMap,
 		displayLoc:         loc,
 		decodeOnly:         decodeOnly,
+		dedup:              opts.Dedup,
+		dedupSeen:          make(map[dedupKey]dedupEntry),
 		sessions:           make(map[string]*recordingSession),
 		runDone:            make(chan struct{}),
 	}
 	r.sub = opts.Bus.Subscribe()
 	return r, nil
+}
+
+// dedupSuppress reports whether this CallStart is a cross-site duplicate of a
+// call already recorded within the window from a DIFFERENT system, and records
+// this call's (talkgroup, source) fingerprint for future checks. Networked /
+// simulcast sites carry the same call under the same talkgroup and calling-radio
+// RID, so only the first system to key it up records; later copies are skipped.
+// A re-key on the SAME system is never suppressed (it is a new over). No-op
+// (returns false) when dedup is disabled. now is passed in for testability.
+func (r *Recorder) dedupSuppress(cs trunking.CallStart, now time.Time) bool {
+	if !r.dedup.Enabled {
+		return false
+	}
+	key := dedupKey{group: cs.Grant.GroupID, source: cs.Grant.SourceID}
+	r.dedupMu.Lock()
+	defer r.dedupMu.Unlock()
+	if prev, ok := r.dedupSeen[key]; ok && now.Sub(prev.at) <= r.dedup.Window && prev.system != cs.Grant.System {
+		// The same call is already being recorded from another system. Refresh
+		// the window so a long call keeps suppressing late copies, keep the
+		// original recording system, and skip this one.
+		prev.at = now
+		r.dedupSeen[key] = prev
+		return true
+	}
+	r.dedupSeen[key] = dedupEntry{system: cs.Grant.System, at: now}
+	if len(r.dedupSeen) > dedupMaxKeys {
+		for k, e := range r.dedupSeen {
+			if now.Sub(e.at) > r.dedup.Window {
+				delete(r.dedupSeen, k)
+			}
+		}
+	}
+	return false
 }
 
 // VoiceEnhance returns the current voice enhancement config (defaults
@@ -676,6 +744,16 @@ func (r *Recorder) handleStart(cs trunking.CallStart) {
 		r.log.Debug("recorder: skipping encrypted call",
 			"device", cs.DeviceSerial, "tg", cs.Grant.GroupID,
 			"alg", cs.Grant.AlgorithmID, "key", cs.Grant.KeyID)
+		return
+	}
+	if !r.decodeOnly && r.dedupSuppress(cs, time.Now()) {
+		// Cross-site duplicate: this exact call (talkgroup + source) is already
+		// being recorded from another monitored system. Skip the file write so a
+		// call heard on several networked/simulcast sites is saved once. Live
+		// follow/monitoring is unaffected (this gate is recording-only).
+		r.log.Info("recorder: skipping cross-site duplicate recording",
+			"device", cs.DeviceSerial, "system", cs.Grant.System,
+			"tg", cs.Grant.GroupID, "src", cs.Grant.SourceID)
 		return
 	}
 	r.mu.Lock()

--- a/internal/voice/recorder_test.go
+++ b/internal/voice/recorder_test.go
@@ -31,6 +31,49 @@ func mkRecorder(t *testing.T, writeRaw bool) (*Recorder, *events.Bus, string) {
 	return r, bus, dir
 }
 
+// TestRecorderCrossSiteDedup pins cross-site duplicate suppression: the same
+// call (talkgroup + source) heard on a second monitored system within the
+// window is skipped, a re-key on the same system is not, a different source on
+// the same talkgroup records, and a copy after the window elapses records.
+func TestRecorderCrossSiteDedup(t *testing.T) {
+	bus := events.NewBus(8)
+	r, err := NewRecorder(RecorderOptions{
+		Bus:        bus,
+		OutDir:     t.TempDir(),
+		SampleRate: 8000,
+		Dedup:      DedupConfig{Enabled: true, Window: 60 * time.Second},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t0 := time.Unix(1_700_000_000, 0)
+	cs := func(system string, tg, src uint32) trunking.CallStart {
+		return trunking.CallStart{Grant: trunking.Grant{System: system, GroupID: tg, SourceID: src}}
+	}
+
+	if r.dedupSuppress(cs("SiteA", 1020529, 1005746), t0) {
+		t.Fatal("first sighting on SiteA should record, not suppress")
+	}
+	if !r.dedupSuppress(cs("SiteB", 1020529, 1005746), t0.Add(time.Second)) {
+		t.Error("SiteB near-simultaneous copy of the same call should be suppressed")
+	}
+	if r.dedupSuppress(cs("SiteA", 1020529, 1005746), t0.Add(2*time.Second)) {
+		t.Error("a re-key on the same system must not be suppressed")
+	}
+	if r.dedupSuppress(cs("SiteB", 1020529, 1009999), t0.Add(2*time.Second)) {
+		t.Error("a different source on the same talkgroup must record")
+	}
+	if r.dedupSuppress(cs("SiteB", 1020529, 1005746), t0.Add(120*time.Second)) {
+		t.Error("a copy after the window elapsed should record")
+	}
+
+	// Disabled by default: nothing is ever suppressed.
+	rOff, _ := NewRecorder(RecorderOptions{Bus: bus, OutDir: t.TempDir(), SampleRate: 8000})
+	if rOff.dedupSuppress(cs("SiteA", 1, 1), t0) || rOff.dedupSuppress(cs("SiteB", 1, 1), t0) {
+		t.Error("dedup disabled: no call should ever be suppressed")
+	}
+}
+
 func TestRecorderWritesPerCallWav(t *testing.T) {
 	r, bus, dir := mkRecorder(t, false)
 	defer r.Close()


### PR DESCRIPTION
## Summary

When monitoring 2–3 networked/simulcast P25 or TETRA sites that share most talkgroups, the same call is currently recorded once per site. This adds an opt-in `recordings.dedup` that saves such a call once instead of once per site.

## Changes

- **`internal/config/config.go`** — new `DedupConfig` (`enabled`, `window_seconds`, default 60 s) under `RecordingsConfig`.
- **`cmd/gophertrunk/daemon.go`** — thread the config into `RecorderOptions` (same pattern as `Normalize`/`Enhance`).
- **`internal/voice/recorder.go`** — a suppression gate in `handleStart` (mirrors the existing `record=false` / `recordDisabled` skips): a small recently-recorded index keyed by `(talkgroup, source)` **across systems**. A CallStart whose fingerprint was recorded by a *different* system within the window is skipped (no files opened, no CallComplete). Same-system re-keys and different-source calls still record; live follow/play is unaffected (decode-only recorder never suppresses); the index self-prunes past the window.
- **`internal/configbuilder/`** — field-help entries for the new fields; `recordings.dedup` round-trips through the web builder's index-signature editor (allow-listed like `crypto_capture_path` / `auto_record`), editable in the TUI, raw YAML, and the generic web editor.

## Test plan

- [x] `make vet test` is green locally
- [ ] `make integration` — n/a (no daemon/DSP/replay wiring beyond the recorder gate)
- [x] Added `internal/voice/recorder_test.go` coverage: cross-system duplicate suppressed; same-system re-key still recorded; different source still recorded; suppression expires after the window; disabled = no-op.
- [ ] Smoke-tested against real hardware — n/a (recorder gate logic)

## Breaking changes

None. Off by default (`recordings.dedup.enabled: false`); no change unless an operator opts in.

## Docs / CHANGELOG

- [x] Added an `## [Unreleased]` bullet to `CHANGELOG.md`
- [ ] `README.md` / `docs/` — n/a (config field is self-documented via field-help)

## Linked issues

n/a (the DMO half of the same request is tracked in #1003; not included here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MRpTF8cuEe99m7am2S1SZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015MRpTF8cuEe99m7am2S1SZ)_