### PR TITLE
dmr: decode and publish talker alias from the voice channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **DMR talker alias decode.** A DMR radio's display name — carried in the
+  voice superframe's embedded Link Control as a header (FLCO 0x04) plus up to
+  three continuation blocks (0x05-0x07) — is now reassembled and published as a
+  `talker.alias` event, the same surface P25 already uses, so the affiliation
+  tracker, decoded-message log, API, and TUI attribute the name to the calling
+  radio on DMR too. All four data formats (7-bit packed, 8-bit ISO 8859-1,
+  UTF-8, UTF-16BE) decode; the header text-bit boundary follows ETSI
+  TS 102 361-2 §7.2.18 cross-checked against the ok-dmrlib reference and is a
+  working model pending on-air capture validation.
 - **Event API reference docs (`docs/api-events.md`).** A stable-contract reference
   for the real-time telemetry surface: the SSE (`/api/v1/events`) and WebSocket
   (`/api/v1/events/ws`) transports and shared event envelope, the full JSON payload

--- a/internal/radio/dmr/emb.go
+++ b/internal/radio/dmr/emb.go
@@ -105,16 +105,27 @@ func AssembleEmbeddedField(e EMB, frag []byte) []byte {
 // any fragment is the wrong length, the BPTC/CRC check fails, or the FLC
 // cannot be parsed.
 func ReassembleEmbeddedLC(frags [4][]byte) (FLC, bool) {
+	_, flc, ok := ReassembleEmbeddedLCInfo(frags)
+	return flc, ok
+}
+
+// ReassembleEmbeddedLCInfo is ReassembleEmbeddedLC but also returns the
+// raw 9-octet recovered info block. Callers that need the payload octets
+// verbatim — e.g. the talker-alias fragment parser, whose octets 2..8 are
+// alias text rather than the ServiceOptions/address fields ParseFLC
+// assumes — use this to read the bits before the generic FLC view
+// reinterprets them.
+func ReassembleEmbeddedLCInfo(frags [4][]byte) ([]byte, FLC, bool) {
 	channel := make([]byte, 0, framing.EmbChannelBits)
 	for _, f := range frags {
 		if len(f) != framing.EmbeddedFragmentBits {
-			return FLC{}, false
+			return nil, FLC{}, false
 		}
 		channel = append(channel, f...)
 	}
 	lcBits, corrected := framing.DecodeEmbeddedLC(channel)
 	if corrected < 0 {
-		return FLC{}, false
+		return nil, FLC{}, false
 	}
 	info := make([]byte, framing.EmbLCBits/8) // 9 octets
 	for i := 0; i < framing.EmbLCBits; i++ {
@@ -124,7 +135,7 @@ func ReassembleEmbeddedLC(frags [4][]byte) (FLC, bool) {
 	}
 	flc, err := ParseFLC(info)
 	if err != nil {
-		return FLC{}, false
+		return nil, FLC{}, false
 	}
-	return flc, true
+	return info, flc, true
 }

--- a/internal/radio/dmr/emb_alias_test.go
+++ b/internal/radio/dmr/emb_alias_test.go
@@ -1,0 +1,51 @@
+package dmr
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
+
+// embeddedFragsFromInfo runs a 9-octet info block through the real
+// embedded-LC BPTC encoder and splits it into the four 32-bit fragments
+// bursts B–E carry — the inverse of ReassembleEmbeddedLCInfo.
+func embeddedFragsFromInfo(t *testing.T, info []byte) [4][]byte {
+	t.Helper()
+	if len(info) < framing.EmbLCBits/8 {
+		t.Fatalf("info too short: %d octets", len(info))
+	}
+	lc := make([]byte, framing.EmbLCBits)
+	for i := 0; i < framing.EmbLCBits; i++ {
+		lc[i] = (info[i/8] >> uint(7-(i%8))) & 1
+	}
+	ch := framing.EncodeEmbeddedLC(lc)
+	var frags [4][]byte
+	for i := range frags {
+		frags[i] = ch[i*framing.EmbeddedFragmentBits : (i+1)*framing.EmbeddedFragmentBits]
+	}
+	return frags
+}
+
+// TestReassembleEmbeddedLCInfoCarriesAliasOctets confirms the raw-info
+// accessor survives the BPTC round-trip and that ParseTalkerAliasFragment
+// recovers a talker-alias header from the recovered octets — the octets
+// the generic FLC view would misread as address fields.
+func TestReassembleEmbeddedLCInfoCarriesAliasOctets(t *testing.T) {
+	header := AssembleTalkerAliasFragments(TalkerAliasFormatUTF8, "Truck 349")[0]
+	frags := embeddedFragsFromInfo(t, header)
+
+	info, flc, ok := ReassembleEmbeddedLCInfo(frags)
+	if !ok {
+		t.Fatal("ReassembleEmbeddedLCInfo failed on a clean alias header")
+	}
+	if flc.FLCO != FLCOTalkerAlias {
+		t.Fatalf("recovered FLCO: got %v want TalkerAlias header", flc.FLCO)
+	}
+	frag, ok := ParseTalkerAliasFragment(info)
+	if !ok || !frag.Header {
+		t.Fatalf("alias header not recovered from raw info: ok=%v hdr=%v", ok, frag.Header)
+	}
+	if frag.Length != 9 || frag.Format != TalkerAliasFormatUTF8 {
+		t.Fatalf("recovered header fields wrong: len=%d fmt=%d", frag.Length, frag.Format)
+	}
+}

--- a/internal/radio/dmr/flc.go
+++ b/internal/radio/dmr/flc.go
@@ -14,7 +14,10 @@ type FLCO uint8
 const (
 	FLCOGroupVoiceUser  FLCO = 0x00 // Group voice channel user
 	FLCOUnitToUnitVoice FLCO = 0x03 // Unit-to-Unit voice channel user
-	FLCOTalkerAlias     FLCO = 0x04 // Talker alias header
+	FLCOTalkerAlias     FLCO = 0x04 // Talker alias header (block 0)
+	FLCOTalkerAlias1    FLCO = 0x05 // Talker alias block 1
+	FLCOTalkerAlias2    FLCO = 0x06 // Talker alias block 2
+	FLCOTalkerAlias3    FLCO = 0x07 // Talker alias block 3
 	FLCOGPS             FLCO = 0x08 // GPS info
 	FLCOTerminator      FLCO = 0x30 // Terminator
 )
@@ -26,7 +29,13 @@ func (o FLCO) String() string {
 	case FLCOUnitToUnitVoice:
 		return "UnitToUnitVoiceChannelUser"
 	case FLCOTalkerAlias:
-		return "TalkerAlias"
+		return "TalkerAliasHeader"
+	case FLCOTalkerAlias1:
+		return "TalkerAliasBlock1"
+	case FLCOTalkerAlias2:
+		return "TalkerAliasBlock2"
+	case FLCOTalkerAlias3:
+		return "TalkerAliasBlock3"
 	case FLCOGPS:
 		return "GPSInfo"
 	case FLCOTerminator:

--- a/internal/radio/dmr/talker_alias.go
+++ b/internal/radio/dmr/talker_alias.go
@@ -1,0 +1,358 @@
+package dmr
+
+import (
+	"strings"
+	"sync"
+	"time"
+	"unicode/utf16"
+	"unicode/utf8"
+)
+
+// DMR talker-alias reassembly. A talker alias — a radio's human-readable
+// display name — is carried in the voice superframe's embedded Link
+// Control as a short numbered sequence of Full LC PDUs: a header
+// (FLCOTalkerAlias / 0x04) that declares the text encoding and total
+// length, followed by up to three blocks (0x05, 0x06, 0x07) that carry
+// the remaining characters. TalkerAliasAssembler buffers the fragments
+// per source radio and emits the completed name once enough blocks have
+// arrived to cover the declared length.
+//
+// This mirrors the P25 Phase 1 assembler
+// (internal/radio/p25/phase1/talker_alias.go): same per-source buffering,
+// staleness eviction, and printable-only cleanup. The DMR wire layout
+// differs (a header-declared length rather than a per-fragment block
+// count), so the reassembly bookkeeping is DMR-specific.
+//
+// Wire layout (the 72-bit / 9-octet embedded-LC info block, bit indices
+// MSB-first as recovered by ReassembleEmbeddedLCInfo), per ETSI
+// TS 102 361-2 §7.2.18 and cross-checked against the OK-DMR ok-dmrlib
+// reference decoder (okdmr/dmrlib Full Link Control):
+//
+//	Header (FLCO 0x04):
+//	  bits 16..17 : Talker Alias Data Format (2 bits)
+//	  bits 18..22 : Talker Alias length — total character count (5 bits, 0..31)
+//	  bit  23     : reserved / format-defined MSB (not treated as text here)
+//	  bits 24..71 : first 48 bits (6 octets) of alias text
+//	Blocks (FLCO 0x05/0x06/0x07):
+//	  bits 16..71 : 56 bits (7 octets) of alias text
+//
+// Like the DMR embedded-LC EMB/CRC constants (see emb.go / docs/status.md),
+// the exact bit boundary of the header's text field is a working model
+// pending validation against a real capture — the 48-bit header / 56-bit
+// block split matches ok-dmrlib; a capture that decodes to garbage should
+// re-check bit 23's inclusion first.
+
+// TalkerAliasFormat is the 2-bit Talker Alias Data Format from the header.
+type TalkerAliasFormat uint8
+
+// Talker Alias Data Format values per ETSI TS 102 361-2 §7.2.18.
+const (
+	TalkerAliasFormat7Bit  TalkerAliasFormat = 0 // 7-bit packed characters
+	TalkerAliasFormat8Bit  TalkerAliasFormat = 1 // 8-bit ISO 8859-1
+	TalkerAliasFormatUTF8  TalkerAliasFormat = 2 // UTF-8
+	TalkerAliasFormatUTF16 TalkerAliasFormat = 3 // UTF-16BE
+)
+
+// aliasHeaderTextOctets is the count of alias-text octets carried in the
+// header PDU (bits 24..71); aliasBlockTextOctets is the count in each of
+// the three continuation blocks (bits 16..71).
+const (
+	aliasHeaderTextOctets = 6
+	aliasBlockTextOctets  = 7
+)
+
+// TalkerAliasFragment is one parsed piece of a talker alias: the header
+// (Header true, carrying Format and Length) or a continuation block. Text
+// holds the fragment's raw alias octets.
+type TalkerAliasFragment struct {
+	Header bool
+	Index  uint8 // 0 for the header, 1..3 for blocks
+	Format TalkerAliasFormat
+	Length uint8 // total character count, valid only when Header
+	Text   []byte
+}
+
+// TalkerAliasFLCO reports whether an FLCO is one of the four talker-alias
+// opcodes (header 0x04 or block 0x05/0x06/0x07).
+func TalkerAliasFLCO(o FLCO) bool {
+	return o == FLCOTalkerAlias || o == FLCOTalkerAlias1 ||
+		o == FLCOTalkerAlias2 || o == FLCOTalkerAlias3
+}
+
+// ParseTalkerAliasFragment decodes a talker-alias fragment from the
+// leading 9 octets of an embedded-LC info block whose FLCO is a
+// talker-alias opcode. It returns ok=false for a non-alias FLCO or a
+// short buffer.
+func ParseTalkerAliasFragment(info []byte) (TalkerAliasFragment, bool) {
+	if len(info) < 9 {
+		return TalkerAliasFragment{}, false
+	}
+	flco := FLCO(info[0] & 0x3F)
+	if !TalkerAliasFLCO(flco) {
+		return TalkerAliasFragment{}, false
+	}
+	if flco == FLCOTalkerAlias {
+		return TalkerAliasFragment{
+			Header: true,
+			Index:  0,
+			Format: TalkerAliasFormat((info[2] >> 6) & 0x03),
+			Length: (info[2] >> 1) & 0x1F,
+			Text:   append([]byte(nil), info[3:3+aliasHeaderTextOctets]...),
+		}, true
+	}
+	return TalkerAliasFragment{
+		Index: uint8(flco - FLCOTalkerAlias), // 0x05→1, 0x06→2, 0x07→3
+		Text:  append([]byte(nil), info[2:2+aliasBlockTextOctets]...),
+	}, true
+}
+
+// AssembleTalkerAliasFragments packs an alias string into the ordered
+// sequence of 9-octet embedded-LC info blocks (header + as many blocks as
+// the length needs) for the given format. It is the inverse of
+// ParseTalkerAliasFragment / TalkerAliasAssembler and is used to build
+// synthetic test vectors. Length is clamped to the 5-bit header field.
+func AssembleTalkerAliasFragments(format TalkerAliasFormat, alias string) [][]byte {
+	text, charLen := encodeAliasText(format, alias)
+	if charLen > 0x1F {
+		charLen = 0x1F
+	}
+	// Distribute text octets: 6 into the header, 7 into each block.
+	var out [][]byte
+	header := make([]byte, 9)
+	header[0] = byte(FLCOTalkerAlias)
+	header[2] = byte(format)<<6 | byte(charLen&0x1F)<<1
+	n := copy(header[3:9], text)
+	out = append(out, header)
+	text = text[n:]
+	for idx := 1; len(text) > 0 && idx <= 3; idx++ {
+		blk := make([]byte, 9)
+		blk[0] = byte(FLCOTalkerAlias) + byte(idx) // 0x05/0x06/0x07
+		m := copy(blk[2:9], text)
+		text = text[m:]
+		out = append(out, blk)
+	}
+	return out
+}
+
+// encodeAliasText renders an alias string to its on-air octet stream for
+// the given format and returns the octets plus the character count that
+// belongs in the header Length field.
+func encodeAliasText(format TalkerAliasFormat, alias string) ([]byte, uint8) {
+	switch format {
+	case TalkerAliasFormat7Bit:
+		runes := []rune(alias)
+		bits := make([]byte, 0, len(runes)*7)
+		for _, r := range runes {
+			c := byte(r) & 0x7F
+			for b := 6; b >= 0; b-- {
+				bits = append(bits, (c>>uint(b))&1)
+			}
+		}
+		return packBits(bits), uint8(len(runes))
+	case TalkerAliasFormatUTF16:
+		u := utf16.Encode([]rune(alias))
+		out := make([]byte, 0, len(u)*2)
+		for _, w := range u {
+			out = append(out, byte(w>>8), byte(w))
+		}
+		return out, uint8(len(u))
+	default: // 8-bit ISO 8859-1 and UTF-8 are byte streams
+		b := []byte(alias)
+		if format == TalkerAliasFormat8Bit {
+			return b, uint8(len(alias)) // ISO-8859-1: 1 octet == 1 char
+		}
+		return b, uint8(utf8.RuneCountInString(alias))
+	}
+}
+
+// packBits packs an MSB-first 0/1 bit slice into octets, zero-padding the
+// final octet.
+func packBits(bits []byte) []byte {
+	out := make([]byte, (len(bits)+7)/8)
+	for i, b := range bits {
+		if b&1 != 0 {
+			out[i>>3] |= 1 << uint(7-(i&7))
+		}
+	}
+	return out
+}
+
+// decodeAliasText renders a reassembled alias octet stream back to a
+// string for the given format, truncated to length characters.
+func decodeAliasText(format TalkerAliasFormat, text []byte, length uint8) string {
+	switch format {
+	case TalkerAliasFormat7Bit:
+		var sb []rune
+		for i := 0; i < int(length); i++ {
+			bit := i * 7
+			var c byte
+			for b := 0; b < 7; b++ {
+				idx := bit + b
+				if idx/8 >= len(text) {
+					break
+				}
+				if text[idx/8]&(1<<uint(7-(idx%8))) != 0 {
+					c |= 1 << uint(6-b)
+				}
+			}
+			sb = append(sb, rune(c))
+		}
+		return string(sb)
+	case TalkerAliasFormatUTF16:
+		u := make([]uint16, 0, len(text)/2)
+		for i := 0; i+1 < len(text); i += 2 {
+			u = append(u, uint16(text[i])<<8|uint16(text[i+1]))
+		}
+		r := utf16.Decode(u)
+		if int(length) < len(r) {
+			r = r[:length]
+		}
+		return string(r)
+	case TalkerAliasFormat8Bit:
+		r := make([]rune, 0, len(text))
+		for _, b := range text { // ISO 8859-1: octet == code point
+			r = append(r, rune(b))
+		}
+		if int(length) < len(r) {
+			r = r[:length]
+		}
+		return string(r)
+	default: // UTF-8
+		s := string(text)
+		if !utf8.ValidString(s) {
+			s = strings.ToValidUTF8(s, "")
+		}
+		r := []rune(s)
+		if int(length) < len(r) {
+			r = r[:length]
+		}
+		return string(r)
+	}
+}
+
+// Talker-alias assembler bounds (mirrors the P25 assembler).
+const (
+	dmrAliasStaleAfter = 10 * time.Second
+	dmrAliasMaxPending = 64
+)
+
+type dmrAliasBuf struct {
+	format  TalkerAliasFormat
+	length  uint8
+	haveHdr bool
+	blocks  map[uint8][]byte // index (0 header .. 3) → text octets
+	updated time.Time
+}
+
+// TalkerAliasAssembler reassembles DMR talker-alias fragments per source
+// radio. Because the embedded-LC fragments carry no source address, the
+// caller supplies the active call's source RID as the buffering key. It
+// is safe for concurrent use; construct one per voice-decode chain.
+type TalkerAliasAssembler struct {
+	now     func() time.Time
+	mu      sync.Mutex
+	pending map[uint32]*dmrAliasBuf
+}
+
+// NewTalkerAliasAssembler returns a ready assembler. now is injectable
+// for tests; nil defaults to time.Now.
+func NewTalkerAliasAssembler(now func() time.Time) *TalkerAliasAssembler {
+	if now == nil {
+		now = time.Now
+	}
+	return &TalkerAliasAssembler{now: now, pending: make(map[uint32]*dmrAliasBuf)}
+}
+
+// Add feeds one fragment (keyed to the active call's source RID) to the
+// assembler. When the fragment set covers the header-declared length it
+// returns (alias, true) and forgets the source; otherwise ("", false).
+// Fragments may arrive in any order. A stray block before its header is
+// buffered until the header lands.
+func (a *TalkerAliasAssembler) Add(sourceID uint32, f TalkerAliasFragment) (string, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	a.evictStaleLocked()
+	buf := a.pending[sourceID]
+	if buf == nil {
+		if len(a.pending) >= dmrAliasMaxPending {
+			a.evictOldestLocked()
+		}
+		buf = &dmrAliasBuf{blocks: make(map[uint8][]byte)}
+		a.pending[sourceID] = buf
+	}
+	if f.Header {
+		buf.haveHdr = true
+		buf.format = f.Format
+		buf.length = f.Length
+	}
+	buf.blocks[f.Index] = append([]byte(nil), f.Text...)
+	buf.updated = a.now()
+
+	alias, done := assembleAlias(buf)
+	if !done {
+		return "", false
+	}
+	delete(a.pending, sourceID)
+	return alias, true
+}
+
+// assembleAlias concatenates the header + contiguous blocks and, once the
+// available text covers the declared character length, decodes it.
+func assembleAlias(buf *dmrAliasBuf) (string, bool) {
+	if !buf.haveHdr || buf.length == 0 {
+		return "", false
+	}
+	need := neededTextOctets(buf.format, buf.length)
+	var text []byte
+	for idx := uint8(0); ; idx++ {
+		blk, ok := buf.blocks[idx]
+		if !ok {
+			break
+		}
+		text = append(text, blk...)
+		if len(text) >= need {
+			break
+		}
+	}
+	if len(text) < need {
+		return "", false
+	}
+	return decodeAliasText(buf.format, text, buf.length), true
+}
+
+// neededTextOctets is the minimum count of alias-text octets required to
+// hold length characters in the given format.
+func neededTextOctets(format TalkerAliasFormat, length uint8) int {
+	switch format {
+	case TalkerAliasFormat7Bit:
+		return (int(length)*7 + 7) / 8
+	case TalkerAliasFormatUTF16:
+		return int(length) * 2
+	default: // 8-bit / UTF-8: at least one octet per character
+		return int(length)
+	}
+}
+
+func (a *TalkerAliasAssembler) evictStaleLocked() {
+	cutoff := a.now().Add(-dmrAliasStaleAfter)
+	for src, buf := range a.pending {
+		if buf.updated.Before(cutoff) {
+			delete(a.pending, src)
+		}
+	}
+}
+
+func (a *TalkerAliasAssembler) evictOldestLocked() {
+	var oldestSrc uint32
+	var oldest time.Time
+	first := true
+	for src, buf := range a.pending {
+		if first || buf.updated.Before(oldest) {
+			oldestSrc, oldest, first = src, buf.updated, false
+		}
+	}
+	if !first {
+		delete(a.pending, oldestSrc)
+	}
+}

--- a/internal/radio/dmr/talker_alias_test.go
+++ b/internal/radio/dmr/talker_alias_test.go
@@ -1,0 +1,124 @@
+package dmr
+
+import (
+	"testing"
+	"time"
+)
+
+// fixedNow returns a now() that advances by a fixed step on each call so
+// staleness eviction is deterministic in tests.
+func fixedNow(start time.Time, step time.Duration) func() time.Time {
+	t := start
+	return func() time.Time {
+		cur := t
+		t = t.Add(step)
+		return cur
+	}
+}
+
+func TestTalkerAliasRoundTripFormats(t *testing.T) {
+	cases := []struct {
+		name   string
+		format TalkerAliasFormat
+		alias  string
+	}{
+		{"7bit-short", TalkerAliasFormat7Bit, "KD2ABC"},
+		{"7bit-multiblock", TalkerAliasFormat7Bit, "DISPATCH-CENTRAL-01"},
+		{"8bit-iso", TalkerAliasFormat8Bit, "Engine 12"},
+		{"utf8", TalkerAliasFormatUTF8, "Café Unit"},
+		{"utf16", TalkerAliasFormatUTF16, "Rescue-7"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			frags := AssembleTalkerAliasFragments(tc.format, tc.alias)
+			if len(frags) == 0 {
+				t.Fatal("no fragments produced")
+			}
+			a := NewTalkerAliasAssembler(fixedNow(time.Unix(0, 0), time.Millisecond))
+			const src = uint32(0x1234)
+			var got string
+			var done bool
+			for _, info := range frags {
+				f, ok := ParseTalkerAliasFragment(info)
+				if !ok {
+					t.Fatalf("ParseTalkerAliasFragment rejected a fragment: %x", info)
+				}
+				got, done = a.Add(src, f)
+			}
+			if !done {
+				t.Fatalf("alias never completed after %d fragments", len(frags))
+			}
+			if got != tc.alias {
+				t.Fatalf("round-trip mismatch: got %q want %q", got, tc.alias)
+			}
+		})
+	}
+}
+
+func TestTalkerAliasHeaderFieldExtraction(t *testing.T) {
+	// A synthetic header: FLCO 0x04, format UTF-8 (2), length 9.
+	frags := AssembleTalkerAliasFragments(TalkerAliasFormatUTF8, "Truck 349")
+	f, ok := ParseTalkerAliasFragment(frags[0])
+	if !ok || !f.Header {
+		t.Fatalf("header fragment not parsed as header: ok=%v hdr=%v", ok, f.Header)
+	}
+	if f.Format != TalkerAliasFormatUTF8 {
+		t.Errorf("format: got %d want %d", f.Format, TalkerAliasFormatUTF8)
+	}
+	if f.Length != 9 {
+		t.Errorf("length: got %d want 9", f.Length)
+	}
+}
+
+func TestTalkerAliasRejectsNonAliasFLCO(t *testing.T) {
+	info := AssembleFLC(FLC{FLCO: FLCOGroupVoiceUser, DstAddr: 100, SrcAddr: 200})
+	if _, ok := ParseTalkerAliasFragment(info); ok {
+		t.Fatal("group-voice FLCO wrongly parsed as talker alias")
+	}
+}
+
+func TestTalkerAliasOutOfOrderReassembly(t *testing.T) {
+	frags := AssembleTalkerAliasFragments(TalkerAliasFormat7Bit, "DISPATCH-CENTRAL-01")
+	if len(frags) < 3 {
+		t.Fatalf("expected a multi-block alias, got %d fragments", len(frags))
+	}
+	a := NewTalkerAliasAssembler(fixedNow(time.Unix(0, 0), time.Millisecond))
+	const src = uint32(0x55)
+	// Feed blocks before the header, and the header last.
+	order := append([]int{}, indicesReversed(len(frags))...)
+	var got string
+	var done bool
+	for _, i := range order {
+		f, ok := ParseTalkerAliasFragment(frags[i])
+		if !ok {
+			t.Fatalf("fragment %d rejected", i)
+		}
+		got, done = a.Add(src, f)
+	}
+	if !done {
+		t.Fatal("alias never completed with out-of-order fragments")
+	}
+	if got != "DISPATCH-CENTRAL-01" {
+		t.Fatalf("out-of-order mismatch: got %q", got)
+	}
+}
+
+func TestTalkerAliasIncompleteStaysPending(t *testing.T) {
+	frags := AssembleTalkerAliasFragments(TalkerAliasFormat7Bit, "DISPATCH-CENTRAL-01")
+	a := NewTalkerAliasAssembler(fixedNow(time.Unix(0, 0), time.Millisecond))
+	const src = uint32(0x99)
+	// Feed only the header — the declared length needs more blocks.
+	f, _ := ParseTalkerAliasFragment(frags[0])
+	if _, done := a.Add(src, f); done {
+		t.Fatal("alias completed from the header alone")
+	}
+}
+
+// indicesReversed returns [n-1, n-2, ..., 0].
+func indicesReversed(n int) []int {
+	out := make([]int, n)
+	for i := 0; i < n; i++ {
+		out[i] = n - 1 - i
+	}
+	return out
+}

--- a/internal/radio/dmr/voice/superframe.go
+++ b/internal/radio/dmr/voice/superframe.go
@@ -45,6 +45,14 @@ type VoiceSuperframe struct {
 	// capture-pending FEC posture.
 	HasRC bool
 	RC    dmr.ReverseChannel
+	// HasTalkerAlias reports that this superframe's embedded Full LC was a
+	// talker-alias header or block (FLCO 0x04-0x07). TalkerAlias then holds
+	// the parsed fragment; the voice chain feeds it to a
+	// dmr.TalkerAliasAssembler to reassemble the radio's display name across
+	// the header + block superframes. Independent of HasLC's group-voice
+	// interpretation, which does not apply to an alias LC.
+	HasTalkerAlias bool
+	TalkerAlias    dmr.TalkerAliasFragment
 }
 
 // voiceSyncs are the sync words that frame burst A of a voice
@@ -324,9 +332,17 @@ func (d *Decoder) sliceAt(start, step int, syncName string) VoiceSuperframe {
 			}
 		}
 	}
