### PR TITLE
Complete call-history metadata: mid-call emergency/priority + unit-to-unit flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **Unit-to-unit / private calls are now flagged in call history.** The
+  `Individual` grant flag (the call's `group_id` is a target radio address,
+  not a talkgroup) already reached the live-grant API but was dropped from the
+  call record, so a followed private call was indistinguishable from a group
+  call in history and its 24-bit target rendered as a phantom talkgroup. Each
+  call record now carries an `individual` field (persisted at call start and
+  latched on at call end for TETRA, which cannot flag a unit-to-unit
+  destination on first sighting), returned by the `/api/v1/calls` endpoint.
 - **Call history now shows who was talking, not just the RID number.** Each
   call record carries a `source_alpha` field resolving the source radio's
   alias/name — preferring the operator-curated RID catalogue (`rid_alias_file`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,14 @@ for tagged releases.
   DMR voice chain now backfills them (plus the source RID) from the embedded
   voice LC via the in-call `CallSourceUpdate` path the P25 Phase 2 chain
   already uses — so an encrypted Tier III call is now recorded as encrypted.
+- **Mid-call emergency / priority was still dropped at the call record.**
+  The engine backfills a followed call's Emergency and Priority (decoded on
+  the traffic channel, since a DMR Tier III / P25 Phase 2 grant carries no
+  Service Options) onto the bound grant, but the call-log end update only
+  persisted the backfilled encrypted flag and source RID — so an emergency
+  Tier III call was still written non-emergency at priority 0. The end update
+  now latches emergency on and takes a non-zero priority, the same
+  never-downgrade discipline it already applied to encrypted.
 
 ### Added
 - **`gophertrunk replay -record-voice -out-dir <dir> -freq <Hz>`** decodes and

