### PR TITLE
fix(tetra): hold individual wakeup pages so a radio SSI can't leak as a talkgroup

### DIFF
--- a/internal/scanner/ccdecoder/decodequeue_test.go
+++ b/internal/scanner/ccdecoder/decodequeue_test.go
@@ -1,0 +1,71 @@
+package ccdecoder
+
+import "testing"
+
+// TestDecodeQueueBudgetScalesWithRate pins the issue #402 fix: the decode queue's
+// depth is a wall-clock sample budget derived from the sample rate, NOT a fixed
+// count of chunks. The old fixed 128-chunk depth collapsed to tens of ms on
+// small-datagram sources (a remote USRP over SoapyRemote), producing decode
+// overruns at idle CPU. The budget must give a usable fraction of a second at
+// every realistic rate and clamp memory at very high rates.
+func TestDecodeQueueBudgetScalesWithRate(t *testing.T) {
+	cases := []struct {
+		name       string
+		rateHz     float64
+		wantMinSec float64 // budget must buy at least this many seconds
+	}{
+		{"usrp-1Msps", 1_000_000, 0.4}, // the reported case: was ~47 ms at 128 chunks
+		{"airspy-2p4Msps", 2_400_000, 0.4},
+		{"replay-144k", 144_000, 0.0}, // floored, not zero
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			budget, chanCap := decodeQueueBudget(c.rateHz)
+			if budget < minDecodeQueueSamples {
+				t.Fatalf("budget %d < floor %d", budget, minDecodeQueueSamples)
+			}
+			gotSec := float64(budget) / c.rateHz
+			if gotSec < c.wantMinSec {
+				t.Errorf("rate %.0f: budget %d = %.3f s, want >= %.3f s", c.rateHz, budget, gotSec, c.wantMinSec)
+			}
+			// The backing channel must hold ~budget/64 chunks (to within
+			// integer-division rounding) so the sample budget — not the slot
+			// count — is the limiter, unless clamped at the max.
+			if chanCap < minDecodeQueueChunks {
+				t.Errorf("chanCap %d below floor %d", chanCap, minDecodeQueueChunks)
+			}
+			if int64(chanCap+1)*64 < budget && chanCap < maxDecodeQueueChunks {
+				t.Errorf("chanCap %d too small for budget %d", chanCap, budget)
+			}
+		})
+	}
+}
+
+// TestDecodeQueueBudgetClampsMemory guards the upper clamp: a very high sample
+// rate must not size an unbounded queue.
+func TestDecodeQueueBudgetClampsMemory(t *testing.T) {
+	budget, chanCap := decodeQueueBudget(50_000_000) // 50 MS/s
+	if budget != maxDecodeQueueSamples {
+		t.Errorf("budget at 50 MS/s = %d, want clamp %d", budget, maxDecodeQueueSamples)
+	}
+	if chanCap > maxDecodeQueueChunks {
+		t.Errorf("chanCap %d exceeds clamp %d", chanCap, maxDecodeQueueChunks)
+	}
+}
+
+// TestDecodeQueueBudgetVsOldFixedDepth documents why the old constant was wrong:
+// 128 chunks of ~369 samples (a SoapyRemote cs16 datagram) at 1 MS/s was ~47 ms,
+// far under the driver's own 400 ms channel — so the decode queue overflowed
+// while the driver reported nothing. The new budget must beat that comfortably.
+func TestDecodeQueueBudgetVsOldFixedDepth(t *testing.T) {
+	const soapyChunkSamples = (1500 - 24) / 4 // MTU - header, complex-int16
+	oldSec := float64(128*soapyChunkSamples) / 1_000_000
+	budget, _ := decodeQueueBudget(1_000_000)
+	newSec := float64(budget) / 1_000_000
+	if newSec <= oldSec {
+		t.Fatalf("new budget %.3f s not better than old fixed depth %.3f s", newSec, oldSec)
+	}
+	if oldSec > 0.1 {
+		t.Fatalf("sanity: old fixed depth %.3f s unexpectedly large", oldSec)
+	}
+}

--- a/internal/scanner/ccdecoder/decoder.go
+++ b/internal/scanner/ccdecoder/decoder.go
@@ -1169,7 +1169,15 @@ func (d *Decoder) observeIQPower(iq []complex64) {
 		d.metrics.RecordIQDCRatioDb(system, ratioDb)
 		d.metrics.RecordIQClipRatio(system, clipRatio)
 	}
