### PR TITLE
Voice: fix trailing-frame tail drop + record conventional DMR (IPSC) voice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ for tagged releases.
   call.
 
 ### Fixed
+- **Conventional DMR (Tier II / IPSC) voice never recorded (#1036).** A
+  conventional DMR repeater carries voice on the *same* carrier it emits Voice
+  LC Headers on, but the daemon's same-carrier voice tap was gated to TETRA
+  only — on the assumption that "for P25/DMR voice is always on a different
+  carrier," which holds for trunked Tier III but not conventional Tier II/I. So
+  a single-SDR conventional DMR system had no voice source: the grant fired,
+  found no voice device, was dropped, and nothing recorded (the decode itself
+  was fine end to end). Same-carrier voice taps are now registered for
+  `dmr-tier2`/`dmr-tier1` too (two, for the 2-slot carrier). Trunked Tier III
+  and P25 still register none, so their "no voice SDR" diagnostic is preserved.
 - **Trailing voice frames dropped at the end of a transmission.** When a call
   ended, the recorder finalized and deleted the recording session on
   `CallEnd` while the composer's voice chain was still draining its buffered

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **`gophertrunk replay -record-voice -out-dir <dir> -freq <Hz>`** decodes and
+  records voice from a capture, not just control-channel locks/grants. It wires
+  the production voice path (trunking engine → voice composer → recorder) onto
+  the replay decode: grants bind a same-carrier voice source fed by the decode's
+  own channelized IQ, and each followed call is written as `.wav`/`.raw`/`.json`.
+  Best for conventional systems whose voice rides the decoded carrier (DMR
+  Tier II / IPSC, TETRA) — it's the offline way to validate that a capture
+  produces audio, and the reproduction vehicle for #1036. Requires `-freq` (a
+  grant with frequency 0 is dropped) and does not support `-auto-tune` (use
+  `-tune-hz`). Backed by a new siglab `Config.Bus` / `Config.OnChannelIQ` seam.
 - **DMR private (unit-to-unit) calls are now followed.** A Tier II
   conventional channel dropped any non-group Voice LC Header, so DMR private
   calls were invisible — no grant, never followed, never recorded. The

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -162,6 +162,29 @@ const lowManualGainTenthDB = 150
 // its granted timeslot (see internal/voice/composer/tetra_voice.go).
 const tetraSameCarrierTaps = 4
 
+// dmrSameCarrierTaps is how many same-carrier voice taps are registered for a
+// conventional DMR (Tier II / Tier I) system. A conventional DMR repeater carries
+// voice on the SAME carrier the state machine decodes (unlike trunked Tier III,
+// whose voice hops to a separate traffic channel), and the carrier is 2-slot TDMA,
+// so up to two concurrent calls can run — one per timeslot. Each tap's DMR voice
+// chain routes to its call's talkgroup (the slotRouter in dmr_voice.go).
+const dmrSameCarrierTaps = 2
+
+// sameCarrierVoiceTaps reports how many same-carrier voice taps a system's protocol
+// needs, or 0 for protocols whose voice is never on the control/decoded carrier
+// (trunked DMR Tier III, P25) — those must bind a real role:voice SDR or a wideband
+// tap, and a same-carrier tap would only mask the "no voice SDR" diagnostic.
+func sameCarrierVoiceTaps(proto trunking.Protocol) int {
+	switch proto {
+	case trunking.ProtocolTETRA:
+		return tetraSameCarrierTaps
+	case trunking.ProtocolDMRTier2, trunking.ProtocolDMRTier1:
+		return dmrSameCarrierTaps
+	default:
+		return 0
+	}
+}
+
 // gainLooksTooLow reports whether a manual (non-auto) gain is below the
 // digital-decode floor but above the tenths-of-dB-mistake band that
 // gainLooksLikeDBMistake already covers. The two checks partition the
@@ -1124,24 +1147,32 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		return nil, err
 	}
 	// Same-carrier voice tap: reuse the control decoder's own channelised IQ so
