### PR TITLE
voice: keep trailing frames by deferring finalize until chain drains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ for tagged releases.
   call.
 
 ### Fixed
+- **Trailing voice frames dropped at the end of a transmission.** When a call
+  ended, the recorder finalized and deleted the recording session on
+  `CallEnd` while the composer's voice chain was still draining its buffered
+  audio in parallel (two independent event-bus subscribers, no ordering) — so
+  the last speech frames the chain wrote during teardown landed on an
+  already-deleted session and were silently dropped. This was most visible on
+  TETRA same-carrier calls, whose shared-demux owner worker could still be
+  draining queued bursts when the chain reported done. The recorder now defers
+  finalize until the composer signals the chain has fully drained (with a
+  safety timeout so a dropped `CallEnd` can't hang a recording), and the
+  same-carrier chain waits for its owner worker to finish draining before
+  reporting done. Digital voice (TETRA/DMR/P25/ProVoice) keeps its full tail.
 - **DMR Tier III private-voice grants were mislabelled as talkgroups.** The
   shared grant path never set `Individual`, so a Tier III private
   (unit-to-unit) call's destination subscriber was published as if it were a

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -4410,6 +4410,30 @@ func (f fanoutSink) WriteRawFrameForCall(serial string, callID uint64, frame []b
 	return nil
 }
 
+// EnableDrainCoordination and NotifyDrainComplete forward the composer's voice-
+// chain drain coordination to the contained recorder. fanoutSink MUST implement
+// these: the composer discovers coordination via `c.sink.(drainCoordinator)` and
+// the daemon hands it a fanoutSink whenever more than one sink is configured
+// (tone-out, live player, audio publisher). Without forwarding, the assertion
+// fails against the fanoutSink, the recorder finalizes on CallEnd as before, and
+// the transmission-tail frames the chain writes during teardown are dropped in
+// the daemon even though the unit tests (which call the recorder directly) pass.
+func (f fanoutSink) EnableDrainCoordination() {
+	for _, s := range f {
+		if dc, ok := s.(interface{ EnableDrainCoordination() }); ok {
+			dc.EnableDrainCoordination()
+		}
+	}
+}
+
+func (f fanoutSink) NotifyDrainComplete(serial string) {
+	for _, s := range f {
+		if dc, ok := s.(interface{ NotifyDrainComplete(string) }); ok {
+			dc.NotifyDrainComplete(serial)
+		}
+	}
+}
+
 // toneProfilesFromConfig converts the YAML config shape into the
 // internal toneout.Profile shape, parsing duration strings.
 func toneProfilesFromConfig(in []config.ToneProfileConfig) ([]toneout.Profile, error) {

--- a/cmd/gophertrunk/dmr_ipsc_replay_test.go
+++ b/cmd/gophertrunk/dmr_ipsc_replay_test.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"context"
+	"encoding/binary"
+	"os"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	dmrrx "github.com/MattCheramie/GopherTrunk/internal/radio/dmr/receiver"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr/tier2"
+	dmrvoice "github.com/MattCheramie/GopherTrunk/internal/radio/dmr/voice"
+	"github.com/MattCheramie/GopherTrunk/internal/scanner/ccdecoder"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TestDMRIPSCReplay is a real-air diagnostic harness for conventional DMR /
+// IPSC captures (issue #1036). Skip unless GT_DMR_IQ points at a cs16
+// (interleaved int16) IQ file; GT_DMR_IQ_RATE gives its sample rate (default
+// 50000). It mirrors the daemon's dmr-tier2 decode: it downconverts to the DMR
+// channel rate, runs the shared DMR receiver, and feeds the recovered dibits to
+// BOTH the Tier II conventional state machine (which emits a grant on every
+// Voice LC Header — "grants but no voice" comes from here) AND the DMR voice
+// superframe/AMBE decoder (the audio the recorder would write). It prints grant,
+// superframe, embedded-LC and AMBE-FEC yields so a capture that "detects frames
+// but records no voice" can be triaged: 0 superframes ⇒ a receiver/DSP problem;
+// superframes>0 with AMBE decoding ⇒ the audio is recoverable and the gap is in
+// grant→voice-device binding, not the DSP.
+//
+// GT_DMR_INTERLEAVED=1 decodes the carrier as 2-slot interleaved (two talkers,
+// one per timeslot) — the common IPSC case — and reports per-phase superframe
+// counts so slot separation is visible.
+func TestDMRIPSCReplay(t *testing.T) {
+	path := os.Getenv("GT_DMR_IQ")
+	if path == "" {
+		t.Skip("set GT_DMR_IQ (cs16 IQ) [+ GT_DMR_IQ_RATE] to run the DMR IPSC replay")
+	}
+	inRate := 50000.0
+	if v := os.Getenv("GT_DMR_IQ_RATE"); v != "" {
+		f, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			t.Fatalf("bad GT_DMR_IQ_RATE: %v", err)
+		}
+		inRate = f
+	}
+	interleaved := os.Getenv("GT_DMR_INTERLEAVED") == "1" || os.Getenv("GT_DMR_INTERLEAVED") == "true"
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	iq := make([]complex64, len(raw)/4)
+	for i := range iq {
+		re := int16(binary.LittleEndian.Uint16(raw[i*4:]))
+		im := int16(binary.LittleEndian.Uint16(raw[i*4+2:]))
+		iq[i] = complex(float32(re)/32768, float32(im)/32768)
+	}
+
+	// DMR is the 4800-baud C4FM family — normalise to the 48 kHz channel rate.
+	ddc := ccdecoder.NewDownconverter(inRate, 48000)
+	outRate := ddc.OutRateHz()
+
+	// Collect grants off the bus (the tier2 state machine publishes KindGrant).
+	bus := events.NewBus(256)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	type grantRec struct {
+		tg, src uint32
+		indiv   bool
+	}
+	var grantsMu sync.Mutex
+	var grants []grantRec
+	ctx, cancel := context.WithCancel(context.Background())
+	drainDone := make(chan struct{})
+	go func() {
+		defer close(drainDone)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case ev, ok := <-sub.C:
+				if !ok {
+					return
+				}
+				if ev.Kind != events.KindGrant {
+					continue
+				}
+				if g, ok := ev.Payload.(trunking.Grant); ok {
+					grantsMu.Lock()
+					grants = append(grants, grantRec{tg: g.GroupID, src: g.SourceID, indiv: g.Individual})
+					grantsMu.Unlock()
+				}
+			}
+		}
+	}()
+
+	cc := tier2.New(tier2.Options{Bus: bus, SystemName: "dmr-ipsc-replay", FrequencyHz: 0})
+
+	var voiceDec *dmrvoice.Decoder
+	if interleaved {
+		voiceDec = dmrvoice.NewInterleavedDecoder()
+	} else {
+		voiceDec = dmrvoice.NewDecoder()
+	}
+
+	var (
+		superframes   int
+		lcSuperframes int
+		ambeOK        int
+		ambeUncorrect int
+		phaseCounts   [2]int
+		// lcGroups records the talkgroup each CRC-valid embedded LC named, so we
+		// can see whether the (issue #644, unvalidated) embedded signalling names
+		// the grant's talkgroup — the composer's interleaved slotRouter routes by
+		// this, and a garbage LC-TG that never matches the grant would make the
+		// router reject the call's own audio and record nothing.
+		lcGroups = map[uint32]int{}
+	)
+	rx := dmrrx.New(dmrrx.Options{
+		SampleRateHz: outRate,
+		DeviationHz:  1944.0,
+		ClockGain:    0.015,
+		DibitSink: func(dibits []uint8, baseIdx int) {
+			cc.Process(dibits, baseIdx)
+			for _, sf := range voiceDec.Process(dibits, baseIdx) {
+				superframes++
+				phaseCounts[sf.Phase&1]++
+				if sf.HasLC {
+					lcSuperframes++
+					if gv, ok := sf.LC.AsGroupVoiceUser(); ok {
+						lcGroups[gv.GroupAddress]++
+					}
+				}
+				for i := range sf.Frames {
+					_, _, derr := dmrvoice.DecodeAMBEFrame(sf.Frames[i])
+					if derr != nil {
+						ambeUncorrect++
+					} else {
+						ambeOK++
+					}
+				}
+			}
+		},
+	})
+
+	const chunk = 65536
+	var scratch []complex64
+	for i := 0; i < len(iq); i += chunk {
+		e := i + chunk
+		if e > len(iq) {
+			e = len(iq)
+		}
+		scratch = ddc.Process(scratch[:0], iq[i:e])
+		rx.Process(scratch)
+	}
+	cancel()
+	<-drainDone
+
+	grantsMu.Lock()
+	defer grantsMu.Unlock()
+	t.Logf("in=%.0fHz out=%.0fHz samples=%d dur=%.1fs interleaved=%v",
+		inRate, outRate, len(iq), float64(len(iq))/inRate, interleaved)
+	t.Logf("grants=%d", len(grants))
+	seen := map[grantRec]int{}
+	for _, g := range grants {
+		seen[grantRec{tg: g.tg, src: g.src, indiv: g.indiv}]++
+	}
+	for g, n := range seen {
+		t.Logf("  grant tg=%d src=%d individual=%v count=%d", g.tg, g.src, g.indiv, n)
+	}
+	t.Logf("superframes=%d lc_superframes=%d phase0=%d phase1=%d ambe_ok=%d ambe_uncorrectable=%d",
+		superframes, lcSuperframes, phaseCounts[0], phaseCounts[1], ambeOK, ambeUncorrect)
+	for tg, n := range lcGroups {
+		t.Logf("  embedded-LC group_address=%d count=%d", tg, n)
+	}
+
+	// The harness is a diagnostic: it must always surface *something* (a grant or
+	// a decoded superframe) or the capture/rate/tune is wrong. A silent pass on a
+	// live capture would hide exactly the failure #1036 is about.
+	if len(grants) == 0 && superframes == 0 {
+		t.Fatalf("no grants and no voice superframes decoded — check GT_DMR_IQ_RATE (%v) / tuning / capture", inRate)
+	}
+}

