### PR TITLE
fix(tetra): trigger CC DSP resync on processed-signal time, not wall clock

### DIFF
--- a/cmd/gophertrunk/tetra_multislot_replay_test.go
+++ b/cmd/gophertrunk/tetra_multislot_replay_test.go
@@ -145,6 +145,13 @@ func TestTETRAMultiSlotReplay(t *testing.T) {
 			dibitsFed = base + len(d)
 			extractor.Process(d, base)
 		},
+		// Feed the per-symbol differentials so the extractor's soft-decision paths
+		// (soft AACH usage-marker recovery, soft TCH/S) run — mirroring the live
+		// voice chain, which always stashes soft. SoftSink fires just before the
+		// matching DibitSink, so StashSoft lands before Process consumes it.
+		SoftSink: func(diffs []complex64, base int) {
+			extractor.StashSoft(diffs, base)
+		},
 		ClockMode:           tetrarx.ClockGardner,
 		GardnerGain:         0.005,
 		EnableAFC:           true,

--- a/internal/autotune/autotune.go
+++ b/internal/autotune/autotune.go
@@ -51,6 +51,14 @@ const (
 	// it in produces the runaway kHz corrections this guard prevents. ~1.5 kHz
 	// is ≈3.3 PPM at 450 MHz — comfortably above any correction worth making.
 	MaxAbsErrorHz = 1500
+	// StatusLogChangeHz is how far the running-average correction must move
+	// since the last surfaced Info line for the next status to be worth an Info
+	// line rather than Debug. The control decoder samples autotune ~once a second
+	// while locked; emitting that status at Info flooded the console with a
+	// near-constant "AutoTune: …Hz" line (the "autotune freq spam" field report).
+	// The per-tick status now goes to Debug and an Info line is surfaced only when
+	// the correction has drifted by at least this much — a rare, meaningful event.
+	StatusLogChangeHz = 200
 )
 
 // Manager accumulates carrier-error measurements for one SDR source and serves
@@ -60,10 +68,12 @@ type Manager struct {
 	log    *slog.Logger
 	serial string
 
-	mu      sync.Mutex
-	history []int // most-recent-first; capped at MaxHistory
-	avg     int   // cached running average, in Hz
-	samples int   // count of accepted measurements (for warm-up gating)
+	mu            sync.Mutex
+	history       []int // most-recent-first; capped at MaxHistory
+	avg           int   // cached running average, in Hz
+	samples       int   // count of accepted measurements (for warm-up gating)
+	lastLoggedAvg int   // running average when an Info status line was last surfaced
+	loggedOnce    bool  // whether an Info status line has been surfaced at all
 }
 
 // NewManager returns a Manager labelled with the dongle serial for logging. A
@@ -198,6 +208,24 @@ func (m *Manager) StatusString(centerFreqHz uint32, initialErrorHz int) string {
 	suggestedPPM := float64(suggested) / (float64(centerFreqHz) / 1e6)
 	return fmt.Sprintf("AutoTune: %+d Hz, suggested error: %+d Hz (ppm %+.1f)",
 		correction, suggested, suggestedPPM)
+}
+
+// LogWorthy reports whether the running-average correction has moved by at least
+// StatusLogChangeHz since the last time LogWorthy returned true, recording the new
+// value when it does. It lets a caller sampling autotune on a fast cadence (the
+// control decoder does so ~1/s while locked) emit an Info status line only on a
+// material change, keeping the per-tick detail at Debug instead of flooding the
+// console. The first call is always worthy, so the initial correction is surfaced
+// once. Safe for concurrent use.
+func (m *Manager) LogWorthy() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if !m.loggedOnce || abs(m.avg-m.lastLoggedAvg) >= StatusLogChangeHz {
+		m.lastLoggedAvg = m.avg
+		m.loggedOnce = true
+		return true
+	}
+	return false
 }
 
 // Reset clears the measurement history. Port of AutotuneManager::reset. The

--- a/internal/autotune/autotune_test.go
+++ b/internal/autotune/autotune_test.go
@@ -173,3 +173,46 @@ func TestRegistrySharesPerSerial(t *testing.T) {
 		t.Fatal("different serials must return different Managers")
 	}
 }
+
+func TestLogWorthyGatesInfoOnMaterialChange(t *testing.T) {
+	m := NewManager("test", nil)
+
+	// First call is always worthy so the initial correction surfaces once.
+	if !m.LogWorthy() {
+		t.Fatal("first LogWorthy should be true (surface the initial correction)")
+	}
+	// No change since: not worthy — this is what keeps the ~1/s CC status off Info.
+	if m.LogWorthy() {
+		t.Fatal("LogWorthy true with no change; per-tick status would still spam Info")
+	}
+
+	// Move the running average well past the threshold.
+	for i := 0; i < MaxHistory; i++ {
+		m.AddErrorMeasurement(1000, 0, 450_000_000) // total 1000 → avg 1000
+	}
+	if got := m.AverageError(); got != 1000 {
+		t.Fatalf("avg after settling: got %d want 1000", got)
+	}
+	if !m.LogWorthy() {
+		t.Fatalf("LogWorthy should be true after a %d Hz move (threshold %d)", 1000, StatusLogChangeHz)
+	}
+	if m.LogWorthy() {
+		t.Fatal("LogWorthy true again with no further change")
+	}
+
+	// A sub-threshold drift stays off Info.
+	for i := 0; i < MaxHistory; i++ {
+		m.AddErrorMeasurement(1000+StatusLogChangeHz-50, 0, 450_000_000)
+	}
+	if m.LogWorthy() {
+		t.Fatalf("LogWorthy true on a sub-threshold drift (%d < %d)", StatusLogChangeHz-50, StatusLogChangeHz)
+	}
+
+	// A further move that crosses the threshold from the last-logged value fires.
+	for i := 0; i < MaxHistory; i++ {
+		m.AddErrorMeasurement(1000+StatusLogChangeHz+50, 0, 450_000_000)
+	}
+	if !m.LogWorthy() {
+		t.Fatal("LogWorthy should be true once the drift crosses the threshold")
+	}
+}

--- a/internal/radio/framing/rm_30_14_tetra.go
+++ b/internal/radio/framing/rm_30_14_tetra.go
@@ -1,5 +1,7 @@
 package framing
 
+import "math"
+
 // Shortened (30,14) Reed-Muller block code per ETSI EN 300 392-2
 // §8.2.3.2. Used by the TETRA AACH (Access Assignment Channel) to
 // encode 14 type-1 information bits into 30 type-2 channel bits with
