### PR TITLE
dmr: decode GPS Info position and publish it to the live map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **DMR GPS position decode → live map.** A DMR radio's GPS Info embedded
+  Link Control (FLCO 0x08) is now decoded — a 25-bit two's-complement
+  longitude and 24-bit two's-complement latitude per ETSI TS 102 361-2,
+  cross-checked against the ok-dmrlib reference — and published as a
+  `location` event bound to the call's source radio. The existing
+  `location_log` storage and web map surface it, so a DMR subscriber's
+  position appears on the map alongside P25 the same way. Stationary radios
+  that rebroadcast an unchanged fix produce one row, not one per superframe.
+  The wire layout is a working model pending on-air capture validation.
 - **DMR talker alias decode.** A DMR radio's display name — carried in the
   voice superframe's embedded Link Control as a header (FLCO 0x04) plus up to
   three continuation blocks (0x05-0x07) — is now reassembled and published as a

--- a/internal/radio/dmr/gps.go
+++ b/internal/radio/dmr/gps.go
@@ -1,0 +1,124 @@
+package dmr
+
+// DMR GPS Info decode. A subscriber unit can report its position in the
+// voice superframe's embedded Link Control as a "GPS Info" Full LC PDU
+// (FLCOGPS / 0x08), the same embedded-LC framing the group-voice and
+// talker-alias LCs use. This file decodes the position fields; the voice
+// chain binds the fix to the call's source radio (the LC itself carries no
+// address) and publishes it on the location bus.
+//
+// Wire layout (the 72-bit / 9-octet embedded-LC info block, bit indices
+// MSB-first as recovered by ReassembleEmbeddedLCInfo), per ETSI
+// TS 102 361-2 §7.1.1.3 and cross-checked against the OK-DMR ok-dmrlib
+// reference decoder (okdmr/dmrlib Full Link Control):
+//
+//	bits  0..15 : PF/FLCO (octet 0) + FID (octet 1)
+//	bits 16..19 : reserved
+//	bits 20..22 : Position Error (3 bits)
+//	bits 23..47 : Longitude — 25-bit two's-complement, deg = raw·360/2^25
+//	bits 48..71 : Latitude  — 24-bit two's-complement, deg = raw·180/2^24
+//
+// Like the other DMR embedded-LC constants (see emb.go / talker_alias.go),
+// this is a working model pending validation against a real capture.
+
+// GPSInfo is a decoded DMR GPS Info Full LC: a geographic fix a subscriber
+// reported over the air. Latitude is positive north, Longitude positive
+// east, both in decimal degrees.
+type GPSInfo struct {
+	Latitude      float64
+	Longitude     float64
+	PositionError uint8 // 3-bit reported position-error class (0 = best)
+}
+
+// gpsLonScale / gpsLatScale convert the raw two's-complement integers to
+// decimal degrees.
+const (
+	gpsLonScale = 360.0 / (1 << 25)
+	gpsLatScale = 180.0 / (1 << 24)
+)
+
+// Valid reports whether the fix is a usable position — within range and
+// not the (0,0) "no fix yet" placeholder (Null Island is open ocean), the
+// same rule the location package's NMEA parser applies.
+func (g GPSInfo) Valid() bool {
+	if g.Latitude == 0 && g.Longitude == 0 {
+		return false
+	}
+	return g.Latitude >= -90 && g.Latitude <= 90 &&
+		g.Longitude >= -180 && g.Longitude <= 180
+}
+
+// ParseGPSInfo decodes a GPS Info fix from the leading 9 octets of an
+// embedded-LC info block whose FLCO is FLCOGPS. It returns ok=false for a
+// non-GPS FLCO or a short buffer.
+func ParseGPSInfo(info []byte) (GPSInfo, bool) {
+	if len(info) < 9 {
+		return GPSInfo{}, false
+	}
+	if FLCO(info[0]&0x3F) != FLCOGPS {
+		return GPSInfo{}, false
+	}
+	lonRaw := int32(readBitsMSB(info, 23, 25))
+	if lonRaw >= 1<<24 { // sign-extend the 25-bit two's-complement value
+		lonRaw -= 1 << 25
+	}
+	latRaw := int32(readBitsMSB(info, 48, 24))
+	if latRaw >= 1<<23 { // sign-extend the 24-bit two's-complement value
+		latRaw -= 1 << 24
+	}
+	return GPSInfo{
+		Latitude:      float64(latRaw) * gpsLatScale,
+		Longitude:     float64(lonRaw) * gpsLonScale,
+		PositionError: uint8(readBitsMSB(info, 20, 3)),
+	}, true
+}
+
+// AssembleGPSInfo packs a fix into the 9-octet GPS Info info block. It is
+// the inverse of ParseGPSInfo, used to build synthetic test vectors. The
+// latitude/longitude round-trip to within one quantisation step.
+func AssembleGPSInfo(g GPSInfo) []byte {
+	info := make([]byte, 9)
+	info[0] = byte(FLCOGPS)
+	lonRaw := int32(round(g.Longitude / gpsLonScale))
+	latRaw := int32(round(g.Latitude / gpsLatScale))
+	writeBitsMSB(info, 20, 3, uint32(g.PositionError))
+	writeBitsMSB(info, 23, 25, uint32(lonRaw)&0x1FFFFFF)
+	writeBitsMSB(info, 48, 24, uint32(latRaw)&0xFFFFFF)
+	return info
+}
+
+// readBitsMSB reads n bits (n<=32) starting at bit offset start from an
+// MSB-first octet slice.
+func readBitsMSB(b []byte, start, n int) uint32 {
+	var v uint32
+	for i := 0; i < n; i++ {
+		idx := start + i
+		v <<= 1
+		if idx/8 < len(b) && b[idx/8]&(1<<uint(7-(idx%8))) != 0 {
+			v |= 1
+		}
+	}
+	return v
+}
+
+// writeBitsMSB writes the low n bits of val into an MSB-first octet slice
+// starting at bit offset start.
+func writeBitsMSB(b []byte, start, n int, val uint32) {
+	for i := 0; i < n; i++ {
+		if val&(1<<uint(n-1-i)) != 0 {
+			idx := start + i
+			if idx/8 < len(b) {
+				b[idx/8] |= 1 << uint(7-(idx%8))
+			}
+		}
+	}
+}
+
+// round rounds a float to the nearest integer (half away from zero)
+// without pulling in math for one call site.
+func round(f float64) float64 {
+	if f < 0 {
+		return float64(int64(f - 0.5))
+	}
+	return float64(int64(f + 0.5))
+}

