### PR TITLE
dmr/tier2: decode a repeater's two timeslots as separate calls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,6 +264,42 @@ confirmation before any close-as-completed.
        is self-contained) and the main risk.
     4. **On-air A/B** on the operator's capture through the full daemon (recording lands, audio
        intelligible) before marking #1003 verified. A green offline decode ≠ on-air correct.
+- **Conventional DMR (Tier II / IPSC) now decodes a repeater's TWO timeslots as two calls.**
+  A base-station DMR repeater carries TS1 and TS2 interleaved on one carrier, each able to hold
+  a separate simultaneous talkgroup. The conventional path (`internal/radio/dmr/tier2`) used to
+  collapse both: two symptoms — "DJ scratchy" audio (both slots' AMBE frames sliced into one
+  superframe) and two talkgroups ping-ponging into one call. Root cause was NOT the DSP: (1) the
+  composer picks single-slot vs interleaved decode from `Grant.DMRInterleavedVoice`, which Tier III
+  stamped but Tier II never did — `dmr_interleaved_voice: true` in config was computed
+  (`resolveDMRInterleavedVoice`, `daemon.go`) but dropped on the floor because `tier2.Options` had
+  no such field; (2) grants carried `Timeslot 0` with scalar `inCall/lastTG/lastSrc` state, so the
+  engine's `(freq, timeslot)` identity folded both slots. Fix wires `InterleavedVoice` through
+  `tier2.Options` + both constructors (`ccdecoder/pipelines.go`, `widebandt2/engine.go`; Tier I
+  direct mode stays single-slot), and replaces the scalar state with a per-destination map that
+  assigns each concurrent call a **synthetic** Timeslot (1/2) — an engine-identity token only; the
+  base-station wire format does NOT label a burst's physical slot (both slots share the BS sync
+  words and the slot-type field carries only colour+datatype), and the composer's `slotRouter`
+  routes audio by the embedded-LC talkgroup, not by this field. The Terminator-with-LC destination
+  is now decoded (RS seed `RS129SeedTerminatorLC`) so a TS1 terminator releases only its own call;
+  a lone active call still tears down promptly on an undecodable terminator, but with two concurrent
+  calls an undecodable terminator defers to per-chain hangtime rather than cross-tear the other slot.
+  Concurrent two-slot recording rides the pre-existing `dmrSameCarrierTaps = 2` taps (distinct
+  serials → no composer per-serial collision). Pinned by `conventional_twoslot_test.go` (failing-first).
+  **NOT yet on-air-verified (#764/#771 discipline):** the operator's only IQ grab
+  (`dmr_ipsc_60sec_bw25k_cs16.raw`, 25 kHz cs16) is a dead capture — ~−75 dBFS RMS, carrier at
+  −11.35 kHz, no frame sync — so the two-slot audio A/B still needs a decodable capture (a wideband
+  `.raw`, or a properly-gained single-channel one). The synthetic regressions + the operator's own
+  `debug.log` (interleaved never reaching the decoder; per-superframe log spam) corroborate the bug.
+  Sharp edge to watch on air: if the embedded LC never decodes (#644), both same-carrier taps'
+  `slotRouter`s fall back to phase parity and could bind the same phase (one slot recorded twice).
+- **DMR group calls are no longer relabeled "individual."** The engine's known-radio →
+  individual reclassification (`HandleGrant`, `internal/trunking/engine.go`) and `noteRadio`'s
+  talkgroup retraction rest on a TETRA-only invariant (GSSIs and ISSIs never overlap). DMR shares
+  one 24-bit space for talkgroup and radio IDs, so ungated it flipped DMR group calls whose TG
+  equalled some radio ID — mis-filing recordings under `individual/<TG>/` and corrupting the
+  `individual` column that backs the Radio IDs roster (its `LastTalkgroup` SQL excludes
+  `individual=1` rows). The whole mechanism is now scoped to `g.Protocol == "tetra"`; DMR's FLCO
+  classification is authoritative. Pinned by `engine_dmr_classify_test.go`.
 - **P25 Phase 1 weak-signal voice is the under-equipped decode path — diagnosed, NOT yet
   fixed (needs a capture).** An operator whose hardware Astro Spectra decodes a marginal
   P25 Phase 1 voice call cleanly gets only ~4-5 IMBE frames from GT on the same antenna.

--- a/internal/radio/dmr/tier2/conventional.go
+++ b/internal/radio/dmr/tier2/conventional.go
@@ -113,6 +113,12 @@ type ConventionalChannel struct {
 	// every colour code (the historical default).
 	colorFilter *uint8
 
+	// interleavedVoice is stamped onto every grant as Grant.DMRInterleavedVoice
+	// (see Options.InterleavedVoice) so the voice composer runs the two-slot
+	// interleaved decoder rather than slicing both timeslots into one garbled
+	// stream.
+	interleavedVoice bool
+
 	// proc is the cross-call dibit / sync state the Process adapter
 	// uses (see process.go). Lazily constructed on the first
 	// Process call.
@@ -122,9 +128,23 @@ type ConventionalChannel struct {
 	locked bool
 	last   LockState
 
-	inCall  bool
-	lastTG  uint32
-	lastSrc uint32
+	// calls tracks the in-progress calls on this repeater, keyed by decoded
+	// destination (the talkgroup for a group call, the called subscriber for a
+	// private call). A conventional DMR repeater carries two independent
+	// timeslots (TS1/TS2), each able to hold a separate simultaneous call, so a
+	// single scalar "current call" collapsed two concurrent talkgroups into one
+	// — the two Voice LC Headers alternate and ping-pong the state, and both
+	// grants carried Timeslot 0 so the engine folded them onto one (freq, 0)
+	// channel. Keying by destination lets the two calls coexist; each is given a
+	// synthetic Timeslot (see assignSlot) so the engine's (freq, timeslot) call
+	// identity keeps them apart. The base-station wire format does not label a
+	// burst's physical slot (both slots share the BS sync words), and the voice
+	// composer routes audio by the embedded-LC talkgroup rather than this field,
+	// so the synthetic slot is purely an engine-identity token and never
+	// mis-routes audio. Touched only on the single decode goroutine (like the
+	// scalar state it replaces), so it needs no lock; Counters() reads only the
+	// atomic cnt below.
+	calls map[uint32]*convCall
 
 	// cnt holds the lock-free decode-activity counters exposed via
 	// Counters(). Incremented on the existing hot paths with atomic
@@ -176,6 +196,15 @@ type Options struct {
 	// lock / decode-error. nil ⇒ accept every colour code. See the colorFilter
 	// field on ConventionalChannel.
 	ColorCodeFilter *uint8
+	// InterleavedVoice stamps Grant.DMRInterleavedVoice so the voice composer
+	// runs the two-slot interleaved AMBE decoder instead of the single-slot one.
+	// A base-station repeater carries TS1 and TS2 interleaved on one carrier, so
+	// the single-slot decoder slices straight through both slots and produces
+	// garbled ("DJ scratchy") audio; the interleaved decoder + slotRouter route
+	// each slot's superframes by their embedded-LC talkgroup. Resolved per
+	// system (true for conventional Tier II, false for Tier I direct mode, which
+	// is genuinely single-slot). Mirrors tier3.Options.InterleavedVoice.
+	InterleavedVoice bool
 }
 
 // New constructs a ConventionalChannel.
@@ -193,14 +222,15 @@ func New(opts Options) *ConventionalChannel {
 		tag = "dmr-tier2"
 	}
 	return &ConventionalChannel{
-		bus:          opts.Bus,
-		log:          log,
-		systemName:   opts.SystemName,
-		freqHz:       opts.FrequencyHz,
-		now:          now,
-		protocolTag:  tag,
-		syncPatterns: opts.SyncPatterns,
-		colorFilter:  opts.ColorCodeFilter,
+		bus:              opts.Bus,
+		log:              log,
+		systemName:       opts.SystemName,
+		freqHz:           opts.FrequencyHz,
+		now:              now,
+		protocolTag:      tag,
+		syncPatterns:     opts.SyncPatterns,
+		colorFilter:      opts.ColorCodeFilter,
+		interleavedVoice: opts.InterleavedVoice,
 	}
 }
 
@@ -237,7 +267,7 @@ func (c *ConventionalChannel) IngestBurst(b *dmr.Burst, slot dmr.SlotType) {
 	case dmr.DTVoiceLCHeader:
 		c.handleVoiceHeader(b, slot)
 	case dmr.DTTerminatorWithLC:
-		c.handleTerminator()
+		c.handleTerminator(b, slot)
 	case dmr.DTCSBK:
 		c.handleCSBK(b, slot)
 	}
@@ -406,27 +436,46 @@ func (c *ConventionalChannel) handleVoiceHeader(b *dmr.Burst, slot dmr.SlotType)
 		c.log.Debug("dmr/tier2: non-voice FLCO ignored", "flco", flc.FLCO)
 		return
 	}
-	if c.inCall && c.lastTG == dest && c.lastSrc == src {
-		// Same call's repeated Voice LC Header — dedupe.
-		return
+	// Assign or refresh this call's synthetic timeslot. Concurrent calls on the
+	// repeater's two slots carry distinct destinations, so key by dest: a
+	// repeated header for the same (dest, src) is a dedupe; a header for a dest
+	// already in call whose source changed is a talker change on the same slot;
+	// a new dest claims the lowest free synthetic slot.
+	now := c.now()
+	if c.calls == nil {
+		c.calls = make(map[uint32]*convCall)
 	}
-	c.inCall = true
-	c.lastTG = dest
-	c.lastSrc = src
+	var ts uint8
+	if existing, ok := c.calls[dest]; ok {
+		existing.lastAt = now
+		if existing.src == src {
+			// Same call's repeated Voice LC Header — dedupe.
+			return
+		}
+		// Same destination, new talker: keep the slot, republish with the new
+		// source so the engine surfaces the talker change.
+		existing.src = src
+		ts = existing.slot
+	} else {
+		ts = c.assignSlot(now)
+		c.calls[dest] = &convCall{src: src, slot: ts, lastAt: now}
+	}
 	c.bus.Publish(events.Event{
 		Kind: events.KindGrant,
 		Payload: trunking.Grant{
-			System:      c.systemName,
-			Protocol:    c.protocolTag,
-			GroupID:     dest,
-			SourceID:    src,
-			Individual:  individual,
-			FrequencyHz: c.freqHz,
-			ChannelID:   slot.ColorCode,
-			Encrypted:   enc,
-			Emergency:   emer,
-			Priority:    prio,
-			At:          c.now(),
+			System:              c.systemName,
+			Protocol:            c.protocolTag,
+			GroupID:             dest,
+			SourceID:            src,
+			Individual:          individual,
+			FrequencyHz:         c.freqHz,
+			ChannelID:           slot.ColorCode,
+			Timeslot:            ts,
+			DMRInterleavedVoice: c.interleavedVoice,
+			Encrypted:           enc,
+			Emergency:           emer,
+			Priority:            prio,
+			At:                  c.now(),
 		},
 	})
 	c.log.Debug("dmr/tier2: grant",
@@ -435,30 +484,123 @@ func (c *ConventionalChannel) handleVoiceHeader(b *dmr.Burst, slot dmr.SlotType)
 		"individual", individual, "enc", enc, "emer", emer)
 }
 
-func (c *ConventionalChannel) handleTerminator() {
-	if !c.inCall {
+func (c *ConventionalChannel) handleTerminator(b *dmr.Burst, slot dmr.SlotType) {
+	if len(c.calls) == 0 {
 		return
 	}
+	// Resolve which of the (up to two) concurrent calls this terminator ends
+	// from its own Full LC destination, so a TS1 terminator cannot tear down the
+	// TS2 call. The Terminator-with-LC carries the same FLC as the Voice LC
+	// Header — group talkgroup or unit-to-unit destination — protected by
+	// BPTC(196,96) + RS(12,9) with the terminator parity seed.
+	dest, ok := c.terminatorDest(b)
+	if !ok {
+		// The terminator's Full LC did not decode. With a single call active the
+		// terminator is unambiguous, so end that call (preserving the prompt
+		// teardown Tier II has always done). With two concurrent calls it is
+		// ambiguous — releasing by a guess could cross-tear the other slot — so
+		// release nothing and let each voice chain's own terminator detector +
+		// hangtime end its call.
+		if len(c.calls) != 1 {
+			c.log.Debug("dmr/tier2: ambiguous terminator (LC undecodable, two calls active); leaving to hangtime",
+				"cc", slot.ColorCode)
+			return
+		}
+		for d := range c.calls {
+			dest = d
+		}
+	}
+	cc, tracked := c.calls[dest]
+	if !tracked {
+		// Terminator for a call we aren't tracking (already ended, or its header
+		// was never decoded) — harmless no-op.
+		return
+	}
+	delete(c.calls, dest)
 	// A Terminator with LC is the explicit end of the transmission. Publish a
 	// call release so the engine ends the call at once, rather than waiting out
 	// the composer's hangtime / no-voice timers — the same prompt-teardown path
-	// TETRA's D-RELEASE drives. Keyed by (System, GroupID); a no-match release
-	// is a harmless no-op.
-	if c.bus != nil && c.lastTG != 0 {
+	// TETRA's D-RELEASE drives. Keyed by (System, GroupID), which uniquely names
+	// this call among the concurrent slots.
+	if c.bus != nil && dest != 0 {
 		c.bus.Publish(events.Event{
 			Kind: events.KindCallRelease,
 			Payload: trunking.CallRelease{
 				System:  c.systemName,
-				GroupID: c.lastTG,
+				GroupID: dest,
 				Reason:  trunking.EndReasonReleased,
 				At:      c.now(),
 			},
 		})
 	}
-	c.inCall = false
-	c.lastTG = 0
-	c.lastSrc = 0
-	c.log.Debug("dmr/tier2: terminator")
+	c.log.Debug("dmr/tier2: terminator", "dst", dest, "slot", cc.slot)
+}
+
+// terminatorDest decodes a Terminator-with-LC burst's Full LC and returns the
+// call destination it names (talkgroup or called subscriber), or ok=false if
+// the embedded LC fails FEC. It mirrors handleVoiceHeader's BPTC + RS(12,9)
+// pipeline but with the terminator parity seed.
+func (c *ConventionalChannel) terminatorDest(b *dmr.Burst) (uint32, bool) {
+	bits, errs := framing.DecodeBPTC196_96(b.PayloadBits())
+	if errs < 0 {
+		return 0, false
+	}
+	infoBytes := infoBitsToBytes(bits)
+	if !framing.VerifyRS12_9(infoBytes, framing.RS129SeedTerminatorLC) {
+		return 0, false
+	}
+	flc, err := dmr.ParseFLC(infoBytes)
+	if err != nil {
+		return 0, false
+	}
+	if gv, ok := flc.AsGroupVoiceUser(); ok {
+		return gv.GroupAddress, true
+	}
+	if uu, ok := flc.AsUnitToUnitVoice(); ok {
+		return uu.DestinationID, true
+	}
+	return 0, false
+}
+
+// convCall is one in-progress conventional-DMR call. slot is the synthetic
+// timeslot (1 or 2) assigned to keep concurrent calls apart in the engine's
+// (frequency, timeslot) call identity; lastAt tracks liveness for slot reuse.
+type convCall struct {
+	src    uint32
+	slot   uint8
+	lastAt time.Time
+}
+
+// assignSlot returns a synthetic timeslot (1 then 2) for a new concurrent call.
+// A conventional DMR carrier runs at most two calls (one per TDMA slot); if
+// both synthetic slots are already in use — only possible when a prior call's
+// terminator was missed and its state went stale — the stalest call is evicted
+// and its slot reused. The engine's own call timeout reaps the evicted call.
+func (c *ConventionalChannel) assignSlot(now time.Time) uint8 {
+	var used1, used2 bool
+	var stalestDest uint32
+	var stalestAt time.Time
+	first := true
+	for dest, cc := range c.calls {
+		switch cc.slot {
+		case 1:
+			used1 = true
+		case 2:
+			used2 = true
+		}
+		if first || cc.lastAt.Before(stalestAt) {
+			stalestDest, stalestAt, first = dest, cc.lastAt, false
+		}
+	}
+	if !used1 {
+		return 1
+	}
+	if !used2 {
+		return 2
+	}
+	slot := c.calls[stalestDest].slot
+	delete(c.calls, stalestDest)
+	return slot
 }
 
 // infoBitsToBytes packs a 96-bit slice (each entry 0/1, MSB-first)

--- a/internal/radio/dmr/tier2/conventional_twoslot_test.go
+++ b/internal/radio/dmr/tier2/conventional_twoslot_test.go
@@ -1,0 +1,201 @@
+package tier2
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// burstWithTerminatorFLC builds a Terminator-with-LC-shaped burst carrying the
+// supplied FLC, using the terminator RS(12,9) parity seed (0x99…) — what a real
+// transmitter puts on air at end-of-call, and what terminatorDest decodes.
+func burstWithTerminatorFLC(f dmr.FLC) *dmr.Burst {
+	flcBytes := dmr.AssembleFLC(f)
+	var data [9]byte
+	copy(data[:], flcBytes)
+	cw := framing.EncodeRS12_9(data)
+	for i := 0; i < 3; i++ {
+		cw[9+i] ^= framing.RS129SeedTerminatorLC[i]
+	}
+	info := cw[:]
+
+	bits := make([]byte, 96)
+	for i := 0; i < 96; i++ {
+		bits[i] = (info[i>>3] >> uint(7-(i&7))) & 1
+	}
+	channel := framing.EncodeBPTC196_96(bits)
+
+	var b dmr.Burst
+	for i := 0; i < dmr.HalfPayloadDibits; i++ {
+		b.Dibits[i] = (channel[2*i] << 1) | channel[2*i+1]
+	}
+	for i := 0; i < dmr.HalfPayloadDibits; i++ {
+		b.Dibits[dmr.BurstDibits-dmr.HalfPayloadDibits+i] =
+			(channel[2*(dmr.HalfPayloadDibits+i)] << 1) | channel[2*(dmr.HalfPayloadDibits+i)+1]
+	}
+	return &b
+}
+
+// drainEvents collects every event published within d.
+func drainEvents(sub *events.Subscription, d time.Duration) []events.Event {
+	var out []events.Event
+	deadline := time.After(d)
+	for {
+		select {
+		case ev := <-sub.C:
+			out = append(out, ev)
+		case <-deadline:
+			return out
+		}
+	}
+}
+
+func grantsOf(evs []events.Event) []trunking.Grant {
+	var out []trunking.Grant
+	for _, ev := range evs {
+		if ev.Kind == events.KindGrant {
+			out = append(out, ev.Payload.(trunking.Grant))
+		}
+	}
+	return out
+}
+
+// TestConventionalStampsInterleavedVoice pins the audio fix: Options.Interleaved-
+// Voice is stamped onto the grant as DMRInterleavedVoice so the composer runs
+// the two-slot interleaved decoder. Default (Tier I direct mode) stays false.
+func TestConventionalStampsInterleavedVoice(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		interleaved bool
+	}{
+		{"interleaved on (Tier II conventional)", true},
+		{"interleaved off (Tier I direct)", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bus := events.NewBus(8)
+			defer bus.Close()
+			sub := bus.Subscribe()
+			defer sub.Close()
+
+			cc := New(Options{Bus: bus, SystemName: "S", FrequencyHz: 1, InterleavedVoice: tc.interleaved})
+			flc := dmr.FLC{FLCO: dmr.FLCOGroupVoiceUser, DstAddr: 0x11, SrcAddr: 0x100}
+			cc.IngestBurst(burstWithFLC(flc), dmr.SlotType{ColorCode: 1, DataType: dmr.DTVoiceLCHeader})
+
+			grants := grantsOf(drainEvents(sub, 100*time.Millisecond))
+			if len(grants) != 1 {
+				t.Fatalf("got %d grants, want 1", len(grants))
+			}
+			if grants[0].DMRInterleavedVoice != tc.interleaved {
+				t.Errorf("DMRInterleavedVoice = %v, want %v", grants[0].DMRInterleavedVoice, tc.interleaved)
+			}
+		})
+	}
+}
+
+// TestConventionalTwoTalkgroupsGetDistinctSlots pins the two-slot identity fix:
+// two concurrent talkgroups on one repeater (TS1/TS2) must produce two grants
+// with distinct synthetic timeslots, and their interleaved repeat headers must
+// not ping-pong out fresh grants. Before the fix both collapsed to Timeslot 0
+// and re-granted on every alternating header.
+func TestConventionalTwoTalkgroupsGetDistinctSlots(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "Fire2", FrequencyHz: 442_387_500})
+	slot := dmr.SlotType{ColorCode: 1, DataType: dmr.DTVoiceLCHeader}
+	tgA := dmr.FLC{FLCO: dmr.FLCOGroupVoiceUser, DstAddr: 0x11, SrcAddr: 0x13000013}
+	tgB := dmr.FLC{FLCO: dmr.FLCOGroupVoiceUser, DstAddr: 0x12, SrcAddr: 0x13000042}
+
+	// Interleaved on air: A, B, A, B, A, B (each slot's Voice LC Header repeats
+	// every superframe).
+	for i := 0; i < 3; i++ {
+		cc.IngestBurst(burstWithFLC(tgA), slot)
+		cc.IngestBurst(burstWithFLC(tgB), slot)
+	}
+
+	grants := grantsOf(drainEvents(sub, 150*time.Millisecond))
+	if len(grants) != 2 {
+		t.Fatalf("got %d grants, want exactly 2 (one per talkgroup, no ping-pong)", len(grants))
+	}
+	byTG := map[uint32]trunking.Grant{}
+	for _, g := range grants {
+		byTG[g.GroupID] = g
+	}
+	a, okA := byTG[0x11]
+	b, okB := byTG[0x12]
+	if !okA || !okB {
+		t.Fatalf("expected grants for both TG 0x11 and 0x12, got %v", byTG)
+	}
+	if a.Timeslot == 0 || b.Timeslot == 0 {
+		t.Errorf("timeslots must be non-zero synthetic slots, got A=%d B=%d", a.Timeslot, b.Timeslot)
+	}
+	if a.Timeslot == b.Timeslot {
+		t.Errorf("the two concurrent talkgroups share timeslot %d; they must differ", a.Timeslot)
+	}
+}
+
+// TestConventionalTerminatorReleasesOnlyItsTalkgroup pins that a Terminator for
+// one slot's talkgroup does not tear down the other slot's active call: only
+// TG-A is released, and a later TG-A header opens a fresh call while TG-B's
+// repeat header still dedupes (it was never released).
+func TestConventionalTerminatorReleasesOnlyItsTalkgroup(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "Fire2", FrequencyHz: 442_387_500})
+	hdr := dmr.SlotType{ColorCode: 1, DataType: dmr.DTVoiceLCHeader}
+	term := dmr.SlotType{ColorCode: 1, DataType: dmr.DTTerminatorWithLC}
+	tgA := dmr.FLC{FLCO: dmr.FLCOGroupVoiceUser, DstAddr: 0x11, SrcAddr: 0x13000013}
+	tgB := dmr.FLC{FLCO: dmr.FLCOGroupVoiceUser, DstAddr: 0x12, SrcAddr: 0x13000042}
+
+	// Both slots in call.
+	cc.IngestBurst(burstWithFLC(tgA), hdr)
+	cc.IngestBurst(burstWithFLC(tgB), hdr)
+	// Terminator for TG-A only.
+	cc.IngestBurst(burstWithTerminatorFLC(tgA), term)
+	// TG-B repeats (still in call → dedupe, no new grant); TG-A opens again.
+	cc.IngestBurst(burstWithFLC(tgB), hdr)
+	cc.IngestBurst(burstWithFLC(tgA), hdr)
+
+	evs := drainEvents(sub, 200*time.Millisecond)
+
+	var releases []trunking.CallRelease
+	for _, ev := range evs {
+		if ev.Kind == events.KindCallRelease {
+			releases = append(releases, ev.Payload.(trunking.CallRelease))
+		}
+	}
+	if len(releases) != 1 {
+		t.Fatalf("got %d releases, want exactly 1 (only TG-A)", len(releases))
+	}
+	if releases[0].GroupID != 0x11 {
+		t.Errorf("released TG = %X, want 0x11 (TG-A); TG-B must not be torn down", releases[0].GroupID)
+	}
+
+	// Grants: TG-A opens (1), TG-B opens (1), TG-B repeat dedupes (0), TG-A
+	// re-opens after its terminator (1) → 3 total, and TG-A appears twice.
+	grants := grantsOf(evs)
+	if len(grants) != 3 {
+		t.Fatalf("got %d grants, want 3 (A, B, A-reopened; B-repeat deduped)", len(grants))
+	}
+	var aCount, bCount int
+	for _, g := range grants {
+		switch g.GroupID {
+		case 0x11:
+			aCount++
+		case 0x12:
+			bCount++
+		}
+	}
+	if aCount != 2 || bCount != 1 {
+		t.Errorf("grant counts A=%d B=%d, want A=2 B=1", aCount, bCount)
+	}
+}

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -1091,11 +1091,12 @@ func (p *dmrPipeline) TopologySnapshot() *trunking.TopologySnapshot {
 // (BPTC(196,96) + RS(12,9,4) parity check) for call setup.
 func newDMRTier2Pipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 	cc := tier2.New(tier2.Options{
-		Bus:             opts.Bus,
-		Log:             opts.Log,
-		SystemName:      opts.SystemName,
-		FrequencyHz:     opts.FrequencyHz,
-		ColorCodeFilter: opts.System.DMRColorCode,
+		Bus:              opts.Bus,
+		Log:              opts.Log,
+		SystemName:       opts.SystemName,
+		FrequencyHz:      opts.FrequencyHz,
+		ColorCodeFilter:  opts.System.DMRColorCode,
+		InterleavedVoice: opts.System.DMRInterleavedVoice,
 	})
 	rx := dmrrx.New(dmrrx.Options{
 		SampleRateHz: opts.SampleRateHz,

--- a/internal/scanner/widebandt2/engine.go
+++ b/internal/scanner/widebandt2/engine.go
@@ -675,12 +675,13 @@ func buildChannel(sys trunking.System, ch ChannelConfig, outRateHz float64, bus 
 
 	case trunking.ProtocolDMRTier2:
 		cc := tier2.New(tier2.Options{
-			Bus:             bus,
-			Log:             log.With("system", sys.Name, "freq_hz", freqHz, "tier", 2),
-			SystemName:      sys.Name,
-			FrequencyHz:     freqHz,
-			Now:             now,
-			ColorCodeFilter: sys.DMRColorCode,
+			Bus:              bus,
+			Log:              log.With("system", sys.Name, "freq_hz", freqHz, "tier", 2),
+			SystemName:       sys.Name,
+			FrequencyHz:      freqHz,
+			Now:              now,
+			ColorCodeFilter:  sys.DMRColorCode,
+			InterleavedVoice: sys.DMRInterleavedVoice,
 		})
 		rx := dmrrx.New(dmrrx.Options{
 			SampleRateHz: outRateHz,

--- a/internal/trunking/engine.go
+++ b/internal/trunking/engine.go
@@ -608,27 +608,41 @@ func (e *Engine) HandleGrant(g Grant) {
 		e.log.Warn("dropping grant with zero frequency", "grant", g.String())
 		return
 	}
-	// Learn subscriber radios this grant reveals and retract any phantom
-	// talkgroup previously catalogued for one. A calling/transmitting party is
-	// always a radio; an Individual grant's destination is a subscriber address.
-	// This both cleans up radio IDs already leaked into the Talkgroups list and
-	// primes the discovery guard below.
-	e.noteRadio(g.SourceID, g.System)
-	if g.Individual {
-		e.noteRadio(g.GroupID, g.System)
-	}
-	// If the grant is addressed to an SSI already known to be a subscriber radio
-	// (seen transmitting, or previously flagged individual), its "talkgroup" is
-	// really a unit-to-unit destination — reclassify so the call is recorded and
-	// surfaced as an INDIVIDUAL call, not filed under a phantom talkgroup named
-	// after the radio ID (the leaked "fake TG" recordings the operator reported:
-	// on-disk under recordings/<system>/<radioID>/ while the WebUI talkgroup list
-	// never shows them). knownRadios is durable across control-channel re-locks —
-	// unlike the control channel's per-lock learned set, which is wiped on every
-	// re-hunt — so this catches radios learned anywhere in the session. GSSIs and
-	// ISSIs never overlap on TETRA, so a known radio is never a real talkgroup.
-	if !g.Individual && g.GroupID != 0 && e.isKnownRadio(g.GroupID) {
-		g.Individual = true
+	// The radio/talkgroup disambiguation below rests on a TETRA-specific
+	// invariant: GSSIs (talkgroups) and ISSIs (subscriber radios) occupy
+	// disjoint address ranges, so a value ever seen acting as a radio can never
+	// be a real talkgroup. That does NOT hold for DMR (nor for other protocols),
+	// where talkgroup and radio IDs share one 24-bit space and routinely
+	// coincide — a fleet talkgroup number can equal some subscriber's radio ID.
+	// Running this for DMR flipped genuine group calls to "individual" whenever a
+	// talkgroup happened to match a previously-heard radio ID, mis-filing the
+	// recording (recordings/<system>/individual/<TG>/) and corrupting the
+	// individual flag that backs the Radio IDs roster. DMR's own FLCO group/unit
+	// classification is authoritative, so scope this whole mechanism to TETRA and
+	// leave every other protocol's decoded classification untouched.
+	if g.Protocol == "tetra" {
+		// Learn subscriber radios this grant reveals and retract any phantom
+		// talkgroup previously catalogued for one. A calling/transmitting party is
+		// always a radio; an Individual grant's destination is a subscriber
+		// address. This both cleans up radio IDs already leaked into the
+		// Talkgroups list and primes the discovery guard below.
+		e.noteRadio(g.SourceID, g.System)
+		if g.Individual {
+			e.noteRadio(g.GroupID, g.System)
+		}
+		// If the grant is addressed to an SSI already known to be a subscriber
+		// radio (seen transmitting, or previously flagged individual), its
+		// "talkgroup" is really a unit-to-unit destination — reclassify so the
+		// call is recorded and surfaced as an INDIVIDUAL call, not filed under a
+		// phantom talkgroup named after the radio ID (the leaked "fake TG"
+		// recordings the operator reported: on-disk under
+		// recordings/<system>/<radioID>/ while the WebUI talkgroup list never
+		// shows them). knownRadios is durable across control-channel re-locks —
+		// unlike the control channel's per-lock learned set, which is wiped on
+		// every re-hunt — so this catches radios learned anywhere in the session.
+		if !g.Individual && g.GroupID != 0 && e.isKnownRadio(g.GroupID) {
+			g.Individual = true
+		}
 	}
 	// Cancel a parked TETRA notification hold on this channel the moment any
 	// authoritative (source-bearing) grant for the same physical channel arrives —

--- a/internal/trunking/engine_dmr_classify_test.go
+++ b/internal/trunking/engine_dmr_classify_test.go
@@ -1,0 +1,71 @@
+package trunking
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// TestEngineDoesNotReclassifyDMRGroupCallAsIndividual pins the DMR half of the
+// classification fix. The engine's known-radio → individual reclassification
+// rests on the TETRA-only invariant that talkgroup (GSSI) and radio (ISSI) IDs
+// never overlap. On DMR they share one 24-bit space, so a fleet talkgroup
+// number can equal some subscriber's radio ID. This asserts:
+//
+//   - a DMR call's source radio ID is NOT learned into knownRadios (the
+//     mechanism is scoped to TETRA), and
+//   - a DMR group call whose GroupID numerically equals a radio ID already
+//     learned from a TETRA system is left classified as a GROUP call — not
+//     flipped to individual and mis-filed under individual/<TG>.
+//
+// The equivalent TETRA case still reclassifies — see
+// TestEngineReclassifiesKnownRadioGrantAsIndividual.
+func TestEngineDoesNotReclassifyDMRGroupCallAsIndividual(t *testing.T) {
+	e, _, bus, _ := mkEngine(t, 2)
+	defer bus.Close()
+
+	const sharedID = 1009267
+
+	// Learn sharedID as a subscriber radio via a TETRA group call (source).
+	e.HandleGrant(Grant{System: "T", Protocol: "tetra", GroupID: 1020545, SourceID: sharedID,
+		FrequencyHz: 467_912_500, Timeslot: 1})
+	if !e.isKnownRadio(sharedID) {
+		t.Fatalf("precondition: %d should be a known radio after a TETRA call source", sharedID)
+	}
+
+	sub := bus.Subscribe()
+	defer sub.Close()
+	collector := &testBusCollector{}
+	done := make(chan struct{})
+	go func() { collector.drain(sub, 1, 500*time.Millisecond); close(done) }()
+
+	// A DMR *group* call whose talkgroup happens to equal that radio ID, with a
+	// distinct source. It must NOT be reclassified individual.
+	e.HandleGrant(Grant{System: "Fire2", Protocol: "dmr-tier2", GroupID: sharedID, SourceID: 13_000_013,
+		FrequencyHz: 442_387_500, Timeslot: 1})
+	<-done
+
+	var found bool
+	for _, ev := range collector.snapshot() {
+		if ev.Kind != events.KindCallStart {
+			continue
+		}
+		cs := ev.Payload.(CallStart)
+		if cs.Grant.Protocol != "dmr-tier2" || cs.Grant.GroupID != sharedID {
+			continue
+		}
+		found = true
+		if cs.Grant.Individual {
+			t.Errorf("DMR group call to TG %d was wrongly reclassified individual: %+v", sharedID, cs.Grant)
+		}
+	}
+	if !found {
+		t.Fatalf("no CallStart for the DMR group call; events=%+v", collector.snapshot())
+	}
+
+	// The DMR call's own source must not have polluted knownRadios.
+	if e.isKnownRadio(13_000_013) {
+		t.Errorf("DMR source 13000013 must not be learned as a known radio")
+	}
+}

--- a/internal/voice/composer/dmr_voice.go
+++ b/internal/voice/composer/dmr_voice.go
@@ -381,6 +381,7 @@ func (c *Composer) runDMRVoiceChain(ctx context.Context, serial, system string, 
 		// by embedded signalling or by the phase fallback (issue #644).
 		lcSuperframes  atomic.Uint64
 		loggedFallback bool
+		loggedRC       bool
 	)
 	rx := dmrrx.New(dmrrx.Options{
 		SampleRateHz: symbolHz,
@@ -437,11 +438,14 @@ func (c *Composer) runDMRVoiceChain(ctx context.Context, serial, system string, 
 				}
 				superframes.Add(1)
 				bt.onVoice(0)
-				if sf.HasRC {
+				if sf.HasRC && !loggedRC {
 					// In-call Reverse Channel signalling — control-plane
 					// visibility only (see dmr/rc.go); it does not affect the
-					// audio path.
-					c.log.Debug("composer: DMR reverse channel",
+					// audio path. Log once per call: it recurs every superframe
+					// on a carrier that uses the reverse channel and otherwise
+					// floods the log.
+					loggedRC = true
+					c.log.Debug("composer: DMR reverse channel present",
 						"serial", serial, "rc_info", sf.RC.Info, "phase", sf.Phase)
 				}
 				if rs == nil {
@@ -453,9 +457,10 @@ func (c *Composer) runDMRVoiceChain(ctx context.Context, serial, system string, 
 						corrErrBits.Add(uint64(errBits))
 					}
 					if err != nil {
+						// Counted only; a per-frame log floods (up to 18 frames
+						// per superframe) and the total surfaces in the rolling
+						// "dmr decode quality" line via uncorrectableFrames.
 						uncorrectableFrames.Add(1)
-						c.log.Debug("composer: DMR AMBE FEC decode failed",
-							"serial", serial, "err", err)
 						continue
 					}
 					packed := packBits(info)
@@ -487,7 +492,10 @@ func (c *Composer) runDMRVoiceChain(ctx context.Context, serial, system string, 
 			return
 		}
 		lastQualityLogSuperframes = n
-		c.log.Info("composer: dmr decode quality",
+		// Debug (not Info): this fires every ~9 s for every active call, so at
+		// Info it was steady per-call noise. The counters remain available at
+		// debug level for weak-signal diagnosis (issue #356).
+		c.log.Debug("composer: dmr decode quality",
 			"serial", serial,
 			"superframes", n, "uncorrectable_frames", uncorrectableFrames.Load(),
 			"corrected_bit_errs", corrErrBits.Load(),

--- a/internal/voice/recorder.go
+++ b/internal/voice/recorder.go
@@ -716,6 +716,10 @@ func (r *Recorder) WriteRawFrameWithErrors(deviceSerial string, frame []byte, co
 	return r.writeRawFrame(deviceSerial, 0, frame, correctedBits, true)
 }
 
+// isPowerOfTwo reports whether n is 1, 2, 4, 8, … — used to rate-limit a
+// repeated log to milestone counts (1st, 2nd, 4th, 8th, … occurrence).
+func isPowerOfTwo(n int) bool { return n > 0 && n&(n-1) == 0 }
+
 func (r *Recorder) writeRawFrame(deviceSerial string, callID uint64, frame []byte, correctedBits int, haveErrs bool) error {
 	s := r.sessionForWrite(deviceSerial, callID)
 	if s == nil {
@@ -751,8 +755,16 @@ func (r *Recorder) writeRawFrame(deviceSerial string, callID uint64, frame []byt
 		}
 		samples, err := s.vocoder.Decode(frame)
 		if err != nil {
-			r.log.Warn("recorder: vocoder decode failed; dropping frame from PCM",
-				"device", deviceSerial, "vocoder", s.vocoder.Name(), "err", err)
+			// Rate-limit: log the first drop and then only at power-of-two
+			// milestones. A garbled call can reject many frames in a row, and at
+			// debug level a per-frame Warn buried the log (the operator's DMR
+			// spam report). The exact drop total is carried in the milestone line.
+			s.vocoderDrops++
+			if isPowerOfTwo(s.vocoderDrops) {
+				r.log.Debug("recorder: vocoder decode failed; dropping frame(s) from PCM",
+					"device", deviceSerial, "vocoder", s.vocoder.Name(),
+					"drops", s.vocoderDrops, "err", err)
+			}
 			return nil
 		}
 		if n := len(samples); n > 0 {
@@ -1718,7 +1730,12 @@ type recordingSession struct {
 	// too-short digital recording is visible without cross-referencing the
 	// composer's follow-ended log.
 	rawFrames int
-	startedAt time.Time
+	// vocoderDrops counts frames the vocoder rejected (undecodable) for this
+	// session; used to rate-limit the per-drop log so a burst of bad frames
+	// summarises to one line per power-of-two milestone instead of one Warn
+	// each (which flooded at debug level on a garbled call).
+	vocoderDrops int
+	startedAt    time.Time
 	// callID is the Grant.CallID of the call this session records. Frames
 	// arriving via WriteRawFrameForCall with a different non-zero callID are
 	// dropped (see sessionForWrite) so a reused tap serial can't bleed the


### PR DESCRIPTION
Conventional DMR (dmr-tier2 / dmr-tier1) collapsed a repeater's two
independent timeslots into one call. Two symptoms fell out of that:

- "DJ scratchy" audio: the composer picks the single-slot vs interleaved
  AMBE decoder from Grant.DMRInterleavedVoice, which Tier III stamps but
  Tier II never did (tier2.Options had no InterleavedVoice field, both
  constructors omitted it, and handleVoiceHeader didn't set it). So even
  with dmr_interleaved_voice: true configured, conventional DMR always ran
  the single-slot decoder, which slices 6 consecutive bursts = TS1,TS2,
  TS1,TS2,... into one superframe and renders alternating-speaker garble.

- Two talkgroups on one repeater collapsing: grants were published with
  Timeslot 0 and the channel held scalar inCall/lastTG/lastSrc state, so
  the two slots' interleaved Voice LC Headers ping-ponged the state and the
  engine (which keys call identity on (freq, timeslot)) folded both onto
  one (freq, 0) channel. A TS1 terminator also tore down the TS2 call.

Wire InterleavedVoice through tier2.Options and both the ccdecoder and
widebandt2 constructors (Tier I direct mode leaves it false). Replace the
scalar call state with a per-destination map that assigns each concurrent
call a synthetic Timeslot (1/2) — an engine-identity token only; audio is
routed by the composer's embedded-LC talkgroup, so the synthetic slot never
mis-routes. Decode the Terminator-with-LC destination so a terminator
releases only its own call; a lone active call still tears down promptly on
an undecodable terminator, but with two concurrent calls an undecodable one
defers to per-chain hangtime rather than risk cross-tearing the other slot.

Regression tests (fail before, pass after): interleaved flag stamped
(false for Tier I), two talkgroups get distinct non-zero timeslots with no
ping-pong re-grants, and a terminator releases only its talkgroup.

Refs #644
Refs #1036

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CmqNqwrxcrKBCnSkPaKm1w