### PR TITLE
tetra: surface the decoded CMCE call priority on grants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Added
+- **TETRA call priority is now surfaced.** The CMCE parser already decoded
+  the mandatory 4-bit Call priority (and derived the emergency flag from it);
+  the value now reaches `Grant.Priority` and the call log, extending on-air
+  call-priority metadata to TETRA alongside P25 and DMR.
+
 ### Fixed
 - **Encrypted / emergency DMR Tier III calls were logged clear.** A DMR
   Tier III channel-grant CSBK carries no service-options octet, so a

--- a/internal/radio/tetra/cmce.go
+++ b/internal/radio/tetra/cmce.go
@@ -71,6 +71,10 @@ type VoiceGrant struct {
 	Individual bool
 	Emergency  bool
 	Encrypted  bool
+	// Priority is the 4-bit CMCE Call priority (EN 300 392-2 Table 14.46;
+	// 0 = lowest, 0xF = pre-emptive priority 4 / emergency). Emergency is
+	// derived from it. Zero when no CMCE priority element was decoded.
+	Priority uint8
 }
 
 // Voice grants and call teardown are decoded bit-accurately from the MAC layer

--- a/internal/radio/tetra/control.go
+++ b/internal/radio/tetra/control.go
@@ -760,6 +760,7 @@ type grantSnapshot struct {
 	encrypted  bool
 	emergency  bool
 	individual bool
+	priority   uint8
 }
 
 // sameContent reports whether two snapshots describe the same grant, ignoring
