### PR TITLE
Web UI: lead with Scan &amp; Hunt, add call playback, maps &amp; contextual diagnostics

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -873,7 +873,10 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		}
 		var sites []trunking.ConfiguredSite
 		for _, sc := range sys.Sites {
-			sites = append(sites, trunking.ConfiguredSite{RFSS: sc.RFSS, Site: sc.Site, Name: sc.Name})
+			sites = append(sites, trunking.ConfiguredSite{
+				RFSS: sc.RFSS, Site: sc.Site, Name: sc.Name,
+				Latitude: sc.Latitude, Longitude: sc.Longitude,
+			})
 		}
 		// Conventional DMR (Tier II / Tier I) has no real control channel —
 		// the operator lists each repeater/simplex carrier in the

--- a/internal/api/handlers_sites.go
+++ b/internal/api/handlers_sites.go
@@ -53,13 +53,17 @@ func (s *Server) handleListSites(w http.ResponseWriter, _ *http.Request) {
 			k := key{sys.Name, cs.RFSS, cs.Site}
 			if dto, ok := byKey[k]; ok {
 				dto.Name = cs.Name
+				dto.Latitude = cs.Latitude
+				dto.Longitude = cs.Longitude
 				continue
 			}
 			byKey[k] = &SiteDTO{
-				System: sys.Name,
-				RFSSID: cs.RFSS,
-				SiteID: cs.Site,
-				Name:   cs.Name,
+				System:    sys.Name,
+				RFSSID:    cs.RFSS,
+				SiteID:    cs.Site,
+				Name:      cs.Name,
+				Latitude:  cs.Latitude,
+				Longitude: cs.Longitude,
 			}
 		}
 	}

--- a/internal/api/handlers_sites_test.go
+++ b/internal/api/handlers_sites_test.go
@@ -92,6 +92,55 @@ func TestListSitesUnionAndNameMerge(t *testing.T) {
 	}
 }
 