--- a/internal/radio/dmr/gps_test.go
+++ b/internal/radio/dmr/gps_test.go
@@ -1,0 +1,72 @@
+package dmr
+
+import (
+	"math"
+	"testing"
+)
+
+func TestGPSInfoRoundTrip(t *testing.T) {
+	cases := []struct {
+		name     string
+		lat, lon float64
+	}{
+		{"melbourne", -37.8136, 144.9631},
+		{"nyc", 40.7128, -74.0060},
+		{"equator-prime", 0.0001, 0.0001},
+		{"southwest", -45.5, -170.25},
+		{"near-limits", 89.9, 179.9},
+	}
+	// One quantisation step is the coarser of the two axes.
+	const tol = 360.0 / (1 << 25)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			info := AssembleGPSInfo(GPSInfo{Latitude: tc.lat, Longitude: tc.lon})
+			g, ok := ParseGPSInfo(info)
+			if !ok {
+				t.Fatal("ParseGPSInfo rejected a GPS info block")
+			}
+			if math.Abs(g.Latitude-tc.lat) > tol {
+				t.Errorf("latitude: got %.6f want %.6f (Δ %.2g)", g.Latitude, tc.lat, g.Latitude-tc.lat)
+			}
+			if math.Abs(g.Longitude-tc.lon) > tol {
+				t.Errorf("longitude: got %.6f want %.6f (Δ %.2g)", g.Longitude, tc.lon, g.Longitude-tc.lon)
+			}
+			if !g.Valid() {
+				t.Errorf("fix %.4f,%.4f reported invalid", g.Latitude, g.Longitude)
+			}
+		})
+	}
+}
+
+func TestGPSInfoSignedHemispheres(t *testing.T) {
+	// A southern + western fix must sign-extend to negative degrees.
+	info := AssembleGPSInfo(GPSInfo{Latitude: -12.5, Longitude: -60.75})
+	g, _ := ParseGPSInfo(info)
+	if g.Latitude >= 0 || g.Longitude >= 0 {
+		t.Fatalf("sign extension failed: lat=%.4f lon=%.4f", g.Latitude, g.Longitude)
+	}
+}
+
+func TestGPSInfoRejectsNonGPSFLCO(t *testing.T) {
+	info := AssembleFLC(FLC{FLCO: FLCOGroupVoiceUser, DstAddr: 1, SrcAddr: 2})
+	if _, ok := ParseGPSInfo(info); ok {
+		t.Fatal("group-voice FLCO wrongly parsed as GPS info")
+	}
+}
+
+func TestGPSInfoValidRejectsNullIsland(t *testing.T) {
+	if (GPSInfo{Latitude: 0, Longitude: 0}).Valid() {
+		t.Fatal("(0,0) placeholder treated as a valid fix")
+	}
+	if (GPSInfo{Latitude: 200, Longitude: 0}).Valid() {
+		t.Fatal("out-of-range latitude treated as valid")
+	}
+}
+
+func TestGPSInfoPositionError(t *testing.T) {
+	info := AssembleGPSInfo(GPSInfo{Latitude: 1, Longitude: 1, PositionError: 5})
+	g, _ := ParseGPSInfo(info)
+	if g.PositionError != 5 {
+		t.Fatalf("position error: got %d want 5", g.PositionError)
+	}
+}

