### PR TITLE
web,tetra: relabel Plots symbol count and register ProtocolTETRADMO

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -178,12 +178,23 @@ func sameCarrierVoiceTaps(proto trunking.Protocol) int {
 	switch proto {
 	case trunking.ProtocolTETRA:
 		return tetraSameCarrierTaps
+	case trunking.ProtocolTETRADMO:
+		// TETRA DMO (Direct Mode) rides voice on the SAME carrier the pipeline
+		// decodes (there is no separate traffic channel), and only one PTT
+		// transmission is on the channel at a time, so a single same-carrier tap
+		// serves the voice chain (composer.runTETRADMOVoiceChain).
+		return tetraDMOSameCarrierTaps
 	case trunking.ProtocolDMRTier2, trunking.ProtocolDMRTier1:
 		return dmrSameCarrierTaps
 	default:
 		return 0
 	}
 }
+
+// tetraDMOSameCarrierTaps is how many same-carrier voice taps a TETRA DMO system
+// registers. DMO is half-duplex peer-to-peer: one MS transmits at a time, so a
+// single tap on the decoded carrier serves the (one) active call.
+const tetraDMOSameCarrierTaps = 1
 
 // gainLooksTooLow reports whether a manual (non-auto) gain is below the
 // digital-decode floor but above the tenths-of-dB-mistake band that

--- a/cmd/gophertrunk/integration_cc_tetra_dmo_test.go
+++ b/cmd/gophertrunk/integration_cc_tetra_dmo_test.go
@@ -1,0 +1,155 @@
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"math"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/config"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/tetra"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+)
+
+// TestDaemonDecodesTETRADMO drives the full daemon (config → protocol parse → DDC →
+// newTETRADMOPipeline → cchunt supervisor) with a synthetic TETRA DMO transmission and
+// asserts the DMO system LOCKS on the DSB SCH/S — the production-path proof that a DMO
+// capture no longer runs the wrong TMO control-channel pipeline (the operator's
+// symptom). The voice/recording half is on-air A/B gated (#1003); this test pins the
+// control-path wiring end to end.
+func TestDaemonDecodesTETRADMO(t *testing.T) {
+	const (
+		controlFreqHz = 438_900_000
+		sampleRate    = 144_000.0 // ddcTargetForProtocol(ProtocolTETRADMO)
+		sps           = 8
+		span          = 8
+		alpha         = 0.35
+		dmColour      = uint32(3)
+	)
+
+	dibits := buildDMODaemonDibits(dmColour, 30)
+	iq := demod.ModulatePiOver4DQPSK(dibits, sps, span, alpha, math.Pi/4)
+	iq = demod.ApplyImpairments(iq, sampleRate, demod.Impairments{SNRdB: 40, Seed: 5})
+
+	dir := t.TempDir()
+	iqPath := filepath.Join(dir, "tetra-dmo.cfile")
+	if err := writeIQToU8File(iqPath, iq); err != nil {
+		t.Fatalf("write IQ: %v", err)
+	}
+	sdr.Register(&sdr.MockDriver{Files: []string{iqPath}})
+
+	cfg := config.Default()
+	cfg.SDR.SampleRate = uint32(sampleRate)
+	cfg.SDR.Devices = []config.DeviceConfig{{Serial: "mock-00", Role: "control"}}
+	cfg.Trunking.Systems = []config.SystemConfig{
+		{
+			Name:            "DMO",
+			Protocol:        "tetra-dmo",
+			ControlChannels: []uint32{controlFreqHz},
+		},
+	}
+	cfg.API.HTTPAddr = freeAddr(t)
+	cfg.Metrics.Enabled = true
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	d, err := NewDaemon(cfg, "integration-cc-tetra-dmo", logger)
+	if err != nil {
+		t.Fatalf("NewDaemon: %v", err)
+	}
+	sub := d.Bus().Subscribe()
+	defer sub.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runErrCh := make(chan error, 1)
+	go func() { runErrCh <- d.Run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-runErrCh:
+		case <-time.After(3 * time.Second):
+		}
+	})
+
+	base := "http://" + cfg.API.HTTPAddr
+	waitReachable(t, base+"/api/v1/health", 3*time.Second)
+
+	deadline := time.After(6 * time.Second)
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind != events.KindCCLocked {
+				continue
+			}
+			ls, ok := ev.Payload.(tetra.LockState)
+			if !ok {
+				t.Errorf("CCLocked payload type = %T, want tetra.LockState", ev.Payload)
+				continue
+			}
+			if ls.FrequencyHz != controlFreqHz {
+				t.Errorf("LockState.FrequencyHz = %d, want %d", ls.FrequencyHz, controlFreqHz)
+			}
+			// Confirm the scanner surfaces the lock too, then done.
+			waitForScannerLock(t, base, "DMO", 2*time.Second)
+			return
+		case <-deadline:
+			t.Fatalf("no cc.locked event arrived within 6s for the DMO system")
+		}
+	}
+}
+
+// buildDMODaemonDibits assembles a TETRA DMO dibit stream (warmup + one DSB + nDNB
+// TCH/S DNBs scrambled with colour) for the π/4-DQPSK modulator, mirroring the
+// EN 300 396-2 Table 15/16 layout from the exported encoders.
+func buildDMODaemonDibits(colour uint32, nDNB int) []uint8 {
+	b2d := tetra.TetraBitsToDibits
+	filler := func(seed, n int) []uint8 {
+		s := make([]uint8, n)
+		for i := range s {
+			s[i] = uint8((seed + i*3) & 3)
+		}
+		return s
+	}
+	seq := func(seed, n int) []byte {
+		s := make([]byte, n)
+		for i := range s {
+			s[i] = byte((seed + i*5) % 2)
+		}
+		return s
+	}
+
+	out := filler(0, 900) // receiver warmup
+	// DSB: 40-dibit freq-corr + 60-dibit SCH/S + 19-dibit sync train + 108-dibit SCH/H.
+	out = append(out, filler(1, 40)...)
+	out = append(out, b2d(tetra.EncodeBSCH(seq(1, 60)))...)
+	out = append(out, tetra.SyncTrainingDibits()...)
+	out = append(out, b2d(tetra.EncodeSCHHD(seq(2, 124), 0))...)
+	// Repeat the DSB a few times through the stream so the supervisor's lock-wait sees
+	// a sync burst regardless of when its receiver converges.
+	for rep := 0; rep < nDNB; rep++ {
+		frameA := seq(7+rep, 137)
+		frameB := seq(9+rep, 137)
+		onair := framing.ScrambleTetra(framing.UnpackBitsMSB(tetra.EncodeTCHS(frameA, frameB), 432), colour)
+		out = append(out, filler(11+rep, 30)...)
+		out = append(out, b2d(onair[:216])...)
+		out = append(out, tetra.NormalSyncDibits()...)
+		out = append(out, b2d(onair[216:])...)
+		if rep%8 == 7 {
+			// Periodic DSB re-sync, as a real DMO transmitter interleaves.
+			out = append(out, filler(2, 20)...)
+			out = append(out, filler(1, 40)...)
+			out = append(out, b2d(tetra.EncodeBSCH(seq(1, 60)))...)
+			out = append(out, tetra.SyncTrainingDibits()...)
+			out = append(out, b2d(tetra.EncodeSCHHD(seq(2, 124), 0))...)
+		}
+	}
+	out = append(out, filler(99, 600)...)
+	return out
+}

