### PR TITLE
nxdn: voice → PCM (grant follow + VCH decoder + composer chain)

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -838,6 +838,30 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 			log.Warn("daemon: dmr Tier III system has no dmr_band_plan; voice grants will be dropped (no-bandplan)",
 				"system", sys.Name)
 		}
+		var nxdnBandPlan *trunking.NXDNBandPlan
+		if bp := sys.NXDNBandPlan; bp != nil {
+			nxdnBandPlan = &trunking.NXDNBandPlan{}
+			if bp.Linear != nil {
+				nxdnBandPlan.Linear = &trunking.NXDNLinearBandPlan{
+					BaseHz:    bp.Linear.BaseHz,
+					SpacingHz: bp.Linear.SpacingHz,
+					Offset:    bp.Linear.Offset,
+				}
+			}
+			for _, e := range bp.Table {
+				nxdnBandPlan.Table = append(nxdnBandPlan.Table, trunking.NXDNBandPlanTableEntry{
+					Channel: e.Channel,
+					FreqHz:  e.FreqHz,
+				})
+			}
+		} else if proto == trunking.ProtocolNXDN {
+			// NXDN VCALL_ASSGN grants reference channels by number;
+			// without a band plan the decoder cannot resolve a downlink
+			// frequency and every voice grant is dropped. CC monitoring
+			// still works, so warn rather than fail the load.
+			log.Warn("daemon: nxdn system has no nxdn_band_plan; voice grants will be dropped (no-bandplan)",
+				"system", sys.Name)
+		}
 		var sites []trunking.ConfiguredSite
 		for _, sc := range sys.Sites {
 			sites = append(sites, trunking.ConfiguredSite{RFSS: sc.RFSS, Site: sc.Site, Name: sc.Name})
@@ -864,6 +888,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 			Sites:                   sites,
 			P25BandPlan:             p25BandPlan,
 			DMRBandPlan:             dmrBandPlan,
+			NXDNBandPlan:            nxdnBandPlan,
 			DMRInterleavedVoice:     resolveDMRInterleavedVoice(proto, sys.DMRInterleavedVoice),
 			TETRAColourCode:         sys.TETRAColourCode,
 			TETRAChannel:            sys.TETRAChannel,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1644,6 +1644,15 @@ type SystemConfig struct {
 	// LCN→Hz list). Ignored for non-dmr protocols.
 	DMRBandPlan *DMRBandPlanConfig `yaml:"dmr_band_plan"`
 
+	// NXDNBandPlan maps the traffic-channel number carried in each NXDN
+	// VCALL_ASSGN message to a downlink frequency. Required for NXDN
+	// voice follow — NXDN grants reference a channel by number, not an
+	// absolute frequency, so without this plan every voice grant is
+	// dropped. Provide exactly one of `linear` (regular base+spacing
+	// grid) or `table` (explicit channel→Hz list). Ignored for non-nxdn
+	// protocols.
+	NXDNBandPlan *NXDNBandPlanConfig `yaml:"nxdn_band_plan"`
+
 	// EncryptionKeys lists operator-supplied decryption keys for this
 	// system. GopherTrunk decrypts only with keys the operator
 	// already holds and is authorized to use — it performs no key
@@ -1701,6 +1710,31 @@ type DMRLinearBandPlanConfig struct {
 type DMRBandPlanTableEntryConfig struct {
 	LCN    uint16 `yaml:"lcn"`
 	FreqHz uint32 `yaml:"freq_hz"`
+}
+
+// NXDNBandPlanConfig is the operator-supplied NXDN traffic-channel →
+// frequency band plan for a system. Exactly one of Linear or Table
+// must be set (enforced by Config.Validate). See
+// internal/radio/nxdn/bandplan.go for the resolution math.
+type NXDNBandPlanConfig struct {
+	Linear *NXDNLinearBandPlanConfig      `yaml:"linear"`
+	Table  []NXDNBandPlanTableEntryConfig `yaml:"table"`
+}
+
+// NXDNLinearBandPlanConfig lays channels out on a regular grid:
+// freq = base_hz + (channel - offset) × spacing_hz. Set offset=1 for
+// sites that number channels from 1.
+type NXDNLinearBandPlanConfig struct {
+	BaseHz    uint32 `yaml:"base_hz"`
+	SpacingHz uint32 `yaml:"spacing_hz"`
+	Offset    int8   `yaml:"offset"`
+}
+
+// NXDNBandPlanTableEntryConfig is one explicit channel→downlink-frequency
+// mapping for sites whose channels don't fall on a regular grid.
+type NXDNBandPlanTableEntryConfig struct {
+	Channel uint16 `yaml:"channel"`
+	FreqHz  uint32 `yaml:"freq_hz"`
 }
 
 // EncryptionKeyConfig is one operator-supplied decryption key for a
@@ -2471,6 +2505,36 @@ func validateSystem(i int, s SystemConfig) error {
 					return fmt.Errorf("trunking.systems[%d].dmr_band_plan.table[%d]: duplicate lcn %d (also at table[%d])", i, k, e.LCN, prev)
 				}
 				seenLCN[e.LCN] = k
+			}
+		}
+	}
+	if bp := s.NXDNBandPlan; bp != nil {
+		hasLinear := bp.Linear != nil
+		hasTable := len(bp.Table) > 0
+		switch {
+		case hasLinear && hasTable:
+			return fmt.Errorf("trunking.systems[%d].nxdn_band_plan: set either linear or table, not both", i)
+		case !hasLinear && !hasTable:
+			return fmt.Errorf("trunking.systems[%d].nxdn_band_plan: one of linear or table is required", i)
+		}
+		if hasLinear {
+			if bp.Linear.SpacingHz == 0 {
+				return fmt.Errorf("trunking.systems[%d].nxdn_band_plan.linear: spacing_hz required (nonzero)", i)
+			}
+			if bp.Linear.BaseHz == 0 {
+				return fmt.Errorf("trunking.systems[%d].nxdn_band_plan.linear: base_hz required (nonzero)", i)
+			}
+		}
+		if hasTable {
+			seenCh := make(map[uint16]int, len(bp.Table))
+			for k, e := range bp.Table {
+				if e.FreqHz == 0 {
+					return fmt.Errorf("trunking.systems[%d].nxdn_band_plan.table[%d]: freq_hz required (nonzero)", i, k)
+				}
+				if prev, dup := seenCh[e.Channel]; dup {
+					return fmt.Errorf("trunking.systems[%d].nxdn_band_plan.table[%d]: duplicate channel %d (also at table[%d])", i, k, e.Channel, prev)
+				}
+				seenCh[e.Channel] = k
 			}
 		}
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -116,6 +116,12 @@ func TestValidate(t *testing.T) {
 		{"dmr band_plan linear zero base", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "dmr", DMRBandPlan: &DMRBandPlanConfig{Linear: &DMRLinearBandPlanConfig{BaseHz: 0, SpacingHz: 1}}}}}}, true},
 		{"dmr band_plan table zero freq", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "dmr", DMRBandPlan: &DMRBandPlanConfig{Table: []DMRBandPlanTableEntryConfig{{LCN: 1, FreqHz: 0}}}}}}}, true},
 		{"dmr band_plan table duplicate lcn", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "dmr", DMRBandPlan: &DMRBandPlanConfig{Table: []DMRBandPlanTableEntryConfig{{LCN: 1, FreqHz: 1}, {LCN: 1, FreqHz: 2}}}}}}}, true},
+		{"nxdn band_plan linear ok", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "nxdn", NXDNBandPlan: &NXDNBandPlanConfig{Linear: &NXDNLinearBandPlanConfig{BaseHz: 461_000_000, SpacingHz: 12_500, Offset: 1}}}}}}, false},
+		{"nxdn band_plan table ok", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "nxdn", NXDNBandPlan: &NXDNBandPlanConfig{Table: []NXDNBandPlanTableEntryConfig{{Channel: 1, FreqHz: 461_000_000}, {Channel: 2, FreqHz: 461_012_500}}}}}}}, false},
+		{"nxdn band_plan both linear and table", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "nxdn", NXDNBandPlan: &NXDNBandPlanConfig{Linear: &NXDNLinearBandPlanConfig{BaseHz: 1, SpacingHz: 1}, Table: []NXDNBandPlanTableEntryConfig{{Channel: 1, FreqHz: 1}}}}}}}, true},
+		{"nxdn band_plan empty", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "nxdn", NXDNBandPlan: &NXDNBandPlanConfig{}}}}}, true},
+		{"nxdn band_plan linear zero spacing", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "nxdn", NXDNBandPlan: &NXDNBandPlanConfig{Linear: &NXDNLinearBandPlanConfig{BaseHz: 1, SpacingHz: 0}}}}}}, true},
+		{"nxdn band_plan table duplicate channel", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "nxdn", NXDNBandPlan: &NXDNBandPlanConfig{Table: []NXDNBandPlanTableEntryConfig{{Channel: 1, FreqHz: 1}, {Channel: 1, FreqHz: 2}}}}}}}, true},
 		// wideband role: pin a dongle to a centre frequency and list
 		// per-repeater carriers inside its IQ bandwidth. Stage 2 added
 		// DMR Tier II conventional; Stage 3 added DMR Tier III trunked