+// TestListSitesCoordinates verifies configured site coordinates reach the
+// SiteDTO through both join branches — a discovered site merged with a
+// configured name+position, and a configured-but-unseen site — so the web
+// console can plot them. A site with no configured position omits lat/lon.
+func TestListSitesCoordinates(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+
+	discovered := fakeSites{sites: []trunking.SiteInfo{
+		{System: "MMR", RFSSID: 1, SiteID: 1, ControlChannelHz: 420012500},
+	}}
+	systems := []trunking.System{{
+		Name: "MMR",
+		Sites: []trunking.ConfiguredSite{
+			{RFSS: 1, Site: 1, Name: "Mt Anakie", Latitude: -37.85, Longitude: 144.2},
+			{RFSS: 2, Site: 9, Name: "Murradoc Hill", Latitude: -38.2, Longitude: 144.6},
+			{RFSS: 3, Site: 3, Name: "No GPS"}, // no position
+		},
+	}}
+
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, Systems: systems, Sites: discovered})
+	defer teardown()
+
+	resp := mustGet(t, base+"/api/v1/sites")
+	defer resp.Body.Close()
+	var body struct {
+		Sites []SiteDTO `json:"sites"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	byID := map[[2]uint8]SiteDTO{}
+	for _, s := range body.Sites {
+		byID[[2]uint8{s.RFSSID, s.SiteID}] = s
+	}
+	// Discovered + configured: coordinates merged onto the live row.
+	if s := byID[[2]uint8{1, 1}]; s.Latitude != -37.85 || s.Longitude != 144.2 {
+		t.Errorf("merged site coords = (%v,%v), want (-37.85,144.2)", s.Latitude, s.Longitude)
+	}
+	// Configured-only row also carries them.
+	if s := byID[[2]uint8{2, 9}]; s.Latitude != -38.2 || s.Longitude != 144.6 {
+		t.Errorf("configured-only site coords = (%v,%v), want (-38.2,144.6)", s.Latitude, s.Longitude)
+	}
+	// No position → zero (omitted in JSON).
+	if s := byID[[2]uint8{3, 3}]; s.Latitude != 0 || s.Longitude != 0 {
+		t.Errorf("positionless site coords = (%v,%v), want (0,0)", s.Latitude, s.Longitude)
+	}
+}
+
 // fakeSitesTopo is a SitesProvider that also implements NetworkTopologyProvider,
 // returning discovered rows plus one system's topology snapshot.
 type fakeSitesTopo struct {

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -571,8 +571,14 @@ type SiteDTO struct {
 	// number. Empty when there is no TSBK data yet. See decodeQuality.
 	ControlChannelDecodeQuality string `json:"control_channel_decode_quality,omitempty"`
 	Name                        string `json:"name"`
-	WACN                        uint32 `json:"wacn,omitempty"`
-	SystemID                    uint16 `json:"system_id,omitempty"`
+	// Latitude / Longitude are the operator-configured (or RadioReference-
+	// imported) site position in decimal degrees, merged from the matching
+	// ConfiguredSite. Omitted when unset, so the web console plots only the
+	// sites that have a known location.
+	Latitude  float64 `json:"latitude,omitempty"`
+	Longitude float64 `json:"longitude,omitempty"`
+	WACN      uint32  `json:"wacn,omitempty"`
+	SystemID  uint16  `json:"system_id,omitempty"`
 	// Hex renderings of the identity numbers, alongside the decimal fields.
 	WACNHex     string `json:"wacn_hex,omitempty"`
 	SystemIDHex string `json:"system_id_hex,omitempty"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1435,6 +1435,14 @@ type SiteConfig struct {
 	RFSS uint8  `yaml:"rfss"`
 	Site uint8  `yaml:"site"`
 	Name string `yaml:"name"`
+	// Latitude / Longitude are the site's optional geographic position
+	// (decimal degrees, WGS84). When set they are merged into
+	// GET /api/v1/sites so the web console can plot the site on a map.
+	// Both zero means "no position" (the console hides such sites from the
+	// map). RadioReference import fills these in automatically; operators can
+	// also set them by hand for a site RR doesn't geolocate.
+	Latitude  float64 `yaml:"latitude"`
+	Longitude float64 `yaml:"longitude"`
 }
 
 type SystemConfig struct {
@@ -2657,6 +2665,12 @@ func validateSystem(i int, s SystemConfig) error {
 			return fmt.Errorf("trunking.systems[%d].sites[%d]: duplicate rfss %d / site %d (also at sites[%d])", i, k, st.RFSS, st.Site, prev)
 		}
 		seenSites[key] = k
+		if st.Latitude < -90 || st.Latitude > 90 {
+			return fmt.Errorf("trunking.systems[%d].sites[%d].latitude: %g outside -90..90", i, k, st.Latitude)
+		}
+		if st.Longitude < -180 || st.Longitude > 180 {
+			return fmt.Errorf("trunking.systems[%d].sites[%d].longitude: %g outside -180..180", i, k, st.Longitude)
+		}
 	}
 	switch s.EncryptedCalls.Mode {
 	case "", "follow", "metadata", "ignore":

--- a/internal/configbuilder/configbuilder_test.go
+++ b/internal/configbuilder/configbuilder_test.go
@@ -98,3 +98,26 @@ func TestRRToSystemConfig(t *testing.T) {
 		t.Fatalf("talkgroups: %+v", rows)
 	}
 }
+
+// TestRRToSystemConfigSites confirms named RR sites become SiteConfig entries
+// carrying name + coordinates (so an imported system maps its sites), and a
+// site with no description is skipped.
+func TestRRToSystemConfigSites(t *testing.T) {
+	full := radioreference.FullSystem{
+		Name:     "Metro",
+		Protocol: "p25",
+		Sites: []radioreference.SiteDetail{
+			{RFSS: 1, SiteNumber: 3, Description: "Downtown", Latitude: 30.27, Longitude: -97.74,
+				ControlChannels: []uint32{851_037_500}},
+			{RFSS: 1, SiteNumber: 4, Description: "", ControlChannels: []uint32{851_062_500}}, // no name → skipped
+		},
+	}
+	sys, _ := RRToSystemConfig(full)
+	if len(sys.Sites) != 1 {
+		t.Fatalf("expected 1 named site, got %+v", sys.Sites)
+	}
+	s := sys.Sites[0]
+	if s.RFSS != 1 || s.Site != 3 || s.Name != "Downtown" || s.Latitude != 30.27 || s.Longitude != -97.74 {
+		t.Errorf("site config = %+v", s)
+	}
+}

--- a/internal/configbuilder/fieldmeta.go
+++ b/internal/configbuilder/fieldmeta.go
@@ -229,10 +229,12 @@ var fieldMetas = map[string]FieldMeta{
 	"EncryptionKeyConfig.Algorithm": {Help: "Decryption algorithm. Today only DMR RC4 (Enhanced Privacy).", Options: opts("rc4", "rc4 (DMR Enhanced Privacy)")},
 	"EncryptionKeyConfig.Key":       {Help: "Raw key, hex-encoded. Spaces and a 0x prefix are tolerated."},
 
-	"SystemConfig.Sites": {Label: "Sites", Help: "Optional human-readable names for the P25 sites of this system, keyed by RFSS/Site. Presentation metadata only — surfaced via GET /api/v1/sites. P25 only."},
-	"SiteConfig.RFSS":    {Label: "RFSS ID", Help: "RF Sub-System ID of the site (from the control channel's RFSS Status Broadcast)."},
-	"SiteConfig.Site":    {Label: "Site ID", Help: "Site ID within the RFSS (from the control channel's RFSS Status Broadcast)."},
-	"SiteConfig.Name":    {Label: "Name", Help: "Human-readable site name shown in GET /api/v1/sites, e.g. \"Mt Anakie\"."},
+	"SystemConfig.Sites":   {Label: "Sites", Help: "Optional human-readable names for the P25 sites of this system, keyed by RFSS/Site. Presentation metadata only — surfaced via GET /api/v1/sites. P25 only."},
+	"SiteConfig.RFSS":      {Label: "RFSS ID", Help: "RF Sub-System ID of the site (from the control channel's RFSS Status Broadcast)."},
+	"SiteConfig.Site":      {Label: "Site ID", Help: "Site ID within the RFSS (from the control channel's RFSS Status Broadcast)."},
+	"SiteConfig.Name":      {Label: "Name", Help: "Human-readable site name shown in GET /api/v1/sites, e.g. \"Mt Anakie\"."},
+	"SiteConfig.Latitude":  {Label: "Latitude", Help: "Site latitude in decimal degrees (WGS84), e.g. -37.85. Filled in automatically by RadioReference import; set by hand to plot a site RR doesn't geolocate. Leave 0 for no map position."},
+	"SiteConfig.Longitude": {Label: "Longitude", Help: "Site longitude in decimal degrees (WGS84), e.g. 144.20. Filled in automatically by RadioReference import; set by hand to plot a site RR doesn't geolocate. Leave 0 for no map position."},
 
 	// ---- API & Web ---------------------------------------------------------
 	"APIConfig.HTTPAddr":            {Label: "HTTP address", Help: "TCP listen address for REST/SSE/WebSocket, e.g. 127.0.0.1:8080. Empty disables it."},

--- a/internal/configbuilder/rr.go
+++ b/internal/configbuilder/rr.go
@@ -32,9 +32,27 @@ func RRToSystemConfig(full radioreference.FullSystem) (config.SystemConfig, []Ta
 			Mode:        tg.Mode,
 		})
 	}
+	// Carry each site's name + position into SiteConfig so the imported system
+	// reads sites as named places and the console can map the ones RR
+	// geolocated. A site needs a usable RFSS/Site and a name (its RR
+	// description) to be worth an entry; positionless sites still get a name.
+	var sites []config.SiteConfig
+	for _, site := range full.Sites {
+		if site.Description == "" {
+			continue
+		}
+		sites = append(sites, config.SiteConfig{
+			RFSS:      uint8(site.RFSS),
+			Site:      uint8(site.SiteNumber),
+			Name:      site.Description,
+			Latitude:  site.Latitude,
+			Longitude: site.Longitude,
+		})
+	}
 	return config.SystemConfig{
 		Name:            full.Name,
 		Protocol:        full.Protocol,
 		ControlChannels: ccs,
+		Sites:           sites,
 	}, rows
 }

