### PR TITLE
p25/phase1: DC-block the voice front end (fix zero-IF/HackRF voice decode collapse)

### DIFF
--- a/cmd/gophertrunk/replay.go
+++ b/cmd/gophertrunk/replay.go
@@ -43,6 +43,7 @@ func runReplay(args []string) {
 	diag := fs.Bool("diag", false, "collect the demod-quality diagnostic report (symbol histogram + P25 FSW landscape + soft-sample eye) and print it at EOF")
 	enableDDA := fs.Bool("dda", false, "enable the experimental decision-directed AFC on the P25 C4FM path (off by default; see issue #402)")
 	enableAdaptiveSlicer := fs.Bool("adaptive-slicer", false, "enable the adaptive C4FM slicer on the P25 C4FM path (off by default; see issue #402)")
+	enableDCBlock := fs.Bool("dc-block", false, "strip the front-end zero-IF DC spur before the C4FM discriminator (decodes on-channel HackRF voice captures whose centre spike otherwise zeroes the decode)")
 	enableSoftSync := fs.Bool("soft-sync", false, "widen the P25 FSW correlator and admit looser sync words whose TSBK CRC corroborates the NID — extends lock reach on marginal-SNR captures without risking a false lock (off by default; see issue #771)")
 	iqCorrect := fs.Bool("iq-correct", false, "apply blind I/Q-imbalance correction to the raw IQ before decimation (off by default; see issue #402)")
 	tuneHzFlag := fs.Float64("tune-hz", 0, "frequency-shift the capture so a channel at +tune-hz lands at 0 Hz before demod (0 = no shift)")
@@ -131,6 +132,7 @@ FLAGS:`)
 		NIDSearchSpan:        *nidSearchSpan,
 		EnableDDA:            *enableDDA,
 		EnableAdaptiveSlicer: *enableAdaptiveSlicer,
+		EnableDCBlock:        *enableDCBlock,
 		EnableSoftSync:       *enableSoftSync,
 		// P25 replay always wants the per-frame CCStats + receiver-state series
 		// (the historical EOF summary + per-second state log); -diag adds the

--- a/internal/radio/p25/phase1/receiver/dcblock.go
+++ b/internal/radio/p25/phase1/receiver/dcblock.go
@@ -1,0 +1,65 @@
+package receiver
+
+// dcBlock is a first-order complex DC-removal high-pass applied to the IQ
+// stream at the very top of Process, ahead of the FM discriminator.
+//
+// Zero-IF front ends (notably the HackRF, but any tuner) leave a static DC
+// spur at 0 Hz from LO self-mixing. When the voice SDR is tuned with the LO
+// on-channel (the P25 voice receivers are fed a channel centred at 0 Hz), that
+// spur sits directly on the wanted C4FM signal. Unlike a residual carrier
+// *frequency* offset — which CoarseAFC removes from the discriminator output —
+// a constant additive DC term on the complex IQ is a bias vector the FM
+// discriminator (a phase-difference operator) folds nonlinearly into every
+// sample, corrupting the 4-level eye. Measured effect: a small on-IQ DC offset
+// (≈0.05 relative to a ~0.16 mean-|x| signal) collapses P25 voice decode from
+// full LDU yield to zero. SDRTrunk avoids this by channelising off-centre so
+// its voice channels never sit on the spur; GopherTrunk's on-channel voice DDC
+// needs the spur stripped here instead.
+//
+// Safety for C4FM: the difference equation's pole (dcBlockPole) puts the −3 dB
+// corner at ~8–12 Hz over the P25 voice sample rates (48–78 kHz). C4FM's four
+// signalling tones ride at ±600 / ±1800 Hz off the carrier, decades above that
+// corner, so the passband — and therefore the modulation — is untouched; only
+// the static DC pedestal is removed. This mirrors the TETRA voice receiver's
+// dcBlock (internal/radio/tetra/receiver/dcblock.go); it is a voice-receiver
+// opt-in and is never enabled on the FM control-channel DDC path (ddc.go),
+// which deliberately leaves DC untouched.
+//
+// Difference equation, applied to the complex IQ (pole at z ≈ dcBlockPole):
+//
+//	y[n] = x[n] − x[n−1] + dcBlockPole·y[n−1]
+//
+// State is continuous across chunks; Reset clears it on receiver re-sync.
+type dcBlock struct {
+	prevX complex64
+	prevY complex64
+}
+
+// dcBlockPole is the feedback coefficient. 0.999 puts the −3 dB corner near
+// ~12 Hz at 78 kHz (fc ≈ (1−a)/(2π)·Fs) — deep enough to kill the DC pedestal,
+// far below the C4FM tones so the passband is untouched.
+const dcBlockPole = 0.9999
+
+// Reset clears the filter memory.
+func (d *dcBlock) Reset() {
+	d.prevX = 0
+	d.prevY = 0
+}
+
+// process applies the DC blocker over src, writing to dst (grown/reused by the
+// caller's convention) and returning it. dst may alias src.
+func (d *dcBlock) process(dst, src []complex64) []complex64 {
+	if cap(dst) < len(src) {
+		dst = make([]complex64, len(src))
+	} else {
+		dst = dst[:len(src)]
+	}
+	prevX, prevY := d.prevX, d.prevY
+	for i, x := range src {
+		y := x - prevX + dcBlockPole*prevY
+		prevX, prevY = x, y
+		dst[i] = y
+	}
+	d.prevX, d.prevY = prevX, prevY
+	return dst
+}

--- a/internal/radio/p25/phase1/receiver/dcblock_test.go
+++ b/internal/radio/p25/phase1/receiver/dcblock_test.go
@@ -1,0 +1,65 @@
+package receiver
+
+import (
+	"math"
+	"math/cmplx"
+	"testing"
+)
+
+// TestDCBlockRemovesConstantOffset feeds a pure tone riding on a large static
+// DC offset — the zero-IF-spur scenario the block exists for — and checks the
+// output has the DC stripped while the tone amplitude survives. A constant IQ
+// bias like this is what collapses the FM-discriminator eye upstream of the
+// slicer (see dcblock.go); the block must remove it without eating the signal.
+func TestDCBlockRemovesConstantOffset(t *testing.T) {
+	const (
+		n    = 200_000 // long enough for the ~1.2 Hz-corner high-pass to settle
+		fs   = 78125.0
+		tone = 1800.0 // a C4FM outer-symbol tone; well above the block's corner
+		amp  = 0.16    // representative signal level (mean|x| of a real capture)
+		dc   = 0.10    // static DC spur — >0.05 zeroes real P25 voice decode
+	)
+	src := make([]complex64, n)
+	for i := range src {
+		ph := 2 * math.Pi * tone * float64(i) / fs
+		src[i] = complex64(complex(amp*math.Cos(ph), amp*math.Sin(ph))) + complex(dc, 0)
+	}
+
+	var d dcBlock
+	out := d.process(nil, src)
+
+	// Measure over the settled tail only (skip the first 20k samples).
+	const skip = 20_000
+	var meanOut complex128
+	var rmsOut float64
+	for i := skip; i < n; i++ {
+		meanOut += complex128(out[i])
+		re, im := float64(real(out[i])), float64(imag(out[i]))
+		rmsOut += re*re + im*im
+	}
+	cnt := float64(n - skip)
+	meanOut /= complex(cnt, 0)
+	rmsOut = math.Sqrt(rmsOut / cnt)
+
+	// DC must be gone (well below the tone amplitude).
+	if got := cmplx.Abs(meanOut); got > amp*0.05 {
+		t.Errorf("residual DC after block = %.4f, want ≤ %.4f (5%% of tone amp)", got, amp*0.05)
+	}
+	// The tone (a pure sinusoid, RMS = amp) must be preserved within a few %.
+	if math.Abs(rmsOut-amp) > amp*0.05 {
+		t.Errorf("tone RMS after block = %.4f, want %.4f ±5%% (passband must be untouched)", rmsOut, amp)
+	}
+}
+
+// TestDCBlockReset clears the filter memory so a re-sync starts clean.
+func TestDCBlockReset(t *testing.T) {
+	var d dcBlock
+	d.process(nil, []complex64{complex(0.5, 0.5), complex(0.5, 0.5)})
+	if d.prevX == 0 && d.prevY == 0 {
+		t.Fatal("state not advanced by process")
+	}
+	d.Reset()
+	if d.prevX != 0 || d.prevY != 0 {
+		t.Errorf("Reset left state prevX=%v prevY=%v, want 0", d.prevX, d.prevY)
+	}
+}

--- a/internal/radio/p25/phase1/receiver/receiver.go
+++ b/internal/radio/p25/phase1/receiver/receiver.go
@@ -232,6 +232,14 @@ type Options struct {
 	// and for A/B experimentation. Ignored when DeviationHz <= 0 or when
 	// DemodMode == DemodCQPSK.
 	EnableAdaptiveC4FMSlicer bool
+	// EnableDCBlock inserts a first-order complex DC-removal high-pass at
+	// the very top of Process, ahead of the FM discriminator, to strip the
+	// static zero-IF DC spur that sits on an on-channel-tuned voice signal
+	// (the HackRF's centre spike is large enough to collapse P25 voice
+	// decode to zero — see dcblock.go). Off by default and intended for the
+	// VOICE receivers only; never the control-channel DDC path. Safe for
+	// C4FM: the ~12 Hz corner is decades below the ±600/±1800 Hz C4FM tones.
+	EnableDCBlock bool
 	// SoftSink, when non-nil, receives the per-symbol soft samples
 	// produced by the matched filter + symbol-clock recovery, just
 	// before slicing. The C4FM path emits the FM-discriminator +
@@ -283,6 +291,8 @@ type Receiver struct {
 	// Process for the bootstrap-then-refine choreography.
 	fm               *demod.FM
 	mf               *demod.C4FM
+	dcBlk            *dcBlock       // optional pre-discriminator complex DC-removal (voice), nil = off
+	dcbuf            []complex64    // scratch for dcBlk.process
 	slicer           *demod.AdaptiveC4FMSlicer // adaptive 4-level slicer; nil on the legacy pre-scaled-fixture path
 	afc              *demod.CoarseAFC
 	dda              *demod.DecisionDirectedAFC
@@ -397,6 +407,9 @@ func New(opts Options) *Receiver {
 			r.slicer = demod.NewAdaptiveC4FMSlicer(slicerScale)
 		}
 		r.afc = demod.NewCoarseAFC(sps)
+		if opts.EnableDCBlock {
+			r.dcBlk = &dcBlock{}
+		}
 		r.clock = sync.NewMuellerMuller(sps, gain)
 		// Symbol-AGC bridges the level mismatch between the spec-
 		// faithful matched filter on a real P25 transmission and the
@@ -486,6 +499,14 @@ func New(opts Options) *Receiver {
 func (r *Receiver) Process(iq []complex64) {
 	if len(iq) == 0 {
 		return
+	}
+	// Strip the static zero-IF DC spur (e.g. the HackRF centre spike) before
+	// anything else. A constant IQ bias corrupts the FM discriminator's phase
+	// differences and collapses C4FM voice decode; the ~12 Hz high-pass leaves
+	// the modulation untouched. Voice-receiver opt-in; nil on the CC path.
+	if r.dcBlk != nil {
+		r.dcbuf = r.dcBlk.process(r.dcbuf, iq)
+		iq = r.dcbuf
 	}
 	if r.demodMode == DemodCQPSK {
 		// cq.process returns its internal dibit buffer; we hand
@@ -868,6 +889,9 @@ func (r *Receiver) Reset() {
 	}
 	if r.afc != nil {
 		r.afc.Reset()
+	}
+	if r.dcBlk != nil {
+		r.dcBlk.Reset()
 	}
 	if r.dda != nil {
 		r.dda.Reset()

--- a/internal/siglab/config.go
+++ b/internal/siglab/config.go
@@ -66,6 +66,12 @@ type Config struct {
 	// EnableAdaptiveSlicer opts the C4FM path into the adaptive slicer
 	// (issue #402; off in production).
 	EnableAdaptiveSlicer bool
+	// EnableDCBlock inserts the pre-discriminator complex DC-removal high-pass
+	// on the P25 C4FM path — strips the static zero-IF DC spur (e.g. the HackRF
+	// centre spike) that otherwise collapses voice decode. Off by default; the
+	// production voice composer enables it unconditionally, this exposes it for
+	// diagnosing/decoding on-channel HackRF captures via replay.
+	EnableDCBlock bool
 	// EnableSoftSync opts the P25 control channel into the wider FSW-fallback
 	// tolerance: sync words carrying 5–8 symbol errors are decoded if the
 	// frame's TSBK CRC corroborates the NID, extending lock reach into
@@ -189,7 +195,7 @@ func (c Config) wantP25Deep() bool {
 		return false
 	}
 	return c.CollectIQDiag || c.CollectReceiverState || c.CollectPDUs ||
-		c.NIDSearchSpan > 0 || c.EnableDDA || c.EnableAdaptiveSlicer ||
+		c.NIDSearchSpan > 0 || c.EnableDDA || c.EnableAdaptiveSlicer || c.EnableDCBlock ||
 		c.EnableSoftSync || c.DemodMode != ""
 }
 

--- a/internal/siglab/engine_p25.go
+++ b/internal/siglab/engine_p25.go
@@ -62,6 +62,7 @@ func buildP25DeepBundle(cfg Config, bus *events.Bus, logger *slog.Logger, receiv
 		DemodMode:                 demodMode,
 		EnableDecisionDirectedAFC: cfg.EnableDDA,
 		EnableAdaptiveC4FMSlicer:  cfg.EnableAdaptiveSlicer,
+		EnableDCBlock:             cfg.EnableDCBlock,
 		SoftSink:                  softTap,
 		// The CQPSK path fires SymbolSink with the post-carrier-recovery
 		// complex constellation points; the C4FM path leaves it uncalled

--- a/internal/voice/composer/p25p1_voice.go
+++ b/internal/voice/composer/p25p1_voice.go
@@ -250,6 +250,11 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial, system st
 		SampleRateHz: symbolHz,
 		DeviationHz:  p25p1DeviationHz,
 		DemodMode:    mode,
+		// Strip the front-end zero-IF DC spur that sits on the on-channel-tuned
+		// voice signal. Without it, a tuner with a large centre spike (the
+		// HackRF especially) corrupts the FM discriminator and yields zero LDU
+		// frames even on a strong clear call (see receiver/dcblock.go).
+		EnableDCBlock: true,
 		// Feed the demod symbol taps into the boundary tracker's per-call
 		// EVM/SNR accumulator. C4FM populates SoftSink (the 4-level soft eye);
 		// the CQPSK/LSM path populates SymbolSink (the complex constellation).


### PR DESCRIPTION
## Problem

P25 Phase 1 C4FM **voice** decode collapses on a small static DC offset. On a baseband recording of a real decoded call, adding just **+0.05** DC drops decode from **30 LDU voice frames to 0**.

Zero-IF front ends — the HackRF especially — leave a DC spur at 0 Hz (LO self-mixing). When the voice SDR is tuned **on-channel** (P25 voice receivers are fed a channel centred at 0 Hz), that spur sits directly on the wanted C4FM signal. A constant additive IQ bias isn't a frequency offset that CoarseAFC removes downstream — the FM discriminator (a phase-difference operator) folds it nonlinearly into every sample and destroys the 4-level eye. SDRTrunk channelizes **off-centre**, so its voice channels never see the spur; GopherTrunk's on-channel voice DDC needs it stripped.

This is why a HackRF can lock a P25 control channel fine but decode **zero** voice frames on the same site where an RTL-SDR (negligible DC) works.

## Fix

TETRA voice already solves this exact problem with a first-order complex DC-removal high-pass (`internal/radio/tetra/receiver/dcblock.go`); the P25 Phase 1 receiver had nothing. Port it:

- **`receiver/dcblock.go`** — the DC blocker (mirrors the TETRA one). Pole `0.9999` puts the −3 dB corner near ~1 Hz, decades below C4FM's ±600/±1800 Hz tones, so only the static pedestal is removed; the modulation passband is untouched.
- **`receiver.Options.EnableDCBlock`** — opt-in; applied at the very top of `Process`, ahead of the FM discriminator. Enabled on the **P25 voice composer**, never the control-channel DDC path (which deliberately leaves DC alone).
- **`siglab.Config.EnableDCBlock` + `replay -dc-block`** — reproduce/decode on-channel HackRF captures offline.

## Validation

- On the +0.10-DC recording of a real call: `replay -dc-block` goes **0 → 24 LDU frames**.
- `dcblock_test.go`: the blocker strips a large DC pedestal while preserving a C4FM-band tone within a few %.
- No regression: `go test ./internal/radio/p25/phase1/receiver/ ./internal/voice/composer/ ./internal/siglab/` all pass.

## Related follow-up (not in this PR)

The HackRF also shows **I/Q imbalance** on the on-channel voice: `-dc-block -iq-correct` **together** lock a real capture where neither alone does. Extending the existing control-path blind I/Q corrector to the voice DDC is a natural next step, but I couldn't independently validate it end-to-end here, so it's left out to keep this PR to the validated change.