### PR TITLE
TETRA DMO decode pipeline, DMR voice-quality reconciliation, Plots symbol-count label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **TETRA DMO (Direct Mode Operation) now decodes in the daemon.** A new
+  `protocol: tetra-dmo` (aliases `dmo` / `tetra_dmo`) camps a direct-mode
+  frequency, locks on the Direct Mode Synchronisation Burst (DSB), auto-recovers
+  the DM colour code, and decodes the Direct Mode Normal Burst (DNB) TCH/S speech
+  train to voice on the same carrier — no separate traffic channel. Previously a
+  DMO capture had to run through the TMO control-channel pipeline, whose burst
+  geometry does not match DMO, so it appeared to "lock" (the DSB SCH/S is
+  colour-0-scrambled like a TMO BSCH) but produced no grants and no audio. The
+  new pipeline reuses the offline-validated DMO decoders behind a bounded
+  streaming burst extractor. Configure with `protocol: tetra-dmo` +
+  `control_channels: [<freq>]` (optional `tetra_colour_code` overrides colour
+  recovery). The DM call-control protocol (EN 300 396-3 source/destination SSI,
+  group) is not yet decoded, so a DMO call records without a talkgroup identity
+  (filed under group `0`); and this path is validated offline/synthetically but
+  not yet A/B'd against a real on-air DMO capture (see docs/reference/tetra-dmo.md).
 - **HackRF Pro is now identified as such, and its narrowband filter is
   configurable.** GopherTrunk reads the firmware's board ID at open, so a HackRF
   Pro (board ID 5, *Praline*) now reports `HackRF Pro` — and a HackRF One R9
@@ -96,6 +111,12 @@ for tagged releases.
   call-priority metadata to TETRA alongside P25 and DMR.
 
 ### Fixed
