### PR TITLE
dmr: auto-correct residual tuner carrier offset in the C4FM receiver (#836)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **DMR now auto-corrects a small residual tuner carrier offset.** The
+  narrowband DMR C4FM decoder tolerates only ~±75 Hz of carrier error before
+  the 4-level slicer mis-decides and nothing decodes (issue #836) — at 446 MHz
+  even a fraction of a ppm exceeds that. The receiver now runs the same coarse
+  AFC the P25 Phase 1 decoder already used (issue #275), recentring the symbol
+  eye, so a lightly-mistuned dongle (up to roughly ±2 ppm) decodes without
+  hand-setting `sdr.ppm`. Grossly-mistuned dongles still want a measured
+  `sdr.ppm`; automatic correction of large offsets is a follow-up.
 - **Conventional DMR / IPSC repeaters now report "site alive" from their idle
   beacons.** On a `dmr-tier2` channel that parks on a fixed carrier with no
   control channel, the periodic idle beacon a repeater emits between calls (a

--- a/internal/radio/dmr/receiver/receiver.go
+++ b/internal/radio/dmr/receiver/receiver.go
@@ -98,6 +98,7 @@ type Receiver struct {
 	fm        *demod.FM
 	mf        *demod.C4FM
 	clock     *sync.MuellerMuller
+	afc       *demod.CoarseAFC
 	agc       c4fmSymbolAGC
 	dibitSink dmr.DibitSink
 	dibitBase int
@@ -145,10 +146,40 @@ func New(opts Options) *Receiver {
 		slicerScale = 2.0 * math.Pi * opts.DeviationHz / opts.SampleRateHz
 	}
 
+	// Coarse carrier-offset correction (issue #836). An uncorrected tuner
+	// ppm error leaves the FM discriminator as a constant DC bias that
+	// slides the 4-level eye off the slicer's fixed thresholds; the
+	// narrowband DMR demod tolerates only ~±75 Hz before decode collapses.
+	// CoarseAFC tracks and subtracts that bias, recentring the eye — the
+	// same primitive the P25 Phase 1 C4FM receiver runs (issue #275), which
+	// DMR was the one 4800-baud C4FM receiver to skip.
+	//
+	// Unlike P25, DMR applies the correction on the recovered SYMBOL stream
+	// (post-clock, pre-slicer), not on the pre-clock matched-filter stream.
+	// The offset's DC bias is present identically in both domains, but the
+	// coarse open-loop estimate wanders by a few Hz as it chases the data
+	// mean, and feeding that time-varying bias into the Mueller-Müller
+	// timing loop destabilises symbol timing on a clean signal (verified:
+	// it drove synthetic-decode sync to zero). Correcting on the symbols
+	// recentres the eye for the fixed-threshold slicer while leaving the
+	// timing loop's input untouched. That keeps large offsets (where the
+	// clock itself needs help) bounded to the timing loop's own pull-in
+	// range — a P25-style before-clock/freeze stage is the follow-up for
+	// grossly-mistuned dongles, which still want sdr.ppm today.
+	//
+	// sps=1: the symbol stream is one sample per symbol, so the 64-symbol
+	// time constant is NewCoarseAFC(1). Allocated only on the calibrated
+	// DeviationHz>0 path so legacy pre-scaled fixtures stay byte-identical.
+	var afc *demod.CoarseAFC
+	if opts.DeviationHz > 0 {
+		afc = demod.NewCoarseAFC(1)
+	}
+
 	return &Receiver{
 		fm:    demod.NewFM(),
 		mf:    demod.NewC4FM(int(sps+0.5), span, alpha, slicerScale),
 		clock: sync.NewMuellerMuller(sps, gain),
+		afc:   afc,
 		// Symbol-AGC bridges the level mismatch between the unit-energy
 		// RRC matched filter and the 4-level slicer's fixed thresholds.
 		// The RRC has a DC gain of ~3.1 (it is normalised to unit
@@ -192,6 +223,16 @@ func (r *Receiver) Process(iq []complex64) {
 	if len(r.symbols) == 0 {
 		return
 	}
+	// Subtract the residual carrier-offset DC bias from the recovered
+	// symbols before slicing, so a real tuner's frequency error doesn't
+	// shift the 4-level eye off the slicer's fixed thresholds and stop the
+	// decode (issue #836). Applied here (post-clock) rather than before the
+	// timing loop so its small, data-driven wander can't destabilise symbol
+	// timing; nil (no-op) on the legacy DeviationHz<=0 path. Runs before the
+	// AGC so the level normalisation sees a centred eye.
+	if r.afc != nil {
+		r.afc.Process(r.symbols)
+	}
 	// Normalise the symbol level to the slicer's expected scale before
 	// slicing, so the unit-energy matched filter's ~3.1× DC gain doesn't
 	// push the 4-level eye past the slicer's fixed thresholds (no-op on
@@ -216,6 +257,9 @@ func (r *Receiver) Process(iq []complex64) {
 func (r *Receiver) Reset() {
 	r.dibitBase = 0
 	r.agc.reset()
+	if r.afc != nil {
+		r.afc.Reset()
+	}
 }
 
 // c4fmSymbolAGC tracks a running estimate of mean|x| over the

--- a/internal/radio/dmr/receiver/receiver_test.go
+++ b/internal/radio/dmr/receiver/receiver_test.go
@@ -5,6 +5,118 @@ import (
 	"testing"
 )
 
+// dibitToSymbol is the inverse of SymbolToDibit — used by the test
+// modulator to turn a dibit stream back into C4FM symbol deviations.
+func dibitToSymbol(d uint8) int {
+	switch d {
+	case 0:
+		return +1
+	case 1:
+		return +3
+	case 2:
+		return -1
+	case 3:
+		return -3
+	}
+	return 0
+}
+
+// makeC4FMIQWithOffset modulates a dibit stream to 48 kHz / 10 sps C4FM
+// IQ (unfiltered NRFM, same shape as makePhaseRampIQ) and rotates the
+// whole buffer by a constant carrier offset in Hz — the exact impairment
+// an uncorrected tuner ppm error imposes (issue #836).
+func makeC4FMIQWithOffset(dibits []uint8, offsetHz float64) []complex64 {
+	const sampleRate = 48_000.0
+	const sps = 10
+	const deviation = 1944.0
+	iq := make([]complex64, len(dibits)*sps)
+	phase := 0.0
+	for i, d := range dibits {
+		dphi := 2 * math.Pi * float64(dibitToSymbol(d)) * deviation / 3.0 / sampleRate
+		base := i * sps
+		for k := 0; k < sps; k++ {
+			iq[base+k] = complex(float32(math.Cos(phase)), float32(math.Sin(phase)))
+			phase += dphi
+		}
+	}
+	if offsetHz != 0 {
+		for n := range iq {
+			th := 2 * math.Pi * offsetHz * float64(n) / sampleRate
+			iq[n] *= complex(float32(math.Cos(th)), float32(math.Sin(th)))
+		}
+	}
+	return iq
+}
+
+// balancedStream builds a deterministic, zero-mean dibit stream long
+// enough for the CoarseAFC to converge and be measured over a steady-state
+// tail.
+func balancedStream(n int) []uint8 {
+	// A period-4 walk visits every symbol equally (mean 0) and a
+	// period-7 twist breaks the trivial repetition so the comparison
+	// exercises all four decision regions rather than one steady rail.
+	out := make([]uint8, n)
+	for i := range out {
+		out[i] = uint8((i%4 + i/7) % 4)
+	}
+	return out
+}
+
+// decodeDibits runs one IQ buffer through a DeviationHz-calibrated DMR
+// receiver and returns the recovered dibit stream.
+func decodeDibits(iq []complex64) []uint8 {
+	var got []uint8
+	r := New(Options{
+		SampleRateHz: 48_000,
+		DeviationHz:  1944.0,
+		DibitSink:    func(dibits []uint8, baseIdx int) { got = append(got, dibits...) },
+	})
+	r.Process(iq)
+	return got
+}
+
+// TestReceiverIsCarrierOffsetInvariant pins issue #836: a narrowband DMR
+// C4FM signal carrying an uncorrected tuner carrier offset far beyond the
+// slicer's ~±75 Hz tolerance must decode to the SAME dibit stream as the
+// zero-offset signal, because the receiver's CoarseAFC removes the
+// offset's constant DC bias from the symbols before the slicer sees them.
+// The offset is the only difference between the two inputs, so after the
+// AFC converges the two recovered streams must agree. Without the AFC the
+// shifted 4-level eye mis-slices and the streams diverge (verified
+// failing-first by disabling the AFC stage: agreement collapses ~0.99 →
+// ~0.79 at this offset).
+func TestReceiverIsCarrierOffsetInvariant(t *testing.T) {
+	const offsetHz = 400.0 // >5× the ~±75 Hz decode cliff
+	stream := balancedStream(600)
+
+	ref := decodeDibits(makeC4FMIQWithOffset(stream, 0))
+	off := decodeDibits(makeC4FMIQWithOffset(stream, offsetHz))
+
+	n := len(ref)
+	if len(off) < n {
+		n = len(off)
+	}
+	// Skip a warm-up region so the measurement is over the AFC's
+	// steady state, not its convergence transient.
+	const warmup = 250
+	if n <= warmup {
+		t.Fatalf("recovered only %d dibits, need > %d", n, warmup)
+	}
+	agree := 0
+	for i := warmup; i < n; i++ {
+		if ref[i] == off[i] {
+			agree++
+		}
+	}
+	frac := float64(agree) / float64(n-warmup)
+	// With the AFC on this sits ~0.99; disabling it drops it to ~0.79
+	// (the shifted eye mis-slices). 0.95 cleanly separates the two while
+	// leaving margin for the coarse AFC's small steady-state residual.
+	if frac < 0.95 {
+		t.Fatalf("offset-vs-baseline dibit agreement = %.3f over %d symbols, want >=0.95 — CoarseAFC should make decode invariant to a %.0f Hz carrier offset (issue #836)", frac, n-warmup, offsetHz)
+	}
+}
+
 func TestReceiverConstructsAndProcessesSilence(t *testing.T) {
 	r := New(Options{
 		SampleRateHz: 48_000,


### PR DESCRIPTION
## Summary

A narrowband DMR C4FM channel fails to decode when the RTL-SDR tuner carries an uncorrected ppm/carrier offset: the 4-level slicer's fixed thresholds tolerate only ~±75 Hz of residual carrier error, and at 446 MHz even a fraction of a ppm exceeds that — the signal is strong but sync never correlates (issue #836). DMR was the one 4800-baud C4FM receiver in the tree with **no AFC stage**; P25 Phase 1 has run one since #275.

## Changes

- **`internal/radio/dmr/receiver`**: wire the existing `demod.CoarseAFC` into the DMR receiver. It tracks the constant DC bias a carrier offset leaves on the symbol stream and subtracts it, recentring the 4-level eye on the slicer thresholds.
  - Applied on the recovered **symbol** stream (post-clock, pre-slicer), **not** on the pre-clock matched-filter stream as P25 does. The offset's DC bias is present identically in both domains, but the coarse open-loop estimate wanders a few Hz chasing the data mean, and feeding that time-varying bias into the Mueller-Müller timing loop destabilises symbol timing on a clean signal — measured: it drove the wideband engine's synthetic-decode sync-hit count to **zero**. Correcting on the symbols recentres the eye for the fixed-threshold slicer while leaving the timing loop's input untouched.
  - This bounds the help to offsets the timing loop can still pull in on its own (~±2 ppm at 446 MHz). A P25-style before-clock/freeze/DDA stage for grossly-mistuned dongles is a follow-up; `sdr.ppm` remains the workaround for those.
  - Allocated only on the calibrated `DeviationHz>0` path, so the legacy pre-scaled fixtures stay byte-identical.
- **CHANGELOG**: an Added bullet.

## Test plan

- [x] `make vet test` is green locally
- [ ] `make integration` — n/a (receiver-level DSP change; exercised by the existing wideband/ccdecoder/daemon DMR tests, all green)
- [x] Added a failing-first test (verified red without the fix): `TestReceiverIsCarrierOffsetInvariant` — a synthesized DMR C4FM signal rotated by a 400 Hz carrier offset (>5× the decode cliff) must recover the same dibit stream as the zero-offset signal; agreement holds at ~0.99 with the AFC and collapses to ~0.79 without it.
- [x] Confirmed no regression: the wideband engine's synthetic-decode tests (`TestEngineEndToEndT2GrantFromSynthesizedIQ`, `TestEngineDiagnosticsCountersOnDecode`) and the real-capture DMR tests still pass — the symbol-domain application is what keeps clean-signal decode intact.
- [ ] Smoke-tested against a real off-tuned dongle — **not yet**. The synthetic test proves the mechanism; on-air confirmation (and the decision to add the large-offset before-clock stage) needs the reporter's raw IQ capture of the 446.500 signal.

## Breaking changes

None. Correction is a near-noop on a well-tuned signal (the estimate converges to ~0), and it is inactive on the legacy `DeviationHz<=0` path, so existing fixtures and tests are byte-identical.

## Docs / CHANGELOG

- [x] Added a `## [Unreleased]` bullet to `CHANGELOG.md`
- [ ] README / docs — n/a (the `sdr.ppm` guidance and the #836 diagnostic WARN already exist)

## Linked issues

Refs #836 (kept as `Refs`, not `Closes`, per the repo's verify-before-close policy — the automatic correction is validated synthetically here; on-air confirmation needs the reporter's capture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaHjpxSRmHT7rF5eHjPyhD

---
_Generated by [Claude Code](https://claude.ai/code/session_01WaHjpxSRmHT7rF5eHjPyhD)_