### PR TITLE
composer: end followed DMR calls promptly on the Terminator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **Followed DMR calls (Tier III / Tier I) end promptly on the Terminator.**
+  The voice chain now detects the Terminator-with-LC burst on the followed
+  traffic channel — reusing the trusted control-path FEC chain (slot-type
+  Hamming, BPTC, RS(12,9) terminator seed) so a garbled data burst can't
+  forge an end-of-call — and publishes a `call.release` for the matching
+  group, so the engine tears the call down at once instead of waiting out
+  the hangtime. Extends the Tier II conventional prompt-release to followed
+  calls; strictly additive (the hangtime path still ends a call whose
+  terminator never decodes).
 - **DMR Tier II conventional calls end promptly on the Terminator.** The
   decoder now publishes a `call.release` when it sees the explicit
   Terminator-with-LC burst, so the engine tears the call down at once

--- a/internal/radio/dmr/voice/terminator.go
+++ b/internal/radio/dmr/voice/terminator.go
@@ -1,0 +1,138 @@
+package voice
+
+import (
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
+
+// TerminatorDetector finds the "Terminator with LC" burst that ends a DMR
+// transmission in a followed traffic-channel dibit stream. The voice
+// Decoder locks on voice sync and so never sees the terminator (a data
+// burst); this detector runs alongside it and lets the voice chain end the
+// call at once instead of waiting out the composer's hangtime — the
+// traffic-channel analogue of the Tier II conventional decoder's
+// KindCallRelease (issue-parity with TETRA D-RELEASE).
+//
+// It reuses the exact, trusted decode chain the Tier II control path uses:
+// multi-pattern sync detection over the data sync words, 132-dibit burst
+// slicing at both discriminator polarities, slot-type Hamming(20,8) decode,
+// BPTC(196,96), and an RS(12,9) parity check with the Terminator-with-LC
+// seed. A burst is only reported when it clears every one of those layers,
+// so a mid-call data burst cannot be miscorrected into a false end-of-call.
+//
+// The recovered FLC's destination names the call being torn down; the
+// caller ends its call only when that destination matches, so a terminator
+// on the other timeslot of an interleaved carrier never ends this call.
+
+// terminatorSyncs are the data-burst sync words that frame a Terminator
+// with LC (BS-sourced and MS/DM direct). Voice syncs are intentionally
+// excluded — the voice Decoder already handles those.
+var terminatorSyncs = []dmr.SyncPattern{dmr.BSData, dmr.MSData, dmr.DMData1, dmr.DMData2}
+
+const (
+	// termBurstLookback / termBurstLookahead mirror the Tier II Process
+	// adapter: the sync match index is the last sync dibit, so the burst
+	// starts 77 dibits behind it and ends 54 ahead.
+	termBurstLookback  = dmr.HalfPayloadDibits + dmr.SlotTypeDibits + dmr.SyncDibits - 1
+	termBurstLookahead = dmr.SlotTypeDibits + dmr.HalfPayloadDibits
+	termBufKeep        = termBurstLookback + termBurstLookahead + 32
+)
+
+// TerminatorDetector is stateful and not safe for concurrent use;
+// construct one per voice-decode chain.
+type TerminatorDetector struct {
+	det      *dmr.SyncDetector
+	buf      []uint8
+	bufStart int
+	pending  []dmr.Match
+}
+
+// NewTerminatorDetector returns a ready detector.
+func NewTerminatorDetector() *TerminatorDetector {
+	return &TerminatorDetector{det: dmr.NewSyncDetector(terminatorSyncs, 2)}
+}
+
+// Process consumes a window of dibits and returns the recovered Full Link
+// Control of every valid Terminator-with-LC burst that completed within it.
+// baseIdx is the absolute dibit index of dibits[0]; it must be
+// monotonically non-decreasing across calls.
+func (d *TerminatorDetector) Process(dibits []uint8, baseIdx int) []dmr.FLC {
+	if len(d.buf) == 0 {
+		d.bufStart = baseIdx
+	}
+	d.buf = append(d.buf, dibits...)
+
+	matches, _ := d.det.Process(nil, dibits, baseIdx)
+	d.pending = append(d.pending, matches...)
+
+	var out []dmr.FLC
+	bufEnd := d.bufStart + len(d.buf)
+	keep := d.pending[:0]
+	for _, m := range d.pending {
+		burstStart := m.Index - termBurstLookback
+		burstEnd := m.Index + termBurstLookahead + 1
+		if burstEnd > bufEnd {
+			keep = append(keep, m) // trailing burst not fully buffered yet
+			continue
+		}
+		if burstStart < d.bufStart {
+			continue // anchor fell off the front of the buffer
+		}
+		offset := burstStart - d.bufStart
+		if flc, ok := decodeTerminator(d.buf[offset : offset+dmr.BurstDibits]); ok {
+			out = append(out, flc)
+		}
+	}
+	d.pending = keep
+
+	if len(d.buf) > termBufKeep {
+		drop := len(d.buf) - termBufKeep
+		copy(d.buf, d.buf[drop:])
+		d.buf = d.buf[:termBufKeep]
+		d.bufStart += drop
+	}
+	return out
+}
+
+// decodeTerminator decodes a candidate 132-dibit burst at both
+// discriminator polarities and returns the FLC when it is a genuine
+// Terminator with LC — slot-type Hamming, BPTC, and RS(12,9) with the
+// terminator seed all clearing. The wrong polarity is dropped by the FEC
+// with no side effect, so spectrum-inverted reception (issue #264) is
+// handled the same way the Tier II adapter handles it.
+func decodeTerminator(burstDibits []uint8) (dmr.FLC, bool) {
+	for _, k := range dmr.CandidatePolarities {
+		var b dmr.Burst
+		copy(b.Dibits[:], burstDibits)
+		dmr.RotateBurstDibits(&b, k)
+
+		slot, _, err := dmr.ParseSlotType(b.SlotTypeBitsAll())
+		if err != nil || slot.DataType != dmr.DTTerminatorWithLC {
+			continue
+		}
+		bits, errs := framing.DecodeBPTC196_96(b.PayloadBits())
+		if errs < 0 {
+			continue
+		}
+		info := infoBitsToBytes96(bits)
+		if !framing.VerifyRS12_9(info, framing.RS129SeedTerminatorLC) {
+			continue
+		}
+		if flc, err := dmr.ParseFLC(info); err == nil {
+			return flc, true
+		}
+	}
+	return dmr.FLC{}, false
+}
+
+// infoBitsToBytes96 packs a 96-bit slice (each entry 0/1, MSB-first) into
+// 12 bytes — the 9 FLC octets plus the 3 RS(12,9) parity octets.
+func infoBitsToBytes96(bits []byte) []byte {
+	out := make([]byte, 12)
+	for i := 0; i < 96 && i < len(bits); i++ {
+		if bits[i]&1 != 0 {
+			out[i>>3] |= 1 << uint(7-(i&7))
+		}
+	}
+	return out
+}

--- a/internal/radio/dmr/voice/terminator_test.go
+++ b/internal/radio/dmr/voice/terminator_test.go
@@ -1,0 +1,80 @@
+package voice
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
+
+// buildTerminatorBurstDibits builds a full on-air Terminator-with-LC burst
+// carrying flc: BPTC(196,96) over the RS(12,9) terminator-seeded FLC, the
+// slot-type Hamming codeword for DTTerminatorWithLC, and a BS-Data sync.
+// Mirrors the Tier II process test's voice-LC-header builder.
+func buildTerminatorBurstDibits(t *testing.T, flc dmr.FLC, colorCode uint8) []uint8 {
+	t.Helper()
+	flcBytes := dmr.AssembleFLC(flc)
+	var data [9]byte
+	copy(data[:], flcBytes)
+	cw := framing.EncodeRS12_9(data)
+	for i := 0; i < 3; i++ {
+		cw[9+i] ^= framing.RS129SeedTerminatorLC[i]
+	}
+	bits := make([]byte, 96)
+	for i := 0; i < 96; i++ {
+		bits[i] = (cw[i>>3] >> uint(7-(i&7))) & 1
+	}
+	payloadDibits := framing.BitsToDibits(framing.EncodeBPTC196_96(bits))
+	slotDibits := framing.BitsToDibits(dmr.AssembleSlotType(dmr.SlotType{ColorCode: colorCode, DataType: dmr.DTTerminatorWithLC}))
+
+	burst := make([]uint8, 0, dmr.BurstDibits)
+	burst = append(burst, payloadDibits[:dmr.HalfPayloadDibits]...)
+	burst = append(burst, slotDibits[:dmr.SlotTypeDibits]...)
+	burst = append(burst, dmr.BSData.Dibits[:]...)
+	burst = append(burst, slotDibits[dmr.SlotTypeDibits:]...)
+	burst = append(burst, payloadDibits[dmr.HalfPayloadDibits:]...)
+	return burst
+}
+
+func TestTerminatorDetectorFindsTerminator(t *testing.T) {
+	flc := dmr.FLC{FLCO: dmr.FLCOGroupVoiceUser, DstAddr: 0x000064, SrcAddr: 0x100200}
+	burst := buildTerminatorBurstDibits(t, flc, 5)
+	stream := append(make([]uint8, 60), burst...) // lead-in filler
+	stream = append(stream, make([]uint8, 40)...) // trailing so the burst is fully buffered
+
+	d := NewTerminatorDetector()
+	got := d.Process(stream, 0)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 terminator, got %d", len(got))
+	}
+	if dest, ok := got[0].AsGroupVoiceUser(); !ok || dest.GroupAddress != 0x64 {
+		t.Fatalf("recovered FLC destination wrong: %+v", got[0])
+	}
+}
+
+func TestTerminatorDetectorIgnoresNonTerminator(t *testing.T) {
+	// A voice-cadence stream (no data-sync terminator) yields nothing.
+	stream, _ := buildStream(t, 1, 40)
+	d := NewTerminatorDetector()
+	if got := d.Process(stream, 0); len(got) != 0 {
+		t.Fatalf("expected no terminator in a voice stream, got %d", len(got))
+	}
+}
+
+func TestTerminatorDetectorRejectsCorruptedPayload(t *testing.T) {
+	// A terminator burst whose payload is corrupted past FEC correction must
+	// not be reported — the RS/BPTC gate is what keeps a garbled mid-call
+	// data burst from forging an end-of-call.
+	flc := dmr.FLC{FLCO: dmr.FLCOGroupVoiceUser, DstAddr: 0x64, SrcAddr: 0x100200}
+	burst := buildTerminatorBurstDibits(t, flc, 5)
+	// Corrupt many payload dibits (well beyond BPTC/RS correction capacity).
+	for i := 0; i < dmr.HalfPayloadDibits; i++ {
+		burst[i] ^= 0x3
+	}
+	stream := append(make([]uint8, 60), burst...)
+	stream = append(stream, make([]uint8, 40)...)
+	d := NewTerminatorDetector()
+	if got := d.Process(stream, 0); len(got) != 0 {
+		t.Fatalf("reported a terminator from a corrupted burst (got %d)", len(got))
+	}
+}

