### PR TITLE
TETRA: autotune spam + individual-call fixes, live DSP scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **TETRA in the live Signals/DSP scopes.** The Constellation / Symbol / Histogram
+  / Tuning / Mixer scopes gain a **TETRA** mode, plotting the π/4-DQPSK
+  constellation (the four ±45°/±135° clusters) and dibits from the TETRA receiver's
+  existing soft tap. The offline Signal Lab's deep visuals (EVM/eye/rotation) stay
+  P25-only for now.
 - **TETRA on the wideband multi-system path.** A `role: wideband` SDR can now
   follow multiple TETRA control channels alongside DMR/P25, so several TETRA
   sites/systems share one dongle. The blocker was never the protocol allowlist —
@@ -278,6 +283,18 @@ for tagged releases.
   rather than a fixed slot 1 — the building block for issue #925.
 
 ### Fixed
+- **Autotune measure/log spam on TETRA.** At debug level a TETRA control channel
+  emitted the autotune measurement + "suggested error" lines every second, always
+  with `applied_hz=0` — the correction is only consumed by the P25 Phase 1 path, so
+  measuring and logging it for TETRA was dead work. The sampler now gates on a
+  narrower marker (only P25 Phase 1), leaving the #815 carrier-offset WARN intact.
+- **TETRA individual calls reported as "tg == src".** A point-to-point (individual)
+  call was surfaced as a phantom talkgroup whose ID equalled the transmitting
+  radio's — "calling yourself." TETRA's MAC can't distinguish a group SSI from an
+  individual SSI, so a call addressed to a subscriber ISSI was misread as a group.
+  Using the invariant that a party can never equal the call's own identity, such
+  calls are now flagged Individual with no self-source, and the self-referential
+  talker update is suppressed.
 - **DC spur leaked into TETRA voice under heavy multislot traffic.** Same-carrier
   TETRA voice rides the control carrier at 0 Hz offset, so the zero-IF front end's
   DC spur (worsened by ADC-clipping/IMD as concurrent-call power rises) sat on the

--- a/cmd/gophertrunk/symbol_provider.go
+++ b/cmd/gophertrunk/symbol_provider.go
@@ -47,6 +47,9 @@ func symbolProtoToReceiver(proto string) (trunking.Protocol, string, error) {
 		return trunking.ProtocolP25, "c4fm", nil
 	case "p25-cqpsk":
 		return trunking.ProtocolP25, "cqpsk", nil
+	case "tetra":
+		// π/4-DQPSK; demod mode is unused by the TETRA receiver.
+		return trunking.ProtocolTETRA, "", nil
 	default:
 		return trunking.ProtocolUnknown, "", fmt.Errorf("symbol: unsupported proto %q", proto)
 	}

--- a/internal/api/symbols.go
+++ b/internal/api/symbols.go
@@ -92,6 +92,7 @@ type SymbolProvider interface {
 var symbolProtos = map[string]bool{
 	"p25-c4fm":  true,
 	"p25-cqpsk": true,
+	"tetra":     true,
 }
 
 // handleSymbolStream answers WS /api/v1/diag/symbols?device=...&proto=...&offset=....
@@ -115,7 +116,7 @@ func (s *Server) handleSymbolStream(w http.ResponseWriter, r *http.Request) {
 		proto = "p25-c4fm"
 	}
 	if !symbolProtos[proto] {
-		s.writeError(w, http.StatusBadRequest, "unsupported proto (want p25-c4fm or p25-cqpsk)")
+		s.writeError(w, http.StatusBadRequest, "unsupported proto (want p25-c4fm, p25-cqpsk, or tetra)")
 		return
 	}
 	offset := int32(parseIntQuery(q, "offset", 0, -30_000_000, 30_000_000))

--- a/internal/radio/tetra/classify_test.go
+++ b/internal/radio/tetra/classify_test.go
@@ -53,6 +53,29 @@ func TestClassifyPartiesGroupAndIndividual(t *testing.T) {
 	}
 }
 
