### PR TITLE
tetra: descramble DMO TCH/S at colour 0 (issue #1003)

### DIFF
--- a/.github/scripts/check_internal_links.py
+++ b/.github/scripts/check_internal_links.py
@@ -45,6 +45,12 @@ SKIP_PARSE_URLS = {"/404.html"}
 
 HREF_RE = re.compile(r'(?:href|src)\s*=\s*["\']([^"\']+)["\']', re.IGNORECASE)
 REFRESH_RE = re.compile(r'http-equiv=["\']?refresh', re.IGNORECASE)
+# Sample markup shown *inside* a code block is not a navigable link — a prose
+# example like `<audio src="…/audio/stream">` renders as escaped text within
+# <code>/<pre>, keeping its literal src="…" attribute, which HREF_RE would
+# otherwise mis-read as a real (and broken) internal link. Strip these regions
+# before scanning so example snippets never register as links.
+CODE_BLOCK_RE = re.compile(r"<(pre|code)\b[^>]*>.*?</\1>", re.IGNORECASE | re.DOTALL)
 POST_FILENAME_RE = re.compile(r"^\d{4}-\d{2}-\d{2}-(?P<slug>.+)\.(?:md|markdown|html)$")
 
 
@@ -170,7 +176,9 @@ def main():
             html = open(fpath, encoding="utf-8", errors="replace").read()
             if REFRESH_RE.search(html):   # redirect stub — nothing to check
                 continue
-            for href in HREF_RE.findall(html):
+            # Ignore href/src that appear inside code samples (see CODE_BLOCK_RE).
+            scan_html = CODE_BLOCK_RE.sub("", html)
+            for href in HREF_RE.findall(scan_html):
                 href = href.strip()
                 if not href or href.startswith("#") or is_external(href):
                     continue

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,3 +217,21 @@ confirmation before any close-as-completed.
     persistent chance floor is now a *decode* defect to keep chasing (next suspects: DNB
     geometry, the DM colour code via `GT_TETRA_DMO_COLOUR`), NOT encryption. Do not mark
     #1003 verified until that A/B lands.
+- **P25 Phase 1 weak-signal voice is the under-equipped decode path — diagnosed, NOT yet
+  fixed (needs a capture).** An operator whose hardware Astro Spectra decodes a marginal
+  P25 Phase 1 voice call cleanly gets only ~4-5 IMBE frames from GT on the same antenna.
+  Root cause is structural, not a bug: the default **C4FM** voice receiver
+  (`internal/radio/p25/phase1/receiver/receiver.go`, C4FM branch) is FM-discriminator →
+  fixed matched filter → CoarseAFC → Mueller-Müller timing → AGC → 4-level slicer → **hard**
+  Golay/Hamming IMBE FEC — with **no channel equalizer and no soft-decision FEC**. A blind
+  CMA/FSE equalizer exists only on the opt-in `DemodCQPSK`/LSM path (`cqpsk.go`, the `fse`
+  field), and P25 Phase 2 wires one too — P25 P1 C4FM is the odd path without either. These
+  are the same two levers that ~2×'d TETRA yield on ISI/weak captures (`SnapshotCMA` +
+  soft TCH/S). ("4-5 frames" also brushes `minAutotuneLDUs=5` in `composer/p25p1_voice.go`,
+  which treats a <5-LDU call as too short to trust.) **The fix is unverifiable without a
+  capture** (#764/#771): drop a raw C4FM Phase-1 **voice** IQ recording into `samples/p25/`
+  (+ `.metadata.json`), baseline it with `TestReplayP25RealCaptureMetrics`
+  (`cmd/gophertrunk/p25_realcapture_metrics_test.go`, tag `integration`; pre-FEC EVM/SNR/
+  FSW-margin/LDU yield), then either port the `cqpsk.go` CMA/FSE equalizer onto the C4FM
+  path or add soft-decision to the IMBE FEC, and A/B LDU/IMBE yield against the capture. No
+  change lands without that capture. See `samples/p25/README.md` (weak-signal voice section).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,36 +180,40 @@ confirmation before any close-as-completed.
   clean, byte-identical without symbols). A/B on captures with `GT_TETRA_DMO_LMS=1` in
   `TestTETRADMOReplay`. Note the whole DMO path is still unverified on air (#1003), so
   this is a lever staged for that validation, not a confirmed win.
-- **DMO on-air, first real capture (#1003): signalling decodes, the reporter's voice is
-  air-interface ENCRYPTED — do NOT re-chase it as a decode bug.** Against the first real
-  DMO capture (`tetra_dmo_test2_20sec_cs16_144k`, a 438.9 MHz single-transmission cs16 at
-  144 kHz), the outcome splits cleanly and is pinned by `TestTETRADMOReplay`:
-  - **Sync + signalling fully decode.** With the receiver blind-CMA equalizer (now the
-    harness default — it lifts CRC-valid SCH/S from **6 → 64** by inverting the ISI that
-    smears the constellation, exactly like the live TMO CC path), `DecodeDMSCHS` gives
-    64/68 CRC-valid SCH/S spanning the whole transmission and `DecodeDMSCHH` 62/68. The
-    **DMO DM-SYNC PDU reuses the TMO SYNC-PDU field layout**, so the existing
-    `ParseSyncPDU` decodes it (colour@4-9=0, TN@10-11, FN@12-16, MN@17-22, MCC/MNC=0) with
-    a monotonically advancing frame counter — proof of a genuine lock, not chance CRC.
-  - **DNB geometry `-108/+11` (`dmDNB*Start`) is CONFIRMED correct** — it is the sharp
-    TCH/S-CRC optimum; osmo-tetra-dmo's TMO-copied `-115/+19` is measurably worse.
-  - **TCH/S voice does NOT decode, and it's not a code bug.** Every decode-side variable
-    was exhausted against the capture — geometry sweep, colour 0-63, ExtendedColourCode,
-    block-order swap, per-block vs concat-432 descramble, with/without a colour-0
-    descramble — and the Viterbi metric stays **uniformly ~35-40 (half-wrong)** with
-    CRC-valid bursts never above ~10/201 (≈ the 1/256 chance floor). A wrong
-    geometry/scramble gives a *sharp* dip; a uniform plateau while signalling is clean is
-    the signature of **air-interface-encrypted voice on clear signalling**. osmo-tetra-dmo
-    (the only DMO reference) doesn't decode DMO voice either, and ETSI EN 300 396-2 is
-    network-blocked in the agent env, so an undocumented coding detail can't be *proven*
-    excluded — but every reachable lever is. **DMO voice validation needs a known-CLEAR
-    (unencrypted) DMO capture; the `TestTETRADMOReplay` VERDICT line flags the encrypted
-    signature automatically.**
-  - **Latent bug spotted, deliberately NOT fixed (unverifiable):** `DMBurstTCHSpeech`/
-    `DMBurstTCHSpeechSoft` skip descrambling when `colour==0`, but the TETRA colour-0
-    scramble is non-identity (it's what BSCH uses; `DecodeBSCH` always descrambles). On
-    real clear colour-0 DMO this would matter — but the synthetic round-trips scramble
-    *and* descramble consistently at colour 0, so they pass either way, and the only real
-    capture is encrypted. Per the #764/#771 rule (a green synthetic ≠ on-air correct),
-    the fix stays deferred until a clear capture can verify it rather than flip a
-    convention on both sides for a green-either-way test.
+- **DMO on-air (#1003): the "encrypted" conclusion was WRONG — it was the colour-0
+  descramble skip, now fixed.** The reporter confirmed their DMO radios are **TEA0 (clear,
+  no encryption)**, colour code 0 (CPS codeplug: `DMO_438.900/.800`, Security Class 1,
+  `NO_KG`). That is the known-clear evidence the earlier note said was required, and it
+  overturns the "air-interface encrypted" reading. What still holds from the first capture
+  (`tetra_dmo_test2_20sec_cs16_144k`, 438.9 MHz cs16 at 144 kHz), pinned by
+  `TestTETRADMOReplay`:
+  - **Sync + signalling fully decode.** With the receiver blind-CMA equalizer (harness
+    default — lifts CRC-valid SCH/S from **6 → 64** by inverting ISI, like the live TMO CC
+    path), `DecodeDMSCHS` gives 64/68 SCH/S and `DecodeDMSCHH` 62/68. The **DMO DM-SYNC PDU
+    reuses the TMO SYNC-PDU field layout**, so `ParseSyncPDU` decodes it (colour 0, TN, FN,
+    MN, MCC/MNC=0) with a monotonically advancing frame counter — a genuine lock.
+  - **DNB geometry `-108/+11` (`dmDNB*Start`) is CONFIRMED correct** — the sharp TCH/S-CRC
+    optimum; osmo-tetra-dmo's TMO-copied `-115/+19` is measurably worse.
+  - **The real cause of "TCH/S doesn't decode": `DMBurstTCHSpeech`/`DMBurstTCHSpeechSoft`
+    skipped descrambling at `colour==0`.** TETRA scrambling is non-identity at colour 0 —
+    `NewScramblerTetra(0)` seeds the LFSR to `0xC0000000` (§8.2.5.2 eq. 8.42), which is
+    exactly why `DecodeBSCH`/`DecodeDMSCHS` *always* descramble and the DSB signalling
+    decodes. The voice path inherited TMO `traffic.go`'s `if colour != 0` shortcut (safe
+    there only because a TMO extended colour code is never 0) and so left a clear colour-0
+    DNB scrambled going into the Viterbi/CRC — producing the uniform ~1/256 chance-floor
+    metric that was misread as encryption. The `#1003` fix removes the guard on both DMO
+    TCH/S paths (`dmo_decode.go`): descramble UNCONDITIONALLY with the DM colour code.
+  - **Why the earlier "with/without a colour-0 descramble" sweep didn't catch it:** the
+    synthetic round-trips scrambled *and* descrambled consistently at colour 0, so they
+    passed either way and hid the asymmetry (the #764/#771 self-consistent-synthetic trap).
+    `dmo_decode_test.go` now scrambles the encode side UNCONDITIONALLY (real-air behaviour),
+    so the colour-0 iterations are the failing-first regression — they fail against the old
+    skip and pass with the fix (verified: old code → `DMBurstTCHSpeech` returns 0 frames at
+    colour 0; fixed → 2 CRC-valid frames).
+  - **Still to verify ON AIR (operator loop, not yet closed):** a green synthetic ≠ on-air
+    correct (#764/#771). The operator must replay their clear 438.9 MHz capture through
+    `TestTETRADMOReplay` (`GT_TETRA_DMO_IQ`) and confirm `tch_crc` rises off the chance
+    floor. `GT_TETRA_DMO_CLEAR=1` flips the VERDICT line: on a capture asserted clear, a
+    persistent chance floor is now a *decode* defect to keep chasing (next suspects: DNB
+    geometry, the DM colour code via `GT_TETRA_DMO_COLOUR`), NOT encryption. Do not mark
+    #1003 verified until that A/B lands.

--- a/cmd/gophertrunk/tetra_dmo_replay_test.go
+++ b/cmd/gophertrunk/tetra_dmo_replay_test.go
@@ -205,14 +205,28 @@ func TestTETRADMOReplay(t *testing.T) {
 
 	// Signalling-vs-traffic verdict. DMO SCH/S is scrambled with colour 0 (like the
 	// TMO BSCH) and decodes clear whenever the RF is receivable; TCH/S traffic is
-	// scrambled with the DM colour code AND, if the call is protected, air-interface
-	// encrypted. A capture that decodes SCH/S well (dsb_schs_crc high, distinct FN)
-	// but yields TCH/S CRC only near the ~1/256 chance floor across the whole
-	// transmission is the signature of ENCRYPTED voice on clear signalling — not a
-	// decoder defect (the geometry/scramble/interleave were exhausted in #1003).
+	// scrambled with the DM colour code (now descrambled UNCONDITIONALLY, incl. at
+	// colour 0 — the issue #1003 fix in dmo_decode.go) and, only if the call is
+	// protected, additionally air-interface encrypted.
+	//
+	// A capture that decodes SCH/S well (dsb_schs_crc high, distinct FN) but yields
+	// TCH/S CRC only near the ~1/256 chance floor has TWO possible causes, no longer
+	// just one:
+	//   - the call is genuinely air-interface ENCRYPTED, or
+	//   - a remaining clear-voice DECODE defect (geometry / interleave / colour code).
+	// The reporter confirmed their radios are TEA0 (clear, colour 0), and the
+	// colour-0 descramble asymmetry that produced this exact chance-floor signature
+	// in #1003 is now fixed. So on a capture KNOWN to be clear, a persistent chance
+	// floor is a decode bug to keep chasing — NOT proof of encryption. Set
+	// GT_TETRA_DMO_CLEAR=1 to assert the capture is clear and flip the verdict.
 	if dsbCRC >= 8 && dnbTotal > 0 && tchCRC*20 < dnbTotal {
-		t.Logf("VERDICT: DMO SIGNALLING decodes (dsb_schs_crc=%d, distinct FN=%d) but TCH/S is at the chance floor (tch_crc=%d/%d) — the voice is most likely air-interface ENCRYPTED. Validate voice against a known-CLEAR DMO call.",
-			dsbCRC, len(fnSeen), tchCRC, dnbTotal)
+		if os.Getenv("GT_TETRA_DMO_CLEAR") == "1" {
+			t.Logf("VERDICT: DMO SIGNALLING decodes (dsb_schs_crc=%d, distinct FN=%d) but TCH/S is at the chance floor (tch_crc=%d/%d) on a capture asserted CLEAR (TEA0) — this is a clear-voice DECODE defect to keep chasing (geometry/interleave/colour), NOT encryption. The colour-0 descramble is already fixed (#1003); next suspects are DNB geometry and the DM colour code (GT_TETRA_DMO_COLOUR).",
+				dsbCRC, len(fnSeen), tchCRC, dnbTotal)
+		} else {
+			t.Logf("VERDICT: DMO SIGNALLING decodes (dsb_schs_crc=%d, distinct FN=%d) but TCH/S is at the chance floor (tch_crc=%d/%d) — either air-interface ENCRYPTED voice or a remaining clear-voice decode defect. If the call is known CLEAR (TEA0), set GT_TETRA_DMO_CLEAR=1; otherwise validate against a known-CLEAR DMO call.",
+				dsbCRC, len(fnSeen), tchCRC, dnbTotal)
+		}
 	}
 
 	// Seconds with >=2 CRC-valid speech bursts = real activity, not a lone

--- a/docs/radio-ids.md
+++ b/docs/radio-ids.md
@@ -22,16 +22,26 @@ far easier than scrolling raw `source_id` numbers.
 
 ## What you get
 
-- A merged view of two RID sources, keyed by radio ID:
+- A merged view of three RID sources, keyed by radio ID, in
+  increasing order of freshness:
   - **Configured** rows from a per-system `rid_alias_file` (CSV or
     JSON) — operator-assigned `alias`, `description`, `tag`,
     `group`, `owner`, `priority`, `lockout`, `watch`, `icon`.
-  - **Live** rows from the affiliation tracker — `last_seen`,
-    `first_seen`, `last_talkgroup`, observed over-the-air
-    `talker_alias`, and a `call_count` for "how recurring is this
-    radio."
-- Configured + live overlap is merged on `id`; either source can
-  contribute a row by itself.
+  - **Persisted** rows aggregated from the call log — the durable,
+    all-time `call_count`, `first_seen`, `last_seen`, and last
+    **group** `last_talkgroup` for every radio ever recorded. This
+    is what keeps a radio in the list after the live tracker's
+    idle TTL sweeps it: the list reflects the daemon's whole
+    lifetime and survives control-channel re-locks and restarts,
+    rather than collapsing to the configured catalogue during a
+    re-hunt gap.
+  - **Live** rows from the affiliation tracker — the freshest
+    in-window `last_seen`, `last_talkgroup`, and observed
+    over-the-air `talker_alias`. The tracker holds a radio for a
+    30-minute idle window; its per-window `call_count` never
+    shrinks the all-time total the persisted layer supplies.
+- Overlapping rows are merged on `id`; any source can contribute a
+  row by itself.
 - Detail modal with the last 50 calls observed for the RID
   (queried from the persisted call log by `source_id`).
 - Write-mode edits to the in-memory catalogue (alias / watch /

--- a/internal/api/handlers_rids.go
+++ b/internal/api/handlers_rids.go
@@ -1,10 +1,12 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"sort"
 	"strconv"
+	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
@@ -18,8 +20,8 @@ import (
 // Configured rows always appear; live-only rows (over-the-air radios
 // without an operator-configured alias) appear when the affiliation
 // tracker has seen them since the last sweep.
-func (s *Server) handleListRIDs(w http.ResponseWriter, _ *http.Request) {
-	dtos := s.mergedRIDList()
+func (s *Server) handleListRIDs(w http.ResponseWriter, r *http.Request) {
+	dtos := s.mergedRIDList(r.Context())
 	writeJSON(w, http.StatusOK, map[string]any{"rids": dtos})
 }
 
@@ -38,10 +40,20 @@ func (s *Server) handleGetRID(w http.ResponseWriter, r *http.Request) {
 	if s.rids != nil {
 		dto = ridToDTO(s.rids.Lookup(id))
 	}
+	// Durable base from the persisted call log, so a radio that has aged out of
+	// the live tracker (or predates a restart) is still found.
+	if p, ok := s.history.(RIDSummaryProvider); ok {
+		if sums, err := p.RIDSummaries(r.Context(), RIDSummaryFilter{SourceID: id, Limit: 1}); err != nil {
+			s.log.Warn("api: rid summary query failed", "err", err, "rid", id)
+		} else if len(sums) > 0 {
+			allTime := sums[0]
+			dto = mergeRIDSummary(dto, allTime)
+		}
+	}
 	if s.affiliations != nil {
 		for _, u := range s.affiliations.Affiliations() {
 			if u.RadioID == id {
-				dto = mergeRIDLive(dto, u)
+				dto = mergeRIDLiveKeepAllTime(dto, u)
 				break
 			}
 		}
@@ -196,19 +208,34 @@ func (s *Server) handleUpdateRID(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, dto)
 }
 
-// mergedRIDList walks both the static RIDDB and the live affiliation
-// tracker, merging by RadioID. The output is sorted by ID for a
-// stable list ordering — the UI applies its own sort on top.
-func (s *Server) mergedRIDList() []*RIDDTO {
+// mergedRIDList merges three sources by RadioID, in increasing order of
+// freshness: the static RIDDB (operator catalogue), the persisted call-log
+// aggregate (durable, all-time observations), then the live affiliation tracker
+// (the most recent in-window observation). The call-log layer is what makes the
+// list durable — a radio no longer drops out once the tracker's 30-minute idle
+// TTL sweeps it, which is what made the list look like it "reset after each CC
+// lock" (the re-hunt gaps let the TTL expire every radio, with nothing behind
+// it). The output is sorted by ID for a stable list ordering — the UI applies
+// its own sort on top.
+func (s *Server) mergedRIDList(ctx context.Context) []*RIDDTO {
 	byID := map[uint32]*RIDDTO{}
 	if s.rids != nil {
 		for _, r := range s.rids.All() {
 			byID[r.ID] = ridToDTO(r)
 		}
 	}
+	if p, ok := s.history.(RIDSummaryProvider); ok {
+		if sums, err := p.RIDSummaries(ctx, RIDSummaryFilter{}); err != nil {
+			s.log.Warn("api: rid summaries query failed", "err", err)
+		} else {
+			for _, sum := range sums {
+				byID[sum.SourceID] = mergeRIDSummary(byID[sum.SourceID], sum)
+			}
+		}
+	}
 	if s.affiliations != nil {
 		for _, u := range s.affiliations.Affiliations() {
-			byID[u.RadioID] = mergeRIDLive(byID[u.RadioID], u)
+			byID[u.RadioID] = mergeRIDLiveKeepAllTime(byID[u.RadioID], u)
 		}
 	}
 	out := make([]*RIDDTO, 0, len(byID))
@@ -217,4 +244,25 @@ func (s *Server) mergedRIDList() []*RIDDTO {
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
 	return out
+}
+
+// mergeRIDLiveKeepAllTime overlays the live tracker's fresh observation onto a
+// DTO that may already carry the durable call-log aggregate, without letting the
+// live counters clobber the all-time ones: CallCount keeps the larger value and
+// FirstSeen the earlier, since the live tracker only counts calls seen since it
+// (re)added the unit after its last idle sweep, whereas the call log is all-time.
+func mergeRIDLiveKeepAllTime(dto *RIDDTO, u trunking.UnitActivity) *RIDDTO {
+	allTimeCalls := uint64(0)
+	var firstSeen time.Time
+	if dto != nil {
+		allTimeCalls, firstSeen = dto.CallCount, dto.FirstSeen
+	}
+	dto = mergeRIDLive(dto, u)
+	if allTimeCalls > dto.CallCount {
+		dto.CallCount = allTimeCalls
+	}
+	if !firstSeen.IsZero() && (dto.FirstSeen.IsZero() || firstSeen.Before(dto.FirstSeen)) {
+		dto.FirstSeen = firstSeen
+	}
+	return dto
 }

--- a/internal/api/handlers_rids_test.go
+++ b/internal/api/handlers_rids_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
@@ -257,6 +258,192 @@ func TestRIDHistoryReturnsSourceFilteredRows(t *testing.T) {
 		if c.SourceID != 4242 {
 			t.Errorf("row source = %d, want 4242", c.SourceID)
 		}
+	}
+}
+
+// seedCallLog opens a fresh sqlite call log, publishes the given CallStart
+// grants through the bus, and waits for them to flush. Returns the storage.DB so
+// the test can wire it as the api History source. Each grant needs a distinct
+// (device_serial, started_at) — the call_log is keyed on that pair.
+func seedCallLog(t *testing.T, bus *events.Bus, grants []trunking.Grant, base time.Time) *storage.DB {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "calls.db")
+	db, err := storage.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	cl, err := storage.NewCallLog(db, bus, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { cl.Close() })
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go cl.Run(ctx)
+
+	for i, g := range grants {
+		bus.Publish(events.Event{
+			Kind: events.KindCallStart,
+			Payload: trunking.CallStart{
+				Grant:        g,
+				DeviceSerial: "VOICE-" + strconv.Itoa(i),
+				StartedAt:    base.Add(time.Duration(i) * time.Minute),
+			},
+		})
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		rows, _ := db.History(context.Background(), storage.HistoryFilter{Limit: 100})
+		if len(rows) == len(grants) {
+			return db
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("call log did not flush %d rows in time", len(grants))
+	return nil
+}
+
+// TestListRIDsBackedByCallLogSurvivesSweptTracker is the failing-first regression
+// for the "RID list resets after each CC lock" report: the live affiliation
+// tracker has a 30-minute idle TTL and no persistence, so during control-channel
+// re-hunt gaps every radio ages out and the list collapsed to the static
+// catalogue. With the list now backed by the persisted call log, radios seen over
+// the daemon's lifetime stay listed even when the tracker has swept them all.
+//
+// The tracker is EMPTY here (modelling the post-sweep state); without the
+// call-log source, /rids would return zero rows.
+func TestListRIDsBackedByCallLogSurvivesSweptTracker(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+
+	// Span the grants across >30 min so it is unambiguously past the tracker TTL.
+	base := time.Now().Add(-2 * time.Hour).UTC().Truncate(time.Second)
+	db := seedCallLog(t, bus, []trunking.Grant{
+		// 4242 — a group call (tg 50) then a later INDIVIDUAL call (target 999).
+		{System: "Metro", Protocol: "tetra", GroupID: 50, SourceID: 4242},
+		{System: "Metro", Protocol: "tetra", GroupID: 999, SourceID: 4242, Individual: true},
+		// 7777 — a single group call (tg 60).
+		{System: "Metro", Protocol: "tetra", GroupID: 60, SourceID: 7777},
+		// source 0 (unknown) must be excluded from the list entirely.
+		{System: "Metro", Protocol: "tetra", GroupID: 70, SourceID: 0},
+	}, base)
+
+	// Empty live tracker: every radio has aged out, exactly as after a re-hunt gap.
+	srv, teardown := mkServer(t, ServerOptions{
+		Bus:          bus,
+		Affiliations: &fakeAffiliationProvider{},
+		History:      HistoryFromStorage(db),
+	})
+	defer teardown()
+
+	resp, err := http.Get(srv + "/api/v1/rids")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	var body struct {
+		RIDs []RIDDTO `json:"rids"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	byID := map[uint32]RIDDTO{}
+	for _, r := range body.RIDs {
+		byID[r.ID] = r
+	}
+	if len(body.RIDs) != 2 {
+		t.Fatalf("rids = %d, want 2 (4242, 7777; source 0 excluded); got %+v", len(body.RIDs), body.RIDs)
+	}
+	// 4242 — durable all-time: 2 calls, last GROUP talkgroup 50 (the individual
+	// call's target 999 must NOT surface as a talkgroup).
+	if r := byID[4242]; r.CallCount != 2 || r.LastTalkgroup != 50 || r.Configured {
+		t.Errorf("RID 4242 = %+v, want CallCount=2 LastTalkgroup=50 Configured=false", r)
+	}
+	if _, ok := byID[7777]; !ok {
+		t.Errorf("RID 7777 missing from list")
+	}
+	if r := byID[7777]; r.CallCount != 1 || r.LastTalkgroup != 60 {
+		t.Errorf("RID 7777 = %+v, want CallCount=1 LastTalkgroup=60", r)
+	}
+}
+
+// TestListRIDsKeepsAllTimeCountOverLiveWindow pins the merge precedence: when a
+// radio is in BOTH the durable call log and the live tracker, the freshest
+// observation (last talkgroup / last-seen) comes from the tracker, but the
+// all-time call count from the call log is kept — the live counter is only a
+// post-sweep partial and must not shrink the displayed CALLS total.
+func TestListRIDsKeepsAllTimeCountOverLiveWindow(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+
+	base := time.Now().Add(-3 * time.Hour).UTC().Truncate(time.Second)
+	db := seedCallLog(t, bus, []trunking.Grant{
+		{System: "Metro", Protocol: "tetra", GroupID: 50, SourceID: 4242},
+		{System: "Metro", Protocol: "tetra", GroupID: 50, SourceID: 4242},
+		{System: "Metro", Protocol: "tetra", GroupID: 50, SourceID: 4242},
+	}, base)
+
+	// Live tracker holds 4242 with a smaller (windowed) count and a fresher TG.
+	live := &fakeAffiliationProvider{units: []trunking.UnitActivity{
+		{RadioID: 4242, System: "Metro", Protocol: "tetra", Talkgroup: 77,
+			CallCount: 1, LastSeen: time.Now().UTC()},
+	}}
+	srv, teardown := mkServer(t, ServerOptions{Bus: bus, Affiliations: live, History: HistoryFromStorage(db)})
+	defer teardown()
+
+	resp, err := http.Get(srv + "/api/v1/rids")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	var body struct {
+		RIDs []RIDDTO `json:"rids"`
+	}
+	json.NewDecoder(resp.Body).Decode(&body)
+	if len(body.RIDs) != 1 {
+		t.Fatalf("rids = %d, want 1", len(body.RIDs))
+	}
+	r := body.RIDs[0]
+	if r.ID != 4242 || r.CallCount != 3 || r.LastTalkgroup != 77 {
+		t.Errorf("RID 4242 = %+v, want CallCount=3 (all-time) LastTalkgroup=77 (live)", r)
+	}
+}
+
+// TestGetRIDBackedByCallLogWhenSwept covers handleGetRID's durable path: a radio
+// swept from the live tracker is still found via the persisted call log
+// (exercising the SourceID-filtered RIDSummaries query), instead of 404ing.
+func TestGetRIDBackedByCallLogWhenSwept(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	base := time.Now().Add(-90 * time.Minute).UTC().Truncate(time.Second)
+	db := seedCallLog(t, bus, []trunking.Grant{
+		{System: "Metro", Protocol: "tetra", GroupID: 88, SourceID: 5150},
+		{System: "Metro", Protocol: "tetra", GroupID: 88, SourceID: 5150},
+	}, base)
+
+	srv, teardown := mkServer(t, ServerOptions{
+		Bus:          bus,
+		Affiliations: &fakeAffiliationProvider{},
+		History:      HistoryFromStorage(db),
+	})
+	defer teardown()
+
+	resp, err := http.Get(srv + "/api/v1/rids/5150")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200 (found via call log)", resp.StatusCode)
+	}
+	var got RIDDTO
+	json.NewDecoder(resp.Body).Decode(&got)
+	if got.ID != 5150 || got.CallCount != 2 || got.LastTalkgroup != 88 {
+		t.Errorf("got = %+v, want ID=5150 CallCount=2 LastTalkgroup=88", got)
 	}
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -608,6 +608,10 @@ type CallRow struct {
 	Encrypted   bool   `json:"encrypted"`
 	Emergency   bool   `json:"emergency"`
 	DataCall    bool   `json:"data_call"`
+	// Individual is true for a unit-to-unit / private call, where GroupID is a
+	// target radio's SSI rather than a talkgroup — so the WebUI can render the
+	// call as individual instead of mistaking the radio ID for a talkgroup.
+	Individual bool `json:"individual,omitempty"`
 	// Timeslot is the 1-based DMR TDMA slot (0 = n/a, 1 = TS1, 2 = TS2).
 	Timeslot       uint8     `json:"timeslot,omitempty"`
 	DeviceSerial   string    `json:"device_serial"`

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -483,6 +483,38 @@ type HistoryQuery interface {
 	History(ctx context.Context, f HistoryFilter) ([]CallRow, error)
 }
 
+// RIDSummary is the durable per-radio aggregate the Radio IDs list falls back to
+// (mirrors storage.RIDSummary in the api layer). It is derived from the
+// persisted call_log, so a radio stays in the list after the live affiliation
+// tracker's 30-minute idle TTL sweeps it — the fix for the RID list appearing to
+// "reset after each CC lock" (it was really the TTL expiring during re-hunt gaps
+// with no persistence behind it).
+type RIDSummary struct {
+	SourceID      uint32
+	System        string
+	Protocol      string
+	LastTalkgroup uint32
+	CallCount     uint64
+	FirstSeen     time.Time
+	LastSeen      time.Time
+	SourceAlpha   string
+}
+
+// RIDSummaryFilter narrows RIDSummaries (mirrors storage.RIDSummaryFilter).
+type RIDSummaryFilter struct {
+	System   string
+	SourceID uint32
+	Limit    int
+}
+
+// RIDSummaryProvider is the optional capability a HistoryQuery may implement to
+// supply the durable, all-time per-radio aggregates from the persisted call log.
+// The storage-backed adapter implements it; test fakes may omit it, in which
+// case the Radio IDs list degrades to the static catalogue + live tracker only.
+type RIDSummaryProvider interface {
+	RIDSummaries(ctx context.Context, f RIDSummaryFilter) ([]RIDSummary, error)
+}
+
 // LocationFix is one geographic fix returned by GET /api/v1/locations.
 type LocationFix struct {
 	System     string  `json:"system"`

--- a/internal/api/storage_adapter.go
+++ b/internal/api/storage_adapter.go
@@ -115,6 +115,7 @@ func (s *storageHistory) History(ctx context.Context, f HistoryFilter) ([]CallRo
 			Encrypted:      r.Encrypted,
 			Emergency:      r.Emergency,
 			DataCall:       r.DataCall,
+			Individual:     r.Individual,
 			Timeslot:       r.Timeslot,
 			DeviceSerial:   r.DeviceSerial,
 			StartedAt:      r.StartedAt,

--- a/internal/api/storage_adapter.go
+++ b/internal/api/storage_adapter.go
@@ -62,6 +62,34 @@ type storageHistory struct {
 	db *storage.DB
 }
 
+// RIDSummaries delegates to storage.DB.RIDSummaries, mapping the storage row
+// type to the api one. This makes storageHistory a RIDSummaryProvider, so the
+// Radio IDs list is backed by the persisted call log.
+func (s *storageHistory) RIDSummaries(ctx context.Context, f RIDSummaryFilter) ([]RIDSummary, error) {
+	rows, err := s.db.RIDSummaries(ctx, storage.RIDSummaryFilter{
+		System:   f.System,
+		SourceID: f.SourceID,
+		Limit:    f.Limit,
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]RIDSummary, len(rows))
+	for i, r := range rows {
+		out[i] = RIDSummary{
+			SourceID:      r.SourceID,
+			System:        r.System,
+			Protocol:      r.Protocol,
+			LastTalkgroup: r.LastTalkgroup,
+			CallCount:     r.CallCount,
+			FirstSeen:     r.FirstSeen,
+			LastSeen:      r.LastSeen,
+			SourceAlpha:   r.SourceAlpha,
+		}
+	}
+	return out, nil
+}
+
 func (s *storageHistory) History(ctx context.Context, f HistoryFilter) ([]CallRow, error) {
 	rows, err := s.db.History(ctx, storage.HistoryFilter{
 		System:    f.System,

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -444,6 +444,29 @@ func ridToDTO(r *trunking.RID) *RIDDTO {
 	}
 }
 
+// mergeRIDSummary applies the durable, call-log-derived aggregate fields to the
+// DTO. If dto is nil a fresh, non-Configured DTO is returned for the persisted
+// row (a radio seen over the air but not in the static catalogue). Applied
+// BENEATH mergeRIDLive: the live tracker, when it still holds the radio, wins for
+// the most-recent columns; this fills them in for radios the tracker has swept.
+func mergeRIDSummary(dto *RIDDTO, s RIDSummary) *RIDDTO {
+	if dto == nil {
+		dto = &RIDDTO{ID: s.SourceID, Watch: true}
+	}
+	dto.System = s.System
+	dto.Protocol = s.Protocol
+	if s.LastTalkgroup != 0 {
+		dto.LastTalkgroup = s.LastTalkgroup
+	}
+	if s.SourceAlpha != "" && dto.TalkerAlias == "" {
+		dto.TalkerAlias = s.SourceAlpha
+	}
+	dto.CallCount = s.CallCount
+	dto.FirstSeen = s.FirstSeen
+	dto.LastSeen = s.LastSeen
+	return dto
+}
+
 // mergeRIDLive applies the live UnitActivity fields to the DTO. If
 // dto is nil a fresh, non-Configured DTO is returned for the live row.
 func mergeRIDLive(dto *RIDDTO, u trunking.UnitActivity) *RIDDTO {

--- a/internal/radio/tetra/dmo_decode.go
+++ b/internal/radio/tetra/dmo_decode.go
@@ -92,16 +92,23 @@ func dmDNBType5(b DMBurst) []byte {
 // vocoder — or nil when the class-2 CRC fails (a non-speech burst, a signalling
 // slot, or a corrupted slot), exactly like the TMO TCHSpeechFrames gate. colour
 // is the 30-bit DM colour code the traffic is scrambled with (§8.2.5.2); pass 0
-// for the spec default / common radio-to-radio DMO, matching the way the TMO
-// traffic path treats colour 0 as "no descramble".
+// for the spec default / common radio-to-radio DMO.
+//
+// The descramble is UNCONDITIONAL — including at colour 0. TETRA scrambling is
+// non-identity at colour 0 (NewScramblerTetra(0) seeds the LFSR to 0xC0000000,
+// §8.2.5.2 eq. 8.42), so a clear (TEA0) colour-0 DMO transmitter still scrambles
+// TCH/S with that seed, exactly as the DSB signalling is scrambled with colour 0
+// and DecodeDMSCHS/DecodeBSCH always descramble it. The earlier `if colour != 0`
+// skip (copied from TMO traffic.go, where the extended colour code is never 0)
+// left a real colour-0 DNB scrambled going into the Viterbi/CRC — the uniform
+// ~1/256 "half-wrong" metric the #1003 investigation measured and misread as
+// air-interface encryption. Descrambling with 0 is the fix (issue #1003).
 func DMBurstTCHSpeech(b DMBurst, colour uint32) [][]byte {
 	type5 := dmDNBType5(b)
 	if type5 == nil {
 		return nil
 	}
-	if colour != 0 {
-		type5 = framing.DescrambleTetra(type5, colour)
-	}
+	type5 = framing.DescrambleTetra(type5, colour)
 	return TCHSpeechFrames(framing.PackBitsMSB(type5))
 }
 
@@ -127,9 +134,9 @@ func DMBurstTCHSpeechSoft(b DMBurst, colour uint32) [][]byte {
 	diffs = append(diffs, b.SoftBKN1...)
 	diffs = append(diffs, b.SoftBKN2...)
 	llr := softType5FromDiffs(diffs, (4-b.Rotation)&3)
-	if colour != 0 {
-		llr = framing.DescrambleTetraSoft(llr, colour)
-	}
+	// Descramble unconditionally, including at colour 0 (seed 0xC0000000 is
+	// non-identity) — the soft twin of the DMBurstTCHSpeech fix (issue #1003).
+	llr = framing.DescrambleTetraSoft(llr, colour)
 	return TCHSpeechFramesSoft(llr)
 }
 

--- a/internal/radio/tetra/dmo_decode_test.go
+++ b/internal/radio/tetra/dmo_decode_test.go
@@ -93,17 +93,22 @@ func TestDMSCHSRoundTrip(t *testing.T) {
 // split into a DNB's two blocks → ExtractDMBursts → DMBurstTCHSpeech recovers
 // the exact speech frames, CRC-valid. Runs at colour 0 (the default) and a
 // non-zero DM colour code to exercise the descramble seed.
+//
+// The colour-0 iteration is the failing-first regression for issue #1003: the
+// encode side scrambles UNCONDITIONALLY (a real DMO transmitter scrambles TCH/S
+// with the DM colour code even at colour 0 — seed 0xC0000000, §8.2.5.2), so a
+// decoder that skipped descramble at colour 0 leaves the block scrambled and the
+// class-2 CRC fails. Before this test scrambled encode-side only when colour!=0,
+// mirroring the decoder's skip, so the round-trip passed either way and hid the
+// bug (the #764/#771 self-consistent-synthetic trap).
 func TestDMTCHSpeechRoundTrip(t *testing.T) {
 	for _, colour := range []uint32{0, 0x0AB1F} {
 		frameA := seqBits(7, tchSpeechFrameBits)
 		frameB := seqBits(9, tchSpeechFrameBits)
 
-		descrambled := framing.UnpackBitsMSB(EncodeTCHS(frameA, frameB), tchType3Bits) // 432 type-4 bits
-		onair := descrambled
-		if colour != 0 {
-			onair = framing.ScrambleTetra(descrambled, colour)
-		}
-		block1 := onair[:dmBlockDibits*2] // first 216 bits → BKN1
+		type4 := framing.UnpackBitsMSB(EncodeTCHS(frameA, frameB), tchType3Bits) // 432 type-4 bits
+		onair := framing.ScrambleTetra(type4, colour)                            // scrambled like real air, incl. colour 0
+		block1 := onair[:dmBlockDibits*2]                                        // first 216 bits → BKN1
 		block2 := onair[dmBlockDibits*2:] // last 216 bits → BKN2
 
 		bursts := ExtractDMBursts(buildDNB(block1, block2), 0)
@@ -131,7 +136,8 @@ func TestDMTCHSpeechRoundTrip(t *testing.T) {
 func TestDMTCHSpeechRotation(t *testing.T) {
 	frameA := seqBits(3, tchSpeechFrameBits)
 	frameB := seqBits(11, tchSpeechFrameBits)
-	onair := framing.UnpackBitsMSB(EncodeTCHS(frameA, frameB), tchType3Bits)
+	// Scrambled with colour 0 like real air (seed 0xC0000000), decoded with 0.
+	onair := framing.ScrambleTetra(framing.UnpackBitsMSB(EncodeTCHS(frameA, frameB), tchType3Bits), 0)
 	base := buildDNB(onair[:dmBlockDibits*2], onair[dmBlockDibits*2:])
 
 	for rot := uint8(1); rot < 4; rot++ {
@@ -200,11 +206,8 @@ func TestDMTCHSpeechSoftRoundTripClean(t *testing.T) {
 	for _, colour := range []uint32{0, 0x0AB1F} {
 		frameA := seqBits(7, tchSpeechFrameBits)
 		frameB := seqBits(9, tchSpeechFrameBits)
-		descrambled := framing.UnpackBitsMSB(EncodeTCHS(frameA, frameB), tchType3Bits)
-		onair := descrambled
-		if colour != 0 {
-			onair = framing.ScrambleTetra(descrambled, colour)
-		}
+		// Scrambled like real air at every colour, incl. 0 (seed 0xC0000000).
+		onair := framing.ScrambleTetra(framing.UnpackBitsMSB(EncodeTCHS(frameA, frameB), tchType3Bits), colour)
 
 		// Build a DNB and its parallel ideal differentials (sigma 0), then run the
 		// soft-capable extractor over the correlated stream so the soft fields come
@@ -250,7 +253,8 @@ func TestDMTCHSpeechSoftRoundTripClean(t *testing.T) {
 func TestDMTCHSpeechSoftOutperformsHardUnderNoise(t *testing.T) {
 	frameA := seqBits(7, tchSpeechFrameBits)
 	frameB := seqBits(9, tchSpeechFrameBits)
-	onair := framing.UnpackBitsMSB(EncodeTCHS(frameA, frameB), tchType3Bits) // colour 0
+	// colour 0, scrambled like real air (seed 0xC0000000); both paths descramble.
+	onair := framing.ScrambleTetra(framing.UnpackBitsMSB(EncodeTCHS(frameA, frameB), tchType3Bits), 0)
 
 	rng := rand.New(rand.NewSource(42))
 	const (

--- a/internal/radio/tetra/dmo_decode_test.go
+++ b/internal/radio/tetra/dmo_decode_test.go
@@ -109,7 +109,7 @@ func TestDMTCHSpeechRoundTrip(t *testing.T) {
 		type4 := framing.UnpackBitsMSB(EncodeTCHS(frameA, frameB), tchType3Bits) // 432 type-4 bits
 		onair := framing.ScrambleTetra(type4, colour)                            // scrambled like real air, incl. colour 0
 		block1 := onair[:dmBlockDibits*2]                                        // first 216 bits → BKN1
-		block2 := onair[dmBlockDibits*2:] // last 216 bits → BKN2
+		block2 := onair[dmBlockDibits*2:]                                        // last 216 bits → BKN2
 
 		bursts := ExtractDMBursts(buildDNB(block1, block2), 0)
 		dnb := findBurst(bursts, DMBurstNormal)

--- a/internal/storage/calllog.go
+++ b/internal/storage/calllog.go
@@ -363,6 +363,116 @@ func (d *DB) History(ctx context.Context, f HistoryFilter) ([]CallRow, error) {
 	return out, rows.Err()
 }
 
+// RIDSummary is one aggregated per-radio (source_id) row derived from the
+// persisted call_log. It is the durable, all-time view of a radio the Radio IDs
+// list falls back to when the in-memory affiliation tracker has swept the radio
+// out of its 30-minute idle window (issue: RID list "reset after each CC lock").
+type RIDSummary struct {
+	SourceID uint32
+	System   string // system of the most recent call
+	Protocol string // protocol of the most recent call
+	// LastTalkgroup is the group_id of the most recent GROUP call (individual=0)
+	// this radio was heard on; 0 when the radio has only ever made individual /
+	// unit-to-unit calls (whose group_id is a target radio, not a talkgroup).
+	LastTalkgroup uint32
+	CallCount     uint64
+	FirstSeen     time.Time
+	LastSeen      time.Time
+	// SourceAlpha is the resolved alias from the most recent call, "" if none.
+	SourceAlpha string
+}
+
+// RIDSummaryFilter narrows RIDSummaries.
+type RIDSummaryFilter struct {
+	System   string // "" = all systems
+	SourceID uint32 // 0 = all radios (filters call_log.source_id)
+	Limit    int    // <= 0 = all radios
+}
+
+// RIDSummaries aggregates the call_log by source_id (radio ID) into a durable
+// per-radio view: total call count, first/last-seen, and the system, protocol,
+// alias and last GROUP talkgroup of the most recent call. Rows with source_id 0
+// (unknown source) are excluded. Ordered by most-recently-seen first.
+//
+// This is the persisted basis for the Radio IDs list, so an observed radio no
+// longer collapses out of the list once the live affiliation tracker's 30-minute
+// idle TTL sweeps it — the list reflects every radio seen over the daemon's
+// lifetime and survives control-channel re-locks and restarts.
+func (d *DB) RIDSummaries(ctx context.Context, f RIDSummaryFilter) ([]RIDSummary, error) {
+	// agg supplies count/first/last per radio; the outer join pulls the most
+	// recent call's system/protocol/alias by matching its started_at, and a
+	// correlated subquery picks the last GROUP call's talkgroup (skipping
+	// individual calls, whose group_id is a target radio rather than a TG). The
+	// optional system / single-source filters appear once per block; args are
+	// bound in the order the blocks appear in the statement text (correlated
+	// subquery c2, then agg, then outer c).
+	filt := func(col string) (string, []any) {
+		frag := ""
+		var a []any
+		if f.System != "" {
+			frag += " AND " + col + "system = ?"
+			a = append(a, f.System)
+		}
+		if f.SourceID != 0 {
+			frag += " AND " + col + "source_id = ?"
+			a = append(a, f.SourceID)
+		}
+		return frag, a
+	}
+	c2Frag, c2Args := filt("c2.")
+	aggFrag, aggArgs := filt("")
+	outerFrag, outerArgs := filt("c.")
+	q := `SELECT c.source_id, agg.cnt, agg.first_seen, agg.last_seen,
+	             c.system, c.protocol, c.source_alpha,
+	             (SELECT c2.group_id FROM call_log c2
+	                WHERE c2.source_id = c.source_id AND c2.individual = 0` + c2Frag + `
+	                ORDER BY c2.started_at DESC LIMIT 1) AS last_tg
+	      FROM call_log c
+	      JOIN (SELECT source_id, COUNT(*) AS cnt,
+	                   MIN(started_at) AS first_seen, MAX(started_at) AS last_seen
+	              FROM call_log
+	              WHERE source_id != 0` + aggFrag + `
+	              GROUP BY source_id) agg
+	        ON agg.source_id = c.source_id AND agg.last_seen = c.started_at
+	      WHERE c.source_id != 0` + outerFrag + `
+	      GROUP BY c.source_id
+	      ORDER BY agg.last_seen DESC`
+	args := []any{}
+	args = append(args, c2Args...)
+	args = append(args, aggArgs...)
+	args = append(args, outerArgs...)
+	if f.Limit > 0 {
+		q += fmt.Sprintf(" LIMIT %d", f.Limit)
+	}
+
+	rows, err := d.sql.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("storage: query rid summaries: %w", err)
+	}
+	defer rows.Close()
+	var out []RIDSummary
+	for rows.Next() {
+		var s RIDSummary
+		var firstNs, lastNs int64
+		var srcAlpha sql.NullString
+		var lastTG sql.NullInt64
+		if err := rows.Scan(&s.SourceID, &s.CallCount, &firstNs, &lastNs,
+			&s.System, &s.Protocol, &srcAlpha, &lastTG); err != nil {
+			return nil, err
+		}
+		s.FirstSeen = time.Unix(0, firstNs).UTC()
+		s.LastSeen = time.Unix(0, lastNs).UTC()
+		if srcAlpha.Valid {
+			s.SourceAlpha = srcAlpha.String
+		}
+		if lastTG.Valid {
+			s.LastTalkgroup = uint32(lastTG.Int64)
+		}
+		out = append(out, s)
+	}
+	return out, rows.Err()
+}
+
 func boolToInt(b bool) int {
 	if b {
 		return 1

--- a/internal/trunking/engine.go
+++ b/internal/trunking/engine.go
@@ -598,6 +598,19 @@ func (e *Engine) HandleGrant(g Grant) {
 	if g.Individual {
 		e.noteRadio(g.GroupID, g.System)
 	}
+	// If the grant is addressed to an SSI already known to be a subscriber radio
+	// (seen transmitting, or previously flagged individual), its "talkgroup" is
+	// really a unit-to-unit destination — reclassify so the call is recorded and
+	// surfaced as an INDIVIDUAL call, not filed under a phantom talkgroup named
+	// after the radio ID (the leaked "fake TG" recordings the operator reported:
+	// on-disk under recordings/<system>/<radioID>/ while the WebUI talkgroup list
+	// never shows them). knownRadios is durable across control-channel re-locks —
+	// unlike the control channel's per-lock learned set, which is wiped on every
+	// re-hunt — so this catches radios learned anywhere in the session. GSSIs and
+	// ISSIs never overlap on TETRA, so a known radio is never a real talkgroup.
+	if !g.Individual && g.GroupID != 0 && e.isKnownRadio(g.GroupID) {
+		g.Individual = true
+	}
 	// Cancel a parked TETRA notification hold on this channel the moment any
 	// authoritative (source-bearing) grant for the same physical channel arrives —
 	// the real group grant has landed, so the notification must not spawn its ghost

--- a/internal/trunking/engine_test.go
+++ b/internal/trunking/engine_test.go
@@ -187,6 +187,57 @@ func TestEngineRetractsRadioIDLeakedAsTalkgroup(t *testing.T) {
 	}
 }
 
+// TestEngineReclassifiesKnownRadioGrantAsIndividual pins the "fake TG" recording
+// fix: a call addressed to an SSI already known to be a subscriber radio (seen
+// transmitting) is reclassified as an INDIVIDUAL call, so the recorder files it
+// as individual rather than under a phantom talkgroup named after the radio ID.
+// The reporter's captures showed hundreds of such src-bearing unit-to-unit grants
+// (GroupID in the radio-ID range) filed as fake talkgroups on disk while the
+// WebUI never listed them.
+func TestEngineReclassifiesKnownRadioGrantAsIndividual(t *testing.T) {
+	e, _, bus, _ := mkEngine(t, 2)
+	defer bus.Close()
+
+	// Reveal 1009267 as a transmitting radio in a group call → durable known radio.
+	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: 1020545, SourceID: 1009267,
+		FrequencyHz: 467_912_500, Timeslot: 1})
+	if !e.isKnownRadio(1009267) {
+		t.Fatalf("precondition: 1009267 should be a known radio after being a call source")
+	}
+
+	// Subscribe AFTER the reveal so the collector only sees the second call.
+	sub := bus.Subscribe()
+	defer sub.Close()
+	collector := &testBusCollector{}
+	done := make(chan struct{})
+	go func() { collector.drain(sub, 1, 500*time.Millisecond); close(done) }()
+
+	// A later grant ADDRESSED to that radio (GroupID = the radio ISSI) arriving as
+	// a plain group grant (Individual=false) with a caller — must be reclassified.
+	e.HandleGrant(Grant{System: "X", Protocol: "tetra", GroupID: 1009267, SourceID: 1005000,
+		FrequencyHz: 468_000_000, Timeslot: 2})
+	<-done
+
+	var cs *CallStart
+	for _, ev := range collector.snapshot() {
+		if ev.Kind == events.KindCallStart {
+			c := ev.Payload.(CallStart)
+			if c.Grant.GroupID == 1009267 {
+				cs = &c
+			}
+		}
+	}
+	if cs == nil {
+		t.Fatalf("no CallStart for the call to known radio 1009267; events=%+v", collector.snapshot())
+	}
+	if !cs.Grant.Individual {
+		t.Errorf("grant to known radio 1009267 not reclassified Individual: %+v", cs.Grant)
+	}
+	if e.talkgroups.Lookup(1009267) != nil {
+		t.Errorf("radio 1009267 must not be catalogued as a talkgroup")
+	}
+}
+
 // engineHasCallForTG reports whether any active (pool-bound) or observed
 // (control-only) call is labelled with talkgroup tg — the union the Active Calls
 // UI renders.

--- a/internal/voice/callmeta.go
+++ b/internal/voice/callmeta.go
@@ -37,6 +37,12 @@ type callMeta struct {
 	CallLength           int             `json:"call_length"`
 	CallLengthMs         int64           `json:"call_length_ms"`
 	Talkgroup            uint32          `json:"talkgroup"`
+	// Individual is a GopherTrunk extension (not in the trunk-recorder schema, so
+	// TR parsers ignore it): true marks a unit-to-unit / private call, where
+	// `talkgroup` is the target radio's SSI rather than a real talkgroup. Lets a
+	// consumer render the recording as an individual call instead of mistaking the
+	// radio ID for a talkgroup. Omitted (false) for ordinary group calls.
+	Individual           bool            `json:"individual,omitempty"`
 	TalkgroupTag         string          `json:"talkgroup_tag"`
 	TalkgroupDescription string          `json:"talkgroup_description"`
 	TalkgroupGroupTag    string          `json:"talkgroup_group_tag"`
@@ -120,6 +126,7 @@ func buildCallMeta(cs trunking.CallStart, startedAt, endedAt time.Time, callNum 
 		CallLength:   int(dur.Seconds()),
 		CallLengthMs: dur.Milliseconds(),
 		Talkgroup:    g.GroupID,
+		Individual:   g.Individual,
 		ColorCode:    -1, // trunk-recorder "unknown" sentinel
 		AudioType:    audioType,
 		ShortName:    g.System,

--- a/internal/voice/callmeta.go
+++ b/internal/voice/callmeta.go
@@ -16,27 +16,27 @@ import (
 // trunk-recorder's own "unknown" conventions (signal/noise = 999, color_code =
 // -1) or a best-effort 0 so a strict parser never trips on a missing key.
 type callMeta struct {
-	CallNum              int             `json:"call_num"`
-	Freq                 uint32          `json:"freq"`
-	FreqError            int             `json:"freq_error"`
-	Signal               int             `json:"signal"`
-	Noise                int             `json:"noise"`
-	SourceNum            int             `json:"source_num"`
-	RecorderNum          int             `json:"recorder_num"`
-	TDMASlot             int             `json:"tdma_slot"`
-	Phase2TDMA           int             `json:"phase2_tdma"`
-	StartTime            int64           `json:"start_time"`
-	StopTime             int64           `json:"stop_time"`
-	StartTimeMs          int64           `json:"start_time_ms"`
-	StopTimeMs           int64           `json:"stop_time_ms"`
-	Emergency            int             `json:"emergency"`
-	Priority             int             `json:"priority"`
-	Mode                 int             `json:"mode"`
-	Duplex               int             `json:"duplex"`
-	Encrypted            int             `json:"encrypted"`
-	CallLength           int             `json:"call_length"`
-	CallLengthMs         int64           `json:"call_length_ms"`
-	Talkgroup            uint32          `json:"talkgroup"`
+	CallNum      int    `json:"call_num"`
+	Freq         uint32 `json:"freq"`
+	FreqError    int    `json:"freq_error"`
+	Signal       int    `json:"signal"`
+	Noise        int    `json:"noise"`
+	SourceNum    int    `json:"source_num"`
+	RecorderNum  int    `json:"recorder_num"`
+	TDMASlot     int    `json:"tdma_slot"`
+	Phase2TDMA   int    `json:"phase2_tdma"`
+	StartTime    int64  `json:"start_time"`
+	StopTime     int64  `json:"stop_time"`
+	StartTimeMs  int64  `json:"start_time_ms"`
+	StopTimeMs   int64  `json:"stop_time_ms"`
+	Emergency    int    `json:"emergency"`
+	Priority     int    `json:"priority"`
+	Mode         int    `json:"mode"`
+	Duplex       int    `json:"duplex"`
+	Encrypted    int    `json:"encrypted"`
+	CallLength   int    `json:"call_length"`
+	CallLengthMs int64  `json:"call_length_ms"`
+	Talkgroup    uint32 `json:"talkgroup"`
 	// Individual is a GopherTrunk extension (not in the trunk-recorder schema, so
 	// TR parsers ignore it): true marks a unit-to-unit / private call, where
 	// `talkgroup` is the target radio's SSI rather than a real talkgroup. Lets a

--- a/internal/voice/recorder.go
+++ b/internal/voice/recorder.go
@@ -1499,6 +1499,14 @@ func (r *Recorder) directoryFor(cs trunking.CallStart) string {
 	if system == "" {
 		system = "unknown-system"
 	}
+	// A unit-to-unit / private (individual) call: GroupID is a target radio
+	// address, not a talkgroup. File it under an "individual" subtree keyed by the
+	// target SSI so these recordings never masquerade as phantom talkgroups — a
+	// radio-ID-named directory alongside real talkgroups that the WebUI talkgroup
+	// list never shows (the leaked "fake TG" recordings the operator reported).
+	if cs.Grant.Individual {
+		return filepath.Join(r.outDir, system, "individual", fmt.Sprintf("%d", cs.Grant.GroupID))
+	}
 	tgDir := fmt.Sprintf("%d", cs.Grant.GroupID)
 	if cs.Talkgroup != nil && cs.Talkgroup.AlphaTag != "" {
 		tgDir = sanitize(cs.Talkgroup.AlphaTag)

--- a/internal/voice/recorder_test.go
+++ b/internal/voice/recorder_test.go
@@ -31,6 +31,41 @@ func mkRecorder(t *testing.T, writeRaw bool) (*Recorder, *events.Bus, string) {
 	return r, bus, dir
 }
 
+// TestRecorderFilesIndividualCallsSeparately pins the "fake TG" recording fix:
+// a unit-to-unit / individual call (GroupID is a target radio ISSI, not a
+// talkgroup) is filed under <system>/individual/<ssi>/ so it never masquerades as
+// a phantom talkgroup directory alongside real talkgroups, and the call metadata
+// carries the individual flag. A group call is unaffected.
+func TestRecorderFilesIndividualCallsSeparately(t *testing.T) {
+	r, bus, dir := mkRecorder(t, false)
+	defer bus.Close()
+
+	group := trunking.CallStart{Grant: trunking.Grant{System: "Metro", GroupID: 1020545}}
+	if got, want := r.directoryFor(group), filepath.Join(dir, "Metro", "1020545"); got != want {
+		t.Errorf("group call dir = %q, want %q", got, want)
+	}
+
+	indiv := trunking.CallStart{Grant: trunking.Grant{System: "Metro", GroupID: 1009267, Individual: true}}
+	if got, want := r.directoryFor(indiv), filepath.Join(dir, "Metro", "individual", "1009267"); got != want {
+		t.Errorf("individual call dir = %q, want %q (must not be filed as a talkgroup)", got, want)
+	}
+
+	// The metadata sidecar marks the call individual so a consumer renders it as
+	// an individual call, not a talkgroup.
+	start := time.Unix(1_700_000_000, 0)
+	m := buildCallMeta(indiv, start, start.Add(3*time.Second), 1, true, nil, nil)
+	if !m.Individual {
+		t.Errorf("call meta Individual = false, want true")
+	}
+	if m.Talkgroup != 1009267 {
+		t.Errorf("call meta Talkgroup = %d, want 1009267 (the target ISSI)", m.Talkgroup)
+	}
+	gm := buildCallMeta(group, start, start.Add(3*time.Second), 2, true, nil, nil)
+	if gm.Individual {
+		t.Errorf("group call meta Individual = true, want false")
+	}
+}
+
 // TestRecorderCrossSiteDedup pins cross-site duplicate suppression: the same
 // call (talkgroup + source) heard on a second monitored system within the
 // window is skipped, a re-key on the same system is not, a different source on

--- a/samples/p25/README.md
+++ b/samples/p25/README.md
@@ -24,6 +24,37 @@ Two captures are most valuable, and you can drop either or both:
   most noise-fragile), and
 - an **LSM / CQPSK simulcast** site (the linear path).
 
+## Weak-signal voice (LDU) captures — the priority ask
+
+The captures above are control-channel recordings. The open **weak-signal voice**
+investigation needs the other kind: a **P25 Phase 1 C4FM voice-channel** recording
+of a *marginal* call — the scenario where a hardware radio (e.g. an Astro Spectra)
+decodes clean audio but GopherTrunk recovers only a handful of IMBE frames on the
+same antenna.
+
+Why this specific capture matters: the default C4FM voice receiver has **no channel
+equalizer and no soft-decision FEC** (a blind CMA/FSE equalizer exists only on the
+opt-in `cqpsk`/LSM path). Those are the two levers that roughly doubled TETRA yield
+on ISI-smeared / weak captures. Before porting either onto the C4FM path, we need a
+real weak call to (a) measure the baseline pre-FEC EVM / SNR / LDU yield and (b) A/B
+the change against — per the project rule that a green synthetic is not proof of an
+on-air fix.
+
+What to capture:
+
+- Tune the **voice channel** (the granted frequency), not the control channel, during
+  a call that is **weak / multipath-degraded** (the condition that fails today). A
+  clean, strong call will not exercise the missing equalizer.
+- C4FM (the FM-discriminator path). If the site is LSM/CQPSK, capture that too and set
+  `demod_mode: "cqpsk"`.
+- Include the same call decoded by the reference radio if possible (note it in
+  `tool_cross_check`) so "hardware decodes, GT doesn't" is anchored to one signal.
+- Set `"expected": { "demod_mode": "c4fm" }` and leave the quality bounds out at first
+  (report-only); the harness logs EVM/SNR/LDU yield as the baseline to improve on.
+
+Drop it here as `*.cfile` + `*.metadata.json` (same format as below); the binary is
+git-ignored, the metadata sidecar is committed.
+
 ## Capture format
 
 | Property | Expected value |

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -466,6 +466,9 @@ export interface CallRow {
   key_id?: number;
   emergency?: boolean;
   data_call?: boolean;
+  // Individual (unit-to-unit / private) call: group_id is a target radio's
+  // SSI, not a talkgroup. Rendered as an individual call, not a talkgroup.
+  individual?: boolean;
   // TDMA timeslot, 1-based (1 = TS1, 2 = TS2; absent for non-slotted).
   timeslot?: number;
   device_serial?: string;

--- a/web/src/panels/History.tsx
+++ b/web/src/panels/History.tsx
@@ -95,9 +95,16 @@ export function History() {
       {
         key: "tg",
         header: "TG",
-        render: (r) => (
-          <span className="font-mono text-accent">{r.group_id}</span>
-        ),
+        render: (r) =>
+          r.individual ? (
+            // Individual (unit-to-unit) call: group_id is a target radio's SSI,
+            // not a talkgroup — label it as a radio ID so it is never read as a TG.
+            <span className="font-mono text-muted" title="Individual (unit-to-unit) call — this is a radio ID, not a talkgroup">
+              →{r.group_id}
+            </span>
+          ) : (
+            <span className="font-mono text-accent">{r.group_id}</span>
+          ),
         sort: (a, b) => a.group_id - b.group_id,
       },
       {
@@ -150,6 +157,11 @@ export function History() {
             )}
             {r.emergency && <span className="pill-err">emerg</span>}
             {r.data_call && <span className="pill">data</span>}
+            {r.individual && (
+              <span className="pill" title="Unit-to-unit / private call (not a talkgroup)">
+                individual
+              </span>
+            )}
           </div>
         ),
       },


### PR DESCRIPTION
DMBurstTCHSpeech/DMBurstTCHSpeechSoft skipped descrambling when the DM
colour code is 0, inheriting the TMO traffic.go `if colour != 0`
shortcut. That shortcut is safe in TMO only because a real cell's
extended colour code is never 0. TETRA scrambling is non-identity at
colour 0 — NewScramblerTetra(0) seeds the LFSR to 0xC0000000 (EN 300
392-2 §8.2.5.2 eq. 8.42) — which is exactly why DecodeBSCH/DecodeDMSCHS
always descramble and DMO signalling decodes. Leaving a clear (TEA0)
colour-0 DNB scrambled going into the Viterbi/CRC produced the uniform
~1/256 chance-floor metric that #1003 misread as air-interface
encryption. The reporter has since confirmed their DMO radios are TEA0
(clear), colour 0.

Fix: descramble the DMO TCH/S blocks unconditionally with the DM colour
code, matching the BSCH/DSB convention.

The synthetic round-trips previously scrambled and descrambled
consistently only when colour != 0, so they passed either way and hid
the asymmetry (the #764/#771 self-consistent-synthetic trap). The tests
now scramble the encode side unconditionally (real-air behaviour), so
the colour-0 iterations fail against the old skip and pass with the fix.

On-air verification is still open: the operator must replay their clear
438.9 MHz capture (GT_TETRA_DMO_IQ) and confirm tch_crc rises off the
chance floor. GT_TETRA_DMO_CLEAR=1 reframes the replay VERDICT so a
persistent chance floor on a known-clear capture reads as a decode
defect to keep chasing, not encryption. Refs #1003.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01211VK5En88GouToF4QixVd