--- a/internal/voice/composer/dmr_terminator_chain_test.go
+++ b/internal/voice/composer/dmr_terminator_chain_test.go
@@ -1,0 +1,124 @@
+package composer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// buildTerminatorBurst builds a full Terminator-with-LC burst carrying flc
+// (RS(12,9) terminator-seeded, BPTC, DTTerminatorWithLC slot type, BS-Data
+// sync) — the burst the followed traffic channel sends at end-of-call.
+func buildTerminatorBurst(t *testing.T, flc dmr.FLC, colorCode uint8) []uint8 {
+	t.Helper()
+	flcBytes := dmr.AssembleFLC(flc)
+	var data [9]byte
+	copy(data[:], flcBytes)
+	cw := framing.EncodeRS12_9(data)
+	for i := 0; i < 3; i++ {
+		cw[9+i] ^= framing.RS129SeedTerminatorLC[i]
+	}
+	bits := make([]byte, 96)
+	for i := 0; i < 96; i++ {
+		bits[i] = (cw[i>>3] >> uint(7-(i&7))) & 1
+	}
+	payloadDibits := framing.BitsToDibits(framing.EncodeBPTC196_96(bits))
+	slotDibits := framing.BitsToDibits(dmr.AssembleSlotType(dmr.SlotType{ColorCode: colorCode, DataType: dmr.DTTerminatorWithLC}))
+	burst := make([]uint8, 0, dmr.BurstDibits)
+	burst = append(burst, payloadDibits[:dmr.HalfPayloadDibits]...)
+	burst = append(burst, slotDibits[:dmr.SlotTypeDibits]...)
+	burst = append(burst, dmr.BSData.Dibits[:]...)
+	burst = append(burst, slotDibits[dmr.SlotTypeDibits:]...)
+	burst = append(burst, payloadDibits[dmr.HalfPayloadDibits:]...)
+	return burst
+}
+
+// TestComposerDMRReleasesOnTerminator drives the full DMR voice chain with
+// a stream that carries a group call (group-voice LCs) and then a
+// Terminator-with-LC for that group, and confirms the chain publishes a
+// KindCallRelease at once rather than waiting out the hangtime.
+func TestComposerDMRReleasesOnTerminator(t *testing.T) {
+	const (
+		sampleRate = 48_000.0
+		sps        = 10
+		span       = 8
+		alpha      = 0.20
+		deviation  = 1944.0
+	)
+	const wantTG = uint32(0x64)
+
+	gv := dmr.AssembleFLC(dmr.FLC{FLCO: dmr.FLCOGroupVoiceUser, DstAddr: wantTG, SrcAddr: 0x100200})
+	var lcInfos [][]byte
+	for i := 0; i < 3; i++ {
+		lcInfos = append(lcInfos, gv)
+	}
+	dibits := buildVoiceStreamWithLCInfos(t, lcInfos)
+	// Append the terminator for this group, then trailing filler so it buffers.
+	dibits = append(dibits, buildTerminatorBurst(t, dmr.FLC{FLCO: dmr.FLCOGroupVoiceUser, DstAddr: wantTG, SrcAddr: 0x100200}, 1)...)
+	dibits = append(dibits, make([]uint8, 200)...)
+	iq := demod.ModulateC4FM(dibits, sps, span, alpha, sampleRate, deviation)
+
+	src := newFakeSource()
+	bus := events.NewBus(64)
+	sub := bus.Subscribe()
+	defer sub.Close()
+	sink := &recordingSink{}
+	eng := &fakeEngine{}
+	c, err := New(Options{
+		Bus:           bus,
+		Devices:       &fakeDevices{src: map[string]IQSource{"VOICE-1": src}},
+		Sink:          sink,
+		Engine:        eng,
+		IQSampleRate:  uint32(sampleRate),
+		PCMSampleRate: 8000,
+		TouchInterval: 30 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go c.Run(ctx)
+	defer c.Close()
+	defer bus.Close()
+
+	bus.Publish(events.Event{
+		Kind: events.KindCallStart,
+		Payload: trunking.CallStart{
+			Grant: trunking.Grant{
+				System: "DMRSite", Protocol: "dmr-tier3",
+				GroupID: wantTG, FrequencyHz: 460_000_000,
+			},
+			DeviceSerial: "VOICE-1",
+			StartedAt:    time.Now().UTC(),
+		},
+	})
+	waitFor(t, 2*time.Second, func() bool { return len(c.ActiveChains()) == 1 })
+	src.SendIQ(iq)
+
+	deadline := time.After(8 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			t.Fatal("no KindCallRelease published on the Terminator")
+		case ev := <-sub.C:
+			if ev.Kind != events.KindCallRelease {
+				continue
+			}
+			r, ok := ev.Payload.(trunking.CallRelease)
+			if !ok {
+				continue
+			}
+			if r.System != "DMRSite" || r.GroupID != wantTG {
+				t.Fatalf("release identity = %s/%X, want DMRSite/%X", r.System, r.GroupID, wantTG)
+			}
+			return
+		}
+	}
+}

--- a/internal/voice/composer/dmr_voice.go
+++ b/internal/voice/composer/dmr_voice.go
@@ -303,6 +303,34 @@ func (c *Composer) runDMRVoiceChain(ctx context.Context, serial, system string, 
 			},
 		})
 	}
