### PR TITLE
TETRA: DC-spike voice fix, wideband multi-system support, hardware pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **TETRA on the wideband multi-system path.** A `role: wideband` SDR can now
+  follow multiple TETRA control channels alongside DMR/P25, so several TETRA
+  sites/systems share one dongle. The blocker was never the protocol allowlist —
+  the DDC/channelizer banks emitted one bank-global 48 kHz per-tap rate, while
+  TETRA's 18000-baud π/4-DQPSK needs 144 kHz; `tuner.DDCBank` now supports per-tap
+  output rates (`AddTapAtRate`), and the wideband engine gives each tap its
+  protocol's rate and forces the per-tap DDC strategy when TETRA is present (the
+  polyphase channelizer can't emit 144 kHz). The wideband path multiplexes
+  control channels; TETRA voice grants still follow on a `role: voice` SDR.
+- **Live signal level (dBFS) in the Scanner cockpit.** The locked carrier's mean
+  channel power is surfaced per system as a numeric read-out + bar, so an operator
+  can aim an antenna / trim LNA gain against a live number instead of only the
+  clean/marginal/poor quality pill.
+- **TETRA network identity on the Systems page.** A TETRA system's decoded MCC/MNC
+  (MNI), Location Area and colour code are now surfaced in place of the P25
+  WACN/RFSS/Site fields, which have no TETRA analogue.
 - **Push grant webhook (`broadcast.grant_webhook`).** A new outbound sink POSTs
   one JSON object per control-channel grant the moment GopherTrunk decodes it —
   the push counterpart to the pollable `GET /api/v1/grants` and the live
@@ -262,6 +278,23 @@ for tagged releases.
   rather than a fixed slot 1 — the building block for issue #925.
 
 ### Fixed
