### PR TITLE
iqautorecord: capture raw IQ on control-channel sync loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **Baseband auto-record trigger on control-channel sync loss
+  (`baseband.auto_record.on_cc_sync_loss`).** Fires an IQ capture when a locked
+  control channel suddenly loses sync (`cc.lost`, which only fires after a genuine
+  lock — never for a hunt that never locked), recording the re-acquisition that
+  follows. That is exactly the raw IQ needed to debug sync-loss and slow
+  warm-up-lock episodes, where the carrier is present but GT fails to re-lock.
+  Off by default; pair with `tap: ddc` for small, directly-replayable captures.
 - **TETRA in the live Signals/DSP scopes.** The Constellation / Symbol / Histogram
   / Tuning / Mixer scopes gain a **TETRA** mode, plotting the π/4-DQPSK
   constellation (the four ±45°/±135° clusters) and dibits from the TETRA receiver's

--- a/cmd/gophertrunk/iqautorecord.go
+++ b/cmd/gophertrunk/iqautorecord.go
@@ -230,7 +230,8 @@ func (a *iqAutoRecorder) Run(ctx context.Context, sub *events.Subscription) erro
 		"dir", a.dir, "format", a.format.String(), "seconds", a.seconds,
 		"cooldown", a.cooldown, "on_concurrent_calls", a.cfg.OnConcurrentCalls,
 		"on_no_voice_device", a.cfg.OnNoVoiceDevice,
-		"on_encrypted", a.cfg.OnEncrypted, "on_emergency", a.cfg.OnEmergency)
+		"on_encrypted", a.cfg.OnEncrypted, "on_emergency", a.cfg.OnEmergency,
+		"on_cc_sync_loss", a.cfg.OnCCSyncLoss)
 	for {
 		select {
 		case <-ctx.Done():
@@ -248,6 +249,8 @@ func (a *iqAutoRecorder) Run(ctx context.Context, sub *events.Subscription) erro
 				if g, ok := ev.Payload.(trunking.Grant); ok {
 					a.onGrantUnserved(g)
 				}
+			case events.KindCCLost:
+				a.onCCLost(ev.Payload)
 			}
 		}
 	}
@@ -274,6 +277,27 @@ func (a *iqAutoRecorder) onGrantUnserved(g trunking.Grant) {
 	if a.cfg.OnNoVoiceDevice {
 		a.maybeFire("no_voice_device", g.System, g.Protocol, false)
 	}
+}
+
+// onCCLost fires the CC-sync-loss trigger. events.KindCCLost is published only
+// after a genuine lock (every protocol's MarkLost early-returns unless locked),
+// so this is exclusively a "was locked, now lost" edge — never a hunt that never
+// locked. The capture is forward-looking, so it records the re-acquisition after
+// the drop: the raw IQ needed to debug sync-loss and slow warm-up-lock episodes,
+// where the carrier is still present but GT fails to re-lock. The event payload
+// carries the frequency but no system name, so the capture is labelled with the
+// primary control system (a.system), like the manual trigger.
+func (a *iqAutoRecorder) onCCLost(payload any) {
+	if !a.cfg.OnCCSyncLoss {
+		return
+	}
+	var freqHz uint32
+	if lp, ok := payload.(trunking.LockedPayload); ok {
+		freqHz = lp.LockedFrequencyHz()
+	}
+	a.log.Info("iq-autorecord: control-channel sync loss — capturing re-acquisition IQ",
+		"system", a.system, "freq_hz", freqHz)
+	a.maybeFire("cc_sync_loss", a.system, a.protocol, false)
 }
 
 // TriggerManual fires a capture on operator request, bypassing the cooldown.

--- a/cmd/gophertrunk/iqautorecord_test.go
+++ b/cmd/gophertrunk/iqautorecord_test.go
@@ -317,6 +317,35 @@ func TestAutoRecordNoVoiceDeviceTrigger(t *testing.T) {
 	}
 }
 