+	// Terminator detection: end the call at once when the followed traffic
+	// channel carries a valid Terminator-with-LC for this call's group,
+	// rather than waiting out the boundary tracker's hangtime. Publish once —
+	// the engine's release handling is idempotent, and a stationary end may
+	// repeat the terminator. Only a terminator whose LC destination matches
+	// this call's groupID ends it, so the other timeslot of an interleaved
+	// carrier never tears this call down; if no terminator ever decodes (real
+	// embedded/data-burst FEC is capture-pending, #644) the hangtime path
+	// still ends the call, so this is strictly additive.
+	termDet := dmrvoice.NewTerminatorDetector()
+	var released bool
+	publishRelease := func() {
+		if released || c.bus == nil || groupID == 0 {
+			return
+		}
+		released = true
+		c.log.Debug("composer: dmr terminator — releasing call",
+			"system", system, "serial", serial, "group", groupID)
+		c.bus.Publish(events.Event{
+			Kind: events.KindCallRelease,
+			Payload: trunking.CallRelease{
+				System:  system,
+				GroupID: groupID,
+				Reason:  trunking.EndReasonReleased,
+				At:      time.Now(),
+			},
+		})
+	}
 	// superframes counts DMR voice superframes the receiver delivered —
 	// i.e. real voice activity. The touch ticker (below) only refreshes
 	// the engine's LastHeardAt when this counter has advanced since the
