### PR TITLE
docs: first-visit "Star the repo" popup + reusable promo system

### DIFF
--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -1820,6 +1820,9 @@ a.category-chip:hover {
   position: absolute;
   top: 0.4rem;
   right: 0.55rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   width: 2rem;
   height: 2rem;
   padding: 0;
@@ -1831,6 +1834,10 @@ a.category-chip:hover {
   line-height: 1;
 }
 .gt-promo__close:hover { color: var(--fg); background: var(--bg-code); }
+/* Comfortable 44px+ tap target on touch devices without bloating it on desktop. */
+@media (pointer: coarse) {
+  .gt-promo__close { width: 2.75rem; height: 2.75rem; top: 0.25rem; right: 0.25rem; }
+}
 .gt-promo__icon {
   display: flex;
   align-items: center;
@@ -1862,18 +1869,30 @@ a.category-chip:hover {
 }
 .gt-promo__later:hover { color: var(--fg); }
 
-/* Modal pop-up: centered, backdrop, above the nav (nav z-index is 1000). */
+/* Modal pop-up: centered, backdrop, above the nav (nav z-index is 1000).
+   The overlay itself scrolls (overflow-y:auto) and the card is centered with
+   margin:auto — this pair keeps the card reachable when it is taller than the
+   viewport (short/landscape phones, large text, browser zoom), where plain
+   flex-centering would clip the top and bottom out of reach. Padding honours
+   the safe-area insets on notched devices. */
 .gt-promo--popup {
   position: fixed;
   inset: 0;
   z-index: 1200;
   display: flex;
-  align-items: center;
-  justify-content: center;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
   padding: 1rem;
+  padding:
+    max(1rem, env(safe-area-inset-top))
+    max(1rem, env(safe-area-inset-right))
+    max(1rem, env(safe-area-inset-bottom))
+    max(1rem, env(safe-area-inset-left));
 }
+/* Fixed so it always covers the viewport even while the overlay scrolls. */
 .gt-promo__backdrop {
-  position: absolute;
+  position: fixed;
   inset: 0;
   background: rgba(15, 23, 42, 0.55);
 }
@@ -1881,6 +1900,7 @@ a.category-chip:hover {
 .gt-promo--popup .gt-promo__card {
   position: relative;
   z-index: 1;
+  margin: auto;
   width: 100%;
   max-width: 26rem;
   animation: gt-promo-pop 0.22s ease-out both;


### PR DESCRIPTION
## Summary

Grow GitHub stars by asking engaged first-time visitors — and only first-time visitors — to star the repo. On any page of gophertrunk.org, a popup appears **once per browser** after the visitor shows engagement (**2 minutes on page OR scrolling 25% down**, whichever comes first), with a compelling ask and a button to star `MattCheramie/GopherTrunk`. It's built as the first instance of a small, reusable promo system so more pop-ups / pop-ins / fly-outs are easy to add later, and it reports through the same tracking path the existing CTAs use.

## Changes

- **`docs/assets/js/analytics.js` (new)** — shared `window.GTMetrics`. The CTA click tracking (gtag event + `gt-cta` localStorage "family" memory) moves out of `site.js` into here so CTAs **and** promos report through one path; adds a `cta_star_ → star` family. `site.js` now delegates to `GTMetrics.cta` and reads CTA state through it (behavior-preserving for existing CTAs).
- **`docs/assets/js/promos.js` (new)** — `window.GTPromos` engine. Auto-discovers any `.gt-promo[data-promo]` element and drives it from `data-promo-*` attributes: variant (`popup`/`popin`/`flyout`), triggers (time and/or scroll fraction, first to fire wins), and frequency (`once` per browser via localStorage, or `session`). Handles reveal, scroll-lock + focus for modals, dismissal (close button, "maybe later", backdrop, Escape), and fires `promo_impression` / `promo_dismiss` through `GTMetrics`. Adding a future promo needs **no JS change**.
- **`docs/_includes/star-popup.html` (new)** — the first promo instance. Shows once, after 2 min or 25% scroll. Contains the ask plus GitHub's official in-place Star widget (buttons.js) and a branded "View on GitHub" fallback that carries the CTA tracking hook.
- **`docs/_layouts/default.html`** — render the include and load `analytics.js` / `promos.js` site-wide (ordered `analytics → site → autolink → promos`).
- **`docs/assets/css/style.scss`** — base `.gt-promo` styling plus popup/popin/flyout variants, theme tokens, reduced-motion and small-screen handling. Overlay scrolls with `margin:auto` centering and a fixed backdrop so the card stays reachable on short/landscape viewports; safe-area insets for notched devices; a 44px close tap target on touch pointers.

## Test plan

This is a docs-site (Jekyll) change only — no Go code — so the `make` targets below are n/a. Verification was done against the built site and in a browser:

- **Jekyll build** through the real layout, includes, and SCSS: popup markup renders hidden, scripts load in the correct order, and all `.gt-promo` CSS rules compile.
- **18-test headless-Chromium behavior suite, all passing**: time trigger, scroll trigger, once-per-browser dedup, all four dismissal methods, `promo_impression`/`promo_dismiss` analytics, star-click `cta_click`/`cta_star_github` + `gt-cta` star family, action-closes-popup, and scroll-lock/unlock.
- **Responsive review** across 7 viewports (320/375/390px portrait phones, landscape phone, iPad, desktop) in light and dark. Found and fixed a short/landscape-viewport clipping bug where the close and "Maybe later" controls became unreachable; re-verified with screenshots + geometry measurements.
- [ ] `make vet test` is green locally — n/a (no Go code changed)
- [ ] `make integration` is green locally (if the change touches the daemon) — n/a
- [x] Added or updated tests where appropriate — browser behavior suite (harness, not committed); no repo unit tests cover the static site
- [ ] Smoke-tested against real hardware — n/a

## Breaking changes

None.

## Docs / CHANGELOG

- [ ] Added a `## [Unreleased]` bullet to `CHANGELOG.md` — n/a (site-only, not a shipped-binary change)
- [x] Updated `docs/` — this PR is the docs-site change

## Linked issues

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LSrrxkPNN2ii6i9358boRN)_