### PR TITLE
dmr/tier2: end conventional calls promptly on the Terminator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **DMR Tier II conventional calls end promptly on the Terminator.** The
+  decoder now publishes a `call.release` when it sees the explicit
+  Terminator-with-LC burst, so the engine tears the call down at once
+  instead of waiting out the composer's hangtime / no-voice timers — the
+  same prompt-teardown TETRA already drives from D-RELEASE. Recorded call
+  durations match the air more closely.
 - **DMR private (unit-to-unit) calls route and attribute correctly on
   interleaved carriers.** The 2-slot `slotRouter` now binds a private call's
   timeslot from its unit-to-unit embedded LC (by called subscriber), instead

--- a/internal/radio/dmr/tier2/conventional.go
+++ b/internal/radio/dmr/tier2/conventional.go
@@ -330,6 +330,22 @@ func (c *ConventionalChannel) handleTerminator() {
 	if !c.inCall {
 		return
 	}
+	// A Terminator with LC is the explicit end of the transmission. Publish a
+	// call release so the engine ends the call at once, rather than waiting out
+	// the composer's hangtime / no-voice timers — the same prompt-teardown path
+	// TETRA's D-RELEASE drives. Keyed by (System, GroupID); a no-match release
+	// is a harmless no-op.
+	if c.bus != nil && c.lastTG != 0 {
+		c.bus.Publish(events.Event{
+			Kind: events.KindCallRelease,
+			Payload: trunking.CallRelease{
+				System:  c.systemName,
+				GroupID: c.lastTG,
+				Reason:  trunking.EndReasonReleased,
+				At:      c.now(),
+			},
+		})
+	}
 	c.inCall = false
 	c.lastTG = 0
 	c.lastSrc = 0

--- a/internal/radio/dmr/tier2/conventional_test.go
+++ b/internal/radio/dmr/tier2/conventional_test.go
@@ -329,6 +329,48 @@ DrainCSBK:
 	}
 }
 
+// TestConventionalPublishesReleaseOnTerminator confirms an explicit
+// Terminator-with-LC ends the call promptly: the decoder publishes a
+// KindCallRelease keyed to the active call's talkgroup, rather than
+// leaving the engine to wait out the hangtime timers.
+func TestConventionalPublishesReleaseOnTerminator(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus:         bus,
+		SystemName:  "TestRepeater",
+		FrequencyHz: 451_000_000,
+		Now:         func() time.Time { return time.Unix(1_700_000_000, 0).UTC() },
+	})
+	// A group call opens (Voice LC Header), then a Terminator ends it.
+	flc := dmr.FLC{FLCO: dmr.FLCOGroupVoiceUser, DstAddr: 0x000064, SrcAddr: 0x100200}
+	cc.IngestBurst(burstWithFLC(flc), dmr.SlotType{ColorCode: 5, DataType: dmr.DTVoiceLCHeader})
+	cc.IngestBurst(burstWithFLC(flc), dmr.SlotType{ColorCode: 5, DataType: dmr.DTTerminatorWithLC})
+
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind != events.KindCallRelease {
+				continue
+			}
+			r := ev.Payload.(trunking.CallRelease)
+			if r.System != "TestRepeater" || r.GroupID != 0x64 {
+				t.Fatalf("release identity = %s/%X, want TestRepeater/64", r.System, r.GroupID)
+			}
+			if r.Reason != trunking.EndReasonReleased {
+				t.Errorf("reason = %v, want Released", r.Reason)
+			}
+			return
+		case <-deadline:
+			t.Fatal("no KindCallRelease on Terminator")
+		}
+	}
+}
+
 func TestConventionalIgnoresTerminatorFLCO(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()


### PR DESCRIPTION
## Summary

A DMR Tier II conventional call ended only when the composer's hangtime / no-voice timers expired. The decoder already sees the explicit **Terminator-with-LC** burst that marks end-of-transmission — but it merely cleared local state and published nothing, so the engine had no signal to tear the call down. TETRA already drives prompt teardown from D-RELEASE via `KindCallRelease`; DMR published no release at all. This brings DMR to parity.

## Changes

- **`tier2/conventional.go`** — `handleTerminator` now publishes a `KindCallRelease` keyed to the active call's `(System, GroupID)` before clearing state. The engine's `handleCallRelease` ends the matching call at once; it is idempotent with the hangtime end, so a release racing the timeout still yields exactly one `CallEnd`, and a no-match release is a harmless no-op.

## Test plan

- [x] `make vet test` is green locally (165 packages, 0 failures)
- [ ] `make integration` — n/a (no daemon/DSP wiring changed; the engine's release handling is already covered)
- [x] Added a failing-first test: `TestConventionalPublishesReleaseOnTerminator` — a group call opened by a Voice LC Header and then closed by a Terminator publishes a `call.release` with the right system/talkgroup/reason. The existing terminator state-clearing test (`TestConventionalNewCallAfterTerminator`) still passes.
- [ ] Smoke-tested against real hardware — n/a (control-path event, covered by unit test).

## Breaking changes

None. Additive event; the engine already consumes `KindCallRelease`.

## Docs / CHANGELOG

- [x] Added an `## [Unreleased]` bullet to `CHANGELOG.md`
- [ ] README/docs — n/a

## Linked issues

n/a — part of the cross-protocol feature-parity roadmap.

## Note

This covers the Tier II conventional path, where the decoder sees the traffic-channel Terminator directly. Tier III's terminator arrives on the followed traffic channel (the composer's voice path), so prompt release there is a separate, larger change — noted for a future PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144w5FXPjW3oeryHqugKAjP

---
_Generated by [Claude Code](https://claude.ai/code/session_0144w5FXPjW3oeryHqugKAjP)_