### PR TITLE
tetra: smooth AFC carrier-offset estimate to kill multipath jitter

### DIFF
--- a/internal/radio/tetra/receiver/afc.go
+++ b/internal/radio/tetra/receiver/afc.go
@@ -26,12 +26,44 @@ type carrierAFC struct {
 	omega   float64     // most recent per-symbol offset estimate (for OffsetHz)
 	buf     []complex64 // oversampled matched-filter samples awaiting a full block
 	wideBuf []complex64 // parallel pre-matched (channel-filtered) samples for the coarse stage
+
+	// omegaEMA slow-tracks the per-block net estimate (coarse+fine); omegaPrimed
+	// guards its first-block seed. The feed-forward estimate re-derived each
+	// ~1024-symbol block is noisy: under multipath/ISI the constellation is
+	// smeared, so both stages jitter block-to-block (a real reporter saw a
+	// fully-locked, calm control channel report carrier_off_hz swinging −1492 →
+	// +616 Hz, and the symbol-scope constellation "drift" that a
+	// continuous-tracking reference demod does not show). The true carrier
+	// offset drifts only slowly (tuner/TCXO), so we derotate by — and report —
+	// the smoothed estimate: this strips the per-block jitter without moving the
+	// tracked mean, so the differential decode is unaffected while the scope and
+	// the status line go steady. A block whose raw estimate jumps by more than
+	// the fine window (an ISI-induced ±f_sym/4 alias) is treated as an outlier:
+	// the mean holds and the block is derotated by the smoothed value, so one
+	// bad block cannot poison the track.
+	omegaEMA    float64
+	omegaPrimed bool
 }
 
 // afcBlockSymbols is the feed-forward re-estimation window in symbols.
 // ~1024 symbols (~57 ms at 18 kBd) averages out the data in the 4×Δφ
 // mean while still following drift.
 const afcBlockSymbols = 1024
