### PR TITLE
replay: accept -in - to decode a raw IQ stream from stdin

### DIFF
--- a/cmd/gophertrunk/replay.go
+++ b/cmd/gophertrunk/replay.go
@@ -32,7 +32,7 @@ import (
 func runReplay(args []string) {
 	fs := flag.NewFlagSet("replay", flag.ExitOnError)
 	verboseFlag := fs.Bool("verbose-errors", false, "print full error chain + stack on failures")
-	in := fs.String("in", "", "raw IQ input file (required)")
+	in := fs.String("in", "", "raw IQ input file, or - for standard input (required). Piping stdin lets an external IQ source feed the decoder, e.g. `iq-source | gophertrunk replay -in - -format f32 -sample-rate 2400000` (issue #314). stdin is a one-way stream, so -auto-tune (which must seek) is not supported with -in -; use -tune-hz.")
 	format := fs.String("format", "u8", "sample format: u8 (rtl_sdr 8-bit unsigned interleaved IQ) | f32 (GNU Radio cfile, interleaved float32) | wav (2-channel 16-bit baseband WAV — SDRtrunk/SDR++/GopherTrunk narrowband recording; sample rate is read from the header)")
 	sampleRate := fs.Float64("sample-rate", 2_400_000, "IQ sample rate in Hz")
 	demod := fs.String("demod", "c4fm", "P25 Phase 1 demod mode: c4fm | cqpsk")
@@ -64,6 +64,11 @@ USAGE:
 EXAMPLES:
   # rtl_sdr capture of a P25 control channel, with the deep demod report
   gophertrunk replay -in mt_anakie.bin -sample-rate 2048000 -demod c4fm -diag
+
+  # Decode a raw IQ stream piped in on stdin (e.g. from OpenWebRX+ / rtl_sdr -),
+  # emitting decoded events to stdout as JSONL
+  iq-source | gophertrunk replay -in - -format f32 -sample-rate 2400000 \
+                    -protocol p25p1 -tune-hz -12500 -out-format jsonl
 
   # Wideband cfile whose control channel is off-centre: auto-tune to 0 Hz
   gophertrunk replay -in mmr-s9.cfile -format f32 -sample-rate 2400000 -auto-tune

--- a/internal/siglab/engine.go
+++ b/internal/siglab/engine.go
@@ -50,11 +50,34 @@ func Run(path string, cfg Config) (*Result, error) {
 	return RunStream(path, cfg, nil)
 }
 
+// openCapture opens the capture at path for a single streaming decode pass,
+// treating "-" as standard input so a raw IQ stream can be piped in — e.g.
+// `openwebrx-iq-source | gophertrunk replay -in - -format f32 -sample-rate …`
+// (issue #314). The returned source name is the path, or "stdin" for "-". stdin
+// is wrapped in a no-op Closer so the caller's defer Close does not close the
+// process's real standard input.
+func openCapture(path string) (io.ReadCloser, string, error) {
+	if path == "-" {
+		return io.NopCloser(os.Stdin), "stdin", nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, "", fmt.Errorf("open %s: %w", path, err)
+	}
+	return f, path, nil
+}
+
 // RunAutoTuneMulti opens the capture at path and decodes cfg.Protocol against
 // each detected carrier candidate, returning the strongest lock (see
 // RunReaderAutoTuneMulti). It is the file-path entry the replay/analyze
 // subcommands use for multi-candidate -auto-tune.
 func RunAutoTuneMulti(path string, cfg Config, maxCandidates int) (*Result, error) {
+	if path == "-" {
+		// Auto-tune reads a prefix then rewinds to decode from the start, so it
+		// needs a seekable source; stdin is a one-way pipe. Fail clearly instead
+		// of letting os.Open("-") produce a confusing "no such file".
+		return nil, fmt.Errorf("siglab: auto-tune cannot read from stdin (it needs to seek the capture); pipe to a file, or use -tune-hz for a fixed offset")
+	}
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("open %s: %w", path, err)
@@ -68,12 +91,12 @@ func RunAutoTuneMulti(path string, cfg Config, maxCandidates int) (*Result, erro
 // It backs the JSONL exporter and the TUI's live event feed. The full
 // Result is still returned at EOF.
 func RunStream(path string, cfg Config, onEvent func(EventRecord)) (*Result, error) {
-	f, err := os.Open(path)
+	f, source, err := openCapture(path)
 	if err != nil {
-		return nil, fmt.Errorf("open %s: %w", path, err)
+		return nil, err
 	}
 	defer f.Close()
-	return RunReaderStream(f, path, cfg, onEvent)
+	return RunReaderStream(f, source, cfg, onEvent)
 }
 
 // RunReader decodes the capture read from r through the production pipeline

--- a/internal/siglab/engine_stdin_test.go
+++ b/internal/siglab/engine_stdin_test.go
@@ -1,0 +1,117 @@
+package siglab
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TestRunStdinMatchesFile proves `-in -` (stdin) decodes a raw IQ stream identically
+// to decoding the same bytes from a file — the offline half of issue #314 (pipe an
+// IQ stream into the decoder). It swaps os.Stdin for a file handle over a
+// synthesized P25 capture and checks the headline Result matches the file path.
+func TestRunStdinMatchesFile(t *testing.T) {
+	iq, meta, err := Synthesize(SynthOptions{Protocol: trunking.ProtocolP25, Format: FormatF32})
+	if err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+	cfg, err := meta.Config(true)
+	if err != nil {
+		t.Fatalf("meta.Config: %v", err)
+	}
+
+	dir := t.TempDir()
+	capPath := filepath.Join(dir, "p25.cfile")
+	data := EncodeCapture(iq, FormatF32)
+	if err := os.WriteFile(capPath, data, 0o644); err != nil {
+		t.Fatalf("write capture: %v", err)
+	}
+
+	fromFile, err := Run(capPath, cfg)
+	if err != nil {
+		t.Fatalf("Run(path): %v", err)
+	}
+	if !fromFile.Locked {
+		t.Fatal("expected synthesized clean P25 to lock from the file path")
+	}
+
+	// Feed the identical bytes through os.Stdin and decode with the "-" sentinel.
+	f, err := os.Open(capPath)
+	if err != nil {
+		t.Fatalf("open capture: %v", err)
+	}
+	orig := os.Stdin
+	os.Stdin = f
+	defer func() {
+		os.Stdin = orig
+		f.Close()
+	}()
+
+	fromStdin, err := Run("-", cfg)
+	if err != nil {
+		t.Fatalf("Run(\"-\"): %v", err)
+	}
+	if !fromStdin.Locked {
+		t.Error("expected the same capture to lock when piped through stdin")
+	}
+	if fromStdin.Source != "stdin" {
+		t.Errorf("Source = %q, want \"stdin\"", fromStdin.Source)
+	}
+	if fromStdin.Locked != fromFile.Locked {
+		t.Errorf("Locked mismatch: file=%v stdin=%v", fromFile.Locked, fromStdin.Locked)
+	}
+	if fromStdin.TotalSamples != fromFile.TotalSamples {
+		t.Errorf("TotalSamples mismatch: file=%d stdin=%d", fromFile.TotalSamples, fromStdin.TotalSamples)
+	}
+	if fromStdin.Symbols != fromFile.Symbols {
+		t.Errorf("Symbols mismatch: file=%d stdin=%d", fromFile.Symbols, fromStdin.Symbols)
+	}
+}
+
+// TestOpenCaptureStdin checks the "-" sentinel resolves to standard input with a
+// no-op closer (so decoding does not close the process's real stdin), and that a
+// real path still opens normally while a missing one errors.
+func TestOpenCaptureStdin(t *testing.T) {
+	rc, source, err := openCapture("-")
+	if err != nil {
+		t.Fatalf("openCapture(\"-\"): %v", err)
+	}
+	if source != "stdin" {
+		t.Errorf("source = %q, want \"stdin\"", source)
+	}
+	if err := rc.Close(); err != nil {
+		t.Errorf("stdin Close should be a no-op, got %v", err)
+	}
+	// The no-op close must leave the real stdin usable.
+	if os.Stdin == nil {
+		t.Fatal("os.Stdin was closed by openCapture's Closer")
+	}
+
+	dir := t.TempDir()
+	p := filepath.Join(dir, "cap.bin")
+	if err := os.WriteFile(p, []byte{1, 2, 3, 4}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rc2, source2, err := openCapture(p)
+	if err != nil {
+		t.Fatalf("openCapture(path): %v", err)
+	}
+	rc2.Close()
+	if source2 != p {
+		t.Errorf("source = %q, want %q", source2, p)
+	}
+	if _, _, err := openCapture(filepath.Join(dir, "missing.bin")); err == nil {
+		t.Error("expected an error opening a missing file")
+	}
+}
+
+// TestRunAutoTuneStdinRejected confirms auto-tune over stdin fails with a clear
+// error rather than a confusing os.Open("-") failure — stdin cannot seek.
+func TestRunAutoTuneStdinRejected(t *testing.T) {
+	cfg := Config{Protocol: trunking.ProtocolP25, SampleRateHz: 2_400_000, Format: FormatF32, AutoTune: true}
+	if _, err := RunAutoTuneMulti("-", cfg, 0); err == nil {
+		t.Fatal("expected auto-tune over stdin to be rejected")
+	}
+}


### PR DESCRIPTION
## Summary

Adds the offline half of #314 (decode an IQ stream from stdin, output to stdout): `gophertrunk replay -in -` reads a raw IQ stream from standard input instead of a file, so an external IQ source can pipe a capture straight into the decoder. Decoded events already go to stdout via `-out-format`, so this covers both "decode IQ from stdin" and "out to stdout" for a piped capture:

```
iq-source | gophertrunk replay -in - -format f32 -sample-rate 2400000 \
              -protocol p25p1 -tune-hz -12500 -out-format jsonl
```

## Changes

- **`internal/siglab/engine.go`** — a shared `openCapture(path)` helper maps the `-` sentinel to `os.Stdin` (wrapped in a no-op `Closer` so decoding never closes the process's real stdin) and reports the source as `"stdin"`. `RunStream` (behind `replay`'s non-auto-tune path) uses it, streaming from stdin with bounded memory. `RunAutoTuneMulti("-")` is rejected with a clear message — auto-tune reads a prefix then seeks back, which a one-way pipe can't do — instead of a confusing `os.Open("-")` failure.
- **`cmd/gophertrunk/replay.go`** — `-in` help + a stdin usage example.
- **`internal/siglab/engine_stdin_test.go`** — failing-first tests.

## Test plan

- [x] `make vet test` is green locally (`go vet ./...` clean; full `go test ./...` exit 0)
- [ ] `make integration` — n/a (no daemon/DSP-pipeline change)
- [x] Added tests: decoding a synthesized P25 capture through a swapped `os.Stdin` locks and matches the file-path Result (with `Source == "stdin"`); `openCapture` resolves `-` to a no-op-closing stdin and still opens real paths / errors on missing ones; auto-tune over stdin is rejected.
- [ ] Smoke-tested against real hardware — n/a (pure I/O plumbing on the existing decode path)

## Breaking changes

None. `-` is a new sentinel for `-in`; every existing file path behaves exactly as before (`openCapture` only special-cases the literal `-`).

## Docs / CHANGELOG

- [ ] CHANGELOG — a one-line `## [Unreleased]` bullet would fit if you'd like ("`replay -in -` reads IQ from stdin"); happy to add it.
- [x] `-in` flag help + a piped-stdin example in `replay -h`

## Linked issues

Refs #314

**Scope note:** this is the finite/piped-capture case (the `replay` offline decoder). A live, *unbounded* stdin IQ source feeding the daemon's scanner/recorder pipeline (a continuous OpenWebRX+ feed) is a larger follow-up in the SDR device layer — I can take that next if that's the shape you want. Flagging it so the reviewer can steer scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUs7kTzCMcnykc3d4kdUer

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUs7kTzCMcnykc3d4kdUer)_