### PR TITLE
docs(site): SDR hardware buyer guides & affiliate content

### DIFF
--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -181,6 +181,16 @@ groups:
         url: /best-scanner-antenna/
       - title: "Scanner hardware (Field Guide)"
         url: /reference/#consumer-scanners
+      - title: Best SDR for GopherTrunk
+        url: /best-sdr-for-gophertrunk/
+      - title: What hardware do I need?
+        url: /what-do-i-need-for-gophertrunk/
+      - title: Best RTL-SDR
+        url: /best-rtl-sdr/
+      - title: Best SDR antenna
+        url: /best-sdr-antenna/
+      - title: SDR cables & connectors
+        url: /sdr-cables-and-connectors/
       - title: "SDR devices (Field Guide)"
         url: /reference/#sdr-devices
       - title: SDR hardware setup

--- a/docs/airspy-vs-rtl-sdr-vs-hackrf.md
+++ b/docs/airspy-vs-rtl-sdr-vs-hackrf.md
@@ -1,0 +1,147 @@
+---
+layout: page
+title: "Airspy vs RTL-SDR vs HackRF for Scanning"
+description: "Airspy vs RTL-SDR vs HackRF compared for scanning P25/DMR/NXDN/TETRA with GopherTrunk — 8-bit vs 12-bit ADCs, capture bandwidth, dynamic range, TX, and which to buy by use case."
+keywords: Airspy vs RTL-SDR, Airspy vs HackRF, RTL-SDR vs HackRF, best SDR for scanning, 12-bit SDR, Airspy R2, HackRF One, P25 SDR comparison
+permalink: /airspy-vs-rtl-sdr-vs-hackrf/
+nav_group: Hardware
+affiliate: true
+faq:
+  - q: "Which is best for scanning: Airspy, RTL-SDR, or HackRF?"
+    a: "For most people an RTL-SDR (around $35) is the best value and decodes P25/DMR/NXDN just as well as anything. Step up to a 12-bit Airspy (around $110–170) only when your RF is weak, congested, or you want to channelize many signals from one wideband capture. A HackRF is overkill for scanning — its extra reach and transmit are wasted on receive-only VHF/UHF."
+  - q: "Is an Airspy really better than an RTL-SDR?"
+    a: "In tough conditions, yes. The Airspy's 12-bit ADC has far more dynamic range than an 8-bit RTL-SDR, so it holds onto weak signals in the presence of strong ones without overloading, and its wider capture lets GopherTrunk channelize multiple control channels at once. On a clean, single-site system the RTL-SDR decodes the same voice."
+  - q: "Should I buy a HackRF for GopherTrunk?"
+    a: "Only if you also need its capabilities for other projects. The HackRF covers 1 MHz to 6 GHz and can transmit, but its 8-bit ADC has less dynamic range than an Airspy, and scanning uses none of the 6 GHz reach or TX. GopherTrunk uses it receive-only; it works but is more radio than scanning needs."
+  - q: "Does more bits mean better audio?"
+    a: "Not directly — decoded P25/DMR voice is either recovered or it is not. More ADC bits mean more dynamic range, so a 12-bit Airspy keeps decoding when a strong nearby signal would push an 8-bit RTL-SDR or HackRF into overload. In easy RF the audio is identical; the bits buy you resilience, not fidelity."
+  - q: "Can any of them decode encrypted police?"
+    a: "No. Airspy, RTL-SDR, and HackRF are all just receivers — none can decode AES-encrypted talkgroups, and neither can any scanner. GopherTrunk decodes clear P25/DMR/NXDN/TETRA only. Buy based on the systems still in the clear."
+  - q: "Is the HackRF's transmit useful for scanning?"
+    a: "No. Scanning is receive-only, and GopherTrunk never transmits. HackRF's TX is for other RF projects and legally needs a license. If you only want to scan, you are paying for a feature you will not use."
+---
+
+# Airspy vs RTL-SDR vs HackRF for Scanning
+
+**For scanning with [GopherTrunk](/downloads.html), the honest ranking is:
+[RTL-SDR](/reference/rtl-sdr/) for value, [Airspy](/reference/airspy/) for tough
+RF, [HackRF](/reference/hackrf/) only if you also need its range or transmit.**
+All three are USB [software-defined radios](/reference/software-defined-radio/)
+GopherTrunk drives natively, but they are built for different jobs — and for
+P25/DMR/NXDN trunk-tracking the cheapest one is usually right.
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**RTL-SDR (8-bit, ~$35):** the default — cheap, plenty for a clean single site.
+**Airspy (12-bit, ~$110–170):** far more dynamic range and wider capture — the
+pick for weak, busy, or multi-site RF. **HackRF (8-bit, 1 MHz–6 GHz + TX, ~$150):**
+huge range and transmit, but **overkill for scanning**. **Bits buy dynamic range,
+not audio fidelity.** **None decode [AES encryption](/police-scanner-encryption/).**
+</div>
+
+## Head-to-head
+
+| | [RTL-SDR Blog V4](/reference/rtl-sdr/) | [Airspy R2 / Mini](/reference/airspy/) | [HackRF One](/reference/hackrf/) |
+|---|---|---|---|
+| ADC | 8-bit | **12-bit** | 8-bit |
+| Frequency range | ~500 kHz–1.77 GHz | ~24 MHz–1.8 GHz | **1 MHz–6 GHz** |
+| Capture bandwidth | ~2.4 MHz | ~6–10 MHz | **~20 MHz** |
+| Dynamic range | Fair | **Best** | Fair |
+| Transmit | No | No | **Yes** (licensed) |
+| Best for | Value / single site | Tough / busy / multi-site | Range + TX projects |
+| GopherTrunk uses | RX | RX | **RX only** |
+| Approx price | ~$40 | ~$110–170 | ~$150 |
+
+> **Bits are about dynamic range, not fidelity.** Decoded P25 voice is recovered
+> or it is not — a 12-bit ADC does not make it "sound better." What the extra bits
+> buy is headroom: an Airspy keeps decoding a weak control channel while a strong
+> nearby pager or FM station would drive an 8-bit RTL-SDR or HackRF into
+> [overload](/best-sdr-lna/). In easy RF, all three sound identical.
+
+## When an RTL-SDR is all you need
+
+Most people scanning one local [trunked system](/reference/trunked-radio/) never
+need more than a [$35 RTL-SDR](/best-rtl-sdr/). One dongle follows one control
+channel and its voice grants cleanly, it has a real TCXO so it stays locked, and
+GopherTrunk decodes the same P25/DMR/NXDN/TETRA a radio ten times the price would.
+If your target signal is reasonably strong and you are tracking a single site,
+stop here — spend the savings on a better [antenna](/best-sdr-antenna/) instead.
+
+## When to step up to an Airspy
+
+The [Airspy](/reference/airspy/) earns its price in exactly two situations:
+
+- **Weak or congested RF.** Its 12-bit front end pulls voice out of conditions
+  that push an 8-bit dongle into overload — a distant control channel next to a
+  strong local transmitter, or an intermod-heavy urban band.
+- **Multi-site / wideband monitoring.** With up to ~10 MHz of capture (R2),
+  GopherTrunk can channelize several control channels from one radio at once,
+  instead of running a [pool of dongles](/multi-dongle-sdr-setup/).
+
+If your problem is dynamic range or bandwidth, the Airspy is the right tool. If
+it is simply low signal, an [LNA](/best-sdr-lna/) on any dongle may be the cheaper
+fix first.
+
+## When a HackRF makes sense (rarely, for scanning)
+
+The [HackRF One](/reference/hackrf/) is a superb general-purpose SDR — 1 MHz to
+6 GHz, ~20 MHz capture, and it can **transmit**. GopherTrunk drives it as a
+receiver just fine. But for scanning specifically it is the wrong buy: its 8-bit
+ADC gives it *less* dynamic range than an Airspy, its 6 GHz reach and transmit are
+irrelevant to receive-only VHF/UHF decoding, and transmit legally needs a license.
+Buy a HackRF if you already want it for RF experimentation, satellite work, or
+protocol hacking — and enjoy that it scans too. Do not buy one *just* to scan.
+
+> **GopherTrunk uses receive only.** Even on the HackRF, GopherTrunk never
+> transmits. That is a feature you are paying for and will not use if scanning is
+> your only goal.
+
+## How to choose
+
+- **Single local system, normal signal?** [RTL-SDR](/best-rtl-sdr/). Done.
+- **Weak / busy / intermod-heavy RF?** [Airspy R2 or Mini](/reference/airspy/).
+- **Many sites or control channels across a band?** [Airspy R2](/reference/airspy/)
+  to channelize, or a [multi-dongle pool](/multi-dongle-sdr-setup/).
+- **Want HF too?** An [Airspy HF+ Discovery](/reference/airspy-hf-plus/) or a
+  V4's [upconverter](/reference/upconverter/).
+- **Already own / want a HackRF?** GopherTrunk will use it — just know it is more
+  radio than scanning needs.
+
+## Where to buy
+
+Airspy is sold through distributors rather than direct Amazon listings, so use a
+search link; the HackRF and RTL-SDR have fixed listings.
+
+<div class="pick-cards" markdown="0">
+<div class="pick-card">
+<span class="pick-card__badge">Best value</span>
+<h3>RTL-SDR Blog V4</h3>
+<p class="pick-card__price">around $40</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0CD745394?tag=gophertrunk-20" rel="nofollow sponsored noopener">RTL-SDR on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/rtl-sdr/">RTL-SDR details</a></p>
+</div>
+<div class="pick-card pick-card--top">
+<span class="pick-card__badge">Best for tough RF</span>
+<h3>Airspy R2 / Mini</h3>
+<p class="pick-card__price">around $110–170</p>
+<a class="btn btn--buy" href="https://www.amazon.com/s?k=Airspy+R2+SDR&tag=gophertrunk-20" rel="nofollow sponsored noopener">Airspy on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/airspy/">Airspy details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Range + TX</span>
+<h3>HackRF One (bundle)</h3>
+<p class="pick-card__price">around $150</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0BKH7Z2NJ?tag=gophertrunk-20" rel="nofollow sponsored noopener">HackRF on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/hackrf/">HackRF details</a></p>
+</div>
+</div>
+
+## Bottom line
+
+Buy an **[RTL-SDR](/best-rtl-sdr/)** unless you have a reason not to — it decodes
+the same digital voice for a third the price. Move to a **12-bit
+[Airspy](/reference/airspy/)** when your RF is genuinely weak, busy, or
+multi-site. Reach for a **[HackRF](/reference/hackrf/)** only if you also want its
+6 GHz range or transmit for other projects. Whichever you pick, **no SDR decodes
+[encryption](/police-scanner-encryption/)**, and the [software is free](/downloads.html).
+For the full ranked lineup see the [best SDR for GopherTrunk](/best-sdr-for-gophertrunk/).

