### PR TITLE
docs+test(tetra): CHANGELOG for the merged USRP fixes + at-scale demux-leak regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **TETRA recordings split per talker, so every over is attributed to its source.**
+  A group call stays on one traffic channel while members key up in turn; GT
+  recorded the whole call as one WAV tagged with only the first talker, so a reply
+  from a second member had no correctly-attributed file. The per-transmission split
+  pipeline P25 already uses (a `CallSegment` boundary rolls the recording to a fresh
+  file named from the current source) is now driven for TETRA: on a talker change
+  (D-TX-GRANTED → call talker) the engine emits the boundary before backfilling the
+  new source, so the closing file keeps the previous talker and the next over opens
+  a file named with the new one. Honors the existing `voice_call_grouping` setting
+  (default splits per transmission, matching P25; `conversation` keeps one file per
+  call). No configuration change.
 - **TETRA demodulator equalizer recovers garbled voice recordings.** On
   concurrent-load captures a residual garble survived the soft-decision TCH/S
   decode: a linear channel / ISI defect (multipath, band-edge group delay) was
@@ -228,6 +239,47 @@ for tagged releases.
   rather than a fixed slot 1 — the building block for issue #925.
 
 ### Fixed
+- **TETRA wakeup / notification grants spawned ghost recordings named after a
+  radio ID.** On a group call the SwMI sends a source-less notification (an
+  Energy-Economy wakeup page, `SourceID==0`, addressed to the calling party's radio
+  SSI) 50–400 ms before the authoritative group grant. The engine spawned it
+  immediately, creating a ghost call and a WAV directory named after the radio ID
+  (`recordings/<sys>/<radioSSI>/…src0…`) that was then torn down when the group
+  grant superseded it — fragmenting audio and leaking radio IDs as talkgroups. The
+  engine now holds a source-less TETRA notification for a short window (500 ms) so
+  the group grant arrives first and cancels it, spawning the one real call under
+  the GSSI. The hold keys on `SourceID==0` (not the `Individual` flag, which the
+  first notification for a radio is published without), and a notification that is
+  never superseded is dropped if it targets a known radio (else recorded under its
+  real talkgroup). A genuine unit-to-unit call carries a source, so it is never
+  held.
+- **Cross-slot audio leaked between concurrent same-carrier TETRA calls.** The
+  shared per-carrier voice demux fell back to a "sole active call" CRC gate for
+  bursts it could not route by AACH marker — but a single *registered* owner is not
+  the same as a single call on the *air*. When another slot carried a call GT was
+  not tracking as an owner (a missed grant, a call in hangtime, a wakeup-page
+  ghost), that foreign slot's speech funnelled through the one owner's CRC gate and
+  bled into its recording (a valid TCH/S CRC proves a burst is speech, not *whose*).
+  The demux now judges on-air concurrency from the SB-anchored physical TDMA slot
+  (available on ~100% of bursts, unlike the marker) and suppresses the sole-owner
+  fallback whenever two or more slots are active, so foreign speech is dropped
+  rather than mis-attributed. Clean single-call captures are unchanged.
+- **`ccdecoder: decode can't keep up… dropping IQ` (#402) fired at idle CPU on a
+  remote USRP.** The decode queue between the IQ forwarder and the decode goroutine
+  was a fixed 128-*chunk* buffer. That is only meaningful in seconds when chunks are
+  large; SoapyRemote delivers a remote USRP ~369-sample datagrams, so 128 chunks was
+  only ~47 ms at 1 MS/s — while the driver's own channel is sized for 400 ms and
+  never overflowed, producing attributable decode overruns the driver never saw. The
+  queue is now bounded by a wall-clock **sample budget** (~0.5 s) derived from the
+  sample rate, so its depth-in-seconds is invariant to how the driver chunks
+  delivery. Airspy/B210 (large native blocks) are unaffected.
+- **`ccdecoder: iq power very low` DEBUG spam while locked and decoding.** The
+  low-power hint fired whenever windowed RMS sat below −55 dBFS with no gate on lock
+  state, so a USRP/SDR run at conservative gain (~−60 dBFS, ~55 dB of unused ADC
+  headroom) that decoded TETRA cleanly logged it every few seconds. It is now gated
+  on `!locked` — a low absolute level only matters when the decoder cannot lock — and
+  throttled to 30 s to match the clip / DC-dominant siblings. The Prometheus IQ-power
+  gauge still records every window.
 - **TETRA radio IDs still surfaced as talkgroups in the live Active Calls list.**
   The engine's RadioID→TGID retraction cleaned the Talkgroups catalogue but not
   the control-only "observed" call set, which is the other half of what the

--- a/internal/voice/composer/tetra_voice_test.go
+++ b/internal/voice/composer/tetra_voice_test.go
@@ -562,6 +562,50 @@ func TestTETRADemuxNoLeakWhenAirConcurrentButOneOwner(t *testing.T) {
 	}
 }
 
