### PR TITLE
web: lead nav with Scan+Hunt, consolidate DSP scopes

### DIFF
--- a/internal/api/call_audio_test.go
+++ b/internal/api/call_audio_test.go
@@ -1,0 +1,117 @@
+package api
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/storage"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TestCallAudioEndpointServesRecording drives the whole playback path: the
+// recorder's KindCallComplete stamps a WAV onto the call row, and
+// GET /api/v1/calls/{id}/audio streams that file back. A call without a
+// recording, and an unknown id, both 404.
+func TestCallAudioEndpointServesRecording(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	db, err := storage.Open(filepath.Join(t.TempDir(), "calls.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	cl, err := storage.NewCallLog(db, bus, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cl.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go cl.Run(ctx)
+
+	// A real WAV file on disk for the recorded call.
+	wavPath := filepath.Join(t.TempDir(), "call.wav")
+	want := []byte("RIFF....WAVEfmt fake-pcm-bytes")
+	if err := os.WriteFile(wavPath, want, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	startedAt := time.Now().UTC().Truncate(time.Microsecond)
+	recorded := trunking.CallStart{
+		Grant:        trunking.Grant{System: "Alpha", Protocol: "p25", GroupID: 700, FrequencyHz: 851_000_000},
+		DeviceSerial: "VOICE-1",
+		StartedAt:    startedAt,
+	}
+	silent := trunking.CallStart{
+		Grant:        trunking.Grant{System: "Alpha", Protocol: "p25", GroupID: 701, FrequencyHz: 851_000_000},
+		DeviceSerial: "VOICE-2",
+		StartedAt:    startedAt.Add(time.Second),
+	}
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: recorded})
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: silent})
+	bus.Publish(events.Event{Kind: events.KindCallComplete, Payload: trunking.CallComplete{
+		Grant: recorded.Grant, DeviceSerial: recorded.DeviceSerial,
+		StartedAt: startedAt, EndedAt: startedAt.Add(2 * time.Second), AudioPath: wavPath,
+	}})
+
+	// Wait until both rows exist and the recorded one is flagged.
+	var recordedID, silentID int64
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		rows, _ := db.History(context.Background(), storage.HistoryFilter{Limit: 10})
+		if len(rows) == 2 {
+			for _, r := range rows {
+				if r.GroupID == 700 && r.HasRecording {
+					recordedID = r.ID
+				}
+				if r.GroupID == 701 {
+					silentID = r.ID
+				}
+			}
+		}
+		if recordedID != 0 && silentID != 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if recordedID == 0 || silentID == 0 {
+		t.Fatalf("setup: recordedID=%d silentID=%d", recordedID, silentID)
+	}
+
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, History: HistoryFromStorage(db)})
+	defer teardown()
+
+	// The recorded call plays back with its bytes and an audio content type.
+	resp := mustGet(t, base+"/api/v1/calls/"+strconv.FormatInt(recordedID, 10)+"/audio")
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("recorded audio status = %d, want 200", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "audio/wav" {
+		t.Errorf("content-type = %q, want audio/wav", ct)
+	}
+	got, _ := io.ReadAll(resp.Body)
+	if string(got) != string(want) {
+		t.Errorf("body = %q, want %q", got, want)
+	}
+
+	// A call with no recording 404s.
+	resp2 := mustGet(t, base+"/api/v1/calls/"+strconv.FormatInt(silentID, 10)+"/audio")
+	resp2.Body.Close()
+	if resp2.StatusCode != 404 {
+		t.Errorf("no-recording status = %d, want 404", resp2.StatusCode)
+	}
+
+	// An unknown id 404s.
+	resp3 := mustGet(t, base+"/api/v1/calls/999999/audio")
+	resp3.Body.Close()
+	if resp3.StatusCode != 404 {
+		t.Errorf("unknown-id status = %d, want 404", resp3.StatusCode)
+	}
+}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -2,7 +2,10 @@ package api
 
 import (
 	"net/http"
+	"os"
+	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	gtdiag "github.com/MattCheramie/GopherTrunk/internal/diag"
@@ -359,6 +362,67 @@ func (s *Server) handleCallHistory(w http.ResponseWriter, r *http.Request) {
 		rows = []CallRow{}
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"calls": rows})
+}
+
+// handleCallAudio streams the finished recording for one call so the web UI
+// can play a past transmission (the call-history "play" button). The call id
+// is resolved to a path through the RecordingProvider capability — the
+// filesystem path is never exposed to the client — and the file is served with
+// range support (http.ServeContent) so the browser can seek.
+//
+//	GET /api/v1/calls/{id}/audio
+func (s *Server) handleCallAudio(w http.ResponseWriter, r *http.Request) {
+	if s.history == nil {
+		s.writeError(w, http.StatusServiceUnavailable, "call log persistence is not enabled")
+		return
+	}
+	prov, ok := s.history.(RecordingProvider)
+	if !ok {
+		s.writeError(w, http.StatusNotImplemented, "recording playback is not available")
+		return
+	}
+	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil || id <= 0 {
+		s.writeError(w, http.StatusBadRequest, "invalid call id")
+		return
+	}
+	path, err := prov.RecordingPathByID(r.Context(), id)
+	if err != nil {
+		s.log.Warn("api: recording path lookup failed", "err", err, "call", id)
+		s.writeError(w, http.StatusInternalServerError, "recording lookup failed")
+		return
+	}
+	if path == "" {
+		s.writeError(w, http.StatusNotFound, "no recording for this call")
+		return
+	}
+	// The path is daemon-generated, but validate defensively before opening:
+	// an absolute audio file, no traversal, actually a regular file. This keeps
+	// the endpoint from ever serving a non-recording even if the row is bad.
+	ext := strings.ToLower(filepath.Ext(path))
+	if !filepath.IsAbs(path) || strings.Contains(path, "..") ||
+		(ext != ".wav" && ext != ".mp3") {
+		s.writeError(w, http.StatusNotFound, "recording unavailable")
+		return
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		// Retention may have deleted it, or the volume moved.
+		s.writeError(w, http.StatusNotFound, "recording file is gone")
+		return
+	}
+	defer f.Close()
+	fi, err := f.Stat()
+	if err != nil || fi.IsDir() {
+		s.writeError(w, http.StatusNotFound, "recording unavailable")
+		return
+	}
+	if ext == ".mp3" {
+		w.Header().Set("Content-Type", "audio/mpeg")
+	} else {
+		w.Header().Set("Content-Type", "audio/wav")
+	}
+	http.ServeContent(w, r, filepath.Base(path), fi.ModTime(), f)
 }
 
 // handleListDevices returns the SDR pool snapshot — every opened

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -515,6 +515,14 @@ type RIDSummaryProvider interface {
 	RIDSummaries(ctx context.Context, f RIDSummaryFilter) ([]RIDSummary, error)
 }
 
+// RecordingProvider is the optional capability a HistoryQuery may implement to
+// resolve a call id to its on-disk recording path, backing
+// GET /api/v1/calls/{id}/audio. Optional so a HistoryQuery fake without
+// recordings simply yields no audio.
+type RecordingProvider interface {
+	RecordingPathByID(ctx context.Context, id int64) (string, error)
+}
+
 // LocationFix is one geographic fix returned by GET /api/v1/locations.
 type LocationFix struct {
 	System     string  `json:"system"`
@@ -628,6 +636,9 @@ type CallRow struct {
 	// against another decoder. nil when unmeasured (P25 Phase 1 only).
 	EVMPct *float64 `json:"evm_pct,omitempty"`
 	SNRDb  *float64 `json:"snr_db,omitempty"`
+	// HasRecording is true when a finished WAV exists for this call. The path
+	// is not exposed; the UI plays via GET /api/v1/calls/{id}/audio.
+	HasRecording bool `json:"has_recording,omitempty"`
 }
 
 // ServerOptions configure a new Server.
@@ -1140,6 +1151,7 @@ func (s *Server) routes() *http.ServeMux {
 	mux.HandleFunc("GET /api/v1/talkgroups/{id}", s.handleGetTalkgroup)
 	mux.HandleFunc("GET /api/v1/calls/active", s.handleActiveCalls)
 	mux.HandleFunc("GET /api/v1/calls/history", s.handleCallHistory)
+	mux.HandleFunc("GET /api/v1/calls/{id}/audio", s.handleCallAudio)
 	mux.HandleFunc("GET /api/v1/locations", s.handleLocations)
 	mux.HandleFunc("GET /api/v1/affiliations", s.handleAffiliations)
 	mux.HandleFunc("GET /api/v1/grants", s.handleGrants)

--- a/internal/api/storage_adapter.go
+++ b/internal/api/storage_adapter.go
@@ -126,7 +126,15 @@ func (s *storageHistory) History(ctx context.Context, f HistoryFilter) ([]CallRo
 			SignalDbFS:     r.SignalDbFS,
 			EVMPct:         r.EVMPct,
 			SNRDb:          r.SNRDb,
+			HasRecording:   r.HasRecording,
 		}
 	}
 	return out, nil
+}
+
+// RecordingPathByID delegates to storage.DB so the audio endpoint can resolve a
+// call id to a file. Presence of this method makes storageHistory a
+// RecordingProvider (see server.go).
+func (s *storageHistory) RecordingPathByID(ctx context.Context, id int64) (string, error) {
+	return s.db.RecordingPathByID(ctx, id)
 }

--- a/internal/storage/calllog.go
+++ b/internal/storage/calllog.go
@@ -221,10 +221,10 @@ UPDATE call_log
 }
 
 // recordComplete stamps the finished recording's path onto the matching call
-// row. Keyed by (device_serial, started_at) exactly like recordEnd. Uses
-// COALESCE(NULLIF(?, ''), recording_path) so an empty path never clobbers a
-// value already written, mirroring the never-downgrade discipline elsewhere in
-// this file. A CallComplete with no matching row (recording without a persisted
+// row. Keyed by (device_serial, started_at) exactly like recordEnd. The
+// COALESCE(NULLIF(...)) update keeps an empty path from clobbering a value
+// already written, mirroring the never-downgrade discipline elsewhere in this
+// file. A CallComplete with no matching row (a recording without a persisted
 // call, e.g. replay tooling) updates nothing and is not an error.
 func (c *CallLog) recordComplete(cc trunking.CallComplete) error {
 	if cc.AudioPath == "" {

--- a/internal/storage/calllog.go
+++ b/internal/storage/calllog.go
@@ -95,6 +95,15 @@ func (c *CallLog) Run(ctx context.Context) error {
 						c.log.Warn("calllog: update end failed", "err", err, "device", ce.DeviceSerial)
 					}
 				}
+			case events.KindCallComplete:
+				// The recorder finished writing the WAV; stamp its path onto the
+				// row so History can offer playback. Fired after CallEnd, keyed by
+				// the same (device_serial, started_at).
+				if cc, ok := ev.Payload.(trunking.CallComplete); ok {
+					if err := c.recordComplete(cc); err != nil {
+						c.log.Warn("calllog: update recording path failed", "err", err, "device", cc.DeviceSerial)
+					}
+				}
 			}
 		}
 	}
@@ -211,6 +220,24 @@ UPDATE call_log
 	return err
 }
 