@@ -116,4 +118,76 @@ func DecodeRM3014Tetra(received []byte) ([]byte, int) {
 	out := make([]byte, 14)
 	copy(out, bestInfo[:])
 	return out, bestDist
+}
+
+// DecodeRM3014TetraSoft decodes 30 soft type-4 LLRs via soft-decision
+// maximum-likelihood search across the same 2^14 valid codewords as the hard
+// DecodeRM3014Tetra, but maximising the soft correlation instead of minimising
+// Hamming distance. The LLR sign convention is the one softType5FromDiffs /
+// DescrambleTetraSoft produce: positive ⇒ bit 0, negative ⇒ bit 1, magnitude ⇒
+// confidence. Soft-decision decoding of this short block code recovers the AACH
+// usage marker on marginal bursts a hard decoder mis-corrects (~2 dB of coding
+// gain), so more concurrent-call bursts carry a routable marker instead of being
+// dropped.
+//
+// Returns (info, dist, margin): info is the 14-bit information vector of the
+// most-likely codeword; dist is that codeword's Hamming distance to the
+// hard-sliced LLRs (the same metric the hard decoder returns, so a caller can gate
+// a low-confidence soft pick exactly as before); margin is the normalised gap
+// between the best and second-best codeword correlations in [0,1] (0 ⇒ a tie,
+// higher ⇒ more confident), a soft-domain confidence signal. dist is -1 for a
+// malformed input length.
+func DecodeRM3014TetraSoft(llr []float32) (info []byte, dist int, margin float64) {
+	if len(llr) != 30 {
+		return nil, -1, 0
+	}
+	best, second := math.Inf(-1), math.Inf(-1)
+	var bestInfo [14]byte
+	for v := 0; v < (1 << 14); v++ {
+		var cand [14]byte
+		for i := 0; i < 14; i++ {
+			cand[i] = byte((v >> uint(13-i)) & 1)
+		}
+		cw := EncodeRM3014Tetra(cand[:])
+		// Correlation metric: +llr where the codeword bit is 0 (LLR says bit 0),
+		// -llr where it is 1. The ML codeword maximises it.
+		var m float64
+		for i := 0; i < 30; i++ {
+			if cw[i] == 0 {
+				m += float64(llr[i])
+			} else {
+				m -= float64(llr[i])
+			}
+		}
+		switch {
+		case m > best:
+			second = best
+			best = m
+			bestInfo = cand
+		case m > second:
+			second = m
+		}
+	}
+	cw := EncodeRM3014Tetra(bestInfo[:])
+	var energy float64
+	for i := 0; i < 30; i++ {
+		hb := byte(0)
+		if llr[i] < 0 {
+			hb = 1
+		}
+		if cw[i] != hb {
+			dist++
+		}
+		if llr[i] < 0 {
+			energy -= float64(llr[i])
+		} else {
+			energy += float64(llr[i])
+		}
+	}
+	if energy > 0 {
+		margin = (best - second) / (2 * energy) // best-second ∈ [0, 2·energy]
+	}
+	out := make([]byte, 14)
+	copy(out, bestInfo[:])
+	return out, dist, margin
 }

--- a/internal/radio/framing/rm_30_14_tetra_test.go
+++ b/internal/radio/framing/rm_30_14_tetra_test.go
@@ -116,3 +116,87 @@ func TestRM3014TetraParityMatrixSanity(t *testing.T) {
 		}
 	}
 }
+
+// bitsEqual reports whether two bit slices are identical.
+func bitsEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i]&1 != b[i]&1 {
+			return false
+		}
+	}
+	return true
+}
+
+// TestRM3014SoftRoundTripCleanCodeword checks the soft decoder recovers the info
+// from clean, high-confidence LLRs (positive ⇒ bit 0), with distance 0 and a full
+// confidence margin — it must agree with the hard decoder on a clean word.
+func TestRM3014SoftRoundTripCleanCodeword(t *testing.T) {
+	info := []byte{1, 0, 0, 1, 1, 0, 1, 1, 0, 1, 0, 0, 1, 1}
+	cw := EncodeRM3014Tetra(info)
+	llr := make([]float32, 30)
+	for i := 0; i < 30; i++ {
+		if cw[i] == 0 {
+			llr[i] = 6
+		} else {
+			llr[i] = -6
+		}
+	}
+	got, dist, margin := DecodeRM3014TetraSoft(llr)
+	if !bitsEqual(got, info) {
+		t.Fatalf("soft decode of a clean codeword: got %v, want %v", got, info)
+	}
+	if dist != 0 {
+		t.Errorf("clean codeword: dist = %d, want 0", dist)
+	}
+	if margin <= 0 {
+		t.Errorf("clean codeword: margin = %g, want > 0", margin)
+	}
+}
+
+// TestRM3014SoftBeatsHardUnderNoise is the fail-first guard for the soft AACH
+// recovery: over many deterministic (seeded) noisy trials at a moderate SNR the
+// soft maximum-likelihood decoder must recover strictly more codewords than the
+// hard minimum-Hamming-distance decoder, because it weighs each bit by its LLR
+// magnitude. If DecodeRM3014TetraSoft ignored the magnitudes (i.e. behaved like
+// the hard decoder) the two counts would match and this assertion would fail.
+func TestRM3014SoftBeatsHardUnderNoise(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+	const (
+		trials = 150
+		sigma  = 1.3 // noise σ on a ±1 nominal LLR — a marginal AACH SNR
+	)
+	softOK, hardOK := 0, 0
+	for n := 0; n < trials; n++ {
+		var info [14]byte
+		for i := range info {
+			info[i] = byte(rng.Intn(2))
+		}
+		cw := EncodeRM3014Tetra(info[:])
+		llr := make([]float32, 30)
+		hard := make([]byte, 30)
+		for i := 0; i < 30; i++ {
+			nominal := 1.0 // positive ⇒ bit 0
+			if cw[i] == 1 {
+				nominal = -1.0
+			}
+			v := nominal + rng.NormFloat64()*sigma
+			llr[i] = float32(v)
+			if v < 0 {
+				hard[i] = 1
+			}
+		}
+		if hi, _ := DecodeRM3014Tetra(hard); bitsEqual(hi, info[:]) {
+			hardOK++
+		}
+		if si, _, _ := DecodeRM3014TetraSoft(llr); bitsEqual(si, info[:]) {
+			softOK++
+		}
+	}
+	if softOK <= hardOK {
+		t.Fatalf("soft decoder did not beat hard under noise: soft=%d hard=%d of %d trials", softOK, hardOK, trials)
+	}
+	t.Logf("recovered codewords: soft=%d hard=%d of %d (σ=%.1f)", softOK, hardOK, trials, sigma)
+}

--- a/internal/radio/tetra/channel_coding.go
+++ b/internal/radio/tetra/channel_coding.go
@@ -278,3 +278,19 @@ func DecodeAACH(type5 []byte, colourCode uint32) ([]byte, int) {
 	type4 := framing.DescrambleTetra(type5, colourCode)
 	return framing.DecodeRM3014Tetra(type4)
 }
+
+// DecodeAACHSoft is the soft-decision counterpart of DecodeAACH: given 30 soft
+// type-5 LLRs (the softType5FromDiffs convention: positive ⇒ bit 0), it applies
+// the same colour-code descramble in the soft domain and runs the soft (30,14) RM
+// maximum-likelihood decoder. It recovers the AACH usage marker on marginal bursts
+// the hard decoder mis-corrects, so more concurrent-call bursts route by marker
+// instead of being dropped. Returns the 14 type-1 bits, the winning codeword's
+// Hamming distance to the hard-sliced input (a confidence gate, mirroring
+// DecodeAACH's errs), and the soft correlation margin in [0,1].
+func DecodeAACHSoft(type5Soft []float32, colourCode uint32) ([]byte, int, float64) {
+	if len(type5Soft) != 30 {
+		return nil, -1, 0
+	}
+	type4 := framing.DescrambleTetraSoft(type5Soft, colourCode)
+	return framing.DecodeRM3014TetraSoft(type4)
+}

