### PR TITLE
tetra: dedup the "call talker" log on unchanged talker

### DIFF
--- a/internal/radio/tetra/control.go
+++ b/internal/radio/tetra/control.go
@@ -126,6 +126,17 @@ type ControlChannel struct {
 	// dropped on release. Guarded by mu.
 	callGroups map[uint16]uint32
 
+	// lastTalker records the last-logged transmitting party (src SSI) per group
+	// (GSSI). D-TX-GRANTED is rebroadcast every few seconds for the same talker —
+	// and keeps coming after GT's voice-follow drops on hangtime while the group
+	// is still live on air — so the "tetra: call talker" debug line otherwise
+	// repeats for an unchanged talker (the "hanging call talker" a field report
+	// flagged). The KindCallTalker event still fires every time (the engine's
+	// backfill is idempotent and its split-tx roll is guarded on a source change),
+	// so this only dedups the LOG: a line is emitted when the talker changes, not
+	// on every rebroadcast. Cleared for a group on release. Lazily built; mu.
+	lastTalker map[uint32]uint32
+
 	// grantSeen deduplicates the voice grants TETRA rebroadcasts on the control
 	// channel every multiframe while a call is up. publishGrant fires one
 	// KindGrant (and a debug line) per decoded grant PDU, so a single call emitted
@@ -1030,7 +1041,9 @@ func (c *ControlChannel) publishRelease(gssi uint32, cause uint8) {
 
 // evictGrantSeen drops the dedup entries for a released group so the next grant
 // addressed to it (a genuinely new call) is announced immediately rather than
-// being swallowed as a rebroadcast of the call that just ended.
+// being swallowed as a rebroadcast of the call that just ended. The talker-log
+// dedup for that group is cleared alongside, so the next call's first talker is
+// logged even if it happens to be the same source SSI.
 func (c *ControlChannel) evictGrantSeen(dst uint32) {
 	if dst == 0 {
 		return
@@ -1041,6 +1054,7 @@ func (c *ControlChannel) evictGrantSeen(dst uint32) {
 			delete(c.grantSeen, k)
 		}
 	}
+	delete(c.lastTalker, dst)
 	c.mu.Unlock()
 }
 
@@ -1073,8 +1087,21 @@ func (c *ControlChannel) publishTalker(gssi, src uint32) {
 			At:       c.now(),
 		},
 	})
-	c.log.Debug("tetra: call talker",
-		"system", c.systemName, "group", gssi, "src", src)
+	// Log only on a talker change, not on every D-TX-GRANTED rebroadcast — the
+	// event above already fired for the engine. See lastTalker.
+	c.mu.Lock()
+	changed := c.lastTalker[gssi] != src
+	if changed {
+		if c.lastTalker == nil {
+			c.lastTalker = make(map[uint32]uint32)
+		}
+		c.lastTalker[gssi] = src
+	}
+	c.mu.Unlock()
+	if changed {
+		c.log.Debug("tetra: call talker",
+			"system", c.systemName, "group", gssi, "src", src)
+	}
 }
 
 // noteActivity stamps the control-channel heartbeat with the current time.

--- a/internal/radio/tetra/ingest_cmce_test.go
+++ b/internal/radio/tetra/ingest_cmce_test.go
@@ -1,6 +1,9 @@
 package tetra
 
 import (
+	"bytes"
+	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
@@ -130,6 +133,65 @@ func TestHandleCMCETxGrantedSuppressesSelfTalker(t *testing.T) {
 			}
 			return
 		}