--- a/internal/configbuilder/fieldmeta.go
+++ b/internal/configbuilder/fieldmeta.go
@@ -171,6 +171,7 @@ var fieldMetas = map[string]FieldMeta{
 	"SystemConfig.RIDAliasFile":    {Label: "RID alias file", Help: "Optional CSV/JSON catalogue of radio-ID (subscriber) aliases for this system."},
 	"SystemConfig.P25BandPlan":     {Label: "P25 band plan", Help: "Static IDEN_UP slot seeds for P25 Phase 1 sites that route grants through an unannounced channel ID. P25 Phase 1 only."},
 	"SystemConfig.DMRBandPlan":     {Label: "DMR band plan", Help: "LCN→frequency map REQUIRED for DMR Tier III voice grants. Pick linear (grid) or table (explicit list). DMR only."},
+	"SystemConfig.NXDNBandPlan":    {Label: "NXDN band plan", Help: "Channel→frequency map REQUIRED for NXDN voice grants (VCALL_ASSGN references a channel number). Pick linear (grid) or table (explicit list). NXDN only."},
 	"SystemConfig.EncryptionKeys":  {Help: "Operator-held decryption keys (today DMR RC4 'Enhanced Privacy'). No key recovery is performed."},
 	"SystemConfig.EncryptedCalls":  {Help: "How scarce voice SDRs are allocated to encrypted calls on this system, so encrypted traffic can't starve clear calls (issue #711)."},
 	// SystemConfig advanced protocol knobs (edited under the Advanced group).
@@ -210,6 +211,14 @@ var fieldMetas = map[string]FieldMeta{
 	"DMRLinearBandPlanConfig.Offset":     {Help: "LCN the grid starts numbering from. Set 1 for sites that number LCNs from 1."},
 	"DMRBandPlanTableEntryConfig.LCN":    {Label: "LCN", Help: "12-bit Logical (Physical) Channel Number from the grant CSBK."},
 	"DMRBandPlanTableEntryConfig.FreqHz": {Label: "Frequency", Hz: true, Help: "Downlink frequency this LCN maps to."},
+
+	"NXDNBandPlanConfig.Linear":            {Help: "Regular base+spacing grid: freq = base + (channel − offset) × spacing."},
+	"NXDNBandPlanConfig.Table":             {Help: "Explicit channel→frequency list for sites that don't fall on a regular grid."},
+	"NXDNLinearBandPlanConfig.BaseHz":      {Label: "Base frequency", Hz: true, Help: "Downlink frequency of the first channel."},
+	"NXDNLinearBandPlanConfig.SpacingHz":   {Label: "Spacing", Hz: true, Help: "Frequency step between consecutive channels."},
+	"NXDNLinearBandPlanConfig.Offset":      {Help: "Channel the grid starts numbering from. Set 1 for sites that number channels from 1."},
+	"NXDNBandPlanTableEntryConfig.Channel": {Label: "Channel", Help: "Traffic-channel number from the VCALL_ASSGN message."},
+	"NXDNBandPlanTableEntryConfig.FreqHz":  {Label: "Frequency", Hz: true, Help: "Downlink frequency this channel maps to."},
 
 	"EncryptionKeyConfig.KeyID":     {Label: "Key ID", Help: "Key identifier the radios carry in the privacy header, so a system that rotates keys still resolves."},
 	"EncryptionKeyConfig.Algorithm": {Help: "Decryption algorithm. Today only DMR RC4 (Enhanced Privacy).", Options: opts("rc4", "rc4 (DMR Enhanced Privacy)")},

--- a/internal/configbuilder/webschema_test.go
+++ b/internal/configbuilder/webschema_test.go
@@ -39,8 +39,17 @@ var webRoundTripAllow = map[string][]string{
 	// through the SystemConfig index signature and the whole Sites array
 	// (each a SiteConfig) is preserved as unknown JSON. Editable in the TUI
 	// and raw YAML; a bespoke web editor is a follow-up.
-	"SystemConfig": {"Sites"},
+	"SystemConfig": {"Sites", "NXDNBandPlan"},
 	"SiteConfig":   {"RFSS", "Site", "Name"},
+
+	// NXDN channel→frequency band plan (WS2a). Required for NXDN voice
+	// grants (VCALL_ASSGN references a channel number, not a frequency).
+	// Round-trips through the SystemConfig index signature and is fully
+	// editable in the TUI and raw YAML; a bespoke web editor (mirroring
+	// the DMR band plan section) is a follow-up.
+	"NXDNBandPlanConfig":           {"Linear", "Table"},
+	"NXDNLinearBandPlanConfig":     {"BaseHz", "SpacingHz", "Offset"},
+	"NXDNBandPlanTableEntryConfig": {"Channel", "FreqHz"},
 
 	// Research/offline cryptolab crypto-frame capture path, and cross-site
 	// duplicate-recording suppression (recordings.dedup) — both round-trip via

--- a/internal/radio/nxdn/bandplan.go
+++ b/internal/radio/nxdn/bandplan.go
@@ -1,0 +1,87 @@
+package nxdn
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// Resolver maps an NXDN traffic-channel number (as carried in a
+// VCALL_ASSGN message) to its downlink frequency in Hz. Two
+// implementations ship, mirroring the DMR Tier III band plan
+// (internal/radio/dmr/tier3): LinearBandPlan for sites that lay
+// channels out on a regular base+spacing grid, and TableBandPlan for
+// the irregular cases where the operator hand-codes the channel → Hz
+// mapping from a license / coordination database.
+type Resolver interface {
+	Frequency(channel uint16) (uint32, error)
+}
+
+// ErrUnknownChannel is returned by a Resolver when the supplied
+// channel is outside the configured plan. The control channel drops
+// such grants (they cannot be tuned) rather than publishing them.
+var ErrUnknownChannel = errors.New("nxdn: channel outside band plan")
+
+// LinearBandPlan resolves channel → BaseHz + (channel - Offset) ×
+// SpacingHz. Offset lets sites that start their channel numbering at 1
+// keep BaseHz pinned to the actual channel-1 downlink.
+type LinearBandPlan struct {
+	BaseHz    uint32
+	SpacingHz uint32
+	Offset    int8 // typically 1 to match channel-1-indexed sites
+}
+
+func (b LinearBandPlan) Frequency(channel uint16) (uint32, error) {
+	if b.SpacingHz == 0 {
+		return 0, fmt.Errorf("nxdn: linear band plan needs non-zero SpacingHz")
+	}
+	idx := int32(channel) - int32(b.Offset)
+	if idx < 0 {
+		return 0, fmt.Errorf("%w: channel=%d below Offset=%d", ErrUnknownChannel, channel, b.Offset)
+	}
+	hz := uint64(b.BaseHz) + uint64(idx)*uint64(b.SpacingHz)
+	if hz > 0xFFFFFFFF {
+		return 0, fmt.Errorf("nxdn: resolved frequency %d Hz overflows uint32", hz)
+	}
+	return uint32(hz), nil
+}
+
+// TableBandPlan is a hand-coded channel → Hz lookup. The map is
+// consulted directly; missing keys return ErrUnknownChannel.
+type TableBandPlan map[uint16]uint32
+
+func (t TableBandPlan) Frequency(channel uint16) (uint32, error) {
+	hz, ok := t[channel]
+	if !ok {
+		return 0, fmt.Errorf("%w: channel=%d", ErrUnknownChannel, channel)
+	}
+	return hz, nil
+}
+
+// ResolverFromPlan builds a Resolver from the operator-supplied band
+// plan carried on a trunking.System. It returns nil when p is nil or
+// empty so callers can pass the result straight into
+// ControlChannel.SetBandPlan and preserve the "no band plan ⇒ drop
+// grant" behaviour. Config validation guarantees exactly one of Linear
+// / Table is set; if both are somehow present Linear wins.
+func ResolverFromPlan(p *trunking.NXDNBandPlan) Resolver {
+	if p == nil {
+		return nil
+	}
+	if p.Linear != nil {
+		return LinearBandPlan{
+			BaseHz:    p.Linear.BaseHz,
+			SpacingHz: p.Linear.SpacingHz,
+			Offset:    p.Linear.Offset,
+		}
+	}
+	if len(p.Table) > 0 {
+		t := make(TableBandPlan, len(p.Table))
+		for _, e := range p.Table {
+			t[e.Channel] = e.FreqHz
+		}
+		return t
+	}
+	return nil
+}

--- a/internal/radio/nxdn/bandplan_test.go
+++ b/internal/radio/nxdn/bandplan_test.go
@@ -1,0 +1,82 @@
+package nxdn
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+func TestLinearBandPlanResolves(t *testing.T) {
+	// Channel-1-indexed site: channel 1 → BaseHz, +SpacingHz per channel.
+	b := LinearBandPlan{BaseHz: 461_000_000, SpacingHz: 12_500, Offset: 1}
+	cases := []struct {
+		ch   uint16
+		want uint32
+	}{
+		{1, 461_000_000},
+		{2, 461_012_500},
+		{5, 461_050_000},
+	}
+	for _, tc := range cases {
+		got, err := b.Frequency(tc.ch)
+		if err != nil {
+			t.Errorf("Frequency(%d) error: %v", tc.ch, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("Frequency(%d) = %d, want %d", tc.ch, got, tc.want)
+		}
+	}
+}
+
+func TestLinearBandPlanRejectsBelowOffset(t *testing.T) {
+	b := LinearBandPlan{BaseHz: 461_000_000, SpacingHz: 12_500, Offset: 1}
+	if _, err := b.Frequency(0); !errors.Is(err, ErrUnknownChannel) {
+		t.Errorf("Frequency(0) err = %v, want ErrUnknownChannel", err)
+	}
+}
+
+func TestLinearBandPlanNeedsSpacing(t *testing.T) {
+	b := LinearBandPlan{BaseHz: 461_000_000, Offset: 1}
+	if _, err := b.Frequency(1); err == nil {
+		t.Error("Frequency with zero SpacingHz should error")
+	}
+}
+
+func TestTableBandPlanResolves(t *testing.T) {
+	tbl := TableBandPlan{3: 462_000_000, 7: 462_500_000}
+	if got, err := tbl.Frequency(7); err != nil || got != 462_500_000 {
+		t.Errorf("Frequency(7) = %d, %v; want 462500000, nil", got, err)
+	}
+	if _, err := tbl.Frequency(4); !errors.Is(err, ErrUnknownChannel) {
+		t.Errorf("Frequency(4) err = %v, want ErrUnknownChannel", err)
+	}
+}
+
+func TestResolverFromPlan(t *testing.T) {
+	if ResolverFromPlan(nil) != nil {
+		t.Error("nil plan should yield nil resolver")
+	}
+	if ResolverFromPlan(&trunking.NXDNBandPlan{}) != nil {
+		t.Error("empty plan should yield nil resolver")
+	}
+	lin := ResolverFromPlan(&trunking.NXDNBandPlan{
+		Linear: &trunking.NXDNLinearBandPlan{BaseHz: 461_000_000, SpacingHz: 12_500, Offset: 1},
+	})
+	if lin == nil {
+		t.Fatal("linear plan should yield a resolver")
+	}
+	if got, _ := lin.Frequency(2); got != 461_012_500 {
+		t.Errorf("linear resolver Frequency(2) = %d, want 461012500", got)
+	}
+	tbl := ResolverFromPlan(&trunking.NXDNBandPlan{
+		Table: []trunking.NXDNBandPlanTableEntry{{Channel: 9, FreqHz: 463_000_000}},
+	})
+	if tbl == nil {
+		t.Fatal("table plan should yield a resolver")
+	}
+	if got, _ := tbl.Frequency(9); got != 463_000_000 {
+		t.Errorf("table resolver Frequency(9) = %d, want 463000000", got)
+	}
+}

--- a/internal/radio/nxdn/cac.go
+++ b/internal/radio/nxdn/cac.go
@@ -127,6 +127,35 @@ func ParseVCall(p [8]byte) VCallPayload {
 	}
 }
 
+// VCallAssignPayload represents the payload of a VCALL_ASSGN (RCCH
+// 0x04) message — the channel-assignment that grants a voice call a
+// traffic channel. The group + source identify the call and Channel is
+// the assigned traffic-channel number the band plan resolves to a
+// downlink frequency (see bandplan.go).
+//
+// Like VCallPayload, the exact bit layout depends on the NXDN service
+// variant; the offsets below match the common Type-C trunked variant
+// (ServiceOptions, group, source, then the assigned channel). They are
+// structural and not yet validated against an on-air capture — keep
+// them easy to correct once a capture lands.
+type VCallAssignPayload struct {
+	ServiceOptions uint8
+	GroupAddress   uint16
+	SourceID       uint16
+	Channel        uint16
+}
+
+// ParseVCallAssign extracts the VCALL_ASSGN fields from the 8-byte
+// payload.
+func ParseVCallAssign(p [8]byte) VCallAssignPayload {
+	return VCallAssignPayload{
+		ServiceOptions: p[0],
+		GroupAddress:   binary.BigEndian.Uint16(p[1:3]),
+		SourceID:       binary.BigEndian.Uint16(p[3:5]),
+		Channel:        binary.BigEndian.Uint16(p[5:7]),
+	}
+}
+
 // SiteInfoPayload represents the SITE_INFO message used by the trunked
 // variant for site identification broadcasts.
 type SiteInfoPayload struct {

--- a/internal/radio/nxdn/control.go
+++ b/internal/radio/nxdn/control.go
@@ -3,8 +3,10 @@ package nxdn
 import (
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
 
 // LockState is the payload of cc.locked / cc.lost events emitted by the
@@ -45,6 +47,18 @@ type ControlChannel struct {
 	locked bool
 	last   LockState
 	topo   topologyModel
+
+	// systemName labels published grants so the trunking engine can
+	// match them to the configured trunking.System. Empty until set
+	// by the connector via SetSystemName.
+	systemName string
+	// bandPlan resolves a VCALL_ASSGN traffic-channel number to a
+	// downlink frequency. nil until set via SetBandPlan; while nil,
+	// voice grants are dropped (they have no frequency to tune).
+	bandPlan Resolver
+	// now returns the current time for grant timestamps; overridable
+	// in tests. Defaults to time.Now.
+	now func() time.Time
 
 	// proc is the cross-call dibit / sync state the Process
 	// adapter uses (see process.go). Lazily constructed on the
@@ -149,8 +163,18 @@ func NewControlChannel(bus *events.Bus, log *slog.Logger, freqHz uint32, rate Ba
 	if log == nil {
 		log = slog.Default()
 	}
-	return &ControlChannel{bus: bus, log: log, freqHz: freqHz, rate: rate}
+	return &ControlChannel{bus: bus, log: log, freqHz: freqHz, rate: rate, now: time.Now}
 }
+
+// SetSystemName sets the system name stamped on published grants so the
+// trunking engine can match them to the configured trunking.System.
+func (c *ControlChannel) SetSystemName(name string) { c.systemName = name }
+
+// SetBandPlan installs the resolver that maps a VCALL_ASSGN
+// traffic-channel number to a downlink frequency. Pass nil (the
+// default) to keep dropping voice grants for want of a frequency.
+// Build one with ResolverFromPlan(system.NXDNBandPlan).
+func (c *ControlChannel) SetBandPlan(r Resolver) { c.bandPlan = r }
 
 // IngestFrame consumes one decoded NXDN frame. The caller must have
 // already extracted and parsed the LICH and CAC fields.
@@ -168,7 +192,48 @@ func (c *ControlChannel) IngestFrame(lich LICH, cac *CACMessage) {
 		c.maybeLock(LockState{FrequencyHz: c.freqHz, BaudRate: c.rate, SiteID: s.SiteID, SystemID: s.SystemID})
 	case RCCHCCH:
 		c.maybeLock(LockState{FrequencyHz: c.freqHz, BaudRate: c.rate})
+	case RCCHVCALLASGN:
+		c.publishGrant(ParseVCallAssign(cac.Payload))
 	}
+}
+
+// publishGrant resolves a VCALL_ASSGN's traffic-channel number to a
+// downlink frequency and publishes a protocol-neutral voice grant on
+// the bus so the trunking engine tunes a Voice device to the call.
+// Drops the grant (no publish) when no band plan is configured or the
+// channel is outside it — mirrors the DMR Tier III "no-bandplan ⇒ drop"
+// behaviour, since a grant with no frequency cannot be followed.
+func (c *ControlChannel) publishGrant(a VCallAssignPayload) {
+	if c.bandPlan == nil {
+		c.log.Warn("nxdn: voice grant dropped; no band plan configured",
+			"system", c.systemName, "group", a.GroupAddress, "channel", a.Channel)
+		return
+	}
+	freq, err := c.bandPlan.Frequency(a.Channel)
+	if err != nil {
+		c.log.Warn("nxdn: voice grant dropped; channel outside band plan",
+			"system", c.systemName, "group", a.GroupAddress, "channel", a.Channel, "err", err)
+		return
+	}
+	now := c.now
+	if now == nil {
+		now = time.Now
+	}
+	c.bus.Publish(events.Event{
+		Kind: events.KindGrant,
+		Payload: trunking.Grant{
+			System:      c.systemName,
+			Protocol:    "nxdn",
+			GroupID:     uint32(a.GroupAddress),
+			SourceID:    uint32(a.SourceID),
+			FrequencyHz: freq,
+			ChannelNum:  a.Channel,
+			At:          now(),
+		},
+	})
+	c.log.Debug("nxdn: voice grant",
+		"system", c.systemName, "group", a.GroupAddress, "src", a.SourceID,
+		"channel", a.Channel, "freq_hz", freq)
 }
 
 func (c *ControlChannel) maybeLock(s LockState) {

--- a/internal/radio/nxdn/control_test.go
+++ b/internal/radio/nxdn/control_test.go
@@ -5,7 +5,18 @@ import (
 	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
+
+func TestParseVCallAssign(t *testing.T) {
+	// ServiceOptions=0x01, group=0x00C8, source=0x1234, channel=0x0007.
+	p := [8]byte{0x01, 0x00, 0xC8, 0x12, 0x34, 0x00, 0x07, 0x00}
+	got := ParseVCallAssign(p)
+	if got.ServiceOptions != 0x01 || got.GroupAddress != 0x00C8 ||
+		got.SourceID != 0x1234 || got.Channel != 0x0007 {
+		t.Errorf("ParseVCallAssign = %+v", got)
+	}
+}
 
 func TestControlChannelEmitsLockOnSiteInfo(t *testing.T) {
 	bus := events.NewBus(8)
@@ -26,6 +37,61 @@ func TestControlChannelEmitsLockOnSiteInfo(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("no event")
+	}
+}
+
+func TestControlChannelEmitsGrantOnVCallAssign(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := NewControlChannel(bus, nil, 467_000_000, Rate9600)
+	cc.SetSystemName("Metro")
+	// Channel-1-indexed linear plan: channel 3 → 461_000_000 + 2*12_500.
+	cc.SetBandPlan(LinearBandPlan{BaseHz: 461_000_000, SpacingHz: 12_500, Offset: 1})
+
+	lich := ParseLICH(AssembleLICH(LICH{RFCh: RFChControl, FCT: FCTNSACCH, Direction: DirectionOutbound}))
+	// VCALL_ASSGN: ServiceOptions, group=0x0064, source=0x1092, channel=3.
+	cac := &CACMessage{Type: RCCHVCALLASGN, Payload: [8]byte{0x00, 0x00, 0x64, 0x10, 0x92, 0x00, 0x03, 0x00}}
+	cc.IngestFrame(lich, cac)
+
+	select {
+	case ev := <-sub.C:
+		if ev.Kind != events.KindGrant {
+			t.Fatalf("event kind = %s, want grant", ev.Kind)
+		}
+		g := ev.Payload.(trunking.Grant)
+		if g.Protocol != "nxdn" || g.System != "Metro" {
+			t.Errorf("grant identity = %+v", g)
+		}
+		if g.GroupID != 0x0064 || g.SourceID != 0x1092 || g.ChannelNum != 3 {
+			t.Errorf("grant ids = group %d src %d chan %d", g.GroupID, g.SourceID, g.ChannelNum)
+		}
+		if g.FrequencyHz != 461_025_000 {
+			t.Errorf("grant freq = %d, want 461025000", g.FrequencyHz)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no grant event")
+	}
+}
+
+func TestControlChannelDropsGrantWithoutBandPlan(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := NewControlChannel(bus, nil, 467_000_000, Rate9600)
+	// No SetBandPlan → grant has no frequency to tune → dropped.
+	lich := ParseLICH(AssembleLICH(LICH{RFCh: RFChControl, FCT: FCTNSACCH, Direction: DirectionOutbound}))
+	cac := &CACMessage{Type: RCCHVCALLASGN, Payload: [8]byte{0x00, 0x00, 0x64, 0x10, 0x92, 0x00, 0x03, 0x00}}
+	cc.IngestFrame(lich, cac)
+
+	select {
+	case ev := <-sub.C:
+		t.Errorf("unexpected event: %s", ev.Kind)
+	case <-time.After(50 * time.Millisecond):
 	}
 }
 

--- a/internal/radio/nxdn/traffic.go
+++ b/internal/radio/nxdn/traffic.go
@@ -1,0 +1,101 @@
+package nxdn
+
+import (
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
+
+// TrafficChannel decodes NXDN VCH (voice) traffic frames from the raw
+// dibit stream, in parallel to (and independent of) the
+// control-channel ControlChannel. The CC path (process.go / control.go)
+// is hardwired to CAC and gates on RFCh==RFChControl, so voice needs its
+// own adapter: this one runs its own outbound-FSW SyncDetector, slices
+// each frame's LICH + Information field, and — for RFChTraffic frames —
+// routes the 144-dibit Info field through ExtractVCHFrames, delivering
+// the decoded AMBE+2 voice frames to a sink callback.
+//
+// The dibit stream + baseIdx contract matches ControlChannel.Process
+// (continuous stream, monotonic baseIdx). Attach a TrafficChannel to the
+// same receiver DibitSink used for the CC, or a dedicated voice-tap
+// receiver.
+//
+// ⚠️ UNVERIFIED ON AIR — see voice_ambe.go / voice.go.
+type TrafficChannel struct {
+	det          *SyncDetector
+	remaining    int
+	frame        []uint8
+	matchScratch []Match
+	sink         func(frames []VCHFrame)
+}
+
+// postSyncDibitsTraffic is the count of dibits collected after the
+// 8-dibit FSW match for a full traffic frame: 8 LICH wire + 32 SACCH +
+// 144 Information = 184 dibits (the whole 192-dibit frame minus the FSW).
+const postSyncDibitsTraffic = LICHWireDibits + SACCHDibits + InfoFieldDibits
+
+// NewTrafficChannel builds a traffic-frame decoder. sink receives the
+// decoded voice frames of each RFChTraffic frame (never called with an
+// empty slice).
+func NewTrafficChannel(sink func(frames []VCHFrame)) *TrafficChannel {
+	return &TrafficChannel{
+		det:   NewSyncDetector([][]uint8{FSWDibitsOutbound}, 1),
+		frame: make([]uint8, 0, postSyncDibitsTraffic),
+		sink:  sink,
+	}
+}
+
+// Process consumes a window of raw dibits (same contract as
+// ControlChannel.Process) and returns baseIdx+len(dibits). It mirrors
+// the process.go countdown: on each outbound FSW match it collects the
+// next postSyncDibitsTraffic dibits, then decodes the frame.
+func (t *TrafficChannel) Process(dibits []uint8, baseIdx int) int {
+	t.matchScratch, _ = t.det.Process(t.matchScratch[:0], dibits, baseIdx)
+	matchIdx := 0
+	for i, d := range dibits {
+		absPos := baseIdx + i
+		if t.remaining > 0 {
+			t.frame = append(t.frame, d)
+			t.remaining--
+			if t.remaining == 0 {
+				t.handleFrame(t.frame)
+				t.frame = t.frame[:0]
+			}
+		}
+		for matchIdx < len(t.matchScratch) && t.matchScratch[matchIdx].Index == absPos {
+			if !t.matchScratch[matchIdx].Inbound {
+				t.remaining = postSyncDibitsTraffic
+				t.frame = t.frame[:0]
+			}
+			matchIdx++
+		}
+	}
+	return baseIdx + len(dibits)
+}
+
+// handleFrame slices a collected post-sync traffic frame: LICH (8 wire
+// dibits), SACCH (32, currently skipped), Information (144). Only
+// RFChTraffic frames with a valid LICH parity are routed to the VCH
+// decoder; everything else (control frames, corrupt LICH) is dropped.
+func (t *TrafficChannel) handleFrame(frame []uint8) {
+	if len(frame) != postSyncDibitsTraffic {
+		return
+	}
+	lichBits := framing.DibitsToBits(frame[0:LICHWireDibits])
+	lichByte, _ := DecodeLICHWire(lichBits)
+	lich := ParseLICH(lichByte)
+	if !lich.ParityOK || lich.RFCh != RFChTraffic {
+		return
+	}
+	infoStart := LICHWireDibits + SACCHDibits
+	info := frame[infoStart : infoStart+InfoFieldDibits]
+	frames := ExtractVCHFrames(info)
+	if len(frames) > 0 && t.sink != nil {
+		t.sink(frames)
+	}
+}
+
+// Reset clears the sync-detection + partial-frame state; call on retune.
+func (t *TrafficChannel) Reset() {
+	t.det.Reset()
+	t.remaining = 0
+	t.frame = t.frame[:0]
+}

--- a/internal/radio/nxdn/traffic_test.go
+++ b/internal/radio/nxdn/traffic_test.go
@@ -1,0 +1,90 @@
+package nxdn
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
+
+// buildTrafficFrame assembles a full NXDN frame preceded by warm-up
+// filler: warmup(8) + FSW(8) + LICH wire(8) + SACCH(32, zeros) +
+// Info(144). The warm-up primes the SyncDetector (it needs FSWDibits of
+// history before it can match), mirroring a live stream where the FSW is
+// never the very first dibit. rfch selects the LICH RF-channel type so
+// the same builder makes traffic and control frames.
+func buildTrafficFrame(t *testing.T, rfch RFChannelType, info []uint8) []uint8 {
+	t.Helper()
+	lichByte := AssembleLICH(LICH{RFCh: rfch, FCT: FCTNSACCH, Direction: DirectionOutbound})
+	lichWire := framing.BitsToDibits(EncodeLICHWire(lichByte))
+	if len(lichWire) != LICHWireDibits {
+		t.Fatalf("lich wire = %d dibits, want %d", len(lichWire), LICHWireDibits)
+	}
+	frame := make([]uint8, 0, FSWDibits+FrameDibits)
+	frame = append(frame, make([]uint8, FSWDibits)...) // warm-up filler (primes the detector)
+	frame = append(frame, FSWDibitsOutbound...)
+	frame = append(frame, lichWire...)
+	frame = append(frame, make([]uint8, SACCHDibits)...) // SACCH (skipped)
+	frame = append(frame, info...)
+	if len(frame) != FSWDibits+FrameDibits {
+		t.Fatalf("frame = %d dibits, want %d", len(frame), FSWDibits+FrameDibits)
+	}
+	return frame
+}
+
+func TestTrafficChannelDecodesVCH(t *testing.T) {
+	payloads := [4][]byte{mkInfo(11), mkInfo(22), mkInfo(33), mkInfo(44)}
+	info := buildVCHInfoDibits(t, payloads)
+	frame := buildTrafficFrame(t, RFChTraffic, info)
+
+	var got [][]VCHFrame
+	tc := NewTrafficChannel(func(frames []VCHFrame) {
+		got = append(got, frames)
+	})
+	tc.Process(frame, 0)
+
+	if len(got) != 1 {
+		t.Fatalf("sink called %d times, want 1", len(got))
+	}
+	if len(got[0]) != VCHVoiceFramesPerFrame {
+		t.Fatalf("got %d voice frames, want %d", len(got[0]), VCHVoiceFramesPerFrame)
+	}
+	for i, f := range got[0] {
+		for j := range payloads[i] {
+			if f.Payload[j] != payloads[i][j] {
+				t.Fatalf("voice frame %d bit %d: got %d want %d", i, j, f.Payload[j], payloads[i][j])
+			}
+		}
+	}
+}
+
+func TestTrafficChannelIgnoresControlFrame(t *testing.T) {
+	payloads := [4][]byte{mkInfo(1), mkInfo(2), mkInfo(3), mkInfo(4)}
+	info := buildVCHInfoDibits(t, payloads)
+	frame := buildTrafficFrame(t, RFChControl, info) // control LICH → not voice
+
+	called := false
+	tc := NewTrafficChannel(func(frames []VCHFrame) { called = true })
+	tc.Process(frame, 0)
+
+	if called {
+		t.Error("sink should not fire for a control-LICH frame")
+	}
+}
+
+func TestTrafficChannelSurvivesChunkedFeed(t *testing.T) {
+	payloads := [4][]byte{mkInfo(5), mkInfo(6), mkInfo(7), mkInfo(8)}
+	info := buildVCHInfoDibits(t, payloads)
+	frame := buildTrafficFrame(t, RFChTraffic, info)
+
+	var got [][]VCHFrame
+	tc := NewTrafficChannel(func(frames []VCHFrame) { got = append(got, frames) })
+	// Feed one dibit at a time to exercise the cross-call countdown.
+	base := 0
+	for i := 0; i < len(frame); i++ {
+		tc.Process(frame[i:i+1], base)
+		base++
+	}
+	if len(got) != 1 || len(got[0]) != VCHVoiceFramesPerFrame {
+		t.Fatalf("chunked feed decoded %v frame-batches", got)
+	}
+}

--- a/internal/radio/nxdn/voice.go
+++ b/internal/radio/nxdn/voice.go
@@ -1,0 +1,57 @@
+package nxdn
+
+import (
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
+
+// VCH (traffic voice channel) decode for NXDN.
+//
+// An NXDN traffic frame's 288-bit Information field (frame.go
+// Frame.Info() = Dibits[48:192], InfoFieldDibits=144) carries the VCH
+// voice payload as 4 AMBE+2 voice frames of 72 on-air bits each
+// (4 × 72 = 288). Each 20 ms AMBE+2 frame decodes (voice_ambe.go) to a
+// 49-bit vocoder payload; four of them span the 80 ms NXDN frame.
+//
+// ⚠️ UNVERIFIED ON AIR — see voice_ambe.go. The 4×72 carve and the AMBE
+// deinterleave are transcribed from spec/reference and validated only by
+// the synthetic round-trip; a real NXDN VCH capture is needed to confirm
+// them (and the codebook variant).
+
+// VCHVoiceFramesPerFrame is the number of AMBE+2 voice frames the VCH
+// carries in one 80 ms NXDN frame.
+const VCHVoiceFramesPerFrame = 4
+
+// VCHFrame is one decoded AMBE+2 voice frame carved from a VCH burst.
+type VCHFrame struct {
+	// Payload is the 49-bit vocoder payload, one bit per byte, in the
+	// order DecodeVCHFrame emits (C0:12 + C1:12 + C2:11 + C3:14). Pack
+	// it MSB-first to 7 bytes (framing.PackBitsMSB) for the ambe2
+	// decoder.
+	Payload []byte
+	// Errors is the Golay-corrected bit count across the C0/C1
+	// sub-vectors — a decode-quality signal to feed the vocoder's
+	// error-aware smoothing.
+	Errors int
+}
+
+// ExtractVCHFrames decodes the 144-dibit (288-bit) Information field of
+// a VCH traffic frame into its VCHVoiceFramesPerFrame AMBE+2 voice
+// frames. Returns nil if infoDibits is not exactly InfoFieldDibits long.
+// Frames whose AMBE FEC hard-fails are skipped (so a partially corrupt
+// burst still yields its good frames).
+func ExtractVCHFrames(infoDibits []uint8) []VCHFrame {
+	if len(infoDibits) != InfoFieldDibits {
+		return nil
+	}
+	bitsAll := framing.DibitsToBits(infoDibits) // 288 bits
+	out := make([]VCHFrame, 0, VCHVoiceFramesPerFrame)
+	for i := 0; i < VCHVoiceFramesPerFrame; i++ {
+		seg := bitsAll[i*nxdnAMBEOnAirBits : (i+1)*nxdnAMBEOnAirBits]
+		payload, errs, err := DecodeVCHFrame(seg)
+		if err != nil {
+			continue
+		}
+		out = append(out, VCHFrame{Payload: payload, Errors: errs})
+	}
+	return out
+}

--- a/internal/radio/nxdn/voice_ambe.go
+++ b/internal/radio/nxdn/voice_ambe.go
@@ -1,0 +1,202 @@
+package nxdn
+
+import (
+	"fmt"
+	"math/bits"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
+
+// AMBE+2 on-air forward-error-correction for NXDN VCH voice frames.
+//
+// NXDN's VCH carries the AMBE+2 3600×2450 vocoder — the SAME codec and
+// SAME 72-bit on-air frame DMR uses. The FEC that wraps the 49-bit
+// vocoder payload (Golay(23,12) over the C0/C1 sub-vectors, the
+// C0-seeded pseudo-random descramble of C1, and the C0:12 + C1:12 +
+// C2:11 + C3:14 = 49-bit assembly) is a property of the AMBE+2 codec,
+// not of the radio protocol, so it is identical to
+// internal/radio/dmr/voice/ambefec.go and is reproduced here reusing
+// the shared framing.Golay23_12 primitives.
+//
+// The ONE protocol-specific piece is how the 72 on-air bits are
+// interleaved into the four C0..C3 sub-vectors. DMR uses the
+// rW/rX/rY/rZ schedule; NXDN uses its own.
+//
+// ⚠️ UNVERIFIED ON AIR. GopherTrunk has no NXDN voice capture, so the
+// deinterleave table below is a documented *placeholder* (a direct
+// sequential split C0|C1|C2|C3) — enough to exercise the FEC machinery
+// end to end via the synthetic round-trip in voice_ambe_test.go, but
+// NOT confirmed against a real NXDN VCH burst. The first thing a
+// capture confirms is this table (and whether the codebook is 3600×2450
+// vs 3600×2400). Until then, treat live NXDN audio as experimental. See
+// the WS2a plan and CLAUDE.md's TETRA-CRC "self-consistent bug" lesson.
+
+const (
+	nxdnAMBEOnAirBits = 72 // on-air bits per AMBE+2 VCH voice frame
+	nxdnAMBEInfoBits  = 49 // vocoder-payload bits per frame (ambe_d)
+)
+
+// nxdnAMBEDeinterleave maps the 72 on-air bits (one bit per byte,
+// MSB-first) into the four C0..C3 sub-vectors carried in fr[4][24]:
+// C0 = fr[0][0..23] (24 bits: fr[0][0] is the Golay(24) overall-parity
+// cell, fr[0][1..23] the 23-bit codeword), C1 = fr[1][0..22] (23 bits),
+// C2 = fr[2][0..10] (11 bits), C3 = fr[3][0..13] (14 bits). Total
+// 24+23+11+14 = 72.
+//
+// PLACEHOLDER: a direct sequential split. Replace with the real NXDN
+// VCH interleave table once a capture is available (the encoder inverse
+// below must be updated in lock-step). Isolated here so that swap is a
+// one-function change.
+func nxdnAMBEDeinterleave(frame []byte) [4][24]uint8 {
+	var fr [4][24]uint8
+	p := 0
+	get := func() uint8 { b := frame[p] & 1; p++; return b }
+	for j := 0; j < 24; j++ {
+		fr[0][j] = get()
+	}
+	for j := 0; j < 23; j++ {
+		fr[1][j] = get()
+	}
+	for j := 0; j < 11; j++ {
+		fr[2][j] = get()
+	}
+	for j := 0; j < 14; j++ {
+		fr[3][j] = get()
+	}
+	return fr
+}
+
+// nxdnAMBEInterleave is the inverse of nxdnAMBEDeinterleave, packing the
+// four sub-vectors back into 72 on-air bits. Kept in lock-step with the
+// deinterleave placeholder so the round-trip test can exercise the FEC.
+func nxdnAMBEInterleave(fr [4][24]uint8) []byte {
+	out := make([]byte, nxdnAMBEOnAirBits)
+	p := 0
+	put := func(b uint8) { out[p] = b & 1; p++ }
+	for j := 0; j < 24; j++ {
+		put(fr[0][j])
+	}
+	for j := 0; j < 23; j++ {
+		put(fr[1][j])
+	}
+	for j := 0; j < 11; j++ {
+		put(fr[2][j])
+	}
+	for j := 0; j < 14; j++ {
+		put(fr[3][j])
+	}
+	return out
+}
+
+// nxdnC1Keystream returns the pseudo-random sequence AMBE+2 XORs onto
+// the C1 sub-vector, seeded by the 12-bit C0 data word. Entries 1..23
+// are valid (index 0 unused). This is the mbelib
+// mbe_demodulateAmbe3600x2450Data keystream — a property of the AMBE+2
+// 3600×2450 codec, identical to the DMR path.
+func nxdnC1Keystream(c0data uint16) [24]uint8 {
+	var pr [24]uint32
+	pr[0] = 16 * uint32(c0data&0x0FFF)
+	for i := 1; i < 24; i++ {
+		pr[i] = (173*pr[i-1] + 13849) & 0xFFFF
+	}
+	var ks [24]uint8
+	for i := 1; i < 24; i++ {
+		ks[i] = uint8(pr[i] >> 15)
+	}
+	return ks
+}
+
+// DecodeVCHFrame decodes one 72-bit on-air AMBE+2 VCH voice frame (72
+// bits, one bit per byte MSB-first) into the 49-bit vocoder payload
+// (one bit per byte). It returns the payload and the number of Golay
+// errors corrected across C0 and C1 (negative counts from an
+// uncorrectable sub-vector are clamped to 0). Pack the payload MSB-first
+// to 7 bytes (framing.PackBitsMSB) and hand it to the ambe2 decoder.
+func DecodeVCHFrame(frame []byte) ([]byte, int, error) {
+	if len(frame) != nxdnAMBEOnAirBits {
+		return nil, 0, fmt.Errorf("nxdn: VCH AMBE frame must be %d bits, got %d", nxdnAMBEOnAirBits, len(frame))
+	}
+	fr := nxdnAMBEDeinterleave(frame)
+
+	// C0: Golay(23,12) over fr[0][1..23] (fr[0][0] is the ext-Golay
+	// overall-parity cell, unused by the 23-bit decode).
+	var c0cw uint32
+	for j := 0; j < 23; j++ {
+		c0cw |= uint32(fr[0][j+1]) << uint(j)
+	}
+	c0data, c0errs := framing.GolayDecode23_12(c0cw)
+
+	// C1: descramble with the C0-seeded keystream, then Golay(23,12).
+	ks := nxdnC1Keystream(c0data)
+	for j := 0; j <= 22; j++ {
+		fr[1][j] ^= ks[23-j]
+	}
+	var c1cw uint32
+	for j := 0; j < 23; j++ {
+		c1cw |= uint32(fr[1][j]) << uint(j)
+	}
+	c1data, c1errs := framing.GolayDecode23_12(c1cw)
+
+	// Assemble ambe_d: C0(12) + C1(12) + C2(11) + C3(14).
+	out := make([]byte, nxdnAMBEInfoBits)
+	for k := 0; k < 12; k++ {
+		out[k] = uint8((c0data >> uint(11-k)) & 1)
+		out[12+k] = uint8((c1data >> uint(11-k)) & 1)
+	}
+	for k := 0; k < 11; k++ {
+		out[24+k] = fr[2][10-k]
+	}
+	for k := 0; k < 14; k++ {
+		out[35+k] = fr[3][13-k]
+	}
+	return out, clampErrs(c0errs) + clampErrs(c1errs), nil
+}
+
+// clampErrs turns a Golay decoder's -1 (uncorrectable) into 0 so the
+// returned corrected-bit count stays a non-negative sum.
+func clampErrs(e int) int {
+	if e < 0 {
+		return 0
+	}
+	return e
+}
+
+// EncodeVCHFrame is the inverse of DecodeVCHFrame: it wraps a 49-bit
+// vocoder payload back into a 72-bit on-air AMBE+2 VCH frame. It exists
+// so the FEC chain can be exercised by round-trip and bit-error tests.
+func EncodeVCHFrame(info []byte) ([]byte, error) {
+	if len(info) != nxdnAMBEInfoBits {
+		return nil, fmt.Errorf("nxdn: VCH AMBE payload must be %d bits, got %d", nxdnAMBEInfoBits, len(info))
+	}
+	var fr [4][24]uint8
+
+	var c0data, c1data uint16
+	for k := 0; k < 12; k++ {
+		c0data |= uint16(info[k]&1) << uint(11-k)
+		c1data |= uint16(info[12+k]&1) << uint(11-k)
+	}
+
+	c0cw := framing.GolayEncode23_12(c0data)
+	for j := 0; j < 23; j++ {
+		fr[0][j+1] = uint8((c0cw >> uint(j)) & 1)
+	}
+	fr[0][0] = uint8(bits.OnesCount32(c0cw) & 1) // ext-Golay overall parity
+
+	c1cw := framing.GolayEncode23_12(c1data)
+	for j := 0; j < 23; j++ {
+		fr[1][j] = uint8((c1cw >> uint(j)) & 1)
+	}
+	ks := nxdnC1Keystream(c0data)
+	for j := 0; j <= 22; j++ {
+		fr[1][j] ^= ks[23-j]
+	}
+
+	for k := 0; k < 11; k++ {
+		fr[2][10-k] = info[24+k] & 1
+	}
+	for k := 0; k < 14; k++ {
+		fr[3][13-k] = info[35+k] & 1
+	}
+
+	return nxdnAMBEInterleave(fr), nil
+}

--- a/internal/radio/nxdn/voice_ambe_test.go
+++ b/internal/radio/nxdn/voice_ambe_test.go
@@ -1,0 +1,82 @@
+package nxdn
+
+import (
+	"testing"
+)
+
+// mkInfo builds a deterministic 49-bit AMBE payload from a seed (a
+// simple LCG), mirroring the DMR ambefec_test helper.
+func mkInfo(seed uint32) []byte {
+	out := make([]byte, nxdnAMBEInfoBits)
+	x := seed | 1
+	for i := range out {
+		x = 1664525*x + 1013904223
+		out[i] = byte((x >> 24) & 1)
+	}
+	return out
+}
+
+// TestVCHFrameRoundTrip pins the AMBE FEC machinery: Encode→Decode over
+// many payloads must reproduce the exact 49-bit input. This validates
+// the Golay(23,12) coding, the C0-seeded C1 descramble, and the
+// C0/C1/C2/C3 assembly — everything except the (capture-unknown) on-air
+// interleave table, which round-trips by construction here.
+func TestVCHFrameRoundTrip(t *testing.T) {
+	for seed := uint32(0); seed < 128; seed++ {
+		info := mkInfo(seed)
+		frame, err := EncodeVCHFrame(info)
+		if err != nil {
+			t.Fatalf("EncodeVCHFrame(seed=%d): %v", seed, err)
+		}
+		if len(frame) != nxdnAMBEOnAirBits {
+			t.Fatalf("encoded frame = %d bits, want %d", len(frame), nxdnAMBEOnAirBits)
+		}
+		got, _, err := DecodeVCHFrame(frame)
+		if err != nil {
+			t.Fatalf("DecodeVCHFrame(seed=%d): %v", seed, err)
+		}
+		for i := range info {
+			if got[i] != info[i] {
+				t.Fatalf("seed=%d bit %d: got %d want %d", seed, i, got[i], info[i])
+			}
+		}
+	}
+}
+
+// TestVCHFrameCorrectsErrors confirms the Golay(23,12) layer corrects up
+// to 3 bit errors injected into each of the C0 and C1 sub-vectors (the
+// FEC-protected regions), recovering the exact payload.
+func TestVCHFrameCorrectsErrors(t *testing.T) {
+	info := mkInfo(42)
+	frame, err := EncodeVCHFrame(info)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	// C0 occupies on-air positions 0..23, C1 24..46 (sequential
+	// placeholder layout). Flip 3 bits in C0's codeword and 3 in C1's.
+	corrupt := append([]byte(nil), frame...)
+	for _, pos := range []int{1, 5, 12, 24, 30, 40} {
+		corrupt[pos] ^= 1
+	}
+	got, errs, err := DecodeVCHFrame(corrupt)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if errs == 0 {
+		t.Errorf("expected corrected-error count > 0, got 0")
+	}
+	for i := range info {
+		if got[i] != info[i] {
+			t.Fatalf("bit %d not corrected: got %d want %d", i, got[i], info[i])
+		}
+	}
+}
+
+func TestDecodeVCHFrameRejectsBadLength(t *testing.T) {
+	if _, _, err := DecodeVCHFrame(make([]byte, 71)); err == nil {
+		t.Error("expected error for 71-bit frame")
+	}
+	if _, err := EncodeVCHFrame(make([]byte, 48)); err == nil {
+		t.Error("expected error for 48-bit payload")
+	}
+}

--- a/internal/radio/nxdn/voice_test.go
+++ b/internal/radio/nxdn/voice_test.go
@@ -1,0 +1,55 @@
+package nxdn
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
+
+// buildVCHInfoDibits encodes four 49-bit payloads into the 144-dibit
+// (288-bit) Information field a VCH traffic frame carries.
+func buildVCHInfoDibits(t *testing.T, payloads [4][]byte) []uint8 {
+	t.Helper()
+	var allBits []byte
+	for i := 0; i < VCHVoiceFramesPerFrame; i++ {
+		frame, err := EncodeVCHFrame(payloads[i])
+		if err != nil {
+			t.Fatalf("EncodeVCHFrame[%d]: %v", i, err)
+		}
+		allBits = append(allBits, frame...)
+	}
+	if len(allBits) != VCHVoiceFramesPerFrame*nxdnAMBEOnAirBits {
+		t.Fatalf("info bits = %d, want %d", len(allBits), VCHVoiceFramesPerFrame*nxdnAMBEOnAirBits)
+	}
+	dibits := framing.BitsToDibits(allBits)
+	if len(dibits) != InfoFieldDibits {
+		t.Fatalf("info dibits = %d, want %d", len(dibits), InfoFieldDibits)
+	}
+	return dibits
+}
+
+func TestExtractVCHFramesRoundTrip(t *testing.T) {
+	payloads := [4][]byte{mkInfo(1), mkInfo(2), mkInfo(3), mkInfo(4)}
+	info := buildVCHInfoDibits(t, payloads)
+
+	frames := ExtractVCHFrames(info)
+	if len(frames) != VCHVoiceFramesPerFrame {
+		t.Fatalf("got %d frames, want %d", len(frames), VCHVoiceFramesPerFrame)
+	}
+	for i, f := range frames {
+		if len(f.Payload) != nxdnAMBEInfoBits {
+			t.Fatalf("frame %d payload = %d bits, want %d", i, len(f.Payload), nxdnAMBEInfoBits)
+		}
+		for j := range payloads[i] {
+			if f.Payload[j] != payloads[i][j] {
+				t.Fatalf("frame %d bit %d: got %d want %d", i, j, f.Payload[j], payloads[i][j])
+			}
+		}
+	}
+}
+
+func TestExtractVCHFramesRejectsWrongLength(t *testing.T) {
+	if got := ExtractVCHFrames(make([]uint8, InfoFieldDibits-1)); got != nil {
+		t.Errorf("wrong-length input should yield nil, got %d frames", len(got))
+	}
+}

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -1176,6 +1176,12 @@ func newNXDNPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 			"system", opts.SystemName, "value", opts.System.NXDNViterbiMode)
 	}
 	cc.SetViterbiMode(viterbiMode)
+	// Wire the system name + band plan so VCALL_ASSGN voice grants
+	// resolve a traffic-channel number to a downlink frequency and the
+	// engine follows the call. With no band plan configured, grants are
+	// dropped (logged) — the control channel still locks and decodes.
+	cc.SetSystemName(opts.SystemName)
+	cc.SetBandPlan(nxdn.ResolverFromPlan(opts.System.NXDNBandPlan))
 	// NXDN spec peak deviation per the Common Air Interface (same
 	// value P25 Phase 1 uses). Calibrates the slicer thresholds
 	// against the FM-discriminator output level so live captures

--- a/internal/trunking/site.go
+++ b/internal/trunking/site.go
@@ -149,6 +149,37 @@ type DMRBandPlanTableEntry struct {
 	FreqHz uint32
 }
 
+// NXDNBandPlan maps the traffic-channel number carried in an NXDN
+// VCALL_ASSGN message to its downlink frequency. Like DMR Tier III,
+// NXDN voice grants reference a channel by number rather than an
+// absolute frequency, so the decoder cannot follow a voice call
+// without this plan — see internal/radio/nxdn (Resolver /
+// nxdn.ResolverFromPlan). The shape mirrors DMRBandPlan (the trunking
+// package keeps its own channel→Hz type rather than importing the
+// radio package). Exactly one of Linear or Table is populated
+// (enforced by config validation).
+type NXDNBandPlan struct {
+	Linear *NXDNLinearBandPlan      // regular base+spacing grid
+	Table  []NXDNBandPlanTableEntry // irregular hand-coded channel→Hz map
+}
+
+// NXDNLinearBandPlan lays channels out on a regular grid:
+// freq = BaseHz + (Channel - Offset) × SpacingHz. Offset lets sites
+// that number channels from 1 pin BaseHz to the channel-1 downlink —
+// set Offset=1 there.
+type NXDNLinearBandPlan struct {
+	BaseHz    uint32
+	SpacingHz uint32
+	Offset    int8
+}
+
+// NXDNBandPlanTableEntry is one explicit channel→downlink-frequency
+// mapping for sites whose channels don't fall on a regular grid.
+type NXDNBandPlanTableEntry struct {
+	Channel uint16
+	FreqHz  uint32
+}
+
 // ConfiguredSite is an operator-supplied name for a P25 site, keyed by
 // its RFSS and Site IDs. It carries no decoding role — GET /api/v1/sites
 // merges the Name onto the matching discovered site (issue #698).
@@ -242,6 +273,12 @@ type System struct {
 	// grant is dropped with decode.error stage=no-bandplan. Ignored
 	// for non-DMR-Tier-III protocols.
 	DMRBandPlan *DMRBandPlan
+
+	// NXDNBandPlan resolves the traffic-channel number in NXDN
+	// VCALL_ASSGN grants to a downlink frequency. Required for NXDN
+	// voice follow — without it a granted call has no frequency to
+	// tune and the grant is dropped. Ignored for non-NXDN protocols.
+	NXDNBandPlan *NXDNBandPlan
 
 	// DMRInterleavedVoice opts the system into the experimental 2-slot
 	// interleaved voice decoder (mirrors config.System.DMRInterleavedVoice).

--- a/internal/voice/composer/composer.go
+++ b/internal/voice/composer/composer.go
@@ -465,10 +465,14 @@ func (c *Composer) handleStart(parent context.Context, cs trunking.CallStart) {
 	// sidecar (TCH/S FEC + ACELP vocoder are follow-ups — see
 	// runTETRAVoiceChain), like the DMR/P25 raw-frame paths.
 	isTETRAVoice := proto == "tetra"
-	if !isFM && !isDMRVoice && !isP25P2Voice && !isP25P1Voice && !isTETRAVoice {
-		// Remaining digital protocols (NXDN, dPMR, YSF, D-STAR, EDACS
-		// ProVoice) have no composer voice chain yet — their voice bursts
-		// are not decoded into PCM here.
+	// NXDN follows the traffic channel with the same receiver the CC
+	// uses; Stage 1 wires the follow+tune+chain lifecycle, the VCH
+	// voice-channel decoder is a follow-up (see runNXDNVoiceChain).
+	isNXDNVoice := proto == "nxdn"
+	if !isFM && !isDMRVoice && !isP25P2Voice && !isP25P1Voice && !isTETRAVoice && !isNXDNVoice {
+		// Remaining digital protocols (dPMR, YSF, D-STAR, EDACS ProVoice)
+		// have no composer voice chain yet — their voice bursts are not
+		// decoded into PCM here.
 		c.log.Info("composer: digital protocol not yet decoded; chain bypassed",
 			"device", cs.DeviceSerial, "protocol", proto,
 			"group", cs.Grant.GroupID)
@@ -564,6 +568,8 @@ func (c *Composer) handleStart(parent context.Context, cs trunking.CallStart) {
 		go c.runP25Phase1VoiceChain(chainCtx, cs.DeviceSerial, cs.Grant.System, iqCh, rateHzF, cs.Grant.P25Phase1DemodMode, cs.Grant.GroupID, cs.Grant.CallID, cs.Grant.PatchedGroups, ch.done)
 	case isTETRAVoice:
 		go c.runTETRAVoiceChain(chainCtx, cs.DeviceSerial, iqCh, rateHzF, cs.Grant.GroupID, cs.Grant.Timeslot, cs.Grant.TETRAColourExt, cs.Grant.TETRAUsageMarker, ch.done)
+	case isNXDNVoice:
+		go c.runNXDNVoiceChain(chainCtx, cs.DeviceSerial, cs.Grant.System, iqCh, rateHzF, cs.Grant.GroupID, ch.done)
 	default:
 		// Analog FM has no symbol clock to drift, so the rounded integer
 		// rate is fine; keep its uint32 signature unchanged.

--- a/internal/voice/composer/composer_test.go
+++ b/internal/voice/composer/composer_test.go
@@ -475,8 +475,8 @@ func TestComposerSkipsDigitalProtocol(t *testing.T) {
 	bus.Publish(events.Event{
 		Kind: events.KindCallStart,
 		Payload: trunking.CallStart{
-			// NXDN has no composer voice chain yet — it must be bypassed.
-			Grant:        trunking.Grant{Protocol: "nxdn", GroupID: 1, FrequencyHz: 851_000_000},
+			// dPMR still has no composer voice chain — it must be bypassed.
+			Grant:        trunking.Grant{Protocol: "dpmr", GroupID: 1, FrequencyHz: 851_000_000},
 			DeviceSerial: "VOICE-1",
 			StartedAt:    time.Now().UTC(),
 		},
@@ -490,6 +490,34 @@ func TestComposerSkipsDigitalProtocol(t *testing.T) {
 	if sink.total("VOICE-1") != 0 {
 		t.Errorf("digital grant produced PCM samples")
 	}
+}
+
+// TestComposerRunsNXDNVoiceChain confirms an NXDN grant is no longer
+// bypassed — Stage 1 wires the follow+tune+chain lifecycle (the VCH
+// voice-channel decoder is a follow-up). The chain must launch for the
+// device even though it produces no PCM until Stage 2.
+func TestComposerRunsNXDNVoiceChain(t *testing.T) {
+	src := newFakeSource()
+	c, bus, _, _, teardown := mkComposer(t, src)
+	defer teardown()
+
+	bus.Publish(events.Event{
+		Kind: events.KindCallStart,
+		Payload: trunking.CallStart{
+			Grant:        trunking.Grant{Protocol: "nxdn", GroupID: 1, FrequencyHz: 851_000_000},
+			DeviceSerial: "VOICE-1",
+			StartedAt:    time.Now().UTC(),
+		},
+	})
+
+	waitFor(t, time.Second, func() bool {
+		for _, s := range c.ActiveChains() {
+			if s == "VOICE-1" {
+				return true
+			}
+		}
+		return false
+	})
 }
 
 func TestComposerRunsFMChainForAnalogTrunking(t *testing.T) {

--- a/internal/voice/composer/nxdn_voice.go
+++ b/internal/voice/composer/nxdn_voice.go
@@ -1,0 +1,125 @@
+package composer
+
+import (
+	"context"
+	"math"
+	"sync/atomic"
+	"time"
+
+	gtlog "github.com/MattCheramie/GopherTrunk/internal/log"
+	nxdnrx "github.com/MattCheramie/GopherTrunk/internal/radio/nxdn/receiver"
+)
+
+// nxdnVoiceIntermediateHz is the rate the wideband IQ is decimated to
+// before the NXDN receiver runs. 48 kHz gives the 4800-baud 4-FSK
+// symbol stream 10 samples per symbol — the same intermediate rate the
+// DMR / P25 Phase 1 C4FM-family voice chains use.
+const nxdnVoiceIntermediateHz = 48_000
+
+// nxdnChannelSelectHz caps the voice front-end channel filter at half
+// the 12.5 kHz NXDN (NXDN96) channel spacing, so a wideband DDC voice
+// tap (which band-limits only to its tap Nyquist) doesn't feed adjacent
+// channel energy into the receiver. Mirrors p25p2ChannelSelectHz.
+const nxdnChannelSelectHz = 6250.0
+
+// nxdnVoiceDeviationHz is the NXDN peak deviation the receiver's slicer
+// + symbol-AGC calibrate against (same value the CC pipeline uses).
+const nxdnVoiceDeviationHz = 1800.0
+
+// newNXDNVoiceFrontEnd builds the channel-select + decimation front end
+// for the NXDN voice chain, mirroring newP25P2VoiceFrontEnd: on the
+// dedicated-tuner path the decimating FIR band-limits as it decimates;
+// on the pass-through path (a wideband DDC tap already at the
+// intermediate rate) it channel-selects to ±min(bw, nxdnChannelSelectHz)
+// before the receiver.
+func newNXDNVoiceFrontEnd(iqHz float64, bw uint32) *decimatingFIR {
+	chanBW := float64(bw)
+	decim := int(math.Round(iqHz)) / nxdnVoiceIntermediateHz
+	filterAtUnity := false
+	if decim <= 1 {
+		filterAtUnity = true
+		if chanBW > nxdnChannelSelectHz {
+			chanBW = nxdnChannelSelectHz
+		}
+	}
+	return newDecimatingFIR(iqHz, nxdnVoiceIntermediateHz, chanBW, filterAtUnity)
+}
+
+// runNXDNVoiceChain consumes IQ for one NXDN voice call: it decimates
+// the wideband IQ to a 4-FSK-friendly rate and recovers the dibit
+// stream with the NXDN receiver (the same receiver the control channel
+// uses, with the symbol-AGC that lets it decode real captures).
+//
+// STAGE 1 (this commit) wires the follow → tune → chain lifecycle: the
+// grant is followed, a Voice device is tuned, and this chain runs the
+// receiver over the traffic channel. The VCH voice-channel decoder that
+// turns traffic frames into 7-byte AMBE+2 payloads is Stage 2; until it
+// lands, extractVoiceFrames returns nothing and the chain produces no
+// audio (the recorder still maps "nxdn" → the "ambe2" vocoder, so once
+// Stage 2 feeds 7-byte frames through rs.WriteRawFrame they render to
+// PCM with no further wiring). Kept structurally identical to
+// runP25Phase2VoiceChain so Stage 2 is a drop-in of the extractor.
+func (c *Composer) runNXDNVoiceChain(ctx context.Context, serial, system string, iqCh <-chan []complex64, iqHz float64, groupID uint32, done chan<- struct{}) {
+	defer close(done)
+	defer gtlog.Recover(c.log, "voice-chain-nxdn:"+serial, nil)
+
+	// Shared boundary controller: hangtime end-of-call + Touch heartbeat.
+	// Talkgroup gating disabled (grantTG 0) until the VCH decoder surfaces
+	// a per-voice-frame talkgroup.
+	bt := c.newBoundaryTracker(serial, 0, nil)
+	go bt.run(ctx)
+
+	c.log.Info("composer: nxdn voice chain started (stage 1: follow+tune; VCH decode is a follow-up)",
+		"serial", serial, "system", system, "group", groupID)
+
+	fe := newNXDNVoiceFrontEnd(iqHz, c.bw)
+	symbolHz := fe.OutRateHz()
+
+	rs, _ := c.sink.(rawFrameSink)
+
+	// extractVoiceFrames is the Stage 2 hook: the NXDN VCH voice
+	// channel-coding decoder (deinterleave + AMBE FEC → 7-byte AMBE+2
+	// payloads). Stage 1 ships an empty extractor so the chain exercises
+	// the receiver + lifecycle without yet producing audio.
+	extractVoiceFrames := func(dibits []uint8, baseIdx int) [][]byte { return nil }
+
+	var voiceFrames atomic.Uint64
+	rx := nxdnrx.New(nxdnrx.Options{
+		SampleRateHz: symbolHz,
+		DeviationHz:  nxdnVoiceDeviationHz,
+		DibitSink: func(dibits []uint8, baseIdx int) {
+			for _, f := range extractVoiceFrames(dibits, baseIdx) {
+				if f == nil {
+					continue
+				}
+				voiceFrames.Add(1)
+				bt.onVoice(0)
+				if rs != nil {
+					if err := rs.WriteRawFrame(serial, f); err != nil {
+						c.log.Warn("composer: nxdn raw-frame write failed", "serial", serial, "err", err)
+					}
+				}
+			}
+		},
+	})
+
+	touchTicker := time.NewTicker(c.touchEvery)
+	defer touchTicker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			c.log.Info("composer: nxdn voice chain ended", "serial", serial, "voice_frames", voiceFrames.Load())
+			return
+		case <-touchTicker.C:
+			// Touch + hangtime end-of-call handled by the boundary tracker.
+		case iq, ok := <-iqCh:
+			if !ok {
+				c.log.Info("composer: nxdn voice chain ended (iq closed)", "serial", serial, "voice_frames", voiceFrames.Load())
+				return
+			}
+			bt.observe(iq)
+			rx.Process(fe.Process(nil, iq))
+		}
+	}
+}

--- a/internal/voice/composer/nxdn_voice.go
+++ b/internal/voice/composer/nxdn_voice.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	gtlog "github.com/MattCheramie/GopherTrunk/internal/log"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/nxdn"
 	nxdnrx "github.com/MattCheramie/GopherTrunk/internal/radio/nxdn/receiver"
 )
 
@@ -46,19 +48,19 @@ func newNXDNVoiceFrontEnd(iqHz float64, bw uint32) *decimatingFIR {
 }
 
 // runNXDNVoiceChain consumes IQ for one NXDN voice call: it decimates
-// the wideband IQ to a 4-FSK-friendly rate and recovers the dibit
-// stream with the NXDN receiver (the same receiver the control channel
-// uses, with the symbol-AGC that lets it decode real captures).
+// the wideband IQ to a 4-FSK-friendly rate, recovers the dibit stream
+// with the NXDN receiver (the same receiver the control channel uses,
+// with the symbol-AGC that lets it decode real captures), and routes the
+// dibits through an nxdn.TrafficChannel that carves the VCH voice frames
+// out of each traffic frame's Information field, FEC-decodes their
+// AMBE+2 payloads, and hands 7-byte frames to the recorder — which maps
+// "nxdn" → the "ambe2-dmr" vocoder and renders them to PCM.
 //
-// STAGE 1 (this commit) wires the follow → tune → chain lifecycle: the
-// grant is followed, a Voice device is tuned, and this chain runs the
-// receiver over the traffic channel. The VCH voice-channel decoder that
-// turns traffic frames into 7-byte AMBE+2 payloads is Stage 2; until it
-// lands, extractVoiceFrames returns nothing and the chain produces no
-// audio (the recorder still maps "nxdn" → the "ambe2" vocoder, so once
-// Stage 2 feeds 7-byte frames through rs.WriteRawFrame they render to
-// PCM with no further wiring). Kept structurally identical to
-// runP25Phase2VoiceChain so Stage 2 is a drop-in of the extractor.
+// ⚠️ UNVERIFIED ON AIR. The VCH carve + AMBE FEC + codebook are
+// transcribed from spec/reference and validated only by synthetic
+// round-trip (internal/radio/nxdn/voice_ambe.go, voice.go, traffic.go);
+// a real NXDN VCH capture is needed to confirm them. Treat live NXDN
+// audio as experimental until then.
 func (c *Composer) runNXDNVoiceChain(ctx context.Context, serial, system string, iqCh <-chan []complex64, iqHz float64, groupID uint32, done chan<- struct{}) {
 	defer close(done)
 	defer gtlog.Recover(c.log, "voice-chain-nxdn:"+serial, nil)
@@ -69,37 +71,45 @@ func (c *Composer) runNXDNVoiceChain(ctx context.Context, serial, system string,
 	bt := c.newBoundaryTracker(serial, 0, nil)
 	go bt.run(ctx)
 
-	c.log.Info("composer: nxdn voice chain started (stage 1: follow+tune; VCH decode is a follow-up)",
+	c.log.Info("composer: nxdn voice chain started (VCH decode is unverified on air — experimental)",
 		"serial", serial, "system", system, "group", groupID)
 
 	fe := newNXDNVoiceFrontEnd(iqHz, c.bw)
 	symbolHz := fe.OutRateHz()
 
 	rs, _ := c.sink.(rawFrameSink)
-
-	// extractVoiceFrames is the Stage 2 hook: the NXDN VCH voice
-	// channel-coding decoder (deinterleave + AMBE FEC → 7-byte AMBE+2
-	// payloads). Stage 1 ships an empty extractor so the chain exercises
-	// the receiver + lifecycle without yet producing audio.
-	extractVoiceFrames := func(dibits []uint8, baseIdx int) [][]byte { return nil }
+	ers, _ := c.sink.(errAwareRawSink)
 
 	var voiceFrames atomic.Uint64
+	// TrafficChannel carves the VCH voice frames out of each RFChTraffic
+	// frame and FEC-decodes their 49-bit AMBE+2 payloads. The sink packs
+	// each payload MSB-first to 7 bytes and writes it to the recorder,
+	// whose "ambe2-dmr" vocoder renders PCM (WriteRawFrameWithErrors when
+	// the sink is error-aware, so the FEC corrected-bit count drives the
+	// vocoder's adaptive smoothing — mirrors dmr_voice.go).
+	tc := nxdn.NewTrafficChannel(func(frames []nxdn.VCHFrame) {
+		for _, vf := range frames {
+			packed := framing.PackBitsMSB(vf.Payload)
+			voiceFrames.Add(1)
+			bt.onVoice(0)
+			var werr error
+			switch {
+			case ers != nil:
+				werr = ers.WriteRawFrameWithErrors(serial, packed, vf.Errors)
+			case rs != nil:
+				werr = rs.WriteRawFrame(serial, packed)
+			}
+			if werr != nil {
+				c.log.Warn("composer: nxdn raw-frame write failed", "serial", serial, "err", werr)
+			}
+		}
+	})
+
 	rx := nxdnrx.New(nxdnrx.Options{
 		SampleRateHz: symbolHz,
 		DeviationHz:  nxdnVoiceDeviationHz,
 		DibitSink: func(dibits []uint8, baseIdx int) {
-			for _, f := range extractVoiceFrames(dibits, baseIdx) {
-				if f == nil {
-					continue
-				}
-				voiceFrames.Add(1)
-				bt.onVoice(0)
-				if rs != nil {
-					if err := rs.WriteRawFrame(serial, f); err != nil {
-						c.log.Warn("composer: nxdn raw-frame write failed", "serial", serial, "err", err)
-					}
-				}
-			}
+			tc.Process(dibits, baseIdx)
 		},
 	})
 

--- a/internal/voice/composer/nxdn_voice_test.go
+++ b/internal/voice/composer/nxdn_voice_test.go
@@ -1,0 +1,50 @@
+package composer
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/nxdn"
+	"github.com/MattCheramie/GopherTrunk/internal/voice/ambe2"
+	"github.com/MattCheramie/GopherTrunk/internal/voice/mbe"
+)
+
+// TestNXDNVCHFrameRendersToPCM closes the WS2a Stage 2 loop end to end at
+// the frame-format boundary: a VCH voice frame's 49-bit payload, packed
+// MSB-first to 7 bytes exactly as runNXDNVoiceChain's sink does, must be
+// accepted by the "ambe2-dmr" (3600x2450) vocoder the recorder maps
+// "nxdn" to, and produce one 20 ms PCM frame. This is the contract that
+// lets the traffic decoder's output render to audio with no further
+// wiring. (The upstream carve/FEC/codebook remain unverified on air.)
+func TestNXDNVCHFrameRendersToPCM(t *testing.T) {
+	// A synthetic 49-bit payload round-tripped through the AMBE FEC, so it
+	// is a well-formed VCH frame (mirrors what ExtractVCHFrames yields).
+	info := make([]byte, 49)
+	x := uint32(1)
+	for i := range info {
+		x = 1664525*x + 1013904223
+		info[i] = byte((x >> 24) & 1)
+	}
+	onair, err := nxdn.EncodeVCHFrame(info)
+	if err != nil {
+		t.Fatalf("EncodeVCHFrame: %v", err)
+	}
+	payload, _, err := nxdn.DecodeVCHFrame(onair)
+	if err != nil {
+		t.Fatalf("DecodeVCHFrame: %v", err)
+	}
+
+	packed := framing.PackBitsMSB(payload)
+	if len(packed) != ambe2.FrameBytes {
+		t.Fatalf("packed frame = %d bytes, want %d (vocoder FrameBytes)", len(packed), ambe2.FrameBytes)
+	}
+
+	dec := ambe2.NewDMR() // the "ambe2-dmr" 3600x2450 vocoder nxdn maps to
+	pcm, err := dec.Decode(packed)
+	if err != nil {
+		t.Fatalf("ambe2-dmr Decode: %v", err)
+	}
+	if len(pcm) != mbe.SamplesPerFrame {
+		t.Fatalf("PCM = %d samples, want %d (20 ms @ 8 kHz)", len(pcm), mbe.SamplesPerFrame)
+	}
+}

--- a/internal/voice/recorder.go
+++ b/internal/voice/recorder.go
@@ -338,7 +338,14 @@ func DefaultVocoderForProtocol() map[string]string {
 		"dmr-tier1":  "ambe2-dmr", // DMR Tier I direct-mode — AMBE+2 3600x2450
 		"dmr-tier2":  "ambe2-dmr", // DMR Tier II — AMBE+2 3600x2450
 		"dmr-tier3":  "ambe2-dmr", // DMR Tier III — AMBE+2 3600x2450
-		"nxdn":       "ambe2",
+		// NXDN VCH voice is AMBE+2 "Enhanced Half Rate" (3600x2450), the
+		// same codebook DMR uses — and the composer's NXDN voice chain
+		// FEC-decodes 49-bit frames with the 3600x2450 C0/C1 Golay +
+		// descramble (internal/radio/nxdn/voice_ambe.go), so it renders
+		// through the 3600x2450 decoder, not the 3600x2400 "ambe2".
+		// (Unverified on air — the 2450-vs-2400 codebook is one of the
+		// things an NXDN voice capture confirms; see voice_ambe.go.)
+		"nxdn":       "ambe2-dmr", // NXDN VCH — AMBE+2 3600x2450 (EHR)
 		"dpmr":       "ambe2",       // dPMR Mode 3 (digital)
 		"tetra":      "tetra-acelp", // TETRA full-rate voice — clean-room ACELP (EN 300 395-2)
 	}

--- a/internal/voice/recorder.go
+++ b/internal/voice/recorder.go
@@ -345,9 +345,9 @@ func DefaultVocoderForProtocol() map[string]string {
 		// through the 3600x2450 decoder, not the 3600x2400 "ambe2".
 		// (Unverified on air — the 2450-vs-2400 codebook is one of the
 		// things an NXDN voice capture confirms; see voice_ambe.go.)
-		"nxdn":       "ambe2-dmr", // NXDN VCH — AMBE+2 3600x2450 (EHR)
-		"dpmr":       "ambe2",       // dPMR Mode 3 (digital)
-		"tetra":      "tetra-acelp", // TETRA full-rate voice — clean-room ACELP (EN 300 395-2)
+		"nxdn":  "ambe2-dmr",   // NXDN VCH — AMBE+2 3600x2450 (EHR)
+		"dpmr":  "ambe2",       // dPMR Mode 3 (digital)
+		"tetra": "tetra-acelp", // TETRA full-rate voice — clean-room ACELP (EN 300 395-2)
 	}
 }
 

--- a/internal/voice/recorder_test.go
+++ b/internal/voice/recorder_test.go
@@ -1194,7 +1194,7 @@ func TestDefaultVocoderForProtocolMappings(t *testing.T) {
 		"dmr-tier1":  "ambe2-dmr",
 		"dmr-tier2":  "ambe2-dmr",
 		"dmr-tier3":  "ambe2-dmr",
-		"nxdn":       "ambe2",
+		"nxdn":       "ambe2-dmr",
 		"dpmr":       "ambe2",
 		"tetra":      "tetra-acelp",
 	}


### PR DESCRIPTION
## Summary

NXDN decoded its control channel but produced no audio — voice grants were never followed and the composer bypassed NXDN entirely. This PR wires NXDN voice end to end: it follows `VCALL_ASSGN` voice grants (resolving the assigned channel number through a new `nxdn_band_plan`), decodes the VCH traffic frames' AMBE+2 payloads, and renders them to PCM through the existing vocoder.

⚠️ **The VCH voice decode is unverified on air.** GopherTrunk has no NXDN voice capture, so the on-air deinterleave table, the Info-field carve, and the 2450-vs-2400 codebook are transcribed from spec/reference and validated only by a synthetic encode→decode round-trip — the "self-consistent bug" risk of CLAUDE.md's TETRA-CRC lesson. Live NXDN audio is **experimental** until a capture confirms them; the caveat is documented in every new file. The grant-follow + band-plan + composer plumbing is fully verifiable and not subject to that caveat.

## Changes

**Follow + tune + chain (verifiable):**
- `nxdn.ParseVCallAssign` — parse the VCALL_ASSGN channel assignment (group, source, traffic-channel number).
- NXDN band plan (`bandplan.go`) — channel→Hz resolver (linear/table), mirroring `dmr/tier3/bandplan.go`; `trunking.NXDNBandPlan` + config `nxdn_band_plan` (validation, daemon conversion, config-builder field help).
- Grant emission (`control.go`) — publish a protocol-neutral `trunking.Grant` on VCALL_ASSGN so the engine tunes a Voice device; drops cleanly (logged) when no band plan is configured, mirroring DMR Tier III.
- Composer (`nxdn_voice.go`) — `runNXDNVoiceChain` mirroring the P25 Phase 2 chain (decimating front end, the NXDN receiver with the merged symbol-AGC, boundary tracker, touch loop); NXDN removed from the "bypassed" set.

**VCH voice decode (unverified on air):**
- AMBE FEC (`voice_ambe.go`) — 72-bit AMBE+2 3600×2450 on-air frame → 49-bit payload: Golay(23,12) over C0/C1 (reusing `framing.Golay23_12`), the C0-seeded C1 descramble, and the C0:12+C1:12+C2:11+C3:14 assembly. The FEC is a property of the codec (identical to DMR's `ambefec.go`); only the 72-bit on-air deinterleave is protocol-specific and is isolated in `nxdnAMBEDeinterleave`.
- VCH carve (`voice.go`) — `ExtractVCHFrames` splits the 288-bit Information field into 4 AMBE frames.
- Traffic adapter (`traffic.go`) — `TrafficChannel`, a parallel FSW-synced frame decoder (the control-channel `Process`/`IngestFrame` path gates on `RFChControl` and is hardwired to CAC, so voice needs its own).
- Composer sink packs each 49-bit payload MSB-first to 7 bytes → `WriteRawFrameWithErrors` (so the FEC corrected-bit count drives the vocoder's smoothing).
- Recorder maps `nxdn → "ambe2-dmr"` (3600×2450 EHR, was `"ambe2"`/3600×2400), consistent with the FEC.

## Test plan

- [x] `make vet test` is green locally
- [ ] `make integration` — not run locally; CI runs the integration-tagged suite. (This touches daemon config conversion + the composer/recorder voice path.)
- [x] Added/updated tests: VCALL_ASSGN parse, band-plan resolution (linear/table, offset/overflow guards), grant publish/drop, composer dispatch (launch-not-bypass), config validation; AMBE FEC round-trip + 1–3-bit error correction, `ExtractVCHFrames`, `TrafficChannel` decode (+ control-frame-ignored, one-dibit-at-a-time feed), and the `VCHFrame → 7 bytes → ambe2-dmr → 160-sample PCM` format loop.
- [ ] Smoke-tested against real hardware — **no**. No NXDN voice capture is available, so the VCH decode is synthetic-round-trip validated only and flagged experimental; a capture is being requested to A/B-validate (deinterleave table, carve, codebook).

## Breaking changes

None for existing operators. Adds an optional config key `nxdn_band_plan` (parallel to `dmr_band_plan`); absent = NXDN voice grants are dropped and logged, the same posture as DMR without a band plan. The recorder's `nxdn` vocoder mapping changes `"ambe2"` → `"ambe2-dmr"`, but NXDN voice was previously bypassed entirely, so no operator-visible behavior regresses.

## Docs / CHANGELOG

- [ ] CHANGELOG `## [Unreleased]` bullet — not added yet. Recommended follow-up (user-visible: experimental NXDN voice + the `nxdn_band_plan` key).
- [ ] README/docs — not updated; NXDN voice is experimental/unverified, so it should be documented once a capture validates it.

## Linked issues

n/a — roadmap workstream WS2a (NXDN voice → PCM); no tracked issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVhBZqXFvZmzGcwfX4anHX

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVhBZqXFvZmzGcwfX4anHX)_