@@ -329,6 +357,12 @@ func (c *Composer) runDMRVoiceChain(ctx context.Context, serial, system string, 
 		DeviationHz: 1944.0,
 		ClockGain:   0.025,
 		DibitSink: func(dibits []uint8, baseIdx int) {
+			// End the call promptly on an explicit Terminator for this group.
+			for _, flc := range termDet.Process(dibits, baseIdx) {
+				if dest, ok := lcCallDestination(flc); ok && dest == groupID {
+					publishRelease()
+				}
+			}
 			for _, sf := range voiceDec.Process(dibits, baseIdx) {
 				if sf.HasLC {
 					lcSuperframes.Add(1)


### PR DESCRIPTION
## Summary

Follow-on to #1040, which made **Tier II conventional** DMR calls end promptly on the Terminator. A **followed** DMR call (Tier III / Tier I) is decoded on a traffic channel by the composer's voice chain, which locks on *voice* sync and so never sees the data-burst Terminator — so those calls could still only end by the composer's hangtime / no-voice timers. This detects the Terminator on the followed channel and ends the call at once, bringing followed calls to the same prompt-teardown parity (workstream: call lifecycle).

## Changes

- **`dmr/voice/terminator.go` — `TerminatorDetector`.** Runs alongside the voice decoder over the same dibit stream and reports the Full Link Control of every valid Terminator-with-LC burst. It reuses the **exact, trusted Tier II decode chain**: data-sync detection, slot-type Hamming(20,8), BPTC(196,96), and RS(12,9) with the terminator seed. A burst must clear every FEC layer to be reported.
- **`voice/composer/dmr_voice.go` — publish the release.** The DMR voice chain runs the detector and publishes a `KindCallRelease` for the call's `(System, GroupID)`. Only a terminator whose LC destination matches this call's `groupID` (via `lcCallDestination` from #1039 — group or unit-to-unit) ends it, so the other timeslot of an interleaved carrier can't tear this call down, and the release fires once.

**Safety:** the change is strictly additive. If no terminator ever decodes (real data-burst embedded FEC is capture-pending, #644), the hangtime path still ends the call — worst case is the current behaviour, never a call ended early. The multi-layer FEC gate (a corrupted-payload test pins it) keeps a garbled mid-call data burst from forging an end-of-call.

## Test plan

- [x] `make vet test` is green locally (race, all packages)
- [x] `make integration` is green locally (this touches the composer/DSP path)
- [x] Added tests (each fails without the change):
  - `dmr/voice/terminator_test.go` — a synthetic Terminator burst is detected; a voice-only stream yields nothing; a corrupted-payload terminator is rejected (the false-positive guard).
  - `voice/composer/dmr_terminator_chain_test.go` — end-to-end: modulated voice + a Terminator through the full receiver → voice chain publishes a `call.release` with the right system/group.
- [ ] Smoke-tested against real hardware — n/a; real-air Terminator decode is capture-pending (#644), and the design falls back to hangtime until then.

## Breaking changes

None. Additive event; the engine already consumes `KindCallRelease` idempotently.

## Docs / CHANGELOG

- [x] Added an `## [Unreleased]` bullet to `CHANGELOG.md`
- [ ] README/docs — n/a

## Linked issues

Refs #1040, #644. Part of the cross-protocol feature-parity roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144w5FXPjW3oeryHqugKAjP

---
_Generated by [Claude Code](https://claude.ai/code/session_0144w5FXPjW3oeryHqugKAjP)_