### PR TITLE
macOS RTL-SDR tuner-init stall recovery (#1038) + DMR conventional beacon "site alive" (#1036)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **Conventional DMR / IPSC repeaters now report "site alive" from their idle
+  beacons.** On a `dmr-tier2` channel that parks on a fixed carrier with no
+  control channel, the periodic idle beacon a repeater emits between calls (a
+  CSBK Preamble / broadcast burst carrying valid sync + colour code but no
+  voice) is now recognised: a CRC-valid CSBK marks the site alive, is counted
+  in the wideband engine's per-channel diagnostics (`beacons`), and logs a
+  rate-limited status line — instead of being ignored or, worse, surfaced as a
+  decode error. Between-beacon noise on the parked channel stays silent. Groundwork
+  for conventional/IPSC monitoring (issue #1036).
 - **On-air call priority now reaches the webhook sinks.** The completed-call
   and grant `broadcast.webhook` payloads already carried the emergency flag but
   not the signalled priority level (the low 3 bits of the P25 / DMR Service
@@ -36,6 +45,15 @@ for tagged releases.
   call-priority metadata to TETRA alongside P25 and DMR.
 
 ### Fixed
+- **macOS: RTL-SDR (R820T) dongles failed to open with "no supported tuner
+  detected."** On Apple silicon the tuner's first I²C-bridge burst write could
+  STALL the USB control pipe (IOKit `kIOUSBPipeStalled`, `kern_return
+  0xe000404f`); unlike the Linux (`EPIPE`) and Windows (`ERROR_GEN_FAILURE`)
+  backends, the macOS backend didn't recognise this as the recoverable stall it
+  is, so the existing R820T cold-boot burst-write retry never fired and tuner
+  init aborted — leaving a plainly-present dongle reported as having no tuner.
+  The macOS backend now maps the IOKit stall to the shared retry path, matching
+  the other platforms. (#1038)
 - **P25 Phase 2 grants could carry a garbage encryption Algorithm ID.** A
   bit-errored MAC Encryption Sync decodes to an Algorithm ID outside the
   TIA-102 registry; the control channel stored any decoded sync and attached

--- a/internal/radio/dmr/tier2/conventional.go
+++ b/internal/radio/dmr/tier2/conventional.go
@@ -21,9 +21,16 @@ import (
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr/tier3"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
+
+// beaconLogInterval rate-limits the operator-facing "site alive" Info log
+// so a repeater whose idle beacon fires every few seconds announces
+// itself once, then stays quiet — the Beacons counter keeps the exact
+// count. See handleCSBK.
+const beaconLogInterval = 30 * time.Second
 
 // LockState is the payload of cc.locked / cc.lost events emitted by
 // the Tier II per-repeater state machine. DMR Tier II is conventional
@@ -55,6 +62,7 @@ type Counters struct {
 	FECPass  uint64 // Voice LC Header with BPTC + RS both valid
 	FECFail  uint64 // Voice LC Header BPTC uncorrectable or RS mismatch
 	Locks    uint64 // cc.locked declarations (lifetime)
+	Beacons  uint64 // CRC-valid CSBK "site alive" bursts (issue #1036)
 }
 
 // LockedFrequencyHz / LockedNAC make LockState satisfy
@@ -112,7 +120,12 @@ type ConventionalChannel struct {
 		fecPass  atomic.Uint64
 		fecFail  atomic.Uint64
 		locks    atomic.Uint64
+		beacons  atomic.Uint64
 	}
+
+	// beaconLogAt is the last time handleCSBK emitted an Info "site alive"
+	// line; guarded by mu and used only to rate-limit that log.
+	beaconLogAt time.Time
 }
 
 // Counters returns a snapshot of this channel's decode-activity
@@ -124,6 +137,7 @@ func (c *ConventionalChannel) Counters() Counters {
 		FECPass:  c.cnt.fecPass.Load(),
 		FECFail:  c.cnt.fecFail.Load(),
 		Locks:    c.cnt.locks.Load(),
+		Beacons:  c.cnt.beacons.Load(),
 	}
 }
 
@@ -177,8 +191,10 @@ func New(opts Options) *ConventionalChannel {
 // then nothing". Instead the lock is gated on a FEC-validated Voice LC
 // Header inside handleVoiceHeader (BPTC + RS both pass), mirroring Tier
 // III's lock-only-after-CRC discipline. Voice payload bursts (B-F)
-// don't carry a fresh FLC and CSBK bursts belong to Tier III, so they
-// fall through untouched.
+// don't carry a fresh FLC, so they fall through untouched. CSBK bursts
+// are routed to handleCSBK: on a conventional/IPSC repeater the periodic
+// idle "beacon" is a CSBK, and a CRC-valid one is surfaced as a "site
+// alive" signal (issue #1036) rather than being ignored.
 func (c *ConventionalChannel) IngestBurst(b *dmr.Burst, slot dmr.SlotType) {
 	c.cnt.bursts.Add(1)
 	switch slot.DataType {
@@ -186,6 +202,61 @@ func (c *ConventionalChannel) IngestBurst(b *dmr.Burst, slot dmr.SlotType) {
 		c.handleVoiceHeader(b, slot)
 	case dmr.DTTerminatorWithLC:
 		c.handleTerminator()
+	case dmr.DTCSBK:
+		c.handleCSBK(b, slot)
+	}
+}
+
+// handleCSBK processes a Control Signaling Block burst on the parked
+// conventional frequency. Issue #1036 asks for conventional DMR / IPSC
+// monitoring where the repeater drops to silence between calls and emits
+// periodic idle "beacons" — short transmissions that carry valid sync +
+// colour code but no voice — so the scanner can log the site as alive
+// instead of flagging the gaps as corrupt data. On DMR that beacon is a
+// CSBK (typically a Preamble or C_BCAST). Tier III owns CSBK *trunking*
+// semantics (grants, aloha); here we only need the keep-alive fact, so a
+// CRC-valid CSBK bumps the Beacons counter and (rate-limited) logs "site
+// alive".
+//
+// The gate is CRC-strict, mirroring handleVoiceHeader's FEC discipline:
+// a noise burst that false-syncs would have to survive BPTC(196,96)
+// correction *and* match the 16-bit CSBK CRC (mask 0x5A5A) to count, so
+// it cannot forge a beacon the way a bare slot-type decode could (the
+// "instalock cc=15" trap this package already guards against). A
+// BPTC-uncorrectable or CRC-failing CSBK is dropped at Debug and,
+// deliberately, is NOT published as a KindDecodeError: between-beacon
+// noise on a parked conventional channel is expected, and surfacing it as
+// a decode error is exactly the "treated as failed/corrupted data"
+// symptom #1036 reports.
+func (c *ConventionalChannel) handleCSBK(b *dmr.Burst, slot dmr.SlotType) {
+	payload := b.PayloadBits()
+	bits, errs := framing.DecodeBPTC196_96(payload)
+	if errs < 0 {
+		c.log.Debug("dmr/tier2: CSBK BPTC uncorrectable (between-beacon noise)", "cc", slot.ColorCode)
+		return
+	}
+	csbk, err := tier3.ParseCSBK(infoBitsToBytes(bits))
+	if err != nil {
+		c.log.Debug("dmr/tier2: CSBK CRC mismatch (between-beacon noise)", "cc", slot.ColorCode)
+		return
+	}
+	c.cnt.beacons.Add(1)
+
+	// Rate-limit the operator-facing Info line so a fast beacon interval
+	// doesn't flood the log; the counter still records every beacon.
+	c.mu.Lock()
+	now := c.now()
+	due := c.beaconLogAt.IsZero() || now.Sub(c.beaconLogAt) >= beaconLogInterval
+	if due {
+		c.beaconLogAt = now
+	}
+	c.mu.Unlock()
+	if due {
+		c.log.Info("dmr/tier2 site alive (beacon)",
+			"freq", c.freqHz, "cc", slot.ColorCode,
+			"csbk", csbk.Opcode.String(), "system", c.systemName)
+	} else {
+		c.log.Debug("dmr/tier2: beacon", "cc", slot.ColorCode, "csbk", csbk.Opcode.String())
 	}
 }
 

--- a/internal/radio/dmr/tier2/conventional_test.go
+++ b/internal/radio/dmr/tier2/conventional_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr/tier3"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
@@ -39,6 +40,110 @@ func burstWithFLC(f dmr.FLC) *dmr.Burst {
 			(channel[2*(dmr.HalfPayloadDibits+i)] << 1) | channel[2*(dmr.HalfPayloadDibits+i)+1]
 	}
 	return &b
+}
+
+// burstWithInfo96 builds a DMR burst whose 196-bit BPTC channel payload
+// carries the supplied 12-byte (96-bit) information block — the generic
+// form of burstWithFLC, used to inject a CSBK beacon block.
+func burstWithInfo96(info []byte) *dmr.Burst {
+	if len(info) != 12 {
+		panic("burstWithInfo96 requires a 12-byte info block")
+	}
+	bits := make([]byte, 96)
+	for i := 0; i < 96; i++ {
+		bits[i] = (info[i>>3] >> uint(7-(i&7))) & 1
+	}
+	channel := framing.EncodeBPTC196_96(bits)
+
+	var b dmr.Burst
+	for i := 0; i < dmr.HalfPayloadDibits; i++ {
+		b.Dibits[i] = (channel[2*i] << 1) | channel[2*i+1]
+	}
+	for i := 0; i < dmr.HalfPayloadDibits; i++ {
+		b.Dibits[dmr.BurstDibits-dmr.HalfPayloadDibits+i] =
+			(channel[2*(dmr.HalfPayloadDibits+i)] << 1) | channel[2*(dmr.HalfPayloadDibits+i)+1]
+	}
+	return &b
+}
+
+// TestConventionalCSBKBeaconMarksSiteAlive pins issue #1036: a CRC-valid
+// CSBK burst on a parked conventional/IPSC channel is recognised as a
+// "site alive" beacon — the Beacons counter increments — instead of being
+// ignored or surfaced as a decode error. Before the DTCSBK handler, CSBK
+// bursts fell straight through IngestBurst's switch and Beacons stayed 0.
+func TestConventionalCSBKBeaconMarksSiteAlive(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus:         bus,
+		SystemName:  "IPSCConv",
+		FrequencyHz: 451_012_500,
+		Now:         func() time.Time { return time.Unix(1_700_000_000, 0).UTC() },
+	})
+
+	// A Preamble CSBK is a canonical conventional/IPSC idle beacon.
+	info := tier3.AssembleCSBK(tier3.CSBK{Opcode: tier3.OpPreamble, FID: 0x00})
+	cc.IngestBurst(burstWithInfo96(info), dmr.SlotType{ColorCode: 3, DataType: dmr.DTCSBK})
+
+	if got := cc.Counters().Beacons; got != 1 {
+		t.Fatalf("Beacons = %d, want 1 (CRC-valid CSBK beacon should mark the site alive)", got)
+	}
+	if got := cc.Counters().FECFail; got != 0 {
+		t.Errorf("FECFail = %d, want 0 (a valid beacon must not count as a FEC failure)", got)
+	}
+	// A beacon must not forge a grant or a decode error.
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindGrant {
+				t.Fatalf("beacon wrongly published a grant: %+v", ev.Payload)
+			}
+			if ev.Kind == events.KindDecodeError {
+				t.Fatalf("beacon wrongly published a decode error: %+v", ev.Payload)
+			}
+		default:
+			return
+		}
+	}
+}
+
+// TestConventionalCSBKNoiseIsSilent pins the anti-spam half of #1036: a
+// CSBK-shaped burst whose CRC does not check (between-beacon noise on a
+// parked channel) must NOT increment Beacons and must NOT publish a
+// decode error — surfacing those gaps as corrupt data is the reported
+// symptom.
+func TestConventionalCSBKNoiseIsSilent(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus:         bus,
+		SystemName:  "IPSCConv",
+		FrequencyHz: 451_012_500,
+		Now:         func() time.Time { return time.Unix(1_700_000_000, 0).UTC() },
+	})
+
+	// Valid CSBK bytes with the CRC trailer corrupted so ParseCSBK's
+	// CRC check fails after a clean BPTC decode.
+	info := tier3.AssembleCSBK(tier3.CSBK{Opcode: tier3.OpPreamble, FID: 0x00})
+	info[11] ^= 0xFF // break the stored CRC
+	cc.IngestBurst(burstWithInfo96(info), dmr.SlotType{ColorCode: 3, DataType: dmr.DTCSBK})
+
+	if got := cc.Counters().Beacons; got != 0 {
+		t.Fatalf("Beacons = %d, want 0 (a CRC-failing CSBK is noise, not a beacon)", got)
+	}
+	select {
+	case ev := <-sub.C:
+		if ev.Kind == events.KindDecodeError {
+			t.Fatalf("between-beacon noise wrongly published a decode error: %+v", ev.Payload)
+		}
+	default:
+	}
 }
 
 // TestConventionalProtocolTagDirectMode pins the Tier I direct-mode

