### PR TITLE
Decode and surface on-air call priority (P25 + DMR)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **On-air call priority is decoded and surfaced.** The call's signalled
+  priority level — the low 3 bits of the P25 / DMR Service Options octet —
+  is now carried on the grant (`Grant.Priority`), persisted to the call log,
+  and returned by the `/api/v1/calls` history endpoint, so an operator can
+  see which calls the radios flagged as high-priority alongside the existing
+  emergency / encrypted metadata. Decoded from P25 Phase 1, P25 Phase 2, and
+  DMR (group and unit-to-unit voice LCs). This is the calling radio's
+  requested priority (distinct from a talkgroup's operator-configured
+  priority); engine preemption is unchanged.
 - **Followed DMR calls (Tier III / Tier I) end promptly on the Terminator.**
   The voice chain now detects the Terminator-with-LC burst on the followed
   traffic channel — reusing the trusted control-path FEC chain (slot-type

--- a/internal/radio/dmr/flc.go
+++ b/internal/radio/dmr/flc.go
@@ -120,6 +120,7 @@ type GroupVoiceChannelUser struct {
 	SourceID     uint32 // 24-bit
 	Encrypted    bool
 	Emergency    bool
+	Priority     uint8 // ServiceOptions bits 2..0 (§7.2.1 Table 7.13)
 }
 
 // AsGroupVoiceUser decodes the FLC into the typed group-voice payload
@@ -135,6 +136,7 @@ func (f FLC) AsGroupVoiceUser() (GroupVoiceChannelUser, bool) {
 		SourceID:     f.SrcAddr,
 		Emergency:    f.ServiceOptions&0x80 != 0,
 		Encrypted:    f.ServiceOptions&0x40 != 0,
+		Priority:     f.ServiceOptions & 0x07,
 	}, true
 }
 
@@ -146,6 +148,7 @@ type UnitToUnitVoiceChannelUser struct {
 	SourceID      uint32 // 24-bit calling subscriber
 	Encrypted     bool
 	Emergency     bool
+	Priority      uint8 // ServiceOptions bits 2..0 (§7.2.1 Table 7.13)
 }
 
 // AsUnitToUnitVoice decodes the FLC into the typed private-voice payload
@@ -162,5 +165,6 @@ func (f FLC) AsUnitToUnitVoice() (UnitToUnitVoiceChannelUser, bool) {
 		SourceID:      f.SrcAddr,
 		Emergency:     f.ServiceOptions&0x80 != 0,
 		Encrypted:     f.ServiceOptions&0x40 != 0,
+		Priority:      f.ServiceOptions & 0x07,
 	}, true
 }