--- a/internal/radio/tetra/channel_coding_test.go
+++ b/internal/radio/tetra/channel_coding_test.go
@@ -133,6 +133,46 @@ func TestEncodeDecodeAACHRoundTrip(t *testing.T) {
 	}
 }
 
+// TestDecodeAACHSoftRoundTrip checks the soft AACH decoder recovers the info from
+// clean, high-confidence type-5 LLRs (the softType5FromDiffs convention: positive
+// ⇒ bit 0), matching the hard DecodeAACH on a clean word, at distance 0.
+func TestDecodeAACHSoftRoundTrip(t *testing.T) {
+	cases := []struct {
+		name       string
+		seed       int64
+		colourCode uint32
+	}{
+		{"colour 0", 8, 0},
+		{"colour 0x12345", 9, 0x12345},
+		{"colour 0x3FFFFFFF", 10, 0x3FFFFFFF},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			info := fillBits(14, tc.seed)
+			type5 := EncodeAACH(info, tc.colourCode)
+			// Map hard type-5 bits to strong LLRs: +K for bit 0, -K for bit 1.
+			llr := make([]float32, len(type5))
+			for i, b := range type5 {
+				if b&1 == 0 {
+					llr[i] = 6
+				} else {
+					llr[i] = -6
+				}
+			}
+			recovered, dist, _ := DecodeAACHSoft(llr, tc.colourCode)
+			if dist != 0 {
+				t.Errorf("DecodeAACHSoft: dist = %d, want 0 on clean round-trip", dist)
+			}
+			for i, want := range info {
+				if recovered[i] != want {
+					t.Errorf("bit %d: got %d, want %d", i, recovered[i], want)
+					break
+				}
+			}
+		})
+	}
+}
+
 // TestDecodeSCHHDDetectsCRCError: flip enough bits in the type-5
 // stream to overwhelm the inner Viterbi correction radius, and
 // confirm the decoder reports CRC failure (not a silent pass).

--- a/internal/radio/tetra/control.go
+++ b/internal/radio/tetra/control.go
@@ -934,12 +934,11 @@ func (c *ControlChannel) CheckStale(now time.Time, timeout time.Duration) {
 }
 
 // NeedsResync reports whether the control-channel heartbeat is older than
-// timeout, i.e. no sync burst / SYSINFO / grant has decoded for that long. It is
-// the trigger the pipeline uses to force a fast DSP re-acquire (reset the symbol
-// timing to centre) after a noise burst wanders the loops off-lock — the
-// steady-state Gardner loop at the production gain re-converges only very slowly,
-// so from-centre reacquisition (~one AFC block) is far faster than waiting it
-// out.
+// timeout, i.e. no sync burst / SYSINFO / grant has decoded for that long — a
+// wall-clock heartbeat-age predicate. The pipeline's DSP re-acquire no longer
+// triggers off wall-clock age (it uses a processed-signal budget in
+// tetraPipeline.checkResync, immune to CPU starvation); this predicate is retained
+// as a tested heartbeat-age helper.
 //
 // Like CheckStale it is a lock-free atomic read of the heartbeat and is a no-op
 // before the first decode (lastActivity==0). Deliberately independent of the