--- a/internal/radioreference/browse.go
+++ b/internal/radioreference/browse.go
@@ -49,6 +49,12 @@ type SiteDetail struct {
 	County          string   `json:"county,omitempty"`
 	ControlChannels []uint32 `json:"control_channels"`
 	Frequencies     []uint32 `json:"frequencies"`
+	// Latitude / Longitude are the site's geographic position in decimal
+	// degrees (RadioReference siteLat / siteLng), zero when RR did not
+	// geolocate the site. Carried through import so a discovered site can be
+	// plotted on the console map.
+	Latitude  float64 `json:"latitude,omitempty"`
+	Longitude float64 `json:"longitude,omitempty"`
 }
 
 // TalkgroupDetail is one talkgroup of a trunked system, shaped to match
@@ -274,12 +280,14 @@ func (c *Client) getTrsTalkgroups(ctx context.Context, sid int) ([]TalkgroupDeta
 func parseSites(raw []byte) []SiteDetail {
 	var sites []SiteDetail
 	for _, block := range blocks(raw, "siteList") {
-		leaves := firstLeaves(block, "rfss", "siteNumber", "siteDescr", "siteCounty", "cName")
+		leaves := firstLeaves(block, "rfss", "siteNumber", "siteDescr", "siteCounty", "cName", "siteLat", "siteLng")
 		site := SiteDetail{
 			RFSS:        atoiDefault(leaves["rfss"], 0),
 			SiteNumber:  atoiDefault(leaves["siteNumber"], 0),
 			Description: leaves["siteDescr"],
 			County:      firstNonEmpty(leaves["siteCounty"], leaves["cName"]),
+			Latitude:    parseDegrees(leaves["siteLat"]),
+			Longitude:   parseDegrees(leaves["siteLng"]),
 		}
 		for _, fb := range blocks(block, "siteFreq") {
 			fl := firstLeaves(fb, "freq", "use")
@@ -401,6 +409,22 @@ func mhzToHz(s string) uint32 {
 		return 0
 	}
 	return uint32(hz)
+}
+
+// parseDegrees parses a decimal-degrees coordinate string, returning 0 for an
+// empty/unparseable value or one outside the valid ±180 range (a longitude's
+// bound; latitude is a tighter subset). Tolerant like the other RR parsers so a
+// missing/renamed leaf degrades to "no position" rather than an error.
+func parseDegrees(s string) float64 {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0
+	}
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil || f < -180 || f > 180 {
+		return 0
+	}
+	return f
 }
 
 // firstNonEmpty returns the first non-empty string of its arguments.

--- a/internal/radioreference/browse_test.go
+++ b/internal/radioreference/browse_test.go
@@ -90,6 +90,31 @@ func TestParseSites(t *testing.T) {
 	}
 }
 
+// TestParseSitesCoordinates confirms RadioReference site coordinates
+// (siteLat/siteLng) are captured, and a missing/invalid leaf degrades to 0.
+func TestParseSitesCoordinates(t *testing.T) {
+	raw := []byte(`
+	<siteList>
+	  <rfss>1</rfss><siteNumber>3</siteNumber><siteDescr>Downtown</siteDescr>
+	  <siteLat>30.2672</siteLat><siteLng>-97.7431</siteLng>
+	  <siteFreq><freq>851.0125</freq><use>d</use></siteFreq>
+	</siteList>
+	<siteList>
+	  <rfss>1</rfss><siteNumber>4</siteNumber><siteDescr>NoGeo</siteDescr>
+	  <siteFreq><freq>852.0125</freq><use>d</use></siteFreq>
+	</siteList>`)
+	sites := parseSites(raw)
+	if len(sites) != 2 {
+		t.Fatalf("expected 2 sites, got %d", len(sites))
+	}
+	if sites[0].Latitude != 30.2672 || sites[0].Longitude != -97.7431 {
+		t.Errorf("site0 coords = (%v,%v), want (30.2672,-97.7431)", sites[0].Latitude, sites[0].Longitude)
+	}
+	if sites[1].Latitude != 0 || sites[1].Longitude != 0 {
+		t.Errorf("site1 (no geo) coords = (%v,%v), want (0,0)", sites[1].Latitude, sites[1].Longitude)
+	}
+}
+
 func TestParseTalkgroups(t *testing.T) {
 	raw := []byte(`
 	<tgList><tgDec>101</tgDec><tgAlpha>PD Disp</tgAlpha><tgDescr>Police Dispatch</tgDescr><tag>Law Dispatch</tag><mode>D</mode><enc>0</enc></tgList>

--- a/internal/trunking/site.go
+++ b/internal/trunking/site.go
@@ -187,6 +187,11 @@ type ConfiguredSite struct {
 	RFSS uint8
 	Site uint8
 	Name string
+	// Latitude / Longitude are the site's optional position (decimal degrees).
+	// Both zero means "no position". Merged into GET /api/v1/sites so the web
+	// console can plot the site on a map.
+	Latitude  float64
+	Longitude float64
 }
 
 // System describes one trunked radio system the engine should track.

--- a/web/configbuilder/src/api/types.ts
+++ b/web/configbuilder/src/api/types.ts
@@ -287,12 +287,24 @@ export interface EncryptionKey {
   Key: string;
 }
 
+// SiteConfig names one trunked site by its RFSS/Site IDs and, optionally,
+// carries its geographic position (decimal degrees) so the console can plot it
+// on a map. Coordinates are filled in automatically by RadioReference import.
+export interface SiteConfig {
+  RFSS: number;
+  Site: number;
+  Name: string;
+  Latitude?: number;
+  Longitude?: number;
+}
+
 export interface SystemConfig {
   Name: string;
   Protocol: string;
   ControlChannels: number[] | null;
   TalkgroupFile: string;
   RIDAliasFile?: string;
+  Sites?: SiteConfig[] | null;
   P25BandPlan?: P25BandPlanEntry[] | null;
   DMRBandPlan?: DMRBandPlan | null;
   EncryptionKeys?: EncryptionKey[] | null;

--- a/web/configbuilder/src/sections/Trunking.tsx
+++ b/web/configbuilder/src/sections/Trunking.tsx
@@ -22,6 +22,7 @@ import type {
   ParsedSystemDTO,
   RRGeoRef,
   RRSearchHit,
+  SiteConfig,
   SystemConfig,
   TalkgroupCSVRow,
   TrunkingConfig,
@@ -208,6 +209,27 @@ function SystemEditor(props: { sys: SystemConfig; onChange: (next: SystemConfig)
           help="CSV/JSON of radio-ID aliases, relative to the config file."
         />
       </div>
+
+      <Fieldset legend="Sites (names & map positions)">
+        <ListEditor<SiteConfig>
+          label="Sites"
+          items={sys.Sites}
+          onChange={(x) => onChange({ ...sys, Sites: x })}
+          makeNew={() => ({ RFSS: 0, Site: 0, Name: "" })}
+          itemTitle={(e) => e.Name || `RFSS ${e.RFSS} / Site ${e.Site}`}
+          emptyHint="Optional. Names sites in GET /api/v1/sites; coordinates plot them on the console map. RadioReference import fills these in automatically."
+          renderItem={(e, set) => (
+            <div className="grid gap-3 sm:grid-cols-2">
+              <NumberField label="RFSS ID" value={e.RFSS} onChange={(v) => set({ ...e, RFSS: v })} />
+              <NumberField label="Site ID" value={e.Site} onChange={(v) => set({ ...e, Site: v })} />
+              <TextField label="Name" value={e.Name} onChange={(v) => set({ ...e, Name: v })} />
+              <div />
+              <NumberField label="Latitude (°)" value={e.Latitude ?? 0} onChange={(v) => set({ ...e, Latitude: v })} />
+              <NumberField label="Longitude (°)" value={e.Longitude ?? 0} onChange={(v) => set({ ...e, Longitude: v })} />
+            </div>
+          )}
+        />
+      </Fieldset>
 
       <Fieldset legend="P25 band plan (manual IDEN_UP override)">
         <ListEditor<P25BandPlanEntry>

--- a/web/src/App.panels.test.tsx
+++ b/web/src/App.panels.test.tsx
@@ -82,9 +82,11 @@ vi.mock("./api/client", () => {
       mutations: ok({ allow_mutations: false }),
       runtime: ok({}),
       systems: ok([]),
+      sites: ok([]),
       talkgroups: ok([]),
       activeCalls: ok([]),
       history: ok([]),
+      locations: ok([]),
       devices: ok([]),
       scanner: ok({
         scan_mode: "idle",

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -9,6 +9,7 @@ import type {
   AudioStatusDTO,
   CallRow,
   LocationFix,
+  SiteDTO,
   ConfigListResponse,
   DeviceDTO,
   Health,
@@ -149,6 +150,10 @@ export const api = {
   systems: (c: ClientConfig) =>
     request<{ systems: SystemDTO[] }>(c, "GET", "/api/v1/systems").then(
       (r) => r.systems,
+    ),
+  sites: (c: ClientConfig) =>
+    request<{ sites: SiteDTO[] }>(c, "GET", "/api/v1/sites").then(
+      (r) => r.sites ?? [],
     ),
   talkgroups: (c: ClientConfig) =>
     request<{ talkgroups: TalkgroupDTO[] }>(

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -648,6 +648,20 @@ export interface EventDTO {
   payload?: unknown;
 }
 
+// SiteDTO is one trunked-system site from GET /api/v1/sites — a fixed RF site
+// (not a moving radio). latitude/longitude are the operator-configured or
+// RadioReference-imported position; absent when the site has no known location
+// (the console maps only the ones that do).
+export interface SiteDTO {
+  system: string;
+  rfss_id: number;
+  site_id: number;
+  name?: string;
+  control_channel_hz?: number;
+  latitude?: number;
+  longitude?: number;
+}
+
 // LocationFix is one over-the-air position report from a subscriber radio
 // (DMR LRRP / Motorola Unit GPS / L3Harris Talker GPS), returned by
 // GET /api/v1/locations. This is a moving radio's own position — the LRRP

--- a/web/src/components/PositionMap.tsx
+++ b/web/src/components/PositionMap.tsx
@@ -27,7 +27,7 @@ export interface MapPoint {
 
   // Color category — one of the spec colours below. Maps to a
   // CircleMarker fillColor + outline.
-  kind: "aprs" | "ais" | "adsb" | "dsc-distress" | "unit" | "default";
+  kind: "aprs" | "ais" | "adsb" | "dsc-distress" | "unit" | "site" | "default";
 
   // Tooltip body. Rendered as bold first line + optional
   // additional details lines.
@@ -53,6 +53,7 @@ const KIND_COLOR: Record<MapPoint["kind"], string> = {
   adsb: "#a855f7",          // purple — aircraft
   "dsc-distress": "#ef4444",// red — distress alert
   unit: "#22c55e",          // green — trunked subscriber radio (LRRP/GPS)
+  site: "#f59e0b",          // amber — fixed trunked site (control channel)
   default: "#6b7280",       // grey — fallback
 };
 
@@ -62,6 +63,7 @@ const KIND_RADIUS: Record<MapPoint["kind"], number> = {
   adsb: 6,
   "dsc-distress": 8, // emphasise distress
   unit: 5,
+  site: 7, // emphasise fixed infrastructure
   default: 4,
 };
 

--- a/web/src/hooks/useSignalQuality.ts
+++ b/web/src/hooks/useSignalQuality.ts
@@ -1,0 +1,103 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import {
+  fetchSpectrumDevices,
+  defaultSymbolDevice,
+  initialDeviceSerial,
+  type SpectrumDevice,
+} from "../api/spectrum";
+import { demodModeToProto, openSymbolStream } from "../api/symbols";
+import {
+  computeQuality,
+  WINDOW_SYMBOLS,
+  type Quality,
+} from "../lib/signalQuality";
+import { selectClientConfig, useShared } from "../store/shared";
+
+export interface SignalQualityState {
+  quality: Quality | null;
+  status: "connecting" | "open" | "closed" | "idle";
+  device: string | null;
+}
+
+// useSignalQuality opens a single /diag/symbols subscriber on the control-role
+// SDR (or the ?device= target) and returns a rolling recovered-symbol quality
+// estimate — the data behind the Plots-hub verdict. It rests the view on the
+// device's configured control channel so it reports control-channel health, and
+// accumulates a WINDOW_SYMBOLS tail (mirroring the Histogram panel's alignment
+// guard), recomputing on a 1 s cadence. One extra websocket while mounted;
+// closed on unmount.
+export function useSignalQuality(): SignalQualityState {
+  const cfg = useShared(selectClientConfig);
+  const targetDevice = useSearchParams()[0].get("device");
+  const [devices, setDevices] = useState<SpectrumDevice[]>([]);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [status, setStatus] = useState<SignalQualityState["status"]>("idle");
+  const [quality, setQuality] = useState<Quality | null>(null);
+  const dibitsRef = useRef<number[]>([]);
+  const softRef = useRef<number[]>([]);
+
+  // Enumerate SDRs once and pick one (control-role default, or ?device=).
+  useEffect(() => {
+    let cancel = false;
+    (async () => {
+      try {
+        const list = await fetchSpectrumDevices(cfg);
+        if (cancel) return;
+        setDevices(list);
+        if (selected == null) {
+          setSelected(
+            initialDeviceSerial(list, targetDevice, defaultSymbolDevice),
+          );
+        }
+      } catch {
+        // No devices reachable — the verdict stays "unknown".
+      }
+    })();
+    return () => {
+      cancel = true;
+    };
+  }, [cfg, selected, targetDevice]);
+
+  const device = useMemo(
+    () => devices.find((d) => d.serial === selected) ?? null,
+    [devices, selected],
+  );
+  const proto = demodModeToProto(device?.p25_modulation);
+  const offset =
+    device?.control_channel_hz && device.center_hz
+      ? device.control_channel_hz - device.center_hz
+      : 0;
+
+  // Stream symbols + accumulate a rolling window; recompute quality on a timer.
+  useEffect(() => {
+    if (!selected) return;
+    dibitsRef.current = [];
+    softRef.current = [];
+    setQuality(null);
+    const stream = openSymbolStream(cfg, {
+      serial: selected,
+      proto,
+      offset,
+      onStatus: setStatus,
+      onFrame: (f) => {
+        const sb = softRef.current.concat(f.soft ?? []);
+        const db = dibitsRef.current.concat(f.dibits ?? []);
+        // Keep soft aligned index-for-index with dibits; drop it on a desync
+        // so computeQuality's soft-SNR path only runs on matched tracks.
+        softRef.current =
+          sb.length === db.length ? sb.slice(Math.max(0, sb.length - WINDOW_SYMBOLS)) : [];
+        dibitsRef.current = db.slice(Math.max(0, db.length - WINDOW_SYMBOLS));
+      },
+    });
+    const t = window.setInterval(() => {
+      setQuality(computeQuality(dibitsRef.current, softRef.current));
+    }, 1000);
+    return () => {
+      stream.close();
+      window.clearInterval(t);
+    };
+  }, [cfg, selected, proto, offset]);
+
+  return { quality, status, device: selected };
+}

--- a/web/src/lib/signalQuality.test.ts
+++ b/web/src/lib/signalQuality.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { computeQuality, qualityVerdict } from "./signalQuality";
+
+describe("computeQuality", () => {
+  it("reports an even 4-level distribution as balanced", () => {
+    const dibits = [0, 1, 2, 3, 0, 1, 2, 3];
+    const q = computeQuality(dibits, []);
+    expect(q.total).toBe(8);
+    expect(q.balanceDev).toBeCloseTo(0, 5); // each level exactly 25%
+    expect(q.snrDb).toBeNull(); // no soft track
+  });
+
+  it("flags a collapsed slicer as far off balance", () => {
+    const dibits = new Array(100).fill(0); // all in one bin
+    const q = computeQuality(dibits, []);
+    expect(q.balanceDev).toBeCloseTo(75, 5); // 100% vs 25% ideal
+  });
+
+  it("computes an SNR from an aligned soft track", () => {
+    // Four tight, well-separated levels → high SNR.
+    const dibits: number[] = [];
+    const soft: number[] = [];
+    const means = [-3, -1, 1, 3];
+    for (let i = 0; i < 400; i++) {
+      const d = i % 4;
+      dibits.push(d);
+      // Small intra-level jitter (not parity-locked to d, so each level has a
+      // real, non-zero spread → finite noise).
+      soft.push(means[d] + ((i % 3) - 1) * 0.02);
+    }
+    const q = computeQuality(dibits, soft);
+    expect(q.snrDb).not.toBeNull();
+    expect(q.snrDb!).toBeGreaterThan(18);
+  });
+
+  it("ignores a misaligned soft track (no SNR)", () => {
+    const q = computeQuality([0, 1, 2, 3], [0.1, 0.2]); // lengths differ
+    expect(q.snrDb).toBeNull();
+  });
+});
+
+describe("qualityVerdict", () => {
+  const base = { pct: [], total: 1000, balanceDev: 0, snrDb: null, levels: null };
+
+  it("is unknown until enough symbols accumulate", () => {
+    expect(qualityVerdict(null)).toBe("unknown");
+    expect(qualityVerdict({ ...base, total: 50 })).toBe("unknown");
+  });
+
+  it("buckets by SNR when a soft track is present", () => {
+    expect(qualityVerdict({ ...base, snrDb: 20 })).toBe("clean");
+    expect(qualityVerdict({ ...base, snrDb: 12 })).toBe("marginal");
+    expect(qualityVerdict({ ...base, snrDb: 5 })).toBe("poor");
+  });
+
+  it("falls back to level balance when there is no SNR (e.g. CQPSK)", () => {
+    expect(qualityVerdict({ ...base, balanceDev: 3 })).toBe("clean");
+    expect(qualityVerdict({ ...base, balanceDev: 9 })).toBe("marginal");
+    expect(qualityVerdict({ ...base, balanceDev: 30 })).toBe("poor");
+  });
+});

--- a/web/src/lib/signalQuality.ts
+++ b/web/src/lib/signalQuality.ts
@@ -1,0 +1,80 @@
+// signalQuality — the recovered-symbol quality math shared by the Histogram
+// panel and the Plots-hub verdict. A clean 4-level (C4FM / CQPSK) control
+// channel is scrambled, so each level sits near 25%; a collapsed slicer skews
+// the distribution. The C4FM soft track additionally yields a per-level
+// mean/spread and an MER-like SNR (a "level meter").
+
+export const WINDOW_SYMBOLS = 4000;
+export const CARDINALITY = 4;
+
+export interface Quality {
+  pct: number[]; // % per dibit bin
+  total: number;
+  balanceDev: number; // max |bin% − ideal%|
+  snrDb: number | null; // MER-like estimate (C4FM soft only)
+  levels: { mean: number; std: number }[] | null;
+}
+
+export function computeQuality(dibits: number[], soft: number[]): Quality {
+  const cnt = new Array(CARDINALITY).fill(0);
+  for (const d of dibits) if (d >= 0 && d < CARDINALITY) cnt[d]++;
+  const total = dibits.length;
+  const pct = cnt.map((c) => (total > 0 ? (100 * c) / total : 0));
+  const ideal = 100 / CARDINALITY;
+  const balanceDev = pct.reduce((m, p) => Math.max(m, Math.abs(p - ideal)), 0);
+
+  // Per-level soft stats + MER-like SNR, when the soft track is aligned.
+  let snrDb: number | null = null;
+  let levels: { mean: number; std: number }[] | null = null;
+  if (soft.length > 0 && soft.length === dibits.length) {
+    const sum = new Array(CARDINALITY).fill(0);
+    const sumsq = new Array(CARDINALITY).fill(0);
+    for (let i = 0; i < dibits.length; i++) {
+      const d = dibits[i];
+      if (d < 0 || d >= CARDINALITY) continue;
+      sum[d] += soft[i];
+      sumsq[d] += soft[i] * soft[i];
+    }
+    levels = [];
+    let grandSum = 0;
+    let noise = 0;
+    let signal = 0;
+    for (let d = 0; d < CARDINALITY; d++) {
+      const c = cnt[d];
+      const mean = c > 0 ? sum[d] / c : 0;
+      const varr = c > 0 ? Math.max(0, sumsq[d] / c - mean * mean) : 0;
+      levels.push({ mean, std: Math.sqrt(varr) });
+      grandSum += sum[d];
+      noise += c * varr;
+    }
+    const mu = total > 0 ? grandSum / total : 0;
+    for (let d = 0; d < CARDINALITY; d++) {
+      signal += cnt[d] * (levels[d].mean - mu) * (levels[d].mean - mu);
+    }
+    if (total > 0 && noise > 0) {
+      snrDb = 10 * Math.log10(signal / noise);
+    }
+  }
+  return { pct, total, balanceDev, snrDb, levels };
+}
+
+export type Verdict = "clean" | "marginal" | "poor" | "unknown";
+
+// qualityVerdict buckets a Quality into a clean/marginal/poor pill for the
+// at-a-glance readout, preferring the MER-like SNR (C4FM soft) when present and
+// otherwise falling back to how evenly the four levels balance (a collapsed
+// slicer skews it far off the 25% ideal). Returns "unknown" until enough
+// symbols have accumulated to be meaningful.
+export function qualityVerdict(q: Quality | null): Verdict {
+  if (!q || q.total < 200) return "unknown";
+  if (q.snrDb != null) {
+    if (q.snrDb >= 18) return "clean";
+    if (q.snrDb >= 10) return "marginal";
+    return "poor";
+  }
+  // No soft SNR (e.g. CQPSK): judge by level balance. A healthy scrambled
+  // channel stays within a few points of 25%; a closing eye collapses it.
+  if (q.balanceDev <= 6) return "clean";
+  if (q.balanceDev <= 12) return "marginal";
+  return "poor";
+}

--- a/web/src/panels/Histogram.tsx
+++ b/web/src/panels/Histogram.tsx
@@ -19,6 +19,7 @@ import {
   type SpectrumDevice,
 } from "../api/spectrum";
 import { openSymbolStream, type SymbolFrame } from "../api/symbols";
+import { computeQuality, WINDOW_SYMBOLS } from "../lib/signalQuality";
 import { selectClientConfig, useShared } from "../store/shared";
 import { prefs } from "../store/prefs";
 import { useActiveCallsPoll } from "../hooks/useActiveCallsPoll";
@@ -40,9 +41,6 @@ ChartJS.register(
 // single-dominant bin. For C4FM the soft samples also give a per-level
 // mean/spread and an MER-like SNR estimate (a "level meter").
 
-const WINDOW_SYMBOLS = 4000;
-const CARDINALITY = 4;
-
 const PROTOS: { value: string; label: string }[] = [
   { value: "p25-c4fm", label: "P25 C4FM" },
   { value: "p25-cqpsk", label: "P25 CQPSK" },
@@ -50,57 +48,6 @@ const PROTOS: { value: string; label: string }[] = [
 ];
 
 type ConnState = "connecting" | "open" | "closed";
-
-interface Quality {
-  pct: number[]; // % per dibit bin
-  total: number;
-  balanceDev: number; // max |bin% − ideal%|
-  snrDb: number | null; // MER-like estimate (C4FM soft only)
-  levels: { mean: number; std: number }[] | null;
-}
-
-function computeQuality(dibits: number[], soft: number[]): Quality {
-  const cnt = new Array(CARDINALITY).fill(0);
-  for (const d of dibits) if (d >= 0 && d < CARDINALITY) cnt[d]++;
-  const total = dibits.length;
-  const pct = cnt.map((c) => (total > 0 ? (100 * c) / total : 0));
-  const ideal = 100 / CARDINALITY;
-  const balanceDev = pct.reduce((m, p) => Math.max(m, Math.abs(p - ideal)), 0);
-
-  // Per-level soft stats + MER-like SNR, when the soft track is aligned.
-  let snrDb: number | null = null;
-  let levels: { mean: number; std: number }[] | null = null;
-  if (soft.length > 0 && soft.length === dibits.length) {
-    const sum = new Array(CARDINALITY).fill(0);
-    const sumsq = new Array(CARDINALITY).fill(0);
-    for (let i = 0; i < dibits.length; i++) {
-      const d = dibits[i];
-      if (d < 0 || d >= CARDINALITY) continue;
-      sum[d] += soft[i];
-      sumsq[d] += soft[i] * soft[i];
-    }
-    levels = [];
-    let grandSum = 0;
-    let noise = 0;
-    let signal = 0;
-    for (let d = 0; d < CARDINALITY; d++) {
-      const c = cnt[d];
-      const mean = c > 0 ? sum[d] / c : 0;
-      const varr = c > 0 ? Math.max(0, sumsq[d] / c - mean * mean) : 0;
-      levels.push({ mean, std: Math.sqrt(varr) });
-      grandSum += sum[d];
-      noise += c * varr;
-    }
-    const mu = total > 0 ? grandSum / total : 0;
-    for (let d = 0; d < CARDINALITY; d++) {
-      signal += cnt[d] * (levels[d].mean - mu) * (levels[d].mean - mu);
-    }
-    if (total > 0 && noise > 0) {
-      snrDb = 10 * Math.log10(signal / noise);
-    }
-  }
-  return { pct, total, balanceDev, snrDb, levels };
-}
 
 export function Histogram() {
   const cfg = useShared(selectClientConfig);

--- a/web/src/panels/Plots.tsx
+++ b/web/src/panels/Plots.tsx
@@ -5,6 +5,9 @@ import { EyeDiagram } from "./EyeDiagram";
 import { Mixer } from "./Mixer";
 import { Tuning } from "./Tuning";
 import { Histogram } from "./Histogram";
+import { Badge } from "../components/ui/Badge";
+import { useSignalQuality } from "../hooks/useSignalQuality";
+import { qualityVerdict } from "../lib/signalQuality";
 
 // Plots hub — a single tabbed home for the signal-plot family, mirroring
 // OP25's Plots tabs. Each sub-tab is the standalone panel rendered inline;
@@ -33,6 +36,7 @@ export function Plots() {
 
   return (
     <div className="space-y-3">
+      <QualityVerdict />
       <div
         className="flex gap-1 overflow-x-auto border-b border-panel pb-1"
         role="tablist"
@@ -62,6 +66,56 @@ export function Plots() {
       {/* Remount on tab change (key) so each panel's stream subscription is
           opened/closed cleanly rather than lingering behind a hidden tab. */}
       <div key={active.key}>{active.el}</div>
+    </div>
+  );
+}
+
+// QualityVerdict is the at-a-glance signal-health banner atop the Plots hub:
+// one clean/marginal/poor pill plus the SNR / balance numbers, from a single
+// symbol stream on the control SDR — so an operator sees whether the signal is
+// healthy without opening the Histogram or Tuning tab. The scopes below explain
+// *why*.
+function QualityVerdict() {
+  const { quality, status } = useSignalQuality();
+  const verdict = qualityVerdict(quality);
+  const tone =
+    verdict === "clean"
+      ? "ok"
+      : verdict === "marginal"
+        ? "warn"
+        : verdict === "poor"
+          ? "err"
+          : "neutral";
+  return (
+    <div className="panel flex flex-wrap items-center gap-3 px-3 py-2 text-sm">
+      <span className="text-muted text-xs uppercase tracking-wider">Signal</span>
+      <Badge tone={tone}>
+        {verdict === "unknown" ? "acquiring…" : verdict}
+      </Badge>
+      {quality?.snrDb != null && (
+        <span className="font-mono text-xs text-muted">
+          SNR {quality.snrDb.toFixed(1)} dB
+        </span>
+      )}
+      {quality && (
+        <span className="font-mono text-xs text-muted">
+          balance ±{quality.balanceDev.toFixed(1)}%
+        </span>
+      )}
+      {quality && quality.total > 0 && (
+        <span className="font-mono text-xs text-muted">
+          {quality.total} symbols
+        </span>
+      )}
+      <span className="ml-auto text-xs text-muted">
+        {status === "open"
+          ? "live"
+          : status === "connecting"
+            ? "connecting…"
+            : status === "closed"
+              ? "offline"
+              : "idle"}
+      </span>
     </div>
   );
 }

--- a/web/src/panels/Systems.test.tsx
+++ b/web/src/panels/Systems.test.tsx
@@ -9,7 +9,7 @@ import { MemoryRouter } from "react-router-dom";
 import type { ReactElement } from "react";
 
 vi.mock("../api/client", () => ({
-  api: { systems: vi.fn(), scanner: vi.fn() },
+  api: { systems: vi.fn(), scanner: vi.fn(), sites: vi.fn().mockResolvedValue([]) },
 }));
 
 import { api } from "../api/client";

--- a/web/src/panels/Systems.tsx
+++ b/web/src/panels/Systems.tsx
@@ -4,7 +4,9 @@ import { api } from "../api/client";
 import { Column, DataTable } from "../components/DataTable";
 import { DetailField, DetailModal } from "../components/DetailModal";
 import { PageHeader } from "../components/ui/PageHeader";
+import { Section } from "../components/ui/Section";
 import { StaleIndicator } from "../components/ui/StaleIndicator";
+import { PositionMap, type MapPoint } from "../components/PositionMap";
 import { useDataPoll } from "../hooks/useDataPoll";
 import { formatIdNumber } from "../lib/idFormat";
 import type {
@@ -13,6 +15,7 @@ import type {
   DMRBandPlanLearnedDTO,
   EventDTO,
   NeighborDTO,
+  SiteDTO,
   SystemDTO,
   SystemHuntStatusDTO,
 } from "../api/types";
@@ -119,15 +122,17 @@ export function Systems() {
   const events = useShared((s) => s.events);
   const idBase = useShared((s) => s.idBase);
   const [selected, setSelected] = useState<SystemDTO | null>(null);
+  const [sites, setSites] = useState<SiteDTO[]>([]);
 
   // Poll the scanner snapshot alongside systems so the detail modal can
   // translate empty WACN/SystemID/RFSS/Site into a hunt-state hint even
-  // when the Scanner panel isn't mounted.
+  // when the Scanner panel isn't mounted. Sites ride along for the map.
   const { stale, lastUpdated } = useDataPoll({
     fetcher: async () => {
-      const [sysRes, scanRes] = await Promise.allSettled([
+      const [sysRes, scanRes, siteRes] = await Promise.allSettled([
         api.systems(cfg),
         api.scanner(cfg),
+        api.sites(cfg),
       ]);
       if (sysRes.status === "rejected" && scanRes.status === "rejected") {
         throw sysRes.reason;
@@ -135,15 +140,38 @@ export function Systems() {
       return {
         systems: sysRes.status === "fulfilled" ? sysRes.value : null,
         scanner: scanRes.status === "fulfilled" ? scanRes.value : null,
+        sites: siteRes.status === "fulfilled" ? siteRes.value : null,
       };
     },
     onData: (d) => {
       if (d.systems) setSystems(d.systems);
       if (d.scanner) setScanner(d.scanner);
+      if (d.sites) setSites(d.sites);
     },
     intervalMs: POLL_INTERVAL_MS,
     resetKey: cfg.baseURL,
   });
+
+  // Sites with a known position become map markers, one per (system, rfss,
+  // site). Sites without coordinates (most, until configured or RR-imported)
+  // are simply omitted, so the map hides entirely when none are located.
+  const sitePoints = useMemo<MapPoint[]>(() => {
+    return sites
+      .filter(
+        (s) =>
+          typeof s.latitude === "number" &&
+          typeof s.longitude === "number" &&
+          (s.latitude !== 0 || s.longitude !== 0),
+      )
+      .map((s) => ({
+        id: `${s.system}-${s.rfss_id}-${s.site_id}`,
+        latitude: s.latitude as number,
+        longitude: s.longitude as number,
+        kind: "site" as const,
+        label: s.name || `RFSS ${s.rfss_id} / Site ${s.site_id}`,
+        detail: `${s.system}${s.control_channel_hz ? ` · ${(s.control_channel_hz / 1e6).toFixed(4)} MHz` : ""}`,
+      }));
+  }, [sites]);
 
   const columns: Column<SystemDTO>[] = useMemo(
     () => [
@@ -222,6 +250,16 @@ export function Systems() {
           </>
         }
       />
+
+      {sitePoints.length > 0 && (
+        <Section
+          id="site-map"
+          title={`Site map (${sitePoints.length})`}
+          description="Located trunked sites (from config or RadioReference import). Sites without coordinates are listed below but not mapped."
+        >
+          <PositionMap points={sitePoints} heightPx={320} />
+        </Section>
+      )}
 
       <DataTable
         rows={systems}


### PR DESCRIPTION
## Summary

Restructures the GopherTrunk web operator console to lead with the two core trunking
workflows — **Scan** and **Hunt** — and to present call, identity, signal-health, and
map information the way established trunking scanners do, while keeping the non-trunking
receivers (ADS-B / AIS / DSC / APRS / paging / MDC1200 / LoRa) available but secondary.
Grounded in a review of the current console plus a competitive analysis of SDRTrunk, OP25,
Rdio Scanner, Trunk Recorder/OpenMHz, Unitrunker, DSD+, ProScan (trunking) and SDR#, GQRX,
SDR++, OpenWebRX, tar1090 (receivers/ADS-B). The Jekyll `docs/` site is intentionally out
of scope and untouched.

## Changes

Each bullet is its own commit, independently shippable:

- **Navigation / IA** — Hunt joins the mobile bottom-nav primaries (Scan **and** Hunt in
  reach; Settings moves to the sidebar/drawer/⌘K); the six per-signal scopes consolidate
  under the Plots hub; "Decoders & Logs" splits into **Logs** + **Other Receivers** to make
  the trunking-vs-other-systems boundary explicit.
- **Call presentation & cross-linking** — fixes a live bug where CC-Activity radio-ID links
  pointed at an unregistered `/rids/:id` route and bounced to the dashboard; adds
  alias-resolved **Source** columns + a shared `RIDLink`; surfaces inline per-call
  EVM/SNR/level (data the daemon already returned) via a shared `SignalHealth`; adds
  TG→History and System→History cross-links.
- **Roster-first dashboard** — replaces the placeholder with Scan/Hunt quick-actions, a live
  call roster hero, and an activity feed that summarizes each event (TG · source · system).
- **Contextual signal diagnostics** — the siloed scopes now accept a `?device=` target;
  Active and Scanner link into them in context; a compact clean/marginal/poor verdict
  (SNR / balance) banners the top of the Plots hub.
- **Call-history playback** (backend + frontend) — persists `recording_path` on `call_log`
  from the recorder's existing `KindCallComplete` event; new `GET /api/v1/calls/{id}/audio`
  streams the WAV with range support + path-safety; History marks, plays, and downloads
  recordings.
- **Maps** — a unit LRRP/GPS map on Radio IDs (from the existing `/api/v1/locations`); and a
  fixed-site map on Systems, sourced by threading site latitude/longitude from operator
  config **and** RadioReference import (`parseSites` now reads `siteLat`/`siteLng`;
  `RRToSystemConfig` projects sites) through `SiteDTO`, plus a Config Builder sites editor so
  coordinates are UI-enterable.

## Test plan

- [ ] `make vet test` is green locally — *not run as-is in this environment; the equivalent
      `go build ./...`, `go vet`, and `go test` on every touched package (api, storage,
      config, trunking, radioreference, configbuilder) are green, and `gofmt -l .` is clean.*
- [ ] `make integration` is green locally — *not run (no SDR/daemon integration path
      changed beyond the additive call-audio endpoint).*
- [x] Added or updated tests where appropriate — failing-first / behavior tests for the
      `/rids/:id` deep-link open, the call-audio endpoint (serves bytes; 404s for
      no-recording / unknown id), recording-path persistence, the site-coordinate join, RR
      `siteLat`/`siteLng` parsing, the RR→`SiteConfig` projection, and the signal-quality
      math + verdict buckets.
- [ ] Smoke-tested against real hardware — *no; offline/replay only. The RR `siteLat`/`siteLng`
      leaf names are asserted only by a synthetic fixture and should be confirmed against a
      live RadioReference pull before that path is considered on-air-verified.*

Additional: frontend `npm run typecheck` + Vitest (327 tests) + Vite build all green; the
Config Builder SPA typechecks, builds, and passes its 47 tests.

## Breaking changes

None — all additions are backward-compatible: new **optional** config keys
(`trunking.systems[].sites[].latitude` / `.longitude`), additive REST fields
(`SiteDTO.latitude`/`.longitude`, `CallRow.has_recording`), and a new endpoint
(`GET /api/v1/calls/{id}/audio`). The nav layout changed, but no config-file key, CLI flag,
REST/gRPC contract, or default decode behaviour an operator depends on was removed or
changed.

## Docs / CHANGELOG

- [ ] `CHANGELOG.md` — not updated in this PR; happy to add an `## [Unreleased]` block for
      the user-visible bits (nav, playback, maps) if preferred before merge.
- [ ] `README.md` / `docs/` — no operator-facing doc changes included.

## Linked issues

n/a — touches areas around site names (#698), the Plots hub (#557), and per-site TSBK
quality (#858), but there's no single tracked issue for this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBH1jXQDyUCzW2YDRmBDLe

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBH1jXQDyUCzW2YDRmBDLe)_