### PR TITLE
p25p2: gate control-channel grant algid on the TIA-102 registry (#924)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,15 @@ for tagged releases.
   call-priority metadata to TETRA alongside P25 and DMR.
 
 ### Fixed
+- **P25 Phase 2 grants could carry a garbage encryption Algorithm ID.** A
+  bit-errored MAC Encryption Sync decodes to an Algorithm ID outside the
+  TIA-102 registry; the control channel stored any decoded sync and attached
+  it to every subsequent encrypted grant, so a single mis-decode leaked a
+  plausible-but-wrong `algorithm_id` + `key_id` onto grants (and downstream
+  onto the call record / webhook). It now refuses to store an out-of-set sync
+  as the reference — the same validity gate the voice path already applied —
+  so a protected grant with no valid sync reports encrypted with alg/key 0
+  rather than smearing garbage keys. (#924)
 - **Encrypted / emergency DMR Tier III calls were logged clear.** A DMR
   Tier III channel-grant CSBK carries no service-options octet, so a
   followed call's encrypted / emergency / priority state never reached the

--- a/internal/radio/p25/phase2/control.go
+++ b/internal/radio/p25/phase2/control.go
@@ -654,7 +654,13 @@ func (c *ControlChannel) Ingest(p MACPDU) {
 		c.bandPlan.Apply(u)
 		c.mu.Unlock()
 	}
-	if es, ok := p.AsEncryptionSync(); ok {
+	if es, ok := p.AsEncryptionSync(); ok && p25.AlgorithmKnown(es.AlgorithmID) {
+		// Validity gate (#924): a bit-errored MAC Encryption Sync decodes to an
+		// Algorithm ID outside the TIA-102 registry (the field-observed smear
+		// across 0x00-0xFF, one Key ID per call). Refusing to store an out-of-set
+		// sync keeps a single mis-decode from poisoning lastEncSync and being
+		// attached to every subsequent encrypted grant in publishGrant — the
+		// same gate the voice composer applies before publishing CallEncryption.
 		c.mu.Lock()
 		c.lastEncSync = es
 		c.hasEncSync = true

--- a/internal/radio/p25/phase2/encryption_test.go
+++ b/internal/radio/p25/phase2/encryption_test.go
@@ -134,6 +134,39 @@ func TestControlChannelClearGrantNotEncrypted(t *testing.T) {
 	}
 }
 
+// TestEncryptedGrantDropsOutOfSetAlgID confirms an Encryption Sync whose
+// decoded Algorithm ID is outside the TIA-102 registry (a bit-error smear,
+// issue #924) never becomes the stored crypto reference: a later protected
+// grant flags Encrypted but carries alg/key 0 rather than the garbage algid,
+// so downstream cannot mistake a mis-decode for a real key.
+func TestEncryptedGrantDropsOutOfSetAlgID(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "p2", FrequencyHz: 851_000_000})
+
+	// 0x42 is not a registered TIA-102 Algorithm ID — a mis-decoded sync.
+	cc.Ingest(EncodeEncryptionSync(EncryptionSync{AlgorithmID: 0x42, KeyID: 0x9ABC}))
+
+	g := grantPDU(0xABCD, 0x00ABCD, 0x1, 0x005)
+	g.Payload[0] = 0x40 // protected, no emergency
+	cc.Ingest(g)
+
+	grants := countGrants(sub)
+	if len(grants) != 1 {
+		t.Fatalf("expected 1 grant, got %d", len(grants))
+	}
+	if !grants[0].Encrypted {
+		t.Error("protected grant not flagged Encrypted")
+	}
+	if grants[0].AlgorithmID != 0 || grants[0].KeyID != 0 {
+		t.Errorf("out-of-set algid leaked onto grant: alg/key = %#x/%#x, want 0/0",
+			grants[0].AlgorithmID, grants[0].KeyID)
+	}
+}
+
 // TestEncryptedGrantWithoutSyncDegrades confirms a protected grant with
 // no Encryption Sync seen yet still flags Encrypted, with alg/key 0.
 func TestEncryptedGrantWithoutSyncDegrades(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes a remaining leak behind #924. A bit-errored MAC Encryption Sync decodes to an Algorithm ID outside the TIA-102 registry (the reporter observed a near-uniform smear across `0x00–0xFF`, roughly one distinct `key_id` per garbage call). The **voice composer** already drops out-of-set algids before publishing `CallEncryption` — but the **control channel** stored *any* decoded Encryption Sync as `lastEncSync` and attached it to every subsequent encrypted grant in `publishGrant`, with no validity gate. So a single mis-decode poisoned the reference and leaked a plausible-but-wrong `algorithm_id` + `key_id` onto grants (and downstream onto the call record / webhook), bypassing the composer fix.

## Changes

- **p25/phase2 (fix):** the Encryption Sync ingest now only stores a sync as `lastEncSync` when its Algorithm ID is registered (`p25.AlgorithmKnown`). Gating at the store site keeps a mis-decode from ever becoming the reference, so `publishGrant` naturally only attaches an in-set algid. A protected grant with no valid sync still flags `Encrypted` with alg/key 0, exactly as before.
- **test:** `TestEncryptedGrantDropsOutOfSetAlgID` — ingest an out-of-set sync (`0x42`), then a protected grant; asserts the grant carries alg/key `0/0`. Fails without the gate (`0x42/0x9abc` leaks).

## Test plan

- [x] `make vet test` is green locally
- [x] New regression test fails first, passes with the fix
- [ ] `make integration` — n/a (control-channel parse only; no daemon/DSP/replay code touched)
- [ ] Smoke-tested against real hardware — n/a; validated against synthetic vectors. On-air confirmation against the reporter's evidence in #924 is still welcome before the issue is closed.

## Breaking changes

None. A protected grant whose only Encryption Sync was a mis-decode now reports alg/key 0 instead of a garbage value — strictly a correction. A real in-set sync is stored and attached exactly as before.

## Docs / CHANGELOG

- [x] Added an `## [Unreleased]` → `### Fixed` bullet to `CHANGELOG.md`
- [ ] README/docs — n/a

## Linked issues

Refs #924 (using `Refs`, not `Closes`, until verified against the reporter's live capture per the repo's issue-closing policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0144w5FXPjW3oeryHqugKAjP)_