### PR TITLE
fix(webui): stabilize live-audio playback (silence, clicks, dropped calls)

### DIFF
--- a/internal/broadcast/backends_test.go
+++ b/internal/broadcast/backends_test.go
@@ -129,6 +129,14 @@ func TestRdioScannerUpload(t *testing.T) {
 		if r.FormValue("talkgroup") != "4321" {
 			t.Errorf("talkgroup = %q", r.FormValue("talkgroup"))
 		}
+		// The tag/group enrichment: RdioScanner shows GopherTrunk's own
+		// talkgroup tag/group instead of falling back to its static config.
+		if r.FormValue("talkgroupTag") != "Fire Dispatch" {
+			t.Errorf("talkgroupTag = %q", r.FormValue("talkgroupTag"))
+		}
+		if r.FormValue("talkgroupGroup") != "Fire" {
+			t.Errorf("talkgroupGroup = %q", r.FormValue("talkgroupGroup"))
+		}
 		f, _, err := r.FormFile("audio")
 		if err != nil {
 			t.Errorf("audio part missing: %v", err)
@@ -150,11 +158,40 @@ func TestRdioScannerUpload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRdioScanner: %v", err)
 	}
-	if err := be.Send(context.Background(), testCall(t)); err != nil {
+	c := testCall(t)
+	c.TalkgroupTag = "Fire Dispatch"
+	c.TalkgroupGroup = "Fire"
+	if err := be.Send(context.Background(), c); err != nil {
 		t.Fatalf("Send: %v", err)
 	}
 	if !ok {
 		t.Fatal("server did not receive a well-formed upload")
+	}
+}
+
+// TestRdioScannerOmitsEmptyTagGroup pins that the optional tag/group fields are
+// absent (not sent as empty strings) when the talkgroup has no tag/group, so
+// RdioScanner keeps its own values rather than being overwritten with blanks.
+func TestRdioScannerOmitsEmptyTagGroup(t *testing.T) {
+	var sawTag, sawGroup bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseMultipartForm(8 << 20); err != nil {
+			t.Errorf("parse multipart: %v", err)
+			return
+		}
+		_, sawTag = r.MultipartForm.Value["talkgroupTag"]
+		_, sawGroup = r.MultipartForm.Value["talkgroupGroup"]
+		io.WriteString(w, "Call imported successfully.")
+	}))
+	defer srv.Close()
+
+	be, _ := NewRdioScanner(RdioScannerConfig{URL: srv.URL, APIKey: "K", SystemID: 1}, srv.Client())
+	c := testCall(t) // no tag/group set
+	if err := be.Send(context.Background(), c); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if sawTag || sawGroup {
+		t.Errorf("empty tag/group should be omitted: sawTag=%v sawGroup=%v", sawTag, sawGroup)
 	}
 }
 

--- a/internal/broadcast/broadcast.go
+++ b/internal/broadcast/broadcast.go
@@ -39,6 +39,14 @@ type Call struct {
 	Protocol       string
 	Talkgroup      uint32
 	TalkgroupLabel string
+	// TalkgroupTag / TalkgroupGroup carry the talkgroup's department/category
+	// and top-level group. Aggregators that show per-call tag/group columns
+	// (RdioScanner's talkgroupTag / talkgroupGroup) render these; without them
+	// the console falls back to its own static per-system config, which is
+	// where a stale label like a wrong protocol type comes from. Both empty
+	// until the talkgroup is resolved/tagged.
+	TalkgroupTag   string
+	TalkgroupGroup string
 	Source         uint32
 	FrequencyHz    uint32
 	// ChannelID / RFSS / Site / NAC / Timeslot carry the P25 site
@@ -167,6 +175,8 @@ func callFromEvent(cc trunking.CallComplete) *Call {
 	}
 	if cc.Talkgroup != nil {
 		c.TalkgroupLabel = cc.Talkgroup.AlphaTag
+		c.TalkgroupTag = cc.Talkgroup.Tag
+		c.TalkgroupGroup = cc.Talkgroup.Group
 	}
 	return c
 }

