### PR TITLE
TETRA: flush a never-superseded source-less notification as an individual call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,24 @@ for tagged releases.
   call-priority metadata to TETRA alongside P25 and DMR.
 
 ### Fixed
+- **TETRA radio IDs still leaked into recordings as phantom talkgroups when a
+  group grant was missed.** On a same-carrier site a group call's first
+  control-channel message is a source-less notification (`SourceID==0`, `dst=` the
+  calling radio's own SSI); the engine holds it 500 ms for the authoritative group
+  grant (`src=SSI dst=GSSI`) to supersede it. Under marginal RF that grant is
+  sometimes never decoded, so the hold flushed into a recording filed under the
+  radio ID as if it were a talkgroup (`recordings/<sys>/<radioID>/…`). The prior
+  safety only dropped the flush when the SSI was already a *known* radio — which
+  missed a radio never heard transmitting, and fired too late for one learned only
+  after the call opened (the retraction cleans the Talkgroups/observed lists but
+  never a live recording). A source-less TETRA notification is addressed to the
+  paged radio's own SSI, so a never-superseded one is now flushed as an
+  **individual** call to that SSI: filed under `recordings/<sys>/individual/<SSI>/`
+  with `"individual": true`, never masquerading as a talkgroup, and no longer
+  dropped (the voiced audio is preserved). No group is guessed; a call whose group
+  grant was entirely missed keeps the honest individual-call label rather than a
+  fabricated talkgroup, so its `srcList` reflects that (reconstructing the full
+  multi-talker list would require attributing the call to a group GT never decoded).
 - **DMR 2-slot voice: a wrong same-slot cadence guess could garble a whole
   call and never recover (reopened #644).** When a call opens on a section
   whose embedded Link Control doesn't decode, the interleaved decoder picks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,6 +217,32 @@ confirmation before any close-as-completed.
     persistent chance floor is now a *decode* defect to keep chasing (next suspects: DNB
     geometry, the DM colour code via `GT_TETRA_DMO_COLOUR`), NOT encryption. Do not mark
     #1003 verified until that A/B lands.
+  - **The A/B landed on a 2nd on-air capture and CLEAR VOICE DECODES — the missing piece is
+    the DM colour code, which is 3 here, NOT the 0 the signalling/CPS advertise.** The
+    operator's `10aug_dmo_test_bw144_cs16.raw` (438.9 MHz DMO, cs16, replay with
+    `GT_TETRA_DMO_RATE=144000`) locks signalling cleanly with the receiver CMA equalizer:
+    `dsb_schs_crc=44/45`, distinct FN advancing. At the default colour 0 TCH/S sits at the
+    chance floor (`tch_crc=1/269`), but a colour sweep is unambiguous: **`GT_TETRA_DMO_COLOUR=3`
+    → `tch_crc=35/269`, `speech_frames=70`, 2.1 s PCM, voice-active seconds [1-8]** (all other
+    colours 0-15 stay at the floor; LMS `GT_TETRA_DMO_LMS=1` doesn't help, 35→32). So the
+    signal is NOT weak/encrypted (signalling decodes at the same RF) — it is a real clear-voice
+    decode that only needs the correct DM colour code for the TCH/S descramble
+    (`DescrambleTetra(type5, colour)` in `dmo_decode.go`). GT parses the DM-SYNC PDU colour as
+    **0** (`ParseSyncPDU` reuses the TMO SYNC-PDU field layout), so the true DM colour code (3)
+    is never recovered and never reaches the traffic descramble — the prime suspect is a
+    DM-SYNC (EN 300 396-3) colour-code field offset that differs from the TMO SYNC PDU, or a
+    scrambler-seed mapping. Reproduce:
+    `GT_TETRA_DMO_IQ=<10aug .raw> GT_TETRA_DMO_RATE=144000 GT_TETRA_DMO_COLOUR=3 GT_TETRA_DMO_CLEAR=1
+    go test ./cmd/gophertrunk -run TestTETRADMOReplay -v`.
+  - **There is still NO production DMO decode pipeline.** `internal/scanner/ccdecoder/pipelines.go`
+    has one TETRA factory (`newTETRAPipeline`, the TMO CC state machine); a DMO capture runs
+    through it and every SCH burst fails because TMO NCDB geometry (`-115/+19`) ≠ DMO DNB
+    (`-108/+11`) — while BSCH still "locks" (DMO DSB SCH/S is colour-0-scrambled like TMO BSCH),
+    which is exactly the operator's live symptom (`sch_pdus=0`, constant `sync gap` / `dsp
+    resync`). The `ExtractDMBursts*`/`DecodeDMSCHS/H`/`DMBurstTCHSpeech*` decoders exist only in
+    `TestTETRADMOReplay`. Getting live DMO voice is a **feature**: wire a DMO pipeline (DMO
+    geometry + frame/sync-gap/resync timing + colour-code recovery, reusing the receiver's
+    `EnableEqualizer`/`SoftSink`) — design-first, its own commit, on-air A/B before closing #1003.
 - **P25 Phase 1 weak-signal voice is the under-equipped decode path — diagnosed, NOT yet
   fixed (needs a capture).** An operator whose hardware Astro Spectra decodes a marginal
   P25 Phase 1 voice call cleanly gets only ~4-5 IMBE frames from GT on the same antenna.

--- a/internal/trunking/engine.go
+++ b/internal/trunking/engine.go
@@ -551,12 +551,16 @@ func (e *Engine) dropHeldNotification(key channelKey) {
 }
 
 // flushHeldGrant handles a notification whose hold window expired with no
-// authoritative group grant to supersede it. If the destination is a known radio
-// SSI, this was a wakeup page for a call whose group grant we never saw — recording
-// under the radio ID is the leak the hold exists to prevent, so it is discarded.
-// Otherwise the destination is a real talkgroup (GSSI) or a genuinely-unknown
-// target, so it allocates (heldFromWakeup skips the hold on re-entry). Runs on the
-// Run goroutine via heldFlush. A no-op if the notification was already cancelled.
+// authoritative group grant to supersede it. A source-less TETRA notification is
+// addressed to the paged radio's own SSI (the calling party), so its GroupID is a
+// subscriber ISSI, never a talkgroup — regardless of whether that SSI has been
+// learned yet. Recording it under the raw ID is exactly the leak the hold exists
+// to prevent (a radio-ID-named "talkgroup" directory), and simply dropping it
+// loses the voiced audio the over actually carried. So flush it as an INDIVIDUAL
+// call to that SSI: recorder.dirFor files it under recordings/<sys>/individual/
+// <SSI>/ with individual=true, and it never masquerades as a phantom talkgroup.
+// Runs on the Run goroutine via heldFlush. A no-op if the notification was already
+// cancelled.
 func (e *Engine) flushHeldGrant(key channelKey) {
 	e.mu.Lock()
 	h := e.held[key]
@@ -568,15 +572,14 @@ func (e *Engine) flushHeldGrant(key channelKey) {
 		return
 	}
 	g := h.grant
-	if e.isKnownRadio(g.GroupID) {
-		// Destination is a learned radio ID — a notification whose group grant was
-		// missed/too-late. Do NOT record under the radio ID (that is the leak).
-		e.log.Debug("tetra: dropping held notification to a known radio (no group grant superseded it)",
-			"grant", g.String())
-		return
-	}
+	// heldFromWakeup skips the re-entry hold; Individual routes the recording to the
+	// individual subtree, skips the talkgroup discovery/catalogue guard, and (via
+	// noteRadio on the Individual dst) retracts any phantom talkgroup already
+	// catalogued for this SSI. No group is guessed — the call is honestly labelled a
+	// call to the addressed radio.
 	g.heldFromWakeup = true
-	e.log.Debug("tetra: flushing held notification grant (no group grant superseded it)",
+	g.Individual = true
+	e.log.Debug("tetra: flushing source-less notification as an individual call (no group grant superseded it)",
 		"grant", g.String())
 	e.HandleGrant(g)
 }

--- a/internal/trunking/engine_tetra_test.go
+++ b/internal/trunking/engine_tetra_test.go
@@ -135,11 +135,13 @@ func TestEngineTETRANotificationDoesNotDiscoverTalkgroup(t *testing.T) {
 	}
 }
 
-// TestEngineTETRANotificationToKnownRadioDropped guards that a held notification
-// targeting a KNOWN radio SSI that no group grant ever supersedes is DROPPED at
-// flush, not recorded under the radio ID — recording under a radio ID is exactly
-// the leak the hold exists to prevent.
-func TestEngineTETRANotificationToKnownRadioDropped(t *testing.T) {
+// TestEngineTETRANotificationToKnownRadioRecordsIndividual: a held notification
+// targeting a KNOWN radio SSI that no group grant ever supersedes is recorded as an
+// INDIVIDUAL call to that SSI at flush — filed under recordings/<sys>/individual/
+// <SSI>/, never under a phantom talkgroup named after the radio ID (the leak the
+// hold exists to prevent). It is NOT dropped: dropping lost the voiced audio the
+// over actually carried, which the operator wants preserved.
+func TestEngineTETRANotificationToKnownRadioRecordsIndividual(t *testing.T) {
 	e, pool, bus, _ := mkEngine(t, 2)
 	defer bus.Close()
 	e.afterFunc = noFireAfterFunc
@@ -156,28 +158,42 @@ func TestEngineTETRANotificationToKnownRadioDropped(t *testing.T) {
 		t.Fatalf("active calls after notification = %d, want 0 (held)", n)
 	}
 
-	// Flush with no group grant: destination is a known radio → dropped, not recorded.
+	// Flush with no group grant: recorded as an individual call to the SSI, never a TG.
 	e.flushHeldGrant(channelKeyOf(page))
-	if n := len(pool.Active()); n != 0 {
-		t.Fatalf("active calls after flush = %d, want 0 (notification to a known radio must not record)", n)
+	act := pool.Active()
+	if len(act) != 1 {
+		t.Fatalf("active calls after flush = %d, want 1 (individual call must record)", len(act))
+	}
+	if !act[0].Grant.Individual {
+		t.Errorf("flushed call Individual = false, want true (must not masquerade as a talkgroup)")
+	}
+	if got := act[0].Grant.GroupID; got != issi {
+		t.Errorf("flushed call GroupID = %d, want %d (the addressed radio SSI)", got, issi)
+	}
+	if tg := e.talkgroups.Lookup(issi); tg != nil {
+		t.Errorf("radio SSI %d catalogued as a talkgroup: %+v", issi, tg)
 	}
 }
 
-// TestEngineTETRANotificationToTalkgroupFlushes guards the legitimate case: a
-// source-less notification addressed to a real talkgroup (not a known radio) that
-// no group grant supersedes still records under that talkgroup once the window
-// expires — the hold must not silently drop a real (if unattributed) group call.
-func TestEngineTETRANotificationToTalkgroupFlushes(t *testing.T) {
+// TestEngineTETRANotificationToUnknownSSIRecordsIndividual is the failing-first
+// regression for the exact leak the operator reported (RID 1005497 / 1005557): a
+// source-less notification whose dst was NEVER seen transmitting (so it is not yet
+// a known radio) and that no group grant supersedes was recorded under the raw
+// radio ID as a phantom talkgroup ("recordings/<sys>/1005497/…", Individual=false).
+// A source-less TETRA notification is always addressed to the paged radio's own
+// SSI, so even an as-yet-unknown dst is a radio, never a real talkgroup. It must now
+// flush to an INDIVIDUAL call. (Old code: Individual=false → fails here.)
+func TestEngineTETRANotificationToUnknownSSIRecordsIndividual(t *testing.T) {
 	e, pool, bus, _ := mkEngine(t, 2)
 	defer bus.Close()
 	e.afterFunc = noFireAfterFunc
 
 	const (
 		freq = uint32(467_912_500)
-		ts   = uint8(1)
-		gssi = uint32(1020545) // a talkgroup — never learned as a radio
+		ts   = uint8(2)
+		issi = uint32(1005497) // reported leak: a radio never seen transmitting
 	)
-	page := Grant{System: "X", Protocol: "tetra", GroupID: gssi, FrequencyHz: freq, Timeslot: ts}
+	page := Grant{System: "X", Protocol: "tetra", GroupID: issi, FrequencyHz: freq, Timeslot: ts}
 	e.HandleGrant(page)
 	if n := len(pool.Active()); n != 0 {
 		t.Fatalf("active calls after notification = %d, want 0 (held)", n)
@@ -186,10 +202,16 @@ func TestEngineTETRANotificationToTalkgroupFlushes(t *testing.T) {
 	e.flushHeldGrant(channelKeyOf(page))
 	act := pool.Active()
 	if len(act) != 1 {
-		t.Fatalf("active calls after flush = %d, want 1 (talkgroup call must record)", len(act))
+		t.Fatalf("active calls after flush = %d, want 1 (individual call must record)", len(act))
 	}
-	if got := act[0].Grant.GroupID; got != gssi {
-		t.Errorf("flushed call talkgroup = %d, want %d", got, gssi)
+	if !act[0].Grant.Individual {
+		t.Errorf("flushed call Individual = false, want true (RID must not become a phantom talkgroup)")
+	}
+	if got := act[0].Grant.GroupID; got != issi {
+		t.Errorf("flushed call GroupID = %d, want %d", got, issi)
+	}
+	if tg := e.talkgroups.Lookup(issi); tg != nil {
+		t.Errorf("RID %d catalogued as a phantom talkgroup: %+v", issi, tg)
 	}
 }
 


### PR DESCRIPTION
On a same-carrier TETRA site a group call's first control-channel message is a
source-less notification (SourceID==0, dst = the calling radio's own SSI); the
engine holds it 500 ms for the authoritative group grant (src=SSI dst=GSSI) to
supersede it. Under marginal RF that grant is sometimes never decoded, so the
hold flushed into a recording filed under the radio ID as if it were a talkgroup
(recordings/<sys>/<radioID>/...), leaking the RID as a phantom talkgroup.

The prior flush safety only dropped when the dst was an ALREADY-known radio,
which missed a radio never heard transmitting (RID 1005497 in the operator's
capture) and fired too late for one learned only after the call opened (1005557 —
the subscriber-retraction cleans the Talkgroups/observed lists but never a live
recording). Dropping also lost the voiced audio the over carried.

A source-less TETRA notification is addressed to the paged radio's own SSI, so a
never-superseded one is now flushed as an INDIVIDUAL call to that SSI: recorded
under recordings/<sys>/individual/<SSI>/ with individual=true, never masquerading
as a talkgroup, and no longer dropped. No group is guessed.

Failing-first regression: the two rewritten flush tests fail on the prior tree
(known-radio dropped -> 0 active; unknown SSI recorded as a phantom TG with
Individual=false) and pass with the fix.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FaALYS7ePdg2Vcm8CmQS6V