+
+// omegaEMAAlpha is the per-block smoothing weight for the net offset estimate.
+// Small enough to strip the block-to-block jitter yet large enough to follow
+// real (slow) carrier drift — a block is ~57 ms, so α=0.08 is a ~0.7 s time
+// constant, far faster than tuner/TCXO drift. The EMA is seeded from the first
+// block, so a genuine multi-kHz offset (issue #940) is acquired immediately
+// regardless of α, and only the residual jitter is smoothed.
+const omegaEMAAlpha = 0.08
+
+// omegaAliasReject is the per-block jump above which the raw estimate is treated
+// as an ISI-induced alias outlier: the smoothed mean holds rather than tracking
+// it. Set at the fine estimator's unambiguous half-window (π/4 ≈ f_sym/8); a
+// real carrier cannot slew that far in one ~57 ms block, so only alias jumps and
+// gross transients are rejected.
+const omegaAliasReject = math.Pi / 4
 
 func newCarrierAFC(sps int) *carrierAFC {
 	if sps < 1 {
@@ -142,13 +174,29 @@ func (a *carrierAFC) Process(dst, matched, wide []complex64) []complex64 {
 		if haveWide {
 			coarse = coarseOmega(a.wideBuf[:blockSamples], a.sps)
 		}
-		// Bring the block within the fine estimator's unambiguous window, then
-		// refine. Total offset = coarse + fine; both derotations are absolute
-		// from phase 0, so per-block errors never accumulate.
+		// Bring the block within the fine estimator's unambiguous window and
+		// refine to the raw per-block net estimate. derotate(coarse) is applied
+		// only to let the fine estimator measure the residual; the block's final
+		// correction below is the *smoothed* net, which composes additively with
+		// the coarse already removed (all derotations are absolute from phase 0).
 		a.derotate(block, coarse)
 		fine := estimateOmega(block, a.sps)
-		a.derotate(block, fine)
-		a.omega = coarse + fine
+		rawOmega := coarse + fine
+
+		// Smooth the net estimate across blocks: strip the per-block jitter that
+		// spins the constellation and swings the reported offset, while the mean
+		// (seeded from the first block, so a real multi-kHz offset is acquired at
+		// once) still follows slow carrier drift. Reject alias-sized outliers.
+		if !a.omegaPrimed {
+			a.omegaEMA = rawOmega
+			a.omegaPrimed = true
+		} else if math.Abs(rawOmega-a.omegaEMA) < omegaAliasReject {
+			a.omegaEMA += omegaEMAAlpha * (rawOmega - a.omegaEMA)
+		}
+		// Finish derotating the block to the smoothed net (coarse is already
+		// removed, so apply the remainder).
+		a.derotate(block, a.omegaEMA-coarse)
+		a.omega = a.omegaEMA
 
 		dst = append(dst, block...)
 		a.buf = append(a.buf[:0], a.buf[blockSamples:]...)
@@ -166,6 +214,8 @@ func (a *carrierAFC) Reset() {
 	a.omega = 0
 	a.buf = a.buf[:0]
 	a.wideBuf = a.wideBuf[:0]
+	a.omegaEMA = 0
+	a.omegaPrimed = false
 }
 
 func conjf(c complex64) complex64 { return complex(real(c), -imag(c)) }

--- a/internal/radio/tetra/receiver/afc_test.go
+++ b/internal/radio/tetra/receiver/afc_test.go
@@ -158,3 +158,142 @@ func TestAFCNoopWithoutOffset(t *testing.T) {
 		t.Errorf("AFC noop: exact sync hits on centred stream = %d, want >=80", n)
 	}
 }
+
+// TestAFCReportedOffsetStableUnderMultipath pins that a locked control channel
+// reports a STABLE residual carrier offset under multipath/ISI — it must not
+// swing by ~±1 kHz block-to-block. A real reporter saw carrier_off_hz jitter
+// from −1492 to +616 Hz on a fully-locked, calm CC (bsch_ok 100%), and the
+// symbol-scope constellation "drift" a continuous-tracking reference demod does
+// not show. The cause is the feed-forward AFC re-deriving a noisy estimate every
+// ~1024-symbol block: on an ISI-smeared constellation both the coarse lag-1 and
+// the fine 4×Δφ stages jitter, so the reported offset (and the per-block
+// derotation that spins the scope) swings even though the true offset is ~fixed.
+//
+// The across-block EMA smooths that jitter without moving the tracked mean. This
+// test drives the production 144 kHz / Gardner / AFC + channel-filter path over
+// a multipath+noise channel and asserts the per-block reported offset stays
+// tightly bounded. On a clean carrier the AFC is already quiet, so the multipath
+// is what makes this fail before the smoothing and pass after.
+func TestAFCReportedOffsetStableUnderMultipath(t *testing.T) {
+	const (
+		sps   = 8
+		span  = 8
+		alpha = 0.35
+		rate  = 144_000.0
+	)
+
+	// A long random π/4-DQPSK stream so the AFC processes many ~1024-symbol
+	// blocks and we can measure the block-to-block spread of its estimate.
+	sync := tetra.NormalSyncDibits()
+	want := make([]uint8, 0, 40000)
+	lcg := uint32(0xC0FFEE)
+	for r := 0; r < 380; r++ {
+		want = append(want, sync...)
+		for i := 0; i < 100; i++ {
+			lcg = lcg*1664525 + 1013904223
+			want = append(want, uint8((lcg>>16)&3))
+		}
+	}
+
+	// Gaussian-ish noise (sum-of-uniforms), deterministic per subtest.
+	noise := func(seed uint32, n int) []complex64 {
+		out := make([]complex64, n)
+		r := seed
+		g := func() float64 {
+			var s float64
+			for k := 0; k < 12; k++ {
+				r = r*1664525 + 1013904223
+				s += float64(r>>8) / float64(1<<24)
+			}
+			return s - 6
+		}
+		for i := range out {
+			out[i] = complex(float32(g()), float32(g()))
+		}
+		return out
+	}
+
+	// A centred carrier plus a modest reflection — the field condition
+	// (ISI-smeared but decodable). The exact reflection differs per case so the
+	// smoothing is exercised against more than one channel.
+	cases := []struct {
+		name   string
+		delay  int
+		gr, gi float32
+		snrDB  float64
+		seed   uint32
+	}{
+		{"mildMultipath", 12, 0.55, -0.35, 16, 0x11},
+		{"medMultipath", 8, -0.6, 0.5, 14, 0x29},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			base := demod.ModulatePiOver4DQPSK(want, sps, span, alpha, math.Pi/4)
+			iq := make([]complex64, len(base))
+			copy(iq, base)
+			g := complex(c.gr, c.gi)
+			for n := len(iq) - 1; n >= c.delay; n-- {
+				iq[n] += g * base[n-c.delay]
+			}
+			var sp float64
+			for _, s := range iq {
+				sp += float64(real(s)*real(s) + imag(s)*imag(s))
+			}
+			sp /= float64(len(iq))
+			sigma := math.Sqrt(sp / math.Pow(10, c.snrDB/10) / 2)
+			nz := noise(c.seed, len(iq))
+			for n := range iq {
+				iq[n] += complex(float32(sigma)*real(nz[n]), float32(sigma)*imag(nz[n]))
+			}
+
+			rx := New(Options{
+				SampleRateHz:        rate,
+				ClockMode:           ClockGardner,
+				GardnerGain:         0.005,
+				EnableAFC:           true,
+				EnableChannelFilter: true, // production CC config
+				DibitSink:           func([]uint8, int) {},
+			})
+
+			// Record the reported offset after each chunk; the AFC updates it once
+			// per ~1024-symbol block, so this samples every block at least once.
+			var samples []float64
+			const chunk = 4096
+			for i := 0; i < len(iq); i += chunk {
+				end := i + chunk
+				if end > len(iq) {
+					end = len(iq)
+				}
+				rx.Process(iq[i:end])
+				samples = append(samples, rx.CarrierOffsetHz())
+			}
+
+			// Skip a short warm-up (filter + EMA priming), then measure the spread
+			// of the remaining per-block estimates.
+			if len(samples) < 12 {
+				t.Fatalf("too few offset samples: %d", len(samples))
+			}
+			tail := samples[6:]
+			min, max := tail[0], tail[0]
+			for _, v := range tail {
+				if v < min {
+					min = v
+				}
+				if v > max {
+					max = v
+				}
+			}
+			spread := max - min
+
+			// A locked carrier has no fast real drift, so a large block-to-block
+			// swing is feed-forward estimate jitter. The raw per-block estimate
+			// swings ~1 kHz+ on these channels; the smoothed report must hold to a
+			// few hundred Hz.
+			if spread > 400 {
+				t.Errorf("%s: reported offset spread = %.0f Hz (min %.0f, max %.0f) — "+
+					"want <=400 Hz; the feed-forward estimate is jittering the residual "+
+					"and spinning the constellation", c.name, spread, min, max)
+			}
+		})
+	}
+}


