### PR TITLE
scanner: surface locked-carrier signal level (dBFS) in the cockpit

### DIFF
--- a/cmd/gophertrunk/scanner_cockpit.go
+++ b/cmd/gophertrunk/scanner_cockpit.go
@@ -48,6 +48,8 @@ func (c scannerCockpit) Status() api.ScannerStatus {
 				DecodeQuality:   ss.DecodeQuality,
 				CarrierOffsetHz: ss.CarrierOffsetHz,
 				HasDecodeHealth: ss.HasDecodeHealth,
+				SignalDbFS:      ss.SignalDbFS,
+				HasSignal:       ss.HasSignal,
 			})
 		}
 	}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -217,6 +217,17 @@ func (s *Server) overlayTopology(dto *SystemDTO) {
 	if snap, ok := tp.Topology(dto.Name); ok {
 		dto.Neighbors = neighborsFromTopology(snap)
 		dto.FrequencyBands = bandPlanFromTopology(snap)
+		// TETRA has no WACN/RFSS/Site; its live identity (MCC/MNC/Location Area +
+		// colour code) rides the same topology snapshot. Surface it so the Systems
+		// panel can render a protocol-appropriate identity block instead of four
+		// forever-empty P25 fields. MCC is always present once identity is decoded.
+		if snap.MCC != 0 {
+			dto.TETRAMCC = snap.MCC
+			dto.TETRAMNC = snap.MNC
+			dto.TETRALocationArea = snap.LocationArea
+			dto.TETRADecodedColourCode = snap.ColorCode
+			dto.HasTETRAIdentity = true
+		}
 	}
 }
 

--- a/internal/api/handlers_systems_neighbors_test.go
+++ b/internal/api/handlers_systems_neighbors_test.go
@@ -92,3 +92,47 @@ func TestGetSystemNeighbors(t *testing.T) {
 		t.Fatalf("list neighbors missing: %+v", list.Systems)
 	}
 }
