### PR TITLE
fix(composer): route conventional analog "fm-conv" grants to the FM chain

### DIFF
--- a/internal/voice/composer/composer.go
+++ b/internal/voice/composer/composer.go
@@ -457,7 +457,12 @@ func (c *Composer) handleStart(parent context.Context, cs trunking.CallStart) {
 	// sidecar rather than FM-demodulated into garbage.
 	isAnalogTrunk := proto == "motorola" || proto == "ltr" || proto == "mpt1327" ||
 		(proto == "edacs" && !cs.Grant.ProVoice)
-	isFM := proto == "" || proto == "fm" || proto == "analog" || isAnalogTrunk
+	// The conventional scanner tags its analog channels "fm-conv"
+	// (internal/scanner/conventional/scanner.go). Like the analog-trunk voice
+	// channels above, there is no digital sync to decode — the channel is
+	// FM-demodulated continuously straight into the recorder, so it routes
+	// through the same runFMChain path.
+	isFM := proto == "" || proto == "fm" || proto == "fm-conv" || proto == "analog" || isAnalogTrunk
 	isDMRVoice := proto == "dmr-tier1" || proto == "dmr-tier2" || proto == "dmr-tier3"
 	isP25P2Voice := proto == "p25-phase2"
 	isP25P1Voice := proto == "p25"

--- a/internal/voice/composer/composer_test.go
+++ b/internal/voice/composer/composer_test.go
@@ -546,6 +546,34 @@ func TestComposerRunsFMChainForAnalogTrunking(t *testing.T) {
 	}
 }
 
+// TestComposerRunsFMChainForConventional pins the #1075 regression: a
+// conventional analog channel (tagged "fm-conv" by the conventional scanner)
+// must build the FM passthrough chain rather than hit the digital-protocol
+// bypass. Before the fix "fm-conv" was absent from the isFM set, so these
+// grants were logged as "digital protocol not yet decoded; chain bypassed",
+// no chain was spawned, no PCM reached the recorder, and no WAV was written.
+func TestComposerRunsFMChainForConventional(t *testing.T) {
+	src := newFakeSource()
+	c, bus, _, _, teardown := mkComposer(t, src)
+	defer teardown()
+	bus.Publish(events.Event{
+		Kind: events.KindCallStart,
+		Payload: trunking.CallStart{
+			Grant:        trunking.Grant{Protocol: "fm-conv", GroupID: 0x80000000, FrequencyHz: 146_670_000},
+			DeviceSerial: "VOICE-1",
+			StartedAt:    time.Now().UTC(),
+		},
+	})
+	waitFor(t, time.Second, func() bool {
+		for _, s := range c.ActiveChains() {
+			if s == "VOICE-1" {
+				return true
+			}
+		}
+		return false
+	})
+}
+
 func TestComposerBypassesEDACSProVoice(t *testing.T) {
 	src := newFakeSource()
 	c, bus, _, _, teardown := mkComposer(t, src)


### PR DESCRIPTION
Conventional analog FM channels (scanner.conventional) never produced
audio: the conventional scanner tags its grants Protocol="fm-conv"
(internal/scanner/conventional/scanner.go), but the composer's isFM gate
only recognised "", "fm", "analog" and the analog-trunk protocols. An
"fm-conv" grant therefore fell through to the digital-protocol branch,
logged "digital protocol not yet decoded; chain bypassed", built no
audio chain, and delivered no PCM to the recorder — so despite the
"recorder: call started" line naming a WAV path, no file was ever written.

There is nothing digital to decode on a conventional analog channel, so
"fm-conv" routes through runFMChain (continuous FM demod → recorder) just
like the analog-trunk voice channels. Add it to the isFM set.

Regression test TestComposerRunsFMChainForConventional fails first
(reproduces the exact "chain bypassed protocol=fm-conv" symptom) and
passes with the fix.

Refs #1075

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Rz2QtYuKDHtgnZmpYEQgWX