### PR TITLE
tetra: wire per-burst training-sequence equalizer into TrafficExtractor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,3 +146,23 @@ confirmation before any close-as-completed.
   case (same reason `receiver_equalizer_test.go`'s clean-channel test adds 30 dB).
   The residual −44 dBFS weak front end is an RF/gain/antenna condition (the #764
   lesson) the equalizer mitigates but does not replace — raise the signal level too.
+- **TETRA training-sequence equalizer (`equalizer.SnapshotLMS`) is now wired into the
+  per-burst traffic path** (#1001 follow-up). The blind `SnapshotCMA` lives in the
+  *receiver* (continuous, framing-free stream); the trained `SnapshotLMS` lives in
+  the *extractor* (`TrafficExtractor.EnableLMSEqualizer`), because only the extractor
+  knows where each burst's midamble sits. The linear channel is a clean convolution
+  only in the **raw symbol** domain, not the differential domain (`s·conj(prev)` is a
+  nonlinear product) — so the extractor carries the raw symbols down parallel to its
+  dibit/diff buffers via the receiver's new `SymbolSink → StashSymbols` (the symbol
+  analog of `SoftSink → StashSoft`). Per burst, softFrame trains on the known NTS1/NTS2
+  midamble from the raw symbols, freezes the taps, equalizes a BKN1..BKN2 span (with a
+  taps-long FIR warm-up so the first BKN1 differential is past the transient), and
+  **re-derives the soft LLRs from the equalized symbols** — hard frame untouched. It is
+  soft-path only and opt-in: no `StashSymbols`/`EnableLMSEqualizer` ⇒ byte-identical to
+  before. The reference is built by differentially encoding the ideal midamble from a
+  unit anchor (arbitrary start phase; the constant rotation cancels in the differential
+  decode, the same property that makes a frozen snapshot safe). Pinned by
+  `traffic_lms_test.go` (synthetic multipath through the real extractor: raw 13% → 0%
+  payload bit-error, no-harm on clean). Production composer still runs CMA only; flip
+  LMS on there once the capture A/B validates it. A/B on captures with `GT_TETRA_LMS=1`
+  in `TestTETRAMultiSlotReplay` (compare `traffic_marked_crc_soft`).

--- a/cmd/gophertrunk/tetra_multislot_replay_test.go
+++ b/cmd/gophertrunk/tetra_multislot_replay_test.go
@@ -79,9 +79,9 @@ func TestTETRAMultiSlotReplay(t *testing.T) {
 	}
 	usage := map[uint8]*usageAcc{}
 
-	var totalBursts, anchoredBursts, trafficMarked, trafficMarkedCRC int
+	var totalBursts, anchoredBursts, trafficMarked, trafficMarkedCRC, trafficMarkedCRCSoft int
 	errsHist := map[string]int{}
-	extractor := tetra.NewTrafficExtractor(colourExt, func(frame []byte, _ []float32, slot, mark uint8) {
+	extractor := tetra.NewTrafficExtractor(colourExt, func(frame []byte, softType5 []float32, slot, mark uint8) {
 		totalBursts++
 		if slot != 0 {
 			anchoredBursts++
@@ -90,6 +90,12 @@ func TestTETRAMultiSlotReplay(t *testing.T) {
 			trafficMarked++
 			if len(tetra.TCHSpeechFrames(frame)) > 0 {
 				trafficMarkedCRC++
+			}
+			// Soft-path CRC yield: this is the stream the LMS equalizer (GT_TETRA_LMS)
+			// conditions, so A/B it via this counter (the hard trafficMarkedCRC above
+			// is unaffected by the soft equalizer).
+			if softType5 != nil && len(tetra.TCHSpeechFramesSoft(softType5)) > 0 {
+				trafficMarkedCRCSoft++
 			}
 		}
 		if _, _, _, errs, ok := tetra.DecodeTCHS(frame); ok {
@@ -135,10 +141,18 @@ func TestTETRAMultiSlotReplay(t *testing.T) {
 		s.activeSec[int(tSec)]++
 	})
 
-	// GT_TETRA_EQ=1 enables the adaptive channel equalizer (issue #1001), so the
-	// same capture can be A/B'd with and without it — compare the total_bursts /
-	// traffic_marked_crc / errs_hist lines and the per-slot crc_bursts counts.
+	// GT_TETRA_EQ=1 enables the blind CMA channel equalizer in the receiver (issue
+	// #1001); GT_TETRA_LMS=1 enables the per-burst training-sequence LMS equalizer
+	// in the extractor's soft path. Either can be A/B'd against the same capture:
+	// compare traffic_marked_crc (hard, moves with CMA) and traffic_marked_crc_soft
+	// (soft, moves with LMS) plus the per-slot crc_bursts counts.
 	enableEQ := os.Getenv("GT_TETRA_EQ") == "1" || os.Getenv("GT_TETRA_EQ") == "true"
+	enableLMS := os.Getenv("GT_TETRA_LMS") == "1" || os.Getenv("GT_TETRA_LMS") == "true"
+	if enableLMS {
+		// Train on each burst's known midamble and equalize BKN1/BKN2 before the
+		// soft TCH/S decode. Requires the raw symbols (SymbolSink → StashSymbols).
+		extractor.EnableLMSEqualizer(0, 0)
+	}
 	rx := tetrarx.New(tetrarx.Options{
 		SampleRateHz: outRate,
 		DibitSink: func(d []uint8, base int) {
@@ -152,13 +166,19 @@ func TestTETRAMultiSlotReplay(t *testing.T) {
 		SoftSink: func(diffs []complex64, base int) {
 			extractor.StashSoft(diffs, base)
 		},
+		// Feed the raw pre-differential symbols the LMS equalizer trains/applies on.
+		// Fires just before the matching DibitSink, so StashSymbols lands before
+		// Process consumes the block. Harmless (buffered, never read) when LMS is off.
+		SymbolSink: func(syms []complex64, base int) {
+			extractor.StashSymbols(syms, base)
+		},
 		ClockMode:           tetrarx.ClockGardner,
 		GardnerGain:         0.005,
 		EnableAFC:           true,
 		EnableChannelFilter: true,
 		EnableEqualizer:     enableEQ,
 	})
-	t.Logf("equalizer=%v (set GT_TETRA_EQ=1 to enable)", enableEQ)
+	t.Logf("cma_equalizer=%v (GT_TETRA_EQ=1) lms_equalizer=%v (GT_TETRA_LMS=1)", enableEQ, enableLMS)
 
 	const chunk = 65536
 	var scratch []complex64
@@ -172,7 +192,7 @@ func TestTETRAMultiSlotReplay(t *testing.T) {
 	}
 
 	t.Logf("in=%.0fHz out=%.0fHz samples=%d dur=%.1fs", inRate, outRate, len(iq), float64(len(iq))/inRate)
-	t.Logf("total_bursts=%d anchored=%d traffic_marked=%d traffic_marked_crc=%d errs_hist=%v", totalBursts, anchoredBursts, trafficMarked, trafficMarkedCRC, errsHist)
+	t.Logf("total_bursts=%d anchored=%d traffic_marked=%d traffic_marked_crc=%d traffic_marked_crc_soft=%d errs_hist=%v", totalBursts, anchoredBursts, trafficMarked, trafficMarkedCRC, trafficMarkedCRCSoft, errsHist)
 	outDir := os.Getenv("GT_TETRA_OUT")
 	for tn := 1; tn <= 4; tn++ {
 		s := slots[tn]

--- a/internal/radio/tetra/receiver/receiver.go
+++ b/internal/radio/tetra/receiver/receiver.go
@@ -128,6 +128,16 @@ type Options struct {
 	// LLRs are Im and Re of the differential). Emitted just before the
 	// matching DibitSink call. nil ⇒ no soft emission, zero overhead.
 	SoftSink func(diffs []complex64, baseIdx int)
+	// SymbolSink, when non-nil, receives the RAW post-timing/AFC/equalizer
+	// complex symbols (before the differential decode), aligned 1:1 with the
+	// dibits emitted to DibitSink and carrying the same baseIdx. Unlike the
+	// SoftSink differential (a nonlinear product s·conj(last), in which the
+	// channel is no longer a clean convolution), the symbol stream is where a
+	// linear channel IS a convolution — so it is the input a training-sequence
+	// equalizer (tetra.TrafficExtractor.EnableLMSEqualizer / equalizer.SnapshotLMS)
+	// must train on and equalize per burst. Emitted just before the matching
+	// DibitSink call. nil ⇒ no symbol emission, zero overhead. See issue #1001.
+	SymbolSink func(symbols []complex64, baseIdx int)
 	// EnableDCBlock inserts a first-order complex DC-removal high-pass at the
 	// very top of Process, ahead of the channel filter, to strip the front-end
 	// DC spur that sits on a same-carrier TETRA voice channel (0 Hz offset) and
@@ -202,15 +212,16 @@ type Receiver struct {
 	dibitBase int
 	rxOffset  int
 
-	clockMode ClockMode
-	gardner   *sync.Gardner
-	afc       *carrierAFC
-	chanFilt  *filter.FIR
-	softSink  func(diffs []complex64, baseIdx int)
-	eq        *equalizer.SnapshotCMA
-	equalized []complex64
-	dcBlk     *dcBlock
-	dcBuf     []complex64
+	clockMode  ClockMode
+	gardner    *sync.Gardner
+	afc        *carrierAFC
+	chanFilt   *filter.FIR
+	softSink   func(diffs []complex64, baseIdx int)
+	symbolSink func(symbols []complex64, baseIdx int)
+	eq         *equalizer.SnapshotCMA
+	equalized  []complex64
+	dcBlk      *dcBlock
+	dcBuf      []complex64
 
 	matched   []complex64
 	filtered  []complex64
@@ -243,11 +254,12 @@ func New(opts Options) *Receiver {
 		alpha = RolloffAlpha
 	}
 	r := &Receiver{
-		dq:        demod.NewPiOver4DQPSK(int(sps+0.5), span, alpha, Rotation),
-		sps:       int(sps + 0.5),
-		dibitSink: opts.DibitSink,
-		softSink:  opts.SoftSink,
-		clockMode: opts.ClockMode,
+		dq:         demod.NewPiOver4DQPSK(int(sps+0.5), span, alpha, Rotation),
+		sps:        int(sps + 0.5),
+		dibitSink:  opts.DibitSink,
+		softSink:   opts.SoftSink,
+		symbolSink: opts.SymbolSink,
+		clockMode:  opts.ClockMode,
 	}
 	if r.clockMode == ClockGardner {
 		gain := opts.GardnerGain
@@ -373,6 +385,15 @@ func (r *Receiver) Process(iq []complex64) {
 		r.softSink(r.diffs, r.dibitBase)
 	} else {
 		r.dibits = r.dq.Decode(r.dibits, r.symbols)
+	}
+	if r.symbolSink != nil {
+		// Emit the raw pre-differential symbols (the linear-channel domain a
+		// training-sequence equalizer works in), aligned 1:1 with the dibits and
+		// keyed by the same base. DecodeBoth/Decode do not mutate r.symbols, so it
+		// is still the symbol stream that produced these dibits. Fired before the
+		// DibitSink so the extractor's StashSymbols lands before Process consumes
+		// the matching dibit block.
+		r.symbolSink(r.symbols, r.dibitBase)
 	}
 	r.dibitSink(r.dibits, r.dibitBase)
 	r.dibitBase += len(r.dibits)

--- a/internal/radio/tetra/traffic.go
+++ b/internal/radio/tetra/traffic.go
@@ -3,6 +3,7 @@ package tetra
 import (
 	"math"
 
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/equalizer"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
 )
 
@@ -102,6 +103,32 @@ type TrafficExtractor struct {
 	pendingSoft     []complex64
 	pendingSoftBase int
 
+	// symBuf holds the RAW pre-differential complex symbols (the receiver's
+	// SymbolSink output) strictly parallel to buf, so a burst can be re-equalized
+	// in the linear-channel domain before the soft decode. Same lockstep contract
+	// as softBuf: either empty (no symbol data supplied — the path used by tests /
+	// any caller that never StashSymbols) or exactly len(buf). Only consulted when
+	// the training-sequence equalizer is enabled (EnableLMSEqualizer). pendingSym
+	// carries the symbols stashed for the NEXT Process call (StashSymbols).
+	symBuf         []complex64
+	pendingSym     []complex64
+	pendingSymBase int
+
+	// lms is the per-burst training-sequence-aided channel equalizer (nil until
+	// EnableLMSEqualizer). When set, softFrame trains it on each burst's known
+	// normal training sequence (the midamble) from the raw symBuf symbols, freezes
+	// the taps, equalizes BKN1+BKN2, and re-derives the soft LLRs from the
+	// equalized symbols — inverting the linear channel / ISI that closes the
+	// π/4-DQPSK eye on a same-carrier site (issue #1001). Off by default: with no
+	// symBuf, or on a burst whose span is not fully buffered, softFrame falls back
+	// to the raw receiver differentials, so the extractor is byte-identical when
+	// the equalizer is not enabled.
+	lms       *equalizer.SnapshotLMS
+	lmsTaps   int
+	lmsPasses int
+	lmsSpan   []complex64 // reused Equalize output scratch
+	lmsDiffs  []complex64 // reused per-burst differential scratch
+
 	// sbAnchor is the absolute dibit index of the most recent SB
 	// synchronisation-training-sequence leading dibit (TN1), pinning the
 	// 255-dibit slot grid; haveAnchor is false until the first SB is seen.
@@ -162,6 +189,18 @@ func (te *TrafficExtractor) Process(dibits []uint8, baseIdx int) {
 		te.softBuf = te.softBuf[:0]
 	}
 	te.pendingSoft = nil
+	// Keep symBuf strictly parallel to buf under the same lockstep contract as
+	// softBuf (append the stashed symbols only when they match this block and the
+	// buffer is already in lockstep; otherwise drop the symbol path rather than
+	// risk a misalignment). Copies the values in, so the receiver may reuse its
+	// symbol backing array for the next call.
+	if te.pendingSym != nil && te.pendingSymBase == baseIdx &&
+		len(te.pendingSym) == len(dibits) && len(te.symBuf) == len(te.buf) {
+		te.symBuf = append(te.symBuf, te.pendingSym...)
+	} else {
+		te.symBuf = te.symBuf[:0]
+	}
+	te.pendingSym = nil
 	te.buf = append(te.buf, dibits...)
 
 	// Anchor the slot grid on the synchronisation burst. The SB's STS is
@@ -230,6 +269,12 @@ func (te *TrafficExtractor) Process(dibits []uint8, baseIdx int) {
 		} else {
 			te.softBuf = te.softBuf[:0]
 		}
+		// Same for symBuf.
+		if len(te.symBuf) >= drop {
+			te.symBuf = append(te.symBuf[:0], te.symBuf[drop:]...)
+		} else {
+			te.symBuf = te.symBuf[:0]
+		}
 		te.bufBase += drop
 	}
 }
@@ -243,6 +288,52 @@ func (te *TrafficExtractor) Process(dibits []uint8, baseIdx int) {
 func (te *TrafficExtractor) StashSoft(diffs []complex64, baseIdx int) {
 	te.pendingSoft = diffs
 	te.pendingSoftBase = baseIdx
+}
+
+// Default training-sequence equalizer parameters (see EnableLMSEqualizer). The
+// TETRA normal training sequence is only 11 dibits, so the equalizer is kept
+// short (a handful of taps) and swept several times over that midamble so the
+// least-mean-squares estimate converges on so few reference symbols. Validated
+// against the synthetic-multipath regression in traffic_lms_test.go.
+const (
+	defaultLMSTaps   = 5
+	defaultLMSPasses = 80
+	defaultLMSStep   = float32(0.02)
+)
+
+// EnableLMSEqualizer turns on per-burst training-sequence-aided equalization of
+// the soft (LLR) decode path. Once enabled, and once the caller feeds the raw
+// symbols via StashSymbols (receiver.Options.SymbolSink), softFrame trains an
+// equalizer.SnapshotLMS on each burst's known normal training sequence, freezes
+// the taps, equalizes BKN1+BKN2, and re-derives the soft LLRs from the equalized
+// symbols — inverting the linear channel / ISI that garbles same-carrier TCH/S
+// (issue #1001). taps <= 0 uses defaultLMSTaps; passes <= 0 uses defaultLMSPasses.
+//
+// It changes only the soft LLR stream; the hard frame is untouched, and with no
+// StashSymbols data (or on a burst whose symbol span is not fully buffered) the
+// soft path falls back to the raw receiver differentials — so a caller that never
+// enables it, or never stashes symbols, is byte-identical to before.
+func (te *TrafficExtractor) EnableLMSEqualizer(taps, passes int) {
+	if taps <= 0 {
+		taps = defaultLMSTaps
+	}
+	if passes <= 0 {
+		passes = defaultLMSPasses
+	}
+	te.lmsTaps = taps
+	te.lmsPasses = passes
+	te.lms = equalizer.NewSnapshotLMS(taps, defaultLMSStep)
+}
+
+// StashSymbols hands the extractor the raw pre-differential complex symbols (the
+// receiver's SymbolSink output) for the dibits the NEXT Process call will
+// deliver, keyed by the same baseIdx — the symbol analog of StashSoft. Only
+// consulted when the training-sequence equalizer is enabled (EnableLMSEqualizer);
+// a caller that never StashSymbols leaves the equalizer inert (soft path
+// unchanged).
+func (te *TrafficExtractor) StashSymbols(syms []complex64, baseIdx int) {
+	te.pendingSym = syms
+	te.pendingSymBase = baseIdx
 }
 
 // emit slices BKN1 and BKN2 around the training sequence leading at L and
@@ -274,6 +365,30 @@ func (te *TrafficExtractor) softFrame(L int) []float32 {
 	if len(te.softBuf) != len(te.buf) {
 		return nil
 	}
+	// Prefer the training-sequence-equalized differentials when the equalizer is
+	// enabled and this burst's raw symbol span is fully buffered; otherwise use the
+	// receiver's raw differentials (the pre-#1001 path). equalizedBurstDiffs returns
+	// nil whenever the equalizer is off or the span is unavailable, so this is a
+	// no-op unless EnableLMSEqualizer + StashSymbols are both in play.
+	diffs := te.equalizedBurstDiffs(L)
+	if diffs == nil {
+		diffs = te.rawBurstDiffs(L)
+	}
+	if diffs == nil {
+		return nil
+	}
+	llr := softType5FromDiffs(diffs, 0)
+	if te.colourCode != 0 {
+		llr = framing.DescrambleTetraSoft(llr, te.colourCode)
+	}
+	return llr
+}
+
+// rawBurstDiffs concatenates the receiver's raw per-symbol differentials for
+// BKN1 then BKN2 around the training sequence leading at L, or nil when the soft
+// buffer does not cover the burst. This is the original (pre-equalizer) soft
+// source.
+func (te *TrafficExtractor) rawBurstDiffs(L int) []complex64 {
 	block := func(off int) []complex64 {
 		s := L + off - te.bufBase
 		if s < 0 || s+ndbBlockDibits > len(te.softBuf) {
@@ -289,11 +404,128 @@ func (te *TrafficExtractor) softFrame(L int) []float32 {
 	diffs := make([]complex64, 0, TrafficFrameDibits)
 	diffs = append(diffs, b1...)
 	diffs = append(diffs, b2...)
-	llr := softType5FromDiffs(diffs, 0)
-	if te.colourCode != 0 {
-		llr = framing.DescrambleTetraSoft(llr, te.colourCode)
+	return diffs
+}
+
+// equalizedBurstDiffs trains the per-burst SnapshotLMS on the burst's known
+// normal training sequence (the midamble), equalizes the raw symbols spanning
+// BKN1..BKN2, and returns the 216 re-derived complex differentials (BKN1 then
+// BKN2) the soft decode consumes. Returns nil — so softFrame falls back to the
+// raw differentials — when the equalizer is disabled, no raw symbols are
+// buffered, or the burst's symbol span (with FIR warm-up) is not fully present.
+//
+// Design (mirrors equalizer.SnapshotLMS's proven usage): train on the midamble
+// symbols against the ideal reference, freeze the taps, apply them across the
+// whole burst, then differential-decode consecutive equalized symbols. A frozen
+// filter imposes only a constant phase/scale, which cancels in the differential
+// decode; the training pins the true channel inverse (phase and all), which blind
+// CMA cannot on so short a reference.
+func (te *TrafficExtractor) equalizedBurstDiffs(L int) []complex64 {
+	if te.lms == nil || len(te.symBuf) != len(te.buf) {
+		return nil
 	}
-	return llr
+	ntsLen := len(NormalSyncDibits()) // 11
+	// Ideal reference symbols for this burst's midamble (anchor + 11), plus the
+	// aligned received symbols to train on.
+	ref := te.midambleRef(L, ntsLen)
+	if ref == nil {
+		return nil
+	}
+	m0 := L - 1 - te.bufBase // anchor symbol one before the first midamble differential
+	if m0 < 0 || m0+ntsLen+1 > len(te.symBuf) {
+		return nil
+	}
+	rx := te.symBuf[m0 : m0+ntsLen+1]
+
+	// Equalize a span that starts warm taps before BKN1's differential anchor, so
+	// the FIR delay line is full before the first BKN1 symbol, and runs through the
+	// end of BKN2. spanStart is the absolute index of the first equalized symbol.
+	warm := te.lmsTaps
+	spanStart := L + ndbBKN1Start - 1 - warm // one before BKN1 start, minus FIR warm-up
+	spanEnd := L + ndbBKN2Start + ndbBlockDibits
+	s0 := spanStart - te.bufBase
+	s1 := spanEnd - te.bufBase
+	if s0 < 0 || s1 > len(te.symBuf) {
+		return nil
+	}
+
+	te.lms.Reset()
+	te.lms.Train(rx, ref, te.lmsPasses)
+	span := te.lms.Equalize(te.lmsSpan[:0], te.symBuf[s0:s1])
+	te.lmsSpan = span
+
+	// Differential for the burst dibit at absolute index m is span[i]·conj(span[i-1])
+	// with i = m - spanStart. warm ensures i-1 >= warm-1 for the first BKN1 dibit,
+	// past the FIR transient.
+	diffAt := func(m int) complex64 {
+		i := m - spanStart
+		a, b := span[i], span[i-1]
+		return complex(real(a)*real(b)+imag(a)*imag(b), imag(a)*real(b)-real(a)*imag(b))
+	}
+	diffs := te.lmsDiffs[:0]
+	for m := L + ndbBKN1Start; m < L+ndbBKN1Start+ndbBlockDibits; m++ {
+		diffs = append(diffs, diffAt(m))
+	}
+	for m := L + ndbBKN2Start; m < L+ndbBKN2Start+ndbBlockDibits; m++ {
+		diffs = append(diffs, diffAt(m))
+	}
+	te.lmsDiffs = diffs
+	return diffs
+}
+
+// midambleRef builds the ideal reference symbols for the burst's normal training
+// sequence: the anchor symbol plus n midamble symbols (n+1 total), the SnapshotLMS
+// training reference. The burst may carry NTS1 or NTS2, so it picks whichever the
+// buffered hard dibits at [L, L+n) match more closely (the receiver's AFC locks
+// the constellation to rotation 0, the same assumption softFrame/usageOf rely on).
+// Returns nil when the midamble dibits are not buffered.
+func (te *TrafficExtractor) midambleRef(L, n int) []complex64 {
+	off := L - te.bufBase
+	if off < 0 || off+n > len(te.buf) {
+		return nil
+	}
+	rxd := te.buf[off : off+n]
+	nts1 := NormalSyncDibits()
+	nts2 := NormalSyncDibits2()
+	var d1, d2 int
+	for i := 0; i < n; i++ {
+		if rxd[i] != nts1[i] {
+			d1++
+		}
+		if rxd[i] != nts2[i] {
+			d2++
+		}
+	}
+	ref := nts1
+	if d2 < d1 {
+		ref = nts2
+	}
+	// Differentially encode the ideal dibits from a unit anchor: for unit-modulus
+	// symbols the differential d = s·conj(prev) gives s[k] = prev·d[k]. The anchor
+	// phase is arbitrary — a constant rotation cancels in the differential decode.
+	out := make([]complex64, n+1)
+	out[0] = 1
+	for k, dv := range ref {
+		out[k+1] = out[k] * idealDiff(dv)
+	}
+	return out
+}
+
+// idealDiff is the ideal π/4-DQPSK differential (unit modulus) for a dibit value,
+// matching the demod's dibit→phase mapping (0:+π/4, 1:+3π/4, 2:−3π/4, 3:−π/4) and
+// softType5FromDiffs's rotation-0 convention.
+func idealDiff(v uint8) complex64 {
+	const s = math.Sqrt2 / 2
+	switch v & 3 {
+	case 0:
+		return complex(s, s)
+	case 1:
+		return complex(-s, s)
+	case 2:
+		return complex(-s, -s)
+	default:
+		return complex(s, -s)
+	}
 }
 
 // usageOf recovers the AACH downlink usage marker of the burst leading at L. The

--- a/internal/radio/tetra/traffic_lms_test.go
+++ b/internal/radio/tetra/traffic_lms_test.go
@@ -1,0 +1,225 @@
+package tetra
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+)
+
+// These tests exercise the #1001 per-burst training-sequence equalizer wired into
+// TrafficExtractor: a full Normal Continuous Downlink Burst is synthesized as a
+// π/4-DQPSK symbol stream, pushed through a multipath channel that closes the
+// constellation eye, and fed to the extractor exactly as the receiver feeds it
+// (hard dibits + the raw differentials via StashSoft + the raw symbols via
+// StashSymbols). With EnableLMSEqualizer on, the extractor trains on the burst's
+// known midamble, equalizes BKN1/BKN2, and re-derives the soft LLRs — which should
+// recover the payload the un-equalized soft path loses to the ISI.
+//
+// Metric is type-5 bit-error rate on the emitted softType5 stream (the
+// constant-phase-invariant, decode-level number CLAUDE.md flags as the trustworthy
+// one), measured against the known transmitted payload.
+
+// tsEncodeSyms differentially encodes a dibit stream into unit-modulus π/4-DQPSK
+// symbols such that idealDiff(dibits[i]) == sym[i]·conj(sym[i-1]) — i.e. the
+// extractor's dibit index i lines up 1:1 with symbol index i, matching how the
+// receiver emits symbols and dibits in lockstep. Index 0 is the phase anchor
+// (its differential is undefined and never read; the burst sits far from it).
+func tsEncodeSyms(dibits []uint8) []complex64 {
+	s := make([]complex64, len(dibits))
+	s[0] = 1
+	for i := 1; i < len(dibits); i++ {
+		s[i] = s[i-1] * idealDiff(dibits[i])
+	}
+	return s
+}
+
+// tsMultipath convolves sym with a causal channel h (h[0] the direct path) and
+// adds complex Gaussian noise — the same minimum-phase ISI model the equalizer
+// package's tests use, so a midamble-trained LMS has a near-zero-delay inverse.
+func tsMultipath(sym, h []complex64, sigma float64, rng *rand.Rand) []complex64 {
+	out := make([]complex64, len(sym))
+	for n := range sym {
+		var acc complex64
+		for k := range h {
+			if n-k >= 0 {
+				acc += h[k] * sym[n-k]
+			}
+		}
+		acc += complex(float32(rng.NormFloat64()*sigma), float32(rng.NormFloat64()*sigma))
+		out[n] = acc
+	}
+	return out
+}
+
+// tsSliceBits hard-slices a softType5 LLR stream (positive ⇒ bit 0) to bits.
+func tsSliceBits(llr []float32) []byte {
+	out := make([]byte, len(llr))
+	for i, v := range llr {
+		if v < 0 {
+			out[i] = 1
+		}
+	}
+	return out
+}
+
+func tsBitErrs(got, want []byte) int {
+	n := len(got)
+	if len(want) < n {
+		n = len(want)
+	}
+	bad := 0
+	for i := 0; i < n; i++ {
+		if got[i] != want[i] {
+			bad++
+		}
+	}
+	return bad
+}
+
+// tsBuildBurst lays a detectable NCDB (NTS1 midamble at index L) into a random
+// dibit stream, runs it through the channel, and returns everything the extractor
+// needs: the channel-decoded hard dibits, the raw differentials, the raw symbols,
+// and the known transmitted payload bits (BKN1+BKN2) to score against.
+func tsBuildBurst(t *testing.T, h []complex64, sigma float64, seed int64) (hard []uint8, diffs, rx []complex64, wantBits []byte, L int) {
+	t.Helper()
+	const M = 600
+	L = 300
+	rng := rand.New(rand.NewSource(seed))
+	edib := make([]uint8, M)
+	for i := range edib {
+		edib[i] = uint8(rng.Intn(4))
+	}
+	nts := NormalSyncDibits()
+	copy(edib[L:L+len(nts)], nts)
+
+	tx := tsEncodeSyms(edib)
+	rx = tsMultipath(tx, h, sigma, rng)
+
+	// Decode the received symbols exactly as the receiver does (π/4 rotation),
+	// yielding the hard dibits and the parallel differentials in one pass.
+	dq := demod.NewDQPSK()
+	dq.SetRotation(math.Pi / 4)
+	hard, diffs = dq.DecodeBoth(nil, nil, rx)
+
+	// Known transmitted payload: BKN1 = [L-115, L-7), BKN2 = [L+19, L+127).
+	var payload []uint8
+	payload = append(payload, edib[L+ndbBKN1Start:L+ndbBKN1Start+ndbBlockDibits]...)
+	payload = append(payload, edib[L+ndbBKN2Start:L+ndbBKN2Start+ndbBlockDibits]...)
+	wantBits = TetraDibitsToBits(payload)
+	return hard, diffs, rx, wantBits, L
+}
+
+// tsRunSoft feeds one prepared burst through an extractor and returns the emitted
+// softType5 and how many bursts were detected. When lms is true the
+// training-sequence equalizer is enabled and symbols are stashed. Callers assert
+// the count is 1 so a spurious rotated-NTS match on the random filler can never
+// silently swap in a garbage burst's soft stream.
+func tsRunSoft(hard []uint8, diffs, rx []complex64, lms bool) ([]float32, int) {
+	var got []float32
+	n := 0
+	te := NewTrafficExtractor(0, func(_ []byte, softType5 []float32, _, _ uint8) {
+		if softType5 != nil {
+			got = softType5
+			n++
+		}
+	})
+	if lms {
+		te.EnableLMSEqualizer(0, 0)
+		te.StashSymbols(rx, 0)
+	}
+	te.StashSoft(diffs, 0)
+	te.Process(hard, 0)
+	return got, n
+}
+
+// TestTrafficExtractorLMSRecoversMultipathBurst is the failing-first regression:
+// on a multipath channel that garbles the raw soft decode, enabling the per-burst
+// training-sequence equalizer drives the emitted softType5 payload bit-error rate
+// down sharply — proving the plumbing trains on the midamble and equalizes the
+// data blocks, not just that a burst was emitted.
+func TestTrafficExtractorLMSRecoversMultipathBurst(t *testing.T) {
+	// A moderate two-tap echo: harsh enough to garble the 216-dibit payload, mild
+	// enough that the 11-dibit midamble still correlates within the detector's
+	// tolerance so the burst is found at all.
+	h := []complex64{1, complex(0.45, 0.25)}
+	hard, diffs, rx, wantBits, _ := tsBuildBurst(t, h, 0.03, 11)
+
+	rawSoft, rawN := tsRunSoft(hard, diffs, rx, false)
+	eqSoft, eqN := tsRunSoft(hard, diffs, rx, true)
+	if rawN != 1 {
+		t.Fatalf("expected exactly one burst on the raw path, got %d", rawN)
+	}
+	if eqN != 1 {
+		t.Fatalf("expected exactly one burst on the equalized path, got %d", eqN)
+	}
+
+	total := len(wantBits)
+	rawErr := float64(tsBitErrs(tsSliceBits(rawSoft), wantBits)) / float64(total)
+	eqErr := float64(tsBitErrs(tsSliceBits(eqSoft), wantBits)) / float64(total)
+	t.Logf("payload type-5 bit-error: raw=%.3f equalized=%.3f (n=%d)", rawErr, eqErr, total)
+
+	if rawErr < 0.08 {
+		t.Fatalf("channel not hard enough: raw soft bit-error %.3f (want the ISI to actually garble it)", rawErr)
+	}
+	if eqErr > 0.02 {
+		t.Fatalf("LMS-equalized soft decode still garbled: bit-error %.3f (raw %.3f)", eqErr, rawErr)
+	}
+	if eqErr >= rawErr {
+		t.Fatalf("equalizer did not improve the decode: equalized %.3f vs raw %.3f", eqErr, rawErr)
+	}
+}
+
+// TestTrafficExtractorLMSNoHarmOnCleanChannel: on an identity channel the frozen
+// taps stay a near pass-through, so enabling the equalizer does not degrade an
+// already-clean burst's soft decode (the SnapshotLMS/SnapshotCMA no-harm rule).
+func TestTrafficExtractorLMSNoHarmOnCleanChannel(t *testing.T) {
+	h := []complex64{1} // identity channel
+	hard, diffs, rx, wantBits, _ := tsBuildBurst(t, h, 0.01, 3)
+
+	eqSoft, eqN := tsRunSoft(hard, diffs, rx, true)
+	if eqN != 1 {
+		t.Fatalf("expected exactly one burst on a clean channel, got %d", eqN)
+	}
+	eqErr := float64(tsBitErrs(tsSliceBits(eqSoft), wantBits)) / float64(len(wantBits))
+	t.Logf("clean-channel equalized payload bit-error: %.4f", eqErr)
+	if eqErr > 0.01 {
+		t.Fatalf("equalizer harmed a clean burst: soft bit-error %.4f", eqErr)
+	}
+}
+
+// TestTrafficExtractorSoftUnchangedWithoutEqualizer guards the byte-identical
+// promise: with the equalizer off, stashing symbols or not, the emitted softType5
+// is exactly the raw-differential path (the pre-#1001 behaviour).
+func TestTrafficExtractorSoftUnchangedWithoutEqualizer(t *testing.T) {
+	h := []complex64{1, complex(0.45, 0.25)}
+	hard, diffs, rx, _, _ := tsBuildBurst(t, h, 0.03, 11)
+
+	base, baseN := tsRunSoft(hard, diffs, rx, false)
+	if baseN != 1 {
+		t.Fatalf("expected exactly one burst, got %d", baseN)
+	}
+	// Even with symbols stashed, an extractor that never enabled the equalizer must
+	// produce the identical soft stream.
+	var withSyms []float32
+	te := NewTrafficExtractor(0, func(_ []byte, softType5 []float32, _, _ uint8) {
+		if softType5 != nil {
+			withSyms = softType5
+		}
+	})
+	te.StashSymbols(rx, 0)
+	te.StashSoft(diffs, 0)
+	te.Process(hard, 0)
+	if withSyms == nil {
+		t.Fatal("no burst detected (symbols stashed, equalizer off)")
+	}
+	if len(withSyms) != len(base) {
+		t.Fatalf("soft length changed: %d vs %d", len(withSyms), len(base))
+	}
+	for i := range base {
+		if withSyms[i] != base[i] {
+			t.Fatalf("soft LLR %d changed with equalizer off: %v vs %v", i, withSyms[i], base[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Activates the `equalizer.SnapshotLMS` primitive (merged earlier for #1001) on the TETRA TMO traffic path — the follow-up flagged when the blind `SnapshotCMA` landed. The blind CMA in the receiver only partially recovers the same-carrier concurrent-load garble; a per-burst equalizer *trained on each burst's known training sequence* pins the true channel inverse (phase and all), where blind CMA's constant-modulus cost has spurious minima on so short a reference.

The blind CMA lives in the **receiver** (continuous, framing-free stream); the trained LMS has to live in the **extractor**, because only the extractor knows where each burst's normal training sequence (midamble) sits. This PR carries the raw symbols the LMS needs down to the extractor and does the per-burst train → freeze → equalize → re-derive-soft-LLRs.

## Changes

- **`receiver.go`** — new opt-in `Options.SymbolSink`, emitting the raw pre-differential symbols aligned 1:1 with the dibits (the symbol analog of `SoftSink`). The linear channel is a clean convolution only in the raw-symbol domain — `s·conj(prev)` is a nonlinear product — so this is the input a training-sequence equalizer must work on. `nil` ⇒ zero overhead.
- **`traffic.go`** — `TrafficExtractor` now keeps a `symBuf` parallel to its dibit/diff buffers (`StashSymbols`, same lockstep contract as `StashSoft`). `EnableLMSEqualizer(taps, passes)` turns on the soft path: per burst, `softFrame` picks NTS1/NTS2 by nearest hard-dibit match, builds the ideal midamble reference (differentially encoded from a unit anchor — the arbitrary start phase cancels in the differential decode), trains a fresh `SnapshotLMS`, freezes the taps, equalizes a `BKN1..BKN2` span with a taps-long FIR warm-up, and re-derives the soft LLRs from the equalized symbols. **Hard frame untouched.**
- **`tetra_multislot_replay_test.go`** — `GT_TETRA_LMS=1` enables the extractor equalizer + symbol wiring for a real-capture A/B; new `traffic_marked_crc_soft` counter (the soft-path yield the LMS conditions).
- **`traffic_lms_test.go`** — failing-first regression through the real extractor.
- **`CLAUDE.md`** — note on the CMA-in-receiver vs LMS-in-extractor split and the symbol-domain rationale.

## Test plan

- [x] `make vet test` is green locally (`go vet ./...` clean; `go test ./...` exit 0)
- [ ] `make integration` — n/a (no daemon/DSP-pipeline default path changed; equalizer is off by default)
- [x] Added tests: `traffic_lms_test.go` drives a synthetic multipath NCDB through the real `TrafficExtractor` — raw soft payload **13% → 0%** bit-error with the equalizer, and a no-harm-on-clean case; plus a guard that with the equalizer off the soft stream is byte-identical.
- [ ] Smoke-tested against real hardware — **not yet; this is the remaining gate.** The acceptance criterion (real-capture yield uplift) is unchanged: run the six reporter captures both ways —
  ```
  GT_TETRA_IQ=cap.cs16 GT_TETRA_IQ_RATE=… go test ./cmd/gophertrunk -run TETRAMultiSlotReplay -v
  GT_TETRA_LMS=1 GT_TETRA_IQ=cap.cs16 GT_TETRA_IQ_RATE=… go test ./cmd/gophertrunk -run TETRAMultiSlotReplay -v
  ```
  and compare `traffic_marked_crc_soft`. Still most valuable: a raw wideband IQ moment where GT garbles and a Motorola decodes cleanly.

## Breaking changes

None. Soft-path only and opt-in: with no `StashSymbols` data or `EnableLMSEqualizer`, the extractor is byte-identical to before. The production voice composer still runs CMA only — enabling LMS there is a follow-up gated on the capture A/B above.

## Docs / CHANGELOG

- [ ] CHANGELOG — n/a (no user-visible default-behaviour change; the lever is test-only until the capture A/B validates it)
- [x] Updated `CLAUDE.md` with the receiver-CMA vs extractor-LMS split and the symbol-domain lesson

## Linked issues

Refs #1001 (kept open per the issue-closing policy until real-air validation is in)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUs7kTzCMcnykc3d4kdUer

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUs7kTzCMcnykc3d4kdUer)_