### PR TITLE
dmr: backfill Tier III call encryption/emergency/priority from the voice LC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Fixed
+- **Encrypted / emergency DMR Tier III calls were logged clear.** A DMR
+  Tier III channel-grant CSBK carries no service-options octet, so a
+  followed call's encrypted / emergency / priority state never reached the
+  call record even though those bits are decoded on the traffic channel. The
+  DMR voice chain now backfills them (plus the source RID) from the embedded
+  voice LC via the in-call `CallSourceUpdate` path the P25 Phase 2 chain
+  already uses — so an encrypted Tier III call is now recorded as encrypted.
+
 ### Added
 - **On-air call priority is decoded and surfaced.** The call's signalled
   priority level — the low 3 bits of the P25 / DMR Service Options octet —

--- a/internal/trunking/engine.go
+++ b/internal/trunking/engine.go
@@ -998,7 +998,7 @@ func (e *Engine) handleCallSourceUpdate(c CallSourceUpdate) {
 	if c.System != "" {
 		return
 	}
-	g, ok := e.pool.UpdateSource(c.DeviceSerial, c.SourceID, c.Encrypted)
+	g, ok := e.pool.UpdateSource(c.DeviceSerial, c.SourceID, c.Encrypted, c.Emergency, c.Priority)
 	if !ok {
 		e.mu.Lock()
 		if ac, sok := e.synthetic[c.DeviceSerial]; sok {
@@ -1007,6 +1007,12 @@ func (e *Engine) handleCallSourceUpdate(c CallSourceUpdate) {
 			}
 			if c.Encrypted {
 				ac.Grant.Encrypted = true
+			}
+			if c.Emergency {
+				ac.Grant.Emergency = true
+			}
+			if c.Priority != 0 {
+				ac.Grant.Priority = c.Priority
 			}
 			g = ac.Grant
 			ok = true
@@ -1025,6 +1031,8 @@ func (e *Engine) handleCallSourceUpdate(c CallSourceUpdate) {
 		GroupID:      g.GroupID,
 		SourceID:     g.SourceID,
 		Encrypted:    g.Encrypted,
+		Emergency:    g.Emergency,
+		Priority:     g.Priority,
 		At:           c.At,
 	}
 	e.bus.Publish(events.Event{

--- a/internal/trunking/engine_test.go
+++ b/internal/trunking/engine_test.go
@@ -1109,6 +1109,8 @@ func TestEngineHandleCallSourceUpdateBackfillsActiveCall(t *testing.T) {
 		DeviceSerial: dev,
 		SourceID:     315203, // @er-imagery's example MMR radio
 		Encrypted:    true,
+		Emergency:    true,
+		Priority:     5,
 		At:           time.Now(),
 	})
 
@@ -1119,6 +1121,10 @@ func TestEngineHandleCallSourceUpdateBackfillsActiveCall(t *testing.T) {
 	if updated[0].Grant.SourceID != 315203 || !updated[0].Grant.Encrypted {
 		t.Errorf("backfill did not land on Grant: src=%d enc=%v",
 			updated[0].Grant.SourceID, updated[0].Grant.Encrypted)
+	}
+	if !updated[0].Grant.Emergency || updated[0].Grant.Priority != 5 {
+		t.Errorf("emergency/priority not backfilled: emer=%v prio=%d",
+			updated[0].Grant.Emergency, updated[0].Grant.Priority)
 	}
 
 	select {

--- a/internal/trunking/grant.go
+++ b/internal/trunking/grant.go
@@ -380,7 +380,15 @@ type CallSourceUpdate struct {
 	GroupID      uint32 // filled in by the engine on republish from the bound Grant
 	SourceID     uint32
 	Encrypted    bool
-	At           time.Time
+	// Emergency and Priority carry the in-call Service Options a followed
+	// call reveals on the traffic channel but whose grant lacked them — a
+	// DMR Tier III channel-grant CSBK has no service-options octet, so an
+	// encrypted / emergency / prioritised Tier III call would otherwise be
+	// logged clear / non-emergency / priority-0. Backfilled additively (an
+	// unset field never clears an already-set one).
+	Emergency bool
+	Priority  uint8
+	At        time.Time
 }
 
 // CallRelease is the payload of an events.KindCallRelease event. A

--- a/internal/trunking/voicepool.go
+++ b/internal/trunking/voicepool.go
@@ -459,7 +459,7 @@ func (p *VoicePool) UpdateEncryption(serial string, algID uint8, keyID uint16) (
 // never the other way (the spec doesn't define mid-call
 // decryption). Returns a copy of the updated Grant + ok=true when
 // a matching call was found.
-func (p *VoicePool) UpdateSource(serial string, sourceID uint32, encrypted bool) (Grant, bool) {
+func (p *VoicePool) UpdateSource(serial string, sourceID uint32, encrypted, emergency bool, priority uint8) (Grant, bool) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	ac, ok := p.active[serial]
@@ -471,6 +471,12 @@ func (p *VoicePool) UpdateSource(serial string, sourceID uint32, encrypted bool)
 	}
 	if encrypted {
 		ac.Grant.Encrypted = true
+	}
+	if emergency {
+		ac.Grant.Emergency = true
+	}
+	if priority != 0 {
+		ac.Grant.Priority = priority
 	}
 	return ac.Grant, true
 }

--- a/internal/voice/composer/dmr_source_backfill_chain_test.go
+++ b/internal/voice/composer/dmr_source_backfill_chain_test.go
@@ -1,0 +1,104 @@
+package composer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TestComposerDMRBackfillsServiceOptions confirms the DMR voice chain
+// publishes a CallSourceUpdate carrying the source + encrypted / emergency
+// / priority it decodes from the embedded voice LC — the metadata a Tier
+// III channel-grant CSBK doesn't carry, so without this an encrypted /
+// emergency Tier III call would be logged clear.
+func TestComposerDMRBackfillsServiceOptions(t *testing.T) {
+	const (
+		sampleRate = 48_000.0
+		sps        = 10
+		span       = 8
+		alpha      = 0.20
+		deviation  = 1944.0
+	)
+	const (
+		wantTG  = uint32(0x64)
+		wantSrc = uint32(0x100200)
+	)
+	// ServiceOptions 0xC5 = emergency(bit7) + encrypted(bit6) + priority 5.
+	gv := dmr.AssembleFLC(dmr.FLC{
+		FLCO: dmr.FLCOGroupVoiceUser, DstAddr: wantTG, SrcAddr: wantSrc, ServiceOptions: 0xC5,
+	})
+	var lcInfos [][]byte
+	for i := 0; i < 4; i++ {
+		lcInfos = append(lcInfos, gv)
+	}
+	dibits := buildVoiceStreamWithLCInfos(t, lcInfos)
+	iq := demod.ModulateC4FM(dibits, sps, span, alpha, sampleRate, deviation)
+
+	src := newFakeSource()
+	bus := events.NewBus(64)
+	sub := bus.Subscribe()
+	defer sub.Close()
+	sink := &recordingSink{}
+	eng := &fakeEngine{}
+	c, err := New(Options{
+		Bus:           bus,
+		Devices:       &fakeDevices{src: map[string]IQSource{"VOICE-1": src}},
+		Sink:          sink,
+		Engine:        eng,
+		IQSampleRate:  uint32(sampleRate),
+		PCMSampleRate: 8000,
+		TouchInterval: 30 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go c.Run(ctx)
+	defer c.Close()
+	defer bus.Close()
+
+	// A Tier III-style grant: no service options on the grant itself.
+	bus.Publish(events.Event{
+		Kind: events.KindCallStart,
+		Payload: trunking.CallStart{
+			Grant: trunking.Grant{
+				System: "DMRSite", Protocol: "dmr-tier3",
+				GroupID: wantTG, FrequencyHz: 460_000_000,
+			},
+			DeviceSerial: "VOICE-1",
+			StartedAt:    time.Now().UTC(),
+		},
+	})
+	waitFor(t, 2*time.Second, func() bool { return len(c.ActiveChains()) == 1 })
+	src.SendIQ(iq)
+
+	deadline := time.After(8 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			t.Fatal("no KindCallSourceUpdate with the decoded service options")
+		case ev := <-sub.C:
+			if ev.Kind != events.KindCallSourceUpdate {
+				continue
+			}
+			u, ok := ev.Payload.(trunking.CallSourceUpdate)
+			if !ok || u.DeviceSerial != "VOICE-1" {
+				continue
+			}
+			if u.SourceID != wantSrc {
+				continue // wait for the clean decode
+			}
+			if !u.Encrypted || !u.Emergency || u.Priority != 5 {
+				t.Fatalf("service options not backfilled: enc=%v emer=%v prio=%d",
+					u.Encrypted, u.Emergency, u.Priority)
+			}
+			return
+		}
+	}
+}

--- a/internal/voice/composer/dmr_voice.go
+++ b/internal/voice/composer/dmr_voice.go
@@ -315,6 +315,26 @@ func (c *Composer) runDMRVoiceChain(ctx context.Context, serial, system string, 
 			},
 		})
 	}
+	// publishSource backfills the call's source + encryption / emergency /
+	// priority from the embedded voice LC. A DMR Tier III channel-grant CSBK
+	// carries no service-options octet, so without this an encrypted / emergency
+	// Tier III call is logged clear — the voice LC is where those bits actually
+	// arrive. Deduped so a repeated LC does not spam the bus; the engine's
+	// backfill is additive, so re-sending unchanged values is also harmless.
+	var lastSrcUpd trunking.CallSourceUpdate
+	var haveSrcUpd bool
+	publishSource := func(src uint32, enc, emer bool, prio uint8) {
+		if src == 0 || c.bus == nil {
+			return
+		}
+		upd := trunking.CallSourceUpdate{DeviceSerial: serial, SourceID: src, Encrypted: enc, Emergency: emer, Priority: prio}
+		if haveSrcUpd && upd == lastSrcUpd {
+			return
+		}
+		lastSrcUpd, haveSrcUpd = upd, true
+		upd.At = time.Now().UTC()
+		c.bus.Publish(events.Event{Kind: events.KindCallSourceUpdate, Payload: upd})
+	}
 	// Terminator detection: end the call at once when the followed traffic
 	// channel carries a valid Terminator-with-LC for this call's group,
 	// rather than waiting out the boundary tracker's hangtime. Publish once —
@@ -380,11 +400,15 @@ func (c *Composer) runDMRVoiceChain(ctx context.Context, serial, system string, 
 					lcSuperframes.Add(1)
 					// Learn the call's source radio from either a group-voice or a
 					// unit-to-unit voice LC, so talker-alias / GPS metadata (which
-					// carry no address of their own) is attributed on private calls too.
+					// carry no address of their own) is attributed on private calls too,
+					// and backfill the call's source + service-options (encrypted /
+					// emergency / priority) — a Tier III grant carries none of these.
 					if gv, ok := sf.LC.AsGroupVoiceUser(); ok && gv.SourceID != 0 {
 						callSrc = gv.SourceID
+						publishSource(gv.SourceID, gv.Encrypted, gv.Emergency, gv.Priority)
 					} else if uu, ok := sf.LC.AsUnitToUnitVoice(); ok && uu.SourceID != 0 {
 						callSrc = uu.SourceID
+						publishSource(uu.SourceID, uu.Encrypted, uu.Emergency, uu.Priority)
 					}
 				}
 				// Talker-alias header/block and GPS Info embedded LCs are

--- a/internal/voice/composer/p25p2_voice.go
+++ b/internal/voice/composer/p25p2_voice.go
@@ -365,6 +365,8 @@ func (c *Composer) publishP25Phase2CallSource(serial string, u p25p2.GroupVoiceC
 			DeviceSerial: serial,
 			SourceID:     u.SourceID,
 			Encrypted:    so.Encrypted(),
+			Emergency:    so.Emergency(),
+			Priority:     so.Priority(),
 			At:           time.Now().UTC(),
 		},
 	})


### PR DESCRIPTION
## Summary

A DMR **Tier III** channel-grant CSBK carries no Service Options octet, so a followed call's **encrypted / emergency / priority** state never reached the call record — an **encrypted Tier III call was logged as clear**, and emergency/priority were lost — even though those bits are decoded on the traffic channel in every voice superframe's embedded LC. This backfills them from the traffic channel, using the same in-call `CallSourceUpdate` mechanism the P25 Phase 2 chain already uses for source + encryption.

A correctness fix that needs no capture and no new wire-format work — it reuses the `AsGroupVoiceUser` / `AsUnitToUnitVoice` decode (already verified, extended for priority in #1043).

## Changes

- **Extend the in-call backfill** (`trunking/grant.go`, `voicepool.go`, `engine.go`): `CallSourceUpdate` gains `Emergency` + `Priority`; `VoicePool.UpdateSource` and `handleCallSourceUpdate` backfill them **additively** (an unset field never clears an already-set one, so a source-less repeat can't downgrade the call). The P25 Phase 2 publisher forwards them too.
- **DMR producer** (`voice/composer/dmr_voice.go`): the voice chain publishes a `CallSourceUpdate` carrying the source RID + encrypted/emergency/priority decoded from the embedded group-voice (or unit-to-unit) LC, deduped so a repeated LC doesn't spam the bus.

## Test plan

- [x] `make vet test` is green locally (race)
- [x] `make integration` is green locally (composer path changed)
- [x] Added / extended tests (each fails without the change):
  - `trunking/engine_test.go` — the backfill lands emergency + priority on the bound call's grant.
  - `voice/composer/dmr_source_backfill_chain_test.go` — end-to-end: a Tier III-style call (grant with **no** service options) whose embedded LC is encrypted+emergency+priority publishes a `CallSourceUpdate` with those bits.
- [ ] Smoke-tested against real hardware — n/a; the embedded-LC decode is the same trusted path used elsewhere (capture-pending FEC constants unchanged, #644).

## Breaking changes

None. `CallSourceUpdate` gains fields; `VoicePool.UpdateSource` gains params (single internal caller updated). Backfill is additive.

## Docs / CHANGELOG

- [x] Added a `## [Unreleased]` **Fixed** bullet to `CHANGELOG.md`
- [ ] README/docs — n/a

## Linked issues

n/a — part of the cross-protocol feature-parity roadmap; follows #1043 (which added `Grant.Priority`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144w5FXPjW3oeryHqugKAjP

---
_Generated by [Claude Code](https://claude.ai/code/session_0144w5FXPjW3oeryHqugKAjP)_