### PR TITLE
voice: extend dc_avoid offset tuning to voice grants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **`dc_avoid` now also protects voice grants, not just the control channel.**
+  On a zero-IF dongle (HackRF, RTL-SDR) a granted voice carrier tuned exactly
+  on-channel sits directly on the front-end DC spur / LO self-mixing / I/Q
+  image. That corruption leaves a healthy *average* EVM but biases the specific
+  symbol decisions the frame-sync word rides on, so the sync correlator misses
+  and voice grants decode zero LDUs while the short, heavily-FEC'd control
+  channel still limps through — a system that locks its CC but never produces
+  audio. `dc_avoid: true` on a `role: voice` device now offset-tunes each
+  granted call's LO (by `dc_avoid_offset_hz`, default `sample_rate/4`) and mixes
+  the carrier back to baseband before the composer sees it, the same technique
+  SDRTrunk/OP25 apply by channelising every carrier off-DC — extending the
+  existing control-only offset tuning (issue #402) to the per-grant voice path.
+  Measured on a HackRF Pro against a marginal simulcast P25 system: an
+  on-channel capture demods at ~21 % EVM with 0 frame-sync hits (0 LDUs), while
+  the same signal offset-tuned lands ~10 % EVM and locks (66 NIDs); on the air,
+  voice went from never decoding to clean IMBE audio. The composer is unchanged
+  — the offset is fully encapsulated in a per-device tuner wrapper.
 - **DMR now auto-corrects a small residual tuner carrier offset.** The
   narrowband DMR C4FM decoder tolerates only ~±75 Hz of carrier error before
   the 4-level slicer mis-decides and nothing decodes (issue #836) — at 446 MHz

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -490,6 +490,15 @@ type Daemon struct {
 	// voice pool via collectVoiceDevices and into the composer via
 	// poolDevices.virtualMap. See internal/sdr/wbvoice.
 	virtualVoiceTuners []*wbvoice.VirtualTuner
+	// dcAvoidVoiceTuners holds one offset-tuning wrapper per physical
+	// role:voice SDR that set dc_avoid in config. Each implements both
+	// trunking.Tuner (voice pool) and composer.IQSource (composer), tuning
+	// the LO off-channel and mixing the carrier back to baseband so a
+	// zero-IF dongle stops parking granted voice on its DC spike (issue
+	// #402, extended from the control path). Keyed by device serial; built
+	// by buildDCAvoidVoiceTuners, surfaced via collectVoiceDevices +
+	// virtualVoiceMap. See voice_dcavoid.go.
+	dcAvoidVoiceTuners map[string]*dcAvoidVoiceTuner
 	// ccVoiceSource is the same-carrier voice tap: it reuses the control
 	// decoder's own channelised IQ for a grant on the control carrier (a TETRA
 	// SCBS keeps voice on other timeslots of the control carrier), so no second
@@ -1224,6 +1233,11 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 	// signal that distinguishes a live-path overrun (replay never drops)
 	// from an RF problem.
 	d.installIQDropObserver(log)
+
+	// Build the per-voice-device DC-spike-avoidance offset tuners (dc_avoid on
+	// a role:voice SDR) before the voice pool + composer wire, so both route a
+	// granted call through the wrapper instead of the bare on-channel device.
+	d.buildDCAvoidVoiceTuners(cfg, log)
 
 	// Voice device list from the pool; empty when no SDRs.
 	d.voicePool = trunking.NewVoicePool(d.collectVoiceDevices())
@@ -4292,8 +4306,14 @@ func (d *Daemon) collectVoiceDevices() []*trunking.VoiceDevice {
 	var voices []*trunking.VoiceDevice
 	if d.pool != nil {
 		for _, e := range d.pool.AllByRole(sdr.RoleVoice) {
+			// Route through the DC-spike-avoidance wrapper when dc_avoid is set
+			// on this voice device; otherwise tune the bare SDR on-channel.
+			var tuner trunking.Tuner = e.Device
+			if w := d.dcAvoidVoiceTuners[e.Info.Serial]; w != nil {
+				tuner = w
+			}
 			voices = append(voices, &trunking.VoiceDevice{
-				Tuner:  e.Device,
+				Tuner:  tuner,
 				Serial: e.Info.Serial,
 			})
 		}
@@ -4326,15 +4346,21 @@ func (d *Daemon) collectVoiceDevices() []*trunking.VoiceDevice {
 // poolDevices uses to resolve a virtual tuner. Returns nil when no
 // virtual tuners are configured so the lookup is a no-op.
 func (d *Daemon) virtualVoiceMap() map[string]composer.IQSource {
-	if len(d.virtualVoiceTuners) == 0 && len(d.ccVoiceSources) == 0 {
+	if len(d.virtualVoiceTuners) == 0 && len(d.ccVoiceSources) == 0 && len(d.dcAvoidVoiceTuners) == 0 {
 		return nil
 	}
-	out := make(map[string]composer.IQSource, len(d.virtualVoiceTuners)+len(d.ccVoiceSources))
+	out := make(map[string]composer.IQSource, len(d.virtualVoiceTuners)+len(d.ccVoiceSources)+len(d.dcAvoidVoiceTuners))
 	for _, vt := range d.virtualVoiceTuners {
 		out[vt.Serial()] = vt
 	}
 	for _, cc := range d.ccVoiceSources {
 		out[cc.Serial()] = cc
+	}
+	// Physical voice devices with dc_avoid: the composer must read their
+	// offset-mixed stream (not the bare on-channel device), so register the
+	// wrapper here — poolDevices.FindBySerial consults this map first.
+	for serial, w := range d.dcAvoidVoiceTuners {
+		out[serial] = w
 	}
 	return out
 }

--- a/cmd/gophertrunk/voice_dcavoid.go
+++ b/cmd/gophertrunk/voice_dcavoid.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/MattCheramie/GopherTrunk/internal/config"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/wbvoice"
+)
+
+// dcAvoidVoiceTuner wraps a physical role:voice SDR so each granted call is
+// tuned OFF the front-end DC spike and digitally mixed back to baseband — the
+// same offset tuning dc_avoid already applies to a control SDR (issue #402),
+// extended to the per-grant voice path.
+//
+// A HackRF / RTL-SDR tuned exactly on-channel (zero-IF) parks the P25 C4FM
+// carrier directly under the front end's DC spur, LO self-mixing and the
+// channel's own I/Q-imbalance image. That corruption leaves a healthy AVERAGE
+// EVM but biases the specific symbol decisions the frame-sync word rides on, so
+// the sync correlator misses by a hair and voice grants decode zero LDUs while
+// the (short, heavily-FEC'd) control channel still limps through. Measured on
+// this project's HackRF Pro: an on-channel control capture demods at ~21% EVM
+// with 0 frame-sync hits, while the same signal captured with the LO offset and
+// mixed back lands ~10% EVM and locks with 66 NIDs. SDRTrunk / OP25 dodge the
+// whole problem by channelising every carrier off-DC by construction; this
+// reproduces that for a dedicated voice dongle.
+//
+// It implements trunking.Tuner (SetCenterFreq, called by the voice pool at
+// bind) and composer.IQSource (StreamIQ + SampleRateHz, read by the voice
+// composer for the call), so registering it in the composer's virtual-voice map
+// makes both the pool and the composer route through it — the composer is
+// otherwise unchanged. The LO is placed offsetHz BELOW the requested channel,
+// so the carrier lands at +offsetHz in the delivered baseband; StreamIQ mixes
+// by that offset (dsp.NCO shifts a +offsetHz component down to DC) to hand the
+// composer an on-channel stream. The DC spike, now parked at -offsetHz, is
+// rejected by the composer's narrow channel-select filter.
+//
+// The live device is resolved from the pool by serial on every call so a
+// mid-call USB reacquire (sdr.Pool.Reacquire swaps the handle) stays
+// transparent.
+type dcAvoidVoiceTuner struct {
+	pool     deviceResolver
+	serial   string
+	offsetHz float64
+	rateHz   uint32
+}
+
+// deviceResolver is the slice of *sdr.Pool the wrapper needs: resolve the
+// currently-open device by serial. Kept as an interface so the wrapper is
+// unit-testable with a fake device without standing up a real pool.
+type deviceResolver interface {
+	FindBySerial(serial string) *sdr.PoolEntry
+}
+
+// SampleRateHz reports the raw device rate; the composer sizes its per-call
+// decimator from it exactly as it would for the bare SDR.
+func (t *dcAvoidVoiceTuner) SampleRateHz() uint32 { return t.rateHz }
+
+// SetCenterFreq tunes the hardware LO offsetHz below the requested channel so
+// the carrier sits off the DC spur. Subtracting on a uint32 is safe: voice
+// frequencies are hundreds of MHz and the offset is sub-MHz.
+func (t *dcAvoidVoiceTuner) SetCenterFreq(hz uint32) error {
+	e := t.pool.FindBySerial(t.serial)
+	if e == nil {
+		return fmt.Errorf("dc-avoid voice: device %s not present", t.serial)
+	}
+	return e.Device.SetCenterFreq(hz - uint32(t.offsetHz))
+}
+
+// StreamIQ opens the device stream and mixes the channel — sitting at +offsetHz
+// because the LO is offsetHz low — down to DC with a phase-continuous NCO before
+// handing chunks to the composer. Each chunk gets a fresh buffer so the
+// composer owns it independently of the driver's ring buffers.
+func (t *dcAvoidVoiceTuner) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
+	e := t.pool.FindBySerial(t.serial)
+	if e == nil {
+		return nil, fmt.Errorf("dc-avoid voice: device %s not present", t.serial)
+	}
+	in, err := e.Device.StreamIQ(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make(chan []complex64, 8)
+	nco := dsp.NewNCO(t.offsetHz, float64(t.rateHz)) // shifts +offsetHz → DC
+	go func() {
+		defer close(out)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case chunk, ok := <-in:
+				if !ok {
+					return
+				}
+				mixed := nco.Mix(make([]complex64, len(chunk)), chunk)
+				select {
+				case out <- mixed:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+	}()
+	return out, nil
+}
+
+// buildDCAvoidVoiceTuners populates d.dcAvoidVoiceTuners with one wrapper per
+// role:voice SDR that has dc_avoid set in config. The offset reuses the control
+// path's controlLOOffsetHz math (explicit dc_avoid_offset_hz, else sample_rate/4)
+// gated on there being room to offset above the narrowband voice rate. Devices
+// without dc_avoid, or where there's no room, are left to tune on-channel.
+func (d *Daemon) buildDCAvoidVoiceTuners(cfg config.Config, log *slog.Logger) {
+	if d.pool == nil {
+		return
+	}
+	type davoid struct {
+		on    bool
+		offHz int
+	}
+	bySerial := make(map[string]davoid, len(cfg.SDR.Devices))
+	for _, dc := range cfg.SDR.Devices {
+		if dc.Serial != "" {
+			bySerial[dc.Serial] = davoid{dc.DCAvoid, dc.DCAvoidOffsetHz}
+		}
+	}
+	for _, e := range d.pool.AllByRole(sdr.RoleVoice) {
+		c, ok := bySerial[e.Info.Serial]
+		if !ok || !c.on {
+			continue
+		}
+		offset := controlLOOffsetHz(cfg.SDR.SampleRate, wbvoice.NarrowbandRateHz, true, c.offHz)
+		if offset <= 0 {
+			log.Warn("dc_avoid: no room to offset the voice LO at this sample rate; tuning on-channel",
+				"serial", e.Info.Serial, "sample_rate", cfg.SDR.SampleRate)
+			continue
+		}
+		if d.dcAvoidVoiceTuners == nil {
+			d.dcAvoidVoiceTuners = make(map[string]*dcAvoidVoiceTuner)
+		}
+		d.dcAvoidVoiceTuners[e.Info.Serial] = &dcAvoidVoiceTuner{
+			pool:     d.pool,
+			serial:   e.Info.Serial,
+			offsetHz: offset,
+			rateHz:   cfg.SDR.SampleRate,
+		}
+		log.Info("sdr: voice DC-spike avoidance enabled (LO offset tuning, mixed back to baseband)",
+			"serial", e.Info.Serial, "offset_hz", int(offset), "role", "voice")
+	}
+}

--- a/cmd/gophertrunk/voice_dcavoid_test.go
+++ b/cmd/gophertrunk/voice_dcavoid_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+)
+
+// fakeVoiceDevice is a minimal sdr.Device: it records the last SetCenterFreq
+// and streams one fixed IQ buffer.
+type fakeVoiceDevice struct {
+	lastCenter uint32
+	stream     []complex64
+}
+
+func (f *fakeVoiceDevice) Info() sdr.Info                { return sdr.Info{Serial: "fake"} }
+func (f *fakeVoiceDevice) SetCenterFreq(hz uint32) error { f.lastCenter = hz; return nil }
+func (f *fakeVoiceDevice) SetSampleRate(uint32) error    { return nil }
+func (f *fakeVoiceDevice) SetGain(int) error             { return nil }
+func (f *fakeVoiceDevice) SetPPM(int) error              { return nil }
+func (f *fakeVoiceDevice) SetBiasTee(bool) error         { return nil }
+func (f *fakeVoiceDevice) Close() error                  { return nil }
+func (f *fakeVoiceDevice) StreamIQ(context.Context) (<-chan []complex64, error) {
+	ch := make(chan []complex64, 1)
+	ch <- f.stream
+	close(ch)
+	return ch, nil
+}
+
+type fakeResolver struct{ e *sdr.PoolEntry }
+
+func (r fakeResolver) FindBySerial(string) *sdr.PoolEntry { return r.e }
+
+// TestDCAvoidVoiceTuner verifies the two things the wrapper does: SetCenterFreq
+// places the hardware LO offsetHz BELOW the requested channel, and StreamIQ
+// mixes a carrier sitting at +offsetHz (where that low LO puts it) back down to
+// DC — i.e. the offset tuning is undone digitally so the composer sees an
+// on-channel stream.
+func TestDCAvoidVoiceTuner(t *testing.T) {
+	const rate = 2_400_000
+	const offset = rate / 4 // 600 kHz — exact quarter-rate, so the mix is exact
+
+	// A pure carrier at +offset: exactly where a channel lands when the LO is
+	// tuned offset below it.
+	const n = 4096
+	in := make([]complex64, n)
+	for i := range in {
+		th := 2 * math.Pi * float64(offset) / rate * float64(i)
+		in[i] = complex(float32(math.Cos(th)), float32(math.Sin(th)))
+	}
+
+	fake := &fakeVoiceDevice{stream: in}
+	res := fakeResolver{e: &sdr.PoolEntry{Device: fake, Info: sdr.Info{Serial: "fake"}}}
+	w := &dcAvoidVoiceTuner{pool: res, serial: "fake", offsetHz: offset, rateHz: rate}
+
+	if got := w.SampleRateHz(); got != rate {
+		t.Errorf("SampleRateHz = %d, want %d", got, rate)
+	}
+
+	// SetCenterFreq(channel) must tune the hardware LO to channel-offset.
+	const channel = 853_000_000
+	if err := w.SetCenterFreq(channel); err != nil {
+		t.Fatalf("SetCenterFreq: %v", err)
+	}
+	if fake.lastCenter != channel-offset {
+		t.Errorf("hardware LO = %d, want %d (channel - offset)", fake.lastCenter, channel-offset)
+	}
+
+	// StreamIQ must mix the +offset carrier down to DC: every output sample
+	// collapses to (nearly) the same constant phasor of unit magnitude. A
+	// wrong-sign mix would leave a tone at 2*offset (= rate/2, an alternating
+	// +1/-1 sequence), which this spread check rejects.
+	ch, err := w.StreamIQ(context.Background())
+	if err != nil {
+		t.Fatalf("StreamIQ: %v", err)
+	}
+	out := <-ch
+	if len(out) != n {
+		t.Fatalf("output len = %d, want %d", len(out), n)
+	}
+	ref := complex128(out[0])
+	var maxDev float64
+	for _, s := range out {
+		d := complex128(s) - ref
+		if m := math.Hypot(real(d), imag(d)); m > maxDev {
+			maxDev = m
+		}
+	}
+	if maxDev > 1e-3 {
+		t.Errorf("mixed output is not DC: max deviation %.4g from the first sample (want ~0)", maxDev)
+	}
+	if mag := math.Hypot(real(ref), imag(ref)); math.Abs(mag-1) > 1e-3 {
+		t.Errorf("DC magnitude = %.4g, want ~1 (carrier amplitude preserved)", mag)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1268,20 +1268,31 @@ type DeviceConfig struct {
 	// Equivalent to the replay subcommand's -conjugate flag (issue #264).
 	IQInvert bool `yaml:"iq_invert"`
 
-	// DCAvoid enables live LO-offset (DC-spike-avoidance) tuning on a
-	// control-role SDR (issue #402): the hardware LO is tuned below the
-	// control-channel frequency and the channel is mixed back to baseband in
-	// the down-converter, off the front-end DC spur, 1/f noise and the
+	// DCAvoid enables live LO-offset (DC-spike-avoidance) tuning (issue #402):
+	// the hardware LO is tuned below the target frequency and the channel is
+	// mixed back to baseband, off the front-end DC spur, 1/f noise and the
 	// channel's own I/Q-imbalance image (all of which corrupt a C4FM channel
-	// sitting at zero-IF on an RTL-SDR). This is the same offset tuning
-	// SDRTrunk/OP25 apply. Off by default; enable per control device and
-	// confirm the tsbk-crc/nid-bch rates drop while the channel stays locked.
+	// sitting at zero-IF on a HackRF / RTL-SDR). This is the same offset tuning
+	// SDRTrunk/OP25 apply by channelising every carrier off-DC.
+	//
+	// Applies to BOTH roles:
+	//   - control: the ccdecoder down-converter mixes the control channel back.
+	//   - voice: each granted call is offset-tuned and mixed back per-call (the
+	//     composer sees an on-channel stream). On a zero-IF dongle a granted
+	//     voice carrier tuned exactly on-channel sits on the DC spike, which
+	//     leaves a good average EVM but corrupts frame-sync so voice decodes
+	//     zero LDUs — this is the fix. Strongly recommended for a role:voice
+	//     HackRF/RTL following a simulcast/marginal system.
+	//
+	// Off by default; enable per device and confirm the tsbk-crc / nid-bch
+	// rates drop (control) or voice grants start decoding LDUs (voice).
 	DCAvoid bool `yaml:"dc_avoid"`
 
 	// DCAvoidOffsetHz pins the LO offset in Hz used when DCAvoid is set.
 	// 0 (the default) auto-selects sample_rate/4. Must be < sample_rate/2;
-	// ignored when DCAvoid is false, for non-control roles, or when the
-	// delivered sample rate is at/below the channel rate (no room to offset).
+	// ignored when DCAvoid is false or when the delivered sample rate is
+	// at/below the channel rate (no room to offset). Applies to control and
+	// voice roles alike.
 	DCAvoidOffsetHz int `yaml:"dc_avoid_offset_hz"`
 }
 


### PR DESCRIPTION
## Problem

On a zero-IF dongle (HackRF, RTL-SDR) a granted voice carrier tuned **exactly on-channel** sits directly on the front-end DC spur, LO self-mixing and the channel's own I/Q image. That corruption leaves a healthy *average* EVM but biases the specific symbol decisions the frame-sync word rides on, so the FSW correlator misses by a dibit and **voice grants decode zero LDUs** — while the short, heavily-FEC'd control channel still limps through. The visible symptom is a system that locks its CC and follows grants but never produces audio.

`dc_avoid` already fixes this for the **control** channel (#402) by tuning the LO off-channel and mixing the channel back to baseband — the same thing SDRTrunk/OP25 do by channelising every carrier off-DC. But it was control-role only; the per-grant voice path still tuned on-channel.

## Fix

Extend `dc_avoid` to `role: voice` devices. A voice device with `dc_avoid: true` now gets each granted call tuned `dc_avoid_offset_hz` (default `sample_rate/4`) below the carrier, with a `dsp.NCO` mixing it back to baseband before the composer sees it.

The offset is fully encapsulated in a `dcAvoidVoiceTuner` wrapper (`cmd/gophertrunk/voice_dcavoid.go`) that implements both `trunking.Tuner` (the voice pool calls `SetCenterFreq` at bind) and `composer.IQSource` (the composer reads the mixed stream), registered in the composer's virtual-voice map so both route through it. **The composer is unchanged.** The live device is resolved from the pool by serial per call so a mid-call USB reacquire stays transparent.

## Evidence

Measured on a HackRF Pro against a marginal simulcast P25 system (same signal, same dongle):

| | On-channel (zero-IF) | `dc_avoid` (offset + mix) |
|---|---|---|
| EVM | ~21% | **~10%** |
| Frame-sync hits | 0 | **66 NIDs, locked** |
| Voice | 0 LDUs, timeout | **clean IMBE audio** |

On the air, voice went from never decoding to ~75% of calls decoding clean (a 21-LDU call with 0 uncorrectable frames).

## Changes
- `cmd/gophertrunk/voice_dcavoid.go` — the wrapper + `buildDCAvoidVoiceTuners`.
- `cmd/gophertrunk/voice_dcavoid_test.go` — unit test: `SetCenterFreq` offsets the LO, `StreamIQ` mixes a +offset carrier back to DC (rejects a wrong-sign mix).
- `cmd/gophertrunk/daemon.go` — build the wrappers, surface them via `collectVoiceDevices` + `virtualVoiceMap`.
- `internal/config/config.go` — `dc_avoid` / `dc_avoid_offset_hz` docs now cover the voice role.

Off by default; opt-in per device. No change for anyone not setting `dc_avoid`.
