### PR TITLE
cchunt: camp on idle conventional DMR / direct-mode channels (#1036)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,19 @@ for tagged releases.
   call-priority metadata to TETRA alongside P25 and DMR.
 
 ### Fixed
+- **Conventional DMR (IPSC) and other camp-on-idle systems no longer spam
+  "hunt failed" while simply idle.** A conventional DMR / IPSC repeater has no
+  continuous control channel — it sits silent between transmissions — but the
+  control-channel supervisor treated a dwell that ended without a lock as a
+  failure: it logged `cchunt: hunt failed — no control-channel lock`, published a
+  `cchunt.failed` event, and backed off exponentially (up to 60 s), so the
+  channel was often retuned away right when someone keyed up. Protocols that
+  legitimately camp on a fixed idle channel — conventional DMR (`dmr-tier2`),
+  DMR Tier I (`dmr-tier1`), and TETRA DMO (`tetra-dmo`) — now enter a new
+  **`camped`** hunt state instead: the supervisor keeps re-dwelling on the
+  frequency (no backoff, no failure event) so the decoder catches the next burst
+  and locks. Trunked systems (P25, DMR Tier III, TETRA TMO, …) are unchanged — an
+  idle hunt is still a real failure for them. (issue #1036)
 - **Conventional scanner recordings no longer run long or hang open on brief
   noise.** A `scanner.conventional` channel released a call only after `hangtime_ms`
   of continuous below-squelch silence, but the trailing-edge logic let a *single*

--- a/internal/scanner/cchunt/supervisor.go
+++ b/internal/scanner/cchunt/supervisor.go
@@ -260,6 +260,15 @@ func (s *Supervisor) Run(ctx context.Context) error {
 			}
 			continue
 		}
+		// A conventional / direct-mode system (CampsWhenIdle) has no
+		// continuous control channel, so a hunt round that ends without a
+		// lock means the channel is idle — not a failure. Camp on it and
+		// re-dwell promptly instead of the WARN + KindHuntFailed +
+		// exponential backoff a trunked no-lock triggers. Issue #1036.
+		if rt.sys.Protocol.CampsWhenIdle() {
+			s.markCamped(name)
+			continue
+		}
 		s.markFailed(name)
 	}
 }
@@ -329,6 +338,32 @@ func (s *Supervisor) SetIQHealthProvider(p IQHealthProvider) {
 	s.mu.Lock()
 	s.iqHealth = p
 	s.mu.Unlock()
+}
+
+// markCamped records that a conventional / direct-mode system's hunt
+// round ended without a lock. Unlike markFailed this is not an error
+// condition — the channel is simply idle — so it keeps the backoff
+// window at its floor (the next round re-dwells promptly, camping on the
+// frequency to catch the next transmission) and publishes no
+// KindHuntFailed event. A single Info log fires only on the transition
+// into camped, so a quiet channel doesn't spam the log every round.
+// Issue #1036.
+func (s *Supervisor) markCamped(name string) {
+	s.mu.Lock()
+	rt := s.states[name]
+	if rt == nil {
+		s.mu.Unlock()
+		return
+	}
+	transitioned := rt.state != StateCamped
+	rt.state = StateCamped
+	rt.backoffWindow = s.initBO // never grow — camp, don't back off
+	s.mu.Unlock()
+
+	if transitioned {
+		s.log.Info("cchunt: camped on conventional channel — idle, waiting for traffic",
+			"system", name)
+	}
 }
 
 func (s *Supervisor) markFailed(name string) {

--- a/internal/scanner/cchunt/supervisor_test.go
+++ b/internal/scanner/cchunt/supervisor_test.go
@@ -102,6 +102,73 @@ func TestSupervisorFailsClosedWhenNothingLocks(t *testing.T) {
 	}
 }
 