+// TestTETRADemuxConcurrentStreamNoLeakToSoleOwner is the at-scale regression for
+// the reported cross-slot leak, streaming a realistic interleaved two-call
+// sequence — one call GT tracks (owner A on physical slot 1), one it does NOT (a
+// call on slot 2 GT never granted an owner for). Before the fix every one of the
+// untracked call's bursts funnelled through owner A's sole-owner CRC gate (a valid
+// TCH/S CRC proves a burst is speech, not whose), over-producing A's recording
+// with the other call's audio. After the fix the demux detects the two active
+// physical slots and suppresses the fallback, so A gets essentially only its own
+// speech — the untracked call's leakage is bounded to the brief concurrency-ramp
+// window, not proportional to its length.
+func TestTETRADemuxConcurrentStreamNoLeakToSoleOwner(t *testing.T) {
+	c, _, _ := mkBoundaryComposer(t, false, 50*time.Millisecond)
+	d := mkDemux(c)
+	frame := tetra.EncodeTCHS(make([]byte, 137), make([]byte, 137)) // CRC-valid → 2 speech frames
+
+	// GT tracks call A (marker 19, physical slot 1) only. Call B (marker 20, slot 2)
+	// is on the air but has no registered owner.
+	oA, rsA := newDemuxOwner(c, "A", 19)
+	d.addOwner(oA)
+
+	const rounds = 40
+	for i := 0; i < rounds; i++ {
+		d.onBurst(frame, nil, 1, 19) // A's own burst — marker-routed to A
+		d.onBurst(frame, nil, 2, 20) // B's burst — ownerless, another physical slot
+	}
+
+	// A must get its own speech (2 frames/burst × rounds).
+	aFrames := len(rsA.rawFrames("A"))
+	own := 2 * rounds
+	if aFrames < own {
+		t.Errorf("owner A lost its own speech: %d frames, want >= %d", aFrames, own)
+	}
+	// Leakage of B is bounded to the ramp-up before both slots read as active
+	// (a few bursts per slot). It must NOT scale with the stream length.
+	maxLeakFrames := 2 * (minSlotBurstsForActive + 2)
+	if leak := aFrames - own; leak > maxLeakFrames {
+		t.Errorf("call B leaked %d frames into A's recording (want <= %d); the sole-owner fallback is not gated on on-air concurrency", leak, maxLeakFrames)
+	}
+	// Most of B's bursts were suppressed, not funnelled.
+	if got := d.concurrencySuppressed.Load(); got < uint64(rounds-minSlotBurstsForActive-2) {
+		t.Errorf("concurrencySuppressed = %d, want most of B's %d bursts suppressed", got, rounds)
+	}
+}
+
 // TestTETRADemuxMarkerCollisionCounted: two calls registering the same usage
 // marker is now counted + warned (previously a silent orphan). Most-recent-grant
 // still wins the marker (existing eviction semantics preserved).


### PR DESCRIPTION
## Summary

Follow-up housekeeping that got left behind when PR #1009 merged one commit early (at `dfe48f4`). The six USRP field-report fixes are already on `main`; this adds their **CHANGELOG entries** — which never landed — plus a **deterministic at-scale regression** for the cross-slot audio-leak fix. No production-code behavior change.

## Changes

- **CHANGELOG.md** — `## [Unreleased]` entries for the fixes already merged via #1008/#1009: the source-less notification hold (radio-ID recording ghosts), the cross-slot audio-leak fix, the #402 decode-queue sample-budget sizing, the "iq power very low" gate, and the per-talker recording split.
- **internal/voice/composer/tetra_voice_test.go** — `TestTETRADemuxConcurrentStreamNoLeakToSoleOwner`: streams a realistic interleaved two-call sequence through the demux (one tracked owner, one untracked call on another physical slot) and asserts the untracked call's leakage into the tracked recording stays bounded to the concurrency-ramp window (it fails at ~80 leaked frames without the on-air-concurrency gate, passes at ≤10 with it). Complements the focused single-burst guard already in `main`.

## Test plan

- [x] `make vet test` is green locally (full tree, `-race`)
- [x] The new regression exercises the merged Fix-2 code (`onAirConcurrent` / `concurrencySuppressed`) and passes

## Breaking changes

None (docs + test only).

## Linked issues

`Refs #402`. Continuation of the work merged in #1008 / #1009.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YLckwcqjmULJFooxdFrLTg)_