### PR TITLE
dmr: follow unit-to-unit (private) calls and label them correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **DMR private (unit-to-unit) calls are now followed.** A Tier II
+  conventional channel dropped any non-group Voice LC Header, so DMR private
+  calls were invisible — no grant, never followed, never recorded. The
+  conventional decoder now publishes a grant for a unit-to-unit voice LC
+  (marked `Individual` so the called subscriber isn't listed as a
+  talkgroup), and the call is followed on the tuned frequency like a group
+  call.
+
+### Fixed
+- **DMR Tier III private-voice grants were mislabelled as talkgroups.** The
+  shared grant path never set `Individual`, so a Tier III private
+  (unit-to-unit) call's destination subscriber was published as if it were a
+  talkgroup — polluting talkgroup discovery. Private-voice grants (standard
+  and vendor) now carry `Individual=true`.
 - **DMR GPS position decode → live map.** A DMR radio's GPS Info embedded
   Link Control (FLCO 0x08) is now decoded — a 25-bit two's-complement
   longitude and 24-bit two's-complement latitude per ETSI TS 102 361-2,

--- a/internal/radio/dmr/flc.go
+++ b/internal/radio/dmr/flc.go
@@ -137,3 +137,30 @@ func (f FLC) AsGroupVoiceUser() (GroupVoiceChannelUser, bool) {
 		Encrypted:    f.ServiceOptions&0x40 != 0,
 	}, true
 }
+
+// UnitToUnitVoiceChannelUser is the structured shape of an FLC whose FLCO
+// is FLCOUnitToUnitVoice — a private (unit-to-unit) call. DestinationID is
+// the called subscriber's 24-bit ID, not a talkgroup.
+type UnitToUnitVoiceChannelUser struct {
+	DestinationID uint32 // 24-bit called subscriber
+	SourceID      uint32 // 24-bit calling subscriber
+	Encrypted     bool
+	Emergency     bool
+}
+
+// AsUnitToUnitVoice decodes the FLC into the typed private-voice payload
+// when its FLCO matches; otherwise (zero, false). ServiceOptions bits are
+// the same emergency/privacy layout as the group-voice LC (§7.2.1
+// Table 7.13); the only difference is the destination is a subscriber, not
+// a talkgroup.
+func (f FLC) AsUnitToUnitVoice() (UnitToUnitVoiceChannelUser, bool) {
+	if f.FLCO != FLCOUnitToUnitVoice {
+		return UnitToUnitVoiceChannelUser{}, false
+	}
+	return UnitToUnitVoiceChannelUser{
+		DestinationID: f.DstAddr,
+		SourceID:      f.SrcAddr,
+		Emergency:     f.ServiceOptions&0x80 != 0,
+		Encrypted:     f.ServiceOptions&0x40 != 0,
+	}, true
+}

--- a/internal/radio/dmr/flc_test.go
+++ b/internal/radio/dmr/flc_test.go
@@ -66,6 +66,30 @@ func TestFLCAsGroupVoiceUser(t *testing.T) {
 	}
 }
 