--- a/internal/broadcast/rdioscanner.go
+++ b/internal/broadcast/rdioscanner.go
@@ -92,6 +92,17 @@ func (b *rdioScannerBackend) Send(ctx context.Context, c *Call) error {
 	if c.TalkgroupLabel != "" {
 		fields = append(fields, multipartField{Name: "talkgroupLabel", Value: c.TalkgroupLabel})
 	}
+	// Forward the talkgroup's tag (department/category) and top-level group so
+	// RdioScanner's console shows GopherTrunk's own metadata instead of falling
+	// back to its static per-system config. RdioScanner's call-upload API has
+	// no protocol/type field, so this does NOT set the system-type label the
+	// console renders (e.g. "P25") — that stays a RdioScanner-side config value.
+	if c.TalkgroupTag != "" {
+		fields = append(fields, multipartField{Name: "talkgroupTag", Value: c.TalkgroupTag})
+	}
+	if c.TalkgroupGroup != "" {
+		fields = append(fields, multipartField{Name: "talkgroupGroup", Value: c.TalkgroupGroup})
+	}
 	if c.System != "" {
 		fields = append(fields, multipartField{Name: "systemLabel", Value: c.System})
 	}

--- a/web/src/audio/fadeEnvelope.test.ts
+++ b/web/src/audio/fadeEnvelope.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import {
+  envelopeTarget,
+  nextEnvelopeGain,
+  rampStepForFrames,
+} from "./fadeEnvelope";
+
+describe("envelopeTarget", () => {
+  it("is 0 while not draining (primed-silent / post-underrun)", () => {
+    expect(envelopeTarget(false, 10_000, 240)).toBe(0);
+  });
+
+  it("is 1 during healthy playback (available deep enough)", () => {
+    expect(envelopeTarget(true, 10_000, 240)).toBe(1);
+  });
+
+  it("drops to 0 once within the release window of empty (tail fade)", () => {
+    expect(envelopeTarget(true, 240, 240)).toBe(0);
+    expect(envelopeTarget(true, 100, 240)).toBe(0);
+    expect(envelopeTarget(true, 241, 240)).toBe(1);
+  });
+});
+
+describe("nextEnvelopeGain", () => {
+  it("steps up toward the target without overshooting", () => {
+    expect(nextEnvelopeGain(0, 1, 0.25)).toBeCloseTo(0.25);
+    expect(nextEnvelopeGain(0.9, 1, 0.25)).toBe(1); // clamps at target
+  });
+
+  it("steps down toward the target without undershooting", () => {
+    expect(nextEnvelopeGain(1, 0, 0.25)).toBeCloseTo(0.75);
+    expect(nextEnvelopeGain(0.1, 0, 0.25)).toBe(0); // clamps at target
+  });
+
+  it("holds when already at target", () => {
+    expect(nextEnvelopeGain(1, 1, 0.25)).toBe(1);
+    expect(nextEnvelopeGain(0, 0, 0.25)).toBe(0);
+  });
+});
+
+describe("rampStepForFrames", () => {
+  it("converts a frame count to a per-frame step", () => {
+    expect(rampStepForFrames(4)).toBe(0.25);
+  });
+  it("is instant for a non-positive length", () => {
+    expect(rampStepForFrames(0)).toBe(1);
+    expect(rampStepForFrames(-5)).toBe(1);
+  });
+});
+
+// Integration: replay the worklet's per-sample envelope math (which mirrors
+// these helpers) and assert the audible property — a boundary that begins and
+// ends at exactly zero, with a monotone ramp, i.e. no click.
+describe("envelope over a call boundary", () => {
+  const step = rampStepForFrames(8); // 8-frame ramp for a readable trace
+
+  function run(
+    frames: { draining: boolean; available: number }[],
+    release: number,
+  ): number[] {
+    let env = 0;
+    const gains: number[] = [];
+    for (const f of frames) {
+      const target = envelopeTarget(f.draining, f.available, release);
+      env = nextEnvelopeGain(env, target, step);
+      gains.push(env);
+    }
+    return gains;
+  }
+
+  it("fades IN from zero on prime (no startup click)", () => {
+    // Draining with plenty buffered: env climbs from 0 up toward 1.
+    const gains = run(
+      Array.from({ length: 8 }, () => ({ draining: true, available: 1000 })),
+      100,
+    );
+    expect(gains[0]).toBeGreaterThan(0);
+    expect(gains[0]).toBeLessThan(1);
+    // Monotonically non-decreasing and reaches unity.
+    for (let i = 1; i < gains.length; i++) {
+      expect(gains[i]).toBeGreaterThanOrEqual(gains[i - 1]);
+    }
+    expect(gains[gains.length - 1]).toBe(1);
+  });
+
+  it("fades OUT to zero as the ring empties (no PTT-out click)", () => {
+    // Start at unity, then the tail drains inside the release window.
+    const frames = [
+      { draining: true, available: 1000 }, // healthy
+      ...Array.from({ length: 8 }, () => ({ draining: true, available: 50 })),
+      { draining: false, available: 0 }, // underran
+    ];
+    const gains = run(frames, 100);
+    // Ends fully faded out.
+    expect(gains[gains.length - 1]).toBe(0);
+    // Once the tail window is entered, the envelope is monotonically
+    // non-increasing down to zero.
+    const tail = gains.slice(1);
+    for (let i = 1; i < tail.length; i++) {
+      expect(tail[i]).toBeLessThanOrEqual(tail[i - 1]);
+    }
+  });
+});

--- a/web/src/audio/fadeEnvelope.ts
+++ b/web/src/audio/fadeEnvelope.ts
@@ -1,0 +1,49 @@
+// Boundary-declick envelope for the live-audio ring-buffer worklet.
+//
+// The recorded/streamed PCM rarely lands on zero at a PTT edge, so starting or
+// stopping playback on a hard sample step injects a broadband click — what the
+// user hears as a "DC spike" at PTT-in / PTT-out and at every mid-stream call
+// seam. A short amplitude ramp at those transitions removes it, exactly the way
+// rdio-scanner fades each clip's head and tail.
+//
+// The math here is intentionally tiny and is MIRRORED inline in
+// ringBufferProcessor.js — that worklet is loaded raw by addModule() and must
+// not import anything, so this module exists to host the logic under test.
+// Keep the two in sync; fadeEnvelope.test.ts pins the behaviour.
+
+// envelopeTarget picks the gain the envelope should be heading toward this
+// render quantum:
+//   - 0 while the ring is not draining (primed-silent or post-underrun), so the
+//     first real sample after a prime fades UP from zero, not a step.
+//   - 0 while draining but within `releaseFrames` of empty, so the tail fades
+//     DOWN to zero before the hard underrun cut instead of clicking off.
+//   - 1 during healthy steady playback (available deep enough), so mid-call
+//     audio is untouched (unity) — no coloration.
+export function envelopeTarget(
+  draining: boolean,
+  available: number,
+  releaseFrames: number,
+): number {
+  if (!draining) return 0;
+  if (available <= releaseFrames) return 0;
+  return 1;
+}
+
+// nextEnvelopeGain steps the current gain toward target by at most `step`
+// (1/rampFrames), clamped to [0, 1]. A linear ramp is enough to kill the click
+// and is cheap per-sample.
+export function nextEnvelopeGain(
+  gain: number,
+  target: number,
+  step: number,
+): number {
+  if (gain < target) return Math.min(target, gain + step);
+  if (gain > target) return Math.max(target, gain - step);
+  return gain;
+}
+
+// rampStepForFrames converts a desired ramp length in frames to a per-frame
+// step. A non-positive length yields an instant (step 1) transition.
+export function rampStepForFrames(rampFrames: number): number {
+  return rampFrames > 0 ? 1 / rampFrames : 1;
+}

--- a/web/src/audio/followSelect.test.ts
+++ b/web/src/audio/followSelect.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { pickFollowSerial } from "./followSelect";
+
+const call = (device_serial: string, started_at: string) => ({
+  device_serial,
+  started_at,
+});
+
+describe("pickFollowSerial", () => {
+  it("returns null when nothing is active", () => {
+    expect(pickFollowSerial([], null)).toBeNull();
+    expect(pickFollowSerial([], "dev-a")).toBeNull();
+  });
+
+  it("picks the newest call when nothing is held yet", () => {
+    const calls = [call("dev-a", "2026-01-01T00:00:01Z"), call("dev-b", "2026-01-01T00:00:03Z")];
+    expect(pickFollowSerial(calls, null)).toBe("dev-b");
+  });
+
+  it("HOLDS the current call while its device is still active", () => {
+    // dev-a is held; dev-b is newer but must NOT steal the stream mid-call.
+    const calls = [
+      call("dev-a", "2026-01-01T00:00:01Z"),
+      call("dev-b", "2026-01-01T00:00:05Z"),
+    ];
+    expect(pickFollowSerial(calls, "dev-a")).toBe("dev-a");
+  });
+
+  it("advances to the newest once the held call ends", () => {
+    // dev-a dropped out of the active set → follow whatever is live now.
+    const calls = [
+      call("dev-b", "2026-01-01T00:00:05Z"),
+      call("dev-c", "2026-01-01T00:00:04Z"),
+    ];
+    expect(pickFollowSerial(calls, "dev-a")).toBe("dev-b");
+  });
+
+  it("ignores calls without a device serial (announced, no tuner)", () => {
+    const calls = [call("", "2026-01-01T00:00:09Z"), call("dev-a", "2026-01-01T00:00:01Z")];
+    expect(pickFollowSerial(calls, null)).toBe("dev-a");
+  });
+});

--- a/web/src/audio/followSelect.ts
+++ b/web/src/audio/followSelect.ts
@@ -1,0 +1,42 @@
+// Follow-selection policy for the live-audio mini-player.
+//
+// The WebUI plays one call at a time (standard scanner behaviour) and the
+// daemon's /audio/stream is filtered to a single device serial. The question
+// this module answers is *which* call to follow as the active-call set churns.
+//
+// The naive "always follow the newest started_at" rule tears the in-progress
+// call off the instant any newer grant appears — and because the live stream
+// has no backfill, the abandoned call's tail is simply lost ("eating
+// conversations"). Instead we HOLD the current call: keep following its device
+// until that device drops out of the active set (the call ended), then advance
+// to whatever is live. Each call plays to completion, then we move on.
+
+interface FollowCall {
+  device_serial: string;
+  started_at: string;
+}
+
+// pickFollowSerial returns the device serial the player should be following.
+//   - null when nothing is up (stream falls silent rather than dropping to the
+//     overlap-prone unfiltered stream).
+//   - the current serial when its call is still active (hold to completion).
+//   - otherwise the newest active call's serial (advance once the held call
+//     ends, or on the very first call when nothing is held yet).
+// Calls without a device serial are ignored — an announced-but-unfollowed call
+// has no tuner and thus no audio to stream.
+export function pickFollowSerial(
+  activeCalls: readonly FollowCall[],
+  current: string | null,
+): string | null {
+  const withSerial = activeCalls.filter((c) => c.device_serial);
+  if (withSerial.length === 0) return null;
+  // Hold the current call while its device is still transmitting.
+  if (current && withSerial.some((c) => c.device_serial === current)) {
+    return current;
+  }
+  // Otherwise advance to the most recently started active call.
+  const newest = withSerial.reduce((a, b) =>
+    b.started_at > a.started_at ? b : a,
+  );
+  return newest.device_serial;
+}

--- a/web/src/audio/ringBufferProcessor.js
+++ b/web/src/audio/ringBufferProcessor.js
@@ -29,6 +29,19 @@ class RingBufferProcessor extends AudioWorkletProcessor {
     this.available = 0; // frames currently buffered
     this.draining = false; // false until primed; flips back on underrun
 
+    // Boundary-declick envelope. A short amplitude ramp at prime-start, mid-
+    // stream call seams, and the pre-underrun tail removes the broadband click
+    // ("DC spike") of starting/stopping on a non-zero PCM sample — the same
+    // per-clip fade rdio-scanner applies. Logic mirrors ../audio/fadeEnvelope.ts
+    // (kept inline: this worklet is loaded raw by addModule and can't import);
+    // fadeEnvelope.test.ts pins it. ~5 ms ramp, and the tail fade begins once
+    // the ring is within `release` frames of empty. Release is capped below the
+    // prime depth so steady playback (ring hovers near prime) stays at unity.
+    const ramp = Math.max(1, Math.round(sampleRate * 0.005));
+    this.envStep = 1 / ramp;
+    this.envRelease = Math.min(ramp, Math.max(1, Math.floor(this.prime / 2)));
+    this.env = 0; // current envelope gain, ramps in [0, 1]
+
     this.port.onmessage = (event) => {
       const msg = event.data;
       if (!msg) return;
@@ -37,6 +50,7 @@ class RingBufferProcessor extends AudioWorkletProcessor {
         this.write = 0;
         this.available = 0;
         this.draining = false;
+        this.env = 0; // re-fade in on the next call rather than stepping in
         return;
       }
       if (msg.type === "push" && msg.samples) {
@@ -66,21 +80,40 @@ class RingBufferProcessor extends AudioWorkletProcessor {
     if (!this.draining && this.available >= this.prime) {
       this.draining = true;
     }
-    if (!this.draining) {
-      channel.fill(0);
-      return true;
-    }
+    // Note: still run the sample loop even when not draining so the envelope
+    // can finish ramping DOWN through this quantum (a fade-out that started as
+    // the ring emptied completes into the silence instead of clicking off).
 
     for (let i = 0; i < channel.length; i++) {
-      if (this.available > 0) {
-        channel[i] = this.ring[this.read];
+      // Envelope target: 0 while silent or within `envRelease` of empty (fade
+      // the tail before the hard cut), 1 during healthy playback. Mirrors
+      // fadeEnvelope.ts envelopeTarget().
+      let target;
+      if (!this.draining) {
+        target = 0;
+      } else if (this.available <= this.envRelease) {
+        target = 0;
+      } else {
+        target = 1;
+      }
+      // Step the envelope toward the target (fadeEnvelope.ts nextEnvelopeGain).
+      if (this.env < target) {
+        this.env = Math.min(target, this.env + this.envStep);
+      } else if (this.env > target) {
+        this.env = Math.max(target, this.env - this.envStep);
+      }
+
+      let sample = 0;
+      if (this.draining && this.available > 0) {
+        sample = this.ring[this.read];
         this.read = (this.read + 1) % this.capacity;
         this.available--;
-      } else {
-        // Underrun: emit silence and re-prime before draining again.
-        channel[i] = 0;
+      } else if (this.draining) {
+        // Underrun: out of buffered frames. Emit (faded) silence and re-prime
+        // before draining again.
         this.draining = false;
       }
+      channel[i] = sample * this.env;
     }
     return true;
   }

--- a/web/src/audio/streamPlayer.test.ts
+++ b/web/src/audio/streamPlayer.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import {
   parseWavHeader,
   int16ToFloat32,
@@ -7,6 +7,7 @@ import {
   createAudioContext,
   STREAM_SAMPLE_RATE,
   WorkletSink,
+  createStreamPlayer,
 } from "./streamPlayer";
 
 // Build a canonical 44-byte RIFF/WAVE header byte-for-byte the way the
@@ -236,5 +237,91 @@ describe("WorkletSink", () => {
     const pushed = posts.filter((p) => p.type === "push");
     expect(pushed.length).toBe(1);
     expect(Array.from(pushed[0].samples!)).toEqual(Array.from(input));
+  });
+});
+
+// Regression for the silence bug: following a new call must REUSE the one
+// AudioContext, not build a fresh one per switch. Building a context per
+// follow-switch accumulated suspended contexts until Chrome's ~6-per-page cap
+// threw and playback went permanently silent (macOS Chrome first). We stand in
+// for that ceiling by counting how many contexts the player constructs.
+describe("createStreamPlayer AudioContext lifecycle", () => {
+  const origFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = origFetch;
+  });
+
+  // A minimal AudioContext stub. audioWorklet is absent so the player takes the
+  // LegacySink path (no worklet module to load), and fetch resolves with no
+  // body so run() returns immediately without touching the network.
+  function makeFakeContext() {
+    return {
+      sampleRate: 48000,
+      currentTime: 0,
+      destination: {},
+      audioWorklet: undefined,
+      createGain: () => ({
+        gain: { setTargetAtTime: () => {} },
+        connect: () => {},
+      }),
+      resume: vi.fn(() => Promise.resolve()),
+      suspend: vi.fn(() => Promise.resolve()),
+      close: vi.fn(() => Promise.resolve()),
+    } as unknown as AudioContext;
+  }
+
+  it("builds exactly one context across many follow-switches", () => {
+    globalThis.fetch = vi.fn(() =>
+      Promise.resolve({ ok: true, body: null } as Response),
+    );
+    const contexts: AudioContext[] = [];
+    const player = createStreamPlayer({
+      url: "https://d/api/v1/audio/stream",
+      token: null,
+      onError: () => {},
+      onStateChange: () => {},
+      contextFactory: () => {
+        const c = makeFakeContext();
+        contexts.push(c);
+        return c;
+      },
+    });
+
+    player.start();
+    for (let i = 0; i < 10; i++) {
+      player.reconnect(`https://d/api/v1/audio/stream?device=dev-${i}`);
+    }
+
+    // The whole point: one context, not eleven.
+    expect(contexts.length).toBe(1);
+    expect((contexts[0].close as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+  });
+
+  it("closes the context on stop and rebuilds on the next start", () => {
+    globalThis.fetch = vi.fn(() =>
+      Promise.resolve({ ok: true, body: null } as Response),
+    );
+    const contexts: AudioContext[] = [];
+    const player = createStreamPlayer({
+      url: "https://d/api/v1/audio/stream",
+      token: null,
+      onError: () => {},
+      onStateChange: () => {},
+      contextFactory: () => {
+        const c = makeFakeContext();
+        contexts.push(c);
+        return c;
+      },
+    });
+
+    player.start();
+    player.stop();
+    expect(contexts.length).toBe(1);
+    expect(contexts[0].close as ReturnType<typeof vi.fn>).toHaveBeenCalledTimes(1);
+
+    // A fresh start must build a new context (the old one was closed, not
+    // suspended-and-leaked).
+    player.start();
+    expect(contexts.length).toBe(2);
   });
 });

--- a/web/src/audio/streamPlayer.ts
+++ b/web/src/audio/streamPlayer.ts
@@ -125,12 +125,24 @@ export interface StreamPlayerOptions {
   token: string | null;
   onError: (msg: string) => void;
   onStateChange: (state: PlayerState) => void;
+  /** Factory for the AudioContext. Defaults to the browser's native
+   *  constructor at the hardware rate. Injectable so tests can count how
+   *  many contexts a player builds (the follow-switch leak that caused
+   *  Chrome's ~6-context ceiling — and the resulting silence — to trip). */
+  contextFactory?: () => AudioContext;
 }
 
 export interface StreamPlayer {
   /** Must be invoked synchronously from a user-gesture handler so the
    *  AudioContext resume isn't rejected by the autoplay policy. */
   start(): void;
+  /** Re-point the running stream at a new URL (following a new call)
+   *  WITHOUT tearing down the AudioContext/worklet. Reusing the one
+   *  context is what keeps the WebUI under Chrome's per-page context
+   *  limit — building a fresh context per call switch is what leaked to
+   *  silence. Safe to call outside a user gesture: the context is already
+   *  running from the initial start(). */
+  reconnect(url: string): void;
   stop(): void;
   setVolume(v: number): void;
   setMuted(muted: boolean): void;
@@ -294,6 +306,9 @@ export function createStreamPlayer(
   let muted = false;
   let userStopped = false;
   let reconnectTimer: number | null = null;
+  // The stream URL is mutable so following a new call can re-point the fetch
+  // (see reconnect) while keeping the same AudioContext/worklet alive.
+  let url = opts.url;
 
   const applyGain = () => {
     if (gain && ctx) {
@@ -303,13 +318,17 @@ export function createStreamPlayer(
 
   const ensureGraph = (): boolean => {
     if (ctx === null) {
-      const Ctor = resolveAudioContext();
-      if (Ctor === null) {
-        opts.onError("Web Audio is not supported in this browser");
-        opts.onStateChange("error");
-        return false;
+      if (opts.contextFactory) {
+        ctx = opts.contextFactory();
+      } else {
+        const Ctor = resolveAudioContext();
+        if (Ctor === null) {
+          opts.onError("Web Audio is not supported in this browser");
+          opts.onStateChange("error");
+          return false;
+        }
+        ctx = createAudioContext(Ctor);
       }
-      ctx = createAudioContext(Ctor);
     }
     if (gain === null) {
       gain = ctx.createGain();
@@ -359,7 +378,7 @@ export function createStreamPlayer(
     opts.onStateChange("connecting");
     let res: Response;
     try {
-      res = await fetch(opts.url, {
+      res = await fetch(url, {
         headers: opts.token
           ? { Authorization: `Bearer ${opts.token}` }
           : {},
@@ -446,6 +465,31 @@ export function createStreamPlayer(
       void getSink();
       void run();
     },
+    reconnect(newURL: string) {
+      // Follow a new call by swapping the fetch URL and re-running on the
+      // SAME context/gain/worklet. Building a fresh AudioContext per switch
+      // (the old behaviour) leaked contexts until Chrome's ~6-per-page cap
+      // threw and playback went silent. Here nothing is torn down: abort the
+      // in-flight read, drop its buffered tail, and reopen.
+      userStopped = false;
+      if (reconnectTimer !== null) {
+        window.clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+      }
+      if (url === newURL && abort) return; // already following this call
+      url = newURL;
+      // No context yet (reconnect raced ahead of the initial start): just
+      // remember the URL; start() will open it inside the user gesture.
+      if (ctx === null) return;
+      abort?.abort();
+      abort = null;
+      // Keep the context live and drop the previous call's buffered audio so
+      // the new call doesn't start behind stale frames. The worklet's fade
+      // envelope smooths the seam.
+      void ctx?.resume();
+      void sinkPromise?.then((sink) => sink.reset());
+      void run();
+    },
     stop() {
       userStopped = true;
       if (reconnectTimer !== null) {
@@ -454,9 +498,14 @@ export function createStreamPlayer(
       }
       abort?.abort();
       abort = null;
-      // Drop buffered audio so a later resume doesn't replay stale frames.
+      // Close (not just suspend) and drop the graph so no AudioContext
+      // lingers past teardown — suspend-only accumulation past Chrome's
+      // per-page limit was the silence bug. start() rebuilds from scratch.
       void sinkPromise?.then((sink) => sink.reset());
-      void ctx?.suspend();
+      void ctx?.close();
+      ctx = null;
+      gain = null;
+      sinkPromise = null;
       opts.onStateChange("stopped");
     },
     setVolume(v: number) {

--- a/web/src/components/AudioPlayer.test.tsx
+++ b/web/src/components/AudioPlayer.test.tsx
@@ -1,15 +1,21 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 
-// Capture every stream the player opens so we can assert the URL it
-// filtered to. start/stop/setVolume/setMuted are inert.
+// Capture how the player is pointed at streams. The component must build the
+// player (and its single AudioContext) ONCE and then re-point it with
+// reconnect() as it follows calls — building a fresh player per switch is the
+// leak that silenced Chrome. `built` counts createStreamPlayer calls; `opened`
+// records every URL the stream is pointed at (initial + each reconnect).
+const built: number[] = [];
 const opened: string[] = [];
 vi.mock("../audio/streamPlayer", () => ({
   createStreamPlayer: (opts: { url: string }) => {
+    built.push(1);
     opened.push(opts.url);
     return {
       start: vi.fn(),
       stop: vi.fn(),
+      reconnect: (url: string) => opened.push(url),
       setVolume: vi.fn(),
       setMuted: vi.fn(),
     };
@@ -30,6 +36,7 @@ function call(serial: string, startedAt: string): ActiveCallDTO {
 
 describe("AudioPlayer live-audio follow", () => {
   beforeEach(() => {
+    built.length = 0;
     opened.length = 0;
     useShared.setState({
       serverURL: "http://localhost:8080",
@@ -38,7 +45,7 @@ describe("AudioPlayer live-audio follow", () => {
     });
   });
 
-  it("opens the stream filtered to the primary call and follows the newest", async () => {
+  it("holds the current call to completion, then follows the next", async () => {
     useShared.setState({ activeCalls: [call("VOICE-1", "2026-01-01T00:00:00Z")] });
 
     render(<AudioPlayer />);
@@ -48,7 +55,9 @@ describe("AudioPlayer live-audio follow", () => {
     await waitFor(() => expect(opened).toHaveLength(1));
     expect(opened[0]).toContain("device=VOICE-1");
 
-    // A newer call on a different device → follow it (one call at a time).
+    // A newer call appears while VOICE-1 is STILL active → we must NOT cut
+    // VOICE-1 off. This is the "eating conversations" regression: the stream
+    // stays on VOICE-1.
     act(() => {
       useShared.setState({
         activeCalls: [
@@ -57,8 +66,22 @@ describe("AudioPlayer live-audio follow", () => {
         ],
       });
     });
+    // Give the follow effect a chance to (wrongly) fire.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(opened).toHaveLength(1); // still only VOICE-1
+
+    // VOICE-1 ends (drops out of the active set) → advance to VOICE-2.
+    act(() => {
+      useShared.setState({
+        activeCalls: [call("VOICE-2", "2026-01-01T00:00:05Z")],
+      });
+    });
     await waitFor(() => expect(opened).toHaveLength(2));
     expect(opened[1]).toContain("device=VOICE-2");
+
+    // The whole point of the leak fix: one player/context, re-pointed — not a
+    // fresh one per switch.
+    expect(built).toHaveLength(1);
   });
 
   it("opens unfiltered when no call is active", async () => {

--- a/web/src/components/AudioPlayer.tsx
+++ b/web/src/components/AudioPlayer.tsx
@@ -4,6 +4,7 @@ import { createStreamPlayer, type StreamPlayer } from "../audio/streamPlayer";
 import { writes } from "../api/write";
 import { selectClientConfig, useShared } from "../store/shared";
 import { useActiveCallsPoll } from "../hooks/useActiveCallsPoll";
+import { pickFollowSerial } from "../audio/followSelect";
 import { prefs } from "../store/prefs";
 
 // AudioPlayer is a floating, dismissable mini-player that streams
@@ -45,19 +46,17 @@ export function AudioPlayer() {
   const mutedRef = useRef(muted);
   mutedRef.current = muted;
 
-  // The single call live audio follows: the most recently started active
-  // call. Playing one call at a time (standard scanner behaviour) is what
-  // stops concurrent talkgroups from overlapping into one garbled stream —
-  // the daemon's /audio/stream supports a ?device= filter, the WebUI just
-  // never used it. null when nothing is up (stream stays unfiltered so the
-  // first call is still audible before the poll narrows onto it).
-  const primarySerial = useMemo(() => {
-    if (activeCalls.length === 0) return null;
-    const newest = activeCalls.reduce((a, b) =>
-      b.started_at > a.started_at ? b : a,
-    );
-    return newest.device_serial;
-  }, [activeCalls]);
+  // The single call live audio follows. Playing one call at a time (standard
+  // scanner behaviour) is what stops concurrent talkgroups from overlapping
+  // into one garbled stream — the daemon's /audio/stream supports a ?device=
+  // filter. pickFollowSerial HOLDS the current call until its device stops
+  // transmitting, then advances to the newest — so a call plays to completion
+  // instead of being cut off the moment a newer grant lands ("eating
+  // conversations"). null when nothing is up.
+  const primarySerial = useMemo(
+    () => pickFollowSerial(activeCalls, playerSerialRef.current),
+    [activeCalls],
+  );
 
   // Reflect the daemon's current audio state into the local toggles.
   const daemonAudio = useShared((s) => s.audio);
@@ -94,16 +93,25 @@ export function AudioPlayer() {
     };
   }, [cfg]);
 
-  // startPlayer (re)opens the stream filtered to one call's device serial.
-  // Stable across volume/mute changes (those read refs) so following a new
-  // call is the only thing that tears down and reopens the stream.
+  // startPlayer points the stream at one call's device serial. On the first
+  // call it builds the player (and its single AudioContext, inside the user
+  // gesture from enable()); every later call REUSES that player via
+  // reconnect() rather than tearing down and rebuilding a context. Building a
+  // fresh AudioContext per follow-switch leaked contexts until Chrome's
+  // ~6-per-page cap threw and playback went silent (macOS Chrome first).
+  // Stable across volume/mute changes (those read refs).
   const startPlayer = useCallback(
     (serial: string | null) => {
       if (!cfg.baseURL) return;
       setError(null);
-      playerRef.current?.stop();
+      const url = audioStreamURL(cfg, serial ? { device: serial } : {});
+      if (playerRef.current) {
+        playerSerialRef.current = serial;
+        playerRef.current.reconnect(url);
+        return;
+      }
       const player = createStreamPlayer({
-        url: audioStreamURL(cfg, serial ? { device: serial } : {}),
+        url,
         token: cfg.token,
         onError: (msg) => {
           setError(msg);


### PR DESCRIPTION
The WebUI's live-audio engine mangled scanner playback in Chrome (macOS
first): total silence after a while, clicks/"DC spikes" at PTT edges, and
in-progress calls being cut off when a newer grant arrived. The recorded
WAVs are clean (start at 0, ramp out, no clipping) — every artifact came
from the playback pipeline, not the files.

- Silence: AudioPlayer rebuilt a whole AudioContext on every follow-switch
  and streamPlayer.stop() only suspended it, so suspended contexts piled up
  until Chrome's ~6-per-page cap threw on the next new AudioContext and
  playback went permanently silent. Reuse one context via a new
  StreamPlayer.reconnect(url); close() (not suspend) on teardown; inject a
  context factory so a test can count constructions.
- Clicks / "DC spikes": nothing ramped gain at call/stream boundaries. Add a
  short attack/release declick envelope in the ring-buffer worklet that rests
  at unity mid-call and only shapes prime-start, the pre-underrun tail, and
  mid-stream seams — mirroring rdio-scanner's per-clip fades. Logic lives in
  a tested helper (fadeEnvelope.ts) and is mirrored inline in the worklet,
  which must stay import-free for addModule().
- Dropped calls ("eating conversations"): the player followed the newest
  started_at on every 2 s poll, tearing the in-progress call off (the live
  stream has no backfill, so its tail was lost). pickFollowSerial() now holds
  the current call until its device leaves the active set, then advances to
  the newest — each call plays to completion.

Also forward talkgroupTag/talkgroupGroup on RdioScanner call-uploads so its
console shows GopherTrunk's own tag/group instead of falling back to stale
static per-system config. RdioScanner's call-upload API has no protocol/type
field, so this deliberately does NOT change the system-type label ("P25")
its console renders — that stays an RdioScanner-side config value.

No color-scheme or layout changes: all WebUI work is in the audio engine.

Tests (fail-first): streamPlayer reconnect reuses one AudioContext and
closes on stop; fadeEnvelope fades in from 0 / out to 0 / unity mid-stream;
pickFollowSerial holds then advances; AudioPlayer follow-hold; rdioscanner
multipart forwards tag/group when set and omits them when empty.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RW9xH8W8Uy6yJX51aMRc8q