--- a/internal/radio/dmr/voice/superframe.go
+++ b/internal/radio/dmr/voice/superframe.go
@@ -53,6 +53,12 @@ type VoiceSuperframe struct {
 	// interpretation, which does not apply to an alias LC.
 	HasTalkerAlias bool
 	TalkerAlias    dmr.TalkerAliasFragment
+	// HasGPS reports that this superframe's embedded Full LC was a GPS Info
+	// PDU (FLCO 0x08). GPS then holds the decoded position; the voice chain
+	// binds it to the call's source radio (the LC carries no address) and
+	// publishes it on the location bus.
+	HasGPS bool
+	GPS    dmr.GPSInfo
 }
 
 // voiceSyncs are the sync words that frame burst A of a voice
@@ -342,6 +348,12 @@ func (d *Decoder) sliceAt(start, step int, syncName string) VoiceSuperframe {
 		if frag, ok := dmr.ParseTalkerAliasFragment(info); ok {
 			sf.HasTalkerAlias = true
 			sf.TalkerAlias = frag
+		}
+		// GPS Info reuses the Full LC framing too — its payload is a position
+		// fix, not the group/source addresses the generic LC view reads.
+		if gps, ok := dmr.ParseGPSInfo(info); ok {
+			sf.HasGPS = true
+			sf.GPS = gps
 		}
 	}
 	return sf

