### PR TITLE
docs: add reusable promo system + first-visit "Star the repo" popup

### DIFF
--- a/docs/_includes/star-popup.html
+++ b/docs/_includes/star-popup.html
@@ -1,0 +1,52 @@
+{%- comment -%}
+  First-visit "Star the repo" promo — the first instance of the promo system
+  (assets/js/promos.js). Rendered site-wide by default.html, hidden until the
+  engine reveals it. The engine shows it ONCE per browser, after the visitor is
+  either 2 minutes in (data-promo-trigger-time) OR a quarter of the way down the
+  page (data-promo-trigger-scroll), whichever comes first. Impressions, closes,
+  and the star click are all reported through the shared metrics module, the
+  same tracking the site's CTAs use.
+
+  To add another pop-up / pop-in / fly-out later, copy this markup shape into a
+  new include with its own data-promo id and variant — no JS changes needed.
+{%- endcomment -%}
+<div class="gt-promo gt-promo--popup" id="gt-promo-star" hidden tabindex="-1"
+     role="dialog" aria-modal="true" aria-labelledby="gt-promo-star-title"
+     aria-describedby="gt-promo-star-body"
+     data-promo="star-repo" data-promo-variant="popup"
+     data-promo-trigger-time="120000" data-promo-trigger-scroll="0.25"
+     data-promo-frequency="once">
+  <div class="gt-promo__backdrop" data-promo-close data-promo-close-method="backdrop"></div>
+  <div class="gt-promo__card" role="document">
+    <button type="button" class="gt-promo__close" aria-label="Close"
+            data-promo-close data-promo-close-method="close_button">&times;</button>
+    <div class="gt-promo__icon" aria-hidden="true">{% include icons/github.svg %}</div>
+    <h2 class="gt-promo__title" id="gt-promo-star-title">Enjoying GopherTrunk? Give it a star ⭐</h2>
+    <p class="gt-promo__body" id="gt-promo-star-body">
+      GopherTrunk is free and open source, built in the open by a tiny team. A
+      GitHub star costs you one click, helps other scanner operators find it, and
+      keeps the project moving. Would you drop one?
+    </p>
+    <div class="gt-promo__actions">
+      {%- comment -%}
+        Official GitHub star widget: buttons.github.io upgrades this anchor into
+        a live iframe that stars in place and shows the count. If the script is
+        blocked, the raw anchor still links to the repo, so the ask degrades
+        gracefully. The branded fallback button below always works and carries
+        the CTA tracking hook.
+      {%- endcomment -%}
+      <a class="github-button" href="https://github.com/MattCheramie/GopherTrunk"
+         data-color-scheme="no-preference: light; light: light; dark: dark;"
+         data-icon="octicon-star" data-size="large" data-show-count="true"
+         aria-label="Star MattCheramie/GopherTrunk on GitHub">Star</a>
+      <a class="btn btn--primary" href="https://github.com/MattCheramie/GopherTrunk"
+         target="_blank" rel="noopener" data-cta-event="cta_star_github">
+        {% include icons/github.svg %}
+        <span>View on GitHub</span>
+      </a>
+    </div>
+    <button type="button" class="gt-promo__later"
+            data-promo-close data-promo-close-method="maybe_later">Maybe later</button>
+  </div>
+</div>
+<script async defer src="https://buttons.github.io/buttons.js"></script>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -9,7 +9,10 @@
     {{ content }}
     {%- include join-cta.html -%}
     {%- include footer.html -%}
+    {%- include star-popup.html -%}
+    <script defer src="{{ '/assets/js/analytics.js' | relative_url }}"></script>
     <script defer src="{{ '/assets/js/site.js' | relative_url }}"></script>
     <script defer src="{{ '/assets/js/autolink.js' | relative_url }}"></script>
+    <script defer src="{{ '/assets/js/promos.js' | relative_url }}"></script>
   </body>
 </html>

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -1800,6 +1800,147 @@ a.category-chip:hover {
   .join-cta__actions .btn { flex: 1 1 auto; justify-content: center; }
 }
 