-	if lc, ok := dmr.ReassembleEmbeddedLC(frags); ok {
+	if info, lc, ok := dmr.ReassembleEmbeddedLCInfo(frags); ok {
 		sf.HasLC = true
 		sf.LC = lc
+		// A talker-alias header/block reuses the Full LC framing but its
+		// octets 2..8 are alias text, not the group/source addresses the
+		// generic LC view reads. Surface the parsed fragment so the voice
+		// chain can reassemble the display name across superframes.
+		if frag, ok := dmr.ParseTalkerAliasFragment(info); ok {
+			sf.HasTalkerAlias = true
+			sf.TalkerAlias = frag
+		}
 	}
 	return sf
 }

--- a/internal/radio/dmr/voice/superframe_alias_test.go
+++ b/internal/radio/dmr/voice/superframe_alias_test.go
@@ -1,0 +1,66 @@
+package voice
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
+
+// aliasFragmentsFromInfo is lcFragments for a raw 9-octet talker-alias
+// info block (whose octets 2..8 are alias text, not FLC address fields).
+func aliasFragmentsFromInfo(t *testing.T, info []byte) [4][]byte {
+	t.Helper()
+	lc := make([]byte, framing.EmbLCBits)
+	for i := 0; i < framing.EmbLCBits; i++ {
+		lc[i] = (info[i/8] >> uint(7-(i%8))) & 1
+	}
+	ch := framing.EncodeEmbeddedLC(lc)
+	var frags [4][]byte
+	for i := range frags {
+		frags[i] = ch[i*framing.EmbeddedFragmentBits : (i+1)*framing.EmbeddedFragmentBits]
+	}
+	return frags
+}
+
+// TestDecoderSurfacesTalkerAlias builds one superframe whose embedded LC
+// is a talker-alias header and confirms the decoder surfaces the parsed
+// fragment on VoiceSuperframe rather than misreading it as a group-voice LC.
+func TestDecoderSurfacesTalkerAlias(t *testing.T) {
+	info := dmr.AssembleTalkerAliasFragments(dmr.TalkerAliasFormatUTF8, "Truck 349")[0]
+	aliasFrags := aliasFragmentsFromInfo(t, info)
+
+	var frames [][]byte
+	for f := 0; f < FramesPerSuperframe; f++ {
+		frames = append(frames, mkFrame(f))
+	}
+	var stream []uint8
+	stream = make([]uint8, 200) // leading filler
+	for b := 0; b < BurstsPerSuperframe; b++ {
+		sync := dmr.BSData.Dibits
+		switch {
+		case b == 0:
+			sync = dmr.BSVoice.Dibits
+		case b >= 1 && b <= 4:
+			sync = embeddedSync(dmr.EMB{ColorCode: 1, LCSS: burstLCSS(b)}, aliasFrags[b-1])
+		}
+		base := b * FramesPerBurst
+		stream = append(stream, makeVoiceBurst(frames[base:base+FramesPerBurst], sync)...)
+	}
+	stream = append(stream, make([]uint8, interleaveTail)...)
+
+	d := NewDecoder()
+	sfs := d.Process(stream, 0)
+	if len(sfs) == 0 {
+		t.Fatal("no superframe decoded")
+	}
+	sf := sfs[0]
+	if !sf.HasTalkerAlias {
+		t.Fatal("HasTalkerAlias not set on an alias-carrying superframe")
+	}
+	if !sf.TalkerAlias.Header || sf.TalkerAlias.Length != 9 ||
+		sf.TalkerAlias.Format != dmr.TalkerAliasFormatUTF8 {
+		t.Fatalf("surfaced alias fragment wrong: hdr=%v len=%d fmt=%d",
+			sf.TalkerAlias.Header, sf.TalkerAlias.Length, sf.TalkerAlias.Format)
+	}
+}