-	// a grant on the control carrier (a TETRA SCBS keeps voice on other timeslots
-	// of the control carrier) is followed without a second SDR or a retune. The
-	// control decoder is built below (after the voice pool), so resolve it lazily.
-	// Gated to TETRA systems: for P25/DMR (voice always on a different carrier) it
-	// would never bind but would mask the "no voice SDR" diagnostic, so skip it.
+	// a grant on the control/decoded carrier is followed without a second SDR or a
+	// retune. The control decoder is built below (after the voice pool), so resolve
+	// it lazily. Registered for protocols whose voice rides the SAME carrier the
+	// state machine decodes: a TETRA SCBS keeps voice on other timeslots of the
+	// control carrier, and a conventional DMR (Tier II / Tier I) repeater keeps
+	// voice on the same repeater carrier it emits Voice LC Headers on (issue #1036).
+	// Trunked protocols (DMR Tier III, P25) whose voice hops to a different carrier
+	// register nothing here — a same-carrier tap would never bind for them but
+	// would mask the "no voice SDR" diagnostic. CCVoiceSource.CanTune binds only a
+	// grant whose freq == the decoder's current carrier, so an off-carrier grant
+	// (or a nil/idle decoder) still falls through to a real role:voice SDR.
 	for _, sys := range cfg.Trunking.Systems {
-		if strings.EqualFold(sys.Protocol, "tetra") {
-			// One tap per TDMA timeslot: a TETRA carrier has four slots, so up
-			// to four calls can run at once on the control carrier. Each tap
-			// subscribes to the control decoder's voice-IQ fan-out independently
-			// and the per-slot voice chain keeps only its granted timeslot.
-			for i := 1; i <= tetraSameCarrierTaps; i++ {
-				d.ccVoiceSources = append(d.ccVoiceSources, ccdecoder.NewCCVoiceSource(
-					func() *ccdecoder.Decoder { return d.ccDecoder },
-					fmt.Sprintf("cc:same-carrier:%d", i)))
-			}
-			break
+		proto, perr := trunking.ParseProtocol(sys.Protocol)
+		if perr != nil {
+			continue
 		}
+		taps := sameCarrierVoiceTaps(proto)
+		if taps == 0 {
+			continue
+		}
+		for i := 1; i <= taps; i++ {
+			d.ccVoiceSources = append(d.ccVoiceSources, ccdecoder.NewCCVoiceSource(
+				func() *ccdecoder.Decoder { return d.ccDecoder },
+				fmt.Sprintf("cc:same-carrier:%d", i)))
+		}
+		break
 	}
 
 	// Metrics — constructed early so downstream components (notably

--- a/cmd/gophertrunk/daemon_samecarrier_voice_test.go
+++ b/cmd/gophertrunk/daemon_samecarrier_voice_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/config"
+)
+
+// buildSameCarrierDaemon constructs a daemon for a single role:control system on
+// one carrier and returns it, so the same-carrier voice-tap registration can be
+// asserted at construction time (no SDR I/O required).
+func buildSameCarrierDaemon(t *testing.T, protocol string) *Daemon {
+	t.Helper()
+	cfg := config.Default()
+	cfg.SDR.SampleRate = 48_000
+	cfg.SDR.Devices = []config.DeviceConfig{{Serial: "mock-00", Role: "control"}}
+	cfg.Trunking.Systems = []config.SystemConfig{
+		{Name: "OneCarrier", Protocol: protocol, ControlChannels: []uint32{460_500_000}},
+	}
+	// Leave no artifacts on disk.
+	cfg.Storage.Path = ""
+	cfg.Storage.CCCacheFile = ""
+	cfg.Recordings.Dir = ""
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	d, err := NewDaemon(cfg, "test-samecarrier", logger)
+	if err != nil {
+		t.Fatalf("NewDaemon(%s): %v", protocol, err)
+	}
+	return d
+}
+
+// TestConventionalDMRRegistersSameCarrierVoiceTaps is the #1036 regression: a
+// conventional DMR (Tier II) repeater carries voice on the SAME carrier its Voice
+// LC Headers decode on, so the daemon must register same-carrier voice taps for it
+// — otherwise a grant on the repeater carrier has no voice source, is dropped, and
+// nothing records. Before the fix the same-carrier tap was gated to TETRA only, so
+// this registered 0 taps.
+func TestConventionalDMRRegistersSameCarrierVoiceTaps(t *testing.T) {
+	for _, proto := range []string{"dmr-tier2", "dmr-tier1"} {
+		t.Run(proto, func(t *testing.T) {
+			d := buildSameCarrierDaemon(t, proto)
+			if got, want := len(d.ccVoiceSources), dmrSameCarrierTaps; got != want {
+				t.Fatalf("%s registered %d same-carrier voice taps, want %d — a grant on the repeater carrier would have no voice source and never record (#1036)",
+					proto, got, want)
+			}
+		})
+	}
+}
+
+// TestTETRARegistersSameCarrierVoiceTaps pins that TETRA still registers its four
+// per-timeslot taps (unchanged by the #1036 generalization).
+func TestTETRARegistersSameCarrierVoiceTaps(t *testing.T) {
+	d := buildSameCarrierDaemon(t, "tetra")
+	if got, want := len(d.ccVoiceSources), tetraSameCarrierTaps; got != want {
+		t.Fatalf("tetra registered %d same-carrier voice taps, want %d", got, want)
+	}
+}
+
+// TestTrunkedDMRRegistersNoSameCarrierVoiceTaps pins that trunked DMR Tier III —
+// whose voice hops to a separate traffic channel — registers NO same-carrier tap,
+// so the "no voice SDR" diagnostic isn't masked for it.
+func TestTrunkedDMRRegistersNoSameCarrierVoiceTaps(t *testing.T) {
+	d := buildSameCarrierDaemon(t, "dmr")
+	if got := len(d.ccVoiceSources); got != 0 {
+		t.Fatalf("trunked DMR Tier III registered %d same-carrier voice taps, want 0", got)
+	}
+}