+/* ---------- Promos (pop-ups / pop-ins / fly-outs) ---------- */
+/* Reusable system driven by assets/js/promos.js. A `.gt-promo` is hidden until
+   the engine reveals it; the `--popup / --popin / --flyout` modifier controls
+   only presentation. All variants share the card styling and theme tokens. */
+.gt-promo[hidden] { display: none; }
+
+.gt-promo__card {
+  position: relative;
+  background: var(--bg-elev);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: 1.75rem 1.5rem 1.25rem;
+  text-align: center;
+}
+.gt-promo__close {
+  position: absolute;
+  top: 0.4rem;
+  right: 0.55rem;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--fg-muted);
+  font-size: 1.5rem;
+  line-height: 1;
+}
+.gt-promo__close:hover { color: var(--fg); background: var(--bg-code); }
+.gt-promo__icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 3rem;
+  height: 3rem;
+  margin: 0 auto 0.75rem;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+.gt-promo__icon svg { width: 1.6rem; height: 1.6rem; }
+.gt-promo__title { margin: 0 0 0.5rem; font-size: 1.3rem; }
+.gt-promo__body { margin: 0 0 1.1rem; color: var(--fg-muted); }
+.gt-promo__actions {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+.gt-promo__later {
+  margin-top: 0.9rem;
+  border: 0;
+  background: transparent;
+  color: var(--fg-muted);
+  font-size: 0.9rem;
+  text-decoration: underline;
+}
+.gt-promo__later:hover { color: var(--fg); }
+
+/* Modal pop-up: centered, backdrop, above the nav (nav z-index is 1000). */
+.gt-promo--popup {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+.gt-promo__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+}
+:root.dark .gt-promo__backdrop { background: rgba(0, 0, 0, 0.65); }
+.gt-promo--popup .gt-promo__card {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  max-width: 26rem;
+  animation: gt-promo-pop 0.22s ease-out both;
+}
+body.gt-promo-open { overflow: hidden; }
+
+/* Pop-in: small card anchored bottom-right, no backdrop / no scroll lock. */
+.gt-promo--popin {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  z-index: 1100;
+  width: min(22rem, calc(100vw - 2rem));
+}
+.gt-promo--popin .gt-promo__card {
+  text-align: left;
+  animation: gt-promo-rise 0.24s ease-out both;
+}
+
+/* Fly-out: edge-anchored panel that slides in from the right. */
+.gt-promo--flyout {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1100;
+  display: flex;
+  align-items: center;
+  width: min(24rem, 100vw);
+}
+.gt-promo--flyout .gt-promo__card {
+  width: 100%;
+  height: 100%;
+  border-radius: 0;
+  text-align: left;
+  animation: gt-promo-slide 0.26s ease-out both;
+}
+
+@keyframes gt-promo-pop {
+  from { opacity: 0; transform: translateY(0.5rem) scale(0.97); }
+  to   { opacity: 1; transform: none; }
+}
+@keyframes gt-promo-rise {
+  from { opacity: 0; transform: translateY(1rem); }
+  to   { opacity: 1; transform: none; }
+}
+@keyframes gt-promo-slide {
+  from { transform: translateX(100%); }
+  to   { transform: none; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .gt-promo--popup .gt-promo__card,
+  .gt-promo--popin .gt-promo__card,
+  .gt-promo--flyout .gt-promo__card { animation: none; }
+}
+@media (max-width: 600px) {
+  .gt-promo__actions { width: 100%; }
+  .gt-promo__actions .btn { flex: 1 1 auto; justify-content: center; }
+}
+
 /* ---------- Lab Bench blog series: figures, charts & persona callouts ---------- */
 /* Used by the Signal Lab / RF Scope / Crypto Lab tutorial series. Charts are
    rendered by assets/js/labcharts.js into <canvas class="lab-chart">. */

--- a/docs/assets/js/analytics.js
+++ b/docs/assets/js/analytics.js
@@ -1,0 +1,75 @@
+/*
+ * GopherTrunk shared metrics. Loaded (deferred) site-wide from default.html
+ * BEFORE site.js and promos.js so both can use the same tracking surface.
+ *
+ * This is the single place that talks to Google Analytics (gtag) and the
+ * localStorage CTA memory. The CTA click tracking used to live privately inside
+ * site.js; it now lives here so promos (pop-ups / pop-ins / fly-outs) record
+ * impressions, clicks, and dismissals through the exact same path — no parallel
+ * analytics.
+ *
+ * Exposes window.GTMetrics:
+ *   GTMetrics.event(name, params)   fire a gtag event (no-op if gtag absent);
+ *                                   page_path is attached automatically.
+ *   GTMetrics.cta(id)               remember the CTA family in localStorage and
+ *                                   fire a 'cta_click' event. Called by site.js
+ *                                   for every [data-cta-event] click.
+ */
+(function () {
+  'use strict';
+
+  var CTA_KEY = 'gt-cta';
+
+  // Fire a gtag event, defensively. gtag may be missing (blocked/offline) — in
+  // that case this is a silent no-op so callers never need to guard.
+  function event(name, params) {
+    if (!name) return;
+    var payload = { page_path: location.pathname };
+    if (params) {
+      for (var k in params) {
+        if (Object.prototype.hasOwnProperty.call(params, k)) payload[k] = params[k];
+      }
+    }
+    try {
+      if (typeof window.gtag === 'function') window.gtag('event', name, payload);
+    } catch (e) {}
+  }
+
+  // CTA interaction memory (localStorage). We record which call-to-action
+  // "families" a visitor has already acted on so we can adapt later pages:
+  // someone who has downloaded sees the Support ask promoted, and vice-versa.
+  function readCtaState() {
+    try { return JSON.parse(localStorage.getItem(CTA_KEY)) || {}; }
+    catch (e) { return {}; }
+  }
+  function rememberCta(family) {
+    if (!family) return;
+    try {
+      var s = readCtaState();
+      s[family] = true;
+      localStorage.setItem(CTA_KEY, JSON.stringify(s));
+    } catch (e) {}
+  }
+  function ctaFamily(id) {
+    if (!id) return null;
+    if (id === 'cta_try_download') return 'try';
+    if (id.indexOf('cta_support_') === 0) return 'support';
+    if (id.indexOf('cta_join_') === 0) return 'join';
+    if (id.indexOf('cta_star_') === 0) return 'star';
+    return null;
+  }
+
+  // Record a CTA click: remember its family (for adaptive ordering) and fire a
+  // gtag event so we can measure whether these CTAs convert.
+  function cta(id) {
+    if (!id) return;
+    rememberCta(ctaFamily(id));
+    event('cta_click', { cta_id: id });
+  }
+
+  window.GTMetrics = {
+    event: event,
+    cta: cta,
+    readCtaState: readCtaState
+  };
+})();

--- a/docs/assets/js/promos.js
+++ b/docs/assets/js/promos.js
@@ -1,0 +1,213 @@
+/*
+ * GopherTrunk promo engine. Loaded (deferred) site-wide from default.html,
+ * after analytics.js and site.js.
+ *
+ * A small, declarative system for pop-ups, pop-ins, and fly-outs. Adding a new
+ * promo requires NO change to this file: drop an include into the page markup
+ * whose root carries the data-promo-* attributes below, and the engine
+ * discovers it, arms its triggers, shows it once, and reports every impression,
+ * dismissal, and action through the shared metrics module (window.GTMetrics) —
+ * the same tracking path the site's CTAs use.
+ *
+ * Markup contract (on the promo root element):
+ *   class="gt-promo gt-promo--{popup|popin|flyout}"  presentation variant
+ *   hidden                                            engine reveals it
+ *   data-promo="<unique-id>"                          analytics + dedup key
+ *   data-promo-variant="popup|popin|flyout"           behavior (backdrop/lock)
+ *   data-promo-trigger-time="<ms>"                    show after N ms (optional)
+ *   data-promo-trigger-scroll="<0..1>"                show at scroll fraction (optional)
+ *   data-promo-frequency="once|session|always"        dedup scope (default once)
+ * Dismiss controls (anywhere inside): [data-promo-close], optionally with
+ *   data-promo-close-method="close_button|maybe_later|backdrop|escape|action".
+ * Action links use data-cta-event="cta_*" — tracked by site.js as a CTA click.
+ *
+ * Triggers are OR'd: the first to fire shows the promo; the rest are disarmed.
+ */
+(function () {
+  'use strict';
+
+  var SEEN_KEY = 'gt-promos';
+
+  function metrics() { return window.GTMetrics || null; }
+  function fire(name, params) { var m = metrics(); if (m) m.event(name, params); }
+
+  // --- Per-frequency "seen" memory -----------------------------------------
+  function store(freq) {
+    // 'session' -> sessionStorage; 'once' (default) -> localStorage; 'always'
+    // -> no persistence (handled by callers skipping read/write).
+    try { return freq === 'session' ? window.sessionStorage : window.localStorage; }
+    catch (e) { return null; }
+  }
+  function readSeen(freq) {
+    var s = store(freq);
+    if (!s) return {};
+    try { return JSON.parse(s.getItem(SEEN_KEY)) || {}; }
+    catch (e) { return {}; }
+  }
+  function hasSeen(id, freq) {
+    if (freq === 'always') return false;
+    return !!readSeen(freq)[id];
+  }
+  function markSeen(id, freq) {
+    if (freq === 'always') return;
+    var s = store(freq);
+    if (!s) return;
+    try {
+      var seen = readSeen(freq);
+      seen[id] = true;
+      s.setItem(SEEN_KEY, JSON.stringify(seen));
+    } catch (e) {}
+  }
+
+  // --- Scroll fraction ------------------------------------------------------
+  function scrollFraction() {
+    var doc = document.documentElement;
+    var max = (doc.scrollHeight || document.body.scrollHeight) - window.innerHeight;
+    if (max <= 0) return 0; // page can't scroll — time trigger will cover it
+    var y = window.pageYOffset || doc.scrollTop || 0;
+    return Math.min(1, Math.max(0, y / max));
+  }
+
+  // --- One promo ------------------------------------------------------------
+  function Promo(el) {
+    this.el = el;
+    this.id = el.getAttribute('data-promo');
+    this.variant = el.getAttribute('data-promo-variant') || 'popup';
+    this.frequency = el.getAttribute('data-promo-frequency') || 'once';
+    this.timeMs = parseInt(el.getAttribute('data-promo-trigger-time'), 10);
+    this.scrollAt = parseFloat(el.getAttribute('data-promo-trigger-scroll'));
+    this.isModal = this.variant === 'popup';
+    this.shown = false;
+    this.closed = false;
+    this.timer = null;
+    this.prevFocus = null;
+    this._onScroll = null;
+    this._onKey = null;
+    this._bound = false;
+  }
+
+  Promo.prototype.arm = function () {
+    if (!this.id || hasSeen(this.id, this.frequency)) return;
+    var self = this;
+
+    if (!isNaN(this.timeMs) && this.timeMs >= 0) {
+      this.timer = window.setTimeout(function () { self.show('time'); }, this.timeMs);
+    }
+
+    if (!isNaN(this.scrollAt)) {
+      this._onScroll = function () {
+        if (scrollFraction() >= self.scrollAt) self.show('scroll');
+      };
+      window.addEventListener('scroll', this._onScroll, { passive: true });
+      // In case the page already loaded scrolled past the threshold.
+      this._onScroll();
+    }
+  };
+
+  Promo.prototype.disarmTriggers = function () {
+    if (this.timer) { window.clearTimeout(this.timer); this.timer = null; }
+    if (this._onScroll) { window.removeEventListener('scroll', this._onScroll); this._onScroll = null; }
+  };
+
+  Promo.prototype.show = function (trigger) {
+    if (this.shown) return;
+    this.shown = true;
+    this.disarmTriggers();
+
+    // Write the seen flag on show (not on interaction) so an ignored or
+    // reloaded promo does not re-appear.
+    markSeen(this.id, this.frequency);
+
+    var el = this.el;
+    el.removeAttribute('hidden');
+    el.setAttribute('aria-hidden', 'false');
+
+    if (this.isModal) {
+      this.prevFocus = document.activeElement;
+      document.body.classList.add('gt-promo-open');
+      this.bindModalDismiss();
+      // Move focus into the dialog for keyboard users.
+      var focusTarget = el.querySelector('[autofocus], [data-promo-focus], .btn, a[href], button');
+      if (focusTarget && focusTarget.focus) {
+        try { focusTarget.focus(); } catch (e) {}
+      } else if (el.focus) {
+        try { el.focus(); } catch (e) {}
+      }
+    }
+
+    fire('promo_impression', { promo_id: this.id, variant: this.variant, trigger: trigger || '' });
+  };
+
+  Promo.prototype.bindModalDismiss = function () {
+    if (this._bound) return;
+    this._bound = true;
+    var self = this;
+    this._onKey = function (e) {
+      if (e.key === 'Escape' || e.keyCode === 27) self.close('escape');
+    };
+    document.addEventListener('keydown', this._onKey);
+  };
+
+  Promo.prototype.close = function (method) {
+    if (this.closed || !this.shown) return;
+    this.closed = true;
+
+    var el = this.el;
+    el.setAttribute('hidden', '');
+    el.setAttribute('aria-hidden', 'true');
+
+    if (this.isModal) {
+      document.body.classList.remove('gt-promo-open');
+      if (this._onKey) { document.removeEventListener('keydown', this._onKey); this._onKey = null; }
+      // Restore focus to wherever it was before we opened.
+      if (this.prevFocus && this.prevFocus.focus) {
+        try { this.prevFocus.focus(); } catch (e) {}
+      }
+    }
+
+    fire('promo_dismiss', { promo_id: this.id, method: method || 'unknown' });
+  };
+
+  // Delegated clicks within the promo: dismiss controls and action links.
+  Promo.prototype.bindClicks = function () {
+    var self = this;
+    this.el.addEventListener('click', function (e) {
+      var closer = e.target.closest && e.target.closest('[data-promo-close]');
+      if (closer) {
+        var method = closer.getAttribute('data-promo-close-method') || 'close_button';
+        self.close(method);
+        return;
+      }
+      // A primary action (e.g. the star link) also closes the promo. The click
+      // itself is tracked by site.js via its data-cta-event attribute.
+      var action = e.target.closest && e.target.closest('[data-cta-event]');
+      if (action) self.close('action');
+    });
+  };
+
+  // --- Engine ---------------------------------------------------------------
+  var registered = {};
+
+  function register(el) {
+    if (!el || el.getAttribute('data-promo-bound') === '1') return;
+    var promo = new Promo(el);
+    if (!promo.id || registered[promo.id]) return;
+    el.setAttribute('data-promo-bound', '1');
+    registered[promo.id] = promo;
+    promo.bindClicks();
+    promo.arm();
+  }
+
+  function scan() {
+    var nodes = document.querySelectorAll('.gt-promo[data-promo]');
+    for (var i = 0; i < nodes.length; i++) register(nodes[i]);
+  }
+
+  window.GTPromos = { register: register, scan: scan };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', scan);
+  } else {
+    scan();
+  }
+})();

--- a/docs/assets/js/site.js
+++ b/docs/assets/js/site.js
@@ -48,28 +48,13 @@
     }
   }
 