--- a/internal/radio/dmr/voice/superframe_gps_test.go
+++ b/internal/radio/dmr/voice/superframe_gps_test.go
@@ -1,0 +1,50 @@
+package voice
+
+import (
+	"math"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+)
+
+// TestDecoderSurfacesGPS builds one superframe whose embedded LC is a GPS
+// Info PDU and confirms the decoder surfaces the decoded fix on
+// VoiceSuperframe rather than misreading it as a group-voice LC.
+func TestDecoderSurfacesGPS(t *testing.T) {
+	const wantLat, wantLon = -37.8136, 144.9631
+	info := dmr.AssembleGPSInfo(dmr.GPSInfo{Latitude: wantLat, Longitude: wantLon})
+	gpsFrags := aliasFragmentsFromInfo(t, info) // same raw-info → 4-fragment helper
+
+	var frames [][]byte
+	for f := 0; f < FramesPerSuperframe; f++ {
+		frames = append(frames, mkFrame(f))
+	}
+	stream := make([]uint8, 200)
+	for b := 0; b < BurstsPerSuperframe; b++ {
+		sync := dmr.BSData.Dibits
+		switch {
+		case b == 0:
+			sync = dmr.BSVoice.Dibits
+		case b >= 1 && b <= 4:
+			sync = embeddedSync(dmr.EMB{ColorCode: 1, LCSS: burstLCSS(b)}, gpsFrags[b-1])
+		}
+		base := b * FramesPerBurst
+		stream = append(stream, makeVoiceBurst(frames[base:base+FramesPerBurst], sync)...)
+	}
+	stream = append(stream, make([]uint8, interleaveTail)...)
+
+	d := NewDecoder()
+	sfs := d.Process(stream, 0)
+	if len(sfs) == 0 {
+		t.Fatal("no superframe decoded")
+	}
+	sf := sfs[0]
+	if !sf.HasGPS {
+		t.Fatal("HasGPS not set on a GPS-carrying superframe")
+	}
+	const tol = 360.0 / (1 << 25)
+	if math.Abs(sf.GPS.Latitude-wantLat) > tol || math.Abs(sf.GPS.Longitude-wantLon) > tol {
+		t.Fatalf("surfaced fix wrong: got %.4f,%.4f want %.4f,%.4f",
+			sf.GPS.Latitude, sf.GPS.Longitude, wantLat, wantLon)
+	}
+}

