### PR TITLE
docs: two-step star promo with download-first ask and blocked-modal inline fallback

### DIFF
--- a/docs/_includes/star-popup.html
+++ b/docs/_includes/star-popup.html
@@ -1,19 +1,32 @@
 {%- comment -%}
-  First-visit "Star the repo" promo — the first instance of the promo system
+  First-visit promo — the first instance of the promo system
   (assets/js/promos.js). Rendered site-wide by default.html, hidden until the
   engine reveals it. The engine shows it ONCE per browser, after the visitor is
   either 2 minutes in (data-promo-trigger-time) OR a quarter of the way down the
   page (data-promo-trigger-scroll), whichever comes first. Impressions, closes,
-  and the star click are all reported through the shared metrics module, the
-  same tracking the site's CTAs use.
+  step advances, and the star click are all reported through the shared metrics
+  module, the same tracking the site's CTAs use.
+
+  Two steps live in the one card:
+    step "try"  — ask whether they've tried GopherTrunk yet + a compelling
+                  download nudge. Shown first.
+    step "star" — the classic "give us a star" ask. Revealed only when the
+                  visitor says they're already using it (data-promo-advance).
+  Asking a fresh visitor to star a tool they haven't run yet is premature; the
+  star ask is earned by "I'm already using GopherTrunk".
+
+  data-promo-fallback="inline" opts this promo into the engine's blocked-modal
+  fallback: if a content/ad blocker suppresses the modal, the engine relocates
+  this same card to the page's midpoint (nearest clean block boundary) and
+  expands it in-flow instead, so the ask survives the block.
 
   To add another pop-up / pop-in / fly-out later, copy this markup shape into a
   new include with its own data-promo id and variant — no JS changes needed.
 {%- endcomment -%}
 <div class="gt-promo gt-promo--popup" id="gt-promo-star" hidden tabindex="-1"
-     role="dialog" aria-modal="true" aria-labelledby="gt-promo-star-title"
-     aria-describedby="gt-promo-star-body"
-     data-promo="star-repo" data-promo-variant="popup"
+     role="dialog" aria-modal="true" aria-labelledby="gt-promo-try-title"
+     aria-describedby="gt-promo-try-body"
+     data-promo="star-repo" data-promo-variant="popup" data-promo-fallback="inline"
      data-promo-trigger-time="120000" data-promo-trigger-scroll="0.25"
      data-promo-frequency="once">
   <div class="gt-promo__backdrop" data-promo-close data-promo-close-method="backdrop"></div>
@@ -21,32 +34,57 @@
     <button type="button" class="gt-promo__close" aria-label="Close"
             data-promo-close data-promo-close-method="close_button">&times;</button>
     <div class="gt-promo__icon" aria-hidden="true">{% include icons/github.svg %}</div>
-    <h2 class="gt-promo__title" id="gt-promo-star-title">Enjoying GopherTrunk? Give it a star ⭐</h2>
-    <p class="gt-promo__body" id="gt-promo-star-body">
-      GopherTrunk is free and open source, built in the open by a tiny team. A
-      GitHub star costs you one click, helps other scanner operators find it, and
-      keeps the project moving. Would you drop one?
-    </p>
-    <div class="gt-promo__actions">
-      {%- comment -%}
-        Official GitHub star widget: buttons.github.io upgrades this anchor into
-        a live iframe that stars in place and shows the count. If the script is
-        blocked, the raw anchor still links to the repo, so the ask degrades
-        gracefully. The branded fallback button below always works and carries
-        the CTA tracking hook.
-      {%- endcomment -%}
-      <a class="github-button" href="https://github.com/MattCheramie/GopherTrunk"
-         data-color-scheme="no-preference: light; light: light; dark: dark;"
-         data-icon="octicon-star" data-size="large" data-show-count="true"
-         aria-label="Star MattCheramie/GopherTrunk on GitHub">Star</a>
-      <a class="btn btn--primary" href="https://github.com/MattCheramie/GopherTrunk"
-         target="_blank" rel="noopener" data-cta-event="cta_star_github">
-        {% include icons/github.svg %}
-        <span>View on GitHub</span>
-      </a>
+
+    {%- comment -%} Step 1: have you tried it? Shown by default. {%- endcomment -%}
+    <div class="gt-promo__step" data-promo-step="try">
+      <h2 class="gt-promo__title" id="gt-promo-try-title">Have you tried GopherTrunk yet?</h2>
+      <p class="gt-promo__body" id="gt-promo-try-body">
+        GopherTrunk turns a cheap RTL-SDR dongle into a full digital-trunking
+        scanner — P25, DMR, TETRA, NXDN and more, decoded by one pure-Go static
+        binary with nothing else to install. Grab the latest build and follow
+        your first system tonight.
+      </p>
+      <div class="gt-promo__actions">
+        <a class="btn btn--primary" href="{{ '/downloads.html' | relative_url }}"
+           target="_blank" rel="noopener" data-cta-event="cta_try_download">
+          {% include icons/github.svg %}
+          <span>Download GopherTrunk</span>
+        </a>
+      </div>
+      <button type="button" class="gt-promo__later" data-promo-advance="star">
+        I'm already using GopherTrunk
+      </button>
     </div>
