### PR TITLE
hackrf: enable the front-end RF amp on auto gain

### DIFF
--- a/internal/sdr/hackrf/hackrf.go
+++ b/internal/sdr/hackrf/hackrf.go
@@ -389,7 +389,11 @@ func (d *Device) SetGain(tenthDB int) error {
 // multiple of 2.
 func splitGain(tenthDB int) (lna, vga int, amp bool) {
 	if tenthDB < 0 {
-		return defaultLNAGainDB, defaultVGAGainDB, false
+		// "auto": enable the front-end RF amp (like SDRTrunk's default
+		// amplifierEnabled:true). The amp sets the noise figure for weak
+		// signals; without it, voice channels on a modest antenna decode
+		// at a much lower SNR and time out with no frames.
+		return defaultLNAGainDB, defaultVGAGainDB, true
 	}
 	target := tenthDB / 10
 	lna = (target / 8) * 8

--- a/internal/sdr/hackrf/hackrf_test.go
+++ b/internal/sdr/hackrf/hackrf_test.go
@@ -286,20 +286,21 @@ func TestSplitGain(t *testing.T) {
 	cases := []struct {
 		tenthDB          int
 		wantLNA, wantVGA int
+		wantAmp          bool
 	}{
-		{-1, defaultLNAGainDB, defaultVGAGainDB},
-		{0, 0, 0},
-		{160, 16, 0},   // 16 dB → all in LNA
-		{180, 16, 2},   // 16 dB LNA + 2 dB VGA
-		{300, 24, 6},   // 24 + 6 = 30 dB
-		{900, 40, 50},  // clamped: 40 dB LNA, 50 dB VGA
-		{1500, 40, 62}, // both saturated
+		{-1, defaultLNAGainDB, defaultVGAGainDB, true}, // "auto" enables the front-end RF amp
+		{0, 0, 0, false},
+		{160, 16, 0, false},   // 16 dB → all in LNA
+		{180, 16, 2, false},   // 16 dB LNA + 2 dB VGA
+		{300, 24, 6, false},   // 24 + 6 = 30 dB
+		{900, 40, 50, false},  // clamped: 40 dB LNA, 50 dB VGA
+		{1500, 40, 62, false}, // both saturated
 	}
 	for _, c := range cases {
 		lna, vga, amp := splitGain(c.tenthDB)
-		if lna != c.wantLNA || vga != c.wantVGA || amp {
-			t.Errorf("splitGain(%d) = (%d,%d,%v), want (%d,%d,false)",
-				c.tenthDB, lna, vga, amp, c.wantLNA, c.wantVGA)
+		if lna != c.wantLNA || vga != c.wantVGA || amp != c.wantAmp {
+			t.Errorf("splitGain(%d) = (%d,%d,%v), want (%d,%d,%v)",
+				c.tenthDB, lna, vga, amp, c.wantLNA, c.wantVGA, c.wantAmp)
 		}
 	}
 }
@@ -307,7 +308,7 @@ func TestSplitGain(t *testing.T) {
 func TestSetGainIssuesAMPLNAVGA(t *testing.T) {
 	dev, mt := withDevice(t)
 	mt.Script = []usb.CtrlExchange{
-		{BRequest: reqAmpEnable, WValue: 0},
+		{BRequest: reqAmpEnable, WValue: 1}, // "auto" (-1) enables the front-end amp
 		{In: true, BRequest: reqSetLNAGain, WIndex: 16, Reply: []byte{1}, N: 1},
 		{In: true, BRequest: reqSetVGAGain, WIndex: 20, Reply: []byte{1}, N: 1},
 	}


### PR DESCRIPTION
## Problem

The HackRF driver's `splitGain` never enables the front-end RF amplifier — it returns `amp=false` on every path, including the `auto` preset. So `gain: auto` runs LNA/VGA only with the amp **off**, giving a much worse noise figure than the reference tools (SDRTrunk defaults `amplifierEnabled=true`). On a HackRF used as a voice receiver, weak channels sit ~14 dB down and can fail to decode entirely.

## Fix

Enable the amp on the `auto` preset (negative tenth-dB `SetGain(-1)`), keeping the existing LNA 16 / VGA 20 split — matching SDRTrunk's default HackRF gain structure. Manual (positive) gains are unchanged.

```go
if tenthDB < 0 {
    return defaultLNAGainDB, defaultVGAGainDB, true // was: false
}
```

## Tests

Updates `TestSplitGain` and `TestSetGainIssuesAMPLNAVGA` to assert the new auto-amp-on behaviour. `go test ./internal/sdr/hackrf/` passes.

Found while debugging why a HackRF decodes a P25 trunked system's control channel far worse than an RTL-SDR on the same antenna; enabling the amp is one of two front-end factors (the other, a DC-block on the voice path, is a separate PR).