-	if dbfs < iqLowPowerThresholdDbFS && now.Sub(d.pwLowLogAt) >= 5*time.Second {
+	if dbfs < iqLowPowerThresholdDbFS && !d.locked.Load() && now.Sub(d.pwLowLogAt) >= 30*time.Second {
+		// Only meaningful when the decoder CANNOT lock — a real antenna/gain/USB
+		// fault. Once the control channel is locked and decoding, a low ABSOLUTE
+		// level is fine (e.g. a USRP/SDR at conservative gain sits at ~-60 dBFS
+		// with ~55 dB of unused ADC headroom yet decodes TETRA cleanly), so
+		// emitting it every few seconds while locked was pure noise. Gated on
+		// !locked and throttled to 30 s to match the clip / DC-dominant siblings.
+		// The Prometheus gauge (RecordIQPowerDbFS above) still reflects every
+		// window regardless of lock, so the level stays observable.
 		d.log.Debug("ccdecoder: iq power very low — check antenna, gain, USB",
 			"system", system, "dbfs", dbfs, "dc_dbfs", dcDbfs, "dc_ratio_db", ratioDb)
 		d.pwLowLogAt = now

--- a/internal/scanner/ccdecoder/decoder.go
+++ b/internal/scanner/ccdecoder/decoder.go
@@ -199,19 +199,55 @@ const zeroIFHealthErrPct = 20
 // iqClipLog / iqDCLog 30 s cadence so a stuck adjacent-channel lock logs steadily.
 const carrierOffsetWarnInterval = 30 * time.Second
 
-// decodeQueueDepth is the size of the internal queue between the
-// lightweight IQ forwarder and the decode goroutine (issue #402). The
-// SDR driver drops the instant its own small delivery channel backs up
-// (~27 ms at 2.4 MS/s, ~68 ms at 960 kS/s), so any decode/retune/GC
-// stall longer than that on a single combined goroutine corrupts the
-// continuous symbol stream. The forwarder drains the driver channel into
-// this larger queue so a transient stall backs up here instead of
-// dropping RF; at 65 KB/chunk this is ~8 MB and buys ≈0.44 s of slack at
-// 2.4 MS/s (≈1.1 s at 960 kS/s). Deeper would absorb longer stalls at the
-// cost of higher decode latency under a sustained backlog; 128 balances
-// the two. Sustained overload still drops here — attributably, via
-// RecordDecodeOverrun — rather than silently in the driver.
-const decodeQueueDepth = 128
+// The decode queue between the lightweight IQ forwarder and the decode goroutine
+// (issue #402) is bounded by a wall-clock SAMPLE BUDGET, not a fixed count of
+// chunks. The SDR driver drops the instant its own delivery channel backs up, so
+// any decode/retune/GC stall longer than the queue's depth-in-seconds corrupts
+// the continuous symbol stream. A fixed chunk count made that depth collapse on
+// small-datagram sources: SoapyRemote hands a remote USRP ~369 samples/datagram,
+// so a 128-chunk queue was only ~47 ms at 1 MS/s — while the driver's own channel
+// is sized for 400 ms and never overflowed, producing decode overruns at idle CPU
+// that the driver never saw. Sizing the budget from the sample rate gives every
+// source the same ~0.5 s of slack regardless of chunk size. Sustained overload
+// still drops here — attributably, via RecordDecodeOverrun — not silently in the
+// driver.
+const (
+	// decodeQueueSeconds is the target wall-clock depth of the decode queue.
+	// ~0.5 s on top of the driver's ~0.4 s channel gives ~0.9 s total slack.
+	decodeQueueSeconds = 0.5
+	// minDecodeQueueSamples floors the budget so a very low sample rate still
+	// gets a usable queue; maxDecodeQueueSamples caps memory at ~64 MB of
+	// complex64 for very high rates (a decode that far behind is unrecoverable
+	// anyway — dropping is correct).
+	minDecodeQueueSamples = 131072
+	maxDecodeQueueSamples = 8 << 20 // 8,388,608 samples
+	// minDecodeQueueChunks / maxDecodeQueueChunks bound the backing channel's
+	// slot count, derived from the budget assuming a small (64-sample) chunk so
+	// the channel is never the real limiter — the sample budget is.
+	minDecodeQueueChunks = 128
+	maxDecodeQueueChunks = 262144
+)
+
+// decodeQueueBudget returns the sample budget and the backing channel's slot
+// count for a decode queue fed at sampleRateHz. Both are clamped so the queue is
+// sane from ~48 kHz replay to 20+ MS/s live SDRs.
+func decodeQueueBudget(sampleRateHz float64) (budgetSamples int64, chanCap int) {
+	b := int64(decodeQueueSeconds * sampleRateHz)
+	if b < minDecodeQueueSamples {
+		b = minDecodeQueueSamples
+	}
+	if b > maxDecodeQueueSamples {
+		b = maxDecodeQueueSamples
+	}
+	c := int(b / 64)
+	if c < minDecodeQueueChunks {
+		c = minDecodeQueueChunks
+	}
+	if c > maxDecodeQueueChunks {
+		c = maxDecodeQueueChunks
+	}
+	return b, c
+}
 
 // Tuner is the subset of sdr.Device the decoder uses for retuning.
 // Matches the same interface cchunt + conventional consume so the
@@ -322,6 +358,12 @@ type Decoder struct {
 	autotuneApplied atomic.Int64
 	locked          atomic.Bool
 	lastATSampleAt  time.Time
+	// queuedSamples counts IQ samples parked in the decode queue (issue #402).
+	// The queue's real limit is a wall-clock sample budget, not a fixed chunk
+	// count, so the depth is invariant to how the SDR driver chunks delivery
+	// (a remote USRP delivers many tiny datagrams; an Airspy a few big blocks).
+	// The forwarder adds on enqueue; the decode goroutine subtracts on dequeue.
+	queuedSamples atomic.Int64
 	// carrierOffsetWarnHz is the large-offset WARN threshold (Options.
 	// CarrierOffsetWarnHz, defaulted in New). lastOffsetWarnAt throttles the
 	// WARN to one line per carrierOffsetWarnInterval while the offset stays
@@ -558,8 +600,10 @@ func (d *Decoder) Run(ctx context.Context) error {
 	// keeps the driver channel drained into a larger queue; decode and
 	// retune run here, off the ingestion path, so a stall backs up in the
 	// queue instead of dropping RF.
-	decodeCh := make(chan []complex64, decodeQueueDepth)
-	go d.forwardIQ(ctx, stream, decodeCh)
+	budgetSamples, chanCap := decodeQueueBudget(d.sampleRateHz)
+	decodeCh := make(chan []complex64, chanCap)
+	d.queuedSamples.Store(0)
+	go d.forwardIQ(ctx, stream, decodeCh, budgetSamples)
 
 	for {
 		select {
@@ -605,6 +649,7 @@ func (d *Decoder) Run(ctx context.Context) error {
 				}
 				return streamClosedErr(d.iq)
 			}
+			d.queuedSamples.Add(-int64(len(iq))) // dequeued — free budget before decode
 			d.pump(iq)
 			d.putIQBuf(iq) // decode done — recycle the queue buffer
 		}
@@ -624,15 +669,33 @@ func (d *Decoder) Run(ctx context.Context) error {
 // hands the driver's ring slot straight back; only the pooled copy lives
 // in the queue. Kept cheap (an O(n) observe + memcpy) so it always
 // out-drains the driver channel. Under *sustained* overload the queue
-// fills and chunks are dropped here, attributably (RecordDecodeOverrun +
-// a throttled WARN), rather than silently in the driver. Closing out on
-// return propagates stream EOF / ctx cancellation to Run.
-func (d *Decoder) forwardIQ(ctx context.Context, in <-chan []complex64, out chan<- []complex64) {
+// exceeds its sample budget and chunks are dropped here, attributably
+// (RecordDecodeOverrun + a throttled WARN), rather than silently in the driver.
+// The limit is a wall-clock sample budget (budgetSamples), not the channel's
+// slot count, so the depth-in-seconds is invariant to the driver's chunk size.
+// Closing out on return propagates stream EOF / ctx cancellation to Run.
+func (d *Decoder) forwardIQ(ctx context.Context, in <-chan []complex64, out chan<- []complex64, budgetSamples int64) {
 	defer close(out)
 	var (
 		dropped   uint64
 		lastLogAt time.Time
 	)
+	drop := func() {
+		// Decode is sustainedly behind real time: the queue is at its budget.
+		// Surface it as a decode overrun, distinct from the driver's
+		// iq_underruns_total, so "CPU can't keep up" is attributable rather than
+		// looking like an RF fault.
+		dropped++
+		if d.metrics != nil {
+			d.metrics.RecordDecodeOverrun()
+		}
+		if now := time.Now(); now.Sub(lastLogAt) >= time.Second {
+			d.log.Warn("ccdecoder: decode can't keep up with real time; dropping IQ at the decode queue (raise CPU / lower sample rate / shed load) — issue #402",
+				"dropped_since_last", dropped)
+			dropped = 0
+			lastLogAt = now
+		}
+	}
 	for {
 		select {
 		case <-ctx.Done():
@@ -642,27 +705,25 @@ func (d *Decoder) forwardIQ(ctx context.Context, in <-chan []complex64, out chan
 				return
 			}
 			d.observeIQPower(iq) // measures the raw driver chunk (every delivery)
+			// Sample-budget gate: drop before copying if enqueueing this chunk
+			// would push the in-flight backlog past the wall-clock budget. This
+			// caps decode latency in seconds, independent of chunk size.
+			if d.queuedSamples.Load()+int64(len(iq)) > budgetSamples {
+				drop()
+				continue
+			}
 			buf := d.getIQBuf(len(iq))
 			copy(buf, iq) // decouple from the driver's reuse ring before queueing
+			d.queuedSamples.Add(int64(len(buf)))
 			select {
 			case out <- buf:
 			default:
-				// Decode is sustainedly behind real time: the queue is full.
-				// Return the copy to the pool and drop the chunk (caps latency
-				// at the queue depth). Surface it as a decode overrun, distinct
-				// from the driver's iq_underruns_total, so "CPU can't keep up"
-				// is attributable rather than looking like an RF fault.
+				// Channel slot count exhausted despite the budget (only reachable
+				// with pathologically tiny chunks). Undo the reservation, recycle
+				// the copy, and drop — same accounting as the budget path.
+				d.queuedSamples.Add(-int64(len(buf)))
 				d.putIQBuf(buf)
-				dropped++
-				if d.metrics != nil {
-					d.metrics.RecordDecodeOverrun()
-				}
-				if now := time.Now(); now.Sub(lastLogAt) >= time.Second {
-					d.log.Warn("ccdecoder: decode can't keep up with real time; dropping IQ at the decode queue (raise CPU / lower sample rate / shed load) — issue #402",
-						"dropped_since_last", dropped)
-					dropped = 0
-					lastLogAt = now
-				}
+				drop()
 			}
 		}
 	}

--- a/internal/scanner/ccdecoder/decoder_test.go
+++ b/internal/scanner/ccdecoder/decoder_test.go
@@ -1816,12 +1816,13 @@ func TestForwardIQDecouplesIngestFromDecode(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 
-	// Pre-load every chunk and close the source. The forwarder's enqueue is
-	// non-blocking (it drops on a full queue), so it runs to completion with
-	// no consumer: the first two chunks land in the cap-2 queue and the next
-	// three are dropped. Waiting for it to finish before draining keeps the
-	// queued set and drop count deterministic (a concurrent drain would race
-	// the last enqueue). Tag each chunk by its first sample to check order.
+	// Pre-load every chunk and close the source. The forwarder drops once the
+	// in-flight sample budget is reached, so with a 2-sample budget and
+	// 1-sample chunks it runs to completion with no consumer: the first two
+	// chunks land in the queue and the next three are dropped. Waiting for it to
+	// finish before draining keeps the queued set and drop count deterministic (a
+	// concurrent drain would race the last enqueue). Tag each chunk by its first
+	// sample to check order.
 	in := make(chan []complex64, 5)
 	out := make(chan []complex64, 2)
 	mk := func(tag float32) []complex64 { return []complex64{complex(tag, 0)} }
@@ -1831,7 +1832,7 @@ func TestForwardIQDecouplesIngestFromDecode(t *testing.T) {
 	close(in)
 
 	done := make(chan struct{})
-	go func() { d.forwardIQ(context.Background(), in, out); close(done) }()
+	go func() { d.forwardIQ(context.Background(), in, out, 2); close(done) }()
 	<-done // forwarder has processed all 5 chunks and closed out
 
 	var got []float32
@@ -1866,7 +1867,7 @@ func TestForwardIQCopiesDriverBuffer(t *testing.T) {
 	close(in)
 
 	done := make(chan struct{})
-	go func() { d.forwardIQ(context.Background(), in, out); close(done) }()
+	go func() { d.forwardIQ(context.Background(), in, out, 1<<20); close(done) }()
 	<-done
 
 	queued := <-out
@@ -1909,7 +1910,7 @@ func TestIQHealthConcurrentWithForwarder(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(2)
-	go func() { defer wg.Done(); d.forwardIQ(ctx, in, out) }()
+	go func() { defer wg.Done(); d.forwardIQ(ctx, in, out, 1<<20) }()
 	go func() {
 		defer wg.Done()
 		for i := 0; i < 2000; i++ {

--- a/internal/scanner/ccdecoder/iqlowpower_test.go
+++ b/internal/scanner/ccdecoder/iqlowpower_test.go
@@ -1,0 +1,58 @@
+package ccdecoder
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// emitLowPowerWindow drives observeIQPower through one full window of
+// low-absolute-level IQ (dbfs well below iqLowPowerThresholdDbFS) and returns
+// nothing — the caller inspects the log buffer. pwLowLogAt is zeroed first so the
+// 30 s throttle never suppresses the line; only the lock gate can.
+func emitLowPowerWindow(d *Decoder) {
+	chunk := make([]complex64, 128)
+	for i := range chunk {
+		chunk[i] = complex(0.001, 0.001) // mean power 2e-6 ⇒ ~-57 dBFS
+	}
+	d.pwLowLogAt = time.Time{}
+	d.observeIQPower(chunk) // primes pwWindowAt, no record yet
+	d.pwWindowAt = d.pwWindowAt.Add(-2 * iqPowerWindow)
+	d.observeIQPower(chunk) // window elapses → evaluate
+}
+
+// TestIQLowPowerSuppressedWhileLocked is the regression for the cosmetic
+// "iq power very low" DEBUG spam: on a USRP/SDR at conservative gain the channel
+// legitimately sits at ~-60 dBFS yet decodes TETRA cleanly, so the line fired
+// every few seconds while locked. It must only fire when the decoder is NOT
+// locked (a real antenna/gain/USB fault), never while locked and decoding.
+func TestIQLowPowerSuppressedWhileLocked(t *testing.T) {
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	bus := events.NewBus(8)
+	defer bus.Close()
+	d, err := New(Options{Bus: bus, IQ: &fakeIQSource{}, SampleRateHz: 48000, Log: log})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	setActiveSystem(d, "TestSys")
+
+	// Not locked: the low-power hint is meaningful and must be emitted.
+	d.locked.Store(false)
+	emitLowPowerWindow(d)
+	if !strings.Contains(buf.String(), "iq power very low") {
+		t.Fatalf("unlocked low-power window did not log the hint; got:\n%s", buf.String())
+	}
+
+	// Locked and decoding: a low absolute level is fine and must NOT be logged.
+	buf.Reset()
+	d.locked.Store(true)
+	emitLowPowerWindow(d)
+	if strings.Contains(buf.String(), "iq power very low") {
+		t.Errorf("low-power hint logged while locked (spam); got:\n%s", buf.String())
+	}
+}

--- a/internal/trunking/engine.go
+++ b/internal/trunking/engine.go
@@ -88,7 +88,52 @@ type Engine struct {
 	// talkgroup. Bounded by knownRadiosCap; guarded by radiosMu.
 	radiosMu    sync.Mutex
 	knownRadios map[uint32]struct{}
+
+	// held holds TETRA individual (wakeup-page) grants for a short window before
+	// they are allowed to spawn a call. On a group call the SwMI often sends an
+	// individual-addressed Energy-Economy wakeup page (individual=true, no source,
+	// dst = the calling party's radio SSI) ~160 ms before the authoritative group
+	// grant. Spawning the wakeup page immediately created a ghost call + a WAV
+	// directory named after the radio ID, then tore it down when the group grant
+	// superseded it (fragmented recordings, radio IDs leaking as talkgroups). The
+	// hold lets the group grant arrive first and cancel the page; a page that is
+	// never superseded (a genuine unit-to-unit call) is flushed when the window
+	// expires. Keyed by physical channel; guarded by mu.
+	held map[channelKey]*heldGrant
+	// heldFlush marshals an expired hold back onto the engine's single grant-
+	// processing goroutine (the Run loop). The afterFunc timer fires on its own
+	// goroutine, so it cannot call HandleGrant directly without racing Run; it
+	// enqueues the channel key here instead. Buffered + non-blocking send so a
+	// stalled/absent Run loop can never wedge a timer goroutine.
+	heldFlush chan channelKey
+	// afterFunc is time.AfterFunc, injectable so tests can drive the hold window
+	// deterministically. Returns a *time.Timer whose Stop cancels a pending flush.
+	afterFunc func(time.Duration, func()) *time.Timer
+	// tetraIndividualHold is how long a TETRA individual (wakeup-page) grant is
+	// held for an authoritative group grant to supersede it. The observed page →
+	// group gap is ~160 ms; 300 ms covers it with margin. A held genuine unit-to-
+	// unit call records this much later, an acceptable cost.
+	tetraIndividualHold time.Duration
 }
+
+// channelKey identifies a physical TETRA logical channel (carrier + timeslot on
+// a system), the granularity at which exactly one call is in progress.
+type channelKey struct {
+	system string
+	freq   uint32
+	ts     uint8
+}
+
+// heldGrant is a TETRA individual grant parked in the hold window plus the timer
+// that will flush it if no authoritative group grant supersedes it first.
+type heldGrant struct {
+	grant Grant
+	timer *time.Timer
+}
+
+// defaultTETRAIndividualHold is the hold window applied when the engine is
+// constructed without an explicit value.
+const defaultTETRAIndividualHold = 300 * time.Millisecond
 
 // observedKey identifies a logical call for the observed-call tracker:
 // (System, talkgroup, timeslot) — the same identity HandleGrant's duplicate-
@@ -191,6 +236,11 @@ func NewEngine(opts EngineOptions) (*Engine, error) {
 		calls:          make(map[string]*ActiveCall),
 		synthetic:      make(map[string]*ActiveCall),
 		observed:       make(map[string]*ActiveCall),
+
+		held:                make(map[channelKey]*heldGrant),
+		heldFlush:           make(chan channelKey, 64),
+		afterFunc:           time.AfterFunc,
+		tetraIndividualHold: defaultTETRAIndividualHold,
 	}
 	// Subscribe at construction time so callers can publish grants
 	// before Run starts without losing them.
@@ -254,6 +304,8 @@ func (e *Engine) Run(ctx context.Context) error {
 					e.handleTalkerAlias(a)
 				}
 			}
+		case key := <-e.heldFlush:
+			e.flushHeldGrant(key)
 		case <-tick.C:
 			e.runWatchdog()
 		}
@@ -360,6 +412,88 @@ func (e *Engine) isKnownRadio(ssi uint32) bool {
 	return ok
 }
 
+// channelKeyOf identifies the physical logical channel a grant addresses.
+func channelKeyOf(g Grant) channelKey {
+	return channelKey{system: g.System, freq: g.FrequencyHz, ts: g.Timeslot}
+}
+
+// isTETRAWakeupPage reports whether g is a TETRA individual-addressed page with
+// no source — the Energy-Economy wakeup frame that precedes a group grant and
+// must not be spawned as a private call. A flushed page (heldFromWakeup) still
+// matches this shape; callers gate on heldFromWakeup separately where it matters.
+func isTETRAWakeupPage(g Grant) bool {
+	return g.Protocol == "tetra" && g.Individual && g.SourceID == 0
+}
+
+// holdWakeupPage parks a wakeup page for tetraIndividualHold, arming a timer to
+// flush it if no authoritative group grant supersedes it first. A repeat page
+// for a channel already held refreshes the stored grant without re-arming, so
+// the original deadline still governs (the page → group gap is fixed regardless
+// of how many page repeats arrive).
+func (e *Engine) holdWakeupPage(g Grant) {
+	key := channelKeyOf(g)
+	e.mu.Lock()
+	if h := e.held[key]; h != nil {
+		h.grant = g
+		e.mu.Unlock()
+		return
+	}
+	h := &heldGrant{grant: g}
+	h.timer = e.afterFunc(e.tetraIndividualHold, func() {
+		// Marshal onto the Run goroutine; never call HandleGrant from the timer
+		// goroutine (it would race Run's pool allocation). Non-blocking so a
+		// stopped/absent Run loop cannot wedge the timer goroutine.
+		select {
+		case e.heldFlush <- key:
+		default:
+		}
+	})
+	e.held[key] = h
+	e.mu.Unlock()
+	e.log.Debug("tetra: holding individual wakeup page for a group grant",
+		"grant", g.String(), "hold", e.tetraIndividualHold)
+}
+
+// dropHeldIndividual cancels and discards any held wakeup page for key. Called
+// when an authoritative grant for the same channel arrives (the page is
+// superseded before it ever spawned a call) and on shutdown.
+func (e *Engine) dropHeldIndividual(key channelKey) {
+	e.mu.Lock()
+	h := e.held[key]
+	if h != nil {
+		delete(e.held, key)
+	}
+	e.mu.Unlock()
+	if h != nil {
+		if h.timer != nil {
+			h.timer.Stop()
+		}
+		e.log.Debug("tetra: cancelled held wakeup page (superseded by group grant)",
+			"grant", h.grant.String())
+	}
+}
+
+// flushHeldGrant re-dispatches a wakeup page whose hold window expired with no
+// authoritative group grant to supersede it — a genuine unit-to-unit individual
+// call, which now allocates (heldFromWakeup skips the hold on re-entry). Runs on
+// the Run goroutine via heldFlush. A no-op if the page was already cancelled.
+func (e *Engine) flushHeldGrant(key channelKey) {
+	e.mu.Lock()
+	h := e.held[key]
+	if h != nil {
+		delete(e.held, key)
+	}
+	e.mu.Unlock()
+	if h == nil {
+		return
+	}
+	g := h.grant
+	g.heldFromWakeup = true
+	e.log.Debug("tetra: flushing held wakeup page (no group grant superseded it)",
+		"grant", g.String())
+	e.HandleGrant(g)
+}
+
 func (e *Engine) HandleGrant(g Grant) {
 	if g.At.IsZero() {
 		g.At = e.now()
@@ -376,6 +510,14 @@ func (e *Engine) HandleGrant(g Grant) {
 	e.noteRadio(g.SourceID, g.System)
 	if g.Individual {
 		e.noteRadio(g.GroupID, g.System)
+	}
+	// Cancel a parked TETRA wakeup-page hold on this channel the moment any
+	// non-page grant for the same physical channel arrives — the authoritative
+	// group grant (or any other real allocation) has landed, so the page must not
+	// spawn its ghost call. A page repeat (still a wakeup page) leaves the hold in
+	// place; it is refreshed in the hold block below. See held/heldGrant.
+	if !isTETRAWakeupPage(g) {
+		e.dropHeldIndividual(channelKeyOf(g))
 	}
 	tg := e.talkgroups.Lookup(g.GroupID)
 	if tg == nil && g.GroupID != 0 && !g.Individual && !e.isKnownRadio(g.GroupID) {
@@ -610,6 +752,20 @@ func (e *Engine) HandleGrant(g Grant) {
 				"grant", g.String(), "device", ac.Device.Serial)
 			return
 		}
+	}
+
+	// Hold a TETRA wakeup page. Reaching here means no active call and no fold
+	// matched this channel, so an individual-addressed page (individual=true, no
+	// source) would spawn a fresh call + a WAV directory named after the paged
+	// radio SSI. Park it for tetraIndividualHold instead: the authoritative group
+	// grant that follows a real group call (~160 ms later) cancels it via the
+	// drop above, and only a page that is never superseded — a genuine unit-to-
+	// unit call — is flushed to allocation when the window expires. A repeat page
+	// refreshes the existing hold without re-arming. heldFromWakeup grants have
+	// already served their window and fall through to allocate.
+	if isTETRAWakeupPage(g) && !g.heldFromWakeup {
+		e.holdWakeupPage(g)
+		return
 	}
 
 	// 1) Free device available? Allocate. FindFreeForFrequency skips
@@ -1159,6 +1315,17 @@ func (e *Engine) runWatchdog() {
 }
 
 func (e *Engine) shutdown() {
+	// Cancel any parked wakeup-page timers so they can't fire into a torn-down
+	// engine (their flush is a no-op once Run has exited, but stopping the timers
+	// releases the goroutines promptly).
+	e.mu.Lock()
+	for key, h := range e.held {
+		if h.timer != nil {
+			h.timer.Stop()
+		}
+		delete(e.held, key)
+	}
+	e.mu.Unlock()
 	for _, ac := range e.pool.Active() {
 		e.endCall(ac, EndReasonNormal)
 	}

--- a/internal/trunking/engine_tetra_test.go
+++ b/internal/trunking/engine_tetra_test.go
@@ -1,6 +1,88 @@
 package trunking
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
+
+// noFireAfterFunc replaces the engine's hold timer with one that never fires
+// during a test (a 1 h timer), so the wakeup-page hold window is driven
+// deterministically by the test rather than wall-clock. Stop still works, so the
+// supersede path (dropHeldIndividual) exercises timer cancellation for real.
+func noFireAfterFunc(d time.Duration, f func()) *time.Timer {
+	return time.AfterFunc(time.Hour, f)
+}
+
+// TestEngineTETRAWakeupPageHeldUntilGroupGrant is the regression for the
+// Energy-Economy wakeup-page bug (Discord report + attached bug report): the SwMI
+// sends an individual-addressed page (individual=true, no source, dst = the
+// calling party's radio SSI) ~160 ms before the authoritative group grant.
+// Spawning the page immediately created a ghost call + a WAV directory named
+// after the radio ID, torn down when the group grant superseded it. The page must
+// instead be held so no ghost is ever created, and the group grant then starts
+// the one true call under the GSSI.
+func TestEngineTETRAWakeupPageHeldUntilGroupGrant(t *testing.T) {
+	e, pool, bus, _ := mkEngine(t, 2)
+	defer bus.Close()
+	e.afterFunc = noFireAfterFunc
+
+	const (
+		freq = uint32(467_912_500)
+		ts   = uint8(2)
+		issi = uint32(1005750) // paged radio ID (leaks as a phantom talkgroup today)
+		gssi = uint32(1020545) // the real talkgroup
+	)
+	// The wakeup page. Before the fix this spawns a ghost call under the radio SSI.
+	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: issi, FrequencyHz: freq, Timeslot: ts, Individual: true, TETRAUsageMarker: 8})
+	if n := len(pool.Active()); n != 0 {
+		t.Fatalf("active calls after wakeup page = %d, want 0 (the page must be held, not spawned)", n)
+	}
+
+	// The authoritative group grant lands within the hold window: it cancels the
+	// held page and starts the one real call under the GSSI.
+	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: gssi, SourceID: issi, FrequencyHz: freq, Timeslot: ts, TETRAUsageMarker: 23})
+	act := pool.Active()
+	if len(act) != 1 {
+		t.Fatalf("active calls = %d, want 1 (only the authoritative group call)", len(act))
+	}
+	if got := act[0].Grant.GroupID; got != gssi {
+		t.Errorf("call talkgroup = %d, want %d (no ghost under the radio SSI)", got, gssi)
+	}
+	if got := act[0].Grant.SourceID; got != issi {
+		t.Errorf("call source = %d, want %d", got, issi)
+	}
+}
+
+// TestEngineTETRAWakeupPageFlushesWithoutGroupGrant guards that a genuine
+// unit-to-unit individual call — an individual page that no group grant ever
+// supersedes — still records once the hold window expires, so the hold does not
+// silently drop private calls.
+func TestEngineTETRAWakeupPageFlushesWithoutGroupGrant(t *testing.T) {
+	e, pool, bus, _ := mkEngine(t, 2)
+	defer bus.Close()
+	e.afterFunc = noFireAfterFunc
+
+	const (
+		freq = uint32(467_912_500)
+		ts   = uint8(1)
+		issi = uint32(1005750) // the individually-called radio
+	)
+	page := Grant{System: "X", Protocol: "tetra", GroupID: issi, FrequencyHz: freq, Timeslot: ts, Individual: true}
+	e.HandleGrant(page)
+	if n := len(pool.Active()); n != 0 {
+		t.Fatalf("active calls after page = %d, want 0 (held)", n)
+	}
+
+	// The hold window expires with no group grant: the flush allocates the call.
+	e.flushHeldGrant(channelKeyOf(page))
+	act := pool.Active()
+	if len(act) != 1 {
+		t.Fatalf("active calls after flush = %d, want 1 (unit-to-unit call must record)", len(act))
+	}
+	if got := act[0].Grant.GroupID; got != issi {
+		t.Errorf("flushed call destination = %d, want %d", got, issi)
+	}
+}
 
 // TestEngineTETRAFoldsGrantsByChannel: a TETRA physical channel + timeslot hosts
 // one call, but the SwMI grants it under several SSIs — the calling party's

--- a/internal/trunking/grant.go
+++ b/internal/trunking/grant.go
@@ -117,6 +117,13 @@ type Grant struct {
 	// channel when publishing the grant; zero on non-Phase-2 grants.
 	P25Phase2Decode P25Phase2Decode
 	At              time.Time
+	// heldFromWakeup is an engine-internal marker (never set by the protocol
+	// layer): true on a TETRA individual grant being re-dispatched after its
+	// wakeup-page hold window expired with no authoritative group grant to
+	// supersede it. It tells HandleGrant to skip the hold and allocate the call
+	// so a genuine unit-to-unit individual call still records. Unexported so it
+	// stays inside the trunking package and never crosses the events bus wire.
+	heldFromWakeup bool
 	// CallID is a process-monotonic identifier the voice pool assigns when
 	// it binds a device to this grant (VoicePool.Bind); a real handoff
 	// (VoicePool.Retune) preserves it so a followed call keeps one identity.

--- a/internal/voice/composer/tetra_voice.go
+++ b/internal/voice/composer/tetra_voice.go
@@ -254,7 +254,35 @@ type tetraSlotDemux struct {
 	ownerlessDrops   atomic.Uint64
 	crcFallbacks     atomic.Uint64
 	markerCollisions atomic.Uint64
+	// concurrencySuppressed counts bursts the single-owner CRC fallback WOULD have
+	// routed but dropped instead because ≥2 physical TDMA slots were carrying
+	// traffic — i.e. the carrier had concurrent calls even though GT had only one
+	// owner registered. Those fallbacks were the cross-slot audio-leak vector:
+	// a valid TCH/S CRC proves a burst is speech, not WHOSE speech, so funnelling
+	// another slot's speech into the sole recording bled calls together.
+	concurrencySuppressed atomic.Uint64
+
+	// slotRing is a sliding window of the physical TDMA slot (1..4) of recent
+	// traffic-marked bursts, used only to decide whether the carrier is currently
+	// running concurrent calls. Unlike the AACH usage marker (which decodes on a
+	// minority of bursts) the SB-anchored physical slot is available on ~100% of
+	// bursts, so counting distinct busy slots is a robust concurrency signal. The
+	// ring is touched only on the single demux goroutine (onBurst), so it needs no
+	// lock. 0 entries are empty slots.
+	slotRing    [concurrencyWindow]uint8
+	slotRingPos int
 }
+
+const (
+	// concurrencyWindow is how many recent traffic-marked bursts the slot ring
+	// remembers — ~one TETRA multiframe of traffic across four slots.
+	concurrencyWindow = 48
+	// minSlotBurstsForActive is how many of a slot's traffic-marked bursts must
+	// appear in the window before it counts as an active call, high enough that
+	// the ~5% SB-anchor slot jitter (a burst tagged one slot off) cannot make a
+	// single active call look like two.
+	minSlotBurstsForActive = 3
+)
 
 // tetraSlotOwner is one call's registration with the carrier demux: the usage
 // marker it follows (0 until a wildcard claims one) plus the boundary tracker +
@@ -295,7 +323,8 @@ func (d *tetraSlotDemux) run(ctx context.Context, iqCh <-chan []complex64, iqHz 
 			"undecoded_drops", d.undecodedDrops.Load(),
 			"ownerless_drops", d.ownerlessDrops.Load(),
 			"crc_fallbacks", d.crcFallbacks.Load(),
-			"marker_collisions", d.markerCollisions.Load())
+			"marker_collisions", d.markerCollisions.Load(),
+			"concurrency_suppressed", d.concurrencySuppressed.Load())
 	}()
 
 	for {
@@ -335,16 +364,28 @@ func (d *tetraSlotDemux) observe(iq []complex64) {
 // possible. Runs on the single demux goroutine, so each owner's boundary tracker
 // has exactly one writer.
 func (d *tetraSlotDemux) onBurst(frame []byte, softType5 []float32, slot, usage uint8) {
+	// Fold this burst's physical slot into the concurrency window (traffic-marked
+	// bursts only — those unambiguously mark a slot as carrying an active call).
+	d.noteSlotActivity(slot, usage)
+
 	// A burst whose AACH did not decode (usage 0) or is a control slot
 	// (< DLUsageTraffic) carries no routable marker. Dropping it outright loses
 	// the granted call's own speech whenever its AACH is momentarily
 	// un-decodable — the shared-demux gap the solo tap did not have. Fall back to
-	// the CRC gate, but ONLY when exactly one call is active (one owner and no
-	// waiting wildcard, or one waiting wildcard and no owner): with a single call
-	// there is no concurrent call to cross-talk into, so this matches the solo
-	// tap's burstUsage==0 behaviour. With ≥2 active calls an unrouteable burst is
-	// dropped (and counted) rather than mixed into an arbitrary recording.
+	// the CRC gate, but ONLY when the carrier is genuinely running one call: a
+	// single registered owner AND the physical slots show no concurrent traffic.
+	// The registered-owner count alone is not enough — a call GT never granted (a
+	// missed grant, a call in hangtime, a wakeup-page ghost) still keys up a
+	// physical slot, and routing that foreign slot's speech to GT's one owner via
+	// the CRC gate is exactly the cross-slot leak (a valid TCH/S CRC proves the
+	// burst is speech, not whose). When ≥2 slots are active the burst is dropped
+	// rather than mixed into an arbitrary recording.
 	if usage < tetra.DLUsageTraffic {
+		if d.onAirConcurrent() {
+			d.concurrencySuppressed.Add(1)
+			d.undecodedDrops.Add(1)
+			return
+		}
 		d.mu.Lock()
 		var sole *tetraSlotOwner
 		switch {
@@ -377,11 +418,12 @@ func (d *tetraSlotDemux) onBurst(frame []byte, softType5 []float32, slot, usage 
 	// one call is active, this is that call's own burst whose AACH usage marker
 	// miscorrected to a stray value (a common RM(30,14) miss on a marginal AACH):
 	// capture the sole owner so it goes through the CRC gate below instead of
-	// being dropped. Safe for the same reason as the usage-0 fallback — with a
-	// single active call there is no peer to cross-talk into, and the class-2 CRC
-	// still rejects a non-matching burst ~255/256.
+	// being dropped. Guarded on BOTH a single registered owner AND no concurrent
+	// on-air traffic — an ownerless traffic marker while another physical slot is
+	// active is far more likely a genuine peer call GT isn't tracking than the one
+	// owner's own miscorrection, and routing it in is the cross-slot leak.
 	var sole *tetraSlotOwner
-	if o == nil && len(d.owners) == 1 && len(d.wildcards) == 0 {
+	if o == nil && len(d.owners) == 1 && len(d.wildcards) == 0 && !d.onAirConcurrent() {
 		for _, only := range d.owners {
 			sole = only
 		}
@@ -394,11 +436,48 @@ func (d *tetraSlotDemux) onBurst(frame []byte, softType5 []float32, slot, usage 
 			d.c.decodeTETRASpeech(sole.bt, sole.rs, sole.serial, frame, softType5, &sole.speech)
 			return
 		}
+		if d.onAirConcurrent() {
+			d.concurrencySuppressed.Add(1)
+		}
 		d.ownerlessDrops.Add(1)
 		return
 	}
 	o.bursts.Add(1)
 	d.c.decodeTETRASpeech(o.bt, o.rs, o.serial, frame, softType5, &o.speech)
+}
+
+// noteSlotActivity folds a traffic-marked burst's physical slot into the sliding
+// concurrency window. Only usage >= DLUsageTraffic bursts are recorded: those
+// unambiguously mark a slot as carrying a live call, whereas an undecoded AACH
+// (usage 0) tells us nothing about which slot is busy. Runs on the demux
+// goroutine, so the ring needs no lock.
+func (d *tetraSlotDemux) noteSlotActivity(slot, usage uint8) {
+	if usage < tetra.DLUsageTraffic || slot < 1 || slot > 4 {
+		return
+	}
+	d.slotRing[d.slotRingPos] = slot
+	d.slotRingPos = (d.slotRingPos + 1) % len(d.slotRing)
+}
+
+// onAirConcurrent reports whether the carrier is currently running more than one
+// call, judged from how many distinct physical slots carry traffic in the recent
+// window. This is decoupled from how many owners GT has registered: a call GT
+// never granted still keys up a slot, and it is exactly that untracked concurrent
+// traffic that the single-owner CRC fallback used to leak into the one recording.
+func (d *tetraSlotDemux) onAirConcurrent() bool {
+	var counts [5]int // index 1..4
+	for _, s := range d.slotRing {
+		if s >= 1 && s <= 4 {
+			counts[s]++
+		}
+	}
+	active := 0
+	for s := 1; s <= 4; s++ {
+		if counts[s] >= minSlotBurstsForActive {
+			active++
+		}
+	}
+	return active >= 2
 }
 
 // addOwner registers o. A marker-bearing grant claims its marker (most-recent

--- a/internal/voice/composer/tetra_voice_test.go
+++ b/internal/voice/composer/tetra_voice_test.go
@@ -511,6 +511,57 @@ func TestTETRADemuxOwnerlessMarkerSingleOwnerCRCFallback(t *testing.T) {
 	}
 }
 
+// TestTETRADemuxNoLeakWhenAirConcurrentButOneOwner is the regression for the
+// reported cross-slot audio leak: when the carrier is running concurrent calls
+// but GT has only ONE owner registered (a call it never granted, one in hangtime,
+// or a wakeup-page ghost keeps the other slot busy), the single-owner CRC
+// fallback funnelled that foreign slot's speech into the one recording — a valid
+// TCH/S CRC proves a burst is speech, not whose. With ≥2 physical slots active
+// the fallback must be suppressed so no foreign audio leaks.
+func TestTETRADemuxNoLeakWhenAirConcurrentButOneOwner(t *testing.T) {
+	c, _, _ := mkBoundaryComposer(t, false, 50*time.Millisecond)
+	d := mkDemux(c)
+	frame := tetra.EncodeTCHS(make([]byte, 137), make([]byte, 137))
+
+	o, rs := newDemuxOwner(c, "A", 19) // the one call GT is following, on slot 1
+	d.addOwner(o)
+
+	// The air is concurrent: slot 1 (owner) and slot 2 (a call GT is not tracking)
+	// both carry traffic. Seed the concurrency window directly so the state is
+	// deterministic regardless of routing.
+	for i := 0; i < minSlotBurstsForActive; i++ {
+		d.noteSlotActivity(1, tetra.DLUsageTraffic)
+		d.noteSlotActivity(2, tetra.DLUsageTraffic)
+	}
+	if !d.onAirConcurrent() {
+		t.Fatal("setup: expected the carrier to read as concurrent")
+	}
+
+	before := len(rs.rawFrames("A"))
+	// A foreign burst whose AACH did not decode (usage 0) on the other slot: must
+	// be dropped, not CRC-fallback-routed to the sole owner.
+	d.onBurst(frame, nil, 2, 0)
+	// A foreign burst carrying an ownerless traffic marker (another call's slot):
+	// also must not leak to the sole owner.
+	d.onBurst(frame, nil, 2, 20)
+	if n := len(rs.rawFrames("A")); n != before {
+		t.Errorf("foreign concurrent-slot speech leaked to the sole owner: %d frames, want %d", n, before)
+	}
+	if got := d.concurrencySuppressed.Load(); got < 2 {
+		t.Errorf("concurrencySuppressed = %d, want >= 2", got)
+	}
+
+	// Control: the SAME owner on a quiet carrier (one active slot) still recovers
+	// its own AACH-undecodable bursts via the fallback — no regression there.
+	d2 := mkDemux(c)
+	o2, rs2 := newDemuxOwner(c, "A", 19)
+	d2.addOwner(o2)
+	d2.onBurst(frame, nil, 1, 0) // single slot, undecoded AACH → fallback recovers it
+	if n := len(rs2.rawFrames("A")); n != 2 {
+		t.Errorf("single-call fallback regressed: A got %d frames, want 2", n)
+	}
+}
+
 // TestTETRADemuxMarkerCollisionCounted: two calls registering the same usage
 // marker is now counted + warned (previously a silent orphan). Most-recent-grant
 // still wins the marker (existing eviction semantics preserved).


### PR DESCRIPTION
On a group call the TETRA SwMI often sends an individual-addressed Energy-Economy
wakeup page (individual=true, no source, dst = the calling party's radio SSI)
~160 ms before the authoritative group grant. The engine spawned that page as a
real call immediately, creating a ghost recording directory named after the radio
ID (recordings/<sys>/<radioSSI>/...) and then tearing it down when the group grant
superseded it — fragmenting audio into two files and surfacing radio IDs as bogus
talkgroups.

Hold a TETRA wakeup page for a short window (300 ms) before letting it spawn a
call. The authoritative group grant that follows a real group call cancels the
held page via the same-channel drop, so the one true call starts directly under
the GSSI and no ghost is ever created. A page that is never superseded — a genuine
unit-to-unit individual call — is flushed to allocation when the window expires,
so private calls still record (delayed by the hold). The existing retroactive
supersede stays as a belt-and-suspenders net.

The hold timer fires on its own goroutine and marshals the flush back onto the
engine's single grant-processing goroutine via a buffered channel, so it never
races the Run loop's pool allocation. afterFunc is injectable for deterministic
tests.

Refs #764-adjacent TETRA call-classification work.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YLckwcqjmULJFooxdFrLTg