### PR TITLE
broadcast: surface on-air call priority on the webhook sinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **On-air call priority now reaches the webhook sinks.** The completed-call
+  and grant `broadcast.webhook` payloads already carried the emergency flag but
+  not the signalled priority level (the low 3 bits of the P25 / DMR Service
+  Options octet, or the TETRA CMCE Call priority); both now include a `priority`
+  field, matching what the call log and `/api/v1/calls` already surface, so a
+  webhook consumer can rank calls the way the local UI does.
 - **Unit-to-unit / private calls are now flagged in call history.** The
   `Individual` grant flag (the call's `group_id` is a target radio address,
   not a talkgroup) already reached the live-grant API but was dropped from the

--- a/internal/broadcast/broadcast.go
+++ b/internal/broadcast/broadcast.go
@@ -74,9 +74,16 @@ type Call struct {
 	// DataCall a data (non-voice) grant. They let a metadata sink emit a
 	// call_type so a downstream consumer doesn't mistake a unit's target RID
 	// for a talkgroup (issue #897). Both false for an ordinary group call.
-	Individual    bool
-	DataCall      bool
-	Emergency     bool
+	Individual bool
+	DataCall   bool
+	Emergency  bool
+	// Priority is the call's on-air signalled priority level (the low 3 bits
+	// of the P25 / DMR Service Options octet, or the 4-bit TETRA CMCE Call
+	// priority; 0 = none/lowest). It is the priority the radio requested,
+	// distinct from a talkgroup's operator-configured priority. A metadata
+	// sink surfaces it alongside emergency so a consumer can rank calls the
+	// way the call log and REST API already do.
+	Priority      uint8
 	PatchedGroups []uint32
 	StartedAt     time.Time
 	EndedAt       time.Time
@@ -167,6 +174,7 @@ func callFromEvent(cc trunking.CallComplete) *Call {
 		Individual:    cc.Grant.Individual,
 		DataCall:      cc.Grant.DataCall,
 		Emergency:     cc.Grant.Emergency,
+		Priority:      cc.Grant.Priority,
 		PatchedGroups: cc.Grant.PatchedGroups,
 		StartedAt:     cc.StartedAt,
 		EndedAt:       cc.EndedAt,

--- a/internal/broadcast/grantwebhook.go
+++ b/internal/broadcast/grantwebhook.go
@@ -74,6 +74,7 @@ type grantWebhookPayload struct {
 	Timeslot      uint8  `json:"timeslot,omitempty"`
 	Encrypted     bool   `json:"encrypted,omitempty"`
 	Emergency     bool   `json:"emergency,omitempty"`
+	Priority      uint8  `json:"priority,omitempty"`
 	DataCall      bool   `json:"data_call,omitempty"`
 	Individual    bool   `json:"individual,omitempty"`
 	AlgorithmID   uint8  `json:"algorithm_id,omitempty"`
@@ -98,6 +99,7 @@ func grantWebhookPayloadFrom(g trunking.Grant, at time.Time, loc *time.Location)
 		Timeslot:      g.Timeslot,
 		Encrypted:     g.Encrypted,
 		Emergency:     g.Emergency,
+		Priority:      g.Priority,
 		DataCall:      g.DataCall,
 		Individual:    g.Individual,
 		AlgorithmID:   g.AlgorithmID,

--- a/internal/broadcast/grantwebhook_test.go
+++ b/internal/broadcast/grantwebhook_test.go
@@ -99,7 +99,7 @@ func TestGrantWebhookPostsDecodedGrant(t *testing.T) {
 	bus.Publish(events.Event{Kind: events.KindGrant, Payload: trunking.Grant{
 		System: "MMR", Protocol: "p25", GroupID: 20001, SourceID: 202419,
 		FrequencyHz: 422612500, RFSSID: 1, SiteID: 9, NAC: 359,
-		Encrypted: true, AlgorithmID: 0x84, KeyID: 3,
+		Encrypted: true, AlgorithmID: 0x84, KeyID: 3, Priority: 4,
 	}})
 	sink.waitFor(t, 1)
 
@@ -133,6 +133,9 @@ func TestGrantWebhookPostsDecodedGrant(t *testing.T) {
 	}
 	if g["algorithm_id"].(float64) != 0x84 {
 		t.Errorf("algorithm_id = %v, want 132", g["algorithm_id"])
+	}
+	if g["priority"].(float64) != 4 {
+		t.Errorf("priority = %v, want 4 surfaced", g["priority"])
 	}
 	if g["at"] != "2026-08-01T12:00:00Z" {
 		t.Errorf("at = %v, want the stamped decode time", g["at"])

--- a/internal/broadcast/webhook.go
+++ b/internal/broadcast/webhook.go
@@ -123,6 +123,7 @@ type webhookPayload struct {
 	AlgorithmID   uint8    `json:"algorithm_id,omitempty"`
 	KeyID         uint16   `json:"key_id,omitempty"`
 	Emergency     bool     `json:"emergency"`
+	Priority      uint8    `json:"priority,omitempty"`
 	PatchedGroups []uint32 `json:"patched_groups,omitempty"`
 	StartedAt     string   `json:"started_at"` // RFC3339 UTC
 	EndedAt       string   `json:"ended_at"`   // RFC3339 UTC
@@ -154,6 +155,7 @@ func (b *webhookBackend) Send(ctx context.Context, c *Call) error {
 		AlgorithmID:   c.AlgorithmID,
 		KeyID:         c.KeyID,
 		Emergency:     c.Emergency,
+		Priority:      c.Priority,
 		PatchedGroups: c.PatchedGroups,
 		StartedAt:     rfc3339In(c.StartedAt, b.loc),
 		EndedAt:       rfc3339In(c.EndedAt, b.loc),

--- a/internal/broadcast/webhook_test.go
+++ b/internal/broadcast/webhook_test.go
@@ -19,6 +19,7 @@ func p25SiteCall(t *testing.T) *Call {
 	c.Site = 9
 	c.NAC = 359
 	c.Emergency = true
+	c.Priority = 6
 	c.PatchedGroups = []uint32{201, 212}
 	return c
 }
@@ -68,6 +69,9 @@ func TestWebhookPostsJSONMetadata(t *testing.T) {
 	}
 	if !got.Emergency {
 		t.Error("emergency flag not surfaced")
+	}
+	if got.Priority != 6 {
+		t.Errorf("priority = %d, want 6 surfaced", got.Priority)
 	}
 	if len(got.PatchedGroups) != 2 || got.PatchedGroups[0] != 201 {
 		t.Errorf("patched_groups = %v, want [201 212]", got.PatchedGroups)


### PR DESCRIPTION
## Summary

The call log and REST API (`/api/v1/calls`) already carry a call's on-air signalled priority — the low 3 bits of the P25 / DMR Service Options octet, or the TETRA CMCE Call priority. But the `broadcast.webhook` payloads (both the completed-call sink and the grant sink) exposed the `emergency` flag without `priority`, so a webhook consumer could see that a call was flagged emergency but not the priority level the radio requested. This closes that parity gap.

## Changes

- **broadcast:** thread `Grant.Priority` onto `broadcast.Call`, and add a `priority` field (JSON `omitempty`) to both the completed-call webhook payload and the grant webhook payload, mirroring the existing `emergency` field.
- Audio-upload backends (RdioScanner / OpenMHz / Broadcastify / Icecast) have fixed upstream schemas and are intentionally untouched — the webhook is the generic metadata sink.
- **tests:** extended `TestWebhookPostsJSONMetadata` and `TestGrantWebhookPostsDecodedGrant` to assert `priority` surfaces (each fails first without the payload mapping).

## Test plan

- [x] `make vet test` is green locally
- [x] New assertions fail first, pass with the mapping
- [ ] `make integration` — n/a (metadata projection only; no daemon/DSP/replay code touched)
- [ ] Smoke-tested against real hardware — n/a

## Breaking changes

None. Additive JSON field (`omitempty`), so a call with no signalled priority (0) omits it and existing consumers are unaffected.

## Docs / CHANGELOG

- [x] Added an `## [Unreleased]` → `### Added` bullet to `CHANGELOG.md`
- [ ] README/docs — n/a

## Linked issues

n/a (parity follow-on to the on-air-priority surfacing already in the call log / REST API; benefits webhook consumers such as the reporters in #915 / #924).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0144w5FXPjW3oeryHqugKAjP)_