--- a/internal/voice/composer/dmr_gps_chain_test.go
+++ b/internal/voice/composer/dmr_gps_chain_test.go
@@ -1,0 +1,107 @@
+package composer
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TestComposerDMRPublishesLocation drives the full DMR voice chain with a
+// stream that carries a group-voice LC (establishing the call's source
+// radio) then GPS Info embedded LCs, and confirms the chain publishes a
+// KindLocation event bound to that radio.
+func TestComposerDMRPublishesLocation(t *testing.T) {
+	const (
+		sampleRate = 48_000.0
+		sps        = 10
+		span       = 8
+		alpha      = 0.20
+		deviation  = 1944.0
+	)
+	const (
+		wantLat = -37.8136
+		wantLon = 144.9631
+		wantSrc = uint32(90210)
+		wantTG  = uint32(7)
+	)
+
+	gv := dmr.AssembleFLC(dmr.FLC{FLCO: dmr.FLCOGroupVoiceUser, DstAddr: wantTG, SrcAddr: wantSrc})
+	gps := dmr.AssembleGPSInfo(dmr.GPSInfo{Latitude: wantLat, Longitude: wantLon})
+
+	var lcInfos [][]byte
+	for cycle := 0; cycle < 6; cycle++ {
+		lcInfos = append(lcInfos, gv, gps)
+	}
+	dibits := buildVoiceStreamWithLCInfos(t, lcInfos)
+	iq := demod.ModulateC4FM(dibits, sps, span, alpha, sampleRate, deviation)
+
+	src := newFakeSource()
+	bus := events.NewBus(64)
+	sub := bus.Subscribe()
+	defer sub.Close()
+	sink := &recordingSink{}
+	eng := &fakeEngine{}
+	c, err := New(Options{
+		Bus:           bus,
+		Devices:       &fakeDevices{src: map[string]IQSource{"VOICE-1": src}},
+		Sink:          sink,
+		Engine:        eng,
+		IQSampleRate:  uint32(sampleRate),
+		PCMSampleRate: 8000,
+		TouchInterval: 30 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go c.Run(ctx)
+	defer c.Close()
+	defer bus.Close()
+
+	bus.Publish(events.Event{
+		Kind: events.KindCallStart,
+		Payload: trunking.CallStart{
+			Grant: trunking.Grant{
+				System: "DMRSite", Protocol: "dmr-tier3",
+				GroupID: wantTG, FrequencyHz: 460_000_000,
+			},
+			DeviceSerial: "VOICE-1",
+			StartedAt:    time.Now().UTC(),
+		},
+	})
+	waitFor(t, 2*time.Second, func() bool { return len(c.ActiveChains()) == 1 })
+	src.SendIQ(iq)
+
+	const tol = 360.0 / (1 << 25)
+	deadline := time.After(8 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			t.Fatal("no KindLocation published within the deadline")
+		case ev := <-sub.C:
+			if ev.Kind != events.KindLocation {
+				continue
+			}
+			loc, ok := ev.Payload.(trunking.Location)
+			if !ok {
+				continue
+			}
+			if math.Abs(loc.Latitude-wantLat) > tol || math.Abs(loc.Longitude-wantLon) > tol {
+				continue // a warmup/garbled partial — keep waiting for the clean fix
+			}
+			if loc.Protocol != "dmr" || loc.System != "DMRSite" ||
+				loc.RadioID != wantSrc || loc.Talkgroup != wantTG {
+				t.Fatalf("location metadata wrong: proto=%q sys=%q rid=%d tg=%d",
+					loc.Protocol, loc.System, loc.RadioID, loc.Talkgroup)
+			}
+			return
+		}
+	}
+}

--- a/internal/voice/composer/dmr_voice.go
+++ b/internal/voice/composer/dmr_voice.go
@@ -235,11 +235,11 @@ func (c *Composer) runDMRVoiceChain(ctx context.Context, serial, system string, 
 		voiceDec = dmrvoice.NewInterleavedDecoder()
 		router = newSlotRouter(groupID)
 	}
-	// Talker-alias reassembly. The alias header/block embedded LCs carry no
-	// source address, so the alias is keyed and published under the most
-	// recent SourceID seen from a group-voice embedded LC on this call.
+	// Talker-alias reassembly and GPS Info both ride the embedded LC, which
+	// carries no source address, so both are attributed to the most recent
+	// SourceID seen from a group-voice embedded LC on this call.
 	aliasAsm := dmr.NewTalkerAliasAssembler(nil)
-	var aliasSrc uint32
+	var callSrc uint32
 	publishAlias := func(src uint32, alias string) {
 		if src == 0 || alias == "" || c.bus == nil {
 			return
@@ -257,6 +257,34 @@ func (c *Composer) runDMRVoiceChain(ctx context.Context, serial, system string, 
 				Alias:      alias,
 				Unreliable: unreliable,
 				At:         time.Now(),
+			},
+		})
+	}
+	// lastGPS dedupes repeated identical fixes — a stationary radio rebroadcasts
+	// the same GPS Info LC, and one row per superframe would flood the log.
+	var lastGPS dmr.GPSInfo
+	var haveGPS bool
+	publishGPS := func(src uint32, g dmr.GPSInfo) {
+		if src == 0 || c.bus == nil || !g.Valid() {
+			return
+		}
+		if haveGPS && g == lastGPS {
+			return
+		}
+		lastGPS, haveGPS = g, true
+		c.log.Info("composer: dmr gps",
+			"system", system, "serial", serial, "src", src,
+			"lat", g.Latitude, "lon", g.Longitude)
+		c.bus.Publish(events.Event{
+			Kind: events.KindLocation,
+			Payload: trunking.Location{
+				System:    system,
+				Protocol:  "dmr",
+				RadioID:   src,
+				Talkgroup: groupID,
+				Latitude:  g.Latitude,
+				Longitude: g.Longitude,
+				At:        time.Now(),
 			},
 		})
 	}