-  // CTA interaction memory (localStorage). We record which call-to-action
-  // "families" a visitor has already acted on so we can adapt later pages:
-  // someone who has downloaded sees the Support ask promoted, and vice-versa.
-  var CTA_KEY = 'gt-cta';
+  // CTA interaction memory now lives in the shared metrics module
+  // (assets/js/analytics.js, window.GTMetrics), loaded before this file, so
+  // promos and CTAs record through the same path. Read state through it, with a
+  // safe fallback if GTMetrics somehow failed to load.
   var readCtaState = function () {
-    try { return JSON.parse(localStorage.getItem(CTA_KEY)) || {}; }
-    catch (e) { return {}; }
-  };
-  var rememberCta = function (family) {
-    if (!family) return;
-    try {
-      var s = readCtaState();
-      s[family] = true;
-      localStorage.setItem(CTA_KEY, JSON.stringify(s));
-    } catch (e) {}
-  };
-  var ctaFamily = function (id) {
-    if (!id) return null;
-    if (id === 'cta_try_download') return 'try';
-    if (id.indexOf('cta_support_') === 0) return 'support';
-    if (id.indexOf('cta_join_') === 0) return 'join';
-    return null;
+    if (window.GTMetrics && window.GTMetrics.readCtaState) return window.GTMetrics.readCtaState();
+    return {};
   };
 
   // In-content CTAs: relocate the "try" / "support" call-outs into the