+// recordComplete stamps the finished recording's path onto the matching call
+// row. Keyed by (device_serial, started_at) exactly like recordEnd. Uses
+// COALESCE(NULLIF(?, ''), recording_path) so an empty path never clobbers a
+// value already written, mirroring the never-downgrade discipline elsewhere in
+// this file. A CallComplete with no matching row (recording without a persisted
+// call, e.g. replay tooling) updates nothing and is not an error.
+func (c *CallLog) recordComplete(cc trunking.CallComplete) error {
+	if cc.AudioPath == "" {
+		return nil
+	}
+	const q = `
+UPDATE call_log
+   SET recording_path = COALESCE(NULLIF(?, ''), recording_path)
+ WHERE device_serial = ? AND started_at = ?`
+	_, err := c.db.sql.Exec(q, cc.AudioPath, cc.DeviceSerial, cc.StartedAt.UnixNano())
+	return err
+}
+
 // HistoryFilter narrows a History query.
 type HistoryFilter struct {
 	System    string
@@ -262,6 +289,10 @@ type CallRow struct {
 	// figures to compare against another decoder, unlike SignalDbFS.
 	EVMPct *float64 `json:"evm_pct,omitempty"`
 	SNRDb  *float64 `json:"snr_db,omitempty"`
+	// HasRecording is true when a finished recording is on disk for this call
+	// (recording_path is set). The path itself is deliberately not serialised —
+	// the UI plays via GET /api/v1/calls/{id}/audio, not a filesystem path.
+	HasRecording bool `json:"has_recording,omitempty"`
 }
 
 // History queries the call_log with the supplied filter, newest-first.
@@ -269,7 +300,8 @@ func (d *DB) History(ctx context.Context, f HistoryFilter) ([]CallRow, error) {
 	q := `SELECT id, system, protocol, group_id, source_id, frequency_hz,
 	             encrypted, algorithm_id, key_id, emergency, data_call, individual, timeslot, priority,
 	             device_serial, started_at, ended_at, duration_ms,
-	             end_reason, talkgroup_alpha, source_alpha, signal_dbfs, evm_pct, snr_db
+	             end_reason, talkgroup_alpha, source_alpha, signal_dbfs, evm_pct, snr_db,
+	             recording_path
 	      FROM call_log WHERE 1=1`
 	args := []any{}
 	if f.System != "" {
@@ -312,16 +344,18 @@ func (d *DB) History(ctx context.Context, f HistoryFilter) ([]CallRow, error) {
 		var endNs sql.NullInt64
 		var durMs sql.NullInt64
 		var reason sql.NullString
-		var alpha, srcAlpha sql.NullString
+		var alpha, srcAlpha, recPath sql.NullString
 		var sig, evm, snr sql.NullFloat64
 		var enc, emer, data, indiv, algID, keyID, slot, prio int
 		if err := rows.Scan(
 			&r.ID, &r.System, &r.Protocol, &r.GroupID, &r.SourceID, &r.FrequencyHz,
 			&enc, &algID, &keyID, &emer, &data, &indiv, &slot, &prio, &r.DeviceSerial,
 			&startNs, &endNs, &durMs, &reason, &alpha, &srcAlpha, &sig, &evm, &snr,
+			&recPath,
 		); err != nil {
 			return nil, err
 		}
+		r.HasRecording = recPath.Valid && recPath.String != ""
 		r.Encrypted = enc != 0
 		r.AlgorithmID = uint8(algID)
 		r.KeyID = uint16(keyID)
@@ -361,6 +395,26 @@ func (d *DB) History(ctx context.Context, f HistoryFilter) ([]CallRow, error) {
 		out = append(out, r)
 	}
 	return out, rows.Err()
+}
+
+// RecordingPathByID returns the on-disk recording path for one call row, or
+// "" when the call has no recording (or the id is unknown). The audio endpoint
+// resolves a call id to a file this way so the filesystem path is never exposed
+// to the client.
+func (d *DB) RecordingPathByID(ctx context.Context, id int64) (string, error) {
+	var p sql.NullString
+	err := d.sql.QueryRowContext(ctx,
+		`SELECT recording_path FROM call_log WHERE id = ?`, id).Scan(&p)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("storage: recording path for call %d: %w", id, err)
+	}
+	if !p.Valid {
+		return "", nil
+	}
+	return p.String, nil
 }
 
 // RIDSummary is one aggregated per-radio (source_id) row derived from the

--- a/internal/storage/calllog_test.go
+++ b/internal/storage/calllog_test.go
@@ -108,6 +108,86 @@ func TestCallLogRecordsStartAndEnd(t *testing.T) {
 	}
 }
 
+// TestCallLogRecordsRecordingPath verifies the recorder's KindCallComplete
+// event stamps the finished WAV onto the matching call row, so History reports
+// HasRecording and the audio endpoint can resolve the file. Fails against the
+// pre-fix code, which ignored KindCallComplete entirely.
+func TestCallLogRecordsRecordingPath(t *testing.T) {
+	db := openTestDB(t)
+	bus := events.NewBus(8)
+	defer bus.Close()
+	cl, err := NewCallLog(db, bus, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cl.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go cl.Run(ctx)
+
+	startedAt := time.Now().UTC().Truncate(time.Microsecond)
+	cs := trunking.CallStart{
+		Grant: trunking.Grant{
+			System: "Alpha", Protocol: "p25", GroupID: 700, SourceID: 42,
+			FrequencyHz: 851_000_000,
+		},
+		DeviceSerial: "VOICE-1",
+		StartedAt:    startedAt,
+	}
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: cs})
+
+	waitRows := func(f HistoryFilter) []CallRow {
+		deadline := time.Now().Add(time.Second)
+		for time.Now().Before(deadline) {
+			rows, _ := db.History(context.Background(), f)
+			if len(rows) == 1 {
+				return rows
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		rows, _ := db.History(context.Background(), f)
+		return rows
+	}
+	if rows := waitRows(HistoryFilter{Limit: 1}); len(rows) != 1 || rows[0].HasRecording {
+		t.Fatalf("before complete: rows=%d hasRecording=%v", len(rows), len(rows) == 1 && rows[0].HasRecording)
+	}
+
+	const wav = "/var/lib/gophertrunk/recordings/Alpha/700-42.wav"
+	bus.Publish(events.Event{Kind: events.KindCallComplete, Payload: trunking.CallComplete{
+		Grant:        cs.Grant,
+		DeviceSerial: cs.DeviceSerial,
+		StartedAt:    startedAt,
+		EndedAt:      startedAt.Add(2 * time.Second),
+		AudioPath:    wav,
+	}})
+
+	// Wait for the recording path to land.
+	deadline := time.Now().Add(time.Second)
+	var id int64
+	for time.Now().Before(deadline) {
+		rows, _ := db.History(context.Background(), HistoryFilter{Limit: 1})
+		if len(rows) == 1 && rows[0].HasRecording {
+			id = rows[0].ID
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if id == 0 {
+		t.Fatal("HasRecording never became true after KindCallComplete")
+	}
+	got, err := db.RecordingPathByID(context.Background(), id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != wav {
+		t.Errorf("RecordingPathByID = %q, want %q", got, wav)
+	}
+	// Unknown id yields "" without error.
+	if p, err := db.RecordingPathByID(context.Background(), 999999); err != nil || p != "" {
+		t.Errorf("unknown id: path=%q err=%v", p, err)
+	}
+}
+
 // TestCallLogPersistsTimeslot verifies the DMR TDMA slot survives the
 // CallStart → call_log round-trip, so a carrier's two concurrent calls
 // (TS1 + TS2) are distinguishable in history.

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -391,6 +391,10 @@ func (d *DB) ensureCallLogColumns() error {
 		{"evm_pct", `ALTER TABLE call_log ADD COLUMN evm_pct REAL`},
 		{"snr_db", `ALTER TABLE call_log ADD COLUMN snr_db REAL`},
 		{"individual", `ALTER TABLE call_log ADD COLUMN individual INTEGER NOT NULL DEFAULT 0`},
+		// Absolute path of the finished recording (WAV), stamped from the
+		// recorder's KindCallComplete event. NULL until (and unless) the call
+		// was recorded, so a non-recording daemon leaves it unset.
+		{"recording_path", `ALTER TABLE call_log ADD COLUMN recording_path TEXT`},
 	}
 	for _, a := range adds {
 		if have[a.name] {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -196,6 +196,7 @@ export function App() {
           <Route path="/systems" element={<Systems />} />
           <Route path="/talkgroups" element={<Talkgroups />} />
           <Route path="/rids" element={<RadioIDs />} />
+          <Route path="/rids/:id" element={<RadioIDs />} />
           <Route path="/history" element={<History />} />
           <Route path="/events" element={<Events />} />
           <Route path="/cc" element={<CCActivity />} />

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -165,6 +165,12 @@ export const api = {
       `/api/v1/rids${qs ? `?${qs}` : ""}`,
     ).then((r) => r.rids);
   },
+  // Fetch one merged RID row by id. Used to open the /rids/:id deep link
+  // (e.g. a source-radio click in CC Activity / call history) even when the
+  // radio isn't in the currently-filtered list. Returns the RIDDTO directly
+  // (the endpoint is unwrapped, unlike the list route).
+  rid: (c: ClientConfig, id: number) =>
+    request<RIDDTO>(c, "GET", `/api/v1/rids/${id}`),
   ridHistory: (
     c: ClientConfig,
     id: number,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -8,6 +8,7 @@ import type {
   ActiveCallDTO,
   AudioStatusDTO,
   CallRow,
+  LocationFix,
   ConfigListResponse,
   DeviceDTO,
   Health,
@@ -191,6 +192,18 @@ export const api = {
       "GET",
       "/api/v1/calls/active",
     ).then((r) => r.calls),
+  // Recent subscriber-radio position fixes (DMR LRRP / unit GPS) for the
+  // unit-location map. Optionally scoped by radio_id client-side.
+  locations: (c: ClientConfig, opts: { limit?: number } = {}) => {
+    const q = new URLSearchParams();
+    if (opts.limit != null) q.set("limit", String(opts.limit));
+    const qs = q.toString();
+    return request<{ locations: LocationFix[] }>(
+      c,
+      "GET",
+      `/api/v1/locations${qs ? `?${qs}` : ""}`,
+    ).then((r) => r.locations ?? []);
+  },
   history: (
     c: ClientConfig,
     opts: { limit?: number; system?: string; group_id?: number } = {},

--- a/web/src/api/spectrum.test.ts
+++ b/web/src/api/spectrum.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   defaultSymbolDevice,
+  initialDeviceSerial,
   parentSerial,
   type SpectrumDevice,
 } from "./spectrum";
@@ -38,6 +39,32 @@ describe("defaultSymbolDevice", () => {
   it("returns the sole device regardless of role", () => {
     const list = [dev("only", "voice")];
     expect(defaultSymbolDevice(list)?.serial).toBe("only");
+  });
+});
+
+describe("initialDeviceSerial", () => {
+  const list = [dev("voice-1", "voice"), dev("ctrl-1", "control")];
+
+  it("honours a ?device= target that is present in the pool", () => {
+    // A "signal detail" link named voice-1; it wins over the control default.
+    expect(initialDeviceSerial(list, "voice-1", defaultSymbolDevice)).toBe(
+      "voice-1",
+    );
+  });
+
+  it("falls back to the panel default when the target is absent/unknown", () => {
+    expect(initialDeviceSerial(list, null, defaultSymbolDevice)).toBe("ctrl-1");
+    expect(initialDeviceSerial(list, "not-in-pool", defaultSymbolDevice)).toBe(
+      "ctrl-1",
+    );
+  });
+
+  it("supports a list[0] fallback (the Constellation panel)", () => {
+    expect(initialDeviceSerial(list, null, (l) => l[0] ?? null)).toBe("voice-1");
+  });
+
+  it("returns null for an empty pool", () => {
+    expect(initialDeviceSerial([], "x", defaultSymbolDevice)).toBeNull();
   });
 });
 

--- a/web/src/api/spectrum.ts
+++ b/web/src/api/spectrum.ts
@@ -38,6 +38,22 @@ export function defaultSymbolDevice(
   return list.find((d) => d.role === "control") ?? list[0];
 }
 
+// initialDeviceSerial picks which SDR a signal-plot panel selects on first
+// load. When a `?device=<serial>` deep link names a device that is actually
+// in the pool, that wins — this is how a "signal detail" link from a live
+// call or a scanner hit lands the scope on the right SDR instead of the
+// enumeration default. Otherwise it falls back to the panel's normal default
+// (`fallback`, e.g. defaultSymbolDevice or list[0]). Returns null for an
+// empty pool.
+export function initialDeviceSerial(
+  list: SpectrumDevice[],
+  wanted: string | null | undefined,
+  fallback: (l: SpectrumDevice[]) => SpectrumDevice | null,
+): string | null {
+  if (wanted && list.some((d) => d.serial === wanted)) return wanted;
+  return fallback(list)?.serial ?? null;
+}
+
 // parentSerial resolves a wideband virtual voice-tap serial back to its
 // parent wideband device. The wbvoice manager registers taps as
 // "wb:<parent>:tap-N" (internal/sdr/wbvoice), and active calls on a wideband

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -645,6 +645,22 @@ export interface EventDTO {
   payload?: unknown;
 }
 
+// LocationFix is one over-the-air position report from a subscriber radio
+// (DMR LRRP / Motorola Unit GPS / L3Harris Talker GPS), returned by
+// GET /api/v1/locations. This is a moving radio's own position — the LRRP
+// map layer — not a fixed trunked-site location.
+export interface LocationFix {
+  system: string;
+  protocol: string;
+  radio_id: number;
+  talkgroup: number;
+  latitude: number;
+  longitude: number;
+  speed_knots: number;
+  heading_deg: number;
+  reported_at: string;
+}
+
 export interface ToneAlertDTO {
   profile: string;
   alpha_tag?: string;

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -477,6 +477,17 @@ export interface CallRow {
   duration_ms?: number;
   end_reason?: string;
   talkgroup_alpha?: string;
+  // Resolved alias/name of the source radio (RID), from the operator RID
+  // catalogue + live-decoded talker aliases; absent when unresolved.
+  source_alpha?: string;
+  // Mean received channel power in dBFS (front-end level, not calibrated
+  // RSSI/SNR); absent when unmeasured.
+  signal_dbfs?: number;
+  // Demod quality: RMS error-vector magnitude (%) and estimated symbol SNR
+  // (dB). Absent when unmeasured (only P25 Phase 1 chains measure them).
+  // These are the true decode-quality figures, unlike signal_dbfs.
+  evm_pct?: number;
+  snr_db?: number;
 }
 
 // CallEncryptionEvent is the SSE payload published as `call.encryption`

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -488,6 +488,9 @@ export interface CallRow {
   // These are the true decode-quality figures, unlike signal_dbfs.
   evm_pct?: number;
   snr_db?: number;
+  // True when a finished recording exists for this call. Play it via
+  // GET /api/v1/calls/{id}/audio — the filesystem path is never exposed.
+  has_recording?: boolean;
 }
 
 // CallEncryptionEvent is the SSE payload published as `call.encryption`

--- a/web/src/components/PositionMap.tsx
+++ b/web/src/components/PositionMap.tsx
@@ -27,7 +27,7 @@ export interface MapPoint {
 
   // Color category — one of the spec colours below. Maps to a
   // CircleMarker fillColor + outline.
-  kind: "aprs" | "ais" | "adsb" | "dsc-distress" | "default";
+  kind: "aprs" | "ais" | "adsb" | "dsc-distress" | "unit" | "default";
 
   // Tooltip body. Rendered as bold first line + optional
   // additional details lines.
@@ -52,6 +52,7 @@ const KIND_COLOR: Record<MapPoint["kind"], string> = {
   ais: "#06b6d4",           // cyan — marine vessel
   adsb: "#a855f7",          // purple — aircraft
   "dsc-distress": "#ef4444",// red — distress alert
+  unit: "#22c55e",          // green — trunked subscriber radio (LRRP/GPS)
   default: "#6b7280",       // grey — fallback
 };
 
@@ -60,6 +61,7 @@ const KIND_RADIUS: Record<MapPoint["kind"], number> = {
   ais: 5,
   adsb: 6,
   "dsc-distress": 8, // emphasise distress
+  unit: 5,
   default: 4,
 };
 

--- a/web/src/components/RIDLink.tsx
+++ b/web/src/components/RIDLink.tsx
@@ -1,0 +1,26 @@
+import { Link } from "react-router-dom";
+
+// RIDLink renders an inline link to the per-radio detail page
+// (/rids/{id}). Shared by the CC Activity feed, the Active-calls list, and
+// Call history so a source radio ID is always a click into that radio's
+// history — the cross-selection every trunking UI is expected to support.
+//
+// Styled like the surrounding mono text, underlined on hover so it reads as
+// actionable. Stops click propagation so it works inside a row that is
+// itself clickable (opens a detail modal). Renders the resolved alias when
+// one is supplied, otherwise the bare numeric id.
+export function RIDLink({
+  rid,
+  alias,
+  className = "font-mono text-accent hover:underline",
+}: {
+  rid: number;
+  alias?: string | null;
+  className?: string;
+}) {
+  return (
+    <Link to={`/rids/${rid}`} className={className} onClick={(e) => e.stopPropagation()}>
+      {alias || rid}
+    </Link>
+  );
+}

--- a/web/src/components/SignalHealth.tsx
+++ b/web/src/components/SignalHealth.tsx
@@ -1,0 +1,112 @@
+import { Badge } from "./ui/Badge";
+
+// SignalHealth — shared signal-quality readouts so an operator sees signal
+// health in context (on the Scanner cockpit, in a live call, in call
+// history) instead of having to open a separate DSP scope. Every trunking
+// UI shows an inline "is it healthy" cue next to the call/channel; these are
+// GopherTrunk's.
+//
+// Three primitives:
+//   - SignalQualityChip — the decoder's clean/marginal/poor verdict pill.
+//   - SignalLevelBar    — raw front-end level (dBFS) as a bar + number.
+//   - CallHealth        — a per-call badge row (SNR / EVM / level) built from
+//                         the measured figures the daemon stamps on a call.
+
+// SignalQualityChip is the simple control-channel signal indicator: a
+// clean/marginal/poor pill (green/amber/red), with the measured carrier offset
+// in its tooltip. Backed by the decoder's live TSBK (P25) / BSCH (TETRA)
+// frame-error rate, so it works across protocols — not just TETRA.
+export function SignalQualityChip({
+  quality,
+  offsetHz,
+}: {
+  quality: string;
+  offsetHz?: number;
+}) {
+  const tone =
+    quality === "clean" ? "ok" : quality === "marginal" ? "warn" : "err";
+  const offset =
+    offsetHz != null ? ` · offset ${offsetHz > 0 ? "+" : ""}${offsetHz} Hz` : "";
+  return (
+    <span title={`control-channel signal: ${quality}${offset}`}>
+      <Badge tone={tone}>signal: {quality}</Badge>
+    </span>
+  );
+}
+
+// SignalLevelBar renders the locked carrier's raw front-end level (mean channel
+// power in dBFS) as a numeric read-out plus a small level bar, so an operator can
+// aim an antenna or trim LNA gain against a live number instead of just the
+// clean/marginal/poor pill. This is signal STRENGTH, not decode quality — a strong
+// bar with a red quality chip means "plenty of signal, but something else (offset,
+// overload, wrong colour code) is hurting the decode".
+//
+// The bar maps the useful SDR range −90…−20 dBFS to 0…100%. Colour is by level:
+// green ≥ −45 dBFS, amber −45…−60, red below −60.
+export function SignalLevelBar({ dbfs }: { dbfs: number }) {
+  const floorDb = -90;
+  const ceilDb = -20;
+  const pct = Math.max(
+    0,
+    Math.min(100, ((dbfs - floorDb) / (ceilDb - floorDb)) * 100),
+  );
+  const color = dbfs >= -45 ? "#34d399" : dbfs >= -60 ? "#fbbf24" : "#f87171";
+  return (
+    <span
+      className="inline-flex items-center gap-1.5"
+      title={`signal level ${dbfs.toFixed(1)} dBFS (mean channel power) — aim antenna / trim LNA gain to maximise`}
+    >
+      <span
+        className="inline-block h-1.5 w-12 rounded-full bg-panel overflow-hidden"
+        aria-hidden
+      >
+        <span
+          className="block h-full rounded-full"
+          style={{ width: `${pct}%`, backgroundColor: color }}
+        />
+      </span>
+      <span className="font-mono text-xs text-muted">{dbfs.toFixed(1)} dBFS</span>
+    </span>
+  );
+}
+
+// CallHealth renders a compact per-call signal-health readout from the figures
+// the daemon stamps on a call. SNR (dB) and EVM (%) are the true decode-quality
+// numbers — the ones to compare against another decoder — and are measured only
+// by the P25 Phase 1 chains today; signal level (dBFS) is front-end power. When a
+// call carries none of them (most protocols, currently), renders an em dash so a
+// history table cell is never blank.
+//
+// Tone thresholds match the C4FM regime GopherTrunk targets: SNR ≥18 dB clean /
+// ≥10 marginal / below poor; EVM ≤10% clean / ≤20 marginal / above poor.
+export function CallHealth({
+  evmPct,
+  snrDb,
+  signalDbfs,
+}: {
+  evmPct?: number | null;
+  snrDb?: number | null;
+  signalDbfs?: number | null;
+}) {
+  const hasSNR = snrDb != null && Number.isFinite(snrDb);
+  const hasEVM = evmPct != null && Number.isFinite(evmPct);
+  const hasLevel = signalDbfs != null && Number.isFinite(signalDbfs);
+  if (!hasSNR && !hasEVM && !hasLevel) {
+    return <span className="text-muted text-xs">—</span>;
+  }
+  return (
+    <span className="inline-flex flex-wrap items-center gap-1.5">
+      {hasSNR && (
+        <Badge tone={snrDb! >= 18 ? "ok" : snrDb! >= 10 ? "warn" : "err"}>
+          SNR {snrDb!.toFixed(1)} dB
+        </Badge>
+      )}
+      {hasEVM && (
+        <Badge tone={evmPct! <= 10 ? "ok" : evmPct! <= 20 ? "warn" : "err"}>
+          EVM {evmPct!.toFixed(1)}%
+        </Badge>
+      )}
+      {hasLevel && <SignalLevelBar dbfs={signalDbfs!} />}
+    </span>
+  );
+}

--- a/web/src/components/shell/AppShell.test.tsx
+++ b/web/src/components/shell/AppShell.test.tsx
@@ -35,7 +35,7 @@ describe("AppShell navigation", () => {
     ).toBeInTheDocument();
   });
 
-  it("opens the drawer from More and exposes every panel — including the previously-orphaned DSP panels", async () => {
+  it("opens the drawer from More and exposes every registry panel", async () => {
     const user = userEvent.setup();
     renderShell();
 
@@ -61,9 +61,11 @@ describe("AppShell navigation", () => {
         `drawer missing ${item.label}`,
       ).toBeInTheDocument();
     }
-    // The headline regression: these were unreachable everywhere before.
-    expect(within(drawer).getByText("Constellation")).toBeInTheDocument();
-    expect(within(drawer).getByText("Histogram")).toBeInTheDocument();
+    // The per-signal scopes (Constellation, Eye, Histogram, …) are tabs
+    // inside the Plots hub now, not standalone drawer items — so the
+    // headline reachability guarantee is that the Plots hub is present.
+    expect(within(drawer).getByText("Plots")).toBeInTheDocument();
+    expect(within(drawer).queryByText("Constellation")).toBeNull();
   });
 
   it("closes the drawer on Escape", async () => {
@@ -87,10 +89,13 @@ describe("AppShell navigation", () => {
     });
 
     const input = within(palette).getByRole("textbox");
+    // "histog" no longer matches a standalone Histogram item — the scope is a
+    // Plots tab now, and its search term is carried on the Plots hub's keywords,
+    // so the palette resolves it to Plots.
     await user.type(input, "histog");
     const options = within(palette).getAllByRole("option");
     expect(options).toHaveLength(1);
-    expect(options[0]).toHaveTextContent("Histogram");
+    expect(options[0]).toHaveTextContent("Plots");
   });
 
   it("reflects the live connection status in the top bar", () => {

--- a/web/src/nav/registry.test.ts
+++ b/web/src/nav/registry.test.ts
@@ -10,11 +10,17 @@ import {
 } from "./registry";
 import { useShared } from "../store/shared";
 
-// Every route mounted by App.tsx must have a registry entry, otherwise
-// it becomes unreachable by navigation (the pre-overhaul bug, where six
-// DSP panels were orphaned). Keep this list in sync with the <Route>
-// table in App.tsx; the dynamic /plots/:tab, the "/" redirect, and the
-// "*" catch-all are intentionally excluded.
+// Every top-level route mounted by App.tsx must have a registry entry,
+// otherwise it becomes unreachable by navigation (the pre-overhaul bug,
+// where six DSP panels were orphaned). Keep this list in sync with the
+// <Route> table in App.tsx; the dynamic /plots/:tab, the "/" redirect,
+// and the "*" catch-all are intentionally excluded — and so are the six
+// per-signal scope routes (/constellation, /symbols, /eye, /mixer,
+// /tuning, /histogram), which are now tabs *inside* the Plots hub rather
+// than standalone nav items. Their routes still resolve for deep links;
+// their reachability is guarded by the "Plots hub carries the scope
+// search terms" test below.
+const SCOPE_PATHS = ["/constellation", "/symbols", "/eye", "/mixer", "/tuning", "/histogram"];
 const ROUTED_PATHS = [
   "/dashboard",
   "/active",
@@ -22,12 +28,6 @@ const ROUTED_PATHS = [
   "/hunt",
   "/spectrum",
   "/plots",
-  "/constellation",
-  "/symbols",
-  "/eye",
-  "/mixer",
-  "/tuning",
-  "/histogram",
   "/bookmarks",
   "/systems",
   "/talkgroups",
@@ -61,14 +61,18 @@ describe("nav registry", () => {
     }
   });
 
-  it("exposes exactly four mobile bottom-nav primaries", () => {
+  it("exposes exactly four mobile bottom-nav primaries — the two core workflows included", () => {
+    // Scan AND Hunt are the primary trunking mission, so both sit in the
+    // 4-slot bottom nav. Settings moved out (still reachable via the
+    // sidebar, drawer, and ⌘K palette).
     expect(PRIMARY_ITEMS).toHaveLength(4);
     expect(PRIMARY_ITEMS.map((i) => i.to)).toEqual([
       "/dashboard",
       "/active",
       "/scanner",
-      "/settings",
+      "/hunt",
     ]);
+    expect(PRIMARY_ITEMS.map((i) => i.to)).not.toContain("/settings");
   });
 
   it("has no duplicate route targets", () => {
@@ -85,17 +89,20 @@ describe("nav registry", () => {
     );
   });
 
-  it("includes the previously-orphaned DSP panels", () => {
+  it("consolidates the per-signal scopes under the Plots hub (not standalone nav items)", () => {
+    // The six DSP scopes are tabs inside Plots now, so they must NOT appear
+    // as their own top-level nav items…
     const registered = new Set(NAV_ITEMS.map((i) => i.to));
-    for (const p of [
-      "/constellation",
-      "/symbols",
-      "/eye",
-      "/mixer",
-      "/tuning",
-      "/histogram",
-    ]) {
-      expect(registered).toContain(p);
+    for (const p of SCOPE_PATHS) {
+      expect(registered, `${p} should not be a standalone nav item`).not.toContain(p);
+    }
+    // …but the Plots hub must still be reachable and carry each scope's
+    // search terms so ⌘K keeps finding them (no discoverability regression).
+    const plots = NAV_ITEMS.find((i) => i.to === "/plots");
+    expect(plots, "Plots hub missing from nav").toBeDefined();
+    const kw = new Set(plots?.keywords ?? []);
+    for (const term of ["constellation", "symbol", "eye", "mixer", "tuning", "histogram"]) {
+      expect(kw, `Plots keywords missing "${term}"`).toContain(term);
     }
   });
 

--- a/web/src/nav/registry.ts
+++ b/web/src/nav/registry.ts
@@ -67,7 +67,7 @@ export const NAV_GROUPS: NavGroup[] = [
     id: "discovery",
     label: "Discovery",
     items: [
-      { to: "/hunt", label: "Hunt", icon: "🔍", keywords: ["discover", "sweep", "spectrum", "survey"] },
+      { to: "/hunt", label: "Hunt", icon: "🔍", primary: true, keywords: ["discover", "sweep", "spectrum", "survey"] },
       { to: "/import", label: "Import", icon: "↗", keywords: ["radioreference", "rr", "csv", "pdf"] },
     ],
   },
@@ -76,21 +76,34 @@ export const NAV_GROUPS: NavGroup[] = [
     label: "Signals & DSP",
     items: [
       { to: "/spectrum", label: "Spectrum", icon: "≈", keywords: ["waterfall", "fft"] },
-      { to: "/plots", label: "Plots", icon: "✦", keywords: ["dsp", "charts"] },
-      { to: "/constellation", label: "Constellation", icon: "✲", keywords: ["iq", "scatter", "psk"] },
-      { to: "/symbols", label: "Symbol Scope", icon: "⋮", keywords: ["dsp", "demod", "slicer"] },
-      { to: "/eye", label: "Eye Diagram", icon: "◉", keywords: ["dsp", "c4fm", "quality"] },
-      { to: "/mixer", label: "Mixer", icon: "⊞", keywords: ["dsp", "baseband", "spectrum"] },
-      { to: "/tuning", label: "Tuning", icon: "⊹", keywords: ["dsp", "receiver", "afc"] },
-      { to: "/histogram", label: "Histogram", icon: "▥", keywords: ["dsp", "symbol", "levels"] },
+      // The Plots hub tabs the per-signal scopes (constellation, symbols, eye,
+      // mixer, tuning, histogram) — they are one screen, opened in context, not
+      // six separate always-listed panels. Their standalone routes still resolve
+      // for deep links; their search terms are carried here so ⌘K still finds them.
+      {
+        to: "/plots",
+        label: "Plots",
+        icon: "✦",
+        keywords: [
+          "dsp", "charts", "constellation", "iq", "scatter", "psk",
+          "symbol", "symbols", "slicer", "eye", "c4fm", "mixer", "baseband",
+          "tuning", "receiver", "afc", "histogram", "levels", "quality",
+        ],
+      },
     ],
   },
   {
-    id: "decoders",
-    label: "Decoders & Logs",
+    id: "logs",
+    label: "Logs",
     items: [
       { to: "/events", label: "Events", icon: "≣", keywords: ["log", "stream"] },
       { to: "/tones", label: "Tones", icon: "♪", keywords: ["tone out", "two tone", "qcii"] },
+    ],
+  },
+  {
+    id: "receivers",
+    label: "Other Receivers",
+    items: [
       { to: "/pagers", label: "Pagers", icon: "✉", keywords: ["pocsag", "flex", "messages"] },
       { to: "/aprs", label: "APRS", icon: "⛯", keywords: ["packet", "position", "ax25"] },
       { to: "/ais", label: "AIS", icon: "⚓", keywords: ["vessel", "marine", "ship"] },
@@ -114,7 +127,7 @@ export const NAV_GROUPS: NavGroup[] = [
     id: "system",
     label: "System",
     items: [
-      { to: "/settings", label: "Settings", icon: "⚙", primary: true, keywords: ["preferences", "theme", "config"] },
+      { to: "/settings", label: "Settings", icon: "⚙", keywords: ["preferences", "theme", "config"] },
       { to: "/devices", label: "Devices", icon: "⌗", keywords: ["sdr", "pool", "rtl", "dongle"] },
       { to: "/metrics", label: "Metrics", icon: "▰", keywords: ["prometheus", "stats", "graphs"] },
       {

--- a/web/src/panels/Active.tsx
+++ b/web/src/panels/Active.tsx
@@ -4,6 +4,7 @@ import { writes } from "../api/write";
 import { Column, DataTable } from "../components/DataTable";
 import { ConfirmModal } from "../components/ConfirmModal";
 import { DetailField, DetailModal } from "../components/DetailModal";
+import { RIDLink } from "../components/RIDLink";
 import { StaleIndicator } from "../components/ui/StaleIndicator";
 import { PageHeader } from "../components/ui/PageHeader";
 import type { ActiveCallDTO } from "../api/types";
@@ -88,6 +89,21 @@ export function Active() {
         header: "System",
         render: (r) => <span className="text-xs">{r.grant.system}</span>,
         sort: (a, b) => a.grant.system.localeCompare(b.grant.system),
+        className: "hidden md:table-cell",
+        headerClassName: "hidden md:table-cell",
+      },
+      {
+        // Who is keyed up — the transmitting radio. A trunking operator scans
+        // this at a glance, so it belongs in the row, not just the modal.
+        key: "source",
+        header: "Source",
+        render: (r) =>
+          r.grant.source_id ? (
+            <RIDLink rid={r.grant.source_id} className="font-mono text-xs text-accent hover:underline" />
+          ) : (
+            <span className="text-muted text-xs">—</span>
+          ),
+        sort: (a, b) => (a.grant.source_id ?? 0) - (b.grant.source_id ?? 0),
         className: "hidden md:table-cell",
         headerClassName: "hidden md:table-cell",
       },
@@ -193,7 +209,11 @@ export function Active() {
             <DetailField
               label="Source"
               mono
-              value={selected.grant.source_id ?? null}
+              value={
+                selected.grant.source_id ? (
+                  <RIDLink rid={selected.grant.source_id} />
+                ) : null
+              }
             />
             <DetailField
               label="Frequency"

--- a/web/src/panels/Active.tsx
+++ b/web/src/panels/Active.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
 import { api } from "../api/client";
+import { parentSerial } from "../api/spectrum";
 import { writes } from "../api/write";
 import { Column, DataTable } from "../components/DataTable";
 import { ConfirmModal } from "../components/ConfirmModal";
@@ -299,6 +301,14 @@ export function Active() {
               />
               <DetailField label="Mode" value={selected.talkgroup.mode} />
             </div>
+          )}
+          {selected.following !== false && selected.device_serial && (
+            <Link
+              to={`/plots/constellation?device=${encodeURIComponent(parentSerial(selected.device_serial))}`}
+              className="inline-block text-sm text-accent hover:underline pt-1"
+            >
+              Signal detail — open the scopes on this SDR →
+            </Link>
           )}
           {selected.following === false ? (
             <p className="text-xs text-muted pt-2">

--- a/web/src/panels/CCActivity.tsx
+++ b/web/src/panels/CCActivity.tsx
@@ -1,9 +1,9 @@
 import { useMemo, useRef, useState } from "react";
-import { Link } from "react-router-dom";
 import { useShared } from "../store/shared";
 import { groupEvents } from "../lib/groupEvents";
 import type { EventDTO, TalkgroupDTO } from "../api/types";
 import { PageHeader } from "../components/ui/PageHeader";
+import { RIDLink } from "../components/RIDLink";
 import { formatClock } from "../lib/formatTime";
 
 // CC Activity panel — a focused view of the trunked control-channel
@@ -51,17 +51,10 @@ interface Row {
 
 // ridLink renders an inline link to the per-RID detail page, styled
 // like the surrounding mono text but underlined on hover so it reads
-// as actionable in the CC Activity feed.
+// as actionable in the CC Activity feed. Thin wrapper over the shared
+// RIDLink so the call sites below read unchanged.
 function ridLink(rid: number) {
-  return (
-    <Link
-      to={`/rids/${rid}`}
-      className="font-mono text-accent hover:underline"
-      onClick={(e) => e.stopPropagation()}
-    >
-      {rid}
-    </Link>
-  );
+  return <RIDLink rid={rid} />;
 }
 
 export function CCActivity() {

--- a/web/src/panels/Constellation.test.tsx
+++ b/web/src/panels/Constellation.test.tsx
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { render as rtlRender, screen, waitFor, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+// Panels render react-router links / read search params, so every
+// render needs a Router context.
+function render(ui: Parameters<typeof rtlRender>[0]) {
+  return rtlRender(<MemoryRouter>{ui}</MemoryRouter>);
+}
 
 vi.mock("../api/spectrum", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../api/spectrum")>();

--- a/web/src/panels/Constellation.tsx
+++ b/web/src/panels/Constellation.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { PageHeader } from "../components/ui/PageHeader";
 import {
   fetchSpectrumDevices,
+  initialDeviceSerial,
   parentSerial,
   type SpectrumDevice,
 } from "../api/spectrum";
@@ -129,6 +131,9 @@ export function Constellation() {
   useActiveCallsPoll();
   const [devices, setDevices] = useState<SpectrumDevice[]>([]);
   const [selected, setSelected] = useState<string | null>(null);
+  // A "signal detail" link from a call / scanner hit can name the SDR to scope
+  // via ?device=; honoured on first load, else the enumeration default.
+  const targetDevice = useSearchParams()[0].get("device");
   const [conn, setConn] = useState<ConnState>("closed");
   const [latest, setLatest] = useState<IQFrame | null>(null);
   const [symLatest, setSymLatest] = useState<SymbolFrame | null>(null);
@@ -249,7 +254,11 @@ export function Constellation() {
         if (cancel) return;
         setDevices(list);
         setError(null);
-        if (list.length > 0 && selected == null) setSelected(list[0].serial);
+        if (list.length > 0 && selected == null) {
+          setSelected(
+            initialDeviceSerial(list, targetDevice, (l) => l[0] ?? null),
+          );
+        }
       } catch (e) {
         if (cancel) return;
         setError(e instanceof Error ? e.message : String(e));
@@ -258,7 +267,7 @@ export function Constellation() {
     return () => {
       cancel = true;
     };
-  }, [cfg, selected]);
+  }, [cfg, selected, targetDevice]);
 
   // Newest active call on the selected SDR, and the view offset (kHz)
   // that would centre it. This is the "last locked channel" the issue

--- a/web/src/panels/Dashboard.test.tsx
+++ b/web/src/panels/Dashboard.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+vi.mock("../api/client", () => ({
+  api: {
+    health: vi.fn().mockResolvedValue({ status: "ok" }),
+    activeCalls: vi.fn().mockResolvedValue([]),
+    devices: vi.fn().mockResolvedValue([]),
+    systems: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+import { useShared } from "../store/shared";
+import { Dashboard } from "./Dashboard";
+
+function resetStore() {
+  useShared.setState({
+    serverURL: "http://localhost:8080",
+    token: null,
+    connected: true,
+    wsStatus: "open",
+    events: [],
+    activeCalls: [],
+    devices: [],
+    systems: [],
+    health: null,
+  });
+}
+
+function renderDash() {
+  return render(
+    <MemoryRouter>
+      <Dashboard />
+    </MemoryRouter>,
+  );
+}
+
+describe("Dashboard landing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStore();
+  });
+
+  it("leads with Scan and Hunt quick actions linking to the workflows", () => {
+    renderDash();
+    const scan = screen.getByRole("link", { name: /Scan known systems/i });
+    const hunt = screen.getByRole("link", { name: /Hunt for new systems/i });
+    expect(scan).toHaveAttribute("href", "/scanner");
+    expect(hunt).toHaveAttribute("href", "/hunt");
+  });
+
+  it("summarizes a recent event with its talkgroup and system, not just the kind", async () => {
+    useShared.setState({
+      events: [
+        {
+          kind: "call.grant",
+          timestamp: "2026-08-12T10:00:00Z",
+          payload: { group_id: 1001, source_id: 4242, system: "CountyP25" },
+        },
+      ],
+    });
+    renderDash();
+    // The compact feed summarizes the payload (TG · source · system), so it
+    // says what happened rather than only naming the event kind.
+    await waitFor(() => {
+      expect(screen.getByText(/TG 1001.*4242.*CountyP25/)).toBeInTheDocument();
+    });
+  });
+
+  it("shows the active-call roster with the transmitting radio", async () => {
+    useShared.setState({
+      activeCalls: [
+        {
+          grant: {
+            system: "CountyP25",
+            protocol: "p25",
+            group_id: 1001,
+            source_id: 4242,
+            frequency_hz: 851_000_000,
+          },
+          talkgroup: { id: 1001, alpha_tag: "Dispatch" },
+          device_serial: "SDR1",
+          started_at: "2026-08-12T10:00:00Z",
+          following: true,
+        },
+      ] as never,
+    });
+    renderDash();
+    expect(screen.getByText("TG 1001")).toBeInTheDocument();
+    expect(screen.getByText("Dispatch")).toBeInTheDocument();
+  });
+});

--- a/web/src/panels/Dashboard.tsx
+++ b/web/src/panels/Dashboard.tsx
@@ -1,46 +1,59 @@
+import { useEffect, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
 import { api } from "../api/client";
 import { PageHeader } from "../components/ui/PageHeader";
 import { Badge } from "../components/ui/Badge";
+import { RIDLink } from "../components/RIDLink";
 import { useDataPoll } from "../hooks/useDataPoll";
 import { selectClientConfig, useShared } from "../store/shared";
+import type { EventDTO } from "../api/types";
 
-// Dashboard: top-line counts + a peek at the last few events. The
-// fuller dashboard (with charts) is a follow-up PR; this one
-// proves the live-update wiring works end-to-end.
+// Dashboard — the operations landing. Trunking scanners lead with the two
+// core tasks (scan / hunt) and a live "who's talking now" roster, not a
+// spectrum or a wall of stats. This mirrors that: prominent Scan/Hunt entry
+// points, the active-call roster as the hero, top-line health, and a
+// recent-activity feed that actually says what happened.
 export function Dashboard() {
   const cfg = useShared(selectClientConfig);
+  const navigate = useNavigate();
   const setHealth = useShared((s) => s.setHealth);
   const setActiveCalls = useShared((s) => s.setActiveCalls);
   const setDevices = useShared((s) => s.setDevices);
-  const setAudio = useShared((s) => s.setAudio);
+  const setSystems = useShared((s) => s.setSystems);
 
   const health = useShared((s) => s.health);
   const activeCalls = useShared((s) => s.activeCalls);
   const devices = useShared((s) => s.devices);
-  const audio = useShared((s) => s.audio);
+  const systems = useShared((s) => s.systems);
   const events = useShared((s) => s.events);
   const wsStatus = useShared((s) => s.wsStatus);
 
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const t = window.setInterval(() => setNow(Date.now()), 1_000);
+    return () => window.clearInterval(t);
+  }, []);
+
   useDataPoll({
     fetcher: async () => {
-      const [h, calls, devs, aud] = await Promise.allSettled([
+      const [h, calls, devs, sys] = await Promise.allSettled([
         api.health(cfg),
         api.activeCalls(cfg),
         api.devices(cfg),
-        api.audio(cfg),
+        api.systems(cfg),
       ]);
       return {
         health: h.status === "fulfilled" ? h.value : null,
         calls: calls.status === "fulfilled" ? calls.value : null,
         devices: devs.status === "fulfilled" ? devs.value : null,
-        audio: aud.status === "fulfilled" ? aud.value : null,
+        systems: sys.status === "fulfilled" ? sys.value : null,
       };
     },
     onData: (d) => {
       if (d.health) setHealth(d.health);
       if (d.calls) setActiveCalls(d.calls);
       if (d.devices) setDevices(d.devices);
-      if (d.audio) setAudio(d.audio);
+      if (d.systems) setSystems(d.systems);
     },
     intervalMs: 3_000,
     resetKey: cfg.baseURL,
@@ -49,7 +62,7 @@ export function Dashboard() {
   return (
     <div className="space-y-4">
       <PageHeader
-        title="Dashboard"
+        title="Operations"
         actions={
           <Badge
             tone={
@@ -69,19 +82,26 @@ export function Dashboard() {
         }
       />
 
+      {/* The two core trunking workflows, front and center. */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <TaskCard
+          to="/scanner"
+          icon="≋"
+          title="Scan known systems"
+          desc="Follow talkgroups on your configured trunked and conventional systems."
+        />
+        <TaskCard
+          to="/hunt"
+          icon="🔍"
+          title="Hunt for new systems"
+          desc="Discover, identify and map unknown control channels and sites."
+        />
+      </div>
+
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
         <StatCard label="Active calls" value={activeCalls.length} />
+        <StatCard label="Systems" value={systems.length} />
         <StatCard label="Devices attached" value={devices.length} />
-        <StatCard
-          label="Audio backend"
-          value={
-            audio
-              ? audio.backend_enabled
-                ? `${(audio.sample_rate / 1000).toFixed(1)} kHz`
-                : "off"
-              : "—"
-          }
-        />
         <StatCard
           label="Daemon"
           value={health?.status ?? "unknown"}
@@ -89,8 +109,69 @@ export function Dashboard() {
         />
       </div>
 
+      {/* Hero: who's talking right now. */}
       <section className="panel p-4">
-        <h3 className="panel-title mb-2">Recent events</h3>
+        <div className="flex items-baseline justify-between mb-2">
+          <h3 className="panel-title">Active calls</h3>
+          <Link to="/active" className="text-xs text-accent hover:underline">
+            Open Active →
+          </Link>
+        </div>
+        {activeCalls.length === 0 ? (
+          <p className="text-muted text-sm">
+            No calls right now. Grants appear here the moment the daemon
+            allocates a voice device.
+          </p>
+        ) : (
+          <ul className="divide-y divide-panel">
+            {activeCalls.slice(0, 8).map((c) => (
+              <li
+                key={`${c.device_serial}-${c.grant.system}-${c.grant.group_id}-${c.started_at}`}
+                className="py-2 flex items-center gap-3 cursor-pointer hover:bg-panel/40 -mx-2 px-2 rounded"
+                onClick={() => navigate("/active")}
+              >
+                <span className="font-mono text-accent shrink-0">
+                  TG {c.grant.group_id}
+                </span>
+                <span className="text-sm truncate">
+                  {c.talkgroup?.alpha_tag ?? c.grant.system}
+                </span>
+                {c.grant.source_id ? (
+                  <span className="text-xs text-muted shrink-0">
+                    from <RIDLink rid={c.grant.source_id} className="text-accent hover:underline" />
+                  </span>
+                ) : null}
+                <span className="ml-auto flex items-center gap-1 shrink-0">
+                  {c.grant.encrypted && <span className="pill-warn">enc</span>}
+                  {c.grant.emergency && <span className="pill-err">emerg</span>}
+                  {c.following === false && (
+                    <span className="pill" title="Announced on the control channel; no voice tuner is following it">
+                      observed
+                    </span>
+                  )}
+                  <span className="font-mono text-xs tabular-nums text-muted">
+                    {elapsed(c.started_at, now)}
+                  </span>
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+        {activeCalls.length > 8 && (
+          <p className="text-xs text-muted mt-2">
+            +{activeCalls.length - 8} more — open Active for the full list.
+          </p>
+        )}
+      </section>
+
+      {/* Recent activity — actually says what happened, not just the kind. */}
+      <section className="panel p-4">
+        <div className="flex items-baseline justify-between mb-2">
+          <h3 className="panel-title">Recent activity</h3>
+          <Link to="/cc" className="text-xs text-accent hover:underline">
+            Open CC Activity →
+          </Link>
+        </div>
         {events.length === 0 ? (
           <p className="text-muted text-sm">
             No events yet. The stream connects automatically.
@@ -98,46 +179,72 @@ export function Dashboard() {
         ) : (
           <ul className="space-y-1 text-xs font-mono max-h-72 overflow-auto">
             {events
-              .slice(-50)
+              .slice(-40)
               .reverse()
               .map((ev, i) => (
                 <li key={`${ev.timestamp}-${i}`} className="flex gap-3">
                   <span className="text-muted shrink-0">
                     {ev.timestamp.replace("T", " ").replace(/\..*$/, "")}
                   </span>
-                  <span className="text-accent shrink-0">{ev.kind}</span>
+                  <span className="text-accent shrink-0 w-28 truncate">
+                    {ev.kind}
+                  </span>
+                  <span className="truncate text-fg/80">
+                    {summarizeEvent(ev)}
+                  </span>
                 </li>
               ))}
           </ul>
         )}
       </section>
-
-      <section className="panel p-4">
-        <h3 className="panel-title mb-2">Active calls</h3>
-        {activeCalls.length === 0 ? (
-          <p className="text-muted text-sm">No calls right now.</p>
-        ) : (
-          <ul className="divide-y divide-panel">
-            {activeCalls.map((c) => (
-              <li
-                key={`${c.device_serial}-${c.started_at}`}
-                className="py-2 flex items-baseline gap-3"
-              >
-                <span className="font-mono text-accent">
-                  TG {c.grant.group_id}
-                </span>
-                <span className="text-sm">
-                  {c.talkgroup?.alpha_tag ?? c.grant.system}
-                </span>
-                <span className="ml-auto text-xs text-muted">
-                  {c.device_serial}
-                </span>
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
     </div>
+  );
+}
+
+// summarizeEvent renders a compact one-line summary from an event payload —
+// TG / source radio / system / frequency for the common trunking kinds — so
+// the feed says what happened instead of only naming the event kind. Reads
+// defensively (payload is typed unknown on the wire).
+function summarizeEvent(ev: EventDTO): string {
+  const p = ev.payload;
+  if (!p || typeof p !== "object") return "";
+  const o = p as Record<string, unknown>;
+  const parts: string[] = [];
+  const tg = o.group_id ?? o.talkgroup;
+  if (typeof tg === "number") parts.push(`TG ${tg}`);
+  const src = o.source_id ?? o.source ?? o.radio_id;
+  if (typeof src === "number" && src !== 0) parts.push(`← ${src}`);
+  if (typeof o.system === "string" && o.system) parts.push(o.system);
+  const freq = o.frequency_hz ?? o.freq_hz ?? o.frequency;
+  if (typeof freq === "number" && freq > 0)
+    parts.push(`${(freq / 1e6).toFixed(4)} MHz`);
+  return parts.join(" · ");
+}
+
+function TaskCard({
+  to,
+  icon,
+  title,
+  desc,
+}: {
+  to: string;
+  icon: string;
+  title: string;
+  desc: string;
+}) {
+  return (
+    <Link
+      to={to}
+      className="panel p-4 flex items-start gap-3 hover:bg-panel/50 transition-colors"
+    >
+      <span className="text-2xl leading-none shrink-0" aria-hidden>
+        {icon}
+      </span>
+      <span>
+        <span className="block font-semibold">{title}</span>
+        <span className="block text-sm text-muted">{desc}</span>
+      </span>
+    </Link>
   );
 }
 
@@ -153,13 +260,18 @@ function StatCard({
   return (
     <div className="panel p-4">
       <p className="panel-title">{label}</p>
-      <p
-        className={
-          ok === false ? "stat-value text-err" : "stat-value"
-        }
-      >
+      <p className={ok === false ? "stat-value text-err" : "stat-value"}>
         {value}
       </p>
     </div>
   );
+}
+
+function elapsed(startedAt: string, now: number): string {
+  const startMs = Date.parse(startedAt);
+  if (Number.isNaN(startMs)) return "—";
+  const totalSeconds = Math.max(0, Math.floor((now - startMs) / 1000));
+  const m = Math.floor(totalSeconds / 60);
+  const s = totalSeconds % 60;
+  return `${m.toString().padStart(2, "0")}:${s.toString().padStart(2, "0")}`;
 }

--- a/web/src/panels/EyeDiagram.test.tsx
+++ b/web/src/panels/EyeDiagram.test.tsx
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { render as rtlRender, screen, waitFor, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+// Panels render react-router links / read search params, so every
+// render needs a Router context.
+function render(ui: Parameters<typeof rtlRender>[0]) {
+  return rtlRender(<MemoryRouter>{ui}</MemoryRouter>);
+}
 
 vi.mock("../api/spectrum", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../api/spectrum")>()),

--- a/web/src/panels/EyeDiagram.tsx
+++ b/web/src/panels/EyeDiagram.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { PageHeader } from "../components/ui/PageHeader";
+import { useSearchParams } from "react-router-dom";
 import {
   fetchSpectrumDevices,
   defaultSymbolDevice,
+  initialDeviceSerial,
   parentSerial,
   type SpectrumDevice,
 } from "../api/spectrum";
@@ -38,6 +40,9 @@ export function EyeDiagram() {
   useActiveCallsPoll();
   const [devices, setDevices] = useState<SpectrumDevice[]>([]);
   const [selected, setSelected] = useState<string | null>(null);
+  // A "signal detail" link from a call / scanner hit can name the SDR to
+  // scope via ?device=; honoured on first load, else the panel default.
+  const targetDevice = useSearchParams()[0].get("device");
   const [conn, setConn] = useState<ConnState>("closed");
   const [latest, setLatest] = useState<SymbolFrame | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -64,8 +69,8 @@ export function EyeDiagram() {
         setDevices(list);
         setError(null);
         if (selected == null) {
-          const def = defaultSymbolDevice(list);
-          if (def) setSelected(def.serial);
+          const s = initialDeviceSerial(list, targetDevice, defaultSymbolDevice);
+          if (s) setSelected(s);
         }
       } catch (e) {
         if (cancel) return;
@@ -75,7 +80,7 @@ export function EyeDiagram() {
     return () => {
       cancel = true;
     };
-  }, [cfg, selected]);
+  }, [cfg, selected, targetDevice]);
 
   const device = useMemo(
     () => devices.find((d) => d.serial === selected) ?? null,

--- a/web/src/panels/Histogram.test.tsx
+++ b/web/src/panels/Histogram.test.tsx
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render as rtlRender, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+// Panels render react-router links / read search params, so every
+// render needs a Router context.
+function render(ui: Parameters<typeof rtlRender>[0]) {
+  return rtlRender(<MemoryRouter>{ui}</MemoryRouter>);
+}
 
 vi.mock("../api/spectrum", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../api/spectrum")>()),

--- a/web/src/panels/Histogram.tsx
+++ b/web/src/panels/Histogram.tsx
@@ -10,9 +10,11 @@ import {
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Bar } from "react-chartjs-2";
 import { PageHeader } from "../components/ui/PageHeader";
+import { useSearchParams } from "react-router-dom";
 import {
   fetchSpectrumDevices,
   defaultSymbolDevice,
+  initialDeviceSerial,
   parentSerial,
   type SpectrumDevice,
 } from "../api/spectrum";
@@ -109,6 +111,9 @@ export function Histogram() {
   useActiveCallsPoll();
   const [devices, setDevices] = useState<SpectrumDevice[]>([]);
   const [selected, setSelected] = useState<string | null>(null);
+  // A "signal detail" link from a call / scanner hit can name the SDR to
+  // scope via ?device=; honoured on first load, else the panel default.
+  const targetDevice = useSearchParams()[0].get("device");
   const [conn, setConn] = useState<ConnState>("closed");
   const [latest, setLatest] = useState<SymbolFrame | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -135,8 +140,8 @@ export function Histogram() {
         setDevices(list);
         setError(null);
         if (selected == null) {
-          const def = defaultSymbolDevice(list);
-          if (def) setSelected(def.serial);
+          const s = initialDeviceSerial(list, targetDevice, defaultSymbolDevice);
+          if (s) setSelected(s);
         }
       } catch (e) {
         if (cancel) return;
@@ -146,7 +151,7 @@ export function Histogram() {
     return () => {
       cancel = true;
     };
-  }, [cfg, selected]);
+  }, [cfg, selected, targetDevice]);
 
   const device = useMemo(
     () => devices.find((d) => d.serial === selected) ?? null,

--- a/web/src/panels/History.tsx
+++ b/web/src/panels/History.tsx
@@ -1,9 +1,12 @@
 import { useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { api } from "../api/client";
 import { writes } from "../api/write";
 import { Column, DataTable } from "../components/DataTable";
 import { ConfirmModal } from "../components/ConfirmModal";
 import { DetailField, DetailModal } from "../components/DetailModal";
+import { RIDLink } from "../components/RIDLink";
+import { CallHealth } from "../components/SignalHealth";
 import { PageHeader } from "../components/ui/PageHeader";
 import type { CallRow } from "../api/types";
 import { formatP25Algorithm, formatP25KeyID } from "../api/p25Algorithm";
@@ -27,16 +30,29 @@ export function History() {
   const [error, setError] = useState<string | null>(null);
   const [confirmSweep, setConfirmSweep] = useState(false);
 
+  // Cross-links from Talkgroups / Systems seed the filter via query params
+  // (?system=, ?group_id=) so "view this TG's / system's calls" lands here
+  // pre-filtered — the cross-selection trunking operators expect.
+  const [searchParams] = useSearchParams();
+  const initSystem = searchParams.get("system") ?? "";
+  const initGroup = searchParams.get("group_id") ?? "";
+
   // Form fields kept separate from the "submitted" filter object so
   // typing into the inputs doesn't trigger a fetch on every keystroke.
   const [limitInput, setLimitInput] = useState("200");
-  const [systemInput, setSystemInput] = useState("");
-  const [groupInput, setGroupInput] = useState("");
+  const [systemInput, setSystemInput] = useState(initSystem);
+  const [groupInput, setGroupInput] = useState(initGroup);
   const [filter, setFilter] = useState<{
     limit?: number;
     system?: string;
     group_id?: number;
-  }>({ limit: 200 });
+  }>(() => {
+    const f: { limit?: number; system?: string; group_id?: number } = { limit: 200 };
+    if (initSystem) f.system = initSystem;
+    const g = parseInt(initGroup, 10);
+    if (Number.isFinite(g)) f.group_id = g;
+    return f;
+  });
 
   const [selected, setSelected] = useState<CallRow | null>(null);
 
@@ -119,12 +135,50 @@ export function History() {
           (a.talkgroup_alpha ?? "").localeCompare(b.talkgroup_alpha ?? ""),
       },
       {
+        // The transmitting radio, alias-resolved when known — "who was
+        // talking", scannable in the row rather than hidden in the modal.
+        key: "source",
+        header: "Source",
+        render: (r) =>
+          r.source_id ? (
+            <RIDLink
+              rid={r.source_id}
+              alias={r.source_alpha}
+              className="text-xs text-accent hover:underline"
+            />
+          ) : (
+            <span className="text-muted text-xs">—</span>
+          ),
+        sort: (a, b) =>
+          (a.source_alpha ?? String(a.source_id ?? "")).localeCompare(
+            b.source_alpha ?? String(b.source_id ?? ""),
+          ),
+        className: "hidden md:table-cell",
+        headerClassName: "hidden md:table-cell",
+      },
+      {
         key: "system",
         header: "System",
         render: (r) => <span className="text-xs">{r.system}</span>,
         sort: (a, b) => a.system.localeCompare(b.system),
-        className: "hidden md:table-cell",
-        headerClassName: "hidden md:table-cell",
+        className: "hidden lg:table-cell",
+        headerClassName: "hidden lg:table-cell",
+      },
+      {
+        // Per-call decode health from the figures the daemon already stamps on
+        // the call (SNR / EVM / level). Lets an operator judge a recording's
+        // quality without opening a scope.
+        key: "signal",
+        header: "Signal",
+        render: (r) => (
+          <CallHealth
+            evmPct={r.evm_pct}
+            snrDb={r.snr_db}
+            signalDbfs={r.signal_dbfs}
+          />
+        ),
+        className: "hidden lg:table-cell",
+        headerClassName: "hidden lg:table-cell",
       },
       {
         key: "duration",
@@ -279,7 +333,11 @@ export function History() {
             <DetailField
               label="Source"
               mono
-              value={selected.source_id ?? null}
+              value={
+                selected.source_id ? (
+                  <RIDLink rid={selected.source_id} alias={selected.source_alpha} />
+                ) : null
+              }
             />
             <DetailField
               label="Frequency"
@@ -287,6 +345,20 @@ export function History() {
               value={formatHz(selected.frequency_hz)}
             />
           </div>
+          {(selected.snr_db != null ||
+            selected.evm_pct != null ||
+            selected.signal_dbfs != null) && (
+            <div>
+              <p className="text-xs uppercase tracking-wider text-muted mb-1">
+                Signal
+              </p>
+              <CallHealth
+                evmPct={selected.evm_pct}
+                snrDb={selected.snr_db}
+                signalDbfs={selected.signal_dbfs}
+              />
+            </div>
+          )}
           <div className="grid grid-cols-2 gap-3">
             <DetailField
               label="Started"

--- a/web/src/panels/History.tsx
+++ b/web/src/panels/History.tsx
@@ -216,6 +216,11 @@ export function History() {
                 individual
               </span>
             )}
+            {r.has_recording && (
+              <span className="pill-ok" title="A recording is available — open the call to play it">
+                ▶ rec
+              </span>
+            )}
           </div>
         ),
       },
@@ -422,6 +427,26 @@ export function History() {
             mono
             value={selected.device_serial ?? null}
           />
+          {selected.has_recording && (
+            <div>
+              <p className="text-xs uppercase tracking-wider text-muted mb-1">
+                Recording
+              </p>
+              <audio
+                controls
+                preload="none"
+                className="w-full"
+                src={`${cfg.baseURL}/api/v1/calls/${selected.id}/audio`}
+              />
+              <a
+                className="inline-block text-xs text-accent hover:underline mt-1"
+                href={`${cfg.baseURL}/api/v1/calls/${selected.id}/audio`}
+                download
+              >
+                Download recording
+              </a>
+            </div>
+          )}
         </DetailModal>
       )}
 

--- a/web/src/panels/Mixer.tsx
+++ b/web/src/panels/Mixer.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { PageHeader } from "../components/ui/PageHeader";
+import { useSearchParams } from "react-router-dom";
 import {
   fetchSpectrumDevices,
   defaultSymbolDevice,
+  initialDeviceSerial,
   parentSerial,
   type SpectrumDevice,
 } from "../api/spectrum";
@@ -43,6 +45,9 @@ export function Mixer() {
   useActiveCallsPoll();
   const [devices, setDevices] = useState<SpectrumDevice[]>([]);
   const [selected, setSelected] = useState<string | null>(null);
+  // A "signal detail" link from a call / scanner hit can name the SDR to
+  // scope via ?device=; honoured on first load, else the panel default.
+  const targetDevice = useSearchParams()[0].get("device");
   const [conn, setConn] = useState<ConnState>("closed");
   const [latest, setLatest] = useState<MixerFrame | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -65,8 +70,8 @@ export function Mixer() {
         setDevices(list);
         setError(null);
         if (selected == null) {
-          const def = defaultSymbolDevice(list);
-          if (def) setSelected(def.serial);
+          const s = initialDeviceSerial(list, targetDevice, defaultSymbolDevice);
+          if (s) setSelected(s);
         }
       } catch (e) {
         if (cancel) return;
@@ -76,7 +81,7 @@ export function Mixer() {
     return () => {
       cancel = true;
     };
-  }, [cfg, selected]);
+  }, [cfg, selected, targetDevice]);
 
   const device = useMemo(
     () => devices.find((d) => d.serial === selected) ?? null,

--- a/web/src/panels/RadioIDs.test.tsx
+++ b/web/src/panels/RadioIDs.test.tsx
@@ -14,6 +14,7 @@ vi.mock("../api/client", async () => {
       rid: vi.fn(),
       ridHistory: vi.fn(),
       systems: vi.fn().mockResolvedValue([]),
+      locations: vi.fn().mockResolvedValue([]),
     },
   };
 });

--- a/web/src/panels/RadioIDs.test.tsx
+++ b/web/src/panels/RadioIDs.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
 
 vi.mock("../api/client", async () => {
   const actual = await vi.importActual<typeof import("../api/client")>(
@@ -11,6 +11,7 @@ vi.mock("../api/client", async () => {
     ...actual,
     api: {
       rids: vi.fn(),
+      rid: vi.fn(),
       ridHistory: vi.fn(),
       systems: vi.fn().mockResolvedValue([]),
     },
@@ -46,6 +47,19 @@ function renderPanel() {
   return render(
     <MemoryRouter>
       <RadioIDs />
+    </MemoryRouter>,
+  );
+}
+
+// renderAt mounts RadioIDs under both /rids and /rids/:id (mirroring App.tsx)
+// starting at the given URL, so the deep-link behaviour can be exercised.
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/rids" element={<RadioIDs />} />
+        <Route path="/rids/:id" element={<RadioIDs />} />
+      </Routes>
     </MemoryRouter>,
   );
 }
@@ -196,6 +210,44 @@ describe("RadioIDs panel", () => {
     // Modal renders the alpha tag of one of the call rows.
     await waitFor(() => {
       expect(screen.getByText(/FIRE-DISP/)).toBeInTheDocument();
+    });
+  });
+
+  // Regression: a /rids/:id deep link (e.g. a source-radio click in CC
+  // Activity or call history) must open that radio's detail modal. The route
+  // used to be unregistered, so such links fell through to the dashboard.
+  it("opens the detail modal from a /rids/:id deep link (row already loaded)", async () => {
+    const rows: RIDDTO[] = [{ id: 777, alias: "DEEPLINK", configured: true }];
+    // Seed the store so the row is present on the first render (the effect
+    // resolves it from the list rather than racing the poll into a fetch).
+    useShared.setState({ rids: rows });
+    vi.mocked(api.rids).mockResolvedValue(rows);
+    vi.mocked(api.ridHistory).mockResolvedValue([]);
+    renderAt("/rids/777");
+
+    // The modal subtitle "RID 777" appears without any click.
+    await waitFor(() => {
+      expect(screen.getByText(/RID 777/)).toBeInTheDocument();
+    });
+    // It resolved from the loaded list, so no single-RID fetch was needed.
+    expect(api.rid).not.toHaveBeenCalled();
+  });
+
+  it("fetches a /rids/:id deep link that is not in the current list", async () => {
+    vi.mocked(api.rids).mockResolvedValue([]); // filtered/empty list
+    vi.mocked(api.ridHistory).mockResolvedValue([]);
+    vi.mocked(api.rid).mockResolvedValue({
+      id: 999,
+      alias: "OFFLIST",
+      configured: false,
+    });
+    renderAt("/rids/999");
+
+    await waitFor(() => {
+      expect(api.rid).toHaveBeenCalledWith(expect.anything(), 999);
+    });
+    await waitFor(() => {
+      expect(screen.getByText("OFFLIST")).toBeInTheDocument();
     });
   });
 });

--- a/web/src/panels/RadioIDs.tsx
+++ b/web/src/panels/RadioIDs.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
 import { api } from "../api/client";
 import { writes } from "../api/write";
 import { Column, DataTable } from "../components/DataTable";
@@ -25,6 +26,11 @@ export function RadioIDs() {
   const notify = useShared((s) => s.notify);
   const rids = useShared((s) => s.rids);
   const setRIDs = useShared((s) => s.setRIDs);
+  // Deep-link support: /rids/:id opens the detail modal for that radio,
+  // so a source-radio click in CC Activity / call history lands on the
+  // radio (issue: the link previously fell through to the dashboard).
+  const { id: routeId } = useParams<{ id: string }>();
+  const navigate = useNavigate();
 
   const [selected, setSelected] = useState<RIDDTO | null>(null);
   const [history, setHistory] = useState<CallRow[]>([]);
@@ -82,6 +88,42 @@ export function RadioIDs() {
     if (system) set.add(system);
     return [...set].sort((a, b) => a.localeCompare(b));
   }, [systemNames, rids, system]);
+
+  // Open the detail modal for the /rids/:id route param. Prefer a row
+  // already in the loaded list; otherwise fetch the single RID directly so a
+  // deep link (or a radio filtered out by the current system scope) still
+  // opens. An unknown id drops back to the list URL rather than stranding the
+  // user on a dead link.
+  useEffect(() => {
+    if (!routeId) return;
+    const idNum = Number(routeId);
+    if (!Number.isFinite(idNum)) return;
+    if (selected?.id === idNum) return;
+    const inList = rids.find((r) => r.id === idNum);
+    if (inList) {
+      setSelected(inList);
+      return;
+    }
+    let cancel = false;
+    api
+      .rid(cfg, idNum)
+      .then((r) => {
+        if (!cancel) setSelected(r);
+      })
+      .catch(() => {
+        if (!cancel) navigate("/rids", { replace: true });
+      });
+    return () => {
+      cancel = true;
+    };
+  }, [routeId, rids, cfg, selected, navigate]);
+
+  // Close the detail modal, restoring the /rids list URL when the modal was
+  // opened via a /rids/:id deep link.
+  function closeDetail() {
+    setSelected(null);
+    if (routeId) navigate("/rids");
+  }
 
   // Fetch per-RID call history when the detail modal opens.
   useEffect(() => {
@@ -247,7 +289,12 @@ export function RadioIDs() {
             ))}
           </Select>
         }
-        onRowClick={(r) => setSelected(r)}
+        onRowClick={(r) => {
+          // Open immediately (works regardless of the route) and reflect the
+          // selection in the URL so it is shareable / back-button friendly.
+          setSelected(r);
+          navigate(`/rids/${r.id}`);
+        }}
         emptyMessage={
           rids.length === 0
             ? system
@@ -265,7 +312,7 @@ export function RadioIDs() {
             `RID ${selected.id}`
           }
           subtitle={`RID ${selected.id}${selected.configured ? "" : " · live only"}`}
-          onClose={() => setSelected(null)}
+          onClose={closeDetail}
         >
           <DetailField label="Description" value={selected.description} />
           <div className="grid grid-cols-2 gap-3">

--- a/web/src/panels/RadioIDs.tsx
+++ b/web/src/panels/RadioIDs.tsx
@@ -5,8 +5,10 @@ import { writes } from "../api/write";
 import { Column, DataTable } from "../components/DataTable";
 import { DetailField, DetailModal } from "../components/DetailModal";
 import { PageHeader } from "../components/ui/PageHeader";
+import { Section } from "../components/ui/Section";
 import { Select } from "../components/ui/Select";
-import type { CallRow, RIDDTO } from "../api/types";
+import { PositionMap, type MapPoint } from "../components/PositionMap";
+import type { CallRow, LocationFix, RIDDTO } from "../api/types";
 import {
   selectCanMutate,
   selectClientConfig,
@@ -40,6 +42,8 @@ export function RadioIDs() {
   // a large multi-system RID roster stays legible.
   const [system, setSystem] = useState("");
   const [systemNames, setSystemNames] = useState<string[]>([]);
+  // Recent subscriber-radio position fixes (DMR LRRP / unit GPS) for the map.
+  const [locations, setLocations] = useState<LocationFix[]>([]);
 
   // Poll the merged list, scoped to the selected system.
   useEffect(() => {
@@ -77,6 +81,52 @@ export function RadioIDs() {
       cancel = true;
     };
   }, [cfg]);
+
+  // Poll recent position fixes for the unit-location map. Empty (no LRRP/GPS
+  // decoded, or the subsystem is off) simply hides the map.
+  useEffect(() => {
+    let cancel = false;
+    const refresh = async () => {
+      try {
+        const fixes = await api.locations(cfg, { limit: 500 });
+        if (!cancel) setLocations(fixes);
+      } catch {
+        // Non-fatal — keep the previous fixes.
+      }
+    };
+    refresh();
+    const t = window.setInterval(refresh, POLL_INTERVAL_MS);
+    return () => {
+      cancel = true;
+      window.clearInterval(t);
+    };
+  }, [cfg]);
+
+  // Map the newest fix per radio to a marker, labelled by alias when the RID
+  // roster resolves one. Keeping only the latest fix per radio avoids stacking
+  // a trail of markers on one unit.
+  const mapPoints = useMemo<MapPoint[]>(() => {
+    const aliasByID = new Map<number, string>();
+    for (const r of rids) if (r.alias) aliasByID.set(r.id, r.alias);
+    const latest = new Map<number, LocationFix>();
+    for (const f of locations) {
+      if (!Number.isFinite(f.latitude) || !Number.isFinite(f.longitude)) continue;
+      const prev = latest.get(f.radio_id);
+      if (!prev || f.reported_at > prev.reported_at) latest.set(f.radio_id, f);
+    }
+    return [...latest.values()].map((f) => {
+      const alias = aliasByID.get(f.radio_id);
+      const speed = f.speed_knots > 0 ? ` · ${f.speed_knots.toFixed(0)} kn` : "";
+      return {
+        id: String(f.radio_id),
+        latitude: f.latitude,
+        longitude: f.longitude,
+        kind: "unit" as const,
+        label: alias ? `${alias} (${f.radio_id})` : `RID ${f.radio_id}`,
+        detail: `${f.system}${f.talkgroup ? ` · TG ${f.talkgroup}` : ""}${speed}`,
+      };
+    });
+  }, [locations, rids]);
 
   // Dropdown options: configured systems ∪ systems seen in the current rows ∪
   // the active selection (so a discovered-only or just-selected system never
@@ -250,6 +300,16 @@ export function RadioIDs() {
           <span className="text-xs text-muted">{rids.length} total</span>
         }
       />
+
+      {mapPoints.length > 0 && (
+        <Section
+          id="rid-map"
+          title={`Unit locations (${mapPoints.length})`}
+          description="Latest GPS / LRRP position per radio. Secondary to the roster — collapse if not needed."
+        >
+          <PositionMap points={mapPoints} heightPx={320} />
+        </Section>
+      )}
 
       <DataTable
         rows={rids}

--- a/web/src/panels/Scanner.test.tsx
+++ b/web/src/panels/Scanner.test.tsx
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render as rtlRender, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+// Panels render react-router links / read search params, so every
+// render needs a Router context.
+function render(ui: Parameters<typeof rtlRender>[0]) {
+  return rtlRender(<MemoryRouter>{ui}</MemoryRouter>);
+}
 
 vi.mock("../api/client", () => ({
   api: { scanner: vi.fn() },

--- a/web/src/panels/Scanner.tsx
+++ b/web/src/panels/Scanner.tsx
@@ -6,6 +6,7 @@ import { PageHeader } from "../components/ui/PageHeader";
 import { Card } from "../components/ui/Card";
 import { Button } from "../components/ui/Button";
 import { Badge } from "../components/ui/Badge";
+import { SignalQualityChip, SignalLevelBar } from "../components/SignalHealth";
 import type {
   ConvChannelStatusDTO,
   SystemHuntStatusDTO,
@@ -538,66 +539,6 @@ function StatePill({ state }: { state: string }) {
           ? "err"
           : "neutral";
   return <Badge tone={tone}>{state}</Badge>;
-}
-
-// SignalQualityChip is the simple control-channel signal indicator: a
-// clean/marginal/poor pill (green/amber/red), with the measured carrier offset in
-// its tooltip. Backed by the decoder's live TSBK (P25) / BSCH (TETRA) frame-error
-// rate, so it works across protocols — not just TETRA.
-function SignalQualityChip({
-  quality,
-  offsetHz,
-}: {
-  quality: string;
-  offsetHz?: number;
-}) {
-  const tone =
-    quality === "clean" ? "ok" : quality === "marginal" ? "warn" : "err";
-  const offset =
-    offsetHz != null ? ` · offset ${offsetHz > 0 ? "+" : ""}${offsetHz} Hz` : "";
-  return (
-    <span title={`control-channel signal: ${quality}${offset}`}>
-      <Badge tone={tone}>signal: {quality}</Badge>
-    </span>
-  );
-}
-
-// SignalLevelBar renders the locked carrier's raw front-end level (mean channel
-// power in dBFS) as a numeric read-out plus a small level bar, so an operator can
-// aim an antenna or trim LNA gain against a live number instead of just the
-// clean/marginal/poor pill. This is signal STRENGTH, not decode quality — a strong
-// bar with a red quality chip means "plenty of signal, but something else (offset,
-// overload, wrong colour code) is hurting the decode".
-//
-// The bar maps the useful SDR range −90…−20 dBFS to 0…100%. Colour is by level:
-// green ≥ −45 dBFS, amber −45…−60, red below −60.
-function SignalLevelBar({ dbfs }: { dbfs: number }) {
-  const floorDb = -90;
-  const ceilDb = -20;
-  const pct = Math.max(
-    0,
-    Math.min(100, ((dbfs - floorDb) / (ceilDb - floorDb)) * 100),
-  );
-  const color = dbfs >= -45 ? "#34d399" : dbfs >= -60 ? "#fbbf24" : "#f87171";
-  return (
-    <span
-      className="inline-flex items-center gap-1.5"
-      title={`signal level ${dbfs.toFixed(1)} dBFS (mean channel power) — aim antenna / trim LNA gain to maximise`}
-    >
-      <span
-        className="inline-block h-1.5 w-12 rounded-full bg-panel overflow-hidden"
-        aria-hidden
-      >
-        <span
-          className="block h-full rounded-full"
-          style={{ width: `${pct}%`, backgroundColor: color }}
-        />
-      </span>
-      <span className="font-mono text-xs text-muted">
-        {dbfs.toFixed(1)} dBFS
-      </span>
-    </span>
-  );
 }
 
 function timeOnly(ts: string): string {

--- a/web/src/panels/Scanner.tsx
+++ b/web/src/panels/Scanner.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import { api } from "../api/client";
 import { writes } from "../api/write";
 import { ConfirmModal } from "../components/ConfirmModal";
@@ -89,6 +90,9 @@ export function Scanner() {
         subtitle={`${scanner.tg_scan_count} of ${scanner.tg_total} talkgroups eligible`}
         actions={
           <div className="flex items-center gap-2 text-xs">
+            <Link to="/plots/constellation" className="text-accent hover:underline">
+              Signal scopes →
+            </Link>
             <span className="text-muted uppercase tracking-wider">scan_mode</span>
             <span className="font-mono">{scanner.scan_mode}</span>
             {canMutate && (

--- a/web/src/panels/SymbolScope.test.tsx
+++ b/web/src/panels/SymbolScope.test.tsx
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render as rtlRender, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+// Panels render react-router links / read search params, so every
+// render needs a Router context.
+function render(ui: Parameters<typeof rtlRender>[0]) {
+  return rtlRender(<MemoryRouter>{ui}</MemoryRouter>);
+}
 
 vi.mock("../api/spectrum", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../api/spectrum")>()),

--- a/web/src/panels/SymbolScope.tsx
+++ b/web/src/panels/SymbolScope.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { PageHeader } from "../components/ui/PageHeader";
+import { useSearchParams } from "react-router-dom";
 import {
   fetchSpectrumDevices,
   defaultSymbolDevice,
+  initialDeviceSerial,
   parentSerial,
   type SpectrumDevice,
 } from "../api/spectrum";
@@ -49,6 +51,9 @@ export function SymbolScope() {
   useActiveCallsPoll();
   const [devices, setDevices] = useState<SpectrumDevice[]>([]);
   const [selected, setSelected] = useState<string | null>(null);
+  // A "signal detail" link from a call / scanner hit can name the SDR to
+  // scope via ?device=; honoured on first load, else the panel default.
+  const targetDevice = useSearchParams()[0].get("device");
   const [conn, setConn] = useState<ConnState>("closed");
   const [latest, setLatest] = useState<SymbolFrame | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -78,8 +83,8 @@ export function SymbolScope() {
         setDevices(list);
         setError(null);
         if (selected == null) {
-          const def = defaultSymbolDevice(list);
-          if (def) setSelected(def.serial);
+          const s = initialDeviceSerial(list, targetDevice, defaultSymbolDevice);
+          if (s) setSelected(s);
         }
       } catch (e) {
         if (cancel) return;
@@ -89,7 +94,7 @@ export function SymbolScope() {
     return () => {
       cancel = true;
     };
-  }, [cfg, selected]);
+  }, [cfg, selected, targetDevice]);
 
   const device = useMemo(
     () => devices.find((d) => d.serial === selected) ?? null,

--- a/web/src/panels/Systems.test.tsx
+++ b/web/src/panels/Systems.test.tsx
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import {
+  render as rtlRender,
+  screen,
+  waitFor,
+  fireEvent,
+} from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import type { ReactElement } from "react";
 
 vi.mock("../api/client", () => ({
   api: { systems: vi.fn(), scanner: vi.fn() },
@@ -8,6 +15,12 @@ vi.mock("../api/client", () => ({
 import { api } from "../api/client";
 import { useShared } from "../store/shared";
 import { Systems } from "./Systems";
+
+// The Systems detail modal contains react-router <Link>s (cross-links to
+// filtered call history), so every render needs a Router context.
+function render(ui: ReactElement) {
+  return rtlRender(<MemoryRouter>{ui}</MemoryRouter>);
+}
 
 function resetStore() {
   useShared.setState({

--- a/web/src/panels/Systems.tsx
+++ b/web/src/panels/Systems.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
 import { api } from "../api/client";
 import { Column, DataTable } from "../components/DataTable";
 import { DetailField, DetailModal } from "../components/DetailModal";
@@ -253,6 +254,12 @@ export function Systems() {
                 : null
             }
           />
+          <Link
+            to={`/history?system=${encodeURIComponent(selected.name)}`}
+            className="inline-block text-sm text-accent hover:underline"
+          >
+            View calls on this system →
+          </Link>
           {(() => {
             const hunt = scanner?.systems?.find((h) => h.name === selected.name);
             // TETRA has no WACN/RFSS/Site; it identifies a cell by MNI (MCC/MNC),

--- a/web/src/panels/Talkgroups.tsx
+++ b/web/src/panels/Talkgroups.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
 import { api } from "../api/client";
 import { writes } from "../api/write";
 import { Column, DataTable } from "../components/DataTable";
@@ -216,6 +217,12 @@ export function Talkgroups() {
               value={selected.lockout ? "locked out" : "active"}
             />
           </div>
+          <Link
+            to={`/history?group_id=${selected.id}`}
+            className="inline-block text-sm text-accent hover:underline"
+          >
+            View calls on this talkgroup →
+          </Link>
           {canMutate ? (
             <div className="pt-3 border-t border-panel space-y-3">
               <p className="text-xs uppercase tracking-wider text-muted flex items-center gap-2">

--- a/web/src/panels/Tuning.test.tsx
+++ b/web/src/panels/Tuning.test.tsx
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { render as rtlRender, screen, waitFor, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+// Panels render react-router links / read search params, so every
+// render needs a Router context.
+function render(ui: Parameters<typeof rtlRender>[0]) {
+  return rtlRender(<MemoryRouter>{ui}</MemoryRouter>);
+}
 
 vi.mock("../api/spectrum", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../api/spectrum")>()),

--- a/web/src/panels/Tuning.tsx
+++ b/web/src/panels/Tuning.tsx
@@ -12,9 +12,11 @@ import {
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Line } from "react-chartjs-2";
 import { PageHeader } from "../components/ui/PageHeader";
+import { useSearchParams } from "react-router-dom";
 import {
   fetchSpectrumDevices,
   defaultSymbolDevice,
+  initialDeviceSerial,
   parentSerial,
   type SpectrumDevice,
 } from "../api/spectrum";
@@ -62,6 +64,9 @@ export function Tuning() {
   useActiveCallsPoll();
   const [devices, setDevices] = useState<SpectrumDevice[]>([]);
   const [selected, setSelected] = useState<string | null>(null);
+  // A "signal detail" link from a call / scanner hit can name the SDR to
+  // scope via ?device=; honoured on first load, else the panel default.
+  const targetDevice = useSearchParams()[0].get("device");
   const [conn, setConn] = useState<ConnState>("closed");
   const [latest, setLatest] = useState<SymbolFrame | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -85,8 +90,8 @@ export function Tuning() {
         setDevices(list);
         setError(null);
         if (selected == null) {
-          const def = defaultSymbolDevice(list);
-          if (def) setSelected(def.serial);
+          const s = initialDeviceSerial(list, targetDevice, defaultSymbolDevice);
+          if (s) setSelected(s);
         }
       } catch (e) {
         if (cancel) return;
@@ -96,7 +101,7 @@ export function Tuning() {
     return () => {
       cancel = true;
     };
-  }, [cfg, selected]);
+  }, [cfg, selected, targetDevice]);
 
   const device = useMemo(
     () => devices.find((d) => d.serial === selected) ?? null,


### PR DESCRIPTION
Restructure the operator console navigation so the two core trunking
workflows are front-and-center and the secondary receivers are clearly
secondary, matching how established trunking scanners organize their UIs.

- Bottom-nav primaries are now Dashboard, Active, Scanner, Hunt (Settings
  drops out of the 4-slot mobile nav; still reachable via sidebar, drawer
  and the command palette). Scan and Hunt are the primary mission, so both
  belong in reach on a phone.
- Collapse the six per-signal scopes (Constellation, Symbol Scope, Eye,
  Mixer, Tuning, Histogram) out of the top-level rail — they are already
  tabs inside the Plots hub. Their routes still resolve for deep links and
  their search terms move onto the Plots hub keywords, so the command
  palette still finds them (no discoverability regression).
- Split "Decoders & Logs" into "Logs" (Events, Tones) and "Other
  Receivers" (Pagers, APRS, AIS, DSC, ADS-B, MDC1200, LoRa) to make the
  trunking-vs-other-systems boundary explicit.

Tests updated to encode the new intent (primaries include Hunt; the six
scopes are consolidated under the Plots hub rather than standalone items).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NBH1jXQDyUCzW2YDRmBDLe