--- a/internal/storage/calllog.go
+++ b/internal/storage/calllog.go
@@ -145,9 +145,12 @@ func (c *CallLog) recordEnd(ce trunking.CallEnd) error {
 	//
 	// The guards mirror the voice pool's never-downgrade semantics
 	// (UpdateSource / UpdateEncryption): COALESCE(NULLIF(?, 0), col) keeps a
-	// legitimate start-time value when the end grant is still zero, and the
-	// CASE only ever upgrades encrypted (the spec defines no mid-call
-	// decryption).
+	// legitimate start-time value when the end grant is still zero (source_id,
+	// algorithm_id, key_id, priority), and the CASE only ever latches
+	// encrypted / emergency on (never off). A DMR Tier III / P25 Phase 2 grant
+	// carries no Service Options, so the emergency + priority bits arrive only
+	// on the traffic channel (UpdateSource) and must be persisted here, the
+	// same way encrypted already is.
 	// signal_dbfs uses COALESCE(?, signal_dbfs) with a NULL-valued bind
 	// when the call carried no measurement, so a non-composer end (watchdog
 	// timeout, preemption, shutdown) never clobbers a value an earlier
@@ -173,8 +176,10 @@ UPDATE call_log
        end_reason = ?,
        source_id    = COALESCE(NULLIF(?, 0), source_id),
        encrypted    = CASE WHEN ? != 0 THEN 1 ELSE encrypted END,
+       emergency    = CASE WHEN ? != 0 THEN 1 ELSE emergency END,
        algorithm_id = COALESCE(NULLIF(?, 0), algorithm_id),
        key_id       = COALESCE(NULLIF(?, 0), key_id),
+       priority     = COALESCE(NULLIF(?, 0), priority),
        source_alpha = COALESCE(NULLIF(?, ''), source_alpha),
        signal_dbfs  = COALESCE(?, signal_dbfs),
        evm_pct      = COALESCE(?, evm_pct),
@@ -186,8 +191,10 @@ UPDATE call_log
 		ce.Reason.String(),
 		ce.Grant.SourceID,
 		boolToInt(ce.Grant.Encrypted),
+		boolToInt(ce.Grant.Emergency),
 		ce.Grant.AlgorithmID,
 		ce.Grant.KeyID,
+		ce.Grant.Priority,
 		// Re-resolve from the end grant's SourceID: a compressed grant's RID is
 		// backfilled mid-call, so the source alias may only be resolvable now.
 		c.sourceAlpha(ce.Grant.SourceID),

--- a/internal/storage/calllog.go
+++ b/internal/storage/calllog.go
@@ -120,13 +120,14 @@ func (c *CallLog) recordStart(cs trunking.CallStart) error {
 	const q = `
 INSERT OR REPLACE INTO call_log (
     system, protocol, group_id, source_id, frequency_hz,
-    encrypted, algorithm_id, key_id, emergency, data_call, timeslot, priority,
+    encrypted, algorithm_id, key_id, emergency, data_call, individual, timeslot, priority,
     device_serial, started_at, talkgroup_alpha, source_alpha
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 	_, err := c.db.sql.Exec(q,
 		cs.Grant.System, cs.Grant.Protocol, cs.Grant.GroupID, cs.Grant.SourceID, cs.Grant.FrequencyHz,
 		boolToInt(cs.Grant.Encrypted), cs.Grant.AlgorithmID, cs.Grant.KeyID,
-		boolToInt(cs.Grant.Emergency), boolToInt(cs.Grant.DataCall), cs.Grant.Timeslot, cs.Grant.Priority,
+		boolToInt(cs.Grant.Emergency), boolToInt(cs.Grant.DataCall), boolToInt(cs.Grant.Individual),
+		cs.Grant.Timeslot, cs.Grant.Priority,
 		cs.DeviceSerial, cs.StartedAt.UnixNano(),
 		alpha, c.sourceAlpha(cs.Grant.SourceID),
 	)
@@ -147,10 +148,12 @@ func (c *CallLog) recordEnd(ce trunking.CallEnd) error {
 	// (UpdateSource / UpdateEncryption): COALESCE(NULLIF(?, 0), col) keeps a
 	// legitimate start-time value when the end grant is still zero (source_id,
 	// algorithm_id, key_id, priority), and the CASE only ever latches
-	// encrypted / emergency on (never off). A DMR Tier III / P25 Phase 2 grant
-	// carries no Service Options, so the emergency + priority bits arrive only
-	// on the traffic channel (UpdateSource) and must be persisted here, the
-	// same way encrypted already is.
+	// encrypted / emergency / individual on (never off). A DMR Tier III / P25
+	// Phase 2 grant carries no Service Options, so the emergency + priority bits
+	// arrive only on the traffic channel (UpdateSource) and must be persisted
+	// here, the same way encrypted already is. individual latches on too: a
+	// TETRA unit-to-unit destination cannot be flagged on first sighting, so a
+	// call can be recognised as individual after its start row is written.
 	// signal_dbfs uses COALESCE(?, signal_dbfs) with a NULL-valued bind
 	// when the call carried no measurement, so a non-composer end (watchdog
 	// timeout, preemption, shutdown) never clobbers a value an earlier
@@ -177,6 +180,7 @@ UPDATE call_log
        source_id    = COALESCE(NULLIF(?, 0), source_id),
        encrypted    = CASE WHEN ? != 0 THEN 1 ELSE encrypted END,
        emergency    = CASE WHEN ? != 0 THEN 1 ELSE emergency END,
+       individual   = CASE WHEN ? != 0 THEN 1 ELSE individual END,
        algorithm_id = COALESCE(NULLIF(?, 0), algorithm_id),
        key_id       = COALESCE(NULLIF(?, 0), key_id),
        priority     = COALESCE(NULLIF(?, 0), priority),
@@ -192,6 +196,7 @@ UPDATE call_log
 		ce.Grant.SourceID,
 		boolToInt(ce.Grant.Encrypted),
 		boolToInt(ce.Grant.Emergency),
+		boolToInt(ce.Grant.Individual),
 		ce.Grant.AlgorithmID,
 		ce.Grant.KeyID,
 		ce.Grant.Priority,
@@ -230,6 +235,9 @@ type CallRow struct {
 	KeyID       uint16 `json:"key_id"`
 	Emergency   bool   `json:"emergency"`
 	DataCall    bool   `json:"data_call"`
+	// Individual is true for a unit-to-unit / private call, where GroupID is a
+	// target radio address rather than a talkgroup. Omitted for group calls.
+	Individual bool `json:"individual,omitempty"`
 	// Timeslot is the 1-based DMR TDMA slot (0 = n/a, 1 = TS1, 2 = TS2).
 	Timeslot uint8 `json:"timeslot,omitempty"`
 	// Priority is the call's on-air signalled priority (service-options low
@@ -259,7 +267,7 @@ type CallRow struct {
 // History queries the call_log with the supplied filter, newest-first.
 func (d *DB) History(ctx context.Context, f HistoryFilter) ([]CallRow, error) {
 	q := `SELECT id, system, protocol, group_id, source_id, frequency_hz,
-	             encrypted, algorithm_id, key_id, emergency, data_call, timeslot, priority,
+	             encrypted, algorithm_id, key_id, emergency, data_call, individual, timeslot, priority,
 	             device_serial, started_at, ended_at, duration_ms,
 	             end_reason, talkgroup_alpha, source_alpha, signal_dbfs, evm_pct, snr_db
 	      FROM call_log WHERE 1=1`
@@ -306,10 +314,10 @@ func (d *DB) History(ctx context.Context, f HistoryFilter) ([]CallRow, error) {
 		var reason sql.NullString
 		var alpha, srcAlpha sql.NullString
 		var sig, evm, snr sql.NullFloat64
-		var enc, emer, data, algID, keyID, slot, prio int
+		var enc, emer, data, indiv, algID, keyID, slot, prio int
 		if err := rows.Scan(
 			&r.ID, &r.System, &r.Protocol, &r.GroupID, &r.SourceID, &r.FrequencyHz,
-			&enc, &algID, &keyID, &emer, &data, &slot, &prio, &r.DeviceSerial,
+			&enc, &algID, &keyID, &emer, &data, &indiv, &slot, &prio, &r.DeviceSerial,
 			&startNs, &endNs, &durMs, &reason, &alpha, &srcAlpha, &sig, &evm, &snr,
 		); err != nil {
 			return nil, err
@@ -319,6 +327,7 @@ func (d *DB) History(ctx context.Context, f HistoryFilter) ([]CallRow, error) {
 		r.KeyID = uint16(keyID)
 		r.Emergency = emer != 0
 		r.DataCall = data != 0
+		r.Individual = indiv != 0
 		r.Timeslot = uint8(slot)
 		r.Priority = uint8(prio)
 		r.StartedAt = time.Unix(0, startNs).UTC()

--- a/internal/storage/calllog_test.go
+++ b/internal/storage/calllog_test.go
@@ -247,6 +247,50 @@ func TestCallLogPersistsPriority(t *testing.T) {
 	}
 }
 
+// TestCallLogPersistsIndividual pins the Grant.Individual → call_log
+// round-trip: a unit-to-unit / private call must be distinguishable in
+// history from a group call, since its GroupID is a target radio address
+// rather than a talkgroup and would otherwise render as a phantom talkgroup.
+func TestCallLogPersistsIndividual(t *testing.T) {
+	db, bus := runningCallLog(t)
+
+	startedAt := time.Now().UTC().Truncate(time.Microsecond)
+	// A TETRA unit-to-unit call: GroupID is the target radio (ISSI).
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: trunking.CallStart{
+		Grant: trunking.Grant{
+			System: "TET", Protocol: "tetra",
+			GroupID: 1005372, SourceID: 1020545, FrequencyHz: 467_912_500, Individual: true,
+		},
+		DeviceSerial: "VOICE-IND", StartedAt: startedAt,
+	}})
+
+	rows := waitHistory(t, db, HistoryFilter{Limit: 1}, func(r []CallRow) bool {
+		return len(r) == 1 && r[0].Individual
+	})
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want 1", len(rows))
+	}
+	if !rows[0].Individual {
+		t.Errorf("Individual = false, want true for a unit-to-unit call")
+	}
+
+	// A group call in the same table must stay Individual=false.
+	group := time.Now().UTC().Truncate(time.Microsecond)
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: trunking.CallStart{
+		Grant: trunking.Grant{
+			System: "TET", Protocol: "tetra",
+			GroupID: 1020545, SourceID: 7, FrequencyHz: 467_912_500,
+		},
+		DeviceSerial: "VOICE-GRP", StartedAt: group,
+	}})
+	all := waitHistory(t, db, HistoryFilter{Limit: 2}, func(r []CallRow) bool { return len(r) == 2 })
+	for _, r := range all {
+		if r.DeviceSerial == "VOICE-GRP" && r.Individual {
+			t.Errorf("group call flagged Individual")
+		}
+	}
+}
+
 func TestCallLogIdempotentStart(t *testing.T) {
 	db := openTestDB(t)
 	bus := events.NewBus(8)
@@ -797,6 +841,9 @@ CREATE TABLE call_log (
 	}
 	if rows[0].Timeslot != 0 {
 		t.Errorf("migrated row: timeslot=%d, want 0 (column added with default)", rows[0].Timeslot)
+	}
+	if rows[0].Individual {
+		t.Errorf("migrated row: individual=true, want false (column added with default 0)")
 	}
 	if rows[0].SignalDbFS != nil {
 		t.Errorf("migrated row: signal_dbfs=%v, want nil (nullable column added, old row NULL)", *rows[0].SignalDbFS)

--- a/internal/storage/calllog_test.go
+++ b/internal/storage/calllog_test.go
@@ -486,6 +486,48 @@ func TestCallLogBackfillsEncryptionOnEnd(t *testing.T) {
 	}
 }
 
+// TestCallLogBackfillsEmergencyPriorityOnEnd models a DMR Tier III / P25
+// Phase 2 call whose grant carries no Service Options: the Emergency /
+// Priority bits only arrive on the traffic channel (GROUP_VOICE_CHANNEL_USER
+// → CallSourceUpdate → VoicePool.UpdateSource), so the start grant is clear
+// and recordEnd must persist the values the engine backfilled onto the bound
+// grant — the same discipline recordEnd already applies to Encrypted.
+func TestCallLogBackfillsEmergencyPriorityOnEnd(t *testing.T) {
+	db, bus := runningCallLog(t)
+
+	startedAt := time.Now().UTC().Truncate(time.Microsecond)
+	startGrant := trunking.Grant{
+		System: "T3", Protocol: "dmr", GroupID: 100, SourceID: 42,
+		FrequencyHz: 851_000_000, Emergency: false, Priority: 0,
+	}
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: trunking.CallStart{
+		Grant: startGrant, DeviceSerial: "VOICE-EP", StartedAt: startedAt,
+	}})
+	waitHistory(t, db, HistoryFilter{Limit: 1}, func(r []CallRow) bool { return len(r) == 1 })
+
+	// The embedded voice LC backfills Emergency + Priority onto the bound grant.
+	endGrant := startGrant
+	endGrant.Emergency = true
+	endGrant.Priority = 5
+	bus.Publish(events.Event{Kind: events.KindCallEnd, Payload: trunking.CallEnd{
+		Grant:        endGrant,
+		DeviceSerial: "VOICE-EP",
+		StartedAt:    startedAt,
+		EndedAt:      startedAt.Add(time.Second),
+		Reason:       trunking.EndReasonNormal,
+	}})
+
+	rows := waitHistory(t, db, HistoryFilter{Limit: 1}, func(r []CallRow) bool {
+		return len(r) == 1 && r[0].Emergency
+	})
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want 1", len(rows))
+	}
+	if r := rows[0]; !r.Emergency || r.Priority != 5 {
+		t.Errorf("row = {emergency:%v priority:%d}, want {true 5}", r.Emergency, r.Priority)
+	}
+}
+
 // TestCallLogEndDoesNotDowngrade confirms the never-downgrade guards: a
 // known start-time RID survives a zero-source end grant, and a call that
 // started encrypted stays encrypted even if the end grant reports clear.
@@ -496,6 +538,7 @@ func TestCallLogEndDoesNotDowngrade(t *testing.T) {
 	startGrant := trunking.Grant{
 		System: "Alpha", Protocol: "p25", GroupID: 1, SourceID: 5150,
 		FrequencyHz: 851_000_000, Encrypted: true, AlgorithmID: 0x84, KeyID: 3,
+		Emergency: true, Priority: 7,
 	}
 	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: trunking.CallStart{
 		Grant: startGrant, DeviceSerial: "VOICE-3", StartedAt: startedAt,
@@ -523,6 +566,10 @@ func TestCallLogEndDoesNotDowngrade(t *testing.T) {
 	if !r.Encrypted || r.AlgorithmID != 0x84 || r.KeyID != 3 {
 		t.Errorf("identity downgraded: {enc:%v alg:%#x key:%d}, want {true 0x84 3}",
 			r.Encrypted, r.AlgorithmID, r.KeyID)
+	}
+	if !r.Emergency || r.Priority != 7 {
+		t.Errorf("flags downgraded: {emergency:%v priority:%d}, want {true 7}",
+			r.Emergency, r.Priority)
 	}
 }
 

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -79,6 +79,7 @@ CREATE TABLE IF NOT EXISTS call_log (
     key_id          INTEGER NOT NULL DEFAULT 0,
     emergency       INTEGER NOT NULL DEFAULT 0,
     data_call       INTEGER NOT NULL DEFAULT 0,
+    individual      INTEGER NOT NULL DEFAULT 0,  -- 1 = unit-to-unit / private call (group_id is a target radio, not a talkgroup)
     timeslot        INTEGER NOT NULL DEFAULT 0,  -- DMR TDMA slot: 0=n/a, 1=TS1, 2=TS2
     priority        INTEGER NOT NULL DEFAULT 0,  -- on-air signalled call priority (service-options low 3 bits)
     device_serial   TEXT    NOT NULL,
@@ -389,6 +390,7 @@ func (d *DB) ensureCallLogColumns() error {
 		// call's chain fed no demod taps (every protocol but P25 Phase 1).
 		{"evm_pct", `ALTER TABLE call_log ADD COLUMN evm_pct REAL`},
 		{"snr_db", `ALTER TABLE call_log ADD COLUMN snr_db REAL`},
+		{"individual", `ALTER TABLE call_log ADD COLUMN individual INTEGER NOT NULL DEFAULT 0`},
 	}
 	for _, a := range adds {
 		if have[a.name] {


### PR DESCRIPTION
## Summary

Two closely-related call-history metadata gaps, both cases of data GopherTrunk already decodes (and already surfaces on the live-grant API) being dropped from the persisted call record:

1. **Mid-call emergency / priority was dropped.** A DMR Tier III channel-grant CSBK (and a P25 Phase 2 compressed grant) carries no Service Options octet, so a followed call's Emergency and Priority are decoded only on the traffic channel and backfilled onto the bound grant (`CallSourceUpdate` → `VoicePool.UpdateSource`). `recordEnd` persisted the backfilled *encrypted* flag and source RID but not *emergency* / *priority* — so an emergency Tier III call was still recorded non-emergency at priority 0.
2. **Unit-to-unit / private calls weren't flagged.** The `Individual` grant flag (the call's `group_id` is a target radio address, not a talkgroup) reached the live-grant API DTO but was dropped from the call record, so a private call was indistinguishable from a group call in history and its 24-bit target rendered as a phantom talkgroup.

## Changes

- **storage (fix):** `recordEnd`'s UPDATE now latches `emergency` on (`CASE WHEN ? != 0` — like `encrypted`, never off) and takes a non-zero `priority` (`COALESCE(NULLIF(?, 0), …)` — like `source_id`, never downgraded).
- **storage (added):** new additive `individual` column (fresh-DB schema + migration); persisted at `recordStart` and latched on at `recordEnd` (a TETRA unit-to-unit destination can't be flagged on first sighting, so a call may be recognised as individual after its start row is written). Surfaced on the `CallRow` JSON (`/api/v1/calls`).
- **tests:**
  - `TestCallLogBackfillsEmergencyPriorityOnEnd` — clear start grant, emergency+priority end grant; fails without the fix (`{emergency:false priority:0}`).
  - `TestCallLogEndDoesNotDowngrade` extended to assert a blank end grant can't clear a start-time emergency/priority.
  - `TestCallLogPersistsIndividual` — individual round-trips; a group call stays `false`.
  - `TestMigrationAddsEncryptionColumns` extended to assert `individual` migrates with default 0.

## Test plan

- [x] `make vet test` is green locally
- [x] New regression tests fail first, pass with the changes
- [ ] `make integration` — n/a (storage-only; no daemon/DSP/replay code touched)
- [ ] Smoke-tested against real hardware — n/a (SQL-only changes)

## Breaking changes

None. One additive nullable-defaulted column (migrated on existing DBs), one additive JSON field (`omitempty`); event shapes unchanged. Never-downgrade guards preserve existing start-time values.

## Docs / CHANGELOG

- [x] Added `## [Unreleased]` bullets to `CHANGELOG.md` (one `Fixed`, one `Added`)
- [ ] README/docs — n/a

## Linked issues

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)