### PR TITLE
fix(voice/dmr): mute the call-startup acquisition scratch (AMBE2 squelch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,25 @@ for tagged releases.
   as the reference — the same validity gate the voice path already applied —
   so a protected grant with no valid sync reports encrypted with alg/key 0
   rather than smearing garbage keys. (#924)
+- **WebUI live-audio playback: silence, PTT clicks, and dropped calls.** The
+  cockpit's live-audio player rebuilt a fresh `AudioContext` every time it
+  followed a new call, and on teardown only suspended (never closed) it — so on
+  a busy system it hit Chrome's ~6-context-per-page ceiling and went silently
+  dead (worst on macOS Chrome). It now reuses a single context and re-points the
+  stream in place. A short fade envelope in the ring-buffer worklet removes the
+  broadband "DC-spike" click at PTT-in / PTT-out and mid-stream call seams, and a
+  follow-hold policy plays the current call to completion before advancing to the
+  newest — instead of cutting it off the instant a newer grant appears ("eating
+  conversations"). No theme or layout changes.
+- **DMR call-startup "scratch" is now squelched.** The AMBE+2/DMR decoder gained
+  the same call-startup acquisition squelch the P25 IMBE decoder already had:
+  while the receiver is acquiring lock, the FEC resolves the marginal dibit
+  stream to random-but-valid AMBE+2 parameters that synthesise as a loud burst at
+  the start of a transmission. Output is now muted until a sustained run of
+  stable-pitch voiced frames confirms real speech (failsafe-released after ~2 s),
+  removing the per-PTT onset scratch. Opt-in and enabled per call by the
+  recorder; the raw decode path stays byte-identical. (The residual synthetic
+  timbre of software AMBE+2 across a whole call is intrinsic to software decode.)
 - **Encrypted / emergency DMR Tier III calls were logged clear.** A DMR
   Tier III channel-grant CSBK carries no service-options octet, so a
   followed call's encrypted / emergency / priority state never reached the
@@ -56,6 +75,11 @@ for tagged releases.
   never-downgrade discipline it already applied to encrypted.
 
 ### Added
+- **rdio-scanner uploads forward the talkgroup tag and group.** The RdioScanner
+  broadcast backend now sends `talkgroupTag` / `talkgroupGroup` when known, so the
+  console shows GopherTrunk's own tag/group instead of falling back to its static
+  per-system config. (The console's system-type label — e.g. "P25" — is not
+  settable: the call-upload API has no protocol/type field.)
 - **`gophertrunk replay -record-voice -out-dir <dir> -freq <Hz>`** decodes and
   records voice from a capture, not just control-channel locks/grants. It wires
   the production voice path (trunking engine → voice composer → recorder) onto

--- a/internal/voice/ambe2/decoder.go
+++ b/internal/voice/ambe2/decoder.go
@@ -41,6 +41,44 @@ const (
 	DMRWarmVocoderName = "ambe2-dmr-warm"
 )
 
+// Call-startup acquisition squelch (opt-in via EnableStartupSquelch; off in
+// the raw decoder so unit tests stay byte-identical). Ports the P25 IMBE
+// squelch (internal/voice/imbe/decoder.go) to AMBE+2/DMR: while a receiver is
+// still acquiring symbol lock at the start of a transmission, the FEC layer
+// resolves the marginal dibit stream to random-but-VALID AMBE+2 parameters
+// that synthesise as a loud "startup scratch" burst (the DMR "DJ Scratchy"
+// onset). There is no error signal to key off, so the squelch gates on the
+// SPEECH signature: real voice opens with a sustained run of stable-pitch
+// voiced frames, whereas acquisition garbage is idle/unvoiced/pitch-jumping.
+// Output is muted until that run appears, then released for the rest of the
+// segment; a failsafe releases after acqMaxMuteFrames so a call is never
+// over-muted. Re-armed per call by the recorder building a fresh vocoder.
+const (
+	// acqRunFrames is how many consecutive stable-pitch voiced frames confirm
+	// real speech (each 20 ms). 4 keeps the leaked onset under ~80 ms; the
+	// first 3 frames are always muted (the run cannot latch sooner).
+	acqRunFrames = 4
+	// acqVoicedFracMin is the minimum voiced-harmonic fraction for a frame to
+	// count as a speech candidate — excludes fully-unvoiced acquisition noise
+	// while still catching a real voiced onset.
+	acqVoicedFracMin = 0.1
+	// acqMaxW0Jump is the largest frame-to-frame fundamental-frequency change
+	// (rad/sample) still counted as "stable". W0 is used instead of the raw
+	// AMBE+2 b0 index because it is unit-consistent with the IMBE port. Tuned
+	// against four real DMR captures (the committed dmr-voice.raw plus three
+	// Fire-dept calls from issue reporting): real voiced speech there glides by
+	// up to ~0.07 rad/sample/frame on marginal captures, while acquisition
+	// garbage jumps ~0.1+. 0.08 is the smallest value that lets every real
+	// call acquire on its true speech onset instead of falling through to the
+	// failsafe (a tighter 0.04–0.06 over-muted one capture to the full ~2 s);
+	// it still rejects the garbage onset (those captures' pre-speech bursts
+	// never form a 4-frame stable run at 0.08).
+	acqMaxW0Jump = 0.08
+	// acqMaxMuteFrames is the failsafe: never squelch more than this many
+	// frames (~2 s), so a pathological call can't be fully muted.
+	acqMaxMuteFrames = 100
+)
+
 // phaseRngSeedOffset offsets the §6.3 voiced-phase-dispersion source from
 // the unvoiced-noise source so the two deterministic streams don't march
 // in lockstep. Any fixed non-zero value works; this one matches imbe.
@@ -133,6 +171,19 @@ type Decoder struct {
 	unpack func([]byte) (Params, error)
 	// name is the registry key this decoder reports from Name().
 	name string
+
+	// Call-startup acquisition squelch state (see acqRunFrames). squelchEnabled
+	// is opt-in via EnableStartupSquelch (the recorder turns it on per call);
+	// off by default so the raw decoder and unit tests stay byte-identical.
+	// acquired latches once real speech is confirmed; acqRun counts the current
+	// stable-pitch voiced run; acqFrames drives the failsafe; acqLastVoicedW0
+	// (-1 = none) holds the previous qualifying frame's fundamental for the
+	// pitch-stability test.
+	squelchEnabled  bool
+	acquired        bool
+	acqRun          int
+	acqFrames       int
+	acqLastVoicedW0 float64
 }
 
 // New returns a fresh Decoder. The unvoiced-excitation noise
@@ -164,6 +215,10 @@ func NewWithConfig(seed int64, cfg mbe.AGCConfig) *Decoder {
 		agc:      mbe.NewAGC(cfg),
 		unpack:   UnpackParams,
 		name:     VocoderName,
+		// Arm the startup squelch's pitch-stability sentinel. The squelch only
+		// acts when EnableStartupSquelch has been called; a fresh vocoder per
+		// call (buildSession) is what re-arms it, so no Reset wiring is needed.
+		acqLastVoicedW0: -1,
 	}
 }
 
@@ -257,6 +312,42 @@ func (d *Decoder) Decode(frame []byte) ([]int16, error) {
 	muteByER := d.smoother.UpdateErrorRate(correctedBits)
 
 	p, err := d.unpack(info)
+
+	// Call-startup acquisition squelch (see acqRunFrames): advance the
+	// stable-pitch voiced run and confirm real speech before un-muting. Runs
+	// for every frame before the disposition switch so idle/bad/silent frames
+	// break the run; applyOutput (called on every return path) zeroes the
+	// output while !acquired, so the mute covers all dispositions uniformly.
+	// Mirrors imbe.Decoder's gate, using p.Tone for IMBE's IdleTone and p.W0
+	// (rad/sample) for the pitch-stability test.
+	if d.squelchEnabled && !d.acquired {
+		voiceCand := err == nil && !p.Silent && !p.Tone
+		vf := 0.0
+		if voiceCand && p.L > 0 {
+			vc := 0
+			for l := 1; l <= p.L; l++ {
+				if p.Vl[l] == 1 {
+					vc++
+				}
+			}
+			vf = float64(vc) / float64(p.L)
+		}
+		if voiceCand && vf >= acqVoicedFracMin {
+			if d.acqLastVoicedW0 >= 0 && math.Abs(p.W0-d.acqLastVoicedW0) <= acqMaxW0Jump {
+				d.acqRun++
+			} else {
+				d.acqRun = 1
+			}
+			d.acqLastVoicedW0 = p.W0
+		} else {
+			d.acqRun = 0
+			d.acqLastVoicedW0 = -1
+		}
+		d.acqFrames++
+		if d.acqRun >= acqRunFrames || d.acqFrames >= acqMaxMuteFrames {
+			d.acquired = true
+		}
+	}
 
 	switch {
 	case err != nil && d.lastGoodParams.L > 0 && d.badFrameCount < mbe.MaxBadFrames:
@@ -585,7 +676,23 @@ func (d *Decoder) applyOutput(pcm []float64, out []int16, freezeEnvelope bool) {
 	// Optional opt-in enhancement chain (nil = pass-through).
 	d.enhancer.Process(pcm)
 	d.agc.Apply(pcm, out, freezeEnvelope)
+	// Call-startup acquisition squelch: zero the output (but keep the AGC
+	// envelope tracking above, so the level is right the instant we release)
+	// until real speech is confirmed. Zeroing rather than dropping preserves
+	// the recording length. No-op unless EnableStartupSquelch was called.
+	if d.squelchEnabled && !d.acquired {
+		for i := range out {
+			out[i] = 0
+		}
+	}
 }
+
+// EnableStartupSquelch turns on the call-startup acquisition squelch (see the
+// acqRunFrames block) for this decoder. It is opt-in — the recorder calls it
+// per DMR call via the voice.StartupSquelchable interface — so the raw decoder
+// and unit tests keep byte-identical faithful output. Idempotent; call once
+// after construction, before decoding.
+func (d *Decoder) EnableStartupSquelch() { d.squelchEnabled = true }
 
 // SetVoiceEnhancer installs (or clears) the optional output enhancement
 // chain on this decoder and, when enabled, raises the AGC peak target so

--- a/internal/voice/ambe2/startup_squelch_test.go
+++ b/internal/voice/ambe2/startup_squelch_test.go
@@ -1,0 +1,69 @@
+package ambe2
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/voice/mbe"
+)
+
+// energy sums the squared samples over a slice (a cheap loudness proxy).
+func energy(pcm []int16) float64 {
+	var e float64
+	for _, s := range pcm {
+		e += float64(s) * float64(s)
+	}
+	return e
+}
+
+// TestStartupSquelchMutesOnsetThenReleases pins the call-startup acquisition
+// squelch ported from the IMBE decoder. It decodes the committed real DMR
+// fixture (testdata/dmr-voice.raw) twice — squelch off vs on — and asserts:
+//  1. the two decodes have identical length (the squelch zeroes, never drops);
+//  2. the guaranteed-mute window (first 2 frames, well inside the ~3-frame
+//     ramp before `acquired` can latch) is all-zero WITH squelch but has real
+//     audio WITHOUT it — this fails before the port (no squelch on AMBE2);
+//  3. the squelch RELEASES on real speech well before the failsafe: every
+//     sample from frame 4 onward is byte-identical to the un-squelched decode
+//     (the mute runs after the AGC, so once released the paths converge). A
+//     mis-tuned acqMaxW0Jump that only released via the 100-frame failsafe
+//     would zero the fixture's short voiced burst and diverge here.
+func TestStartupSquelchMutesOnsetThenReleases(t *testing.T) {
+	const fr = mbe.SamplesPerFrame // 160 samples / 20 ms
+
+	off := decodeSampleWith(t, NewDMR())
+
+	sq := NewDMR()
+	sq.EnableStartupSquelch()
+	on := decodeSampleWith(t, sq)
+
+	if len(on) != len(off) {
+		t.Fatalf("squelch changed length: on=%d off=%d (must zero, not drop)", len(on), len(off))
+	}
+	if len(off) < 5*fr {
+		t.Fatalf("fixture too short: %d samples", len(off))
+	}
+
+	// (2) Guaranteed-mute window: first 2 frames muted with squelch on...
+	muteWin := on[:2*fr]
+	if e := energy(muteWin); e != 0 {
+		t.Errorf("first 2 frames not muted with squelch on: energy=%.0f", e)
+	}
+	// ...but real audio there without it (otherwise the assertion is vacuous).
+	if energy(off[:2*fr]) == 0 {
+		t.Fatal("fixture has no onset energy to squelch — test would be vacuous")
+	}
+
+	// (3) Early release: identical from frame 4 onward (proves the squelch
+	// un-muted on real speech, not via the failsafe, and left audio untouched).
+	for i := 4 * fr; i < len(on); i++ {
+		if on[i] != off[i] {
+			t.Fatalf("post-release sample %d differs (frame %d): on=%d off=%d — "+
+				"squelch did not release cleanly (mis-tuned acqMaxW0Jump?)",
+				i, i/fr, on[i], off[i])
+		}
+	}
+	// And the released tail must actually carry audio (not silence).
+	if energy(on[4*fr:]) == 0 {
+		t.Fatal("no audio after release — squelch over-muted the call")
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #1049 (merged). That PR fixed the WebUI live-audio playback
(silence / PTT clicks / dropped calls) and added rdio-scanner tag/group
forwarding, but left one item from the same user report open: the "DJ Scratchy"
DMR voice onset. This PR ports the P25 IMBE **call-startup acquisition squelch**
to the AMBE+2 / DMR decoder so the loud per-transmission startup burst is muted,
and backfills `CHANGELOG.md` for the already-merged WebUI/rdio work plus this
change.

The recorded WAVs from the reporter are clean, so the onset artifact is a
decoder issue: while the receiver is acquiring symbol lock at the start of a
transmission, the FEC resolves the marginal dibit stream to random-but-**valid**
AMBE+2 parameters that synthesise as a loud scratch. The P25 IMBE decoder
already suppresses this; the DMR AMBE+2 decoder did not.

## Changes

- **`internal/voice/ambe2/decoder.go`** — port the startup acquisition squelch.
  Mute output until a sustained run of stable-pitch, sufficiently-voiced frames
  confirms real speech, then release for the rest of the segment; a failsafe
  releases after ~2 s so a call is never over-muted. The gate mirrors the IMBE
  decoder, using `p.Tone` for IMBE's `IdleTone` and `p.W0` (rad/sample,
  unit-consistent across codecs) for the pitch-stability test. Muting happens in
  `applyOutput` **after** the AGC (so the level is right on release) and zeroes
  rather than drops, preserving recording length. `acqMaxW0Jump` is tuned to
  0.08 against four real DMR captures (the committed `dmr-voice.raw` plus three
  Fire-dept calls): real speech glides up to ~0.07 rad/sample/frame while
  acquisition garbage jumps ~0.1+, so 0.08 lets every real call acquire on its
  true onset rather than the failsafe, while still rejecting the garbage burst.
- **Opt-in.** `EnableStartupSquelch()` makes `*Decoder` satisfy
  `voice.StartupSquelchable`; the recorder already calls it per DMR call, so no
  recorder change is needed. The raw decode path (`gophertrunk decode`, unit
  tests) stays byte-identical.
- **`internal/voice/ambe2/startup_squelch_test.go`** — failing-first regression
  test on the committed real DMR fixture.
- **`CHANGELOG.md`** — `[Unreleased]` entries for the WebUI playback fixes and
  rdio-scanner tag/group forwarding (shipped in #1049 without a changelog note)
  and this DMR squelch.

> Note: this suppresses the per-PTT **acquisition** scratch. The residual
> synthetic timbre of software AMBE+2 across a whole call is intrinsic to
> software decode (only a DVSI hardware vocoder removes it) — this improves the
> onset, it does not change the codec's character.

## Test plan

- [x] `make vet test` green locally (full run, all packages `ok`)
- [ ] `make integration` — n/a (no daemon / DSP / replay change)
- [x] Added a failing-first regression test (`startup_squelch_test.go`): decode
      the real fixture squelch-off vs -on and assert the onset window is muted,
      the paths converge byte-identically after release, and the call is not
      over-muted. Existing ambe2 tests (incl. `TestDecodeDMRSampleIssue644`)
      stay green.
- [x] Smoke-tested on the reporter's own DMR `.raw` sidecars: a 14 s call's loud
      onset burst (energy 4.65e10) is muted to zero and releases at real speech
      ~1.1 s; the threshold tuning was validated across four real captures.

## Breaking changes

None. The squelch is opt-in and off in the raw decoder; no config keys, CLI
flags, REST/gRPC schemas, or default raw-decode behaviour change.

## Docs / CHANGELOG

- [x] Added `## [Unreleased]` bullets for the user-visible changes.
- [ ] No `README.md` / `docs/` change needed.

## Linked issues

n/a — reported via Discord, no tracked issue. The WebUI/rdio half shipped in
#1049; this PR completes the DMR-onset item from the same report.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RW9xH8W8Uy6yJX51aMRc8q

---
_Generated by [Claude Code](https://claude.ai/code/session_01RW9xH8W8Uy6yJX51aMRc8q)_