### PR TITLE
docs(learn): add Databases, Web Development & Scanning learning modules

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -177,6 +177,30 @@ defaults:
       learn_module: deployment
       nav_group: Learn
       permalink: /learn/deployment/:basename/
+  - scope:
+      path: "learn/databases"
+      type: pages
+    values:
+      layout: lesson
+      learn_module: databases
+      nav_group: Learn
+      permalink: /learn/databases/:basename/
+  - scope:
+      path: "learn/web-dev"
+      type: pages
+    values:
+      layout: lesson
+      learn_module: web-dev
+      nav_group: Learn
+      permalink: /learn/web-dev/:basename/
+  - scope:
+      path: "learn/scanning"
+      type: pages
+    values:
+      layout: lesson
+      learn_module: scanning
+      nav_group: Learn
+      permalink: /learn/scanning/:basename/
   # Field Guide articles under /reference/ get the reference layout and nav
   # group automatically. The hub (reference/index.md) overrides to reference-hub.
   - scope:

--- a/docs/_data/learn.yml
+++ b/docs/_data/learn.yml
@@ -96,6 +96,8 @@ learning_paths:
         note: "Version control — the backbone of any real codebase."
       - id: digital-trunking
         note: "Apply it: how trunked systems work and how software follows them."
+      - id: scanning
+        note: "Operate it — find, follow, and monitor real systems with your decoder."
       - id: deployment
         note: "Ship it — package and run your decoder as a real service."
       - id: ai-software-dev
@@ -134,6 +136,10 @@ learning_paths:
         note: "The command line every developer lives in."
       - id: networking
         note: "How software talks across machines."
+      - id: databases
+        note: "Where your application's data lives — SQL, NoSQL, and vector stores."
+      - id: web-dev
+        note: "The web layer most software meets its users through."
       - id: deployment
         note: "Containers, CI/CD, and getting your software running in production."
       - id: software-licensing
@@ -152,6 +158,10 @@ learning_paths:
         note: "A concrete language to build in — Go, from basics to concurrency."
       - id: git
         note: "Version control for any real project."
+      - id: databases
+        note: "Store your data — including the vector search that powers RAG features."
+      - id: web-dev
+        note: "Deliver AI features to users through a web app."
       - id: ai-software-dev
         note: "Use AI tools to write and ship software faster."
       - id: building-ai
@@ -190,6 +200,8 @@ learning_paths:
         note: "The signal processing that recovers bits from a noisy channel."
       - id: digital-trunking
         note: "How trunked control channels and voice calls work."
+      - id: scanning
+        note: "Apply it — build a station and follow live systems in the field."
       - id: intro-hardware
         note: "The SDR hardware that feeds a scanner."
 
@@ -3622,6 +3634,751 @@ modules:
       slug: glossary
       title: Glossary of deployment terms
       summary: Plain-language definitions for every deployment term in the path — container, image, registry, Dockerfile, Compose, systemd, CI/CD, artifact, secret, and more — cross-linked to the lessons.
+      minutes: 10
+      level: beginner
+      status: full
+
+  - id: databases
+    label: "Databases & Data"
+    title: "Databases & Data — where your application's data lives, from a first table to production"
+    tagline: "Every app needs somewhere to keep its data — tables, SQL, keys and joins, the relational and NoSQL and vector stores, and how to query, model, and run a database from your own code."
+    start_slug: what-is-a-database
+    workload: "PT7H"
+    intro: >
+      Almost every program you build eventually needs to remember something — a
+      user, a setting, a log of decoded calls. A database is where that data lives:
+      structured so you can store it reliably and get it back fast. This module
+      starts from why plain files aren't enough, builds up the relational model and
+      SQL — the language nearly every database speaks — then teaches you to design
+      data well, reach beyond relational to key-value, document, time-series, and
+      vector stores, and finally talk to a database from your own code and run one
+      in production. Examples lean on real software, including how a project like
+      GopherTrunk stores the calls and systems it decodes. Pairs with the Software
+      Engineering and AI Software Development paths; no prior database experience
+      assumed.
+    units:
+      - id: why-data-needs-structure
+        label: "Unit 1 — Why Data Needs Structure"
+        blurb: "What a database is and the ideas underneath it: persistence, the relational model, schemas and types, and the keys that tie data together."
+        lessons:
+          - slug: what-is-a-database
+            title: What a database is (and why not just files)
+            summary: The problem databases solve — storing data so many readers and writers can query it reliably, safely, and fast, instead of hand-rolling files.
+            minutes: 8
+            level: beginner
+            status: full
+          - slug: data-and-persistence
+            title: Data, state & persistence
+            summary: The difference between data your program holds in memory and data that outlives it — persistence, durability, and why "save it somewhere" is harder than it looks.
+            minutes: 8
+            level: beginner
+            status: full
+          - slug: the-relational-model
+            title: The relational model — tables, rows & columns
+            summary: The idea that has run the data world for fifty years — organising data into tables of rows and columns, and why that simple shape is so powerful.
+            minutes: 9
+            level: beginner
+            status: full
+          - slug: schemas-and-types
+            title: Schemas, columns & data types
+            summary: A schema is the shape of your data — the columns, their types, and the rules — and why deciding it up front saves you from a mess later.
+            minutes: 8
+            level: beginner
+            status: full
+          - slug: keys-and-relationships
+            title: Keys & relationships
+            summary: Primary keys that name each row and foreign keys that link tables — how a database models the relationships between your things.
+            minutes: 9
+            level: beginner
+            status: full
+
+      - id: sql
+        label: "Unit 2 — SQL, the Language of Data"
+        blurb: "The query language almost every database understands: selecting, filtering, joining, aggregating, changing data, and making it all fast with indexes."
+        lessons:
+          - slug: what-is-sql
+            title: What SQL is
+            summary: The declarative language for talking to a relational database — you describe the data you want, not how to fetch it, and the database works out the rest.
+            minutes: 8
+            level: beginner
+            status: full
+          - slug: querying-with-select
+            title: Querying with SELECT
+            summary: The single most-used statement in all of software — SELECT — and how to ask a database for exactly the columns and rows you need.
+            minutes: 9
+            level: beginner
+            status: full
+          - slug: filtering-and-sorting
+            title: Filtering, sorting & limiting
+            summary: WHERE, ORDER BY, and LIMIT — narrowing a result set to the rows that matter, in the order you want, without dragging back the whole table.
+            minutes: 9
+            level: beginner
+            status: full
+          - slug: joins
+            title: Joining tables
+            summary: The heart of relational power — combining rows from two tables on a shared key, and the difference between inner and outer joins.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: aggregation-and-grouping
+            title: Aggregation & GROUP BY
+            summary: Turning many rows into a summary — counts, sums, and averages — with GROUP BY and HAVING, the tools behind every dashboard number.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: inserting-updating-deleting
+            title: Inserting, updating & deleting
+            summary: The write side of SQL — INSERT, UPDATE, and DELETE — and the WHERE clause you forget at your peril.
+            minutes: 8
+            level: beginner
+            status: full
+          - slug: indexes
+            title: Indexes & how queries get fast
+            summary: Why the same query can take a millisecond or a minute — indexes, what they cost, and the mental model of a book's index that explains them.
+            minutes: 10
+            level: intermediate
+            status: full
+
+      - id: designing-data-well
+        label: "Unit 3 — Designing Data Well"
+        blurb: "Turning a pile of columns into a sound design: normalization, modeling a real app, constraints, transactions, and evolving the schema safely over time."
+        lessons:
+          - slug: normalization
+            title: Normalization & avoiding duplication
+            summary: Why storing the same fact in two places will eventually betray you — normalization, and the handful of normal forms worth actually knowing.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: data-modeling
+            title: Data modeling for a real app
+            summary: Going from "what does my app do" to a set of tables and relationships — the practical craft of modeling data before you write a line of code.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: constraints-and-integrity
+            title: Constraints & data integrity
+            summary: Letting the database enforce the rules — NOT NULL, UNIQUE, CHECK, and foreign-key constraints that keep bad data out no matter what the app does.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: transactions-and-acid
+            title: Transactions & ACID
+            summary: All-or-nothing changes — transactions, the ACID guarantees behind them, and why moving money (or updating two tables) needs them.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: migrations
+            title: Schema migrations & evolving a database
+            summary: Your schema is never finished — migrations are how you change a live database's shape safely, in version control, without losing data.
+            minutes: 9
+            level: intermediate
+            status: full
+
+      - id: beyond-relational
+        label: "Unit 4 — Beyond Relational"
+        blurb: "The other database families and when they beat a table: key-value and document stores, time-series and analytics, vector search, and caching layers."
+        lessons:
+          - slug: sql-vs-nosql
+            title: SQL vs. NoSQL
+            summary: What "NoSQL" actually means, the tradeoff it makes, and how to tell when a non-relational store fits a problem better than tables do.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: key-value-and-document
+            title: Key-value & document stores
+            summary: Two of the most common NoSQL shapes — the dictionary-like key-value store and the JSON-document store — and the jobs each is built for.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: time-series-and-analytics
+            title: Time-series & analytical stores
+            summary: Databases tuned for when-it-happened data and for crunching huge tables — time-series and column stores, and why your metrics live in one.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: vector-databases
+            title: Vector databases & similarity search
+            summary: The store behind AI retrieval — embeddings as vectors, searching by meaning instead of keywords, and how RAG features lean on it.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: caching-layers
+            title: Caching layers
+            summary: Keeping hot data in fast memory in front of the database — caches like Redis, what they buy you, and the classic hard problem of keeping them fresh.
+            minutes: 9
+            level: intermediate
+            status: full
+
+      - id: using-a-database-from-code
+        label: "Unit 5 — Using a Database From Code"
+        blurb: "Wiring a database into a program: connecting, pooling connections, ORMs versus raw SQL, defending against injection, and doing it all in Go."
+        lessons:
+          - slug: connecting-from-code
+            title: Connecting from your program
+            summary: Drivers, connection strings, and credentials — how a running program actually opens a link to a database and sends it queries.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: connection-pooling
+            title: Connection pools
+            summary: Opening a connection is expensive, so real apps reuse a pool of them — what a pool is, why you need one, and how to size it.
+            minutes: 8
+            level: intermediate
+            status: full
+          - slug: orms-vs-raw-sql
+            title: ORMs vs. raw SQL
+            summary: The perennial choice — let a library map objects to rows, or write SQL by hand — what each buys you and what each costs.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: sql-injection
+            title: SQL injection & querying safely
+            summary: The classic, still-common vulnerability where user input becomes SQL — how it happens and why parameterised queries end it.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: databases-in-go
+            title: Talking to a database from Go
+            summary: The Go way — database/sql, drivers, prepared statements, and querying safely — with the patterns GopherTrunk-style services use.
+            minutes: 10
+            level: advanced
+            status: full
+
+      - id: databases-in-production
+        label: "Unit 6 — Running a Database in Production"
+        blurb: "Everything applied: keeping data safe with backups, scaling with replication, watching performance, choosing the right database, and the data behind GopherTrunk."
+        lessons:
+          - slug: backups-and-recovery
+            title: Backups & recovery
+            summary: The single most important operational habit — backups you have actually restored, point-in-time recovery, and testing them before you need them.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: replication-and-scaling
+            title: Replication, sharding & scaling
+            summary: When one server isn't enough — read replicas, sharding, and the CAP tradeoffs that shape how a database scales out.
+            minutes: 10
+            level: advanced
+            status: full
+          - slug: performance-and-monitoring
+            title: Performance tuning & monitoring
+            summary: Finding the slow query before your users do — EXPLAIN, query plans, the metrics that matter, and the usual suspects behind a sluggish database.
+            minutes: 10
+            level: advanced
+            status: full
+          - slug: choosing-a-database
+            title: Choosing a database
+            summary: SQLite, Postgres, MySQL, a document store, a managed service like Supabase — a practical framework for picking the right one for a project.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: data-in-gophertrunk
+            title: Data in GopherTrunk
+            summary: A worked example — how a scanner like GopherTrunk models systems, talkgroups, and decoded calls, and stores them for search and playback.
+            minutes: 10
+            level: advanced
+            status: full
+
+    # Standalone reference, not part of the sequential path (no prev/next slot).
+    glossary:
+      slug: glossary
+      title: Glossary of database terms
+      summary: Plain-language definitions for every term in the module — database, schema, SQL, primary and foreign key, join, index, normalization, transaction, ACID, NoSQL, vector store, ORM, migration, replica, and more — cross-linked to the lessons.
+      minutes: 11
+      level: beginner
+      status: full
+
+  - id: web-dev
+    label: "Web Development"
+    title: "Web Development — how a website becomes a web app, from the browser to production"
+    tagline: "How the web is actually built — HTML, CSS, and JavaScript on the front end, HTTP servers and REST APIs on the back, auth and real-time and security, and shipping the whole thing to production."
+    start_slug: what-is-web-development
+    workload: "PT8H"
+    intro: >
+      The web is where most software meets its users. This module is the working
+      developer's tour of how a web app is built — not a framework tutorial, but the
+      durable ideas that outlast any framework. Start with how the browser and the
+      client-server web actually work, learn the front-end trio of HTML, CSS, and
+      JavaScript and how modern component frameworks build on them, then cross to
+      the back end: HTTP servers, REST APIs, and the database behind them. From
+      there you'll handle the parts that separate a page from a product — auth and
+      sessions, real-time updates, web security, caching — and finish by shipping,
+      measuring, and operating a real web app, using GopherTrunk's own web dashboard
+      as the worked example. Pairs with the Networking, Databases, and Deployment
+      modules; a little programming experience helps but no web background is
+      assumed.
+    units:
+      - id: how-the-web-works
+        label: "Unit 1 — How the Web Works (for Building)"
+        blurb: "The mental model every web developer needs: what web development is, how the browser renders a page, the client-server web, the anatomy of a web app, and static versus dynamic."
+        lessons:
+          - slug: what-is-web-development
+            title: What web development is
+            summary: The lay of the land — front end, back end, and full stack — and what actually happens between typing a URL and seeing a page.
+            minutes: 8
+            level: beginner
+            status: full
+          - slug: how-the-browser-works
+            title: How the browser works
+            summary: The most important program in web development — how a browser fetches, parses, and renders HTML, CSS, and JavaScript into the page you see.
+            minutes: 9
+            level: beginner
+            status: full
+          - slug: client-server-web
+            title: The client-server web
+            summary: Every web interaction is a request and a response — the client-server model on the web, building on how a web request works under the hood.
+            minutes: 8
+            level: beginner
+            status: full
+          - slug: anatomy-of-a-web-app
+            title: Anatomy of a modern web app
+            summary: The pieces and how they fit — front end, back end, database, and the APIs between them — the map the rest of the module fills in.
+            minutes: 9
+            level: beginner
+            status: full
+          - slug: static-vs-dynamic
+            title: Static vs. dynamic sites
+            summary: A file served as-is versus a page built on the fly — the spectrum from static sites to full web apps, and why this very site is static.
+            minutes: 8
+            level: beginner
+            status: full
+
+      - id: the-frontend-trio
+        label: "Unit 2 — The Front-End Trio"
+        blurb: "The three languages of the browser and how a user interacts with them: HTML structure, CSS styling, JavaScript behaviour, the DOM, forms, and accessibility."
+        lessons:
+          - slug: html-structure
+            title: HTML — structure & semantics
+            summary: The skeleton of every page — HTML elements, semantic markup, and why the right tag matters for meaning, accessibility, and search.
+            minutes: 9
+            level: beginner
+            status: full
+          - slug: css-and-layout
+            title: CSS — styling & layout
+            summary: How a page goes from plain text to designed — selectors, the box model, and the flexbox and grid layout systems modern sites are built on.
+            minutes: 10
+            level: beginner
+            status: full
+          - slug: javascript-in-the-browser
+            title: JavaScript in the browser
+            summary: The language that makes pages interactive — what JavaScript does in the browser, events, and where it runs versus server-side code.
+            minutes: 10
+            level: beginner
+            status: full
+          - slug: the-dom
+            title: The DOM — manipulating the page
+            summary: The live tree the browser builds from your HTML — the DOM — and how JavaScript reads and changes it to update the page without a reload.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: forms-and-user-input
+            title: Forms & user input
+            summary: How the web takes input — forms, validation, and safely getting what a user types from the browser to your server.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: accessibility-basics
+            title: Accessibility basics
+            summary: Building for everyone — semantic HTML, keyboard use, contrast, and ARIA — the accessibility fundamentals that are also just good engineering.
+            minutes: 9
+            level: intermediate
+            status: full
+
+      - id: frontend-at-scale
+        label: "Unit 3 — The Front End at Scale"
+        blurb: "How real front ends are built today: component frameworks, state, fetching data from the browser, the build toolchain, and responsive design."
+        lessons:
+          - slug: frontend-frameworks
+            title: Front-end frameworks
+            summary: Why React and its peers exist — the problem of keeping a complex UI in sync with data, and what a framework does that hand-written DOM code doesn't.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: components-and-state
+            title: Components & state
+            summary: The building block of modern UIs — a component — and the idea of state that drives what it shows, the core mental model of every framework.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: fetching-data
+            title: Fetching data from the front end
+            summary: How a page pulls fresh data without reloading — fetch, JSON, async requests, and talking to an API from the browser.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: build-tools-and-bundlers
+            title: Build tools & bundlers
+            summary: What turns your source into what the browser downloads — bundlers, transpiling, and why modern front ends have a build step at all.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: responsive-design
+            title: Responsive design
+            summary: One site, every screen — fluid layouts, media queries, and the mobile-first mindset that keeps a page usable from phone to desktop.
+            minutes: 9
+            level: intermediate
+            status: full
+
+      - id: the-backend
+        label: "Unit 4 — The Back End"
+        blurb: "The server side of a web app: what a back end does, HTTP servers and routing, building a REST API, the database behind it, rendering strategies, and templating."
+        lessons:
+          - slug: what-a-backend-does
+            title: What a back end does
+            summary: The work that can't happen in the browser — business logic, data, auth, and secrets — and why a web app needs a server behind it.
+            minutes: 9
+            level: beginner
+            status: full
+          - slug: http-servers-and-routing
+            title: HTTP servers & routing
+            summary: How a server answers the web — listening for requests, routing a URL and method to the right handler, and returning a response.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: building-a-rest-api
+            title: Building a REST API
+            summary: The contract between front and back end — resources, HTTP verbs, status codes, and JSON — assembled into an API a front end can consume.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: backend-and-database
+            title: The back end & its database
+            summary: Where the server meets the data layer — how a back end reads and writes a database safely, and where the boundary belongs.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: ssr-spa-static
+            title: SSR vs. SPA vs. static
+            summary: Three ways to build a page — rendered on the server, in the browser, or ahead of time — what each is good at, and how to choose.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: templating-and-static-sites
+            title: Templating & static site generators
+            summary: Generating HTML from templates and data — server-side templating and static generators like the Jekyll build behind this very site.
+            minutes: 9
+            level: intermediate
+            status: full
+
+      - id: auth-sessions-realtime
+        label: "Unit 5 — Auth, Sessions & Real-Time"
+        blurb: "The features that make a web app real and safe: authentication and sessions, cookies and tokens, live updates over WebSockets, web security, and caching."
+        lessons:
+          - slug: authentication-and-sessions
+            title: Authentication & sessions
+            summary: Knowing who a user is across stateless requests — logging in, sessions, and the difference between authentication and authorization on the web.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: cookies-tokens-jwt
+            title: Cookies, tokens & JWTs
+            summary: How the browser remembers you between requests — cookies, bearer tokens, and JWTs — and the tradeoffs and pitfalls of each.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: websockets-and-realtime
+            title: WebSockets & real-time updates
+            summary: When request-response isn't enough — pushing live data to the browser over WebSockets, the way a live scanner dashboard updates.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: web-security-essentials
+            title: Web security essentials
+            summary: The vulnerabilities every web dev must know — XSS, CSRF, and CORS — how they work and the defenses that stop them.
+            minutes: 11
+            level: advanced
+            status: full
+          - slug: caching-and-cdns
+            title: Caching & CDNs
+            summary: Making the web fast — browser caches, HTTP cache headers, and content delivery networks that serve your site from close to the user.
+            minutes: 9
+            level: intermediate
+            status: full
+
+      - id: shipping-a-web-app
+        label: "Unit 6 — Shipping a Web App"
+        blurb: "From working locally to running for users: deploying, measuring performance, monitoring, choosing a stack, and a look at GopherTrunk's own dashboard."
+        lessons:
+          - slug: deploying-a-web-app
+            title: Deploying a web app
+            summary: Getting your app onto the internet — build, host, and serve the front end and back end, connecting to the deployment module's toolkit.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: performance-and-web-vitals
+            title: Performance & Core Web Vitals
+            summary: What "fast" means on the web and how it's measured — load, interactivity, and layout stability — and the levers that move them.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: monitoring-and-analytics
+            title: Monitoring & analytics
+            summary: Knowing what your app does in the wild — error tracking, uptime, and privacy-respecting analytics — after it ships.
+            minutes: 8
+            level: intermediate
+            status: full
+          - slug: choosing-a-web-stack
+            title: Choosing your web stack
+            summary: A practical framework for the endless "what should I use" question — matching front end, back end, and hosting to the project in front of you.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: gophertrunk-web-dashboard
+            title: The GopherTrunk web dashboard
+            summary: A worked example — how a live dashboard for a scanner is built, from the API that serves decoded calls to the browser that shows them in real time.
+            minutes: 10
+            level: advanced
+            status: full
+
+    # Standalone reference, not part of the sequential path (no prev/next slot).
+    glossary:
+      slug: glossary
+      title: Glossary of web-development terms
+      summary: Plain-language definitions for every term in the module — front end, back end, HTML, CSS, DOM, framework, component, state, REST API, SSR, SPA, session, cookie, JWT, WebSocket, XSS, CSRF, CORS, CDN, and more — cross-linked to the lessons.
+      minutes: 11
+      level: beginner
+      status: full
+
+  - id: scanning
+    label: "Scanning & Monitoring"
+    title: "Scanning & Monitoring — the practical craft of listening to the radio spectrum"
+    tagline: "The operator's side of the hobby — building a listening station, finding and identifying systems, following trunked calls in the field, and logging, recording, and monitoring them with a scanner or SDR."
+    start_slug: what-is-scanning
+    workload: "PT7H"
+    intro: >
+      The Digital & Trunked Radio module explains how these systems work on the
+      inside; this one is about actually listening to them. Scanning is the decades-
+      old hobby of monitoring the radio spectrum — public safety, utilities,
+      aviation, business — and this module is the practical craft of doing it well
+      and legally. Start with what scanning is and what you can and can't hear
+      today, build a real listening station out of a scanner or SDR and a decent
+      antenna, learn to find and identify systems in the field, follow trunked calls
+      across a system, and log, record, and share what you hear. It finishes by
+      turning GopherTrunk into an always-on monitoring post. Pairs with the RF & SDR
+      and Digital & Trunked Radio modules; it assumes only curiosity, and everything
+      here stays firmly on the right side of the law.
+    units:
+      - id: the-scanning-hobby
+        label: "Unit 1 — The Scanning Hobby"
+        blurb: "What radio scanning is and the ground rules: a short history, conventional versus trunked, what's listenable today, and the legal and ethical lines."
+        lessons:
+          - slug: what-is-scanning
+            title: What radio scanning is
+            summary: The hobby of monitoring live radio traffic — who's on the air, why people listen, and what a modern scanning setup actually does.
+            minutes: 8
+            level: beginner
+            status: full
+          - slug: history-of-scanning
+            title: A short history of scanners
+            summary: From crystal-controlled boxes to SDR — how scanners evolved alongside the radio systems they follow, and why that history still shapes the hobby.
+            minutes: 8
+            level: beginner
+            status: full
+          - slug: conventional-vs-trunked-recap
+            title: Conventional vs. trunked, in the field
+            summary: The one distinction that changes how you scan — a fixed channel you can park on versus a trunked system you have to follow — from the listener's chair.
+            minutes: 8
+            level: beginner
+            status: full
+          - slug: what-you-can-hear
+            title: What you can (and can't) hear today
+            summary: A realistic tour of the spectrum — the analog and unencrypted traffic still open, and the encrypted systems that have gone dark.
+            minutes: 9
+            level: beginner
+            status: full
+          - slug: scanning-legal-and-ethical
+            title: Legal & ethical scanning
+            summary: The rules that keep the hobby healthy — what's legal to receive, what's not legal to do with it, and the etiquette of responsible monitoring.
+            minutes: 9
+            level: beginner
+            status: full
+
+      - id: your-listening-station
+        label: "Unit 2 — Your Listening Station"
+        blurb: "The gear that puts signals in front of you: scanners versus SDR, choosing hardware, antennas and feedlines, station setup, and beating noise."
+        lessons:
+          - slug: scanners-vs-sdr
+            title: Hardware scanners vs. SDR
+            summary: The two roads into the hobby — a dedicated scanner you switch on versus an SDR and software like GopherTrunk — and what each is best at.
+            minutes: 9
+            level: beginner
+            status: full
+          - slug: choosing-a-scanner
+            title: Choosing a scanner or SDR
+            summary: Matching hardware to what you want to hear — bands, trunking support, and budget — so you buy the right receiver the first time.
+            minutes: 9
+            level: beginner
+            status: full
+          - slug: antennas-for-scanning
+            title: Antennas for scanning
+            summary: The single biggest upgrade to what you can hear — discones, verticals, and the difference the right antenna makes over the stock whip.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: feedlines-and-connectors
+            title: Feedlines, connectors & grounding
+            summary: The unglamorous parts that quietly cost you signal — coax loss, connectors, and grounding your station safely.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: station-setup
+            title: Setting up your station
+            summary: Putting it together — receiver, antenna, and computer — into a working monitoring setup, indoors or on a rooftop.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: reducing-interference
+            title: Reducing noise & interference
+            summary: Why the city is loud on the radio — where local noise comes from, how to hunt it down, and the filters and habits that cut it.
+            minutes: 9
+            level: intermediate
+            status: full
+
+      - id: finding-what-to-listen-to
+        label: "Unit 3 — Finding What to Listen To"
+        blurb: "Turning a quiet radio into a busy one: system databases, band plans, searching and discovery, identifying unknown signals, and keeping records."
+        lessons:
+          - slug: radioreference-database
+            title: RadioReference & system databases
+            summary: The scanning community's shared map of the airwaves — how databases like RadioReference tell you what's on the air near you.
+            minutes: 9
+            level: beginner
+            status: full
+          - slug: band-plans
+            title: Band plans & where services live
+            summary: The spectrum has a floor plan — the bands where public safety, business, aviation, and the rest live, so you know where to look.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: searching-and-discovery
+            title: Search, scan & discovery
+            summary: Finding what the databases don't list — searching a band, spotting active channels, and close-call techniques for catching nearby transmitters.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: identifying-unknown-signals
+            title: Identifying an unknown signal
+            summary: You found a signal — now what is it? — using the waterfall, bandwidth, and modulation to name a mystery transmission.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: frequency-records
+            title: Building your frequency records
+            summary: Turning what you find into a reusable log — organising frequencies, talkgroups, and notes so your setup gets smarter over time.
+            minutes: 8
+            level: beginner
+            status: full
+
+      - id: following-trunked-systems
+        label: "Unit 4 — Following Trunked Systems"
+        blurb: "The heart of modern scanning: programming a trunked system, working with talkgroups and scan lists, following a call, multisite and roaming, and troubleshooting."
+        lessons:
+          - slug: programming-a-trunked-system
+            title: Programming a trunked system
+            summary: Getting a scanner or SDR to follow a trunked system — the control channel, system parameters, and what you actually enter to track it.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: talkgroups-and-scan-lists
+            title: Talkgroups, scan lists & priorities
+            summary: Deciding what you hear — organising talkgroups into scan lists, locking out the noise, and setting priorities so you never miss the calls you care about.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: following-a-call
+            title: Following a call across the system
+            summary: What happens in the seconds after a radio keys up — how your setup follows a grant from the control channel to the voice channel and back.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: multisite-and-roaming
+            title: Multisite, simulcast & roaming
+            summary: Big systems have many sites — picking the right one to monitor, what simulcast does to your signal, and following units as they roam.
+            minutes: 10
+            level: advanced
+            status: full
+          - slug: when-decoding-fails
+            title: When decoding fails
+            summary: The field troubleshooting guide — no control-channel lock, garbled voice, missed calls — and how to tell a signal problem from a setup problem.
+            minutes: 10
+            level: advanced
+            status: full
+
+      - id: logging-recording-sharing
+        label: "Unit 5 — Logging, Recording & Sharing"
+        blurb: "Getting value out of what you hear: logging and recording calls, tagging them, streaming feeds, alerting on what matters, and building an always-on post."
+        lessons:
+          - slug: logging-and-recording
+            title: Logging & recording calls
+            summary: Capturing traffic so you can review it later — call logging, per-call recording, and the storage that a busy system quickly demands.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: metadata-and-tagging
+            title: Metadata, tagging & searchability
+            summary: A recording is only useful if you can find it — tagging calls with talkgroup, time, and system so a month of audio stays searchable.
+            minutes: 8
+            level: intermediate
+            status: full
+          - slug: audio-feeds-and-streaming
+            title: Audio feeds & streaming
+            summary: Sharing what you hear — how live scanner feeds like Broadcastify work, and what it takes to put one on the air responsibly.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: alerting-on-calls
+            title: Alerting on the calls you care about
+            summary: Letting the setup watch for you — triggers and alerts on specific talkgroups or keywords so you're notified when something happens.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: building-a-monitoring-post
+            title: Building an always-on monitoring post
+            summary: Going from "switch it on when I'm home" to a setup that runs unattended — the hardware, software, and reliability of a 24/7 post.
+            minutes: 10
+            level: advanced
+            status: full
+
+      - id: scanning-with-gophertrunk
+        label: "Unit 6 — Scanning With GopherTrunk"
+        blurb: "Everything applied with real software: SDR scanning tools, GopherTrunk as a scanner, a full worked setup, the community, and where to go next."
+        lessons:
+          - slug: scanning-with-sdr-software
+            title: Scanning with SDR software
+            summary: The software side of SDR scanning — the tools that turn a raw receiver into a trunk-tracking scanner, and where GopherTrunk fits among them.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: gophertrunk-as-a-scanner
+            title: GopherTrunk as a scanner
+            summary: Using GopherTrunk to follow and decode a real system — the control channel, the calls it grants, and the audio that comes out.
+            minutes: 10
+            level: advanced
+            status: full
+          - slug: a-worked-monitoring-setup
+            title: A worked end-to-end monitoring setup
+            summary: Start to finish — antenna, SDR, GopherTrunk, logging, and a dashboard — assembled into a complete, always-on monitoring station.
+            minutes: 11
+            level: advanced
+            status: full
+          - slug: contributing-and-community
+            title: The community & contributing data
+            summary: The hobby runs on shared knowledge — the forums, databases, and open-source projects, and how to give back the systems and fixes you find.
+            minutes: 8
+            level: beginner
+            status: full
+          - slug: where-to-go-next
+            title: Where to go next
+            summary: Where the hobby leads — decoding data modes, digging into protocols, or writing your own decoder — and the modules that take you there.
+            minutes: 8
+            level: beginner
+            status: full
+
+    # Standalone reference, not part of the sequential path (no prev/next slot).
+    glossary:
+      slug: glossary
+      title: Glossary of scanning terms
+      summary: Plain-language definitions for every term in the module — scanner, SDR, control channel, talkgroup, scan list, lockout, simulcast, multisite, roaming, feed, discone, squelch, close call, and more — cross-linked to the lessons.
       minutes: 10
       level: beginner
       status: full

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -43,6 +43,12 @@ groups:
         url: /learn/dsp/
       - title: "Module: Containers & Deployment"
         url: /learn/deployment/
+      - title: "Module: Databases & Data"
+        url: /learn/databases/
+      - title: "Module: Web Development"
+        url: /learn/web-dev/
+      - title: "Module: Scanning & Monitoring"
+        url: /learn/scanning/
   - label: Field Guide
     items:
       - title: Field Guide overview

--- a/docs/learn/databases/aggregation-and-grouping.md
+++ b/docs/learn/databases/aggregation-and-grouping.md
@@ -1,0 +1,157 @@
+---
+slug: aggregation-and-grouping
+title: Aggregation & GROUP BY
+description: Turning many rows into a summary — counts, sums, and averages — with GROUP BY and HAVING, the tools behind every dashboard number. Learn aggregate functions, how grouping partitions rows, and why HAVING is not the same as WHERE.
+keywords: aggregation, GROUP BY, HAVING, COUNT, SUM, AVG, MIN, MAX, aggregate functions, summary, dashboard, grouping rows
+level: intermediate
+status: full
+prereq:
+  - filtering-and-sorting
+faq:
+  - q: "What's the difference between WHERE and HAVING?"
+    a: "WHERE filters individual rows before they're grouped; HAVING filters the groups after aggregation. Use WHERE to pick which rows count (only P25 systems), and HAVING to pick which group results survive (only systems with more than 100 calls). WHERE can't reference an aggregate like COUNT; HAVING can."
+  - q: "Do I always need GROUP BY to use COUNT or SUM?"
+    a: "No. Without GROUP BY, an aggregate collapses the whole result into a single number — COUNT(*) returns the total row count. Add GROUP BY when you want one summary row per category instead of one for the entire table."
+  - q: "Why does the database complain about a column not in GROUP BY?"
+    a: "Because once you group, each output row stands for many input rows, so a plain column has many possible values and no single answer. Every column in the SELECT must either be in the GROUP BY or wrapped in an aggregate that reduces the many values to one."
+---
+
+# Aggregation & GROUP BY
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Aggregate functions** — **COUNT**, **SUM**, **AVG**, **MIN**, **MAX** — collapse
+many rows into one summary number. **GROUP BY** partitions rows into groups and
+produces one summary row per group (calls *per system*). **HAVING** then filters those
+groups — and it's *not* the same as **WHERE**, which filters rows *before* grouping.
+These are the tools behind every dashboard total, building on
+[filtering & sorting](/learn/databases/filtering-and-sorting/).
+</div>
+
+So far every query returned rows more or less as they're stored — filtered, sorted,
+joined, but still individual rows. Often what you actually want is a *summary*: not
+every call, but how many; not each duration, but the average. That's **aggregation** —
+turning many rows into a single computed answer — and with **GROUP BY** you get one
+answer per category. Every "1,204 calls today" and "avg duration 8.3s" on a dashboard is
+this lesson.
+
+## Aggregate functions collapse rows
+
+An **aggregate function** takes many rows and returns one value. The five you'll use
+constantly:
+
+- **`COUNT`** — how many rows. `COUNT(*)` counts all rows; `COUNT(column)` counts rows
+  where that column isn't NULL.
+- **`SUM`** — the total of a numeric column.
+- **`AVG`** — the average.
+- **`MIN`** / **`MAX`** — the smallest and largest value.
+
+Used on their own, they reduce the whole table to a single row:
+
+```sql
+SELECT COUNT(*) AS total_calls,
+       AVG(duration_s) AS avg_duration,
+       MAX(duration_s) AS longest
+FROM calls;
+```
+
+One row comes back: the total number of calls, their average duration, and the longest.
+The individual rows vanish into the summary.
+
+## GROUP BY: a summary per category
+
+A single grand total is often too coarse. You want calls *per system*, average duration
+*per talkgroup*. **`GROUP BY`** partitions the rows into groups that share a value, and
+the aggregate runs *once per group*, yielding one summary row each:
+
+```sql
+SELECT system_id,
+       COUNT(*) AS call_count,
+       AVG(duration_s) AS avg_duration
+FROM calls
+GROUP BY system_id;
+```
+
+Instead of one row for the whole table, you get one row per `system_id` — its call
+count and average duration. That's the classic dashboard shape: a metric broken down by
+category. Group by more than one column to break down by combinations (system *and*
+day, say).
+
+## The golden rule of GROUP BY
+
+There's one rule that trips up every beginner, so internalise it now: **every column in
+the SELECT must either appear in the GROUP BY or be inside an aggregate.**
+
+Why? Once you group by `system_id`, each output row represents *many* input rows.
+Asking for a plain `started_at` alongside it is incoherent — which of the many
+timestamps in that group should it show? There's no single answer, so the database
+rejects it. The column has to be either the thing you grouped on (one value per group,
+fine) or reduced by an aggregate like `MAX(started_at)` (many values, collapsed to one).
+When the database complains that a column "must appear in the GROUP BY clause," this is
+what it's protecting you from.
+
+## HAVING: filter the groups
+
+You already have [WHERE](/learn/databases/filtering-and-sorting/) to filter rows. But
+what if you want to filter on the *aggregate result* — say, only systems with more than
+100 calls? WHERE can't do it: WHERE runs *before* grouping, when `COUNT(*)` doesn't
+exist yet. That's what **`HAVING`** is for — it filters the groups *after* aggregation:
+
+```sql
+SELECT system_id, COUNT(*) AS call_count
+FROM calls
+WHERE started_at >= '2026-08-01'    -- filter rows first
+GROUP BY system_id
+HAVING COUNT(*) > 100               -- then filter groups
+ORDER BY call_count DESC;
+```
+
+Notice both clauses working together. **WHERE picks which rows count** (only calls since
+August 1st). **HAVING picks which group results survive** (only systems that ended up
+with more than 100). The order the database applies them is the order to think in:
+filter rows, form groups, aggregate, filter groups, sort. Keeping WHERE and HAVING
+straight — rows before, groups after — is most of getting aggregation right.
+
+## Aggregation with joins
+
+Aggregation and [joins](/learn/databases/joins/) combine naturally, and it's where
+summaries get readable. Join first to bring in the names, then group and count:
+
+```sql
+SELECT systems.name, COUNT(calls.id) AS call_count
+FROM systems
+LEFT JOIN calls ON calls.system_id = systems.id
+GROUP BY systems.name
+ORDER BY call_count DESC;
+```
+
+The LEFT JOIN ensures systems with zero calls still appear (with a count of 0 — note
+`COUNT(calls.id)` counts non-NULL matches, so an unmatched system counts 0, not 1).
+This one query — join, group, count, sort — is the shape of a huge fraction of every
+report and dashboard you'll ever build.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — WHERE filters rows before grouping; HAVING filters the groups after aggregation." markdown="0">
+  <p class="knowledge-check__q">Quick check: you want only systems with more than 100 calls. Which clause?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">WHERE COUNT(*) > 100 — WHERE can filter on aggregates</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">HAVING COUNT(*) > 100 — HAVING filters groups after aggregation</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">LIMIT 100 — it keeps only groups over 100</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Aggregate functions** — **COUNT**, **SUM**, **AVG**, **MIN**, **MAX** — collapse
+  many rows into one summary value.
+- Without grouping, an aggregate reduces the whole result to a single number.
+- **GROUP BY** partitions rows into groups and produces one summary row per group — the
+  metric-by-category shape of every dashboard.
+- The golden rule: every SELECT column must be in the **GROUP BY** or inside an
+  **aggregate**, because each output row stands for many input rows.
+- **WHERE** filters rows *before* grouping; **HAVING** filters groups *after*
+  aggregation — they are not interchangeable.
+- Aggregation combines with **joins** (join to get names, then group and count) to
+  produce readable reports.
+
+Next up: [Inserting, updating & deleting](/learn/databases/inserting-updating-deleting/).

--- a/docs/learn/databases/backups-and-recovery.md
+++ b/docs/learn/databases/backups-and-recovery.md
@@ -1,0 +1,144 @@
+---
+slug: backups-and-recovery
+title: Backups & recovery
+description: The single most important operational habit for a database — backups you have actually restored, the difference between a dump and point-in-time recovery, and why an untested backup is not a backup at all.
+keywords: database backup, restore, point-in-time recovery, PITR, logical dump, physical backup, WAL, RPO RTO, tested backups, disaster recovery
+level: intermediate
+status: full
+prereq:
+  - transactions-and-acid
+faq:
+  - q: "What's the difference between a backup and point-in-time recovery?"
+    a: "A plain **backup** is a snapshot of your data at one moment — restore it and you're back to how things were then, losing everything since. **Point-in-time recovery** (PITR) combines a base backup with a continuous log of every change, so you can restore to *any* moment — say, the second before an accidental `DELETE` — instead of only to the last snapshot."
+  - q: "Why do people say an untested backup isn't a backup?"
+    a: "Because a backup you've never restored is a guess, not a guarantee. Backups fail silently — a broken cron job, a corrupt file, a missing table — and you find out only when you try to restore during a real emergency, which is the worst possible time. Restoring regularly to a scratch environment is the only way to know it works."
+  - q: "What are RPO and RTO?"
+    a: "Two targets that shape your backup strategy. **RPO** (recovery point objective) is how much recent data you can afford to lose — an hour, a minute, none. **RTO** (recovery time objective) is how long you can afford to be down while restoring. Tighter targets cost more; you pick them deliberately per system."
+---
+
+# Backups & recovery
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Backups are the most important operational habit a database has, and the rule that
+matters most is that **an untested backup is not a backup** — you must actually
+restore it, regularly, before you need it. Know the difference between a **snapshot**
+(restore to one moment) and **point-in-time recovery** (restore to any moment), and
+set your **RPO** and **RTO** — how much data and downtime you can tolerate — on
+purpose. This is the database side of [backups & data in deployment](/learn/deployment/backups-and-data/).
+</div>
+
+Every other lesson in this unit is about keeping a database fast and available.
+This one is about the day it goes wrong — a disk fails, a bad migration corrupts a
+table, someone runs a `DELETE` without a `WHERE`. On that day, the only thing
+standing between you and permanent data loss is a backup you can actually restore.
+It is unglamorous work, which is exactly why it's so often neglected until it's
+too late. Get it right and everything else is recoverable.
+
+## Backups are the floor
+
+A running database can fail in ways that no amount of good code prevents: hardware
+dies, a region goes dark, a deploy ships a destructive bug, or a person makes a
+mistake. Transactions and constraints keep your data *consistent*; they do nothing
+if the data is *gone*. Backups are the floor beneath everything — the guarantee that
+however bad the failure, you can get back to a known-good state.
+
+Because they're the floor, they deserve more care than any single feature. A lost
+week of decoded calls is an annoyance; a lost *database* with no backup is often the
+end of a project. Treat backups as the non-negotiable baseline, not an optimisation.
+
+## Snapshots vs. point-in-time recovery
+
+There are two broad shapes of backup, and the difference determines how much you can
+lose.
+
+- **A snapshot / dump** captures the whole database at one moment. Restore it and you
+  return to exactly that moment — but everything that happened *after* the snapshot is
+  lost. If you snapshot nightly and the database dies at 5pm, you lose the day. A
+  **logical dump** exports data as SQL statements (portable, slower to restore); a
+  **physical backup** copies the underlying files (faster, tied to the engine).
+
+- **Point-in-time recovery (PITR)** goes further. You keep a base backup *plus* a
+  continuous record of every change the database makes — the **write-ahead log** (WAL)
+  or equivalent. To recover, you restore the base and then replay the log up to a
+  chosen instant. That lets you rewind to *any* moment — crucially, to the second
+  **before** a mistake — instead of only to the last snapshot.
+
+```bash
+# Logical dump of a Postgres database (a snapshot in time)
+pg_dump --format=custom gophertrunk > gophertrunk-2026-08-04.dump
+
+# Restore it into a fresh database
+pg_restore --dbname=gophertrunk_restored gophertrunk-2026-08-04.dump
+```
+
+Snapshots are simple and often enough for a small project; PITR is what you want when
+losing even an hour of data is unacceptable.
+
+## RPO and RTO
+
+How much backup machinery you need isn't a matter of taste — it follows from two
+numbers you choose per system:
+
+- **RPO — recovery point objective.** How much recent data can you afford to lose?
+  Nightly snapshots mean an RPO of up to a day. Continuous WAL archiving pushes it
+  toward seconds. A smaller RPO costs more.
+- **RTO — recovery time objective.** How long can you be down while you restore? A
+  huge database restored from a logical dump can take hours; a physical snapshot or a
+  standby replica can cut that to minutes.
+
+Deciding these on purpose keeps you honest. "We back up nightly and a full restore
+takes three hours" is a real RPO and RTO — you just have to confirm the business can
+live with them before the outage, not during it.
+
+## The rule that matters most: test the restore
+
+Here is the lesson that costs people their data: **a backup you have never restored is
+not a backup — it's a hope.** Backups fail silently in every imaginable way. A cron
+job stops running after a server move. A dump completes but excludes a schema. The
+files are written to a disk that's also failing. The compression is corrupt. You
+cannot tell any of this from the fact that a backup *file exists*.
+
+The only proof is to **restore it, regularly, into a scratch environment** and check
+the data is all there and usable. Automate a periodic restore-and-verify so a broken
+backup surfaces on an ordinary Tuesday, not during a 3am incident. Many teams that
+"had backups" discovered during a real disaster that the backups had been unusable
+for months. Restore drills are what separate a real recovery plan from a false sense
+of safety.
+
+## Where and how many copies
+
+A backup on the same server as the database dies with the server. The durable habit
+is captured by the old **3-2-1 rule**: keep **3** copies of the data, on **2**
+different kinds of media or systems, with **1** copy off-site (a different region or
+provider). Encrypt backups — they contain all your data, so a stolen backup is a full
+breach — and control who can access and delete them, since an attacker or a buggy
+script that can wipe your backups can turn a recoverable incident into a permanent
+loss. The deployment path treats the operational side of this in
+[backups & data](/learn/deployment/backups-and-data/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a backup you've never restored is only a hope; failures are silent, so you must regularly restore and verify." markdown="0">
+  <p class="knowledge-check__q">Quick check: why is "an untested backup is not a backup"?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Because backups always work as long as the file exists</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Because backups fail silently, and only actually restoring one proves it works</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Because you must encrypt a backup before it counts</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Backups are the **floor** beneath a database — transactions keep data consistent,
+  but only a backup brings it back once it's gone.
+- A **snapshot / dump** restores to one moment (losing everything after);
+  **point-in-time recovery** replays a change log to restore to *any* moment, including
+  just before a mistake.
+- Set **RPO** (how much data you can lose) and **RTO** (how long you can be down) on
+  purpose — they drive how much backup machinery you need.
+- The rule that matters most: **test the restore.** An unrestored backup is a hope;
+  failures are silent, so restore and verify regularly in a scratch environment.
+- Keep multiple copies, at least one **off-site** (3-2-1), **encrypt** them, and guard
+  who can delete them.
+
+Next up: [replication, sharding & scaling](/learn/databases/replication-and-scaling/).

--- a/docs/learn/databases/caching-layers.md
+++ b/docs/learn/databases/caching-layers.md
@@ -1,0 +1,167 @@
+---
+slug: caching-layers
+title: Caching layers
+description: A cache keeps hot data in fast memory in front of the database so repeated reads skip the slow lookup. Learn what a cache buys you, the cache-aside pattern, TTLs, and why cache invalidation is one of the genuinely hard problems in software.
+keywords: caching, cache layer, Redis, cache-aside, TTL, cache invalidation, stale data, cache hit, cache miss, memcached, read-through cache, hot data
+level: intermediate
+status: full
+prereq:
+  - key-value-and-document
+faq:
+  - q: What is a cache, in one sentence?
+    a: "A small, fast store — usually in memory — that holds copies of data you read often, sitting in front of your slower database so repeated reads can be answered from the cache instead of hitting the database every time."
+  - q: What is the cache-aside pattern?
+    a: "The most common caching approach: your app checks the cache first; on a hit it returns the cached value, and on a miss it reads from the database, stores the result in the cache, and returns it. The cache fills itself lazily with whatever data actually gets requested, and each entry usually has a TTL so it eventually refreshes."
+  - q: Why is cache invalidation considered so hard?
+    a: "Because a cache holds a *copy* of data that can change underneath it. The moment the database updates, the cached copy is stale, and knowing exactly when and how to remove or refresh every affected entry — without missing one or clearing too much — is genuinely tricky. A TTL bounds staleness by time; explicit invalidation on write is more precise but easy to get subtly wrong."
+---
+
+# Caching layers
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A **cache** is a small, fast store — usually in-memory, like **Redis** — that holds
+copies of frequently-read data **in front of** your database, so repeated reads are
+answered from memory instead of a slower lookup. The common approach is
+**cache-aside**: check the cache, and on a **miss** fetch from the database and store
+the result. The catch — and one of the genuinely hard problems in software — is
+**invalidation**: a cached copy goes **stale** the moment the underlying data changes.
+A cache is itself a [key-value store](/learn/databases/key-value-and-document/) put to
+a specific job.
+</div>
+
+This unit's last stop isn't a new *kind* of data — it's a technique that sits in front
+of whatever database you already have. Caching is how you make a system that reads the
+same data over and over dramatically faster, and it's nearly universal in production
+apps. It also comes with one famously hard problem, which is worth understanding
+clearly before you rely on one.
+
+## What a cache buys you
+
+Some data gets read far more than it changes. A system's configuration, a popular
+talkgroup's label, a user's profile — read on nearly every request, updated rarely.
+Hitting the database for each of those reads is wasteful: the same query, the same
+answer, again and again, each one costing a round-trip and some database work.
+
+A **cache** is a small, very fast store — almost always in **memory**, which is orders
+of magnitude faster than disk — that sits **between your app and the database** and
+holds copies of that hot data. When the data's already there (a **cache hit**), you
+answer from memory and never touch the database. Two big wins follow:
+
+- **Latency** — a memory lookup is far faster than a database query, so cached reads
+  return almost instantly.
+- **Load** — every hit is a query your database *didn't* have to run, so the database
+  survives far more traffic before it strains.
+
+**Redis** and **Memcached** are the usual tools, and it's no accident they're key-value
+stores from the last lesson: fetch-by-key is exactly the fast, simple operation a cache
+needs.
+
+## Cache-aside: the standard pattern
+
+The most common way to use a cache is **cache-aside** (also called lazy loading). Your
+application code sits between the cache and the database and follows a simple dance:
+
+```go
+func getSystem(id string) (System, error) {
+    // 1. Try the cache first.
+    if v, ok := cache.Get("system:" + id); ok {
+        return v, nil                       // cache hit
+    }
+    // 2. Miss — read from the database.
+    sys, err := db.LoadSystem(id)
+    if err != nil {
+        return System{}, err
+    }
+    // 3. Store it in the cache for next time, then return.
+    cache.Set("system:"+id, sys, 5*time.Minute)
+    return sys, nil
+}
+```
+
+On a **hit**, you return immediately. On a **miss**, you read from the database, *put
+the result in the cache*, and return it — so the next request for the same key is a hit.
+The cache fills itself **lazily** with exactly the data that actually gets requested;
+data nobody reads never takes up space. This is the pattern you'll reach for most.
+
+## TTL: letting entries expire
+
+Notice the `5*time.Minute` above — that's a **TTL** (time to live). Each cached entry is
+stamped with an expiry, and once it passes, the cache drops the entry; the next read
+misses and refetches fresh data from the database. TTLs do two jobs at once:
+
+- They **bound staleness**: no cached value is ever more than its TTL out of date, even
+  if you do nothing else.
+- They **bound memory**: entries that stop being read eventually expire and free space,
+  and caches also **evict** old entries when full (commonly least-recently-used).
+
+Choosing a TTL is a trade. Longer means more hits and less database load but more time
+serving slightly-old data; shorter means fresher data but more misses. Data that can
+tolerate being a few minutes old — most read-heavy display data — is the sweet spot for
+a generous TTL.
+
+## The hard problem: invalidation and staleness
+
+Here's the rub, captured in a famous programmers' joke: *there are only two hard things
+in computer science — cache invalidation and naming things.* A cache holds a **copy**.
+The instant the real data changes in the database, that copy is **stale** — it says
+something the source of truth no longer says. If you cached a talkgroup's label and
+someone renames it, every cache hit now returns the old name until something fixes the
+entry.
+
+You have two levers, and both are imperfect:
+
+- **Expire by TTL.** Simple and robust — the stale window is at most the TTL. But you
+  *will* serve stale data for that window, so it only suits data that tolerates being a
+  little old.
+- **Invalidate on write.** When you update the database, also delete (or update) the
+  affected cache entry, so the next read refetches fresh. More precise, but harder than
+  it sounds: you must find *every* key that depends on the changed data, do it reliably
+  even if the write and the invalidation can't be one atomic step, and avoid both
+  missing an entry (stale forever) and clearing too much (needless misses).
+
+The reason invalidation is genuinely hard is that it re-creates, in a new place, the
+same **duplication** problem [normalization](/learn/databases/normalization/) warned
+about: a fact now lives in two places — the database and the cache — and keeping them in
+agreement is exactly the difficulty. A cache is deliberate, managed duplication for
+speed, and the price is that you own the job of keeping the copy honest.
+
+## Use a cache on purpose
+
+A cache is a powerful tool, not a default to sprinkle everywhere. Add one when you have
+a **measured** read-heavy hotspot — the same expensive reads dominating your load — and
+data that can tolerate being briefly stale. Match the staleness lever to the data:
+generous TTLs for display data, tight invalidation for things that must look fresh, and
+no cache at all for data that changes as often as it's read. Done well, a caching layer
+is one of the highest-leverage performance wins available; done carelessly, it's a
+machine for serving wrong answers quickly. Get it right and you have the front of a
+production data stack — which is exactly where the next unit picks up, wiring a database
+into real running code.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the cache holds a copy, so when the source data changes the copy is stale, and knowing exactly what to refresh and when is the hard part." markdown="0">
+  <p class="knowledge-check__q">Quick check: why is cache invalidation considered a genuinely hard problem?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Caches are too slow to update once data is written</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The cache holds a copy that goes stale when the source changes, and knowing exactly what to refresh, and when, is tricky</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Caches can only ever store data permanently and never remove it</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **cache** is a small, fast, usually in-memory store (like **Redis**) **in front of**
+  your database, holding copies of frequently-read data.
+- It cuts **latency** (memory beats disk) and **load** (every **hit** is a query the
+  database didn't run).
+- **Cache-aside** is the standard pattern: check the cache, and on a **miss** read the
+  database, store the result, and return it — filling the cache lazily.
+- A **TTL** expires each entry after a set time, bounding both **staleness** and memory
+  use; longer TTLs mean more hits but staler data.
+- **Invalidation is the hard part**: a cached copy goes **stale** when the source
+  changes. Bound it with a TTL, or invalidate on write for precision — both are easy to
+  get subtly wrong because a cache is deliberate duplication you must keep honest.
+- Add a cache **on purpose**, for a measured read-heavy hotspot with staleness-tolerant
+  data — not by default everywhere.
+
+Next up: [Connecting from your program](/learn/databases/connecting-from-code/).

--- a/docs/learn/databases/choosing-a-database.md
+++ b/docs/learn/databases/choosing-a-database.md
@@ -1,0 +1,145 @@
+---
+slug: choosing-a-database
+title: Choosing a database
+description: A practical framework for picking the right database for a project — SQLite, Postgres, MySQL, a document store, or a managed service like Supabase — starting from your data shape and access patterns rather than hype.
+keywords: choosing a database, SQLite, PostgreSQL, MySQL, document database, managed database, Supabase, boring technology, database selection, default to Postgres
+level: intermediate
+status: full
+prereq:
+  - sql-vs-nosql
+faq:
+  - q: "What database should I default to?"
+    a: "For most applications, **Postgres** — a mature, free, relational database that does an enormous amount well, from ordinary tables to JSON documents and vector search. Defaulting to Postgres and only diverging when you have a concrete reason is a strategy that rarely goes wrong. For a small local or embedded app, **SQLite** is the even simpler default."
+  - q: "When is SQLite actually the right choice?"
+    a: "More often than people think. SQLite is a full SQL database that lives in a single file inside your process — no server to run. It's ideal for local apps, desktop and mobile software, tests, prototypes, and even modest web apps with light write concurrency. You reach for a client-server database when many machines must write concurrently at scale."
+  - q: "Should I pick the newest, most exciting database?"
+    a: "Usually not. Databases hold your most important asset — your data — and maturity, stability, and a deep pool of documentation and hiring matter more than novelty. 'Choose boring technology' is genuinely good advice here: pick the well-understood option unless a specific need forces something specialised."
+---
+
+# Choosing a database
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Choosing a database starts from your **data shape and access patterns**, not from
+hype. For most projects the right default is **Postgres** (or **SQLite** for a small,
+local, or embedded app) — mature, relational, and capable far beyond plain tables.
+Reach for a specialised store only when a concrete need — a document model, extreme
+scale, time-series, vectors — forces it. **Choose boring technology**: your data is
+too important to bet on novelty. This ties together everything from
+[SQL vs. NoSQL](/learn/databases/sql-vs-nosql/) onward.
+</div>
+
+By now you've met relational databases, key-value and document stores, time-series
+and column stores, vector databases, and caches. The natural question is: for *my*
+project, which one? The honest answer is less exciting than the marketing suggests —
+most projects are best served by a well-understood relational database, and the skill
+is knowing the few situations that genuinely call for something else. This lesson is a
+framework for deciding, and a strong default so you're not choosing from a blank page.
+
+## Start from your data, not the tool
+
+The wrong way to choose a database is to pick a technology you've heard is fast or
+web-scale and then bend your problem to fit it. The right way is to look at your data
+first and let it point you:
+
+- **What shape is the data?** Rows with clear relationships between things (users have
+  calls, calls belong to systems)? That's relational. Self-contained documents that
+  vary in shape? Maybe a document store. Just values behind keys? Key-value.
+- **How will you read it?** Rich queries, joins, and reports across the data pull
+  strongly toward SQL. A single known-key lookup is happy in almost anything.
+- **How much, and how fast will it grow?** Thousands of rows and a hobbyist's traffic
+  need nothing exotic. Billions of writes a day is a different conversation.
+- **What consistency do you need?** Money and bookings want strong transactional
+  guarantees; a metrics feed can tolerate eventual consistency.
+
+Answer those and the field narrows itself. The [data modeling](/learn/databases/data-modeling/)
+and [SQL vs. NoSQL](/learn/databases/sql-vs-nosql/) lessons are the deeper version of
+this step.
+
+## A strong default: Postgres (or SQLite)
+
+If you take one thing from this lesson: **default to Postgres, and diverge only for a
+reason.** Postgres is a free, mature, relational database that quietly does a
+staggering amount — solid SQL and transactions, JSON columns when you want document-ish
+flexibility, full-text search, and even vector search through an extension. It scales
+far past where most projects ever reach, and it has decades of documentation, tooling,
+and people who know it.
+
+For a smaller footprint, **SQLite** is the even simpler default. It's a complete SQL
+database in a single file, embedded in your process with no server to run or secure —
+perfect for local apps, desktop and mobile software, tests, and prototypes, and
+capable of running real web apps with modest write concurrency. GopherTrunk itself
+leans on SQLite for exactly these reasons, as the next lesson shows.
+
+Between them, these two cover the overwhelming majority of projects. Starting from one
+of them is rarely a decision you'll regret.
+
+## When to reach for something else
+
+Diverge from the default when you have a **concrete, specific need** that a specialised
+store serves markedly better — the kinds of jobs Unit 4 covered:
+
+- **A genuine document model** — deeply nested, schema-varying documents you always
+  fetch whole — can fit a [document store](/learn/databases/key-value-and-document/).
+- **Massive time-stamped data** — metrics, sensor readings, events — belongs in a
+  [time-series or column store](/learn/databases/time-series-and-analytics/) tuned for it.
+- **Search by meaning** for AI retrieval calls for a
+  [vector database](/learn/databases/vector-databases/) or a vector-capable Postgres.
+- **A hot, simple, high-throughput cache or key-value need** suits Redis or a
+  [caching layer](/learn/databases/caching-layers/).
+- **Truly extreme write scale** beyond one machine is where distributed and NoSQL
+  systems and [sharding](/learn/databases/replication-and-scaling/) earn their
+  complexity.
+
+Notice these are *needs*, not preferences. "I might go web-scale someday" is not one of
+them; you can migrate when the need is real and measured.
+
+## Run it yourself or use a managed service
+
+Separate from *which* database is *who operates it*. Running a production database well
+— backups, upgrades, replication, monitoring, security — is real, ongoing work. A
+**managed database** (a cloud provider's Postgres/MySQL, or a service like Supabase,
+Neon, or PlanetScale) hands that operational burden to a vendor: they handle patching,
+backups, and failover, and you pay for it and give up some low-level control.
+
+For most teams, especially small ones, a managed service is the right call — your time
+is better spent on your product than on database administration. Run your own only when
+cost, control, or specific requirements justify the operational load. The tradeoff is
+the same managed-versus-self one that runs through all of
+[deployment](/learn/deployment/).
+
+## Choose boring technology
+
+The thread through all of this: **your data is your most important and least
+replaceable asset, so choose conservatively.** A database's maturity, stability,
+documentation, and the number of people who know it matter more than benchmarks or
+novelty. The newest database with the best landing page is the one you'll be debugging
+alone at 3am with no Stack Overflow answers. "Choose boring technology" is not
+cynicism — it's how you keep your data safe and your future self sane. Pick the
+well-understood option, and let a specific, demonstrated need be the only thing that
+moves you off it.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — start from your data shape and access patterns, default to a mature relational database like Postgres, and diverge only for a concrete need." markdown="0">
+  <p class="knowledge-check__q">Quick check: what's the soundest way to choose a database for a new project?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Pick the newest, most hyped database so you're ready for web scale</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Start from your data shape and access patterns; default to a mature option like Postgres and diverge only for a concrete need</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Always use whichever NoSQL store is fastest in benchmarks</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Choose from your **data shape, access patterns, scale, and consistency needs** —
+  not from hype or a technology you want to try.
+- **Default to Postgres** — mature, relational, and capable far beyond tables — or
+  **SQLite** for small, local, or embedded apps; together they fit most projects.
+- Reach for a **specialised store** (document, time-series, vector, cache, distributed)
+  only when a **concrete need** genuinely calls for it — not "someday" scale.
+- Decide separately whether to **self-host or use a managed service**; for most teams a
+  managed database is the better use of time.
+- **Choose boring technology** — your data is too important to bet on novelty; pick the
+  well-understood option and diverge only for a demonstrated reason.
+
+Next up: [data in GopherTrunk](/learn/databases/data-in-gophertrunk/).

--- a/docs/learn/databases/connecting-from-code.md
+++ b/docs/learn/databases/connecting-from-code.md
@@ -1,0 +1,155 @@
+---
+slug: connecting-from-code
+title: Connecting from your program
+description: How a running program actually opens a link to a database — the driver that speaks the database's protocol, the connection string that says where and who, and where to keep the credentials so they never end up in your code.
+keywords: database driver, connection string, DSN, credentials, host port user password, TCP connection, TLS, environment variable, connect from code, database client
+level: intermediate
+status: full
+prereq:
+  - what-is-sql
+faq:
+  - q: "What is a database driver?"
+    a: "A **driver** is the library that lets your program speak a specific database's wire protocol. Postgres, MySQL, and SQLite each have their own on-the-wire format; the driver turns your query into bytes the server understands and turns the response back into values your code can read. You pick the driver that matches your database."
+  - q: "What goes in a connection string?"
+    a: "Where the database is and who is connecting: the host and port, the database name, a username and password, and options like TLS mode. It is often written as one URL-like string (a **DSN**, data source name). The credentials in it are secrets — load them from the environment, never hard-code them."
+  - q: "Do I open a new connection for every query?"
+    a: "No. Opening a connection is expensive — a TCP handshake, TLS, and authentication every time. Real apps open a small set once and reuse them, which is what a **connection pool** does. The next lesson covers pooling in full."
+---
+
+# Connecting from your program
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+To talk to a database, your program needs three things: a **driver** that speaks
+the database's protocol, a **connection string** that says where the database is
+and who is connecting, and **credentials** kept safely out of your source. The
+driver turns your SQL into bytes on a socket and the reply back into values. Get
+these right and every query in this module runs from real code. Next you will
+learn why you should never open one connection per query — see
+[connection pools](/learn/databases/connection-pooling/).
+</div>
+
+So far every query in this module has been something you might type into a
+database shell. Real software doesn't type queries — it sends them from a running
+program. This lesson is the bridge: how a process on your machine actually opens a
+link to a database, authenticates, and starts sending SQL. There is less magic
+here than you might expect, and knowing the pieces makes every "cannot connect"
+error readable.
+
+## The driver speaks the protocol
+
+A database server doesn't accept plain text over a socket the way a web server
+accepts HTTP. Each database has its own **wire protocol** — a binary format for
+requests and responses. Postgres speaks one, MySQL another, SQLite doesn't use a
+socket at all because it lives inside your process as a file.
+
+The library that knows a given protocol is the **driver**. Your code calls a
+normal function like "run this query"; the driver serialises that into the exact
+bytes the server expects, reads the response, and hands you back rows and values.
+You choose a driver to match your database — a Postgres driver won't talk to
+MySQL. In most languages the standard library gives you a common *interface* and
+you plug in the driver underneath, so your code looks the same across databases
+even though the wire format differs.
+
+## The connection string says where and who
+
+To open a link, the driver needs to know two things: **where** the database is and
+**who** is connecting. That information is usually packed into one
+**connection string**, also called a **DSN** (data source name). It commonly looks
+like a URL:
+
+```
+postgres://scanner:s3cret@db.internal:5432/gophertrunk?sslmode=require
+```
+
+Read left to right, that says: use the Postgres driver, log in as user `scanner`
+with password `s3cret`, connect to host `db.internal` on port `5432`, use the
+database named `gophertrunk`, and require an encrypted (**TLS**) connection. Some
+drivers take the same information as separate key-value pairs instead:
+
+```
+host=db.internal port=5432 user=scanner password=s3cret dbname=gophertrunk sslmode=require
+```
+
+Either way the ingredients are the same — **host, port, database, user, password,
+and options**. The options matter more than they look: `sslmode=require`, for
+instance, is the difference between your password crossing the network encrypted
+or in the clear.
+
+## Credentials are secrets
+
+A connection string contains a password, so it is a secret — treat it exactly like
+an API key. **Never hard-code it in source, and never commit it to git.** A leaked
+database credential is worse than a leaked API key: it can mean someone reading,
+altering, or deleting all your data.
+
+Load the connection string, or at least the password, from an **environment
+variable** or a secret manager at runtime:
+
+```bash
+export DATABASE_URL="postgres://scanner:s3cret@db.internal:5432/gophertrunk?sslmode=require"
+```
+
+Then your program reads `DATABASE_URL` from its environment and passes it to the
+driver. The value lives in your deployment's configuration, not your repository.
+This is the same discipline the AI path teaches for API keys in
+[your first API call](/learn/building-ai/your-first-api-call/), and the security
+path treats as a rule in [secure coding](/learn/cybersecurity/secure-coding/).
+
+## What "open" actually does
+
+When your code opens a connection, a fair amount happens under the hood:
+
+- **A network connection** is established to the host and port — a TCP handshake,
+  and for a remote database a TLS handshake on top to encrypt the link.
+- **Authentication** — the driver sends the username and password (or a token),
+  and the server checks them and grants a session.
+- **A session** is now open: a stateful channel over which you can send queries and
+  read results until you close it or it drops.
+
+All of that costs real time — often milliseconds, sometimes more across a slow
+network. That cost is exactly why you don't want to pay it on every query, which
+leads straight into pooling.
+
+## When connecting fails
+
+The failures here are common and, once you know the pieces, self-explanatory:
+
+- **Connection refused / timeout** — nothing is listening at that host and port, or
+  a firewall is blocking you. Check the host, the port, and network reach.
+- **Authentication failed** — wrong username or password, or the user isn't allowed
+  from your address. Check the credentials and the database's access rules.
+- **Database does not exist** — the server is reachable and you authenticated, but
+  the named database isn't there. Check the `dbname` part.
+- **TLS / SSL errors** — the server requires encryption you didn't offer, or a
+  certificate doesn't verify. Check the `sslmode` and certificate settings.
+
+Each maps to one ingredient of the connection string, which is why reading the
+string carefully is usually the fastest way to fix a connection problem.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the driver speaks the database's wire protocol, turning your query into bytes and the reply back into values." markdown="0">
+  <p class="knowledge-check__q">Quick check: what is a database driver's job?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">To store your tables and indexes on disk</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">To speak the database's wire protocol — turning queries into bytes and replies into values</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">To write your SQL for you so you don't have to</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- To talk to a database from code you need a **driver**, a **connection string**,
+  and **credentials** — and the driver must match your database.
+- The driver speaks the database's **wire protocol**, turning your query into bytes
+  on a socket and the response back into values.
+- A **connection string** (DSN) carries **host, port, database, user, password, and
+  options** like TLS mode — often as one URL-like string.
+- The credentials are secrets: load them from an **environment variable** or secret
+  manager, never hard-code or commit them.
+- Opening a connection is real work — TCP, TLS, and authentication — which is why
+  you reuse connections rather than open one per query.
+- Most connection failures map cleanly to one part of the connection string: host,
+  auth, database name, or TLS.
+
+Next up: [connection pools](/learn/databases/connection-pooling/).

--- a/docs/learn/databases/connection-pooling.md
+++ b/docs/learn/databases/connection-pooling.md
@@ -1,0 +1,151 @@
+---
+slug: connection-pooling
+title: Connection pools
+description: Opening a database connection is expensive, so real applications keep a small pool of connections open and hand them out for each query — what a pool is, why it exists, and how to size one without starving the database or your app.
+keywords: connection pool, database pooling, max connections, pool size, connection reuse, idle connection, connection lifetime, pgbouncer, pool exhaustion, sizing a pool
+level: intermediate
+status: full
+prereq:
+  - connecting-from-code
+faq:
+  - q: "Why not just open a connection for each query?"
+    a: "Because opening one is slow — a TCP handshake, TLS, and authentication every time — and the database can only handle so many open connections at once. Under load, open-per-query either crawls or overwhelms the server. A **pool** opens a handful once and reuses them, so a query borrows a ready connection instead of paying the setup cost."
+  - q: "How big should the pool be?"
+    a: "Smaller than you think. A pool of tens, not thousands. The database has a hard cap on total connections, and past a point more connections mean more contention, not more throughput. Size the pool to your database's limit divided across all your app instances, and tune from measurements."
+  - q: "What happens when the pool is empty?"
+    a: "A query that needs a connection waits for one to be returned, up to a timeout. If every connection is busy and none free up in time, the query fails with a pool-exhaustion or timeout error — usually a sign the pool is too small, queries are too slow, or connections are being held too long."
+---
+
+# Connection pools
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Opening a database connection is expensive, so applications keep a **pool** of them
+open and lend one out per query, returning it when done. A pool trades a little
+memory for a lot of speed and protects the database from being swamped by too many
+connections. The main knobs are **pool size**, **idle timeout**, and **connection
+lifetime**, and the main failure is **pool exhaustion** — all connections busy at
+once. Sizing it well starts from your database's own
+[connection limits](/learn/databases/connecting-from-code/).
+</div>
+
+The previous lesson showed how much work opening a connection is: a network
+handshake, TLS, and authentication, all before a single query runs. Paying that on
+every query would be absurd — like re-negotiating a phone contract before each call.
+So real applications don't. They open a small set of connections once, keep them
+alive, and reuse them. That set is a **connection pool**, and understanding it is
+the difference between an app that stays fast under load and one that falls over.
+
+## What a pool is
+
+A **connection pool** is a managed collection of open database connections that your
+application holds ready. When code needs to run a query it **borrows** a connection
+from the pool, uses it, and **returns** it — the connection stays open for the next
+borrower rather than being torn down.
+
+Think of it like a pool of shared bikes at a station. Bikes are expensive to build,
+so you don't manufacture one each time someone wants to ride; you keep a rack of
+them, riders take one and bring it back, and the rack serves far more trips than it
+has bikes. A connection pool works the same way: a handful of connections serves a
+stream of queries, because no single query holds one for long.
+
+In most stacks you never manage this by hand. You configure a pool once at startup
+and the library hands out connections behind your normal "run this query" calls.
+
+## Why a pool, not a connection per query
+
+Two problems make open-per-query a bad idea, and the pool solves both.
+
+- **Setup cost.** Every open pays for TCP, TLS, and auth — often several
+  milliseconds. Under hundreds of queries a second, that overhead dominates. A
+  pooled connection has already paid it once, so borrowing is nearly free.
+- **The database's own limit.** A database server can only keep so many connections
+  open at once — each one costs it memory and a process or thread. Open a fresh
+  connection per concurrent request and a traffic spike can blow straight past that
+  cap, at which point the server rejects *everyone*. A pool bounds how many
+  connections you ever open, so your app can't overwhelm the database.
+
+The second point surprises people: a pool isn't only a speed optimisation, it's a
+**safety limit**. It's the throttle that keeps your app a well-behaved client.
+
+## Sizing the pool
+
+The tempting instinct — "more connections, more speed" — is wrong past a small
+number. A database does real work per connection, and beyond the point where it can
+keep every connection busy, extra ones just add contention and context-switching.
+Throughput goes *down*, not up.
+
+The right size is usually **surprisingly small** — often in the tens. Two limits box
+it in:
+
+- **The database's max connections.** This is a hard ceiling on the server. Your
+  pool — across *every* app instance — must fit under it. Ten app instances each
+  with a pool of 20 means 200 connections; the database must allow at least that.
+- **How many queries are truly running at once.** A connection is only useful while
+  it's executing a query. If your queries are fast, a few connections churn through
+  an enormous number of them.
+
+Start from the database's limit, divide it across your instances with headroom to
+spare, and then **tune from measurements** — watch how often the pool is full and
+how long queries wait, and adjust. Guessing large is the classic mistake.
+
+## The knobs that matter
+
+Beyond raw size, a pool exposes a few settings worth knowing:
+
+- **Max open / max pool size** — the ceiling on total connections. The safety limit
+  above.
+- **Max idle** — how many connections to keep open when things are quiet. Too low and
+  you re-open constantly on the next burst; too high and you hold connections you
+  aren't using.
+- **Idle timeout** — close a connection that's been unused for this long, so a quiet
+  period releases resources back to the database.
+- **Max lifetime** — retire and replace a connection after this long, even if it's
+  healthy. This lets load rebalance after a failover and sidesteps connections that
+  slowly go stale.
+
+## Pool exhaustion
+
+The signature failure is **pool exhaustion**: every connection is checked out and a
+new query has nowhere to go. It waits for one to be returned, and if none frees up
+within the timeout, it fails.
+
+Exhaustion almost always points at one of three things: the pool is **too small** for
+the load, queries are **too slow** (each holds its connection longer), or code is
+**holding connections it isn't using** — the classic bug of borrowing a connection,
+starting a slow non-database task, and only then returning it. The fix is rarely
+"make the pool huge"; it's usually to speed up the queries or shorten how long each
+connection is held.
+
+For very high connection counts — many app instances, or serverless functions that
+each want a pool — a dedicated **external pooler** (like PgBouncer in front of
+Postgres) sits between your apps and the database and multiplexes many client
+connections onto a few real ones.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a pool reuses a small set of already-open connections, avoiding the setup cost and bounding how many you ever open." markdown="0">
+  <p class="knowledge-check__q">Quick check: why do applications use a connection pool?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">To make queries return more rows at once</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">To reuse a small set of open connections, avoiding per-query setup cost and capping load on the database</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">To encrypt the connection so credentials stay safe</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Opening a connection is expensive, so apps keep a **pool** of open connections and
+  **borrow and return** one per query instead of opening a fresh one each time.
+- A pool avoids per-query **setup cost** and, just as important, **caps** how many
+  connections your app opens — protecting the database from being swamped.
+- The right pool size is usually **small** (tens): past the point the database can
+  keep them busy, more connections *reduce* throughput.
+- Size it from the database's **max connections** divided across your app instances,
+  then tune from measurements.
+- Know the knobs — **max size, max idle, idle timeout, max lifetime** — and their
+  tradeoffs.
+- **Pool exhaustion** (all connections busy) usually means the pool is too small,
+  queries are too slow, or connections are held too long — not that the pool needs
+  to be enormous.
+
+Next up: [ORMs vs. raw SQL](/learn/databases/orms-vs-raw-sql/).

--- a/docs/learn/databases/constraints-and-integrity.md
+++ b/docs/learn/databases/constraints-and-integrity.md
@@ -1,0 +1,175 @@
+---
+slug: constraints-and-integrity
+title: Constraints & data integrity
+description: Constraints let the database enforce your data's rules no matter what code writes to it. Learn NOT NULL, UNIQUE, CHECK, primary-key, and foreign-key constraints, and why the database is a safer place for a rule than your application.
+keywords: constraints, data integrity, NOT NULL, UNIQUE constraint, CHECK constraint, foreign key constraint, referential integrity, primary key, database rules, validation, cascade
+level: intermediate
+status: full
+prereq:
+  - keys-and-relationships
+  - data-modeling
+faq:
+  - q: Why enforce a rule in the database if my app already checks it?
+    a: "Because the database is the one place every write must pass through. App checks can be bypassed — by another service, a bug, a manual query, or a second app hitting the same database. A constraint is enforced no matter what code does the writing, so it can't be skipped by accident."
+  - q: What's the difference between a primary key and a UNIQUE constraint?
+    a: "Both guarantee no duplicate values. A primary key is the row's official identifier — one per table, and it can't be null. A UNIQUE constraint enforces uniqueness on some other column (like an email), can be applied to several columns, and typically does allow nulls. Use the primary key for identity, UNIQUE for other must-be-distinct fields."
+  - q: What does a foreign key with ON DELETE CASCADE do?
+    a: "It tells the database that when a parent row is deleted, its child rows should be deleted too — automatically. It's one way to keep referential integrity when removing data. The alternatives are to block the delete (RESTRICT) or set the child's reference to null (SET NULL); which you want depends on what the relationship means."
+---
+
+# Constraints & data integrity
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Constraints** are rules you declare *in the schema* so the **database itself**
+enforces them on every write — not your app, which can be bypassed. The core set is
+**NOT NULL** (a value is required), **UNIQUE** (no duplicates), **CHECK** (a value
+must satisfy a condition), **PRIMARY KEY** (unique identity), and **FOREIGN KEY**
+(a reference must point at a row that exists). Together they guarantee **data
+integrity** — that the data in your tables is always valid — building directly on
+[keys & relationships](/learn/databases/keys-and-relationships/).
+</div>
+
+You've modeled your tables and normalized them. But a schema that merely *allows* good
+data isn't the same as one that *guarantees* it. Constraints are how you move a rule
+out of hopeful application code and into the database, where it's enforced on every
+single write, forever, no matter who or what is doing the writing.
+
+## The rule that matters: put integrity where writes can't dodge it
+
+Here's the core argument. Your application validates input — good. But your database
+is very likely written to by more than just that one code path: a second service, a
+background job, a data-migration script, a developer running SQL by hand at 2am, or a
+future rewrite in another language. Every one of those can *skip* your app's checks.
+Not one of them can skip a **constraint**, because a constraint lives in the table and
+the database refuses any write that violates it.
+
+So the principle is: **the database is the last line of defense, and the only one
+every write must cross.** App-level validation is still worth having — it gives users
+friendly, immediate errors — but it's a convenience on top of the constraint, not a
+replacement for it. This is the same defense-in-depth thinking as
+[secure coding](/learn/cybersecurity/secure-coding/): don't trust that callers behaved.
+
+## NOT NULL: a value is required
+
+The simplest constraint. **NOT NULL** says this column must always have a value —
+inserting or updating a row without one is rejected. `NULL` in SQL means "unknown or
+absent," and it's a frequent source of bugs (it isn't equal to anything, not even
+another `NULL`). Marking the columns that *must* be present keeps those surprises out
+of the data entirely.
+
+```sql
+CREATE TABLE calls (
+    call_id    INTEGER PRIMARY KEY,
+    system_id  INTEGER NOT NULL,     -- every call must belong to a system
+    started_at TIMESTAMP NOT NULL,   -- every call has a start time
+    notes      TEXT                  -- optional: null is allowed here
+);
+```
+
+Decide for each column whether absence is meaningful. A call with no start time is
+nonsense — `NOT NULL`. A call with no notes is fine — leave it nullable.
+
+## UNIQUE: no duplicates
+
+A **UNIQUE** constraint forbids two rows from sharing the same value in a column (or
+combination of columns). It's how you enforce that emails, usernames, or a system's
+external ID are distinct:
+
+```sql
+CREATE TABLE users (
+    user_id INTEGER PRIMARY KEY,
+    email   TEXT NOT NULL UNIQUE      -- no two users share an email
+);
+```
+
+This overlaps with the **primary key**, which is also unique — but they play different
+roles. The primary key is the row's one official **identity**, one per table, never
+null. A `UNIQUE` constraint enforces distinctness on *other* fields, can be declared on
+several columns at once (a composite uniqueness rule), and usually permits nulls. Use
+the primary key for identity; use `UNIQUE` for every other "these can't repeat" rule.
+
+## CHECK: the value has to make sense
+
+A **CHECK** constraint enforces an arbitrary condition on a row's values — anything you
+can write as a boolean expression. It's how you stop impossible data at the door:
+
+```sql
+CREATE TABLE calls (
+    call_id     INTEGER PRIMARY KEY,
+    duration_ms INTEGER NOT NULL CHECK (duration_ms >= 0),
+    frequency   BIGINT  NOT NULL CHECK (frequency BETWEEN 25000000 AND 1300000000)
+);
+```
+
+A negative duration or a frequency outside the radio spectrum you support is now
+simply *impossible to store*. `CHECK` is the constraint people reach for least and
+benefit from most: it encodes your domain's real limits into the schema, so a bug that
+tries to write garbage fails loudly instead of quietly corrupting a row.
+
+## FOREIGN KEY: references must point at something real
+
+A **foreign key** constraint enforces **referential integrity** — the guarantee that a
+reference actually points at a row that exists. If `calls.system_id` is a foreign key
+into `systems`, the database will reject any call whose `system_id` has no matching
+system, and it will refuse to delete a system that still has calls pointing at it
+(unless you tell it otherwise). No more **orphan rows** referring to things that were
+never there or have since vanished.
+
+```sql
+CREATE TABLE calls (
+    call_id   INTEGER PRIMARY KEY,
+    system_id INTEGER NOT NULL REFERENCES systems(system_id)
+);
+```
+
+You control what happens to children when a parent is deleted with a **referential
+action**:
+
+- **ON DELETE RESTRICT** (often the default) — block the delete while children exist.
+  Safe: you must clean up children first.
+- **ON DELETE CASCADE** — delete the children automatically with the parent. Convenient
+  for truly owned data (delete a system, delete its calls), dangerous if you didn't
+  mean it.
+- **ON DELETE SET NULL** — keep the child but null out its reference. For optional links
+  where the child outlives the parent.
+
+Which you choose is a statement about what the relationship *means*, so choose it
+deliberately rather than accepting the default by accident.
+
+## Integrity is a property you declare once
+
+The payoff of all this is that **data integrity stops being a thing you remember to do
+and becomes a property the schema holds automatically.** Once the constraints are in
+place, invalid data can't enter through any door. Bad writes fail with a clear error
+at the moment they happen — right where the bug is — instead of surfacing as
+mysterious wrong answers weeks later. When you combine constraints with the all-or-
+nothing guarantee of the next lesson, you get a database that keeps itself correct even
+under concurrent, partial, and failing writes.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a constraint is enforced by the database on every write, so no code path, script, or second app can bypass it." markdown="0">
+  <p class="knowledge-check__q">Quick check: your app validates input, so why also add a constraint in the database?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Constraints make queries run faster than app-side checks</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Every write must pass the database, but app checks can be bypassed by other code, scripts, or services</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">The database can validate data that application code is unable to check</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Constraints** move a rule into the schema so the **database enforces it on every
+  write** — the one path no code can skip.
+- **NOT NULL** requires a value; use it for every column where absence would be
+  nonsense.
+- **UNIQUE** forbids duplicates on non-identity columns like email; the **primary key**
+  is the row's single official, non-null identity.
+- **CHECK** enforces any condition on a row's values, encoding your domain's real limits
+  so impossible data can't be stored.
+- **FOREIGN KEY** enforces referential integrity — references must point at real rows —
+  with **RESTRICT / CASCADE / SET NULL** deciding what happens to children on delete.
+- App validation is a friendly extra; the constraint is the guarantee. Together they
+  make **data integrity** a property the schema holds by itself.
+
+Next up: [Transactions & ACID](/learn/databases/transactions-and-acid/).

--- a/docs/learn/databases/data-and-persistence.md
+++ b/docs/learn/databases/data-and-persistence.md
@@ -1,0 +1,133 @@
+---
+slug: data-and-persistence
+title: Data, state & persistence
+description: The difference between data your program holds in memory and data that outlives it. Learn what persistence and durability really mean, why "just save it" is harder than it looks, and why a database is the reliable place for state that must survive.
+keywords: data persistence, state, in-memory, volatile, durability, save data, RAM vs disk, ephemeral data, fsync, crash safety, persistent storage
+level: beginner
+status: full
+prereq:
+  - what-is-a-database
+faq:
+  - q: "What's the difference between memory and persistence?"
+    a: "Data in memory (RAM) lives only while your program runs — quit or crash and it's gone. Persistent data is written to durable storage (disk) so it survives the program ending, a restart, or a power loss. Persistence is the act of moving state from the volatile place to the lasting one."
+  - q: "If I write to a file, is my data safe?"
+    a: "Not necessarily. The operating system often buffers a write in memory before it actually reaches the disk, so a crash in that window loses it. True durability means the data is confirmed on disk — which is one of the guarantees a database is built to give you, and hand-rolled file code usually isn't."
+  - q: "Does persistent mean permanent?"
+    a: "No. Persistent means it survives the program that created it — a restart, a crash. It can still be deleted, overwritten, or lost if the disk fails. That's why persistence and backups are different concerns; you need both."
+---
+
+# Data, state & persistence
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Data your program holds in memory is **volatile** — it vanishes when the program
+stops. **Persistence** is writing that **state** somewhere durable so it outlives
+the process; **durability** is the stronger promise that a confirmed write really
+reached the disk and survives a crash. "Just save it" is deceptively hard, which
+is exactly the work a database takes off your hands — building on
+[what a database is](/learn/databases/what-is-a-database/).
+</div>
+
+The last lesson said a program eventually needs to *remember* something. This one
+is about what "remember" actually means, because there are two very different
+kinds of memory in a computer — one that forgets the moment you stop, and one that
+holds on. Knowing which is which, and how to move data safely between them, is the
+foundation everything else in this module sits on.
+
+## State: the data a program holds right now
+
+While your program runs, it holds **state** — the current values of everything
+it's working with. The user who's logged in, the list of calls decoded so far, a
+half-filled form. This state lives in **memory** (RAM): fast, close to the CPU,
+and easy to change. It's where all the actual work happens.
+
+But RAM has one defining property: it's **volatile**. When the program exits — on
+purpose, from a crash, or because the power blinked — everything in memory is
+gone, instantly and completely. There's no undo. A program that keeps its data
+only in memory is a program that forgets everything the moment it stops. For a
+calculator, fine. For anything that has to remember across runs, that's the whole
+problem.
+
+## Persistence: making state outlive the program
+
+**Persistence** is the fix: writing state out to **durable storage** — a disk, an
+SSD, a database — so it survives the process ending. Persistent data is data you
+can still read tomorrow, after a restart, after the machine was off all night.
+The move from volatile to durable is the act of *persisting*.
+
+The two live on very different terms:
+
+| | In-memory state | Persistent data |
+|---|---|---|
+| **Lives in** | RAM | Disk / SSD / database |
+| **Survives program exit?** | No | Yes |
+| **Speed** | Extremely fast | Slower |
+| **Capacity** | Limited by RAM | Much larger |
+| **On a crash** | Lost | Survives (if durably written) |
+
+Almost every real application is a dance between the two: load persistent data
+into memory to work with it, and write changes back out so they aren't lost. The
+in-memory copy is the working set; the persistent copy is the source of truth.
+
+## "Just save it" is harder than it sounds
+
+Here's the trap. Writing data to a file *looks* like persistence — you called
+`write`, the data's on disk, done. Except often it isn't. For speed, the operating
+system usually **buffers** your write in memory and reports success before the
+bytes actually hit the disk platter. If the machine loses power in that window,
+the write you thought was safe is gone.
+
+**Durability** is the stronger guarantee: once the system confirms a write, the
+data is truly on disk and will survive a crash. Getting there means explicitly
+flushing buffers to the physical device (the `fsync` system call), and ordering
+writes so a crash mid-operation leaves recoverable data, not a corrupt heap. Doing
+that correctly, for concurrent writers, is genuinely hard engineering.
+
+```go
+// Naive: looks saved, may not survive a crash mid-flight.
+os.WriteFile("calls.log", data, 0644)
+
+// The OS may buffer this. Real durability needs an explicit
+// flush to the physical disk — and correct ordering if a crash
+// hits partway through. A database does this for you, correctly.
+```
+
+This is one of the biggest reasons to reach for a database. A DBMS makes
+durability a *promise*: when it confirms a write, that data is committed and will
+be there after a crash. You get to think about your data, not about `fsync`
+ordering.
+
+## Persistence isn't the same as permanent
+
+One more distinction that saves grief later: **persistent** means "survives the
+program," not "safe forever." A persisted file can still be deleted, overwritten
+by a bug, or lost when the disk itself dies. Guarding against *that* is a separate
+job — copies kept elsewhere, tested restores — which the deployment path covers in
+[backups & data](/learn/deployment/backups-and-data/). Persistence keeps your data
+across a restart; backups keep it across a disaster. Real systems need both, and
+confusing the two is how people lose data they thought was safe.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — in-memory state is volatile and vanishes on exit; persistence writes it to durable storage that survives." markdown="0">
+  <p class="knowledge-check__q">Quick check: what happens to data your program holds only in memory when it crashes?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It's automatically saved to disk by the operating system</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">It's lost — memory is volatile, so unpersisted state vanishes</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Nothing — memory survives a crash just like disk does</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A program's **state** lives in **memory (RAM)**, which is **volatile** — it
+  vanishes when the program stops or crashes.
+- **Persistence** writes state to **durable storage** so it outlives the process; a
+  restart later can read it back.
+- **Durability** is the stronger promise that a *confirmed* write actually reached
+  the disk — the OS often buffers writes, so a naive file save can still be lost.
+- Getting durability right (flushing, crash-safe ordering, concurrent writers) is
+  hard — a **database** makes it a guarantee so you don't have to.
+- **Persistent** is not the same as **permanent**: persisted data can still be
+  deleted or lost, which is why persistence and **backups** are separate concerns.
+
+Next up: [The relational model — tables, rows & columns](/learn/databases/the-relational-model/).

--- a/docs/learn/databases/data-in-gophertrunk.md
+++ b/docs/learn/databases/data-in-gophertrunk.md
@@ -1,0 +1,204 @@
+---
+slug: data-in-gophertrunk
+title: Data in GopherTrunk
+description: A worked example that ties the whole module together — how a trunking scanner like GopherTrunk models systems, talkgroups, units, and decoded calls into tables, stores them in embedded SQLite, indexes them for search and playback, and sweeps old data away.
+keywords: GopherTrunk data model, SQLite call log, scanner database, systems talkgroups calls schema, foreign keys, indexes, retention sweep, worked example, embedded database
+level: advanced
+status: full
+prereq:
+  - choosing-a-database
+---
+
+# Data in GopherTrunk
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+This is the module's worked example: [GopherTrunk](/) decodes radio traffic into a
+stream of **calls**, and it stores them in an **embedded SQLite** database. The domain
+maps cleanly onto the relational model — **systems**, **talkgroups**, **units**, and
+**calls** become tables joined by **foreign keys** — with **indexes** for the searches
+the UI runs and a **retention sweep** to bound growth. Every idea from this module —
+schema, keys, joins, indexes, transactions, and choosing the right database — shows up
+here in one real system. See the [architecture](/architecture.html) for the full picture.
+</div>
+
+We'll finish where the module started — with a real program that needs to remember
+things — and watch every concept line up against it. [GopherTrunk](/) is a software
+radio scanner: it tunes trunked radio systems, decodes the control channel, follows
+voice calls, and records them. That produces a steady stream of events that have to be
+stored so you can search, replay, and analyse them later. This is the data problem, and
+it's a good one because it's neither trivial nor exotic — exactly the kind most software
+faces.
+
+## The domain, as things and relationships
+
+Before any SQL, the [data-modeling](/learn/databases/data-modeling/) step: what are the
+*things*, and how do they relate? Listening to the scanner, they fall out naturally:
+
+- A **system** — a trunked radio network (a county's P25 system, say), with a name and
+  identifiers.
+- A **talkgroup** — a logical channel within a system (Fire Dispatch, Police North).
+  Each talkgroup **belongs to** one system.
+- A **unit** — an individual radio (a **radio ID**, or RID) heard on the system.
+- A **call** — a single voice transmission: which system and talkgroup, which unit
+  keyed up, when it started and stopped, the frequency, whether it was encrypted, and a
+  path to the recorded audio.
+
+The relationships are plain English: a system **has many** talkgroups; a talkgroup
+**has many** calls; a call is **made by** a unit. That "has many / belongs to" language
+is the tell that this is [relational](/learn/databases/the-relational-model/) data —
+tables joined by [keys](/learn/databases/keys-and-relationships/).
+
+## The schema
+
+Each thing becomes a table, each relationship a **foreign key**. Here is the shape,
+trimmed to the essentials:
+
+```sql
+CREATE TABLE systems (
+    id          INTEGER PRIMARY KEY,
+    name        TEXT    NOT NULL,
+    protocol    TEXT    NOT NULL          -- 'P25', 'DMR', 'NXDN', ...
+);
+
+CREATE TABLE talkgroups (
+    id          INTEGER PRIMARY KEY,
+    system_id   INTEGER NOT NULL REFERENCES systems(id),
+    tgid        INTEGER NOT NULL,          -- the on-air talkgroup number
+    label       TEXT,
+    UNIQUE (system_id, tgid)               -- a TGID is unique within its system
+);
+
+CREATE TABLE calls (
+    id            INTEGER PRIMARY KEY,
+    system_id     INTEGER NOT NULL REFERENCES systems(id),
+    talkgroup_id  INTEGER          REFERENCES talkgroups(id),
+    unit_rid      INTEGER,                 -- the radio that keyed up
+    started_at    INTEGER NOT NULL,        -- unix time
+    ended_at      INTEGER,
+    frequency_hz  INTEGER NOT NULL,
+    encrypted     INTEGER NOT NULL DEFAULT 0,
+    audio_path    TEXT
+);
+```
+
+Notice how much the schema enforces on its own, exactly as the
+[constraints](/learn/databases/constraints-and-integrity/) lesson argued: `NOT NULL`
+means a call can never exist without a start time or a frequency, `REFERENCES` means a
+call can't point at a system that doesn't exist, and the `UNIQUE (system_id, tgid)`
+means the same talkgroup number can't be registered twice for one system. The database
+refuses bad data regardless of any bug in the decoder feeding it. The design is
+[normalized](/learn/databases/normalization/): a system's name lives in exactly one row,
+so renaming it is a single update, not a hunt through every call.
+
+## Querying it
+
+The web dashboard's questions become [joins](/learn/databases/joins/) and
+[filters](/learn/databases/filtering-and-sorting/). "Show the last 50 calls on this
+system, newest first, with talkgroup labels":
+
+```sql
+SELECT c.started_at, t.label, c.unit_rid, c.frequency_hz, c.audio_path
+FROM calls c
+LEFT JOIN talkgroups t ON t.id = c.talkgroup_id
+WHERE c.system_id = ?
+ORDER BY c.started_at DESC
+LIMIT 50;
+```
+
+It's a `LEFT JOIN` because a call might be heard before its talkgroup is known, and we
+still want to show it. "How busy was each talkgroup today?" is
+[aggregation](/learn/databases/aggregation-and-grouping/):
+
+```sql
+SELECT t.label, COUNT(*) AS calls, SUM(c.ended_at - c.started_at) AS air_seconds
+FROM calls c
+JOIN talkgroups t ON t.id = c.talkgroup_id
+WHERE c.started_at > ?
+GROUP BY t.label
+ORDER BY calls DESC;
+```
+
+Every dashboard number in the UI is a query of this kind — the same `SELECT`, `JOIN`,
+`WHERE`, `GROUP BY` you've built up all module.
+
+## Making it fast — and safe from Go
+
+A scanner running for weeks accumulates a lot of calls, and the common queries all
+filter by system and sort by time. So the [indexes](/learn/databases/indexes/) follow
+the access patterns:
+
+```sql
+CREATE INDEX idx_calls_system_time ON calls (system_id, started_at DESC);
+CREATE INDEX idx_calls_talkgroup   ON calls (talkgroup_id);
+```
+
+With those, "last 50 calls on system 7" is an index lookup, not a scan over every call
+ever recorded — the difference between an instant page and a spinner. The storage layer
+writes from Go using [`database/sql`](/learn/databases/databases-in-go/) with
+**parameterised queries** throughout, so an operator-supplied search term is bound as a
+value and can never become SQL — [injection](/learn/databases/sql-injection/) closed by
+construction:
+
+```go
+rows, err := db.QueryContext(ctx,
+    `SELECT started_at, unit_rid, audio_path
+     FROM calls WHERE system_id = ? AND started_at > ?
+     ORDER BY started_at DESC LIMIT ?`,
+    systemID, since, limit)
+```
+
+Recording a completed call — insert the row, update the talkgroup's last-heard time —
+happens in a [transaction](/learn/databases/transactions-and-acid/) so a crash can never
+leave a half-written call.
+
+## Why SQLite, and keeping it bounded
+
+GopherTrunk [chooses](/learn/databases/choosing-a-database/) **embedded SQLite** for its
+call log, and the reasoning is a clean instance of that lesson. The scanner is often a
+single machine — a mini-PC or a Raspberry Pi in a closet — with one writer (the decode
+engine) and light read traffic (an operator's dashboard). There's no need for a separate
+database server to install, secure, and keep running; SQLite is a single file in the
+process, which means zero operational overhead and trivial backups (copy the file). It's
+the right default for exactly this shape of workload.
+
+Left alone, that file would grow forever, so a **retention sweep** runs periodically to
+delete calls (and their audio) older than a configured window — bounding the database
+the way any long-running system must. Backing it up is as simple as the
+[backups](/learn/databases/backups-and-recovery/) lesson's copy-and-verify, and if a
+deployment ever outgrows one machine, the same relational model ports to Postgres with
+the [migrations](/learn/databases/migrations/) discipline. The
+[architecture overview](/architecture.html) shows the storage layer in the context of
+the whole decode pipeline.
+
+That's the module in one system: a real domain modeled as tables, tied together by keys,
+queried with joins and aggregation, kept fast with indexes and safe with constraints and
+parameterised Go, stored in a database chosen to fit — and bounded so it runs for years.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a call belongs to one system and one talkgroup via foreign keys, so a call can never reference a system that doesn't exist and shared facts live in one place." markdown="0">
+  <p class="knowledge-check__q">Quick check: in GopherTrunk's schema, how is a call linked to its system and talkgroup?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">By copying the full system and talkgroup names into every call row</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">By foreign keys — the call stores the system and talkgroup ids, joined back when needed</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">By storing all calls for a system inside a single JSON blob</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- GopherTrunk's domain — **systems, talkgroups, units, calls** — is naturally
+  [relational](/learn/databases/the-relational-model/), modeled as tables joined by
+  **foreign keys**.
+- The **schema** lets the database enforce the rules — `NOT NULL`, `REFERENCES`, and
+  `UNIQUE` [constraints](/learn/databases/constraints-and-integrity/) keep bad data out
+  — and is [normalized](/learn/databases/normalization/) so each fact lives once.
+- The dashboard's questions are ordinary **joins, filters, and aggregations**, made fast
+  with [indexes](/learn/databases/indexes/) that follow the access patterns.
+- Writes go through Go's `database/sql` with **parameterised queries** and
+  **transactions** — [injection](/learn/databases/sql-injection/)-safe and atomic.
+- **Embedded SQLite** is the deliberate [choice](/learn/databases/choosing-a-database/)
+  for a single-machine, single-writer workload, with a **retention sweep** to bound
+  growth and a trivial file-copy backup.
+
+Next up: keep the [glossary](/learn/databases/glossary/) handy, and see how it all ships in [Containers &amp; Deployment](/learn/deployment/).

--- a/docs/learn/databases/data-modeling.md
+++ b/docs/learn/databases/data-modeling.md
@@ -1,0 +1,172 @@
+---
+slug: data-modeling
+title: Data modeling for a real app
+description: Data modeling is the craft of turning what an app does into a set of tables and relationships. Learn to find entities from the nouns, relationships from the verbs, and how to model one-to-many and many-to-many links before writing code.
+keywords: data modeling, database design, entities, relationships, entity relationship, one-to-many, many-to-many, junction table, schema design, modeling data, ERD, database schema
+level: intermediate
+status: full
+prereq:
+  - keys-and-relationships
+  - normalization
+faq:
+  - q: Where do I start when modeling a new app?
+    a: "With the nouns. Write down the important things your app talks about — users, orders, systems, calls — and each distinct kind of thing usually becomes a table (an entity). Then look at the verbs connecting them to find the relationships. You can sketch this on paper before touching a database."
+  - q: What's a junction table and when do I need one?
+    a: "A junction (or join) table sits between two tables to model a many-to-many relationship — where each side can link to many of the other. It holds a foreign key to each side, turning one many-to-many link into two clean one-to-many links. You need one whenever both sides can have many of the other."
+  - q: Should I model everything perfectly up front?
+    a: "No. Model the core entities and relationships you understand now, keep it normalized, and expect it to evolve. Migrations exist precisely because schemas change — a good model is one that's clear today and easy to extend, not one that predicts every future need."
+---
+
+# Data modeling for a real app
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Data modeling** turns "what does my app do" into a set of **tables and
+relationships** before you write code. The reliable method: **entities come from the
+nouns**, **relationships come from the verbs**, and each relationship is
+**one-to-one**, **one-to-many**, or **many-to-many** — the last of which needs a
+**junction table**. It's the same keys-and-foreign-keys machinery from
+[keys & relationships](/learn/databases/keys-and-relationships/), applied on purpose
+to a real problem, and kept clean with
+[normalization](/learn/databases/normalization/).
+</div>
+
+Normalization told you how to arrange columns *correctly*. Data modeling is the step
+before that: deciding what the tables even are. It's the part of database work that
+feels most like design rather than mechanics, and doing it well up front saves you
+from fighting your own schema for months. The good news is there's a dependable
+recipe.
+
+## Start with the nouns
+
+Write one or two plain sentences describing what your app does, then **underline the
+nouns**. Each important, distinct kind of thing is an **entity**, and most entities
+become a table.
+
+> "A scanner decodes **calls** on trunked **systems**. Each call belongs to a
+> **talkgroup** and may be recorded to an audio **file**."
+
+The nouns — *call*, *system*, *talkgroup*, *file* — are your candidate tables. Give
+each one a **primary key** to name its rows and the columns that are genuinely *its
+own* attributes. A system has a name and a WACN; a call has a start time and a
+duration. Attributes that turn out to belong to a *different* noun are exactly the
+duplication normalization warns about — they go with their real owner.
+
+## Find relationships in the verbs
+
+Now look at the **verbs** connecting those nouns: a call *belongs to* a system, a
+talkgroup *is heard on* a system, a call *is recorded to* a file. Each verb is a
+**relationship**, and every relationship has a **cardinality** — how many of each side
+connect to the other. There are three shapes, and telling them apart is the whole
+game.
+
+## One-to-many: the workhorse
+
+A **one-to-many** relationship means one row on one side links to many rows on the
+other, but each of those links back to just one. One system has many calls; each call
+belongs to exactly one system. This is by far the most common shape.
+
+You model it by putting a **foreign key on the "many" side**, pointing at the "one":
+
+```sql
+CREATE TABLE systems (
+    system_id  INTEGER PRIMARY KEY,
+    name       TEXT NOT NULL
+);
+
+CREATE TABLE calls (
+    call_id    INTEGER PRIMARY KEY,
+    system_id  INTEGER NOT NULL REFERENCES systems(system_id),  -- the "many" side
+    talkgroup  TEXT NOT NULL,
+    started_at TIMESTAMP NOT NULL
+);
+```
+
+The foreign key always lives on the many side. A quick test: ask "does *this* thing
+belong to *one* of the other?" If a call belongs to one system, the call row carries
+the `system_id`.
+
+## Many-to-many: use a junction table
+
+Sometimes both sides can have many of the other. A **talkgroup** might be patched
+across several systems, and a system carries many talkgroups — that's a
+**many-to-many** relationship, and you *cannot* model it with a single foreign key on
+either side, because neither side has just one of the other.
+
+The answer is a third table — a **junction table** (also called a join, link, or
+bridge table) — that holds a foreign key to each side. Each row is one pairing:
+
+```sql
+CREATE TABLE talkgroups (
+    talkgroup_id INTEGER PRIMARY KEY,
+    label        TEXT NOT NULL
+);
+
+CREATE TABLE system_talkgroups (        -- the junction table
+    system_id    INTEGER NOT NULL REFERENCES systems(system_id),
+    talkgroup_id INTEGER NOT NULL REFERENCES talkgroups(talkgroup_id),
+    PRIMARY KEY (system_id, talkgroup_id)
+);
+```
+
+A junction table turns one messy many-to-many into two clean one-to-many
+relationships — system-to-link and talkgroup-to-link — which is why it's the standard
+solution. It's also the natural home for facts *about the pairing itself*, like when a
+talkgroup was first heard on that system.
+
+## One-to-one: less common, real enough
+
+A **one-to-one** relationship links exactly one row to one row. You reach for it when
+you want to split a table — say, to keep a large, rarely-read blob (a call's full audio
+metadata) out of the hot main row, or to separate optional data. It's modeled with a
+foreign key on one side that's also marked **unique**, so at most one match exists. Use
+it sparingly; often a one-to-one is really just more columns on the same table.
+
+## Sketch it, then check it against the questions
+
+Before you commit, draw the entities as boxes and the relationships as lines — an
+**entity-relationship diagram**, even a rough one on paper. Then pressure-test the
+model by asking the real questions your app needs to answer: "show every call on this
+system in the last hour," "list the talkgroups this system carries," "find the file
+for this call." Each question should be answerable by following keys and joins you've
+actually modeled. If a question forces an awkward workaround, the model is telling you
+something's missing.
+
+Finally, sanity-check against normalization: is any fact stored twice? If a system's
+name appears in the `calls` table, back it out. A model that's clean here is a model
+that stays trustworthy as data pours in.
+
+## Model for change, not for prophecy
+
+You will not get it perfectly right, and you don't need to. Model the entities and
+relationships you understand *now*, keep them normalized, and lean on
+[migrations](/learn/databases/migrations/) to evolve the schema as the app grows. A
+good model is clear today and cheap to extend tomorrow — not an attempt to foresee
+every feature. The recipe stays the same at every scale: nouns become entities, verbs
+become relationships, and many-to-many gets a junction table.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — when both sides can have many of the other, you need a junction table holding a foreign key to each side." markdown="0">
+  <p class="knowledge-check__q">Quick check: a talkgroup can be on many systems and a system carries many talkgroups. How do you model that?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Put a foreign key to systems on the talkgroups table</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Add a junction table with a foreign key to each side</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Store a comma-separated list of system IDs in a talkgroup column</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Data modeling** turns what an app does into **tables and relationships** before
+  you write code.
+- **Entities come from the nouns**; each distinct kind of thing becomes a table with
+  its own primary key and its own attributes.
+- **Relationships come from the verbs**, and each has a cardinality: one-to-one,
+  one-to-many, or many-to-many.
+- **One-to-many** — the common case — is a **foreign key on the "many" side**.
+- **Many-to-many** needs a **junction table** holding a foreign key to each side, which
+  also stores facts about the pairing.
+- **Sketch the model, test it against the real questions**, check it for duplication,
+  and expect to evolve it with migrations rather than predicting the future.
+
+Next up: [Constraints & data integrity](/learn/databases/constraints-and-integrity/).

--- a/docs/learn/databases/databases-in-go.md
+++ b/docs/learn/databases/databases-in-go.md
@@ -1,0 +1,215 @@
+---
+slug: databases-in-go
+title: Talking to a database from Go
+description: The Go way to use a database — the database/sql package and its driver model, opening a pooled handle, running parameterised queries, scanning rows, prepared statements, and transactions — the patterns a service like GopherTrunk uses.
+keywords: Go database/sql, Go database driver, sql.DB, QueryContext, Scan rows, prepared statement, parameterised query Go, sql.Tx transaction, connection pool Go, pgx
+level: advanced
+status: full
+prereq:
+  - sql-injection
+faq:
+  - q: "Do I need an ORM to use a database in Go?"
+    a: "No. Go's standard library ships `database/sql`, a clean interface for running SQL directly, and idiomatic Go leans toward using it (or a thin helper) rather than a heavy ORM. You get parameterised queries, a built-in connection pool, and full control over the SQL, with a small amount of row-scanning boilerplate."
+  - q: "Is sql.DB a single connection?"
+    a: "No — and this trips people up. An `sql.DB` is a **pool** of connections managed for you, safe for concurrent use by many goroutines. You open one per database at startup and share it for the life of the program; you do not open one per request."
+  - q: "How do I avoid SQL injection in Go?"
+    a: "Pass values as query arguments, never format them into the SQL string. `db.QueryContext(ctx, \"... WHERE id = $1\", id)` sends the value as a parameter, so it can never be parsed as SQL. Using `fmt.Sprintf` to build a query with user input is the bug to avoid."
+---
+
+# Talking to a database from Go
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Go talks to databases through the standard library's **`database/sql`** package: you
+register a **driver**, open a single **`sql.DB`** — which is a **connection pool**, not
+one connection — and run **parameterised queries** whose values are passed as
+arguments, never formatted into the string. You **scan** result rows into variables,
+use **prepared statements** for repeated queries, and wrap multi-step writes in a
+**transaction**. This is the concrete, idiomatic version of everything in this unit,
+and the shape a service like [GopherTrunk](/learn/databases/data-in-gophertrunk/) uses.
+</div>
+
+Everything in this unit — connecting, pooling, avoiding injection, choosing between
+raw SQL and an ORM — comes together in real code. Go is a good language to see it in,
+because its standard library takes a clear position: it gives you a thin, safe SQL
+interface rather than an ORM, so the concepts you've just learned are right on the
+surface. If you're new to the language, the [Programming in Go](/learn/programming-go/)
+path covers the basics; here we focus on the database.
+
+## The database/sql model
+
+Go's `database/sql` package defines a **generic interface** to SQL databases, and the
+actual database-specific code lives in a **driver** you import separately. You write
+against `database/sql`; the driver underneath speaks Postgres, MySQL, SQLite, or
+whatever you chose. The driver registers itself via a blank import:
+
+```go
+import (
+    "database/sql"
+
+    _ "github.com/jackc/pgx/v5/stdlib" // registers the "pgx" driver
+)
+```
+
+The underscore means "import for its side effects only" — you never call the driver
+directly, you just make it available to `database/sql` by name. Swap the driver and
+your query code barely changes.
+
+## Open a pooled handle
+
+You open the database once, at startup, and keep the handle for the program's life:
+
+```go
+db, err := sql.Open("pgx", os.Getenv("DATABASE_URL"))
+if err != nil {
+    log.Fatalf("open db: %v", err)
+}
+defer db.Close()
+
+// Open() doesn't actually connect — verify with a ping.
+if err := db.PingContext(ctx); err != nil {
+    log.Fatalf("connect db: %v", err)
+}
+
+db.SetMaxOpenConns(20)
+db.SetMaxIdleConns(5)
+db.SetConnMaxLifetime(time.Hour)
+```
+
+The crucial thing to understand: **`sql.DB` is a connection pool, not a connection.**
+It is safe to share across every goroutine, it opens and reuses connections for you,
+and the `SetMax*` calls are exactly the [pool knobs](/learn/databases/connection-pooling/)
+from earlier. You do **not** open a new `sql.DB` per request — that would defeat the
+pool entirely. Note too that `sql.Open` is lazy; it validates arguments but doesn't
+connect, so a `Ping` confirms the credentials and reachability up front.
+
+## Querying safely
+
+Reading rows is a query, then a loop that **scans** each row into variables:
+
+```go
+rows, err := db.QueryContext(ctx,
+    `SELECT id, started_at, talkgroup
+     FROM calls
+     WHERE system_id = $1 AND started_at > $2
+     ORDER BY started_at DESC
+     LIMIT 50`,
+    systemID, since,
+)
+if err != nil {
+    return nil, err
+}
+defer rows.Close()
+
+var calls []Call
+for rows.Next() {
+    var c Call
+    if err := rows.Scan(&c.ID, &c.StartedAt, &c.Talkgroup); err != nil {
+        return nil, err
+    }
+    calls = append(calls, c)
+}
+return calls, rows.Err() // check Err() after the loop, too
+```
+
+The `$1` and `$2` are **placeholders**, and `systemID` and `since` are passed as
+**arguments** — they travel to the database as data, so this is injection-proof by
+construction. This is the whole lesson of [SQL injection](/learn/databases/sql-injection/)
+in one idiom: never build the query with `fmt.Sprintf`, always pass values as
+parameters. `QueryRowContext` is the variant for a query you expect to return a
+single row.
+
+## Prepared statements
+
+If you run the same query many times — say, inserting every decoded call — you can
+**prepare** it once so the database parses and plans it a single time, then execute it
+repeatedly with different values:
+
+```go
+stmt, err := db.PrepareContext(ctx,
+    `INSERT INTO calls (system_id, talkgroup, started_at) VALUES ($1, $2, $3)`)
+if err != nil {
+    return err
+}
+defer stmt.Close()
+
+for _, c := range batch {
+    if _, err := stmt.ExecContext(ctx, c.SystemID, c.Talkgroup, c.StartedAt); err != nil {
+        return err
+    }
+}
+```
+
+Prepared statements are still fully parameterised — the same injection safety — and
+they save the parse-and-plan cost on each execution. `ExecContext` is what you use
+for statements that don't return rows (`INSERT`, `UPDATE`, `DELETE`).
+
+## Transactions
+
+When several writes must succeed or fail together, wrap them in a **transaction** so
+the change is all-or-nothing, exactly the [ACID](/learn/databases/transactions-and-acid/)
+guarantee:
+
+```go
+tx, err := db.BeginTx(ctx, nil)
+if err != nil {
+    return err
+}
+defer tx.Rollback() // no-op if we've already committed
+
+if _, err := tx.ExecContext(ctx,
+    `UPDATE systems SET last_seen = $1 WHERE id = $2`, now, systemID); err != nil {
+    return err // deferred Rollback undoes any partial work
+}
+if _, err := tx.ExecContext(ctx,
+    `INSERT INTO calls (system_id, talkgroup, started_at) VALUES ($1, $2, $3)`,
+    systemID, tg, now); err != nil {
+    return err
+}
+return tx.Commit()
+```
+
+The pattern is idiomatic Go: `defer tx.Rollback()` right after `BeginTx`, so any
+early return unwinds the transaction, and a successful `Commit()` at the end makes the
+rollback a harmless no-op. All statements on `tx` run on the **same connection**, which
+is what makes them one atomic unit.
+
+## A few Go-specific habits
+
+- **Always pass a `context.Context`** (the `...Context` methods). It carries deadlines
+  and cancellation, so a slow query dies with its request instead of hanging a pooled
+  connection.
+- **Always `defer rows.Close()`** and check `rows.Err()` after the loop — a leaked
+  `rows` holds its connection out of the pool.
+- **`sql.ErrNoRows`** is how `QueryRow(...).Scan` signals "no row found"; handle it as
+  a normal case, not an error.
+- **Prefer the standard library or a thin helper.** Idiomatic Go tends toward
+  `database/sql` (or a light layer like `sqlx`) over a full ORM — the
+  [raw-SQL end of the tradeoff](/learn/databases/orms-vs-raw-sql/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — an sql.DB is a connection pool safe for concurrent use, opened once and shared, not a single connection per request." markdown="0">
+  <p class="knowledge-check__q">Quick check: what is a Go <code>sql.DB</code>?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">A single database connection you open per request</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">A connection pool, safe for concurrent use, opened once and shared for the program's life</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">An ORM that maps Go structs to tables automatically</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Go uses the standard library's **`database/sql`** with a separately imported
+  **driver** — you write generic SQL code and swap the driver underneath.
+- **`sql.Open` returns an `sql.DB`, which is a connection pool**, not a single
+  connection — open it once, share it, and tune it with `SetMaxOpenConns` and friends.
+- Run **parameterised queries** with placeholders (`$1`) and pass values as arguments;
+  never build SQL with `fmt.Sprintf` — that's injection-proof by construction.
+- **Scan** result rows into variables in a `rows.Next()` loop, always `defer
+  rows.Close()`, and check `rows.Err()`.
+- Use **prepared statements** for repeated queries and **transactions** (`BeginTx` /
+  `Commit` with a deferred `Rollback`) for all-or-nothing writes.
+- Pass a **`context.Context`** to every call, and lean on the standard library rather
+  than reaching first for an ORM.
+
+Next up: [backups & recovery](/learn/databases/backups-and-recovery/).

--- a/docs/learn/databases/filtering-and-sorting.md
+++ b/docs/learn/databases/filtering-and-sorting.md
@@ -1,0 +1,152 @@
+---
+slug: filtering-and-sorting
+title: Filtering, sorting & limiting
+description: WHERE, ORDER BY, and LIMIT narrow a result set to the rows that matter, in the order you want, without dragging back the whole table. Learn to filter with conditions, combine them, handle NULL correctly, sort, and page through results.
+keywords: WHERE, ORDER BY, LIMIT, filtering, sorting, SQL conditions, AND OR, IN, LIKE, BETWEEN, NULL, IS NULL, pagination, OFFSET
+level: beginner
+status: full
+prereq:
+  - querying-with-select
+faq:
+  - q: "Why can't I use = NULL to find empty values?"
+    a: "Because NULL means 'unknown', and unknown compared to anything — even another NULL — is itself unknown, never true. So frequency_hz = NULL matches nothing. You must use IS NULL (or IS NOT NULL), which is the special syntax for testing the absence of a value."
+  - q: "Does ORDER BY change the table's stored order?"
+    a: "No. Rows in a table have no inherent order; ORDER BY sorts only the result set of that one query. If you want results sorted, you must say so every time — never rely on the order rows happen to come back without an ORDER BY."
+  - q: "What's the point of LIMIT?"
+    a: "LIMIT caps how many rows come back, so you fetch just the first page or the top few rather than an entire large table. Paired with ORDER BY (and OFFSET) it's how apps show 'the 20 most recent calls' without dragging back millions of rows."
+---
+
+# Filtering, sorting & limiting
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Three clauses turn a whole-table SELECT into a precise question. **WHERE** keeps only
+the rows matching a condition, **ORDER BY** sorts the result, and **LIMIT** caps how
+many rows come back. Together they let you ask for "the 20 newest P25 calls" without
+dragging back the whole table. Watch out for **NULL** — test it with **IS NULL**, not
+`= NULL` — building on [querying with SELECT](/learn/databases/querying-with-select/).
+</div>
+
+A bare SELECT returns *every* row. Real questions are narrower: not "all calls" but
+"today's calls on this talkgroup, newest first, top twenty." This lesson adds the three
+clauses that get you there — **WHERE** to filter, **ORDER BY** to sort, **LIMIT** to
+cap — the trio behind almost every list you've ever seen in an app.
+
+## WHERE: keep only matching rows
+
+**`WHERE`** filters the rows: the database keeps only those for which your condition is
+true, and discards the rest before you ever see them.
+
+```sql
+SELECT name, frequency_hz
+FROM systems
+WHERE protocol = 'P25';
+```
+
+Only P25 systems come back. The condition can use the comparisons you'd expect: `=`,
+`!=` (or `<>`), `<`, `>`, `<=`, `>=`. And a few SQL-specific operators earn their keep:
+
+- **`IN`** — matches any value in a list: `WHERE protocol IN ('P25', 'DMR')`.
+- **`BETWEEN`** — an inclusive range: `WHERE frequency_hz BETWEEN 851000000 AND 860000000`.
+- **`LIKE`** — pattern matching on text, with `%` as a wildcard:
+  `WHERE name LIKE 'Metro%'` matches anything starting "Metro".
+
+Filtering in the database, not in your application, is the whole point. Let the
+database return 20 matching rows rather than shipping a million to your program to sift
+through — it's dramatically faster and it's what [indexes](/learn/databases/indexes/)
+are built to accelerate.
+
+## Combining conditions
+
+Real filters stack up. Join conditions with **`AND`** (all must hold) and **`OR`** (any
+may hold), and group them with parentheses to keep the logic unambiguous:
+
+```sql
+SELECT name, frequency_hz
+FROM systems
+WHERE protocol = 'P25'
+  AND (frequency_hz > 851000000 OR active = FALSE);
+```
+
+Those parentheses matter. `AND` binds tighter than `OR`, so without them the meaning
+shifts. When a filter mixes AND and OR, parenthesise the intent explicitly — it's the
+difference between the query you meant and the one you typed.
+
+## NULL needs special handling
+
+Here's the classic trap. To find systems with no recorded frequency, you'd reach for
+`WHERE frequency_hz = NULL` — and get *zero rows*, always, even when NULLs exist.
+
+The reason goes back to what [NULL means](/learn/databases/schemas-and-types/):
+"unknown." Comparing unknown to anything — even to another unknown — yields *unknown*,
+never true, so the row is never kept. SQL gives you dedicated syntax for the absence of
+a value:
+
+```sql
+SELECT name FROM systems WHERE frequency_hz IS NULL;      -- missing
+SELECT name FROM systems WHERE frequency_hz IS NOT NULL;  -- present
+```
+
+Use **`IS NULL`** and **`IS NOT NULL`** whenever you're testing presence. This one
+gotcha catches nearly everyone once; now it won't catch you.
+
+## ORDER BY: sort the result
+
+Table rows have no inherent order — the database may return them however it likes.
+**`ORDER BY`** sorts the *result set* by one or more columns:
+
+```sql
+SELECT name, frequency_hz
+FROM systems
+ORDER BY frequency_hz DESC, name ASC;
+```
+
+`ASC` sorts ascending (the default), `DESC` descending. List several columns to break
+ties: here, by frequency high-to-low, and equal frequencies alphabetically by name.
+The crucial rule: **if you want a particular order, you must ask for it.** Without an
+ORDER BY, don't assume rows come back in insertion order, or any order at all — that's
+undefined and *will* eventually surprise you.
+
+## LIMIT: just the first page
+
+**`LIMIT`** caps how many rows return, so you fetch the top few instead of everything:
+
+```sql
+SELECT name, started_at
+FROM calls
+ORDER BY started_at DESC
+LIMIT 20;
+```
+
+That's "the 20 most recent calls" — the pattern behind virtually every feed and
+top-N list. LIMIT paired with ORDER BY is what makes it meaningful: the *newest*
+twenty, not an arbitrary twenty. To page further, add **`OFFSET`** to skip rows —
+`LIMIT 20 OFFSET 20` is the second page. That's the basic recipe for **pagination**,
+letting an app show huge tables one screen at a time without ever loading the whole
+thing.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — NULL means 'unknown', so = NULL is never true; use IS NULL to test for a missing value." markdown="0">
+  <p class="knowledge-check__q">Quick check: how do you find rows where a column has no value?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">WHERE column = NULL</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">WHERE column IS NULL</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">WHERE column = '' — an empty string always matches NULL</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **WHERE** filters rows to those matching a condition, using `=`, `<`, `>`, and
+  SQL operators like **IN**, **BETWEEN**, and **LIKE** — done in the database, not your
+  app.
+- Combine conditions with **AND**/**OR**, and use parentheses to make mixed logic
+  unambiguous.
+- **NULL** means "unknown", so `= NULL` is never true — test presence with **IS NULL**
+  and **IS NOT NULL**.
+- **ORDER BY** sorts the result set (`ASC`/`DESC`); rows have no inherent order, so ask
+  for the order you want every time.
+- **LIMIT** caps returned rows for top-N lists; with **OFFSET** it gives you
+  **pagination** through a large table.
+
+Next up: [Joining tables](/learn/databases/joins/).

--- a/docs/learn/databases/glossary.md
+++ b/docs/learn/databases/glossary.md
@@ -1,0 +1,294 @@
+---
+slug: glossary
+title: Glossary of database terms
+description: Plain-language definitions of every term in the Databases & Data module — database, schema, SQL, primary and foreign key, join, index, normalization, transaction, ACID, NoSQL, vector store, ORM, connection pool, migration, replica, backup, and more — each linked to the lesson that explains it.
+keywords: database glossary, SQL terms, primary key, foreign key, join, index, normalization, transaction, ACID, NoSQL, ORM, connection pool, replication, backup, vector database
+level: beginner
+status: full
+lesson_standalone: true
+---
+
+# Glossary of database terms
+
+Every term used across the [Databases &amp; Data](/learn/databases/) module, defined
+in plain language and linked to the lesson where it's explained in full. Skim it as a
+refresher, or use your browser's find (Ctrl/Cmd-F) to jump to a word. Terms are grouped
+by theme, roughly in the order the module introduces them.
+
+## Foundations
+
+**Database** — An organised store of data that many readers and writers can query
+reliably, safely, and fast, instead of hand-rolling files. See
+[What a database is](/learn/databases/what-is-a-database/)
+
+**Persistence** — Data outliving the program that created it, by being written to
+durable storage rather than held only in memory. See
+[Data, state & persistence](/learn/databases/data-and-persistence/)
+
+**State (in-memory)** — Data a program holds while it runs, which vanishes when the
+process stops — the opposite of persisted data. See
+[Data, state & persistence](/learn/databases/data-and-persistence/)
+
+**Durability** — The guarantee that once data is saved it survives crashes and power
+loss, not just that it was written. See
+[Data, state & persistence](/learn/databases/data-and-persistence/)
+
+**Relational model** — Organising data into **tables** of **rows** and **columns**, the
+shape that has run the data world for fifty years. See
+[The relational model](/learn/databases/the-relational-model/)
+
+**Table / row / column** — A table is a named collection of rows (records); each row is
+one item; each column is one field with a fixed type across all rows. See
+[The relational model](/learn/databases/the-relational-model/)
+
+**Schema** — The shape of your data: the tables, their columns, the types, and the
+rules — decided up front to save a mess later. See
+[Schemas, columns & data types](/learn/databases/schemas-and-types/)
+
+**Data type** — The kind of value a column holds — integer, text, timestamp, boolean —
+which the database enforces on every row. See
+[Schemas, columns & data types](/learn/databases/schemas-and-types/)
+
+**Primary key** — A column (or set) that uniquely names each row in a table, so any row
+can be found and referenced unambiguously. See
+[Keys & relationships](/learn/databases/keys-and-relationships/)
+
+**Foreign key** — A column that points at another table's primary key, linking rows
+across tables and modeling a relationship between things. See
+[Keys & relationships](/learn/databases/keys-and-relationships/)
+
+## SQL, the language of data
+
+**SQL** — The declarative language nearly every relational database speaks: you describe
+the data you want, and the database works out how to fetch it. See
+[What SQL is](/learn/databases/what-is-sql/)
+
+**Declarative** — Saying *what* you want, not *how* to get it — the defining trait of
+SQL, which leaves the execution strategy to the database. See
+[What SQL is](/learn/databases/what-is-sql/)
+
+**SELECT** — The statement that reads data, asking for specific columns and rows — the
+single most-used statement in all of software. See
+[Querying with SELECT](/learn/databases/querying-with-select/)
+
+**WHERE** — The clause that filters a query to only the rows matching a condition,
+instead of returning the whole table. See
+[Filtering, sorting & limiting](/learn/databases/filtering-and-sorting/)
+
+**ORDER BY / LIMIT** — `ORDER BY` sorts the result rows; `LIMIT` caps how many come
+back — together, "the newest 50" without dragging the whole table. See
+[Filtering, sorting & limiting](/learn/databases/filtering-and-sorting/)
+
+**JOIN** — Combining rows from two tables on a shared key — the heart of relational
+power. An **inner join** keeps only matched rows; an **outer (left) join** keeps
+unmatched rows too. See [Joining tables](/learn/databases/joins/)
+
+**Aggregation** — Turning many rows into a summary value with functions like `COUNT`,
+`SUM`, and `AVG` — the tools behind every dashboard number. See
+[Aggregation & GROUP BY](/learn/databases/aggregation-and-grouping/)
+
+**GROUP BY / HAVING** — `GROUP BY` collapses rows into groups to aggregate each one;
+`HAVING` filters those groups after aggregating (as `WHERE` filters rows before). See
+[Aggregation & GROUP BY](/learn/databases/aggregation-and-grouping/)
+
+**INSERT / UPDATE / DELETE** — The write side of SQL: add new rows, change existing
+ones, or remove them — with a `WHERE` clause you forget at your peril. See
+[Inserting, updating & deleting](/learn/databases/inserting-updating-deleting/)
+
+**Index** — A secondary structure, like a book's index, that lets the database jump
+straight to matching rows instead of scanning the whole table — the difference between
+a millisecond and a minute. See [Indexes & how queries get fast](/learn/databases/indexes/)
+
+## Designing data well
+
+**Normalization** — Structuring tables so each fact is stored in exactly one place,
+avoiding the duplication that eventually betrays you. See
+[Normalization & avoiding duplication](/learn/databases/normalization/)
+
+**Normal form** — One of a graded series of rules (1NF, 2NF, 3NF…) describing how far a
+schema removes duplication and update anomalies. See
+[Normalization & avoiding duplication](/learn/databases/normalization/)
+
+**Data modeling** — The craft of going from "what does my app do" to a set of tables and
+relationships, before writing any code. See
+[Data modeling for a real app](/learn/databases/data-modeling/)
+
+**Constraint** — A rule the database enforces on data — `NOT NULL`, `UNIQUE`, `CHECK`,
+and foreign keys — that keeps bad data out no matter what the app does. See
+[Constraints & data integrity](/learn/databases/constraints-and-integrity/)
+
+**Data integrity** — The property that the data in a database stays valid and consistent
+with its rules, upheld by constraints. See
+[Constraints & data integrity](/learn/databases/constraints-and-integrity/)
+
+**Transaction** — A group of changes treated as one all-or-nothing unit: either every
+change applies or none does. See [Transactions & ACID](/learn/databases/transactions-and-acid/)
+
+**ACID** — The four guarantees behind a transaction — **Atomicity** (all or nothing),
+**Consistency** (rules always hold), **Isolation** (concurrent transactions don't
+corrupt each other), **Durability** (committed changes survive). See
+[Transactions & ACID](/learn/databases/transactions-and-acid/)
+
+**Migration** — A versioned, repeatable change to a live database's schema, letting you
+evolve its shape safely without losing data. See
+[Schema migrations](/learn/databases/migrations/)
+
+## Beyond relational
+
+**NoSQL** — An umbrella for non-relational stores that trade some of SQL's structure and
+guarantees for a different shape, scale, or flexibility. See
+[SQL vs. NoSQL](/learn/databases/sql-vs-nosql/)
+
+**Key-value store** — A dictionary-like database that stores values behind unique keys,
+built for fast lookups by known key. See
+[Key-value & document stores](/learn/databases/key-value-and-document/)
+
+**Document store** — A NoSQL database that stores self-contained, often JSON documents
+that can vary in shape, fetched whole. See
+[Key-value & document stores](/learn/databases/key-value-and-document/)
+
+**Time-series database** — A store tuned for when-it-happened data — metrics, events,
+sensor readings — written in time order and queried by range. See
+[Time-series & analytical stores](/learn/databases/time-series-and-analytics/)
+
+**Column store / analytical (OLAP)** — A database that stores data by column for fast
+aggregation over huge tables — where your metrics and analytics live. See
+[Time-series & analytical stores](/learn/databases/time-series-and-analytics/)
+
+**Vector database** — A store that indexes **embeddings** (vectors) to search by meaning
+— nearest-neighbour lookups — the store behind AI retrieval and RAG. See
+[Vector databases & similarity search](/learn/databases/vector-databases/)
+
+**Embedding** — A list of numbers representing the meaning of a piece of data, so
+similar meanings sit close together in vector space. See
+[Vector databases & similarity search](/learn/databases/vector-databases/) and
+[Embeddings & vector search](/learn/building-ai/embeddings-and-vector-search/)
+
+**Similarity search** — Finding the items whose vectors are nearest to a query vector —
+searching by meaning instead of exact keywords. See
+[Vector databases & similarity search](/learn/databases/vector-databases/)
+
+**Cache / caching layer** — Fast in-memory storage in front of the database that holds
+hot data so repeated reads skip the slower database. See
+[Caching layers](/learn/databases/caching-layers/)
+
+**Cache invalidation** — Keeping cached data fresh — deciding when a cached value is
+stale and must be refreshed — the classic hard problem of caching. See
+[Caching layers](/learn/databases/caching-layers/)
+
+## Using a database from code
+
+**Driver** — The library that speaks a specific database's wire protocol, turning your
+query into bytes on a socket and the reply back into values. See
+[Connecting from your program](/learn/databases/connecting-from-code/)
+
+**Connection string / DSN** — The string that says where a database is and who is
+connecting — host, port, database, user, password, and options like TLS. See
+[Connecting from your program](/learn/databases/connecting-from-code/)
+
+**Credentials** — The username and password (or token) that authenticate a connection —
+secrets to load from the environment, never hard-code. See
+[Connecting from your program](/learn/databases/connecting-from-code/)
+
+**Connection pool** — A managed set of open connections the app borrows and returns per
+query, avoiding per-query setup cost and capping load on the database. See
+[Connection pools](/learn/databases/connection-pooling/)
+
+**Pool exhaustion** — The failure where every pooled connection is busy at once, so new
+queries wait and may time out — usually a sign of slow queries or a too-small pool. See
+[Connection pools](/learn/databases/connection-pooling/)
+
+**ORM (object-relational mapper)** — A library that maps table rows to objects in your
+code and generates the SQL to load and save them, cutting boilerplate. See
+[ORMs vs. raw SQL](/learn/databases/orms-vs-raw-sql/)
+
+**Raw SQL** — Writing query text by hand and mapping the results yourself, for full
+control and no hidden queries. See [ORMs vs. raw SQL](/learn/databases/orms-vs-raw-sql/)
+
+**N+1 problem** — The ORM trap where a loop lazily loads a related row per item, firing
+one query plus one per row instead of a single join. See
+[ORMs vs. raw SQL](/learn/databases/orms-vs-raw-sql/)
+
+**SQL injection** — A vulnerability where untrusted input is glued into a query and gets
+executed as SQL, letting an attacker read, alter, or destroy data. See
+[SQL injection & querying safely](/learn/databases/sql-injection/)
+
+**Parameterised query / prepared statement** — A query with placeholders whose values
+are sent separately, so input is always bound as data and can never become SQL — the
+fix for injection. See [SQL injection & querying safely](/learn/databases/sql-injection/)
+
+**database/sql** — Go's standard-library interface to SQL databases; you register a
+driver and run parameterised queries against a pooled `sql.DB`. See
+[Talking to a database from Go](/learn/databases/databases-in-go/)
+
+**sql.DB** — In Go, a **connection pool** (not a single connection), safe for concurrent
+use, opened once and shared for the program's life. See
+[Talking to a database from Go](/learn/databases/databases-in-go/)
+
+**Scan** — In Go, copying the columns of a result row into your variables, row by row,
+in a `rows.Next()` loop. See [Talking to a database from Go](/learn/databases/databases-in-go/)
+
+## Running a database in production
+
+**Backup** — A copy of your data you can restore from after failure — the operational
+floor beneath everything, worthless until you've actually restored it. See
+[Backups & recovery](/learn/databases/backups-and-recovery/)
+
+**Point-in-time recovery (PITR)** — Restoring to *any* moment by replaying a change log
+on top of a base backup — including the instant before a mistake. See
+[Backups & recovery](/learn/databases/backups-and-recovery/)
+
+**RPO / RTO** — Recovery **point** objective (how much recent data you can afford to
+lose) and recovery **time** objective (how long you can be down) — the targets that
+shape a backup strategy. See [Backups & recovery](/learn/databases/backups-and-recovery/)
+
+**Replication** — Keeping copies of a database in sync with the original, for read
+capacity and failover. See [Replication, sharding & scaling](/learn/databases/replication-and-scaling/)
+
+**Primary / read replica** — The **primary** takes all writes; **replicas** receive every
+change and serve reads (and stand by for failover). Writes still funnel through the one
+primary. See [Replication, sharding & scaling](/learn/databases/replication-and-scaling/)
+
+**Replication lag** — The small delay before a replica reflects a write, so a replica
+read can miss a just-written value — **eventual consistency**. See
+[Replication, sharding & scaling](/learn/databases/replication-and-scaling/)
+
+**Sharding** — Splitting the data itself across servers on a **shard key** to scale
+**writes**, at real cost in cross-shard queries and lost cross-shard transactions. See
+[Replication, sharding & scaling](/learn/databases/replication-and-scaling/)
+
+**Vertical / horizontal scaling** — Scaling **up** (a bigger server) versus **out** (more
+servers). Scale up first; scale out only when forced. See
+[Replication, sharding & scaling](/learn/databases/replication-and-scaling/)
+
+**CAP theorem** — During a network partition, a distributed database must trade
+**consistency** (never serve stale data) against **availability** (always answer) — you
+can't have both. See [Replication, sharding & scaling](/learn/databases/replication-and-scaling/)
+
+**EXPLAIN / query plan** — `EXPLAIN` prints the **query plan** — the strategy the
+database will use to run a query — so you can see *why* it's slow. See
+[Performance tuning & monitoring](/learn/databases/performance-and-monitoring/)
+
+**Full table scan (sequential scan)** — The database reading every row to satisfy a
+query, usually because an index is missing — the most common cause of slowness. See
+[Performance tuning & monitoring](/learn/databases/performance-and-monitoring/)
+
+**p95 / p99 latency** — The slowest 5% and 1% of query times — the tail that averages
+hide and your unhappiest users feel; the metric to watch. See
+[Performance tuning & monitoring](/learn/databases/performance-and-monitoring/)
+
+**Slow-query log** — A record of every query slower than a threshold, used to find which
+query to optimise before guessing. See
+[Performance tuning & monitoring](/learn/databases/performance-and-monitoring/)
+
+**Managed database** — A database a cloud provider or service (Postgres/MySQL, Supabase,
+Neon…) runs for you — handling backups, patching, and failover — versus self-hosting.
+See [Choosing a database](/learn/databases/choosing-a-database/)
+
+**Choose boring technology** — The principle that for something as important as your
+data you pick the mature, well-understood option (often Postgres or SQLite) and diverge
+only for a concrete need. See [Choosing a database](/learn/databases/choosing-a-database/)
+
+**Retention sweep** — A periodic job that deletes data older than a configured window to
+bound a long-running database's growth — as GopherTrunk does with old calls. See
+[Data in GopherTrunk](/learn/databases/data-in-gophertrunk/)

--- a/docs/learn/databases/index.md
+++ b/docs/learn/databases/index.md
@@ -1,0 +1,35 @@
+---
+layout: learn-hub
+learn_module: databases
+permalink: /learn/databases/
+title: Databases & Data — where your application's data lives, from a first table to production
+description: A free, structured module on databases and data — the relational model and SQL, designing and modeling data, NoSQL and vector stores, using a database from your own code, and running one in production, with GopherTrunk's own data as the worked example.
+keywords: learn databases, SQL tutorial, relational model, database design, normalization, joins, indexes, transactions, ACID, NoSQL, vector database, ORM, migrations, database in Go, choosing a database, Postgres, SQLite, Supabase
+---
+
+Almost every program you build eventually needs to **remember something** — a
+user, a setting, a log of the calls it decoded. A **database** is where that data
+lives: structured so you can store it reliably and get it back fast, even with many
+readers and writers at once. Learning databases is one of the highest-leverage
+things a developer can do, because the same handful of ideas — tables, keys, SQL,
+transactions — show up in almost every application ever built.
+
+**Who this is for.** Anyone who can write a little code (or wants to) and keeps
+bumping into the question of *where does the data go?* You don't need any database
+background — this starts from why plain files aren't enough and builds up from
+there. It pairs naturally with the
+[Intro to Software Dev]({{ '/learn/intro-software-dev/' | relative_url }}),
+[Programming in Go]({{ '/learn/programming-go/' | relative_url }}), and
+[Building AI Into Software]({{ '/learn/building-ai/' | relative_url }}) modules.
+
+**How the module works.** Six units take you from a first table to a database
+running in production. The early units build the core ideas — the relational model,
+**SQL**, and how to design data well. The middle unit reaches beyond relational to
+the **NoSQL, time-series, and vector stores** that modern apps lean on, including
+the vector search behind AI retrieval. The last two units are the working
+developer's part: talking to a database from your own **code** (safely, in Go), and
+the operational reality of backups, scaling, and monitoring. Examples lean on real
+software, including how a scanner like [GopherTrunk]({{ '/' | relative_url }}) stores
+the systems and calls it decodes. Mark lessons complete as you go — your progress is
+saved in your browser. New here?
+**[Start with lesson 1: What a database is](/learn/databases/what-is-a-database/)**

--- a/docs/learn/databases/indexes.md
+++ b/docs/learn/databases/indexes.md
@@ -1,0 +1,150 @@
+---
+slug: indexes
+title: Indexes & how queries get fast
+description: Why the same query can take a millisecond or a minute — indexes, what they cost, and the mental model of a book's index that explains them. Learn how a full table scan differs from an index lookup, when to add an index, and the price you pay on writes.
+keywords: database index, full table scan, index lookup, B-tree, query performance, EXPLAIN, index cost, write overhead, primary key index, when to index
+level: intermediate
+status: full
+prereq:
+  - filtering-and-sorting
+  - keys-and-relationships
+faq:
+  - q: "What actually is an index?"
+    a: "A separate, sorted data structure — usually a B-tree — that maps the values in a column to the rows that hold them, so the database can jump straight to matching rows instead of scanning the whole table. It's exactly like the index at the back of a book: a pre-sorted lookup that saves you reading every page."
+  - q: "If indexes make queries faster, why not index every column?"
+    a: "Because indexes aren't free. Each one takes storage and must be updated on every insert, update, and delete — so more indexes mean slower writes and more disk. Index the columns you actually filter, join, or sort on; skip the rest. It's a deliberate read-speed-for-write-cost trade."
+  - q: "How do I know if a query is using an index?"
+    a: "Run it through EXPLAIN, which shows the query plan the database chose. If you see a sequential or full table scan on a big table where you expected a lookup, you're likely missing an index — or the query is written so the index can't be used."
+---
+
+# Indexes & how queries get fast
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+An **index** is a separate sorted structure (usually a **B-tree**) that lets the
+database jump straight to matching rows instead of a **full table scan** — the
+difference between a millisecond and a minute. It's the back-of-the-book index made
+literal. But indexes **cost**: storage, plus slower **writes**, because every insert,
+update, and delete must maintain them. So you index the columns you **filter, join, or
+sort** on — not every column. Use **EXPLAIN** to see what the database actually does.
+</div>
+
+You can now write queries that read, filter, join, and summarise. This final lesson of
+the unit answers a question that decides whether those queries are usable at scale: why
+does the *same* query take a millisecond on one table and a minute on another? The
+answer, almost always, is **indexes** — and understanding them is the leap from queries
+that work to queries that work *fast*.
+
+## The full table scan
+
+Picture the calls table with ten million rows, and this query:
+
+```sql
+SELECT * FROM calls WHERE system_id = 3;
+```
+
+Without help, the database has exactly one option: read *every* row and check each
+one's `system_id`. That's a **full table scan** (or sequential scan) — ten million
+comparisons to find maybe a few hundred matches. It works, and it's fine on small
+tables. On a big one it's slow, and it gets slower as the table grows, because the work
+is proportional to the *whole* table, not to the number of matches.
+
+## The book-index mental model
+
+Now think about finding every mention of "downconverter" in a 900-page book. You could
+read all 900 pages (the full scan). Or you could flip to the **index** at the back — an
+alphabetical list of terms with the pages they appear on — find the word in seconds, and
+turn straight to those pages.
+
+A database **index** is exactly this. It's a separate structure that keeps a column's
+values in *sorted* order, each paired with a pointer to the row that holds it. With an
+index on `system_id`, the database doesn't scan ten million rows — it navigates the
+sorted index straight to `system_id = 3` and follows the pointers to just those rows. The
+lookup cost grows with the *logarithm* of the table size, not the size itself, so it
+stays fast even as the table balloons.
+
+```sql
+CREATE INDEX idx_calls_system ON calls (system_id);
+```
+
+That one statement can turn a minute-long scan into an instant lookup. Under the hood
+most indexes are a **B-tree**, a structure built for exactly this: staying balanced and
+sorted so any value is reachable in a few steps regardless of size.
+
+## What indexes speed up
+
+Indexes help precisely the operations that need to *locate* rows by a column's value:
+
+- **WHERE filters** — `WHERE system_id = 3` or `WHERE started_at > '2026-08-01'` jump to
+  matches instead of scanning.
+- **[Joins](/learn/databases/joins/)** — matching a foreign key to a primary key is a
+  lookup per row; an index on the join key is what keeps joins fast.
+- **ORDER BY** — because an index is already sorted, the database can often read rows in
+  order straight from it, skipping a separate sort step.
+
+This is why **primary keys are automatically indexed** — you look rows up by their key
+constantly, so the database indexes it for you. Foreign keys usually deserve an index
+too, precisely because you join on them.
+
+## Indexes aren't free
+
+If indexes are so good, why not index every column? Because they have a real **cost**,
+and it's the crux of using them well:
+
+- **Storage.** An index is extra data on disk — a copy of the column's values plus
+  pointers. Many indexes can rival the size of the table itself.
+- **Slower writes.** This is the big one. Every **INSERT**, **UPDATE**, and **DELETE**
+  must *also* update every index on the table to keep it sorted and correct. Five indexes
+  mean each write does roughly five times the index maintenance. Indexes trade *write*
+  speed for *read* speed.
+
+So indexing is a deliberate trade, not a free win. Index the columns you actually
+**filter, join, or sort** on in real queries; leave the rest unindexed. A table that's
+written far more than it's read might want *fewer* indexes; a read-heavy reporting table
+might want several. Match the indexes to how the data is actually used.
+
+## Seeing what the database does
+
+You don't have to guess whether an index is helping — the database will tell you. Prefix
+a query with **`EXPLAIN`** and it shows the **query plan**: the strategy the
+[planner](/learn/databases/what-is-sql/) chose, including whether it's doing an index
+lookup or a full scan.
+
+```sql
+EXPLAIN SELECT * FROM calls WHERE system_id = 3;
+```
+
+If you see a sequential scan over a large table where you expected a lookup, you're
+probably missing an index — or the query is written in a way that prevents one being used
+(wrapping the column in a function, or a `LIKE '%foo'` with a leading wildcard, can both
+defeat an index). Reading query plans is the core skill of database performance work, and
+the module's later
+[performance & monitoring](/learn/databases/performance-and-monitoring/) lesson goes deeper. For now, the
+essential mental model is the one that carries you a long way: an index is a book's index,
+it makes lookups fast, and it isn't free.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — an index is a sorted lookup structure that skips the full scan, at the cost of storage and slower writes." markdown="0">
+  <p class="knowledge-check__q">Quick check: why not just put an index on every column?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Databases only allow one index per table</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Each index costs storage and slows writes, since every write must update it</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Extra indexes make SELECT queries slower, not faster</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Without help, a filter runs a **full table scan** — reading every row — which grows
+  slower as the table grows.
+- An **index** is a separate **sorted** structure (usually a **B-tree**) that lets the
+  database jump straight to matching rows, like a book's back-of-index.
+- Indexes speed up **WHERE filters**, **joins** on keys, and **ORDER BY**; **primary
+  keys** are indexed automatically.
+- Indexes **cost** storage and, crucially, slow every **INSERT/UPDATE/DELETE**, since
+  each write must maintain them — a read-speed-for-write-cost trade.
+- Index the columns you **filter, join, or sort** on; don't index everything.
+- Use **EXPLAIN** to see the query plan and confirm whether an index is actually being
+  used.
+
+Next up: [Normalization & avoiding duplication](/learn/databases/normalization/).

--- a/docs/learn/databases/inserting-updating-deleting.md
+++ b/docs/learn/databases/inserting-updating-deleting.md
@@ -1,0 +1,167 @@
+---
+slug: inserting-updating-deleting
+title: Inserting, updating & deleting
+description: The write side of SQL — INSERT adds rows, UPDATE changes them, DELETE removes them — and the WHERE clause you forget at your peril. Learn the syntax, the danger of a missing WHERE, and why real writes lean on transactions.
+keywords: INSERT, UPDATE, DELETE, SQL writes, DML, WHERE clause, RETURNING, transaction, rollback, data manipulation, modifying data
+level: beginner
+status: full
+prereq:
+  - querying-with-select
+  - filtering-and-sorting
+faq:
+  - q: "What happens if I run UPDATE or DELETE without a WHERE clause?"
+    a: "It applies to every row in the table. UPDATE without WHERE changes all rows; DELETE without WHERE empties the whole table. There's no confirmation prompt — the database does exactly what you said. This is the single most common way people wreck data, so always write and check the WHERE first."
+  - q: "Can I undo a DELETE?"
+    a: "Only if it ran inside a transaction you haven't committed — then you can ROLLBACK. Once committed, the rows are gone and your only recovery is a backup. This is exactly why writes that matter run inside transactions and why tested backups exist."
+  - q: "How do I get the id of a row I just inserted?"
+    a: "Many databases support a RETURNING clause (INSERT ... RETURNING id) that hands back generated values from the new row. Where that's not available, the driver usually exposes a 'last insert id'. Either way you don't have to run a second query to find it."
+---
+
+# Inserting, updating & deleting
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+The write side of SQL is three statements: **INSERT** adds rows, **UPDATE** changes
+existing ones, **DELETE** removes them. UPDATE and DELETE take a **WHERE** clause that
+decides *which* rows — and **forgetting it hits every row in the table**. Because a
+write can go wrong, real applications wrap important ones in a **transaction** so they
+can **ROLLBACK**. This is the counterpart to the reads you've learned since
+[querying with SELECT](/learn/databases/querying-with-select/).
+</div>
+
+Everything so far has *read* data. Now you'll change it. The write statements —
+**INSERT**, **UPDATE**, **DELETE** — are collectively called **DML** (data manipulation
+language), and they're refreshingly simple in form. The catch is that they're
+*powerful*: a single careless statement can rewrite or erase an entire table with no
+undo. This lesson teaches the syntax and, just as importantly, the habits that keep you
+from a very bad afternoon.
+
+## INSERT: add rows
+
+**`INSERT`** adds new rows. Name the columns you're supplying and give their values:
+
+```sql
+INSERT INTO systems (name, frequency_hz, protocol)
+VALUES ('Harbor P25', 852000000, 'P25');
+```
+
+Columns you don't list take their defaults (or NULL) — that's how an auto-generated
+`id` and a `first_seen DEFAULT now()` fill themselves in. Naming the columns explicitly
+(rather than relying on their order) is the robust habit: it keeps working when someone
+adds a column later. You can insert several rows at once by listing multiple value
+tuples:
+
+```sql
+INSERT INTO systems (name, frequency_hz, protocol) VALUES
+  ('County DMR', 453100000, 'DMR'),
+  ('Rail TETRA', 390000000, 'TETRA');
+```
+
+Often you want the new row's generated id straight back. Many databases offer a
+**`RETURNING`** clause for exactly that:
+
+```sql
+INSERT INTO systems (name, frequency_hz, protocol)
+VALUES ('Harbor P25', 852000000, 'P25')
+RETURNING id;
+```
+
+No second query needed — the new `id` comes back with the insert.
+
+## UPDATE: change existing rows
+
+**`UPDATE`** modifies rows already in the table. You set new column values and — this is
+the important part — you say *which* rows with **`WHERE`**:
+
+```sql
+UPDATE systems
+SET active = FALSE
+WHERE id = 3;
+```
+
+That deactivates exactly system 3. The `WHERE` uses everything from the
+[filtering lesson](/learn/databases/filtering-and-sorting/) — you can update all rows
+matching any condition, and set several columns at once with commas.
+
+## The WHERE you forget at your peril
+
+Here is the most important sentence in this lesson. **UPDATE and DELETE without a WHERE
+clause apply to every row in the table.** There's no "are you sure?" — the database does
+precisely what you wrote:
+
+```sql
+UPDATE systems SET active = FALSE;   -- deactivates EVERY system
+DELETE FROM systems;                 -- empties the ENTIRE table
+```
+
+This is the classic career-defining mistake, and it's made by experienced people, not
+just beginners. Two habits defend against it:
+
+- **Write the WHERE first.** Type the `WHERE` clause before the `SET` or even before
+  `UPDATE`/`DELETE`, so a half-finished statement can't fire against everything.
+- **SELECT before you write.** Run `SELECT * FROM systems WHERE id = 3;` first, confirm
+  it returns exactly the rows you mean to change, then swap `SELECT *` for your UPDATE
+  or DELETE with the *same* WHERE.
+
+## DELETE: remove rows
+
+**`DELETE`** removes rows matching its WHERE:
+
+```sql
+DELETE FROM calls
+WHERE started_at < '2026-01-01';
+```
+
+That prunes old calls. As with UPDATE, the WHERE is what stands between "delete the old
+ones" and "delete everything." Note that a DELETE can be blocked by
+[referential integrity](/learn/databases/keys-and-relationships/): if other rows have a
+foreign key pointing at the row you're deleting, the database may refuse (or cascade the
+delete), which is the guardrail working as designed.
+
+## Writes deserve transactions
+
+Reads are safe; writes are not, and things go wrong — a bug computes the wrong values, a
+multi-step change fails halfway. That's why important writes run inside a
+**transaction**: a group of statements that either *all* take effect or *none* do. If
+anything looks wrong before you finish, you **`ROLLBACK`** and it's as if nothing
+happened:
+
+```sql
+BEGIN;
+UPDATE accounts SET balance = balance - 100 WHERE id = 1;
+UPDATE accounts SET balance = balance + 100 WHERE id = 2;
+COMMIT;   -- or ROLLBACK to undo both
+```
+
+If the second update fails, you roll back and the first is undone too — you never leave
+money removed from one account but not added to the other. Transactions and the
+guarantees behind them (the "ACID" properties) are a full topic later in the module; for
+now, know that once a DELETE is **committed**, it's gone, and your only recovery is a
+[backup](/learn/deployment/backups-and-data/) — one more reason those exist.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — without a WHERE clause, UPDATE and DELETE apply to every row in the table." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does <code>DELETE FROM systems;</code> with no WHERE do?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Nothing — a DELETE requires a WHERE clause to run</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Deletes every row in the table — no confirmation, no undo once committed</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Deletes only the most recently inserted row</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- The write side of SQL is **INSERT** (add rows), **UPDATE** (change rows), and
+  **DELETE** (remove rows) — collectively **DML**.
+- **INSERT** names columns and supplies values; unlisted columns take defaults, and
+  **RETURNING** hands back generated values like a new id.
+- **UPDATE** and **DELETE** use a **WHERE** clause to choose rows — and **without one
+  they hit every row in the table**, with no undo once committed.
+- Defend against that with two habits: **write the WHERE first**, and **SELECT to
+  preview** the rows before writing.
+- A **DELETE** may be blocked or cascaded by **foreign-key** integrity — the guardrail
+  working.
+- Important writes run inside a **transaction** so you can **ROLLBACK**; once
+  **committed**, recovery means a **backup**.
+
+Next up: [Indexes & how queries get fast](/learn/databases/indexes/).

--- a/docs/learn/databases/joins.md
+++ b/docs/learn/databases/joins.md
@@ -1,0 +1,151 @@
+---
+slug: joins
+title: Joining tables
+description: Joins are the heart of relational power — combining rows from two tables on a shared key. Learn how an inner join works, the difference between inner and outer joins, and why splitting data across tables and rejoining it is the whole point of the relational model.
+keywords: SQL join, inner join, outer join, left join, join key, combining tables, ON clause, relational, foreign key join, join condition
+level: intermediate
+status: full
+prereq:
+  - keys-and-relationships
+  - querying-with-select
+faq:
+  - q: "What's the difference between an inner join and a left join?"
+    a: "An inner join returns only rows that have a match in both tables — unmatched rows from either side are dropped. A left join returns every row from the left table, matched or not, filling the right side with NULLs where there's no match. Use inner when you only want matched pairs; use left when you want all of one side regardless."
+  - q: "What do I join two tables on?"
+    a: "On a shared value — almost always a foreign key matching a primary key. To join calls to their systems you match calls.system_id to systems.id in the ON clause. That shared key is the thread the relational model uses to reconnect data it split across tables."
+  - q: "Why split data into separate tables if I just have to join them back?"
+    a: "Because splitting keeps each fact in one place — no duplication, no update anomalies — which is the goal of normalization. Joins are cheap and fast (especially with indexes on the keys), so you get clean storage and can still assemble any combined view you need on demand."
+---
+
+# Joining tables
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A **join** combines rows from two tables by matching a **shared key** — usually a
+foreign key meeting a primary key. An **inner join** returns only rows with a match on
+both sides; an **outer join** (like a **LEFT JOIN**) keeps all rows from one side,
+filling missing matches with **NULL**. Joins are why you can split data across tables
+for cleanliness and still assemble any combined view — the payoff of
+[keys & relationships](/learn/databases/keys-and-relationships/).
+</div>
+
+You split data into separate tables — systems here, calls there — linked by
+[keys](/learn/databases/keys-and-relationships/). That keeps each fact in one place,
+but it raises an obvious question: how do you get a call *and* the name of its system
+in one result? Neither table holds both. The answer, and arguably the single most
+important operation in relational databases, is the **join**. This lesson is where the
+relational model earns its keep.
+
+## Why you need a join
+
+Recall the shape: `calls` has a `system_id` foreign key pointing at `systems.id`. To
+show "each recent call with its system's name," you need columns from both tables at
+once. Querying `calls` alone gives you a `system_id` — a bare number — not the human
+name. A join brings the two tables together on that key so a single result row carries
+data from both.
+
+## The inner join
+
+An **inner join** matches rows from two tables on a condition and returns the combined
+rows where the match holds:
+
+```sql
+SELECT calls.started_at, systems.name, systems.protocol
+FROM calls
+JOIN systems ON calls.system_id = systems.id;
+```
+
+Read the **`ON`** clause as the rule for pairing rows: for each call, find the system
+whose `id` equals that call's `system_id`, and stitch them into one wide row. The
+result has columns from both tables — the call's timestamp beside its system's name and
+protocol.
+
+Two details worth noting. First, prefix columns with their table (`calls.started_at`,
+`systems.name`) when a name could be ambiguous — both tables have an `id`, so you must
+say which. Second, the join key is the foreign-key/primary-key pair; matching on the
+relationship you designed is the overwhelmingly common case, and
+[indexing those keys](/learn/databases/indexes/) is what keeps joins fast.
+
+The word **inner** matters: an inner join keeps only rows that have a match on *both*
+sides. A call whose `system_id` points nowhere (if that were allowed), or a system with
+no calls, simply doesn't appear. Matched pairs only.
+
+## Outer joins keep the unmatched
+
+Sometimes dropping the unmatched rows is exactly wrong. "List every system and how many
+calls it had" must include systems with *zero* calls — but an inner join would silently
+omit them. That's what an **outer join** is for.
+
+The most common is the **LEFT JOIN**: keep *every* row from the left (first) table,
+matched or not, and fill the right side's columns with **NULL** where there's no match.
+
+```sql
+SELECT systems.name, calls.started_at
+FROM systems
+LEFT JOIN calls ON calls.system_id = systems.id;
+```
+
+Now a system with no calls still appears once, with `calls.started_at` as NULL. The
+mental model:
+
+- **INNER JOIN** — only rows matched on both sides.
+- **LEFT JOIN** — all left rows; right side NULL when unmatched.
+- **RIGHT JOIN** — the mirror image (all right rows); less common, since you can flip
+  the tables and use LEFT.
+- **FULL OUTER JOIN** — all rows from both sides, NULLs wherever a match is missing.
+
+Choosing between them is really one question: *when a row on one side has no partner,
+do I still want it?* Yes means outer; no means inner.
+
+## Joining more than two tables
+
+Joins chain. To reach across the [join table](/learn/databases/keys-and-relationships/)
+of a many-to-many, you join through it — calls to `call_talkgroups` to `talkgroups`:
+
+```sql
+SELECT calls.started_at, talkgroups.name
+FROM calls
+JOIN call_talkgroups ON call_talkgroups.call_id = calls.id
+JOIN talkgroups      ON talkgroups.id = call_talkgroups.talkgroup_id;
+```
+
+Each `JOIN ... ON` adds another table to the growing combined row. This is how a query
+assembles a rich result from a well-split schema — three normalized tables becoming one
+readable answer.
+
+## Splitting and rejoining is the point
+
+It can feel circular: split data into tables, then write joins to glue it back. But
+that's precisely the relational bargain, and it's a good one. Splitting keeps every
+fact in exactly one place — no duplicated system names to drift out of sync, the
+discipline of [normalization](/learn/databases/normalization/). Joins then let you
+reassemble *any* combined view on demand, cheaply, especially with the join keys
+indexed. You store data cleanly and read it flexibly. That combination — clean writes,
+flexible reads — is the whole reason the relational model has lasted, and the join is
+the hinge it turns on.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — an inner join returns only matched rows; a left join keeps all left rows, NULLing the unmatched right side." markdown="0">
+  <p class="knowledge-check__q">Quick check: you want every system listed, even ones with no calls. Which join?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">An inner join — it always includes every row from both tables</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">A left join from systems — it keeps all systems, NULLing calls where there are none</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">No join is needed; one table already has both</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **join** combines rows from two tables on a **shared key** — typically a foreign
+  key matching a primary key — named in the **`ON`** clause.
+- An **inner join** returns only rows with a match on **both** sides; unmatched rows are
+  dropped.
+- An **outer join** keeps unmatched rows: a **LEFT JOIN** keeps every left row and fills
+  the right side with **NULL** when there's no match.
+- Choose inner vs. outer by asking whether you still want a row that has no partner.
+- Joins **chain** across multiple tables, including through a join table for
+  many-to-many relationships.
+- Splitting data for clean storage and **rejoining** it on demand is the core relational
+  bargain — clean writes, flexible reads.
+
+Next up: [Aggregation & GROUP BY](/learn/databases/aggregation-and-grouping/).

--- a/docs/learn/databases/key-value-and-document.md
+++ b/docs/learn/databases/key-value-and-document.md
@@ -1,0 +1,173 @@
+---
+slug: key-value-and-document
+title: Key-value & document stores
+description: Two of the most common NoSQL shapes explained — the dictionary-like key-value store built for fast lookups by key, and the JSON-document store built for self-contained records with flexible schemas. Learn what each is good at and where each falls down.
+keywords: key-value store, document store, document database, NoSQL, Redis, MongoDB, JSON documents, denormalization, schema flexibility, key lookup, embedding vs referencing
+level: intermediate
+status: full
+prereq:
+  - sql-vs-nosql
+faq:
+  - q: What's the difference between a key-value store and a document store?
+    a: "A key-value store treats each value as an opaque blob you can only fetch or set by its exact key — it doesn't look inside the value. A document store keeps structured JSON-like documents it *can* look inside, so you can query and index on fields within a document. Document stores are essentially key-value stores that understand their values' contents."
+  - q: When should I use a key-value store?
+    a: "When your access pattern is 'give me the value for this exact key' and you don't need to query by anything else — caches, user sessions, feature flags, rate-limit counters. They're extremely fast and simple precisely because they do so little. If you need to search by the contents of the value, you've outgrown a pure key-value store."
+  - q: Do document stores mean I don't have to design my data?
+    a: "No. The database stops enforcing a schema, but your data still has one — it just lives in your application code now. You still decide what fields a document has and whether to embed related data or reference it. Flexibility shifts the modeling burden onto you rather than removing it."
+---
+
+# Key-value & document stores
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A **key-value store** is a giant dictionary: set and get an opaque **value** by its
+exact **key**, nothing more — blazing fast and dead simple, perfect for caches,
+sessions, and counters. A **document store** keeps self-contained **JSON-like
+documents** it can look *inside*, so you can query and index fields within them, with
+a **flexible schema** per record. Both are NoSQL shapes from the
+[SQL vs. NoSQL](/learn/databases/sql-vs-nosql/) lesson; both trade joins and enforced
+structure for speed and flexibility, and both push the modeling work into your code.
+</div>
+
+The last lesson said "NoSQL" is really a family of specific stores. Here are the two
+you'll meet most often. They sit at different points on the same spectrum: the
+key-value store does the least possible and is fast because of it, and the document
+store adds just enough structure to query inside its records. Understanding both, and
+where each breaks down, is most of what you need to use them well.
+
+## The key-value store: a dictionary at scale
+
+A **key-value store** is exactly the data structure you already know from every
+programming language — a dictionary, map, or hash — turned into a database. You **set**
+a value under a key, and later **get** it back by that same key:
+
+```
+SET  session:abc123   {"user":42,"expires":1699999999}
+GET  session:abc123
+DEL  session:abc123
+```
+
+The defining property is that the value is **opaque**: the store doesn't know or care
+what's inside it — a string, a number, a serialized blob — it just hands it back
+whole. You can *only* find a value by its exact key. There's no "find all sessions for
+user 42," because that would require looking inside the values, which a pure key-value
+store doesn't do.
+
+That limitation is also the source of its power. Doing so little means it can be
+extraordinarily **fast** and **simple to scale** — spreading keys across many machines
+is easy when each key is independent. This is why **Redis** and similar stores are the
+default tool for:
+
+- **Caching** — hold the result of an expensive query under a key (the whole next
+  lesson).
+- **Sessions** — a logged-in user's session data, fetched by session ID every request.
+- **Counters and rate limits** — increment a number under a key, atomically.
+- **Feature flags and simple config** — one lookup by name.
+
+Many key-value stores keep data in **memory** for speed, which makes them fast but also
+means you treat the data as transient unless the store is configured for durability.
+The moment you find yourself wanting to query by anything *other* than the key, you've
+outgrown it — and that's exactly the door a document store opens.
+
+## The document store: values you can look inside
+
+A **document store** keeps records as **documents** — typically JSON — and, crucially,
+it *understands* those documents. It can query and index on fields *within* a document,
+not just fetch by an outer key. Records live in **collections**, and each document is
+meant to be **self-contained**: as much of what you need for one thing as makes sense,
+in one place.
+
+```json
+{
+  "_id": "call_0192",
+  "system": { "name": "Metro P25", "wacn": 782336 },
+  "talkgroup": "Fire Dispatch",
+  "started_at": "2026-08-04T09:00:00Z",
+  "frequencies": [851000000, 851012500],
+  "recorded": true
+}
+```
+
+Notice what's happening: the system's details are **embedded** right in the call
+document rather than sitting in a separate table you'd join to. A document store leans
+into this — it's built to hand you a whole self-contained record in one read, no join
+required. You can also index and query on inner fields, like "all documents where
+`talkgroup` is `Fire Dispatch`."
+
+## Flexible schema — a gift and a bill
+
+The headline feature is a **flexible schema**: two documents in the same collection can
+have different fields. Add a new field to new documents without a migration; older ones
+simply don't have it. For fast-moving or genuinely irregular data, that's a real
+advantage.
+
+But the schema doesn't vanish — it **moves into your application code**. The database no
+longer guarantees every call document has a `started_at`, so *your code* must handle the
+ones that don't. All the rules that
+[constraints](/learn/databases/constraints-and-integrity/) enforced for you become your
+responsibility. Flexibility isn't the absence of a schema; it's the schema being
+unenforced. That's a fine trade when you want it and a quiet source of bugs when you
+forget you took it.
+
+## Embed or reference: the modeling decision
+
+Document stores resurface a decision relational normalization made for you: when data
+relates, do you **embed** it (copy it into the document) or **reference** it (store an
+ID and look it up separately)?
+
+- **Embed** when the data is owned by and read with its parent, and rarely changes on
+  its own — a call's frequency list, an order's line items. One read gets everything.
+- **Reference** when the data is shared, large, or changes independently — the system a
+  thousand calls belong to. Embedding it into every call recreates exactly the
+  [duplication](/learn/databases/normalization/) problem: update the system and you'd
+  have to rewrite a thousand documents.
+
+Document stores tolerate — even encourage — some **denormalization** for read speed,
+but the update, insert, and delete anomalies from the normalization lesson are still
+real. You've just taken on the job of managing them, because the store won't join the
+data back for you or keep the copies in sync.
+
+## Which one, and when
+
+The two stores answer different questions:
+
+- Use a **key-value store** when your access is purely **"value for this exact key"** and
+  you need it fast and simple — caches, sessions, counters. Its whole virtue is doing
+  one thing at speed.
+- Use a **document store** when your data is naturally a set of **self-contained
+  documents** you'll query by their fields, and a rigid table schema fights the shape of
+  your data more than it helps.
+- Use **neither** — stay relational — when your data is highly interconnected and you
+  need joins, strong transactions across records, and enforced integrity. That's most
+  business data, which is why relational is still the default.
+
+Both of these are tools you'll often run *alongside* a relational database, not instead
+of it — a document store for a flexible slice of data, a key-value cache in front of
+your SQL. Speaking of which, that cache is the next lesson.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a key-value store only fetches by exact key and treats the value as opaque; a document store understands the value and can query fields inside it." markdown="0">
+  <p class="knowledge-check__q">Quick check: what's the key difference between a key-value store and a document store?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Key-value stores are relational; document stores are not</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">A key-value store treats the value as opaque; a document store can query fields inside the value</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Document stores can't be queried at all, only fetched by ID</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **key-value store** is a dictionary at scale: **set/get an opaque value by its exact
+  key**, nothing more — fast, simple, and easy to scale.
+- It fits **caches, sessions, counters, and flags**; the moment you need to query by
+  anything but the key, you've outgrown it.
+- A **document store** keeps **self-contained JSON-like documents** it can look inside,
+  so you query and index on **fields within** a document, and often **embed** related
+  data instead of joining.
+- A **flexible schema** doesn't remove the schema — it **moves it into your code**, along
+  with the integrity rules a relational database used to enforce.
+- **Embed** owned, co-read data; **reference** shared or independently-changing data — or
+  you recreate the duplication anomalies from normalization.
+- Both commonly run **alongside** a relational database, not instead of it.
+
+Next up: [Time-series & analytical stores](/learn/databases/time-series-and-analytics/).

--- a/docs/learn/databases/keys-and-relationships.md
+++ b/docs/learn/databases/keys-and-relationships.md
@@ -1,0 +1,161 @@
+---
+slug: keys-and-relationships
+title: Keys & relationships
+description: Primary keys name each row and foreign keys link tables together. Learn how a database models the relationships between your things — one-to-many and many-to-many — and why keys are what make the relational model relational in practice.
+keywords: primary key, foreign key, keys, relationships, one-to-many, many-to-many, join table, referential integrity, surrogate key, natural key, relational database
+level: beginner
+status: full
+prereq:
+  - the-relational-model
+  - schemas-and-types
+faq:
+  - q: "What's the difference between a primary key and a foreign key?"
+    a: "A primary key uniquely identifies each row within its own table — no two rows share it. A foreign key is a column in one table that points at another table's primary key, linking the two. Primary keys name rows; foreign keys connect them."
+  - q: "Should a primary key be meaningful data or just a number?"
+    a: "Usually just a number (a surrogate key) — an auto-generated id with no meaning of its own. It never has to change, can't collide, and doesn't leak business meaning. Natural keys (like an email) work but tie your row's identity to data that might change, so surrogate keys are the safer default."
+  - q: "How do I link two tables where both sides can have many of the other?"
+    a: "With a join table — a third table whose rows each pair one key from each side. A call can hit many talkgroups and a talkgroup has many calls, so a call_talkgroups table with one row per pairing models the many-to-many cleanly."
+---
+
+# Keys & relationships
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A **primary key** uniquely names each row in a table; a **foreign key** is a column
+that points at another table's primary key, **linking** the two. Together they model
+the **relationships** between your things — **one-to-many** (a system has many
+calls) and **many-to-many** (via a **join table**). Keys are what let you split data
+across tables without losing the connections, and they set up
+[joins](/learn/databases/joins/) later — building on
+[schemas & types](/learn/databases/schemas-and-types/).
+</div>
+
+Real data isn't one table — it's several, connected. You have systems *and* the
+calls on them, users *and* their settings. The relational model splits these into
+separate tables, and **keys** are the threads that stitch them back together. This
+lesson is about those threads: the **primary key** that names a row and the
+**foreign key** that links to it. Get keys right and the rest of relational
+databases falls into place.
+
+## Primary keys: naming each row
+
+A **primary key** is a column (or set of columns) whose value **uniquely
+identifies** each row — no two rows in the table may share it, and it can't be
+NULL. It's the row's name, the handle you use to point at exactly one record. In
+the systems table, `id` is the primary key: system 2 is *the* County DMR system,
+unambiguously.
+
+You have two flavours to choose from:
+
+- A **natural key** is real data that happens to be unique — an email address, a
+  system's callsign. It's meaningful, but it ties the row's identity to data that
+  might change or turn out not to be as unique as you thought.
+- A **surrogate key** is a made-up identifier with no meaning of its own — usually
+  an auto-incrementing integer or a UUID. It never has to change and can't collide.
+
+Most of the time, reach for a surrogate key. An auto-generated `id` never forces
+you to update every reference just because someone changed their email:
+
+```sql
+CREATE TABLE talkgroups (
+    id       INTEGER PRIMARY KEY,   -- surrogate key
+    name     TEXT    NOT NULL,
+    tg_number INTEGER NOT NULL
+);
+```
+
+## Foreign keys: linking tables
+
+A **foreign key** is a column in one table that holds the **primary key value of a
+row in another table** — a pointer across the gap. Say each decoded call belongs to
+one system. The calls table carries a `system_id` foreign key referencing
+`systems.id`:
+
+```sql
+CREATE TABLE calls (
+    id         INTEGER PRIMARY KEY,
+    system_id  INTEGER NOT NULL REFERENCES systems(id),
+    started_at TIMESTAMP NOT NULL,
+    duration_s REAL
+);
+```
+
+That `REFERENCES systems(id)` does real work. It declares the link *and* enforces
+**referential integrity**: the database now refuses to store a call whose
+`system_id` doesn't match a real system, and can stop you deleting a system that
+still has calls. The relationship isn't just a convention you hope everyone
+follows — the database guarantees it. (This is one of several
+[constraints](/learn/databases/schemas-and-types/) the database enforces for you.)
+
+## One-to-many: the everyday relationship
+
+The calls-and-systems link above is a **one-to-many** relationship: one system has
+many calls, but each call belongs to one system. This is by far the most common
+shape in real schemas — a user has many orders, a system has many talkgroups, a
+post has many comments.
+
+The rule of thumb: the foreign key lives on the **"many" side**. Each call points
+at its one system, so `system_id` sits on the calls table. You never need a list of
+call-ids on the system row; to find a system's calls you just ask for every call
+whose `system_id` matches — which is exactly what a [join](/learn/databases/joins/)
+does.
+
+## Many-to-many: the join table
+
+Some relationships go both ways. A call might be heard on several talkgroups, and a
+talkgroup certainly carries many calls — **many-to-many**. A single foreign key
+can't express this; you can't fit a list of talkgroups in one column and stay
+relational.
+
+The answer is a third table, a **join table** (or junction table), whose every row
+pairs one key from each side:
+
+```sql
+CREATE TABLE call_talkgroups (
+    call_id      INTEGER NOT NULL REFERENCES calls(id),
+    talkgroup_id INTEGER NOT NULL REFERENCES talkgroups(id),
+    PRIMARY KEY (call_id, talkgroup_id)
+);
+```
+
+Each row is one pairing: "call 42 involved talkgroup 7." Want a call's talkgroups?
+Find the rows with that `call_id`. Want a talkgroup's calls? Find the rows with that
+`talkgroup_id`. The many-to-many becomes two clean one-to-many links through the
+middle table — the standard, boring, correct way to model it.
+
+## Why keys matter
+
+Splitting data across tables is what keeps it clean — no duplication, each fact in
+one place, a design goal we formalise in
+[normalization](/learn/databases/normalization/). But splitting only works if you
+can reliably *reconnect* the pieces, and keys are that mechanism. Primary keys give
+every row a stable name; foreign keys turn those names into enforced links. Without
+them you'd have tables that can't refer to each other — a filing cabinet of drawers
+with no cross-references. With them, you have a genuine relational database.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a foreign key holds another table's primary key, enforcing the link between the two." markdown="0">
+  <p class="knowledge-check__q">Quick check: what is a foreign key?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">A password that unlocks a protected table</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">A column holding the primary key value of a row in another table, linking them</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">The column a table is physically sorted by on disk</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **primary key** uniquely identifies each row in its table — no duplicates, no
+  NULL; it's the row's stable name.
+- Prefer a **surrogate key** (an auto-generated id) over a **natural key**, so a
+  row's identity never has to change.
+- A **foreign key** holds another table's primary key value, linking the two and
+  enforcing **referential integrity** — no orphan references.
+- **One-to-many** is the common case; the foreign key lives on the **many** side (a
+  call points at its system).
+- **Many-to-many** needs a **join table** with one row per pairing, turning it into
+  two one-to-many links.
+- Keys are what let you split data cleanly and still reconnect it — the foundation
+  for **joins**.
+
+Next up: [What SQL is](/learn/databases/what-is-sql/).

--- a/docs/learn/databases/migrations.md
+++ b/docs/learn/databases/migrations.md
@@ -1,0 +1,160 @@
+---
+slug: migrations
+title: Schema migrations & evolving a database
+description: A migration is a versioned, ordered change to a database's schema that you run to move it from one shape to the next. Learn why schema changes belong in version control, how up and down migrations work, and how to change a live database without losing data.
+keywords: migrations, schema migration, database migration, schema evolution, version control database, up migration, down migration, migration tool, ALTER TABLE, zero downtime migration, backwards compatible
+level: intermediate
+status: full
+prereq:
+  - schemas-and-types
+  - data-modeling
+faq:
+  - q: Why not just change the schema by hand when I need to?
+    a: "Because a hand-run ALTER TABLE leaves no record of what changed, can't be reproduced on another environment, and drifts out of sync between your laptop, staging, and production. A migration is a checked-in file that any environment can apply in the same order, so every database ends up with the identical, known schema."
+  - q: What are up and down migrations?
+    a: "The up migration applies a change — add a column, create a table. The down migration reverses it — drop that column, drop the table — so you can roll back if something goes wrong. Each migration is a matched pair, and the tool tracks which ones have run so it applies each exactly once."
+  - q: How do I change a schema on a live app without downtime?
+    a: "Make the change in backwards-compatible steps. Add new columns as nullable or with a default, deploy code that writes both old and new, backfill existing rows, then switch reads over and finally remove the old column in a later migration. Each step leaves the running app working against the schema as it is at that moment."
+---
+
+# Schema migrations & evolving a database
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A **migration** is a versioned, ordered change to your database's schema, kept as a
+file **in version control** and applied by a tool that records which migrations have
+already run. Migrations turn schema changes into something **reproducible** across
+every environment, **reviewable** like code, and **reversible** via paired **up** and
+**down** steps. On a live database you change the schema in **backwards-compatible**
+stages so the running app never breaks. This is how the design from
+[data modeling](/learn/databases/data-modeling/) keeps evolving safely.
+</div>
+
+Your [schema](/learn/databases/schemas-and-types/) is never truly finished. Features
+get added, columns get renamed, tables get split — the shape of your data changes for
+as long as the app lives. The question is *how* you make those changes: as risky,
+undocumented, one-off surgery, or as ordinary, version-controlled steps. Migrations
+are the second answer, and they're one of the habits that separates a hobby database
+from a production one.
+
+## The problem with changing schemas by hand
+
+Suppose you `ALTER TABLE` on your laptop to add a column. It works. But now your
+database and everyone else's have quietly diverged: your teammate's copy doesn't have
+the column, staging doesn't, production doesn't. There's no record of *what* you
+changed or *why*, no way to reproduce it reliably, and no way to review it before it
+hits real data. Multiply that across months and a team, and your environments drift
+into subtly different shapes — the source of "works on my machine" bugs that are
+miserable to track down.
+
+The fix is to treat a schema change exactly like a code change: **write it down, check
+it in, and apply it the same way everywhere.**
+
+## A migration is a checked-in, ordered change
+
+A **migration** is a small file describing one schema change, stored in your
+repository alongside your code. Each has a version — usually a timestamp or sequence
+number — that fixes its place in an **ordered** list. A migration **tool** keeps a
+little table in the database recording which migrations have already run, so when you
+say "migrate," it applies exactly the ones that haven't, in order, and stops.
+
+```sql
+-- 20260804_add_recorded_flag.up.sql
+ALTER TABLE calls ADD COLUMN recorded BOOLEAN NOT NULL DEFAULT false;
+```
+
+Because every environment applies the *same files in the same order*, they all
+converge on the *same* schema. New developer joining? They run the migrations from
+zero and get a database identical to production's shape. That reproducibility is the
+whole point.
+
+## Up and down: applying and reversing
+
+Most migrations come as a matched pair. The **up** migration makes the change; the
+**down** migration undoes it, so you can **roll back** if a deploy goes wrong:
+
+```sql
+-- up: apply the change
+ALTER TABLE calls ADD COLUMN recorded BOOLEAN NOT NULL DEFAULT false;
+
+-- down: reverse it
+ALTER TABLE calls DROP COLUMN recorded;
+```
+
+The tool tracks a "current version" and moves you forward or backward through the
+ordered list. Forward applies pending ups; rolling back one step runs the matching
+down. Not every change is cleanly reversible — a down that drops a column throws away
+the data in it — so a good down migration is a *best effort* to restore the previous
+shape, and you lean on [backups](/learn/deployment/backups-and-data/) for the cases a
+rollback can't recover.
+
+## The dangerous part: changing a live database
+
+Adding a table nobody uses yet is easy. The hard migrations change data or columns
+that a **running application** is actively reading and writing. The trap is a change
+that's fine *after* it finishes but breaks the app *during* the moment old code meets
+new schema, or new code meets old schema.
+
+The rule is to make every change **backwards-compatible** at each step, so at no point
+is the deployed code out of step with the schema as it exists right then. A rename —
+which looks trivial — is the classic example of what *not* to do in one shot, because
+the instant you rename a column, the old still-running code that references the old
+name breaks.
+
+## The expand-and-contract pattern
+
+The standard way to make a breaking change safely is to split it into small,
+individually-safe steps — often called **expand and contract**. To rename `label` to
+`talkgroup_label`:
+
+1. **Expand.** Add the new `talkgroup_label` column (nullable, or with a default). The
+   old column still exists; nothing reading `label` breaks.
+2. **Backfill and dual-write.** Deploy code that writes *both* columns, and run a
+   migration to copy existing `label` values into `talkgroup_label`. Now both are
+   populated and correct.
+3. **Migrate reads.** Deploy code that reads the new column. The old one is now unused
+   but still present, so a rollback is still safe.
+4. **Contract.** In a *later* migration, once you're confident, drop the old `label`
+   column.
+
+Each step leaves a database and an app that agree with each other, so you can deploy —
+and roll back — at any point without a broken window. The same shape works for
+splitting a table, changing a type, or adding a `NOT NULL` constraint to existing data
+(add nullable, backfill, then enforce). It's more steps than a raw `ALTER`, and that's
+exactly why it's safe.
+
+## Migrations are part of your deploy
+
+The last habit: migrations run as a **step in your deployment**, in order, before or
+alongside the code that depends on them — never as a manual afterthought someone might
+forget. Combined with backups and a rollback plan, that makes evolving a live database
+a routine, low-drama event instead of a held-breath one. Your schema stays a living,
+version-controlled artifact that any environment can rebuild exactly, which is the
+foundation everything operational later in this module — replication, backups,
+scaling — is built on.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — checked-in, ordered migrations mean every environment applies the same changes and converges on the same schema, reviewably and reversibly." markdown="0">
+  <p class="knowledge-check__q">Quick check: what's the main reason to use migration files instead of running ALTER TABLE by hand?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">ALTER TABLE is slower than a migration tool</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Checked-in, ordered migrations are reproducible across every environment and reviewable like code</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Migration files let you skip writing SQL entirely</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **migration** is a versioned, ordered schema change kept **in version control** and
+  applied by a tool that records which have already run.
+- Migrations make schema changes **reproducible** across environments, **reviewable**
+  like code, and **reversible** through paired **up** and **down** steps.
+- **Up** applies a change; **down** reverses it — though some downs can't recover data,
+  which is what backups are for.
+- Changing a **live** database is the dangerous part: keep every step
+  **backwards-compatible** so the running app never meets a schema it doesn't expect.
+- The **expand-and-contract** pattern splits a breaking change (like a rename) into
+  add, backfill, dual-write, switch reads, then drop — each step individually safe.
+- Run migrations **as part of your deploy**, in order, not as a manual afterthought.
+
+Next up: [SQL vs. NoSQL](/learn/databases/sql-vs-nosql/).

--- a/docs/learn/databases/normalization.md
+++ b/docs/learn/databases/normalization.md
@@ -1,0 +1,184 @@
+---
+slug: normalization
+title: Normalization & avoiding duplication
+description: Normalization is the practice of storing every fact in exactly one place so it can never disagree with itself. Learn the update, insert, and delete anomalies that duplication causes, and the first three normal forms that fix them.
+keywords: normalization, database normalization, normal forms, first normal form, second normal form, third normal form, 3NF, data duplication, update anomaly, redundancy, functional dependency, denormalization
+level: intermediate
+status: full
+prereq:
+  - keys-and-relationships
+  - the-relational-model
+faq:
+  - q: What problem does normalization actually solve?
+    a: "Duplication. When the same fact is copied into many rows, the copies can drift out of sync, and you get update, insert, and delete anomalies. Normalization stores each fact once, so there is only one copy to keep correct."
+  - q: How far should I normalize?
+    a: "Third normal form (3NF) is the practical target for almost all everyday application data, and getting to it is mostly common sense once you can spot duplication. Higher normal forms exist but rarely change a design that is already in 3NF."
+  - q: Is denormalization ever right?
+    a: "Yes — deliberately, for performance, after you have a normalized design and a measured reason. Denormalization trades safe, single-copy data for faster reads, and you take on the job of keeping the copies in sync yourself. Normalize first; denormalize only when a real workload demands it."
+---
+
+# Normalization & avoiding duplication
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Normalization** is the discipline of storing every fact in **exactly one
+place**. Duplicated data eventually **disagrees with itself** — the same customer
+name spelled two ways, a price updated in one row but not another — which produces
+**update, insert, and delete anomalies**. The fix is to split data into tables
+until each fact lives once, linked back together with the **keys** from
+[keys & relationships](/learn/databases/keys-and-relationships/). For everyday
+application data, **third normal form (3NF)** is the target.
+</div>
+
+The previous unit gave you tables, keys, and SQL. This unit is about using them
+*well* — turning a workable pile of columns into a sound design. The first and most
+important idea is normalization, and its whole motivation fits in one sentence: a
+fact stored twice is a fact that can eventually be wrong in one of the two places.
+
+## The one-sentence rule
+
+**Store each fact exactly once.** That is normalization in a nutshell. Everything
+below is just the mechanics of achieving it. A customer's email address, a system's
+control-channel frequency, a product's price — each of these is a single fact about
+a single thing, and it should live in exactly one row of one table. When you need it
+elsewhere, you *point* at it with a key rather than copying it.
+
+The opposite of this is **redundancy**: the same fact physically written into many
+rows. Redundancy feels harmless — even convenient — right up until two copies stop
+agreeing, and then you have data you can no longer trust.
+
+## What duplication does to you
+
+Imagine a single flat table that records decoded calls, and jams the *system* details
+into every call row:
+
+| call_id | system_name | system_wacn | talkgroup | started_at |
+|---|---|---|---|---|
+| 1 | Metro P25 | 0xBEE00 | Fire Dispatch | 09:00 |
+| 2 | Metro P25 | 0xBEE00 | EMS | 09:01 |
+| 3 | Metro P25 | 0xBEE0**8** | Police | 09:02 |
+
+The system's WACN is copied into every call. Look at row 3: someone fat-fingered it,
+and now the database says Metro P25 has two different WACNs. Which is right? The table
+can't tell you. This is the disease normalization cures, and it shows up as three
+classic **anomalies**:
+
+- **Update anomaly.** The system gets renamed. You must find and change *every* call
+  row that mentions it. Miss one, and the data contradicts itself.
+- **Insert anomaly.** You want to record a newly discovered system that has no calls
+  yet. In this design you can't — there's no row to put it in without inventing a fake
+  call.
+- **Delete anomaly.** You purge old calls and accidentally delete the last row that
+  mentioned a system. The system's details vanish with it, even though you only meant
+  to remove call history.
+
+Every one of these disappears the moment each fact lives in exactly one place.
+
+## First normal form: one value per cell
+
+**First normal form (1NF)** is the price of admission to the relational model: every
+cell holds a **single, atomic value**, and there are no repeating groups. No
+comma-separated lists stuffed into one column, no `talkgroup1`, `talkgroup2`,
+`talkgroup3` columns marching across the table.
+
+If a call can involve several talkgroups, you don't cram them into one cell:
+
+```sql
+-- NOT 1NF: a list hidden in a text column
+talkgroups TEXT   -- "Fire Dispatch, EMS, Police"
+```
+
+You give each value its own row in a related table instead. A list in a cell is
+invisible to the query planner — you can't index it, join on it, or filter it
+cleanly — so 1NF is what makes the rest of SQL actually work on your data.
+
+## Second and third normal form: facts belong to their key
+
+Once every table has a **primary key**, the next two forms are both variations on a
+single idea: **every non-key column must describe the whole key, and nothing but the
+key.**
+
+**Second normal form (2NF)** rules out a column that depends on only *part* of a
+composite key. If a table's key is `(system_id, talkgroup_id)` but it also stores
+`system_name`, that name depends on `system_id` alone — half the key — so it's
+misplaced. It belongs in a `systems` table keyed by `system_id`.
+
+**Third normal form (3NF)** rules out a column that depends on another *non-key*
+column. If a `calls` table stores `system_id` and also `system_wacn`, the WACN really
+depends on the system, not on the call — it's a fact *about the system* that has
+leaked into the call row. Move it to `systems` and let the calls point at it:
+
+```sql
+CREATE TABLE systems (
+    system_id   INTEGER PRIMARY KEY,
+    name        TEXT NOT NULL,
+    wacn        INTEGER NOT NULL      -- the WACN lives here, once
+);
+
+CREATE TABLE calls (
+    call_id     INTEGER PRIMARY KEY,
+    system_id   INTEGER NOT NULL REFERENCES systems(system_id),
+    talkgroup   TEXT NOT NULL,
+    started_at  TIMESTAMP NOT NULL
+    -- no system_name, no wacn: point at systems instead
+);
+```
+
+Now the WACN exists in one row. Rename the system, correct its WACN, or add a system
+with no calls yet — each is a single change in one obvious place, and no anomaly is
+possible.
+
+## Getting to 3NF is mostly common sense
+
+You don't need to recite the formal definitions to normalize well. The instinct is
+this: whenever you notice a value being **repeated across rows**, ask "what is this a
+fact *about*?" If it's a fact about something other than this row's identity, it wants
+its own table, referenced by a key. A repeated system name is a fact about the system;
+a repeated author name is a fact about the author. Pull it out, key it, point at it.
+
+Third normal form is the sweet spot for nearly all everyday data. There are higher
+forms (BCNF, 4NF, and beyond) that handle subtle key overlaps, but a clean 3NF design
+is already free of the anomalies that bite real applications, and pushing further
+rarely changes anything.
+
+## When to denormalize on purpose
+
+Normalization optimises for **correctness**; it can cost you **read speed**, because
+answering a question may now require joining several tables back together. Sometimes,
+for a hot query on a large table, that cost matters. **Denormalization** is the
+deliberate choice to reintroduce some duplication — a cached count, a copied name — to
+make reads faster.
+
+The key word is *deliberate*. You normalize first, get a clean design, and denormalize
+only where a **measured** workload demands it — and when you do, you accept the job of
+keeping the duplicated copies in sync, usually with the tools from later lessons like
+[transactions](/learn/databases/transactions-and-acid/) or application logic. A
+duplicated fact you *chose*, know about, and maintain is fine. A duplicated fact you
+stumbled into is the bug this whole lesson is about.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — storing a fact once means there's only ever one copy to keep correct, so it can't disagree with itself." markdown="0">
+  <p class="knowledge-check__q">Quick check: what is normalization fundamentally trying to prevent?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Tables from ever growing beyond a few thousand rows</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The same fact being stored in two places where the copies can disagree</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Queries from ever needing to join more than one table</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Normalization** means storing every fact **exactly once**, so no two copies can
+  drift apart.
+- Duplication causes **update, insert, and delete anomalies** — data that contradicts
+  itself, facts you can't record, and facts you lose by accident.
+- **First normal form**: one atomic value per cell, no lists or repeating column
+  groups.
+- **Second and third normal form**: every non-key column must describe the **whole
+  key and nothing but the key** — pull out facts that really belong to something else.
+- **3NF** is the practical target for everyday data, and reaching it is mostly a habit
+  of spotting repeated values and giving them their own keyed table.
+- **Denormalize only on purpose** — for a measured performance need, accepting that
+  you now maintain the duplicate yourself.
+
+Next up: [Data modeling for a real app](/learn/databases/data-modeling/).

--- a/docs/learn/databases/orms-vs-raw-sql.md
+++ b/docs/learn/databases/orms-vs-raw-sql.md
@@ -1,0 +1,158 @@
+---
+slug: orms-vs-raw-sql
+title: ORMs vs. raw SQL
+description: The perennial choice when your code talks to a database — let an ORM map objects to rows and generate SQL for you, or write the SQL by hand — what each approach buys you, what each costs, and how to decide (or blend the two).
+keywords: ORM, object-relational mapping, raw SQL, query builder, N+1 problem, leaky abstraction, data mapper, active record, SQL by hand, ORM tradeoffs
+level: intermediate
+status: full
+prereq:
+  - querying-with-select
+faq:
+  - q: "What does an ORM actually do?"
+    a: "An **ORM** (object-relational mapper) maps rows in a table to objects in your code, so you work with `user.name` instead of columns and result sets, and it generates the SQL to load and save them. It handles the boilerplate of turning query results into typed objects and back, plus relationships, migrations, and more depending on the library."
+  - q: "Is raw SQL faster than an ORM?"
+    a: "Often, at the extremes. An ORM's generated SQL is usually fine for ordinary queries, but for complex or performance-critical ones a hand-written query gives you full control and no surprises. The bigger cost of an ORM isn't raw speed — it's losing visibility into what SQL actually runs, which is where problems like N+1 hide."
+  - q: "Do I have to pick one for the whole project?"
+    a: "No, and most mature codebases don't. A common pattern is to use an ORM or a lightweight mapper for the routine create-read-update-delete work, and drop to raw SQL for the handful of complex reports and hot-path queries where control matters. The two coexist against the same database."
+---
+
+# ORMs vs. raw SQL
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+When your code talks to a database you can let an **ORM** map rows to objects and
+generate the SQL for you, or write the **raw SQL** yourself. An ORM cuts boilerplate
+and keeps you in your language; raw SQL gives full control and no hidden queries.
+The real cost of an ORM is **losing sight of the SQL that actually runs** — the
+source of traps like the **N+1 problem**. Most codebases **blend** the two. Whichever
+you choose, keep queries safe with [parameterised queries](/learn/databases/sql-injection/).
+</div>
+
+Once your program is connected and pooled, you have to decide *how* to express
+queries in code. There are two schools. One says: work with objects in your
+language and let a library translate to SQL. The other says: write the SQL yourself,
+it's a perfectly good language. This is one of the oldest debates in software, and
+the honest answer is that both are right, for different queries. This lesson gives
+you the tradeoffs so you can choose deliberately instead of by habit.
+
+## What an ORM gives you
+
+An **ORM** — object-relational mapper — bridges two worlds: the tables-and-rows of a
+database and the objects-and-fields of your program. You define that a `Call` object
+corresponds to the `calls` table, and the ORM lets you write code like:
+
+```
+call = Call.find(42)
+call.talkgroup = "Fireground"
+call.save()
+```
+
+Behind those three lines the ORM generates a `SELECT ... WHERE id = 42`, tracks that
+you changed a field, and generates the matching `UPDATE`. You never wrote SQL, never
+mapped columns to fields by hand, and never assembled a result set into an object.
+
+That's the pitch, and it's a strong one:
+
+- **Less boilerplate.** The tedious work of reading rows into typed objects and
+  writing objects back is automated.
+- **One language.** You stay in your program's types and idioms instead of switching
+  to SQL strings.
+- **Safety by default.** Good ORMs parameterise every value, so the most common
+  injection mistakes don't happen.
+- **Extras.** Many bundle migrations, relationship loading, validation, and
+  connection handling.
+
+For ordinary create-read-update-delete work over a well-shaped schema, an ORM
+removes a great deal of repetitive code.
+
+## What raw SQL gives you
+
+Writing **raw SQL** means composing the query text yourself and mapping the results
+into your own structures:
+
+```sql
+SELECT c.id, c.started_at, t.name AS talkgroup
+FROM calls c
+JOIN talkgroups t ON t.id = c.talkgroup_id
+WHERE c.system_id = $1 AND c.started_at > $2
+ORDER BY c.started_at DESC
+LIMIT 50;
+```
+
+What you get in return is **control and clarity**:
+
+- **Exactly the query you intend.** No generated SQL, no surprises about what hit the
+  database.
+- **The full power of SQL.** Complex joins, window functions, CTEs, and
+  database-specific features an ORM may not express well.
+- **Predictable performance.** You can read the query, run `EXPLAIN` on it, and tune
+  it directly — see [performance & monitoring](/learn/databases/performance-and-monitoring/).
+- **No extra abstraction to learn or fight.** SQL is the interface, and you already
+  know it from this module.
+
+The cost is that you write and maintain the mapping code yourself, and you have to
+be disciplined about parameterising every value.
+
+## The leaky abstraction problem
+
+The deepest issue with ORMs is that the database doesn't go away — it's just hidden.
+An ORM is a **leaky abstraction**: most of the time it lets you ignore SQL, but the
+moment performance matters, the SQL underneath leaks back through and you have to
+understand it anyway.
+
+The classic example is the **N+1 problem**. You load a list of 100 calls, then loop
+over them printing each call's talkgroup name. If the ORM loads each talkgroup
+lazily, that innocent loop fires **1 query for the list plus 100 more** — one per
+call — where a single join would have done. The code looks clean; the database is
+drowning. You only see it if you look at the SQL the ORM emits.
+
+This is the real tradeoff. An ORM's convenience comes from hiding the SQL, and
+hidden SQL is SQL you can't reason about until it hurts. Raw SQL is more work up
+front but nothing is hidden.
+
+## Choosing — and blending
+
+You rarely have to pick one for everything, and you usually shouldn't. A common,
+pragmatic split:
+
+- **Use an ORM or a light mapper for the routine 90%** — the straightforward inserts,
+  lookups, and updates where boilerplate is the only real cost.
+- **Drop to raw SQL for the hard 10%** — complex reports, aggregations, and the
+  performance-critical queries on your hot path, where control beats convenience.
+
+Between the two sits the **query builder** — a library that helps you assemble SQL
+programmatically (composable `where` and `join` calls) while still producing plain
+SQL you can see. It gives some of the ORM's ergonomics without hiding the query.
+
+Whatever you choose, two rules don't bend: **always parameterise values** to prevent
+injection, and **stay able to see the SQL** so you can debug and tune it. An ORM that
+lets you log its generated queries keeps that door open; one that hides them
+entirely is a liability. Go's own standard library leans toward the raw-SQL end, as
+the [talking to a database from Go](/learn/databases/databases-in-go/) lesson shows.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the N+1 problem: a loop that lazily loads a related row per item fires one query plus one per row, where a single join would do." markdown="0">
+  <p class="knowledge-check__q">Quick check: which problem is a classic hazard of ORMs hiding the SQL they run?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">SQL injection from unescaped input</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The N+1 problem — a loop firing one query per row instead of a single join</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Connection pool exhaustion under heavy load</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- An **ORM** maps rows to objects and generates SQL for you — cutting boilerplate,
+  keeping you in your language, and parameterising values by default.
+- **Raw SQL** means writing queries by hand for full control, the complete power of
+  SQL, and predictable, inspectable performance.
+- An ORM is a **leaky abstraction**: the database is hidden, not gone, and the SQL
+  leaks back through when performance matters.
+- The **N+1 problem** — a loop that lazily loads a related row per item — is the
+  classic ORM trap, invisible until you look at the emitted SQL.
+- Most codebases **blend** the two: an ORM or mapper for routine work, raw SQL for
+  complex and hot-path queries, with a query builder as a middle ground.
+- Non-negotiables either way: **parameterise every value**, and **stay able to see
+  the SQL**.
+
+Next up: [SQL injection & querying safely](/learn/databases/sql-injection/).

--- a/docs/learn/databases/performance-and-monitoring.md
+++ b/docs/learn/databases/performance-and-monitoring.md
@@ -1,0 +1,155 @@
+---
+slug: performance-and-monitoring
+title: Performance tuning & monitoring
+description: How to find the slow query before your users do — reading a query plan with EXPLAIN, the metrics that actually matter, the usual suspects behind a sluggish database, and why you measure before you optimise.
+keywords: query performance, EXPLAIN, query plan, slow query log, sequential scan, missing index, database metrics, p99 latency, monitoring, N+1, measure before optimising
+level: advanced
+status: full
+prereq:
+  - indexes
+faq:
+  - q: "What does EXPLAIN do?"
+    a: "`EXPLAIN` shows the **query plan** — the step-by-step strategy the database will use to run a query: which indexes it uses (or doesn't), how it joins tables, and how many rows it expects at each step. `EXPLAIN ANALYZE` actually runs the query and reports real timings. It's the first tool you reach for when a query is slow, because it tells you *why*."
+  - q: "What's the single most common cause of a slow query?"
+    a: "A **missing index** causing a full table scan — the database reading every row to find the few it needs. `EXPLAIN` reveals it as a sequential scan over a large table. Adding the right index usually turns a query from seconds to milliseconds, which is why indexes are the first thing to check."
+  - q: "Which metrics should I actually watch?"
+    a: "Query latency (especially the **p95/p99**, not just the average), throughput (queries per second), error rate, connection-pool usage, cache hit ratio, and replication lag if you have replicas. Averages hide the slow tail; the p99 is what your unhappiest users feel."
+---
+
+# Performance tuning & monitoring
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Finding a slow database is a measurement problem, not a guessing game. **`EXPLAIN`**
+shows the **query plan** — how the database will actually run a query — and usually
+points straight at the culprit, most often a **missing index** causing a full table
+scan. Watch the metrics that matter (**p95/p99 latency**, throughput, errors, pool
+usage), catch slow queries with a **slow-query log**, and always **measure before you
+optimise**. The biggest wins are almost always [indexes](/learn/databases/indexes/)
+and killing [N+1 queries](/learn/databases/orms-vs-raw-sql/).
+</div>
+
+A database rarely gets slow all at once. It creeps: a table grows, a query that was
+fine at a thousand rows crawls at ten million, and one day the dashboard times out.
+The skill here is diagnosis — knowing how to ask the database *why* a query is slow
+rather than guessing and adding random indexes. This lesson is the toolkit: read the
+plan, watch the right numbers, and fix the usual suspects, in that order.
+
+## Measure before you optimise
+
+The first rule is discipline: **don't optimise what you haven't measured.** It is
+astonishingly easy to spend a day speeding up a query that runs once a week while the
+real problem — a query firing ten thousand times a minute — sits untouched. Optimising
+on a hunch usually adds complexity and indexes you don't need, and sometimes makes
+things *slower*.
+
+So start by finding *which* query is actually the problem. A **slow-query log** records
+every query that takes longer than a threshold, and database statistics views show
+which queries consume the most total time (frequency × duration). Let the data point
+you at the one query worth your afternoon, then optimise that one.
+
+## Reading a query plan with EXPLAIN
+
+Once you have the offending query, ask the database how it intends to run it. Every
+relational database has an **`EXPLAIN`** command that prints the **query plan** — the
+strategy the planner chose:
+
+```sql
+EXPLAIN ANALYZE
+SELECT c.id, c.started_at, t.name
+FROM calls c
+JOIN talkgroups t ON t.id = c.talkgroup_id
+WHERE c.system_id = 7 AND c.started_at > '2026-08-01'
+ORDER BY c.started_at DESC
+LIMIT 50;
+```
+
+`EXPLAIN` shows the plan; `EXPLAIN ANALYZE` actually runs it and reports real
+timings. Reading a plan, you're looking for a few tells:
+
+- **Sequential scan (full table scan)** on a big table — the database reading *every*
+  row. Fine on a tiny table, a disaster on a huge one. Usually the smoking gun.
+- **Index scan** — the database using an index to jump to the rows it needs. What you
+  want on your filter and join columns.
+- **Row estimates far off from reality** — the planner expected 10 rows and hit a
+  million, a sign its statistics are stale.
+- **An expensive sort or join** high in the plan — sometimes fixed by an index that
+  provides the order, sometimes by rewriting the query.
+
+The plan turns "it's slow" into "it's doing a sequential scan over ten million rows
+because there's no index on `system_id`" — a problem you can actually fix.
+
+## The usual suspects
+
+Most database slowness comes from a short list of causes, and knowing them shortcuts
+diagnosis:
+
+- **Missing indexes.** By far the most common. A filter or join on an unindexed column
+  forces a full scan. Add the right [index](/learn/databases/indexes/) and the query
+  often drops from seconds to milliseconds.
+- **N+1 queries.** Not one slow query but a flood of small ones — the
+  [ORM trap](/learn/databases/orms-vs-raw-sql/) of looping and lazily loading a related
+  row per item. Replace the loop with a single join.
+- **`SELECT *` and over-fetching.** Pulling every column and every row when you need a
+  few. Select only what you use and always `LIMIT` large result sets.
+- **Too many indexes.** Indexes speed reads but slow **writes**, since every insert or
+  update must maintain them. An over-indexed table is slow to write; indexes have a
+  cost, so add them deliberately.
+- **Lock contention.** Long transactions holding locks block others. Keep
+  transactions short.
+
+## The metrics that matter
+
+You can't watch a database by staring at it; you instrument it and watch trends. The
+metrics worth a dashboard and alerts:
+
+- **Query latency — and the *tail*.** Not just the average but the **p95 and p99**: the
+  slowest 5% and 1% of queries. Averages hide a slow tail, and the p99 is exactly what
+  your most frustrated users experience.
+- **Throughput** — queries per second, so you can see load and correlate spikes with
+  slowness.
+- **Error rate** — failed queries, timeouts, deadlocks.
+- **Connection-pool usage** — how often the [pool](/learn/databases/connection-pooling/)
+  is saturated and queries wait.
+- **Cache hit ratio** — how much is served from memory versus disk; a falling ratio
+  often precedes a slowdown.
+- **Replication lag** — if you run [replicas](/learn/databases/replication-and-scaling/),
+  how far behind they are.
+
+The goal is to see the problem in a graph before it's an incident — the database
+version of the observability the AI path describes in
+[observability & monitoring](/learn/building-ai/observability-and-monitoring/).
+
+## A tuning loop
+
+Put it together into a repeatable loop: **measure** to find the worst query, **explain**
+it to learn why, **change one thing** (add an index, rewrite the query, kill an N+1),
+**measure again** to confirm it helped, and stop when it's fast enough. One change at a
+time, always verified — the same measure-change-verify discipline as any good
+performance work.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — EXPLAIN shows the query plan, revealing things like a full table scan from a missing index, so you fix the real cause instead of guessing." markdown="0">
+  <p class="knowledge-check__q">Quick check: a query is slow. What's the first thing to reach for?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Add indexes to every column in the table and see if it helps</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Run EXPLAIN to see the query plan and find out why it's slow</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Move the database to a bigger server immediately</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Measure before you optimise** — use a **slow-query log** and stats views to find
+  the query that actually matters, then fix that one.
+- **`EXPLAIN`** shows the **query plan**; `EXPLAIN ANALYZE` runs it with real timings.
+  Look for **sequential (full table) scans**, bad row estimates, and expensive sorts.
+- The usual suspects: **missing indexes** (the big one), **N+1 queries**, `SELECT *`
+  over-fetching, **too many indexes** slowing writes, and lock contention.
+- Watch the metrics that matter — latency at the **p95/p99 tail**, throughput, errors,
+  pool usage, cache hit ratio, replication lag — to catch trouble in a graph, not an
+  outage.
+- Work a **measure → explain → change one thing → measure again** loop, and stop when
+  it's fast enough.
+
+Next up: [choosing a database](/learn/databases/choosing-a-database/).

--- a/docs/learn/databases/querying-with-select.md
+++ b/docs/learn/databases/querying-with-select.md
@@ -1,0 +1,146 @@
+---
+slug: querying-with-select
+title: Querying with SELECT
+description: SELECT is the single most-used statement in all of software. Learn how to ask a database for exactly the columns and rows you need, why SELECT * is a habit to break, and how to rename and compute columns in your results.
+keywords: SELECT, SQL query, columns, SELECT star, FROM, aliases, computed columns, DISTINCT, projection, reading data
+level: beginner
+status: full
+prereq:
+  - what-is-sql
+faq:
+  - q: "What's wrong with SELECT *?"
+    a: "SELECT * grabs every column, which is handy for quick exploration but a poor habit in real code. It fetches data you don't need (slower, more memory), and it breaks silently when someone adds or reorders columns. Naming the columns you actually want is clearer, faster, and stable against schema changes."
+  - q: "Does SELECT change the data in the table?"
+    a: "No. SELECT only reads — it produces a result set to look at and never modifies the stored rows. The statements that change data are INSERT, UPDATE, and DELETE, covered later. You can run any SELECT freely without fear of altering anything."
+  - q: "What does DISTINCT do?"
+    a: "DISTINCT removes duplicate rows from the result, so you get each unique combination once. SELECT DISTINCT protocol FROM systems gives you the set of protocols in use — one of each — rather than one entry per system."
+---
+
+# Querying with SELECT
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**SELECT** is how you read data from a database — it names the **columns** you want
+**FROM** a table and returns a **result set**. Name the columns you need rather than
+reaching for **`SELECT *`**, which is convenient for exploring but fragile in real
+code. You can **rename** columns with aliases, **compute** new ones, and drop
+duplicates with **DISTINCT**. It's the foundation every later query builds on, and it
+only reads — building on [what SQL is](/learn/databases/what-is-sql/).
+</div>
+
+`SELECT` is, without much exaggeration, the most-used statement in all of software.
+Every dashboard number, every list on a screen, every report starts as a SELECT. The
+good news is the basic form is simple and reads almost like English. This lesson gets
+you fluent in that basic form; the next lessons pile on filtering, sorting, joining,
+and grouping — but they're all *SELECT with more clauses*.
+
+## The basic shape
+
+A SELECT names the columns you want and the table to get them from:
+
+```sql
+SELECT name, frequency_hz, protocol
+FROM systems;
+```
+
+Two clauses: `SELECT` lists the columns, `FROM` names the table. The result is a
+**result set** — itself a table of rows and columns, containing just what you asked
+for. Run it and you get every row of `systems`, but only those three columns.
+
+That "only those columns" part has a name: **projection**. You're projecting the
+table down to the columns you care about. A table might have twenty columns; if you
+need three, you ask for three.
+
+## Break the SELECT * habit
+
+You'll constantly see (and be tempted to write) `SELECT *`, where the `*` means
+"every column":
+
+```sql
+SELECT * FROM systems;
+```
+
+For poking around at a table interactively, that's fine — it's the fastest way to see
+what's there. But in real application code it's a habit worth breaking, for concrete
+reasons:
+
+- **It fetches data you don't need.** Pulling twenty columns to use three wastes
+  bandwidth and memory, and can defeat an [index](/learn/databases/indexes/) that
+  would otherwise satisfy the query from the index alone.
+- **It's fragile.** Add, remove, or reorder a column and `SELECT *` silently returns a
+  different shape — code that assumed a column position or count now breaks in
+  surprising ways.
+- **It hides intent.** Naming the columns documents exactly what this query depends
+  on. The next reader (often you) sees precisely what's used.
+
+Name the columns you want. It's a little more typing now and a lot less debugging
+later.
+
+## Renaming and computing columns
+
+The `SELECT` list isn't limited to bare column names. You can give a column a new name
+in the result with **`AS`** (an **alias**), and you can compute values on the fly:
+
+```sql
+SELECT
+    name AS system_name,
+    frequency_hz / 1000000.0 AS frequency_mhz
+FROM systems;
+```
+
+Here `frequency_mhz` is a **computed column** — the result set carries a value that
+isn't stored anywhere, calculated per row as the query runs. Aliases are especially
+useful for computed columns (which otherwise get an ugly auto-generated name) and for
+giving results friendly labels an application can rely on. The stored table is
+untouched; you're just shaping the *output*.
+
+## DISTINCT: unique rows only
+
+Sometimes you want the *set* of values, not one per row. **`DISTINCT`** collapses
+duplicate rows in the result to one each:
+
+```sql
+SELECT DISTINCT protocol
+FROM systems;
+```
+
+If a hundred systems use only P25, DMR, and TETRA, this returns three rows, not a
+hundred. It's the quick way to answer "what distinct values appear in this column?"
+Keep in mind DISTINCT has to compare rows to weed out duplicates, so it's not free on
+large results — but for exactly this question it's the right tool. (When you want
+*counts* per value rather than just the list, that's
+[aggregation and GROUP BY](/learn/databases/aggregation-and-grouping/), a couple of
+lessons on.)
+
+## SELECT only reads
+
+One reassuring fact to lock in: **SELECT never changes your data**. It reads and
+returns a result set, and the stored rows are exactly as they were. You can run any
+SELECT — on production, even — without fear of altering anything. The statements that
+*modify* data are `INSERT`, `UPDATE`, and `DELETE`, and they come later in
+[inserting, updating & deleting](/learn/databases/inserting-updating-deleting/). This
+read-only safety is why exploring a database with SELECT is a great way to learn one:
+you genuinely can't break anything by looking.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — name the columns you need; SELECT * is handy for exploring but fragile and wasteful in real code." markdown="0">
+  <p class="knowledge-check__q">Quick check: why prefer naming columns over <code>SELECT *</code> in application code?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">SELECT * doesn't actually work on most databases</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">It fetches only what you need and won't silently break when columns change</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Naming columns lets SELECT modify the table, which SELECT * can't</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **SELECT** reads data: it names the **columns** you want **FROM** a table and
+  returns a **result set** — itself a table of rows and columns.
+- Choosing specific columns is **projection**; prefer it over **`SELECT *`**, which is
+  fine for exploring but wasteful and fragile in real code.
+- **Aliases** (`AS`) rename columns in the result, and you can add **computed columns**
+  calculated per row without changing stored data.
+- **DISTINCT** removes duplicate rows, giving you the unique set of values.
+- **SELECT only reads** — it never modifies stored data, so you can run it freely.
+
+Next up: [Filtering, sorting & limiting](/learn/databases/filtering-and-sorting/).

--- a/docs/learn/databases/replication-and-scaling.md
+++ b/docs/learn/databases/replication-and-scaling.md
@@ -1,0 +1,142 @@
+---
+slug: replication-and-scaling
+title: Replication, sharding & scaling
+description: When one database server isn't enough — read replicas that copy your data for more read capacity and failover, sharding that splits data across servers for write capacity, and the CAP tradeoff that shapes every distributed database.
+keywords: replication, read replica, primary replica, failover, sharding, partitioning, horizontal scaling, vertical scaling, CAP theorem, replication lag, eventual consistency
+level: advanced
+status: full
+prereq:
+  - transactions-and-acid
+faq:
+  - q: "What's the difference between vertical and horizontal scaling?"
+    a: "**Vertical scaling** means a bigger server — more CPU, RAM, and faster disks for the one database. It's simple and gets you a long way, but there's a ceiling and it's a single point of failure. **Horizontal scaling** means more servers — replicas and shards — which has no hard ceiling but adds real complexity. Most systems scale up first and out only when they must."
+  - q: "What is a read replica?"
+    a: "A copy of your database that continuously receives every change from the primary, kept nearly in sync. Your app sends writes to the primary and spreads reads across the replicas, multiplying read capacity. Replicas also serve as failover targets: if the primary dies, a replica can be promoted to take its place."
+  - q: "What is the CAP theorem in one line?"
+    a: "When a distributed database is partitioned — some nodes can't reach others — it must choose between staying **consistent** (refuse to serve possibly-stale data) or staying **available** (serve what it has, possibly stale). You can't have both during a partition, so every distributed store makes this tradeoff on purpose."
+---
+
+# Replication, sharding & scaling
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+When one server isn't enough you scale **up** (a bigger machine) until you must scale
+**out** (more machines). **Replication** copies your data to **read replicas** —
+multiplying read capacity and giving you a **failover** target — but writes still go
+to one **primary**. **Sharding** splits the data itself across servers to scale
+**writes**, at real cost in complexity. And the **CAP theorem** says a partitioned
+distributed database must trade **consistency** against **availability**. Fast reads
+also lean on a [caching layer](/learn/databases/caching-layers/) in front of all this.
+</div>
+
+For a long time, the answer to "my database is slow" is a better query or a bigger
+machine, and this lesson's honest first message is that you should exhaust those
+before reaching for anything here. But every single server has a ceiling, and past
+it you need more than one. Spreading a database across machines buys capacity and
+survivability — and introduces the hardest tradeoffs in all of data systems. This
+lesson maps the terrain so you know which tool solves which problem.
+
+## Scale up before you scale out
+
+There are two directions to grow.
+
+- **Vertical scaling (scale up)** — give the one server more resources: more CPU
+  cores, more RAM, faster disks. It's the simplest lever, requires no application
+  changes, and modern hardware takes you remarkably far. Its limits are a hard
+  ceiling (the biggest machine you can buy) and that it's still a **single point of
+  failure**.
+- **Horizontal scaling (scale out)** — add more servers and spread the work across
+  them. There's no fixed ceiling, but every distributed technique below adds
+  operational and correctness complexity.
+
+The seasoned instinct is **up first, out only when forced.** A single well-tuned
+database with good indexes and a cache in front handles more than most projects will
+ever need. Scale out because you've hit a real wall, not because it sounds impressive.
+
+## Replication: copies for reads and failover
+
+**Replication** keeps one or more **copies** of your database in sync with the
+original. The common shape is **primary/replica** (also called leader/follower): one
+**primary** accepts all the **writes**, and every change streams to one or more
+**replicas** that stay nearly current.
+
+That buys two big things:
+
+- **Read capacity.** Most workloads read far more than they write. Send writes to the
+  primary and spread reads across the replicas, and you multiply how many reads you
+  can serve without touching write capacity.
+- **Failover / availability.** A replica is a warm standby. If the primary dies, you
+  **promote** a replica to become the new primary, and the system keeps running.
+  Replicas can also live in another region for disaster resilience.
+
+The catch is **replication lag.** A replica is a moment behind the primary, so a read
+from a replica may miss a write that just landed — you write a value, immediately read
+it from a replica, and it's not there yet. This is **eventual consistency**: replicas
+converge to the same state, but not instantly. You design around it by routing
+reads-that-must-see-your-own-writes to the primary, and sending everything else to
+replicas.
+
+## Sharding: splitting the data itself
+
+Replication scales *reads* — but every write still funnels through the single
+primary, so it doesn't help a write-bound system. For that you need **sharding**
+(horizontal **partitioning**): splitting the data across multiple servers so each
+**shard** holds a slice and handles the writes for that slice.
+
+You split on a **shard key** — say, `system_id`, so all of one radio system's calls
+live on one shard. Now writes spread across shards and total write capacity grows with
+the number of shards.
+
+The cost is steep, which is why sharding is a last resort:
+
+- **Cross-shard queries are hard.** A query spanning shards must hit several servers
+  and combine results; a join across shards may be impractical.
+- **The shard key is a heavy commitment.** Choose it badly and one shard gets all the
+  traffic (a **hot shard**), or rebalancing later means moving huge amounts of data.
+- **Transactions across shards** lose the easy [ACID](/learn/databases/transactions-and-acid/)
+  guarantees you get on one machine.
+
+Reach for sharding only when a single primary genuinely can't keep up with writes and
+you've already scaled up and cached.
+
+## The CAP tradeoff
+
+Once data lives on multiple machines, a law of distributed systems bites — the **CAP
+theorem**. It says that when a **network partition** happens (some nodes can't reach
+others, which *will* happen), a distributed database must choose between two goods:
+
+- **Consistency** — every read sees the latest write, or an error. The system refuses
+  to serve data it can't confirm is current.
+- **Availability** — every request gets an answer, even if some nodes are unreachable —
+  but that answer might be **stale**.
+
+You cannot have both **during a partition**: either you reject requests to stay
+correct, or you answer them and risk staleness. Every distributed store picks a side
+on purpose — a bank ledger leans consistent, a social feed leans available — and that
+choice, not a benchmark, is often what makes a database right or wrong for a job. It's
+a big part of the [SQL vs. NoSQL](/learn/databases/sql-vs-nosql/) conversation.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — replication multiplies read capacity and gives a failover target, but writes still funnel through the single primary." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does adding read replicas primarily buy you?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">More write capacity, since writes spread across replicas</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">More read capacity and a failover target — writes still go to the one primary</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Stronger consistency, since every replica is always exactly in sync</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Scale **up** (a bigger server) before you scale **out** (more servers) — a single
+  tuned database with a cache goes a very long way.
+- **Replication** copies data to **read replicas**, multiplying **read** capacity and
+  providing a **failover** target — but all **writes** still go to one **primary**.
+- **Replication lag** means replicas are slightly behind (**eventual consistency**);
+  route reads that must see their own writes to the primary.
+- **Sharding** splits the data across servers on a **shard key** to scale **writes**,
+  at heavy cost — cross-shard queries, hot shards, and lost cross-shard transactions.
+- The **CAP theorem**: during a network partition a distributed database must trade
+  **consistency** against **availability** — a deliberate choice per system.
+
+Next up: [performance tuning & monitoring](/learn/databases/performance-and-monitoring/).

--- a/docs/learn/databases/schemas-and-types.md
+++ b/docs/learn/databases/schemas-and-types.md
@@ -1,0 +1,144 @@
+---
+slug: schemas-and-types
+title: Schemas, columns & data types
+description: A schema is the shape of your data — the columns, their types, and the rules. Learn what common data types to reach for, why deciding the shape up front saves you from a mess later, and how the database enforces it.
+keywords: database schema, data types, columns, integer, text, varchar, boolean, timestamp, NULL, NOT NULL, CREATE TABLE, DDL, typed columns
+level: beginner
+status: full
+prereq:
+  - the-relational-model
+faq:
+  - q: "What is a schema, exactly?"
+    a: "A schema is the defined shape of your data: which tables exist, what columns each has, the data type of every column, and the rules like 'this can't be empty.' It's the blueprint the database enforces on every row you store. In relational databases the schema is fixed up front, before you insert data."
+  - q: "What does NULL mean?"
+    a: "NULL is the database's marker for 'no value here' — unknown or missing, not zero and not an empty string. A column marked NOT NULL forbids it, forcing every row to supply a value. NULL has surprising behaviour in comparisons, so it's worth understanding early."
+  - q: "Why not just make every column text?"
+    a: "Because types are how the database catches bad data and works efficiently. A numeric column rejects 'banana', sorts and sums correctly, and stores compactly; a date column knows what 'before yesterday' means. Storing everything as text throws all of that away and pushes the checking onto you."
+---
+
+# Schemas, columns & data types
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A **schema** is the shape of your data — which **columns** a table has, the **data
+type** of each, and the rules like **NOT NULL**. In a relational database you
+decide it *up front*, and the database enforces it on every row, rejecting anything
+that doesn't fit. Picking sensible **types** (integer, text, boolean, timestamp)
+lets the database catch bad data, store it compactly, and query it correctly —
+building on [the relational model](/learn/databases/the-relational-model/).
+</div>
+
+A table is columns and rows. This lesson is about the columns: what a **schema**
+is, the **types** you'll reach for, and why relational databases make you decide
+the shape before you store a single row. That "decide up front" discipline feels
+like a chore at first and turns out to be one of the model's quiet superpowers.
+
+## A schema is the shape of your data
+
+The **schema** is the full definition of your data's structure: the tables, their
+columns, each column's **data type**, and the constraints on them. It's a blueprint
+the database holds and enforces. Every row you insert is checked against it — try
+to store text where a number belongs, or leave out a required field, and the
+database refuses. Bad data bounces at the door instead of quietly rotting inside
+your tables.
+
+You write a schema with a `CREATE TABLE` statement. Here's the systems table from
+the last lesson, defined properly:
+
+```sql
+CREATE TABLE systems (
+    id           INTEGER      PRIMARY KEY,
+    name         TEXT         NOT NULL,
+    frequency_hz BIGINT       NOT NULL,
+    protocol     TEXT         NOT NULL,
+    active       BOOLEAN      NOT NULL DEFAULT TRUE,
+    first_seen   TIMESTAMP    NOT NULL DEFAULT now()
+);
+```
+
+Each line names a column, gives its type, and adds any rules. This is the shape
+every row must obey. (Statements that define structure like this are called
+**DDL** — data definition language — as opposed to the queries that read and
+change data.)
+
+## The types you'll actually use
+
+Databases offer many types, but a handful cover most of what you'll store:
+
+- **Integer** (`INTEGER`, `BIGINT`) — whole numbers: counts, IDs, a frequency in
+  hertz. `BIGINT` holds bigger values than `INTEGER`.
+- **Text** (`TEXT`, `VARCHAR(n)`) — strings: names, descriptions. `VARCHAR(n)` caps
+  the length; `TEXT` is unbounded.
+- **Boolean** (`BOOLEAN`) — true or false: is this system active?
+- **Decimal / floating point** (`DECIMAL`, `REAL`) — fractional numbers. Use
+  `DECIMAL` for money, where exact rounding matters; `REAL` for measurements where
+  a tiny imprecision is fine.
+- **Timestamp / date** (`TIMESTAMP`, `DATE`) — points in time: when a call was
+  decoded. The database understands these, so "everything from the last hour" is a
+  real, sortable query.
+
+Choosing the *right* type isn't pedantry. A numeric column sorts and sums
+correctly and stores compactly; a timestamp column knows what "before yesterday"
+means; a boolean is one bit of truth, not the strings "yes"/"no"/"Y"/"true" you'd
+have to reconcile forever. The type is the first line of data integrity.
+
+## NULL: the "no value" marker
+
+Every column also answers one question: can it be empty? The database's marker for
+"no value here" is **NULL** — meaning unknown or missing, which is *not* the same
+as zero, and *not* the same as an empty string. A `frequency_hz` of NULL means "we
+don't know the frequency"; a `frequency_hz` of 0 means "the frequency is zero
+hertz." Those are different facts, and NULL keeps them distinct.
+
+You control whether NULL is allowed. A column marked **NOT NULL** must have a real
+value in every row — the database rejects an insert that omits it. Marking the
+columns that truly must be present as NOT NULL is one of the cheapest, highest-value
+things you can do for data quality. (NULL also behaves oddly in comparisons —
+`frequency_hz = NULL` is never true — which the
+[filtering lesson](/learn/databases/filtering-and-sorting/) returns to.)
+
+## Why decide the shape up front
+
+Relational databases are **schema-on-write**: the shape is fixed before data goes
+in, and the database enforces it on every write. That front-loading has real
+payoffs:
+
+- **Bad data can't get in.** Wrong type, missing required field, malformed value —
+  rejected at write time, so your tables stay trustworthy.
+- **Everyone knows the shape.** The schema is documentation the database can't let
+  drift out of date. New code, new teammates, and your future self all read the
+  same source of truth.
+- **The database can optimise.** Knowing every row's exact layout lets it store,
+  index, and query the data efficiently.
+
+The tradeoff is rigidity: changing the shape later means a deliberate
+[migration](/learn/databases/migrations/) rather than just writing a differently-
+shaped record. Some non-relational stores flip this to **schema-on-read** — store
+anything, sort out the shape when you read — which buys flexibility at the cost of
+these guarantees. We weigh that tradeoff in Unit 4; for now, know that the
+up-front schema is a feature, not red tape.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a schema is the fixed, enforced shape of your data: columns, their types, and rules like NOT NULL." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does a table's schema define?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">The order rows are physically stored in on disk</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The columns, their data types, and the rules every row must obey</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">The list of users allowed to read the table</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **schema** is the defined shape of your data: the tables, their **columns**,
+  each column's **data type**, and its rules — written with `CREATE TABLE`.
+- Common **types** are integer, text, boolean, decimal, and timestamp; picking the
+  right one lets the database catch errors, store compactly, and query correctly.
+- **NULL** marks a missing/unknown value — distinct from zero or empty string; a
+  **NOT NULL** column forbids it and forces a real value.
+- Relational databases are **schema-on-write**: the shape is fixed up front and
+  enforced on every write, so bad data bounces at the door.
+- Deciding the shape up front buys **data quality, shared documentation, and
+  optimisation**, at the cost of needing a deliberate change to evolve it later.
+
+Next up: [Keys & relationships](/learn/databases/keys-and-relationships/).

--- a/docs/learn/databases/sql-injection.md
+++ b/docs/learn/databases/sql-injection.md
@@ -1,0 +1,162 @@
+---
+slug: sql-injection
+title: SQL injection & querying safely
+description: The classic and still-common vulnerability where user input is glued into a query and becomes SQL — how it happens, the damage it does, and why parameterised queries (not manual escaping) end it for good.
+keywords: SQL injection, parameterised query, prepared statement, query parameters, string concatenation, input validation, escaping, least privilege, OWASP, querying safely
+level: intermediate
+status: full
+prereq:
+  - querying-with-select
+faq:
+  - q: "What is SQL injection in one sentence?"
+    a: "It's when untrusted input gets treated as part of your SQL command instead of as mere data, letting an attacker change what the query does — read, alter, or destroy data they shouldn't reach. It happens whenever you build a query by gluing user input into the query string."
+  - q: "How do parameterised queries fix it?"
+    a: "They send the SQL and the values to the database *separately*. The query text with placeholders is fixed and parsed first; your values are then bound to the placeholders as pure data that can never be reinterpreted as SQL. Because the structure is locked before the values arrive, injected SQL is just a string, not a command."
+  - q: "Isn't escaping the input enough?"
+    a: "No — manual escaping is fragile and easy to get wrong across encodings, quoting styles, and edge cases, and one missed spot is a hole. Parameterised queries remove the class of bug entirely rather than trying to sanitise your way around it. Use them everywhere and don't hand-escape."
+---
+
+# SQL injection & querying safely
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**SQL injection** happens when untrusted input is glued into a query string and
+gets executed as **SQL** rather than treated as data — the most famous database
+vulnerability, and still common. The fix is not to escape input by hand but to use
+**parameterised queries** (prepared statements), which send the query and the values
+to the database separately so input can never become command. Pair that with
+**least privilege** and validation. This is the database face of
+[secure coding](/learn/cybersecurity/secure-coding/).
+</div>
+
+Every lesson so far assumed the SQL you send is the SQL you meant to send. This one
+is about what happens when an attacker gets to write part of it for you. SQL
+injection has been near the top of every vulnerability list for over two decades,
+not because it's clever but because it's easy to introduce and devastating when it
+lands. The good news is that it has a complete, boring fix — and once you use it
+everywhere, this entire class of bug goes away.
+
+## How injection happens
+
+Injection comes from one mistake: **building a query by gluing user input into the
+query text.** Imagine a search box, and code that assembles the query like this:
+
+```
+query = "SELECT * FROM users WHERE name = '" + userInput + "'"
+```
+
+If someone types `Alice`, you get the query you expected. But the input is being
+treated as part of the *command*, not just data, and an attacker knows it. Type:
+
+```
+' OR '1'='1
+```
+
+and the query becomes:
+
+```sql
+SELECT * FROM users WHERE name = '' OR '1'='1'
+```
+
+`'1'='1'` is always true, so this returns **every user**. Worse inputs terminate the
+statement and add their own — `'; DROP TABLE users; --` — turning a search into a
+delete. The database faithfully runs whatever SQL it receives; it has no way to know
+part of that SQL came from a stranger. That confusion between **code and data** is
+the whole vulnerability.
+
+## What an attacker can do
+
+Once input can become SQL, the blast radius is large. Depending on the query and the
+database account's permissions, an attacker may:
+
+- **Read data they shouldn't** — dump entire tables, including password hashes and
+  personal data.
+- **Bypass authentication** — the `OR '1'='1'` trick can make a login check pass
+  without a valid password.
+- **Alter or destroy data** — `UPDATE` values, or `DELETE`/`DROP` whole tables.
+- **Escalate** — on some setups, reach the operating system or other databases on
+  the server.
+
+This is why injection is treated as critical: it can compromise **confidentiality,
+integrity, and availability** all at once — the whole [CIA triad](/learn/cybersecurity/cia-triad/).
+
+## Parameterised queries end it
+
+The fix is to stop building queries by concatenation and use **parameterised
+queries**, also called **prepared statements**. You write the SQL with **placeholders**
+where values go, and pass the values separately:
+
+```sql
+SELECT * FROM users WHERE name = ?
+```
+
+```
+db.query("SELECT * FROM users WHERE name = ?", userInput)
+```
+
+The database receives the query text and the value on **separate channels**. It
+parses the SQL *first* — with the placeholder, so the statement's structure is fixed
+— and only then binds your value into the placeholder as pure **data**. Now if
+someone submits `' OR '1'='1`, that entire string is treated as one literal name to
+search for; there is no name equal to that string, so it matches nothing. The
+injected SQL is never parsed as SQL, because parsing already happened before the
+value arrived. The **structure of the query is locked before the value is seen** —
+that's the whole mechanism, and it's airtight.
+
+Different databases spell the placeholder differently — `?`, `$1`, `:name` — but the
+principle is identical everywhere.
+
+## Why not just escape?
+
+A tempting alternative is to **sanitise** the input yourself — strip or escape quotes
+and dangerous characters. Resist it. Manual escaping is a losing game: quoting rules
+differ across databases, character encodings introduce edge cases, and a single
+place you forget is a single hole an attacker needs. You are trying to out-clever a
+problem that parameterisation removes entirely. **Use parameterised queries
+everywhere and don't hand-escape.** The only inputs you can't parameterise —
+occasionally a table or column *name* — must be checked against a fixed allow-list,
+never concatenated raw.
+
+## Defence in depth
+
+Parameterised queries are the cure, but a couple of habits back them up so a single
+slip isn't catastrophic:
+
+- **Least privilege.** The database account your app uses should have only the
+  permissions it needs. An app that only reads and inserts calls shouldn't be able
+  to `DROP TABLE`. If an injection ever does land, least privilege bounds the damage.
+- **Validate input anyway.** Checking that a value is the expected type, length, and
+  format is good practice — it catches bad data and shrinks the attack surface. It is
+  a complement to parameterisation, never a replacement for it.
+- **Least data exposed.** Don't return more than the caller needs; verbose errors and
+  over-broad queries hand attackers information.
+
+These are the same layered ideas the security path calls
+[defense in depth](/learn/cybersecurity/defense-in-depth/), applied to the database.
+Go's standard library makes the safe path the default, as the next lesson shows.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — parameterised queries send SQL and values separately, so input is always bound as data and can never be parsed as command." markdown="0">
+  <p class="knowledge-check__q">Quick check: what actually prevents SQL injection?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Carefully escaping quotes in user input before concatenating it</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Parameterised queries — sending the SQL and the values separately so input is always data</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Hiding error messages so attackers can't see the query</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **SQL injection** happens when untrusted input is glued into a query string and
+  executed as **SQL** instead of treated as data — a confusion of **code and data**.
+- The damage is severe: reading private data, bypassing login, altering or destroying
+  data, sometimes reaching the host.
+- **Parameterised queries** (prepared statements) fix it by sending the SQL and the
+  values separately — the query structure is **locked before the value is seen**, so
+  input can never become command.
+- **Don't hand-escape** input; manual sanitisation is fragile and one miss is a hole.
+  Parameterise everywhere; allow-list the rare non-value inputs.
+- Back it with **least privilege** on the database account and **input validation** —
+  defence in depth so one slip isn't fatal.
+
+Next up: [talking to a database from Go](/learn/databases/databases-in-go/).

--- a/docs/learn/databases/sql-vs-nosql.md
+++ b/docs/learn/databases/sql-vs-nosql.md
@@ -1,0 +1,150 @@
+---
+slug: sql-vs-nosql
+title: SQL vs. NoSQL
+description: NoSQL is the umbrella for databases that dropped the rigid relational table for a different data model and different tradeoffs. Learn what NoSQL actually means, the flexibility-for-guarantees trade it makes, and how to tell when a non-relational store fits a problem better than tables.
+keywords: SQL vs NoSQL, NoSQL, relational vs non-relational, schema flexibility, eventual consistency, horizontal scaling, key-value, document database, BASE, CAP theorem, when to use NoSQL
+level: intermediate
+status: full
+prereq:
+  - the-relational-model
+  - transactions-and-acid
+faq:
+  - q: What does NoSQL actually mean?
+    a: "It's an umbrella term for databases that don't use the rigid relational table-and-SQL model — key-value stores, document stores, wide-column, graph, and more. The name is misleading: it means 'not only SQL,' not 'no SQL,' and NoSQL databases vary wildly among themselves. What they share is having dropped some relational assumption in exchange for a different data model or scaling story."
+  - q: Is NoSQL faster or more scalable than SQL?
+    a: "Sometimes, for specific shapes of work — many NoSQL stores are built to scale horizontally across many machines and to serve simple lookups very fast. But it's not a free upgrade: they usually give up rich joins, strict schemas, or strong transactional guarantees to get there. It's a different set of tradeoffs, not a strictly better database."
+  - q: How do I choose between them?
+    a: "Start relational unless you have a concrete reason not to — the guarantees, joins, and mature tooling of SQL fit most applications. Reach for a specific NoSQL store when your data or access pattern genuinely matches what it's built for: a document store for self-contained documents, a key-value store for a cache or session data, a time-series store for metrics. Choose the store for the job, not the label."
+---
+
+# SQL vs. NoSQL
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**NoSQL** is an umbrella for databases that dropped the rigid **relational**
+table-and-SQL model for a different one — **key-value**, **document**, wide-column,
+graph. The name means "not only SQL," and these stores differ enormously among
+themselves. The common thread is a **trade**: they relax something relational
+databases guarantee — strict schema, rich joins, or strong
+[ACID](/learn/databases/transactions-and-acid/) — usually to gain schema flexibility
+or the ability to scale across many machines. The right question is never "SQL or
+NoSQL" in the abstract but **which store fits this job**.
+</div>
+
+You've spent this module deep in the relational model — tables, keys, SQL, ACID. It
+has run the data world for fifty years because its guarantees are genuinely valuable.
+But it isn't the only way to store data, and this unit surveys the alternatives. The
+place to start is understanding what "NoSQL" even means, because it's one of the most
+misunderstood terms in software.
+
+## "NoSQL" is a terrible name for a real idea
+
+Taken literally, "NoSQL" sounds like a rejection of SQL. It isn't. The term is best
+read as **"not only SQL"** — a loose label for the wave of databases that, starting
+around 2009, chose *not* to be a relational store with a SQL front end. It groups
+together things with almost nothing in common:
+
+- **Key-value stores** — a giant dictionary: one key, one blob of value.
+- **Document stores** — collections of self-contained JSON-like documents.
+- **Wide-column stores** — rows with flexible, sparse sets of columns, built for scale.
+- **Graph databases** — nodes and edges, built for richly interconnected data.
+
+Calling these one thing is like calling every vehicle that isn't a sedan "NotSedan."
+So the first correction: **there is no single "NoSQL database"** to compare against
+SQL. There are specific stores with specific shapes, and the useful comparisons are
+always against one of them — which the next lessons make.
+
+## What relational databases give you
+
+To see what NoSQL trades away, name what you're trading. A mature relational database
+hands you, out of the box:
+
+- **A strict schema** — every row has the same typed columns, with
+  [constraints](/learn/databases/constraints-and-integrity/) keeping data valid.
+- **Joins** — combine data from many tables on shared keys, cheaply and expressively.
+- **Strong transactions (ACID)** — all-or-nothing changes with real consistency and
+  isolation.
+- **A declarative query language** — SQL, understood everywhere, with decades of tools.
+
+These aren't small things. For most applications they're exactly what you want, which
+is why "start relational" is sound default advice.
+
+## What NoSQL trades to get flexibility and scale
+
+NoSQL stores relax one or more of those in exchange for something else. The two things
+they're usually buying are **schema flexibility** and **horizontal scale**.
+
+**Schema flexibility.** A document store lets each record have a different shape — no
+migration to add a field, just write it. That's liberating for fast-moving or
+irregular data, and it moves the burden of consistency from the database into your
+code. The schema doesn't disappear; it just stops being enforced for you.
+
+**Horizontal scale.** Relational databases traditionally scale *up* (a bigger server)
+and are harder to spread across many machines, partly *because* joins and strict
+transactions are expensive to coordinate across a network. Many NoSQL stores were built
+from the start to **shard** data across many commodity machines — to scale *out*. To
+make that work cheaply, they often loosen the strongest guarantees.
+
+## Strong vs. eventual consistency
+
+The deepest part of the trade is **consistency**. A single relational node gives you
+**strong consistency**: once a write commits, every subsequent read sees it. Spreading
+data across many machines makes that expensive, so some distributed stores offer
+**eventual consistency** instead: a write propagates to the copies *over time*, and for
+a brief window different replicas can return different answers, until they converge.
+
+This is the heart of the famous **CAP theorem**: when a network partition splits your
+machines, a distributed store can stay **consistent** or stay **available**, but not
+both — it has to choose. Relational databases traditionally lean toward consistency;
+many NoSQL stores lean toward availability and accept eventual consistency. Neither is
+wrong; they suit different problems. A bank ledger wants strong consistency; a "last
+seen online" timestamp is perfectly happy being eventually consistent. This distinction
+is why NoSQL guarantees are sometimes summarized as **BASE** (basically available, soft
+state, eventually consistent) in contrast to ACID.
+
+## Choosing: match the store to the job
+
+Put it together and the decision rule is simple to state:
+
+- **Default to relational.** Unless you have a concrete reason otherwise, a SQL database
+  (Postgres, SQLite, MySQL) is the safe, powerful, well-understood choice, and its
+  guarantees save you from bugs you'd otherwise write yourself.
+- **Reach for a specific NoSQL store when your data or access pattern truly matches
+  it.** A document store when your data is naturally self-contained documents; a
+  key-value store for a cache, session, or feature flag; a time-series store for
+  metrics; a vector store for similarity search. Each of those is a lesson in this
+  unit.
+- **You can use both.** Real systems commonly run a relational database as the source of
+  truth *and* a NoSQL store for a job it's better at — a cache in front, a search index
+  beside. It's not either/or.
+
+The mistake is choosing by hype or by label. The right frame is the one the whole
+[choosing a database](/learn/databases/choosing-a-database/) lesson later develops:
+what does *this* data look like, how will you *query* it, and what must you
+*guarantee*? Answer those, and the store picks itself.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — NoSQL means 'not only SQL,' a diverse family that trades relational guarantees for flexibility or scale; it's not a single faster database." markdown="0">
+  <p class="knowledge-check__q">Quick check: which best describes what "NoSQL" means?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">A single, newer database that is strictly faster than SQL databases</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">An umbrella for diverse non-relational stores that trade some relational guarantees for flexibility or scale</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Any database that doesn't let you write queries at all</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **NoSQL** means "not only SQL" — an umbrella over **key-value, document, wide-column,
+  and graph** stores that have little in common except *not* being relational.
+- There's no single "NoSQL database" to compare with SQL; useful comparisons are always
+  against a *specific* store.
+- Relational databases give you a **strict schema, joins, strong ACID transactions, and
+  SQL** — genuinely valuable defaults.
+- NoSQL stores **trade** some of those for **schema flexibility** or **horizontal
+  scale**, often accepting **eventual** instead of strong consistency (the **CAP**
+  tradeoff).
+- **Default to relational**, reach for a specific NoSQL store when the data and access
+  pattern truly fit it, and freely **use both** in one system.
+
+Next up: [Key-value & document stores](/learn/databases/key-value-and-document/).

--- a/docs/learn/databases/the-relational-model.md
+++ b/docs/learn/databases/the-relational-model.md
@@ -1,0 +1,139 @@
+---
+slug: the-relational-model
+title: The relational model — tables, rows & columns
+description: The idea that has run the data world for fifty years — organising data into tables of rows and columns. Learn what a relation, a row, and a column really are, and why this simple shape is so powerful and enduring.
+keywords: relational model, tables, rows, columns, relation, tuple, attribute, relational database, Edgar Codd, structured data, records
+level: beginner
+status: full
+prereq:
+  - what-is-a-database
+faq:
+  - q: "Why is it called the 'relational' model if it's just tables?"
+    a: "The name comes from the mathematical term relation, which is what a table technically is — a set of rows sharing the same columns. It is not, confusingly, about the relationships between tables; those (via keys) come later. A table is a relation; that's where the name comes from."
+  - q: "What's the difference between a row and a column?"
+    a: "A column is a named field that every row has — like 'frequency' or 'name' — with a fixed type. A row is one complete record: one system, one call, one user, holding a value for each column. Columns define the shape; rows are the actual data."
+  - q: "Do all databases use tables?"
+    a: "No — but the relational, table-based model is overwhelmingly the most common, and it's the foundation SQL is built on. Non-relational (NoSQL) stores use other shapes like documents or key-value pairs, which a later unit covers. Learn tables first; they're the default for good reason."
+---
+
+# The relational model — tables, rows & columns
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+The **relational model** organises data into **tables** — grids of **rows** and
+**columns**. Each **column** is a named, typed field every row shares; each **row**
+is one complete record. A table is formally a **relation**, which is where the name
+comes from. This deceptively simple shape has run the data world for fifty years
+because it's easy to reason about, query, and validate — and it's what
+[SQL](/learn/databases/what-is-sql/) is built on.
+</div>
+
+You now know a database stores data durably and lets you query it. But *how* is the
+data arranged so that querying is even possible? For most databases you'll meet,
+the answer is the **relational model**: everything lives in tables. It sounds almost
+too plain to matter, yet this one idea has outlasted decades of technology churn.
+This lesson is about why that shape is the right one.
+
+## Tables: the one shape to learn
+
+A **table** is a grid, exactly like a well-behaved spreadsheet. It has named
+**columns** running across the top and **rows** stacked below, each row a single
+record. Here's a table of radio systems:
+
+| id | name       | frequency_hz | protocol |
+|----|------------|--------------|----------|
+| 1  | Metro P25  | 851012500    | P25      |
+| 2  | County DMR | 453100000    | DMR      |
+| 3  | Rail TETRA | 390000000    | TETRA    |
+
+That's the whole model in one picture. A database is a collection of tables like
+this. When people say "relational database," this grid is what they mean, and
+learning to think in tables is most of what it takes to think in databases.
+
+## Columns define the shape
+
+A **column** is a named field that *every* row in the table has: `name`,
+`frequency_hz`, `protocol`. A column has a fixed **data type** — text, a number, a
+date — so the database knows what kind of value belongs there and can reject
+anything that doesn't fit. The set of columns and their types is the table's
+**schema**, its shape, which the [next lesson](/learn/databases/schemas-and-types/)
+covers in full.
+
+The key idea: columns are decided *up front* and apply to the whole table. Every
+row has a `frequency_hz`; none has some extra field the others lack. That
+uniformity is exactly what lets the database query the table efficiently — it knows
+in advance what's there.
+
+## Rows are the records
+
+A **row** (also called a **record**) is one complete entry: one system, one call,
+one user. In the table above, row 2 is the County DMR system — one value for each
+column, together describing one real thing. Adding data means adding rows; the
+columns stay put.
+
+Two properties make rows well-behaved. First, each row should be **uniquely
+identifiable** — that's the `id` column, a
+[primary key](/learn/databases/keys-and-relationships/), so you can always point at
+exactly one row. Second, **row order carries no meaning**. A table is a *set* of
+rows; the database is free to store them however it likes, and if you want results
+in a particular order you ask for it explicitly with
+[ORDER BY](/learn/databases/filtering-and-sorting/). Don't ever rely on "the order
+they were inserted."
+
+## Why the name "relational"
+
+Here's a nuance worth getting straight, because the name misleads almost everyone.
+"Relational" does **not** refer to the relationships *between* tables (those come
+from [keys](/learn/databases/keys-and-relationships/) in a later lesson). It comes
+from mathematics: a **relation** is a set of rows that all share the same columns —
+which is exactly what a table is. The model was formalised by Edgar Codd in 1970,
+and its staying power comes from that rigor. Because a table is a precise
+mathematical object, you can define exact operations on it — filter, combine,
+summarise — and that's what SQL turns into a practical language.
+
+You'll hear the formal words occasionally: a **relation** (table), a **tuple**
+(row), an **attribute** (column). You don't need them day to day, but now they
+won't throw you.
+
+## Why this shape wins
+
+Why has such a simple idea dominated for fifty years? Because tables are:
+
+- **Easy to reason about.** A grid of rows and columns is something anyone can
+  picture and talk about, from junior dev to DBA.
+- **Uniform.** Every row has the same columns, so one query works across all of
+  them — no special cases.
+- **Composable.** Tables can be filtered, sorted, and *joined* to each other on
+  shared values, letting you answer questions no single table holds — the power we
+  reach in [joins](/learn/databases/joins/).
+- **Enforceable.** Fixed columns and types let the database reject bad data before
+  it's stored.
+
+Newer database shapes exist and earn their place for particular jobs — we cover
+them in Unit 4 — but the table remains the default, and for most applications it's
+the right default.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a table is a relation: rows are records, columns are the shared, typed fields." markdown="0">
+  <p class="knowledge-check__q">Quick check: in a table, what does a single row represent?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">A named field, like 'frequency', that every record shares</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">One complete record — one system, call, or user — with a value per column</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">The type rule that decides what values a column can hold</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- The **relational model** stores data in **tables** — grids of **rows** and
+  **columns** — and it's the default shape for most databases.
+- A **column** is a named, typed field every row shares; the columns and their
+  types make up the table's **schema**.
+- A **row** (record) is one complete entry, one value per column; rows should be
+  uniquely identifiable, and their stored **order carries no meaning**.
+- "Relational" comes from the mathematical **relation** (a table), *not* from
+  relationships between tables — those come later, from keys.
+- Tables win because they're **easy to reason about, uniform, composable, and
+  enforceable** — the foundation SQL and the rest of this module build on.
+
+Next up: [Schemas, columns & data types](/learn/databases/schemas-and-types/).

--- a/docs/learn/databases/time-series-and-analytics.md
+++ b/docs/learn/databases/time-series-and-analytics.md
@@ -1,0 +1,160 @@
+---
+slug: time-series-and-analytics
+title: Time-series & analytical stores
+description: Databases tuned for two special jobs — time-series stores for a relentless stream of timestamped measurements, and column-oriented analytical stores for crunching huge tables. Learn why your metrics live in one and why analytics doesn't run on your app's database.
+keywords: time-series database, analytical database, column store, columnar, OLTP vs OLAP, metrics, InfluxDB, TimescaleDB, data warehouse, aggregation, downsampling, row vs column storage
+level: intermediate
+status: full
+prereq:
+  - sql-vs-nosql
+  - aggregation-and-grouping
+faq:
+  - q: What makes a time-series database different from a normal table with a timestamp?
+    a: "Time-series data has a specific shape — a huge, append-only stream of timestamped measurements that you almost always query by time range and aggregate. Time-series databases optimize hard for exactly that: fast writes of new points, storage that compresses old data, and built-in time-bucketing and downsampling. You *can* store it in a regular table, but a purpose-built store handles the volume and the time-window queries far better."
+  - q: What is a column store and why is it faster for analytics?
+    a: "A column store keeps each column's values together on disk instead of each row's values together. Analytical queries usually read a few columns across millions of rows — a sum of one column, say — so reading just those columns, tightly compressed, is dramatically faster than reading whole rows. Row stores win for fetching whole records; column stores win for aggregating across many."
+  - q: Why not run analytics on my application's main database?
+    a: "Because the workloads conflict. Your app database (OLTP) is tuned for many small, fast reads and writes of individual rows; big analytical scans (OLAP) hammer it and slow down real users. The usual pattern is to copy data into a separate analytical store or warehouse and run the heavy queries there, keeping the two workloads apart."
+---
+
+# Time-series & analytical stores
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Two special jobs get their own databases. A **time-series store** is built for a
+relentless, append-only stream of **timestamped measurements** — metrics, sensor
+readings, decoded-call events — queried by **time range** and aggregated. An
+**analytical (column) store** keeps data **column by column** instead of row by row,
+which makes crunching a few columns across **millions of rows** vastly faster. The
+theme is **OLTP vs. OLAP**: your app's database serves many small transactions;
+analytics is a different workload that belongs in a different store, leaning on the
+[aggregation](/learn/databases/aggregation-and-grouping/) you already know.
+</div>
+
+Key-value and document stores changed the *shape* of your records. This lesson changes
+what the database is *optimized for*. Some data isn't a special shape so much as a
+special *pattern of use* — a firehose of timestamped points, or an enormous table you
+summarize rather than read row by row — and two families of database exist because
+that pattern breaks a normal relational store's assumptions.
+
+## Time-series data: a firehose of timestamps
+
+**Time-series data** is measurements stamped with *when they happened*, arriving
+continuously and rarely changing once written. Server CPU every second, temperature
+every minute, a decoded-call event every time GopherTrunk hears one — all the same
+shape: `(timestamp, what, value)`, forever appended, almost never updated.
+
+```
+2026-08-04T09:00:00Z  system=metro_p25  calls_active=3
+2026-08-04T09:00:01Z  system=metro_p25  calls_active=4
+2026-08-04T09:00:02Z  system=metro_p25  calls_active=4
+```
+
+You almost always query it the same way too: **over a time range, aggregated** — "average
+active calls per minute over the last hour," "peak in the last day." You rarely ask for
+one exact point by ID the way you'd fetch one user.
+
+## Why time-series stores exist
+
+You *can* put this in a regular table with a timestamp column, and for modest volumes
+that's fine. But at scale the pattern strains a general-purpose database in ways a
+**time-series database** (InfluxDB, TimescaleDB, Prometheus, and others) is built to
+handle:
+
+- **Write volume.** Points arrive constantly — thousands per second is normal. These
+  stores optimize hard for fast, append-only writes.
+- **Compression.** Old points are highly repetitive and ordered by time, so they
+  compress enormously. A time-series store squeezes months of history into a fraction of
+  the space.
+- **Time-window queries and downsampling.** Bucketing by minute/hour/day and rolling old
+  fine-grained data up into coarser summaries (**downsampling** — keep per-second for a
+  day, per-minute for a month) are first-class, built-in operations.
+- **Retention.** Automatically expiring data older than N days, because you rarely need
+  per-second detail from last year.
+
+This is why **your metrics and monitoring live in one**. Any dashboard of graphs over
+time — the subject of [performance & monitoring](/learn/databases/performance-and-monitoring/)
+later — is almost certainly backed by a time-series store.
+
+## The other axis: analytical (OLAP) workloads
+
+The second special job is **analytics**: questions that scan huge amounts of data to
+produce a summary. "Total call-seconds per system per day across the last year," "the
+ten busiest talkgroups this month." These read *many* rows but usually only a *few*
+columns, and they don't need to be instant — they need to chew through volume.
+
+This is the classic split between two workload types:
+
+- **OLTP** (Online Transaction Processing) — your application's database. Many small,
+  fast reads and writes of individual rows: fetch this user, insert this call, update
+  this balance. Tuned for low-latency single-row work.
+- **OLAP** (Online Analytical Processing) — analytics and reporting. A few big queries
+  that scan and aggregate millions of rows. Tuned for throughput over huge scans.
+
+They pull a database in opposite directions, which is why serious systems keep them
+apart.
+
+## Row stores vs. column stores
+
+The technical heart of analytical databases is **how data is laid out on disk**. A
+normal (OLTP) database is **row-oriented**: it stores all of row 1's columns together,
+then all of row 2's, and so on. That's perfect for "give me this whole call" — one
+seek grabs the entire record.
+
+An analytical database is often **column-oriented**: it stores all of the `duration`
+values together, all of the `system_id` values together, column by column. Now consider
+`SELECT system_id, SUM(duration) ... GROUP BY system_id` over ten million calls. A
+column store reads *only* the two columns it needs — tightly packed and heavily
+compressed — and skips every other column entirely. A row store would drag every full
+row off disk just to use two fields of each.
+
+```
+Row store:     [call1: id,sys,tg,dur,ts][call2: id,sys,tg,dur,ts]...   ← reads everything
+Column store:  [all system_id][all duration][all timestamp]...          ← reads two columns
+```
+
+So the rule of thumb: **row stores win at fetching whole records; column stores win at
+aggregating a few columns across many rows.** It's the same data — just organized for
+the opposite question.
+
+## Keep the workloads apart
+
+The practical consequence ties it together: **don't run heavy analytics on your live
+application database.** A big OLAP scan competes with your users' small OLTP queries for
+the same resources and can grind real traffic to a crawl. The standard pattern is to
+move data out — copy or stream it into a separate **analytical store** or **data
+warehouse** (column-oriented, OLAP-tuned) and run the heavy queries there, where they
+can't hurt production.
+
+The takeaway of the whole lesson is that "database" isn't one thing tuned one way. The
+*shape* and *pattern* of your data pick the tool: a firehose of timestamps wants a
+time-series store, a mountain of rows you summarize wants a column store, and your
+transactional app data stays where it is. Recognizing which workload you're looking at
+is half of [choosing a database](/learn/databases/choosing-a-database/) well.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a column store reads only the few columns a query touches, tightly compressed, instead of dragging whole rows off disk." markdown="0">
+  <p class="knowledge-check__q">Quick check: why is a column store faster for a query that sums one column across millions of rows?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It keeps the whole table in memory at all times</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">It stores each column together, so it reads only the columns the query needs, not whole rows</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It skips aggregation entirely and precomputes every possible answer</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Time-series data** is an append-only stream of **timestamped measurements**, queried
+  by **time range** and aggregated — metrics, sensors, decoded-call events.
+- **Time-series databases** optimize for high write volume, heavy compression of old
+  data, built-in **time-bucketing / downsampling**, and automatic retention — which is
+  why your **metrics live in one**.
+- **OLTP** (your app's database) does many small, fast single-row reads and writes;
+  **OLAP** (analytics) does a few huge scans that aggregate millions of rows.
+- **Row stores** keep each row together and win at fetching whole records; **column
+  stores** keep each column together and win at aggregating a few columns across many
+  rows.
+- **Keep the workloads apart** — copy data into a separate analytical store/warehouse so
+  heavy queries don't starve your live application.
+
+Next up: [Vector databases & similarity search](/learn/databases/vector-databases/).

--- a/docs/learn/databases/transactions-and-acid.md
+++ b/docs/learn/databases/transactions-and-acid.md
@@ -1,0 +1,153 @@
+---
+slug: transactions-and-acid
+title: Transactions & ACID
+description: A transaction groups several database changes into one all-or-nothing unit that either fully happens or not at all. Learn the ACID guarantees — atomicity, consistency, isolation, durability — and why moving money or updating two tables needs them.
+keywords: transactions, ACID, atomicity, consistency, isolation, durability, commit, rollback, database transaction, all or nothing, concurrency, isolation levels
+level: intermediate
+status: full
+prereq:
+  - inserting-updating-deleting
+  - constraints-and-integrity
+faq:
+  - q: What is a transaction, in one sentence?
+    a: "A group of database operations treated as a single all-or-nothing unit: either every operation in the group takes effect (commit) or none of them do (rollback), so the data is never left half-changed."
+  - q: What do the letters in ACID stand for?
+    a: "Atomicity (all-or-nothing), Consistency (the database moves from one valid state to another, honoring constraints), Isolation (concurrent transactions don't see each other's half-done work), and Durability (once committed, the change survives a crash). Together they're the guarantees a relational database makes about transactions."
+  - q: When do I actually need a transaction?
+    a: "Whenever a single logical change touches more than one row or table and a partial result would be wrong — transferring money between two accounts, creating an order and its line items, or updating a record and a counter that must stay in sync. If a half-completed version of the change would corrupt your data, wrap it in a transaction."
+---
+
+# Transactions & ACID
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A **transaction** groups several changes into one **all-or-nothing** unit: it either
+**commits** entirely or **rolls back** entirely, so the data is never left
+half-changed. The guarantees behind it are **ACID** — **Atomicity** (all or
+nothing), **Consistency** (constraints stay satisfied), **Isolation** (concurrent
+transactions don't see each other's unfinished work), and **Durability** (a commit
+survives a crash). You need one whenever a single logical change spans more than one
+write and a partial result would corrupt your data. It works hand in hand with the
+[constraints](/learn/databases/constraints-and-integrity/) from the last lesson.
+</div>
+
+Constraints keep any single row valid. But real changes often span several rows or
+tables at once — and between the first write and the last, a crash, an error, or
+another user can catch your data mid-change, in a state that's briefly *wrong*.
+Transactions are the mechanism that makes a multi-step change behave like a single
+indivisible one.
+
+## The canonical example: moving money
+
+The textbook case, for good reason. Transfer 100 units from account A to B, and it
+takes two writes:
+
+```sql
+UPDATE accounts SET balance = balance - 100 WHERE id = 'A';
+UPDATE accounts SET balance = balance + 100 WHERE id = 'B';
+```
+
+Now imagine the process crashes, the connection drops, or an error fires *between*
+those two statements. Money has left A and never arrived at B. It has simply vanished.
+No constraint catches this, because each row is individually valid — A's balance is a
+real number, B's is a real number — yet the *system* is corrupt. The problem isn't any
+one write; it's that the two writes must happen **together or not at all**.
+
+## All-or-nothing: BEGIN, COMMIT, ROLLBACK
+
+A transaction wraps the group so the database treats it as one unit. You open it with
+`BEGIN`, do your writes, and finish with `COMMIT` to make them all permanent — or
+`ROLLBACK` to throw them all away:
+
+```sql
+BEGIN;
+    UPDATE accounts SET balance = balance - 100 WHERE id = 'A';
+    UPDATE accounts SET balance = balance + 100 WHERE id = 'B';
+COMMIT;
+```
+
+If anything goes wrong before `COMMIT` — a crash, an error, an explicit `ROLLBACK` —
+the database undoes *everything* since `BEGIN`, as if the transaction never ran. There
+is no state in which A was debited but B wasn't. That's the promise: the change is
+**atomic**, one indivisible step from the outside, no matter how many writes it takes
+inside.
+
+## ACID: the four guarantees
+
+Transactions are backed by four properties, abbreviated **ACID**. They're the
+guarantees a relational database makes, and each one earns its letter.
+
+- **Atomicity** — all or nothing. Every operation in the transaction takes effect, or
+  none does. This is the money-transfer guarantee: no half-done changes survive.
+- **Consistency** — the transaction moves the database from one **valid state to
+  another**. Every constraint, foreign key, and check still holds after commit; if a
+  transaction would violate one, it's rejected whole. Transactions and constraints
+  reinforce each other here.
+- **Isolation** — concurrent transactions don't step on each other. While your transfer
+  is mid-flight, other transactions don't see A debited-but-B-not; they see the state
+  either fully before or fully after. It's *as if* transactions ran one at a time, even
+  when they overlap.
+- **Durability** — once the database says `COMMIT` succeeded, the change is permanent.
+  It's written to durable storage and will survive a power loss or crash the instant
+  after. A confirmed commit is a kept promise.
+
+## Isolation is where concurrency lives
+
+Atomicity and durability are about a single transaction surviving failure; **isolation**
+is about many transactions running *at the same time* without corrupting each other. If
+two people transfer money involving account A simultaneously, isolation stops their
+reads and writes from interleaving into a wrong total — for instance, both reading the
+old balance and both subtracting from it, losing one of the deductions.
+
+Perfect isolation is expensive, so databases offer **isolation levels** — a dial
+trading strictness for speed. Lower levels allow certain anomalies (a transaction
+seeing another's uncommitted or newly-inserted rows) in exchange for more concurrency;
+the strictest level, **serializable**, makes transactions behave exactly as if they ran
+one after another. Most applications run at a sensible middle default and only reach for
+serializable on the operations that truly can't tolerate a race. You don't need the
+details yet — just the idea that isolation is a setting, and that concurrency bugs live
+where it's set too loose.
+
+## When you need one — and when you don't
+
+Reach for a transaction whenever a **single logical change touches more than one row or
+table and a partial result would be wrong**:
+
+- Transferring a value between two rows (the money case).
+- Creating a parent and its children together — an order and its line items, a call and
+  its audio-file record — so you never have one without the other.
+- Updating a row and a running counter or summary that must stay in agreement.
+- Any sequence where step two depends on step one having really happened.
+
+You *don't* need to think about it for a single `INSERT`, `UPDATE`, or `DELETE`: those
+are already atomic on their own — the database runs each statement as its own tiny
+transaction. Transactions matter precisely when *one* meaningful change is made of
+*several* statements. Wrapping those in `BEGIN`/`COMMIT` is what keeps a database
+correct not just at rest, but through failure and concurrency — the reason relational
+databases are trusted with data that has to be right.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the two updates must both happen or both not, or money vanishes; a transaction makes them one atomic unit." markdown="0">
+  <p class="knowledge-check__q">Quick check: why does transferring money between two accounts need a transaction?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Because updating a balance is too slow to do without one</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Because the debit and credit must both happen or both not — a crash between them would lose money</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Because balances can't be negative and only a transaction can check that</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **transaction** groups multiple changes into one **all-or-nothing** unit: `BEGIN`,
+  then `COMMIT` to keep everything or `ROLLBACK` to discard everything.
+- It prevents **partial results** — the classic case is money debited from one account
+  but never credited to another after a crash.
+- **ACID** names the four guarantees: **Atomicity** (all or nothing), **Consistency**
+  (constraints stay satisfied), **Isolation** (concurrent transactions don't see each
+  other's unfinished work), **Durability** (a commit survives a crash).
+- **Isolation levels** dial strictness against speed; **serializable** is strictest, and
+  concurrency bugs appear where isolation is set too loose.
+- Use a transaction whenever **one logical change spans several writes** and a partial
+  version would be wrong; single statements are already atomic.
+
+Next up: [Schema migrations & evolving a database](/learn/databases/migrations/).

--- a/docs/learn/databases/vector-databases.md
+++ b/docs/learn/databases/vector-databases.md
@@ -1,0 +1,150 @@
+---
+slug: vector-databases
+title: Vector databases & similarity search
+description: The database behind modern AI retrieval — it stores embeddings as high-dimensional vectors and finds the nearest ones, so you can search by meaning instead of exact keywords. Learn how vectors, distance, and approximate nearest-neighbor search power RAG.
+keywords: vector database, similarity search, embeddings, nearest neighbor, ANN, semantic search, RAG, retrieval augmented generation, cosine similarity, vector index, pgvector, high-dimensional vectors
+level: intermediate
+status: full
+prereq:
+  - sql-vs-nosql
+faq:
+  - q: What does a vector database actually store?
+    a: "Embeddings — lists of numbers (vectors) that a model produces to represent the *meaning* of a piece of text, an image, or other data. Similar meanings get vectors that sit close together in space. The database stores these vectors alongside a reference to the original item, and its core job is finding the vectors nearest to a query vector."
+  - q: How is similarity search different from a normal WHERE clause?
+    a: "A WHERE clause matches exact or pattern-based conditions — this word appears, this value equals that. Similarity search matches by *closeness in meaning*: it finds the items whose vectors are nearest to your query's vector, so 'radio signal fading' can match a document about 'weak reception' with no shared keywords. It's search by meaning rather than by literal text."
+  - q: Why not just store vectors in a regular table?
+    a: "You can store them, but finding the nearest vectors by brute force means comparing your query against every stored vector — far too slow at scale. Vector databases (and vector extensions like pgvector) add a specialized index for approximate nearest-neighbor search that finds the closest matches quickly without checking every one."
+---
+
+# Vector databases & similarity search
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A **vector database** stores **embeddings** — lists of numbers that capture the
+*meaning* of text or other data — and its core job is **similarity search**: given a
+query vector, find the stored vectors **nearest** to it. That lets you search by
+**meaning instead of keywords**, and it's the retrieval engine behind **RAG**
+(retrieval-augmented generation). It does this fast with an **approximate
+nearest-neighbor** index. The vectors themselves come from the models covered in
+[embeddings & vector search](/learn/building-ai/embeddings-and-vector-search/); this
+lesson is about the *store* that holds and searches them.
+</div>
+
+Every store so far — relational, key-value, document, time-series — finds data by
+**matching**: this key, this value, this condition. A vector database does something
+different in kind. It finds data by **meaning**, returning the items most *similar* to
+what you asked for even when they share no words with your query. It's the database
+that appeared alongside the current wave of AI, and understanding it demystifies a lot
+of how those systems work.
+
+## Embeddings: meaning as coordinates
+
+The idea rests on **embeddings**. A model can turn a piece of text (or an image, or
+audio) into a **vector** — a fixed-length list of numbers, often hundreds or thousands
+of them:
+
+```
+"weak radio reception"  →  [0.021, -0.44, 0.13, ..., 0.08]   (e.g. 768 numbers)
+```
+
+The magic is that the model arranges these numbers so that **similar meanings land
+close together** in this high-dimensional space. "Weak radio reception" and "signal
+fading" produce vectors that sit near each other; "chocolate cake recipe" lands far
+away. The vector *is* a numerical fingerprint of meaning. (How models produce these is
+the [embeddings & vector search](/learn/building-ai/embeddings-and-vector-search/)
+lesson in the AI path — here we take the vectors as given.)
+
+Once meaning is coordinates, "find things that mean something similar" becomes a
+geometry problem: **find the nearest points**.
+
+## Similarity search: nearest instead of equal
+
+A vector database stores each embedding alongside a reference to its original item (the
+document, the paragraph, the record). Its defining operation is: given a **query
+vector**, return the **k nearest** stored vectors — a **k-nearest-neighbor** search.
+
+"Nearest" needs a definition of distance. The common measures are **cosine similarity**
+(the angle between two vectors — are they pointing the same way?) and **Euclidean
+distance** (straight-line distance between the points). The details matter less than the
+concept: the database ranks stored vectors by how close they are to your query and hands
+back the top few.
+
+Contrast that with a `WHERE` clause. SQL filtering asks "does this row *equal* or
+*contain* this exact thing?" Vector search asks "which rows are *most like* this?" — a
+ranked, fuzzy, meaning-based match with no requirement of shared words. That's why it's
+called **semantic search**: search by sense, not by string.
+
+## Why it needs a special database
+
+Here's the catch that makes it a database problem rather than a one-liner. Finding the
+true nearest vectors by brute force means comparing your query against **every** stored
+vector and sorting — fine for a thousand vectors, hopeless for ten million. Each
+comparison is real arithmetic across hundreds of dimensions.
+
+So vector databases (Pinecone, Weaviate, Milvus, Qdrant, and the **pgvector** extension
+that adds this to Postgres) build a specialized **index** for **approximate
+nearest-neighbor (ANN)** search. Instead of checking every vector, the index cleverly
+narrows the search to a promising neighborhood and returns *almost certainly* the
+nearest matches, thousands of times faster. The word **approximate** is the trade: you
+give up a tiny chance of missing the exact closest match in exchange for speed that
+makes the whole thing usable at scale. For search-by-meaning, near-perfect and instant
+beats perfect and unusable.
+
+## RAG: what this is all for
+
+The headline use is **retrieval-augmented generation (RAG)** — the standard way to give
+a language model access to *your* documents. A model on its own only knows its training
+data; RAG lets it answer from a knowledge base you control. The flow:
+
+1. **Index once.** Split your documents into chunks, embed each chunk into a vector, and
+   store the vectors in the vector database.
+2. **Embed the question.** When a user asks something, turn *their question* into a
+   vector with the same model.
+3. **Retrieve.** Ask the vector database for the chunks whose vectors are nearest the
+   question's vector — the passages most *relevant in meaning*.
+4. **Generate.** Hand those retrieved chunks to the language model as context, and it
+   answers grounded in your actual documents.
+
+The vector database is step 3 — the retrieval engine. It's why a chatbot can answer from
+your company's manuals, or why "how do I fix a fading signal" can surface a
+troubleshooting note that never uses the word "fading." The
+[building AI](/learn/building-ai/) path covers RAG as a whole; the piece it leans on
+here is exactly this store.
+
+## Where it fits alongside everything else
+
+A vector database rarely replaces your other databases — it **joins** them. The source
+of truth for your documents might be relational or a document store; the vector database
+holds their embeddings for meaning-based retrieval; a cache sits in front of it all. In
+fact, with an extension like **pgvector** you can add similarity search *to* a
+relational database you already run, keeping vectors right next to the rows they
+describe. That mirrors the whole unit's lesson: reach for the store whose shape matches
+the job — and "search by meaning" is a job that wanted its own shape.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a vector database finds the stored embeddings nearest to a query vector, matching by meaning rather than by exact words." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does a vector database primarily do?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Store rows and fetch them by an exact primary key, like a relational table</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Store embeddings and find the ones nearest a query vector — search by meaning, not exact words</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Compress time-stamped metrics for dashboards over time</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **vector database** stores **embeddings** — vectors of numbers that encode the
+  *meaning* of text or other data, with similar meanings landing close together.
+- Its core operation is **similarity search**: find the **k nearest** stored vectors to a
+  query vector, ranked by **cosine** or **Euclidean** distance.
+- This is **search by meaning** (semantic search), fundamentally different from a
+  `WHERE` clause's exact or pattern matching.
+- Brute-force nearest-neighbor is too slow at scale, so these stores use an
+  **approximate nearest-neighbor (ANN)** index — trading a tiny bit of exactness for
+  huge speed.
+- It's the retrieval engine behind **RAG**: embed and store your documents, embed the
+  question, retrieve the nearest chunks, and feed them to the model.
+- It usually runs **alongside** your other databases (or as the **pgvector** extension
+  inside Postgres), not instead of them.
+
+Next up: [Caching layers](/learn/databases/caching-layers/).

--- a/docs/learn/databases/what-is-a-database.md
+++ b/docs/learn/databases/what-is-a-database.md
@@ -1,0 +1,141 @@
+---
+slug: what-is-a-database
+title: What a database is (and why not just files)
+description: A database is software built to store data so many readers and writers can query it reliably, safely, and fast. Learn the problems it solves that hand-rolled files can't — concurrency, querying, integrity, and durability.
+keywords: what is a database, database vs files, DBMS, concurrency, querying, data integrity, durability, transactions, relational database, why use a database
+level: beginner
+status: full
+faq:
+  - q: "Can't I just save my data to a file?"
+    a: "For a tiny, single-user program, yes — a file is fine. The trouble starts when more than one thing reads or writes at once, when you need to find one record among millions without scanning the whole file, or when a crash mid-write must not corrupt everything. A database exists to handle exactly those situations so you don't have to reinvent them."
+  - q: "What does DBMS mean?"
+    a: "A **database management system** is the actual software — Postgres, SQLite, MySQL — that stores the data and answers queries. People usually say \"database\" for both the software and the data it holds; the DBMS is the engine doing the work."
+  - q: "Is a spreadsheet a database?"
+    a: "Not really. A spreadsheet holds rows and columns, but it has no query language, weak types, no real concurrency, and no guarantees against corruption. It's great for a human eyeballing numbers; a database is built for programs storing and querying data at scale."
+---
+
+# What a database is (and why not just files)
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A **database** is software built to store data so it can be **queried**,
+shared by **many readers and writers at once**, and trusted to survive a crash.
+The engine that does this is a **DBMS** (like Postgres or SQLite). You *could*
+hand-roll files instead — but you'd end up rebuilding concurrency, fast lookups,
+**integrity**, and **durability** yourself, badly. This module builds from here;
+the sibling path covers the same ground from a different angle in
+[databases & persistence](/learn/intro-software-dev/databases-and-persistence/).
+</div>
+
+Almost every program eventually needs to remember something — a user, a setting,
+a log of decoded calls. The naive answer is "write it to a file." That works
+right up until a second user shows up, or the data grows past what you can scan,
+or the power cuts out mid-write. A database is the accumulated answer to all the
+ways that plain files let you down, packaged so you can lean on it instead of
+rebuilding it.
+
+## The file approach, and where it breaks
+
+Say you're storing a list of radio systems your scanner has seen. You could keep
+them in a text file, one per line, and append a new line each time. For a quick
+script on your own laptop, that's genuinely fine — don't over-engineer a toy.
+
+The cracks appear as soon as the program grows up:
+
+- **Finding one record is slow.** To pull "the system on 851.0125 MHz" you read
+  the *whole* file and check every line. At a thousand rows that's instant; at ten
+  million it's a real wait, every time.
+- **Two writers collide.** If two parts of your program (or two users) append at
+  the same moment, their writes interleave and you get a garbled line — or one
+  overwrites the other. Files have no idea the two are happening at once.
+- **A crash corrupts everything.** If the machine dies halfway through rewriting
+  the file, you can be left with a truncated, unreadable mess — and no clean
+  version to fall back to.
+- **There are no rules.** Nothing stops you writing a system with no name, or the
+  same one twice, or a frequency that's actually the word "banana." The file
+  stores whatever bytes you hand it.
+
+Each of these is solvable. Solving *all* of them, correctly, is a large amount of
+careful engineering — and it has already been done, many times over, inside a
+database.
+
+## What a database gives you instead
+
+A **database** is purpose-built software that stores data and answers questions
+about it. The engine itself is called a **database management system**, or
+**DBMS** — Postgres, MySQL, SQLite, and others. In everyday speech "database"
+means both the software and the data it holds; the DBMS is the part doing the
+work. What you get for handing your data to one:
+
+- **Querying.** You *ask* for the data you want — "every call on talkgroup 101
+  yesterday, newest first" — and the database figures out how to fetch it. That
+  language is [SQL](/learn/databases/what-is-sql/), and it's most of this module.
+- **Fast lookups.** With an [index](/learn/databases/indexes/), the database jumps
+  straight to matching rows instead of scanning everything — the difference
+  between a millisecond and a minute.
+- **Concurrency.** Many readers and writers can work at once without stepping on
+  each other, coordinated by the DBMS so nobody sees a half-written mess.
+- **Integrity.** You can declare rules — this column can't be empty, this value
+  must be unique, this row must point at a real one in another table — and the
+  database refuses to store data that breaks them.
+- **Durability.** Once the database confirms a write, it's on disk to stay, even
+  if the power dies a millisecond later. Getting this right underlies
+  [transactions](/learn/databases/inserting-updating-deleting/) and the guarantees
+  behind them.
+
+## Structured storage, not a magic box
+
+A database isn't magic — it's structured. Most databases you'll meet are
+**relational**: they organise data into **tables** of rows and columns, a shape
+we unpack in [the relational model](/learn/databases/the-relational-model/). You
+decide the **schema** — what columns exist and what type each holds — up front,
+and the database enforces it. That structure is *why* it can query, index, and
+validate so well: it knows exactly what your data looks like.
+
+Here's the whole idea in miniature. Instead of appended text lines, a system
+table might look like this, and you'd ask for one row by name rather than reading
+the file:
+
+```sql
+SELECT frequency_hz
+FROM systems
+WHERE name = 'Metro P25';
+```
+
+The database reads *only* the matching row, using an index, no matter how many
+million rows sit alongside it. You described *what* you wanted; it worked out
+*how*.
+
+## When a plain file really is fine
+
+The honest counterpoint: databases aren't always the answer. A config file a
+program reads once at startup, a handful of settings, a scratch log you'll delete
+tomorrow — reach for a file and move on. The moment you need to *query* that data,
+share it between writers, or trust it to survive a crash, that's the signal to
+put it in a database. Most of software development is knowing which situation
+you're in.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — databases exist to handle querying, concurrency, integrity, and durability that hand-rolled files don't." markdown="0">
+  <p class="knowledge-check__q">Quick check: what's the main reason to use a database instead of a plain file?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Files can't store text, only databases can</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">It handles querying, concurrent access, integrity, and durability for you</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Databases are always faster than files for every single task</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **database** is software built to store data so it can be queried, shared, and
+  trusted — the engine is a **DBMS** like Postgres or SQLite.
+- Plain files break down on **fast lookups**, **concurrent writers**, **crash
+  safety**, and **enforcing rules** — a database solves all four.
+- Databases give you **querying** (via SQL), **indexes** for speed,
+  **concurrency**, **integrity** rules, and **durability**.
+- Most databases are **relational**: data lives in **tables** with a defined
+  **schema**, which is what makes querying and validation possible.
+- A plain file is still fine for tiny, single-user, throwaway data — reach for a
+  database when you need to query, share, or protect the data.
+
+Next up: [Data, state & persistence](/learn/databases/data-and-persistence/).

--- a/docs/learn/databases/what-is-sql.md
+++ b/docs/learn/databases/what-is-sql.md
@@ -1,0 +1,137 @@
+---
+slug: what-is-sql
+title: What SQL is
+description: SQL is the declarative language for talking to a relational database — you describe the data you want, not how to fetch it, and the database works out the rest. Learn what makes SQL declarative, its main statement families, and why it's worth learning once.
+keywords: SQL, structured query language, declarative language, relational database, query, DDL, DML, SELECT, standard, dialects, database language
+level: beginner
+status: full
+prereq:
+  - the-relational-model
+faq:
+  - q: "What does 'declarative' mean for SQL?"
+    a: "You describe the result you want — which rows, which columns, in what order — and leave it to the database to figure out how to produce it efficiently. You don't write the loops that scan tables or the logic that uses indexes; the database's query planner does that. You say what, it decides how."
+  - q: "Is SQL the same on every database?"
+    a: "Mostly. There's an ANSI SQL standard that the core — SELECT, INSERT, JOIN, WHERE — follows everywhere, so skills transfer across Postgres, MySQL, SQLite, and others. But each database has its own dialect with extra functions and small differences, so the edges vary even though the middle is shared."
+  - q: "Do I really need to learn SQL if I use an ORM?"
+    a: "Yes. An ORM (object-relational mapper) generates SQL for you, but it's a leaky abstraction — when a query is slow or behaves oddly, you have to read the SQL underneath to understand why. SQL is the lingua franca of data; learning it once pays off across every database and every tool."
+---
+
+# What SQL is
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**SQL** (Structured Query Language) is how you talk to a relational database. It's
+**declarative**: you *describe* the data you want — which rows, which columns, in
+what order — and the database's **query planner** figures out *how* to fetch it.
+Learn it once and it transfers everywhere, because a shared **standard** underlies
+Postgres, MySQL, SQLite, and the rest (with small **dialect** differences). SQL is
+what the [relational model](/learn/databases/the-relational-model/) is queried with,
+and the rest of this unit is SQL in practice.
+</div>
+
+You've got tables, columns, and keys. Now you need a way to *ask questions* of them
+— and that language, for essentially every relational database, is **SQL**. It's one
+of the highest-leverage things a developer can learn: a single language that's stayed
+relevant for fifty years and works across nearly every database you'll ever touch.
+This lesson is the orientation; the lessons after it are SQL in your hands.
+
+## Say what you want, not how to get it
+
+The defining trait of SQL is that it's **declarative**. In most programming you write
+*imperative* code: step-by-step instructions — open the file, loop over the rows,
+check each one, collect the matches. SQL flips that. You state the *result you want*
+and stay silent on the mechanics:
+
+```sql
+SELECT name, frequency_hz
+FROM systems
+WHERE protocol = 'P25'
+ORDER BY frequency_hz;
+```
+
+Read it almost like English: "give me the name and frequency of every system whose
+protocol is P25, sorted by frequency." Nowhere did you say *how* — no loop, no
+index lookup, no decision about what order to scan the table. You described the
+destination; the database plots the route.
+
+## The query planner does the "how"
+
+Who works out the how? A part of the database called the **query planner** (or
+optimiser). It takes your declarative request and decides on an efficient execution
+strategy — whether to use an [index](/learn/databases/indexes/) or scan the table,
+what order to combine tables in a join, and so on. For the same query it might pick
+different strategies as your data grows, all without you rewriting a line.
+
+This is the deal SQL offers: you give up fine control over the mechanics, and in
+return the database handles the hard, data-dependent optimisation for you. It's
+usually a great trade — the planner is better at it than hand-written loops would be,
+and your query stays readable. When it *doesn't* choose well, you can inspect its plan
+and nudge it, which the [performance lesson](/learn/databases/indexes/) touches on.
+
+## The families of statements
+
+SQL isn't only for reading. Its statements fall into a few groups, and you'll spend
+this unit meeting them:
+
+- **Querying (reading)** — `SELECT`, the workhorse you'll use most, covered next in
+  [querying with SELECT](/learn/databases/querying-with-select/). Everything about
+  filtering, sorting, joining, and aggregating hangs off it.
+- **Changing data** — `INSERT`, `UPDATE`, `DELETE`: adding rows, modifying them, and
+  removing them. This is **DML** (data manipulation language), covered in
+  [inserting, updating & deleting](/learn/databases/inserting-updating-deleting/).
+- **Defining structure** — `CREATE TABLE`, `ALTER TABLE`, `DROP`: the schema
+  statements you met earlier. This is **DDL** (data definition language).
+
+Reading data is where you'll live day to day, so `SELECT` gets the lion's share of
+attention. But it's the same language throughout — one grammar for asking, changing,
+and shaping.
+
+## One language, many dialects
+
+Here's what makes SQL such a good investment: it's largely **standard**. There's an
+ANSI SQL standard, and the core — `SELECT`, `WHERE`, `JOIN`, `INSERT` — works
+essentially the same across Postgres, MySQL, SQLite, SQL Server, and Oracle. Learn it
+on one and you can query all of them.
+
+Each database also has its own **dialect**: extra built-in functions, slightly
+different syntax for dates or JSON, its own way to auto-generate keys. So the *edges*
+differ even though the *middle* is shared. In practice you learn the common core once
+(that's this unit) and pick up a specific database's quirks as you need them. The
+transferable skill is real — SQL fluency moves with you across jobs, stacks, and
+decades.
+
+## Why it's worth learning properly
+
+You might reach a database through an **ORM** — a library that maps your program's
+objects to rows and writes the SQL for you (we compare the approaches in
+[ORMs vs. raw SQL](/learn/databases/orms-vs-raw-sql/) later). Tempting to think you can
+then skip SQL. You can't, really. An ORM is a convenience over SQL, not a replacement
+for understanding it: the moment a query is slow, returns the wrong rows, or does
+something surprising, you're reading the generated SQL to find out why. SQL is the
+ground truth underneath every relational tool. Learn it once; use it forever.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — SQL is declarative: you describe the result you want and the database's planner works out how to fetch it." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does it mean that SQL is a declarative language?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">You write step-by-step loops telling the database how to scan each table</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">You describe the result you want; the database works out how to produce it</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It only works on one specific database and doesn't transfer</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **SQL** (Structured Query Language) is the language for talking to a relational
+  database — the way you ask questions of your tables.
+- It's **declarative**: you describe the *result* you want, not the step-by-step *how*
+  of fetching it.
+- The database's **query planner** turns your request into an efficient execution
+  strategy, choosing indexes and join order for you.
+- SQL statements group into **querying** (`SELECT`), **changing data** (`INSERT`,
+  `UPDATE`, `DELETE` — DML), and **defining structure** (`CREATE TABLE` — DDL).
+- The core is a shared **standard** across databases, with per-database **dialect**
+  differences at the edges — so the skill transfers widely.
+- Even with an **ORM**, SQL is the ground truth worth learning once.
+
+Next up: [Querying with SELECT](/learn/databases/querying-with-select/).

--- a/docs/learn/scanning/a-worked-monitoring-setup.md
+++ b/docs/learn/scanning/a-worked-monitoring-setup.md
@@ -1,0 +1,141 @@
+---
+slug: a-worked-monitoring-setup
+title: A worked end-to-end monitoring setup
+description: Start to finish, one complete build — antenna, feedline, SDR, GopherTrunk, per-call recording, alerting, and a dashboard, assembled and running as an always-on monitoring station that follows a real trunked system.
+keywords: monitoring setup, end-to-end scanner, GopherTrunk build, worked example, SDR monitoring station, complete scanner setup, trunk tracking build, always-on monitoring, scanner dashboard, full setup
+level: advanced
+status: full
+prereq:
+  - gophertrunk-as-a-scanner
+  - building-a-monitoring-post
+faq:
+  - q: What does a complete monitoring setup include?
+    a: The whole chain, in order — a good outdoor antenna, low-loss feedline into the shack, an SDR receiver, a low-power computer running GopherTrunk to lock the control channel and follow calls, per-call recording and logging to disk, alerting on the talkgroups you care about, and a dashboard to watch it all. Each piece is a lesson from this module; this one bolts them together.
+  - q: In what order do you build it?
+    a: Signal-path order, because each stage depends on the one before it. Antenna and feedline first (nothing downstream beats a bad antenna), then the SDR, then GopherTrunk locked on a control channel, then recording and logging, then alerting, then the dashboard and the always-on service wrapper last. Get each stage working before adding the next.
+  - q: How do I know the whole thing is working?
+    a: Trace one call end to end. A radio keys up, the control channel grants it, GopherTrunk follows it to a voice channel, you hear decoded audio, a tagged recording lands on disk with a matching log row, and any alert you set fires. If that full path works for one call, it works for all of them.
+---
+
+# A worked end-to-end monitoring setup
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+This is the whole module in one build. In **signal-path order** — antenna → feedline
+→ **SDR** → **GopherTrunk** → recording & logging → alerting → dashboard, wrapped as
+an **always-on service** — you assemble a complete station that locks a real trunked
+system's control channel, follows its calls, and produces **tagged per-call audio**
+you can search and get alerted on. Build **one stage at a time**, confirm each before
+the next, and test the finished post by **tracing a single call end to end**.
+</div>
+
+Every lesson so far has been one piece. This one is the assembly: a single, concrete,
+end-to-end monitoring setup, built in the order the signal actually flows, so you can
+see how the parts you've met click together into a working station. Nothing here is
+new — it's the module, wired up. Follow it as a template and adapt the specifics to
+your own systems and gear. The [architecture overview](/architecture.html) shows the
+same chain from GopherTrunk's side; the [project home](/) is where you get the
+software.
+
+## Build in signal-path order
+
+Assemble the chain the way the signal travels, because every stage depends on the one
+before it — a brilliant decoder can't rescue a bad antenna, and a flawless antenna is
+wasted if the service keeps crashing. Get each stage working and verified before you
+add the next:
+
+1. **Antenna** — the biggest single factor in what you hear.
+2. **Feedline & connectors** — deliver the signal indoors without throwing it away.
+3. **SDR** — digitise the spectrum.
+4. **GopherTrunk** — lock the control channel and follow calls.
+5. **Recording & logging** — write tagged per-call audio and a searchable log.
+6. **Alerting** — get told when the calls you care about happen.
+7. **Dashboard & always-on service** — watch it, and keep it running unattended.
+
+## Stage 1 — antenna and feedline
+
+Start outdoors and up high. A wideband [antenna](/learn/scanning/antennas-for-scanning/)
+like a discone, mounted as high and clear as you can manage, does more for your
+results than any other single choice. Run it down to the shack with **low-loss
+[feedline](/learn/scanning/feedlines-and-connectors/)** and good connectors, keeping
+the run as short as practical — coax loss is signal you spend once and never get back.
+Ground the install for safety while you're at it. This unglamorous stage sets the
+ceiling on everything that follows.
+
+## Stage 2 — the SDR
+
+Plug the feedline into your [SDR](/learn/rf-sdr/what-is-sdr/) and the SDR into the
+computer. Confirm the raw basics before decoding anything: the receiver is recognised,
+you can see the [waterfall](/learn/scanning/identifying-unknown-signals/), and your
+target system's control channel shows up as that solid, never-quiet carrier. If you
+can see the control channel here, GopherTrunk can lock it; if you can't, fix reception
+now, not later.
+
+## Stage 3 — GopherTrunk locks and follows
+
+Point [GopherTrunk](/learn/scanning/gophertrunk-as-a-scanner/) at the SDR and give it
+the system's **control-channel frequency and type**. It locks the control channel,
+starts reading grants, and follows each call to its voice channel — decoding P25, DMR,
+NXDN, TETRA, or whatever the system runs. Confirm the lock the same way you always do:
+within seconds you should see affiliations and voice grants scrolling, and hear
+decoded audio when a call is granted. This is [following a
+call](/learn/scanning/following-a-call/), running for real. If the lock won't hold,
+[when decoding fails](/learn/scanning/when-decoding-fails/) is your checklist.
+
+## Stage 4 — recording, logging, and alerting
+
+Now capture what you're hearing. Turn on **per-call
+[recording](/learn/scanning/logging-and-recording/)** so each call lands as its own
+tagged file, with a matching row in the **log**. Load your
+[talkgroup aliases](/learn/scanning/metadata-and-tagging/) so the log reads in names,
+not numbers, and set a **[retention policy](/learn/scanning/logging-and-recording/)**
+so the disk doesn't fill. Then add a couple of narrow
+**[alerts](/learn/scanning/alerting-on-calls/)** on the talkgroups or units you most
+care about — and only those, to keep them trustworthy. At this point the station is
+producing a searchable archive on its own.
+
+## Stage 5 — dashboard and always-on
+
+Finally, make it watchable and durable. A **dashboard** gives you live status — locks,
+recent calls, disk space — so you can check the post at a glance or from your phone,
+which matters because it runs [headless](/learn/scanning/building-a-monitoring-post/).
+Then wrap GopherTrunk as a **managed service** with
+[systemd](/learn/linux-cli/services-and-systemd/) so it starts on boot and restarts on
+failure, and follow the [deployment guide](/learn/deployment/deploying-gophertrunk/) to
+stand it up properly. Now it's not a program you launched — it's a
+[monitoring post](/learn/scanning/building-a-monitoring-post/) that looks after
+itself.
+
+## Prove it: trace one call
+
+The whole build is verified by a single test. Wait for — or watch for — one call, and
+follow it the entire way: a radio keys up, the control channel grants it, GopherTrunk
+tunes to the voice channel, you hear clean decoded audio, a **tagged recording lands
+on disk with a matching log row**, and any alert you set **fires**. If that complete
+path works for one call, it works for all of them, and you have a real, end-to-end,
+always-on monitoring station — every lesson in this module, running at once.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — build in signal-path order, because each stage depends on the one before it and a bad antenna can't be fixed downstream." markdown="0">
+  <p class="knowledge-check__q">Quick check: why build the setup antenna-first, in signal-path order?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Because the antenna is the most expensive part and should be tested for defects</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Because each stage depends on the one before it — nothing downstream can fix a bad antenna</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Because GopherTrunk refuses to start until an antenna is detected</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A complete setup is the whole chain: **antenna → feedline → SDR → GopherTrunk →
+  recording & logging → alerting → dashboard**, wrapped as an always-on service.
+- Build in **signal-path order**, verifying each stage before the next — nothing
+  downstream fixes a bad antenna.
+- GopherTrunk **locks the control channel and follows grants**; recording, logging,
+  and alerting turn that into a searchable, watched archive.
+- Make it durable with a **dashboard** and a **managed service** (systemd), per the
+  [deployment guide](/learn/deployment/deploying-gophertrunk/).
+- Verify the whole thing by **tracing one call end to end** — key-up to tagged
+  recording, log row, and alert.
+
+Next up: [the community & contributing data](/learn/scanning/contributing-and-community/).

--- a/docs/learn/scanning/alerting-on-calls.md
+++ b/docs/learn/scanning/alerting-on-calls.md
@@ -1,0 +1,136 @@
+---
+slug: alerting-on-calls
+title: Alerting on the calls you care about
+description: Let the setup watch for you — triggers and alerts on specific talkgroups, unit IDs, or activity patterns so you're notified the moment something happens, instead of babysitting a scanner for the one call that matters.
+keywords: scanner alerts, talkgroup alert, call trigger, priority talkgroup, unit ID alert, notification, alerting, scanner notification, keyword alert, monitoring trigger
+level: intermediate
+status: full
+prereq:
+  - talkgroups-and-scan-lists
+faq:
+  - q: What can I set an alert on?
+    a: Anything your setup knows about a call from the control channel — most usefully a specific talkgroup or set of talkgroups, a particular source unit ID, or a pattern like "any activity on a talkgroup that's normally quiet." Since scanner audio isn't transcribed by default, alerts fire on metadata (who and where), not on spoken words, unless you add speech-to-text.
+  - q: How does an alert reach me?
+    a: However you wire it up — a sound or pop-up on the monitoring machine, a push notification to your phone, an email or chat message, or triggering a recording and a log entry. The alert is just an action fired when a call matches your rule; where it goes is your choice.
+  - q: How do I avoid alert fatigue?
+    a: Alert narrowly. An alert on a busy dispatch talkgroup fires constantly and you quickly learn to ignore it, which defeats the purpose. Reserve alerts for the genuinely notable — a tac channel that only lights up during an incident, a specific unit, or unusual activity — and let everything else flow into the log silently.
+---
+
+# Alerting on the calls you care about
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+You can't watch a scanner all day, so let it watch for you. An **alert** is an
+**action fired when a call matches a rule** you set — a specific
+**talkgroup**, a **source unit**, or an unusual activity pattern. It can pop up on
+screen, push to your phone, or kick off a recording. The craft is **alerting
+narrowly**: a rule that fires constantly becomes noise you ignore, so reserve alerts
+for the genuinely notable and let routine traffic flow into the
+[log](/learn/scanning/logging-and-recording/) silently.
+</div>
+
+The whole promise of a monitoring setup is that it does the waiting for you. You care
+about a handful of things — a tac channel that only lights up during a working
+incident, a particular unit, the first sign of a big call-out — but they happen at
+unpredictable times, buried in hours of routine chatter. Alerting is how you get
+notified the instant one occurs, without babysitting the radio. This lesson covers
+what to alert on, how the alert reaches you, and how to keep alerts trustworthy.
+
+## What you can alert on
+
+An alert fires on what your setup already knows about a call from the control
+channel, so the natural triggers are all **metadata**:
+
+- **A talkgroup, or a set of them.** The most common alert — "tell me the moment
+  County Fire Tac 2 keys up." You already grouped talkgroups when you built your
+  [scan lists](/learn/scanning/talkgroups-and-scan-lists/); an alert is a scan-list
+  entry with a notification attached.
+- **A source unit ID.** Follow one radio wherever it goes — useful for tracking a
+  specific unit across an event, regardless of which talkgroup it's on.
+- **An activity pattern.** "Any traffic at all on a talkgroup that's normally
+  silent," or "more than N calls a minute on this system" — a quiet channel suddenly
+  going busy is often the earliest sign something is happening.
+
+What you *can't* alert on out of the box is spoken words: scanner audio isn't
+transcribed by default, so alerts fire on **who and where**, not on **what was
+said** — unless you bolt on speech-to-text, which is a much heavier add-on and beyond
+a normal setup.
+
+## How the alert reaches you
+
+An alert is just an **action** wired to a matching rule, and where that action goes
+is entirely your choice. Common destinations:
+
+- **On the machine** — a sound, a pop-up, or a highlighted row so a call you care
+  about jumps out of the scrolling log.
+- **To your phone** — a push notification, so you learn about the incident whether
+  you're at the desk or across town.
+- **To a channel** — an email, a chat message, or a webhook into another tool, handy
+  if a group of people watches the same system.
+- **A recording or priority action** — the match itself triggers a
+  [recording](/learn/scanning/logging-and-recording/), bumps the call to priority, or
+  jumps the receiver to it.
+
+You can fire several at once: highlight it on screen, push to your phone, *and* start
+recording. The alert engine matches; the actions are yours to compose.
+
+## Priority: alerting's real-time cousin
+
+Alerting has a close relative you already met — **priority**. A priority talkgroup
+interrupts whatever you're monitoring the instant it becomes active, so the receiver
+jumps to the important call in real time. Think of priority as an alert whose action
+is "listen to this *now*," while a notification alert's action is "tell me it
+happened." They complement each other: priority handles the call you must hear live,
+notifications handle the ones you want to know about but can catch up on later. Both
+draw on the same matching rules you built into your scan lists.
+
+## Keep alerts trustworthy: alert narrowly
+
+The failure mode of alerting is **alert fatigue**. Put an alert on a busy dispatch
+talkgroup and it fires every thirty seconds; within a day you've trained yourself to
+ignore it, and now it's worse than useless — it's noise that hides the real thing.
+An alert you ignore is an alert that isn't working.
+
+So alert **narrowly and deliberately**. Reserve alerts for events that are genuinely
+notable *and* genuinely infrequent: the tac channel that's silent until an incident,
+the specific unit, the quiet talkgroup that suddenly wakes up. Everything routine
+should flow into the log without a peep. The test is simple — if an alert fires and
+your honest reaction is "so what," it's the wrong alert. Tune it down until every
+alert that fires is one you're glad to have gotten.
+
+## Building it up over time
+
+Good alerting isn't designed once; it accretes. You start with one or two obvious
+rules, notice you keep missing a certain kind of call, add a rule for it, then prune
+one that cries wolf. Over weeks your alert set converges on the small handful of
+things that reliably mean "pay attention," and the rest of the traffic keeps filling
+the [searchable log](/learn/scanning/metadata-and-tagging/) quietly in the
+background. That combination — loud about the few things that matter, silent about
+everything else — is what makes an unattended setup genuinely useful, and it's the
+mindset the [monitoring-post](/learn/scanning/building-a-monitoring-post/) lesson
+builds a full station around.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — alerting on a constantly-busy talkgroup causes alert fatigue, so you learn to ignore it and miss the calls that matter." markdown="0">
+  <p class="knowledge-check__q">Quick check: why should you avoid setting an alert on a busy dispatch talkgroup?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Busy talkgroups can't be alerted on — only quiet ones can</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">It fires constantly, so you learn to ignore it and miss the calls that matter</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Alerts on busy talkgroups are illegal in most places</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- An **alert** is an action fired when a call matches a rule — a **talkgroup**, a
+  **unit ID**, or an unusual **activity pattern**.
+- Alerts fire on **metadata** (who and where), not on spoken words, unless you add
+  speech-to-text.
+- The action can go anywhere — on-screen, a phone push, a message, or triggering a
+  recording — and you can fire several at once.
+- **Priority** is alerting's real-time cousin: its action is "listen now," where a
+  notification's action is "tell me it happened."
+- **Alert narrowly** to avoid alert fatigue — reserve alerts for the notable and
+  infrequent, and let routine traffic flow into the log silently.
+
+Next up: [building an always-on monitoring post](/learn/scanning/building-a-monitoring-post/).

--- a/docs/learn/scanning/antennas-for-scanning.md
+++ b/docs/learn/scanning/antennas-for-scanning.md
@@ -1,0 +1,146 @@
+---
+slug: antennas-for-scanning
+title: Antennas for scanning
+description: The antenna is the single biggest upgrade to what you can hear — far more than any receiver. Discones, wideband verticals, tuned whips, and directional Yagis, plus the placement and height that beat any fancier antenna, for the scanner listener.
+keywords: scanner antenna, discone antenna, wideband vertical, scanning antenna placement, antenna height, outdoor scanner antenna, tuned whip, Yagi scanning, best antenna for scanning
+level: intermediate
+status: full
+prereq:
+  - choosing-a-scanner
+faq:
+  - q: What is the best antenna for scanning?
+    a: "For general scanning across many bands, a wideband vertical or a discone outdoors and up high is the usual answer — it hears all directions and covers a huge frequency range. If you only chase one band, a tuned antenna cut for it will outperform a wideband one there. But placement matters more than the antenna model: outside, high, and clear of obstructions beats a fancier antenna indoors almost every time."
+  - q: Why is the stock whip antenna so limiting?
+    a: The rubber whip that ships with a scanner or SDR is a compromise — short, broadband, and designed to be convenient rather than sensitive, and it usually sits indoors near electrical noise. Almost any purpose-built antenna, especially one mounted outdoors and up high, is a dramatic upgrade. Replacing the stock whip is the single most cost-effective improvement most listeners can make.
+  - q: Should I get a wideband or a tuned antenna?
+    a: It depends on how many bands you follow. A wideband antenna like a discone covers everything at once with modest efficiency on any single band — ideal when you scan across services. A tuned antenna cut for one band is more efficient there but poor elsewhere. Many listeners run a wideband antenna for general use and add a tuned or directional antenna for a specific weak system.
+---
+
+# Antennas for scanning
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+The **antenna sets the ceiling on everything** — no receiver or software recovers a
+signal the antenna never caught, so it is the **highest-value upgrade** in the hobby.
+For general scanning, a **wideband vertical or discone**, mounted **outdoors and up
+high**, hears all directions across many bands; a **tuned** antenna beats it on one
+band; a **directional Yagi** pulls in a single distant system. Above all, **placement
+and height usually beat a fancier antenna**. The [RF & SDR antenna
+lesson](/learn/rf-sdr/antennas/) covers the physics; this is the scanning-specific
+guide.
+</div>
+
+You have [chosen a receiver](/learn/scanning/choosing-a-scanner/). Now comes the
+component that will do more for what you actually hear than any other decision: the
+antenna. The
+[RF & SDR module's Antennas 101](/learn/rf-sdr/antennas/) explains *why* antennas behave
+as they do — wavelength, resonance, polarization, gain, SWR. This lesson assumes that
+groundwork and focuses on the practical scanning question: **what should I actually put
+up, and where?**
+
+## Why the antenna matters most
+
+Start with the principle worth tattooing on the hobby: **the antenna is the ceiling.**
+Everything downstream — the receiver's sensitivity, the software's decoding, the
+filters — can only work with the signal the antenna delivers. A weak signal the antenna
+failed to capture is gone; no amount of gain or clever DSP invents it back. That is why a
+modest receiver on a good antenna, up high and outdoors, routinely outperforms an
+expensive receiver on the stock whip sitting on a desk. If you have money to spend, the
+antenna and its placement are where it buys the most hearing.
+
+## Ditch the stock whip
+
+Almost every scanner and SDR ships with a short **rubber whip** or telescopic antenna.
+It exists to make the box work out of the packaging, not to work *well*. It is a broadband
+compromise, it is short, and — worst of all — it usually ends up **indoors**, next to the
+computer, the power supplies, and every other source of electrical
+[noise](/learn/scanning/reducing-interference/) in the room. Replacing it is the single
+most cost-effective thing most listeners ever do. Even a cheap purpose-built antenna
+moved to a window, and dramatically so moved outdoors, transforms what you hear.
+
+## Wideband verticals and the discone
+
+For general-purpose scanning across many services and bands, the workhorse is a
+**wideband vertical** — often a **discone**. A discone's distinctive disc-and-cone shape
+gives it usable performance across a huge frequency range, from VHF up through UHF and
+beyond, which is exactly what you want when your interests span aviation, public safety,
+rail, and business all at once.
+
+Its trade-off, as [Antennas 101](/learn/rf-sdr/antennas/) explains, is that broadband
+coverage means **modest efficiency on any one band** — it is a generalist, not a
+specialist. For most listeners that is the right bargain: one antenna, one feedline, and
+everything from the air band to 800 MHz within reach. It is **omnidirectional**, hearing
+all compass directions roughly equally, which suits scanning where systems surround you.
+
+## Tuned antennas for one band
+
+If you spend most of your time on a *single* band — only the air band, say, or only an
+800 MHz trunked system — a **tuned antenna cut for that band** will outperform a wideband
+antenna there. Because its length matches the wavelength (a quarter-wave whip is *λ/4*, a
+half-wave dipole *λ/2*), it is more efficient at its design frequency, pulling in weaker
+signals on that band than a generalist can. The price is that it is poor everywhere else.
+Many listeners run a wideband antenna as their everyday setup and add a tuned antenna when
+one system becomes their main interest.
+
+## Directional antennas for a distant system
+
+When you are chasing **one specific weak, distant system**, a **directional** antenna — a
+**Yagi** — is the tool. It concentrates its sensitivity in the direction it points,
+adding gain toward that system at the cost of hearing anything off to the sides. Point it
+at the distant tower and it can pull in a signal an omnidirectional antenna loses in the
+noise. It is the wrong choice for general scanning (you would be deaf to everything not in
+front of it), but exactly right for reaching a single stubborn target.
+
+## Polarization: go vertical
+
+Match your antenna's **polarization** to the transmitter's, or you throw away signal — a
+full mismatch can cost around 20 dB. The good news is that **most land-mobile and
+public-safety radio is vertically polarized**, so a **vertical** scanner antenna is the
+safe default and the reason discones and whips are mounted upright. (FM broadcast is
+often horizontal or circular, but that is not your usual target.) For scanning, vertical
+is almost always the right orientation.
+
+## Placement and height beat everything
+
+Here is the lesson that overrides all the others: at VHF and UHF, signals are essentially
+**line-of-sight**, so **height and a clear view of the horizon usually matter more than the
+antenna model.** The priorities, in order:
+
+- **Get it outside.** An outdoor antenna escapes the wall of electrical noise inside a
+  building and sees far more of the sky.
+- **Get it high.** Higher means a longer line of sight over rooftops and terrain — the
+  single biggest lever on range.
+- **Get it clear.** Away from large metal objects, wiring, and obstructions that block or
+  distort the signal.
+
+A modest antenna on the roof will routinely beat a premium antenna in the shack. So before
+you spend on a better antenna, ask whether you can mount the one you have **higher and
+outdoors** — it is usually the bigger win, and it costs mostly effort. How that antenna
+connects to your receiver — the coax and connectors that quietly eat signal on the way
+down — is the [next lesson](/learn/scanning/feedlines-and-connectors/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — at VHF/UHF, getting the antenna outdoors and up high usually helps more than a fancier antenna model." markdown="0">
+  <p class="knowledge-check__q">Quick check: you can either upgrade to a premium antenna indoors, or mount your current antenna outdoors on the roof. Which usually helps more?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">The premium antenna indoors — the model always matters most</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The current antenna outdoors and up high — placement and height usually beat a fancier antenna</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Neither makes a difference for line-of-sight VHF/UHF signals</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- The **antenna is the ceiling** on everything downstream — the highest-value upgrade in
+  the hobby.
+- **Replace the stock whip**; it's a short broadband compromise usually stuck indoors in
+  the noise.
+- A **wideband vertical or discone** is the general-purpose default — omnidirectional,
+  huge frequency range, modest per-band efficiency.
+- A **tuned antenna** wins on one band; a **directional Yagi** pulls in one distant
+  system.
+- Go **vertical** — most scannable traffic is vertically polarized.
+- **Placement and height beat the antenna model**: outside, high, and clear is the biggest
+  lever on what you hear.
+
+Next up: [Feedlines, connectors &amp; grounding](/learn/scanning/feedlines-and-connectors/).

--- a/docs/learn/scanning/audio-feeds-and-streaming.md
+++ b/docs/learn/scanning/audio-feeds-and-streaming.md
@@ -1,0 +1,135 @@
+---
+slug: audio-feeds-and-streaming
+title: Audio feeds & streaming
+description: How live scanner feeds like Broadcastify put local radio traffic on the internet — the encoder-to-server chain that streams your audio, and the legal, ethical, and reliability duties of running a feed responsibly.
+keywords: scanner feed, Broadcastify, audio streaming, live scanner audio, feed provider, streaming encoder, Icecast, scanner stream, online scanner, audio feed setup
+level: intermediate
+status: full
+prereq:
+  - logging-and-recording
+faq:
+  - q: How does a live scanner feed work?
+    a: Your receiver decodes audio as usual, an encoder on your computer compresses it into a streaming format and sends it to a feed provider's server, and the provider relays that stream to everyone listening on the web or an app. It's the same chain as any internet radio station — a source encoder pushing to a streaming server that fans the audio out to many listeners.
+  - q: What is Broadcastify?
+    a: Broadcastify is the largest public directory of live scanner audio feeds, an outgrowth of the RadioReference community. Volunteers run receivers and stream their local audio to Broadcastify's servers, which host thousands of feeds that anyone can listen to on the web or a phone app. It's how most people hear scanner traffic without owning a scanner.
+  - q: Is streaming a scanner feed legal?
+    a: In many places receiving and sharing unencrypted radio is legal, but the rules vary by country and even by state, and legality of receiving is not the same as legality of every use. Feed providers also impose their own rules — commonly no encrypted traffic and delays on sensitive channels. Check the law where you are and the provider's terms before you stream, the same care the legal-and-ethical lesson stresses.
+---
+
+# Audio feeds & streaming
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A **feed** puts your local scanner audio on the internet for anyone to hear. The
+chain is simple: your receiver decodes audio, an **encoder** compresses and pushes
+it to a **feed provider** like **Broadcastify**, and the provider relays it to every
+listener. Running a feed is a small broadcasting responsibility — keep it **reliable
+and identified**, and stay inside the **law and the provider's rules** (no encrypted
+traffic, delays where required). It's the same care the
+[legal & ethical](/learn/scanning/scanning-legal-and-ethical/) lesson stresses,
+applied to *sharing* rather than just listening.
+</div>
+
+Most people who have "listened to a scanner" have never owned one — they heard it on
+a phone app, streamed by a volunteer somewhere with a receiver and an internet
+connection. Those volunteers run **feeds**, and it's one of the most social things
+you can do in the hobby: your rooftop antenna becomes something the whole world can
+tune to. This lesson explains how a feed works and what running one responsibly asks
+of you.
+
+## The streaming chain
+
+A live feed is ordinary internet radio, and it has three links:
+
+1. **Source** — your receiver produces decoded audio, exactly as if you were
+   listening. For a trunked system that's the followed voice channel; for a
+   conventional channel it's whatever the squelch opens on.
+2. **Encoder** — software on your computer compresses that audio into a streaming
+   codec (MP3 or AAC, at a modest bitrate) and pushes it to the provider's server.
+   This is the same job an internet-radio broadcaster's encoder does.
+3. **Provider / server** — a service like Broadcastify receives your single stream
+   and **fans it out** to everyone listening, so you upload once no matter how many
+   people tune in. The provider also hosts the directory, the web player, and the
+   phone apps.
+
+You supply the first two links and a stable internet connection; the provider
+supplies the third. Your upstream bandwidth only ever carries **one** copy of the
+stream, which is why even a modest home connection can feed thousands of listeners.
+
+## Broadcastify and feed providers
+
+**Broadcastify** is the dominant public feed directory, grown out of the same
+[RadioReference](/learn/scanning/radioreference-database/) community that maintains
+the system database. Volunteers stream their local audio to its servers, and it hosts
+thousands of feeds that anyone can browse by location and listen to free. When you
+apply to run a feed, you typically pick the system or area it covers, get stream
+credentials, point your encoder at their server, and appear in the directory once
+it's live.
+
+Other providers and self-hosted options exist — you can run your own **Icecast**
+server and publish a stream yourself — but for reach and discoverability, a shared
+directory is where the listeners already are. The trade-off is that a directory
+imposes its own rules on top of the law, which is the next thing to get right.
+
+## Doing it responsibly
+
+Putting audio on the air, even relayed, is a small broadcasting responsibility, and
+feeds live or die on trust. A few duties come with it:
+
+- **Respect the law first.** Whether you may receive and re-share a given
+  transmission depends on where you are; receiving unencrypted traffic is broadly
+  permitted in many places, but not everywhere, and legality of *receiving* is not
+  legality of every *use*. Revisit
+  [legal & ethical scanning](/learn/scanning/scanning-legal-and-ethical/) before you
+  publish anything.
+- **Never stream encrypted traffic** even if you could — providers forbid it and it
+  serves no one, since it decodes to noise anyway.
+- **Follow the provider's channel rules.** Many require a broadcast delay or exclude
+  sensitive channels (tactical talkgroups, phone patches) to avoid interfering with
+  operations or exposing personal information.
+- **Keep it clean and identified.** A good feed is a stable, well-labelled stream of
+  the system it claims to carry — not a mix of half-tuned channels drifting in and
+  out.
+
+The guiding idea is the hobby's oldest: **receive freely, act responsibly.** A feed
+amplifies both — reaching more people and carrying more responsibility for what those
+people hear.
+
+## Reliability is the real work
+
+The technical setup is a one-evening job; keeping the feed *up* is the ongoing one.
+Listeners rely on it, and a feed that drops out during the one big incident of the
+month is the feed nobody trusts again. Reliability means the boring things: a
+receiver and computer that run unattended, an encoder that reconnects automatically
+when the network hiccups, and a machine that comes back on its own after a power
+blip.
+
+That's precisely the always-on discipline the
+[monitoring-post](/learn/scanning/building-a-monitoring-post/) lesson is about, and
+a public feed is one of the best reasons to build a post properly. If people are
+counting on your audio, "I'll restart it when I get home" isn't good enough.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — you upload one stream to the provider, and the provider's server fans it out to every listener." markdown="0">
+  <p class="knowledge-check__q">Quick check: when a thousand people listen to your feed, how many copies of the stream does your connection upload?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">One per listener — a thousand copies</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">One — the provider's server fans that single stream out to everyone</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">None — listeners connect directly to your receiver</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **feed** streams your local scanner audio to the internet through a
+  source → **encoder** → **provider** chain, the same as internet radio.
+- The provider (commonly **Broadcastify**) **fans out** your single uploaded stream
+  to every listener, so your bandwidth carries just one copy.
+- Streaming is **sharing**, which carries duties: obey the law, never stream
+  encrypted traffic, follow the provider's channel rules and delays.
+- Keep the feed **clean, labelled, and identified** — feeds run on the trust of the
+  people listening.
+- **Reliability** is the ongoing job; a public feed is a strong reason to build a
+  proper [monitoring post](/learn/scanning/building-a-monitoring-post/).
+
+Next up: [alerting on the calls you care about](/learn/scanning/alerting-on-calls/).

--- a/docs/learn/scanning/band-plans.md
+++ b/docs/learn/scanning/band-plans.md
@@ -1,0 +1,123 @@
+---
+slug: band-plans
+title: Band plans & where services live
+description: The radio spectrum has a floor plan — a band plan that tells you where public safety, business, aviation, marine, amateur, and other services live, so you know which slice to search instead of hunting the whole dial.
+keywords: band plan, radio spectrum, VHF low band, VHF high band, UHF, 700 800 MHz, public safety spectrum, aviation band, marine VHF, frequency allocation, where to scan
+level: intermediate
+status: full
+prereq:
+  - radioreference-database
+faq:
+  - q: What is a band plan?
+    a: A band plan is the agreed-upon layout of the radio spectrum — which ranges of frequency are set aside for which kinds of service. Regulators allocate bands to public safety, aviation, marine, business, amateur radio, and more, so a signal's frequency alone already tells you a lot about what it probably is.
+  - q: Do I need to memorise every frequency?
+    a: No. You need the shape of the map, not every street. Knowing that aircraft live around 108–137 MHz in AM, that marine sits near 156–162 MHz, and that modern public-safety trunking clusters in the 700/800 MHz range lets you point your search at the right neighbourhood. The exact channels you look up as you go.
+  - q: Are band plans the same everywhere?
+    a: The broad strokes are similar worldwide because international coordination keeps aviation and marine consistent, but the details differ by country. Public-safety allocations especially vary from one nation to the next, so confirm your own country's plan rather than assuming a list from elsewhere applies unchanged.
+---
+
+# Band plans & where services live
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+The spectrum isn't a random jumble — it has a **floor plan**. A **band plan** allocates ranges
+of frequency to services: **aviation**, **marine**, **business**, **amateur**, and the
+**public-safety** systems most scanning is about. Knowing the map means a signal's **frequency
+alone** already narrows down what it is, and it tells you which slice to
+[search](/learn/scanning/searching-and-discovery/) instead of hunting the whole dial. You don't
+memorise every channel — you learn the neighbourhoods, then look up the addresses.
+</div>
+
+A newcomer often imagines scanning as sweeping the entire radio spectrum looking for anything.
+That's a slow way to work, because the spectrum is already organised. Regulators divide it into
+**bands**, each set aside for particular kinds of use, and once you know which band a service
+lives in, you can point your search straight at it. This lesson is the map: the major bands, who
+lives there, and how the frequency of a signal is itself a clue.
+
+## Why the spectrum has a plan
+
+Radio waves don't respect borders, and two transmitters on the same frequency in the same place
+interfere. To keep the airwaves usable, national regulators — the FCC in the United States, and
+its equivalents elsewhere — coordinated internationally allocate slices of spectrum to specific
+**services**. Aviation gets one band, marine another, public safety several, and so on.
+
+For a scanner this planning is a gift. Because a fire department can't legally transmit in the
+aviation band, the frequency you hear something on already rules out most of what it could be.
+Frequency is your first and cheapest identification clue — long before you analyse the
+[signal's shape](/learn/rf-sdr/signal-anatomy/), its neighbourhood tells you the likely tenant.
+
+## The major bands, roughly
+
+Scanning mostly lives in the VHF and UHF ranges, with a few notable bands within them. The exact
+edges vary by country, but the character of each is broadly consistent:
+
+| Rough range | Common name | Who lives there |
+|-------------|-------------|-----------------|
+| 30–50 MHz | VHF low band | Older public safety, some utilities, long-range in odd conditions |
+| 108–137 MHz | Aircraft band | Aviation voice, **AM** mode, air traffic control |
+| 137–174 MHz | VHF high band | Public safety, business, marine (156–162), weather |
+| 225–400 MHz | Military air | Military aviation, AM |
+| 400–512 MHz | UHF | Business, public safety, some trunking |
+| 700 / 800 MHz | Public-safety trunking | Modern P25 and other trunked systems |
+
+A few landmarks are worth carrying in your head: **aircraft is AM** in the 118–137 MHz range,
+**marine VHF** clusters near 156–162 MHz, **weather radio** sits around 162.4–162.55 MHz, and
+**modern public-safety trunking** has largely migrated to the **700 and 800 MHz** bands. Those
+few anchors let you place most of what you'll hear.
+
+## Frequency as an identification clue
+
+Combine the band plan with a signal's basic characteristics and you can often name a transmission
+before you decode a word of it. A carrier at 121.5 MHz in **AM** with the tinny sound of an
+aircraft cockpit is almost certainly aviation. A brief **FM** exchange at 154 MHz is very likely
+public safety or business. A wall of continuous data at 851 MHz is a strong candidate for a
+[trunked control channel](/learn/digital-trunking/the-control-channel/).
+
+None of this is proof on its own, but it dramatically shrinks the search. When you reach the
+[identifying an unknown signal](/learn/scanning/identifying-unknown-signals/) lesson, the band
+is the first column of evidence you'll use, alongside bandwidth and modulation.
+
+## Where the interesting traffic clusters
+
+Because services are grouped, so is the traffic worth scanning. Public-safety dispatch on older
+conventional systems tends to sit in the VHF high band and the 450–470 MHz UHF range. The big
+county and state trunked systems dominate 700/800 MHz. Business and utility users spread across
+UHF. Aviation and marine each have their own tidy band. Knowing this lets you build a
+[search](/learn/scanning/searching-and-discovery/) plan that spends time where the action is,
+rather than sweeping quiet spectrum.
+
+It also tells you where *not* to look. Vast stretches of spectrum are allocated to services a
+scanner can't usefully hear — broadcast, cellular, satellite, radar — and skipping them keeps
+your search efficient.
+
+## Band plans change
+
+Allocations are not frozen. Spectrum gets **rebanded**, reallocated, and repurposed as needs
+shift — the migration of public safety to 700/800 MHz is a decades-long example still playing
+out. A band plan you learned years ago may have moved services around, and a database entry can
+lag a change on the air. Keep a current reference for your own country, and when a band seems
+oddly quiet or busy, check whether its allocation has shifted.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — aircraft voice lives around 108–137 MHz and uses AM, unlike the FM used by most land-mobile services." markdown="0">
+  <p class="knowledge-check__q">Quick check: you hear an AM voice transmission near 125 MHz. Which service is it most likely?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Marine VHF</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Aviation / air traffic control</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">An 800 MHz trunked system</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **band plan** allocates ranges of spectrum to services, so a signal's **frequency alone**
+  is an identification clue.
+- Scanning lives mostly in **VHF and UHF**, with landmark bands for **aviation** (AM),
+  **marine**, **weather**, and modern **700/800 MHz trunking**.
+- The band is the **first column of evidence** when identifying an unknown signal, alongside
+  bandwidth and mode.
+- Traffic **clusters** by service, so a good search plan spends time where the interesting
+  systems live and skips what a scanner can't hear.
+- Allocations **change** over time, so keep a current plan for your own country.
+
+Next up: [search, scan &amp; discovery](/learn/scanning/searching-and-discovery/).

--- a/docs/learn/scanning/building-a-monitoring-post.md
+++ b/docs/learn/scanning/building-a-monitoring-post.md
@@ -1,0 +1,138 @@
+---
+slug: building-a-monitoring-post
+title: Building an always-on monitoring post
+description: Go from "switch it on when I'm home" to a setup that runs unattended 24/7 — the low-power hardware, headless software, and reliability habits that make a monitoring post keep logging and recording while you're not watching.
+keywords: monitoring post, 24/7 scanner, unattended monitoring, headless SDR, always-on scanner, remote monitoring, low-power SDR server, scanner uptime, monitoring station, systemd scanner
+level: advanced
+status: full
+prereq:
+  - logging-and-recording
+  - alerting-on-calls
+faq:
+  - q: What is a monitoring post?
+    a: A receiver, antenna, and computer set up to run continuously and unattended — logging, recording, and alerting on radio traffic whether or not anyone is watching. Where a scanner on the desk is something you switch on, a monitoring post is something that's always on, so the interesting call at 3 a.m. is captured instead of missed.
+  - q: What hardware does an always-on post need?
+    a: Less than you'd think. A low-power computer like a Raspberry Pi or a small mini-PC, one or more SDR receivers, a good fixed antenna, and reliable power and network. The priorities shift from raw speed to running cool, quiet, and continuously — heat and power blips are the enemies of uptime, not CPU cycles.
+  - q: How do I make it recover on its own?
+    a: Run the software as a managed service that restarts on failure and starts on boot, so a crash or a power cut heals itself without you. On Linux that's typically a systemd unit. The goal is that after any hiccup — crash, reboot, network drop — the post comes back to full operation with no keyboard involved.
+---
+
+# Building an always-on monitoring post
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A **monitoring post** is a receiver, antenna, and computer built to run
+**unattended, around the clock** — so the interesting call at 3 a.m. is
+[logged and recorded](/learn/scanning/logging-and-recording/) instead of missed. The
+hardware is modest (a **low-power computer**, an SDR, a good fixed antenna); the real
+work is **reliability** — running **headless**, as a **managed service** that
+restarts on failure and boots on power-up, so any crash or outage heals itself. Build
+it to survive the hiccups you won't be there to fix.
+</div>
+
+Everything so far — logging, recording, tagging, feeds, alerting — assumes the setup
+is *running* when the traffic happens. A scanner on your desk only runs when you
+switch it on, which means it misses the overnight incident, the weekend call-out, the
+event you didn't know was coming. A **monitoring post** removes that gap: it's a
+station built to be always on, capturing continuously so you review at your
+convenience instead of listening in real time. This lesson is about crossing from
+"on when I'm home" to "on, full stop."
+
+## What changes when it's always on
+
+The shift from an attended scanner to an unattended post is less about capability
+than about **assumptions**. When you're sitting there, you're the error handler — you
+notice the lock dropped, restart the crashed program, re-tune after a glitch. An
+always-on post has no one in that chair, so every job you used to do by hand has to
+happen by itself.
+
+That reframes what "good" means. A desktop setup is judged on how well it decodes
+right now; a monitoring post is judged on how many days it runs **without you
+touching it**. Uptime, self-recovery, and unattended reliability become the headline
+features, and raw performance takes a back seat to not-falling-over.
+
+## Hardware for uptime, not speed
+
+The hardware is more modest than newcomers expect, because the priorities are
+different. You want gear that runs **cool, quiet, and continuously**:
+
+- **A low-power computer.** A Raspberry Pi or a small fanless mini-PC is plenty for
+  following a system or two, sips power, and makes no noise — ideal for something
+  that runs in a closet forever.
+- **One or more SDR receivers.** One SDR follows a system; add more to cover more
+  systems or sites at once, which is where dedicated software earns its keep.
+- **A good fixed antenna.** The single biggest factor in what you hear, and a post
+  rewards a proper permanent install — revisit
+  [antennas](/learn/scanning/antennas-for-scanning/) and
+  [feedlines](/learn/scanning/feedlines-and-connectors/) for the real gains.
+- **Reliable power and network.** Heat and power blips are the enemies of uptime, not
+  CPU cycles. Good ventilation and, if you can, a small battery backup keep a brief
+  outage from taking the post down.
+
+Notice raw speed isn't on the list. Decoding a control channel and a few voice
+channels is light work; the hard part is doing it for months without a stumble.
+
+## Headless and hands-off
+
+An always-on post usually runs **headless** — no monitor, no keyboard, tucked next to
+the antenna feedline and reached over the network. That's a feature: it can live
+wherever the antenna run is shortest, and you check on it from your laptop or phone.
+It does mean the software has to be operable without a screen in front of it — a web
+dashboard, a status page, remote logs — which is exactly how server software (and
+GopherTrunk) is built to run.
+
+Running headless also forces good hygiene. You can't rely on "I'll see it on the
+screen," so status has to be *reported*: uptime, current locks, recent calls, disk
+space. A post you can't check remotely is a post you're flying blind on.
+
+## Reliability: make it heal itself
+
+This is the heart of a monitoring post. Unattended means **self-recovering**: after
+any hiccup — a crashed decoder, a rebooted machine, a dropped network link — the post
+must return to full operation with no keyboard involved. The mechanism is to run the
+software as a **managed service** rather than a program you launched in a terminal.
+
+On Linux that's a service manager like **systemd**, covered in
+[services & systemd](/learn/linux-cli/services-and-systemd/): you define the decoder
+as a unit that **starts on boot** and **restarts on failure**, so a crash respawns in
+seconds and a power cut brings the whole post back by itself when the lights return.
+Layer on the basics — automatic disk pruning from your
+[retention policy](/learn/scanning/logging-and-recording/), an
+[alert](/learn/scanning/alerting-on-calls/) if the post goes quiet when it shouldn't —
+and you have a station that looks after itself. The test of a good post is simple:
+pull the power, plug it back in, walk away, and it's fully monitoring again before you
+reach the door.
+
+## Where to put it
+
+A little planning on **siting** pays off for years. Keep the feedline run to the
+antenna short (loss you spend once, forever), give the computer airflow, and put it
+somewhere power and network are stable and you can reach it remotely. An attic, a
+closet near the mast, or a shelf by the router are all common homes. The best
+monitoring post is one you set up once, site well, and then mostly forget about —
+because it just keeps running, and the archive just keeps filling.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — an always-on post must self-recover, so running the software as a managed service that restarts on failure and boots on power-up is the key." markdown="0">
+  <p class="knowledge-check__q">Quick check: what most defines a good always-on monitoring post?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">The fastest possible CPU so it can decode more channels</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">It self-recovers — running as a managed service that restarts on failure and boots on power-up</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">A monitor and keyboard attached so you can watch it constantly</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **monitoring post** runs **unattended, 24/7**, so overnight and weekend traffic
+  is captured instead of missed.
+- The mindset shifts from raw performance to **uptime and self-recovery** — no one is
+  there to handle errors by hand.
+- The hardware is modest: a **low-power computer**, one or more SDRs, a good **fixed
+  antenna**, and reliable power and network that run cool and continuously.
+- Run it **headless** and report status remotely, since there's no screen in front of
+  it.
+- Make it **heal itself** — a **managed service** (systemd) that restarts on failure
+  and boots on power-up, plus disk pruning and a quiet-post alert.
+
+Next up: [scanning with SDR software](/learn/scanning/scanning-with-sdr-software/).

--- a/docs/learn/scanning/choosing-a-scanner.md
+++ b/docs/learn/scanning/choosing-a-scanner.md
@@ -1,0 +1,142 @@
+---
+slug: choosing-a-scanner
+title: Choosing a scanner or SDR
+description: How to match a receiver to what you actually want to hear — the bands it must cover, the trunking and digital modes your local systems use, and your budget — so you buy the right scanner or SDR the first time instead of the wrong one twice.
+keywords: choosing a scanner, best scanner for beginners, digital trunking scanner, which SDR to buy, RTL-SDR Airspy, scanner buying guide, P25 scanner, band coverage
+level: beginner
+status: full
+prereq:
+  - scanners-vs-sdr
+faq:
+  - q: How do I choose the right scanner?
+    a: Work backwards from what you want to hear. Look up your local systems in a database, note which bands they use and whether they are conventional, trunked, or digital and in which mode. Then buy a receiver that covers those bands and supports those modes. The most common beginner mistake is buying on price or brand first and discovering the local system uses a mode the receiver cannot follow.
+  - q: What's the cheapest way to start?
+    a: An RTL-SDR dongle plus a computer you already own is the lowest-cost entry, and with software like GopherTrunk it can follow unencrypted digital trunked systems. If you would rather have a self-contained box, entry-level analog scanners are inexpensive but cannot follow digital trunking — check that your local traffic is analog before choosing one, or you will need to upgrade.
+  - q: Do I need a digital scanner?
+    a: Only if the systems you care about are digital. Many areas still have plenty of analog traffic, and an analog scanner covers it cheaply. But if your local public safety runs P25, DMR, NXDN, or TETRA, you need a digital-capable receiver — a digital trunk-tracking scanner or an SDR with software that decodes that mode. The database listing for your area tells you which.
+---
+
+# Choosing a scanner or SDR
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Choose by **working backwards from what you want to hear**, not from price or brand.
+Look up your local systems, note the **bands** they use and whether they are
+**conventional, trunked, or digital** (and in which mode — P25, DMR, NXDN, TETRA), then
+buy a receiver that **covers those bands and decodes those modes**. The classic mistake
+is buying first and discovering the local system uses a mode your radio can't follow.
+For SDR, [front-end quality](/learn/rf-sdr/front-end-and-overload/) matters as much as
+raw specs.
+</div>
+
+The [previous lesson](/learn/scanning/scanners-vs-sdr/) framed the two roads — a
+dedicated scanner or an SDR with software. This one helps you pick a specific receiver
+without wasting money. The single most important idea is that the *right* choice is
+defined by *your local spectrum*, so the process starts with research, not shopping.
+
+## Start with what you want to hear
+
+Before you look at a single product, answer this: **what systems do you actually want to
+follow?** Open a database like [RadioReference](/learn/scanning/radioreference-database/)
+for your county or region and read the entries for the agencies and services you care
+about. For each, note three things:
+
+1. **The band(s)** — VHF low, VHF high, UHF, 700/800 MHz, and so on.
+2. **Conventional or trunked** — and if trunked, the **system type**.
+3. **Analog or digital** — and if digital, the **mode** (P25 Phase 1/2, DMR, NXDN,
+   TETRA).
+
+Those three facts are your **requirements list**. Every candidate receiver either meets
+them or it doesn't, and that turns a bewildering market into a simple filter. Buying
+before you have this list is how people end up with a scanner that hears everything
+except the one system they bought it for.
+
+## Match the bands
+
+A receiver only hears the frequency ranges it is built to cover. Most modern scanners and
+general-coverage SDRs span the common scanning bands (roughly VHF through 800 MHz), but
+**check** — some cheap or specialised receivers have gaps, and a few services live in
+unusual ranges. If your target system is on 800 MHz, a receiver that stops at 512 MHz is
+useless for it no matter how good it otherwise is. Match coverage to the bands on your
+requirements list first; it is a hard yes/no.
+
+## Match trunking and digital support
+
+This is where most upgrades — and most regrets — happen. Two capabilities are separate,
+and you may need both:
+
+- **Trunk-tracking.** To follow a *trunked* system the receiver must decode its
+  **[control channel](/learn/digital-trunking/the-control-channel/)** and chase grants.
+  An analog-only or conventional-only scanner cannot do this, period.
+- **Digital decoding.** To hear *digital voice* the receiver must decode the specific
+  **mode**. "Digital" is not one thing — a P25 scanner does not automatically do DMR or
+  NXDN, and a receiver that does P25 Phase 1 may not do Phase 2.
+
+So a modern public-safety system that is *P25 Phase 2 trunked* demands a receiver that
+does **both** P25 Phase 2 and trunk-tracking. On the SDR side, GopherTrunk supplies the
+trunk-tracking and multi-protocol decoding in software, so a plain wideband dongle can
+follow systems a fixed analog scanner never could — one of the strongest arguments for
+the SDR road when your local systems are digital and trunked.
+
+## For SDRs, mind the front end
+
+If you go the SDR route, resist judging a receiver on headline numbers alone. The
+**front end** — how well the receiver handles strong signals without distorting — matters
+enormously in the real world, especially in a city crowded with broadcast, cellular, and
+pager transmitters. A cheap dongle can **[overload](/learn/rf-sdr/front-end-and-overload/)**
+in that environment, producing phantom signals and desensitisation. The very cheapest
+RTL-SDR dongles are a superb, low-risk way to learn, and often enough; stepping up to a
+better-filtered SDR buys headroom in tough RF conditions. Either way, factor a decent
+**[antenna](/learn/scanning/antennas-for-scanning/)** into the budget — it does more for
+what you hear than a receiver upgrade of the same money.
+
+## Match the budget honestly
+
+Money spent in the wrong place is the real waste, so spend it in this order:
+
+- **Meet the requirements first.** A receiver that cannot decode your local mode is not a
+  bargain at any price — it simply doesn't do the job.
+- **Then invest in the antenna and feedline.** These set the ceiling on everything and are
+  usually the highest-value dollars in the whole station.
+- **Then chase nice-to-haves.** Better ergonomics, a nicer display, a stronger SDR front
+  end, more memory — real improvements, but only after the essentials are met.
+
+Rough shape of the market: entry-level **analog** scanners are cheap but analog-only;
+**digital trunk-tracking** scanners cost considerably more; an **RTL-SDR dongle** is the
+least-cost entry to digital trunk-tracking *if you already have a computer*, with
+better-filtered SDRs available as you outgrow it. There is no single "best" — only the
+cheapest thing that satisfies your requirements list.
+
+## Don't forget the ecosystem
+
+A receiver is easier to live with when it plays well with the rest of the hobby:
+database-driven programming (so you can load your county in a few clicks), an active
+community, and — for SDRs — well-supported software. GopherTrunk, for instance, is built
+to turn a supported SDR into a trunk-tracking scanner, so choosing hardware GopherTrunk
+handles well saves you friction later. A slightly cheaper receiver that fights you at
+every step is no bargain.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the receiver must cover the band AND decode the exact trunking and digital mode your local system uses." markdown="0">
+  <p class="knowledge-check__q">Quick check: your local public safety runs a P25 Phase 2 trunked system. What must your receiver do?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Only cover the 800 MHz band — any scanner that reaches it will work</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Cover the band and both trunk-track and decode P25 Phase 2 — coverage alone isn't enough</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Support encryption keys so it can unscramble the digital voice</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Work backwards from what you want to hear**: list each local system's **band**,
+  **conventional/trunked**, and **analog/digital mode** — that's your requirements list.
+- **Match coverage** first (a hard yes/no) and then **trunking + digital support** —
+  "digital" is not one mode, and trunk-tracking is separate from decoding.
+- For **SDRs**, weigh **front-end quality**, not just headline specs — cheap dongles can
+  [overload](/learn/rf-sdr/front-end-and-overload/) in a noisy city.
+- **Spend in order**: meet requirements, then the **antenna and feedline**, then
+  nice-to-haves.
+- Favour receivers with a good **ecosystem** — database programming, community, and
+  software support like GopherTrunk.
+
+Next up: [Antennas for scanning](/learn/scanning/antennas-for-scanning/).

--- a/docs/learn/scanning/contributing-and-community.md
+++ b/docs/learn/scanning/contributing-and-community.md
@@ -1,0 +1,137 @@
+---
+slug: contributing-and-community
+title: The community & contributing data
+description: The scanning hobby runs on shared knowledge — the forums, the databases like RadioReference, the live feeds, and the open-source decoders — and this is how to give back the systems, talkgroups, and fixes you discover.
+keywords: scanning community, contributing data, RadioReference submission, talkgroup submission, open source radio, giving back, scanner forums, community database, feed volunteer, GopherTrunk contribute
+level: beginner
+status: full
+prereq:
+  - radioreference-database
+faq:
+  - q: How can I contribute to the scanning community?
+    a: Several ways, all valuable. Submit new or corrected system and talkgroup information to databases like RadioReference. Run a live feed so others can hear your area. Share findings and help newcomers on forums. And if you use open-source software like GopherTrunk, contribute captures, bug reports, protocol details, or code. The hobby is a commons — most of what you rely on was contributed by someone before you.
+  - q: What kind of data is most useful to submit?
+    a: The things a database can't know without a local listener — new control-channel frequencies, talkgroup IDs and their real-world purpose, aliases, and corrections when a system rebands or changes. You did the identifying work by listening; writing it back is what keeps the shared map accurate for the next person.
+  - q: Do I need to be an expert to give back?
+    a: No. Correcting one wrong talkgroup, confirming a frequency still works, answering a beginner's question, or filing a clear bug report all help. Contribution scales from a one-line correction to running a feed or writing a decoder. Everyone starts by consuming the commons; giving back begins the moment you've learned something worth passing on.
+---
+
+# The community & contributing data
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Almost everything you've relied on in this module — the
+[databases](/learn/scanning/radioreference-database/), the
+[feeds](/learn/scanning/audio-feeds-and-streaming/), the open-source decoders — was
+**contributed by other listeners**. The hobby is a **commons**, and it stays accurate
+only because people write back what they learn. You give back by **submitting system
+and talkgroup data**, **running a feed**, **helping newcomers on forums**, and
+**contributing to open-source projects** like GopherTrunk. Contribution scales from a
+one-line correction to a whole decoder — and it starts the moment you've learned
+something worth passing on.
+</div>
+
+Scanning looks like a solitary hobby — you and a receiver — but it runs almost
+entirely on shared knowledge. The database that told you what's on the air, the feed
+you listened to before you owned a scanner, the software that decodes a protocol you'd
+never reverse-engineer alone: every one of those is the accumulated work of a
+community. This lesson is about the other direction — how to give back, and why it
+matters more than it looks.
+
+## The hobby is a commons
+
+Think about what got you this far. You looked up systems in
+[RadioReference](/learn/scanning/radioreference-database/), which is filled in by
+volunteers. You may have heard scanner audio on a
+[feed](/learn/scanning/audio-feeds-and-streaming/) run by someone with a rooftop
+antenna. You're decoding with software written and maintained in the open. None of
+that is a product you bought — it's a **commons**, maintained by people who
+contributed a little more than they took.
+
+A commons only stays healthy if it's replenished. Databases go stale when systems
+reband and nobody updates them; feeds go dark when the last volunteer in an area quits;
+open-source decoders stagnate without new captures and fixes. The hobby's continued
+existence isn't automatic — it's the sum of small contributions, and once you've
+benefited from it, you're in a position to add to it.
+
+## Contribute what only a listener knows
+
+The most valuable thing you can give is exactly what you produced by
+[identifying signals](/learn/scanning/identifying-unknown-signals/) and
+[building your frequency records](/learn/scanning/frequency-records/): local knowledge
+a remote database can't have. Specifically:
+
+- **New systems and control channels** — a county system that isn't documented yet,
+  or a [control channel you found by hunting](/learn/scanning/searching-and-discovery/).
+- **Talkgroup IDs and their real-world purpose** — which talkgroup is dispatch, which
+  is a tac channel, and the aliases that make a log readable.
+- **Corrections** — a frequency that moved, a system that rebanded, an alias that was
+  wrong. Corrections are as valuable as new data, because stale data quietly misleads
+  everyone downstream.
+
+Submitting this back to RadioReference (or a similar database) is often a simple form.
+You already did the hard part by listening; writing it down for the next person is the
+small step that keeps the shared map true.
+
+## Run a feed, help newcomers
+
+Beyond data, two of the most useful contributions are time and patience. **Running a
+[feed](/learn/scanning/audio-feeds-and-streaming/)** puts your area on the air for
+everyone who can't listen locally — sometimes the only public monitoring an entire
+region has. And **helping newcomers** on forums and community sites is how the hobby
+reproduces itself: the questions you struggled with a month ago are the ones someone
+is asking today, and a clear answer saves them the time you lost. Neither requires
+expertise — just a willingness to share what you now know.
+
+## Contribute to open source
+
+If you scan with open software like **GopherTrunk**, you can give back to the tool
+itself, and this is where the scanning hobby meets software development. Useful
+contributions come in many sizes:
+
+- **Captures** — a recorded IQ file of a system that decodes poorly is often the
+  single most useful thing a developer can receive, because it lets them reproduce and
+  fix the exact problem you hit. (This is a recurring theme in GopherTrunk's own
+  history — the real fix usually starts with the reporter's capture.)
+- **Bug reports** — clear, specific, reproducible reports of what failed, on what
+  system, with what symptom.
+- **Protocol details** — documentation, field observations, or corrections about how a
+  system behaves on the air.
+- **Code** — fixes and features, if you're inclined and able.
+
+You don't need to write a line of Go to help; a good capture and a clear report move a
+decoder forward as much as a patch. The [project home](/) is where to start, and it's
+the natural bridge to the software side of the hobby that the final lesson points you
+toward.
+
+## Start small, give back anyway
+
+None of this asks for expertise. Correct one talkgroup. Confirm a frequency still
+works. Answer one beginner's question. File one clear bug report with a capture
+attached. Every person who maintains the commons you've been using started exactly
+there — consuming it, then noticing they'd learned something worth passing on. The
+moment you have is the moment to begin.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a recorded IQ capture of a poorly-decoding system lets a developer reproduce and fix the exact problem, making it one of the most useful contributions." markdown="0">
+  <p class="knowledge-check__q">Quick check: what's often the single most useful thing you can give an open-source decoder project?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">A screenshot of the software running correctly</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">A recorded IQ capture of a system that decodes poorly, so the problem can be reproduced</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">A donation of a faster computer to the developers</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- The scanning hobby is a **commons** — databases, feeds, and open-source decoders,
+  all maintained by contributing listeners — and it stays healthy only if replenished.
+- Contribute the **local knowledge only a listener has**: new systems and control
+  channels, talkgroup IDs and purposes, and **corrections** when systems change.
+- **Run a feed** and **help newcomers** — time and patience are as valuable as data.
+- For open software like **GopherTrunk**, **IQ captures** and clear **bug reports**
+  are often the most useful contributions, no code required.
+- Contribution **scales from a one-line correction to a decoder** — start small, and
+  start as soon as you've learned something worth sharing.
+
+Next up: [where to go next](/learn/scanning/where-to-go-next/).

--- a/docs/learn/scanning/conventional-vs-trunked-recap.md
+++ b/docs/learn/scanning/conventional-vs-trunked-recap.md
@@ -1,0 +1,145 @@
+---
+slug: conventional-vs-trunked-recap
+title: Conventional vs. trunked, in the field
+description: "The one distinction that changes how you scan — a conventional channel you can park on versus a trunked system you have to follow. Seen from the listener's chair: what each sounds like, what you program, and why trunk-tracking exists."
+keywords: conventional vs trunked, trunked radio scanning, conventional channel, control channel, trunk tracking, following a call, scanning a trunked system, talkgroup
+level: beginner
+status: full
+prereq:
+  - what-is-scanning
+  - history-of-scanning
+faq:
+  - q: What is the practical difference between conventional and trunked scanning?
+    a: On a conventional system each channel lives on a fixed frequency, so you can park your scanner on it and hear everything said there. On a trunked system the frequencies are pooled and handed out per call by a control channel, so a single conversation hops between frequencies. To follow trunked traffic your scanner must decode the control channel and chase each grant — you cannot just sit on one voice frequency.
+  - q: How do I tell if a system is trunked?
+    a: A trunked system has a control channel — a carrier that transmits data continuously and never goes quiet — alongside voice channels that light up only during calls. In a database like RadioReference a system is labelled conventional or trunked, with the trunked entries listing a control channel and talkgroups rather than named channel frequencies. On the air, the always-on data carrier is the giveaway.
+  - q: Can one scanner do both?
+    a: Yes. A trunk-tracking scanner (or SDR software like GopherTrunk) handles both — it can park on conventional channels and follow trunked systems in the same scan. An older analog-only scanner can do conventional but cannot follow trunking, which is the main reason people upgrade.
+---
+
+# Conventional vs. trunked, in the field
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+This is the single distinction that changes *how you scan*. A **conventional** channel
+lives on a **fixed frequency** — park on it and you hear everything. A **trunked**
+system **pools frequencies and hands them out per call**, coordinated by a
+**[control channel](/learn/digital-trunking/the-control-channel/)**, so one conversation
+hops around the pool. To follow trunked traffic your scanner must **read the control
+channel and chase the grants** — which is exactly why trunk-tracking scanners and
+GopherTrunk exist. The [theory lives in the digital
+module](/learn/digital-trunking/conventional-vs-trunked/); this is the view from your
+chair.
+</div>
+
+You met these two families in passing in the
+[first lesson](/learn/scanning/what-is-scanning/), and the
+[history](/learn/scanning/history-of-scanning/) explained why trunking forced a new kind
+of scanner. Now we look at the difference the way a listener experiences it — because it
+decides what you program, what you hear, and why some systems seem to fall apart on an
+older radio.
+
+## Conventional: a channel you can park on
+
+A **conventional** system is the intuitive kind. Each logical channel — dispatch,
+tactical 1, fireground, public works — is a **fixed frequency**. "Dispatch" is always
+on, say, 154.250 MHz, and it is always there. If you want to hear dispatch, you program
+that frequency and you are done; the traffic comes and goes on that one carrier.
+
+From the listener's chair this is wonderfully simple:
+
+- **One channel = one frequency.** Program it once and it never moves.
+- **You can park.** Sit on the frequency and you hear every transmission on it,
+  start to finish.
+- **What you load is what you hear.** A list of conventional frequencies is a complete,
+  self-contained scan — no extra machinery required.
+
+Plenty of the spectrum is still conventional: many fire and EMS operations, business
+radios, aviation, marine, rail, amateur repeaters, and smaller agencies. For all of
+these, an ordinary programmable scanner parked on the right frequencies does the whole
+job.
+
+## Trunked: a system you have to follow
+
+A **trunked** system is designed to serve many talkgroups with only a handful of
+frequencies, by refusing to tie any conversation to a fixed channel. Instead the system
+keeps a **pool** of voice frequencies and a controlling computer that hands them out on
+demand. When a radio keys up, the system finds a free frequency in the pool, assigns the
+call to it, and tells everyone involved where to go — all over a
+**[control channel](/learn/digital-trunking/the-control-channel/)**.
+
+The consequence for you is decisive: **a single conversation is not on any fixed
+frequency**. The first call of the day might be assigned frequency A; the next call on
+the very same talkgroup might land on frequency C; the one after that on frequency B.
+Park on frequency A and you will hear a random scrap of one call and then silence, while
+the conversation you wanted continues elsewhere. This is precisely the chaos that broke
+conventional scanners when trunking arrived.
+
+## The control channel is the map
+
+What makes a trunked system followable is that all of this assignment traffic is out in
+the open on the control channel. The **control channel** transmits data **continuously**
+— it never goes quiet — announcing every call: *talkgroup 1234 is now on frequency C.*
+A trunk-tracking scanner decodes that stream and, the instant it sees a grant for a
+talkgroup you care about, **jumps to the assigned frequency** to hear the call, then
+returns to the control channel to wait for the next one.
+
+So following a trunked system is a two-step dance the radio does for you:
+
+1. **Lock the control channel** and read its running commentary of grants.
+2. **Follow each grant** to its voice frequency, listen, and come back.
+
+You program the *system* — its control-channel frequency and the talkgroups you want —
+rather than a list of voice frequencies. The digital module details the signalling in
+[the control channel](/learn/digital-trunking/the-control-channel/) and identity in
+[talkgroups & affiliation](/learn/digital-trunking/talkgroups-ids-affiliation/); the
+field-side steps come later in this module in
+[programming a trunked system](/learn/scanning/programming-a-trunked-system/) and
+[following a call](/learn/scanning/following-a-call/).
+
+## Talkgroups replace channels
+
+On a conventional system you think in **channels** (frequencies). On a trunked system
+you think in **talkgroups** — logical groups like "City Fire Dispatch" or "PD North
+Patrol" that exist independently of any frequency. A talkgroup is an *identity* the
+system routes to whatever frequency is free, and it is the unit you select, prioritise,
+and lock out. Learning to think in talkgroups instead of frequencies is the mental shift
+trunked scanning demands, and we build scan lists out of them in
+[talkgroups & scan lists](/learn/scanning/talkgroups-and-scan-lists/).
+
+## Telling them apart
+
+In practice you rarely have to guess. A database like
+[RadioReference](/learn/scanning/radioreference-database/) labels each system as
+conventional or trunked: conventional entries list named channel frequencies, while
+trunked entries list a control channel, a system type (P25, DMR, and so on), and
+talkgroups. On the air, the signature is the **always-on control-channel carrier** — a
+data stream that never pauses — sitting among voice channels that flicker only during
+calls. That constant carrier is the surest sign you are looking at a trunked system, and
+[finding it](/learn/digital-trunking/the-control-channel/) is the first step to following
+the system.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — on a trunked system a single call can be assigned to any frequency in the pool, so you must follow the control channel." markdown="0">
+  <p class="knowledge-check__q">Quick check: why can't you just park on one voice frequency to follow a trunked conversation?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Because voice frequencies on trunked systems are always encrypted</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Because the system assigns each call to whatever frequency is free, so the conversation hops around the pool</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Because trunked voice channels only transmit for one second at a time</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Conventional** = a channel on a **fixed frequency**; park on it and hear everything.
+  Simple to program, still common across many services.
+- **Trunked** = a **pool of frequencies handed out per call**, so a conversation hops
+  around and you cannot park on it.
+- The **control channel** announces every grant continuously; a trunk-tracking scanner
+  reads it and **follows each call** to its assigned frequency.
+- You program a trunked **system and its talkgroups**, not a list of voice frequencies —
+  and you think in **talkgroups** instead of channels.
+- Tell them apart via a **database label** or the **always-on control-channel carrier**
+  on the air.
+
+Next up: [What you can (and can't) hear today](/learn/scanning/what-you-can-hear/).

--- a/docs/learn/scanning/feedlines-and-connectors.md
+++ b/docs/learn/scanning/feedlines-and-connectors.md
@@ -1,0 +1,150 @@
+---
+slug: feedlines-and-connectors
+title: Feedlines, connectors & grounding
+description: The unglamorous parts that quietly cost you signal — coax feedline loss that worsens with frequency and length, the SMA/BNC/N/PL-259 connectors that join it all, and how to ground an outdoor antenna safely against static and lightning.
+keywords: coax feedline, coax loss, scanner connectors, SMA BNC N PL-259, feedline loss frequency, antenna grounding, lightning protection, low-loss coax, adapter loss
+level: intermediate
+status: full
+prereq:
+  - antennas-for-scanning
+faq:
+  - q: Does coax type really matter for receiving?
+    a: Yes, more than people expect, and more at higher frequencies and longer runs. Cheap thin coax can lose a large fraction of your signal over a long run at UHF, undoing a good antenna. For a short desk jumper it barely matters; for a run up to a rooftop antenna, better low-loss coax is worth it. Keep runs as short as practical and use quality cable for the length you do need.
+  - q: Why do connectors and adapters cost signal?
+    a: Every connector and every adapter introduces a small loss and a small impedance discontinuity, and stacking several adapters multiplies the effect. A tower of SMA-to-BNC-to-N adapters can quietly eat a meaningful fraction of a decibel and add failure points. Use the right single connector where you can, keep adapter stacks short, and make sure each connection is clean and tight.
+  - q: Do I need to ground an outdoor antenna?
+    a: If your antenna is outdoors, especially up high, grounding is a safety matter, not an optional upgrade. A proper ground and a lightning arrestor bleed off static build-up and give a nearby strike a path to earth other than through your equipment and home. Follow local electrical codes and, if unsure, have it done properly — this is the one part of the hobby where getting it wrong is dangerous.
+---
+
+# Feedlines, connectors & grounding
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Between the [antenna](/learn/scanning/antennas-for-scanning/) and the receiver sits the
+**feedline**, and it quietly costs you signal. **Coax loss grows with frequency and
+length**, so keep runs **short** and use **low-loss cable** for the length you need.
+Every **connector and adapter** (SMA, BNC, N, PL-259) adds a little loss — don't build
+adapter towers. And any **outdoor antenna must be grounded**, with a lightning
+arrestor, for **safety** — this is the one place in the hobby where getting it wrong is
+dangerous, so follow local code.
+</div>
+
+The [last lesson](/learn/scanning/antennas-for-scanning/) got a good antenna up high. Now
+the signal has to travel down to your receiver without leaking away — and the antenna has
+to be safe up there. This lesson covers the plumbing: coax, connectors, and grounding.
+None of it is glamorous, and all of it can undo the work you just did on the antenna if
+you get it wrong.
+
+## Coax loss: the tax on every metre
+
+The cable that carries your signal from the antenna to the receiver is **coaxial cable —
+coax** — and it is not lossless. Every metre absorbs a fraction of a
+[decibel](/learn/rf-sdr/antennas/), and two things make that worse:
+
+- **Higher frequency.** Coax loss climbs with frequency. The same cable that barely
+  touches a VHF signal can eat a serious chunk of an 800 MHz one.
+- **Longer runs.** Loss accumulates with length. A short jumper is nearly free; a long run
+  up to a rooftop antenna is where it bites.
+
+The two combine into the practical rule: **the higher your band and the longer your run,
+the more the cable matters.** A long, thin, cheap coax at UHF can throw away much of the
+signal your good antenna just captured — the classic way a strong antenna is quietly
+wasted.
+
+## Choosing and running coax
+
+You do not need exotic cable, just the right cable for the job:
+
+- **Keep runs short.** The cheapest loss reduction is fewer metres. Mount the receiver
+  (or an SDR) as close to the antenna as practical, and don't coil up excess cable "just
+  in case."
+- **Match the cable to the length.** For a short desk jumper, thin flexible coax is fine.
+  For a long rooftop run, step up to a proper **low-loss** coax — the extra cost buys back
+  decibels you would otherwise lose every second.
+- **Weatherproof outdoor connections.** Water in coax is ruinous. Seal outdoor connectors
+  against the weather so the cable doesn't slowly fill and rot.
+- **Mind the bends.** Sharp kinks damage coax and change its behaviour; keep bends gentle.
+
+Think of it as a budget: you spent effort getting signal onto the antenna, and the coax is
+where you can either preserve it or throw it away.
+
+## Connectors you'll meet
+
+The cable ends in **connectors**, and the scanning world uses a handful. You met these in
+[Antennas 101](/learn/rf-sdr/antennas/); here they are with where each turns up:
+
+| Connector | Where you'll see it |
+|-----------|---------------------|
+| SMA | Most RTL-SDR dongles and small antennas |
+| MCX | Some SDR dongles |
+| BNC | Handheld scanners, lab gear — quick twist-lock |
+| N | Larger outdoor antennas and low-loss runs |
+| PL-259 / SO-239 (UHF) | Common on scanner antennas and mounts |
+
+The practical point is that your antenna and your receiver often **don't share a
+connector**, so you will need an **adapter** — SMA-to-BNC, N-to-SMA, and so on.
+
+## Every connection is a small tax
+
+Each connector and each adapter introduces a **small loss** and a tiny impedance bump, and
+— crucially — the effect **stacks**. A tower of three adapters chaining SMA to BNC to N to
+PL-259 adds up to a measurable loss and, worse, several extra points that can loosen,
+corrode, or fail. The habits that keep this in check:
+
+- **Use the right single connector** where you can, rather than adapting through several.
+- **Keep adapter stacks short** — one adapter is fine, a tower of four is asking for
+  trouble.
+- **Keep every connection clean and tight.** A loose or corroded connector is intermittent
+  signal and maddening noise.
+
+None of this is dramatic on its own, but combined with a long lossy coax it is exactly how
+a good antenna ends up sounding mediocre.
+
+## Grounding and lightning: the safety part
+
+Everything above is about signal. **Grounding is about safety**, and it is not optional
+for an outdoor antenna. A metal antenna up high does two dangerous things: it accumulates
+**static charge** from the atmosphere, and it presents an attractive path for a nearby
+**lightning** strike. Without a proper ground, both look for a route to earth — and that
+route can be through your coax, your receiver, and your house wiring.
+
+The essentials, done to **local electrical code**:
+
+- **Ground the antenna mast and system** to a proper earth ground, so static bleeds off
+  harmlessly instead of building up.
+- **Fit a lightning arrestor** in the coax line where it enters the building, bonded to
+  ground, to divert surge energy away from your equipment.
+- **Disconnect during storms.** Even with protection, unplugging the antenna during an
+  electrical storm is cheap insurance for your gear.
+- **When in doubt, get it done properly.** This is the one area of the hobby where a
+  mistake risks your equipment, your home, and your safety — not just a weak signal.
+
+Grounding earns no better reception, but it is what makes an outdoor antenna a safe,
+long-term part of your station rather than a liability. With the antenna up, fed, and
+grounded, the next step is assembling it all into a working
+[station](/learn/scanning/station-setup/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — coax loss grows with both frequency and length, so it bites hardest on long UHF/800 MHz runs." markdown="0">
+  <p class="knowledge-check__q">Quick check: where does coax feedline loss hurt the most?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">On a short jumper at low VHF frequencies</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">On a long run at high frequencies like 800 MHz — loss grows with both length and frequency</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It's the same regardless of frequency or cable length</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Coax loss grows with frequency and length** — it bites hardest on long runs at high
+  bands, and can quietly undo a good antenna.
+- **Keep runs short**, use **low-loss coax** for the length you need, weatherproof outdoor
+  connections, and avoid sharp bends.
+- Learn the **connectors** (SMA, MCX, BNC, N, PL-259) and expect to need an **adapter** to
+  join antenna to receiver.
+- **Every connector and adapter adds a small loss that stacks** — use the right single
+  connector, keep adapter towers short, keep connections clean and tight.
+- **Ground any outdoor antenna** and fit a **lightning arrestor** for **safety** — follow
+  local code, disconnect in storms, and get it done properly if unsure.
+
+Next up: [Setting up your station](/learn/scanning/station-setup/).

--- a/docs/learn/scanning/following-a-call.md
+++ b/docs/learn/scanning/following-a-call.md
@@ -1,0 +1,126 @@
+---
+slug: following-a-call
+title: Following a call across the system
+description: What happens in the seconds after a radio keys up on a trunked system — how the control channel grants a voice channel, how your receiver jumps to it, plays the call, and returns, and why calls sometimes clip at the start or hop mid-conversation.
+keywords: following a call, trunked call, voice grant, channel grant, control channel to voice, call sequence, trunk tracking, missed call start, late entry, GopherTrunk following
+level: intermediate
+status: full
+prereq:
+  - talkgroups-and-scan-lists
+faq:
+  - q: What happens when someone keys up on a trunked system?
+    a: The radio asks the system for a channel, the control channel grants one and announces it, and every radio in that talkgroup — and your receiver — tunes to the assigned voice channel to hear the call. When the talker unkeys, the channel is released back to the pool. The whole grant-and-tune happens in a fraction of a second.
+  - q: Why do I sometimes miss the first word of a call?
+    a: Because your receiver has to read the grant on the control channel and retune to the voice channel before it can play audio, and that takes a moment. On most systems it's quick enough to catch the whole call, but a slow retune, a weak control channel, or a call you join late can clip the opening syllable.
+  - q: Why does a call sometimes jump to a different frequency mid-conversation?
+    a: On some systems a long call can be reassigned to a different voice channel, and the control channel announces the move. A receiver following the control channel reads the update and hops along automatically. If it doesn't hop cleanly, you hear the call cut off — usually a sign the control channel decode is marginal.
+---
+
+# Following a call across the system
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A trunked call is a **fast handshake**. A radio keys up, the
+[control channel](/learn/digital-trunking/the-control-channel/) **grants** a voice channel and
+announces it, and your receiver **jumps** to that frequency, plays the call, and returns to the
+control channel to wait for the next one — all in a fraction of a second. Understanding this
+sequence explains the quirks: why the **first word** sometimes clips, why a call can **hop**
+mid-conversation, and why everything depends on a clean control-channel decode. The full protocol
+view is in [anatomy of a call](/learn/digital-trunking/anatomy-of-a-call/).
+</div>
+
+You've built your [scan lists](/learn/scanning/talkgroups-and-scan-lists/); now watch what happens
+when one of those talkgroups actually keys up. A trunked call is over in seconds, but a lot happens
+in those seconds, and knowing the sequence turns puzzling behaviour — clipped starts, sudden hops,
+calls you almost catch — into something you can read and, when needed, fix. This lesson walks the
+call from key-up to release from the listener's chair.
+
+## The sequence, step by step
+
+When a user presses the transmit key on a trunked radio, a quick exchange unfolds:
+
+1. **Request.** The radio sends a channel request to the system over the control channel — "this
+   talkgroup wants to talk."
+2. **Grant.** The system picks a free voice channel and the control channel **announces the grant**:
+   this talkgroup, on that frequency.
+3. **Tune.** Every radio in the talkgroup — and your receiver — reads the grant and **retunes** to
+   the assigned voice channel.
+4. **Talk.** The voice rides on that channel until the user unkeys.
+5. **Release.** The channel returns to the shared pool, free for the next call, and the receiver
+   goes back to watching the control channel.
+
+The [anatomy of a call](/learn/digital-trunking/anatomy-of-a-call/) lesson covers the protocol-level
+detail; what matters here is that your receiver is a passive listener riding along on the same grant
+the real radios follow.
+
+## What your receiver is doing
+
+While all this happens, your receiver's job is to **read the control channel continuously** and act
+on grants for talkgroups in your active [scan list](/learn/scanning/talkgroups-and-scan-lists/). When
+a matching grant appears, it tunes to the voice channel, plays the audio, and — the moment the call
+ends — snaps back to the control channel so it doesn't miss the next grant.
+
+This is why the control channel is everything: the receiver is only ever *following instructions* it
+reads there. A perfect voice channel is useless if the receiver never saw the grant that pointed to
+it. Everything you hear is downstream of a clean control-channel decode.
+
+## Why the first word sometimes clips
+
+Between the grant and the audio there's a small delay: the receiver must decode the grant and retune
+before it can play anything. On most systems that's fast enough to catch the whole call, but not
+always. A **weak or marginal control channel** slows the decode; a **slow retune** on some hardware
+adds a beat; and if you **join a call already in progress** (late entry), you naturally miss what
+came before you locked on.
+
+A consistently clipped first syllable usually points at the control-channel decode being marginal
+rather than a fault in the audio path — which is exactly the kind of distinction the
+[when decoding fails](/learn/scanning/when-decoding-fails/) lesson helps you make.
+
+## Why a call can hop mid-conversation
+
+Sometimes a call jumps to a different voice channel partway through. On some systems a long
+transmission can be **reassigned** — the system moves it to another channel and the control channel
+announces the change. A receiver following the control channel reads that update and **hops along**
+automatically, so you hear the call continue seamlessly.
+
+When the hop *isn't* seamless — the call cuts off where it should have continued — it's a strong
+hint that the control-channel decode dropped the update. The audio was fine; the instruction to
+follow it went missing. Again, the health of the control channel decides whether following works.
+
+## The priority interrupt in action
+
+If you've set a [priority](/learn/scanning/talkgroups-and-scan-lists/) talkgroup, the following
+behaviour changes in one important way: while you're listening to a routine call, the receiver keeps
+watching the control channel for a **grant on your priority talkgroup**, and when one appears it
+**breaks away** from the current call to follow the priority one. This is the whole sequence running
+in service of your priorities — the receiver constantly reading grants and choosing which to follow
+based on the rules you set.
+
+Seen this way, "following a call" and "priority" are the same machinery: read the control channel,
+match grants against your lists, and jump. Master that mental model and the receiver's behaviour
+stops being mysterious.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the receiver reads the grant on the control channel and retunes to the assigned voice channel; that small delay can clip the opening syllable." markdown="0">
+  <p class="knowledge-check__q">Quick check: why might you miss the very first word of a trunked call?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">The talker always pauses before speaking</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The receiver must read the grant and retune to the voice channel first, which takes a moment</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Trunked systems mute the first second of every call</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A trunked call is a fast handshake: **request → grant → tune → talk → release**.
+- The [control channel](/learn/digital-trunking/the-control-channel/) **announces the grant**; your
+  receiver reads it, **jumps** to the assigned voice channel, plays the call, and returns.
+- Everything you hear is **downstream of the control-channel decode** — a perfect voice channel is
+  useless if the grant was missed.
+- The **first word can clip** because of the decode-and-retune delay, a marginal control channel, or
+  late entry.
+- A call can **hop** to a new channel mid-conversation; the receiver follows if it reads the update
+  cleanly.
+- **Priority** is the same machinery — read grants, match your lists, and jump to what matters most.
+
+Next up: [multisite, simulcast &amp; roaming](/learn/scanning/multisite-and-roaming/).

--- a/docs/learn/scanning/frequency-records.md
+++ b/docs/learn/scanning/frequency-records.md
@@ -1,0 +1,121 @@
+---
+slug: frequency-records
+title: Building your frequency records
+description: Turning what you find on the air into a reusable log — how to organise frequencies, talkgroups, and field notes so your setup gets smarter over time and you never have to rediscover the same signal twice.
+keywords: frequency log, scanner records, radio logbook, talkgroup list, field notes, organising frequencies, alpha tags, scanner programming file, backup, monitoring log
+level: beginner
+status: full
+prereq:
+  - identifying-unknown-signals
+faq:
+  - q: Why keep frequency records at all?
+    a: Because discovery is work, and memory is unreliable. Every signal you identify represents time spent searching and confirming, and a good record means you never have to redo that work. Over months your log becomes a personalised map of your area's airwaves — far more relevant to you than any generic database, because it reflects what you actually hear.
+  - q: What should each entry include?
+    a: At minimum the frequency (or talkgroup ID), a short label, the mode, and what it is. Beyond that, notes on when it's active, how strong it is at your location, and any tone or system detail make an entry genuinely useful. The goal is that a future you can read the entry and know instantly whether it's worth listening to.
+  - q: Do I need special software?
+    a: No. A plain spreadsheet works perfectly well and is easy to back up. Dedicated scanner-programming software adds convenience — importing from databases, pushing straight to a radio — but the discipline of keeping records matters far more than the tool. Start simple and upgrade only when you feel the friction.
+---
+
+# Building your frequency records
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Every signal you [identify](/learn/scanning/identifying-unknown-signals/) is work — and a **log**
+keeps that work from evaporating. Good records turn scattered catches into a **personalised map**
+of your area: frequencies, talkgroups, modes, and **field notes** on when and how well each is
+heard. A useful entry is one a future you can read and instantly know whether it's worth tuning.
+Keep it simple (a spreadsheet is fine), **back it up**, and it becomes the foundation everything
+else in the hobby builds on — [scan lists](/learn/scanning/talkgroups-and-scan-lists/),
+alerting, and sharing.
+</div>
+
+Discovery without record-keeping is a leaky bucket. You spend an evening searching, identify a
+handful of signals, and a month later you can't remember which frequency was the good one. This
+short lesson is about closing that leak — building a log that captures what you find in a shape
+you can actually reuse, so your setup gets steadily smarter instead of forgetting every session.
+
+## Why a log beats memory
+
+The scanning payoff compounds only if you keep records. Each identified signal cost you time to
+find and confirm; writing it down means that cost is paid **once**. Over months, your log grows
+into something no public database can match — a map of what's genuinely active *at your location*,
+with your own notes on the systems that matter to you. That relevance is the whole point: a
+generic county list has a thousand entries, but your log has the fifty you actually listen to.
+
+A log also protects you against the thing that always happens: you rebuild your setup, switch
+radios, or reinstall software, and without records you start from zero. With them, you're back on
+the air in minutes.
+
+## What to record
+
+An entry earns its place by telling a future you enough to act on it. A workable minimum:
+
+- **Frequency or talkgroup ID** — the thing you tune. For trunked systems, the talkgroup ID and
+  its parent system; for conventional, the frequency.
+- **A short label (alpha tag)** — "County Fire Dispatch," not a bare number. This is what you'll
+  read at a glance while scanning.
+- **Mode and any detail** — FM/AM/digital, a subaudible tone or colour code, the system type.
+- **What it is** — the plain-language identity you worked out.
+
+Beyond the minimum, the notes are where a log becomes valuable: **when** it's active (weekday
+mornings? incidents only?), **how strong** it is at your location, and any quirk worth
+remembering. Those field notes are what turn a list of numbers into knowledge.
+
+## Keep it organised
+
+A flat pile of entries becomes unusable at a few hundred rows, so give it structure early. Group
+by **agency or service** (all the fire channels together), by **band**, or by **geography** —
+whatever matches how you actually listen. Consistent **alpha tags** matter more than they sound:
+if your labels follow a pattern, you can scan, sort, and search them, and later turn whole groups
+into [scan lists](/learn/scanning/talkgroups-and-scan-lists/) in one move.
+
+Trunked systems deserve their own grouping, because a system is a container: one system holds many
+talkgroups, and your records should mirror that — the system and its control channel at the top,
+the talkgroups nested under it. That structure is exactly what you'll feed into
+[programming a trunked system](/learn/scanning/programming-a-trunked-system/).
+
+## Tools — start simple
+
+You do not need special software. A **spreadsheet** handles thousands of entries, sorts and
+filters instantly, and is trivial to back up. Many hobbyists never outgrow it. Dedicated
+**scanner-programming software** adds convenience — importing directly from
+[RadioReference](/learn/scanning/radioreference-database/), pushing a finished list straight to a
+hardware scanner — and is worth it once you're programming radios regularly. The rule is to let
+the friction tell you when to upgrade, not to over-tool on day one.
+
+Whatever you use, the discipline matters more than the tool: record consistently, and record at
+the moment of the catch, while the details are fresh.
+
+## Back it up and keep it current
+
+A log you've built over a year is genuinely irreplaceable, so **back it up** — a copy in the cloud
+or on another drive costs nothing and saves everything. Just as important, keep it **current**:
+prune entries for systems that have gone dark, correct anything you've since identified better,
+and fold in new catches as they come. A living log stays trustworthy; a stale one slowly fills
+with dead frequencies you no longer trust. And when you confirm something new, consider giving it
+back to the [shared databases](/learn/scanning/radioreference-database/) so the next listener
+benefits too.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — records mean each identified signal is found once, and your log becomes a personalised, reusable map of your area." markdown="0">
+  <p class="knowledge-check__q">Quick check: what's the main reason to keep frequency records?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Regulators require every listener to log what they hear</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">So each signal is identified once and your setup keeps getting smarter</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">A larger log makes your receiver more sensitive</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **log** pays the cost of discovery once — without it, you keep rediscovering the same signals.
+- Record at least the **frequency or talkgroup ID**, a **label**, the **mode**, and **what it
+  is**; add **field notes** on when and how well it's heard.
+- **Organise early** by agency, band, or geography, with consistent **alpha tags**, and nest
+  talkgroups under their system.
+- A **spreadsheet** is plenty to start; add programming software only when the friction calls for
+  it.
+- **Back it up** and keep it **current** — a living log is one of your most valuable pieces of
+  gear.
+
+Next up: [programming a trunked system](/learn/scanning/programming-a-trunked-system/).

--- a/docs/learn/scanning/glossary.md
+++ b/docs/learn/scanning/glossary.md
@@ -1,0 +1,292 @@
+---
+slug: glossary
+title: Glossary of scanning terms
+description: Plain-language definitions of the terms used in radio scanning and monitoring — scanner, SDR, control channel, talkgroup, scan list, lockout, simulcast, multisite, roaming, feed, discone, squelch, close call, and more — each cross-linked to the lesson that explains it.
+keywords: scanning glossary, scanner terms, SDR glossary, talkgroup, scan list, control channel, discone, squelch, simulcast, multisite, roaming, Broadcastify, trunk tracking, close call
+level: beginner
+status: full
+lesson_standalone: true
+---
+
+# Glossary of scanning terms
+
+Every term used across the [Scanning &amp; Monitoring](/learn/scanning/) module,
+defined in plain language and linked to the lesson where it's explained in full. Skim
+it as a refresher, or use your browser's find (Ctrl/Cmd-F) to jump to a word. Terms
+are grouped by theme, roughly in the order the module introduces them.
+
+## The hobby
+
+**Scanning** — Monitoring live radio traffic by rapidly checking channels or following
+a system, to hear who's on the air right now. See
+[What radio scanning is](/learn/scanning/what-is-scanning/)
+
+**Monitoring** — Listening to radio communications you don't take part in — the
+receive-only heart of the hobby. See
+[What radio scanning is](/learn/scanning/what-is-scanning/)
+
+**Crystal scanner** — An early scanner whose channels were fixed by physical crystals,
+one per frequency — the ancestor of the programmable radio. See
+[A short history of scanners](/learn/scanning/history-of-scanning/)
+
+**Programmable scanner** — A scanner whose frequencies are entered in software or a
+keypad rather than set by hardware, the format that opened the hobby up. See
+[A short history of scanners](/learn/scanning/history-of-scanning/)
+
+**Conventional system** — A system where each channel is a fixed frequency you can park
+on and listen to directly. See
+[Conventional vs. trunked, in the field](/learn/scanning/conventional-vs-trunked-recap/)
+
+**Trunked system** — A system that shares a pool of frequencies dynamically, assigning
+calls to channels on the fly, so you must follow it rather than park on it. See
+[Conventional vs. trunked, in the field](/learn/scanning/conventional-vs-trunked-recap/)
+
+**Encryption** — Scrambling a transmission so only authorised radios can understand it;
+to a scanner it decodes as noise and can't be listened to. See
+[What you can (and can't) hear today](/learn/scanning/what-you-can-hear/)
+
+**Clear / analog traffic** — Unencrypted transmissions — analog or plain digital — that
+a scanner can receive and understand, the traffic that's still open to listen to. See
+[What you can (and can't) hear today](/learn/scanning/what-you-can-hear/)
+
+**Legal reception** — The principle, varying by country and state, that receiving
+unencrypted radio is broadly permitted while certain *uses* are not; the hobby's ground
+rules. See [Legal &amp; ethical scanning](/learn/scanning/scanning-legal-and-ethical/)
+
+## Station &amp; hardware
+
+**Hardware scanner** — A dedicated appliance with tuning, trunk-tracking, and recording
+built in — you switch it on. See
+[Hardware scanners vs. SDR](/learn/scanning/scanners-vs-sdr/)
+
+**SDR (software-defined radio)** — A receiver that digitises a chunk of spectrum and
+hands the raw samples to software, which does all the demodulating and decoding. See
+[Hardware scanners vs. SDR](/learn/scanning/scanners-vs-sdr/)
+
+**Trunking scanner** — A scanner able to follow a trunked system by decoding its control
+channel, as opposed to a conventional-only receiver. See
+[Choosing a scanner or SDR](/learn/scanning/choosing-a-scanner/)
+
+**Discone** — A wideband antenna, shaped like a disc over a cone, that receives well
+across a huge frequency range — a scanning favourite. See
+[Antennas for scanning](/learn/scanning/antennas-for-scanning/)
+
+**Vertical antenna** — An omnidirectional antenna that receives equally from all
+directions, common for general scanning. See
+[Antennas for scanning](/learn/scanning/antennas-for-scanning/)
+
+**Gain (antenna)** — How much an antenna concentrates its reception, trading coverage in
+some directions for more in others. See
+[Antennas for scanning](/learn/scanning/antennas-for-scanning/)
+
+**Feedline / coax** — The cable carrying the signal from antenna to receiver; longer
+runs and cheaper cable lose more signal. See
+[Feedlines, connectors &amp; grounding](/learn/scanning/feedlines-and-connectors/)
+
+**Connector** — The fitting that joins feedline to gear (SMA, BNC, N, and others); the
+wrong or a poor one quietly costs signal. See
+[Feedlines, connectors &amp; grounding](/learn/scanning/feedlines-and-connectors/)
+
+**Grounding** — Safely bonding your antenna and station to earth to protect against
+static and lightning. See
+[Feedlines, connectors &amp; grounding](/learn/scanning/feedlines-and-connectors/)
+
+**Station** — Your assembled setup — receiver, antenna, feedline, and computer — working
+together as a monitoring position. See
+[Setting up your station](/learn/scanning/station-setup/)
+
+**Squelch** — A control that mutes the receiver until a signal exceeds a threshold, so
+you hear calls instead of constant hiss. See
+[Setting up your station](/learn/scanning/station-setup/)
+
+**Noise floor** — The background level of radio noise below which signals are lost; the
+lower it is, the weaker the signals you can hear. See
+[Reducing noise &amp; interference](/learn/scanning/reducing-interference/)
+
+**RFI (radio-frequency interference)** — Unwanted noise from electronics, chargers, and
+the like that raises your noise floor and buries signals. See
+[Reducing noise &amp; interference](/learn/scanning/reducing-interference/)
+
+**Filter** — Hardware that passes the frequencies you want and rejects the rest, cutting
+interference and overload. See
+[Reducing noise &amp; interference](/learn/scanning/reducing-interference/)
+
+## Finding systems
+
+**RadioReference** — The largest community database of radio systems, listing
+frequencies, control channels, talkgroups, and aliases for tens of thousands of
+systems. See [RadioReference &amp; system databases](/learn/scanning/radioreference-database/)
+
+**Database** — A shared, community-maintained record of what's on the air where, the
+scanning hobby's map of the spectrum. See
+[RadioReference &amp; system databases](/learn/scanning/radioreference-database/)
+
+**Band plan** — The regulatory floor plan of the spectrum, dividing it into bands for
+public safety, business, aviation, and the rest, so you know where to look. See
+[Band plans &amp; where services live](/learn/scanning/band-plans/)
+
+**Band** — A range of frequencies allocated to a class of use (VHF, UHF, 700/800 MHz,
+and so on). See [Band plans &amp; where services live](/learn/scanning/band-plans/)
+
+**Search / scan** — Sweeping a range of frequencies to find active transmissions the
+databases don't list. See [Search, scan &amp; discovery](/learn/scanning/searching-and-discovery/)
+
+**Close call** — A technique (and scanner feature) that detects a strong nearby
+transmitter and jumps to its frequency automatically. See
+[Search, scan &amp; discovery](/learn/scanning/searching-and-discovery/)
+
+**Waterfall** — A scrolling visual of the spectrum over time, where a control channel
+shows as a solid unbroken column and voice channels flicker. See
+[Identifying an unknown signal](/learn/scanning/identifying-unknown-signals/)
+
+**Bandwidth** — How wide a signal is in frequency, a key clue to what a mystery
+transmission is. See [Identifying an unknown signal](/learn/scanning/identifying-unknown-signals/)
+
+**Modulation** — How information is impressed on a carrier (FM, P25 C4FM, DMR, and so
+on); recognising it helps name a signal. See
+[Identifying an unknown signal](/learn/scanning/identifying-unknown-signals/)
+
+**Frequency records** — Your personal, organised log of frequencies, talkgroups, and
+notes that makes your setup smarter over time. See
+[Building your frequency records](/learn/scanning/frequency-records/)
+
+## Trunking
+
+**Control channel** — The one frequency a trunked system uses to coordinate everything,
+continuously sending the signalling that tells radios where calls are; find it and you
+can follow the whole system. See
+[Programming a trunked system](/learn/scanning/programming-a-trunked-system/)
+
+**System parameters** — The details identifying a trunked system — type, control
+channel(s), site and system IDs — that you enter to track it. See
+[Programming a trunked system](/learn/scanning/programming-a-trunked-system/)
+
+**Talkgroup** — A virtual channel on a trunked system — a group of radios that hear each
+other — identified by a numeric ID. See
+[Talkgroups, scan lists &amp; priorities](/learn/scanning/talkgroups-and-scan-lists/)
+
+**Scan list** — A curated set of talkgroups you choose to monitor, so you hear what you
+care about and skip the rest. See
+[Talkgroups, scan lists &amp; priorities](/learn/scanning/talkgroups-and-scan-lists/)
+
+**Lockout** — Marking a talkgroup or frequency to be skipped, so noise and uninteresting
+traffic never interrupt you. See
+[Talkgroups, scan lists &amp; priorities](/learn/scanning/talkgroups-and-scan-lists/)
+
+**Priority** — A setting that makes an important talkgroup interrupt whatever you're
+monitoring the instant it becomes active. See
+[Talkgroups, scan lists &amp; priorities](/learn/scanning/talkgroups-and-scan-lists/)
+
+**Grant** — A message on the control channel assigning a talkgroup's call to a specific
+voice channel, the instruction your setup follows. See
+[Following a call across the system](/learn/scanning/following-a-call/)
+
+**Voice channel** — A frequency temporarily carrying an actual conversation, assigned by
+a grant and released when the call ends. See
+[Following a call across the system](/learn/scanning/following-a-call/)
+
+**Multisite** — A trunked system built from many sites covering a wide area; you pick the
+site whose signal you monitor. See
+[Multisite, simulcast &amp; roaming](/learn/scanning/multisite-and-roaming/)
+
+**Simulcast** — Several transmitters sending the same signal on the same frequency at
+once; overlapping coverage can distort reception. See
+[Multisite, simulcast &amp; roaming](/learn/scanning/multisite-and-roaming/)
+
+**Roaming** — Radios moving between sites of a system as they travel, which you follow by
+tracking the right site. See
+[Multisite, simulcast &amp; roaming](/learn/scanning/multisite-and-roaming/)
+
+**Control-channel lock** — A clean, sustained decode of the control channel; without it
+nothing downstream works, so it's the first thing to check when decoding fails. See
+[When decoding fails](/learn/scanning/when-decoding-fails/)
+
+## Logging, recording &amp; sharing
+
+**Call log** — The timestamped text record of which talkgroup or unit was active, when,
+and for how long — cheap, durable, and useful on its own. See
+[Logging &amp; recording calls](/learn/scanning/logging-and-recording/)
+
+**Per-call recording** — Saving each call as its own short, tagged audio file, which is
+what makes an archive searchable instead of an endless tape. See
+[Logging &amp; recording calls](/learn/scanning/logging-and-recording/)
+
+**Retention policy** — Your rule for how long recordings are kept before old ones are
+pruned, so a busy system doesn't fill the disk. See
+[Logging &amp; recording calls](/learn/scanning/logging-and-recording/)
+
+**Metadata** — The facts captured with each call — timestamp, system, talkgroup, unit,
+frequency, duration — that make it findable later. See
+[Metadata, tagging &amp; searchability](/learn/scanning/metadata-and-tagging/)
+
+**Alias** — A human name mapped to a numeric talkgroup or unit ID ("1201" →
+"County Fire Dispatch"), the biggest readability upgrade an archive gets. See
+[Metadata, tagging &amp; searchability](/learn/scanning/metadata-and-tagging/)
+
+**Source unit ID** — The identifier of the individual radio that keyed up a call, when
+the system sends it; lets you follow one unit across talkgroups. See
+[Metadata, tagging &amp; searchability](/learn/scanning/metadata-and-tagging/)
+
+**Feed** — A live stream of your local scanner audio published to the internet for others
+to hear. See [Audio feeds &amp; streaming](/learn/scanning/audio-feeds-and-streaming/)
+
+**Broadcastify** — The largest public directory of live scanner feeds, hosting volunteers'
+streams for anyone to listen to. See
+[Audio feeds &amp; streaming](/learn/scanning/audio-feeds-and-streaming/)
+
+**Encoder** — Software that compresses your audio into a streaming codec and pushes it to
+a feed provider's server. See
+[Audio feeds &amp; streaming](/learn/scanning/audio-feeds-and-streaming/)
+
+**Alert** — An action fired when a call matches a rule you set — a talkgroup, a unit, or
+an activity pattern — so you're notified when something happens. See
+[Alerting on the calls you care about](/learn/scanning/alerting-on-calls/)
+
+**Alert fatigue** — The failure mode where an alert fires so often you learn to ignore
+it; the reason to alert narrowly. See
+[Alerting on the calls you care about](/learn/scanning/alerting-on-calls/)
+
+**Monitoring post** — A receiver, antenna, and computer built to run unattended around
+the clock, capturing traffic whether or not anyone is watching. See
+[Building an always-on monitoring post](/learn/scanning/building-a-monitoring-post/)
+
+**Headless** — Running a computer with no monitor or keyboard, operated over the network
+— the normal way to run an always-on post. See
+[Building an always-on monitoring post](/learn/scanning/building-a-monitoring-post/)
+
+**Managed service** — Software run under a service manager (like systemd) that starts on
+boot and restarts on failure, so the post heals itself. See
+[Building an always-on monitoring post](/learn/scanning/building-a-monitoring-post/)
+
+## Software &amp; GopherTrunk
+
+**Trunk-tracker** — Software (or a scanner) that reads a system's control channel and
+follows grants to voice channels automatically — the top rung of scanning tools. See
+[Scanning with SDR software](/learn/scanning/scanning-with-sdr-software/)
+
+**Demodulation** — Pulling a signal out of the raw SDR samples, the first software step
+before decoding. See [Scanning with SDR software](/learn/scanning/scanning-with-sdr-software/)
+
+**Decoding** — Turning a demodulated digital signal into bits and then into voice or
+data — where a protocol's rules are applied. See
+[Scanning with SDR software](/learn/scanning/scanning-with-sdr-software/)
+
+**GopherTrunk** — An open-source, multi-protocol trunk-tracking decoder that turns a bare
+SDR into a scanner across P25, DMR, NXDN, TETRA, and more. See
+[GopherTrunk as a scanner](/learn/scanning/gophertrunk-as-a-scanner/)
+
+**Hunt** — GopherTrunk's feature that sweeps a band, detects carriers, identifies the
+protocol, and reports which one is the control channel. See
+[GopherTrunk as a scanner](/learn/scanning/gophertrunk-as-a-scanner/)
+
+**Signal path** — The order the signal travels — antenna → feedline → SDR → decoder →
+recording — which is also the order to build and troubleshoot a setup. See
+[A worked end-to-end monitoring setup](/learn/scanning/a-worked-monitoring-setup/)
+
+**IQ capture** — A recorded file of raw SDR samples; the single most useful thing you can
+give a decoder developer, because it reproduces the exact problem. See
+[The community &amp; contributing data](/learn/scanning/contributing-and-community/)
+
+**Commons** — The shared, community-maintained knowledge — databases, feeds, and
+open-source decoders — that the hobby runs on and that contributors replenish. See
+[The community &amp; contributing data](/learn/scanning/contributing-and-community/)

--- a/docs/learn/scanning/gophertrunk-as-a-scanner.md
+++ b/docs/learn/scanning/gophertrunk-as-a-scanner.md
@@ -1,0 +1,146 @@
+---
+slug: gophertrunk-as-a-scanner
+title: GopherTrunk as a scanner
+description: Using GopherTrunk to follow and decode a real trunked system — point it at an SDR, lock the control channel, follow the grants it hands out, and get tagged per-call audio out the other end.
+keywords: GopherTrunk scanner, trunk tracking, control channel decode, follow grants, GopherTrunk config, P25 DMR NXDN TETRA, per-call audio, open source scanner, SDR decoder, GopherTrunk setup
+level: advanced
+status: full
+prereq:
+  - programming-a-trunked-system
+  - scanning-with-sdr-software
+faq:
+  - q: What does GopherTrunk actually do?
+    a: It takes raw samples from an SDR, locks a trunked system's control channel, reads the grants that control channel hands out, tunes to and decodes the voice channels those grants point to, and produces tagged per-call audio with logs and metadata. In short, it's the software that turns a bare SDR into a trunk-tracking scanner across P25, DMR, NXDN, TETRA, and more.
+  - q: What do I need to give it to start?
+    a: A supported SDR, an antenna, and one system's control-channel frequency and type — the same details you'd program into any trunking scanner. From that single frequency GopherTrunk discovers the rest of the system by decoding the control channel, or you can let its Hunt feature find control channels you don't have.
+  - q: How is it different from a hardware trunking scanner?
+    a: Same behaviour — lock control channel, follow calls — but open and exposed. It's multi-protocol, updatable, can follow more from one wideband capture, and lays every call's metadata, logs, and audio open for recording, alerting, and integration. It's the brain of the setup rather than a sealed appliance.
+---
+
+# GopherTrunk as a scanner
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+GopherTrunk is the software that turns a bare [SDR](/learn/rf-sdr/what-is-sdr/) into a
+**trunk-tracking scanner**. Give it an SDR and **one system's control-channel
+frequency and type**; it **locks the control channel**, reads the **grants** that
+channel hands out, **follows** each to its voice channel, and produces **tagged
+per-call audio** with logs and metadata — across P25, DMR, NXDN, TETRA, and more.
+It's the same lock-and-follow behaviour as a hardware trunking scanner, but **open,
+multi-protocol, and fully exposed** for recording, alerting, and integration.
+</div>
+
+You've seen where GopherTrunk sits among
+[SDR scanning software](/learn/scanning/scanning-with-sdr-software/) — a
+multi-protocol trunk-tracker on the top rung. This lesson puts it to work: what you
+feed it, what it does with a real system, and what comes out. Everything you learned
+about [programming a trunked system](/learn/scanning/programming-a-trunked-system/)
+and [following a call](/learn/scanning/following-a-call/) is exactly what GopherTrunk
+does automatically — here it is in the flesh. The [project home](/) and the
+[architecture overview](/architecture.html) go deeper than one lesson can; this is the
+scanner's-eye view.
+
+## What you point it at
+
+GopherTrunk needs the same three things any trunking scanner does, no more:
+
+- **An SDR and antenna** — the [receiver](/learn/scanning/scanners-vs-sdr/) that hands
+  it raw samples, fed by a [good antenna](/learn/scanning/antennas-for-scanning/).
+- **One control-channel frequency** — the single frequency that unlocks the whole
+  system, exactly as in
+  [programming a trunked system](/learn/scanning/programming-a-trunked-system/).
+- **The system type** — P25, DMR, NXDN, TETRA, and so on, so it knows which decoder
+  to run.
+
+From that one control-channel frequency it discovers the rest of the system by
+listening. And when you *don't* have a control-channel frequency, its **Hunt** feature
+sweeps a band, detects carriers, identifies the protocol, and reports which one is the
+control channel — the [search-and-discovery](/learn/scanning/searching-and-discovery/)
+job, automated.
+
+## Locking the control channel
+
+The moment GopherTrunk has the control-channel frequency and type, its first job is to
+**lock** that channel — tune to it, demodulate it, and start decoding the steady
+stream of [signalling](/learn/scanning/programming-a-trunked-system/) the control
+channel never stops sending. A good lock is the foundation of everything else; if the
+control channel isn't decoding cleanly, nothing downstream works, which is why
+[when decoding fails](/learn/scanning/when-decoding-fails/) starts there.
+
+Once locked, GopherTrunk is reading the system's live bookkeeping: affiliations,
+registrations, and — the part that matters for scanning — the **grants** that assign a
+talkgroup's call to a voice channel. It's the same control channel a
+[hardware scanner](/learn/scanning/scanners-vs-sdr/) reads, decoded in the open.
+
+## Following the grants
+
+This is trunk-tracking, and it's the whole point. Each time the control channel grants
+a call — "talkgroup 1201, go to this voice channel" — GopherTrunk **follows** it: it
+tunes to that voice channel, decodes the digital voice, and plays or records the call,
+then returns to watching the control channel for the next grant. That
+control-channel-to-voice-and-back loop is precisely
+[following a call across the system](/learn/scanning/following-a-call/), running
+continuously and automatically.
+
+Because it works from a wideband capture, GopherTrunk can follow more of a system at
+once than switching a single tuner around — several concurrent calls decoded in
+parallel from the same receiver, which is where software pulls ahead of a
+one-call-at-a-time box.
+
+## What comes out
+
+The output is everything Unit 5 was about, produced for you:
+
+- **Tagged per-call audio** — each call as its own
+  [recording](/learn/scanning/logging-and-recording/), labelled with system,
+  talkgroup, unit, time, and frequency straight from the control channel.
+- **A live call log** and **metadata** — the searchable record from
+  [metadata & tagging](/learn/scanning/metadata-and-tagging/), written as calls
+  happen.
+- **Hooks for the rest** — [alerting](/learn/scanning/alerting-on-calls/),
+  [feeds](/learn/scanning/audio-feeds-and-streaming/), and dashboards all draw on the
+  same exposed stream of calls and metadata.
+
+In other words, GopherTrunk isn't just a decoder — it's the engine that drives the
+whole logging, recording, and alerting apparatus you built earlier in the module.
+
+## Running it for real
+
+For a quick listen you run it on your desk; for anything lasting you run it as the
+[always-on post](/learn/scanning/building-a-monitoring-post/) — headless, managed, and
+self-recovering. Because GopherTrunk is server-shaped software, that's its natural
+home, and the [deploying GopherTrunk](/learn/deployment/deploying-gophertrunk/) guide
+walks through standing it up as a durable service rather than a program you babysit.
+The [architecture overview](/architecture.html) shows how the pieces — receiver,
+control-channel decoder, grant follower, voice decoders, recorders — fit together, and
+the [project home](/) is where to start if you want to actually run it.
+
+The next lesson assembles all of this — antenna, SDR, GopherTrunk, logging, and a
+dashboard — into one complete, worked monitoring setup.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — from one control-channel frequency GopherTrunk locks the control channel, then follows every grant to its voice channel automatically." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does GopherTrunk do after it locks a system's control channel?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Nothing more — locking the control channel is the whole job</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">It reads the grants and follows each call to its voice channel, decoding the audio</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It re-transmits the control channel to other scanners nearby</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- GopherTrunk turns a bare **SDR** into a **trunk-tracking scanner** across P25, DMR,
+  NXDN, TETRA, and more.
+- You give it an **SDR, one control-channel frequency, and the system type**; its
+  **Hunt** feature can find control channels you don't have.
+- It **locks the control channel**, reads the **grants**, and **follows** each call to
+  its voice channel — trunk-tracking, automated.
+- It outputs **tagged per-call audio**, a **live log and metadata**, and **hooks** for
+  alerting, feeds, and dashboards.
+- Run it briefly on the desk or, for real, as an
+  [always-on post](/learn/scanning/building-a-monitoring-post/) — see the
+  [architecture overview](/architecture.html) and
+  [deployment guide](/learn/deployment/deploying-gophertrunk/).
+
+Next up: [a worked end-to-end monitoring setup](/learn/scanning/a-worked-monitoring-setup/).

--- a/docs/learn/scanning/history-of-scanning.md
+++ b/docs/learn/scanning/history-of-scanning.md
@@ -1,0 +1,138 @@
+---
+slug: history-of-scanning
+title: A short history of scanners
+description: How radio scanners evolved from crystal-controlled boxes through programmable synthesized receivers to trunk-tracking scanners and today's software-defined radios — and why that history still shapes what you buy and how you listen.
+keywords: history of scanners, crystal scanner, programmable scanner, trunk tracking scanner, scanner evolution, SDR scanning history, Bearcat Uniden, digital scanner
+level: beginner
+status: full
+prereq:
+  - what-is-scanning
+faq:
+  - q: Why did scanners move from crystals to programmable tuning?
+    a: Early scanners used a physical quartz crystal for each channel, so listening to a new frequency meant buying and installing a new crystal. Frequency synthesizers replaced the crystal bank with a single tunable circuit driven by a keypad, so any frequency in range became a matter of typing it in. That one change turned a fixed, expensive box into a flexible one and is why every scanner since has been programmable.
+  - q: What made trunk-tracking scanners necessary?
+    a: When agencies moved to trunked systems, a single conversation no longer lived on one frequency — it hopped across a pool of channels under the direction of a control channel. A conventional scanner parked on one frequency would catch only fragments. Trunk-tracking scanners decode the control channel and follow the grants, reassembling a call as it moves, which is the only way to monitor a trunked system coherently.
+  - q: Are old scanners still useful?
+    a: For conventional analog traffic, an old programmable scanner still works fine. What it cannot do is follow trunked or digital systems it was never designed for, and much public-safety traffic has moved to exactly those. That is the practical dividing line — the history explains why an older box hears some of the spectrum perfectly and none of the rest.
+---
+
+# A short history of scanners
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Scanners evolved in step with the systems they follow. **Crystal-controlled** boxes
+gave way to **programmable synthesized** receivers, which gave way to
+**trunk-tracking** scanners once agencies adopted trunked systems, and finally to
+**digital** scanners and **[software-defined radio](/learn/rf-sdr/what-is-sdr/)**. Each
+leap was a response to a change on the air — and that history is exactly why an old
+scanner hears some of today's spectrum perfectly and none of the rest.
+</div>
+
+The [previous lesson](/learn/scanning/what-is-scanning/) described what a scanner does.
+This one explains how it got that way. You do not need the history to listen, but it
+makes sense of the market you are about to shop in: why scanners are described the way
+they are, why "trunk-tracking" and "digital" are the words that matter on a spec sheet,
+and why the hobby keeps chasing the systems it monitors.
+
+## The crystal era
+
+The first scanners, in the late 1960s and 1970s, were **crystal-controlled**. Each
+channel was tuned by a physical quartz **crystal** cut for one exact frequency, and the
+radio had a bank of sockets — often eight or ten. To listen to a new frequency you
+bought a crystal ground for it and plugged it in. A scanner was therefore a fixed
+instrument: it could only ever hear the handful of channels you had crystals for, and
+expanding it cost money and a trip to the parts counter.
+
+Even so, the core idea was already there. The radio would sweep across its installed
+crystals, stop on the one carrying traffic, and resume — the sweep-and-stop loop that
+still defines a scanner today. What it lacked was flexibility.
+
+## Programmable, synthesized scanners
+
+The breakthrough was the **frequency synthesizer**. Instead of a separate crystal per
+channel, a synthesizer uses a single reference and a tunable circuit (a phase-locked
+loop) to generate any frequency in its range on command. Paired with a **keypad** and
+memory, this turned the crystal bank into software: you simply *typed in* a frequency,
+stored it in a memory channel, and the radio tuned there.
+
+This is the scanner most people picture — a **programmable** box with dozens or
+hundreds of memory channels, banks you could turn on and off, and a keypad to enter
+whatever you wanted to hear. Brands like Bearcat/Uniden and Radio Shack made these
+household items through the 1980s and 1990s. The flexibility was transformative:
+one radio could now follow an entire county's worth of conventional channels, and
+reprogramming it for a trip or a new interest cost nothing but time.
+
+## Trunking breaks the model
+
+Then the systems changed. As agencies grew, assigning a permanent frequency to every
+talkgroup became wasteful, and **trunked** radio systems appeared to share a small pool
+of frequencies dynamically. On a trunked system a single conversation is not tied to
+one channel — a computer, signalling over a
+**[control channel](/learn/digital-trunking/the-control-channel/)**, hands each call
+whatever frequency is free at that instant, so the audio hops around the pool.
+
+To a conventional scanner this was chaos. Park on a voice frequency and you would catch
+a random fragment of one call, then silence as the next call was assigned elsewhere.
+The answer was the **trunk-tracking scanner**: a radio that decodes the control
+channel, reads the grants, and **follows the call** to whichever frequency it lands on,
+reassembling a coherent conversation. This is the same job GopherTrunk does in software,
+and the digital module covers the mechanics in
+[conventional vs. trunked](/learn/digital-trunking/conventional-vs-trunked/) and
+[talkgroups & affiliation](/learn/digital-trunking/talkgroups-ids-affiliation/).
+
+## Going digital
+
+Trunking changed *how calls were assigned*; digital voice changed *how they sounded*.
+Systems began replacing analog FM voice with digital protocols — **P25** in North
+American public safety, **DMR** and **NXDN** in business and some public-safety use,
+**TETRA** in much of the world. A digital signal is a stream of symbols, not an audible
+tone, so a scanner now needed a **decoder** to turn those symbols back into speech.
+
+Scanner makers responded with **digital trunk-tracking scanners** that could both follow
+a trunked system and decode its digital voice. These are the high end of the hardware
+market today. The dividing line for a buyer is simple: an older analog-only scanner
+still hears conventional analog traffic perfectly, but it is deaf to the digital,
+trunked systems that carry much of modern public-safety radio.
+
+## The software-defined turn
+
+The most recent chapter moves the intelligence out of the box entirely. A
+**[software-defined radio](/learn/rf-sdr/what-is-sdr/)** is a receiver that digitizes a
+wide swath of spectrum and hands the raw samples to a computer, where **software** does
+the tuning, demodulation, trunk-tracking, and digital decoding. A cheap SDR dongle plus
+a program like **GopherTrunk** can do what an expensive dedicated scanner does — and
+often more, because it can watch a whole band at once, log everything, and gain new
+protocols with a software update rather than a new purchase.
+
+This is why the hobby now has two distinct roads, which we compare in
+[hardware scanners vs. SDR](/learn/scanning/scanners-vs-sdr/). The hardware scanner is
+the mature, self-contained appliance; the SDR is the flexible, evolving platform. Both
+are direct descendants of that first crystal box, and both still do the same fundamental
+thing: sweep, stop on activity, and let you listen.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — trunk-tracking scanners decode the control channel and follow a call across the frequency pool." markdown="0">
+  <p class="knowledge-check__q">Quick check: why did trunked systems require a new kind of scanner?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Because trunked systems transmit on frequencies too high for older radios</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Because a single call hops across a pool of frequencies, so the scanner must read the control channel and follow it</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Because trunked systems are always encrypted and need a decryption key</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Early scanners were **crystal-controlled**: one quartz crystal per channel, fixed and
+  costly to expand.
+- **Frequency synthesizers** made scanners **programmable** — type in any frequency —
+  which defined the classic keypad-and-memory scanner.
+- **Trunked systems** broke the one-channel model, so **trunk-tracking scanners** arose
+  to decode the control channel and follow a call across the frequency pool.
+- **Digital voice** (P25, DMR, NXDN, TETRA) added the need for a **decoder** in the
+  radio, giving us digital trunk-tracking scanners.
+- **Software-defined radio** moves the intelligence into a computer, so a cheap receiver
+  plus software like GopherTrunk can match or beat a dedicated scanner.
+- Every step was a response to a change on the air — which is why old gear hears part of
+  the spectrum and misses the rest.
+
+Next up: [Conventional vs. trunked, in the field](/learn/scanning/conventional-vs-trunked-recap/).

--- a/docs/learn/scanning/identifying-unknown-signals.md
+++ b/docs/learn/scanning/identifying-unknown-signals.md
@@ -1,0 +1,126 @@
+---
+slug: identifying-unknown-signals
+title: Identifying an unknown signal
+description: You found a signal — now what is it? — a practical method for naming a mystery transmission from its frequency, bandwidth, and modulation, using the waterfall's visual shape and the way it behaves on the air.
+keywords: identify unknown signal, signal identification, waterfall shape, bandwidth, modulation, AM vs FM, digital signal, control channel signature, signal fingerprint, what is this frequency
+level: intermediate
+status: full
+prereq:
+  - searching-and-discovery
+faq:
+  - q: How do I tell what an unknown signal is?
+    a: Gather clues rather than guessing. The frequency tells you the likely service via the band plan; the bandwidth tells you whether it's narrow voice or something wider; the modulation and the waterfall shape tell you AM, FM, or digital; and the behaviour — constant versus bursty — tells you data from voice. Together these usually narrow a mystery to one or two candidates.
+  - q: Can the waterfall alone identify a signal?
+    a: Not by itself, but it's the single most useful view. The width and shape of a trace on the waterfall reveal bandwidth and often the modulation at a glance, and the pattern over time — solid, bursty, or stepping — separates a control channel from a voice channel from noise. It narrows the field fast, then you confirm with the audio and the band plan.
+  - q: What does a digital signal look like?
+    a: Digital signals tend to show as a flat-topped block of fairly uniform width rather than the peaked shape of analog voice, and they sound like a harsh buzz or hiss instead of speech. A trunked control channel is the clearest case — a constant, unbroken block that never stops transmitting, unlike voice channels that come and go.
+---
+
+# Identifying an unknown signal
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Finding a signal and *naming* it are two different skills. Identification is **detective work**:
+combine the **frequency** (which service, via the [band plan](/learn/scanning/band-plans/)), the
+**bandwidth** and **modulation** (read off the [waterfall](/learn/rf-sdr/fft-and-waterfall/)),
+and the **behaviour** — constant data versus bursty voice — into a short list of candidates.
+No single clue is proof, but together they usually settle it. The waterfall's **visual shape** is
+your fastest tool; the audio and band plan confirm it.
+</div>
+
+You've caught a signal you can't name. Resist the urge to guess — identification is a process of
+stacking clues until only one answer fits. Each property of a transmission narrows the field:
+where it sits, how wide it is, how it's modulated, and how it behaves over time. This lesson is
+that method, and it leans heavily on the [waterfall](/learn/rf-sdr/fft-and-waterfall/), because a
+signal's picture reveals most of what you need before you've listened to a word.
+
+## Clue 1 — frequency and the band plan
+
+Start with where it lives. The [band plan](/learn/scanning/band-plans/) turns a frequency into a
+short list of likely services: a signal at 156.8 MHz is almost certainly marine, one at 121 MHz
+in AM is aviation, one at 855 MHz is a strong trunking candidate. This is the cheapest clue and
+often the most powerful, because services are legally confined to their bands. Write the exact
+frequency down first — everything else builds on it.
+
+## Clue 2 — bandwidth and shape
+
+How **wide** is the signal? On the waterfall, a trace's width is its bandwidth, and bandwidth is
+one of the best discriminators there is. Narrowband voice channels are slim; a wideband data or
+video signal sprawls. The **shape** helps too: analog FM voice tends to show a peaked, wandering
+trace that moves with the speaker's voice, while many digital signals show a **flat-topped block**
+of uniform width. The [signal anatomy](/learn/rf-sdr/signal-anatomy/) lesson breaks down what
+each part of that picture means.
+
+A rough field guide to widths:
+
+| Rough bandwidth | Typical signal |
+|-----------------|----------------|
+| ~3 kHz | SSB / narrow utility voice |
+| ~5–15 kHz | Analog FM / AM voice channel |
+| ~6–12 kHz | Digital voice (P25, DMR, and kin) |
+| Tens of kHz+ | Wideband data, paging, some trunking |
+
+## Clue 3 — modulation and sound
+
+Next, how is it **modulated**? AM and FM voice each have a characteristic sound — AM thin and
+prone to fading, FM full and quieting to silence between words — while digital sounds like a harsh
+buzz or hiss with no intelligible speech. On the waterfall, AM often shows a strong centre carrier
+with sidebands, FM a fuller block that breathes with the audio, and digital a steady, textured
+block. Switching your receiver's mode and hearing which one makes the signal intelligible is a
+quick, decisive test for analog.
+
+## Clue 4 — behaviour over time
+
+Finally, watch what it **does**. A signal that keys up, carries a short exchange, and falls silent
+behaves like a **voice channel**. A signal that transmits **continuously and never stops** behaves
+like **data** — and a constant, unbroken block on the waterfall is the classic signature of a
+[trunked control channel](/learn/digital-trunking/the-control-channel/). Something that bursts in
+a regular rhythm might be telemetry or paging. Time-behaviour is exactly the clue that separates a
+control channel from the voice channels around it, and it's only visible if you watch for a while.
+
+## Putting the clues together
+
+No single clue names a signal — the method is to **stack** them. Suppose you catch a carrier at
+851.0125 MHz, a flat-topped block about 12 kHz wide, digital-sounding, transmitting without
+pause. Frequency says 800 MHz public-safety band; width and sound say digital voice family;
+constant behaviour says data — and the combination points hard at a **P25 control channel**. Any
+one clue is weak; four pointing the same way is a confident identification.
+
+When the clues *disagree* — an unexpected width in a band, an odd mode — that's a signal worth
+extra attention, and often the start of the most interesting catches. If you're still stuck, note
+everything and come back; identification gets faster with every mystery you solve.
+
+## From identification to a decode
+
+Once you believe you know what a signal is, the next step depends on the answer. Analog voice you
+simply listen to. A trunked control channel you hand to a decoder — which is where the
+[digital-trunking](/learn/digital-trunking/identifying-the-system/) side of the site picks up,
+turning a named control channel into a followed system. Either way, an identified signal belongs
+in your [frequency records](/learn/scanning/frequency-records/) so you never have to solve the
+same mystery twice.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a constant, unbroken block that never stops transmitting is the classic control-channel signature." markdown="0">
+  <p class="knowledge-check__q">Quick check: on the waterfall you see a digital-sounding block in the 800 MHz band that transmits without ever pausing. Most likely?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">An analog FM voice channel</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">A trunked control channel</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">A marine voice channel</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Identification is **detective work** — stack clues until only one candidate fits.
+- **Frequency** plus the [band plan](/learn/scanning/band-plans/) gives the likely service; it's
+  the cheapest and often strongest clue.
+- **Bandwidth and shape** on the [waterfall](/learn/rf-sdr/fft-and-waterfall/) separate narrow
+  voice from wide data and hint at the modulation.
+- **Modulation and sound** distinguish AM, FM, and digital; switching mode is a fast test for
+  analog.
+- **Behaviour over time** separates bursty voice from constant data — and a never-stopping block
+  is a **control channel**.
+- No one clue is proof; a confident ID is several clues agreeing, then logged so you needn't solve
+  it twice.
+
+Next up: [building your frequency records](/learn/scanning/frequency-records/).

--- a/docs/learn/scanning/index.md
+++ b/docs/learn/scanning/index.md
@@ -1,0 +1,33 @@
+---
+layout: learn-hub
+learn_module: scanning
+permalink: /learn/scanning/
+title: Scanning & Monitoring — the practical craft of listening to the radio spectrum
+description: A free, structured module on radio scanning and monitoring — building a listening station, finding and identifying systems, following trunked calls in the field, and logging, recording, and monitoring them with a scanner or SDR, finishing with GopherTrunk as an always-on monitoring post.
+keywords: radio scanning, learn to scan, scanner setup, SDR scanning, trunk tracking, RadioReference, talkgroups, scan lists, control channel, discone antenna, monitoring post, Broadcastify feed, following a call, scanning legal
+---
+
+The [Digital &amp; Trunked Radio]({{ '/learn/digital-trunking/' | relative_url }})
+module explains how these systems work on the *inside*. This one is about actually
+**listening to them**. Scanning is the decades-old hobby of monitoring the live
+radio spectrum — public safety, utilities, aviation, business, and more — and it's a
+craft with its own skills: building a station, finding what's out there, following a
+call the instant a radio keys up, and capturing it all so you can come back to it.
+
+**Who this is for.** Anyone curious about what's on the air above them — new to the
+hobby or a longtime listener who wants the trunked, software-defined side to click.
+It assumes no background beyond curiosity. It pairs with the
+[RF &amp; SDR]({{ '/learn/rf-sdr/' | relative_url }}) module (how radio and SDR work)
+and the [Digital &amp; Trunked Radio]({{ '/learn/digital-trunking/' | relative_url }})
+module (how the systems you'll follow are built). Everything here stays firmly on the
+right side of the law.
+
+**How the module works.** Six units take you from switching on a receiver to running
+an unattended monitoring post. The first two cover the **hobby and the station** —
+what you can hear, and the receiver and antenna that let you hear it. The middle two
+are the core skills: **finding and identifying** systems, and **following trunked
+systems** in the field. The last two cover **logging, recording, and sharing** what
+you hear, and doing all of it with real software — turning
+[GopherTrunk]({{ '/' | relative_url }}) into an always-on monitoring post. Mark
+lessons complete as you go — your progress is saved in your browser. New here?
+**[Start with lesson 1: What radio scanning is](/learn/scanning/what-is-scanning/)**

--- a/docs/learn/scanning/logging-and-recording.md
+++ b/docs/learn/scanning/logging-and-recording.md
@@ -1,0 +1,139 @@
+---
+slug: logging-and-recording
+title: Logging & recording calls
+description: Turn live scanner traffic into a reviewable archive — call logging that writes down who talked and when, per-call recording that captures the audio, and the storage a busy trunked system quickly demands.
+keywords: call logging, scanner recording, per-call recording, call log, audio archive, trunk recorder, recording storage, talkgroup log, scanner history, monitoring records
+level: intermediate
+status: full
+prereq:
+  - following-a-call
+faq:
+  - q: What is the difference between logging and recording?
+    a: A log is text — a timestamped list of which talkgroup or unit was active, when, and for how long. A recording is the actual audio of the call. Logging tells you a call happened; recording lets you hear it. Most modern setups do both at once, writing one log row per call alongside the audio file it points to.
+  - q: What is per-call recording?
+    a: Instead of one long continuous audio file, a per-call recorder saves each transmission (or each call) as its own short file, tagged with the talkgroup, time, and system. That is what makes an archive searchable — you can jump straight to a single call instead of scrubbing through hours of mostly-silence.
+  - q: How much storage does recording use?
+    a: Far less than you would guess, because decoded voice is low-bitrate and calls are short. A busy public-safety system might produce a few hundred megabytes to a couple of gigabytes of compressed per-call audio a day. The metadata log is tiny by comparison. The real question is retention — how many days or weeks you keep before old audio is pruned.
+---
+
+# Logging & recording calls
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Listening live means you hear a call **once**; logging and recording let you review
+it later. A **call log** is the timestamped text record — which **talkgroup** or unit
+was active, when, and for how long — while a **recording** is the audio itself.
+Modern setups do **per-call recording**: each call becomes its own short, tagged
+file, which is what makes an archive searchable rather than one endless tape. Plan
+for **storage and retention** up front — a busy system fills a disk steadily, so
+decide how many days you keep before old audio is pruned.
+</div>
+
+You can only pay attention to so much in real time, and the interesting call is
+always the one you half-heard while doing something else. Logging and recording fix
+that: they turn the fleeting live stream into an archive you can search, replay, and
+share. This lesson covers what to capture, how per-call recording works, and the
+storage that a busy system quietly demands.
+
+## Logging: the text record
+
+A **call log** is the cheapest, most durable thing you can keep. Every time the
+control channel grants a call, your setup writes one row: a timestamp, the talkgroup
+(and its alias, if you have one), the source unit ID if the system sends it, the
+frequency the call landed on, and the duration. That's it — a few dozen bytes per
+call.
+
+That humble list is more useful than it looks. It shows you the **rhythm** of a
+system: which talkgroups are busy at 3 a.m. versus rush hour, which units check in
+where, when a big incident lights up half the fleet at once. You can keep months of
+logs in a text file or a small database and never notice the space. Even if you
+never record a second of audio, the log alone answers "was anything happening on
+that channel last Tuesday?"
+
+## Recording: capturing the audio
+
+A log tells you a call happened; a **recording** lets you hear it. Once you follow a
+[call across the system](/learn/scanning/following-a-call/), the decoded voice is
+just audio, and audio can be written to a file as easily as it's played to a speaker.
+
+There are two ways to do it. The old way is **continuous recording** — one long file
+per channel or per session, running whether or not anyone is talking. It's simple,
+but it leaves you scrubbing through hours of dead air to find thirty seconds of
+traffic, and it wastes space on silence. The modern way, described next, is far
+better for scanning.
+
+## Per-call recording
+
+**Per-call recording** saves each call as its own short file, created the moment the
+call starts and closed when it ends. Because your setup already knows the call's
+metadata from the control channel, it can name and tag each file automatically:
+system, talkgroup, timestamp, source unit, frequency. A morning's monitoring becomes
+a folder of hundreds of small, labelled clips instead of one giant tape.
+
+This is the format that makes an archive genuinely useful:
+
+- **You jump straight to a call** — no scrubbing. Find the row in the log, open the
+  file it points to.
+- **Silence costs nothing** — the recorder only writes while a call is active, so a
+  quiet night produces a quiet folder.
+- **Each file carries its own context** — the talkgroup and time travel with the
+  audio, which is exactly what the next lesson on
+  [metadata & tagging](/learn/scanning/metadata-and-tagging/) builds on.
+
+Per-call recording pairs naturally with trunk tracking, because the recorder and the
+[grant follower](/learn/scanning/following-a-call/) are reading the same control
+channel. The log row and the audio file are written together, pointing at each other.
+
+## What to record — and what not to
+
+You rarely want *everything*. A busy metro system can grant thousands of calls a day
+across dozens of talkgroups, most of which you don't care about. Lean on your
+[talkgroups and scan lists](/learn/scanning/talkgroups-and-scan-lists/): record the
+talkgroups you're monitoring and let the rest scroll past in the log only. That keeps
+the archive focused and the disk usage sane.
+
+Two things you can't usefully record: **encrypted** calls, which decode to noise, and
+calls your receiver never followed because it was busy on another one. Neither is a
+fault in your recorder — the first is by design on the system's end, and the second
+is the nature of following one call at a time, a limit the
+[when-decoding-fails](/learn/scanning/when-decoding-fails/) lesson returns to.
+
+## Storage and retention
+
+Decoded voice is low-bitrate and calls are short, so recordings are smaller than
+newcomers expect — a busy public-safety system might produce anywhere from a few
+hundred megabytes to a couple of gigabytes of compressed per-call audio a day, and
+the text log is a rounding error beside it. Still, "a couple of gigabytes a day"
+fills a disk in a month or two, so the real decision is **retention**: how long you
+keep audio before old files are pruned.
+
+Pick a policy and automate it. Common patterns are a rolling window (keep the last N
+days, delete the rest), a size cap (prune oldest when the folder passes a limit), or
+keeping the log forever while ageing out only the heavy audio. Whatever you choose,
+decide it now — an archive with no retention policy is a disk that fills up at the
+worst possible moment.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — per-call recording writes each call as its own tagged file, so you can jump straight to it instead of scrubbing a long tape." markdown="0">
+  <p class="knowledge-check__q">Quick check: what makes per-call recording more useful than one continuous file?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It records encrypted calls that continuous recording can't</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Each call is its own short, tagged file, so you jump straight to it</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It uses more disk space, which means higher audio quality</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **call log** is the timestamped text record of which talkgroup or unit was
+  active, when, and for how long — cheap, durable, and useful on its own.
+- A **recording** captures the audio; logging and recording usually run together,
+  one log row per call.
+- **Per-call recording** saves each call as its own tagged file, which is what makes
+  an archive searchable instead of an endless tape.
+- Record the talkgroups you care about, not everything — encrypted calls decode to
+  noise and can't be usefully saved.
+- Decoded voice is small, but a busy system still fills a disk over weeks, so set a
+  **retention policy** up front.
+
+Next up: [metadata, tagging & searchability](/learn/scanning/metadata-and-tagging/).

--- a/docs/learn/scanning/metadata-and-tagging.md
+++ b/docs/learn/scanning/metadata-and-tagging.md
@@ -1,0 +1,140 @@
+---
+slug: metadata-and-tagging
+title: Metadata, tagging & searchability
+description: A recording you can't find is a recording you don't have — tag every call with talkgroup, time, system, and unit so a month of scanner audio stays searchable, and build the aliases that turn raw IDs into names.
+keywords: call metadata, tagging recordings, talkgroup alias, searchable archive, scanner metadata, unit ID alias, call tagging, audio metadata, filename convention, monitoring database
+level: intermediate
+status: full
+prereq:
+  - logging-and-recording
+faq:
+  - q: What metadata should every recorded call carry?
+    a: At minimum a timestamp, the system, the talkgroup (both its numeric ID and a human alias), the source unit ID if the system sends one, the frequency the call landed on, and the duration. That set lets you find any call later by who, when, or where — and it's exactly what your setup already knows from the control channel, so capturing it costs nothing extra.
+  - q: What is a talkgroup alias?
+    a: A friendly name mapped to a numeric talkgroup ID — turning "talkgroup 1201" into "County Fire Dispatch." Aliases live in a lookup table you build or import from a database like RadioReference. They make logs and recordings readable at a glance instead of a wall of numbers, and they're the single biggest quality-of-life upgrade to an archive.
+  - q: Should I encode metadata in the filename or a database?
+    a: Both, ideally. A structured filename (system, talkgroup, timestamp) makes files self-describing even if the database is lost, while a database or index makes bulk search and filtering fast. The filename is your durable fallback; the index is your fast path.
+---
+
+# Metadata, tagging & searchability
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A [recording](/learn/scanning/logging-and-recording/) is only worth keeping if you
+can **find it again**. Every call should carry **metadata** — timestamp, system,
+talkgroup, source unit, frequency, duration — captured automatically from the
+control channel at no extra cost. **Aliases** turn raw numbers ("talkgroup 1201")
+into names ("County Fire Dispatch"), which is the single biggest readability upgrade
+an archive gets. Store that metadata in **both the filename and an index** so a
+month of audio stays searchable by who, when, or where.
+</div>
+
+Capturing calls is half the job; being able to *find* one later is the other half.
+An unlabelled folder of ten thousand audio clips is nearly useless — the call you
+want is in there, but so is everything else, and you have no way to reach it. Tagging
+is what turns a pile of recordings into a searchable archive. The good news: your
+setup already knows everything it needs to tag each call.
+
+## The metadata that matters
+
+When the control channel grants a call, it hands your setup a small bundle of facts.
+Capture all of them with the recording:
+
+- **Timestamp** — when the call started, ideally to the second and in a consistent
+  time zone (UTC saves you grief across daylight-saving changes).
+- **System** — which trunked system or site the call belongs to, so a multi-system
+  archive doesn't blur together.
+- **Talkgroup** — the numeric ID *and* its alias. Keep both: the ID is authoritative,
+  the alias is readable.
+- **Source unit ID** — which radio keyed up, if the system sends it. Following one
+  unit across talkgroups is a powerful way to track an event.
+- **Frequency** — the voice channel the call landed on, useful for troubleshooting
+  and for confirming multisite behaviour.
+- **Duration** — how long the call ran, which lets you spot the long incident calls
+  amid the short routine ones.
+
+None of this is extra work at capture time — it's the same data that drives
+[following a call](/learn/scanning/following-a-call/). You're simply writing it down
+next to the audio instead of letting it scroll off the screen.
+
+## Aliases: from numbers to names
+
+Raw scanning is a wall of numbers. Talkgroup 1201, unit 4471, system 0x2A. Nobody
+remembers those, and a log full of them is barely more searchable than the audio it
+describes. **Aliases** fix this by mapping each ID to a human name in a lookup table:
+talkgroup 1201 becomes "County Fire Dispatch," unit 4471 becomes "Engine 12."
+
+You build alias tables two ways, usually together. You **import** them from a
+community database like [RadioReference](/learn/scanning/radioreference-database/),
+which has aliases for tens of thousands of documented systems, and you **add your
+own** as you identify talkgroups by listening — the local knowledge no database has.
+Feed those aliases into your logs and recordings and the whole archive becomes
+readable at a glance. This is the highest-value, lowest-effort improvement you can
+make; do it early.
+
+## Filenames and folders that describe themselves
+
+The simplest tag lives in the filename. A convention like
+
+```
+SystemName/2026-08-04/1201_CountyFireDispatch_143207_unit4471.wav
+```
+
+makes a file self-describing: you can read the system, date, talkgroup, time, and
+unit without opening anything or consulting a database. Group files into folders by
+system and day and the filesystem itself becomes a coarse search tool — you can
+navigate to "County Fire, last Tuesday" with nothing but a file browser.
+
+A structured filename is also your **durable fallback**. Databases get corrupted,
+software changes, indexes get rebuilt — but a well-named file explains itself years
+later on any machine. Never rely on an external index as the *only* place the
+metadata lives.
+
+## An index for fast search
+
+Filenames are durable but slow to search in bulk. For that you want an **index**: a
+small database, or even a well-structured log file, holding one row per call with all
+its metadata and a pointer to the audio. With an index you can ask real questions —
+"every County Fire call over two minutes long between 6 and 9 p.m. last week" — and
+get an answer in a moment instead of grepping ten thousand filenames.
+
+The two aren't rivals; they're layers. The **filename is the durable copy** of the
+metadata, the **index is the fast path** to it, and if the index is ever lost you can
+rebuild it by walking the self-describing filenames. Keep both and your archive stays
+both searchable and recoverable. This searchable base is exactly what the next
+lessons on [feeds](/learn/scanning/audio-feeds-and-streaming/) and
+[alerting](/learn/scanning/alerting-on-calls/) build on top of.
+
+## Consistency is the whole game
+
+Whatever scheme you pick, **apply it the same way every time**. The value of metadata
+comes from uniformity: if half your calls use UTC and half use local time, or one
+system spells a talkgroup two ways, search silently misses things and you learn not
+to trust it. Decide the fields, the time zone, the alias source, and the filename
+format once, automate them, and don't drift. An archive you can trust is worth ten
+you have to second-guess.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — an alias maps a numeric talkgroup or unit ID to a human name, making logs and recordings readable at a glance." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does a talkgroup alias do?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It encrypts the talkgroup ID so it can't be read from the log</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">It maps a numeric ID to a human name, like 1201 to "County Fire Dispatch"</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It merges several talkgroups into one recording</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Every call should carry **metadata** — timestamp, system, talkgroup, unit,
+  frequency, duration — captured automatically from the control channel.
+- **Aliases** map raw IDs to human names and are the single biggest readability
+  upgrade an archive gets; import them and add your own.
+- A structured **filename** makes each file self-describing and is your durable,
+  recoverable copy of the metadata.
+- An **index** or small database makes bulk search fast; it's the fast path, the
+  filename is the fallback.
+- **Consistency** — same fields, time zone, and format every time — is what makes an
+  archive you can actually trust.
+
+Next up: [audio feeds & streaming](/learn/scanning/audio-feeds-and-streaming/).

--- a/docs/learn/scanning/multisite-and-roaming.md
+++ b/docs/learn/scanning/multisite-and-roaming.md
@@ -1,0 +1,124 @@
+---
+slug: multisite-and-roaming
+title: Multisite, simulcast & roaming
+description: Big trunked systems have many sites — how to pick the right one to monitor from where you sit, what simulcast does to your received signal and why it can wreck a decode, and how to follow units as they roam from site to site.
+keywords: multisite trunking, simulcast, simulcast distortion, roaming, trunked sites, wide-area system, site selection, control channel per site, directional antenna, GopherTrunk site
+level: advanced
+status: full
+prereq:
+  - following-a-call
+faq:
+  - q: Why does a big trunked system have multiple sites?
+    a: To cover a wide area. A single transmitter site reaches only so far, so a county or statewide system chains many sites together, each covering its own patch, and radios roam between them. Each site has its own control channel and its own set of voice channels, so from a listener's seat a multisite system is really several local systems sharing one identity.
+  - q: What is simulcast and why is it a problem for scanning?
+    a: Simulcast is when several transmitters broadcast the same signal on the same frequency at once to blanket an area. Where their coverage overlaps, the copies arrive slightly out of step and interfere, distorting the signal. A strong meter with a fuzzy, un-lockable signal in a simulcast overlap zone is a classic decode killer.
+  - q: How do I follow a unit that roams between sites?
+    a: You generally monitor the site you can hear best, and you'll follow any talkgroup active on that site. A unit that physically moves to another site drops off yours and appears on the one it moved to — so following a roaming unit across a wide area can mean monitoring the site it's currently in range of, not chasing it site to site.
+---
+
+# Multisite, simulcast & roaming
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Wide-area trunked systems chain many **sites** together, each with its own
+[control channel](/learn/digital-trunking/the-control-channel/) and voice channels — so from your
+chair a multisite system is really several local systems sharing one identity. Monitor the **site
+you hear best**. **Simulcast** — several transmitters sending the same signal on the same frequency
+to blanket an area — can **distort** the signal where their coverage overlaps, a classic decode
+killer that a strong meter won't warn you about. And **roaming** units move between sites, so you
+follow the one in range rather than chasing a unit across the map. The system view is in
+[sites, simulcast &amp; roaming](/learn/digital-trunking/sites-simulcast-roaming/).
+</div>
+
+A small trunked system lives at one site, and following it is straightforward. Big systems — county,
+regional, statewide — are different animals: dozens of sites, overlapping coverage, and units that
+move between them. This lesson is about operating in that world from a fixed listening post: which
+site to point at, why simulcast can defeat an otherwise strong signal, and what "following a
+roaming unit" really means when you can't be everywhere at once.
+
+## A system is really many sites
+
+To cover more ground than one transmitter can reach, a wide-area system deploys many **sites**, each
+blanketing its own area and handing off to the next. Crucially, **each site has its own control
+channel and its own pool of voice channels**. The talkgroups and system identity are shared across
+the whole system, but the frequencies are per-site.
+
+For a listener this has a concrete consequence: you monitor **one site at a time** — whichever one
+you can hear from where you sit. When you [programmed the system](/learn/scanning/programming-a-trunked-system/)
+you may have entered several sites' control channels; in practice your receiver follows the site
+whose control channel it's locked to. A call on a *different* site, out of your range, simply isn't
+receivable from your location, no matter how it's listed.
+
+## Picking the site to monitor
+
+Site selection is mostly a question of signal. Point your receiver at the control channel of the
+site that comes in strongest and cleanest — usually the nearest one — and follow that. If you're
+between two sites and both are weak, a **directional antenna** aimed at one can lift it clear of the
+other and give you a solid lock on the site you actually want.
+
+The trade-off is coverage: the strongest site carries the traffic *in your area*, which is usually
+what you want to hear anyway. Chasing a distant site's traffic from a weak signal rarely pays off —
+better to monitor the site you're genuinely in range of and accept that a wide-area system's far
+corners belong to listeners who live there.
+
+## Simulcast — a strong signal that won't decode
+
+**Simulcast** is a coverage technique where several transmitters send the **same signal on the same
+frequency at the same time** to blanket a large area from multiple towers. Inside any one
+transmitter's coverage it works beautifully. But where two transmitters' coverage **overlaps**, your
+receiver hears two copies of the signal arriving *slightly out of step*, and they interfere — a
+self-inflicted multipath that smears the digital constellation.
+
+The signature is distinctive and counter-intuitive: a **strong signal meter** but a **fuzzy,
+un-lockable signal**. Newcomers raise the gain, which doesn't help, because the problem isn't weak
+signal — it's distortion. The fixes are about favouring **one** transmitter: a **directional
+antenna** to reject the competing copy, sometimes **lowering gain**, and choosing a listening spot
+that isn't deep in an overlap zone. This is exactly the simulcast entry on the
+[troubleshooting checklist](/learn/digital-trunking/troubleshooting-a-decode/), and it's one of the
+few decode problems that punishes a *strong* signal.
+
+## Roaming — following units that move
+
+Radios on a wide-area system **roam**: as a unit drives out of one site's coverage, it registers on
+the next and its calls now appear there. From a single fixed post you can't follow a unit physically
+across the whole system, because a call on a site you can't hear is unreceivable. What you *can* do
+is monitor the site the unit is currently in range of — which, if it's the site near you, is often
+exactly the traffic you care about.
+
+For genuinely wide-area following, listeners sometimes monitor several sites (with multiple receivers,
+or by choosing the busiest site), but the honest picture is that one post hears one site's worth of
+the system at a time. Understanding this keeps expectations realistic: you're not losing calls to a
+fault when a roaming unit "disappears" — it's simply moved to a site beyond your antenna.
+
+## Operating a multisite system well
+
+Put it together and a practical multisite strategy emerges. Identify the site you hear best and lock
+its control channel. If simulcast distortion appears — strong meter, fuzzy lock — reach for a
+directional antenna and back the gain down rather than up. Accept that you monitor one site's slice
+of the system, and pick the site that carries the traffic you want. Note in your
+[records](/learn/scanning/frequency-records/) which site works best from your location, because for a
+fixed post that answer rarely changes — and it saves you rediscovering it every session.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — simulcast overlap makes a strong signal arrive as interfering copies, so it reads strong but won't lock; favour one transmitter with a directional antenna and less gain." markdown="0">
+  <p class="knowledge-check__q">Quick check: your meter is strong but the signal is fuzzy and won't lock, in an area covered by several towers. Most likely?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">The signal is too weak — raise the gain</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Simulcast distortion from overlapping transmitters — favour one with a directional antenna</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">The talkgroup is encrypted</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A wide-area system is **many sites**, each with its own **control channel and voice channels**;
+  you monitor **one site at a time** — the one you hear best.
+- **Pick the site** by signal — nearest and cleanest — and use a **directional antenna** when two
+  sites compete.
+- **Simulcast** distorts the signal where transmitter coverage overlaps, giving a **strong meter but
+  a fuzzy, un-lockable signal** — favour one transmitter, don't raise gain.
+- **Roaming** units move between sites, so from a fixed post you follow the site in range, not the
+  unit across the whole map.
+- Note the best site for your location in your **records** — for a fixed post the answer is stable.
+
+Next up: [when decoding fails](/learn/scanning/when-decoding-fails/).

--- a/docs/learn/scanning/programming-a-trunked-system.md
+++ b/docs/learn/scanning/programming-a-trunked-system.md
@@ -1,0 +1,125 @@
+---
+slug: programming-a-trunked-system
+title: Programming a trunked system
+description: How to get a scanner or SDR to follow a trunked system — entering the control channel and the handful of system parameters that let the receiver read grants and jump to voice channels for you, and what each field actually does.
+keywords: program trunked system, scanner trunking, control channel, system type, site frequencies, P25 programming, talkgroup import, GopherTrunk config, trunk tracking, system parameters
+level: intermediate
+status: full
+prereq:
+  - frequency-records
+faq:
+  - q: What do I actually enter to follow a trunked system?
+    a: Far less than you'd expect. The core is the system type and at least one control-channel frequency; from there the receiver reads everything else — which voice channel a call is on, who's talking — off the control channel itself. You add talkgroups and site frequencies to shape and improve what you hear, but the control channel is the one thing you can't skip.
+  - q: Why don't I program the voice frequencies?
+    a: Because on a trunked system the voice channel changes call to call — the system assigns whichever channel is free. You can't park on a fixed voice frequency the way you would on a conventional channel. Instead you give the receiver the control channel, and it reads each call's assigned voice frequency in real time and jumps there for you.
+  - q: Do I need every site's frequencies?
+    a: Only the sites you can hear and care about. Each site has its own control channel, so to follow a particular site you program that site's control channel. For a single location you often need just one; for a wide-area system you might add several so the receiver can pick the site you're in range of.
+---
+
+# Programming a trunked system
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Following a trunked system takes surprisingly little: the **system type** and at least one
+**control-channel frequency**. From there the receiver reads each call's assigned voice channel
+off the [control channel](/learn/digital-trunking/the-control-channel/) and jumps there for you —
+you never program the voice frequencies, because they **change call to call**. You add
+**talkgroups** to decide what you hear and extra **site** control channels to follow the site
+you're in range of. Get the system type and control channel right and the system comes alive; get
+them wrong and nothing decodes.
+</div>
+
+Conventional scanning is simple: enter a frequency, park on it, listen. Trunked systems don't work
+that way — the conversation hops across a pool of shared voice channels, and a fixed frequency
+would catch only fragments. Programming a trunked system means giving the receiver the *one*
+channel that coordinates everything, plus a little context, and letting it do the following. This
+lesson covers exactly what you enter and why each field matters.
+
+## Why you can't just enter a frequency
+
+On a trunked system there is no permanent "fire dispatch frequency." When someone keys up, the
+system grants the call whichever voice channel happens to be free, and the next call from the same
+group might land somewhere else entirely. Park on one voice frequency and you'll hear scattered,
+disconnected snippets — a bit of one conversation, silence, a bit of another.
+
+The fix is to follow the **control channel** instead. It carries the signalling that assigns every
+call to its voice channel, so a receiver reading it knows, in real time, where each conversation
+is and who it belongs to. That's why trunk programming centres on the control channel, not the
+voice frequencies — a point the [conventional-vs-trunked](/learn/scanning/conventional-vs-trunked-recap/)
+recap first raised, now made concrete.
+
+## The parameters that matter
+
+Strip trunk programming to essentials and it's a short list:
+
+- **System type** — P25, DMR, or whichever protocol the system uses. This is the single most
+  important field, because it selects the decoder; the wrong type means nothing locks. You worked
+  this out when you [identified the system](/learn/digital-trunking/identifying-the-system/).
+- **Control-channel frequency** — at least one, ideally with alternates. This is the frequency the
+  receiver locks onto and reads. Everything else flows from it.
+- **Site frequencies** — for multi-site systems, each site has its own control channel; you add
+  the ones you can hear.
+- **Talkgroups** — the list of conversations, so the receiver can label calls and you can decide
+  which to follow (the [next lesson](/learn/scanning/talkgroups-and-scan-lists/)).
+
+Notice what's *not* there: voice frequencies, because the system assigns those dynamically and the
+receiver reads them live.
+
+## Where the numbers come from
+
+You rarely enter these by hand from scratch. The [databases](/learn/scanning/radioreference-database/)
+hand you a ready-made profile — system type, every site's control channel, and the full talkgroup
+list — which you import wholesale. Your own [frequency records](/learn/scanning/frequency-records/)
+fill the gaps and correct anything stale. And if a system isn't documented anywhere, the
+[finding the control channel](/learn/digital-trunking/finding-the-control-channel/) lesson shows
+how to discover its control channel on the air and confirm the type before you program it.
+
+Whichever way you get them, double-check the system type and control-channel frequency above all
+else — those two carry the whole decode.
+
+## What the receiver does with it
+
+Once programmed, the receiver **locks the control channel** and starts reading its stream. When a
+radio keys up, the control channel announces a **grant** — this talkgroup, on that voice channel —
+and the receiver jumps to the assigned frequency to play the audio, then returns to the control
+channel to await the next grant. All of this happens in a fraction of a second, and it's the
+subject of the [following a call](/learn/scanning/following-a-call/) lesson.
+
+In GopherTrunk you confirm the lock the same way you would for any system: watch the control
+channel's chatter start scrolling. If it stays empty, the system type or control-channel frequency
+is wrong — the first things to re-check, and the top of the
+[when decoding fails](/learn/scanning/when-decoding-fails/) checklist.
+
+## Getting it wrong — and right
+
+The two mistakes that stop a trunked system decoding are almost always the same two fields.
+**Wrong system type** picks the wrong decoder, so even a perfect signal won't lock. **Wrong
+control channel** — an inactive alternate, a voice frequency mistaken for the control channel, a
+typo — gives you a carrier but no data. Because both are configuration, both are quick to fix once
+you suspect them: reconfirm the type, then try each listed control channel in turn. Get those two
+right and the rest of trunk following mostly takes care of itself.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — on a trunked system the voice channel is assigned per call, so you program the control channel and the receiver reads each call's voice frequency live." markdown="0">
+  <p class="knowledge-check__q">Quick check: why don't you program the voice-channel frequencies when following a trunked system?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Voice channels are always encrypted and can't be tuned</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The system assigns a voice channel per call, and the receiver reads it off the control channel</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Voice channels use a different antenna than the control channel</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A trunked call hops across shared voice channels, so you **can't park on a fixed frequency** —
+  you follow the **control channel** instead.
+- The two fields that carry the decode are the **system type** (selects the decoder) and a
+  **control-channel frequency**.
+- You add **site** control channels and **talkgroups** to shape what you follow, but never the
+  voice frequencies — those are assigned per call.
+- The numbers come from **databases**, your own **records**, or on-air **discovery**; double-check
+  type and control channel above all.
+- Once locked, the receiver reads **grants** and jumps to each call's voice channel for you; an
+  empty control channel means the type or frequency is wrong.
+
+Next up: [talkgroups, scan lists &amp; priorities](/learn/scanning/talkgroups-and-scan-lists/).

--- a/docs/learn/scanning/radioreference-database.md
+++ b/docs/learn/scanning/radioreference-database.md
@@ -1,0 +1,129 @@
+---
+slug: radioreference-database
+title: RadioReference & system databases
+description: How the scanning community's shared databases — RadioReference chief among them — tell you what's on the air near you, from conventional frequencies to full trunked-system profiles, and how to read a system page without getting lost.
+keywords: RadioReference, scanner database, RRDB, trunked system database, control channel frequency, talkgroup list, county frequencies, system profile, scanner programming, FCC ULS
+level: beginner
+status: full
+faq:
+  - q: What is RadioReference?
+    a: RadioReference.com is the largest community-maintained database of radio systems in North America. Volunteers document conventional frequencies, trunked-system parameters, talkgroups, and site details, organised mostly by county and agency. It is where nearly every scanner hobbyist starts when they want to know what is on the air near them.
+  - q: Do I have to pay to use it?
+    a: The core frequency and talkgroup data is free to browse. A modest paid membership unlocks bulk export, the mobile apps, and some convenience features, but you can find a control channel and a talkgroup list without spending anything. Most people join once they are hooked and want faster programming.
+  - q: Is everything in the database?
+    a: No. Databases are only as complete as their volunteers, so new systems, recently rebanded sites, low-traffic business licences, and anything private may be missing or out of date. When a database comes up empty, that is exactly when the searching, discovery, and identification skills in the rest of this unit earn their keep.
+---
+
+# RadioReference & system databases
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Before you tune a single frequency, look up what is already documented. **RadioReference**
+is the scanning community's shared map — a free-to-browse database of **conventional
+frequencies**, **trunked-system parameters**, and **talkgroups**, organised by county and
+agency. A system page hands you the **control-channel frequency** and **system type** you need
+to start following a trunked system. Databases are never complete, though, so treat them as a
+head start, not the whole story — the [searching](/learn/scanning/searching-and-discovery/) and
+[identifying](/learn/scanning/identifying-unknown-signals/) lessons cover what they miss.
+</div>
+
+The fastest way to fill a scanner with things worth hearing is to stand on the work others
+have already done. Somewhere, a local hobbyist has probably already logged the frequencies,
+identified the systems, and named the talkgroups for your area — and posted them to a shared
+database. This lesson is about finding that work and reading it, so you spend your air time
+listening instead of rediscovering what is already known.
+
+## Why a shared database exists
+
+Radio scanning has always been a community hobby. Long before the web, listeners traded
+printed frequency lists and club newsletters; today that collective knowledge lives in online
+databases that anyone can search. The largest by far is **RadioReference.com** (often just
+"the RRDB"), which documents tens of thousands of systems across North America, with sister
+projects and regional databases covering other parts of the world.
+
+The value is not any single frequency — it is the **structure**. A good database doesn't just
+tell you that 154.265 MHz is active; it tells you it's the county fire dispatch, what tone it
+uses, and which neighbouring channels belong to the same agency. For trunked systems the
+payoff is bigger still: a single page can hand you the control channel, the system type, every
+site, and a full talkgroup list.
+
+## What's in a database
+
+Most databases organise around a few core record types. Learning to recognise them makes any
+system page readable:
+
+- **Conventional frequencies** — a plain list of fixed channels: frequency, mode (FM, digital),
+  any subaudible tone or colour code, and a plain-language description like "PD Dispatch."
+  These are the park-on-a-channel systems from the
+  [conventional-vs-trunked](/learn/scanning/conventional-vs-trunked-recap/) recap.
+- **Trunked systems** — a richer profile: the system name and type (P25, DMR, and so on), its
+  **system identifiers**, a list of **sites** with their **control-channel frequencies**, and
+  the **talkgroups** that ride on it.
+- **Talkgroups** — the logical channels within a trunked system, each with an ID, an alpha tag,
+  and a description. This is the list you'll turn into [scan
+  lists](/learn/scanning/talkgroups-and-scan-lists/) later.
+- **Licence data** — many databases surface the official FCC (or national regulator) licence
+  records, which show who is legally assigned a frequency even when no one has logged it on the
+  air yet.
+
+## Reading a trunked system page
+
+A trunked-system page is the one that intimidates newcomers, because it packs the most in.
+Read it top to bottom and it settles into a clear shape. The **header** names the system and
+its type — the single most important line, because it tells you which decoder to use. Below
+that, a **sites** table lists each transmitter site with its control-channel frequency (and
+often alternates); this is what you point your receiver at, and it's the same value the
+[finding the control channel](/learn/digital-trunking/finding-the-control-channel/) lesson
+teaches you to confirm on the air.
+
+Further down sits the **talkgroups** table — the actual conversations. Each row has a numeric
+ID, a short **alpha tag**, and a description, so you can decide what's worth hearing before a
+single call comes in. You don't need to understand every field to get started: the system type
+and one control-channel frequency are enough to begin, and the talkgroups tell you what you'll
+hear once you're locked.
+
+## Databases are a starting point, not gospel
+
+The great strength of a community database — that volunteers maintain it — is also its limit.
+Coverage is uneven: a well-documented metro system might have every talkgroup named, while the
+county next door is a stub. Records go stale when a system rebands, adds a site, or is replaced,
+and encrypted or newly built systems may never appear at all.
+
+So treat a database as a strong first draft. When the page is complete, you've saved hours;
+when it's thin or empty, that's your cue to switch to the discovery skills in the rest of this
+unit — searching a band, watching the [waterfall](/learn/rf-sdr/fft-and-waterfall/), and
+identifying what you find. The most rewarding catches are often the ones no database listed.
+
+## Give back what you learn
+
+The databases stay useful only because listeners contribute. When you confirm a frequency,
+identify an unlisted talkgroup, or catch a new site, submitting that back keeps the shared map
+alive for the next person. You don't have to — but a hobby built on shared knowledge works
+best when the people it helps also feed it. The
+[frequency records](/learn/scanning/frequency-records/) lesson shows how to keep your own logs
+in a shape that makes contributing painless.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the system type and a control-channel frequency are the two things a database gives you to start following a trunked system." markdown="0">
+  <p class="knowledge-check__q">Quick check: from a trunked system's database page, what two things do you most need to start following it?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">The number of talkgroups and the licence expiry date</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The system type and a control-channel frequency</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">The tower's height and the transmit power</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **RadioReference** and similar databases are the scanning community's shared map — the
+  fastest way to learn what's on the air near you.
+- Records come in a few types: **conventional frequencies**, **trunked systems**, **talkgroups**,
+  and official **licence data**.
+- A trunked-system page hands you the **system type** and a **control-channel frequency** — the
+  two things you need to start following it.
+- Databases are **never complete**: coverage is uneven and records go stale, so treat them as a
+  starting point.
+- When a page is thin, switch to **searching and identifying**; when you learn something new,
+  **give it back** so the map stays current.
+
+Next up: [band plans &amp; where services live](/learn/scanning/band-plans/).

--- a/docs/learn/scanning/reducing-interference.md
+++ b/docs/learn/scanning/reducing-interference.md
@@ -1,0 +1,161 @@
+---
+slug: reducing-interference
+title: Reducing noise & interference
+description: Why the modern city is so loud on the radio — where local electrical noise comes from, how to hunt down the sources in your own home, and the filters, ferrites, grounding, and habits that cut the racket so weak signals come through.
+keywords: radio noise reduction, RFI interference, scanner noise floor, electrical noise radio, front-end overload, band-pass filter, ferrite choke, finding noise source, raise noise floor
+level: intermediate
+status: full
+prereq:
+  - station-setup
+faq:
+  - q: Why is my scanner so noisy in the city?
+    a: Modern homes and cities are full of radio noise from switching power supplies, LED lighting, chargers, computers, networking gear, and countless other electronics, all raising the noise floor your receiver has to hear signals above. On top of that, strong nearby transmitters can overload a receiver's front end and create phantom interference. Most of this is local and can be reduced by finding the sources and filtering the strong signals.
+  - q: What's the difference between noise and overload?
+    a: "Noise raises the floor — a rising hiss from many small sources that buries weak signals. Overload is different: one or a few very strong signals push the receiver's front end past its limits, creating spurious signals and desensitisation across the band even where nothing is really transmitting. Noise is cured by finding and killing sources; overload is cured by attenuating or filtering the strong signal, not by turning up gain."
+  - q: How do I find what's causing my noise?
+    a: Hunt it down by elimination. Note the noise, then switch off circuits or unplug devices one at a time and watch the noise floor. When the hiss drops as something goes off, you've found a culprit. A portable receiver can also help you sniff along walls and outlets toward the loudest source. Once identified, you can filter it, move your antenna away from it, or replace the offending device.
+---
+
+# Reducing noise & interference
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+The modern city is **loud on the radio** — switching supplies, LED lighting, chargers,
+computers, and networking gear raise the **noise floor** that weak signals must rise
+above. Separately, strong nearby transmitters can **[overload your
+front end](/learn/rf-sdr/front-end-and-overload/)**, creating phantom signals across the
+band. **Noise** is cured by **finding and killing sources**; **overload** by
+**attenuating or filtering** the strong signal — never by adding gain. Ferrites, filters,
+good grounding, and a well-placed [antenna](/learn/scanning/antennas-for-scanning/) are
+your tools.
+</div>
+
+Your [station is built and verified](/learn/scanning/station-setup/). If weak signals
+still won't come through cleanly, the culprit is usually not the receiver or the antenna
+but the **noise** drowning them — and much of it comes from inside your own home. This
+final lesson of the unit is about quieting the racket so the signals you fought to capture
+actually surface.
+
+## Noise floor vs. overload — two different enemies
+
+Two distinct problems get lumped together as "interference," and they have opposite cures,
+so separate them first:
+
+- **A high noise floor.** Countless small sources add up to a rising hiss — the
+  **[decibel](/learn/rf-sdr/antennas/) floor** your receiver must hear signals above. Raise
+  the floor and weak signals vanish under it. The cure is to **find and eliminate
+  sources**.
+- **Front-end overload.** One or a few **very strong** signals push the receiver's front
+  end past its linear range, producing spurious "phantom" signals and desensitising it
+  across the band — even where nothing is transmitting. The cure is to **attenuate or
+  filter the strong signal**, covered in depth in [front-end &
+  overload](/learn/rf-sdr/front-end-and-overload/).
+
+The critical mistake with overload is reaching for **more gain**: adding gain amplifies the
+overloading signal too and makes it *worse*. When phantom signals appear across the band,
+think "too much signal," not "too little" — and reduce, don't boost.
+
+## Where the noise comes from
+
+Almost every device in a modern home emits some radio noise, and a few are notorious:
+
+- **Switching power supplies** — phone chargers, laptop bricks, cheap wall-warts — buzz
+  across wide swaths of spectrum.
+- **LED and fluorescent lighting**, and especially cheap LED drivers and dimmers.
+- **Computers, monitors, and their cables**, and USB devices — including, ironically, the
+  very computer running your SDR.
+- **Networking gear** — routers, powerline (Ethernet-over-mains) adapters, which are
+  spectacular noise sources.
+- **Motors and appliances** — furnaces, fans, chargers, EV equipment, solar inverters.
+- **The neighbours.** Noise doesn't respect property lines; a bad supply next door can
+  raise your floor.
+
+The unifying theme: this is mostly **local, human-made noise**, and because it's local,
+you have real power to reduce it — unlike distant atmospheric or cosmic noise you simply
+live with.
+
+## Hunt the source down
+
+You cannot filter what you can't find, so the highest-value skill is **locating** the
+noise, by elimination:
+
+1. **Watch the floor.** Note the noise level on a quiet frequency or the
+   [waterfall](/learn/rf-sdr/finding-systems/).
+2. **Kill power in blocks.** Switch off circuits at the breaker, or unplug devices one at a
+   time, and watch the floor. When the hiss **drops** as something goes off, that device or
+   circuit is a culprit.
+3. **Sniff it out.** A portable receiver (or an SDR on a laptop) tuned to the noise can be
+   walked around the house — the signal gets louder toward the source, letting you home in
+   on the offending outlet or gadget.
+4. **Confirm and decide.** Once identified, you can replace the device, filter it, move
+   your antenna away from it, or simply switch it off while listening.
+
+This detective work, done once, often buys back more weak-signal reception than any
+equipment purchase.
+
+## Filters, ferrites, and grounding
+
+Once you know your enemies, a handful of tools cut them down:
+
+- **Ferrite chokes.** Clamp-on ferrite beads around a power lead, USB cable, or coax choke
+  off common-mode noise riding on the cable — cheap, easy, and effective against the noise
+  many devices radiate along their wires.
+- **Band-pass and notch filters.** A **band-pass filter** passes only the range you care
+  about and rejects everything else — the standard defence against **overload** from strong
+  out-of-band transmitters (broadcast FM, pagers, cellular). A **notch filter** kills one
+  specific offending frequency. On the SDR side these are often the single biggest fix for
+  a receiver being swamped.
+- **Attenuation.** Deliberately reducing signal level with an attenuator can pull an
+  overloaded front end back into its linear range — the counter-intuitive fix where *less*
+  signal means *more* usable reception.
+- **Good grounding and clean power.** A properly
+  [grounded](/learn/scanning/feedlines-and-connectors/) antenna system and clean power
+  supplies keep noise from being injected in the first place; a cheap supply feeding your
+  SDR can be its own worst source.
+
+## Habits that keep it quiet
+
+Beyond hardware, a few habits keep the floor low for good:
+
+- **Get the antenna away from the noise.** Distance and height do double duty — an
+  [outdoor, elevated antenna](/learn/scanning/antennas-for-scanning/) escapes the household
+  noise cloud as well as seeing further. This alone is often the biggest single
+  improvement.
+- **Isolate the SDR from its computer.** A short USB extension and a ferrite move the
+  dongle out of the computer's noise field.
+- **Retest after changes.** Noise sources come and go — a new charger, a neighbour's new
+  gadget — so re-run the hunt when a once-quiet band gets loud.
+- **Don't chase the impossible.** Some floor is unavoidable; aim to get weak signals *above*
+  it, not to reach a perfect silence that doesn't exist in a real environment.
+
+Quieting your station is what lets everything in the previous lessons pay off — a good
+antenna, a short feedline, and a capable receiver only shine once the racket is down. With
+the station built and the noise tamed, you're ready to point it at the airwaves and find
+something to listen to, starting with the community's shared map of what's out there.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — overload comes from too much signal, so adding gain makes it worse; you attenuate or filter instead." markdown="0">
+  <p class="knowledge-check__q">Quick check: phantom signals appear across the band whenever a strong local transmitter is active. What's the fix?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Turn up the gain to lift the real signals above the phantoms</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Attenuate or band-pass filter the strong signal — overload is too much signal, so reduce, don't boost</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Add a longer antenna to capture more of the weak signals</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Separate the two enemies: a **high noise floor** (many small sources) versus **front-end
+  overload** (a few very strong signals) — they have **opposite cures**.
+- **Never add gain to fix overload** — it amplifies the offender; attenuate or filter
+  instead.
+- Most noise is **local and human-made** — switching supplies, LED lighting, computers,
+  networking gear — so you can actually reduce it.
+- **Hunt the source by elimination**: watch the floor, kill power in blocks, sniff with a
+  portable receiver, then filter, move, or replace it.
+- Tools: **ferrite chokes**, **band-pass/notch filters**, **attenuation**, and **clean
+  power and grounding**.
+- Habits: get the **antenna away from the noise**, **isolate the SDR from its computer**,
+  and **retest** when a quiet band gets loud.
+
+Next up: [RadioReference &amp; system databases](/learn/scanning/radioreference-database/).

--- a/docs/learn/scanning/scanners-vs-sdr.md
+++ b/docs/learn/scanning/scanners-vs-sdr.md
@@ -1,0 +1,151 @@
+---
+slug: scanners-vs-sdr
+title: Hardware scanners vs. SDR
+description: The two roads into scanning — a dedicated hardware scanner you switch on and program, versus a software-defined radio driving software like GopherTrunk. What each is best at, where each falls short, and how to choose the one that fits you.
+keywords: hardware scanner vs SDR, dedicated scanner, software defined radio scanning, GopherTrunk scanner, SDR vs scanner, trunk tracking, RTL-SDR, scanner or SDR
+level: beginner
+status: full
+prereq:
+  - scanning-legal-and-ethical
+faq:
+  - q: Is an SDR better than a dedicated scanner?
+    a: Neither is simply better — they trade off differently. A dedicated scanner is self-contained, reliable, portable, and easy to live with, but fixed in capability. An SDR plus software like GopherTrunk is more flexible and powerful — it can watch a whole band at once, log everything, and gain features through updates — but it needs a computer and more setup. The right choice depends on whether you value simplicity or capability.
+  - q: Do I need a computer to use an SDR for scanning?
+    a: Yes. An SDR is only the receiver front end — it digitizes radio and hands the samples to software running on a computer (or a small board like a Raspberry Pi), where the tuning, decoding, and trunk-tracking happen. A dedicated scanner needs no computer because all of that is built into the box.
+  - q: Can GopherTrunk replace a hardware scanner?
+    a: For many purposes, yes. GopherTrunk drives an SDR to follow trunked systems, decode digital voice, and log calls — the core jobs of a trunk-tracking scanner — and adds things a fixed scanner cannot do, like watching a whole band and recording everything. What it asks in return is a computer and a willingness to set it up, which is the essence of the SDR trade-off.
+---
+
+# Hardware scanners vs. SDR
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Two roads lead into scanning. A **dedicated hardware scanner** is a self-contained box
+you switch on, program, and trust — simple, portable, reliable, but **fixed in
+capability**. A **[software-defined radio](/learn/rf-sdr/what-is-sdr/)** plus software
+like **GopherTrunk** turns a cheap receiver and a computer into a scanner that can watch
+a **whole band at once**, **log everything**, and **grow through updates** — at the cost
+of more setup and a computer to run it. Neither is "better"; they trade **simplicity for
+capability**.
+</div>
+
+You have decided the hobby is for you and you know [what's on the
+air](/learn/scanning/what-you-can-hear/) and [where the lines
+are](/learn/scanning/scanning-legal-and-ethical/). The first equipment decision is which
+kind of receiver to build your station around. This lesson lays out the two families
+honestly so the [next one](/learn/scanning/choosing-a-scanner/) can help you pick a
+specific model.
+
+## The dedicated hardware scanner
+
+A **hardware scanner** is the classic appliance: a purpose-built box with a display, a
+keypad or knobs, a speaker, and an antenna jack. Everything it needs is inside it. You
+program in frequencies or systems, switch it on, and it scans — no computer, no software
+install, no configuration files. Modern trunk-tracking models handle P25, DMR, and other
+digital systems out of the box, and the best ones can be programmed from a database with
+a few clicks.
+
+What a dedicated scanner is genuinely good at:
+
+- **Simplicity.** Turn it on and it works. There is one thing to learn — its own menu —
+  and then you are listening.
+- **Portability.** It runs on batteries, fits in a pocket or a car, and needs nothing
+  else. Ideal for the field, an event, or a walk.
+- **Reliability.** A single dedicated device with no operating system to crash and no
+  computer to babysit. Leave it on for a week and it keeps scanning.
+- **Purpose-built controls.** Real buttons for the things you do constantly — hold,
+  lockout, scan — rather than a mouse and a window.
+
+Its limits are the flip side of being a sealed appliance: **its capabilities are fixed**
+at purchase. It hears one channel at a time, cannot watch a whole band, has limited
+logging, and gains new protocols only if the manufacturer ships a firmware update — if
+ever. What you buy is roughly what you keep.
+
+## The software-defined radio
+
+A **[software-defined radio](/learn/rf-sdr/what-is-sdr/)** flips the architecture. The
+hardware is a minimal receiver that **digitizes a slice of spectrum** and streams the raw
+samples to a **computer**, where software does all the intelligent work — tuning,
+demodulating, decoding digital voice, and following trunked systems. **GopherTrunk** is
+exactly this kind of software: point it at an SDR and it becomes a trunk-tracking,
+digital-decoding scanner.
+
+What the SDR path unlocks:
+
+- **See a whole band at once.** Because the SDR captures a wide swath of spectrum, the
+  software can watch many channels — even an entire trunked system's frequency pool —
+  simultaneously, rather than sweeping one at a time.
+- **Record and log everything.** Storage is the computer's, so you can log every call,
+  record per-call audio, and review a whole day later — far beyond a scanner's memory.
+- **Grow through software.** New protocols, new features, and bug fixes arrive as updates
+  to the software, not as a new purchase. The same hardware improves over time.
+- **Cost at the entry point.** A basic SDR dongle is cheap — often the least expensive way
+  to start following digital trunked systems, if you already own a computer.
+- **Visibility.** A [waterfall](/learn/rf-sdr/finding-systems/) display shows you the
+  spectrum itself, which is invaluable for finding and identifying signals.
+
+The costs are real too: you need a **computer** (even a small board like a Raspberry Pi),
+you have to **install and configure software**, and the whole thing is a *system* you
+assemble and maintain rather than an appliance you switch on. Cheap SDRs also have weaker
+front ends that can [overload](/learn/rf-sdr/front-end-and-overload/) in strong-signal
+environments — a solvable problem, but one you have to think about.
+
+## How they line up
+
+| | Hardware scanner | SDR + software |
+|---|---|---|
+| Setup | Minimal — program and go | More — computer, install, config |
+| Portability | Excellent (battery, pocket) | Needs a computer |
+| Channels at once | One at a time | A whole band |
+| Logging / recording | Limited | Extensive |
+| New protocols | Firmware, if ever | Software updates |
+| Entry cost | Higher (complete device) | Lower (dongle + your PC) |
+| Reliability | Very high, sealed appliance | Depends on your setup |
+
+Read the table as a single trade: the scanner buys you **simplicity and independence**;
+the SDR buys you **capability and flexibility**. Both do the fundamental job — sweep,
+stop on activity, follow trunked calls — and both can decode unencrypted digital systems.
+
+## Which one is you?
+
+A few honest questions usually settle it:
+
+- **Do you want to switch it on and listen, or do you enjoy building a setup?** The first
+  points to a scanner; the second to an SDR.
+- **Will it move around — car, pocket, field?** A scanner travels effortlessly; an SDR
+  wants a computer along.
+- **Do you want to log, record, and analyse, or watch a whole system at once?** That is
+  SDR territory, and GopherTrunk's home ground.
+- **Is budget tight and do you already have a computer?** A cheap SDR is the lowest-cost
+  door into digital trunk-tracking.
+
+Plenty of people end up with **both** — a dedicated scanner for the car and portability,
+and an SDR running GopherTrunk as an always-on monitoring post at home. They are
+complementary as often as they are alternatives, which is why the rest of this module
+teaches the concepts in a way that applies to either.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the SDR captures a wide slice of spectrum, so software can watch many channels at once instead of sweeping one at a time." markdown="0">
+  <p class="knowledge-check__q">Quick check: what can an SDR-plus-software setup do that a dedicated scanner fundamentally cannot?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Decode encrypted voice without the key</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Watch a whole band at once and log everything on it, rather than sweeping one channel at a time</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Run on batteries in your pocket with no other equipment</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **hardware scanner** is a self-contained appliance — simple, portable, reliable, but
+  **fixed in capability** and one-channel-at-a-time.
+- An **SDR plus software** like GopherTrunk is a flexible system — it can **watch a whole
+  band**, **log and record everything**, and **grow through updates** — but needs a
+  **computer** and setup.
+- The core trade is **simplicity vs. capability**; both do the fundamental scanning job
+  and both decode unencrypted digital systems.
+- Cheap SDR front ends can **overload** in strong-signal areas, a solvable but
+  real consideration.
+- Many listeners run **both** — a scanner for the field, an SDR for an always-on post at
+  home.
+
+Next up: [Choosing a scanner or SDR](/learn/scanning/choosing-a-scanner/).

--- a/docs/learn/scanning/scanning-legal-and-ethical.md
+++ b/docs/learn/scanning/scanning-legal-and-ethical.md
@@ -1,0 +1,153 @@
+---
+slug: scanning-legal-and-ethical
+title: Legal & ethical scanning
+description: The rules and etiquette that keep the scanning hobby healthy — what is legal to receive, what is not legal to do with it, why encryption is off-limits, and the responsible-monitoring habits that separate a good listener from a nuisance.
+keywords: scanning legal, is scanning legal, scanner laws, encrypted radio law, receive-only legal, scanner ethics, responsible monitoring, rebroadcasting scanner audio
+level: beginner
+status: full
+prereq:
+  - what-you-can-hear
+faq:
+  - q: Is it legal to listen to a scanner?
+    a: "In most of the United States and many other countries, receiving unencrypted radio for personal use is legal — the airwaves are open and a receiver is passive. But the details vary by jurisdiction: some places restrict scanners in vehicles, some regulate reception of certain services, and what you may lawfully do with what you hear is a separate question from whether you may hear it. Always check the law where you are."
+  - q: Can I share or rebroadcast what I hear?
+    a: Receiving a transmission and rebroadcasting or publishing its contents are different acts with different rules. Many jurisdictions restrict divulging or using the contents of radio communications, and even where sharing is legal it may be harmful — publishing names, addresses, or medical details from a call can hurt real people. Treat rebroadcasting as a deliberate decision with its own responsibilities, not an automatic right.
+  - q: Why can't I just decrypt encrypted traffic?
+    a: "Encrypted traffic is scrambled so only authorized radios can recover it, and defeating that encryption is generally illegal as well as technically impractical — no scanner or software, GopherTrunk included, decodes it. The ethical and legal stance is the same: encrypted means not for you. Leave it, and spend your time on the large open portion of the spectrum."
+---
+
+# Legal & ethical scanning
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Scanning is **receive-only**, and in most places **receiving unencrypted radio for
+personal use is legal** — but *what you may do with what you hear* is a separate
+question, and both vary by jurisdiction. **Never try to defeat encryption** (illegal
+and impossible), be careful about **rebroadcasting or publishing** what you hear, and
+never **act on traffic in ways that interfere or cause harm**. The
+[RF & SDR module's legal & ethical lesson](/learn/rf-sdr/legal-ethical/) covers the same
+ground for SDR; this is the scanner-listener's version. Good etiquette is what keeps the
+hobby open.
+</div>
+
+The [last lesson](/learn/scanning/what-you-can-hear/) mapped what is open and what is
+closed. This one is about staying on the right side of both the law and good conduct —
+the ground rules that let the hobby continue. None of this is legal advice, and the
+specifics differ by country and even by state, so treat it as a framework and verify the
+details where you live.
+
+## Receiving is passive — and mostly legal
+
+The foundational fact is that a scanner is a **receiver**. It emits nothing; it simply
+detects radio waves that are already passing through the space you occupy. Because
+reception is passive and the airwaves are a shared public resource, **receiving
+unencrypted radio for personal use is legal in most of the United States and many other
+countries.** You are not tapping a line or breaking into anything — the signal came to
+you.
+
+That said, "mostly legal" is not "always legal everywhere":
+
+- Some jurisdictions **restrict scanners in vehicles**, or tie legality to intent (e.g.
+  using a scanner in the commission of a crime).
+- Some countries **regulate reception** of particular services more tightly than the US
+  does.
+- Some places distinguish between **owning**, **using**, and **using for a particular
+  purpose**.
+
+The safe habit is to look up the rules for **your** jurisdiction before you assume, the
+same way you would check what is on the air locally.
+
+## Receiving vs. using — two different questions
+
+Here is the distinction that trips up newcomers: **being allowed to hear something is
+not the same as being allowed to do anything you like with it.** Many legal systems draw
+a line between *receiving* a communication and *divulging or using its contents*. You may
+lawfully hear a call and still be restricted in publishing it, acting on it, or profiting
+from it.
+
+Practically, keep two questions separate in your mind:
+
+1. **May I receive this?** (Usually yes, if it is unencrypted and you are listening
+   personally.)
+2. **May I share, publish, or act on it?** (Often more restricted — and even when legal,
+   frequently unwise.)
+
+Answering the first "yes" tells you nothing about the second.
+
+## Encryption is off-limits, full stop
+
+If a system is **encrypted**, it is not for you — legally, technically, and ethically.
+Encrypted voice is scrambled so only radios with the key can recover it; to everyone else
+it is noise, and **no scanner or software, GopherTrunk included, can decode it.**
+Attempting to defeat encryption is generally **illegal** on top of being impractical, and
+there is no grey area to explore. The agency chose to close that traffic; respect the
+wall and move on to the [large open portion of the
+spectrum](/learn/scanning/what-you-can-hear/).
+
+## Don't interfere, don't cause harm
+
+The receive-only nature of scanning also carries a duty: **do no harm with what you
+hear.** A few concrete lines the community holds to:
+
+- **Never transmit on, jam, or interfere with** the systems you monitor. A scanner
+  cannot transmit, but the principle extends to never using other equipment to disrupt
+  the traffic you listen to.
+- **Never act on live public-safety traffic** in a way that impedes responders — showing
+  up at an active scene, interfering with an operation, or beating first responders to a
+  call is dangerous and can be criminal.
+- **Never use monitored information to commit or aid a crime.** This is exactly the kind
+  of "use" that turns lawful reception into an offence.
+
+The hobby's freedom rests on scanner listeners being harmless observers. One person
+acting badly on what they heard is how restrictions get written.
+
+## Rebroadcasting and privacy
+
+Sharing what you hear — a live feed, a posted recording, a social-media clip — is its own
+decision with its own weight. Even where rebroadcasting is legal, remember that the
+traffic often concerns **real people on their worst day**: victims, patients, callers.
+Broadcasting a name, an address, a licence plate, or a medical detail can cause genuine
+harm and follows people long after the incident.
+
+If you run a feed or publish recordings, the responsible practice is to think about
+**what you are exposing and about whom**, to honour any delay or filtering norms in your
+community, and to err toward the person in the traffic rather than the story. We return
+to feeds specifically in
+[audio feeds & streaming](/learn/scanning/audio-feeds-and-streaming/), where the
+mechanics and the responsibilities meet.
+
+## The etiquette that keeps the hobby healthy
+
+Beyond the law there is simply being a good citizen of the airwaves. Listen out of
+interest, not intrusion. Don't sensationalise. Don't dox. Share knowledge with newcomers,
+contribute accurate frequencies back to the community databases, and treat the agencies
+you monitor as neighbours rather than targets. The scanning hobby has stayed broadly
+legal and welcome because most of its practitioners behave this way — quiet, curious, and
+respectful. Keeping it that way is on all of us.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — being allowed to receive something is a separate question from what you may lawfully or ethically do with it." markdown="0">
+  <p class="knowledge-check__q">Quick check: you can legally receive an unencrypted call. What does that tell you about sharing it?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">That you are automatically free to publish or rebroadcast it however you like</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Nothing on its own — using, sharing, or publishing the contents is a separate question with its own rules and risks</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">That the traffic must not have been sensitive, or it would have been encrypted</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A scanner is **receive-only and passive**, and **receiving unencrypted radio for
+  personal use is legal in most places** — but rules vary, so check your jurisdiction.
+- **Receiving** something and **using or publishing** it are **separate questions**;
+  "yes" to the first says nothing about the second.
+- **Encryption is off-limits** — illegal to defeat and impossible to decode; leave it and
+  enjoy the open spectrum.
+- **Do no harm**: never interfere, never act on live traffic in ways that impede
+  responders, never use what you hear to commit a crime.
+- **Rebroadcasting carries responsibility** — real people are in that traffic, so weigh
+  privacy before you publish.
+- **Good etiquette keeps the hobby legal and welcome** — listen with respect and give
+  back to the community.
+
+Next up: [Hardware scanners vs. SDR](/learn/scanning/scanners-vs-sdr/).

--- a/docs/learn/scanning/scanning-with-sdr-software.md
+++ b/docs/learn/scanning/scanning-with-sdr-software.md
@@ -1,0 +1,136 @@
+---
+slug: scanning-with-sdr-software
+title: Scanning with SDR software
+description: The software side of SDR scanning — the tools that turn a raw software-defined radio into a trunk-tracking scanner, from waterfall viewers to full decoders, and where GopherTrunk fits among them.
+keywords: SDR software, trunk tracking software, SDRTrunk, DSDplus, OP25, GopherTrunk, SDR scanner, software defined radio scanning, decoder software, wideband capture
+level: intermediate
+status: full
+prereq:
+  - scanners-vs-sdr
+faq:
+  - q: Why do you need software to scan with an SDR?
+    a: "An SDR is just a receiver — it hands your computer a raw stream of radio samples and does nothing with it on its own. All the scanning intelligence lives in software: tuning, demodulating, decoding a control channel, following grants, recording, and logging. With a hardware scanner that logic is baked into the box; with an SDR you choose the software, which is both the freedom and the work."
+  - q: What kinds of SDR scanning software are there?
+    a: A rough ladder. General SDR viewers show you the spectrum and demodulate one signal. Digital-voice decoders add the ability to decode specific protocols. Full trunk-trackers read the control channel and follow calls across a whole system automatically. GopherTrunk sits at that top rung — a multi-protocol trunk-tracking decoder.
+  - q: What's the advantage of software over a hardware scanner?
+    a: Flexibility and reach. Software can be updated to handle new protocols, can decode several channels or systems at once from one wideband capture, exposes everything for logging and integration, and turns a cheap receiver into a capable scanner. The trade is that you assemble and maintain the setup yourself instead of switching on a finished appliance.
+---
+
+# Scanning with SDR software
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+An [SDR](/learn/rf-sdr/what-is-sdr/) is just a receiver — it hands your computer raw
+radio samples and nothing more. **All the scanning intelligence lives in software**:
+tuning, demodulating, decoding the control channel, following calls, recording. The
+tools form a ladder — from **spectrum viewers**, to **digital-voice decoders**, up to
+full **trunk-trackers** that follow a whole system automatically. **GopherTrunk** sits
+at that top rung: a multi-protocol trunk-tracking decoder. Software is the freedom of
+SDR — and the work.
+</div>
+
+A hardware scanner is an appliance: the tuning, the trunk-tracking, the recording are
+all baked into the box, and you switch it on. An SDR is the opposite — a bare
+receiver that streams raw samples to your computer and does *nothing* with them by
+itself. Everything that makes it a scanner is software you choose and run. That's the
+trade at the heart of [scanners vs. SDR](/learn/scanning/scanners-vs-sdr/): more
+power and flexibility, in exchange for assembling the setup yourself. This lesson maps
+the software landscape and shows where GopherTrunk fits.
+
+## The SDR is just the front door
+
+It's worth being blunt about the division of labour. If you've read
+[what an SDR is](/learn/rf-sdr/what-is-sdr/), you know the hardware's whole job is to
+tune to a chunk of spectrum and digitise it — turn radio into a stream of numbers.
+From there, **everything is software**:
+
+- **Demodulation** — pulling the signal out of the samples.
+- **Decoding** — turning the demodulated symbols into bits, then into voice or data.
+- **Trunk-tracking** — reading the control channel and following grants to voice
+  channels.
+- **Recording, logging, alerting** — everything you built up over Unit 5.
+
+With a hardware scanner all of that is invisible, inside the case. With an SDR it's
+laid bare, which is exactly why SDR scanning is where the interesting work — and this
+whole path — lives.
+
+## A ladder of tools
+
+SDR scanning software isn't one thing; it's a range, and it helps to see it as rungs
+on a ladder from "look at the spectrum" to "follow the whole system":
+
+1. **Spectrum viewers / general SDR apps.** These show you the
+   [waterfall](/learn/scanning/identifying-unknown-signals/), let you tune around,
+   and demodulate one signal at a time. Superb for exploring a band and
+   [identifying signals](/learn/scanning/identifying-unknown-signals/), but they don't
+   trunk-track — they're the eyes, not the brain.
+2. **Digital-voice decoders.** Add the ability to decode specific digital protocols,
+   so you hear a P25 or DMR conversation instead of a buzz. A step up, but often still
+   channel-at-a-time rather than following a trunked system.
+3. **Trunk-trackers.** The top rung: software that reads the
+   [control channel](/learn/scanning/programming-a-trunked-system/), follows grants
+   automatically, and decodes the resulting voice — the full behaviour a hardware
+   trunking scanner gives you, in software.
+
+Several well-known projects live on that top rung, and GopherTrunk is one of them.
+The point of the ladder isn't to rank them but to know *what job you're asking the
+software to do* before you pick a tool.
+
+## What software buys you over a box
+
+Why go through the assembly at all? Because software reaches places a sealed scanner
+can't:
+
+- **New protocols by update.** A scanner's decoding is fixed at manufacture; software
+  gains new modes with a new release.
+- **Many channels at once.** One wideband SDR capture can contain a whole system's
+  worth of channels, and software can decode several in parallel — a single receiver
+  covering what would take several scanners.
+- **Everything is exposed.** Logs, metadata, recordings, and live status are all
+  available to script, store, and integrate, which is what made Unit 5's
+  [logging](/learn/scanning/logging-and-recording/) and
+  [alerting](/learn/scanning/alerting-on-calls/) so natural.
+- **Cheap hardware, capable scanner.** An inexpensive SDR plus good software rivals a
+  far pricier appliance — and grows instead of ageing out.
+
+The cost is real and worth naming: you build and maintain the setup, keep the
+software current, and own the troubleshooting. For many people that's not a downside
+at all — it's the fun.
+
+## Where GopherTrunk fits
+
+GopherTrunk is a **multi-protocol trunk-tracking decoder** on that top rung — it takes
+the raw samples from an SDR, locks a system's control channel, follows every grant,
+and decodes the voice, across P25, DMR, NXDN, TETRA, and more. It's built to be the
+brain behind the receiver: the piece that turns a bare SDR into a scanner that follows
+whole systems, records per call, and runs unattended. It's open source, so you can see
+and shape exactly how it decodes, which is the theme this module's final unit is all
+about.
+
+The next lesson puts it to work on a real system, and the one after assembles it into
+a complete, worked monitoring setup end to end.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — an SDR only digitises the spectrum; demodulation, decoding, and trunk-tracking all happen in software." markdown="0">
+  <p class="knowledge-check__q">Quick check: with an SDR, where does the trunk-tracking and decoding actually happen?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Inside the SDR hardware, like a scanner in a box</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">In software on your computer — the SDR only digitises the spectrum</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">On the trunked system's control channel, which does it for you</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- An **SDR is just a receiver** — it digitises the spectrum; all scanning
+  intelligence lives in **software** on your computer.
+- SDR scanning tools form a ladder: **spectrum viewers**, **digital-voice decoders**,
+  and full **trunk-trackers** that follow a whole system.
+- Software buys you **new protocols by update**, **many channels from one wideband
+  capture**, **everything exposed** for logging and integration, and a capable
+  scanner from cheap hardware.
+- The cost is that you **assemble and maintain** the setup yourself.
+- **GopherTrunk** is a multi-protocol **trunk-tracker** on the top rung — the brain
+  that turns a bare SDR into a system-following scanner.
+
+Next up: [GopherTrunk as a scanner](/learn/scanning/gophertrunk-as-a-scanner/).

--- a/docs/learn/scanning/searching-and-discovery.md
+++ b/docs/learn/scanning/searching-and-discovery.md
@@ -1,0 +1,123 @@
+---
+slug: searching-and-discovery
+title: Search, scan & discovery
+description: How to find what the databases don't list — running a frequency search across a band, spotting active channels on a hardware scanner or an SDR waterfall, and close-call techniques for catching the transmitters right next to you.
+keywords: frequency search, scanner search mode, close call, signal stalker, SDR waterfall discovery, band scan, finding unlisted frequencies, active channel, service search, spectrum sweep
+level: intermediate
+status: full
+prereq:
+  - band-plans
+faq:
+  - q: What's the difference between scanning and searching?
+    a: Scanning steps through a list of frequencies you already know and stops on activity. Searching sweeps a continuous range of frequency looking for any transmission at all, whether or not you have it listed. Scanning tells you when your known channels are busy; searching is how you discover channels you never had.
+  - q: What is close call or signal stalker?
+    a: It's a feature on many hardware scanners that instantly detects and tunes a strong nearby transmitter without you knowing its frequency in advance. Because a close transmitter overwhelms the receiver, the scanner can lock onto it in a fraction of a second — ideal for catching a radio being used right next to you.
+  - q: Is an SDR better than a scanner for discovery?
+    a: For discovery, an SDR's waterfall is a real advantage — it shows a whole band at once, so you see every active carrier as a visible trace instead of stepping through frequencies one at a time. A hardware scanner searches faster per channel but sees only where it's tuned this instant. Many hobbyists use both.
+---
+
+# Search, scan & discovery
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+When the [databases](/learn/scanning/radioreference-database/) come up empty, you go find the
+signals yourself. **Searching** sweeps a continuous range of frequency for any activity — unlike
+**scanning**, which only steps through channels you already know. On an **SDR** the
+[waterfall](/learn/rf-sdr/fft-and-waterfall/) shows a whole band at once so active carriers jump
+out visually; on a **hardware scanner**, search mode and **close-call** features hunt for you.
+Discovery is where the [band plan](/learn/scanning/band-plans/) pays off — you search the right
+neighbourhood, then confirm what you caught.
+</div>
+
+Databases document the known. But new systems appear, business licences go unlogged, and the
+transmitter in the truck next to you at a traffic light is on *some* frequency nobody has ever
+written down. Discovery is the craft of finding those signals — and it's some of the most
+satisfying work in the hobby, because what you catch is genuinely yours to identify. This lesson
+covers the three main ways to hunt: searching a band, watching a waterfall, and close-call
+detection.
+
+## Scanning vs. searching
+
+The two words get used loosely, but the distinction matters. **Scanning** steps through a list
+of frequencies you already have and stops when one is active — it tells you *which of your known
+channels is busy right now*. **Searching** sweeps a continuous span of frequency, say 450 to 460
+MHz, listening for *any* transmission, listed or not. Scanning works a list; searching works a
+range.
+
+Discovery is almost entirely a searching activity. You point a search at a band where the
+[band plan](/learn/scanning/band-plans/) says interesting traffic lives, let it sweep, and note
+every frequency it stops on. Over a few sessions you build a picture of what's actually on the
+air in your area — including plenty the databases never captured.
+
+## Searching on a hardware scanner
+
+Most scanners have a **search mode** where you set a lower and upper frequency and the radio steps
+across the range, pausing on any active channel. You can define **service searches** (pre-set
+ranges for public safety, air, marine, and so on) or your own custom limits. When the scanner
+stops, note the frequency, the mode, and anything you can tell about the traffic.
+
+Search mode has a rhythm to learn. Set the step size to match the band's channel spacing so you
+land on real channel centres, not between them. Expect false stops on noise and intermittent
+carriers, and expect to sit through dead air — searching rewards patience. The payoff is a list
+of live frequencies you can then look up or identify.
+
+## Discovery on an SDR waterfall
+
+An SDR changes the game because it shows a whole slice of spectrum **at once**. On the
+[waterfall](/learn/rf-sdr/fft-and-waterfall/), every active carrier appears as a visible vertical
+trace, so instead of stepping through frequencies blind, you *see* where the activity is. A busy
+band lights up like a city skyline, and you simply click the traces that interest you.
+
+This visual search is faster for surveying a band and far better at catching brief or bursty
+transmissions, because a signal that keys up anywhere in view leaves a mark you can scroll back
+to. It's also how you spot the tell-tale **solid, unbroken column** of a
+[control channel](/learn/digital-trunking/the-control-channel/) — a signature that's obvious on
+a waterfall and invisible on a channel-stepping scanner. The
+[finding-systems](/learn/rf-sdr/finding-systems/) lesson goes deeper on the SDR discovery
+workflow.
+
+## Close call — catching what's right next to you
+
+One of the most fun tricks in the hobby is **close call** (branded "Signal Stalker" on some
+scanners): the radio instantly detects and tunes a **strong nearby transmitter** without you
+knowing its frequency at all. Because a transmitter a few metres away floods the receiver, the
+scanner can identify its frequency in a fraction of a second and jump straight to it.
+
+It's ideal for catching a security guard's handheld, a store's radios, an event's crew, or the
+service truck at the next pump — anything transmitting close by. The catch is in the name: it
+only works on *close, strong* signals, so it's a proximity tool, not a general search. Used well,
+it turns "I wonder what they're on" into an answer in seconds.
+
+## Turning a catch into knowledge
+
+Finding a signal is only half the job — next you have to figure out **what it is**. Note
+everything at the moment of the catch: the exact frequency, the mode (AM or FM), how wide it is,
+whether it's voice or data, and what the [band plan](/learn/scanning/band-plans/) suggests for
+that neighbourhood. That bundle of clues feeds straight into the
+[identifying an unknown signal](/learn/scanning/identifying-unknown-signals/) lesson, and once
+you've named it, into your [frequency records](/learn/scanning/frequency-records/) so the catch
+isn't lost.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — searching sweeps a continuous range for any activity, which is how you find frequencies no database listed." markdown="0">
+  <p class="knowledge-check__q">Quick check: you want to find transmitters that aren't in any database. Which do you use?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Scan mode, stepping through your saved channel list</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Search mode, sweeping a continuous range of frequency</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">A priority scan on your favourite talkgroup</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Scanning** works a list of known channels; **searching** sweeps a continuous range for *any*
+  activity — discovery is a searching job.
+- On a **hardware scanner**, search mode and service searches step across a band; mind the step
+  size and expect patience.
+- On an **SDR**, the [waterfall](/learn/rf-sdr/fft-and-waterfall/) shows a whole band at once, so
+  active carriers — and control channels — are visible at a glance.
+- **Close call** instantly tunes a strong *nearby* transmitter without knowing its frequency —
+  perfect for what's right next to you.
+- Note the frequency, mode, and width at the moment of a catch, then **identify** it and log it.
+
+Next up: [identifying an unknown signal](/learn/scanning/identifying-unknown-signals/).

--- a/docs/learn/scanning/station-setup.md
+++ b/docs/learn/scanning/station-setup.md
@@ -1,0 +1,150 @@
+---
+slug: station-setup
+title: Setting up your station
+description: Assembling the pieces into a working monitoring setup — receiver, antenna, feedline, and (for SDR) a computer running software like GopherTrunk — whether it's a scanner on the desk or a rooftop antenna feeding an always-on post. A practical setup walkthrough.
+keywords: scanner station setup, SDR station, monitoring setup, GopherTrunk setup, receiver antenna computer, home scanning station, desk scanner, rooftop antenna setup
+level: intermediate
+status: full
+prereq:
+  - feedlines-and-connectors
+faq:
+  - q: What do I actually need to set up a scanning station?
+    a: At minimum a receiver, an antenna, and the feedline joining them. A hardware scanner adds nothing else — antenna in, switch on. An SDR setup also needs a computer (even a small board) running software like GopherTrunk to do the tuning and decoding. From there, sound output, power, and a place to put it all turn the pieces into a station you actually use.
+  - q: Where should I put the receiver relative to the antenna?
+    a: As close as practical, to keep the feedline short and its loss low. For an SDR that often means mounting the dongle near the antenna and running USB or network to the computer, rather than a long coax run down to the desk. For a hardware scanner, a short good-quality coax to a well-placed antenna is the goal. Short feedline, well-placed antenna is the recurring theme.
+  - q: Can I run a scanning station unattended?
+    a: Yes, and an SDR running GopherTrunk is well suited to it — it can decode, log, and record around the clock on a small always-on computer. A basic always-on post needs reliable power, stable software, and somewhere to store recordings. This lesson gets the pieces working together; building a hardened 24/7 post is its own later topic.
+---
+
+# Setting up your station
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A station is just the pieces of the last three lessons **connected and working
+together**: a **receiver**, an **[antenna](/learn/scanning/antennas-for-scanning/)**, the
+**[feedline](/learn/scanning/feedlines-and-connectors/)** between them, and — for SDR — a
+**computer running software** like GopherTrunk. Keep the **feedline short** by putting the
+receiver near the antenna, get the **power and audio** sorted, and give it a stable home.
+The same recipe scales from a **scanner on the desk** to a **rooftop antenna feeding an
+always-on post**.
+</div>
+
+You have [chosen a receiver](/learn/scanning/choosing-a-scanner/), got an
+[antenna](/learn/scanning/antennas-for-scanning/) up high, and understand the
+[feedline and grounding](/learn/scanning/feedlines-and-connectors/). This lesson assembles
+those parts into a working **station** — something you switch on and listen to. The
+components are the same whichever road you took; only the amount of assembly differs.
+
+## The pieces, and how they connect
+
+Every scanning station, from the simplest to the most elaborate, is the same short chain:
+
+1. **Antenna** — captures the signal (the ceiling on everything).
+2. **Feedline** — carries it down, losing as little as possible.
+3. **Receiver** — a hardware scanner, or an SDR that digitizes the spectrum.
+4. **(SDR only) Computer + software** — GopherTrunk or similar, doing the tuning,
+   decoding, and trunk-tracking.
+5. **Output** — a speaker or headphones, plus logging and recording if you want them.
+
+A **hardware scanner** collapses steps 3–5 into one box: antenna in, switch on, listen. An
+**SDR** setup keeps them separate — the dongle is the receiver, and a computer does the
+rest — which is what gives it its flexibility and what asks a little more of you to set up.
+
+## The desk setup
+
+The simplest station lives on a desk. For a **hardware scanner**, that is genuinely: plug
+the antenna in, apply power, and program it. The only real decisions are where the antenna
+goes (as [high and outdoor as you can manage](/learn/scanning/antennas-for-scanning/)) and
+keeping the feedline decent.
+
+For an **SDR on the desk**, the chain is antenna → coax → SDR dongle → USB → computer →
+GopherTrunk. Two practical notes make it painless:
+
+- **Mind USB noise and heat.** SDR dongles run warm and are sensitive to USB electrical
+  noise; a short USB extension to move the dongle away from the computer often *reduces*
+  interference and improves what you hear.
+- **Keep the coax short.** The same feedline logic applies — a long coax to a desk in the
+  basement is loss you don't need.
+
+This is the ideal setup to *learn* on. Everything is in reach, easy to change, and quick
+to troubleshoot. Get comfortable here before you commit an antenna to the roof.
+
+## The remote-antenna setup
+
+To hear well you want the antenna outdoors and high, but that puts it far from your desk —
+and a long coax run [loses signal](/learn/scanning/feedlines-and-connectors/), worst of all
+at UHF. The elegant answer, especially for SDR, is to **move the receiver to the antenna
+instead of the antenna to the receiver**:
+
+- Mount the **SDR near the antenna** (in a weatherproof enclosure) so the lossy coax run is
+  as short as centimetres, then carry the signal the rest of the way as **USB or over the
+  network** — which, unlike RF in coax, doesn't degrade with distance.
+- A small always-on computer — a Raspberry Pi or mini-PC — up near the antenna running
+  GopherTrunk can decode on the spot and stream results to wherever you actually sit.
+
+This is the shape of a serious home station: antenna high and outside, receiver right
+behind it, short feedline, and the intelligence delivered to you over a cable that doesn't
+care about distance. It is also the natural seed of an
+[always-on monitoring post](/learn/scanning/building-a-monitoring-post/).
+
+## Power, audio, and the boring essentials
+
+A station is only as reliable as its dull supporting parts:
+
+- **Power.** Give the receiver and computer clean, stable power. Cheap switching supplies
+  can inject [noise](/learn/scanning/reducing-interference/) straight into your reception —
+  a common, maddening, and avoidable problem.
+- **Audio.** Decide how you'll listen: the scanner's own speaker, powered speakers, or
+  headphones on the computer. For SDR, check the software is routed to the output you
+  expect.
+- **Storage.** If you'll log and record — and an SDR makes that easy — make sure there's
+  somewhere for the files to go. A busy trunked system produces a surprising amount of
+  audio.
+- **A stable home.** Somewhere the gear can sit undisturbed, ventilated, and cabled
+  tidily. Nothing kills a station faster than a knocked antenna lead or an overheating
+  dongle.
+
+## Verify it end to end
+
+Before you call it done, confirm the whole chain actually works, in order:
+
+1. **Signal in.** Does the receiver see the band — noise floor, and real carriers on the
+   [waterfall](/learn/rf-sdr/finding-systems/) for an SDR, or activity on a known-busy
+   channel for a scanner?
+2. **Decode.** Point it at a known local system and confirm it locks and produces audio.
+   For a trunked system, confirm it reads the
+   [control channel](/learn/digital-trunking/the-control-channel/) and follows a call.
+3. **Output and logging.** Confirm you can hear it, and that recordings and logs land where
+   you expect.
+
+If a step fails, you've localised the problem to that link in the chain rather than staring
+at the whole station. That habit — test the chain link by link — is the single most useful
+troubleshooting skill you can build, and it carries straight into
+[reducing interference](/learn/scanning/reducing-interference/), where the enemy is the
+noise your own setup and city inject into that chain.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — putting the receiver near the antenna keeps the lossy RF feedline short, then USB or network carries the signal the rest of the way without loss." markdown="0">
+  <p class="knowledge-check__q">Quick check: your antenna is on the roof and your desk is in the basement. What's the low-loss way to connect them?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Run a long coax all the way down to the desk — cable length doesn't matter for receiving</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Mount the receiver near the antenna to keep the coax short, then carry the signal down over USB or the network</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Use a higher-gain antenna to overcome the long coax loss</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A station is the same short chain every time: **antenna → feedline → receiver → (SDR)
+  computer + software → output**.
+- A **hardware scanner** collapses the receiver-and-brains into one box; an **SDR** keeps
+  them separate, driven by software like GopherTrunk.
+- The **desk setup** is ideal to learn on; keep coax short and mind **USB noise and heat**
+  on an SDR.
+- For a remote antenna, **move the receiver to the antenna** and carry the signal the rest
+  of the way over **USB or the network**, which doesn't degrade with distance.
+- Don't neglect **clean power, audio routing, storage, and a stable home** — the boring
+  parts make or break reliability.
+- **Verify the chain link by link** — signal, decode, output — so any fault is localised.
+
+Next up: [Reducing noise &amp; interference](/learn/scanning/reducing-interference/).

--- a/docs/learn/scanning/talkgroups-and-scan-lists.md
+++ b/docs/learn/scanning/talkgroups-and-scan-lists.md
@@ -1,0 +1,123 @@
+---
+slug: talkgroups-and-scan-lists
+title: Talkgroups, scan lists & priorities
+description: Deciding what you actually hear on a busy trunked system — organising talkgroups into scan lists, locking out the traffic you don't want, and setting priorities so the calls you care about interrupt everything else.
+keywords: talkgroups, scan list, priority scan, lockout, alpha tag, trunked scanning, talkgroup ID, favourites list, avoid channel, monitoring priorities
+level: intermediate
+status: full
+prereq:
+  - programming-a-trunked-system
+faq:
+  - q: What is a talkgroup?
+    a: A talkgroup is a logical channel on a trunked system — a group of radios that talk to each other, like "County Fire Dispatch" or "PD Patrol North." It isn't a frequency; it's an ID the system uses to route a conversation to whichever voice channel is free. Following a trunked system means following talkgroups, not frequencies.
+  - q: What's a scan list for?
+    a: A scan list is your curated selection of which talkgroups the receiver should follow. A busy system can carry hundreds of talkgroups, most of which won't interest you, so a scan list lets you monitor just the ones you care about — and swap between different lists for different situations.
+  - q: What does priority do?
+    a: Priority lets an important talkgroup interrupt a lower-priority call in progress. Set your key dispatch channel as priority and, even while you're listening to routine chatter, the receiver breaks away the instant that priority talkgroup keys up — so you never miss the calls that matter most.
+---
+
+# Talkgroups, scan lists & priorities
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A busy trunked system carries far more traffic than you want to hear, so you **curate**. A
+**talkgroup** is a logical channel — a group of radios, identified by an ID, not a frequency — and
+following a trunked system means following talkgroups. **Scan lists** are your chosen selection of
+them; **lockout** silences the ones you don't want; and **priority** lets a key talkgroup interrupt
+whatever else is playing. Together these turn a firehose into exactly the calls you care about.
+Build on [talkgroup basics](/learn/digital-trunking/talkgroups-ids-affiliation/) and your
+[frequency records](/learn/scanning/frequency-records/).
+</div>
+
+Once a trunked system is [programmed](/learn/scanning/programming-a-trunked-system/) and locked,
+you face a new problem: there's too much to hear. A metro system might carry hundreds of
+talkgroups — every fire, police, public-works, transit, and school channel in a county — and
+listening to all of them at once is just noise. This lesson is about *curation*: choosing what you
+hear, silencing what you don't, and making sure the important calls always win.
+
+## Talkgroups, not frequencies
+
+The unit of a trunked system is the **talkgroup** — a set of radios that talk together, identified
+by a numeric ID and usually a short **alpha tag** like "Fire Dispatch." It is *not* a frequency;
+the system routes a talkgroup's calls to whichever voice channel is free at that moment. So when
+you follow a trunked system, you follow **talkgroups**, and the receiver handles the frequency
+hopping underneath.
+
+This is why your [records](/learn/scanning/frequency-records/) for a trunked system are a list of
+talkgroup IDs and tags rather than frequencies, and why the [talkgroup
+basics](/learn/digital-trunking/talkgroups-ids-affiliation/) lesson matters here — the ID is the
+handle you organise everything around.
+
+## Scan lists — choosing what you follow
+
+A **scan list** is your curated set of talkgroups to monitor. Instead of following every talkgroup
+on the system, you pick the ones that interest you — say, county fire and the two police districts
+near you — and group them into a list. The receiver then follows only those, ignoring the rest.
+
+The real power is having **several lists** for different situations. A "daily" list of the channels
+you always want, an "incident" list you switch to when something's happening, a "railfan" or
+"aviation" list for a specific interest. Switching lists reshapes what you hear in one action,
+which is far faster than editing talkgroups one at a time. Consistent alpha tags from your records
+make these lists quick to build and easy to read while scanning.
+
+## Lockout — silencing the noise
+
+The mirror image of a scan list is **lockout** (sometimes "avoid"). When a talkgroup you don't care
+about keeps interrupting — an automated data channel, a chatty maintenance group, a distant
+talkgroup you can barely hear — you lock it out and the receiver skips it from then on. Lockout is
+how you refine a list in the field: leave everything on at first, then lock out whatever annoys you
+until only the good traffic remains.
+
+It's worth distinguishing **temporary** from **permanent** lockout on radios that offer both — a
+temporary lockout clears when you power-cycle, handy for a talkgroup that's busy today but usually
+interesting, while a permanent one sticks.
+
+## Priority — never missing the important call
+
+Even within a good scan list, some talkgroups matter more than others. **Priority** solves this: a
+talkgroup you mark as priority can **interrupt** a lower-priority call already in progress. Set your
+main dispatch channel as priority, and while you're listening to routine chatter the receiver keeps
+one ear on that priority talkgroup and breaks away the instant it keys up.
+
+This is the feature that lets you monitor casually without missing the calls you actually tuned in
+for. On a busy system it's the difference between hearing a dispatch as it happens and catching it
+three calls later — if at all. Use it sparingly: mark only the handful of talkgroups you'd genuinely
+drop everything for, or priority loses its meaning.
+
+## Building a listening strategy
+
+Put the three together and you have a strategy rather than a raw feed. Start broad — follow most of
+the system to learn what's active and when. Lock out the dead weight as it reveals itself. Group the
+keepers into purpose-built scan lists. Then flag the one or two must-hear talkgroups as priority.
+The result is a setup tuned to *you*: quiet when nothing's happening, and loud with exactly the
+right call when it is.
+
+Every choice you make here also feeds back into your [records](/learn/scanning/frequency-records/) —
+which talkgroups earned a place, which got locked out, which deserve priority — so the strategy
+sharpens each time you use it. With the lists built, the next question is what actually happens on
+the air when one of those talkgroups keys up.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a priority talkgroup interrupts a lower-priority call in progress, so you never miss the calls that matter most." markdown="0">
+  <p class="knowledge-check__q">Quick check: you're listening to routine chatter but must not miss main dispatch. What do you set?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Lock out the routine chatter permanently</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Mark main dispatch as a priority talkgroup so it interrupts</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Delete all your other scan lists</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **talkgroup** is a logical channel — a group of radios identified by an ID, not a frequency —
+  and trunked following means following talkgroups.
+- **Scan lists** are your curated selection of talkgroups; keeping several for different situations
+  lets you reshape what you hear in one action.
+- **Lockout** silences talkgroups you don't want; use temporary lockout for the busy-today,
+  interesting-usually ones.
+- **Priority** lets a key talkgroup **interrupt** a lower-priority call, so you never miss what you
+  tuned in for — use it sparingly.
+- A good strategy is: follow broadly, lock out the dead weight, group the keepers, flag a few as
+  priority — and feed the choices back into your records.
+
+Next up: [following a call across the system](/learn/scanning/following-a-call/).

--- a/docs/learn/scanning/what-is-scanning.md
+++ b/docs/learn/scanning/what-is-scanning.md
@@ -1,0 +1,148 @@
+---
+slug: what-is-scanning
+title: What radio scanning is
+description: Radio scanning is the hobby of monitoring live two-way radio traffic — police, fire, EMS, aviation, rail, utilities, and business — as it happens. Learn what a scanner does, why people listen, and what a modern scanning setup looks like today.
+keywords: radio scanning, what is scanning, police scanner, monitoring radio traffic, two-way radio, scanner hobby, listening to the radio spectrum, trunk tracking scanner
+level: beginner
+status: full
+faq:
+  - q: What is radio scanning?
+    a: "Radio scanning is monitoring live two-way radio traffic — the working communications of public-safety agencies, aviation, rail, utilities, and business — as it happens over the air. A scanner is a receiver that sweeps quickly through a list of frequencies, stops when it hears activity, lets you listen, then resumes sweeping. It is a receive-only hobby: you listen, you do not transmit."
+  - q: Is scanning just listening to the police?
+    a: Public-safety dispatch is the classic draw, but it is a small slice of what is on the air. Scanner listeners follow aircraft and air-traffic control, marine and rail operations, weather and emergency services, utility crews, event and business radios, and amateur repeaters. Much of that traffic is routine and open, and the hobby is as much about the breadth of the spectrum as any one service.
+  - q: Do I need special equipment to start scanning?
+    a: A modern setup is either a dedicated hardware scanner or a software-defined radio (SDR) connected to a computer running software like GopherTrunk. Either one, plus a decent antenna, is enough to start. The rest of this module walks through choosing the gear, putting up an antenna, and finding something to listen to.
+---
+
+# What radio scanning is
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Radio scanning** is the hobby of monitoring live two-way radio traffic — public
+safety, aviation, rail, utilities, business — *as it happens*. A **scanner** is a
+receiver that sweeps quickly through many frequencies, **stops when it hears
+activity**, and lets you listen before moving on. It is a **receive-only** pursuit:
+you listen, you never transmit. A modern setup is either a dedicated hardware
+scanner or a **[software-defined radio](/learn/rf-sdr/what-is-sdr/)** driving software
+like GopherTrunk — and everything downstream starts with a decent antenna.
+</div>
+
+This module is the operator's side of the hobby: not how digital radio works on the
+inside, but how you actually sit down and *listen* to it. This first lesson answers
+the simplest question — what is scanning, really? — and sketches what a working setup
+looks like today. Later lessons build the station, find the systems, and follow the
+calls.
+
+## What a scanner actually does
+
+Most of the radio spectrum is quiet most of the time. A given police dispatch
+channel might carry a few seconds of traffic, then nothing for a minute. If you
+parked a radio on one frequency you would spend most of your time listening to
+silence. A **scanner** solves that by doing what its name says: it **sweeps** — steps
+rapidly through a list of frequencies you have programmed, checking each one for a
+signal.
+
+When it finds a channel that is active, it **stops and lets you hear it**. As long as
+someone is talking, the scanner holds on that frequency. When the transmission ends
+and the channel goes quiet, the scanner resumes sweeping, looking for the next active
+channel. The whole loop happens many times a second, so from your chair it feels like
+one radio that is somehow always on whatever is busy right now.
+
+That single behaviour — sweep, stop on activity, resume — is the heart of the hobby.
+Everything else is refinement: which frequencies you load, how you group them, how you
+decide what is worth stopping for, and how you follow the more complicated systems that
+do not sit still on one channel.
+
+## Why people listen
+
+People come to scanning for very different reasons, and all of them are valid:
+
+- **Situational awareness.** Hearing your local fire, EMS, and public-works traffic
+  gives you a real-time picture of your town — a crash on the highway, a storm rolling
+  in, a water main that just broke — often well before the news.
+- **The technical hobby.** For many, the radios *are* the interest: understanding
+  modulation, antennas, trunking, and digital protocols, and building a station that
+  pulls in weak or distant systems.
+- **A specific service.** Aviation enthusiasts follow air-traffic control; railfans
+  follow train crews and dispatchers; storm-spotters follow weather nets; event-goers
+  follow race or airshow operations.
+- **Emergency preparedness.** When cell networks are down in a disaster, the two-way
+  radio traffic of the responders is still on the air, and a scanner is a way to stay
+  informed.
+
+You do not have to pick one. Most listeners drift across several of these over time.
+
+## Receive only — the one rule that defines the hobby
+
+Scanning is **listening, not talking**. A scanner is a receiver: it has no
+transmitter, and the whole hobby is built on quietly receiving signals that are
+already travelling through the air around you. This is what keeps it legal in most
+places and separates it from **amateur radio**, where you are licensed to transmit and
+hold a two-way conversation.
+
+That receive-only nature also shapes the ethics. You are a listener, not a
+participant — you do not interfere, you do not act on what you hear in ways that cause
+harm, and you respect that some traffic, while receivable, is not yours to
+rebroadcast. We give that its own lesson in
+[legal & ethical scanning](/learn/scanning/scanning-legal-and-ethical/), because the
+line between *what you can receive* and *what you may do with it* matters.
+
+## What a modern setup looks like
+
+Twenty years ago a scanner was a single box with a whip antenna and a numeric keypad.
+That box still exists and still works, but the modern hobby has two roads into it:
+
+- **A dedicated hardware scanner** — a self-contained receiver you switch on, program,
+  and listen to. It is the plug-and-play path: no computer required, purpose-built
+  buttons, and trunk-tracking built in on the better models.
+- **A software-defined radio (SDR)** — a small, cheap receiver that hands raw radio to
+  a computer, where software like **GopherTrunk** does the tuning, decoding, and
+  following. This path is more flexible and more capable, at the cost of a bit more
+  setup.
+
+We compare the two in depth in
+[hardware scanners vs. SDR](/learn/scanning/scanners-vs-sdr/). Either way, the setup is
+the same shape: a **receiver**, a **decent antenna** (the single biggest factor in what
+you can hear), and — for anything trunked or digital — some brains to decode and follow
+the system. GopherTrunk sits at the software end of that spectrum, turning an SDR into a
+trunk-tracking scanner.
+
+## Conventional and trunked, in one breath
+
+You will meet two families of radio systems early. **Conventional** systems assign a
+fixed frequency to a channel — dispatch is *here*, tactical is *there* — so you can park
+on it and listen. **Trunked** systems pool a handful of frequencies and hand them out to
+calls on demand, coordinated by a **[control channel](/learn/digital-trunking/the-control-channel/)**,
+so a single conversation can hop from frequency to frequency. Following a trunked system
+means letting your scanner read that control channel and chase the calls it grants — the
+whole reason trunk-tracking scanners exist. The next few lessons unpack this; the
+digital module covers the theory in
+[conventional vs. trunked](/learn/digital-trunking/conventional-vs-trunked/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a scanner sweeps through frequencies and stops when it hears activity, then resumes." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does a scanner do that a radio parked on one frequency does not?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It transmits a reply so the dispatcher knows you're listening</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">It sweeps through many frequencies and stops on whichever one is active</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It decrypts encrypted traffic automatically</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Scanning** is monitoring live two-way radio traffic as it happens — public safety,
+  aviation, rail, utilities, business, and more.
+- A **scanner** sweeps through many frequencies, **stops on activity**, lets you
+  listen, and resumes — that sweep-and-stop loop is the core of the hobby.
+- People listen for **situational awareness**, the **technical challenge**, a
+  **specific service**, or **preparedness** — often several at once.
+- The hobby is **receive-only**: you listen, you never transmit, which is what keeps it
+  legal and shapes its ethics.
+- A modern setup is a **hardware scanner** or an **SDR plus software** like GopherTrunk,
+  and always a **decent antenna**.
+- Systems come in two families — **conventional** (fixed channels) and **trunked**
+  (frequencies handed out on demand) — and following trunked systems is what the rest of
+  the module builds toward.
+
+Next up: [A short history of scanners](/learn/scanning/history-of-scanning/).

--- a/docs/learn/scanning/what-you-can-hear.md
+++ b/docs/learn/scanning/what-you-can-hear.md
@@ -1,0 +1,142 @@
+---
+slug: what-you-can-hear
+title: What you can (and can't) hear today
+description: A realistic tour of the scannable spectrum — the analog and unencrypted digital traffic still wide open, and the encrypted systems that have gone dark. What's listenable in aviation, marine, rail, weather, business, amateur, and public safety today.
+keywords: what can you hear on a scanner, encrypted police radio, scannable frequencies, analog vs digital scanning, aviation scanning, marine radio, railroad scanning, unencrypted traffic
+level: beginner
+status: full
+prereq:
+  - conventional-vs-trunked-recap
+faq:
+  - q: Can you still hear police on a scanner?
+    a: It depends entirely on your area. Many agencies still run unencrypted digital or analog dispatch you can follow with a trunk-tracking scanner or SDR. A growing number, though, have encrypted some or all of their traffic, and encrypted voice is not decodable by any legal scanner or software — it simply plays as noise. Check a database like RadioReference for your county to see what is open before assuming either way.
+  - q: What is always listenable regardless of encryption trends?
+    a: "Large parts of the spectrum are effectively always open because encryption there is rare or impractical: civil aviation (air-band AM), marine VHF, railroad road channels, NOAA and other weather broadcasts, amateur radio, FRS/GMRS and business itinerant channels, and much utility and public-works traffic. These make a rich hobby on their own even where public safety has gone dark."
+  - q: Why do some systems play as noise?
+    a: Two reasons. Either the traffic is encrypted — scrambled so only radios with the key can recover the audio, which no scanner can defeat — or it is a digital mode your receiver cannot decode. Encryption is a wall; an unsupported-but-unencrypted digital mode is just a gap in your decoder that better software or hardware may close.
+---
+
+# What you can (and can't) hear today
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Plenty of the spectrum is **wide open** — civil **aviation**, **marine**, **rail**,
+**weather**, **amateur**, **business**, and much utility and even public-safety traffic
+is analog or **unencrypted digital** you can follow. What you **cannot** hear is
+**encrypted** voice: it plays as noise and no legal scanner or software defeats it. The
+map varies enormously **by region and agency**, so check a
+[database](/learn/scanning/radioreference-database/) for your area rather than assuming.
+Encryption is a wall; an *unencrypted* mode your gear can't yet decode is just a gap.
+</div>
+
+You now know the [difference](/learn/scanning/conventional-vs-trunked-recap/) between a
+channel you park on and a system you follow. The next honest question is: with all that
+capability, what is actually *there* to listen to today? The answer is a
+lot — but not everything, and the mix has shifted. This lesson is a realistic tour of
+what is open, what has gone dark, and why.
+
+## The two ways a signal can be closed to you
+
+Before the tour, it helps to separate two very different reasons a signal might be
+unlistenable, because people conflate them constantly:
+
+- **Encryption.** The traffic is deliberately scrambled so only radios holding the key
+  can recover the audio. To everyone else it is noise. **No scanner and no software —
+  including GopherTrunk — can decode encrypted voice**, and attempting to defeat
+  encryption is both futile and, in many places, illegal. This is a hard wall.
+- **An unsupported mode.** The traffic is *not* encrypted, but it uses a digital
+  protocol your particular receiver or software does not decode yet. This is a soft gap:
+  better software, a firmware update, or different hardware may open it.
+
+The distinction matters. "I hear noise" is not automatically "it's encrypted." It might
+be an unencrypted mode you simply cannot decode with what you have — and knowing which is
+which tells you whether to upgrade or to move on.
+
+## What's wide open
+
+Large swaths of the spectrum are, in practice, always listenable — because encryption
+there is rare, impractical, or forbidden by the service's own rules:
+
+- **Civil aviation.** The air band (around 118–137 MHz) is **AM** voice and, by
+  international convention, unencrypted — air-traffic control, tower, ground, and
+  en-route are all in the clear. A perennial favourite and utterly reliable.
+- **Marine VHF.** Ship-to-ship, ship-to-shore, and harbour operations on marine VHF are
+  open analog voice.
+- **Railroads.** Road, yard, and dispatcher channels are typically analog (or
+  unencrypted NXDN in some regions) and heavily followed by railfans.
+- **Weather.** NOAA Weather Radio and equivalents broadcast continuously in the clear.
+- **Amateur radio.** By its rules, amateur (ham) traffic **may not be encrypted**, so
+  repeaters and simplex are always open — and often the most technically interesting
+  listening.
+- **FRS / GMRS / MURS and business itinerant.** Consumer and low-power business radios
+  are mostly analog and open.
+- **Utilities and public works.** Power, water, gas, roads, and transit crews are often
+  still analog or unencrypted digital.
+
+Any one of these could sustain the hobby indefinitely, even in a region where public
+safety has locked up.
+
+## Public safety: the shifting frontier
+
+Police, fire, and EMS are the traffic most people first think of, and here the picture
+genuinely varies. A great deal of public-safety radio is still **unencrypted** — analog
+in smaller jurisdictions, or unencrypted **P25** (and DMR, NXDN, or TETRA depending on
+the region) on trunked systems — and a trunk-tracking scanner or GopherTrunk follows it
+fine.
+
+But the trend is toward encryption. Some agencies encrypt only sensitive channels
+(surveillance, tactical, records checks) while leaving dispatch in the clear; others
+have encrypted **everything**. This is a policy decision made agency by agency, so two
+neighbouring counties can be night and day. There is no universal answer to "can I hear
+the police" — only the answer *for your specific area*, which you get from a
+[database](/learn/scanning/radioreference-database/) listing, not from a general
+assumption.
+
+## Trunked and digital, but still open
+
+It is worth stressing that **digital does not mean encrypted, and trunked does not mean
+encrypted.** A modern P25 trunked system can be entirely in the clear; the digital voice
+is a *format*, not a lock. GopherTrunk and trunk-tracking scanners exist precisely to
+decode these unencrypted digital systems and follow their calls. So a region that has
+"gone digital" or "gone trunked" has not necessarily gone dark — it has simply moved to
+systems that need a capable receiver. The [RF & SDR module's
+finding-systems](/learn/rf-sdr/finding-systems/) lesson covers spotting these on the
+air.
+
+## Reading your own area honestly
+
+The practical upshot is that **what you can hear is local**. Before you buy gear or
+write off a service, look your county or region up in a database and read what is
+listed: which systems are conventional, which are trunked, which protocol each uses, and
+crucially which talkgroups are flagged **encrypted**. That listing is the ground truth
+for your location, and it will tell you whether a basic analog scanner is plenty, whether
+you need trunk-tracking, or whether the interesting traffic has been encrypted and your
+attention is better spent on aviation, rail, or the amateur bands. We make that database
+the subject of its own lesson in
+[RadioReference & system databases](/learn/scanning/radioreference-database/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — encrypted voice cannot be decoded by any scanner or software, no matter how capable." markdown="0">
+  <p class="knowledge-check__q">Quick check: which of these can no scanner or software recover?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">An unencrypted P25 trunked system in a digital mode</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Encrypted voice traffic scrambled with a key you don't have</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Analog FM dispatch on a conventional channel</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Two reasons a signal is closed: **encryption** (a hard wall no scanner defeats) and an
+  **unsupported mode** (a soft gap better gear may close) — do not confuse them.
+- **Wide open** almost everywhere: civil **aviation** (AM air band), **marine**,
+  **rail**, **weather**, **amateur** (encryption forbidden), **FRS/GMRS**, and much
+  **utility** traffic.
+- **Public safety varies by agency** — much is still unencrypted analog or digital, but
+  a growing share is encrypted, so the answer is always *local*.
+- **Digital and trunked do not mean encrypted** — GopherTrunk and trunk-tracking
+  scanners follow unencrypted digital systems fine.
+- **Check a database for your area** to learn what is open before buying gear or giving
+  up on a service.
+
+Next up: [Legal & ethical scanning](/learn/scanning/scanning-legal-and-ethical/).

--- a/docs/learn/scanning/when-decoding-fails.md
+++ b/docs/learn/scanning/when-decoding-fails.md
@@ -1,0 +1,117 @@
+---
+slug: when-decoding-fails
+title: When decoding fails
+description: The field troubleshooting guide for trunked scanning — no control-channel lock, garbled or silent voice, missed calls — with a symptom-first method for telling a signal problem from a setup problem so you fix the right thing.
+keywords: trunked decode fails, no control channel lock, garbled voice, missed calls, silent calls encryption, signal vs setup problem, scanner troubleshooting, wrong system type, gain overload, field checklist
+level: advanced
+status: full
+prereq:
+  - multisite-and-roaming
+faq:
+  - q: My trunked system won't decode — where do I start?
+    a: Start by separating a setup problem from a signal problem, because the fixes are completely different. Confirm the system type and control-channel frequency are right (setup), then check whether the signal is clean enough to decode — strong but not overloading, on frequency, not distorted by simulcast. Work it as a checklist rather than changing things at random.
+  - q: Calls appear but play back silent — is that broken?
+    a: Usually not. If the control channel decodes and grants show up but one talkgroup's audio is silent, that talkgroup is almost certainly encrypted, which no receiver can decode. Check whether other talkgroups on the system produce audio; if they do, your setup is fine and the silent one is simply encrypted.
+  - q: How do I tell a signal problem from a setup problem?
+    a: A setup problem is consistent and total — nothing ever locks, or the wrong decoder is selected — and it doesn't change with the weather or where you point the antenna. A signal problem varies — better on strong signals, worse in overload or simulcast zones, sensitive to gain and antenna. If moving the antenna or adjusting gain changes things, it's signal.
+---
+
+# When decoding fails
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+When a trunked system won't decode, **work a checklist and change one thing at a time**. The single
+most useful question is whether you have a **setup problem** (wrong system type or control channel —
+consistent and total) or a **signal problem** (weak, overloading, off-frequency, or simulcast-
+distorted — varies with gain and antenna). The usual culprits: **no control-channel lock**,
+**garbled voice**, **silent calls** (encryption — *not fixable*), and **missed calls**. Each has a
+distinct symptom, so match what you see to its cause. The digital-radio version of this checklist is
+[troubleshooting a decode](/learn/digital-trunking/troubleshooting-a-decode/).
+</div>
+
+Everything before this lesson assumed things work. This one is for when they don't — the control
+channel won't lock, the voice is garbled, or calls slip past you. The temptation is to change
+settings at random until something helps, which usually just moves the problem around. Instead, this
+lesson gives you a **symptom-first method**: read what you're seeing, decide whether it's setup or
+signal, and apply the one fix that matches.
+
+## First, split setup from signal
+
+Before touching anything, ask the diagnostic question that saves the most time: **is this a setup
+problem or a signal problem?** They look different once you know to look:
+
+- A **setup problem** is *consistent and total*. Nothing ever locks, or the wrong decoder is
+  selected. It doesn't change with the weather, the time of day, or where you aim the antenna,
+  because it's a configuration mismatch — usually the **system type** or the **control-channel
+  frequency**.
+- A **signal problem** *varies*. It's better on strong signals and worse when the signal is weak,
+  overloading, off-frequency, or distorted by [simulcast](/learn/scanning/multisite-and-roaming/).
+  If moving the antenna or adjusting gain changes what you get, it's signal.
+
+Make this call first and you've halved the search: fix the config, or fix the reception.
+
+## No control-channel lock
+
+The most common failure is the control channel never locking — no chatter, no grants, nothing. Walk
+it in order. First, **setup**: is the **system type** right (it selects the decoder), and is the
+**control-channel frequency** correct and *currently active*? Many systems list alternates; the one
+you entered may be idle — try the others. A voice frequency mistaken for the control channel gives a
+carrier but no data.
+
+If setup checks out, it's **signal**: too little **gain** buries the control channel in noise, too
+much **overloads** the front end and sprays distortion, and a **frequency/PPM error** on a cheap
+dongle lands the signal off-channel so it never quite locks. Because everything downstream depends on
+the control channel, this is always the first thing to get right — the same lesson the
+[following a call](/learn/scanning/following-a-call/) sequence drove home.
+
+## Garbled or distorted voice
+
+When the control channel locks and calls come through but the **voice is garbled**, the control
+channel is healthy and the problem is on the **voice channel or the signal**. A strong meter with a
+fuzzy, un-lockable signal in an area of overlapping towers is the classic **simulcast** signature
+from the [multisite lesson](/learn/scanning/multisite-and-roaming/) — favour one transmitter with a
+directional antenna and lower the gain, don't raise it. Otherwise, garbled voice usually tracks a
+marginal signal: weak, fading, or overloaded. Improve the reception and the audio usually clears.
+
+## Silent calls — the one you can't fix
+
+A special case worth naming clearly: calls that **appear in the log with a talkgroup and radio ID but
+play back silent**. This is almost always **encryption**, not a fault. Encrypted voice is scrambled
+with a key only authorised radios hold, and **no receiver can recover it**. Confirm by checking
+whether *other* talkgroups on the same system produce audio — if they do, your setup and signal are
+both fine, and the silent one is simply encrypted. Chasing it is wasted effort; it's a fundamental
+limit, not a bug.
+
+## Missed calls
+
+Sometimes everything decodes but you keep **missing calls** you expected to hear. This is usually not
+a decode failure at all — it's your [scan-list](/learn/scanning/talkgroups-and-scan-lists/) setup. A
+talkgroup you forgot to add, one you locked out, or the absence of a **priority** flag on the channel
+that matters can all make calls slip past while you're on something else. On a
+[multisite](/learn/scanning/multisite-and-roaming/) system, a "missed" call may simply be traffic on
+a site you can't hear. Check the list and the site before you suspect the decode.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — if it varies with gain and antenna position, it's a signal problem; a setup problem is consistent and doesn't change when you move the antenna." markdown="0">
+  <p class="knowledge-check__q">Quick check: moving your antenna and adjusting gain changes whether the system decodes. Setup problem or signal problem?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Setup — the system type or control channel is wrong</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Signal — something that responds to gain and antenna is a reception issue</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Neither — the system is encrypted</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Split setup from signal first**: setup problems are consistent and total; signal problems vary
+  with gain and antenna.
+- **No lock** is usually the **system type** or **control-channel frequency** (setup), or gain/PPM
+  (signal) — try alternate control channels.
+- **Garbled voice** with a locked control channel points at the signal — often **simulcast**
+  distortion, which a directional antenna and *less* gain fix.
+- **Silent calls** with visible grants are **encryption** — expected and **not fixable**; confirm by
+  checking other talkgroups.
+- **Missed calls** are usually a **scan-list** or **site** issue, not a decode failure.
+- Change **one thing at a time** so you know which fix actually worked.
+
+Next up: [Logging &amp; recording calls](/learn/scanning/logging-and-recording/).

--- a/docs/learn/scanning/where-to-go-next.md
+++ b/docs/learn/scanning/where-to-go-next.md
@@ -1,0 +1,121 @@
+---
+slug: where-to-go-next
+title: Where to go next
+description: Where the scanning hobby leads once you can follow a system — decoding data modes, digging into the protocols underneath, or writing your own decoder — and the GopherTrunk.org modules that take you each of those directions.
+keywords: next steps scanning, learn radio protocols, decoding data modes, write a decoder, DSP for radio, digital trunking module, RF software development, scanning to development, radio deep dive, GopherTrunk learning path
+level: beginner
+status: full
+prereq:
+  - a-worked-monitoring-setup
+faq:
+  - q: I can follow a system now — what's the next challenge?
+    a: Three directions branch from here. Go deeper into how trunked systems work on the inside with the Digital & Trunked Radio module. Learn the signal processing that turns raw samples into symbols with the DSP module. Or head toward building the tools yourself with the RF Software Development path. Which you pick depends on whether protocols, signals, or software pulls at you most.
+  - q: Do I need to code to go further?
+    a: Not to go deeper into the radio side — the digital-trunking and DSP material is about understanding, not programming. Coding only becomes the point if you choose the software-development direction, where the goal is building and modifying decoders like GopherTrunk. Plenty of the hobby's most knowledgeable people never write a line of code.
+  - q: What ties all of this together?
+    a: GopherTrunk. Everything you monitored in this module — control channels, grants, voice decoding, logging — is something you can now open up, understand more deeply, and eventually shape. The other modules explain the layers beneath the scanner, and the glossary keeps the vocabulary handy as you go.
+---
+
+# Where to go next
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+You can now build a station, find and identify systems, follow trunked calls, and log
+and record them with a scanner or [GopherTrunk](/learn/scanning/gophertrunk-as-a-scanner/).
+From here the hobby branches **three ways**: deeper into **how systems work**
+([Digital & Trunked Radio](/learn/digital-trunking/)), down into **the signal
+processing** underneath ([DSP](/learn/dsp/)), or outward into **building the tools
+yourself** ([RF Software Development](/learn/paths/rf-software-dev/)). Pick the one
+that pulls at you — protocols, signals, or software — and keep the
+[glossary](/learn/scanning/glossary/) handy as you go.
+</div>
+
+You've come the whole way: from what scanning *is*, through building a listening
+station, finding and identifying systems, following trunked calls in the field, and
+turning it all into a logged, recorded, always-on monitoring post. That's a real,
+complete skill — you can sit down at a receiver anywhere and make sense of the traffic
+above you. This last lesson is about what comes after "I can follow a system," and
+where each direction leads on GopherTrunk.org.
+
+## You've closed the loop
+
+Take stock of what you can do now. You understand
+[conventional versus trunked](/learn/scanning/conventional-vs-trunked-recap/), you can
+[build a station](/learn/scanning/station-setup/) with a decent
+[antenna](/learn/scanning/antennas-for-scanning/), you can
+[find and identify](/learn/scanning/identifying-unknown-signals/) systems and
+[follow a call](/learn/scanning/following-a-call/) across one, and you can
+[log, record](/learn/scanning/logging-and-recording/), and
+[alert](/learn/scanning/alerting-on-calls/) on what matters — running unattended if you
+like. The scanner is no longer a mystery box; it's a tool you drive. From a solid base
+like that, "deeper" can go in a few different directions.
+
+## Deeper into how systems work
+
+If following calls left you curious *why* the control channel says what it says, the
+[Digital & Trunked Radio](/learn/digital-trunking/) module is your next stop. This
+module was the operator's view — point it here, follow that call. That one is the
+inside view: how the control channel signals, how grants and affiliations actually
+work, how P25, DMR, NXDN, and TETRA differ under the hood, and how a system behaves
+across sites. It answers the "but how does it *know*?" questions this module kept
+deferring.
+
+## Down into the signal
+
+If the part that fascinated you was the leap from a raw carrier to clean symbols —
+how a smear of radio becomes bits — then the [DSP](/learn/dsp/) module goes there. It's
+the signal-processing layer beneath every decoder: filtering, down-conversion,
+demodulation, symbol timing, the maths that pulls a signal out of noise. It's the
+difference between using a decoder and understanding what it's doing when a marginal
+signal locks — or doesn't. This is where "why won't this system decode?" becomes a
+question you can answer from first principles.
+
+## Outward into building the tools
+
+And if what you really want is to *shape* the software — fix a decoder, add a
+protocol, build your own scanner — the
+[RF Software Development path](/learn/paths/rf-software-dev/) is the road from listener
+to builder. It braids the radio knowledge with the programming to turn samples into
+working software, using GopherTrunk as the worked example throughout. The
+[trunked-radio path](/learn/paths/trunked-radio/) is the companion route focused on the
+systems themselves. This is where the hobby becomes engineering, and where the
+[captures and bug reports](/learn/scanning/contributing-and-community/) you learned to
+contribute turn into code.
+
+## It all runs through GopherTrunk
+
+Whichever direction you take, GopherTrunk is the thread. As a
+[scanner](/learn/scanning/gophertrunk-as-a-scanner/) it's what you monitored with; as
+open software it's something you can open up, understand layer by layer, and
+eventually change. The [project home](/) and the
+[architecture overview](/architecture.html) are the map of those layers, and the other
+modules explain each one in turn. You started this module curious about what's on the
+air; you can finish it able to hear it, follow it, record it — and, if you want, build
+the very tools that decode it.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the DSP module covers the signal processing beneath every decoder: filtering, demodulation, and symbol timing that turn raw samples into bits." markdown="0">
+  <p class="knowledge-check__q">Quick check: which direction goes deepest into how raw radio samples become clean symbols?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">The Digital &amp; Trunked Radio module</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The DSP module — filtering, demodulation, and symbol timing</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">The community & contributing lesson</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- You've closed the loop: **build a station, find and identify systems, follow calls,
+  and log, record, and alert** — unattended if you like.
+- Go **deeper into how systems work** with
+  [Digital & Trunked Radio](/learn/digital-trunking/) — the inside view of control
+  channels, grants, and protocols.
+- Go **down into the signal** with [DSP](/learn/dsp/) — the filtering, demodulation,
+  and timing beneath every decoder.
+- Go **outward into building tools** with the
+  [RF Software Development path](/learn/paths/rf-software-dev/) — listener to builder,
+  with GopherTrunk as the worked example.
+- **GopherTrunk is the thread** through all of it — a scanner you used and open
+  software you can now understand and shape.
+
+Next up: keep the [glossary](/learn/scanning/glossary/) handy, and dive deeper with [Digital &amp; Trunked Radio](/learn/digital-trunking/) or the [RF Software Development path](/learn/paths/rf-software-dev/).

--- a/docs/learn/web-dev/accessibility-basics.md
+++ b/docs/learn/web-dev/accessibility-basics.md
@@ -1,0 +1,179 @@
+---
+slug: accessibility-basics
+title: Accessibility basics
+description: Building for everyone. This lesson covers the accessibility fundamentals every web developer should know — semantic HTML, keyboard navigation, colour contrast, text alternatives, labelled forms, and ARIA — and why they are also just good engineering that helps every user.
+keywords: accessibility, a11y, semantic HTML, keyboard navigation, ARIA, alt text, color contrast, screen reader, WCAG, accessible forms
+level: intermediate
+status: full
+prereq:
+  - forms-and-user-input
+faq:
+  - q: What is web accessibility?
+    a: "**Accessibility** (often shortened to **a11y**) means building web pages that everyone can use, including people with visual, motor, hearing, or cognitive disabilities — for example, someone using a screen reader or navigating with only a keyboard. It overlaps heavily with good engineering: most accessible practices also make a site clearer and more robust for every user."
+  - q: Do I need to learn ARIA to make an accessible site?
+    a: "Mostly no. The single biggest win is **semantic HTML** — using the right elements, which are accessible by default. **ARIA** is a set of attributes for filling gaps semantic HTML can't cover, like custom widgets. The guiding rule is that no ARIA is better than bad ARIA, so reach for a native element first and use ARIA only when nothing native fits."
+  - q: Is accessibility only for people with disabilities?
+    a: "It's driven by that need, but the benefits are universal. Captions help in a noisy room, good contrast helps in bright sun, keyboard support helps power users, and clear structure helps search engines. Accessibility is often legally required, too — but even setting that aside, it's simply a mark of well-built software."
+---
+
+# Accessibility basics
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Accessibility** (a11y) means building pages **everyone** can use — including
+people relying on screen readers or keyboards. The biggest win is **semantic
+HTML**, which is accessible by default, backed by **keyboard** support, sufficient
+**colour contrast**, **text alternatives** for images, and properly **labelled
+forms**. **ARIA** fills the gaps semantic HTML can't, but native elements come
+first. Almost every accessible practice is also just **good engineering** that
+helps all users — and it's often legally required. This closes the front-end trio
+unit, drawing on [HTML](/learn/web-dev/html-structure/) and
+[forms](/learn/web-dev/forms-and-user-input/).
+</div>
+
+We've built structure, style, behaviour, and input. This lesson asks the question
+that separates a page that works for *you* from one that works for *everyone*: can
+someone who can't see the screen, can't use a mouse, or struggles with low
+contrast still use what you built? **Accessibility** is the practice of making sure
+the answer is yes — and, satisfyingly, most of it is things you should be doing
+anyway. It's the natural close to the front-end trio, because it ties HTML, CSS,
+and JavaScript back to the humans on the other end.
+
+## Why accessibility matters
+
+A large share of people use the web with some assistive technology or constraint:
+screen readers that speak the page aloud, keyboard-only navigation, screen
+magnifiers, captions, reduced motion. If a site assumes a sighted mouse user, it
+quietly excludes all of them.
+
+Two things make this more than a nice-to-have. First, it's frequently a **legal
+requirement** — many jurisdictions mandate accessible public services and
+products. Second, and more usefully day to day, accessible practices are **better
+engineering for everyone**: captions help in a loud room, contrast helps in
+sunlight, keyboard support helps power users, and clean structure helps search
+engines and future maintainers. Accessibility and quality point the same
+direction.
+
+## Semantic HTML is most of the battle
+
+The single highest-leverage thing you can do costs nothing extra: use **semantic
+HTML**. This is the payoff of the [HTML lesson](/learn/web-dev/html-structure/) —
+the right elements are **accessible by default**.
+
+- A real `<button>` is focusable, works with Enter and Space, and is announced as a
+  button. A `<div>` dressed up as one is none of those unless you rebuild it all by
+  hand.
+- Headings `<h1>`–`<h6>` give a screen-reader user an outline to navigate by, the
+  way a sighted user skims.
+- Landmarks like `<nav>`, `<main>`, and `<footer>` let users jump straight to a
+  region.
+- A `<label>` tied to an input tells the user what the field is for.
+
+```html
+<!-- Accessible: native element, keyboard and screen-reader ready -->
+<button type="button">Refresh</button>
+
+<!-- Not accessible: no focus, no keyboard, no announcement -->
+<div class="button" onclick="refresh()">Refresh</div>
+```
+
+Get the elements right and you've done most of the work before touching a single
+accessibility-specific feature.
+
+## Keyboard navigation
+
+Many people don't use a mouse — because of motor disabilities, because they rely on
+a screen reader, or just because the keyboard is faster. Everything interactive
+must work with the **keyboard** alone.
+
+The key ideas: users move between interactive elements with **Tab**, activate them
+with **Enter** or **Space**, and there must always be a visible **focus indicator**
+showing where they are. Native elements (`<button>`, `<a>`, `<input>`) get all of
+this for free — another reason to use them. The most common accessibility failure
+is a custom control built from `<div>`s that a keyboard simply cannot reach. Never
+remove the focus outline just because it's not to your taste; if anything, make it
+clearer.
+
+## Text alternatives and contrast
+
+Two visual essentials cover a lot of ground:
+
+- **Text alternatives.** Every meaningful image needs **`alt`** text describing what
+  it conveys, so a screen reader can speak it and it still communicates if the image
+  fails to load. Purely decorative images get an *empty* `alt=""` so they're skipped
+  rather than announced as noise.
+
+```html
+<img src="waterfall.png" alt="A P25 control channel spike at 851.3 MHz">
+<img src="divider.png" alt="">
+```
+
+- **Colour contrast.** Text must stand out enough from its background to be legible,
+  including for people with low vision or colour-blindness. Accessibility guidelines
+  (WCAG) give minimum contrast ratios, and it's worth checking with a tool. A
+  related rule: **don't rely on colour alone** to carry meaning — pair a red error
+  state with an icon or text, so it still reads for someone who can't distinguish the
+  colour.
+
+## Accessible forms
+
+Forms are where accessibility and the last lesson meet. An input with no label is a
+mystery to a screen reader — it announces "edit text" with no clue what to type.
+Every field needs a programmatically associated **`<label>`**:
+
+```html
+<label for="tg">Talkgroup</label>
+<input id="tg" name="talkgroup" type="text" required>
+```
+
+The `for="tg"` binds the label to the input's `id`, so the screen reader speaks
+"Talkgroup, edit text" and — a nice bonus for everyone — clicking the label focuses
+the field. Beyond labels, group related fields, mark required ones clearly (not by
+colour alone), and make error messages specific and tied to the field they concern.
+Accessible validation is just good validation, spoken aloud.
+
+## ARIA — the gap-filler
+
+Sometimes semantic HTML can't express a complex, custom widget — a tab set, a
+combobox, a live-updating region. That's what **ARIA** (Accessible Rich Internet
+Applications) is for: attributes that add roles, states, and properties screen
+readers understand.
+
+```html
+<div role="alert">Connection lost — retrying…</div>
+```
+
+That `role="alert"` tells assistive tech to announce the message immediately, handy
+for the live updates a dashboard pushes. But ARIA comes with a firm warning: **no
+ARIA is better than bad ARIA.** It's easy to misuse in ways that make things
+*worse* than plain HTML. So the order of preference is always: use a **native
+semantic element** first; reach for **ARIA only** when there is genuinely no native
+element for what you're building. ARIA supplements semantic HTML — it never
+replaces it.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — using the correct semantic elements is accessible by default and is the highest-leverage step you can take." markdown="0">
+  <p class="knowledge-check__q">Quick check: what's the single most effective thing you can do for accessibility?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Add ARIA attributes to every element on the page</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Use semantic HTML — the right elements are accessible by default</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Increase the font size of all text to at least 24px</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Accessibility (a11y)** means building pages everyone can use; it's often legally
+  required and is **good engineering** that benefits all users.
+- **Semantic HTML** is the biggest win — native elements like `<button>` and real
+  headings are **accessible by default**.
+- Everything interactive must work by **keyboard**: Tab to move, Enter/Space to
+  activate, and a visible **focus indicator**.
+- Give images meaningful **`alt`** text (empty for decorative ones), ensure enough
+  **colour contrast**, and never rely on **colour alone** for meaning.
+- **Label** every form field with `<label for>`, and make errors specific and
+  clearly marked.
+- **ARIA** fills gaps semantic HTML can't, but **native elements come first** — no
+  ARIA beats bad ARIA.
+
+Next up: [Front-end frameworks](/learn/web-dev/frontend-frameworks/).

--- a/docs/learn/web-dev/anatomy-of-a-web-app.md
+++ b/docs/learn/web-dev/anatomy-of-a-web-app.md
@@ -1,0 +1,155 @@
+---
+slug: anatomy-of-a-web-app
+title: Anatomy of a modern web app
+description: The map of a web app and how its pieces fit — the front end in the browser, the back end on a server, the database that stores data, and the API that connects them — so the rest of the module has a place to hang each new idea.
+keywords: web app architecture, front end back end database, API, three-tier, web application components, client server database, how a web app is structured, tiers of a web app
+level: beginner
+status: full
+prereq:
+  - client-server-web
+faq:
+  - q: What are the main parts of a web app?
+    a: "Four, most of the time: a **front end** running in the browser, a **back end** running on a server, a **database** that stores data durably, and an **API** — the agreed set of requests — that lets the front end talk to the back end. Simple sites drop some of these; big ones split each into many pieces, but the roles stay the same."
+  - q: What is an API in a web app?
+    a: "An **API** (application programming interface) is the contract between the front end and the back end: a defined set of requests the front end can make and responses the back end promises to give. It's how the browser asks the server for data or tells it to do something, without either side knowing the other's internal details."
+  - q: Does every web app need a database?
+    a: "No. A purely static site has no database at all — it's just files. But any app that remembers things between visits or between users — accounts, posts, saved settings, decoded calls — needs somewhere durable to keep that data, and that's the database's job."
+---
+
+# Anatomy of a modern web app
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A typical web app has four parts: a **front end** in the browser, a **back end**
+on a server, a **database** that stores data, and an **API** connecting the front
+end to the back end. The front end handles what the user sees; the back end holds
+the logic and secrets; the database remembers things between visits; the API is
+the agreed set of requests between them. This is the map the rest of the module
+fills in, and it slots straight onto the
+[client-server](/learn/web-dev/client-server-web/) rhythm you already know.
+</div>
+
+You now have the rhythm — client asks, server answers. This lesson zooms out to
+the whole machine and names its parts, so that every later lesson has an obvious
+place to attach. Think of it as the floor plan: not much detail yet, but you'll
+know which room you're standing in when we go deep on auth, or databases, or
+real-time updates.
+
+## The four parts
+
+Most web apps, however large, are built from four kinds of thing:
+
+- **Front end** — the code in the browser: HTML, CSS, and JavaScript. It draws the
+  interface and handles interaction. It is the **client**.
+- **Back end** — the code on a server. It runs the business logic, checks
+  permissions, keeps secrets, and answers requests. It is the **server**.
+- **Database** — where data lives durably: accounts, records, settings, decoded
+  calls. It survives restarts and is shared across all users.
+- **API** — the defined set of requests the front end makes to the back end, and
+  the responses it gets back. It's the **contract** between the two halves.
+
+The classic name for this layering is a **three-tier architecture**:
+presentation (front end), application logic (back end), and data (database), with
+the API stitching the first two together. You don't need the jargon, but you'll
+see it, and it names a real and durable pattern.
+
+## How a request flows through them
+
+Follow one action — a user opening a page that lists live calls — and watch it
+pass through all four parts:
+
+1. The **front end** in the browser needs the list of calls, so it makes an
+   **API** request to the back end — something like *GET /api/calls*.
+2. The **back end** receives it, checks the user is allowed to see it, and asks the
+   **database** for the current calls.
+3. The **database** returns the rows; the back end shapes them into a tidy
+   response (usually **JSON**) and sends it back across the API.
+4. The **front end** receives the data and updates the page to show the calls — no
+   full reload needed.
+
+Every arrow there is a client-server exchange, and every box is one of the four
+parts. This is the skeleton under an enormous range of apps, from a to-do list to
+GopherTrunk's own scanner dashboard, which we dissect at the end of the module in
+[the GopherTrunk web dashboard](/learn/web-dev/gophertrunk-web-dashboard/).
+
+## The API is the seam
+
+Of the four parts, the **API** is the one worth dwelling on, because it's the seam
+that lets the two halves be built and changed independently.
+
+The front end doesn't know *how* the back end stores calls or what language it's
+written in; it only knows the **agreed requests** and the shape of the data that
+comes back. The back end doesn't know whether the client is a browser, a phone
+app, or a script; it just honours the contract. As long as both sides keep to the
+API, either can be rebuilt without breaking the other.
+
+```http
+GET /api/calls HTTP/1.1
+Host: dashboard.example
+```
+
+```json
+[
+  { "id": 41, "talkgroup": "Fire dispatch", "started": "12:04:31" },
+  { "id": 42, "talkgroup": "Police tac 2",  "started": "12:05:02" }
+]
+```
+
+That request-and-JSON pair *is* the API in miniature. When an API organises its
+requests around resources and standard HTTP methods in a consistent style, you get
+**REST**, the dominant convention on the web — covered here in
+[building a REST API](/learn/web-dev/building-a-rest-api/) and, from the network
+angle, in [web APIs & REST](/learn/networking/web-apis-and-rest/).
+
+## Where the data lives
+
+The **database** deserves its own callout because it answers a question the other
+parts can't: how does the app remember anything?
+
+The front end forgets everything when you close the tab. The back end, by itself,
+forgets everything when it restarts. Durable memory — the state that must outlive a
+single request, a single user, and a single server — lives in the **database**. It
+holds the authoritative copy of everything the app knows, and the back end is the
+only part allowed to touch it directly. We come back to this boundary in
+[the back end & its database](/learn/web-dev/backend-and-database/), and the
+[databases module](/learn/databases/) covers the data layer in its own right.
+
+## Simple apps and big apps
+
+Real apps stretch this map in both directions. A plain static site is *only* a
+front end — files served as-is, no back end or database at all, which is exactly
+how this learning site works. At the other extreme, a large product splits each
+box into many: several front ends, dozens of back-end services, multiple
+databases, and layers of caching and delivery in between.
+
+But the four roles stay constant. Whether you're looking at a weekend project or a
+platform serving millions, you can always ask: what's the front end, what's the
+back end, where's the data, and what's the API between them? Answer those and
+you've understood the shape of the system.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the API is the agreed contract of requests and responses between the front end and back end." markdown="0">
+  <p class="knowledge-check__q">Quick check: what connects the front end to the back end?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">The database, which the browser queries directly</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The API — the agreed set of requests and responses between them</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Nothing — they run as one combined program</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Most web apps have four parts: a **front end** (browser), a **back end**
+  (server), a **database** (durable data), and an **API** (the contract between
+  front and back).
+- This is the classic **three-tier** shape: presentation, logic, and data.
+- A request flows front end → API → back end → database and back again, each arrow
+  a client-server exchange.
+- The **API** is the seam that lets the two halves change independently; organised
+  in a consistent style it becomes **REST**.
+- The **database** provides the durable memory the front end and back end lack on
+  their own, and only the back end touches it directly.
+- Simple apps drop parts (a static site is front end only); big apps multiply them,
+  but the four roles stay the same.
+
+Next up: [Static vs. dynamic sites](/learn/web-dev/static-vs-dynamic/).

--- a/docs/learn/web-dev/authentication-and-sessions.md
+++ b/docs/learn/web-dev/authentication-and-sessions.md
@@ -1,0 +1,154 @@
+---
+slug: authentication-and-sessions
+title: Authentication & sessions
+description: How a web app knows who a user is across stateless HTTP requests — logging in, keeping a session, and the crucial difference between authentication (who you are) and authorization (what you're allowed to do).
+keywords: authentication, authorization, login, session, session ID, stateless HTTP, password hashing, credentials, sign in, access control
+level: intermediate
+status: full
+prereq:
+  - building-a-rest-api
+faq:
+  - q: "What's the difference between authentication and authorization?"
+    a: "**Authentication** answers *who are you* — it verifies identity, usually with a password or token. **Authorization** answers *what are you allowed to do* — it checks whether the now-known user may perform this action. You authenticate once, then authorize every request. A logged-in user is authenticated; whether they can delete another user's data is authorization."
+  - q: "Why can't the server just remember I logged in?"
+    a: "Because HTTP is **stateless** — each request arrives with no memory of the ones before it. The server holds no per-user connection open. So after you log in, the app hands the browser a **session identifier** that rides along on every later request, and the server uses it to look you up again."
+  - q: "Should I ever store passwords in plain text?"
+    a: "Never. Store only a **salted hash** made with a slow, purpose-built algorithm (bcrypt, scrypt, or Argon2). When someone logs in you hash what they typed and compare hashes — the real password is never kept, so a database leak doesn't hand attackers the passwords themselves."
+---
+
+# Authentication & sessions
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+The web is **stateless** — every request stands alone — so an app has to re-learn
+who you are on each one. **Authentication** proves *who you are* (logging in);
+**authorization** decides *what you may do*. After a successful login the server
+issues a **session** identified by a token the browser sends back on every request,
+turning a string of anonymous requests into a recognised user. Passwords are never
+stored raw — only a **salted hash**. The next lesson,
+[cookies, tokens & JWTs](/learn/web-dev/cookies-tokens-jwt/), covers exactly how
+that session token travels.
+</div>
+
+Once your app has a [REST API](/learn/web-dev/building-a-rest-api/) and a
+[database](/learn/web-dev/backend-and-database/), the next thing almost every real
+app needs is to know *who is asking*. That sounds simple until you remember how the
+web actually works: the server answers one request and forgets everything. This
+lesson is about bridging that gap — turning a stream of anonymous, unrelated
+requests into a recognised, logged-in user.
+
+## The stateless problem
+
+HTTP has no memory. As the [client-server](/learn/web-dev/client-server-web/)
+lesson showed, each request is independent: the server reads it, sends a response,
+and moves on holding nothing about you. There is no open phone line between your
+browser and the server that stays "you" between clicks.
+
+That is great for scaling — any server can handle any request — but it means the
+question *"is this the person who just logged in?"* has no built-in answer. The web
+solves it by making the **client carry proof of identity on every request**. Log in
+once, receive a token, and send that token back each time. The server checks the
+token and knows you again.
+
+## Authentication vs. authorization
+
+These two words look alike and are constantly confused, but they are different jobs:
+
+- **Authentication** — *who are you?* Verifying identity. The user proves they are
+  who they claim, typically with a username and password, and possibly a second
+  factor.
+- **Authorization** — *what are you allowed to do?* Given a known identity, deciding
+  whether this particular action is permitted — can this user see this record, edit
+  this setting, reach this admin page?
+
+You authenticate **once** (at login) and authorize **every request** thereafter. A
+logged-in user is authenticated, but that alone doesn't let them delete another
+person's account — that's an authorization check. Conflating the two is a classic
+source of security holes: an app that checks *are you logged in?* but forgets to
+check *is this yours?* leaks data between users. The sibling
+[authentication basics](/learn/cybersecurity/authentication-basics/) lesson digs
+into the identity side in more depth.
+
+## The login flow
+
+A typical username-and-password login looks like this:
+
+1. The user submits a [form](/learn/web-dev/forms-and-user-input/) with their
+   credentials over HTTPS.
+2. The server looks up the account and **verifies the password** against the stored
+   hash.
+3. On success, it creates a **session** and hands the browser a session identifier.
+4. Every later request includes that identifier; the server uses it to reload the
+   user and treat the request as theirs.
+5. On logout (or expiry), the session is destroyed and the identifier stops working.
+
+The pseudocode is short — the care is in the details around it:
+
+```python
+def login(request):
+    user = db.find_user(request.form["email"])
+    if user is None or not verify_hash(request.form["password"], user.pw_hash):
+        return error(401, "Invalid credentials")   # don't say which was wrong
+    session_id = create_session(user.id)           # store server-side
+    return set_session_cookie(session_id)          # browser sends it back
+```
+
+## Storing passwords safely
+
+The single rule that matters most: **never store a password you can read.** If your
+database keeps plain-text passwords, one leak exposes every user — and because
+people reuse passwords, it exposes their other accounts too.
+
+Instead, store a **hash**: a one-way transformation you can't reverse. When a user
+logs in, hash what they typed and compare it to the stored hash. Two extra
+requirements make this safe:
+
+- **Salt** — a unique random value mixed into each hash, so identical passwords
+  don't produce identical hashes and precomputed "rainbow table" attacks fail.
+- **A slow, purpose-built algorithm** — **bcrypt**, **scrypt**, or **Argon2**.
+  Ordinary hashes like SHA-256 are *too fast*: an attacker can try billions per
+  second. Password hashes are deliberately slow to make guessing expensive.
+
+Never invent your own scheme, and never use a plain fast hash for passwords.
+
+## What a session actually is
+
+A **session** is server-side state about one logged-in user, referenced by an
+opaque **session ID**. Classically the server keeps a table — session ID → user,
+plus when it was created and when it expires — and the browser holds only the ID.
+Because the ID is meaningless on its own, stealing it is the whole game, which is
+why it travels in a secure [cookie](/learn/web-dev/cookies-tokens-jwt/) and why
+sessions expire.
+
+There are two broad styles, both covered next lesson: **server-side sessions**,
+where the server stores the state and the client holds only a reference, and
+**token-based** approaches like JWTs, where the client holds signed claims and the
+server stores nothing. Each has tradeoffs around revocation, scale, and where trust
+lives — but both solve the same stateless problem you met above.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — authentication verifies who you are; authorization decides what that known user may do." markdown="0">
+  <p class="knowledge-check__q">Quick check: a logged-in user tries to delete another user's post. Which check should stop them?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Authentication — they must not really be logged in</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Authorization — they're authenticated but not permitted to do this</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Neither — any logged-in user may do anything</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- HTTP is **stateless**, so an app must re-establish identity on every request; it
+  does this by having the client carry proof of login each time.
+- **Authentication** verifies *who you are*; **authorization** decides *what you may
+  do*. Authenticate once, authorize every request.
+- The **login flow** verifies credentials, creates a **session**, and hands the
+  browser a session identifier to send back thereafter.
+- **Never store plain-text passwords** — keep a **salted hash** made with bcrypt,
+  scrypt, or Argon2, which are deliberately slow.
+- A **session** is server-side state keyed by an opaque **session ID**; stealing the
+  ID is the main risk, so it's kept secret and expires.
+- Missing authorization checks — logged in but *is this yours?* — are a common,
+  serious bug class.
+
+Next up: [cookies, tokens & JWTs](/learn/web-dev/cookies-tokens-jwt/).

--- a/docs/learn/web-dev/backend-and-database.md
+++ b/docs/learn/web-dev/backend-and-database.md
@@ -1,0 +1,168 @@
+---
+slug: backend-and-database
+title: The back end & its database
+description: Where the server meets the data layer — how a back end connects to a database, reads and writes it safely with parameterised queries, reuses connections with a pool, and keeps the boundary between web logic and data logic in the right place.
+keywords: back end database, database connection, parameterised query, SQL injection, connection pool, ORM, data access layer, prepared statement, query, persistence, data layer
+level: intermediate
+status: full
+prereq:
+  - building-a-rest-api
+faq:
+  - q: How does the back end talk to the database?
+    a: "It opens a connection to the database server, sends queries (usually SQL), and reads back rows. In practice it keeps a pool of open connections to reuse, and often uses a driver, query builder, or ORM library so it works with the database in the language's own types rather than raw wire protocol."
+  - q: What is SQL injection and how do I prevent it?
+    a: "SQL injection is when user input is concatenated into a query so that the input changes what the query does — a classic way attackers read or destroy data. You prevent it by using parameterised queries (placeholders bound to values), which keep the input as data, never executable SQL. Never build a query by string-concatenating user input."
+  - q: Should the front end ever talk to the database directly?
+    a: "Almost never. The database holds shared, sensitive data and its credentials are secrets, so it lives on the trusted server side. The browser talks to your API, and only the back end talks to the database — that boundary is what lets the server enforce rules and keep credentials hidden."
+---
+
+# The back end & its database
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+The **database** is where a [back end](/learn/web-dev/what-a-backend-does/) keeps its
+**shared, durable data**, and the server is the **only** thing that talks to it — never
+the browser. The back end **connects** to the database, sends **queries**, and maps rows
+into objects, reusing connections through a **[pool](/learn/databases/connection-pooling/)**
+rather than opening one per request. The rule that matters most for safety is
+**parameterised queries** — never build SQL by concatenating user input, or you invite
+[SQL injection](/learn/databases/sql-injection/). Keep **web logic and data logic**
+separate so the boundary stays clean. The data layer itself is the
+[Databases module](/learn/databases/).
+</div>
+
+A [REST API](/learn/web-dev/building-a-rest-api/) is only useful if there's real data
+behind it. That data lives in a **database**, and this lesson is where the server meets it:
+how a handler goes from "the client asked for the calls" to actually reading them, and how
+to do that **safely** and with the boundaries in the right place. It's the seam between
+this module and the [Databases module](/learn/databases/), which covers the data layer in
+depth; here we focus on the back end's side of the relationship.
+
+## Only the server touches the database
+
+First, a boundary. The database holds **shared, sensitive data**, and its credentials are
+**secrets** — so it lives entirely on the trusted server side, and the **browser never
+connects to it directly.** The flow is always:
+
+```
+Browser ──HTTP──▶ Back-end handler ──query──▶ Database
+        ◀─JSON──                    ◀─rows──
+```
+
+The front end calls your API; the handler queries the database; the handler shapes the
+result into JSON and returns it. This is the same trust argument from
+[what a back end does](/learn/web-dev/what-a-backend-does/): if the browser could reach the
+database, every rule you enforce and every secret you hold would be bypassable. The server
+in the middle is what keeps the data layer both safe and abstract — clients see an API, not
+tables.
+
+## Connecting and querying
+
+To use a database, the back end opens a **connection** to the database server, sends a
+**query**, and reads back **rows**. Most relational databases speak **SQL**; the handler
+sends a statement and maps the results into the language's own types.
+
+```go
+func listCalls(w http.ResponseWriter, r *http.Request) {
+    rows, err := db.Query("SELECT id, talkgroup, seconds FROM calls ORDER BY id DESC")
+    if err != nil { http.Error(w, "db error", 500); return }
+    defer rows.Close()
+
+    var calls []Call
+    for rows.Next() {
+        var c Call
+        rows.Scan(&c.ID, &c.Talkgroup, &c.Seconds)   // row → struct
+        calls = append(calls, c)
+    }
+    json.NewEncoder(w).Encode(calls)                 // structs → JSON
+}
+```
+
+That's the whole loop of the data layer: query, scan rows into objects, return them. Writes
+work the same way with `INSERT`, `UPDATE`, and `DELETE` statements — often mapping directly
+onto the [REST verbs](/learn/web-dev/building-a-rest-api/) from the last lesson.
+
+## Never concatenate user input: parameterise
+
+Here is the single most important safety rule on the back end. **Never build a query by
+gluing user input into a string.** Do this and an attacker can inject SQL that changes what
+the query does — reading other users' data, or dropping your tables. That's
+**[SQL injection](/learn/databases/sql-injection/)**, one of the oldest and most damaging
+web vulnerabilities.
+
+```go
+// NEVER — user input becomes part of the SQL itself.
+db.Query("SELECT * FROM calls WHERE talkgroup = '" + input + "'")
+
+// ALWAYS — a placeholder; the driver binds the value as data, never as code.
+db.Query("SELECT * FROM calls WHERE talkgroup = ?", input)
+```
+
+A **parameterised query** (also called a prepared statement) sends the SQL and the values
+**separately**, so the input is always treated as data and can never become executable SQL —
+no matter what the user types. This isn't an optimisation you add later; it's the default
+you never deviate from. The [SQL injection lesson](/learn/databases/sql-injection/) shows
+exactly how the attack works and why parameterisation stops it cold.
+
+## Connection pooling
+
+Opening a fresh database connection for every request is slow — each involves a network
+handshake and authentication. Instead the back end keeps a **[connection
+pool](/learn/databases/connection-pooling/)**: a set of open connections it **reuses**
+across requests, handing one to a handler for the duration of a query and returning it
+afterward. The pool caps how many connections exist at once, which also protects the
+database from being overwhelmed under load. Most database libraries manage the pool for
+you — you configure a size and borrow/return happens automatically — but knowing it's there
+explains a lot of production behaviour, from latency to "too many connections" errors. The
+[connection pooling lesson](/learn/databases/connection-pooling/) goes into how to size and
+tune it.
+
+## Keep the boundary clean
+
+As an app grows, it pays to keep **web logic** and **data logic** in separate places rather
+than scattering SQL through your handlers. A common shape is a **data-access layer** (a
+repository or store): handlers deal with HTTP — parse the request, check auth, format JSON —
+and call into functions like `store.ListCalls()` that own the queries.
+
+```go
+// Handler stays about HTTP; the store owns the SQL.
+func listCalls(w http.ResponseWriter, r *http.Request) {
+    calls, err := store.ListCalls(r.Context())   // data logic lives here
+    if err != nil { http.Error(w, "db error", 500); return }
+    json.NewEncoder(w).Encode(calls)
+}
+```
+
+This separation keeps handlers readable, makes the data layer testable on its own, and
+means a change to how data is stored doesn't ripple through your web code. Some teams use an
+**ORM** (object-relational mapper) to generate much of this layer from data models — a
+convenience with real trade-offs, covered in the [Databases module](/learn/databases/).
+Whichever you choose, the principle holds: the database is the server's private
+responsibility, accessed safely, behind a clean boundary — and everything the front end
+knows about it comes through your [API](/learn/web-dev/building-a-rest-api/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — parameterised queries send SQL and values separately, so user input can never become executable SQL. That's the defense against SQL injection." markdown="0">
+  <p class="knowledge-check__q">Quick check: how do you safely include user input in a database query?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Concatenate it into the SQL string after escaping a few quotes</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Use a parameterised query with a placeholder bound to the value</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Let the browser send the finished SQL so the server doesn't build it</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- The **database** holds shared, durable data; **only the server** connects to it — the
+  browser talks to your [API](/learn/web-dev/building-a-rest-api/), never the database.
+- The back end **connects, queries, and maps rows** into objects; writes use
+  `INSERT`/`UPDATE`/`DELETE`, often mirroring the REST verbs.
+- **Never concatenate user input into SQL** — use **parameterised queries** to prevent
+  [SQL injection](/learn/databases/sql-injection/); this is the non-negotiable default.
+- Reuse connections with a **[connection pool](/learn/databases/connection-pooling/)**
+  rather than opening one per request.
+- Keep **web logic and data logic separate** — a data-access layer (or ORM) — so the
+  boundary stays clean and testable.
+- The data layer itself is the subject of the [Databases module](/learn/databases/).
+
+Next up: [SSR vs. SPA vs. static](/learn/web-dev/ssr-spa-static/).

--- a/docs/learn/web-dev/build-tools-and-bundlers.md
+++ b/docs/learn/web-dev/build-tools-and-bundlers.md
@@ -1,0 +1,151 @@
+---
+slug: build-tools-and-bundlers
+title: Build tools & bundlers
+description: What turns your source code into the files a browser downloads — why modern front ends have a build step at all, what a bundler like Vite or webpack does, and what transpiling, minifying, and tree-shaking each contribute.
+keywords: build tool, bundler, Vite, webpack, esbuild, transpile, Babel, minify, tree shaking, source map, dev server, hot module replacement, build step
+level: intermediate
+status: full
+prereq:
+  - frontend-frameworks
+faq:
+  - q: Why can't the browser just run my source code directly?
+    a: "Sometimes it can — plain HTML, CSS, and JavaScript run as-is. But modern front ends use things the browser doesn't understand directly: JSX, TypeScript, imported CSS, dozens of small module files. A build step converts all of that into the plain HTML, CSS, and JavaScript the browser does understand, bundled and optimised for fast loading."
+  - q: What is the difference between a bundler and a transpiler?
+    a: "A transpiler converts one flavour of code into another the browser accepts — JSX or TypeScript into plain JavaScript. A bundler combines many source files (and their dependencies) into a few optimised files to download. Modern tools like Vite do both, plus minifying and tree-shaking, in one pipeline."
+  - q: Do I always need a build step?
+    a: "No. A static page of hand-written HTML, CSS, and JavaScript needs no build at all — this site is largely like that. You need a build step when you use a framework, a language like TypeScript, or a component syntax like JSX, because those must be transformed into what the browser runs."
+---
+
+# Build tools & bundlers
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Modern front ends have a **build step**: the code you write isn't the code the browser
+runs. A **bundler** like **Vite** or **webpack** takes your many source files — plus
+things the browser can't run directly, like **JSX** or **TypeScript** — and turns them
+into a few optimised **HTML, CSS, and JavaScript** files to download. Along the way it
+**transpiles** newer syntax to what browsers accept, **minifies** to shrink the files,
+and **tree-shakes** away unused code. In development it runs a fast **dev server** with
+instant updates; for production it emits a small, optimised bundle.
+</div>
+
+The [framework lessons](/learn/web-dev/frontend-frameworks/) quietly assumed something:
+that the JSX and imported modules you write somehow become files a browser can run. That
+conversion is the **build step**, and the tool that does it is a **bundler**. This lesson
+is what that step is, why modern front ends need one, and what each part of it buys you.
+It is also the honest answer to "why is there so much tooling?" — every piece earns its
+place, but it helps to see what each does.
+
+## Why a build step exists
+
+The browser runs exactly three things: **HTML, CSS, and JavaScript**. But a modern
+front end is written in things it can't run directly:
+
+- **JSX** — the HTML-in-JavaScript syntax React uses is not valid JavaScript.
+- **TypeScript** — JavaScript with types; the types must be stripped out first.
+- **Many small modules** — you split code across dozens or hundreds of files and
+  `import` between them, plus third-party packages from `node_modules`.
+- **Imported CSS, images, and other assets** handled through your JavaScript.
+
+A build step converts all of that into the plain HTML, CSS, and JavaScript the browser
+understands — and, while it's at it, makes those files small and fast. Without it, you'd
+be hand-writing browser-ready code and manually wiring together every file. With it, you
+write in whatever is productive and the tooling produces what actually ships.
+
+## What a bundler does
+
+A **bundler** — Vite, webpack, Parcel, esbuild — is the engine of the build. Its core job
+is in the name: take your entry file, follow every `import` to build a graph of all the
+code your app actually uses, and **bundle** it into a small number of output files. It
+does several jobs in that one pass:
+
+- **Resolve modules.** Follow every `import` — your files and installed packages — into
+  one dependency graph.
+- **Transpile.** Convert JSX, TypeScript, and newer JavaScript features into plain
+  JavaScript older browsers accept (the classic transpiler here is **Babel**).
+- **Bundle.** Combine those many files into a few, so the browser makes a handful of
+  requests instead of hundreds.
+- **Optimise.** **Minify** (strip whitespace, shorten names) and **tree-shake** (drop
+  code nothing references) to shrink what downloads.
+
+```js
+// You write small, focused modules and import between them…
+import { formatCall } from "./format.js";
+import { Dashboard } from "./Dashboard.jsx";
+
+// …the bundler follows every import, transpiles, and emits a few tight files.
+```
+
+The output is typically one or a few `.js` files, a `.css` file, and an `index.html`
+wired to them — the artifact you actually deploy, covered in
+[deploying a web app](/learn/deployment/what-is-deployment/).
+
+## Transpiling, minifying, tree-shaking
+
+Three transforms show up constantly, and it's worth knowing them by name:
+
+- **Transpiling** turns code the browser can't run into code it can — JSX and
+  TypeScript into JavaScript, or a brand-new language feature into an older equivalent.
+  It's translation between flavours of the same kind of code.
+- **Minifying** rewrites the shipped JavaScript and CSS to be as small as possible —
+  removing whitespace and comments, shortening variable names — without changing
+  behaviour. Smaller files download and parse faster.
+- **Tree-shaking** analyses the import graph and **removes code nothing uses**. Import
+  one helper from a big library and tree-shaking can drop the rest, so you ship only
+  what you actually call.
+
+Together these are why a huge, readable codebase can become a tiny, fast download — a
+direct win for [performance](/learn/web-dev/responsive-design/) and the load times users
+feel.
+
+## The dev server and the production build
+
+A bundler wears two hats. In **development** it runs a **dev server**: it serves your app
+locally and, thanks to **hot module replacement (HMR)**, pushes each change into the
+running page **instantly** — often without losing your place — so the edit-refresh loop
+is near-immediate. It also emits **source maps**, which let the browser's debugger show
+your original source instead of the transpiled, minified output.
+
+For **production** you run a separate **build** command that does the full pipeline —
+transpile, bundle, minify, tree-shake — and writes optimised files to an output folder
+(often `dist/`). The two modes have opposite priorities: development optimises for
+**fast feedback**, production optimises for **small, fast-loading output**. Newer tools
+like **Vite** and **esbuild** made both dramatically faster than the older webpack setups,
+which is much of why front-end tooling feels lighter than it did a few years ago.
+
+## When you don't need one
+
+None of this is mandatory. A page of hand-written HTML, CSS, and a little JavaScript
+runs in the browser with **no build step at all** — and that's a perfectly good way to
+build many sites, including largely this one (see
+[static vs. dynamic](/learn/web-dev/static-vs-dynamic/) and
+[templating &amp; static sites](/learn/web-dev/templating-and-static-sites/)). You take on
+a build step when you adopt a framework, JSX, TypeScript, or a big dependency graph —
+that is, when the productivity of writing in those outweighs the cost of the tooling. The
+build step is a tool, not a rite of passage; reach for it when it pays for itself.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the browser only runs plain HTML, CSS, and JavaScript, so a build step transpiles and bundles things like JSX and TypeScript into what it can run." markdown="0">
+  <p class="knowledge-check__q">Quick check: why do front ends using JSX or TypeScript need a build step?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">To encrypt the source code so users can't read it</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The browser only runs plain HTML, CSS, and JS, so JSX/TS must be transpiled and bundled first</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Browsers charge for JavaScript unless it's bundled into one file</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- The browser runs only **HTML, CSS, and JavaScript**, so a **build step** converts
+  everything else — **JSX, TypeScript, many modules** — into those.
+- A **bundler** (Vite, webpack, esbuild) resolves imports into a dependency graph and
+  combines many source files into a few optimised outputs.
+- **Transpiling** translates newer or non-standard syntax to what browsers accept;
+  **minifying** shrinks files; **tree-shaking** drops unused code.
+- In **development** a dev server gives instant updates (**HMR**) and **source maps**;
+  a separate **production build** emits small, optimised files.
+- Newer tools like **Vite** made both modes much faster than older setups.
+- A hand-written static page needs **no build step** — you take one on when a
+  framework or typed language makes it worth it.
+
+Next up: [Responsive design](/learn/web-dev/responsive-design/).

--- a/docs/learn/web-dev/building-a-rest-api.md
+++ b/docs/learn/web-dev/building-a-rest-api.md
@@ -1,0 +1,160 @@
+---
+slug: building-a-rest-api
+title: Building a REST API
+description: Turning routes and handlers into a coherent API a front end can consume — modelling resources as URLs, mapping HTTP verbs to actions, returning the right status codes, and speaking JSON, with the design conventions that make an API predictable.
+keywords: REST API, resource, endpoint, HTTP verbs, GET POST PUT DELETE, status codes, JSON API, API design, RESTful, CRUD, request body, API contract
+level: intermediate
+status: full
+prereq:
+  - http-servers-and-routing
+faq:
+  - q: What makes an API RESTful?
+    a: "A REST API models your data as resources, each with a URL, and uses HTTP's own verbs to act on them — GET to read, POST to create, PUT/PATCH to update, DELETE to remove — returning standard status codes and usually JSON. The style is 'RESTful' when it uses HTTP the way HTTP was designed rather than inventing its own scheme on top."
+  - q: What's the difference between PUT and PATCH?
+    a: "Both update an existing resource. PUT replaces the whole resource with the body you send, so it should contain the complete new state. PATCH applies a partial change — just the fields you include. PUT is idempotent (repeating it lands the same state); a careless PATCH may not be."
+  - q: Why does the status code matter if the body already has the data?
+    a: "Because the status code is the machine-readable summary the client checks first — 200/201 for success, 404 for missing, 400 for a bad request, 401/403 for auth. A front end (and every tool and proxy in between) relies on it to know what happened without parsing the body, which is exactly why fetch makes you check it."
+---
+
+# Building a REST API
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A **REST API** is the contract your [back end](/learn/web-dev/what-a-backend-does/) offers
+the front end. You model your data as **resources**, each with a **URL** (`/api/calls`,
+`/api/calls/42`), and act on them with **HTTP verbs** — **GET** read, **POST** create,
+**PUT/PATCH** update, **DELETE** remove. Every response carries a meaningful
+[**status code**](/learn/networking/http/) and usually a **JSON** body. Done consistently,
+the API becomes **predictable** — a front end can guess the next endpoint from the
+pattern. The deeper reference is [web APIs &amp; REST](/learn/networking/web-apis-and-rest/).
+</div>
+
+The [routing lesson](/learn/web-dev/http-servers-and-routing/) gave you routes and
+handlers. A **REST API** is what you get when you organise those routes into a coherent,
+predictable **contract** — a set of conventions so consistent that a front-end developer
+can consume it without reading much documentation. This lesson is those conventions:
+resources, verbs, status codes, and JSON, assembled into an API a
+[fetch](/learn/web-dev/fetching-data/) call can rely on. For the full protocol-level
+treatment, the [networking module's REST lesson](/learn/networking/web-apis-and-rest/) is
+the companion reference.
+
+## Resources: nouns as URLs
+
+The central idea of REST is to model your app as **resources** — the *things* it manages —
+and give each a **URL**. Resources are **nouns**, not actions, and collections are plural:
+
+- `/api/calls` — the collection of all calls.
+- `/api/calls/42` — a single call, identified by id.
+- `/api/talkgroups` — the collection of talkgroups.
+
+The URL names *what*; the HTTP method (next section) says *what to do* with it. So you
+never put a verb in the path — it's `POST /api/calls`, **not** `/api/createCall`. That one
+discipline is most of what makes an API feel RESTful, because it means the same small set
+of verbs works across every resource in a uniform way.
+
+## Verbs: the same actions on every resource
+
+REST reuses [HTTP's methods](/learn/networking/http/) as the verbs of the API, so the
+*actions* are identical no matter which resource you're touching:
+
+| Method | On `/api/calls` | On `/api/calls/42` |
+|--------|-----------------|--------------------|
+| **GET** | list all calls | fetch call 42 |
+| **POST** | create a new call | — |
+| **PUT / PATCH** | — | replace / update call 42 |
+| **DELETE** | — | delete call 42 |
+
+This is the familiar **CRUD** set — create, read, update, delete — mapped onto four verbs.
+Because the mapping is uniform, learning one resource teaches you all of them: if you know
+`GET /api/calls` and `POST /api/calls`, you already know `GET /api/talkgroups` and
+`POST /api/talkgroups`. Remember the [method semantics](/learn/networking/http/) too — GET
+is safe (never changes anything), and GET, PUT, and DELETE are idempotent while POST
+generally isn't.
+
+## Status codes: say what happened
+
+Every response must return a meaningful [status code](/learn/networking/http/) — it's the
+machine-readable summary the client checks before anything else. Pick the code that
+actually describes the outcome:
+
+- **200 OK** — a successful GET, PUT, or DELETE.
+- **201 Created** — a successful POST that made a new resource.
+- **400 Bad Request** — the client sent something malformed or invalid.
+- **401 Unauthorized / 403 Forbidden** — not logged in / not allowed.
+- **404 Not Found** — no such resource.
+- **500 Internal Server Error** — the server failed.
+
+Returning `200 OK` on an error — with the real problem buried in the body — is a common
+mistake that breaks clients, because the [fetch](/learn/web-dev/fetching-data/) call sees
+success and marches on. The status code is a promise: get it right and every client, proxy,
+and tool downstream can trust it.
+
+## JSON: the body format
+
+REST APIs speak **JSON** in both directions. A GET returns a resource (or a list) as JSON;
+a POST or PUT sends the new state in a JSON request body with a
+`Content-Type: application/json` header.
+
+```json
+POST /api/calls
+{ "talkgroup": "Fire-1", "seconds": 12 }
+```
+
+```json
+HTTP/1.1 201 Created
+Location: /api/calls/42
+{ "id": 42, "talkgroup": "Fire-1", "seconds": 12 }
+```
+
+Notice the response echoes the created resource **with its new id**, and a `Location`
+header points at its URL — small touches that make the API pleasant to consume. Keep field
+names and shapes **consistent across endpoints** (same casing, same date format, the same
+error shape everywhere) so a client learns your conventions once. And because this JSON
+crosses the network, serve it over [HTTPS](/learn/networking/tls-and-https/) so it's
+encrypted in transit.
+
+## Design for predictability
+
+The thread through all of this is **predictability**. A well-designed REST API is one a
+developer can *guess*: see `GET /api/calls` and `GET /api/calls/42`, and they'll correctly
+expect `DELETE /api/calls/42` to remove it and `POST /api/calls` to create one. Consistency
+is the whole feature. A few conventions that pay off:
+
+- **Version the API** (`/api/v1/…`) so you can change it later without breaking clients.
+- **Return a consistent error shape** — same JSON structure for every error, with a
+  message and maybe a code — so clients handle failures uniformly.
+- **Validate every request on the server** — never trust the body — as
+  [what a back end does](/learn/web-dev/what-a-backend-does/) insisted.
+- **Paginate large collections** rather than returning ten thousand items at once.
+
+Get these right and the front end's job — the [fetch](/learn/web-dev/fetching-data/) layer
+— becomes almost mechanical, because the API behaves exactly as its shape implies. That
+predictable contract is the real product of REST.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — in REST the URL names the resource (a noun) and the HTTP method says what to do, so it's POST /api/calls, not /api/createCall." markdown="0">
+  <p class="knowledge-check__q">Quick check: in a REST API, how should you create a new call?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">GET /api/createCall?talkgroup=Fire-1</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">POST /api/calls with the new call in a JSON body</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">POST /api/calls/create with the verb in the path</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **REST API** is a **contract** built from consistent conventions the front end can
+  rely on — see [web APIs &amp; REST](/learn/networking/web-apis-and-rest/) for the full
+  reference.
+- Model data as **resources** with **URLs** (nouns, plural collections); never put a verb
+  in the path.
+- Reuse **HTTP verbs** — GET/POST/PUT/PATCH/DELETE — so the same **CRUD** actions apply
+  uniformly to every resource.
+- Return a **meaningful status code** on every response — 201 on create, 404 on missing,
+  400 on bad input — never 200 on an error.
+- Speak **JSON** both ways with consistent field names and shapes, over
+  [HTTPS](/learn/networking/tls-and-https/).
+- Design for **predictability**: versioning, consistent errors, server-side validation,
+  and pagination make an API a developer can guess.
+
+Next up: [The back end &amp; its database](/learn/web-dev/backend-and-database/).

--- a/docs/learn/web-dev/caching-and-cdns.md
+++ b/docs/learn/web-dev/caching-and-cdns.md
@@ -1,0 +1,145 @@
+---
+slug: caching-and-cdns
+title: Caching & CDNs
+description: Making the web fast by not doing the same work twice — browser caches, HTTP cache headers like Cache-Control and ETag, and content delivery networks that serve your site from a location close to each user.
+keywords: caching, CDN, content delivery network, Cache-Control, ETag, browser cache, cache invalidation, edge server, TTL, cache busting, latency
+level: intermediate
+status: full
+prereq:
+  - http-servers-and-routing
+faq:
+  - q: "What's the difference between a cache and a CDN?"
+    a: "A **cache** is any store of previously computed or fetched results kept so you can reuse them instead of redoing the work — the browser has one, the server can have one. A **CDN (content delivery network)** is a specific, distributed cache: a network of servers spread around the world that hold copies of your files and serve each user from a nearby one, cutting the distance data must travel."
+  - q: "Why do people say cache invalidation is hard?"
+    a: "Because a cache trades freshness for speed: once a copy is stored, how do you know when it's stale? Serve it too long and users see old content; expire it too soon and you lose the benefit. The usual answer is **content-hashed filenames** — when a file changes its name changes, so the new URL misses the cache while unchanged files stay cached forever. That sidesteps the hard part instead of guessing expiry times."
+  - q: "Does a CDN help a dynamic app, or only static sites?"
+    a: "Both, in different ways. A **static site** can be served almost entirely from the CDN. A **dynamic app** still uses a CDN for its static assets — scripts, styles, images — and often caches some API responses at the edge too, while personalised or fast-changing data goes to the origin server. Even a fully dynamic app usually has plenty that a CDN can accelerate."
+---
+
+# Caching & CDNs
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+The fastest work is the work you don't repeat. **Caching** stores a result so it can
+be reused instead of recomputed or refetched — the browser caches assets it already
+has, guided by HTTP headers like **`Cache-Control`** and **`ETag`**. A **CDN
+(content delivery network)** is a worldwide distributed cache that serves each user
+from a nearby **edge** server, shrinking the distance data travels. The perennial
+catch is **cache invalidation** — knowing when a stored copy is stale — usually
+solved with **content-hashed filenames**. Caching underlies real
+[web performance](/learn/web-dev/performance-and-web-vitals/).
+</div>
+
+By this point your app works — it authenticates users, serves data, stays secure.
+The next question is *speed*, and a huge fraction of web performance comes down to a
+single idea: **don't do the same work twice.** This lesson covers caching, from the
+browser's own cache to a global CDN, and the one genuinely tricky part — deciding
+when a cached copy has gone stale.
+
+## Why caching matters
+
+Every asset your page needs — scripts, styles, images, fonts — must be fetched, and
+each fetch costs a round trip across the network. On a repeat visit, or across your
+site's many pages, most of those files haven't changed at all. **Caching** means
+keeping a copy of a result so the next request can reuse it instead of fetching or
+computing it again. Done well, the browser skips whole downloads and your servers do
+far less work. Caching appears at every layer — the browser, a CDN, a
+[reverse proxy](/learn/deployment/reverse-proxies-and-tls/), the server, even the
+[database](/learn/web-dev/backend-and-database/) — but they share the same logic.
+
+## The browser cache & HTTP headers
+
+The browser keeps its own cache, and your server steers it with **HTTP response
+headers**. The main one is **`Cache-Control`**:
+
+```http
+Cache-Control: public, max-age=31536000, immutable
+```
+
+That tells the browser it may keep the file for a year without asking again — ideal
+for an asset whose name changes when its content does. For things that change, you'd
+send a short lifetime, or `no-cache` to force a check each time.
+
+When a cached copy *might* still be good, **validation** avoids re-downloading it. An
+**`ETag`** is a fingerprint of the file the server sends the first time; on the next
+request the browser asks *"still this version?"* with `If-None-Match`, and the server
+replies `304 Not Modified` — no body — if nothing changed:
+
+```http
+ETag: "a1b2c3"                 ← server sends the fingerprint
+If-None-Match: "a1b2c3"        ← browser asks: still current?
+304 Not Modified               ← server: yes, reuse your copy
+```
+
+Between `max-age` (don't even ask for a while) and `ETag` validation (ask cheaply),
+you control the freshness-versus-speed tradeoff per resource.
+
+## CDNs: caching close to the user
+
+Even a cached-perfectly site has a physics problem on the *first* fetch: data travels
+at a finite speed, and a user far from your server waits longer. A **CDN** attacks
+that by putting copies of your files on **edge servers** spread across the globe.
+When a user requests an asset, the CDN serves it from the nearest edge — often a few
+milliseconds away instead of across an ocean.
+
+A CDN does three things at once:
+
+- **Cuts latency** by serving from a location physically near the user.
+- **Offloads your origin** — most requests never reach your own server, so it handles
+  far more traffic.
+- **Absorbs spikes** — a burst of visitors hits the distributed edge, not one box.
+
+Because [this very site](/learn/web-dev/templating-and-static-sites/) is static, a
+CDN can serve essentially all of it. A dynamic app puts its **static assets** on the
+CDN and sends personalised or fast-changing requests to the origin — often caching
+some API responses at the edge too.
+
+## The hard part: cache invalidation
+
+There's an old joke that the two hardest problems in computing are naming things,
+cache invalidation, and off-by-one errors. The middle one is real: once you've stored
+a copy, **how do you know when it's stale?** Set a long lifetime and users get speed
+but risk seeing outdated files after a deploy; set a short one and you lose most of
+the benefit.
+
+The standard trick sidesteps the guessing entirely — **content-hashed filenames**
+(cache busting). The [build step](/learn/web-dev/build-tools-and-bundlers/) names
+each file after a hash of its contents:
+
+```
+app.a1b2c3.js      ← change one byte and the hash — and the filename — changes
+styles.9f8e7d.css
+```
+
+Now you can cache these *forever* (`max-age` of a year, `immutable`), because a
+changed file gets a **new URL** the browser has never seen, so it fetches the new one
+while every unchanged file stays cached. You never invalidate anything — you rename
+it. The HTML that references these files gets a short cache lifetime so new filenames
+are picked up promptly.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a CDN serves copies from an edge server near each user, cutting the distance and time data travels." markdown="0">
+  <p class="knowledge-check__q">Quick check: what's the main way a CDN speeds up your site?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It compresses your database so queries run faster</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">It serves cached copies from an edge server physically near each user</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It rewrites your JavaScript to use fewer functions</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- The core idea is **don't repeat work**: **caching** stores a result so it can be
+  reused instead of recomputed or refetched.
+- The **browser cache** is steered by HTTP headers — **`Cache-Control`** sets how
+  long a copy is good, and an **`ETag`** lets the browser cheaply revalidate for a
+  `304 Not Modified`.
+- A **CDN** is a distributed cache of **edge servers** that serves each user from a
+  nearby location, cutting latency, offloading your origin, and absorbing traffic
+  spikes.
+- **Cache invalidation** — knowing when a copy is stale — is the hard part, usually
+  solved with **content-hashed filenames** so a changed file gets a brand-new URL.
+- Caching applies at every layer and is a foundation of the performance work in the
+  next unit.
+
+Next up: [deploying a web app](/learn/web-dev/deploying-a-web-app/).

--- a/docs/learn/web-dev/choosing-a-web-stack.md
+++ b/docs/learn/web-dev/choosing-a-web-stack.md
@@ -1,0 +1,132 @@
+---
+slug: choosing-a-web-stack
+title: Choosing your web stack
+description: A practical framework for the endless "what should I use?" question — matching a front-end approach, back-end language, database, and hosting to the project actually in front of you, instead of chasing whatever's trending.
+keywords: web stack, tech stack, choosing a framework, front-end choice, back-end language, database choice, hosting, boring technology, project requirements, full-stack
+level: intermediate
+status: full
+prereq:
+  - anatomy-of-a-web-app
+faq:
+  - q: "Is there a single best web stack?"
+    a: "No — and anyone who says otherwise is selling something. The best stack is the one that fits *your* project's requirements, your team's existing skills, and how the app needs to run. A tiny content site and a real-time collaborative app have almost nothing in common in their ideal tooling. The skill isn't knowing the 'right' stack; it's matching tools to the job in front of you."
+  - q: "Should I always use the newest, most popular framework?"
+    a: "Usually not. Popularity is a weak signal and novelty is a real cost — new tools have fewer answered questions, more churn, and fewer people who know them. **Boring, proven technology** you or your team already understand ships faster and breaks less. Reach for something new when the project genuinely needs what it offers, not because it's trending."
+  - q: "What matters most when choosing?"
+    a: "Your **team's existing skills**, more often than not. A stack your team knows well beats a theoretically better one they'd have to learn under deadline. After that: the project's real requirements (does it even need a heavy front-end framework?), how it must run and scale, and the size of the ecosystem you can lean on when you're stuck."
+---
+
+# Choosing your web stack
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+There is **no single best stack** — only the one that fits *this* project. Choose by
+**requirements** (what does the app actually need to do?), your **team's existing
+skills** (the biggest real-world factor), and how it must **run and scale**. Prefer
+**boring, proven technology** you understand over whatever is trending; novelty is a
+cost, not a feature. A stack is a **front-end approach**, a **back-end language**, a
+**database**, and **hosting** — pick each to match the job, not a hype cycle. This
+lesson pulls together the whole [module](/learn/web-dev/anatomy-of-a-web-app/) into a
+decision.
+</div>
+
+Every developer eventually faces the paralysing question: *what should I build this
+with?* The internet answers with a thousand contradictory opinions and a new
+framework every month. This lesson replaces that noise with a durable way to decide —
+one that outlives any specific tool, because it's about matching technology to a
+project rather than memorising a "right answer" that changes yearly.
+
+## There is no best stack
+
+The single most freeing thing to accept: **the best stack depends entirely on the
+project.** A marketing site, an internal dashboard, a real-time app, and a
+high-traffic API each have a different ideal — and a choice that's perfect for one is
+wasteful or inadequate for another. The [anatomy of a web
+app](/learn/web-dev/anatomy-of-a-web-app/) laid out the pieces; choosing a stack is
+deciding *how* to fill each one for your specific case. So the question is never
+"what's the best framework?" but "what does *this* project need?"
+
+## Start from requirements
+
+Good choices start from the work, not the tools. A few questions cut through most of
+it:
+
+- **How dynamic is it?** A mostly-static content site may need no
+  [front-end framework](/learn/web-dev/frontend-frameworks/) at all — a
+  [static generator](/learn/web-dev/templating-and-static-sites/) is simpler, faster,
+  and cheaper. A highly interactive app justifies a heavier front end.
+- **What's the rendering need?** Public and SEO-sensitive leans
+  [server-rendered or static](/learn/web-dev/ssr-spa-static/); an app-like tool behind
+  a login can be a client-rendered SPA.
+- **What's the data shape?** Structured, relational data with clear relationships
+  suits a relational [database](/learn/databases/); other shapes may not. Let the data
+  drive the store, not fashion.
+- **Real-time?** If live updates are core, you're committing to
+  [WebSockets or similar](/learn/web-dev/websockets-and-realtime/) and a back end that
+  supports them well.
+
+Answering these usually narrows the field far more than any framework comparison
+does.
+
+## Weigh the real factors
+
+With requirements in hand, weigh the factors that actually predict success:
+
+- **Your team's existing skills.** This dominates. A stack your team knows ships
+  faster and breaks less than a "better" one learned under deadline. A language you're
+  fluent in is worth more than a marginally superior one you're not.
+- **Ecosystem and maturity.** A large, mature ecosystem means libraries for the boring
+  parts, answered questions when you're stuck, and people you can hire. A tiny or
+  churning ecosystem means you build and debug more yourself.
+- **How it runs and scales.** Match the [deployment](/learn/web-dev/deploying-a-web-app/)
+  and scaling story to reality — most projects need far less than they fear, so don't
+  architect for a scale you don't have.
+- **Cost and operational burden.** Someone has to run this. A simpler stack with fewer
+  moving parts is less to [monitor](/learn/web-dev/monitoring-and-analytics/), secure,
+  and keep alive.
+
+## Prefer boring technology
+
+A principle that pays off repeatedly: **prefer boring, proven technology.** Novelty
+has a real, often-hidden cost — fewer answered questions, more breaking changes, fewer
+people who know it, and a higher chance the tool is abandoned in two years. Mature,
+"boring" tools are boring precisely *because* they work: their sharp edges are known
+and documented. Choose something new when the project genuinely needs what it uniquely
+offers — not because it's trending or looks good on a résumé. The goal is a working,
+maintainable product, and unexciting tools ship those more reliably than exciting ones.
+
+## Putting it together
+
+A stack is really four coupled choices — a front-end approach, a back-end language, a
+database, and hosting — and they interact. The move is to make them **coherently**:
+start from requirements, lean on what your team knows, favour proven pieces, and keep
+the whole thing no more complex than the project demands. GopherTrunk's own dashboard,
+the [next lesson's](/learn/web-dev/gophertrunk-web-dashboard/) worked example, is a
+small, deliberate stack chosen exactly this way — Go on the back end because the whole
+project is Go, a light front end because the job is a live table of calls, and no more
+than that.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the best stack is the one that fits the project's requirements and your team, not whatever is newest." markdown="0">
+  <p class="knowledge-check__q">Quick check: what's the soundest basis for choosing a web stack?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Whichever framework is newest and trending right now</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The project's real requirements and your team's existing skills</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Whatever has the most stars on its repository this week</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- There is **no single best stack** — the right one depends on the project in front of
+  you, so ask *what does this need?*, not *what's best?*
+- **Start from requirements**: how dynamic, what rendering, what data shape, and
+  whether real-time is core — these narrow the field fast.
+- Weigh the factors that predict success: **your team's existing skills** (the
+  dominant one), ecosystem maturity, how it runs and scales, and operational cost.
+- **Prefer boring, proven technology**; novelty is a hidden cost, so reach for the new
+  only when the project genuinely needs it.
+- A stack is four coupled choices — front end, back end, database, hosting — made
+  **coherently** and no more complex than the job requires.
+
+Next up: [the GopherTrunk web dashboard](/learn/web-dev/gophertrunk-web-dashboard/).

--- a/docs/learn/web-dev/client-server-web.md
+++ b/docs/learn/web-dev/client-server-web.md
@@ -1,0 +1,144 @@
+---
+slug: client-server-web
+title: The client-server web
+description: Every web interaction is one side asking and the other answering. This lesson explains the client-server model on the web — who the client and server are, what a request and response carry, why the model scales, and how it maps to the front end and back end you already know.
+keywords: client server, request and response, web client, web server, client-server model, HTTP request, front end back end, stateless web, how the web works
+level: beginner
+status: full
+prereq:
+  - how-the-browser-works
+faq:
+  - q: What is the difference between a client and a server?
+    a: "The **client** is the program that starts the conversation by making a request — on the web, almost always a browser. The **server** is the program that listens for requests and sends back a response. One asks, the other answers; the roles are defined by who initiates, not by the hardware."
+  - q: Can one machine be both a client and a server?
+    a: "Yes. The roles are about the direction of a given request, not fixed labels. A back-end server answering your browser might itself act as a **client** when it calls another service — say a payment provider — for data it needs to build its response."
+  - q: Why is the client-server model so common on the web?
+    a: "Because it centralises the parts that must be shared and trusted. One server can hold the authoritative data and rules and serve many clients at once, while each client only needs to know how to make a request. That separation is what lets millions of browsers safely use the same application."
+---
+
+# The client-server web
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Every web interaction is a **request** and a **response**: a **client** asks, a
+**server** answers. On the web the client is almost always the **browser** (the
+front end) and the server is the machine running your **back end**. One server can
+serve many clients at once, which is what makes the model scale. The web is also
+**stateless** — each request stands alone — so anything to be remembered gets sent
+again next time. This is the same rhythm under
+[how a web request works](/learn/networking/how-a-web-request-works/), viewed from
+the web developer's chair.
+</div>
+
+The first two lessons kept returning to one idea: the front end asks and the back
+end answers. That idea has a name — the **client-server model** — and it is the
+organising principle of the entire web. Once you can see any web interaction as a
+client making a request and a server returning a response, a great deal of what
+follows in this module is just detail hung on that frame.
+
+## Who is the client, who is the server
+
+The two roles are defined by **who starts the conversation**:
+
+- The **client** initiates. It sends a request whenever it wants something — a
+  page, an image, some data. On the web the client is overwhelmingly the
+  **browser**, though a mobile app or a command-line tool can play the same role.
+- The **server** waits and responds. It sits listening for requests, does whatever
+  work each one needs, and sends back a response. Your **back end** is a server.
+
+Notice the mapping to the last two lessons: the **front end is the client**, the
+**back end is the server**. "Client-server," "front end / back end," and "browser /
+server" are three ways of naming the same divide, each emphasising a different
+angle — the role, the codebase, or the machine.
+
+## Request and response
+
+The unit of a client-server exchange is a **request** paired with a **response**.
+The client sends a request that says, in effect, *what* it wants and *how*; the
+server sends back a response with the result and some information about it.
+
+A request typically carries:
+
+- A **method** — the kind of action wanted, like *read this* or *submit this*.
+- A **path** — which resource it's about, such as `/calls` or `/login`.
+- **Headers** — metadata about the request (who's asking, what format is
+  acceptable).
+- Sometimes a **body** — data being sent, such as the contents of a form.
+
+A response typically carries a **status** (did it work?), its own **headers**, and
+usually a **body** — the HTML, the data, the image. This request/response format
+is written in a protocol called **HTTP**, which the networking module covers in
+[HTTP — the web's protocol](/learn/networking/http/). The whole low-level journey a
+single request takes across the network — DNS, connection, and all — is walked
+through in [how a web request works](/learn/networking/how-a-web-request-works/).
+
+## Many clients, one server
+
+The reason the web is built this way is that it **scales** and it **centralises
+trust**. A single server can hold the one authoritative copy of the data and the
+rules, and answer thousands of clients at once. Each client is simple — it only
+needs to know how to make a request — while the hard, shared, sensitive parts live
+in one place the operator controls.
+
+That's also *why* the back end exists at all. You can't put the master database or
+the "who is allowed to do what" rules on the user's device, because the user
+controls that device and could change anything on it. Centralising those on a
+server the operator runs is what makes a multi-user application possible and safe.
+We build out that reasoning in
+[what a back end does](/learn/web-dev/what-a-backend-does/).
+
+## Roles can swap
+
+The client and server labels describe a *single* request, not a permanent
+identity. The same machine can be both, depending on the direction of a given
+call.
+
+Picture your back-end server handling a browser's request for a page. To build
+that page it might need exchange-rate data, so it calls another company's API. In
+*that* exchange your server is the **client** and the other company's is the
+**server**. Web systems are full of these chains — browser to your server, your
+server to a database, your server to a third-party API — each link a small
+client-server conversation. Seeing the pattern repeat is more useful than
+memorising which box is which.
+
+## Stateless by default
+
+One property shapes everything built on top of the model: HTTP is **stateless**.
+The server handles each request on its own and, by default, remembers nothing
+about the previous one. Two clicks a second apart arrive as complete strangers to
+each other.
+
+That keeps servers simple and lets any server in a pool handle any request, but it
+raises an obvious problem: how does a site know you're still logged in on the next
+click? The answer is that the client **resends** the proof every time — a cookie or
+token travels with each request, reconstructing continuity out of many independent
+exchanges. This is such a central idea that a later lesson,
+[authentication & sessions](/learn/web-dev/authentication-and-sessions/), is
+devoted to it.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the client is whoever initiates the request; on the web that's usually the browser." markdown="0">
+  <p class="knowledge-check__q">Quick check: in the client-server model, what makes something the client?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It's the more powerful machine in the exchange</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">It initiates the request — on the web, usually the browser</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It's always the machine in the data centre</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- The **client-server model** is the web's organising principle: a **client**
+  requests, a **server** responds.
+- On the web the **client is the browser** (the front end) and the **server runs
+  the back end** — three names for one divide.
+- A **request** carries a method, path, headers, and sometimes a body; a
+  **response** carries a status, headers, and usually a body — all over **HTTP**.
+- One server can serve **many clients**, centralising the authoritative data and
+  rules where the operator controls them.
+- Roles can **swap** per request — a server calling another service is itself a
+  client.
+- HTTP is **stateless**, so continuity like being logged in is re-sent with every
+  request.
+
+Next up: [Anatomy of a modern web app](/learn/web-dev/anatomy-of-a-web-app/).

--- a/docs/learn/web-dev/components-and-state.md
+++ b/docs/learn/web-dev/components-and-state.md
@@ -1,0 +1,175 @@
+---
+slug: components-and-state
+title: Components & state
+description: The two ideas at the heart of every modern front-end framework — the component as a reusable, self-contained piece of UI, and state as the data that drives what a component shows and re-renders it when it changes.
+keywords: component, state, props, re-render, UI state, component tree, reusable UI, React state, useState, lifting state up, unidirectional data flow
+level: intermediate
+status: full
+prereq:
+  - frontend-frameworks
+faq:
+  - q: What is the difference between props and state?
+    a: "Props are the inputs a component receives from its parent — read-only data passed down. State is data a component owns and can change over time. When state changes, the component re-renders; when a parent passes new props, the child re-renders too. Roughly: props flow in from outside, state lives inside."
+  - q: What does 'the UI is a function of state' mean?
+    a: "It means the screen is fully determined by the current state — feed the same state in and you get the same UI out. You never reach in and edit the DOM; you update the state, and the framework re-renders the affected components to match. This is what makes complex UIs predictable."
+  - q: Why do frameworks make you call a setter instead of just reassigning a variable?
+    a: "Because the framework needs to know the data changed so it can re-render. A plain reassignment is invisible to it. Calling the setter (or mutating a reactive object it's watching) is the signal that says 'this changed — update the UI,' which is how declarative rendering stays in sync."
+---
+
+# Components & state
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Every modern UI is built from **components** — small, reusable, self-contained pieces
+of UI — arranged into a tree. What a component shows is driven by **state**: the data
+it holds, plus **props** passed in from its parent. The golden rule is that the **UI
+is a function of state** — you never edit the page directly; you change the state and
+the [framework](/learn/web-dev/frontend-frameworks/) re-renders the components that
+depend on it. Data flows **down** through props and changes flow **up** through
+events, which keeps even a large app predictable.
+</div>
+
+The [previous lesson](/learn/web-dev/frontend-frameworks/) said frameworks let you
+describe the UI declaratively and keep it in sync with your data. This lesson is the
+two ideas that make that work in practice: the **component**, which is how you break a
+UI into pieces, and **state**, which is the data that drives those pieces. Get these
+two and you have the mental model behind React, Vue, Svelte, and the rest — the syntax
+is just detail on top.
+
+## A component is a reusable piece of UI
+
+A component is a self-contained chunk of interface — a button, a search box, a call
+row, a whole panel — bundling its markup, its styling, and its behaviour in one place.
+You define it once and use it wherever you need it, like a function you call to get UI.
+
+```jsx
+// A small component: takes inputs, returns the UI for one call.
+function CallRow({ talkgroup, seconds }) {
+  return (
+    <li className="call-row">
+      <span className="tg">{talkgroup}</span>
+      <span className="len">{seconds}s</span>
+    </li>
+  );
+}
+```
+
+Components **compose**: bigger ones are built from smaller ones, forming a **tree** with
+one root at the top. A `Dashboard` contains a `CallList`, which renders many `CallRow`s.
+This is the same "break a big thing into small, named, reusable pieces" instinct as
+functions in ordinary code — applied to the interface — and it is why a screen with
+thousands of elements stays comprehensible.
+
+## Props: inputs passed down
+
+A component almost never stands alone; it takes **inputs** from its parent, called
+**props**. In `CallRow` above, `talkgroup` and `seconds` are props — the parent decides
+their values, the child just renders them. Props are **read-only** to the child: it
+displays them but does not change them. That one-way flow — data handed *down* the tree
+— is what makes a component reusable, because the same `CallRow` works for any call the
+parent gives it.
+
+```jsx
+// The parent supplies props for each child.
+function CallList({ calls }) {
+  return (
+    <ul>
+      {calls.map((c) => (
+        <CallRow key={c.id} talkgroup={c.talkgroup} seconds={c.seconds} />
+      ))}
+    </ul>
+  );
+}
+```
+
+## State: data that changes over time
+
+Props come from outside; **state** is data a component **owns and can change**. A
+search box owns the text you've typed; a dashboard owns the list of calls received so
+far; a toggle owns whether it's on. State is the memory of the UI between events.
+
+The crucial move is *how* you change it. You don't reach into the DOM and edit the
+page — you update the state through the framework, and it **re-renders** the component
+to match.
+
+```jsx
+import { useState } from "react";
+
+function Filter() {
+  const [query, setQuery] = useState("");   // state, starts empty
+  return (
+    <input
+      value={query}
+      onChange={(e) => setQuery(e.target.value)}  // change state → re-render
+      placeholder="Filter talkgroups"
+    />
+  );
+}
+```
+
+Calling `setQuery` is you telling the framework "this data changed." That signal is
+essential: a plain `query = "..."` reassignment would be invisible, and the UI would
+never update. The setter is the bridge between your data and the declarative render.
+
+## The UI is a function of state
+
+Put props and state together and you get the single most important rule in front-end
+development: **the UI is a function of state.** Given the current state, the screen is
+fully determined — same state in, same UI out. You never manually sync the DOM; you
+change the state and the framework recomputes the affected components.
+
+This is why the counter-out-of-sync bug from the last lesson simply cannot happen: the
+count and the list are both derived from the same `calls` state, so they can't
+disagree. It also makes UIs easier to reason about and test — to check a screen, you set
+up a state and look at what renders, no clicking through steps required.
+
+## Data down, events up
+
+If props only flow *down*, how does a child change something a parent owns — like a
+row telling the dashboard it was clicked? The answer is the mirror of props: the parent
+passes a **callback** down, and the child **calls it** to send a change back up. Data
+flows **down** as props; changes flow **up** as events. State lives at the lowest
+component that needs it, and when two siblings need the same state, you **lift it up** to
+their shared parent.
+
+```jsx
+// Parent owns the state and passes a callback down; child calls it up.
+function Dashboard() {
+  const [selected, setSelected] = useState(null);
+  return <CallRow talkgroup="Fire-1" onSelect={() => setSelected("Fire-1")} />;
+}
+```
+
+This one-way, top-down flow — often called **unidirectional data flow** — is what keeps
+a big component tree predictable: there is always one owner of each piece of state, and
+one direction changes travel. It is the discipline that lets an app grow to hundreds of
+components without becoming a tangle, and it carries directly into
+[fetching data](/learn/web-dev/fetching-data/), where the data comes from a server
+instead of a click.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — you change the state and the framework re-renders; you never edit the DOM directly. The UI is a function of state." markdown="0">
+  <p class="knowledge-check__q">Quick check: in a component framework, how do you update what's on screen?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Find the DOM node and edit its text directly, as with plain JavaScript</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Change the component's state and let the framework re-render to match</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Reload the whole page so the new data is fetched again</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **component** is a reusable, self-contained piece of UI; components **compose**
+  into a tree with one root.
+- **Props** are read-only inputs a parent passes **down** to a child, which is what
+  makes a component reusable.
+- **State** is data a component owns and can change; changing state through the
+  framework triggers a **re-render**.
+- The core rule is that the **UI is a function of state** — you change state, never the
+  DOM, and the framework keeps the screen in sync.
+- Data flows **down** as props and changes flow **up** as events; shared state is
+  **lifted** to a common parent (**unidirectional data flow**).
+- This mental model — components plus state — is the same across
+  [every framework](/learn/web-dev/frontend-frameworks/).
+
+Next up: [Fetching data from the front end](/learn/web-dev/fetching-data/).

--- a/docs/learn/web-dev/cookies-tokens-jwt.md
+++ b/docs/learn/web-dev/cookies-tokens-jwt.md
@@ -1,0 +1,147 @@
+---
+slug: cookies-tokens-jwt
+title: Cookies, tokens & JWTs
+description: How the browser remembers you between stateless requests — session cookies, bearer tokens, and JSON Web Tokens (JWTs) — with the security flags and tradeoffs that decide which to reach for.
+keywords: cookie, session cookie, HttpOnly, Secure, SameSite, bearer token, JWT, JSON Web Token, access token, refresh token, authorization header
+level: intermediate
+status: full
+prereq:
+  - authentication-and-sessions
+faq:
+  - q: "What's the difference between a cookie and a token?"
+    a: "A **cookie** is a small named value the browser stores and *automatically* attaches to matching requests — you don't write code to send it. A **token** (like a JWT) is a string your code stores and sends *deliberately*, usually in an `Authorization` header. Cookies are convenient for browser apps; tokens are common for APIs and mobile clients. They're not mutually exclusive — a token can even be delivered inside a cookie."
+  - q: "Are JWTs encrypted?"
+    a: "No — a standard **JWT is signed, not encrypted**. Anyone holding it can read its contents (the payload is just base64-encoded JSON), but the signature lets the server detect tampering. So never put secrets in a JWT payload, and always send it over HTTPS so it can't be read or stolen in transit."
+  - q: "Why can't I just log the user out by deleting their JWT?"
+    a: "Because a self-contained JWT is valid until it **expires**, no matter what the server does — the server keeps no record of it to delete. That's the tradeoff for being stateless. Real systems keep JWT lifetimes short and pair them with a **refresh token** or a revocation list when instant logout matters."
+---
+
+# Cookies, tokens & JWTs
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+The [session](/learn/web-dev/authentication-and-sessions/) identifier has to ride on
+every request — the three common vehicles are **cookies**, **bearer tokens**, and
+**JWTs**. A **cookie** is stored by the browser and sent automatically; harden it
+with the **HttpOnly**, **Secure**, and **SameSite** flags. A **bearer token** is
+sent deliberately in an `Authorization` header, common for APIs. A **JWT** is a
+*signed, not encrypted* token that carries its own claims so the server can trust it
+without a lookup — powerful, but hard to revoke before it **expires**. Which you
+pick trades convenience against control.
+</div>
+
+The previous lesson ended with a session identified by a token the browser sends
+back on every request. This lesson is about that token: what form it takes, how it
+travels, and how to keep it from being stolen. Get this wrong and a stolen token
+means a stolen account — so the security flags here matter as much as the mechanics.
+
+## Cookies: the browser's memory
+
+A **cookie** is a small named value the server asks the browser to store, using a
+`Set-Cookie` response header. From then on the browser **automatically** includes it
+on every request to that site — you write no code to send it. That automatic
+behaviour is what makes cookies the classic home for a session ID.
+
+```http
+Set-Cookie: session=abc123; HttpOnly; Secure; SameSite=Lax; Max-Age=3600
+```
+
+Three flags on that header do the security heavy lifting:
+
+- **HttpOnly** — JavaScript can't read the cookie. This blunts
+  [cross-site scripting](/learn/web-dev/web-security-essentials/) from stealing the
+  session, because a script that runs on your page still can't see the value.
+- **Secure** — the cookie is only sent over HTTPS, so it never crosses the network
+  in the clear. (See [TLS & HTTPS](/learn/networking/tls-and-https/).)
+- **SameSite** — controls whether the cookie rides along on requests coming *from
+  other sites*. `Lax` or `Strict` is a primary defence against
+  [CSRF](/learn/web-dev/web-security-essentials/), which abuses the browser's
+  automatic cookie-sending.
+
+A session cookie holds an **opaque ID**; the real state lives on the server. That
+makes logout trivial — the server forgets the session and the ID is worthless.
+
+## Tokens: identity you send on purpose
+
+The other model hands the client a **token** — a string it stores itself and sends
+*explicitly*, usually as a **bearer token** in an HTTP header:
+
+```http
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+```
+
+Nothing is automatic here: your [front-end code](/learn/web-dev/fetching-data/)
+attaches the header on each request. That extra work buys flexibility — the same
+API can serve a browser app, a mobile app, and other servers, none of which share
+the browser's cookie machinery. Because tokens aren't sent automatically, they
+sidestep CSRF; the cost is that *you* must store them somewhere safe, and browser
+storage readable by JavaScript is exposed to XSS.
+
+## JWTs: a token that carries its own claims
+
+A **JSON Web Token (JWT)** is a specific, popular token format. It packs a small
+JSON payload — the **claims**, such as the user ID and an expiry time — and **signs**
+it. The three dot-separated parts are a header, the payload, and a signature:
+
+```
+header.payload.signature   ->   eyJ...  .  eyJ...  .  SflKx...
+```
+
+The signature is the point. The server signs the token with a secret at login; on
+each later request it re-checks the signature. If it matches, the claims are
+trustworthy and **the server needs no database lookup** to know who you are — the
+identity travels *inside* the token. That statelessness is the JWT's whole appeal,
+especially across many servers.
+
+Two things trip people up, both worth memorising:
+
+- **A JWT is signed, not encrypted.** The payload is readable by anyone holding the
+  token. Never put a secret in it, and always send it over HTTPS.
+- **A self-contained JWT is hard to revoke.** Because the server stores nothing, a
+  leaked token is valid until it **expires** — deleting it server-side isn't
+  possible. The fix is short lifetimes plus a **refresh token** (a longer-lived
+  credential used to mint new short access tokens), or a server-side revocation list
+  that trades away some of the statelessness.
+
+## Choosing between them
+
+There's no universal winner — match the tool to the client:
+
+| | Session cookie | Bearer token / JWT |
+|---|---|---|
+| **Sent** | Automatically by the browser | Deliberately, in a header |
+| **State** | Server-side (opaque ID) | Often self-contained (JWT) |
+| **Revoke / logout** | Easy — drop the session | Hard for stateless JWTs |
+| **Main risk** | CSRF (mitigate with SameSite) | Theft via XSS if JS-readable |
+| **Good fit** | Classic server-rendered web apps | APIs, mobile, cross-service |
+
+A common, sound default for a browser app is **session cookies with HttpOnly,
+Secure, and SameSite set**. Reach for tokens when non-browser clients or many
+independent services are in the picture. Whatever you choose, the token is the keys
+to the account — protect it as such.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a JWT is signed for integrity but readable by anyone, so never put secrets in the payload." markdown="0">
+  <p class="knowledge-check__q">Quick check: is it safe to store a user's secret data inside a JWT payload?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Yes — the signature encrypts the payload so no one can read it</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">No — a JWT is signed, not encrypted; the payload is readable by anyone holding it</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Yes — JWTs are always sent over HTTPS so the contents are hidden</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- The session token has to travel on every request; the three vehicles are
+  **cookies**, **bearer tokens**, and **JWTs**.
+- A **cookie** is stored and sent **automatically** by the browser; harden it with
+  **HttpOnly** (no JS access), **Secure** (HTTPS only), and **SameSite** (limits
+  cross-site sending).
+- A **bearer token** is sent **deliberately** in an `Authorization` header, which
+  suits APIs and non-browser clients and avoids CSRF.
+- A **JWT** carries **signed** claims so the server can trust it without a lookup —
+  but it's readable (**not encrypted**) and **hard to revoke** before it **expires**.
+- Match the tool to the client: cookies for classic web apps, tokens for APIs and
+  cross-service; either way, guard the token like the account it unlocks.
+
+Next up: [WebSockets & real-time updates](/learn/web-dev/websockets-and-realtime/).

--- a/docs/learn/web-dev/css-and-layout.md
+++ b/docs/learn/web-dev/css-and-layout.md
@@ -1,0 +1,170 @@
+---
+slug: css-and-layout
+title: CSS — styling & layout
+description: CSS turns plain HTML into a designed page. This lesson covers how CSS attaches to markup with selectors, the properties that control appearance, the box model every element follows, and the two modern layout systems — flexbox and grid — that arrange elements on the page.
+keywords: CSS, selectors, box model, flexbox, grid, styling, layout, CSS properties, padding margin border, responsive layout, cascade
+level: beginner
+status: full
+prereq:
+  - html-structure
+faq:
+  - q: What does CSS do?
+    a: "**CSS** (Cascading Style Sheets) controls how a page *looks* — colours, fonts, spacing, sizes, and the arrangement of elements. HTML says what content is; CSS says how it should be presented. You write rules that select elements and set properties on them, and the browser applies those rules when it renders the page."
+  - q: What is the box model?
+    a: "Every element the browser lays out is a rectangular **box** with four layers from the inside out: the **content**, the **padding** around it, the **border** around that, and the **margin** separating it from other boxes. Almost all spacing and sizing in CSS comes down to adjusting these four layers."
+  - q: Should I use flexbox or grid?
+    a: "Both are modern layout tools and you'll use them together. **Flexbox** arranges items in a single direction — a row or a column — and is ideal for things like navigation bars and toolbars. **Grid** works in two dimensions at once — rows and columns — and suits page-level layouts. A common pattern is grid for the overall page, flexbox within its pieces."
+---
+
+# CSS — styling & layout
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**CSS** is how a page goes from plain text to designed. You write **rules** that
+**select** elements and set **properties** — colour, font, spacing, size — and the
+browser applies them. Every element is a **box** with content, **padding**,
+**border**, and **margin** (the **box model**), and the two systems that arrange
+those boxes are **flexbox** (one direction) and **grid** (two directions).
+Together with [HTML](/learn/web-dev/html-structure/) for structure, CSS is the
+second of the front-end trio — it controls everything about how the page *looks*.
+</div>
+
+HTML gives you a structured but unstyled page — black text on a white background,
+stacked top to bottom. **CSS** is what makes it look like a designed product. It's
+the second language of the browser, and where HTML answers "what is this content,"
+CSS answers "how should it look and where should it go." The two are deliberately
+separate: structure in HTML, presentation in CSS, so each can change without
+disturbing the other.
+
+## How CSS attaches to HTML
+
+A CSS **rule** has two parts: a **selector** that picks which elements it applies
+to, and a block of **declarations** — `property: value` pairs — that say what to do
+to them:
+
+```css
+h1 {
+  color: navy;
+  font-size: 2rem;
+}
+```
+
+That rule selects every `<h1>` and makes it navy and larger. Selectors are how you
+target elements:
+
+- A **type** selector like `h1` matches every element of that kind.
+- A **class** selector like `.alert` matches elements with `class="alert"`.
+- An **id** selector like `#header` matches the one element with `id="header"`.
+
+Classes are the workhorse — you add a `class` to the HTML elements you want to
+style as a group, then write one rule for that class. This is the main reason the
+`class` attribute from the last lesson matters so much.
+
+## The cascade
+
+The "cascading" in CSS names how the browser resolves conflicts when **several
+rules** target the same element. Rather than error, it decides which wins, based
+mainly on:
+
+- **Specificity** — a more specific selector (an id) beats a less specific one (a
+  type).
+- **Order** — when specificity ties, the rule written later wins.
+- **Inheritance** — some properties, like `color` and `font`, pass down from a
+  parent to its children unless overridden.
+
+You don't need to master the rules today, but knowing they exist explains a
+classic beginner moment: "my style isn't applying." Usually another, more specific
+rule is winning the cascade. Reach for clear, consistent class names before you
+reach for ever-more-specific selectors.
+
+## The box model
+
+Here's the idea that underlies all CSS layout: **every element is a rectangular
+box**, and each box has four nested layers, from the inside out:
+
+- **Content** — the text or image itself.
+- **Padding** — space *inside* the box, between the content and the border.
+- **Border** — a line around the padding.
+- **Margin** — space *outside* the box, separating it from its neighbours.
+
+```css
+.card {
+  padding: 16px;          /* space inside, around the content */
+  border: 1px solid gray; /* the edge */
+  margin: 24px;           /* space outside, between cards */
+}
+```
+
+Nearly all spacing and sizing comes down to these four. A frequent stumbling block
+is that, by default, `width` sets the *content* width and padding and border add on
+top — so a "300px" box can end up wider. The common fix, `box-sizing: border-box`,
+makes `width` include padding and border, which is far more intuitive and is set
+almost universally today.
+
+## Laying out with flexbox
+
+Stacking boxes top to bottom is the default, but real designs arrange things in
+rows, columns, and grids. **Flexbox** is the tool for laying out items along a
+**single direction** — a row or a column — and distributing space among them.
+
+```css
+.toolbar {
+  display: flex;
+  gap: 12px;              /* space between items */
+  justify-content: space-between;
+  align-items: center;
+}
+```
+
+Set `display: flex` on a container and its children become flex items you can
+space, align, and size fluidly. Flexbox shines for navigation bars, toolbars,
+button rows, and card strips — anything that's essentially a line of items you want
+arranged and aligned. It also handles wrapping and flexible sizing, which is a big
+part of adapting to different screens.
+
+## Laying out with grid
+
+Where flexbox thinks in one direction, **CSS grid** works in **two dimensions** at
+once — rows *and* columns — which makes it the natural choice for the overall shape
+of a page or any genuinely grid-like arrangement:
+
+```css
+.layout {
+  display: grid;
+  grid-template-columns: 200px 1fr;  /* sidebar + flexible main */
+  gap: 24px;
+}
+```
+
+That creates a fixed sidebar next to a main area that takes the remaining space
+(`1fr` means "one fraction of what's left"). Grid excels at page layouts, image
+galleries, and dashboards. In practice you **combine** the two: grid for the
+big-picture structure, flexbox inside its regions. Both systems are also central
+to [responsive design](/learn/web-dev/responsive-design/), where the same layout
+rearranges itself to fit any screen.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the box model is content, padding, border, and margin, the four layers that control an element's spacing and size." markdown="0">
+  <p class="knowledge-check__q">Quick check: which four layers make up the CSS box model, inside to out?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Header, body, footer, and sidebar</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Content, padding, border, and margin</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Selector, property, value, and rule</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **CSS** controls how a page looks — colour, font, spacing, size, and layout —
+  keeping presentation separate from HTML's structure.
+- A **rule** pairs a **selector** (type, class, or id) with **declarations**
+  (`property: value`); **classes** are the everyday workhorse.
+- The **cascade** resolves conflicting rules by **specificity**, **order**, and
+  **inheritance** — the usual reason a style "won't apply."
+- Every element is a **box** with **content, padding, border, and margin**; the
+  **box model** governs spacing and sizing.
+- **Flexbox** lays items out in **one direction** (rows or columns); **grid** works
+  in **two dimensions** for page-level layout.
+- Real designs **combine** grid and flexbox, and both underpin responsive layouts.
+
+Next up: [JavaScript in the browser](/learn/web-dev/javascript-in-the-browser/).

--- a/docs/learn/web-dev/deploying-a-web-app.md
+++ b/docs/learn/web-dev/deploying-a-web-app.md
@@ -1,0 +1,151 @@
+---
+slug: deploying-a-web-app
+title: Deploying a web app
+description: Getting your web app off your laptop and onto the internet — building the front end, running the back end on a host, pointing a domain at it, and putting a reverse proxy with TLS in front, connecting to the deployment module's toolkit.
+keywords: deployment, hosting, build, static hosting, reverse proxy, TLS, HTTPS, domain, DNS, environment variables, CI/CD, production
+level: intermediate
+status: full
+prereq:
+  - what-a-backend-does
+faq:
+  - q: "Do the front end and back end deploy the same way?"
+    a: "Usually not. A **front end** (or a fully static site) is a bundle of files that can be dropped onto static hosting or a CDN — no server process runs your code. A **back end** is a program that must *run* somewhere: a server, container, or platform that keeps the process alive, restarts it if it crashes, and gives it a database and secrets. Many apps host each separately."
+  - q: "How does my code know its production settings, like the database URL?"
+    a: "Through **environment variables** and secrets injected by the host at runtime — never hard-coded in the source. The same code runs in development and production; only the configuration differs. This keeps credentials out of your repository and lets one build run in any environment."
+  - q: "Why do I need a reverse proxy if my app already serves HTTP?"
+    a: "A **reverse proxy** sits in front of your app and handles the cross-cutting concerns you don't want in your application code — terminating **TLS** (HTTPS), routing to the right service, load-balancing across instances, and serving static files. Your app can speak plain HTTP internally while the proxy presents a single secure front door to the world. See [reverse proxies & TLS](/learn/deployment/reverse-proxies-and-tls/)."
+---
+
+# Deploying a web app
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Deploying means moving your app from *works on my laptop* to *running for users on
+the internet*. A **front end** is built into static files you host or push to a
+[CDN](/learn/web-dev/caching-and-cdns/); a **back end** is a process that must *run*
+on a host with a database, secrets, and something to restart it. Production settings
+come from **environment variables**, never hard-coded. A **reverse proxy** presents
+the public HTTPS front door, terminating **TLS** and routing to your services. This
+is the on-ramp to the [Containers & Deployment](/learn/deployment/what-is-deployment/)
+module, which owns the full toolkit.
+</div>
+
+You've built an app. Now it has to *run somewhere other than your machine* — reachable
+at a domain, over HTTPS, staying up when you close your laptop. That step is
+**deployment**, and it's a big enough subject to have its own module. This lesson is
+the web developer's orientation: the shape of getting a web app live, and where the
+[deployment path](/learn/deployment/what-is-deployment/) takes over with the details.
+
+## What "deploying" actually means
+
+Locally, your app runs because *you* start it and keep the terminal open. In
+production none of that holds: no one is watching the terminal, traffic arrives at
+all hours, and a crash must not mean permanent downtime. **Deploying** is the work of
+making your app run reliably, unattended, on infrastructure the public can reach. The
+[deployment module's opener](/learn/deployment/what-is-deployment/) frames the whole
+discipline; here we map it onto the front-end/back-end split you already know.
+
+## Front end vs. back end hosting
+
+The two halves of a web app deploy differently because they *are* different:
+
+- **The front end** — after a [build step](/learn/web-dev/build-tools-and-bundlers/),
+  it's just static files: HTML, CSS, JavaScript, images. Static files don't run code,
+  so they can be dropped onto **static hosting** or a **CDN** and served fast from the
+  edge. A [static site](/learn/web-dev/static-vs-dynamic/) like this one deploys
+  entirely this way.
+- **The back end** — a running **process**. It needs a host that keeps it alive,
+  restarts it on failure, connects it to a [database](/learn/web-dev/backend-and-database/),
+  and supplies its secrets. That's a server, a container platform, or a managed
+  runtime — the subject of most of the deployment module.
+
+A typical modern app hosts the front end on a CDN and the back end as a service, with
+the browser calling the back end's [API](/learn/web-dev/building-a-rest-api/). A
+server-rendered app deploys as one running process instead.
+
+## The build step
+
+Deployment starts with a **build** — the repeatable step that turns your source into
+exactly what runs in production. For a front end that's bundling and minifying (with
+[content-hashed filenames](/learn/web-dev/caching-and-cdns/) for caching); for a back
+end it might be compiling a binary or assembling a container image. The output is an
+**artifact**: a fixed, versioned thing you deploy. The key discipline is that the same
+artifact you tested is the one you ship — you don't rebuild differently for
+production.
+
+```bash
+# Front end: source -> static bundle
+npm run build          # emits dist/  (hashed, minified files to host)
+
+# Back end (Go, as GopherTrunk): source -> single binary
+go build -o gophertrunk ./cmd/gophertrunk
+```
+
+## Configuration & secrets
+
+The same build has to run in staging and production without code changes, so
+everything that *differs* between environments — the database URL, API keys, the port
+— comes from **environment variables** injected by the host at runtime. As the
+[first API call](/learn/building-ai/your-first-api-call/) lesson stressed for keys,
+secrets never live in source or in git; the host supplies them:
+
+```bash
+DATABASE_URL=postgres://…   API_KEY=…   PORT=8080   ./gophertrunk
+```
+
+This is what lets one tested artifact run anywhere — only its configuration changes.
+
+## The public front door: reverse proxy & TLS
+
+Your back end can speak plain HTTP on some internal port, but the public internet
+needs one secure, stable entry point. That's a **reverse proxy** — a server that sits
+in front of your app and handles the cross-cutting concerns:
+
+- **TLS termination** — it holds the certificate and serves **HTTPS**, so browsers get
+  an encrypted, trusted connection (see [TLS & HTTPS](/learn/networking/tls-and-https/)).
+- **Routing** — it maps incoming paths or hostnames to the right service.
+- **Load balancing** — it spreads traffic across multiple instances of your app.
+- **Serving static files** — it can hand back assets without troubling your app.
+
+A **domain name** points at the proxy via DNS, the proxy terminates TLS and forwards
+to your app, and the whole thing looks like one clean `https://` site.
+[Reverse proxies & TLS](/learn/deployment/reverse-proxies-and-tls/) covers this
+setup in full.
+
+## Where the deployment module takes over
+
+This lesson is deliberately the *shape* of deployment. The mechanics — containers,
+CI/CD pipelines that build and ship on every commit, orchestration, rollbacks,
+monitoring — are the whole
+[Containers & Deployment](/learn/deployment/what-is-deployment/) module. The bridge to
+remember: a web app is a **buildable artifact** plus **runtime configuration**,
+running behind a **TLS-terminating proxy** on a host that keeps it alive. Everything
+else is detail on top of that spine.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a built front end is static files you can host on a CDN; a back end is a process that must run on a host." markdown="0">
+  <p class="knowledge-check__q">Quick check: why do the front end and back end of an app usually deploy differently?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">The front end runs on the database and the back end runs in the browser</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">A built front end is static files you can host; a back end is a process that must keep running</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">The front end needs a reverse proxy but the back end never does</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Deploying** makes your app run reliably and unattended on infrastructure the
+  public can reach — the step from *works on my laptop* to *running for users*.
+- **Front end** and **back end** host differently: a built front end is **static
+  files** for a CDN; a back end is a **running process** that needs a host, database,
+  and secrets.
+- Every deploy starts from a repeatable **build** that emits a versioned **artifact** —
+  ship the same artifact you tested.
+- Production settings and secrets come from **environment variables** injected at
+  runtime, never hard-coded in source.
+- A **reverse proxy** presents the public front door — terminating **TLS**/HTTPS,
+  routing, and load-balancing — while your app speaks plain HTTP behind it.
+- The full toolkit lives in the [Containers & Deployment](/learn/deployment/what-is-deployment/)
+  module; a web app is an **artifact plus configuration** behind a proxy.
+
+Next up: [performance & Core Web Vitals](/learn/web-dev/performance-and-web-vitals/).

--- a/docs/learn/web-dev/fetching-data.md
+++ b/docs/learn/web-dev/fetching-data.md
@@ -1,0 +1,180 @@
+---
+slug: fetching-data
+title: Fetching data from the front end
+description: How a page pulls fresh data without reloading — the browser's fetch API, sending and parsing JSON, async/await, and the loading-error-success states every real request has to handle when the front end talks to a back-end API.
+keywords: fetch, fetch API, JSON, async await, promise, HTTP request from browser, loading state, error handling, calling an API, XHR, fetching data
+level: intermediate
+status: full
+prereq:
+  - components-and-state
+faq:
+  - q: What is fetch?
+    a: "fetch is the browser's built-in function for making HTTP requests from JavaScript. You give it a URL (and options like method and body), and it returns a promise that resolves to a response object. It's how a page asks a back-end API for data without reloading — the modern replacement for the older XMLHttpRequest."
+  - q: Why do I have to call response.json()?
+    a: "Because the response arrives as a stream of bytes, and reading the body is itself asynchronous. fetch resolves as soon as the headers are in; response.json() reads the rest of the body and parses it from JSON text into a JavaScript object. It returns a promise, so you await it too."
+  - q: Does a 404 or 500 make fetch throw an error?
+    a: "No — and this trips up almost everyone. fetch only rejects on a network failure (no connection, DNS error). An HTTP error like 404 or 500 is a successful round-trip as far as fetch is concerned, so you must check response.ok yourself and handle the bad status."
+---
+
+# Fetching data from the front end
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A modern page pulls fresh data **without reloading** by making HTTP requests from
+JavaScript with the browser's **fetch** API. Requests are **asynchronous** — they take
+time and return a **promise** — so you handle them with **async/await**. Data usually
+travels as **JSON**, which you parse from the response. Every real fetch has three
+states you must design for — **loading**, **error**, and **success** — and, crucially,
+**fetch does not throw on a 404 or 500**, so you check the [status](/learn/networking/http/)
+yourself. The result flows into component [state](/learn/web-dev/components-and-state/)
+and the UI re-renders.
+</div>
+
+So far the data driving a component came from props or a click. In a real app most of
+it comes from a **server** — a list of decoded calls, a user profile, search results.
+This lesson is how the browser goes and gets that data over
+[HTTP](/learn/networking/http/) and folds it into the UI, all without the full-page
+reload that older sites needed. It is the bridge between the front-end mental model and
+the back-end half of this module.
+
+## fetch: an HTTP request from JavaScript
+
+The browser gives you **fetch**, a function that makes an HTTP request from your code.
+You pass a URL; it returns a **promise** that resolves to a **response** object. Reading
+the body — here, parsing it as JSON — is a second asynchronous step. The cleanest way to
+write it is **async/await**, which lets asynchronous code read top to bottom:
+
+```js
+async function getCalls() {
+  const response = await fetch("/api/calls");   // send the request, wait for headers
+  const data = await response.json();           // read + parse the JSON body
+  return data;                                  // a normal JavaScript array/object
+}
+```
+
+`fetch` is asynchronous because a network request takes real time — often much longer
+than anything happening locally, as [treating a remote call](/learn/networking/http/)
+taught. `await` pauses this function until the response is ready **without freezing the
+page**; the browser stays responsive while the request is in flight. Under the hood
+`await` is just friendlier syntax over promises and their `.then()` chains.
+
+## JSON: the data format on the wire
+
+Data almost always crosses the network as **JSON** — JavaScript Object Notation — a
+plain-text format of objects, arrays, strings, numbers, and booleans that both sides
+understand. It maps so cleanly onto JavaScript values that `response.json()` turns the
+text straight into usable objects.
+
+```json
+{
+  "calls": [
+    { "id": 1, "talkgroup": "Fire-1", "seconds": 12 },
+    { "id": 2, "talkgroup": "EMS-3",  "seconds": 4  }
+  ]
+}
+```
+
+To *send* data — say, saving a setting — you go the other way: set the method and
+headers, and put a JSON string in the body.
+
+```js
+await fetch("/api/settings", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ theme: "dark" }),
+});
+```
+
+The `Content-Type` header tells the server the body is JSON, and `JSON.stringify` turns
+your object into the text that rides in the request. This is the same request shape the
+[REST API](/learn/web-dev/building-a-rest-api/) on the back end is built to receive.
+
+## fetch doesn't throw on HTTP errors
+
+Here is the gotcha that catches everyone. `fetch` **only rejects on a network failure** —
+no connection, DNS error, request never completes. An HTTP error status like **404 Not
+Found** or **500 Internal Server Error** is, to `fetch`, a perfectly successful
+round-trip: the server answered. So you must check the status yourself with
+`response.ok` (true for 2xx) and handle a bad one:
+
+```js
+async function getCalls() {
+  const response = await fetch("/api/calls");
+  if (!response.ok) {
+    throw new Error(`Request failed: ${response.status}`);   // 404, 500, ...
+  }
+  return response.json();
+}
+```
+
+Skip this check and a 500 sails silently past `try/catch`, and your code tries to read
+JSON out of an error page. Reading the [status code](/learn/networking/http/) — 2xx
+worked, 4xx your request, 5xx the server — is the whole job here.
+
+## Loading, error, success: three states
+
+A request is not instant, and it can fail, so a fetch is never just "the data." It is
+**three states** the UI has to represent: **loading** while it's in flight, **error** if
+it fails, and **success** with the data. Design for all three or the page looks broken
+the moment the network is slow. In a [component](/learn/web-dev/components-and-state/),
+each is a piece of state:
+
+```jsx
+function Calls() {
+  const [data, setData] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    getCalls().then(setData).catch(setError);   // runs after first render
+  }, []);
+
+  if (error) return <p>Couldn't load calls.</p>;   // error state
+  if (!data) return <p>Loading…</p>;               // loading state
+  return <ul>{data.calls.map((c) => <li key={c.id}>{c.talkgroup}</li>)}</ul>;
+}
+```
+
+The `useEffect` hook runs the fetch **after** the component first renders — you don't
+fetch during render itself — and each resolved result drops into state, re-rendering the
+UI. This loading-error-success shape is so universal that libraries like React Query and
+SWR exist to manage it, plus caching and retries, so you don't hand-write it every time.
+
+## Where fetch fits in the bigger picture
+
+Fetching is the front end's half of a conversation whose other half is the back end. The
+browser calls an endpoint like `/api/calls`; a [HTTP server](/learn/web-dev/http-servers-and-routing/)
+routes it to a handler, which reads a [database](/learn/web-dev/backend-and-database/) and
+returns JSON. Everything you send and receive rides on
+[HTTP](/learn/networking/http/) and, in production, over
+[HTTPS](/learn/networking/tls-and-https/) so the data is encrypted in transit. Fetching
+is also what makes a **single-page app** feel live — swapping data in place instead of
+reloading, a rendering style we compare in
+[SSR vs. SPA vs. static](/learn/web-dev/ssr-spa-static/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — fetch only rejects on a network failure, so you must check response.ok (or the status) to catch a 404 or 500." markdown="0">
+  <p class="knowledge-check__q">Quick check: your fetch gets a 500 response but your try/catch never fires. Why?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">A 500 is impossible from a real server, so nothing happened</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">fetch only rejects on network failures — you must check response.ok for HTTP errors</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">async/await swallows all errors, so catch never runs</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A page pulls fresh data **without reloading** using the browser's **fetch** API,
+  which returns a **promise** you handle with **async/await**.
+- Requests are **asynchronous** because the network takes time; `await` pauses your
+  function without freezing the page.
+- Data travels as **JSON** — parse it with `response.json()`, and send it with
+  `JSON.stringify` plus a `Content-Type: application/json` header.
+- **fetch does not throw on 404 or 500** — check `response.ok` (or the status code)
+  and handle HTTP errors yourself.
+- Every real fetch has **loading, error, and success** states; each is a piece of
+  component [state](/learn/web-dev/components-and-state/) that re-renders the UI.
+- Fetching is the front-end half of a conversation with a
+  [back-end API](/learn/web-dev/building-a-rest-api/) over
+  [HTTP](/learn/networking/http/).
+
+Next up: [Build tools &amp; bundlers](/learn/web-dev/build-tools-and-bundlers/).

--- a/docs/learn/web-dev/forms-and-user-input.md
+++ b/docs/learn/web-dev/forms-and-user-input.md
@@ -1,0 +1,171 @@
+---
+slug: forms-and-user-input
+title: Forms & user input
+description: Forms are how the web takes input. This lesson covers how HTML forms collect and submit data, the difference between GET and POST submissions, client-side versus server-side validation, and the security rule that underlies all of it — never trust input from the browser.
+keywords: forms, user input, form validation, GET POST, input fields, client-side validation, server-side validation, never trust user input, form submission, HTML forms
+level: intermediate
+status: full
+prereq:
+  - the-dom
+faq:
+  - q: How does an HTML form send data to the server?
+    a: "A form has a set of input fields and a submit action. When submitted, the browser gathers the fields' values and sends them to the URL in the form's `action`, using the method in its `method` — usually **GET** (values in the URL) or **POST** (values in the request body). The server receives them as a request and processes them."
+  - q: What's the difference between client-side and server-side validation?
+    a: "**Client-side** validation runs in the browser for fast, friendly feedback before submitting. **Server-side** validation runs on the server after the data arrives. You need both — client-side for experience, server-side for safety — because the browser's checks can be bypassed and the server is the only place you actually control."
+  - q: Why should I never trust user input?
+    a: "Because anything sent from a browser can be altered, faked, or crafted maliciously — the user controls their own device and the requests it sends. Treating input as untrusted, and validating and sanitising it on the server, is the foundation that prevents whole classes of attacks like injection and cross-site scripting."
+---
+
+# Forms & user input
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Forms** are how the web collects input — fields the user fills in and submits.
+The browser gathers the values and sends them to the server, usually by **GET**
+(values in the URL) or **POST** (values in the body). **Validation** happens in two
+places: **client-side** in the browser for fast, friendly feedback, and
+**server-side** for safety — and you need **both**, because the golden rule is
+**never trust input from the browser**. This is where user data crosses from the
+front end into your back end, so it's where security begins. Builds on
+[the DOM](/learn/web-dev/the-dom/) and the client/server split from earlier.
+</div>
+
+So far the user has only *looked* at pages. Forms are how they *talk back* —
+typing a search, logging in, submitting a report. A form is the main doorway
+through which data crosses from the browser into your system, which makes it two
+things at once: the primary tool of interactivity, and the primary place security
+has to start. This lesson covers both faces.
+
+## The anatomy of a form
+
+An HTML **form** groups input controls and defines what happens when they're
+submitted. The `<form>` element wraps the fields; each `<input>` (or `<textarea>`,
+`<select>`) collects one value; a submit control sends the lot:
+
+```html
+<form action="/api/report" method="post">
+  <label for="tg">Talkgroup</label>
+  <input id="tg" name="talkgroup" type="text" required>
+
+  <label for="note">Note</label>
+  <textarea id="note" name="note"></textarea>
+
+  <button type="submit">Submit report</button>
+</form>
+```
+
+Two things do the real work. The **`name`** on each field becomes the key the
+server receives the value under (`talkgroup=...`). And the pairing of `<label>`
+with an input's `id` (via `for`) ties the label to the field — which matters for
+usability and, as [accessibility basics](/learn/web-dev/accessibility-basics/)
+will stress, is essential for screen-reader users. When submitted, the browser
+bundles every named field and sends it to the form's `action`.
+
+## GET and POST
+
+A form's `method` decides *how* the data is sent, and the choice mirrors the HTTP
+methods from [HTTP — the web's protocol](/learn/networking/http/):
+
+- **GET** appends the values to the URL as a **query string** (`/search?q=fire`).
+  Use it for requests that only **read** — searches, filters — where it's fine for
+  the values to show in the URL, be bookmarked, and be repeated safely.
+- **POST** puts the values in the **request body**, out of the URL. Use it for
+  anything that **changes state** — creating a record, logging in, submitting a
+  report — and for anything sensitive, since body data isn't sitting in the address
+  bar or browser history.
+
+The rule of thumb: **GET to read, POST to change**. A login form is always POST; a
+search box is usually GET.
+
+## Reading input with JavaScript
+
+Forms work with no JavaScript at all — the browser can submit them directly. But
+JavaScript lets you read and react to input *as it happens*, using the DOM skills
+from the last lesson, for things like live feedback or updating the page without a
+full submit:
+
+```js
+const form = document.querySelector("form");
+
+form.addEventListener("submit", (event) => {
+  event.preventDefault();               // stop the default page reload
+  const tg = form.talkgroup.value;      // read a field by name
+  console.log("Submitting talkgroup:", tg);
+  // ...validate, then send with fetch()...
+});
+```
+
+Calling `preventDefault()` stops the browser's default submit-and-reload, letting
+you handle the data yourself — validate it, then send it in the background with
+`fetch` ([fetching data](/learn/web-dev/fetching-data/)). This is how modern apps
+submit forms without the page flashing and reloading.
+
+## Validation: two places, two jobs
+
+**Validation** means checking that input is well-formed and acceptable — a real
+email, a required field filled, a number in range. It happens in two places, and
+they do different jobs:
+
+- **Client-side** (in the browser) is about **experience**. HTML attributes like
+  `required`, `type="email"`, and `min`/`max` — plus JavaScript checks — give
+  instant feedback *before* the user submits, so they fix mistakes without a round
+  trip to the server. It's fast and friendly.
+- **Server-side** (on the back end) is about **safety and truth**. After the data
+  arrives, the server checks it again before acting on it or storing it.
+
+You need **both**, and it's vital to understand *why*: client-side validation is a
+convenience that can be **completely bypassed**. A user can edit the page, disable
+JavaScript, or send a request straight to your server without ever loading your
+form. So the browser's checks improve the experience but guarantee nothing.
+
+## Never trust the browser
+
+This is the security principle the whole lesson has been building toward, and it
+outlives any specific technique: **never trust input from the browser.**
+
+Everything the browser sends — form fields, URL parameters, headers, the request
+itself — comes from a device the **user controls** and can be altered or forged.
+Recall from [JavaScript in the browser](/learn/web-dev/javascript-in-the-browser/)
+that client-side code is untrusted; the data it sends is untrusted for the same
+reason. So on the server you always:
+
+- **Validate** — reject anything that isn't the shape and range you expect, even if
+  the form "should" have prevented it.
+- **Sanitise / escape** — treat input as data, never as code. Input pasted straight
+  into a database query or into a page is how **SQL injection** and
+  **cross-site scripting (XSS)** happen, both covered in
+  [web application attacks](/learn/cybersecurity/web-application-attacks/) and
+  [web security essentials](/learn/web-dev/web-security-essentials/).
+- **Authorise** — confirm the user is actually allowed to do what the request asks,
+  no matter what the front end appeared to permit.
+
+Internalise this and a huge swath of web vulnerabilities simply never opens up.
+Forms are the friendly face of user input; "never trust the browser" is the
+discipline behind that face.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — client-side validation can be bypassed, so the server must validate again; you need both." markdown="0">
+  <p class="knowledge-check__q">Quick check: your form validates input in the browser. Is server-side validation still needed?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">No — if the browser checks it, the data is guaranteed clean</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Yes — browser checks can be bypassed, so the server must validate too</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">No — server-side validation is only for GET requests</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Forms** collect input in named fields and submit it to the server at the form's
+  `action`.
+- The **`name`** attribute becomes the key the server reads; pairing `<label>` with
+  an input's `id` is essential for usability and accessibility.
+- **GET** sends values in the URL (for reads); **POST** sends them in the body (for
+  changes and sensitive data) — **GET to read, POST to change**.
+- JavaScript can intercept submission with `preventDefault()` to validate and send
+  data in the background with `fetch`.
+- **Validate in both places**: client-side for **experience**, server-side for
+  **safety** — client checks can be bypassed.
+- **Never trust the browser** — validate, sanitise, and authorise all input on the
+  server, which shuts down whole classes of attacks.
+
+Next up: [Accessibility basics](/learn/web-dev/accessibility-basics/).

--- a/docs/learn/web-dev/frontend-frameworks.md
+++ b/docs/learn/web-dev/frontend-frameworks.md
@@ -1,0 +1,167 @@
+---
+slug: frontend-frameworks
+title: Front-end frameworks
+description: Why React, Vue, Svelte, and their peers exist — the problem of keeping a complex UI in sync with changing data, why hand-written DOM code stops scaling, and what a framework actually gives you in return for the extra machinery.
+keywords: front-end framework, React, Vue, Svelte, declarative UI, keeping UI in sync, virtual DOM, reactivity, component framework, why use a framework, hand-written DOM
+level: intermediate
+status: full
+prereq:
+  - the-dom
+faq:
+  - q: Do I need a framework to build a website?
+    a: "No. Plenty of good sites are plain HTML, CSS, and a little JavaScript, and this very site is one of them. Frameworks earn their keep on apps with lots of interactive, data-driven UI that changes as the user works — a dashboard, an editor, a feed. For a mostly-static page, a framework is weight you don't need."
+  - q: What is the difference between React, Vue, and Svelte?
+    a: "They solve the same core problem — keeping the UI in sync with your data — with different trade-offs. React is the most widely used and has the biggest ecosystem; Vue aims for an approachable middle ground; Svelte pushes the work into a compile step so the browser ships less framework code. The mental model of components and state carries across all of them."
+  - q: What does 'declarative' mean for a UI?
+    a: "You describe what the page should look like for the current data, and the framework works out the DOM changes needed to get there. That's the opposite of imperative code, where you write each step — create this node, set that text, remove that child — by hand. Declarative UI is why frameworks scale to complex screens."
+---
+
+# Front-end frameworks
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A front-end framework like **React**, **Vue**, or **Svelte** exists to solve one
+stubborn problem: **keeping a complex UI in sync with changing data**. Hand-written
+[DOM](/learn/web-dev/the-dom/) code works for a few elements, but as an app grows,
+the manual "find the node, change it" updates multiply and drift out of sync. A
+framework lets you write **declarative** UI — describe what the screen should show
+for the current data — and it figures out the DOM changes for you. The price is a
+**build step** and more machinery; the payoff is UI that stays correct as it scales.
+</div>
+
+You already know how to change a page by hand: grab an element from the
+[DOM](/learn/web-dev/the-dom/), set its text or add a class, and the browser
+repaints. That works beautifully for a handful of updates. This lesson is about what
+happens when a handful becomes a hundred — when the same piece of data shows up in
+five places, updates ten times a second, and every path through the code has to keep
+all of it consistent. That is the wall hand-written DOM code hits, and it is exactly
+the wall frameworks were built to get over.
+
+## The problem: keeping the UI in sync
+
+Picture a live scanner dashboard. A decoded call arrives, and now you must update:
+the call list, the active-call banner, the talkgroup counter, the "last heard" time,
+and maybe a little activity light. With plain DOM code, *you* write every one of
+those updates, in the right order, for every event that could change them — a new
+call, a call ending, the user filtering the list, a reconnect that reloads
+everything.
+
+```js
+// Imperative: you spell out every DOM change, everywhere data can change.
+function onCall(call) {
+  document.querySelector("#count").textContent = String(calls.length);
+  const li = document.createElement("li");
+  li.textContent = call.talkgroup;
+  document.querySelector("#call-list").prepend(li);
+  document.querySelector("#banner").textContent = "Active: " + call.talkgroup;
+  // ...and every other place this call is shown, kept in sync by hand.
+}
+```
+
+Each line is simple. The trouble is that there are dozens of them, scattered across
+dozens of event handlers, and **nothing enforces that they agree**. Miss one spot
+and the counter says 12 while the list shows 13. This class of bug — the UI and the
+data disagreeing — is the tax you pay for updating the page manually, and it grows
+faster than the app does.
+
+## The idea: describe the UI, don't mutate it
+
+A framework flips the model. Instead of writing the *steps* to change the DOM, you
+write a function of your data to the UI: "given these calls, here is what the screen
+looks like." When the data changes, you don't touch the DOM — you hand the framework
+the new data and let it work out the difference.
+
+```jsx
+// Declarative: describe the UI for the current data. React figures out the DOM.
+function Dashboard({ calls }) {
+  return (
+    <div>
+      <p>Active calls: {calls.length}</p>
+      <ul>
+        {calls.map((c) => <li key={c.id}>{c.talkgroup}</li>)}
+      </ul>
+    </div>
+  );
+}
+```
+
+There is no `createElement`, no `prepend`, no counter to update by hand. You state
+that the count *is* `calls.length` and the list *is* one item per call. Add a call to
+the data and every place it appears updates together, because they are all derived
+from the same source. This is the core trade every framework makes: **you give up
+direct control of the DOM, and in return the UI can't drift out of sync with the
+data.**
+
+## How frameworks pull it off
+
+If you re-describe the whole UI on every change, why isn't it slow to rebuild the
+page constantly? Frameworks avoid that with different strategies, but they share a
+goal — apply the **smallest real DOM change** that matches your new description:
+
+- **A virtual DOM (React, historically).** The framework builds a lightweight
+  in-memory picture of the UI, compares the new picture to the old one, and touches
+  only the DOM nodes that actually differ.
+- **Fine-grained reactivity (Vue, Solid, Svelte).** The framework tracks exactly
+  which bits of data each part of the UI depends on, so when one value changes it
+  updates just the nodes bound to it — no diffing a whole tree.
+- **A compile step (Svelte).** Much of the work happens ahead of time: your
+  components compile to tight, direct DOM instructions, so less framework code ships
+  to the browser.
+
+You rarely need to think about which mechanism is running. What matters is the
+promise they all keep: describe the UI declaratively, and the framework makes the
+DOM match — efficiently.
+
+## What you get, and what it costs
+
+Frameworks bundle more than syncing. Most give you a **component model** (reusable,
+self-contained UI pieces — the [next lesson](/learn/web-dev/components-and-state/)),
+a way to manage **state**, **client-side routing** so navigation feels instant, and
+a large **ecosystem** of libraries. That is real leverage for building an app.
+
+It is not free. A framework adds a **build step** (covered in
+[build tools &amp; bundlers](/learn/web-dev/build-tools-and-bundlers/)), ships
+JavaScript the browser must download and run, and brings its own concepts to learn.
+For a mostly-static page — a blog, a docs site, a marketing page — that machinery is
+overhead with little return, which is why so much of the web, including this site, is
+happily framework-free (see [static vs. dynamic](/learn/web-dev/static-vs-dynamic/)).
+The honest rule: reach for a framework when the UI is **interactive and
+data-driven** enough that keeping it in sync by hand has become the hard part.
+
+## They're more alike than different
+
+React, Vue, Svelte, Angular, Solid — the arguments about which is best are loud, but
+the **mental model is shared**. All of them are built on components and state, all of
+them are declarative, and all of them exist to keep the UI in sync with the data.
+Learn that model once and you can read and reason about any of them; the syntax
+differs, the idea does not. That is why the next two lessons focus on the ideas —
+[components &amp; state](/learn/web-dev/components-and-state/) and
+[fetching data](/learn/web-dev/fetching-data/) — rather than one framework's API.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the core job of a front-end framework is keeping the UI in sync with changing data, so you describe the UI declaratively instead of updating the DOM by hand." markdown="0">
+  <p class="knowledge-check__q">Quick check: what core problem does a front-end framework primarily solve?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Making the network faster so pages download in less time</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Keeping a complex UI in sync with changing data without manual DOM updates</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Replacing HTML and CSS so you no longer need them</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Hand-written [DOM](/learn/web-dev/the-dom/) updates work for small UIs but drift
+  out of sync as an app grows and the same data appears in many places.
+- A **front-end framework** solves that by letting you write **declarative** UI —
+  describe what the screen shows for the current data — instead of mutating the DOM
+  step by step.
+- When the data changes, the framework computes the **smallest DOM change** needed,
+  via a virtual DOM, fine-grained reactivity, or a compile step.
+- Frameworks also bundle components, state management, routing, and a large
+  ecosystem — real leverage for interactive, data-driven apps.
+- The cost is a **build step**, shipped JavaScript, and more to learn, so a
+  mostly-static page is often better off without one.
+- **React, Vue, and Svelte share the same mental model** — components and state —
+  so learning the idea transfers across all of them.
+
+Next up: [Components &amp; state](/learn/web-dev/components-and-state/).

--- a/docs/learn/web-dev/glossary.md
+++ b/docs/learn/web-dev/glossary.md
@@ -1,0 +1,354 @@
+---
+slug: glossary
+title: Glossary of web-development terms
+description: Plain-language definitions of the terms used to build a modern web app — front end, back end, HTML, CSS, the DOM, framework, component, state, REST API, SSR, SPA, session, cookie, JWT, WebSocket, XSS, CSRF, CORS, CDN, Core Web Vitals, and more — each cross-linked to the lesson that explains it.
+keywords: web development glossary, front end, back end, HTML, CSS, DOM, framework, REST API, SSR, SPA, session, cookie, JWT, WebSocket, XSS, CSRF, CORS, CDN, Core Web Vitals, caching
+level: beginner
+status: full
+lesson_standalone: true
+---
+
+# Glossary of web-development terms
+
+Every term used across the [Web Development](/learn/web-dev/) path, defined in plain
+language and linked to the lesson where it's explained in full. Skim it as a
+refresher, or use your browser's find (Ctrl/Cmd-F) to jump to a word. Terms are
+grouped by theme, roughly in the order the module introduces them.
+
+## The web &amp; the browser
+
+**Front end** — Everything that runs in the user's browser — the HTML, CSS, and
+JavaScript that make up what they see and interact with. See
+[What web development is](/learn/web-dev/what-is-web-development/)
+
+**Back end** — The server-side half of a web app — code, data, and logic that run on
+a server the user never sees directly. See
+[What a back end does](/learn/web-dev/what-a-backend-does/)
+
+**Full stack** — Working across both front end and back end, and the layers between.
+See [What web development is](/learn/web-dev/what-is-web-development/)
+
+**Browser** — The program that fetches, parses, and renders web pages, turning HTML,
+CSS, and JavaScript into the page you see and interact with. See
+[How the browser works](/learn/web-dev/how-the-browser-works/)
+
+**Rendering** — The browser's process of turning parsed HTML and CSS into the actual
+pixels on screen. See [How the browser works](/learn/web-dev/how-the-browser-works/)
+
+**Client** — The party that makes a request — usually the browser — in the
+client-server model. See [The client-server web](/learn/web-dev/client-server-web/)
+
+**Server** — The party that listens for requests and returns responses. See
+[The client-server web](/learn/web-dev/client-server-web/)
+
+**Request / response** — The two halves of every web interaction: the client sends a
+**request**, the server returns a **response**. See
+[The client-server web](/learn/web-dev/client-server-web/)
+
+**HTTP** — The protocol browsers and servers use to exchange requests and responses on
+the web. See [The client-server web](/learn/web-dev/client-server-web/)
+
+**Stateless** — HTTP keeps no memory between requests; each one arrives independent of
+the ones before it, which is why apps need sessions. See
+[Authentication & sessions](/learn/web-dev/authentication-and-sessions/)
+
+**Static site** — A site whose pages are pre-built files served as-is, with no code
+run per request. See [Static vs. dynamic sites](/learn/web-dev/static-vs-dynamic/)
+
+**Dynamic site** — A site whose pages are built on the fly for each request, often
+from a database. See [Static vs. dynamic sites](/learn/web-dev/static-vs-dynamic/)
+
+## The front end
+
+**HTML** — The markup language that gives a page its structure and meaning through
+elements and tags. See [HTML — structure & semantics](/learn/web-dev/html-structure/)
+
+**Element / tag** — The building blocks of HTML — a tag like `<p>` marks a piece of
+content as an element with a specific meaning. See
+[HTML — structure & semantics](/learn/web-dev/html-structure/)
+
+**Semantic markup** — Using the HTML element that matches the *meaning* of the content
+(a heading, a nav, a button), which aids accessibility and search. See
+[HTML — structure & semantics](/learn/web-dev/html-structure/)
+
+**CSS** — The language that styles a page — colours, spacing, and layout — separately
+from its HTML structure. See [CSS — styling & layout](/learn/web-dev/css-and-layout/)
+
+**Selector** — The part of a CSS rule that says *which* elements the styles apply to.
+See [CSS — styling & layout](/learn/web-dev/css-and-layout/)
+
+**Box model** — The rule that every element is a box of content, padding, border, and
+margin, which governs sizing and spacing. See
+[CSS — styling & layout](/learn/web-dev/css-and-layout/)
+
+**Flexbox / grid** — The two modern CSS layout systems for arranging elements in one
+dimension (flexbox) or two (grid). See
+[CSS — styling & layout](/learn/web-dev/css-and-layout/)
+
+**JavaScript** — The programming language of the browser, which makes pages
+interactive by responding to events and changing the page. See
+[JavaScript in the browser](/learn/web-dev/javascript-in-the-browser/)
+
+**Event** — A signal that something happened (a click, a keypress, a load) that
+JavaScript can run code in response to. See
+[JavaScript in the browser](/learn/web-dev/javascript-in-the-browser/)
+
+**DOM (Document Object Model)** — The live tree the browser builds from your HTML;
+JavaScript reads and changes it to update the page without a reload. See
+[The DOM](/learn/web-dev/the-dom/)
+
+**Form** — The HTML mechanism for collecting user input and submitting it to a server.
+See [Forms & user input](/learn/web-dev/forms-and-user-input/)
+
+**Validation** — Checking that user input is well-formed and acceptable — on the
+client for feedback, and always on the server for safety. See
+[Forms & user input](/learn/web-dev/forms-and-user-input/)
+
+**Accessibility (a11y)** — Building so everyone can use your site, including people
+using keyboards, screen readers, or low vision — largely achieved with semantic HTML.
+See [Accessibility basics](/learn/web-dev/accessibility-basics/)
+
+**ARIA** — Extra attributes that describe custom UI to assistive technology when plain
+semantic HTML isn't enough. See [Accessibility basics](/learn/web-dev/accessibility-basics/)
+
+## Frameworks &amp; the front end at scale
+
+**Framework** — A library like React that keeps a complex UI in sync with data, so you
+describe *what* the UI should look like rather than hand-writing DOM updates. See
+[Front-end frameworks](/learn/web-dev/frontend-frameworks/)
+
+**Component** — A reusable, self-contained piece of UI — its markup, styling, and
+behaviour together — the building block of modern front ends. See
+[Components & state](/learn/web-dev/components-and-state/)
+
+**State** — The data a component holds that drives what it shows; when state changes,
+the UI updates to match. See [Components & state](/learn/web-dev/components-and-state/)
+
+**Fetch** — The browser API for making HTTP requests from JavaScript to load data
+without reloading the page. See [Fetching data from the front end](/learn/web-dev/fetching-data/)
+
+**JSON** — A lightweight text format for structured data, the common language between a
+front end and an API. See [Fetching data from the front end](/learn/web-dev/fetching-data/)
+
+**Async** — Doing work (like a network request) without freezing the page, handling the
+result when it arrives. See [Fetching data from the front end](/learn/web-dev/fetching-data/)
+
+**Bundler** — A build tool that combines and optimises your source files into what the
+browser downloads. See [Build tools & bundlers](/learn/web-dev/build-tools-and-bundlers/)
+
+**Transpiling** — Converting modern or non-browser code into a form browsers
+understand, as part of the build step. See
+[Build tools & bundlers](/learn/web-dev/build-tools-and-bundlers/)
+
+**Responsive design** — Building one site that works on any screen size using fluid
+layouts and media queries, usually mobile-first. See
+[Responsive design](/learn/web-dev/responsive-design/)
+
+**Media query** — A CSS rule that applies styles only under certain conditions, such as
+a minimum screen width. See [Responsive design](/learn/web-dev/responsive-design/)
+
+## Back end &amp; APIs
+
+**Business logic** — The app-specific rules and work that must run on the server, out
+of the user's reach — the reason a back end exists. See
+[What a back end does](/learn/web-dev/what-a-backend-does/)
+
+**Routing** — Matching an incoming request's URL and method to the code (a handler)
+that should answer it. See [HTTP servers & routing](/learn/web-dev/http-servers-and-routing/)
+
+**Handler** — The function on the server that runs for a matched route and produces the
+response. See [HTTP servers & routing](/learn/web-dev/http-servers-and-routing/)
+
+**HTTP method (verb)** — The action word on a request — GET, POST, PUT, DELETE — that
+says what to do with a resource. See
+[HTTP servers & routing](/learn/web-dev/http-servers-and-routing/)
+
+**REST API** — A common style of web API built around resources, HTTP verbs, status
+codes, and JSON — the contract a front end consumes. See
+[Building a REST API](/learn/web-dev/building-a-rest-api/)
+
+**Resource** — A thing your API exposes (a user, a call, an order), addressed by a URL.
+See [Building a REST API](/learn/web-dev/building-a-rest-api/)
+
+**Status code** — The number in an HTTP response saying how it went — 200 OK, 404 Not
+Found, 500 error, and so on. See [Building a REST API](/learn/web-dev/building-a-rest-api/)
+
+**Endpoint** — A specific URL (plus method) your API answers, mapping to one
+operation. See [Building a REST API](/learn/web-dev/building-a-rest-api/)
+
+**Database** — The system a back end reads and writes to persist data between requests.
+See [The back end & its database](/learn/web-dev/backend-and-database/)
+
+**Query** — A request to the database for data, or to change it. See
+[The back end & its database](/learn/web-dev/backend-and-database/)
+
+**Parameterised query** — A query where user data is passed as separate parameters, not
+concatenated into the query string — the core defence against SQL injection. See
+[The back end & its database](/learn/web-dev/backend-and-database/)
+
+**SSR (server-side rendering)** — Building the page's HTML on the server for each
+request, so content arrives ready to display. See
+[SSR vs. SPA vs. static](/learn/web-dev/ssr-spa-static/)
+
+**SPA (single-page application)** — An app that loads once and then renders and
+re-renders pages in the browser with JavaScript. See
+[SSR vs. SPA vs. static](/learn/web-dev/ssr-spa-static/)
+
+**Templating** — Generating HTML by filling a template with data, on the server or at
+build time. See [Templating & static site generators](/learn/web-dev/templating-and-static-sites/)
+
+**Static site generator** — A tool (like the Jekyll behind this site) that builds a set
+of static HTML pages from templates and content ahead of time. See
+[Templating & static site generators](/learn/web-dev/templating-and-static-sites/)
+
+## Auth &amp; sessions
+
+**Authentication** — Verifying *who* a user is, typically at login with a password or
+token. See [Authentication & sessions](/learn/web-dev/authentication-and-sessions/)
+
+**Authorization** — Deciding *what* an authenticated user is allowed to do — checked on
+every request, not just at login. See
+[Authentication & sessions](/learn/web-dev/authentication-and-sessions/)
+
+**Session** — Server-side state about one logged-in user, referenced by an opaque
+session ID the browser sends back on each request. See
+[Authentication & sessions](/learn/web-dev/authentication-and-sessions/)
+
+**Password hashing** — Storing only a one-way, salted hash of a password (via bcrypt,
+scrypt, or Argon2), never the password itself. See
+[Authentication & sessions](/learn/web-dev/authentication-and-sessions/)
+
+**Salt** — A unique random value mixed into each password hash so identical passwords
+don't hash alike and precomputed attacks fail. See
+[Authentication & sessions](/learn/web-dev/authentication-and-sessions/)
+
+**Cookie** — A small named value the browser stores and sends *automatically* on
+matching requests — the classic home of a session ID. See
+[Cookies, tokens & JWTs](/learn/web-dev/cookies-tokens-jwt/)
+
+**HttpOnly / Secure / SameSite** — Cookie flags that harden a session: **HttpOnly**
+hides it from JavaScript, **Secure** sends it only over HTTPS, **SameSite** limits
+cross-site sending. See [Cookies, tokens & JWTs](/learn/web-dev/cookies-tokens-jwt/)
+
+**Bearer token** — A credential the client sends *deliberately* in an `Authorization`
+header, common for APIs and non-browser clients. See
+[Cookies, tokens & JWTs](/learn/web-dev/cookies-tokens-jwt/)
+
+**JWT (JSON Web Token)** — A signed (not encrypted) token carrying its own claims, so
+the server can trust it without a lookup — powerful but hard to revoke before it
+expires. See [Cookies, tokens & JWTs](/learn/web-dev/cookies-tokens-jwt/)
+
+**Refresh token** — A longer-lived credential used to mint fresh short-lived access
+tokens, so tokens can expire quickly without forcing constant logins. See
+[Cookies, tokens & JWTs](/learn/web-dev/cookies-tokens-jwt/)
+
+## Real-time
+
+**WebSocket** — A single persistent, bidirectional connection either side can send over
+at any time, letting a server push data the instant it has it. See
+[WebSockets & real-time updates](/learn/web-dev/websockets-and-realtime/)
+
+**Polling** — Repeatedly asking the server "anything new?" over ordinary HTTP — simple
+but wasteful compared with a push channel. See
+[WebSockets & real-time updates](/learn/web-dev/websockets-and-realtime/)
+
+**Server-sent events (SSE)** — A one-way (server → browser) live stream over ordinary
+HTTP that reconnects automatically — simpler than WebSockets when the browser needn't
+talk back. See [WebSockets & real-time updates](/learn/web-dev/websockets-and-realtime/)
+
+## Security
+
+**XSS (cross-site scripting)** — An attack that runs an attacker's JavaScript in your
+users' browsers; defended by encoding output and a content security policy. See
+[Web security essentials](/learn/web-dev/web-security-essentials/)
+
+**CSRF (cross-site request forgery)** — An attack that tricks a logged-in browser into
+sending an unintended request; defended with anti-CSRF tokens and `SameSite` cookies.
+See [Web security essentials](/learn/web-dev/web-security-essentials/)
+
+**CORS (cross-origin resource sharing)** — The browser rules that control which *other*
+origins may read your responses, relaxing the same-origin policy — not a server-side
+access control. See [Web security essentials](/learn/web-dev/web-security-essentials/)
+
+**Same-origin policy** — The browser default that JavaScript on one origin can't read
+responses from another, which CORS selectively relaxes. See
+[Web security essentials](/learn/web-dev/web-security-essentials/)
+
+**Content Security Policy (CSP)** — An HTTP header restricting which scripts the browser
+will run, blunting XSS even if injection slips through. See
+[Web security essentials](/learn/web-dev/web-security-essentials/)
+
+## Speed &amp; caching
+
+**Caching** — Storing a result so it can be reused instead of recomputed or refetched —
+the foundation of a fast site. See [Caching & CDNs](/learn/web-dev/caching-and-cdns/)
+
+**Cache-Control / ETag** — HTTP headers that steer the browser cache: **Cache-Control**
+sets how long a copy is good, an **ETag** lets the browser cheaply revalidate for a
+`304 Not Modified`. See [Caching & CDNs](/learn/web-dev/caching-and-cdns/)
+
+**CDN (content delivery network)** — A worldwide network of edge servers that cache
+copies of your files and serve each user from a nearby one, cutting latency. See
+[Caching & CDNs](/learn/web-dev/caching-and-cdns/)
+
+**Cache invalidation** — The hard problem of knowing when a cached copy is stale,
+usually sidestepped with content-hashed filenames so a changed file gets a new URL. See
+[Caching & CDNs](/learn/web-dev/caching-and-cdns/)
+
+**Core Web Vitals** — Google's three user-centred performance metrics: **LCP** (loading),
+**INP** (interactivity), and **CLS** (visual stability). See
+[Performance & Core Web Vitals](/learn/web-dev/performance-and-web-vitals/)
+
+**Perceived performance** — How fast a page *feels* to a user, which matters more than
+raw load time and is what the Web Vitals try to capture. See
+[Performance & Core Web Vitals](/learn/web-dev/performance-and-web-vitals/)
+
+**Lazy loading** — Deferring the load of offscreen or non-critical assets (like images)
+so they don't delay the content the user can see. See
+[Performance & Core Web Vitals](/learn/web-dev/performance-and-web-vitals/)
+
+## Shipping &amp; running
+
+**Deployment** — Making your app run reliably and unattended on infrastructure the
+public can reach — the step from *works on my laptop* to *running for users*. See
+[Deploying a web app](/learn/web-dev/deploying-a-web-app/)
+
+**Build / artifact** — The repeatable step that turns source into exactly what runs in
+production, producing a fixed, versioned **artifact** you deploy. See
+[Deploying a web app](/learn/web-dev/deploying-a-web-app/)
+
+**Environment variable** — Configuration and secrets injected by the host at runtime
+rather than hard-coded, so one build runs in any environment. See
+[Deploying a web app](/learn/web-dev/deploying-a-web-app/)
+
+**Reverse proxy** — A server in front of your app that presents the public HTTPS front
+door — terminating TLS, routing, and load-balancing — while your app speaks plain HTTP
+behind it. See [Deploying a web app](/learn/web-dev/deploying-a-web-app/)
+
+**TLS / HTTPS** — The encryption that secures data in transit; a reverse proxy usually
+terminates it to serve your site over HTTPS. See
+[Deploying a web app](/learn/web-dev/deploying-a-web-app/)
+
+**Monitoring** — Watching a live app's health — uptime, errors, latency — so you learn
+about problems proactively, before users report them. See
+[Monitoring & analytics](/learn/web-dev/monitoring-and-analytics/)
+
+**Health check** — A small endpoint that returns "OK" when the app is alive, pinged
+constantly so a crash or bad deploy is caught in minutes. See
+[Monitoring & analytics](/learn/web-dev/monitoring-and-analytics/)
+
+**Error tracking** — Capturing and grouping exceptions from production (server and
+browser) so you see how many users a bug affects. See
+[Monitoring & analytics](/learn/web-dev/monitoring-and-analytics/)
+
+**Analytics** — Measuring user behaviour to guide product decisions, ideally with
+privacy-respecting tools that count aggregates instead of profiling people. See
+[Monitoring & analytics](/learn/web-dev/monitoring-and-analytics/)
+
+**Web stack** — The coherent set of choices — front-end approach, back-end language,
+database, hosting — matched to a project's real requirements and the team's skills. See
+[Choosing your web stack](/learn/web-dev/choosing-a-web-stack/)
+
+**Boring technology** — The principle of preferring mature, proven tools over trendy
+ones, because novelty is a hidden cost. See
+[Choosing your web stack](/learn/web-dev/choosing-a-web-stack/)

--- a/docs/learn/web-dev/gophertrunk-web-dashboard.md
+++ b/docs/learn/web-dev/gophertrunk-web-dashboard.md
@@ -1,0 +1,145 @@
+---
+slug: gophertrunk-web-dashboard
+title: The GopherTrunk web dashboard
+description: A worked example that ties the whole module together — how a live dashboard for a scanner is built, from the Go back end that serves decoded calls over a REST API and a real-time stream, to the browser that shows them the instant a radio keys up.
+keywords: worked example, scanner dashboard, live dashboard, REST API, WebSocket, real-time, Go backend, event bus, full stack, GopherTrunk
+level: advanced
+status: full
+prereq:
+  - choosing-a-web-stack
+faq:
+  - q: "Why does a scanner even need a web dashboard?"
+    a: "Because the interesting output — decoded calls, active talkgroups, which sites are up — arrives continuously and is far easier to watch in a browser than a terminal. A dashboard turns GopherTrunk's stream of events into a live, glanceable view anyone on the network can open, without touching the command line. It's the human-facing front end on top of the decoding engine."
+  - q: "How does a call get from the radio to my screen?"
+    a: "The [engine](/architecture.html) decodes a call and emits it on its internal event bus. The web back end subscribes to that bus, and pushes each new call to connected browsers over a real-time channel. The browser, which loaded recent history over the REST API when it opened, appends the call to the live table the moment it arrives — no refresh."
+  - q: "Is this a heavy front-end framework app?"
+    a: "No — and that's deliberate. The job is a live table of calls, so the stack is intentionally small: Go on the back end (the whole project is Go), a REST API for history, a real-time stream for live updates, and a light front end. It's a concrete example of the 'match the stack to the job' principle from the previous lesson."
+---
+
+# The GopherTrunk web dashboard
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+This is the whole module in one worked example. GopherTrunk's
+[engine](/architecture.html) decodes radio calls and emits them on an internal event
+bus; a **Go back end** exposes them two ways — a **[REST API](/learn/web-dev/building-a-rest-api/)**
+for history and a **[real-time stream](/learn/web-dev/websockets-and-realtime/)** for
+live pushes — and a **light front end** renders them into a live table the instant a
+radio keys up. It's a deliberately **small [stack](/learn/web-dev/choosing-a-web-stack/)
+matched to the job**, and it exercises nearly every idea in this path. See the running
+project at [gophertrunk.org](/).
+</div>
+
+Every idea in this module — [client and server](/learn/web-dev/client-server-web/),
+[APIs](/learn/web-dev/building-a-rest-api/), [real-time](/learn/web-dev/websockets-and-realtime/),
+[security](/learn/web-dev/web-security-essentials/), [deployment](/learn/web-dev/deploying-a-web-app/) —
+has been a piece in isolation. This final lesson assembles them into one real thing:
+the dashboard that shows what a scanner is hearing, live. It's a worked example, not
+new theory, so read it as a walk-through of how the parts click together.
+
+## The problem it solves
+
+GopherTrunk is a headless [decoding engine](/architecture.html): it manages SDR
+hardware, follows trunked systems, and decodes calls — but it has no screen. Its
+output is a stream of events (a call started on this talkgroup, a site went active,
+audio was recorded) arriving unpredictably and continuously. A terminal is a poor
+place to watch that. The dashboard's job is to turn that live stream into a
+**glanceable web view** anyone on the network can open in a browser — the human face
+on top of the engine.
+
+## The back end: engine to API
+
+The engine already emits everything of interest on an internal **event bus** — one of
+the sinks in the [architecture diagram](/architecture.html), alongside voice and
+storage. The web back end, written in **Go** like the rest of the project, subscribes
+to that bus and exposes it to browsers. It presents two surfaces, because a dashboard
+needs both *history* and *what's happening now*:
+
+- A **REST API** for state and history — recent calls, active talkgroups, system
+  status — that a freshly opened page can [fetch](/learn/web-dev/fetching-data/) to
+  populate itself.
+- A **real-time stream** that pushes each new call as the engine emits it.
+
+```http
+GET /api/calls?limit=50     ->  200 OK   [ {call}, {call}, … ]   # history
+GET /api/systems            ->  200 OK   [ {system, active} ]    # status
+(live stream)               ->  {call}   pushed as each one is decoded
+```
+
+Because the engine is [Go with typed channels](/architecture.html), bridging the event
+bus to an HTTP handler and a stream is a small, natural amount of code — the back end
+is mostly a thin translation layer from internal events to web responses.
+
+## The front end: a live table
+
+The browser side is deliberately light, because the job is a table that updates. When
+the page loads it does two things, exactly the pairing from the
+[WebSockets lesson](/learn/web-dev/websockets-and-realtime/): fetch recent history
+once over the REST API to fill the table, then subscribe to the live stream so every
+new call appends at the top the moment it's decoded.
+
+```javascript
+// 1. Load history once so the table isn't empty on open
+const history = await (await fetch("/api/calls?limit=50")).json();
+history.forEach(renderCall);
+
+// 2. Subscribe to the live stream — new calls appear instantly, no refresh
+const live = new EventSource("/api/stream");
+live.onmessage = (e) => renderCall(JSON.parse(e.data));   // prepend to the table
+```
+
+Each call becomes a row — talkgroup, time, duration, system — built by updating the
+[DOM](/learn/web-dev/the-dom/) as data arrives. There's no heavy
+[framework](/learn/web-dev/frontend-frameworks/) here because the UI is simple enough
+not to need one; the [stack](/learn/web-dev/choosing-a-web-stack/) was matched to the
+job rather than to fashion.
+
+## Where the module's pieces show up
+
+The dashboard is a checklist of the whole path in one place:
+
+- **[Client–server](/learn/web-dev/client-server-web/) & [REST](/learn/web-dev/building-a-rest-api/)** —
+  the browser requests, the Go server responds with JSON.
+- **[Real-time](/learn/web-dev/websockets-and-realtime/)** — live calls pushed, not
+  polled, so the table is current to the second.
+- **[The DOM](/learn/web-dev/the-dom/) & [fetching data](/learn/web-dev/fetching-data/)** —
+  the front end reads JSON and updates the page in place.
+- **[Security](/learn/web-dev/web-security-essentials/)** — call text is encoded, not
+  injected as HTML; the API is read-only and access-controlled.
+- **[Static site](/learn/web-dev/static-vs-dynamic/)** — this very docs site
+  ([gophertrunk.org](/)) is the static counterpart, built by
+  [Jekyll](/learn/web-dev/templating-and-static-sites/), while the dashboard is the
+  dynamic one.
+- **[Deploying](/learn/web-dev/deploying-a-web-app/) & [monitoring](/learn/web-dev/monitoring-and-analytics/)** —
+  it ships behind a [TLS reverse proxy](/learn/deployment/reverse-proxies-and-tls/) and
+  is watched like any running service.
+
+Seeing them together is the point: a web app isn't any one of these ideas, it's all of
+them cooperating around a clear job.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the page fetches history once over REST, then subscribes to a live stream so new calls appear instantly." markdown="0">
+  <p class="knowledge-check__q">Quick check: how does the dashboard show both past calls and new ones the instant they happen?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It reloads the whole page every second to get fresh data</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">It fetches recent history once over the REST API, then subscribes to a live stream for new calls</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">The browser reads the SDR hardware directly over USB</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- The dashboard is the **human-facing front end** on top of GopherTrunk's headless
+  [decoding engine](/architecture.html), turning a live event stream into a glanceable
+  web view.
+- The **Go back end** subscribes to the engine's internal **event bus** and exposes it
+  two ways — a **REST API** for history/status and a **real-time stream** for live
+  pushes.
+- The **light front end** fetches history once, then subscribes to the stream, so new
+  calls append to a live table the instant they're decoded — no refresh.
+- The **stack is small and deliberate** — Go throughout, a simple front end, no heavy
+  framework — a direct application of matching the stack to the job.
+- It exercises nearly the whole module at once: client–server, REST, real-time, the
+  DOM, security, static vs. dynamic, and deployment.
+
+Next up: keep the [glossary](/learn/web-dev/glossary/) handy, and take it live with [Containers &amp; Deployment](/learn/deployment/).

--- a/docs/learn/web-dev/how-the-browser-works.md
+++ b/docs/learn/web-dev/how-the-browser-works.md
@@ -1,0 +1,164 @@
+---
+slug: how-the-browser-works
+title: How the browser works
+description: The browser is web development's most important program. This lesson traces how it turns a response into a page — fetching HTML, CSS, and JavaScript, parsing HTML into the DOM, applying styles, laying out and painting pixels, and running scripts — plus why script placement affects load speed.
+keywords: how a browser works, rendering, parsing HTML, DOM, CSSOM, render tree, layout, paint, JavaScript engine, browser engine, critical rendering path
+level: beginner
+status: full
+prereq:
+  - what-is-web-development
+faq:
+  - q: What does a browser actually do with the HTML it receives?
+    a: "It **parses** the HTML into a tree of objects called the **DOM**, parses the CSS into style rules, combines them to decide how every element looks, calculates where each one goes on the page (**layout**), and finally **paints** the pixels. It also downloads and runs any JavaScript, which can change the page after it first appears."
+  - q: Why do people put <script> tags at the bottom of the page?
+    a: "Because a plain script tag can block the browser from parsing the rest of the HTML while it downloads and runs. Putting scripts at the end — or marking them `defer` — lets the page's content appear first, then runs the JavaScript, so the user isn't staring at a blank screen."
+  - q: Is the browser the same as the internet?
+    a: "No. The **internet** is the network that carries data between machines; the **browser** is a program on your device that requests web pages over that network and turns the responses into something you can see and use. The browser is one of many programs that use the internet."
+---
+
+# How the browser works
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+The **browser** is the most important program in web development — it turns a
+server's response into the page you see. It **fetches** the HTML, CSS, and
+JavaScript, **parses** the HTML into a tree called the **DOM**, works out how each
+element should look and where it goes (**layout**), and **paints** the result to
+the screen. It also runs the **JavaScript**, which can change the page after it
+loads. Everything a front-end developer writes is instructions for this one
+program. Building on [what web development is](/learn/web-dev/what-is-web-development/),
+this is the machine your front-end code actually runs on.
+</div>
+
+In the last lesson we said the front end runs "in the browser." That makes the
+browser the single most important program in all of web development: it is the
+runtime your HTML, CSS, and JavaScript execute inside, the way the JVM runs Java
+or an operating system runs an app. Knowing roughly what it does with your code —
+and in what order — explains an enormous number of things that otherwise look like
+magic or bugs.
+
+## From response to pixels
+
+When a server sends back a response (as we traced in the previous lesson), what
+arrives first is a text document: **HTML**. That HTML usually references other
+files — stylesheets, scripts, images, fonts — which the browser then requests as
+well. Turning all of that into a visible, interactive page is a pipeline, often
+called the **rendering** process, and it runs in a fairly fixed order.
+
+The stages are: **parse the HTML**, **parse the CSS**, **combine them** into what
+gets shown, **lay out** the page geometry, and **paint** the pixels. Scripts can
+run partway through and change things. Let's walk each stage.
+
+## Parsing HTML into the DOM
+
+The browser reads the HTML text top to bottom and builds it into a tree of
+objects in memory. Each tag becomes a **node**; nesting becomes parent-and-child
+relationships. This live, in-memory tree is the **DOM** — the Document Object
+Model — and it is the single most important data structure on the front end.
+
+```html
+<body>
+  <h1>Live calls</h1>
+  <ul>
+    <li>Fire dispatch</li>
+    <li>Police tac 2</li>
+  </ul>
+</body>
+```
+
+That snippet becomes a tree: a `body` node with an `h1` child and a `ul` child,
+and the `ul` with two `li` children. The DOM matters because it's not just how the
+page is drawn — it's the thing JavaScript reads and changes to make the page
+interactive. We give it a whole lesson later, [the DOM](/learn/web-dev/the-dom/).
+
+## Applying CSS
+
+In parallel, the browser parses the **CSS** — the style rules — into its own
+structure. It then walks the DOM and, for every element, works out the final set
+of styles that apply: colour, font, size, spacing, position, and so on. An element
+with no matching rule still gets sensible defaults.
+
+The result is a version of the tree annotated with how everything should look.
+Only elements that will actually be shown are included — something hidden with
+`display: none`, for instance, is computed but left out of what gets drawn. CSS
+gets its own lesson in [CSS & layout](/learn/web-dev/css-and-layout/); here it's
+enough to know the browser marries **structure (DOM)** with **style (CSS)** before
+it can draw anything.
+
+## Layout and paint
+
+With structure and style in hand, the browser does two final jobs:
+
+- **Layout** (sometimes called *reflow*): it calculates the exact geometry — how
+  big every element is and where it sits on the page. This is where the box model,
+  flexbox, and grid do their work. Change the width of the window and layout runs
+  again.
+- **Paint**: it fills in the actual pixels — text, colours, borders, images,
+  shadows — turning the laid-out boxes into what you see.
+
+These steps are not free. When JavaScript changes the page in a way that affects
+size or position, the browser has to lay out and paint again, which is why sloppy
+updates can make a page feel sluggish. You don't need to optimise this yet, but
+it's worth knowing the pixels you see are the *end* of a pipeline, not the start.
+
+## Running JavaScript
+
+The browser also contains a **JavaScript engine** that downloads and runs your
+scripts. JavaScript can read and change the DOM, respond to clicks and typing, and
+fetch more data from a server — which is how a page updates without a full reload.
+We cover what it does in [JavaScript in the browser](/learn/web-dev/javascript-in-the-browser/).
+
+The catch is *timing*. A plain `<script>` tag, by default, **pauses HTML parsing**
+while the browser downloads and executes it. Put a big script in the `<head>` and
+the user can be staring at a blank page while it loads. That's why scripts
+traditionally go at the **bottom** of the page, or are marked to load without
+blocking:
+
+```html
+<!-- Blocks parsing until it finishes -->
+<script src="app.js"></script>
+
+<!-- Downloads alongside parsing, runs after the HTML is ready -->
+<script src="app.js" defer></script>
+```
+
+The `defer` attribute lets the page's content appear first and runs the script
+once the HTML is parsed — the usual choice today. This one detail explains a lot of
+"why is my page slow to show up" questions.
+
+## One program, many jobs
+
+Under the hood, a browser is several coordinated engines: a **networking** layer
+that fetches resources, a **rendering engine** that runs the parse-layout-paint
+pipeline, and a **JavaScript engine** that executes scripts — all wrapped in the
+interface with its tabs and address bar. Modern browsers also enforce important
+**security** boundaries, keeping one site's code from reaching into another's.
+When you write for "the browser," you're really writing instructions these engines
+carry out on the user's behalf.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the browser parses HTML into the DOM, a live in-memory tree of the page's structure." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does the browser build when it parses your HTML?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">A compiled binary that runs on the server</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The DOM — a live in-memory tree of the page's structure</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">A database record for each page element</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- The **browser** is web development's key program — the runtime your HTML, CSS,
+  and JavaScript execute inside.
+- It **fetches** the page's resources, then runs a **rendering** pipeline: parse
+  HTML, apply CSS, lay out geometry, and paint pixels.
+- Parsing HTML produces the **DOM**, a live in-memory tree that is also what
+  JavaScript reads and changes.
+- **Layout** computes size and position; **paint** draws the pixels — and changes
+  that affect geometry make both run again.
+- The **JavaScript engine** runs your scripts, which can update the page after it
+  loads.
+- A plain `<script>` **blocks parsing**; placing scripts at the end or using
+  `defer` lets content appear first.
+
+Next up: [The client-server web](/learn/web-dev/client-server-web/).

--- a/docs/learn/web-dev/html-structure.md
+++ b/docs/learn/web-dev/html-structure.md
@@ -1,0 +1,171 @@
+---
+slug: html-structure
+title: HTML — structure & semantics
+description: "HTML is the skeleton of every web page. This lesson covers elements and tags, nesting, the shape of a document, and — most importantly — semantic markup: why choosing the tag that describes meaning matters for accessibility, search, and the developers who come after you."
+keywords: HTML, elements, tags, semantic HTML, markup, document structure, HTML tags, semantic markup, attributes, headings, accessibility
+level: beginner
+status: full
+prereq:
+  - static-vs-dynamic
+faq:
+  - q: What is HTML?
+    a: "**HTML** (HyperText Markup Language) is the language that describes the structure and content of a web page. It marks up text with **tags** — like `<h1>` for a heading or `<p>` for a paragraph — so the browser knows what each piece *is*. HTML is the skeleton; CSS styles it and JavaScript makes it interactive."
+  - q: What does semantic HTML mean?
+    a: "**Semantic** HTML means choosing tags that describe the *meaning* of content, not just its appearance — `<nav>` for navigation, `<button>` for a button, `<h1>` for the main heading. Semantic markup is understood by screen readers, search engines, and other developers, whereas a generic `<div>` says nothing about what it holds."
+  - q: Is HTML a programming language?
+    a: "Not in the usual sense — it has no logic, loops, or variables. HTML is a **markup language**: it describes and structures content. The logic on a web page comes from JavaScript. That said, writing good HTML is a genuine skill, because the structure you choose affects meaning, accessibility, and everything layered on top."
+---
+
+# HTML — structure & semantics
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**HTML** is the skeleton of every web page — the language that marks up content
+with **tags** so the browser knows what each piece *is*. An **element** is a tag,
+its content, and any **attributes**; elements **nest** to form the tree the browser
+turns into the [DOM](/learn/web-dev/the-dom/). The most important habit is
+**semantic** markup: choosing the tag that describes **meaning** (`<nav>`,
+`<button>`, `<h1>`) rather than a generic `<div>`, because meaning is what screen
+readers, search engines, and future developers rely on. This is the first of the
+front-end trio, building on
+[how the browser works](/learn/web-dev/how-the-browser-works/).
+</div>
+
+We've talked about HTML as "the structure" since the first lesson. Now we meet it
+directly. HTML is the first of the three browser languages — structure (HTML),
+style ([CSS](/learn/web-dev/css-and-layout/)), and behaviour
+([JavaScript](/learn/web-dev/javascript-in-the-browser/)) — and it's the
+foundation the other two build on. Get the structure right and everything above it
+is easier; get it wrong and no amount of styling or scripting fully rescues it.
+
+## Elements and tags
+
+HTML marks up content with **tags**. Most come in pairs — an opening tag and a
+closing tag — wrapping some content between them. The opening tag, its content, and
+the closing tag together make an **element**:
+
+```html
+<p>This is a paragraph.</p>
+<h1>The main heading</h1>
+<a href="/learn/">A link to the learn hub</a>
+```
+
+The `<p>` marks a paragraph, `<h1>` the top-level heading, `<a>` a link. Some
+elements are **empty** — they have no content and no closing tag, like `<img>` for
+an image or `<br>` for a line break. The browser reads these tags to know what each
+piece of content *is*, which is exactly what it needs to build the page.
+
+## Attributes
+
+Tags can carry **attributes** — extra information, written as `name="value"` inside
+the opening tag. Attributes configure an element without changing its content:
+
+```html
+<a href="/learn/networking/http/">Read the HTTP lesson</a>
+<img src="antenna.jpg" alt="A discone antenna on a rooftop">
+<button type="button">Refresh</button>
+```
+
+Here `href` says where the link goes, `src` where the image lives, and `alt` gives
+a text description of the image for anyone who can't see it. A few attributes turn
+up everywhere — `id` (a unique name for one element), `class` (a label used for
+styling and grouping), and `alt` — and you'll lean on them constantly once CSS and
+JavaScript enter the picture.
+
+## The shape of a document
+
+A complete HTML page has a standard skeleton. The whole document sits inside
+`<html>`, split into a `<head>` (information *about* the page — its title, its
+links to CSS and scripts) and a `<body>` (the content that's actually shown):
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Live calls</title>
+    <link rel="stylesheet" href="style.css">
+  </head>
+  <body>
+    <h1>Live calls</h1>
+    <p>The latest decoded traffic.</p>
+  </body>
+</html>
+```
+
+Elements **nest** inside one another — the `body` contains an `h1` and a `p`, and
+those could contain more elements still. That nesting is what forms the **tree**
+the browser parses into the DOM, as we saw in
+[how the browser works](/learn/web-dev/how-the-browser-works/). Proper nesting
+matters: tags should close in the reverse order they opened, so the tree stays
+well-formed.
+
+## Semantic HTML
+
+Here is the idea that separates careful HTML from careless HTML: **semantics**.
+Semantic markup means choosing the tag that describes what the content *means*, not
+just how you want it to look.
+
+HTML gives you meaningful elements for the common parts of a page:
+
+```html
+<header>…the top of the page…</header>
+<nav>…the site navigation…</nav>
+<main>
+  <article>…a self-contained piece of content…</article>
+</main>
+<footer>…the bottom of the page…</footer>
+```
+
+Each of those *says something* about the content it holds. Compare that to wrapping
+everything in a generic **`<div>`** — a box with no meaning at all. Both can be
+made to look identical with CSS, but only the semantic version tells anyone *what
+the content is*. Use `<button>` for a button, `<h1>`–`<h6>` for a heading
+hierarchy, `<ul>`/`<ol>` for lists, `<a>` for links — reach for `<div>` and
+`<span>` only when no meaningful element fits.
+
+## Why semantics matter
+
+Choosing the right tag isn't pedantry; it pays off in three concrete ways:
+
+- **Accessibility.** Screen readers use semantics to navigate. A real `<button>` is
+  focusable and announced as a button; a `<nav>` lets a user jump to navigation.
+  Rebuilt out of `<div>`s, none of that works without heavy extra effort. This is
+  the heart of [accessibility basics](/learn/web-dev/accessibility-basics/).
+- **Search and machines.** Search engines and other tools read your markup to
+  understand the page. Clear structure — a real heading hierarchy, articles marked
+  as articles — helps them index and present it correctly.
+- **The next developer.** Semantic HTML is self-documenting. Someone reading
+  `<nav>…</nav>` knows instantly what it is; someone reading the fortieth nested
+  `<div>` has to guess. That someone is often future-you.
+
+The rule of thumb: **describe the content, don't just position it.** Styling is
+CSS's job — HTML's job is to say what things are. A page built on honest semantics
+is more accessible, more findable, and easier to maintain, all at once.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — semantic tags like <nav> and <button> describe what content means, which screen readers, search engines, and developers all rely on." markdown="0">
+  <p class="knowledge-check__q">Quick check: why prefer a semantic tag like <code>&lt;button&gt;</code> over a styled <code>&lt;div&gt;</code>?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It renders faster than a div in every browser</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">It describes meaning, so screen readers, search engines, and developers understand it</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">A div can't be styled with CSS but a button can</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **HTML** is the structural skeleton of a page — a **markup** language that
+  describes what content *is*, not logic.
+- An **element** is an opening tag, content, and a closing tag; **empty** elements
+  like `<img>` have no closing tag.
+- **Attributes** (`href`, `src`, `alt`, `id`, `class`) configure elements with
+  extra information.
+- A document nests inside `<html>`, split into `<head>` (about the page) and
+  `<body>` (shown content); nesting forms the **tree** the browser turns into the
+  DOM.
+- **Semantic** markup chooses tags by **meaning** — `<nav>`, `<button>`, `<h1>` —
+  rather than reaching for a meaningless `<div>`.
+- Semantics pay off in **accessibility**, **search**, and **maintainability**:
+  describe the content, and leave the styling to CSS.
+
+Next up: [CSS — styling & layout](/learn/web-dev/css-and-layout/).

--- a/docs/learn/web-dev/http-servers-and-routing.md
+++ b/docs/learn/web-dev/http-servers-and-routing.md
@@ -1,0 +1,162 @@
+---
+slug: http-servers-and-routing
+title: HTTP servers & routing
+description: How a server answers the web — a listening loop that accepts HTTP requests, a router that maps a URL path and method to the right handler function, and a handler that builds and returns the response, shown with a small Go example.
+keywords: HTTP server, routing, router, handler, request handler, listen, port, URL path, HTTP method, Go http server, middleware, ServeMux
+level: intermediate
+status: full
+prereq:
+  - what-a-backend-does
+faq:
+  - q: What is a route?
+    a: "A route is a rule that maps an incoming request — identified by its HTTP method and URL path, like GET /api/calls — to the handler function that should answer it. The router is the part of the server that looks at each request and picks the matching route, so the right code runs for each URL."
+  - q: What does 'listening on a port' mean?
+    a: "A server binds to a port number (like 8080) on the machine and waits for incoming connections there. The port is the address within the machine that clients connect to; a URL's host and port tell the network which machine and which listening program should receive the request."
+  - q: What is a handler?
+    a: "A handler is the function that runs for a matched route. It receives the request (path, method, headers, body) and a way to write the response, does whatever work is needed — read a database, check auth — and writes back a status code, headers, and a body. One handler per kind of request."
+---
+
+# HTTP servers & routing
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+An **HTTP server** is a program that **listens on a port**, accepts incoming
+[HTTP requests](/learn/networking/http/), and returns responses — running the loop
+forever. A **router** inspects each request's **method and path** (like `GET /api/calls`)
+and dispatches it to the matching **handler** function. The **handler** does the work —
+read a [database](/learn/web-dev/backend-and-database/), check auth — and writes back a
+**status code, headers, and body**. **Middleware** wraps handlers to run shared work
+(logging, auth) around every request. This is the machinery behind every
+[back end](/learn/web-dev/what-a-backend-does/).
+</div>
+
+The [last lesson](/learn/web-dev/what-a-backend-does/) said the back end runs on a
+server; this one is what that server actually *is* as a program. Strip away the framework
+names and it's three things: something that **listens** for requests, something that
+**routes** each one to the right code, and the **handler** code that produces a response.
+Every web framework in every language — Express, Flask, Rails, Go's standard library — is
+a variation on those three parts. We'll use Go, since it makes the shape especially clear.
+
+## The listening loop
+
+A server's outermost job is to **listen** on a **port** and accept connections. It binds
+to a port number on the machine — say `8080` — and then waits, handling each request that
+arrives and looping forever. A client reaches it via the host and port in a URL; the
+network delivers the request to whichever program is listening there.
+
+```go
+package main
+
+import (
+    "fmt"
+    "net/http"
+)
+
+func main() {
+    mux := http.NewServeMux()          // the router
+    mux.HandleFunc("GET /api/calls", listCalls)
+
+    fmt.Println("listening on :8080")
+    http.ListenAndServe(":8080", mux)  // bind the port and serve forever
+}
+```
+
+`ListenAndServe` is the loop: it accepts each connection, parses the HTTP request, and
+hands it to the router (`mux`). You write that line once; everything interesting happens
+in the routes and handlers it dispatches to. Under the hood the server also runs each
+request concurrently, so a slow one doesn't block the rest — but the mental model is
+simply "accept a request, route it, respond, repeat."
+
+## Routing: method + path to a handler
+
+A real back end answers many different requests, so it needs to decide **which code**
+handles each one. That's **routing**: matching a request's **HTTP method and URL path** to
+a **handler**. `GET /api/calls` lists calls; `POST /api/calls` creates one;
+`GET /api/calls/42` fetches one by id. The **router** holds a table of these rules and
+picks the match.
+
+```go
+mux := http.NewServeMux()
+mux.HandleFunc("GET  /api/calls",      listCalls)    // read the collection
+mux.HandleFunc("POST /api/calls",      createCall)   // create in the collection
+mux.HandleFunc("GET  /api/calls/{id}", getCall)      // read one item
+```
+
+Note that **the same path with a different method routes to different handlers** —
+`GET /api/calls` and `POST /api/calls` are separate routes. That method-plus-path pairing
+is exactly the structure a [REST API](/learn/web-dev/building-a-rest-api/) is built on, so
+routing and REST design go hand in hand. Bigger apps use richer routers (path parameters,
+groups, patterns), but the job never changes: request in, correct handler chosen.
+
+## The handler: build the response
+
+A **handler** is the function that answers a matched route. It receives the **request**
+(method, path, headers, body) and a **response writer**, does the work, and writes back a
+**status code, headers, and body** — the response shape from the
+[HTTP lesson](/learn/networking/http/).
+
+```go
+func listCalls(w http.ResponseWriter, r *http.Request) {
+    calls := readCallsFromDB()               // do the work (query the database)
+
+    w.Header().Set("Content-Type", "application/json")
+    w.WriteHeader(http.StatusOK)             // 200
+    json.NewEncoder(w).Encode(calls)         // write the JSON body
+}
+```
+
+That's the whole contract: read what came in, do something trustworthy on the server, and
+write a response out. A handler that creates something returns **201 Created**; one that
+can't find the item returns **404**; one that hits an internal error returns **500** — the
+[status codes](/learn/networking/http/) are how the handler tells the client what
+happened. Keep handlers focused: parse and validate the input, call into your logic and
+[database](/learn/web-dev/backend-and-database/), and format the response.
+
+## Middleware: shared work around every request
+
+Most requests need the same surrounding work — log the request, check the user is
+authenticated, set common headers, recover from a panic. Rather than repeat that in every
+handler, you wrap handlers in **middleware**: a function that runs **before and/or after**
+the handler, forming a chain the request passes through.
+
+```go
+func withLogging(next http.Handler) http.Handler {
+    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        log.Printf("%s %s", r.Method, r.URL.Path)  // before
+        next.ServeHTTP(w, r)                        // run the real handler
+    })
+}
+```
+
+The request flows **listener → middleware chain → router → handler**, and the response
+flows back out through the same chain. Cross-cutting concerns — authentication (a natural
+fit, checking identity once for many routes), logging, rate limiting,
+[CORS](/learn/web-dev/what-a-backend-does/) — live in middleware so handlers stay focused
+on their one job. This layered shape is universal, whatever the language; learn it once
+and every server framework reads the same. If you want to go deeper on Go itself, the
+[Go module](/learn/programming-go/) covers the language behind these examples.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — routing maps a request's method and path (like GET /api/calls) to the handler function that should answer it." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does a router do in an HTTP server?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Encrypts the connection between the browser and the server</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Maps each request's method and path to the handler function that answers it</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Stores the app's data so handlers don't need a database</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- An **HTTP server** binds to a **port**, **listens** for requests, and responds in a
+  loop that runs forever.
+- A **router** maps each request's **method and path** (like `GET /api/calls`) to the
+  matching **handler**; the same path with a different method is a different route.
+- A **handler** reads the request, does trusted server-side work, and writes a
+  **status code, headers, and body** back.
+- **Middleware** wraps handlers to run shared work — logging, auth, CORS — before and
+  after the request, keeping handlers focused.
+- The request flows **listener → middleware → router → handler** and the response back
+  out — the same shape in every language and framework.
+
+Next up: [Building a REST API](/learn/web-dev/building-a-rest-api/).

--- a/docs/learn/web-dev/index.md
+++ b/docs/learn/web-dev/index.md
@@ -1,0 +1,32 @@
+---
+layout: learn-hub
+learn_module: web-dev
+permalink: /learn/web-dev/
+title: Web Development — how a website becomes a web app, from the browser to production
+description: A free, structured module on web development — how the browser and the client-server web work, HTML/CSS/JavaScript and modern front-end frameworks, HTTP servers and REST APIs on the back end, auth, real-time and web security, and shipping to production, with GopherTrunk's dashboard as the worked example.
+keywords: learn web development, how the web works, HTML CSS JavaScript, DOM, front-end frameworks, REST API, back end, HTTP server, authentication, sessions, JWT, WebSockets, web security, XSS CSRF CORS, CDN, deploy a web app, full stack
+---
+
+The web is where most software **meets its users**. A web app is also one of the
+most satisfying things to build, because you can put it in front of anyone with a
+browser. This module is the working developer's tour of how a web app is actually
+built — not a tutorial for one framework that's fashionable this year, but the
+durable ideas that outlast every framework.
+
+**Who this is for.** Developers who want to build for the web, whether you've never
+written a line of HTML or you've dabbled and want the whole picture to click. A
+little programming experience helps, but no web background is assumed. It builds
+directly on the [Networking]({{ '/learn/networking/' | relative_url }}) module (how
+requests move) and pairs with [Databases &amp; Data]({{ '/learn/databases/' | relative_url }})
+(where the data lives) and [Containers &amp; Deployment]({{ '/learn/deployment/' | relative_url }})
+(how it ships).
+
+**How the module works.** Six units take you from the browser to production. The
+first three cover the **front end** — how the browser works, the HTML/CSS/JavaScript
+trio, and how modern component frameworks build on them. The fourth crosses to the
+**back end**: HTTP servers, REST APIs, and the database behind them. The last two
+cover the parts that separate a page from a product — **auth, real-time, and web
+security** — and then shipping, measuring, and operating a real app, using
+[GopherTrunk]({{ '/' | relative_url }})'s own web dashboard as the worked example.
+Mark lessons complete as you go — your progress is saved in your browser. New here?
+**[Start with lesson 1: What web development is](/learn/web-dev/what-is-web-development/)**

--- a/docs/learn/web-dev/javascript-in-the-browser.md
+++ b/docs/learn/web-dev/javascript-in-the-browser.md
@@ -1,0 +1,163 @@
+---
+slug: javascript-in-the-browser
+title: JavaScript in the browser
+description: JavaScript is the language that makes web pages interactive. This lesson covers what JavaScript does in the browser, how it responds to events like clicks and typing, the single-threaded event loop, and the crucial distinction between code that runs in the browser and code that runs on the server.
+keywords: JavaScript, browser scripting, events, event listener, client-side JavaScript, DOM scripting, event loop, interactivity, client vs server code, async
+level: beginner
+status: full
+prereq:
+  - css-and-layout
+faq:
+  - q: What does JavaScript do in the browser?
+    a: "JavaScript adds **behaviour** to a page. It responds to what the user does — clicks, typing, scrolling — by changing the page, fetching new data from a server, validating input, and running logic. Where HTML is structure and CSS is appearance, JavaScript is the interactivity that makes a page feel like an application rather than a document."
+  - q: Is JavaScript in the browser the same as Node.js on the server?
+    a: "It's the same *language*, but a different environment. In the **browser**, JavaScript can touch the page (the DOM) and respond to user events, but not the file system. On a **server** with Node.js it can read files and talk to a database, but there's no page to manipulate. Same syntax, different powers, decided by where the code runs."
+  - q: How does JavaScript respond to a click?
+    a: "You attach an **event listener** — a function the browser calls when a particular event happens on a particular element. When the user clicks the button, the browser runs your function. This event-driven style is the core of how interactive pages work: the code waits for things to happen and reacts."
+---
+
+# JavaScript in the browser
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**JavaScript** is the third of the front-end trio — the language that makes a page
+**interactive**. It runs inside the browser's JavaScript engine, responds to
+**events** like clicks and typing through **event listeners**, and can change the
+page, validate input, and fetch fresh data. It's **single-threaded** and
+**event-driven**: the code reacts to things as they happen. The most important
+distinction to hold is **where code runs** — the same language behaves very
+differently in the **browser** than on the **server**. This builds on
+[HTML](/learn/web-dev/html-structure/) and [CSS](/learn/web-dev/css-and-layout/) to
+complete the trio.
+</div>
+
+HTML gave us structure and CSS gave us style, but both are static — the page just
+sits there. **JavaScript** is what makes it *do* things: respond to a click, check
+a form as you type, pull in new data, update part of the page without a reload.
+It's the third and final language of the browser, and it's what turns a document
+into an application. This lesson is about what it does and, crucially, *where* it
+runs.
+
+## What JavaScript adds
+
+HTML and CSS describe a page; JavaScript **changes it while it's running**. With
+JavaScript a page can:
+
+- **React to the user** — run code when someone clicks, types, scrolls, or submits.
+- **Change the page** — add, remove, or update elements on the fly (the next
+  lesson, [the DOM](/learn/web-dev/the-dom/), is entirely about this).
+- **Fetch data** — request fresh information from a server in the background and
+  show it without a full reload ([fetching data](/learn/web-dev/fetching-data/)).
+- **Validate and compute** — check input, do calculations, manage state in the page.
+
+That's the leap from a *document* to an *app*. A static article needs no
+JavaScript; a live dashboard that updates as calls come in is JavaScript from top
+to bottom.
+
+## Events and listeners
+
+The browser runs JavaScript in an **event-driven** style. Rather than a script
+that runs start to finish and stops, browser JavaScript mostly sets up **listeners
+** — functions the browser calls later, when something happens.
+
+```js
+const button = document.querySelector("#refresh");
+
+button.addEventListener("click", () => {
+  console.log("Refresh clicked!");
+  // ...update the page, fetch new data, etc.
+});
+```
+
+That code finds the refresh button and says "when it's clicked, run this
+function." The function doesn't run now; it runs *whenever the user clicks*, however
+many times. Almost all interactivity is built this way: attach listeners for the
+events you care about — `click`, `input`, `submit`, `keydown` — and put your
+response inside. The page becomes a set of reactions waiting to fire.
+
+## Single-threaded and asynchronous
+
+Browser JavaScript runs on a **single thread** — it does one thing at a time.
+That raises a question: if it can only do one thing at once, how does a page stay
+responsive while waiting seconds for a server to reply?
+
+The answer is that slow work is **asynchronous**. When you fetch data, JavaScript
+doesn't freeze waiting for it — it kicks off the request and carries on, and the
+browser runs your "when it arrives" code later, once the response is back. This is
+managed by the **event loop**, which juggles pending events and callbacks so the
+one thread is never blocked waiting.
+
+```js
+// Kick off a request; keep running; handle the result when it arrives.
+fetch("/api/calls")
+  .then((response) => response.json())
+  .then((data) => console.log("Got calls:", data));
+
+console.log("This line runs before the data arrives.");
+```
+
+You'll meet `fetch` and async data properly in
+[fetching data from the front end](/learn/web-dev/fetching-data/). The takeaway
+here is the *shape*: start something slow, don't wait, react when it's done. That's
+how one thread keeps a page smooth.
+
+## Where the code runs
+
+This is the single most important idea in the lesson, and a frequent source of
+confusion: **the same JavaScript language runs in two very different places.**
+
+- In the **browser** (client-side), JavaScript can touch the **page** — read and
+  change the DOM, respond to user events — but it *cannot* read the user's files or
+  reach a database directly. It runs on the user's device, so it's untrusted and
+  sandboxed.
+- On a **server** (with a runtime like Node.js), JavaScript has *no page* to
+  manipulate, but it *can* read files, talk to a database, and hold secrets. It
+  runs on the operator's machine.
+
+Same syntax, different powers — decided entirely by **where it runs**. This maps
+straight onto the client-server split from earlier: browser JavaScript is the
+front end, server JavaScript is a back end. Confusing the two leads to real bugs
+and real security holes — for instance, trusting the browser to enforce a rule it
+can't, since the user controls their own device.
+
+## Client-side means untrusted
+
+That last point deserves emphasis. Because browser JavaScript runs on the user's
+machine, the user can read it, change it, or skip it entirely. So client-side code
+is for **convenience and experience** — instant feedback, a smoother interface —
+never the final word on anything that matters.
+
+The classic example is form validation. Checking input in the browser gives a fast,
+friendly "that email looks wrong" *before* the user submits — but the **server must
+check again**, because a determined user can bypass the browser's check completely.
+Anything security-relevant — permissions, prices, whether an action is allowed —
+belongs on the server. We return to this in
+[forms & user input](/learn/web-dev/forms-and-user-input/) and, from the attacker's
+side, in [web application attacks](/learn/cybersecurity/web-application-attacks/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — browser JavaScript runs on the user's device and can be changed or bypassed, so the server must re-check anything that matters." markdown="0">
+  <p class="knowledge-check__q">Quick check: why can't you rely on browser JavaScript alone to enforce a security rule?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Browser JavaScript is too slow to run security checks</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">It runs on the user's device, so the user can change or bypass it — the server must re-check</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">JavaScript can't do comparisons, only display text</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **JavaScript** is the browser's language of **behaviour** — it makes a page
+  interactive, completing the trio with HTML and CSS.
+- It's **event-driven**: you attach **event listeners** (for `click`, `input`,
+  `submit`, …) and the browser runs your function when the event fires.
+- It's **single-threaded** but handles slow work **asynchronously** via the **event
+  loop**, so the page stays responsive.
+- The same language runs in **two places**: in the **browser** it touches the page
+  but is sandboxed; on a **server** it touches files and databases but has no page.
+- **Where code runs** determines its powers — browser JavaScript is the front end,
+  server JavaScript is a back end.
+- Client-side code is **untrusted**: use it for experience, but re-check anything
+  that matters on the **server**.
+
+Next up: [The DOM — manipulating the page](/learn/web-dev/the-dom/).

--- a/docs/learn/web-dev/monitoring-and-analytics.md
+++ b/docs/learn/web-dev/monitoring-and-analytics.md
@@ -1,0 +1,125 @@
+---
+slug: monitoring-and-analytics
+title: Monitoring & analytics
+description: Knowing what your web app actually does once real users touch it — error tracking, uptime and health checks, structured logs, and privacy-respecting analytics — so you learn about problems before your users tell you.
+keywords: monitoring, analytics, error tracking, uptime, health check, logging, structured logs, observability, alerting, privacy-respecting analytics, real user monitoring
+level: intermediate
+status: full
+prereq:
+  - deploying-a-web-app
+faq:
+  - q: "What's the difference between monitoring and analytics?"
+    a: "**Monitoring** watches the *health* of your app — is it up, is it erroring, is it slow — so you can keep it running. **Analytics** watches *user behaviour* — which pages people visit, where they drop off, what they do — so you can improve the product. They overlap in tooling but answer different questions: monitoring keeps you out of trouble; analytics helps you decide what to build."
+  - q: "Why not just check the logs when someone reports a problem?"
+    a: "Because by then real users have already been affected, and a reactive check only finds problems people bother to report — many just leave. Good monitoring is **proactive**: automated health checks, error tracking, and alerts tell *you* about a broken deploy or a spike in errors within minutes, often before a single user complains. You want to find issues before they find you."
+  - q: "Can I do analytics without invading users' privacy?"
+    a: "Yes. **Privacy-respecting analytics** measures aggregate behaviour — page views, referrers, broad device types — without tracking individuals across sites or storing personal data. It answers *what's happening on my site* without building profiles of people, which is usually all you actually need and keeps you clear of the heavier consent and compliance burden."
+---
+
+# Monitoring & analytics
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Once your app is [deployed](/learn/web-dev/deploying-a-web-app/), you need to know
+what it does *in the wild*. **Monitoring** watches the app's **health** — uptime,
+errors, latency — so you learn about problems **before your users do**, through
+**health checks**, **error tracking**, structured **logs**, and **alerts**.
+**Analytics** watches **user behaviour** to guide the product, ideally with
+**privacy-respecting** tools that measure aggregates instead of profiling people. The
+throughline: shipping isn't the end — running it well means measuring it continuously.
+</div>
+
+Deploying gets your app onto the internet; it doesn't tell you whether it's *working*.
+The moment real users, real devices, and real networks are involved, things break in
+ways your laptop never showed you — and the worst way to find out is a user emailing
+"your site is down." This lesson is about closing that gap: watching a live app so you
+learn what it's doing before anyone has to tell you.
+
+## Why you can't just watch the logs
+
+A running app is a black box unless you deliberately make it observable. Waiting for
+users to report problems is a losing strategy for two reasons: by the time they
+report, people have already had a bad experience, and most unhappy users simply leave
+without a word. The goal is to be **proactive** — to have the app tell *you* the
+moment something's wrong. That splits into two related jobs: keeping it healthy
+(**monitoring**) and understanding how it's used (**analytics**).
+
+## Monitoring: is it healthy?
+
+**Monitoring** answers *is the app up, working, and fast?* The pieces build on each
+other:
+
+- **Uptime & health checks.** A tiny endpoint — often `/health` — that returns "OK"
+  when the app is alive. An external service pings it constantly and alerts you if it
+  stops answering, so a crashed process or bad deploy is caught in minutes.
+
+  ```http
+  GET /health   ->   200 OK   {"status":"ok","db":"connected"}
+  ```
+
+- **Error tracking.** When code throws in production, an error tracker captures it —
+  the message, stack trace, and context — and groups repeats, so you see *"this bug
+  hit 400 users since the 3pm deploy"* instead of nothing. Server errors matter, and
+  so do errors in the user's [browser JavaScript](/learn/web-dev/javascript-in-the-browser/),
+  which you'd otherwise never see.
+
+- **Structured logs.** Logs are the app's diary. Written as **structured** records
+  (consistent fields you can search and filter) rather than free-form text, they let
+  you reconstruct what happened around an incident. Log meaningful events and errors —
+  never secrets or personal data.
+
+- **Alerting.** Data no one looks at helps no one. Alerts turn signals into action:
+  notify a human when errors spike, latency climbs, or the health check fails — but
+  tune them, because alerts that fire constantly get ignored.
+
+Together these are the app-level side of **observability**, the same discipline the
+[deployment module](/learn/deployment/what-is-deployment/) applies to infrastructure.
+
+## Analytics: how is it used?
+
+**Analytics** answers a different question: *what are users actually doing?* Which
+pages they visit, where they arrive from, where they abandon a flow, which feature
+gets used. This guides *product* decisions — what to build, fix, or cut — in a way no
+amount of monitoring can, because a page can be perfectly healthy and still useless.
+
+Analytics also overlaps with performance: **real-user monitoring** collects the
+[Core Web Vitals](/learn/web-dev/performance-and-web-vitals/) from actual visitors,
+which is the field data that ultimately decides whether your site *feels* fast.
+
+## Respecting privacy
+
+Analytics has a bad reputation because it's often done invasively — tracking
+individuals across the web and hoarding personal data. You rarely need any of that.
+**Privacy-respecting analytics** measures **aggregate** behaviour — counts of page
+views, referrers, broad device categories — without building profiles of people or
+following them off your site. It answers *what's happening on my site* while sidestepping
+the heavier consent and [compliance](/learn/web-dev/web-security-essentials/) burden,
+and it's usually all the insight you actually need. Collect the minimum that answers
+your question, and treat any personal data with the same care as everything else in
+this module.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — monitoring watches the app's health so you catch problems proactively, before users report them." markdown="0">
+  <p class="knowledge-check__q">Quick check: what's the main point of monitoring a deployed app?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">To make the app load faster for every user automatically</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">To learn about health problems proactively, before users have to report them</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">To replace the need for automated tests before deploying</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Deploying isn't the end — a live app needs watching, because problems appear with
+  real users, devices, and networks that your laptop never surfaced.
+- **Monitoring** watches **health**: **uptime/health checks**, **error tracking**,
+  structured **logs**, and **alerting** so you catch issues *proactively*, before
+  users report them.
+- **Analytics** watches **user behaviour** — pages, drop-off, feature use — to guide
+  product decisions a healthy-but-useless page would otherwise hide.
+- **Real-user monitoring** collects Core Web Vitals from actual visitors, the field
+  data that decides whether the site truly feels fast.
+- Prefer **privacy-respecting analytics** that measures aggregates over tools that
+  profile individuals — collect the minimum that answers your question.
+
+Next up: [choosing your web stack](/learn/web-dev/choosing-a-web-stack/).

--- a/docs/learn/web-dev/performance-and-web-vitals.md
+++ b/docs/learn/web-dev/performance-and-web-vitals.md
@@ -1,0 +1,136 @@
+---
+slug: performance-and-web-vitals
+title: Performance & Core Web Vitals
+description: What "fast" actually means on the web and how it's measured — loading, interactivity, and visual stability captured by Google's Core Web Vitals (LCP, INP, CLS) — plus the concrete levers that move each metric.
+keywords: web performance, Core Web Vitals, LCP, largest contentful paint, INP, interaction to next paint, CLS, cumulative layout shift, page speed, perceived performance, lazy loading
+level: intermediate
+status: full
+prereq:
+  - caching-and-cdns
+faq:
+  - q: "What are the Core Web Vitals?"
+    a: "Three user-centred metrics Google standardised. **LCP (Largest Contentful Paint)** measures *loading* — when the main content appears. **INP (Interaction to Next Paint)** measures *interactivity* — how quickly the page responds to a tap or click. **CLS (Cumulative Layout Shift)** measures *visual stability* — how much the layout jumps around as it loads. Together they approximate how fast a page *feels*, not just how fast it technically loads."
+  - q: "Why does perceived performance matter more than raw load time?"
+    a: "Because users experience *feel*, not milliseconds on a stopwatch. A page that shows meaningful content quickly and responds instantly to taps feels fast even if some assets are still loading in the background. Techniques like showing content progressively, reserving space for images, and prioritising visible content all improve the *perception* of speed, which is what the Web Vitals try to capture."
+  - q: "Where do I even start optimising?"
+    a: "Measure first — never guess. Use a tool like Lighthouse or field data from real users to find *your* actual bottleneck, then fix the biggest one. The common wins are almost always the same: send less (smaller images and JavaScript), send it from closer ([a CDN](/learn/web-dev/caching-and-cdns/)), and don't block the page while non-essential work runs."
+---
+
+# Performance & Core Web Vitals
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+"Fast" on the web is about how a page *feels*, and Google's **Core Web Vitals** put
+numbers on it: **LCP** (loading — when main content appears), **INP** (interactivity —
+response to taps), and **CLS** (visual stability — how much things jump). You improve
+them by **sending less** (smaller images and JavaScript), **sending it from closer**
+(a [CDN](/learn/web-dev/caching-and-cdns/)), and **not blocking** the page while
+non-critical work runs. The rule above all: **measure before you optimise** — fix
+your real bottleneck, not a guessed one.
+</div>
+
+Users abandon slow pages, search engines rank them lower, and "slow" is decided in
+the first couple of seconds. But performance is easy to chase in the wrong direction —
+tuning something that was never the problem. This lesson defines what fast *means* in
+terms users actually feel, the standard way it's measured, and the handful of levers
+that move it.
+
+## Fast is a feeling, not a stopwatch
+
+The trap in performance work is optimising a number no user notices. What matters is
+**perceived performance** — how quickly the page seems ready and responsive. A page
+that paints its headline and article instantly *feels* fast even while images and
+analytics still load quietly in the background. So the goal isn't "everything loaded"
+as early as possible; it's **the parts the user cares about, ready and responsive,
+first**. The Core Web Vitals exist to measure exactly that feeling.
+
+## The Core Web Vitals
+
+Google standardised three **user-centred** metrics, each capturing a different way a
+page can feel slow:
+
+- **LCP — Largest Contentful Paint** (loading). When the biggest, main piece of
+  content — usually the hero image or headline — finishes rendering. It answers *"has
+  the useful content shown up yet?"* Aim for a couple of seconds or less.
+- **INP — Interaction to Next Paint** (interactivity). How quickly the page visibly
+  responds after the user taps, clicks, or types. A page that looks done but freezes
+  when touched fails here — usually because heavy
+  [JavaScript](/learn/web-dev/javascript-in-the-browser/) is hogging the main thread.
+- **CLS — Cumulative Layout Shift** (visual stability). How much content jumps around
+  as the page loads — the maddening moment a button shifts just as you tap it.
+  Reserving space for images and ads keeps this low.
+
+Together they approximate *loading*, *responsiveness*, and *stability* — the three
+axes of how fast a page feels.
+
+## The levers that move them
+
+Most performance wins come from a short list, and they map cleanly onto the Vitals.
+
+**Send less.** The biggest lever is fewer and smaller bytes:
+
+- **Images** are usually the heaviest thing on a page — compress them, size them to
+  how they're displayed, use modern formats, and **lazy-load** offscreen ones so they
+  don't delay the visible content (helps **LCP**).
+- **JavaScript** is expensive twice — to download *and* to run. Ship less of it, split
+  it so each page loads only what it needs, and defer non-critical scripts so they
+  don't block interactivity (helps **INP**).
+
+```html
+<!-- Lazy-load offscreen images; reserve space to avoid layout shift -->
+<img src="photo.jpg" loading="lazy" width="800" height="600" alt="…">
+```
+
+**Send it from closer, and reuse it.** A [CDN](/learn/web-dev/caching-and-cdns/)
+serves assets from near the user, and good **caching** means repeat visits fetch
+almost nothing (helps **LCP**).
+
+**Don't block, and reserve space.** Let the critical content render before secondary
+work; always set image and element dimensions so the layout doesn't jump (helps
+**CLS** and **INP**). The [rendering strategy](/learn/web-dev/ssr-spa-static/) matters
+too — server-rendered or static HTML often shows content sooner than a client-rendered
+app that must download and run JavaScript before anything appears.
+
+## Measure first, always
+
+The one rule that saves the most wasted effort: **measure before you optimise.** Your
+intuition about the bottleneck is often wrong, and the fix for one site does nothing
+for another. Two kinds of measurement matter:
+
+- **Lab data** — a synthetic test in a tool like Lighthouse, run on demand, giving a
+  reproducible score and a prioritised list of issues.
+- **Field data** — real Core Web Vitals from actual users on real devices and
+  networks, which is what ultimately counts.
+
+Find *your* biggest bottleneck, fix it, measure again. Optimising by guesswork —
+shaving milliseconds off code no one waits on — is the classic way to spend real
+effort for no felt improvement. This measure-and-verify loop is the same discipline
+the [monitoring](/learn/web-dev/monitoring-and-analytics/) lesson applies to the rest
+of a running app.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — LCP measures loading (when the main content paints), one of the three Core Web Vitals." markdown="0">
+  <p class="knowledge-check__q">Quick check: which aspect of the experience does LCP (Largest Contentful Paint) measure?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">How secure the page's HTTPS connection is</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Loading — when the main content of the page finishes rendering</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">How many database queries the back end runs</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Web performance is about **perceived speed** — how ready and responsive a page
+  *feels*, not a raw stopwatch time.
+- The **Core Web Vitals** measure three axes: **LCP** (loading — main content
+  appears), **INP** (interactivity — response to input), and **CLS** (visual
+  stability — how much the layout jumps).
+- The main levers are **send less** (compress and lazy-load images, ship and defer
+  less JavaScript), **send it from closer** (a CDN plus caching), and **don't block
+  or shift** (render critical content first, reserve space for elements).
+- Rendering strategy matters: static or server-rendered HTML often paints content
+  sooner than a client-rendered app.
+- Above all, **measure before you optimise** — use lab and field data to fix your real
+  bottleneck, not a guessed one.
+
+Next up: [monitoring & analytics](/learn/web-dev/monitoring-and-analytics/).

--- a/docs/learn/web-dev/responsive-design.md
+++ b/docs/learn/web-dev/responsive-design.md
@@ -1,0 +1,157 @@
+---
+slug: responsive-design
+title: Responsive design
+description: How one website serves every screen — fluid layouts that flex to the viewport, CSS media queries that adapt at breakpoints, the mobile-first mindset, and the viewport meta tag that makes it all work on phones.
+keywords: responsive design, media query, breakpoint, mobile-first, fluid layout, viewport meta tag, responsive web design, CSS breakpoints, flexbox grid responsive, adaptive layout
+level: intermediate
+status: full
+prereq:
+  - css-and-layout
+faq:
+  - q: What is responsive design?
+    a: "Responsive design is building one website that adapts its layout to fit any screen — phone, tablet, laptop, or desktop — rather than shipping separate sites. It combines fluid, flexible layouts with CSS media queries that change the design at certain widths, so the page stays usable and readable everywhere."
+  - q: What is a media query?
+    a: "A media query is a CSS rule that applies styles only when a condition about the device is true — most often the viewport width. You write a block that says 'when the screen is at least this wide, use these styles,' letting one stylesheet describe several layouts for different screen sizes."
+  - q: Why start mobile-first?
+    a: "Because it forces you to prioritise the essential content and layout for the smallest, most constrained screen first, then progressively add complexity for larger ones with min-width media queries. It tends to produce simpler, faster pages than designing for desktop and trying to cram it down to a phone."
+---
+
+# Responsive design
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Responsive design** makes **one site work on every screen** — phone to desktop —
+instead of building separate ones. It rests on **fluid layouts** that flex to the
+viewport (relative units, [flexbox and grid](/learn/web-dev/css-and-layout/)) plus **CSS
+media queries** that change the design at **breakpoints**. The modern default is
+**mobile-first**: style the small screen first, then add for larger ones with
+`min-width` queries. None of it works on phones without the **viewport meta tag** in your
+HTML, which is the one line people most often forget.
+</div>
+
+Your users show up on a five-inch phone, a tablet, a laptop, and a wide desktop monitor,
+and they expect the same site to be usable on all of them. **Responsive design** is how
+you deliver that from a single codebase. It builds directly on
+[CSS &amp; layout](/learn/web-dev/css-and-layout/) — the box model, flexbox, and grid — and
+adds the tools that let one design adapt to whatever screen it lands on. This lesson is
+those tools and the mindset that ties them together.
+
+## The problem: one site, many screens
+
+There is no single screen size to design for. Widths range from roughly 320 pixels on a
+small phone to 2560 and beyond on a desktop, and orientation, pixel density, and window
+size all vary too. A layout that looks great at 1440px — three columns, a wide sidebar —
+is unusable crammed onto a phone, where those same columns become slivers. The old
+answer was a separate "m-dot" mobile site; the modern answer is **one responsive site**
+that reflows to fit. That's cheaper to build, cheaper to maintain, and better for search,
+since there's a single URL for every device.
+
+## Fluid layouts: flex, don't fix
+
+The foundation of responsive design is refusing to hard-code sizes in pixels. Use
+**relative units** and flexible layout systems so the page **fluidly** fills whatever
+width it's given:
+
+- **Relative units** — percentages, `rem`/`em`, `vw`/`vh`, `fr` in grid — size things
+  relative to the viewport or the font, not to a fixed pixel count.
+- **Flexbox and grid** — from the [layout lesson](/learn/web-dev/css-and-layout/) — wrap
+  and redistribute space as the container changes width.
+- **`max-width` on images and media** so they shrink to fit and never overflow.
+
+```css
+/* Fluid by default: the grid fits as many 250px columns as will fit, then wraps. */
+.call-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1rem;
+}
+img { max-width: 100%; height: auto; }
+```
+
+A genuinely fluid layout already handles a lot of screen sizes before you write a single
+media query. Media queries then handle the points where fluidity alone isn't enough —
+where the design needs to *change*, not just stretch.
+
+## Media queries: adapt at breakpoints
+
+A **media query** applies CSS only when a condition about the device holds — almost always
+the **viewport width**. The widths where you change the layout are called **breakpoints**.
+
+```css
+/* Base styles: single column, tuned for a phone. */
+.layout { display: block; }
+
+/* At 768px and up (tablet), switch to a sidebar + content layout. */
+@media (min-width: 768px) {
+  .layout { display: grid; grid-template-columns: 250px 1fr; }
+}
+
+/* At 1200px and up (desktop), widen and add a third column. */
+@media (min-width: 1200px) {
+  .layout { grid-template-columns: 250px 1fr 300px; }
+}
+```
+
+One stylesheet now describes three layouts, each taking over at its breakpoint. Choose
+breakpoints where **the content needs them**, not by chasing specific device models —
+the moment a line of text gets too long or a row gets too cramped is a breakpoint, no
+matter what device hits it first.
+
+## Mobile-first
+
+Notice the direction of those queries: the base styles target the **small** screen, and
+`min-width` queries **add** complexity as the screen grows. That's **mobile-first**, the
+modern default, and the direction matters. Designing for the phone first forces you to
+decide what's essential — the constrained screen has no room for anything else — and then
+you progressively enhance for the space larger screens offer.
+
+The alternative, desktop-first (`max-width` queries stripping things away for phones),
+tends to produce heavier pages that feel like a big design apologetically shrunk down.
+Mobile-first also lines up with reality: for most sites, phones are the majority of
+traffic, so the smallest screen deserves to be the one you get right first. It pairs
+naturally with the performance mindset — smaller screens often mean slower networks, so a
+lean mobile baseline helps the users who need it most.
+
+## The viewport meta tag
+
+Here's the line that trips people up: without it, none of the above works on phones. By
+default a mobile browser pretends to be a ~980px-wide desktop and shrinks the whole page
+to fit, so your media queries never see the real width. This one tag in your HTML
+`<head>` tells the browser to use the device's actual width:
+
+```html
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+```
+
+`width=device-width` makes the layout viewport match the physical screen, and
+`initial-scale=1` starts at normal zoom. With it in place, a phone reports ~390px and
+your mobile-first styles apply as intended; leave it out and a beautifully responsive
+stylesheet still renders as a tiny, zoomed-out desktop page. It's the first thing to
+check when "my media queries aren't working on mobile." Responsive design then feeds
+straight into the [Core Web Vitals](/learn/web-dev/responsive-design/) and performance
+work that a page needs to feel fast on real devices.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — mobile-first means styling the small screen as the base and adding complexity for larger screens with min-width media queries." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does a mobile-first approach mean in practice?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Building a separate m-dot site just for phones</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Styling the small screen as the base, then adding for larger screens with min-width queries</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Designing for desktop first and stripping things away for phones</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Responsive design** serves **one site to every screen** by adapting the layout
+  rather than shipping separate mobile and desktop versions.
+- **Fluid layouts** — relative units plus [flexbox and grid](/learn/web-dev/css-and-layout/)
+  — flex to the viewport and handle many sizes before any media query.
+- **Media queries** apply CSS at **breakpoints**, letting one stylesheet describe
+  several layouts; choose breakpoints where the content needs them.
+- **Mobile-first** styles the small screen as the base and adds complexity upward with
+  `min-width` queries — simpler, faster, and aligned with real traffic.
+- The **viewport meta tag** (`width=device-width`) is required for any of it to work on
+  phones — the most common thing people forget.
+
+Next up: [What a back end does](/learn/web-dev/what-a-backend-does/).

--- a/docs/learn/web-dev/ssr-spa-static.md
+++ b/docs/learn/web-dev/ssr-spa-static.md
@@ -1,0 +1,144 @@
+---
+slug: ssr-spa-static
+title: SSR vs. SPA vs. static
+description: The three ways to produce the HTML a browser shows — rendered on the server per request (SSR), built in the browser by JavaScript (SPA), or generated ahead of time as static files — what each is good at, their trade-offs, and how to choose.
+keywords: SSR, SPA, static site, server-side rendering, single-page app, static site generation, SSG, hydration, rendering strategy, time to first byte, SEO, isomorphic
+level: intermediate
+status: full
+prereq:
+  - fetching-data
+faq:
+  - q: What's the difference between SSR and a SPA?
+    a: "In server-side rendering (SSR) the server builds the full HTML for each request and sends a ready-to-show page. In a single-page app (SPA) the server sends a near-empty shell plus JavaScript, and the browser builds the page and fetches data itself, then updates in place without full reloads. SSR is faster to first paint and better for SEO; a SPA feels more app-like after it loads."
+  - q: What does 'static' mean here?
+    a: "A static site is HTML generated ahead of time — at build, not per request — and served as plain files. There's no server rendering work per visit, so it's the fastest and cheapest to serve. It's ideal for content that's the same for everyone, like docs, blogs, or marketing pages. This site is static."
+  - q: Do I have to pick just one?
+    a: "No. Modern frameworks mix them — statically generate some pages, server-render others, and hydrate into an interactive SPA on the client. The three are points on a spectrum of when the HTML is built (ahead of time, per request, or in the browser), and real apps often use more than one."
+---
+
+# SSR vs. SPA vs. static
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+There are three ways to produce the HTML the browser shows, differing in **when the HTML
+is built**. **Static** generates it **ahead of time** at build and serves plain files —
+fastest and cheapest, best for content that's the same for everyone (this site).
+**SSR** builds the HTML **on the server per request** — great for first paint, SEO, and
+personalised pages. A **SPA** ships a shell plus JavaScript and builds the page **in the
+browser**, then updates in place with [fetch](/learn/web-dev/fetching-data/) — the most
+app-like feel, but slower to start. Real frameworks **mix** all three.
+</div>
+
+You've seen the front end ([components and fetch](/learn/web-dev/components-and-state/))
+and the back end ([servers and APIs](/learn/web-dev/http-servers-and-routing/)). This
+lesson is the question that sits between them: **where and when does the HTML get built?**
+The answer — on the server per request, in the browser, or ahead of time — is the
+**rendering strategy**, and it shapes performance, SEO, and how the app feels. The three
+options are really points on one spectrum of *timing*, so understanding that axis matters
+more than memorising labels.
+
+## Static: built ahead of time
+
+The simplest strategy: generate the HTML **once, at build time**, and serve the resulting
+files as-is to every visitor. No per-request rendering, no application server in the hot
+path — just files. That makes static sites the **fastest and cheapest** to serve and the
+easiest to put on a [CDN](/learn/web-dev/responsive-design/) close to users.
+
+The catch is that the content is the **same for everyone** until the next build, so it
+suits pages that don't change per user or per request: documentation, blogs, marketing
+sites, this very learning module. When the data does change, you **rebuild** and redeploy.
+This is exactly what a [static site generator](/learn/web-dev/templating-and-static-sites/)
+does, and it connects to [static vs. dynamic](/learn/web-dev/static-vs-dynamic/) from Unit 1
+— static here means the *rendering is done up front*.
+
+## SSR: built on the server per request
+
+**Server-side rendering** builds the full HTML **on the server, fresh for each request**,
+and sends a **complete, ready-to-show page**. The browser gets meaningful content on the
+very first response — no waiting for JavaScript to construct the page — which is good for:
+
+- **First paint / time-to-content** — the page shows immediately, even on slow devices.
+- **SEO and link previews** — crawlers and social scrapers see real HTML, not an empty
+  shell they'd have to run JavaScript to fill.
+- **Personalised or always-fresh pages** — each request can render the current data for
+  *this* user, which static can't.
+
+The cost is that the server does rendering work on **every request**, so it needs compute
+and is slower and pricier to serve than static files. SSR is the classic model behind
+[templating](/learn/web-dev/templating-and-static-sites/) — a server building HTML from a
+template and data per request — and it's making a strong comeback in modern frameworks.
+
+## SPA: built in the browser
+
+A **single-page app** flips it: the server sends a near-**empty HTML shell** plus a bundle
+of JavaScript, and **the browser builds the page**. From then on the app **fetches data**
+([the fetch lesson](/learn/web-dev/fetching-data/)) and updates the page **in place** —
+navigating between "pages" without a full reload, swapping content instantly. That's the
+snappy, app-like feel of a dashboard or editor.
+
+```text
+SPA first load:  server → tiny HTML shell + JS bundle
+                 browser runs JS → builds UI → fetch()es data → renders
+Later actions:   browser fetch()es data → updates the page in place (no reload)
+```
+
+The trade-off is the **start**: the browser must download and run the JavaScript before
+anything meaningful appears, so first paint is slower, and a naive SPA is weak for SEO
+because the initial HTML is nearly empty. SPAs shine **after** they load — for highly
+interactive, stateful apps where the user stays a while and the up-front cost is worth it.
+GopherTrunk's live [dashboard](/architecture.html) leans this way: load once, then stream
+updates in place.
+
+## Hydration: the hybrid
+
+The two dynamic approaches combine. A page can be **server-rendered (or statically
+generated) for a fast, SEO-friendly first paint**, and then the same JavaScript **hydrates**
+it in the browser — attaching event handlers and taking over so it behaves like a SPA from
+there. You get the best of both: instant meaningful content *and* rich interactivity. This
+"render on the server, hydrate on the client" pattern is the default in frameworks like
+Next.js, Nuxt, and SvelteKit, which is why the SSR-vs-SPA argument has softened into "use
+each where it fits." The mental model to keep is the timing axis: **build ahead of time,
+per request, or in the browser** — hydration simply uses more than one point on it.
+
+## Choosing
+
+Match the strategy to the page, not to fashion:
+
+- **Static** — content that's the same for everyone and changes rarely: docs, blog,
+  marketing, this site. Fastest, cheapest, simplest.
+- **SSR** — content that must be fresh, personalised, or SEO-critical on first load: a
+  news feed, a product page, a logged-in home screen.
+- **SPA** — highly interactive, stateful apps where users stay a while: dashboards,
+  editors, tools. Often SSR/static for the first paint, then hydrated.
+
+You don't have to pick one for the whole app — statically generate the marketing pages,
+server-render the product pages, and hydrate the dashboard into a SPA. The question is
+always the same: **when should this page's HTML be built, and by whom?**
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a static site's HTML is generated ahead of time at build and served as files, which is why it's the fastest and cheapest to serve." markdown="0">
+  <p class="knowledge-check__q">Quick check: when is the HTML built for a static site?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">On the server, freshly for each incoming request</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Ahead of time at build, then served as plain files</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">In the browser by JavaScript after the shell loads</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- The three strategies differ in **when the HTML is built**: ahead of time, per request,
+  or in the browser.
+- **Static** builds HTML at build time and serves files — fastest and cheapest, for
+  content that's the same for everyone (like this site).
+- **SSR** builds HTML on the server per request — best for first paint, SEO, and
+  personalised or always-fresh pages, at the cost of per-request compute.
+- A **SPA** ships a shell plus JavaScript and builds the page in the browser, updating in
+  place with [fetch](/learn/web-dev/fetching-data/) — app-like, but slower to start and
+  weaker for SEO.
+- **Hydration** combines them: server-render or statically generate for first paint, then
+  hydrate into a SPA — the modern default.
+- **Choose per page**, matching the strategy to whether the content is shared, fresh, or
+  highly interactive.
+
+Next up: [Templating &amp; static site generators](/learn/web-dev/templating-and-static-sites/).

--- a/docs/learn/web-dev/static-vs-dynamic.md
+++ b/docs/learn/web-dev/static-vs-dynamic.md
@@ -1,0 +1,140 @@
+---
+slug: static-vs-dynamic
+title: Static vs. dynamic sites
+description: The spectrum from a file served as-is to a page built on the fly — what static and dynamic mean, the tradeoffs in speed, cost, and freshness, why this learning site is static, and how modern approaches blur the line.
+keywords: static site, dynamic site, static vs dynamic, static site generator, server-rendered, CDN, prerendered HTML, when to use static, web app vs website, Jekyll
+level: beginner
+status: full
+prereq:
+  - anatomy-of-a-web-app
+faq:
+  - q: What is the difference between a static and a dynamic site?
+    a: "A **static** site serves pre-built files exactly as they are — every visitor gets the same file. A **dynamic** site builds each page on request, often personalised and drawn from a database. Static is faster and cheaper to serve; dynamic can show fresh, per-user content. Most real sites mix both."
+  - q: Is a static site the same as a simple site?
+    a: "Not necessarily. \"Static\" describes how pages are served — as fixed files — not how sophisticated they are. A static site can have rich design and interactivity through JavaScript running in the browser; what makes it static is that the server hands over the same file rather than generating it per request."
+  - q: Why would you choose a static site?
+    a: "For speed, cost, security, and reliability. Serving a fixed file is extremely fast and cheap, has almost no attack surface, and rarely breaks. If your content is the same for everyone and doesn't change every second — docs, blogs, marketing, this learning site — static is often the best choice."
+---
+
+# Static vs. dynamic sites
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A **static** site serves pre-built files unchanged — every visitor gets the same
+HTML. A **dynamic** site builds each page on request, often personalised and
+pulled from a **database**. Static wins on **speed, cost, and security**; dynamic
+wins when content must be **fresh or per-user**. It's a spectrum, not a binary, and
+modern tools deliberately blur the line. This very site is **static** — generated
+ahead of time and served as plain files — which is why it loads fast and rarely
+breaks.
+</div>
+
+The last lesson mapped the four parts of a web app and noted that real sites use
+different amounts of each. This lesson turns that observation into a spectrum. At
+one end a page is a **file served as-is**; at the other it's **assembled fresh for
+every request**. Understanding where a project sits on that line drives real
+decisions about speed, cost, and complexity — including the choice behind the pages
+you're reading now.
+
+## What "static" means
+
+A **static** site is a set of files — HTML, CSS, JavaScript, images — sitting on a
+server. When a request comes in, the server finds the matching file and sends it
+back **unchanged**. There's no logic, no database lookup, no per-visitor assembly:
+everyone who asks for `/about` gets the exact same `about.html`.
+
+That doesn't mean *boring*. A static page can still be beautifully designed and can
+run JavaScript in the browser to be interactive — animations, menus, even fetching
+data from some other API after it loads. What makes it static is only this: the
+**server did no work to build it**. It reached for a finished file and handed it
+over.
+
+## What "dynamic" means
+
+A **dynamic** site builds the page **on request**. When a request arrives, the
+back end runs code — checks who you are, queries the database, applies logic — and
+**generates** the HTML (or data) for that specific request, then sends it back.
+
+This is what lets a page be different for every visitor and every moment: your
+name in the corner, your account's data, the current contents of a constantly
+changing list. A social feed, a bank dashboard, an email inbox — all dynamic,
+because the whole point is that the page reflects *live, personalised* state that
+couldn't have been baked into a file in advance.
+
+## The tradeoffs
+
+Neither is better in the abstract; they trade different things.
+
+| | Static | Dynamic |
+|---|--------|---------|
+| **Speed** | Very fast — just hand over a file | Slower — must build each page |
+| **Cost** | Cheap — minimal server work | Higher — servers, database, logic |
+| **Freshness** | Fixed until rebuilt | Live, up-to-the-second |
+| **Personalisation** | Same for everyone | Per-user |
+| **Security** | Tiny attack surface | More to defend |
+| **Complexity** | Simple to run | More moving parts |
+
+The pattern is clear: static is **fast, cheap, and simple** but shows the **same
+fixed content** to everyone; dynamic is **flexible and fresh** but **costs more**
+in servers, complexity, and things that can break. The right choice follows from
+what the content actually needs to do.
+
+## Why this site is static
+
+This learning site is **static**, and it's a good illustration of why you'd
+choose that. The content — these lessons — is the same for every reader and
+changes only when an author edits it, not second by second. So there's no reason
+to build each page on every request. Instead the pages are generated **ahead of
+time** by a **static site generator** (Jekyll, in this case) and served as plain
+files.
+
+The payoff is exactly the static column above: pages load fast, hosting is cheap,
+there's almost nothing to attack because there's no live back end or database in
+the request path, and it's very hard to break. When your content fits — docs,
+blogs, marketing, reference — static is often the *right* engineering call, not a
+lesser one. We cover how these generators work in
+[templating & static site generators](/learn/web-dev/templating-and-static-sites/).
+
+## A spectrum, and the blur
+
+In practice, the line is deliberately fuzzy, and most real sites live in the
+middle:
+
+- A mostly **static** site can fetch dynamic data in the browser after it loads —
+  static shell, live contents.
+- A **static site generator** can pre-build thousands of pages from a database at
+  build time, so pages that *look* dynamic are actually served as files.
+- A **dynamic** site can **cache** its generated pages so repeat requests are served
+  fast, like static ones — the subject of
+  [caching & CDNs](/learn/web-dev/caching-and-cdns/).
+
+The deeper question — render on the server, in the browser, or ahead of time — is a
+lesson of its own, [SSR vs. SPA vs. static](/learn/web-dev/ssr-spa-static/). For
+now, hold the spectrum in mind: not "which one," but "how much of each, and where."
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a static site serves the same pre-built file to everyone; the server does no per-request work to build it." markdown="0">
+  <p class="knowledge-check__q">Quick check: what defines a static site?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It has no JavaScript and can't be interactive at all</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The server sends pre-built files unchanged, doing no per-request work</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It stores its pages in a database instead of files</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **static** site serves pre-built files unchanged; a **dynamic** site builds
+  each page on request from logic and a database.
+- Static means the **server did no work to build the page** — it can still be
+  designed and interactive in the browser.
+- Dynamic means the page is **generated per request**, enabling fresh and
+  per-user content.
+- The tradeoffs: static is **faster, cheaper, simpler, and safer**; dynamic is
+  **fresher and personalised** but more complex.
+- **This site is static**, generated ahead of time by a static site generator and
+  served as files — the right call for content that's the same for everyone.
+- It's a **spectrum**: static shells fetch live data, generators pre-build many
+  pages, and dynamic sites cache — the line is intentionally blurred.
+
+Next up: [HTML — structure & semantics](/learn/web-dev/html-structure/).

--- a/docs/learn/web-dev/templating-and-static-sites.md
+++ b/docs/learn/web-dev/templating-and-static-sites.md
@@ -1,0 +1,166 @@
+---
+slug: templating-and-static-sites
+title: Templating & static site generators
+description: Generating HTML from templates and data instead of writing every page by hand — how server-side templating fills a layout per request, how static site generators like Jekyll build a whole site at once, and where each fits.
+keywords: templating, template engine, static site generator, Jekyll, SSG, layout, template, front matter, Liquid, server-side templating, build a static site
+level: intermediate
+status: full
+prereq:
+  - ssr-spa-static
+faq:
+  - q: What is a template?
+    a: "A template is HTML with placeholders and a little logic — loops, conditionals, variable slots — that gets filled with data to produce a finished page. Instead of writing a hundred near-identical pages by hand, you write one template and render it many times with different data, which keeps the markup consistent and the content separate."
+  - q: What is a static site generator?
+    a: "A static site generator (SSG) runs your templates plus content files through a build step once, producing a folder of plain HTML you can serve anywhere. Jekyll, which builds this site, is one; Hugo, Eleventy, and Astro are others. It's server-side templating moved to build time so there's no rendering work per visit."
+  - q: When should I use a static site generator versus server-side templating?
+    a: "Use an SSG when the content is the same for everyone and changes at a manageable pace — docs, blogs, marketing — because building ahead of time is the fastest and cheapest to serve. Use per-request server-side templating when pages must be personalised or always fresh, since those can't be baked at build time."
+---
+
+# Templating & static site generators
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Rather than hand-writing every page, you generate HTML from **templates** — layouts with
+placeholders and light logic — filled with **data**. **Server-side templating** does this
+**per request** (the classic [SSR](/learn/web-dev/ssr-spa-static/) path). A **static site
+generator** does it **once at build time**, producing plain HTML files to serve anywhere —
+the fastest, cheapest option for content that's the same for everyone. **Jekyll**, which
+builds **this very site**, is an SSG: Markdown and templates in, a static folder out, then
+[deployed](/learn/deployment/what-is-deployment/) as files. Same idea, different timing.
+</div>
+
+The [rendering lesson](/learn/web-dev/ssr-spa-static/) put "when is the HTML built" on a
+spectrum. This lesson is the *how* for two points on it — server-side templating and static
+generation — which share one mechanism: **templates plus data produce HTML.** It's how most
+of the web's content pages are made, from a server rendering a profile page to the static
+generator that turned the Markdown you're reading into this HTML. Understanding it demystifies
+both a lot of back-end code and this site itself.
+
+## Templates: HTML with slots and logic
+
+Writing every page by hand doesn't scale — a hundred product pages share the same structure
+and differ only in data. A **template** captures the structure once as HTML with
+**placeholders** for values and a little **logic** (loops, conditionals), and you **render**
+it against data to get a finished page.
+
+```html
+<!-- A template: static structure, dynamic slots. -->
+<article>
+  <h1>{{ call.talkgroup }}</h1>
+  <p>Duration: {{ call.seconds }}s</p>
+  <ul>
+    {% for tag in call.tags %}
+      <li>{{ tag }}</li>
+    {% endfor %}
+  </ul>
+</article>
+```
+
+Render this with one call's data and you get that call's page; render it with another and you
+get the next — same markup, different content. The win is **separation**: designers and
+developers work on the template, the data comes from wherever data lives, and the two meet at
+render time. Every ecosystem has template engines — Go's `html/template`, Jinja, ERB, Liquid,
+Handlebars — but they all do this one job.
+
+## Server-side templating: render per request
+
+The traditional dynamic web renders templates **on the server, per request**. A request comes
+in, the handler loads the data (often from the [database](/learn/web-dev/backend-and-database/)),
+fills the template, and returns the finished HTML — the [SSR](/learn/web-dev/ssr-spa-static/)
+strategy from the last lesson.
+
+```go
+// A handler renders a template with per-request data.
+func callPage(w http.ResponseWriter, r *http.Request) {
+    call := store.GetCall(r.PathValue("id"))   // fresh data for THIS request
+    tmpl.Execute(w, call)                       // fill the template → HTML
+}
+```
+
+Because it runs on each visit, server-side templating handles **personalised and always-fresh**
+pages — a logged-in dashboard, a live listing — that can't be baked ahead of time. The price is
+per-request rendering work, and importantly a **security responsibility**: template engines
+**escape** inserted values by default so user data can't inject markup or scripts. Never disable
+that escaping for untrusted data, or you open an [XSS](/learn/web-dev/what-a-backend-does/) hole
+— the [web security lesson](/learn/web-dev/ssr-spa-static/) covers it, and it's why "trust
+nothing from the client" extends all the way to how you render it.
+
+## Static site generators: render once at build
+
+A **static site generator (SSG)** takes the same templates-plus-data idea and moves it to
+**build time**. You run a build step **once**; it renders every page and writes a folder of plain
+**HTML** files. There's no application server rendering per visit — the output is just files, so
+it's the fastest and cheapest to serve, and it drops straight onto a
+[CDN](/learn/web-dev/responsive-design/) or any static host.
+
+The trade is that the content is fixed until the **next build**, so SSGs fit content that's the
+same for everyone and changes at a manageable pace: documentation, blogs, marketing sites — and
+learning modules like this one. When the content changes, you **rebuild and redeploy**. Popular
+generators include **Jekyll**, **Hugo**, **Eleventy**, and **Astro**; they differ in language and
+speed but share the model — content and templates in, static HTML out.
+
+## Jekyll: how this site is built
+
+This site runs on **Jekyll**, so it's a concrete example you're literally reading. The lesson
+content is **Markdown** with a block of **front matter** at the top — the `slug`, `title`, and
+`description` metadata you'd see if you viewed the source of this file. Jekyll's build:
+
+```text
+Markdown + front matter  ─┐
+Liquid templates/layouts ─┼─▶  jekyll build  ─▶  _site/  (plain HTML)  ─▶  served as files
+_data/*.yml (site data)  ─┘
+```
+
+- **Front matter** — per-page metadata (title, description, keywords) the templates read.
+- **Layouts and includes** — Liquid templates wrapping your content in the shared page chrome.
+- **`_data` files** — structured data (like the module's lesson list) the templates loop over to
+  build navigation.
+
+Jekyll renders all of that **once** into a `_site/` folder of static HTML, which is then
+[deployed](/learn/deployment/what-is-deployment/) as plain files — no server-side code runs when
+you load a page, which is why it's fast and simple to host. This is the payoff of
+[static vs. dynamic](/learn/web-dev/static-vs-dynamic/) made real: a rich, navigable site that is,
+under the hood, just files a [reverse proxy](/learn/deployment/reverse-proxies-and-tls/) serves.
+
+## Choosing between them
+
+The decision mirrors the [rendering lesson](/learn/web-dev/ssr-spa-static/):
+
+- **Static generation** when content is **shared and reasonably stable** — docs, blogs,
+  marketing, this module. Build once, serve files, rebuild on change.
+- **Server-side templating** when pages must be **personalised or always fresh** — anything that
+  depends on who's asking or on data that changes every second.
+- **Both, on one site** — statically generate the content pages and server-render (or hydrate
+  into a [SPA](/learn/web-dev/ssr-spa-static/)) the interactive parts.
+
+Whichever you use, the core skill is the same: express a page as a **template**, keep the
+**content as data**, and let the render step — at build or per request — put them together. Master
+that and a huge swath of web development, from a Go server's HTML to this Jekyll site, works the
+same way.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a static site generator like Jekyll renders templates and content into plain HTML once at build time, then serves those files." markdown="0">
+  <p class="knowledge-check__q">Quick check: when does a static site generator like Jekyll produce the HTML?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">On the server, freshly for each visitor's request</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Once at build time, writing plain HTML files that are then served as-is</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">In the browser, assembled by JavaScript after the page loads</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Templating** generates pages from **templates** (HTML with placeholders and light logic)
+  filled with **data**, instead of hand-writing every page.
+- **Server-side templating** renders **per request**, handling **personalised and fresh** pages;
+  template engines **escape** inserted values to prevent XSS — don't turn that off for untrusted
+  data.
+- A **static site generator** renders the same way but **once at build time**, producing plain
+  HTML files that are the fastest and cheapest to serve.
+- **Jekyll builds this site**: Markdown + front matter + Liquid templates + `_data` →
+  `jekyll build` → static HTML, then [deployed](/learn/deployment/what-is-deployment/) as files.
+- **Choose static** for shared, stable content and **server-side templating** for personalised or
+  always-fresh pages — or mix both on one site.
+- The durable skill is the same everywhere: **template + data → HTML**, at build or per request.
+
+Next up: [Authentication &amp; sessions](/learn/web-dev/authentication-and-sessions/).

--- a/docs/learn/web-dev/the-dom.md
+++ b/docs/learn/web-dev/the-dom.md
@@ -1,0 +1,186 @@
+---
+slug: the-dom
+title: The DOM — manipulating the page
+description: The DOM is the live tree the browser builds from your HTML, and the bridge JavaScript uses to change a page after it loads. This lesson explains what the DOM is, how to select and change elements, how to handle events, and why frequent DOM changes have a performance cost.
+keywords: DOM, document object model, DOM manipulation, querySelector, event handling, update page without reload, DOM tree, nodes, reflow, JavaScript DOM
+level: intermediate
+status: full
+prereq:
+  - javascript-in-the-browser
+faq:
+  - q: What is the DOM?
+    a: "The **DOM** (Document Object Model) is the browser's live, in-memory representation of the page — a tree of objects built from your HTML, where each element is a node. It's what JavaScript reads and changes to update the page. The HTML you write is the starting point; the DOM is the running version the browser and your code both work with."
+  - q: How is the DOM different from HTML?
+    a: "HTML is the static text you write and the server sends. The **DOM** is the live tree the browser builds from that HTML and then keeps in memory. Once the page is running, JavaScript changes the *DOM*, not the original HTML — which is why the page can look different from its source after scripts run."
+  - q: Why can changing the DOM a lot make a page slow?
+    a: "Because some DOM changes force the browser to recalculate layout and repaint — recomputing the size and position of elements. Doing that many times in quick succession, especially inside a loop, can make a page feel sluggish. The fix is to batch changes so the browser reflows once instead of many times."
+---
+
+# The DOM — manipulating the page
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+The **DOM** (Document Object Model) is the live, in-memory **tree** the browser
+builds from your HTML — each element a **node**. It's the bridge
+[JavaScript](/learn/web-dev/javascript-in-the-browser/) uses to change a page
+**after it loads**: your code **selects** elements, **reads or changes** them, and
+**listens** for events, and the browser updates the display — no reload needed.
+Changing the DOM has a **cost**, though: some updates force **layout and paint**
+again, so frequent changes can be slow. Understanding the DOM is the key to every
+interactive page, and to why frameworks exist.
+</div>
+
+The last lesson said JavaScript can "change the page." This lesson is about *how* —
+and the answer is the **DOM**. We first met it in
+[how the browser works](/learn/web-dev/how-the-browser-works/): when the browser
+parses your HTML, it builds a tree of objects in memory. That tree is the DOM, and
+it's the thing your JavaScript actually manipulates. Master it and you understand
+the machinery under every interactive page — and the problem that
+[frameworks](/learn/web-dev/frontend-frameworks/) were invented to solve.
+
+## What the DOM is
+
+When the browser reads your HTML, it doesn't keep the text around — it builds a
+**tree of objects**, one **node** per element, mirroring the nesting of your
+markup. This is the **DOM**: a live model of the page, sitting in memory, that both
+the browser and your JavaScript can work with.
+
+The crucial word is **live**. The DOM is not a one-time snapshot of your HTML; it's
+the running state of the page. When JavaScript changes a node, the browser
+re-renders to match, and the page updates on screen. So the page you see is really
+a view of the *current DOM*, which may have drifted far from the original HTML the
+server sent. That's exactly what makes dynamic, no-reload interfaces possible.
+
+## Selecting elements
+
+To change something, you first have to **find** it. The browser gives JavaScript a
+global `document` object — the root of the DOM — with methods to select nodes,
+most commonly `querySelector` (first match) and `querySelectorAll` (all matches),
+using the same selector syntax as CSS:
+
+```js
+// One element by id
+const heading = document.querySelector("#title");
+
+// A list of elements by class
+const items = document.querySelectorAll(".call");
+```
+
+Because the selectors are the same ones you learned for
+[CSS](/learn/web-dev/css-and-layout/), the `class` and `id` attributes you add to
+your HTML do double duty: they're both styling hooks and the handles JavaScript
+grabs elements by. Selecting is always step one — get a reference to the node, then
+do something with it.
+
+## Changing the page
+
+With a node in hand, you can read and change it: its text, its attributes, its
+styles, and the elements around it.
+
+```js
+const heading = document.querySelector("#title");
+
+heading.textContent = "Live calls (updated)";   // change its text
+heading.classList.add("active");                 // toggle a CSS class
+
+// Build and insert a brand-new element
+const li = document.createElement("li");
+li.textContent = "New call on Fire dispatch";
+document.querySelector("#calls").append(li);
+```
+
+Setting `textContent` changes what the element says; `classList.add` flips a CSS
+class on (often the cleanest way to restyle — let CSS define the look, let JS just
+toggle the class); and `createElement` plus `append` adds a whole new element to
+the page. This — reading and writing nodes — is the entire vocabulary of DOM
+manipulation, and it's how a page rebuilds itself as data changes.
+
+A safety note that connects to security: when you insert content that came from a
+user, set it as **text** (`textContent`), not as raw HTML. Injecting untrusted
+HTML into the DOM is the classic route to a cross-site scripting (XSS) attack,
+covered in [web application attacks](/learn/cybersecurity/web-application-attacks/)
+and [web security essentials](/learn/web-dev/web-security-essentials/).
+
+## Handling events on the DOM
+
+The DOM is also where **events** happen. As we saw in the last lesson, you attach a
+listener to a node and the browser runs your function when the event fires on it —
+and typically that function then *changes the DOM* in response:
+
+```js
+document.querySelector("#refresh").addEventListener("click", () => {
+  const status = document.querySelector("#status");
+  status.textContent = "Refreshing…";
+});
+```
+
+Select, listen, change — that loop is the beating heart of front-end code. A click
+comes in, your handler runs, it updates the DOM, and the user sees the result. Most
+interactive features are just this pattern repeated: an event, a response, a DOM
+update.
+
+## The cost of DOM changes
+
+DOM manipulation is powerful, but it isn't free, and this is where "intermediate"
+starts to matter. Some changes — anything affecting an element's size or position —
+force the browser to redo **layout** and **paint**, the pipeline stages from
+[how the browser works](/learn/web-dev/how-the-browser-works/). One update is
+nothing; a thousand in a tight loop, each triggering a fresh layout, can make a
+page stutter.
+
+```js
+const list = document.querySelector("#calls");
+
+// Costly: touches the live DOM on every iteration
+for (const call of calls) {
+  const li = document.createElement("li");
+  li.textContent = call.name;
+  list.append(li);           // may reflow each time
+}
+```
+
+The general fix is to **batch**: build up your changes and apply them in as few
+DOM operations as possible, so the browser reflows once instead of a thousand
+times. You don't need micro-optimisation now, just the instinct that *touching the
+DOM has a cost*.
+
+## Why frameworks exist
+
+Here's the payoff of this lesson for the rest of the module. Keeping the DOM in
+sync with your data **by hand** — selecting the right nodes, updating exactly the
+ones that changed, and doing it efficiently — gets fiddly and error-prone fast as
+an interface grows. Miss a spot and the screen shows stale data; over-update and
+the page is slow.
+
+That precise pain is why **front-end frameworks** like React exist: you describe
+what the page *should* look like for the current data, and the framework works out
+the minimal DOM changes to get there. It's still manipulating this same DOM
+underneath — the framework is a smarter layer over the exact machinery you've just
+learned. We pick that thread up in
+[front-end frameworks](/learn/web-dev/frontend-frameworks/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the DOM is the browser's live in-memory tree of the page, and JavaScript changes the DOM to update what's shown." markdown="0">
+  <p class="knowledge-check__q">Quick check: when JavaScript updates the page, what is it actually changing?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">The original HTML file on the server</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The DOM — the browser's live in-memory tree of the page</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">The CSS stylesheet, which then redraws the HTML</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- The **DOM** is the browser's **live, in-memory tree** built from your HTML — one
+  **node** per element — and it's what JavaScript reads and changes.
+- It's **live**: change a node and the browser re-renders, so the page can drift
+  from the original HTML source.
+- You **select** nodes with `querySelector`/`querySelectorAll` (CSS selectors),
+  then **read or change** their text, classes, attributes, and children.
+- Insert user content as **text**, not raw HTML, to avoid **XSS**.
+- Events happen on the DOM: **select, listen, change** is the core loop of
+  interactive code.
+- DOM changes can trigger **layout and paint**, so **batch** updates to keep pages
+  fast — and this very difficulty is why **frameworks** exist.
+
+Next up: [Forms & user input](/learn/web-dev/forms-and-user-input/).

--- a/docs/learn/web-dev/web-security-essentials.md
+++ b/docs/learn/web-dev/web-security-essentials.md
@@ -1,0 +1,167 @@
+---
+slug: web-security-essentials
+title: Web security essentials
+description: The vulnerabilities every web developer must understand — cross-site scripting (XSS), cross-site request forgery (CSRF), and the cross-origin resource sharing (CORS) rules — how each attack works and the concrete defenses that stop it.
+keywords: web security, XSS, cross-site scripting, CSRF, cross-site request forgery, CORS, same-origin policy, input validation, output encoding, content security policy
+level: advanced
+status: full
+prereq:
+  - cookies-tokens-jwt
+faq:
+  - q: "What's the single most important habit for web security?"
+    a: "**Never trust input, and never trust the client.** Every value that reaches your server — form fields, URLs, headers, uploaded files, even data from your own JavaScript — could be crafted by an attacker. Validate and encode it on the server. Most web vulnerabilities, XSS included, come down to treating attacker-controlled data as if it were safe."
+  - q: "Isn't HTTPS enough to make my site secure?"
+    a: "No. **HTTPS protects data *in transit*** — it stops eavesdropping and tampering on the network — but it does nothing about XSS, CSRF, broken authorization, or SQL injection, which attack the application itself. HTTPS is necessary and non-negotiable, but it's the floor, not the ceiling."
+  - q: "Does CORS make my API more secure?"
+    a: "Not exactly — **CORS relaxes** the browser's same-origin restriction in a controlled way; it doesn't add protection to your server. It decides which *other* origins a browser will let read your API's responses. A permissive CORS policy can expose data, but CORS is enforced by the browser, so it's never a substitute for real server-side authentication and authorization."
+---
+
+# Web security essentials
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Three vulnerabilities belong in every web developer's head. **XSS (cross-site
+scripting)** runs an attacker's JavaScript in your users' browsers — defended by
+**encoding output** and a content security policy. **CSRF (cross-site request
+forgery)** tricks a logged-in browser into making a request it didn't intend —
+defended by **anti-CSRF tokens** and the [`SameSite`](/learn/web-dev/cookies-tokens-jwt/)
+cookie flag. **CORS** is the browser rule governing which *other* origins may read
+your responses. The through-line: **never trust input, never trust the client.** The
+cybersecurity path covers the attacker's view in
+[web application attacks](/learn/cybersecurity/web-application-attacks/).
+</div>
+
+Everything you've built so far — [forms](/learn/web-dev/forms-and-user-input/),
+[auth](/learn/web-dev/authentication-and-sessions/), a
+[REST API](/learn/web-dev/building-a-rest-api/) — is also an attack surface. This
+lesson covers the three vulnerabilities you'll meet first and most often. It's a
+working developer's introduction, not a complete security course; for the offensive
+perspective and more attack classes, see
+[web application attacks](/learn/cybersecurity/web-application-attacks/).
+
+## The core mindset: trust nothing from the client
+
+Before the specific attacks, the mindset behind all of them: **any data that comes
+from the client can be hostile.** Form fields, query strings, headers, cookies,
+uploaded files, and even requests from your own front-end code can all be forged by
+someone who bypasses your UI entirely. So every defense in this lesson is a variation
+on one rule — **validate input, encode output, and re-check permissions on the
+server.** The browser is a convenience for real users and no obstacle at all to an
+attacker.
+
+## XSS — cross-site scripting
+
+**XSS** is when an attacker gets their **JavaScript to run in another user's
+browser**, inside your site's origin. Once their script runs on your page it can do
+anything the user can: read the [DOM](/learn/web-dev/the-dom/), steal data, make
+authenticated requests, or lift a token that JavaScript can reach.
+
+The classic path is unescaped user content. Suppose a comment field is written
+straight into the page:
+
+```javascript
+// DANGEROUS — attacker's markup becomes live HTML
+element.innerHTML = "Comment: " + userComment;
+// if userComment is  <script>steal(document.cookie)</script>  it runs
+```
+
+The defenses:
+
+- **Encode output for its context.** When user data lands in HTML, escape it so
+  `<script>` becomes inert text, not a tag. Use your framework's safe rendering
+  (React's `{value}`, templating auto-escaping) rather than building HTML by hand.
+- **A Content Security Policy (CSP).** An HTTP header that restricts which scripts
+  the browser will run, so injected inline script is blocked even if it slips in.
+- **HttpOnly cookies.** As covered in
+  [cookies & tokens](/learn/web-dev/cookies-tokens-jwt/), an HttpOnly session cookie
+  is invisible to JavaScript, so XSS can't read it directly.
+
+The single rule: **treat all user content as data, never as code**, and let a
+vetted encoder decide how it's safely displayed.
+
+## CSRF — cross-site request forgery
+
+**CSRF** abuses the browser's helpfulness. Recall that cookies are sent
+**automatically** on every request to a site. So if you're logged in to your bank
+and then visit a malicious page, that page can quietly submit a request to the
+bank — and the browser attaches your session cookie, making it look like *you*:
+
+```html
+<!-- On evil.com — fires a request to your bank, with your cookies attached -->
+<img src="https://bank.example/transfer?to=attacker&amount=1000">
+```
+
+The server can't tell this forged request from a real one, because it *is* your
+authenticated session. The defenses close that gap:
+
+- **Anti-CSRF tokens.** The server embeds a secret, per-session token in each form
+  and requires it back on state-changing requests. The attacker's page can't read
+  it (that's blocked by the same-origin policy), so the forged request fails.
+- **`SameSite` cookies.** Setting `SameSite=Lax` or `Strict` tells the browser *not*
+  to send the cookie on cross-site requests, cutting off the mechanism CSRF relies
+  on. This is now a strong first-line default.
+
+CSRF targets **cookie-based** auth specifically; a [bearer
+token](/learn/web-dev/cookies-tokens-jwt/) sent by hand isn't attached
+automatically, which is why token APIs are largely immune to it.
+
+## CORS & the same-origin policy
+
+Browsers enforce the **same-origin policy**: by default, JavaScript on one origin
+(scheme + host + port) can't *read* responses from a different origin. This quietly
+stops a lot of cross-site mischief — a random page can't just read your logged-in
+API's data.
+
+**CORS (cross-origin resource sharing)** is the controlled way to *relax* that rule.
+When your API needs to be called from a front end on a different origin, it sends
+headers naming who's allowed:
+
+```http
+Access-Control-Allow-Origin: https://app.example.org
+Access-Control-Allow-Credentials: true
+```
+
+Two things to keep straight. First, **CORS is enforced by the browser, not your
+server** — it governs whether the *browser* hands the response back to JavaScript;
+it is not a server-side access control. Second, a wildcard policy
+(`Access-Control-Allow-Origin: *`) on an authenticated API can expose data broadly,
+so name specific origins. CORS decides who may *read* your responses in a browser;
+real protection still comes from
+[authentication and authorization](/learn/web-dev/authentication-and-sessions/) on
+the server.
+
+## Beyond the big three
+
+XSS, CSRF, and CORS are the essentials, but the same mindset guards the rest:
+**parameterised queries** stop SQL injection (never build queries by string
+concatenation — see [the database lesson](/learn/web-dev/backend-and-database/)),
+**HTTPS everywhere** protects data in transit, and **rigorous authorization checks**
+stop one user reaching another's data. Security is a habit applied on every request,
+not a feature you add once.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — encoding user content so it renders as text, not markup, is the core XSS defense." markdown="0">
+  <p class="knowledge-check__q">Quick check: which best prevents XSS when showing a user's comment on a page?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Serving the page over HTTPS instead of HTTP</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Encoding the comment so any markup renders as text, not live HTML</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Trusting it because it came from your own front-end form</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- The core mindset is **trust nothing from the client**: validate input, encode
+  output, and re-check permissions on the server.
+- **XSS** runs an attacker's JavaScript in your users' browsers; defend by
+  **encoding output**, using a **Content Security Policy**, and keeping session
+  cookies **HttpOnly**.
+- **CSRF** tricks a logged-in browser into sending an unintended request; defend with
+  **anti-CSRF tokens** and **`SameSite`** cookies — it targets cookie-based auth.
+- **CORS** is the browser rule that controls which *other* origins may read your
+  responses; it relaxes the same-origin policy and is **not** a server-side access
+  control.
+- **HTTPS protects transit only** — it doesn't stop XSS, CSRF, or broken
+  authorization; those need application-level defenses.
+
+Next up: [caching & CDNs](/learn/web-dev/caching-and-cdns/).

--- a/docs/learn/web-dev/websockets-and-realtime.md
+++ b/docs/learn/web-dev/websockets-and-realtime.md
@@ -1,0 +1,150 @@
+---
+slug: websockets-and-realtime
+title: WebSockets & real-time updates
+description: When request-and-response isn't enough — pushing live data to the browser over WebSockets and server-sent events, the way a live scanner dashboard streams decoded calls the instant they happen.
+keywords: WebSocket, real-time, server push, server-sent events, SSE, polling, long polling, live updates, bidirectional, streaming, scanner dashboard
+level: intermediate
+status: full
+prereq:
+  - client-server-web
+faq:
+  - q: "Why can't a normal HTTP request just wait for new data?"
+    a: "It can — that's **long polling** — but it's a workaround. Plain HTTP is client-initiated: the browser asks and the server answers, then the connection closes. The server has no way to speak first. For a steady stream of updates you'd be opening request after request. A **WebSocket** keeps one connection open in both directions so the server can push the instant something happens."
+  - q: "When should I use server-sent events instead of WebSockets?"
+    a: "Use **server-sent events (SSE)** when data only flows *one way* — server to browser — like a live feed or notifications. SSE is simpler, runs over ordinary HTTP, and reconnects automatically. Reach for a **WebSocket** when you also need the browser to send messages back over the same live channel, such as a chat or an interactive control."
+  - q: "Do real-time connections replace my REST API?"
+    a: "No — they complement it. You still load the initial page and historical data over your [REST API](/learn/web-dev/building-a-rest-api/); the real-time channel carries only the *live changes* on top. A dashboard typically fetches the current state once, then subscribes to a stream for everything new."
+---
+
+# WebSockets & real-time updates
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Ordinary HTTP is **client-initiated** — the browser asks, the server answers — so it
+can't *push*. For live data you either **poll** repeatedly (simple, wasteful), open
+a one-way **server-sent events** stream, or open a **WebSocket**: a single
+long-lived, **bidirectional** connection either side can send over at any time. A
+[live scanner dashboard](/learn/web-dev/gophertrunk-web-dashboard/) is the perfect
+case — decoded calls must appear the instant they're received, not on the next
+refresh. The deeper networking mechanics live in
+[WebSockets & real-time](/learn/networking/websockets-and-realtime/).
+</div>
+
+Everything so far in this module has followed one shape: the browser makes a
+[request](/learn/web-dev/client-server-web/), the server sends a response, done.
+That shape is a poor fit for anything *live* — a chat, a stock ticker, a
+notification, or a scanner dashboard where a call can key up at any moment. This
+lesson covers the ways a server pushes data to the browser, and when each fits.
+
+## The problem: HTTP can't push
+
+Plain HTTP is **client-initiated**. The server never speaks first; it only answers
+what it's asked. That's fine for loading a page, but it means a server that *has*
+new data — a call just decoded, a message just arrived — has no way to tell the
+browser. The browser has to come asking.
+
+For live features that leaves a fundamental gap: how does fresh data reach a page
+that's just sitting there? The three answers below each close the gap differently,
+trading simplicity for immediacy.
+
+## Polling: asking over and over
+
+The simplest approach needs no new technology. The browser just **asks
+repeatedly** — every few seconds, "anything new?" — using ordinary
+[fetch requests](/learn/web-dev/fetching-data/):
+
+```javascript
+setInterval(async () => {
+  const res = await fetch("/api/calls/latest");
+  render(await res.json());
+}, 3000);   // ask every 3 seconds
+```
+
+**Polling** is easy and works everywhere, but it's a blunt instrument. Poll too
+slowly and updates feel laggy; poll too fast and you flood the server with mostly
+empty responses. **Long polling** improves on it — the server holds the request open
+until it *has* something to say, then answers — but you're still reopening
+connections. Polling is a fine default for data that changes slowly; it strains
+under a genuine live stream.
+
+## WebSockets: a two-way open line
+
+A **WebSocket** replaces all that with a single **persistent, bidirectional**
+connection. It starts as a normal HTTP request that asks to "upgrade"; once the
+server agrees, the same connection stays open and **either side can send a message
+at any time** with no new request. The server pushes the instant it has something.
+
+```javascript
+const socket = new WebSocket("wss://example.org/live");
+
+socket.onmessage = (event) => {
+  const call = JSON.parse(event.data);
+  addCallToDashboard(call);   // arrives the moment the server sends it
+};
+
+socket.send(JSON.stringify({ subscribe: "talkgroup-42" }));  // browser can talk back
+```
+
+Note `wss://` — the secure, TLS-wrapped form, the WebSocket equivalent of HTTPS, and
+what you should always use in production. Because the channel is two-way, WebSockets
+suit anything interactive: chat, collaborative editing, games, or a dashboard where
+the browser both receives updates *and* sends controls. The tradeoff is that a
+long-lived connection is more to manage — reconnection, scaling many open sockets —
+than a stateless request. The
+[networking lesson on WebSockets](/learn/networking/websockets-and-realtime/) covers
+the protocol handshake and framing underneath.
+
+## Server-sent events: one-way and simpler
+
+Between polling and full WebSockets sits **server-sent events (SSE)**: a single
+long-lived HTTP response the server streams updates down, **one way only**
+(server → browser). The browser subscribes with `EventSource` and the browser
+handles reconnection for you:
+
+```javascript
+const stream = new EventSource("/api/calls/stream");
+stream.onmessage = (event) => addCallToDashboard(JSON.parse(event.data));
+```
+
+If your data only flows *outward* — a feed, notifications, live decoded calls with
+no controls to send back — SSE is often the better choice: it's simpler, rides
+ordinary HTTP, and reconnects automatically. Choose a WebSocket when you need the
+browser to send over the same live channel too.
+
+## Framing the live scanner dashboard
+
+This is exactly the shape of GopherTrunk's
+[web dashboard](/learn/web-dev/gophertrunk-web-dashboard/). Decoded calls arrive
+whenever radios key up — unpredictably, and potentially many per second on a busy
+system. Polling would either miss the timing or hammer the server; a **push**
+channel lets a call appear on screen the moment the decoder emits it. The dashboard
+loads its current state over the [REST API](/learn/web-dev/building-a-rest-api/),
+then subscribes to a live stream for everything new — the standard pairing of a
+one-time fetch with an ongoing push, which the worked-example lesson builds out in
+full.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a WebSocket keeps one connection open that either side can send over, so the server pushes the instant it has data." markdown="0">
+  <p class="knowledge-check__q">Quick check: what makes a WebSocket different from repeatedly polling with fetch?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It downloads the whole page again each time, but faster</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">It keeps one connection open that either side can send over, so the server can push instantly</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It lets the browser read files directly from the server's disk</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Plain HTTP is **client-initiated** and can't push, so a server with fresh data has
+  no way to reach an idle page on its own.
+- **Polling** (and long polling) asks repeatedly — simple and universal, but wasteful
+  and laggy for a real live stream.
+- A **WebSocket** is a single **persistent, bidirectional** connection either side
+  can send over at any time; use `wss://` for the secure form.
+- **Server-sent events** stream updates **one way** (server → browser) over ordinary
+  HTTP, simpler than WebSockets when the browser doesn't need to talk back.
+- Real-time channels **complement** your REST API: load initial state once, then
+  subscribe for live changes — exactly how a live scanner dashboard shows decoded
+  calls as they happen.
+
+Next up: [web security essentials](/learn/web-dev/web-security-essentials/).

--- a/docs/learn/web-dev/what-a-backend-does.md
+++ b/docs/learn/web-dev/what-a-backend-does.md
@@ -1,0 +1,155 @@
+---
+slug: what-a-backend-does
+title: What a back end does
+description: The work a web app can't trust to the browser — business logic, the database, authentication, secrets, and talking to other services — and why every serious web app needs a server behind the front end doing the things the client can't.
+keywords: back end, server, business logic, database, authentication, secrets, API keys, why a backend, client cannot be trusted, server-side, trusted environment
+level: beginner
+status: full
+prereq:
+  - anatomy-of-a-web-app
+faq:
+  - q: Why can't everything just run in the browser?
+    a: "Because the browser is a place you don't control and can't trust. Users can read all its code, change it, and forge its requests, so any rule enforced only in the browser can be bypassed. Data that must be shared, secrets that must stay hidden, and logic that must be trusted all belong on a server you control — the back end."
+  - q: What is the difference between the front end and the back end?
+    a: "The front end is the part that runs in the user's browser — the HTML, CSS, and JavaScript they can see and interact with. The back end runs on a server you control, out of the user's reach, holding the business logic, the database, secrets, and authentication. The two talk over HTTP, usually through an API."
+  - q: Does a static site have a back end?
+    a: "Not necessarily. A purely static site is just files served as-is, with no server-side logic — this site is largely like that. You need a back end when the app must store shared data, keep secrets, enforce rules, or do work that can't be trusted to the client."
+---
+
+# What a back end does
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+The **back end** is the part of a web app that runs on a **server you control**, out of
+the user's reach. It exists because the **browser can't be trusted**: users can read,
+change, and forge everything the front end does. So the work that must be **trusted or
+hidden** lives on the server — **business logic** and rules, the **database** of shared
+data, **authentication** (who the user is), and **secrets** like [API keys](/learn/building-ai/your-first-api-call/)
+and database passwords. The front end and back end talk over
+[HTTP](/learn/networking/http/), usually through a
+[REST API](/learn/web-dev/building-a-rest-api/).
+</div>
+
+The [anatomy lesson](/learn/web-dev/anatomy-of-a-web-app/) named the pieces of a web
+app; this unit is the server side of it. Before the how — [servers](/learn/web-dev/http-servers-and-routing/),
+[APIs](/learn/web-dev/building-a-rest-api/), [databases](/learn/web-dev/backend-and-database/)
+— comes the *why*: why a browser full of capable JavaScript still isn't enough, and what
+specific jobs a server has to do. The answer comes down to one idea — **the browser is a
+place you don't control** — and everything a back end does follows from it.
+
+## The browser can't be trusted
+
+Everything on the front end runs on the **user's** machine, in **their** browser. That
+means they can:
+
+- **Read all of it** — every line of your JavaScript, every URL it calls, is right there
+  in the developer tools.
+- **Change it** — edit the running code, tweak values, disable your checks.
+- **Forge requests** — send any HTTP request they like to your server, with any data,
+  bypassing your UI entirely.
+
+So any rule you enforce *only* in the browser is a suggestion, not a guarantee. Hide the
+"delete" button and someone can still send the delete request by hand; validate a price
+in JavaScript and someone can submit a different one. This isn't paranoia — it's the
+security model of the web. Anything that has to be **true no matter what the user does**
+must be enforced somewhere the user can't reach: **a server you control.** That server is
+the back end, and it's why it exists at all.
+
+## Business logic and rules
+
+The first job of the back end is to be the **authority** on how the app behaves — the
+**business logic** and rules that must hold regardless of what any client sends. Can this
+user delete this record? Is this booking still available? Does this input actually make
+sense? The server decides, because only the server's decision can be trusted.
+
+The front end may (and should) check the same things too, but only for a **fast, friendly
+experience** — instant feedback, not enforcement. The rule is: **validate on the client
+for UX, enforce on the server for real.** A price, a permission, a limit — if it matters,
+the server is the one that gets the final say, every request, no exceptions. This is the
+same principle the [forms lesson](/learn/web-dev/frontend-frameworks/) hinted at from the
+input side: never trust what arrives from the browser without re-checking it on the
+server.
+
+## Data that has to be shared and durable
+
+The browser's memory lasts as long as the tab. Anything that must **outlive a session**
+or be **shared between users** needs to live somewhere central — a **database** on the
+back end. The list of decoded calls, user accounts, saved settings, an audit log: the
+server owns that data, reads and writes it, and serves it to whichever client asks (and
+is allowed).
+
+```
+Browser (front end)                Server (back end)
+  fetch("/api/calls")  ───────────▶  read the database
+                       ◀───────────  return JSON
+```
+
+This is the durable, shared source of truth. Two users see the same calls because both
+are reading the one database behind the server, not separate copies in their own
+browsers. How the server talks to that database — safely — is its own lesson,
+[the back end &amp; its database](/learn/web-dev/backend-and-database/), and the data layer
+itself is the [Databases module](/learn/databases/).
+
+## Secrets stay on the server
+
+Some values must **never reach the browser**: your database password, a payment
+provider's secret key, the [API keys](/learn/building-ai/your-first-api-call/) for
+services you call. If any of those shipped to the client, every user would have them —
+and could spend, read, or break things on your account. Because the front end is fully
+visible, **there is no such thing as a hidden secret in the browser.**
+
+So secrets live only on the server. When the app needs to, say, call a paid third-party
+API, the **browser asks your back end**, and your back end makes the real call using the
+secret key the user never sees. The server acts as a trusted middleman precisely so the
+secret stays on the trusted side. This is the same "keep the key out of client code" rule
+from [your first API call](/learn/building-ai/your-first-api-call/), applied at the whole
+app level.
+
+## Knowing who the user is
+
+Because [HTTP is stateless](/learn/networking/http/), the server treats every request as
+a stranger unless something proves who's asking. Establishing and checking that identity
+— **authentication** — is a core back-end job: verify a login, issue a session or token,
+and check it on each request before doing anything sensitive. And once it knows *who* you
+are, it decides *what you're allowed to do* — authorization. Both must happen on the
+server, for the same reason as everything else here: the browser can claim to be anyone,
+so only the server's verification counts. This is a whole unit on its own, starting with
+[authentication &amp; sessions](/learn/web-dev/authentication-and-sessions/).
+
+## Talking to the outside world
+
+Finally, the back end is where the app **integrates with other systems** the browser
+shouldn't touch directly: sending email, charging a card, calling internal services,
+running a scheduled job. These need secrets, need to be trusted, or simply don't belong
+in a user's tab. The pattern is consistent — the front end makes a simple request to
+*your* server, and your server does the sensitive, trusted work behind it. In
+GopherTrunk's own [dashboard](/architecture.html), the back end is what reads the live
+decode pipeline and exposes it as an API the browser can safely consume — the front end
+never touches the radio directly.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the browser is fully visible and editable by the user, so secrets and trusted rules must live on a server you control." markdown="0">
+  <p class="knowledge-check__q">Quick check: why can't a secret API key be kept safe in front-end JavaScript?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Front-end code runs too slowly to protect a key in time</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The browser is fully visible to the user, so any key shipped to it can be read</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Browsers refuse to store strings longer than a few characters</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- The **back end** runs on a **server you control** because the **browser can't be
+  trusted** — users can read, change, and forge everything the front end does.
+- **Business logic and rules** must be **enforced on the server**; client-side checks are
+  for UX only, never for security.
+- **Shared, durable data** lives in a **database** on the back end, giving every user one
+  source of truth.
+- **Secrets** — database passwords, API keys — stay on the server and never ship to the
+  browser; the server acts as a trusted middleman.
+- **Authentication and authorization** happen on the server, since the browser can claim
+  to be anyone.
+- The back end also **integrates with other systems** — email, payments, internal
+  services — that don't belong in a user's tab.
+
+Next up: [HTTP servers &amp; routing](/learn/web-dev/http-servers-and-routing/).

--- a/docs/learn/web-dev/what-is-web-development.md
+++ b/docs/learn/web-dev/what-is-web-development.md
@@ -1,0 +1,140 @@
+---
+slug: what-is-web-development
+title: What web development is
+description: A plain-language map of web development — the front end you see in the browser, the back end that runs on a server, and full-stack work that spans both — plus what actually happens in the seconds between typing a URL and seeing a page.
+keywords: web development, front end, back end, full stack, browser, server, HTML CSS JavaScript, what happens when you visit a website, web app, client and server
+level: beginner
+status: full
+faq:
+  - q: What is the difference between front end and back end?
+    a: "The **front end** is everything that runs in the browser and that a user sees and touches — the HTML, CSS, and JavaScript that make up the page. The **back end** is the code that runs on a server the user never sees: it stores data, enforces rules, and answers requests. A **full-stack** developer works across both."
+  - q: Do I need to know how to code to understand web development?
+    a: "No. This lesson and the next few build the mental model with no code at all. You'll meet HTML, CSS, and JavaScript later in the module, but the ideas — client and server, request and response, front end and back end — come first and stand on their own."
+  - q: Is web development the same as building a website?
+    a: "A simple website is one point on a wide spectrum. Web development ranges from a single static page served as a file, up to a full **web app** with logins, live data, and a database behind it. The tools and ideas scale across that whole range, which is why one module can cover both."
+---
+
+# What web development is
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Web development is building the software that runs on the web. It splits into a
+**front end** — the part that runs in your **browser** and that you see and click
+— and a **back end** — the part that runs on a **server** you never see and that
+stores data and enforces rules. Someone who works across both is **full-stack**.
+Underneath every page is one simple rhythm: the browser sends a **request** and a
+server sends back a **response**. This lesson draws the map; the rest of the
+module fills it in.
+</div>
+
+The web is where most software meets its users. When you check a bank balance,
+book a flight, or watch a scanner dashboard update in real time, you are using a
+web application — and someone built it. This module is a working developer's tour
+of how that gets done. It is not a tutorial for one framework; it is the set of
+durable ideas that outlast any framework, starting here with the plainest
+question of all: what *is* web development?
+
+## The front end and the back end
+
+Every web app has two halves, and almost everything in web development hangs off
+the difference between them.
+
+The **front end** is the part that lives in your **browser**. It is the page you
+look at — the text, images, buttons, forms, and animations — and the code that
+makes them respond when you click or type. Front-end work is built from three
+languages you'll meet soon: **HTML** for structure, **CSS** for appearance, and
+**JavaScript** for behaviour. Because it runs on the user's own device, the front
+end is sometimes called the **client** side.
+
+The **back end** is the part the user never sees. It runs on a **server** — a
+computer, usually in a data centre, that waits for requests and answers them. The
+back end holds the data (your account, your saved items, everyone else's too),
+enforces the rules (who is allowed to do what), and does the work that can't
+safely happen on a stranger's device. It's written in languages like Go, Python,
+JavaScript, Ruby, or Java, and it talks to a **database** behind it.
+
+A developer who works on the browser side is a **front-end developer**; one who
+works on the server side is a **back-end developer**; and one comfortable across
+both is **full-stack**. These are roles and emphases, not walls — the ideas in
+this module are worth knowing wherever you sit.
+
+## Client and server
+
+The reason for the split is a single, load-bearing idea: the web is a
+conversation between a **client** and a **server**.
+
+- The **client** is the program making the request — almost always a browser, but
+  it could be a mobile app or a script.
+- The **server** is the program that receives the request and sends back a
+  response.
+
+You ask; it answers. That request-and-response rhythm is the heartbeat of the
+whole web, and we give it a lesson of its own in
+[the client-server web](/learn/web-dev/client-server-web/). For now, hold onto the
+shape: the front end is the client, the back end is the server, and everything
+that happens between them is one side asking and the other answering.
+
+## What happens when you visit a page
+
+Put the pieces together by following one ordinary action — typing an address and
+hitting Enter. In the second or two before the page appears, a surprising amount
+happens:
+
+1. The browser figures out **which server** the address belongs to and opens a
+   connection to it.
+2. It sends a **request** for the page.
+3. The server runs its **back-end** code — perhaps looking things up in a database
+   — and sends back a **response**: the HTML for the page, plus its CSS and
+   JavaScript.
+4. The browser **renders** that HTML and CSS into the visual page, and runs the
+   JavaScript to make it interactive.
+5. As you click around, the front end may send **more requests** in the
+   background for fresh data, updating the page without a full reload.
+
+Every step there is a lesson later in this module. [How the browser
+works](/learn/web-dev/how-the-browser-works/) unpacks step 4; the plumbing of
+steps 1–3 is the domain of the networking module, especially
+[how a web request works](/learn/networking/how-a-web-request-works/) and
+[HTTP](/learn/networking/http/), the protocol the request and response are
+written in.
+
+## A spectrum, not a single thing
+
+"A website" and "a web app" sit at different points on one spectrum. At the
+simple end, a page can be a plain **static** file the server hands over
+unchanged — this very learning site is built that way. At the rich end, a page is
+assembled **dynamically** for each visitor, with logins, live data, and a database
+doing real work behind it. Most of what you use daily lives somewhere in between.
+
+The good news is that the same core ideas carry across the whole range. A static
+page and a sprawling web app both come down to a client requesting and a server
+responding; they differ in how much happens on each side, not in the shape of the
+conversation. We map that spectrum directly in
+[static vs. dynamic sites](/learn/web-dev/static-vs-dynamic/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the back end runs on a server the user never sees, holding data and rules; the front end is the browser side." markdown="0">
+  <p class="knowledge-check__q">Quick check: which part of a web app runs on a server the user never directly sees?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">The front end — the HTML and CSS in the browser</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The back end — the code that stores data and enforces rules</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Neither — a web app runs entirely in the browser</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Web development** is building the software that runs on the web, from a single
+  page to a full application.
+- The **front end** runs in the **browser** (the client) and is what the user sees
+  and interacts with; the **back end** runs on a **server** and holds the data and
+  rules.
+- A **full-stack** developer works across both; the roles are emphases, not walls.
+- The web's underlying rhythm is **request and response** — the client asks, the
+  server answers.
+- Visiting a page sets off a chain: resolve the server, send a request, run
+  back-end code, return a response, and **render** it in the browser.
+- Sites range from **static** files to **dynamic** apps, but the same client-server
+  ideas carry across the whole spectrum.
+
+Next up: [How the browser works](/learn/web-dev/how-the-browser-works/).


### PR DESCRIPTION
Add three full-length learning modules to the /learn section, matching the
existing modules' four-level structure (path → module → unit → lesson) and
per-lesson house style (front-matter, key-takeaways box, sections, one
knowledge-check quiz, recap, and prev/next chain).

- Databases & Data (databases): 6 units, 32 lessons + glossary — the
  relational model and SQL, data design, NoSQL/vector stores, using a
  database from code (incl. Go), and running one in production.
- Web Development (web-dev): 6 units, 32 lessons + glossary — the browser and
  client-server web, HTML/CSS/JS and front-end frameworks, back-end HTTP/REST
  and databases, auth/real-time/security, and shipping.
- Scanning & Monitoring (scanning): 6 units, 31 lessons + glossary — the
  operator's craft of building a station, finding and identifying systems,
  following trunked calls, and logging/monitoring with a scanner or SDR.

Wire the new modules into the learning paths in _data/learn.yml
(software-engineering + ai-development gain databases and web-dev;
trunked-radio + rf-software-dev gain scanning) and add them to the Learn nav
group in _data/nav.yml. llms.txt and the module hubs regenerate from
learn.yml automatically. Each new module uses GopherTrunk's own domain
(decoded calls, the dashboard, a monitoring post) as its worked example.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QxjeGuKiJek9Fxq8JBxPcf