+
+// TestGetSystemTETRAIdentity checks that a TETRA system's decoded identity
+// (MCC/MNC/Location Area + colour code) from the live topology snapshot is
+// overlaid onto SystemDTO — the fields the Systems page renders in place of the
+// P25 WACN/SysID/RFSS/Site block, which is always empty for TETRA.
+func TestGetSystemTETRAIdentity(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+
+	snap := &trunking.TopologySnapshot{
+		SystemName:   "250_013",
+		Protocol:     "tetra",
+		MCC:          250,
+		MNC:          13,
+		LocationArea: 0,
+		ColorCode:    44,
+	}
+	prov := fakeTopoProvider{system: "250_013", snap: snap}
+	systems := []trunking.System{{Name: "250_013", Protocol: trunking.ProtocolTETRA}}
+
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, Systems: systems, Sites: prov})
+	defer teardown()
+
+	resp := mustGet(t, base+"/api/v1/systems/250_013")
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var dto SystemDTO
+	if err := json.NewDecoder(resp.Body).Decode(&dto); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !dto.HasTETRAIdentity {
+		t.Fatal("HasTETRAIdentity = false, want true")
+	}
+	if dto.TETRAMCC != 250 || dto.TETRAMNC != 13 || dto.TETRADecodedColourCode != 44 {
+		t.Fatalf("TETRA identity = MCC %d MNC %d colour %d, want 250/13/44",
+			dto.TETRAMCC, dto.TETRAMNC, dto.TETRADecodedColourCode)
+	}
+	// The P25 identity fields stay empty for a TETRA system.
+	if dto.WACN != 0 || dto.RFSS != 0 || dto.Site != 0 {
+		t.Errorf("P25 identity should be zero for TETRA: %+v", dto)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -237,6 +237,12 @@ type SystemHuntStatusDTO struct {
 	DecodeQuality   string `json:"decode_quality,omitempty"`
 	CarrierOffsetHz int32  `json:"carrier_offset_hz,omitempty"`
 	HasDecodeHealth bool   `json:"has_decode_health,omitempty"`
+	// SignalDbFS is the locked carrier's mean channel power in dBFS — the raw
+	// front-end level for antenna/LNA aiming, shown as a numeric value + bar in the
+	// cockpit. HasSignal distinguishes a real reading from no data (0 is ambiguous
+	// since a genuine level is negative). Present as soon as the CC locks.
+	SignalDbFS float64 `json:"signal_dbfs,omitempty"`
+	HasSignal  bool    `json:"has_signal,omitempty"`
 }
 
 // ConvScannerStatusDTO is the conventional FM scanner's read shape.

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -124,6 +124,19 @@ type SystemDTO struct {
 	RFSSHex     string `json:"rfss_hex,omitempty"`
 	SiteHex     string `json:"site_hex,omitempty"`
 
+	// TETRA network identity decoded live from the control channel
+	// (MLE-SYSINFO / D-NWRK-BROADCAST), overlaid from the SiteTracker topology —
+	// the TETRA analogue of WACN/SystemID/RFSS/Site. TETRA has no WACN/RFSS/Site
+	// concept, so those P25 fields stay zero for a TETRA system; the UI shows
+	// these instead. MCC+MNC form the Mobile Network Identity (MNI). Zero until
+	// the CC locks and broadcasts identity; HasTETRAIdentity distinguishes a
+	// decoded value from "not yet" (colour code / LA can legitimately be 0).
+	TETRAMCC               uint16 `json:"tetra_mcc,omitempty"`
+	TETRAMNC               uint16 `json:"tetra_mnc,omitempty"`
+	TETRALocationArea      uint16 `json:"tetra_location_area,omitempty"`
+	TETRADecodedColourCode uint8  `json:"tetra_decoded_colour_code,omitempty"`
+	HasTETRAIdentity       bool   `json:"has_tetra_identity,omitempty"`
+
 	// Per-protocol FEC opt-out surface. Empty strings indicate the
 	// new spec-correct default is active (channel coding / FEC on
 	// for every protocol). Non-empty values that parse to "off" /

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1332,12 +1332,18 @@ type TrunkingConfig struct {
 	CallTimeoutMs int `yaml:"call_timeout_ms"`
 
 	// VoiceHangtimeMs is the universal "end of transmission" window
-	// applied to EVERY voice protocol (FM, DMR, P25 Phase 1 / 2): once a
-	// call has been decoding voice, the composer ends it this long after
-	// the last decoded voice frame, instead of waiting out the much
+	// applied to EVERY voice protocol (FM, DMR, P25 Phase 1 / 2, TETRA):
+	// once a call has been decoding voice, the composer ends it this long
+	// after the last decoded voice frame, instead of waiting out the much
 	// longer CallTimeoutMs watchdog. Keeps recordings tightly bounded to
 	// the actual transmission. Defaults to 3500 (3.5 s) when zero;
 	// negative values are rejected by Validate.
+	//
+	// Note this governs when the SDR/voice chain is released, NOT the audio
+	// length. For digital protocols the recording is exactly the decoded
+	// voice frames, so raising this cannot lengthen a recording that ends
+	// early — that is a decode-completeness matter (e.g. CRC-failed tail
+	// bursts), not a hangtime one.
 	VoiceHangtimeMs int `yaml:"voice_hangtime_ms"`
 
 	// VoiceCallGrouping controls how voice recordings are split, for

--- a/internal/radio/tetra/control.go
+++ b/internal/radio/tetra/control.go
@@ -442,6 +442,58 @@ type TopologyConfig struct {
 	UplinkHz    uint32
 }
 
+// TopologySnapshot renders the decoded single-cell identity as the protocol-
+// neutral trunking.TopologySnapshot the SiteTracker stores per system, so the
+// live systems API can surface TETRA identity (MCC/MNC/Location Area + colour
+// code) the same way it surfaces P25 WACN/SysID/RFSS/Site. TETRA advertises no
+// adjacent cells, so there are no neighbours. Mirrors the offline
+// tetraPipeline.TopologySnapshot. Returns nil-safe zero when nothing is decoded.
+func (c *ControlChannel) TopologySnapshot() *trunking.TopologySnapshot {
+	t := c.Topology()
+	snap := &trunking.TopologySnapshot{
+		SystemName:   c.systemName,
+		Protocol:     "tetra",
+		MCC:          t.MCC,
+		MNC:          t.MNC,
+		LocationArea: t.LocationArea,
+		// The ETSI 6-bit colour code is the low 6 bits of the 30-bit extended
+		// colour code (MCC<<20 | MNC<<6 | CC); masking wider would drag in MNC bits.
+		ColorCode: uint8(t.ColourCode & 0x3F),
+	}
+	if t.DownlinkHz != 0 {
+		snap.PrimaryCC = &trunking.TopoChannelRef{
+			ChannelNumber: t.MainCarrier,
+			FrequencyHz:   t.DownlinkHz,
+			UplinkHz:      t.UplinkHz,
+		}
+	}
+	return snap
+}
+
+// publishSiteIdentity emits a KindSiteUpdate carrying the decoded TETRA identity
+// so the SiteTracker records it per system (topo map) and the live systems API
+// can render it. TETRA has no RFSS/Site, so those are left zero — the same shape
+// a P25 system with only a voted System ID publishes. No-op without a bus or
+// before any identity is decoded.
+func (c *ControlChannel) publishSiteIdentity() {
+	if c.bus == nil {
+		return
+	}
+	topo := c.TopologySnapshot()
+	if topo.Empty() {
+		return
+	}
+	c.bus.Publish(events.Event{
+		Kind: events.KindSiteUpdate,
+		Payload: trunking.SiteUpdate{
+			System:           c.systemName,
+			ControlChannelHz: c.freqHz,
+			Topology:         topo,
+			At:               c.now(),
+		},
+	})
+}
+
 // Topology returns the accumulated single-cell identity. Safe for concurrent
 // use (reads the lock state + colour code under the control-channel mutex).
 func (c *ControlChannel) Topology() TopologyConfig {
@@ -1064,8 +1116,8 @@ func (c *ControlChannel) LastActivityNano() int64 {
 func (c *ControlChannel) maybeLock(s LockState) {
 	c.noteActivity()
 	c.mu.Lock()
-	defer c.mu.Unlock()
 	if c.locked && c.last == s {
+		c.mu.Unlock()
 		return
 	}
 	// Preserve previously-learned MCC/MNC/LA if the new state has none.
@@ -1074,6 +1126,7 @@ func (c *ControlChannel) maybeLock(s LockState) {
 		s.MNC = c.last.MNC
 		s.LocationArea = c.last.LocationArea
 		if c.last == s {
+			c.mu.Unlock()
 			return
 		}
 	}
@@ -1083,6 +1136,13 @@ func (c *ControlChannel) maybeLock(s LockState) {
 	c.log.Info("tetra cc locked",
 		"freq", s.FrequencyHz, "mcc", s.MCC, "mnc", s.MNC,
 		"la", s.LocationArea, "system", c.systemName)
+	c.mu.Unlock()
+
+	// Surface the decoded single-cell identity (MCC/MNC/LA + colour) to the live
+	// systems API, mirroring P25's publishSiteUpdate. Published after releasing mu
+	// because TopologySnapshot takes the lock itself. Edge-triggered like the lock
+	// transition above, so a steady lock publishes once per identity change.
+	c.publishSiteIdentity()
 }
 
 // MarkLost publishes cc.lost and resets the locked flag. CheckStale calls this

--- a/internal/radio/tetra/control.go
+++ b/internal/radio/tetra/control.go
@@ -126,6 +126,17 @@ type ControlChannel struct {
 	// dropped on release. Guarded by mu.
 	callGroups map[uint16]uint32
 
+	// grantSeen deduplicates the voice grants TETRA rebroadcasts on the control
+	// channel every multiframe while a call is up. publishGrant fires one
+	// KindGrant (and a debug line) per decoded grant PDU, so a single call emitted
+	// ~3-4 grant events — the "CC spam" a field report flagged. An entry records
+	// the last-published grant content for a given (group, carrier, timeslot); an
+	// IDENTICAL re-publish within grantDedupWindow is suppressed, but a grant that
+	// carries new information (a source SSI backfilled from a reassembled fragment,
+	// an emergency flag, a changed frequency) still publishes. Entries are dropped
+	// on the call's release and pruned by age. Lazily built; guarded by mu.
+	grantSeen map[grantKey]grantSnapshot
+
 	// fragTMSDU accumulates a TM-SDU that spans a start-fragment MAC-RESOURCE and
 	// one or more following MAC-FRAG / MAC-END PDUs (§21.4.3.3/.4). fragResource
 	// is the start fragment's MAC-RESOURCE context (address + channel allocation),
@@ -675,6 +686,45 @@ func (c *ControlChannel) cellFrequencies() (downlinkHz, uplinkHz uint32, downlin
 	return uint32(dl), 0, true, false
 }
 
+// grantKey identifies a distinct voice grant for dedup: the destination group
+// (or individual) SSI plus the physical channel it was granted on. A repeat with
+// the same key inside grantDedupWindow is the same call's rebroadcast.
+type grantKey struct {
+	dst      uint32
+	carrier  uint16
+	timeslot uint8
+}
+
+// grantSnapshot is the last-published content for a grantKey. `at` times the
+// dedup window; the remaining fields are the grant payload details that can
+// legitimately change mid-call (so a re-publish carrying new info is NOT
+// suppressed as a rebroadcast). The key fields (dst/carrier/timeslot) are not
+// repeated here.
+type grantSnapshot struct {
+	at         time.Time
+	src        uint32
+	freq       uint32
+	usage      uint8
+	encrypted  bool
+	emergency  bool
+	individual bool
+}
+
+// sameContent reports whether two snapshots describe the same grant, ignoring
+// when it was published.
+func (s grantSnapshot) sameContent(o grantSnapshot) bool {
+	return s.src == o.src && s.freq == o.freq && s.usage == o.usage &&
+		s.encrypted == o.encrypted && s.emergency == o.emergency &&
+		s.individual == o.individual
+}
+
+// grantDedupWindow is how long a repeated identical voice grant is suppressed
+// after it was last published. TETRA rebroadcasts the grant roughly every
+// multiframe (~1.02 s) for the life of the call, so a few seconds collapses the
+// steady-state rebroadcasts to one event while still re-announcing a genuinely
+// new call promptly (its entry is also dropped on release).
+const grantDedupWindow = 5 * time.Second
+
 func (c *ControlChannel) publishGrant(g VoiceGrant) {
 	if c.bus == nil {
 		return
@@ -716,6 +766,35 @@ func (c *ControlChannel) publishGrant(g VoiceGrant) {
 			return
 		}
 	}
+	// Suppress the rebroadcast spam: TETRA re-announces an active call's grant
+	// every multiframe, so an IDENTICAL (group, carrier, timeslot) grant with the
+	// same content is published only once per grantDedupWindow. A re-publish that
+	// carries new info (backfilled source SSI, emergency, changed frequency) is
+	// not identical and still publishes. The entry is dropped on release
+	// (evictGrantSeen), so a genuinely new call for the same target re-announces.
+	now := c.now()
+	snap := grantSnapshot{
+		at: now, src: g.SourceSSI, freq: freq, usage: g.UsageMarker,
+		encrypted: g.Encrypted, emergency: g.Emergency, individual: g.Individual,
+	}
+	c.mu.Lock()
+	if c.grantSeen == nil {
+		c.grantSeen = make(map[grantKey]grantSnapshot)
+	}
+	key := grantKey{dst: g.DestSSI, carrier: g.CarrierNumber, timeslot: g.Timeslot}
+	if prev, seen := c.grantSeen[key]; seen && now.Sub(prev.at) < grantDedupWindow && prev.sameContent(snap) {
+		c.mu.Unlock()
+		return
+	}
+	c.grantSeen[key] = snap
+	// Opportunistic age-prune so the map can't grow unbounded on a busy site.
+	for k, s := range c.grantSeen {
+		if now.Sub(s.at) >= grantDedupWindow {
+			delete(c.grantSeen, k)
+		}
+	}
+	c.mu.Unlock()
+
 	c.bus.Publish(events.Event{
 		Kind: events.KindGrant,
 		Payload: trunking.Grant{
@@ -885,6 +964,23 @@ func (c *ControlChannel) publishRelease(gssi uint32, cause uint8) {
 	})
 	c.log.Debug("tetra: call release",
 		"system", c.systemName, "group", gssi, "cause", cause)
+	c.evictGrantSeen(gssi)
+}
+
+// evictGrantSeen drops the dedup entries for a released group so the next grant
+// addressed to it (a genuinely new call) is announced immediately rather than
+// being swallowed as a rebroadcast of the call that just ended.
+func (c *ControlChannel) evictGrantSeen(dst uint32) {
+	if dst == 0 {
+		return
+	}
+	c.mu.Lock()
+	for k := range c.grantSeen {
+		if k.dst == dst {
+			delete(c.grantSeen, k)
+		}
+	}
+	c.mu.Unlock()
 }
 
 // publishTalker emits a KindCallTalker so the engine backfills the current

--- a/internal/radio/tetra/grant_dedup_test.go
+++ b/internal/radio/tetra/grant_dedup_test.go
@@ -1,0 +1,78 @@
+package tetra
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// drainGrants collects every KindGrant currently queued on sub.
+func drainGrants(sub *events.Subscription) []trunking.Grant {
+	var grants []trunking.Grant
+	for {
+		select {
+		case ev := <-sub.C:
+			if g, ok := ev.Payload.(trunking.Grant); ok && ev.Kind == events.KindGrant {
+				grants = append(grants, g)
+			}
+		default:
+			return grants
+		}
+	}
+}
+
+// TestGrantRebroadcastDeduped pins the "CC spam" fix: TETRA re-announces an
+// active call's voice grant every multiframe, so publishGrant must emit exactly
+// one KindGrant per call within grantDedupWindow — not one per rebroadcast — and
+// must re-announce a genuinely new call for the same target after a release.
+// Before the dedup a single call produced ~3-4 grant events (field-reported 173
+// grants for 47 calls).
+func TestGrantRebroadcastDeduped(t *testing.T) {
+	bus := events.NewBus(64)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	clock := time.Unix(1_785_000_000, 0)
+	cc := New(Options{
+		Bus: bus, Log: slog.Default(), SystemName: "Sys", FrequencyHz: 467_912_500,
+		Now: func() time.Time { return clock },
+	})
+	cc.learnMainCarrier(2716)
+
+	grant := VoiceGrant{DestSSI: 1020543, CarrierNumber: 2716, Timeslot: 1}
+
+	// Four rebroadcasts ~1 s apart, all inside grantDedupWindow → one event.
+	for i := 0; i < 4; i++ {
+		cc.publishGrant(grant)
+		clock = clock.Add(1 * time.Second)
+	}
+	if g := drainGrants(sub); len(g) != 1 {
+		t.Fatalf("published %d grants for one call's rebroadcasts, want 1", len(g))
+	}
+
+	// A distinct concurrent call on another slot is NOT a duplicate.
+	cc.publishGrant(VoiceGrant{DestSSI: 1020544, CarrierNumber: 2716, Timeslot: 2})
+	if g := drainGrants(sub); len(g) != 1 {
+		t.Fatalf("distinct slot grant published %d, want 1", len(g))
+	}
+
+	// After the call is released, a new grant to the same target re-announces
+	// even though it is still within grantDedupWindow of the last rebroadcast.
+	cc.publishRelease(grant.DestSSI, 0)
+	drainGrants(sub) // discard the KindCallRelease-adjacent traffic, if any
+	cc.publishGrant(grant)
+	if g := drainGrants(sub); len(g) != 1 {
+		t.Fatalf("grant after release published %d, want 1 (release must clear the dedup)", len(g))
+	}
+
+	// Past the window (no release), the rebroadcast is announced again.
+	clock = clock.Add(grantDedupWindow + time.Second)
+	cc.publishGrant(grant)
+	if g := drainGrants(sub); len(g) != 1 {
+		t.Fatalf("grant past the dedup window published %d, want 1", len(g))
+	}
+}

--- a/internal/radio/tetra/tetra_test.go
+++ b/internal/radio/tetra/tetra_test.go
@@ -408,6 +408,7 @@ func TestControlChannelMarkLost(t *testing.T) {
 		Payload: buildSysInfoPayload(234, 1234, 5678),
 	})
 	<-sub.C // cc.locked
+	<-sub.C // site.update (decoded TETRA identity surfaced to the systems API)
 
 	cc.MarkLost()
 	select {
@@ -431,6 +432,48 @@ func TestControlChannelMarkLost(t *testing.T) {
 	}
 }
 
+// TestControlChannelPublishesSiteIdentity pins that a TETRA lock surfaces the
+// decoded single-cell identity to the systems API: after cc.locked, a
+// KindSiteUpdate carries a TopologySnapshot with the MCC/MNC/Location Area and
+// the 6-bit colour code (low 6 bits of the extended colour code). Before this
+// the TETRA identity was decoded but never reached GET /api/v1/systems, so the
+// Systems page showed only empty P25 fields.
+func TestControlChannelPublishesSiteIdentity(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "250_013", FrequencyHz: 467_912_500})
+	cc.Ingest(PDU{
+		Disc:    DiscMLE,
+		Type:    uint8(MLESystemInfo),
+		Payload: buildSysInfoPayload(250, 13, 42),
+	})
+
+	var update *trunking.SiteUpdate
+	for i := 0; i < 2; i++ { // cc.locked then site.update, in that order
+		ev := <-sub.C
+		if ev.Kind == events.KindSiteUpdate {
+			u := ev.Payload.(trunking.SiteUpdate)
+			update = &u
+		}
+	}
+	if update == nil {
+		t.Fatal("no site.update published on TETRA lock")
+	}
+	if update.System != "250_013" || update.Topology == nil {
+		t.Fatalf("site.update missing system/topology: %+v", update)
+	}
+	if update.Topology.MCC != 250 || update.Topology.MNC != 13 || update.Topology.LocationArea != 42 {
+		t.Errorf("topology identity = MCC %d MNC %d LA %d, want 250/13/42",
+			update.Topology.MCC, update.Topology.MNC, update.Topology.LocationArea)
+	}
+	if update.Topology.Protocol != "tetra" {
+		t.Errorf("topology protocol = %q, want tetra", update.Topology.Protocol)
+	}
+}
+
 func TestControlChannelNoRepublishOnSameSysInfo(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()
@@ -444,7 +487,8 @@ func TestControlChannelNoRepublishOnSameSysInfo(t *testing.T) {
 		Payload: buildSysInfoPayload(234, 1234, 5678),
 	}
 	cc.Ingest(pdu)
-	<-sub.C
+	<-sub.C // cc.locked
+	<-sub.C // site.update (decoded TETRA identity surfaced to the systems API)
 	cc.Ingest(pdu)
 	select {
 	case ev := <-sub.C:

--- a/internal/scanner/ccdecoder/decoder.go
+++ b/internal/scanner/ccdecoder/decoder.go
@@ -1020,6 +1020,33 @@ func (d *Decoder) DecodeHealth(system string) (quality string, offsetHz int32, o
 	return bucketErrorRate(rate), offsetHz, true
 }
 
+// SignalDbFS returns the last-window mean channel power in dBFS for `system`
+// when it is the pipeline this decoder is currently locked to. This is the raw
+// front-end signal level — the metric an operator aims an antenna or trims LNA
+// gain against — and is a different axis from DecodeHealth's error-rate quality
+// bucket (which needs a run of decoded frames before it means anything). The
+// value is available as soon as the CC locks and the first IQ-power window has
+// been observed, so it is reported independently of the frame-count gate.
+//
+// ok is false when `system` is not the active locked pipeline, or no IQ-power
+// window has been observed for it yet. A lightweight pull, safe for the status
+// path (mirrors DecodeHealth). The dBFS snapshot is guarded by healthMu; take
+// d.mu first then healthMu, the same order IQHealth / clearActiveLocked use.
+func (d *Decoder) SignalDbFS(system string) (dbfs float64, ok bool) {
+	d.mu.Lock()
+	active := d.active != nil && d.activeAt == system && d.locked.Load()
+	d.mu.Unlock()
+	if !active {
+		return 0, false
+	}
+	d.healthMu.Lock()
+	defer d.healthMu.Unlock()
+	if d.lastHealthSystem != system || d.lastHealthAt.IsZero() {
+		return 0, false
+	}
+	return d.lastDbfs, true
+}
+
 // sampleAutotuneLocked folds the active receiver's residual carrier offset
 // into the running average about once a second while the CC is locked, then
 // logs the suggested correction. The new average takes effect at the next

--- a/internal/scanner/ccdecoder/decoder_test.go
+++ b/internal/scanner/ccdecoder/decoder_test.go
@@ -1800,6 +1800,57 @@ func TestIQHealthPartialSamples(t *testing.T) {
 	}
 }
 
+// TestSignalDbFSReportsLockedLevel pins the cockpit signal-strength read-out:
+// once the CC is locked and a full IQ-power window has been observed for the
+// active system, SignalDbFS returns that window's mean dBFS. It must gate on
+// active+locked (a different or unlocked system reports nothing) but, unlike
+// DecodeHealth, must NOT gate on a frame-count — the level is available before
+// any decode quality is.
+func TestSignalDbFSReportsLockedLevel(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	d, err := New(Options{Bus: bus, IQ: &fakeIQSource{}, SampleRateHz: 48000})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	d.active = &recordingPipeline{}
+	setActiveSystem(d, "Sys")
+	d.locked.Store(true)
+
+	// No window observed yet → no reading.
+	if _, ok := d.SignalDbFS("Sys"); ok {
+		t.Fatal("SignalDbFS before any window ok = true, want false")
+	}
+
+	// Drive one full window of a known level (~-57 dBFS) so lastDbfs persists.
+	chunk := make([]complex64, 128)
+	for i := range chunk {
+		chunk[i] = complex(0.001, 0.001)
+	}
+	d.observeIQPower(chunk) // primes pwWindowAt
+	d.pwWindowAt = d.pwWindowAt.Add(-2 * iqPowerWindow)
+	d.observeIQPower(chunk) // window elapses → persists lastDbfs
+
+	dbfs, ok := d.SignalDbFS("Sys")
+	if !ok {
+		t.Fatal("SignalDbFS(Sys) ok = false after a window, want true")
+	}
+	if dbfs > -20 || dbfs < -90 {
+		t.Errorf("SignalDbFS = %.2f dBFS, want a plausible negative level", dbfs)
+	}
+
+	// A different system reports nothing (snapshot belongs to "Sys").
+	if _, ok := d.SignalDbFS("Other"); ok {
+		t.Error("SignalDbFS(Other) ok = true, want false")
+	}
+
+	// Unlocked → no reading even for the active system.
+	d.locked.Store(false)
+	if _, ok := d.SignalDbFS("Sys"); ok {
+		t.Error("SignalDbFS while unlocked ok = true, want false")
+	}
+}
+
 // TestForwardIQDecouplesIngestFromDecode pins the issue-#402 live-path
 // fix: the forwarder drains the SDR channel into the decode queue,
 // preserves order, drops only when the queue is full (and counts each

--- a/internal/scanner/cchunt/supervisor.go
+++ b/internal/scanner/cchunt/supervisor.go
@@ -36,6 +36,11 @@ type IQHealthProvider interface {
 // via an interface so the supervisor doesn't import the decoder.
 type CCHealthProvider interface {
 	DecodeHealth(system string) (quality string, offsetHz int32, ok bool)
+	// SignalDbFS reports the last-window mean channel power (dBFS) for a locked,
+	// active system — the raw front-end level for antenna/LNA aiming, distinct
+	// from the DecodeHealth error-rate bucket. ok is false when the system is not
+	// the active locked pipeline or no IQ-power window has been observed yet.
+	SignalDbFS(system string) (dbfs float64, ok bool)
 }
 
 // noIQDiagnosis is published when the decoder reports no observations
@@ -728,6 +733,13 @@ func (s *Supervisor) Snapshot() []SystemStatus {
 				out[i].DecodeQuality = q
 				out[i].CarrierOffsetHz = off
 				out[i].HasDecodeHealth = true
+			}
+			// Signal level is reported independently of the decode-quality gate:
+			// a freshly-locked system has a dBFS reading before enough frames
+			// have decoded to bucket its error rate.
+			if dbfs, ok := h.SignalDbFS(out[i].Name); ok {
+				out[i].SignalDbFS = dbfs
+				out[i].HasSignal = true
 			}
 		}
 	}

--- a/internal/scanner/cchunt/supervisor_test.go
+++ b/internal/scanner/cchunt/supervisor_test.go
@@ -495,9 +495,11 @@ func TestMarkFailedNoProvider(t *testing.T) {
 // fakeHealth is a CCHealthProvider (and IQHealthProvider) test double so the
 // snapshot-enrichment path can be exercised without a real decoder.
 type fakeHealth struct {
-	quality string
-	offset  int32
-	ok      bool
+	quality  string
+	offset   int32
+	ok       bool
+	dbfs     float64
+	signalOK bool
 }
 
 func (f fakeHealth) IQHealth(string) (trunking.HuntDiagnostics, bool) {
@@ -505,6 +507,9 @@ func (f fakeHealth) IQHealth(string) (trunking.HuntDiagnostics, bool) {
 }
 func (f fakeHealth) DecodeHealth(string) (string, int32, bool) {
 	return f.quality, f.offset, f.ok
+}
+func (f fakeHealth) SignalDbFS(string) (float64, bool) {
+	return f.dbfs, f.signalOK
 }
 
 // TestSupervisorSnapshotCarriesDecodeHealth pins the live signal-quality wiring:
@@ -530,8 +535,8 @@ func TestSupervisorSnapshotCarriesDecodeHealth(t *testing.T) {
 		t.Fatalf("expected one system with no decode health, got %+v", snap)
 	}
 
-	// A provider reporting quality must surface it on the snapshot.
-	sup.SetIQHealthProvider(fakeHealth{quality: "marginal", offset: -958, ok: true})
+	// A provider reporting quality + signal must surface both on the snapshot.
+	sup.SetIQHealthProvider(fakeHealth{quality: "marginal", offset: -958, ok: true, dbfs: -42.3, signalOK: true})
 	snap := sup.Snapshot()
 	if len(snap) != 1 {
 		t.Fatalf("systems = %d, want 1", len(snap))
@@ -539,10 +544,25 @@ func TestSupervisorSnapshotCarriesDecodeHealth(t *testing.T) {
 	if !snap[0].HasDecodeHealth || snap[0].DecodeQuality != "marginal" || snap[0].CarrierOffsetHz != -958 {
 		t.Fatalf("decode health not surfaced: %+v", snap[0])
 	}
+	if !snap[0].HasSignal || snap[0].SignalDbFS != -42.3 {
+		t.Fatalf("signal level not surfaced: %+v", snap[0])
+	}
 
-	// A provider reporting nothing (ok=false) leaves the fields clear.
-	sup.SetIQHealthProvider(fakeHealth{ok: false})
-	if snap := sup.Snapshot(); snap[0].HasDecodeHealth {
+	// Signal level is reported independently of the decode-quality gate: a
+	// freshly-locked system reads a dBFS level before enough frames decode to
+	// bucket its error rate (DecodeHealth ok=false).
+	sup.SetIQHealthProvider(fakeHealth{ok: false, dbfs: -55.0, signalOK: true})
+	snap = sup.Snapshot()
+	if snap[0].HasDecodeHealth {
 		t.Fatalf("ok=false must leave decode health clear, got %+v", snap[0])
+	}
+	if !snap[0].HasSignal || snap[0].SignalDbFS != -55.0 {
+		t.Fatalf("signal level must surface even without decode quality: %+v", snap[0])
+	}
+
+	// A provider reporting no signal leaves the signal fields clear.
+	sup.SetIQHealthProvider(fakeHealth{ok: false, signalOK: false})
+	if snap := sup.Snapshot(); snap[0].HasSignal {
+		t.Fatalf("signalOK=false must leave signal level clear, got %+v", snap[0])
 	}
 }

--- a/internal/scanner/cchunt/types.go
+++ b/internal/scanner/cchunt/types.go
@@ -68,4 +68,11 @@ type SystemStatus struct {
 	DecodeQuality   string `json:"decode_quality,omitempty"`
 	CarrierOffsetHz int32  `json:"carrier_offset_hz,omitempty"`
 	HasDecodeHealth bool   `json:"has_decode_health,omitempty"`
+	// SignalDbFS is the last-window mean channel power (dBFS) of the locked
+	// carrier — the raw front-end level an operator aims an antenna / trims LNA
+	// gain against, a different axis from DecodeQuality. HasSignal distinguishes a
+	// real reading from "no data" (a genuine level is always negative dBFS, so 0
+	// alone is ambiguous). Present as soon as the CC locks, before DecodeQuality.
+	SignalDbFS float64 `json:"signal_dbfs,omitempty"`
+	HasSignal  bool    `json:"has_signal,omitempty"`
 }

--- a/internal/voice/composer/boundary.go
+++ b/internal/voice/composer/boundary.go
@@ -13,14 +13,17 @@ import (
 )
 
 // boundaryTracker is the protocol-agnostic recording-boundary controller
-// shared by every voice chain (FM, DMR, P25 Phase 1 / 2). It centralises
-// the universal call-boundary behaviour so hangtime + split/conversation
-// grouping work identically across protocols:
+// shared by every voice chain (FM, DMR, P25 Phase 1 / 2, TETRA). It
+// centralises the universal call-boundary behaviour so hangtime +
+// split/conversation grouping work identically across protocols:
 //
 //   - Hangtime end-of-call: once voice has been decoding, the call is
 //     ended VoiceHangtime after the last decoded voice frame, instead of
 //     waiting out the engine's much longer call-timeout watchdog. This
-//     keeps recordings tightly bounded to the actual transmission.
+//     keeps recordings tightly bounded to the actual transmission. It
+//     controls teardown timing only — for digital protocols the audio is
+//     exactly the decoded voice frames, so hangtime never extends a
+//     recording's length.
 //   - Talkgroup gating (digital protocols that decode an in-band TG):
 //     audio whose talkgroup differs from the granted talkgroup is not
 //     written, and a sustained foreign talkgroup ends the call — fixing

--- a/internal/voice/composer/tetra_voice.go
+++ b/internal/voice/composer/tetra_voice.go
@@ -101,11 +101,25 @@ func (c *Composer) runTETRAVoiceChain(ctx context.Context, serial string, iqCh <
 			"other_call_bursts", offSlot.Load())
 	}()
 
+	process := func(iq []complex64) {
+		bt.observe(iq)
+		rx.Process(fe.Process(nil, iq))
+	}
 	touchTicker := time.NewTicker(c.touchEvery)
 	defer touchTicker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
+			// The call is being torn down (usually a control-channel D-RELEASE,
+			// which cancels immediately and bypasses the voice hangtime). Drain
+			// whatever IQ is already buffered in iqCh before returning, so the tail
+			// of the transmission — the last speech bursts that arrived just before
+			// the release — is still demodulated and recorded instead of dropped
+			// mid-flight. The recorder is finalized only after this goroutine
+			// returns (handleEnd's <-ch.done), so these late frames still land in
+			// the .raw. Mirrors the same-carrier owner worker's cancel drain
+			// (tetraOwnerWorker).
+			drainTETRAIQ(iqCh, process)
 			return
 		case <-touchTicker.C:
 			// Touch + hangtime end-of-call are driven by the boundary tracker.
@@ -113,8 +127,26 @@ func (c *Composer) runTETRAVoiceChain(ctx context.Context, serial string, iqCh <
 			if !ok {
 				return
 			}
-			bt.observe(iq)
-			rx.Process(fe.Process(nil, iq))
+			process(iq)
+		}
+	}
+}
+
+// drainTETRAIQ consumes whatever IQ is already buffered in ch (non-blocking) and
+// feeds each chunk to process. It returns as soon as the buffer is empty or the
+// channel is closed — it never waits for more IQ. Used on call teardown to
+// recover the tail of a transmission still queued when the chain is cancelled,
+// rather than dropping it (the "recordings end a beat early" report).
+func drainTETRAIQ(ch <-chan []complex64, process func([]complex64)) {
+	for {
+		select {
+		case iq, ok := <-ch:
+			if !ok {
+				return
+			}
+			process(iq)
+		default:
+			return
 		}
 	}
 }

--- a/internal/voice/composer/tetra_voice_offload_test.go
+++ b/internal/voice/composer/tetra_voice_offload_test.go
@@ -65,6 +65,49 @@ func TestTETRASlotOwnerEnqueueCopiesSlices(t *testing.T) {
 	}
 }
 
+// TestDrainTETRAIQProcessesBufferedTail pins the solo voice chain's teardown
+// drain: when a call is cancelled (typically a control-channel D-RELEASE, which
+// bypasses the voice hangtime), the IQ still buffered in the chain's channel must
+// be demodulated before the chain exits, not dropped. Dropping it truncated the
+// tail of the transmission — the "recordings end a beat early" report. Fail-first:
+// before the fix runTETRAVoiceChain returned immediately on ctx.Done with no
+// drain, so this buffered tail was lost.
+func TestDrainTETRAIQProcessesBufferedTail(t *testing.T) {
+	ch := make(chan []complex64, 8)
+	const n = 5
+	for i := 0; i < n; i++ {
+		ch <- []complex64{complex(float32(i), 0)}
+	}
+
+	var got []float32
+	done := make(chan struct{})
+	go func() {
+		drainTETRAIQ(ch, func(iq []complex64) { got = append(got, real(iq[0])) })
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("drainTETRAIQ blocked instead of returning once the buffer emptied")
+	}
+
+	if len(got) != n {
+		t.Fatalf("drained %d buffered chunks, want %d (tail dropped)", len(got), n)
+	}
+	for i := 0; i < n; i++ {
+		if got[i] != float32(i) {
+			t.Fatalf("drain reordered chunks: got %v", got)
+		}
+	}
+
+	// A closed channel makes drain return immediately (chain teardown when the
+	// carrier IQ stream ends).
+	closed := make(chan []complex64)
+	close(closed)
+	drainTETRAIQ(closed, func([]complex64) { t.Fatal("processed from a closed empty channel") })
+}
+
 // TestTETRAOwnerWorkerDrainsAndExits confirms the worker consumes its backlog and
 // exits promptly on ctx cancel (call end). Garbage frames decode to no speech, so
 // the worker loop is exercised without needing a real TCH/S bitstream or sink.

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -419,6 +419,12 @@ export interface SystemHuntStatusDTO {
   decode_quality?: string;
   carrier_offset_hz?: number;
   has_decode_health?: boolean;
+  // Locked carrier's mean channel power in dBFS — the raw front-end level for
+  // antenna/LNA aiming, a different axis from decode_quality. has_signal
+  // distinguishes a real reading from "no data" (0 is ambiguous since a genuine
+  // level is negative). Present as soon as the CC locks.
+  signal_dbfs?: number;
+  has_signal?: boolean;
 }
 
 export interface ConvScannerStatusDTO {

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -27,6 +27,15 @@ export interface SystemDTO {
   system_id?: number;
   rfss?: number;
   site?: number;
+  // TETRA network identity decoded live from the control channel (MLE-SYSINFO /
+  // D-NWRK-BROADCAST). TETRA has no WACN/RFSS/Site, so the P25 fields above stay
+  // zero and the UI shows these instead. MCC+MNC form the Mobile Network Identity
+  // (MNI). has_tetra_identity distinguishes decoded from "not yet".
+  tetra_mcc?: number;
+  tetra_mnc?: number;
+  tetra_location_area?: number;
+  tetra_decoded_colour_code?: number;
+  has_tetra_identity?: boolean;
   // Active DMR Tier III LCN→frequency band plan (configured or learned),
   // surfaced so the Systems panel can show how voice grants resolve. (#638)
   dmr_band_plan?: DMRBandPlanDTO;

--- a/web/src/panels/Scanner.tsx
+++ b/web/src/panels/Scanner.tsx
@@ -193,6 +193,9 @@ function Hunt({
                     offsetHz={sys.carrier_offset_hz}
                   />
                 )}
+                {sys.has_signal && sys.signal_dbfs != null && (
+                  <SignalLevelBar dbfs={sys.signal_dbfs} />
+                )}
                 {sys.locked_freq_hz != null && (
                   <span className="font-mono text-xs text-muted">
                     lock {formatHz(sys.locked_freq_hz)}
@@ -555,6 +558,44 @@ function SignalQualityChip({
   return (
     <span title={`control-channel signal: ${quality}${offset}`}>
       <Badge tone={tone}>signal: {quality}</Badge>
+    </span>
+  );
+}
+
+// SignalLevelBar renders the locked carrier's raw front-end level (mean channel
+// power in dBFS) as a numeric read-out plus a small level bar, so an operator can
+// aim an antenna or trim LNA gain against a live number instead of just the
+// clean/marginal/poor pill. This is signal STRENGTH, not decode quality — a strong
+// bar with a red quality chip means "plenty of signal, but something else (offset,
+// overload, wrong colour code) is hurting the decode".
+//
+// The bar maps the useful SDR range −90…−20 dBFS to 0…100%. Colour is by level:
+// green ≥ −45 dBFS, amber −45…−60, red below −60.
+function SignalLevelBar({ dbfs }: { dbfs: number }) {
+  const floorDb = -90;
+  const ceilDb = -20;
+  const pct = Math.max(
+    0,
+    Math.min(100, ((dbfs - floorDb) / (ceilDb - floorDb)) * 100),
+  );
+  const color = dbfs >= -45 ? "#34d399" : dbfs >= -60 ? "#fbbf24" : "#f87171";
+  return (
+    <span
+      className="inline-flex items-center gap-1.5"
+      title={`signal level ${dbfs.toFixed(1)} dBFS (mean channel power) — aim antenna / trim LNA gain to maximise`}
+    >
+      <span
+        className="inline-block h-1.5 w-12 rounded-full bg-panel overflow-hidden"
+        aria-hidden
+      >
+        <span
+          className="block h-full rounded-full"
+          style={{ width: `${pct}%`, backgroundColor: color }}
+        />
+      </span>
+      <span className="font-mono text-xs text-muted">
+        {dbfs.toFixed(1)} dBFS
+      </span>
     </span>
   );
 }

--- a/web/src/panels/Systems.tsx
+++ b/web/src/panels/Systems.tsx
@@ -255,6 +255,49 @@ export function Systems() {
           />
           {(() => {
             const hunt = scanner?.systems?.find((h) => h.name === selected.name);
+            // TETRA has no WACN/RFSS/Site; it identifies a cell by MNI (MCC/MNC),
+            // Location Area, and colour code, all decoded from MLE-SYSINFO. Render
+            // those instead of the P25 fields, which would sit empty forever.
+            if (selected.protocol === "tetra") {
+              const tHint =
+                hunt?.state === "hunting"
+                  ? "Hunting control channel"
+                  : "Awaiting SYSINFO broadcast";
+              const has = selected.has_tetra_identity ?? false;
+              return (
+                <div>
+                  <p className="text-xs uppercase tracking-wider text-muted mb-2">
+                    Network identity (decoded live)
+                  </p>
+                  <div className="grid grid-cols-2 gap-3">
+                    <DetailField
+                      label="MNI (MCC / MNC)"
+                      mono
+                      value={
+                        has
+                          ? `${selected.tetra_mcc ?? 0} / ${selected.tetra_mnc ?? 0}`
+                          : null
+                      }
+                      emptyHint={tHint}
+                    />
+                    <DetailField
+                      label="Location area"
+                      mono
+                      value={has ? String(selected.tetra_location_area ?? 0) : null}
+                      emptyHint={tHint}
+                    />
+                    <DetailField
+                      label="Colour code"
+                      mono
+                      value={
+                        has ? String(selected.tetra_decoded_colour_code ?? 0) : null
+                      }
+                      emptyHint={tHint}
+                    />
+                  </div>
+                </div>
+              );
+            }
             const hint = identityEmptyHint(hunt);
             return (
               <div>


### PR DESCRIPTION
The Scanner cockpit only showed a 3-state clean/marginal/poor quality
pill, which measures the control channel's frame-error rate — not how
much signal is actually reaching the front end. Operators aiming an
antenna or trimming LNA gain had no live number to optimise against
(field-reported on a TETRA system).

The mean channel power in dBFS is already computed every second by the
IQ-power observer and persisted for the cchunt failure diagnosis; it was
just never exposed on the live status path. Add SignalDbFS() to the
decoder (gated on active+locked, but independent of the decode-quality
frame-count gate so a freshly-locked system reads a level immediately),
widen CCHealthProvider, and thread the value through SystemStatus →
SystemHuntStatusDTO → the web types. The cockpit renders it as a compact
colour-coded level bar plus the numeric dBFS next to the quality pill.

This is signal strength, a different axis from decode quality: a strong
bar with a red quality chip means "plenty of signal, but something else
(offset, overload, wrong colour code) is hurting the decode". Works for
every trunked protocol, not just TETRA.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Runhxw6f6AG6vBeibvrdxn