### PR TITLE
feat(broadcast): push kind=grant webhook sink for the control-channel grant feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **Push grant webhook (`broadcast.grant_webhook`).** A new outbound sink POSTs
+  one JSON object per control-channel grant the moment GopherTrunk decodes it —
+  the push counterpart to the pollable `GET /api/v1/grants` and the live
+  `KindGrant` SSE stream, all on one schema. The payload carries the grant as
+  decoded (system, protocol, talkgroup, source RID, frequency, P25 site
+  identity, timeslot, encryption + algorithm/key), stamped with the decode time.
+  Grants are coverage-truthful: a grant whose TSBK carried `source_id=0` is sent
+  with `source_id=0`, never backfilled — so the feed reports exactly what the
+  control channel saw, the way SDRtrunk's grant log does, letting a consumer
+  read the source RID off the grant at call-setup time without holding an SSE
+  connection or polling. Off by default; opt in per feed with a URL, optional
+  `Authorization` header, and an optional system filter. Refs #915, #268.
 - **TETRA demodulator equalizer recovers garbled voice recordings.** On
   concurrent-load captures a residual garble survived the soft-decision TCH/S
   decode: a linear channel / ISI defect (multipath, band-edge group delay) was

--- a/cmd/gophertrunk/broadcast.go
+++ b/cmd/gophertrunk/broadcast.go
@@ -128,3 +128,38 @@ func buildBroadcastManager(cfg config.BroadcastConfig, normCfg config.NormalizeC
 		Normalize:   normalize,
 	})
 }
+
+// buildGrantWebhooks constructs the push grant-webhook sinks from config —
+// one per enabled feed. It returns nil when none are enabled, so the daemon
+// simply skips the subsystem. Each sink subscribes to the bus at construction
+// (so grants decoded before Run starts are not lost) and POSTs the GrantDTO
+// schema per control-channel grant (issue #915 / #268).
+func buildGrantWebhooks(cfg config.BroadcastConfig, bus *events.Bus, loc *time.Location, log *slog.Logger) ([]*broadcast.GrantWebhook, error) {
+	var hooks []*broadcast.GrantWebhook
+	for _, f := range cfg.GrantWebhook {
+		if !f.Enabled {
+			continue
+		}
+		h, err := broadcast.NewGrantWebhook(broadcast.GrantWebhookOptions{
+			Bus: bus,
+			Log: log,
+			Config: broadcast.GrantWebhookConfig{
+				Name:       f.Name,
+				URL:        f.URL,
+				AuthHeader: f.AuthHeader,
+				Systems:    f.Systems,
+				Loc:        loc,
+			},
+		})
+		if err != nil {
+			// Close any already-built sinks so their bus subscriptions
+			// don't leak on a partial failure.
+			for _, done := range hooks {
+				_ = done.Close()
+			}
+			return nil, err
+		}
+		hooks = append(hooks, h)
+	}
+	return hooks, nil
+}

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -405,6 +405,7 @@ type Daemon struct {
 	iqAutoRec    *iqAutoRecorder
 	iqAutoRecSub *events.Subscription
 	broadcast    *broadcast.Manager
+	grantHooks   []*broadcast.GrantWebhook
 	composer     *composer.Composer
 	player       *player.Player
 	toneout      *toneout.Detector
@@ -1357,6 +1358,22 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		if mgr != nil {
 			d.broadcast = mgr
 			log.Info("outbound call streaming enabled", "backends", mgr.Backends())
+		}
+	}
+
+	// Push grant-webhook sinks — optional. Each POSTs one JSON object per
+	// decoded control-channel grant (the push form of GET /api/v1/grants,
+	// issue #915 / #268). Subscribes to the bus at construction so grants
+	// decoded before Run starts are not lost. Built only when at least one
+	// feed is enabled.
+	{
+		hooks, err := buildGrantWebhooks(cfg.Broadcast, d.bus, dispLoc, log)
+		if err != nil {
+			return nil, fmt.Errorf("daemon: grant webhook: %w", err)
+		}
+		if len(hooks) > 0 {
+			d.grantHooks = hooks
+			log.Info("grant webhook sinks enabled", "count", len(hooks))
 		}
 	}
 
@@ -2828,6 +2845,12 @@ func (d *Daemon) Run(ctx context.Context) error {
 			return d.broadcast.Run(ctx)
 		})
 	}