@@ -123,15 +108,13 @@
     }
   }
 
-  // CTA clicks: remember the family in localStorage (for adaptive ordering)
-  // and fire a gtag event so we can measure whether these CTAs convert.
+  // CTA clicks: delegate to the shared metrics module, which remembers the
+  // family in localStorage (for adaptive ordering) and fires the gtag event.
   document.addEventListener('click', function (e) {
     var link = e.target.closest && e.target.closest('[data-cta-event]');
     if (!link) return;
-    var id = link.getAttribute('data-cta-event');
-    rememberCta(ctaFamily(id));
-    if (typeof window.gtag === 'function') {
-      window.gtag('event', 'cta_click', { cta_id: id, page_path: location.pathname });
+    if (window.GTMetrics && window.GTMetrics.cta) {
+      window.GTMetrics.cta(link.getAttribute('data-cta-event'));
     }
   });
 


### PR DESCRIPTION
Introduce a small, declarative promo engine (pop-ups / pop-ins / fly-outs)
and use it for a one-time "Star GopherTrunk on GitHub" ask shown to engaged
first-time visitors on any page of the site.

- analytics.js: new shared window.GTMetrics module. The CTA click tracking
  (gtag event + gt-cta localStorage "family" memory) moves out of site.js into
  here so CTAs and promos report through the exact same path. Adds a
  `cta_star_ -> star` family. site.js now delegates to GTMetrics.cta and reads
  CTA state through it (behavior-preserving for existing CTAs).
- promos.js: new window.GTPromos engine. Auto-discovers any
  `.gt-promo[data-promo]` element and drives it from data-promo-* attributes:
  variant (popup/popin/flyout), triggers (time and/or scroll fraction, first to
  fire wins), and frequency (once per browser via localStorage, or session).
  Handles reveal, scroll-lock + focus for modals, dismissal (close button,
  "maybe later", backdrop, Escape), and fires promo_impression / promo_dismiss
  through GTMetrics. Adding a future promo needs no JS change.
- star-popup.html: first promo instance. Shows once, after 2 minutes on page or
  scrolling 25% down. Contains a compelling ask plus GitHub's official in-place
  Star widget (buttons.js) and a branded "View on GitHub" fallback that carries
  the CTA tracking hook.
- default.html: render the include and load analytics/promos site-wide.
- style.scss: base .gt-promo styling plus popup/popin/flyout variants, theme
  tokens, reduced-motion and small-screen handling.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LSrrxkPNN2ii6i9358boRN