--- a/docs/dmr-voice-quality.md
+++ b/docs/dmr-voice-quality.md
@@ -1,0 +1,167 @@
+---
+layout: page
+title: DMR voice quality
+description: Why DMR (AMBE+2) voice — especially female voices — sounds rough, what was ruled out, and how to verify a fix
+nav_group: Reference
+---
+
+# DMR voice quality (AMBE+2)
+
+Conventional DMR now decodes end to end, but the decoded voice — **female
+voices especially** — can sound rough. This page records what the decode chain
+does, a mbelib reconciliation review (what was ruled out and the one genuine
+divergence found), the operator levers you can pull today, and the
+calibration-gated path to a *verified* fix.
+
+The short version: GopherTrunk's default DMR decoder
+([`internal/voice/ambe2`](https://github.com/MattCheramie/GopherTrunk/tree/main/internal/voice/ambe2))
+is a clean-room Go re-implementation of **mbelib**'s `ambe3600x2450` path. mbelib
+is a reverse-engineered, *approximate* AMBE+2 decoder — it is known to sound
+worse than DVSI silicon, and worst on high-pitched (female) voices. So a large
+part of what you hear is inherent to the algorithm being mirrored, not a discrete
+bug. That said, one genuine divergence from the reference was found (below), and
+it is the prime suspect for the female-voice-specific roughness.
+
+## Why female voices are the hard case
+
+A female voice has a higher fundamental ω₀, hence **fewer harmonics** L
+(`internal/voice/ambe2/tables2450.go`: L ranges 9…56, and the low-L rows are the
+high-pitch ones). Everything in the model that is indexed by harmonic position
+`l` relative to `L` therefore behaves differently for small L — most of the
+band sits in the "high band" (`8l > L`) where the spectral-amplitude enhancement
+acts, and the voiced/unvoiced and phase-dispersion decisions cover proportionally
+more of the voice. So a mis-tuned or mis-transcribed high-band step hits female
+voices hardest.
+
+## Reconciliation review (mbelib `ambe3600x2450` + TIA-102.BABA §6.2)
+
+### Ruled OUT — these faithfully match the reference
+
+- **Pitch / L / w₀ tables** (`tables2450.go`) — generated from mbelib's
+  `ambe3600x2450_const.h`; the b0→(w₀, L) lookup matches.
+- **Voiced/unvoiced decode** (`params2450.go:60-72`). The `jl = int(l·16·f0)`
+  index and the `dmrVuv[b1][jl]` lookup match mbelib. The clamp to `[0,7]` is a
+  defined-behaviour guard; across the real f0 range `jl` spans the full 0…7 of
+  the table (e.g. at the highest f0≈0.05, `jl = 0.8·l` reaches 7 only at l≈9), so
+  there is **no pathological V/UV collapse** for female frames.
+- **§6.3 voiced-phase de-buzz** (`decoder.go:synthFrame`, ~627-664). mbelib does
+  `PHIl = PSIl` for `l ≤ L/4` and `PHIl = PSIl + numUv·rand_phase()/L` above it,
+  with `rand_phase() ∈ [-π, π]`. GT draws `(-1..1)·π · (numUv/L)` for `l > L/4`
+  voiced harmonics — the **same** distribution and scaling. Faithful.
+
+### Found — the one genuine divergence (§6.2 spectral-amplitude enhancement)
+
+[`internal/voice/mbe/enhance.go`](https://github.com/MattCheramie/GopherTrunk/blob/main/internal/voice/mbe/enhance.go)
+`EnhanceAmplitudes` is on the **default** decode path (`ambe2/decoder.go:485`,
+and `imbe/decoder.go:552` for P25). Its per-harmonic weight ξ drops a factor that
+is present in **both** references the code cites (TIA-102.BABA §6.2 *and*
+mbelib's `mbe_spectralAmpEnhance`):
+
+```
+mbelib / spec:   ξ = 0.96·π·num / ( ω0 · R_M0 · (R_M0² − R_M1²) )
+GopherTrunk:     ξ = 0.96·num   / (       R_M0 · (R_M0² − R_M1²) )
+                                   └─ missing the  π / ω0  factor ─┘
+        num = R_M0² + R_M1² − 2·R_M0·R_M1·cos(ω0·l),   W_l = ξ^0.25, clamped [0.5, 1.2]
+```
+
+For DMR, ω₀ ∈ [~0.05, ~0.31] rad, so `π/ω0 ∈ [~10, ~63]`. GT's ξ is therefore
+10–63× **smaller** than the spec's; after the `^0.25`, GT's high-band weights are
+~1.8–2.8× lower, so they land on the **0.5 (attenuate)** clamp where the spec
+would push toward the **1.2 (boost)** clamp. Because the frame is then
+energy-renormalised (γ = √(R_M0/Σ)), the *relative* spectral tilt shifts energy
+out of the high band into the low band — a duller timbre, and, since small-L
+(female) frames have most of their harmonics in that high band, the effect is
+**strongest on female voices**. This matches the reported symptom.
+
+`enhance.go`'s own header comment flags this as unfinished: *"spec-tuning to
+bit-match mbelib output is part of step 5c (gain calibration)."* So it is a known
+TODO, not a deliberate design choice.
+
+The one-line correction (restore the spec/mbelib factor) is:
+
+```go
+// internal/voice/mbe/enhance.go, inside EnhanceAmplitudes:
+xi := 0.96 * math.Pi * num / (p.W0 * den)   // was: xi := 0.96 * num / den
+```
+
+**Why this is not shipped as a default change yet.** It is deliberately left for
+the calibration A/B, per this repo's #764/#771 discipline:
+
+1. It cannot be verified to *improve* audio without a reference decode of the
+   same frames — mbelib is itself approximate, and matching its (or the spec's)
+   number is not proof of better perceived quality.
+2. `EnhanceAmplitudes` is shared with the **P25 IMBE** path, so a blind change has
+   blast radius beyond DMR.
+
+The calibrate harness below is the gate: with a real reference WAV in place, the
+`TestCompareAMBE2` cross-correlation will *rise* if this correction helps and
+*fall* if it hurts — decide from that, not from the formula.
+
+> A secondary, lower-confidence note: mbelib additionally multiplies the weight by
+> `√M_l` (`Wl = sqrtf(Ml[l]) · powf(...)`), which the spec closed form does not.
+> GT (correctly, per spec) omits it. Leave it omitted; it is a mbelib artefact,
+> not part of the spec.
+
+## Levers you can pull today (no code change)
+
+These are perceptual, not spec-exact, but cost nothing to try and can meaningfully
+warm up / brighten DMR audio while the calibration above is pending:
+
+- **`recordings.enhance`** — the opt-in output chain
+  ([`EnhanceConfig`](https://github.com/MattCheramie/GopherTrunk/blob/main/internal/config/config.go)).
+  A high-shelf and a louder AGC target help intelligibility:
+
+  ```yaml
+  recordings:
+    write_raw: true          # also needed for calibration below
+    enhance:
+      enabled: true
+      hpf_hz: 200            # trim rumble
+      lpf_hz: 3400           # telephone band
+      shelf_hz: 1600         # gentle presence
+      shelf_db: 2            # dB of cut above shelf_hz (positive; <=0 disables)
+      agc_target: 22000      # louder playback
+  ```
+
+- **`ambe2-dmr-warm`** — the warm DMR vocoder variant (a high-shelf `ToneTilt`),
+  selected by `recordings.warm_dmr_audio: true` (`WarmDMRAudio`). Softens the
+  synthetic "edge" without touching the model decode.
+
+## Verified-fix path (calibration-first)
+
+You already have the input side: every DMR call the daemon records with
+`recordings.write_raw: true` writes a `<UTC>_<id>.raw` sidecar of the packed
+AMBE+2 frames (7 bytes/frame) next to the `.wav`. Pick a **female-voice** call —
+the hard case — and:
+
+1. **Reference-decode the same `.raw`** through an independent AMBE+2 decoder:
+
+   ```sh
+   dsd-fme -r <call>.raw -o reference.wav      # 8 kHz mono 16-bit PCM
+   ```
+
+2. **Drop both files in and run the A/B** (the test skips until the reference
+   lands, so CI stays green today):
+
+   ```sh
+   cp <call>.raw    internal/voice/ambe2/testdata/dmr-voice.raw
+   cp reference.wav internal/voice/ambe2/testdata/dmr-voice-dsdfme.wav
+   go test ./internal/voice/calibrate/ -v -run TestCompareAMBE2
+   ```
+
+   Acceptance: `|RMSRatioDb| < 3.0` (loudness) and `PeakXcorr > 0.85` (waveform
+   similarity). A clean RMS but low xcorr is the **synthesis** signature — i.e.
+   the §6.2 enhancement above, not a gain knob.
+
+3. **A/B the §6.2 correction.** Note the baseline `PeakXcorr`, apply the one-line
+   `xi` change, re-run. If xcorr rises (and DMR + P25 both hold or improve), ship
+   it; if not, leave the default and keep the correction documented here.
+
+See [Voice calibration](voice-calibration.md) for the full harness reference
+(the `cmd/voice-calibrate` CLI, the IMBE path, and the AGC `TargetPeak` knob for
+the loudness half).
+
+> **Do not commit real over-the-air public-safety recordings as fixtures.** The
+> calibrate testdata dirs are for **local**, operator-provided captures — the
+> tests `t.Skip` when the files are absent, which is the intended state in the
+> repo.

--- a/docs/voice-calibration.md
+++ b/docs/voice-calibration.md
@@ -120,7 +120,11 @@ A failing PeakXcorr (with a clean RMSRatio) means the synthesis
 path itself is producing a different waveform. That's deeper than a
 gain knob — check the spectral envelope decoder
 ([`internal/voice/mbe/synth.go`](https://github.com/MattCheramie/GopherTrunk/blob/main/internal/voice/mbe/synth.go))
-and the prediction-residual gain path.
+and the prediction-residual gain path. For DMR (AMBE+2) specifically —
+especially rough **female** voices — see
+[DMR voice quality](dmr-voice-quality.md), which documents a mbelib
+reconciliation review and a §6.2 spectral-enhancement divergence that
+this same PeakXcorr A/B is the gate for.
 
 ## Reading P25 Phase 1 decode quality
 

--- a/internal/radio/tetra/dmo_stream.go
+++ b/internal/radio/tetra/dmo_stream.go
@@ -1,0 +1,164 @@
+package tetra
+
+import "sort"
+
+// DMO (Direct Mode) streaming burst extraction. ExtractDMBurstsSoft (dmo.go) is
+// stateless over a COMPLETE dibit slice — perfect for the offline replay harness,
+// which accumulates the whole capture before slicing. The live daemon instead sees
+// the demodulated dibit/soft-differential stream arrive in chunks and must decode
+// as it goes without buffering the whole (unbounded) transmission. DMStreamExtractor
+// is that streaming adapter: it keeps a BOUNDED sliding window of the most recent
+// dibits + differentials, re-runs ExtractDMBurstsSoft over the window each time new
+// symbols arrive, and emits each newly-completed DSB/DNB exactly once (deduped by its
+// absolute training-sequence lead index) in time order.
+//
+// It is the DMO analog of TrafficExtractor's streaming role for TMO, and is shared by
+// both the control-side pipeline (newTETRADMOPipeline: DSB SCH/S → lock/colour) and the
+// voice chain (DNB TCH/S → speech). Because it delegates the framing to the same
+// ExtractDMBurstsSoft the offline path uses, the two stay bit-identical on the bursts
+// they both see.
+
+const (
+	// dmStreamKeepTail is how many trailing dibits the window retains after each
+	// extraction pass. It must exceed the widest burst span so a burst straddling the
+	// trim boundary is not lost: a DNB reaches from L+dmDNBBKN1Start (L-108) to
+	// L+dmDNBBKN2Start+dmBlockDibits (L+119), a DSB from L+dmDSBFreqCorrStart (L-100)
+	// to L+dmDSBBKN2Start+dmBlockDibits (L+127) — ~235 dibits — plus the 19-dibit sync
+	// correlation lead. 384 gives comfortable margin so a burst whose lead sits just
+	// inside the retained tail is still fully present (and re-scanned) next pass.
+	dmStreamKeepTail = 384
+	// dmStreamMinRun is the smallest window (in dibits) worth running an extraction
+	// pass over — a little more than dmStreamKeepTail so the first pass has at least
+	// one burst-width of fresh symbols beyond the retained tail.
+	dmStreamMinRun = dmStreamKeepTail + 256
+)
+
+// DMStreamExtractor turns a chunked DMO dibit/soft-differential stream into a
+// time-ordered sequence of DMBursts via a bounded sliding window. Not safe for
+// concurrent use; drive it from a single goroutine (the receiver's sink callback,
+// like TrafficExtractor).
+type DMStreamExtractor struct {
+	onBurst func(DMBurst)
+
+	dibits  []uint8
+	diffs   []complex64
+	baseIdx int  // absolute dibit index of dibits[0]
+	nextIdx int  // absolute index the next appended dibit should carry (baseIdx+len)
+	primed  bool // nextIdx is meaningful once at least one chunk has been appended
+	softOK  bool // the diffs buffer is strictly parallel to dibits (no hard-chunk gap)
+
+	// lastLead is the highest absolute training-sequence lead already emitted, so a
+	// burst re-seen in a later window (its lead still inside the retained tail) is not
+	// emitted twice. Absolute, so it survives window trimming.
+	lastLead int
+}
+
+// NewDMStreamExtractor builds a streaming DMO extractor that calls onBurst for each
+// newly-completed DSB/DNB, in ascending lead order. The burst's slices are freshly
+// allocated by ExtractDMBursts, so onBurst may retain them, but treat them as
+// read-only.
+func NewDMStreamExtractor(onBurst func(DMBurst)) *DMStreamExtractor {
+	return &DMStreamExtractor{onBurst: onBurst, lastLead: -1, softOK: true}
+}
+
+// Process appends one chunk of dibits and its parallel per-symbol differentials
+// (diffs, the receiver's SoftSink output — same length as dibits, or nil for a
+// hard-only stream), then extracts and emits any newly-completed bursts. base is the
+// absolute dibit index of dibits[0]; a base that is not contiguous with the previous
+// chunk (a receiver Reset restarts the index at 0) transparently restarts the window.
+func (e *DMStreamExtractor) Process(dibits []uint8, diffs []complex64, base int) {
+	if len(dibits) == 0 {
+		return
+	}
+	if len(diffs) != len(dibits) {
+		diffs = nil // keep the two strictly parallel; degrade to hard on mismatch
+	}
+	// A non-contiguous base means the upstream receiver re-anchored (Reset): drop the
+	// stale window and restart from the new base so leads stay absolute-consistent.
+	if e.primed && base != e.nextIdx {
+		e.reset(base)
+	}
+	if !e.primed {
+		e.baseIdx = base
+		e.nextIdx = base
+		e.primed = true
+	}
+
+	e.dibits = append(e.dibits, dibits...)
+	if diffs == nil {
+		e.softOK = false
+	}
+	if e.softOK {
+		e.diffs = append(e.diffs, diffs...)
+	} else {
+		e.diffs = e.diffs[:0]
+	}
+	e.nextIdx = base + len(dibits)
+
+	if len(e.dibits) < dmStreamMinRun {
+		return
+	}
+	e.extractAndEmit()
+	e.trim()
+}
+
+// Flush runs a final extraction pass over whatever remains in the window (used at
+// end-of-stream so the last buffered burst is not stranded below dmStreamMinRun). It
+// does not trim, so it is safe to call repeatedly.
+func (e *DMStreamExtractor) Flush() {
+	if len(e.dibits) == 0 {
+		return
+	}
+	e.extractAndEmit()
+}
+
+// Reset drops all buffered state, as if the extractor were freshly constructed. The
+// lead-dedup watermark is cleared too, so a stream that restarts from index 0 (a
+// receiver Reset) does not suppress its first bursts.
+func (e *DMStreamExtractor) Reset() { e.reset(0) }
+
+func (e *DMStreamExtractor) reset(base int) {
+	e.dibits = e.dibits[:0]
+	e.diffs = e.diffs[:0]
+	e.baseIdx = base
+	e.nextIdx = base
+	e.primed = false
+	e.softOK = true
+	e.lastLead = -1
+}
+
+func (e *DMStreamExtractor) extractAndEmit() {
+	var bursts []DMBurst
+	if e.softOK && len(e.diffs) == len(e.dibits) {
+		bursts = ExtractDMBurstsSoft(e.dibits, e.diffs, e.baseIdx)
+	} else {
+		bursts = ExtractDMBursts(e.dibits, e.baseIdx)
+	}
+	// Emit strictly in ascending lead order so downstream (voice frames especially)
+	// stays time-ordered, and only bursts past the dedup watermark.
+	sort.Slice(bursts, func(i, j int) bool { return bursts[i].Lead < bursts[j].Lead })
+	for i := range bursts {
+		if bursts[i].Lead <= e.lastLead {
+			continue
+		}
+		e.lastLead = bursts[i].Lead
+		if e.onBurst != nil {
+			e.onBurst(bursts[i])
+		}
+	}
+}
+
+// trim discards all but the trailing dmStreamKeepTail dibits so the window stays
+// bounded. lastLead is absolute and unaffected, so a burst re-seen in the retained
+// tail after the trim is still suppressed by the dedup check.
+func (e *DMStreamExtractor) trim() {
+	over := len(e.dibits) - dmStreamKeepTail
+	if over <= 0 {
+		return
+	}
+	e.dibits = append(e.dibits[:0], e.dibits[over:]...)
+	if e.softOK {
+		e.diffs = append(e.diffs[:0], e.diffs[over:]...)
+	}
+	e.baseIdx += over
+}

--- a/internal/radio/tetra/dmo_stream_test.go
+++ b/internal/radio/tetra/dmo_stream_test.go
@@ -1,0 +1,157 @@
+package tetra
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
+
+// idealDiffsFromDibits synthesizes the noiseless (sigma 0) per-symbol π/4-DQPSK
+// differentials parallel to a dibit stream, using the same rotation-0 polarity the
+// soft decoder reads (Im→b1, Re→b2, +⇒bit 0 — see dmoNoisyDNB). Feeding these to the
+// streaming extractor exercises the soft TCH/S path deterministically.
+func idealDiffsFromDibits(dibits []uint8) []complex64 {
+	bits := TetraDibitsToBits(dibits) // 2 bits per dibit, [b1(Im), b2(Re)]
+	amp := func(b byte) float32 {
+		if b&1 == 0 {
+			return 1 // bit 0 ⇒ +
+		}
+		return -1 // bit 1 ⇒ -
+	}
+	diffs := make([]complex64, len(dibits))
+	for i := range dibits {
+		diffs[i] = complex(amp(bits[2*i+1]), amp(bits[2*i])) // (Re=b2, Im=b1)
+	}
+	return diffs
+}
+
+// buildDMOStream lays out a realistic multi-burst DMO transmission: a leading DSB
+// (SCH/S + SCH/H) followed by several TCH/S DNBs, separated by inter-burst filler,
+// so the streaming extractor is exercised over bursts at a range of absolute
+// offsets. Returns the dibit stream plus the encoded speech frames per DNB so the
+// caller can assert decode fidelity end to end.
+func buildDMOStream(t *testing.T, colour uint32, nDNB int) (dibits []uint8, wantFrames [][2][]byte) {
+	t.Helper()
+	// DSB.
+	schs := EncodeBSCH(seqBits(1, 60))
+	schh := EncodeSCHHD(seqBits(2, 124), 0)
+	dibits = append(dibits, ramp(5, 50)...) // leading noise/preamble before the first burst
+	dibits = append(dibits, buildDSB(schs, schh)...)
+
+	for i := 0; i < nDNB; i++ {
+		frameA := seqBits(7+i, tchSpeechFrameBits)
+		frameB := seqBits(9+i, tchSpeechFrameBits)
+		type4 := framing.UnpackBitsMSB(EncodeTCHS(frameA, frameB), tchType3Bits)
+		onair := framing.ScrambleTetra(type4, colour)
+		block1 := onair[:dmBlockDibits*2]
+		block2 := onair[dmBlockDibits*2:]
+		dibits = append(dibits, ramp(11+i, 30)...) // inter-burst filler
+		dibits = append(dibits, buildDNB(block1, block2)...)
+		wantFrames = append(wantFrames, [2][]byte{framing.PackBitsMSB(frameA), framing.PackBitsMSB(frameB)})
+	}
+	dibits = append(dibits, ramp(99, 400)...) // trailing filler so the last burst is fully inside the window
+	return dibits, wantFrames
+}
+
+// TestDMStreamExtractorMatchesWholeSlice feeds a multi-burst DMO stream through the
+// streaming extractor in small chunks and asserts it emits exactly the bursts a
+// single whole-slice ExtractDMBursts finds — same leads, same kinds, in ascending
+// lead order, with no duplicates. This is the streaming adapter's contract: the
+// sliding window must not drop, duplicate, or reorder bursts relative to the
+// offline path the replay harness validates.
+func TestDMStreamExtractorMatchesWholeSlice(t *testing.T) {
+	dibits, _ := buildDMOStream(t, 0, 4)
+
+	// Reference: whole-slice extraction (what the offline replay harness runs).
+	ref := ExtractDMBursts(dibits, 0)
+	wantLeads := map[int]DMBurstKind{}
+	for _, b := range ref {
+		wantLeads[b.Lead] = b.Kind
+	}
+	if len(wantLeads) < 5 { // 1 DSB + 4 DNB
+		t.Fatalf("reference extraction found only %d distinct bursts, want >=5", len(wantLeads))
+	}
+
+	for _, chunk := range []int{1, 7, 64, 250, 4096} {
+		var got []DMBurst
+		e := NewDMStreamExtractor(func(b DMBurst) { got = append(got, b) })
+		for i := 0; i < len(dibits); i += chunk {
+			end := i + chunk
+			if end > len(dibits) {
+				end = len(dibits)
+			}
+			// Hard stream (nil diffs) for this contract test.
+			e.Process(dibits[i:end], nil, i)
+		}
+		e.Flush()
+
+		// Ordering + no duplicates.
+		seen := map[int]struct{}{}
+		lastLead := -1
+		for _, b := range got {
+			if _, dup := seen[b.Lead]; dup {
+				t.Errorf("chunk=%d: burst lead %d emitted twice", chunk, b.Lead)
+			}
+			seen[b.Lead] = struct{}{}
+			if b.Lead <= lastLead {
+				t.Errorf("chunk=%d: bursts not in ascending lead order (%d after %d)", chunk, b.Lead, lastLead)
+			}
+			lastLead = b.Lead
+			if k, ok := wantLeads[b.Lead]; !ok {
+				t.Errorf("chunk=%d: emitted a burst at lead %d not in the reference set", chunk, b.Lead)
+			} else if k != b.Kind {
+				t.Errorf("chunk=%d: lead %d kind=%v, reference kind=%v", chunk, b.Lead, b.Kind, k)
+			}
+		}
+		// Every reference burst must be emitted.
+		for lead := range wantLeads {
+			if _, ok := seen[lead]; !ok {
+				t.Errorf("chunk=%d: reference burst at lead %d was never emitted", chunk, lead)
+			}
+		}
+	}
+}
+
+// TestDMStreamExtractorSoftDecodes checks the streaming path carries the soft
+// differentials through to a CRC-valid TCH/S soft decode: a DNB fed with its
+// parallel differentials must yield the two speech frames DMBurstTCHSpeechSoft
+// recovers, matching what was encoded.
+func TestDMStreamExtractorSoftDecodes(t *testing.T) {
+	const colour = 0x0AB1F
+	dibits, wantFrames := buildDMOStream(t, colour, 3)
+	// Synthesize a parallel soft-differential stream from the ideal dibits so the
+	// soft extraction path is exercised (the receiver would supply real
+	// differentials; here the ideal π/4 phasors make the soft decode deterministic).
+	diffs := idealDiffsFromDibits(dibits)
+
+	var speech [][]byte
+	e := NewDMStreamExtractor(func(b DMBurst) {
+		if b.Kind != DMBurstNormal {
+			return
+		}
+		if fr := DMBurstTCHSpeechSoft(b, colour); len(fr) == 2 {
+			speech = append(speech, fr...)
+		} else if fr := DMBurstTCHSpeech(b, colour); len(fr) == 2 {
+			speech = append(speech, fr...)
+		}
+	})
+	const chunk = 512
+	for i := 0; i < len(dibits); i += chunk {
+		end := i + chunk
+		if end > len(dibits) {
+			end = len(dibits)
+		}
+		e.Process(dibits[i:end], diffs[i:end], i)
+	}
+	e.Flush()
+
+	if len(speech) != 2*len(wantFrames) {
+		t.Fatalf("recovered %d speech frames, want %d", len(speech), 2*len(wantFrames))
+	}
+	for i, want := range wantFrames {
+		if !reflect.DeepEqual(speech[2*i], want[0]) || !reflect.DeepEqual(speech[2*i+1], want[1]) {
+			t.Errorf("DNB %d: speech frame mismatch", i)
+		}
+	}
+}

--- a/internal/scanner/ccdecoder/ddc.go
+++ b/internal/scanner/ccdecoder/ddc.go
@@ -41,9 +41,11 @@ const tetraDDCTargetRateHz = 144000.0
 // converter decimates to for a protocol. The 4800-baud C4FM family
 // (P25 / DMR / NXDN / dPMR / YSF / D-STAR) and the other ≤9600-baud
 // protocols all channelize to ddcTargetRateHz; TETRA's 18000-baud
-// π/4-DQPSK needs a wider channel, so it gets tetraDDCTargetRateHz.
+// π/4-DQPSK needs a wider channel, so it gets tetraDDCTargetRateHz —
+// including TETRA DMO (Direct Mode), which shares the same 18000-baud
+// physical layer as TMO.
 func ddcTargetForProtocol(p trunking.Protocol) float64 {
-	if p == trunking.ProtocolTETRA {
+	if p == trunking.ProtocolTETRA || p == trunking.ProtocolTETRADMO {
 		return tetraDDCTargetRateHz
 	}
 	return ddcTargetRateHz

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -211,6 +211,7 @@ var factories = map[trunking.Protocol]PipelineFactory{
 	trunking.ProtocolLTR:       newLTRPipeline,
 	trunking.ProtocolMPT1327:   newMPT1327Pipeline,
 	trunking.ProtocolTETRA:     newTETRAPipeline,
+	trunking.ProtocolTETRADMO:  newTETRADMOPipeline,
 	trunking.ProtocolYSF:       newYSFPipeline,
 	trunking.ProtocolDStar:     newDStarPipeline,
 	trunking.ProtocolDMRTier2:  newDMRTier2Pipeline,

--- a/internal/scanner/ccdecoder/pipelines_dmo.go
+++ b/internal/scanner/ccdecoder/pipelines_dmo.go
@@ -1,0 +1,311 @@
+package ccdecoder
+
+import (
+	"context"
+	"log/slog"
+	"math"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/tetra"
+	tetrarx "github.com/MattCheramie/GopherTrunk/internal/radio/tetra/receiver"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TETRA DMO (Direct Mode Operation) control-side pipeline. Unlike TMO — which has a
+// continuous control channel the daemon locks and follows — DMO is infrastructure-
+// less peer-to-peer: a transmitting MS keys up, sends a Direct Mode Synchronisation
+// Burst (DSB) then a train of Direct Mode Normal Bursts (DNB) carrying the call, and
+// the channel is silent between transmissions (EN 300 396-2). So newTETRADMOPipeline
+// cannot reuse tetra.ControlChannel (a TMO CC state machine that slices the TMO NDB
+// geometry and expects a persistent carrier); it drives the standalone, offline-
+// validated DMO burst decoders (dmo.go / dmo_decode.go) over the receiver's dibit +
+// soft-differential stream via DMStreamExtractor instead.
+//
+// Its job on the daemon control path is:
+//   - LOCK: publish events.KindCCLocked the first time a DSB's SCH/S decodes CRC-valid
+//     with a parseable SYNC PDU, so the cchunt supervisor stops hunting and camps the
+//     DM channel. The lock is sticky (no cc.lost on inter-transmission silence) —
+//     re-hunting a camped DMO frequency every quiet gap is exactly the churn the TMO
+//     pipeline produced on a DMO capture.
+//   - COLOUR: recover the DM traffic colour code once (RecoverDMColourCode), so the
+//     voice chain can descramble TCH/S. A non-zero tetra_colour_code overrides.
+//   - GRANT: publish events.KindGrant (Protocol "tetra-dmo") on the rising edge of a
+//     DNB traffic burst train, so the engine starts a same-carrier voice chain that
+//     decodes the actual speech (composer.runTETRADMOVoiceChain). Edge-triggered and
+//     re-armed only after a traffic drought, because a DMO grant carries no talkgroup
+//     (GroupID 0) and the engine does not de-duplicate zero-group grants.
+//
+// The actual TCH/S → ACELP audio is decoded in the voice chain, not here; this
+// pipeline decodes SCH/S (lock) and brute-forces the colour, and only needs to detect
+// DNB *presence* to grant. This is #1003, design-first and on-air A/B gated: a green
+// synthetic decode is not proof of on-air correctness (the #764/#771 rule).
+
+const (
+	// dmoStatusInterval throttles the DMO decode-status debug line (mirrors the TMO
+	// tetraStatusInterval).
+	dmoStatusInterval = 5 * time.Second
+	// dmoColourBatch is how many DNBs to buffer before brute-forcing the DM colour
+	// code (RecoverDMColourCode). ~one second of a full-rate call, enough for the
+	// confidence gate (dmColourMinCRC/dmColourDominance) to separate the true colour
+	// from the chance floor.
+	dmoColourBatch = 20
+	// dmoColourMaxAttempts caps how many recovery passes to try before giving up and
+	// falling back to colour 0 (a channel that never clears the confidence gate is
+	// encrypted or unreceivable — chasing it forever would burn CPU on every DNB).
+	dmoColourMaxAttempts = 6
+	// dmoGrantMinDNB is how many DNBs must follow a lock before a grant fires — a
+	// short guard so a lone stray DNB detection does not spawn a call.
+	dmoGrantMinDNB = 4
+	// dmoGrantRearm is the DNB-traffic drought after which the grant re-arms, so the
+	// next PTT transmission grants afresh. Longer than the voice chain's hangtime so a
+	// brief intra-call gap does not double-grant an already-active call.
+	dmoGrantRearm = 3 * time.Second
+)
+
+func newTETRADMOPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
+	log := opts.Log
+	if log == nil {
+		log = slog.Default()
+	}
+	tetraClockMode, ok := tetrarx.ParseClockMode(opts.System.TETRAClockMode)
+	if !ok {
+		log.Warn("ccdecoder: unrecognised tetra_clock_mode; falling back to gardner",
+			"system", opts.SystemName, "value", opts.System.TETRAClockMode)
+	}
+	p := &tetraDMOPipeline{
+		bus:          opts.Bus,
+		log:          log,
+		system:       opts.SystemName,
+		freqHz:       opts.FrequencyHz,
+		rateHz:       opts.SampleRateHz,
+		now:          time.Now,
+		configColour: opts.System.TETRAColourCode,
+		fnSeen:       map[uint8]struct{}{},
+		debug:        log.Enabled(context.Background(), slog.LevelDebug),
+	}
+	if p.configColour != 0 {
+		p.colour = p.configColour
+		p.colourKnown = true
+	}
+	p.ext = tetra.NewDMStreamExtractor(p.onBurst)
+	p.rx = tetrarx.New(tetrarx.Options{
+		SampleRateHz: opts.SampleRateHz,
+		DibitSink: func(dibits []uint8, baseIdx int) {
+			opts.tapDibits(dibits, baseIdx)
+			p.ext.Process(dibits, p.pendingSoft, baseIdx)
+			p.pendingSoft = nil
+		},
+		// The SoftSink fires just before the matching DibitSink with the same base
+		// (issue #553), so stash the differentials and hand them to the extractor
+		// alongside the dibits, keeping the two strictly parallel.
+		SoftSink: func(diffs []complex64, baseIdx int) {
+			p.pendingSoft = diffs
+		},
+		ClockMode:           tetraClockMode,
+		GardnerGain:         0.005,
+		EnableAFC:           true,
+		EnableChannelFilter: true,
+		// The blind SnapshotCMA equalizer is REQUIRED for DMO, not optional: on the
+		// reporter's 438.9 MHz capture it lifts CRC-valid SCH/S from ~6 to ~64 by
+		// inverting the ISI that smears the π/4-DQPSK constellation (same lever the
+		// TMO CC path and the offline TestTETRADMOReplay run by default).
+		EnableEqualizer: true,
+	})
+	log.Info("ccdecoder: tetra DMO pipeline configured",
+		"system", opts.SystemName, "freq_hz", opts.FrequencyHz,
+		"colour_override", opts.System.TETRAColourCode)
+	return p, nil
+}
+
+type tetraDMOPipeline struct {
+	rx  *tetrarx.Receiver
+	ext *tetra.DMStreamExtractor
+	bus *events.Bus
+	log *slog.Logger
+
+	system string
+	freqHz uint32
+	rateHz float64
+	now    func() time.Time
+	debug  bool
+
+	// SoftSink → DibitSink hand-off (both fire on the single rx.Process goroutine).
+	pendingSoft []complex64
+
+	// Colour recovery: 0 = auto-recover via RecoverDMColourCode; a non-zero
+	// tetra_colour_code overrides.
+	configColour  uint32
+	colour        uint32
+	colourKnown   bool
+	colourCand    []tetra.DMBurst
+	colourTries   int
+
+	// Lock + liveness.
+	locked bool
+	fnSeen map[uint8]struct{}
+
+	// Grant edge-trigger state.
+	grantActive  bool
+	dnbSinceLock int
+	lastDNB      time.Time
+
+	// Status counters (single-goroutine; no atomics needed).
+	dsbTotal, dsbCRC, dnbTotal, tchCRC int64
+	lastLog                            time.Time
+}
+
+func (p *tetraDMOPipeline) Process(iq []complex64) {
+	p.rx.Process(iq)
+	p.maybeLogStatus()
+}
+
+// onBurst is the DMStreamExtractor callback, invoked (in time order) for each
+// newly-completed DSB/DNB during rx.Process. Runs on the single receiver goroutine,
+// so all pipeline state below is touched by exactly one writer.
+func (p *tetraDMOPipeline) onBurst(b tetra.DMBurst) {
+	switch b.Kind {
+	case tetra.DMBurstSync:
+		p.dsbTotal++
+		type1, ok := tetra.DecodeDMSCHS(b)
+		if !ok {
+			return
+		}
+		p.dsbCRC++
+		if pdu, pok := tetra.ParseSyncPDU(type1); pok {
+			p.fnSeen[pdu.FN] = struct{}{}
+			p.maybeLock()
+		}
+	case tetra.DMBurstNormal:
+		p.dnbTotal++
+		now := p.now()
+		// Re-arm the grant after a traffic drought so the next PTT grants afresh.
+		if !p.lastDNB.IsZero() && now.Sub(p.lastDNB) > dmoGrantRearm {
+			p.grantActive = false
+			p.dnbSinceLock = 0
+		}
+		p.lastDNB = now
+		p.dnbSinceLock++
+		p.recoverColour(b)
+		// Telemetry only: count CRC-valid TCH/S when the colour is known (the voice
+		// chain does the real decode). Cheap — a single decode at the known colour.
+		if p.colourKnown {
+			if len(tetra.DMBurstTCHSpeechSoft(b, p.colour)) == 2 ||
+				len(tetra.DMBurstTCHSpeech(b, p.colour)) == 2 {
+				p.tchCRC++
+			}
+		}
+		p.maybeGrant()
+	}
+}
+
+// maybeLock publishes cc.locked once, on the first CRC-valid SCH/S with a parseable
+// SYNC PDU. The lock is sticky: the pipeline never publishes cc.lost, so a camped DMO
+// frequency is not re-hunted during the silence between transmissions.
+func (p *tetraDMOPipeline) maybeLock() {
+	if p.locked || p.bus == nil {
+		return
+	}
+	p.locked = true
+	p.bus.Publish(events.Event{
+		Kind:    events.KindCCLocked,
+		Payload: tetra.LockState{FrequencyHz: p.freqHz},
+	})
+	p.log.Info("tetra dmo cc locked", "freq", p.freqHz, "system", p.system)
+}
+
+// recoverColour brute-forces the DM traffic colour code once (RecoverDMColourCode),
+// buffering DNBs until a batch is available. No-op once the colour is known (config
+// override or a prior successful recovery) or after dmoColourMaxAttempts give up.
+func (p *tetraDMOPipeline) recoverColour(b tetra.DMBurst) {
+	if p.colourKnown || p.colourTries >= dmoColourMaxAttempts {
+		return
+	}
+	p.colourCand = append(p.colourCand, b)
+	if len(p.colourCand) < dmoColourBatch {
+		return
+	}
+	p.colourTries++
+	if c, n, confident := tetra.RecoverDMColourCode(p.colourCand); confident {
+		p.colour = c
+		p.colourKnown = true
+		p.log.Info("tetra dmo colour code recovered", "colour", c, "crc_valid_tchs", n, "system", p.system)
+	}
+	// Keep only the freshest half so the next attempt reflects current channel
+	// conditions rather than re-scoring stale bursts.
+	keep := len(p.colourCand) / 2
+	p.colourCand = append(p.colourCand[:0], p.colourCand[keep:]...)
+}
+
+// maybeGrant publishes a tetra-dmo grant on the rising edge of a DNB traffic burst
+// train (after a short DNB-count guard). DMO carries no talkgroup, so GroupID is 0;
+// the engine does not de-duplicate zero-group grants, so this must fire exactly once
+// per transmission — grantActive gates that, re-armed only after dmoGrantRearm of DNB
+// silence. The recovered DM colour rides in TETRAColourExt so the voice chain can
+// descramble TCH/S; when it is not yet recovered the grant still fires (colour 0
+// hint) and the voice chain recovers it independently.
+func (p *tetraDMOPipeline) maybeGrant() {
+	if p.grantActive || p.bus == nil || p.dnbSinceLock < dmoGrantMinDNB {
+		return
+	}
+	p.grantActive = true
+	p.bus.Publish(events.Event{
+		Kind: events.KindGrant,
+		Payload: trunking.Grant{
+			System:         p.system,
+			Protocol:       "tetra-dmo",
+			FrequencyHz:    p.freqHz,
+			TETRAColourExt: p.colour,
+			At:             p.now(),
+		},
+	})
+	p.log.Info("tetra dmo grant (traffic detected)",
+		"freq", p.freqHz, "colour", p.colour, "system", p.system)
+}
+
+func (p *tetraDMOPipeline) maybeLogStatus() {
+	if !p.debug || p.log == nil {
+		return
+	}
+	now := p.now()
+	if p.lastLog.IsZero() {
+		p.lastLog = now
+		return
+	}
+	if now.Sub(p.lastLog) < dmoStatusInterval {
+		return
+	}
+	p.lastLog = now
+	p.log.Debug("tetra dmo: decode status",
+		"system", p.system,
+		"locked", p.locked,
+		"carrier_off_hz", math.Round(p.rx.CarrierOffsetHz()*10)/10,
+		"dsb_total", p.dsbTotal,
+		"dsb_schs_crc", p.dsbCRC,
+		"dnb_total", p.dnbTotal,
+		"tch_crc", p.tchCRC,
+		"distinct_fn", len(p.fnSeen),
+		"colour", p.colour,
+		"colour_known", p.colourKnown,
+		"grant_active", p.grantActive,
+	)
+}
+
+// AFCOffsetHz reports the receiver's measured carrier offset (Hz). Satisfies the
+// afcReporter capability the decoder type-asserts for.
+func (p *tetraDMOPipeline) AFCOffsetHz() float64 { return p.rx.CarrierOffsetHz() }
+
+// BSCHCounts exposes the DSB SCH/S (ok, fail) decode counts as the DMO analogue of
+// the TMO BSCH counts, from which the decoder derives a decode-quality bucket.
+func (p *tetraDMOPipeline) BSCHCounts() (ok, fail int64) {
+	return p.dsbCRC, p.dsbTotal - p.dsbCRC
+}
+
+func (p *tetraDMOPipeline) Reset() {
+	p.rx.Reset()
+	p.ext.Reset()
+	p.pendingSoft = nil
+	p.lastLog = time.Time{}
+}
+
+func (p *tetraDMOPipeline) Close() error { return nil }

--- a/internal/scanner/ccdecoder/pipelines_dmo.go
+++ b/internal/scanner/ccdecoder/pipelines_dmo.go
@@ -135,11 +135,11 @@ type tetraDMOPipeline struct {
 
 	// Colour recovery: 0 = auto-recover via RecoverDMColourCode; a non-zero
 	// tetra_colour_code overrides.
-	configColour  uint32
-	colour        uint32
-	colourKnown   bool
-	colourCand    []tetra.DMBurst
-	colourTries   int
+	configColour uint32
+	colour       uint32
+	colourKnown  bool
+	colourCand   []tetra.DMBurst
+	colourTries  int
 
 	// Lock + liveness.
 	locked bool

--- a/internal/scanner/ccdecoder/pipelines_dmo_test.go
+++ b/internal/scanner/ccdecoder/pipelines_dmo_test.go
@@ -82,7 +82,7 @@ func buildDMODibitStream(colour uint32, nDNB int) []uint8 {
 func TestTETRADMOPipelineLocksAndGrants(t *testing.T) {
 	const (
 		sampleRate = 144_000.0 // ddcTargetForProtocol(ProtocolTETRADMO)
-		sps        = 8          // 144000 / 18000
+		sps        = 8         // 144000 / 18000
 		span       = 8
 		alpha      = 0.35
 		freqHz     = 438_900_000

--- a/internal/scanner/ccdecoder/pipelines_dmo_test.go
+++ b/internal/scanner/ccdecoder/pipelines_dmo_test.go
@@ -1,0 +1,179 @@
+package ccdecoder
+
+import (
+	"math"
+	"sync"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/tetra"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// tchSpeechFrameBits / tchType3Bits mirror the unexported tetra constants: a TCH/S
+// speech frame is 137 type-1 bits, and the full slot is 432 type-4 (post-FEC, pre-
+// scramble) bits.
+const (
+	dmoTestSpeechBits = 137
+	dmoTestType4Bits  = 432
+)
+
+func dmoSeqBits(seed, n int) []byte {
+	out := make([]byte, n)
+	for i := range out {
+		out[i] = byte((seed + i*5) % 2)
+	}
+	return out
+}
+
+func dmoFiller(seed, n int) []uint8 {
+	out := make([]uint8, n)
+	for i := range out {
+		out[i] = uint8((seed + i*3) & 3)
+	}
+	return out
+}
+
+// buildDMODibitStream synthesizes a DMO transmission's demodulated dibit stream: a
+// long receiver lead-in, one DSB (SCH/S + SCH/H), then nDNB TCH/S DNBs scrambled with
+// colour, separated by filler. It mirrors the buildDSB/buildDNB layout the tetra
+// package tests use (EN 300 396-2 Tables 15/16), built from the exported encoders so
+// it can live in the ccdecoder package.
+func buildDMODibitStream(colour uint32, nDNB int) []uint8 {
+	b2d := tetra.TetraBitsToDibits
+	schs := b2d(tetra.EncodeBSCH(dmoSeqBits(1, 60)))
+	schh := b2d(tetra.EncodeSCHHD(dmoSeqBits(2, 124), 0))
+
+	var out []uint8
+	out = append(out, dmoFiller(0, 900)...) // lead-in: let Gardner/AFC/equalizer converge
+
+	// DSB: 40-dibit freq-corr + 60-dibit SCH/S + 19-dibit sync train + 108-dibit SCH/H.
+	out = append(out, dmoFiller(1, 40)...)
+	out = append(out, schs...)
+	out = append(out, tetra.SyncTrainingDibits()...)
+	out = append(out, schh...)
+
+	for i := 0; i < nDNB; i++ {
+		frameA := dmoSeqBits(7+i, dmoTestSpeechBits)
+		frameB := dmoSeqBits(9+i, dmoTestSpeechBits)
+		type4 := framing.UnpackBitsMSB(tetra.EncodeTCHS(frameA, frameB), dmoTestType4Bits)
+		onair := framing.ScrambleTetra(type4, colour)
+		blk1 := b2d(onair[:dmoTestType4Bits/2])
+		blk2 := b2d(onair[dmoTestType4Bits/2:])
+		out = append(out, dmoFiller(11+i, 30)...)
+		out = append(out, blk1...)
+		out = append(out, tetra.NormalSyncDibits()...)
+		out = append(out, blk2...)
+	}
+	out = append(out, dmoFiller(99, 600)...) // trailing filler so the last burst is inside the window
+	return out
+}
+
+// TestTETRADMOPipelineLocksAndGrants drives newTETRADMOPipeline with a synthetic DMO
+// transmission modulated to the 144 kHz channel rate (the production DDC target) and
+// asserts the production control path: it locks on the DSB SCH/S (publishing
+// cc.locked), brute-force-recovers the DM traffic colour code, and publishes a
+// tetra-dmo grant so the composer starts a voice chain. This is the production-path
+// analogue of the offline TestTETRADMOReplay — a green synthetic decode is a
+// necessary (not sufficient) gate; on-air A/B on the operator's capture is still
+// required to close #1003 (#764/#771).
+func TestTETRADMOPipelineLocksAndGrants(t *testing.T) {
+	const (
+		sampleRate = 144_000.0 // ddcTargetForProtocol(ProtocolTETRADMO)
+		sps        = 8          // 144000 / 18000
+		span       = 8
+		alpha      = 0.35
+		freqHz     = 438_900_000
+		testColour = uint32(3) // the DM traffic colour to recover (0 = config default)
+		nDNB       = 40
+	)
+
+	dibits := buildDMODibitStream(testColour, nDNB)
+	iq := demod.ModulatePiOver4DQPSK(dibits, sps, span, alpha, math.Pi/4)
+	// Light noise floor: the blind CMA equalizer's constant-modulus adaptation is
+	// well-defined only against a signal with a noise floor (mirrors the TMO
+	// integration test + receiver clean-channel tests).
+	iq = demod.ApplyImpairments(iq, sampleRate, demod.Impairments{SNRdB: 40, Seed: 7})
+
+	bus := events.NewBus(256)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	var (
+		mu     sync.Mutex
+		locked bool
+		grants []trunking.Grant
+	)
+	drainDone := make(chan struct{})
+	go func() {
+		defer close(drainDone)
+		for ev := range sub.C {
+			mu.Lock()
+			switch ev.Kind {
+			case events.KindCCLocked:
+				locked = true
+			case events.KindGrant:
+				if g, ok := ev.Payload.(trunking.Grant); ok {
+					grants = append(grants, g)
+				}
+			}
+			mu.Unlock()
+		}
+	}()
+
+	pl, err := newTETRADMOPipeline(PipelineOptions{
+		Bus:          bus,
+		SystemName:   "DMO",
+		FrequencyHz:  freqHz,
+		SampleRateHz: sampleRate,
+		System:       trunking.System{Protocol: trunking.ProtocolTETRADMO},
+	})
+	if err != nil {
+		t.Fatalf("newTETRADMOPipeline: %v", err)
+	}
+	dmo := pl.(*tetraDMOPipeline)
+
+	const chunk = 4096
+	for i := 0; i < len(iq); i += chunk {
+		end := i + chunk
+		if end > len(iq) {
+			end = len(iq)
+		}
+		pl.Process(iq[i:end])
+	}
+
+	// Inspect the pipeline's own decode state (same package → unexported access).
+	if !dmo.locked {
+		t.Errorf("pipeline did not lock (dsb_total=%d dsb_crc=%d)", dmo.dsbTotal, dmo.dsbCRC)
+	}
+	if dmo.dsbCRC == 0 {
+		t.Errorf("no CRC-valid DSB SCH/S decoded")
+	}
+	if !dmo.colourKnown {
+		t.Errorf("DM colour code not recovered (dnb_total=%d tch_crc=%d)", dmo.dnbTotal, dmo.tchCRC)
+	} else if dmo.colour != testColour {
+		t.Errorf("recovered colour=%d, want %d", dmo.colour, testColour)
+	}
+	if dmo.tchCRC == 0 {
+		t.Errorf("no CRC-valid TCH/S decoded at the recovered colour")
+	}
+
+	bus.Close()
+	<-drainDone
+	mu.Lock()
+	defer mu.Unlock()
+	if !locked {
+		t.Errorf("no cc.locked event published")
+	}
+	if len(grants) == 0 {
+		t.Fatalf("no tetra-dmo grant published")
+	}
+	g := grants[0]
+	if g.Protocol != "tetra-dmo" {
+		t.Errorf("grant protocol=%q, want tetra-dmo", g.Protocol)
+	}
+	if g.FrequencyHz != freqHz {
+		t.Errorf("grant freq=%d, want %d", g.FrequencyHz, freqHz)
+	}
+}

--- a/internal/trunking/site.go
+++ b/internal/trunking/site.go
@@ -28,6 +28,7 @@ const (
 	ProtocolDStar              // D-STAR (GMSK 4800 bps, amateur — header-only repeater protocol; config "dstar")
 	ProtocolDMRTier2           // DMR Tier II conventional (per-repeater; config "dmr-tier2")
 	ProtocolDMRTier1           // DMR Tier I direct-mode (license-free simplex; config "dmr-tier1")
+	ProtocolTETRADMO           // TETRA DMO / Direct Mode Operation (ETSI EN 300 396; config "tetra-dmo")
 )
 
 func (p Protocol) String() string {
@@ -60,6 +61,8 @@ func (p Protocol) String() string {
 		return "dmr-tier2"
 	case ProtocolDMRTier1:
 		return "dmr-tier1"
+	case ProtocolTETRADMO:
+		return "tetra-dmo"
 	default:
 		return "unknown"
 	}
@@ -98,9 +101,11 @@ func ParseProtocol(s string) (Protocol, error) {
 		return ProtocolDMRTier2, nil
 	case "dmr-tier1", "dmr_tier1", "dmr-t1", "dmrtier1":
 		return ProtocolDMRTier1, nil
+	case "tetra-dmo", "tetra_dmo", "tetradmo", "dmo":
+		return ProtocolTETRADMO, nil
 	default:
 		return ProtocolUnknown, fmt.Errorf("trunking: unknown protocol %q "+
-			"(want p25|p25-phase2|dmr|dmr-tier2|dmr-tier1|nxdn|dpmr|edacs|motorola|ltr|mpt1327|tetra|ysf|dstar)", s)
+			"(want p25|p25-phase2|dmr|dmr-tier2|dmr-tier1|nxdn|dpmr|edacs|motorola|ltr|mpt1327|tetra|tetra-dmo|ysf|dstar)", s)
 	}
 }
 
@@ -470,7 +475,7 @@ func (s System) Validate() error {
 		return errors.New("trunking: system name is required")
 	}
 	if s.Protocol == ProtocolUnknown {
-		return errors.New("trunking: protocol must be p25|p25-phase2|dmr|dmr-tier2|dmr-tier1|nxdn|dpmr|edacs|motorola|ltr|mpt1327|tetra|ysf|dstar")
+		return errors.New("trunking: protocol must be p25|p25-phase2|dmr|dmr-tier2|dmr-tier1|nxdn|dpmr|edacs|motorola|ltr|mpt1327|tetra|tetra-dmo|ysf|dstar")
 	}
 	if len(s.ControlChannels) == 0 {
 		return errors.New("trunking: at least one control_channel frequency is required")

--- a/internal/voice/composer/composer.go
+++ b/internal/voice/composer/composer.go
@@ -470,11 +470,16 @@ func (c *Composer) handleStart(parent context.Context, cs trunking.CallStart) {
 	// sidecar (TCH/S FEC + ACELP vocoder are follow-ups — see
 	// runTETRAVoiceChain), like the DMR/P25 raw-frame paths.
 	isTETRAVoice := proto == "tetra"
+	// TETRA DMO (Direct Mode): voice rides the SAME carrier the DMO pipeline
+	// decodes (no separate traffic channel), so it binds a same-carrier tap and
+	// decodes DNB TCH/S itself — see runTETRADMOVoiceChain. Distinct from the TMO
+	// same-carrier demux (no TDMA usage markers; a single PTT call at a time).
+	isTETRADMOVoice := proto == "tetra-dmo"
 	// NXDN follows the traffic channel with the same receiver the CC
 	// uses; Stage 1 wires the follow+tune+chain lifecycle, the VCH
 	// voice-channel decoder is a follow-up (see runNXDNVoiceChain).
 	isNXDNVoice := proto == "nxdn"
-	if !isFM && !isDMRVoice && !isP25P2Voice && !isP25P1Voice && !isTETRAVoice && !isNXDNVoice {
+	if !isFM && !isDMRVoice && !isP25P2Voice && !isP25P1Voice && !isTETRAVoice && !isTETRADMOVoice && !isNXDNVoice {
 		// Remaining digital protocols (dPMR, YSF, D-STAR, EDACS ProVoice)
 		// have no composer voice chain yet — their voice bursts are not
 		// decoded into PCM here.
@@ -573,6 +578,8 @@ func (c *Composer) handleStart(parent context.Context, cs trunking.CallStart) {
 		go c.runP25Phase1VoiceChain(chainCtx, cs.DeviceSerial, cs.Grant.System, iqCh, rateHzF, cs.Grant.P25Phase1DemodMode, cs.Grant.GroupID, cs.Grant.CallID, cs.Grant.PatchedGroups, ch.done)
 	case isTETRAVoice:
 		go c.runTETRAVoiceChain(chainCtx, cs.DeviceSerial, iqCh, rateHzF, cs.Grant.GroupID, cs.Grant.Timeslot, cs.Grant.TETRAColourExt, cs.Grant.TETRAUsageMarker, ch.done)
+	case isTETRADMOVoice:
+		go c.runTETRADMOVoiceChain(chainCtx, cs.DeviceSerial, iqCh, rateHzF, cs.Grant.TETRAColourExt, ch.done)
 	case isNXDNVoice:
 		go c.runNXDNVoiceChain(chainCtx, cs.DeviceSerial, cs.Grant.System, iqCh, rateHzF, cs.Grant.GroupID, ch.done)
 	default:

--- a/internal/voice/composer/tetra_dmo_voice.go
+++ b/internal/voice/composer/tetra_dmo_voice.go
@@ -1,0 +1,203 @@
+package composer
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	gtlog "github.com/MattCheramie/GopherTrunk/internal/log"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/tetra"
+	tetrarx "github.com/MattCheramie/GopherTrunk/internal/radio/tetra/receiver"
+)
+
+// runTETRADMOVoiceChain decodes one TETRA DMO (Direct Mode) transmission on the
+// same-carrier tap the DMO pipeline granted. DMO has no separate traffic channel and
+// no TDMA per-call slots: a single MS keys up and transmits a DSB + a train of DNBs
+// on the decoded carrier (EN 300 396-2), so unlike the TMO same-carrier demux (usage-
+// marker routing across four slots) this is a self-contained single-call chain,
+// closest in shape to the solo-tap runTETRAVoiceChain. It decimates the tap IQ to the
+// TETRA symbol rate, recovers the π/4-DQPSK stream with the shared receiver (blind CMA
+// equalizer + soft differentials, as the offline DMO path requires), slices each DNB
+// with the streaming DMStreamExtractor, TCH/S-decodes it (soft, with a hard fallback)
+// and emits the 137-bit speech frames to the recorder — which renders them to PCM with
+// the same clean-room ACELP vocoder ("tetra-acelp") the TMO path uses.
+//
+// colourHint is the DM traffic colour code the pipeline stamped on the grant. Because
+// the grant fires on the first DNBs (before the pipeline finishes brute-forcing the
+// colour), the hint is often 0, so this chain recovers the colour independently from
+// its own buffered DNBs (tetra.RecoverDMColourCode) and decodes the buffer
+// retroactively once known — no leading speech is lost. This is #1003 work: on-air A/B
+// still gates it (a green synthetic decode is not proof — #764/#771).
+func (c *Composer) runTETRADMOVoiceChain(ctx context.Context, serial string, iqCh <-chan []complex64, iqHz float64, colourHint uint32, done chan<- struct{}) {
+	defer close(done)
+	defer gtlog.Recover(c.log, "voice-chain-tetra-dmo:"+serial, nil)
+
+	bt := c.newBoundaryTracker(serial, 0, nil)
+	go bt.run(ctx)
+
+	fe := newTETRAVoiceFrontEnd(iqHz, c.bw)
+	symbolHz := fe.OutRateHz()
+	rs, _ := c.sink.(rawFrameSink)
+
+	dec := &dmoVoiceDecoder{
+		c:           c,
+		serial:      serial,
+		bt:          bt,
+		rs:          rs,
+		colour:      colourHint,
+		colourKnown: colourHint != 0,
+	}
+	ext := tetra.NewDMStreamExtractor(dec.onBurst)
+
+	var pendingSoft []complex64
+	rx := tetrarx.New(tetrarx.Options{
+		SampleRateHz: symbolHz,
+		DibitSink: func(d []uint8, base int) {
+			ext.Process(d, pendingSoft, base)
+			pendingSoft = nil
+		},
+		SoftSink:            func(diffs []complex64, base int) { pendingSoft = diffs },
+		ClockMode:           tetrarx.ClockGardner,
+		GardnerGain:         0.005,
+		EnableAFC:           true,
+		EnableChannelFilter: true,
+		EnableEqualizer:     true, // invert the ISI that garbles DMO TCH/S (required for DMO)
+		EnableDCBlock:       true, // strip the front-end DC spur on the voice tap
+	})
+
+	c.log.Info("composer: tetra DMO voice follow started — DNB TCH/S decode + ACELP vocoder",
+		"serial", serial, "colour_hint", colourHint, "rate_hz", symbolHz)
+	defer func() {
+		dec.flush() // decode any DNBs still buffered awaiting colour recovery
+		c.log.Info("composer: tetra DMO voice follow ended",
+			"serial", serial, "dnb_bursts", dec.dnb.Load(),
+			"speech_frames", dec.speech.Load(), "bfi_count", dec.bfi.Load(),
+			"colour", dec.colour, "colour_known", dec.colourKnown)
+	}()
+
+	process := func(iq []complex64) {
+		bt.observe(iq)
+		rx.Process(fe.Process(nil, iq))
+	}
+	touchTicker := time.NewTicker(c.touchEvery)
+	defer touchTicker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			// Drain buffered IQ so the transmission tail is recorded (mirrors
+			// runTETRAVoiceChain's drainTETRAIQ).
+			drainTETRAIQ(iqCh, process)
+			return
+		case <-touchTicker.C:
+		case iq, ok := <-iqCh:
+			if !ok {
+				return
+			}
+			process(iq)
+		}
+	}
+}
+
+const (
+	// dmoVoiceColourBatch is how many DNBs the voice chain buffers before attempting
+	// colour-code recovery (matches the pipeline's dmoColourBatch cadence).
+	dmoVoiceColourBatch = 20
+	// dmoVoiceColourMax caps the buffer: past this, if no colour has cleared the
+	// confidence gate, decode the buffer at colour 0 (a clear radio-to-radio call) and
+	// stop buffering — an encrypted/unrecoverable call then simply yields no speech.
+	dmoVoiceColourMax = 120
+)
+
+// dmoVoiceDecoder holds the streaming DMO voice decode state for one call. All methods
+// run on the single receiver goroutine (the voice chain's process loop), so the fields
+// need no locking; the atomic counters are read from the deferred ended-log on the
+// same goroutine after the loop exits.
+type dmoVoiceDecoder struct {
+	c      *Composer
+	serial string
+	bt     *boundaryTracker
+	rs     rawFrameSink
+
+	colour      uint32
+	colourKnown bool
+	buffer      []tetra.DMBurst // DNBs awaiting colour recovery
+
+	dnb, speech, bfi atomic.Uint64
+}
+
+// onBurst handles one streamed DMO burst. DSBs carry no speech (signalling only), so
+// only DNBs are decoded. Until the colour code is known, DNBs are buffered; once
+// recovered (or the cap forces a colour-0 fallback) the buffer is decoded in order and
+// each subsequent DNB decodes immediately.
+func (d *dmoVoiceDecoder) onBurst(b tetra.DMBurst) {
+	if b.Kind != tetra.DMBurstNormal {
+		return
+	}
+	d.dnb.Add(1)
+	if d.colourKnown {
+		d.emit(b)
+		return
+	}
+	d.buffer = append(d.buffer, b)
+	if len(d.buffer) < dmoVoiceColourBatch {
+		return
+	}
+	if c, _, ok := tetra.RecoverDMColourCode(d.buffer); ok {
+		d.colour, d.colourKnown = c, true
+		d.c.log.Info("composer: tetra DMO colour code recovered", "serial", d.serial, "colour", c)
+	} else if len(d.buffer) >= dmoVoiceColourMax {
+		// Give up recovering; assume clear colour 0. A genuinely encrypted call then
+		// yields no CRC-valid speech (bfi), which the hangtime ends normally.
+		d.colour, d.colourKnown = 0, true
+	} else {
+		return // keep buffering
+	}
+	buf := d.buffer
+	d.buffer = nil
+	for _, bb := range buf {
+		d.emit(bb)
+	}
+}
+
+// emit TCH/S-decodes one DNB (soft with a hard fallback) at the known colour and writes
+// its speech frames to the recorder, refreshing call liveness on real speech. A DNB
+// that yields no CRC-valid speech is a Bad Frame Indication (encrypted/corrupt).
+func (d *dmoVoiceDecoder) emit(b tetra.DMBurst) {
+	frames := tetra.DMBurstTCHSpeechSoft(b, d.colour)
+	if len(frames) != 2 {
+		frames = tetra.DMBurstTCHSpeech(b, d.colour)
+	}
+	if len(frames) != 2 {
+		d.bfi.Add(1)
+		return
+	}
+	d.bt.onVoice(0)
+	for _, sf := range frames {
+		d.speech.Add(1)
+		if d.rs != nil {
+			if err := d.rs.WriteRawFrame(d.serial, sf); err != nil {
+				d.c.log.Warn("composer: TETRA DMO speech-frame write failed", "serial", d.serial, "err", err)
+			}
+		}
+	}
+}
+
+// flush decodes any DNBs still buffered awaiting colour recovery at end-of-call. If the
+// colour never cleared the confidence gate, it makes a final best-effort attempt over
+// the whole buffer, then falls back to colour 0 so a short clear call is not dropped.
+func (d *dmoVoiceDecoder) flush() {
+	if len(d.buffer) == 0 {
+		return
+	}
+	if !d.colourKnown {
+		if c, _, ok := tetra.RecoverDMColourCode(d.buffer); ok {
+			d.colour = c
+		}
+		d.colourKnown = true
+	}
+	buf := d.buffer
+	d.buffer = nil
+	for _, bb := range buf {
+		d.emit(bb)
+	}
+}

--- a/internal/voice/composer/tetra_dmo_voice_test.go
+++ b/internal/voice/composer/tetra_dmo_voice_test.go
@@ -1,0 +1,147 @@
+package composer
+
+import (
+	"io"
+	"log/slog"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/tetra"
+)
+
+// fakeDMOSink captures the raw ACELP speech frames the DMO voice decoder writes.
+type fakeDMOSink struct{ frames [][]byte }
+
+func (f *fakeDMOSink) WritePCM(string, []int16) error { return nil }
+func (f *fakeDMOSink) WriteRawFrame(_ string, frame []byte) error {
+	f.frames = append(f.frames, append([]byte(nil), frame...))
+	return nil
+}
+
+func dmoVFiller(seed, n int) []uint8 {
+	s := make([]uint8, n)
+	for i := range s {
+		s[i] = uint8((seed + i*3) & 3)
+	}
+	return s
+}
+
+func dmoVSeq(seed, n int) []byte {
+	s := make([]byte, n)
+	for i := range s {
+		s[i] = byte((seed + i*5) % 2)
+	}
+	return s
+}
+
+func dmoVIdealDiffs(dibits []uint8) []complex64 {
+	bits := tetra.TetraDibitsToBits(dibits)
+	amp := func(b byte) float32 {
+		if b&1 == 0 {
+			return 1
+		}
+		return -1
+	}
+	diffs := make([]complex64, len(dibits))
+	for i := range dibits {
+		diffs[i] = complex(amp(bits[2*i+1]), amp(bits[2*i]))
+	}
+	return diffs
+}
+
+// buildDMODNBBursts builds n TCH/S DNBs scrambled with colour and returns them as real
+// tetra.DMBursts (with soft info, via ExtractDMBurstsSoft), plus the encoded speech
+// frames per DNB.
+func buildDMODNBBursts(t *testing.T, colour uint32, n int) ([]tetra.DMBurst, [][2][]byte) {
+	t.Helper()
+	b2d := tetra.TetraBitsToDibits
+	var dibits []uint8
+	var want [][2][]byte
+	dibits = append(dibits, dmoVFiller(0, 50)...)
+	for i := 0; i < n; i++ {
+		fa := dmoVSeq(7+i, 137)
+		fb := dmoVSeq(9+i, 137)
+		t4 := framing.UnpackBitsMSB(tetra.EncodeTCHS(fa, fb), 432)
+		onair := framing.ScrambleTetra(t4, colour)
+		dibits = append(dibits, dmoVFiller(11+i, 30)...)
+		dibits = append(dibits, b2d(onair[:216])...)
+		dibits = append(dibits, tetra.NormalSyncDibits()...)
+		dibits = append(dibits, b2d(onair[216:])...)
+		want = append(want, [2][]byte{framing.PackBitsMSB(fa), framing.PackBitsMSB(fb)})
+	}
+	dibits = append(dibits, dmoVFiller(99, 200)...)
+
+	all := tetra.ExtractDMBurstsSoft(dibits, dmoVIdealDiffs(dibits), 0)
+	var dnbs []tetra.DMBurst
+	for _, b := range all {
+		if b.Kind == tetra.DMBurstNormal {
+			dnbs = append(dnbs, b)
+		}
+	}
+	if len(dnbs) != n {
+		t.Fatalf("built %d DNB bursts, want %d", len(dnbs), n)
+	}
+	return dnbs, want
+}
+
+// TestDMOVoiceDecoderRecoversColourAndEmits pins the voice chain's core logic: when the
+// grant carries no colour (hint 0), the decoder buffers DNBs, brute-force-recovers the
+// DM colour code, decodes the buffered DNBs retroactively (so no leading speech is
+// lost), and emits every call's two 137-bit speech frames to the recorder sink — the
+// same frames that were encoded. This is the composer half of the #1003 DMO voice path
+// (the receiver→extractor half is covered by the pipeline test); on-air A/B still gates
+// closing #1003.
+func TestDMOVoiceDecoderRecoversColourAndEmits(t *testing.T) {
+	const colour = 3
+	bursts, want := buildDMODNBBursts(t, colour, 24)
+
+	sink := &fakeDMOSink{}
+	c := &Composer{log: slog.New(slog.NewTextHandler(io.Discard, nil)), hangtime: time.Second}
+	bt := c.newBoundaryTracker("s", 0, nil)
+	dec := &dmoVoiceDecoder{c: c, serial: "s", bt: bt, rs: sink}
+
+	for _, b := range bursts {
+		dec.onBurst(b)
+	}
+	dec.flush()
+
+	if !dec.colourKnown || dec.colour != colour {
+		t.Fatalf("recovered colour=%d known=%v, want %d", dec.colour, dec.colourKnown, colour)
+	}
+	if len(sink.frames) != 2*len(want) {
+		t.Fatalf("emitted %d speech frames, want %d", len(sink.frames), 2*len(want))
+	}
+	for i, w := range want {
+		if !reflect.DeepEqual(sink.frames[2*i], w[0]) || !reflect.DeepEqual(sink.frames[2*i+1], w[1]) {
+			t.Errorf("DNB %d: emitted speech frame mismatch", i)
+		}
+	}
+	if dec.dnb.Load() != uint64(len(bursts)) {
+		t.Errorf("counted %d DNBs, want %d", dec.dnb.Load(), len(bursts))
+	}
+}
+
+// TestDMOVoiceDecoderUsesGrantColour checks the fast path: when the grant already
+// carries the recovered colour, the decoder uses it directly with no buffering — every
+// DNB decodes immediately.
+func TestDMOVoiceDecoderUsesGrantColour(t *testing.T) {
+	const colour = 3
+	bursts, want := buildDMODNBBursts(t, colour, 4)
+	sink := &fakeDMOSink{}
+	c := &Composer{log: slog.New(slog.NewTextHandler(io.Discard, nil)), hangtime: time.Second}
+	dec := &dmoVoiceDecoder{
+		c: c, serial: "s", bt: c.newBoundaryTracker("s", 0, nil), rs: sink,
+		colour: colour, colourKnown: true,
+	}
+	for _, b := range bursts {
+		dec.onBurst(b)
+	}
+	if len(dec.buffer) != 0 {
+		t.Errorf("decoder buffered %d bursts despite a known colour", len(dec.buffer))
+	}
+	if len(sink.frames) != 2*len(want) {
+		t.Fatalf("emitted %d speech frames, want %d", len(sink.frames), 2*len(want))
+	}
+}

--- a/internal/voice/recorder.go
+++ b/internal/voice/recorder.go
@@ -366,7 +366,8 @@ func DefaultVocoderForProtocol() map[string]string {
 		// things an NXDN voice capture confirms; see voice_ambe.go.)
 		"nxdn":  "ambe2-dmr",   // NXDN VCH — AMBE+2 3600x2450 (EHR)
 		"dpmr":  "ambe2",       // dPMR Mode 3 (digital)
-		"tetra": "tetra-acelp", // TETRA full-rate voice — clean-room ACELP (EN 300 395-2)
+		"tetra":     "tetra-acelp", // TETRA full-rate voice — clean-room ACELP (EN 300 395-2)
+		"tetra-dmo": "tetra-acelp", // TETRA DMO (Direct Mode) — same TCH/S ACELP speech frames
 	}
 }
 

--- a/internal/voice/recorder.go
+++ b/internal/voice/recorder.go
@@ -364,8 +364,8 @@ func DefaultVocoderForProtocol() map[string]string {
 		// through the 3600x2450 decoder, not the 3600x2400 "ambe2".
 		// (Unverified on air — the 2450-vs-2400 codebook is one of the
 		// things an NXDN voice capture confirms; see voice_ambe.go.)
-		"nxdn":  "ambe2-dmr",   // NXDN VCH — AMBE+2 3600x2450 (EHR)
-		"dpmr":  "ambe2",       // dPMR Mode 3 (digital)
+		"nxdn":      "ambe2-dmr",   // NXDN VCH — AMBE+2 3600x2450 (EHR)
+		"dpmr":      "ambe2",       // dPMR Mode 3 (digital)
 		"tetra":     "tetra-acelp", // TETRA full-rate voice — clean-room ACELP (EN 300 395-2)
 		"tetra-dmo": "tetra-acelp", // TETRA DMO (Direct Mode) — same TCH/S ACELP speech frames
 	}

--- a/internal/voice/recorder_test.go
+++ b/internal/voice/recorder_test.go
@@ -1235,6 +1235,7 @@ func TestDefaultVocoderForProtocolMappings(t *testing.T) {
 		"nxdn":       "ambe2-dmr",
 		"dpmr":       "ambe2",
 		"tetra":      "tetra-acelp",
+		"tetra-dmo":  "tetra-acelp",
 	}
 	if len(got) != len(want) {
 		t.Errorf("len = %d, want %d", len(got), len(want))

--- a/web/src/panels/Plots.tsx
+++ b/web/src/panels/Plots.tsx
@@ -103,8 +103,11 @@ function QualityVerdict() {
         </span>
       )}
       {quality && quality.total > 0 && (
-        <span className="font-mono text-xs text-muted">
-          {quality.total} symbols
+        <span
+          className="font-mono text-xs text-muted"
+          title="Symbols in the rolling signal-quality window — not the symbol rate (see the constellation subtitle for sym/s)"
+        >
+          {quality.total} sym analysed
         </span>
       )}
       <span className="ml-auto text-xs text-muted">


### PR DESCRIPTION
Two independent, low-risk changes toward the DMR/TETRA decoding fixes:

- web: the Plots signal-quality banner showed "N symbols" (the rolling
  analysis-window count, capped at WINDOW_SYMBOLS=4000) directly above the
  constellation's "18000 sym/s" rate, so a saturated "4000 symbols" read like
  a bogus symbol rate. Relabel it "N sym analysed" with a clarifying tooltip;
  value semantics unchanged. The true rate label (Constellation.tsx) is
  untouched.

- trunking/ccdecoder: register ProtocolTETRADMO ("tetra-dmo"/"dmo") in the
  Protocol enum, String(), ParseProtocol and the validation error strings, and
  route it to the 144 kHz TETRA channel rate in ddcTargetForProtocol so its
  down-converter gives 8 samples/symbol like TMO. This is the foundation for
  wiring the offline-validated DMO decoders into the daemon (Refs #1003).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HgssxZEJxyeYtAAdJM2u8f