### PR TITLE
soapyremote: timed stream start for multi-channel (MRC) activation

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -2059,6 +2059,7 @@ func (d *Daemon) buildRecorderAndVoiceDecoder(cfg config.Config, log *slog.Logge
 			OutDir:        cfg.Recordings.Dir,
 			SampleRate:    cfg.Recordings.SampleRate,
 			WriteRaw:      cfg.Recordings.WriteRaw,
+			WriteMBE:      cfg.Recordings.MBEFiles,
 			SkipEncrypted: cfg.Recordings.SkipEncrypted,
 			// Trunk-recorder .json sidecar per recording; tri-state, defaults ON.
 			WriteCallJSON:      cfg.Recordings.WriteCallJSON == nil || *cfg.Recordings.WriteCallJSON,

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -214,6 +214,10 @@ recordings:
       release_ms: 80     # envelope release (default 80)
       makeup_db: 0       # fixed post-compression gain (default 0)
   write_raw: true   # also append a .raw sidecar with the vocoder frames
+  mbe_files: false  # also write a dsd-fme-playable sidecar per call (.imb for
+                    # P25 Phase 1, .amb for DMR/NXDN/P25p2) so recordings can be
+                    # decoded offline with `dsd-fme -r <file>`; TETRA/ProVoice/
+                    # analog have no dsd-fme playback mode and produce none
   skip_encrypted: false  # don't write files for calls flagged encrypted.
                          # NOTE: true also suppresses the completed-call
                          # broadcast backends (webhook/rdioscanner) for

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1659,6 +1659,14 @@ type RecordingsConfig struct {
 	// byte-identical when disabled. Listed high so it's easy to find.
 	Enhance  EnhanceConfig `yaml:"enhance"`
 	WriteRaw bool          `yaml:"write_raw"`
+	// MBEFiles additionally writes a dsd-fme-playable MBE sidecar per call
+	// for protocols dsd-fme can play offline: <basename>.imb (P25 Phase 1
+	// IMBE) / <basename>.amb (DMR / NXDN / P25 Phase 2 AMBE+2), in dsd-fme's
+	// own cookie-headed container so `dsd-fme -r <file>` decodes it directly.
+	// Unlike the flat .raw (write_raw), these need no external knowledge of
+	// the frame size or protocol. TETRA ACELP / ProVoice / analog calls
+	// produce no MBE file (dsd-fme has no playback mode for them).
+	MBEFiles bool `yaml:"mbe_files"`
 	// SkipEncrypted, when true, suppresses recording of calls flagged
 	// encrypted. A call whose grant already signals encryption is never
 	// opened; a call whose encryption is only discovered mid-stream has

--- a/internal/configbuilder/fieldmeta.go
+++ b/internal/configbuilder/fieldmeta.go
@@ -265,6 +265,7 @@ var fieldMetas = map[string]FieldMeta{
 	"RecordingsConfig.Dir":                  {Label: "Directory", Help: "Output directory for per-call WAV recordings."},
 	"RecordingsConfig.SampleRate":           {Label: "Sample rate", Help: "Recorder PCM rate (4000–48000 Hz). Match audio.sample_rate to avoid a resample stage."},
 	"RecordingsConfig.WriteRaw":             {Help: "Also write the raw (un-equalized) audio alongside the processed WAV."},
+	"RecordingsConfig.MBEFiles":             {Label: "dsd-fme MBE files", Help: "Also write a dsd-fme-playable MBE sidecar per call — .imb for P25 Phase 1 IMBE, .amb for DMR/NXDN/P25 Phase 2 AMBE+2 — so recordings decode offline with `dsd-fme -r <file>`. Protocols dsd-fme can't play (TETRA, ProVoice, analog) produce no file."},
 	"RecordingsConfig.SkipEncrypted":        {Label: "Skip encrypted", Help: "Don't record calls flagged encrypted. Aborts and deletes the file if encryption is only detected mid-call."},
 	"RecordingsConfig.CryptoCapturePath":    {Label: "Crypto capture path", Help: "Research/offline: append each encrypted P25 Phase 1 superframe's Message Indicator + encrypted voice frames as JSONL for `gophertrunk cryptolab assess`, the security-test harness that attempts decryption by every applicable method and grades the cipher's resistance. Empty disables."},
 	"RecordingsConfig.Equalizer":            {Help: "Per-call CMA blind equalizer in the FM voice chain — useful on simulcast systems."},

--- a/internal/scanner/ccdecoder/decoder.go
+++ b/internal/scanner/ccdecoder/decoder.go
@@ -415,6 +415,14 @@ type Decoder struct {
 	// in New. A no-op on the hot path when nothing is subscribed.
 	voiceFan *voiceFanout
 
+	// dmoColour is the DM traffic colour code the active TETRA DMO pipeline
+	// has recovered (or was configured with), encoded colour<<1|1 so an
+	// unrecovered state (0) is distinguishable from a recovered colour 0.
+	// Written by the pipeline via PipelineOptions.TETRADMOColourSink on the
+	// decode goroutine, cleared in clearActiveLocked, read lock-free by voice
+	// chains via Decoder.TETRADMOColour (voicetap.go).
+	dmoColour atomic.Uint64
+
 	// sub is the bus subscription the Decoder uses to learn about
 	// KindHuntProgress retunes. Subscribed in New so the
 	// subscription is alive before any other goroutine
@@ -549,8 +557,11 @@ func New(opts Options) (*Decoder, error) {
 		metrics:      opts.Metrics,
 		fec:          opts.FEC,
 		autotune:     opts.Autotune,
-		voiceFan:     newVoiceFanout(log, opts.VoiceTapBufferChunks),
 	}
+	// Wired after the literal so the fanout's auto-sizing can read the
+	// decoder's pipeline rate at subscribe time (the rate is unknown until
+	// the first acquisition builds the DDC).
+	d.voiceFan = newVoiceFanout(log, opts.VoiceTapBufferChunks, d.PipelineRateHz)
 	empty := ""
 	d.activeSystem.Store(&empty)
 	if opts.IQCorrect {
@@ -791,6 +802,11 @@ func (d *Decoder) handleProgress(p trunking.HuntProgress) {
 		// autotune off this is always 0, so the published value is unchanged
 		// (issue #815).
 		CarrierBiasHz: func() float64 { return float64(d.autotuneApplied.Load()) },
+		// Publish the DMO pipeline's recovered DM colour so a same-carrier
+		// voice chain that started before recovery completed can adopt it
+		// (see Decoder.TETRADMOColour). Encoded known-bit-in-LSB so an
+		// unrecovered state is distinguishable from colour 0.
+		TETRADMOColourSink: func(c uint32) { d.dmoColour.Store(uint64(c)<<1 | 1) },
 	}
 	if d.fec != nil {
 		// Bind the system name so the pipeline reports a per-burst FEC
@@ -835,6 +851,9 @@ func (d *Decoder) clearActiveLocked() {
 		_ = d.active.Close()
 		d.active = nil
 	}
+	// A torn-down/retuned system's recovered DM colour must not leak into the
+	// next acquisition (a different DMO network may use a different colour).
+	d.dmoColour.Store(0)
 	// Drop the issue #402 zero-IF health window so the next pipeline
 	// re-baselines against its own fresh TSBK counters instead of
 	// diffing against the torn-down pipeline's totals.

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -96,6 +96,15 @@ type PipelineOptions struct {
 	// instead of the residual-only value that drops toward 0 once autotune
 	// re-centres the carrier (issue #815). Nil ⇒ residual only.
 	CarrierBiasHz func() float64
+
+	// TETRADMOColourSink, when non-nil, receives the DM traffic colour code
+	// the moment the DMO pipeline knows it (tetra_colour_code override at
+	// construction, or a confident RecoverDMColourCode). The decoder stores
+	// it and exposes it via Decoder.TETRADMOColour so an already-running
+	// same-carrier voice chain — whose grant structurally fired before
+	// recovery could complete — can adopt the colour instead of brute-forcing
+	// its own. Only newTETRADMOPipeline calls it. nil ⇒ zero overhead.
+	TETRADMOColourSink func(colour uint32)
 }
 
 // tapDibits / tapBits forward a recovered-symbol chunk to SymbolTap when

--- a/internal/scanner/ccdecoder/pipelines_dmo.go
+++ b/internal/scanner/ccdecoder/pipelines_dmo.go
@@ -96,12 +96,16 @@ func newTETRADMOPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 		rateHz:       opts.SampleRateHz,
 		now:          time.Now,
 		configColour: opts.System.TETRAColourCode,
+		colourSink:   opts.TETRADMOColourSink,
 		fnSeen:       map[uint8]struct{}{},
 		debug:        log.Enabled(context.Background(), slog.LevelDebug),
 	}
 	if p.configColour != 0 {
 		p.colour = p.configColour
 		p.colourKnown = true
+		if p.colourSink != nil {
+			p.colourSink(p.colour)
+		}
 	}
 	p.ext = tetra.NewDMStreamExtractor(p.onBurst)
 	p.grid = tetra.NewDMSlotGrid()
@@ -159,6 +163,13 @@ type tetraDMOPipeline struct {
 	colourKnown  bool
 	colourCand   []tetra.DMBurst
 	colourTries  int
+	// colourSink, when non-nil, is told the DM colour the moment it is known
+	// (config override at construction, or a confident recovery). The decoder
+	// exposes it to the same-carrier voice chain, which typically starts
+	// before recovery completes (the grant fires at dmoGrantMinDNB=4 bursts,
+	// recovery needs dmoColourBatch=20) and would otherwise brute-force the
+	// colour all over again — or fail to, on a noisy tap.
+	colourSink func(colour uint32)
 
 	// Lock + liveness.
 	locked bool
@@ -218,8 +229,10 @@ func (p *tetraDMOPipeline) onBurst(b tetra.DMBurst) {
 		// chain does the real decode). This is a full Viterbi pass per burst (two when
 		// the soft decode fails and the hard fallback runs), which was unbounded while
 		// noise detections reached here; qualified bursts cap it at the ~17/s a real
-		// transmission produces, and only while one is in progress.
-		if p.colourKnown {
+		// transmission produces, and only while one is in progress. Debug-gated: the
+		// counter only feeds the debug status line, so at INFO level the decode is
+		// pure waste on the control decode goroutine.
+		if p.debug && p.colourKnown {
 			if len(tetra.DMBurstTCHSpeechSoft(b, p.colour)) == 2 ||
 				len(tetra.DMBurstTCHSpeech(b, p.colour)) == 2 {
 				p.tchCRC++
@@ -242,6 +255,15 @@ func (p *tetraDMOPipeline) maybeRearmGrant(now time.Time) {
 	p.dnbSinceLock = 0
 	p.lastDNB = time.Time{}
 	p.grid.Reset()
+	// A drought ends the transmission, so the colour-recovery attempt budget is
+	// per-transmission, not per-process: without this, six failed attempts (a
+	// weak first PTT, or noise-diluted early batches) disabled recovery for the
+	// daemon's lifetime — the operator's run showed colour_known=false forever
+	// while hundreds of later, perfectly decodable qualified DNBs arrived.
+	// Buffered candidates are stale for the same reason: bursts carried across
+	// a transmission boundary dilute the next attempt's dominance gate.
+	p.colourTries = 0
+	p.colourCand = p.colourCand[:0]
 }
 
 // maybeLock publishes cc.locked once, on the first CRC-valid SCH/S with a parseable
@@ -275,6 +297,9 @@ func (p *tetraDMOPipeline) recoverColour(b tetra.DMBurst) {
 		p.colour = c
 		p.colourKnown = true
 		p.log.Info("tetra dmo colour code recovered", "colour", c, "crc_valid_tchs", n, "system", p.system)
+		if p.colourSink != nil {
+			p.colourSink(c)
+		}
 	}
 	// Keep only the freshest half so the next attempt reflects current channel
 	// conditions rather than re-scoring stale bursts.
@@ -363,6 +388,11 @@ func (p *tetraDMOPipeline) Reset() {
 	p.lastDNB = time.Time{}
 	p.pendingSoft = nil
 	p.lastLog = time.Time{}
+	// Buffered colour candidates predate the re-anchor and the attempt budget is
+	// per-transmission (see maybeRearmGrant); a recovered/configured colour itself
+	// stays — the DM colour is a network constant, not receiver state.
+	p.colourTries = 0
+	p.colourCand = p.colourCand[:0]
 }
 
 func (p *tetraDMOPipeline) Close() error { return nil }

--- a/internal/scanner/ccdecoder/pipelines_dmo_test.go
+++ b/internal/scanner/ccdecoder/pipelines_dmo_test.go
@@ -1,6 +1,8 @@
 package ccdecoder
 
 import (
+	"io"
+	"log/slog"
 	"math"
 	"math/rand"
 	"sync"
@@ -167,7 +169,10 @@ func TestTETRADMOPipelineLocksAndGrants(t *testing.T) {
 	}()
 
 	pl, err := newTETRADMOPipeline(PipelineOptions{
-		Bus:          bus,
+		Bus: bus,
+		// Debug logger: the tch_crc telemetry decode this test asserts on is
+		// debug-gated (it only feeds the debug status line in production).
+		Log:          slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelDebug})),
 		SystemName:   "DMO",
 		FrequencyHz:  freqHz,
 		SampleRateHz: sampleRate,
@@ -378,6 +383,173 @@ func TestTETRADMOPipelineGrantsOnlyAfterLock(t *testing.T) {
 	}
 	if w.preLock != 0 {
 		t.Errorf("%d grant(s) published before cc.locked", w.preLock)
+	}
+}
+
+// buildDMOUndecodableDibitStream mirrors buildDMODibitStream — a lock-worthy DSB
+// followed by slot-aligned, correctly-trained DNBs — but the DNB payload blocks are
+// filler, not TCH/S codewords at any colour. The shape of an encrypted or
+// unreceivably-weak transmission: the grid qualifies every burst, but
+// RecoverDMColourCode's confidence gate can never clear.
+// dmoRandDibits returns n pseudo-random dibits (LCG-mixed). The periodic
+// dmoFiller pattern is fine as inter-burst guard, but as a 108-dibit payload it
+// modulates to a strong tone that upsets timing recovery / the CMA equalizer
+// and most bursts go undetected — random payload keeps the receiver honest.
+func dmoRandDibits(seed, n int) []uint8 {
+	s := uint32(seed)*2654435761 + 12345
+	out := make([]uint8, n)
+	for i := range out {
+		s = s*1664525 + 1013904223
+		out[i] = uint8(s >> 30)
+	}
+	return out
+}
+
+func buildDMOUndecodableDibitStream(nDNB int) []uint8 {
+	b2d := tetra.TetraBitsToDibits
+	schs := b2d(tetra.EncodeBSCH(dmoSeqBits(1, 60)))
+	schh := b2d(tetra.EncodeSCHHD(dmoSeqBits(2, 124), 0))
+
+	var out []uint8
+	out = append(out, dmoFiller(0, 4*dmoTestSlotDibits)...)
+	out = append(out, dmoSlot(1,
+		dmoFiller(3, dmoTestDSBLead-dmoTestBurstStart-60),
+		schs,
+		tetra.SyncTrainingDibits(),
+		schh,
+	)...)
+	for i := 0; i < nDNB; i++ {
+		out = append(out, dmoSlot(11+i,
+			dmoRandDibits(211+i*7, 108),
+			tetra.NormalSyncDibits(),
+			dmoRandDibits(509+i*13, 108),
+		)...)
+	}
+	out = append(out, dmoFiller(99, 3*dmoTestSlotDibits)...)
+	return out
+}
+
+// TestTETRADMOPipelineRecoversColourAfterRearm is the regression for the operator's
+// run where colour_known stayed false for the daemon's whole life: colourTries was
+// never reset, so six failed attempts on an early undecodable transmission disabled
+// colour recovery permanently — hundreds of later, perfectly decodable qualified DNBs
+// arrived with recovery already switched off. The attempt budget is per-transmission
+// now: a re-arm (traffic drought) clears colourTries and the stale candidate buffer,
+// so the next PTT recovers. Fails against the old code (colour never recovered on the
+// second transmission).
+func TestTETRADMOPipelineRecoversColourAfterRearm(t *testing.T) {
+	bus := events.NewBus(256)
+	defer bus.Close()
+	w := dmoWatch(bus)
+	clock := time.Unix(1_760_000_000, 0)
+	p := dmoTestPipeline(t, bus, &clock)
+
+	// First transmission: undecodable payload, long enough (~90 qualified DNBs) to
+	// burn all dmoColourMaxAttempts recovery attempts.
+	dmoFeed(p, dmoModulate(buildDMOUndecodableDibitStream(90), 7))
+	if p.colourKnown {
+		t.Fatalf("recovered a colour from undecodable payload (colour=%d)", p.colour)
+	}
+	if p.colourTries < dmoColourMaxAttempts {
+		t.Fatalf("burned %d attempts, want %d — the scenario is not exercising the cap",
+			p.colourTries, dmoColourMaxAttempts)
+	}
+
+	// Silence past the re-arm drought: the attempt budget must reset with the grid.
+	gap := dmoNoiseIQ(1, 99)
+	for i := 0; i < 5; i++ {
+		clock = clock.Add(time.Second)
+		dmoFeed(p, gap)
+	}
+	if p.colourTries != 0 {
+		t.Errorf("colourTries = %d after the re-arm drought, want 0", p.colourTries)
+	}
+	if len(p.colourCand) != 0 {
+		t.Errorf("%d stale colour candidates survived the re-arm, want 0", len(p.colourCand))
+	}
+
+	// Second transmission: clean colour-3 traffic must now recover.
+	clock = clock.Add(time.Second)
+	dmoFeed(p, dmoModulate(buildDMODibitStream(3, 40), 11))
+	if !p.colourKnown {
+		t.Fatalf("colour not recovered on a clean transmission after re-arm (tries=%d, qualified=%d)",
+			p.colourTries, p.dnbQualified)
+	}
+	if p.colour != 3 {
+		t.Errorf("recovered colour=%d, want 3", p.colour)
+	}
+
+	bus.Close()
+	<-w.drainEnd
+}
+
+// TestTETRADMOPipelinePublishesColourToSink pins the colour hand-off to the decoder:
+// the pipeline must call TETRADMOColourSink when recovery lands (and immediately for
+// a tetra_colour_code override), because the same-carrier voice chain's grant
+// structurally fires before recovery completes and polls the decoder for the answer.
+func TestTETRADMOPipelinePublishesColourToSink(t *testing.T) {
+	bus := events.NewBus(256)
+	defer bus.Close()
+	w := dmoWatch(bus)
+
+	var got []uint32
+	pl, err := newTETRADMOPipeline(PipelineOptions{
+		Bus:                bus,
+		SystemName:         "DMO",
+		FrequencyHz:        dmoTestFreqHz,
+		SampleRateHz:       dmoTestSampleRate,
+		System:             trunking.System{Protocol: trunking.ProtocolTETRADMO},
+		TETRADMOColourSink: func(c uint32) { got = append(got, c) },
+	})
+	if err != nil {
+		t.Fatalf("newTETRADMOPipeline: %v", err)
+	}
+	dmoFeed(pl, dmoModulate(buildDMODibitStream(3, 40), 7))
+	if len(got) != 1 || got[0] != 3 {
+		t.Errorf("colour sink calls = %v, want exactly [3]", got)
+	}
+
+	// A configured colour publishes at construction, before any IQ.
+	got = nil
+	_, err = newTETRADMOPipeline(PipelineOptions{
+		Bus:                bus,
+		SystemName:         "DMO",
+		FrequencyHz:        dmoTestFreqHz,
+		SampleRateHz:       dmoTestSampleRate,
+		System:             trunking.System{Protocol: trunking.ProtocolTETRADMO, TETRAColourCode: 44},
+		TETRADMOColourSink: func(c uint32) { got = append(got, c) },
+	})
+	if err != nil {
+		t.Fatalf("newTETRADMOPipeline (override): %v", err)
+	}
+	if len(got) != 1 || got[0] != 44 {
+		t.Errorf("override colour sink calls = %v, want exactly [44]", got)
+	}
+
+	bus.Close()
+	<-w.drainEnd
+}
+
+// TestDecoderTETRADMOColourRoundTrip pins the decoder-side store the sink writes
+// into: unknown until stored (distinguishing "colour 0" from "nothing known"), and
+// cleared when the active pipeline is torn down so one system's colour cannot leak
+// into the next acquisition.
+func TestDecoderTETRADMOColourRoundTrip(t *testing.T) {
+	d := &Decoder{}
+	if c, known := d.TETRADMOColour(); known || c != 0 {
+		t.Fatalf("fresh decoder colour = (%d, %v), want (0, false)", c, known)
+	}
+	d.dmoColour.Store(0<<1 | 1) // a recovered colour of literally 0 is still known
+	if c, known := d.TETRADMOColour(); !known || c != 0 {
+		t.Fatalf("stored colour 0 reads (%d, %v), want (0, true)", c, known)
+	}
+	d.dmoColour.Store(44<<1 | 1)
+	if c, known := d.TETRADMOColour(); !known || c != 44 {
+		t.Fatalf("stored colour 44 reads (%d, %v), want (44, true)", c, known)
+	}
+	d.clearActiveLocked()
+	if c, known := d.TETRADMOColour(); known || c != 0 {
+		t.Fatalf("colour after clearActiveLocked = (%d, %v), want (0, false)", c, known)
 	}
 }
 

--- a/internal/scanner/ccdecoder/voicetap.go
+++ b/internal/scanner/ccdecoder/voicetap.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"sync"
 	"sync/atomic"
 )
@@ -26,17 +27,56 @@ type voiceFanout struct {
 	subs map[int]*voiceSub
 	next int
 	log  *slog.Logger
-	// bufDepth is the per-subscriber channel capacity: how many post-DDC IQ
-	// chunks may queue before a lagging consumer starts dropping (issue #402).
-	// Configurable via recordings.voice_tap_buffer_chunks; 0 uses the default.
+	// bufDepth is the explicit per-subscriber channel capacity override
+	// (recordings.voice_tap_buffer_chunks); 0 auto-sizes each subscription
+	// from the pipeline rate at subscribe time (voiceTapBudget).
 	bufDepth int
+	// rateHz reports the channelised pipeline rate for auto-sizing. May be
+	// nil (tests); called OUTSIDE f.mu because the production getter
+	// (Decoder.PipelineRateHz) takes the decoder lock.
+	rateHz func() float64
 }
 
-// defaultVoiceTapBufferChunks is the per-subscriber buffer depth when none is
-// configured. Concurrent same-carrier calls share one tap consumer, so the
-// memory cost is a single buffer per active carrier — a depth well above the
-// original 64 buys jitter headroom for a few tens of KB.
+// defaultVoiceTapBufferChunks is the per-subscriber buffer depth floor.
+// Concurrent same-carrier calls share one tap consumer, so the memory cost is
+// a single buffer per active carrier — a depth well above the original 64
+// buys jitter headroom for a few tens of KB.
 const defaultVoiceTapBufferChunks = 128
+
+// Voice-tap auto-sizing. A fixed chunk COUNT is the wrong unit for this buffer
+// — the exact defect decodeQueueBudget already fixed for the decode queue
+// (decoder.go): SoapyRemote hands a remote SDR ~369-sample datagrams, which
+// decimate to ~53-sample post-DDC chunks, so 128 chunks was only ~47 ms at
+// 144 kHz. The DMO voice chain runs multi-tens-of-ms work bursts (colour
+// recovery Viterbi sweeps) on its drain goroutine, so every burst overflowed
+// the tap and starved the call's decode (the operator's dropped_chunks≈240
+// per call). Size from wall-clock instead: voiceTapSeconds of IQ at the
+// pipeline rate, assuming pessimistically small chunks so the slot count is
+// never the limiter.
+const (
+	voiceTapSeconds             = 1.0
+	voiceTapAssumedChunkSamples = 32
+	maxVoiceTapChunks           = 16384
+)
+
+// voiceTapBudget converts the channelised pipeline rate into a subscriber
+// buffer depth covering voiceTapSeconds, clamped to
+// [defaultVoiceTapBufferChunks, maxVoiceTapChunks]. An unknown rate (0 —
+// subscriber attached before the first pipeline built the DDC) falls back to
+// the floor.
+func voiceTapBudget(rateHz float64) int {
+	if rateHz <= 0 {
+		return defaultVoiceTapBufferChunks
+	}
+	depth := int(math.Ceil(voiceTapSeconds * rateHz / voiceTapAssumedChunkSamples))
+	if depth < defaultVoiceTapBufferChunks {
+		return defaultVoiceTapBufferChunks
+	}
+	if depth > maxVoiceTapChunks {
+		return maxVoiceTapChunks
+	}
+	return depth
+}
 
 // voiceSub is one subscriber's channel plus its dropped-chunk counter. A drop
 // is a gap of missing IQ delivered to the followed call's voice chain, which
@@ -48,14 +88,14 @@ type voiceSub struct {
 	drops atomic.Uint64
 }
 
-func newVoiceFanout(log *slog.Logger, bufDepth int) *voiceFanout {
+func newVoiceFanout(log *slog.Logger, bufDepth int, rateHz func() float64) *voiceFanout {
 	if log == nil {
 		log = slog.Default()
 	}
-	if bufDepth <= 0 {
-		bufDepth = defaultVoiceTapBufferChunks
+	if bufDepth < 0 {
+		bufDepth = 0
 	}
-	return &voiceFanout{subs: map[int]*voiceSub{}, log: log, bufDepth: bufDepth}
+	return &voiceFanout{subs: map[int]*voiceSub{}, log: log, bufDepth: bufDepth, rateHz: rateHz}
 }
 
 // subscribe registers a voice subscriber and returns its IQ channel plus an
@@ -64,7 +104,18 @@ func newVoiceFanout(log *slog.Logger, bufDepth int) *voiceFanout {
 // that wants the count — e.g. a triggered DDC capture reporting whether the grab
 // has gaps — can read it; callers that don't care simply ignore the return.
 func (f *voiceFanout) subscribe() (<-chan []complex64, func() uint64) {
-	sub := &voiceSub{ch: make(chan []complex64, f.bufDepth)}
+	depth := f.bufDepth
+	if depth <= 0 {
+		// Auto-size from the pipeline rate, resolved OUTSIDE f.mu (the getter
+		// takes the decoder lock). By subscribe time the DDC exists, so the
+		// rate is real; a 0 rate clamps to the floor.
+		var rate float64
+		if f.rateHz != nil {
+			rate = f.rateHz()
+		}
+		depth = voiceTapBudget(rate)
+	}
+	sub := &voiceSub{ch: make(chan []complex64, depth)}
 	f.mu.Lock()
 	id := f.next
 	f.next++
@@ -141,6 +192,20 @@ func (d *Decoder) PipelineRateHz() float64 {
 	return d.pipelineRateHz
 }
 
+// TETRADMOColour reports the DM traffic colour code the active TETRA DMO
+// pipeline knows (config override or a confident RecoverDMColourCode), and
+// whether one is known at all. Lock-free; safe from any goroutine. A voice
+// chain whose grant fired before recovery completed polls this to adopt the
+// pipeline's colour instead of brute-forcing its own (see
+// composer.runTETRADMOVoiceChain).
+func (d *Decoder) TETRADMOColour() (uint32, bool) {
+	v := d.dmoColour.Load()
+	if v&1 == 0 {
+		return 0, false
+	}
+	return uint32(v >> 1), true
+}
+
 // CCVoiceSource adapts a control-channel Decoder into a voice device that
 // streams the control carrier's own IQ for a same-carrier grant — no second
 // SDR, no retune. It satisfies the voice composer's IQSource, the trunking
@@ -192,6 +257,17 @@ func (s *CCVoiceSource) CanTune(hz uint32) bool {
 	}
 	cc := dec.CenterFreqHz()
 	return cc != 0 && hz == cc
+}
+
+// TETRADMOColour delegates to the backing Decoder's recovered DM colour;
+// (0, false) while no decoder exists or nothing is known. The composer
+// type-asserts for this so a dedicated voice SDR (no CC decoder) simply
+// lacks the capability.
+func (s *CCVoiceSource) TETRADMOColour() (uint32, bool) {
+	if dec := s.get(); dec != nil {
+		return dec.TETRADMOColour()
+	}
+	return 0, false
 }
 
 func (s *CCVoiceSource) SampleRateHz() uint32 {

--- a/internal/scanner/ccdecoder/voicetap_test.go
+++ b/internal/scanner/ccdecoder/voicetap_test.go
@@ -12,7 +12,7 @@ import (
 // TestVoiceFanoutDeliversCopies verifies subscribers get their own copy of each
 // broadcast chunk and that a broadcast with no subscribers is a no-op.
 func TestVoiceFanoutDeliversCopies(t *testing.T) {
-	f := newVoiceFanout(nil, 0)
+	f := newVoiceFanout(nil, 0, nil)
 	f.broadcast([]complex64{1, 2, 3}) // no subscribers: must not panic/block
 
 	ch, unsub := f.subscribe()
@@ -42,7 +42,7 @@ func TestVoiceFanoutDeliversCopies(t *testing.T) {
 // starvation diagnostic) rather than lost silently.
 func TestVoiceFanoutDropsWhenFull(t *testing.T) {
 	var logs bytes.Buffer
-	f := newVoiceFanout(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn})), 0)
+	f := newVoiceFanout(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn})), 0, nil)
 	_, unsub := f.subscribe()
 	for i := 0; i < 1000; i++ {
 		f.broadcast([]complex64{complex(float32(i), 0)}) // never blocks despite full buffer
@@ -63,7 +63,7 @@ func TestVoiceFanoutDropsWhenFull(t *testing.T) {
 // logs nothing at unsubscribe (no false starvation warnings).
 func TestVoiceFanoutNoDropWarningWhenDrained(t *testing.T) {
 	var logs bytes.Buffer
-	f := newVoiceFanout(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn})), 0)
+	f := newVoiceFanout(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn})), 0, nil)
 	ch, unsub := f.subscribe()
 	done := make(chan struct{})
 	go func() {
@@ -89,7 +89,7 @@ func TestVoiceFanoutNoDropWarningWhenDrained(t *testing.T) {
 // zero drops.
 func TestVoiceFanoutHonoursConfiguredDepth(t *testing.T) {
 	const depth = 4
-	f := newVoiceFanout(nil, depth)
+	f := newVoiceFanout(nil, depth, nil)
 	_, unsub := f.subscribe() // never drained
 
 	// The first `depth` chunks fit; each subsequent one drops.
@@ -102,6 +102,40 @@ func TestVoiceFanoutHonoursConfiguredDepth(t *testing.T) {
 	f.broadcast([]complex64{complex(99, 0)}) // (depth+1)th: must drop
 	if got := unsub(); got != 1 {
 		t.Fatalf("dropped %d chunks after exceeding depth %d, want exactly 1", got, depth)
+	}
+}
+
+// TestVoiceTapAutoDepthCoversOneSecond is the regression for the DMO
+// starvation half of issue #1003's on-air failure: with no explicit depth
+// configured, the tap must auto-size from the pipeline rate to at least
+// voiceTapSeconds of IQ at SoapyRemote's observed ~53-sample post-DDC chunks
+// — the old fixed 128-chunk buffer held only ~47 ms at 144 kHz, so every
+// colour-recovery Viterbi sweep on the chain goroutine overflowed it and
+// starved the call it was serving.
+func TestVoiceTapAutoDepthCoversOneSecond(t *testing.T) {
+	const rateHz = 144_000.0
+	const observedChunkSamples = 53
+	f := newVoiceFanout(nil, 0, func() float64 { return rateHz })
+	ch, unsub := f.subscribe()
+	defer unsub()
+	if got := float64(cap(ch) * observedChunkSamples); got < rateHz {
+		t.Fatalf("auto depth %d chunks ≈ %.0f samples at %d samples/chunk, want ≥ %.0f (1 s at %.0f Hz)",
+			cap(ch), got, observedChunkSamples, rateHz, rateHz)
+	}
+
+	// An unknown rate (pre-acquisition) falls back to the floor, and an
+	// explicit configured depth still wins over auto-sizing.
+	fUnknown := newVoiceFanout(nil, 0, func() float64 { return 0 })
+	chU, unsubU := fUnknown.subscribe()
+	defer unsubU()
+	if cap(chU) != defaultVoiceTapBufferChunks {
+		t.Errorf("unknown-rate depth = %d, want floor %d", cap(chU), defaultVoiceTapBufferChunks)
+	}
+	fExplicit := newVoiceFanout(nil, 7, func() float64 { return rateHz })
+	chE, unsubE := fExplicit.subscribe()
+	defer unsubE()
+	if cap(chE) != 7 {
+		t.Errorf("explicit depth = %d, want 7 (config override beats auto)", cap(chE))
 	}
 }
 
@@ -119,7 +153,7 @@ func unsubDropCount(f *voiceFanout) uint64 {
 // TestCCVoiceSourceSameCarrierGate checks the tap binds only the CC's current
 // carrier and streams until the context ends.
 func TestCCVoiceSourceSameCarrierGate(t *testing.T) {
-	d := &Decoder{voiceFan: newVoiceFanout(nil, 0), activeFreqHz: 467_913_000, pipelineRateHz: 144_000}
+	d := &Decoder{voiceFan: newVoiceFanout(nil, 0, nil), activeFreqHz: 467_913_000, pipelineRateHz: 144_000}
 	src := NewCCVoiceSource(func() *Decoder { return d }, "cc:SDR1")
 
 	// A nil decoder (before startup / after teardown) stays inert.

--- a/internal/sdr/soapyremote/driver.go
+++ b/internal/sdr/soapyremote/driver.go
@@ -532,14 +532,7 @@ func (d *device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 		return nil, fmt.Errorf("soapyremote: initial stream ack: %w", err)
 	}
 
-	// ACTIVATE_STREAM (streamId, flags=0, timeNs=0, numElems=0).
-	if err := d.rpcVoid(func(p *packer) {
-		p.call(callActivateStream)
-		p.i32(streamID)
-		p.i32(0)
-		p.i64(0)
-		p.i32(0)
-	}); err != nil {
+	if err := d.activateStream(streamID); err != nil {
 		d.clearStreamConns()
 		return nil, err
 	}
@@ -561,6 +554,63 @@ func (d *device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 	}
 	go d.streamLoop(ctx, dataConn, streamID, out)
 	return out, nil
+}
+
+// activateStream issues ACTIVATE_STREAM. A single-channel stream starts
+// immediately (flags=0, timeNs=0). A multi-channel (MRC diversity) stream must
+// instead start at a scheduled device timestamp: UHD rejects an immediate
+// start on a multi-channel streamer ("Invalid recv stream command - stream now
+// on multiple channels in a single streamer will fail to time align") because
+// the two receive chains can only be sample-aligned by starting both at the
+// same hardware time. So under diversity we read the remote hardware clock and
+// schedule the start diversityActivateLead in the future (SOAPY_SDR_HAS_TIME).
+// Remotes without a hardware clock — or that reject the timed form — fall back
+// to the immediate start, preserving the single-channel behaviour.
+func (d *device) activateStream(streamID int32) error {
+	if d.rxChannelCount() > 1 {
+		hw, err := d.getHardwareTime()
+		if err == nil {
+			err = d.rpcVoid(func(p *packer) {
+				p.call(callActivateStream)
+				p.i32(streamID)
+				p.i32(soapyFlagHasTime)
+				p.i64(hw + diversityActivateLead.Nanoseconds())
+				p.i32(0)
+			})
+			if err == nil {
+				return nil
+			}
+		}
+		if errors.Is(err, errClosed) {
+			return err
+		}
+		d.log.Debug("soapyremote: timed multi-channel stream start unavailable; falling back to immediate start",
+			"addr", d.addr, "err", err)
+	}
+	return d.rpcVoid(func(p *packer) {
+		p.call(callActivateStream)
+		p.i32(streamID)
+		p.i32(0)
+		p.i64(0)
+		p.i32(0)
+	})
+}
+
+// getHardwareTime queries the remote device's hardware clock in nanoseconds
+// (GET_HARDWARE_TIME with no clock qualifier). Not every SoapySDR driver keeps
+// a hardware clock; callers treat an error as "no time source".
+func (d *device) getHardwareTime() (int64, error) {
+	u, err := d.rpc(func(p *packer) {
+		p.call(callGetHardwareTime)
+		p.str("")
+	})
+	if err != nil {
+		return 0, err
+	}
+	if err := u.checkException(); err != nil {
+		return 0, err
+	}
+	return u.i64()
 }
 
 // setupStreamTCP performs SoapyRemote's two-phase TCP stream setup. The wire

--- a/internal/sdr/soapyremote/driver_test.go
+++ b/internal/sdr/soapyremote/driver_test.go
@@ -50,13 +50,25 @@ type fakeSoapyServer struct {
 	// GET_SAMPLE_RATE echoes lastSetRateHz (an exact-divisor device).
 	lastSetRateHz   float64
 	getSampleRateHz float64
+
+	// hardwareTimeNs is served on GET_HARDWARE_TIME; failHardwareTime makes the
+	// call reply with a remote exception (a driver with no hardware clock).
+	hardwareTimeNs   int64
+	failHardwareTime bool
+
+	// rejectImmediateMultiChannel mimics UHD: an ACTIVATE_STREAM without
+	// SOAPY_SDR_HAS_TIME on a multi-channel stream is rejected with the
+	// "stream now on multiple channels" exception (issue: MRC on X310).
+	rejectImmediateMultiChannel bool
 }
 
 type recordedCall struct {
-	id       int32
-	freqHz   float64
-	gainDB   float64
-	gainAuto bool
+	id        int32
+	freqHz    float64
+	gainDB    float64
+	gainAuto  bool
+	actFlags  int32
+	actTimeNs int64
 }
 
 func newFakeSoapyServer(t *testing.T) *fakeSoapyServer {
@@ -161,6 +173,18 @@ func readSetupStreamKwargs(u *unpacker) ([]int, map[string]string, error) {
 	return channels, m, nil
 }
 
+// recordedActivates returns the ACTIVATE_STREAM calls seen so far, with their
+// parsed flags/timeNs.
+func (s *fakeSoapyServer) recordedActivates() []recordedCall {
+	var out []recordedCall
+	for _, c := range s.recorded() {
+		if c.id == callActivateStream {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
 func (s *fakeSoapyServer) sawCall(id int32) bool {
 	for _, c := range s.recorded() {
 		if c.id == id {
@@ -249,7 +273,35 @@ func (s *fakeSoapyServer) handleRPC(conn net.Conn) {
 			}
 		case callActivateStream:
 			_, _ = u.i32() // streamId (int)
-			doActivate = true
+			rec.actFlags, _ = u.i32()
+			rec.actTimeNs, _ = u.i64()
+			_, _ = u.i32() // numElems
+			s.mu.Lock()
+			multi := len(s.setupChannels) > 1
+			reject := s.rejectImmediateMultiChannel
+			s.mu.Unlock()
+			if reject && multi && rec.actFlags&soapyFlagHasTime == 0 {
+				reply = func(p *packer) {
+					p.raw8(tException)
+					p.str("RuntimeError: Invalid recv stream command - stream now on multiple channels in a single streamer will fail to time align.")
+				}
+			} else {
+				doActivate = true
+			}
+		case callGetHardwareTime:
+			_, _ = u.str() // clock qualifier ("")
+			s.mu.Lock()
+			hw := s.hardwareTimeNs
+			fail := s.failHardwareTime
+			s.mu.Unlock()
+			if fail {
+				reply = func(p *packer) {
+					p.raw8(tException)
+					p.str("RuntimeError: get_time_now(): this device has no hardware clock")
+				}
+			} else {
+				reply = func(p *packer) { p.i64(hw) }
+			}
 		default:
 			// MAKE, DEACTIVATE, CLOSE, WRITE_SETTING, FREQ_CORRECTION, ...
 		}
@@ -657,6 +709,141 @@ func TestStreamIQDiversity(t *testing.T) {
 
 	if chans := srv.recordedSetupChannels(); len(chans) != 2 || chans[0] != 0 || chans[1] != 1 {
 		t.Errorf("SETUP_STREAM channels = %v, want [0 1]", chans)
+	}
+}
+
+// TestStreamIQDiversityTimedActivate is the regression for MRC on a UHD X310:
+// a multi-channel streamer rejects an immediate start ("Invalid recv stream
+// command - stream now on multiple channels in a single streamer will fail to
+// time align"), so under diversity the client must activate with
+// SOAPY_SDR_HAS_TIME and a start time scheduled after the remote hardware
+// clock. The fake enforces the UHD rejection, so this test fails against the
+// old flags=0 activate.
+func TestStreamIQDiversityTimedActivate(t *testing.T) {
+	const hwNow = int64(5_000_000_000) // 5 s on the device clock
+	srv := newFakeSoapyServer(t)
+	srv.hardwareTimeNs = hwNow
+	srv.rejectImmediateMultiChannel = true
+	ch := []complex64{complex(0.5, -0.5), complex(0.25, 0.25)}
+	srv.streamSamples = append(append([]complex64{}, ch...), ch...)
+
+	drv := New([]Spec{{Addr: srv.Addr(), Format: "CS16", Diversity: "mrc"}}, testLogger())
+	dev, err := drv.Open(0)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer dev.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	out, err := dev.StreamIQ(ctx)
+	if err != nil {
+		t.Fatalf("StreamIQ with diversity on a timed-start-only server: %v", err)
+	}
+	select {
+	case _, ok := <-out:
+		if !ok {
+			t.Fatal("stream channel closed before any data")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for IQ")
+	}
+
+	acts := srv.recordedActivates()
+	if len(acts) == 0 {
+		t.Fatal("server saw no ACTIVATE_STREAM")
+	}
+	last := acts[len(acts)-1]
+	if last.actFlags&soapyFlagHasTime == 0 {
+		t.Errorf("diversity activate flags = %#x, want SOAPY_SDR_HAS_TIME set", last.actFlags)
+	}
+	if last.actTimeNs <= hwNow {
+		t.Errorf("diversity activate timeNs = %d, want > hardware time %d (a future start)", last.actTimeNs, hwNow)
+	}
+	if lead := last.actTimeNs - hwNow; lead > int64(2*time.Second) {
+		t.Errorf("diversity activate lead = %s, unreasonably far in the future", time.Duration(lead))
+	}
+}
+
+// TestStreamIQSingleChannelImmediateActivate pins that the single-channel path
+// is untouched by the timed-start logic: no GET_HARDWARE_TIME RPC, activate
+// with flags=0/timeNs=0 as before.
+func TestStreamIQSingleChannelImmediateActivate(t *testing.T) {
+	srv := newFakeSoapyServer(t)
+	srv.hardwareTimeNs = 123456789
+	srv.streamSamples = []complex64{complex(0.5, -0.5)}
+
+	drv := New([]Spec{{Addr: srv.Addr(), Format: "CS16"}}, testLogger())
+	dev, err := drv.Open(0)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer dev.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	out, err := dev.StreamIQ(ctx)
+	if err != nil {
+		t.Fatalf("StreamIQ: %v", err)
+	}
+	select {
+	case _, ok := <-out:
+		if !ok {
+			t.Fatal("stream channel closed before any data")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for IQ")
+	}
+
+	if srv.sawCall(callGetHardwareTime) {
+		t.Error("single-channel stream queried GET_HARDWARE_TIME; immediate start needs no clock")
+	}
+	acts := srv.recordedActivates()
+	if len(acts) == 0 {
+		t.Fatal("server saw no ACTIVATE_STREAM")
+	}
+	if a := acts[len(acts)-1]; a.actFlags != 0 || a.actTimeNs != 0 {
+		t.Errorf("single-channel activate = flags %#x timeNs %d, want 0/0", a.actFlags, a.actTimeNs)
+	}
+}
+
+// TestStreamIQDiversityNoHardwareClock covers the fallback: a remote whose
+// driver has no hardware clock (GET_HARDWARE_TIME raises) must still stream
+// under diversity via the immediate start, as before the timed path existed.
+func TestStreamIQDiversityNoHardwareClock(t *testing.T) {
+	srv := newFakeSoapyServer(t)
+	srv.failHardwareTime = true
+	ch := []complex64{complex(0.5, -0.5), complex(0.25, 0.25)}
+	srv.streamSamples = append(append([]complex64{}, ch...), ch...)
+
+	drv := New([]Spec{{Addr: srv.Addr(), Format: "CS16", Diversity: "mrc"}}, testLogger())
+	dev, err := drv.Open(0)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer dev.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	out, err := dev.StreamIQ(ctx)
+	if err != nil {
+		t.Fatalf("StreamIQ with diversity on a clockless server: %v", err)
+	}
+	select {
+	case _, ok := <-out:
+		if !ok {
+			t.Fatal("stream channel closed before any data")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for IQ")
+	}
+
+	acts := srv.recordedActivates()
+	if len(acts) == 0 {
+		t.Fatal("server saw no ACTIVATE_STREAM")
+	}
+	if a := acts[len(acts)-1]; a.actFlags != 0 {
+		t.Errorf("fallback activate flags = %#x, want 0 (immediate start)", a.actFlags)
 	}
 }
 

--- a/internal/sdr/soapyremote/mrc.go
+++ b/internal/sdr/soapyremote/mrc.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"strings"
 	"sync/atomic"
+	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/diversity"
 )
@@ -26,6 +27,12 @@ func parseDiversity(mode string) (bool, error) {
 // diversityChannels is the RX channel count for phase-coherent MRC diversity: a
 // shared-LO front-end's RX0 (reference) + RX1. Only 2-branch MRC is supported.
 const diversityChannels = 2
+
+// diversityActivateLead is how far in the future (relative to the remote
+// hardware clock) a multi-channel stream start is scheduled. It only needs to
+// cover the RPC round-trip plus the radio's command latency; UHD's own
+// examples use ~100 ms, and being generous costs one-time startup delay only.
+const diversityActivateLead = 200 * time.Millisecond
 
 // mrcCalFloorDbFS is the reference-branch mean-power floor (dBFS, 0 = unit
 // amplitude) above which the combiner takes its one-time phase calibration.

--- a/internal/sdr/soapyremote/rpc.go
+++ b/internal/sdr/soapyremote/rpc.go
@@ -77,11 +77,17 @@ const (
 	callSetFrequency           int32 = 800
 	callSetSampleRate          int32 = 900
 	callGetSampleRate          int32 = 901
+	callGetHardwareTime        int32 = 1101
 	callWriteSetting           int32 = 1400
 )
 
 // dirRX is SoapySDR's SOAPY_SDR_RX direction (TX is 0).
 const dirRX byte = 1
+
+// soapyFlagHasTime is SoapySDR's SOAPY_SDR_HAS_TIME stream flag: the timeNs
+// argument of ACTIVATE_STREAM carries a valid hardware timestamp, so the
+// remote driver schedules the stream start instead of starting immediately.
+const soapyFlagHasTime int32 = 1 << 2
 
 // dblMantDig mirrors C's DBL_MANT_DIG used in the frexp/ldexp double codec.
 const dblMantDig = 53

--- a/internal/voice/callmeta.go
+++ b/internal/voice/callmeta.go
@@ -42,16 +42,24 @@ type callMeta struct {
 	// `talkgroup` is the target radio's SSI rather than a real talkgroup. Lets a
 	// consumer render the recording as an individual call instead of mistaking the
 	// radio ID for a talkgroup. Omitted (false) for ordinary group calls.
-	Individual           bool            `json:"individual,omitempty"`
-	TalkgroupTag         string          `json:"talkgroup_tag"`
-	TalkgroupDescription string          `json:"talkgroup_description"`
-	TalkgroupGroupTag    string          `json:"talkgroup_group_tag"`
-	TalkgroupGroup       string          `json:"talkgroup_group"`
-	ColorCode            int             `json:"color_code"`
-	AudioType            string          `json:"audio_type"`
-	ShortName            string          `json:"short_name"`
-	FreqList             []callFreqEntry `json:"freqList"`
-	SrcList              []callSrcEntry  `json:"srcList"`
+	Individual           bool   `json:"individual,omitempty"`
+	TalkgroupTag         string `json:"talkgroup_tag"`
+	TalkgroupDescription string `json:"talkgroup_description"`
+	TalkgroupGroupTag    string `json:"talkgroup_group_tag"`
+	TalkgroupGroup       string `json:"talkgroup_group"`
+	ColorCode            int    `json:"color_code"`
+	AudioType            string `json:"audio_type"`
+	ShortName            string `json:"short_name"`
+	// Vocoder / FrameBytes are GopherTrunk extensions (TR parsers ignore
+	// them): the registry name of the vocoder that decoded this call (e.g.
+	// "imbe", "ambe2-dmr") and the fixed byte size of one frame in the .raw
+	// sidecar. Together they make the flat .raw self-describing — filesize /
+	// FrameBytes = frame count, no config cross-reference needed. Omitted for
+	// analog calls and protocols with no in-process vocoder.
+	Vocoder    string          `json:"vocoder,omitempty"`
+	FrameBytes int             `json:"frame_bytes,omitempty"`
+	FreqList   []callFreqEntry `json:"freqList"`
+	SrcList    []callSrcEntry  `json:"srcList"`
 }
 
 // callFreqEntry mirrors trunk-recorder's freqList element. error_count /

--- a/internal/voice/composer/composer.go
+++ b/internal/voice/composer/composer.go
@@ -93,6 +93,19 @@ type exactRateSource interface {
 	SampleRateExactHz() float64
 }
 
+// dmoColourSource is the optional capability a voice IQ source implements when
+// it can report the DM traffic colour code the control-side TETRA DMO pipeline
+// has recovered (ccdecoder.CCVoiceSource delegates to the decoder's atomic).
+// A DMO grant structurally fires before the pipeline finishes recovering the
+// colour (grant at 4 qualified DNBs, recovery needs 20), so the grant's colour
+// hint is almost always 0; the running voice chain polls this instead, adopting
+// the pipeline's answer the moment it lands rather than brute-forcing 64
+// colours on its own IQ goroutine. A dedicated voice SDR has no CC decoder and
+// simply lacks the capability.
+type dmoColourSource interface {
+	TETRADMOColour() (colour uint32, known bool)
+}
+
 // Devices resolves a Voice-role IQ source by its serial. The daemon
 // supplies a wrapper around sdr.Pool; tests use a map.
 type Devices interface {
@@ -597,7 +610,11 @@ func (c *Composer) handleStart(parent context.Context, cs trunking.CallStart) {
 	case voiceKindTETRA:
 		go c.runTETRAVoiceChain(chainCtx, cs.DeviceSerial, iqCh, rateHzF, cs.Grant.GroupID, cs.Grant.Timeslot, cs.Grant.TETRAColourExt, cs.Grant.TETRAUsageMarker, ch.done)
 	case voiceKindTETRADMO:
-		go c.runTETRADMOVoiceChain(chainCtx, cs.DeviceSerial, iqCh, rateHzF, cs.Grant.TETRAColourExt, ch.done)
+		var liveColour func() (uint32, bool)
+		if dcs, ok := src.(dmoColourSource); ok {
+			liveColour = dcs.TETRADMOColour
+		}
+		go c.runTETRADMOVoiceChain(chainCtx, cs.DeviceSerial, iqCh, rateHzF, cs.Grant.TETRAColourExt, liveColour, ch.done)
 	case voiceKindNXDN:
 		go c.runNXDNVoiceChain(chainCtx, cs.DeviceSerial, cs.Grant.System, iqCh, rateHzF, cs.Grant.GroupID, ch.done)
 	default:

--- a/internal/voice/composer/tetra_dmo_voice.go
+++ b/internal/voice/composer/tetra_dmo_voice.go
@@ -24,11 +24,17 @@ import (
 //
 // colourHint is the DM traffic colour code the pipeline stamped on the grant. Because
 // the grant fires on the first DNBs (before the pipeline finishes brute-forcing the
-// colour), the hint is often 0, so this chain recovers the colour independently from
-// its own buffered DNBs (tetra.RecoverDMColourCode) and decodes the buffer
-// retroactively once known — no leading speech is lost. This is #1003 work: on-air A/B
-// still gates it (a green synthetic decode is not proof — #764/#771).
-func (c *Composer) runTETRADMOVoiceChain(ctx context.Context, serial string, iqCh <-chan []complex64, iqHz float64, colourHint uint32, done chan<- struct{}) {
+// colour), the hint is often 0, so this chain recovers the colour on its own and
+// decodes the buffer retroactively once known — no leading speech is lost. Recovery
+// runs, in preference order: (1) liveColour — a poll of the control pipeline's own
+// recovery via the same-carrier source (dmoColourSource), verified against a few
+// buffered bursts before adoption, at ~1/64 the cost of a brute force; (2) the local
+// RecoverDMColourCode brute force, scored ONLY on slot-grid-qualified bursts — the DNB
+// correlator false-alarms ~18/s (tetra/dmo_grid.go), and un-gated scoring windows were
+// ~half noise, which is why the dominance gate never cleared on air and all six
+// attempts burned. This is #1003 work: on-air A/B still gates it (a green synthetic
+// decode is not proof — #764/#771).
+func (c *Composer) runTETRADMOVoiceChain(ctx context.Context, serial string, iqCh <-chan []complex64, iqHz float64, colourHint uint32, liveColour func() (uint32, bool), done chan<- struct{}) {
 	defer close(done)
 	defer gtlog.Recover(c.log, "voice-chain-tetra-dmo:"+serial, nil)
 
@@ -40,11 +46,13 @@ func (c *Composer) runTETRADMOVoiceChain(ctx context.Context, serial string, iqC
 	rs, _ := c.sink.(rawFrameSink)
 
 	dec := &dmoVoiceDecoder{
-		c:      c,
-		serial: serial,
-		bt:     bt,
-		rs:     rs,
-		colour: colourHint,
+		c:          c,
+		serial:     serial,
+		bt:         bt,
+		rs:         rs,
+		colour:     colourHint,
+		liveColour: liveColour,
+		grid:       tetra.NewDMSlotGrid(),
 		// A non-zero hint from the grant is the pipeline's already-recovered colour
 		// (or the operator's tetra_colour_code override), so it counts as recovered.
 		colourKnown:     colourHint != 0,
@@ -71,6 +79,7 @@ func (c *Composer) runTETRADMOVoiceChain(ctx context.Context, serial string, iqC
 	c.log.Info("composer: tetra DMO voice follow started — DNB TCH/S decode + ACELP vocoder",
 		"serial", serial, "colour_hint", colourHint, "rate_hz", symbolHz)
 	defer func() {
+		ext.Flush() // emit any tail burst still inside the extractor window
 		dec.flush() // decode any DNBs still buffered awaiting colour recovery
 		c.log.Info("composer: tetra DMO voice follow ended",
 			"serial", serial, "dnb_bursts", dec.dnb.Load(),
@@ -79,9 +88,14 @@ func (c *Composer) runTETRADMOVoiceChain(ctx context.Context, serial string, iqC
 			"colour_attempts", dec.colourTries)
 	}()
 
+	// feBuf is the reused front-end output scratch: fe.Process(nil, …) allocated
+	// a fresh slice per chunk (~2700/s on SoapyRemote's small datagrams), pure GC
+	// pressure on the one goroutine that must keep up with the tap.
+	var feBuf []complex64
 	process := func(iq []complex64) {
 		bt.observe(iq)
-		rx.Process(fe.Process(nil, iq))
+		feBuf = fe.Process(feBuf[:0], iq)
+		rx.Process(feBuf)
 	}
 	touchTicker := time.NewTicker(c.touchEvery)
 	defer touchTicker.Stop()
@@ -122,6 +136,15 @@ const (
 	// voice consumer"). Attempting only at batch boundaries, over a decimated buffer,
 	// brings it to the ~10k the control pipeline already budgets for.
 	dmoVoiceColourMaxAttempts = 6
+	// dmoVoiceHintMinBursts / dmoVoiceHintMinValid gate adopting the control
+	// pipeline's recovered colour (liveColour): at least MinBursts slot-grid-
+	// qualified bursts must be buffered, and decoding them at the hinted colour
+	// must yield at least MinValid CRC-valid bursts. Verification is N single-
+	// colour decodes — ~1/64 of one brute-force pass — so a correct hint makes
+	// the local brute force unnecessary, and a wrong/stale one cannot blindly
+	// latch.
+	dmoVoiceHintMinBursts = 4
+	dmoVoiceHintMinValid  = 2
 )
 
 // dmoVoiceDecoder holds the streaming DMO voice decode state for one call. All methods
@@ -136,15 +159,33 @@ type dmoVoiceDecoder struct {
 
 	colour      uint32
 	colourKnown bool
-	// colourRecovered distinguishes "RecoverDMColourCode cleared its confidence
-	// gate" from "we gave up and fell back to colour 0", which colourKnown alone
-	// conflates — the end-of-call log used to claim colour_known=true colour=0 on a
-	// call where nothing was ever recovered.
+	// colourRecovered distinguishes "a colour cleared verification (local brute
+	// force or an adopted pipeline hint)" from "we gave up and fell back to
+	// colour 0", which colourKnown alone conflates — the end-of-call log used to
+	// claim colour_known=true colour=0 on a call where nothing was ever recovered.
 	colourRecovered bool
-	buffer          []tetra.DMBurst // DNBs awaiting colour recovery
+	buffer          []tetra.DMBurst // ALL DNBs awaiting colour recovery (retroactive decode)
+	// scored holds only the slot-grid-QUALIFIED DNBs (freshest
+	// dmoVoiceColourBatch), the set colour recovery and hint verification score
+	// against. The DNB correlator false-alarms ~18/s, so an un-gated scoring
+	// window is ~half noise on a live tap and RecoverDMColourCode's dominance
+	// gate can never clear — the on-air "colour_attempts=6, colour_recovered=
+	// false, all BFI" failure. Buffering/emission stay un-gated (the CRC gates
+	// output; a pre-latch real burst must not be dropped).
+	scored []tetra.DMBurst
+	// grid votes DNB leads onto the 255-dibit slot grid to qualify them (the
+	// same tetra.DMSlotGrid the control pipeline uses).
+	grid *tetra.DMSlotGrid
+	// liveColour, when non-nil, polls the control pipeline's own colour
+	// recovery (via the same-carrier source). lastHint/lastHintValid remember a
+	// hinted value that FAILED verification so it is not re-verified every
+	// burst — only a changed hint is retried.
+	liveColour    func() (uint32, bool)
+	lastHint      uint32
+	lastHintValid bool
 	// colourTries counts recovery passes run, capped at dmoVoiceColourMaxAttempts.
-	// sinceTry is how many bursts have arrived since the last pass, so the brute
-	// force runs once per batch instead of once per burst.
+	// sinceTry is how many QUALIFIED bursts arrived since the last pass, so the
+	// brute force runs once per batch instead of once per burst.
 	colourTries int
 	sinceTry    int
 
@@ -154,19 +195,25 @@ type dmoVoiceDecoder struct {
 // tryRecoverColour runs one capped colour-recovery pass and reports whether the
 // confidence gate was cleared.
 //
-// It scores only the FRESHEST dmoVoiceColourBatch bursts, not the whole buffer: the
-// gate needs a couple of dozen bursts to separate the true colour from the ~1/256
-// chance floor, so scoring more costs linearly more Viterbi work for no extra
-// discrimination. The full buffer is deliberately left intact — unlike the control
-// pipeline, which only wants the colour and can decimate, this chain must still
-// decode every buffered burst retroactively once the colour lands, or the start of
-// the transmission is lost from the recording.
+// It scores only the qualified window (d.scored — the freshest
+// dmoVoiceColourBatch slot-grid-qualified bursts), not the whole buffer: the
+// gate needs a couple of dozen REAL bursts to separate the true colour from the
+// ~1/256 chance floor, and correlator noise in the window dilutes the dominance
+// ratio it needs. The full buffer is deliberately left intact — unlike the
+// control pipeline, which only wants the colour and can decimate, this chain
+// must still decode every buffered burst retroactively once the colour lands,
+// or the start of the transmission is lost from the recording. A call whose
+// grid never latched (very short PTT) falls back to the buffer tail — worse
+// odds, but better than scoring nothing at flush.
 func (d *dmoVoiceDecoder) tryRecoverColour() bool {
 	d.colourTries++
 	d.sinceTry = 0
-	scored := d.buffer
-	if len(scored) > dmoVoiceColourBatch {
-		scored = scored[len(scored)-dmoVoiceColourBatch:]
+	scored := d.scored
+	if len(scored) == 0 {
+		scored = d.buffer
+		if len(scored) > dmoVoiceColourBatch {
+			scored = scored[len(scored)-dmoVoiceColourBatch:]
+		}
 	}
 	c, _, ok := tetra.RecoverDMColourCode(scored)
 	if !ok {
@@ -178,32 +225,85 @@ func (d *dmoVoiceDecoder) tryRecoverColour() bool {
 	return true
 }
 
+// tryAdoptLiveColour polls the control pipeline's own colour recovery and, when
+// it has an answer this chain hasn't already rejected, verifies it against the
+// buffered qualified bursts before adopting: at least dmoVoiceHintMinValid of
+// them must TCH/S-decode CRC-valid at the hinted colour. Verification is a
+// handful of single-colour decodes (~1/64 of one brute-force pass), so a
+// correct hint replaces the local brute force almost for free, while a wrong
+// or stale hint cannot blindly latch. A hint that fails is remembered
+// (lastHint) and only re-verified if the pipeline's answer changes. Returns
+// true when a colour was adopted.
+func (d *dmoVoiceDecoder) tryAdoptLiveColour() bool {
+	if d.liveColour == nil || d.colourRecovered {
+		return false
+	}
+	c, known := d.liveColour()
+	if !known || (d.colourKnown && c == d.colour) {
+		return false
+	}
+	if d.lastHintValid && c == d.lastHint {
+		return false // this exact value already failed verification here
+	}
+	if len(d.scored) < dmoVoiceHintMinBursts {
+		return false // too few real bursts to verify; retry as more arrive
+	}
+	valid := 0
+	for i := len(d.scored) - 1; i >= 0 && valid < dmoVoiceHintMinValid; i-- {
+		bb := d.scored[i]
+		if len(tetra.DMBurstTCHSpeechSoft(bb, c)) == 2 || len(tetra.DMBurstTCHSpeech(bb, c)) == 2 {
+			valid++
+		}
+	}
+	if valid < dmoVoiceHintMinValid {
+		d.lastHint, d.lastHintValid = c, true
+		return false
+	}
+	d.colour, d.colourKnown, d.colourRecovered = c, true, true
+	d.c.log.Info("composer: tetra DMO colour adopted from control pipeline",
+		"serial", d.serial, "colour", c)
+	return true
+}
+
 // onBurst handles one streamed DMO burst. DSBs carry no speech (signalling only), so
 // only DNBs are decoded. Until the colour code is known, DNBs are buffered; once
-// recovered (or the cap forces a colour-0 fallback) the buffer is decoded in order and
-// each subsequent DNB decodes immediately.
+// recovered/adopted (or the cap forces a colour-0 fallback) the buffer is decoded in
+// order and each subsequent DNB decodes immediately.
 func (d *dmoVoiceDecoder) onBurst(b tetra.DMBurst) {
 	if b.Kind != tetra.DMBurstNormal {
 		return
 	}
 	d.dnb.Add(1)
+	qualified := d.grid.Observe(b.Lead)
 	if d.colourKnown {
+		// A give-up latch (colourKnown without colourRecovered) can still be
+		// rescued by the pipeline's recovery landing later: keep the qualified
+		// window fresh and adopt a verified hint for the remaining bursts.
+		if !d.colourRecovered {
+			if qualified {
+				d.pushScored(b)
+			}
+			d.tryAdoptLiveColour()
+		}
 		d.emit(b)
 		return
 	}
 	d.buffer = append(d.buffer, b)
-	d.sinceTry++
-	if len(d.buffer) < dmoVoiceColourBatch {
-		return
+	if qualified {
+		d.pushScored(b)
+		d.sinceTry++
 	}
-	// Attempt only once per batch of fresh bursts, and only up to the attempt cap —
-	// re-running the 64-colour brute force on every arriving burst is what made this
-	// chain starve its own IQ tap.
-	canTry := d.colourTries < dmoVoiceColourMaxAttempts &&
+	// Attempt only once per batch of fresh QUALIFIED bursts, and only up to the
+	// attempt cap — re-running the 64-colour brute force on every arriving burst is
+	// what made this chain starve its own IQ tap.
+	canBrute := d.colourTries < dmoVoiceColourMaxAttempts &&
+		len(d.scored) >= dmoVoiceColourBatch &&
 		(d.colourTries == 0 || d.sinceTry >= dmoVoiceColourBatch)
 	switch {
-	case canTry && d.tryRecoverColour():
-		// Recovered; fall through and flush the buffer.
+	case d.tryAdoptLiveColour():
+		// Adopted the pipeline's verified colour; fall through and flush.
+	case canBrute && d.tryRecoverColour():
+		// Recovered locally; fall through and flush.
 	case len(d.buffer) >= dmoVoiceColourMax || d.colourTries >= dmoVoiceColourMaxAttempts:
 		// Give up recovering; assume clear colour 0. A genuinely encrypted call then
 		// yields no CRC-valid speech (bfi), which the hangtime ends normally.
@@ -215,6 +315,15 @@ func (d *dmoVoiceDecoder) onBurst(b tetra.DMBurst) {
 	d.buffer = nil
 	for _, bb := range buf {
 		d.emit(bb)
+	}
+}
+
+// pushScored appends a qualified burst to the scoring window, keeping only the
+// freshest dmoVoiceColourBatch entries.
+func (d *dmoVoiceDecoder) pushScored(b tetra.DMBurst) {
+	d.scored = append(d.scored, b)
+	if len(d.scored) > dmoVoiceColourBatch {
+		d.scored = append(d.scored[:0], d.scored[len(d.scored)-dmoVoiceColourBatch:]...)
 	}
 }
 
@@ -255,7 +364,9 @@ func (d *dmoVoiceDecoder) flush() {
 		return
 	}
 	if !d.colourKnown {
-		d.tryRecoverColour()
+		if !d.tryAdoptLiveColour() {
+			d.tryRecoverColour()
+		}
 		d.colourKnown = true
 	}
 	buf := d.buffer

--- a/internal/voice/composer/tetra_dmo_voice_test.go
+++ b/internal/voice/composer/tetra_dmo_voice_test.go
@@ -28,6 +28,27 @@ func dmoVFiller(seed, n int) []uint8 {
 	return s
 }
 
+// dmoVSlotDibits is one TETRA timeslot in dibits. The voice decoder now
+// qualifies DNBs on the 255-dibit slot grid (tetra.DMSlotGrid) before scoring
+// them for colour recovery, so a synthetic "real transmission" MUST lay its
+// bursts one per slot — as a real radio transmits them — or nothing qualifies.
+const dmoVSlotDibits = 255
+
+// dmoVSlot places burst fields at a fixed offset inside one 255-dibit slot.
+// A DNB (108 + 11 + 108 = 227 dibits) at offset 7 ends at 234, inside the slot.
+func dmoVSlot(seed int, fields ...[]uint8) []uint8 {
+	slot := dmoVFiller(seed, dmoVSlotDibits)
+	at := 7
+	for _, f := range fields {
+		copy(slot[at:], f)
+		at += len(f)
+	}
+	if at > dmoVSlotDibits {
+		panic("dmoVSlot: fields overflow the slot")
+	}
+	return slot
+}
+
 func dmoVSeq(seed, n int) []byte {
 	s := make([]byte, n)
 	for i := range s {
@@ -59,19 +80,20 @@ func buildDMODNBBursts(t *testing.T, colour uint32, n int) ([]tetra.DMBurst, [][
 	b2d := tetra.TetraBitsToDibits
 	var dibits []uint8
 	var want [][2][]byte
-	dibits = append(dibits, dmoVFiller(0, 50)...)
+	dibits = append(dibits, dmoVFiller(0, dmoVSlotDibits)...)
 	for i := 0; i < n; i++ {
 		fa := dmoVSeq(7+i, 137)
 		fb := dmoVSeq(9+i, 137)
 		t4 := framing.UnpackBitsMSB(tetra.EncodeTCHS(fa, fb), 432)
 		onair := framing.ScrambleTetra(t4, colour)
-		dibits = append(dibits, dmoVFiller(11+i, 30)...)
-		dibits = append(dibits, b2d(onair[:216])...)
-		dibits = append(dibits, tetra.NormalSyncDibits()...)
-		dibits = append(dibits, b2d(onair[216:])...)
+		dibits = append(dibits, dmoVSlot(11+i,
+			b2d(onair[:216]),
+			tetra.NormalSyncDibits(),
+			b2d(onair[216:]),
+		)...)
 		want = append(want, [2][]byte{framing.PackBitsMSB(fa), framing.PackBitsMSB(fb)})
 	}
-	dibits = append(dibits, dmoVFiller(99, 200)...)
+	dibits = append(dibits, dmoVFiller(99, dmoVSlotDibits)...)
 
 	all := tetra.ExtractDMBurstsSoft(dibits, dmoVIdealDiffs(dibits), 0)
 	var dnbs []tetra.DMBurst
@@ -95,12 +117,12 @@ func buildDMODNBBursts(t *testing.T, colour uint32, n int) ([]tetra.DMBurst, [][
 // closing #1003.
 func TestDMOVoiceDecoderRecoversColourAndEmits(t *testing.T) {
 	const colour = 3
-	bursts, want := buildDMODNBBursts(t, colour, 24)
+	bursts, want := buildDMODNBBursts(t, colour, 28)
 
 	sink := &fakeDMOSink{}
 	c := &Composer{log: slog.New(slog.NewTextHandler(io.Discard, nil)), hangtime: time.Second}
 	bt := c.newBoundaryTracker("s", 0, nil)
-	dec := &dmoVoiceDecoder{c: c, serial: "s", bt: bt, rs: sink}
+	dec := &dmoVoiceDecoder{c: c, serial: "s", bt: bt, rs: sink, grid: tetra.NewDMSlotGrid()}
 
 	for _, b := range bursts {
 		dec.onBurst(b)
@@ -133,7 +155,8 @@ func TestDMOVoiceDecoderUsesGrantColour(t *testing.T) {
 	c := &Composer{log: slog.New(slog.NewTextHandler(io.Discard, nil)), hangtime: time.Second}
 	dec := &dmoVoiceDecoder{
 		c: c, serial: "s", bt: c.newBoundaryTracker("s", 0, nil), rs: sink,
-		colour: colour, colourKnown: true,
+		grid:   tetra.NewDMSlotGrid(),
+		colour: colour, colourKnown: true, colourRecovered: true,
 	}
 	for _, b := range bursts {
 		dec.onBurst(b)
@@ -155,14 +178,15 @@ func TestDMOVoiceDecoderUsesGrantColour(t *testing.T) {
 func buildDMOUndecodableDNBs(t *testing.T, n int) []tetra.DMBurst {
 	t.Helper()
 	var dibits []uint8
-	dibits = append(dibits, dmoVFiller(0, 50)...)
+	dibits = append(dibits, dmoVFiller(0, dmoVSlotDibits)...)
 	for i := 0; i < n; i++ {
-		dibits = append(dibits, dmoVFiller(11+i, 30)...)
-		dibits = append(dibits, dmoVFiller(200+i*7, 108)...) // BKN1: not a TCH/S codeword
-		dibits = append(dibits, tetra.NormalSyncDibits()...)
-		dibits = append(dibits, dmoVFiller(500+i*13, 108)...) // BKN2
+		dibits = append(dibits, dmoVSlot(11+i,
+			dmoVFiller(200+i*7, 108), // BKN1: not a TCH/S codeword
+			tetra.NormalSyncDibits(),
+			dmoVFiller(500+i*13, 108), // BKN2
+		)...)
 	}
-	dibits = append(dibits, dmoVFiller(99, 200)...)
+	dibits = append(dibits, dmoVFiller(99, dmoVSlotDibits)...)
 
 	var dnbs []tetra.DMBurst
 	for _, b := range tetra.ExtractDMBurstsSoft(dibits, dmoVIdealDiffs(dibits), 0) {
@@ -176,6 +200,172 @@ func buildDMOUndecodableDNBs(t *testing.T, n int) []tetra.DMBurst {
 	return dnbs
 }
 
+// buildDMOGoodWithNoise builds ONE dibit stream carrying nGood slot-aligned
+// colour-scrambled TCH/S DNBs interleaved with ~3 correlator-noise DNBs each
+// (well-formed training sequences at varying NON-slot-aligned offsets inside
+// whole filler slots, so the good bursts keep one residue and the noise does
+// not). This is what a live tap actually feeds the voice chain: the DNB
+// correlator false-alarms ~18/s against ~17/s of real traffic. Returns all
+// extracted DNBs in stream order plus the encoded speech frames per good DNB.
+func buildDMOGoodWithNoise(t *testing.T, colour uint32, nGood int) ([]tetra.DMBurst, [][2][]byte) {
+	t.Helper()
+	b2d := tetra.TetraBitsToDibits
+	var dibits []uint8
+	var want [][2][]byte
+	dibits = append(dibits, dmoVFiller(0, dmoVSlotDibits)...)
+	for i := 0; i < nGood; i++ {
+		fa := dmoVSeq(7+i, 137)
+		fb := dmoVSeq(9+i, 137)
+		t4 := framing.UnpackBitsMSB(tetra.EncodeTCHS(fa, fb), 432)
+		onair := framing.ScrambleTetra(t4, colour)
+		dibits = append(dibits, dmoVSlot(11+i,
+			b2d(onair[:216]),
+			tetra.NormalSyncDibits(),
+			b2d(onair[216:]),
+		)...)
+		want = append(want, [2][]byte{framing.PackBitsMSB(fa), framing.PackBitsMSB(fb)})
+		// Four whole slots of filler carrying three bogus DNB training
+		// sequences at drifting offsets. The good DNB's training lead sits at
+		// slot offset 7+108=115; the noise offsets (see below) never land on
+		// 115±1 mod 255, so they cannot vote for the traffic residue.
+		noise := dmoVFiller(300+i*17, 4*dmoVSlotDibits)
+		for j := 0; j < 3; j++ {
+			off := 130 + ((i*3+j)*37)%520 // lead at off+108; varies, ≢ 115 (mod 255)
+			if lead := (off + 108) % dmoVSlotDibits; lead >= 114 && lead <= 116 {
+				off += 5
+			}
+			copy(noise[off+108:], tetra.NormalSyncDibits())
+		}
+		dibits = append(dibits, noise...)
+	}
+	dibits = append(dibits, dmoVFiller(99, dmoVSlotDibits)...)
+
+	var dnbs []tetra.DMBurst
+	for _, b := range tetra.ExtractDMBurstsSoft(dibits, dmoVIdealDiffs(dibits), 0) {
+		if b.Kind == tetra.DMBurstNormal {
+			dnbs = append(dnbs, b)
+		}
+	}
+	if len(dnbs) < 3*nGood {
+		t.Fatalf("built %d DNB bursts, want ≥ %d (good + noise)", len(dnbs), 3*nGood)
+	}
+	return dnbs, want
+}
+
+// TestDMOVoiceDecoderAdoptsLiveColourHint pins the pipeline→voice-chain colour
+// hand-off: a DMO grant structurally fires before the control pipeline finishes
+// its own colour recovery, so the chain polls liveColour and must adopt a
+// verified answer with far fewer bursts than the local brute force needs. Only
+// 12 bursts are fed — below dmoVoiceColourBatch — so with no hint plumbing the
+// brute force could not have fired mid-stream at all; adoption must land with
+// zero local attempts and every burst's speech emitted. Fails against the old
+// code (no liveColour parameter existed).
+func TestDMOVoiceDecoderAdoptsLiveColourHint(t *testing.T) {
+	const colour = 44
+	bursts, want := buildDMODNBBursts(t, colour, 12)
+
+	sink := &fakeDMOSink{}
+	c := &Composer{log: slog.New(slog.NewTextHandler(io.Discard, nil)), hangtime: time.Second}
+	calls := 0
+	dec := &dmoVoiceDecoder{
+		c: c, serial: "s", bt: c.newBoundaryTracker("s", 0, nil), rs: sink,
+		grid: tetra.NewDMSlotGrid(),
+		liveColour: func() (uint32, bool) {
+			// The pipeline's recovery lands a few bursts into the call.
+			calls++
+			if calls > 3 {
+				return colour, true
+			}
+			return 0, false
+		},
+	}
+	for _, b := range bursts {
+		dec.onBurst(b)
+	}
+	dec.flush()
+
+	if !dec.colourRecovered || dec.colour != colour {
+		t.Fatalf("adopted colour=%d recovered=%v, want %d via the live hint",
+			dec.colour, dec.colourRecovered, colour)
+	}
+	if dec.colourTries != 0 {
+		t.Errorf("ran %d local brute-force attempts despite a valid live hint, want 0", dec.colourTries)
+	}
+	if len(sink.frames) != 2*len(want) {
+		t.Fatalf("emitted %d speech frames, want %d (buffered speech lost?)",
+			len(sink.frames), 2*len(want))
+	}
+}
+
+// TestDMOVoiceDecoderRejectsBadLiveHint is the companion: a wrong/stale hint
+// (different DMO net, cleared-too-late atomic) must NOT blindly latch — it
+// fails CRC verification against the buffered bursts and local recovery still
+// lands the true colour.
+func TestDMOVoiceDecoderRejectsBadLiveHint(t *testing.T) {
+	const colour = 3
+	bursts, want := buildDMODNBBursts(t, colour, 30)
+
+	sink := &fakeDMOSink{}
+	c := &Composer{log: slog.New(slog.NewTextHandler(io.Discard, nil)), hangtime: time.Second}
+	dec := &dmoVoiceDecoder{
+		c: c, serial: "s", bt: c.newBoundaryTracker("s", 0, nil), rs: sink,
+		grid:       tetra.NewDMSlotGrid(),
+		liveColour: func() (uint32, bool) { return 17, true }, // wrong colour
+	}
+	for _, b := range bursts {
+		dec.onBurst(b)
+	}
+	dec.flush()
+
+	if dec.colour != colour || !dec.colourRecovered {
+		t.Fatalf("colour=%d recovered=%v, want %d recovered locally despite the bad hint",
+			dec.colour, dec.colourRecovered, colour)
+	}
+	if dec.colourTries == 0 {
+		t.Errorf("local recovery never ran — the bad hint was adopted?")
+	}
+	if len(sink.frames) != 2*len(want) {
+		t.Fatalf("emitted %d speech frames, want %d", len(sink.frames), 2*len(want))
+	}
+}
+
+// TestDMOVoiceDecoderRecoversColourThroughNoise reproduces the on-air failure
+// that left every real DMO call at colour_attempts=6, colour_recovered=false,
+// all-BFI: on a live tap the DNB correlator's ~18/s false alarms outnumber real
+// traffic, and the old un-gated colour scoring windows were mostly noise, so
+// RecoverDMColourCode's dominance gate could never clear and the attempt budget
+// burned out before enough real bursts arrived. With slot-grid gating, only the
+// grid-qualified (real) bursts are scored, recovery lands, and every real
+// burst's speech is emitted. Fails against the old un-gated code.
+func TestDMOVoiceDecoderRecoversColourThroughNoise(t *testing.T) {
+	const colour = 3
+	bursts, want := buildDMOGoodWithNoise(t, colour, 30)
+
+	sink := &fakeDMOSink{}
+	c := &Composer{log: slog.New(slog.NewTextHandler(io.Discard, nil)), hangtime: time.Second}
+	dec := &dmoVoiceDecoder{c: c, serial: "s", bt: c.newBoundaryTracker("s", 0, nil), rs: sink, grid: tetra.NewDMSlotGrid()}
+
+	for _, b := range bursts {
+		dec.onBurst(b)
+	}
+	dec.flush()
+
+	if !dec.colourRecovered || dec.colour != colour {
+		t.Fatalf("colour=%d recovered=%v (attempts=%d), want %d recovered through the noise",
+			dec.colour, dec.colourRecovered, dec.colourTries, colour)
+	}
+	// Every GOOD burst's two speech frames must be present, in order; the noise
+	// bursts BFI at the recovered colour and contribute nothing.
+	if len(sink.frames) != 2*len(want) {
+		t.Fatalf("emitted %d speech frames, want %d", len(sink.frames), 2*len(want))
+	}
+	for i, w := range want {
+		if !reflect.DeepEqual(sink.frames[2*i], w[0]) || !reflect.DeepEqual(sink.frames[2*i+1], w[1]) {
+			t.Errorf("good DNB %d: emitted speech frame mismatch", i)
+		}
+	}
+}
+
 // TestDMOVoiceDecoderBoundsColourRecovery pins the cost bound on the 64-colour brute
 // force. RecoverDMColourCode is a full soft-Viterbi TCH/S decode per colour per burst
 // (plus a hard decode on the failing fallback), and it used to be re-run on EVERY
@@ -187,7 +377,7 @@ func TestDMOVoiceDecoderBoundsColourRecovery(t *testing.T) {
 	bursts := buildDMOUndecodableDNBs(t, 200)
 	sink := &fakeDMOSink{}
 	c := &Composer{log: slog.New(slog.NewTextHandler(io.Discard, nil)), hangtime: time.Second}
-	dec := &dmoVoiceDecoder{c: c, serial: "s", bt: c.newBoundaryTracker("s", 0, nil), rs: sink}
+	dec := &dmoVoiceDecoder{c: c, serial: "s", bt: c.newBoundaryTracker("s", 0, nil), rs: sink, grid: tetra.NewDMSlotGrid()}
 
 	for _, b := range bursts {
 		dec.onBurst(b)
@@ -216,7 +406,7 @@ func TestDMOVoiceDecoderDoesNotClaimUnrecoveredColour(t *testing.T) {
 	bursts := buildDMOUndecodableDNBs(t, 60)
 	sink := &fakeDMOSink{}
 	c := &Composer{log: slog.New(slog.NewTextHandler(io.Discard, nil)), hangtime: time.Second}
-	dec := &dmoVoiceDecoder{c: c, serial: "s", bt: c.newBoundaryTracker("s", 0, nil), rs: sink}
+	dec := &dmoVoiceDecoder{c: c, serial: "s", bt: c.newBoundaryTracker("s", 0, nil), rs: sink, grid: tetra.NewDMSlotGrid()}
 
 	for _, b := range bursts {
 		dec.onBurst(b)
@@ -245,7 +435,7 @@ func TestDMOVoiceDecoderKeepsBufferedSpeechAcrossAttempts(t *testing.T) {
 
 	sink := &fakeDMOSink{}
 	c := &Composer{log: slog.New(slog.NewTextHandler(io.Discard, nil)), hangtime: time.Second}
-	dec := &dmoVoiceDecoder{c: c, serial: "s", bt: c.newBoundaryTracker("s", 0, nil), rs: sink}
+	dec := &dmoVoiceDecoder{c: c, serial: "s", bt: c.newBoundaryTracker("s", 0, nil), rs: sink, grid: tetra.NewDMSlotGrid()}
 
 	for _, b := range append(append([]tetra.DMBurst{}, bad...), good...) {
 		dec.onBurst(b)

--- a/internal/voice/composer/tetra_voice.go
+++ b/internal/voice/composer/tetra_voice.go
@@ -94,9 +94,14 @@ func (c *Composer) runTETRAVoiceChain(ctx context.Context, serial string, iqCh <
 			"other_call_bursts", offSlot.Load())
 	}()
 
+	// feBuf is the reused front-end output scratch — fe.Process(nil, …)
+	// allocated a fresh slice per chunk (~2700/s on SoapyRemote's small
+	// datagrams), pure GC pressure on the tap-drain goroutine.
+	var feBuf []complex64
 	process := func(iq []complex64) {
 		bt.observe(iq)
-		rx.Process(fe.Process(nil, iq))
+		feBuf = fe.Process(feBuf[:0], iq)
+		rx.Process(feBuf)
 	}
 	touchTicker := time.NewTicker(c.touchEvery)
 	defer touchTicker.Stop()

--- a/internal/voice/mbe_sidecar.go
+++ b/internal/voice/mbe_sidecar.go
@@ -1,0 +1,81 @@
+package voice
+
+// dsd-fme-playable MBE sidecar support (.imb / .amb).
+//
+// GopherTrunk's .raw sidecar is a bare concatenation of post-FEC vocoder
+// frames — the right shape for BYO decoders, but not directly playable by
+// DSD-FME, whose offline player (playMbeFiles) only reads its own container:
+// a file that STARTS with a 4-byte ASCII cookie naming the type, followed by
+// fixed-size per-frame records (lwvmobile/dsd-fme src/dsd_file.c):
+//
+//	".imb" — P25 Phase 1 IMBE 4400: [1 errs byte][11 bytes = 88 IMBE bits,
+//	         MSB-first] per frame (readImbe4400Data).
+//	".amb" — AMBE+2 (DMR / NXDN / P25 Phase 2): [1 errs byte][6 bytes =
+//	         bits 0..47 MSB-first][1 byte whose LSB is bit 48] per frame
+//	         (readAmbe2450Data).
+//
+// Both record payloads are exactly the post-FEC information bits GT already
+// stores in the .raw sidecar (11-byte IMBE / 7-byte 49-bit AMBE+2, MSB-first,
+// DSD/OP25 bit order — see internal/voice/{imbe,ambe2}/testdata/README.md),
+// so the sidecar is a repack, not a re-decode. The errs byte is the channel
+// error count DSD feeds to mbelib's smoothing; the recorder seam has no
+// per-frame error counts, so it writes 0 ("clean"), which mbelib treats as
+// no-repair — fine for offline analysis.
+//
+// TETRA ACELP has no DSD-FME playback mode and ProVoice frames are not in
+// mbelib parameter-bit form, so neither gets an MBE sidecar.
+
+// MBE sidecar cookies. The file extension deliberately equals the cookie —
+// dsd-fme identifies the container by the leading bytes, and matching names
+// keep the on-disk tree self-describing.
+const (
+	mbeCookieIMB = ".imb"
+	mbeCookieAMB = ".amb"
+)
+
+// Frame sizes (bytes) of the .raw payloads each cookie repacks.
+const (
+	imbeRawFrameBytes = 11 // 88 IMBE information bits
+	ambeRawFrameBytes = 7  // 49 AMBE+2 information bits (7 pad bits)
+)
+
+// mbeCookieForProtocol maps a Grant.Protocol to the dsd-fme container its
+// frames belong in; ok=false means the protocol has no dsd-fme playback
+// format. p25-phase2 is nominally AMBE+2 3600x2400, but dsd-fme files phase 2
+// under .amb alongside DMR/NXDN (openMbeOutFile: "dmr, nxdn, phase 2,
+// x2-tdma"), so we match that.
+func mbeCookieForProtocol(protocol string) (string, bool) {
+	switch protocol {
+	case "p25":
+		return mbeCookieIMB, true
+	case "dmr-tier1", "dmr-tier2", "dmr-tier3", "nxdn", "p25-phase2":
+		return mbeCookieAMB, true
+	default:
+		return "", false
+	}
+}
+
+// mbeRecord converts one .raw-format frame into the corresponding dsd-fme
+// record. Returns nil for a frame whose length doesn't match the cookie's
+// expected payload (a malformed frame must not desync the fixed-size record
+// stream — dropping it keeps every later record readable).
+func mbeRecord(cookie string, frame []byte) []byte {
+	switch cookie {
+	case mbeCookieIMB:
+		if len(frame) != imbeRawFrameBytes {
+			return nil
+		}
+		rec := make([]byte, 0, 1+imbeRawFrameBytes)
+		rec = append(rec, 0) // errs
+		return append(rec, frame...)
+	case mbeCookieAMB:
+		if len(frame) != ambeRawFrameBytes {
+			return nil
+		}
+		rec := make([]byte, 0, 8)
+		rec = append(rec, 0)            // errs
+		rec = append(rec, frame[:6]...) // bits 0..47
+		return append(rec, frame[6]>>7) // bit 48 → LSB of the trailing byte
+	}
+	return nil
+}

--- a/internal/voice/mbe_sidecar_test.go
+++ b/internal/voice/mbe_sidecar_test.go
@@ -1,0 +1,217 @@
+package voice
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// mkMBERecorder builds a recorder with the dsd-fme MBE sidecar enabled.
+func mkMBERecorder(t *testing.T) (*Recorder, *events.Bus, string) {
+	t.Helper()
+	bus := events.NewBus(8)
+	dir := t.TempDir()
+	r, err := NewRecorder(RecorderOptions{
+		Bus:        bus,
+		OutDir:     dir,
+		SampleRate: 8000,
+		WriteMBE:   true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return r, bus, dir
+}
+
+func runMBECall(t *testing.T, r *Recorder, bus *events.Bus, grant trunking.Grant, frames [][]byte) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go r.Run(ctx)
+
+	cs := trunking.CallStart{
+		Grant:        grant,
+		DeviceSerial: "VOICE-1",
+		StartedAt:    time.Date(2026, 5, 5, 0, 0, 0, 0, time.UTC),
+	}
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: cs})
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) && !r.HasSession("VOICE-1") {
+		time.Sleep(5 * time.Millisecond)
+	}
+	for _, f := range frames {
+		if err := r.WriteRawFrame("VOICE-1", f); err != nil {
+			t.Fatal(err)
+		}
+	}
+	bus.Publish(events.Event{
+		Kind: events.KindCallEnd,
+		Payload: trunking.CallEnd{
+			Grant: cs.Grant, DeviceSerial: "VOICE-1",
+			StartedAt: cs.StartedAt, EndedAt: cs.StartedAt.Add(time.Second),
+			Reason: trunking.EndReasonNormal,
+		},
+	})
+	deadline = time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) && r.HasSession("VOICE-1") {
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// readAmbeSidecar mirrors dsd-fme's openMbeInFile + readAmbe2450Data
+// (src/dsd_file.c): a 4-byte cookie, then per frame 1 errs byte, 6 bytes of
+// bits 0..47 and a final byte whose LSB is bit 48. It reconstructs GT's
+// 7-byte .raw packing (bit 48 in the MSB of byte 6) so the round-trip can be
+// compared bit-exactly against the frames the recorder was fed.
+func readAmbeSidecar(t *testing.T, path string) [][]byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", path, err)
+	}
+	if len(data) < 4 || string(data[:4]) != ".amb" {
+		t.Fatalf("cookie = %q, want %q", data[:min(4, len(data))], ".amb")
+	}
+	body := data[4:]
+	if len(body)%8 != 0 {
+		t.Fatalf("record stream length %d not a multiple of 8", len(body))
+	}
+	var frames [][]byte
+	for off := 0; off < len(body); off += 8 {
+		rec := body[off : off+8]
+		if rec[0] != 0 {
+			t.Errorf("record %d errs byte = %d, want 0", off/8, rec[0])
+		}
+		frame := make([]byte, 7)
+		copy(frame, rec[1:7])
+		frame[6] = (rec[7] & 1) << 7
+		frames = append(frames, frame)
+	}
+	return frames
+}
+
+// TestRecorderMBESidecarAMB drives a DMR call through the recorder with
+// recordings.mbe_files enabled and verifies the .amb sidecar is dsd-fme's
+// container, bit-exactly recoverable to the AMBE+2 frames that were written.
+func TestRecorderMBESidecarAMB(t *testing.T) {
+	r, bus, dir := mkMBERecorder(t)
+	defer r.Close()
+	defer bus.Close()
+
+	// A real on-air AMBE+2 silence frame (49 bits; bit 48 set) plus a
+	// bit-pattern frame exercising both byte edges.
+	frames := [][]byte{
+		{0xF8, 0x05, 0xC1, 0x8F, 0xA4, 0x54, 0x80},
+		{0x01, 0xFE, 0x00, 0xFF, 0xAA, 0x55, 0x00},
+	}
+	runMBECall(t, r, bus, trunking.Grant{System: "S", Protocol: "dmr-tier2", GroupID: 11, SourceID: 7}, frames)
+
+	got := readAmbeSidecar(t, filepath.Join(dir, "S", "11", "20260505_000000_11.amb"))
+	if len(got) != len(frames) {
+		t.Fatalf("decoded %d frames, want %d", len(got), len(frames))
+	}
+	for i := range frames {
+		if string(got[i]) != string(frames[i]) {
+			t.Errorf("frame %d round-trip = % X, want % X", i, got[i], frames[i])
+		}
+	}
+}
+
+// TestRecorderMBESidecarIMB does the same for a P25 Phase 1 call: the .imb
+// container is cookie + [errs][11 bytes] records, payload verbatim.
+func TestRecorderMBESidecarIMB(t *testing.T) {
+	r, bus, dir := mkMBERecorder(t)
+	defer r.Close()
+	defer bus.Close()
+
+	frame := []byte{0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD}
+	runMBECall(t, r, bus, trunking.Grant{System: "S", Protocol: "p25", GroupID: 42, SourceID: 7}, [][]byte{frame})
+
+	data, err := os.ReadFile(filepath.Join(dir, "S", "42", "20260505_000000_42.imb"))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(data[:4]) != ".imb" {
+		t.Fatalf("cookie = %q, want .imb", data[:4])
+	}
+	body := data[4:]
+	if len(body) != 12 {
+		t.Fatalf("body length = %d, want 12 (1 errs + 11 payload)", len(body))
+	}
+	if body[0] != 0 {
+		t.Errorf("errs byte = %d, want 0", body[0])
+	}
+	if string(body[1:]) != string(frame) {
+		t.Errorf("payload = % X, want % X", body[1:], frame)
+	}
+}
+
+// TestRecorderMBESidecarSkipsUnsupportedProtocol pins that protocols dsd-fme
+// cannot play (TETRA ACELP here) produce no MBE sidecar even with the option
+// on — and that a malformed frame size cannot desync a stream that IS open.
+func TestRecorderMBESidecarSkipsUnsupportedProtocol(t *testing.T) {
+	r, bus, dir := mkMBERecorder(t)
+	defer r.Close()
+	defer bus.Close()
+
+	// 18-byte TETRA ACELP speech frame shape.
+	frame := make([]byte, 18)
+	runMBECall(t, r, bus, trunking.Grant{System: "S", Protocol: "tetra", GroupID: 9, SourceID: 7}, [][]byte{frame})
+
+	entries, err := os.ReadDir(filepath.Join(dir, "S", "9"))
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, e := range entries {
+		if ext := filepath.Ext(e.Name()); ext == ".amb" || ext == ".imb" {
+			t.Errorf("unexpected MBE sidecar %s for TETRA call", e.Name())
+		}
+	}
+}
+
+// TestRecorderMBESidecarSkipsMalformedFrame: a wrong-size frame is dropped
+// from the MBE stream (not written) so later records stay readable.
+func TestRecorderMBESidecarSkipsMalformedFrame(t *testing.T) {
+	r, bus, dir := mkMBERecorder(t)
+	defer r.Close()
+	defer bus.Close()
+
+	good := []byte{0xF8, 0x05, 0xC1, 0x8F, 0xA4, 0x54, 0x80}
+	frames := [][]byte{good, {0x01, 0x02}, good} // middle frame malformed
+	runMBECall(t, r, bus, trunking.Grant{System: "S", Protocol: "dmr-tier2", GroupID: 12, SourceID: 7}, frames)
+
+	got := readAmbeSidecar(t, filepath.Join(dir, "S", "12", "20260505_000000_12.amb"))
+	if len(got) != 2 {
+		t.Fatalf("decoded %d frames, want 2 (malformed skipped)", len(got))
+	}
+}
+
+// TestRemoveSessionFilesIncludesMBE pins that discarding a recording (dead-key
+// / encrypted abort paths both call removeSessionFiles) deletes the MBE
+// sidecar along with the .wav/.raw.
+func TestRemoveSessionFilesIncludesMBE(t *testing.T) {
+	r, _, _ := mkMBERecorder(t)
+	defer r.Close()
+	dir := t.TempDir()
+	s := &recordingSession{
+		wavPath: filepath.Join(dir, "a.wav"),
+		rawPath: filepath.Join(dir, "a.raw"),
+		mbePath: filepath.Join(dir, "a.amb"),
+	}
+	for _, p := range []string{s.wavPath, s.rawPath, s.mbePath} {
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	r.removeSessionFiles(s)
+	for _, p := range []string{s.wavPath, s.rawPath, s.mbePath} {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Errorf("%s still exists after removeSessionFiles", filepath.Base(p))
+		}
+	}
+}

--- a/internal/voice/recorder.go
+++ b/internal/voice/recorder.go
@@ -97,6 +97,7 @@ type Recorder struct {
 	outDir             string
 	sampleRate         uint32
 	writeRaw           bool
+	writeMBE           bool
 	skipEncrypted      bool
 	writeCallJSON      bool
 	normalize          NormalizeConfig
@@ -293,6 +294,14 @@ type RecorderOptions struct {
 	OutDir     string
 	SampleRate uint32 // 8000 typical
 	WriteRaw   bool   // emit a .raw sidecar alongside each .wav
+	// WriteMBE emits a dsd-fme-playable MBE sidecar next to each recording
+	// for protocols dsd-fme can play offline: <basename>.imb for P25 Phase 1
+	// IMBE, <basename>.amb for DMR / NXDN / P25 Phase 2 AMBE+2. The file is
+	// dsd-fme's own container (4-byte cookie + per-frame records; see
+	// mbe_sidecar.go), so `dsd-fme -r <file>` decodes it with a standard
+	// toolchain — no GopherTrunk-specific parsing. Protocols dsd-fme cannot
+	// play (TETRA ACELP, ProVoice, analog) produce no MBE file.
+	WriteMBE bool
 	// WriteCallJSON emits a trunk-recorder-compatible <basename>.json metadata
 	// sidecar next to each recording (per WAV / segment).
 	WriteCallJSON bool
@@ -456,6 +465,7 @@ func NewRecorder(opts RecorderOptions) (*Recorder, error) {
 		outDir:             opts.OutDir,
 		sampleRate:         opts.SampleRate,
 		writeRaw:           opts.WriteRaw,
+		writeMBE:           opts.WriteMBE,
 		skipEncrypted:      opts.SkipEncrypted,
 		writeCallJSON:      opts.WriteCallJSON,
 		normalize:          opts.Normalize,
@@ -776,6 +786,16 @@ func (r *Recorder) writeRawFrame(deviceSerial string, callID uint64, frame []byt
 			return err
 		}
 	}
+	if s.mbe != nil {
+		// Repack into the dsd-fme record; a frame whose size doesn't match the
+		// container is skipped so it can't desync the fixed-size record stream.
+		if rec := mbeRecord(s.mbeCookie, frame); rec != nil {
+			if _, err := s.mbe.Write(rec); err != nil {
+				s.mu.Unlock()
+				return err
+			}
+		}
+	}
 	sessCallID := s.callID
 	vocName := s.vocoderName
 	s.mu.Unlock()
@@ -999,7 +1019,7 @@ func (r *Recorder) handleEncryptionUpdate(deviceSerial string, encrypted bool) {
 		r.log.Warn("recorder: closing aborted encrypted session",
 			"device", deviceSerial, "err", err)
 	}
-	for _, p := range []string{s.wavPath, s.rawPath} {
+	for _, p := range []string{s.wavPath, s.rawPath, s.mbePath} {
 		if p == "" {
 			continue
 		}
@@ -1098,6 +1118,15 @@ func (r *Recorder) buildSession(cs trunking.CallStart, startedAt time.Time) *rec
 		s.rawPath = filepath.Join(dir, base+".raw")
 		s.rawWanted = true
 	}
+	// Optional dsd-fme-playable sidecar (recordings.mbe_files) for protocols
+	// dsd-fme's offline player can decode; the cookie doubles as extension.
+	if r.writeMBE {
+		if cookie, ok := mbeCookieForProtocol(cs.Grant.Protocol); ok {
+			s.mbePath = filepath.Join(dir, base+cookie)
+			s.mbeCookie = cookie
+			s.mbeWanted = true
+		}
+	}
 	// The on-disk files are NOT opened here — they are created lazily on the
 	// first write (openSessionFiles). A grant that never yields audio (a
 	// dead-key, an immediately-aborted encrypted call, or a tap that never
@@ -1139,6 +1168,19 @@ func (r *Recorder) openSessionFiles(s *recordingSession) error {
 			r.log.Error("recorder: open raw", "path", s.rawPath, "err", err)
 		} else {
 			s.raw = raw
+		}
+	}
+	if s.mbeWanted && s.mbe == nil {
+		mbe, err := os.Create(s.mbePath)
+		if err != nil {
+			r.log.Error("recorder: open mbe sidecar", "path", s.mbePath, "err", err)
+		} else if _, err := mbe.WriteString(s.mbeCookie); err != nil {
+			// A sidecar without its cookie is unreadable by dsd-fme; drop it.
+			r.log.Error("recorder: write mbe cookie", "path", s.mbePath, "err", err)
+			_ = mbe.Close()
+			_ = os.Remove(s.mbePath)
+		} else {
+			s.mbe = mbe
 		}
 	}
 	return nil
@@ -1316,6 +1358,13 @@ func (r *Recorder) finalizeLocked(s *recordingSession, serial string, endedAt ti
 			srcs = ct
 		}
 		meta = buildCallMeta(s.cs, s.startedAt, endedAt, int(r.callNum.Add(1)), s.vocoder != nil, srcs, s.freqs)
+		// Label the vocoder + .raw frame size so the flat raw sidecar is
+		// self-describing (GT extension fields; trunk-recorder parsers
+		// ignore unknown keys).
+		if s.vocoder != nil {
+			meta.Vocoder = s.vocoderName
+			meta.FrameBytes = s.vocoder.FrameSize()
+		}
 	}
 	return cc, meta
 }
@@ -1325,7 +1374,7 @@ func (r *Recorder) finalizeLocked(s *recordingSession, serial string, endedAt ti
 // idle-only call) so it doesn't spam the recordings tree. The session must
 // already be closed. Mirrors the removal in handleEncryptionUpdate.
 func (r *Recorder) removeSessionFiles(s *recordingSession) {
-	for _, p := range []string{s.wavPath, s.rawPath} {
+	for _, p := range []string{s.wavPath, s.rawPath, s.mbePath} {
 		if p == "" {
 			continue
 		}
@@ -1796,6 +1845,15 @@ type recordingSession struct {
 	// first frame (openSessionFiles), so a call with no audio never leaves a
 	// 0-byte .raw behind.
 	rawWanted bool
+	// mbe* mirror raw* for the optional dsd-fme-playable MBE sidecar
+	// (recordings.mbe_files): mbeCookie is ".imb"/".amb" (doubling as the
+	// file extension and the 4-byte header dsd-fme identifies the container
+	// by), and the file is created lazily alongside the .raw so an audio-less
+	// call leaves nothing behind. See mbe_sidecar.go.
+	mbe       *os.File
+	mbePath   string
+	mbeCookie string
+	mbeWanted bool
 	// rawFrames counts vocoder frames delivered to this session (each ~one
 	// speech frame, e.g. 30 ms for TETRA ACELP). Surfaced in the
 	// "recording shorter than call span" diagnostic so the frame yield of a
@@ -1876,6 +1934,11 @@ func (s *recordingSession) closeLocked() error {
 	}
 	if s.raw != nil {
 		if err := s.raw.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	if s.mbe != nil {
+		if err := s.mbe.Close(); err != nil && firstErr == nil {
 			firstErr = err
 		}
 	}

--- a/web/configbuilder/src/api/types.ts
+++ b/web/configbuilder/src/api/types.ts
@@ -183,6 +183,7 @@ export interface RecordingsConfig {
   SampleRate: number;
   Enhance: EnhanceConfig;
   WriteRaw: boolean;
+  MBEFiles?: boolean;
   SkipEncrypted: boolean;
   Equalizer: EqualizerConfig;
   Normalize: NormalizeConfig;

--- a/web/configbuilder/src/sections/simple.tsx
+++ b/web/configbuilder/src/sections/simple.tsx
@@ -297,6 +297,12 @@ export function RecordingsSection() {
         onChange={(x) => set({ ...cfg, WriteRaw: x })}
       />
       <BoolField
+        label="dsd-fme MBE files"
+        value={!!cfg.MBEFiles}
+        onChange={(x) => set({ ...cfg, MBEFiles: x })}
+        help="Also write a dsd-fme-playable sidecar per call (.imb for P25 Phase 1, .amb for DMR/NXDN/P25p2) so recordings decode offline with dsd-fme -r. TETRA/ProVoice/analog produce no file."
+      />
+      <BoolField
         label="Skip encrypted calls"
         value={cfg.SkipEncrypted}
         onChange={(x) => set({ ...cfg, SkipEncrypted: x })}

--- a/web/src/components/AudioPlayer.tsx
+++ b/web/src/components/AudioPlayer.tsx
@@ -77,7 +77,7 @@ export function AudioPlayer() {
     }
     navigator.mediaSession.metadata = new MediaMetadata({
       title:
-        top.talkgroup?.alpha_tag ?? `TG ${top.grant.group_id}`,
+        top.talkgroup?.alpha_tag || `TG ${top.grant.group_id}`,
       artist: top.grant.system,
       album: top.talkgroup?.group ?? "",
     });

--- a/web/src/panels/Active.tsx
+++ b/web/src/panels/Active.tsx
@@ -88,7 +88,7 @@ export function Active() {
         header: "Alpha tag",
         render: (r) => (
           <span className="font-medium">
-            {r.talkgroup?.alpha_tag ?? <em className="text-muted">—</em>}
+            {r.talkgroup?.alpha_tag || <em className="text-muted">—</em>}
           </span>
         ),
         sort: (a, b) =>
@@ -221,7 +221,7 @@ export function Active() {
 
       {selected && (
         <DetailModal
-          title={selected.talkgroup?.alpha_tag ?? `TG ${selected.grant.group_id}`}
+          title={selected.talkgroup?.alpha_tag || `TG ${selected.grant.group_id}`}
           subtitle={`${selected.grant.system} · ${selected.grant.protocol}`}
           onClose={() => setSelected(null)}
         >

--- a/web/src/panels/Dashboard.tsx
+++ b/web/src/panels/Dashboard.tsx
@@ -163,7 +163,9 @@ export function Dashboard() {
                   TG {c.grant.group_id}
                 </span>
                 <span className="text-sm truncate">
-                  {c.talkgroup?.alpha_tag ?? c.grant.system}
+                  {/* || not ??: auto-discovered talkgroups carry alpha_tag "" (present,
+                      not null), which must still fall back to the system name. */}
+                  {c.talkgroup?.alpha_tag || c.grant.system}
                 </span>
                 {c.grant.source_id ? (
                   <span className="text-xs text-muted shrink-0">

--- a/web/src/panels/History.tsx
+++ b/web/src/panels/History.tsx
@@ -328,7 +328,7 @@ export function History() {
 
       {selected && (
         <DetailModal
-          title={selected.talkgroup_alpha ?? `TG ${selected.group_id}`}
+          title={selected.talkgroup_alpha || `TG ${selected.group_id}`}
           subtitle={`${selected.system} · ${selected.protocol}`}
           onClose={() => setSelected(null)}
         >


### PR DESCRIPTION
A UHD multi-channel streamer rejects an immediate stream start:
"Invalid recv stream command - stream now on multiple channels in a
single streamer will fail to time align." — which made every MRC
diversity session on an X310 die at ACTIVATE_STREAM, exhaust the
ccdecoder retries, and take the daemon down.

Under diversity (rxChannelCount > 1) the client now reads the remote
hardware clock (GET_HARDWARE_TIME, opcode 1101) and activates with
SOAPY_SDR_HAS_TIME and a start scheduled 200 ms ahead, which is how
UHD wants multi-channel chains aligned. Remotes without a hardware
clock, or that reject the timed form, fall back to the immediate
start; the single-channel path is byte-identical to before.

Regression: TestStreamIQDiversityTimedActivate drives a fake server
that enforces the UHD rejection — it fails against the old
flags=0/timeNs=0 activate and passes now. Companions pin the
single-channel wire format (no clock query, flags=0) and the
clockless-remote fallback.

Refs #1062

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PPZrPniaF5eyPeLErJZvni