+// TestSupervisorCampsIdleConventionalDMR is the regression for issue
+// #1036. A conventional DMR (IPSC) repeater has no continuous control
+// channel — it sits silent until someone keys up. The supervisor must
+// camp on such a channel and wait, NOT treat an idle (no-lock) hunt
+// round as a failure. The old path ran markFailed → KindHuntFailed WARN
+// + StateFailed + exponential backoff, which is exactly the "hunt failure
+// with no control-channel lock" symptom operators reported.
+func TestSupervisorCampsIdleConventionalDMR(t *testing.T) {
+	bus := events.NewBus(32)
+	defer bus.Close()
+	tuner := &fakeTuner{}
+	sys := trunking.System{
+		Name:            "ConvDMR",
+		Protocol:        trunking.ProtocolDMRTier2,
+		ControlChannels: []uint32{451_000_000},
+	}
+	sup, err := New(Options{
+		Bus:            bus,
+		Tuner:          tuner,
+		Systems:        []trunking.System{sys},
+		Dwell:          40 * time.Millisecond,
+		InitialBackoff: 40 * time.Millisecond,
+		MaxBackoff:     160 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = sup.Run(ctx) }()
+
+	// The channel never locks (no cc.locked is injected). Success = the
+	// system reaches StateCamped and keeps re-dwelling, with NO
+	// KindHuntFailed ever fired for it. Reaching StateCamped is itself
+	// proof of the fix (the old code only ever produced StateFailed here).
+	deadline := time.After(2 * time.Second)
+	poll := time.NewTicker(10 * time.Millisecond)
+	defer poll.Stop()
+	sawCamped := false
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindHuntFailed {
+				if f, ok := ev.Payload.(trunking.HuntFailed); ok && f.System == "ConvDMR" {
+					t.Fatalf("idle conventional DMR emitted KindHuntFailed; want camped (issue #1036)")
+				}
+			}
+		case <-poll.C:
+			if sup.Snapshot()[0].State == StateCamped {
+				sawCamped = true
+			}
+			// Require several dwells' worth of quiet camping so a stray
+			// HuntFailed (or a backoff stall) would have surfaced.
+			if sawCamped && len(tuner.tuned()) >= 3 {
+				return
+			}
+		case <-deadline:
+			t.Fatalf("conventional DMR never camped: state=%q tunes=%d (issue #1036)",
+				sup.Snapshot()[0].State, len(tuner.tuned()))
+		}
+	}
+}
+
 func TestSupervisorLocksAndParks(t *testing.T) {
 	bus := events.NewBus(32)
 	defer bus.Close()

--- a/internal/scanner/cchunt/types.go
+++ b/internal/scanner/cchunt/types.go
@@ -15,6 +15,13 @@
 // list and report failed; that's intentional, not a bug. See the
 // README "Roadmap" / "Known gaps" sections for the broader
 // IQ-domain decoder dependency.
+//
+// Exception: conventional / direct-mode protocols (Protocol.CampsWhenIdle
+// — conventional DMR, DMR Tier I, TETRA DMO) have no continuous control
+// channel, so a hunt round that exhausts without a lock means the channel
+// is idle, not that acquisition failed. Those systems camp (StateCamped)
+// on the frequency and re-dwell promptly instead of backing off. Issue
+// #1036.
 package cchunt
 
 import "time"
@@ -37,6 +44,14 @@ const (
 	// StateFailed means the last hunt round exhausted without a
 	// lock; the supervisor is in backoff before retrying.
 	StateFailed HuntState = "failed"
+	// StateCamped means the system runs a conventional / direct-mode
+	// protocol (Protocol.CampsWhenIdle — conventional DMR, DMR Tier I,
+	// TETRA DMO) whose channel legitimately sits silent between
+	// transmissions. A hunt round that ended without a lock is not a
+	// failure here: the supervisor camps on the frequency and keeps
+	// re-dwelling (no backoff, no KindHuntFailed) so the decoder catches
+	// the next transmission. Issue #1036.
+	StateCamped HuntState = "camped"
 	// StateHeld means the operator pinned the supervisor on its
 	// current lock (or on its current failed state) — retunes are
 	// suppressed until Resume.

--- a/internal/trunking/site.go
+++ b/internal/trunking/site.go
@@ -68,6 +68,23 @@ func (p Protocol) String() string {
 	}
 }
 
+// CampsWhenIdle reports whether this protocol runs on a fixed channel
+// that legitimately sits silent between transmissions, with no
+// continuous control channel to acquire — conventional DMR (Tier II /
+// IPSC), DMR Tier I direct mode, and TETRA DMO. For these, a
+// control-channel hunt round that ends without a lock means the channel
+// is simply idle, not that acquisition failed; the cchunt supervisor
+// camps on the frequency and waits for traffic rather than emitting a
+// hunt-failure warning and backing off. Issue #1036.
+func (p Protocol) CampsWhenIdle() bool {
+	switch p {
+	case ProtocolDMRTier2, ProtocolDMRTier1, ProtocolTETRADMO:
+		return true
+	default:
+		return false
+	}
+}
+
 // ParseProtocol maps a string ("p25", "dmr", "nxdn", "dpmr",
 // "edacs", "motorola", "ltr", "mpt1327", "p25-phase2", "tetra") to
 // a Protocol value.

--- a/internal/trunking/site_test.go
+++ b/internal/trunking/site_test.go
@@ -18,6 +18,24 @@ func TestParseProtocol(t *testing.T) {
 	}
 }
 
