### PR TITLE
tetra/dmo: qualify DNBs on the slot grid so noise stops granting (Refs #1003)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,17 @@ for tagged releases.
   actually shown. The client-side chip for a just-ended call is now labelled
   `ended` rather than `observed`, which collided with the daemon's own meaning of
   "observed" (announced on the control channel but not tuned — shown as `untuned`).
+- **A camped conventional / direct-mode system now actually reports itself as
+  camped.** The camp-on-idle state added for conventional DMR, DMR Tier I and TETRA
+  DMO was overwritten at the top of every hunt round, so it survived only the few
+  microseconds between being set and the next dwell starting — against a whole dwell
+  spent reporting `hunting`. Three things fell out of that: the Scanner panel's
+  `camped` badge (with the frequency it is parked on) never rendered, the log line
+  that is deliberately de-spammed to fire once on entry fired on *every* dwell
+  instead — roughly 25 INFO lines a second on a quiet channel — and the regression
+  test for the feature was left sampling a state that is almost never true, so it
+  failed under CI load. Camping is now durable: a re-dwell on an idle channel is the
+  camp, not a fresh acquisition attempt. (Refs #1036)
 - **Conventional DMR (IPSC) and other camp-on-idle systems no longer spam
   "hunt failed" while simply idle.** A conventional DMR / IPSC repeater has no
   continuous control channel — it sits silent between transmissions — but the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,16 @@ for tagged releases.
   daemon now reports a protocol-aware `symbol_proto` per device and the panels use
   it, which also stops an extra, wrong receiver being spun up per open panel. The
   symbol-quality tooltip now names which measurement produced its verdict.
+- **One talkgroup is one row in Active calls.** The same talkgroup could occupy
+  three rows at once — because the roster keyed rows on source, timeslot and
+  frequency while the daemon reports followed and control-channel-observed calls
+  from two separate maps — and the "Active calls" stat tile could read `0` above a
+  visible call row, because the tile counted the raw poll response while the
+  roster rendered the linger-augmented list. Rows are now de-duplicated per
+  talkgroup (preferring a live, followed call) and the tile counts the rows
+  actually shown. The client-side chip for a just-ended call is now labelled
+  `ended` rather than `observed`, which collided with the daemon's own meaning of
+  "observed" (announced on the control channel but not tuned — shown as `untuned`).
 - **Conventional DMR (IPSC) and other camp-on-idle systems no longer spam
   "hunt failed" while simply idle.** A conventional DMR / IPSC repeater has no
   continuous control channel — it sits silent between transmissions — but the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,16 @@ for tagged releases.
   as "recovered colour 0" and sends the investigation after the wrong thing. The
   fallback that picks colour 0 in order to decode *something* is now distinct from
   a recovery that actually cleared the confidence gate (`colour_recovered`).
+- **"symbol: poor" no longer latches permanently on TETRA, TETRA DMO and DMR
+  systems.** The web panels' "Auto" mode resolved the symbol-stream receiver from
+  a field that is only ever populated for P25 Phase 1 systems, so a non-P25 rig
+  fell back to a **P25 C4FM** receiver. Demodulating a π/4-DQPSK carrier that way
+  produces a meaningless — but non-empty — 4-level soft track, from which the
+  panels computed an MER-like SNR around 9 dB and bucketed the symbol quality as
+  "poor" for ever, sitting confusingly next to a correct "decode: clean". The
+  daemon now reports a protocol-aware `symbol_proto` per device and the panels use
+  it, which also stops an extra, wrong receiver being spun up per open panel. The
+  symbol-quality tooltip now names which measurement produced its verdict.
 - **Conventional DMR (IPSC) and other camp-on-idle systems no longer spam
   "hunt failed" while simply idle.** A conventional DMR / IPSC repeater has no
   continuous control channel — it sits silent between transmissions — but the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,40 @@ for tagged releases.
   call-priority metadata to TETRA alongside P25 and DMR.
 
 ### Fixed
+- **TETRA DMO no longer grants and opens a recording on an idle channel, and now
+  grants for every real transmission.** On air, `protocol: tetra-dmo` started a
+  call and a recording session about 230 ms after the daemon came up — before any
+  control-channel lock, with nobody transmitting — and then never granted again,
+  so an operator's actual 10 s PTT produced no recording at all. Both symptoms
+  were the same root cause: a DNB was detected purely by an 11-dibit
+  training-sequence correlation at tolerance 2 under eight matched filters, which
+  fires roughly **18 times a second on noise**, and a DMO channel is silent
+  between transmissions. Four of those false detections were enough to grant, and
+  the steady rain of them meant the "traffic drought" that re-arms the grant edge
+  could never elapse. Every DNB is now qualified against the 255-dibit TETRA
+  timeslot grid before it counts as traffic: a real transmission comes from one
+  radio on one clock, so all of its bursts share one slot residue, while
+  correlator false alarms spread uniformly across all 255. The grant additionally
+  requires a real DSB lock, and the drought is evaluated on the IQ stream rather
+  than only when a burst arrives, so silence actually re-arms it. The decode
+  status line now reports `dnb_qualified` alongside the raw `dnb_total`, so the
+  false-alarm rate stays visible. Trade-off: a grant now lands ~0.5 s into a
+  transmission rather than instantly. (Refs #1003)
+- **A TETRA DMO call no longer burns CPU brute-forcing the colour code, starving
+  its own audio.** The voice chain re-ran the full 64-colour `RecoverDMColourCode`
+  search over its entire, still-growing burst buffer on *every* arriving burst —
+  roughly 450 000 Viterbi decodes per call, on exactly the calls (encrypted or too
+  weak) that cannot be recovered anyway. That is enough to stall the same-carrier
+  IQ tap feeding the chain, which then logged `same-carrier voice tap dropped IQ
+  to a lagging voice consumer`. Recovery now runs at most six passes over a
+  bounded scoring window, matching the control pipeline's existing budget, while
+  still keeping every buffered burst so the start of the transmission is decoded
+  retroactively into the recording.
+- **The DMO end-of-call log no longer claims a colour code it never recovered.**
+  A call that decoded nothing reported `colour=0 colour_known=true`, which reads
+  as "recovered colour 0" and sends the investigation after the wrong thing. The
+  fallback that picks colour 0 in order to decode *something* is now distinct from
+  a recovery that actually cleared the confidence gate (`colour_recovered`).
 - **Conventional DMR (IPSC) and other camp-on-idle systems no longer spam
   "hunt failed" while simply idle.** A conventional DMR / IPSC repeater has no
   continuous control channel — it sits silent between transmissions — but the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -265,12 +265,46 @@ confirmation before any close-as-completed.
     - Pinned by `pipelines_dmo_test.go` (modulated-IQ lock+colour-3+grant), `dmo_stream_test.go`
       (chunk-invariance + soft decode), `tetra_dmo_voice_test.go` (colour recovery + retroactive
       emit), and `integration_cc_tetra_dmo_test.go` (full-daemon lock, `make integration`).
-    4. **STILL OPEN — on-air A/B (the #1003 gate).** A green synthetic/offline decode ≠ on-air
+    4. **FIRST on-air run found the grant path was driven by NOISE, now fixed.** The operator's
+      first live DMO run granted + opened a recording ~230 ms after startup on a silent channel,
+      then never granted again — their real 10 s PTT (which *did* lock, `dsb_schs_crc=46/54`)
+      produced nothing. One root cause: **a raw DNB detection is not evidence of traffic.** The
+      DNB correlator is an 11-dibit training match at tolerance 2 under 8 filters (2 sequences ×
+      4 rotations), so `Σ_{k≤2} C(11,k)·3^k = 529` of `4^11` match by chance ⇒ ~1.0e-3 per dibit
+      position ⇒ **~18 false DNBs/s** at 18 kdibit/s. The operator's own log is the proof:
+      `dnb_total` climbed 1076→4541 in 185 s (**18.7/s**) while `dsb_schs_crc` sat frozen at 46.
+      `dmoGrantMinDNB=4` therefore tripped in ~0.22 s, `maybeGrant` never checked `p.locked`
+      despite the counter being named `dnbSinceLock`, and the 3 s re-arm drought could never
+      elapse against a 55 ms mean inter-arrival — *and* was only evaluated inside the DNB branch,
+      so on a truly silent channel it could not fire at all. Fix: `tetra.DMSlotGrid`
+      (`internal/radio/tetra/dmo_grid.go`) votes DNB leads onto the **255-dibit timeslot grid** —
+      one radio on one clock puts every burst on one residue mod 255; noise is uniform over all
+      255. The residue is **learned, never hardcoded** (a wrong spec-derived DSB→DNB lead offset
+      would silently stop DMO granting, which is worse than over-granting), the latch is centred
+      on the agreeing leads and tracks symbol slips, and it is **dropped when the train ends**
+      (`dmGridTrainGap`) — without that, the ~0.2/s of noise landing on the latched residue keeps
+      a finished transmission "alive" and the grant latches anyway. The grant now also requires
+      `p.locked`, and the drought is evaluated from `Process`. Pinned failing-first by
+      `TestTETRADMOPipelineIgnoresIdleChannel` / `GrantsOnlyAfterLock` / `RearmsBetweenTransmissions`
+      (all three fail against the old code) plus `dmo_grid_test.go`. Note `buildDMODibitStream`
+      now lays bursts on a true 255-dibit slot grid — the old arbitrary-filler layout was not a
+      faithful transmitter and would not have caught this.
+      Related, same run: the voice chain re-ran the 64-colour `RecoverDMColourCode` over its whole
+      growing buffer on **every** burst (≈450k Viterbi decodes/call, `64·Σ(20..120)`), which
+      starved its own same-carrier IQ tap (`dropped_chunks=5904`); it is now capped at 6 passes
+      over a bounded scoring window, while still keeping the full buffer so leading speech is
+      still decoded retroactively. And `flush()` set `colourKnown = true` outside the confidence
+      gate, so a call that decoded nothing logged `colour=0 colour_known=true` — read as
+      "recovered colour 0" and sends you after the wrong thing; `colourRecovered` is now separate.
+    5. **STILL OPEN — on-air A/B (the #1003 gate).** A green synthetic/offline decode ≠ on-air
       correct (#764/#771): the operator must replay a clear 438.9 MHz DMO capture through the
       full daemon (`protocol: tetra-dmo`) and confirm a recording lands with intelligible audio.
       Watch on air: the DMO grant carries **no talkgroup** (`GroupID 0`, EN 300 396-3 call-control
-      not decoded), so recordings file under group `0`; and colour recovery needs ~20 DNBs, so a
-      very short first PTT may grant before the colour is known (the voice chain re-recovers it).
+      not decoded), so recordings file under group `0`; colour recovery needs ~20 DNBs, so a
+      very short first PTT may grant before the colour is known (the voice chain re-recovers it);
+      and the grant now lands ~0.5 s into a transmission (grid latch + 4 qualified DNBs) rather
+      than instantly. `dnb_qualified` in the decode-status line is the number that means traffic —
+      `dnb_total` is a noise meter, and a large gap between them is normal, not a fault.
 - **Conventional DMR (Tier II / IPSC) now decodes a repeater's TWO timeslots as two calls.**
   A base-station DMR repeater carries TS1 and TS2 interleaved on one carrier, each able to hold
   a separate simultaneous talkgroup. The conventional path (`internal/radio/dmr/tier2`) used to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -341,6 +341,30 @@ confirmation before any close-as-completed.
   `individual` column that backs the Radio IDs roster (its `LastTalkgroup` SQL excludes
   `individual=1` rows). The whole mechanism is now scoped to `g.Protocol == "tetra"`; DMR's FLCO
   classification is authoritative. Pinned by `engine_dmr_classify_test.go`.
+- **The web symbol panels pick their receiver from the SYSTEM's protocol, not the P25 demod
+  mode.** An operator on a TETRA rig saw a permanent `symbol: poor` badge next to a correct
+  `decode: clean`. The two chips are deliberately different axes (frame-error rate vs raw
+  constellation), but this was not that: `p25ModulationFor` (`cmd/gophertrunk/spectrum_provider.go`)
+  only inspects `ProtocolP25` systems, so a TETRA/DMO/DMR-only config reported `""`, the web
+  `demodModeToProto("")` fell back to `p25-c4fm`, and the panels opened a **P25 C4FM receiver on a
+  π/4-DQPSK carrier**. Its 4-level soft track is meaningless there but *non-empty*, so
+  `computeQuality` took the MER branch, measured ~9 dB, and `qualityVerdict` bucketed `<10 dB` as
+  "poor" for ever. (Tell-tale: the Histogram panel with Mode manually set to TETRA showed
+  `SNR (MER) —` and `balance ±5.7%`, which grades *clean* — two panels running different
+  receivers on the same carrier.) Fix: `symbolProtoFor` + `SpectrumDevice.SymbolProto`
+  (`symbol_proto`) resolve the actual `/diag/symbols` selector per protocol, and the web
+  `autoProtoFor` prefers it. This also removes a whole wrong receiver per open panel.
+  **Watch the CPU angle:** every `/diag/symbols` subscriber builds its own `Downconverter` from
+  the FULL input rate plus a receiver (`internal/scanner/symbolscope/scope.go`), nothing is
+  pooled, and Dashboard + Scanner + Plots each mount `useSignalQuality` while Histogram opens a
+  fourth. Several open tabs = several full DSP chains. Pooling them is still open work.
+- **`soapyremote: SDR overruns … host_drops` is a DOWNSTREAM signal, not a driver bug.**
+  `sendOrDrop` (`internal/sdr/soapyremote/driver.go`) only sheds when the consumer stops draining
+  a ~400 ms / ~1084-chunk channel, and it drops the OLDEST queued chunk, so each event is an IQ
+  discontinuity mid-queue. `internal/sdr/soapyremote/` has not been modified since the repo
+  import, so when this fires, look at what got slower on the decode side (the DMO colour brute
+  force above was one such cause) — and check for the companion
+  `ccdecoder: decode can't keep up with real time` WARN, which confirms CPU rather than network.
 - **P25 Phase 1 weak-signal voice is the under-equipped decode path — diagnosed, NOT yet
   fixed (needs a capture).** An operator whose hardware Astro Spectra decodes a marginal
   P25 Phase 1 voice call cleanly gets only ~4-5 IMBE frames from GT on the same antenna.

--- a/cmd/gophertrunk/spectrum_provider.go
+++ b/cmd/gophertrunk/spectrum_provider.go
@@ -72,6 +72,7 @@ func (p *spectrumProvider) Devices() []api.SpectrumDevice {
 			CenterHz:         centerHz,
 			SampleRateHz:     sampleRateHz,
 			P25Modulation:    p25ModulationFor(p.systems, centerHz, sampleRateHz),
+			SymbolProto:      symbolProtoFor(p.systems, centerHz, sampleRateHz),
 			ControlChannelHz: controlChannelFor(p.systems, centerHz, sampleRateHz),
 		})
 	}
@@ -159,6 +160,74 @@ func controlChannelFor(systems []trunking.System, centerHz, sampleRateHz uint32)
 func demodModeName(cfg string) string {
 	mode, _ := p25phase1rx.ParseDemodMode(cfg)
 	return mode.String()
+}
+
+// symbolProtoFor reports which symbol-scope receiver the device at
+// (centerHz, sampleRateHz) should be demodulated with — one of the
+// selectors WS /api/v1/diag/symbols accepts ("p25-c4fm", "p25-cqpsk",
+// "tetra", "dmr") — or "" when no configured system matches, in which
+// case the panels keep their existing default.
+//
+// This exists because p25ModulationFor only inspects P25 Phase 1
+// systems, so a TETRA-, DMO- or DMR-only rig reported "" and the web
+// panels' "Auto" mode fell back to p25-c4fm. That opened a full P25
+// C4FM receiver on a π/4-DQPSK carrier: the 4-level soft track it
+// produces there is meaningless, but it is non-empty, so the symbol
+// panels computed an MER-like SNR from it (~9 dB on a healthy TETRA
+// control channel) and latched "symbol: poor" permanently while the
+// decode-health chip correctly read "decode: clean". It also burned a
+// whole extra receiver per open panel.
+//
+// Matching follows p25ModulationFor: a system matches when one of its
+// control channels falls inside the device passband, with a fallback to
+// the sole configured system when exactly one exists.
+func symbolProtoFor(systems []trunking.System, centerHz, sampleRateHz uint32) string {
+	proto := func(s trunking.System) string {
+		switch s.Protocol {
+		case trunking.ProtocolP25:
+			// P25 Phase 1 voice shares the CC's modulation, so one value
+			// covers both the control channel and any followed call.
+			if demodModeName(s.P25Phase1DemodMode) == "cqpsk" {
+				return "p25-cqpsk"
+			}
+			return "p25-c4fm"
+		case trunking.ProtocolTETRA, trunking.ProtocolTETRADMO:
+			// DMO reuses the TMO physical layer (π/4-DQPSK at 18 ksym/s),
+			// so the same receiver applies.
+			return "tetra"
+		case trunking.ProtocolDMR, trunking.ProtocolDMRTier2, trunking.ProtocolDMRTier1:
+			return "dmr"
+		default:
+			// NXDN, MPT1327, EDACS, … have no symbol-scope receiver yet;
+			// "" leaves the panel on its default rather than asserting a
+			// wrong one.
+			return ""
+		}
+	}
+
+	var only *trunking.System
+	count := 0
+	for i := range systems {
+		if proto(systems[i]) == "" {
+			continue
+		}
+		count++
+		only = &systems[i]
+		half := int64(sampleRateHz) / 2
+		for _, cc := range systems[i].ControlChannels {
+			delta := int64(cc) - int64(centerHz)
+			if delta < 0 {
+				delta = -delta
+			}
+			if delta <= half {
+				return proto(systems[i])
+			}
+		}
+	}
+	if count == 1 {
+		return proto(*only)
+	}
+	return ""
 }
 
 // Tune programs the named SDR's centre frequency. Routes through

--- a/cmd/gophertrunk/spectrum_provider_test.go
+++ b/cmd/gophertrunk/spectrum_provider_test.go
@@ -401,3 +401,93 @@ func TestControlChannelFor(t *testing.T) {
 		})
 	}
 }
