### PR TITLE
fix(tetra/ccdecoder): USRP field-report fixes — radio-ID leak, cross-slot audio, #402 overruns, per-talker recordings

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -1250,6 +1250,10 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		EncryptedModes:   encryptedModesBySystem(cfg.Trunking.Systems),
 		EncryptedFollows: encryptedFollowsBySystem(cfg.Trunking.Systems),
 		ConfiguredKeys:   configuredKeysBySystem(cfg.Trunking.Systems),
+		// Same per-transmission grouping the voice composer uses (below): lets the
+		// engine roll a TETRA recording on a talker change so each over is
+		// attributed to its own source.
+		SplitPerTransmission: cfg.Trunking.VoiceCallGrouping != "conversation",
 	})
 	if err != nil {
 		return nil, fmt.Errorf("daemon: engine: %w", err)

--- a/internal/trunking/engine.go
+++ b/internal/trunking/engine.go
@@ -89,16 +89,17 @@ type Engine struct {
 	radiosMu    sync.Mutex
 	knownRadios map[uint32]struct{}
 
-	// held holds TETRA individual (wakeup-page) grants for a short window before
-	// they are allowed to spawn a call. On a group call the SwMI often sends an
-	// individual-addressed Energy-Economy wakeup page (individual=true, no source,
-	// dst = the calling party's radio SSI) ~160 ms before the authoritative group
-	// grant. Spawning the wakeup page immediately created a ghost call + a WAV
-	// directory named after the radio ID, then tore it down when the group grant
-	// superseded it (fragmented recordings, radio IDs leaking as talkgroups). The
-	// hold lets the group grant arrive first and cancel the page; a page that is
-	// never superseded (a genuine unit-to-unit call) is flushed when the window
-	// expires. Keyed by physical channel; guarded by mu.
+	// held holds TETRA source-less notification grants for a short window before
+	// they are allowed to spawn a call. On a group call the SwMI sends a
+	// notification (SourceID==0, dst = the calling party's radio SSI — an
+	// Energy-Economy wakeup page or a plain group-call notification) 50-400 ms
+	// before the authoritative group grant. Spawning it immediately created a ghost
+	// call + a WAV directory named after the radio ID, then tore it down when the
+	// group grant superseded it (fragmented recordings, radio IDs leaking as
+	// talkgroups). The hold lets the group grant arrive first and cancel the
+	// notification; a notification never superseded is resolved at flush (dropped if
+	// it targets a known radio, else allocated under a real GSSI). Keyed by physical
+	// channel; guarded by mu.
 	held map[channelKey]*heldGrant
 	// heldFlush marshals an expired hold back onto the engine's single grant-
 	// processing goroutine (the Run loop). The afterFunc timer fires on its own
@@ -109,10 +110,9 @@ type Engine struct {
 	// afterFunc is time.AfterFunc, injectable so tests can drive the hold window
 	// deterministically. Returns a *time.Timer whose Stop cancels a pending flush.
 	afterFunc func(time.Duration, func()) *time.Timer
-	// tetraIndividualHold is how long a TETRA individual (wakeup-page) grant is
-	// held for an authoritative group grant to supersede it. The observed page →
-	// group gap is ~160 ms; 300 ms covers it with margin. A held genuine unit-to-
-	// unit call records this much later, an acceptable cost.
+	// tetraIndividualHold is how long a TETRA source-less notification grant is
+	// held for an authoritative group grant to supersede it. See
+	// defaultTETRAIndividualHold for sizing.
 	tetraIndividualHold time.Duration
 }
 
@@ -132,8 +132,11 @@ type heldGrant struct {
 }
 
 // defaultTETRAIndividualHold is the hold window applied when the engine is
-// constructed without an explicit value.
-const defaultTETRAIndividualHold = 300 * time.Millisecond
+// constructed without an explicit value. Sized to cover the observed
+// notification→group-grant gap (52-400 ms on the reporter's system) with margin;
+// a group grant cancels the hold the instant it arrives, so a real call incurs no
+// added latency — only a never-superseded notification waits the full window.
+const defaultTETRAIndividualHold = 500 * time.Millisecond
 
 // observedKey identifies a logical call for the observed-call tracker:
 // (System, talkgroup, timeslot) — the same identity HandleGrant's duplicate-
@@ -417,20 +420,27 @@ func channelKeyOf(g Grant) channelKey {
 	return channelKey{system: g.System, freq: g.FrequencyHz, ts: g.Timeslot}
 }
 
-// isTETRAWakeupPage reports whether g is a TETRA individual-addressed page with
-// no source — the Energy-Economy wakeup frame that precedes a group grant and
-// must not be spawned as a private call. A flushed page (heldFromWakeup) still
-// matches this shape; callers gate on heldFromWakeup separately where it matters.
-func isTETRAWakeupPage(g Grant) bool {
-	return g.Protocol == "tetra" && g.Individual && g.SourceID == 0
+// isTETRANotificationGrant reports whether g is a TETRA source-less notification
+// grant: the SwMI announces an imminent transmission (an Energy-Economy wakeup
+// page, or a group-call notification) with no calling party yet, addressed to the
+// paged radio's SSI. It is followed ~50-400 ms later by the authoritative group
+// grant (source populated, dst = GSSI). The reliable signature is SourceID==0 —
+// NOT the Individual flag: classifyParties only sets Individual=true once the SSI
+// is already known as a party, so the FIRST notification for a radio is published
+// individual=false and would otherwise slip past the hold. A genuine unit-to-unit
+// call carries its caller (SourceID!=0), so it is never a notification. A flushed
+// notification (heldFromWakeup) still matches this shape; callers gate on
+// heldFromWakeup separately where it matters. Data calls are excluded.
+func isTETRANotificationGrant(g Grant) bool {
+	return g.Protocol == "tetra" && g.SourceID == 0 && !g.DataCall
 }
 
-// holdWakeupPage parks a wakeup page for tetraIndividualHold, arming a timer to
-// flush it if no authoritative group grant supersedes it first. A repeat page
-// for a channel already held refreshes the stored grant without re-arming, so
-// the original deadline still governs (the page → group gap is fixed regardless
-// of how many page repeats arrive).
-func (e *Engine) holdWakeupPage(g Grant) {
+// holdNotificationGrant parks a source-less notification for tetraIndividualHold,
+// arming a timer to flush it if no authoritative group grant supersedes it first.
+// A repeat notification for a channel already held refreshes the stored grant
+// without re-arming, so the original deadline still governs (the notification →
+// group gap is fixed regardless of how many repeats arrive).
+func (e *Engine) holdNotificationGrant(g Grant) {
 	key := channelKeyOf(g)
 	e.mu.Lock()
 	if h := e.held[key]; h != nil {
@@ -450,14 +460,14 @@ func (e *Engine) holdWakeupPage(g Grant) {
 	})
 	e.held[key] = h
 	e.mu.Unlock()
-	e.log.Debug("tetra: holding individual wakeup page for a group grant",
+	e.log.Debug("tetra: holding source-less notification grant for a group grant",
 		"grant", g.String(), "hold", e.tetraIndividualHold)
 }
 
-// dropHeldIndividual cancels and discards any held wakeup page for key. Called
-// when an authoritative grant for the same channel arrives (the page is
+// dropHeldNotification cancels and discards any held notification for key. Called
+// when an authoritative grant for the same channel arrives (the notification is
 // superseded before it ever spawned a call) and on shutdown.
-func (e *Engine) dropHeldIndividual(key channelKey) {
+func (e *Engine) dropHeldNotification(key channelKey) {
 	e.mu.Lock()
 	h := e.held[key]
 	if h != nil {
@@ -468,15 +478,18 @@ func (e *Engine) dropHeldIndividual(key channelKey) {
 		if h.timer != nil {
 			h.timer.Stop()
 		}
-		e.log.Debug("tetra: cancelled held wakeup page (superseded by group grant)",
+		e.log.Debug("tetra: cancelled held notification grant (superseded by group grant)",
 			"grant", h.grant.String())
 	}
 }
 
-// flushHeldGrant re-dispatches a wakeup page whose hold window expired with no
-// authoritative group grant to supersede it — a genuine unit-to-unit individual
-// call, which now allocates (heldFromWakeup skips the hold on re-entry). Runs on
-// the Run goroutine via heldFlush. A no-op if the page was already cancelled.
+// flushHeldGrant handles a notification whose hold window expired with no
+// authoritative group grant to supersede it. If the destination is a known radio
+// SSI, this was a wakeup page for a call whose group grant we never saw — recording
+// under the radio ID is the leak the hold exists to prevent, so it is discarded.
+// Otherwise the destination is a real talkgroup (GSSI) or a genuinely-unknown
+// target, so it allocates (heldFromWakeup skips the hold on re-entry). Runs on the
+// Run goroutine via heldFlush. A no-op if the notification was already cancelled.
 func (e *Engine) flushHeldGrant(key channelKey) {
 	e.mu.Lock()
 	h := e.held[key]
@@ -488,8 +501,15 @@ func (e *Engine) flushHeldGrant(key channelKey) {
 		return
 	}
 	g := h.grant
+	if e.isKnownRadio(g.GroupID) {
+		// Destination is a learned radio ID — a notification whose group grant was
+		// missed/too-late. Do NOT record under the radio ID (that is the leak).
+		e.log.Debug("tetra: dropping held notification to a known radio (no group grant superseded it)",
+			"grant", g.String())
+		return
+	}
 	g.heldFromWakeup = true
-	e.log.Debug("tetra: flushing held wakeup page (no group grant superseded it)",
+	e.log.Debug("tetra: flushing held notification grant (no group grant superseded it)",
 		"grant", g.String())
 	e.HandleGrant(g)
 }
@@ -511,13 +531,13 @@ func (e *Engine) HandleGrant(g Grant) {
 	if g.Individual {
 		e.noteRadio(g.GroupID, g.System)
 	}
-	// Cancel a parked TETRA wakeup-page hold on this channel the moment any
-	// non-page grant for the same physical channel arrives — the authoritative
-	// group grant (or any other real allocation) has landed, so the page must not
-	// spawn its ghost call. A page repeat (still a wakeup page) leaves the hold in
-	// place; it is refreshed in the hold block below. See held/heldGrant.
-	if !isTETRAWakeupPage(g) {
-		e.dropHeldIndividual(channelKeyOf(g))
+	// Cancel a parked TETRA notification hold on this channel the moment any
+	// authoritative (source-bearing) grant for the same physical channel arrives —
+	// the real group grant has landed, so the notification must not spawn its ghost
+	// call. A notification repeat (still source-less) leaves the hold in place; it
+	// is refreshed in the hold block below. See held/heldGrant.
+	if !isTETRANotificationGrant(g) {
+		e.dropHeldNotification(channelKeyOf(g))
 	}
 	tg := e.talkgroups.Lookup(g.GroupID)
 	if tg == nil && g.GroupID != 0 && !g.Individual && !e.isKnownRadio(g.GroupID) {
@@ -754,17 +774,18 @@ func (e *Engine) HandleGrant(g Grant) {
 		}
 	}
 
-	// Hold a TETRA wakeup page. Reaching here means no active call and no fold
-	// matched this channel, so an individual-addressed page (individual=true, no
-	// source) would spawn a fresh call + a WAV directory named after the paged
-	// radio SSI. Park it for tetraIndividualHold instead: the authoritative group
-	// grant that follows a real group call (~160 ms later) cancels it via the
-	// drop above, and only a page that is never superseded — a genuine unit-to-
-	// unit call — is flushed to allocation when the window expires. A repeat page
-	// refreshes the existing hold without re-arming. heldFromWakeup grants have
-	// already served their window and fall through to allocate.
-	if isTETRAWakeupPage(g) && !g.heldFromWakeup {
-		e.holdWakeupPage(g)
+	// Hold a TETRA source-less notification grant. Reaching here means no active
+	// call and no fold matched this channel, so a notification (SourceID==0,
+	// regardless of the Individual flag) would spawn a fresh call + a WAV directory
+	// named after its destination SSI — a ghost when that destination is the paged
+	// radio. Park it for tetraIndividualHold instead: the authoritative group grant
+	// that follows (~50-400 ms later) cancels it via the drop above; a notification
+	// never superseded is resolved at flush (dropped if it targets a known radio,
+	// else allocated under a real GSSI). A repeat notification refreshes the hold
+	// without re-arming. heldFromWakeup grants have already served their window and
+	// fall through to allocate.
+	if isTETRANotificationGrant(g) && !g.heldFromWakeup {
+		e.holdNotificationGrant(g)
 		return
 	}
 
@@ -1315,7 +1336,7 @@ func (e *Engine) runWatchdog() {
 }
 
 func (e *Engine) shutdown() {
-	// Cancel any parked wakeup-page timers so they can't fire into a torn-down
+	// Cancel any parked notification-hold timers so they can't fire into a torn-down
 	// engine (their flush is a no-op once Run has exited, but stopping the timers
 	// releases the goroutines promptly).
 	e.mu.Lock()

--- a/internal/trunking/engine.go
+++ b/internal/trunking/engine.go
@@ -101,6 +101,9 @@ type Engine struct {
 	// it targets a known radio, else allocated under a real GSSI). Keyed by physical
 	// channel; guarded by mu.
 	held map[channelKey]*heldGrant
+	// splitTx mirrors EngineOptions.SplitPerTransmission — emit a per-transmission
+	// segment on a TETRA talker change. Read-only after NewEngine.
+	splitTx bool
 	// heldFlush marshals an expired hold back onto the engine's single grant-
 	// processing goroutine (the Run loop). The afterFunc timer fires on its own
 	// goroutine, so it cannot call HandleGrant directly without racing Run; it
@@ -183,6 +186,14 @@ type EngineOptions struct {
 	// IDs. Calls whose KeyID matches are exempt from the encrypted-call
 	// policy (always followed). nil disables the exemption. Issue #711.
 	ConfiguredKeys map[string]map[uint16]bool
+	// SplitPerTransmission mirrors the voice composer's per-transmission
+	// grouping (trunking.voice_call_grouping != "conversation"). When set, the
+	// engine emits a KindCallSegment on a TETRA talker change so each over is
+	// recorded to its own file named with the new talker's source — the same
+	// per-transmission split P25 Phase 1 gets from its traffic-channel terminator,
+	// which the TETRA traffic path cannot see (the over boundary arrives on the
+	// control channel as D-TX-GRANTED). Default false keeps one file per call.
+	SplitPerTransmission bool
 }
 
 // defaultEncryptedMetadataFollow is the metadata-mode follow window
@@ -240,6 +251,7 @@ func NewEngine(opts EngineOptions) (*Engine, error) {
 		synthetic:      make(map[string]*ActiveCall),
 		observed:       make(map[string]*ActiveCall),
 
+		splitTx:             opts.SplitPerTransmission,
 		held:                make(map[channelKey]*heldGrant),
 		heldFlush:           make(chan channelKey, 64),
 		afterFunc:           time.AfterFunc,
@@ -996,11 +1008,33 @@ func (e *Engine) handleCallRelease(r CallRelease) {
 // call(s) for (System, GroupID), reusing the KindCallSourceUpdate path (keyed by
 // the resolved device serial). A talker update for an unfollowed call resolves
 // to no serials and is a no-op.
+//
+// When per-transmission grouping is enabled, a genuine talker change on a TETRA
+// call (a new member keying up on the same channel — the reporter's "second
+// person replying") also rolls the recording to a fresh file: emit a
+// KindCallSegment BEFORE the source backfill so the recorder closes the current
+// file (still tagged the previous talker) and the next over opens a file named
+// with the new talker. This is the split P25 Phase 1 gets from its traffic-channel
+// terminator; TETRA's over boundary (D-TX-GRANTED) only surfaces here on the
+// control channel, so the engine is the one place that can drive it.
 func (e *Engine) handleCallTalker(t CallTalker) {
 	if t.SourceID == 0 {
 		return
 	}
 	for _, ac := range e.callsBySystemGroup(t.System, t.GroupID) {
+		if e.splitTx && ac.Grant.Protocol == "tetra" &&
+			ac.Grant.SourceID != 0 && ac.Grant.SourceID != t.SourceID {
+			// A real talker change on a live call — split the recording so each
+			// over is attributed to its own source. Emit before the source update
+			// so the closing file keeps the prior talker's id.
+			e.bus.Publish(events.Event{
+				Kind:    events.KindCallSegment,
+				Payload: CallSegment{DeviceSerial: ac.Device.Serial, At: t.At},
+			})
+			e.log.Debug("tetra: talker change — rolling recording to new transmission",
+				"device", ac.Device.Serial, "tg", t.GroupID,
+				"prev_src", ac.Grant.SourceID, "new_src", t.SourceID)
+		}
 		e.handleCallSourceUpdate(CallSourceUpdate{
 			DeviceSerial: ac.Device.Serial,
 			SourceID:     t.SourceID,

--- a/internal/trunking/engine_test.go
+++ b/internal/trunking/engine_test.go
@@ -1577,7 +1577,7 @@ func TestEngineHandleCallReleaseEndsCall(t *testing.T) {
 	sub := bus.Subscribe()
 	defer sub.Close()
 
-	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: 100, FrequencyHz: 851_000_000})
+	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: 100, SourceID: 500, FrequencyHz: 851_000_000})
 	if len(pool.Active()) != 1 {
 		t.Fatalf("precondition: want 1 active call, got %d", len(pool.Active()))
 	}
@@ -1613,7 +1613,7 @@ func TestEngineHandleCallReleaseNoMatchNoop(t *testing.T) {
 	e, pool, bus, _ := mkEngine(t, 1)
 	defer bus.Close()
 
-	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: 100, FrequencyHz: 851_000_000})
+	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: 100, SourceID: 500, FrequencyHz: 851_000_000})
 	e.handleCallRelease(CallRelease{System: "X", GroupID: 999}) // different group
 	if len(pool.Active()) != 1 {
 		t.Errorf("unrelated release ended the call: active=%d", len(pool.Active()))
@@ -1629,7 +1629,7 @@ func TestEngineHandleCallReleaseIdempotent(t *testing.T) {
 	sub := bus.Subscribe()
 	defer sub.Close()
 
-	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: 100, FrequencyHz: 851_000_000})
+	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: 100, SourceID: 500, FrequencyHz: 851_000_000})
 	e.handleCallRelease(CallRelease{System: "X", GroupID: 100})
 	e.handleCallRelease(CallRelease{System: "X", GroupID: 100})
 
@@ -1655,7 +1655,7 @@ func TestEngineHandleCallTalkerUpdatesSource(t *testing.T) {
 	sub := bus.Subscribe()
 	defer sub.Close()
 
-	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: 100, FrequencyHz: 851_000_000})
+	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: 100, SourceID: 500, FrequencyHz: 851_000_000})
 	e.handleCallTalker(CallTalker{System: "X", GroupID: 100, SourceID: 4242})
 
 	c := &testBusCollector{}

--- a/internal/trunking/engine_test.go
+++ b/internal/trunking/engine_test.go
@@ -1676,3 +1676,85 @@ func TestEngineHandleCallTalkerUpdatesSource(t *testing.T) {
 		t.Errorf("source update = %+v, want src 4242 group 100", *upd)
 	}
 }
+
+// TestEngineTETRATalkerChangeSplitsRecording is the regression for the
+// "missing second srcID" report: a TETRA group call stays on one channel while a
+// second member keys up (a reply). With per-transmission grouping the engine must
+// roll the recording to a fresh file on the talker change — emitting a
+// KindCallSegment (for the bound device) BEFORE the source backfill — so each over
+// is attributed to its own talker instead of the whole call keeping the first src.
+func TestEngineTETRATalkerChangeSplitsRecording(t *testing.T) {
+	e, pool, bus, _ := mkEngine(t, 1)
+	defer bus.Close()
+	e.splitTx = true
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: 1020545, SourceID: 1005736, FrequencyHz: 467_912_500, Timeslot: 2})
+	if len(pool.Active()) != 1 {
+		t.Fatalf("precondition: want 1 active call, got %d", len(pool.Active()))
+	}
+	serial := pool.Active()[0].Device.Serial
+
+	// A different member replies on the same call → talker change.
+	e.handleCallTalker(CallTalker{System: "X", GroupID: 1020545, SourceID: 1005526})
+
+	c := &testBusCollector{}
+	evs := c.drain(sub, 6, 500*time.Millisecond)
+	segAt, srcAt := -1, -1
+	for i, ev := range evs {
+		switch ev.Kind {
+		case events.KindCallSegment:
+			if seg, ok := ev.Payload.(CallSegment); ok && seg.DeviceSerial == serial {
+				segAt = i
+			}
+		case events.KindCallSourceUpdate:
+			if u, ok := ev.Payload.(CallSourceUpdate); ok && u.System != "" && u.SourceID == 1005526 {
+				srcAt = i
+			}
+		}
+	}
+	if segAt < 0 {
+		t.Fatal("no KindCallSegment published on the TETRA talker change (recording not split per talker)")
+	}
+	if srcAt < 0 {
+		t.Fatal("no enriched source update for the new talker")
+	}
+	if segAt > srcAt {
+		t.Errorf("segment (idx %d) must precede the source update (idx %d) so the closed file keeps the prior talker", segAt, srcAt)
+	}
+}
+
+// TestEngineTETRATalkerSplitGatedOffAndOnSameSource guards the two negatives: no
+// segment when the source is unchanged (a repeat talker), and no segment when
+// per-transmission grouping is disabled (conversation mode = one file per call).
+func TestEngineTETRATalkerSplitGatedOffAndOnSameSource(t *testing.T) {
+	// (a) splitTx on, but the talker is the SAME as the current source.
+	e, _, bus, _ := mkEngine(t, 1)
+	defer bus.Close()
+	e.splitTx = true
+	sub := bus.Subscribe()
+	defer sub.Close()
+	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: 1020545, SourceID: 1005736, FrequencyHz: 467_912_500, Timeslot: 2})
+	e.handleCallTalker(CallTalker{System: "X", GroupID: 1020545, SourceID: 1005736}) // same src
+	c := &testBusCollector{}
+	for _, ev := range c.drain(sub, 8, 200*time.Millisecond) {
+		if ev.Kind == events.KindCallSegment {
+			t.Error("segment published for an unchanged talker (no over boundary)")
+		}
+	}
+
+	// (b) splitTx OFF: a genuine talker change must NOT split.
+	e2, _, bus2, _ := mkEngine(t, 1)
+	defer bus2.Close()
+	sub2 := bus2.Subscribe()
+	defer sub2.Close()
+	e2.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: 1020545, SourceID: 1005736, FrequencyHz: 467_912_500, Timeslot: 2})
+	e2.handleCallTalker(CallTalker{System: "X", GroupID: 1020545, SourceID: 1005526})
+	c2 := &testBusCollector{}
+	for _, ev := range c2.drain(sub2, 8, 200*time.Millisecond) {
+		if ev.Kind == events.KindCallSegment {
+			t.Error("segment published while per-transmission grouping is off")
+		}
+	}
+}

--- a/internal/trunking/engine_tetra_test.go
+++ b/internal/trunking/engine_tetra_test.go
@@ -13,15 +13,15 @@ func noFireAfterFunc(d time.Duration, f func()) *time.Timer {
 	return time.AfterFunc(time.Hour, f)
 }
 
-// TestEngineTETRAWakeupPageHeldUntilGroupGrant is the regression for the
-// Energy-Economy wakeup-page bug (Discord report + attached bug report): the SwMI
-// sends an individual-addressed page (individual=true, no source, dst = the
-// calling party's radio SSI) ~160 ms before the authoritative group grant.
-// Spawning the page immediately created a ghost call + a WAV directory named
-// after the radio ID, torn down when the group grant superseded it. The page must
-// instead be held so no ghost is ever created, and the group grant then starts
-// the one true call under the GSSI.
-func TestEngineTETRAWakeupPageHeldUntilGroupGrant(t *testing.T) {
+// TestEngineTETRANotificationHeldUntilGroupGrant is the regression for the
+// source-less notification bug (Discord reports + attached bug report): the SwMI
+// sends a notification (no source, dst = the calling party's radio SSI) 50-400 ms
+// before the authoritative group grant. Spawning it immediately created a ghost
+// call + a WAV directory named after the radio ID, torn down when the group grant
+// superseded it. Crucially the FIRST notification for a radio is published
+// individual=FALSE (classifyParties only learns the SSI is a party later), so the
+// hold must trigger on SourceID==0, NOT the Individual flag.
+func TestEngineTETRANotificationHeldUntilGroupGrant(t *testing.T) {
 	e, pool, bus, _ := mkEngine(t, 2)
 	defer bus.Close()
 	e.afterFunc = noFireAfterFunc
@@ -32,14 +32,15 @@ func TestEngineTETRAWakeupPageHeldUntilGroupGrant(t *testing.T) {
 		issi = uint32(1005750) // paged radio ID (leaks as a phantom talkgroup today)
 		gssi = uint32(1020545) // the real talkgroup
 	)
-	// The wakeup page. Before the fix this spawns a ghost call under the radio SSI.
-	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: issi, FrequencyHz: freq, Timeslot: ts, Individual: true, TETRAUsageMarker: 8})
+	// The notification — individual=FALSE (the common first-sighting case), no
+	// source. Before the fix this spawns a ghost call under the radio SSI.
+	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: issi, FrequencyHz: freq, Timeslot: ts, TETRAUsageMarker: 8})
 	if n := len(pool.Active()); n != 0 {
-		t.Fatalf("active calls after wakeup page = %d, want 0 (the page must be held, not spawned)", n)
+		t.Fatalf("active calls after notification = %d, want 0 (must be held, not spawned)", n)
 	}
 
 	// The authoritative group grant lands within the hold window: it cancels the