--- a/internal/scanner/widebandt2/engine.go
+++ b/internal/scanner/widebandt2/engine.go
@@ -1191,6 +1191,7 @@ func (e *Engine) maybeLogDiagnostics(now time.Time) {
 					"bursts", c.Bursts-ec.lastCnt.Bursts,
 					"fec_pass", fecPassDelta,
 					"fec_fail", c.FECFail-ec.lastCnt.FECFail,
+					"beacons", c.Beacons-ec.lastCnt.Beacons,
 					"locks_total", c.Locks)
 			}
 			ec.lastCnt = c

--- a/internal/sdr/rtlsdr/usb/usb_darwin_iokit.go
+++ b/internal/sdr/rtlsdr/usb/usb_darwin_iokit.go
@@ -52,6 +52,19 @@ const (
 	kIOReturnTimeout       = 0xE00002D6
 	kIOReturnExclusive     = 0xE00002C5 // already opened by another process
 	kIOReturnNotResponding = 0xE00002ED
+
+	// kIOUSBPipeStalled is the USB-family IOReturn the host controller
+	// raises when the device STALLs a pipe — "pipe has stalled, error
+	// needs to be cleared". Value from IOKit/usb/IOUSBLib.h:
+	// iokit_usb_err(0x4f) = sys_iokit(0xE0000000) | sub_iokit_usb(0x4000)
+	// | 0x4f = 0xE000404F. This is the macOS analog of the recoverable
+	// I²C-bridge stall that surfaces as syscall.EPIPE on Linux and
+	// ERROR_GEN_FAILURE on Windows/WinUSB; translateIOReturn maps all
+	// three to usb.ErrPipeStalled so the R820T cold-boot burst-write
+	// recovery (issue #248) fires identically across the OS matrix
+	// (issue #1038: NESDR/R820T tuner-init failed on macOS because this
+	// stall fell through as a raw kern_return the retry couldn't match).
+	kIOUSBPipeStalled = 0xE000404F
 )
 
 // CFNumberType for CFNumberGetValue. Only kCFNumberSInt32Type is
