### PR TITLE
Show the source radio's alias on call history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **Call history now shows who was talking, not just the RID number.** Each
+  call record carries a `source_alpha` field resolving the source radio's
+  alias/name — preferring the operator-curated RID catalogue (`rid_alias_file`)
+  and falling back to the most-recently-decoded over-the-air talker alias. The
+  alias is persisted to the call log and returned by the `/api/v1/calls`
+  history endpoint alongside the existing talkgroup alias, and is re-resolved
+  at call end so a compressed grant whose source RID is backfilled mid-call
+  still lands with a name.
 - **TETRA call priority is now surfaced.** The CMCE parser already decoded
   the mandatory 4-bit Call priority (and derived the emergency flag from it);
   the value now reaches `Grant.Priority` and the call log, extending on-air

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -2340,6 +2340,25 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 			db.Close()
 			return nil, fmt.Errorf("daemon: call log: %w", err)
 		}
+		// Resolve the source radio's alias/name onto each call record so call
+		// history shows "who was talking", not just the RID number. Prefer the
+		// operator-curated RID catalogue (rid_alias_file); fall back to the
+		// most-recently-decoded over-the-air talker alias.
+		if d.rids != nil || d.affiliations != nil {
+			cl.SetRIDResolver(func(id uint32) string {
+				if d.rids != nil {
+					if r := d.rids.Lookup(id); r != nil && r.Alias != "" {
+						return r.Alias
+					}
+				}
+				if d.affiliations != nil {
+					if u, ok := d.affiliations.Lookup(id); ok {
+						return u.TalkerAlias
+					}
+				}
+				return ""
+			})
+		}
 		d.callLog = cl
 
 		ll, err := storage.NewLocationLog(db, d.bus, log)

--- a/internal/storage/calllog.go
+++ b/internal/storage/calllog.go
@@ -28,6 +28,25 @@ type CallLog struct {
 	sub       *events.Subscription
 	runDone   chan struct{}
 	closeOnce sync.Once
+	// ridAlias resolves a source radio ID to its human alias/name (from the
+	// operator RID catalogue + live-decoded talker aliases). Optional — nil
+	// leaves source_alpha unresolved. Set via SetRIDResolver.
+	ridAlias func(radioID uint32) string
+}
+
+// SetRIDResolver installs the source-radio alias resolver used to stamp
+// source_alpha onto call records — "who was talking", not just the RID.
+// Safe to call once before Run. A nil fn (or nil resolver) leaves
+// source_alpha NULL.
+func (c *CallLog) SetRIDResolver(fn func(radioID uint32) string) { c.ridAlias = fn }
+
+// sourceAlpha resolves the source radio's alias, or "" when no resolver is
+// set or the radio is unknown / anonymous (id 0).
+func (c *CallLog) sourceAlpha(radioID uint32) string {
+	if c.ridAlias == nil || radioID == 0 {
+		return ""
+	}
+	return c.ridAlias(radioID)
 }
 
 // NewCallLog wires the call log to the bus. It subscribes immediately