+	}
+}
+
+// TestHandleCMCETxGrantedDedupsTalkerLog: TETRA rebroadcasts D-TX-GRANTED for the
+// same talker every few seconds (and keeps doing so after a voice-follow drops on
+// hangtime while the group is still up), so the "tetra: call talker" debug line
+// used to repeat for an unchanged talker — the "hanging call talker" a field
+// report flagged. The dedup logs on a talker *change* only, while the
+// KindCallTalker event still fires on every rebroadcast (the engine backfill is
+// idempotent). Pre-fix this logs one line per rebroadcast; after, one per change.
+func TestHandleCMCETxGrantedDedupsTalkerLog(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	cc := New(Options{Bus: bus, SystemName: "Sys", FrequencyHz: 467_913_000, Log: log})
+
+	const (
+		gssi    = 0x0ABCDE
+		talkerA = 0x00CAFE
+		talkerB = 0x00BEEF
+	)
+	tx := func(party uint32) {
+		cc.handleCMCE(
+			MACResource{Address: MACAddress{Type: addrSSI, SSI: gssi}},
+			CMCEMessage{Type: CMCETypeDTxGranted, CallIdentifier: 0x66, PartySSI: party},
+		)
+	}
+	// Same talker rebroadcast four times, then a genuine talker change.
+	tx(talkerA)
+	tx(talkerA)
+	tx(talkerA)
+	tx(talkerA)
+	tx(talkerB)
+
+	// The event fires on every rebroadcast — the dedup is log-only.
+	got := 0
+drain:
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindCallTalker {
+				got++
+			}
+		default:
+			break drain
+		}
+	}
+	if got != 5 {
+		t.Errorf("KindCallTalker events = %d, want 5 (the event must not be deduped)", got)
+	}
+
+	// The log collapses the four identical talkers to one line, plus one for the
+	// change — two, not five.
+	if n := strings.Count(buf.String(), "tetra: call talker"); n != 2 {
+		t.Fatalf(`"tetra: call talker" log lines = %d, want 2 (4 identical rebroadcasts collapse to 1, +1 for the changed talker); pre-fix this is 5`, n)
 	}
 }
 


### PR DESCRIPTION
## Summary

Follow-up to the merged AFC/iq-autorecord work (PR #1065). Closes out the "hanging `tetra: call talker`" log an operator flagged: TETRA rebroadcasts D-TX-GRANTED for the same transmitting party every few seconds — and keeps sending it after GT's voice-follow drops on hangtime while the group is still live on air — so `publishTalker` logged `tetra: call talker` on every one and the same `group=… src=…` line repeated endlessly, including past the call's end.

## Changes

- **`internal/radio/tetra/control.go`** — dedup the log per group: `publishTalker` now emits the debug line only when the talker (GSSI → src) changes, gated by a new `lastTalker` map (mirrors the existing `grantSeen` "CC spam" dedup). The `KindCallTalker` event still fires on every rebroadcast — the engine's source backfill is idempotent and its split-tx segment roll is already guarded on an actual source change (`engine.go` `handleCallTalker`), so nothing behaviour-visible changes; only the log noise goes away. The per-group entry is cleared on release inside `evictGrantSeen`, so the next call's first talker is logged even if it's the same SSI.

## Test plan

- [x] `make vet test` is green locally
- [x] `make integration` — n/a; this is a control-channel logging change, no daemon wiring touched
- [x] Added test `TestHandleCMCETxGrantedDedupsTalkerLog`: fires four identical D-TX-GRANTED then one with a changed party; asserts **two** `tetra: call talker` log lines (not five) while all **five** `KindCallTalker` events still publish. Fails pre-fix (five lines), passes after. Existing `TestHandleCMCETxGrantedPublishesTalker` / `…SuppressesSelfTalker` stay green.
- [ ] Smoke-tested against real hardware — n/a (logging-only change; validated against the CMCE D-TX-GRANTED handler).

## Breaking changes

None. Log-only change; the event stream, call tracking, and split-tx recording behaviour are untouched.

## Docs / CHANGELOG

- [ ] n/a — internal debug-log hygiene, no operator-facing surface.

## Linked issues

n/a — no tracked issue. Follow-up to the same TETRA field report behind the merged AFC carrier-offset fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDS37XfizkeDmLie8ikQfF

---
_Generated by [Claude Code](https://claude.ai/code/session_01SDS37XfizkeDmLie8ikQfF)_