+func TestFLCAsUnitToUnitVoice(t *testing.T) {
+	f := FLC{
+		FLCO:           FLCOUnitToUnitVoice,
+		ServiceOptions: 0x40, // encrypted only
+		DstAddr:        0x00ABCD,
+		SrcAddr:        0x001234,
+	}
+	uu, ok := f.AsUnitToUnitVoice()
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if uu.DestinationID != 0x00ABCD || uu.SourceID != 0x001234 {
+		t.Errorf("addresses = %x/%x", uu.DestinationID, uu.SourceID)
+	}
+	if uu.Emergency || !uu.Encrypted {
+		t.Errorf("flags = emer=%v enc=%v, want emer=false enc=true", uu.Emergency, uu.Encrypted)
+	}
+
+	// A group-voice FLC is not a unit-to-unit call.
+	if _, ok := (FLC{FLCO: FLCOGroupVoiceUser}).AsUnitToUnitVoice(); ok {
+		t.Error("group-voice FLC reported as unit-to-unit")
+	}
+}
+
 func TestFLCOStringCoversKnownAndUnknown(t *testing.T) {
 	cases := map[FLCO]string{
 		FLCOGroupVoiceUser:  "GroupVoiceChannelUser",

--- a/internal/radio/dmr/tier2/conventional.go
+++ b/internal/radio/dmr/tier2/conventional.go
@@ -283,38 +283,47 @@ func (c *ConventionalChannel) handleVoiceHeader(b *dmr.Burst, slot dmr.SlotType)
 		c.log.Debug("dmr/tier2: FLC parse failed", "err", err)
 		return
 	}
-	gv, ok := flc.AsGroupVoiceUser()
-	if !ok {
-		// Unit-to-unit and other opcodes are out of scope for this
-		// pass — the engine's grant model is talkgroup-keyed.
-		c.log.Debug("dmr/tier2: non-group FLCO ignored", "flco", flc.FLCO)
+	// A Voice LC Header names either a group call (destination is a
+	// talkgroup) or a private unit-to-unit call (destination is a
+	// subscriber). Both are followed on the tuned frequency; the only
+	// difference to the engine is Grant.Individual, which keeps a private
+	// call's destination RID out of the talkgroup list.
+	var dest, src uint32
+	var enc, emer, individual bool
+	if gv, ok := flc.AsGroupVoiceUser(); ok {
+		dest, src, enc, emer = gv.GroupAddress, gv.SourceID, gv.Encrypted, gv.Emergency
+	} else if uu, ok := flc.AsUnitToUnitVoice(); ok {
+		dest, src, enc, emer, individual = uu.DestinationID, uu.SourceID, uu.Encrypted, uu.Emergency, true
+	} else {
+		c.log.Debug("dmr/tier2: non-voice FLCO ignored", "flco", flc.FLCO)
 		return
 	}
-	if c.inCall && c.lastTG == gv.GroupAddress && c.lastSrc == gv.SourceID {
+	if c.inCall && c.lastTG == dest && c.lastSrc == src {
 		// Same call's repeated Voice LC Header — dedupe.
 		return
 	}
 	c.inCall = true
-	c.lastTG = gv.GroupAddress
-	c.lastSrc = gv.SourceID
+	c.lastTG = dest
+	c.lastSrc = src
 	c.bus.Publish(events.Event{
 		Kind: events.KindGrant,
 		Payload: trunking.Grant{
 			System:      c.systemName,
 			Protocol:    c.protocolTag,
-			GroupID:     gv.GroupAddress,
-			SourceID:    gv.SourceID,
+			GroupID:     dest,
+			SourceID:    src,
+			Individual:  individual,
 			FrequencyHz: c.freqHz,
 			ChannelID:   slot.ColorCode,
-			Encrypted:   gv.Encrypted,
-			Emergency:   gv.Emergency,
+			Encrypted:   enc,
+			Emergency:   emer,
 			At:          c.now(),
 		},
 	})
 	c.log.Debug("dmr/tier2: grant",
 		"system", c.systemName, "freq_hz", c.freqHz,
-		"cc", slot.ColorCode, "tg", gv.GroupAddress, "src", gv.SourceID,
-		"enc", gv.Encrypted, "emer", gv.Emergency)
+		"cc", slot.ColorCode, "dst", dest, "src", src,
+		"individual", individual, "enc", enc, "emer", emer)
 }
 
 func (c *ConventionalChannel) handleTerminator() {

--- a/internal/radio/dmr/tier2/conventional_test.go
+++ b/internal/radio/dmr/tier2/conventional_test.go
@@ -127,9 +127,62 @@ func TestConventionalPublishesGrantOnVoiceLCHeader(t *testing.T) {
 			if !g.Encrypted || !g.Emergency {
 				t.Errorf("flags = enc=%v emer=%v, want both", g.Encrypted, g.Emergency)
 			}
+			if g.Individual {
+				t.Error("group grant wrongly marked Individual")
+			}
 			return
 		case <-deadline:
 			t.Fatal("no grant event")
+		}
+	}
+}
+
+// TestConventionalPublishesUnitToUnitGrant confirms a private
+// (unit-to-unit) Voice LC Header now yields a grant marked Individual,
+// rather than being dropped as a "non-group FLCO" — DMR private calls were
+// previously invisible on a Tier II conventional channel.
+func TestConventionalPublishesUnitToUnitGrant(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus:         bus,
+		SystemName:  "TestRepeater",
+		FrequencyHz: 451_000_000,
+		Now:         func() time.Time { return time.Unix(1_700_000_000, 0).UTC() },
+	})
+	flc := dmr.FLC{
+		FLCO:    dmr.FLCOUnitToUnitVoice,
+		DstAddr: 0x00ABCD, // called subscriber, NOT a talkgroup
+		SrcAddr: 0x001234,
+	}
+	cc.IngestBurst(burstWithFLC(flc), dmr.SlotType{ColorCode: 3, DataType: dmr.DTVoiceLCHeader})
+
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindCCLocked {
+				continue
+			}
+			if ev.Kind != events.KindGrant {
+				t.Fatalf("kind = %s", ev.Kind)
+			}
+			g := ev.Payload.(trunking.Grant)
+			if !g.Individual {
+				t.Error("unit-to-unit grant not marked Individual")
+			}
+			if g.GroupID != 0x00ABCD || g.SourceID != 0x001234 {
+				t.Errorf("dst/src = %X/%X", g.GroupID, g.SourceID)
+			}
+			if g.Protocol != "dmr-tier2" {
+				t.Errorf("protocol = %s", g.Protocol)
+			}
+			return
+		case <-deadline:
+			t.Fatal("no unit-to-unit grant event (private call dropped?)")
 		}
 	}
 }