--- a/internal/voice/composer/composer.go
+++ b/internal/voice/composer/composer.go
@@ -262,6 +262,15 @@ type Composer struct {
 	autotune   *autotune.Registry
 	cryptoSink cryptocap.Sink
 
+	// drainCoord, when the sink supports it (the recorder does), lets the
+	// composer tell the recorder that a call's voice chain has fully drained
+	// its buffered audio, so the recorder finalizes the recording only AFTER
+	// the transmission-tail frames have been written. Cached once at New so the
+	// hot teardown path does no type-assert. nil for sinks that don't support
+	// coordination (test stubs, analog-only callers) — the recorder then
+	// finalizes on CallEnd as before.
+	drainCoord drainCoordinator
+
 	sub       *events.Subscription
 	runDone   chan struct{}
 	closeOnce sync.Once
@@ -370,6 +379,14 @@ func New(opts Options) (*Composer, error) {
 		chains:       make(map[string]*chain),
 		tetraDemuxes: make(map[string]*tetraSlotDemux),
 		runDone:      make(chan struct{}),
+	}
+	// Enable drain coordination when the sink (the recorder) supports it: the
+	// composer will signal NotifyDrainComplete once each call's chain has
+	// drained, and the recorder defers finalize until that signal (or a safety
+	// timeout) so the transmission tail is not dropped by the finalize race.
+	if dc, ok := c.sink.(drainCoordinator); ok && dc != nil {
+		c.drainCoord = dc
+		dc.EnableDrainCoordination()
 	}
 	c.sub = opts.Bus.Subscribe()
 	return c, nil
@@ -559,11 +576,22 @@ func (c *Composer) handleEnd(ce trunking.CallEnd) {
 	ch := c.chains[ce.DeviceSerial]
 	delete(c.chains, ce.DeviceSerial)
 	c.mu.Unlock()
-	if ch == nil {
-		return
+	if ch != nil {
+		ch.cancel()
+		// Block until the chain goroutine has fully drained and written every
+		// tail frame (drainTETRAIQ / the same-carrier owner worker for TETRA,
+		// the in-line teardown for DMR/P25/FM). Only after this returns are all
+		// of the call's frames guaranteed written to the recorder.
+		<-ch.done
 	}
-	ch.cancel()
-	<-ch.done
+	// Tell the recorder the drain is complete so it can finalize the recording.
+	// Fired for EVERY CallEnd — including calls with no chain — so a
+	// drain-coordinated recorder never blocks waiting for a signal that will
+	// not come. Ordering (this vs the recorder's own CallEnd handling) is
+	// arbitrary; the recorder finalizes once both have arrived.
+	if c.drainCoord != nil {
+		c.drainCoord.NotifyDrainComplete(ce.DeviceSerial)
+	}
 }
 
 func (c *Composer) cancelAll() {

--- a/internal/voice/composer/dmr_voice.go
+++ b/internal/voice/composer/dmr_voice.go
@@ -96,6 +96,18 @@ type errAwareRawSink interface {
 	WriteRawFrameWithErrors(deviceSerial string, frame []byte, correctedBits int) error
 }
 
+// drainCoordinator is the optional recorder capability that lets the composer
+// tell the recorder when a voice call's chain has fully drained its buffered
+// audio, so the recorder finalizes the recording only AFTER the tail frames
+// have been written — closing the finalize race that dropped the last speech
+// frames of a transmission. The recorder implements it; sinks that don't (test
+// stubs, analog-only callers) skip coordination and the recorder finalizes on
+// CallEnd as before.
+type drainCoordinator interface {
+	EnableDrainCoordination()
+	NotifyDrainComplete(deviceSerial string)
+}
+
 // callAwareRawSink is the richest sink: it carries the per-frame FEC
 // corrected-bit count AND the call identity (Grant.CallID) the frame was
 // decoded for, so the recorder can reject a stale frame from the call that

--- a/internal/voice/composer/tetra_samecarrier_drain_test.go
+++ b/internal/voice/composer/tetra_samecarrier_drain_test.go
@@ -1,0 +1,114 @@
+package composer
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/tetra"
+)
+
+// blockingRawSink is a PCMSink + rawFrameSink whose WriteRawFrame blocks in the
+// first call until release is closed, so a test can observe that a call's tail
+// frame is still being written and assert the chain has not finalized yet.
+type blockingRawSink struct {
+	entered     chan struct{}
+	release     chan struct{}
+	onceEntered sync.Once
+	writes      atomic.Int64
+}
+
+func (s *blockingRawSink) WritePCM(string, []int16) error { return nil }
+
+func (s *blockingRawSink) WriteRawFrame(_ string, _ []byte) error {
+	s.onceEntered.Do(func() { close(s.entered) })
+	<-s.release
+	s.writes.Add(1)
+	return nil
+}
+
+func waitForOwner(t *testing.T, d *tetraSlotDemux, marker uint8) *tetraSlotOwner {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		d.mu.Lock()
+		o := d.owners[marker]
+		d.mu.Unlock()
+		if o != nil {
+			return o
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatal("owner never registered with the demux")
+	return nil
+}
+
+// TestTETRASameCarrierChainWaitsForOwnerDrain pins part (B) of the trailing-frame
+// fix: a same-carrier TETRA chain must not close its done channel (which the
+// composer takes as "all frames written" before signalling the recorder to
+// finalize) until its owner worker has drained the bursts queued at call end and
+// written their speech frames. A blocking sink holds the tail write open so the
+// test can prove done stays open while the write is in flight.
+func TestTETRASameCarrierChainWaitsForOwnerDrain(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sink := &blockingRawSink{entered: make(chan struct{}), release: make(chan struct{})}
+	c := &Composer{
+		log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		bus:        bus,
+		sink:       sink,
+		hangtime:   time.Hour, // never let the boundary tracker end the call itself
+		touchEvery: time.Hour,
+	}
+	d := &tetraSlotDemux{
+		c:      c,
+		key:    "k",
+		owners: make(map[uint8]*tetraSlotOwner),
+		done:   make(chan struct{}),
+	}
+
+	marker := uint8(tetra.DLUsageTraffic)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go c.runTETRASameCarrierChain(ctx, d, "serial-1", 1, 1, marker, done)
+
+	// Queue a CRC-valid TCH/S burst so the worker has a tail job to drain at cancel.
+	o := waitForOwner(t, d, marker)
+	frame := tetra.EncodeTCHS(make([]byte, 137), make([]byte, 137))
+	o.enqueue(frame, nil)
+
+	cancel() // call end (control-channel D-RELEASE analogue)
+
+	// The worker drains the queued burst and blocks writing its first speech frame.
+	select {
+	case <-sink.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("owner worker did not process the queued tail burst after cancel")
+	}
+
+	// While the tail write is in flight, done MUST stay open — otherwise the
+	// composer would signal finalize and the recorder would delete the session
+	// out from under the write (the dropped trailing-frames bug).
+	select {
+	case <-done:
+		t.Fatal("chain done closed before the owner worker finished draining the tail")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Let the write complete; the worker exits and only then does done close.
+	close(sink.release)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("chain done never closed after the drain completed")
+	}
+	if got := sink.writes.Load(); got < 1 {
+		t.Fatalf("tail frames not written: %d", got)
+	}
+}

--- a/internal/voice/composer/tetra_voice.go
+++ b/internal/voice/composer/tetra_voice.go
@@ -648,13 +648,27 @@ func (c *Composer) runTETRASameCarrierChain(ctx context.Context, d *tetraSlotDem
 	}
 	// Start the vocoder worker BEFORE registering the owner, so a burst routed the
 	// instant addOwner returns already has a draining consumer. The worker exits
-	// (after draining) when ctx is cancelled at call end.
-	go c.tetraOwnerWorker(ctx, o)
+	// (after draining) when ctx is cancelled at call end. workerDone closes when
+	// the worker has finished draining its queued jobs and written the last
+	// speech frame.
+	workerDone := make(chan struct{})
+	go func() {
+		defer close(workerDone)
+		c.tetraOwnerWorker(ctx, o)
+	}()
 	d.addOwner(o)
 	c.log.Info("composer: tetra voice follow started (shared demux) — TCH/S decode + ACELP vocoder",
 		"serial", serial, "group", groupID, "timeslot", grantSlot, "usage_marker", usageMarker)
 	defer func() {
+		// Stop new bursts routing to this owner, then WAIT for the worker to
+		// drain the bursts already queued (the transmission tail) and write
+		// their speech frames. This must complete before runTETRASameCarrierChain
+		// returns and closes done: composer.handleEnd signals the recorder to
+		// finalize right after <-ch.done, so a worker still draining here would
+		// otherwise land the tail frames on an already-finalized (deleted)
+		// session and drop them (the "missing trailing voice frames" report).
 		d.removeOwner(o)
+		<-workerDone
 		c.log.Info("composer: tetra voice follow ended",
 			"serial", serial, "bursts", o.bursts.Load(), "speech_frames", o.speech.Load(),
 			"vocoder_drops", o.vocoderDrops.Load())

--- a/internal/voice/recorder.go
+++ b/internal/voice/recorder.go
@@ -117,9 +117,24 @@ type Recorder struct {
 	// call (handleStart), appended on a talker change (backfillSessionGrant), read at
 	// finalize, and cleared when the call ends. Guarded by mu.
 	callTalkers map[string][]srcEvent
-	sub         *events.Subscription
-	runDone     chan struct{}
-	closeOnce   sync.Once
+
+	// drainCoordinated is set (via EnableDrainCoordination) when a composer that
+	// signals NotifyDrainComplete is wired to this recorder. When true, handleEnd
+	// does NOT finalize a call immediately on KindCallEnd; it defers until the
+	// composer signals its voice chain has drained (or a safety timeout fires),
+	// so the transmission-tail frames the chain writes during teardown land in
+	// the recording instead of on an already-deleted session. When false the
+	// recorder finalizes on CallEnd exactly as before (standalone use, tests).
+	drainCoordinated bool
+	// pendingFinalize holds calls awaiting drain coordination, keyed by device
+	// serial. A call finalizes once BOTH its KindCallEnd (handleEnd) and the
+	// composer's NotifyDrainComplete have arrived — in either order — or the
+	// safety timer fires. Guarded by mu.
+	pendingFinalize map[string]*pendingFinalize
+
+	sub       *events.Subscription
+	runDone   chan struct{}
+	closeOnce sync.Once
 
 	// decodedTap, when set, receives the PCM decoded from digital
 	// vocoder frames in WriteRawFrame — the live consumers (web
@@ -400,6 +415,7 @@ func NewRecorder(opts RecorderOptions) (*Recorder, error) {
 		dedupSeen:          make(map[dedupKey]dedupEntry),
 		sessions:           make(map[string]*recordingSession),
 		callTalkers:        make(map[string][]srcEvent),
+		pendingFinalize:    make(map[string]*pendingFinalize),
 		runDone:            make(chan struct{}),
 	}
 	r.sub = opts.Bus.Subscribe()
@@ -520,6 +536,10 @@ func (r *Recorder) Close() error {
 // Run drains CallStart/CallEnd events until ctx cancels.
 func (r *Recorder) Run(ctx context.Context) error {
 	defer close(r.runDone)
+	// On teardown, finalize any calls still deferred for drain coordination so a
+	// pending recording is flushed to disk rather than left open until its safety
+	// timer fires (or lost if the process exits first).
+	defer r.flushPendingFinalize()
 	for {
 		select {
 		case <-ctx.Done():
@@ -1276,7 +1296,157 @@ func (r *Recorder) voiceStatsFor(s *recordingSession) (VoiceStats, bool) {
 func round1(v float64) float64 { return math.Round(v*10) / 10 }
 func round2(v float64) float64 { return math.Round(v*100) / 100 }
 
+// drainFinalizeTimeout bounds how long a drain-coordinated call waits for the
+// composer's NotifyDrainComplete after its KindCallEnd before finalizing anyway.
+// It is a safety backstop for the rare case where the composer never signals —
+// e.g. the event bus dropped the composer's copy of KindCallEnd under
+// backpressure (Bus.Publish drops for slow subscribers), so the composer never
+// tears down that chain. The normal path finalizes immediately on the signal
+// (drains are milliseconds), so this timeout only ever fires on a lost signal;
+// it is generous so it never pre-empts a legitimately in-progress drain (which
+// would re-introduce the tail-drop it exists to prevent).
+const drainFinalizeTimeout = 3 * time.Second
+
+// pendingFinalize tracks one call deferred for drain coordination. It finalizes
+// when both haveCE (KindCallEnd seen) and drained (NotifyDrainComplete seen) are
+// true, or when timer fires. Guarded by Recorder.mu.
+type pendingFinalize struct {
+	ce      trunking.CallEnd
+	haveCE  bool
+	drained bool
+	timer   *time.Timer
+}
+
+// EnableDrainCoordination switches the recorder into drain-coordinated finalize:
+// handleEnd defers a call's finalize until the composer signals the call's voice
+// chain has drained (NotifyDrainComplete), closing the race where the recorder
+// deleted the session before the chain wrote the transmission tail. Called once
+// by the composer at construction when it is wired to this recorder. Idempotent.
+func (r *Recorder) EnableDrainCoordination() {
+	r.mu.Lock()
+	r.drainCoordinated = true
+	r.mu.Unlock()
+}
+
+// NotifyDrainComplete tells the recorder that the composer has finished draining
+// the named call's voice chain (all tail frames written). If the call's
+// KindCallEnd has already been seen, the call finalizes now; otherwise the drain
+// is recorded and finalize happens when handleEnd runs. A serial with no open
+// session and no pending CallEnd is ignored (nothing to finalize).
+func (r *Recorder) NotifyDrainComplete(deviceSerial string) {
+	r.mu.Lock()
+	if !r.drainCoordinated {
+		r.mu.Unlock()
+		return
+	}
+	st := r.pendingFinalize[deviceSerial]
+	if st == nil {
+		// Drain signal arrived before handleEnd. Only track it if a session is
+		// still open (a CallEnd for it is therefore still coming); otherwise
+		// there is nothing to finalize and tracking it would leak.
+		if _, hasSession := r.sessions[deviceSerial]; !hasSession {
+			r.mu.Unlock()
+			return
+		}
+		st = &pendingFinalize{}
+		r.pendingFinalize[deviceSerial] = st
+	}
+	st.drained = true
+	if !st.haveCE {
+		r.mu.Unlock()
+		return // wait for handleEnd to supply the CallEnd
+	}
+	ce := st.ce
+	if st.timer != nil {
+		st.timer.Stop()
+	}
+	delete(r.pendingFinalize, deviceSerial)
+	r.mu.Unlock()
+	r.finalizeCall(ce)
+}
+
+// finalizeOnDrainTimeout is the safety backstop: it finalizes a deferred call
+// whose drain signal never arrived within drainFinalizeTimeout.
+func (r *Recorder) finalizeOnDrainTimeout(deviceSerial string) {
+	r.mu.Lock()
+	st := r.pendingFinalize[deviceSerial]
+	if st == nil {
+		r.mu.Unlock()
+		return // already finalized by NotifyDrainComplete
+	}
+	ce := st.ce
+	delete(r.pendingFinalize, deviceSerial)
+	r.mu.Unlock()
+	r.log.Warn("recorder: drain signal missing; finalizing call on timeout",
+		"device", deviceSerial, "timeout", drainFinalizeTimeout)
+	r.finalizeCall(ce)
+}
+
 func (r *Recorder) handleEnd(ce trunking.CallEnd) {
+	if !r.drainCoordinated {
+		r.finalizeCall(ce)
+		return
+	}
+	// Drain-coordinated: keep the session alive until the composer signals the
+	// call's voice chain has drained, so the tail frames it writes during
+	// teardown are not dropped onto a deleted session. Finalize when both this
+	// CallEnd and the drain signal have arrived, or when the safety timer fires.
+	serial := ce.DeviceSerial
+	r.mu.Lock()
+	if _, hasSession := r.sessions[serial]; !hasSession {
+		// No session to keep alive (skipped/dead call): finalizeCall is a cheap
+		// no-op cleanup — run it now rather than wait for a drain signal.
+		r.mu.Unlock()
+		r.finalizeCall(ce)
+		return
+	}
+	st := r.pendingFinalize[serial]
+	if st == nil {
+		st = &pendingFinalize{}
+		r.pendingFinalize[serial] = st
+	}
+	st.ce = ce
+	st.haveCE = true
+	if st.drained {
+		if st.timer != nil {
+			st.timer.Stop()
+		}
+		delete(r.pendingFinalize, serial)
+		r.mu.Unlock()
+		r.finalizeCall(ce)
+		return
+	}
+	if st.timer == nil {
+		st.timer = time.AfterFunc(drainFinalizeTimeout, func() { r.finalizeOnDrainTimeout(serial) })
+	}
+	r.mu.Unlock()
+}
+
+// flushPendingFinalize finalizes every call still awaiting drain coordination.
+// Called on Run teardown so nothing is left dangling.
+func (r *Recorder) flushPendingFinalize() {
+	r.mu.Lock()
+	pend := r.pendingFinalize
+	r.pendingFinalize = make(map[string]*pendingFinalize)
+	ends := make([]trunking.CallEnd, 0, len(pend))
+	for _, st := range pend {
+		if st.timer != nil {
+			st.timer.Stop()
+		}
+		if st.haveCE {
+			ends = append(ends, st.ce)
+		}
+	}
+	r.mu.Unlock()
+	for _, ce := range ends {
+		r.finalizeCall(ce)
+	}
+}
+
+// finalizeCall closes and finalizes the recording for a completed call. It is
+// the terminal step for both the immediate (uncoordinated) and drain-coordinated
+// paths.
+func (r *Recorder) finalizeCall(ce trunking.CallEnd) {
 	r.mu.Lock()
 	s, ok := r.sessions[ce.DeviceSerial]
 	if ok {

--- a/internal/voice/recorder_drain_test.go
+++ b/internal/voice/recorder_drain_test.go
@@ -1,0 +1,206 @@
+package voice
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// rawFrameCount returns the number of fixed-size vocoder frames written to the
+// single .raw sidecar under dir (frameSize bytes each).
+func rawFrameCount(t *testing.T, dir string, frameSize int) int {
+	t.Helper()
+	var raws []string
+	err := filepath.Walk(dir, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() && filepath.Ext(p) == ".raw" {
+			raws = append(raws, p)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(raws) != 1 {
+		t.Fatalf("want exactly one .raw sidecar, found %d: %v", len(raws), raws)
+	}
+	fi, err := os.Stat(raws[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Size()%int64(frameSize) != 0 {
+		t.Fatalf(".raw size %d not a multiple of frame size %d", fi.Size(), frameSize)
+	}
+	return int(fi.Size() / int64(frameSize))
+}
+
+func newDrainRecorder(t *testing.T) (*Recorder, string) {
+	t.Helper()
+	DefaultRegistry.Register("loud-voc-drain", func() (Vocoder, error) { return loudVocoder{}, nil })
+	bus := events.NewBus(8)
+	t.Cleanup(bus.Close)
+	dir := t.TempDir()
+	r, err := NewRecorder(RecorderOptions{
+		Bus:                bus,
+		OutDir:             dir,
+		SampleRate:         8000,
+		WriteRaw:           true,
+		VocoderForProtocol: map[string]string{"test-drain": "loud-voc-drain"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return r, dir
+}
+
+func drainCallStart() trunking.CallStart {
+	return trunking.CallStart{
+		Grant:        trunking.Grant{System: "S", Protocol: "test-drain", GroupID: 1, SourceID: 3},
+		DeviceSerial: "VOICE-1",
+		StartedAt:    time.Date(2026, 8, 5, 0, 0, 0, 0, time.UTC),
+	}
+}
+
+func drainCallEnd(cs trunking.CallStart) trunking.CallEnd {
+	return trunking.CallEnd{
+		Grant: cs.Grant, DeviceSerial: cs.DeviceSerial,
+		StartedAt: cs.StartedAt, EndedAt: cs.StartedAt.Add(time.Second),
+		Reason: trunking.EndReasonNormal,
+	}
+}
+
+// TestRecorderDrainCoordinationKeepsTailFrames is the regression test for the
+// dropped trailing-frames race: with drain coordination enabled, the recorder
+// must keep the session alive after KindCallEnd until the composer signals the
+// voice chain has drained, so the tail frames the chain writes during teardown
+// (here, after handleEnd runs) are recorded rather than dropped onto a deleted
+// session. Drives the recorder's methods directly to force the exact ordering
+// deterministically (handleEnd fully processed BEFORE the tail is written).
+func TestRecorderDrainCoordinationKeepsTailFrames(t *testing.T) {
+	r, dir := newDrainRecorder(t)
+	const frameSize = 11 // loudVocoder.FrameSize()
+	frame := make([]byte, frameSize)
+
+	r.EnableDrainCoordination()
+	cs := drainCallStart()
+	r.handleStart(cs)
+
+	const bodyFrames, tailFrames = 5, 3
+	for i := 0; i < bodyFrames; i++ {
+		if err := r.WriteRawFrame(cs.DeviceSerial, frame); err != nil {
+			t.Fatalf("WriteRawFrame body: %v", err)
+		}
+	}
+
+	// Call end arrives and is fully processed. Without drain coordination the
+	// old recorder deleted the session here; with it, the session must survive.
+	r.handleEnd(drainCallEnd(cs))
+	if !r.HasSession(cs.DeviceSerial) {
+		t.Fatal("session was finalized on CallEnd; tail frames from the chain drain would be dropped (the bug)")
+	}
+
+	// The composer's chain drain writes the transmission tail AFTER CallEnd.
+	for i := 0; i < tailFrames; i++ {
+		if err := r.WriteRawFrame(cs.DeviceSerial, frame); err != nil {
+			t.Fatalf("WriteRawFrame tail: %v", err)
+		}
+	}
+
+	// Drain complete: the recorder finalizes now.
+	r.NotifyDrainComplete(cs.DeviceSerial)
+	if r.HasSession(cs.DeviceSerial) {
+		t.Fatal("session not finalized after NotifyDrainComplete")
+	}
+
+	if got, want := rawFrameCount(t, dir, frameSize), bodyFrames+tailFrames; got != want {
+		t.Fatalf("recorded %d frames, want %d (body %d + tail %d) — trailing frames dropped",
+			got, want, bodyFrames, tailFrames)
+	}
+}
+
+// TestRecorderDrainSignalBeforeCallEnd covers the reverse arrival order:
+// NotifyDrainComplete arriving before handleEnd must still finalize exactly once
+// (when the CallEnd then arrives), not leak the session or double-finalize.
+func TestRecorderDrainSignalBeforeCallEnd(t *testing.T) {
+	r, dir := newDrainRecorder(t)
+	const frameSize = 11
+	frame := make([]byte, frameSize)
+
+	r.EnableDrainCoordination()
+	cs := drainCallStart()
+	r.handleStart(cs)
+	for i := 0; i < 4; i++ {
+		if err := r.WriteRawFrame(cs.DeviceSerial, frame); err != nil {
+			t.Fatalf("WriteRawFrame: %v", err)
+		}
+	}
+
+	// Drain signal wins the race with the recorder's own CallEnd handling.
+	r.NotifyDrainComplete(cs.DeviceSerial)
+	if !r.HasSession(cs.DeviceSerial) {
+		t.Fatal("session finalized on the drain signal alone, before CallEnd arrived")
+	}
+	r.handleEnd(drainCallEnd(cs))
+	if r.HasSession(cs.DeviceSerial) {
+		t.Fatal("session not finalized after both drain signal and CallEnd arrived")
+	}
+	if got := rawFrameCount(t, dir, frameSize); got != 4 {
+		t.Fatalf("recorded %d frames, want 4", got)
+	}
+}
+
+// TestRecorderDrainTimeoutFinalizes covers the safety backstop: if the composer
+// never signals (e.g. the bus dropped its KindCallEnd under backpressure), the
+// deferred call must still finalize when the timeout path runs, rather than
+// leaking the session forever.
+func TestRecorderDrainTimeoutFinalizes(t *testing.T) {
+	r, dir := newDrainRecorder(t)
+	const frameSize = 11
+	frame := make([]byte, frameSize)
+
+	r.EnableDrainCoordination()
+	cs := drainCallStart()
+	r.handleStart(cs)
+	for i := 0; i < 2; i++ {
+		if err := r.WriteRawFrame(cs.DeviceSerial, frame); err != nil {
+			t.Fatalf("WriteRawFrame: %v", err)
+		}
+	}
+	r.handleEnd(drainCallEnd(cs)) // defers, arming the safety timer
+	if !r.HasSession(cs.DeviceSerial) {
+		t.Fatal("session finalized immediately instead of deferring")
+	}
+	// Simulate the safety timer firing (the drain signal never came).
+	r.finalizeOnDrainTimeout(cs.DeviceSerial)
+	if r.HasSession(cs.DeviceSerial) {
+		t.Fatal("timeout backstop did not finalize the deferred call")
+	}
+	if got := rawFrameCount(t, dir, frameSize); got != 2 {
+		t.Fatalf("recorded %d frames, want 2", got)
+	}
+}
+
+// TestRecorderUncoordinatedFinalizesOnCallEnd pins that without drain
+// coordination the recorder finalizes on CallEnd exactly as before (standalone
+// use / non-composer callers must be unaffected).
+func TestRecorderUncoordinatedFinalizesOnCallEnd(t *testing.T) {
+	r, _ := newDrainRecorder(t)
+	const frameSize = 11
+	frame := make([]byte, frameSize)
+
+	cs := drainCallStart()
+	r.handleStart(cs)
+	if err := r.WriteRawFrame(cs.DeviceSerial, frame); err != nil {
+		t.Fatalf("WriteRawFrame: %v", err)
+	}
+	r.handleEnd(drainCallEnd(cs))
+	if r.HasSession(cs.DeviceSerial) {
+		t.Fatal("uncoordinated recorder should finalize immediately on CallEnd")
+	}
+}


### PR DESCRIPTION
The recorder finalized and deleted a call's recording session on CallEnd
while the composer's voice chain was still draining buffered audio in
parallel — two independent event-bus subscribers with no ordering. The
recorder almost always won, so the tail speech frames the chain wrote
during teardown hit sessionForWrite's now-deleted session and were
dropped (the "missing trailing voice frames" report; the b2e5e59 drain
fix was largely defeated by this race).

Add drain coordination between composer and recorder: the recorder defers
finalize until the composer signals NotifyDrainComplete for the call (or a
3s safety timeout, since the bus drops events for slow subscribers and a
missed CallEnd must not hang a recording). The composer signals right
after <-ch.done for every CallEnd. fanoutSink forwards the coordination to
the wrapped recorder so it engages in the daemon, not just unit tests.

Also fix a nested race the coordination relies on: the TETRA same-carrier
chain closed its done channel without waiting for its owner worker to
drain the bursts queued at call end, so <-ch.done could return before the
tail was written. The chain now waits for the worker before returning.

Failing-first tests: recorder_drain_test.go pins the deferred finalize
(both arrival orders + timeout backstop); tetra_samecarrier_drain_test.go
pins that the same-carrier chain's done stays open until the tail write
completes.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HoLkGCGGYD4PnfETCDPjEh