### PR TITLE
tetra: DMO channel decode (SCH/S, SCH/H, TCH/S, SCH/F) + replay harness

### DIFF
--- a/cmd/gophertrunk/tetra_dmo_replay_test.go
+++ b/cmd/gophertrunk/tetra_dmo_replay_test.go
@@ -104,9 +104,9 @@ func TestTETRADMOReplay(t *testing.T) {
 	bursts := tetra.ExtractDMBursts(allDibits, 0)
 
 	var dsbTotal, dsbCRC, dnbTotal, tchCRC int
-	var syncSecs []int              // seconds carrying a CRC-valid SCH/S (transmission starts)
-	speechBySec := map[int]int{}    // CRC-valid TCH/S bursts per second
-	var speechFrames [][]byte       // ordered speech frames for the vocoder
+	var syncSecs []int           // seconds carrying a CRC-valid SCH/S (transmission starts)
+	speechBySec := map[int]int{} // CRC-valid TCH/S bursts per second
+	var speechFrames [][]byte    // ordered speech frames for the vocoder
 	seenSyncSec := map[int]struct{}{}
 
 	for i := range bursts {

--- a/cmd/gophertrunk/tetra_dmo_replay_test.go
+++ b/cmd/gophertrunk/tetra_dmo_replay_test.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"encoding/binary"
+	"os"
+	"sort"
+	"strconv"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/tetra"
+	tetrarx "github.com/MattCheramie/GopherTrunk/internal/radio/tetra/receiver"
+	"github.com/MattCheramie/GopherTrunk/internal/scanner/ccdecoder"
+	"github.com/MattCheramie/GopherTrunk/internal/voice/acelp"
+)
+
+// TestTETRADMOReplay is the real-air validation gate for TETRA Direct Mode
+// Operation (DMO) voice decode — the acceptance criterion of issue #1003. Skip
+// unless GT_TETRA_DMO_IQ points at a cs16 (interleaved int16) IQ file of a DMO
+// transmission; GT_TETRA_DMO_RATE gives its sample rate (default 150000, the
+// reporter's Tetra_DMO_Two_TX_cs16_30sec_bw150.raw), GT_TETRA_DMO_COLOUR sets the
+// DM colour code the TCH/S traffic is scrambled with (default 0 — the spec
+// default for DSB signalling and the common radio-to-radio value; the SYNC-PDU
+// parser that would learn it live is EN 300 396-3, a follow-up), and
+// GT_TETRA_DMO_OUT optionally names a dir for the decoded WAV.
+//
+// It resamples to the 144 kHz TETRA channel rate, runs the shared π/4-DQPSK
+// receiver, accumulates the whole dibit stream, then:
+//   - ExtractDMBursts (dmo.go) slices every DSB / DNB (EN 300 396-2 Tables 15/16);
+//   - each DSB's SCH/S is channel-decoded with colour 0 (§8.2.5.2) — a CRC-valid
+//     SCH/S is the DMO sync/lock indicator, marking a PTT/transmission start;
+//   - each DNB's TCH/S is descrambled + decoded (dmo_decode.go) into 137-bit
+//     speech frames, gated on the class-2 CRC exactly like the TMO path;
+//   - the speech frames feed the clean-room ACELP vocoder to PCM.
+//
+// The pass signal is CRC-valid speech clustered in time on the transmissions
+// (versus the ~1/256 chance floor a wrong scramble/geometry would give — the
+// symptom the #1003 investigation measured before the spec constants were
+// sourced). It prints a per-transmission timeline and the recovered PCM duration
+// so the maintainer can A/B it and confirm the audio is intelligible.
+func TestTETRADMOReplay(t *testing.T) {
+	path := os.Getenv("GT_TETRA_DMO_IQ")
+	if path == "" {
+		t.Skip("set GT_TETRA_DMO_IQ (cs16 IQ) + GT_TETRA_DMO_RATE to run the DMO replay")
+	}
+	inRate := 150000.0
+	if v := os.Getenv("GT_TETRA_DMO_RATE"); v != "" {
+		f, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			t.Fatalf("bad GT_TETRA_DMO_RATE: %v", err)
+		}
+		inRate = f
+	}
+	var colour uint32
+	if v := os.Getenv("GT_TETRA_DMO_COLOUR"); v != "" {
+		c, err := strconv.ParseUint(v, 0, 32)
+		if err != nil {
+			t.Fatalf("bad GT_TETRA_DMO_COLOUR: %v", err)
+		}
+		colour = uint32(c)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	iq := make([]complex64, len(raw)/4)
+	for i := range iq {
+		re := int16(binary.LittleEndian.Uint16(raw[i*4:]))
+		im := int16(binary.LittleEndian.Uint16(raw[i*4+2:]))
+		iq[i] = complex(float32(re)/32768, float32(im)/32768)
+	}
+
+	ddc := ccdecoder.NewDownconverter(inRate, 144000)
+	outRate := ddc.OutRateHz()
+
+	// Accumulate the full demodulated dibit stream; ExtractDMBursts is stateless
+	// over a complete slice, which keeps the offline framing deterministic.
+	var allDibits []uint8
+	enableEQ := os.Getenv("GT_TETRA_DMO_EQ") == "1" || os.Getenv("GT_TETRA_DMO_EQ") == "true"
+	rx := tetrarx.New(tetrarx.Options{
+		SampleRateHz: outRate,
+		DibitSink: func(d []uint8, _ int) {
+			allDibits = append(allDibits, d...)
+		},
+		ClockMode:           tetrarx.ClockGardner,
+		GardnerGain:         0.005,
+		EnableAFC:           true,
+		EnableChannelFilter: true,
+		EnableEqualizer:     enableEQ,
+	})
+
+	const chunk = 65536
+	var scratch []complex64
+	for i := 0; i < len(iq); i += chunk {
+		e := i + chunk
+		if e > len(iq) {
+			e = len(iq)
+		}
+		scratch = ddc.Process(scratch[:0], iq[i:e])
+		rx.Process(scratch)
+	}
+
+	dibitRate := tetrarx.SymbolRate // 18000 dibits/sec
+	bursts := tetra.ExtractDMBursts(allDibits, 0)
+
+	var dsbTotal, dsbCRC, dnbTotal, tchCRC int
+	var syncSecs []int              // seconds carrying a CRC-valid SCH/S (transmission starts)
+	speechBySec := map[int]int{}    // CRC-valid TCH/S bursts per second
+	var speechFrames [][]byte       // ordered speech frames for the vocoder
+	seenSyncSec := map[int]struct{}{}
+
+	for i := range bursts {
+		b := bursts[i]
+		sec := int(float64(b.Lead) / dibitRate)
+		switch b.Kind {
+		case tetra.DMBurstSync:
+			dsbTotal++
+			if _, ok := tetra.DecodeDMSCHS(b); ok {
+				dsbCRC++
+				if _, dup := seenSyncSec[sec]; !dup {
+					seenSyncSec[sec] = struct{}{}
+					syncSecs = append(syncSecs, sec)
+				}
+			}
+		case tetra.DMBurstNormal:
+			dnbTotal++
+			frames := tetra.DMBurstTCHSpeech(b, colour)
+			if len(frames) == 2 {
+				tchCRC++
+				speechBySec[sec]++
+				speechFrames = append(speechFrames, frames...)
+			}
+		}
+	}
+
+	t.Logf("in=%.0fHz out=%.0fHz samples=%d dur=%.1fs colour=%#x eq=%v",
+		inRate, outRate, len(iq), float64(len(iq))/inRate, colour, enableEQ)
+	t.Logf("bursts: dsb_total=%d dsb_schs_crc=%d dnb_total=%d tch_crc=%d",
+		dsbTotal, dsbCRC, dnbTotal, tchCRC)
+	sort.Ints(syncSecs)
+	t.Logf("sync (SCH/S CRC-valid) at seconds: %v", syncSecs)
+
+	// Seconds with >=2 CRC-valid speech bursts = real activity, not a lone
+	// chance-CRC hit. On the reporter's capture these should cluster on the two
+	// transmissions (~0.9-13s and ~15.2-25.7s).
+	var speechSecs []int
+	for s, n := range speechBySec {
+		if n >= 2 {
+			speechSecs = append(speechSecs, s)
+		}
+	}
+	sort.Ints(speechSecs)
+	t.Logf("speech active seconds (>=2 CRC bursts): %v", speechSecs)
+
+	if len(speechFrames) == 0 {
+		t.Logf("no CRC-valid TCH/S speech recovered — if the capture is a known-good DMO voice call, try GT_TETRA_DMO_COLOUR (the DM colour code) or GT_TETRA_DMO_EQ=1")
+		return
+	}
+
+	voc := acelp.NewVocoder()
+	var pcm []int16
+	for _, sf := range speechFrames {
+		out, _ := voc.Decode(sf)
+		pcm = append(pcm, out...)
+	}
+	var peak int16
+	for _, v := range pcm {
+		if v > peak {
+			peak = v
+		} else if -v > peak {
+			peak = -v
+		}
+	}
+	t.Logf("decoded speech_frames=%d pcm=%.1fs peak=%d", len(speechFrames), float64(len(pcm))/8000, peak)
+
+	if outDir := os.Getenv("GT_TETRA_DMO_OUT"); outDir != "" {
+		writeWav8kLocal(outDir+"/dmo.wav", pcm)
+		t.Logf("wrote %s/dmo.wav", outDir)
+	}
+}

--- a/internal/radio/tetra/dmo_decode.go
+++ b/internal/radio/tetra/dmo_decode.go
@@ -1,0 +1,118 @@
+package tetra
+
+import "github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+
+// DMO (Direct Mode Operation) channel decode — the descramble → channel-decode
+// layer that turns the scrambled type-5 blocks ExtractDMBursts slices out of a
+// DSB/DNB (dmo.go) into decoded content: the DSB's SCH/S synchronisation block,
+// the DSB's SCH/H, and the DNB's TCH/S speech or SCH/F short-data.
+//
+// The headline finding of the #1003 investigation, confirmed against ETSI
+// EN 300 396-2 V1.4.1, is that DMO's channel coding is NOT a new code family —
+// it is the SAME per-channel chains this package already implements for TMO,
+// with two DMO-specific rules the spec pins exactly:
+//
+//   - SCH/S  §8.3.1.1:  60 type-1 → (76,60) block code + 4 tail → RCPC r=2/3 →
+//     (120,11) interleave → scramble. Identical to the TMO BSCH chain, so
+//     DecodeBSCH decodes it. Per §8.2.5.2 the SCH/S (and SCH/H) of a DSB are
+//     scrambled with the colour code set to ZERO — exactly like TMO's BSCH.
+//   - SCH/H  §8.3.1.2:  124 type-1 → (140,124) + 4 tail → RCPC r=2/3 →
+//     (216,101) interleave → scramble. Identical to TMO SCH/HD (DecodeSCHHD).
+//   - SCH/F  §8.3.1.3:  268 type-1 → (284,268) + 4 tail → RCPC r=2/3 →
+//     (432,103) interleave → scramble. Identical to TMO SCH/F (DecodeSCHF).
+//   - TCH/S  §8.3.2.4:  the 432 type-4 speech bits are defined by EN 300 395-2
+//     (the SAME ACELP speech construction GT already decodes for TMO), then
+//     scrambled and split into BKN1(216)+BKN2(216). So DecodeTCHS decodes it
+//     once the two blocks are concatenated and descrambled.
+//
+// The scrambler polynomial (§8.2.5.2) is byte-for-byte the TMO one
+// (framing.ScrambleTetra); only the seed differs — DMO seeds it from the 30-bit
+// DM colour code, versus TMO's MCC/MNC/colour extended code. For the DSB
+// signalling the seed is 0 (the rule above), and for the DNB traffic it is the
+// DM colour code. The DM colour code itself is signalled in the SYNC PDU that
+// rides in SCH/S, whose message layout is EN 300 396-3 (a separate spec); until
+// that PDU parser lands, callers pass the colour code explicitly (0 is both the
+// spec default for the DSB blocks and the common radio-to-radio DMO value).
+//
+// This layer is hard-decision. Soft-decision TCH/S decode (which ~doubled the
+// TMO same-carrier yield, #1001) needs the receiver's per-dibit differentials
+// carried parallel to the sliced blocks (the TrafficExtractor.StashSoft bridge);
+// wiring that for DMO is the natural follow-up once this hard path is validated
+// on air.
+
+// dmDerotatedBits converts a burst's sliced dibit block back to on-air type-5
+// bits, undoing the residual π/4-DQPSK rotation (0..3) the detector reported for
+// the burst. ExtractDMBursts correlates the training sequence under all four
+// rotations and records which one matched in DMBurst.Rotation; de-rotating by
+// (4-Rotation)&3 returns the transmitted dibits before the Gray→bit expansion
+// (the same relationship TestExtractDMBurstsRotation pins).
+func dmDerotatedBits(block []uint8, rot uint8) []byte {
+	return TetraDibitsToBits(rotateDibits(block, (4-rot)&3))
+}
+
+// DecodeDMSCHS decodes the SCH/S carried in a DSB's block 1 (120 type-5 bits) to
+// its 60 type-1 synchronisation bits, returning a CRC-pass flag. Per
+// EN 300 396-2 §8.2.5.2 a DSB's SCH/S is scrambled with colour code 0, so this
+// is the DMO analog of the TMO BSCH decode. The 60 type-1 bits are the SYNC PDU
+// (EN 300 396-3), which carries the DM colour code and the master's slot/frame
+// numbering used to anchor the DNB traffic that follows.
+func DecodeDMSCHS(b DMBurst) (type1 []byte, crcOK bool) {
+	if b.Kind != DMBurstSync || len(b.SCHS) != dmSCHSDibits {
+		return nil, false
+	}
+	return DecodeBSCH(dmDerotatedBits(b.SCHS, b.Rotation))
+}
+
+// DecodeDMSCHH decodes the SCH/H carried in a DSB's block 2 (216 type-5 bits) to
+// its 124 type-1 bits, with a CRC-pass flag. Colour code 0 for a DSB's SCH/H
+// (§8.2.5.2), so it reuses the TMO SCH/HD chain.
+func DecodeDMSCHH(b DMBurst) (type1 []byte, crcOK bool) {
+	if b.Kind != DMBurstSync || len(b.BKN2) != dmBlockDibits {
+		return nil, false
+	}
+	return DecodeSCHHD(dmDerotatedBits(b.BKN2, b.Rotation), 0)
+}
+
+// dmDNBType5 concatenates a DNB's two 108-dibit blocks (BKN1 then BKN2) into the
+// 432 on-air type-5 bits of the full slot, de-rotated but still scrambled.
+// Returns nil if b is not a well-formed DNB.
+func dmDNBType5(b DMBurst) []byte {
+	if b.Kind != DMBurstNormal || len(b.BKN1) != dmBlockDibits || len(b.BKN2) != dmBlockDibits {
+		return nil
+	}
+	bits := make([]byte, 0, 2*dmBlockDibits*2)
+	bits = append(bits, dmDerotatedBits(b.BKN1, b.Rotation)...)
+	bits = append(bits, dmDerotatedBits(b.BKN2, b.Rotation)...)
+	return bits
+}
+
+// DMBurstTCHSpeech decodes a DNB carrying full-slot TCH/S speech into its two
+// 137-bit speech frames (packed MSB-first, 18 bytes each), ready for the ACELP
+// vocoder — or nil when the class-2 CRC fails (a non-speech burst, a signalling
+// slot, or a corrupted slot), exactly like the TMO TCHSpeechFrames gate. colour
+// is the 30-bit DM colour code the traffic is scrambled with (§8.2.5.2); pass 0
+// for the spec default / common radio-to-radio DMO, matching the way the TMO
+// traffic path treats colour 0 as "no descramble".
+func DMBurstTCHSpeech(b DMBurst, colour uint32) [][]byte {
+	type5 := dmDNBType5(b)
+	if type5 == nil {
+		return nil
+	}
+	if colour != 0 {
+		type5 = framing.DescrambleTetra(type5, colour)
+	}
+	return TCHSpeechFrames(framing.PackBitsMSB(type5))
+}
+
+// DecodeDMSCHF decodes a DNB carrying SCH/F short-data signalling (the full-slot
+// 432→268 chain) to its 268 type-1 bits, with a CRC-pass flag. colour is the
+// 30-bit DM colour code (0 for the default). SCH/F rides a DNB (a DM-SDU short
+// data message), distinct from the TCH/S speech a DNB carries during a voice
+// call; a caller distinguishes them by which decode's CRC passes.
+func DecodeDMSCHF(b DMBurst, colour uint32) (type1 []byte, crcOK bool) {
+	type5 := dmDNBType5(b)
+	if type5 == nil {
+		return nil, false
+	}
+	return DecodeSCHF(type5, colour)
+}

--- a/internal/radio/tetra/dmo_decode_test.go
+++ b/internal/radio/tetra/dmo_decode_test.go
@@ -62,7 +62,7 @@ func seqBits(seed, n int) []byte {
 // DecodeDMSCHS recovers it CRC-valid.
 func TestDMSCHSRoundTrip(t *testing.T) {
 	sync := seqBits(1, 60)
-	schs := EncodeBSCH(sync)   // 120 type-5 bits, colour 0
+	schs := EncodeBSCH(sync)                // 120 type-5 bits, colour 0
 	schh := EncodeSCHHD(seqBits(2, 124), 0) // DSB BKN2 (SCH/H), colour 0
 
 	bursts := ExtractDMBursts(buildDSB(schs, schh), 0)

--- a/internal/radio/tetra/dmo_decode_test.go
+++ b/internal/radio/tetra/dmo_decode_test.go
@@ -1,0 +1,173 @@
+package tetra
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
+
+// These tests close the loop dmo.go's slicer left open: they build a spec-shaped
+// DSB / DNB out of REAL encoded channel blocks (EncodeBSCH / EncodeSCHHD /
+// EncodeSCHF / EncodeTCHS — the inverses of the decoders this file exercises),
+// lay them out per EN 300 396-2 Tables 15/16, run the full
+// ExtractDMBursts → descramble → channel-decode path, and assert the original
+// content comes back CRC-valid. A round-trip is not proof of on-air decode (the
+// #764/#771 lesson — the skip-guarded replay harness is that gate), but it does
+// pin that the DMO descramble/slice/decode wiring is the exact inverse of a
+// spec-built burst, and it fails without dmo_decode.go.
+
+// dmoBitsToDibits packs on-air type-5 bits into the dibit block the demodulator
+// emits for them (the inverse the receiver would produce).
+func dmoBitsToDibits(bits []byte) []uint8 { return TetraBitsToDibits(bits) }
+
+// buildDSB lays out a Direct Mode Synchronisation Burst per Table 16:
+// preamble/phase (folded into a leading ramp) + 80-bit freq-corr + 120-bit
+// SCH/S + 38-bit sync training seq + 216-bit SCH/H (BKN2). Blocks are supplied
+// as already-encoded type-5 bit slices.
+func buildDSB(schsType5, schhType5 []byte) []uint8 {
+	freqCorr := ramp(0, 40) // 80 bits → 40 dibits, content irrelevant to the slicer
+	schs := dmoBitsToDibits(schsType5)
+	sts := SyncTrainingDibits()
+	bkn2 := dmoBitsToDibits(schhType5)
+	return concatDibits(ramp(3, 12), freqCorr, schs, sts, bkn2, ramp(3, 12))
+}
+
+// buildDNB lays out a Direct Mode Normal Burst per Table 15: 216-bit BKN1 +
+// 22-bit normal training seq + 216-bit BKN2. block1/block2 are already-encoded
+// type-5 bit slices (108 dibits each).
+func buildDNB(block1, block2 []byte) []uint8 {
+	return concatDibits(ramp(3, 12), dmoBitsToDibits(block1), NormalSyncDibits(), dmoBitsToDibits(block2), ramp(3, 12))
+}
+
+func findBurst(bursts []DMBurst, kind DMBurstKind) *DMBurst {
+	for i := range bursts {
+		if bursts[i].Kind == kind {
+			return &bursts[i]
+		}
+	}
+	return nil
+}
+
+func seqBits(seed, n int) []byte {
+	out := make([]byte, n)
+	for i := range out {
+		out[i] = byte((seed + i*5) % 2)
+	}
+	return out
+}
+
+// TestDMSCHSRoundTrip encodes a 60-bit SYNC block through the BSCH chain (a DSB's
+// SCH/S is scrambled with colour 0, §8.2.5.2), frames it as a DSB, and asserts
+// DecodeDMSCHS recovers it CRC-valid.
+func TestDMSCHSRoundTrip(t *testing.T) {
+	sync := seqBits(1, 60)
+	schs := EncodeBSCH(sync)   // 120 type-5 bits, colour 0
+	schh := EncodeSCHHD(seqBits(2, 124), 0) // DSB BKN2 (SCH/H), colour 0
+
+	bursts := ExtractDMBursts(buildDSB(schs, schh), 0)
+	dsb := findBurst(bursts, DMBurstSync)
+	if dsb == nil {
+		t.Fatalf("no DSB detected (bursts=%d)", len(bursts))
+	}
+	got, ok := DecodeDMSCHS(*dsb)
+	if !ok {
+		t.Fatalf("DecodeDMSCHS CRC failed")
+	}
+	if !reflect.DeepEqual(got, sync) {
+		t.Errorf("SCH/S mismatch:\n got %v\nwant %v", got, sync)
+	}
+
+	gotH, okH := DecodeDMSCHH(*dsb)
+	if !okH {
+		t.Fatalf("DecodeDMSCHH CRC failed")
+	}
+	if !reflect.DeepEqual(gotH, seqBits(2, 124)) {
+		t.Errorf("SCH/H mismatch")
+	}
+}
+
+// TestDMTCHSpeechRoundTrip is the voice path: two 137-bit speech frames → the
+// EN 300 395-2 TCH/S coding (EncodeTCHS) → scramble with the DM colour code →
+// split into a DNB's two blocks → ExtractDMBursts → DMBurstTCHSpeech recovers
+// the exact speech frames, CRC-valid. Runs at colour 0 (the default) and a
+// non-zero DM colour code to exercise the descramble seed.
+func TestDMTCHSpeechRoundTrip(t *testing.T) {
+	for _, colour := range []uint32{0, 0x0AB1F} {
+		frameA := seqBits(7, tchSpeechFrameBits)
+		frameB := seqBits(9, tchSpeechFrameBits)
+
+		descrambled := framing.UnpackBitsMSB(EncodeTCHS(frameA, frameB), tchType3Bits) // 432 type-4 bits
+		onair := descrambled
+		if colour != 0 {
+			onair = framing.ScrambleTetra(descrambled, colour)
+		}
+		block1 := onair[:dmBlockDibits*2] // first 216 bits → BKN1
+		block2 := onair[dmBlockDibits*2:] // last 216 bits → BKN2
+
+		bursts := ExtractDMBursts(buildDNB(block1, block2), 0)
+		dnb := findBurst(bursts, DMBurstNormal)
+		if dnb == nil {
+			t.Fatalf("colour %#x: no DNB detected (bursts=%d)", colour, len(bursts))
+		}
+		frames := DMBurstTCHSpeech(*dnb, colour)
+		if len(frames) != 2 {
+			t.Fatalf("colour %#x: DMBurstTCHSpeech returned %d frames, want 2 (CRC failed?)", colour, len(frames))
+		}
+		if !reflect.DeepEqual(frames[0], framing.PackBitsMSB(frameA)) {
+			t.Errorf("colour %#x: speech frame A mismatch", colour)
+		}
+		if !reflect.DeepEqual(frames[1], framing.PackBitsMSB(frameB)) {
+			t.Errorf("colour %#x: speech frame B mismatch", colour)
+		}
+	}
+}
+
+// TestDMTCHSpeechRotation proves the reported burst rotation de-rotates the
+// speech blocks back to the transmitted values through the full decode: the same
+// four-rotation robustness the DSB slicer test covers, but carried all the way
+// to CRC-valid speech.
+func TestDMTCHSpeechRotation(t *testing.T) {
+	frameA := seqBits(3, tchSpeechFrameBits)
+	frameB := seqBits(11, tchSpeechFrameBits)
+	onair := framing.UnpackBitsMSB(EncodeTCHS(frameA, frameB), tchType3Bits)
+	base := buildDNB(onair[:dmBlockDibits*2], onair[dmBlockDibits*2:])
+
+	for rot := uint8(1); rot < 4; rot++ {
+		bursts := ExtractDMBursts(rotateDibits(base, rot), 0)
+		dnb := findBurst(bursts, DMBurstNormal)
+		if dnb == nil {
+			t.Fatalf("rot %d: no DNB detected", rot)
+		}
+		if dnb.Rotation != rot {
+			t.Errorf("rot %d: reported rotation %d", rot, dnb.Rotation)
+		}
+		frames := DMBurstTCHSpeech(*dnb, 0)
+		if len(frames) != 2 {
+			t.Fatalf("rot %d: speech CRC failed (frames=%d)", rot, len(frames))
+		}
+		if !reflect.DeepEqual(frames[0], framing.PackBitsMSB(frameA)) {
+			t.Errorf("rot %d: frame A mismatch after de-rotation", rot)
+		}
+	}
+}
+
+// TestDMSCHFRoundTrip covers a DNB carrying SCH/F short-data (as opposed to
+// speech): the 268→432 chain, recovered CRC-valid.
+func TestDMSCHFRoundTrip(t *testing.T) {
+	const colour = uint32(0x1234)
+	msg := seqBits(5, 268)
+	onair := EncodeSCHF(msg, colour) // 432 type-5 bits (bit-per-byte)
+	bursts := ExtractDMBursts(buildDNB(onair[:dmBlockDibits*2], onair[dmBlockDibits*2:]), 0)
+	dnb := findBurst(bursts, DMBurstNormal)
+	if dnb == nil {
+		t.Fatalf("no DNB detected")
+	}
+	got, ok := DecodeDMSCHF(*dnb, colour)
+	if !ok {
+		t.Fatalf("DecodeDMSCHF CRC failed")
+	}
+	if !reflect.DeepEqual(got, msg) {
+		t.Errorf("SCH/F message mismatch")
+	}
+}


### PR DESCRIPTION
Adds the descramble -> channel-decode layer that turns the scrambled type-5
blocks ExtractDMBursts already slices out of a DSB/DNB (dmo.go) into decoded
content, completing the TETRA Direct Mode Operation voice path (Refs #1003).

The ETSI EN 300 396-2 V1.4.1 constants confirm DMO's channel coding is not a
new code family: it reuses the same per-channel chains this package implements
for TMO, with two DMO-specific rules the spec pins exactly:

- SCH/S  (DSB block 1, 120->60):  identical to the BSCH chain; a DSB's SCH/S
  and SCH/H are scrambled with colour code 0 (EN 300 396-2 section 8.2.5.2).
- SCH/H  (DSB block 2, 216->124): identical to TMO SCH/HD.
- SCH/F  (DNB, 432->268):         identical to TMO SCH/F.
- TCH/S  (DNB, 432 speech bits):  the EN 300 395-2 ACELP construction GT
  already decodes for TMO, scrambled with the 30-bit DM colour code and split
  into BKN1(216)+BKN2(216).

The scrambler polynomial is byte-for-byte the TMO one; only the seed differs
(DM colour code vs the MCC/MNC/colour extended code), and it is 0 for the DSB
signalling. The DM colour code for DNB traffic is signalled in the SYNC PDU
(EN 300 396-3, a follow-up); until that parser lands callers pass it explicitly
(0 default).

New:
- dmo_decode.go: DecodeDMSCHS / DecodeDMSCHH / DMBurstTCHSpeech / DecodeDMSCHF,
  reusing DecodeBSCH / DecodeSCHHD / DecodeSCHF / TCHSpeechFrames.
- dmo_decode_test.go: failing-first synthetic round-trips (encode a spec-shaped
  DSB/DNB -> extract -> decode -> exact recovery, incl. a rotation case and a
  non-zero DM colour code).
- cmd/gophertrunk/tetra_dmo_replay_test.go: skip-guarded on-air validation gate
  (GT_TETRA_DMO_IQ) mirroring the TMO multislot harness: DDC -> receiver ->
  ExtractDMBursts -> SCH/S sync + TCH/S speech -> ACELP -> PCM/WAV, with a
  per-transmission timeline for the reporter's two-transmission capture.

Hard-decision for now; soft-decision TCH/S (the ~2x TMO yield lever) is the
next step once this is validated on air. make vet test green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Cf1MgfpbMHTzFp5Sa9z7Yo