+// TestClassifyPartiesIndividualSelfCall pins the fix for the "call source update
+// tg==src" a TETRA operator reported: when the CMCE calling/transmitting party
+// equals the addressed SSI, the PDU is addressed to the transmitting radio itself
+// — an INDIVIDUAL call, not a group (you can't call yourself). It must be flagged
+// Individual with no self-source, instead of surfaced as "group X, source X".
+func TestClassifyPartiesIndividualSelfCall(t *testing.T) {
+	cc := New(Options{FrequencyHz: 467_913_000})
+	const radio = 1005499 // the reporter's ISSI
+	var g VoiceGrant
+	cc.classifyParties(&g,
+		MACResource{Address: MACAddress{Type: addrSSI, SSI: radio}},
+		CMCEMessage{Type: CMCETypeDConnect, CallIdentifier: 42, PartySSI: radio}, true)
+	if !g.Individual {
+		t.Errorf("self-addressed call not flagged Individual: %+v", g)
+	}
+	if g.SourceSSI == g.DestSSI {
+		t.Errorf("individual call left with source==dest (%d): a radio cannot call itself", g.SourceSSI)
+	}
+	if g.SourceSSI != 0 {
+		t.Errorf("SourceSSI = %d, want 0 (counterparty unknown from a self-addressed PDU)", g.SourceSSI)
+	}
+}
+
 // TestClassifyPartiesUnknownStaysGroup guards the conservative default: an SSI
 // never seen as a party (and no CMCE party on this PDU) is left as a talkgroup —
 // the MAC address type cannot distinguish a GSSI from an ISSI, so we never guess