+func TestProtocolCampsWhenIdle(t *testing.T) {
+	camp := []Protocol{ProtocolDMRTier2, ProtocolDMRTier1, ProtocolTETRADMO}
+	for _, p := range camp {
+		if !p.CampsWhenIdle() {
+			t.Errorf("CampsWhenIdle(%s) = false, want true", p)
+		}
+	}
+	// Trunked protocols (continuous control channel) must NOT camp — an
+	// idle hunt round is a real failure for them.
+	trunked := []Protocol{ProtocolP25, ProtocolP25Phase2, ProtocolDMR, ProtocolNXDN,
+		ProtocolTETRA, ProtocolMotorola, ProtocolEDACS, ProtocolLTR, ProtocolMPT1327}
+	for _, p := range trunked {
+		if p.CampsWhenIdle() {
+			t.Errorf("CampsWhenIdle(%s) = true, want false", p)
+		}
+	}
+}
+
 func TestSystemValidate(t *testing.T) {
 	good := System{Name: "Test", Protocol: ProtocolP25, ControlChannels: []uint32{851_000_000}}
 	if err := good.Validate(); err != nil {

--- a/internal/tui/panels/scanner.go
+++ b/internal/tui/panels/scanner.go
@@ -440,7 +440,7 @@ func (p *ScannerPanel) renderSystems(width int, s *state.SharedState) string {
 			stateStyle = dashWarn
 		case "failed":
 			stateStyle = dashErr
-		case "held":
+		case "held", "camped":
 			stateStyle = dashDim
 		}
 		freq := "—"
@@ -452,6 +452,12 @@ func (p *ScannerPanel) renderSystems(width int, s *state.SharedState) string {
 				sys.AttemptIndex+1, sys.TotalCandidates)
 		case "failed":
 			freq = fmt.Sprintf("retry in %s", formatBackoff(sys.BackoffMs))
+		case "camped":
+			// Conventional/direct channel parked and idle, waiting for
+			// traffic (issue #1036). Show the frequency it's camped on.
+			if sys.AttemptedFreqHz != 0 {
+				freq = client.FormatFreqMHz(sys.AttemptedFreqHz) + " (idle)"
+			}
 		}
 		grantAge := "—"
 		if !sys.LastGrantAt.IsZero() {


### PR DESCRIPTION
## Summary

A conventional DMR (IP Multi-Site Connect / IPSC) repeater has **no continuous control channel** — it sits silent between transmissions, waking only when a subscriber keys up (plus brief periodic beacons). The control-channel supervisor (`internal/scanner/cchunt`) treated a hunt round that ended without a lock as a *failure*: it logged `cchunt: hunt failed — no control-channel lock`, published a `cchunt.failed` event, and backed off exponentially up to 60 s — so the channel was frequently retuned away exactly when someone keyed up. That is precisely the *"Hunt & Lock Failures … hunt failure with no control-channel lock"* symptom described in #1036.

**Scoping note (what #1036 asked for vs. what already exists).** Most of the issue's requested behaviour is already implemented on the existing `dmr-tier2` path: beacon recognition + a clean "site alive" log (`handleCSBK`, tagged for #1036), TG/source-ID + colour-code scraping from active bursts (`handleVoiceHeader`), and a sticky lock that isn't re-hunted on inter-PTT silence (the Tier II channel wires no stale watchdog). So a **new `dmr_ipsc_conventional` protocol is unnecessary** — a conventional DMR/IPSC system is configured today as `protocol: dmr-tier2` (+ optional `color_code:` to pin the IPSC colour code). This PR closes the one remaining gap: the **acquisition side**, where an *idle* channel that hasn't locked yet was mis-reported as a hunt failure.

## Changes

- **`internal/trunking/site.go`** — `Protocol.CampsWhenIdle()`: true for conventional DMR (`dmr-tier2`), DMR Tier I (`dmr-tier1`), and TETRA DMO (`tetra-dmo`) — the protocols that legitimately sit silent on a fixed channel with no continuous control channel.
- **`internal/scanner/cchunt/types.go`** — new `StateCamped` hunt state + package-doc note on the exception.
- **`internal/scanner/cchunt/supervisor.go`** — when a `CampsWhenIdle` system's hunt round exhausts without a lock, `markCamped` (no backoff growth, no `KindHuntFailed`, a single Info log on the transition into camped) instead of `markFailed`. The loop re-dwells promptly, camping on the frequency so the decoder catches the next burst and locks. Trunked protocols are untouched — an idle hunt is still a real failure for them.
- **`internal/tui/panels/scanner.go`** — render the `camped` state (dim, showing the parked frequency with an `(idle)` marker) rather than blank.
- **CHANGELOG.md** — `Fixed` bullet.

## Test plan

- [x] `make vet test` — ran the touched packages (`internal/scanner/cchunt`, `internal/trunking`, `internal/tui/panels`) under `go test -race`; all green. `go build ./...` + `go vet` clean; gofmt clean.
- [ ] `make integration` — not run locally; CI runs it. (No daemon-path behaviour changed beyond supervisor scheduling.)
- [x] Added/updated tests:
  - `TestSupervisorCampsIdleConventionalDMR` — an idle `dmr-tier2` system must reach `StateCamped` and never emit `KindHuntFailed`. **Verified failing-first**: with the `markCamped` branch reverted it fails (the system fires `KindHuntFailed`); with the fix it passes. The existing `TestSupervisorFailsClosedWhenNothingLocks` (P25) still passes, proving trunked failure behaviour is unchanged.
  - `TestProtocolCampsWhenIdle` — pins the predicate (camp protocols true; all trunked protocols false).
- [ ] Smoke-tested against real hardware — **no**. This is control-supervisor scheduling logic verified deterministically in unit tests. On-air confirmation against a real IPSC repeater is still wanted (see below).

## Breaking changes

None. No config keys, flags, endpoints, or defaults change. A new runtime hunt-state string (`camped`) is additive and degrades gracefully in existing consumers (the web panel renders it as-is).

## Docs / CHANGELOG

- [x] Added a `## [Unreleased]` bullet to `CHANGELOG.md`
- [ ] README/docs — n/a (no new config surface; conventional DMR config via `dmr-tier2` is already documented)

## Linked issues

Refs #1036

<!-- `Refs`, not `Closes`, per the verify-before-close policy: unit-verified, not yet confirmed on a real on-air IPSC repeater. A capture (idle beacons + a keyup) from the reporter would let us confirm the camp→lock→grant transition end-to-end. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLorGf2nsrwoBhLy2YKmea

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLorGf2nsrwoBhLy2YKmea)_