@@ -326,6 +339,11 @@ func translateIOReturn(rc uintptr) error {
 		return ErrDeviceGone
 	case kIOReturnTimeout:
 		return ErrTimeout
+	case kIOUSBPipeStalled:
+		// Recoverable pipe STALL — same class as Linux EPIPE / Windows
+		// ERROR_GEN_FAILURE. Surfacing the shared sentinel lets the
+		// tuner burst-write retry (isI2CBurstStall) recover on macOS.
+		return ErrPipeStalled
 	case kIOReturnAborted:
 		return ErrBulkInactive
 	case kIOReturnExclusive:

--- a/internal/sdr/rtlsdr/usb/usb_darwin_test.go
+++ b/internal/sdr/rtlsdr/usb/usb_darwin_test.go
@@ -3,9 +3,40 @@
 package usb
 
 import (
+	"errors"
 	"testing"
 	"unsafe"
 )
+
+// TestTranslateIOReturn_PipeStalledMapsToErrPipeStalled pins the fix for
+// issue #1038: on macOS a NESDR/R820T tuner init failed with
+//
+//	tuner init: r82xx init: burst write: rtl2832u: I2CWrite addr=0x34:
+//	usb: DeviceRequest OUT: usb: IOKit kern_return 0xe000404f
+//
+// 0xe000404f is kIOUSBPipeStalled — the recoverable I²C-bridge STALL
+// that surfaces as syscall.EPIPE on Linux and ERROR_GEN_FAILURE on
+// Windows. The R820T cold-boot burst-write recovery (issue #248) keys
+// off usb.ErrPipeStalled via isI2CBurstStall, so translateIOReturn must
+// map the IOKit stall to that shared sentinel or the retry never fires
+// and tuner detection reports "no supported tuner detected". This is the
+// macOS analog of TestWinErr_GenFailureMapsToPipeStalled.
+func TestTranslateIOReturn_PipeStalledMapsToErrPipeStalled(t *testing.T) {
+	got := translateIOReturn(kIOUSBPipeStalled)
+	if !errors.Is(got, ErrPipeStalled) {
+		t.Fatalf("translateIOReturn(0x%08x) = %v, want errors.Is(err, ErrPipeStalled) so the R820T burst-write stall recovery fires on macOS", uint32(kIOUSBPipeStalled), got)
+	}
+}
+
+// TestKIOUSBPipeStalledValue guards the constant against a typo: the
+// value is Apple's iokit_usb_err(0x4f) and the whole fix hinges on it
+// exactly matching the kern_return the host controller returns.
+func TestKIOUSBPipeStalledValue(t *testing.T) {
+	const want = 0xE000404F // sys_iokit | sub_iokit_usb | 0x4f
+	if kIOUSBPipeStalled != want {
+		t.Fatalf("kIOUSBPipeStalled = 0x%08x, want 0x%08x", uint32(kIOUSBPipeStalled), uint32(want))
+	}
+}
 
 // These tests pin compile-time invariants (UUIDs, struct sizes,
 // vtable indices) that don't depend on IOKit actually loading at


### PR DESCRIPTION
## Summary

Two independent fixes from an open-issue review, on the shared review branch:

- **#1038** — on macOS, RTL-SDR (R820T) dongles failed to open with "no supported tuner detected" because the tuner's first I²C-bridge burst write STALLed the USB control pipe and the macOS backend didn't recognise the stall, so the existing R820T cold-boot burst-write retry never fired.
- **#1036** — conventional DMR / IPSC repeaters that park on a fixed carrier (no control channel) emit periodic idle *beacons* between calls; those bursts were ignored, so there was no "site alive" signal. Most of the request already ships as `protocol: dmr-tier2`; this adds beacon recognition.

## Changes

- **macOS USB (`internal/sdr/rtlsdr/usb`)**: map IOKit `kIOUSBPipeStalled` (`kern_return 0xe000404f`) to the shared `usb.ErrPipeStalled` sentinel in `translateIOReturn`, mirroring the Windows `ERROR_GEN_FAILURE` mapping and the Linux `EPIPE` path. The existing R820T burst-write recovery (`isI2CBurstStall` → per-chunk retry + chunk-size halving, issue #248) now fires on macOS. A control-pipe (EP0) stall is cleared by the host controller on the next SETUP, so retrying the same request is the correct recovery — same reasoning the Linux/Windows paths already use.
- **DMR Tier II (`internal/radio/dmr/tier2`)**: route `DTCSBK` bursts to a new `handleCSBK` that BPTC(196,96)-decodes and CRC-validates via `tier3.ParseCSBK` (CRC-CCITT, mask `0x5A5A`). A CRC-valid CSBK bumps a new `Beacons` counter and logs a rate-limited "site alive" line. The gate is CRC-strict — mirroring the Voice-LC-Header FEC discipline — so a false-synced noise burst can't forge a beacon. BPTC-uncorrectable / CRC-failing CSBKs are dropped at Debug and deliberately **not** published as `KindDecodeError` (between-beacon noise is expected, not a fault — that's the "treated as corrupt data" symptom the issue describes).
- **Wideband engine (`internal/scanner/widebandt2/engine.go`)**: surface the new `beacons` delta in the per-channel decode-activity diagnostic line.
- **CHANGELOG**: an Added bullet (#1036) and a Fixed bullet (#1038).

## Test plan

- [x] `make vet test` is green locally
- [ ] `make integration` — n/a (no daemon/DSP behaviour change; the DMR change is additive to the Tier II state machine and the USB change is darwin-only)
- [x] Added or updated tests where appropriate:
  - macOS (darwin-gated, the analog of the existing Windows `TestWinErr_GenFailureMapsToPipeStalled`): `translateIOReturn(kIOUSBPipeStalled)` must satisfy `errors.Is(err, ErrPipeStalled)`, plus a constant-value guard. The Linux-runnable `TestR82xx_InitBurst_ErrPipeStalled*` tests already pin the retry→recovery half of the chain.
  - DMR (failing-first, confirmed red without the fix): a CRC-valid CSBK marks the site alive (`Beacons=1`, no grant, no decode error); a CRC-broken CSBK stays silent (`Beacons=0`, no decode error).
- [ ] Smoke-tested against real hardware — **not yet**. Neither fix is on-air verified (I don't have an Apple-silicon Mac + R820T, and #1036 needs a real IPSC capture). #1038 awaits the reporter confirming the tuner initializes; #1036's on-air gate is the existing `TestDMRIPSCReplay` harness, and which specific beacon encodings a given system emits should be confirmed against a capture before widening beyond CSBK.

## Breaking changes

None. The macOS change only adds a stall→retry mapping; the DMR change is additive (a new burst type handled, a new counter, a new log line) and byte-identical for non-CSBK bursts.

## Docs / CHANGELOG

- [x] Added `## [Unreleased]` bullets to `CHANGELOG.md` (both are user-visible)
- [ ] README / docs — n/a

## Linked issues

Refs #1038, Refs #1036 (kept as `Refs`, not `Closes`, per the repo's verify-before-close policy — both await on-air confirmation).

<!-- Note for reviewers: these are two independent changes sharing one review branch; happy to split into two PRs if you'd prefer to land them separately. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaHjpxSRmHT7rF5eHjPyhD