--- a/internal/radio/tetra/control.go
+++ b/internal/radio/tetra/control.go
@@ -1041,6 +1041,20 @@ func (c *ControlChannel) publishTalker(gssi, src uint32) {
 	if c.bus == nil || gssi == 0 || src == 0 {
 		return
 	}
+	if gssi == src {
+		// The transmitting party equals the call's own identity — impossible for a
+		// real call (you can't call yourself). This is an INDIVIDUAL (point-to-point)
+		// call whose called-party ISSI GT is tracking as a phantom "group"; the
+		// D-TX-GRANTED then names that same radio as the party. Learn it as an
+		// individual and drop the self-referential source update rather than emit
+		// "tg=X src=X" (the "call source update tg==src" a TETRA operator reported).
+		// Fully modelling both parties of a direct call needs the CMCE
+		// communication-type field and a labelled capture to validate.
+		c.noteIndividual(src)
+		c.log.Debug("tetra: suppressing self-referential talker (individual call)",
+			"system", c.systemName, "ssi", src)
+		return
+	}
 	c.bus.Publish(events.Event{
 		Kind: events.KindCallTalker,
 		Payload: trunking.CallTalker{

--- a/internal/radio/tetra/downlink.go
+++ b/internal/radio/tetra/downlink.go
@@ -370,6 +370,15 @@ func (c *ControlChannel) classifyParties(g *VoiceGrant, m MACResource, msg CMCEM
 		// individual so a later PDU addressed to it is classified correctly.
 		g.SourceSSI = msg.PartySSI
 		c.noteIndividual(msg.PartySSI)
+		// Party == addressed SSI means the PDU is addressed to the transmitting
+		// radio itself: this is an INDIVIDUAL (point-to-point) call, not a group —
+		// you can't call yourself. Flag it and drop the impossible self-source so
+		// the call is not surfaced as "group X, source X" (the tg==src the operator
+		// reported). The counterparty isn't in this PDU, so the source is unknown.
+		if g.SourceSSI == g.DestSSI {
+			g.Individual = true
+			g.SourceSSI = 0
+		}
 		return
 	}
 

--- a/internal/radio/tetra/ingest_cmce_test.go
+++ b/internal/radio/tetra/ingest_cmce_test.go
@@ -98,6 +98,41 @@ func TestHandleCMCETxGrantedPublishesTalker(t *testing.T) {
 	}
 }
 
+// TestHandleCMCETxGrantedSuppressesSelfTalker: a D-TX-GRANTED whose party equals
+// the call's own identity (an individual call GT tracks by the radio's ISSI) must
+// NOT publish a KindCallTalker — a "tg==src" self-reference is impossible and was
+// the "call source update tg==src" the operator reported. It's learned as an
+// individual instead.
+func TestHandleCMCETxGrantedSuppressesSelfTalker(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "Sys", FrequencyHz: 467_913_000})
+	const radio = 1005499
+	// No remembered call → resolveGroup returns the addressed SSI, so gssi == party.
+	cc.handleCMCE(
+		MACResource{Address: MACAddress{Type: addrSSI, SSI: radio}},
+		CMCEMessage{Type: CMCETypeDTxGranted, CallIdentifier: 0x66, PartySSI: radio},
+	)
+
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindCallTalker {
+				tk := ev.Payload.(trunking.CallTalker)
+				t.Fatalf("published a self-referential talker %+v (tg==src), want none", tk)
+			}
+		default:
+			if !cc.isIndividual(radio) {
+				t.Errorf("self-talker radio %d not learned as an individual", radio)
+			}
+			return
+		}
+	}
+}
+
 func waitForRelease(t *testing.T, sub *events.Subscription) trunking.CallRelease {
 	t.Helper()
 	for {

--- a/internal/scanner/ccdecoder/decoder.go
+++ b/internal/scanner/ccdecoder/decoder.go
@@ -947,6 +947,20 @@ type afcReporter interface {
 	AFCOffsetHz() float64
 }
 
+// autotuneApplier marks the pipelines whose measured carrier error is actually
+// consumed by the autotune subsystem — the P25 Phase 1 control channel feeds the
+// per-dongle autotune Manager that the P25 Phase 1 voice composer reads to
+// pre-rotate voice IQ toward lock. Only these protocols should sample + log
+// autotune. A protocol like TETRA implements afcReporter (for the issue #815
+// carrier-offset WARN) but has NO autotune consumer, so sampling it just
+// measured and logged a correction it never applied — every second, at debug
+// level — the "autotune spam" a TETRA operator reported. sampleAutotuneLocked
+// gates on this marker; checkCarrierOffsetLocked still uses afcReporter so the
+// #815 WARN keeps working for every protocol.
+type autotuneApplier interface {
+	appliesAutotune()
+}
+
 // ccHealthReporter is the optional capability a pipeline exposes when it can
 // report cumulative TSBK decode success/failure counts. Today only the P25
 // Phase 1 pipeline implements it; the decoder uses it to nudge the operator
@@ -1058,6 +1072,13 @@ func (d *Decoder) sampleAutotuneLocked() {
 	}
 	rep, ok := d.active.(afcReporter)
 	if !ok {
+		return
+	}
+	// Only sample + log for a protocol that actually consumes the correction
+	// (P25 Phase 1). TETRA implements afcReporter for the #815 offset WARN but
+	// has no autotune consumer, so measuring/logging it every second was dead
+	// work that flooded the debug console.
+	if _, applies := d.active.(autotuneApplier); !applies {
 		return
 	}
 	now := time.Now()

--- a/internal/scanner/ccdecoder/decoder_test.go
+++ b/internal/scanner/ccdecoder/decoder_test.go
@@ -2063,6 +2063,54 @@ func (f *fakeAFCPipeline) AFCOffsetHz() float64 { return f.offsetHz }
 
 const carrierOffsetWarnMsg = "control carrier offset far from configured frequency"
 
+// fakeAutotunePipeline is a P25-Phase-1-like pipeline: afcReporter AND
+// autotuneApplier (its measured correction is consumed downstream).
+type fakeAutotunePipeline struct{ offsetHz float64 }
+
+func (f *fakeAutotunePipeline) Process([]complex64)  {}
+func (f *fakeAutotunePipeline) Reset()               {}
+func (f *fakeAutotunePipeline) Close() error         { return nil }
+func (f *fakeAutotunePipeline) AFCOffsetHz() float64 { return f.offsetHz }
+func (f *fakeAutotunePipeline) appliesAutotune()     {}
+
+// TestSampleAutotuneGatedToApplier pins the fix for the TETRA "autotune spam":
+// sampleAutotuneLocked samples + logs only for a protocol whose correction is
+// actually consumed (implements autotuneApplier, like P25 Phase 1). A pipeline
+// that implements afcReporter but not autotuneApplier — TETRA, which needs
+// afcReporter only for the #815 carrier-offset WARN — is not sampled at all, so
+// the per-second measure-and-log dead work is gone.
+func TestSampleAutotuneGatedToApplier(t *testing.T) {
+	newLockedDecoder := func(active ProtocolPipeline) (*Decoder, *autotune.Manager) {
+		bus := events.NewBus(8)
+		t.Cleanup(bus.Close)
+		mgr := autotune.NewManager("dongle", nil)
+		d, err := New(Options{Bus: bus, IQ: &fakeIQSource{}, SampleRateHz: 48000, Autotune: mgr})
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		t.Cleanup(func() { d.Close() })
+		setActiveSystem(d, "Sys")
+		d.activeFreqHz = 467_912_500
+		d.active = active
+		d.locked.Store(true)
+		return d, mgr
+	}
+
+	// TETRA-like (afcReporter only): must NOT be sampled.
+	dT, mgrT := newLockedDecoder(&fakeAFCPipeline{offsetHz: -800})
+	dT.sampleAutotuneLocked()
+	if got := mgrT.AverageError(); got != 0 {
+		t.Errorf("afcReporter-only (TETRA-like) pipeline was sampled: avg=%d Hz, want 0", got)
+	}
+
+	// P25-Phase-1-like (afcReporter + autotuneApplier): must be sampled.
+	dP, mgrP := newLockedDecoder(&fakeAutotunePipeline{offsetHz: -800})
+	dP.sampleAutotuneLocked()
+	if got := mgrP.AverageError(); got == 0 {
+		t.Errorf("autotuneApplier (P25-like) pipeline was not sampled: avg=0, want the -800 Hz measurement")
+	}
+}
+
 func newOffsetTestDecoder(t *testing.T, buf *bytes.Buffer) *Decoder {
 	t.Helper()
 	bus := events.NewBus(8)

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -405,6 +405,14 @@ func (p *p25Phase1Pipeline) Close() error           { return nil }
 // the unexported afcReporter capability the decoder type-asserts for.
 func (p *p25Phase1Pipeline) AFCOffsetHz() float64 { return p.rx.AFCOffsetHz() }
 
+// appliesAutotune marks P25 Phase 1 as a protocol whose measured control-channel
+// carrier error is consumed downstream (the P25 Phase 1 voice composer reads the
+// per-dongle autotune Manager to pre-rotate voice IQ). Only marked pipelines are
+// sampled + logged by sampleAutotuneLocked, so a protocol without an autotune
+// consumer (e.g. TETRA) no longer floods the debug log with a correction it never
+// applies. See autotuneApplier in decoder.go.
+func (p *p25Phase1Pipeline) appliesAutotune() {}
+
 // TSBKCounts reports the control channel's cumulative decoded and failed
 // (Viterbi + CRC) TSBK block counts. Satisfies the unexported ccHealthReporter
 // capability the decoder type-asserts for, so it can watch the live TSBK error

--- a/internal/scanner/symbolscope/scope.go
+++ b/internal/scanner/symbolscope/scope.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	p25phase1rx "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1/receiver"
+	tetrarx "github.com/MattCheramie/GopherTrunk/internal/radio/tetra/receiver"
 	"github.com/MattCheramie/GopherTrunk/internal/scanner/ccdecoder"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
@@ -143,8 +144,12 @@ type Options struct {
 // Process calls — drive it from a single goroutine (the broker drain
 // loop), exactly like diag.Decimator.
 type Engine struct {
-	ddc          *ccdecoder.Downconverter
+	ddc *ccdecoder.Downconverter
+	// Exactly one receiver is built per engine. rx is the P25 Phase 1 receiver;
+	// tetraRx is the TETRA π/4-DQPSK receiver. Process/stampMetrics branch on
+	// which is non-nil.
 	rx           *p25phase1rx.Receiver
+	tetraRx      *tetrarx.Receiver
 	symbolRateHz float64
 	centerHz     uint32
 	offsetHz     int32
@@ -187,12 +192,8 @@ func New(opts Options) (*Engine, error) {
 	if opts.InRateHz <= 0 {
 		return nil, errors.New("symbolscope: InRateHz must be > 0")
 	}
-	if opts.Protocol != trunking.ProtocolP25 {
-		return nil, fmt.Errorf("symbolscope: protocol %s is not supported yet (P25 Phase 1 only)", opts.Protocol)
-	}
-	demodMode, ok := p25phase1rx.ParseDemodMode(opts.DemodMode)
-	if !ok {
-		return nil, fmt.Errorf("symbolscope: unknown demod mode %q (want c4fm or cqpsk)", opts.DemodMode)
+	if opts.Protocol != trunking.ProtocolP25 && opts.Protocol != trunking.ProtocolTETRA {
+		return nil, fmt.Errorf("symbolscope: protocol %s is not supported (P25 Phase 1 and TETRA only)", opts.Protocol)
 	}
 
 	frameSymbols := opts.FrameSymbols
@@ -204,33 +205,58 @@ func New(opts Options) (*Engine, error) {
 		nowNs = func() int64 { return time.Now().UnixNano() }
 	}
 
-	target := ccdecoder.DDCTargetForProtocol(trunking.ProtocolP25)
+	target := ccdecoder.DDCTargetForProtocol(opts.Protocol)
 	ddc := ccdecoder.NewDownconverterWithOffset(opts.InRateHz, target, float64(opts.OffsetHz))
 
 	e := &Engine{
 		ddc:          ddc,
-		symbolRateHz: p25phase1rx.SymbolRate,
 		centerHz:     opts.CenterHz,
 		offsetHz:     opts.OffsetHz,
 		frameSymbols: frameSymbols,
-		isCQPSK:      demodMode == p25phase1rx.DemodCQPSK,
 		nowNs:        nowNs,
 		emit:         opts.Emit,
 	}
 
-	// Build the receiver directly (no control channel) so the SoftSink
-	// surfaces the pre-slicer waveform. The DibitSink drives the frame
-	// accumulator; soft↔dibit alignment holds because the receiver
-	// fires SoftSink then DibitSink on the same symbol batch.
-	e.rx = p25phase1rx.New(p25phase1rx.Options{
-		SampleRateHz: ddc.OutRateHz(),
-		DeviationHz:  p25DeviationHz,
-		DemodMode:    demodMode,
-		SoftSink:     e.onSoft,
-		SymbolSink:   e.onSymbols,
-		EyeSink:      e.onEye,
-		DibitSink:    e.onDibits,
-	})
+	// Build the receiver directly (no control channel) so its symbol taps surface
+	// the constellation. The DibitSink drives the frame accumulator; the
+	// soft/symbol tap fires just before DibitSink on the same batch, so alignment
+	// holds.
+	switch opts.Protocol {
+	case trunking.ProtocolTETRA:
+		e.symbolRateHz = tetrarx.SymbolRate
+		// The receiver's SoftSink emits the complex π/4-DQPSK differential
+		// (s·conj(last)) per symbol — the constellation points (clustering at the
+		// four ±45°/±135° positions on a clean signal). Route them into the same
+		// complex-symbol accumulator the P25 CQPSK path uses. TETRA has no 4-level
+		// soft eye, so no soft/eye tap. AFC + channel filter + equalizer mirror the
+		// live decode so the scope shows what the decoder sees.
+		e.tetraRx = tetrarx.New(tetrarx.Options{
+			SampleRateHz:        ddc.OutRateHz(),
+			DibitSink:           e.onDibits,
+			SoftSink:            func(diffs []complex64, _ int) { e.onSymbols(diffs) },
+			ClockMode:           tetrarx.ClockGardner,
+			GardnerGain:         0.005,
+			EnableAFC:           true,
+			EnableChannelFilter: true,
+			EnableEqualizer:     true,
+		})
+	default: // P25 Phase 1
+		demodMode, ok := p25phase1rx.ParseDemodMode(opts.DemodMode)
+		if !ok {
+			return nil, fmt.Errorf("symbolscope: unknown demod mode %q (want c4fm or cqpsk)", opts.DemodMode)
+		}
+		e.symbolRateHz = p25phase1rx.SymbolRate
+		e.isCQPSK = demodMode == p25phase1rx.DemodCQPSK
+		e.rx = p25phase1rx.New(p25phase1rx.Options{
+			SampleRateHz: ddc.OutRateHz(),
+			DeviationHz:  p25DeviationHz,
+			DemodMode:    demodMode,
+			SoftSink:     e.onSoft,
+			SymbolSink:   e.onSymbols,
+			EyeSink:      e.onEye,
+			DibitSink:    e.onDibits,
+		})
+	}
 
 	if opts.MixerEmit != nil {
 		mx, err := newMixerAccum(mixerOptions{
@@ -257,7 +283,11 @@ func (e *Engine) Process(iq []complex64) {
 		return
 	}
 	e.chanBuf = e.ddc.Process(e.chanBuf, iq)
-	e.rx.Process(e.chanBuf)
+	if e.tetraRx != nil {
+		e.tetraRx.Process(e.chanBuf)
+	} else {
+		e.rx.Process(e.chanBuf)
+	}
 	// Feed the Mixer accumulator after the receiver has updated its
 	// carrier-offset estimate, so the "tuned" re-mix uses this chunk's
 	// loop state. chanBuf is consumed synchronously (copied into the
@@ -374,6 +404,13 @@ func (e *Engine) flush(n int) {
 // The getters are demod-specific (Mueller-Müller vs Gardner, AFC vs
 // carrier-recovery), so this routes by the configured demod mode.
 func (e *Engine) stampMetrics(f *Frame) {
+	if e.tetraRx != nil {
+		// TETRA exposes its residual carrier offset; the other loop getters
+		// (AGC/clock) aren't surfaced by the receiver, so they stay zero — the
+		// constellation, offset, and dibits are the useful TETRA scope views.
+		f.CarrierOffsetHz = e.tetraRx.CarrierOffsetHz()
+		return
+	}
 	if e.rx == nil {
 		return
 	}
@@ -397,6 +434,9 @@ func (e *Engine) stampMetrics(f *Frame) {
 // CQPSK). The Mixer plot uses it to re-mix the raw baseband onto centre
 // for the "tuned" view; it mirrors the routing stampMetrics uses.
 func (e *Engine) carrierOffsetHz() float64 {
+	if e.tetraRx != nil {
+		return e.tetraRx.CarrierOffsetHz()
+	}
 	if e.rx == nil {
 		return 0
 	}

--- a/internal/scanner/symbolscope/scope_test.go
+++ b/internal/scanner/symbolscope/scope_test.go
@@ -1,10 +1,12 @@
 package symbolscope
 
 import (
+	"math"
 	"sort"
 	"testing"
 
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	tetrarx "github.com/MattCheramie/GopherTrunk/internal/radio/tetra/receiver"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
 
@@ -160,6 +162,69 @@ func TestC4FMRecoversSoftAndDibits(t *testing.T) {
 // the constellation), so frames carry an empty Soft track but a complex
 // symbol-decision track (SymI/SymQ) aligned index-for-index with the
 // dibits.
+// TestTETRAEmitsComplexConstellation pins the TETRA scope support: a π/4-DQPSK
+// stream drives the TETRA receiver, whose complex differential (the constellation
+// points) reaches the frame as SymI/SymQ aligned with the dibits, at the 18 kHz
+// TETRA symbol rate, with no C4FM soft/eye track.
+func TestTETRAEmitsComplexConstellation(t *testing.T) {
+	// 8 samples/symbol × 18000 baud = 144 kHz, the TETRA channel rate the DDC
+	// targets, so the input feeds the receiver near-unity.
+	const sps = 8
+	dibits := make([]uint8, 4000)
+	for i := range dibits {
+		dibits[i] = uint8((i*7 + 3) & 3)
+	}
+	iq := demod.ModulatePiOver4DQPSK(dibits, sps, 8, tetrarx.RolloffAlpha, tetrarx.Rotation)
+	for i := range iq {
+		iq[i] *= 100
+	}
+
+	var frames []Frame
+	e, err := New(Options{
+		Emit:         func(f Frame) { frames = append(frames, f) },
+		InRateHz:     18000 * sps,
+		Protocol:     trunking.ProtocolTETRA,
+		FrameSymbols: 64,
+	})
+	if err != nil {
+		t.Fatalf("New(TETRA): %v", err)
+	}
+	if math.Abs(e.SymbolRateHz()-tetrarx.SymbolRate) > 1 {
+		t.Fatalf("SymbolRateHz = %v, want %v", e.SymbolRateHz(), tetrarx.SymbolRate)
+	}
+	e.Process(iq)
+
+	if len(frames) == 0 {
+		t.Fatal("no frames emitted on the TETRA path")
+	}
+	sawSymbols := false
+	for fi, f := range frames {
+		if math.Abs(f.SymbolRateHz-tetrarx.SymbolRate) > 1 {
+			t.Errorf("frame %d: SymbolRateHz = %v, want %v", fi, f.SymbolRateHz, tetrarx.SymbolRate)
+		}
+		if len(f.Soft) != 0 || len(f.EyeSoft) != 0 {
+			t.Errorf("frame %d: TETRA has no soft/eye track, got soft=%d eye=%d", fi, len(f.Soft), len(f.EyeSoft))
+		}
+		if len(f.SymI) != len(f.SymQ) {
+			t.Fatalf("frame %d: SymI len %d != SymQ len %d", fi, len(f.SymI), len(f.SymQ))
+		}
+		if len(f.SymI) != 0 {
+			if len(f.SymI) != len(f.Dibits) {
+				t.Fatalf("frame %d: symbol track len %d != dibit len %d", fi, len(f.SymI), len(f.Dibits))
+			}
+			sawSymbols = true
+		}
+		for _, d := range f.Dibits {
+			if d > 3 {
+				t.Fatalf("frame %d: dibit %d out of range", fi, d)
+			}
+		}
+	}
+	if !sawSymbols {
+		t.Fatal("TETRA path emitted no complex constellation points")
+	}
+}
+
 func TestCQPSKEmitsComplexSymbolsWithoutSoft(t *testing.T) {
 	iq, _ := makeC4FMIQ(960_000, 4000) // any IQ drives the Gardner loop
 

--- a/web/src/api/symbols.ts
+++ b/web/src/api/symbols.ts
@@ -52,6 +52,11 @@ export function demodModeToProto(mod: string | undefined | null): string {
     case "lsm":
     case "linear":
       return "p25-cqpsk";
+    case "tetra":
+    case "pi/4-dqpsk":
+    case "pi4dqpsk":
+    case "dqpsk":
+      return "tetra";
     default:
       return "p25-c4fm";
   }

--- a/web/src/panels/Constellation.tsx
+++ b/web/src/panels/Constellation.tsx
@@ -62,6 +62,7 @@ const PROTOS: { value: string; label: string }[] = [
   { value: "auto", label: "Auto" },
   { value: "p25-cqpsk", label: "P25 CQPSK" },
   { value: "p25-c4fm", label: "P25 C4FM" },
+  { value: "tetra", label: "TETRA" },
 ];
 
 // Reference markers (ideal post-normalisation cluster centres) drawn as

--- a/web/src/panels/Histogram.tsx
+++ b/web/src/panels/Histogram.tsx
@@ -44,6 +44,7 @@ const CARDINALITY = 4;
 const PROTOS: { value: string; label: string }[] = [
   { value: "p25-c4fm", label: "P25 C4FM" },
   { value: "p25-cqpsk", label: "P25 CQPSK" },
+  { value: "tetra", label: "TETRA" },
 ];
 
 type ConnState = "connecting" | "open" | "closed";

--- a/web/src/panels/Mixer.tsx
+++ b/web/src/panels/Mixer.tsx
@@ -29,6 +29,7 @@ const PLOT_H = 200;
 const PROTOS: { value: string; label: string }[] = [
   { value: "p25-c4fm", label: "P25 C4FM" },
   { value: "p25-cqpsk", label: "P25 CQPSK" },
+  { value: "tetra", label: "TETRA" },
 ];
 
 type ConnState = "connecting" | "open" | "closed";

--- a/web/src/panels/SymbolScope.tsx
+++ b/web/src/panels/SymbolScope.tsx
@@ -35,6 +35,7 @@ const PROTOS: { value: string; label: string }[] = [
   { value: "auto", label: "Auto" },
   { value: "p25-c4fm", label: "P25 C4FM" },
   { value: "p25-cqpsk", label: "P25 CQPSK" },
+  { value: "tetra", label: "TETRA" },
 ];
 
 type ConnState = "connecting" | "open" | "closed";

--- a/web/src/panels/Tuning.tsx
+++ b/web/src/panels/Tuning.tsx
@@ -48,6 +48,7 @@ const HISTORY_POINTS = 240; // ~12 s at the ~50 ms frame cadence
 const PROTOS: { value: string; label: string }[] = [
   { value: "p25-c4fm", label: "P25 C4FM" },
   { value: "p25-cqpsk", label: "P25 CQPSK" },
+  { value: "tetra", label: "TETRA" },
 ];
 
 type ConnState = "connecting" | "open" | "closed";


### PR DESCRIPTION
## Summary

Follow-up to the merged TETRA work (#1022, #1023), fixing two field-reported TETRA bugs and adding TETRA to the live Signals/DSP scopes. From the same operator's debug log + capture.

## Changes

- **Fix: autotune measure/log spam on TETRA** (`ccdecoder: stop autotune…`). At debug level a TETRA CC emitted the autotune measurement + "suggested error" lines every second, always `applied_hz=0` (1,952 lines in the operator's log). The correction is only consumed by the P25 Phase 1 path, so it was dead work on TETRA. The sampler now gates on a narrow `autotuneApplier` marker (P25 Phase 1 only); the #815 carrier-offset WARN keeps using `afcReporter`, unaffected.
- **Fix: TETRA individual calls reported as "tg == src"** (`tetra: stop reporting…`). A point-to-point call was surfaced as a phantom talkgroup whose ID equalled the transmitting radio ("calling yourself"). TETRA's MAC can't distinguish a group SSI from an individual SSI, so a call to a subscriber ISSI was misread as a group. Using the invariant that a party can never equal the call's own identity, such calls are flagged `Individual` with no self-source, and the self-referential talker update is suppressed.
- **Feature: TETRA in the live DSP scopes** (`symbolscope: add TETRA…`). Constellation / Symbol / Histogram / Tuning / Mixer gain a **TETRA** mode. The TETRA receiver already emits the complex π/4-DQPSK differential (the constellation) + dibits, and the DDC knows the 144 kHz target, so this is wiring: a TETRA branch in `symbolscope.Engine`, the provider/API allow-list, and a dropdown option in the five panels. Ideal-cluster markers fall to the ±45°/±135° set (π/4-DQPSK's positions).

## Test plan

- [x] `go vet ./...` clean; `go test` green on all touched packages (`internal/scanner/ccdecoder`, `internal/radio/tetra/...`, `internal/scanner/symbolscope`, `internal/api`, `cmd/gophertrunk`, `internal/scanner/widebandt2`). Full `make vet test` exceeds the sandbox timeout, so per-package.
- [x] Added failing-first tests: autotune sampler gated to `autotuneApplier` (TETRA-like pipeline not sampled, P25-like is); individual self-call flagged Individual with no self-source + suppressed self-talker; a π/4-DQPSK stream through the TETRA scope engine emits aligned constellation points at 18 kHz with no soft/eye track.
- [x] Frontend `tsc --noEmit` clean; Constellation + SymbolScope panel tests pass (26/26).
- [ ] `make integration` not run (sandbox limits).

**Not fixed here (needs data):** the intermittent "warm-up CC lock" (locks in ~0.3 s some runs, ~57 s with `sb_bursts=0` throughout others). Confirmed **not** carrier offset — the fast run locks and decodes at −1700 Hz. The provided autoIQ is a 144 kHz *voice* capture, so it can't reproduce a cold-start CC acquisition; per the repo's "reproduce before fixing DSP" rule I've left it uninvestigated in code pending a cold-start IQ capture (a `.cfile`/cs16 from daemon start during a slow-lock episode).

## Breaking changes

None. The autotune change removes only dead measurement/logging on TETRA (no tuning behaviour changed). `tetra` is newly *accepted* by the symbol-scope API (widens valid input).

## Docs / CHANGELOG

- [x] `## [Unreleased]` bullets added to `CHANGELOG.md`.

## Linked issues

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Runhxw6f6AG6vBeibvrdxn)_