--- a/docs/best-hf-sdr.md
+++ b/docs/best-hf-sdr.md
@@ -1,0 +1,130 @@
+---
+layout: page
+title: "Best SDR for HF (Shortwave, Ham, Utility)"
+description: "The best SDR for HF listening — Airspy HF+ Discovery vs the RTL-SDR Blog V4's built-in upconverter vs an external Ham It Up upconverter on a VHF dongle, compared for shortwave, ham, and utility."
+keywords: best HF SDR, Airspy HF+ Discovery, RTL-SDR HF, upconverter, Ham It Up, shortwave SDR, ham radio SDR, utility monitoring, direct sampling, GopherTrunk HF
+permalink: /best-hf-sdr/
+nav_group: Hardware
+affiliate: true
+faq:
+  - q: "What is the best SDR for HF?"
+    a: "For dedicated HF listening the Airspy HF+ Discovery is the clear best pick — its high-dynamic-range front end pulls weak shortwave, ham, and utility signals out of a band full of strong broadcasters. If you also scan VHF/UHF and only dabble in HF, an RTL-SDR Blog V4 with its built-in upconverter is a fine one-radio compromise."
+  - q: "Can an RTL-SDR receive HF?"
+    a: "Yes. The RTL-SDR Blog V4 has a built-in HF upconverter, and the older V3 uses direct sampling, so both cover roughly 500 kHz to 30 MHz out of the box. A plain VHF-only dongle needs an external upconverter such as a Ham It Up to reach HF."
+  - q: "What is an upconverter and do I need one?"
+    a: "An upconverter shifts the HF band up into the VHF range a standard RTL-SDR can tune, so it can hear shortwave. You need one only if your dongle has no HF capability of its own. The RTL-SDR Blog V4 already includes an upconverter internally, so you do not need an external one with it."
+  - q: "Is the Airspy HF+ Discovery worth the extra money over an RTL-SDR?"
+    a: "For HF, yes. HF is a high-dynamic-range environment — a distant weak signal sits right next to a 60 dB stronger broadcaster. The HF+ Discovery's front end handles that far better than an 8-bit RTL-SDR plus upconverter, so weak-signal work is dramatically cleaner."
+  - q: "Does GopherTrunk decode HF signals?"
+    a: "GopherTrunk targets VHF/UHF digital trunking (P25, DMR, NXDN, TETRA), which does not live on HF. Use an HF SDR for shortwave, ham, and utility listening in general SDR software; pick a VHF/UHF dongle for GopherTrunk trunk-tracking. Some people own both."
+  - q: "Will the RTL-SDR Blog V4 do both HF and trunk-tracking?"
+    a: "Yes — it covers HF via its internal upconverter and VHF/UHF for GopherTrunk, making it the most versatile single dongle. It will not match a dedicated Airspy HF+ Discovery on weak HF, but it is the best value if you want one radio for everything."
+---
+
+# Best SDR for HF (Shortwave, Ham, Utility)
+
+**The best SDR for serious HF listening is the [Airspy HF+ Discovery](/reference/airspy-hf-plus/);
+the best value if you also scan VHF/UHF is an [RTL-SDR Blog V4](/reference/rtl-sdr/)
+with its built-in [upconverter](/reference/upconverter/).** HF — shortwave broadcast,
+ham bands, and utility stations — is a different game from VHF/UHF: the band is packed
+with signals of wildly different strengths, so front-end dynamic range matters more
+than anything else.
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Best for HF:** [Airspy HF+ Discovery](/reference/airspy-hf-plus/) (~$170) — outstanding
+dynamic range for weak shortwave/ham/utility. **Best value / one radio:**
+[RTL-SDR Blog V4](/reference/rtl-sdr/) (~$40), HF included via its internal upconverter.
+**Own a VHF-only dongle already?** Add a
+[Ham It Up upconverter](https://www.amazon.com/dp/B009LQT3G6?tag=gophertrunk-20) (~$50).
+**Note:** GopherTrunk decodes VHF/UHF trunking, not HF — this page is for general HF
+listening.
+</div>
+
+## Three ways to get on HF
+
+<div class="pick-cards" markdown="0">
+<div class="pick-card pick-card--top">
+<span class="pick-card__badge">Best for HF</span>
+<h3>Airspy HF+ Discovery</h3>
+<p class="pick-card__price">around $170</p>
+<p>Polyphase-harmonic-rejection front end with exceptional dynamic range. Hears weak DX right next to broadcast blowtorches. HF plus 60–260 MHz.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/s?k=Airspy+HF+Discovery&tag=gophertrunk-20" rel="nofollow sponsored noopener">HF+ on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/airspy-hf-plus/">HF+ details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Best value</span>
+<h3>RTL-SDR Blog V4</h3>
+<p class="pick-card__price">around $40</p>
+<p>HF built in via an internal upconverter, plus full VHF/UHF for GopherTrunk. One dongle covers shortwave and trunk-tracking.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0CD745394?tag=gophertrunk-20" rel="nofollow sponsored noopener">V4 on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/rtl-sdr/">RTL-SDR details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Add-on</span>
+<h3>Ham It Up upconverter</h3>
+<p class="pick-card__price">around $50</p>
+<p>Bolts HF onto any VHF-only RTL-SDR by shifting 0–30 MHz up to where the dongle can tune. Use it to give an existing dongle shortwave.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B009LQT3G6?tag=gophertrunk-20" rel="nofollow sponsored noopener">Ham It Up on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/upconverter/">Upconverter details</a></p>
+</div>
+</div>
+
+## Comparison
+
+| Path | How it reaches HF | HF dynamic range | Also does VHF/UHF? | Approx price |
+|---|---|---|---|---|
+| [Airspy HF+ Discovery](/reference/airspy-hf-plus/) | Native HF front end | Excellent | Yes (60–260 MHz) | ~$170 |
+| [RTL-SDR Blog V4](/reference/rtl-sdr/) | Built-in upconverter | Modest (8-bit) | Yes (full) | ~$40 |
+| [RTL-SDR Blog V3](/reference/rtl-sdr/) | Direct sampling (Q-branch) | Modest, needs care | Yes (full) | ~$45 |
+| VHF dongle + [Ham It Up](/reference/upconverter/) | External upconverter | Modest (8-bit) | Yes (full) | dongle + ~$50 |
+
+## Why HF punishes cheap front ends
+
+On VHF/UHF you usually chase one signal in a fairly quiet neighborhood. **HF is the
+opposite:** the shortwave broadcast bands are jammed with signals, and after dark a
+50 kW international broadcaster can sit a few kilohertz from the faint ham or utility
+station you want. That is a high-dynamic-range problem, and it is exactly where an
+8-bit [RTL-SDR](/reference/rtl-sdr/) struggles — the strong signal drives its front end
+toward overload and buries the weak one.
+
+The [Airspy HF+ Discovery](/reference/airspy-hf-plus/) is engineered specifically for
+this: its high-dynamic-range design and sharp filtering let the weak signal survive next
+to the strong one. That is what you are paying the extra money for, and on HF it is
+worth it.
+
+> **On HF, a [filter](/sdr-filters/) still helps.** Even a good SDR benefits from an
+> [AM broadcast notch](/sdr-filters/) if a local mediumwave station is overwhelming the
+> input. Filtering the interferer out in hardware protects the front end before the ADC.
+
+## Upconverter vs built-in HF
+
+If you are buying fresh and want HF, **do not buy a bare VHF dongle plus an external
+upconverter** — the [RTL-SDR Blog V4](/reference/rtl-sdr/) already has an upconverter
+inside it for around the same total money and far less cabling. An external
+[Ham It Up](https://www.amazon.com/dp/B009LQT3G6?tag=gophertrunk-20) makes sense in one
+situation: **you already own a VHF-only dongle** (an older NESDR, a FlightAware stick)
+and want to add HF without replacing it. The direct-sampling V3 also reaches HF but
+requires more care with imaging and gain than the V4's cleaner upconverter path.
+
+## Where GopherTrunk fits
+
+Be clear about the split: **GopherTrunk decodes VHF/UHF digital trunking** — 
+[P25](/reference/project-25/), DMR, NXDN, TETRA — which does not live on HF. So HF
+capability is a *bonus*, not a GopherTrunk requirement. If you want one radio that does
+GopherTrunk trunk-tracking *and* lets you tune shortwave in other SDR software, the
+[V4](/reference/rtl-sdr/) is the natural choice. If HF weak-signal work is your main
+hobby and trunking is secondary, buy the [HF+ Discovery](/reference/airspy-hf-plus/) for
+HF and a cheap dongle for GopherTrunk.
+
+## Bottom line
+
+For dedicated HF — shortwave DX, ham weak-signal, utility monitoring — the
+**[Airspy HF+ Discovery](/reference/airspy-hf-plus/)** is the best SDR, full stop, thanks
+to its dynamic range. For the best *value*, and for anyone who also wants to run
+GopherTrunk on VHF/UHF, the **[RTL-SDR Blog V4](/reference/rtl-sdr/)** covers HF with its
+built-in [upconverter](/reference/upconverter/) at a fraction of the price. Only reach
+for an external [Ham It Up](https://www.amazon.com/dp/B009LQT3G6?tag=gophertrunk-20) when
+you are adding HF to a dongle you already own. See the full lineup in
+[best SDR for GopherTrunk](/best-sdr-for-gophertrunk/) and the starter list in
+[what do I need](/what-do-i-need-for-gophertrunk/).

--- a/docs/best-rtl-sdr.md
+++ b/docs/best-rtl-sdr.md
@@ -1,0 +1,145 @@
+---
+layout: page
+title: "Best RTL-SDR for Scanning (2026)"
+description: "The best RTL-SDR dongles for scanning P25, DMR, NXDN, and TETRA with GopherTrunk in 2026 — RTL-SDR Blog V4 vs V3 vs NooElec NESDR SMArt v5 vs generic, ranked by need and stock."
+keywords: best RTL-SDR, best RTL-SDR dongle, RTL-SDR Blog V4, RTL-SDR Blog V3, NESDR SMArt v5, RTL-SDR scanning, RTL2832U, P25 RTL-SDR, RTL-SDR for GopherTrunk
+permalink: /best-rtl-sdr/
+nav_group: Hardware
+affiliate: true
+faq:
+  - q: "What is the best RTL-SDR for scanning?"
+    a: "For most people the NooElec NESDR SMArt v5 (around $35) is the best RTL-SDR to buy today — a 0.5 ppm TCXO, aluminium heatsink case, and reliable stock. The RTL-SDR Blog V4 is the enthusiast reference and slightly better on HF, but it is end-of-line, so buy it while stock lasts and treat the NESDR as the always-available pick."
+  - q: "Is the RTL-SDR Blog V4 discontinued?"
+    a: "Effectively yes. The Rafael Micro R828D tuner the V4 depends on is discontinued, so RTL-SDR Blog has said the V4 is the last of that line. It still works perfectly for GopherTrunk, but once current stock sells through, the V3 and NESDR-class R820T2/R860 dongles are what remain."
+  - q: "Do I need the V4, or is a cheaper dongle fine?"
+    a: "A cheaper R820T2/R860 dongle like the NESDR SMArt v5 decodes the exact same P25, DMR, and NXDN voice. The V4's advantages are built-in HF coverage without an upconverter and a bit better front-end filtering — nice to have, not required for VHF/UHF trunk-tracking."
+  - q: "Should I avoid generic $15 RTL-SDR dongles?"
+    a: "For scanning, yes. Generic dongles usually lack a TCXO, so they drift with temperature and lose the control channel, and their cheap regulators add noise. Spend the extra $15–20 on a NESDR SMArt or RTL-SDR Blog unit — it is the difference between a lock and constant retunes."
+  - q: "Can an RTL-SDR decode encrypted police?"
+    a: "No. No RTL-SDR — and no scanner — can decode AES-encrypted talkgroups. GopherTrunk decodes clear P25/DMR/NXDN/TETRA, never keyed encryption. Buy based on the systems in your area that are still in the clear."
+  - q: "How many trunked channels can one RTL-SDR follow?"
+    a: "One dongle cleanly follows one control channel and the voice grants on that site's band. For multi-site systems or control channels spread far apart, GopherTrunk can drive a pool of dongles or a wideband Airspy."
+---
+
+# Best RTL-SDR for Scanning (2026)
+
+**The best RTL-SDR for scanning is the cheapest one with a real TCXO that cleanly
+hears your local control channel** — and in 2026 that is a
+[NooElec NESDR SMArt v5](/reference/nesdr/) or an
+[RTL-SDR Blog V4](/reference/rtl-sdr/) for about $35–40. Both drive
+[GopherTrunk](/downloads.html) — free, open-source
+[software-defined radio](/reference/software-defined-radio/) — as a
+P25/DMR/NXDN/TETRA trunking scanner. The dongle is the only thing you buy.
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Best overall / always in stock:** [NESDR SMArt v5](/reference/nesdr/) (~$35).
+**Enthusiast reference (but end-of-line):** [RTL-SDR Blog V4](/reference/rtl-sdr/) (~$40)
+— buy while stock lasts. **Still great:** [RTL-SDR Blog V3](/reference/rtl-sdr/)
+(~$45 with kit). **Skip:** unbranded $15 dongles with no TCXO. **You only buy the
+radio** — the software is free. **No RTL-SDR decodes
+[AES encryption](/police-scanner-encryption/).**
+</div>
+
+## Quick picks
+
+<div class="pick-cards" markdown="0">
+<div class="pick-card pick-card--top">
+<span class="pick-card__badge">Best overall</span>
+<h3>NooElec NESDR SMArt v5</h3>
+<p class="pick-card__price">around $35</p>
+<p>0.5 ppm TCXO, aluminium heatsink case, R820T2/R860 tuner. The mainstream "just buy this" RTL-SDR — reliable stock and rock-steady control-channel lock.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B01HA642SW?tag=gophertrunk-20" rel="nofollow sponsored noopener">NESDR on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/nesdr/">NESDR details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Enthusiast reference</span>
+<h3>RTL-SDR Blog V4</h3>
+<p class="pick-card__price">around $40</p>
+<p>1 ppm TCXO, built-in HF upconverter, front-end filtering, SMA, switchable bias tee. The reference dongle — but end-of-line, so buy while it is in stock.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0CD745394?tag=gophertrunk-20" rel="nofollow sponsored noopener">V4 on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/rtl-sdr/">RTL-SDR details</a> · <a href="/rtl-sdr-blog-v3-vs-v4/">V3 vs V4</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Best starter bundle</span>
+<h3>RTL-SDR Blog V3 + dipole kit</h3>
+<p class="pick-card__price">around $45</p>
+<p>The proven R860 dongle plus the multipurpose dipole antenna kit. Everything you need to hear a trunked system out of one box.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0BMKB3L47?tag=gophertrunk-20" rel="nofollow sponsored noopener">V3 kit on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/rtl-sdr/">RTL-SDR details</a> · <a href="/best-sdr-antenna/">antenna guide</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Bias-tee variant</span>
+<h3>NESDR SMArTee v2</h3>
+<p class="pick-card__price">around $40</p>
+<p>An always-on 4.5 V bias tee to power a mast-mounted <a href="/best-sdr-lna/">LNA</a> up the coax. The same solid NESDR front end otherwise.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B079C3FHPG?tag=gophertrunk-20" rel="nofollow sponsored noopener">SMArTee on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/bias-tee/">bias-tee details</a></p>
+</div>
+</div>
+
+## Full comparison
+
+| Dongle | Tuner | TCXO | HF | Notes | Approx price |
+|---|---|---|---|---|---|
+| [NESDR SMArt v5](/reference/nesdr/) | R820T2 / R860 | 0.5 ppm | via upconverter | Always in stock, aluminium case | ~$35 |
+| [RTL-SDR Blog V4](/reference/rtl-sdr/) | R828D | 1 ppm | **built-in** | Best filtering; **end-of-line** | ~$40 |
+| [RTL-SDR Blog V3](/reference/rtl-sdr/) | R860 | 1 ppm | direct-sampling Q | Proven, kit includes dipole | ~$45 |
+| [NESDR SMArTee v2](/reference/nesdr/) | R820T2 | 0.5 ppm | via upconverter | Always-on bias tee for an LNA | ~$40 |
+| Generic no-name | R820T2 | usually none | — | Drifts with heat — **skip for scanning** | ~$15 |
+
+> **The TCXO is the whole point.** A trunking scanner has to sit on one control
+> channel for hours. A generic dongle with no temperature-compensated oscillator
+> drifts as it warms up and slides off the control channel; a $35 NESDR or
+> RTL-SDR Blog unit stays locked. This one part is why "just buy the cheap one"
+> is bad advice for [trunk-tracking](/reference/trunked-radio/).
+
+## The V4 end-of-line situation
+
+The [RTL-SDR Blog V4](/reference/rtl-sdr/) is the dongle enthusiasts reach for,
+thanks to its Rafael Micro R828D tuner, built-in HF upconverter (no separate
+[upconverter](/reference/upconverter/) box), and improved input filtering. But the
+R828D has been discontinued, so RTL-SDR Blog has confirmed the V4 is the last of
+that line. It still works flawlessly with GopherTrunk today — nothing about it
+"expires" — but stock is finite.
+
+Practically, that means: if you want the best single dongle and can find one, buy
+the V4 now. If you want something you can re-order in a year, or you are buying
+several for a [multi-dongle pool](/multi-dongle-sdr-setup/), standardise on the
+[NESDR SMArt v5](/reference/nesdr/) — its R820T2/R860 tuner is not going anywhere.
+See the full [V3 vs V4 breakdown](/rtl-sdr-blog-v3-vs-v4/) if you are torn between
+the two RTL-SDR Blog models.
+
+## How to choose
+
+- **Just want it to work, forever in stock?** [NESDR SMArt v5](/reference/nesdr/).
+  It is the boring, correct answer for most people.
+- **Want the best single dongle and HF without an upconverter?**
+  [RTL-SDR Blog V4](/reference/rtl-sdr/), bought while stock lasts.
+- **Starting from nothing?** The [V3 + dipole kit](/best-sdr-antenna/) puts a
+  proven dongle and a real antenna in one order.
+- **Powering a mast-mounted [LNA](/best-sdr-lna/)?** [NESDR SMArTee v2](/reference/nesdr/)
+  with its always-on [bias tee](/reference/bias-tee/).
+- **Tough or congested RF?** No RTL-SDR fixes an overloaded 8-bit front end — that
+  is when you step up to a 12-bit [Airspy](/reference/airspy/). See
+  [Airspy vs RTL-SDR vs HackRF](/airspy-vs-rtl-sdr-vs-hackrf/).
+
+## Don't forget the rest of the kit
+
+The dongle is one piece. You also need a decent
+**[antenna](/best-sdr-antenna/)** (it matters more than the dongle), the right
+**[cables and adapters](/sdr-cables-and-connectors/)**, and a computer — any PC or
+a [Raspberry Pi for 24/7](/raspberry-pi-sdr-scanner/). Our
+[what-you-need checklist](/what-do-i-need-for-gophertrunk/) covers every part, and
+the [hardware setup guide](/hardware.html) gets you decoding.
+
+## Bottom line
+
+Buy the **[NESDR SMArt v5](/reference/nesdr/)** if you want one dongle that is
+always in stock, or an **[RTL-SDR Blog V4](/reference/rtl-sdr/)** while it lasts
+if you want the enthusiast reference with built-in HF. Both run
+[GopherTrunk](/downloads.html) beautifully for about $35–40, both decode the same
+P25/DMR/NXDN voice, and **neither — nor any radio — decodes
+[encryption](/police-scanner-encryption/)**. Skip the no-name $15 dongles; the
+TCXO is worth every cent. Want more front end for tough RF? Compare against the
+[best SDRs overall](/best-sdr-for-gophertrunk/).

--- a/docs/best-sdr-antenna.md
+++ b/docs/best-sdr-antenna.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "Best SDR Antenna for Scanning"
-description: "The best antennas for SDR scanning with GopherTrunk — RTL-SDR dipole kit for starters, a discone for outdoor wideband coverage, and the Nagoya NA-771 whip for portable use, plus mounting and coax tips."
+description: "The best antennas for SDR scanning with GopherTrunk — RTL-SDR dipole kit for starters, a discone for outdoor wideband coverage, and the Nagoya NA-771 whip for portable use, plus mounting and coax."
 keywords: best SDR antenna, best scanner antenna SDR, RTL-SDR antenna, discone antenna, dipole antenna kit, Nagoya NA-771, SDR antenna for scanning, wideband scanner antenna
 permalink: /best-sdr-antenna/
 nav_group: Hardware
@@ -20,7 +20,6 @@ faq:
   - q: "Does coax length hurt reception?"
     a: "Yes — every foot of coax adds loss, and thin cable like RG316 loses a lot at UHF. Use as short a run as practical, use better cable (RG58 or RG8X) for long outdoor runs, and if the run is long, a mast-mounted LNA recovers the loss."
 ---
-
 # Best SDR Antenna for Scanning
 
 **The antenna matters more than the dongle.** A cheap

--- a/docs/best-sdr-antenna.md
+++ b/docs/best-sdr-antenna.md
@@ -1,0 +1,129 @@
+---
+layout: page
+title: "Best SDR Antenna for Scanning"
+description: "The best antennas for SDR scanning with GopherTrunk — RTL-SDR dipole kit for starters, a discone for outdoor wideband coverage, and the Nagoya NA-771 whip for portable use, plus mounting and coax tips."
+keywords: best SDR antenna, best scanner antenna SDR, RTL-SDR antenna, discone antenna, dipole antenna kit, Nagoya NA-771, SDR antenna for scanning, wideband scanner antenna
+permalink: /best-sdr-antenna/
+nav_group: Hardware
+affiliate: true
+faq:
+  - q: "What is the best antenna for SDR scanning?"
+    a: "For starting out, the RTL-SDR Blog multipurpose dipole kit (around $25) is the best value — it tunes to your target band and works indoors or on a window. For the best coverage, an outdoor discone like the Tram/D3000 (around $40) hears everything from 25 MHz to 3 GHz. For portable use, the Nagoya NA-771 whip is a solid compromise."
+  - q: "Does the antenna matter more than the SDR?"
+    a: "Yes. A better antenna, mounted higher and outdoors, improves reception far more than upgrading the dongle. A $35 RTL-SDR on a rooftop discone will out-hear a $170 Airspy on the stock indoor whip. Spend on the antenna and its placement first."
+  - q: "What is a discone antenna and why use one?"
+    a: "A discone is a wideband omnidirectional antenna that receives across a huge range — roughly 25 MHz to 3 GHz — without tuning. That makes it ideal for scanning, where you want to hear many bands at once, and for feeding a wideband SDR that channelizes multiple signals."
+  - q: "Can I use my SDR antenna indoors?"
+    a: "You can, and the dipole kit is designed for it, but indoors is the worst place for reception — walls, wiring, and electronics all attenuate and add noise. Even moving the antenna to a window helps; getting it outdoors and up high helps most."
+  - q: "Do I need a special connector for an SDR antenna?"
+    a: "Most SDRs use an SMA jack, while many antennas terminate in BNC, UHF (PL-259), or N. A cheap SMA adapter kit bridges the gap. Match the connectors before you order, or grab an adapter kit so you are covered — see our cables and connectors guide."
+  - q: "Does coax length hurt reception?"
+    a: "Yes — every foot of coax adds loss, and thin cable like RG316 loses a lot at UHF. Use as short a run as practical, use better cable (RG58 or RG8X) for long outdoor runs, and if the run is long, a mast-mounted LNA recovers the loss."
+---
+
+# Best SDR Antenna for Scanning
+
+**The antenna matters more than the dongle.** A cheap
+[RTL-SDR](/reference/rtl-sdr/) on a well-placed outdoor antenna will out-hear an
+expensive [Airspy](/reference/airspy/) on the stock whip every time. For
+[GopherTrunk](/downloads.html) to lock a [trunked](/reference/trunked-radio/)
+control channel and hold it, get the antenna right first — the right type, tuned
+to your band, mounted as high and as far outdoors as you can manage.
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Best starter / indoor:** [RTL-SDR dipole kit](/reference/dipole-antenna/) (~$25)
+— tunable, works on a window. **Best coverage / outdoor:**
+[discone D3000](/reference/discone-antenna/) (~$40) — 25 MHz–3 GHz, no tuning.
+**Best portable:** Nagoya NA-771 whip (~$18). **Antenna placement beats dongle
+price.** **Mind your [connectors](/sdr-cables-and-connectors/) and coax loss.**
+</div>
+
+## Quick picks
+
+<div class="pick-cards" markdown="0">
+<div class="pick-card pick-card--top">
+<span class="pick-card__badge">Best starter</span>
+<h3>RTL-SDR Multipurpose Dipole Kit</h3>
+<p class="pick-card__price">around $25</p>
+<p>Adjustable dipole with a tripod, window mount, and telescoping elements you tune to your target band. The right first antenna for almost everyone.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B075445JDF?tag=gophertrunk-20" rel="nofollow sponsored noopener">Dipole kit on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/dipole-antenna/">dipole details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Best coverage</span>
+<h3>Discone D3000 (25–3000 MHz)</h3>
+<p class="pick-card__price">around $40</p>
+<p>Wideband omnidirectional — hears everything from low VHF to L-band with no tuning. Mount it outdoors and up high for the best all-band scanning.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0CL5ZBN94?tag=gophertrunk-20" rel="nofollow sponsored noopener">Discone on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/discone-antenna/">discone details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Best portable</span>
+<h3>Nagoya NA-771 Whip (SMA-F)</h3>
+<p class="pick-card__price">around $18</p>
+<p>Flexible dual-band whip that screws straight onto an SMA SDR. A big step up from the stub antenna for portable or handheld setups.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B00KC4PWQQ?tag=gophertrunk-20" rel="nofollow sponsored noopener">NA-771 on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/best-scanner-antenna/">scanner antenna guide</a></p>
+</div>
+</div>
+
+## Which type for which job
+
+| Antenna | Coverage | Where | Best for | Approx price |
+|---|---|---|---|---|
+| [Dipole kit](/reference/dipole-antenna/) | Tunable band | Indoor / window | Starting out, single band | ~$25 |
+| [Discone D3000](/reference/discone-antenna/) | 25 MHz–3 GHz | Outdoor / mast | All-band scanning, wideband SDR | ~$40 |
+| Nagoya NA-771 whip | Dual-band VHF/UHF | Portable | Handheld, travel, quick setup | ~$18 |
+
+> **Tune the dipole to your control channel.** The [dipole kit](/reference/dipole-antenna/)
+> is only broadband if you leave it stubby and lossy. Set the element length to a
+> quarter-wave of your [target frequency](/reference/trunked-radio/) (RadioReference
+> lists it) and it becomes a genuinely resonant, low-noise antenna on that band.
+
+## Why the antenna beats the dongle
+
+Reception is set by three things, in order: **where the antenna is, what type it
+is, and only then the receiver.** A resonant antenna outdoors and up high collects
+far more signal and far less local noise than any radio can recover from a whip
+sitting next to a PC. This is why upgrading from the stock stub to even a $25
+dipole is the single biggest improvement most people make — and why we tell people
+to fix the antenna before considering a pricier [Airspy](/airspy-vs-rtl-sdr-vs-hackrf/).
+
+## Mounting, height, and placement
+
+- **Get it outside and up.** Every wall between the antenna and the signal costs
+  you. A discone on the roof or a mast beats the same antenna in the attic.
+- **Keep it clear of metal and noise.** Mount away from gutters, HVAC units, and
+  the mess of RF noise a house radiates. A few feet of separation matters.
+- **Vertical for scanning.** Public-safety VHF/UHF is vertically polarised — mount
+  whips and discones vertically to match.
+- **Ground and protect an outdoor run.** An outdoor antenna wants a proper ground
+  and, ideally, a lightning arrestor on the feedline.
+
+## Don't let the coax undo it
+
+A great antenna on bad cable is a compromised antenna. Every foot of coax adds
+loss, and it gets worse at UHF where trunked systems live. Thin
+[RG316](/reference/coaxial-cable/) is fine for a short bench pigtail but bleeds
+signal over distance; for a long outdoor run use thicker RG58 or RG8X, keep the
+run as short as practical, and if it must be long, put a mast-mounted
+[LNA](/best-sdr-lna/) at the antenna to recover the loss before it happens. Match
+your [connectors](/sdr-cables-and-connectors/) too — most SDRs are SMA while many
+antennas are BNC, UHF, or N, so an adapter kit is worth having on hand.
+
+> **Different from a handheld scanner antenna.** These pick the same physics but
+> terminate in SDR-friendly connectors. If you are outfitting a portable
+> [police scanner](/best-police-scanners/) instead, see the
+> [best scanner antenna](/best-scanner-antenna/) sibling guide.
+
+## Bottom line
+
+Start with the **[RTL-SDR dipole kit](/reference/dipole-antenna/)** and actually
+tune it to your control channel — it is the best $25 you can spend on reception.
+When you are ready for real coverage, put a **[discone](/reference/discone-antenna/)**
+outdoors and up high, and keep the **coax short and the
+[connectors](/sdr-cables-and-connectors/) right**. Do that and a plain
+[$35 dongle](/best-rtl-sdr/) will hear more than most people ever get from an
+expensive receiver on the stock whip. Then [download GopherTrunk](/downloads.html)
+and follow the [hardware setup](/hardware.html).

--- a/docs/best-sdr-for-gophertrunk.md
+++ b/docs/best-sdr-for-gophertrunk.md
@@ -1,0 +1,134 @@
+---
+layout: page
+title: "Best SDR for GopherTrunk (2026 Buyer's Guide)"
+description: "The best software-defined radios for running GopherTrunk in 2026 — RTL-SDR Blog V4, NooElec NESDR, Airspy, and HackRF compared for P25/DMR/NXDN trunk-tracking, ranked by need and budget."
+keywords: best SDR for GopherTrunk, best SDR for scanning, best RTL-SDR, RTL-SDR Blog V4, NESDR SMArt, Airspy, HackRF, P25 SDR, software defined radio police scanner
+permalink: /best-sdr-for-gophertrunk/
+nav_group: Hardware
+affiliate: true
+faq:
+  - q: "What is the best SDR for GopherTrunk?"
+    a: "For most people, an RTL-SDR Blog V4 or a NooElec NESDR SMArt v5 (around $35–40) is the best SDR for GopherTrunk — cheap, well-shielded, and more than enough to follow P25, DMR, and NXDN trunked systems. Step up to an Airspy R2 for tough or busy RF, or an Airspy HF+ Discovery if you also want HF."
+  - q: "Do I need an expensive SDR to run GopherTrunk?"
+    a: "No. GopherTrunk is built to run on a ~$30 RTL-SDR dongle. A better SDR (Airspy) helps in congested band conditions or when you channelize many signals from one wideband capture, but a good RTL-SDR decodes the same P25/DMR/NXDN voice."
+  - q: "Can one SDR follow a whole trunked system?"
+    a: "Yes — one RTL-SDR can follow a single trunked site by tracking its control channel. For a multi-site system or control channels spread far apart, GopherTrunk can drive a pool of dongles, or use a wideband Airspy to channelize several at once."
+  - q: "Is a HackRF One good for GopherTrunk?"
+    a: "It works but is overkill for scanning: its 8-bit ADC has less dynamic range than an Airspy, and its transmit and 6 GHz reach are wasted on receive-only VHF/UHF decoding. Buy a HackRF only if you also need those capabilities for other projects."
+  - q: "Can an SDR decode encrypted police?"
+    a: "No. No SDR — and no scanner — can decode AES-encrypted talkgroups. GopherTrunk decodes clear and even scrambled traffic but never keyed encryption. Choose hardware based on the systems still in the clear."
+  - q: "What else do I need besides the SDR?"
+    a: "A computer (any PC, or a Raspberry Pi for 24/7), a decent antenna, and usually an SMA adapter or two. See our complete what-you-need checklist for the full list."
+---
+
+# Best SDR for GopherTrunk (2026 Buyer's Guide)
+
+**The best SDR for GopherTrunk is the cheapest one that cleanly hears your local
+control channel** — and for most people that's a ~$35 [RTL-SDR](/reference/rtl-sdr/).
+GopherTrunk is [free, open-source software](/downloads.html) that turns a USB
+[software-defined radio](/reference/software-defined-radio/) into a P25/DMR/NXDN/TETRA
+trunking scanner, so the radio is the only thing you buy.
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Best overall:** [RTL-SDR Blog V4](/reference/rtl-sdr/) or
+[NooElec NESDR SMArt v5](/reference/nesdr/) (~$35–40). **Best for tough/busy RF:**
+[Airspy R2](/reference/airspy/) (12-bit, wideband). **Best for HF too:**
+[Airspy HF+ Discovery](/reference/airspy-hf-plus/). **Overkill but versatile:**
+[HackRF One](/reference/hackrf/). **You only buy the radio** — the software is free and
+runs on a PC or [Raspberry Pi](/raspberry-pi-sdr-scanner/). **No SDR decodes
+[AES encryption](/police-scanner-encryption/).**
+</div>
+
+## Quick picks
+
+<div class="pick-cards" markdown="0">
+<div class="pick-card pick-card--top">
+<span class="pick-card__badge">Best overall</span>
+<h3>RTL-SDR Blog V4</h3>
+<p class="pick-card__price">around $40</p>
+<p>The reference dongle: 1 ppm TCXO, built-in HF upconverter, SMA, switchable bias tee. Plenty for P25/DMR/NXDN trunk-tracking.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0CD745394?tag=gophertrunk-20" rel="nofollow sponsored noopener">V4 on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/rtl-sdr/">RTL-SDR details</a> · <a href="/best-rtl-sdr/">best RTL-SDR guide</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Best value</span>
+<h3>NooElec NESDR SMArt v5</h3>
+<p class="pick-card__price">around $35</p>
+<p>0.5 ppm TCXO, aluminium case, R820T2/R860. The mainstream "just buy this" RTL-SDR — always in stock.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B01HA642SW?tag=gophertrunk-20" rel="nofollow sponsored noopener">NESDR on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/nesdr/">NESDR details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Best for tough RF</span>
+<h3>Airspy R2 / Mini</h3>
+<p class="pick-card__price">around $110–170</p>
+<p>12-bit ADC and up to ~10 MHz capture — decodes weak and congested channels and channelizes multiple control channels at once.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/s?k=Airspy+R2+SDR&tag=gophertrunk-20" rel="nofollow sponsored noopener">Airspy on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/airspy/">Airspy details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Best for HF</span>
+<h3>Airspy HF+ Discovery</h3>
+<p class="pick-card__price">around $170</p>
+<p>Exceptional HF/low-VHF dynamic range. The pick if you also want shortwave, ham HF, or utility monitoring.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/s?k=Airspy+HF+Discovery&tag=gophertrunk-20" rel="nofollow sponsored noopener">HF+ on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/airspy-hf-plus/">HF+ details</a></p>
+</div>
+</div>
+
+## Full comparison
+
+| SDR | ADC | Range | Bandwidth | Best for | Approx price |
+|---|---|---|---|---|---|
+| [RTL-SDR Blog V4](/reference/rtl-sdr/) | 8-bit | ~500 kHz–1.77 GHz | ~2.4 MHz | The default; HF via upconverter | ~$40 |
+| [NESDR SMArt v5](/reference/nesdr/) | 8-bit | ~100 kHz–1.75 GHz | ~2.4 MHz | Value, always in stock | ~$35 |
+| [NESDR SMArTee v2](/reference/nesdr/) | 8-bit | VHF/UHF | ~2.4 MHz | Powering an LNA (bias tee) | ~$40 |
+| [Airspy Mini](/reference/airspy/) | 12-bit | ~24 MHz–1.8 GHz | ~6 MHz | Better decode, portable | ~$110 |
+| [Airspy R2](/reference/airspy/) | 12-bit | ~24 MHz–1.8 GHz | ~10 MHz | Wideband multi-site channelizing | ~$170 |
+| [Airspy HF+ Discovery](/reference/airspy-hf-plus/) | high-DR | HF + 60–260 MHz | ~0.66 MHz | HF / low-VHF | ~$170 |
+| [HackRF One](/reference/hackrf/) | 8-bit | 1 MHz–6 GHz | ~20 MHz | Range + transmit (overkill for scanning) | ~$150 |
+
+> **Read your system first.** Look up your target on [RadioReference](https://www.radioreference.com/):
+> one RTL-SDR follows one control channel cleanly. If a system's sites or control
+> channels are spread across a band, plan for a wideband [Airspy](/reference/airspy/) or a
+> [multi-dongle pool](/multi-dongle-sdr-setup/).
+
+## How to choose
+
+- **Just starting / on a budget?** [RTL-SDR Blog V4](/reference/rtl-sdr/) or
+  [NESDR SMArt v5](/reference/nesdr/). One dongle follows most local trunked systems.
+- **Weak signal, congested band, or lots of intermod?** An [Airspy](/reference/airspy/)'s
+  12-bit front end pulls voice out of conditions that push an 8-bit RTL-SDR into overload.
+- **Multiple sites / wideband monitoring?** An [Airspy R2](/reference/airspy/) channelizes
+  several control channels from one capture, or run a
+  [pool of RTL-SDRs](/multi-dongle-sdr-setup/).
+- **Want HF (shortwave, ham, utility) too?** [Airspy HF+ Discovery](/reference/airspy-hf-plus/),
+  or a V4's built-in [upconverter](/reference/upconverter/). See [best HF SDR](/best-hf-sdr/).
+- **Already own a HackRF or need 6 GHz / transmit?** GopherTrunk will
+  [use it as a receiver](/reference/hackrf/) — just know it's more than scanning needs.
+
+## Don't forget the rest of the kit
+
+An SDR alone won't scan. You also need a **computer** (any PC, or a
+[Raspberry Pi for 24/7](/raspberry-pi-sdr-scanner/)), a decent
+**[antenna](/best-sdr-antenna/)**, and usually an **[SMA adapter or cable](/sdr-cables-and-connectors/)**.
+Our [complete what-you-need checklist](/what-do-i-need-for-gophertrunk/) walks through
+every piece. Then [download GopherTrunk](/downloads.html) and follow the
+[hardware setup guide](/hardware.html).
+
+## SDR vs a dedicated scanner
+
+A dedicated [police scanner](/best-police-scanners/) is turnkey and portable; an SDR +
+GopherTrunk is free (after the dongle), records and timestamps every call, follows
+unlimited talkgroups, and streams to a web console. The honest head-to-head is in
+[police scanner vs GopherTrunk](/police-scanner-vs-sdr/).
+
+## Bottom line
+
+Start with a **[RTL-SDR Blog V4](/reference/rtl-sdr/)** or **[NESDR SMArt v5](/reference/nesdr/)** —
+they run GopherTrunk beautifully for about $35. Move up to an
+**[Airspy](/reference/airspy/)** only when your RF is genuinely tough or you want
+wideband multi-site capture. Whatever you pick, no SDR decodes
+[encryption](/police-scanner-encryption/), and the software is free — so the cheapest
+capable dongle is usually the right answer.

--- a/docs/best-sdr-for-p25-trunking.md
+++ b/docs/best-sdr-for-p25-trunking.md
@@ -1,0 +1,133 @@
+---
+layout: page
+title: "Best SDR for P25 Trunking (GopherTrunk)"
+description: "The best SDR for P25 trunking with GopherTrunk — RTL-SDR V4 or NESDR for a single site, a wideband Airspy to channelize multiple control channels, plus P25 Phase I/II and simulcast notes."
+keywords: best SDR for P25, P25 trunking SDR, P25 Phase 2 SDR, RTL-SDR P25, Airspy P25, simulcast P25, control channel, wideband SDR trunking, GopherTrunk P25
+permalink: /best-sdr-for-p25-trunking/
+nav_group: Hardware
+affiliate: true
+faq:
+  - q: "What is the best SDR for P25 trunking?"
+    a: "For a single P25 site, a ~$35–40 RTL-SDR Blog V4 or NooElec NESDR SMArt v5 is the best pick — one dongle tracks the control channel and follows voice grants across the site's channels. For multi-site systems or control channels spread across a band, a wideband Airspy R2 that channelizes several at once is the better tool."
+  - q: "Can one RTL-SDR follow a whole P25 system?"
+    a: "One RTL-SDR follows one P25 site: it locks the control channel and retunes to each voice grant. That covers most listeners. A system with multiple sites on widely separated frequencies needs either several dongles or a wideband Airspy capturing the whole span at once."
+  - q: "Does GopherTrunk decode P25 Phase II?"
+    a: "Yes. GopherTrunk decodes both P25 Phase I (C4FM/FDMA) and Phase II (H-DQPSK/TDMA) trunked voice. The SDR hardware requirement is the same for both — any good RTL-SDR receives Phase II; the decoding is done in software."
+  - q: "Can an SDR decode P25 simulcast?"
+    a: "Simulcast is difficult for every receiver because multiple synchronized transmitters create multipath distortion. A higher-dynamic-range SDR such as an Airspy gives GopherTrunk cleaner samples to work with, which helps, but no receiver fully escapes simulcast distortion — dedicated Uniden SDS scanners have the strongest simulcast front ends."
+  - q: "Do I need an Airspy for P25?"
+    a: "No. An 8-bit RTL-SDR decodes P25 voice perfectly well on a clean single site. Step up to an Airspy only when the band is congested, signals are weak, you fight simulcast, or you want to channelize multiple control channels from one wideband capture."
+  - q: "Can an SDR decode encrypted P25?"
+    a: "No. No SDR and no scanner can decode AES-encrypted P25 talkgroups. GopherTrunk decodes clear P25 (and identifies encrypted calls) but cannot break the encryption. Buy based on the talkgroups still transmitted in the clear."
+---
+
+# Best SDR for P25 Trunking (GopherTrunk)
+
+**The best SDR for P25 trunking is the cheapest one that cleanly hears your site's
+[control channel](/reference/project-25/): a ~$35–40 [RTL-SDR](/reference/rtl-sdr/) for a
+single site, or a wideband [Airspy](/reference/airspy/) when you need to channelize
+several control channels at once.** GopherTrunk decodes both
+[P25 Phase I and Phase II](/reference/p25-phase-2/) in software, so the radio is the only
+variable.
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Single P25 site:** [RTL-SDR Blog V4](/reference/rtl-sdr/) or
+[NESDR SMArt v5](/reference/nesdr/) (~$35–40) — one dongle tracks the control channel and
+follows grants. **Multi-site / wideband:** [Airspy R2](/reference/airspy/) channelizes
+several [control channels](/reference/project-25/) from one capture. **Phase I & II**
+both decode on any good dongle — it is software. **Simulcast** is hard for every
+receiver; more dynamic range helps. **No SDR decodes
+[AES-encrypted P25](/police-scanner-encryption/).**
+</div>
+
+## Quick picks
+
+<div class="pick-cards" markdown="0">
+<div class="pick-card pick-card--top">
+<span class="pick-card__badge">Best single site</span>
+<h3>RTL-SDR Blog V4</h3>
+<p class="pick-card__price">around $40</p>
+<p>One dongle tracks a P25 site's control channel and retunes to each voice grant. Decodes Phase I and Phase II. The default P25 receiver.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0CD745394?tag=gophertrunk-20" rel="nofollow sponsored noopener">V4 on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/rtl-sdr/">RTL-SDR details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Best value</span>
+<h3>NESDR SMArt v5</h3>
+<p class="pick-card__price">around $35</p>
+<p>0.5 ppm TCXO and a shielded case — rock-stable tuning for tracking a control channel all day. Always in stock.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B01HA642SW?tag=gophertrunk-20" rel="nofollow sponsored noopener">NESDR on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/nesdr/">NESDR details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Best wideband / multi-site</span>
+<h3>Airspy R2</h3>
+<p class="pick-card__price">around $170</p>
+<p>12-bit ADC and up to ~10 MHz capture — channelize several control channels at once and pull P25 out of congested or weak conditions.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/s?k=Airspy+R2+SDR&tag=gophertrunk-20" rel="nofollow sponsored noopener">Airspy on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/airspy/">Airspy details</a></p>
+</div>
+</div>
+
+## How P25 trunking uses your SDR
+
+A P25 trunked system does not park voice on a fixed frequency. One or more
+**[control channels](/reference/project-25/)** continuously broadcast which talkgroup is
+active and on which voice frequency. GopherTrunk locks the control channel, reads those
+grant messages, and follows the conversation. That is why **a single
+[RTL-SDR](/reference/rtl-sdr/) can follow an entire site**: it only needs to hear one
+control channel and retune to grants.
+
+The question that decides your hardware is simply: **how many control channels do you
+need to watch at once, and how far apart are they?**
+
+## One dongle per site vs a wideband Airspy
+
+| Scenario | Best approach | Why |
+|---|---|---|
+| One local P25 site | Single [RTL-SDR](/reference/rtl-sdr/) | Tracks the control channel, follows grants — done |
+| Two sites, control channels close together | One wideband [Airspy R2](/reference/airspy/) | [Channelize](/multi-dongle-sdr-setup/) both from one capture |
+| Several sites spread across a band | [Multi-dongle pool](/multi-dongle-sdr-setup/) | Assign a dongle per site/role |
+| Congested band, weak signal, simulcast | [Airspy](/reference/airspy/) | 12-bit front end resists overload, cleaner samples |
+
+> **Read your system on [RadioReference](https://www.radioreference.com/) first.** Note
+> how many sites you can hear and where their control channels sit. If they fall inside a
+> few MHz of each other, one wideband [Airspy](/reference/airspy/) can
+> [channelize them all at once](/multi-dongle-sdr-setup/). If they are scattered, a
+> [pool of cheap dongles](/multi-dongle-sdr-setup/) is more flexible and often cheaper.
+
+## Phase I, Phase II, and simulcast
+
+**[P25 Phase I](/reference/project-25/)** uses C4FM/FDMA; **[Phase II](/reference/p25-phase-2/)**
+uses H-DQPSK TDMA to fit two voice paths in one channel. GopherTrunk decodes **both** —
+and importantly, the SDR requirement is identical. Any good [RTL-SDR](/reference/rtl-sdr/)
+receives Phase II; the difference is entirely in software decoding, not hardware.
+
+**[Simulcast](/reference/simulcast/)** is the one place hardware really strains. When
+several transmitters send the same signal in sync, their overlapping arrivals create
+multipath distortion that smears the constellation. A higher-dynamic-range
+[Airspy](/reference/airspy/) gives GopherTrunk cleaner input to work with, which helps,
+but be honest: **no receiver fully escapes simulcast distortion**, and dedicated Uniden
+SDS scanners still hold the edge on the worst simulcast fringes. See the honest
+comparison in [police scanner vs SDR](/police-scanner-vs-sdr/).
+
+## What an SDR can't do
+
+No SDR — and no scanner — decodes **[AES-encrypted P25](/police-scanner-encryption/)**.
+GopherTrunk will identify encrypted calls but cannot break them. Check
+[RadioReference](https://www.radioreference.com/) to see which of your local talkgroups
+are still in the clear before buying; in most areas that still includes plenty of
+dispatch and nearly all fire/EMS.
+
+## Bottom line
+
+For one P25 site, buy the cheapest capable dongle — a
+**[RTL-SDR Blog V4](/reference/rtl-sdr/)** or
+**[NESDR SMArt v5](/reference/nesdr/)** — and GopherTrunk will track the control channel
+and follow every grant, Phase I or [Phase II](/reference/p25-phase-2/). Step up to a
+wideband **[Airspy R2](/reference/airspy/)** only when you need to
+[channelize multiple control channels](/multi-dongle-sdr-setup/), fight congestion or
+weak signal, or claw back some [simulcast](/reference/simulcast/) margin. See the full
+lineup in [best SDR for GopherTrunk](/best-sdr-for-gophertrunk/) and the software side in
+the [P25 scanner guide](/p25-scanner/).

--- a/docs/best-sdr-lna.md
+++ b/docs/best-sdr-lna.md
@@ -1,0 +1,138 @@
+---
+layout: page
+title: "Best LNA for SDR (and When You Need One)"
+description: "When an SDR LNA helps and when it hurts — the RTL-SDR Blog Wideband LNA, bias-tee powering, recovering feedline loss, and why an amplifier can overload your receiver in strong-signal areas."
+keywords: best LNA for SDR, SDR LNA, RTL-SDR LNA, low noise amplifier, bias tee LNA, mast-mounted preamp, SDR overload, when do I need an LNA
+permalink: /best-sdr-lna/
+nav_group: Hardware
+affiliate: true
+faq:
+  - q: "What is the best LNA for an SDR?"
+    a: "The RTL-SDR Blog Wideband LNA (around $30) is the standard pick — it is a low-noise, bias-tee-powered amplifier that mounts at the antenna and works across the VHF/UHF bands GopherTrunk scans. It powers over the coax from any SDR with a bias tee, so there is no separate power wire up the mast."
+  - q: "Do I actually need an LNA?"
+    a: "Only in specific cases: a weak signal, or a long feedline that loses signal before it reaches the receiver. If your control channel already decodes cleanly, an LNA adds nothing and can make things worse by overloading the front end. Fix the antenna and shorten the coax first."
+  - q: "Can an LNA make reception worse?"
+    a: "Yes. In a strong-signal area an LNA amplifies everything — including nearby broadcast FM, pagers, and cellular — and can drive the SDR into overload and intermodulation, burying the signal you want. That is the overload trap: more gain is not always better. Pair an LNA with a filter, or skip it."
+  - q: "Where should an LNA go — at the antenna or the radio?"
+    a: "At the antenna. An LNA works by setting a low noise figure before the feedline loss, so mounting it at the mast recovers coax loss that would otherwise be unrecoverable. Putting it at the radio end, after the loss, gives almost none of the benefit."
+  - q: "What is a bias tee and do I need one to power the LNA?"
+    a: "A bias tee injects DC power onto the coax so it reaches a mast-mounted LNA without a separate wire. Many SDRs — the RTL-SDR Blog V3/V4 and NESDR SMArTee — have a switchable or always-on bias tee built in. If yours does not, you need an external bias-tee injector."
+  - q: "Will an LNA help me hear encrypted channels?"
+    a: "No. An LNA only improves weak-signal reception — it cannot decode anything. No amplifier, SDR, or scanner can decode AES-encrypted talkgroups. GopherTrunk decodes clear P25/DMR/NXDN/TETRA only, and an LNA just helps a weak clear signal decode."
+---
+
+# Best LNA for SDR (and When You Need One)
+
+**An [LNA](/reference/low-noise-amplifier/) is a scalpel, not a volume knob** — it
+rescues a genuinely weak or feedline-starved signal, and it *wrecks* a setup that
+is already awash in strong RF. Before you add gain to your
+[SDR](/best-sdr-for-gophertrunk/), be honest about which situation you are in,
+because for a lot of urban users the right amount of amplification is *none*.
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Best pick:** [RTL-SDR Blog Wideband LNA](/reference/low-noise-amplifier/) (~$30),
+[bias-tee](/reference/bias-tee/) powered. **Use it for:** weak signals and long
+feedlines. **Mount it at the antenna**, not the radio. **The overload trap:** in
+strong-signal areas an LNA makes things *worse* — pair it with a
+[filter](/sdr-filters/) or skip it. **Fix the [antenna](/best-sdr-antenna/) and
+coax first.** **An LNA never decodes [encryption](/police-scanner-encryption/).**
+</div>
+
+## The pick
+
+<div class="pick-cards" markdown="0">
+<div class="pick-card pick-card--top">
+<span class="pick-card__badge">Best overall</span>
+<h3>RTL-SDR Blog Wideband LNA</h3>
+<p class="pick-card__price">around $30</p>
+<p>Low noise figure across VHF/UHF, powered up the coax by a bias tee — no separate mast wire. Mount it at the antenna to recover feedline loss cleanly.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B07G14Q6XX?tag=gophertrunk-20" rel="nofollow sponsored noopener">LNA on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/low-noise-amplifier/">LNA details</a> · <a href="/reference/bias-tee/">bias tee</a></p>
+</div>
+</div>
+
+## What an LNA actually does
+
+A low-noise amplifier sets the **noise figure** of your receive chain right at the
+front, before the signal is degraded by cable and by the SDR's own noisier input.
+Placed correctly, it lets a weak signal survive the trip down the coax and arrive
+strong enough to decode. What it does **not** do is add information — it cannot
+pull a signal out of thin air, and it amplifies noise and interference right along
+with your target.
+
+## When you genuinely need one
+
+- **Long feedline.** Every foot of [coax](/reference/coaxial-cable/) loses signal,
+  worse at UHF. A mast-mounted LNA recovers that loss *before* it happens, which
+  is why placement matters (see below).
+- **A truly weak signal.** A distant control channel that decodes intermittently,
+  where the antenna is already as good and as high as you can get it, is the
+  textbook case for a preamp.
+- **Feeding a splitter or multiple radios.** Passive splits cost signal; an LNA
+  ahead of the split restores headroom.
+
+> **Mount it at the antenna, not the radio.** An LNA only delivers its low noise
+> figure if it comes *before* the feedline loss. At the mast it recovers coax
+> loss; bolted to the SDR at the bottom of a long run, after the loss, it buys you
+> almost nothing.
+
+## The overload trap
+
+This is the part the marketing skips: **more gain is often worse.** An LNA
+amplifies *everything* the antenna receives — including strong local broadcast FM,
+pagers, cellular, and TV. In a signal-rich urban environment, that extra gain can
+push the [SDR](/reference/rtl-sdr/)'s front end into **overload and
+intermodulation**, generating spurious mixing products that bury the weak channel
+you were trying to hear. An 8-bit RTL-SDR is especially prone to this because its
+[dynamic range](/airspy-vs-rtl-sdr-vs-hackrf/) is limited to start with.
+
+The symptom is telling: adding the LNA makes a marginal channel *disappear*, or
+fills the waterfall with ghost signals that move when you change gain. If that
+happens, the answer is not more amplification — it is **less**, plus a
+[filter](/sdr-filters/) to knock down the strong out-of-band signals that are
+causing the overload.
+
+> **LNA + filter, not LNA alone.** In strong-signal areas the winning combination
+> is a band or notch [filter](/sdr-filters/) *ahead of* the LNA, so the amplifier
+> only boosts the band you care about. A bare LNA in a hot RF environment usually
+> hurts.
+
+## Powering it: the bias tee
+
+The [RTL-SDR Blog LNA](/reference/low-noise-amplifier/) is powered by a
+[bias tee](/reference/bias-tee/) — DC injected onto the coax so it reaches the
+mast without a second wire. Many SDRs have this built in: the
+[RTL-SDR Blog V3/V4](/rtl-sdr-blog-v3-vs-v4/) has a switchable bias tee, and the
+[NESDR SMArTee v2](/reference/nesdr/) has an always-on 4.5 V one. If your dongle
+lacks a bias tee, you add an external injector between the SDR and the coax. Turn
+the bias tee **on** only when a device up the line actually needs the power —
+feeding DC into a plain antenna does nothing useful and, on a short, could stress
+the port.
+
+## Do this before buying an LNA
+
+Most "I need an amplifier" problems are really antenna or cable problems:
+
+1. **Improve the [antenna](/best-sdr-antenna/) and its placement** — outdoors,
+   higher, resonant on your band. This helps far more than a preamp.
+2. **Shorten and upgrade the [coax](/sdr-cables-and-connectors/)** — a shorter,
+   lower-loss run removes the very loss an LNA would be recovering.
+3. **Set the SDR's own gain correctly** — too much gain overloads before any LNA
+   is involved.
+
+Only if the signal is *still* weak after all three, and your feedline is genuinely
+long, does an LNA earn its place.
+
+## Bottom line
+
+Buy the **[RTL-SDR Blog Wideband LNA](/reference/low-noise-amplifier/)** if you
+have a weak signal or a long feedline and you have already sorted the
+[antenna](/best-sdr-antenna/) and [coax](/sdr-cables-and-connectors/). Mount it
+**at the antenna**, power it over a [bias tee](/reference/bias-tee/), and in any
+strong-signal area pair it with a [filter](/sdr-filters/) so you do not fall into
+the overload trap. Used wrongly, an LNA makes reception *worse* — used in the
+right situation, it is the difference between a weak channel that drops and one
+that locks. And like everything else, it never decodes
+[encryption](/police-scanner-encryption/). Then
+[download GopherTrunk](/downloads.html) and get scanning.

--- a/docs/cheap-sdr-scanner.md
+++ b/docs/cheap-sdr-scanner.md
@@ -1,0 +1,121 @@
+---
+layout: page
+title: "Cheapest Way to Scan Digital Radio (SDR + GopherTrunk)"
+description: "The cheapest way to scan digital P25, DMR, and NXDN radio — a ~$30 RTL-SDR plus free GopherTrunk, far under a $380+ digital scanner. Budget breakdown and the honest trade-offs."
+keywords: cheap SDR scanner, cheapest digital scanner, RTL-SDR P25, budget police scanner, scan P25 cheap, DMR NXDN SDR, GopherTrunk cheap, $30 scanner, digital scanner alternative
+permalink: /cheap-sdr-scanner/
+nav_group: Hardware
+affiliate: true
+faq:
+  - q: "What is the cheapest way to scan digital police radio?"
+    a: "A ~$30 RTL-SDR dongle plus free, open-source GopherTrunk is the cheapest route to decoding digital P25, DMR, and NXDN — a fraction of the $380-plus a dedicated digital trunking scanner costs. You supply a computer you already own; the software is free."
+  - q: "How much does a cheap SDR scanner cost?"
+    a: "About $30–60 all in if you own a computer: roughly $30 for an RTL-SDR, ~$18–25 for a decent antenna, and a few dollars for an SMA adapter. GopherTrunk itself costs nothing. That undercuts even entry-level analog-only scanners while doing digital that they cannot."
+  - q: "Can a cheap RTL-SDR really decode P25 and DMR?"
+    a: "Yes. GopherTrunk does the digital decoding in software, so a ~$30 8-bit RTL-SDR handles P25 Phase I/II, DMR, and NXDN on a clean signal. The dongle just delivers samples; the decoding smarts are free software, which is why it is so cheap."
+  - q: "What is the catch with a cheap SDR scanner?"
+    a: "It needs a computer — a PC you own, or a ~$80 Raspberry Pi for always-on use — so it is not a grab-and-go handheld. It also has a weaker simulcast front end than a premium scanner and cannot decode AES encryption. For a fixed home or desk setup, none of that matters."
+  - q: "Is a cheap SDR better than a cheap scanner?"
+    a: "For digital systems, usually yes — most inexpensive scanners are analog-only and cannot follow P25/DMR/NXDN at all, while a ~$30 RTL-SDR plus GopherTrunk can. A cheap scanner wins only if you specifically need a portable, no-computer, battery-powered box."
+  - q: "Can a cheap SDR decode encrypted channels?"
+    a: "No. No SDR or scanner at any price can decode AES-encrypted talkgroups. A cheap SDR hears everything transmitted in the clear, which in most areas still includes plenty of dispatch and nearly all fire/EMS — exactly what a $380 scanner would also hear."
+---
+
+# Cheapest Way to Scan Digital Radio (SDR + GopherTrunk)
+
+**The cheapest way to scan digital P25, DMR, and NXDN radio is a ~$30
+[RTL-SDR](/reference/rtl-sdr/) dongle plus free, open-source
+[GopherTrunk](/downloads.html) — a small fraction of the $380-plus a dedicated digital
+trunking scanner costs.** The decoding lives in free software, so the only money is a
+cheap USB dongle and an antenna.
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Cheapest digital setup:** a ~$30 [RTL-SDR](/reference/rtl-sdr/) + free
+[GopherTrunk](/downloads.html). **Total ~$30–60** with an antenna and adapter, vs
+**$380+** for a digital scanner. **Decodes** P25 Phase I/II, DMR, NXDN in software.
+**The catch:** it needs a computer (a PC you own, or a
+[~$80 Raspberry Pi](/raspberry-pi-sdr-scanner/)). **No SDR at any price decodes
+[AES encryption](/police-scanner-encryption/).**
+</div>
+
+## The whole cost, laid out
+
+Because GopherTrunk is free, the "scanner" is just a handful of cheap parts:
+
+| Part | Why | Pick | Approx $ |
+|---|---|---|---|
+| **SDR dongle** | The receiver + digital decoder (in software) | [NooElec NESDR Nano 3](https://www.amazon.com/dp/B073JZ8CC2?tag=gophertrunk-20) / [NESDR SMArt v5](/reference/nesdr/) | ~$30–35 |
+| **Antenna** | Actually hears signals | [Nagoya NA-771 whip](https://www.amazon.com/dp/B00KC4PWQQ?tag=gophertrunk-20) or a [dipole kit](/reference/dipole-antenna/) | ~$18–25 |
+| **SMA adapter** | Connects antenna to dongle | [SMA adapter kit](https://www.amazon.com/dp/B07PXCC5G2?tag=gophertrunk-20) | ~$13 |
+| **GopherTrunk** | Does all the decoding | [Free download](/downloads.html) | $0 |
+| **Computer** | Runs the software | A PC you already own | $0 |
+| | | **Total** | **~$30–60** |
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B01HA642SW?tag=gophertrunk-20" rel="nofollow sponsored noopener">Cheapest solid dongle on Amazon &rarr;</a>
+
+The absolute floor is a bare [NESDR Nano 3](https://www.amazon.com/dp/B073JZ8CC2?tag=gophertrunk-20)
+around $30; spend a few dollars more on a [NESDR SMArt v5](/reference/nesdr/) and you get
+a shielded case and a stable TCXO that make tracking a control channel far more reliable.
+Either way you are **an order of magnitude under a digital scanner.**
+
+## Why it is so much cheaper than a scanner
+
+A dedicated [digital police scanner](/best-police-scanners/) has to build the P25/DMR/NXDN
+decoder, the trunk-tracking logic, the screen, the battery, and the case into one
+handheld — and P25 decoding carries licensing costs. That is why entry-level *digital*
+scanners start around $380 and good ones run higher. Cheap scanners under ~$100 are
+**analog-only** and cannot follow digital trunked systems at all.
+
+GopherTrunk moves all of that — the decoding, the trunk-tracking, the logging, the
+display — into **free software running on a computer you already own**. The
+[RTL-SDR](/reference/rtl-sdr/) only has to deliver raw samples, which an 8-bit dongle does
+just fine on a clean signal. So you pay ~$30 for the antenna-to-USB hardware and nothing
+for the brains.
+
+> **Cheap dongle, real digital.** A ~$30 [RTL-SDR](/reference/rtl-sdr/) plus GopherTrunk
+> decodes [P25 Phase I and II](/best-sdr-for-p25-trunking/), DMR, and NXDN — the exact
+> digital modes that put a scanner into the $380+ bracket. The savings come from free
+> software, not from cutting capability.
+
+## The honest trade-offs
+
+Cheap is real, but so are the compromises. Be clear-eyed:
+
+- **It needs a computer.** This is a fixed or desk setup, not a grab-and-go handheld. A
+  PC you own costs nothing; for always-on use add a
+  [~$80 Raspberry Pi](/raspberry-pi-sdr-scanner/).
+- **No battery, less portable.** A scanner clips to your belt at the track or a parade; an
+  SDR does not (short of a laptop or Pi power bank rig).
+- **Weaker simulcast front end.** On tough [simulcast](/reference/simulcast/) systems a
+  premium Uniden SDS scanner still has the edge. A cheap dongle is fine on clean single
+  sites.
+- **No encryption, ever.** Like every receiver, it cannot decode
+  [AES-encrypted](/police-scanner-encryption/) talkgroups — but neither can the $380
+  scanner.
+
+None of these matter for the common case: **a home or desk digital scanner that logs
+everything in the clear for the price of a pizza.** The full head-to-head is in
+[police scanner vs SDR](/police-scanner-vs-sdr/), and the budget-scanner angle in
+[cheap police scanner](/cheap-police-scanner/).
+
+## What you actually get for ~$30
+
+Do not mistake cheap for limited. On top of decoding the same digital modes as an
+expensive scanner, GopherTrunk **records and timestamps every call, follows unlimited
+talkgroups, logs to a database, and serves a [web console](/raspberry-pi-sdr-scanner/)**
+you can reach from your phone — features that cost extra or do not exist on many
+dedicated scanners. It is genuinely more capable in software than hardware many times its
+price, provided you can sit it next to a computer.
+
+## Bottom line
+
+If you want to hear digital P25/DMR/NXDN and spend as little as possible, buy a **~$30
+[RTL-SDR](/reference/rtl-sdr/)** (a [NESDR Nano 3](https://www.amazon.com/dp/B073JZ8CC2?tag=gophertrunk-20)
+or the sturdier [SMArt v5](https://www.amazon.com/dp/B01HA642SW?tag=gophertrunk-20)), add
+a cheap [antenna](https://www.amazon.com/dp/B00KC4PWQQ?tag=gophertrunk-20) and
+[adapter](https://www.amazon.com/dp/B07PXCC5G2?tag=gophertrunk-20), and run
+[free GopherTrunk](/downloads.html) on a computer you already have. That is ~$30–60 versus
+$380+ for a digital scanner — the cheapest real route into digital monitoring. Just
+remember it needs a PC and cannot break [encryption](/police-scanner-encryption/). Full
+shopping list: [what do I need for GopherTrunk](/what-do-i-need-for-gophertrunk/).

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -66,6 +66,20 @@ Consumer scanner hardware (Uniden, Whistler) compared honestly against a free SD
 - [Digital vs analog scanners]({{ '/digital-vs-analog-scanner/' | absolute_url }}): what you can still hear on an analog radio in 2026.
 - [P25 scanners]({{ '/p25-scanner/' | absolute_url }}): what Phase I/II and simulcast mean for buyers.
 
+## SDR hardware for GopherTrunk (buyer's guides)
+The receivers, antennas, cables, and accessories to run GopherTrunk, with honest picks and Amazon links.
+- [Best SDR for GopherTrunk]({{ '/best-sdr-for-gophertrunk/' | absolute_url }}): RTL-SDR, NESDR, Airspy, and HackRF compared for P25/DMR/NXDN decoding.
+- [What hardware do I need to run GopherTrunk?]({{ '/what-do-i-need-for-gophertrunk/' | absolute_url }}): the complete dongle + antenna + adapter + computer checklist.
+- [Best RTL-SDR for scanning]({{ '/best-rtl-sdr/' | absolute_url }}): which RTL-SDR dongle to buy (and why the V4 is end-of-line).
+- [Airspy vs RTL-SDR vs HackRF]({{ '/airspy-vs-rtl-sdr-vs-hackrf/' | absolute_url }}): choosing a receiver by use case.
+- [Best SDR antenna]({{ '/best-sdr-antenna/' | absolute_url }}): dipole kits, discones, and mounting for better reception.
+- [SDR cables & connectors]({{ '/sdr-cables-and-connectors/' | absolute_url }}): SMA/BNC/N/F/UHF adapters and coax.
+- [Best LNA for SDR]({{ '/best-sdr-lna/' | absolute_url }}) and [SDR filters]({{ '/sdr-filters/' | absolute_url }}): fixing weak signals and overload.
+- [Best SDR for HF]({{ '/best-hf-sdr/' | absolute_url }}): Airspy HF+ and upconverters for shortwave/ham.
+- [Run GopherTrunk on a Raspberry Pi]({{ '/raspberry-pi-sdr-scanner/' | absolute_url }}): 24/7 headless decoding.
+- [Best SDR for P25 trunking]({{ '/best-sdr-for-p25-trunking/' | absolute_url }}) and [multi-dongle setups]({{ '/multi-dongle-sdr-setup/' | absolute_url }}): single-site vs wideband multi-site.
+- [Cheapest way to scan digital radio]({{ '/cheap-sdr-scanner/' | absolute_url }}): a $30 SDR beats a $380 digital scanner.
+
 ## Technical docs
 - [Architecture]({{ '/architecture.html' | absolute_url }}): how the engine is built.
 - [Vocoders]({{ '/vocoders.html' | absolute_url }}): IMBE and AMBE+2 voice decoding.

--- a/docs/multi-dongle-sdr-setup.md
+++ b/docs/multi-dongle-sdr-setup.md
@@ -1,0 +1,130 @@
+---
+layout: page
+title: "Multi-Dongle & Wideband SDR Setup for GopherTrunk"
+description: "How to run multiple SDRs with GopherTrunk — a pool of RTL-SDRs by serial and role, wideband Airspy channelizing several control channels, rtl_tcp/SoapySDR remotes, powered hubs, and overload."
+keywords: multi-dongle SDR, wideband SDR, GopherTrunk multiple SDR, rtl_tcp, SoapySDR, channelize control channels, SDR pool, powered USB hub, Airspy channelizer, remote SDR
+permalink: /multi-dongle-sdr-setup/
+nav_group: Hardware
+affiliate: true
+faq:
+  - q: "Can GopherTrunk use more than one SDR at once?"
+    a: "Yes. GopherTrunk can drive a pool of SDRs simultaneously — locally over USB or remotely over rtl_tcp and SoapySDR — and assign each a role such as control-channel tracking, voice following, or wideband capture. That lets one instance cover multiple sites or split control and voice across dongles."
+  - q: "How do I tell multiple identical dongles apart?"
+    a: "Give each RTL-SDR a unique serial number with rtl_eeprom, then reference dongles by serial in GopherTrunk's configuration. Without unique serials the operating system can enumerate identical dongles in an unpredictable order, so setting serials is the first step in any multi-dongle build."
+  - q: "Can one wideband Airspy replace several dongles?"
+    a: "Often, yes. A wideband Airspy captures up to ~10 MHz at once, and GopherTrunk can channelize several control channels from that single capture in software. If a system's control channels fall within one Airspy's bandwidth, one wideband receiver can do the work of several narrow dongles."
+  - q: "Do I need a powered USB hub for multiple SDRs?"
+    a: "Yes. Several RTL-SDRs draw more current than an unpowered hub or a Raspberry Pi can supply, and they run warm. A quality powered (active) USB hub gives each dongle stable power and keeps them physically spaced so they run cooler and interfere less."
+  - q: "Can GopherTrunk use SDRplay, LimeSDR, or a USRP in a pool?"
+    a: "Only over the network. SDRplay RSP, LimeSDR, USRP, bladeRF, and PlutoSDR are supported through SoapySDR/SoapyRemote or rtl_tcp, not as direct pure-Go USB devices. RTL-SDR, HackRF, and Airspy are the direct-USB devices; everything else is mounted as a network source."
+  - q: "Does sharing one antenna across dongles cause problems?"
+    a: "It can. Splitting one antenna into several dongles adds loss and, more importantly, a strong signal in a shared wideband capture can overload the front end for every channel you extract from it. Filter strong local signals ahead of the split and watch gain on shared captures."
+  - q: "Can I run SDRs on another machine?"
+    a: "Yes. Run rtl_tcp or a SoapySDR server on a remote host — say a Raspberry Pi at the antenna — and point GopherTrunk at it over the network. You can mix local USB dongles and remote network sources in the same pool."
+---
+
+# Multi-Dongle & Wideband SDR Setup for GopherTrunk
+
+**GopherTrunk can drive a whole pool of SDRs at once — locally over USB or remotely over
+[rtl_tcp](/reference/rtl-tcp/) and [SoapySDR](/reference/soapysdr/) — and it can
+channelize several control channels from a single wideband
+[Airspy](/reference/airspy/) capture.** That means one instance can cover multiple sites,
+split control and voice across dongles, or feed many decoders from one wideband front
+end.
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Pool of dongles:** assign each [RTL-SDR](/reference/rtl-sdr/) a **unique serial** and a
+**role** (control / voice / wideband). **Wideband path:** one
+[Airspy](/reference/airspy/) channelizes several control channels from one ~10 MHz
+capture. **Remotes:** mount SDRs over [rtl_tcp](/reference/rtl-tcp/) or
+[SoapySDR](/reference/soapysdr/) from another host. **Power:** use a **powered USB hub**.
+**Watch overload** on shared captures. **SDRplay/Lime/USRP are network-only** via
+SoapyRemote.
+</div>
+
+## Two ways to cover more than one channel
+
+There are two distinct strategies, and many builds combine them:
+
+1. **A pool of narrow dongles.** Each [RTL-SDR](/reference/rtl-sdr/) tunes its own
+   frequency. Perfect when a system's sites or control channels are spread far across a
+   band — assign a dongle per site, or one dongle to the control channel and another to
+   follow voice.
+2. **One wideband receiver, channelized.** A single [Airspy](/reference/airspy/) grabs up
+   to ~10 MHz in one capture and GopherTrunk **channelizes** it — extracting several
+   control channels from that one stream in software. Ideal when the channels you want
+   fall inside one wideband window.
+
+| Approach | Best when | Hardware |
+|---|---|---|
+| Dongle pool | Sites/channels spread across a band | Several [RTL-SDRs](/reference/rtl-sdr/) + [powered hub](/reference/rtl-tcp/) |
+| Wideband channelize | Channels within ~10 MHz | One [Airspy R2](/reference/airspy/) |
+| Hybrid | Big multi-site systems | Airspy wideband + dongles for the outliers |
+
+## Serials and roles
+
+The first practical step with multiple dongles is making them addressable.
+
+> **Set unique serials first.** Fresh [RTL-SDRs](/reference/rtl-sdr/) often share the
+> same default serial, so the OS enumerates them in an unpredictable order. Use
+> `rtl_eeprom` to give each a unique serial (e.g. `00000001`, `00000002`), then refer to
+> each dongle by serial in GopherTrunk. Now "the control dongle" is always the same
+> physical stick.
+
+With serials set, you assign **roles**: which dongle tracks a
+[control channel](/reference/project-25/), which follows voice grants, which does
+wideband capture. GopherTrunk coordinates the pool so grants read on the control dongle
+are followed on a voice dongle without missing calls.
+
+## Remote SDRs over the network
+
+Dongles do not have to hang off the same machine. Run **[rtl_tcp](/reference/rtl-tcp/)**
+or a **[SoapySDR](/reference/soapysdr/)** server on another host — commonly a
+[Raspberry Pi at the antenna](/raspberry-pi-sdr-scanner/) — and point GopherTrunk at it
+over your LAN. You can freely **mix local USB dongles and remote network sources** in one
+pool, keeping the noisy USB and the long coax runs out at the antenna while the decoder
+runs wherever is convenient.
+
+> **SDRplay, LimeSDR, USRP, bladeRF, and PlutoSDR are network-only.** GopherTrunk speaks
+> pure-Go USB directly to the [RTL-SDR](/reference/rtl-sdr/) family, HackRF, and
+> [Airspy](/reference/airspy/). Everything else is mounted through
+> [SoapySDR](/reference/soapysdr/)/SoapyRemote or [rtl_tcp](/reference/rtl-tcp/) as a
+> network device — plan on running a Soapy server for those.
+
+## Power, hubs, and heat
+
+Several dongles are a real electrical and thermal load:
+
+- **Use a powered (active) USB hub.** Multiple [RTL-SDRs](/reference/rtl-sdr/) draw more
+  current than an unpowered hub — or a bare [Raspberry Pi](/raspberry-pi-sdr-scanner/) —
+  can safely source. A good powered hub gives each dongle clean, stable power.
+- **Space them out.** Dongles run warm and can couple noise into each other when stacked.
+  A hub with spacing, or short
+  [USB extensions](https://www.amazon.com/dp/B00BWK9VZ2?tag=gophertrunk-20), keeps them
+  cool and quiet.
+- **Mind total current.** Add a bias-tee-powered [LNA](/best-sdr-lna/) and the draw grows
+  again — size the supply accordingly.
+
+## Overload on shared captures
+
+The catch with wideband and shared-antenna setups is **front-end overload**, and it bites
+harder here than with a single dongle:
+
+> **A strong local signal poisons every channel in a shared capture.** When you split one
+> antenna across dongles, or channelize many signals out of one wideband
+> [Airspy](/reference/airspy/) stream, an overloading broadcast FM, pager, or AM
+> transmitter degrades *all* of them at once. Put a
+> [broadcast notch or bandpass filter](/sdr-filters/) ahead of the split, keep gain
+> conservative on wideband captures, and check the noise floor before blaming the decoder.
+
+## Bottom line
+
+GopherTrunk scales from one dongle to a coordinated **pool** — by serial and role, over
+USB or [rtl_tcp](/reference/rtl-tcp/)/[SoapySDR](/reference/soapysdr/) — and can
+**channelize a wideband [Airspy](/reference/airspy/)** to cover several
+[control channels](/reference/project-25/) from one capture. Set unique serials, feed the
+dongles from a powered hub, keep [SDRplay/Lime/USRP](/reference/soapysdr/) in mind as
+network-only devices, and [filter](/sdr-filters/) strong locals before any split. Plan
+the whole system in [best SDR for P25 trunking](/best-sdr-for-p25-trunking/) and wire it
+up from the [hardware guide](/hardware.html).

--- a/docs/raspberry-pi-sdr-scanner.md
+++ b/docs/raspberry-pi-sdr-scanner.md
@@ -1,0 +1,121 @@
+---
+layout: page
+title: "Run GopherTrunk 24/7 on a Raspberry Pi"
+description: "How to run GopherTrunk 24/7 as a headless SDR scanner on a Raspberry Pi 5 — the hardware, power and USB tips, and remote access through GopherTrunk's built-in web console."
+keywords: Raspberry Pi SDR scanner, GopherTrunk Raspberry Pi, headless RTL-SDR, 24/7 scanner, Pi 5 SDR, remote scanner web console, always-on P25 decoder, RTL-SDR Pi setup
+permalink: /raspberry-pi-sdr-scanner/
+nav_group: Hardware
+affiliate: true
+faq:
+  - q: "Can a Raspberry Pi run GopherTrunk?"
+    a: "Yes. GopherTrunk runs on 64-bit Raspberry Pi OS, and a Raspberry Pi 5 (8GB) has ample CPU to decode one or more control channels plus voice around the clock. A single Go binary runs headless with no desktop, so the Pi can sit next to the antenna and be reached over your network."
+  - q: "Which Raspberry Pi should I use?"
+    a: "A Raspberry Pi 5 with 8GB of RAM is the recommended pick — its faster cores comfortably handle P25/DMR/NXDN decoding and even wideband channelizing. A Pi 4 works for a single site. Give either a good power supply and, ideally, active cooling for 24/7 duty."
+  - q: "How do I control a headless Pi scanner?"
+    a: "GopherTrunk has a built-in web console. Point any browser on your network at the Pi's address and you get live spectrum, call logs, and controls — no monitor or keyboard needed on the Pi itself. That is what makes an always-on Pi so convenient."
+  - q: "Do I need a powered USB hub or extension for the Pi?"
+    a: "Often yes. RTL-SDR dongles draw meaningful current and run warm, and plugging one directly into the Pi can cause brownouts or put the hot dongle right against the board. An active (powered) USB extension cable moves the dongle away and stabilizes power."
+  - q: "Will a Pi keep up with decoding?"
+    a: "For one or two control channels plus voice, easily. A Pi 5 can even channelize several signals from one wideband capture. If you drive a large multi-dongle pool you may want a more powerful host, but for a typical single-site setup a Pi is plenty."
+  - q: "Does the Pi need a good power supply?"
+    a: "Yes — use the official USB-C supply. Under-powering a Pi 5 while also feeding a power-hungry SDR is the number-one cause of random dropouts and USB errors. Adequate, stable power is the single most important reliability factor for a 24/7 build."
+---
+
+# Run GopherTrunk 24/7 on a Raspberry Pi
+
+**A [Raspberry Pi 5](https://www.amazon.com/dp/B0CK2FCG1K?tag=gophertrunk-20) plus a
+~$35 [RTL-SDR](/reference/rtl-sdr/) is the ideal always-on GopherTrunk scanner** — low
+power, silent, headless, and reachable from any browser on your network through
+GopherTrunk's [built-in web console](/web.html). Leave it next to the antenna and it
+logs every call, day and night, while you check in from your phone or laptop.
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Host:** [Raspberry Pi 5, 8GB](https://www.amazon.com/dp/B0CK2FCG1K?tag=gophertrunk-20)
+(~$80). **Receiver:** any good [RTL-SDR](/reference/rtl-sdr/) (~$35). **Connect the
+dongle** through an
+[active USB extension](https://www.amazon.com/dp/B00BWK9VZ2?tag=gophertrunk-20) (~$15) —
+better power, moves the warm dongle off the board. **Control it** from any browser via
+the [web console](/web.html) — no monitor on the Pi. **Use a solid power supply** — the
+top cause of 24/7 dropouts is under-powering the Pi.
+</div>
+
+## Why a Pi for always-on scanning
+
+A desktop PC works, but it is overkill for a job that runs forever. A
+[Raspberry Pi](https://www.amazon.com/dp/B0CK2FCG1K?tag=gophertrunk-20) is the natural
+home for a permanent GopherTrunk decoder because it is:
+
+- **Low power and silent.** A Pi 5 sips a few watts — cheap to leave on 24/7, with no
+  fan noise if you cool it passively.
+- **Headless by design.** GopherTrunk is a single Go binary; it runs with no desktop and
+  is driven entirely through its [web console](/web.html), so the Pi needs no monitor,
+  keyboard, or mouse once configured.
+- **Small enough to live at the antenna.** Mount it in a closet, attic, or by a window
+  right where the feedline comes in, minimizing coax loss to the dongle.
+- **Plenty capable.** A Pi 5's cores decode one or more [P25](/reference/project-25/) /
+  DMR / NXDN control channels plus voice with headroom to spare.
+
+## The parts list
+
+| Part | Why | Pick | Approx $ |
+|---|---|---|---|
+| **Raspberry Pi 5 (8GB)** | The always-on host | [Pi 5 8GB](https://www.amazon.com/dp/B0CK2FCG1K?tag=gophertrunk-20) | ~$80 |
+| **SDR dongle** | Receives the radio | [RTL-SDR Blog V4](/reference/rtl-sdr/) / [NESDR](/reference/nesdr/) | ~$35–40 |
+| **Active USB extension** | Stable power, moves the warm dongle away | [Shielded active repeater cable](https://www.amazon.com/dp/B00BWK9VZ2?tag=gophertrunk-20) | ~$15 |
+| **Antenna + adapter** | Actually hears signals | [Dipole](/reference/dipole-antenna/) / [discone](/reference/discone-antenna/) | ~$25–40 |
+| **Official power supply + cooling** | Reliability | Official USB-C PSU, active cooler | ~$20 |
+
+Full shopping context is in the
+[what-you-need checklist](/what-do-i-need-for-gophertrunk/) and the dongle rundown in
+[best SDR for GopherTrunk](/best-sdr-for-gophertrunk/).
+
+## Power and USB — the reliability part
+
+Almost every "my Pi scanner randomly drops out" story comes down to **power and USB**,
+not software. Two rules:
+
+> **Feed the Pi properly.** Use the official USB-C supply. A Pi 5 driving a
+> power-hungry, warm-running [RTL-SDR](/reference/rtl-sdr/) on a marginal charger will
+> brown out and throw USB errors. Adequate, stable power is the single biggest
+> reliability factor.
+
+An **[active (powered) USB extension cable](https://www.amazon.com/dp/B00BWK9VZ2?tag=gophertrunk-20)**
+does double duty: it provides a cleaner power path to the dongle *and* moves the hot
+dongle away from the Pi's board and away from RF-noisy USB 3 ports. If you run several
+dongles, use a **powered USB hub** instead so the Pi is not asked to source all that
+current itself — see the [multi-dongle setup guide](/multi-dongle-sdr-setup/).
+
+## Remote access through the web console
+
+The payoff of a headless Pi is GopherTrunk's **[web console](/web.html)**. Once the Pi
+is running, point any browser on your network at its address and you get live spectrum,
+per-call logs with timestamps, and full control — no screen attached to the Pi at all.
+Tune it from the couch, check overnight logs from work, or watch calls scroll in on your
+phone. This is what turns a Pi in a closet into a genuinely convenient scanner.
+
+## Setup in brief
+
+1. Flash **64-bit Raspberry Pi OS** and boot the Pi headless (enable SSH, join Wi-Fi or
+   Ethernet).
+2. [Download the GopherTrunk binary](/downloads.html) for ARM64 and follow the
+   [hardware setup guide](/hardware.html).
+3. Plug the [RTL-SDR](/reference/rtl-sdr/) in through the
+   [active extension](https://www.amazon.com/dp/B00BWK9VZ2?tag=gophertrunk-20); attach
+   the antenna.
+4. Enter your system's control channel (look it up on
+   [RadioReference](https://www.radioreference.com/)), start GopherTrunk, and open the
+   [web console](/web.html) from another device.
+5. Set it to start on boot so it comes back after any power blip.
+
+## Bottom line
+
+For a scanner that just *runs*, a
+**[Raspberry Pi 5](https://www.amazon.com/dp/B0CK2FCG1K?tag=gophertrunk-20) + a
+[RTL-SDR](/reference/rtl-sdr/) + an
+[active USB extension](https://www.amazon.com/dp/B00BWK9VZ2?tag=gophertrunk-20)** is the
+sweet spot: cheap, silent, always on, and controlled entirely through GopherTrunk's
+[web console](/web.html). Get the power supply right, place it near the antenna, and you
+have a purpose-built digital scanner logging every call around the clock. Start from the
+[hardware guide](/hardware.html) and the
+[what-you-need checklist](/what-do-i-need-for-gophertrunk/).

--- a/docs/reference/airspy-hf-plus.md
+++ b/docs/reference/airspy-hf-plus.md
@@ -7,6 +7,14 @@ description: "Airspy HF+ is a software-defined radio optimised for the HF and lo
 keywords: Airspy HF+, Airspy HF plus, HF+ Discovery, HF SDR, shortwave receiver, high dynamic range, polyphase harmonic rejection, low VHF, 18-bit
 aka: [Airspy HF+, Airspy HF plus, HF+ Discovery]
 autolink: true
+affiliate: true
+product:
+  name: "Airspy HF+ Discovery"
+  brand: Airspy
+  category: Software-defined radio
+  lowPrice: "155"
+  highPrice: "185"
+  url: https://www.amazon.com/s?k=Airspy+HF+Discovery&tag=gophertrunk-20
 infobox:
   - { label: Type, value: HF / low-VHF SDR receiver }
   - { label: Vendor, value: Airspy }
@@ -14,6 +22,8 @@ infobox:
   - { label: Range, value: "~9 kHz – 31 MHz, 60–260 MHz" }
   - { label: Bandwidth, value: up to ~768 kHz }
   - { label: TX, value: No (receive only) }
+  - { label: Price, value: around $170 }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/s?k=Airspy+HF+Discovery&tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
 see_also: [airspy, rtl-sdr, sdrplay-rsp1a, funcube-dongle, upconverter, ionospheric-propagation, frequency-bands, dynamic-range]
 related_lessons:
   - { title: "SDR hardware — RTL-SDR, HackRF, Airspy", url: /learn/rf-sdr/sdr-hardware/ }
@@ -22,6 +32,15 @@ related_reading:
 cite_urls:
   - https://en.wikipedia.org/wiki/Software-defined_radio
   - https://airspy.com/airspy-hf-discovery/
+faq:
+  - q: "Is the Airspy HF+ Discovery the right SDR for GopherTrunk?"
+    a: "Only if the low bands are your target. GopherTrunk decodes land-mobile trunking (P25/DMR/NXDN/TETRA) that lives in VHF/UHF, where an Airspy R2 or an RTL-SDR is the right radio. The HF+ Discovery is the pick when you also want shortwave, amateur SSB/CW or marine HF — its dynamic range is the best in class on a crowded low band. GopherTrunk can drive it as a receiver, but its wideband-channelizer strengths don't apply to the HF+'s narrow captures."
+  - q: "Why choose the HF+ Discovery over an RTL-SDR with an upconverter for HF?"
+    a: "Dynamic range. On HF the challenge is not sensitivity but surviving dozens of strong broadcasters at once. The HF+ Discovery's polyphase harmonic-rejection mixer and high-resolution ADC hear a weak signal next to a broadcaster tens of dB louder, where an 8-bit RTL-SDR plus a lossy upconverter or direct-sampling hack folds under overload."
+  - q: "How wide a capture does the HF+ Discovery give?"
+    a: "Up to about 768 kHz — deliberately narrow. That is all a shortwave, marine or amateur channel needs, and keeping the window small is exactly what lets the ADC deliver its very high dynamic range. It will not give you the 10 MHz-wide slice an Airspy R2 does."
+  - q: "Can it decode encrypted transmissions?"
+    a: "No. The HF+ Discovery is receive-only and GopherTrunk is a receive-only decoder — no SDR or scanner can decode AES-encrypted traffic."
 ---
 
 **Airspy HF+** is a [software-defined radio](/reference/software-defined-radio/)
@@ -43,6 +62,23 @@ broadcaster can otherwise desensitise the whole receiver.
 </svg>
 <figcaption>The Airspy HF+ covers HF (to ~31 MHz) and a low-VHF window (60–260 MHz), trading wide bandwidth for exceptional dynamic range.</figcaption>
 </figure>
+
+<a class="btn btn--buy" href="https://www.amazon.com/s?k=Airspy+HF+Discovery&tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The HF / low-VHF dynamic-range champion.** The Airspy HF+ Discovery covers HF (to
+~31 MHz) and a low-VHF window (60–260 MHz) with a narrow (~768 kHz), exceptionally
+clean capture — its polyphase harmonic-rejection mixer and high-resolution ADC survive
+a crowded shortwave band where cheaper receivers fold under overload. **Pick it if you
+want shortwave or ham HF too**, not primarily for scanning:
+[GopherTrunk](/downloads.html)'s trunking targets ([P25](/reference/project-25/),
+[DMR](/reference/dmr/), [NXDN](/reference/nxdn/)) live in VHF/UHF, where an
+[Airspy R2](/reference/airspy/) or an [RTL-SDR](/reference/rtl-sdr/) is the right radio.
+**Receive-only, ~$170.** Like every receiver it can't decode
+[AES encryption](/police-scanner-encryption/). See
+[best SDR for GopherTrunk](/best-sdr-for-gophertrunk/).
+</div>
 
 ## How it works
 
@@ -91,6 +127,24 @@ trunking systems GopherTrunk decodes (P25, DMR, NXDN, TETRA) live in VHF/UHF, wh
 [Airspy R2](/reference/airspy/) or an RTL-SDR is the right radio. GopherTrunk can drive
 the HF+ as a receiver, but its wideband-channelizer strengths don't apply to the HF+'s
 narrow captures. Choose the HF+ when the low bands themselves are what you want to hear.
+
+## Where to buy
+
+The current mainstream model is the **Airspy HF+ Discovery**. Airspy sells through its
+own distributor network, so Amazon stock is intermittent — the button below is a tagged
+search that resolves to the live listings rather than a single page that may be out of
+stock.
+
+<a class="btn btn--buy" href="https://www.amazon.com/s?k=Airspy+HF+Discovery&tag=gophertrunk-20" rel="nofollow sponsored noopener">Airspy HF+ Discovery on Amazon &rarr;</a>
+
+If your target is really VHF/UHF trunking rather than the low bands, an
+[Airspy R2](/reference/airspy/) or an [RTL-SDR](/reference/rtl-sdr/) is the better buy —
+see [best SDR for GopherTrunk](/best-sdr-for-gophertrunk/) and, if you're comparing
+against a handheld, [police scanner vs SDR](/police-scanner-vs-sdr/). Then get the
+software from the [downloads page](/downloads.html).
+
+*As an Amazon Associate, GopherTrunk earns from qualifying purchases — at no extra cost
+to you. It never changes what we recommend.*
 
 ## Sources
 

--- a/docs/reference/airspy.md
+++ b/docs/reference/airspy.md
@@ -7,6 +7,14 @@ description: "Airspy is a line of high-performance VHF/UHF software-defined radi
 keywords: Airspy, Airspy R2, Airspy Mini, high performance SDR, VHF UHF receiver, 12-bit ADC, real-to-complex, oversampling, wideband capture
 aka: [Airspy]
 autolink: true
+affiliate: true
+product:
+  name: "Airspy R2"
+  brand: Airspy
+  category: Software-defined radio
+  lowPrice: "150"
+  highPrice: "185"
+  url: https://www.amazon.com/s?k=Airspy+R2+SDR&tag=gophertrunk-20
 infobox:
   - { label: Type, value: VHF/UHF SDR receiver }
   - { label: Vendor/Chip, value: "Airspy; R820T2 tuner + LPC4370" }
@@ -15,6 +23,8 @@ infobox:
   - { label: Range, value: ~24 MHz – 1.8 GHz }
   - { label: Bandwidth, value: up to ~10 MHz (R2) }
   - { label: TX, value: No (receive only) }
+  - { label: Price, value: around $110–170 }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/s?k=Airspy+R2+SDR&tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
 see_also: [rtl-sdr, rtl2832u, r820t-tuner, airspy-hf-plus, hackrf, sdrplay-rsp1a, dynamic-range, software-defined-radio]
 related_lessons:
   - { title: "SDR hardware — RTL-SDR, HackRF, Airspy", url: /learn/rf-sdr/sdr-hardware/ }
@@ -23,6 +33,15 @@ related_reading:
 cite_urls:
   - https://en.wikipedia.org/wiki/Software-defined_radio
   - https://airspy.com/airspy-r2/
+faq:
+  - q: "Is an Airspy worth it over an RTL-SDR for GopherTrunk?"
+    a: "For tough or busy RF, yes. The Airspy's 12-bit ADC carries far more dynamic range than an RTL-SDR's 8-bit converter, and its wider capture (up to ~10 MS/s on the R2) lets a single dongle channelize multiple control channels at once. For a first radio on a clean single-site system a $30 RTL-SDR is still the cheapest thing that works — step up to an Airspy when bandwidth or sensitivity is the thing standing between you and a decode."
+  - q: "Airspy R2 or Airspy Mini?"
+    a: "Same architecture and 12-bit front end; the R2 captures up to ~10 MS/s with a clock output and a bias tee, the Mini tops out around 6 MS/s in a smaller, cheaper dongle. Choose the R2 for wideband multi-site channelizing; the Mini if you want most of the quality in a more portable, lower-cost package."
+  - q: "Does GopherTrunk need libairspy or SoapySDR to use an Airspy?"
+    a: "No. GopherTrunk drives the Airspy directly over USB with a pure-Go backend — no libairspy, no SoapySDR. It is the recommended device for GopherTrunk's wideband, multi-tap channelizer role."
+  - q: "Can an Airspy decode encrypted police channels?"
+    a: "No. An Airspy is a receiver, and GopherTrunk is receive-only. It decodes clear P25/DMR/NXDN/TETRA traffic but no radio or scanner can decode AES-encrypted transmissions."
 ---
 
 **Airspy** is a line of high-performance VHF/UHF
@@ -39,6 +58,22 @@ smaller Mini) offering better sensitivity, dynamic range, and wider
 </svg>
 <figcaption>Airspy adds sensitivity and bandwidth over RTL-SDR across VHF/UHF.</figcaption>
 </figure>
+
+<a class="btn btn--buy" href="https://www.amazon.com/s?k=Airspy+R2+SDR&tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**12-bit, cleaner decode than [RTL-SDR](/reference/rtl-sdr/).** The Airspy R2/Mini
+carry roughly **72 dB** of [dynamic range](/reference/dynamic-range/) against an
+RTL-SDR's ~48 dB, and capture up to **~10 MS/s** — so they decode weak and busy
+[P25](/reference/project-25/)/[DMR](/reference/dmr/)/[NXDN](/reference/nxdn/) channels
+an 8-bit dongle stumbles on. **This is GopherTrunk's recommended wideband /
+multi-site channelizer:** one Airspy can follow several sites of one system out of a
+single capture. **Receive-only, ~$110–170.** Airspy is distributor-sold, so Amazon
+stock is intermittent — the button tracks live listings. Like every receiver it can't
+decode [AES encryption](/police-scanner-encryption/). New here? See
+[best SDR for GopherTrunk](/best-sdr-for-gophertrunk/).
+</div>
 
 ## Overview
 
@@ -197,6 +232,26 @@ cleanly.
 > shedding samples on the host — that is an overrun (degraded decode), *not* the
 > reaper death above, which the `IQ stream died` cause line identifies
 > separately.
+
+## Where to buy
+
+Airspy is sold through its own distributor network, so Amazon stock comes and goes —
+the buttons below are tagged searches that always resolve to the current listings
+rather than a single product page that may be out of stock. Get the **R2** for the
+full ~10 MS/s wideband capture and clock output, or the smaller **Mini** for most of
+the quality at a lower price.
+
+<a class="btn btn--buy" href="https://www.amazon.com/s?k=Airspy+R2+SDR&tag=gophertrunk-20" rel="nofollow sponsored noopener">Airspy R2 on Amazon &rarr;</a>
+<a class="btn btn--buy" href="https://www.amazon.com/s?k=Airspy+Mini+SDR&tag=gophertrunk-20" rel="nofollow sponsored noopener">Airspy Mini on Amazon &rarr;</a>
+
+Deciding between radios? See [best SDR for GopherTrunk](/best-sdr-for-gophertrunk/),
+compare against the [RTL-SDR](/reference/rtl-sdr/) and [HackRF One](/reference/hackrf/),
+or, if you also want shortwave/ham HF, the [Airspy HF+](/reference/airspy-hf-plus/).
+Weighing a scanner instead? Read [police scanner vs SDR](/police-scanner-vs-sdr/).
+Then grab GopherTrunk from the [downloads page](/downloads.html).
+
+*As an Amazon Associate, GopherTrunk earns from qualifying purchases — at no extra cost
+to you. It never changes what we recommend.*
 
 ## Sources
 

--- a/docs/reference/bias-tee.md
+++ b/docs/reference/bias-tee.md
@@ -7,16 +7,34 @@ description: A bias tee injects DC power onto the coax feeding an antenna-mounte
 keywords: bias tee, bias-T, DC injection, LNA power, phantom power, coax, mast-mounted amplifier, inductor capacitor network
 aka: [bias tee, bias-T]
 autolink: true
+affiliate: true
+product:
+  name: "NooElec NESDR SMArTee v2"
+  brand: NooElec
+  category: RTL-SDR with built-in bias tee
+  lowPrice: "34"
+  highPrice: "46"
+  url: https://www.amazon.com/dp/B079C3FHPG?tag=gophertrunk-20
 infobox:
   - { label: Type, value: RF/DC combining network }
   - { label: Function, value: DC power up the coax, RF through }
   - { label: Powers, value: Antenna-mounted LNA / active antenna }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B079C3FHPG?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
 see_also: [low-noise-amplifier, preamplifier, coaxial-cable, antenna, rtl-sdr, sma-connector]
 related_lessons:
   - { title: "How an SDR receiver works", url: /learn/rf-sdr/sdr-receiver/ }
 cite_urls:
   - https://en.wikipedia.org/wiki/Bias_tee
   - https://en.wikipedia.org/wiki/Inductor
+faq:
+  - q: "What does a bias tee do on an SDR?"
+    a: "It injects DC power up the coax to run an antenna-mounted device — usually a low-noise amplifier or active antenna — while passing the received RF straight through to the receiver. A series capacitor blocks the DC from the SDR's input and a shunt inductor feeds the voltage to the amplifier, so one cable carries both signal and power."
+  - q: "Do I need a separate bias tee, or is one built in?"
+    a: "Many SDRs already include a software-switchable bias tee, so you may not need a separate module. The RTL-SDR Blog V3/V4 and the NooElec NESDR SMArTee v2 (around $40, an always-on 4.5 V feed) can power an inline LNA directly. Buy a standalone inline bias tee only when the amplifier needs more current or a different voltage."
+  - q: "Which SDR has the best built-in bias tee for a mast LNA?"
+    a: "For SDR scanning, the NESDR SMArTee v2 is a convenient pick because its bias tee is always on and needs no software toggle, so a masthead LNA powers up the moment the dongle is plugged in. The RTL-SDR Blog V3/V4 offer a software-enabled bias tee if you prefer to switch it on only when needed."
+  - q: "Can a bias tee damage my SDR?"
+    a: "It can if misused. Never enable a bias tee into a device not expecting DC — a passive antenna, a DC-grounded filter input, or a splitter can short the supply and, at worst, damage the SDR. Check the current rating against the LNA's draw and confirm the connector polarity first."
 ---
 
 A **bias tee** is a small three-port network that injects **DC power onto the coax**
@@ -83,6 +101,20 @@ for ADS-B, satellite, and weak-signal work. GopherTrunk itself is purely a decod
 not toggle bias-tee hardware, but the practice it enables — a low-noise amplifier at the
 antenna over a single feedline — directly improves the [SNR](/reference/signal-to-noise-ratio/)
 of the [IQ](/reference/iq-data/) stream GopherTrunk decodes.
+
+## Where to buy
+
+The easiest way to get a bias tee for SDR use is to buy a dongle that already has
+one. For scanner use the **NooElec NESDR SMArTee v2** (around $40) is the standard
+pick — an RTL-SDR with an always-on 4.5 V bias tee, so a mast-mounted
+[LNA](/reference/low-noise-amplifier/) powers up with no software toggle. The
+[RTL-SDR Blog V3/V4](/reference/rtl-sdr/) offer a software-switchable bias tee
+instead if you'd rather enable it only when needed.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B079C3FHPG?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+*As an Amazon Associate, GopherTrunk earns from qualifying purchases — at no extra
+cost to you. It never changes what we recommend.*
 
 ## Sources
 

--- a/docs/reference/bladerf.md
+++ b/docs/reference/bladerf.md
@@ -7,6 +7,14 @@ description: "BladeRF is Nuand's line of USB 3.0 full-duplex transceiver SDRs bu
 keywords: BladeRF, bladeRF 2.0 micro, Nuand, FPGA SDR, LMS6002D, AD9361, Cyclone IV, Cyclone V, full duplex transceiver, USB 3.0 SDR, xA4, xA9
 aka: [BladeRF, blade RF, bladeRF 2.0 micro]
 autolink: true
+affiliate: true
+product:
+  name: "bladeRF 2.0 micro"
+  brand: Nuand
+  category: Software-defined radio
+  lowPrice: "480"
+  highPrice: "720"
+  url: https://www.amazon.com/s?k=bladeRF+2.0&tag=gophertrunk-20
 infobox:
   - { label: Type, value: USB full-duplex transceiver SDR }
   - { label: Vendor, value: Nuand }
@@ -15,11 +23,22 @@ infobox:
   - { label: Range, value: "47 MHz – 6 GHz (2.0 micro)" }
   - { label: Bandwidth, value: up to ~56 MHz }
   - { label: TX, value: Yes (full duplex) }
+  - { label: With GopherTrunk, value: Network only (SoapySDR/rtl_tcp bridge) }
   - { label: Typical price, value: "$480 – $720" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/s?k=bladeRF+2.0&tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
 see_also: [software-defined-radio, field-programmable-gate-array, hackrf, usrp-ettus, limesdr, rtl-sdr]
 cite_urls:
   - https://en.wikipedia.org/wiki/BladeRF
   - https://www.nuand.com/bladerf-2-0-micro/
+faq:
+  - q: "Does GopherTrunk support the bladeRF?"
+    a: "Yes, but network only. GopherTrunk's pure-Go USB drivers cover RTL-SDR, HackRF, and Airspy — not Nuand's libbladeRF stack. You drive the bladeRF over the network via a SoapySDRServer/SoapyRemote (or rtl_tcp) bridge: run the Soapy module and server on the machine it's plugged into, then mount it over TCP. See the hardware guide."
+  - q: "Does GopherTrunk use the bladeRF's FPGA or transmit path?"
+    a: "No. GopherTrunk is a receive-only decoder and treats the bladeRF as a plain wideband IQ source over the bridge — it loads no custom FPGA images and never keys the transmitter. The FPGA and TX chain are the bladeRF's strengths for other projects, not for trunk-tracking."
+  - q: "Is a bladeRF worth it just for scanning?"
+    a: "For most users, no. At $480–$720 it is many times the price of an RTL-SDR, and its 12-bit front end and wide capture bandwidth — while capable of channelising several control channels at once — are more radio than trunk-tracking needs. If you already own one it makes a capable capture front end; if you're buying for scanning, an RTL-SDR pool or an Airspy is cheaper and better matched."
+  - q: "bladeRF x40 or bladeRF 2.0 micro for GopherTrunk?"
+    a: "The 2.0 micro (AD9361, Cyclone V) is the current generation, covering ~47 MHz–6 GHz with up to ~56 MHz bandwidth — the one to get for VHF/UHF trunking coverage. Either way it feeds GopherTrunk only through the SoapySDR/rtl_tcp bridge, not as a direct USB device."
 ---
 
 **BladeRF** is a line of USB 3.0
@@ -51,6 +70,28 @@ custom real-time DSP in fabric before samples ever reach the host.
 </svg>
 <figcaption>An RF transceiver front end feeds an on-board FPGA that can process samples before they cross USB 3.0 to the host.</figcaption>
 </figure>
+
+<a class="btn btn--buy" href="https://www.amazon.com/s?k=bladeRF+2.0&tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**FPGA-equipped full-duplex transceiver — overkill for scanning.** Nuand's bladeRF pairs a
+12-bit front end with an on-board [FPGA](/reference/field-programmable-gate-array/) and true
+transmit/receive; the 2.0 micro covers ~47 MHz–6 GHz with up to ~56 MHz of bandwidth.
+GopherTrunk uses none of the FPGA or TX capability — just its wideband IQ. **GopherTrunk
+support is network only:** it drives the bladeRF over a
+[SoapySDR](/reference/soapysdr/)/[rtl_tcp](/reference/rtl-tcp/) bridge, not as a direct USB
+device, because the pure-Go USB drivers cover only RTL-SDR, HackRF, and Airspy. At
+**$480–$720** it's far more radio than trunk-tracking needs. Like every receiver, it can't
+decode [AES encryption](/police-scanner-encryption/).
+</div>
+
+> **GopherTrunk support: network only.** GopherTrunk drives the bladeRF over the network via
+> SoapySDRServer/SoapyRemote (or an `rtl_tcp`-style bridge), not as a direct USB device —
+> you run the `libbladeRF`-backed [SoapySDR](/reference/soapysdr/) module and server on the
+> machine it's plugged into and mount it over TCP. GopherTrunk's pure-Go USB drivers cover
+> only RTL-SDR, HackRF, and Airspy. See the [hardware guide](/hardware.html) and
+> [rtl_tcp](/reference/rtl-tcp/) notes.
 
 ## Overview
 
@@ -104,6 +145,21 @@ and wide capture bandwidth can channelise several control channels at once, much
 BladeRF is more radio than trunk-tracking needs — an RTL-SDR pool or an Airspy is the
 cheaper, better-matched tool — but if you already own one, it is a capable capture front
 end. See the [hardware guide](/hardware.html) for GopherTrunk's tested devices.
+
+## Where to buy
+
+The bladeRF is sold by Nuand and its distributors, and listed on Amazon. Before buying one
+for GopherTrunk, note the integration path: it is supported **over the network only**,
+through a [SoapySDR](/reference/soapysdr/)/[rtl_tcp](/reference/rtl-tcp/) bridge rather than
+GopherTrunk's direct USB drivers — see the [hardware guide](/hardware.html). For pure
+trunk-tracking a [RTL-SDR](/reference/rtl-sdr/) pool or an [Airspy](/reference/airspy/) is
+the cheaper, better-matched tool; the bladeRF earns its keep on FPGA and transmit projects,
+and doubles as a capable capture front end if you already own one.
+
+<a class="btn btn--buy" href="https://www.amazon.com/s?k=bladeRF+2.0&tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+*As an Amazon Associate, GopherTrunk earns from qualifying purchases — at no extra cost
+to you. It never changes what we recommend.*
 
 ## Sources
 

--- a/docs/reference/coaxial-cable.md
+++ b/docs/reference/coaxial-cable.md
@@ -7,12 +7,29 @@ description: "Coaxial cable carries RF from antenna to receiver on a shielded ce
 keywords: coaxial cable, coax, feedline, RG-58, RG-6, LMR-400, cable loss, shield, impedance, velocity factor, characteristic impedance
 aka: [coax, "coaxial cable", feedline]
 autolink: true
+affiliate: true
+product:
+  name: "NooElec SMA coaxial cable connectivity kit"
+  brand: NooElec
+  category: SDR coaxial cable kit
+  lowPrice: "15"
+  highPrice: "21"
+  url: https://www.amazon.com/dp/B077H87LTS?tag=gophertrunk-20
 see_also: [attenuation, path-loss, antenna, standing-wave-ratio, low-noise-amplifier, sma-connector, n-type-connector]
 related_lessons:
   - { title: "Antennas 101", url: /learn/rf-sdr/antennas/ }
 cite_urls:
   - https://en.wikipedia.org/wiki/Coaxial_cable
   - https://en.wikipedia.org/wiki/Characteristic_impedance
+faq:
+  - q: "What coax should I buy for an SDR?"
+    a: "For short bench and patch leads with the SMA connectors SDRs use, a NooElec SMA cable connectivity kit (around $18) covers the common lengths and adapters. For any run over a few metres, especially at UHF or 800 MHz, step up to low-loss RG8X or LMR-400 rather than thin RG58, which throws away too much signal over distance."
+  - q: "How much does cable loss matter for scanning?"
+    a: "A lot on the higher bands. Loss grows with frequency, so a long thin cable that is fine at HF can cost several dB at 1 GHz — and 6 dB of feedline loss throws away three-quarters of the signal before it reaches the SDR. Keep runs short and thick, or mount an LNA at the antenna so its gain is applied before the cable loss."
+  - q: "RG58 or RG8X for an SDR feedline?"
+    a: "RG58 (or thin RG174) is fine only for short patch leads. For a real feedline run use RG8X for moderate lengths or LMR-400/RG213 for masthead installs — the extra thickness cuts loss sharply at VHF/UHF. RG6 (75 Ω TV cable) is also excellent and cheap for receive-only use if you accept the minor impedance mismatch."
+  - q: "Do connectors and adapters add loss too?"
+    a: "Yes — each junction adds a small insertion loss and a potential mismatch, so use the fewest transitions you can. Weatherproof any outdoor connectors, since water in coax raises loss dramatically."
 ---
 
 **Coaxial cable** ("coax") carries RF between the [antenna](/reference/antenna/) and
@@ -86,6 +103,22 @@ weak trunking signal is most often lost before digitisation. On a UHF or 800 MHz
 using proper low-loss cable — or moving the SDR to the antenna and streaming
 [IQ](/reference/iq-data/) back over the network — is frequently the single biggest
 improvement to GopherTrunk's decode reliability.
+
+## Where to buy
+
+For the short SMA-terminated patch leads an SDR bench setup needs, a **NooElec SMA
+coaxial cable connectivity kit** (around $18) bundles common lengths and adapters in
+one box. For an actual feedline run of more than a few metres — especially at UHF or
+800 MHz P25 — buy proper low-loss **RG8X** or **LMR-400** by the length instead of
+relying on thin RG58.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B077H87LTS?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+For connectors, adapters, and full cable choices, see the
+[SDR cables and connectors guide](/sdr-cables-and-connectors/).
+
+*As an Amazon Associate, GopherTrunk earns from qualifying purchases — at no extra
+cost to you. It never changes what we recommend.*
 
 ## Sources
 

--- a/docs/reference/dipole-antenna.md
+++ b/docs/reference/dipole-antenna.md
@@ -7,16 +7,34 @@ description: A dipole is a simple resonant antenna of two conductors fed at the 
 keywords: dipole, half-wave dipole, resonant antenna, radiation pattern, balun, feedpoint impedance, dBd, folded dipole
 aka: [dipole antenna, dipole]
 autolink: true
+affiliate: true
+product:
+  name: "RTL-SDR Blog Multipurpose Dipole Antenna Kit"
+  brand: RTL-SDR Blog
+  category: SDR dipole antenna kit
+  lowPrice: "21"
+  highPrice: "29"
+  url: https://www.amazon.com/dp/B075445JDF?tag=gophertrunk-20
 infobox:
   - { label: Type, value: Resonant antenna }
   - { label: Length, value: ~λ/2 (half-wave) }
   - { label: Pattern, value: Omnidirectional broadside }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B075445JDF?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
 see_also: [antenna, monopole-antenna, yagi-uda-antenna, antenna-gain, radiation-pattern, feedpoint-impedance, polarization, wavelength]
 related_lessons:
   - { title: "Antennas 101", url: /learn/rf-sdr/antennas/ }
 cite_urls:
   - https://en.wikipedia.org/wiki/Dipole_antenna
   - https://en.wikipedia.org/wiki/Balun
+faq:
+  - q: "Which dipole should I buy for an SDR?"
+    a: "The RTL-SDR Blog Multipurpose Dipole Antenna Kit (around $25) is the standard SDR starter antenna: two telescopic elements you extend to length for your target band, a mount and tripod, and SMA coax. It is a cheap, effective step up from the tiny whip that ships with most dongles."
+  - q: "How do I set the dipole length for my band?"
+    a: "Each element is about a quarter wavelength: total half-wave length in metres is roughly 143 / f(MHz), so extend each side to half of that. Cut for the centre of your target band and it stays usable across a fair range on either side. The RTL-SDR Blog kit includes a length chart for common bands."
+  - q: "Should I mount the dipole vertically or horizontally?"
+    a: "Vertically for scanning. Land-mobile P25, DMR, and NXDN traffic is vertically polarized, so a vertical dipole matches it and stays omnidirectional in the horizontal plane — exactly what you want when signals can come from any bearing. Mount it up high with a clear path."
+  - q: "Is a dipole better than the whip that came with my dongle?"
+    a: "Almost always. A resonant dipole cut for the band hands the SDR a stronger, cleaner signal than the short, poorly grounded rubber-duck whip, which improves lock on weak control channels. A few ferrite chokes on the feedline can clean up a marginal install further."
 ---
 
 A **dipole antenna** is a simple resonant [antenna](/reference/antenna/) made of two
@@ -84,6 +102,21 @@ a wideband SDR that watches many sites at once, and its predictable ~73 Ω feedp
 front end delivers; a resonant dipole simply hands the [ADC](/reference/analog-to-digital-converter/)
 a stronger, cleaner signal than a random wire, improving lock on weak
 [control channels](/reference/control-channel/).
+
+## Where to buy
+
+For SDR and scanner use, the **RTL-SDR Blog Multipurpose Dipole Antenna Kit** (around
+$25) is the standard starter antenna: adjustable telescopic elements you extend to
+length for your target band, plus a mount, tripod, and SMA coax. It is the cheapest
+worthwhile upgrade from the tiny whip bundled with most dongles.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B075445JDF?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+For wideband discones and band-cut options, see the
+[best SDR antenna guide](/best-sdr-antenna/).
+
+*As an Amazon Associate, GopherTrunk earns from qualifying purchases — at no extra
+cost to you. It never changes what we recommend.*
 
 ## Sources
 

--- a/docs/reference/discone-antenna.md
+++ b/docs/reference/discone-antenna.md
@@ -7,14 +7,32 @@ description: A discone is an extremely wideband vertical antenna, a disc over a 
 keywords: discone antenna, disc cone antenna, wideband antenna, scanner antenna, omnidirectional vertical, decade bandwidth, biconical
 aka: [discone, disc-cone antenna]
 autolink: true
+affiliate: true
+product:
+  name: "Discone D3000 wideband antenna (25–3000 MHz)"
+  brand: Tram / generic
+  category: Wideband scanner antenna
+  lowPrice: "34"
+  highPrice: "46"
+  url: https://www.amazon.com/dp/B0CL5ZBN94?tag=gophertrunk-20
 infobox:
   - { label: Type, value: Wideband vertical }
   - { label: Bandwidth, value: Up to ~10:1 (a decade) }
   - { label: Pattern, value: Omnidirectional, vertical }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B0CL5ZBN94?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
 see_also: [biconical-antenna, monopole-antenna, ground-plane-antenna, bandwidth, radiation-pattern]
 cite_urls:
   - https://en.wikipedia.org/wiki/Discone_antenna
   - https://en.wikipedia.org/wiki/Biconical_antenna
+faq:
+  - q: "Which discone should I buy for SDR scanning?"
+    a: "A wideband discone like the D3000 (25–3000 MHz, around $40) is the classic all-round scanner and SDR antenna: one feedline covers VHF, UHF, and beyond, so you can sweep aviation, marine, public-safety trunking, and business bands without swapping hardware. Mount it high with a clear horizon for the best results."
+  - q: "Is a discone good for trunked P25/DMR scanning?"
+    a: "Yes, as a do-everything antenna. Its omnidirectional pattern hears every trunking site at once and its vertical polarization matches land-mobile traffic, which suits GopherTrunk's multi-protocol, multi-band nature. For a single weak, distant site a directional Yagi or a band-cut antenna will hear better, but for 'one antenna, everything,' the discone is hard to beat."
+  - q: "How high should I mount a discone?"
+    a: "As high and clear as practical. A discone is vertically polarized and radiates toward the horizon with a null overhead, so height and an unobstructed sky view matter more than aiming — there is nothing to aim, since it is omnidirectional."
+  - q: "Discone or dipole for a scanner?"
+    a: "A discone trades gain for sheer bandwidth — one antenna covers a decade of frequency. A dipole cut for a target band has more gain there but only over a narrow range. Choose a discone when you monitor many bands at once; choose a dipole when you focus on one band and want the extra signal."
 ---
 
 A **discone antenna** is an ultra-wideband vertical [antenna](/reference/antenna/) formed
@@ -77,6 +95,21 @@ connected while monitoring different systems across the spectrum. The cost is mo
 for a weak, distant single site, a directional [Yagi](/reference/yagi-uda-antenna/) or a
 band-optimized [ground-plane](/reference/ground-plane-antenna/) will hear better, but for
 "one antenna, everything," the discone is hard to beat.
+
+## Where to buy
+
+For general SDR and scanner use, a wideband **Discone D3000** (25–3000 MHz, around
+$40) is the classic single-antenna answer: one feedline covers VHF, UHF, and beyond,
+so you can leave it connected while GopherTrunk monitors different systems across the
+spectrum. Mount it high with a clear horizon.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0CL5ZBN94?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+For dipoles, band-cut antennas, and how the discone compares, see the
+[best SDR antenna guide](/best-sdr-antenna/).
+
+*As an Amazon Associate, GopherTrunk earns from qualifying purchases — at no extra
+cost to you. It never changes what we recommend.*
 
 ## Sources
 

--- a/docs/reference/ferrite-choke.md
+++ b/docs/reference/ferrite-choke.md
@@ -7,16 +7,27 @@ description: "A ferrite choke is a ferrite core clamped over a cable that adds i
 keywords: ferrite choke, ferrite bead, ferrite core, common-mode choke, RFI suppression, EMI filter, snap-on ferrite, clip-on ferrite, cable choke, feedline choke, current balun
 aka: [ferrite choke, "ferrite bead", "clip-on ferrite", "common-mode choke"]
 autolink: true
+affiliate: true
 infobox:
   - { label: Type, value: "Common-mode suppression component" }
   - { label: Material, value: "Ferrite core (NiZn or MnZn mix)" }
   - { label: Key spec, value: "Impedance vs frequency, mix number" }
   - { label: TX, value: "Yes (as feedline choke)" }
   - { label: Typical price, value: "$0.50–$10 each" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/s?k=snap+on+ferrite+choke+kit&tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">Search on Amazon &rarr;</a>" }
 see_also: [balun, coaxial-cable, feedpoint-impedance, dipole-antenna]
 cite_urls:
   - https://en.wikipedia.org/wiki/Ferrite_bead
   - https://en.wikipedia.org/wiki/Ferrite_core
+faq:
+  - q: "Will a ferrite choke reduce noise on my SDR?"
+    a: "Often, yes. Common-mode current on the feedline and USB cable is one of the most common — and most misdiagnosed — noise sources for SDR listeners, showing up as birdies and a raised noise floor. A snap-on ferrite choke of the right mix at the antenna feedpoint and at the SDR end of the USB cable breaks that path and can drop the noise floor by several dB with no change to the wanted signal."
+  - q: "What ferrite choke should I buy for USB/computer noise?"
+    a: "An assorted snap-on (clip-on) ferrite choke kit — around $10 for a mixed pack — is the practical buy, since you clamp them over existing USB and coax cables without cutting anything. Get a variety of sizes so you can fit the USB lead, the power lead, and the feedline. Wind the cable through the core a couple of turns for extra effect at lower frequencies."
+  - q: "Where do I put the ferrite chokes?"
+    a: "Clamp one at the SDR end of the USB cable (the most common source of computer 'hash'), and one on the coax near the antenna feedpoint. For a dipole or other balanced antenna, a choke at the feedpoint also restores balance and keeps the coax shield from becoming part of the antenna."
+  - q: "Does the ferrite mix matter?"
+    a: "Yes. Manganese-zinc mixes (types 31, 43) work best from a few MHz through VHF, while nickel-zinc (type 61) peaks higher into UHF. For general SDR USB and feedline noise a type 31/43 snap-on is the usual first choice; a variety kit lets you try a couple across your bands."
 ---
 
 A **ferrite choke** is a ring or clamp of ferrite material placed around a cable so
@@ -84,6 +95,20 @@ purely part of the analog install ahead of the SDR. Its payoff for GopherTrunk i
 practical: lowering feedline-borne noise directly improves the signal-to-noise ratio
 at the demodulator, which is often the cheapest way to turn a marginal
 control-channel lock into a solid one.
+
+## Where to buy
+
+For SDR use, an assorted **snap-on ferrite choke kit** (around $10) is the practical
+buy — clip-on cores in a range of sizes that clamp over your existing USB and coax
+cables without cutting anything. Fit one at the SDR end of the USB lead (the usual
+source of computer birdies) and one on the feedline near the antenna. Because the
+right size and mix depend on your cables and bands, a variety pack is the safest
+choice.
+
+<a class="btn btn--buy" href="https://www.amazon.com/s?k=snap+on+ferrite+choke+kit&tag=gophertrunk-20" rel="nofollow sponsored noopener">Search on Amazon &rarr;</a>
+
+*As an Amazon Associate, GopherTrunk earns from qualifying purchases — at no extra
+cost to you. It never changes what we recommend.*
 
 ## Sources
 

--- a/docs/reference/hackrf.md
+++ b/docs/reference/hackrf.md
@@ -7,12 +7,23 @@ description: HackRF One is an open-source wideband half-duplex software-defined 
 keywords: HackRF One, Great Scott Gadgets, wideband SDR, transceiver, 1 MHz 6 GHz, transmit
 aka: [HackRF, HackRF One]
 autolink: true
+affiliate: true
+product:
+  name: "HackRF One"
+  brand: Great Scott Gadgets
+  category: Software-defined radio
+  lowPrice: "140"
+  highPrice: "170"
+  url: https://www.amazon.com/dp/B0BKH7Z2NJ?tag=gophertrunk-20
 infobox:
   - { label: Type, value: Wideband SDR transceiver }
   - { label: Vendor, value: Great Scott Gadgets }
   - { label: Range, value: 1 MHz – 6 GHz }
   - { label: Bandwidth, value: up to ~20 MHz }
   - { label: TX, value: Yes (half-duplex) }
+  - { label: With GopherTrunk, value: Receive-only decode }
+  - { label: Price, value: around $150 }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B0BKH7Z2NJ?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
 see_also: [rtl-sdr, airspy, airspy-hf-plus, bladerf, limesdr, plutosdr, sdrplay-rsp1a, zadig, software-defined-radio]
 related_lessons:
   - { title: "SDR hardware — RTL-SDR, HackRF, Airspy", url: /learn/rf-sdr/sdr-hardware/ }
@@ -20,6 +31,15 @@ related_reading:
   - { title: "RF Front End, Part 11: HackRF One", url: /blog/deep-dives/rf-front-end-11-hackrf-one/ }
 cite_urls:
   - https://en.wikipedia.org/wiki/HackRF_One
+faq:
+  - q: "Is the HackRF One good for police scanning with GopherTrunk?"
+    a: "It works, but it is overkill. HackRF's 8-bit ADC gives less dynamic range than an Airspy, and its transmit and 6 GHz reach are wasted on receive-only VHF/UHF scanning. For following P25/DMR/NXDN trunked systems, a $30 RTL-SDR or an Airspy is usually the better buy. Reach for a HackRF when you also want its huge tuning range or transmit for other projects."
+  - q: "Can GopherTrunk transmit with a HackRF?"
+    a: "No. GopherTrunk is a receive-only decoder — it uses the HackRF purely as a receiver. Transmitting also requires appropriate licensing and is outside GopherTrunk's scope."
+  - q: "Does GopherTrunk need libhackrf or hackrf-tools?"
+    a: "No. GopherTrunk speaks the HackRF's USB protocol directly with a pure-Go driver. On Linux you add one udev rule; on Windows the in-box WinUSB driver usually binds automatically. No SoapySDR or vendor C libraries required."
+  - q: "HackRF One or Airspy for GopherTrunk?"
+    a: "For scanning, the Airspy — its 12-bit ADC and cleaner front end decode weak and busy channels better than the HackRF's 8-bit sampling. Choose the HackRF only if you need 1 MHz–6 GHz coverage or transmit for other work."
 ---
 
 **HackRF One** is an open-source, wideband, half-duplex
@@ -36,6 +56,19 @@ Gadgets, covering **1 MHz to 6 GHz** with up to ~20 MHz bandwidth and the abilit
 </svg>
 <figcaption>HackRF spans a huge range and can transmit, but with lower dynamic range — overkill for scanning.</figcaption>
 </figure>
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0BKH7Z2NJ?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Huge range, transmit-capable, 8-bit.** HackRF One covers **1 MHz–6 GHz** and can
+transmit — but its 8-bit ADC gives less dynamic range than an
+[Airspy](/reference/airspy/), and **GopherTrunk uses it receive-only**. **For scanning
+it's overkill:** a ~$30 [RTL-SDR](/reference/rtl-sdr/) or an Airspy decodes
+[P25](/reference/project-25/)/[DMR](/reference/dmr/)/[NXDN](/reference/nxdn/) better for
+less. **Buy it** if you also want 6 GHz reach or transmit for other projects. **~$150.**
+Like every receiver, it can't decode [AES encryption](/police-scanner-encryption/).
+</div>
 
 ## Overview
 
@@ -130,6 +163,20 @@ full serial so each entry pins exactly one device.
 > string — the leading 16 digits are a constant prefix (commonly all zeros) and
 > the trailing digits are the unique part. `gophertrunk sdr list` prints the
 > whole string, matching `hackrf_info`'s "Serial number".
+
+## Where to buy
+
+The HackRF One is sold by Great Scott Gadgets and resellers; the Amazon listing below
+is a Nooelec bundle that adds an ANT500 telescopic antenna and SMA adapters — a
+convenient way to get on the air. If you only want to *scan* trunked systems, a
+[RTL-SDR](/reference/rtl-sdr/) or [Airspy](/reference/airspy/) is the cheaper, better-
+suited pick — see [best SDR for GopherTrunk](/best-sdr-for-gophertrunk/) and
+[Airspy vs RTL-SDR vs HackRF](/airspy-vs-rtl-sdr-vs-hackrf/).
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0BKH7Z2NJ?tag=gophertrunk-20" rel="nofollow sponsored noopener">HackRF One bundle on Amazon &rarr;</a>
+
+*As an Amazon Associate, GopherTrunk earns from qualifying purchases — at no extra cost
+to you. It never changes what we recommend.*
 
 ## Sources
 

--- a/docs/reference/krakensdr.md
+++ b/docs/reference/krakensdr.md
@@ -19,6 +19,15 @@ see_also: [rtl-sdr, music-algorithm, beamforming, multilateration, rtl2832u, sof
 cite_urls:
   - https://en.wikipedia.org/wiki/RTL-SDR
   - https://www.krakenrf.com/
+faq:
+  - q: "Does GopherTrunk support the KrakenSDR?"
+    a: "Yes, in the sense that each of its five channels is an ordinary R820T2/RTL2832U RTL-SDR, which GopherTrunk drives natively over USB with its pure-Go driver — so you can treat a KrakenSDR as up to five plain RTL-SDR IQ sources. GopherTrunk does not use the array's phase-coherence or direction-finding features; there is no reason to buy a KrakenSDR just for decoding."
+  - q: "Can GopherTrunk do radio direction finding with a KrakenSDR?"
+    a: "No. GopherTrunk is a trunking decoder, not a DF platform — it does not use the coherent array or the MUSIC direction-of-arrival math. Direction finding and passive radar require KrakenRF's own open-source software, which is the reason to own the hardware."
+  - q: "Is a KrakenSDR worth it for scanning trunked systems?"
+    a: "Not on its own merits. It is five 8-bit RTL-SDRs priced for a DF niche; for decoding, a single good RTL-SDR or an Airspy is cheaper and simpler. Buy a KrakenSDR when you actually want direction finding or passive radar."
+  - q: "Where do I buy a KrakenSDR?"
+    a: "Direct from KrakenRF (krakenrf.com) and via Crowd Supply — it is not sold on Amazon. Beware third-party listings claiming otherwise."
 ---
 
 **KrakenSDR** is a **five-channel, phase-coherent** [RTL-SDR](/reference/rtl-sdr/)
@@ -52,6 +61,19 @@ arrival** of a signal using array-processing algorithms.
 </svg>
 <figcaption>Five coherent channels plus a switched noise source for phase calibration let the array compute a signal's bearing.</figcaption>
 </figure>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Five phase-coherent RTL-SDRs built for direction finding.** KrakenSDR shares one reference
+clock across five [R820T2](/reference/rtl2832u/) tuners plus a switched noise source, so it
+can run the [MUSIC](/reference/music-algorithm/) direction-of-arrival math and passive radar
+that independent dongles can't. **With GopherTrunk** each channel is just a plain
+[RTL-SDR](/reference/rtl-sdr/) it drives natively over USB — you can use it as up to five IQ
+sources — but GopherTrunk uses **none** of the coherent-array or DF features, so there's no
+reason to buy one purely for decoding. **Direction finding needs KrakenRF's own software.**
+**Sold direct** from KrakenRF / Crowd Supply — **not on Amazon**. Like every RTL-SDR, it's
+8-bit and can't decode [AES encryption](/police-scanner-encryption/).
+</div>
 
 ## Overview
 
@@ -102,6 +124,17 @@ or an [Airspy](/reference/airspy/) is the right tool. KrakenSDR is worth knowing
 canonical example of how cheap coherent receivers bring array signal processing —
 direction finding, [MUSIC](/reference/music-algorithm/), passive radar — within hobbyist
 reach.
+
+## Where to buy
+
+The KrakenSDR is sold **direct from [KrakenRF](https://www.krakenrf.com/)**
+and through Crowd Supply — it is **not** available on Amazon, so treat any Amazon listing
+claiming to be a KrakenSDR with suspicion. With GopherTrunk it works simply as **five
+individual [RTL-SDRs](/reference/rtl-sdr/)** (each driven natively over USB), which is all
+GopherTrunk needs from it; its **direction-finding and passive-radar features require
+KrakenRF's own open-source software**, not GopherTrunk. If you only want to decode trunked
+systems, a single [RTL-SDR](/reference/rtl-sdr/) or an [Airspy](/reference/airspy/) is the
+cheaper, simpler choice — see the [hardware guide](/hardware.html).
 
 ## Sources
 

--- a/docs/reference/limesdr.md
+++ b/docs/reference/limesdr.md
@@ -7,6 +7,14 @@ description: LimeSDR is a full-duplex transmit-and-receive software-defined radi
 keywords: LimeSDR, LMS7002M, Lime Microsystems, full duplex SDR, MIMO transceiver, 100 kHz 3.8 GHz, 12-bit, SoapySDR, LimeSDR Mini
 aka: [LimeSDR, LimeSDR Mini]
 autolink: true
+affiliate: true
+product:
+  name: "LimeSDR Mini"
+  brand: Lime Microsystems
+  category: Software-defined radio
+  lowPrice: "160"
+  highPrice: "200"
+  url: https://www.amazon.com/s?k=LimeSDR+Mini&tag=gophertrunk-20
 infobox:
   - { label: Type, value: Full-duplex SDR transceiver }
   - { label: Vendor/Chip, value: "Lime Microsystems, LMS7002M" }
@@ -14,11 +22,22 @@ infobox:
   - { label: Range, value: 100 kHz – 3.8 GHz }
   - { label: Bandwidth, value: up to ~61.44 MHz }
   - { label: TX, value: Yes (full-duplex) }
-  - { label: Typical price, value: ~US$300 }
+  - { label: With GopherTrunk, value: Network only (SoapySDR/rtl_tcp bridge) }
+  - { label: Typical price, value: "~US$180 (Mini)" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/s?k=LimeSDR+Mini&tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
 see_also: [software-defined-radio, soapysdr, hackrf, mimo, gnuradio]
 cite_urls:
   - https://en.wikipedia.org/wiki/LimeSDR
   - https://limesdr.org/
+faq:
+  - q: "Does GopherTrunk support the LimeSDR?"
+    a: "Yes, but network only. GopherTrunk's pure-Go USB drivers cover RTL-SDR, HackRF, and Airspy — not Lime's LimeSuite stack. You drive the LimeSDR (or LimeSDR Mini) over the network via a SoapySDRServer/SoapyRemote (or rtl_tcp) bridge: run the SoapyLMS7 module and Soapy server on the machine it's plugged into, then mount it over TCP. See the hardware guide."
+  - q: "LimeSDR or LimeSDR Mini for GopherTrunk?"
+    a: "The Mini is the common, cheaper single-channel board and is plenty for feeding IQ to GopherTrunk. The full-size LimeSDR adds a second channel, ~61.44 MHz bandwidth, and full 2×2 MIMO — capabilities aimed at TX and lab work that receive-only scanning doesn't use."
+  - q: "Can GopherTrunk transmit with a LimeSDR?"
+    a: "No. GopherTrunk is a receive-only decoder and uses the LimeSDR purely as an IQ source over the bridge. Its transmit and MIMO features go unused, and transmitting would require appropriate licensing regardless."
+  - q: "Is a LimeSDR worth it for scanning versus a directly-supported SDR?"
+    a: "For pure trunk-tracking, a plug-and-play RTL-SDR or Airspy is cheaper, needs no SoapySDR bridge, and has GopherTrunk's native USB backend. The LimeSDR shines at two-way and development work; treat scanning as a secondary role."
 ---
 
 **LimeSDR** is an open-source, **full-duplex** transmit-and-receive
@@ -37,6 +56,28 @@ independent channels, making it a [MIMO](/reference/mimo/)-capable platform.[^li
 </svg>
 <figcaption>LimeSDR transmits and receives full-duplex across HF through low-microwave, with two channels for MIMO.</figcaption>
 </figure>
+
+<a class="btn btn--buy" href="https://www.amazon.com/s?k=LimeSDR+Mini&tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Full-duplex 12-bit transceiver for developers.** The LMS7002M-based LimeSDR transmits and
+receives at once across 100 kHz–3.8 GHz with two channels for [MIMO](/reference/mimo/) — a
+workhorse for cellular and protocol lab work more than a scanner. **GopherTrunk support is
+network only:** it drives the LimeSDR over a
+[SoapySDR](/reference/soapysdr/)/[rtl_tcp](/reference/rtl-tcp/) bridge, not as a direct USB
+device, because GopherTrunk's pure-Go USB drivers cover only RTL-SDR, HackRF, and Airspy.
+For scanning, transmit and MIMO go unused, so a cheaper directly-supported SDR is usually
+the better buy. **Mini around $180.** Like every receiver, it can't decode
+[AES encryption](/police-scanner-encryption/).
+</div>
+
+> **GopherTrunk support: network only.** GopherTrunk drives the LimeSDR over the network via
+> SoapySDRServer/SoapyRemote (or an `rtl_tcp`-style bridge), not as a direct USB device —
+> you run the LimeSuite/`SoapyLMS7` module and a [SoapySDR](/reference/soapysdr/) server on
+> the machine it's plugged into and mount it over TCP. GopherTrunk's pure-Go USB drivers
+> cover only RTL-SDR, HackRF, and Airspy. See the [hardware guide](/hardware.html) and
+> [rtl_tcp](/reference/rtl-tcp/) notes.
 
 ## Overview
 
@@ -88,6 +129,22 @@ comparable to other 12-bit SDRs rather than exceptional. GopherTrunk provides na
 backends for RTL-SDR, HackRF, and Airspy, not for the LimeSuite stack, so any LimeSDR use
 would go through a SoapySDR bridge; treat it as a general-purpose transceiver whose scanning
 role is secondary to its development strengths.
+
+## Where to buy
+
+LimeSDR boards are sold through Crowd Supply, Lime Microsystems' distributors, and Amazon;
+the **LimeSDR Mini** is the common, lower-cost entry point. Before buying one for
+GopherTrunk, note the integration path: it is supported **over the network only**, via a
+[SoapySDR](/reference/soapysdr/)/[rtl_tcp](/reference/rtl-tcp/) bridge rather than
+GopherTrunk's direct USB drivers — see the [hardware guide](/hardware.html). For scanning
+alone, a [RTL-SDR](/reference/rtl-sdr/) or [Airspy](/reference/airspy/) is cheaper and
+plug-and-play; the LimeSDR pays off when you also want its transmit and development
+capabilities.
+
+<a class="btn btn--buy" href="https://www.amazon.com/s?k=LimeSDR+Mini&tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+*As an Amazon Associate, GopherTrunk earns from qualifying purchases — at no extra cost
+to you. It never changes what we recommend.*
 
 ## Sources
 

--- a/docs/reference/low-noise-amplifier.md
+++ b/docs/reference/low-noise-amplifier.md
@@ -7,16 +7,34 @@ description: A low-noise amplifier boosts a weak antenna signal early in the rec
 keywords: LNA, low noise amplifier, noise figure, sensitivity, front end, preamp, preamplifier, Friis, cascade noise, mast-mounted amplifier
 aka: [low-noise amplifier, LNA]
 autolink: true
+affiliate: true
+product:
+  name: "RTL-SDR Blog Wideband LNA"
+  brand: RTL-SDR Blog
+  category: Low-noise amplifier
+  lowPrice: "26"
+  highPrice: "35"
+  url: https://www.amazon.com/dp/B07G14Q6XX?tag=gophertrunk-20
 infobox:
   - { label: Type, value: RF amplifier }
   - { label: Placed, value: Early in receive chain (near antenna) }
   - { label: Key spec, value: Noise figure }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B07G14Q6XX?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
 see_also: [noise-figure, preamplifier, signal-to-noise-ratio, superheterodyne-receiver, bias-tee, antenna]
 related_lessons:
   - { title: "How an SDR receiver works", url: /learn/rf-sdr/sdr-receiver/ }
 cite_urls:
   - https://en.wikipedia.org/wiki/Low-noise_amplifier
   - https://en.wikipedia.org/wiki/Friis_formulas_for_noise
+faq:
+  - q: "Which LNA should I buy for SDR scanning?"
+    a: "For general SDR and scanner use the RTL-SDR Blog Wideband LNA (around $30) is the popular pick: flat gain from roughly 20 MHz to 2 GHz and powered over the coax by your dongle's bias tee, so no separate power lead is needed. Enable the bias tee in software and the LNA lives right at the antenna, where its gain suppresses feedline loss."
+  - q: "How is the RTL-SDR Blog LNA powered?"
+    a: "By a bias tee — it takes 3.3–5 V DC injected up the coax. Any SDR with a switchable bias tee (RTL-SDR Blog V3/V4, NESDR SMArTee) can feed it, or an inline bias tee module can. See our note on the bias tee for how DC and RF share one cable."
+  - q: "Can an LNA make reception worse?"
+    a: "Yes. In a strong-signal urban environment an un-filtered wideband LNA amplifies everything, including nearby FM, pager, and cellular transmitters, and can push the SDR into overload and intermodulation. Add it only when the front end is genuinely noise-limited — long coax, a weak target — and pair it with an RF filter if strong signals are present."
+  - q: "Do I need a filter with a wideband LNA?"
+    a: "Often, yes. Because a wideband LNA boosts out-of-band signals too, a band-pass or notch filter ahead of it keeps strong local transmitters from overloading the amplifier. A filtered (band-specific) LNA does this in one box for services like 1090 MHz ADS-B."
 ---
 
 A **low-noise amplifier** (**LNA**) boosts a weak [antenna](/reference/antenna/) signal
@@ -97,6 +115,24 @@ control the LNA, but a well-chosen LNA raises the in-channel SNR that GopherTrun
 demodulators see, which is the difference between a locked control channel and a dropped
 one. See the DSP notes on rate-invariance — the decode path is only as good as the samples
 handed to it, and the LNA is where that quality is won or lost.
+
+## Recommended for SDR
+
+For SDR and scanner use, the **RTL-SDR Blog Wideband LNA** (around $30) is the
+default choice: flat gain of roughly 20 dB from ~20 MHz to 2 GHz, and it is
+[bias-tee](/reference/bias-tee/) powered, so the dongle feeds it DC up the coax
+with no extra wiring. Mount it at the antenna to suppress feedline loss per the
+Friis budget — but don't over-amplify: in a strong-signal environment an
+un-filtered LNA can overload the SDR, so add an [RF filter](/reference/rf-filter/)
+or reach for a filtered LNA if nearby transmitters are hot.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B07G14Q6XX?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+For a wider comparison of LNAs and where each one helps, see
+[the best SDR LNA guide](/best-sdr-lna/).
+
+*As an Amazon Associate, GopherTrunk earns from qualifying purchases — at no extra
+cost to you. It never changes what we recommend.*
 
 ## Sources
 

--- a/docs/reference/nesdr.md
+++ b/docs/reference/nesdr.md
@@ -7,6 +7,14 @@ description: "Nooelec NESDR is a family of purpose-built RTL-SDR receivers with 
 keywords: NESDR, Nooelec NESDR, NESDR SMArt, NESDR Nano, NESDR SMArTee, NESDR XTR, RTL-SDR variant, RTL2832U, R820T2, TCXO, bias tee
 aka: [NESDR, Nooelec NESDR, NooElec NESDR]
 autolink: true
+affiliate: true
+product:
+  name: "NooElec NESDR SMArt v5"
+  brand: NooElec
+  category: Software-defined radio
+  lowPrice: "30"
+  highPrice: "40"
+  url: https://www.amazon.com/dp/B01HA642SW?tag=gophertrunk-20
 infobox:
   - { label: Type, value: USB SDR receiver (RTL-SDR) }
   - { label: Vendor, value: Nooelec }
@@ -16,10 +24,20 @@ infobox:
   - { label: Range, value: "~100 kHz – 1.75 GHz" }
   - { label: TX, value: No (receive only) }
   - { label: Typical price, value: "$25 – $45" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B01HA642SW?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
 see_also: [rtl-sdr, rtl2832u, r820t-tuner, e4000-tuner, bias-tee, software-defined-radio]
 cite_urls:
   - https://en.wikipedia.org/wiki/RTL-SDR
   - https://www.nooelec.com/store/sdr/sdr-receivers.html
+faq:
+  - q: "Which NESDR should I buy for GopherTrunk?"
+    a: "The NESDR SMArt v5 for most people — it is the mainstream 'just buy this' RTL-SDR, an R820T2/R860 dongle with a 0.5 ppm TCXO in an aluminium case, and it's essentially always in stock. Get the SMArTee v2 instead if you need an always-on bias tee to power an inline LNA or active antenna, the Nano 3 for a tiny embedded build, or the SMArt XTR (E4000) if you need tuning up toward ~2.2 GHz."
+  - q: "Is a NESDR better than a generic RTL-SDR dongle?"
+    a: "Yes, for a small premium. A NESDR is functionally an RTL-SDR — same 8-bit RTL2832U and ~2.4 MHz of bandwidth — but the board around the chips fixes a generic stick's worst faults: a 0.5 ppm TCXO holds frequency as it warms up instead of drifting tens of kHz, plus better shielding, ESD protection and a proper SMA connector. That stability means steadier control-channel lock for long trunk-tracking sessions."
+  - q: "Does GopherTrunk need Zadig or extra drivers for a NESDR?"
+    a: "On Windows you bind the driver with Zadig once, exactly as for any RTL-SDR. On Linux it works with the standard librtlsdr-style raw-IQ interface. GopherTrunk then drives it like any other RTL-SDR, including in a pool of several dongles to cover channels spread across a band."
+  - q: "Can a NESDR decode encrypted or trunked police traffic?"
+    a: "It decodes clear P25/DMR/NXDN/TETRA trunked systems in software with GopherTrunk, which is receive-only. No RTL-SDR — and no scanner — can decode AES-encrypted transmissions."
 ---
 
 **Nooelec NESDR** is a family of purpose-built [RTL-SDR](/reference/rtl-sdr/) receivers
@@ -49,6 +67,22 @@ a generic no-name stick at only a small price premium.
 </svg>
 <figcaption>A NESDR is a well-built RTL-SDR: the same two chips, plus a 0.5 ppm TCXO for stable tuning, in a metal case.</figcaption>
 </figure>
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B01HA642SW?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The mainstream "just buy this" [RTL-SDR](/reference/rtl-sdr/).** A NooElec NESDR is a
+purpose-built RTL-SDR — same 8-bit [RTL2832U](/reference/rtl2832u/) and
+[R820T2](/reference/r820t-tuner/)/R860 tuner as any dongle, but with a **0.5 ppm TCXO**,
+a metal case and a proper SMA connector that fix a generic stick's drift and shielding
+faults. The **SMArt v5** is the model to get for a first GopherTrunk radio — cheap
+(~$35) and reliably in stock. Variants add a bias tee (SMArTee v2), a tiny body
+(Nano 3) or extended range (SMArt XTR). **Receive-only;** it decodes clear
+[P25](/reference/project-25/)/[DMR](/reference/dmr/)/[NXDN](/reference/nxdn/) but no
+dongle can decode [AES encryption](/police-scanner-encryption/). See
+[best SDR for GopherTrunk](/best-sdr-for-gophertrunk/).
+</div>
 
 ## Overview
 
@@ -95,6 +129,31 @@ a **pool** of several dongles to cover channels spread across a band, and on Win
 bind the driver with Zadig first. For a first radio, an R820T2/R860-class NESDR SMArt v5
 is a strong choice. See the [hardware guide](/hardware.html) for GopherTrunk's tested
 devices.
+
+## Where to buy
+
+The **NESDR SMArt v5** is the one to buy for a first GopherTrunk radio; the other
+NESDRs cover specific needs (an always-on bias tee, a tiny body, or extended range).
+All are widely stocked on Amazon.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B01HA642SW?tag=gophertrunk-20" rel="nofollow sponsored noopener">NESDR SMArt v5 on Amazon &rarr;</a>
+
+| Model | Tuner | Best for | Amazon |
+|-------|-------|----------|--------|
+| **NESDR SMArt v5** | R820T2/R860 | The mainstream pick — buy this first (~$35) | <a href="https://www.amazon.com/dp/B01HA642SW?tag=gophertrunk-20" rel="nofollow sponsored noopener">product</a> |
+| **NESDR SMArt v5** (3-antenna bundle) | R820T2/R860 | Same dongle with a set of antennas | <a href="https://www.amazon.com/dp/B01GDN1T4S?tag=gophertrunk-20" rel="nofollow sponsored noopener">product</a> |
+| **NESDR SMArTee v2** (bias tee) | R820T2 | Powering an inline LNA / active antenna | <a href="https://www.amazon.com/dp/B079C3FHPG?tag=gophertrunk-20" rel="nofollow sponsored noopener">product</a> |
+| **NESDR Nano 3** (tiny) | R820T2 | Embedded / portable builds | <a href="https://www.amazon.com/dp/B073JZ8CC2?tag=gophertrunk-20" rel="nofollow sponsored noopener">product</a> |
+| **NESDR SMArt XTR** (extended range) | E4000 | Tuning up toward ~2.2 GHz | <a href="https://www.amazon.com/dp/B06Y1HKLHY?tag=gophertrunk-20" rel="nofollow sponsored noopener">product</a> |
+
+Comparing radios? See [best SDR for GopherTrunk](/best-sdr-for-gophertrunk/), the
+[RTL-SDR](/reference/rtl-sdr/) family overview, or step up to an
+[Airspy](/reference/airspy/) for tougher RF. Weighing a handheld instead? Read
+[police scanner vs SDR](/police-scanner-vs-sdr/). Then grab the software from the
+[downloads page](/downloads.html).
+
+*As an Amazon Associate, GopherTrunk earns from qualifying purchases — at no extra cost
+to you. It never changes what we recommend.*
 
 ## Sources
 

--- a/docs/reference/plutosdr.md
+++ b/docs/reference/plutosdr.md
@@ -7,6 +7,14 @@ description: ADALM-Pluto (PlutoSDR) is Analog Devices' low-cost learning SDR, an
 keywords: ADALM-Pluto, PlutoSDR, Pluto SDR, AD9363, AD9364, Analog Devices, learning SDR, transceiver, 12-bit, full duplex, Zynq
 aka: [PlutoSDR, ADALM-Pluto, Pluto]
 autolink: true
+affiliate: true
+product:
+  name: "ADALM-Pluto (PlutoSDR)"
+  brand: Analog Devices
+  category: Software-defined radio
+  lowPrice: "210"
+  highPrice: "250"
+  url: https://www.amazon.com/s?k=ADALM+Pluto+SDR&tag=gophertrunk-20
 infobox:
   - { label: Type, value: Learning SDR transceiver }
   - { label: Vendor/Chip, value: "Analog Devices, AD9363" }
@@ -14,11 +22,22 @@ infobox:
   - { label: Range, value: 325 MHz – 3.8 GHz }
   - { label: Bandwidth, value: up to ~20 MHz }
   - { label: TX, value: Yes (full-duplex) }
+  - { label: With GopherTrunk, value: Network only, RX (SoapySDR/rtl_tcp bridge) }
   - { label: Typical price, value: ~US$230 }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/s?k=ADALM+Pluto+SDR&tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
 see_also: [software-defined-radio, iq-data, mimo, gnuradio, hackrf]
 cite_urls:
   - https://en.wikipedia.org/wiki/ADALM-PLUTO
   - https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/adalm-pluto.html
+faq:
+  - q: "Does GopherTrunk support the ADALM-Pluto?"
+    a: "Only over the network, and receive-only. GopherTrunk's pure-Go USB drivers cover RTL-SDR, HackRF, and Airspy — not the Pluto's IIO stack. You drive it over the network via a SoapySDRServer/SoapyRemote (or rtl_tcp) bridge: run the Soapy server against libiio on the machine the Pluto is plugged into, then mount it over TCP. GopherTrunk uses only its receive path. See the hardware guide."
+  - q: "Is the PlutoSDR a good choice for scanning trunked systems?"
+    a: "Not really. On stock firmware its lower limit of ~325 MHz misses VHF systems entirely, its dynamic range is ordinary, and its transmit capability is irrelevant to receive-only scanning. The Pluto is designed as a learning and RF-development tool, not a scanner front end."
+  - q: "Can GopherTrunk transmit with a Pluto?"
+    a: "No. GopherTrunk is a receive-only decoder; it uses the Pluto purely as an IQ source over the bridge and never keys the transmitter. Transmitting also requires appropriate licensing and is outside GopherTrunk's scope."
+  - q: "Pluto or a directly-supported SDR for GopherTrunk?"
+    a: "For trunk-tracking, a plug-and-play RTL-SDR or Airspy is both cheaper and better matched — they cover VHF, need no network bridge, and have GopherTrunk's native USB backends. Buy a Pluto for learning digital comms and TX/RX experiments, not for scanning."
 ---
 
 **ADALM-Pluto** (often **PlutoSDR**) is Analog Devices' low-cost learning
@@ -37,6 +56,27 @@ Analog Devices' documentation and courseware.[^adi]
 </svg>
 <figcaption>Pluto is a compact full-duplex transceiver spanning UHF through low microwave, aimed at learners.</figcaption>
 </figure>
+
+<a class="btn btn--buy" href="https://www.amazon.com/s?k=ADALM+Pluto+SDR&tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**A learning transceiver, not a scanner.** The Pluto is a 12-bit, full-duplex TX/RX radio
+(325 MHz–3.8 GHz on stock firmware) built for teaching digital comms with tight
+MATLAB/Python tooling. For trunking it's a **poor fit**: stock firmware misses VHF, dynamic
+range is ordinary, and transmit is irrelevant to receive-only scanning. **GopherTrunk
+support is network only** and receive-only: it drives the Pluto over a
+[SoapySDR](/reference/soapysdr/)/[rtl_tcp](/reference/rtl-tcp/) bridge (not the pure-Go USB
+path used for RTL-SDR, HackRF, and Airspy). **Around $230.** Like every receiver, it can't
+decode [AES encryption](/police-scanner-encryption/).
+</div>
+
+> **GopherTrunk support: network only.** GopherTrunk drives the ADALM-Pluto over the network
+> via SoapySDRServer/SoapyRemote (or an `rtl_tcp`-style bridge), not as a direct USB device —
+> you run a [SoapySDR](/reference/soapysdr/) server against the Pluto's IIO/`libiio` stack on
+> the machine it's plugged into and mount it over TCP, using its receive path only.
+> GopherTrunk's pure-Go USB drivers cover only RTL-SDR, HackRF, and Airspy. See the
+> [hardware guide](/hardware.html) and [rtl_tcp](/reference/rtl-tcp/) notes.
 
 ## Overview
 
@@ -83,6 +123,21 @@ transmit is irrelevant to scanning. GopherTrunk offers native USB backends for R
 HackRF, and Airspy, not for the Pluto's IIO stack, so any use would rely on an external
 bridge. It belongs in the learning and RF-development category rather than the scanning
 toolbox.
+
+## Where to buy
+
+The ADALM-Pluto is sold by Analog Devices and its distributors, and listed on Amazon. If
+you're buying it to use with GopherTrunk, remember two things: support is **network only**
+(through a [SoapySDR](/reference/soapysdr/)/[rtl_tcp](/reference/rtl-tcp/) bridge, not
+GopherTrunk's direct USB drivers — see the [hardware guide](/hardware.html)) and GopherTrunk
+uses **receive only**. For actual trunk-tracking, a [RTL-SDR](/reference/rtl-sdr/) or
+[Airspy](/reference/airspy/) is the cheaper, better-matched, plug-and-play choice; buy the
+Pluto for learning and TX/RX experiments.
+
+<a class="btn btn--buy" href="https://www.amazon.com/s?k=ADALM+Pluto+SDR&tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+*As an Amazon Associate, GopherTrunk earns from qualifying purchases — at no extra cost
+to you. It never changes what we recommend.*
 
 ## Sources
 

--- a/docs/reference/rf-filter.md
+++ b/docs/reference/rf-filter.md
@@ -7,16 +7,34 @@ description: "An RF filter is a frequency-selective network (low-pass, high-pass
 keywords: RF filter, low-pass filter, high-pass filter, band-pass filter, notch filter, preselector, front-end selectivity, LPF, HPF, BPF, insertion loss, stopband
 aka: [RF filter, "radio-frequency filter", preselector]
 autolink: true
+affiliate: true
+product:
+  name: "RTL-SDR Blog Flamingo+ FM broadcast notch filter"
+  brand: RTL-SDR Blog
+  category: FM broadcast notch filter
+  lowPrice: "21"
+  highPrice: "29"
+  url: https://www.amazon.com/dp/B07XKY8YKB?tag=gophertrunk-20
 infobox:
   - { label: Type, value: "Passive/active frequency-selective network" }
   - { label: Responses, value: "Low-pass, high-pass, band-pass, notch" }
   - { label: Key spec, value: "Insertion loss, stopband rejection, shape factor" }
   - { label: TX, value: "Yes (power-rated types)" }
   - { label: Typical price, value: "$2–$50 (module)" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B07XKY8YKB?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
 see_also: [saw-filter, cavity-filter, crystal-filter, helical-filter, digital-filter, low-noise-amplifier]
 cite_urls:
   - https://en.wikipedia.org/wiki/Electronic_filter
   - https://en.wikipedia.org/wiki/Band-pass_filter
+faq:
+  - q: "Which RF filter fixes SDR overload from strong FM stations?"
+    a: "A broadcast FM notch (band-stop) filter. The RTL-SDR Blog Flamingo+ FM (around $25) rejects the 88–108 MHz FM band while passing everything else, which stops strong local FM transmitters from overloading a wideband dongle and spraying spurious products across your scanning range. For strong AM broadcast interference the Flamingo AM notch does the same below the medium-wave band."
+  - q: "Notch filter or band-pass filter — which do I need?"
+    a: "Use a notch (band-stop) filter to kill one strong offender, such as the FM or AM broadcast band, while keeping the rest of the spectrum. Use a band-pass filter when you only care about one service and want to reject everything else — a preselector cut for your target VHF/UHF band. Notches are the common first fix for broadcast-band overload."
+  - q: "Will a filter hurt my weak signals?"
+    a: "A little. Every filter has some passband insertion loss — a fraction of a dB for a good part. That trade is usually worth it: by restoring dynamic range and lowering intermodulation, a well-chosen preselector recovers far more than the small loss it costs when strong out-of-band signals are present."
+  - q: "Does GopherTrunk need an RF filter?"
+    a: "GopherTrunk is pure software and contains no physical filter — that job belongs to the analog hardware ahead of the SDR. Its digital filters cannot undo an overloaded ADC, so on a site crowded with strong FM, pager, or cellular signals an analog notch or band-pass filter is often what turns an unusable spectrum into a clean control-channel lock."
 ---
 
 An **RF filter** is a frequency-selective network that passes signals inside a
@@ -98,6 +116,23 @@ why a good analog RF filter and clean gain staging remain essential for reliable
 trunking decodes. In practice, users running RTL-SDR or Airspy dongles for P25 or
 DMR often add an inexpensive band-pass module for the target VHF/UHF band to keep
 strong nearby transmitters from desensitising the receiver.
+
+## Where to buy
+
+For the most common SDR problem — a wideband dongle overloaded by strong local FM
+broadcast stations — a notch filter is the fix. The **RTL-SDR Blog Flamingo+ FM**
+(around $25) rejects the 88–108 MHz FM band while passing everything else. For strong
+AM broadcast interference the **Flamingo AM** notch does the same below the
+medium-wave band.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B07XKY8YKB?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B079CMB44V?tag=gophertrunk-20" rel="nofollow sponsored noopener">AM notch on Amazon &rarr;</a>
+
+For band-pass preselectors and a fuller rundown of front-end filtering, see the
+[SDR filters guide](/sdr-filters/).
+
+*As an Amazon Associate, GopherTrunk earns from qualifying purchases — at no extra
+cost to you. It never changes what we recommend.*
 
 ## Sources
 

--- a/docs/reference/rtl-sdr.md
+++ b/docs/reference/rtl-sdr.md
@@ -7,6 +7,14 @@ description: RTL-SDR is a family of low-cost USB software-defined radio receiver
 keywords: RTL-SDR, RTL2832U, cheap SDR, DVB-T dongle, R820T2, R828D, R828S, E4000, RTL-SDR Blog V3, RTL-SDR Blog V4, V4 Lite, NooElec NESDR, FlightAware Pro Stick, 24 MHz 1.7 GHz, receive only, which RTL-SDR to buy
 aka: [RTL-SDR, RTL SDR, RTL2832U dongle]
 autolink: true
+affiliate: true
+product:
+  name: "RTL-SDR Blog V4"
+  brand: RTL-SDR Blog
+  category: Software-defined radio
+  lowPrice: "35"
+  highPrice: "50"
+  url: https://www.amazon.com/dp/B0CD745394?tag=gophertrunk-20
 infobox:
   - { label: Type, value: USB SDR receiver }
   - { label: Bridge chip, value: RTL2832U }
@@ -35,6 +43,15 @@ cite_urls:
   - https://www.rtl-sdr.com/rtl-sdr-blog-v4-end-of-line/
   - https://www.rtl-sdr.com/comparisons-r820t-r820t2-rtl-sdr-tuners/
   - https://en.wikipedia.org/wiki/Software-defined_radio#RTL-SDR
+faq:
+  - q: "Which RTL-SDR should I buy for GopherTrunk?"
+    a: "An R820T2/R860-class dongle. The RTL-SDR Blog V4 is the flagship — a built-in HF upconverter, 1 ppm TCXO and broadcast notch filtering — but it's end-of-line as of 2026, so buy it while stock lasts. The NooElec NESDR SMArt v5 is the ongoing mainstream pick if the V4 is sold out. Either follows most VHF/UHF trunked systems on one ~$35 stick."
+  - q: "How much does a good RTL-SDR cost?"
+    a: "About $35–50 for a purpose-built dongle like the RTL-SDR Blog V4 or a NESDR SMArt v5. A generic no-name stick is ~$12–15 but drifts, overloads and has poor shielding — the small premium for a TCXO board is worth it for steady control-channel lock."
+  - q: "Can an RTL-SDR decode encrypted police channels?"
+    a: "No. An RTL-SDR is receive-only and GopherTrunk is a receive-only decoder — it decodes clear P25/DMR/NXDN/TETRA traffic, but no SDR or scanner can decode AES-encrypted transmissions."
+  - q: "RTL-SDR or a step up to an Airspy?"
+    a: "Start with an RTL-SDR — it's the cheapest thing that works and the baseline GopherTrunk targets. Move to an Airspy when its 12-bit ADC and wider capture are what stands between you and a decode on a busy or weak-signal system. See best SDR for GopherTrunk."
 ---
 
 **RTL-SDR** is a family of inexpensive USB [software-defined radio](/reference/software-defined-radio/)
@@ -54,6 +71,24 @@ GopherTrunk is built to run on.
 </svg>
 <figcaption>RTL-SDR covers most VHF/UHF scanning at low cost — receive only.</figcaption>
 </figure>
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0CD745394?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The ~$35 baseline GopherTrunk is built to run on.** An RTL-SDR is two chips on a
+stick — an [R820T2](/reference/r820t-tuner/)-class tuner and the 8-bit
+[RTL2832U](/reference/rtl2832u/) — tuning ~24 MHz–1.7 GHz with ~2.4 MHz of usable
+[bandwidth](/reference/bandwidth/), enough to follow most VHF/UHF trunked systems.
+**Buy an R820T2/R860 dongle:** the [RTL-SDR Blog V4](#dongle-variants-the-products)
+(flagship, but end-of-line as of 2026 — grab it while stock lasts) or the ongoing
+[NESDR SMArt v5](/reference/nesdr/). Skip generic no-name sticks that drift and
+overload. Step up to an [Airspy](/reference/airspy/) only when 8-bit dynamic range or
+2.4 MHz is the thing standing between you and a decode. **Receive-only;** no dongle
+decodes [AES encryption](/police-scanner-encryption/). See
+[best SDR for GopherTrunk](/best-sdr-for-gophertrunk/) or the buy table
+[below](#where-to-buy).
+</div>
 
 ## A short history
 

--- a/docs/reference/rtl-sdr.md
+++ b/docs/reference/rtl-sdr.md
@@ -3,7 +3,7 @@ slug: rtl-sdr
 title: RTL-SDR
 entry_type: hardware
 category: sdr-devices
-description: RTL-SDR is a family of low-cost USB software-defined radio receivers built on the RTL2832U chip — repurposed from DVB-T TV tuners — covering roughly 24 MHz to 1.7 GHz. A full history, the hardware explained, every major tuner and dongle variant compared, and where to buy the ones still in production.
+description: "RTL-SDR is a family of low-cost USB software-defined radio receivers built on the RTL2832U chip — repurposed from DVB-T TV tuners — covering roughly 24 MHz to 1.7 GHz. A full history, the hardware."
 keywords: RTL-SDR, RTL2832U, cheap SDR, DVB-T dongle, R820T2, R828D, R828S, E4000, RTL-SDR Blog V3, RTL-SDR Blog V4, V4 Lite, NooElec NESDR, FlightAware Pro Stick, 24 MHz 1.7 GHz, receive only, which RTL-SDR to buy
 aka: [RTL-SDR, RTL SDR, RTL2832U dongle]
 autolink: true
@@ -53,7 +53,6 @@ faq:
   - q: "RTL-SDR or a step up to an Airspy?"
     a: "Start with an RTL-SDR — it's the cheapest thing that works and the baseline GopherTrunk targets. Move to an Airspy when its 12-bit ADC and wider capture are what stands between you and a decode on a busy or weak-signal system. See best SDR for GopherTrunk."
 ---
-
 **RTL-SDR** is a family of inexpensive USB [software-defined radio](/reference/software-defined-radio/)
 receivers built around the [RTL2832U](/reference/rtl2832u/) chip — originally a DVB-T
 digital-TV tuner that hobbyists discovered could stream raw [IQ](/reference/iq-data/)

--- a/docs/reference/saw-filter.md
+++ b/docs/reference/saw-filter.md
@@ -7,16 +7,34 @@ description: "A SAW (surface acoustic wave) filter is a compact, sharp band-pass
 keywords: SAW filter, surface acoustic wave, band-pass, front-end filter, 1090 MHz, ADS-B, preselector, piezoelectric, interdigital transducer, IDT
 aka: [SAW filter, "surface acoustic wave filter"]
 autolink: true
+affiliate: true
+product:
+  name: "RTL-SDR Blog Flamingo+ FM broadcast notch filter"
+  brand: RTL-SDR Blog
+  category: SDR front-end filter
+  lowPrice: "21"
+  highPrice: "29"
+  url: https://www.amazon.com/dp/B07XKY8YKB?tag=gophertrunk-20
 infobox:
   - { label: Type, value: Band-pass RF filter }
   - { label: Principle, value: Acoustic wave on piezoelectric substrate }
   - { label: Used for, value: Front-end preselection (e.g. 1090 MHz) }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B07XKY8YKB?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
 see_also: [rf-filter, crystal-filter, cavity-filter, low-noise-amplifier, ads-b, attenuation]
 related_lessons:
   - { title: "Antennas 101", url: /learn/rf-sdr/antennas/ }
 cite_urls:
   - https://en.wikipedia.org/wiki/Surface_acoustic_wave
   - https://en.wikipedia.org/wiki/Interdigital_transducer
+faq:
+  - q: "How do I buy a SAW filter for SDR use?"
+    a: "SAW band-pass filters are usually sold as a filter-and-LNA 'green' board cut for one service — the 1090 MHz ADS-B module is the classic example — or as part of a filter kit for a target band. For the broadcast-band overload most scanner users hit first, a notch filter such as the RTL-SDR Blog Flamingo+ FM (around $25) is the everyday buy; add a band-specific SAW when you need steep preselection for one band."
+  - q: "What is a SAW filter good for on a scanner?"
+    a: "Sharp, fixed-frequency preselection. A SAW gives near-rectangular skirts in a tiny package, so it passes only the wanted band (e.g. 1090 MHz, 137 MHz weather satellite, GPS L1) and strongly rejects nearby cellular and broadcast signals that would otherwise overload the dongle. Because it is fixed-frequency it only helps the one service it was cut for."
+  - q: "SAW filter or notch filter?"
+    a: "A SAW band-pass is preselection — it keeps only one band. A notch filter removes one strong offender (like the FM broadcast band) while passing everything else, which is what you want for general wideband scanning. Reach for a SAW when you are dedicated to a single service; reach for a notch when you scan many bands but one strong transmitter is the problem."
+  - q: "Does a SAW filter need its own amplifier?"
+    a: "A passive SAW costs a few dB of insertion loss, so it is usually followed immediately by a low-noise amplifier to restore the noise budget — which is why most hobby SAW modules are sold as a combined filter-plus-LNA board."
 ---
 
 A **SAW** (**surface acoustic wave**) filter is a compact, sharp **band-pass**
@@ -86,6 +104,22 @@ filter; on a trunking site crowded with strong pager, cellular, and broadcast si
 band-appropriate SAW or [cavity filter](/reference/cavity-filter/) ahead of the SDR is often
 what turns an unusable, intermod-riddled spectrum into a clean control channel GopherTrunk
 can lock.
+
+## Where to buy
+
+A SAW band-pass filter is bought cut for one service — the 1090 MHz ADS-B
+filter-and-LNA board is the classic example — so choose it by your target band. For
+the broadcast-band overload most scanner users hit first, the notch filters in the
+same RTL-SDR Blog **Flamingo** family are the everyday buy: the **Flamingo+ FM**
+(around $25) rejects the 88–108 MHz band while passing your scanning range.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B07XKY8YKB?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+For band-pass and SAW preselectors matched to a specific band, see the
+[SDR filters guide](/sdr-filters/).
+
+*As an Amazon Associate, GopherTrunk earns from qualifying purchases — at no extra
+cost to you. It never changes what we recommend.*
 
 ## Sources
 

--- a/docs/reference/sdrplay-rsp1a.md
+++ b/docs/reference/sdrplay-rsp1a.md
@@ -7,6 +7,14 @@ description: SDRplay RSP1A is a 14-bit, 1 kHz–2 GHz receive-only software-defi
 keywords: SDRplay RSP1A, RSP1A, MSi001, MSi2500, 14-bit SDR receiver, wideband receiver, 1 kHz 2 GHz, SoapySDR
 aka: [RSP1A, SDRplay RSP1A]
 autolink: true
+affiliate: true
+product:
+  name: "SDRplay RSP1A"
+  brand: SDRplay
+  category: Software-defined radio
+  lowPrice: "110"
+  highPrice: "130"
+  url: https://www.amazon.com/s?k=SDRplay+RSP1A&tag=gophertrunk-20
 infobox:
   - { label: Type, value: Receive-only SDR }
   - { label: Vendor/Chip, value: "SDRplay, MSi001 + MSi2500" }
@@ -14,11 +22,22 @@ infobox:
   - { label: Range, value: 1 kHz – 2 GHz }
   - { label: Bandwidth, value: up to ~10 MHz }
   - { label: TX, value: No }
+  - { label: With GopherTrunk, value: Network only (SoapySDR/rtl_tcp bridge) }
   - { label: Typical price, value: ~US$120 }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/s?k=SDRplay+RSP1A&tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
 see_also: [software-defined-radio, soapysdr, msi001-tuner, rtl-sdr, airspy]
 cite_urls:
   - https://en.wikipedia.org/wiki/Software-defined_radio
   - https://www.sdrplay.com/rsp1a/
+faq:
+  - q: "Does GopherTrunk support the SDRplay RSP1A?"
+    a: "Yes, but network only. GopherTrunk's pure-Go USB drivers cover RTL-SDR, HackRF, and Airspy — not the RSP's closed API/service. You drive the RSP1A over the network via a SoapySDRServer/SoapyRemote (or rtl_tcp) bridge: run SDRplay's service and the Soapy server on the machine the RSP1A is plugged into, then mount it over TCP. See the hardware guide."
+  - q: "Is the RSP1A a good SDR for scanning trunked systems?"
+    a: "As RF hardware, yes — its 14-bit ADC, continuous 1 kHz–2 GHz coverage, and front-end preselection give it far more dynamic range than an 8-bit RTL-SDR, and its ~10 MHz span can cover a system's control and voice channels in one capture. The only caveat is the integration path: it runs over a network bridge, not as a plug-and-play USB device."
+  - q: "Why can't GopherTrunk open the RSP1A directly over USB?"
+    a: "The RSP line is not libusb-generic. SDRplay ships a closed API/service that applications must talk to, so there is no pure-Go USB path the way there is for RTL-SDR, HackRF, and Airspy. The supported route is the vendor service plus a SoapySDR module, mounted over the network."
+  - q: "RSP1A or an RTL-SDR / Airspy for GopherTrunk?"
+    a: "If you want the simplest setup, a directly-supported RTL-SDR or Airspy plugs in and works with no bridge. Choose the RSP1A when you specifically want its 14-bit dynamic range and continuous HF-through-UHF coverage and don't mind running a SoapySDR server for it."
 ---
 
 **SDRplay RSP1A** is a low-cost, receive-only
@@ -38,6 +57,28 @@ similar price class.[^sdrplay]
 </svg>
 <figcaption>The RSP1A covers everything from VLF through UHF with one antenna port and a 14-bit converter.</figcaption>
 </figure>
+
+<a class="btn btn--buy" href="https://www.amazon.com/s?k=SDRplay+RSP1A&tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**14-bit, continuous 1 kHz–2 GHz, receive-only.** The RSP1A gives you far more
+[dynamic range](/reference/dynamic-range/) and real front-end
+[preselection](/reference/rf-filter/) than an 8-bit [RTL-SDR](/reference/rtl-sdr/), with a
+~10 MHz span that can capture a trunked system's control and voice channels at once.
+**GopherTrunk support is network only:** it drives the RSP1A over a
+[SoapySDR](/reference/soapysdr/)/[rtl_tcp](/reference/rtl-tcp/) bridge, not as a direct USB
+device — SDRplay's closed API/service rules out the pure-Go USB path used for RTL-SDR,
+HackRF, and Airspy. **Around $120.** Like every receiver, it can't decode
+[AES encryption](/police-scanner-encryption/).
+</div>
+
+> **GopherTrunk support: network only.** GopherTrunk drives the RSP1A over the network via
+> SoapySDRServer/SoapyRemote (or an `rtl_tcp`-style bridge), not as a direct USB device —
+> you run SDRplay's API service and a [SoapySDR](/reference/soapysdr/) server on the machine
+> it's plugged into and mount it over TCP. GopherTrunk's pure-Go USB drivers cover only
+> RTL-SDR, HackRF, and Airspy. See the [hardware guide](/hardware.html) and
+> [rtl_tcp](/reference/rtl-tcp/) notes.
 
 ## Overview
 
@@ -93,6 +134,20 @@ RSP1A with GopherTrunk therefore hinges on a SoapySDR/RSP bridge rather than a n
 backend — check the project status before assuming turn-key support. As a receiver the
 hardware is well suited to the task; the integration path, not the RF, is the limiting
 factor.
+
+## Where to buy
+
+The RSP1A is sold by SDRplay and its distributors, and listed on Amazon. Before you buy it
+for GopherTrunk, remember the integration path: it is supported **over the network only**,
+through a [SoapySDR](/reference/soapysdr/)/[rtl_tcp](/reference/rtl-tcp/) bridge rather than
+GopherTrunk's direct USB drivers — see the [hardware guide](/hardware.html). If you want a
+plug-and-play device, a [RTL-SDR](/reference/rtl-sdr/) or [Airspy](/reference/airspy/) is
+the simpler pick.
+
+<a class="btn btn--buy" href="https://www.amazon.com/s?k=SDRplay+RSP1A&tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+*As an Amazon Associate, GopherTrunk earns from qualifying purchases — at no extra cost
+to you. It never changes what we recommend.*
 
 ## Sources
 

--- a/docs/reference/sdrplay-rspdx.md
+++ b/docs/reference/sdrplay-rspdx.md
@@ -7,6 +7,14 @@ description: SDRplay RSPdx (and the current RSPdx-R2 revision) is a 14-bit, 1 kH
 keywords: SDRplay RSPdx, RSPdx-R2, RSPdx R2, HDR mode, high dynamic range SDR, 14-bit receiver, three antenna ports, wideband receiver, SoapySDR
 aka: [RSPdx, RSPdx-R2, SDRplay RSPdx, SDRplay RSPdx-R2]
 autolink: true
+affiliate: true
+product:
+  name: "SDRplay RSPdx"
+  brand: SDRplay
+  category: Software-defined radio
+  lowPrice: "220"
+  highPrice: "260"
+  url: https://www.amazon.com/dp/B0821NMGVP?tag=gophertrunk-20
 infobox:
   - { label: Type, value: Receive-only SDR }
   - { label: Vendor/Chip, value: "SDRplay, Mirics chipset" }
@@ -15,13 +23,22 @@ infobox:
   - { label: Bandwidth, value: up to ~10 MHz }
   - { label: TX, value: No }
   - { label: Current model, value: "RSPdx-R2 (2023 refresh)" }
+  - { label: With GopherTrunk, value: Network only (SoapySDR/rtl_tcp bridge) }
   - { label: Typical price, value: ~US$250 }
   - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B0821NMGVP?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
 see_also: [sdrplay-rsp1a, sdrplay-rspduo, software-defined-radio, soapysdr, rf-filter, dynamic-range]
-affiliate: true
 cite_urls:
   - https://en.wikipedia.org/wiki/Software-defined_radio
   - https://www.sdrplay.com/rspdx/
+faq:
+  - q: "Does GopherTrunk support the SDRplay RSPdx?"
+    a: "Yes, but network only. GopherTrunk's pure-Go USB drivers cover RTL-SDR, HackRF, and Airspy — not the RSP's closed API/service. You drive the RSPdx over the network via a SoapySDRServer/SoapyRemote (or rtl_tcp) bridge: run SDRplay's service and the Soapy server on the machine the RSPdx is plugged into, then mount it over TCP. See the hardware guide."
+  - q: "What does the RSPdx add over the RSP1A?"
+    a: "A much larger bank of switchable preselection filters, three antenna ports (two SMA plus a dedicated HF/BNC path), and an HDR (high-dynamic-range) mode below about 2 MHz that trades span for cleaner dynamic range. For VHF/UHF trunking the two behave similarly; the RSPdx earns its price mainly on crowded HF and below."
+  - q: "Can I use the RSPdx's HDR mode with GopherTrunk?"
+    a: "GopherTrunk sees the RSPdx only as an IQ source over the SoapySDR/rtl_tcp bridge, so HDR mode and antenna-port selection are configured on the SDRplay service side, not from GopherTrunk. For VHF/UHF trunking you would typically run it as a plain wideband receiver anyway."
+  - q: "RSPdx or a directly-supported SDR for GopherTrunk?"
+    a: "For scanning simplicity, a plug-and-play RTL-SDR or Airspy needs no bridge. Reach for the RSPdx when you want its best-in-class front-end filtering and HDR dynamic range and are willing to run a SoapySDR server for it."
 ---
 
 **SDRplay RSPdx** is a top-of-line receive-only
@@ -41,6 +58,27 @@ ports, and an extensive bank of front-end filters.[^wiki] It extends the
 </svg>
 <figcaption>The RSPdx spans VLF to UHF; below ~2 MHz its HDR mode trades span for cleaner dynamic range.</figcaption>
 </figure>
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0821NMGVP?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Top-of-line single-tuner RSP: 14-bit, three antenna ports, HDR mode.** The RSPdx wraps
+the Mirics tuner in the family's richest [preselection](/reference/rf-filter/) filter bank
+and adds an HDR [dynamic-range](/reference/dynamic-range/) mode below ~2 MHz — the pick for
+DXers fighting overload under strong broadcasters. **GopherTrunk support is network only:**
+it drives the RSPdx over a [SoapySDR](/reference/soapysdr/)/[rtl_tcp](/reference/rtl-tcp/)
+bridge, not as a direct USB device, because SDRplay's closed API/service rules out the
+pure-Go USB path used for RTL-SDR, HackRF, and Airspy. **Around $220.** Like every receiver,
+it can't decode [AES encryption](/police-scanner-encryption/).
+</div>
+
+> **GopherTrunk support: network only.** GopherTrunk drives the RSPdx over the network via
+> SoapySDRServer/SoapyRemote (or an `rtl_tcp`-style bridge), not as a direct USB device —
+> you run SDRplay's API service and a [SoapySDR](/reference/soapysdr/) server on the machine
+> it's plugged into and mount it over TCP. GopherTrunk's pure-Go USB drivers cover only
+> RTL-SDR, HackRF, and Airspy. See the [hardware guide](/hardware.html) and
+> [rtl_tcp](/reference/rtl-tcp/) notes.
 
 ## Overview
 
@@ -95,6 +133,21 @@ closed API/service, so any use goes through a SoapySDR bridge rather than Gopher
 direct USB drivers for RTL-SDR, HackRF, and Airspy. The RF hardware is more than capable;
 the practical question is driver integration, so verify current project support before
 relying on it.
+
+## Where to buy
+
+The RSPdx is sold by SDRplay and its distributors, and listed on Amazon. Note the
+integration path before buying it for GopherTrunk: it is supported **over the network only**,
+through a [SoapySDR](/reference/soapysdr/)/[rtl_tcp](/reference/rtl-tcp/) bridge rather than
+GopherTrunk's direct USB drivers — see the [hardware guide](/hardware.html). If you want a
+plug-and-play scanner front end instead, a [RTL-SDR](/reference/rtl-sdr/) or
+[Airspy](/reference/airspy/) is the simpler choice; the RSPdx's real edge is HF/below-UHF
+DXing.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0821NMGVP?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+*As an Amazon Associate, GopherTrunk earns from qualifying purchases — at no extra cost
+to you. It never changes what we recommend.*
 
 ## Sources
 

--- a/docs/reference/sma-connector.md
+++ b/docs/reference/sma-connector.md
@@ -7,15 +7,33 @@ description: "SMA is a compact 50Ω threaded coaxial connector rated to 18 GHz, 
 keywords: SMA connector, SubMiniature version A, 50 ohm, RP-SMA, reverse polarity SMA, coaxial connector, SDR antenna port, 18 GHz
 aka: [SMA, "SubMiniature version A", RP-SMA]
 autolink: true
+affiliate: true
+product:
+  name: "SMA adapter kit (SMA to BNC/UHF/F/N, 16pc)"
+  brand: Generic
+  category: SMA connector adapter kit
+  lowPrice: "11"
+  highPrice: "15"
+  url: https://www.amazon.com/dp/B07PXCC5G2?tag=gophertrunk-20
 infobox:
   - { label: Type, value: "Threaded coaxial connector" }
   - { label: Impedance, value: "50 Ω (75 Ω variant rare)" }
   - { label: Range, value: "DC to 18 GHz" }
   - { label: Coupling, value: "1/4-36 threaded" }
   - { label: TX, value: "Yes (low power)" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B07PXCC5G2?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
 see_also: [bnc-connector, n-type-connector, coaxial-cable, rtl-sdr, antenna]
 cite_urls:
   - https://en.wikipedia.org/wiki/SMA_connector
+faq:
+  - q: "What connector do SDR dongles use?"
+    a: "Almost all of them use SMA — a small 50 Ω threaded coaxial jack. RTL-SDR Blog V3/V4, Airspy, and HackRF all present an SMA antenna port, as do the bias-tee LNAs and filters that sit between antenna and radio. To connect an older BNC, UHF (PL-259), F, or N-type antenna you need an SMA adapter."
+  - q: "Which SMA adapter kit should I buy for SDR use?"
+    a: "A 16-piece SMA adapter kit (around $13) covers the common transitions — SMA to BNC, UHF/PL-259, F, and N-type — so almost any antenna you own can mate with an SDR's SMA port. Pair it with a set of RG316 SMA pigtails when you need a short flexible lead rather than a rigid barrel adapter."
+  - q: "Is SMA the same as RP-SMA?"
+    a: "No, and mixing them is the most common cause of a cable that screws together but passes no signal. RP-SMA (reverse-polarity, common on Wi-Fi gear) swaps the centre pin and socket while keeping the same thread, so an RP-SMA plug threads onto a standard SMA jack but the centre conductors never touch. Always check the pin/socket, not just the thread."
+  - q: "Do SMA adapters hurt my signal?"
+    a: "Each adapter adds a small reflection and a little insertion loss, so a clean run uses the fewest transitions possible. For an occasional connection a good adapter is fine; for a permanent install, use the right connector on the cable rather than stacking multiple adapters."
 ---
 
 **SMA** (SubMiniature version A) is a small threaded [coaxial](/reference/coaxial-cable/)
@@ -87,6 +105,22 @@ clean run uses the fewest transitions possible. GopherTrunk is decode software a
 no connectors directly, but the quality and correctness of the SMA joints in front of the
 receiver set the signal-to-noise ratio it has to work with — a loose nut or an RP-SMA
 mismatch shows up as missing or weak captures long before any DSP tuning matters.
+
+## Where to buy
+
+Because nearly every SDR uses an SMA antenna port, a small **SMA adapter kit** (16
+pieces, around $13) is the cheapest way to mate whatever antennas and cables you
+already own — SMA to BNC, UHF/PL-259, F, and N-type. Add a set of **RG316 SMA
+pigtails** when you want a short flexible lead instead of a rigid barrel adapter.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B07PXCC5G2?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0132N1DM0?tag=gophertrunk-20" rel="nofollow sponsored noopener">RG316 pigtail kit &rarr;</a>
+
+For coax, patch leads, and full runs, see the
+[SDR cables and connectors guide](/sdr-cables-and-connectors/).
+
+*As an Amazon Associate, GopherTrunk earns from qualifying purchases — at no extra
+cost to you. It never changes what we recommend.*
 
 ## Sources
 

--- a/docs/reference/upconverter.md
+++ b/docs/reference/upconverter.md
@@ -7,16 +7,34 @@ description: An upconverter shifts HF signals up into the tuning range of a VHF/
 keywords: upconverter, HF converter, Ham It Up, shortwave, RTL-SDR HF, frequency shifting, mixer, local oscillator, image frequency
 aka: [upconverter]
 autolink: true
+affiliate: true
+product:
+  name: "Nooelec Ham It Up v1.3 upconverter"
+  brand: Nooelec
+  category: HF upconverter
+  lowPrice: "43"
+  highPrice: "58"
+  url: https://www.amazon.com/dp/B009LQT3G6?tag=gophertrunk-20
 infobox:
   - { label: Type, value: External RF converter }
   - { label: Function, value: Shifts HF up into VHF tuning range }
   - { label: Enables, value: HF reception on VHF/UHF SDRs }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B009LQT3G6?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
 see_also: [mixer-rf, local-oscillator, rtl-sdr, airspy-hf-plus, frequency-bands, image-frequency]
 related_lessons:
   - { title: "Frequency, bands & the spectrum", url: /learn/rf-sdr/frequency-and-spectrum/ }
 cite_urls:
   - https://en.wikipedia.org/wiki/Frequency_mixer
   - https://en.wikipedia.org/wiki/Heterodyne
+faq:
+  - q: "Which upconverter should I buy for HF on an RTL-SDR?"
+    a: "The classic pick is the Nooelec Ham It Up v1.3 (around $50): a 125 MHz LO upconverter that shifts the whole 0–30 MHz HF spectrum up into an RTL-SDR's tuning range. The smaller Ham It Up Nano (around $45) does the same job in a more compact board. Set the app's LO offset to 125 MHz and the display reads the true HF frequency."
+  - q: "Do I still need an upconverter with a modern RTL-SDR?"
+    a: "Not always. The RTL-SDR Blog V3 and V4 add direct-sampling HF built in, so they reach the HF bands without an external converter. An upconverter is for older or other VHF/UHF-only dongles, or when you want a cleaner front end than the V3's direct-sampling branch."
+  - q: "Upconverter or a dedicated HF SDR?"
+    a: "An upconverter is the budget route to HF on a dongle you already own and is fine for casual shortwave and ham listening. For serious HF work a native HF receiver like the Airspy HF+ digitises HF directly with far better dynamic range and no LO phase-noise penalty."
+  - q: "Does GopherTrunk use an upconverter?"
+    a: "No. GopherTrunk decodes VHF/UHF trunked land-mobile systems and does no HF work, so an upconverter is not part of a typical GopherTrunk setup — it is covered here as front-end vocabulary for SDR users whose interests reach below the dongle's native range."
 ---
 
 An **upconverter** is an external device that **shifts HF signals up** into the tuning
@@ -81,6 +99,23 @@ SSB/CW, and digital HF modes to a dongle that otherwise stops around 24 MHz. Gop
 targets trunked land-mobile systems in VHF/UHF and does not itself do HF work, so an
 upconverter is not part of a typical GopherTrunk setup; it is included here as core
 front-end vocabulary for SDR users whose interests reach below the dongle's native range.
+
+## Where to buy
+
+For adding HF to a VHF/UHF [RTL-SDR](/reference/rtl-sdr/), the **Nooelec Ham It Up
+v1.3** (around $50) is the long-standing default — a 125 MHz upconverter that lifts
+the entire 0–30 MHz HF spectrum into the dongle's range. The **Ham It Up Nano**
+(around $45) is the compact version of the same board.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B009LQT3G6?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B084KL1MXM?tag=gophertrunk-20" rel="nofollow sponsored noopener">Ham It Up Nano &rarr;</a>
+
+If HF is your main interest, a native receiver like the
+[Airspy HF+](/reference/airspy-hf-plus/) outperforms an upconverter — see the
+[best HF SDR guide](/best-hf-sdr/) for the full comparison.
+
+*As an Amazon Associate, GopherTrunk earns from qualifying purchases — at no extra
+cost to you. It never changes what we recommend.*
 
 ## Sources
 

--- a/docs/reference/whip-antenna.md
+++ b/docs/reference/whip-antenna.md
@@ -7,14 +7,32 @@ description: A whip antenna is a flexible single-rod monopole, usually a quarter
 keywords: whip antenna, flexible whip, telescopic antenna, monopole, mobile antenna, rubber duck, quarter-wave whip, vehicle antenna
 aka: [whip, flexible whip, telescopic whip, rubber duck]
 autolink: true
+affiliate: true
+product:
+  name: "Nagoya NA-771 telescopic whip antenna (SMA-Female)"
+  brand: Nagoya
+  category: Portable whip antenna
+  lowPrice: "15"
+  highPrice: "21"
+  url: https://www.amazon.com/dp/B00KC4PWQQ?tag=gophertrunk-20
 infobox:
   - { label: Type, value: Flexible monopole }
   - { label: Length, value: ~λ/4 (often shortened/loaded) }
   - { label: Pattern, value: Omnidirectional, vertical }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B00KC4PWQQ?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
 see_also: [monopole-antenna, ground-plane-antenna, dipole-antenna, rtl-sdr, polarization]
 cite_urls:
   - https://en.wikipedia.org/wiki/Whip_antenna
   - https://en.wikipedia.org/wiki/Monopole_antenna
+faq:
+  - q: "Which whip antenna should I buy for a handheld SDR?"
+    a: "For portable SDR and scanner use the Nagoya NA-771 (around $18) is a popular telescopic/whip upgrade. Make sure you get the SMA-Female version to mate with most SDR dongles, whose antenna port is an SMA jack — check the connector before ordering, since the NA-771 also ships in SMA-Male and BNC variants."
+  - q: "Will a Nagoya whip beat the antenna that came with my dongle?"
+    a: "For portable use, usually yes — a full-length telescopic whip you can extend to a quarter wave for the band hears better than a short, poorly grounded rubber duck. The biggest single gain still comes from a real ground plane; a magnetic-mount ground plane or a couple of counterpoise wires under any whip adds several dB."
+  - q: "How long should I extend a telescopic whip?"
+    a: "To about a quarter wavelength for your target frequency: length in cm ≈ 7125 / f(MHz). A collapsed whip sits far off resonance and hears poorly, so extend it to match the band you are scanning."
+  - q: "Does a whip need a ground plane?"
+    a: "A quarter-wave whip works against a ground plane — on a handheld the body, your hand, and the coax shield form an imperfect one, which is why rubber ducks are lossy. A half-wave whip (like many NA-771-class antennas at some bands) needs no ground plane and keeps a stable pattern on a poor mount."
 ---
 
 A **whip antenna** is a [monopole](/reference/monopole-antenna/) built from a single
@@ -82,6 +100,21 @@ and NXDN signals, so a well-mounted vertical whip already suits the traffic GT t
   distant sites.
 - **Give it a ground.** A magnetic-mount ground plane or a couple of counterpoise wires
   dramatically improves a handheld whip.
+
+## Where to buy
+
+For portable SDR and scanner use, the **Nagoya NA-771** (around $18) is a common
+telescopic/whip upgrade over the tiny rubber duck bundled with a dongle. Get the
+**SMA-Female** version to mate with most SDR antenna ports, and extend it toward a
+quarter wave for the band you are scanning.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B00KC4PWQQ?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+For dipoles, discones, and ground-plane options that outperform a handheld whip at a
+fixed location, see the [best SDR antenna guide](/best-sdr-antenna/).
+
+*As an Amazon Associate, GopherTrunk earns from qualifying purchases — at no extra
+cost to you. It never changes what we recommend.*
 
 ## Sources
 

--- a/docs/rtl-sdr-blog-v3-vs-v4.md
+++ b/docs/rtl-sdr-blog-v3-vs-v4.md
@@ -1,0 +1,131 @@
+---
+layout: page
+title: "RTL-SDR Blog V3 vs V4: Which to Buy"
+description: "RTL-SDR Blog V3 vs V4 compared for scanning with GopherTrunk — R860 direct-sampling HF vs R828D built-in upconverter, HF fold, filtering, insertion loss, and the V4 end-of-line question."
+keywords: RTL-SDR Blog V3 vs V4, RTL-SDR V3 vs V4, RTL-SDR Blog V4, RTL-SDR Blog V3, R828D, R860, RTL-SDR HF, RTL-SDR discontinued, which RTL-SDR to buy
+permalink: /rtl-sdr-blog-v3-vs-v4/
+nav_group: Hardware
+affiliate: true
+faq:
+  - q: "Should I buy the RTL-SDR Blog V3 or V4?"
+    a: "For VHF/UHF scanning with GopherTrunk, either is excellent and they decode identically. Buy the V4 if you want built-in HF without an upconverter and slightly better front-end filtering, and you can find one in stock. Buy the V3 if you want a unit you can re-order for years, since the V4 is end-of-line."
+  - q: "Is the RTL-SDR Blog V4 discontinued?"
+    a: "Effectively yes. The V4's Rafael Micro R828D tuner is discontinued, so RTL-SDR Blog has stated the V4 is the last of its line. It still works perfectly, but once current stock is gone it will not be restocked, whereas the R860-based V3 continues."
+  - q: "What is the real difference between V3 and V4 on HF?"
+    a: "The V3 receives HF by direct sampling on the ADC's second Nyquist zone, which folds signals above roughly 14.4 MHz and needs a Q-branch mode. The V4 adds a built-in upconverter so all of HF appears cleanly in normal quadrature-sampling mode with no fold and no aliasing images to fight."
+  - q: "Does the V4 have better filtering than the V3?"
+    a: "Yes. The V4 adds notch filtering and improved input band filtering that reject strong out-of-band signals — broadcast FM and cellular — better than the V3. The trade-off is a couple of dB of insertion loss from those filters, which is rarely a problem in practice."
+  - q: "Can either one decode encrypted police?"
+    a: "No. Neither the V3, the V4, nor any radio can decode AES-encrypted talkgroups. GopherTrunk decodes clear P25/DMR/NXDN/TETRA only. Choose based on the systems still in the clear in your area."
+  - q: "Do I need the V4's HF coverage for scanning?"
+    a: "Only if you also want shortwave, ham HF, or utility monitoring. Trunked police, fire, and EMS systems live in VHF/UHF (roughly 136–870 MHz), which both dongles cover natively. If you never touch HF, the HF difference between V3 and V4 does not matter."
+---
+
+# RTL-SDR Blog V3 vs V4: Which to Buy
+
+**For scanning with [GopherTrunk](/downloads.html), the V3 and V4 decode
+identically — the choice comes down to HF handling and stock.** Buy the
+[V4](/reference/rtl-sdr/) for built-in HF and better filtering while it is still
+available; buy the [V3](/reference/rtl-sdr/) if you want a dongle you can re-order
+for years. Both are proper [RTL-SDR](/reference/rtl-sdr/) units with a real TCXO,
+SMA connector, and switchable [bias tee](/reference/bias-tee/).
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**V4 wins on HF** (built-in upconverter, no fold) **and filtering** (notch +
+better band filters). **V3 wins on availability** — the V4 is
+**end-of-line** because its R828D tuner is discontinued. **For VHF/UHF
+trunk-tracking they are equal.** The V4's extra filters cost ~2–3 dB of
+insertion loss. **Neither decodes [AES encryption](/police-scanner-encryption/).**
+</div>
+
+## Comparison at a glance
+
+| | RTL-SDR Blog V3 | RTL-SDR Blog V4 |
+|---|---|---|
+| Tuner | R860 (R820T2 family) | Rafael Micro **R828D** |
+| HF reception | Direct sampling (Q-branch) | **Built-in upconverter** |
+| HF fold / aliasing | Folds above ~14.4 MHz | **None** — clean across HF |
+| Input filtering | Basic | **Notch + improved band filters** |
+| Insertion loss | Lower | ~2–3 dB higher (the filters) |
+| TCXO | 1 ppm | 1 ppm |
+| Connector / bias tee | SMA / switchable | SMA / switchable |
+| Availability | **Ongoing** | **End-of-line** |
+| Approx price (with kit) | ~$45 | ~$40–50 |
+
+## HF: direct sampling vs a built-in upconverter
+
+This is the biggest technical difference. The **V3** reaches HF by *direct
+sampling* — feeding the antenna straight into the [ADC](/reference/analog-to-digital-converter/)
+and listening on its second Nyquist zone. It works, but signals above roughly
+14.4 MHz **fold** back down, you have to switch to a special Q-branch mode, and
+strong broadcast stations can alias into your passband.
+
+The **V4** puts a small *upconverter* on the board. It shifts all of HF up into a
+range the tuner handles natively, so shortwave, ham HF, and utility signals appear
+cleanly in normal quadrature mode with **no fold and no images**. If HF matters to
+you, the V4 is the easier, better receiver — no external
+[upconverter](/reference/upconverter/) box required.
+
+> **For police/fire/EMS this is a non-issue.** Trunked public-safety systems live
+> in VHF/UHF (roughly 136–870 MHz), which both dongles cover natively and
+> identically. The HF advantage of the V4 only matters if you also want to listen
+> below 30 MHz.
+
+## Filtering vs insertion loss
+
+The V4 adds **notch filtering** (to reject broadcast FM and other strong local
+signals) and improved input band filtering. In a strong-signal environment — near
+FM transmitters or cellular sites — that cleaner front end can be the difference
+between a clean control-channel lock and intermod hash.
+
+The trade-off is honest: those filters add roughly **2–3 dB of insertion loss**.
+On a weak, rural signal a couple of dB matters, and a mast-mounted
+[LNA](/best-sdr-lna/) more than makes it back. In most suburban and urban setups
+the filtering is worth far more than the loss. If your problem is a genuinely weak
+signal rather than overload, that is a front-end dynamic-range issue no filter
+fixes — see [when you actually need an Airspy](/airspy-vs-rtl-sdr-vs-hackrf/).
+
+## The end-of-line reality
+
+The V4's R828D tuner has been discontinued, and RTL-SDR Blog has said the V4 is
+the last production run of that design. **Nothing about your V4 stops working** —
+it is a great dongle for years to come — but it will not be restocked once current
+inventory sells through. The R860-based **V3** (and the wider
+[NESDR SMArt](/reference/nesdr/) class of R820T2/R860 dongles) continue in
+production, so they are the safer bet if you are buying several for a
+[multi-dongle pool](/multi-dongle-sdr-setup/) or want to standardise on something
+you can re-order.
+
+## Which should you buy?
+
+<div class="pick-cards" markdown="0">
+<div class="pick-card pick-card--top">
+<span class="pick-card__badge">Best while in stock</span>
+<h3>RTL-SDR Blog V4</h3>
+<p class="pick-card__price">around $40</p>
+<p>Built-in HF, best filtering, the enthusiast reference. Buy now if you want the best single dongle and can find one — it is end-of-line.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0CD745394?tag=gophertrunk-20" rel="nofollow sponsored noopener">V4 on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/rtl-sdr/">RTL-SDR details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Best for the long haul</span>
+<h3>RTL-SDR Blog V3 + dipole kit</h3>
+<p class="pick-card__price">around $45</p>
+<p>Proven R860 dongle plus a real antenna, and a design that stays in production. The safe pick if you want to re-order or buy in quantity.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0BMKB3L47?tag=gophertrunk-20" rel="nofollow sponsored noopener">V3 kit on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/best-rtl-sdr/">best RTL-SDR guide</a></p>
+</div>
+</div>
+
+## Bottom line
+
+If HF interests you and you can find one, the **V4** is the better all-round
+receiver — built-in upconverter, cleaner filtering, the reference dongle. If you
+want something you can buy again next year, or you only care about VHF/UHF
+scanning, the **V3** is every bit as good on the bands that matter and stays in
+production. Either way you are getting a proper TCXO-equipped
+[RTL-SDR](/reference/rtl-sdr/) that runs [GopherTrunk](/downloads.html) for about
+$40–45, and **neither decodes [encryption](/police-scanner-encryption/)**. Still
+deciding across brands? See the [best RTL-SDR](/best-rtl-sdr/) roundup and the
+[best SDR overall](/best-sdr-for-gophertrunk/).

--- a/docs/sdr-cables-and-connectors.md
+++ b/docs/sdr-cables-and-connectors.md
@@ -1,0 +1,132 @@
+---
+layout: page
+title: "SDR Cables & Connectors Guide"
+description: "A plain-English guide to SDR cables and connectors for GopherTrunk — SMA, BNC, N, F, and UHF/PL-259 explained, plus adapter kits, RG316 pigtails, and which coax to use to avoid signal loss."
+keywords: SDR cables and connectors, SMA connector, BNC connector, PL-259, RG316, RG58, SDR adapter kit, SDR coax, SMA to BNC, antenna connector guide
+permalink: /sdr-cables-and-connectors/
+nav_group: Hardware
+affiliate: true
+faq:
+  - q: "What connector does an SDR use?"
+    a: "Most modern SDRs — RTL-SDR Blog, Airspy, HackRF — use an SMA jack. Older or cheaper dongles sometimes use the smaller MCX or the TV-style PAL/F. Many antennas, meanwhile, use BNC, UHF (PL-259/SO-239), or N. An SMA adapter kit bridges almost any mismatch for a few dollars."
+  - q: "What is the difference between SMA and RP-SMA?"
+    a: "They look identical but the pin and socket are reversed. Standard SMA (used by SDRs and most antennas) has a center pin on the male side; RP-SMA (common on Wi-Fi gear) has a center socket. They do not mate properly. Buy plain SMA for SDR work and check listings carefully."
+  - q: "Which coax should I use for an SDR antenna?"
+    a: "For short bench runs, thin RG316 pigtails are fine and flexible. For any real distance, use lower-loss cable — RG58 or RG8X — because loss climbs steeply at the UHF frequencies trunked systems use. Keep every run as short as practical."
+  - q: "Do adapters and cables lose signal?"
+    a: "A little. Each adapter and connector adds a small insertion loss, and cable adds loss per foot that worsens with frequency. One or two quality adapters are negligible; a stack of cheap ones on a long thin cable is not. Minimize the number of junctions and the cable length."
+  - q: "What is a PL-259 / UHF connector?"
+    a: "UHF connectors — the plug is a PL-259, the jack an SO-239 — are the large screw-on connectors common on scanners, CB, and ham gear. Despite the name they are used mostly at HF/VHF. An SMA-to-UHF adapter lets an SDR use an antenna or coax terminated this way."
+  - q: "Do I need a whole connector kit or just one adapter?"
+    a: "If you know both ends, a single adapter is enough. If you are not sure what your antenna terminates in, or you tinker with different gear, a 16-piece SMA adapter kit costs about the price of two single adapters and covers BNC, UHF, N, and F in both directions."
+---
+
+# SDR Cables & Connectors Guide
+
+**Your SDR is almost certainly SMA; your antenna might not be — and the cable
+between them can quietly throw away signal.** This is the unglamorous plumbing of
+an [SDR scanner](/best-sdr-for-gophertrunk/), but getting it right is the
+difference between a clean [control-channel](/reference/trunked-radio/) lock and a
+mysteriously deaf setup. Here is what plugs into what, and which
+[coax](/reference/coaxial-cable/) to run.
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Most SDRs use [SMA](/reference/sma-connector/)**; antennas often use BNC, UHF
+(PL-259), N, or F. **An adapter kit bridges any mismatch** for a few dollars.
+**SMA ≠ RP-SMA** — the pins are reversed. **[Coax](/reference/coaxial-cable/) loss
+climbs with frequency** — keep runs short, use RG58/RG8X for distance. **Every
+junction costs a little signal** — minimize them.
+</div>
+
+## The connectors you will meet
+
+| Connector | Where you see it | Notes |
+|---|---|---|
+| **[SMA](/reference/sma-connector/)** | Most SDRs, small antennas | The SDR default. Watch for RP-SMA (reversed pin). |
+| **MCX** | Some older/cheaper dongles | Tiny snap-on; adapt to SMA. |
+| **BNC** | Scanners, test gear, some antennas | Quarter-turn bayonet; common on whips. |
+| **UHF (PL-259 / SO-239)** | Scanners, CB, ham, discones | Large screw-on; despite the name, mostly HF/VHF. |
+| **N** | Outdoor / higher-end antennas | Rugged, weatherproof, good to UHF. |
+| **F** | TV-style dongles, cable TV | Push/screw; low quality for RF work. |
+
+> **SMA and RP-SMA are not interchangeable.** They look the same but the center
+> conductor is reversed — RP-SMA (Wi-Fi gear) will not properly mate with the
+> plain SMA on your SDR. When in doubt, buy standard SMA and read the listing.
+
+## Adapters and pigtails to keep on hand
+
+<div class="pick-cards" markdown="0">
+<div class="pick-card pick-card--top">
+<span class="pick-card__badge">Most useful</span>
+<h3>16-piece SMA adapter kit</h3>
+<p class="pick-card__price">around $13</p>
+<p>SMA to/from BNC, UHF, N, and F in both genders. Covers almost any SDR-to-antenna mismatch you will hit — the one thing to buy if unsure.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B07PXCC5G2?tag=gophertrunk-20" rel="nofollow sponsored noopener">Adapter kit on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/sma-connector/">SMA details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Flexible pigtails</span>
+<h3>RTL-SDR Blog RG316 pigtail kit</h3>
+<p class="pick-card__price">around $15</p>
+<p>Short flexible RG316 pigtails with SMA and common terminations — perfect for connecting a dongle to a fixed antenna or feedline without stress on the jack.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0132N1DM0?tag=gophertrunk-20" rel="nofollow sponsored noopener">Pigtail kit on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/coaxial-cable/">coax details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Cable assortment</span>
+<h3>NooElec SMA connectivity kit</h3>
+<p class="pick-card__price">around $18</p>
+<p>Eight assorted SMA cables and adapters — extensions, gender changers, and jumpers to reach a window or bench-mounted antenna cleanly.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B077H87LTS?tag=gophertrunk-20" rel="nofollow sponsored noopener">Cable kit on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/sdr-cables-and-connectors/#coax-and-loss">coax loss below</a></p>
+</div>
+</div>
+
+## Coax and loss {#coax-and-loss}
+
+Cable is not free signal — it is a lossy component, and the loss gets worse as
+frequency rises. That matters because trunked public-safety systems sit at UHF
+(700/800 MHz), right where thin cable bleeds the most.
+
+| Coax | Loss | Flexibility | Best for |
+|---|---|---|---|
+| **RG316** | High (per foot) | Very flexible, thin | Short bench pigtails, tight bends |
+| **RG58** | Medium | Moderate | General jumpers, medium runs |
+| **RG8X** | Lower | Stiffer, thicker | Longer outdoor feedlines |
+
+Rules of thumb that keep signal on the wire:
+
+- **Short is better than good.** The cheapest way to cut loss is a shorter run.
+  Put the SDR near the antenna and send USB or network the long way, not RF.
+- **Match the cable to the distance.** RG316 for a foot or two; RG58/RG8X for
+  anything across a room or up a mast.
+- **Fewer junctions.** Each adapter adds a little loss and a possible bad contact.
+  One clean adapter is fine; a tower of six is not.
+- **Long run? Amplify at the antenna.** If distance is unavoidable, a mast-mounted
+  [LNA](/best-sdr-lna/) recovers feedline loss *before* it happens — but only if
+  the signal environment is not already strong enough to overload.
+
+> **Weatherproof outdoor connections.** Any junction exposed to weather needs
+> self-amalgamating tape or a proper boot. Water in coax raises loss permanently
+> and corrodes connectors — the slow death of many rooftop antennas.
+
+## A typical clean setup
+
+For most people: an [SDR](/best-rtl-sdr/) with an SMA jack, a short
+[RG316](/reference/coaxial-cable/) pigtail or SMA jumper out to a
+[dipole](/best-sdr-antenna/) or discone, and — if the antenna terminates in BNC or
+UHF — one adapter from the [kit](/reference/sma-connector/). That is the whole RF
+chain. Keep it short, keep it clean, and the [dongle](/best-rtl-sdr/) will hear
+everything the antenna does.
+
+## Bottom line
+
+Assume your SDR is **[SMA](/reference/sma-connector/)** and your antenna might be
+anything — so keep a **cheap adapter kit** on hand and you will never be stuck.
+Use **[RG316](/reference/coaxial-cable/)** for short jumpers and thicker RG58/RG8X
+for distance, keep every run as short as you can, and minimize junctions. Get the
+plumbing right and a [$35 dongle](/best-rtl-sdr/) on a good
+[antenna](/best-sdr-antenna/) runs [GopherTrunk](/downloads.html) flawlessly.
+Next stop: the [what-you-need checklist](/what-do-i-need-for-gophertrunk/) and the
+[hardware setup guide](/hardware.html).

--- a/docs/sdr-filters.md
+++ b/docs/sdr-filters.md
@@ -1,0 +1,146 @@
+---
+layout: page
+title: "SDR Filters: Fix Overload & Interference"
+description: "How to fix RTL-SDR overload and interference with broadcast FM/AM notch filters, bandpass and SAW filters — when a filter beats an LNA for GopherTrunk decoding."
+keywords: SDR filter, RTL-SDR overload, broadcast FM notch filter, AM band reject filter, SAW filter, bandpass filter SDR, FM interference, desensitization, GopherTrunk
+permalink: /sdr-filters/
+nav_group: Hardware
+affiliate: true
+faq:
+  - q: "Why does my RTL-SDR hear noise or ghost signals everywhere?"
+    a: "An 8-bit RTL-SDR has limited dynamic range. A strong nearby broadcast FM, AM, TV, or pager transmitter can overload its front end, raising the noise floor and creating false images across the band. A notch or bandpass filter removes the offending signal before it reaches the tuner and restores weak-signal reception."
+  - q: "Do I need an FM notch or an AM notch filter?"
+    a: "Use an FM broadcast notch (88–108 MHz) if you live near FM towers and scan VHF/UHF — it is the single most common fix. Add an AM broadcast notch (roughly below 1.7 MHz) if you monitor HF and a local AM station is swamping your upconverter or direct-sampling input."
+  - q: "Should I buy a filter or an LNA first?"
+    a: "If your problem is a raised noise floor, images, or intermod from strong local signals, buy the filter — an LNA would only amplify the interference and make overload worse. Buy an LNA only when a genuinely weak, distant signal needs a lift and the band is otherwise clean."
+  - q: "What is a SAW filter?"
+    a: "A surface-acoustic-wave (SAW) bandpass filter passes one narrow band (for example the 380–520 MHz public-safety range) and sharply rejects everything else. It is the strongest fix when you only care about one band and want maximum out-of-band rejection."
+  - q: "Will a filter reduce my wanted signal?"
+    a: "A little — every filter has some insertion loss in its passband, typically 1–3 dB. That is almost always a good trade: removing a strong interferer lowers the noise floor far more than the small loss costs you, so the net signal-to-noise ratio improves."
+  - q: "Can a filter help with simulcast distortion?"
+    a: "No. Simulcast distortion is multipath from multiple transmitters, not front-end overload. A filter cannot fix it. See our simulcast reference for what actually helps."
+---
+
+# SDR Filters: Fix Overload & Interference
+
+**If your [RTL-SDR](/reference/rtl-sdr/) suddenly hears static, ghost signals, or a
+raised noise floor across the whole band, the cause is almost always front-end
+overload — and an [RF filter](/reference/rf-filter/) fixes it far better than any
+amount of gain twiddling.** An 8-bit dongle has limited dynamic range, so one strong
+local transmitter can swamp everything you actually want to decode with GopherTrunk.
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Most common fix:** a **[broadcast FM notch filter](https://www.amazon.com/dp/B07XKY8YKB?tag=gophertrunk-20)**
+(~$25) kills 88–108 MHz overload. **On HF:** add an
+**[AM broadcast notch](https://www.amazon.com/dp/B079CMB44V?tag=gophertrunk-20)** (~$20).
+**Best out-of-band rejection:** a **[SAW bandpass filter](/reference/saw-filter/)** for
+your one band. **Filter first, LNA later** — an [LNA](/best-sdr-lna/) amplifies
+interference too. Filters cost 1–3 dB of insertion loss but can drop the noise floor
+by 10 dB or more.
+</div>
+
+## Why strong signals wreck a cheap dongle
+
+An [RTL-SDR](/reference/rtl-sdr/)'s 8-bit ADC gives it roughly 48 dB of usable
+dynamic range. That is plenty when the band is quiet, but a
+**broadcast FM station a few miles away can arrive 60–80 dB stronger** than the
+distant P25 control channel you are trying to follow. When that happens the tuner's
+amplifier is driven into compression — it stops behaving linearly — and three bad
+things follow:
+
+- **Desensitization.** The strong signal steals the front end's headroom, so weak
+  signals across the *entire* band get quieter or vanish.
+- **Intermodulation.** Two or more strong signals mix inside the overloaded tuner and
+  produce phantom "signals" on frequencies where nothing is actually transmitting.
+- **Images and a raised noise floor.** The whole spectrum display lifts, burying the
+  low-level modulation your decoder needs.
+
+None of this is a software problem, and none of it is fixed by more gain. The signal
+you want is being drowned before it ever reaches the ADC. You have to remove the
+offender in hardware, in front of the dongle — that is what a filter does.
+
+## The three filter types
+
+<div class="pick-cards" markdown="0">
+<div class="pick-card pick-card--top">
+<span class="pick-card__badge">Most common fix</span>
+<h3>Broadcast FM notch</h3>
+<p class="pick-card__price">around $25</p>
+<p>Deep rejection of 88–108 MHz, passes everything else. The default fix for city dwellers scanning VHF/UHF near FM towers.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B07XKY8YKB?tag=gophertrunk-20" rel="nofollow sponsored noopener">FM notch on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/rf-filter/">RF filter details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">For HF users</span>
+<h3>AM broadcast notch</h3>
+<p class="pick-card__price">around $20</p>
+<p>Rejects the AM broadcast band (below ~1.7 MHz) so a local mediumwave blowtorch stops swamping your HF input or upconverter.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B079CMB44V?tag=gophertrunk-20" rel="nofollow sponsored noopener">AM notch on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/best-hf-sdr/">HF SDR guide</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Strongest rejection</span>
+<h3>SAW bandpass</h3>
+<p class="pick-card__price">around $25–40</p>
+<p>Passes only one band (e.g. 380–520 MHz public safety) and rejects everything outside it. Best when you scan a single band.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B07G14Q6XX?tag=gophertrunk-20" rel="nofollow sponsored noopener">LNA + filter combos &rarr;</a>
+<p class="pick-card__note"><a href="/reference/saw-filter/">SAW filter details</a></p>
+</div>
+</div>
+
+**Notch (band-stop) filters** remove one band and pass everything else — ideal when a
+single culprit (FM broadcast, AM broadcast, a nearby pager transmitter on 152/929 MHz)
+is the problem but you still want wide coverage. **Bandpass filters** do the opposite:
+they pass one band and reject the rest. **[SAW filters](/reference/saw-filter/)** are
+bandpass filters built from a surface-acoustic-wave element, giving very steep skirts
+and deep out-of-band rejection in a tiny package.
+
+## When a filter beats an LNA
+
+This is the decision people get wrong most often, so be honest about which problem you
+have:
+
+> **Filter vs LNA.** A **[filter](/reference/rf-filter/)** removes unwanted signal; an
+> **[LNA](/best-sdr-lna/)** amplifies *all* signal. If your band is crowded with strong
+> locals, an LNA makes overload *worse* — it pushes the interferer deeper into
+> compression. Reach for the LNA only when the wanted signal is genuinely weak *and*
+> the band is clean; reach for the filter whenever the noise floor is raised, you see
+> images, or intermod products appear.
+
+A useful order of operations for a stubborn setup:
+
+1. **Turn gain down first.** Free. If lowering RTL-SDR gain cleans up the ghosts, you
+   were overloading — a filter will let you run more gain cleanly.
+2. **Add the right notch filter.** FM notch for VHF/UHF scanning; AM notch if you are
+   on HF. This solves the large majority of city overload complaints.
+3. **Add a SAW bandpass** if you only care about one band and want maximum rejection.
+4. **Only then consider an LNA** — and put it *after* the filter (antenna → filter →
+   LNA → dongle) so you never amplify the interference you just removed.
+
+## Where filters live in the chain
+
+Order matters. The general rule is **filter as early as possible, amplify as late as
+possible**:
+
+```
+Antenna → (filter) → (LNA) → coax → RTL-SDR
+```
+
+Putting the filter ahead of any amplifier protects the whole chain from overload. If
+you power an LNA from the dongle's [bias tee](/reference/bias-tee/), make sure the
+filter you place before it passes DC or is placed on the antenna side of the LNA — a
+DC-blocking filter between the bias tee and the LNA will starve it of power.
+
+## Bottom line
+
+If GopherTrunk was decoding fine and then went noisy — or never worked well in a city —
+suspect **front-end overload before anything else**. A
+**[broadcast FM notch filter](https://www.amazon.com/dp/B07XKY8YKB?tag=gophertrunk-20)**
+is the ~$25 fix for the vast majority of VHF/UHF cases; add an
+**[AM notch](https://www.amazon.com/dp/B079CMB44V?tag=gophertrunk-20)** if you work HF,
+and a **[SAW bandpass](/reference/saw-filter/)** if you live on one band. Buy the filter
+before the [LNA](/best-sdr-lna/): amplifying interference never helps. Then get the rest
+of the kit right in our
+[what-you-need checklist](/what-do-i-need-for-gophertrunk/) and pick the dongle in
+[best SDR for GopherTrunk](/best-sdr-for-gophertrunk/).

--- a/docs/what-do-i-need-for-gophertrunk.md
+++ b/docs/what-do-i-need-for-gophertrunk.md
@@ -1,0 +1,124 @@
+---
+layout: page
+title: "What Hardware Do I Need to Run GopherTrunk? (Complete Checklist)"
+description: "Everything you need to get GopherTrunk decoding police, fire, and EMS radio — the SDR dongle, antenna, adapters, computer, and optional LNA/filters — with tested picks and Amazon links."
+keywords: what do I need for GopherTrunk, SDR scanner starter kit, RTL-SDR setup, GopherTrunk hardware, SDR scanning kit, police scanner SDR setup, RTL-SDR antenna adapter
+permalink: /what-do-i-need-for-gophertrunk/
+nav_group: Hardware
+affiliate: true
+faq:
+  - q: "What do I need to run GopherTrunk?"
+    a: "Four things: a computer (any modern PC, Mac, or a Raspberry Pi), an SDR USB dongle (a ~$35 RTL-SDR is ideal), an antenna, and usually an SMA adapter or cable to connect them. GopherTrunk itself is free. That's a complete digital-scanning setup for well under $100."
+  - q: "How much does a GopherTrunk setup cost?"
+    a: "If you already own a computer, about $40–70 total: ~$35 for a good RTL-SDR, ~$25 for a dipole antenna kit, and a few dollars for adapters. A dedicated Raspberry Pi for 24/7 use adds ~$80. The software is free and open source."
+  - q: "Do I need a special computer?"
+    a: "No. GopherTrunk runs on Windows, macOS, and Linux, and on a Raspberry Pi 4 or 5 for always-on use. Any machine from the last decade with a spare USB port is fine — decoding one or two control channels is light work."
+  - q: "Do I need an antenna, or is the one in the box enough?"
+    a: "The tiny antenna bundled with cheap dongles will hear strong local signals but little else. A ~$25 telescopic dipole kit dramatically improves reception, and an outdoor discone is better still. The antenna matters more than the dongle."
+  - q: "What connects the antenna to the dongle?"
+    a: "Most SDRs use an SMA connector. Coax antennas often use BNC, N, F (TV), or UHF (PL-259). A cheap SMA adapter kit bridges whatever you have. See our cables and connectors guide."
+  - q: "Can I hear encrypted police with this setup?"
+    a: "No. No SDR or scanner can decode AES-encrypted talkgroups — it's a cryptographic and legal wall. This setup hears everything still transmitted in the clear, which in most areas includes plenty of dispatch and nearly all fire/EMS."
+---
+
+# What Hardware Do I Need to Run GopherTrunk?
+
+**Four things get you decoding police, fire, and EMS radio with GopherTrunk: a
+computer, an [SDR](/reference/software-defined-radio/) dongle, an antenna, and a
+connector or two.** GopherTrunk is [free, open-source software](/downloads.html), so the
+only money is a bit of hardware — a complete digital-scanning rig costs well under $100
+if you already own a computer.
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The four essentials:** ① a **computer** (PC/Mac/Linux, or a
+[Raspberry Pi](/raspberry-pi-sdr-scanner/) for 24/7), ② an **[SDR dongle](/best-sdr-for-gophertrunk/)**
+(~$35 [RTL-SDR](/reference/rtl-sdr/)), ③ an **[antenna](/best-sdr-antenna/)** (~$25 dipole
+kit), ④ an **[SMA adapter/cable](/sdr-cables-and-connectors/)**. **Optional:** an
+[LNA](/best-sdr-lna/) or [filter](/sdr-filters/) for weak signals or overload.
+**Total ~$40–70** + free software. **No setup decodes [encryption](/police-scanner-encryption/).**
+</div>
+
+## The complete checklist
+
+| # | What | Why | Pick | Approx $ |
+|---|---|---|---|---|
+| 1 | **Computer** | Runs GopherTrunk | A PC you own, or a [Raspberry Pi 5](/raspberry-pi-sdr-scanner/) for 24/7 | $0–80 |
+| 2 | **SDR dongle** | Receives the radio | [RTL-SDR Blog V4](/reference/rtl-sdr/) or [NESDR SMArt v5](/reference/nesdr/) | ~$35–40 |
+| 3 | **Antenna** | Actually hears signals | [Dipole kit](/best-sdr-antenna/) (indoor) or [discone](/reference/discone-antenna/) (outdoor) | ~$25–40 |
+| 4 | **Adapter/cable** | Connects antenna to dongle | [SMA adapter kit](/sdr-cables-and-connectors/) | ~$13 |
+| + | **LNA** (optional) | Boosts weak signals | [RTL-SDR Blog Wideband LNA](/best-sdr-lna/) | ~$30 |
+| + | **Filter** (optional) | Fixes FM/AM overload | [Broadcast notch filter](/sdr-filters/) | ~$25 |
+| + | **USB extension** (optional) | Antenna near a window, PC elsewhere | [Active shielded USB cable](https://www.amazon.com/dp/B00BWK9VZ2?tag=gophertrunk-20) | ~$15 |
+
+## 1. A computer
+
+GopherTrunk runs on **Windows, macOS, and Linux**, and on a **Raspberry Pi 4 or 5** for
+always-on monitoring. Decoding one or two control channels is light work — almost any
+machine from the last decade with a free USB port will do. For a dedicated, low-power
+box that runs 24/7 next to the antenna, a [Raspberry Pi 5](https://www.amazon.com/dp/B0CK2FCG1K?tag=gophertrunk-20)
+is ideal; see [running GopherTrunk on a Raspberry Pi](/raspberry-pi-sdr-scanner/).
+
+## 2. The SDR dongle
+
+This is the receiver. A good **[RTL-SDR](/reference/rtl-sdr/)** — the
+[RTL-SDR Blog V4](https://www.amazon.com/dp/B0CD745394?tag=gophertrunk-20) or a
+[NooElec NESDR SMArt v5](https://www.amazon.com/dp/B01HA642SW?tag=gophertrunk-20) — is
+the sweet spot at ~$35–40: shielded, temperature-stable, and more than enough to follow
+[P25](/reference/project-25/)/[DMR](/reference/dmr/)/[NXDN](/reference/nxdn/). Step up to
+an [Airspy](/reference/airspy/) only for tough RF or wideband capture. Full comparison:
+[best SDR for GopherTrunk](/best-sdr-for-gophertrunk/).
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0CD7558GT?tag=gophertrunk-20" rel="nofollow sponsored noopener">RTL-SDR Blog V4 + antenna kit on Amazon &rarr;</a>
+
+> **Buy the bundle.** The [RTL-SDR Blog V4 with the dipole antenna kit](https://www.amazon.com/dp/B0CD7558GT?tag=gophertrunk-20)
+> gets you the dongle *and* a proper antenna in one box — the simplest way to start.
+
+## 3. An antenna
+
+**The antenna matters more than the dongle.** The stub that ships with cheap sticks
+hears strong locals and little else. A **[telescopic dipole kit](https://www.amazon.com/dp/B075445JDF?tag=gophertrunk-20)**
+(~$25) you can tune to your band is a huge upgrade; a roof-mounted
+**[discone](https://www.amazon.com/dp/B0CL5ZBN94?tag=gophertrunk-20)** covers 25–3000 MHz
+for serious coverage. Details and mounting: [best SDR antenna](/best-sdr-antenna/).
+
+## 4. Adapters and cables
+
+Most SDRs use an **[SMA connector](/reference/sma-connector/)**. Antennas and coax often
+end in BNC, N, F (TV-style), or UHF/PL-259. A cheap
+**[SMA adapter kit](https://www.amazon.com/dp/B07PXCC5G2?tag=gophertrunk-20)** bridges
+whatever you've got, and a [pigtail or extension cable](/sdr-cables-and-connectors/) lets
+you place the antenna where the signal is. Full guide:
+[SDR cables and connectors](/sdr-cables-and-connectors/).
+
+## Optional upgrades
+
+- **[LNA (low-noise amplifier)](/best-sdr-lna/)** — helps a weak, distant control channel,
+  especially with feedline loss to a rooftop antenna. Powered over the dongle's
+  [bias tee](/reference/bias-tee/). Don't overdo gain — it can *cause* overload.
+- **[Broadcast notch filter](/sdr-filters/)** — if a strong FM or AM station desensitizes
+  your dongle (common in cities), a notch filter restores weak-signal reception.
+- **[Active USB extension](https://www.amazon.com/dp/B00BWK9VZ2?tag=gophertrunk-20)** —
+  put the dongle at the window/antenna and the computer wherever's convenient.
+
+## Put it together
+
+1. Screw the antenna (via any needed adapter) onto the SDR.
+2. Plug the SDR into the computer.
+3. [Download GopherTrunk](/downloads.html) and follow the
+   [hardware setup guide](/hardware.html) (on Windows, bind the driver with
+   [Zadig](/reference/zadig/) first).
+4. Enter your system's control channel — look it up on
+   [RadioReference](https://www.radioreference.com/) — and start decoding.
+
+New to how any of this works? Start with the [RF & SDR learning path](/learn/rf-sdr/) and
+[what is trunked radio](/learn/digital-trunking/).
+
+## Bottom line
+
+A **computer + a ~$35 [RTL-SDR](/reference/rtl-sdr/) + a ~$25
+[antenna](/best-sdr-antenna/) + a few-dollar [adapter](/sdr-cables-and-connectors/)** is
+the entire shopping list for a GopherTrunk digital scanner — under $100, or the price of
+the free software plus one bundle. Add an [LNA](/best-sdr-lna/) or
+[filter](/sdr-filters/) only if your reception needs it. Everything hits the same
+[encryption](/police-scanner-encryption/) wall, so buy for the traffic that's in the clear.


### PR DESCRIPTION
## Summary

GopherTrunk.org already has a monetized "Hardware" cluster for dedicated police
scanners (merged in #1019), but nothing for the **SDR hardware GopherTrunk actually
runs on**. Only `rtl-sdr.md` had Amazon links; the other SDR receiver, accessory, and
antenna Field Guide articles had none, and there was no SDR buyer landing page. This PR
closes that gap so the site ranks for "best RTL-SDR", "SDR for scanning", "what do I
need to run GopherTrunk", etc., and earns via the `gophertrunk-20` Associates tag —
reusing the existing affiliate infrastructure (no new includes/layouts/CSS/taxonomy).

## Changes

- **Receiver articles augmented** with the affiliate pattern (Product JSON-LD, buy CTA,
  FAQ, `.tldr`): `hackrf`, `airspy`, `airspy-hf-plus`, `nesdr`, `rtl-sdr` (kept its buy
  table), plus SoapyRemote-only devices `sdrplay-rsp1a`, `sdrplay-rspdx`, `plutosdr`,
  `limesdr`, `bladerf` — each with an explicit **"GopherTrunk support: network only"**
  caveat. `krakensdr` gets an honest "sold direct, not on Amazon" note (no affiliate link).
- **Accessory/antenna articles augmented** with recommended-product buy sections:
  `low-noise-amplifier`, `upconverter`, `bias-tee`, `rf-filter`, `saw-filter`,
  `discone-antenna`, `dipole-antenna`, `whip-antenna`, `sma-connector`, `coaxial-cable`,
  `ferrite-choke`.
- **14 new buyer landing pages** (`layout: page`, `.tldr`, pick-cards, comparison tables,
  FAQPage schema): `best-sdr-for-gophertrunk`, `what-do-i-need-for-gophertrunk` (the
  complete get-running checklist), `best-rtl-sdr`, `rtl-sdr-blog-v3-vs-v4`,
  `airspy-vs-rtl-sdr-vs-hackrf`, `best-sdr-antenna`, `sdr-cables-and-connectors`,
  `best-sdr-lna`, `sdr-filters`, `best-hf-sdr`, `raspberry-pi-sdr-scanner`,
  `best-sdr-for-p25-trunking`, `multi-dongle-sdr-setup`, `cheap-sdr-scanner`.
- **Registration:** added the SDR guides to the existing **Hardware** nav group
  (`_data/nav.yml`) and `llms.txt`. No `reference.yml` changes — every slug already existed.
- **Honesty throughout:** no SDR (or scanner) decodes AES encryption; RTL-SDR Blog V4 is
  end-of-line (NESDR SMArt v5 is the always-in-stock pick); Airspy is distributor-sold
  (tagged search links); SDRplay/Lime/USRP/bladeRF/Pluto are SoapyRemote-only; HackRF is
  receive-only under GopherTrunk. No fabricated reviews/ratings.
- Every Amazon link carries `tag=gophertrunk-20`; every buy button is
  `rel="nofollow sponsored noopener"`.

## Test plan

Docs-only change (no Go code touched), verified with the repo's docs CI locally:

- [x] `jekyll build -s docs` succeeds
- [x] `check_site_pages.py` — "Site map check passed: 1711 content pages"
- [x] `check_internal_links.py` — "Internal link check passed: 276170 internal links, all resolve"
- [x] Built pages emit valid `Product` + `FAQPage` JSON-LD; pick-cards, buy buttons, and network-only caveats render; Hardware nav shows the new SDR guides
- [x] Affiliate audit: 100% `gophertrunk-20`, all buy links `rel="nofollow sponsored noopener"`
- [ ] `make vet test` — n/a (no Go code changed)
- [ ] `make integration` — n/a (no daemon/DSP change)

## Breaking changes

None.

## Docs / CHANGELOG

- [ ] CHANGELOG — n/a (site content only, not a shipped-binary change)
- [x] This PR *is* the `docs/` update.

## Linked issues

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMF7oNNhSH6BYKJkSmfcXw

---
_Generated by [Claude Code](https://claude.ai/code/session_01TMF7oNNhSH6BYKJkSmfcXw)_