--- a/internal/radio/dmr/flc_test.go
+++ b/internal/radio/dmr/flc_test.go
@@ -59,6 +59,15 @@ func TestFLCAsGroupVoiceUser(t *testing.T) {
 	if !g.Emergency || g.Encrypted {
 		t.Errorf("flags = emer=%v enc=%v, want emer=true enc=false", g.Emergency, g.Encrypted)
 	}
+	if g.Priority != 0 {
+		t.Errorf("priority = %d, want 0 (none signalled)", g.Priority)
+	}
+
+	// ServiceOptions low 3 bits carry the call priority (§7.2.1 Table 7.13).
+	g5, _ := (FLC{FLCO: FLCOGroupVoiceUser, ServiceOptions: 0x85}).AsGroupVoiceUser()
+	if g5.Priority != 5 || !g5.Emergency {
+		t.Errorf("priority/emergency = %d/%v, want 5/true", g5.Priority, g5.Emergency)
+	}
 
 	// Wrong opcode → no group-voice projection.
 	if _, ok := (FLC{FLCO: FLCOTerminator}).AsGroupVoiceUser(); ok {

--- a/internal/radio/dmr/tier2/conventional.go
+++ b/internal/radio/dmr/tier2/conventional.go
@@ -289,11 +289,12 @@ func (c *ConventionalChannel) handleVoiceHeader(b *dmr.Burst, slot dmr.SlotType)
 	// difference to the engine is Grant.Individual, which keeps a private
 	// call's destination RID out of the talkgroup list.
 	var dest, src uint32
+	var prio uint8
 	var enc, emer, individual bool
 	if gv, ok := flc.AsGroupVoiceUser(); ok {
-		dest, src, enc, emer = gv.GroupAddress, gv.SourceID, gv.Encrypted, gv.Emergency
+		dest, src, enc, emer, prio = gv.GroupAddress, gv.SourceID, gv.Encrypted, gv.Emergency, gv.Priority
 	} else if uu, ok := flc.AsUnitToUnitVoice(); ok {
-		dest, src, enc, emer, individual = uu.DestinationID, uu.SourceID, uu.Encrypted, uu.Emergency, true
+		dest, src, enc, emer, individual, prio = uu.DestinationID, uu.SourceID, uu.Encrypted, uu.Emergency, true, uu.Priority
 	} else {
 		c.log.Debug("dmr/tier2: non-voice FLCO ignored", "flco", flc.FLCO)
 		return
@@ -317,6 +318,7 @@ func (c *ConventionalChannel) handleVoiceHeader(b *dmr.Burst, slot dmr.SlotType)
 			ChannelID:   slot.ColorCode,
 			Encrypted:   enc,
 			Emergency:   emer,
+			Priority:    prio,
 			At:          c.now(),
 		},
 	})

