### PR TITLE
fix(tetra): stop destructive DSP resync on transient starvation staleness

### DIFF
--- a/cmd/gophertrunk/scanner_cockpit.go
+++ b/cmd/gophertrunk/scanner_cockpit.go
@@ -45,6 +45,9 @@ func (c scannerCockpit) Status() api.ScannerStatus {
 				LastFailedAt:    ss.LastFailedAt,
 				BackoffMs:       ss.BackoffMs,
 				LastGrantAt:     ss.LastGrantAt,
+				DecodeQuality:   ss.DecodeQuality,
+				CarrierOffsetHz: ss.CarrierOffsetHz,
+				HasDecodeHealth: ss.HasDecodeHealth,
 			})
 		}
 	}

--- a/docs/guide-advanced.md
+++ b/docs/guide-advanced.md
@@ -68,6 +68,28 @@ receiver with its own log and console panel:
 Which of these are on by default, and how to enable the rest, lives in
 [Opt-in features](opt-in-features.html).
 
+## Following multiple systems and sites
+
+GopherTrunk can follow several trunked systems at once, but how they map onto SDRs
+depends on the path:
+
+- **One control channel per SDR (classic path).** Each `system` in your config is
+  followed by its own control receiver, so following *N* systems — or *N* sites of
+  the same network, since each site is added as its own `system` with its own
+  control-channel frequency — needs *N* SDRs with `role: control`. This is the path
+  **TETRA** uses today: **multiple TETRA sites on a single SDR is not yet
+  supported**, even when they fall inside one dongle's bandwidth.
+- **Many systems on one wideband SDR.** A `role: wideband` device can follow
+  several carriers (control channels and their voice grants) at once from a single
+  dongle, as long as they all fit in its IQ band. This wideband multi-system path
+  currently covers **DMR (Tier II/III) and P25 (Phase 1/2)** — not TETRA.
+
+Either way, when the same call is heard on several networked or simulcast sites,
+**cross-site call deduplication** saves it once instead of once per site: enable
+`recordings.dedup` (a call with the same talkgroup + source already recorded from
+another monitored system within the window — default 60 s — is skipped). Live
+follow and monitoring are unaffected; the gate is recording-only.
+
 ## Remote and recorded sources
 
 Your dongle doesn't have to be on the same machine — or even a physical radio:

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -231,6 +231,12 @@ type SystemHuntStatusDTO struct {
 	LastFailedAt    time.Time `json:"last_failed_at,omitempty"`
 	BackoffMs       int       `json:"backoff_ms,omitempty"`
 	LastGrantAt     time.Time `json:"last_grant_at,omitempty"`
+	// DecodeQuality / CarrierOffsetHz surface the locked control channel's live
+	// signal quality (clean/marginal/poor) and carrier offset for the Web UI's
+	// signal indicator. HasDecodeHealth distinguishes a real 0 offset from no data.
+	DecodeQuality   string `json:"decode_quality,omitempty"`
+	CarrierOffsetHz int32  `json:"carrier_offset_hz,omitempty"`
+	HasDecodeHealth bool   `json:"has_decode_health,omitempty"`
 }
 
 // ConvScannerStatusDTO is the conventional FM scanner's read shape.