### PR DESCRIPTION
A reporter running a locked, calm TETRA control channel saw carrier_off_hz
swing wildly (−1492 → +616 Hz) with the constellation "drifting" in the
symbol scope, though BSCH decoded 100% and the true offset was ~fixed —
"I dont think those carrier drifts are real."

Per-block instrumentation through the receiver front-end confirms it: the
feed-forward AFC re-derives its offset every ~1024-symbol block, and on an
ISI-smeared (multipath) constellation both the coarse lag-1 and the fine
4×Δφ stages jitter block-to-block — plus occasional ±f_sym/4 alias jumps
when the ISI-spurious coarse overshoots the fine estimator's unambiguous
window. The reported offset and the per-block derotation follow that
jitter, so the status line swings and the scope constellation spins.

Derotate by, and report, a smoothed net estimate: an across-block EMA
(α=0.08, ~0.7 s) seeded from the first block, with alias-sized outliers
rejected. Seeding from the first block means a genuine multi-kHz offset is
still acquired immediately (α only governs how fast slow drift is
followed), and smoothing strips the jitter without moving the tracked
mean, so the differential decode is unaffected.

Regression test TestAFCReportedOffsetStableUnderMultipath drives the
production 144 kHz / Gardner / AFC + channel-filter path over a
multipath+noise channel: baseline reports spread 559 Hz / 4044 Hz, the
smoothed AFC ≤400 Hz. The #940 large-offset acquisition, AFC-recovers, and
AFC-noop tests stay green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SDS37XfizkeDmLie8ikQfF