--- a/internal/voice/composer/composer.go
+++ b/internal/voice/composer/composer.go
@@ -531,7 +531,7 @@ func (c *Composer) handleStart(parent context.Context, cs trunking.CallStart) {
 				"device", cs.DeviceSerial, "system", cs.Grant.System,
 				"group", cs.Grant.GroupID)
 		}
-		go c.runDMRVoiceChain(chainCtx, cs.DeviceSerial, iqCh, rateHzF, cs.Grant.GroupID, cs.Grant.DMRInterleavedVoice, ch.done)
+		go c.runDMRVoiceChain(chainCtx, cs.DeviceSerial, cs.Grant.System, iqCh, rateHzF, cs.Grant.GroupID, cs.Grant.DMRInterleavedVoice, ch.done)
 	case isP25P2Voice:
 		macCfg := p25p2.MACDecodeConfig{
 			Trellis:      p25p2.TrellisMode(cs.Grant.P25Phase2Decode.Trellis),

--- a/internal/voice/composer/dmr_alias_printable_test.go
+++ b/internal/voice/composer/dmr_alias_printable_test.go
@@ -10,9 +10,9 @@ func TestAliasPrintable(t *testing.T) {
 		{"Truck 349", true},
 		{"Café Unit", true}, // accented UTF-8 is legitimate
 		{"", false},
-		{"   ", false},               // whitespace only, no printable glyph
-		{"Bad\x01Name", false},       // C0 control char → corrupted decode
-		{"weird�", false},       // replacement rune → bad decode
+		{"   ", false},         // whitespace only, no printable glyph
+		{"Bad\x01Name", false}, // C0 control char → corrupted decode
+		{"weird�", false},      // replacement rune → bad decode
 	}
 	for _, tc := range cases {
 		if got := aliasPrintable(tc.in); got != tc.want {

--- a/internal/voice/composer/dmr_alias_printable_test.go
+++ b/internal/voice/composer/dmr_alias_printable_test.go
@@ -1,0 +1,22 @@
+package composer
+
+import "testing"
+
+func TestAliasPrintable(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"Truck 349", true},
+		{"Café Unit", true}, // accented UTF-8 is legitimate
+		{"", false},
+		{"   ", false},               // whitespace only, no printable glyph
+		{"Bad\x01Name", false},       // C0 control char → corrupted decode
+		{"weird�", false},       // replacement rune → bad decode
+	}
+	for _, tc := range cases {
+		if got := aliasPrintable(tc.in); got != tc.want {
+			t.Errorf("aliasPrintable(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/voice/composer/dmr_talker_alias_chain_test.go
+++ b/internal/voice/composer/dmr_talker_alias_chain_test.go
@@ -1,0 +1,175 @@
+package composer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+	dmrvoice "github.com/MattCheramie/GopherTrunk/internal/radio/dmr/voice"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// embeddedFragsFromInfo runs a 9-octet info block through the embedded-LC
+// BPTC encoder and returns the four 32-bit fragments bursts B–E carry.
+func embeddedFragsFromInfo(t *testing.T, info []byte) [4][]byte {
+	t.Helper()
+	lc := make([]byte, framing.EmbLCBits)
+	for i := 0; i < framing.EmbLCBits; i++ {
+		lc[i] = (info[i/8] >> uint(7-(i%8))) & 1
+	}
+	ch := framing.EncodeEmbeddedLC(lc)
+	var frags [4][]byte
+	for i := range frags {
+		frags[i] = ch[i*framing.EmbeddedFragmentBits : (i+1)*framing.EmbeddedFragmentBits]
+	}
+	return frags
+}
+
+// buildVoiceStreamWithLCInfos builds a single-slot voice dibit stream in
+// which superframe s embeds lcInfos[s] (a raw 9-octet embedded-LC info
+// block) across bursts B–E; a nil entry embeds plain BS-Data filler.
+func buildVoiceStreamWithLCInfos(t *testing.T, lcInfos [][]byte) []uint8 {
+	t.Helper()
+	lcss := func(b int) dmr.LCSS {
+		switch b {
+		case 1:
+			return dmr.LCSSFirst
+		case 4:
+			return dmr.LCSSLast
+		default:
+			return dmr.LCSSCont
+		}
+	}
+	dibits := make([]uint8, 240) // clock-settling lead
+	for i := range dibits {
+		dibits[i] = uint8(i % 4)
+	}
+	for s, info := range lcInfos {
+		var frags [4][]byte
+		if info != nil {
+			frags = embeddedFragsFromInfo(t, info)
+		}
+		for b := 0; b < dmrvoice.BurstsPerSuperframe; b++ {
+			sync := dmr.BSData.Dibits
+			switch {
+			case b == 0:
+				sync = dmr.BSVoice.Dibits
+			case b >= 1 && b <= 4 && info != nil:
+				sync = embeddedSyncDibits(dmr.EMB{ColorCode: 1, LCSS: lcss(b)}, frags[b-1])
+			}
+			// Audio content is irrelevant to this test; any valid AMBE frames
+			// keep the superframe decodable so the embedded LC is reached.
+			frames := make([][]byte, dmrvoice.FramesPerBurst)
+			for i := range frames {
+				f, err := dmrvoice.EncodeAMBEFrame(mkInfo(s*100 + b*3 + i))
+				if err != nil {
+					t.Fatalf("EncodeAMBEFrame: %v", err)
+				}
+				frames[i] = f
+			}
+			dibits = append(dibits, voiceBurstDibits(frames, sync)...)
+		}
+	}
+	return dibits
+}
+
+// TestComposerDMRPublishesTalkerAlias drives the full DMR voice chain with
+// a stream that first carries a group-voice LC (establishing the call's
+// source radio) and then the talker-alias header + block embedded LCs, and
+// confirms the chain reassembles and publishes a KindTalkerAlias event.
+func TestComposerDMRPublishesTalkerAlias(t *testing.T) {
+	const (
+		sampleRate = 48_000.0
+		sps        = 10
+		span       = 8
+		alpha      = 0.20
+		deviation  = 1944.0
+	)
+	const wantAlias = "Truck 349"
+	const wantSrc = uint32(4242)
+
+	gv := dmr.AssembleFLC(dmr.FLC{FLCO: dmr.FLCOGroupVoiceUser, DstAddr: 7, SrcAddr: wantSrc})
+	aliasFrags := dmr.AssembleTalkerAliasFragments(dmr.TalkerAliasFormatUTF8, wantAlias)
+
+	// Repeat [group-voice, alias-header, alias-block…] several times so the
+	// receiver's sync/cadence warmup can drop the first cycle and a later,
+	// fully-aligned cycle still completes the alias.
+	var lcInfos [][]byte
+	for cycle := 0; cycle < 6; cycle++ {
+		lcInfos = append(lcInfos, gv)
+		for _, f := range aliasFrags {
+			lcInfos = append(lcInfos, f)
+		}
+	}
+	dibits := buildVoiceStreamWithLCInfos(t, lcInfos)
+	iq := demod.ModulateC4FM(dibits, sps, span, alpha, sampleRate, deviation)
+
+	src := newFakeSource()
+	bus := events.NewBus(64)
+	sub := bus.Subscribe()
+	defer sub.Close()
+	sink := &recordingSink{}
+	eng := &fakeEngine{}
+	c, err := New(Options{
+		Bus:           bus,
+		Devices:       &fakeDevices{src: map[string]IQSource{"VOICE-1": src}},
+		Sink:          sink,
+		Engine:        eng,
+		IQSampleRate:  uint32(sampleRate),
+		PCMSampleRate: 8000,
+		TouchInterval: 30 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go c.Run(ctx)
+	defer c.Close()
+	defer bus.Close()
+
+	bus.Publish(events.Event{
+		Kind: events.KindCallStart,
+		Payload: trunking.CallStart{
+			Grant: trunking.Grant{
+				System: "DMRSite", Protocol: "dmr-tier3",
+				GroupID: 7, FrequencyHz: 460_000_000,
+			},
+			DeviceSerial: "VOICE-1",
+			StartedAt:    time.Now().UTC(),
+		},
+	})
+	waitFor(t, 2*time.Second, func() bool { return len(c.ActiveChains()) == 1 })
+	src.SendIQ(iq)
+
+	deadline := time.After(8 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			t.Fatalf("no KindTalkerAlias %q published within the deadline", wantAlias)
+		case ev := <-sub.C:
+			if ev.Kind != events.KindTalkerAlias {
+				continue
+			}
+			ta, ok := ev.Payload.(trunking.TalkerAlias)
+			if !ok {
+				continue
+			}
+			if ta.Alias != wantAlias {
+				continue // a warmup/garbled partial — keep waiting for the clean one
+			}
+			if ta.Protocol != "dmr" || ta.System != "DMRSite" || ta.SourceID != wantSrc {
+				t.Fatalf("alias metadata wrong: proto=%q sys=%q src=%d",
+					ta.Protocol, ta.System, ta.SourceID)
+			}
+			if ta.Unreliable {
+				t.Fatalf("clean alias %q flagged unreliable", ta.Alias)
+			}
+			return
+		}
+	}
+}

--- a/internal/voice/composer/dmr_voice.go
+++ b/internal/voice/composer/dmr_voice.go
@@ -5,10 +5,15 @@ import (
 	"math"
 	"sync/atomic"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
+	"github.com/MattCheramie/GopherTrunk/internal/events"
 	gtlog "github.com/MattCheramie/GopherTrunk/internal/log"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
 	dmrrx "github.com/MattCheramie/GopherTrunk/internal/radio/dmr/receiver"
 	dmrvoice "github.com/MattCheramie/GopherTrunk/internal/radio/dmr/voice"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
 
 // dmrVoiceIntermediateHz is the rate the wideband IQ is decimated to
@@ -50,6 +55,29 @@ func newDMRVoiceFrontEnd(iqHz float64, bw uint32) *decimatingFIR {
 		}
 	}
 	return newDecimatingFIR(iqHz, dmrVoiceIntermediateHz, chanBW, filterAtUnity)
+}
+
+// aliasPrintable reports whether a reassembled talker alias looks like a
+// clean decode: it holds at least one printable character and no C0/C1
+// control characters or Unicode replacement runes (the hallmark of a
+// bit-error-corrupted or wrong-format decode). Unlike the P25 ASCII-only
+// cleaner it tolerates accented / non-Latin names, since DMR aliases carry
+// a UTF-8 / UTF-16 format bit. Mirrors the trunking.TalkerAlias.Unreliable
+// contract (#711).
+func aliasPrintable(s string) bool {
+	if s == "" {
+		return false
+	}
+	printable := false
+	for _, r := range s {
+		if r == utf8.RuneError || r < 0x20 || (r >= 0x7F && r < 0xA0) {
+			return false
+		}
+		if !unicode.IsSpace(r) {
+			printable = true
+		}
+	}
+	return printable
 }
 
 // rawFrameSink is the subset of voice.Recorder the DMR voice chain
@@ -171,7 +199,7 @@ func (r *slotRouter) accept(sf dmrvoice.VoiceSuperframe) bool {
 	return false
 }
 
-func (c *Composer) runDMRVoiceChain(ctx context.Context, serial string, iqCh <-chan []complex64, iqHz float64, groupID uint32, interleaved bool, done chan<- struct{}) {
+func (c *Composer) runDMRVoiceChain(ctx context.Context, serial, system string, iqCh <-chan []complex64, iqHz float64, groupID uint32, interleaved bool, done chan<- struct{}) {
 	defer close(done)
 	defer gtlog.Recover(c.log, "voice-chain-dmr:"+serial, nil)
 
@@ -207,6 +235,31 @@ func (c *Composer) runDMRVoiceChain(ctx context.Context, serial string, iqCh <-c
 		voiceDec = dmrvoice.NewInterleavedDecoder()
 		router = newSlotRouter(groupID)
 	}
+	// Talker-alias reassembly. The alias header/block embedded LCs carry no
+	// source address, so the alias is keyed and published under the most
+	// recent SourceID seen from a group-voice embedded LC on this call.
+	aliasAsm := dmr.NewTalkerAliasAssembler(nil)
+	var aliasSrc uint32
+	publishAlias := func(src uint32, alias string) {
+		if src == 0 || alias == "" || c.bus == nil {
+			return
+		}
+		unreliable := !aliasPrintable(alias)
+		c.log.Info("composer: dmr talker alias",
+			"system", system, "serial", serial, "src", src, "alias", alias,
+			"unreliable", unreliable)
+		c.bus.Publish(events.Event{
+			Kind: events.KindTalkerAlias,
+			Payload: trunking.TalkerAlias{
+				System:     system,
+				Protocol:   "dmr",
+				SourceID:   src,
+				Alias:      alias,
+				Unreliable: unreliable,
+				At:         time.Now(),
+			},
+		})
+	}
 	// superframes counts DMR voice superframes the receiver delivered —
 	// i.e. real voice activity. The touch ticker (below) only refreshes
 	// the engine's LastHeardAt when this counter has advanced since the
@@ -236,6 +289,18 @@ func (c *Composer) runDMRVoiceChain(ctx context.Context, serial string, iqCh <-c
 			for _, sf := range voiceDec.Process(dibits, baseIdx) {
 				if sf.HasLC {
 					lcSuperframes.Add(1)
+					if gv, ok := sf.LC.AsGroupVoiceUser(); ok && gv.SourceID != 0 {
+						aliasSrc = gv.SourceID
+					}
+				}
+				// Talker-alias header/block embedded LC: reassemble the display
+				// name across superframes and publish it once complete. Runs on
+				// every superframe (both slots) — it is call-metadata, not this
+				// slot's audio, so it is intentionally before the slot-router gate.
+				if sf.HasTalkerAlias {
+					if alias, done := aliasAsm.Add(aliasSrc, sf.TalkerAlias); done {
+						publishAlias(aliasSrc, alias)
+					}
 				}
 				if router != nil && !router.accept(sf) {
 					// A superframe from the other timeslot (or an


### PR DESCRIPTION
## Summary

DMR carries a radio's display name (its **talker alias**) in the voice superframe's embedded Link Control, but GopherTrunk only recognized the alias opcodes as enum labels — the name was never reassembled or surfaced. P25 already decodes and publishes talker aliases; this brings DMR to parity so the affiliation tracker, decoded-message log, API, and TUI attribute the name to the calling radio on DMR calls too.

This is the first increment of the cross-protocol feature-parity work (workstream **W6** in the plan): a portable capability that P25 has and DMR lacked.

## Changes

- **`dmr` package — talker-alias parser + reassembler** (`talker_alias.go`). Per-source `TalkerAliasAssembler` mirroring the P25 Phase 1 assembler, plus a fragment field parser and a synthetic-vector encoder. All four data formats decode: 7-bit packed, 8-bit ISO 8859-1, UTF-8, UTF-16BE. Adds the block FLCO constants (0x05/0x06/0x07).
- **Embedded-LC raw-info accessor** (`emb.go`). `ReassembleEmbeddedLCInfo` returns the raw recovered 9-octet info block alongside the parsed FLC — the alias PDUs reuse the Full LC framing but their octets 2..8 are alias text, not the address fields `ParseFLC` reads.
- **Superframe surfacing** (`dmr/voice/superframe.go`). The voice-superframe decoder sets `HasTalkerAlias` / `TalkerAlias` when the embedded LC is one of the four alias opcodes.
- **Composer publish** (`voice/composer/dmr_voice.go`). The DMR voice chain buffers the fragments, keys them to the source radio learned from the call's group-voice LC, and publishes a `talker.alias` event once the name is complete. `runDMRVoiceChain` gains the system name (mirroring the P25 chain) so the alias is attributed to the right system. A reliability check flags corrupted decodes without penalizing legitimate accented names.

The `talker.alias` event's existing consumers (affiliation tracker, storage, message log, engine) dispatch by payload type, not protocol, so DMR aliases flow through RID binding and the API/TUI with no further wiring.

The header text-bit boundary and 2-bit-format / 5-bit-length header layout follow ETSI TS 102 361-2 §7.2.18, cross-checked against the OK-DMR ok-dmrlib reference decoder. Like the other DMR embedded-LC constants, it is a working model pending validation against a real capture.

## Test plan

- [x] `make vet test` is green locally
- [ ] `make integration` — n/a (no daemon/replay wiring changed; the composer chain change is covered by the end-to-end unit test below)
- [x] Added tests where appropriate:
  - `talker_alias_test.go` — encode/decode round-trip for all four formats, header field extraction, out-of-order and incomplete reassembly, non-alias FLCO rejection.
  - `emb_alias_test.go` — the raw-info accessor survives the BPTC round-trip and recovers a header.
  - `superframe_alias_test.go` — a full superframe carrying an alias header surfaces the parsed fragment.
  - `dmr_talker_alias_chain_test.go` — end-to-end: modulated IQ → receiver → superframe → reassembly asserts a `talker.alias` event with the correct source, system, and protocol.
  - `dmr_alias_printable_test.go` — reliability flagging.
- [ ] Smoke-tested against real hardware — not yet; the header text-bit split is flagged as capture-pending (see Summary).

## Breaking changes

None. New behaviour only; no config keys, flags, or endpoints change.

## Docs / CHANGELOG

- [x] Added a `## [Unreleased]` bullet to `CHANGELOG.md`
- [ ] README/docs — n/a (the `talker.alias` surface is already documented; this adds DMR as a producer)

## Linked issues

n/a — part of the cross-protocol feature-parity roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144w5FXPjW3oeryHqugKAjP

---
_Generated by [Claude Code](https://claude.ai/code/session_0144w5FXPjW3oeryHqugKAjP)_