-    <button type="button" class="gt-promo__later"
-            data-promo-close data-promo-close-method="maybe_later">Maybe later</button>
+
+    {%- comment -%}
+      Step 2: the star ask. Hidden until "I'm already using GopherTrunk" advances
+      here. Official GitHub star widget: buttons.github.io upgrades the anchor
+      into a live iframe that stars in place and shows the count. If the script
+      is blocked, the raw anchor still links to the repo, so the ask degrades
+      gracefully. The branded fallback button below always works and carries the
+      CTA tracking hook.
+    {%- endcomment -%}
+    <div class="gt-promo__step" data-promo-step="star" hidden>
+      <h2 class="gt-promo__title" id="gt-promo-star-title">Enjoying GopherTrunk? Give it a star ⭐</h2>
+      <p class="gt-promo__body" id="gt-promo-star-body">
+        GopherTrunk is free and open source, built in the open by a tiny team. A
+        GitHub star costs you one click, helps other scanner operators find it, and
+        keeps the project moving. Would you drop one?
+      </p>
+      <div class="gt-promo__actions">
+        <a class="github-button" href="https://github.com/MattCheramie/GopherTrunk"
+           data-color-scheme="no-preference: light; light: light; dark: dark;"
+           data-icon="octicon-star" data-size="large" data-show-count="true"
+           aria-label="Star MattCheramie/GopherTrunk on GitHub">Star</a>
+        <a class="btn btn--primary" href="https://github.com/MattCheramie/GopherTrunk"
+           target="_blank" rel="noopener" data-cta-event="cta_star_github">
+          {% include icons/github.svg %}
+          <span>View on GitHub</span>
+        </a>
+      </div>
+      <button type="button" class="gt-promo__later"
+              data-promo-close data-promo-close-method="maybe_later">Maybe later</button>
+    </div>
   </div>
 </div>
 <script async defer src="https://buttons.github.io/buttons.js"></script>

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -1806,6 +1806,9 @@ a.category-chip:hover {
    only presentation. All variants share the card styling and theme tokens. */
 .gt-promo[hidden] { display: none; }
 
+/* Multi-step promos: only the active step is in the DOM flow. */
+.gt-promo__step[hidden] { display: none; }
+
 .gt-promo__card {
   position: relative;
   background: var(--bg-elev);
@@ -1906,6 +1909,48 @@ a.category-chip:hover {
   animation: gt-promo-pop 0.22s ease-out both;
 }
 body.gt-promo-open { overflow: hidden; }
+
+/* Inline fallback: when a content/ad blocker suppresses the modal, the engine
+   reclasses the card to this variant and relocates it to a clean block boundary
+   at the page midpoint (see assets/js/promos.js). It renders in the normal
+   content flow — no backdrop, no scroll lock — with hairline separators so the
+   two page halves read as cleanly divided, and expands open from that point. */
+.gt-promo--inline {
+  position: static;
+  inset: auto;
+  z-index: auto;
+  display: block;
+  overflow: hidden;
+  width: 100%;
+  margin: 2.5rem 0;
+  padding: 0;
+  /* Collapsed until .is-open; a generous max-height covers the tallest step. */
+  max-height: 0;
+  opacity: 0;
+  transition: max-height 0.32s ease-out, opacity 0.32s ease-out;
+}
+.gt-promo--inline.is-open {
+  max-height: 60rem;
+  opacity: 1;
+}
+.gt-promo--inline .gt-promo__card {
+  margin: 0 auto;
+  max-width: 34rem;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  border-left: 0;
+  border-right: 0;
+  border-radius: 0;
+  box-shadow: none;
+  padding: 1.75rem 1.5rem;
+  animation: none;
+}
+/* Modal-only chrome has no place in the in-flow section. */
+.gt-promo--inline .gt-promo__backdrop,
+.gt-promo--inline .gt-promo__close { display: none; }
+@media (prefers-reduced-motion: reduce) {
+  .gt-promo--inline { transition: none; }
+}
 
 /* Pop-in: small card anchored bottom-right, no backdrop / no scroll lock. */
 .gt-promo--popin {

--- a/docs/assets/js/promos.js
+++ b/docs/assets/js/promos.js
@@ -17,11 +17,23 @@
  *   data-promo-trigger-time="<ms>"                    show after N ms (optional)
  *   data-promo-trigger-scroll="<0..1>"                show at scroll fraction (optional)
  *   data-promo-frequency="once|session|always"        dedup scope (default once)
+ *   data-promo-fallback="inline"                      if the modal is suppressed
+ *                                                     (content/ad blocker), relocate
+ *                                                     the card to the page midpoint
+ *                                                     and expand it in-flow instead
  * Dismiss controls (anywhere inside): [data-promo-close], optionally with
  *   data-promo-close-method="close_button|maybe_later|backdrop|escape|action".
+ * Multi-step promos: wrap each step in [data-promo-step="<name>"] (the first, or
+ *   one without `hidden`, shows first); a control with
+ *   [data-promo-advance="<name>"] swaps to that step without closing the promo.
  * Action links use data-cta-event="cta_*" — tracked by site.js as a CTA click.
  *
  * Triggers are OR'd: the first to fire shows the promo; the rest are disarmed.
+ *
+ * QA override: append ?gtpromo=show to force-show immediately (bypassing the
+ * time/scroll triggers and the once-per-browser dedup), or ?gtpromo=inline to
+ * force the blocked-modal inline fallback, so both presentations can be checked
+ * deterministically.
  */
 (function () {
   'use strict';
@@ -59,6 +71,14 @@
     } catch (e) {}
   }
 
+  // --- QA override (?gtpromo=show|inline) -----------------------------------
+  function queryPromo() {
+    try {
+      var m = /[?&]gtpromo=([^&#]+)/.exec(window.location.search || '');
+      return m ? decodeURIComponent(m[1]) : null;
+    } catch (e) { return null; }
+  }
+
   // --- Scroll fraction ------------------------------------------------------
   function scrollFraction() {
     var doc = document.documentElement;
@@ -77,7 +97,9 @@
     this.timeMs = parseInt(el.getAttribute('data-promo-trigger-time'), 10);
     this.scrollAt = parseFloat(el.getAttribute('data-promo-trigger-scroll'));
     this.isModal = this.variant === 'popup';
+    this.fallback = el.getAttribute('data-promo-fallback') || '';
     this.shown = false;
+    this.inlined = false;
     this.closed = false;
     this.timer = null;
     this.prevFocus = null;
@@ -87,8 +109,21 @@
   }
 
   Promo.prototype.arm = function () {
-    if (!this.id || hasSeen(this.id, this.frequency)) return;
+    if (!this.id) return;
     var self = this;
+
+    // QA override: ?gtpromo=show forces an immediate modal; ?gtpromo=inline
+    // forces the inline fallback (only for promos that opt into it). Both bypass
+    // the triggers and the once-per-browser dedup.
+    var q = queryPromo();
+    if (q === 'show' || (q === 'inline' && this.fallback === 'inline')) {
+      window.setTimeout(function () {
+        self.show(q, { debug: true, forceInline: q === 'inline' });
+      }, 0);
+      return;
+    }
+
+    if (hasSeen(this.id, this.frequency)) return;
 
     if (!isNaN(this.timeMs) && this.timeMs >= 0) {
       this.timer = window.setTimeout(function () { self.show('time'); }, this.timeMs);
@@ -109,18 +144,23 @@
     if (this._onScroll) { window.removeEventListener('scroll', this._onScroll); this._onScroll = null; }
   };
 
-  Promo.prototype.show = function (trigger) {
+  Promo.prototype.show = function (trigger, opts) {
     if (this.shown) return;
     this.shown = true;
     this.disarmTriggers();
+    opts = opts || {};
 
     // Write the seen flag on show (not on interaction) so an ignored or
-    // reloaded promo does not re-appear.
-    markSeen(this.id, this.frequency);
+    // reloaded promo does not re-appear. The QA override skips this so repeated
+    // debug loads keep working.
+    if (!opts.debug) markSeen(this.id, this.frequency);
 
     var el = this.el;
     el.removeAttribute('hidden');
     el.setAttribute('aria-hidden', 'false');
+
+    // QA: jump straight to the inline presentation.
+    if (opts.forceInline) { this.convertToInline('debug'); return; }
 
     if (this.isModal) {
       this.prevFocus = document.activeElement;
@@ -133,9 +173,140 @@
       } else if (el.focus) {
         try { el.focus(); } catch (e) {}
       }
+
+      // If this promo opts into the inline fallback, defer the impression until
+      // we know whether the modal actually rendered — a content/ad blocker can
+      // reveal-then-hide it. scheduleBlockedCheck fires the right impression
+      // (popup when visible, fallback_inline when suppressed).
+      if (this.fallback === 'inline') { this.scheduleBlockedCheck(trigger); return; }
     }
 
     fire('promo_impression', { promo_id: this.id, variant: this.variant, trigger: trigger || '' });
+  };
+
+  // --- Blocked-modal detection + inline fallback ---------------------------
+  // Best-effort: after revealing the modal, verify on the next frames that the
+  // card is actually painted. Cosmetic filters that hide the popup by class/id
+  // are defeated by reclassing + relocating the node; a filter on [data-promo]
+  // itself cannot be evaded — acceptable.
+  Promo.prototype.scheduleBlockedCheck = function (trigger) {
+    var self = this;
+    var run = function () {
+      if (self.closed) return;
+      if (self.isBlocked()) self.convertToInline(trigger);
+      else fire('promo_impression', { promo_id: self.id, variant: self.variant, trigger: trigger || '' });
+    };
+    if (window.requestAnimationFrame) {
+      window.requestAnimationFrame(function () { window.requestAnimationFrame(run); });
+    } else {
+      window.setTimeout(run, 50);
+    }
+  };
+
+  Promo.prototype.isBlocked = function () {
+    var card = this.el.querySelector('.gt-promo__card') || this.el;
+    // No box at all (display:none anywhere up the chain) or zero-sized.
+    if (!card.getClientRects || !card.getClientRects().length) return true;
+    var r = card.getBoundingClientRect();
+    if (r.height === 0 || r.width === 0) return true;
+    // Explicit hide on the root or the card. Cosmetic blockers use
+    // `display:none`/`visibility:hidden`; opacity is deliberately NOT checked —
+    // the modal's entry animation legitimately starts at opacity:0, and
+    // opacity-hiding leaves layout height intact so it isn't a reliable signal.
+    var nodes = [this.el, card];
+    for (var i = 0; i < nodes.length; i++) {
+      var cs = window.getComputedStyle(nodes[i]);
+      if (!cs) continue;
+      if (cs.display === 'none' || cs.visibility === 'hidden') return true;
+    }
+    return false;
+  };
+
+  // Nearest clean top-level content-block boundary to 50% of the content height,
+  // so the two page halves separate cleanly (no element cut mid-block).
+  Promo.prototype.relocateToMidpoint = function () {
+    var host = document.querySelector('.prose') || document.getElementById('content');
+    if (!host) return false;
+    var kids = [];
+    for (var i = 0; i < host.children.length; i++) {
+      if (host.children[i] !== this.el) kids.push(host.children[i]);
+    }
+    if (!kids.length) return false;
+    var hostTop = host.getBoundingClientRect().top + (window.pageYOffset || 0);
+    var target = hostTop + host.offsetHeight / 2;
+    var bestChild = null, bestDist = Infinity;
+    for (var j = 0; j < kids.length; j++) {
+      var top = kids[j].getBoundingClientRect().top + (window.pageYOffset || 0);
+      var d = Math.abs(top - target);
+      if (d < bestDist) { bestDist = d; bestChild = kids[j]; }
+    }
+    if (bestChild) host.insertBefore(this.el, bestChild);
+    else host.appendChild(this.el);
+    return true;
+  };
+
+  Promo.prototype.convertToInline = function (trigger) {
+    if (this.inlined) return;
+    this.inlined = true;
+
+    // Shed the modal-only behaviors.
+    document.body.classList.remove('gt-promo-open');
+    if (this._onKey) { document.removeEventListener('keydown', this._onKey); this._onKey = null; }
+    this._bound = false;
+    this.isModal = false;
+
+    var el = this.el;
+    el.classList.remove('gt-promo--popup');
+    el.classList.add('gt-promo--inline');
+    // No longer a modal dialog; present as a labelled region. Dropping the id
+    // also dodges the common cosmetic filters keyed on it.
+    el.removeAttribute('aria-modal');
+    el.setAttribute('role', 'region');
+    el.setAttribute('aria-label', 'Support GopherTrunk');
+    el.removeAttribute('id');
+    el.removeAttribute('hidden');
+    el.setAttribute('aria-hidden', 'false');
+
+    this.relocateToMidpoint();
+
+    // Expand from the insertion point on the next frame.
+    var open = function () { el.classList.add('is-open'); };
+    if (window.requestAnimationFrame) window.requestAnimationFrame(open); else open();
+
+    fire('promo_impression', {
+      promo_id: this.id,
+      variant: 'inline',
+      trigger: trigger === 'debug' ? 'debug_inline' : 'fallback_inline'
+    });
+  };
+
+  // --- Steps ---------------------------------------------------------------
+  Promo.prototype.showStep = function (name, opts) {
+    opts = opts || {};
+    var steps = this.el.querySelectorAll('[data-promo-step]');
+    if (!steps.length) return;
+    var from = null, target = null;
+    for (var i = 0; i < steps.length; i++) {
+      var s = steps[i];
+      if (!s.hasAttribute('hidden')) from = s.getAttribute('data-promo-step');
+      if (s.getAttribute('data-promo-step') === name) { target = s; s.removeAttribute('hidden'); }
+      else s.setAttribute('hidden', '');
+    }
+    if (!target) return;
+
+    // Keep the dialog's accessible name pointed at the active step.
+    var title = target.querySelector('.gt-promo__title');
+    var body = target.querySelector('.gt-promo__body');
+    if (title && title.id) this.el.setAttribute('aria-labelledby', title.id);
+    if (body && body.id) this.el.setAttribute('aria-describedby', body.id);
+
+    if (opts.focus) {
+      var f = target.querySelector('a[href], button, [tabindex]');
+      if (f && f.focus) { try { f.focus(); } catch (e) {} }
+    }
+    if (opts.track && from && from !== name) {
+      fire('promo_step', { promo_id: this.id, from: from, to: name });
+    }
   };
 
   Promo.prototype.bindModalDismiss = function () {
@@ -176,6 +347,14 @@
       if (closer) {
         var method = closer.getAttribute('data-promo-close-method') || 'close_button';
         self.close(method);
+        return;
+      }
+      // Step advance (e.g. "I'm already using GopherTrunk"): swap steps in place,
+      // do NOT close the promo.
+      var adv = e.target.closest && e.target.closest('[data-promo-advance]');
+      if (adv) {
+        e.preventDefault();
+        self.showStep(adv.getAttribute('data-promo-advance'), { focus: true, track: true });
         return;
       }
       // A primary action (e.g. the star link) also closes the promo. The click


### PR DESCRIPTION
Rework the site-wide "Star the repo" pop-up so the ask is earned. A fresh
visitor is asked first whether they've tried GopherTrunk, with a compelling
download nudge; only "I'm already using GopherTrunk" advances (in the same
card, no close) to the existing star messaging.

Add a graceful fallback for suppressed pop-ups: promos opting in with
data-promo-fallback="inline" are auto-detected as blocked (revealed-then-hidden
by a content/ad blocker) and relocated into the page's content at the nearest
clean top-level block boundary to the 50% mark, then expanded in place — so the
page splits cleanly in two and the ask survives the block.

- star-popup.html: two [data-promo-step] steps in one card; download CTA reuses
  the /downloads.html + cta_try_download pattern; star step keeps the GitHub
  widget and graceful anchor fallback.
- promos.js: generic step support ([data-promo-advance] + promo_step event) and
  generic blocked-modal detection + inline relocation/expand, plus a
  ?gtpromo=show|inline QA override. No promo-specific logic in the engine.
- style.scss: step visibility and the .gt-promo--inline in-flow expanding
  section with hairline separators (reduced-motion aware).

Verified with a headless-Chromium harness (two-step advance, forced inline, and
a simulated ad-blocker cosmetic filter): the blocked modal auto-converts to an
inline section at the midpoint block boundary and the two-step flow still works.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01N9N3MijLk5ZExQbpJP1Nka