--- a/internal/radio/dmr/tier2/conventional_test.go
+++ b/internal/radio/dmr/tier2/conventional_test.go
@@ -94,7 +94,7 @@ func TestConventionalPublishesGrantOnVoiceLCHeader(t *testing.T) {
 	flc := dmr.FLC{
 		FLCO:           dmr.FLCOGroupVoiceUser,
 		FID:            0x00,
-		ServiceOptions: 0xC0, // emergency + encrypted
+		ServiceOptions: 0xC5, // emergency + encrypted + priority 5
 		DstAddr:        0x000064,
 		SrcAddr:        0x100200,
 	}
@@ -126,6 +126,9 @@ func TestConventionalPublishesGrantOnVoiceLCHeader(t *testing.T) {
 			}
 			if !g.Encrypted || !g.Emergency {
 				t.Errorf("flags = enc=%v emer=%v, want both", g.Encrypted, g.Emergency)
+			}
+			if g.Priority != 5 {
+				t.Errorf("priority = %d, want 5", g.Priority)
 			}
 			if g.Individual {
 				t.Error("group grant wrongly marked Individual")

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -1695,6 +1695,7 @@ func (c *ControlChannel) publishVoiceGrant(g voiceGrant, nac uint16) {
 			NAC:                nac,
 			Encrypted:          so.Encrypted(),
 			Emergency:          so.Emergency(),
+			Priority:           so.Priority(),
 			DataCall:           g.dataCall,
 			Individual:         g.individual,
 			P25Phase1DemodMode: c.p25Phase1DemodMode,

--- a/internal/radio/p25/phase1/control_test.go
+++ b/internal/radio/p25/phase1/control_test.go
@@ -260,7 +260,7 @@ func TestControlChannelAppliesIdentifierUpdateAndPublishesGrant(t *testing.T) {
 	})
 
 	grantPayload := [8]byte{
-		0xC0,                  // service options: emergency + encrypted
+		0xC3,                  // service options: emergency + encrypted + priority 3
 		(1 << 4) | 0x00, 0x10, // channel = ID 1, number 0x010 (=16)
 		0x12, 0x34, // group address 0x1234
 		0xAB, 0xCD, 0xEF, // source ID 0xABCDEF
@@ -307,6 +307,9 @@ func TestControlChannelAppliesIdentifierUpdateAndPublishesGrant(t *testing.T) {
 	}
 	if !got.Encrypted || !got.Emergency {
 		t.Errorf("flags = enc=%v emer=%v, want both", got.Encrypted, got.Emergency)
+	}
+	if got.Priority != 3 {
+		t.Errorf("priority = %d, want 3 (service-options low bits)", got.Priority)
 	}
 	if got.At.Unix() != 1_700_000_000 {
 		t.Errorf("At = %v, want injected Now", got.At)

--- a/internal/radio/p25/phase2/control.go
+++ b/internal/radio/p25/phase2/control.go
@@ -857,6 +857,7 @@ func (c *ControlChannel) publishGrant(g GroupVoiceChannelGrant, op Opcode, group
 			NAC:             nac,
 			Encrypted:       so.Encrypted(),
 			Emergency:       so.Emergency(),
+			Priority:        so.Priority(),
 			AlgorithmID:     algID,
 			KeyID:           keyID,
 			P25Phase2Decode: dec,

--- a/internal/storage/calllog.go
+++ b/internal/storage/calllog.go
@@ -101,13 +101,13 @@ func (c *CallLog) recordStart(cs trunking.CallStart) error {
 	const q = `
 INSERT OR REPLACE INTO call_log (
     system, protocol, group_id, source_id, frequency_hz,
-    encrypted, algorithm_id, key_id, emergency, data_call, timeslot,
+    encrypted, algorithm_id, key_id, emergency, data_call, timeslot, priority,
     device_serial, started_at, talkgroup_alpha
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 	_, err := c.db.sql.Exec(q,
 		cs.Grant.System, cs.Grant.Protocol, cs.Grant.GroupID, cs.Grant.SourceID, cs.Grant.FrequencyHz,
 		boolToInt(cs.Grant.Encrypted), cs.Grant.AlgorithmID, cs.Grant.KeyID,
-		boolToInt(cs.Grant.Emergency), boolToInt(cs.Grant.DataCall), cs.Grant.Timeslot,
+		boolToInt(cs.Grant.Emergency), boolToInt(cs.Grant.DataCall), cs.Grant.Timeslot, cs.Grant.Priority,
 		cs.DeviceSerial, cs.StartedAt.UnixNano(),
 		alpha,
 	)
@@ -201,7 +201,10 @@ type CallRow struct {
 	Emergency   bool   `json:"emergency"`
 	DataCall    bool   `json:"data_call"`
 	// Timeslot is the 1-based DMR TDMA slot (0 = n/a, 1 = TS1, 2 = TS2).
-	Timeslot       uint8     `json:"timeslot,omitempty"`
+	Timeslot uint8 `json:"timeslot,omitempty"`
+	// Priority is the call's on-air signalled priority (service-options low
+	// 3 bits, 0 = none/lowest). Distinct from a talkgroup's configured priority.
+	Priority       uint8     `json:"priority,omitempty"`
 	DeviceSerial   string    `json:"device_serial"`
 	StartedAt      time.Time `json:"started_at"`
 	EndedAt        time.Time `json:"ended_at,omitempty"` // zero if call still active
@@ -222,7 +225,7 @@ type CallRow struct {
 // History queries the call_log with the supplied filter, newest-first.
 func (d *DB) History(ctx context.Context, f HistoryFilter) ([]CallRow, error) {
 	q := `SELECT id, system, protocol, group_id, source_id, frequency_hz,
-	             encrypted, algorithm_id, key_id, emergency, data_call, timeslot,
+	             encrypted, algorithm_id, key_id, emergency, data_call, timeslot, priority,
 	             device_serial, started_at, ended_at, duration_ms,
 	             end_reason, talkgroup_alpha, signal_dbfs, evm_pct, snr_db
 	      FROM call_log WHERE 1=1`
@@ -269,10 +272,10 @@ func (d *DB) History(ctx context.Context, f HistoryFilter) ([]CallRow, error) {
 		var reason sql.NullString
 		var alpha sql.NullString
 		var sig, evm, snr sql.NullFloat64
-		var enc, emer, data, algID, keyID, slot int
+		var enc, emer, data, algID, keyID, slot, prio int
 		if err := rows.Scan(
 			&r.ID, &r.System, &r.Protocol, &r.GroupID, &r.SourceID, &r.FrequencyHz,
-			&enc, &algID, &keyID, &emer, &data, &slot, &r.DeviceSerial,
+			&enc, &algID, &keyID, &emer, &data, &slot, &prio, &r.DeviceSerial,
 			&startNs, &endNs, &durMs, &reason, &alpha, &sig, &evm, &snr,
 		); err != nil {
 			return nil, err
@@ -283,6 +286,7 @@ func (d *DB) History(ctx context.Context, f HistoryFilter) ([]CallRow, error) {
 		r.Emergency = emer != 0
 		r.DataCall = data != 0
 		r.Timeslot = uint8(slot)
+		r.Priority = uint8(prio)
 		r.StartedAt = time.Unix(0, startNs).UTC()
 		if endNs.Valid {
 			r.EndedAt = time.Unix(0, endNs.Int64).UTC()

--- a/internal/storage/calllog_test.go
+++ b/internal/storage/calllog_test.go
@@ -150,6 +150,46 @@ func TestCallLogPersistsTimeslot(t *testing.T) {
 	}
 }
 
+// TestCallLogPersistsPriority pins the Grant.Priority → call_log round-trip
+// so the on-air call priority surfaces in history and the REST API.
+func TestCallLogPersistsPriority(t *testing.T) {
+	db := openTestDB(t)
+	bus := events.NewBus(8)
+	defer bus.Close()
+	cl, err := NewCallLog(db, bus, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cl.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go cl.Run(ctx)
+
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: trunking.CallStart{
+		Grant: trunking.Grant{
+			System: "P25A", Protocol: "p25",
+			GroupID: 100, SourceID: 7, FrequencyHz: 851_000_000, Priority: 6,
+		},
+		DeviceSerial: "VOICE-3",
+		StartedAt:    time.Now().UTC(),
+	}})
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if rows, _ := db.History(context.Background(), HistoryFilter{Limit: 1}); len(rows) == 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	rows, _ := db.History(context.Background(), HistoryFilter{Limit: 1})
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want 1", len(rows))
+	}
+	if rows[0].Priority != 6 {
+		t.Errorf("Priority = %d, want 6", rows[0].Priority)
+	}
+}
+
 func TestCallLogIdempotentStart(t *testing.T) {
 	db := openTestDB(t)
 	bus := events.NewBus(8)

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -80,6 +80,7 @@ CREATE TABLE IF NOT EXISTS call_log (
     emergency       INTEGER NOT NULL DEFAULT 0,
     data_call       INTEGER NOT NULL DEFAULT 0,
     timeslot        INTEGER NOT NULL DEFAULT 0,  -- DMR TDMA slot: 0=n/a, 1=TS1, 2=TS2
+    priority        INTEGER NOT NULL DEFAULT 0,  -- on-air signalled call priority (service-options low 3 bits)
     device_serial   TEXT    NOT NULL,
     started_at      INTEGER NOT NULL,  -- unix nanoseconds
     ended_at        INTEGER,
@@ -378,6 +379,7 @@ func (d *DB) ensureCallLogColumns() error {
 		{"algorithm_id", `ALTER TABLE call_log ADD COLUMN algorithm_id INTEGER NOT NULL DEFAULT 0`},
 		{"key_id", `ALTER TABLE call_log ADD COLUMN key_id INTEGER NOT NULL DEFAULT 0`},
 		{"timeslot", `ALTER TABLE call_log ADD COLUMN timeslot INTEGER NOT NULL DEFAULT 0`},
+		{"priority", `ALTER TABLE call_log ADD COLUMN priority INTEGER NOT NULL DEFAULT 0`},
 		// Nullable (no DEFAULT) so a row with no measurement reads NULL —
 		// "unset" is distinct from a legitimate 0 dBFS reading.
 		{"signal_dbfs", `ALTER TABLE call_log ADD COLUMN signal_dbfs REAL`},

--- a/internal/trunking/grant.go
+++ b/internal/trunking/grant.go
@@ -48,6 +48,16 @@ type Grant struct {
 	Timeslot  uint8
 	Encrypted bool
 	Emergency bool
+	// Priority is the call's on-air signalled priority level, the low 3
+	// bits of the P25 / DMR Service Options octet (0 = lowest, 7 = highest;
+	// 0 also when no priority is signalled). It is the priority the calling
+	// radio requested, distinct from a talkgroup's operator-configured
+	// priority; the engine's preemption still keys off the configured
+	// talkgroup priority, so this is surfaced as call metadata (call log +
+	// API) rather than driving preemption. Zero on protocols/grants whose
+	// signalling carries no service-options octet (e.g. the DMR Tier III
+	// channel-grant CSBK).
+	Priority uint8
 	// DMRInterleavedVoice mirrors the system-level
 	// trunking.System.DMRInterleavedVoice opt-in onto the grant so the
 	// voice composer selects the 2-slot interleaved decoder and routes


### PR DESCRIPTION
## Summary

The Service Options octet on P25 and DMR voice grants carries a 3-bit **call priority** in its low bits, and P25 already decoded it (`ServiceOptions.Priority()`) — but there was no `Grant.Priority` field, so it was dropped on the floor for every protocol. This adds the field, decodes it on P25 (both phases) and DMR, and persists + surfaces it, so an operator can see which calls the radios flagged as high-priority alongside the existing emergency / encrypted metadata (workstream **W10** — priority — from the cross-protocol parity plan). Finally a change that touches P25 as well as DMR.

## Changes

- **`trunking` — `Grant.Priority uint8`** (`grant.go`): the call's on-air signalled priority (0 = none/lowest … 7). Documented as the calling radio's requested priority, *distinct* from a talkgroup's operator-configured priority — engine preemption is intentionally left keyed off the configured talkgroup priority.
- **DMR decode** (`dmr/flc.go`, `dmr/tier2/conventional.go`): `AsGroupVoiceUser` / `AsUnitToUnitVoice` extract the priority (Service Options bits 2..0, ETSI TS 102 361-2 §7.2.1 Table 7.13); the Tier II conventional decoder surfaces it on the grant. (Tier III channel-grant CSBKs carry no service-options octet, so priority stays 0 there — noted in the field doc.)
- **P25 decode** (`p25/phase1/control.go`, `p25/phase2/control.go`): carry the already-decoded `ServiceOptions.Priority()` onto the grant for both phases.
- **Persistence + API** (`storage/sqlite.go`, `storage/calllog.go`): additive `priority` column (migration + fresh-DB schema), written on CallStart and read into `CallRow.Priority`. The REST `/api/v1/calls` history endpoint JSON-encodes `CallRow` directly, so the field surfaces to the web console automatically.

## Test plan

- [x] `make vet test` is green locally (race, 165 packages, 0 failures)
- [ ] `make integration` — n/a (no daemon/DSP path changed)
- [x] Added / extended tests (each fails without the change):
  - `dmr/flc_test.go` — priority extracted from Service Options low bits.
  - `dmr/tier2/conventional_test.go` — the grant carries priority end-to-end.
  - `p25/phase1/control_test.go` — the published P25 grant carries priority.
  - `storage/calllog_test.go` — `Grant.Priority` round-trips through the call log.

## Breaking changes

None. New optional field + additive DB column with a default; existing rows read priority 0.

## Docs / CHANGELOG

- [x] Added an `## [Unreleased]` bullet to `CHANGELOG.md`
- [ ] README/docs — n/a

## Follow-up (not in this PR)

- The gRPC `RIDCallRow` protobuf is a generated surface; adding `priority` there needs a `.proto` change + codegen — deferred.
- Feeding the on-air priority into `EffectivePriority` preemption (when a talkgroup has no configured priority) is a deliberate behaviour change for its own PR, since the on-air priority scale is system-dependent.

## Linked issues

n/a — part of the cross-protocol feature-parity roadmap (W10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144w5FXPjW3oeryHqugKAjP

---
_Generated by [Claude Code](https://claude.ai/code/session_0144w5FXPjW3oeryHqugKAjP)_