### PR TITLE
tetra: wire training-sequence equalizer into the DMO burst path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,3 +166,17 @@ confirmation before any close-as-completed.
   payload bit-error, no-harm on clean). Production composer still runs CMA only; flip
   LMS on there once the capture A/B validates it. A/B on captures with `GT_TETRA_LMS=1`
   in `TestTETRAMultiSlotReplay` (compare `traffic_marked_crc_soft`).
+- **The same training-sequence LMS lever is wired into the DMO (Direct Mode) path**
+  (#1003 follow-up). `ExtractDMBurstsEqualized` (`dmo.go` → `dmo_equalizer.go`) re-derives
+  each **rotation-0** DNB's `SoftBKN1/SoftBKN2` from equalized raw symbols, so the
+  existing `DMBurstTCHSpeechSoft` decodes it unchanged. Two DMO-specific points vs the
+  TMO wiring: the DNB geometry differs (BKN1 `[L-108,L)`, BKN2 `[L+11,L+119)`,
+  `dmDNB*Start`), and it **only equalizes rotation-0 bursts** — a frozen constant-tap
+  filter cannot invert the per-symbol phase ramp of a non-zero residual rotation, and
+  at rotation 0 the soft decode's `(4-Rotation)&3` de-rotation is a no-op so the
+  rotation-0-trained differentials slot straight in. Opt-in via `ExtractDMBurstsEqualized`
+  (needs the `SymbolSink`); `ExtractDMBursts`/`ExtractDMBurstsSoft` are byte-identical.
+  Pinned by `dmo_equalizer_test.go` (raw 12% → 0% DNB payload bit-error, no-harm on
+  clean, byte-identical without symbols). A/B on captures with `GT_TETRA_DMO_LMS=1` in
+  `TestTETRADMOReplay`. Note the whole DMO path is still unverified on air (#1003), so
+  this is a lever staged for that validation, not a confirmed win.

--- a/cmd/gophertrunk/tetra_dmo_replay_test.go
+++ b/cmd/gophertrunk/tetra_dmo_replay_test.go
@@ -82,7 +82,9 @@ func TestTETRADMOReplay(t *testing.T) {
 	// order keeps allDiffs strictly parallel to allDibits.
 	var allDibits []uint8
 	var allDiffs []complex64
+	var allSymbols []complex64
 	enableEQ := os.Getenv("GT_TETRA_DMO_EQ") == "1" || os.Getenv("GT_TETRA_DMO_EQ") == "true"
+	enableLMS := os.Getenv("GT_TETRA_DMO_LMS") == "1" || os.Getenv("GT_TETRA_DMO_LMS") == "true"
 	rx := tetrarx.New(tetrarx.Options{
 		SampleRateHz: outRate,
 		DibitSink: func(d []uint8, _ int) {
@@ -90,6 +92,10 @@ func TestTETRADMOReplay(t *testing.T) {
 		},
 		SoftSink: func(diffs []complex64, _ int) {
 			allDiffs = append(allDiffs, diffs...)
+		},
+		// Raw symbols for the per-burst training-sequence equalizer (GT_TETRA_DMO_LMS).
+		SymbolSink: func(syms []complex64, _ int) {
+			allSymbols = append(allSymbols, syms...)
 		},
 		ClockMode:           tetrarx.ClockGardner,
 		GardnerGain:         0.005,
@@ -113,8 +119,15 @@ func TestTETRADMOReplay(t *testing.T) {
 	// Soft-capable extraction: carry the differentials so DMBurstTCHSpeechSoft can
 	// recover corrupted TCH/S bursts the hard path drops (the #1001 ~2× lever).
 	// Falls back to the hard ExtractDMBursts geometry if the soft stream didn't
-	// stay parallel (length mismatch).
-	bursts := tetra.ExtractDMBurstsSoft(allDibits, allDiffs, 0)
+	// stay parallel (length mismatch). GT_TETRA_DMO_LMS=1 additionally trains a
+	// per-burst equalizer on each rotation-0 DNB's midamble and re-derives the soft
+	// blocks from the equalized symbols (#1001's LMS lever for Direct Mode).
+	var bursts []tetra.DMBurst
+	if enableLMS {
+		bursts = tetra.ExtractDMBurstsEqualized(allDibits, allDiffs, allSymbols, 0, 0, 0)
+	} else {
+		bursts = tetra.ExtractDMBurstsSoft(allDibits, allDiffs, 0)
+	}
 
 	var dsbTotal, dsbCRC, dnbTotal, tchCRC, tchSoftOnly int
 	var syncSecs []int           // seconds carrying a CRC-valid SCH/S (transmission starts)
@@ -155,8 +168,8 @@ func TestTETRADMOReplay(t *testing.T) {
 		}
 	}
 
-	t.Logf("in=%.0fHz out=%.0fHz samples=%d dur=%.1fs colour=%#x eq=%v",
-		inRate, outRate, len(iq), float64(len(iq))/inRate, colour, enableEQ)
+	t.Logf("in=%.0fHz out=%.0fHz samples=%d dur=%.1fs colour=%#x eq=%v lms=%v",
+		inRate, outRate, len(iq), float64(len(iq))/inRate, colour, enableEQ, enableLMS)
 	t.Logf("bursts: dsb_total=%d dsb_schs_crc=%d dnb_total=%d tch_crc=%d (soft_only=%d)",
 		dsbTotal, dsbCRC, dnbTotal, tchCRC, tchSoftOnly)
 	sort.Ints(syncSecs)
@@ -175,7 +188,7 @@ func TestTETRADMOReplay(t *testing.T) {
 	t.Logf("speech active seconds (>=2 CRC bursts): %v", speechSecs)
 
 	if len(speechFrames) == 0 {
-		t.Logf("no CRC-valid TCH/S speech recovered — if the capture is a known-good DMO voice call, try GT_TETRA_DMO_COLOUR (the DM colour code) or GT_TETRA_DMO_EQ=1")
+		t.Logf("no CRC-valid TCH/S speech recovered — if the capture is a known-good DMO voice call, try GT_TETRA_DMO_COLOUR (the DM colour code), GT_TETRA_DMO_EQ=1 (blind CMA) or GT_TETRA_DMO_LMS=1 (training-sequence equalizer)")
 		return
 	}
 

--- a/internal/radio/tetra/dmo.go
+++ b/internal/radio/tetra/dmo.go
@@ -1,5 +1,7 @@
 package tetra
 
+import "github.com/MattCheramie/GopherTrunk/internal/dsp/equalizer"
+
 // DMO (Direct Mode Operation) radio-layer framing — ETSI EN 300 396-2 (part 2:
 // radio aspects). DMO is TETRA's infrastructure-less peer-to-peer mode: a
 // transmitting MS sends a Direct Mode Synchronisation Burst (DSB) to let the
@@ -122,7 +124,7 @@ type DMBurst struct {
 // baseIdx is the absolute dibit index of dibits[0], carried into DMBurst.Lead so
 // callers can order bursts across calls; pass 0 for a one-shot slice.
 func ExtractDMBursts(dibits []uint8, baseIdx int) []DMBurst {
-	return extractDMBursts(dibits, nil, baseIdx)
+	return extractDMBursts(dibits, nil, baseIdx, nil)
 }
 
 // ExtractDMBurstsSoft is the soft-decision-capable twin of ExtractDMBursts: it
@@ -136,23 +138,61 @@ func ExtractDMBurstsSoft(dibits []uint8, diffs []complex64, baseIdx int) []DMBur
 	if len(diffs) != len(dibits) {
 		diffs = nil
 	}
-	return extractDMBursts(dibits, diffs, baseIdx)
+	return extractDMBursts(dibits, diffs, baseIdx, nil)
 }
 
-func extractDMBursts(dibits []uint8, diffs []complex64, baseIdx int) []DMBurst {
+// ExtractDMBurstsEqualized is ExtractDMBurstsSoft plus per-burst training-sequence
+// equalization of each DNB's TCH/S soft blocks (issue #1001's LMS lever applied to
+// Direct Mode). symbols is the receiver's raw pre-differential symbol stream
+// (SymbolSink output), parallel to and the same length as dibits; when it is
+// parallel each rotation-0 DNB's SoftBKN1/SoftBKN2 are re-derived from the
+// equalized symbols (see dmEqualizeDNBSoft) instead of the raw differentials. When
+// symbols is nil or a length mismatch it degrades to ExtractDMBurstsSoft. taps <= 0
+// uses defaultLMSTaps; passes <= 0 uses defaultLMSPasses.
+func ExtractDMBurstsEqualized(dibits []uint8, diffs, symbols []complex64, baseIdx, taps, passes int) []DMBurst {
+	if len(diffs) != len(dibits) {
+		diffs = nil
+	}
+	var eqx *dmEqualizeCtx
+	if len(symbols) == len(dibits) {
+		if taps <= 0 {
+			taps = defaultLMSTaps
+		}
+		if passes <= 0 {
+			passes = defaultLMSPasses
+		}
+		eqx = &dmEqualizeCtx{
+			symbols: symbols,
+			eq:      equalizer.NewSnapshotLMS(taps, defaultLMSStep),
+			taps:    taps,
+			passes:  passes,
+		}
+	}
+	return extractDMBursts(dibits, diffs, baseIdx, eqx)
+}
+
+// dmEqualizeCtx carries the raw symbols and the reusable per-burst equalizer for
+// ExtractDMBurstsEqualized. nil ⇒ no equalization (the raw soft path).
+type dmEqualizeCtx struct {
+	symbols      []complex64
+	eq           *equalizer.SnapshotLMS
+	taps, passes int
+}
+
+func extractDMBursts(dibits []uint8, diffs []complex64, baseIdx int, eqx *dmEqualizeCtx) []DMBurst {
 	var out []DMBurst
 
 	// DSB: correlate the 19-dibit synchronisation training sequence (shared with
 	// TMO's SB). Threshold 3 matches processSB / TrafficExtractor.
 	sts := SyncTrainingDibits()
 	out = appendDMBursts(out, dibits, diffs, baseIdx, DMBurstSync, sts, 3,
-		dmDSBBKN1Start, dmSCHSDibits, dmDSBBKN2Start, dmBlockDibits)
+		dmDSBBKN1Start, dmSCHSDibits, dmDSBBKN2Start, dmBlockDibits, nil)
 
 	// DNB: correlate either 11-dibit normal training sequence. Threshold 2 matches
 	// TrafficExtractor's normal-burst detectors.
 	for _, nts := range [][]uint8{NormalSyncDibits(), NormalSyncDibits2()} {
 		out = appendDMBursts(out, dibits, diffs, baseIdx, DMBurstNormal, nts, 2,
-			dmDNBBKN1Start, dmBlockDibits, dmDNBBKN2Start, dmBlockDibits)
+			dmDNBBKN1Start, dmBlockDibits, dmDNBBKN2Start, dmBlockDibits, eqx)
 	}
 	return out
 }
@@ -163,7 +203,7 @@ func extractDMBursts(dibits []uint8, diffs []complex64, baseIdx int) []DMBurst {
 // for a DNB both blocks are 108-dibit (placed in BKN1/BKN2). De-duplicates a lead
 // that correlates under more than one rotation (keeps the first).
 func appendDMBursts(out []DMBurst, dibits []uint8, diffs []complex64, baseIdx int, kind DMBurstKind,
-	pattern []uint8, tol, b1Start, b1Len, b2Start, b2Len int) []DMBurst {
+	pattern []uint8, tol, b1Start, b1Len, b2Start, b2Len int, eqx *dmEqualizeCtx) []DMBurst {
 	n := len(pattern)
 	seen := map[int]struct{}{}
 	for rot := uint8(0); rot < 4; rot++ {
@@ -196,6 +236,15 @@ func appendDMBursts(out []DMBurst, dibits []uint8, diffs []complex64, baseIdx in
 				b.SoftBKN2 = cloneDiffs(diffs[b2From:b2To])
 				if kind == DMBurstNormal {
 					b.SoftBKN1 = cloneDiffs(diffs[b1From:b1To])
+				}
+			}
+			// Training-sequence equalization of the DNB soft blocks (opt-in, rotation
+			// 0 only): re-derive SoftBKN1/SoftBKN2 from the equalized raw symbols. A
+			// nil result (rot != 0, span off-buffer, no symbols) leaves the raw diffs
+			// above in place, so it can only help.
+			if eqx != nil && kind == DMBurstNormal && rot == 0 {
+				if s1, s2 := dmEqualizeDNBSoft(eqx.symbols, baseIdx, lead, pattern, eqx.eq, eqx.taps, eqx.passes); s1 != nil && s2 != nil {
+					b.SoftBKN1, b.SoftBKN2 = s1, s2
 				}
 			}
 			out = append(out, b)

--- a/internal/radio/tetra/dmo_equalizer.go
+++ b/internal/radio/tetra/dmo_equalizer.go
@@ -1,0 +1,84 @@
+package tetra
+
+import "github.com/MattCheramie/GopherTrunk/internal/dsp/equalizer"
+
+// DMO per-burst training-sequence equalization — the Direct Mode analog of the
+// TMO TrafficExtractor.equalizedBurstDiffs path (#1001), applied to the DNB
+// traffic blocks so the soft TCH/S decode inverts the linear channel / ISI that
+// closes the π/4-DQPSK eye before the differential decode.
+//
+// Like the TMO path it trains equalizer.SnapshotLMS on the burst's known normal
+// training sequence (the 11-dibit midamble), freezes the taps, equalizes a span
+// covering BKN1..BKN2 (with a taps-long FIR warm-up so the first BKN1 differential
+// clears the transient), and re-derives the per-symbol differentials from the
+// equalized RAW symbols — the domain in which a linear channel is a clean
+// convolution (s·conj(prev) is a nonlinear product). The result replaces a DNB's
+// SoftBKN1/SoftBKN2, so the existing DMBurstTCHSpeechSoft decodes it unchanged.
+//
+// It only equalizes a DNB detected at rotation 0 — the AFC-locked case the soft
+// decode already assumes (DMBurstTCHSpeechSoft de-rotates by (4-Rotation)&3, which
+// is a no-op at rotation 0, so the rotation-0-trained differentials slot straight
+// in). A burst at any other rotation carries a residual per-symbol phase ramp a
+// constant frozen filter cannot invert, so it is left on the raw soft path. Off by
+// default: only ExtractDMBurstsEqualized reaches this, so ExtractDMBursts /
+// ExtractDMBurstsSoft are byte-identical.
+
+// dmEqualizeDNBSoft trains on the DNB midamble at lead and returns the equalized
+// BKN1/BKN2 per-symbol differentials (108 each), or nil,nil to fall back to the
+// raw soft path. symbols is the raw pre-differential symbol stream parallel to the
+// extractor's dibits (baseIdx-relative); nts is the exact normal training sequence
+// that correlated for this burst; eq is a reusable SnapshotLMS (reset per burst).
+func dmEqualizeDNBSoft(symbols []complex64, baseIdx, lead int, nts []uint8, eq *equalizer.SnapshotLMS, taps, passes int) (soft1, soft2 []complex64) {
+	if eq == nil || symbols == nil {
+		return nil, nil
+	}
+	n := len(nts) // 11
+	// Ideal reference symbols for the midamble (anchor + n), differentially encoded
+	// from a unit anchor — the arbitrary start phase cancels in the differential
+	// decode, the property that makes the frozen snapshot safe.
+	ref := make([]complex64, n+1)
+	ref[0] = 1
+	for k, dv := range nts {
+		ref[k+1] = ref[k] * idealDiff(dv)
+	}
+
+	// Received midamble symbols aligned 1:1 with ref: [lead-1 .. lead+n-1].
+	m0 := lead - 1 - baseIdx
+	if m0 < 0 || m0+n+1 > len(symbols) {
+		return nil, nil
+	}
+	rx := symbols[m0 : m0+n+1]
+
+	// Span: warm taps before BKN1's differential anchor (dibit lead+dmDNBBKN1Start
+	// needs symbols lead+dmDNBBKN1Start and lead+dmDNBBKN1Start-1) through the end of
+	// BKN2 (dibit lead+dmDNBBKN2Start+dmBlockDibits-1).
+	warm := taps
+	spanStart := lead + dmDNBBKN1Start - 1 - warm
+	spanEnd := lead + dmDNBBKN2Start + dmBlockDibits
+	s0 := spanStart - baseIdx
+	s1 := spanEnd - baseIdx
+	if s0 < 0 || s1 > len(symbols) {
+		return nil, nil
+	}
+
+	eq.Reset()
+	eq.Train(rx, ref, passes)
+	span := eq.Equalize(nil, symbols[s0:s1])
+
+	// Differential for the burst dibit at absolute index m is span[i]·conj(span[i-1])
+	// with i = m - spanStart; warm guarantees i-1 clears the FIR transient.
+	diffAt := func(m int) complex64 {
+		i := m - spanStart
+		a, b := span[i], span[i-1]
+		return complex(real(a)*real(b)+imag(a)*imag(b), imag(a)*real(b)-real(a)*imag(b))
+	}
+	soft1 = make([]complex64, 0, dmBlockDibits)
+	for m := lead + dmDNBBKN1Start; m < lead+dmDNBBKN1Start+dmBlockDibits; m++ {
+		soft1 = append(soft1, diffAt(m))
+	}
+	soft2 = make([]complex64, 0, dmBlockDibits)
+	for m := lead + dmDNBBKN2Start; m < lead+dmDNBBKN2Start+dmBlockDibits; m++ {
+		soft2 = append(soft2, diffAt(m))
+	}
+	return soft1, soft2
+}

--- a/internal/radio/tetra/dmo_equalizer_test.go
+++ b/internal/radio/tetra/dmo_equalizer_test.go
@@ -1,0 +1,154 @@
+package tetra
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+)
+
+// These tests exercise the #1003/#1001 per-burst training-sequence equalizer wired
+// into the DMO (Direct Mode) extractor: a Direct Mode Normal Burst is synthesized
+// as a π/4-DQPSK symbol stream, pushed through a multipath channel that closes the
+// eye, and run through ExtractDMBurstsEqualized. Training on the burst's known
+// normal training sequence and equalizing BKN1/BKN2 should recover the TCH/S soft
+// payload the raw ExtractDMBurstsSoft loses to the ISI. Metric is type-5 bit-error
+// on the re-derived soft differentials (the constant-phase-invariant number), the
+// same shape as the TMO traffic_lms_test.
+
+// dmBuildDNB lays a detectable DNB (NTS1 midamble at lead L) into a random dibit
+// stream, runs it through the channel, and returns the channel-decoded hard
+// dibits, the raw differentials, the raw symbols, the known transmitted BKN1+BKN2
+// type-5 bits, and L.
+func dmBuildDNB(t *testing.T, h []complex64, sigma float64, seed int64) (hard []uint8, diffs, rx []complex64, wantBits []byte, L int) {
+	t.Helper()
+	const M = 400
+	L = 200
+	rng := rand.New(rand.NewSource(seed))
+	edib := make([]uint8, M)
+	for i := range edib {
+		edib[i] = uint8(rng.Intn(4))
+	}
+	nts := NormalSyncDibits()
+	copy(edib[L:L+len(nts)], nts)
+
+	tx := tsEncodeSyms(edib)
+	rx = tsMultipath(tx, h, sigma, rng)
+	dq := demod.NewDQPSK()
+	dq.SetRotation(math.Pi / 4)
+	hard, diffs = dq.DecodeBoth(nil, nil, rx)
+
+	// DNB payload: BKN1 = [L-108, L), BKN2 = [L+11, L+119).
+	var payload []uint8
+	payload = append(payload, edib[L+dmDNBBKN1Start:L]...)
+	payload = append(payload, edib[L+dmDNBBKN2Start:L+dmDNBBKN2Start+dmBlockDibits]...)
+	wantBits = TetraDibitsToBits(payload)
+	return hard, diffs, rx, wantBits, L
+}
+
+func dmFindDNB(bursts []DMBurst, lead int) *DMBurst {
+	for i := range bursts {
+		if bursts[i].Kind == DMBurstNormal && bursts[i].Lead == lead {
+			return &bursts[i]
+		}
+	}
+	return nil
+}
+
+// dmSoftPayloadBitErr hard-slices a DNB's soft blocks (de-rotated by the burst's
+// own rotation) and returns the type-5 bit-error against the known payload.
+func dmSoftPayloadBitErr(b *DMBurst, want []byte) float64 {
+	d := make([]complex64, 0, len(b.SoftBKN1)+len(b.SoftBKN2))
+	d = append(d, b.SoftBKN1...)
+	d = append(d, b.SoftBKN2...)
+	llr := softType5FromDiffs(d, (4-b.Rotation)&3)
+	return float64(tsBitErrs(tsSliceBits(llr), want)) / float64(len(want))
+}
+
+// TestExtractDMBurstsEqualizedRecoversMultipath is the failing-first regression:
+// on a multipath channel that garbles the raw soft DNB decode, ExtractDMBurstsEqualized
+// drives the soft TCH/S payload bit-error down sharply while ExtractDMBurstsSoft
+// (raw differentials) stays high.
+func TestExtractDMBurstsEqualizedRecoversMultipath(t *testing.T) {
+	h := []complex64{1, complex(0.45, 0.25)}
+	hard, diffs, rx, wantBits, L := dmBuildDNB(t, h, 0.03, 7)
+
+	rawB := dmFindDNB(tetraExtractSoft(hard, diffs), L)
+	eqB := dmFindDNB(ExtractDMBurstsEqualized(hard, diffs, rx, 0, 0, 0), L)
+	if rawB == nil {
+		t.Fatal("DNB not detected on the raw path — midamble too corrupted; soften the channel")
+	}
+	if eqB == nil {
+		t.Fatal("DNB not detected on the equalized path")
+	}
+	if eqB.Rotation != 0 {
+		t.Fatalf("expected rotation-0 DNB for the equalized case, got %d", eqB.Rotation)
+	}
+
+	rawErr := dmSoftPayloadBitErr(rawB, wantBits)
+	eqErr := dmSoftPayloadBitErr(eqB, wantBits)
+	t.Logf("DNB soft payload type-5 bit-error: raw=%.3f equalized=%.3f (n=%d)", rawErr, eqErr, len(wantBits))
+
+	if rawErr < 0.08 {
+		t.Fatalf("channel not hard enough: raw soft bit-error %.3f", rawErr)
+	}
+	if eqErr > 0.02 {
+		t.Fatalf("DMO LMS-equalized soft decode still garbled: bit-error %.3f (raw %.3f)", eqErr, rawErr)
+	}
+	if eqErr >= rawErr {
+		t.Fatalf("equalizer did not improve the DNB decode: equalized %.3f vs raw %.3f", eqErr, rawErr)
+	}
+}
+
+// TestExtractDMBurstsEqualizedNoHarmOnClean: on an identity channel the equalized
+// soft blocks decode as cleanly as the raw path (frozen taps ≈ pass-through).
+func TestExtractDMBurstsEqualizedNoHarmOnClean(t *testing.T) {
+	h := []complex64{1}
+	hard, diffs, rx, wantBits, L := dmBuildDNB(t, h, 0.01, 5)
+
+	eqB := dmFindDNB(ExtractDMBurstsEqualized(hard, diffs, rx, 0, 0, 0), L)
+	if eqB == nil {
+		t.Fatal("DNB not detected on a clean channel")
+	}
+	eqErr := dmSoftPayloadBitErr(eqB, wantBits)
+	t.Logf("clean-channel DMO equalized payload bit-error: %.4f", eqErr)
+	if eqErr > 0.01 {
+		t.Fatalf("equalizer harmed a clean DNB: bit-error %.4f", eqErr)
+	}
+}
+
+// TestExtractDMBurstsEqualizedNoSymbolsUnchanged guards the fallback: with no
+// symbols supplied, ExtractDMBurstsEqualized is identical to ExtractDMBurstsSoft
+// (the soft differentials are the raw ones), so it can never regress the caller
+// that hasn't wired the SymbolSink.
+func TestExtractDMBurstsEqualizedNoSymbolsUnchanged(t *testing.T) {
+	h := []complex64{1, complex(0.4, 0.2)}
+	hard, diffs, _, wantBits, L := dmBuildDNB(t, h, 0.02, 7)
+
+	soft := dmFindDNB(tetraExtractSoft(hard, diffs), L)
+	// nil symbols ⇒ no equalization; must equal the raw soft path.
+	noSym := dmFindDNB(ExtractDMBurstsEqualized(hard, diffs, nil, 0, 0, 0), L)
+	if soft == nil || noSym == nil {
+		t.Fatal("DNB not detected")
+	}
+	_ = wantBits
+	if len(noSym.SoftBKN1) != len(soft.SoftBKN1) || len(noSym.SoftBKN2) != len(soft.SoftBKN2) {
+		t.Fatal("soft block lengths diverged")
+	}
+	for i := range soft.SoftBKN1 {
+		if noSym.SoftBKN1[i] != soft.SoftBKN1[i] {
+			t.Fatalf("SoftBKN1[%d] changed without symbols: %v vs %v", i, noSym.SoftBKN1[i], soft.SoftBKN1[i])
+		}
+	}
+	for i := range soft.SoftBKN2 {
+		if noSym.SoftBKN2[i] != soft.SoftBKN2[i] {
+			t.Fatalf("SoftBKN2[%d] changed without symbols: %v vs %v", i, noSym.SoftBKN2[i], soft.SoftBKN2[i])
+		}
+	}
+}
+
+// tetraExtractSoft is a tiny wrapper so the tests read symmetrically.
+func tetraExtractSoft(hard []uint8, diffs []complex64) []DMBurst {
+	return ExtractDMBurstsSoft(hard, diffs, 0)
+}


### PR DESCRIPTION
## Summary

Applies the `SnapshotLMS` training-sequence equalizer (added for TMO in #1001, merged in #1047) to **Direct Mode** — the named yield follow-up on the DMO voice thread, which already carries a blind-CMA toggle (`GT_TETRA_DMO_EQ`) and soft-decision TCH/S. It inverts the linear channel / ISI that closes the π/4-DQPSK eye before the DNB's soft TCH/S decode, the same lever the TMO path just got.

## Changes

- **`dmo.go` / `dmo_equalizer.go`** — new `ExtractDMBurstsEqualized(dibits, diffs, symbols, baseIdx, taps, passes)`. For each **rotation-0** DNB it trains a per-burst `SnapshotLMS` on the known 11-dibit normal training sequence, freezes the taps, equalizes the `BKN1..BKN2` span (taps-long FIR warm-up), and re-derives `SoftBKN1/SoftBKN2` from the equalized raw symbols — so the existing `DMBurstTCHSpeechSoft` decodes it unchanged.
- **`tetra_dmo_replay_test.go`** — `GT_TETRA_DMO_LMS=1` enables it (new `SymbolSink` accumulator) for a real-capture A/B.
- **`dmo_equalizer_test.go`** — failing-first regression through the real extractor.
- **`CLAUDE.md`** — note on the DMO-specific geometry and the rotation-0-only rule.

Two DMO-specific points vs the TMO wiring, both in the code comments: the DNB block geometry differs (BKN1 `[L-108,L)`, BKN2 `[L+11,L+119)`), and it **equalizes rotation-0 bursts only** — a frozen constant-tap filter cannot invert the per-symbol phase ramp of a non-zero residual rotation, and at rotation 0 the soft decode's `(4-Rotation)&3` de-rotation is a no-op so the rotation-0-trained differentials slot straight in.

## Test plan

- [x] `make vet test` is green locally (`go vet ./...` clean; full `go test ./...` exit 0)
- [ ] `make integration` — n/a (DMO isn't wired into the daemon; this is offline extractor code behind an opt-in)
- [x] Added tests: `dmo_equalizer_test.go` drives a synthetic multipath DNB through the real extractor — raw soft payload **12% → 0%** bit-error with the equalizer, a no-harm-on-clean case, and a guard that with no symbols supplied the soft blocks are byte-identical to `ExtractDMBurstsSoft`.
- [ ] Smoke-tested against real hardware — **not yet.** The whole DMO path is still unverified on air (#1003); this is a lever staged for that validation. A/B on the reporter's capture:
  ```
  GT_TETRA_DMO_IQ=Tetra_DMO_Two_TX_cs16_30sec_bw150.raw GT_TETRA_DMO_RATE=150000 \
  go test ./cmd/gophertrunk -run TestTETRADMOReplay -v            # baseline
  GT_TETRA_DMO_LMS=1 GT_TETRA_DMO_IQ=… go test ./cmd/gophertrunk -run TestTETRADMOReplay -v   # +LMS
  ```

## Breaking changes

None. Opt-in and additive: `ExtractDMBursts` / `ExtractDMBurstsSoft` are unchanged; a burst at a non-zero rotation, or when no symbols are supplied, keeps the raw soft differentials, so the change can only help and never regresses the (still-unverified) baseline.

## Docs / CHANGELOG

- [ ] CHANGELOG — n/a (no user-visible default-behaviour change; DMO isn't a shipped daemon mode yet)
- [x] Updated `CLAUDE.md` with the DMO equalizer note

## Linked issues

Refs #1003 (kept open per the issue-closing policy — the DMO path awaits on-air validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUs7kTzCMcnykc3d4kdUer

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUs7kTzCMcnykc3d4kdUer)_