### PR TITLE
tetra: smooth AFC carrier-offset jitter; iq-autorecord: unique same-second capture paths

### DIFF
--- a/cmd/gophertrunk/iqautorecord.go
+++ b/cmd/gophertrunk/iqautorecord.go
@@ -84,6 +84,7 @@ type iqAutoRecorder struct {
 	seen     map[string]time.Time // observed-call key -> last grant time
 	lastAuto time.Time            // last automatic (non-manual) trigger, for cooldown
 	inFlight int
+	reserved map[string]struct{} // capture paths handed out, so concurrent/same-second captures never collide
 }
 
 // newIQAutoRecorder builds an auto-recorder for the control SDR's broker.
@@ -127,6 +128,7 @@ func newIQAutoRecorder(cfg config.BasebandAutoRecordConfig, system, protocol, se
 		now:      time.Now,
 		baseCtx:  context.Background(),
 		seen:     make(map[string]time.Time),
+		reserved: make(map[string]struct{}),
 	}
 	a.capture = a.defaultCapture
 	return a
@@ -401,7 +403,7 @@ func (a *iqAutoRecorder) runCapture(ctx context.Context, reason, system, protoco
 		a.log.Warn("iq-autorecord: could not create capture dir", "reason", reason, "dir", a.dir, "err", err)
 		return
 	}
-	path := filepath.Join(a.dir, autoRecordFilename(system, reason, at, centerHz, rateHz, a.format))
+	path := a.reserveCapturePath(autoRecordFilename(system, reason, at, centerHz, rateHz, a.format))
 
 	a.log.Info("iq-autorecord: capturing", "reason", reason, "path", path,
 		"seconds", a.seconds, "center_hz", centerHz, "rate_hz", rateHz)
@@ -424,6 +426,39 @@ func (a *iqAutoRecorder) runCapture(ctx context.Context, reason, system, protoco
 	}
 	a.log.Info("iq-autorecord: captured", "reason", reason, "path", path,
 		"samples", samples, "drops", drops)
+}
+
+// reserveCapturePath turns a capture name into a collision-free path under
+// a.dir. autoRecordFilename is only unique to the second, and autoRecordMaxInFlight
+// permits concurrent captures by design, so two triggers in the same second (or
+// the same nanosecond) would otherwise build the same name and the second
+// os.Create would truncate/race the first. On a name that is already handed out
+// this session (a.reserved) or already present on disk (surviving a restart), a
+// -2, -3, … counter is inserted before the extension until the path is free; the
+// winner is recorded so a second concurrent caller skips past it. Held under a.mu
+// so the two runCapture goroutines serialise. Entries are never released: once a
+// file is written its name must never be reused, and the disk check would catch
+// it anyway; growth is one small string per capture (cooldown-throttled).
+func (a *iqAutoRecorder) reserveCapturePath(name string) string {
+	ext := filepath.Ext(name)
+	stem := strings.TrimSuffix(name, ext)
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for n := 1; ; n++ {
+		candidate := name
+		if n > 1 {
+			candidate = fmt.Sprintf("%s-%d%s", stem, n, ext)
+		}
+		path := filepath.Join(a.dir, candidate)
+		if _, taken := a.reserved[path]; taken {
+			continue
+		}
+		if _, err := os.Stat(path); err == nil {
+			continue // already on disk (e.g. from a previous run)
+		}
+		a.reserved[path] = struct{}{}
+		return path
+	}
 }
 
 // autoRecordFilename builds a self-describing capture name:

--- a/cmd/gophertrunk/iqautorecord_test.go
+++ b/cmd/gophertrunk/iqautorecord_test.go
@@ -146,6 +146,74 @@ func TestAutoRecordDDCTapMetadata(t *testing.T) {
 	}
 }
 