@@ -290,17 +318,19 @@ func (c *Composer) runDMRVoiceChain(ctx context.Context, serial, system string, 
 				if sf.HasLC {
 					lcSuperframes.Add(1)
 					if gv, ok := sf.LC.AsGroupVoiceUser(); ok && gv.SourceID != 0 {
-						aliasSrc = gv.SourceID
+						callSrc = gv.SourceID
 					}
 				}
-				// Talker-alias header/block embedded LC: reassemble the display
-				// name across superframes and publish it once complete. Runs on
-				// every superframe (both slots) — it is call-metadata, not this
-				// slot's audio, so it is intentionally before the slot-router gate.
+				// Talker-alias header/block and GPS Info embedded LCs are
+				// call-metadata, not this slot's audio, so they run on every
+				// superframe (both slots) before the slot-router gate.
 				if sf.HasTalkerAlias {
-					if alias, done := aliasAsm.Add(aliasSrc, sf.TalkerAlias); done {
-						publishAlias(aliasSrc, alias)
+					if alias, done := aliasAsm.Add(callSrc, sf.TalkerAlias); done {
+						publishAlias(callSrc, alias)
 					}
+				}
+				if sf.HasGPS {
+					publishGPS(callSrc, sf.GPS)
 				}
 				if router != nil && !router.accept(sf) {
 					// A superframe from the other timeslot (or an


### PR DESCRIPTION
## Summary

The location subsystem — the `location` event, the `trunking.Location` payload, the `location_log` storage, and the web map — is fully built, but nothing produced a fix: the `location` package's NMEA parser was imported by zero decoders and `FLCOGPS` was an enum label only. This wires up the first producer: a DMR radio's **GPS Info** embedded Link Control (FLCO 0x08), so a DMR subscriber's position now appears on the live map the same way P25 will.

This is the next increment of the cross-protocol feature-parity work (workstream **W3** — the plan calls location the single biggest cross-cutting gap). It reuses the embedded-LC path added for DMR talker alias in #1032.

## Changes

- **`dmr` package — GPS Info decoder** (`gps.go`). Decodes the 3-bit position-error class, a 25-bit two's-complement longitude (`deg = raw·360/2²⁵`), and a 24-bit two's-complement latitude (`deg = raw·180/2²⁴`) from the 9-octet embedded-LC info block, with a `Valid()` gate that drops the (0,0) no-fix placeholder. Includes the inverse encoder for synthetic vectors.
- **Superframe surfacing** (`dmr/voice/superframe.go`). The voice-superframe decoder sets `HasGPS` / `GPS` when the embedded LC is a GPS Info opcode — mirroring the `HasTalkerAlias` path and reusing `ReassembleEmbeddedLCInfo`.
- **Composer publish** (`voice/composer/dmr_voice.go`). The DMR voice chain binds the fix to the call's source radio (learned from the group-voice embedded LC), dedupes unchanged rebroadcasts, and publishes a `location` event. The alias/GPS source key is renamed `callSrc` since both now share it.

The `location` event's storage sink and web map consume `trunking.Location` generically, so no further wiring is needed.

The bit layout follows ETSI TS 102 361-2 cross-checked against the OK-DMR ok-dmrlib reference decoder; like the other DMR embedded-LC constants it is a working model pending validation against a real capture.

## Test plan

- [x] `make vet test` is green locally (165 packages, 0 failures)
- [ ] `make integration` — n/a (no daemon/replay wiring changed; the composer chain is covered by the end-to-end unit test below)
- [x] Added tests:
  - `gps_test.go` — encode/decode round-trip across hemispheres to within one quantisation step, signed sign-extension, `Valid()` gating, position-error, non-GPS FLCO rejection.
  - `superframe_gps_test.go` — a full superframe carrying a GPS Info LC surfaces the decoded fix.
  - `dmr_gps_chain_test.go` — end-to-end: modulated IQ → receiver → superframe → publish asserts a `location` event with the correct radio, talkgroup, and system.
- [ ] Smoke-tested against real hardware — not yet; the wire layout is flagged capture-pending (see Summary).

## Breaking changes

None. New behaviour only; no config keys, flags, or endpoints change.

## Docs / CHANGELOG

- [x] Added a `## [Unreleased]` bullet to `CHANGELOG.md`
- [ ] README/docs — n/a (the `location` surface + map are already documented; this adds DMR as a producer)

## Linked issues

n/a — part of the cross-protocol feature-parity roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144w5FXPjW3oeryHqugKAjP

---
_Generated by [Claude Code](https://claude.ai/code/session_0144w5FXPjW3oeryHqugKAjP)_