### PR TITLE
dmr: let a CRC-valid LC override a wrong same-slot cadence guess (#644)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,19 @@ for tagged releases.
   call-priority metadata to TETRA alongside P25 and DMR.
 
 ### Fixed
+- **DMR 2-slot voice: a wrong same-slot cadence guess could garble a whole
+  call and never recover (reopened #644).** When a call opens on a section
+  whose embedded Link Control doesn't decode, the interleaved decoder picks
+  the same-slot stride (264 vs 288 dibits) by AMBE Golay-FEC quality. That
+  guess was frozen for the rest of the call — and because a wrong stride
+  slices every later burst across the timeslot boundary, the CRC-valid LC
+  that would correct it can never reassemble, so one confident-but-wrong
+  guess produced persistent "sounds-encrypted / DJ-scratch" garble. An
+  FEC-quality lock is now **provisional**: a later CRC-valid embedded LC (or
+  a later clear FEC winner at a different stride) overrides it and re-locks
+  the correct cadence, after which the LC lock is authoritative. Single-slot
+  (Tier I) decoding is unchanged. Pinned by
+  `TestInterleavedDecoderLCOverridesWrongProvisionalCadence`.
 - **macOS: RTL-SDR (R820T) dongles failed to open with "no supported tuner
   detected."** On Apple silicon the tuner's first I²C-bridge burst write could
   STALL the USB control pipe (IOKit `kIOUSBPipeStalled`, `kern_return

--- a/docs/status.md
+++ b/docs/status.md
@@ -129,7 +129,12 @@ The inner FEC layers still pending real-air validation:
   a phase binds to a concrete talkgroup — the absolute TS1/TS2 label the
   identical BS-sourced burst-A sync cannot give. The chain is unit-tested
   against synthetic interleaved + embedded-LC vectors at **both** cadences
-  (`TestInterleavedDecoderAutoDetects{CACH,NoCACH}Cadence`).
+  (`TestInterleavedDecoderAutoDetects{CACH,NoCACH}Cadence`). A cadence chosen
+  only by FEC quality (no LC yet) is held **provisionally**: a later CRC-valid
+  LC — or a clear FEC winner at a different stride — overrides a wrong early
+  guess and re-locks the correct cadence, so one bad guess no longer garbles
+  the rest of the call
+  (`TestInterleavedDecoderLCOverridesWrongProvisionalCadence`).
   The interleaved + LC path is the **default for DMR Tier II conventional
   and Tier III** (#644, extended to Tier II after a field report of garbled
   "DJ-scratch" audio on a `dmr-tier2` site — the same single-slot/2-slot

--- a/internal/radio/dmr/voice/superframe.go
+++ b/internal/radio/dmr/voice/superframe.go
@@ -121,6 +121,17 @@ type Decoder struct {
 	// picks the candidate whose bursts B–E reassemble a CRC-valid embedded
 	// Link Control (sliceAt → HasLC); a wrong cadence cannot.
 	lockedStep int
+	// lockedByLC records HOW lockedStep was set: true once a CRC-valid embedded
+	// Link Control confirmed the cadence (authoritative — nothing overrides it),
+	// false while the lock is only a provisional AMBE-FEC-quality guess. A
+	// provisional lock stays re-checkable every superframe so a wrong early
+	// heuristic guess can be corrected by a later CRC-valid LC (or a later clear
+	// FEC winner at a different stride) — without this a single confident-but-
+	// wrong lock garbles the whole rest of the call and can never self-correct,
+	// because a wrong slice never reassembles the LC that would fix it (#644).
+	// Set true for a single-cadence (single-slot) decoder: its one stride is not
+	// a guess, so its decode path is unchanged.
+	lockedByLC bool
 	// maxSpan is the dibit span of a full A–F superframe at the LARGEST
 	// candidate stride. The Process gate waits for this many dibits past an
 	// anchor before slicing, so every candidate is fully buffered when
@@ -150,9 +161,12 @@ func newDecoder(candidates []int) *Decoder {
 		// the trailing bursts being trimmed out from under them.
 		bufKeep: 2*maxSpan + dmr.BurstDibits,
 	}
-	// A single-cadence decoder has nothing to detect: lock immediately.
+	// A single-cadence decoder has nothing to detect: lock immediately, and
+	// authoritatively (its one stride is not a guess) so its decode path is
+	// unchanged by the provisional-lock re-checking below.
 	if len(candidates) == 1 {
 		d.lockedStep = candidates[0]
+		d.lockedByLC = true
 	}
 	return d
 }
@@ -255,26 +269,38 @@ func ambeErrorScore(sf VoiceSuperframe) int {
 	return score
 }
 
-// resolveAndSlice produces the superframe anchored at start. A decoder with
-// a locked cadence slices at it directly; an undetected interleaved decoder
-// tries each candidate cadence. A bursts-B–E CRC-valid embedded Link Control
-// is authoritative and locks immediately. Absent any LC, it scores each
-// candidate by AMBE FEC quality (ambeErrorScore) and locks the clearly-best
-// one — so a real carrier whose embedded LC never decodes still finds its
-// cadence (issue #644). With no clear winner it falls back to the smallest
-// candidate without locking, so a later LC-bearing or cleaner superframe can
-// still detect. The caller has guaranteed maxSpan dibits past start are
-// buffered, so every candidate is sliceable.
+// resolveAndSlice produces the superframe anchored at start.
+//
+// A CRC-valid embedded Link Control is authoritative: once one confirms the
+// cadence (lockedByLC) the decoder slices at that stride for the rest of the
+// call. Absent any authoritative lock — undetected, or only a provisional
+// AMBE-FEC-quality guess — it re-scores every candidate this superframe and:
+//   - a bursts-B–E CRC-valid LC on any candidate locks it authoritatively;
+//   - otherwise the clearly-best candidate by AMBE FEC quality (ambeErrorScore)
+//     becomes a PROVISIONAL lock, so a real carrier whose LC never decodes
+//     still finds its cadence (issue #644);
+//   - with no clear winner it falls back to the smallest candidate.
+//
+// Re-scoring while the lock is only provisional is what lets a wrong early FEC
+// guess be corrected — by a later CRC-valid LC, or by a later clear FEC winner
+// at a different stride. Without it a single confident-but-wrong lock would
+// garble the whole rest of the call and could never self-correct, since a wrong
+// slice never reassembles the LC that would fix it (the reopened #644 garble).
+// The caller has guaranteed maxSpan dibits past start are buffered, so every
+// candidate is sliceable.
 func (d *Decoder) resolveAndSlice(start int, syncName string) VoiceSuperframe {
-	if d.lockedStep != 0 {
+	// An LC-confirmed cadence is authoritative — slice at it directly.
+	if d.lockedStep != 0 && d.lockedByLC {
 		return d.sliceAt(start, d.lockedStep, syncName)
 	}
+
 	bestIdx, bestScore, secondScore := -1, math.MaxInt, math.MaxInt
 	var bestSF VoiceSuperframe
 	for i, step := range d.cadenceCandidates {
 		sf := d.sliceAt(start, step, syncName)
 		if sf.HasLC {
-			d.lockedStep = step
+			// Authoritative: a CRC-valid LC overrides any provisional lock.
+			d.lockedStep, d.lockedByLC = step, true
 			return sf
 		}
 		switch s := ambeErrorScore(sf); {
@@ -285,9 +311,22 @@ func (d *Decoder) resolveAndSlice(start int, syncName string) VoiceSuperframe {
 			secondScore = s
 		}
 	}
-	if bestIdx >= 0 && bestScore <= ambeCadenceLockCeiling &&
-		bestScore*2+ambeCadenceLockMargin <= secondScore {
-		d.lockedStep = d.cadenceCandidates[bestIdx]
+
+	clearWinner := bestIdx >= 0 && bestScore <= ambeCadenceLockCeiling &&
+		bestScore*2+ambeCadenceLockMargin <= secondScore
+
+	if d.lockedStep != 0 {
+		// Provisionally (FEC-)locked. Keep the current stride unless the data
+		// now clearly favours a different one — then move the provisional lock.
+		if clearWinner && d.cadenceCandidates[bestIdx] != d.lockedStep {
+			d.lockedStep = d.cadenceCandidates[bestIdx]
+			return bestSF
+		}
+		return d.sliceAt(start, d.lockedStep, syncName)
+	}
+
+	if clearWinner {
+		d.lockedStep = d.cadenceCandidates[bestIdx] // provisional — lockedByLC stays false
 		return bestSF
 	}
 	return d.sliceAt(start, d.cadenceCandidates[0], syncName)

--- a/internal/radio/dmr/voice/superframe_test.go
+++ b/internal/radio/dmr/voice/superframe_test.go
@@ -575,6 +575,61 @@ func TestInterleavedDecoderDoesNotLockOnGarbledFrames(t *testing.T) {
 	}
 }
 
+// TestInterleavedDecoderLCOverridesWrongProvisionalCadence is the reopened-#644
+// guard for a wrong cadence GUESS that later signalling contradicts. A call can
+// open on a section whose embedded LC never decodes, where the AMBE-FEC quality
+// metric picks — and provisionally locks — the wrong same-slot stride (here a
+// CACH-free 264 preamble locks 264). When the real 288-cadence traffic then
+// arrives carrying a CRC-valid embedded LC, an authoritative LC must OVERRIDE the
+// provisional guess and re-lock 288. The old decoder froze the first lock forever
+// and, slicing every later burst at the wrong 264 stride, could never reassemble
+// the LC that would fix it — so the whole rest of the call garbled ("sounds
+// encrypted"). This drives the two phases through one decoder and asserts it
+// recovers.
+func TestInterleavedDecoderLCOverridesWrongProvisionalCadence(t *testing.T) {
+	// Phase 1: a CACH-free (264) codeword section with NO embedded LC. The FEC
+	// metric locks 264 — provisionally, since no LC confirmed it.
+	pre, _, _ := buildInterleavedStreamNoLC(t, 1, 0, 0, true)
+
+	d := NewInterleavedDecoder()
+	d.Process(pre, 0)
+	if d.lockedStep != 2*dmr.BurstDibits {
+		t.Fatalf("phase 1: lockedStep = %d, want %d (264 FEC guess)", d.lockedStep, 2*dmr.BurstDibits)
+	}
+	if d.lockedByLC {
+		t.Fatalf("phase 1: lockedByLC = true, want false (an FEC guess is provisional)")
+	}
+
+	// Phase 2: the real call is 288-cadence and carries a CRC-valid embedded LC.
+	aLC := dmr.FLC{FLCO: dmr.FLCOGroupVoiceUser, DstAddr: 1001, SrcAddr: 55}
+	bLC := dmr.FLC{FLCO: dmr.FLCOGroupVoiceUser, DstAddr: 2002, SrcAddr: 66}
+	call, aFrames, bFrames := buildInterleavedStreamWithLC(t, aLC, bLC, cachDibits)
+
+	got := d.Process(call, len(pre))
+
+	// The authoritative LC must have overridden the wrong 264 guess.
+	if d.lockedStep != 2*(dmr.BurstDibits+cachDibits) || !d.lockedByLC {
+		t.Fatalf("phase 2: lockedStep=%d lockedByLC=%v, want %d and true (LC overrides the wrong provisional cadence)",
+			d.lockedStep, d.lockedByLC, 2*(dmr.BurstDibits+cachDibits))
+	}
+	// And the slots must decode cleanly at the corrected 288 stride: their own
+	// LC-named talkgroups and their own AMBE frames, not the garbled 264 splice.
+	var a, b *VoiceSuperframe
+	for i := range got {
+		switch {
+		case got[i].HasLC && got[i].LC.DstAddr == 1001:
+			a = &got[i]
+		case got[i].HasLC && got[i].LC.DstAddr == 2002:
+			b = &got[i]
+		}
+	}
+	if a == nil || b == nil {
+		t.Fatalf("phase 2: recovered LC slots a=%v b=%v, want both talkgroups (1001,2002) decoded after the override", a != nil, b != nil)
+	}
+	checkFrames(t, *a, aFrames, 0)
+	checkFrames(t, *b, bFrames, 0)
+}
+
 // TestDecoderSuperframeNoLCWhenAbsent confirms a superframe whose B–E
 // bursts carry no valid embedded LC (the plain single-slot synth) leaves
 // HasLC false rather than surfacing a garbage talkgroup.


### PR DESCRIPTION
The 2-slot interleaved voice decoder picks the same-slot burst stride
(264 vs 288 dibits) by AMBE Golay-FEC quality when no embedded Link
Control has decoded yet, then froze that choice for the rest of the call.
Because a wrong stride slices every later burst across the timeslot
boundary, the CRC-valid LC that would correct it can never reassemble —
so a single confident-but-wrong guess produced persistent
"sounds-encrypted / DJ-scratch" garble with no way to recover (the
reopened #644 symptom).

An FEC-quality lock is now provisional (tracked by a new lockedByLC
flag): every superframe re-scores the candidates until a CRC-valid
embedded LC confirms the cadence, at which point the lock becomes
authoritative. A later LC — or a later clear FEC winner at a different
stride — overrides a wrong early guess and re-locks the correct cadence.
Single-slot (Tier I) decoding locks authoritatively at construction and
is byte-for-byte unchanged.

Pinned by a fail-first test that drives a wrong 264 provisional lock, then
288-cadence traffic carrying a valid LC through one decoder and asserts it
re-locks 288 and decodes both slots cleanly.

Refs #644

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YVyXuepxPPLV5WdnMzciSf