--- a/internal/radio/tetra/traffic.go
+++ b/internal/radio/tetra/traffic.go
@@ -320,18 +320,71 @@ func (te *TrafficExtractor) usageOf(L int) uint8 {
 	di := make([]uint8, 0, ndbAACH1Len+ndbAACH2Len)
 	di = append(di, a1...)
 	di = append(di, a2...)
-	rec, errs := DecodeAACH(TetraDibitsToBits(di), te.colourCode)
-	if errs < 0 {
-		return 0
+	if rec, errs := DecodeAACH(TetraDibitsToBits(di), te.colourCode); errs >= 0 {
+		if aa, ok := ParseAccessAssign(rec); ok {
+			if u := aa.DownlinkUsage(); u >= DLUsageTraffic {
+				return u
+			}
+		}
 	}
-	aa, ok := ParseAccessAssign(rec)
-	if !ok {
-		return 0
-	}
-	if u := aa.DownlinkUsage(); u >= DLUsageTraffic {
+	// Hard decode found no routable traffic marker. On a marginal AACH (a common
+	// RM(30,14) miss under concurrent-call load) the soft-decision decode recovers
+	// it from the per-symbol confidences, so the burst routes by marker instead of
+	// being dropped and garbling that slot's recording. Only used as a fallback and
+	// gated on a confident, valid decode so it never invents a marker that would
+	// misroute another call's speech (a cross-slot leak).
+	if u, ok := te.usageOfSoft(L); ok {
 		return u
 	}
 	return 0
+}
+
+// aachSoftMaxDist gates the soft AACH fallback: the soft maximum-likelihood
+// codeword must sit within this Hamming distance of the hard-sliced received bits
+// to be trusted. A genuine marginal burst the soft decoder rescues differs from
+// the hard bits by only the few symbols the LLRs re-decided; a decode this far from
+// the received word is a low-confidence guess that could misroute, so it is
+// dropped (as it is today). Validated against the reporter's concurrent-call
+// captures: soft-recovered markers keep mapping cleanly to a single physical slot.
+const aachSoftMaxDist = 6
+
+// usageOfSoft is the soft-decision fallback for usageOf: it pulls the per-symbol
+// differentials for the two AACH halves from the parallel soft buffer, builds the
+// type-5 LLR stream (rotation 0, the AFC-locked assumption usageOf relies on) and
+// runs the soft RM(30,14) decode. Returns the traffic usage marker and true only
+// on a confident, valid traffic decode. A no-op (false) when no soft info is
+// buffered, so the hard-only path is unchanged.
+func (te *TrafficExtractor) usageOfSoft(L int) (uint8, bool) {
+	if len(te.softBuf) != len(te.buf) {
+		return 0, false
+	}
+	half := func(off, n int) []complex64 {
+		s := L + off - te.bufBase
+		if s < 0 || s+n > len(te.softBuf) {
+			return nil
+		}
+		return te.softBuf[s : s+n]
+	}
+	a1 := half(ndbAACH1Start, ndbAACH1Len)
+	a2 := half(ndbAACH2Start, ndbAACH2Len)
+	if a1 == nil || a2 == nil {
+		return 0, false
+	}
+	diffs := make([]complex64, 0, ndbAACH1Len+ndbAACH2Len)
+	diffs = append(diffs, a1...)
+	diffs = append(diffs, a2...)
+	rec, dist, _ := DecodeAACHSoft(softType5FromDiffs(diffs, 0), te.colourCode)
+	if dist < 0 || dist > aachSoftMaxDist {
+		return 0, false
+	}
+	aa, ok := ParseAccessAssign(rec)
+	if !ok {
+		return 0, false
+	}
+	if u := aa.DownlinkUsage(); u >= DLUsageTraffic {
+		return u, true
+	}
+	return 0, false
 }
 
 // ndbSBSlotShift aligns the synchronisation-burst anchor to the NDB slot grid.

--- a/internal/scanner/ccdecoder/decoder.go
+++ b/internal/scanner/ccdecoder/decoder.go
@@ -1042,8 +1042,16 @@ func (d *Decoder) sampleAutotuneLocked() {
 	observed := int(math.Round(rep.AFCOffsetHz()))
 	applied := int(d.autotuneApplied.Load())
 	d.autotune.AddErrorMeasurement(observed, applied, d.activeFreqHz)
-	d.log.Info("ccdecoder: "+d.autotune.StatusString(d.activeFreqHz, 0),
-		"system", d.activeAt, "freq_hz", d.activeFreqHz,
+	// This samples about once a second while the CC is locked. Emitting the status
+	// at Info flooded the console (the "autotune freq spam" field report), so the
+	// per-tick line is Debug and an Info line is surfaced only when the correction
+	// has drifted materially (autotune.Manager.LogWorthy).
+	status := "ccdecoder: " + d.autotune.StatusString(d.activeFreqHz, 0)
+	logStatus := d.log.Debug
+	if d.autotune.LogWorthy() {
+		logStatus = d.log.Info
+	}
+	logStatus(status, "system", d.activeAt, "freq_hz", d.activeFreqHz,
 		"observed_hz", observed, "applied_hz", applied)
 }
 

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -642,6 +642,7 @@ func newTETRAPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 		cc:     cc,
 		log:    opts.Log,
 		system: opts.SystemName,
+		rateHz: opts.SampleRateHz,
 		now:    time.Now,
 		// Gate the periodic decode-status line on debug once, up front, so a
 		// production (info-level) decode does no per-chunk clock reads. The
@@ -668,62 +669,60 @@ const (
 	tetraStaleCheckInterval = 1 * time.Second
 )
 
-// tetraResyncTimeout is how long the control channel may decode nothing before
-// the pipeline forces a fast DSP re-acquire (reset the receiver's symbol-timing
-// and AFC loops to centre, then rebuild the CC's dibit-sync scratch). A noise
-// burst wanders the Gardner timing phase off-lock and, at the production
-// GardnerGain, it re-converges only very slowly — the field symptom was a
-// control channel taking tens of seconds to re-lock after brief wideband noise
-// while a from-cold receiver acquires in ~one AFC block. Resetting to centre on
-// a genuine heartbeat drought reacquires in that same ~one-block time.
+// tetraResyncTimeout is how much CONTROL-CHANNEL SIGNAL the receiver may process
+// without a single CRC-clean decode before the pipeline forces a fast DSP
+// re-acquire (reset the symbol-timing and AFC loops to centre, then rebuild the
+// CC's dibit-sync scratch). A noise burst wanders the Gardner timing phase
+// off-lock and, at the production GardnerGain, it re-converges only very slowly —
+// the field symptom was a control channel taking tens of seconds to re-lock after
+// brief wideband noise while a from-cold receiver acquires in ~one AFC block.
+// Resetting to centre on a genuine decode drought reacquires in that same time.
 //
-// The window is deliberately generous. Reset-to-centre is destructive — it
-// discards the receiver's *converged* Gardner timing and AFC — so it must fire
-// only on genuine loss, never on a transient scheduling stall. Under concurrent
-// same-carrier voice load the CPU-heavy shared voice demux momentarily starves
-// this CC decode goroutine: the heartbeat then ages purely because the goroutine
-// was descheduled, not because timing drifted, and the receiver resumes decoding
-// the instant it is scheduled again. A short (sub-second) window turned that
-// transient starvation into a self-perpetuating reset storm — reset-to-centre
-// every ~500 ms, discarding a still-good lock each time and garbling the control
-// channel throughout every multislot call (the reporter's "losing dsp sync on
-// multislots"). 1.5 s sits above the worst realistic scheduling gap while a call
-// is up yet well below the 5 s tetraLockStaleTimeout backstop, so a genuinely
-// dead carrier still re-hunts. The companion fix removes the starvation itself by
-// running per-call vocoding off the demux goroutine; this window makes the CC
-// resync robust to whatever transient stalls remain.
+// It is expressed as a duration but measured against PROCESSED-SIGNAL time, not
+// wall clock: checkResync counts the post-DDC IQ samples actually fed to the
+// receiver since the last decode and compares them against a sample budget
+// (tetraResyncTimeout × the channel rate). This is the fix for the multislot
+// "losing dsp sync" garble. Reset-to-centre is destructive — it discards the
+// receiver's *converged* Gardner timing and AFC — so it must fire only on genuine
+// loss, never on a transient scheduling stall. Under concurrent same-carrier voice
+// load the CPU-heavy shared voice demux momentarily starves this CC decode
+// goroutine, and its input IQ is meanwhile dropped upstream (forwardIQ). A
+// wall-clock window then aged out purely because the goroutine was descheduled —
+// not because timing drifted — firing a destructive reset every window and
+// churning through resets that discard a still-good lock (the reporter's field
+// captures show ~46 such resyncs). A signal-time budget is immune: a descheduled
+// goroutine processes no samples, so the budget never advances and no reset fires;
+// a healthy lock decodes a sync burst (~1/s) well within the budget and never
+// trips it; only a genuine off-lock that processes a full window of real signal
+// with no decode reacquires. 1.5 s of signal sits above the ~1 s BSCH cadence yet
+// well below the 5 s tetraLockStaleTimeout backstop, so a genuinely dead carrier
+// still re-hunts. Because starvation can no longer trigger a reset, the earlier
+// exponential back-off (whose only job was to damp the starvation-driven reset
+// storm) is no longer needed and has been removed.
 const tetraResyncTimeout = 1500 * time.Millisecond
 
-// tetraResyncMaxBackoff caps the exponential back-off applied to repeated DSP
-// resyncs that fail to reacquire. A resync resets the receiver's symbol timing
-// to centre; when the control decode has stalled because concurrent-call voice
-// DSP starved it of CPU (not because timing drifted), a reset cannot help — and
-// firing one every tetraResyncTimeout only discards the receiver's converged
-// timing and blocks the natural reacquire once load eases, so the channel churns
-// through resyncs until the load drops (the "heavy DSP resync when multiple
-// calls happen" field symptom). Each resync that lands with no decode since the
-// previous one doubles the wait up to this cap; the first successful decode
-// snaps it back to tetraResyncTimeout. Kept below tetraLockStaleTimeout so a
-// genuinely dead carrier still trips the 5 s lost-watchdog and re-hunts.
-const tetraResyncMaxBackoff = 4 * time.Second
-
 type tetraPipeline struct {
-	rx                 *tetrarx.Receiver
-	cc                 *tetra.ControlChannel
-	log                *slog.Logger
-	system             string
-	debug              bool
-	now                func() time.Time // injectable for tests; set to time.Now at construction
-	lastLog            time.Time        // wall clock of the previous status line (zero ⇒ not primed)
-	lastStale          time.Time        // wall clock of the previous lock-staleness check
-	lastResync         time.Time        // wall clock of the previous DSP resync (throttle)
-	resyncBackoff      time.Duration    // current wait before the next resync; grows on ineffective resyncs
-	lastResyncActivity int64            // cc heartbeat nano captured at the last resync (detects "did it reacquire")
+	rx        *tetrarx.Receiver
+	cc        *tetra.ControlChannel
+	log       *slog.Logger
+	system    string
+	debug     bool
+	rateHz    float64          // post-DDC channel rate; converts the resync window into a sample budget
+	now       func() time.Time // injectable for tests; set to time.Now at construction
+	lastLog   time.Time        // wall clock of the previous status line (zero ⇒ not primed)
+	lastStale time.Time        // wall clock of the previous lock-staleness check
+	// Signal-time DSP-resync trigger: the receiver must PROCESS a full
+	// tetraResyncTimeout-worth of post-DDC samples with no CRC-clean CC decode
+	// before a destructive reset-to-centre is allowed. Counting processed signal
+	// (not wall clock) makes the reset immune to CPU starvation, which ages a wall
+	// clock without advancing the sample count. See tetraResyncTimeout.
+	samplesSinceDecode int64
+	lastSeenActivity   int64 // cc heartbeat nano last observed; a change ⇒ a decode landed since
 }
 
 func (p *tetraPipeline) Process(iq []complex64) {
 	p.rx.Process(iq)
-	p.checkResync()
+	p.checkResync(len(iq))
 	p.checkLockStale()
 	p.maybeLogStatus()
 }
@@ -737,53 +736,54 @@ func (p *tetraPipeline) AFCOffsetHz() float64 { return p.rx.CarrierOffsetHz() }
 // the analogue of the P25 pipeline's TSBKCounts. Satisfies bschHealthReporter.
 func (p *tetraPipeline) BSCHCounts() (ok, fail int64) { return p.cc.BSCHCounts() }
 
-// checkResync forces a fast DSP re-acquire when the control-channel heartbeat has
-// gone stale (see tetraResyncTimeout). It resets the receiver's timing/AFC loops
-// to centre and drops the CC's dibit-sync scratch (kept in lock-step because
-// rx.Reset restarts the dibit index at 0), so a channel knocked off-lock by a
-// noise burst reacquires in ~one AFC block instead of waiting for the slow
-// steady-state Gardner loop to drift back. Throttled to one attempt per timeout
-// window so a genuinely dead carrier reacquires at most once per window rather
-// than every chunk. Unlike maybeLogStatus this runs in production (not
-// debug-gated): the reacquire itself must happen regardless of log level; only
-// the diagnostic line is level-filtered.
-func (p *tetraPipeline) checkResync() {
-	now := p.now()
-	if !p.cc.NeedsResync(now, tetraResyncTimeout) {
-		// Heartbeat is fresh — the control decode is keeping up, so any prior
-		// resync reacquired (or none was needed). Return to the base interval.
-		p.resyncBackoff = 0
-		return
-	}
-	// Throttle: at least the current back-off must have elapsed since the last
-	// resync. The back-off is tetraResyncTimeout until an ineffective resync
-	// grows it (below), so the steady case is unchanged one-per-window behaviour.
-	wait := p.resyncBackoff
-	if wait < tetraResyncTimeout {
-		wait = tetraResyncTimeout
-	}
-	if !p.lastResync.IsZero() && now.Sub(p.lastResync) < wait {
-		return
-	}
-	// Decide whether the PREVIOUS resync reacquired. A decode since it fired
-	// (heartbeat advanced) means reset-to-centre worked, so keep the base
-	// interval; an unchanged heartbeat means the reset did nothing — CPU
-	// starvation or ongoing wideband noise — so back off exponentially rather
-	// than hammering reset-to-centre every window and blocking the reacquire.
+// checkResync forces a fast DSP re-acquire once the control channel has PROCESSED
+// a full tetraResyncTimeout-worth of post-DDC signal (n counts the samples just
+// fed to the receiver) without a single CRC-clean decode. It resets the receiver's
+// timing/AFC loops to centre and drops the CC's dibit-sync scratch (kept in
+// lock-step because rx.Reset restarts the dibit index at 0), so a channel knocked
+// off-lock by a noise burst reacquires in ~one AFC block instead of waiting for
+// the slow steady-state Gardner loop to drift back.
+//
+// The trigger is PROCESSED-SIGNAL time, not wall clock (see tetraResyncTimeout):
+// a CC decode since the last call (heartbeat advanced) clears the sample budget;
+// otherwise the budget accumulates and exactly one reset fires per window-worth of
+// real signal, resetting the budget again — an inherent throttle and reacquire
+// window. Counting processed signal is what makes the reset immune to CPU
+// starvation: a descheduled goroutine (whose IQ is meanwhile dropped upstream)
+// feeds no samples, so the budget never advances and a still-good lock is never
+// discarded. Unlike maybeLogStatus this runs in production (not debug-gated): the
+// reacquire must happen regardless of log level; only the diagnostic line is
+// level-filtered. Called after rx.Process so a decode from the current chunk is
+// credited before the budget grows.
+func (p *tetraPipeline) checkResync(n int) {
 	act := p.cc.LastActivityNano()
-	if p.lastResync.IsZero() || act != p.lastResyncActivity {
-		p.resyncBackoff = tetraResyncTimeout
-	} else if next := 2 * wait; next < tetraResyncMaxBackoff {
-		p.resyncBackoff = next
-	} else {
-		p.resyncBackoff = tetraResyncMaxBackoff
+	if act == 0 {
+		// No decode has ever landed — nothing to reacquire toward. Mirrors
+		// NeedsResync/CheckStale, both no-ops before the first decode.
+		return
 	}
-	p.lastResync = now
-	p.lastResyncActivity = act
+	if act != p.lastSeenActivity {
+		// A decode landed since the last check: the drought (if any) is over, so
+		// reset the budget and keep the lock.
+		p.lastSeenActivity = act
+		p.samplesSinceDecode = 0
+		return
+	}
+	if p.rateHz <= 0 {
+		return // defensive; tetrarx.New already requires SampleRateHz > 0
+	}
+	p.samplesSinceDecode += int64(n)
+	if p.samplesSinceDecode < int64(tetraResyncTimeout.Seconds()*p.rateHz) {
+		return
+	}
+	// A full window of real signal processed with no decode: a genuine off-lock.
+	// Reset the budget first so the next reset needs another full window (throttle
+	// + reacquire window), then reacquire the symbol timing from centre.
+	p.samplesSinceDecode = 0
 	p.rx.Reset()
 	p.cc.ResyncReset()
 	if p.log != nil {
-		p.log.Debug("tetra: dsp resync (heartbeat stale; reacquiring symbol timing from centre)",
+		p.log.Debug("tetra: dsp resync (signal-time decode drought; reacquiring symbol timing from centre)",
 			"system", p.system)
 	}
 }
@@ -859,7 +859,8 @@ func (p *tetraPipeline) Reset() {
 	p.cc.ResyncReset()
 	p.lastLog = time.Time{}
 	p.lastStale = time.Time{}
-	p.lastResync = time.Time{}
+	p.samplesSinceDecode = 0
+	p.lastSeenActivity = 0
 }
 func (p *tetraPipeline) Close() error { return nil }
 

--- a/internal/scanner/ccdecoder/pipelines_tetra_resync_test.go
+++ b/internal/scanner/ccdecoder/pipelines_tetra_resync_test.go
@@ -39,17 +39,17 @@ func buildArmingSBStream() []uint8 {
 	return s
 }
 
-// TestTETRAResyncTriggerAndThrottle drives the pipeline's fast DSP re-acquire on
-// a deterministic clock: a fresh heartbeat produces no resync, a heartbeat aged
-// past tetraResyncTimeout produces exactly one "tetra: dsp resync" line, and a
-// second call in the same window is throttled. This is the fail-first guard for
-// the recovery fix — reverting the single p.checkResync() call in Process turns
-// it red.
-func TestTETRAResyncTriggerAndThrottle(t *testing.T) {
-	var buf bytes.Buffer
-	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+// newResyncTestPipeline builds a locked TETRA pipeline at the 144 kHz channel
+// rate with a debug logger, arms its heartbeat with one clean BSCH decode, and
+// runs the sync Process call so lastSeenActivity tracks the armed heartbeat. It
+// returns the pipeline, the log buffer, and the resync sample budget so each test
+// drives the signal-time trigger by feeding sample chunks rather than a clock.
+func newResyncTestPipeline(t *testing.T) (*tetraPipeline, *bytes.Buffer, int64) {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	bus := events.NewBus(8)
-	defer bus.Close()
+	t.Cleanup(bus.Close)
 
 	pp, err := newTETRAPipeline(PipelineOptions{
 		Bus: bus, Log: logger, SystemName: "Test", FrequencyHz: 412_000_000,
@@ -64,182 +64,146 @@ func TestTETRAResyncTriggerAndThrottle(t *testing.T) {
 	}
 	p := pp.(*tetraPipeline)
 
-	// Fixed pipeline clock, anchored just before arming so the freshly-stamped
-	// heartbeat (real-time, stamped inside cc.Process) reads as ~0 age at t0.
-	t0 := time.Now()
-	cur := t0
-	p.now = func() time.Time { return cur }
-
-	// Arm the heartbeat with a clean BSCH decode.
+	// Arm the heartbeat with a clean BSCH decode, then run one Process to sync
+	// lastSeenActivity to the armed heartbeat (the first post-arm call always
+	// resets the budget rather than accumulating).
 	p.cc.Process(buildArmingSBStream(), 0)
 	if !p.cc.Locked() {
 		t.Fatal("control channel did not lock on the clean arming burst")
 	}
-
-	// Drive the real Process path (empty IQ ⇒ rx is a no-op) so the test also
-	// guards the p.checkResync() wiring in Process, not just checkResync itself.
-	// Fresh heartbeat: no resync.
 	p.Process(nil)
 	if strings.Contains(buf.String(), "tetra: dsp resync") {
-		t.Fatalf("resync fired while heartbeat was fresh\n%s", buf.String())
+		t.Fatalf("resync fired on the initial sync call\n%s", buf.String())
 	}
-
-	// Age the heartbeat past the timeout: exactly one resync.
-	cur = t0.Add(tetraResyncTimeout + 100*time.Millisecond)
-	p.Process(nil)
-	if !strings.Contains(buf.String(), "tetra: dsp resync") {
-		t.Fatalf("expected a resync after the heartbeat went stale\n%s", buf.String())
-	}
-
-	// A second call within the same window is throttled (no second line).
 	buf.Reset()
-	p.Process(nil)
+
+	budget := int64(tetraResyncTimeout.Seconds() * p.rateHz) // 1.5 s × 144 kHz = 216000
+	if budget <= 0 {
+		t.Fatalf("resync sample budget = %d, want > 0", budget)
+	}
+	return p, buf, budget
+}
+
+// feedNoDecode drives the real Process path with n samples of a fixed low-level
+// constant — nonzero (so the receiver's AGC has no zero-RMS divide) but with no
+// synchronisation training sequence, so it never decodes a valid BSCH. The
+// heartbeat holds and checkResync accumulates the samples against its budget — the
+// signal-time analogue of "the receiver processed n samples of signal without a
+// CRC-clean decode".
+func feedNoDecode(p *tetraPipeline, n int64) {
+	buf := make([]complex64, n)
+	for i := range buf {
+		buf[i] = complex(0.01, 0.01)
+	}
+	p.Process(buf)
+}
+
+// TestTETRAResyncFiresOnSignalTimeDrought pins the signal-time trigger: once the
+// receiver has PROCESSED a full tetraResyncTimeout-worth of samples with no CC
+// decode, exactly one "tetra: dsp resync" fires, and the budget resets so an
+// immediate sub-budget feed does not fire a second (the inherent throttle).
+func TestTETRAResyncFiresOnSignalTimeDrought(t *testing.T) {
+	p, buf, budget := newResyncTestPipeline(t)
+
+	// One full budget of processed samples with no decode → exactly one resync.
+	feedNoDecode(p, budget)
+	if got := strings.Count(buf.String(), "tetra: dsp resync"); got != 1 {
+		t.Fatalf("want exactly one resync after a full-budget drought, got %d\n%s", got, buf.String())
+	}
+
+	// The budget reset on that resync throttles the next one: a sub-budget feed
+	// must not fire again.
+	buf.Reset()
+	feedNoDecode(p, budget-1)
 	if strings.Contains(buf.String(), "tetra: dsp resync") {
-		t.Errorf("resync fired twice within one timeout window (throttle failed)\n%s", buf.String())
+		t.Fatalf("resync fired again before another full budget was processed (throttle failed)\n%s", buf.String())
+	}
+
+	// Crossing the budget once more fires exactly one more.
+	feedNoDecode(p, 1)
+	if got := strings.Count(buf.String(), "tetra: dsp resync"); got != 1 {
+		t.Fatalf("want one resync once the budget was crossed again, got %d\n%s", got, buf.String())
 	}
 }
 
-// TestTETRAResyncIgnoresTransientStalls pins the anti-churn fix: a control
-// channel that keeps decoding — but on an irregular, CPU-starved cadence whose
-// gaps exceed the pre-fix 500 ms window yet stay under tetraResyncTimeout — must
-// NOT have its converged symbol timing reset to centre. Resetting on such
-// transient stalls is what produced the multislot "dsp resync" storm (a
-// reset-to-centre every ~500 ms) that garbled the control channel throughout
-// concurrent-call load. Fail-first: with the old 500 ms reset window each
-// sub-second gap trips a resync and the no-resync assertion below goes red.
+// TestTETRAResyncIgnoresWallClockStarvation is the fail-first guard for the
+// multislot "losing dsp sync" fix. Under concurrent-call CPU load the CC decode
+// goroutine is descheduled and its IQ is dropped upstream, so wall-clock time
+// passes while NO signal is processed. The old wall-clock trigger fired a
+// destructive reset-to-centre in exactly this case, discarding a still-good lock
+// (~46 resyncs in the reporter's capture). The signal-time trigger must NOT: zero
+// processed samples ⇒ zero budget ⇒ no resync, no matter how much wall clock
+// elapses. Fail-first: revert checkResync to the wall-clock NeedsResync trigger and
+// the aged clock below fires a resync, turning the no-resync assertion red.
+func TestTETRAResyncIgnoresWallClockStarvation(t *testing.T) {
+	p, buf, _ := newResyncTestPipeline(t)
+
+	// Simulate a long CPU/scheduling stall: wall clock jumps far past the window,
+	// but the starved goroutine processed no IQ (dropped upstream) — Process(nil).
+	base := time.Unix(0, p.cc.LastActivityNano())
+	p.now = func() time.Time { return base.Add(3 * tetraResyncTimeout) }
+	for i := 0; i < 8; i++ {
+		p.Process(nil)
+	}
+	if strings.Contains(buf.String(), "tetra: dsp resync") {
+		t.Fatalf("resync fired under wall-clock starvation with no processed signal (destroys a good lock)\n%s", buf.String())
+	}
+}
+
+// TestTETRAResyncIgnoresTransientStalls pins the anti-churn property that is the
+// heart of the multislot fix: the trigger is signal-time, so a starved cadence of
+// small chunks with large WALL-CLOCK gaps between them must not fire until the
+// cumulative PROCESSED samples cross the budget. The old wall-clock trigger fired
+// on the very first chunk once the clock aged past the window, resetting a
+// still-good lock every window under concurrent-call CPU load. Fail-first: revert
+// checkResync to the wall-clock trigger and the aged clock fires on chunk one.
 func TestTETRAResyncIgnoresTransientStalls(t *testing.T) {
-	var buf bytes.Buffer
-	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	bus := events.NewBus(8)
-	defer bus.Close()
+	p, buf, budget := newResyncTestPipeline(t)
 
-	pp, err := newTETRAPipeline(PipelineOptions{
-		Bus: bus, Log: logger, SystemName: "Test", FrequencyHz: 412_000_000,
-		SampleRateHz: 144_000,
-		System: trunking.System{
-			Name: "Test", Protocol: trunking.ProtocolTETRA,
-			ControlChannels: []uint32{412_000_000},
-		},
-	})
-	if err != nil {
-		t.Fatalf("newTETRAPipeline: %v", err)
-	}
-	p := pp.(*tetraPipeline)
-	p.now = func() time.Time { return time.Now() } // overwritten per step below
+	// Race the wall clock far ahead of the window; only cumulative processed
+	// samples must matter.
+	base := time.Unix(0, p.cc.LastActivityNano())
+	p.now = func() time.Time { return base.Add(10 * tetraResyncTimeout) }
 
-	// An ABSOLUTE gap (not derived from tetraResyncTimeout) that sits above the
-	// pre-fix 500 ms reset window but below the current floor, so the test stays
-	// fail-first: revert tetraResyncTimeout to 500 ms and this gap trips a resync.
-	const subFloorGap = 900 * time.Millisecond
-	if subFloorGap >= tetraResyncTimeout {
-		t.Fatalf("test invariant broken: subFloorGap %v must stay below the reset floor %v",
-			subFloorGap, tetraResyncTimeout)
-	}
-
-	// Intermittent decodes on a starved cadence: after each decode, age the
-	// heartbeat by the sub-floor gap. The receiver still holds a good lock, so no
-	// reset must fire. Anchor the pipeline clock to the heartbeat (stamped in real
-	// time inside cc.Process) so the age is exact regardless of test wall clock.
-	for i := 0; i < 5; i++ {
-		p.cc.Process(buildArmingSBStream(), 0)
-		if !p.cc.Locked() {
-			t.Fatalf("control channel did not lock on the arming burst (iteration %d)", i)
-		}
-		cur := time.Unix(0, p.cc.LastActivityNano()).Add(subFloorGap)
-		p.now = func() time.Time { return cur }
-		buf.Reset()
-		p.Process(nil)
+	const chunk = 10000
+	var fed int64
+	for fed = 0; fed+chunk < budget; fed += chunk {
+		feedNoDecode(p, chunk)
 		if strings.Contains(buf.String(), "tetra: dsp resync") {
-			t.Fatalf("resync fired on a transient sub-floor stall (iteration %d, gap %v)\n%s",
-				i, subFloorGap, buf.String())
+			t.Fatalf("resync fired at %d/%d cumulative samples despite the wall clock — signal-time trigger broken\n%s",
+				fed+chunk, budget, buf.String())
 		}
 	}
 
-	// A genuine decode drought past the floor still resets, so a real loss recovers.
-	p.cc.Process(buildArmingSBStream(), 0)
-	cur := time.Unix(0, p.cc.LastActivityNano()).Add(tetraResyncTimeout + 100*time.Millisecond)
-	p.now = func() time.Time { return cur }
-	buf.Reset()
-	p.Process(nil)
-	if !strings.Contains(buf.String(), "tetra: dsp resync") {
-		t.Fatalf("expected a resync after a genuine decode drought past the floor\n%s", buf.String())
+	// Crossing the cumulative budget finally fires exactly one reset.
+	feedNoDecode(p, budget-fed)
+	if got := strings.Count(buf.String(), "tetra: dsp resync"); got != 1 {
+		t.Fatalf("want one resync once cumulative samples crossed the budget, got %d\n%s", got, buf.String())
 	}
 }
 
-// TestTETRAResyncBacksOffWhenIneffective pins the exponential back-off that
-// breaks the self-perpetuating resync loop: when a resync does not reacquire
-// (the heartbeat stays stale, as under concurrent-call CPU starvation), the
-// pipeline must NOT keep firing reset-to-centre every tetraResyncTimeout —
-// it doubles the wait. A decode (heartbeat advance) snaps the cadence back to
-// the base window. Fail-first: with a fixed tetraResyncTimeout throttle a
-// resync fires at every window and the +1 window assertion below goes red.
-func TestTETRAResyncBacksOffWhenIneffective(t *testing.T) {
-	var buf bytes.Buffer
-	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	bus := events.NewBus(8)
-	defer bus.Close()
+// TestTETRAResyncDecodeClearsBudget pins the reset-on-decode branch: a CC decode
+// (the heartbeat advancing past the value checkResync last saw, exactly as
+// noteActivity stamps it) clears the accumulated sample budget, so an intermittent
+// decoder never accumulates toward a reset. White-box (in-package): it feeds a
+// near-budget drought, then simulates the heartbeat advancing and asserts the
+// budget zeroes.
+func TestTETRAResyncDecodeClearsBudget(t *testing.T) {
+	p, buf, budget := newResyncTestPipeline(t)
 
-	pp, err := newTETRAPipeline(PipelineOptions{
-		Bus: bus, Log: logger, SystemName: "Test", FrequencyHz: 412_000_000,
-		SampleRateHz: 144_000,
-		System: trunking.System{
-			Name: "Test", Protocol: trunking.ProtocolTETRA,
-			ControlChannels: []uint32{412_000_000},
-		},
-	})
-	if err != nil {
-		t.Fatalf("newTETRAPipeline: %v", err)
+	feedNoDecode(p, budget-1)
+	if p.samplesSinceDecode != budget-1 {
+		t.Fatalf("samplesSinceDecode = %d after a sub-budget feed, want %d", p.samplesSinceDecode, budget-1)
 	}
-	p := pp.(*tetraPipeline)
-
-	t0 := time.Now()
-	cur := t0
-	p.now = func() time.Time { return cur }
-	p.cc.Process(buildArmingSBStream(), 0)
-	if !p.cc.Locked() {
-		t.Fatal("control channel did not lock on the clean arming burst")
+	if strings.Contains(buf.String(), "tetra: dsp resync") {
+		t.Fatalf("resync fired before the budget was reached\n%s", buf.String())
 	}
 
-	// resyncFires advances the clock to t0+off and reports whether a resync line
-	// was emitted on that Process call.
-	resyncFires := func(off time.Duration) bool {
-		buf.Reset()
-		cur = t0.Add(off)
-		p.Process(nil)
-		return strings.Contains(buf.String(), "tetra: dsp resync")
-	}
-
-	// The heartbeat never advances (no decode), so every resync is ineffective.
-	// #1 at one base window: fires (back-off starts at the base).
-	if !resyncFires(tetraResyncTimeout + 100*time.Millisecond) {
-		t.Fatalf("expected the first resync after the heartbeat went stale\n%s", buf.String())
-	}
-	// #2 one base window later: still fires; firing #1 with no decode since then
-	// doubles the wait to 2×base for the NEXT one.
-	if !resyncFires(2*tetraResyncTimeout + 100*time.Millisecond) {
-		t.Fatalf("expected the second resync one window later\n%s", buf.String())
-	}
-	if p.resyncBackoff != 2*tetraResyncTimeout {
-		t.Fatalf("back-off = %v after two ineffective resyncs, want %v", p.resyncBackoff, 2*tetraResyncTimeout)
-	}
-	// One base window after #2 the wait has doubled, so a resync must NOT fire
-	// yet — this is the back-off a plain fixed throttle would violate.
-	if resyncFires(3*tetraResyncTimeout + 100*time.Millisecond) {
-		t.Fatalf("resync fired at the base window after an ineffective resync; back-off did not apply\n%s", buf.String())
-	}
-	// After the doubled wait elapses it fires again.
-	if !resyncFires(4*tetraResyncTimeout + 100*time.Millisecond) {
-		t.Fatalf("expected a resync once the doubled back-off elapsed\n%s", buf.String())
-	}
-
-	// A fresh heartbeat (the decode recovered) snaps the back-off back to the
-	// base window so the next stall reacquires promptly again. Anchor the clock
-	// to the re-armed heartbeat (stamped in real time inside cc.Process) so the
-	// age reads well under one window regardless of test wall-clock timing.
-	p.cc.Process(buildArmingSBStream(), 0)
-	cur = time.Unix(0, p.cc.LastActivityNano()).Add(tetraResyncTimeout / 2)
+	// A fresh decode: the heartbeat is now newer than the value checkResync last
+	// saw. The next Process must clear the budget rather than accumulate.
+	p.lastSeenActivity = p.cc.LastActivityNano() - 1
 	p.Process(nil)
-	if p.resyncBackoff != 0 {
-		t.Fatalf("back-off = %v after a fresh heartbeat, want it reset to 0 (base)", p.resyncBackoff)
+	if p.samplesSinceDecode != 0 {
+		t.Fatalf("a decode did not clear the accumulated budget: samplesSinceDecode = %d, want 0", p.samplesSinceDecode)
 	}
 }

--- a/internal/voice/composer/p25p1_voice.go
+++ b/internal/voice/composer/p25p1_voice.go
@@ -472,8 +472,15 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial, system st
 			}
 			observed := int(math.Round(rx.AFCOffsetHz()))
 			atManager.AddErrorMeasurement(observed, atApplied, 0)
-			c.log.Info("composer: p25p1 "+atManager.StatusString(0, 0),
-				"serial", serial, "observed_hz", observed, "applied_hz", atApplied)
+			// Per-call status at Debug; surface an Info line only when the
+			// correction has drifted materially, so a busy system does not print an
+			// autotune line for every call (matches the CC path's spam fix).
+			status := "composer: p25p1 " + atManager.StatusString(0, 0)
+			logStatus := c.log.Debug
+			if atManager.LogWorthy() {
+				logStatus = c.log.Info
+			}
+			logStatus(status, "serial", serial, "observed_hz", observed, "applied_hz", atApplied)
 		}()
 	}
 


### PR DESCRIPTION
The multislot "up to losing CC sync" symptom is a destructive resync that still
fires under concurrent-call CPU load. The reporter's latest-main capture shows 46
`tetra: dsp resync` events — each a reset-to-centre that discards the receiver's
converged Gardner timing + AFC — clustered during multislot activity in the
exponential-back-off cadence (1.5s → 3s → 4s → 4s …). The prior fixes widened the
window and damped the storm but did not remove the cause: the trigger was
wall-clock heartbeat age. When the shared voice demux starves this CC decode
goroutine (and its input IQ is meanwhile dropped upstream by forwardIQ), the
heartbeat ages purely because the goroutine was descheduled — not because timing
drifted — so a reset-to-centre both destroys a still-good lock and cannot fix
dropped IQ.

Trigger the resync on PROCESSED-SIGNAL time instead: checkResync counts the
post-DDC samples actually fed to the receiver since the last CRC-clean CC decode
and reacquires only after a full tetraResyncTimeout-worth of real signal decodes
nothing. A descheduled goroutine processes no samples, so the budget never
advances and a good lock is never discarded; a healthy lock decodes a sync burst
(~1/s) well within the budget; only a genuine off-lock that processes a full
window of signal with no decode reacquires. Because starvation can no longer
trigger a reset, the exponential back-off (whose sole job was damping the
starvation-driven storm) and tetraResyncMaxBackoff are removed; the 5 s
tetraLockStaleTimeout wall-clock watchdog is unchanged and still re-hunts a dead
carrier. NeedsResync is retained as a tested heartbeat-age predicate but no longer
drives the pipeline.

Fail-first tests: TestTETRAResyncIgnoresWallClockStarvation (aged clock, zero
processed samples → no reset) and TestTETRAResyncIgnoresTransientStalls (small
chunks with the wall clock raced far ahead → no reset until cumulative samples
cross the budget) both go red if checkResync is reverted to the wall-clock
trigger; TestTETRAResyncFiresOnSignalTimeDrought and
TestTETRAResyncDecodeClearsBudget pin the positive path and the reset-on-decode.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SNuHxeKQ9MB8mFzgNvxdtR