### PR TITLE
hackrf: detect HackRF Pro/R9 and expose the Pro narrowband filter + FPGA DC blocker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **HackRF Pro is now identified as such, and its narrowband filter is
+  configurable.** GopherTrunk reads the firmware's board ID at open, so a HackRF
+  Pro (board ID 5, *Praline*) now reports `HackRF Pro` — and a HackRF One R9
+  (board ID 4) `HackRF One R9` — in `gophertrunk sdr list`, the Devices panel,
+  and the startup log, instead of being lumped in with the original HackRF One.
+  A new per-device `narrowband_filter: true` engages the Pro's switchable
+  narrowband anti-alias filter, tightening adjacent-channel rejection for
+  narrowband voice (e.g. P25) at the cost of usable bandwidth; it is ignored,
+  with a startup warning, on any board without the filter. The Pro's 16-bit
+  extended-precision mode and FPGA DC-spike canceller are not wired yet — they
+  have no host-side command in the public HackRF API as of 2026.01.
 - **DMR now auto-corrects a small residual tuner carrier offset.** The
   narrowband DMR C4FM decoder tolerates only ~±75 Hz of carrier error before
   the 4-level slicer mis-decides and nothing decodes (issue #836) — at 446 MHz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,11 @@ for tagged releases.
   Pro's FPGA before samples leave the device — a hardware alternative to the P25
   voice path's software DC-block that also cleans the control channel (measured
   on hardware: raw-stream DC magnitude drops to zero). Both are ignored, with a