+// TestAutoRecordSameSecondCapturesDoNotOverwrite pins that two captures triggered
+// within the same wall-clock second get distinct files. autoRecordFilename stamps
+// the name to 1-second resolution, and autoRecordMaxInFlight allows concurrent
+// captures by design, so before the per-capture path reservation two same-second
+// triggers built the identical <system>_<ts>_<reason>_<freq>_<rate>hz.cs16 name
+// and the second os.Create truncated/raced the first — the operator's observed
+// "two captures, same path" overwrite.
+func TestAutoRecordSameSecondCapturesDoNotOverwrite(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "iq", "auto")
+	cfg := config.BasebandAutoRecordConfig{
+		Enabled: true, Dir: dir, Seconds: 1, Format: "cs16", Tap: "ddc",
+	}
+	a := newIQAutoRecorder(cfg, "250_013", "tetra", "AIRSPY", nil, nil, nil)
+	if a == nil {
+		t.Fatal("newIQAutoRecorder returned nil")
+	}
+
+	// Stub the actuation: record each path handed to a capture and write a couple
+	// of bytes there, so a collision manifests as one file instead of two.
+	var mu sync.Mutex
+	var paths []string
+	a.capture = func(_ context.Context, path string, _ siglab.SampleFormat, _ int) (int64, uint64, error) {
+		mu.Lock()
+		paths = append(paths, path)
+		mu.Unlock()
+		if err := os.WriteFile(path, []byte("iq"), 0o644); err != nil {
+			return 0, 0, err
+		}
+		return 1, 0, nil
+	}
+
+	// Both triggers land in the same UTC second (the reported collision second).
+	at := time.Date(2026, 8, 7, 10, 9, 23, 0, time.UTC)
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			a.runCapture(context.Background(), "concurrent", "250_013", "tetra", at)
+		}()
+	}
+	wg.Wait()
+
+	mu.Lock()
+	got := append([]string(nil), paths...)
+	mu.Unlock()
+	if len(got) != 2 {
+		t.Fatalf("expected 2 capture invocations, got %d", len(got))
+	}
+	if got[0] == got[1] {
+		t.Fatalf("both captures wrote the same path %q — they overwrite each other", got[0])
+	}
+
+	var cs16 int
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".cs16") {
+			cs16++
+		}
+	}
+	if cs16 != 2 {
+		t.Fatalf("found %d .cs16 files, want 2 — same-second captures overwrote each other", cs16)
+	}
+}
+
 // fakeClock is a manually-advanced clock for deterministic cooldown tests.
 type fakeClock struct {
 	mu sync.Mutex


### PR DESCRIPTION
## Summary

Two independent, small fixes prompted by operator reports on a live TETRA TMO trunk. Each is self-contained with its own reproduce-first regression test; they're bundled here because they were investigated in the same session — **happy to split into two PRs if you'd prefer one logical change each.**

1. **TETRA AFC carrier-offset jitter** (`0e70e9f`) — a fully-locked, calm control channel reported `carrier_off_hz` swinging −1492 → +616 Hz with the symbol-scope constellation "drifting", though BSCH decoded 100% and the true offset was ~fixed ("I don't think those carrier drifts are real"). Root cause: the feed-forward AFC re-derives its estimate every ~1024-symbol block, and on an ISI-smeared (multipath) constellation both the coarse lag-1 and fine 4×Δφ stages jitter block-to-block — plus occasional ±f_sym/4 alias jumps when the ISI-spurious coarse overshoots the fine estimator's ±2250 Hz unwrap window.

2. **iq-autorecord same-second overwrite** (`ff31011`) — an operator saw two auto-IQ captures write the *identical* path (`…20260807T100923Z_concurrent_467912500_144000hz.cs16`) and asked whether they overwrite each other. They do: `autoRecordFilename` is unique only to the second, `autoRecordMaxInFlight = 2` allows concurrent captures by design, and `os.Create` truncates — so two same-second triggers clobber each other (and their `.metadata.json` sidecars).

## Changes

**AFC (`internal/radio/tetra/receiver/afc.go`):**
- Derotate by, and report, a **smoothed** net offset: an across-block EMA (`omegaEMAAlpha = 0.08`, ~0.7 s) **seeded from the first block**, with alias-sized outliers (`> π/4`) rejected so one bad block can't poison the track.
- Seeding means a genuine multi-kHz offset is still acquired immediately (α only governs slow-drift tracking); smoothing strips the per-block jitter **without moving the tracked mean**, so the differential decode is unaffected and the status line / Mixer / symbol-scope readout (all read the single `Receiver.CarrierOffsetHz()`) go steady.

**iq-autorecord (`cmd/gophertrunk/iqautorecord.go`):**
- New `reserveCapturePath` hands each capture a collision-free path: inserts a `-2`, `-3`, … counter before the extension when the name is already reserved this session or present on disk, under the recorder mutex so concurrent `runCapture` goroutines serialise. `autoRecordFilename` is unchanged, so a lone capture keeps its clean self-describing name — the suffix appears only on a real collision.

## Test plan

- [x] `make vet test` is green locally
- [x] `make integration` — n/a locally; CI runs the integration-tagged suite. (The iq-autorecord change lives under `cmd/gophertrunk`; no daemon wiring changed.)
- [x] Added tests:
  - `TestAFCReportedOffsetStableUnderMultipath` — drives the production 144 kHz / Gardner / AFC + channel-filter path over a multipath+noise channel; per-block reported offset spread must stay ≤ 400 Hz. Fails pre-fix (559 Hz / 4044 Hz), passes after. Existing `TestReceiverAFCLocksWithLargeCarrierOffset` (#940, 3–5.5 kHz), `TestAFCRecoversDibitsUnderCarrierOffset`, `TestAFCNoopWithoutOffset` stay green.
  - `TestAutoRecordSameSecondCapturesDoNotOverwrite` — fires two same-second captures concurrently; asserts distinct paths + two files on disk. Fails pre-fix (one path, one file), passes after. Existing auto-record tests (incl. the exact-name `TestAutoRecordFilename`) stay green.
- [ ] Smoke-tested against real hardware — the AFC change is validated against synthetic multipath + the existing #940/#553 regression suite; a live A/B on the reporter's captures is a follow-up (the same captures gate the still-open TETRA voice "scratch" / DMO investigation). The iq-autorecord change is filesystem-only.

## Breaking changes

None. Both are internal fixes. `autoRecordFilename`'s output is byte-identical for a non-colliding capture; the AFC change only affects the residual-offset estimate/derotation, not the decode contract.

## Docs / CHANGELOG

- [ ] n/a — both are internal bug fixes with no operator-facing config/CLI/endpoint surface.

## Linked issues

n/a — no tracked issues. (The AFC fix is adjacent to #940/#553/#815 and the ongoing TETRA voice/DMO work, but closes none of them; `Refs` only.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDS37XfizkeDmLie8ikQfF

---
_Generated by [Claude Code](https://claude.ai/code/session_01SDS37XfizkeDmLie8ikQfF)_