### PR TITLE
tetra: fix dead SCH/SYSINFO counters, add failure + voice telemetry

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -869,6 +869,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 			TETRAChannel:            sys.TETRAChannel,
 			TETRAChannelCoding:      sys.TETRAChannelCoding,
 			TETRAClockMode:          sys.TETRAClockMode,
+			TETRAStatusIntervalSecs: sys.TETRAStatusIntervalSecs,
 			LTRFCSMode:              sys.LTRFCSMode,
 			LTRManchesterMode:       sys.LTRManchesterMode,
 			P25Phase1DemodMode:      sys.P25Phase1DemodMode,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1450,6 +1450,14 @@ type SystemConfig struct {
 	// protocols.
 	TETRAChannelCoding string `yaml:"tetra_channel_coding"`
 
+	// TETRAStatusIntervalSecs sets how often (seconds) the throttled
+	// "tetra: decode status" DEBUG line is emitted, and therefore the
+	// window its per-interval counters (sb_bursts, bsch_ok/fail,
+	// sysinfo, sch_pdus/sch_pdus_fail, grants) accumulate over. 0 or
+	// unset ⇒ the 5 s default. Debug-only diagnostics; has no effect
+	// unless the log level is debug. Ignored for non-TETRA protocols.
+	TETRAStatusIntervalSecs float64 `yaml:"tetra_status_interval_secs"`
+
 	// LTRFCSMode enables the CRC-7 FCS check on the LTR Status
 	// Ingest path. Recognised values: "" / "on" / "true" / "1"
 	// (the new default — drop Status words whose FCS trailer

--- a/internal/configbuilder/advanced.go
+++ b/internal/configbuilder/advanced.go
@@ -13,6 +13,7 @@ var AdvancedFields = map[string][]string{
 	"SystemConfig": {
 		// TETRA
 		"TETRAColourCode", "TETRAChannel", "TETRAChannelCoding", "TETRAClockMode",
+		"TETRAStatusIntervalSecs",
 		// LTR
 		"LTRFCSMode", "LTRManchesterMode",
 		// P25 Phase 1

--- a/internal/configbuilder/fieldmeta.go
+++ b/internal/configbuilder/fieldmeta.go
@@ -178,6 +178,7 @@ var fieldMetas = map[string]FieldMeta{
 	"SystemConfig.TETRAChannel":            {Label: "TETRA channel", Help: "Which TETRA logical channel each burst carries (sch/hd, sch/f, sch/hu, bsch, aach). Empty = sch/hd. TETRA only."},
 	"SystemConfig.TETRAChannelCoding":      {Label: "TETRA channel coding", Help: "Gate the full ETSI channel-coding chain. on (default, live captures) or off (raw-dibit fixtures). TETRA only."},
 	"SystemConfig.TETRAClockMode":          {Label: "TETRA clock mode", Help: "Symbol-timing recovery: gardner (default, live SDR) or naive (sample-aligned fixtures). TETRA only."},
+	"SystemConfig.TETRAStatusIntervalSecs": {Label: "TETRA status interval (s)", Help: "How often the debug 'tetra: decode status' line is emitted, and the window its counters accumulate over. 0 = 5 s default. Debug diagnostics only. TETRA only."},
 	"SystemConfig.LTRFCSMode":              {Label: "LTR FCS mode", Help: "CRC-7 FCS check on LTR Status words. on (default) or off (un-populated fixtures). LTR only."},
 	"SystemConfig.LTRManchesterMode":       {Label: "LTR Manchester mode", Help: "LTR sub-audible decode: soft (default), strict, or off/nrz. LTR only."},
 	"SystemConfig.P25Phase1DemodMode":      {Label: "P25 Ph1 demod mode", Help: "Phase 1 symbol recovery: c4fm/fm (default, correct for most systems including most simulcast) or cqpsk/lsm (only for systems that actually transmit linear/LSM modulation). Simulcast alone does not require cqpsk. P25 Phase 1 only."},

--- a/internal/radio/tetra/control.go
+++ b/internal/radio/tetra/control.go
@@ -518,13 +518,14 @@ func (c *ControlChannel) Topology() TopologyConfig {
 // fields are cumulative counts over the drain window except Dibits, which is
 // the symbol count used to estimate the effective baud.
 type Stats struct {
-	Dibits   int64 // symbols (dibits) processed — effective-baud numerator
-	SBBursts int64 // synchronisation-burst candidates entering the SB decoder
-	BSCHOK   int64 // BSCH blocks recovered CRC-clean
-	BSCHFail int64 // SB candidates whose BSCH did not decode under any rotation
-	SysInfo  int64 // BNCH SYSINFO PDUs decoded off the synchronisation burst
-	SCHPDUs  int64 // signalling PDUs parsed off the normal-sync path
-	Grants   int64 // voice grants published
+	Dibits      int64 // symbols (dibits) processed — effective-baud numerator
+	SBBursts    int64 // synchronisation-burst candidates entering the SB decoder
+	BSCHOK      int64 // BSCH blocks recovered CRC-clean
+	BSCHFail    int64 // SB candidates whose BSCH did not decode under any rotation
+	SysInfo     int64 // SYSINFO PDUs decoded: sync-burst BNCH (L3) or downlink NCDB broadcast (MAC, the real-air path)
+	SCHPDUs     int64 // signalling channel (SCH/F, SCH/HD) blocks recovered CRC-clean off a real NCDB slot
+	SCHPDUsFail int64 // AACH-confirmed control slots that yielded no CRC-clean SCH block
+	Grants      int64 // voice grants published
 }
 
 // addStat adds n to a decode-health counter when debug telemetry is on. A
@@ -703,6 +704,11 @@ func (c *ControlChannel) learnSysInfo(si SysInfo) {
 	c.mainCarrier = si.MainCarrier
 	c.mainCarrierSet = true
 	c.mu.Unlock()
+	// Count every SYSINFO MAC broadcast we decode this window. This is the real
+	// on-air path (bit-packed MAC PDU via ParseSysInfo), unlike the byte-aligned
+	// L3 AsSystemBroadcast that the sync-burst BNCH rarely matches — so the
+	// decode-status line's sysinfo now moves on a locked carrier.
+	c.addStat(&c.stats.SysInfo, 1)
 	if first {
 		dl := tetraDLCarrierHz(si.FreqBand, si.MainCarrier, si.Offset)
 		ul, ulOK := tetraULCarrierHz(dl, si.FreqBand, si.DuplexSpacing, si.ReverseOper)

--- a/internal/radio/tetra/downlink.go
+++ b/internal/radio/tetra/downlink.go
@@ -173,13 +173,18 @@ func (c *ControlChannel) decodeDownlinkSlot(bkn1, aach1, aach2, bkn2 []uint8, bk
 
 	// The AACH is present in every downlink slot and decodes ~100% on a locked
 	// carrier, so it pins the rotation cheaply; fall back to trying all four
-	// only when it does not decode (e.g. a synthesised slot with no AACH).
+	// only when it does not decode (e.g. a synthesised slot with no AACH). The
+	// parsed ACCESS-ASSIGN also classifies the slot (control vs traffic), which
+	// gates the SCHPDUsFail counter below.
 	rots := []uint8{0, 1, 2, 3}
+	var aa AccessAssign
+	var aachOK bool
 	aachDi := append(append([]uint8{}, aach1...), aach2...)
 	for r := uint8(0); r < 4; r++ {
 		rec, errs := DecodeAACH(derot(aachDi, r), colour)
 		if errs >= 0 {
-			if _, ok := ParseAccessAssign(rec); ok {
+			if parsed, ok := ParseAccessAssign(rec); ok {
+				aa, aachOK = parsed, true
 				rots = []uint8{r}
 				break
 			}
@@ -193,35 +198,59 @@ func (c *ControlChannel) decodeDownlinkSlot(bkn1, aach1, aach2, bkn2 []uint8, bk
 	// and hard use the identical rotation. CRC gates both, so no double-count.
 	haveF := bkn1Diffs != nil && bkn2Diffs != nil && len(bkn1Diffs) == len(bkn1) && len(bkn2Diffs) == len(bkn2)
 
+	recovered := 0
 	for _, r := range rots {
 		full := append(append([]uint8{}, bkn1...), bkn2...)
 		if haveF {
 			fullDiffs := append(append([]complex64{}, bkn1Diffs...), bkn2Diffs...)
 			if rec, ok := DecodeSCHFSoft(softType5FromDiffs(fullDiffs, (4-r)&3), colour); ok {
 				c.ingestMAC(rec)
+				recovered++
 			} else if rec, ok := DecodeSCHF(derot(full, r), colour); ok {
 				c.ingestMAC(rec)
+				recovered++
 			}
 		} else if rec, ok := DecodeSCHF(derot(full, r), colour); ok {
 			c.ingestMAC(rec)
+			recovered++
 		}
-		c.decodeDownlinkHalf(bkn1, bkn1Diffs, r, derot, colour)
-		c.decodeDownlinkHalf(bkn2, bkn2Diffs, r, derot, colour)
+		if c.decodeDownlinkHalf(bkn1, bkn1Diffs, r, derot, colour) {
+			recovered++
+		}
+		if c.decodeDownlinkHalf(bkn2, bkn2Diffs, r, derot, colour) {
+			recovered++
+		}
+	}
+
+	// Decode-health telemetry (debug-gated). SCHPDUs counts CRC-clean signalling
+	// blocks off the real NCDB slot — one for a full-slot SCH/F, up to two for a
+	// two-half SCH/HD slot — the metric that stayed 0 on air when it was bolted to
+	// the legacy fixed-slice path. SCHPDUsFail counts a slot the AACH confirms is
+	// carrying control that yielded no CRC-clean block: a real signalling-payload
+	// decode failure. The AACH gate keeps same-carrier traffic (TCH) slots and
+	// correlator noise (AACH itself fails to decode) out of the failure count.
+	if recovered > 0 {
+		c.addStat(&c.stats.SCHPDUs, int64(recovered))
+	} else if aachOK && aa.IsControlChannel() {
+		c.addStat(&c.stats.SCHPDUsFail, 1)
 	}
 }
 
 // decodeDownlinkHalf decodes one SCH/HD half-slot under rotation r, soft-first
-// (when the per-symbol differentials are available and aligned) then hard.
-func (c *ControlChannel) decodeDownlinkHalf(bkn []uint8, diffs []complex64, r uint8, derot func([]uint8, uint8) []byte, colour uint32) {
+// (when the per-symbol differentials are available and aligned) then hard. It
+// reports whether a CRC-clean block was recovered so the caller can count it.
+func (c *ControlChannel) decodeDownlinkHalf(bkn []uint8, diffs []complex64, r uint8, derot func([]uint8, uint8) []byte, colour uint32) bool {
 	if diffs != nil && len(diffs) == len(bkn) {
 		if rec, ok := DecodeSCHHDSoft(softType5FromDiffs(diffs, (4-r)&3), colour); ok {
 			c.ingestMAC(rec)
-			return
+			return true
 		}
 	}
 	if rec, ok := DecodeSCHHD(derot(bkn, r), colour); ok {
 		c.ingestMAC(rec)
+		return true
 	}
+	return false
 }
 
 // ingestMAC demultiplexes a recovered logical-channel block (type-1 bits) at the

--- a/internal/radio/tetra/process.go
+++ b/internal/radio/tetra/process.go
@@ -383,6 +383,11 @@ func (c *ControlChannel) decodeSB(p *processState, L int) {
 				if sb.MCC != 0 {
 					ls.MCC, ls.MNC = sb.MCC, sb.MNC
 				}
+				// Count a SYSINFO decoded off the sync-burst BNCH as a byte-aligned
+				// L3 System Broadcast. On real air this rarely matches (real BNCH
+				// SYSINFO is a bit-packed MAC PDU counted via learnSysInfo instead),
+				// but it keeps the sync-burst decode-health signal for fixtures that
+				// carry it and adds nothing spurious on air.
 				c.addStat(&c.stats.SysInfo, 1)
 			}
 			if c.fecObserver != nil {
@@ -560,7 +565,10 @@ func (c *ControlChannel) dispatchSlice(slice []uint8, mode ChannelCodingMode, ch
 	}
 	if len(info) >= 1 {
 		if pdu, err := ParsePDU(info); err == nil {
-			c.addStat(&c.stats.SCHPDUs, 1)
+			// SCHPDUs is now counted on the real NCDB path (decodeDownlinkSlot),
+			// not here: this legacy fixed-slice slice only decodes the synthetic
+			// in-package fixtures (a block placed contiguously after the training
+			// sequence), never a real NCDB burst, so counting it reported 0 on air.
 			c.Ingest(pdu)
 		}
 	}

--- a/internal/radio/tetra/stats_test.go
+++ b/internal/radio/tetra/stats_test.go
@@ -211,29 +211,90 @@ func TestSyncBurstDebugLines(t *testing.T) {
 	})
 }
 
-// TestDrainStatsCountsSCHPDU confirms the SCHPDUs counter tracks signalling
-// PDUs recovered off the normal-sync path (dispatchSlice), the other decode
-// route alongside the synchronisation burst.
-func TestDrainStatsCountsSCHPDU(t *testing.T) {
+// buildNCDBStream assembles one Normal Continuous Downlink Burst as a hard dibit
+// stream with the real on-air geometry: BKN1 look-back headroom, BKN1(108),
+// AACH-half-1(7), the normal training sequence, AACH-half-2(8), BKN2(108), then a
+// look-ahead tail. Mirrors the layout in TestProcessDecodesGrantFromNCDB and the
+// ndb* geometry constants. aach1/aach2 may be nil (left as fill, so the AACH does
+// not decode and the slot falls back to trying all rotations).
+func buildNCDBStream(bkn1, aach1, aach2, bkn2 []uint8) []uint8 {
+	if aach1 == nil {
+		aach1 = make([]uint8, ndbAACH1Len)
+	}
+	if aach2 == nil {
+		aach2 = make([]uint8, ndbAACH2Len)
+	}
+	var s []uint8
+	s = append(s, make([]uint8, 24)...) // priming / BKN1 look-back headroom
+	s = append(s, bkn1...)
+	s = append(s, aach1...)
+	s = append(s, NormalSyncDibits()...)
+	s = append(s, aach2...)
+	s = append(s, bkn2...)
+	s = append(s, make([]uint8, 8)...) // look-ahead tail
+	return s
+}
+
+// TestDrainStatsCountsSCHPDUFromNCDB confirms SCHPDUs tracks CRC-clean signalling
+// blocks recovered off a *real* NCDB slot (the decodeDownlinkSlot path), not the
+// legacy fixed-slice dispatchSlice path — which never fired on air and left the
+// counter stuck at 0. Fail-first: before SCHPDUs was re-homed onto the NCDB path
+// this stayed 0.
+func TestDrainStatsCountsSCHPDUFromNCDB(t *testing.T) {
+	const colour = 0x1234
 	cc, bus := debugCC(t, io.Discard, slog.LevelDebug)
 	defer bus.Close()
-	cc.SetExpectedChannel(ChannelSCHHD)
-	cc.SetColourCode(0x12345)
+	cc.SetColourCode(colour)
 
-	pdu := PDU{Disc: DiscMLE, Type: uint8(MLESystemInfo), Payload: []byte{0x00, 0x40, 0x00, 0x00, 0x00}}
-	info := pduToType1Bits(pdu, 124)
-	if info == nil {
-		t.Fatal("PDU too large for SCH/HD 124 type-1 bits")
-	}
-	dibits := TetraBitsToDibits(EncodeSCHHD(info, 0x12345))
-
-	stream := make([]uint8, 30)
-	stream = append(stream, NormalSyncDibits()...)
-	stream = append(stream, dibits...)
-	cc.Process(stream, 0)
+	// A real MAC-RESOURCE SCH/F type-1 payload (same capture as
+	// TestProcessDecodesGrantFromNCDB) laid into BKN1+BKN2.
+	info := hexToBits(t, "20760f572c3c83d538c90a1fe305009e0f92813c83d538c91e1fe301304a1eae5880")[:268]
+	dibits := TetraBitsToDibits(EncodeSCHF(info, colour)) // 216 dibits
+	cc.Process(buildNCDBStream(dibits[:108], nil, nil, dibits[108:]), 0)
 
 	if got := cc.DrainStats(); got.SCHPDUs < 1 {
-		t.Errorf("SCHPDUs = %d, want >= 1 (normal-sync SCH/HD PDU)", got.SCHPDUs)
+		t.Errorf("SCHPDUs = %d, want >= 1 (CRC-clean SCH/F off a real NCDB slot)", got.SCHPDUs)
+	}
+}
+
+// TestDrainStatsCountsSCHPDUFail confirms SCHPDUsFail counts an AACH-confirmed
+// control slot that yields no CRC-clean SCH block — a real signalling-payload
+// decode failure — while leaving SCHPDUs at 0. The AACH decodes as common control
+// (Header 0), but the BKN blocks are fill, so neither SCH/F nor SCH/HD passes CRC.
+func TestDrainStatsCountsSCHPDUFail(t *testing.T) {
+	const colour = 0x1234
+	cc, bus := debugCC(t, io.Discard, slog.LevelDebug)
+	defer bus.Close()
+	cc.SetColourCode(colour)
+
+	// A valid ACCESS-ASSIGN whose header (0) marks the downlink as common control.
+	aachDibits := TetraBitsToDibits(EncodeAACH(make([]byte, 14), colour)) // 15 dibits
+	aach1, aach2 := aachDibits[:ndbAACH1Len], aachDibits[ndbAACH1Len:]
+	// Fill BKN blocks so no SCH/F or SCH/HD decodes CRC-clean.
+	bkn1, bkn2 := make([]uint8, ndbBlockDibits), make([]uint8, ndbBlockDibits)
+	cc.Process(buildNCDBStream(bkn1, aach1, aach2, bkn2), 0)
+
+	got := cc.DrainStats()
+	if got.SCHPDUsFail < 1 {
+		t.Errorf("SCHPDUsFail = %d, want >= 1 (control slot with no CRC-clean SCH block)", got.SCHPDUsFail)
+	}
+	if got.SCHPDUs != 0 {
+		t.Errorf("SCHPDUs = %d, want 0 (no block should have decoded)", got.SCHPDUs)
+	}
+}
+
+// TestDrainStatsCountsSysInfo confirms SysInfo counts SYSINFO MAC broadcast PDUs
+// decoded off the real NCDB/MAC path (learnSysInfo), not the byte-aligned L3
+// AsSystemBroadcast gate that rarely matched real bit-packed MAC SYSINFO and left
+// the counter at 0 on air. Fail-first: before the re-home this stayed 0.
+func TestDrainStatsCountsSysInfo(t *testing.T) {
+	cc, bus := debugCC(t, io.Discard, slog.LevelDebug)
+	defer bus.Close()
+	// A real recovered SYSINFO MAC broadcast (same capture as
+	// TestGrantPublishesResolvedFrequency).
+	cc.ingestMAC(hexToBits(t, "8a9c4c0e928eec8bd0c0041cffffd700"))
+	if got := cc.DrainStats(); got.SysInfo < 1 {
+		t.Errorf("SysInfo = %d, want >= 1 (SYSINFO MAC broadcast via learnSysInfo)", got.SysInfo)
 	}
 }
 

--- a/internal/radio/tetra/traffic.go
+++ b/internal/radio/tetra/traffic.go
@@ -82,16 +82,30 @@ const TrafficFrameBytes = (2 * ndbBlockDibits * 2) / 8 // 54
 // look-ahead to BKN2 around each detected normal training sequence.
 //
 // Not safe for concurrent use; construct one per followed call.
+// pendingHit is one training-sequence detection awaiting enough look-ahead to
+// emit: its leading dibit index L and whether it matched the *second* normal
+// training sequence (NTS2) — the on-air flag for a stolen half-slot (STCH).
+type pendingHit struct {
+	L      int
+	stolen bool
+}
+
 type TrafficExtractor struct {
 	dets       []*SyncDetector // NTS1 + NTS2, each under all four constellation rotations
+	detStolen  []bool          // parallel to dets: true for the NTS2 (stolen-slot) detectors
 	stsDets    []*SyncDetector // synchronisation training sequence, all four rotations (slot-1 anchor)
 	scratch    []int
 	stsScratch []int
 	buf        []uint8
 	bufBase    int
-	pending    []int // training-sequence leading indices awaiting look-ahead
+	pending    []pendingHit // training-sequence hits awaiting look-ahead
 	colourCode uint32
 	onBurst    func(frame []byte, softType5 []float32, slot, usage uint8)
+
+	// stolenBursts counts emitted bursts whose training sequence was NTS2 — a
+	// stolen half-slot (STCH) carrying urgent signalling in place of speech.
+	// Telemetry only; touched solely on the Process goroutine (see StolenBursts).
+	stolenBursts uint64
 
 	// softBuf holds the per-dibit complex differentials (the receiver's soft
 	// info) strictly parallel to buf, so emit can build a soft-decision type-5
@@ -154,9 +168,10 @@ func NewTrafficExtractor(colourCode uint32, onBurst func(frame []byte, softType5
 	// π/4-DQPSK leaves a constant 0..3 dibit rotation (residual CFO), so
 	// correlate the training sequence under all four rotations of the
 	// pattern — the same trick processSB uses for the sync burst.
-	for _, base := range [][]uint8{NormalSyncDibits(), NormalSyncDibits2()} {
+	for bi, base := range [][]uint8{NormalSyncDibits(), NormalSyncDibits2()} {
 		for r := uint8(0); r < 4; r++ {
 			te.dets = append(te.dets, NewSyncDetector(rotateDibits(base, r), 2))
+			te.detStolen = append(te.detStolen, bi == 1) // NTS2 ⇒ stolen half-slot
 		}
 	}
 	// Synchronisation-training-sequence detectors (all four rotations) pin
@@ -215,44 +230,51 @@ func (te *TrafficExtractor) Process(dibits []uint8, baseIdx int) {
 	}
 
 	ntsLen := len(NormalSyncDibits()) // 11
-	for _, det := range te.dets {
+	for di, det := range te.dets {
 		var hits []int
 		hits, _ = det.Process(te.scratch[:0], dibits, baseIdx)
+		stolen := te.detStolen[di]
 		for _, trailing := range hits {
 			L := trailing - (ntsLen - 1)
 			dup := false
-			for _, q := range te.pending {
-				if q == L {
+			for i := range te.pending {
+				if te.pending[i].L == L {
 					dup = true
+					// A stolen (NTS2) match on an L already pending as NTS1 wins:
+					// the same burst can correlate weakly under the other sequence,
+					// but the stolen flag is the decision that matters downstream.
+					if stolen {
+						te.pending[i].stolen = true
+					}
 					break
 				}
 			}
 			if !dup {
-				te.pending = append(te.pending, L)
+				te.pending = append(te.pending, pendingHit{L: L, stolen: stolen})
 			}
 		}
 	}
 
 	bufEnd := te.bufBase + len(te.buf)
-	kept := make([]int, 0, len(te.pending))
-	for _, L := range te.pending {
-		needStart := L + ndbBKN1Start
-		needEnd := L + ndbBKN2Start + ndbBlockDibits
+	kept := make([]pendingHit, 0, len(te.pending))
+	for _, p := range te.pending {
+		needStart := p.L + ndbBKN1Start
+		needEnd := p.L + ndbBKN2Start + ndbBlockDibits
 		if needStart < te.bufBase {
 			continue // look-back already trimmed; give up on this hit
 		}
 		if needEnd > bufEnd {
-			kept = append(kept, L) // not enough look-ahead yet
+			kept = append(kept, p) // not enough look-ahead yet
 			continue
 		}
-		te.emit(L)
+		te.emit(p.L, p.stolen)
 	}
 	te.pending = kept
 
 	// Trim, keeping the trailing margin plus any unresolved hit's look-back.
 	keepFrom := bufEnd - ndbTrimMargin
-	for _, L := range te.pending {
-		if ns := L + ndbBKN1Start; ns < keepFrom {
+	for _, p := range te.pending {
+		if ns := p.L + ndbBKN1Start; ns < keepFrom {
 			keepFrom = ns
 		}
 	}
@@ -336,10 +358,20 @@ func (te *TrafficExtractor) StashSymbols(syms []complex64, baseIdx int) {
 	te.pendingSymBase = baseIdx
 }
 
+// StolenBursts returns the cumulative count of emitted bursts whose training
+// sequence was NTS2 — the on-air flag for a stolen half-slot (STCH) carrying
+// urgent signalling in place of speech (ETSI EN 300 392-2). Telemetry for the
+// composer's voice-path summary; single-goroutine (mutated only under Process),
+// so read it after the IQ stream has ended.
+func (te *TrafficExtractor) StolenBursts() uint64 { return te.stolenBursts }
+
 // emit slices BKN1 and BKN2 around the training sequence leading at L and
 // forwards the concatenated raw type-5 frame, tagged with the burst's TDMA slot
-// and its AACH downlink usage marker.
-func (te *TrafficExtractor) emit(L int) {
+// and its AACH downlink usage marker. stolen marks an NTS2 (STCH) burst.
+func (te *TrafficExtractor) emit(L int, stolen bool) {
+	if stolen {
+		te.stolenBursts++
+	}
 	block := func(off int) []uint8 {
 		s := L + off - te.bufBase
 		return te.buf[s : s+ndbBlockDibits]

--- a/internal/radio/tetra/traffic_test.go
+++ b/internal/radio/tetra/traffic_test.go
@@ -59,6 +59,38 @@ func TestTrafficExtractorSingleBurst(t *testing.T) {
 // non-zero colour code the emitted frame is the raw type-5 bits descrambled
 // with the cell's extended colour code — the input the TCH/S channel decoder
 // expects — not the still-scrambled bits.
+// TestTrafficExtractorStolenBurst confirms StolenBursts counts a burst whose
+// training sequence is NTS2 — the STCH stolen-half-slot flag — while a normal
+// NTS1 burst leaves the count at 0. Both still emit exactly one frame: the stolen
+// flag is telemetry only and must not change the extracted payload.
+func TestTrafficExtractorStolenBurst(t *testing.T) {
+	bkn1 := rampDibits(ndbBlockDibits, 0)
+	bkn2 := rampDibits(ndbBlockDibits, 2)
+
+	build := func(t *testing.T, nts []uint8) *TrafficExtractor {
+		t.Helper()
+		stream := make([]uint8, 600)
+		L := 200
+		copy(stream[L:], nts)
+		copy(stream[L+ndbBKN1Start:], bkn1)
+		copy(stream[L+ndbBKN2Start:], bkn2)
+		var n int
+		te := NewTrafficExtractor(0, func(_ []byte, _ []float32, _, _ uint8) { n++ })
+		te.Process(stream, 0)
+		if n != 1 {
+			t.Fatalf("emitted %d frames, want 1", n)
+		}
+		return te
+	}
+
+	if te := build(t, NormalSyncDibits2()); te.StolenBursts() != 1 {
+		t.Errorf("NTS2 (stolen) burst StolenBursts = %d, want 1", te.StolenBursts())
+	}
+	if te := build(t, NormalSyncDibits()); te.StolenBursts() != 0 {
+		t.Errorf("NTS1 (normal) burst StolenBursts = %d, want 0", te.StolenBursts())
+	}
+}
+
 func TestTrafficExtractorDescrambles(t *testing.T) {
 	bkn1 := rampDibits(ndbBlockDibits, 0)
 	bkn2 := rampDibits(ndbBlockDibits, 2)

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -659,13 +659,21 @@ func newTETRAPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 		// voice receivers; it must not disturb steady-state CC decode.
 		EnableEqualizer: true,
 	})
+	// Emission cadence of the decode-status line, operator-configurable via
+	// tetra_status_interval_secs; falls back to the 5 s default when unset or
+	// non-positive.
+	statusInterval := tetraStatusInterval
+	if s := opts.System.TETRAStatusIntervalSecs; s > 0 {
+		statusInterval = time.Duration(s * float64(time.Second))
+	}
 	return &tetraPipeline{
-		rx:     rx,
-		cc:     cc,
-		log:    opts.Log,
-		system: opts.SystemName,
-		rateHz: opts.SampleRateHz,
-		now:    time.Now,
+		rx:             rx,
+		cc:             cc,
+		log:            opts.Log,
+		system:         opts.SystemName,
+		rateHz:         opts.SampleRateHz,
+		now:            time.Now,
+		statusInterval: statusInterval,
 		// Gate the periodic decode-status line on debug once, up front, so a
 		// production (info-level) decode does no per-chunk clock reads. The
 		// control channel gates its own counter accumulation the same way.
@@ -673,10 +681,11 @@ func newTETRAPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 	}, nil
 }
 
-// tetraStatusInterval throttles the aggregate "tetra: decode status" debug
-// line so a long capture emits a compact health summary a few times a minute
-// rather than once per IQ chunk. Mirrors the ~1 s AFC-status throttle in
-// decoder.go.
+// tetraStatusInterval is the DEFAULT throttle for the aggregate "tetra: decode
+// status" debug line so a long capture emits a compact health summary a few
+// times a minute rather than once per IQ chunk. Mirrors the ~1 s AFC-status
+// throttle in decoder.go. Operators can override the cadence per system via
+// tetra_status_interval_secs (see newTETRAPipeline / tetraPipeline.statusInterval).
 const tetraStatusInterval = 5 * time.Second
 
 // tetraLockStaleTimeout is how long a locked TETRA control channel may decode
@@ -724,15 +733,16 @@ const (
 const tetraResyncTimeout = 1500 * time.Millisecond
 
 type tetraPipeline struct {
-	rx        *tetrarx.Receiver
-	cc        *tetra.ControlChannel
-	log       *slog.Logger
-	system    string
-	debug     bool
-	rateHz    float64          // post-DDC channel rate; converts the resync window into a sample budget
-	now       func() time.Time // injectable for tests; set to time.Now at construction
-	lastLog   time.Time        // wall clock of the previous status line (zero ⇒ not primed)
-	lastStale time.Time        // wall clock of the previous lock-staleness check
+	rx             *tetrarx.Receiver
+	cc             *tetra.ControlChannel
+	log            *slog.Logger
+	system         string
+	debug          bool
+	rateHz         float64          // post-DDC channel rate; converts the resync window into a sample budget
+	now            func() time.Time // injectable for tests; set to time.Now at construction
+	statusInterval time.Duration    // decode-status emission cadence (tetra_status_interval_secs; default 5 s)
+	lastLog        time.Time        // wall clock of the previous status line (zero ⇒ not primed)
+	lastStale      time.Time        // wall clock of the previous lock-staleness check
 	// Signal-time DSP-resync trigger: the receiver must PROCESS a full
 	// tetraResyncTimeout-worth of post-DDC samples with no CRC-clean CC decode
 	// before a destructive reset-to-centre is allowed. Counting processed signal
@@ -850,7 +860,7 @@ func (p *tetraPipeline) maybeLogStatus() {
 		return
 	}
 	elapsed := now.Sub(p.lastLog)
-	if elapsed < tetraStatusInterval {
+	if elapsed < p.statusInterval {
 		return
 	}
 	p.lastLog = now
@@ -868,6 +878,7 @@ func (p *tetraPipeline) maybeLogStatus() {
 		"bsch_fail", st.BSCHFail,
 		"sysinfo", st.SysInfo,
 		"sch_pdus", st.SCHPDUs,
+		"sch_pdus_fail", st.SCHPDUsFail,
 		"grants", st.Grants,
 		"colour_code", p.cc.Topology().ColourCode&0x3F,
 	)

--- a/internal/scanner/ccdecoder/pipelines_tetra_status_test.go
+++ b/internal/scanner/ccdecoder/pipelines_tetra_status_test.go
@@ -83,7 +83,7 @@ func TestTETRAStatusLineThrottled(t *testing.T) {
 	if !strings.Contains(out, "baud=18000") {
 		t.Errorf("expected baud=18000 in status line\n%s", out)
 	}
-	for _, key := range []string{"carrier_off_hz=", "locked=", "sb_bursts=", "colour_code="} {
+	for _, key := range []string{"carrier_off_hz=", "locked=", "sb_bursts=", "sch_pdus=", "sch_pdus_fail=", "colour_code="} {
 		if !strings.Contains(out, key) {
 			t.Errorf("status line missing key %q\n%s", key, out)
 		}
@@ -95,6 +95,62 @@ func TestTETRAStatusLineThrottled(t *testing.T) {
 	if strings.Contains(buf.String(), "tetra: decode status") {
 		t.Errorf("status line emitted twice within one interval\n%s", buf.String())
 	}
+}
+
+// TestTETRAStatusIntervalConfigurable confirms tetra_status_interval_secs sets the
+// emission cadence: a 10 s interval stays silent at 6 s (where the 5 s default
+// would already have emitted) and emits once 10 s have elapsed. An unset interval
+// falls back to the 5 s default.
+func TestTETRAStatusIntervalConfigurable(t *testing.T) {
+	newPipe := func(t *testing.T, intervalSecs float64) (*tetraPipeline, *bytes.Buffer) {
+		t.Helper()
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+		bus := events.NewBus(8)
+		t.Cleanup(bus.Close)
+		pp, err := newTETRAPipeline(PipelineOptions{
+			Bus: bus, Log: logger, SystemName: "Test", FrequencyHz: 412_000_000,
+			SampleRateHz: 144_000,
+			System: trunking.System{
+				Name: "Test", Protocol: trunking.ProtocolTETRA,
+				ControlChannels:         []uint32{412_000_000},
+				TETRAStatusIntervalSecs: intervalSecs,
+			},
+		})
+		if err != nil {
+			t.Fatalf("newTETRAPipeline: %v", err)
+		}
+		return pp.(*tetraPipeline), &buf
+	}
+
+	t.Run("10s interval waits past the 5s default", func(t *testing.T) {
+		p, buf := newPipe(t, 10)
+		if p.statusInterval != 10*time.Second {
+			t.Fatalf("statusInterval = %v, want 10s", p.statusInterval)
+		}
+		now := time.Unix(2000, 0)
+		p.now = func() time.Time { return now }
+		p.maybeLogStatus() // prime
+
+		now = now.Add(6 * time.Second) // past the 5 s default, before 10 s
+		p.maybeLogStatus()
+		if strings.Contains(buf.String(), "tetra: decode status") {
+			t.Fatalf("status line emitted at 6 s with a 10 s interval\n%s", buf.String())
+		}
+
+		now = now.Add(5 * time.Second) // now 11 s since prime
+		p.maybeLogStatus()
+		if !strings.Contains(buf.String(), "tetra: decode status") {
+			t.Fatalf("status line not emitted after 10 s interval elapsed\n%s", buf.String())
+		}
+	})
+
+	t.Run("unset falls back to 5s default", func(t *testing.T) {
+		p, _ := newPipe(t, 0)
+		if p.statusInterval != tetraStatusInterval {
+			t.Fatalf("statusInterval = %v, want default %v", p.statusInterval, tetraStatusInterval)
+		}
+	})
 }
 
 // TestTETRAStatusLineSilentAtInfo confirms the status line is gated on debug —

--- a/internal/trunking/site.go
+++ b/internal/trunking/site.go
@@ -203,6 +203,11 @@ type System struct {
 	// Forwarded into tetra.ControlChannel.SetChannelCoding by the
 	// ccdecoder connector after parsing via tetra.ParseChannelCoding.
 	TETRAChannelCoding string
+	// TETRAStatusIntervalSecs sets the emission cadence (seconds) of the
+	// throttled "tetra: decode status" debug line — and thus the window
+	// its per-interval counters accumulate over. 0/unset ⇒ 5 s default.
+	// Consumed by newTETRAPipeline. Ignored for non-TETRA protocols.
+	TETRAStatusIntervalSecs float64
 
 	// LTRFCSMode enables CRC-7 FCS verification on the LTR Status
 	// Ingest path (per DSheirer/sdrtrunk's CRCLTR.java layout).

--- a/internal/voice/composer/tetra_voice.go
+++ b/internal/voice/composer/tetra_voice.go
@@ -75,9 +75,9 @@ func (c *Composer) runTETRAVoiceChain(ctx context.Context, serial string, iqCh <
 	symbolHz := fe.OutRateHz()
 
 	rs, _ := c.sink.(rawFrameSink)
-	var bursts, speech, offSlot atomic.Uint64
+	var bursts, speech, offSlot, bfi atomic.Uint64
 	extractor := tetra.NewTrafficExtractor(colourExt, func(frame []byte, softType5 []float32, slot, usage uint8) {
-		c.onTETRATrafficBurst(bt, rs, serial, frame, softType5, usage, usageMarker, &bursts, &speech, &offSlot)
+		c.onTETRATrafficBurst(bt, rs, serial, frame, softType5, usage, usageMarker, &bursts, &speech, &offSlot, &bfi)
 	})
 
 	rx := tetrarx.New(tetrarx.Options{
@@ -98,7 +98,9 @@ func (c *Composer) runTETRAVoiceChain(ctx context.Context, serial string, iqCh <
 
 	defer func() {
 		c.log.Info("composer: tetra voice follow ended",
-			"serial", serial, "bursts", bursts.Load(), "speech_frames", speech.Load(),
+			"serial", serial, "bursts", bursts.Load(),
+			"speech_frames", speech.Load(), "tch_frames", speech.Load(),
+			"stch_bursts", extractor.StolenBursts(), "bfi_count", bfi.Load(),
 			"other_call_bursts", offSlot.Load())
 	}()
 
@@ -187,7 +189,7 @@ func drainTETRAIQ(ch <-chan []complex64, process func([]complex64)) {
 // behave like every other protocol — the call ends hangtime after its last
 // decoded speech frame (or via the no-voice startup timeout when a grant never
 // decodes any speech).
-func (c *Composer) onTETRATrafficBurst(bt *boundaryTracker, rs rawFrameSink, serial string, frame []byte, softType5 []float32, burstUsage, grantUsage uint8, bursts, speech, offSlot *atomic.Uint64) {
+func (c *Composer) onTETRATrafficBurst(bt *boundaryTracker, rs rawFrameSink, serial string, frame []byte, softType5 []float32, burstUsage, grantUsage uint8, bursts, speech, offSlot, bfi *atomic.Uint64) {
 	bursts.Add(1)
 	// Drop bursts that carry a different call's AACH usage marker. Only when both
 	// markers are known (>= DLUsageTraffic) — an unknown marker on either side
@@ -196,7 +198,11 @@ func (c *Composer) onTETRATrafficBurst(bt *boundaryTracker, rs rawFrameSink, ser
 		offSlot.Add(1)
 		return
 	}
-	c.decodeTETRASpeech(bt, rs, serial, frame, softType5, speech)
+	// A burst accepted for this call that yields no speech is a Bad Frame
+	// Indication (corrupt/encrypted → concealment); count it.
+	if c.decodeTETRASpeech(bt, rs, serial, frame, softType5, speech) == 0 {
+		bfi.Add(1)
+	}
 }
 
 // decodeTETRASpeech TCH/S-decodes one traffic frame for an owning call: it
@@ -205,7 +211,10 @@ func (c *Composer) onTETRATrafficBurst(bt *boundaryTracker, rs rawFrameSink, ser
 // `.raw` sidecar (the ACELP vocoder renders it to PCM downstream). A non-TCH/S
 // burst (signalling, encrypted, or corrupt) yields no frames and does not touch
 // liveness. Shared by the solo traffic tap and the same-carrier slot demux.
-func (c *Composer) decodeTETRASpeech(bt *boundaryTracker, rs rawFrameSink, serial string, frame []byte, softType5 []float32, speech *atomic.Uint64) {
+// Returns the number of CRC-valid 137-bit speech frames recovered: 0 for a burst
+// that yielded no speech (a Bad Frame Indication the callers count toward
+// bfi_count), a positive count for real speech (feeds tch_frames).
+func (c *Composer) decodeTETRASpeech(bt *boundaryTracker, rs rawFrameSink, serial string, frame []byte, softType5 []float32, speech *atomic.Uint64) int {
 	// Prefer soft-decision TCH/S when the extractor supplied the burst's LLRs:
 	// the soft Viterbi's ~2 dB coding gain recovers real speech bursts the
 	// hard-decision gate drops on a marginal same-carrier signal (the fix for
@@ -218,13 +227,15 @@ func (c *Composer) decodeTETRASpeech(bt *boundaryTracker, rs rawFrameSink, seria
 		frames = tetra.TCHSpeechFrames(frame)
 	}
 	if len(frames) == 0 {
-		// Not the granted call's speech — do NOT touch call liveness.
-		return
+		// Not the granted call's speech — do NOT touch call liveness. A burst
+		// routed to an owner that yields nothing here is a Bad Frame Indication
+		// (the caller counts it).
+		return 0
 	}
 	// CRC-valid speech: keep the call alive and reset the hangtime timer.
 	bt.onVoice(0)
 	if rs == nil {
-		return
+		return len(frames)
 	}
 	// Emit each recovered 137-bit speech frame to the recorder, which renders it
 	// with the ACELP vocoder and appends it to the `.raw` sidecar.
@@ -236,6 +247,7 @@ func (c *Composer) decodeTETRASpeech(bt *boundaryTracker, rs rawFrameSink, seria
 			c.log.Warn("composer: TETRA speech-frame write failed", "serial", serial, "err", err)
 		}
 	}
+	return len(frames)
 }
 
 // --- Shared per-carrier TETRA voice demultiplexer --------------------------
@@ -295,6 +307,15 @@ type tetraSlotDemux struct {
 	// another slot's speech into the sole recording bled calls together.
 	concurrencySuppressed atomic.Uint64
 
+	// Voice-path decode telemetry, aggregated across all owners on this carrier
+	// and logged at demux teardown (the voice analogue of the CC decode-status
+	// line). tchFrames = CRC-valid speech frames routed to the ACELP vocoder;
+	// bfiFrames = bursts routed to an owner that yielded no speech (Bad Frame
+	// Indication → concealment). Stolen-slot (STCH) bursts are counted by the
+	// TrafficExtractor and read from it directly at teardown.
+	tchFrames atomic.Uint64
+	bfiFrames atomic.Uint64
+
 	// slotRing is a sliding window of the physical TDMA slot (1..4) of recent
 	// traffic-marked bursts, used only to decide whether the carrier is currently
 	// running concurrent calls. Unlike the AACH usage marker (which decodes on a
@@ -350,7 +371,8 @@ type tetraDecodeJob struct {
 // from onVoice's (lastMatch/foreignRun/…), so the two goroutines do not race.
 type tetraSlotOwner struct {
 	serial         string
-	marker         uint8 // grant usage marker; 0 = wildcard until it claims one
+	marker         uint8           // grant usage marker; 0 = wildcard until it claims one
+	d              *tetraSlotDemux // owning carrier demux, for aggregate voice telemetry (nil in the solo tap)
 	bt             *boundaryTracker
 	rs             rawFrameSink
 	bursts, speech atomic.Uint64
@@ -378,6 +400,23 @@ func (o *tetraSlotOwner) enqueue(frame []byte, softType5 []float32) {
 	}
 }
 
+// decode runs one queued burst through decodeTETRASpeech and folds the outcome
+// into the carrier demux's aggregate voice telemetry: CRC-valid speech frames
+// into tch_frames, a burst that yielded no speech into bfi_count (a Bad Frame
+// Indication — this burst was routed to the owner as its slot but could not be
+// turned into speech, so it is concealed).
+func (o *tetraSlotOwner) decode(c *Composer, job tetraDecodeJob) {
+	n := c.decodeTETRASpeech(o.bt, o.rs, o.serial, job.frame, job.softType5, &o.speech)
+	if o.d == nil {
+		return
+	}
+	if n > 0 {
+		o.d.tchFrames.Add(uint64(n))
+	} else {
+		o.d.bfiFrames.Add(1)
+	}
+}
+
 // tetraOwnerWorker is the single per-owner goroutine that runs the CPU-heavy
 // TCH/S channel decode + ACELP synthesis for one call, off the shared demux
 // goroutine. On ctx cancel (call end) it drains whatever bursts are already
@@ -390,13 +429,13 @@ func (c *Composer) tetraOwnerWorker(ctx context.Context, o *tetraSlotOwner) {
 			for {
 				select {
 				case job := <-o.jobs:
-					c.decodeTETRASpeech(o.bt, o.rs, o.serial, job.frame, job.softType5, &o.speech)
+					o.decode(c, job)
 				default:
 					return
 				}
 			}
 		case job := <-o.jobs:
-			c.decodeTETRASpeech(o.bt, o.rs, o.serial, job.frame, job.softType5, &o.speech)
+			o.decode(c, job)
 		}
 	}
 }
@@ -427,6 +466,9 @@ func (d *tetraSlotDemux) run(ctx context.Context, iqCh <-chan []complex64, iqHz 
 		"key", d.key, "colour_code", d.colour&0x3F, "rate_hz", symbolHz)
 	defer func() {
 		d.c.log.Info("composer: tetra shared voice demux ended", "key", d.key,
+			"tch_frames", d.tchFrames.Load(),
+			"stch_bursts", extractor.StolenBursts(),
+			"bfi_count", d.bfiFrames.Load(),
 			"undecoded_drops", d.undecodedDrops.Load(),
 			"ownerless_drops", d.ownerlessDrops.Load(),
 			"crc_fallbacks", d.crcFallbacks.Load(),
@@ -643,7 +685,7 @@ func (c *Composer) runTETRASameCarrierChain(ctx context.Context, d *tetraSlotDem
 	rs, _ := c.sink.(rawFrameSink)
 
 	o := &tetraSlotOwner{
-		serial: serial, marker: usageMarker, bt: bt, rs: rs,
+		serial: serial, marker: usageMarker, d: d, bt: bt, rs: rs,
 		jobs: make(chan tetraDecodeJob, tetraVocoderQueueDepth),
 	}
 	// Start the vocoder worker BEFORE registering the owner, so a burst routed the

--- a/internal/voice/composer/tetra_voice_test.go
+++ b/internal/voice/composer/tetra_voice_test.go
@@ -187,7 +187,7 @@ func TestTETRATrafficBurstLivenessGatedByCRC(t *testing.T) {
 	c, _, _ := mkBoundaryComposer(t, false, 50*time.Millisecond)
 	bt := c.newBoundaryTracker("VOICE-1", 0, nil)
 	rs := &recordingSink{}
-	var bursts, speech, offSlot atomic.Uint64
+	var bursts, speech, offSlot, bfi atomic.Uint64
 
 	// Case A: a deterministic non-TCH/S 54-byte burst. Guard that the CRC gate
 	// rejects it (it does for this fixed vector), then confirm it leaves the
@@ -199,7 +199,7 @@ func TestTETRATrafficBurstLivenessGatedByCRC(t *testing.T) {
 	if tetra.TCHSpeechFrames(junk) != nil {
 		t.Fatalf("test vector precondition: junk frame unexpectedly passed the TCH/S CRC gate")
 	}
-	c.onTETRATrafficBurst(bt, rs, "VOICE-1", junk, nil, 0, 0, &bursts, &speech, &offSlot)
+	c.onTETRATrafficBurst(bt, rs, "VOICE-1", junk, nil, 0, 0, &bursts, &speech, &offSlot, &bfi)
 	if bt.sawVoice.Load() {
 		t.Error("non-speech burst set sawVoice — liveness not gated on CRC-valid speech")
 	}
@@ -215,11 +215,14 @@ func TestTETRATrafficBurstLivenessGatedByCRC(t *testing.T) {
 	if got := bursts.Load(); got != 1 {
 		t.Errorf("bursts = %d after one call, want 1", got)
 	}
+	if got := bfi.Load(); got != 1 {
+		t.Errorf("non-speech burst bfi_count = %d, want 1 (concealment)", got)
+	}
 
 	// Case B: a CRC-valid TCH/S burst carrying two 137-bit speech frames. It must
 	// mark voice activity and emit both speech frames to the recorder.
 	frame := tetra.EncodeTCHS(make([]byte, 137), make([]byte, 137))
-	c.onTETRATrafficBurst(bt, rs, "VOICE-1", frame, nil, 0, 0, &bursts, &speech, &offSlot)
+	c.onTETRATrafficBurst(bt, rs, "VOICE-1", frame, nil, 0, 0, &bursts, &speech, &offSlot, &bfi)
 	if !bt.sawVoice.Load() {
 		t.Error("CRC-valid TCH/S burst did not set sawVoice")
 	}
@@ -235,6 +238,9 @@ func TestTETRATrafficBurstLivenessGatedByCRC(t *testing.T) {
 	if got := bursts.Load(); got != 2 {
 		t.Errorf("bursts = %d after two calls, want 2", got)
 	}
+	if got := bfi.Load(); got != 1 {
+		t.Errorf("bfi_count = %d after a valid speech burst, want 1 (unchanged)", got)
+	}
 }
 
 // TestTETRATrafficBurstUsageMarkerFilter is the regression for concurrent
@@ -249,14 +255,14 @@ func TestTETRATrafficBurstUsageMarkerFilter(t *testing.T) {
 	c, _, _ := mkBoundaryComposer(t, false, 50*time.Millisecond)
 	bt := c.newBoundaryTracker("VOICE-2", 0, nil)
 	rs := &recordingSink{}
-	var bursts, speech, offSlot atomic.Uint64
+	var bursts, speech, offSlot, bfi atomic.Uint64
 
 	// A CRC-valid TCH/S frame (belongs to whichever call it arrives on).
 	frame := tetra.EncodeTCHS(make([]byte, 137), make([]byte, 137))
 	const grantUsage uint8 = 20 // this call's downlink usage marker
 
 	// Another call's slot (marker 19 != granted 20): dropped off-call, no decode.
-	c.onTETRATrafficBurst(bt, rs, "VOICE-2", frame, nil, 19, grantUsage, &bursts, &speech, &offSlot)
+	c.onTETRATrafficBurst(bt, rs, "VOICE-2", frame, nil, 19, grantUsage, &bursts, &speech, &offSlot, &bfi)
 	if got := offSlot.Load(); got != 1 {
 		t.Errorf("foreign-call burst offSlot = %d, want 1", got)
 	}
@@ -268,7 +274,7 @@ func TestTETRATrafficBurstUsageMarkerFilter(t *testing.T) {
 	}
 
 	// Granted marker (20 == granted 20): decoded and written.
-	c.onTETRATrafficBurst(bt, rs, "VOICE-2", frame, nil, grantUsage, grantUsage, &bursts, &speech, &offSlot)
+	c.onTETRATrafficBurst(bt, rs, "VOICE-2", frame, nil, grantUsage, grantUsage, &bursts, &speech, &offSlot, &bfi)
 	if n := len(rs.rawFrames("VOICE-2")); n != 2 {
 		t.Errorf("granted-marker burst wrote %d frames, want 2", n)
 	}
@@ -278,7 +284,7 @@ func TestTETRATrafficBurstUsageMarkerFilter(t *testing.T) {
 
 	// Undecoded AACH (marker 0): CRC-gated fallback still processes it — an AACH
 	// miss must not drop the granted call's own speech.
-	c.onTETRATrafficBurst(bt, rs, "VOICE-2", frame, nil, 0, grantUsage, &bursts, &speech, &offSlot)
+	c.onTETRATrafficBurst(bt, rs, "VOICE-2", frame, nil, 0, grantUsage, &bursts, &speech, &offSlot, &bfi)
 	if n := len(rs.rawFrames("VOICE-2")); n != 4 {
 		t.Errorf("undecoded-AACH burst wrote total %d frames, want 4", n)
 	}
@@ -295,12 +301,12 @@ func TestTETRATrafficBurstNoGrantMarkerFallback(t *testing.T) {
 	c, _, _ := mkBoundaryComposer(t, false, 50*time.Millisecond)
 	bt := c.newBoundaryTracker("VOICE-3", 0, nil)
 	rs := &recordingSink{}
-	var bursts, speech, offSlot atomic.Uint64
+	var bursts, speech, offSlot, bfi atomic.Uint64
 	frame := tetra.EncodeTCHS(make([]byte, 137), make([]byte, 137))
 
 	// Grant marker 0 (unknown): a burst with any marker is decoded, none dropped.
-	c.onTETRATrafficBurst(bt, rs, "VOICE-3", frame, nil, 19, 0, &bursts, &speech, &offSlot)
-	c.onTETRATrafficBurst(bt, rs, "VOICE-3", frame, nil, 0, 0, &bursts, &speech, &offSlot)
+	c.onTETRATrafficBurst(bt, rs, "VOICE-3", frame, nil, 19, 0, &bursts, &speech, &offSlot, &bfi)
+	c.onTETRATrafficBurst(bt, rs, "VOICE-3", frame, nil, 0, 0, &bursts, &speech, &offSlot, &bfi)
 	if n := len(rs.rawFrames("VOICE-3")); n != 4 {
 		t.Errorf("no-grant-marker fallback wrote %d frames, want 4 (accept all CRC-valid speech)", n)
 	}

--- a/web/configbuilder/src/sections/Trunking.tsx
+++ b/web/configbuilder/src/sections/Trunking.tsx
@@ -35,7 +35,7 @@ const PROTOCOLS = [
 // Long-tail protocol decoder knobs surfaced via AdvancedJSON. None are
 // enforced by config.Validate, so a free JSON editor is lossless.
 const PROTOCOL_KNOBS: (keyof SystemConfig)[] = [
-  "TETRAColourCode", "TETRAChannel", "TETRAChannelCoding", "TETRAClockMode",
+  "TETRAColourCode", "TETRAChannel", "TETRAChannelCoding", "TETRAClockMode", "TETRAStatusIntervalSecs",
   "LTRFCSMode", "LTRManchesterMode", "P25Phase1DemodMode", "DMRInterleavedVoice",
   "P25Phase2TrellisMode", "P25Phase2RSMode", "P25Phase2InterleaveMode",
   "P25Phase2ScramblerMode", "P25Phase2SoftDecision", "P25Phase2ClockMode", "NXDNViterbiMode",


### PR DESCRIPTION
The "tetra: decode status" debug line reported sch_pdus=0 and sysinfo=0 on
real air even under a healthy lock, because both counters were wired to the
legacy fixed-slice dispatchSlice path (process.go) that only fires on the
synthetic in-package fixtures — a real Normal Continuous Downlink Burst
carries its data in BKN1 before + BKN2 after the training sequence, which
that path misses. The actual on-air decode happens in decodeDownlinkSlot →
ingestMAC, which never touched the counters.

Signaling counters (real-air re-home):
- Move SCHPDUs onto decodeDownlinkSlot, counting CRC-clean SCH/F + SCH/HD
  blocks per NCDB slot. decodeDownlinkHalf now reports recovery.
- Add SCHPDUsFail, counting an AACH-confirmed control slot that yields no
  CRC-clean block — a real signalling-payload decode failure. The AACH gate
  keeps same-carrier traffic slots and correlator noise out of the count.
- Count SysInfo in learnSysInfo (the real bit-packed MAC broadcast path),
  keeping the sync-burst BNCH L3 count for fixtures.
- Surface sch_pdus_fail in the decode-status line.

Configurable status interval:
- New tetra_status_interval_secs config field (config → trunking.System →
  daemon → newTETRAPipeline), defaulting to the existing 5 s. The per-window
  interval machinery already existed; only the cadence is now operator-set.
  Registered in the config-builder field metadata + advanced-fields allow-list.

Voice-path telemetry in the composer's demux/solo summaries:
- tch_frames (CRC-valid speech routed to the vocoder), bfi_count (bursts
  routed to an owner that yielded no speech → concealment), and stch_bursts
  (NTS2 stolen-half-slot bursts, counted in TrafficExtractor via a new
  StolenBursts getter — the onBurst callback signature is unchanged).

Regression-first tests: real-NCDB SCHPDUs>0, SCHPDUsFail on a control slot
with no decode, SysInfo via learnSysInfo, configurable-interval throttle,
STCH stolen-burst count, and BFI on a non-speech burst.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012whiUHDhL9UmTQsFjMsT8p