### PR TITLE
tetra: soft-decision DMO TCH/S (#1003) + training-sequence equalizer (#1001)

### DIFF
--- a/cmd/gophertrunk/tetra_dmo_replay_test.go
+++ b/cmd/gophertrunk/tetra_dmo_replay_test.go
@@ -29,7 +29,9 @@ import (
 //   - each DSB's SCH/S is channel-decoded with colour 0 (§8.2.5.2) — a CRC-valid
 //     SCH/S is the DMO sync/lock indicator, marking a PTT/transmission start;
 //   - each DNB's TCH/S is descrambled + decoded (dmo_decode.go) into 137-bit
-//     speech frames, gated on the class-2 CRC exactly like the TMO path;
+//     speech frames, gated on the class-2 CRC exactly like the TMO path —
+//     soft-decision (DMBurstTCHSpeechSoft, off the receiver's differentials) with
+//     a hard fallback, the ~2× same-carrier yield lever from #1001;
 //   - the speech frames feed the clean-room ACELP vocoder to PCM.
 //
 // The pass signal is CRC-valid speech clustered in time on the transmissions
@@ -73,14 +75,21 @@ func TestTETRADMOReplay(t *testing.T) {
 	ddc := ccdecoder.NewDownconverter(inRate, 144000)
 	outRate := ddc.OutRateHz()
 
-	// Accumulate the full demodulated dibit stream; ExtractDMBursts is stateless
-	// over a complete slice, which keeps the offline framing deterministic.
+	// Accumulate the full demodulated dibit stream and the parallel per-symbol
+	// differentials (soft info); ExtractDMBurstsSoft is stateless over a complete
+	// slice, which keeps the offline framing deterministic. The SoftSink fires
+	// just before the matching DibitSink with the same base, so appending both in
+	// order keeps allDiffs strictly parallel to allDibits.
 	var allDibits []uint8
+	var allDiffs []complex64
 	enableEQ := os.Getenv("GT_TETRA_DMO_EQ") == "1" || os.Getenv("GT_TETRA_DMO_EQ") == "true"
 	rx := tetrarx.New(tetrarx.Options{
 		SampleRateHz: outRate,
 		DibitSink: func(d []uint8, _ int) {
 			allDibits = append(allDibits, d...)
+		},
+		SoftSink: func(diffs []complex64, _ int) {
+			allDiffs = append(allDiffs, diffs...)
 		},
 		ClockMode:           tetrarx.ClockGardner,
 		GardnerGain:         0.005,
@@ -101,9 +110,13 @@ func TestTETRADMOReplay(t *testing.T) {
 	}
 
 	dibitRate := tetrarx.SymbolRate // 18000 dibits/sec
-	bursts := tetra.ExtractDMBursts(allDibits, 0)
+	// Soft-capable extraction: carry the differentials so DMBurstTCHSpeechSoft can
+	// recover corrupted TCH/S bursts the hard path drops (the #1001 ~2× lever).
+	// Falls back to the hard ExtractDMBursts geometry if the soft stream didn't
+	// stay parallel (length mismatch).
+	bursts := tetra.ExtractDMBurstsSoft(allDibits, allDiffs, 0)
 
-	var dsbTotal, dsbCRC, dnbTotal, tchCRC int
+	var dsbTotal, dsbCRC, dnbTotal, tchCRC, tchSoftOnly int
 	var syncSecs []int           // seconds carrying a CRC-valid SCH/S (transmission starts)
 	speechBySec := map[int]int{} // CRC-valid TCH/S bursts per second
 	var speechFrames [][]byte    // ordered speech frames for the vocoder
@@ -124,7 +137,16 @@ func TestTETRADMOReplay(t *testing.T) {
 			}
 		case tetra.DMBurstNormal:
 			dnbTotal++
-			frames := tetra.DMBurstTCHSpeech(b, colour)
+			// Prefer soft-decision; fall back to hard when no differentials were
+			// carried for this burst (e.g. an edge burst).
+			frames := tetra.DMBurstTCHSpeechSoft(b, colour)
+			if len(frames) != 2 {
+				if hard := tetra.DMBurstTCHSpeech(b, colour); len(hard) == 2 {
+					frames = hard
+				}
+			} else if tetra.DMBurstTCHSpeech(b, colour) == nil {
+				tchSoftOnly++ // recovered by soft-decision that the hard path missed
+			}
 			if len(frames) == 2 {
 				tchCRC++
 				speechBySec[sec]++
@@ -135,8 +157,8 @@ func TestTETRADMOReplay(t *testing.T) {
 
 	t.Logf("in=%.0fHz out=%.0fHz samples=%d dur=%.1fs colour=%#x eq=%v",
 		inRate, outRate, len(iq), float64(len(iq))/inRate, colour, enableEQ)
-	t.Logf("bursts: dsb_total=%d dsb_schs_crc=%d dnb_total=%d tch_crc=%d",
-		dsbTotal, dsbCRC, dnbTotal, tchCRC)
+	t.Logf("bursts: dsb_total=%d dsb_schs_crc=%d dnb_total=%d tch_crc=%d (soft_only=%d)",
+		dsbTotal, dsbCRC, dnbTotal, tchCRC, tchSoftOnly)
 	sort.Ints(syncSecs)
 	t.Logf("sync (SCH/S CRC-valid) at seconds: %v", syncSecs)
 

--- a/internal/dsp/equalizer/snapshot_lms.go
+++ b/internal/dsp/equalizer/snapshot_lms.go
@@ -1,0 +1,128 @@
+package equalizer
+
+// SnapshotLMS is a training-sequence-aided linear equalizer that is safe to place
+// ahead of a DIFFERENTIAL demodulator — the trained counterpart to SnapshotCMA.
+//
+// Where SnapshotCMA adapts BLINDLY to a constant-modulus target, SnapshotLMS
+// trains on a burst's KNOWN training sequence (the π/4-DQPSK normal/synchronisation
+// midamble). That difference matters: CMA's cost J = E[(|y|²−R²)²] is satisfied by
+// any equalizer output that has the right modulus, so it has spurious minima and
+// can converge to a constant-modulus but WRONG solution — the failure the package
+// history records (a numerically-unstable CMA once drove differential EVM 34%→8%
+// while CRC stayed 0). Training to a known reference removes that ambiguity: the
+// LMS error e = d − y is minimised only when the composite channel·equalizer maps
+// the reference back to itself, so a good training sequence pins the true channel
+// inverse (phase and all), not merely its modulus. This is the #1001 follow-up:
+// per-burst training-sequence-aided equalization for the same-carrier TETRA voice
+// that blind CMA only partially recovers.
+//
+// It shares SnapshotCMA's differential-safety principle: ADAPT on the training
+// sequence, then APPLY a FROZEN snapshot of the taps to the whole burst. A held-
+// constant filter imposes only a constant phase/scale, which cancels in the
+// downstream s[n]·conj(s[n−1]) differential decode; a continuously-adapting filter
+// would not (its inter-symbol phase drift corrupts every dibit). So the intended
+// use is: Train(midamble_rx, midamble_ref) once per burst, then Equalize the whole
+// burst's symbols through the frozen taps before the differential decoder.
+//
+// The taps are centre-spike initialised, so before training (or on a benign
+// channel with a short/absent reference) Equalize is a near pass-through — the
+// equalizer can only help or leave a clean burst essentially unchanged. The
+// forward FIR convention matches LMS exactly (tap 0 multiplies the newest sample),
+// so a snapshot of an LMS weight vector means the same thing in Equalize.
+type SnapshotLMS struct {
+	adapt   *LMS        // trained on the reference; never applied while adapting
+	apply   []complex64 // frozen snapshot of adapt's taps, applied to the burst
+	hist    []complex64 // Equalize delay line (newest written at histPos-1)
+	histPos int
+}
+
+// NewSnapshotLMS builds a training-sequence equalizer with taps complex weights
+// and LMS step size stepSize. taps must be > 0; an odd count gives a well-defined
+// centre spike. Panics on taps <= 0 (mirroring NewLMS).
+func NewSnapshotLMS(taps int, stepSize float32) *SnapshotLMS {
+	e := &SnapshotLMS{
+		adapt: NewLMS(taps, stepSize),
+		apply: make([]complex64, taps),
+		hist:  make([]complex64, taps),
+	}
+	e.apply[taps/2] = 1 // centre-spike pass-through until trained
+	return e
+}
+
+// Train adapts the tracking filter over the aligned (received, reference) symbol
+// pairs, then freezes the result into the applied taps. rx[i] is the received
+// symbol for reference symbol ref[i]; both must be the same length (the shorter
+// prevails). passes repeats the sweep over the reference so a short midamble still
+// converges (1 for a long training sequence, several for a burst-length one); a
+// passes < 1 is treated as 1. Training does NOT reset the adapt taps, so repeated
+// Train calls refine the same estimate — call Reset first for a fresh channel.
+func (e *SnapshotLMS) Train(rx, ref []complex64, passes int) {
+	n := len(rx)
+	if len(ref) < n {
+		n = len(ref)
+	}
+	if n == 0 {
+		return
+	}
+	if passes < 1 {
+		passes = 1
+	}
+	for p := 0; p < passes; p++ {
+		for i := 0; i < n; i++ {
+			e.adapt.Process(rx[i], ref[i])
+		}
+	}
+	copy(e.apply, e.adapt.Taps())
+}
+
+// Equalize applies the frozen taps to src as a plain FIR, appending the equalized
+// symbols to dst[:0] and returning it (dst may be nil or reused across bursts).
+// The delay line persists across calls so a burst can be streamed in chunks; call
+// Reset between independent bursts. Using the frozen taps for the whole burst is
+// what keeps the output safe for a differential decoder (constant phase cancels).
+func (e *SnapshotLMS) Equalize(dst, src []complex64) []complex64 {
+	dst = dst[:0]
+	n := len(e.apply)
+	for _, x := range src {
+		e.hist[e.histPos] = x
+		e.histPos = (e.histPos + 1) % n
+
+		var yr, yi float32
+		idx := e.histPos - 1
+		if idx < 0 {
+			idx = n - 1
+		}
+		for i := 0; i < n; i++ {
+			hr, hi := real(e.hist[idx]), imag(e.hist[idx])
+			tr, ti := real(e.apply[i]), imag(e.apply[i])
+			yr += tr*hr - ti*hi
+			yi += tr*hi + ti*hr
+			idx--
+			if idx < 0 {
+				idx = n - 1
+			}
+		}
+		dst = append(dst, complex(yr, yi))
+	}
+	return dst
+}
+
+// Taps returns a copy of the currently-applied (frozen) weight vector.
+func (e *SnapshotLMS) Taps() []complex64 {
+	out := make([]complex64, len(e.apply))
+	copy(out, e.apply)
+	return out
+}
+
+// Reset returns the equalizer to its centre-spike pass-through state and clears
+// the Equalize delay line — call between independent bursts / on re-sync so a
+// stale channel estimate does not corrupt the next burst.
+func (e *SnapshotLMS) Reset() {
+	e.adapt.Reset()
+	for i := range e.apply {
+		e.apply[i] = 0
+		e.hist[i] = 0
+	}
+	e.apply[len(e.apply)/2] = 1
+	e.histPos = 0
+}

--- a/internal/dsp/equalizer/snapshot_lms_test.go
+++ b/internal/dsp/equalizer/snapshot_lms_test.go
@@ -1,0 +1,210 @@
+package equalizer
+
+import (
+	"math"
+	"math/cmplx"
+	"math/rand"
+	"testing"
+)
+
+// These tests exercise SnapshotLMS on a π/4-DQPSK differential stream through a
+// synthetic multipath channel — the #1001 case: a same-carrier signal whose
+// inter-symbol interference closes the constellation eye and garbles the
+// differential decode. A training-sequence-aided equalizer trained on a known
+// midamble should invert the channel where the raw stream (and, on a burst-length
+// sequence, the blind SnapshotCMA) cannot. Metric is differential dibit-error
+// rate — the constant-phase-invariant, decode-level number that CLAUDE.md flags
+// as the only trustworthy one (EVM is a trap).
+
+// piBy4Inc maps a dibit to its π/4-DQPSK phase increment (matches the receiver /
+// soft_test.go dibitIdealDiff convention).
+func piBy4Inc(d uint8) float64 {
+	switch d & 3 {
+	case 0:
+		return math.Pi / 4
+	case 1:
+		return 3 * math.Pi / 4
+	case 2:
+		return -3 * math.Pi / 4
+	default:
+		return -math.Pi / 4
+	}
+}
+
+// piBy4Encode differential-encodes dibits into unit-modulus symbols, starting
+// from phase 0. Returns len(dibits)+1 symbols (the extra leading reference).
+func piBy4Encode(dibits []uint8) []complex64 {
+	sym := make([]complex64, len(dibits)+1)
+	phase := 0.0
+	sym[0] = 1
+	for i, d := range dibits {
+		phase += piBy4Inc(d)
+		sym[i+1] = complex64(cmplx.Rect(1, phase))
+	}
+	return sym
+}
+
+// piBy4DecodeDibits differential-decodes symbols back to dibits: the dibit whose
+// ideal phase increment is closest to arg(s[i]·conj(s[i-1])).
+func piBy4DecodeDibits(sym []complex64) []uint8 {
+	out := make([]uint8, 0, len(sym)-1)
+	for i := 1; i < len(sym); i++ {
+		diff := complex128(sym[i]) * cmplx.Conj(complex128(sym[i-1]))
+		ang := cmplx.Phase(diff)
+		best := uint8(0)
+		bestErr := math.Pi * 2
+		for d := uint8(0); d < 4; d++ {
+			e := math.Abs(math.Remainder(ang-piBy4Inc(d), 2*math.Pi))
+			if e < bestErr {
+				bestErr = e
+				best = d
+			}
+		}
+		out = append(out, best)
+	}
+	return out
+}
+
+// multipath convolves sym with a causal channel h (h[0] is the direct path),
+// adding complex Gaussian noise of the given sigma per component. A minimum-phase
+// h (dominant first tap) keeps a near-zero-delay causal inverse, so an LMS trained
+// with the reference aligned 1:1 (no delay) converges cleanly.
+func multipath(sym []complex64, h []complex64, sigma float64, rng *rand.Rand) []complex64 {
+	out := make([]complex64, len(sym))
+	for n := range sym {
+		var acc complex64
+		for k := range h {
+			if n-k >= 0 {
+				acc += h[k] * sym[n-k]
+			}
+		}
+		acc += complex(float32(rng.NormFloat64()*sigma), float32(rng.NormFloat64()*sigma))
+		out[n] = acc
+	}
+	return out
+}
+
+func dibitErrRate(got, want []uint8) float64 {
+	n := len(got)
+	if len(want) < n {
+		n = len(want)
+	}
+	if n == 0 {
+		return 0
+	}
+	bad := 0
+	for i := 0; i < n; i++ {
+		if got[i] != want[i] {
+			bad++
+		}
+	}
+	return float64(bad) / float64(n)
+}
+
+// hardMultipath is a minimum-phase channel whose echoes close the π/4-DQPSK eye.
+var hardMultipath = []complex64{
+	1,
+	complex64(cmplx.Rect(0.6, 0.8)),
+	complex64(cmplx.Rect(0.35, -1.2)),
+}
+
+// TestSnapshotLMSInvertsMultipath is the failing-first behavioural regression: a
+// multipath channel garbles the raw differential decode, and SnapshotLMS trained
+// on a known midamble drives the PAYLOAD (post-training) dibit-error rate to near
+// zero — proving it inverts the channel, not just memorises the reference.
+func TestSnapshotLMSInvertsMultipath(t *testing.T) {
+	rng := rand.New(rand.NewSource(7))
+	const (
+		nDibits  = 600
+		trainLen = 160 // midamble length in dibits
+		sigma    = 0.02
+	)
+	dibits := make([]uint8, nDibits)
+	for i := range dibits {
+		dibits[i] = uint8(rng.Intn(4))
+	}
+	tx := piBy4Encode(dibits)
+	rx := multipath(tx, hardMultipath, sigma, rng)
+
+	// Raw (unequalized) differential decode over the payload region.
+	rawErr := dibitErrRate(piBy4DecodeDibits(rx)[trainLen:], dibits[trainLen:])
+
+	// Train on the aligned midamble (reference symbols the receiver knows), then
+	// equalize the whole burst and decode the payload.
+	eq := NewSnapshotLMS(11, 0.02)
+	eq.Train(rx[:trainLen+1], tx[:trainLen+1], 40)
+	out := eq.Equalize(nil, rx)
+	eqErr := dibitErrRate(piBy4DecodeDibits(out)[trainLen:], dibits[trainLen:])
+
+	t.Logf("payload dibit-error: raw=%.3f equalized=%.3f", rawErr, eqErr)
+	if rawErr < 0.10 {
+		t.Fatalf("channel not hard enough: raw payload error %.3f (want the ISI to actually garble it)", rawErr)
+	}
+	if eqErr > 0.03 {
+		t.Fatalf("SnapshotLMS did not invert the channel: payload error %.3f (raw %.3f)", eqErr, rawErr)
+	}
+	if eqErr >= rawErr {
+		t.Fatalf("SnapshotLMS did not improve the decode: equalized %.3f vs raw %.3f", eqErr, rawErr)
+	}
+}
+
+// TestSnapshotLMSNoHarmOnCleanChannel: on an identity channel the frozen taps
+// stay a near pass-through, so the equalized differential decode is exactly the
+// raw one — no regression on already-clean bursts (the SnapshotCMA no-harm rule).
+func TestSnapshotLMSNoHarmOnCleanChannel(t *testing.T) {
+	rng := rand.New(rand.NewSource(3))
+	dibits := make([]uint8, 300)
+	for i := range dibits {
+		dibits[i] = uint8(rng.Intn(4))
+	}
+	tx := piBy4Encode(dibits)
+	rx := multipath(tx, []complex64{1}, 0, rng) // identity channel, no noise
+
+	eq := NewSnapshotLMS(11, 0.02)
+	eq.Train(rx[:121], tx[:121], 40)
+	out := eq.Equalize(nil, rx)
+
+	if err := dibitErrRate(piBy4DecodeDibits(out), dibits); err > 0.001 {
+		t.Fatalf("SnapshotLMS harmed a clean channel: dibit error %.3f", err)
+	}
+}
+
+// TestSnapshotLMSBeatsBlindCMAOnBurst substantiates the value claim over the
+// already-shipped blind equalizer: on a burst-length multipath sequence the
+// training-sequence LMS resolves the channel while blind SnapshotCMA — starved of
+// symbols and prone to constant-modulus spurious minima — does materially worse.
+func TestSnapshotLMSBeatsBlindCMAOnBurst(t *testing.T) {
+	rng := rand.New(rand.NewSource(11))
+	const (
+		nDibits  = 500
+		trainLen = 160
+		sigma    = 0.02
+	)
+	dibits := make([]uint8, nDibits)
+	for i := range dibits {
+		dibits[i] = uint8(rng.Intn(4))
+	}
+	tx := piBy4Encode(dibits)
+	rx := multipath(tx, hardMultipath, sigma, rng)
+
+	lms := NewSnapshotLMS(11, 0.02)
+	lms.Train(rx[:trainLen+1], tx[:trainLen+1], 40)
+	lmsOut := lms.Equalize(nil, rx)
+	lmsErr := dibitErrRate(piBy4DecodeDibits(lmsOut)[trainLen:], dibits[trainLen:])
+
+	// Blind CMA gets the same samples but no reference; snapshot every 64 symbols.
+	cma := NewSnapshotCMA(11, 0.01, 64)
+	cmaOut := make([]complex64, len(rx))
+	for i, x := range rx {
+		cmaOut[i] = cma.Process(x)
+	}
+	cmaErr := dibitErrRate(piBy4DecodeDibits(cmaOut)[trainLen:], dibits[trainLen:])
+
+	t.Logf("payload dibit-error: trained-LMS=%.3f blind-CMA=%.3f", lmsErr, cmaErr)
+	if lmsErr >= cmaErr {
+		t.Fatalf("training-sequence LMS did not beat blind CMA: lms=%.3f cma=%.3f", lmsErr, cmaErr)
+	}
+	if lmsErr > 0.03 {
+		t.Fatalf("training-sequence LMS payload error too high: %.3f", lmsErr)
+	}
+}

--- a/internal/radio/tetra/dmo.go
+++ b/internal/radio/tetra/dmo.go
@@ -98,6 +98,13 @@ type DMBurst struct {
 	// burst kinds; BKN1 is set only for a DNB (a DSB's shorter block 1 is in SCHS,
 	// so BKN1 is nil for a DSB).
 	BKN1, BKN2 []uint8
+	// SoftBKN1, SoftBKN2 are the per-symbol complex differentials (the receiver's
+	// SoftSink output) strictly parallel to BKN1/BKN2, populated only by
+	// ExtractDMBurstsSoft — nil after the hard ExtractDMBursts. They let
+	// DMBurstTCHSpeechSoft soft-decode a DNB's TCH/S speech (the ~2× yield lever
+	// soft-decision gives the TMO path, #1001), and are the DMO analog of the
+	// differentials TrafficExtractor carries via StashSoft/softFrame.
+	SoftBKN1, SoftBKN2 []complex64
 	// Rotation is the residual π/4-DQPSK dibit rotation (0..3) at which the
 	// training sequence correlated — the burst's dibits must be de-rotated by this
 	// before channel decoding (rotateDibits(dibits, (4-Rotation)&3)).
@@ -115,18 +122,36 @@ type DMBurst struct {
 // baseIdx is the absolute dibit index of dibits[0], carried into DMBurst.Lead so
 // callers can order bursts across calls; pass 0 for a one-shot slice.
 func ExtractDMBursts(dibits []uint8, baseIdx int) []DMBurst {
+	return extractDMBursts(dibits, nil, baseIdx)
+}
+
+// ExtractDMBurstsSoft is the soft-decision-capable twin of ExtractDMBursts: it
+// carries the receiver's per-symbol complex differentials (diffs, the SoftSink
+// output — strictly parallel to dibits and the SAME length) into each DNB's
+// SoftBKN1/SoftBKN2, so DMBurstTCHSpeechSoft can soft-decode the TCH/S speech
+// (the ~2× yield lever, #1001). When diffs is nil or a length mismatch it
+// degrades cleanly to the hard ExtractDMBursts (soft fields left nil, callers
+// fall back to the hard decode) rather than misaligning.
+func ExtractDMBurstsSoft(dibits []uint8, diffs []complex64, baseIdx int) []DMBurst {
+	if len(diffs) != len(dibits) {
+		diffs = nil
+	}
+	return extractDMBursts(dibits, diffs, baseIdx)
+}
+
+func extractDMBursts(dibits []uint8, diffs []complex64, baseIdx int) []DMBurst {
 	var out []DMBurst
 
 	// DSB: correlate the 19-dibit synchronisation training sequence (shared with
 	// TMO's SB). Threshold 3 matches processSB / TrafficExtractor.
 	sts := SyncTrainingDibits()
-	out = appendDMBursts(out, dibits, baseIdx, DMBurstSync, sts, 3,
+	out = appendDMBursts(out, dibits, diffs, baseIdx, DMBurstSync, sts, 3,
 		dmDSBBKN1Start, dmSCHSDibits, dmDSBBKN2Start, dmBlockDibits)
 
 	// DNB: correlate either 11-dibit normal training sequence. Threshold 2 matches
 	// TrafficExtractor's normal-burst detectors.
 	for _, nts := range [][]uint8{NormalSyncDibits(), NormalSyncDibits2()} {
-		out = appendDMBursts(out, dibits, baseIdx, DMBurstNormal, nts, 2,
+		out = appendDMBursts(out, dibits, diffs, baseIdx, DMBurstNormal, nts, 2,
 			dmDNBBKN1Start, dmBlockDibits, dmDNBBKN2Start, dmBlockDibits)
 	}
 	return out
@@ -137,7 +162,7 @@ func ExtractDMBursts(dibits []uint8, baseIdx int) []DMBurst {
 // training lead. For a DSB the first block is the 60-dibit SCH/S (placed in SCHS);
 // for a DNB both blocks are 108-dibit (placed in BKN1/BKN2). De-duplicates a lead
 // that correlates under more than one rotation (keeps the first).
-func appendDMBursts(out []DMBurst, dibits []uint8, baseIdx int, kind DMBurstKind,
+func appendDMBursts(out []DMBurst, dibits []uint8, diffs []complex64, baseIdx int, kind DMBurstKind,
 	pattern []uint8, tol, b1Start, b1Len, b2Start, b2Len int) []DMBurst {
 	n := len(pattern)
 	seen := map[int]struct{}{}
@@ -164,6 +189,15 @@ func appendDMBursts(out []DMBurst, dibits []uint8, baseIdx int, kind DMBurstKind
 			} else {
 				b.BKN1 = blk1
 			}
+			// Carry the parallel soft differentials for the DNB traffic blocks
+			// (soft SCH/S isn't the yield lever, so a DSB keeps only SoftBKN2 for
+			// symmetry). diffs is guaranteed parallel to dibits by the caller.
+			if diffs != nil {
+				b.SoftBKN2 = cloneDiffs(diffs[b2From:b2To])
+				if kind == DMBurstNormal {
+					b.SoftBKN1 = cloneDiffs(diffs[b1From:b1To])
+				}
+			}
 			out = append(out, b)
 		}
 	}
@@ -172,6 +206,12 @@ func appendDMBursts(out []DMBurst, dibits []uint8, baseIdx int, kind DMBurstKind
 
 func cloneDibits(s []uint8) []uint8 {
 	c := make([]uint8, len(s))
+	copy(c, s)
+	return c
+}
+
+func cloneDiffs(s []complex64) []complex64 {
+	c := make([]complex64, len(s))
 	copy(c, s)
 	return c
 }

--- a/internal/radio/tetra/dmo_decode.go
+++ b/internal/radio/tetra/dmo_decode.go
@@ -34,11 +34,12 @@ import "github.com/MattCheramie/GopherTrunk/internal/radio/framing"
 // that PDU parser lands, callers pass the colour code explicitly (0 is both the
 // spec default for the DSB blocks and the common radio-to-radio DMO value).
 //
-// This layer is hard-decision. Soft-decision TCH/S decode (which ~doubled the
-// TMO same-carrier yield, #1001) needs the receiver's per-dibit differentials
-// carried parallel to the sliced blocks (the TrafficExtractor.StashSoft bridge);
-// wiring that for DMO is the natural follow-up once this hard path is validated
-// on air.
+// Both a hard-decision path (DMBurstTCHSpeech, off the sliced dibits) and a
+// soft-decision path (DMBurstTCHSpeechSoft, off the per-symbol differentials
+// ExtractDMBurstsSoft carries in DMBurst.SoftBKN1/SoftBKN2) are provided. The
+// soft path is the DMO analog of the TMO TrafficExtractor.softFrame bridge and
+// gives the same ~2× same-carrier yield lever (#1001); callers try soft first
+// and fall back to hard when no differentials were stashed.
 
 // dmDerotatedBits converts a burst's sliced dibit block back to on-air type-5
 // bits, undoing the residual π/4-DQPSK rotation (0..3) the detector reported for
@@ -102,6 +103,34 @@ func DMBurstTCHSpeech(b DMBurst, colour uint32) [][]byte {
 		type5 = framing.DescrambleTetra(type5, colour)
 	}
 	return TCHSpeechFrames(framing.PackBitsMSB(type5))
+}
+
+// DMBurstTCHSpeechSoft is the soft-decision analog of DMBurstTCHSpeech: it
+// decodes a DNB's TCH/S speech from the per-symbol complex differentials
+// ExtractDMBurstsSoft stashed in b.SoftBKN1/SoftBKN2 (rather than the hard-sliced
+// dibits), running the soft-Viterbi TCH/S chain that recovers several more
+// corrupted bursts per the #1001 soft-decision win. Returns the two 137-bit
+// speech frames when the class-2 CRC passes, or nil — including when no soft
+// info is present (a hard-only extraction), so a caller can fall back to
+// DMBurstTCHSpeech. colour is the 30-bit DM colour code (0 for the default).
+//
+// The differentials are de-rotated by the same (4-Rotation)&3 the hard
+// dmDerotatedBits applies: softType5FromDiffs(diffs, r) hard-slices to exactly
+// TetraDibitsToBits(rotateDibits(dibits, r)), so passing r=(4-Rotation)&3 makes
+// the soft LLR stream the differential twin of the hard dmDNBType5 bits, and
+// DescrambleTetraSoft applies the same colour-code sign flips as DescrambleTetra.
+func DMBurstTCHSpeechSoft(b DMBurst, colour uint32) [][]byte {
+	if b.Kind != DMBurstNormal || len(b.SoftBKN1) != dmBlockDibits || len(b.SoftBKN2) != dmBlockDibits {
+		return nil
+	}
+	diffs := make([]complex64, 0, 2*dmBlockDibits)
+	diffs = append(diffs, b.SoftBKN1...)
+	diffs = append(diffs, b.SoftBKN2...)
+	llr := softType5FromDiffs(diffs, (4-b.Rotation)&3)
+	if colour != 0 {
+		llr = framing.DescrambleTetraSoft(llr, colour)
+	}
+	return TCHSpeechFramesSoft(llr)
 }
 
 // DecodeDMSCHF decodes a DNB carrying SCH/F short-data signalling (the full-slot

--- a/internal/radio/tetra/dmo_decode_test.go
+++ b/internal/radio/tetra/dmo_decode_test.go
@@ -1,6 +1,7 @@
 package tetra
 
 import (
+	"math/rand"
 	"reflect"
 	"testing"
 
@@ -149,6 +150,131 @@ func TestDMTCHSpeechRotation(t *testing.T) {
 		if !reflect.DeepEqual(frames[0], framing.PackBitsMSB(frameA)) {
 			t.Errorf("rot %d: frame A mismatch after de-rotation", rot)
 		}
+	}
+}
+
+// dmoNoisyDNB builds a DNB carrying the 432 on-air (post-scramble) type-5 bits
+// onair as BOTH the hard dibit blocks (BKN1/BKN2) and the parallel per-symbol
+// complex differentials (SoftBKN1/SoftBKN2), adding Gaussian noise of the given
+// sigma to each π/4-DQPSK quadrature. Crucially the hard dibits are sign-sliced
+// from the SAME noisy differentials the soft path reads, so the hard and soft
+// decoders see one identical channel realisation — the only difference is hard
+// vs soft decision, which is exactly what the outperform test must isolate.
+// Constellation rotation 0 (softType5FromDiffs polarity: Im→b1, Re→b2, +⇒bit 0).
+func dmoNoisyDNB(onair []byte, sigma float64, rng *rand.Rand) DMBurst {
+	half := dmBlockDibits * 2 // 216 on-air bits per block
+	block := func(bits []byte) ([]uint8, []complex64) {
+		nsym := len(bits) / 2
+		diffs := make([]complex64, nsym)
+		hard := make([]byte, len(bits))
+		amp := func(b byte) float64 {
+			if b&1 == 0 {
+				return 1 // bit 0 ⇒ +LLR
+			}
+			return -1 // bit 1 ⇒ -LLR
+		}
+		for i := 0; i < nsym; i++ {
+			im := amp(bits[2*i]) + rng.NormFloat64()*sigma   // b1 → Im
+			re := amp(bits[2*i+1]) + rng.NormFloat64()*sigma // b2 → Re
+			diffs[i] = complex(float32(re), float32(im))
+			if im < 0 {
+				hard[2*i] = 1
+			}
+			if re < 0 {
+				hard[2*i+1] = 1
+			}
+		}
+		return TetraBitsToDibits(hard), diffs
+	}
+	bkn1, soft1 := block(onair[:half])
+	bkn2, soft2 := block(onair[half:])
+	return DMBurst{Kind: DMBurstNormal, BKN1: bkn1, BKN2: bkn2, SoftBKN1: soft1, SoftBKN2: soft2}
+}
+
+// TestDMTCHSpeechSoftRoundTripClean pins that the soft DNB path is the exact
+// soft twin of the hard one: on a noiseless channel ExtractDMBurstsSoft carries
+// the differentials, and DMBurstTCHSpeechSoft recovers the same two speech
+// frames the hard DMBurstTCHSpeech does — through the four-rotation search and at
+// a non-zero DM colour code (the descramble seed).
+func TestDMTCHSpeechSoftRoundTripClean(t *testing.T) {
+	for _, colour := range []uint32{0, 0x0AB1F} {
+		frameA := seqBits(7, tchSpeechFrameBits)
+		frameB := seqBits(9, tchSpeechFrameBits)
+		descrambled := framing.UnpackBitsMSB(EncodeTCHS(frameA, frameB), tchType3Bits)
+		onair := descrambled
+		if colour != 0 {
+			onair = framing.ScrambleTetra(descrambled, colour)
+		}
+
+		// Build a DNB and its parallel ideal differentials (sigma 0), then run the
+		// soft-capable extractor over the correlated stream so the soft fields come
+		// from ExtractDMBurstsSoft, not hand-set — exercising the real slicing.
+		src := dmoNoisyDNB(onair, 0, rand.New(rand.NewSource(1)))
+		dibits := buildDNB(TetraDibitsToBits(src.BKN1), TetraDibitsToBits(src.BKN2))
+		diffs := make([]complex64, len(dibits))
+		// Place the block differentials at the same offsets buildDNB lays the
+		// blocks (ramp(3,12) lead, BKN1, 11-dibit train, BKN2, trailing ramp).
+		lead := 12
+		copy(diffs[lead:], src.SoftBKN1)
+		copy(diffs[lead+dmBlockDibits+len(NormalSyncDibits()):], src.SoftBKN2)
+
+		bursts := ExtractDMBurstsSoft(dibits, diffs, 0)
+		dnb := findBurst(bursts, DMBurstNormal)
+		if dnb == nil {
+			t.Fatalf("colour %#x: no DNB detected", colour)
+		}
+		if len(dnb.SoftBKN1) != dmBlockDibits || len(dnb.SoftBKN2) != dmBlockDibits {
+			t.Fatalf("colour %#x: soft blocks not carried (%d/%d)", colour, len(dnb.SoftBKN1), len(dnb.SoftBKN2))
+		}
+		frames := DMBurstTCHSpeechSoft(*dnb, colour)
+		if len(frames) != 2 {
+			t.Fatalf("colour %#x: soft TCH/S returned %d frames, want 2", colour, len(frames))
+		}
+		if !reflect.DeepEqual(frames[0], framing.PackBitsMSB(frameA)) || !reflect.DeepEqual(frames[1], framing.PackBitsMSB(frameB)) {
+			t.Errorf("colour %#x: soft speech frames mismatch", colour)
+		}
+	}
+}
+
+// TestDMTCHSpeechSoftOutperformsHardUnderNoise is the failing-first regression
+// for the #1003 soft-decision lever: at a noise level where the hard
+// DMBurstTCHSpeech mostly fails the class-2 CRC, the soft DMBurstTCHSpeechSoft
+// passes far more of the SAME noisy bursts — the soft-Viterbi coding gain that
+// ~doubled the TMO same-carrier yield (#1001), now on the DMO path. The metric
+// is class-2-CRC yield (a returned frame pair), exactly what the replay harness
+// counts as a CRC-valid TCH/S burst; the CLAUDE.md rule "CRC yield is the only
+// trustworthy metric" applies. Exact speech recovery is pinned separately by the
+// noiseless TestDMTCHSpeechSoftRoundTripClean — under noise the uncoded class-0
+// speech bits legitimately differ even on a CRC pass, so they are not asserted
+// here (that is why class-0 is unprotected).
+func TestDMTCHSpeechSoftOutperformsHardUnderNoise(t *testing.T) {
+	frameA := seqBits(7, tchSpeechFrameBits)
+	frameB := seqBits(9, tchSpeechFrameBits)
+	onair := framing.UnpackBitsMSB(EncodeTCHS(frameA, frameB), tchType3Bits) // colour 0
+
+	rng := rand.New(rand.NewSource(42))
+	const (
+		sigma  = 0.9
+		trials = 200
+	)
+	hardPass, softPass := 0, 0
+	for tr := 0; tr < trials; tr++ {
+		b := dmoNoisyDNB(onair, sigma, rng)
+		if frames := DMBurstTCHSpeech(b, 0); len(frames) == 2 {
+			hardPass++
+		}
+		if frames := DMBurstTCHSpeechSoft(b, 0); len(frames) == 2 {
+			softPass++
+		}
+	}
+	t.Logf("sigma=%.2f trials=%d hardPass=%d softPass=%d", sigma, trials, hardPass, softPass)
+	if softPass <= hardPass {
+		t.Fatalf("soft-decision did not outperform hard: softPass=%d hardPass=%d", softPass, hardPass)
+	}
+	// Guard against a degenerate "both near zero" pass: soft must recover a
+	// meaningful share the hard path misses.
+	if softPass < hardPass+trials/10 {
+		t.Errorf("soft-decision uplift too small: softPass=%d hardPass=%d (trials=%d)", softPass, hardPass, trials)
 	}
 }
 

--- a/internal/sdr/rtlsdr/usb/bulk_stall.go
+++ b/internal/sdr/rtlsdr/usb/bulk_stall.go
@@ -156,10 +156,17 @@ func (w *bulkStallWatch) run(now func() int64, tick <-chan time.Time, stop <-cha
 		case <-stop:
 			return
 		case <-tick:
+			// Sample the clock AT tick receipt, before onTick(). onTick is a
+			// test-only hook that hands control back to the driver, which may
+			// advance an injected clock for the next tick; reading now() after it
+			// would let that next value decide THIS tick's stall (a false early
+			// fire — the flake behind the CI hang in the stall-watch test). In
+			// production onTick is nil, so this is behaviour-identical there.
+			atTick := now()
 			if onTick != nil {
 				onTick()
 			}
-			if w.shouldFire(now(), stallTimeoutNanos) {
+			if w.shouldFire(atTick, stallTimeoutNanos) {
 				if w.fired.CompareAndSwap(false, true) {
 					if onStall != nil {
 						onStall()

--- a/internal/sdr/rtlsdr/usb/bulk_stall_test.go
+++ b/internal/sdr/rtlsdr/usb/bulk_stall_test.go
@@ -54,6 +54,50 @@ func TestBulkStallWatchFiresOnceAfterTimeout(t *testing.T) {
 	close(stop)
 }
 
+// TestBulkStallWatchSamplesNowAtTickReceipt is the regression for the CI hang in
+// TestBulkStallWatchFiresOnceAfterTimeout: run() must decide a stall on the clock
+// AS OF the tick it just received, not a value that races in afterwards. The
+// original loop called onTick() before sampling now(); onTick unblocks the test,
+// which advances now for the NEXT tick, and that store could be observed by the
+// CURRENT tick's stall check — so a below-threshold tick fired early and returned,
+// stranding the test's next `tick <-` send with no receiver (a 10-minute timeout).
+//
+// This models that adverse schedule deterministically by advancing now inside
+// onTick (the exact window the flake exploited). Tick 1 arrives at 1s (below the
+// 2s threshold): run must NOT fire on it. If it mis-samples the leaked 3s it fires
+// and returns, and the follow-up tick send blocks — detected here with a timeout
+// instead of hanging.
+func TestBulkStallWatchSamplesNowAtTickReceipt(t *testing.T) {
+	w := newBulkStallWatch(1)
+	w.start(0)
+
+	var now atomic.Int64
+	now.Store(int64(1 * time.Second)) // tick 1 is below the 2s threshold
+	nowFn := func() int64 { return now.Load() }
+	tick := make(chan time.Time)
+	stop := make(chan struct{})
+	stalled := make(chan struct{}, 1)
+	// Advance now for the "next" tick from inside onTick — the leaked store the
+	// real test races on. run must have already sampled now for tick 1 by now.
+	onTick := func() { now.Store(int64(3 * time.Second)) }
+	onStall := func() { stalled <- struct{}{} }
+
+	go w.run(nowFn, tick, stop, testStallTimeoutNanos, onTick, onStall)
+
+	tick <- time.Time{} // deliver tick 1 (rendezvous: run has received it)
+
+	// If run judged tick 1 on the leaked 3s it fired and returned, so this send
+	// has no receiver; if it correctly used the 1s at receipt it stayed in its
+	// loop and accepts another tick. The timeout tells them apart without hanging.
+	select {
+	case tick <- time.Time{}:
+		// run still looping — tick 1 did not fire. Correct.
+	case <-time.After(2 * time.Second):
+		t.Fatal("run returned after a below-threshold tick — stall decision used a leaked next-tick now()")
+	}
+	close(stop)
+}
+
 // TestBulkStallWatchStaysQuietWhileActive proves a healthy stream — one
 // that keeps delivering packets — never trips the stall path, and that
 // the throughput counters accumulate as data flows.


### PR DESCRIPTION
Both issues' headline fixes already merged; these implement each issue's
explicitly-named next follow-up, additive and production byte-identical.

#1003 — soft-decision DMO TCH/S ("the ~2x yield lever from #1001"):
  - ExtractDMBurstsSoft carries the receiver's per-symbol differentials into
    new DMBurst.SoftBKN1/SoftBKN2 (the DMO analog of the TMO StashSoft bridge);
    hard ExtractDMBursts unchanged, soft fields nil.
  - DMBurstTCHSpeechSoft: soft twin of DMBurstTCHSpeech reusing the proven
    softType5FromDiffs -> DescrambleTetraSoft -> TCHSpeechFramesSoft chain,
    de-rotated by the same (4-Rotation)&3 as the hard path.
  - DMO replay harness feeds SoftSink and prefers soft with a hard fallback.
  - Failing-first test: at sigma 0.9 soft recovers ~3x the CRC-valid bursts
    hard does (148 vs 48 / 200); clean round-trip pins exact recovery.

#1001 — training-sequence-aided equalizer (named follow-up beyond blind CMA):
  - equalizer.SnapshotLMS: the differential-decoder-safe, midamble-trained
    counterpart of SnapshotCMA. Trains on the known training sequence (no
    constant-modulus spurious minima), applies a frozen per-burst snapshot so
    the constant phase cancels in the differential decode.
  - Failing-first tests: inverts a multipath channel (payload dibit-error
    0.266 -> 0.016), no harm on a clean channel, and beats blind SnapshotCMA
    on a burst-length sequence (0.018 vs 0.750).

Refs #1003, Refs #1001. make vet test green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NrPkQLQFS7xJLBVakdbdfn