### PR TITLE
composer: route and attribute DMR unit-to-unit voice calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **DMR private (unit-to-unit) calls route and attribute correctly on
+  interleaved carriers.** The 2-slot `slotRouter` now binds a private call's
+  timeslot from its unit-to-unit embedded LC (by called subscriber), instead
+  of only recording it via the phase fallback, and the voice chain learns the
+  call's source radio from a unit-to-unit LC too — so talker-alias / GPS
+  metadata is attributed to the caller on private calls, not just group calls.
+  Completes the unit-to-unit voice-follow work.
 - **DMR private (unit-to-unit) calls are now followed.** A Tier II
   conventional channel dropped any non-group Voice LC Header, so DMR private
   calls were invisible — no grant, never followed, never recorded. The

--- a/internal/voice/composer/dmr_slot_router_test.go
+++ b/internal/voice/composer/dmr_slot_router_test.go
@@ -19,6 +19,37 @@ func sfNoLC(phase uint8) dmrvoice.VoiceSuperframe {
 	return dmrvoice.VoiceSuperframe{Phase: phase}
 }
 
+// sfWithU2ULC is sfWithLC for a unit-to-unit (private) call: the embedded
+// LC's destination is the called subscriber, which is the private grant's
+// GroupID.
+func sfWithU2ULC(phase uint8, dest uint32) dmrvoice.VoiceSuperframe {
+	return dmrvoice.VoiceSuperframe{
+		Phase: phase,
+		HasLC: true,
+		LC:    dmr.FLC{FLCO: dmr.FLCOUnitToUnitVoice, DstAddr: dest, SrcAddr: 9},
+	}
+}
+
+// TestSlotRouterRoutesUnitToUnitLC confirms a private call's embedded LC
+// binds the slot by its destination subscriber, exactly like a group LC
+// binds by talkgroup — otherwise a private call on an interleaved carrier
+// would only ever record via the phase fallback.
+func TestSlotRouterRoutesUnitToUnitLC(t *testing.T) {
+	r := newSlotRouter(0x00ABCD) // grant GroupID = called subscriber
+
+	if !r.accept(sfWithU2ULC(1, 0x00ABCD)) {
+		t.Fatal("rejected our own unit-to-unit LC")
+	}
+	// The other slot carries a group call for a different TG.
+	if r.accept(sfWithLC(0, 200)) {
+		t.Error("accepted the other slot's group LC")
+	}
+	// Bound to phase 1: an LC-less phase-1 superframe is ours.
+	if !r.accept(sfNoLC(1)) {
+		t.Error("rejected a bound-phase superframe missing its LC")
+	}
+}
+
 func TestSlotRouterRoutesByEmbeddedLC(t *testing.T) {
 	r := newSlotRouter(100)
 

--- a/internal/voice/composer/dmr_u2u_attribution_test.go
+++ b/internal/voice/composer/dmr_u2u_attribution_test.go
@@ -1,0 +1,99 @@
+package composer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TestComposerDMRAttributesAliasOnUnitToUnitCall confirms the voice chain
+// learns the call's source radio from a unit-to-unit (private) voice LC —
+// not just a group LC — so talker-alias metadata is attributed on private
+// calls. Regression for the source-tracking half of the unit-to-unit work.
+func TestComposerDMRAttributesAliasOnUnitToUnitCall(t *testing.T) {
+	const (
+		sampleRate = 48_000.0
+		sps        = 10
+		span       = 8
+		alpha      = 0.20
+		deviation  = 1944.0
+	)
+	const wantAlias = "Truck 349"
+	const wantSrc = uint32(77000)
+
+	// A private call: the Voice LC destination is a called subscriber; its
+	// source is the radio the alias names.
+	u2u := dmr.AssembleFLC(dmr.FLC{FLCO: dmr.FLCOUnitToUnitVoice, DstAddr: 0x00ABCD, SrcAddr: wantSrc})
+	aliasFrags := dmr.AssembleTalkerAliasFragments(dmr.TalkerAliasFormatUTF8, wantAlias)
+
+	var lcInfos [][]byte
+	for cycle := 0; cycle < 6; cycle++ {
+		lcInfos = append(lcInfos, u2u)
+		lcInfos = append(lcInfos, aliasFrags...)
+	}
+	dibits := buildVoiceStreamWithLCInfos(t, lcInfos)
+	iq := demod.ModulateC4FM(dibits, sps, span, alpha, sampleRate, deviation)
+
+	src := newFakeSource()
+	bus := events.NewBus(64)
+	sub := bus.Subscribe()
+	defer sub.Close()
+	sink := &recordingSink{}
+	eng := &fakeEngine{}
+	c, err := New(Options{
+		Bus:           bus,
+		Devices:       &fakeDevices{src: map[string]IQSource{"VOICE-1": src}},
+		Sink:          sink,
+		Engine:        eng,
+		IQSampleRate:  uint32(sampleRate),
+		PCMSampleRate: 8000,
+		TouchInterval: 30 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go c.Run(ctx)
+	defer c.Close()
+	defer bus.Close()
+
+	bus.Publish(events.Event{
+		Kind: events.KindCallStart,
+		Payload: trunking.CallStart{
+			Grant: trunking.Grant{
+				System: "DMRSite", Protocol: "dmr-tier3",
+				GroupID: 0x00ABCD, Individual: true, FrequencyHz: 460_000_000,
+			},
+			DeviceSerial: "VOICE-1",
+			StartedAt:    time.Now().UTC(),
+		},
+	})
+	waitFor(t, 2*time.Second, func() bool { return len(c.ActiveChains()) == 1 })
+	src.SendIQ(iq)
+
+	deadline := time.After(8 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			t.Fatalf("no KindTalkerAlias attributed to the private call's source %d", wantSrc)
+		case ev := <-sub.C:
+			if ev.Kind != events.KindTalkerAlias {
+				continue
+			}
+			ta, ok := ev.Payload.(trunking.TalkerAlias)
+			if !ok || ta.Alias != wantAlias {
+				continue
+			}
+			if ta.SourceID != wantSrc {
+				t.Fatalf("alias SourceID = %d, want %d (from unit-to-unit LC)", ta.SourceID, wantSrc)
+			}
+			return
+		}
+	}
+}

--- a/internal/voice/composer/dmr_voice.go
+++ b/internal/voice/composer/dmr_voice.go
@@ -332,8 +332,13 @@ func (c *Composer) runDMRVoiceChain(ctx context.Context, serial, system string, 
 			for _, sf := range voiceDec.Process(dibits, baseIdx) {
 				if sf.HasLC {
 					lcSuperframes.Add(1)
+					// Learn the call's source radio from either a group-voice or a
+					// unit-to-unit voice LC, so talker-alias / GPS metadata (which
+					// carry no address of their own) is attributed on private calls too.
 					if gv, ok := sf.LC.AsGroupVoiceUser(); ok && gv.SourceID != 0 {
 						callSrc = gv.SourceID
+					} else if uu, ok := sf.LC.AsUnitToUnitVoice(); ok && uu.SourceID != 0 {
+						callSrc = uu.SourceID
 					}
 				}
 				// Talker-alias header/block and GPS Info embedded LCs are

--- a/internal/voice/composer/dmr_voice.go
+++ b/internal/voice/composer/dmr_voice.go
@@ -158,6 +158,21 @@ func newSlotRouter(groupID uint32) *slotRouter {
 	return &slotRouter{groupID: groupID, bound: -1}
 }
 
+// lcCallDestination returns the destination address a voice embedded LC
+// names — a talkgroup for a group call or the called subscriber for a
+// unit-to-unit (private) call — so a call's slot can be bound by its
+// grant's GroupID regardless of call type. ok is false for any other FLCO
+// (talker alias, GPS, terminator, …), which carries no call destination.
+func lcCallDestination(lc dmr.FLC) (uint32, bool) {
+	if gv, ok := lc.AsGroupVoiceUser(); ok {
+		return gv.GroupAddress, true
+	}
+	if uu, ok := lc.AsUnitToUnitVoice(); ok {
+		return uu.DestinationID, true
+	}
+	return 0, false
+}
+
 // accept reports whether sf belongs to this call's timeslot. An embedded LC
 // naming this call's talkgroup is authoritative and binds (or re-binds) the
 // phase. Absent a usable LC, once a phase is bound we route by it; while still
@@ -165,14 +180,14 @@ func newSlotRouter(groupID uint32) *slotRouter {
 // the active slot's phase so the call still records rather than dropping it.
 func (r *slotRouter) accept(sf dmrvoice.VoiceSuperframe) bool {
 	if sf.HasLC {
-		if gv, ok := sf.LC.AsGroupVoiceUser(); ok {
-			if gv.GroupAddress == r.groupID {
+		if dest, ok := lcCallDestination(sf.LC); ok {
+			if dest == r.groupID {
 				r.bound = int(sf.Phase)
 				r.byFallback = false
 				return true
 			}
-			// LC names a different talkgroup — this phase is positively the
-			// other slot, so never fall back onto it later.
+			// LC names a different destination (talkgroup or called unit) — this
+			// phase is positively the other slot, so never fall back onto it.
 			r.foreignPhaseMask |= 1 << (sf.Phase & 1)
 			return false
 		}


### PR DESCRIPTION
## Summary

Follow-on to #1037 (which made DMR private / unit-to-unit calls produce grants). The composer's voice path still only understood *group*-voice embedded LCs, so a private call was handled second-class:

- On a 2-slot interleaved carrier, the `slotRouter` bound a timeslot only from a group LC, so a private call never bound positively — it recorded via the phase fallback.
- The chain learned the call's source radio only from a group LC, so talker-alias / GPS metadata (which carry no address of their own) went unattributed on private calls — source 0, so nothing published.

This completes the unit-to-unit voice-follow work (workstream **W11**), reusing the `FLC.AsUnitToUnitVoice` accessor from #1037.

## Changes

- **Route private calls by their LC** (`dmr_voice.go`). Add `lcCallDestination`, which returns the destination a voice LC names — a talkgroup for a group call, the called subscriber for a private call — and bind the slot on it. A private grant's `GroupID` is its called subscriber, so the destinations line up.
- **Attribute source on private calls** (`dmr_voice.go`). Learn the call's source radio from a unit-to-unit voice LC as well as a group LC, so talker-alias / GPS metadata is attributed to the caller.

## Test plan

- [x] `make vet test` is green locally (165 packages, 0 failures)
- [ ] `make integration` — n/a (composer chain covered by the end-to-end unit test below)
- [x] Added tests:
  - `dmr_slot_router_test.go` — `TestSlotRouterRoutesUnitToUnitLC`: a private call's LC binds the slot by called subscriber, and an LC-less bound-phase superframe is then attributed to it.
  - `dmr_u2u_attribution_test.go` — end-to-end: a private call carrying a talker alias publishes it with the caller's source ID.
- [ ] Smoke-tested against real hardware — n/a (covered by unit tests; the DMR embedded-signalling constants remain capture-pending per #644, unchanged here).

## Breaking changes

None. Behaviour for group calls is unchanged (the group path is the first branch of the shared helper).

## Docs / CHANGELOG

- [x] Added an `## [Unreleased]` bullet to `CHANGELOG.md`
- [ ] README/docs — n/a

## Linked issues

Refs #1037. Part of the cross-protocol feature-parity roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144w5FXPjW3oeryHqugKAjP

---
_Generated by [Claude Code](https://claude.ai/code/session_0144w5FXPjW3oeryHqugKAjP)_