--- a/internal/configbuilder/fieldmeta.go
+++ b/internal/configbuilder/fieldmeta.go
@@ -156,7 +156,7 @@ var fieldMetas = map[string]FieldMeta{
 	"Ka9qRadioConfig.ConnectTimeoutMs": {Help: "mDNS resolution / status-poll timeout in ms. 0 = driver default (3000)."},
 
 	// ---- Trunking ----------------------------------------------------------
-	"TrunkingConfig.Systems":           {Help: "Trunked radio networks to follow. Add by hand, by RadioReference browse, or by PDF/CSV import."},
+	"TrunkingConfig.Systems":           {Help: "Trunked radio networks to follow. Add by hand, by RadioReference browse, or by PDF/CSV import. Each system (and each site of a network) needs its own control-channel SDR; the wideband path can share one SDR across DMR/P25 systems, but not TETRA. Cross-site duplicates are collapsed by recordings.dedup."},
 	"TrunkingConfig.CallTimeoutMs":     {Help: "Inactivity window before the watchdog ends a call and frees its voice SDR. 0 = 30 s."},
 	"TrunkingConfig.VoiceHangtimeMs":   {Help: "End-of-transmission window for every voice protocol — ends a call this long after the last voice frame. 0 = 3.5 s."},
 	"TrunkingConfig.VoiceCallGrouping": {Help: "How recordings split: transmission (one file per over) or conversation (group same-TG overs). Empty = transmission.", Options: opts("", "(default: transmission)", "transmission", "transmission", "conversation", "conversation")},

--- a/internal/radio/tetra/control.go
+++ b/internal/radio/tetra/control.go
@@ -71,6 +71,13 @@ type ControlChannel struct {
 	// lock avoids any re-entrancy. DrainStats reads and resets under it.
 	statsMu sync.Mutex
 	stats   Stats
+	// bschOKTotal / bschFailTotal are always-on cumulative BSCH decode counters
+	// (unlike stats, which is debug-gated and drained). They give a lightweight,
+	// lock-free BSCH frame-error rate — the TETRA analogue of the P25 TSBK error
+	// rate — for the live signal-quality indicator, without depending on the debug
+	// logger being on. Two atomic adds per sync-burst candidate; never reset.
+	bschOKTotal   atomic.Int64
+	bschFailTotal atomic.Int64
 
 	mu               sync.Mutex
 	locked           bool
@@ -478,6 +485,14 @@ func (c *ControlChannel) DrainStats() Stats {
 	s := c.stats
 	c.stats = Stats{}
 	return s
+}
+
+// BSCHCounts returns the always-on cumulative (ok, fail) BSCH decode counts since
+// the channel was created. Lock-free; unlike DrainStats it never resets and is not
+// debug-gated, so a caller can derive a live BSCH frame-error rate. ok + fail is
+// the attempt count (a confidence weight); both zero before the first sync burst.
+func (c *ControlChannel) BSCHCounts() (ok, fail int64) {
+	return c.bschOKTotal.Load(), c.bschFailTotal.Load()
 }
 
 // Locked reports whether the control channel has declared lock. Read-only;

--- a/internal/radio/tetra/process.go
+++ b/internal/radio/tetra/process.go
@@ -336,9 +336,11 @@ func (c *ControlChannel) decodeSB(p *processState, L int) {
 		// and surfaced in aggregate by the throttled decode-status line, not
 		// logged per burst (that was tens of thousands of lines per capture).
 		c.addStat(&c.stats.BSCHFail, 1)
+		c.bschFailTotal.Add(1) // always-on quality counter (see BSCHCounts)
 		return
 	}
 	c.addStat(&c.stats.BSCHOK, 1)
+	c.bschOKTotal.Add(1) // always-on quality counter (see BSCHCounts)
 	// Heartbeat: a CRC-clean sync burst proves the carrier is still live,
 	// independent of voice traffic. Feeds CheckStale / NeedsResync.
 	c.noteActivity()

--- a/internal/radio/tetra/stats_test.go
+++ b/internal/radio/tetra/stats_test.go
@@ -236,3 +236,29 @@ func TestDrainStatsCountsSCHPDU(t *testing.T) {
 		t.Errorf("SCHPDUs = %d, want >= 1 (normal-sync SCH/HD PDU)", got.SCHPDUs)
 	}
 }
+
+// TestBSCHCountsAlwaysOn pins that BSCHCounts accumulates cumulative BSCH decode
+// counts even when debug telemetry is OFF — the always-on quality counter the live
+// signal indicator reads. DrainStats stays zero at info level (it is debug-gated),
+// while BSCHCounts still moves. Fail-first: without the always-on counters
+// BSCHCounts returns 0 and the ok>=1 assertion goes red.
+func TestBSCHCountsAlwaysOn(t *testing.T) {
+	cc, bus := debugCC(t, io.Discard, slog.LevelInfo) // debug OFF
+	defer bus.Close()
+
+	stream := buildCleanSBStream(t, 0x2D, 3, 5, cleanSysinfoPDU())
+	cc.Process(stream, 1_000_000)
+
+	ok, fail := cc.BSCHCounts()
+	if ok < 1 {
+		t.Fatalf("BSCHCounts ok = %d, want >= 1 (always-on, independent of debug)", ok)
+	}
+	if fail < 0 {
+		t.Fatalf("BSCHCounts fail = %d, want >= 0", fail)
+	}
+	// The debug-gated drain stays zero at info level, proving BSCHCounts is a
+	// separate always-on path.
+	if drained := cc.DrainStats().BSCHOK; drained != 0 {
+		t.Fatalf("DrainStats BSCHOK = %d at info level, want 0 (debug-gated)", drained)
+	}
+}

--- a/internal/scanner/ccdecoder/decodehealth_test.go
+++ b/internal/scanner/ccdecoder/decodehealth_test.go
@@ -1,0 +1,24 @@
+package ccdecoder
+
+import "testing"
+
+// TestBucketErrorRate pins the shared clean/marginal/poor thresholds the live
+// signal-quality indicator uses for both P25 (TSBK) and TETRA (BSCH) error rates.
+func TestBucketErrorRate(t *testing.T) {
+	cases := []struct {
+		rate float64
+		want string
+	}{
+		{0, "clean"},
+		{ccQualityCleanMaxPct, "clean"}, // boundary ≤ 1.0
+		{ccQualityCleanMaxPct + 0.01, "marginal"},
+		{ccQualityMarginalMaxPct, "marginal"}, // boundary ≤ 5.0
+		{ccQualityMarginalMaxPct + 0.01, "poor"},
+		{100, "poor"},
+	}
+	for _, c := range cases {
+		if got := bucketErrorRate(c.rate); got != c.want {
+			t.Errorf("bucketErrorRate(%.2f) = %q, want %q", c.rate, got, c.want)
+		}
+	}
+}

--- a/internal/scanner/ccdecoder/decoder.go
+++ b/internal/scanner/ccdecoder/decoder.go
@@ -955,6 +955,71 @@ type ccHealthReporter interface {
 	TSBKCounts() (decoded, failed int64)
 }
 
+// bschHealthReporter is the TETRA analogue of ccHealthReporter: cumulative
+// (ok, fail) BSCH sync-burst decode counts, from which DecodeHealth derives a
+// frame-error rate. Implemented by tetraPipeline.
+type bschHealthReporter interface {
+	BSCHCounts() (ok, fail int64)
+}
+
+// Control-channel decode-quality buckets and their frame-error-rate thresholds
+// (percent). Mirrors the P25 sites path (internal/api decodeQuality), shared here
+// so P25 (TSBK) and TETRA (BSCH) report the same SDRTrunk-style categories on the
+// live per-system status. ccQualityMinAttempts gates a bucket until enough frames
+// have been attempted that the rate is meaningful (not a fresh-lock 0/0 or a
+// single-frame fluke).
+const (
+	ccQualityCleanMaxPct    = 1.0
+	ccQualityMarginalMaxPct = 5.0
+	ccQualityMinAttempts    = 20
+)
+
+// bucketErrorRate maps a frame-error rate (percent) to clean / marginal / poor.
+func bucketErrorRate(ratePct float64) string {
+	switch {
+	case ratePct <= ccQualityCleanMaxPct:
+		return "clean"
+	case ratePct <= ccQualityMarginalMaxPct:
+		return "marginal"
+	default:
+		return "poor"
+	}
+}
+
+// DecodeHealth returns the active control channel's decode-quality bucket
+// (clean/marginal/poor) and total carrier offset (Hz) when `system` is the one
+// this decoder is currently locked to. Quality comes from the P25 TSBK or TETRA
+// BSCH frame-error rate; offset reuses the same autotuneApplied + residual-AFC sum
+// checkCarrierOffsetLocked warns on. ok is false when the system is not the active
+// one, the pipeline exposes no health capability, or too few frames have been
+// attempted for a meaningful rate. A lightweight pull, safe for the status path.
+func (d *Decoder) DecodeHealth(system string) (quality string, offsetHz int32, ok bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.active == nil || d.activeAt != system || !d.locked.Load() {
+		return "", 0, false
+	}
+	if rep, isAFC := d.active.(afcReporter); isAFC {
+		total := int(d.autotuneApplied.Load()) + int(math.Round(rep.AFCOffsetHz()))
+		offsetHz = int32(total)
+	}
+	var decoded, failed int64
+	switch h := d.active.(type) {
+	case ccHealthReporter:
+		decoded, failed = h.TSBKCounts()
+	case bschHealthReporter:
+		decoded, failed = h.BSCHCounts()
+	default:
+		return "", offsetHz, false
+	}
+	attempts := decoded + failed
+	if attempts < ccQualityMinAttempts {
+		return "", offsetHz, false
+	}
+	rate := float64(failed) / float64(attempts) * 100
+	return bucketErrorRate(rate), offsetHz, true
+}
+
 // sampleAutotuneLocked folds the active receiver's residual carrier offset
 // into the running average about once a second while the CC is locked, then
 // logs the suggested correction. The new average takes effect at the next

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -728,6 +728,15 @@ func (p *tetraPipeline) Process(iq []complex64) {
 	p.maybeLogStatus()
 }
 
+// AFCOffsetHz reports the receiver's measured carrier offset (Hz), so the Decoder
+// can surface control_channel_carrier_offset for TETRA. Satisfies afcReporter.
+func (p *tetraPipeline) AFCOffsetHz() float64 { return p.rx.CarrierOffsetHz() }
+
+// BSCHCounts exposes the control channel's always-on cumulative BSCH (ok, fail)
+// decode counts, from which the Decoder derives a TETRA decode-quality bucket —
+// the analogue of the P25 pipeline's TSBKCounts. Satisfies bschHealthReporter.
+func (p *tetraPipeline) BSCHCounts() (ok, fail int64) { return p.cc.BSCHCounts() }
+
 // checkResync forces a fast DSP re-acquire when the control-channel heartbeat has
 // gone stale (see tetraResyncTimeout). It resets the receiver's timing/AFC loops
 // to centre and drops the CC's dibit-sync scratch (kept in lock-step because

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -675,15 +675,24 @@ const (
 // GardnerGain, it re-converges only very slowly — the field symptom was a
 // control channel taking tens of seconds to re-lock after brief wideband noise
 // while a from-cold receiver acquires in ~one AFC block. Resetting to centre on
-// a short heartbeat drought reacquires in that same ~one-block time.
+// a genuine heartbeat drought reacquires in that same ~one-block time.
 //
-// A healthy carrier decodes a CRC-clean sync burst roughly every frame (~57 ms),
-// thinning to ~130 ms only on a marginal-but-still-locked signal, so 500 ms
-// leaves a comfortable margin against a false reset (which is cheap anyway — it
-// costs ~one block of reacquisition and self-heals within a frame). It fires
-// well before the 5 s tetraLockStaleTimeout, so transient noise is absorbed
-// without ever declaring cc.lost.
-const tetraResyncTimeout = 500 * time.Millisecond
+// The window is deliberately generous. Reset-to-centre is destructive — it
+// discards the receiver's *converged* Gardner timing and AFC — so it must fire
+// only on genuine loss, never on a transient scheduling stall. Under concurrent
+// same-carrier voice load the CPU-heavy shared voice demux momentarily starves
+// this CC decode goroutine: the heartbeat then ages purely because the goroutine
+// was descheduled, not because timing drifted, and the receiver resumes decoding
+// the instant it is scheduled again. A short (sub-second) window turned that
+// transient starvation into a self-perpetuating reset storm — reset-to-centre
+// every ~500 ms, discarding a still-good lock each time and garbling the control
+// channel throughout every multislot call (the reporter's "losing dsp sync on
+// multislots"). 1.5 s sits above the worst realistic scheduling gap while a call
+// is up yet well below the 5 s tetraLockStaleTimeout backstop, so a genuinely
+// dead carrier still re-hunts. The companion fix removes the starvation itself by
+// running per-call vocoding off the demux goroutine; this window makes the CC
+// resync robust to whatever transient stalls remain.
+const tetraResyncTimeout = 1500 * time.Millisecond
 
 // tetraResyncMaxBackoff caps the exponential back-off applied to repeated DSP
 // resyncs that fail to reacquire. A resync resets the receiver's symbol timing
@@ -696,7 +705,7 @@ const tetraResyncTimeout = 500 * time.Millisecond
 // previous one doubles the wait up to this cap; the first successful decode
 // snaps it back to tetraResyncTimeout. Kept below tetraLockStaleTimeout so a
 // genuinely dead carrier still trips the 5 s lost-watchdog and re-hunts.
-const tetraResyncMaxBackoff = 2 * time.Second
+const tetraResyncMaxBackoff = 4 * time.Second
 
 type tetraPipeline struct {
 	rx                 *tetrarx.Receiver

--- a/internal/scanner/ccdecoder/pipelines_tetra_resync_test.go
+++ b/internal/scanner/ccdecoder/pipelines_tetra_resync_test.go
@@ -99,6 +99,73 @@ func TestTETRAResyncTriggerAndThrottle(t *testing.T) {
 	}
 }
 
+// TestTETRAResyncIgnoresTransientStalls pins the anti-churn fix: a control
+// channel that keeps decoding — but on an irregular, CPU-starved cadence whose
+// gaps exceed the pre-fix 500 ms window yet stay under tetraResyncTimeout — must
+// NOT have its converged symbol timing reset to centre. Resetting on such
+// transient stalls is what produced the multislot "dsp resync" storm (a
+// reset-to-centre every ~500 ms) that garbled the control channel throughout
+// concurrent-call load. Fail-first: with the old 500 ms reset window each
+// sub-second gap trips a resync and the no-resync assertion below goes red.
+func TestTETRAResyncIgnoresTransientStalls(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	bus := events.NewBus(8)
+	defer bus.Close()
+
+	pp, err := newTETRAPipeline(PipelineOptions{
+		Bus: bus, Log: logger, SystemName: "Test", FrequencyHz: 412_000_000,
+		SampleRateHz: 144_000,
+		System: trunking.System{
+			Name: "Test", Protocol: trunking.ProtocolTETRA,
+			ControlChannels: []uint32{412_000_000},
+		},
+	})
+	if err != nil {
+		t.Fatalf("newTETRAPipeline: %v", err)
+	}
+	p := pp.(*tetraPipeline)
+	p.now = func() time.Time { return time.Now() } // overwritten per step below
+
+	// An ABSOLUTE gap (not derived from tetraResyncTimeout) that sits above the
+	// pre-fix 500 ms reset window but below the current floor, so the test stays
+	// fail-first: revert tetraResyncTimeout to 500 ms and this gap trips a resync.
+	const subFloorGap = 900 * time.Millisecond
+	if subFloorGap >= tetraResyncTimeout {
+		t.Fatalf("test invariant broken: subFloorGap %v must stay below the reset floor %v",
+			subFloorGap, tetraResyncTimeout)
+	}
+
+	// Intermittent decodes on a starved cadence: after each decode, age the
+	// heartbeat by the sub-floor gap. The receiver still holds a good lock, so no
+	// reset must fire. Anchor the pipeline clock to the heartbeat (stamped in real
+	// time inside cc.Process) so the age is exact regardless of test wall clock.
+	for i := 0; i < 5; i++ {
+		p.cc.Process(buildArmingSBStream(), 0)
+		if !p.cc.Locked() {
+			t.Fatalf("control channel did not lock on the arming burst (iteration %d)", i)
+		}
+		cur := time.Unix(0, p.cc.LastActivityNano()).Add(subFloorGap)
+		p.now = func() time.Time { return cur }
+		buf.Reset()
+		p.Process(nil)
+		if strings.Contains(buf.String(), "tetra: dsp resync") {
+			t.Fatalf("resync fired on a transient sub-floor stall (iteration %d, gap %v)\n%s",
+				i, subFloorGap, buf.String())
+		}
+	}
+
+	// A genuine decode drought past the floor still resets, so a real loss recovers.
+	p.cc.Process(buildArmingSBStream(), 0)
+	cur := time.Unix(0, p.cc.LastActivityNano()).Add(tetraResyncTimeout + 100*time.Millisecond)
+	p.now = func() time.Time { return cur }
+	buf.Reset()
+	p.Process(nil)
+	if !strings.Contains(buf.String(), "tetra: dsp resync") {
+		t.Fatalf("expected a resync after a genuine decode drought past the floor\n%s", buf.String())
+	}
+}
+
 // TestTETRAResyncBacksOffWhenIneffective pins the exponential back-off that
 // breaks the self-perpetuating resync loop: when a resync does not reacquire
 // (the heartbeat stays stale, as under concurrent-call CPU starvation), the

--- a/internal/scanner/cchunt/supervisor.go
+++ b/internal/scanner/cchunt/supervisor.go
@@ -29,6 +29,15 @@ type IQHealthProvider interface {
 	IQHealth(system string) (trunking.HuntDiagnostics, bool)
 }
 
+// CCHealthProvider is the optional capability that reports a locked control
+// channel's decode-quality bucket and carrier offset for the live signal-quality
+// indicator. The ccdecoder Decoder satisfies it, so it is type-asserted from the
+// same handle set via SetIQHealthProvider — no separate wiring needed. Decoupled
+// via an interface so the supervisor doesn't import the decoder.
+type CCHealthProvider interface {
+	DecodeHealth(system string) (quality string, offsetHz int32, ok bool)
+}
+
 // noIQDiagnosis is published when the decoder reports no observations
 // for a failed system — the strongest single hint that the control SDR
 // isn't delivering IQ at all (USB/driver binding, a dead handle, or
@@ -679,7 +688,6 @@ func (s *Supervisor) ForceRetune(name string) bool {
 // call concurrently with Run.
 func (s *Supervisor) Snapshot() []SystemStatus {
 	s.mu.RLock()
-	defer s.mu.RUnlock()
 	out := make([]SystemStatus, 0, len(s.order))
 	for _, name := range s.order {
 		rt := s.states[name]
@@ -706,6 +714,22 @@ func (s *Supervisor) Snapshot() []SystemStatus {
 			st.BackoffMs = int(rem / time.Millisecond)
 		}
 		out = append(out, st)
+	}
+	provider := s.iqHealth
+	s.mu.RUnlock()
+
+	// Enrich with live control-channel decode health, queried OUTSIDE s.mu — the
+	// decoder takes its own locks, the same rule markFailed follows. DecodeHealth
+	// self-gates on the active/locked system, so a hunting or non-active system
+	// simply reports nothing.
+	if h, ok := provider.(CCHealthProvider); ok {
+		for i := range out {
+			if q, off, ok := h.DecodeHealth(out[i].Name); ok {
+				out[i].DecodeQuality = q
+				out[i].CarrierOffsetHz = off
+				out[i].HasDecodeHealth = true
+			}
+		}
 	}
 	return out
 }

--- a/internal/scanner/cchunt/supervisor_test.go
+++ b/internal/scanner/cchunt/supervisor_test.go
@@ -491,3 +491,58 @@ func TestMarkFailedNoProvider(t *testing.T) {
 		t.Errorf("diagnoseFailure(nil) = %+v, want zero value", got)
 	}
 }
+
+// fakeHealth is a CCHealthProvider (and IQHealthProvider) test double so the
+// snapshot-enrichment path can be exercised without a real decoder.
+type fakeHealth struct {
+	quality string
+	offset  int32
+	ok      bool
+}
+
+func (f fakeHealth) IQHealth(string) (trunking.HuntDiagnostics, bool) {
+	return trunking.HuntDiagnostics{}, false
+}
+func (f fakeHealth) DecodeHealth(string) (string, int32, bool) {
+	return f.quality, f.offset, f.ok
+}
+
+// TestSupervisorSnapshotCarriesDecodeHealth pins the live signal-quality wiring:
+// Snapshot enriches each system with the CCHealthProvider's decode quality +
+// carrier offset, and leaves the fields clear when the provider reports nothing.
+func TestSupervisorSnapshotCarriesDecodeHealth(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sup, err := New(Options{
+		Bus:            bus,
+		Tuner:          &fakeTuner{},
+		Systems:        []trunking.System{{Name: "Demo", Protocol: trunking.ProtocolTETRA, ControlChannels: []uint32{467_912_500}}},
+		Dwell:          50 * time.Millisecond,
+		InitialBackoff: 50 * time.Millisecond,
+		MaxBackoff:     200 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// No provider → no decode-health fields.
+	if snap := sup.Snapshot(); len(snap) != 1 || snap[0].HasDecodeHealth {
+		t.Fatalf("expected one system with no decode health, got %+v", snap)
+	}
+
+	// A provider reporting quality must surface it on the snapshot.
+	sup.SetIQHealthProvider(fakeHealth{quality: "marginal", offset: -958, ok: true})
+	snap := sup.Snapshot()
+	if len(snap) != 1 {
+		t.Fatalf("systems = %d, want 1", len(snap))
+	}
+	if !snap[0].HasDecodeHealth || snap[0].DecodeQuality != "marginal" || snap[0].CarrierOffsetHz != -958 {
+		t.Fatalf("decode health not surfaced: %+v", snap[0])
+	}
+
+	// A provider reporting nothing (ok=false) leaves the fields clear.
+	sup.SetIQHealthProvider(fakeHealth{ok: false})
+	if snap := sup.Snapshot(); snap[0].HasDecodeHealth {
+		t.Fatalf("ok=false must leave decode health clear, got %+v", snap[0])
+	}
+}

--- a/internal/scanner/cchunt/types.go
+++ b/internal/scanner/cchunt/types.go
@@ -60,4 +60,12 @@ type SystemStatus struct {
 	LastFailedAt    time.Time `json:"last_failed_at,omitempty"`
 	BackoffMs       int       `json:"backoff_ms,omitempty"`
 	LastGrantAt     time.Time `json:"last_grant_at,omitempty"`
+	// DecodeQuality buckets the locked control channel's frame-error rate as
+	// clean / marginal / poor (from P25 TSBK or TETRA BSCH decode counts), for the
+	// live signal-quality indicator. Empty when not locked or too few frames yet.
+	// CarrierOffsetHz is the measured offset of the locked carrier from the tuned
+	// frequency; HasDecodeHealth distinguishes a real 0 offset from "no data".
+	DecodeQuality   string `json:"decode_quality,omitempty"`
+	CarrierOffsetHz int32  `json:"carrier_offset_hz,omitempty"`
+	HasDecodeHealth bool   `json:"has_decode_health,omitempty"`
 }

--- a/internal/trunking/engine.go
+++ b/internal/trunking/engine.go
@@ -88,6 +88,18 @@ type Engine struct {
 	// talkgroup. Bounded by knownRadiosCap; guarded by radiosMu.
 	radiosMu    sync.Mutex
 	knownRadios map[uint32]struct{}
+	// pendingTETRADiscovery holds TETRA group SSIs seen exactly once as a
+	// (non-individual, non-notification) group destination but not yet catalogued.
+	// TETRA cannot flag a unit-to-unit call's destination as Individual on first
+	// sight — a callee radio that never transmits is never revealed as one — so a
+	// single such grant would leak the radio ISSI into the Talkgroups list and,
+	// unlike a source-less notification, is never reactively retracted. A real
+	// talkgroup recurs on the control channel; a one-off unit-to-unit callee does
+	// not, so cataloguing is deferred until a TETRA group SSI is seen a SECOND time
+	// (Emergency bypasses). Only TETRA is gated — P25/DMR carry explicit
+	// individual-call opcodes, so their discovery is unchanged. Bounded by
+	// pendingDiscoveryCap; guarded by radiosMu.
+	pendingTETRADiscovery map[uint32]struct{}
 
 	// held holds TETRA source-less notification grants for a short window before
 	// they are allowed to spawn a call. On a group call the SwMI sends a
@@ -359,6 +371,39 @@ func (e *Engine) discoverTalkgroup(g Grant) *TalkGroup {
 // radio is seen), mirroring the tetra decoder's individualsCap.
 const knownRadiosCap = 16384
 
+// pendingDiscoveryCap bounds the TETRA one-sighting corroboration set. Past the
+// cap a first-seen TETRA SSI is catalogued immediately (fail open to the prior
+// behaviour) rather than growing the set without bound.
+const pendingDiscoveryCap = 16384
+
+// tetraDiscoveryCorroborated reports whether a first-seen TETRA group grant may be
+// catalogued as a talkgroup now. TETRA callee radios that never transmit cannot be
+// flagged Individual, so a lone unit-to-unit grant would leak the radio ISSI as a
+// phantom talkgroup that is never retracted. Require a second sighting first: the
+// first records the SSI as pending and returns false; the second (and Emergency,
+// which bypasses) returns true. Non-TETRA grants are never gated. On the return of
+// true the pending entry is cleared. Guarded by radiosMu.
+func (e *Engine) tetraDiscoveryCorroborated(g Grant) bool {
+	if g.Protocol != "tetra" || g.Emergency {
+		return true
+	}
+	e.radiosMu.Lock()
+	defer e.radiosMu.Unlock()
+	if e.pendingTETRADiscovery == nil {
+		e.pendingTETRADiscovery = make(map[uint32]struct{})
+	}
+	if _, seen := e.pendingTETRADiscovery[g.GroupID]; seen {
+		delete(e.pendingTETRADiscovery, g.GroupID)
+		return true
+	}
+	if len(e.pendingTETRADiscovery) < pendingDiscoveryCap {
+		e.pendingTETRADiscovery[g.GroupID] = struct{}{}
+	} else {
+		return true // set full — fail open rather than suppress discovery forever
+	}
+	return false
+}
+
 // noteRadio records that ssi is a subscriber radio (an individual unit) rather
 // than a talkgroup, and retracts any talkgroup previously auto-discovered for
 // it. A radio is revealed by any grant that carries it as a calling /
@@ -381,6 +426,9 @@ func (e *Engine) noteRadio(ssi uint32, system string) {
 	if !known && len(e.knownRadios) < knownRadiosCap {
 		e.knownRadios[ssi] = struct{}{}
 	}
+	// If this radio was a pending TETRA discovery candidate, drop it — it is a
+	// subscriber, never a talkgroup, so its second sighting must not catalogue it.
+	delete(e.pendingTETRADiscovery, ssi)
 	e.radiosMu.Unlock()
 	if known {
 		return // already learned — any phantom was retracted on first sighting
@@ -559,7 +607,7 @@ func (e *Engine) HandleGrant(g Grant) {
 		e.dropHeldNotification(channelKeyOf(g))
 	}
 	tg := e.talkgroups.Lookup(g.GroupID)
-	if tg == nil && g.GroupID != 0 && !g.Individual && !e.isKnownRadio(g.GroupID) && !isTETRANotificationGrant(g) {
+	if tg == nil && g.GroupID != 0 && !g.Individual && !e.isKnownRadio(g.GroupID) && !isTETRANotificationGrant(g) && e.tetraDiscoveryCorroborated(g) {
 		// First time this talkgroup has been heard: catalogue it so
 		// Database → Talkgroups fills in from the air (the trunk-recorder
 		// behaviour the operator asked for). Individual (unit-to-unit /

--- a/internal/trunking/engine_test.go
+++ b/internal/trunking/engine_test.go
@@ -142,15 +142,22 @@ func TestEngineRetractsRadioIDLeakedAsTalkgroup(t *testing.T) {
 	// Ordering A — phantom first, then the SSI is seen as a calling party.
 	// A group grant addressed under radio 1005387's SSI with a different calling
 	// party (a unit-to-unit call the SwMI carried as a group, before 1005387 is
-	// known to be a radio) leaks it in. (A source-less notification no longer
-	// leaks — the discovery gate skips those; see
-	// TestEngineTETRANotificationDoesNotDiscoverTalkgroup.)
-	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: 1005387, SourceID: 1009000, FrequencyHz: 467_912_500})
+	// known to be a radio) can still leak it in when the call has more than one
+	// over — corroboration (two sightings) suppresses the single-over case but a
+	// repeated unit-to-unit grant slips through, and the retraction net below is
+	// what catches it. (A source-less notification no longer leaks — the discovery
+	// gate skips those; see TestEngineTETRANotificationDoesNotDiscoverTalkgroup.)
+	leak := Grant{System: "X", Protocol: "tetra", GroupID: 1005387, SourceID: 1009000, FrequencyHz: 467_912_500}
+	e.HandleGrant(leak)
+	e.HandleGrant(leak) // second sighting corroborates the (mis-classified) TG
 	if tg := e.talkgroups.Lookup(1005387); tg == nil || tg.Tag != discoveredTag {
-		t.Fatalf("precondition: radio 1005387 should be leaked as a Discovered TG, got %+v", tg)
+		t.Fatalf("precondition: radio 1005387 should be leaked as a Discovered TG after two sightings, got %+v", tg)
 	}
-	// A real group call where 1005387 is the calling party reveals it as a radio.
-	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: 1020529, SourceID: 1005387, FrequencyHz: 467_912_500})
+	// A real group call where 1005387 is the calling party reveals it as a radio;
+	// send it twice so the real TG 1020529 also corroborates.
+	reveal := Grant{System: "X", Protocol: "tetra", GroupID: 1020529, SourceID: 1005387, FrequencyHz: 467_912_500}
+	e.HandleGrant(reveal)
+	e.HandleGrant(reveal)
 	if e.talkgroups.Lookup(1005387) != nil {
 		t.Errorf("radio 1005387 was not retracted after being seen as a calling party")
 	}

--- a/internal/trunking/engine_tetra_test.go
+++ b/internal/trunking/engine_tetra_test.go
@@ -54,6 +54,47 @@ func TestEngineTETRANotificationHeldUntilGroupGrant(t *testing.T) {
 	}
 }
 
+// TestEngineTETRADiscoveryRequiresCorroboration pins the residual RadioID→TGID
+// leak fix: a TETRA unit-to-unit call's destination radio that never transmits is
+// never revealed as an individual, so a single such grant (Individual=false,
+// source-bearing, not a notification) would catalogue the callee ISSI as a phantom
+// talkgroup that retraction never cleans up. TETRA discovery is therefore
+// corroborated — a first sighting is held pending and only a second catalogues it
+// (a real talkgroup recurs; a one-off callee does not). Non-TETRA protocols carry
+// explicit individual-call opcodes and are NOT gated, so P25 discovery is
+// unchanged. Fail-first: without corroboration the first TETRA grant catalogues
+// the SSI and the "must not be catalogued yet" assertion goes red.
+func TestEngineTETRADiscoveryRequiresCorroboration(t *testing.T) {
+	e, _, bus, _ := mkEngine(t, 2)
+	defer bus.Close()
+	e.afterFunc = noFireAfterFunc
+
+	// TETRA: a single source-bearing group grant to a fresh SSI is NOT catalogued.
+	g := Grant{System: "X", Protocol: "tetra", GroupID: 1020600, SourceID: 1005001, FrequencyHz: 467_912_500}
+	e.HandleGrant(g)
+	if tg := e.talkgroups.Lookup(1020600); tg != nil {
+		t.Fatalf("first TETRA sighting must not catalogue SSI 1020600 yet (corroboration), got %+v", tg)
+	}
+	// The second sighting corroborates and catalogues it.
+	e.HandleGrant(g)
+	if tg := e.talkgroups.Lookup(1020600); tg == nil || tg.Tag != discoveredTag {
+		t.Fatalf("second TETRA sighting should catalogue SSI 1020600, got %+v", tg)
+	}
+
+	// Emergency bypasses corroboration (a first-sighting emergency is catalogued).
+	em := Grant{System: "X", Protocol: "tetra", GroupID: 1020601, SourceID: 1005002, FrequencyHz: 467_912_500, Emergency: true}
+	e.HandleGrant(em)
+	if tg := e.talkgroups.Lookup(1020601); tg == nil {
+		t.Errorf("emergency TETRA grant should catalogue on first sight, got nil")
+	}
+
+	// Non-TETRA (P25) discovery is unchanged: catalogued on the first sighting.
+	e.HandleGrant(Grant{System: "X", Protocol: "p25", GroupID: 4321, SourceID: 7, FrequencyHz: 851_000_000})
+	if tg := e.talkgroups.Lookup(4321); tg == nil {
+		t.Errorf("P25 discovery must be unchanged (catalogued on first sight), got nil")
+	}
+}
+
 // TestEngineTETRANotificationDoesNotDiscoverTalkgroup is the regression for the
 // residual RadioID→TGID leak seen in the reporter's captures (e.g. tg=1009311):
 // a source-less TETRA notification grant addresses the paged radio's SSI, not a
@@ -78,10 +119,15 @@ func TestEngineTETRANotificationDoesNotDiscoverTalkgroup(t *testing.T) {
 	if tg := e.talkgroups.Lookup(issi); tg != nil {
 		t.Fatalf("source-less notification catalogued radio SSI %d as a talkgroup: %+v", issi, tg)
 	}
-	// The authoritative source-bearing group grant still discovers the real TG.
-	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: gssi, SourceID: issi, FrequencyHz: freq, Timeslot: 1})
+	// The authoritative source-bearing group grant discovers the real TG — but
+	// TETRA discovery is now corroborated, so a second sighting is needed (a real
+	// talkgroup recurs; a one-off unit-to-unit callee does not). See
+	// TestEngineTETRADiscoveryRequiresCorroboration.
+	authoritative := Grant{System: "X", Protocol: "tetra", GroupID: gssi, SourceID: issi, FrequencyHz: freq, Timeslot: 1}
+	e.HandleGrant(authoritative)
+	e.HandleGrant(authoritative)
 	if tg := e.talkgroups.Lookup(gssi); tg == nil || tg.Tag != discoveredTag {
-		t.Errorf("authoritative group grant should have discovered TG %d, got %+v", gssi, tg)
+		t.Errorf("authoritative group grant should have discovered TG %d after corroboration, got %+v", gssi, tg)
 	}
 	// And the notification's SSI is still not a talkgroup afterwards.
 	if tg := e.talkgroups.Lookup(issi); tg != nil {

--- a/internal/voice/callmeta.go
+++ b/internal/voice/callmeta.go
@@ -153,12 +153,24 @@ func buildCallMeta(cs trunking.CallStart, startedAt, endedAt time.Time, callNum 
 		})
 	}
 
-	// srcList: one entry per talker, in order.
+	// srcList: one entry per talker, in order. pos is seconds from the CALL start
+	// (cs.StartedAt), not this file's start — in transmission grouping the list is
+	// call-complete, so a talker from an earlier over would otherwise get a negative
+	// pos. For a single-transmission call the two starts coincide, so pos is
+	// unchanged. Clamp at 0 as a floor against clock skew.
+	srcBase := cs.StartedAt
+	if srcBase.IsZero() {
+		srcBase = startedAt
+	}
 	for _, se := range srcs {
+		pos := se.at.Sub(srcBase).Seconds()
+		if pos < 0 {
+			pos = 0
+		}
 		m.SrcList = append(m.SrcList, callSrcEntry{
 			Src:       se.src,
 			Time:      se.at.Unix(),
-			Pos:       round2(se.at.Sub(startedAt).Seconds()),
+			Pos:       round2(pos),
 			Emergency: boolToInt(se.emergency),
 		})
 	}

--- a/internal/voice/callmeta_test.go
+++ b/internal/voice/callmeta_test.go
@@ -123,3 +123,96 @@ func TestRecorderWritesCallJSON(t *testing.T) {
 		}
 	}
 }
+
+// TestRecorderCallJSONSrcListSpansTransmissions pins that the .json srcList is
+// CALL-complete: in transmission grouping a talker change rolls the WAV to a new
+// file (KindCallSegment), yet each transmission's sidecar must still list every
+// talker of the whole call — so the operator's "second srcID is missed" cannot
+// happen. Fail-first: before the call-level accumulator, the second file's srcs
+// were reseeded from the current talker on the roll, so its sidecar carried only
+// the second srcID and the two-entry assertion goes red.
+func TestRecorderCallJSONSrcListSpansTransmissions(t *testing.T) {
+	bus := events.NewBus(8)
+	dir := t.TempDir()
+	r, err := NewRecorder(RecorderOptions{
+		Bus: bus, OutDir: dir, SampleRate: 8000, WriteCallJSON: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	defer bus.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go r.Run(ctx)
+
+	const talkerA, talkerB = uint32(132622), uint32(145000)
+	cs := trunking.CallStart{
+		Grant: trunking.Grant{
+			System: "Ostankino", Protocol: "tetra", GroupID: 1020539, SourceID: talkerA,
+			FrequencyHz: 451_925_000, Timeslot: 2,
+		},
+		Talkgroup:    &trunking.TalkGroup{ID: 1020539, AlphaTag: "OPS-1", Record: true},
+		DeviceSerial: "V1",
+		StartedAt:    time.Date(2026, 8, 1, 1, 2, 3, 0, time.UTC),
+	}
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: cs})
+	waitSession(t, r, "V1", true)
+
+	// First over (talker A), then a per-transmission roll — the engine emits the
+	// segment BEFORE the source update, exactly as handleCallTalker does.
+	if err := r.WritePCM("V1", make([]int16, 800)); err != nil {
+		t.Fatal(err)
+	}
+	bus.Publish(events.Event{Kind: events.KindCallSegment, Payload: trunking.CallSegment{
+		DeviceSerial: "V1", At: cs.StartedAt.Add(1 * time.Second),
+	}})
+	time.Sleep(50 * time.Millisecond)
+	// Talker change to B, then the second over's audio → second file.
+	bus.Publish(events.Event{Kind: events.KindCallSourceUpdate, Payload: trunking.CallSourceUpdate{
+		DeviceSerial: "V1", SourceID: talkerB,
+	}})
+	time.Sleep(50 * time.Millisecond)
+	if err := r.WritePCM("V1", make([]int16, 800)); err != nil {
+		t.Fatal(err)
+	}
+	bus.Publish(events.Event{Kind: events.KindCallEnd, Payload: trunking.CallEnd{
+		Grant: cs.Grant, DeviceSerial: "V1", StartedAt: cs.StartedAt,
+		EndedAt: cs.StartedAt.Add(3 * time.Second), Reason: trunking.EndReasonNormal,
+	}})
+	waitSession(t, r, "V1", false)
+
+	// The second transmission's file is named from talker B; its sidecar must
+	// carry BOTH talkers in order.
+	tgDir := filepath.Join(dir, "Ostankino", "OPS-1")
+	entries, err := os.ReadDir(tgDir)
+	if err != nil {
+		t.Fatalf("read tg dir: %v", err)
+	}
+	var secondJSON string
+	for _, e := range entries {
+		if strings.Contains(e.Name(), "src145000") && strings.HasSuffix(e.Name(), ".json") {
+			secondJSON = filepath.Join(tgDir, e.Name())
+		}
+	}
+	if secondJSON == "" {
+		t.Fatalf("no second-transmission .json (src145000) found in %v", entries)
+	}
+	b, err := os.ReadFile(secondJSON)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m callMeta
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("second sidecar is not valid JSON: %v", err)
+	}
+	if len(m.SrcList) != 2 || m.SrcList[0].Src != talkerA || m.SrcList[1].Src != talkerB {
+		t.Fatalf("second-transmission srcList = %+v, want the call-complete [%d, %d]", m.SrcList, talkerA, talkerB)
+	}
+	// pos is call-relative and non-negative even for the earlier talker.
+	for i, e := range m.SrcList {
+		if e.Pos < 0 {
+			t.Errorf("srcList[%d].pos = %v, want >= 0 (call-relative)", i, e.Pos)
+		}
+	}
+}

--- a/internal/voice/composer/boundary.go
+++ b/internal/voice/composer/boundary.go
@@ -38,7 +38,11 @@ import (
 // Concurrency: onVoice / onTransmissionEnd are called from the single
 // chain goroutine; run executes in its own goroutine and only reads the
 // atomics. The mutable match/segment bookkeeping is touched only by the
-// chain goroutine.
+// chain goroutine. (For the shared TETRA same-carrier demux the "chain
+// goroutine" for onVoice is the owner's single vocoder worker, while the
+// demux goroutine calls observe(); the two touch disjoint non-atomic field
+// sets — onVoice: lastMatch/foreignRun/voiceSinceRoll; observe: sumSq/nSamp —
+// so they do not race. See tetraSlotOwner.)
 type boundaryTracker struct {
 	c              *Composer
 	serial         string

--- a/internal/voice/composer/tetra_voice.go
+++ b/internal/voice/composer/tetra_voice.go
@@ -284,15 +284,88 @@ const (
 	minSlotBurstsForActive = 3
 )
 
+// tetraVocoderQueueDepth is the per-owner backlog of decoded traffic bursts
+// awaiting TCH/S channel decode + ACELP synthesis on the owner's worker
+// goroutine. A downlink call occupies one TDMA slot ≈ 18 bursts/s, so a worker
+// clears its backlog far faster than it fills; the depth only absorbs scheduling
+// jitter (~3 s here). It exists so the demux goroutine's enqueue is non-blocking:
+// vocoding must never stall the single goroutine that drains the carrier's IQ (a
+// stall there drops post-DDC IQ chunks upstream and garbles every slot — the
+// multislot garble). On the rare overflow a burst is dropped and counted rather
+// than blocking the demux.
+const tetraVocoderQueueDepth = 64
+
+// tetraDecodeJob is one decoded traffic burst handed from the demux goroutine to
+// an owner's vocoder worker. The frame / soft-LLR slices are COPIES: the
+// TrafficExtractor may reuse its backing arrays for the next burst, so the demux
+// goroutine must not hand the worker a slice it will overwrite.
+type tetraDecodeJob struct {
+	frame     []byte
+	softType5 []float32
+}
+
 // tetraSlotOwner is one call's registration with the carrier demux: the usage
 // marker it follows (0 until a wildcard claims one) plus the boundary tracker +
 // recorder sink its decoded speech drives. bursts/speech feed the ended log line.
+//
+// Concurrency: the demux goroutine routes a burst to this owner and enqueues it on
+// jobs; a single per-owner worker goroutine (tetraOwnerWorker) dequeues and runs
+// decodeTETRASpeech. One worker per owner keeps decodeTETRASpeech's boundary-tracker
+// bookkeeping single-writer (as boundary.go requires), while moving the heavy
+// Viterbi + ACELP off the demux goroutine. The demux still folds carrier power into
+// bt via observe(), but that touches a disjoint non-atomic field set (sumSq/nSamp)
+// from onVoice's (lastMatch/foreignRun/…), so the two goroutines do not race.
 type tetraSlotOwner struct {
 	serial         string
 	marker         uint8 // grant usage marker; 0 = wildcard until it claims one
 	bt             *boundaryTracker
 	rs             rawFrameSink
 	bursts, speech atomic.Uint64
+
+	jobs         chan tetraDecodeJob // decoded bursts awaiting the vocoder worker
+	vocoderDrops atomic.Uint64       // bursts dropped because the worker queue was full
+}
+
+// enqueue hands a decoded burst to the owner's vocoder worker without ever
+// blocking the demux goroutine. The slices are copied (the extractor reuses its
+// buffers) and, on a full queue, the burst is dropped and counted rather than
+// stalling IQ intake.
+func (o *tetraSlotOwner) enqueue(frame []byte, softType5 []float32) {
+	job := tetraDecodeJob{}
+	if frame != nil {
+		job.frame = append([]byte(nil), frame...)
+	}
+	if softType5 != nil {
+		job.softType5 = append([]float32(nil), softType5...)
+	}
+	select {
+	case o.jobs <- job:
+	default:
+		o.vocoderDrops.Add(1)
+	}
+}
+
+// tetraOwnerWorker is the single per-owner goroutine that runs the CPU-heavy
+// TCH/S channel decode + ACELP synthesis for one call, off the shared demux
+// goroutine. On ctx cancel (call end) it drains whatever bursts are already
+// queued — so tail speech at the end of a transmission is not lost — then exits.
+func (c *Composer) tetraOwnerWorker(ctx context.Context, o *tetraSlotOwner) {
+	defer gtlog.Recover(c.log, "tetra-voice-worker:"+o.serial, nil)
+	for {
+		select {
+		case <-ctx.Done():
+			for {
+				select {
+				case job := <-o.jobs:
+					c.decodeTETRASpeech(o.bt, o.rs, o.serial, job.frame, job.softType5, &o.speech)
+				default:
+					return
+				}
+			}
+		case job := <-o.jobs:
+			c.decodeTETRASpeech(o.bt, o.rs, o.serial, job.frame, job.softType5, &o.speech)
+		}
+	}
 }
 
 // run streams the carrier's post-DDC IQ through one front end + receiver +
@@ -403,7 +476,7 @@ func (d *tetraSlotDemux) onBurst(frame []byte, softType5 []float32, slot, usage 
 		}
 		d.crcFallbacks.Add(1)
 		sole.bursts.Add(1)
-		d.c.decodeTETRASpeech(sole.bt, sole.rs, sole.serial, frame, softType5, &sole.speech)
+		sole.enqueue(frame, softType5)
 		return
 	}
 	d.mu.Lock()
@@ -433,7 +506,7 @@ func (d *tetraSlotDemux) onBurst(frame []byte, softType5 []float32, slot, usage 
 		if sole != nil {
 			d.crcFallbacks.Add(1)
 			sole.bursts.Add(1)
-			d.c.decodeTETRASpeech(sole.bt, sole.rs, sole.serial, frame, softType5, &sole.speech)
+			sole.enqueue(frame, softType5)
 			return
 		}
 		if d.onAirConcurrent() {
@@ -443,7 +516,7 @@ func (d *tetraSlotDemux) onBurst(frame []byte, softType5 []float32, slot, usage 
 		return
 	}
 	o.bursts.Add(1)
-	d.c.decodeTETRASpeech(o.bt, o.rs, o.serial, frame, softType5, &o.speech)
+	o.enqueue(frame, softType5)
 }
 
 // noteSlotActivity folds a traffic-marked burst's physical slot into the sliding
@@ -535,14 +608,22 @@ func (c *Composer) runTETRASameCarrierChain(ctx context.Context, d *tetraSlotDem
 	go bt.run(ctx)
 	rs, _ := c.sink.(rawFrameSink)
 
-	o := &tetraSlotOwner{serial: serial, marker: usageMarker, bt: bt, rs: rs}
+	o := &tetraSlotOwner{
+		serial: serial, marker: usageMarker, bt: bt, rs: rs,
+		jobs: make(chan tetraDecodeJob, tetraVocoderQueueDepth),
+	}
+	// Start the vocoder worker BEFORE registering the owner, so a burst routed the
+	// instant addOwner returns already has a draining consumer. The worker exits
+	// (after draining) when ctx is cancelled at call end.
+	go c.tetraOwnerWorker(ctx, o)
 	d.addOwner(o)
 	c.log.Info("composer: tetra voice follow started (shared demux) — TCH/S decode + ACELP vocoder",
 		"serial", serial, "group", groupID, "timeslot", grantSlot, "usage_marker", usageMarker)
 	defer func() {
 		d.removeOwner(o)
 		c.log.Info("composer: tetra voice follow ended",
-			"serial", serial, "bursts", o.bursts.Load(), "speech_frames", o.speech.Load())
+			"serial", serial, "bursts", o.bursts.Load(), "speech_frames", o.speech.Load(),
+			"vocoder_drops", o.vocoderDrops.Load())
 	}()
 
 	<-ctx.Done()

--- a/internal/voice/composer/tetra_voice_offload_test.go
+++ b/internal/voice/composer/tetra_voice_offload_test.go
@@ -1,0 +1,95 @@
+package composer
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+)
+
+// TestTETRASlotOwnerEnqueueNeverBlocks pins the core property of running the
+// TETRA per-call vocoder off the shared demux goroutine: enqueue must NEVER block
+// the caller, even when the worker is not draining. The demux goroutine that
+// drains the carrier's post-DDC IQ calls enqueue for every routed burst; if that
+// blocked on a slow/stuck vocoder the goroutine would stop reading IQ, the
+// upstream voice-tap buffer would overflow, and every concurrent slot would
+// garble (the multislot garble this commit fixes). Fail-first: replace enqueue's
+// non-blocking select with a plain `o.jobs <- job` and this test deadlocks/times
+// out once the queue fills.
+func TestTETRASlotOwnerEnqueueNeverBlocks(t *testing.T) {
+	o := &tetraSlotOwner{serial: "s", jobs: make(chan tetraDecodeJob, 4)}
+
+	const n = 20 // > queue depth, with no worker draining
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < n; i++ {
+			o.enqueue([]byte{byte(i)}, nil)
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("enqueue blocked with a full queue — the demux goroutine would stall on a slow vocoder")
+	}
+
+	wantDrops := n - cap(o.jobs)
+	if got := int(o.vocoderDrops.Load()); got != wantDrops {
+		t.Fatalf("vocoderDrops = %d, want %d (enqueued %d into a %d-deep queue)", got, wantDrops, n, cap(o.jobs))
+	}
+	if len(o.jobs) != cap(o.jobs) {
+		t.Fatalf("queued = %d, want the queue full at %d", len(o.jobs), cap(o.jobs))
+	}
+}
+
+// TestTETRASlotOwnerEnqueueCopiesSlices guards the copy-on-enqueue contract: the
+// TrafficExtractor reuses its frame/soft backing arrays for the next burst, so a
+// job handed to the worker must not alias caller memory that is about to be
+// overwritten. Fail-first: drop the append-copies in enqueue and the mutated
+// bytes below leak into the queued job.
+func TestTETRASlotOwnerEnqueueCopiesSlices(t *testing.T) {
+	o := &tetraSlotOwner{serial: "s", jobs: make(chan tetraDecodeJob, 2)}
+	frame := []byte{1, 2, 3}
+	soft := []float32{1, 2, 3}
+	o.enqueue(frame, soft)
+	// Simulate the extractor overwriting its buffers for the next burst.
+	frame[0], soft[0] = 9, 9
+	job := <-o.jobs
+	if job.frame[0] != 1 {
+		t.Fatalf("queued frame aliases caller buffer: got %d, want 1", job.frame[0])
+	}
+	if job.softType5[0] != 1 {
+		t.Fatalf("queued soft aliases caller buffer: got %v, want 1", job.softType5[0])
+	}
+}
+
+// TestTETRAOwnerWorkerDrainsAndExits confirms the worker consumes its backlog and
+// exits promptly on ctx cancel (call end). Garbage frames decode to no speech, so
+// the worker loop is exercised without needing a real TCH/S bitstream or sink.
+func TestTETRAOwnerWorkerDrainsAndExits(t *testing.T) {
+	c := &Composer{log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	o := &tetraSlotOwner{
+		serial: "s",
+		jobs:   make(chan tetraDecodeJob, 8),
+		bt:     &boundaryTracker{c: c, grantTG: 0},
+	}
+	for i := 0; i < 8; i++ {
+		o.enqueue([]byte{byte(i)}, nil) // garbage → decodeTETRASpeech is a fast no-op
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	workerDone := make(chan struct{})
+	go func() { c.tetraOwnerWorker(ctx, o); close(workerDone) }()
+
+	cancel()
+	select {
+	case <-workerDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("vocoder worker did not exit after ctx cancel")
+	}
+	if n := len(o.jobs); n != 0 {
+		t.Fatalf("worker exited without draining its backlog: %d jobs left", n)
+	}
+}

--- a/internal/voice/composer/tetra_voice_test.go
+++ b/internal/voice/composer/tetra_voice_test.go
@@ -55,13 +55,13 @@ func TestTETRADemuxSoftDecodeUsesLLRs(t *testing.T) {
 
 	o, rs := newDemuxOwner(c, "A", 19)
 	d.addOwner(o)
-	d.onBurst(corrupt, soft, 1, 19)
+	d.onBurstSync(corrupt, soft, 1, 19)
 	if n := len(rs.rawFrames("A")); n != 2 {
 		t.Fatalf("soft-decode path: A got %d frames, want 2 (soft LLRs must decode despite a corrupt hard frame)", n)
 	}
 	// The SAME corrupt hard frame with no soft info decodes nothing — confirming
 	// it was the soft LLRs, not the frame bytes, that produced the speech above.
-	d.onBurst(corrupt, nil, 1, 19)
+	d.onBurstSync(corrupt, nil, 1, 19)
 	if n := len(rs.rawFrames("A")); n != 2 {
 		t.Errorf("hard fallback on a CRC-failing frame should add no frames; total = %d, want 2", n)
 	}
@@ -316,11 +316,47 @@ func TestTETRATrafficBurstNoGrantMarkerFallback(t *testing.T) {
 func newDemuxOwner(c *Composer, serial string, marker uint8) (*tetraSlotOwner, *recordingSink) {
 	rs := &recordingSink{}
 	bt := c.newBoundaryTracker(serial, 0, nil)
-	return &tetraSlotOwner{serial: serial, marker: marker, bt: bt, rs: rs}, rs
+	return &tetraSlotOwner{
+		serial: serial, marker: marker, bt: bt, rs: rs,
+		jobs: make(chan tetraDecodeJob, tetraVocoderQueueDepth),
+	}, rs
 }
 
 func mkDemux(c *Composer) *tetraSlotDemux {
 	return &tetraSlotDemux{c: c, key: "test", owners: make(map[uint8]*tetraSlotOwner)}
+}
+
+// drainForTest synchronously runs any queued vocoder jobs for every currently
+// registered owner (and pending wildcards), mirroring tetraOwnerWorker. Vocoding
+// now runs off the demux goroutine (a per-owner worker), so a routing test that
+// asserts delivery right after onBurst must first drain the queue to see the
+// (now off-goroutine) speech deterministically.
+func (d *tetraSlotDemux) drainForTest() {
+	d.mu.Lock()
+	owners := make([]*tetraSlotOwner, 0, len(d.owners)+len(d.wildcards))
+	for _, o := range d.owners {
+		owners = append(owners, o)
+	}
+	owners = append(owners, d.wildcards...)
+	d.mu.Unlock()
+	for _, o := range owners {
+	drain:
+		for {
+			select {
+			case job := <-o.jobs:
+				d.c.decodeTETRASpeech(o.bt, o.rs, o.serial, job.frame, job.softType5, &o.speech)
+			default:
+				break drain
+			}
+		}
+	}
+}
+
+// onBurstSync routes a burst and then synchronously drains the resulting vocoder
+// work, so the demux routing regressions keep asserting delivery immediately.
+func (d *tetraSlotDemux) onBurstSync(frame []byte, softType5 []float32, slot, usage uint8) {
+	d.onBurst(frame, softType5, slot, usage)
+	d.drainForTest()
 }
 
 // TestTETRADemuxRoutesByUsageMarker is the core regression for cross-slot audio
@@ -336,8 +372,8 @@ func TestTETRADemuxRoutesByUsageMarker(t *testing.T) {
 	d.addOwner(oA)
 	d.addOwner(oB)
 
-	d.onBurst(frame, nil, 1, 19) // marker 19 → A only
-	d.onBurst(frame, nil, 2, 20) // marker 20 → B only
+	d.onBurstSync(frame, nil, 1, 19) // marker 19 → A only
+	d.onBurstSync(frame, nil, 2, 20) // marker 20 → B only
 	if n := len(rsA.rawFrames("A")); n != 2 {
 		t.Errorf("owner A got %d frames, want 2", n)
 	}
@@ -346,12 +382,12 @@ func TestTETRADemuxRoutesByUsageMarker(t *testing.T) {
 	}
 
 	// A marker with no owner is dropped (not broadcast to A or B).
-	d.onBurst(frame, nil, 3, 21)
+	d.onBurstSync(frame, nil, 3, 21)
 	if n := len(rsA.rawFrames("A")) + len(rsB.rawFrames("B")); n != 4 {
 		t.Errorf("unowned marker 21 leaked: total frames now %d, want 4", n)
 	}
 	// A non-traffic AACH marker (< DLUsageTraffic, e.g. undecoded 0) is dropped.
-	d.onBurst(frame, nil, 1, 0)
+	d.onBurstSync(frame, nil, 1, 0)
 	if n := len(rsA.rawFrames("A")); n != 2 {
 		t.Errorf("non-traffic marker leaked to A: %d frames, want 2", n)
 	}
@@ -368,7 +404,7 @@ func TestTETRADemuxMostRecentGrantEvicts(t *testing.T) {
 
 	oOld, rsOld := newDemuxOwner(c, "old", 19)
 	d.addOwner(oOld)
-	d.onBurst(frame, nil, 1, 19)
+	d.onBurstSync(frame, nil, 1, 19)
 	if n := len(rsOld.rawFrames("old")); n != 2 {
 		t.Fatalf("old owner got %d frames before reuse, want 2", n)
 	}
@@ -376,7 +412,7 @@ func TestTETRADemuxMostRecentGrantEvicts(t *testing.T) {
 	// New call reuses marker 19 while "old" is still registered (hangtime).
 	oNew, rsNew := newDemuxOwner(c, "new", 19)
 	d.addOwner(oNew)
-	d.onBurst(frame, nil, 1, 19)
+	d.onBurstSync(frame, nil, 1, 19)
 	if n := len(rsNew.rawFrames("new")); n != 2 {
 		t.Errorf("new owner got %d frames after reuse, want 2", n)
 	}
@@ -386,7 +422,7 @@ func TestTETRADemuxMostRecentGrantEvicts(t *testing.T) {
 
 	// The lingering old owner unregistering must NOT remove the new owner's marker.
 	d.removeOwner(oOld)
-	d.onBurst(frame, nil, 1, 19)
+	d.onBurstSync(frame, nil, 1, 19)
 	if n := len(rsNew.rawFrames("new")); n != 4 {
 		t.Errorf("new owner lost its marker after old unregistered: %d frames, want 4", n)
 	}
@@ -407,7 +443,7 @@ func TestTETRADemuxWildcardBinding(t *testing.T) {
 	d.addOwner(oW)
 
 	// Burst on 19 goes to A, not the wildcard.
-	d.onBurst(frame, nil, 1, 19)
+	d.onBurstSync(frame, nil, 1, 19)
 	if n := len(rsA.rawFrames("A")); n != 2 {
 		t.Errorf("owner A got %d frames, want 2", n)
 	}
@@ -416,13 +452,13 @@ func TestTETRADemuxWildcardBinding(t *testing.T) {
 	}
 
 	// A burst on an unclaimed marker 25 binds the wildcard to 25.
-	d.onBurst(frame, nil, 3, 25)
-	d.onBurst(frame, nil, 3, 25)
+	d.onBurstSync(frame, nil, 3, 25)
+	d.onBurstSync(frame, nil, 3, 25)
 	if n := len(rsW.rawFrames("W")); n != 4 {
 		t.Errorf("wildcard did not bind marker 25: %d frames, want 4", n)
 	}
 	// It must not also grab a different unclaimed marker now that it is bound.
-	d.onBurst(frame, nil, 4, 30)
+	d.onBurstSync(frame, nil, 4, 30)
 	if n := len(rsW.rawFrames("W")); n != 4 {
 		t.Errorf("bound wildcard grabbed a second marker: %d frames, want 4", n)
 	}
@@ -441,7 +477,7 @@ func TestTETRADemuxCRCFallbackSingleOwner(t *testing.T) {
 	o, rs := newDemuxOwner(c, "A", 0) // wildcard: grant carried no usage marker
 	d.addOwner(o)
 
-	d.onBurst(frame, nil, 2, 0) // undecoded AACH, single active call → CRC fallback
+	d.onBurstSync(frame, nil, 2, 0) // undecoded AACH, single active call → CRC fallback
 	if n := len(rs.rawFrames("A")); n != 2 {
 		t.Errorf("single-owner CRC fallback: A got %d frames, want 2", n)
 	}
@@ -464,7 +500,7 @@ func TestTETRADemuxCRCFallbackNoCrossTalkConcurrent(t *testing.T) {
 	d.addOwner(oA)
 	d.addOwner(oB)
 
-	d.onBurst(frame, nil, 2, 0) // undecoded AACH, two active calls → drop, no cross-talk
+	d.onBurstSync(frame, nil, 2, 0) // undecoded AACH, two active calls → drop, no cross-talk
 	if n := len(rsA.rawFrames("A")) + len(rsB.rawFrames("B")); n != 0 {
 		t.Errorf("undecoded burst leaked to a concurrent owner: %d frames, want 0", n)
 	}
@@ -488,7 +524,7 @@ func TestTETRADemuxOwnerlessMarkerSingleOwnerCRCFallback(t *testing.T) {
 	d := mkDemux(c)
 	o, rs := newDemuxOwner(c, "A", 24)
 	d.addOwner(o)
-	d.onBurst(frame, nil, 1, 25) // decoded marker 25, no owner, single call → CRC fallback
+	d.onBurstSync(frame, nil, 1, 25) // decoded marker 25, no owner, single call → CRC fallback
 	if n := len(rs.rawFrames("A")); n != 2 {
 		t.Errorf("ownerless single-owner fallback: A got %d frames, want 2", n)
 	}
@@ -502,7 +538,7 @@ func TestTETRADemuxOwnerlessMarkerSingleOwnerCRCFallback(t *testing.T) {
 	oB, rsB := newDemuxOwner(c, "B", 26)
 	d2.addOwner(oA)
 	d2.addOwner(oB)
-	d2.onBurst(frame, nil, 1, 25) // stray marker 25, two calls → drop, no cross-talk
+	d2.onBurstSync(frame, nil, 1, 25) // stray marker 25, two calls → drop, no cross-talk
 	if n := len(rsA.rawFrames("A")) + len(rsB.rawFrames("B")); n != 0 {
 		t.Errorf("ownerless burst leaked to a concurrent owner: %d frames, want 0", n)
 	}
@@ -540,10 +576,10 @@ func TestTETRADemuxNoLeakWhenAirConcurrentButOneOwner(t *testing.T) {
 	before := len(rs.rawFrames("A"))
 	// A foreign burst whose AACH did not decode (usage 0) on the other slot: must
 	// be dropped, not CRC-fallback-routed to the sole owner.
-	d.onBurst(frame, nil, 2, 0)
+	d.onBurstSync(frame, nil, 2, 0)
 	// A foreign burst carrying an ownerless traffic marker (another call's slot):
 	// also must not leak to the sole owner.
-	d.onBurst(frame, nil, 2, 20)
+	d.onBurstSync(frame, nil, 2, 20)
 	if n := len(rs.rawFrames("A")); n != before {
 		t.Errorf("foreign concurrent-slot speech leaked to the sole owner: %d frames, want %d", n, before)
 	}
@@ -556,7 +592,7 @@ func TestTETRADemuxNoLeakWhenAirConcurrentButOneOwner(t *testing.T) {
 	d2 := mkDemux(c)
 	o2, rs2 := newDemuxOwner(c, "A", 19)
 	d2.addOwner(o2)
-	d2.onBurst(frame, nil, 1, 0) // single slot, undecoded AACH → fallback recovers it
+	d2.onBurstSync(frame, nil, 1, 0) // single slot, undecoded AACH → fallback recovers it
 	if n := len(rs2.rawFrames("A")); n != 2 {
 		t.Errorf("single-call fallback regressed: A got %d frames, want 2", n)
 	}
@@ -584,8 +620,8 @@ func TestTETRADemuxConcurrentStreamNoLeakToSoleOwner(t *testing.T) {
 
 	const rounds = 40
 	for i := 0; i < rounds; i++ {
-		d.onBurst(frame, nil, 1, 19) // A's own burst — marker-routed to A
-		d.onBurst(frame, nil, 2, 20) // B's burst — ownerless, another physical slot
+		d.onBurstSync(frame, nil, 1, 19) // A's own burst — marker-routed to A
+		d.onBurstSync(frame, nil, 2, 20) // B's burst — ownerless, another physical slot
 	}
 
 	// A must get its own speech (2 frames/burst × rounds).
@@ -622,7 +658,7 @@ func TestTETRADemuxMarkerCollisionCounted(t *testing.T) {
 	if got := d.markerCollisions.Load(); got != 1 {
 		t.Errorf("markerCollisions = %d, want 1", got)
 	}
-	d.onBurst(frame, nil, 1, 19) // newest owns the marker
+	d.onBurstSync(frame, nil, 1, 19) // newest owns the marker
 	if n := len(rsNew.rawFrames("new")); n != 2 {
 		t.Errorf("newest owner got %d frames, want 2 (most-recent-grant wins)", n)
 	}

--- a/internal/voice/recorder.go
+++ b/internal/voice/recorder.go
@@ -106,11 +106,20 @@ type Recorder struct {
 	enhanceMu sync.RWMutex
 	enhance   mbe.EnhancerConfig
 
-	mu        sync.Mutex
-	sessions  map[string]*recordingSession // by device serial
-	sub       *events.Subscription
-	runDone   chan struct{}
-	closeOnce sync.Once
+	mu       sync.Mutex
+	sessions map[string]*recordingSession // by device serial
+	// callTalkers accumulates every distinct talker heard during a call, keyed by
+	// device serial and spanning the call's whole life — unlike a recordingSession's
+	// srcs, which resets on each per-transmission segment roll. In transmission
+	// grouping each rolled WAV legitimately holds one talker, but the trunk-recorder
+	// .json is call metadata, so every transmission's sidecar srcList should list all
+	// the call's talkers (the operator's "second srcID is missed"). Seeded on a new
+	// call (handleStart), appended on a talker change (backfillSessionGrant), read at
+	// finalize, and cleared when the call ends. Guarded by mu.
+	callTalkers map[string][]srcEvent
+	sub         *events.Subscription
+	runDone     chan struct{}
+	closeOnce   sync.Once
 
 	// decodedTap, when set, receives the PCM decoded from digital
 	// vocoder frames in WriteRawFrame — the live consumers (web
@@ -390,6 +399,7 @@ func NewRecorder(opts RecorderOptions) (*Recorder, error) {
 		dedup:              opts.Dedup,
 		dedupSeen:          make(map[dedupKey]dedupEntry),
 		sessions:           make(map[string]*recordingSession),
+		callTalkers:        make(map[string][]srcEvent),
 		runDone:            make(chan struct{}),
 	}
 	r.sub = opts.Bus.Subscribe()
@@ -779,6 +789,13 @@ func (r *Recorder) handleStart(cs trunking.CallStart) {
 		return
 	}
 	r.sessions[cs.DeviceSerial] = s
+	// Reset+seed the call-level talker list for this new call (the previous call
+	// on this serial, if any, is over). Later talkers accrue in backfillSessionGrant.
+	if cs.Grant.SourceID != 0 {
+		r.callTalkers[cs.DeviceSerial] = []srcEvent{{src: cs.Grant.SourceID, at: cs.StartedAt, emergency: cs.Grant.Emergency}}
+	} else {
+		delete(r.callTalkers, cs.DeviceSerial)
+	}
 	r.log.Info("recorder: call started",
 		"device", cs.DeviceSerial, "wav", s.wavPath,
 		"tg", cs.Grant.GroupID, "provoice", cs.Grant.ProVoice,
@@ -820,11 +837,17 @@ func (r *Recorder) backfillSessionGrant(deviceSerial string, encrypted bool, alg
 	}
 	if sourceID != 0 {
 		s.cs.Grant.SourceID = sourceID
+		now := time.Now().UTC()
 		// Record a talker change for the .json srcList: append when the source
 		// differs from the last one recorded for this file (a genuine talker
 		// change, not a repeat backfill of the same source).
 		if n := len(s.srcs); n == 0 || s.srcs[n-1].src != sourceID {
-			s.srcs = append(s.srcs, srcEvent{src: sourceID, at: time.Now().UTC(), emergency: s.cs.Grant.Emergency})
+			s.srcs = append(s.srcs, srcEvent{src: sourceID, at: now, emergency: s.cs.Grant.Emergency})
+		}
+		// Also accrue onto the call-level list (spans segment rolls) so every
+		// transmission's sidecar can list all the call's talkers.
+		if t := r.callTalkers[deviceSerial]; len(t) == 0 || t[len(t)-1].src != sourceID {
+			r.callTalkers[deviceSerial] = append(t, srcEvent{src: sourceID, at: now, emergency: s.cs.Grant.Emergency})
 		}
 	}
 }
@@ -847,6 +870,7 @@ func (r *Recorder) handleEncryptionUpdate(deviceSerial string, encrypted bool) {
 		return
 	}
 	delete(r.sessions, deviceSerial)
+	delete(r.callTalkers, deviceSerial) // call aborted — drop its talker history
 	// A dormant post-segment session (parked between overs) has no open
 	// files; only close when a WAV is actually open, mirroring handleEnd.
 	if s.wav == nil {
@@ -1152,7 +1176,14 @@ func (r *Recorder) finalizeLocked(s *recordingSession, serial string, endedAt ti
 	}
 	var meta *callMeta
 	if r.writeCallJSON {
-		meta = buildCallMeta(s.cs, s.startedAt, endedAt, int(r.callNum.Add(1)), s.vocoder != nil, s.srcs, s.freqs)
+		// Prefer the call-level talker list (all talkers of the whole call, across
+		// transmission rolls) so a rolled segment's sidecar still lists every
+		// srcID; fall back to this file's own srcs when none was accumulated.
+		srcs := s.srcs
+		if ct := r.callTalkers[serial]; len(ct) > 0 {
+			srcs = ct
+		}
+		meta = buildCallMeta(s.cs, s.startedAt, endedAt, int(r.callNum.Add(1)), s.vocoder != nil, srcs, s.freqs)
 	}
 	return cc, meta
 }
@@ -1262,6 +1293,7 @@ func (r *Recorder) handleEnd(ce trunking.CallEnd) {
 		// open WAV and there's nothing to publish, but the session may still
 		// hold a live vocoder — close it so it isn't leaked.
 		_ = s.close()
+		delete(r.callTalkers, ce.DeviceSerial) // call over — drop its talker history
 		r.mu.Unlock()
 		return
 	}
@@ -1269,6 +1301,9 @@ func (r *Recorder) handleEnd(ce trunking.CallEnd) {
 	// Announce the finished WAV so the outbound-streaming subsystem can
 	// upload it. Skip (and delete) calls that captured no PCM.
 	cc, meta := r.finalizeLocked(s, ce.DeviceSerial, ce.EndedAt, ce.Reason)
+	// The call is over — drop its talker history now that finalizeLocked has read
+	// it for the closing sidecar (still under r.mu, before the unlock below).
+	delete(r.callTalkers, ce.DeviceSerial)
 	r.mu.Unlock()
 	r.log.Info("recorder: call ended",
 		"device", ce.DeviceSerial,

--- a/web/configbuilder/src/components/FreqListField.test.tsx
+++ b/web/configbuilder/src/components/FreqListField.test.tsx
@@ -1,0 +1,51 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { FreqListField } from "./fields";
+
+// A controlled host that mirrors real usage: the parsed value round-trips back
+// into the field on every change, exactly as the Trunking section does.
+function Host({ onChange }: { onChange?: (v: number[]) => void }) {
+  const [value, setValue] = useState<number[]>([]);
+  return (
+    <FreqListField
+      label="Control channels"
+      value={value}
+      onChange={(v) => {
+        setValue(v);
+        onChange?.(v);
+      }}
+    />
+  );
+}
+
+describe("FreqListField", () => {
+  it("seeds the textarea from the Hz list as MHz, one per line", () => {
+    render(<FreqListField label="CC" value={[851037500, 851287500]} onChange={vi.fn()} />);
+    expect((screen.getByRole("textbox") as HTMLTextAreaElement).value).toBe("851.0375 MHz\n851.2875 MHz");
+  });
+
+  it("keeps a newline so a second control channel can be entered", () => {
+    const onChange = vi.fn();
+    render(<Host onChange={onChange} />);
+    const area = screen.getByRole("textbox") as HTMLTextAreaElement;
+
+    // Type the first frequency, then a newline. Before the fix the newline was
+    // parsed away and the value round-tripped back to "469.875 MHz" with no
+    // second line — the caret collapsed and a second channel was impossible.
+    fireEvent.change(area, { target: { value: "469.875" } });
+    fireEvent.change(area, { target: { value: "469.875 MHz\n" } });
+    expect(area.value).toBe("469.875 MHz\n"); // the newline survives the round-trip
+
+    // Now the second line can be filled in.
+    fireEvent.change(area, { target: { value: "469.875 MHz\n467.9125" } });
+    expect(onChange).toHaveBeenLastCalledWith([469875000, 467912500]);
+    expect(area.value).toBe("469.875 MHz\n467.9125");
+  });
+
+  it("resyncs the buffer when the bound value changes out-of-band", () => {
+    const { rerender } = render(<FreqListField label="CC" value={[469875000]} onChange={vi.fn()} />);
+    rerender(<FreqListField label="CC" value={[453000000, 454000000]} onChange={vi.fn()} />);
+    expect((screen.getByRole("textbox") as HTMLTextAreaElement).value).toBe("453 MHz\n454 MHz");
+  });
+});

--- a/web/configbuilder/src/components/fields.tsx
+++ b/web/configbuilder/src/components/fields.tsx
@@ -148,21 +148,43 @@ export function SelectField(props: {
 // FreqListField edits a list of integer Hz values as a comma/space/newline
 // separated textarea, accepting MHz or Hz per line (values < 10000 are
 // treated as MHz for convenience).
+//
+// It keeps a local text buffer (like HzField) instead of deriving the textarea
+// value from the parsed list every render. Deriving it swallowed newlines: a
+// trailing "\n" (or a blank in-progress line) parses to no token, so the value
+// round-tripped back to a newline-free string and the caret collapsed — the user
+// could never open a second line to enter a second control channel. The buffer is
+// the source of truth while editing and only resyncs from props.value on a genuine
+// out-of-band change (e.g. loading a different config), so newlines survive.
 export function FreqListField(props: {
   label: string;
   value: number[] | null;
   onChange: (v: number[]) => void;
   help?: ReactNode;
 }) {
-  const text = (props.value ?? []).map(hzToDisplay).join("\n");
+  const [text, setText] = useState(() => (props.value ?? []).map(hzToDisplay).join("\n"));
+  const emitted = useRef<number[]>(props.value ?? []);
+  useEffect(() => {
+    const v = props.value ?? [];
+    if (!sameFreqList(v, emitted.current)) {
+      emitted.current = v;
+      setText(v.map(hzToDisplay).join("\n"));
+    }
+  }, [props.value]);
+  const onText = (raw: string) => {
+    setText(raw);
+    const parsed = parseFreqList(raw);
+    emitted.current = parsed;
+    props.onChange(parsed);
+  };
   return (
     <label className="block">
       <span className="label">{props.label}</span>
       <textarea
         className="input font-mono"
-        rows={Math.max(2, (props.value ?? []).length + 1)}
+        rows={Math.max(2, text.split("\n").length + 1)}
         value={text}
-        onChange={(e) => props.onChange(parseFreqList(e.target.value))}
+        onChange={(e) => onText(e.target.value)}
       />
       <p className="help mt-1">
         One frequency per line. Accepts MHz (851.0375) or Hz (851037500).
@@ -170,6 +192,17 @@ export function FreqListField(props: {
       </p>
     </label>
   );
+}
+
+// sameFreqList reports whether two Hz lists are element-for-element equal, so
+// FreqListField only rebuilds its text buffer on a genuine out-of-band change and
+// not on the value it just emitted itself (which would clobber the caret).
+function sameFreqList(a: number[], b: number[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
 }
 
 // HzField edits a single integer-Hz value as text, accepting MHz or Hz

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -413,6 +413,12 @@ export interface SystemHuntStatusDTO {
   last_failed_at?: string;
   backoff_ms?: number;
   last_grant_at?: string;
+  // Live control-channel signal quality (clean/marginal/poor) and carrier offset
+  // (Hz) for the locked CC. has_decode_health distinguishes a real 0 offset from
+  // "no data yet"; decode_quality is empty until enough frames have decoded.
+  decode_quality?: string;
+  carrier_offset_hz?: number;
+  has_decode_health?: boolean;
 }
 
 export interface ConvScannerStatusDTO {

--- a/web/src/lib/formatTime.test.ts
+++ b/web/src/lib/formatTime.test.ts
@@ -1,0 +1,29 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { formatClock } from "./formatTime";
+
+// Pin a non-UTC timezone so the "local, not GMT" behaviour is observable and
+// deterministic regardless of where the suite runs.
+beforeAll(() => {
+  vi.stubEnv("TZ", "America/New_York"); // UTC-5 (EST) in January
+});
+afterAll(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("formatClock", () => {
+  it("renders the timestamp in local time, not UTC", () => {
+    // 2026-01-15T12:00:00Z is 07:00:00 in America/New_York (UTC-5).
+    // The old toISOString().slice(11,19) would have returned "12:00:00".
+    expect(formatClock("2026-01-15T12:00:00Z")).toBe("07:00:00");
+  });
+
+  it("keeps a 24-hour HH:MM:SS shape", () => {
+    expect(formatClock("2026-01-15T23:30:45Z")).toBe("18:30:45");
+  });
+
+  it("falls back to the raw time slice on an unparseable value", () => {
+    // Non-date input: Date() is NaN, so it returns raw.slice(11,19) — here the
+    // 8 chars starting at index 11 ("XXXXXXXXXXX" is 11 chars) = "12:34:56".
+    expect(formatClock("XXXXXXXXXXX12:34:56")).toBe("12:34:56");
+  });
+});

--- a/web/src/lib/formatTime.ts
+++ b/web/src/lib/formatTime.ts
@@ -1,0 +1,22 @@
+// formatClock renders an RFC3339 / ISO event timestamp as a compact
+// HH:MM:SS wall-clock string in the BROWSER'S LOCAL timezone.
+//
+// The live-event panels previously did `new Date(ts).toISOString().slice(11,19)`,
+// which always emits UTC — so an operator in any non-UTC zone saw GMT times in
+// CC Activity and the other event logs (the reported bug). toLocaleTimeString
+// with hour12:false keeps the same 24-hour HH:MM:SS shape but in local time.
+//
+// On an unparseable timestamp it falls back to the raw time-of-day slice so a
+// malformed daemon value is still shown rather than throwing.
+export function formatClock(ts: string): string {
+  const d = new Date(ts);
+  if (Number.isNaN(d.getTime())) {
+    return ts.slice(11, 19);
+  }
+  return d.toLocaleTimeString(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  });
+}

--- a/web/src/panels/ADSB.tsx
+++ b/web/src/panels/ADSB.tsx
@@ -7,6 +7,7 @@ import { Badge } from "../components/ui/Badge";
 import { StaleIndicator } from "../components/ui/StaleIndicator";
 import { useDataPoll } from "../hooks/useDataPoll";
 import { selectClientConfig, useShared } from "../store/shared";
+import { formatClock } from "../lib/formatTime";
 
 // ADS-B panel — list of recent decoded Mode-S frames. Each row
 // shows the ICAO 24-bit address (hex form, the standard "tail
@@ -198,10 +199,4 @@ export function ADSB() {
   );
 }
 
-function formatTime(ts: string): string {
-  try {
-    return new Date(ts).toISOString().slice(11, 19);
-  } catch {
-    return ts.slice(11, 19);
-  }
-}
+const formatTime = formatClock;

--- a/web/src/panels/AIS.tsx
+++ b/web/src/panels/AIS.tsx
@@ -7,6 +7,7 @@ import { Badge } from "../components/ui/Badge";
 import { StaleIndicator } from "../components/ui/StaleIndicator";
 import { useDataPoll } from "../hooks/useDataPoll";
 import { selectClientConfig, useShared } from "../store/shared";
+import { formatClock } from "../lib/formatTime";
 
 // AIS panel — list of recent decoded marine-AIS messages. Each row
 // shows the MMSI, the message-type tag, a short body summary, and
@@ -173,10 +174,4 @@ export function AIS() {
   );
 }
 
-function formatTime(ts: string): string {
-  try {
-    return new Date(ts).toISOString().slice(11, 19);
-  } catch {
-    return ts.slice(11, 19);
-  }
-}
+const formatTime = formatClock;

--- a/web/src/panels/APRS.tsx
+++ b/web/src/panels/APRS.tsx
@@ -7,6 +7,7 @@ import { Badge } from "../components/ui/Badge";
 import { StaleIndicator } from "../components/ui/StaleIndicator";
 import { useDataPoll } from "../hooks/useDataPoll";
 import { selectClientConfig, useShared } from "../store/shared";
+import { formatClock } from "../lib/formatTime";
 
 // APRS panel — list of recent decoded APRS / AX.25 packets. Each row
 // shows the AX.25 envelope (src → dst + path), the decoded APRS
@@ -159,10 +160,4 @@ export function APRS() {
   );
 }
 
-function formatTime(ts: string): string {
-  try {
-    return new Date(ts).toISOString().slice(11, 19);
-  } catch {
-    return ts.slice(11, 19);
-  }
-}
+const formatTime = formatClock;

--- a/web/src/panels/CCActivity.tsx
+++ b/web/src/panels/CCActivity.tsx
@@ -4,6 +4,7 @@ import { useShared } from "../store/shared";
 import { groupEvents } from "../lib/groupEvents";
 import type { EventDTO, TalkgroupDTO } from "../api/types";
 import { PageHeader } from "../components/ui/PageHeader";
+import { formatClock } from "../lib/formatTime";
 
 // CC Activity panel — a focused view of the trunked control-channel
 // "chatter" already flowing on the events bus. Filters the rolling
@@ -408,10 +409,4 @@ function num(v: unknown): number {
   return 0;
 }
 
-function formatTime(ts: string): string {
-  try {
-    return new Date(ts).toISOString().slice(11, 19);
-  } catch {
-    return ts.slice(11, 19);
-  }
-}
+const formatTime = formatClock;

--- a/web/src/panels/DSC.tsx
+++ b/web/src/panels/DSC.tsx
@@ -7,6 +7,7 @@ import { Badge } from "../components/ui/Badge";
 import { StaleIndicator } from "../components/ui/StaleIndicator";
 import { useDataPoll } from "../hooks/useDataPoll";
 import { selectClientConfig, useShared } from "../store/shared";
+import { formatClock } from "../lib/formatTime";
 
 // DSC panel — list of recent decoded marine DSC sequences. The
 // category badge reflects priority: distress = red, urgency = amber,
@@ -193,10 +194,4 @@ export function DSC() {
   );
 }
 
-function formatTime(ts: string): string {
-  try {
-    return new Date(ts).toISOString().slice(11, 19);
-  } catch {
-    return ts.slice(11, 19);
-  }
-}
+const formatTime = formatClock;

--- a/web/src/panels/LoRa.tsx
+++ b/web/src/panels/LoRa.tsx
@@ -6,6 +6,7 @@ import { Badge } from "../components/ui/Badge";
 import { StaleIndicator } from "../components/ui/StaleIndicator";
 import { useDataPoll } from "../hooks/useDataPoll";
 import { selectClientConfig, useShared } from "../store/shared";
+import { formatClock } from "../lib/formatTime";
 
 // LoRa panel — list of recent decoded LoRa frames. Each row shows the
 // sub-channel frequency, the PHY parameters (SF / CR / BW), link
@@ -167,10 +168,4 @@ export function LoRa() {
   );
 }
 
-function formatTime(ts: string): string {
-  try {
-    return new Date(ts).toISOString().slice(11, 19);
-  } catch {
-    return ts.slice(11, 19);
-  }
-}
+const formatTime = formatClock;

--- a/web/src/panels/MDC1200.tsx
+++ b/web/src/panels/MDC1200.tsx
@@ -6,6 +6,7 @@ import { Badge } from "../components/ui/Badge";
 import { StaleIndicator } from "../components/ui/StaleIndicator";
 import { useDataPoll } from "../hooks/useDataPoll";
 import { selectClientConfig, useShared } from "../store/shared";
+import { formatClock } from "../lib/formatTime";
 
 // MDC1200 panel — list of recent decoded Motorola FFSK signaling
 // bursts off conventional analog voice channels. Each row shows the
@@ -141,10 +142,4 @@ function hex2(v: number): string {
   return "0x" + v.toString(16).toUpperCase().padStart(2, "0");
 }
 
-function formatTime(ts: string): string {
-  try {
-    return new Date(ts).toISOString().slice(11, 19);
-  } catch {
-    return ts.slice(11, 19);
-  }
-}
+const formatTime = formatClock;

--- a/web/src/panels/Scanner.test.tsx
+++ b/web/src/panels/Scanner.test.tsx
@@ -83,4 +83,48 @@ describe("Scanner panel", () => {
       expect(screen.getByText(/7 of 42 talkgroups eligible/i)).toBeInTheDocument(),
     );
   });
+
+  // The signal-quality chip renders from the per-system decode-health fields, with
+  // the carrier offset in its tooltip. Cross-protocol — here a locked TETRA system.
+  it("shows a signal-quality chip when decode health is present", async () => {
+    vi.mocked(api.scanner).mockResolvedValue({
+      scan_mode: "all",
+      systems: [
+        {
+          name: "Tetra1",
+          protocol: "tetra",
+          state: "locked",
+          locked_freq_hz: 467_912_500,
+          decode_quality: "marginal",
+          carrier_offset_hz: -958,
+          has_decode_health: true,
+        },
+      ],
+      conventional: { enabled: false, channels: [] },
+      tg_scan_count: 0,
+      tg_total: 0,
+    } as unknown as ScannerStatusDTO);
+
+    render(<Scanner />);
+
+    const chip = await screen.findByText(/signal: marginal/i);
+    expect(chip).toBeInTheDocument();
+    expect(chip.closest("[title]")?.getAttribute("title")).toContain("offset -958 Hz");
+  });
+
+  // No chip when the daemon reports no decode health (unlocked / too few frames).
+  it("omits the signal chip when decode health is absent", async () => {
+    vi.mocked(api.scanner).mockResolvedValue({
+      scan_mode: "all",
+      systems: [{ name: "Tetra1", protocol: "tetra", state: "hunting" }],
+      conventional: { enabled: false, channels: [] },
+      tg_scan_count: 0,
+      tg_total: 0,
+    } as unknown as ScannerStatusDTO);
+
+    render(<Scanner />);
+
+    await waitFor(() => expect(screen.getByText("Tetra1")).toBeInTheDocument());
+    expect(screen.queryByText(/signal:/i)).not.toBeInTheDocument();
+  });
 });

--- a/web/src/panels/Scanner.tsx
+++ b/web/src/panels/Scanner.tsx
@@ -187,6 +187,12 @@ function Hunt({
                   {sys.protocol}
                 </span>
                 <StatePill state={sys.state} />
+                {sys.has_decode_health && sys.decode_quality && (
+                  <SignalQualityChip
+                    quality={sys.decode_quality}
+                    offsetHz={sys.carrier_offset_hz}
+                  />
+                )}
                 {sys.locked_freq_hz != null && (
                   <span className="font-mono text-xs text-muted">
                     lock {formatHz(sys.locked_freq_hz)}
@@ -529,6 +535,28 @@ function StatePill({ state }: { state: string }) {
           ? "err"
           : "neutral";
   return <Badge tone={tone}>{state}</Badge>;
+}
+
+// SignalQualityChip is the simple control-channel signal indicator: a
+// clean/marginal/poor pill (green/amber/red), with the measured carrier offset in
+// its tooltip. Backed by the decoder's live TSBK (P25) / BSCH (TETRA) frame-error
+// rate, so it works across protocols — not just TETRA.
+function SignalQualityChip({
+  quality,
+  offsetHz,
+}: {
+  quality: string;
+  offsetHz?: number;
+}) {
+  const tone =
+    quality === "clean" ? "ok" : quality === "marginal" ? "warn" : "err";
+  const offset =
+    offsetHz != null ? ` · offset ${offsetHz > 0 ? "+" : ""}${offsetHz} Hz` : "";
+  return (
+    <span title={`control-channel signal: ${quality}${offset}`}>
+      <Badge tone={tone}>signal: {quality}</Badge>
+    </span>
+  );
 }
 
 function timeOnly(ts: string): string {


### PR DESCRIPTION
The multislot "losing dsp sync" garble is a self-perpetuating reset storm.
The 500 ms heartbeat-stale resync reset the receiver's converged Gardner
timing + AFC to centre — a destructive operation — whenever the control decode
went 500 ms without a CRC-clean burst. Under concurrent same-carrier voice load
the CPU-heavy shared voice demux momentarily starves the CC decode goroutine, so
the heartbeat ages purely because the goroutine was descheduled, not because
timing drifted. The receiver still holds a good lock and resumes decoding the
instant it is scheduled — but the resync had already discarded that lock, and did
so again every ~500 ms (the reporter's capture shows ~15 resyncs in ~13 s, only
while three concurrent calls are up, then a clean 1 Hz sync cadence once they
end). The existing exponential back-off never engaged because an intermittent
burst decoded each window, snapping the back-off back to the base.

Raise the reset window to 1.5 s so a transient scheduling stall no longer resets
still-good timing, while a genuine decode drought (a real off-lock) still
reacquires well before the 5 s lost-watchdog. The companion change removes the
starvation itself by running per-call vocoding off the demux goroutine; this
window makes the CC resync robust to whatever transient stalls remain. Back-off
cap raised to 4 s to keep the doubling meaningful against the larger base.

Fail-first test: a control channel decoding on a starved cadence whose gaps
exceed the old 500 ms window but stay under the floor must not reset to centre;
a genuine drought past the floor still does.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UE5fnyMxETs5PD6bTKeqS8