@@ -276,22 +329,22 @@ DrainCSBK:
 	}
 }
 
-func TestConventionalIgnoresNonGroupFLCO(t *testing.T) {
+func TestConventionalIgnoresTerminatorFLCO(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()
 	sub := bus.Subscribe()
 	defer sub.Close()
 
 	cc := New(Options{Bus: bus, SystemName: "S", FrequencyHz: 1})
-	// Unit-to-unit calls are intentionally not republished as grants
-	// in this PR; the engine's grant model is talkgroup-keyed. They
-	// still trigger cc.locked because the burst itself is valid.
-	flc := dmr.FLC{FLCO: dmr.FLCOUnitToUnitVoice, DstAddr: 0x100, SrcAddr: 0x200}
+	// A non-voice FLCO (e.g. Terminator) carries no call, so it yields no
+	// grant — but a valid Voice LC Header burst still locks the channel.
+	// (Group- and unit-to-unit voice LCs DO grant; see the dedicated tests.)
+	flc := dmr.FLC{FLCO: dmr.FLCOTerminator, DstAddr: 0x100, SrcAddr: 0x200}
 	cc.IngestBurst(burstWithFLC(flc), dmr.SlotType{ColorCode: 1, DataType: dmr.DTVoiceLCHeader})
 
 	timeout := time.After(50 * time.Millisecond)
 	var sawLock bool
-DrainU2U:
+DrainTerm:
 	for {
 		select {
 		case ev := <-sub.C:
@@ -300,12 +353,12 @@ DrainU2U:
 				continue
 			}
 			if ev.Kind == events.KindGrant {
-				t.Errorf("unit-to-unit FLCO produced a grant event")
+				t.Errorf("Terminator FLCO produced a grant event")
 				continue
 			}
-			t.Errorf("unexpected event for unit-to-unit FLCO: %s", ev.Kind)
+			t.Errorf("unexpected event for Terminator FLCO: %s", ev.Kind)
 		case <-timeout:
-			break DrainU2U
+			break DrainTerm
 		}
 	}
 	if !sawLock {

--- a/internal/radio/dmr/tier3/control.go
+++ b/internal/radio/dmr/tier3/control.go
@@ -270,7 +270,12 @@ func (c *ControlChannel) handleBroadcast(cc uint8, b BroadcastAnnouncement) {
 // DMR call's slot becomes part of the engine's (frequency, timeslot)
 // call identity — both slots of a 12.5 kHz carrier carry independent
 // calls.
-func (c *ControlChannel) publishGrant(cc uint8, lcn uint16, slot uint8, group, source uint32) (uint32, bool) {
+//
+// individual marks a private (unit-to-unit) call: its group argument is a
+// destination subscriber, not a talkgroup, so the grant carries
+// Individual=true and discovery never lists the destination as a TG. The
+// shared TV/PV grant callers pass false/true respectively.
+func (c *ControlChannel) publishGrant(cc uint8, lcn uint16, slot uint8, group, source uint32, individual bool) (uint32, bool) {
 	// Observe the granted LCN before resolution so the autoconfig learner
 	// sees it even when no band plan is configured yet (the very case it
 	// exists to fix). Additive: success/no-bandplan behaviour is unchanged.
@@ -298,6 +303,7 @@ func (c *ControlChannel) publishGrant(cc uint8, lcn uint16, slot uint8, group, s
 			Protocol:            "dmr-tier3",
 			GroupID:             group,
 			SourceID:            source,
+			Individual:          individual,
 			FrequencyHz:         freq,
 			ChannelID:           cc,
 			ChannelNum:          lcn,
@@ -313,7 +319,7 @@ func (c *ControlChannel) publishGrant(cc uint8, lcn uint16, slot uint8, group, s
 }
 
 func (c *ControlChannel) publishTVGrant(cc uint8, g TVGrant) {
-	freq, ok := c.publishGrant(cc, g.LCN, g.Timeslot, g.GroupAddress, g.SourceID)
+	freq, ok := c.publishGrant(cc, g.LCN, g.Timeslot, g.GroupAddress, g.SourceID, false)
 	if !ok {
 		return
 	}
@@ -323,7 +329,7 @@ func (c *ControlChannel) publishTVGrant(cc uint8, g TVGrant) {
 }
 
 func (c *ControlChannel) publishPVGrant(cc uint8, g PVGrant) {
-	freq, ok := c.publishGrant(cc, g.LCN, g.Timeslot, g.DestinationID, g.SourceID)
+	freq, ok := c.publishGrant(cc, g.LCN, g.Timeslot, g.DestinationID, g.SourceID, true)
 	if !ok {
 		return
 	}

--- a/internal/radio/dmr/tier3/control_test.go
+++ b/internal/radio/dmr/tier3/control_test.go
@@ -149,6 +149,10 @@ func TestControlChannelPublishesTVGrant(t *testing.T) {
 			if g.Encrypted || g.Emergency {
 				t.Errorf("flags = enc=%v emer=%v, want both false", g.Encrypted, g.Emergency)
 			}
+			// A talkgroup-voice grant is not an individual call.
+			if g.Individual {
+				t.Error("TV grant wrongly marked Individual")
+			}
 			// payload bit 12 set → CSBK TS2 (0-based 1) → 1-based Timeslot 2.
 			if g.Timeslot != 2 {
 				t.Errorf("Timeslot = %d, want 2 (TS2)", g.Timeslot)
@@ -233,6 +237,12 @@ func TestControlChannelPublishesPVGrant(t *testing.T) {
 			// payload bit 12 clear → CSBK TS1 (0-based 0) → 1-based Timeslot 1.
 			if g.Timeslot != 1 {
 				t.Errorf("Timeslot = %d, want 1 (TS1)", g.Timeslot)
+			}
+			// A private (unit-to-unit) call: GroupID is a destination
+			// subscriber, not a talkgroup, so the grant must be marked
+			// Individual — otherwise discovery lists the dst RID as a TG.
+			if !g.Individual {
+				t.Error("PV grant not marked Individual")
 			}
 			return
 		case <-deadline:

--- a/internal/radio/dmr/tier3/vendor.go
+++ b/internal/radio/dmr/tier3/vendor.go
@@ -96,7 +96,7 @@ func (c *ControlChannel) handleVendorCSBK(vendor Vendor, cc uint8, csbk CSBK) {
 // layer, not the voice codec, so the engine / recorder / vocoder paths
 // are unaffected.
 func (c *ControlChannel) publishVendorTVGrant(vendor Vendor, cc uint8, g TVGrant) {
-	freq, ok := c.publishGrant(cc, g.LCN, g.Timeslot, g.GroupAddress, g.SourceID)
+	freq, ok := c.publishGrant(cc, g.LCN, g.Timeslot, g.GroupAddress, g.SourceID, false)
 	if !ok {
 		return
 	}
@@ -107,7 +107,7 @@ func (c *ControlChannel) publishVendorTVGrant(vendor Vendor, cc uint8, g TVGrant
 
 // publishVendorPVGrant emits a private voice grant from a vendor CSBK.
 func (c *ControlChannel) publishVendorPVGrant(vendor Vendor, cc uint8, g PVGrant) {
-	freq, ok := c.publishGrant(cc, g.LCN, g.Timeslot, g.DestinationID, g.SourceID)
+	freq, ok := c.publishGrant(cc, g.LCN, g.Timeslot, g.DestinationID, g.SourceID, true)
 	if !ok {
 		return
 	}


### PR DESCRIPTION
## Summary

DMR private (unit-to-unit) calls were handled inconsistently and incompletely:

- **Tier II conventional dropped them entirely** — any non-group Voice LC Header was ignored, so a private call produced no grant, was never followed, and never recorded.
- **Tier III mislabelled them** — the shared grant path never set `trunking.Grant.Individual`, so a private call's *destination subscriber* was published as if it were a talkgroup, polluting talkgroup discovery.

P25 already models this correctly via `Grant.Individual`. This brings DMR to parity (workstream **W11** — unit-to-unit — from the cross-protocol feature-parity plan).

## Changes

- **Tier III — set `Individual` on private-voice grants** (`tier3/control.go`, `tier3/vendor.go`). Thread an `individual` flag through the shared `publishGrant`; the TV / vendor-TV callers pass `false`, the PV / vendor-PV callers pass `true`.
- **Tier II — follow unit-to-unit calls** (`tier2/conventional.go`). Add `FLC.AsUnitToUnitVoice` (mirroring `AsGroupVoiceUser`, `flc.go`) and publish a grant for a private Voice LC Header with `Individual=true`, `GroupID`=destination subscriber. The call is followed on the tuned frequency exactly like a group call; the audio path already decodes it, so no composer change is needed.

## Test plan

- [x] `make vet test` is green locally (165 packages, 0 failures)
- [ ] `make integration` — n/a (no daemon/DSP/replay wiring changed)
- [x] Added / updated tests (each fails without the change):
  - `tier3/control_test.go` — the PV grant test now asserts `Individual` is set; the TV test asserts it is not.
  - `tier2/conventional_test.go` — new `TestConventionalPublishesUnitToUnitGrant`; the obsolete `TestConventionalIgnoresNonGroupFLCO` (which pinned the old drop behaviour) is repurposed to cover a genuinely non-voice FLCO (Terminator).
  - `flc_test.go` — `TestFLCAsUnitToUnitVoice` covers the new accessor incl. the emergency/encrypted service-option bits.
- [ ] Smoke-tested against real hardware — n/a (pure control-path metadata fix, covered by unit tests).

## Breaking changes

None. `Grant.Individual` is an existing field; this only starts populating it correctly for DMR. No config keys, flags, or endpoints change.

## Docs / CHANGELOG

- [x] Added `## [Unreleased]` bullets to `CHANGELOG.md` (an Added entry for Tier II following, a Fixed entry for the Tier III mislabel)
- [ ] README/docs — n/a

## Linked issues

n/a — part of the cross-protocol feature-parity roadmap.

## Follow-up (not in this PR)

The interleaved-voice `slotRouter` binds a call's timeslot via the embedded LC's `AsGroupVoiceUser`; a unit-to-unit call's embedded LC won't match, so it records via the existing phase fallback (#644). Binding unit-to-unit embedded LCs to a slot is a separate, additive change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144w5FXPjW3oeryHqugKAjP

---
_Generated by [Claude Code](https://claude.ai/code/session_0144w5FXPjW3oeryHqugKAjP)_