+- **The Plots signal-quality banner no longer reads like a bogus symbol rate.**
+  The banner's "N symbols" figure is the count of symbols in the rolling
+  signal-quality analysis window (capped at 4000), but sitting directly above the
+  constellation's "18000 sym/s" it looked like the symbol rate stuck at 4000. It
+  is now labelled "N sym analysed" with a tooltip clarifying it is the analysis
+  window, not the rate.
 - **TETRA radio IDs still leaked into recordings as phantom talkgroups when a
   group grant was missed.** On a same-carrier site a group call's first
   control-channel message is a source-less notification (`SourceID==0`, `dst=` the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,29 +241,36 @@ confirmation before any close-as-completed.
     Pinned synthetic: `TestRecoverDMColourCode`. Reproduce:
     `GT_TETRA_DMO_IQ=<10aug .raw> GT_TETRA_DMO_RATE=144000 GT_TETRA_DMO_CLEAR=1
     go test ./cmd/gophertrunk -run TestTETRADMOReplay -v`.
-  - **Remaining: NO production DMO decode pipeline (C2, design-first, on-air A/B gates #1003).**
-    `internal/scanner/ccdecoder/pipelines.go` has one TETRA factory (`newTETRAPipeline`, the TMO
-    CC state machine); a DMO capture runs through it and every SCH burst fails because TMO NCDB
-    geometry (`-115/+19`) ≠ DMO DNB (`-108/+11`) — while BSCH still "locks" (DMO DSB SCH/S is
-    colour-0-scrambled like TMO BSCH), the operator's live symptom (`sch_pdus=0`, constant
-    `sync gap` / `dsp resync`). The `ExtractDMBursts*`/`DecodeDMSCHS/H`/`DMBurstTCHSpeech*`
-    decoders + `RecoverDMColourCode` now exist and are validated offline (`TestTETRADMOReplay`),
-    but are not wired into the daemon. Execution-ready plan:
-    1. **Register** `ProtocolTETRADMO` (`tetra-dmo`) in `internal/trunking/site.go` (enum,
-       `String()`, `ParseProtocol`, error strings) + a `factories` entry in `pipelines.go`.
-    2. **`newTETRADMOPipeline`** mirroring `newTETRAPipeline`'s receiver (`EnableEqualizer` +
-       `SoftSink` + AFC + channel filter), but buffering dibits/diffs and, on a cadence,
-       `ExtractDMBurstsSoft` (DNB `-108/+11`) → `DecodeDMSCHS` (sync → `KindCCLocked` + SYNC-PDU
-       FN-advance liveness) → `RecoverDMColourCode` (once, then lock) → `DMBurstTCHSpeechSoft`.
-       Needs DMO sync-gap/resync timing (TMO's `tetraResyncTimeout`/`tetraLockStaleTimeout` are
-       CC-cadence; DMO is bursty PTT — retune).
-    3. **Composer voice chain**: DMO voice rides the SAME carrier (no grant→tap split), so add a
-       `proto == "tetra-dmo"` branch in `internal/voice/composer/composer.go` (dispatch at
-       `runVoiceChain`, ~line 466) → a `runTETRADMOVoiceChain` that decodes DMO bursts → ACELP →
-       PCM to the recorder. This is the architectural piece (TMO uses the traffic extractor; DMO
-       is self-contained) and the main risk.
-    4. **On-air A/B** on the operator's capture through the full daemon (recording lands, audio
-       intelligible) before marking #1003 verified. A green offline decode ≠ on-air correct.
+  - **Production DMO decode pipeline is now WIRED (C2 done); only on-air A/B remains to close
+    #1003.** The offline decoders are now driven by a real daemon pipeline, so a DMO capture no
+    longer runs the wrong TMO CC path (the operator's `sch_pdus=0` / `sync gap` / `dsp resync`
+    symptom). What landed:
+    1. **`ProtocolTETRADMO` (`tetra-dmo`/`dmo`)** registered in `internal/trunking/site.go`
+       (enum, `String()`, `ParseProtocol`, `Validate`) + `internal/scanner/ccdecoder/ddc.go`
+       (`ddcTargetForProtocol` → 144 kHz) + the `factories` map in `pipelines.go`.
+    2. **`newTETRADMOPipeline`** (`internal/scanner/ccdecoder/pipelines_dmo.go`): the TMO
+       receiver knobs (`EnableEqualizer` blind CMA + `SoftSink` + AFC + channel filter) feeding a
+       new **`tetra.DMStreamExtractor`** (`internal/radio/tetra/dmo_stream.go`) — a bounded
+       sliding-window streaming adapter over the stateless `ExtractDMBurstsSoft` (emits each DSB/
+       DNB once, in lead order, deduped). Decodes `DecodeDMSCHS` → **sticky** `KindCCLocked`
+       (no cc.lost on inter-PTT silence, so a camped DMO channel isn't re-hunted) + SYNC-PDU FN
+       liveness, `RecoverDMColourCode` once, and an **edge-triggered** `tetra-dmo` `KindGrant`
+       on a DNB traffic train (re-armed after a `dmoGrantRearm` drought).
+    3. **`runTETRADMOVoiceChain`** (`internal/voice/composer/tetra_dmo_voice.go`): a
+       self-contained same-carrier chain (one same-carrier tap — `sameCarrierVoiceTaps` in
+       `daemon.go`) that re-runs the extractor → `DMBurstTCHSpeechSoft` (recovers the colour
+       independently, since the grant fires before the pipeline's recovery, decoding its buffer
+       retroactively so no leading speech is lost) → ACELP (`tetra-dmo`→`tetra-acelp` in
+       `recorder.go`). Dispatched from `composer.handleStart` on `proto == "tetra-dmo"`.
+    - Pinned by `pipelines_dmo_test.go` (modulated-IQ lock+colour-3+grant), `dmo_stream_test.go`
+      (chunk-invariance + soft decode), `tetra_dmo_voice_test.go` (colour recovery + retroactive
+      emit), and `integration_cc_tetra_dmo_test.go` (full-daemon lock, `make integration`).
+    4. **STILL OPEN — on-air A/B (the #1003 gate).** A green synthetic/offline decode ≠ on-air
+      correct (#764/#771): the operator must replay a clear 438.9 MHz DMO capture through the
+      full daemon (`protocol: tetra-dmo`) and confirm a recording lands with intelligible audio.
+      Watch on air: the DMO grant carries **no talkgroup** (`GroupID 0`, EN 300 396-3 call-control
+      not decoded), so recordings file under group `0`; and colour recovery needs ~20 DNBs, so a
+      very short first PTT may grant before the colour is known (the voice chain re-recovers it).
 - **Conventional DMR (Tier II / IPSC) now decodes a repeater's TWO timeslots as two calls.**
   A base-station DMR repeater carries TS1 and TS2 interleaved on one carrier, each able to hold
   a separate simultaneous talkgroup. The conventional path (`internal/radio/dmr/tier2`) used to

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ TAGS    ?=
 GO      ?= go
 PKGS    := ./...
 
-.PHONY: all build dist test test-dvsi test-cryptolab test-airspy-real test-airspy-real-bias test-airspy-real-diag test-integration integration integration-cc integration-cc-grant integration-cc-nxdn integration-cc-dmr integration-cc-dpmr integration-cc-edacs integration-cc-motorola integration-cc-tetra integration-cc-p25p2 integration-cc-mpt1327 integration-cc-ltr integration-cc-ysf lint tidy vet vulncheck licenses clean run proto cross-build release-archives release-dry-run web-build web-dev web-clean web-test siglab-web-build siglab-web-dev siglab-web-clean siglab-web-test rfscope-web-build rfscope-web-dev rfscope-web-clean rfscope-web-test cryptolab-web-build cryptolab-web-dev cryptolab-web-clean cryptolab-web-test
+.PHONY: all build dist test test-dvsi test-cryptolab test-airspy-real test-airspy-real-bias test-airspy-real-diag test-integration integration integration-cc integration-cc-grant integration-cc-nxdn integration-cc-dmr integration-cc-dpmr integration-cc-edacs integration-cc-motorola integration-cc-tetra integration-cc-tetra-dmo integration-cc-p25p2 integration-cc-mpt1327 integration-cc-ltr integration-cc-ysf lint tidy vet vulncheck licenses clean run proto cross-build release-archives release-dry-run web-build web-dev web-clean web-test siglab-web-build siglab-web-dev siglab-web-clean siglab-web-test rfscope-web-build rfscope-web-dev rfscope-web-clean rfscope-web-test cryptolab-web-build cryptolab-web-dev cryptolab-web-clean cryptolab-web-test
 
 all: build
 
@@ -147,6 +147,13 @@ integration-cc-motorola:
 # exercise the π/4-DQPSK modulator primitive shipped alongside this PR.
 integration-cc-tetra:
 	$(GO) test -tags "integration $(TAGS)" -race -count=1 -run TestDaemonCCDecodesTETRA ./cmd/gophertrunk/...
+
+# integration-cc-tetra-dmo boots the daemon with synthesized TETRA DMO IQ (a DSB
+# + DNB burst train at 18000 sym/s) and asserts the production tetra-dmo pipeline
+# (protocol parse -> 144 kHz DDC -> newTETRADMOPipeline -> cchunt supervisor)
+# locks on the DSB SCH/S. The voice/recording half is on-air A/B gated (#1003).
+integration-cc-tetra-dmo:
+	$(GO) test -tags "integration $(TAGS)" -race -count=1 -run TestDaemonDecodesTETRADMO ./cmd/gophertrunk/...
 
 # integration-cc-p25p2 boots the daemon with synthesized H-DQPSK IQ
 # (6000 sym/s, α = 0.20, π/8 rotation) carrying a 20-dibit outbound sync

--- a/docs/reference/tetra-dmo.md
+++ b/docs/reference/tetra-dmo.md
@@ -82,25 +82,48 @@ SCH/F short-data signalling — a receiver tells them apart by which decode's CR
 block boundaries relative to the training-sequence lead dibit are *not* the same as TMO's NDB,
 so DMO needs its own slicer.
 
+## Configuring a DMO system
+
+A DMO channel is decoded by setting a system's `protocol: tetra-dmo` (aliases `dmo` /
+`tetra_dmo`) and pointing `control_channels` at the direct-mode frequency — the daemon *camps*
+that frequency rather than hunting, locks on the first DSB, auto-recovers the DM colour code,
+and records the DNB voice train. An optional `tetra_colour_code` overrides the auto-recovery
+when the traffic colour is known.
+
+```yaml
+trunking:
+  systems:
+    - name: DMO
+      protocol: tetra-dmo
+      control_channels: [438900000]
+      # tetra_colour_code: 3   # optional; 0/omitted = auto-recover the DM colour
+```
+
 ## Scope and honesty
 
-GopherTrunk's DMO support is burst detection and block slicing plus the reused channel decode:
-it turns a demodulated DMO dibit stream into per-burst BKN1/BKN2 type-5 blocks and, for a DNB,
-decodes TCH/S speech both hard- and soft-decision (the same ~2× same-carrier yield lever the
-TMO traffic path gets). The DM call-control *protocol* that rides in SCH/S / SCH/F — source
-and destination SSI, group, call type — is EN 300 396-3, a separate specification, and is not
-yet wired. Nothing here has been validated against a real DMO capture, which is a prerequisite
-before DMO voice can be attributed and recorded, per the standing lesson that synthetic
-round-trips can pass while on-air decode fails.
+GopherTrunk decodes DMO end to end in the daemon: `newTETRADMOPipeline`
+(`internal/scanner/ccdecoder/pipelines_dmo.go`) locks on the DSB SCH/S, recovers the DM colour
+code, and grants; a same-carrier voice chain (`runTETRADMOVoiceChain`,
+`internal/voice/composer/tetra_dmo_voice.go`) decodes the DNB TCH/S speech — both hard- and
+soft-decision (the same ~2× yield lever the TMO traffic path gets) — through the clean-room
+ACELP vocoder to a recording. The DM call-control *protocol* that rides in SCH/S / SCH/F —
+source and destination SSI, group, call type — is EN 300 396-3, a separate specification, and
+is **not** yet decoded, so a DMO call is recorded without a talkgroup/party identity (it files
+under group `0`). And while the decode chain is validated offline (synthetic round-trips +
+`TestTETRADMOReplay` on captures) and with a synthetic full-daemon lock test, it has **not**
+yet been A/B'd against a real on-air DMO capture through the full daemon — the standing lesson
+(#764/#771) is that synthetic round-trips can pass while on-air decode fails, so treat DMO
+voice as functional-but-unverified-on-air until that A/B lands.
 
 ## Relevance to SDR
 
 `internal/radio/tetra/dmo.go` defines the `DMBurstKind` (DSB/DNB), the burst geometry, and the
 `ExtractDMBursts` / `ExtractDMBurstsSoft` slicers that correlate the training sequences under
-all four residual π/4-DQPSK rotations. `dmo_decode.go` maps the sliced blocks onto the shared
+all four residual π/4-DQPSK rotations; `dmo_stream.go` wraps them in a bounded sliding-window
+`DMStreamExtractor` for the live daemon. `dmo_decode.go` maps the sliced blocks onto the shared
 decoders — `DecodeDMSCHS` (via the BSCH chain), `DecodeDMSCHH` (via SCH/HD), `DecodeDMSCHF`,
 and `DMBurstTCHSpeech` / `DMBurstTCHSpeechSoft` (via the TCH/S chain) — de-rotating and
-descrambling with the DM colour code before each decode.
+descrambling with the DM colour code (recovered by `RecoverDMColourCode`) before each decode.
 
 ## Sources
 


### PR DESCRIPTION
## Summary

Addresses three operator reports from one field session (a live DMO daemon log, decoded DMR audio, and a Plots screenshot), bundled onto one branch at the reporter's request. The headline is **TETRA DMO (Direct Mode) now decodes in the daemon** — previously a DMO capture ran through the TMO control-channel pipeline (wrong burst geometry), so it appeared to "lock" on the DSB but produced no grants and no audio. Also: a calibration-first diagnosis of rough DMR (AMBE+2) voice, and a fix for a confusing Plots signal-banner label.

## Changes

- **TETRA DMO production pipeline (`Refs #1003`)** — wires the previously offline-only DMO decoders into the daemon:
  - `ProtocolTETRADMO` (`tetra-dmo` / `dmo`) registered in `internal/trunking/site.go` + `internal/scanner/ccdecoder/ddc.go` (144 kHz DDC target) + the pipeline `factories` map.
  - `tetra.DMStreamExtractor` (`internal/radio/tetra/dmo_stream.go`) — a bounded sliding-window streaming adapter over the stateless `ExtractDMBurstsSoft`, emitting each DSB/DNB once, in lead order, deduped. Shared by the pipeline and voice chain.
  - `newTETRADMOPipeline` (`internal/scanner/ccdecoder/pipelines_dmo.go`) — receiver (blind CMA equalizer + soft differentials) → DSB SCH/S **sticky** lock (`KindCCLocked`, no re-hunt on inter-PTT silence) + SYNC-PDU FN liveness → `RecoverDMColourCode` (once) → edge-triggered `tetra-dmo` grant on a DNB traffic train.
  - `runTETRADMOVoiceChain` (`internal/voice/composer/tetra_dmo_voice.go`) — same-carrier voice chain decoding DNB TCH/S (soft, hard fallback) → ACELP (`tetra-dmo` → `tetra-acelp` in the recorder). Recovers the colour code independently and decodes its buffer retroactively so no leading speech is lost. One same-carrier tap registered in `daemon.go`.
- **DMR voice quality (calibration-first, docs-only)** — `docs/dmr-voice-quality.md`: mbelib reconciliation review. Ruled out the V/UV decode and §6.3 phase-dispersion (faithful to mbelib); found one genuine divergence — the §6.2 spectral-enhancement weight drops the `π/ω0` factor present in both TIA-102.BABA §6.2 and mbelib, pushing high-band weights to the attenuate clamp (worst on small-L female frames). The exact one-line fix is documented but **not shipped by default** — it is unverifiable-for-quality without a reference decode and also touches the P25 IMBE path, so the `calibrate` A/B is the gate. Includes an operator runbook + the config palliatives (`recordings.enhance`, `warm_dmr_audio`).
- **Plots symbol-count label** — `web/src/panels/Plots.tsx`: relabel the signal banner's "N symbols" (the rolling analysis-window count, capped at 4000) to "N sym analysed" with a tooltip, so it no longer reads like the symbol rate stuck at 4000 next to the constellation's "18000 sym/s".
- **Docs/tooling sync** — CLAUDE.md `#1003/C2` section rewritten (pipeline now exists; only on-air A/B remains), `docs/reference/tetra-dmo.md` updated with the production config + honest caveats, CHANGELOG `[Unreleased]` entries, and a `make integration-cc-tetra-dmo` target.

## Test plan

- [x] `make vet test` is green locally (`go vet` + `go test -race -count=1 ./...`)
- [x] `make integration` is green locally (includes the new `TestDaemonDecodesTETRADMO` full-daemon lock test)
- [x] Added tests: `dmo_stream_test.go` (chunk-invariance + soft TCH/S decode), `pipelines_dmo_test.go` (modulated-IQ lock + colour-3 recovery + grant), `tetra_dmo_voice_test.go` (colour recovery + retroactive emit), `integration_cc_tetra_dmo_test.go` (full-daemon lock), plus a new focused `make integration-cc-tetra-dmo` target
- [ ] **On-air smoke test still pending (the #1003 gate):** the DMO voice path is validated synthetically/offline but **not** yet A/B'd against a real on-air DMO capture through the full daemon. Requires the operator to replay a clear 438.9 MHz DMO capture (`protocol: tetra-dmo`) and confirm a recording lands with intelligible audio. Likewise the DMR §6.2 correction needs a DSD-FME reference WAV to A/B. Web build for the label change was not run locally (no `web/node_modules`); the change is a text/tooltip JSX edit.

## Breaking changes

None. `tetra-dmo` is a new opt-in protocol value; all existing config, endpoints and default behaviour are unchanged.

## Docs / CHANGELOG

- [x] Added `## [Unreleased]` bullets to `CHANGELOG.md` (Added: TETRA DMO decode; Fixed: Plots symbol-count label)
- [x] Updated `docs/` — new `docs/dmr-voice-quality.md`, updated `docs/reference/tetra-dmo.md` and `docs/voice-calibration.md`

## Linked issues

Refs #1003 (kept as `Refs`, not `Closes`: a green synthetic/offline decode is not proof of on-air correctness per the repo's #764/#771 discipline — the on-air A/B above must land first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HgssxZEJxyeYtAAdJM2u8f)_