@@ -767,7 +768,7 @@ type grantSnapshot struct {
 func (s grantSnapshot) sameContent(o grantSnapshot) bool {
 	return s.src == o.src && s.freq == o.freq && s.usage == o.usage &&
 		s.encrypted == o.encrypted && s.emergency == o.emergency &&
-		s.individual == o.individual
+		s.individual == o.individual && s.priority == o.priority
 }
 
 // grantDedupWindow is how long a repeated identical voice grant is suppressed
@@ -828,6 +829,7 @@ func (c *ControlChannel) publishGrant(g VoiceGrant) {
 	snap := grantSnapshot{
 		at: now, src: g.SourceSSI, freq: freq, usage: g.UsageMarker,
 		encrypted: g.Encrypted, emergency: g.Emergency, individual: g.Individual,
+		priority: g.Priority,
 	}
 	c.mu.Lock()
 	if c.grantSeen == nil {
@@ -863,6 +865,7 @@ func (c *ControlChannel) publishGrant(g VoiceGrant) {
 			Timeslot:         g.Timeslot + 1,
 			Encrypted:        g.Encrypted,
 			Emergency:        g.Emergency,
+			Priority:         g.Priority,
 			Individual:       g.Individual,
 			TETRAColourExt:   colourExt,
 			TETRAUsageMarker: g.UsageMarker,

--- a/internal/radio/tetra/downlink.go
+++ b/internal/radio/tetra/downlink.go
@@ -342,6 +342,9 @@ func (c *ControlChannel) publishGrantFromMAC(m MACResource, msg CMCEMessage, hav
 	}
 	if haveCMCE {
 		g.Emergency = msg.Emergency
+		if msg.HasPriority {
+			g.Priority = msg.Priority
+		}
 	}
 	c.classifyParties(&g, m, msg, haveCMCE)
 	c.publishGrant(g)

--- a/internal/radio/tetra/downlink_test.go
+++ b/internal/radio/tetra/downlink_test.go
@@ -128,6 +128,39 @@ func TestGrantForeignCarrierRejected(t *testing.T) {
 	}
 }
 
+// TestGrantCarriesCallPriority pins the VoiceGrant.Priority → trunking.Grant
+// plumbing: the 4-bit CMCE Call priority the parser already decodes now
+// reaches the published grant as call metadata.
+func TestGrantCarriesCallPriority(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Sys", FrequencyHz: 467_912_500})
+	cc.learnMainCarrier(2716)
+	cc.publishGrant(VoiceGrant{DestSSI: 1020543, CarrierNumber: 2716, Timeslot: 1, Priority: 6})
+
+	var grant *trunking.Grant
+	for drained := false; !drained; {
+		select {
+		case ev := <-sub.C:
+			if g, ok := ev.Payload.(trunking.Grant); ok && ev.Kind == events.KindGrant {
+				gg := g
+				grant = &gg
+			}
+		default:
+			drained = true
+		}
+	}
+	if grant == nil {
+		t.Fatal("no grant published")
+	}
+	if grant.Priority != 6 {
+		t.Errorf("grant priority = %d, want 6", grant.Priority)
+	}
+}
+
 // TestCarrierFrequencyDerivation checks that a grant carrier number resolves to
 // Hz relative to the cell's own carrier (learned from SYSINFO) at 25 kHz
 // spacing, with no configured band plan.

--- a/internal/trunking/grant.go
+++ b/internal/trunking/grant.go
@@ -48,15 +48,16 @@ type Grant struct {
 	Timeslot  uint8
 	Encrypted bool
 	Emergency bool
-	// Priority is the call's on-air signalled priority level, the low 3
-	// bits of the P25 / DMR Service Options octet (0 = lowest, 7 = highest;
-	// 0 also when no priority is signalled). It is the priority the calling
-	// radio requested, distinct from a talkgroup's operator-configured
-	// priority; the engine's preemption still keys off the configured
-	// talkgroup priority, so this is surfaced as call metadata (call log +
-	// API) rather than driving preemption. Zero on protocols/grants whose
-	// signalling carries no service-options octet (e.g. the DMR Tier III
-	// channel-grant CSBK).
+	// Priority is the call's on-air signalled priority level, on a
+	// protocol-specific scale: the low 3 bits of the P25 / DMR Service
+	// Options octet (0..7), or the 4-bit TETRA CMCE Call priority (0..15,
+	// 0xF = pre-emptive/emergency). 0 = lowest, and also when no priority is
+	// signalled. It is the priority the calling radio requested, distinct
+	// from a talkgroup's operator-configured priority; the engine's
+	// preemption still keys off the configured talkgroup priority, so this is
+	// surfaced as call metadata (call log + API) rather than driving
+	// preemption. Zero on grants whose signalling carries no priority element
+	// (e.g. the DMR Tier III channel-grant CSBK).
 	Priority uint8
 	// DMRInterleavedVoice mirrors the system-level
 	// trunking.System.DMRInterleavedVoice opt-in onto the grant so the


### PR DESCRIPTION
## Summary

The TETRA CMCE parser already decodes the **mandatory 4-bit Call priority** (EN 300 392-2 Table 14.15 / 14.46) and derives the emergency flag from it (`priority == 0xF`) — but the priority *value itself* was dropped. Now that `Grant.Priority` exists (#1043, for P25/DMR), this carries it through, extending on-air call-priority metadata to a **third protocol**. Pure plumbing — no new decode, no capture, no wire-format reference needed.

## Changes

- **`tetra/cmce.go`** — `VoiceGrant` gains `Priority` (the 4-bit CMCE Call priority).
- **`tetra/downlink.go`** — set it from `msg.Priority` when a CMCE priority element was decoded (`HasPriority`).
- **`tetra/control.go`** — carry it onto the published `trunking.Grant.Priority`, and track it in the grant-dedup snapshot so a priority change re-announces.
- **`trunking/grant.go`** — generalize the `Grant.Priority` doc: it's now a protocol-specific scale (P25/DMR 3-bit 0..7; TETRA 4-bit 0..15, 0xF = pre-emptive/emergency).

## Test plan

- [x] `make vet test` is green locally (race, 165 packages, 0 failures)
- [ ] `make integration` — n/a (no daemon/DSP path changed)
- [x] Added `TestGrantCarriesCallPriority` — a `VoiceGrant` with a priority publishes a `trunking.Grant` carrying it. The existing CMCE parser tests already cover priority extraction (`setPriority`).

## Breaking changes

None. `VoiceGrant` gains a field; `Grant.Priority` was already present.

## Docs / CHANGELOG

- [x] Added an `## [Unreleased]` bullet to `CHANGELOG.md`
- [ ] README/docs — n/a

## Linked issues

Refs #1043 (which added `Grant.Priority`). Part of the cross-protocol feature-parity roadmap (W10 — priority).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144w5FXPjW3oeryHqugKAjP

---
_Generated by [Claude Code](https://claude.ai/code/session_0144w5FXPjW3oeryHqugKAjP)_