--- a/cmd/gophertrunk/replay.go
+++ b/cmd/gophertrunk/replay.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"time"
 
+	"github.com/MattCheramie/GopherTrunk/internal/scanner/ccdecoder"
 	"github.com/MattCheramie/GopherTrunk/internal/siglab"
 )
 
@@ -48,6 +50,9 @@ func runReplay(args []string) {
 	recordDDC := fs.String("record-ddc", "", "also write the post-DDC narrowband IQ (the exact channelized stream the receiver decodes) to this 2-channel 16-bit baseband WAV — shrinks a fat 2.5/10 MS/s capture into a small shareable fixture that `replay -format wav` decodes identically")
 	outFormat := fs.String("out-format", "text", "output format: text | json | jsonl | yaml | csv | csv-events")
 	out := fs.String("out", "", "write structured output to this file (default: stdout for non-text)")
+	recordVoice := fs.Bool("record-voice", false, "decode and record voice for the capture's grants, writing .wav/.raw/.json under -out-dir. Wires the production voice path (engine → composer → recorder) onto the decode, following each grant on the decoded (same) carrier. Best for conventional systems (DMR Tier II / IPSC, TETRA) whose voice rides the decoded carrier.")
+	outDir := fs.String("out-dir", "", "recordings directory for -record-voice (required with it)")
+	voiceHangtimeMs := fs.Int("voice-hangtime-ms", 3500, "end-of-transmission hangtime for -record-voice, in ms")
 	fs.Usage = func() {
 		fmt.Fprintln(fs.Output(), `gophertrunk replay — decode a raw IQ capture file offline (any protocol).
 
@@ -129,6 +134,34 @@ FLAGS:`)
 		Log:                  logger,
 	}
 
+	// Optional voice recording: wire the production voice path (engine → composer
+	// → recorder) onto the decode's grant bus + channelized-IQ tap, so grants
+	// become .wav/.raw/.json recordings. -auto-tune runs several candidate decodes
+	// internally, which would each drive the voice rig, so it is disallowed here —
+	// use -tune-hz for a fixed offset.
+	var voiceRig *replayVoiceRig
+	if *recordVoice {
+		if *outDir == "" {
+			rep.Fatalf(2, "-record-voice requires -out-dir")
+		}
+		if *autoTune {
+			rep.Fatalf(2, "-record-voice does not support -auto-tune; use -tune-hz for a fixed offset")
+		}
+		if *freq == 0 {
+			rep.Fatalf(2, "-record-voice requires -freq (the carrier frequency in Hz): grants carry the decode frequency, and a grant with freq 0 is dropped by the engine (nothing records)")
+		}
+		ddcRate := *sampleRate
+		if target := ccdecoder.DDCTargetForProtocol(proto); *sampleRate != target {
+			ddcRate = target
+		}
+		voiceRig, err = setupReplayVoice(*outDir, ddcRate, time.Duration(*voiceHangtimeMs)*time.Millisecond, logger)
+		if err != nil {
+			rep.Fatal(1, err)
+		}
+		cfg.Bus = voiceRig.bus
+		cfg.OnChannelIQ = voiceRig.onChannelIQ
+	}
+
 	// Under -auto-tune, try the ranked carrier candidates and keep the best
 	// lock — so a control channel that is off-centre and not the loudest carrier
 	// in a wideband capture is still found (a single dominant-carrier estimate
@@ -138,6 +171,12 @@ FLAGS:`)
 		res, err = siglab.RunAutoTuneMulti(*in, cfg, 0)
 	} else {
 		res, err = siglab.Run(*in, cfg)
+	}
+	if voiceRig != nil {
+		// Let in-flight calls reach hangtime end + finalize their recordings,
+		// then tear the rig down. Done regardless of the decode error so a
+		// partial capture still flushes what it recorded.
+		voiceRig.finalize()
 	}
 	if err != nil {
 		rep.Fatal(1, err)

--- a/cmd/gophertrunk/replay_voice.go
+++ b/cmd/gophertrunk/replay_voice.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"math"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+	"github.com/MattCheramie/GopherTrunk/internal/voice"
+	"github.com/MattCheramie/GopherTrunk/internal/voice/composer"
+)
+
+// replayVoiceSerial is the single voice device serial the replay rig exposes.
+const replayVoiceSerial = "replay-voice:1"
+
+// replayVoiceSource is the same-carrier voice device the replay rig binds every
+// grant to. It streams the control carrier's own channelized IQ (fed from
+// siglab's OnChannelIQ tap) to each following voice chain — the offline analogue
+// of ccdecoder.CCVoiceSource, which the daemon uses for the same job. Because a
+// conventional capture decodes ONE carrier, every grant belongs to it, so the
+// source tunes anywhere (CanTune always true).
+//
+// Backpressure: push blocks on each subscriber's channel, so a fast file replay
+// is paced to the (real-time-cost) voice chain instead of overrunning it.
+type replayVoiceSource struct {
+	rateBits atomic.Uint64 // float64 DDC rate, learned from the first push
+
+	mu   sync.Mutex
+	next int
+	subs map[int]*replayVoiceSub
+}
+
+type replayVoiceSub struct {
+	ch   chan []complex64
+	done chan struct{}
+}
+
+func newReplayVoiceSource(rateHz float64) *replayVoiceSource {
+	s := &replayVoiceSource{subs: make(map[int]*replayVoiceSub)}
+	s.rateBits.Store(math.Float64bits(rateHz))
+	return s
+}
+
+func (s *replayVoiceSource) Serial() string { return replayVoiceSerial }
+
+// SetCenterFreq is a no-op: the carrier is already tuned by the replayed capture.
+func (s *replayVoiceSource) SetCenterFreq(uint32) error { return nil }
+
+// CanTune accepts any grant — a replay decodes a single carrier, so every grant
+// it produces belongs to that carrier.
+func (s *replayVoiceSource) CanTune(uint32) bool { return true }
+
+func (s *replayVoiceSource) rate() float64 { return math.Float64frombits(s.rateBits.Load()) }
+
+func (s *replayVoiceSource) SampleRateHz() uint32       { return uint32(s.rate() + 0.5) }
+func (s *replayVoiceSource) SampleRateExactHz() float64 { return s.rate() }
+
+// StreamIQ registers a subscriber for the carrier IQ until ctx ends (the composer
+// cancels it at call end).
+func (s *replayVoiceSource) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
+	sub := &replayVoiceSub{ch: make(chan []complex64, 16), done: make(chan struct{})}
+	s.mu.Lock()
+	id := s.next
+	s.next++
+	s.subs[id] = sub
+	s.mu.Unlock()
+	go func() {
+		<-ctx.Done()
+		s.mu.Lock()
+		delete(s.subs, id)
+		s.mu.Unlock()
+		close(sub.done) // unblocks any in-flight push targeting this sub
+	}()
+	return sub.ch, nil
+}
+
+// push fans one channelized IQ chunk to every following voice chain, copying it
+// (siglab reuses the backing array) and blocking until each consumer takes it
+// (backpressure — see the type comment). A sub cancelled mid-send is skipped via
+// its done channel rather than deadlocking.
+func (s *replayVoiceSource) push(iq []complex64, rateHz float64) {
+	if rateHz > 0 {
+		s.rateBits.Store(math.Float64bits(rateHz))
+	}
+	s.mu.Lock()
+	if len(s.subs) == 0 {
+		s.mu.Unlock()
+		return
+	}
+	subs := make([]*replayVoiceSub, 0, len(s.subs))
+	for _, sub := range s.subs {
+		subs = append(subs, sub)
+	}
+	s.mu.Unlock()
+	cp := make([]complex64, len(iq))
+	copy(cp, iq)
+	for _, sub := range subs {
+		select {
+		case sub.ch <- cp:
+		case <-sub.done:
+		}
+	}
+}
+
+// replayVoiceDevices resolves the composer's device lookups to the single replay
+// voice source.
+type replayVoiceDevices struct{ src *replayVoiceSource }
+
+func (d replayVoiceDevices) FindBySerial(serial string) composer.IQSource {
+	if serial == d.src.Serial() {
+		return d.src
+	}
+	return nil
+}
+
+// replayVoiceRig wires a trunking engine + voice composer + recorder onto a
+// siglab decode's grant bus and channelized-IQ tap, so `replay -record-voice`
+// turns a capture's grants into .wav/.raw/.json recordings using the exact
+// production voice path (VoicePool.Bind → composer voice chains → recorder).
+type replayVoiceRig struct {
+	bus      *events.Bus
+	src      *replayVoiceSource
+	engine   *trunking.Engine
+	composer *composer.Composer
+	recorder *voice.Recorder
+	cancel   context.CancelFunc
+	hangtime time.Duration
+	wg       sync.WaitGroup
+}
+
+// setupReplayVoice builds and starts the engine/composer/recorder rig writing to
+// outDir. rateHz is the expected channelized (DDC output) rate; the source also
+// refines it from the first IQ chunk.
+func setupReplayVoice(outDir string, rateHz float64, hangtime time.Duration, log *slog.Logger) (*replayVoiceRig, error) {
+	bus := events.NewBus(1024)
+	src := newReplayVoiceSource(rateHz)
+
+	pool := trunking.NewVoicePool([]*trunking.VoiceDevice{{Tuner: src, Serial: src.Serial()}})
+	engine, err := trunking.NewEngine(trunking.EngineOptions{
+		Bus:        bus,
+		Log:        log,
+		VoicePool:  pool,
+		Talkgroups: trunking.NewTalkgroupDB(),
+		ScanMode:   trunking.ScanModeAll,
+	})
+	if err != nil {
+		bus.Close()
+		return nil, fmt.Errorf("replay voice: engine: %w", err)
+	}
+	rec, err := voice.NewRecorder(voice.RecorderOptions{
+		Bus:                bus,
+		Log:                log,
+		OutDir:             outDir,
+		SampleRate:         8000,
+		WriteRaw:           true,
+		WriteCallJSON:      true,
+		VocoderForProtocol: voice.DefaultVocoderForProtocol(),
+	})
+	if err != nil {
+		bus.Close()
+		return nil, fmt.Errorf("replay voice: recorder: %w", err)
+	}
+	comp, err := composer.New(composer.Options{
+		Bus:           bus,
+		Devices:       replayVoiceDevices{src: src},
+		Sink:          rec,
+		Engine:        engine,
+		Log:           log,
+		IQSampleRate:  uint32(rateHz + 0.5),
+		PCMSampleRate: 8000,
+		VoiceHangtime: hangtime,
+	})
+	if err != nil {
+		bus.Close()
+		return nil, fmt.Errorf("replay voice: composer: %w", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	rig := &replayVoiceRig{
+		bus: bus, src: src, engine: engine, composer: comp, recorder: rec,
+		cancel: cancel, hangtime: hangtime,
+	}
+	for _, r := range []func(context.Context) error{rec.Run, comp.Run, engine.Run} {
+		run := r
+		rig.wg.Add(1)
+		go func() { defer rig.wg.Done(); _ = run(ctx) }()
+	}
+	return rig, nil
+}
+
+// onChannelIQ is the siglab tap: it forwards the channelized IQ to the voice
+// source (blocking, so decode is paced to the voice chain).
+func (r *replayVoiceRig) onChannelIQ(iq []complex64, rateHz float64) { r.src.push(iq, rateHz) }
+
+// finalize lets any in-flight call reach its hangtime end (so its recording is
+// finalized), then tears the rig down and flushes.
+func (r *replayVoiceRig) finalize() {
+	// No more IQ arrives after decode EOF; the composer's boundary tracker ends
+	// the active call one hangtime later (wall clock), which publishes CallEnd and
+	// finalizes the recording. Wait that out with margin before tearing down.
+	time.Sleep(r.hangtime + 2*time.Second)
+	_ = r.composer.Close() // cancels chains, draining tails (drain coordination)
+	r.cancel()             // stop engine/composer/recorder Run loops
+	r.bus.Close()
+	_ = r.recorder.Close() // flushPendingFinalize writes any still-pending recording
+	r.wg.Wait()
+}

--- a/cmd/gophertrunk/replay_voice_test.go
+++ b/cmd/gophertrunk/replay_voice_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/scanner/ccdecoder"
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TestReplayVoiceSourceFanoutCopiesAndSurvivesCancel pins the replay voice
+// source's contract: a pushed chunk is delivered as an independent copy to each
+// subscriber, and after a subscriber's ctx is cancelled a further push neither
+// blocks nor panics (no send on a closed channel).
+func TestReplayVoiceSourceFanoutCopiesAndSurvivesCancel(t *testing.T) {
+	s := newReplayVoiceSource(48000)
+	if s.SampleRateHz() != 48000 {
+		t.Fatalf("SampleRateHz = %d, want 48000", s.SampleRateHz())
+	}
+	if !s.CanTune(123456789) {
+		t.Fatal("CanTune should accept any grant for a single-carrier replay")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch, err := s.StreamIQ(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := []complex64{1 + 2i, 3 + 4i}
+	go s.push(src, 48000)
+	got := <-ch
+	if len(got) != 2 || got[0] != 1+2i || got[1] != 3+4i {
+		t.Fatalf("delivered chunk = %v, want [1+2i 3+4i]", got)
+	}
+	got[0] = 0 // mutating the delivered copy must not affect the source slice
+	if src[0] != 1+2i {
+		t.Fatal("push did not copy: mutating the delivered chunk changed the source")
+	}
+
+	cancel()
+	// Let the unsubscribe goroutine run, then confirm a further push returns
+	// promptly (the sub is gone / its done channel is selected) rather than
+	// blocking or panicking.
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 100; i++ {
+			s.push([]complex64{9}, 48000)
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("push blocked after subscriber cancel")
+	}
+}
+
+// TestReplayRecordVoiceEndToEnd is the skip-guarded end-to-end reproduction for
+// #1036: it runs a real DMR IPSC capture through the production voice path wired
+// by replay -record-voice (siglab decode → grant bus → engine → composer →
+// recorder) and asserts a non-empty .wav is produced — i.e. conventional DMR
+// voice records from a capture. Set GT_DMR_IQ (cs16) [+ GT_DMR_IQ_RATE].
+func TestReplayRecordVoiceEndToEnd(t *testing.T) {
+	path := os.Getenv("GT_DMR_IQ")
+	if path == "" {
+		t.Skip("set GT_DMR_IQ (cs16 IQ) [+ GT_DMR_IQ_RATE] to run the replay -record-voice end-to-end test")
+	}
+	rate := 50000.0
+	if v := os.Getenv("GT_DMR_IQ_RATE"); v != "" {
+		f, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			t.Fatalf("bad GT_DMR_IQ_RATE: %v", err)
+		}
+		rate = f
+	}
+	outDir := t.TempDir()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	proto := trunking.ProtocolDMRTier2
+	ddcRate := rate
+	if target := ccdecoder.DDCTargetForProtocol(proto); rate != target {
+		ddcRate = target
+	}
+	rig, err := setupReplayVoice(outDir, ddcRate, 3500*time.Millisecond, log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := siglab.Config{
+		Protocol:     proto,
+		SystemName:   "replay-voice-test",
+		FrequencyHz:  443237500, // non-zero so grants bind (freq 0 is dropped)
+		SampleRateHz: rate,
+		Format:       siglab.FormatS16,
+		Log:          log,
+		Bus:          rig.bus,
+		OnChannelIQ:  rig.onChannelIQ,
+	}
+	if _, err := siglab.Run(path, cfg); err != nil {
+		t.Fatalf("siglab.Run: %v", err)
+	}
+	rig.finalize()
+
+	var wavs []string
+	_ = filepath.Walk(outDir, func(p string, info os.FileInfo, err error) error {
+		if err == nil && !info.IsDir() && filepath.Ext(p) == ".wav" && info.Size() > 1024 {
+			wavs = append(wavs, p)
+		}
+		return nil
+	})
+	if len(wavs) == 0 {
+		t.Fatal("replay -record-voice produced no non-empty .wav — conventional DMR voice did not record (#1036)")
+	}
+	t.Logf("recorded %d wav(s), e.g. %s", len(wavs), filepath.Base(wavs[0]))
+}

--- a/internal/siglab/config.go
+++ b/internal/siglab/config.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"strings"
 
+	"github.com/MattCheramie/GopherTrunk/internal/events"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
 
@@ -123,6 +124,25 @@ type Config struct {
 	// a discard logger (the engine never wants a nil *slog.Logger reaching a
 	// factory that does not nil-guard it).
 	Log *slog.Logger
+
+	// Bus, when non-nil, is the event bus the decode pipeline publishes grants
+	// / decode errors to (and the internal collector subscribes to). Supplying
+	// one lets a caller wire additional subscribers — e.g. a trunking engine +
+	// voice composer + recorder that turn grants into recordings (replay
+	// -record-voice). nil ⇒ the engine creates and closes its own bus (the
+	// default; grants are only collected into the Result).
+	Bus *events.Bus
+
+	// OnChannelIQ, when non-nil, is called with each post-DDC channelized IQ
+	// chunk (the exact complex stream the receiver decodes, at the DDC output
+	// rate) as it is produced. The slice is reused after the call returns, so
+	// an implementation that keeps the samples MUST copy them. This is the
+	// live counterpart of RecordDDCPath: it feeds a same-carrier voice source
+	// so replay can decode voice off the control carrier's own IQ. A slow
+	// consumer paces the decode (the call is synchronous), which is what keeps
+	// a fast file replay from overrunning the real-time voice chain. rateHz is
+	// the DDC output (channelized) rate the samples are at.
+	OnChannelIQ func(iq []complex64, rateHz float64)
 }
 
 const defaultChunkSamples = 8192

--- a/internal/siglab/engine.go
+++ b/internal/siglab/engine.go
@@ -304,7 +304,15 @@ func runReader(r io.Reader, source string, decode SampleDecoder, bytesPerSample 
 		}()
 	}
 
-	bus := events.NewBus(1024)
+	// Use the caller's bus when supplied (replay -record-voice wires an engine +
+	// composer + recorder onto it), else create and own one. Only close a bus we
+	// created — the caller manages the lifetime of one it passed in.
+	bus := cfg.Bus
+	ownBus := false
+	if bus == nil {
+		bus = events.NewBus(1024)
+		ownBus = true
+	}
 	sub := bus.Subscribe()
 
 	// Optional protocol-agnostic analyzer + raw-IQ imbalance corrector.
@@ -370,7 +378,9 @@ func runReader(r io.Reader, source string, decode SampleDecoder, bytesPerSample 
 	bundle, err := buildBundle(cfg, bus, logger, receiverRate, symbolTap, softTap, constTap, pduTap)
 	if err != nil {
 		sub.Close()
-		bus.Close()
+		if ownBus {
+			bus.Close()
+		}
 		return nil, err
 	}
 	if bundle.closeFn != nil {
@@ -439,6 +449,14 @@ func runReader(r io.Reader, source string, decode SampleDecoder, bytesPerSample 
 			if iqTap != nil {
 				iqTap.observeIQ(feed)
 			}
+			// Offer the channelized IQ to a voice source BEFORE decoding it, so a
+			// grant this chunk produces is published to a subscriber that is already
+			// receiving the carrier's IQ. The call is synchronous, so a slow voice
+			// consumer paces the decode (prevents a fast file replay from overrunning
+			// the real-time voice chain).
+			if cfg.OnChannelIQ != nil {
+				cfg.OnChannelIQ(feed, receiverRate)
+			}
 			bundle.proc.Process(feed)
 			totalSamples += int64(pairs)
 
@@ -478,10 +496,15 @@ func runReader(r io.Reader, source string, decode SampleDecoder, bytesPerSample 
 		}
 	}
 
-	// Release the drainer and wait for it so totals are complete.
-	bus.Close()
-	<-done
+	// Release the drainer and wait for it so totals are complete. Close the bus
+	// only if we own it; a caller-supplied bus (replay -record-voice) stays open
+	// so its engine/composer/recorder can finalize before the caller closes it.
+	// Closing our subscription ends the collector's range loop either way.
+	if ownBus {
+		bus.Close()
+	}
 	sub.Close()
+	<-done
 	if readErr != nil {
 		return nil, readErr
 	}


### PR DESCRIPTION
## Summary

Two field-reported voice problems from an ~12 h TETRA + DMR session. (1) Recordings lost the last few speech frames of a transmission — a finalize race between the recorder and the composer's teardown drain. (2) Conventional DMR (Tier II / IPSC) never recorded voice even though it decoded perfectly: the same-carrier voice tap was gated to TETRA only, so a conventional DMR carrier had no voice source and every grant was dropped (#1036). Also adds `replay -record-voice`, the offline tool used to reproduce and validate #1036 end to end.

## Changes

- **Trailing voice frames kept.** The recorder finalized/deleted a call's session on `CallEnd` while the composer was still draining the tail in parallel (two independent bus subscribers, no ordering), so drained tail frames landed on a deleted session and were dropped. The recorder now defers finalize until the composer signals drain-complete (`NotifyDrainComplete`), with a safety timeout so a dropped `CallEnd` can't hang a recording. Also fixes a nested race: the TETRA same-carrier chain closed `done` before its owner worker finished draining. (`internal/voice/recorder.go`, `internal/voice/composer/{composer,tetra_voice,dmr_voice}.go`, `cmd/gophertrunk/daemon.go` fanoutSink forwarding.)
- **Conventional DMR voice records (#1036).** Same-carrier voice taps are now registered for `dmr-tier2`/`dmr-tier1` (2, for the 2-slot carrier), not just TETRA — a conventional DMR repeater carries voice on the same carrier it decodes. Trunked Tier III / P25 still register none, preserving their "no voice SDR" diagnostic. (`cmd/gophertrunk/daemon.go`.)
- **`replay -record-voice -out-dir <dir> -freq <Hz>`.** Wires the production voice path (engine → composer → recorder) onto the replay decode via two additive siglab hooks (`Config.Bus`, `Config.OnChannelIQ`); grants bind a same-carrier voice source fed by the decode's own channelized IQ, and each call is written as `.wav`/`.raw`/`.json`. (`internal/siglab/{config,engine}.go`, `cmd/gophertrunk/{replay,replay_voice}.go`.)
- **DMR IPSC decode diagnostic harness** — skip-guarded, `cmd/gophertrunk/dmr_ipsc_replay_test.go`.

## Test plan

- [x] `go vet` + `go test` green on all touched packages (`internal/voice/...`, `internal/voice/composer/...`, `internal/siglab/...`, `cmd/gophertrunk/...`), including `-race` on the concurrency changes. Note: the full `make test` (`go test -race ./...`) exceeds the CI sandbox's 9-minute wall limit, so it was run per-package rather than in one invocation.
- [x] Added regression tests: `recorder_drain_test.go` + `tetra_samecarrier_drain_test.go` (trailing frames, both verified failing-first); `daemon_samecarrier_voice_test.go` (#1036 tap registration, failing-first); `replay_voice_test.go` (source contract + skip-guarded end-to-end).
- [x] Smoke-tested `replay -record-voice` against the reporter's real 50 kHz cs16 IPSC capture: produces a valid `.wav` of decoded speech (peak ~26k, rms ~2k, DC ~−2, 0 uncorrectable AMBE), confirming the decode chain works end to end and the #1036 gap was purely voice-source binding.
- [ ] `make integration` not run to completion (needs mock-hardware fixtures); the #1036 end-to-end path is covered by the skip-guarded `TestReplayRecordVoiceEndToEnd` against a real capture instead.

## Breaking changes

None. New CLI flags (`-record-voice`, `-out-dir`, `-voice-hangtime-ms`) are additive; the new `siglab.Config` fields default to prior behaviour when unset; the recorder's drain coordination is off unless a composer enables it.

## Docs / CHANGELOG

- [x] Added `## [Unreleased]` bullets to `CHANGELOG.md` (trailing frames, conventional DMR voice, `replay -record-voice`).
- [ ] No README/docs change needed (CLI `-h` documents the new flags).

## Linked issues

Refs #1036 — kept open (not `Closes`) until the reporter confirms recordings on live air, per the repo's issue-closing policy. The decode + record path is proven against their captures; live confirmation is the remaining step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HoLkGCGGYD4PnfETCDPjEh

---
_Generated by [Claude Code](https://claude.ai/code/session_01HoLkGCGGYD4PnfETCDPjEh)_