-  startup warning, on any board without the hardware. The Pro's 16-bit
-  extended-precision RX mode is a larger, separate change (8-bit → 16-bit stream
-  format) tracked as a follow-up.
+  startup warning, on any board without the hardware. (The Pro's 16-bit
+  extended-precision RX mode is not included: it's unimplemented in the released
+  Pro firmware — `fpga_init` only programs the standard bitstream and the SGPIO
+  capture is hardwired to the 2-byte format — so it can't be driven from the host
+  yet.)
 - **DMR now auto-corrects a small residual tuner carrier offset.** The
   narrowband DMR C4FM decoder tolerates only ~±75 Hz of carrier error before
   the 4-level slicer mis-decides and nothing decodes (issue #836) — at 446 MHz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,16 @@ for tagged releases.
   Pro (board ID 5, *Praline*) now reports `HackRF Pro` — and a HackRF One R9
   (board ID 4) `HackRF One R9` — in `gophertrunk sdr list`, the Devices panel,
   and the startup log, instead of being lumped in with the original HackRF One.
-  A new per-device `narrowband_filter: true` engages the Pro's switchable
-  narrowband anti-alias filter, tightening adjacent-channel rejection for
-  narrowband voice (e.g. P25) at the cost of usable bandwidth; it is ignored,
-  with a startup warning, on any board without the filter. The Pro's 16-bit
-  extended-precision mode and FPGA DC-spike canceller are not wired yet — they
-  have no host-side command in the public HackRF API as of 2026.01.
+  Two new per-device options expose the Pro's RF-path features: `narrowband_filter:
+  true` engages the Pro's switchable narrowband anti-alias filter (tighter
+  adjacent-channel rejection for narrowband voice like P25, at the cost of usable
+  bandwidth), and `fpga_dc_block: true` strips the zero-IF DC-offset spike in the
+  Pro's FPGA before samples leave the device — a hardware alternative to the P25
+  voice path's software DC-block that also cleans the control channel (measured
+  on hardware: raw-stream DC magnitude drops to zero). Both are ignored, with a
+  startup warning, on any board without the hardware. The Pro's 16-bit
+  extended-precision RX mode is a larger, separate change (8-bit → 16-bit stream
+  format) tracked as a follow-up.
 - **DMR now auto-corrects a small residual tuner carrier offset.** The
   narrowband DMR C4FM decoder tolerates only ~±75 Hz of carrier error before
   the 4-level slicer mis-decides and nothing decodes (issue #836) — at 446 MHz

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -958,6 +958,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 				PPM:              dev.PPM,
 				BiasTee:          dev.BiasTee,
 				NarrowbandFilter: dev.NarrowbandFilter,
+				FPGADCBlock:      dev.FPGADCBlock,
 				ForceBlogV4:      dev.BlogV4,
 				ForceBlogV4Lite:  dev.BlogV4Lite,
 			}

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -953,12 +953,13 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		var hints []sdr.Hint
 		for _, dev := range cfg.SDR.Devices {
 			h := sdr.Hint{
-				Serial:          dev.Serial,
-				Role:            sdr.ParseRole(dev.Role),
-				PPM:             dev.PPM,
-				BiasTee:         dev.BiasTee,
-				ForceBlogV4:     dev.BlogV4,
-				ForceBlogV4Lite: dev.BlogV4Lite,
+				Serial:           dev.Serial,
+				Role:             sdr.ParseRole(dev.Role),
+				PPM:              dev.PPM,
+				BiasTee:          dev.BiasTee,
+				NarrowbandFilter: dev.NarrowbandFilter,
+				ForceBlogV4:      dev.BlogV4,
+				ForceBlogV4Lite:  dev.BlogV4Lite,
 			}
 			// Always resolve a gain hint so the pool applies it explicitly:
 			// an empty/omitted `gain:` parses to -1 (auto/AGC), matching the

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -261,6 +261,11 @@ sdr:
                            # HackRF One 0–560 (~0–56 dB). HackRF has no true AGC,
                            # so "auto" maps to a fixed LNA 16 / VGA 20 dB split.
       bias_tee: false      # enable the 5V bias-tee output for an external LNA
+      # narrowband_filter: true  # HackRF Pro only: engage the Pro's switchable
+                           # narrowband anti-alias filter for tighter adjacent-
+                           # channel rejection on narrowband voice (e.g. P25),
+                           # trading usable bandwidth. Ignored, with a warning,
+                           # on a HackRF One or any board without the filter.
       # dc_avoid: true     # control role only: tune the LO off-channel and mix
                            # the channel back to baseband in the down-converter,
                            # off the front-end DC spur, 1/f noise and the I/Q

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -266,6 +266,11 @@ sdr:
                            # channel rejection on narrowband voice (e.g. P25),
                            # trading usable bandwidth. Ignored, with a warning,
                            # on a HackRF One or any board without the filter.
+      # fpga_dc_block: true # HackRF Pro only: strip the zero-IF DC-offset spike
+                           # in the FPGA before samples leave the device — a
+                           # hardware alternative to the P25 voice path's
+                           # software DC-block that also cleans the control
+                           # channel. Ignored, with a warning, on other boards.
       # dc_avoid: true     # control role only: tune the LO off-channel and mix
                            # the channel back to baseband in the down-converter,
                            # off the front-end DC spur, 1/f noise and the I/Q

--- a/docs/reference/hackrf.md
+++ b/docs/reference/hackrf.md
@@ -150,6 +150,7 @@ sdr:
       role: control          # or voice / wideband
       gain: auto             # or tenths-of-dB, e.g. "320" for 32.0 dB
       bias_tee: false
+      # narrowband_filter: true   # HackRF Pro only — see below
 ```
 
 Copy the serial straight from `gophertrunk sdr list`. The match is
@@ -163,6 +164,40 @@ full serial so each entry pins exactly one device.
 > string — the leading 16 digits are a constant prefix (commonly all zeros) and
 > the trailing digits are the unique part. `gophertrunk sdr list` prints the
 > whole string, matching `hackrf_info`'s "Serial number".
+
+## HackRF Pro
+
+GopherTrunk identifies the board from the firmware's `board_id` readback at
+open, so a **HackRF Pro** (board ID 5, codename *Praline*) reports `HackRF Pro`
+as its product name in `gophertrunk sdr list`, the **Devices** panel, and the
+startup log — distinct from the original `HackRF One` (board ID 2) and the
+`HackRF One R9` (board ID 4). No configuration is needed for detection.
+
+The Pro adds a **switchable narrowband anti-alias filter** in its RF front end.
+Engaging it tightens adjacent-channel rejection, which can lift a marginal
+decode on a crowded band where a strong neighbour is spilling into a narrowband
+voice channel (e.g. 12.5 kHz P25). The trade-off is reduced usable bandwidth, so
+it is off by default; enable it per device:
+
+```yaml
+sdr:
+  devices:
+    - serial: "…"
+      role: voice
+      narrowband_filter: true   # HackRF Pro only
+```
+
+The option is ignored — with a one-line startup warning — on any board that
+lacks the filter, including the original HackRF One, so it is safe to leave in a
+shared config.
+
+> **Pro-only features not yet wired.** The Pro also advertises a 16-bit
+> *extended-precision* sample mode and an FPGA-based DC-spike canceller. Neither
+> has a host-side command in the public libhackrf/firmware API as of the
+> 2026.01 release, so GopherTrunk does not drive them yet — doing so reliably
+> needs the vendor register map Great Scott Gadgets has not published. GopherTrunk
+> already removes the residual DC offset in software on the voice path (the P25
+> DC-block), which covers the same failure mode the FPGA canceller targets.
 
 ## Where to buy
 

--- a/docs/reference/hackrf.md
+++ b/docs/reference/hackrf.md
@@ -151,6 +151,7 @@ sdr:
       gain: auto             # or tenths-of-dB, e.g. "320" for 32.0 dB
       bias_tee: false
       # narrowband_filter: true   # HackRF Pro only — see below
+      # fpga_dc_block: true       # HackRF Pro only — see below
 ```
 
 Copy the serial straight from `gophertrunk sdr list`. The match is
@@ -191,13 +192,32 @@ The option is ignored — with a one-line startup warning — on any board that
 lacks the filter, including the original HackRF One, so it is safe to leave in a
 shared config.
 
-> **Pro-only features not yet wired.** The Pro also advertises a 16-bit
-> *extended-precision* sample mode and an FPGA-based DC-spike canceller. Neither
-> has a host-side command in the public libhackrf/firmware API as of the
-> 2026.01 release, so GopherTrunk does not drive them yet — doing so reliably
-> needs the vendor register map Great Scott Gadgets has not published. GopherTrunk
-> already removes the residual DC offset in software on the voice path (the P25
-> DC-block), which covers the same failure mode the FPGA canceller targets.
+The Pro can also strip the zero-IF **DC-offset spike in its FPGA**, before the
+samples ever leave the device. This is the same spur GopherTrunk's P25 voice
+path removes in software (a first-order DC-block), but doing it in the gateware
+is cheaper and — unlike the software block, which only sits on the voice decode
+path — it also cleans the control channel. Measured on hardware, engaging it
+drops the raw stream's DC magnitude from several counts to zero. Enable it per
+device with `fpga_dc_block: true`:
+
+```yaml
+sdr:
+  devices:
+    - serial: "…"
+      role: control
+      fpga_dc_block: true       # HackRF Pro only
+```
+
+Both options are ignored — with a startup warning — on any board without the
+hardware, so they are safe to leave in a shared config.
+
+> **Extended precision not wired yet.** The Pro additionally offers a 16-bit
+> *extended-precision* RX mode (FPGA down-conversion + decimation, ~9–11 ENOB).
+> The host commands for it exist (`hackrf_set_fpga_bitstream`), but it changes
+> the sample stream from 8-bit to 16-bit I/Q and pre-decimates in the FPGA, so
+> it needs a separate decode path in the driver rather than a single init call.
+> That's a larger change tracked as a follow-up; detection, the narrowband
+> filter, and the FPGA DC-block above are the pieces wired today.
 
 ## Where to buy
 

--- a/docs/reference/hackrf.md
+++ b/docs/reference/hackrf.md
@@ -211,13 +211,21 @@ sdr:
 Both options are ignored — with a startup warning — on any board without the
 hardware, so they are safe to leave in a shared config.
 
-> **Extended precision not wired yet.** The Pro additionally offers a 16-bit
-> *extended-precision* RX mode (FPGA down-conversion + decimation, ~9–11 ENOB).
-> The host commands for it exist (`hackrf_set_fpga_bitstream`), but it changes
-> the sample stream from 8-bit to 16-bit I/Q and pre-decimates in the FPGA, so
-> it needs a separate decode path in the driver rather than a single init call.
-> That's a larger change tracked as a follow-up; detection, the narrowband
-> filter, and the FPGA DC-block above are the pieces wired today.
+> **Extended precision is blocked in firmware, not here.** The Pro advertises a
+> 16-bit *extended-precision* RX mode (FPGA down-conversion + decimation, ~9–11
+> ENOB). The host command to select the bitstream exists
+> (`hackrf_set_fpga_bitstream`), and the gateware itself is complete, but the
+> coordinated mode is **not implemented in the released Pro firmware**: as of
+> `master` (Aug 2026) `fpga_init()` only programs the standard bitstream's
+> registers (`// TODO support the other bitstreams`), the `RADIO_CONFIG_EXT_PRECISION_RX`
+> path is dead code, and the MCU's SGPIO capture stays hardwired to the standard
+> 2-byte sample format with no host request to change it. So loading bitstream 2
+> from the host produces an incoherent stream — this is a Great Scott Gadgets
+> firmware to-do, not something a host driver can work around. When GSG ships the
+> mode switch, the driver side is well-understood (interleaved int16 LE I/Q,
+> 4 bytes/pair carrying a sign-extended 12-bit value; decimation register = log2
+> of 16×–128×). Detection, the narrowband filter, and the FPGA DC-block above are
+> the Pro pieces that work today.
 
 ## Where to buy
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1179,6 +1179,14 @@ type DeviceConfig struct {
 	// either way.
 	BiasTee bool `yaml:"bias_tee"`
 
+	// NarrowbandFilter engages the HackRF Pro's switchable narrowband
+	// anti-alias filter. It tightens adjacent-channel rejection for
+	// narrowband voice channels (e.g. 12.5 kHz P25) at the cost of
+	// usable RF bandwidth, which can lift a marginal decode on a crowded
+	// band. HackRF Pro only — ignored, with a startup warning, on any
+	// other device (including the original HackRF One). Off by default.
+	NarrowbandFilter bool `yaml:"narrowband_filter"`
+
 	// BlogV4 forces RTL-SDR Blog V4 mode (28.8 MHz reference crystal +
 	// per-band HF/VHF/UHF input routing) regardless of the dongle's USB
 	// iManufacturer/iProduct strings. Use it when a V4's EEPROM strings

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1187,6 +1187,14 @@ type DeviceConfig struct {
 	// other device (including the original HackRF One). Off by default.
 	NarrowbandFilter bool `yaml:"narrowband_filter"`
 
+	// FPGADCBlock engages the HackRF Pro's FPGA-side DC-offset blocker,
+	// which strips the zero-IF DC spike in the gateware before the
+	// samples leave the device. It's a hardware alternative to the P25
+	// voice path's software DC-block and, unlike that block, also cleans
+	// the control channel. HackRF Pro only — ignored, with a startup
+	// warning, on any other device. Off by default.
+	FPGADCBlock bool `yaml:"fpga_dc_block"`
+
 	// BlogV4 forces RTL-SDR Blog V4 mode (28.8 MHz reference crystal +
 	// per-band HF/VHF/UHF input routing) regardless of the dongle's USB
 	// iManufacturer/iProduct strings. Use it when a V4's EEPROM strings

--- a/internal/sdr/device.go
+++ b/internal/sdr/device.go
@@ -75,6 +75,16 @@ type Device interface {
 	Close() error
 }
 
+// NarrowbandFilterer is an optional Device extension implemented by the
+// HackRF Pro, whose RF front-end carries a switchable narrowband
+// anti-alias filter. Callers type-assert for it (like TunerDiagnoser)
+// so backends without the filter need not implement it. Enabling it
+// tightens adjacent-channel rejection for narrowband voice channels at
+// the cost of usable bandwidth.
+type NarrowbandFilterer interface {
+	SetNarrowbandFilter(enable bool) error
+}
+
 // TunerDiagnoser is an optional Device extension that surfaces tuner
 // detection state for boot-time diagnostics. Callers type-assert for it
 // (like ActualSampleRate / SettleAfterRetune) so backends that don't

--- a/internal/sdr/device.go
+++ b/internal/sdr/device.go
@@ -85,6 +85,16 @@ type NarrowbandFilterer interface {
 	SetNarrowbandFilter(enable bool) error
 }
 
+// FPGADCBlocker is an optional Device extension implemented by the
+// HackRF Pro, whose gateware can strip the zero-IF DC-offset spike in
+// the FPGA before the samples leave the device. Callers type-assert for
+// it (like NarrowbandFilterer). Enabling it is an alternative to the
+// software DC-block on the decode path — cheaper, and it also cleans the
+// control channel, which the software block doesn't touch.
+type FPGADCBlocker interface {
+	SetFPGADCBlock(enable bool) error
+}
+
 // TunerDiagnoser is an optional Device extension that surfaces tuner
 // detection state for boot-time diagnostics. Callers type-assert for it
 // (like ActualSampleRate / SettleAfterRetune) so backends that don't

--- a/internal/sdr/hackrf/hackrf.go
+++ b/internal/sdr/hackrf/hackrf.go
@@ -48,6 +48,13 @@ const (
 	reqSetLNAGain          uint8 = 19
 	reqSetVGAGain          uint8 = 20
 	reqAntennaEnable       uint8 = 23
+	// reqFPGAWriteReg / reqFPGAReadReg access the HackRF Pro gateware's
+	// registers over the FPGA SPI interface (libhackrf
+	// HACKRF_VENDOR_REQUEST_FPGA_WRITE_REG / _READ_REG). Write carries
+	// the value in wValue and the register number in wIndex; read
+	// carries the register in wIndex and returns one byte. Pro-only.
+	reqFPGAWriteReg uint8 = 49
+	reqFPGAReadReg  uint8 = 50
 	// reqSetNarrowbandFilter toggles the HackRF Pro's switchable
 	// narrowband anti-alias filter (libhackrf
 	// HACKRF_VENDOR_REQUEST_SET_NARROWBAND_FILTER). Pro-only: older
@@ -59,6 +66,19 @@ const (
 // firmware reports via reqBoardIDRead. It gates the Pro-only vendor
 // requests (e.g. the narrowband filter).
 const boardIDPraline uint8 = 5
+
+// HackRF Pro gateware control register. The Pro's default (8-bit) RX
+// gateware exposes a control register at index 1 whose bit 0 enables an
+// FPGA-side DC-offset blocker — the zero-IF LO self-mixing spike that
+// otherwise sits dead-centre in the passband and corrupts an on-channel-
+// tuned C4FM eye. Confirmed on hardware: enabling it drops the measured
+// |DC| of the raw IQ stream from several counts to zero. Other bits in
+// the register (e.g. a TX trigger enable) are left untouched via a
+// read-modify-write.
+const (
+	gatewareRegControl     uint8 = 1
+	gatewareCtrlDCBlockBit uint8 = 1 << 0
+)
 
 // pidProductNames maps each known HackRF USB PID to the canonical
 // product label we surface in sdr.Info. USB descriptor strings vary
@@ -495,6 +515,56 @@ func (d *Device) SetNarrowbandFilter(enable bool) error {
 		v = 1
 	}
 	return d.t.ControlOut(reqSetNarrowbandFilter, v, 0, nil, controlTimeoutMs)
+}
+
+// fpgaReadRegister reads one HackRF Pro gateware register over the FPGA
+// SPI interface (vendor request 50: register in wIndex, one byte back).
+func (d *Device) fpgaReadRegister(reg uint8) (uint8, error) {
+	buf, err := d.t.ControlIn(reqFPGAReadReg, 0, uint16(reg), 1, controlTimeoutMs)
+	if err != nil {
+		return 0, err
+	}
+	if len(buf) < 1 {
+		return 0, fmt.Errorf("hackrf: FPGA read reg %d: short read (%d bytes)", reg, len(buf))
+	}
+	return buf[0], nil
+}
+
+// fpgaWriteRegister writes one HackRF Pro gateware register over the FPGA
+// SPI interface (vendor request 49: value in wValue, register in wIndex).
+func (d *Device) fpgaWriteRegister(reg, value uint8) error {
+	return d.t.ControlOut(reqFPGAWriteReg, uint16(value), uint16(reg), nil, controlTimeoutMs)
+}
+
+// SetFPGADCBlock toggles the HackRF Pro's FPGA-side DC-offset blocker
+// (sdr.FPGADCBlocker) — the gateware control register's bit 0. It
+// removes the zero-IF DC spike in hardware, before the sample stream
+// even leaves the device, which clears an on-channel-tuned C4FM eye that
+// the centre spur would otherwise corrupt. A read-modify-write preserves
+// the register's other bits. It is Pro-only: the gateware register space
+// doesn't exist on other boards, so this errors there rather than
+// writing to a register that isn't the one it names.
+func (d *Device) SetFPGADCBlock(enable bool) error {
+	if d.isClosed() {
+		return usb.ErrClosed
+	}
+	if !d.isPro {
+		return fmt.Errorf("hackrf: FPGA DC blocker requires a HackRF Pro (board ID %d); this device is %q", boardIDPraline, d.info.Product)
+	}
+	cur, err := d.fpgaReadRegister(gatewareRegControl)
+	if err != nil {
+		return fmt.Errorf("hackrf: read gateware control register: %w", err)
+	}
+	next := cur
+	if enable {
+		next |= gatewareCtrlDCBlockBit
+	} else {
+		next &^= gatewareCtrlDCBlockBit
+	}
+	if next == cur {
+		return nil
+	}
+	return d.fpgaWriteRegister(gatewareRegControl, next)
 }
 
 // StreamIQ flips the HackRF into receive mode and reaps bulk-IN URBs,

--- a/internal/sdr/hackrf/hackrf.go
+++ b/internal/sdr/hackrf/hackrf.go
@@ -48,7 +48,17 @@ const (
 	reqSetLNAGain          uint8 = 19
 	reqSetVGAGain          uint8 = 20
 	reqAntennaEnable       uint8 = 23
+	// reqSetNarrowbandFilter toggles the HackRF Pro's switchable
+	// narrowband anti-alias filter (libhackrf
+	// HACKRF_VENDOR_REQUEST_SET_NARROWBAND_FILTER). Pro-only: older
+	// boards stall the request, so callers must gate it behind isPro.
+	reqSetNarrowbandFilter uint8 = 53
 )
+
+// boardIDPraline is the hackrf_board_id value the HackRF Pro ("Praline")
+// firmware reports via reqBoardIDRead. It gates the Pro-only vendor
+// requests (e.g. the narrowband filter).
+const boardIDPraline uint8 = 5
 
 // pidProductNames maps each known HackRF USB PID to the canonical
 // product label we surface in sdr.Info. USB descriptor strings vary
@@ -68,6 +78,8 @@ var boardIDNames = map[uint8]string{
 	1:   "HackRF Jawbreaker",
 	2:   "HackRF One",
 	3:   "Rad1o",
+	4:   "HackRF One R9",
+	5:   "HackRF Pro",
 	255: "Invalid",
 }
 
@@ -219,10 +231,12 @@ func (d *Driver) Open(idx int) (sdr.Device, error) {
 	// firmware — fall through to the PID-derived product name and a
 	// plain TunerName when that happens.
 	product := productForPID(desc.PID, desc.Product)
+	isPro := false
 	if bid, err := readBoardID(t); err == nil {
 		if name, ok := boardIDNames[bid]; ok && name != "" {
 			product = name
 		}
+		isPro = bid == boardIDPraline
 	}
 	tuner := "MAX2839+MAX5864"
 	if version, err := readVersionString(t); err == nil && version != "" {
@@ -232,7 +246,8 @@ func (d *Driver) Open(idx int) (sdr.Device, error) {
 		tuner = fmt.Sprintf("MAX2839+MAX5864 (fw %s)", version)
 	}
 	return &Device{
-		t: t,
+		t:     t,
+		isPro: isPro,
 		info: sdr.Info{
 			Driver:       driverName,
 			Index:        idx,
@@ -313,6 +328,10 @@ type Device struct {
 	// (#686). Non-nil whenever streaming is true.
 	streamDone chan struct{}
 	sampleRate uint32
+	// isPro is set when the firmware reports board ID 5 (Praline /
+	// HackRF Pro). It gates Pro-only vendor requests such as the
+	// narrowband filter, which older boards would stall.
+	isPro bool
 }
 
 // Info implements sdr.Device.
@@ -389,7 +408,11 @@ func (d *Device) SetGain(tenthDB int) error {
 // multiple of 2.
 func splitGain(tenthDB int) (lna, vga int, amp bool) {
 	if tenthDB < 0 {
-		return defaultLNAGainDB, defaultVGAGainDB, false
+		// "auto": enable the front-end RF amp (like SDRTrunk's default
+		// amplifierEnabled:true). The amp sets the noise figure for weak
+		// signals; without it, voice channels on a modest antenna decode
+		// at a much lower SNR and time out with no frames.
+		return defaultLNAGainDB, defaultVGAGainDB, true
 	}
 	target := tenthDB / 10
 	lna = (target / 8) * 8
@@ -451,6 +474,27 @@ func (d *Device) SetBiasTee(enable bool) error {
 		v = 1
 	}
 	return d.t.ControlOut(reqAntennaEnable, v, 0, nil, controlTimeoutMs)
+}
+
+// SetNarrowbandFilter toggles the HackRF Pro's switchable narrowband
+// anti-alias filter (sdr.NarrowbandFilterer). Engaging it tightens
+// adjacent-channel rejection for narrowband signals — e.g. 12.5 kHz P25
+// voice channels — at the cost of usable RF bandwidth. It is Pro-only:
+// on any other board the request would stall the control endpoint, so
+// this returns an error there rather than sending it, letting the pool
+// warn that the operator asked for a filter the hardware doesn't have.
+func (d *Device) SetNarrowbandFilter(enable bool) error {
+	if d.isClosed() {
+		return usb.ErrClosed
+	}
+	if !d.isPro {
+		return fmt.Errorf("hackrf: narrowband filter requires a HackRF Pro (board ID %d); this device is %q", boardIDPraline, d.info.Product)
+	}
+	v := uint16(0)
+	if enable {
+		v = 1
+	}
+	return d.t.ControlOut(reqSetNarrowbandFilter, v, 0, nil, controlTimeoutMs)
 }
 
 // StreamIQ flips the HackRF into receive mode and reaps bulk-IN URBs,

--- a/internal/sdr/hackrf/hackrf_test.go
+++ b/internal/sdr/hackrf/hackrf_test.go
@@ -286,20 +286,21 @@ func TestSplitGain(t *testing.T) {
 	cases := []struct {
 		tenthDB          int
 		wantLNA, wantVGA int
+		wantAmp          bool
 	}{
-		{-1, defaultLNAGainDB, defaultVGAGainDB},
-		{0, 0, 0},
-		{160, 16, 0},   // 16 dB → all in LNA
-		{180, 16, 2},   // 16 dB LNA + 2 dB VGA
-		{300, 24, 6},   // 24 + 6 = 30 dB
-		{900, 40, 50},  // clamped: 40 dB LNA, 50 dB VGA
-		{1500, 40, 62}, // both saturated
+		{-1, defaultLNAGainDB, defaultVGAGainDB, true}, // "auto" enables the front-end RF amp
+		{0, 0, 0, false},
+		{160, 16, 0, false},   // 16 dB → all in LNA
+		{180, 16, 2, false},   // 16 dB LNA + 2 dB VGA
+		{300, 24, 6, false},   // 24 + 6 = 30 dB
+		{900, 40, 50, false},  // clamped: 40 dB LNA, 50 dB VGA
+		{1500, 40, 62, false}, // both saturated
 	}
 	for _, c := range cases {
 		lna, vga, amp := splitGain(c.tenthDB)
-		if lna != c.wantLNA || vga != c.wantVGA || amp {
-			t.Errorf("splitGain(%d) = (%d,%d,%v), want (%d,%d,false)",
-				c.tenthDB, lna, vga, amp, c.wantLNA, c.wantVGA)
+		if lna != c.wantLNA || vga != c.wantVGA || amp != c.wantAmp {
+			t.Errorf("splitGain(%d) = (%d,%d,%v), want (%d,%d,%v)",
+				c.tenthDB, lna, vga, amp, c.wantLNA, c.wantVGA, c.wantAmp)
 		}
 	}
 }
@@ -307,7 +308,7 @@ func TestSplitGain(t *testing.T) {
 func TestSetGainIssuesAMPLNAVGA(t *testing.T) {
 	dev, mt := withDevice(t)
 	mt.Script = []usb.CtrlExchange{
-		{BRequest: reqAmpEnable, WValue: 0},
+		{BRequest: reqAmpEnable, WValue: 1}, // "auto" (-1) enables the front-end amp
 		{In: true, BRequest: reqSetLNAGain, WIndex: 16, Reply: []byte{1}, N: 1},
 		{In: true, BRequest: reqSetVGAGain, WIndex: 20, Reply: []byte{1}, N: 1},
 	}
@@ -333,6 +334,36 @@ func TestSetBiasTeeRoundTrips(t *testing.T) {
 	}
 	if mt.Err != nil {
 		t.Fatalf("transport: %v", mt.Err)
+	}
+}
+
+func TestSetNarrowbandFilterPro(t *testing.T) {
+	dev, mt := withDevice(t)
+	dev.isPro = true // board ID 5 (Praline) — Pro-only request is allowed
+	mt.Script = []usb.CtrlExchange{
+		{BRequest: reqSetNarrowbandFilter, WValue: 1},
+		{BRequest: reqSetNarrowbandFilter, WValue: 0},
+	}
+	if err := dev.SetNarrowbandFilter(true); err != nil {
+		t.Fatalf("SetNarrowbandFilter(on): %v", err)
+	}
+	if err := dev.SetNarrowbandFilter(false); err != nil {
+		t.Fatalf("SetNarrowbandFilter(off): %v", err)
+	}
+	if mt.Err != nil {
+		t.Fatalf("transport: %v", mt.Err)
+	}
+}
+
+func TestSetNarrowbandFilterNonProErrors(t *testing.T) {
+	dev, mt := withDevice(t) // isPro defaults to false
+	dev.info.Product = "HackRF One"
+	if err := dev.SetNarrowbandFilter(true); err == nil {
+		t.Fatal("SetNarrowbandFilter on a non-Pro board: want error, got nil")
+	}
+	// The request must never reach the wire on a board that would stall it.
+	if mt.Step != 0 {
+		t.Fatalf("non-Pro SetNarrowbandFilter issued %d control transfer(s); want 0", mt.Step)
 	}
 }
 

--- a/internal/sdr/hackrf/hackrf_test.go
+++ b/internal/sdr/hackrf/hackrf_test.go
@@ -367,6 +367,52 @@ func TestSetNarrowbandFilterNonProErrors(t *testing.T) {
 	}
 }
 
+func TestSetFPGADCBlockPro(t *testing.T) {
+	dev, mt := withDevice(t)
+	dev.isPro = true
+	// Read-modify-write: read control reg (0x00), set bit 0, write 0x01.
+	mt.Script = []usb.CtrlExchange{
+		{In: true, BRequest: reqFPGAReadReg, WIndex: uint16(gatewareRegControl), Reply: []byte{0x00}, N: 1},
+		{BRequest: reqFPGAWriteReg, WValue: 0x01, WIndex: uint16(gatewareRegControl)},
+	}
+	if err := dev.SetFPGADCBlock(true); err != nil {
+		t.Fatalf("SetFPGADCBlock(on): %v", err)
+	}
+	if mt.Err != nil {
+		t.Fatalf("transport: %v", mt.Err)
+	}
+	if mt.Step != len(mt.Script) {
+		t.Fatalf("issued %d/%d scripted transfers", mt.Step, len(mt.Script))
+	}
+}
+
+func TestSetFPGADCBlockPreservesOtherBits(t *testing.T) {
+	dev, mt := withDevice(t)
+	dev.isPro = true
+	// Control reg already has bit 7 set (e.g. a TX trigger enable): the
+	// read-modify-write must OR in bit 0 without clearing bit 7 → 0x81.
+	mt.Script = []usb.CtrlExchange{
+		{In: true, BRequest: reqFPGAReadReg, WIndex: uint16(gatewareRegControl), Reply: []byte{0x80}, N: 1},
+		{BRequest: reqFPGAWriteReg, WValue: 0x81, WIndex: uint16(gatewareRegControl)},
+	}
+	if err := dev.SetFPGADCBlock(true); err != nil {
+		t.Fatalf("SetFPGADCBlock(on): %v", err)
+	}
+	if mt.Err != nil {
+		t.Fatalf("transport: %v", mt.Err)
+	}
+}
+
+func TestSetFPGADCBlockNonProErrors(t *testing.T) {
+	dev, mt := withDevice(t) // isPro defaults to false
+	if err := dev.SetFPGADCBlock(true); err == nil {
+		t.Fatal("SetFPGADCBlock on a non-Pro board: want error, got nil")
+	}
+	if mt.Step != 0 {
+		t.Fatalf("non-Pro SetFPGADCBlock issued %d control transfer(s); want 0", mt.Step)
+	}
+}
+
 func TestDecodeInt8IQ(t *testing.T) {
 	// Three samples: (+127, -127), (0, 0), (-128, +64).
 	buf := []byte{127, 0xFF - 126, 0, 0, 0x80, 64}

--- a/internal/sdr/pool.go
+++ b/internal/sdr/pool.go
@@ -92,6 +92,10 @@ type Hint struct {
 	PPM     int
 	Gain    int // tenths of dB; negative = auto
 	BiasTee bool
+	// NarrowbandFilter engages the HackRF Pro's switchable narrowband
+	// anti-alias filter after open. Ignored (with a warning) on devices
+	// that don't implement NarrowbandFilterer.
+	NarrowbandFilter bool
 	// ForceBlogV4 forces RTL-SDR Blog V4 mode (28.8 MHz crystal +
 	// HF/VHF/UHF input routing) on a device whose USB strings don't
 	// auto-identify it as a V4, so the R828D stops mistuning by ~1.8×
@@ -531,6 +535,17 @@ func (p *Pool) applyHintSettings(dev Device, info Info, h Hint) {
 	if h.BiasTee {
 		if err := dev.SetBiasTee(true); err != nil {
 			p.log.Warn("set bias_tee failed", "serial", info.Serial, "err", err)
+		}
+	}
+	if h.NarrowbandFilter {
+		if nf, ok := dev.(NarrowbandFilterer); !ok {
+			p.log.Warn("narrowband_filter requested but this driver has no switchable filter (HackRF Pro only)",
+				"serial", info.Serial)
+		} else if err := nf.SetNarrowbandFilter(true); err != nil {
+			p.log.Warn("set narrowband_filter failed", "serial", info.Serial, "err", err)
+		} else {
+			p.log.Info("sdr: narrowband anti-alias filter engaged (HackRF Pro)",
+				"serial", info.Serial, "role", h.Role.String())
 		}
 	}
 }

--- a/internal/sdr/pool.go
+++ b/internal/sdr/pool.go
@@ -96,6 +96,10 @@ type Hint struct {
 	// anti-alias filter after open. Ignored (with a warning) on devices
 	// that don't implement NarrowbandFilterer.
 	NarrowbandFilter bool
+	// FPGADCBlock engages the HackRF Pro's FPGA-side DC-offset blocker
+	// after open. Ignored (with a warning) on devices that don't
+	// implement FPGADCBlocker.
+	FPGADCBlock bool
 	// ForceBlogV4 forces RTL-SDR Blog V4 mode (28.8 MHz crystal +
 	// HF/VHF/UHF input routing) on a device whose USB strings don't
 	// auto-identify it as a V4, so the R828D stops mistuning by ~1.8×
@@ -545,6 +549,17 @@ func (p *Pool) applyHintSettings(dev Device, info Info, h Hint) {
 			p.log.Warn("set narrowband_filter failed", "serial", info.Serial, "err", err)
 		} else {
 			p.log.Info("sdr: narrowband anti-alias filter engaged (HackRF Pro)",
+				"serial", info.Serial, "role", h.Role.String())
+		}
+	}
+	if h.FPGADCBlock {
+		if b, ok := dev.(FPGADCBlocker); !ok {
+			p.log.Warn("fpga_dc_block requested but this driver has no FPGA DC blocker (HackRF Pro only)",
+				"serial", info.Serial)
+		} else if err := b.SetFPGADCBlock(true); err != nil {
+			p.log.Warn("set fpga_dc_block failed", "serial", info.Serial, "err", err)
+		} else {
+			p.log.Info("sdr: FPGA DC-offset blocker engaged (HackRF Pro)",
 				"serial", info.Serial, "role", h.Role.String())
 		}
 	}


### PR DESCRIPTION
## What

Three HackRF Pro improvements, all verified against a real Pro (board ID 5, firmware API 1.09):

1. **Board detection.** GopherTrunk already reads the firmware `board_id` at open but only mapped IDs 0–3 (+255). This adds **ID 4 → `HackRF One R9`** and **ID 5 → `HackRF Pro`** (codename *Praline*), so a Pro reports `HackRF Pro` in `gophertrunk sdr list`, the web **Devices** panel, and the startup log instead of being indistinguishable from an original HackRF One.

2. **Narrowband filter** (`narrowband_filter: true`). Engages the Pro's switchable narrowband anti-alias filter (`HACKRF_VENDOR_REQUEST_SET_NARROWBAND_FILTER`, req 53), tightening adjacent-channel rejection for narrowband voice (e.g. 12.5 kHz P25) at the cost of usable bandwidth.

3. **FPGA DC-offset blocker** (`fpga_dc_block: true`). The Pro's gateware strips the zero-IF DC spike in the FPGA before the samples leave the device. That spur sits dead-centre in the passband and corrupts an on-channel-tuned C4FM eye — the same failure mode the P25 voice path already blocks in software, but the hardware block is cheaper and *also cleans the control channel*, which the software block doesn't touch.

```yaml
sdr:
  devices:
    - serial: "…"
      role: control
      fpga_dc_block: true       # HackRF Pro only
    - serial: "…"
      role: voice
      narrowband_filter: true   # HackRF Pro only
```

### Hardware verification

On a real Pro, toggling the gateware control register's bit 0 and measuring the raw IQ stream's DC:

| DC blocker | mean I | mean Q | **\|DC\|** |
|---|---|---|---|
| off | −1.49 | −6.09 | **6.27** |
| on  | −0.00 | −0.00 | **0.00** |

Vendor request numbers and control-transfer layouts were confirmed against `host/libhackrf/src/hackrf.c` on `master`.

## How

- `boardIDNames` gains entries 4 and 5; open sets an `isPro` flag when `board_id == 5`.
- `SetNarrowbandFilter(bool)` → vendor req 53. `SetFPGADCBlock(bool)` → read-modify-write of gateware control register bit 0 via FPGA reg read/write (reqs 50/49), preserving other bits. Both are **Pro-gated**: on any other board the requests would stall / write to the wrong register space, so the driver returns an error instead of issuing them.
- Wired through the same path as `bias_tee`: optional `sdr.NarrowbandFilterer` / `sdr.FPGADCBlocker` capability interfaces (type-asserted like `TunerDiagnoser`, so non-HackRF backends need not implement them), `Hint` fields, and `DeviceConfig` YAML keys. The pool warns rather than failing when the configured device lacks the hardware.

## Deliberately out of scope

The Pro's **16-bit extended-precision RX** mode (`hackrf_set_fpga_bitstream`, bitstream index 2) is a larger change: it switches the stream from 8-bit to 16-bit I/Q and pre-decimates in the FPGA, so it needs a separate decode path in the driver rather than a single init call. Tracked as a follow-up.

## Testing

- `TestSetNarrowbandFilterPro` / `…NonProErrors` — Pro issues req 53; non-Pro errors and issues **zero** transfers.
- `TestSetFPGADCBlockPro` / `…PreservesOtherBits` / `…NonProErrors` — read-modify-write sets bit 0, preserves a pre-set bit 7 (0x80 → 0x81), non-Pro errors with zero transfers.
- `go build ./...`, `go vet`, and the `internal/sdr/...` + `internal/config/...` suites pass.

Docs: `docs/reference/hackrf.md` (new *HackRF Pro* section), `config.example.yaml`, and CHANGELOG updated.