@@ -102,14 +121,14 @@ func (c *CallLog) recordStart(cs trunking.CallStart) error {
 INSERT OR REPLACE INTO call_log (
     system, protocol, group_id, source_id, frequency_hz,
     encrypted, algorithm_id, key_id, emergency, data_call, timeslot, priority,
-    device_serial, started_at, talkgroup_alpha
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    device_serial, started_at, talkgroup_alpha, source_alpha
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 	_, err := c.db.sql.Exec(q,
 		cs.Grant.System, cs.Grant.Protocol, cs.Grant.GroupID, cs.Grant.SourceID, cs.Grant.FrequencyHz,
 		boolToInt(cs.Grant.Encrypted), cs.Grant.AlgorithmID, cs.Grant.KeyID,
 		boolToInt(cs.Grant.Emergency), boolToInt(cs.Grant.DataCall), cs.Grant.Timeslot, cs.Grant.Priority,
 		cs.DeviceSerial, cs.StartedAt.UnixNano(),
-		alpha,
+		alpha, c.sourceAlpha(cs.Grant.SourceID),
 	)
 	return err
 }
@@ -156,6 +175,7 @@ UPDATE call_log
        encrypted    = CASE WHEN ? != 0 THEN 1 ELSE encrypted END,
        algorithm_id = COALESCE(NULLIF(?, 0), algorithm_id),
        key_id       = COALESCE(NULLIF(?, 0), key_id),
+       source_alpha = COALESCE(NULLIF(?, ''), source_alpha),
        signal_dbfs  = COALESCE(?, signal_dbfs),
        evm_pct      = COALESCE(?, evm_pct),
        snr_db       = COALESCE(?, snr_db)
@@ -168,6 +188,9 @@ UPDATE call_log
 		boolToInt(ce.Grant.Encrypted),
 		ce.Grant.AlgorithmID,
 		ce.Grant.KeyID,
+		// Re-resolve from the end grant's SourceID: a compressed grant's RID is
+		// backfilled mid-call, so the source alias may only be resolvable now.
+		c.sourceAlpha(ce.Grant.SourceID),
 		sig,
 		evm,
 		snr,
@@ -211,6 +234,10 @@ type CallRow struct {
 	DurationMs     int64     `json:"duration_ms,omitempty"`
 	EndReason      string    `json:"end_reason,omitempty"`
 	TalkgroupAlpha string    `json:"talkgroup_alpha,omitempty"`
+	// SourceAlpha is the resolved alias/name of the source radio (RID), from
+	// the operator RID catalogue + live-decoded talker aliases; "" when
+	// unresolved.
+	SourceAlpha string `json:"source_alpha,omitempty"`
 	// SignalDbFS is the call's mean received channel power in dBFS
 	// (channel power, not calibrated RSSI or SNR). nil when unmeasured.
 	SignalDbFS *float64 `json:"signal_dbfs,omitempty"`
@@ -227,7 +254,7 @@ func (d *DB) History(ctx context.Context, f HistoryFilter) ([]CallRow, error) {
 	q := `SELECT id, system, protocol, group_id, source_id, frequency_hz,
 	             encrypted, algorithm_id, key_id, emergency, data_call, timeslot, priority,
 	             device_serial, started_at, ended_at, duration_ms,
-	             end_reason, talkgroup_alpha, signal_dbfs, evm_pct, snr_db
+	             end_reason, talkgroup_alpha, source_alpha, signal_dbfs, evm_pct, snr_db
 	      FROM call_log WHERE 1=1`
 	args := []any{}
 	if f.System != "" {
@@ -270,13 +297,13 @@ func (d *DB) History(ctx context.Context, f HistoryFilter) ([]CallRow, error) {
 		var endNs sql.NullInt64
 		var durMs sql.NullInt64
 		var reason sql.NullString
-		var alpha sql.NullString
+		var alpha, srcAlpha sql.NullString
 		var sig, evm, snr sql.NullFloat64
 		var enc, emer, data, algID, keyID, slot, prio int
 		if err := rows.Scan(
 			&r.ID, &r.System, &r.Protocol, &r.GroupID, &r.SourceID, &r.FrequencyHz,
 			&enc, &algID, &keyID, &emer, &data, &slot, &prio, &r.DeviceSerial,
-			&startNs, &endNs, &durMs, &reason, &alpha, &sig, &evm, &snr,
+			&startNs, &endNs, &durMs, &reason, &alpha, &srcAlpha, &sig, &evm, &snr,
 		); err != nil {
 			return nil, err
 		}
@@ -299,6 +326,9 @@ func (d *DB) History(ctx context.Context, f HistoryFilter) ([]CallRow, error) {
 		}
 		if alpha.Valid {
 			r.TalkgroupAlpha = alpha.String
+		}
+		if srcAlpha.Valid {
+			r.SourceAlpha = srcAlpha.String
 		}
 		if sig.Valid {
 			v := sig.Float64

--- a/internal/storage/calllog_test.go
+++ b/internal/storage/calllog_test.go
@@ -150,6 +150,63 @@ func TestCallLogPersistsTimeslot(t *testing.T) {
 	}
 }
 
+// TestCallLogPersistsSourceAlias pins the source-radio alias resolution:
+// the call record carries "who was talking", resolved from the RID via the
+// injected resolver, and re-resolved at CallEnd when a compressed grant's
+// RID is only backfilled mid-call.
+func TestCallLogPersistsSourceAlias(t *testing.T) {
+	db := openTestDB(t)
+	bus := events.NewBus(8)
+	defer bus.Close()
+	cl, err := NewCallLog(db, bus, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cl.SetRIDResolver(func(id uint32) string {
+		if id == 4242 {
+			return "DISPATCH-1"
+		}
+		return ""
+	})
+	defer cl.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go cl.Run(ctx)
+
+	start := time.Now().UTC()
+	// A compressed grant: source unknown at start, backfilled by CallEnd.
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: trunking.CallStart{
+		Grant:        trunking.Grant{System: "P25A", Protocol: "p25", GroupID: 100, SourceID: 0, FrequencyHz: 851_000_000},
+		DeviceSerial: "VOICE-9",
+		StartedAt:    start,
+	}})
+	bus.Publish(events.Event{Kind: events.KindCallEnd, Payload: trunking.CallEnd{
+		Grant:        trunking.Grant{System: "P25A", Protocol: "p25", GroupID: 100, SourceID: 4242, FrequencyHz: 851_000_000},
+		DeviceSerial: "VOICE-9",
+		StartedAt:    start,
+		EndedAt:      start.Add(3 * time.Second),
+		Reason:       trunking.EndReasonReleased,
+	}})
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if rows, _ := db.History(context.Background(), HistoryFilter{Limit: 1}); len(rows) == 1 && rows[0].EndedAt.After(start) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	rows, _ := db.History(context.Background(), HistoryFilter{Limit: 1})
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want 1", len(rows))
+	}
+	if rows[0].SourceID != 4242 {
+		t.Fatalf("source_id = %d, want 4242 (backfilled)", rows[0].SourceID)
+	}
+	if rows[0].SourceAlpha != "DISPATCH-1" {
+		t.Errorf("source_alpha = %q, want DISPATCH-1", rows[0].SourceAlpha)
+	}
+}
+
 // TestCallLogPersistsPriority pins the Grant.Priority → call_log round-trip
 // so the on-air call priority surfaces in history and the REST API.
 func TestCallLogPersistsPriority(t *testing.T) {

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -82,6 +82,7 @@ CREATE TABLE IF NOT EXISTS call_log (
     timeslot        INTEGER NOT NULL DEFAULT 0,  -- DMR TDMA slot: 0=n/a, 1=TS1, 2=TS2
     priority        INTEGER NOT NULL DEFAULT 0,  -- on-air signalled call priority (service-options low 3 bits)
     device_serial   TEXT    NOT NULL,
+    source_alpha    TEXT,  -- resolved alias/name of the source radio (RID); NULL = unresolved
     started_at      INTEGER NOT NULL,  -- unix nanoseconds
     ended_at        INTEGER,
     duration_ms     INTEGER,
@@ -380,6 +381,7 @@ func (d *DB) ensureCallLogColumns() error {
 		{"key_id", `ALTER TABLE call_log ADD COLUMN key_id INTEGER NOT NULL DEFAULT 0`},
 		{"timeslot", `ALTER TABLE call_log ADD COLUMN timeslot INTEGER NOT NULL DEFAULT 0`},
 		{"priority", `ALTER TABLE call_log ADD COLUMN priority INTEGER NOT NULL DEFAULT 0`},
+		{"source_alpha", `ALTER TABLE call_log ADD COLUMN source_alpha TEXT`},
 		// Nullable (no DEFAULT) so a row with no measurement reads NULL —
 		// "unset" is distinct from a legitimate 0 dBFS reading.
 		{"signal_dbfs", `ALTER TABLE call_log ADD COLUMN signal_dbfs REAL`},

--- a/internal/trunking/affiliation_tracker.go
+++ b/internal/trunking/affiliation_tracker.go
@@ -237,6 +237,18 @@ func (t *AffiliationTracker) Snapshot() []UnitActivity {
 	return out
 }
 
+// Lookup returns the tracked activity for a radio ID (a copy, safe to
+// retain), and false when the unit is not currently tracked. Used to
+// resolve a radio's most-recently-decoded talker alias.
+func (t *AffiliationTracker) Lookup(radioID uint32) (UnitActivity, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if u, ok := t.units[radioID]; ok {
+		return *u, true
+	}
+	return UnitActivity{}, false
+}
+
 // UnitsOnTalkgroup returns the radio IDs currently associated with the
 // given talkgroup.
 func (t *AffiliationTracker) UnitsOnTalkgroup(talkgroup uint32) []uint32 {


### PR DESCRIPTION
## Summary

Call history records who a call was *to* (the talkgroup, with its alias) but only ever recorded who it was *from* as a bare RID number. This surfaces the source radio's alias/name on every call record — "who was talking" — reusing data GopherTrunk already has (the operator RID catalogue and live-decoded talker aliases), with no new decoding.

## Changes

- **storage:** new additive `source_alpha` column on `call_log` (fresh-DB schema + migration). `CallLog.SetRIDResolver` installs a resolver; `source_alpha` is stamped at CallStart and re-resolved at CallEnd (a compressed grant's source RID is only backfilled mid-call). Never clobbered by a later empty resolution; nil resolver leaves it NULL. Surfaced on the `CallRow` JSON returned by `GET /api/v1/calls`.
- **daemon:** wires the resolver — prefer the operator-curated RID catalogue (`rid_alias_file`), fall back to the most-recently-decoded over-the-air talker alias from the affiliation tracker.
- **trunking:** `AffiliationTracker.Lookup(radioID)` returns a copy of a unit's tracked activity so the resolver can read its live talker alias without racing the tracker's map.
- **test:** `TestCallLogPersistsSourceAlias` publishes a compressed-grant call (source unknown at start, RID 4242 backfilled at end) and asserts the alias resolves to the injected name — fails without the storage change.

## Test plan

- [x] `make vet test` is green locally
- [x] `make integration` is green locally (daemon touched)
- [x] Added a regression test for the new behaviour
- [ ] Smoke-tested against real hardware — n/a (no DSP/vocoder/USB code changed; resolver is fed by already-decoded metadata)

## Breaking changes

None. Additive nullable column (migrated on existing DBs), additive JSON field (`omitempty`), and a new setter with a nil-safe default — existing callers and the on-disk schema are unaffected.

## Docs / CHANGELOG

- [x] Added an `## [Unreleased]` bullet to `CHANGELOG.md`
- [ ] README/docs — n/a (no config keys, CLI flags, or endpoint shapes changed)

## Linked issues

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0144w5FXPjW3oeryHqugKAjP)_