### PR TITLE
docs(site): single-board-computer buyer guides + sectioned Hardware nav

### DIFF
--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -163,10 +163,14 @@ groups:
         url: /blog/category/solution-postmortem/
   - label: Hardware
     items:
-      - title: Best police scanners (buyer's guide)
-        url: /best-police-scanners/
-      - title: Police scanner vs GopherTrunk
+      - heading: Start here
+      - title: What hardware do I need?
+        url: /what-do-i-need-for-gophertrunk/
+      - title: Police scanner vs GopherTrunk (SDR)
         url: /police-scanner-vs-sdr/
+      - heading: Police scanners
+      - title: Best police scanners
+        url: /best-police-scanners/
       - title: How police scanners work
         url: /how-police-scanners-work/
       - title: Scanner encryption explained
@@ -177,22 +181,34 @@ groups:
         url: /scanner-frequencies/
       - title: How to program a scanner
         url: /how-to-program-a-police-scanner/
-      - title: Best scanner antennas
-        url: /best-scanner-antenna/
-      - title: "Scanner hardware (Field Guide)"
+      - title: "All scanner models (Field Guide)"
         url: /reference/#consumer-scanners
+      - heading: SDRs & receivers
       - title: Best SDR for GopherTrunk
         url: /best-sdr-for-gophertrunk/
-      - title: What hardware do I need?
-        url: /what-do-i-need-for-gophertrunk/
       - title: Best RTL-SDR
         url: /best-rtl-sdr/
+      - title: Best HF SDR
+        url: /best-hf-sdr/
+      - title: "All SDR devices (Field Guide)"
+        url: /reference/#sdr-devices
+      - heading: Antennas & accessories
+      - title: Best scanner antennas
+        url: /best-scanner-antenna/
       - title: Best SDR antenna
         url: /best-sdr-antenna/
       - title: SDR cables & connectors
         url: /sdr-cables-and-connectors/
-      - title: "SDR devices (Field Guide)"
-        url: /reference/#sdr-devices
+      - title: LNAs & filters
+        url: /best-sdr-lna/
+      - heading: Computers
+      - title: Best single-board computer
+        url: /best-single-board-computer-for-gophertrunk/
+      - title: Run GopherTrunk on a Raspberry Pi
+        url: /raspberry-pi-sdr-scanner/
+      - title: "All SBCs (Field Guide)"
+        url: /reference/#hw-sbc
+      - heading: Setup
       - title: SDR hardware setup
         url: /hardware.html
   - label: Install

--- a/docs/_includes/nav.html
+++ b/docs/_includes/nav.html
@@ -22,10 +22,14 @@
             </button>
             <ul class="nav-group__items" role="menu">
               {%- for item in group.items -%}
-                {%- assign item_url = item.url | relative_url -%}
-                <li role="none">
-                  <a role="menuitem" href="{{ item_url }}"{% if page.url == item.url %} aria-current="page"{% endif %}>{{ item.title }}</a>
-                </li>
+                {%- if item.heading -%}
+                  <li role="presentation" class="nav-group__heading">{{ item.heading }}</li>
+                {%- else -%}
+                  {%- assign item_url = item.url | relative_url -%}
+                  <li role="none">
+                    <a role="menuitem" href="{{ item_url }}"{% if page.url == item.url %} aria-current="page"{% endif %}>{{ item.title }}</a>
+                  </li>
+                {%- endif -%}
               {%- endfor -%}
             </ul>
           </li>

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -265,6 +265,24 @@ button { font: inherit; cursor: pointer; }
   color: var(--accent);
   font-weight: 600;
 }
+/* Long dropdowns (e.g. Hardware) stay inside the viewport and scroll. */
+.nav-group__items { max-height: min(78vh, 44rem); overflow-y: auto; }
+/* Section headings inside a dropdown, grouping a long item list. */
+.nav-group__heading {
+  padding: 0.5rem 0.65rem 0.2rem;
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--fg-muted);
+  pointer-events: none;
+}
+.nav-group__heading + li a { margin-top: 0; }
+li.nav-group__heading:not(:first-child) {
+  margin-top: 0.3rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--border);
+}
 
 .site-nav__external a {
   display: inline-flex;
@@ -356,6 +374,8 @@ button { font: inherit; cursor: pointer; }
     min-width: 0;
     background: transparent;
     display: none;
+    max-height: none;
+    overflow: visible;
   }
   // On touch/mobile the submenu is driven solely by the JS-toggled
   // .is-open class. Hover/focus-within are deliberately excluded here:

--- a/docs/best-single-board-computer-for-gophertrunk.md
+++ b/docs/best-single-board-computer-for-gophertrunk.md
@@ -95,6 +95,33 @@ scanner. **No host decodes [AES encryption](/police-scanner-encryption/).**
 > accelerator is wasted on scanning. Spend on RAM and CPU cores if you'll run a
 > [multi-SDR pool](/multi-dongle-sdr-setup/), not on a Jetson.
 