+// fakeLostPayload is a trunking.LockedPayload for the cc.lost event.
+type fakeLostPayload struct{ freq uint32 }
+
+func (f fakeLostPayload) LockedFrequencyHz() uint32 { return f.freq }
+func (f fakeLostPayload) LockedNAC() uint16         { return 0 }
+
+// TestAutoRecordCCSyncLossTrigger pins the new on_cc_sync_loss trigger: a cc.lost
+// event (a locked control channel that suddenly lost sync) fires a capture
+// labelled "cc_sync_loss" when enabled, and is ignored when off.
+func TestAutoRecordCCSyncLossTrigger(t *testing.T) {
+	a, rec, _ := newTestAutoRecorder(t, config.BasebandAutoRecordConfig{OnCCSyncLoss: true})
+	a.onCCLost(fakeLostPayload{freq: 467_912_500})
+	waitFor(t, func() bool { return rec.count() == 1 })
+	rec.mu.Lock()
+	path := rec.paths[0]
+	rec.mu.Unlock()
+	if !strings.Contains(path, "cc_sync_loss") {
+		t.Errorf("capture path %q missing cc_sync_loss reason", path)
+	}
+
+	// With the trigger off, a sync-loss event is ignored.
+	b, rec2, _ := newTestAutoRecorder(t, config.BasebandAutoRecordConfig{OnConcurrentCalls: 2})
+	b.onCCLost(fakeLostPayload{freq: 467_912_500})
+	time.Sleep(20 * time.Millisecond)
+	if rec2.count() != 0 {
+		t.Fatalf("on_cc_sync_loss off should ignore cc.lost; got %d captures", rec2.count())
+	}
+}
+
 func TestAutoRecordCooldownThrottlesAuto(t *testing.T) {
 	a, rec, clock := newTestAutoRecorder(t, config.BasebandAutoRecordConfig{OnEncrypted: true, Cooldown: "10s"})
 	enc := func(tg uint32) trunking.Grant { g := grant("TETRA_Site_1", tg, 1); g.Encrypted = true; return g }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1349,6 +1349,10 @@ broadcast:
 #     on_no_voice_device: true   # fire when a grant found no free voice tuner
 #     on_encrypted: true         # fire on an encrypted grant
 #     on_emergency: true         # fire on an emergency grant
+#     on_cc_sync_loss: true      # fire when a locked control channel suddenly
+#                                #   loses sync — captures the re-acquisition IQ,
+#                                #   ideal for debugging sync-loss / slow warm-up
+#                                #   lock (pair with tap: ddc for small files)
 
 # User-interface tabs. Every navigation tab shows by default in both the
 # web UI and the terminal TUI. If you run GopherTrunk for one main task

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -533,6 +533,12 @@ type BasebandAutoRecordConfig struct {
 	OnEncrypted bool `yaml:"on_encrypted"`
 	// OnEmergency fires on an emergency-flagged grant.
 	OnEmergency bool `yaml:"on_emergency"`
+	// OnCCSyncLoss fires when a locked control channel suddenly loses sync
+	// (events.KindCCLost, which only fires after a genuine lock — never for a
+	// hunt that never locked). It captures the seconds AFTER the loss, i.e. the
+	// re-acquisition attempt, which is exactly the raw IQ needed to debug
+	// sync-loss and slow warm-up-lock episodes. Most useful with the "ddc" tap.
+	OnCCSyncLoss bool `yaml:"on_cc_sync_loss"`
 	// Tap selects what IQ is captured, mirroring BasebandRecordConfig.Tap:
 	//   "wideband" (default) — the control SDR's full-rate raw IQ (the historical
 	//     behaviour; large files, e.g. ~50 MB per 30 s at 2.5 MS/s).

--- a/internal/configbuilder/fieldmeta.go
+++ b/internal/configbuilder/fieldmeta.go
@@ -407,6 +407,7 @@ var fieldMetas = map[string]FieldMeta{
 	"BasebandAutoRecordConfig.OnNoVoiceDevice":   {Label: "On no voice device", Help: "Fire when a grant arrives but every voice tuner is busy."},
 	"BasebandAutoRecordConfig.OnEncrypted":       {Label: "On encrypted", Help: "Fire on a grant flagged encrypted."},
 	"BasebandAutoRecordConfig.OnEmergency":       {Label: "On emergency", Help: "Fire on an emergency-flagged grant."},
+	"BasebandAutoRecordConfig.OnCCSyncLoss":      {Label: "On CC sync loss", Help: "Fire when a locked control channel suddenly loses sync — captures the re-acquisition IQ, ideal for debugging sync-loss / slow warm-up lock. Pair with the ddc tap for small files."},
 	"BasebandAutoRecordConfig.Tap":               {Help: "What IQ to capture: wideband (default, full-rate SDR — large files) or ddc (narrowband channelised stream at the pipeline rate, e.g. 144 kHz for TETRA — far smaller and directly replayable).", Options: opts("", "wideband (default)", "ddc", "ddc")},
 
 	// ---- Paging ------------------------------------------------------------

--- a/internal/configbuilder/webschema_test.go
+++ b/internal/configbuilder/webschema_test.go
@@ -56,6 +56,7 @@ var webRoundTripAllow = map[string][]string{
 	"BasebandAutoRecordConfig": {
 		"Enabled", "Dir", "Format", "Seconds", "Cooldown",
 		"OnConcurrentCalls", "OnNoVoiceDevice", "OnEncrypted", "OnEmergency",
+		"OnCCSyncLoss",
 	},
 }
 


### PR DESCRIPTION
## Summary

A TETRA operator asked for a baseband auto-record trigger on sudden control-channel sync loss, so GopherTrunk captures the raw IQ around a drop. This is exactly the data we've been missing to debug the intermittent "warm-up CC lock" (carrier present, GT fails to re-lock) and general sync-loss episodes — the existing autoIQ triggers (concurrent calls, no-voice-device, encrypted, emergency) never catch a lock failure.

## Changes

- **New trigger `baseband.auto_record.on_cc_sync_loss`** (off by default). Fires an IQ capture on `events.KindCCLost`. That event is the right signal: every protocol's `MarkLost` early-returns unless locked, so `cc.lost` is exclusively a "was locked, now lost" edge — never a hunt that never locked (that's `KindHuntFailed`). For TETRA the stale watchdog (`CheckStale`, 5 s) drives it in production. The capture is forward-looking, so it records the re-acquisition after the drop.
- Wiring: a `KindCCLost` case in the recorder's event dispatch + an `onCCLost` handler modelled on the existing `no_voice_device` trigger; the startup-log field; the config-struct field; and the `config.example.yaml` block. The event payload carries the frequency (`trunking.LockedPayload`) but no system name, so the capture is labelled with the primary control system, like the manual trigger.

Pair with `tap: ddc` for small, directly-replayable captures (the DDC tap holds all four voice timeslots of a same-carrier TETRA site).

## Test plan

- [x] `go vet` clean; `go test ./cmd/gophertrunk ./internal/config` green.
- [x] Added `TestAutoRecordCCSyncLossTrigger`: a `cc.lost` event fires a capture labelled `cc_sync_loss` when enabled, and is ignored when off (mirrors the no-voice-device trigger test).
- [ ] `make integration` not run (sandbox limits); the recorder path is covered by unit tests with a stubbed capture actuator.

## Breaking changes

None. New opt-in config key defaulting to `false`; no behaviour change unless enabled.

## Docs / CHANGELOG

- [x] `## [Unreleased]` bullet added to `CHANGELOG.md`; documented in `config.example.yaml`.

## Linked issues

n/a — this is the capture mechanism that will feed a future fix for the intermittent warm-up/sync-loss CC-lock behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Runhxw6f6AG6vBeibvrdxn)_