-	// held page and starts the one real call under the GSSI.
+	// held notification and starts the one real call under the GSSI.
 	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: gssi, SourceID: issi, FrequencyHz: freq, Timeslot: ts, TETRAUsageMarker: 23})
 	act := pool.Active()
 	if len(act) != 1 {
@@ -53,11 +54,11 @@ func TestEngineTETRAWakeupPageHeldUntilGroupGrant(t *testing.T) {
 	}
 }
 
-// TestEngineTETRAWakeupPageFlushesWithoutGroupGrant guards that a genuine
-// unit-to-unit individual call — an individual page that no group grant ever
-// supersedes — still records once the hold window expires, so the hold does not
-// silently drop private calls.
-func TestEngineTETRAWakeupPageFlushesWithoutGroupGrant(t *testing.T) {
+// TestEngineTETRANotificationToKnownRadioDropped guards that a held notification
+// targeting a KNOWN radio SSI that no group grant ever supersedes is DROPPED at
+// flush, not recorded under the radio ID — recording under a radio ID is exactly
+// the leak the hold exists to prevent.
+func TestEngineTETRANotificationToKnownRadioDropped(t *testing.T) {
 	e, pool, bus, _ := mkEngine(t, 2)
 	defer bus.Close()
 	e.afterFunc = noFireAfterFunc
@@ -65,22 +66,49 @@ func TestEngineTETRAWakeupPageFlushesWithoutGroupGrant(t *testing.T) {
 	const (
 		freq = uint32(467_912_500)
 		ts   = uint8(1)
-		issi = uint32(1005750) // the individually-called radio
+		issi = uint32(1005750) // a radio the engine has already learned
 	)
-	page := Grant{System: "X", Protocol: "tetra", GroupID: issi, FrequencyHz: freq, Timeslot: ts, Individual: true}
+	e.noteRadio(issi, "X") // learned from an earlier call's source
+	page := Grant{System: "X", Protocol: "tetra", GroupID: issi, FrequencyHz: freq, Timeslot: ts}
 	e.HandleGrant(page)
 	if n := len(pool.Active()); n != 0 {
-		t.Fatalf("active calls after page = %d, want 0 (held)", n)
+		t.Fatalf("active calls after notification = %d, want 0 (held)", n)
 	}
 
-	// The hold window expires with no group grant: the flush allocates the call.
+	// Flush with no group grant: destination is a known radio → dropped, not recorded.
+	e.flushHeldGrant(channelKeyOf(page))
+	if n := len(pool.Active()); n != 0 {
+		t.Fatalf("active calls after flush = %d, want 0 (notification to a known radio must not record)", n)
+	}
+}
+
+// TestEngineTETRANotificationToTalkgroupFlushes guards the legitimate case: a
+// source-less notification addressed to a real talkgroup (not a known radio) that
+// no group grant supersedes still records under that talkgroup once the window
+// expires — the hold must not silently drop a real (if unattributed) group call.
+func TestEngineTETRANotificationToTalkgroupFlushes(t *testing.T) {
+	e, pool, bus, _ := mkEngine(t, 2)
+	defer bus.Close()
+	e.afterFunc = noFireAfterFunc
+
+	const (
+		freq = uint32(467_912_500)
+		ts   = uint8(1)
+		gssi = uint32(1020545) // a talkgroup — never learned as a radio
+	)
+	page := Grant{System: "X", Protocol: "tetra", GroupID: gssi, FrequencyHz: freq, Timeslot: ts}
+	e.HandleGrant(page)
+	if n := len(pool.Active()); n != 0 {
+		t.Fatalf("active calls after notification = %d, want 0 (held)", n)
+	}
+
 	e.flushHeldGrant(channelKeyOf(page))
 	act := pool.Active()
 	if len(act) != 1 {
-		t.Fatalf("active calls after flush = %d, want 1 (unit-to-unit call must record)", len(act))
+		t.Fatalf("active calls after flush = %d, want 1 (talkgroup call must record)", len(act))
 	}
-	if got := act[0].Grant.GroupID; got != issi {
-		t.Errorf("flushed call destination = %d, want %d", got, issi)
+	if got := act[0].Grant.GroupID; got != gssi {
+		t.Errorf("flushed call talkgroup = %d, want %d", got, gssi)
 	}
 }
 
@@ -163,8 +191,10 @@ func TestEngineTETRAConcurrentSlotsStayDistinct(t *testing.T) {
 	e, pool, bus, _ := mkEngine(t, 2)
 	defer bus.Close()
 
-	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: 100, FrequencyHz: 467_912_500, Timeslot: 1})
-	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: 200, FrequencyHz: 467_912_500, Timeslot: 2})
+	// Authoritative group grants (source-bearing) on distinct timeslots: both spawn
+	// immediately and must not fold into one.
+	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: 100, SourceID: 501, FrequencyHz: 467_912_500, Timeslot: 1})
+	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: 200, SourceID: 502, FrequencyHz: 467_912_500, Timeslot: 2})
 
 	if n := len(pool.Active()); n != 2 {
 		t.Fatalf("active calls = %d, want 2 (distinct timeslots are distinct calls)", n)


### PR DESCRIPTION
## Summary

Six narrow fixes for TETRA / ccdecoder issues a field tester hit running GopherTrunk on a **USRP X310 over SoapyRemote** (system `250_013`), reported across two test rounds (Discord + `debug.log`s + raw cs16/audio captures). Each is its own commit with a fails-first regression test. Supersedes the earlier, closed PR #1008 (same branch, first four commits) and adds two follow-up fixes on top.

## Changes

Six fix commits (+ a housekeeping commit), each independently reviewable:

- **`fix(tetra): hold individual wakeup pages…`** — a TETRA wakeup/notification grant was spawned as a real call, creating a ghost recording dir named after a radio ID before the authoritative group grant tore it down.
- **`fix(ccdecoder): size the decode queue by wall-clock budget… (#402)`** — the decode queue was a fixed 128-*chunk* channel (~47 ms at 1 MS/s on SoapyRemote's tiny datagrams), so short stalls overflowed it at idle CPU while the driver saw nothing. Now bounded by a wall-clock **sample budget** (~0.5 s) invariant to chunk size.
- **`fix(ccdecoder): stop "iq power very low" DEBUG spam while locked…`** — the low-power hint fired every few seconds on a legitimately low (~-60 dBFS) but cleanly-decoding USRP stream. Gated on `!locked`.
- **`fix(tetra): stop cross-slot audio leaks by gating the CRC fallback on on-air concurrency`** — the same-carrier demux's "sole active call" CRC fallback funnelled *foreign* timeslots' speech into the one tracked recording (a valid TCH/S CRC proves "is speech", not "whose"). Now suppressed whenever ≥2 physical TDMA slots are active.
- **`fix(tetra): hold source-less notification grants on SourceID==0, not the Individual flag`** — follow-up: notifications are classified `individual=false` on first sighting, so the original hold missed them. Now holds on `SourceID==0`, widens the window 300→500 ms (measured notification→group gaps 52–389 ms), and drops-on-flush when the destination is a known radio. Eliminates all 5 ghost dirs in the follow-up capture.
- **`feat(tetra): split recording per talker so every over is attributed to its source`** — follow-up: a group call spanning multiple talkers was recorded as one file tagged with only the first talker. TETRA now emits a `KindCallSegment` on a talker change (reusing the existing P25 segment→recorder-rename pipeline) so each over gets its own correctly-named file.
- **`docs+test: changelog … at-scale demux leak regression`** — CHANGELOG entries for the above, plus a deterministic at-scale regression that streams an interleaved two-call sequence through the demux and asserts the untracked call's leakage into the tracked recording stays bounded to the concurrency-ramp window (not proportional to length).

## Test plan

- [x] `make vet test` is green locally (full tree, `-race`)
- [x] `make integration` is green locally (`-race`; daemon/DSP/replay paths touched)
- [x] Added a fails-first regression test with each fix (engine hold/notification/talker-split, decode-queue sizing, iq-power gate, demux concurrency-suppression + at-scale leak bound)
- [x] Smoke-tested against the reporter's real captures — cs16 USRP concurrent-call IQ replayed through the multislot harness confirmed the physical-slot concurrency signal and burst separation; the notification→group-grant gaps and ghost-dir counts were measured from the supplied `debug.log`s. **Live end-to-end confirmation on the reporter's USRP/Airspy is still pending** (see below).

## Breaking changes

None. The only behavior change is per-transmission splitting for TETRA, gated on the existing `voice_call_grouping` setting (default already implies per-transmission, matching P25); `voice_call_grouping: conversation` still yields one file per call. New `EngineOptions.SplitPerTransmission` is internal.

## Docs / CHANGELOG

- [x] Added `## [Unreleased]` `CHANGELOG.md` bullets (Fixed: notification hold / cross-slot leak / #402 decode-queue / iq-power spam; Added: per-talker recording split).
- [ ] No operator-facing docs changed.

## Linked issues

`Refs #402` (decode-queue overruns). The remaining items are Discord-reported with no tracked issue, so they're intentionally **not** `Closes` — per the CLAUDE.md / #764 verify-before-close policy they await the reporter confirming on his own USRP/Airspy hardware. One reported item — the intermittent "warming up" cc-lock — was investigated and is **not a bug** (it's the normal `hunting` dwell while the TETRA AFC/Gardner/BSCH acquisition converges; nondeterministic by nature), so no code change is included for it.

### Documented as follow-up (out of scope here)

- **Fuller per-slot audio recovery.** This PR's cross-slot fix stops the *leak* by dropping unrouteable bursts during concurrency; it does not yet *recover* the ~⅔ of bursts whose AACH marker doesn't decode by routing them on the reliable physical TDMA slot. That is a larger demux redesign (the two captures disagree on marker↔slot stability) and deserves its own change.
- **Decode-path recorder I/O.** `ccdecoder.pump` still holds `d.mu` across synchronous DDC-recording file writes; only bites when DDC recording is enabled and disk hiccups — noted, not changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)