+## What GopherTrunk needs from an SBC
+
+GopherTrunk is deliberately light on its host — it's a **[pure-Go](/downloads.html)** static
+binary with no vendor toolchain, so "will it run?" almost always answers itself. What
+matters is how much you ask of it:
+
+- **Architecture.** GopherTrunk ships **ARM64, ARMv7, and amd64** builds. Nearly every
+  modern SBC is ARM64 — drop the binary on 64-bit Linux and it runs.
+- **CPU.** Following **one** trunked system with one [RTL-SDR](/reference/rtl-sdr/) is light
+  real-time DSP — a quad-A53 (Pi Zero 2 W, Le Potato) handles it. A
+  [multi-SDR pool](/multi-dongle-sdr-setup/) or **wideband** channelizing of several control
+  channels wants more cores and clock — a Pi 5 or an RK3588 board.
+- **RAM.** ~**512 MB** covers a single channel; **2–8 GB** is comfortable once you add the
+  [web console](/web.html), call **recording**, and several systems at once.
+- **USB.** One free **USB 2.0+** port per dongle. RTL-SDR's ~2.4 MS/s is trivial; a wideband
+  [Airspy](/reference/airspy/) capture pushes real USB bandwidth, and multiple dongles want a
+  **powered hub**. USB 3 ports (Pi 4/5, RK3588) give the most headroom.
+- **Storage.** An **SD card** is fine to start; **eMMC or NVMe** (Pi 5, Rock 5B) is faster
+  and more durable for 24/7 recording and the call database.
+- **Power & heat.** Low draw suits an always-on box by the antenna; **RK3588** boards run hot
+  under load and want a heatsink/fan.
+- **Networking.** Ethernet or Wi-Fi lets you run it **headless** and reach the
+  [web console](/web.html) from your phone or laptop.
+
+In short: **one dongle, one channel → any SBC.** Recording, several systems, or wideband
+multi-site → **more cores, more RAM, USB 3, and faster storage.**
+
 ## How to choose
 
 - **Want the easy, best-supported path?** [Raspberry Pi 5](/reference/raspberry-pi/) (or a

--- a/docs/best-single-board-computer-for-gophertrunk.md
+++ b/docs/best-single-board-computer-for-gophertrunk.md
@@ -1,0 +1,126 @@
+---
+layout: page
+title: "Best Single-Board Computer for GopherTrunk (2026)"
+description: "The best single-board computers for running GopherTrunk 24/7 — Raspberry Pi 5/4/Zero 2 W, Orange Pi 5, Radxa Rock 5B, ODROID, and Le Potato compared for SDR scanning, with Amazon links."
+keywords: best single board computer for SDR, Raspberry Pi SDR scanner, best SBC for GopherTrunk, Raspberry Pi 5 vs Orange Pi 5, Radxa Rock 5B, run scanner on Raspberry Pi, headless SDR
+permalink: /best-single-board-computer-for-gophertrunk/
+nav_group: Hardware
+affiliate: true
+faq:
+  - q: "What is the best single-board computer for GopherTrunk?"
+    a: "A Raspberry Pi 5 (8GB) is the best all-round choice — fast enough for multiple SDRs, low-power for 24/7 use, and the best-documented Linux SBC. A Raspberry Pi 4 (4GB) is the value pick, and a Pi Zero 2 W works for a single control channel on a tight budget."
+  - q: "Can a Raspberry Pi run GopherTrunk?"
+    a: "Yes. GopherTrunk is pure-Go and ships ARM/ARM64 builds, so it runs on a Raspberry Pi 4 or 5 (and most Linux SBCs) with no vendor toolchain. A Pi is the standard way to run GopherTrunk headless, 24/7, next to the antenna, and reach it from the web console."
+  - q: "How powerful an SBC do I need?"
+    a: "Following one trunked system with one RTL-SDR is light work — even a Pi Zero 2 W or Le Potato can do it. For a multi-SDR pool or wideband channelizing of several control channels, use a Pi 5 or an RK3588 board (Orange Pi 5, Radxa Rock 5B) with more RAM and CPU."
+  - q: "Is an NVIDIA Jetson worth it for GopherTrunk?"
+    a: "No. GopherTrunk uses only the CPU — it has no CUDA/GPU workload — so a Jetson's expensive GPU sits idle. Buy a Raspberry Pi unless you already want the Jetson for AI projects."
+  - q: "Do I need a computer at all, or just the SBC?"
+    a: "The SBC is the computer. Add an SDR dongle, an antenna, and an SD card, and it's a complete standalone GopherTrunk scanner. See the full what-you-need checklist."
+  - q: "Does the SBC change what I can decode?"
+    a: "No. The host only runs the software — decoding is identical to a laptop or desktop. And no host, however powerful, can decode AES-encrypted talkgroups; that limit is cryptographic, not computational."
+---
+
+# Best Single-Board Computer for GopherTrunk
+
+**The best single-board computer for GopherTrunk is a [Raspberry Pi 5](/reference/raspberry-pi/)** —
+it's fast enough for several SDRs, sips power for 24/7 use, and has the deepest Linux
+support of any SBC. Because GopherTrunk is [pure Go](/downloads.html) with ARM/ARM64
+builds, it runs on almost any Linux board with a USB port, so a low-cost SBC makes a
+perfect always-on, headless scanner beside the antenna.
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Best overall:** [Raspberry Pi 5](/reference/raspberry-pi/) (8GB, ~$80). **Best value:**
+[Raspberry Pi 4](/reference/raspberry-pi/) (4GB, ~$55). **Cheapest / tiny:**
+[Pi Zero 2 W](/reference/raspberry-pi/) (~$18, one channel). **Most power (multi-SDR):**
+[Orange Pi 5](/reference/orange-pi/) / [Radxa Rock 5B](/reference/rock-pi/) (RK3588).
+**Skip** the [Jetson](/reference/nvidia-jetson/) — GopherTrunk doesn't use its GPU. Add an
+[SDR](/best-sdr-for-gophertrunk/) + [antenna](/best-sdr-antenna/) and it's a complete
+scanner. **No host decodes [AES encryption](/police-scanner-encryption/).**
+</div>
+
+## Quick picks
+
+<div class="pick-cards" markdown="0">
+<div class="pick-card pick-card--top">
+<span class="pick-card__badge">Best overall</span>
+<h3>Raspberry Pi 5 (8GB)</h3>
+<p class="pick-card__price">around $80</p>
+<p>Fast quad-core, PCIe for NVMe, low-power. Handles multiple SDRs and runs GopherTrunk headless 24/7 with the best community support.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0CK2FCG1K?tag=gophertrunk-20" rel="nofollow sponsored noopener">Pi 5 on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/raspberry-pi/">Raspberry Pi details</a> · <a href="/raspberry-pi-sdr-scanner/">Pi setup guide</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Best value</span>
+<h3>Raspberry Pi 4 (4GB)</h3>
+<p class="pick-card__price">around $55</p>
+<p>More than enough for one or two SDRs, huge community, cheap. The safe default if the Pi 5 is out of budget.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B09TTNF8BT?tag=gophertrunk-20" rel="nofollow sponsored noopener">Pi 4 on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/raspberry-pi/">Raspberry Pi details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Most power</span>
+<h3>Orange Pi 5 / Radxa Rock 5B</h3>
+<p class="pick-card__price">around $90–150</p>
+<p>RK3588-class boards for a multi-SDR pool or wideband channelizing. Less turnkey OS than Raspberry Pi OS, but a lot of horsepower.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0BN15SS83?tag=gophertrunk-20" rel="nofollow sponsored noopener">Orange Pi 5 on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/orange-pi/">Orange Pi</a> · <a href="/reference/rock-pi/">Rock 5B</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Cheapest</span>
+<h3>Pi Zero 2 W / Le Potato</h3>
+<p class="pick-card__price">around $18–35</p>
+<p>Enough to follow a single control channel with one RTL-SDR. RAM/CPU-limited — not for wideband or multi-SDR.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/s?k=Raspberry+Pi+Zero+2+W&tag=gophertrunk-20" rel="nofollow sponsored noopener">Pi Zero 2 W on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/libre-computer/">Le Potato</a></p>
+</div>
+</div>
+
+## Full comparison
+
+| Board | CPU / RAM | Power | Best for | Approx price |
+|---|---|---|---|---|
+| [Raspberry Pi 5](/reference/raspberry-pi/) | Quad A76 / up to 8GB | Low | Best all-round; multi-SDR | ~$80 |
+| [Raspberry Pi 4](/reference/raspberry-pi/) | Quad A72 / up to 8GB | Low | Value; 1–2 SDRs | ~$55 |
+| [Pi Zero 2 W](/reference/raspberry-pi/) | Quad A53 / 512MB | Tiny | One control channel | ~$18 |
+| [Orange Pi 5](/reference/orange-pi/) | RK3588S / up to 16GB | Med | Multi-SDR / wideband | ~$90 |
+| [Radxa Rock 5B](/reference/rock-pi/) | RK3588 / up to 16GB | Med | Fastest; PCIe/NVMe | ~$150 |
+| [ODROID-N2+](/reference/odroid/) | A73+A53 / up to 4GB | Low | Well-supported Pi alt | ~$110 |
+| [Banana Pi BPI-M7](/reference/banana-pi/) | RK3588 / up to 16GB | Med | Capable RK3588 | ~$180 |
+| [Le Potato](/reference/libre-computer/) | Quad A53 / up to 2GB | Low | Cheapest Pi alt | ~$35 |
+| [NVIDIA Jetson Orin Nano](/reference/nvidia-jetson/) | A78AE + GPU | Med | Overkill (GPU unused) | ~$250 |
+
+> **GopherTrunk is CPU-only.** It never touches a GPU or NPU, so an AI board's
+> accelerator is wasted on scanning. Spend on RAM and CPU cores if you'll run a
+> [multi-SDR pool](/multi-dongle-sdr-setup/), not on a Jetson.
+
+## How to choose
+
+- **Want the easy, best-supported path?** [Raspberry Pi 5](/reference/raspberry-pi/) (or a
+  Pi 4 to save money). Raspberry Pi OS + the huge community make setup painless.
+- **Running many SDRs or [wideband multi-site](/multi-dongle-sdr-setup/)?** An RK3588 board
+  — [Orange Pi 5](/reference/orange-pi/) or [Radxa Rock 5B](/reference/rock-pi/) — has the
+  cores and RAM headroom.
+- **Tiny budget / one channel?** A [Pi Zero 2 W](/reference/raspberry-pi/) or
+  [Le Potato](/reference/libre-computer/) will follow a single trunked system.
+- **Already own a board?** If it runs Linux and has a USB port, GopherTrunk almost
+  certainly runs on it — [download an ARM build](/downloads.html) and try it.
+
+## Turn it into a scanner
+
+An SBC is only the host. Add an **[SDR dongle](/best-sdr-for-gophertrunk/)**, an
+**[antenna](/best-sdr-antenna/)**, an SD card, and power, and you have a complete
+standalone GopherTrunk scanner you can leave running by the window. The full parts list
+is in [what hardware do I need](/what-do-i-need-for-gophertrunk/), and the step-by-step is
+in [run GopherTrunk on a Raspberry Pi](/raspberry-pi-sdr-scanner/).
+
+## Bottom line
+
+For almost everyone, a **[Raspberry Pi 5](/reference/raspberry-pi/)** (or a Pi 4 on a
+budget) is the best single-board computer for GopherTrunk — cheap, low-power, and
+endlessly documented. Reach for an [RK3588 board](/reference/rock-pi/) only if you're
+driving several SDRs at once, and skip the [Jetson](/reference/nvidia-jetson/) unless its
+GPU is for something else. The host never changes the
+[encryption](/police-scanner-encryption/) wall — so buy the cheapest board that fits your
+channel count.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -79,6 +79,7 @@ The receivers, antennas, cables, and accessories to run GopherTrunk, with honest
 - [Run GopherTrunk on a Raspberry Pi]({{ '/raspberry-pi-sdr-scanner/' | absolute_url }}): 24/7 headless decoding.
 - [Best SDR for P25 trunking]({{ '/best-sdr-for-p25-trunking/' | absolute_url }}) and [multi-dongle setups]({{ '/multi-dongle-sdr-setup/' | absolute_url }}): single-site vs wideband multi-site.
 - [Cheapest way to scan digital radio]({{ '/cheap-sdr-scanner/' | absolute_url }}): a $30 SDR beats a $380 digital scanner.
+- [Best single-board computer for GopherTrunk]({{ '/best-single-board-computer-for-gophertrunk/' | absolute_url }}): Raspberry Pi 5/4/Zero 2 W, Orange Pi 5, Radxa Rock 5B, ODROID, and Le Potato compared as GopherTrunk hosts.
 
 ## Technical docs
 - [Architecture]({{ '/architecture.html' | absolute_url }}): how the engine is built.

--- a/docs/reference/banana-pi.md
+++ b/docs/reference/banana-pi.md
@@ -5,17 +5,35 @@ entry_type: hardware
 category: hw-sbc
 description: Banana Pi is a brand of single-board computers in the Raspberry Pi mould, notable early on for onboard SATA and gigabit Ethernet, and later for a wide range of ARM and RISC-V boards.
 keywords: Banana Pi, SATA SBC, Allwinner, gigabit Ethernet, Raspberry Pi alternative, RISC-V board, ARM single-board computer, onboard storage
+affiliate: true
+product:
+  name: "Banana Pi BPI-M7 (RK3588)"
+  brand: Banana Pi
+  category: Single-board computer
+  lowPrice: "160"
+  highPrice: "200"
+  url: https://www.amazon.com/dp/B0CXF3D84W?tag=gophertrunk-20
 infobox:
   - { label: Type, value: Single-board computer }
   - { label: CPU, value: ARM (Allwinner / others), some RISC-V }
   - { label: Runs, value: Linux / Android }
   - { label: Noted for, value: Onboard SATA, gigabit Ethernet }
   - { label: Typical price, value: ~$25 – $100 }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B0CXF3D84W?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
 see_also: [raspberry-pi, single-board-computer, orange-pi, odroid, rock-pi, risc-v]
 related_lessons:
   - { title: "Raspberry Pi and family", url: /learn/intro-hardware/raspberry-pi-and-family/ }
 cite_urls:
   - https://en.wikipedia.org/wiki/Banana_Pi
+faq:
+  - q: "Can I run GopherTrunk on a Banana Pi BPI-M7?"
+    a: "Yes. GopherTrunk is pure Go and cross-compiles to ARM64, so it runs on any Linux SBC with a USB port — no vendor toolchain. The BPI-M7's RK3588 is a capable chip with plenty of power for a multi-SDR or wideband GopherTrunk node; its onboard storage and networking also suit a node that both captures and serves decoded data."
+  - q: "How does the BPI-M7 compare to a Raspberry Pi?"
+    a: "The RK3588 in the BPI-M7 is considerably more powerful than a Pi, but Banana Pi's Linux support varies model to model and is generally less polished than Raspberry Pi OS. For a simple, well-documented build a Raspberry Pi is the default; choose the BPI-M7 when you want the RK3588's extra muscle and don't mind more setup."
+  - q: "Does the RK3588 help with encrypted channels?"
+    a: "No. No SBC changes the encryption wall — GopherTrunk cannot decode AES-protected traffic on any host. More power only lets you decode more unencrypted channels at once."
+  - q: "Which OS should I use?"
+    a: "Any 64-bit Linux with a working RK3588 image, since GopherTrunk ships as a static ARM64 binary. Check how mature the specific board's vendor image and kernel are before committing — it's the main variable with Banana Pi boards."
 ---
 
 **Banana Pi** is a brand of [single-board computers](/reference/single-board-computer/) in the [Raspberry Pi](/reference/raspberry-pi/) mould — an early Pi alternative that stood out for onboard SATA and gigabit Ethernet.[^wiki]
@@ -52,6 +70,18 @@ cite_urls:
 <figcaption>The early Banana Pi's calling cards were a real SATA data port (plus its power header) and a gigabit Ethernet jack on a Pi-sized board — enough to build a small file server or storage-backed node without a USB disk adapter.</figcaption>
 </figure>
 
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**A capable RK3588 board.** The Banana Pi BPI-M7 (RK3588, ~$180) has plenty of power for a
+multi-SDR or wideband GopherTrunk node, plus the line's traditional strengths in onboard
+storage and wired networking. GopherTrunk runs on it as a pure-Go ARM64 binary. The usual
+caveat applies: **Banana Pi's Linux support is less polished than Raspberry Pi OS** and
+varies by model, so expect more setup. For a simple, well-supported build, a
+[Raspberry Pi](/reference/raspberry-pi/) is the cheaper default. No SBC decodes
+[AES encryption](/police-scanner-encryption/). Compare on
+[best SBC for GopherTrunk](/best-single-board-computer-for-gophertrunk/).
+</div>
+
 ## Overview
 
 The first Banana Pi boards matched the Pi's size and 40-pin [GPIO](/reference/gpio/) header but added a SATA port and gigabit networking, making them attractive for small file servers and network-attached storage. Where a stock Pi of the era had to hang a disk off USB, a Banana Pi could drive a 2.5-inch drive natively, and its faster Ethernet moved data off the board without bottlenecking.
@@ -72,6 +102,35 @@ Banana Pi is best understood as one of several Pi-alternative brands, each with 
 ## Where it fits
 
 Banana Pi sits among the Pi alternatives — [Orange Pi](/reference/orange-pi/), [ODROID](/reference/odroid/), [Rock Pi](/reference/rock-pi/) — and is worth a look when you want a disk and wired networking on one cheap board. For a GopherTrunk setup that both captures and serves decoded data, the built-in SATA can host the storage locally without a USB adapter hanging off the board, and gigabit Ethernet keeps recorded IQ or a growing call archive moving to a collector without saturating the link.
+
+## Running GopherTrunk on the Banana Pi M7
+
+The BPI-M7 pairs the same RK3588 as the higher-end alternatives with strong onboard storage
+and fast networking, making it a capable host for a busy, storage-backed GopherTrunk node:
+
+- **Architecture** — the RK3588 is ARM64 (aarch64), so the standard static `linux/arm64` GopherTrunk binary from the [downloads page](/downloads.html) runs as-is, no vendor toolchain.
+- **CPU** — the 8-core RK3588 (4× Cortex-A76 up to 2.4 GHz + 4× Cortex-A55) has ample real-time DSP power for a multi-SDR pool or [wideband channelizing](/reference/software-defined-radio/), far beyond a single control channel.
+- **RAM** — up to 16 GB, room for large recording buffers, the web console, and many systems decoded at once.
+- **USB** — USB 3.0 ports (plus USB-C) carry several SDR dongles with bandwidth for wideband Airspy capture; use a powered hub for a bank of [dongles](/multi-dongle-sdr-setup/).
+- **Storage** — an M.2 [NVMe](/reference/nvme/) slot over PCIe plus onboard eMMC, so continuous IQ recording and the call database run on fast storage instead of a wear-prone SD card.
+- **Power / thermals** — like every RK3588 board it runs hot under sustained load, so a heatsink and fan are needed for a dependable 24/7 node; draw is otherwise modest.
+- **OS / networking** — any 64-bit Linux with an RK3588 image (Banana Pi's Debian/Ubuntu builds or Armbian), less polished than Raspberry Pi OS. The standout for GopherTrunk is networking: 2.5 GbE (plus gigabit and Wi-Fi) keeps recorded IQ and a growing archive moving to a collector and serves the [web console](/what-do-i-need-for-gophertrunk/) headless without saturating the link.
+
+**Bottom line:** a Banana Pi M7 comfortably runs a wideband, multi-SDR GopherTrunk pool with
+local recording and fast networking — given a heatsink/fan and a bit more OS setup than a Pi.
+
+## Where to buy
+
+The Banana Pi BPI-M7 is a capable RK3588 board worth a look when you want that chip's power
+for a multi-SDR GopherTrunk node with onboard storage and networking, and don't mind more
+setup than a Pi. If you'd rather it just work, a [Raspberry Pi](/reference/raspberry-pi/) is
+the default recommendation — see
+[best single-board computer for GopherTrunk](/best-single-board-computer-for-gophertrunk/).
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0CXF3D84W?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+*As an Amazon Associate, GopherTrunk earns from qualifying purchases — at no extra cost
+to you. It never changes what we recommend.*
 
 ## Sources
 

--- a/docs/reference/beaglebone.md
+++ b/docs/reference/beaglebone.md
@@ -6,6 +6,14 @@ category: hw-sbc
 description: BeagleBone is an open-source single-board computer known for strong real-time I/O, with many GPIO pins and onboard programmable real-time units, favored for industrial control.
 keywords: BeagleBone, BeagleBone Black, PRU, programmable real-time unit, real-time I/O, industrial control, open-source SBC, GPIO, deterministic timing
 autolink: true
+affiliate: true
+product:
+  name: "BeagleBone Black"
+  brand: BeagleBoard.org
+  category: Single-board computer
+  lowPrice: "62"
+  highPrice: "78"
+  url: https://www.amazon.com/s?k=BeagleBone+Black&tag=gophertrunk-20
 infobox:
   - { label: Type, value: Single-board computer }
   - { label: CPU, value: ARM (TI SoC) + PRUs }
@@ -13,12 +21,22 @@ infobox:
   - { label: Runs, value: Linux }
   - { label: Noted for, value: Real-time I/O, dual expansion headers }
   - { label: Typical price, value: ~$50 – $150 }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/s?k=BeagleBone+Black&tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
 see_also: [single-board-computer, gpio, raspberry-pi, nvidia-jetson, input-output, microcontroller]
 related_lessons:
   - { title: "Raspberry Pi and family", url: /learn/intro-hardware/raspberry-pi-and-family/ }
   - { title: "SBC use cases and limits", url: /learn/intro-hardware/sbc-use-cases-and-limits/ }
 cite_urls:
   - https://en.wikipedia.org/wiki/BeagleBoard#BeagleBone
+faq:
+  - q: "Can I run GopherTrunk on a BeagleBone Black?"
+    a: "Yes. GopherTrunk is pure Go and cross-compiles to ARM, so it runs on the BeagleBone's Linux with a USB port for your SDR — no vendor toolchain. It's older, weaker hardware, though, so treat it as a host for a single decoder rather than a multi-SDR pool or wideband work."
+  - q: "Is the BeagleBone a good choice for GopherTrunk?"
+    a: "Only situationally. Its strength is deterministic real-time I/O via the PRUs — great for the jobs around a capture node (PPS/GPS timing, antenna-relay switching, driving a rotator) but not for raw decode throughput. For the decode host itself, a Raspberry Pi is faster, cheaper, and better documented, and is the default recommendation."
+  - q: "Do the PRUs help decode faster?"
+    a: "No — GopherTrunk's decoders run on the ARM CPU, not the PRUs. The PRUs are for cycle-accurate pin timing around the node, not signal decoding. And no SBC changes the encryption wall: GopherTrunk cannot decode AES-protected traffic on any host."
+  - q: "Is it powerful enough for busy trunked systems?"
+    a: "It can handle a single decoder, but its older CPU will struggle with several busy systems at once or with wideband capture. Step up to a Raspberry Pi 4/5 or an RK3588 board for those."
 ---
 
 **BeagleBone** is an open-source [single-board computer](/reference/single-board-computer/) known for strong real-time I/O — many [GPIO](/reference/gpio/) pins and onboard programmable real-time units (PRUs).[^wiki]
@@ -52,6 +70,18 @@ cite_urls:
 <figcaption>Beyond the Linux-running ARM CPU, a BeagleBone carries two programmable real-time units on the same chip; because they run outside the OS scheduler, they can bit-bang protocols and sample inputs with cycle-accurate timing across the board's two long expansion headers.</figcaption>
 </figure>
 
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Older/weaker — fine for one decoder.** The BeagleBone Black (~$70) is an aging board whose
+real strength is deterministic real-time I/O (its PRUs) rather than decode throughput.
+GopherTrunk runs on it as a pure-Go ARM binary and it can host a single decoder, but it's
+**not for multi-SDR or wideband** work. Its PRUs suit the jobs *around* a node — PPS/GPS
+timing, relay switching, a rotator. For the decode host itself, a
+[Raspberry Pi](/reference/raspberry-pi/) is faster, cheaper, and the default pick. No SBC
+decodes [AES encryption](/police-scanner-encryption/). See
+[best SBC for GopherTrunk](/best-single-board-computer-for-gophertrunk/).
+</div>
+
 ## Overview
 
 The PRUs are small, deterministic processors alongside the main ARM CPU, which lets a BeagleBone handle precise, timing-critical signalling that a general-purpose Linux board struggles with. On an ordinary SBC the OS scheduler can preempt your code at any moment, so software-driven waveforms jitter; a PRU runs a tight loop with no operating system underneath it, so its timing is repeatable to the clock cycle.
@@ -72,6 +102,37 @@ The split of duties between the Linux CPU and the PRUs is the whole point of the
 ## Where it fits
 
 The BeagleBone is the SBC alternative to the [Raspberry Pi](/reference/raspberry-pi/) when [I/O](/reference/input-output/) and determinism matter more than raw cost or community size. For general-purpose use a Pi is simpler and cheaper; for GPU work at the edge see the [NVIDIA Jetson](/reference/nvidia-jetson/). In a GopherTrunk context the BeagleBone is rarely the decode host itself, but its real-time pins suit the jobs *around* a capture node — precise PPS/GPS timing, antenna-relay switching, or driving a rotator — where jitter would otherwise creep in.
+
+## Running GopherTrunk on the BeagleBone Black
+
+The BeagleBone Black *can* host GopherTrunk, but it's the weakest board here — an older,
+single-core, 32-bit design. Be realistic about what that supports:
+
+- **Architecture** — unlike the ARM64 boards, the BeagleBone Black is 32-bit ARMv7 (a TI Sitara AM3358). GopherTrunk ships a static `linux/arm` (ARMv7) Go binary for exactly this case — grab it from the [downloads page](/downloads.html); no vendor toolchain needed.
+- **CPU** — a single Cortex-A8 core at 1 GHz. That's enough for the light real-time DSP of one RTL-SDR control channel, but it has no headroom for a second busy channel, a multi-SDR pool, or [wideband channelizing](/reference/software-defined-radio/).
+- **RAM** — 512 MB, sufficient for a single channel plus light logging, but not for large recording buffers or many concurrent systems.
+- **USB** — one USB 2.0 host port, so it's a single-dongle board in practice; ~2.4 MS/s from an RTL-SDR is well within USB 2.0, but wideband Airspy capture is not a good fit. A powered hub is needed for anything beyond one dongle — see [multi-dongle setups](/multi-dongle-sdr-setup/).
+- **Storage** — 4 GB onboard eMMC plus microSD, adequate for logs and a small call database; avoid continuous IQ recording to the SD card.
+- **Power / thermals** — very low draw and fanless, so it's happy running 24/7 as a small dedicated node.
+- **OS / networking** — its Debian-based 32-bit Linux image is well supported; 10/100 Ethernet on board (no Wi-Fi) is enough for the headless [web console](/what-do-i-need-for-gophertrunk/) and one system's traffic.
+
+**Bottom line:** a BeagleBone Black comfortably runs a single, light control channel — and is
+often more valuable running the real-time timing and switching jobs *around* a node than as
+the decode host itself. For a busier build, a [Raspberry Pi](/reference/raspberry-pi/) is the
+better choice.
+
+## Where to buy
+
+The BeagleBone Black is worth it mainly if you value its real-time PRUs for the timing and
+switching jobs around a capture node, and are content running a single decoder on older
+hardware. For the decode host itself, a [Raspberry Pi](/reference/raspberry-pi/) is faster,
+cheaper, and better documented — the default recommendation. See
+[best single-board computer for GopherTrunk](/best-single-board-computer-for-gophertrunk/).
+
+<a class="btn btn--buy" href="https://www.amazon.com/s?k=BeagleBone+Black&tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+*As an Amazon Associate, GopherTrunk earns from qualifying purchases — at no extra cost
+to you. It never changes what we recommend.*
 
 ## Sources
 

--- a/docs/reference/compute-module.md
+++ b/docs/reference/compute-module.md
@@ -6,17 +6,35 @@ category: hw-sbc
 description: A Compute Module is a single-board computer stripped to a small module without ports, designed to be soldered or socketed into a custom carrier board for embedded products.
 keywords: Raspberry Pi Compute Module, CM4, CM5, SO-DIMM module, carrier board, system on module, embedded SBC, custom carrier
 aka: [Raspberry Pi Compute Module, CM4]
+affiliate: true
+product:
+  name: "Raspberry Pi Compute Module (CM4/CM5)"
+  brand: Raspberry Pi
+  category: Single-board computer
+  lowPrice: "48"
+  highPrice: "62"
+  url: https://www.amazon.com/s?k=Raspberry+Pi+Compute+Module+4&tag=gophertrunk-20
 infobox:
   - { label: Type, value: Embeddable SBC module }
   - { label: Form, value: SO-DIMM or board-to-board }
   - { label: Needs, value: A custom carrier board }
   - { label: Runs, value: Linux }
   - { label: Best-known, value: Raspberry Pi CM4 / CM5 }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/s?k=Raspberry+Pi+Compute+Module+4&tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
 see_also: [raspberry-pi, single-board-computer, system-on-a-chip, hat-add-on-board, gpio, embedded-system]
 related_lessons:
   - { title: "Raspberry Pi and family", url: /learn/intro-hardware/raspberry-pi-and-family/ }
 cite_urls:
   - https://en.wikipedia.org/wiki/Raspberry_Pi#Compute_Module
+faq:
+  - q: "Can I run GopherTrunk on a Compute Module?"
+    a: "Yes — a CM4/CM5 runs the same Raspberry Pi OS and the same pure-Go ARM64 GopherTrunk binary as a full Pi. The catch is that a Compute Module is just the module: it needs a carrier board to expose USB, Ethernet, and power before you can plug in an SDR. For most builds, a standard Raspberry Pi is far simpler and the default recommendation."
+  - q: "Do I need a carrier board?"
+    a: "Yes. A Compute Module has no ports of its own — it mates through an edge connector into a carrier board that provides USB, Ethernet, GPIO, and power. You either buy an off-the-shelf carrier or design your own, which is the whole reason to choose a module over a stock board."
+  - q: "When is a Compute Module the right choice for GopherTrunk?"
+    a: "Only when you're building a custom, embedded capture node — a sealed, antenna-mounted product with exactly the connectors it needs — and the engineering effort pays off at volume. For a normal home or hobby setup, a full Raspberry Pi is cheaper and much less work."
+  - q: "Does it decode anything a full Pi can't?"
+    a: "No. A CM4/CM5 is the same silicon as the matching Pi, so it decodes exactly the same signals — and no SBC changes the encryption wall: GopherTrunk cannot decode AES-protected traffic on any host."
 ---
 
 **A Compute Module** is a [single-board computer](/reference/single-board-computer/) stripped down to a small module — the processor, memory, and storage — without the usual ports, meant to plug into a custom carrier board.[^wiki]
@@ -50,6 +68,18 @@ cite_urls:
 <figcaption>A Compute Module holds only the brains — SoC, RAM, and storage — and mates through an edge connector into a carrier board that the product designer lays out with exactly the ports and shape the product requires.</figcaption>
 </figure>
 
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**A module — it needs a carrier board.** The Raspberry Pi Compute Module (CM4/CM5, ~$55) is
+the same silicon as a full Pi but with no ports of its own: it plugs into a
+[carrier board](/reference/hat-add-on-board/) that provides USB, Ethernet, and power. It runs
+the same pure-Go ARM64 GopherTrunk binary, but it's aimed at **custom, embedded capture
+nodes** built at volume, not everyday setups. For a normal build, a full
+[Raspberry Pi](/reference/raspberry-pi/) is far simpler and the default recommendation. No
+SBC decodes [AES encryption](/police-scanner-encryption/). Compare on
+[best SBC for GopherTrunk](/best-single-board-computer-for-gophertrunk/).
+</div>
+
 ## Overview
 
 The best-known example is the Raspberry Pi Compute Module (CM4, CM5), but the idea is general: take the [system on a chip](/reference/system-on-a-chip/) and memory of a board like the [Raspberry Pi](/reference/raspberry-pi/) and put it on a compact module that breaks all of its signals out to an edge connector. A product designer then lays out a *carrier board* that routes the [GPIO](/reference/gpio/), USB, Ethernet, and power exactly as the product needs, rather than working around a fixed consumer layout.
@@ -69,6 +99,37 @@ This separation lets one well-supported compute module serve many different prod
 ## Where it fits
 
 A Compute Module is the choice when an [embedded system](/reference/embedded-system/) needs the brains of an SBC but its own enclosure, connectors, and shape — a step beyond bolting a [HAT](/reference/hat-add-on-board/) onto a stock board. In a GopherTrunk-style product, a Compute Module on a custom carrier could host the SDR front end, timing, and storage in a sealed, antenna-mounted capture node with only the connectors it actually uses. The trade-off is engineering effort: you design, lay out, and manufacture the carrier yourself, which only pays off past a certain volume.
+
+## Running GopherTrunk on a Compute Module
+
+A Compute Module is the same silicon as the matching [Raspberry Pi](/reference/raspberry-pi/),
+so its GopherTrunk abilities equal that Pi's — with the crucial caveat that the module has no
+ports of its own and depends on a carrier board to expose them:
+
+- **Architecture** — the CM4 and CM5 are ARM64 (aarch64), running the same static `linux/arm64` GopherTrunk binary from the [downloads page](/downloads.html) as a full Pi — no vendor toolchain.
+- **CPU** — a CM4 carries the Pi 4's quad Cortex-A72 (1.5 GHz); a CM5 carries the Pi 5's quad Cortex-A76 (2.4 GHz). Real-time DSP capacity is identical to those boards: a couple of channels on the CM4, comfortable multi-channel work on the CM5.
+- **RAM** — the same options as the matching Pi (up to 8 GB on the CM4, up to 16 GB on the CM5), enough for recording, the web console, and several systems.
+- **USB** — the module breaks USB out to the carrier, so the number and speed (USB 2.0 vs 3.0) of ports for your SDR dongle(s) is whatever the carrier board provides — check that it offers USB 3.0 if you plan on wideband Airspy capture or [several dongles](/multi-dongle-sdr-setup/).
+- **Storage** — most modules include onboard eMMC (a "Lite" variant uses microSD on the carrier), and the carrier can route PCIe to an [NVMe](/reference/nvme/) drive for continuous IQ recording and the call database.
+- **Power / thermals** — draw matches the equivalent Pi; a CM5-class module under sustained load wants a heatsink, and cooling is designed into the carrier/enclosure since the module has none.
+- **OS / networking** — runs Raspberry Pi OS (64-bit), the most turnkey Linux for GopherTrunk; Ethernet and Wi-Fi come from the carrier, so a well-chosen carrier gives you the same headless [web console](/what-do-i-need-for-gophertrunk/) access as a stock Pi.
+
+**Bottom line:** a Compute Module runs exactly the workload of the Pi it's based on — a
+couple of SDRs with recording (CM4) up through comfortable multi-channel work (CM5) — once
+it's on a carrier board that supplies the USB, storage, and networking it needs.
+
+## Where to buy
+
+A Compute Module makes sense only for a custom, embedded GopherTrunk build — remember it's a
+*module* and needs a carrier board to expose USB, Ethernet, and power before you can plug in
+an SDR. For a normal setup, a full [Raspberry Pi](/reference/raspberry-pi/) is cheaper, needs
+no carrier, and is the default recommendation — see
+[best single-board computer for GopherTrunk](/best-single-board-computer-for-gophertrunk/).
+
+<a class="btn btn--buy" href="https://www.amazon.com/s?k=Raspberry+Pi+Compute+Module+4&tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+*As an Amazon Associate, GopherTrunk earns from qualifying purchases — at no extra cost
+to you. It never changes what we recommend.*
 
 ## Sources
 

--- a/docs/reference/libre-computer.md
+++ b/docs/reference/libre-computer.md
@@ -3,20 +3,38 @@ slug: libre-computer
 title: Libre Computer
 entry_type: hardware
 category: hw-sbc
-description: Libre Computer is a maker of single-board computers that emphasise open, mainline software support and Raspberry Pi compatibility, with boards such as Le Potato and Renegade built on Amlogic and Rockchip chips.
+description: Libre Computer makes low-cost single-board computers with open, mainline Linux support and Raspberry Pi compatibility, such as Le Potato and Renegade, built on Amlogic and Rockchip chips.
 keywords: Libre Computer, Le Potato, AML-S905X-CC, Renegade, open source SBC, mainline Linux, Raspberry Pi compatible, ARM single-board computer, upstream drivers
+affiliate: true
+product:
+  name: "Libre Computer Le Potato (AML-S905X-CC)"
+  brand: Libre Computer
+  category: Single-board computer
+  lowPrice: "31"
+  highPrice: "39"
+  url: https://www.amazon.com/dp/B074P6BNGZ?tag=gophertrunk-20
 infobox:
   - { label: Type, value: Single-board computer }
   - { label: Emphasis, value: Open, mainline software }
   - { label: CPU, value: ARM (Amlogic / Rockchip) }
   - { label: Runs, value: Mainline Linux, Android }
   - { label: Boards, value: Le Potato, Renegade, others }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B074P6BNGZ?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
 see_also: [raspberry-pi, single-board-computer, orange-pi, odroid, rock-pi, gpio]
 related_lessons:
   - { title: "Raspberry Pi and family", url: /learn/intro-hardware/raspberry-pi-and-family/ }
 cite_urls:
   - https://en.wikipedia.org/wiki/Libre_Computer_Project
   - https://libre.computer/
+faq:
+  - q: "Can I run GopherTrunk on a Le Potato?"
+    a: "Yes. GopherTrunk is pure Go and cross-compiles to ARM64, so it runs on any Linux SBC with a USB port — no vendor toolchain. Le Potato is modest hardware, so treat it as a light single-channel decode node; it's the cheapest Pi alternative and its mainline-Linux support helps an always-on box stay current."
+  - q: "Why choose Le Potato over a Raspberry Pi?"
+    a: "Two reasons: price — it's the cheapest board here at ~$35 — and Libre Computer's focus on mainline (upstream) Linux support, so an always-on node is less likely to be stranded on a frozen vendor image years later. You give up some performance per dollar, and a Raspberry Pi is still the better-documented default for most builds."
+  - q: "Is it powerful enough for multiple channels?"
+    a: "Not really — it's modest hardware best suited to a light, single-control-channel decoder. For a multi-SDR pool or wideband work, step up to a Raspberry Pi 4/5 or an RK3588 board."
+  - q: "Does it change what can be decoded?"
+    a: "No. No SBC changes the encryption wall — GopherTrunk cannot decode AES-protected traffic on any host. Le Potato decodes exactly what any other Linux host does, just with less headroom."
 ---
 
 **Libre Computer** is a maker of [single-board computers](/reference/single-board-computer/) that emphasise open, mainline software support and broad [Raspberry Pi](/reference/raspberry-pi/) compatibility.[^wiki]
@@ -50,6 +68,18 @@ cite_urls:
 <figcaption>Many cheap boards ship a frozen vendor image with a one-off patch that strands them when the OS moves on; Libre Computer's pitch is upstream support — drivers merged into the mainline Linux kernel so standard, current software keeps running.</figcaption>
 </figure>
 
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The cheapest Pi alternative — fine for light use.** Le Potato (AML-S905X-CC, ~$35) is
+modest hardware, well suited to a light, single-control-channel GopherTrunk decoder.
+GopherTrunk runs on it as a pure-Go ARM64 binary, and Libre Computer's mainline-Linux focus
+helps an always-on node stay patched for years. It's **not for multi-SDR or wideband** work
+— step up to a [Raspberry Pi](/reference/raspberry-pi/) 4/5 for that, which is also the
+better-documented default. No SBC decodes
+[AES encryption](/police-scanner-encryption/). Compare on
+[best SBC for GopherTrunk](/best-single-board-computer-for-gophertrunk/).
+</div>
+
 ## Overview
 
 Boards such as Le Potato (AML-S905X-CC) and the Renegade use Amlogic and Rockchip ARM chips and copy the Pi's footprint and 40-pin [GPIO](/reference/gpio/) header, so existing cases and add-ons often fit. On paper they look like any other Pi alternative — the difference is in how the software is delivered.
@@ -59,6 +89,35 @@ The project's distinguishing goal is upstream support: getting drivers into the 
 ## Where it fits
 
 Among Pi alternatives like [Orange Pi](/reference/orange-pi/), [ODROID](/reference/odroid/), and [Rock Pi](/reference/rock-pi/), Libre Computer's pitch is longevity and trust in the software stack rather than raw specs — you may give up a little performance per dollar in exchange for a board that stays current. For an always-on GopherTrunk capture node you intend to leave in place for years, that trade favours Libre: mainline support means OS and security updates are far less likely to strand the board, so a decode node bolted up near an antenna keeps receiving patches without a risky vendor-image migration.
+
+## Running GopherTrunk on Le Potato
+
+Le Potato is modest, mainline-supported hardware — a good fit for a small, always-on
+single-channel decoder rather than a busy pool. What it brings to a GopherTrunk node:
+
+- **Architecture** — the Amlogic S905X is ARM64 (aarch64), so it runs the standard static `linux/arm64` GopherTrunk binary from the [downloads page](/downloads.html) with no vendor toolchain, and its mainline-kernel support keeps that binary working across OS updates.
+- **CPU** — a quad Cortex-A53 at up to 1.5 GHz handles the light real-time DSP of a single RTL-SDR control channel comfortably, but it will run short for a multi-SDR pool or [wideband channelizing](/reference/software-defined-radio/) — treat it as a one-decoder board.
+- **RAM** — up to 2 GB, which covers one channel plus the web console and modest logging; not the board for large in-memory recording buffers.
+- **USB** — four USB 2.0 ports, fine for one RTL-SDR dongle (~2.4 MS/s is light); there's no USB 3.0, so heavy wideband Airspy capture and multiple busy dongles are out of scope. Use a powered hub for anything beyond a single dongle — see [multi-dongle setups](/multi-dongle-sdr-setup/).
+- **Storage** — microSD plus an optional eMMC module, enough for logs and a modest call database; keep continuous IQ recording off the SD card to avoid wear.
+- **Power / thermals** — very low draw and no cooling required, so it's well suited to a fanless, leave-it-running node.
+- **OS / networking** — Libre Computer ships mainline-based 64-bit Linux images (their Raspbian/Ubuntu builds) so it stays current; Fast (100 Mbps) Ethernet on board, Wi-Fi via a USB adapter, both plenty for the headless [web console](/what-do-i-need-for-gophertrunk/) and one system's traffic.
+
+**Bottom line:** Le Potato comfortably runs a single control channel as a cheap, low-power,
+always-on decoder — step up to a [Raspberry Pi](/reference/raspberry-pi/) for anything busier.
+
+## Where to buy
+
+Le Potato is the budget pick — the cheapest board here — and a fine host for a light,
+single-channel GopherTrunk decoder that you want to leave running for years on mainline
+Linux. For anything busier, or for the smoothest setup, a
+[Raspberry Pi](/reference/raspberry-pi/) is the default recommendation — see
+[best single-board computer for GopherTrunk](/best-single-board-computer-for-gophertrunk/).
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B074P6BNGZ?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+*As an Amazon Associate, GopherTrunk earns from qualifying purchases — at no extra cost
+to you. It never changes what we recommend.*
 
 ## Sources
 

--- a/docs/reference/nvidia-jetson.md
+++ b/docs/reference/nvidia-jetson.md
@@ -6,18 +6,36 @@ category: hw-sbc
 description: NVIDIA Jetson is a family of single-board computers with a powerful onboard GPU, aimed at on-device AI and computer vision such as edge inference and robotics.
 keywords: NVIDIA Jetson, Jetson Nano, Jetson Orin, edge AI, GPU SBC, computer vision, edge inference, robotics, CUDA, JetPack
 autolink: true
+affiliate: true
+product:
+  name: "NVIDIA Jetson Orin Nano"
+  brand: NVIDIA
+  category: Single-board computer
+  lowPrice: "220"
+  highPrice: "280"
+  url: https://www.amazon.com/dp/B0BZJTQ5YP?tag=gophertrunk-20
 infobox:
   - { label: Type, value: Single-board computer (GPU) }
   - { label: CPU, value: ARM + NVIDIA GPU }
   - { label: RAM, value: ~4 GB – 64 GB }
   - { label: Runs, value: Linux (JetPack) }
   - { label: Typical price, value: ~$100 – $2000+ }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B0BZJTQ5YP?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
 see_also: [single-board-computer, raspberry-pi, beaglebone, gpio, central-processing-unit, edge-ai]
 related_lessons:
   - { title: "Raspberry Pi and family", url: /learn/intro-hardware/raspberry-pi-and-family/ }
   - { title: "SBC use cases and limits", url: /learn/intro-hardware/sbc-use-cases-and-limits/ }
 cite_urls:
   - https://en.wikipedia.org/wiki/Nvidia_Jetson
+faq:
+  - q: "Should I buy a Jetson to run GopherTrunk?"
+    a: "No — for plain trunk-following it is overkill. GopherTrunk is pure Go and uses the CPU only; it does not touch CUDA or the Jetson's GPU at all. A ~$55–80 Raspberry Pi decodes exactly the same channels. Buy a Jetson only if you also want its GPU for other work — signal-classification, machine-learning analysis of decoded traffic, or computer vision on the same node."
+  - q: "Does GopherTrunk use the Jetson's GPU or CUDA?"
+    a: "No. GopherTrunk's DSP and decoders run on the ARM CPU. On a Jetson the expensive GPU sits idle during decoding, which is why it is poor value as a dedicated decode host."
+  - q: "Can the Jetson decode encrypted channels a Pi can't?"
+    a: "No. No single-board computer changes the encryption wall — GopherTrunk cannot decode AES-protected traffic on any host, Jetson included. The GPU does not help here."
+  - q: "Will GopherTrunk even install on a Jetson?"
+    a: "Yes — it cross-compiles to ARM64 and runs on the JetPack Linux image with just a USB port for your SDR, no vendor toolchain. It simply won't use most of what you paid for."
 ---
 
 **NVIDIA Jetson** is a family of [single-board computers](/reference/single-board-computer/) with a powerful onboard GPU, aimed at on-device AI and computer vision.[^wiki]
@@ -66,6 +84,19 @@ cite_urls:
 <figcaption>A Jetson pairs a conventional ARM CPU with a large array of GPU cores; frames from a camera are classified by the neural network running across those cores and the result comes straight back on-device, without a cloud round trip.</figcaption>
 </figure>
 
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Overkill for GopherTrunk.** The Jetson Orin Nano (~$250) is a GPU board built for
+[edge AI](/reference/edge-ai/) — but **GopherTrunk uses the CPU only, never CUDA or the
+GPU**, so the pricey silicon sits idle during decoding. A ~$55–80
+[Raspberry Pi](/reference/raspberry-pi/) follows the exact same channels for a fraction of
+the cost. **Buy a Jetson only if you also need the GPU** for signal-classification, ML
+analysis of decoded traffic, or vision on the same node. It runs GopherTrunk fine
+(pure-Go ARM64 binary), but no board — Jetson included — decodes
+[AES encryption](/police-scanner-encryption/). For a decode host, get a
+[Pi](/best-single-board-computer-for-gophertrunk/) instead.
+</div>
+
 ## Overview
 
 Where a general-purpose board leans on its [CPU](/reference/central-processing-unit/), a Jetson pairs an ARM CPU with an NVIDIA GPU so that machine-learning inference can run locally. Neural-network math is overwhelmingly parallel — the same operation across thousands of values — which is precisely what a GPU's many cores are built for, so a model that would crawl on a CPU runs in real time on the Jetson's silicon. This makes it a fit for robotics, cameras, and other edge devices that cannot rely on the cloud.
@@ -85,6 +116,37 @@ Jetsons run Linux through NVIDIA's JetPack distribution, which bundles the CUDA 
 ## Where it fits
 
 A Jetson is more expensive and more power-hungry than a [Raspberry Pi](/reference/raspberry-pi/), so it is the SBC you reach for specifically when you need GPU compute at the edge — [edge AI](/reference/edge-ai/), computer vision, robotics — rather than a general-purpose board. For lighter, always-on roles a Pi is usually the better fit; when real-time I/O matters more than compute, look at the [BeagleBone](/reference/beaglebone/). In a GopherTrunk context a Jetson is overkill for plain decoding, but its GPU could accelerate signal-classification or machine-learning analysis of decoded traffic on the same node.
+
+## Running GopherTrunk on the Jetson Orin Nano
+
+A Jetson runs GopherTrunk perfectly well — it simply does so on its ARM CPU, leaving the
+expensive GPU idle, which is why it's overkill as a dedicated decode host. Concretely:
+
+- **Architecture** — the Orin Nano is ARM64 (aarch64), so it takes the same static `linux/arm64` Go binary as a [Raspberry Pi](/reference/raspberry-pi/) from the [downloads page](/downloads.html). No CUDA build, no vendor toolchain, and GopherTrunk never links against the GPU stack.
+- **CPU** — its 6-core Arm Cortex-A78AE (~1.5 GHz) is more than enough for real-time DSP on a multi-SDR pool — but so is a far cheaper Pi. The GPU that justifies the Jetson's price does no decoding work.
+- **RAM** — the 8 GB shared between CPU and GPU leaves plenty for recording, the web console, and several systems at once; only a fraction is needed for the decode itself.
+- **USB** — USB 3.2 ports handle one or more SDR dongles with bandwidth to spare for wideband Airspy capture; use a powered hub for [several dongles](/multi-dongle-sdr-setup/).
+- **Storage** — microSD plus an M.2 [NVMe](/reference/nvme/) slot, so continuous IQ recording and a large call database can live on fast solid-state storage.
+- **Power / thermals** — considerably more draw than a Pi (roughly 7–25 W depending on power mode) and it ships with an active heatsink-fan; fine for 24/7 but far from the most efficient always-on option.
+- **OS / networking** — runs NVIDIA's JetPack (an Ubuntu-based 64-bit Linux); gigabit Ethernet is on board (Wi-Fi is an M.2 add-in) for reaching the [web console](/what-do-i-need-for-gophertrunk/) headless.
+
+**Bottom line:** the Orin Nano handles the same workload as a Raspberry Pi — a couple of SDRs
+with recording, or a small pool — with the GPU sitting unused; buy it only if that GPU will
+earn its keep on other work.
+
+## Where to buy
+
+Be honest with yourself about why you want one. As a GopherTrunk decode host the Jetson
+Orin Nano is overkill — it runs the decoders on its CPU and leaves the GPU idle, so a
+[Raspberry Pi](/reference/raspberry-pi/) at a quarter of the price does the same job. The
+Jetson earns its keep only if the GPU will do real work alongside decoding. If that's you,
+the Orin Nano developer kit is the sensible entry point; otherwise see
+[best single-board computer for GopherTrunk](/best-single-board-computer-for-gophertrunk/).
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0BZJTQ5YP?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+*As an Amazon Associate, GopherTrunk earns from qualifying purchases — at no extra cost
+to you. It never changes what we recommend.*
 
 ## Sources
 

--- a/docs/reference/odroid.md
+++ b/docs/reference/odroid.md
@@ -5,18 +5,36 @@ entry_type: hardware
 category: hw-sbc
 description: ODROID is a line of single-board computers from Hardkernel of South Korea, known for higher performance than the Raspberry Pi and unusual models such as big.LITTLE and x86 boards.
 keywords: ODROID, Hardkernel, ODROID-N2, ODROID-XU4, Amlogic, big.LITTLE, high-performance SBC, Raspberry Pi alternative, heterogeneous cores
+affiliate: true
+product:
+  name: "ODROID-N2+"
+  brand: Hardkernel
+  category: Single-board computer
+  lowPrice: "100"
+  highPrice: "120"
+  url: https://www.amazon.com/dp/B07WYRBJMX?tag=gophertrunk-20
 infobox:
   - { label: Type, value: Single-board computer }
   - { label: Maker, value: Hardkernel (South Korea) }
   - { label: CPU, value: ARM (Amlogic) or x86 }
   - { label: Runs, value: Linux / Android }
   - { label: Known for, value: Performance per board }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B07WYRBJMX?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
 see_also: [raspberry-pi, single-board-computer, rock-pi, orange-pi, banana-pi, gpio]
 related_lessons:
   - { title: "Raspberry Pi and family", url: /learn/intro-hardware/raspberry-pi-and-family/ }
   - { title: "SBC use cases and limits", url: /learn/intro-hardware/sbc-use-cases-and-limits/ }
 cite_urls:
   - https://en.wikipedia.org/wiki/ODROID
+faq:
+  - q: "Can I run GopherTrunk on an ODROID-N2+?"
+    a: "Yes. GopherTrunk is pure Go and cross-compiles to ARM64, so it runs on any Linux SBC with a USB port — no vendor toolchain. The N2+ is a strong, well-supported board whose extra cores keep the demodulators fed when you're decoding several busy trunked systems at once."
+  - q: "Is an ODROID better than a Raspberry Pi for GopherTrunk?"
+    a: "The ODROID-N2+ gives more CPU and memory bandwidth without jumping into GPU-board prices, which helps a busy multi-system node. But a Raspberry Pi is cheaper, better documented, and the default recommendation for most builds. Pick the ODROID when a Pi runs out of headroom but a Jetson would be overkill."
+  - q: "Does more CPU let it decode encrypted channels?"
+    a: "No. No SBC changes the encryption wall — GopherTrunk cannot decode AES-protected traffic on any host. Extra cores only let you follow more unencrypted channels concurrently."
+  - q: "How well is it supported?"
+    a: "Hardkernel maintains solid Linux images for the N2+, making it one of the better-supported Pi alternatives — though Raspberry Pi OS is still the most turnkey. Any 64-bit Linux works, since GopherTrunk ships as a static ARM64 binary."
 ---
 
 **ODROID** is a line of [single-board computers](/reference/single-board-computer/) from Hardkernel of South Korea, known for offering more performance than the [Raspberry Pi](/reference/raspberry-pi/) and for some unusual designs.[^wiki]
@@ -55,6 +73,18 @@ cite_urls:
 <figcaption>Boards like the ODROID-XU4 use a big.LITTLE layout: a cluster of large high-performance cores paired with a cluster of small efficient ones, letting the scheduler run background work cheaply and burst onto the big cores when load demands.</figcaption>
 </figure>
 
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**A strong, well-supported Pi alternative.** The ODROID-N2+ (~$110) offers more CPU and
+memory bandwidth than a [Raspberry Pi](/reference/raspberry-pi/) without paying for a GPU
+board — good headroom for a node decoding several busy trunked systems at once. GopherTrunk
+runs on it as a pure-Go ARM64 binary, and Hardkernel's images are among the better-supported
+alternatives. For most builds a **Pi is still the cheaper, better-documented default**; step
+up to the ODROID when a Pi runs short but a [Jetson](/reference/nvidia-jetson/) is overkill.
+No SBC decodes [AES encryption](/police-scanner-encryption/). See
+[best SBC for GopherTrunk](/best-single-board-computer-for-gophertrunk/).
+</div>
+
 ## Overview
 
 ODROID boards mostly use Amlogic ARM chips, and over the years the line has included big.LITTLE designs (the ODROID-XU4), strong general-purpose boards (the ODROID-N2+), and even x86 models. The big.LITTLE arrangement pairs a cluster of fast cores with a cluster of efficient ones so the scheduler can keep light background work on the small cores and only spin up the power-hungry cores when a burst of load arrives — more sustained throughput without a proportional jump in power.
@@ -75,6 +105,35 @@ A representative slice of the ODROID line shows the range of designs:
 ## Where it fits
 
 ODROID is the alternative you reach for when a [Raspberry Pi](/reference/raspberry-pi/) is not fast enough but a [Jetson](/reference/nvidia-jetson/) is overkill — more CPU and memory bandwidth without a price jump into GPU territory. It competes with [Rock Pi](/reference/rock-pi/) and [Orange Pi](/reference/orange-pi/). For a GopherTrunk node decoding several busy trunked systems at once, an ODROID's extra cores can keep the demodulators fed where a smaller board would fall behind, and the big.LITTLE scheduling means the board still idles efficiently between bursts of traffic.
+
+## Running GopherTrunk on the ODROID-N2+
+
+The ODROID-N2+ is one of the better-supported Pi alternatives, and its big.LITTLE Amlogic
+chip keeps the demodulators fed where a smaller board would fall behind. For a decode node:
+
+- **Architecture** — the Amlogic S922X is ARM64 (aarch64), so it runs the standard static `linux/arm64` GopherTrunk binary from the [downloads page](/downloads.html) with no vendor toolchain — just plug in an SDR.
+- **CPU** — 6 cores (4× Cortex-A73 up to 2.4 GHz + 2× Cortex-A53) give solid real-time DSP throughput: enough for several busy trunked systems at once, well beyond the single control channel a light board manages, while the little cores handle background work efficiently between bursts.
+- **RAM** — up to 4 GB, which is comfortable for a multi-SDR setup plus the web console and recording; it's the one spec that trails the RK3588 boards, so extremely large in-memory buffering is where you'd feel the ceiling.
+- **USB** — four USB 3.0 ports carry multiple SDR dongles with bandwidth for wideband Airspy capture; use a powered hub when running [several dongles](/multi-dongle-sdr-setup/).
+- **Storage** — microSD plus a fast eMMC module socket, so recordings, logs, and the call database can live on eMMC rather than a slower, wear-prone SD card.
+- **Power / thermals** — low draw for its performance and it ships with a substantial heatsink, so it runs cool and reliably 24/7 without extra cooling.
+- **OS / networking** — any 64-bit Linux with an N2+ image (Ubuntu and Armbian are well maintained by Hardkernel and the community); gigabit Ethernet is on board (Wi-Fi via a USB adapter) for headless operation and the remote [web console](/what-do-i-need-for-gophertrunk/).
+
+**Bottom line:** an ODROID-N2+ comfortably runs several busy systems or a small multi-SDR
+pool with recording — a clear step up from a Pi when you need more decode headroom.
+
+## Where to buy
+
+The ODROID-N2+ is the pick when a [Raspberry Pi](/reference/raspberry-pi/) is running out of
+headroom for a busy multi-system GopherTrunk node but you don't need a GPU board. It is one
+of the better-supported Pi alternatives. If you want the simplest, best-documented path,
+start with a Pi instead — see
+[best single-board computer for GopherTrunk](/best-single-board-computer-for-gophertrunk/).
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B07WYRBJMX?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+*As an Amazon Associate, GopherTrunk earns from qualifying purchases — at no extra cost
+to you. It never changes what we recommend.*
 
 ## Sources
 

--- a/docs/reference/orange-pi.md
+++ b/docs/reference/orange-pi.md
@@ -5,17 +5,35 @@ entry_type: hardware
 category: hw-sbc
 description: Orange Pi is a family of low-cost single-board computers from China that mimic the Raspberry Pi form factor, often offering more cores or ports per dollar with less mature software support.
 keywords: Orange Pi, Allwinner, Rockchip, Raspberry Pi alternative, low-cost SBC, ARM single-board computer, value SBC, vendor image
+affiliate: true
+product:
+  name: "Orange Pi 5 (RK3588S)"
+  brand: Orange Pi
+  category: Single-board computer
+  lowPrice: "80"
+  highPrice: "100"
+  url: https://www.amazon.com/dp/B0BN15SS83?tag=gophertrunk-20
 infobox:
   - { label: Type, value: Single-board computer }
   - { label: Maker, value: Shenzhen Xunlong (China) }
   - { label: CPU, value: ARM (Allwinner / Rockchip) }
   - { label: Runs, value: Linux / Android }
   - { label: Typical price, value: ~$15 – $90 }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B0BN15SS83?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
 see_also: [raspberry-pi, single-board-computer, banana-pi, rock-pi, libre-computer, gpio]
 related_lessons:
   - { title: "Raspberry Pi and family", url: /learn/intro-hardware/raspberry-pi-and-family/ }
 cite_urls:
   - https://en.wikipedia.org/wiki/Orange_Pi
+faq:
+  - q: "Can I run GopherTrunk on an Orange Pi 5?"
+    a: "Yes. GopherTrunk is pure Go and cross-compiles to ARM64, so it runs on any Linux SBC with a USB port — no vendor toolchain. The RK3588S in the Orange Pi 5 is powerful enough for a multi-SDR pool or wideband channelizing. The catch is the OS: Orange Pi's vendor images are less turnkey than Raspberry Pi OS, so expect a bit more setup."
+  - q: "Is the Orange Pi 5 better than a Raspberry Pi for GopherTrunk?"
+    a: "It has more raw horsepower — good when you're decoding several busy systems or channelizing a wide band. But for a straightforward single- or dual-system node, a Raspberry Pi is easier to set up and better documented, and we recommend it as the default. Choose the Orange Pi when you specifically need the extra cores."
+  - q: "Does the extra power let it decode encrypted channels?"
+    a: "No. No SBC changes the encryption wall — GopherTrunk cannot decode AES-protected traffic on any host. More cores only let you follow more unencrypted channels at once."
+  - q: "Which OS should I use?"
+    a: "Any 64-bit Linux with an RK3588S image works, since GopherTrunk ships as a static ARM64 binary. Expect vendor or community images to be less polished than Raspberry Pi OS; pick a well-maintained build to save setup time."
 ---
 
 **Orange Pi** is a family of low-cost [single-board computers](/reference/single-board-computer/) made in China that copy the [Raspberry Pi](/reference/raspberry-pi/) form factor while often packing more cores or ports per dollar.[^wiki]
@@ -40,6 +58,18 @@ cite_urls:
 <figcaption>Orange Pi's bargain is asymmetric: you get more hardware per dollar than a comparable Raspberry Pi, but driver maturity and community support trail it, so the same board can take more effort to bring fully to life.</figcaption>
 </figure>
 
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Powerful, good for multi-SDR — less turnkey OS.** The Orange Pi 5 (RK3588S, ~$90) packs
+plenty of horsepower for a multi-SDR pool or wideband channelizing, and GopherTrunk runs on
+it fine as a pure-Go ARM64 binary. The trade-off is software: **Orange Pi's OS images are
+less turnkey than Raspberry Pi OS**, so expect extra setup. For a simple one- or two-system
+node, a [Raspberry Pi](/reference/raspberry-pi/) is the easier default — reach for the
+Orange Pi when you need the extra cores. No SBC decodes
+[AES encryption](/police-scanner-encryption/). Compare boards on
+[best SBC for GopherTrunk](/best-single-board-computer-for-gophertrunk/).
+</div>
+
 ## Overview
 
 Orange Pi boards are built around Allwinner and Rockchip ARM chips and run Linux or Android. Many keep a Pi-style layout and a compatible 40-pin [GPIO](/reference/gpio/) header, so existing add-ons and cases often fit — the physical compatibility is close enough that swapping an Orange Pi in for a Pi is frequently mechanical, not just electrical.
@@ -59,6 +89,35 @@ The catch is software: drivers and community support are usually less mature tha
 ## Where it fits
 
 Orange Pi sits alongside [Banana Pi](/reference/banana-pi/), [Rock Pi](/reference/rock-pi/), and [Libre Computer](/reference/libre-computer/) as a Raspberry Pi alternative chosen on price or specs. For a GopherTrunk capture node where you control the OS image and just need a cheap Linux box near the antenna, an Orange Pi can be good value — provided you accept the extra setup time over a Pi. It is a natural pick when you are deploying several capture nodes and the per-board saving adds up, and less attractive for a one-off build where the Pi's smooth software would save you an afternoon.
+
+## Running GopherTrunk on the Orange Pi 5
+
+The Orange Pi 5's RK3588S gives GopherTrunk far more real-time headroom than a Pi; the price
+is a less turnkey OS and more heat to manage. What it brings to a decode node:
+
+- **Architecture** — the RK3588S is ARM64 (aarch64), so GopherTrunk runs from the same static `linux/arm64` Go binary on the [downloads page](/downloads.html) — no vendor toolchain needed, just a free USB port.
+- **CPU** — the 8-core RK3588S (4× Cortex-A76 up to 2.4 GHz + 4× Cortex-A55) has the cores and clock for heavy real-time DSP: a multi-SDR pool or [wideband channelizing](/reference/software-defined-radio/) where several demodulators run at once, not just a single control channel.
+- **RAM** — configurations from 4 GB up to 16/32 GB leave generous room for recording, the web console, and following many systems simultaneously.
+- **USB** — USB 3.0 (plus USB-C) ports carry multiple SDR dongles with the bandwidth wideband Airspy capture needs; add a powered hub for [several dongles](/multi-dongle-sdr-setup/).
+- **Storage** — microSD, an eMMC module, and an M.2 [NVMe](/reference/nvme/) slot over PCIe, so continuous IQ recording and a large call database can sit on fast storage rather than a wear-prone SD card.
+- **Power / thermals** — the RK3588S runs hot under sustained decode load; fit a heatsink (and ideally a fan) for a reliable 24/7 node. Draw is still modest for the performance.
+- **OS / networking** — any 64-bit Linux with an RK3588S image works — Orange Pi's own OS, Armbian, or Ubuntu builds — though none is as polished as Raspberry Pi OS. Gigabit Ethernet (and an optional Wi-Fi module) let you run it headless and reach the [web console](/what-do-i-need-for-gophertrunk/) remotely.
+
+**Bottom line:** an Orange Pi 5 comfortably runs a wideband, multi-SDR GopherTrunk pool with
+recording — provided you add cooling and accept a rougher OS setup than a Pi.
+
+## Where to buy
+
+The Orange Pi 5 (RK3588S) is a strong value pick when you want more cores for a multi-SDR
+or wideband GopherTrunk node and don't mind a less polished OS setup. If you'd rather it
+"just work" out of the box, a [Raspberry Pi](/reference/raspberry-pi/) remains the default
+recommendation — see
+[best single-board computer for GopherTrunk](/best-single-board-computer-for-gophertrunk/).
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0BN15SS83?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+*As an Amazon Associate, GopherTrunk earns from qualifying purchases — at no extra cost
+to you. It never changes what we recommend.*
 
 ## Sources
 

--- a/docs/reference/raspberry-pi.md
+++ b/docs/reference/raspberry-pi.md
@@ -6,18 +6,36 @@ category: hw-sbc
 description: Raspberry Pi is a popular, low-cost single-board computer used for learning, hobby projects, home servers, and edge devices, running Linux and programmed in Python, C, or Go.
 keywords: Raspberry Pi, Pi Zero 2 W, Pi 4, Pi 5, Compute Module, HAT, Raspberry Pi OS, single-board computer, 40-pin header, SDR host
 autolink: true
+affiliate: true
+product:
+  name: "Raspberry Pi 5 (8GB)"
+  brand: Raspberry Pi
+  category: Single-board computer
+  lowPrice: "70"
+  highPrice: "90"
+  url: https://www.amazon.com/dp/B0CK2FCG1K?tag=gophertrunk-20
 infobox:
   - { label: Type, value: Single-board computer }
   - { label: CPU, value: ARM (Broadcom SoC) }
   - { label: RAM, value: ~512 MB – 16 GB }
   - { label: Runs, value: Raspberry Pi OS / Linux }
   - { label: Typical price, value: ~$15 – $80 }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B0CK2FCG1K?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
 see_also: [single-board-computer, gpio, nvidia-jetson, beaglebone, home-server, software-defined-radio]
 related_lessons:
   - { title: "Raspberry Pi and family", url: /learn/intro-hardware/raspberry-pi-and-family/ }
   - { title: "What is an SBC?", url: /learn/intro-hardware/what-is-an-sbc/ }
 cite_urls:
   - https://en.wikipedia.org/wiki/Raspberry_Pi
+faq:
+  - q: "Which Raspberry Pi should I run GopherTrunk on?"
+    a: "A Raspberry Pi 4 (4GB) or Pi 5 (8GB) is the recommended, best-supported GopherTrunk host. GopherTrunk is pure Go and cross-compiles to ARM64, so it runs on Raspberry Pi OS with nothing but a USB port for your SDR dongle — no vendor toolchain. The Pi 5 has the most headroom for decoding several channels or a small SDR pool; the Pi 4 is the value pick for one or two systems."
+  - q: "Can a Pi Zero 2 W run GopherTrunk?"
+    a: "For a single control channel, yes — but it is RAM- and CPU-limited, so it is not the board for wideband capture or a multi-SDR pool. Treat the Zero 2 W as a tiny, low-power node for one system and step up to a Pi 4 or Pi 5 for anything busier."
+  - q: "Does a faster Pi let me decode encrypted channels?"
+    a: "No. No single-board computer changes the encryption wall — GopherTrunk (like every scanner) cannot decode AES-protected traffic on any host. A faster Pi only helps you follow more unencrypted channels at once."
+  - q: "Do I need Raspberry Pi OS specifically?"
+    a: "No — any 64-bit Linux for the Pi works, since GopherTrunk ships as a static ARM64 binary. Raspberry Pi OS is simply the most documented and turnkey choice, which is why it is the default recommendation."
 ---
 
 **Raspberry Pi** is the popular, low-cost [single-board computer](/reference/single-board-computer/) that defined the category — used for learning, hobby projects, home servers, and edge devices.[^wiki]
@@ -57,6 +75,20 @@ cite_urls:
 <figcaption>The Raspberry Pi's layout — a 40-pin GPIO header along one edge, a Broadcom SoC and RAM in the middle, and USB, Ethernet, HDMI, power, and a microSD slot around the sides — became the de-facto template that most Pi-compatible boards copy.</figcaption>
 </figure>
 
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The recommended GopherTrunk host.** The Raspberry Pi is the best-documented,
+best-supported [SDR](/reference/software-defined-radio/) capture node — GopherTrunk is
+pure Go and runs as a static ARM64 binary on Raspberry Pi OS with just a USB port for
+your dongle. **A Pi 4 (4GB, ~$55) or Pi 5 (8GB, ~$80) is the mainstream pick;** the Pi 5
+has the most headroom for multiple channels. The **Pi Zero 2 W (~$18)** works for a single
+control channel but is RAM-limited — not for wideband or multi-SDR. Unless you have a
+specific reason for another board, **start with a Pi.** No Pi decodes
+[AES encryption](/police-scanner-encryption/) — no host does. See
+[best SBC for GopherTrunk](/best-single-board-computer-for-gophertrunk/) and the
+[Raspberry Pi SDR scanner guide](/raspberry-pi-sdr-scanner/).
+</div>
+
 ## Overview
 
 The range runs from the tiny Pi Zero 2 W through the Pi 4 and Pi 5 to the [Compute Module](/reference/compute-module/) for embedding in custom hardware. A Raspberry Pi runs Raspberry Pi OS (a Linux distribution) and is programmed in ordinary languages such as [Python](/reference/python-language/), [C](/reference/c-language/), and [Go](/reference/go-language/) — the same tools and workflow as a desktop Linux machine, which is a large part of why it became the default teaching board.
@@ -75,6 +107,42 @@ What sets it apart from a sealed PC is the 40-pin [GPIO](/reference/gpio/) heade
 ## Where it fits
 
 For most projects the Pi is the default choice: cheap, well documented, and broadly supported. A Raspberry Pi by the antenna can run GopherTrunk as a small, low-power [SDR](/reference/software-defined-radio/) capture node, hosting an RTL-SDR or similar dongle and decoding locally while drawing only a few watts — headless, fanless, and easy to leave in place. When you need GPU compute at the edge, the [NVIDIA Jetson](/reference/nvidia-jetson/) is an alternative; when you need stronger real-time I/O, look at the [BeagleBone](/reference/beaglebone/); and when you want more of it as a [home server](/reference/home-server/), the Pi handles that too.
+
+## Running GopherTrunk on a Raspberry Pi
+
+The Raspberry Pi is the reference GopherTrunk host — the combination of capable hardware and
+the most turnkey software makes it the board every setup guide assumes. Here is what each
+part of the Pi brings to a decode node:
+
+- **Architecture** — the Pi 4, Pi 5, Zero 2 W (and the [Compute Modules](/reference/compute-module/)) are all ARM64 (aarch64). GopherTrunk ships as a static ARM64 Go binary you drop on the board and run — no cross-compiler, no vendor toolchain, no SoapySDR. Grab the `linux/arm64` build from the [downloads page](/downloads.html).
+- **CPU** — the Pi 5's quad Cortex-A76 at 2.4 GHz has ample headroom for real-time DSP across several demodulators; the Pi 4's quad Cortex-A72 at 1.8 GHz comfortably handles a couple of channels. The Zero 2 W's quad Cortex-A53 is enough for a single control channel but not for a multi-SDR pool or [wideband channelizing](/reference/software-defined-radio/).
+- **RAM** — the Zero 2 W's 512 MB suits one channel; a Pi 4 or Pi 5 with 4–8 GB has room for recording, the web console, and following several systems at once.
+- **USB** — the Pi 4 and Pi 5 expose two USB 3.0 and two USB 2.0 ports, plenty for one or more SDR dongles; USB 3.0 bandwidth matters for wideband Airspy capture. Run several dongles from a powered hub so the board isn't back-powering them. The Zero 2 W has only a micro-USB (OTG) port, so you'll need an adapter and it's really a single-dongle board. See [running several dongles](/multi-dongle-sdr-setup/).
+- **Storage** — every model boots from microSD; the Pi 4 can add a USB SSD and the Pi 5 a proper [NVMe](/reference/nvme/) drive over its PCIe connector, which is the better choice for continuous IQ recording or a growing call database than a wear-prone SD card.
+- **Power / thermals** — a Pi 4/5 draws only a few watts and is fine 24/7; the Pi 5 runs hot under sustained load, so fit the active cooler for an always-on node. The Zero 2 W sips power and needs no cooling.
+- **OS / networking** — Raspberry Pi OS (64-bit) is the most turnkey Linux for GopherTrunk, with Ubuntu also well supported. The Pi 4/5 have gigabit Ethernet plus Wi-Fi and the Zero 2 W has Wi-Fi, so you can run the board headless by the antenna and reach the [web console](/what-do-i-need-for-gophertrunk/) from your desk.
+
+**Bottom line:** a Pi 4 or Pi 5 comfortably runs a couple of SDRs with recording and the web
+console — the mainstream GopherTrunk build — while a Pi Zero 2 W is a tiny, low-power host
+for a single control channel.
+
+## Where to buy
+
+The Raspberry Pi is the recommended GopherTrunk host, and three models cover almost every
+build. The Pi 4 and Pi 5 are the mainstream picks; the Zero 2 W is a tiny, low-power option
+for a single control channel only. See the
+[Raspberry Pi SDR scanner guide](/raspberry-pi-sdr-scanner/) for a full walkthrough and
+[best single-board computer for GopherTrunk](/best-single-board-computer-for-gophertrunk/)
+to compare the alternatives.
+
+| Model | Best for | Approx. price | Buy |
+|-------|----------|--------------|-----|
+| Raspberry Pi 5 (8GB) | Flagship — most headroom, multiple channels / small SDR pool | ~$80 | <a class="btn btn--buy" href="https://www.amazon.com/dp/B0CK2FCG1K?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a> |
+| Raspberry Pi 4 Model B (4GB) | Value mainstream host, huge community | ~$55 | <a class="btn btn--buy" href="https://www.amazon.com/dp/B09TTNF8BT?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a> |
+| Raspberry Pi Zero 2 W | Tiny/low-power, single control channel only (RAM-limited) | ~$18 | <a class="btn btn--buy" href="https://www.amazon.com/s?k=Raspberry+Pi+Zero+2+W&tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a> |
+
+*As an Amazon Associate, GopherTrunk earns from qualifying purchases — at no extra cost
+to you. It never changes what we recommend.*
 
 ## Sources
 

--- a/docs/reference/rock-pi.md
+++ b/docs/reference/rock-pi.md
@@ -6,17 +6,35 @@ category: hw-sbc
 description: Rock Pi is a family of single-board computers from Radxa of China, built mainly on Rockchip processors and often offering NVMe, faster networking, or more RAM than a comparably priced Raspberry Pi.
 keywords: Rock Pi, Radxa, Rockchip, RK3588, ROCK 5, NVMe SBC, Raspberry Pi alternative, ARM single-board computer, fast storage
 aka: [Radxa Rock]
+affiliate: true
+product:
+  name: "Radxa Rock 5B (RK3588)"
+  brand: Radxa
+  category: Single-board computer
+  lowPrice: "132"
+  highPrice: "168"
+  url: https://www.amazon.com/dp/B0BRL4PCG7?tag=gophertrunk-20
 infobox:
   - { label: Type, value: Single-board computer }
   - { label: Maker, value: Radxa (China) }
   - { label: CPU, value: ARM (Rockchip, e.g. RK3588) }
   - { label: Runs, value: Linux / Android }
   - { label: Known for, value: NVMe, fast I/O, high RAM }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B0BRL4PCG7?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
 see_also: [raspberry-pi, single-board-computer, odroid, orange-pi, banana-pi, nvme]
 related_lessons:
   - { title: "Raspberry Pi and family", url: /learn/intro-hardware/raspberry-pi-and-family/ }
 cite_urls:
   - https://en.wikipedia.org/wiki/Radxa
+faq:
+  - q: "Can I run GopherTrunk on a Rock 5B?"
+    a: "Yes. GopherTrunk is pure Go and cross-compiles to ARM64, so it runs on any Linux SBC with a USB port — no vendor toolchain. The RK3588 Rock 5B is the fastest board here and its PCIe/NVMe storage suits an enthusiast multi-SDR node that also records raw IQ or keeps a large call archive."
+  - q: "Why pick a Rock 5B over a Raspberry Pi for GopherTrunk?"
+    a: "For its I/O and speed: native NVMe over PCIe sustains the write throughput a busy capture-and-archive node generates, where a Pi's microSD card is slow and wears out under continuous writes. The extra cores and RAM also give more room for decoding many channels. For a simpler single-system node, a Raspberry Pi is cheaper and better documented — and remains the default recommendation."
+  - q: "Does its speed help with encrypted channels?"
+    a: "No. No SBC changes the encryption wall — GopherTrunk cannot decode AES-protected traffic on any host. Faster hardware only helps you decode and store more unencrypted channels."
+  - q: "Is the software as polished as a Pi's?"
+    a: "Radxa's images are among the better-supported alternatives, but still trail Raspberry Pi OS. Any 64-bit Linux with an RK3588 image works, since GopherTrunk ships as a static ARM64 binary."
 ---
 
 **Rock Pi** is a family of [single-board computers](/reference/single-board-computer/) from Radxa of China, built mainly on Rockchip chips and often offering faster I/O than a similarly priced [Raspberry Pi](/reference/raspberry-pi/).[^wiki]
@@ -46,6 +64,18 @@ cite_urls:
 <figcaption>The Rock Pi's edge is I/O: an NVMe SSD on a PCIe lane moves data far faster than the microSD card a stock Pi of the same price relies on — the difference that matters when a node records raw IQ or keeps a large archive.</figcaption>
 </figure>
 
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The fastest board here — enthusiast multi-SDR host.** The Radxa Rock 5B (RK3588, ~$150)
+brings PCIe/NVMe storage and 8 fast cores, ideal for a GopherTrunk node that runs a multi-SDR
+pool and records raw IQ or keeps a big call archive — NVMe sustains writes a Pi's microSD
+can't. GopherTrunk runs on it as a pure-Go ARM64 binary; Radxa's images are decent but trail
+Raspberry Pi OS. For a simple single-system build, a
+[Raspberry Pi](/reference/raspberry-pi/) is cheaper and the default pick. No SBC decodes
+[AES encryption](/police-scanner-encryption/). See
+[best SBC for GopherTrunk](/best-single-board-computer-for-gophertrunk/).
+</div>
+
 ## Overview
 
 The line is built around Rockchip SoCs — the powerful RK3588 powers the higher-end ROCK 5 boards — and frequently adds features the Pi lacks at the same price, such as an [NVMe](/reference/nvme/) slot, faster Ethernet, or more RAM. The NVMe slot is the headline: instead of running the whole system off a microSD card, a Rock Pi can boot and store data on a proper solid-state drive over PCIe, which transforms any workload that reads or writes a lot of data.
@@ -65,6 +95,35 @@ Boards run Linux or Android and keep a Pi-style [GPIO](/reference/gpio/) header,
 ## Where it fits
 
 Rock Pi competes with [ODROID](/reference/odroid/), [Orange Pi](/reference/orange-pi/), and [Banana Pi](/reference/banana-pi/), and is a natural pick when fast local storage matters. A GopherTrunk node that records raw IQ or keeps days of decoded calls benefits from NVMe rather than an SD card, which is where a Rock Pi can clearly edge out a stock Pi: SD cards are both slow and prone to wear out under continuous writes, while an NVMe drive sustains the throughput a busy capture-and-archive node generates. The extra RAM and cores also give more headroom for decoding several channels at once.
+
+## Running GopherTrunk on the Rock 5B
+
+The Rock 5B is the fastest board covered here, and its NVMe storage makes it the natural host
+for a GopherTrunk node that both decodes a lot and records a lot. What it offers:
+
+- **Architecture** — the RK3588 is ARM64 (aarch64), so the standard static `linux/arm64` GopherTrunk binary from the [downloads page](/downloads.html) runs directly, no vendor toolchain required.
+- **CPU** — the full 8-core RK3588 (4× Cortex-A76 up to 2.4 GHz + 4× Cortex-A55) has the most real-time DSP headroom of any board here: comfortably a wideband, multi-SDR pool with many demodulators running at once, not just a single channel.
+- **RAM** — 4 GB up to 16/32 GB, ample for large recording buffers, the web console, and following many systems concurrently.
+- **USB** — multiple USB 3.0 ports (plus USB-C) carry several SDR dongles with plenty of bandwidth for wideband Airspy capture; a powered hub keeps a bank of [dongles](/multi-dongle-sdr-setup/) stable.
+- **Storage** — the headline feature: an M.2 [NVMe](/reference/nvme/) slot on PCIe means continuous IQ recording and a growing call database run on a proper SSD, which sustains write throughput a microSD card can't and won't wear out under constant writes. microSD and eMMC are also available for boot.
+- **Power / thermals** — the RK3588 runs hot under sustained decode load, so a heatsink and fan are essential for a 24/7 node; power draw stays modest for the performance.
+- **OS / networking** — any 64-bit Linux with an RK3588 image (Armbian, Radxa's Debian/Ubuntu, DietPi); support is good but trails Raspberry Pi OS. It has 2.5 GbE (and gigabit) plus optional Wi-Fi, so a headless node moves recorded IQ and serves the [web console](/what-do-i-need-for-gophertrunk/) without bottlenecking.
+
+**Bottom line:** a Rock 5B comfortably runs a wideband, multi-site SDR pool with fast NVMe
+recording — the enthusiast build when both decode count and storage throughput matter.
+
+## Where to buy
+
+The Radxa Rock 5B is the enthusiast pick — the fastest board here, with PCIe/NVMe for a
+multi-SDR GopherTrunk node that records raw IQ or archives calls. If you don't need that
+speed or storage, a [Raspberry Pi](/reference/raspberry-pi/) is cheaper, simpler, and the
+default recommendation — see
+[best single-board computer for GopherTrunk](/best-single-board-computer-for-gophertrunk/).
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0BRL4PCG7?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+*As an Amazon Associate, GopherTrunk earns from qualifying purchases — at no extra cost
+to you. It never changes what we recommend.*
 
 ## Sources
 


### PR DESCRIPTION
## Summary

Follow-up to the scanner (#1019) and SDR (#1021) hardware content, both merged. This adds
buyer content for the **single-board computers** that host GopherTrunk, and reorganizes the
now-long **Hardware** nav dropdown so it stays usable. GopherTrunk is a pure-Go binary that
runs on almost any Linux SBC, so readers searching "best Raspberry Pi for a scanner" / "run
GopherTrunk on a Pi" should find an honest, GopherTrunk-specific answer — monetized with the
`gophertrunk-20` Associates tag.

## Changes

- **9 single-board-computer Field Guide articles augmented** (kept all prose; added the
  affiliate pattern): `raspberry-pi`, `nvidia-jetson`, `orange-pi`, `odroid`, `rock-pi`,
  `banana-pi`, `libre-computer`, `beaglebone`, `compute-module`. Each gains `affiliate: true`,
  a `product:` block (Product JSON-LD), an infobox Buy row, a `.tldr` box, a `faq:`, and a
  `## Where to buy` section with an Amazon buy button.
- **Each SBC article gets a board-specific `## Running GopherTrunk on the <board>` section** —
  architecture (static Go ARM64/ARMv7/amd64 binary, no vendor toolchain), CPU→DSP capacity,
  RAM→workload, USB for the dongle(s)/wideband/powered hub, storage, power & thermals
  (RK3588 heat called out), OS/networking for the headless web console, and the concrete
  workload the board comfortably runs (one control channel → any board; multi-SDR/wideband →
  Pi 5 or an RK3588 board).
- **New landing page** `best-single-board-computer-for-gophertrunk` (pick-cards, comparison
  table, FAQPage schema) with a "What GopherTrunk needs from an SBC" requirements section.
- **Hardware nav reorganized** into labeled sections (Start here / Police scanners / SDRs &
  receivers / Antennas & accessories / Computers / Setup). `nav.html` now renders `heading`
  items; CSS styles them and caps the dropdown height (`max-height: min(78vh, 44rem);
  overflow-y: auto`) so the long menu always fits the viewport (reset to static on mobile).
- `llms.txt` lists the new SBC page. No `reference.yml` changes — every SBC slug already
  existed in the `hw-sbc` category.
- Honesty: no host decodes AES encryption; a Jetson's GPU is unused by GopherTrunk (buy a Pi);
  RK3588 boards are less turnkey than Raspberry Pi OS. Every Amazon link carries
  `tag=gophertrunk-20`; every buy button is `rel="nofollow sponsored noopener"`.

## Test plan

Docs-only change (no Go code touched), verified with the repo's docs CI locally:

- [x] `jekyll build -s docs` succeeds
- [x] `check_site_pages.py` — site map check passes
- [x] `check_internal_links.py` — all internal links resolve (incl. the new nav links)
- [x] Built SBC pages emit `Product` + `FAQPage` JSON-LD; nav renders the section headings
- [x] Affiliate audit: 100% `gophertrunk-20`, all buy links `rel="nofollow sponsored noopener"`
- [ ] `make vet test` — n/a (no Go code changed)
- [ ] `make integration` — n/a (no daemon/DSP change)

## Breaking changes

None.

## Docs / CHANGELOG

- [ ] CHANGELOG — n/a (site content only)
- [x] This PR *is* the `docs/` update.

## Linked issues

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMF7oNNhSH6BYKJkSmfcXw

---
_Generated by [Claude Code](https://claude.ai/code/session_01TMF7oNNhSH6BYKJkSmfcXw)_