+- **DC spur leaked into TETRA voice under heavy multislot traffic.** Same-carrier
+  TETRA voice rides the control carrier at 0 Hz offset, so the zero-IF front end's
+  DC spur (worsened by ADC-clipping/IMD as concurrent-call power rises) sat on the
+  wanted signal and biased the π/4-DQPSK differential decode; nothing in the voice
+  path removed it. A first-order complex DC-block high-pass is now applied on the
+  TETRA voice receivers (safe because π/4-DQPSK has a spectral null at DC), leaving
+  the control-channel path untouched.
+- **TETRA recordings ended a beat early.** On the solo voice path a control-channel
+  D-RELEASE cancelled the chain immediately and dropped IQ still buffered in its
+  channel; that in-flight tail is now drained before teardown. (Raising
+  `voice_hangtime_ms` does not help — hangtime governs SDR release, not digital
+  audio length.)
+- **TETRA control-channel grant spam.** TETRA re-announces an active call's grant
+  every multiframe; each was published as a separate `KindGrant` event (~3.7 per
+  call). Identical grants are now de-duplicated per `(group, carrier, timeslot)`
+  within a short window, while an enriched re-grant (backfilled source, emergency)
+  still publishes.
 - **TETRA wakeup / notification grants spawned ghost recordings named after a
   radio ID.** On a group call the SwMI sends a source-less notification (an
   Energy-Economy wakeup page, `SourceID==0`, addressed to the calling party's radio

--- a/docs/_data/reference.yml
+++ b/docs/_data/reference.yml
@@ -676,12 +676,14 @@ domains:
           - { slug: nesdr, title: Nooelec NESDR, type: hardware }
           - { slug: hackrf, title: HackRF One, type: hardware }
           - { slug: airspy, title: Airspy, type: hardware }
+          - { slug: hydrasdr, title: HydraSDR RFOne, type: hardware }
           - { slug: airspy-hf-plus, title: Airspy HF+, type: hardware }
           - { slug: sdrplay-rsp1a, title: SDRplay RSP1A, type: hardware }
           - { slug: sdrplay-rspdx, title: SDRplay RSPdx, type: hardware }
           - { slug: sdrplay-rspduo, title: SDRplay RSPduo, type: hardware }
           - { slug: limesdr, title: LimeSDR, type: hardware }
           - { slug: usrp-ettus, title: USRP (Ettus), type: hardware }
+          - { slug: usrp-b210, title: USRP B210, type: hardware }
           - { slug: plutosdr, title: ADALM-Pluto (PlutoSDR), type: hardware }
           - { slug: bladerf, title: BladeRF, type: hardware }
           - { slug: krakensdr, title: KrakenSDR, type: hardware }
@@ -725,6 +727,7 @@ domains:
           - { slug: duplexer, title: Duplexer, type: hardware }
           - { slug: diplexer, title: Diplexer, type: hardware }
           - { slug: rf-filter, title: RF filter, type: hardware }
+          - { slug: fm-broadcast-filter, title: FM broadcast notch filter, type: hardware }
           - { slug: saw-filter, title: SAW filter, type: hardware }
           - { slug: cavity-filter, title: Cavity filter, type: hardware }
           - { slug: helical-filter, title: Helical filter, type: hardware }

--- a/docs/best-police-scanners.md
+++ b/docs/best-police-scanners.md
@@ -30,8 +30,10 @@ four facts decide everything below.
 
 <div class="tldr" markdown="1">
 <span class="tldr__label">Key takeaways</span>
-**Best overall (digital/simulcast):** [Uniden SDS100](/reference/uniden-sds100/)
-(handheld) / [SDS200](/reference/uniden-sds200/) (base). **Best for beginners:**
+**Best RF (digital/simulcast):** [Uniden SDS150](/reference/uniden-sds150/) — the newest
+True I/Q handheld, best-in-class on P25 Phase II simulcast. **Best value simulcast:**
+[SDS100](/reference/uniden-sds100/) (handheld) / [SDS200](/reference/uniden-sds200/)
+(base) — same True I/Q engine for less. **Best for beginners:**
 [Uniden BCD436HP](/reference/uniden-bcd436hp/) — ZIP-code programming. **Best
 value digital:** [BCD996P2](/reference/uniden-bcd996p2/). **Best budget/analog:**
 [BC125AT](/reference/uniden-bc125at/) (~$110). **Free alternative:** a $30
@@ -43,10 +45,18 @@ here decodes [encryption](/police-scanner-encryption/).**
 
 <div class="pick-cards" markdown="0">
 <div class="pick-card pick-card--top">
-<span class="pick-card__badge">Best overall</span>
+<span class="pick-card__badge">Best RF (newest)</span>
+<h3>Uniden SDS150</h3>
+<p class="pick-card__price">around $800</p>
+<p>Uniden's newest True I/Q handheld — the best RF on P25 Phase II simulcast, superseding the SDS100, with a color touchscreen and built-in GPS.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0FXNFPB4C?tag=gophertrunk-20" rel="nofollow sponsored noopener">SDS150 on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/uniden-sds150/">SDS150 details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Best value simulcast</span>
 <h3>Uniden SDS100 / SDS200</h3>
 <p class="pick-card__price">around $650</p>
-<p>True I/Q decode beats every other scanner on P25 Phase II simulcast. SDS100 is the handheld; SDS200 is base/mobile.</p>
+<p>The same True I/Q simulcast engine as the SDS150 for less. SDS100 is the handheld; SDS200 is base/mobile.</p>
 <a class="btn btn--buy" href="https://www.amazon.com/dp/B07DK26FDN?tag=gophertrunk-20" rel="nofollow sponsored noopener">SDS100 on Amazon &rarr;</a>
 <p class="pick-card__note"><a href="/reference/uniden-sds100/">SDS100 details</a> · <a href="/reference/uniden-sds200/">SDS200 details</a></p>
 </div>
@@ -82,7 +92,7 @@ here decodes [encryption](/police-scanner-encryption/).**
 |---|---|---|---|---|---|
 | [Uniden SDS100](/reference/uniden-sds100/) | Handheld | P25 P1/P2, DMR, NXDN | **True I/Q (best)** | ZIP / DB | ~$650 |
 | [Uniden SDS200](/reference/uniden-sds200/) | Base/mobile | P25 P1/P2, DMR, NXDN | **True I/Q (best)** | ZIP / DB | ~$650 |
-| [Uniden SDS150](/reference/uniden-sds150/) | Handheld | P25 P1/P2, DMR, NXDN | True I/Q | ZIP / DB | ~$800 |
+| [Uniden SDS150](/reference/uniden-sds150/) | Handheld | P25 P1/P2, DMR, NXDN | **True I/Q (best)** | ZIP / DB | ~$800 |
 | [Uniden BCD536HP](/reference/uniden-bcd536hp/) | Base/mobile | P25 P1/P2 | Fair | **ZIP** / Wi-Fi | ~$550 |
 | [Uniden BCD436HP](/reference/uniden-bcd436hp/) | Handheld | P25 P1/P2 | Fair | **ZIP** | ~$520 |
 | [Uniden BCD996P2](/reference/uniden-bcd996p2/) | Base/mobile | P25 P1/P2 | Fair | Manual / SW | ~$470 |

--- a/docs/guide-advanced.md
+++ b/docs/guide-advanced.md
@@ -76,13 +76,15 @@ depends on the path:
 - **One control channel per SDR (classic path).** Each `system` in your config is
   followed by its own control receiver, so following *N* systems — or *N* sites of
   the same network, since each site is added as its own `system` with its own
-  control-channel frequency — needs *N* SDRs with `role: control`. This is the path
-  **TETRA** uses today: **multiple TETRA sites on a single SDR is not yet
-  supported**, even when they fall inside one dongle's bandwidth.
+  control-channel frequency — needs *N* SDRs with `role: control`.
 - **Many systems on one wideband SDR.** A `role: wideband` device can follow
-  several carriers (control channels and their voice grants) at once from a single
-  dongle, as long as they all fit in its IQ band. This wideband multi-system path
-  currently covers **DMR (Tier II/III) and P25 (Phase 1/2)** — not TETRA.
+  several carriers at once from a single dongle, as long as they all fit in its IQ
+  band. This wideband multi-system path covers **DMR (Tier II/III)**, **P25 (Phase
+  1/2)**, and **TETRA** control channels — so multiple TETRA sites/systems can now
+  share one wideband SDR. Note the boundary: the wideband path multiplexes
+  **control channels**; a TETRA channel is channelized to its own 144 kHz tap
+  (DMR/P25 use 48 kHz), and TETRA **voice** grants still follow on a `role: voice`
+  SDR (or its own control SDR's same-carrier voice), not on a wideband voice tap.
 
 Either way, when the same call is heard on several networked or simulcast sites,
 **cross-site call deduplication** saves it once instead of once per site: enable

--- a/docs/reference/airspy.md
+++ b/docs/reference/airspy.md
@@ -70,7 +70,8 @@ give it its edge:
 
 The R2 delivers up to about **10 MS/s** of complex [bandwidth](/reference/bandwidth/);
 the smaller **Mini** tops out around 6 MS/s.[^airspy] Both are **receive-only** — there
-is no transmit path.
+is no transmit path. The [HydraSDR RFOne](/reference/hydrasdr/) is an independent successor
+to the R2 built on the same 12-bit R820T2 architecture.
 
 ## Variants
 
@@ -113,7 +114,9 @@ the others sit at the noise floor, the cause is RF, not the DDC:
   into clipping, raising the noise floor and burying weaker sites. Gain is in
   **tenths of a dB** — `gain: 600` means 60 dB, very high for a wideband capture.
   If `gophertrunk_sdr_wideband_input_clip_ratio` is non-zero (a throttled WARN
-  also fires), **lower the gain or add attenuation** — do not raise it.
+  also fires), **lower the gain or add attenuation** — do not raise it. In a metro
+  area the usual culprit is broadcast FM; an [FM broadcast notch
+  filter](/reference/fm-broadcast-filter/) inline is often the cheapest fix.
 - **A genuinely weak/distant site** may not survive a capture optimised for a
   stronger one. Give it a dedicated dongle if it matters.
 

--- a/docs/reference/fm-broadcast-filter.md
+++ b/docs/reference/fm-broadcast-filter.md
@@ -1,0 +1,100 @@
+---
+slug: fm-broadcast-filter
+title: FM broadcast notch filter
+entry_type: hardware
+category: rf-front-end
+description: "An FM broadcast notch (band-stop) filter rejects the strong 88–108 MHz broadcast band before it reaches an SDR's front end, stopping the overload and raised noise floor that broadcast FM causes on direct-sampling and DDC receivers."
+keywords: FM notch filter, FM band stop filter, broadcast FM filter, 88-108 MHz filter, FM trap, SDR front end overload, RTL-SDR FM filter, noise floor, intermodulation, DDC SDR filter
+aka: [FM notch filter, FM band-stop filter, FM trap, broadcast FM filter]
+autolink: true
+affiliate: true
+product:
+  name: "RTL-SDR Blog Broadcast FM Block Filter (88–108 MHz)"
+  brand: RTL-SDR Blog
+  category: RF band-stop filter
+  price: "24.95"
+  url: https://www.amazon.com/dp/B01LE9LRPM?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: Band-stop (notch) filter }
+  - { label: Stop band, value: "~88–108 MHz (broadcast FM)" }
+  - { label: Attenuation, value: ">50 dB in band" }
+  - { label: Insertion loss, value: "<0.5 dB out of band" }
+  - { label: Connectors, value: "SMA (typical)" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B01LE9LRPM?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [rf-filter, low-noise-amplifier, attenuator, bias-tee, dynamic-range, rtl-sdr, airspy, software-defined-radio]
+related_lessons:
+  - { title: "SDR hardware — RTL-SDR, HackRF, Airspy", url: /learn/rf-sdr/sdr-hardware/ }
+cite_urls:
+  - https://www.rtl-sdr.com/
+  - https://en.wikipedia.org/wiki/Band-stop_filter
+---
+
+An **FM broadcast notch filter** is a [band-stop filter](/reference/rf-filter/) that
+rejects the **88–108 MHz** broadcast-FM band before it reaches a receiver's front end.
+On [software-defined radios](/reference/software-defined-radio/) — especially cheap
+direct-sampling dongles and wideband DDC receivers — the local broadcast-FM transmitters
+are often the strongest signals at the antenna by tens of dB, and left unfiltered they
+push the front end into overload.[^rtlsdr]
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Every DDC / direct-sampling SDR wants one.** Broadcast FM (88–108 MHz) is usually the
+loudest thing at your antenna; unfiltered it **overloads the front end**, raising the
+[noise floor](/reference/dynamic-range/) and generating
+[intermodulation](/reference/intermodulation/) products across the band you actually
+want. A ~$25 band-stop filter drops broadcast FM by >50 dB with <0.5 dB loss elsewhere —
+often the single cheapest way to lower your noise floor.
+</div>
+
+## Overview
+
+A wideband receiver shares one [ADC](/reference/analog-to-digital-converter/) and one
+front-end gain stage across everything in its capture. Its
+[dynamic range](/reference/dynamic-range/) is finite, so the **strongest** signal present
+sets the gain the whole capture must live within. In most populated areas that strongest
+signal is broadcast FM. When it drives the front end near clipping, two things happen:
+the [noise floor](/reference/dynamic-range/) rises (burying weak signals like a distant
+[control channel](/reference/control-channel/)), and non-linear mixing produces
+[intermodulation](/reference/intermodulation/) products — phantom carriers — elsewhere in
+the spectrum.
+
+Because broadcast FM sits in a fixed, well-defined band, a **band-stop filter** tuned to
+88–108 MHz removes the offender while leaving the VHF/UHF public-safety and business bands
+essentially untouched. This is distinct from a [broadcast-FM band-pass](/reference/rf-filter/)
+(which keeps only FM) — a notch keeps everything *except* FM.
+
+## How it works
+
+The filter is a passive LC (or SAW) network with a deep rejection null across ~88–108 MHz
+and low [insertion loss](/reference/rf-filter/) on either side. Typical numbers for the
+common SDR-oriented parts: **>50 dB** of stop-band attenuation, **<0.5 dB** insertion loss
+outside the notch, on SMA connectors. Good designs keep the adjacent VHF airband
+(108–137 MHz) minimally affected. Install it inline between the antenna (or the
+[LNA](/reference/low-noise-amplifier/)) and the SDR; being passive and bidirectional, it
+needs no power.
+
+## Relevance to SDR
+
+GopherTrunk decodes weak [P25](/reference/project-25/), [DMR](/reference/dmr/) and
+[TETRA](/reference/tetra/) [control channels](/reference/control-channel/) that a raised
+noise floor can bury, and the wideband `role: wideband` path is *especially* sensitive
+because one overloaded capture starves every tap on it — the same front-end-overload
+failure the [Airspy](/reference/airspy/) wideband notes describe (`clip_ratio` non-zero,
+weak sites at the noise floor). If a wideband dongle shows clipping or a stubbornly high
+noise floor in a metro area, an FM notch filter is usually the first and cheapest fix,
+ahead of adding an [attenuator](/reference/attenuator/) or lowering gain.
+
+## Where to buy
+
+Common, inexpensive options on Amazon: the
+**[RTL-SDR Blog Broadcast FM Block Filter](https://www.amazon.com/dp/B01LE9LRPM?tag=gophertrunk-20)**
+(~$25, >50 dB rejection) and the
+**[Nooelec Flamingo+ FM](https://www.amazon.com/dp/B07XKY8YKB?tag=gophertrunk-20)** (higher
+rejection, low airband impact). Equivalent notch filters are also widely sold on eBay and
+AliExpress.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B01LE9LRPM?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+## Sources
+
+[^rtlsdr]: [RTL-SDR.com](https://www.rtl-sdr.com/) — background on broadcast-FM overload of SDR front ends and the use of 88–108 MHz band-stop filters to lower the noise floor and suppress intermodulation on direct-sampling and DDC receivers.

--- a/docs/reference/hydrasdr.md
+++ b/docs/reference/hydrasdr.md
@@ -1,0 +1,105 @@
+---
+slug: hydrasdr
+title: HydraSDR RFOne
+entry_type: hardware
+category: sdr-devices
+description: "The HydraSDR RFOne is a high-performance VHF/UHF software-defined radio receiver — a successor to the Airspy R2 with a 12-bit ADC, up to 10 MS/s, and a clean front end, designed in France and made in the USA."
+keywords: HydraSDR, HydraSDR RFOne, RFOne, Airspy R2 successor, high performance SDR, VHF UHF receiver, 12-bit ADC, R820T2, 10 MSPS, wideband capture, best SDR USA
+aka: [HydraSDR, RFOne]
+autolink: true
+infobox:
+  - { label: Type, value: VHF/UHF SDR receiver }
+  - { label: Vendor/Chip, value: "HydraSDR (Benjamin Vernoux); R820T2 tuner + LPC4370" }
+  - { label: Models, value: HydraSDR RFOne }
+  - { label: ADC, value: 12-bit }
+  - { label: Range, value: ~24 MHz – 1.8 GHz }
+  - { label: Bandwidth, value: up to ~10 MHz }
+  - { label: TX, value: No (receive only) }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.digikey.com/en/products/detail/benjamin-vernoux/HYDRASDR-RFONE/26256067\" rel=\"nofollow noopener\">Buy at DigiKey &rarr;</a>" }
+see_also: [airspy, airspy-hf-plus, rtl-sdr, r820t-tuner, sdrplay-rspdx, dynamic-range, software-defined-radio]
+related_lessons:
+  - { title: "SDR hardware — RTL-SDR, HackRF, Airspy", url: /learn/rf-sdr/sdr-hardware/ }
+related_reading:
+  - { title: "RF Front End, Part 10: Airspy — real to complex", url: /blog/deep-dives/rf-front-end-10-airspy-real-to-complex/ }
+cite_urls:
+  - https://hydrasdr.com/
+  - https://en.wikipedia.org/wiki/Software-defined_radio
+---
+
+**HydraSDR RFOne** is a high-performance VHF/UHF
+[software-defined radio](/reference/software-defined-radio/) receiver in the lineage of
+the [Airspy R2](/reference/airspy/) — same 12-bit oversampling architecture and
+[R820T2](/reference/r820t-tuner/) front end, carried forward as an independent open
+project. It samples up to ~10 MHz of spectrum anywhere from ~24 MHz to 1.8 GHz.[^hydra]
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 110" role="img" aria-label="A frequency coverage bar for HydraSDR RFOne (~24 MHz–1.8 GHz) on an axis from about 0 to 6 gigahertz." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="70" x2="430" y2="70" stroke="currentColor" stroke-opacity="0.4"/>
+  <g font-size="8" fill="currentColor" text-anchor="middle"><text x="30" y="86">0</text><text x="163" y="86">2 GHz</text><text x="296" y="86">4 GHz</text><text x="430" y="86">6 GHz</text></g>
+  <rect x="32" y="40" width="120" height="20" rx="3" fill="currentColor" fill-opacity="0.25" stroke="currentColor" stroke-width="1.3"/>
+  <text x="230" y="28" text-anchor="middle" font-size="10" fill="currentColor">HydraSDR RFOne (~24 MHz–1.8 GHz) coverage</text>
+</svg>
+<figcaption>HydraSDR RFOne covers the VHF/UHF bands scanners use, at Airspy-class resolution.</figcaption>
+</figure>
+
+## Overview
+
+The RFOne is aimed squarely at the niche the [Airspy R2](/reference/airspy/) created: a
+receiver with the sensitivity, [dynamic range](/reference/dynamic-range/), and capture
+[bandwidth](/reference/bandwidth/) an [RTL-SDR](/reference/rtl-sdr/) can't reach, in the
+bands public-safety and business radio actually use. It is designed in France by
+Benjamin Vernoux and manufactured in the USA, which — with the recent rise in RTL-SDR
+dongle prices — makes it one of the better value high-performance receivers on the US
+market.[^hydra]
+
+## How it works
+
+Like the Airspy R2, the RFOne pairs a Rafael Micro [R820T2](/reference/r820t-tuner/)
+tuner with a **12-bit** [ADC](/reference/analog-to-digital-converter/) driven by an NXP
+LPC4370, replacing the [RTL2832U](/reference/rtl2832u/)'s 8-bit ADC and USB bridge. Two
+design choices give it its edge over a dongle:
+
+- **More bits.** A 12-bit ADC carries roughly **72 dB** of theoretical
+  [dynamic range](/reference/dynamic-range/) against the RTL2832U's ~48 dB — the
+  headroom that lets a weak signal survive next to a strong one without the front end
+  clipping.
+- **Oversampling and real-to-complex conversion.** The receiver samples the IF at a high
+  real rate and digitally converts it to complex baseband on the way out, decimating to
+  the requested rate. Averaging many high-rate samples into each output adds effective
+  bits (process gain), so the delivered stream is quieter than the raw ADC alone.
+
+It delivers up to about **10 MS/s** of complex [bandwidth](/reference/bandwidth/) and is
+**receive-only** — there is no transmit path.
+
+## Variants
+
+- **HydraSDR RFOne** — the single current model: ~24 MHz–1.8 GHz, up to ~10 MS/s, 12-bit,
+  with a clock reference and a [bias tee](/reference/bias-tee/) for powering an inline
+  [LNA](/reference/low-noise-amplifier/).
+
+Compared with the [Airspy R2](/reference/airspy/) it is architecturally very close — a
+practical alternative in the same slot. Against an [SDRplay RSPdx](/reference/sdrplay-rspdx/)
+it trades the RSPdx's 14-bit ADC and HF coverage for the R820T2 path's simplicity and a
+pure-USB streaming model. As with any 12-bit direct-sampling receiver, put a
+[broadcast-FM notch filter](/reference/fm-broadcast-filter/) in front of it in a strong
+signal environment to keep the front end out of overload.
+
+## Relevance to SDR
+
+GopherTrunk drives the HydraSDR over USB for demanding reception where an RTL-SDR's
+bandwidth or sensitivity falls short — a congested band, a distant control channel, or a
+multi-site system whose control channels are spread too far apart to fit one RTL-SDR
+capture. The extra ADC bits and wider capture are exactly what a wideband, multi-tap
+channelizer wants, so like the Airspy it is a strong choice for the `role: wideband` use.
+It remains a receiver only, so it decodes clear and scrambled traffic, never keyed
+encryption.
+
+## Where to buy
+
+The RFOne is sold through **[DigiKey](https://www.digikey.com/en/products/detail/benjamin-vernoux/HYDRASDR-RFONE/26256067)**
+(~US$189) and listed on the manufacturer's site at
+**[hydrasdr.com](https://hydrasdr.com/)** — it is not currently carried on Amazon.
+
+## Sources
+
+[^hydra]: [HydraSDR](https://hydrasdr.com/) — manufacturer site, on the RFOne's R820T2 + 12-bit oversampling architecture, ~24 MHz–1.8 GHz range, up-to-10 MS/s capture, and France-designed / USA-made origin.

--- a/docs/reference/sdrplay-rspdx.md
+++ b/docs/reference/sdrplay-rspdx.md
@@ -3,9 +3,9 @@ slug: sdrplay-rspdx
 title: SDRplay RSPdx
 entry_type: hardware
 category: sdr-devices
-description: SDRplay RSPdx is a 14-bit, 1 kHz–2 GHz receive-only SDR with extensive preselection, three antenna ports, and an HDR mode for high-dynamic-range LF/MW/HF reception.
-keywords: SDRplay RSPdx, RSPdx, HDR mode, high dynamic range SDR, 14-bit receiver, three antenna ports, wideband receiver, SoapySDR
-aka: [RSPdx, SDRplay RSPdx]
+description: SDRplay RSPdx (and the current RSPdx-R2 revision) is a 14-bit, 1 kHz–2 GHz receive-only SDR with extensive preselection, three antenna ports, and an HDR mode for high-dynamic-range LF/MW/HF reception.
+keywords: SDRplay RSPdx, RSPdx-R2, RSPdx R2, HDR mode, high dynamic range SDR, 14-bit receiver, three antenna ports, wideband receiver, SoapySDR
+aka: [RSPdx, RSPdx-R2, SDRplay RSPdx, SDRplay RSPdx-R2]
 autolink: true
 infobox:
   - { label: Type, value: Receive-only SDR }
@@ -14,8 +14,11 @@ infobox:
   - { label: Range, value: 1 kHz – 2 GHz }
   - { label: Bandwidth, value: up to ~10 MHz }
   - { label: TX, value: No }
+  - { label: Current model, value: "RSPdx-R2 (2023 refresh)" }
   - { label: Typical price, value: ~US$250 }
-see_also: [sdrplay-rsp1a, software-defined-radio, soapysdr, rf-filter, dynamic-range]
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B0821NMGVP?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [sdrplay-rsp1a, sdrplay-rspduo, software-defined-radio, soapysdr, rf-filter, dynamic-range]
+affiliate: true
 cite_urls:
   - https://en.wikipedia.org/wiki/Software-defined_radio
   - https://www.sdrplay.com/rspdx/
@@ -65,9 +68,11 @@ receiver with the fuller filter bank switched in as you tune.
 
 ## Variants
 
-The RSPdx anchors the high end of the single-tuner RSP family; the closely related
-**RSPdx-R2** is a hardware refresh with the same interface and feature set. It contrasts
-with:
+The **RSPdx-R2** is the current-production revision (2023) and the one you will buy new
+today — it supersedes the original RSPdx with a refreshed front end and an upgraded
+processor for improved performance, while keeping the same three antenna ports, 14-bit
+converter, HDR mode, interface, and software. Treat "RSPdx" and "RSPdx-R2" as the same
+device for GopherTrunk purposes; prefer the R2 when buying. The line contrasts with:
 
 - **[RSP1A](/reference/sdrplay-rsp1a/)** — the entry model: one antenna port, fewer filters,
   no HDR mode.

--- a/docs/reference/usrp-b210.md
+++ b/docs/reference/usrp-b210.md
@@ -1,0 +1,100 @@
+---
+slug: usrp-b210
+title: USRP B210 (and AD9361 clones)
+entry_type: hardware
+category: sdr-devices
+description: "The Ettus USRP B210 is a wideband AD9361-based SDR transceiver covering 70 MHz–6 GHz with up to 56 MHz of instantaneous bandwidth and 2x2 MIMO; low-cost functional clones of the same design are widely sold and behave nearly identically."
+keywords: USRP B210, Ettus B210, AD9361 SDR, B210 clone, wideband transceiver, 70 MHz 6 GHz, 56 MHz bandwidth, 2x2 MIMO, UHD, best value wideband SDR, TX RX SDR
+aka: [USRP B210, B210, AD9361 SDR]
+autolink: true
+infobox:
+  - { label: Type, value: Wideband SDR transceiver (RX + TX) }
+  - { label: Vendor/Chip, value: "Ettus (NI); Analog Devices AD9361 + Xilinx Spartan-6" }
+  - { label: Range, value: "70 MHz – 6 GHz" }
+  - { label: Bandwidth, value: "up to 56 MHz (30.72 MS/s stable over USB 3.0)" }
+  - { label: ADC, value: "12-bit" }
+  - { label: MIMO, value: "2x2 (two coherent RX + TX)" }
+  - { label: TX, value: "Yes (full-duplex)" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://opensourcesdrlab.com/products/b210-ad9361\" rel=\"nofollow noopener\">Buy a B210 clone &rarr;</a>" }
+see_also: [usrp-ettus, limesdr, plutosdr, bladerf, hackrf, dynamic-range, software-defined-radio]
+related_lessons:
+  - { title: "SDR hardware — RTL-SDR, HackRF, Airspy", url: /learn/rf-sdr/sdr-hardware/ }
+cite_urls:
+  - https://www.ettus.com/all-products/ub210-kit/
+  - https://en.wikipedia.org/wiki/Universal_Software_Radio_Peripheral
+---
+
+The **USRP B210** is a wideband [SDR](/reference/software-defined-radio/) transceiver from
+[Ettus Research](/reference/usrp-ettus/) built around the Analog Devices **AD9361** RFIC.
+It covers **70 MHz – 6 GHz** continuous, with up to **56 MHz** of instantaneous
+[bandwidth](/reference/bandwidth/), two coherent receive and two transmit channels (2x2
+MIMO), and full-duplex TX/RX over USB 3.0.[^ettus] Because the AD9361 does most of the
+work, functionally-identical **low-cost clones** of the same reference design are widely
+sold — and for receive-only monitoring they behave essentially the same as the original.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 110" role="img" aria-label="A frequency coverage bar for USRP B210 (70 MHz–6 GHz) on an axis from about 0 to 6 gigahertz." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="70" x2="430" y2="70" stroke="currentColor" stroke-opacity="0.4"/>
+  <g font-size="8" fill="currentColor" text-anchor="middle"><text x="30" y="86">0</text><text x="163" y="86">2 GHz</text><text x="296" y="86">4 GHz</text><text x="430" y="86">6 GHz</text></g>
+  <rect x="35" y="40" width="391" height="20" rx="3" fill="currentColor" fill-opacity="0.25" stroke="currentColor" stroke-width="1.3"/>
+  <text x="230" y="28" text-anchor="middle" font-size="10" fill="currentColor">USRP B210 (70 MHz–6 GHz) coverage</text>
+</svg>
+<figcaption>The B210's AD9361 front end spans 70 MHz–6 GHz with wide instantaneous bandwidth.</figcaption>
+</figure>
+
+## Overview
+
+Where an [Airspy](/reference/airspy/) or [HydraSDR](/reference/hydrasdr/) is a tuned
+receive dongle, the B210 is a full **transceiver**: two RX and two TX chains, wide
+capture, and the [UHD](/reference/usrp-ettus/) driver stack. For a scanning workload its
+draw is the **wide instantaneous bandwidth** — comfortably enough to hold an entire
+trunked system's control and voice channels inside one capture — and the coherent second
+receiver, useful for direction finding or diversity. The trade-off versus a purpose-built
+receive dongle is cost, power, and a heavier software stack.
+
+## How it works
+
+The AD9361 is a complete 2x2 zero-IF transceiver on a chip: programmable synthesizers,
+mixers, baseband filters, and 12-bit converters, all tuned by the host. A Xilinx Spartan-6
+FPGA packetizes the streams to the host over USB 3.0. The sustained rate over USB tops out
+around **30.72 MS/s** (≈56 MHz with the AD9361's filters), well beyond what a single
+trunked system needs. Being zero-IF, it carries the usual DC-offset and I/Q-imbalance
+behaviour of that architecture — GopherTrunk's DDC keeps the wanted channel off the DC
+spike, and a [broadcast-FM notch filter](/reference/fm-broadcast-filter/) still pays off
+in a strong-signal metro.
+
+## Variants and clones
+
+- **Ettus USRP B210** — the original (NI/Ettus), the reference against which the clones are
+  measured; the **B200** is the single-channel sibling.
+- **AD9361 "B210" clones** — several vendors sell boards built to the B210 reference design
+  (e.g. via [opensourcesdrlab](https://opensourcesdrlab.com/products/b210-ad9361)). In
+  practice they are a strong value: for receive monitoring the difference from an original
+  is negligible, at a fraction of the price. Firmware/UHD compatibility varies by vendor —
+  confirm the seller supports the current UHD before buying.
+
+Against a [LimeSDR](/reference/limesdr/) or [BladeRF](/reference/bladerf/) the B210 is the
+most mature of the AD9361/wideband-transceiver class in software support (UHD is
+ubiquitous); against an [ADALM-Pluto](/reference/plutosdr/) it adds a second coherent
+channel and much wider bandwidth.
+
+## Relevance to SDR
+
+GopherTrunk drives USRP hardware through UHD (see [USRP (Ettus)](/reference/usrp-ettus/)).
+The B210's wide capture suits following a whole trunked system — or several control
+channels — on one device via the `role: wideband` path, and its receive quality is well
+above a dongle's. As always it is a receiver for monitoring here: it decodes clear and
+scrambled traffic, never keyed encryption, and its transmit capability is irrelevant to
+scanning.
+
+## Where to buy
+
+The original is sold by **[Ettus/NI](https://www.ettus.com/all-products/ub210-kit/)**
+(around $1,500). Functionally-equivalent AD9361 clones are far cheaper and widely
+available — e.g.
+**[opensourcesdrlab B210 (AD9361)](https://opensourcesdrlab.com/products/b210-ad9361)** —
+and on eBay/AliExpress. Confirm current UHD support with the seller.
+
+## Sources
+
+[^ettus]: [Ettus USRP B210](https://www.ettus.com/all-products/ub210-kit/) — Ettus Research (NI), on the B210's AD9361 front end, 70 MHz–6 GHz range, up to 56 MHz bandwidth, 2x2 MIMO and USB 3.0 streaming.

--- a/docs/reference/usrp-ettus.md
+++ b/docs/reference/usrp-ettus.md
@@ -68,8 +68,9 @@ well. That common driver — not any one board — is the real ecosystem.
 
 ## Variants
 
-- **B200 / B210** — bus-powered USB 3.0, single (B200) or dual (B210) channel, AD9361-class
-  front end; the affordable research entry.
+- **[B200 / B210](/reference/usrp-b210/)** — bus-powered USB 3.0, single (B200) or dual
+  (B210) channel, AD9361-class front end; the affordable research entry, and the model with
+  widely-sold low-cost clones.
 - **N-series (N200/N210, N3xx)** — Ethernet-connected, daughterboard or integrated front
   ends, suited to fixed installations and multi-unit synchronisation.
 - **X-series (X300/X310, X4xx)** — the widest bandwidth and highest channel counts, 10 GbE

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2750,13 +2750,15 @@ func validateWidebandDevice(idx int, d DeviceConfig, sampleRateHz uint32, system
 			// Tier II conventional / Tier I direct-mode — channel freq is a
 			// repeater or simplex carrier, no relationship to
 			// system.ControlChannels required.
-		case "dmr", "p25", "p25-phase2", "p25_phase2", "p25p2":
+		case "dmr", "p25", "p25-phase2", "p25_phase2", "p25p2", "tetra":
 			// Trunked control-channel protocols — the wideband channel
 			// MUST be one of the system's declared control channels.
-			// Tier III DMR's CSBK chain, P25 Phase 1's TSBK chain, and
-			// P25 Phase 2's H-DQPSK MAC chain all run on a frequency
-			// the system advertises in control_channels; voice grants
-			// hop elsewhere.
+			// Tier III DMR's CSBK chain, P25 Phase 1's TSBK chain, P25
+			// Phase 2's H-DQPSK MAC chain, and TETRA's MAC/CMCE chain all
+			// run on a frequency the system advertises in control_channels;
+			// voice grants hop elsewhere (TETRA voice follows on a
+			// role: voice SDR — the wideband path multiplexes control
+			// channels, not the 144 kHz TETRA voice slots).
 			matched := false
 			for _, cc := range sys.ControlChannels {
 				if cc == ch.FrequencyHz {
@@ -2774,7 +2776,8 @@ func validateWidebandDevice(idx int, d DeviceConfig, sampleRateHz uint32, system
 			return fmt.Errorf(
 				"sdr.devices[%d].channels[%d]: system %q has protocol %q; wideband currently supports "+
 					"dmr-tier2 (Tier II conventional), dmr (Tier III trunked control channel), "+
-					"p25 (Phase 1 trunked control channel), and p25-phase2 (Phase 2 trunked control channel)",
+					"p25 (Phase 1 trunked control channel), p25-phase2 (Phase 2 trunked control channel), "+
+					"and tetra (trunked control channel)",
 				idx, j, ch.System, sys.Protocol)
 		}
 		offset := float64(ch.FrequencyHz) - float64(d.CenterFreqHz)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -167,6 +167,43 @@ func TestValidate(t *testing.T) {
 				{Name: "regional-t3", Protocol: "dmr", ControlChannels: []uint32{453_775_000}},
 			}},
 		}, false},
+		{"wideband TETRA ok", Config{
+			SDR: SDRConfig{SampleRate: 2_400_000, Devices: []DeviceConfig{{
+				Serial: "00000010", Role: "wideband", CenterFreqHz: 467_900_000,
+				Channels: []DeviceChannelConfig{
+					{FrequencyHz: 467_912_500, System: "tetra-net"},
+				},
+			}}},
+			Trunking: TrunkingConfig{Systems: []SystemConfig{{
+				Name: "tetra-net", Protocol: "tetra",
+				ControlChannels: []uint32{467_912_500},
+			}}},
+		}, false},
+		{"wideband mixed T3 + TETRA", Config{
+			SDR: SDRConfig{SampleRate: 2_400_000, Devices: []DeviceConfig{{
+				Serial: "00000010", Role: "wideband", CenterFreqHz: 460_000_000,
+				Channels: []DeviceChannelConfig{
+					{FrequencyHz: 459_775_000, System: "regional-t3"},
+					{FrequencyHz: 460_212_500, System: "tetra-net"},
+				},
+			}}},
+			Trunking: TrunkingConfig{Systems: []SystemConfig{
+				{Name: "regional-t3", Protocol: "dmr", ControlChannels: []uint32{459_775_000}},
+				{Name: "tetra-net", Protocol: "tetra", ControlChannels: []uint32{460_212_500}},
+			}},
+		}, false},
+		{"wideband TETRA channel not in CC list", Config{
+			SDR: SDRConfig{SampleRate: 2_400_000, Devices: []DeviceConfig{{
+				Serial: "00000010", Role: "wideband", CenterFreqHz: 467_900_000,
+				Channels: []DeviceChannelConfig{
+					{FrequencyHz: 467_800_000, System: "tetra-net"},
+				},
+			}}},
+			Trunking: TrunkingConfig{Systems: []SystemConfig{{
+				Name: "tetra-net", Protocol: "tetra",
+				ControlChannels: []uint32{467_912_500}, // doesn't include 467_800_000
+			}}},
+		}, true},
 		{"wideband missing serial", Config{
 			SDR: SDRConfig{SampleRate: 2_400_000, Devices: []DeviceConfig{{
 				Role: "wideband", CenterFreqHz: 453_500_000,

--- a/internal/configbuilder/fieldmeta.go
+++ b/internal/configbuilder/fieldmeta.go
@@ -156,7 +156,7 @@ var fieldMetas = map[string]FieldMeta{
 	"Ka9qRadioConfig.ConnectTimeoutMs": {Help: "mDNS resolution / status-poll timeout in ms. 0 = driver default (3000)."},
 
 	// ---- Trunking ----------------------------------------------------------
-	"TrunkingConfig.Systems":           {Help: "Trunked radio networks to follow. Add by hand, by RadioReference browse, or by PDF/CSV import. Each system (and each site of a network) needs its own control-channel SDR; the wideband path can share one SDR across DMR/P25 systems, but not TETRA. Cross-site duplicates are collapsed by recordings.dedup."},
+	"TrunkingConfig.Systems":           {Help: "Trunked radio networks to follow. Add by hand, by RadioReference browse, or by PDF/CSV import. Each system (and each site of a network) needs its own control-channel SDR; the wideband path can share one SDR across DMR/P25/TETRA control channels (TETRA voice still follows on a role: voice SDR). Cross-site duplicates are collapsed by recordings.dedup."},
 	"TrunkingConfig.CallTimeoutMs":     {Help: "Inactivity window before the watchdog ends a call and frees its voice SDR. 0 = 30 s."},
 	"TrunkingConfig.VoiceHangtimeMs":   {Help: "End-of-transmission window for every voice protocol — ends a call this long after the last voice frame. 0 = 3.5 s."},
 	"TrunkingConfig.VoiceCallGrouping": {Help: "How recordings split: transmission (one file per over) or conversation (group same-TG overs). Empty = transmission.", Options: opts("", "(default: transmission)", "transmission", "transmission", "conversation", "conversation")},

--- a/internal/dsp/tuner/ddc.go
+++ b/internal/dsp/tuner/ddc.go
@@ -78,6 +78,7 @@ type DDCBank struct {
 
 type ddcTap struct {
 	offsetHz  float64
+	actualOut float64 // this tap's emitted rate (may differ per tap; see AddTapAtRate)
 	nco       *nco
 	resampler *dsp.Resampler
 	outBuf    []complex64
@@ -155,24 +156,44 @@ func buildSharedDecimator(inRateHz, minRedRateHz float64) (redRateHz float64, pr
 	return red, dsp.NewResampler(1, d, tapsPerBranch, ddcKaiserBeta)
 }
 
-// AddTap registers a new tap at the given offset.
+// AddTap registers a new tap at the given offset, emitting the bank's default
+// output rate (OutputRateHz).
 func (b *DDCBank) AddTap(offsetHz float64, sink SinkFunc) error {
+	_, err := b.AddTapAtRate(offsetHz, b.outRateHz, sink)
+	return err
+}
+
+// AddTapAtRate registers a tap that emits its OWN output rate, independent of the
+// bank default and of other taps. This lets one bank host, e.g., 48 kHz DMR/P25
+// taps alongside a 144 kHz TETRA tap out of the same wideband capture: each tap
+// owns an independent polyphase resampler from the shared reduced-rate stream, so
+// mixed per-tap rates cost nothing extra. Returns the tap's actual emitted rate,
+// which may differ from outRateHz by a fraction of a percent when the exact ratio
+// exceeds the resampler caps (issue #550) — build that tap's symbol clock from the
+// returned value. The offset gate is unchanged (the shared reduced band is common
+// to all taps).
+func (b *DDCBank) AddTapAtRate(offsetHz, outRateHz float64, sink SinkFunc) (actualHz float64, err error) {
 	if !b.offsetInBand(offsetHz) {
-		return ErrOffsetOutOfBand
+		return 0, ErrOffsetOutOfBand
 	}
-	l, m := rationalRatio(b.outRateHz, b.redRateHz)
+	if outRateHz <= 0 {
+		outRateHz = b.outRateHz
+	}
+	l, m := rationalRatio(outRateHz, b.redRateHz)
 	tapsPerBranch := (ddcStopbandTaps*m + l - 1) / l
 	if tapsPerBranch < ddcMinTapsPerBranch {
 		tapsPerBranch = ddcMinTapsPerBranch
 	}
+	actual := b.redRateHz * float64(l) / float64(m)
 	tap := &ddcTap{
 		offsetHz:  offsetHz,
+		actualOut: actual,
 		nco:       newNCO(offsetHz, b.redRateHz),
 		resampler: dsp.NewResampler(l, m, tapsPerBranch, ddcKaiserBeta),
 		sink:      sink,
 	}
 	b.taps = append(b.taps, tap)
-	return nil
+	return actual, nil
 }
 
 // offsetInBand tests the offset against the usable band AFTER the shared
@@ -237,6 +258,19 @@ func (b *DDCBank) InputRateHz() float64 { return b.inRateHz }
 // ratio exceeds the resampler caps (issue #550); consumers should build their
 // symbol clocks from this value, not the nominal target.
 func (b *DDCBank) OutputRateHz() float64 { return b.actualOutHz }
+
+// ActualRateFor returns the rate a tap requesting outRateHz would actually emit,
+// without adding a tap. Lets a caller size a receiver's symbol clock before it
+// wires the tap's sink (AddTapAtRate needs that sink). outRateHz <= 0 selects the
+// bank default. Uses the same rational-ratio computation as AddTapAtRate, so the
+// two agree.
+func (b *DDCBank) ActualRateFor(outRateHz float64) float64 {
+	if outRateHz <= 0 {
+		outRateHz = b.outRateHz
+	}
+	l, m := rationalRatio(outRateHz, b.redRateHz)
+	return b.redRateHz * float64(l) / float64(m)
+}
 
 // Reset clears the shared decimator plus every tap's NCO and resampler state.
 func (b *DDCBank) Reset() {

--- a/internal/dsp/tuner/ddc_test.go
+++ b/internal/dsp/tuner/ddc_test.go
@@ -470,3 +470,46 @@ func BenchmarkDDCBankProcess10MHz4Taps(b *testing.B) {
 		bank.Process(chunk)
 	}
 }
+
+// TestDDCBankPerTapRates pins the mixed-rate support that lets one wideband SDR
+// host a 144 kHz TETRA tap alongside 48 kHz DMR/P25 taps: two taps on one bank,
+// each requesting its own rate via AddTapAtRate, emit at that rate independently.
+func TestDDCBankPerTapRates(t *testing.T) {
+	const inRate = 2_400_000.0
+	b := NewDDCBank(inRate, 48_000.0, 0.05) // bank default 48 kHz
+
+	// ActualRateFor is exact for these integer ratios.
+	if got := b.ActualRateFor(48_000); math.Abs(got-48_000) > 1 {
+		t.Fatalf("ActualRateFor(48k) = %.1f, want 48000", got)
+	}
+	if got := b.ActualRateFor(144_000); math.Abs(got-144_000) > 1 {
+		t.Fatalf("ActualRateFor(144k) = %.1f, want 144000", got)
+	}
+
+	var got48, got144 int
+	if a, err := b.AddTapAtRate(-150_000, 48_000, func(out []complex64) { got48 += len(out) }); err != nil || math.Abs(a-48_000) > 1 {
+		t.Fatalf("AddTapAtRate(48k) = %.1f, %v", a, err)
+	}
+	if a, err := b.AddTapAtRate(+320_000, 144_000, func(out []complex64) { got144 += len(out) }); err != nil || math.Abs(a-144_000) > 1 {
+		t.Fatalf("AddTapAtRate(144k) = %.1f, %v", a, err)
+	}
+
+	const inSamples = 4096 * 32
+	gen := newToneGen(inRate, 0.2, -150_000, +320_000)
+	for produced := 0; produced < inSamples; produced += 4096 {
+		b.Process(gen.Next(4096))
+	}
+
+	// Each tap emits ~ inSamples * rate/inRate; the 144 kHz tap emits ~3x the 48 kHz tap.
+	want48 := float64(inSamples) * 48_000 / inRate
+	want144 := float64(inSamples) * 144_000 / inRate
+	if d := math.Abs(float64(got48)-want48) / want48; d > 0.05 {
+		t.Errorf("48 kHz tap emitted %d samples, want ~%.0f (%.0f%% off)", got48, want48, d*100)
+	}
+	if d := math.Abs(float64(got144)-want144) / want144; d > 0.05 {
+		t.Errorf("144 kHz tap emitted %d samples, want ~%.0f (%.0f%% off)", got144, want144, d*100)
+	}
+	if ratio := float64(got144) / float64(got48); math.Abs(ratio-3) > 0.15 {
+		t.Errorf("144k/48k sample ratio = %.2f, want ~3", ratio)
+	}
+}

--- a/internal/radio/tetra/receiver/dcblock.go
+++ b/internal/radio/tetra/receiver/dcblock.go
@@ -1,0 +1,61 @@
+package receiver
+
+// dcBlock is a first-order complex DC-removal high-pass applied to the IQ
+// stream at the top of Process, ahead of the channel/matched filters.
+//
+// The R820T2 (and other zero-IF front ends) leave a static DC spur at 0 Hz —
+// LO self-mixing plus, under heavy load, rectified ADC-clipping/IMD content.
+// On a TETRA Single-Carrier Base Station the voice slots ride the SAME carrier
+// as the control channel, tapped at 0 Hz offset, so that spur sits directly on
+// the wanted signal. A constant additive DC term shifts the π/4-DQPSK
+// constellation centroid, which carrierAFC (a frequency corrector) and the CMA
+// equalizer (a modulus corrector) both leave in place, biasing every
+// differential decision — the "DC spikes leaking into voice under heavy
+// multislot" report.
+//
+// Blocking DC is safe for TETRA specifically because π/4-DQPSK is a linear
+// modulation with a spectral null at the exact carrier (0 Hz here): no
+// information lives in the DC bin, unlike the C4FM/FM control channel that the
+// shared ccdecoder DDC deliberately leaves untouched (ddc.go). Hence this is a
+// TETRA-receiver opt-in, never applied to the control-channel path.
+//
+// Difference equation, applied independently to I and Q (pole at z ≈ dcBlockPole):
+//
+//	y[n] = x[n] − x[n−1] + dcBlockPole·y[n−1]
+//
+// Mirrors internal/voice/mbe/dcblock.go (the IMBE/AMBE audio-PCM blocker) in
+// form, adapted to complex64 IQ. The state is continuous across chunks; Reset
+// clears it on receiver re-sync alongside the other stages.
+type dcBlock struct {
+	prevX complex64
+	prevY complex64
+}
+
+// dcBlockPole is the feedback coefficient. 0.999 puts the −3 dB corner near
+// ~23 Hz at 144 kHz (fc ≈ (1−a)/(2π)·Fs) — deep enough to kill the DC pedestal,
+// far below the π/4-DQPSK modulation so the passband is untouched.
+const dcBlockPole = 0.999
+
+// Reset clears the filter memory.
+func (d *dcBlock) Reset() {
+	d.prevX = 0
+	d.prevY = 0
+}
+
+// process applies the DC blocker over src, writing to dst (grown/reused by the
+// caller's convention) and returning it. dst may alias src.
+func (d *dcBlock) process(dst, src []complex64) []complex64 {
+	if cap(dst) < len(src) {
+		dst = make([]complex64, len(src))
+	} else {
+		dst = dst[:len(src)]
+	}
+	prevX, prevY := d.prevX, d.prevY
+	for i, x := range src {
+		y := x - prevX + dcBlockPole*prevY
+		prevX, prevY = x, y
+		dst[i] = y
+	}
+	d.prevX, d.prevY = prevX, prevY
+	return dst
+}

--- a/internal/radio/tetra/receiver/dcblock_test.go
+++ b/internal/radio/tetra/receiver/dcblock_test.go
@@ -1,0 +1,83 @@
+package receiver
+
+import (
+	"math"
+	"math/cmplx"
+	"testing"
+)
+
+// TestDCBlockRemovesOffsetPreservesTone pins the DC-spike fix: the complex DC
+// blocker drives a constant additive DC offset to ~0 while passing a modulated
+// (zero-mean) tone essentially untouched. Without the blocker the DC pedestal
+// survives and biases the π/4-DQPSK differential decode — the "DC leaks into
+// voice under heavy multislot" report.
+func TestDCBlockRemovesOffsetPreservesTone(t *testing.T) {
+	const (
+		fs   = 144000.0
+		tone = 6000.0 // well inside the passband, away from DC
+		dc   = complex(0.30, -0.20)
+		n    = 1 << 15
+	)
+	// Build: a complex tone (zero mean over many cycles) plus a constant DC term.
+	sig := make([]complex64, n)
+	clean := make([]complex64, n)
+	for i := 0; i < n; i++ {
+		s := cmplx.Exp(complex(0, 2*math.Pi*tone*float64(i)/fs))
+		clean[i] = complex64(s)
+		sig[i] = complex64(s) + dc
+	}
+
+	// Baseline (no block): the mean stays at the DC offset — the bug.
+	var rawMean complex128
+	for _, x := range sig {
+		rawMean += complex128(x)
+	}
+	rawMean /= complex(float64(n), 0)
+	if cmplx.Abs(rawMean-complex128(dc)) > 1e-3 {
+		t.Fatalf("precondition: input mean %.4f, want ~the DC offset %.4f", rawMean, dc)
+	}
+
+	d := &dcBlock{}
+	out := d.process(nil, sig)
+
+	// After the blocker: the steady-state mean (skip the filter's startup
+	// transient) is ~0 — the DC pedestal is gone.
+	const skip = 4096
+	var mean complex128
+	for _, x := range out[skip:] {
+		mean += complex128(x)
+	}
+	mean /= complex(float64(n-skip), 0)
+	if got := cmplx.Abs(mean); got > 5e-3 {
+		t.Errorf("DC not removed: residual mean |%.5f| = %.5f, want < 0.005", mean, got)
+	}
+
+	// The tone amplitude is preserved (a ~23 Hz-corner high-pass barely touches a
+	// 6 kHz tone). Compare steady-state RMS of output vs the clean tone.
+	rms := func(v []complex64) float64 {
+		var s float64
+		for _, x := range v {
+			s += float64(real(x)*real(x) + imag(x)*imag(x))
+		}
+		return math.Sqrt(s / float64(len(v)))
+	}
+	gotRMS := rms(out[skip:])
+	wantRMS := rms(clean[skip:])
+	if math.Abs(gotRMS-wantRMS)/wantRMS > 0.02 {
+		t.Errorf("tone amplitude altered: RMS %.4f vs clean %.4f (>2%%)", gotRMS, wantRMS)
+	}
+}
+
+// TestDCBlockResetClearsState confirms Reset zeroes the filter memory so a
+// re-synced stream starts clean.
+func TestDCBlockResetClearsState(t *testing.T) {
+	d := &dcBlock{}
+	d.process(nil, []complex64{complex(1, 1), complex(1, 1), complex(1, 1)})
+	if d.prevX == 0 && d.prevY == 0 {
+		t.Fatal("precondition: filter state should be non-zero after processing")
+	}
+	d.Reset()
+	if d.prevX != 0 || d.prevY != 0 {
+		t.Errorf("Reset left state: prevX=%v prevY=%v", d.prevX, d.prevY)
+	}
+}

--- a/internal/radio/tetra/receiver/receiver.go
+++ b/internal/radio/tetra/receiver/receiver.go
@@ -128,6 +128,14 @@ type Options struct {
 	// LLRs are Im and Re of the differential). Emitted just before the
 	// matching DibitSink call. nil ⇒ no soft emission, zero overhead.
 	SoftSink func(diffs []complex64, baseIdx int)
+	// EnableDCBlock inserts a first-order complex DC-removal high-pass at the
+	// very top of Process, ahead of the channel filter, to strip the front-end
+	// DC spur that sits on a same-carrier TETRA voice channel (0 Hz offset) and
+	// biases the π/4-DQPSK differential decode under heavy multislot load. Safe
+	// for TETRA because π/4-DQPSK has a spectral null at DC; off by default and
+	// intended for the VOICE receivers only — never the control-channel path,
+	// which must not disturb steady-state CC decode. See dcblock.go.
+	EnableDCBlock bool
 	// EnableEqualizer inserts a blind CMA adaptive equalizer between symbol-
 	// timing recovery and the differential decoder. It inverts the linear
 	// channel (multipath / ISI / band-edge group delay) that smears the
@@ -201,6 +209,8 @@ type Receiver struct {
 	softSink  func(diffs []complex64, baseIdx int)
 	eq        *equalizer.SnapshotCMA
 	equalized []complex64
+	dcBlk     *dcBlock
+	dcBuf     []complex64
 
 	matched   []complex64
 	filtered  []complex64
@@ -246,6 +256,9 @@ func New(opts Options) *Receiver {
 		}
 		r.gardner = sync.NewGardner(float64(r.sps), gain)
 	}
+	if opts.EnableDCBlock {
+		r.dcBlk = &dcBlock{}
+	}
 	if opts.EnableAFC {
 		r.afc = newCarrierAFC(r.sps)
 	}
@@ -278,6 +291,13 @@ func New(opts Options) *Receiver {
 func (r *Receiver) Process(iq []complex64) {
 	if len(iq) == 0 {
 		return
+	}
+	if r.dcBlk != nil {
+		// Strip the front-end DC spur before any filtering so it never enters the
+		// matched filter / AFC / differential decode. TETRA-only (voice path); a
+		// no-op numerically on a clean, DC-free synthetic fixture.
+		r.dcBuf = r.dcBlk.process(r.dcBuf, iq)
+		iq = r.dcBuf
 	}
 	if r.chanFilt != nil {
 		// Reject adjacent carriers in the wide channelised passband
@@ -378,6 +398,9 @@ func (r *Receiver) Reset() {
 	r.dq.Reset()
 	r.pending = r.pending[:0]
 	r.rxOffset = 0
+	if r.dcBlk != nil {
+		r.dcBlk.Reset()
+	}
 	if r.gardner != nil {
 		r.gardner.Reset()
 	}

--- a/internal/scanner/widebandt2/engine.go
+++ b/internal/scanner/widebandt2/engine.go
@@ -521,6 +521,15 @@ func New(opts Options) (*Engine, error) {
 	}
 
 	strategy, tag := pickStrategy(opts.TunerStrategy, len(opts.Channels))
+	// A TETRA channel needs a 144 kHz tap; the polyphase channelizer emits one
+	// bank-global rate and can't, so force the per-tap DDC strategy when any TETRA
+	// channel is present. Warn when this overrides a polyphase choice so the CPU
+	// trade-off (per-tap DDC is heavier at high channel counts) isn't silent.
+	if anyTETRA(opts.Channels, systemsByName) && strategy != "ddc" {
+		log.Warn("widebandt2: forcing DDC tuner strategy — a TETRA channel needs a 144 kHz tap the polyphase channelizer cannot emit; per-tap DDC costs more CPU at high channel counts",
+			"serial", opts.Serial, "channels", len(opts.Channels), "requested_strategy", tag)
+		strategy, tag = "ddc", "ddc(tetra-forced)"
+	}
 	var bank tuner.Bank
 	switch strategy {
 	case "ddc":
@@ -560,7 +569,15 @@ func New(opts Options) (*Engine, error) {
 				ch.FrequencyHz, ch.SystemName)
 		}
 		offset := offsets[i]
-		ec, err := buildChannel(sys, ch, bank.OutputRateHz(), opts.Bus, log, opts.Now)
+		// Per-tap output rate: the DDC bank gives each channel its protocol's rate
+		// (144 kHz TETRA vs 48 kHz DMR/P25) so mixed protocols share one SDR. The
+		// channelizer path (no TETRA present here) has a single bank-global rate.
+		outRateHz := bank.OutputRateHz()
+		ddc, isDDC := bank.(*tuner.DDCBank)
+		if isDDC {
+			outRateHz = ddc.ActualRateFor(channelOutRateHz(sys.Protocol))
+		}
+		ec, err := buildChannel(sys, ch, outRateHz, opts.Bus, log, opts.Now)
 		if err != nil {
 			return nil, err
 		}
@@ -573,7 +590,12 @@ func New(opts Options) (*Engine, error) {
 				ec.receiver.Process(out)
 			}
 		}(ec)
-		if err := bank.AddTap(offset, sink); err != nil {
+		if isDDC {
+			if _, err := ddc.AddTapAtRate(offset, channelOutRateHz(sys.Protocol), sink); err != nil {
+				return nil, fmt.Errorf("widebandt2: AddTapAtRate freq=%d offset=%.0f Hz: %w",
+					ch.FrequencyHz, offset, err)
+			}
+		} else if err := bank.AddTap(offset, sink); err != nil {
 			return nil, fmt.Errorf("widebandt2: AddTap freq=%d offset=%.0f Hz: %w",
 				ch.FrequencyHz, offset, err)
 		}
@@ -770,9 +792,12 @@ func buildChannel(sys trunking.System, ch ChannelConfig, outRateHz float64, bus 
 		return &engineChannel{freqHz: freqHz, sysName: sys.Name, protoTag: "p25-phase2", processor: cc, receiver: rx,
 			decoded: func() uint64 { return cc.DecodedFrames() }}, nil
 
+	case trunking.ProtocolTETRA:
+		return buildTETRAChannel(sys, ch, outRateHz, bus, log, now)
+
 	default:
 		return nil, fmt.Errorf(
-			"widebandt2: system %q has protocol %q; wideband supports dmr-tier2, dmr, p25, and p25-phase2",
+			"widebandt2: system %q has protocol %q; wideband supports dmr-tier2, dmr, p25, p25-phase2, and tetra",
 			sys.Name, sys.Protocol.String())
 	}
 }

--- a/internal/scanner/widebandt2/engine_test.go
+++ b/internal/scanner/widebandt2/engine_test.go
@@ -869,3 +869,65 @@ func TestEngineProcessesWhenNotSuspended(t *testing.T) {
 		t.Error("running engine recorded 0 diagnostics windows; want > 0 (fixture should process)")
 	}
 }
+
+// tetraSystem is a test helper for a TETRA wideband channel: a trunked control
+// channel, like DMR Tier III / P25.
+func tetraSystem(name string, ccFreq uint32) trunking.System {
+	return trunking.System{Name: name, Protocol: trunking.ProtocolTETRA, ControlChannels: []uint32{ccFreq}}
+}
+
+// TestEngineMixedTETRAWidebandPerTapRates pins TETRA wideband support: a TETRA
+// channel builds alongside a 48 kHz DMR channel on one wideband SDR, gets its own
+// 144 kHz tap, and forces the per-tap DDC strategy (the polyphase channelizer
+// can't emit 144 kHz), warning when it overrides a requested polyphase strategy.
+func TestEngineMixedTETRAWidebandPerTapRates(t *testing.T) {
+	var logBuf strings.Builder
+	log := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	dev := newMockDevice(nil)
+	bus := events.NewBus(8)
+	defer bus.Close()
+
+	const (
+		center  = 467_900_000
+		tetraCC = 467_912_500
+		dmrFreq = 467_800_000
+	)
+	e, err := New(Options{
+		Device: dev, Bus: bus, Log: log,
+		SampleRateHz: 2_400_000, CenterFreqHz: center,
+		TunerStrategy: "polyphase", // must be overridden to ddc by the TETRA tap
+		Channels: []ChannelConfig{
+			{FrequencyHz: dmrFreq, SystemName: "dmr"},
+			{FrequencyHz: tetraCC, SystemName: "tet"},
+		},
+		Systems: []trunking.System{t2System("dmr"), tetraSystem("tet", tetraCC)},
+	})
+	if err != nil {
+		t.Fatalf("New with a mixed DMR+TETRA plan: %v", err)
+	}
+	if e.strategyTag != "ddc(tetra-forced)" {
+		t.Errorf("strategyTag = %q, want ddc(tetra-forced)", e.strategyTag)
+	}
+	if !strings.Contains(logBuf.String(), "forcing DDC") {
+		t.Errorf("expected a 'forcing DDC' warning; log:\n%s", logBuf.String())
+	}
+	if len(e.channels) != 2 {
+		t.Fatalf("channels = %d, want 2", len(e.channels))
+	}
+	var tetraRcv *tetraChannelReceiver
+	for _, ec := range e.channels {
+		if ec.protoTag == "tetra" {
+			r, ok := ec.receiver.(*tetraChannelReceiver)
+			if !ok {
+				t.Fatalf("tetra channel receiver is %T, want *tetraChannelReceiver", ec.receiver)
+			}
+			tetraRcv = r
+		}
+	}
+	if tetraRcv == nil {
+		t.Fatal("no tetra channel built")
+	}
+	if tetraRcv.rateHz < 143_000 || tetraRcv.rateHz > 145_000 {
+		t.Errorf("tetra tap rate = %.0f Hz, want ~144000", tetraRcv.rateHz)
+	}
+}

--- a/internal/scanner/widebandt2/tetra.go
+++ b/internal/scanner/widebandt2/tetra.go
@@ -1,0 +1,182 @@
+package widebandt2
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	tetra "github.com/MattCheramie/GopherTrunk/internal/radio/tetra"
+	tetrarx "github.com/MattCheramie/GopherTrunk/internal/radio/tetra/receiver"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// tetraChannelRateHz is the per-tap sample rate a TETRA channel needs: its
+// 18000-baud π/4-DQPSK wants a wider channel than the 4800-baud C4FM family, so
+// it channelizes to 144 kHz where DMR/P25 use 48 kHz. Mirrors
+// ccdecoder.DDCTargetForProtocol / tetra/receiver so a wideband-channelized
+// TETRA stream behaves identically to the dedicated-dongle path.
+const tetraChannelRateHz = 144_000.0
+
+// TETRA control-channel resync/stale timers, mirrored from the single-frequency
+// ccdecoder tetraPipeline so a wideband TETRA tap reacquires and surfaces lock
+// loss the same way. TETRA's maybeLock is edge-triggered and never re-affirms a
+// steady lock, so without these a decode drought (the multislot case) would
+// never reacquire and a dead carrier would never surface cc.lost.
+const (
+	tetraResyncTimeout      = 1500 * time.Millisecond
+	tetraLockStaleTimeout   = 5 * time.Second
+	tetraStaleCheckInterval = 1 * time.Second
+)
+
+// channelOutRateHz is the per-tap output rate a channel's protocol needs. TETRA
+// gets tetraChannelRateHz; every other protocol uses the C4FM-family
+// narrowbandRateHz. Used to give each DDC tap its own rate (AddTapAtRate) so a
+// TETRA channel can share one wideband SDR with 48 kHz DMR/P25 channels.
+func channelOutRateHz(proto trunking.Protocol) float64 {
+	if proto == trunking.ProtocolTETRA {
+		return tetraChannelRateHz
+	}
+	return narrowbandRateHz
+}
+
+// anyTETRA reports whether any configured channel belongs to a TETRA system.
+// The polyphase channelizer can only emit one bank-global rate, so a TETRA tap
+// (144 kHz) forces the per-tap DDC strategy.
+func anyTETRA(channels []ChannelConfig, byName map[string]trunking.System) bool {
+	for _, ch := range channels {
+		if sys, ok := byName[ch.SystemName]; ok && sys.Protocol == trunking.ProtocolTETRA {
+			return true
+		}
+	}
+	return false
+}
+
+// tetraChannelReceiver adapts a TETRA receiver + control channel to the engine's
+// narrowbandReceiver interface, driving the same resync + lock-stale watchdogs
+// the ccdecoder tetraPipeline runs after every Process. The tap sink calls
+// Process(iq); this feeds the receiver, credits any decode, and reacquires symbol
+// timing after a full tetraResyncTimeout-worth of signal with no CRC-clean CC
+// decode (the multislot drought). Runs on the single wideband pump goroutine.
+type tetraChannelReceiver struct {
+	rx     *tetrarx.Receiver
+	cc     *tetra.ControlChannel
+	log    *slog.Logger
+	system string
+	rateHz float64
+	now    func() time.Time
+
+	samplesSinceDecode int64
+	lastSeenActivity   int64
+	lastStale          time.Time
+}
+
+func (t *tetraChannelReceiver) Process(iq []complex64) {
+	t.rx.Process(iq)
+	t.checkResync(len(iq))
+	t.checkLockStale()
+}
+
+// checkResync reacquires symbol timing after a full window of processed signal
+// with no decode. Signal-time (not wall-clock) budget, mirroring
+// ccdecoder.tetraPipeline.checkResync so a wideband tap recovers from the same
+// multislot decode drought.
+func (t *tetraChannelReceiver) checkResync(n int) {
+	act := t.cc.LastActivityNano()
+	if act == 0 {
+		return // no decode has ever landed — nothing to reacquire toward
+	}
+	if act != t.lastSeenActivity {
+		t.lastSeenActivity = act
+		t.samplesSinceDecode = 0
+		return
+	}
+	if t.rateHz <= 0 {
+		return
+	}
+	t.samplesSinceDecode += int64(n)
+	if t.samplesSinceDecode < int64(tetraResyncTimeout.Seconds()*t.rateHz) {
+		return
+	}
+	t.samplesSinceDecode = 0
+	t.rx.Reset()
+	t.cc.ResyncReset()
+	if t.log != nil {
+		t.log.Debug("widebandt2: tetra dsp resync (signal-time decode drought; reacquiring symbol timing from centre)",
+			"system", t.system)
+	}
+}
+
+// checkLockStale runs the control-channel lock watchdog on a light throttle so a
+// silent carrier surfaces cc.lost and the supervisor can re-hunt.
+func (t *tetraChannelReceiver) checkLockStale() {
+	now := t.now()
+	if now.Sub(t.lastStale) < tetraStaleCheckInterval {
+		return
+	}
+	t.lastStale = now
+	t.cc.CheckStale(now, tetraLockStaleTimeout)
+}
+
+// buildTETRAChannel wires a TETRA control-channel tap for the wideband engine,
+// mirroring ccdecoder.newTETRAPipeline: a tetra.ControlChannel fed by a
+// tetrarx.Receiver (AFC + channel filter + equalizer + soft-decision + DC block
+// on, as the dedicated-dongle voice/CC paths use). It publishes cc.locked /
+// grant / site.update on the bus exactly like the single-frequency path, so the
+// trunking engine's voice-follow allocator handles TETRA grants unchanged.
+func buildTETRAChannel(sys trunking.System, ch ChannelConfig, outRateHz float64, bus *events.Bus, log *slog.Logger, now func() time.Time) (*engineChannel, error) {
+	freqHz := ch.FrequencyHz
+	if err := requireControlChannel(sys, freqHz, "tetra"); err != nil {
+		return nil, err
+	}
+	if now == nil {
+		now = time.Now
+	}
+	clog := log.With("system", sys.Name, "freq_hz", freqHz, "proto", "tetra")
+	cc := tetra.New(tetra.Options{
+		Bus:         bus,
+		Log:         clog,
+		SystemName:  sys.Name,
+		FrequencyHz: freqHz,
+	})
+	codingMode, ok := tetra.ParseChannelCoding(sys.TETRAChannelCoding)
+	if !ok {
+		clog.Warn("widebandt2: unrecognised tetra_channel_coding; falling back to on", "value", sys.TETRAChannelCoding)
+	}
+	cc.SetChannelCoding(codingMode)
+	if codingMode == tetra.ChannelCodingOn {
+		chType, chOK := tetra.ParseChannelType(sys.TETRAChannel)
+		if !chOK {
+			clog.Warn("widebandt2: unrecognised tetra_channel; falling back to SCH/HD", "value", sys.TETRAChannel)
+		}
+		cc.SetExpectedChannel(chType)
+		cc.SetColourCode(sys.TETRAColourCode)
+	}
+	clockMode, clockOK := tetrarx.ParseClockMode(sys.TETRAClockMode)
+	if !clockOK {
+		clog.Warn("widebandt2: unrecognised tetra_clock_mode; falling back to gardner", "value", sys.TETRAClockMode)
+	}
+	rx := tetrarx.New(tetrarx.Options{
+		SampleRateHz: outRateHz,
+		DibitSink:    func(dibits []uint8, baseIdx int) { cc.Process(dibits, baseIdx) },
+		SoftSink:     func(diffs []complex64, baseIdx int) { cc.StashSoft(diffs, baseIdx) },
+		ClockMode:    clockMode,
+		GardnerGain:  0.005,
+		// The wideband DDC has no AFC and channelizes far wider than a 25 kHz
+		// TETRA channel; these mirror the ccdecoder pipeline's on-air settings.
+		EnableAFC:           true,
+		EnableChannelFilter: true,
+		EnableEqualizer:     true,
+		EnableDCBlock:       true,
+	})
+	rcv := &tetraChannelReceiver{
+		rx: rx, cc: cc, log: clog, system: sys.Name, rateHz: outRateHz, now: now,
+	}
+	return &engineChannel{
+		freqHz:    freqHz,
+		sysName:   sys.Name,
+		protoTag:  "tetra",
+		processor: cc,
+		receiver:  rcv,
+		decoded:   func() uint64 { ok, _ := cc.BSCHCounts(); return uint64(ok) },
+	}, nil
+}

--- a/internal/voice/composer/tetra_voice.go
+++ b/internal/voice/composer/tetra_voice.go
@@ -89,6 +89,7 @@ func (c *Composer) runTETRAVoiceChain(ctx context.Context, serial string, iqCh <
 		EnableAFC:           true,
 		EnableChannelFilter: true,
 		EnableEqualizer:     true, // invert linear channel/ISI that garbles TCH/S (#764/#771 follow-up)
+		EnableDCBlock:       true, // strip the front-end DC spur that leaks into same-carrier voice under heavy multislot
 	})
 
 	c.log.Info("composer: tetra voice follow started — TCH/S decode + ACELP vocoder",
@@ -420,6 +421,7 @@ func (d *tetraSlotDemux) run(ctx context.Context, iqCh <-chan []complex64, iqHz 
 		EnableAFC:           true,
 		EnableChannelFilter: true,
 		EnableEqualizer:     true, // invert linear channel/ISI that garbles TCH/S (#764/#771 follow-up)
+		EnableDCBlock:       true, // strip the front-end DC spur that leaks into same-carrier voice under heavy multislot
 	})
 	d.c.log.Info("composer: tetra shared voice demux started (usage-marker routing)",
 		"key", d.key, "colour_code", d.colour&0x3F, "rate_hz", symbolHz)


### PR DESCRIPTION
## Summary

Follow-up to the round-1 TETRA work (merged in #1022), addressing a batch of field-reported items from the same operator: DC spikes bleeding into TETRA voice under heavy multislot traffic, the "why can't TETRA use the wideband path" question (now implemented), and hardware additions for the site.

## Changes

- **Fix: DC spur leaking into TETRA voice** (`tetra: block the front-end DC spur…`). Same-carrier TETRA voice rides the control carrier at 0 Hz offset, so the zero-IF DC spur (worsened by ADC-clipping/IMD as concurrent-call power rises) sat on the wanted signal and biased the π/4-DQPSK differential decode — and nothing in the voice path removed it. Adds an opt-in complex DC-block high-pass (`EnableDCBlock`, ~23 Hz corner) on the two voice receivers only; safe because π/4-DQPSK has a spectral null at DC. The control-channel path is untouched.
- **Feature: TETRA on the wideband multi-system path** (`widebandt2: follow TETRA control channels…`). The real blocker was the DDC/channelizer banks emitting one bank-global 48 kHz per-tap rate while TETRA needs 144 kHz. `tuner.DDCBank` gains per-tap output rates (`AddTapAtRate`/`ActualRateFor`); the engine gives each tap its protocol's rate and forces the DDC strategy when TETRA is present (the polyphase channelizer can't emit mixed rates — warns when it overrides a requested polyphase strategy); a `ProtocolTETRA` case in `buildChannel` mirrors the single-dongle pipeline (receiver + control channel + resync/stale watchdogs); the config validator accepts `tetra` on a `role: wideband` device. The path multiplexes **control channels**; TETRA voice still follows on a `role: voice` SDR (documented).
- **Docs: hardware pages** (`docs: add HydraSDR, FM notch, B210 pages…`). New Field Guide pages for HydraSDR RFOne, an FM broadcast notch filter, and USRP B210 + AD9361 clones; refreshed the SDRplay RSPdx page for the RSPdx-R2; promoted the Uniden SDS150 over the SDS100 in the buyer's guide. Each new page carries a purchase link (Amazon affiliate tag where the product is listed, direct retailer otherwise). All registered in `_data/reference.yml`; every internal link verified.
- CHANGELOG entries for the above and the round-1 signal/systems/recording-tail/grant-spam work.

## Test plan

- [x] `go vet ./...` clean; `go test` green on all touched packages (`internal/radio/tetra/...`, `internal/voice/composer`, `internal/dsp/tuner`, `internal/scanner/widebandt2`, `internal/config`, `internal/scanner/ccdecoder`, `internal/api`, `cmd/gophertrunk`). Full `make vet test` exceeds the sandbox timeout, so it was run per-package.
- [x] Added tests: `dcblock_test.go` (DC removed, tone preserved, reset); `DDCBank` per-tap-rate test; a mixed DMR+TETRA wideband engine test (forced DDC + 144 kHz tap); TETRA `role: wideband` config-validation cases.
- [x] **Smoke-tested against the reporter's capture.** A/B replay of the concurrent multislot autoIQ (`…concurrent_467912500_144000hz.cs16`, 144 kHz) through `TestTETRAMultiSlotReplay` shows **identical CRC yield with the DC block on (137 = 137) — no regression**. The residual failures on that capture are signal-limited (558 bursts in the worst error bin), so the DC block cleans the constellation of the frames that decode (the audible artifact) without changing which bursts pass CRC.
- [ ] `make integration` not run (exceeds sandbox limits); the voice-composer and wideband paths are covered by unit tests above.

## Breaking changes

None. `EnableDCBlock` is a new opt-in defaulting off; `DDCBank.AddTap` is unchanged (delegates to `AddTapAtRate` at the bank default); `tetra` is newly *accepted* on `role: wideband` (previously rejected), which only widens valid config.

## Docs / CHANGELOG

- [x] Added `## [Unreleased]` bullets to `CHANGELOG.md`
- [x] Updated `docs/` (new hardware pages, `guide-advanced.md` wideband note) and `internal/configbuilder/fieldmeta.go` help text

## Linked issues

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Runhxw6f6AG6vBeibvrdxn)_