+
+// TestSymbolProtoFor is the regression for the permanent "symbol: poor" badge on a
+// non-P25 rig. p25ModulationFor only inspects P25 Phase 1 systems, so a TETRA, TETRA
+// DMO or DMR deployment reported "" and the web panels' "Auto" mode fell back to
+// p25-c4fm — demodulating a π/4-DQPSK carrier with a 4-level C4FM receiver, whose
+// meaningless soft track then produced an MER-like SNR around 9 dB and latched the
+// symbol-quality verdict at "poor" while decode health correctly read "clean".
+func TestSymbolProtoFor(t *testing.T) {
+	const sr = 2_048_000 // ±1.024 MHz passband
+
+	c4fm := trunking.System{
+		Name: "P25-C4FM", Protocol: trunking.ProtocolP25,
+		ControlChannels: []uint32{851_000_000}, P25Phase1DemodMode: "c4fm",
+	}
+	lsm := trunking.System{
+		Name: "P25-LSM", Protocol: trunking.ProtocolP25,
+		ControlChannels: []uint32{770_000_000}, P25Phase1DemodMode: "cqpsk",
+	}
+	tmo := trunking.System{
+		Name: "TETRA", Protocol: trunking.ProtocolTETRA,
+		ControlChannels: []uint32{467_912_500},
+	}
+	dmo := trunking.System{
+		Name: "DMO", Protocol: trunking.ProtocolTETRADMO,
+		ControlChannels: []uint32{438_900_000},
+	}
+	dmr := trunking.System{
+		Name: "DMR", Protocol: trunking.ProtocolDMR,
+		ControlChannels: []uint32{451_000_000},
+	}
+	nxdn := trunking.System{
+		Name: "NXDN", Protocol: trunking.ProtocolNXDN,
+		ControlChannels: []uint32{157_000_000},
+	}
+
+	tests := []struct {
+		name     string
+		systems  []trunking.System
+		centerHz uint32
+		want     string
+	}{
+		{"TETRA DMO device — the reported case", []trunking.System{dmo}, 438_900_000, "tetra"},
+		{"TETRA TMO device", []trunking.System{tmo}, 467_912_500, "tetra"},
+		{"DMR device", []trunking.System{dmr}, 451_000_000, "dmr"},
+		{"P25 C4FM device", []trunking.System{c4fm, lsm}, 851_000_000, "p25-c4fm"},
+		{"P25 LSM device", []trunking.System{c4fm, lsm}, 770_000_000, "p25-cqpsk"},
+		{
+			name:    "mixed rig picks the system in this device's passband",
+			systems: []trunking.System{c4fm, dmo}, centerHz: 438_900_000, want: "tetra",
+		},
+		{
+			name:    "sole configured system wins even off its control channel",
+			systems: []trunking.System{dmo}, centerHz: 400_000_000, want: "tetra",
+		},
+		{
+			name:    "no symbol receiver for this protocol leaves the panel default",
+			systems: []trunking.System{nxdn}, centerHz: 157_000_000, want: "",
+		},
+		{"no systems", nil, 851_000_000, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := symbolProtoFor(tt.systems, tt.centerHz, sr); got != tt.want {
+				t.Errorf("symbolProtoFor() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSymbolProtoForMatchesHandlerSelectors pins symbolProtoFor's output against the
+// set WS /api/v1/diag/symbols actually accepts — a value the handler rejects would
+// leave the panel with no symbol stream at all, which is worse than the wrong one.
+func TestSymbolProtoForMatchesHandlerSelectors(t *testing.T) {
+	protocols := []trunking.Protocol{
+		trunking.ProtocolP25, trunking.ProtocolTETRA, trunking.ProtocolTETRADMO,
+		trunking.ProtocolDMR, trunking.ProtocolDMRTier2, trunking.ProtocolDMRTier1,
+	}
+	for _, proto := range protocols {
+		sys := trunking.System{Name: proto.String(), Protocol: proto, ControlChannels: []uint32{450_000_000}}
+		got := symbolProtoFor([]trunking.System{sys}, 450_000_000, 2_048_000)
+		if got == "" {
+			t.Errorf("%s: symbolProtoFor returned empty", proto)
+			continue
+		}
+		if _, _, err := symbolProtoToReceiver(got); err != nil {
+			t.Errorf("%s: symbolProtoFor returned %q, which the symbols handler rejects: %v",
+				proto, got, err)
+		}
+	}
+}

--- a/docs/reference/tetra-dmo.md
+++ b/docs/reference/tetra-dmo.md
@@ -120,7 +120,23 @@ voice as functional-but-unverified-on-air until that A/B lands.
 `internal/radio/tetra/dmo.go` defines the `DMBurstKind` (DSB/DNB), the burst geometry, and the
 `ExtractDMBursts` / `ExtractDMBurstsSoft` slicers that correlate the training sequences under
 all four residual π/4-DQPSK rotations; `dmo_stream.go` wraps them in a bounded sliding-window
-`DMStreamExtractor` for the live daemon. `dmo_decode.go` maps the sliced blocks onto the shared
+`DMStreamExtractor` for the live daemon.
+
+A DNB detection on its own is **not** evidence of traffic, and treating it as such is a trap
+worth understanding. The DNB training sequence is only 11 dibits and is matched at tolerance 2
+under eight filters (two sequences × four rotations), so the number of sequences that match by
+chance is `Σ_{k≤2} C(11,k)·3^k = 529` out of `4^11`, giving ≈1.0 × 10⁻³ per dibit position
+across the eight — about **18 false DNBs per second** at the 18 kdibit/s symbol rate. Since a
+DMO channel is silent between transmissions, that is what the detector reports almost all of
+the time. `dmo_grid.go`'s `DMSlotGrid` is the discriminator: a real transmission comes from one
+radio on one clock, so every one of its bursts lands on the 255-dibit timeslot grid and all its
+DNB leads share a single residue mod 255, whereas false alarms are uniform across all 255. The
+residue is *learned* from the stream rather than derived from a hardcoded burst offset, so a
+wrong constant cannot silently stop DMO from granting; the latch is dropped when the burst
+train ends so the next transmission re-votes. The 19-dibit DSB detector needs no such gate —
+its false-alarm rate is ~0.007/s and it must still pass the SCH/S CRC.
+
+`dmo_decode.go` maps the sliced blocks onto the shared
 decoders — `DecodeDMSCHS` (via the BSCH chain), `DecodeDMSCHH` (via SCH/HD), `DecodeDMSCHF`,
 and `DMBurstTCHSpeech` / `DMBurstTCHSpeechSoft` (via the TCH/S chain) — de-rotating and
 descrambling with the DM colour code (recovered by `RecoverDMColourCode`) before each decode.

--- a/internal/api/spectrum.go
+++ b/internal/api/spectrum.go
@@ -27,6 +27,15 @@ type SpectrumDevice struct {
 	// instead of asking the operator to pick it. Empty when no P25
 	// Phase 1 system matches (e.g. a DMR-only device).
 	P25Modulation string `json:"p25_modulation,omitempty"`
+	// SymbolProto is the WS /api/v1/diag/symbols receiver selector for
+	// the system this SDR is decoding — "p25-c4fm", "p25-cqpsk",
+	// "tetra" or "dmr" — or empty when no configured system matches.
+	// P25Modulation only ever describes P25 Phase 1 systems, so on a
+	// TETRA/DMO/DMR rig the web panels' "Auto" mode fell back to
+	// p25-c4fm and demodulated the carrier with the wrong receiver;
+	// this field is protocol-aware so they pick the right one. Kept
+	// separate from P25Modulation, which older clients still read.
+	SymbolProto string `json:"symbol_proto,omitempty"`
 	// ControlChannelHz is the configured control-channel frequency that
 	// falls inside this SDR's passband (the one closest to centre when
 	// several are in band), or 0 when none matches. The web Plots panels

--- a/internal/radio/tetra/dmo_grid.go
+++ b/internal/radio/tetra/dmo_grid.go
@@ -1,0 +1,272 @@
+package tetra
+
+// DMO burst-train qualification — the noise gate the DMO grant path needs.
+//
+// A DNB is detected by correlating an 11-dibit normal training sequence at
+// tolerance 2 (extractDMBursts, dmo.go), under two training sequences × four
+// residual rotations = eight matched filters. That is deliberately loose so a
+// marginal real burst is not missed, but it means the detector fires freely on
+// noise: the number of 11-dibit sequences within Hamming distance 2 of a given
+// pattern is
+//
+//	Σ_{k≤2} C(11,k)·3^k = 1 + 33 + 495 = 529
+//
+// so p ≈ 529/4^11 ≈ 1.26e-4 per position per filter, ≈ 1.0e-3 across the eight
+// filters, and at the 18 000 dibit/s TETRA symbol rate that is ≈ 18 spurious
+// DNB "detections" per second off an idle channel. A DMO channel is idle most
+// of the time (EN 300 396-2: infrastructure-less, silent between transmissions),
+// so a raw DNB count is not evidence of traffic — it is a noise meter. Treating
+// it as traffic is what made the daemon grant and open a recording ~230 ms after
+// startup, and then latch that grant forever so the operator's real PTT never
+// granted at all.
+//
+// The discriminator is the TDMA slot grid. A real transmission is emitted by one
+// radio on one clock, so every one of its bursts lands on the 255-dibit timeslot
+// grid and every DNB shares ONE residue mod 255 (both normal training sequences
+// sit at the same intra-slot offset, so NTS1 and NTS2 hits agree). Noise hits are
+// uniform over all 255 residues. Voting on the residue therefore separates the
+// two populations without any decode, at negligible cost, and — importantly —
+// without hardcoding a spec-derived DSB→DNB lead offset: the residue is LEARNED
+// from the stream, so a wrong constant cannot silently stop DMO from granting.
+//
+// This is the DMO analogue of the TMO slot anchor (TrafficExtractor.slotOf,
+// traffic.go), except TMO only labels bursts with their slot while DMO must gate
+// on it.
+
+const (
+	// dmSlotDibits is the dibit span of one TETRA timeslot (510 bits). The grid
+	// a single transmitter's bursts are laid on. Mirrors ndbSlotDibits.
+	dmSlotDibits = 255
+	// dmGridTolerance is how far (in dibits) a lead may sit from the latched
+	// residue and still qualify, absorbing symbol-clock jitter and the odd
+	// slipped symbol from the timing-recovery loop.
+	dmGridTolerance = 1
+	// dmGridWindow is the residue-vote window in dibits — 1 s at the 18 kdibit/s
+	// TETRA symbol rate. The dibit index is used as the clock throughout (it is
+	// exact and deterministic, unlike wall time, which makes this testable and
+	// immune to a stalled decode goroutine).
+	dmGridWindow = 18000
+	// dmGridMinTrain is how many in-window leads must agree on a residue before
+	// it is latched as a real burst train. Sizing: noise puts ~18 leads/s across
+	// 255 residues, so a 1 s window holds ~18 leads and the expected number
+	// matching any given residue within ±dmGridTolerance is 18·3/255 ≈ 0.21;
+	// requiring 5 further matches is P(Poisson(0.21) ≥ 5) ≈ 1.4e-6 per detection,
+	// i.e. a false latch about once per 11 hours. A real transmission puts
+	// ~17 leads/s on ONE residue and so latches after ~6 bursts ≈ 340 ms.
+	dmGridMinTrain = 6
+	// dmGridMaxLeads bounds the ring. A full second of noise is ~18 leads and of
+	// traffic ~17, so 64 is comfortable headroom; beyond it the oldest lead is
+	// dropped regardless of the window.
+	dmGridMaxLeads = 64
+	// dmGridTrainGap is the largest slot gap between consecutive qualified bursts
+	// that still counts as the same transmission. A transmitting radio emits a burst
+	// every frame, so a real train never gaps by more than a few slots; noise that
+	// happens to land on the latched residue arrives at only ~18·3/255 ≈ 0.2/s, i.e.
+	// a mean gap of ~5 s ≈ 90 000 dibits. Anything past this threshold means the
+	// train has ended, so the latch is dropped and the next transmission must re-vote
+	// — without it, that noise trickle silently keeps a finished transmission "alive"
+	// and the grant edge never re-arms.
+	dmGridTrainGap = 16 * dmSlotDibits
+	// dmGridDriftAdjust is how many dibits of accumulated signed offset (each
+	// qualified lead contributes -1, 0 or +1) shift the latched residue by one.
+	// The symbol-clock loop tracks the transmitter, so the recovered index does
+	// not drift steadily — but an occasional slipped symbol does step it, and
+	// without this the latched residue would eventually sit at the edge of the
+	// tolerance band and start dropping real bursts mid-transmission.
+	dmGridDriftAdjust = 4
+)
+
+// DMSlotGrid votes the recent DNB training-sequence lead indices onto the
+// 255-dibit timeslot grid and reports which of them belong to a real burst
+// train. Not safe for concurrent use; drive it from the single goroutine that
+// drives DMStreamExtractor.
+type DMSlotGrid struct {
+	// leads is a bounded, time-ordered ring of recent absolute DNB lead indices.
+	leads []int
+
+	// residue is the latched traffic residue (mod dmSlotDibits) once
+	// dmGridMinTrain leads have agreed on it; latched is false until then.
+	// drift integrates the signed offset of qualified leads from it, so a
+	// slipped symbol re-centres the band instead of walking off its edge.
+	residue int
+	latched bool
+	drift   int
+
+	// lastQualified is the absolute lead index of the most recent qualified DNB,
+	// and qualifiedSeen whether there has been one since the last Reset. Callers
+	// use these to measure a traffic drought in the dibit domain.
+	lastQualified int
+	qualifiedSeen bool
+}
+
+// NewDMSlotGrid returns an empty grid with no residue latched.
+func NewDMSlotGrid() *DMSlotGrid { return &DMSlotGrid{} }
+
+// Observe records one DNB training-sequence lead (an absolute dibit index, as
+// carried in DMBurst.Lead) and reports whether it belongs to a real burst train.
+//
+// Before a residue is latched, a lead qualifies only once dmGridMinTrain leads
+// in the trailing dmGridWindow agree on its residue — at which point that
+// residue is latched and this lead (the one that completed the vote) qualifies.
+// After latching, a lead qualifies iff it matches the latched residue, so the
+// rest of the transmission qualifies immediately and noise on other residues
+// does not.
+func (g *DMSlotGrid) Observe(lead int) bool {
+	g.trim(lead)
+
+	if g.latched {
+		// Drop a stale latch rather than trusting it, in two cases: the burst train
+		// has ended (gap past dmGridTrainGap — otherwise noise landing on the latched
+		// residue keeps a finished transmission alive), or the upstream dibit index
+		// ran backwards because the receiver re-anchored (a Reset), which would
+		// otherwise reject every burst of the new stream forever.
+		if g.qualifiedSeen && (lead-g.lastQualified > dmGridTrainGap || lead < g.lastQualified) {
+			g.Reset()
+		} else {
+			if !residueNear(lead, g.residue) {
+				g.push(lead)
+				return false
+			}
+			g.push(lead)
+			g.track(lead)
+			g.markQualified(lead)
+			return true
+		}
+	}
+
+	// Not latched: count how many in-window leads share this lead's residue.
+	r := residueOf(lead)
+	agree := 1 // this lead
+	sum := 0   // signed offsets of the agreeing leads, for the centred latch
+	for _, l := range g.leads {
+		if d, ok := residueOffset(l, r); ok {
+			agree++
+			sum += d
+		}
+	}
+	g.push(lead)
+	if agree < dmGridMinTrain {
+		return false
+	}
+	// Latch the CENTRE of the agreeing leads, not this lead's residue: with a
+	// ±dmGridTolerance band, latching on an extreme of a jittering train leaves
+	// the other extreme outside the band and drops half the real bursts.
+	g.residue = wrapResidue(r + roundDiv(sum, agree))
+	g.latched = true
+	g.drift = 0
+	g.markQualified(lead)
+	return true
+}
+
+// track integrates a qualified lead's signed offset from the latched residue and
+// re-centres the band once the accumulated slip reaches dmGridDriftAdjust.
+func (g *DMSlotGrid) track(lead int) {
+	d, ok := residueOffset(lead, g.residue)
+	if !ok {
+		return
+	}
+	g.drift += d
+	switch {
+	case g.drift >= dmGridDriftAdjust:
+		g.residue = wrapResidue(g.residue + 1)
+		g.drift = 0
+	case g.drift <= -dmGridDriftAdjust:
+		g.residue = wrapResidue(g.residue - 1)
+		g.drift = 0
+	}
+}
+
+// Latched reports whether a traffic residue has been identified.
+func (g *DMSlotGrid) Latched() bool { return g.latched }
+
+// LastQualifiedLead returns the absolute dibit index of the most recent
+// qualified DNB and whether there has been one.
+func (g *DMSlotGrid) LastQualifiedLead() (int, bool) {
+	return g.lastQualified, g.qualifiedSeen
+}
+
+// Reset drops the latched residue and all buffered leads, so the next
+// transmission re-learns its own grid. Callers invoke it on a traffic drought
+// and on a receiver re-anchor.
+func (g *DMSlotGrid) Reset() {
+	g.leads = g.leads[:0]
+	g.residue = 0
+	g.latched = false
+	g.drift = 0
+	g.lastQualified = 0
+	g.qualifiedSeen = false
+}
+
+func (g *DMSlotGrid) markQualified(lead int) {
+	g.lastQualified = lead
+	g.qualifiedSeen = true
+}
+
+// push appends a lead to the ring, dropping the oldest when it is full.
+func (g *DMSlotGrid) push(lead int) {
+	if len(g.leads) >= dmGridMaxLeads {
+		copy(g.leads, g.leads[1:])
+		g.leads = g.leads[:len(g.leads)-1]
+	}
+	g.leads = append(g.leads, lead)
+}
+
+// trim drops leads that have fallen out of the trailing dmGridWindow relative to
+// the newest lead. Leads arrive in ascending order (DMStreamExtractor emits by
+// ascending Lead), so this is a prefix drop.
+func (g *DMSlotGrid) trim(newest int) {
+	cut := 0
+	for cut < len(g.leads) && newest-g.leads[cut] > dmGridWindow {
+		cut++
+	}
+	if cut > 0 {
+		g.leads = append(g.leads[:0], g.leads[cut:]...)
+	}
+}
+
+// residueOf is the lead's position within the 255-dibit slot, normalised to
+// [0, dmSlotDibits) for negative indices too.
+func residueOf(lead int) int { return wrapResidue(lead) }
+
+// wrapResidue normalises any integer into [0, dmSlotDibits).
+func wrapResidue(v int) int {
+	r := v % dmSlotDibits
+	if r < 0 {
+		r += dmSlotDibits
+	}
+	return r
+}
+
+// residueOffset returns lead's signed offset from residue r, measured the
+// shorter way round the 255-residue ring, and whether that offset is within
+// dmGridTolerance.
+func residueOffset(lead, r int) (int, bool) {
+	d := residueOf(lead) - r
+	if d > dmSlotDibits/2 {
+		d -= dmSlotDibits
+	} else if d < -dmSlotDibits/2 {
+		d += dmSlotDibits
+	}
+	a := d
+	if a < 0 {
+		a = -a
+	}
+	return d, a <= dmGridTolerance
+}
+
+// residueNear reports whether lead's residue is within dmGridTolerance of r.
+func residueNear(lead, r int) bool {
+	_, ok := residueOffset(lead, r)
+	return ok
+}
+
+// roundDiv divides n by d rounding to nearest (ties away from zero).
+func roundDiv(n, d int) int {
+	if d == 0 {
+		return 0
+	}
+	if n >= 0 {
+		return (2*n + d) / (2 * d)
+	}
+	return -((-2*n + d) / (2 * d))
+}

--- a/internal/radio/tetra/dmo_grid_test.go
+++ b/internal/radio/tetra/dmo_grid_test.go
@@ -1,0 +1,296 @@
+package tetra
+
+import (
+	"math/rand"
+	"testing"
+)
+
+// TestDMSlotGridLatchesTrafficResidue drives a grid with leads laid on a real
+// 255-dibit slot grid and asserts it latches that residue and qualifies the
+// train once dmGridMinTrain bursts agree.
+func TestDMSlotGridLatchesTrafficResidue(t *testing.T) {
+	g := NewDMSlotGrid()
+	const start = 100_000 // arbitrary absolute index; residue 100000%255 = 130
+
+	qualified := 0
+	for i := 0; i < 20; i++ {
+		if g.Observe(start + i*dmSlotDibits) {
+			qualified++
+		}
+	}
+	if !g.Latched() {
+		t.Fatalf("grid did not latch on a clean %d-dibit burst train", dmSlotDibits)
+	}
+	if g.residue != residueOf(start) {
+		t.Errorf("latched residue = %d, want %d", g.residue, residueOf(start))
+	}
+	// The first dmGridMinTrain-1 leads vote but do not yet qualify; every lead
+	// from the one that completes the vote onwards does.
+	want := 20 - (dmGridMinTrain - 1)
+	if qualified != want {
+		t.Errorf("qualified %d of 20 leads, want %d", qualified, want)
+	}
+	if last, ok := g.LastQualifiedLead(); !ok || last != start+19*dmSlotDibits {
+		t.Errorf("LastQualifiedLead() = %d,%v; want %d,true", last, ok, start+19*dmSlotDibits)
+	}
+}
+
+// TestDMSlotGridToleratesSymbolJitter pins that a ±dmGridTolerance wobble in the
+// recovered symbol clock does not break a train: the grid still latches, and once
+// latched it centres the band so it does not drop bursts on the far edge.
+//
+// A full ±1 dibit wobble on EVERY burst is far harsher than a tracking symbol
+// clock produces, so the latch is allowed to take a few extra bursts to find six
+// mutually-agreeing leads; what must not happen is bursts being dropped after it.
+func TestDMSlotGridToleratesSymbolJitter(t *testing.T) {
+	g := NewDMSlotGrid()
+	const (
+		start  = 4_000
+		bursts = 24
+	)
+	jitter := []int{0, 1, 0, -1, 0, 1, -1, 0, 1, 0, -1, 1}
+	latchedAt := -1
+	for i := 0; i < bursts; i++ {
+		j := jitter[i%len(jitter)]
+		lead := start + i*dmSlotDibits + j
+		got := g.Observe(lead)
+		if latchedAt >= 0 && !got {
+			t.Errorf("lead %d (jitter %+d, burst %d) dropped after latch at burst %d",
+				lead, j, i, latchedAt)
+		}
+		if got && latchedAt < 0 {
+			latchedAt = i
+		}
+	}
+	if !g.Latched() {
+		t.Fatalf("grid did not latch through ±%d dibit jitter", dmGridTolerance)
+	}
+	if latchedAt > dmGridMinTrain+4 {
+		t.Errorf("latched only at burst %d, want by burst %d", latchedAt, dmGridMinTrain+4)
+	}
+	// The centred latch must sit at the middle of the jitter band, not an edge.
+	if want := residueOf(start); g.residue != want {
+		t.Errorf("latched residue = %d, want the band centre %d", g.residue, want)
+	}
+}
+
+// TestDMSlotGridTracksSlippedSymbols covers a symbol-clock slip mid-transmission:
+// the recovered dibit index steps by one, so every later burst sits one dibit off
+// the original residue. Without drift tracking the train would sit at the edge of
+// the tolerance band and a second slip would drop it entirely.
+func TestDMSlotGridTracksSlippedSymbols(t *testing.T) {
+	g := NewDMSlotGrid()
+	const start = 60_000
+	lead := start
+	for i := 0; i < 12; i++ { // establish the train
+		g.Observe(lead)
+		lead += dmSlotDibits
+	}
+	if !g.Latched() {
+		t.Fatalf("did not latch")
+	}
+	base := g.residue
+
+	// Two slips in the same direction, well separated.
+	drops := 0
+	for slip := 0; slip < 2; slip++ {
+		lead++ // the slipped symbol
+		for i := 0; i < 12; i++ {
+			if !g.Observe(lead) {
+				drops++
+			}
+			lead += dmSlotDibits
+		}
+	}
+	if drops != 0 {
+		t.Errorf("dropped %d bursts across two symbol slips", drops)
+	}
+	if g.residue == base {
+		t.Errorf("latched residue never followed the slips (still %d)", base)
+	}
+}
+
+// TestDMSlotGridRejectsNoise is the core regression: the DNB correlator fires
+// ~18 times a second on an idle channel (see dmo_grid.go for the arithmetic),
+// and those detections are uniform over the 255 residues. Ten simulated seconds
+// of that must not latch a traffic residue or qualify a burst — otherwise the
+// daemon grants and opens a recording on a silent DMO channel.
+func TestDMSlotGridRejectsNoise(t *testing.T) {
+	g := NewDMSlotGrid()
+	rng := rand.New(rand.NewSource(20260813))
+
+	const (
+		seconds       = 10
+		leadsPerSec   = 18 // measured false-alarm rate off an idle channel
+		meanSpacing   = dmGridWindow / leadsPerSec
+		totalExpected = seconds * leadsPerSec
+	)
+	lead := 0
+	qualified := 0
+	for i := 0; i < totalExpected; i++ {
+		// Uniformly-random spacing → uniformly-distributed residues, which is
+		// what an uncorrelated correlator false alarm looks like.
+		lead += 1 + rng.Intn(2*meanSpacing)
+		if g.Observe(lead) {
+			qualified++
+		}
+	}
+	if qualified != 0 {
+		t.Errorf("qualified %d of %d noise detections, want 0 (latched=%v residue=%d)",
+			qualified, totalExpected, g.Latched(), g.residue)
+	}
+	if g.Latched() {
+		t.Errorf("latched residue %d on pure noise", g.residue)
+	}
+}
+
+// TestDMSlotGridQualifiesTrafficThroughNoise checks the discriminator works when
+// both populations are present at once — a real train buried in the same ~18/s
+// false-alarm rain, which is what the live pipeline actually sees.
+func TestDMSlotGridQualifiesTrafficThroughNoise(t *testing.T) {
+	g := NewDMSlotGrid()
+	rng := rand.New(rand.NewSource(7))
+
+	const (
+		base    = 500_000
+		bursts  = 40
+		noisePB = 1 // interleaved noise detections per real burst
+	)
+	trafficQualified, noiseQualified := 0, 0
+	for i := 0; i < bursts; i++ {
+		real := base + i*dmSlotDibits
+		// A noise hit somewhere inside this slot, off the traffic residue.
+		off := 8 + rng.Intn(dmSlotDibits-16)
+		if residueNear(real+off, residueOf(base)) {
+			off += dmGridTolerance + 2
+		}
+		for _, l := range []int{real, real + off} {
+			ok := g.Observe(l)
+			if l == real {
+				if ok {
+					trafficQualified++
+				}
+			} else if ok {
+				noiseQualified++
+			}
+		}
+	}
+	if noiseQualified != 0 {
+		t.Errorf("qualified %d off-grid noise detections, want 0", noiseQualified)
+	}
+	if want := bursts - (dmGridMinTrain - 1); trafficQualified != want {
+		t.Errorf("qualified %d of %d on-grid bursts, want %d", trafficQualified, bursts, want)
+	}
+}
+
+// TestDMSlotGridResetRelearns pins that after a Reset (the pipeline's traffic
+// drought) a second transmission on a DIFFERENT residue latches afresh — the
+// next PTT must grant even though it does not share the previous grid.
+func TestDMSlotGridResetRelearns(t *testing.T) {
+	g := NewDMSlotGrid()
+	for i := 0; i < 10; i++ {
+		g.Observe(1_000 + i*dmSlotDibits)
+	}
+	if !g.Latched() {
+		t.Fatalf("first transmission did not latch")
+	}
+	first := g.residue
+
+	g.Reset()
+	if g.Latched() {
+		t.Fatalf("Reset left the grid latched")
+	}
+	// Second transmission, deliberately off the first residue.
+	base := 900_000 + first + dmSlotDibits/2
+	qualified := 0
+	for i := 0; i < 10; i++ {
+		if g.Observe(base + i*dmSlotDibits) {
+			qualified++
+		}
+	}
+	if !g.Latched() {
+		t.Fatalf("second transmission did not re-latch after Reset")
+	}
+	if g.residue == first {
+		t.Errorf("re-latched the stale residue %d", first)
+	}
+	if want := 10 - (dmGridMinTrain - 1); qualified != want {
+		t.Errorf("qualified %d of 10 second-transmission bursts, want %d", qualified, want)
+	}
+}
+
+// TestDMSlotGridReanchorDropsStaleLatch covers the receiver Reset case, where the
+// absolute dibit index restarts at 0 while a residue is still latched: the grid
+// must re-learn rather than reject every burst of the new stream forever.
+func TestDMSlotGridReanchorDropsStaleLatch(t *testing.T) {
+	g := NewDMSlotGrid()
+	for i := 0; i < 10; i++ {
+		g.Observe(5_000_000 + i*dmSlotDibits)
+	}
+	if !g.Latched() {
+		t.Fatalf("did not latch before the re-anchor")
+	}
+	// Stream restarts near zero on a different residue.
+	base := 37
+	qualified := 0
+	for i := 0; i < 12; i++ {
+		if g.Observe(base + i*dmSlotDibits) {
+			qualified++
+		}
+	}
+	if !g.Latched() {
+		t.Fatalf("did not re-latch after the index re-anchored")
+	}
+	if qualified == 0 {
+		t.Errorf("no burst qualified after the index re-anchored (stale latch stuck)")
+	}
+}
+
+// TestDMSlotGridBounded pins the ring bound so a long transmission cannot grow
+// the lead buffer without limit.
+func TestDMSlotGridBounded(t *testing.T) {
+	g := NewDMSlotGrid()
+	for i := 0; i < 10_000; i++ {
+		g.Observe(i * dmSlotDibits)
+	}
+	if len(g.leads) > dmGridMaxLeads {
+		t.Errorf("lead ring grew to %d, want <= %d", len(g.leads), dmGridMaxLeads)
+	}
+}
+
+// TestDMSlotGridDropsLatchWhenTrainEnds is the subtle half of the noise gate. Once a
+// residue is latched, the ~18/s correlator false alarms still land on it about
+// 18·3/255 ≈ 0.2 times a second. Without a train-gap check those stray hits qualify
+// forever after the transmission has ended, which keeps the caller's traffic drought
+// from ever firing — exactly the latch that stopped the operator's second PTT from
+// granting. A hit arriving long after the train must NOT qualify.
+func TestDMSlotGridDropsLatchWhenTrainEnds(t *testing.T) {
+	g := NewDMSlotGrid()
+	const base = 200_000
+	for i := 0; i < 12; i++ {
+		g.Observe(base + i*dmSlotDibits)
+	}
+	if !g.Latched() {
+		t.Fatalf("did not latch")
+	}
+	last, _ := g.LastQualifiedLead()
+
+	// A lone stray hit on the latched residue, a long silence later.
+	stray := last + dmGridTrainGap + 5*dmSlotDibits
+	if g.Observe(stray) {
+		t.Errorf("stray on-residue noise hit %d qualified after the train ended", stray)
+	}
+	if g.Latched() {
+		t.Errorf("latch survived a %d-dibit gap", stray-last)
+	}
+
+	// A gap INSIDE the tolerance is still the same transmission.
+	g2 := NewDMSlotGrid()
+	for i := 0; i < 12; i++ {
+		g2.Observe(base + i*dmSlotDibits)
+	}
+	l2, _ := g2.LastQualifiedLead()
+	if !g2.Observe(l2 + 4*dmSlotDibits) {
+		t.Errorf("a 4-slot intra-train gap broke the latch")
+	}
+}

--- a/internal/scanner/ccdecoder/pipelines_dmo.go
+++ b/internal/scanner/ccdecoder/pipelines_dmo.go
@@ -36,6 +36,17 @@ import (
 //     re-armed only after a traffic drought, because a DMO grant carries no talkgroup
 //     (GroupID 0) and the engine does not de-duplicate zero-group grants.
 //
+// A raw DNB detection is NOT evidence of traffic. The DNB correlator is an 11-dibit
+// training-sequence match at tolerance 2 under eight matched filters, which fires
+// ~18 times a second on an idle channel (the arithmetic is in tetra/dmo_grid.go), and
+// a DMO channel is idle most of the time. Taking that at face value is what made the
+// daemon grant and open a recording ~230 ms after startup and then latch the grant
+// forever, so the operator's real PTT never granted at all. Every DNB is therefore
+// qualified against the 255-dibit TETRA slot grid (tetra.DMSlotGrid) before it counts
+// towards the grant, the colour recovery or the drought: a real transmission comes
+// from one radio on one clock, so all its DNB leads share one residue mod 255, while
+// noise hits spread uniformly over all 255.
+//
 // The actual TCH/S → ACELP audio is decoded in the voice chain, not here; this
 // pipeline decodes SCH/S (lock) and brute-forces the colour, and only needs to detect
 // DNB *presence* to grant. This is #1003, design-first and on-air A/B gated: a green
@@ -54,12 +65,16 @@ const (
 	// falling back to colour 0 (a channel that never clears the confidence gate is
 	// encrypted or unreceivable — chasing it forever would burn CPU on every DNB).
 	dmoColourMaxAttempts = 6
-	// dmoGrantMinDNB is how many DNBs must follow a lock before a grant fires — a
-	// short guard so a lone stray DNB detection does not spawn a call.
+	// dmoGrantMinDNB is how many SLOT-GRID-QUALIFIED DNBs must follow a lock before a
+	// grant fires — a short guard on top of the grid gate so a call is not spawned
+	// before the burst train is unambiguous.
 	dmoGrantMinDNB = 4
-	// dmoGrantRearm is the DNB-traffic drought after which the grant re-arms, so the
-	// next PTT transmission grants afresh. Longer than the voice chain's hangtime so a
-	// brief intra-call gap does not double-grant an already-active call.
+	// dmoGrantRearm is the qualified-DNB traffic drought after which the grant re-arms,
+	// so the next PTT transmission grants afresh. Longer than the voice chain's hangtime
+	// so a brief intra-call gap does not double-grant an already-active call. It is
+	// evaluated from Process (per IQ chunk) as well as from onBurst, because once the
+	// grid gate is in place a silent channel produces NO qualified bursts at all — the
+	// old onBurst-only check could never fire, which is precisely why the grant latched.
 	dmoGrantRearm = 3 * time.Second
 )
 
@@ -89,6 +104,7 @@ func newTETRADMOPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 		p.colourKnown = true
 	}
 	p.ext = tetra.NewDMStreamExtractor(p.onBurst)
+	p.grid = tetra.NewDMSlotGrid()
 	p.rx = tetrarx.New(tetrarx.Options{
 		SampleRateHz: opts.SampleRateHz,
 		DibitSink: func(dibits []uint8, baseIdx int) {
@@ -121,8 +137,11 @@ func newTETRADMOPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 type tetraDMOPipeline struct {
 	rx  *tetrarx.Receiver
 	ext *tetra.DMStreamExtractor
-	bus *events.Bus
-	log *slog.Logger
+	// grid separates real burst trains from the DNB correlator's ~18/s noise
+	// false-alarm rate by voting DNB leads onto the 255-dibit slot grid.
+	grid *tetra.DMSlotGrid
+	bus  *events.Bus
+	log  *slog.Logger
 
 	system string
 	freqHz uint32
@@ -150,13 +169,17 @@ type tetraDMOPipeline struct {
 	dnbSinceLock int
 	lastDNB      time.Time
 
-	// Status counters (single-goroutine; no atomics needed).
-	dsbTotal, dsbCRC, dnbTotal, tchCRC int64
-	lastLog                            time.Time
+	// Status counters (single-goroutine; no atomics needed). dnbTotal counts RAW
+	// correlator detections (mostly noise on an idle channel — kept visible so the
+	// false-alarm rate stays diagnosable) and dnbQualified only those that passed
+	// the slot-grid gate, which is the number that means "traffic".
+	dsbTotal, dsbCRC, dnbTotal, dnbQualified, tchCRC int64
+	lastLog                                          time.Time
 }
 
 func (p *tetraDMOPipeline) Process(iq []complex64) {
 	p.rx.Process(iq)
+	p.maybeRearmGrant(p.now())
 	p.maybeLogStatus()
 }
 
@@ -179,16 +202,23 @@ func (p *tetraDMOPipeline) onBurst(b tetra.DMBurst) {
 	case tetra.DMBurstNormal:
 		p.dnbTotal++
 		now := p.now()
-		// Re-arm the grant after a traffic drought so the next PTT grants afresh.
-		if !p.lastDNB.IsZero() && now.Sub(p.lastDNB) > dmoGrantRearm {
-			p.grantActive = false
-			p.dnbSinceLock = 0
+		// Re-arm first, so a burst arriving after a long drought re-learns the grid
+		// (the next PTT is a new transmission with its own slot phase).
+		p.maybeRearmGrant(now)
+		// Qualify against the slot grid: an unqualified detection is a correlator
+		// false alarm and must not count as traffic anywhere below.
+		if !p.grid.Observe(b.Lead) {
+			return
 		}
+		p.dnbQualified++
 		p.lastDNB = now
 		p.dnbSinceLock++
 		p.recoverColour(b)
 		// Telemetry only: count CRC-valid TCH/S when the colour is known (the voice
-		// chain does the real decode). Cheap — a single decode at the known colour.
+		// chain does the real decode). This is a full Viterbi pass per burst (two when
+		// the soft decode fails and the hard fallback runs), which was unbounded while
+		// noise detections reached here; qualified bursts cap it at the ~17/s a real
+		// transmission produces, and only while one is in progress.
 		if p.colourKnown {
 			if len(tetra.DMBurstTCHSpeechSoft(b, p.colour)) == 2 ||
 				len(tetra.DMBurstTCHSpeech(b, p.colour)) == 2 {
@@ -197,6 +227,21 @@ func (p *tetraDMOPipeline) onBurst(b tetra.DMBurst) {
 		}
 		p.maybeGrant()
 	}
+}
+
+// maybeRearmGrant clears the grant edge (and the learned slot grid) once qualified
+// DNB traffic has been absent for dmoGrantRearm, so the next PTT transmission grants
+// afresh. Driven from Process as well as onBurst: with the grid gate in place an idle
+// channel produces no qualified bursts at all, so a burst-driven check alone would
+// never fire and the grant would latch for the life of the daemon.
+func (p *tetraDMOPipeline) maybeRearmGrant(now time.Time) {
+	if p.lastDNB.IsZero() || now.Sub(p.lastDNB) <= dmoGrantRearm {
+		return
+	}
+	p.grantActive = false
+	p.dnbSinceLock = 0
+	p.lastDNB = time.Time{}
+	p.grid.Reset()
 }
 
 // maybeLock publishes cc.locked once, on the first CRC-valid SCH/S with a parseable
@@ -237,15 +282,21 @@ func (p *tetraDMOPipeline) recoverColour(b tetra.DMBurst) {
 	p.colourCand = append(p.colourCand[:0], p.colourCand[keep:]...)
 }
 
-// maybeGrant publishes a tetra-dmo grant on the rising edge of a DNB traffic burst
-// train (after a short DNB-count guard). DMO carries no talkgroup, so GroupID is 0;
-// the engine does not de-duplicate zero-group grants, so this must fire exactly once
-// per transmission — grantActive gates that, re-armed only after dmoGrantRearm of DNB
-// silence. The recovered DM colour rides in TETRAColourExt so the voice chain can
-// descramble TCH/S; when it is not yet recovered the grant still fires (colour 0
-// hint) and the voice chain recovers it independently.
+// maybeGrant publishes a tetra-dmo grant on the rising edge of a QUALIFIED DNB
+// traffic burst train. DMO carries no talkgroup, so GroupID is 0; the engine does not
+// de-duplicate zero-group grants, so this must fire exactly once per transmission —
+// grantActive gates that, re-armed only after dmoGrantRearm of traffic silence. The
+// recovered DM colour rides in TETRAColourExt so the voice chain can descramble
+// TCH/S; when it is not yet recovered the grant still fires (colour 0 hint) and the
+// voice chain recovers it independently.
+//
+// The lock check is load-bearing, not belt-and-braces: dnbSinceLock is named for a
+// lock it never actually consulted, so before this the pipeline would grant on an
+// unlocked, silent channel. A DSB SCH/S lock is CRC- and SYNC-PDU-validated and so is
+// real evidence a DMO radio is on this frequency; qualified DNBs then say it is
+// transmitting traffic right now. Both are required.
 func (p *tetraDMOPipeline) maybeGrant() {
-	if p.grantActive || p.bus == nil || p.dnbSinceLock < dmoGrantMinDNB {
+	if p.grantActive || p.bus == nil || !p.locked || p.dnbSinceLock < dmoGrantMinDNB {
 		return
 	}
 	p.grantActive = true
@@ -283,6 +334,7 @@ func (p *tetraDMOPipeline) maybeLogStatus() {
 		"dsb_total", p.dsbTotal,
 		"dsb_schs_crc", p.dsbCRC,
 		"dnb_total", p.dnbTotal,
+		"dnb_qualified", p.dnbQualified,
 		"tch_crc", p.tchCRC,
 		"distinct_fn", len(p.fnSeen),
 		"colour", p.colour,
@@ -304,6 +356,11 @@ func (p *tetraDMOPipeline) BSCHCounts() (ok, fail int64) {
 func (p *tetraDMOPipeline) Reset() {
 	p.rx.Reset()
 	p.ext.Reset()
+	// The receiver re-anchors its dibit index, so the learned slot residue is stale.
+	p.grid.Reset()
+	p.grantActive = false
+	p.dnbSinceLock = 0
+	p.lastDNB = time.Time{}
 	p.pendingSoft = nil
 	p.lastLog = time.Time{}
 }

--- a/internal/scanner/ccdecoder/pipelines_dmo_test.go
+++ b/internal/scanner/ccdecoder/pipelines_dmo_test.go
@@ -2,8 +2,10 @@ package ccdecoder
 
 import (
 	"math"
+	"math/rand"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
 	"github.com/MattCheramie/GopherTrunk/internal/events"
@@ -18,6 +20,14 @@ import (
 const (
 	dmoTestSpeechBits = 137
 	dmoTestType4Bits  = 432
+)
+
+// Shared DMO test channel parameters: the production DDC target for
+// ProtocolTETRADMO (ddcTargetForProtocol) and the resulting samples per symbol.
+const (
+	dmoTestSampleRate = 144_000.0
+	dmoTestSPS        = 8 // 144000 / 18000
+	dmoTestFreqHz     = 438_900_000
 )
 
 func dmoSeqBits(seed, n int) []byte {
@@ -36,24 +46,60 @@ func dmoFiller(seed, n int) []uint8 {
 	return out
 }
 
+// DMO slot geometry in dibits, from EN 300 396-2 Tables 15/16 (the same table the
+// dmDSB*/dmDNB* offsets in tetra/dmo.go are derived from), expressed here as
+// positions WITHIN a 255-dibit timeslot rather than relative to the training lead:
+//
+//	DSB: freq-corr 7..47, SCH/S 47..107, sync train 107..126 (lead 107), BKN2 126..234
+//	DNB: BKN1 7..115, normal train 115..126 (lead 115), BKN2 126..234
+//
+// Both bursts occupy dibits 7..234 of their slot, leaving the real guard either side.
+// A synthetic stream MUST be laid out this way: a real transmitter emits one burst per
+// timeslot from one clock, so all its DNB leads share one residue mod 255 — the
+// property tetra.DMSlotGrid uses to tell traffic from correlator noise.
+const (
+	dmoTestSlotDibits = 255
+	dmoTestDSBLead    = 107
+	dmoTestDNBLead    = 115
+	dmoTestBurstStart = 7
+)
+
+// dmoSlot places a burst's fields into one 255-dibit timeslot, padding either side
+// with filler so the emitted slot is exactly dmoTestSlotDibits long.
+func dmoSlot(seed int, fields ...[]uint8) []uint8 {
+	slot := dmoFiller(seed, dmoTestSlotDibits)
+	at := dmoTestBurstStart
+	for _, f := range fields {
+		copy(slot[at:], f)
+		at += len(f)
+	}
+	if at != 234 {
+		panic("dmo test slot: burst ends at dibit " + string(rune('0'+at%10)) + ", want 234")
+	}
+	return slot
+}
+
 // buildDMODibitStream synthesizes a DMO transmission's demodulated dibit stream: a
 // long receiver lead-in, one DSB (SCH/S + SCH/H), then nDNB TCH/S DNBs scrambled with
-// colour, separated by filler. It mirrors the buildDSB/buildDNB layout the tetra
-// package tests use (EN 300 396-2 Tables 15/16), built from the exported encoders so
-// it can live in the ccdecoder package.
+// colour — every burst on its own 255-dibit timeslot, as a real radio transmits them.
+// It mirrors the buildDSB/buildDNB layout the tetra package tests use (EN 300 396-2
+// Tables 15/16), built from the exported encoders so it can live in the ccdecoder
+// package.
 func buildDMODibitStream(colour uint32, nDNB int) []uint8 {
 	b2d := tetra.TetraBitsToDibits
 	schs := b2d(tetra.EncodeBSCH(dmoSeqBits(1, 60)))
 	schh := b2d(tetra.EncodeSCHHD(dmoSeqBits(2, 124), 0))
 
 	var out []uint8
-	out = append(out, dmoFiller(0, 900)...) // lead-in: let Gardner/AFC/equalizer converge
+	// Lead-in (a whole number of slots): let Gardner/AFC/equalizer converge.
+	out = append(out, dmoFiller(0, 4*dmoTestSlotDibits)...)
 
-	// DSB: 40-dibit freq-corr + 60-dibit SCH/S + 19-dibit sync train + 108-dibit SCH/H.
-	out = append(out, dmoFiller(1, 40)...)
-	out = append(out, schs...)
-	out = append(out, tetra.SyncTrainingDibits()...)
-	out = append(out, schh...)
+	out = append(out, dmoSlot(1,
+		dmoFiller(3, dmoTestDSBLead-dmoTestBurstStart-60), // 40-dibit freq-corr field
+		schs,
+		tetra.SyncTrainingDibits(),
+		schh,
+	)...)
 
 	for i := 0; i < nDNB; i++ {
 		frameA := dmoSeqBits(7+i, dmoTestSpeechBits)
@@ -62,12 +108,10 @@ func buildDMODibitStream(colour uint32, nDNB int) []uint8 {
 		onair := framing.ScrambleTetra(type4, colour)
 		blk1 := b2d(onair[:dmoTestType4Bits/2])
 		blk2 := b2d(onair[dmoTestType4Bits/2:])
-		out = append(out, dmoFiller(11+i, 30)...)
-		out = append(out, blk1...)
-		out = append(out, tetra.NormalSyncDibits()...)
-		out = append(out, blk2...)
+		out = append(out, dmoSlot(11+i, blk1, tetra.NormalSyncDibits(), blk2)...)
 	}
-	out = append(out, dmoFiller(99, 600)...) // trailing filler so the last burst is inside the window
+	// Trailing filler so the last burst is inside the extractor's window.
+	out = append(out, dmoFiller(99, 3*dmoTestSlotDibits)...)
 	return out
 }
 
@@ -175,5 +219,213 @@ func TestTETRADMOPipelineLocksAndGrants(t *testing.T) {
 	}
 	if g.FrequencyHz != freqHz {
 		t.Errorf("grant freq=%d, want %d", g.FrequencyHz, freqHz)
+	}
+}
+
+// dmoTestEvents subscribes to bus and records the ordered lock/grant events the DMO
+// control path publishes, so a test can assert BOTH how many grants fired and that
+// none preceded the lock.
+type dmoTestEvents struct {
+	mu       sync.Mutex
+	locked   bool
+	grants   []trunking.Grant
+	preLock  int // grants published while the pipeline had not yet locked
+	drainEnd chan struct{}
+}
+
+func dmoWatch(bus *events.Bus) *dmoTestEvents {
+	w := &dmoTestEvents{drainEnd: make(chan struct{})}
+	sub := bus.Subscribe()
+	go func() {
+		defer close(w.drainEnd)
+		for ev := range sub.C {
+			w.mu.Lock()
+			switch ev.Kind {
+			case events.KindCCLocked:
+				w.locked = true
+			case events.KindGrant:
+				if g, ok := ev.Payload.(trunking.Grant); ok {
+					if !w.locked {
+						w.preLock++
+					}
+					w.grants = append(w.grants, g)
+				}
+			}
+			w.mu.Unlock()
+		}
+	}()
+	return w
+}
+
+// dmoNoiseIQ returns seconds' worth of complex Gaussian noise at the DMO channel
+// rate — an idle DMO frequency, which is what the channel looks like almost all the
+// time (EN 300 396-2: silent between transmissions).
+func dmoNoiseIQ(seconds float64, seed int64) []complex64 {
+	rng := rand.New(rand.NewSource(seed))
+	out := make([]complex64, int(seconds*dmoTestSampleRate))
+	for i := range out {
+		out[i] = complex(float32(rng.NormFloat64()*0.1), float32(rng.NormFloat64()*0.1))
+	}
+	return out
+}
+
+func dmoFeed(pl ProtocolPipeline, iq []complex64) {
+	const chunk = 4096
+	for i := 0; i < len(iq); i += chunk {
+		end := i + chunk
+		if end > len(iq) {
+			end = len(iq)
+		}
+		pl.Process(iq[i:end])
+	}
+}
+
+// dmoTestPipeline builds a DMO pipeline whose clock the test drives, so a
+// multi-second scenario runs in milliseconds and the 3 s grant re-arm is exercised
+// deterministically rather than by sleeping.
+func dmoTestPipeline(t *testing.T, bus *events.Bus, clock *time.Time) *tetraDMOPipeline {
+	t.Helper()
+	pl, err := newTETRADMOPipeline(PipelineOptions{
+		Bus:          bus,
+		SystemName:   "DMO",
+		FrequencyHz:  dmoTestFreqHz,
+		SampleRateHz: dmoTestSampleRate,
+		System:       trunking.System{Protocol: trunking.ProtocolTETRADMO},
+	})
+	if err != nil {
+		t.Fatalf("newTETRADMOPipeline: %v", err)
+	}
+	p := pl.(*tetraDMOPipeline)
+	p.now = func() time.Time { return *clock }
+	return p
+}
+
+// dmoModulate renders a dibit stream to IQ at the DMO channel rate with a light noise
+// floor (the blind CMA equalizer needs one to be well defined).
+func dmoModulate(dibits []uint8, seed int64) []complex64 {
+	iq := demod.ModulatePiOver4DQPSK(dibits, dmoTestSPS, 8, 0.35, math.Pi/4)
+	return demod.ApplyImpairments(iq, dmoTestSampleRate, demod.Impairments{SNRdB: 40, Seed: seed})
+}
+
+// TestTETRADMOPipelineIgnoresIdleChannel is the core regression for the reported
+// "as soon as I start GopherTrunk it starts call recording and grants" symptom. The
+// DNB correlator fires ~18 times a second on noise (see tetra/dmo_grid.go), and the
+// grant path used to take that at face value: four detections — about 230 ms — were
+// enough to publish a grant, open a voice chain and a recording session, on an idle
+// channel with no lock. Ten simulated seconds of an idle DMO frequency must produce
+// no lock, no grant, and no qualified DNB.
+func TestTETRADMOPipelineIgnoresIdleChannel(t *testing.T) {
+	bus := events.NewBus(256)
+	defer bus.Close()
+	w := dmoWatch(bus)
+	clock := time.Unix(1_760_000_000, 0)
+	p := dmoTestPipeline(t, bus, &clock)
+
+	dmoFeed(p, dmoNoiseIQ(10, 424242))
+
+	if p.dnbTotal == 0 {
+		t.Fatalf("no raw DNB detections on noise — the test is not exercising the gate")
+	}
+	if p.dnbQualified != 0 {
+		t.Errorf("qualified %d of %d noise DNB detections as traffic, want 0",
+			p.dnbQualified, p.dnbTotal)
+	}
+	if p.grantActive {
+		t.Errorf("grant fired on an idle channel (dnb_total=%d)", p.dnbTotal)
+	}
+	if p.locked {
+		t.Errorf("locked on an idle channel (dsb_total=%d dsb_crc=%d)", p.dsbTotal, p.dsbCRC)
+	}
+
+	bus.Close()
+	<-w.drainEnd
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if len(w.grants) != 0 {
+		t.Errorf("published %d grants on an idle channel, want 0", len(w.grants))
+	}
+}
+
+// TestTETRADMOPipelineGrantsOnlyAfterLock pins the ordering the grant guard now
+// enforces: dnbSinceLock was named for a lock the guard never consulted, so a grant
+// could precede cc.locked entirely.
+//
+// The idle-channel lead-in is what makes this bite, and it is what the operator
+// actually had: the daemon starts on a silent DMO frequency, and four correlator
+// false alarms — about 230 ms — were enough to grant long before any DSB appeared.
+func TestTETRADMOPipelineGrantsOnlyAfterLock(t *testing.T) {
+	bus := events.NewBus(256)
+	defer bus.Close()
+	w := dmoWatch(bus)
+	clock := time.Unix(1_760_000_000, 0)
+	p := dmoTestPipeline(t, bus, &clock)
+
+	dmoFeed(p, dmoNoiseIQ(3, 5150)) // silent channel before anyone keys up
+	if p.locked {
+		t.Fatalf("locked on the idle lead-in")
+	}
+	dmoFeed(p, dmoModulate(buildDMODibitStream(3, 40), 7))
+
+	bus.Close()
+	<-w.drainEnd
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if !w.locked {
+		t.Fatalf("pipeline did not lock")
+	}
+	if len(w.grants) == 0 {
+		t.Fatalf("no grant published for a real transmission")
+	}
+	if w.preLock != 0 {
+		t.Errorf("%d grant(s) published before cc.locked", w.preLock)
+	}
+}
+
+// TestTETRADMOPipelineRearmsBetweenTransmissions is the regression for the second
+// half of the report: after the bogus startup grant latched, the operator's real
+// 10 s PTT never granted and never recorded. The re-arm needed a DNB drought that the
+// ~18/s noise detections made impossible, and it was only ever evaluated when a burst
+// arrived — so on a genuinely silent channel it could not fire at all. A second
+// transmission after a silent gap must grant again.
+func TestTETRADMOPipelineRearmsBetweenTransmissions(t *testing.T) {
+	bus := events.NewBus(256)
+	defer bus.Close()
+	w := dmoWatch(bus)
+	clock := time.Unix(1_760_000_000, 0)
+	p := dmoTestPipeline(t, bus, &clock)
+
+	tx := dmoModulate(buildDMODibitStream(3, 40), 7)
+	gap := dmoNoiseIQ(1, 99) // idle channel, still raining false DNB detections
+
+	dmoFeed(p, tx)
+	afterFirst := p.dnbQualified
+	w.mu.Lock()
+	first := len(w.grants)
+	w.mu.Unlock()
+	if first != 1 {
+		t.Fatalf("first transmission published %d grants, want exactly 1", first)
+	}
+
+	// Silence long enough to clear the grant edge (the clock is ours to advance).
+	for i := 0; i < 5; i++ {
+		clock = clock.Add(time.Second)
+		dmoFeed(p, gap)
+	}
+	if p.grantActive {
+		t.Errorf("grant still armed after %v of silence", 5*time.Second)
+	}
+
+	clock = clock.Add(time.Second)
+	dmoFeed(p, dmoModulate(buildDMODibitStream(3, 40), 11))
+
+	if p.dnbQualified <= afterFirst {
+		t.Errorf("second transmission qualified no DNBs (%d → %d)", afterFirst, p.dnbQualified)
+	}
+	bus.Close()
+	<-w.drainEnd
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if len(w.grants) != 2 {
+		t.Errorf("published %d grants across two transmissions, want 2", len(w.grants))
 	}
 }

--- a/internal/scanner/cchunt/supervisor.go
+++ b/internal/scanner/cchunt/supervisor.go
@@ -325,9 +325,24 @@ func (s *Supervisor) runtime(name string) *systemRuntime {
 func (s *Supervisor) startRound(name string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if rt := s.states[name]; rt != nil {
-		rt.state = StateHunting
+	rt := s.states[name]
+	if rt == nil {
+		return
 	}
+	// A camped conventional / direct-mode system stays camped across its
+	// re-dwells: sitting on the frequency waiting for the next transmission IS
+	// the camp, not a fresh acquisition attempt. Overwriting it here left
+	// StateCamped set only for the few microseconds between markCamped
+	// returning and the next round starting, against a whole dwell of
+	// StateHunting — about a 0.1% duty cycle. Three things fell out of that:
+	// the TUI's "camped" badge (panels/scanner.go) never rendered, markCamped's
+	// transitioned guard logged every round instead of once (~25 INFO lines a
+	// second on a quiet channel), and TestSupervisorCampsIdleConventionalDMR
+	// was left racing a transient it usually lost. Issue #1036.
+	if rt.state == StateCamped {
+		return
+	}
+	rt.state = StateHunting
 }
 
 // SetIQHealthProvider wires an optional IQ-health source the supervisor

--- a/internal/scanner/cchunt/supervisor_test.go
+++ b/internal/scanner/cchunt/supervisor_test.go
@@ -1,7 +1,10 @@
 package cchunt
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -138,13 +141,22 @@ func TestSupervisorCampsIdleConventionalDMR(t *testing.T) {
 	go func() { _ = sup.Run(ctx) }()
 
 	// The channel never locks (no cc.locked is injected). Success = the
-	// system reaches StateCamped and keeps re-dwelling, with NO
-	// KindHuntFailed ever fired for it. Reaching StateCamped is itself
+	// system reaches StateCamped and STAYS there while it keeps re-dwelling,
+	// with NO KindHuntFailed ever fired for it. Reaching StateCamped is itself
 	// proof of the fix (the old code only ever produced StateFailed here).
+	//
+	// The durability half matters as much as reaching it. startRound used to
+	// overwrite StateCamped with StateHunting at the top of every round, so the
+	// state was set for microseconds out of each ~40 ms dwell: the operator-facing
+	// "camped" badge never rendered, markCamped's transitioned guard logged every
+	// round instead of once, and a level-sampling test like this one lost the race
+	// the majority of the time under load. Sampling once is therefore not enough —
+	// require the state to still read camped across several further rounds.
+	const wantCampedRounds = 3
 	deadline := time.After(2 * time.Second)
 	poll := time.NewTicker(10 * time.Millisecond)
 	defer poll.Stop()
-	sawCamped := false
+	campedAtTunes := -1
 	for {
 		select {
 		case ev := <-sub.C:
@@ -154,12 +166,22 @@ func TestSupervisorCampsIdleConventionalDMR(t *testing.T) {
 				}
 			}
 		case <-poll.C:
-			if sup.Snapshot()[0].State == StateCamped {
-				sawCamped = true
+			state := sup.Snapshot()[0].State
+			tunes := len(tuner.tuned())
+			if campedAtTunes < 0 {
+				if state == StateCamped {
+					campedAtTunes = tunes
+				}
+				continue
 			}
-			// Require several dwells' worth of quiet camping so a stray
-			// HuntFailed (or a backoff stall) would have surfaced.
-			if sawCamped && len(tuner.tuned()) >= 3 {
+			// Camped once — it must not fall back to hunting while it keeps
+			// re-dwelling on the same idle channel.
+			if state != StateCamped {
+				t.Fatalf("camped system reverted to %q after %d further tunes; "+
+					"StateCamped must persist across camped re-dwells (issue #1036)",
+					state, tunes-campedAtTunes)
+			}
+			if tunes-campedAtTunes >= wantCampedRounds {
 				return
 			}
 		case <-deadline:
@@ -167,6 +189,97 @@ func TestSupervisorCampsIdleConventionalDMR(t *testing.T) {
 				sup.Snapshot()[0].State, len(tuner.tuned()))
 		}
 	}
+}
+
+// TestSupervisorCampedStateSurvivesNextRound is the direct, timing-free
+// regression for the state-clobber half of issue #1036: startRound wrote
+// StateHunting unconditionally, so the StateCamped that markCamped had just set
+// was gone before the next dwell began. Driving the two calls in sequence pins
+// the ordering without depending on the scheduler.
+func TestSupervisorCampedStateSurvivesNextRound(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sup, err := New(Options{
+		Bus:   bus,
+		Tuner: &fakeTuner{},
+		Systems: []trunking.System{{
+			Name:            "ConvDMR",
+			Protocol:        trunking.ProtocolDMRTier2,
+			ControlChannels: []uint32{451_000_000},
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// First round: genuinely acquiring, so it reports hunting.
+	sup.startRound("ConvDMR")
+	if got := sup.Snapshot()[0].State; got != StateHunting {
+		t.Fatalf("first round state = %q, want %q", got, StateHunting)
+	}
+
+	sup.markCamped("ConvDMR")
+	if got := sup.Snapshot()[0].State; got != StateCamped {
+		t.Fatalf("state after markCamped = %q, want %q", got, StateCamped)
+	}
+
+	// The next re-dwell IS the camp — it must not reset the state.
+	sup.startRound("ConvDMR")
+	if got := sup.Snapshot()[0].State; got != StateCamped {
+		t.Fatalf("state after the next round = %q, want %q to persist (issue #1036)", got, StateCamped)
+	}
+}
+
+// TestSupervisorMarkCampedLogsOnce pins the de-spam guard in markCamped. It
+// computes transitioned := rt.state != StateCamped so a quiet channel logs on
+// entry only; because startRound reset the state between every pair of calls,
+// that was always true and an idle conventional channel emitted the INFO line
+// every dwell — roughly 25 lines a second, forever.
+func TestSupervisorMarkCampedLogsOnce(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	var buf lockedBuffer
+	sup, err := New(Options{
+		Bus:   bus,
+		Tuner: &fakeTuner{},
+		Log:   slog.New(slog.NewTextHandler(&buf, nil)),
+		Systems: []trunking.System{{
+			Name:            "ConvDMR",
+			Protocol:        trunking.ProtocolDMRTier2,
+			ControlChannels: []uint32{451_000_000},
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Five camped rounds, each preceded by the round start the hunt loop runs.
+	for i := 0; i < 5; i++ {
+		sup.startRound("ConvDMR")
+		sup.markCamped("ConvDMR")
+	}
+
+	if n := strings.Count(buf.String(), "camped on conventional channel"); n != 1 {
+		t.Errorf("logged the camp line %d times across 5 camped rounds, want 1 (issue #1036)", n)
+	}
+}
+
+// lockedBuffer is a concurrency-safe io.Writer for capturing slog output.
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }
 
 func TestSupervisorLocksAndParks(t *testing.T) {

--- a/internal/voice/composer/tetra_dmo_voice.go
+++ b/internal/voice/composer/tetra_dmo_voice.go
@@ -40,12 +40,15 @@ func (c *Composer) runTETRADMOVoiceChain(ctx context.Context, serial string, iqC
 	rs, _ := c.sink.(rawFrameSink)
 
 	dec := &dmoVoiceDecoder{
-		c:           c,
-		serial:      serial,
-		bt:          bt,
-		rs:          rs,
-		colour:      colourHint,
-		colourKnown: colourHint != 0,
+		c:      c,
+		serial: serial,
+		bt:     bt,
+		rs:     rs,
+		colour: colourHint,
+		// A non-zero hint from the grant is the pipeline's already-recovered colour
+		// (or the operator's tetra_colour_code override), so it counts as recovered.
+		colourKnown:     colourHint != 0,
+		colourRecovered: colourHint != 0,
 	}
 	ext := tetra.NewDMStreamExtractor(dec.onBurst)
 
@@ -72,7 +75,8 @@ func (c *Composer) runTETRADMOVoiceChain(ctx context.Context, serial string, iqC
 		c.log.Info("composer: tetra DMO voice follow ended",
 			"serial", serial, "dnb_bursts", dec.dnb.Load(),
 			"speech_frames", dec.speech.Load(), "bfi_count", dec.bfi.Load(),
-			"colour", dec.colour, "colour_known", dec.colourKnown)
+			"colour", dec.colour, "colour_recovered", dec.colourRecovered,
+			"colour_attempts", dec.colourTries)
 	}()
 
 	process := func(iq []complex64) {
@@ -106,6 +110,18 @@ const (
 	// confidence gate, decode the buffer at colour 0 (a clear radio-to-radio call) and
 	// stop buffering — an encrypted/unrecoverable call then simply yields no speech.
 	dmoVoiceColourMax = 120
+	// dmoVoiceColourMaxAttempts caps how many recovery passes to run, mirroring the
+	// control pipeline's dmoColourMaxAttempts.
+	//
+	// RecoverDMColourCode is a 64-colour brute force and each candidate is a full
+	// soft-Viterbi TCH/S decode over every buffered burst, plus a hard decode on the
+	// (usually failing) fallback path. Retrying it on EVERY arriving burst from buffer
+	// size 20 up to 120 is 64·Σ(20..120) ≈ 450 000 Viterbi decodes per call, crammed
+	// into the few seconds it takes to accumulate them — enough to starve the
+	// same-carrier IQ tap feeding this very chain ("voice tap dropped IQ to a lagging
+	// voice consumer"). Attempting only at batch boundaries, over a decimated buffer,
+	// brings it to the ~10k the control pipeline already budgets for.
+	dmoVoiceColourMaxAttempts = 6
 )
 
 // dmoVoiceDecoder holds the streaming DMO voice decode state for one call. All methods
@@ -120,9 +136,46 @@ type dmoVoiceDecoder struct {
 
 	colour      uint32
 	colourKnown bool
-	buffer      []tetra.DMBurst // DNBs awaiting colour recovery
+	// colourRecovered distinguishes "RecoverDMColourCode cleared its confidence
+	// gate" from "we gave up and fell back to colour 0", which colourKnown alone
+	// conflates — the end-of-call log used to claim colour_known=true colour=0 on a
+	// call where nothing was ever recovered.
+	colourRecovered bool
+	buffer          []tetra.DMBurst // DNBs awaiting colour recovery
+	// colourTries counts recovery passes run, capped at dmoVoiceColourMaxAttempts.
+	// sinceTry is how many bursts have arrived since the last pass, so the brute
+	// force runs once per batch instead of once per burst.
+	colourTries int
+	sinceTry    int
 
 	dnb, speech, bfi atomic.Uint64
+}
+
+// tryRecoverColour runs one capped colour-recovery pass and reports whether the
+// confidence gate was cleared.
+//
+// It scores only the FRESHEST dmoVoiceColourBatch bursts, not the whole buffer: the
+// gate needs a couple of dozen bursts to separate the true colour from the ~1/256
+// chance floor, so scoring more costs linearly more Viterbi work for no extra
+// discrimination. The full buffer is deliberately left intact — unlike the control
+// pipeline, which only wants the colour and can decimate, this chain must still
+// decode every buffered burst retroactively once the colour lands, or the start of
+// the transmission is lost from the recording.
+func (d *dmoVoiceDecoder) tryRecoverColour() bool {
+	d.colourTries++
+	d.sinceTry = 0
+	scored := d.buffer
+	if len(scored) > dmoVoiceColourBatch {
+		scored = scored[len(scored)-dmoVoiceColourBatch:]
+	}
+	c, _, ok := tetra.RecoverDMColourCode(scored)
+	if !ok {
+		return false
+	}
+	d.colour, d.colourKnown, d.colourRecovered = c, true, true
+	d.c.log.Info("composer: tetra DMO colour code recovered",
+		"serial", d.serial, "colour", c, "attempt", d.colourTries)
+	return true
 }
 
 // onBurst handles one streamed DMO burst. DSBs carry no speech (signalling only), so
@@ -139,17 +192,23 @@ func (d *dmoVoiceDecoder) onBurst(b tetra.DMBurst) {
 		return
 	}
 	d.buffer = append(d.buffer, b)
+	d.sinceTry++
 	if len(d.buffer) < dmoVoiceColourBatch {
 		return
 	}
-	if c, _, ok := tetra.RecoverDMColourCode(d.buffer); ok {
-		d.colour, d.colourKnown = c, true
-		d.c.log.Info("composer: tetra DMO colour code recovered", "serial", d.serial, "colour", c)
-	} else if len(d.buffer) >= dmoVoiceColourMax {
+	// Attempt only once per batch of fresh bursts, and only up to the attempt cap —
+	// re-running the 64-colour brute force on every arriving burst is what made this
+	// chain starve its own IQ tap.
+	canTry := d.colourTries < dmoVoiceColourMaxAttempts &&
+		(d.colourTries == 0 || d.sinceTry >= dmoVoiceColourBatch)
+	switch {
+	case canTry && d.tryRecoverColour():
+		// Recovered; fall through and flush the buffer.
+	case len(d.buffer) >= dmoVoiceColourMax || d.colourTries >= dmoVoiceColourMaxAttempts:
 		// Give up recovering; assume clear colour 0. A genuinely encrypted call then
 		// yields no CRC-valid speech (bfi), which the hangtime ends normally.
 		d.colour, d.colourKnown = 0, true
-	} else {
+	default:
 		return // keep buffering
 	}
 	buf := d.buffer
@@ -183,16 +242,20 @@ func (d *dmoVoiceDecoder) emit(b tetra.DMBurst) {
 }
 
 // flush decodes any DNBs still buffered awaiting colour recovery at end-of-call. If the
-// colour never cleared the confidence gate, it makes a final best-effort attempt over
-// the whole buffer, then falls back to colour 0 so a short clear call is not dropped.
+// colour never cleared the confidence gate, it makes a final best-effort attempt, then
+// falls back to colour 0 so a short clear call is not dropped.
+//
+// The fallback sets colourKnown (the buffer is about to be decoded at SOME colour) but
+// deliberately NOT colourRecovered, so the end-of-call log distinguishes "recovered
+// colour 0" from "never recovered anything". Setting the flag unconditionally is what
+// made a call that decoded nothing report `colour=0 colour_known=true`, which reads as
+// a successful recovery.
 func (d *dmoVoiceDecoder) flush() {
 	if len(d.buffer) == 0 {
 		return
 	}
 	if !d.colourKnown {
-		if c, _, ok := tetra.RecoverDMColourCode(d.buffer); ok {
-			d.colour = c
-		}
+		d.tryRecoverColour()
 		d.colourKnown = true
 	}
 	buf := d.buffer

--- a/internal/voice/composer/tetra_dmo_voice_test.go
+++ b/internal/voice/composer/tetra_dmo_voice_test.go
@@ -145,3 +145,125 @@ func TestDMOVoiceDecoderUsesGrantColour(t *testing.T) {
 		t.Fatalf("emitted %d speech frames, want %d", len(sink.frames), 2*len(want))
 	}
 }
+
+// buildDMOUndecodableDNBs builds n well-formed DNBs (correct geometry and training
+// sequence, so the extractor finds them) carrying payload that is not a valid TCH/S
+// codeword at any colour — an encrypted call, or a transmission too weak to decode.
+// Every colour then sits at the ~1/256 chance floor, so RecoverDMColourCode's
+// confidence gate correctly never clears: the path that used to burn ~450k Viterbi
+// decodes per call.
+func buildDMOUndecodableDNBs(t *testing.T, n int) []tetra.DMBurst {
+	t.Helper()
+	var dibits []uint8
+	dibits = append(dibits, dmoVFiller(0, 50)...)
+	for i := 0; i < n; i++ {
+		dibits = append(dibits, dmoVFiller(11+i, 30)...)
+		dibits = append(dibits, dmoVFiller(200+i*7, 108)...) // BKN1: not a TCH/S codeword
+		dibits = append(dibits, tetra.NormalSyncDibits()...)
+		dibits = append(dibits, dmoVFiller(500+i*13, 108)...) // BKN2
+	}
+	dibits = append(dibits, dmoVFiller(99, 200)...)
+
+	var dnbs []tetra.DMBurst
+	for _, b := range tetra.ExtractDMBurstsSoft(dibits, dmoVIdealDiffs(dibits), 0) {
+		if b.Kind == tetra.DMBurstNormal {
+			dnbs = append(dnbs, b)
+		}
+	}
+	if len(dnbs) < n {
+		t.Fatalf("built %d DNB bursts, want at least %d", len(dnbs), n)
+	}
+	return dnbs
+}
+
+// TestDMOVoiceDecoderBoundsColourRecovery pins the cost bound on the 64-colour brute
+// force. RecoverDMColourCode is a full soft-Viterbi TCH/S decode per colour per burst
+// (plus a hard decode on the failing fallback), and it used to be re-run on EVERY
+// arriving burst from buffer size 20 to 120 — 64·Σ(20..120) ≈ 450 000 decodes per
+// call, on exactly the calls that cannot be recovered anyway. That is what starved the
+// same-carrier IQ tap feeding this chain. It must now run at most
+// dmoVoiceColourMaxAttempts times, scoring a bounded window.
+func TestDMOVoiceDecoderBoundsColourRecovery(t *testing.T) {
+	bursts := buildDMOUndecodableDNBs(t, 200)
+	sink := &fakeDMOSink{}
+	c := &Composer{log: slog.New(slog.NewTextHandler(io.Discard, nil)), hangtime: time.Second}
+	dec := &dmoVoiceDecoder{c: c, serial: "s", bt: c.newBoundaryTracker("s", 0, nil), rs: sink}
+
+	for _, b := range bursts {
+		dec.onBurst(b)
+	}
+	dec.flush()
+
+	if dec.colourTries > dmoVoiceColourMaxAttempts {
+		t.Errorf("ran %d colour-recovery passes, want at most %d",
+			dec.colourTries, dmoVoiceColourMaxAttempts)
+	}
+	if dec.colourTries == 0 {
+		t.Errorf("never attempted colour recovery — the test is not exercising the path")
+	}
+	if len(sink.frames) != 0 {
+		t.Errorf("emitted %d speech frames from undecodable bursts, want 0", len(sink.frames))
+	}
+}
+
+// TestDMOVoiceDecoderDoesNotClaimUnrecoveredColour is the honesty regression for the
+// end-of-call log. flush() used to set colourKnown = true OUTSIDE the confidence-gate
+// branch, so a call where nothing was ever recovered reported `colour=0
+// colour_known=true` — which reads as "recovered colour 0" and sent the investigation
+// after the wrong thing. The fallback still has to pick a colour to decode at, so
+// colourKnown is separate from colourRecovered.
+func TestDMOVoiceDecoderDoesNotClaimUnrecoveredColour(t *testing.T) {
+	bursts := buildDMOUndecodableDNBs(t, 60)
+	sink := &fakeDMOSink{}
+	c := &Composer{log: slog.New(slog.NewTextHandler(io.Discard, nil)), hangtime: time.Second}
+	dec := &dmoVoiceDecoder{c: c, serial: "s", bt: c.newBoundaryTracker("s", 0, nil), rs: sink}
+
+	for _, b := range bursts {
+		dec.onBurst(b)
+	}
+	dec.flush()
+
+	if dec.colourRecovered {
+		t.Errorf("reported colour %d as recovered when the confidence gate never cleared",
+			dec.colour)
+	}
+	if !dec.colourKnown {
+		t.Errorf("colourKnown = false after flush; the buffer would never be decoded")
+	}
+}
+
+// TestDMOVoiceDecoderKeepsBufferedSpeechAcrossAttempts guards the interaction between
+// the new attempt cap and the retroactive decode: the control pipeline decimates its
+// candidate buffer between passes because it only wants the colour, but this chain
+// must still emit every buffered burst once the colour lands, or the start of the
+// transmission is missing from the recording. Recovery is deliberately delayed past
+// the first attempt here by prefixing undecodable bursts.
+func TestDMOVoiceDecoderKeepsBufferedSpeechAcrossAttempts(t *testing.T) {
+	const colour = 3
+	good, want := buildDMODNBBursts(t, colour, 24)
+	bad := buildDMOUndecodableDNBs(t, dmoVoiceColourBatch)
+
+	sink := &fakeDMOSink{}
+	c := &Composer{log: slog.New(slog.NewTextHandler(io.Discard, nil)), hangtime: time.Second}
+	dec := &dmoVoiceDecoder{c: c, serial: "s", bt: c.newBoundaryTracker("s", 0, nil), rs: sink}
+
+	for _, b := range append(append([]tetra.DMBurst{}, bad...), good...) {
+		dec.onBurst(b)
+	}
+	dec.flush()
+
+	if !dec.colourRecovered || dec.colour != colour {
+		t.Fatalf("recovered colour=%d recovered=%v, want %d", dec.colour, dec.colourRecovered, colour)
+	}
+	// Every good burst's two speech frames must still be emitted, in order, even
+	// though they were buffered across more than one recovery attempt.
+	if len(sink.frames) != 2*len(want) {
+		t.Fatalf("emitted %d speech frames, want %d (buffered speech was dropped)",
+			len(sink.frames), 2*len(want))
+	}
+	for i, w := range want {
+		if !reflect.DeepEqual(sink.frames[2*i], w[0]) || !reflect.DeepEqual(sink.frames[2*i+1], w[1]) {
+			t.Errorf("DNB %d: emitted speech frame mismatch", i)
+		}
+	}
+}

--- a/web/src/api/spectrum.ts
+++ b/web/src/api/spectrum.ts
@@ -17,6 +17,12 @@ export interface SpectrumDevice {
   // applies. The symbol/constellation panels' "Auto" mode reads this to
   // pick the receiver without operator input.
   p25_modulation?: string;
+  // Symbol-stream receiver selector for the system this SDR is decoding
+  // ("p25-c4fm" | "p25-cqpsk" | "tetra" | "dmr"), or absent when no
+  // configured system matches. Protocol-aware, unlike p25_modulation,
+  // which only ever describes P25 Phase 1 systems — on a TETRA/DMO/DMR
+  // rig that was absent and "Auto" fell back to a P25 C4FM receiver.
+  symbol_proto?: string;
   // Configured control-channel frequency in this SDR's passband (Hz), or
   // absent when none matches. The Plots panels rest their view here so
   // they default off the centre DC spike onto a decodable channel. (#557)

--- a/web/src/api/symbols.test.ts
+++ b/web/src/api/symbols.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { autoProtoFor, demodModeToProto } from "./symbols";
+
+describe("autoProtoFor", () => {
+  // The regression: p25_modulation is only ever populated for P25 Phase 1
+  // systems, so a TETRA / TETRA DMO / DMR rig sent nothing and "Auto" fell back
+  // to a P25 C4FM receiver. Demodulating a π/4-DQPSK carrier that way yields a
+  // meaningless-but-non-empty 4-level soft track, from which the panels computed
+  // an MER around 9 dB and latched "symbol: poor" forever — next to a correct
+  // "decode: clean" from the frame-error rate.
+  it("uses the daemon's protocol-aware selector for non-P25 systems", () => {
+    expect(autoProtoFor({ symbol_proto: "tetra" })).toBe("tetra");
+    expect(autoProtoFor({ symbol_proto: "dmr" })).toBe("dmr");
+  });
+
+  it("does not fall back to C4FM when the daemon knows the protocol", () => {
+    // A TETRA device carries no p25_modulation; the old path returned p25-c4fm.
+    expect(autoProtoFor({ symbol_proto: "tetra", p25_modulation: undefined }))
+      .toBe("tetra");
+    expect(demodModeToProto(undefined)).toBe("p25-c4fm"); // the old behaviour
+  });
+
+  it("prefers symbol_proto over p25_modulation when both are present", () => {
+    expect(autoProtoFor({ symbol_proto: "p25-cqpsk", p25_modulation: "c4fm" }))
+      .toBe("p25-cqpsk");
+  });
+
+  it("falls back to p25_modulation for a daemon too old to send symbol_proto", () => {
+    expect(autoProtoFor({ p25_modulation: "cqpsk" })).toBe("p25-cqpsk");
+    expect(autoProtoFor({ p25_modulation: "c4fm" })).toBe("p25-c4fm");
+  });
+
+  it("defaults to C4FM when nothing is known", () => {
+    expect(autoProtoFor(null)).toBe("p25-c4fm");
+    expect(autoProtoFor(undefined)).toBe("p25-c4fm");
+    expect(autoProtoFor({})).toBe("p25-c4fm");
+  });
+});

--- a/web/src/api/symbols.ts
+++ b/web/src/api/symbols.ts
@@ -40,12 +40,29 @@ export interface SymbolFrame {
   cma_error: number;
 }
 
+// autoProtoFor picks the symbol-stream receiver for a device in the panels'
+// "Auto" mode. It prefers the daemon's protocol-aware symbol_proto and only
+// falls back to inferring one from p25_modulation for a daemon too old to send
+// it.
+//
+// The distinction matters: p25_modulation is populated only for P25 Phase 1
+// systems, so on a TETRA, TETRA DMO or DMR rig it is absent and the fallback
+// yields p25-c4fm. That opens a 4-level C4FM receiver on a π/4-DQPSK carrier,
+// whose soft track is meaningless but non-empty — which is what made the
+// symbol-quality chip compute an MER around 9 dB and read "symbol: poor"
+// permanently while the decode chip correctly read "decode: clean".
+export function autoProtoFor(
+  device: { symbol_proto?: string; p25_modulation?: string } | null | undefined,
+): string {
+  return device?.symbol_proto || demodModeToProto(device?.p25_modulation);
+}
+
 // Map a device's reported P25 demod mode (from SpectrumDevice
 // .p25_modulation — the daemon's canonical "c4fm"/"cqpsk", with the
 // other ParseDemodMode spellings tolerated) to the symbol-stream proto
 // selector. Unknown / empty falls back to C4FM, matching the receiver's
-// default. Used by the panels' "Auto" mode to pick the receiver from the
-// system the SDR is actually decoding.
+// default. Prefer autoProtoFor, which consults the protocol-aware
+// symbol_proto first.
 export function demodModeToProto(mod: string | undefined | null): string {
   switch ((mod ?? "").toLowerCase()) {
     case "cqpsk":

--- a/web/src/components/SignalHealth.tsx
+++ b/web/src/components/SignalHealth.tsx
@@ -60,15 +60,19 @@ export function SymbolQualityChip({ quality }: { quality: Quality | null }) {
         : verdict === "poor"
           ? "err"
           : "neutral";
+  // Say WHICH measurement produced the verdict. The MER-like SNR only exists on
+  // a 4-level (C4FM) soft track; on TETRA / π-4-DQPSK there is no such track and
+  // the verdict comes from level balance instead. Naming it avoids the confusion
+  // of a "poor" chip with no visible reason next to a clean decode.
   const detail =
     quality?.snrDb != null
-      ? ` — SNR ${quality.snrDb.toFixed(1)} dB`
+      ? ` from level SNR (MER) ${quality.snrDb.toFixed(1)} dB`
       : quality
-        ? ` — balance ±${quality.balanceDev.toFixed(1)}%`
+        ? ` from level balance ±${quality.balanceDev.toFixed(1)}% (no 4-level soft track on this modulation)`
         : "";
   return (
     <span
-      title={`recovered-symbol quality (raw constellation SNR / eye${detail}) — a different axis from control-channel decode health`}
+      title={`recovered-symbol quality${detail} — a different axis from control-channel decode health`}
     >
       <Badge tone={tone}>
         symbol: {verdict === "unknown" ? "acquiring…" : verdict}

--- a/web/src/hooks/useLingeringActiveCalls.test.ts
+++ b/web/src/hooks/useLingeringActiveCalls.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import {
+  callDuration,
+  dedupeByTalkgroup,
+  liveCallCount,
+} from "./useLingeringActiveCalls";
+import type { LingeringCall } from "./useLingeringActiveCalls";
+
+// The hook's exported helpers are pure, so they are tested directly rather than
+// through a renderer. dedupeByTalkgroup is exercised via liveCallCount and the
+// roster shape the panels consume.
+
+function row(
+  over: Partial<LingeringCall> & { group_id: number; started_at: string },
+): LingeringCall {
+  const { group_id, started_at, ...rest } = over;
+  return {
+    grant: {
+      system: "DMO",
+      group_id,
+      source_id: 0,
+      frequency_hz: 438_900_000,
+      encrypted: false,
+      emergency: false,
+    },
+    started_at,
+    device_serial: "d",
+    following: true,
+    _ended: false,
+    _endMs: null,
+    ...rest,
+  } as unknown as LingeringCall;
+}
+
+describe("liveCallCount", () => {
+  // The reported symptom: the "Active calls" tile read 0 while a call row was
+  // visible right below it. The tile counted the raw poll response; the roster
+  // rendered the linger-augmented list, which still held the just-ended call.
+  it("counts the live rows the roster renders, not the ended ones", () => {
+    const rows = [
+      row({ group_id: 1, started_at: "2026-08-13T23:57:26Z" }),
+      row({ group_id: 2, started_at: "2026-08-13T23:57:20Z", _ended: true, _endMs: 1 }),
+    ];
+    expect(liveCallCount(rows)).toBe(1);
+  });
+
+  it("is zero when every row is a lingering ended call", () => {
+    const rows = [
+      row({ group_id: 1, started_at: "2026-08-13T23:57:26Z", _ended: true, _endMs: 1 }),
+    ];
+    expect(liveCallCount(rows)).toBe(0);
+  });
+});
+
+describe("callDuration", () => {
+  it("ticks while live and freezes once ended", () => {
+    const start = "2026-08-13T23:57:00Z";
+    const now = Date.parse("2026-08-13T23:57:34Z");
+    expect(callDuration(start, null, now)).toBe("00:34");
+    expect(callDuration(start, Date.parse("2026-08-13T23:57:09Z"), now)).toBe("00:09");
+  });
+
+  it("renders an em dash for an unparseable start", () => {
+    expect(callDuration("not-a-date", null, Date.now())).toBe("—");
+  });
+});
+
+describe("dedupeByTalkgroup", () => {
+  // The reported symptom: "funny spam of same TG in Active calls" — one
+  // talkgroup occupying three rows at once (an ended one, an untuned one, and a
+  // second talker), because the row key splits on source_id, timeslot and
+  // frequency while the daemon reports followed and observed-only calls from two
+  // separate maps.
+  it("collapses one talkgroup on one system to a single row", () => {
+    const rows = [
+      row({ group_id: 1020539, started_at: "2026-08-13T23:58:20Z", _ended: true, _endMs: 1 }),
+      row({ group_id: 1020539, started_at: "2026-08-13T23:58:10Z", following: false }),
+      row({ group_id: 1020539, started_at: "2026-08-13T23:58:25Z" }),
+    ];
+    const out = dedupeByTalkgroup(rows);
+    expect(out).toHaveLength(1);
+    // A followed live call is the most informative state — audio is recording.
+    expect(out[0].following).toBe(true);
+    expect(out[0]._ended).toBe(false);
+  });
+
+  it("prefers a live row over a lingering ended one", () => {
+    const out = dedupeByTalkgroup([
+      row({ group_id: 7, started_at: "2026-08-13T23:58:20Z", _ended: true, _endMs: 1 }),
+      row({ group_id: 7, started_at: "2026-08-13T23:58:25Z", following: false }),
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0]._ended).toBe(false);
+  });
+
+  it("keeps the earliest start so the duration spans the whole conversation", () => {
+    const out = dedupeByTalkgroup([
+      row({ group_id: 7, started_at: "2026-08-13T23:58:25Z" }),
+      row({ group_id: 7, started_at: "2026-08-13T23:58:05Z" }),
+    ]);
+    expect(out[0].started_at).toBe("2026-08-13T23:58:05Z");
+  });
+
+  it("keeps genuinely different talkgroups and systems apart", () => {
+    const a = row({ group_id: 1, started_at: "2026-08-13T23:58:00Z" });
+    const b = row({ group_id: 2, started_at: "2026-08-13T23:58:00Z" });
+    const c = row({ group_id: 1, started_at: "2026-08-13T23:58:00Z" });
+    (c.grant as { system: string }).system = "OTHER";
+    expect(dedupeByTalkgroup([a, b, c])).toHaveLength(3);
+  });
+});

--- a/web/src/hooks/useLingeringActiveCalls.ts
+++ b/web/src/hooks/useLingeringActiveCalls.ts
@@ -3,7 +3,7 @@ import type { ActiveCallDTO } from "../api/types";
 
 // How long an ended call keeps showing in the list (frozen) after it drops out
 // of GET /api/v1/calls/active, so an operator sees it come to rest with a final
-// duration and an "observed" (ended) marker instead of it just vanishing.
+// duration and an "ended" marker instead of it just vanishing.
 const LINGER_MS = 7_000;
 
 export interface LingeringCall extends ActiveCallDTO {
@@ -24,12 +24,54 @@ function callKey(c: ActiveCallDTO): string {
   return `${g.system}|${g.group_id}|${g.source_id ?? ""}|${g.timeslot ?? ""}|${g.frequency_hz}`;
 }
 
+// talkgroupKey identifies the CALL, as an operator thinks of it: one talkgroup
+// up on one system. Deliberately coarser than callKey — it drops source,
+// timeslot and frequency.
+function talkgroupKey(c: ActiveCallDTO): string {
+  return `${c.grant.system}|${c.grant.group_id}`;
+}
+
+// dedupeByTalkgroup collapses rows that describe the same talkgroup on the same
+// system down to one, so a single conversation is a single line in the roster.
+//
+// One talkgroup could previously produce three rows at once. The daemon reports
+// followed calls and control-channel-observed calls from two different maps
+// (engine.ActiveCalls / engine.ObservedCalls), keyed by system|talkgroup|timeslot,
+// while callKey above additionally splits on source_id and frequency_hz — so a
+// re-grant on another frequency, a second talker, or a followed call whose
+// observed-only sibling carries a different timeslot each opened a new row, and
+// the linger window kept the old ones on screen alongside.
+//
+// Preference order within a group: a live row beats a lingering ended one (the
+// call is still up), and among live rows a followed one beats an untuned one
+// (audio is being recorded, which is the more informative state). Ties keep the
+// earliest start so the duration reflects the whole conversation.
+export function dedupeByTalkgroup(rows: LingeringCall[]): LingeringCall[] {
+  const best = new Map<string, LingeringCall>();
+  const rank = (c: LingeringCall) => (c._ended ? 0 : c.following === false ? 1 : 2);
+  for (const c of rows) {
+    const k = talkgroupKey(c);
+    const cur = best.get(k);
+    if (
+      !cur ||
+      rank(c) > rank(cur) ||
+      (rank(c) === rank(cur) && c.started_at < cur.started_at)
+    ) {
+      best.set(k, c);
+    }
+  }
+  return [...best.values()];
+}
+
 // useLingeringActiveCalls augments the live active-call list with calls that
 // have just ended: when a call drops out of the poll it is kept for LINGER_MS,
 // marked _ended with a frozen _endMs, then removed. This is what lets the call
 // log show a call's final "call duration" (stopped, not still ticking) and flag
-// it "observed" while it is still on screen. Purely client-side — no backend
+// it "ended" while it is still on screen. Purely client-side — no backend
 // change; the daemon still just omits ended calls from the active endpoint.
+//
+// The result is de-duplicated by talkgroup (see dedupeByTalkgroup), so one
+// conversation is one row rather than one row per (source, timeslot, frequency).
 export function useLingeringActiveCalls(
   active: ActiveCallDTO[],
 ): LingeringCall[] {
@@ -84,7 +126,16 @@ export function useLingeringActiveCalls(
     }
     out.push({ ...call, _ended: ended, _endMs: endMs });
   }
-  return out;
+  return dedupeByTalkgroup(out);
+}
+
+// liveCallCount counts the rows that represent a call still up, for the
+// "Active calls" stat tile. It counts the SAME rows the roster renders (minus
+// the lingering ended ones), so the tile can no longer read 0 above a visible
+// call — it used to count the raw poll response while the roster rendered the
+// de-duplicated, linger-augmented list.
+export function liveCallCount(rows: LingeringCall[]): number {
+  return rows.reduce((n, c) => (c._ended ? n : n + 1), 0);
 }
 
 // callDuration formats a fixed mm:ss "call duration" that ticks while the call

--- a/web/src/hooks/useSignalQuality.ts
+++ b/web/src/hooks/useSignalQuality.ts
@@ -6,7 +6,7 @@ import {
   initialDeviceSerial,
   type SpectrumDevice,
 } from "../api/spectrum";
-import { demodModeToProto, openSymbolStream } from "../api/symbols";
+import { autoProtoFor, openSymbolStream } from "../api/symbols";
 import {
   computeQuality,
   WINDOW_SYMBOLS,
@@ -63,7 +63,7 @@ export function useSignalQuality(): SignalQualityState {
     () => devices.find((d) => d.serial === selected) ?? null,
     [devices, selected],
   );
-  const proto = demodModeToProto(device?.p25_modulation);
+  const proto = autoProtoFor(device);
   const offset =
     device?.control_channel_hz && device.center_hz
       ? device.control_channel_hz - device.center_hz

--- a/web/src/panels/Active.tsx
+++ b/web/src/panels/Active.tsx
@@ -40,7 +40,7 @@ export function Active() {
   const [now, setNow] = useState(() => Date.now());
 
   // Keep just-ended calls on screen (frozen) for a few seconds so the log shows
-  // a final "call duration" and an "observed" marker instead of the row
+  // a final "call duration" and an "ended" marker instead of the row
   // vanishing the instant the call drops from the poll.
   const rows = useLingeringActiveCalls(activeCalls);
 
@@ -145,7 +145,7 @@ export function Active() {
                 className="pill"
                 title="This call has ended; still shown briefly with its final duration before it clears from the log"
               >
-                observed
+                ended
               </span>
             ) : (
               r.following === false && (

--- a/web/src/panels/Constellation.tsx
+++ b/web/src/panels/Constellation.tsx
@@ -13,7 +13,7 @@ import {
   type IQPoint,
 } from "../api/diag";
 import {
-  demodModeToProto,
+  autoProtoFor,
   openSymbolStream,
   type SymbolFrame,
 } from "../api/symbols";
@@ -172,7 +172,7 @@ export function Constellation() {
   // falling back to C4FM when unknown; an explicit choice is used as-is.
   // The symbol stream and ideal-cluster markers both key off this.
   const effectiveProto = useMemo(
-    () => (proto === "auto" ? demodModeToProto(device?.p25_modulation) : proto),
+    () => (proto === "auto" ? autoProtoFor(device) : proto),
     [proto, device],
   );
 

--- a/web/src/panels/Dashboard.tsx
+++ b/web/src/panels/Dashboard.tsx
@@ -11,6 +11,7 @@ import { useLockedSystemSignal } from "../hooks/useLockedSystemSignal";
 import {
   useLingeringActiveCalls,
   callDuration,
+  liveCallCount,
 } from "../hooks/useLingeringActiveCalls";
 import { selectClientConfig, useShared } from "../store/shared";
 import type { EventDTO } from "../api/types";
@@ -48,7 +49,7 @@ export function Dashboard() {
   const lockedSignal = useLockedSystemSignal();
 
   // Freeze just-ended calls briefly so the roster shows a final duration +
-  // "observed" marker rather than the row blinking out.
+  // "ended" marker rather than the row blinking out.
   const callRows = useLingeringActiveCalls(activeCalls);
 
   useDataPoll({
@@ -116,7 +117,7 @@ export function Dashboard() {
       </div>
 
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
-        <StatCard label="Active calls" value={activeCalls.length} />
+        <StatCard label="Active calls" value={liveCallCount(callRows)} />
         <StatCard label="Systems" value={systems.length} />
         <StatCard label="Devices attached" value={devices.length} />
         <StatCard
@@ -173,12 +174,12 @@ export function Dashboard() {
                   {c.grant.encrypted && <span className="pill-warn">enc</span>}
                   {c.grant.emergency && <span className="pill-err">emerg</span>}
                   {c._ended ? (
-                    <span className="pill" title="This call has ended; still shown briefly before it clears">
-                      observed
+                    <span className="pill" title="This call has ended; still shown briefly with its final duration before it clears">
+                      ended
                     </span>
                   ) : (
                     c.following === false && (
-                      <span className="pill" title="Announced on the control channel; no voice tuner is following it">
+                      <span className="pill" title="Announced on the control channel, but no voice tuner is following it — no audio is being recorded. Add voice_taps or a voice SDR to decode more calls at once.">
                         untuned
                       </span>
                     )

--- a/web/src/panels/SymbolScope.tsx
+++ b/web/src/panels/SymbolScope.tsx
@@ -9,7 +9,7 @@ import {
   type SpectrumDevice,
 } from "../api/spectrum";
 import {
-  demodModeToProto,
+  autoProtoFor,
   openSymbolStream,
   type SymbolFrame,
 } from "../api/symbols";
@@ -106,7 +106,7 @@ export function SymbolScope() {
   // selected SDR's system is decoding (device.p25_modulation, C4FM when
   // unknown); an explicit choice is used verbatim.
   const effectiveProto = useMemo(
-    () => (proto === "auto" ? demodModeToProto(device?.p25_modulation) : proto),
+    () => (proto === "auto" ? autoProtoFor(device) : proto),
     [proto, device],
   );
 


### PR DESCRIPTION
The first on-air run of the production TETRA DMO path granted and opened a
recording ~230 ms after the daemon started, on a silent channel with no lock,
and then never granted again — the operator's real 10 s PTT (which did lock:
dsb_schs_crc=46/54) produced no recording at all.

Both symptoms are one root cause: a raw DNB detection is not evidence of
traffic. The DNB detector is an 11-dibit training-sequence correlation at
tolerance 2 run under eight matched filters (two sequences x four rotations),
so the sequences matching by chance number

    sum_{k<=2} C(11,k)*3^k = 1 + 33 + 495 = 529   of 4^11

giving p ~ 1.26e-4 per position per filter, ~1.0e-3 across the eight, and at
the 18 kdibit/s symbol rate about 18 false DNBs per second. A DMO channel is
silent between transmissions (EN 300 396-2), so that is what the detector
reports almost all the time. The operator's log shows exactly this rate:
dnb_total climbed 1076 -> 4541 in 185 s (18.7/s) while dsb_schs_crc stayed
frozen at 46.

Everything in the grant path keyed off that count. dmoGrantMinDNB=4 tripped in
~0.22 s; maybeGrant never consulted p.locked despite the counter being named
dnbSinceLock; and the 3 s re-arm drought could not elapse against a 55 ms mean
inter-arrival, and was only evaluated inside the DNB branch, so on a genuinely
silent channel it could not fire at all.

Add tetra.DMSlotGrid: a real transmission comes from one radio on one clock, so
every burst lands on the 255-dibit timeslot grid and all its DNB leads share one
residue mod 255, while correlator false alarms are uniform across all 255.
Voting the recent leads separates the two populations with no decode. Design
notes that cost thought:

  - The residue is LEARNED from the stream, not derived from a hardcoded
    DSB->DNB lead offset. A wrong constant there would silently stop DMO
    granting at all, which is worse than the over-granting it replaces.
  - The latch is centred on the agreeing leads rather than taken from the lead
    that completes the vote, or a jittering train sits on the edge of the +/-1
    band and half its bursts fall outside; a drift accumulator then follows
    symbol slips.
  - The latch is DROPPED when the burst train ends (dmGridTrainGap). Without
    that, the ~0.2/s of noise that lands on the latched residue keeps a finished
    transmission "alive" and the grant latches anyway — caught by the re-arm
    test, not by inspection.

The grant now also requires a real DSB lock, and the drought is evaluated from
Process (per IQ chunk) as well as from onBurst. The decode-status line reports
dnb_qualified alongside the raw dnb_total so the false-alarm rate stays visible.
Trade-off: a grant lands ~0.5 s into a transmission rather than instantly.

Also fixes two problems on the voice side that the same run exposed:

  - runTETRADMOVoiceChain re-ran the 64-colour RecoverDMColourCode over its
    entire, still-growing buffer on every arriving burst: 64*sum(20..120) ~
    450k Viterbi decodes per call, on exactly the calls (encrypted or too weak)
    that cannot be recovered anyway. That starved the same-carrier IQ tap
    feeding the chain ("voice tap dropped IQ to a lagging voice consumer",
    dropped_chunks=5904). Now capped at six passes over a bounded scoring
    window. Unlike the control pipeline it must NOT decimate the buffer — those
    bursts are decoded retroactively so the start of the transmission is not
    missing from the recording.
  - flush() set colourKnown = true outside the confidence-gate branch, so a call
    that decoded nothing logged colour=0 colour_known=true. That reads as
    "recovered colour 0" and sends the next investigation after the wrong thing;
    colourRecovered is now separate from the decode-at-some-colour fallback.

Failing-first: TestTETRADMOPipelineIgnoresIdleChannel, GrantsOnlyAfterLock and
RearmsBetweenTransmissions all fail against the old code (grant on noise, grant
before lock, no second grant) and pass with the gate. buildDMODibitStream now
lays bursts on a true 255-dibit slot grid — the old arbitrary-filler layout was
not a faithful transmitter and could not have caught this. dmo_grid_test.go pins
the qualifier itself, including 10 simulated seconds of the measured 18/s noise
rate qualifying nothing.

On-air A/B still gates #1003 (#764/#771): a green synthetic decode is not proof.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QVQyJd9yF1NQkH5RwY2tgU