+	for _, h := range d.grantHooks {
+		h := h
+		d.spawn(runCtx, "grant-webhook", false, func(ctx context.Context) error {
+			return h.Run(ctx)
+		})
+	}
 	if d.composer != nil {
 		d.spawn(runCtx, "composer", false, func(ctx context.Context) error {
 			return d.composer.Run(ctx)
@@ -3441,6 +3464,9 @@ func (d *Daemon) Close() {
 		}
 		if d.broadcast != nil {
 			_ = d.broadcast.Close()
+		}
+		for _, h := range d.grantHooks {
+			_ = h.Close()
 		}
 		// Closes the file recorder or the decode-only recorder (same object
 		// when recording; voiceDecoder is a superset of recorder).

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1285,6 +1285,24 @@ broadcast:
   #     include_audio: false               # true embeds the base64 MP3 in each POST
   #     systems: ["Metro P25"]             # empty = every system
 
+  # Push grant webhook: POST one JSON object per control-channel grant the
+  # moment it is decoded — the push form of GET /api/v1/grants (issue #915).
+  # The payload is the same grant schema the REST snapshot and the KindGrant
+  # SSE stream use (system, protocol, group_id, source_id, frequency_hz, P25
+  # site identity, timeslot, encryption + algorithm_id/key_id, plus an `at`
+  # decode timestamp). Grants are surfaced exactly as decoded: a grant whose
+  # TSBK carried source_id=0 is POSTed with source_id=0, never backfilled — the
+  # source RID rides the grant at call-setup time the way SDRtrunk's grant log
+  # reads it, letting a consumer retire a separate grant-log dependency. Unlike
+  # the per-call webhook this carries no audio (a grant is a control-channel
+  # event, not a recording), and it is independent of recordings.skip_encrypted.
+  # grant_webhook:
+  #   - enabled: true
+  #     name: "grant-log"
+  #     url: "https://example.org/gophertrunk/grants"
+  #     auth_header: "Bearer YOUR_TOKEN"   # sent verbatim as Authorization; omit to disable
+  #     systems: ["Metro P25"]             # empty = every system
+
 # Baseband (IQ) recording and offline replay. `record` taps a tuner and
 # writes IQ to a two-channel 16-bit WAV (the same layout SDRtrunk/SDR++ use);
 # `replay` mounts recorded WAVs as virtual tuners so a capture can be decoded

--- a/internal/broadcast/grantwebhook.go
+++ b/internal/broadcast/grantwebhook.go
@@ -1,0 +1,357 @@
+package broadcast
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// Default tuning for a GrantWebhook.
+const (
+	// grantWebhookQueueDepth bounds the in-flight grant backlog. A busy
+	// control channel emits thousands of grants an hour; when the endpoint
+	// wedges we drop the oldest overflow rather than block the event loop
+	// (and the decoder behind it), the same discipline the call Manager uses.
+	grantWebhookQueueDepth = 256
+	grantWebhookMaxRetries = 3
+	grantWebhookRetryBase  = 2 * time.Second
+)
+
+// GrantWebhookConfig configures one push grant-webhook sink.
+type GrantWebhookConfig struct {
+	// Name is an optional log label; defaults to "grant-webhook".
+	Name string
+	// URL is the endpoint each grant is POSTed to (required).
+	URL string
+	// AuthHeader, when set, is sent verbatim as the Authorization header
+	// (e.g. "Bearer <token>"). Empty omits the header.
+	AuthHeader string
+	// Systems restricts the feed to these trunking-system names. Empty
+	// streams every system.
+	Systems []string
+	// Loc is the timezone the `at` RFC3339 timestamp renders in. Nil means
+	// time.Local. The format stays RFC3339, so the offset keeps the instant
+	// unambiguous whichever zone is chosen.
+	Loc *time.Location
+}
+
+// grantWebhookPayload is the JSON object POSTed for each decoded
+// control-channel grant. It mirrors the api.GrantDTO schema that
+// GET /api/v1/grants and the KindGrant SSE stream already publish — same
+// field names, same omitempty rules — plus an "event" discriminator and the
+// decode timestamp, so a consumer reads one schema across the REST snapshot,
+// the SSE live stream, and this push feed (issue #915 / #268).
+//
+// Grants are surfaced exactly as decoded off the control channel: the source
+// RID rides the grant at call-setup time for every protocol, and a grant whose
+// TSBK carried src=0 is POSTed with source_id=0 (never backfilled), so the feed
+// reports what the control channel actually saw — the way SDRtrunk's grant log
+// does. That makes it distinct from the completed-call webhook, whose source
+// RID depends on a separate voice-side decode landing.
+type grantWebhookPayload struct {
+	Event         string `json:"event"` // always "grant"
+	System        string `json:"system"`
+	Protocol      string `json:"protocol"`
+	GroupID       uint32 `json:"group_id"`
+	SourceID      uint32 `json:"source_id"`
+	FrequencyHz   uint32 `json:"frequency_hz"`
+	ChannelID     uint8  `json:"channel_id,omitempty"`
+	ChannelNumber uint16 `json:"channel_number,omitempty"`
+	RFSSID        uint8  `json:"rfss_id,omitempty"`
+	SiteID        uint8  `json:"site_id,omitempty"`
+	NAC           uint16 `json:"nac,omitempty"`
+	Timeslot      uint8  `json:"timeslot,omitempty"`
+	Encrypted     bool   `json:"encrypted,omitempty"`
+	Emergency     bool   `json:"emergency,omitempty"`
+	DataCall      bool   `json:"data_call,omitempty"`
+	Individual    bool   `json:"individual,omitempty"`
+	AlgorithmID   uint8  `json:"algorithm_id,omitempty"`
+	KeyID         uint16 `json:"key_id,omitempty"`
+	At            string `json:"at"` // RFC3339 decode time
+}
+
+// grantWebhookPayloadFrom projects a trunking.Grant onto the wire schema.
+func grantWebhookPayloadFrom(g trunking.Grant, at time.Time, loc *time.Location) grantWebhookPayload {
+	return grantWebhookPayload{
+		Event:         "grant",
+		System:        g.System,
+		Protocol:      g.Protocol,
+		GroupID:       g.GroupID,
+		SourceID:      g.SourceID,
+		FrequencyHz:   g.FrequencyHz,
+		ChannelID:     g.ChannelID,
+		ChannelNumber: g.ChannelNum,
+		RFSSID:        g.RFSSID,
+		SiteID:        g.SiteID,
+		NAC:           g.NAC,
+		Timeslot:      g.Timeslot,
+		Encrypted:     g.Encrypted,
+		Emergency:     g.Emergency,
+		DataCall:      g.DataCall,
+		Individual:    g.Individual,
+		AlgorithmID:   g.AlgorithmID,
+		KeyID:         g.KeyID,
+		At:            rfc3339In(at, loc),
+	}
+}
+
+// GrantWebhookOptions configure a GrantWebhook.
+type GrantWebhookOptions struct {
+	// Bus is the event bus to subscribe to. Required.
+	Bus *events.Bus
+	// Log defaults to slog.Default().
+	Log *slog.Logger
+	// Config is the sink's destination and filter. URL is required.
+	Config GrantWebhookConfig
+	// MaxRetries is the per-grant retry budget on a failed POST. Default 3.
+	MaxRetries int
+	// RetryBase is the first backoff delay; it doubles per attempt. Default 2s.
+	RetryBase time.Duration
+	// Now is injectable for tests; defaults to time.Now. It stamps a grant
+	// that reached the bus with a zero At.
+	Now func() time.Time
+	// HTTP is the client used for delivery; defaults to http.DefaultClient.
+	HTTP *http.Client
+}
+
+// GrantWebhook POSTs each decoded control-channel grant to a JSON endpoint as
+// it lands — the push form of GET /api/v1/grants (issue #915). It subscribes to
+// the bus at construction, so grants decoded before Run starts are not lost,
+// and delivers on a single worker with retry/backoff. A wedged endpoint fills
+// the bounded queue and overflow grants are dropped rather than stalling the
+// decoder.
+type GrantWebhook struct {
+	name       string
+	endpoint   string
+	authHeader string
+	filter     systemFilter
+	loc        *time.Location
+	http       *http.Client
+	log        *slog.Logger
+	now        func() time.Time
+	maxRetries int
+	retryBase  time.Duration
+
+	sub       *events.Subscription
+	jobs      chan grantWebhookPayload
+	wg        sync.WaitGroup
+	runDone   chan struct{}
+	closeOnce sync.Once
+
+	mu      sync.Mutex
+	queued  int
+	dropped int
+	sent    int
+	failed  int
+}
+
+// NewGrantWebhook validates opts and returns a sink that has already
+// subscribed to the bus. The caller must invoke Run and, on shutdown, Close.
+func NewGrantWebhook(opts GrantWebhookOptions) (*GrantWebhook, error) {
+	if opts.Bus == nil {
+		return nil, errors.New("broadcast/grantwebhook: events.Bus is required")
+	}
+	if opts.Config.URL == "" {
+		return nil, errors.New("broadcast/grantwebhook: url is required")
+	}
+	if opts.Log == nil {
+		opts.Log = slog.Default()
+	}
+	if opts.MaxRetries <= 0 {
+		opts.MaxRetries = grantWebhookMaxRetries
+	}
+	if opts.RetryBase <= 0 {
+		opts.RetryBase = grantWebhookRetryBase
+	}
+	if opts.Now == nil {
+		opts.Now = time.Now
+	}
+	if opts.HTTP == nil {
+		opts.HTTP = http.DefaultClient
+	}
+	name := opts.Config.Name
+	if name == "" {
+		name = "grant-webhook"
+	}
+	w := &GrantWebhook{
+		name:       name,
+		endpoint:   opts.Config.URL,
+		authHeader: opts.Config.AuthHeader,
+		filter:     newSystemFilter(opts.Config.Systems),
+		loc:        opts.Config.Loc,
+		http:       opts.HTTP,
+		log:        opts.Log,
+		now:        opts.Now,
+		maxRetries: opts.MaxRetries,
+		retryBase:  opts.RetryBase,
+		jobs:       make(chan grantWebhookPayload, grantWebhookQueueDepth),
+		runDone:    make(chan struct{}),
+	}
+	w.sub = opts.Bus.Subscribe()
+	w.wg.Add(1)
+	go w.worker()
+	return w, nil
+}
+
+// Name reports the sink's log label.
+func (w *GrantWebhook) Name() string { return w.name }
+
+// Run drains KindGrant events until ctx is cancelled or the bus subscription
+// closes.
+func (w *GrantWebhook) Run(ctx context.Context) error {
+	defer close(w.runDone)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case ev, ok := <-w.sub.C:
+			if !ok {
+				return nil
+			}
+			if ev.Kind != events.KindGrant {
+				continue
+			}
+			g, ok := ev.Payload.(trunking.Grant)
+			if !ok {
+				continue
+			}
+			w.enqueue(g)
+		}
+	}
+}
+
+// enqueue applies the system filter and hands the grant to the worker,
+// dropping it when the queue is full rather than blocking the event loop.
+func (w *GrantWebhook) enqueue(g trunking.Grant) {
+	if !w.filter.Accepts(g.System) {
+		return
+	}
+	at := g.At
+	if at.IsZero() {
+		at = w.now()
+	}
+	p := grantWebhookPayloadFrom(g, at, w.loc)
+	select {
+	case w.jobs <- p:
+		w.mu.Lock()
+		w.queued++
+		w.mu.Unlock()
+	default:
+		w.mu.Lock()
+		w.dropped++
+		w.mu.Unlock()
+		w.log.Warn("broadcast/grantwebhook: queue full, dropping grant",
+			"name", w.name, "system", g.System, "tg", g.GroupID)
+	}
+}
+
+func (w *GrantWebhook) worker() {
+	defer w.wg.Done()
+	for p := range w.jobs {
+		w.sendWithRetry(p)
+	}
+}
+
+// sendWithRetry attempts delivery up to maxRetries+1 times with exponential
+// backoff between attempts.
+func (w *GrantWebhook) sendWithRetry(p grantWebhookPayload) {
+	backoff := w.retryBase
+	for attempt := 0; attempt <= w.maxRetries; attempt++ {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		err := w.post(ctx, p)
+		cancel()
+		if err == nil {
+			w.mu.Lock()
+			w.sent++
+			w.mu.Unlock()
+			return
+		}
+		w.log.Warn("broadcast/grantwebhook: post failed",
+			"name", w.name, "system", p.System, "tg", p.GroupID,
+			"attempt", attempt+1, "of", w.maxRetries+1, "err", err)
+		if attempt < w.maxRetries {
+			time.Sleep(backoff)
+			backoff *= 2
+		}
+	}
+	w.mu.Lock()
+	w.failed++
+	w.mu.Unlock()
+	w.log.Error("broadcast/grantwebhook: giving up on grant",
+		"name", w.name, "system", p.System, "tg", p.GroupID)
+}
+
+// post marshals and POSTs one grant as application/json.
+func (w *GrantWebhook) post(ctx context.Context, p grantWebhookPayload) error {
+	body, err := json.Marshal(p)
+	if err != nil {
+		return fmt.Errorf("%s: marshal: %w", w.name, err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, w.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if w.authHeader != "" {
+		req.Header.Set("Authorization", w.authHeader)
+	}
+	resp, err := w.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("%s: post: %w", w.name, err)
+	}
+	defer resp.Body.Close()
+	msg, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("%s: HTTP %d: %s", w.name, resp.StatusCode,
+			strings.TrimSpace(string(msg)))
+	}
+	return nil
+}
+
+// GrantWebhookStats is a point-in-time snapshot of a GrantWebhook's counters.
+type GrantWebhookStats struct {
+	Name    string `json:"name"`
+	Queued  int    `json:"queued"`
+	Dropped int    `json:"dropped"`
+	Sent    int    `json:"sent"`
+	Failed  int    `json:"failed"`
+}
+
+// Stats returns a snapshot of the sink's counters.
+func (w *GrantWebhook) Stats() GrantWebhookStats {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return GrantWebhookStats{
+		Name:    w.name,
+		Queued:  w.queued,
+		Dropped: w.dropped,
+		Sent:    w.sent,
+		Failed:  w.failed,
+	}
+}
+
+// Close releases the bus subscription, waits for Run to drain, then stops the
+// delivery worker. Safe to call multiple times.
+func (w *GrantWebhook) Close() error {
+	w.closeOnce.Do(func() {
+		w.sub.Close()
+		select {
+		case <-w.runDone:
+		case <-time.After(2 * time.Second):
+		}
+		close(w.jobs)
+		w.wg.Wait()
+	})
+	return nil
+}

--- a/internal/broadcast/grantwebhook_test.go
+++ b/internal/broadcast/grantwebhook_test.go
@@ -1,0 +1,243 @@
+package broadcast
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// grantSink is an httptest server that records every POSTed grant payload.
+type grantSink struct {
+	*httptest.Server
+	mu   sync.Mutex
+	got  []map[string]any
+	auth string
+	ct   string
+}
+
+func newGrantSink(t *testing.T) *grantSink {
+	t.Helper()
+	gs := &grantSink{}
+	gs.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		var m map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&m); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		gs.mu.Lock()
+		gs.auth = r.Header.Get("Authorization")
+		gs.ct = r.Header.Get("Content-Type")
+		gs.got = append(gs.got, m)
+		gs.mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(gs.Server.Close)
+	return gs
+}
+
+func (gs *grantSink) count() int {
+	gs.mu.Lock()
+	defer gs.mu.Unlock()
+	return len(gs.got)
+}
+
+func (gs *grantSink) waitFor(t *testing.T, want int) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if gs.count() >= want {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d POSTed grants (have %d)", want, gs.count())
+}
+
+func startGrantWebhook(t *testing.T, opts GrantWebhookOptions) *GrantWebhook {
+	t.Helper()
+	w, err := NewGrantWebhook(opts)
+	if err != nil {
+		t.Fatalf("NewGrantWebhook: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go w.Run(ctx)
+	t.Cleanup(func() { cancel(); w.Close() })
+	return w
+}
+
+// TestGrantWebhookPostsDecodedGrant is the issue #915 / #268 guard for the push
+// grant sink: a grant decoded off the control channel is POSTed as one JSON
+// object carrying the source RID (and talkgroup, frequency, site, encryption)
+// on the GrantDTO schema, so a consumer reads it the way SDRtrunk's grant log
+// exposes it — without holding an SSE connection or polling /api/v1/grants.
+func TestGrantWebhookPostsDecodedGrant(t *testing.T) {
+	sink := newGrantSink(t)
+	bus := events.NewBus(16)
+	defer bus.Close()
+
+	fixed := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	startGrantWebhook(t, GrantWebhookOptions{
+		Bus:  bus,
+		HTTP: sink.Client(),
+		Now:  func() time.Time { return fixed },
+		Config: GrantWebhookConfig{
+			URL:        sink.URL,
+			AuthHeader: "Bearer t0ken",
+			Loc:        time.UTC,
+		},
+	})
+
+	bus.Publish(events.Event{Kind: events.KindGrant, Payload: trunking.Grant{
+		System: "MMR", Protocol: "p25", GroupID: 20001, SourceID: 202419,
+		FrequencyHz: 422612500, RFSSID: 1, SiteID: 9, NAC: 359,
+		Encrypted: true, AlgorithmID: 0x84, KeyID: 3,
+	}})
+	sink.waitFor(t, 1)
+
+	sink.mu.Lock()
+	defer sink.mu.Unlock()
+	if sink.ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", sink.ct)
+	}
+	if sink.auth != "Bearer t0ken" {
+		t.Errorf("Authorization = %q, want Bearer t0ken", sink.auth)
+	}
+	g := sink.got[0]
+	if g["event"] != "grant" {
+		t.Errorf("event = %v, want grant", g["event"])
+	}
+	// JSON numbers decode as float64.
+	if g["source_id"].(float64) != 202419 {
+		t.Errorf("source_id = %v, want 202419", g["source_id"])
+	}
+	if g["group_id"].(float64) != 20001 {
+		t.Errorf("group_id = %v, want 20001", g["group_id"])
+	}
+	if g["frequency_hz"].(float64) != 422612500 {
+		t.Errorf("frequency_hz = %v, want 422612500", g["frequency_hz"])
+	}
+	if g["rfss_id"].(float64) != 1 || g["site_id"].(float64) != 9 {
+		t.Errorf("site identity = rfss %v site %v, want 1/9", g["rfss_id"], g["site_id"])
+	}
+	if g["encrypted"] != true {
+		t.Errorf("encrypted = %v, want true", g["encrypted"])
+	}
+	if g["algorithm_id"].(float64) != 0x84 {
+		t.Errorf("algorithm_id = %v, want 132", g["algorithm_id"])
+	}
+	if g["at"] != "2026-08-01T12:00:00Z" {
+		t.Errorf("at = %v, want the stamped decode time", g["at"])
+	}
+}
+
+// TestGrantWebhookSourceZeroTruthful pins the coverage-truthful contract: a
+// grant whose TSBK carried src=0 is POSTed with source_id=0 present (not
+// omitted, not backfilled), so the feed reports exactly what the control
+// channel saw — the property #915 relies on to distinguish a real grant log
+// from the voice-side completed-call source.
+func TestGrantWebhookSourceZeroTruthful(t *testing.T) {
+	sink := newGrantSink(t)
+	bus := events.NewBus(16)
+	defer bus.Close()
+
+	startGrantWebhook(t, GrantWebhookOptions{
+		Bus:    bus,
+		HTTP:   sink.Client(),
+		Config: GrantWebhookConfig{URL: sink.URL},
+	})
+
+	bus.Publish(events.Event{Kind: events.KindGrant, Payload: trunking.Grant{
+		System: "MMR", Protocol: "p25", GroupID: 20001, SourceID: 0,
+		FrequencyHz: 422612500,
+	}})
+	sink.waitFor(t, 1)
+
+	sink.mu.Lock()
+	defer sink.mu.Unlock()
+	g := sink.got[0]
+	v, ok := g["source_id"]
+	if !ok {
+		t.Fatal("source_id absent; must be present and zero (coverage-truthful)")
+	}
+	if v.(float64) != 0 {
+		t.Errorf("source_id = %v, want 0", v)
+	}
+}
+
+// TestGrantWebhookSystemFilter confirms the Systems filter drops grants from
+// other systems and delivers only the configured one.
+func TestGrantWebhookSystemFilter(t *testing.T) {
+	sink := newGrantSink(t)
+	bus := events.NewBus(16)
+	defer bus.Close()
+
+	startGrantWebhook(t, GrantWebhookOptions{
+		Bus:    bus,
+		HTTP:   sink.Client(),
+		Config: GrantWebhookConfig{URL: sink.URL, Systems: []string{"Metro"}},
+	})
+
+	bus.Publish(events.Event{Kind: events.KindGrant, Payload: trunking.Grant{
+		System: "Regional", Protocol: "p25", GroupID: 1, FrequencyHz: 1,
+	}})
+	bus.Publish(events.Event{Kind: events.KindGrant, Payload: trunking.Grant{
+		System: "Metro", Protocol: "p25", GroupID: 2, FrequencyHz: 2,
+	}})
+	sink.waitFor(t, 1)
+	// Give any erroneously-delivered second grant a chance to land.
+	time.Sleep(50 * time.Millisecond)
+
+	sink.mu.Lock()
+	defer sink.mu.Unlock()
+	if len(sink.got) != 1 {
+		t.Fatalf("delivered %d grants, want 1 (filtered)", len(sink.got))
+	}
+	if sink.got[0]["system"] != "Metro" {
+		t.Errorf("delivered system = %v, want Metro", sink.got[0]["system"])
+	}
+}
+
+// TestGrantWebhookIgnoresNonGrant confirms non-grant events never reach the
+// sink (the sink is a grant feed, not the call feed).
+func TestGrantWebhookIgnoresNonGrant(t *testing.T) {
+	sink := newGrantSink(t)
+	bus := events.NewBus(16)
+	defer bus.Close()
+
+	startGrantWebhook(t, GrantWebhookOptions{
+		Bus:    bus,
+		HTTP:   sink.Client(),
+		Config: GrantWebhookConfig{URL: sink.URL},
+	})
+
+	bus.Publish(events.Event{Kind: events.KindCallComplete, Payload: trunking.CallComplete{}})
+	bus.Publish(events.Event{Kind: events.KindGrant, Payload: trunking.Grant{
+		System: "MMR", Protocol: "p25", GroupID: 1, FrequencyHz: 1,
+	}})
+	sink.waitFor(t, 1)
+
+	if n := sink.count(); n != 1 {
+		t.Fatalf("delivered %d payloads, want only the grant (1)", n)
+	}
+}
+
+// TestNewGrantWebhookRequiresURL guards the constructor validation.
+func TestNewGrantWebhookRequiresURL(t *testing.T) {
+	bus := events.NewBus(1)
+	defer bus.Close()
+	if _, err := NewGrantWebhook(GrantWebhookOptions{Bus: bus}); err == nil {
+		t.Fatal("NewGrantWebhook with no URL: want error, got nil")
+	}
+	if _, err := NewGrantWebhook(GrantWebhookOptions{Config: GrantWebhookConfig{URL: "http://x"}}); err == nil {
+		t.Fatal("NewGrantWebhook with no Bus: want error, got nil")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -622,6 +622,11 @@ type BroadcastConfig struct {
 	OpenMHz      []OpenMHzFeedConfig      `yaml:"openmhz"`
 	Icecast      []IcecastFeedConfig      `yaml:"icecast"`
 	Webhook      []WebhookFeedConfig      `yaml:"webhook"`
+	// GrantWebhook lists zero or more push grant-webhook sinks. Each POSTs
+	// one JSON object per control-channel grant as it is decoded — the push
+	// form of GET /api/v1/grants (issue #915 / #268). A feed with
+	// enabled=false is parsed but skipped.
+	GrantWebhook []GrantWebhookFeedConfig `yaml:"grant_webhook"`
 }
 
 // BroadcastifyFeedConfig is one Broadcastify Calls upload feed.
@@ -665,6 +670,22 @@ type WebhookFeedConfig struct {
 	// keeps the webhook a lightweight metadata feed.
 	IncludeAudio bool     `yaml:"include_audio"`
 	Systems      []string `yaml:"systems"`
+}
+
+// GrantWebhookFeedConfig is one push grant-webhook sink: each control-channel
+// grant is POSTed as one JSON object to URL as it is decoded (issue #915 /
+// #268). The payload is the same GrantDTO schema GET /api/v1/grants and the
+// KindGrant SSE stream publish, so a consumer reads one schema across all
+// three. Unlike the per-call webhook it carries no audio — a grant is a
+// control-channel event, not a recording.
+type GrantWebhookFeedConfig struct {
+	Enabled bool   `yaml:"enabled"`
+	Name    string `yaml:"name"`
+	URL     string `yaml:"url"`
+	// AuthHeader is sent verbatim as the Authorization header (e.g.
+	// "Bearer <token>"). Empty omits the header.
+	AuthHeader string   `yaml:"auth_header"`
+	Systems    []string `yaml:"systems"`
 }
 
 // IcecastFeedConfig is one live Icecast/ShoutCast feed.
@@ -2808,6 +2829,14 @@ func (b BroadcastConfig) validate() error {
 		}
 		if f.URL == "" {
 			return fmt.Errorf("broadcast.webhook[%d]: url required", i)
+		}
+	}
+	for i, f := range b.GrantWebhook {
+		if !f.Enabled {
+			continue
+		}
+		if f.URL == "" {
+			return fmt.Errorf("broadcast.grant_webhook[%d]: url required", i)
 		}
 	}
 	return nil

--- a/internal/configbuilder/fieldmeta.go
+++ b/internal/configbuilder/fieldmeta.go
@@ -345,6 +345,7 @@ var fieldMetas = map[string]FieldMeta{
 	"BroadcastConfig.OpenMHz":         {Label: "OpenMHz", Help: "OpenMHz upload feeds."},
 	"BroadcastConfig.Icecast":         {Help: "Live Icecast/ShoutCast mountpoint feeds."},
 	"BroadcastConfig.Webhook":         {Help: "Generic JSON-webhook call sinks: POST one JSON object per completed call."},
+	"BroadcastConfig.GrantWebhook":    {Help: "Push grant-webhook sinks: POST one JSON object per control-channel grant as it is decoded (the push form of GET /api/v1/grants)."},
 	"BroadcastifyFeedConfig.Enabled":  {Help: "Enable this feed. false keeps it configured but skipped."},
 	"BroadcastifyFeedConfig.Name":     {Help: "Feed label for logs/metrics."},
 	"BroadcastifyFeedConfig.APIKey":   {Label: "API key", Help: "Broadcastify Calls API key."},
@@ -376,6 +377,12 @@ var fieldMetas = map[string]FieldMeta{
 	"WebhookFeedConfig.AuthHeader":    {Label: "Auth header", Help: "Sent verbatim as the Authorization header (e.g. 'Bearer <token>'). Empty omits it."},
 	"WebhookFeedConfig.IncludeAudio":  {Help: "Embed the base64 MP3 in the payload. Off keeps the webhook a lightweight metadata feed."},
 	"WebhookFeedConfig.Systems":       {Help: "GopherTrunk system names to stream. Empty = every system."},
+
+	"GrantWebhookFeedConfig.Enabled":    {Help: "Enable this feed. false keeps it configured but skipped."},
+	"GrantWebhookFeedConfig.Name":       {Help: "Feed label for logs/metrics."},
+	"GrantWebhookFeedConfig.URL":        {Label: "URL", Help: "Endpoint each decoded control-channel grant is POSTed to as JSON."},
+	"GrantWebhookFeedConfig.AuthHeader": {Label: "Auth header", Help: "Sent verbatim as the Authorization header (e.g. 'Bearer <token>'). Empty omits it."},
+	"GrantWebhookFeedConfig.Systems":    {Help: "GopherTrunk system names to stream. Empty = every system."},
 
 	// ---- Baseband ----------------------------------------------------------
 	"BasebandConfig.Record":       {Help: "Tap tuners and write their IQ to WAV (wideband or narrowband DDC output)."},

--- a/web/configbuilder/src/api/types.ts
+++ b/web/configbuilder/src/api/types.ts
@@ -376,6 +376,13 @@ export interface WebhookFeed {
   IncludeAudio: boolean;
   Systems: string[] | null;
 }
+export interface GrantWebhookFeed {
+  Enabled: boolean;
+  Name: string;
+  URL: string;
+  AuthHeader: string;
+  Systems: string[] | null;
+}
 export interface BroadcastConfig {
   MinDurationMs: number;
   Workers: number;
@@ -384,6 +391,7 @@ export interface BroadcastConfig {
   OpenMHz: OpenMHzFeed[] | null;
   Icecast: IcecastFeed[] | null;
   Webhook: WebhookFeed[] | null;
+  GrantWebhook: GrantWebhookFeed[] | null;
 }
 
 export interface BasebandRecordConfig {

--- a/web/configbuilder/src/sections/Broadcast.tsx
+++ b/web/configbuilder/src/sections/Broadcast.tsx
@@ -6,6 +6,7 @@ import { useSection } from "./useSection";
 import type {
   BroadcastConfig,
   BroadcastifyFeed,
+  GrantWebhookFeed,
   IcecastFeed,
   OpenMHzFeed,
   RdioScannerFeed,
@@ -18,7 +19,7 @@ export function BroadcastSection() {
   const [cfg, set] = useSection("Broadcast");
   const c =
     (cfg as BroadcastConfig) ??
-    ({ MinDurationMs: 0, Workers: 0, Broadcastify: null, RdioScanner: null, OpenMHz: null, Icecast: null, Webhook: null } as BroadcastConfig);
+    ({ MinDurationMs: 0, Workers: 0, Broadcastify: null, RdioScanner: null, OpenMHz: null, Icecast: null, Webhook: null, GrantWebhook: null } as BroadcastConfig);
   return (
     <Section
       sectionKey="broadcast"
@@ -148,6 +149,28 @@ export function BroadcastSection() {
                 <TextField label="URL" value={f.URL} onChange={(v) => setF({ ...f, URL: v })} placeholder="https://example/hook" />
                 <TextField label="Auth header" value={f.AuthHeader} onChange={(v) => setF({ ...f, AuthHeader: v })} placeholder="Bearer …" help="Sent verbatim as the Authorization header. Empty omits it." />
                 <BoolField label="Include audio" value={f.IncludeAudio} onChange={(v) => setF({ ...f, IncludeAudio: v })} />
+                <TextField label="Systems" value={formatCommaList(f.Systems)} onChange={(v) => setF({ ...f, Systems: parseCommaList(v) })} help={SYSTEMS_HELP} />
+              </div>
+            </div>
+          )}
+        />
+      </Fieldset>
+
+      <Fieldset legend="Grant webhook (JSON POST per grant)">
+        <ListEditor<GrantWebhookFeed>
+          label="Feeds"
+          items={c.GrantWebhook}
+          onChange={(x) => set({ ...c, GrantWebhook: x })}
+          makeNew={() => ({ Enabled: true, Name: "", URL: "", AuthHeader: "", Systems: null })}
+          itemTitle={(f) => f.Name || "feed"}
+          emptyHint="No grant webhook feeds."
+          renderItem={(f, setF) => (
+            <div className="space-y-3">
+              <BoolField label="Enabled" value={f.Enabled} onChange={(v) => setF({ ...f, Enabled: v })} />
+              <div className="grid gap-3 sm:grid-cols-2">
+                <TextField label="Name" value={f.Name} onChange={(v) => setF({ ...f, Name: v })} />
+                <TextField label="URL" value={f.URL} onChange={(v) => setF({ ...f, URL: v })} placeholder="https://example/grants" />
+                <TextField label="Auth header" value={f.AuthHeader} onChange={(v) => setF({ ...f, AuthHeader: v })} placeholder="Bearer …" help="Sent verbatim as the Authorization header. Empty omits it." />
                 <TextField label="Systems" value={formatCommaList(f.Systems)} onChange={(v) => setF({ ...f, Systems: parseCommaList(v) })} help={SYSTEMS_HELP} />
               </div>
             </div>

--- a/web/configbuilder/src/sections/sections.smoke.test.tsx
+++ b/web/configbuilder/src/sections/sections.smoke.test.tsx
@@ -26,7 +26,7 @@ describe("section editors patch the draft with capitalized Go keys", () => {
 
   it("Broadcast add Broadcastify feed writes config.Broadcast.Broadcastify", () => {
     seed({
-      Broadcast: { MinDurationMs: 0, Workers: 0, Broadcastify: null, RdioScanner: null, OpenMHz: null, Icecast: null, Webhook: null },
+      Broadcast: { MinDurationMs: 0, Workers: 0, Broadcastify: null, RdioScanner: null, OpenMHz: null, Icecast: null, Webhook: null, GrantWebhook: null },
     });
     render(<BroadcastSection />);
     // The first "+ Add" button belongs to the Broadcastify list.


### PR DESCRIPTION
Add broadcast.grant_webhook: an opt-in outbound sink that POSTs one JSON
object per control-channel grant the moment it is decoded — the push
counterpart to the pollable GET /api/v1/grants and the live KindGrant SSE
stream. The payload is the same GrantDTO schema all three already share
(system, protocol, talkgroup, source RID, frequency, P25 site identity,
timeslot, encryption + algorithm/key), stamped with the decode time.

Grants are surfaced coverage-truthfully: a grant whose TSBK carried
source_id=0 is POSTed with source_id=0, never backfilled, so the feed
reports exactly what the control channel saw — the way SDRtrunk's grant log
does. This lets a telemetry consumer read the source RID off the grant at
call-setup time and retire a separate grant-log dependency without holding
an SSE connection or polling.

The sink subscribes to the bus at construction (so grants decoded before
Run starts are not lost), delivers on a single worker with retry/backoff,
and drops overflow when the endpoint wedges rather than stalling the
decoder — the same discipline the completed-call Manager uses. Off by
default; each feed configures a URL, an optional Authorization header, and
an optional system filter. Wired through config validation, the config
builder field metadata + web schema, and the daemon lifecycle.

Refs #915, #268

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01L1QsrPRcicY5eTqqsXmTFf