### PR TITLE
MRC antennas, P25 panel fixes, DMO/vocoder diagnostics, replay harness upgrades

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,6 +305,46 @@ confirmation before any close-as-completed.
       and the grant now lands ~0.5 s into a transmission (grid latch + 4 qualified DNBs) rather
       than instantly. `dnb_qualified` in the decode-status line is the number that means traffic —
       `dnb_total` is a noise meter, and a large gap between them is normal, not a fault.
+    6. **On-air A/B ran (15aug): the ceiling is RF/model, NOT colour recovery — and colour
+      recovery is behaving CORRECTLY.** The operator's purpose-built capture
+      (`dmo_test_15aug/25sec_ptt_then_off_30sec_cs16_144khz.raw`, 25 s clear colour-0 silent PTT,
+      144 kHz cs16) decodes DSB SCH/S at ~90% (105/117) but TCH/S sits near the chance floor at
+      **every** DM colour. `TestTETRADMOColourScan` (`GT_TETRA_DMO_SCAN=1`, the new diagnostic)
+      sweeps all 64 colours: several rise modestly at once (28→140, 57→74, 30→46 of 831 DNBs)
+      rather than one dominating — which one radio scrambling with one label cannot produce, and
+      which is why `RecoverDMColourCode`'s dominance gate (best ≥ 3×runner-up) correctly REFUSES
+      to pick one (140 < 3×74). That refusal is the operator's "colour guessing problem": not a
+      broken guesser but a marginal signal with no dominant colour. The SYNC PDU is self-consistent
+      with MNI=0/colour=0 (extended colour 0, matching osmo-tetra-dmo's `tetra_scramb_get_init`
+      offsets — GT's `ParseSyncPDU` bit offsets are identical), so the extended-colour path is not
+      the gap here. The blind CMA equalizer (already on by default) lifts DSB 77→105 and TCH 80→140;
+      LMS does not move it — so the receiver is already doing the right thing. NEXT: need a cleaner,
+      KNOWN-colour (from the CPS codeplug), actually-TALKING DMO capture — the 25 s silent PTT is a
+      poor vector (comfort-noise/DTX frames, and the sweep winners are partial keystream artifacts
+      of a marginal signal). Do NOT change the descramble to fit a 33%-yield non-dominant colour
+      (the #764/#771 self-consistency trap). The colour→colour_map is preserved in the diagnostic.
+- **Vocoder "sounds awful" is a MEASURED, LOCALIZED AMBE+2 3600×2450 (DMR) high-band deficit —
+  NOT RF, NOT post-processing.** Using the operator's DSD-FME (mbelib) decode of the SAME `.amb`
+  frames as ground truth (`err=[0]`, identical frame count), GopherTrunk's `ambe2-dmr` decode has
+  4–10× less energy above 1 kHz: octave band fractions (0-300/300-1k/1-2k/2-3k/3-4k) are
+  mbelib `0.200/0.513/0.181/0.073/0.033` vs GT-raw-`ambe2-dmr` `0.405/0.540/0.041/0.008/0.005`.
+  Content matches (envelope corr 0.69 — same speech, crushed highs). Isolation: the base `ambe2`
+  (3600×2400) decoder shares the exact same synthesis + §6.2 `EnhanceAmplitudes` and gives
+  mbelib-like highs (`0.121/0.053/0.020`), so the deficit is purely in `unpackParams2450`
+  (`internal/voice/ambe2/params2450.go` + `tables2450.go`) — the 3600×2450 spectral-amplitude
+  quantization reconstruction produces systematically low high-`l` amplitudes. NOT fixed this
+  round: this is conformance-pinned table code, so the fix needs a frame-by-frame diff against a
+  wired mbelib 2450 reference (an objective band-energy regression target), not a speculative table
+  change. Config note: the operator's `warm_dmr_audio: true` + `enhance` LPF only make it worse
+  (they cut highs further); the synthesis is the cause. Reproduce:
+  `gophertrunk decode -in <dmr>.raw -out gt.wav -vocoder ambe2-dmr` and compare octave-band
+  fractions to the DSD-FME decode of the paired `.amb`. IMBE (P25) shows the same direction, milder.
+- **DSD-FME `.imb`/`.amb` interop VERIFIED (frame-exact); the "slow/pitch" playback is an upstream
+  DSD-FME quirk.** `recordings.mbe_files` writes DSD-FME's native cookie-headed container and
+  DSD-FME decodes it cleanly (`err=[0]`). DSD-FME's `-w single.wav` writer stamps an 8 kHz header
+  on 12 kHz synthesis (file plays ~1.5× slow) — envelope correlation is 0.69 after a 1.5× time
+  correction, proving content parity. Not a GT bug; use DSD-FME `-P` (per-call) or `-o pulse`, or
+  relabel the `-w` WAV to 12 kHz. Documented in `docs/vocoders.md`.
 - **Conventional DMR (Tier II / IPSC) now decodes a repeater's TWO timeslots as two calls.**
   A base-station DMR repeater carries TS1 and TS2 interleaved on one carrier, each able to hold
   a separate simultaneous talkgroup. The conventional path (`internal/radio/dmr/tier2`) used to

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -1115,6 +1115,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 					StreamWindow:   s.StreamWindow,
 					ConnectTimeout: time.Duration(s.ConnectTimeoutMs) * time.Millisecond,
 					Diversity:      s.Diversity,
+					Antennas:       s.Antennas,
 				})
 				if s.Serial != "" {
 					h := sdr.Hint{

--- a/cmd/gophertrunk/dmr_ipsc_replay_test.go
+++ b/cmd/gophertrunk/dmr_ipsc_replay_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/binary"
+	"fmt"
 	"os"
 	"strconv"
 	"sync"
@@ -176,10 +177,18 @@ func TestDMRIPSCReplay(t *testing.T) {
 		t.Logf("  embedded-LC group_address=%d count=%d", tg, n)
 	}
 
-	// The harness is a diagnostic: it must always surface *something* (a grant or
-	// a decoded superframe) or the capture/rate/tune is wrong. A silent pass on a
-	// live capture would hide exactly the failure #1036 is about.
+	// The harness is a diagnostic. On a signal-bearing capture it should surface
+	// a grant or a superframe, and zero of both usually means a wrong rate/tune.
+	// But a genuinely weak-signal capture that decodes NOTHING is itself a valid
+	// baseline measurement (the 0/0 floor the equalizer work is measured
+	// against), so GT_DMR_ALLOW_EMPTY=1 downgrades the hard failure to a logged
+	// warning. Default stays strict so an accidental mistune is still caught.
 	if len(grants) == 0 && superframes == 0 {
-		t.Fatalf("no grants and no voice superframes decoded — check GT_DMR_IQ_RATE (%v) / tuning / capture", inRate)
+		msg := fmt.Sprintf("no grants and no voice superframes decoded — check GT_DMR_IQ_RATE (%v) / tuning / capture", inRate)
+		if os.Getenv("GT_DMR_ALLOW_EMPTY") == "1" {
+			t.Logf("WARNING: %s (GT_DMR_ALLOW_EMPTY=1: treating as a weak-signal 0/0 baseline)", msg)
+		} else {
+			t.Fatalf("%s", msg)
+		}
 	}
 }

--- a/cmd/gophertrunk/replay.go
+++ b/cmd/gophertrunk/replay.go
@@ -33,7 +33,7 @@ func runReplay(args []string) {
 	fs := flag.NewFlagSet("replay", flag.ExitOnError)
 	verboseFlag := fs.Bool("verbose-errors", false, "print full error chain + stack on failures")
 	in := fs.String("in", "", "raw IQ input file, or - for standard input (required). Piping stdin lets an external IQ source feed the decoder, e.g. `iq-source | gophertrunk replay -in - -format f32 -sample-rate 2400000` (issue #314). stdin is a one-way stream, so -auto-tune (which must seek) is not supported with -in -; use -tune-hz.")
-	format := fs.String("format", "u8", "sample format: u8 (rtl_sdr 8-bit unsigned interleaved IQ) | f32 (GNU Radio cfile, interleaved float32) | wav (2-channel 16-bit baseband WAV — SDRtrunk/SDR++/GopherTrunk narrowband recording; sample rate is read from the header)")
+	format := fs.String("format", "u8", "sample format: u8 (rtl_sdr 8-bit unsigned interleaved IQ) | f32 (GNU Radio cfile, interleaved float32) | cs16/sc16 (interleaved little-endian int16 IQ, the .raw/.cs16 SDR capture format) | wav (2-channel 16-bit baseband WAV — SDRtrunk/SDR++/GopherTrunk narrowband recording; sample rate is read from the header)")
 	sampleRate := fs.Float64("sample-rate", 2_400_000, "IQ sample rate in Hz")
 	demod := fs.String("demod", "c4fm", "P25 Phase 1 demod mode: c4fm | cqpsk")
 	protocolFlag := fs.String("protocol", "p25p1", "decoder to run: p25p1 | p25-phase2 | dmr | dmr-tier2 | nxdn | dpmr | edacs | motorola | ltr | mpt1327 | tetra | ysf | dstar (aliases: dmr-tier3)")

--- a/cmd/gophertrunk/tetra_dmo_replay_test.go
+++ b/cmd/gophertrunk/tetra_dmo_replay_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"encoding/binary"
+	"fmt"
+	"math"
 	"os"
 	"sort"
 	"strconv"
@@ -41,18 +43,6 @@ import (
 // sourced). It prints a per-transmission timeline and the recovered PCM duration
 // so the maintainer can A/B it and confirm the audio is intelligible.
 func TestTETRADMOReplay(t *testing.T) {
-	path := os.Getenv("GT_TETRA_DMO_IQ")
-	if path == "" {
-		t.Skip("set GT_TETRA_DMO_IQ (cs16 IQ) + GT_TETRA_DMO_RATE to run the DMO replay")
-	}
-	inRate := 150000.0
-	if v := os.Getenv("GT_TETRA_DMO_RATE"); v != "" {
-		f, err := strconv.ParseFloat(v, 64)
-		if err != nil {
-			t.Fatalf("bad GT_TETRA_DMO_RATE: %v", err)
-		}
-		inRate = f
-	}
 	var colour uint32
 	colourSet := false
 	if v := os.Getenv("GT_TETRA_DMO_COLOUR"); v != "" {
@@ -64,79 +54,8 @@ func TestTETRADMOReplay(t *testing.T) {
 		colourSet = true
 	}
 
-	raw, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	iq := make([]complex64, len(raw)/4)
-	for i := range iq {
-		re := int16(binary.LittleEndian.Uint16(raw[i*4:]))
-		im := int16(binary.LittleEndian.Uint16(raw[i*4+2:]))
-		iq[i] = complex(float32(re)/32768, float32(im)/32768)
-	}
-
-	ddc := ccdecoder.NewDownconverter(inRate, 144000)
-	outRate := ddc.OutRateHz()
-
-	// Accumulate the full demodulated dibit stream and the parallel per-symbol
-	// differentials (soft info); ExtractDMBurstsSoft is stateless over a complete
-	// slice, which keeps the offline framing deterministic. The SoftSink fires
-	// just before the matching DibitSink with the same base, so appending both in
-	// order keeps allDiffs strictly parallel to allDibits.
-	var allDibits []uint8
-	var allDiffs []complex64
-	var allSymbols []complex64
-	// The receiver blind-CMA equalizer is REQUIRED, not optional, for DMO: on the
-	// reporter's 438.9 MHz capture it lifts CRC-valid SCH/S from 6 → 64 (the whole
-	// transmission) by inverting the ISI/multipath that smears the π/4-DQPSK
-	// constellation — the same lever the live TMO CC path already runs by default
-	// (pipelines.go newTETRAPipeline). So it is ON by default here; set
-	// GT_TETRA_DMO_EQ=0 to A/B the raw (un-equalized) receiver.
-	enableEQ := os.Getenv("GT_TETRA_DMO_EQ") != "0" && os.Getenv("GT_TETRA_DMO_EQ") != "false"
-	enableLMS := os.Getenv("GT_TETRA_DMO_LMS") == "1" || os.Getenv("GT_TETRA_DMO_LMS") == "true"
-	rx := tetrarx.New(tetrarx.Options{
-		SampleRateHz: outRate,
-		DibitSink: func(d []uint8, _ int) {
-			allDibits = append(allDibits, d...)
-		},
-		SoftSink: func(diffs []complex64, _ int) {
-			allDiffs = append(allDiffs, diffs...)
-		},
-		// Raw symbols for the per-burst training-sequence equalizer (GT_TETRA_DMO_LMS).
-		SymbolSink: func(syms []complex64, _ int) {
-			allSymbols = append(allSymbols, syms...)
-		},
-		ClockMode:           tetrarx.ClockGardner,
-		GardnerGain:         0.005,
-		EnableAFC:           true,
-		EnableChannelFilter: true,
-		EnableEqualizer:     enableEQ,
-	})
-
-	const chunk = 65536
-	var scratch []complex64
-	for i := 0; i < len(iq); i += chunk {
-		e := i + chunk
-		if e > len(iq) {
-			e = len(iq)
-		}
-		scratch = ddc.Process(scratch[:0], iq[i:e])
-		rx.Process(scratch)
-	}
-
+	bursts, inRate, outRate, iqLen, enableEQ, enableLMS := loadDMOReplayBursts(t)
 	dibitRate := tetrarx.SymbolRate // 18000 dibits/sec
-	// Soft-capable extraction: carry the differentials so DMBurstTCHSpeechSoft can
-	// recover corrupted TCH/S bursts the hard path drops (the #1001 ~2× lever).
-	// Falls back to the hard ExtractDMBursts geometry if the soft stream didn't
-	// stay parallel (length mismatch). GT_TETRA_DMO_LMS=1 additionally trains a
-	// per-burst equalizer on each rotation-0 DNB's midamble and re-derives the soft
-	// blocks from the equalized symbols (#1001's LMS lever for Direct Mode).
-	var bursts []tetra.DMBurst
-	if enableLMS {
-		bursts = tetra.ExtractDMBurstsEqualized(allDibits, allDiffs, allSymbols, 0, 0, 0)
-	} else {
-		bursts = tetra.ExtractDMBurstsSoft(allDibits, allDiffs, 0)
-	}
 
 	// Recover the DM colour code the TCH/S is scrambled with when it was not
 	// pinned via GT_TETRA_DMO_COLOUR (#1003). The DSB SCH/S is always colour-0
@@ -207,7 +126,7 @@ func TestTETRADMOReplay(t *testing.T) {
 	}
 
 	t.Logf("in=%.0fHz out=%.0fHz samples=%d dur=%.1fs colour=%#x eq=%v lms=%v",
-		inRate, outRate, len(iq), float64(len(iq))/inRate, colour, enableEQ, enableLMS)
+		inRate, outRate, iqLen, float64(iqLen)/inRate, colour, enableEQ, enableLMS)
 	t.Logf("bursts: dsb_total=%d dsb_schs_crc=%d dnb_total=%d tch_crc=%d (soft_only=%d)",
 		dsbTotal, dsbCRC, dnbTotal, tchCRC, tchSoftOnly)
 	sort.Ints(syncSecs)
@@ -284,4 +203,290 @@ func TestTETRADMOReplay(t *testing.T) {
 		writeWav8kLocal(outDir+"/dmo.wav", pcm)
 		t.Logf("wrote %s/dmo.wav", outDir)
 	}
+}
+
+// loadDMOReplayBursts reads GT_TETRA_DMO_IQ (cs16, GT_TETRA_DMO_RATE), resamples
+// to the 144 kHz TETRA channel rate, runs the shared receiver (GT_TETRA_DMO_EQ /
+// GT_TETRA_DMO_LMS as in TestTETRADMOReplay) and returns every extracted DM
+// burst with soft info, plus the run parameters for logging. Skips the calling
+// test when no capture is configured.
+func loadDMOReplayBursts(t *testing.T) (bursts []tetra.DMBurst, inRate, outRate float64, iqLen int, enableEQ, enableLMS bool) {
+	t.Helper()
+	path := os.Getenv("GT_TETRA_DMO_IQ")
+	if path == "" {
+		t.Skip("set GT_TETRA_DMO_IQ (cs16 IQ) + GT_TETRA_DMO_RATE to run the DMO replay")
+	}
+	inRate = 150000.0
+	if v := os.Getenv("GT_TETRA_DMO_RATE"); v != "" {
+		f, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			t.Fatalf("bad GT_TETRA_DMO_RATE: %v", err)
+		}
+		inRate = f
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	iq := make([]complex64, len(raw)/4)
+	for i := range iq {
+		re := int16(binary.LittleEndian.Uint16(raw[i*4:]))
+		im := int16(binary.LittleEndian.Uint16(raw[i*4+2:]))
+		iq[i] = complex(float32(re)/32768, float32(im)/32768)
+	}
+	iqLen = len(iq)
+
+	ddc := ccdecoder.NewDownconverter(inRate, 144000)
+	outRate = ddc.OutRateHz()
+
+	// Accumulate the full demodulated dibit stream and the parallel per-symbol
+	// differentials (soft info); ExtractDMBurstsSoft is stateless over a complete
+	// slice, which keeps the offline framing deterministic. The SoftSink fires
+	// just before the matching DibitSink with the same base, so appending both in
+	// order keeps allDiffs strictly parallel to allDibits.
+	var allDibits []uint8
+	var allDiffs []complex64
+	var allSymbols []complex64
+	// The receiver blind-CMA equalizer is REQUIRED, not optional, for DMO: on the
+	// reporter's 438.9 MHz capture it lifts CRC-valid SCH/S from 6 → 64 (the whole
+	// transmission) by inverting the ISI/multipath that smears the π/4-DQPSK
+	// constellation — the same lever the live TMO CC path already runs by default
+	// (pipelines.go newTETRAPipeline). So it is ON by default here; set
+	// GT_TETRA_DMO_EQ=0 to A/B the raw (un-equalized) receiver.
+	enableEQ = os.Getenv("GT_TETRA_DMO_EQ") != "0" && os.Getenv("GT_TETRA_DMO_EQ") != "false"
+	enableLMS = os.Getenv("GT_TETRA_DMO_LMS") == "1" || os.Getenv("GT_TETRA_DMO_LMS") == "true"
+	rx := tetrarx.New(tetrarx.Options{
+		SampleRateHz: outRate,
+		DibitSink: func(d []uint8, _ int) {
+			allDibits = append(allDibits, d...)
+		},
+		SoftSink: func(diffs []complex64, _ int) {
+			allDiffs = append(allDiffs, diffs...)
+		},
+		// Raw symbols for the per-burst training-sequence equalizer (GT_TETRA_DMO_LMS).
+		SymbolSink: func(syms []complex64, _ int) {
+			allSymbols = append(allSymbols, syms...)
+		},
+		ClockMode:           tetrarx.ClockGardner,
+		GardnerGain:         0.005,
+		EnableAFC:           true,
+		EnableChannelFilter: true,
+		EnableEqualizer:     enableEQ,
+	})
+
+	const chunk = 65536
+	var scratch []complex64
+	for i := 0; i < len(iq); i += chunk {
+		e := i + chunk
+		if e > len(iq) {
+			e = len(iq)
+		}
+		scratch = ddc.Process(scratch[:0], iq[i:e])
+		rx.Process(scratch)
+	}
+
+	// Soft-capable extraction: carry the differentials so DMBurstTCHSpeechSoft can
+	// recover corrupted TCH/S bursts the hard path drops (the #1001 ~2× lever).
+	// GT_TETRA_DMO_LMS=1 additionally trains a per-burst equalizer on each
+	// rotation-0 DNB's midamble and re-derives the soft blocks from the equalized
+	// symbols (#1001's LMS lever for Direct Mode).
+	if enableLMS {
+		bursts = tetra.ExtractDMBurstsEqualized(allDibits, allDiffs, allSymbols, 0, 0, 0)
+	} else {
+		bursts = tetra.ExtractDMBurstsSoft(allDibits, allDiffs, 0)
+	}
+	return bursts, inRate, outRate, iqLen, enableEQ, enableLMS
+}
+
+// TestTETRADMOColourScan is the #1003 descramble-model diagnostic. The 15aug
+// capture (25 s of clear, colour-0 silent PTT) decodes SCH/S at ~90% yet TCH/S
+// sits near the chance floor at EVERY single colour — and a 64-colour sweep
+// shows several colours rising modestly above the floor at once (28/57/30),
+// which one radio scrambling with one label cannot produce. That signature
+// means the DM descramble model is missing a per-burst component. This scan
+// maps, for every DNB: which colours CRC-decode it, its slot-grid position,
+// and its frame number estimated from the CRC-valid DSBs' SYNC PDU FN — so the
+// burst→colour map reveals the rule (FN-dependent seed, cross-burst pairing,
+// …) instead of guessing. It also tries the cross-burst pairing hypothesis
+// (BKN2 of burst k + BKN1 of burst k+1 as one slot) across all colours.
+//
+// Diagnostic only: it asserts nothing and prints the map for analysis.
+func TestTETRADMOColourScan(t *testing.T) {
+	if os.Getenv("GT_TETRA_DMO_SCAN") == "" {
+		t.Skip("set GT_TETRA_DMO_SCAN=1 (plus GT_TETRA_DMO_IQ/RATE) to run the colour-map scan")
+	}
+	bursts, _, _, _, _, _ := loadDMOReplayBursts(t)
+
+	// FN anchors from CRC-valid DSBs: (lead, FN).
+	type anchor struct {
+		lead int
+		fn   int
+	}
+	var anchors []anchor
+	for i := range bursts {
+		b := bursts[i]
+		if b.Kind != tetra.DMBurstSync {
+			continue
+		}
+		if type1, ok := tetra.DecodeDMSCHS(b); ok {
+			if pdu, pok := tetra.ParseSyncPDU(type1); pok {
+				anchors = append(anchors, anchor{lead: b.Lead, fn: int(pdu.FN)})
+			}
+		}
+	}
+	// estFN estimates a burst's TETRA frame number (1..18) from the nearest
+	// anchor, assuming one occupied slot per frame (4 slots × 255 dibits between
+	// consecutive frames — the spacing consecutive DNBs of a DMO call show).
+	const frameDibits = 4 * 255
+	estFN := func(lead int) int {
+		if len(anchors) == 0 {
+			return -1
+		}
+		best := anchors[0]
+		for _, a := range anchors[1:] {
+			if iabsDMO(lead-a.lead) < iabsDMO(lead-best.lead) {
+				best = a
+			}
+		}
+		off := int(math.Round(float64(lead-best.lead) / frameDibits))
+		fn := (best.fn - 1 + off) % 18
+		for fn < 0 {
+			fn += 18
+		}
+		return fn + 1
+	}
+
+	decodesAt := func(b tetra.DMBurst, c uint32) bool {
+		return len(tetra.DMBurstTCHSpeechSoft(b, c)) == 2 || len(tetra.DMBurstTCHSpeech(b, c)) == 2
+	}
+
+	// Per-burst colour map + aggregations.
+	var dnbs []tetra.DMBurst
+	for i := range bursts {
+		if bursts[i].Kind == tetra.DMBurstNormal {
+			dnbs = append(dnbs, bursts[i])
+		}
+	}
+	colourTotals := map[int]int{}
+	fnColour := map[[2]int]int{} // {fn, colour} -> count
+	deltaHist := map[int]int{}   // consecutive-DNB lead deltas (slot units ×255)
+	multi := 0
+	prevLead := -1
+	for _, b := range dnbs {
+		if prevLead >= 0 {
+			deltaHist[b.Lead-prevLead]++
+		}
+		prevLead = b.Lead
+		var wins []int
+		for c := 0; c < 64; c++ {
+			if decodesAt(b, uint32(c)) {
+				wins = append(wins, c)
+			}
+		}
+		if len(wins) > 1 {
+			multi++
+		}
+		fn := estFN(b.Lead)
+		for _, c := range wins {
+			colourTotals[c]++
+			fnColour[[2]int{fn, c}]++
+		}
+		if len(wins) > 0 {
+			t.Logf("dnb lead=%d sec=%.1f rot=%d fn=%d colours=%v",
+				b.Lead, float64(b.Lead)/tetrarx.SymbolRate, b.Rotation, fn, wins)
+		}
+	}
+	t.Logf("dnbs=%d multi-colour bursts=%d anchors=%d", len(dnbs), multi, len(anchors))
+
+	type kv struct{ k, v int }
+	var totals []kv
+	for c, n := range colourTotals {
+		totals = append(totals, kv{c, n})
+	}
+	sort.Slice(totals, func(i, j int) bool { return totals[i].v > totals[j].v })
+	if len(totals) > 12 {
+		totals = totals[:12]
+	}
+	t.Logf("top colour totals: %v", totals)
+	var fnMap []string
+	for k, n := range fnColour {
+		if n >= 3 {
+			fnMap = append(fnMap, fmt.Sprintf("fn%02d:c%02d=%d", k[0], k[1], n))
+		}
+	}
+	sort.Strings(fnMap)
+	t.Logf("fn→colour (n>=3): %v", fnMap)
+	var deltas []kv
+	for d, n := range deltaHist {
+		deltas = append(deltas, kv{d, n})
+	}
+	sort.Slice(deltas, func(i, j int) bool { return deltas[i].v > deltas[j].v })
+	if len(deltas) > 8 {
+		deltas = deltas[:8]
+	}
+	t.Logf("top DNB lead deltas (dibits): %v", deltas)
+
+	// Cross-burst pairing hypothesis: decode BKN2 of burst k + BKN1 of burst k+1
+	// as one 432-bit slot, for consecutive same-rotation DNBs one slot-multiple
+	// apart, across all colours.
+	pairTotals := map[int]int{}
+	pairs := 0
+	for i := 0; i+1 < len(dnbs); i++ {
+		a, b := dnbs[i], dnbs[i+1]
+		gap := b.Lead - a.Lead
+		if a.Rotation != b.Rotation || gap <= 0 || gap > 8*255 || gap%255 != 0 {
+			continue
+		}
+		pairs++
+		pb := tetra.DMBurst{
+			Kind: tetra.DMBurstNormal, Lead: a.Lead, Rotation: a.Rotation,
+			BKN1: a.BKN2, BKN2: b.BKN1,
+			SoftBKN1: a.SoftBKN2, SoftBKN2: b.SoftBKN1,
+		}
+		for c := 0; c < 64; c++ {
+			if decodesAt(pb, uint32(c)) {
+				pairTotals[c]++
+			}
+		}
+	}
+	var ptotals []kv
+	for c, n := range pairTotals {
+		ptotals = append(ptotals, kv{c, n})
+	}
+	sort.Slice(ptotals, func(i, j int) bool { return ptotals[i].v > ptotals[j].v })
+	if len(ptotals) > 12 {
+		ptotals = ptotals[:12]
+	}
+	t.Logf("cross-burst pairing: pairs=%d top colour totals: %v", pairs, ptotals)
+
+	// Swapped-block hypothesis: BKN2+BKN1 of the SAME burst as one slot.
+	swapTotals := map[int]int{}
+	for _, b := range dnbs {
+		sb := tetra.DMBurst{
+			Kind: tetra.DMBurstNormal, Lead: b.Lead, Rotation: b.Rotation,
+			BKN1: b.BKN2, BKN2: b.BKN1,
+			SoftBKN1: b.SoftBKN2, SoftBKN2: b.SoftBKN1,
+		}
+		for c := 0; c < 64; c++ {
+			if decodesAt(sb, uint32(c)) {
+				swapTotals[c]++
+			}
+		}
+	}
+	var stotals []kv
+	for c, n := range swapTotals {
+		stotals = append(stotals, kv{c, n})
+	}
+	sort.Slice(stotals, func(i, j int) bool { return stotals[i].v > stotals[j].v })
+	if len(stotals) > 6 {
+		stotals = stotals[:6]
+	}
+	t.Logf("same-burst swapped blocks: top colour totals: %v", stotals)
+}
+
+func iabsDMO(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
 }

--- a/cmd/gophertrunk/tetra_multislot_replay_test.go
+++ b/cmd/gophertrunk/tetra_multislot_replay_test.go
@@ -41,7 +41,20 @@ func TestTETRAMultiSlotReplay(t *testing.T) {
 		}
 		inRate = f
 	}
-	const colourExt = 262144876 // the reporter's cell
+	// The extended colour code (MCC|MNC|colour) the TCH/S is scrambled with —
+	// cell-specific, so on any capture other than the original reporter's it
+	// must be overridden or the TCH/S descramble is wrong and the CRC counts
+	// sit at the ~1/256 chance floor (indistinguishable from a weak signal).
+	// GT_TETRA_COLOUR overrides it (decimal or 0x-hex); default is the
+	// reporter's cell.
+	var colourExt uint32 = 262144876
+	if v := os.Getenv("GT_TETRA_COLOUR"); v != "" {
+		c, err := strconv.ParseUint(v, 0, 32)
+		if err != nil {
+			t.Fatalf("bad GT_TETRA_COLOUR: %v", err)
+		}
+		colourExt = uint32(c)
+	}
 
 	raw, err := os.ReadFile(path)
 	if err != nil {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -603,6 +603,15 @@ sdr:
   #     gain: "auto"                # "auto" or tenths-of-dB ("300" = 30.0 dB)
   #     bias_tee: false             # best-effort (driver-dependent)
   #     connect_timeout_ms: 3000
+  #     diversity: ""               # "" (single channel) or "mrc" — opens RX0+RX1
+  #                                 #  and phase-coherently combines them into one
+  #                                 #  maximised-SNR stream. Shared-LO front-ends
+  #                                 #  only (USRP B210 / AD9361). Experimental.
+  #     antennas: []                # RX antenna port per channel, in order, e.g.
+  #                                 #  [RX1, RX2] for a USRP X310 under diversity:
+  #                                 #  mrc. Use this instead of antenna= in args —
+  #                                 #  a comma-separated antenna can't live in the
+  #                                 #  flat args string. Empty = device default.
 
   # ka9q-radio channels. radiod (https://github.com/ka9q/ka9q-radio)
   # runs fast-convolution downconverters on a front end (RX888, Airspy,

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -810,14 +810,40 @@ sdr:
       # are fine too). But remote:mtu / remote:window are SoapyRemote STREAM
       # args — set the MTU under stream_mtu below, not in args (config load
       # rejects remote:* here).
-      args: "addr=10.110.162.17,rx_subdev_spec=A:0,antenna=RX1,clock_source=gpsdo,time_source=gpsdo,enable_bias_tee=1"
+      args: "addr=10.110.162.17,rx_subdev_spec=A:0,antenna=RX1,clock_source=gpsdo,time_source=gpsdo"
       format: "CS16"
       role: "auto"
       gain: "750"                     # 75.0 dB, set manually — see gain note below
-      bias_tee: true
+      bias_tee: true                  # do NOT also put enable_bias_tee=1 in args (duplicate)
       stream_mtu: 8192                 # jumbo-frame link; sizes SETUP_STREAM + window
       connect_timeout_ms: 20000
 ```
+
+**Per-channel antenna selection (`antennas:`).** A single antenna can go in
+`args` as `antenna=RX1`, but a comma inside a flat `key=value` args string
+splits arguments, so a *multi-value* antenna (one per RX channel) can't be
+expressed there — SoapySDR's own kwargs parser has the same limitation. Use the
+dedicated `antennas:` list instead, applied in channel order via SoapySDR
+`setAntenna` after the device opens. This is what an X310 in **MRC diversity**
+needs, RX1 on channel 0 and RX2 on channel 1:
+
+```yaml
+  soapy_remote:
+    - addr: "10.110.162.1:23313"
+      driver: "uhd"
+      # Two RX channels: A:0 B:0 (a space inside a value is fine here — args
+      # only split on commas). clock/time_source stay in args (real UHD
+      # make() kwargs). Do NOT put antenna= in args when antennas: is set.
+      args: "addr=10.110.162.17,rx_subdev_spec=A:0 B:0,clock_source=gpsdo,time_source=gpsdo"
+      diversity: mrc                  # opens RX0+RX1, phase-coherent combine
+      antennas: [RX1, RX2]            # RX1→channel 0, RX2→channel 1
+      format: "CS16"
+      gain: "750"
+```
+
+`antennas:` accepts at most two entries; more than one requires `diversity: mrc`
+(only one RX channel is opened otherwise). Setting both `antennas:` and
+`antenna=` in `args` is rejected — pick one.
 
 Two operational notes from that deployment:
 

--- a/docs/vocoders.md
+++ b/docs/vocoders.md
@@ -139,6 +139,30 @@ consumers (web UIs, batch processors, post-mortem analysis tools)
 can reuse the same decode path without spawning a binary. See
 `internal/voice/streamdecode.go`.
 
+### DSD-FME-playable sidecars (`recordings.mbe_files`)
+
+With `recordings.mbe_files: true` the recorder additionally writes a
+DSD-FME-native container next to each recording, for the protocols
+DSD-FME can play offline: `<name>.imb` for P25 Phase 1 IMBE and
+`<name>.amb` for DMR / NXDN / P25 Phase 2 AMBE+2. These are DSD-FME's
+own cookie-headed format, so they decode directly:
+
+```sh
+dsd-fme -f1 -w out.wav -r call.imb    # P25 Phase 1 IMBE
+dsd-fme -fs -w out.wav -r call.amb    # DMR AMBE+2
+```
+
+TETRA ACELP and EDACS ProVoice have no DSD-FME playback mode, so they
+produce no MBE sidecar (the flat `.raw` remains the escape hatch).
+
+**Note on DSD-FME's `-w` output rate.** DSD-FME's `-w single.wav`
+writer stamps an 8 kHz header on synthesis it produces at 12 kHz, so
+the file plays ~1.5× slow / low-pitched. This is an upstream DSD-FME
+quirk, not a GopherTrunk one — the `.amb`/`.imb` frame counts match
+GopherTrunk's own decode exactly. Use DSD-FME's per-call output
+(`-P`) or live audio (`-o pulse`) to hear it at the right rate, or
+re-label the `-w` WAV to 12 kHz.
+
 ## Implementation notes
 
 - `internal/voice/mbe/` is the shared MBE-family synthesis core:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -786,6 +786,15 @@ type SoapyRemoteConfig struct {
 	// (issue #1062): the 2-channel wire de-interleave is not yet confirmed on a
 	// live dual-RX server.
 	Diversity string `yaml:"diversity"`
+	// Antennas selects the RX antenna port per channel (SoapySDR setAntenna),
+	// applied in channel order after the device opens — antennas[0] to RX
+	// channel 0, antennas[1] to channel 1. A multi-value antenna cannot be
+	// expressed in the flat "key=value" args string (a comma there splits
+	// arguments), so a USRP X310 in MRC diversity that needs RX1 on channel 0
+	// and RX2 on channel 1 uses this list instead of args. Empty leaves the
+	// device default. More than one entry requires diversity: mrc (only one RX
+	// channel is opened otherwise).
+	Antennas []string `yaml:"antennas"`
 }
 
 // parseDeviceArgs parses a SoapySDR-style "key=value,key2=value2" argument

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -396,6 +396,13 @@ func TestValidate(t *testing.T) {
 		{"soapy diversity mrc ok", Config{SDR: SDRConfig{SoapyRemote: []SoapyRemoteConfig{{Addr: "h:1", Diversity: "mrc"}}}}, false},
 		{"soapy diversity empty ok", Config{SDR: SDRConfig{SoapyRemote: []SoapyRemoteConfig{{Addr: "h:1", Diversity: ""}}}}, false},
 		{"soapy diversity bad rejected", Config{SDR: SDRConfig{SoapyRemote: []SoapyRemoteConfig{{Addr: "h:1", Diversity: "selection"}}}}, true},
+		// antennas[]: one is fine single-channel; two require mrc; >2 and empties rejected.
+		{"soapy antennas single ok", Config{SDR: SDRConfig{SoapyRemote: []SoapyRemoteConfig{{Addr: "h:1", Antennas: []string{"RX2"}}}}}, false},
+		{"soapy antennas two with mrc ok", Config{SDR: SDRConfig{SoapyRemote: []SoapyRemoteConfig{{Addr: "h:1", Diversity: "mrc", Antennas: []string{"RX1", "RX2"}}}}}, false},
+		{"soapy antennas two without mrc rejected", Config{SDR: SDRConfig{SoapyRemote: []SoapyRemoteConfig{{Addr: "h:1", Antennas: []string{"RX1", "RX2"}}}}}, true},
+		{"soapy antennas three rejected", Config{SDR: SDRConfig{SoapyRemote: []SoapyRemoteConfig{{Addr: "h:1", Diversity: "mrc", Antennas: []string{"RX1", "RX2", "RX3"}}}}}, true},
+		{"soapy antennas empty entry rejected", Config{SDR: SDRConfig{SoapyRemote: []SoapyRemoteConfig{{Addr: "h:1", Antennas: []string{""}}}}}, true},
+		{"soapy antennas conflict with args rejected", Config{SDR: SDRConfig{SoapyRemote: []SoapyRemoteConfig{{Addr: "h:1", Args: "antenna=RX1", Antennas: []string{"RX2"}}}}}, true},
 		// soapy_remote stream_mtu: 0 = default; a real MTU is fine; out-of-range fails.
 		{"soapy stream_mtu zero ok", Config{SDR: SDRConfig{SoapyRemote: []SoapyRemoteConfig{{Addr: "h:1"}}}}, false},
 		{"soapy stream_mtu valid", Config{SDR: SDRConfig{SoapyRemote: []SoapyRemoteConfig{{Addr: "h:1", StreamMTU: 8192}}}}, false},

--- a/internal/config/config_validate.go
+++ b/internal/config/config_validate.go
@@ -238,10 +238,39 @@ func validateSoapyFields(i int, s SoapyRemoteConfig) error {
 	default:
 		return fmt.Errorf("sdr.soapy_remote[%d]: stream_protocol must be tcp", i)
 	}
+	diversityMRC := false
 	switch strings.ToLower(strings.TrimSpace(s.Diversity)) {
-	case "", "none", "off", "mrc":
+	case "", "none", "off":
+	case "mrc":
+		diversityMRC = true
 	default:
 		return fmt.Errorf("sdr.soapy_remote[%d]: diversity must be mrc or empty", i)
+	}
+	// antennas[] selects an RX antenna per channel. At most two (RX0, RX1), and
+	// more than one only makes sense under mrc (a single-channel stream opens
+	// only channel 0). No empty entries — an empty string is a silent no-op that
+	// reads like an intentional default and hides a typo.
+	if len(s.Antennas) > 2 {
+		return fmt.Errorf("sdr.soapy_remote[%d]: antennas has %d entries (max 2: RX channel 0 and 1)", i, len(s.Antennas))
+	}
+	if len(s.Antennas) > 1 && !diversityMRC {
+		return fmt.Errorf("sdr.soapy_remote[%d]: antennas has %d entries but only one RX channel is opened without diversity: mrc", i, len(s.Antennas))
+	}
+	for j, a := range s.Antennas {
+		if strings.TrimSpace(a) == "" {
+			return fmt.Errorf("sdr.soapy_remote[%d]: antennas[%d] is empty", i, j)
+		}
+	}
+	// An antenna= left in the flat args string reaches make() but does NOT set a
+	// per-channel antenna the way antennas[] does (make() args can't carry a
+	// comma-separated multi-value), so a config with both is ambiguous — point
+	// at the field that actually applies per channel.
+	if len(s.Antennas) > 0 {
+		if args, err := s.DeviceArgs(); err == nil {
+			if _, ok := args["antenna"]; ok {
+				return fmt.Errorf("sdr.soapy_remote[%d]: set the antenna via the antennas: list, not antenna= in args (the args value applies to make() only, not per RX channel)", i)
+			}
+		}
 	}
 	// stream_mtu is in bytes; 0 means SoapyRemote's default (1500). Reject
 	// values that can't be a real endpoint MTU — too small to hold a useful

--- a/internal/configbuilder/fieldmeta.go
+++ b/internal/configbuilder/fieldmeta.go
@@ -148,6 +148,7 @@ var fieldMetas = map[string]FieldMeta{
 	"SoapyRemoteConfig.BiasTee":          {Label: "Bias-tee", Help: "Toggle the remote device's bias-tee (best-effort)."},
 	"SoapyRemoteConfig.ConnectTimeoutMs": {Help: "TCP dial timeout in ms. 0 = driver default (3000)."},
 	"SoapyRemoteConfig.Diversity":        {Help: "Spatial diversity combiner. Empty = single channel. 'mrc' opens RX0+RX1 and phase-coherently combines them (shared-LO front-ends only, e.g. USRP B210). Experimental.", Options: opts("", "(none)", "mrc", "mrc")},
+	"SoapyRemoteConfig.Antennas":         {Help: "RX antenna port per channel, in channel order (e.g. [RX1, RX2] for an X310 under diversity: mrc). Empty leaves the device default. Use this instead of antenna= in args, which a comma-separated value can't express."},
 
 	"Ka9qRadioConfig.Addr":             {Label: "Address", Help: "ka9q-radio status+command multicast group: an mDNS name like hf.local (or hf.local:5006), or a literal 239.x.x.x:5006. Missing port defaults to 5006. Required."},
 	"Ka9qRadioConfig.SSRC":             {Label: "SSRC", Help: "Channel's RTP SSRC within the radiod instance (e.g. 162550). Required, non-zero."},

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -1246,6 +1246,11 @@ func (c *ControlChannel) dispatchTSBK(t TSBK, nac uint16, metric int) {
 			"base_hz", u.BaseHz, "spacing_hz", u.SpacingHz,
 			"tx_offset_hz", u.TxOffsetHz)
 		c.drainPendingGrants(u.ChannelID, nac)
+		// A newly-applied band lets a neighbour on it resolve its downlink
+		// frequency; republish topology so the site table / API pick it up
+		// (symmetric with drainPendingGrants for the grant side). No-op until
+		// the site is otherwise identified (publishSiteUpdate's guard).
+		c.publishSiteUpdate()
 	case OpIdentifierUpdateVUHF:
 		u := ParseIdentifierUpdateVUHF(t.Payload)
 		c.bandPlan.Apply(u)
@@ -1255,6 +1260,7 @@ func (c *ControlChannel) dispatchTSBK(t TSBK, nac uint16, metric int) {
 			"tx_offset_hz", u.TxOffsetHz,
 			"bandwidth_hz", u.BandwidthHz)
 		c.drainPendingGrants(u.ChannelID, nac)
+		c.publishSiteUpdate()
 	case OpIdentifierUpdateTDMA:
 		u := ParseIdentifierUpdateTDMA(t.Payload)
 		c.bandPlan.Apply(u)
@@ -1264,6 +1270,7 @@ func (c *ControlChannel) dispatchTSBK(t TSBK, nac uint16, metric int) {
 			"tx_offset_hz", u.TxOffsetHz,
 			"bandwidth_hz", u.BandwidthHz)
 		c.drainPendingGrants(u.ChannelID, nac)
+		c.publishSiteUpdate()
 	case OpGroupVoiceChannelGrant:
 		c.publishGroupGrant(ParseGroupVoiceChannelGrant(t.Payload), nac)
 	case OpGroupVoiceChannelUpdate:

--- a/internal/scanner/ccdecoder/decoder.go
+++ b/internal/scanner/ccdecoder/decoder.go
@@ -631,9 +631,18 @@ func (d *Decoder) Run(ctx context.Context) error {
 			}
 			switch ev.Kind {
 			case events.KindCCLocked:
+				// The bus is shared with every other decoder/protocol in the
+				// process, so honour only lock edges for THIS decoder's active
+				// carrier — a foreign system's lock (or, below, its cc.lost)
+				// must not drive our locked flag, which gates autotune and (via
+				// DecodeHealth) the dashboard decode-quality chip. Both P25 and
+				// TETRA lock payloads carry the frequency; an unrecognised
+				// payload falls through to the old behaviour (accept the edge).
+				if !d.lockEventMatchesActive(ev.Payload) {
+					continue
+				}
 				// Gate autotune sampling on a real lock — the AFC estimate
-				// only means anything once the FSW is correlating. Payload
-				// shape is per-protocol, so we only read the lock edge.
+				// only means anything once the FSW is correlating.
 				d.locked.Store(true)
 				// Re-arm the issue #402 dc_avoid nudge for this lock session,
 				// so a fresh acquisition gets one clean measurement window.
@@ -643,6 +652,9 @@ func (d *Decoder) Run(ctx context.Context) error {
 				d.mu.Unlock()
 				continue
 			case events.KindCCLost:
+				if !d.lockEventMatchesActive(ev.Payload) {
+					continue
+				}
 				d.locked.Store(false)
 				continue
 			case events.KindHuntProgress:
@@ -835,6 +847,24 @@ func (d *Decoder) handleProgress(p trunking.HuntProgress) {
 	// previous channel doesn't bleed into the freshly-tuned one.
 	d.ddc.Reset()
 	d.mu.Unlock()
+}
+
+// lockEventMatchesActive reports whether a cc.locked/cc.lost payload belongs to
+// this decoder's currently-active carrier. Both the P25 and TETRA lock payloads
+// implement trunking.LockedPayload (LockedFrequencyHz); a lock edge for another
+// system on the shared bus is rejected so it can't flip our locked flag. An
+// unrecognised payload (no frequency) is accepted, preserving the pre-filter
+// behaviour rather than dropping a lock we can't attribute.
+func (d *Decoder) lockEventMatchesActive(payload any) bool {
+	lp, ok := payload.(trunking.LockedPayload)
+	if !ok {
+		return true
+	}
+	d.mu.Lock()
+	active := d.activeFreqHz
+	d.mu.Unlock()
+	// Before any acquisition (activeFreqHz 0) there is nothing to protect.
+	return active == 0 || lp.LockedFrequencyHz() == active
 }
 
 func (d *Decoder) clearActive() {

--- a/internal/scanner/ccdecoder/decoder_test.go
+++ b/internal/scanner/ccdecoder/decoder_test.go
@@ -2580,3 +2580,30 @@ func TestDecoderPublishesTotalCarrierOffsetWithAutotune(t *testing.T) {
 			siteOffset, appliedBias)
 	}
 }
+
+// TestLockEventMatchesActiveFiltersForeignSystem pins the fix for a P25 (or any)
+// decoder showing decode: — on the dashboard: d.locked is driven off the shared
+// event bus, so a cc.lost from ANOTHER system in the same process used to latch
+// this decoder's locked flag false and blank its DecodeHealth. Lock edges are
+// now filtered to the decoder's active carrier.
+func TestLockEventMatchesActiveFiltersForeignSystem(t *testing.T) {
+	d := &Decoder{activeFreqHz: 450_125_000}
+
+	// A lock/lost for our own carrier is honoured.
+	if !d.lockEventMatchesActive(tetra.LockState{FrequencyHz: 450_125_000}) {
+		t.Error("own-carrier lock event was rejected")
+	}
+	// A foreign system's carrier is rejected.
+	if d.lockEventMatchesActive(tetra.LockState{FrequencyHz: 851_012_500}) {
+		t.Error("foreign-carrier lock event was accepted (would flip our locked flag)")
+	}
+	// An unattributable payload (no frequency) is accepted (pre-filter behaviour).
+	if !d.lockEventMatchesActive(struct{}{}) {
+		t.Error("payload without a frequency should be accepted")
+	}
+	// Before any acquisition there is nothing to protect.
+	idle := &Decoder{activeFreqHz: 0}
+	if !idle.lockEventMatchesActive(tetra.LockState{FrequencyHz: 851_012_500}) {
+		t.Error("idle decoder should accept any lock edge")
+	}
+}

--- a/internal/sdr/soapyremote/driver.go
+++ b/internal/sdr/soapyremote/driver.go
@@ -102,6 +102,13 @@ type Spec struct {
 	// one stream (shared-LO front-ends only, e.g. USRP B210 / AD9361). See
 	// mrc.go. EXPERIMENTAL — issue #1062.
 	Diversity string
+	// Antennas selects the RX antenna port per channel (SoapySDR setAntenna),
+	// applied in channel order after MAKE: Antennas[0] to RX channel 0,
+	// Antennas[1] to channel 1 (the diversity second receiver). Empty leaves the
+	// device default. A comma-separated multi-antenna value cannot be expressed
+	// in the flat DeviceArgs kwargs string, so per-channel antenna routing (e.g.
+	// an X310's RX1/RX2 under MRC) goes here instead of args.
+	Antennas []string
 }
 
 // Driver implements sdr.Driver over a set of SoapySDRServer endpoints.
@@ -222,6 +229,14 @@ func (d *Driver) Open(idx int) (sdr.Device, error) {
 		conn.Close()
 		return nil, fmt.Errorf("soapyremote: make device: %w", err)
 	}
+	// Apply per-channel RX antennas (X310 RX1/RX2 under MRC, etc.) now that the
+	// device exists and its RX channels are known. An explicitly configured
+	// antenna that the remote rejects is a real misconfiguration, so this is
+	// rpcVoid (loud), not best-effort.
+	if err := dev.applyAntennas(spec.Antennas); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("soapyremote: set antenna: %w", err)
+	}
 	// Best-effort: learn the native format for diagnostics.
 	if native, ok := dev.nativeStreamFormat(); ok {
 		dev.info.TunerName = native
@@ -330,6 +345,28 @@ func (d *device) rpcBestEffort(what string, build func(*packer)) error {
 			return err
 		}
 		d.log.Debug("soapyremote: "+what+" not applied", "addr", d.addr, "err", err)
+	}
+	return nil
+}
+
+// applyAntennas sets the RX antenna port for channel i to antennas[i] via
+// SET_ANTENNA (SoapySDR setAntenna). Channels past len(antennas) keep the
+// device default. Called once at Open, after MAKE.
+func (d *device) applyAntennas(antennas []string) error {
+	for ch, name := range antennas {
+		if name == "" {
+			continue
+		}
+		ch := int32(ch)
+		if err := d.rpcVoid(func(p *packer) {
+			p.call(callSetAntenna)
+			p.char(dirRX)
+			p.i32(ch)
+			p.str(name)
+		}); err != nil {
+			return fmt.Errorf("channel %d antenna %q: %w", ch, name, err)
+		}
+		d.log.Info("soapyremote: rx antenna set", "addr", d.addr, "channel", ch, "antenna", name)
 	}
 	return nil
 }

--- a/internal/sdr/soapyremote/driver_test.go
+++ b/internal/sdr/soapyremote/driver_test.go
@@ -60,6 +60,14 @@ type fakeSoapyServer struct {
 	// SOAPY_SDR_HAS_TIME on a multi-channel stream is rejected with the
 	// "stream now on multiple channels" exception (issue: MRC on X310).
 	rejectImmediateMultiChannel bool
+
+	// antennas records (channel, name) pairs seen on SET_ANTENNA.
+	antennas []antennaSet
+}
+
+type antennaSet struct {
+	ch   int32
+	name string
 }
 
 type recordedCall struct {
@@ -288,6 +296,13 @@ func (s *fakeSoapyServer) handleRPC(conn net.Conn) {
 			} else {
 				doActivate = true
 			}
+		case callSetAntenna:
+			_, _ = u.char() // direction
+			ch, _ := u.i32()
+			name, _ := u.str()
+			s.mu.Lock()
+			s.antennas = append(s.antennas, antennaSet{ch: ch, name: name})
+			s.mu.Unlock()
 		case callGetHardwareTime:
 			_, _ = u.str() // clock qualifier ("")
 			s.mu.Lock()
@@ -420,6 +435,32 @@ func encodeCS16(samples []complex64) []byte {
 		buf = append(buf, b[:]...)
 	}
 	return buf
+}
+
+// TestOpenAppliesPerChannelAntennas pins that Spec.Antennas applies a
+// SET_ANTENNA per RX channel at Open, in channel order (the X310 RX1/RX2 MRC
+// case). An empty entry is skipped (leaves the device default).
+func TestOpenAppliesPerChannelAntennas(t *testing.T) {
+	srv := newFakeSoapyServer(t)
+	drv := New([]Spec{{Addr: srv.Addr(), Format: "CS16", Diversity: "mrc", Antennas: []string{"RX1", "RX2"}}}, testLogger())
+	dev, err := drv.Open(0)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer dev.Close()
+
+	srv.mu.Lock()
+	got := append([]antennaSet(nil), srv.antennas...)
+	srv.mu.Unlock()
+	want := []antennaSet{{0, "RX1"}, {1, "RX2"}}
+	if len(got) != len(want) {
+		t.Fatalf("SET_ANTENNA calls = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("antenna[%d] = %+v, want %+v", i, got[i], want[i])
+		}
+	}
 }
 
 func TestOpenAndSetters(t *testing.T) {

--- a/internal/sdr/soapyremote/rpc.go
+++ b/internal/sdr/soapyremote/rpc.go
@@ -71,6 +71,7 @@ const (
 	callActivateStream         int32 = 302
 	callDeactivateStream       int32 = 303
 	callGetNativeStreamFormat  int32 = 305
+	callSetAntenna             int32 = 600
 	callSetFrequencyCorrection int32 = 504
 	callSetGainMode            int32 = 701
 	callSetGain                int32 = 703

--- a/internal/trunking/network_report.go
+++ b/internal/trunking/network_report.go
@@ -3,6 +3,7 @@ package trunking
 import (
 	"fmt"
 	"io"
+	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -229,10 +230,26 @@ func ReportFromTopology(t *TopologySnapshot) NetworkReport {
 		return NetworkReport{}
 	}
 	offsets := make(map[uint8]int64, len(t.BandPlan))
+	bands := make(map[uint8]TopoBandPlanSlot, len(t.BandPlan))
 	for _, b := range t.BandPlan {
 		offsets[b.ChannelID] = b.TxOffsetHz
+		bands[b.ChannelID] = b
 	}
 	conv := func(id uint8, num uint16, downHz, upHz uint32) ReportChannel {
+		// Resolve the downlink from the band plan when the protocol didn't carry
+		// an explicit frequency. A P25 neighbour (ADJ_STS_BCST) is reported as a
+		// (channel id, channel number) pair, not a frequency, so its downlink is
+		// base + number*spacing from the matching IDEN_UP — the same computation
+		// voice-grant channels use (identifier.BandPlan.Frequency). Without this a
+		// neighbour whose band arrived after it stays at 0 Hz forever, which is
+		// what left the web "Neighbor sites" downlink blank (SDRtrunk shows it).
+		if downHz == 0 && num != 0 {
+			if b, ok := bands[id]; ok && b.BaseHz != 0 && b.SpacingHz != 0 {
+				if hz := b.BaseHz + uint64(num)*uint64(b.SpacingHz); hz > 0 && hz <= math.MaxUint32 {
+					downHz = uint32(hz)
+				}
+			}
+		}
 		c := ReportChannel{ChannelID: id, ChannelNumber: num, DownlinkHz: downHz}
 		switch {
 		case upHz != 0:

--- a/internal/trunking/network_report_test.go
+++ b/internal/trunking/network_report_test.go
@@ -112,6 +112,34 @@ func TestReportFromTopologyMapsFieldsAndUplink(t *testing.T) {
 	}
 }
 
+// TestReportFromTopologyResolvesNeighbourDownlinkFromBandPlan is the regression
+// for the blank "Neighbor sites" downlink: a P25 ADJ_STS_BCST reports a neighbour
+// as a (channel id, channel number) pair with NO frequency, so the report must
+// compute the downlink from the matching IDEN_UP band plan (base + number *
+// spacing) — the same math a voice grant uses. Fails before the fix (downlink 0).
+func TestReportFromTopologyResolvesNeighbourDownlinkFromBandPlan(t *testing.T) {
+	snap := &TopologySnapshot{
+		SystemName: "Main Site",
+		Protocol:   "p25",
+		BandPlan:   []TopoBandPlanSlot{{ChannelID: 2, BaseHz: 450_000_000, SpacingHz: 12_500, TxOffsetHz: 10_000_000}},
+		// FrequencyHz deliberately 0 — the neighbour's band hadn't resolved when
+		// the ADJ_STS was heard; the report must fill it in from the band plan.
+		Neighbors: []TopoNeighborRef{{RFSS: 1, Site: 7, ChannelID: 2, ChannelNumber: 77}},
+	}
+	r := ReportFromTopology(snap)
+	if len(r.Sites) != 1 || len(r.Sites[0].Neighbors) != 1 {
+		t.Fatalf("expected one neighbour: %+v", r.Sites)
+	}
+	// downlink = 450_000_000 + 77*12_500 = 450_962_500; uplink = +10 MHz.
+	n := r.Sites[0].Neighbors[0].Channel
+	if n.DownlinkHz != 450_962_500 {
+		t.Errorf("neighbour downlink = %d, want 450962500 (base + number*spacing)", n.DownlinkHz)
+	}
+	if n.UplinkHz != 460_962_500 {
+		t.Errorf("neighbour uplink = %d, want 460962500 (downlink + tx offset)", n.UplinkHz)
+	}
+}
+
 // TestReportFromTopologyDirectUplink covers a protocol (TETRA) that resolves the
 // uplink directly from its own duplex spacing, with no band plan: the explicit
 // TopoChannelRef.UplinkHz must flow through to the report and the rendered

--- a/web/configbuilder/src/api/types.ts
+++ b/web/configbuilder/src/api/types.ts
@@ -117,6 +117,7 @@ export interface SoapyRemoteConfig {
   BiasTee: boolean;
   ConnectTimeoutMs: number;
   Diversity: string;
+  Antennas?: string[];
 }
 
 export interface Ka9qRadioConfig {

--- a/web/configbuilder/src/sections/SDR.tsx
+++ b/web/configbuilder/src/sections/SDR.tsx
@@ -166,6 +166,18 @@ export function SDRSection() {
                   { value: "mrc", label: "mrc (RX0+RX1, shared-LO)" },
                 ]}
               />
+              <TextField
+                label="RX antennas (per channel)"
+                value={(s.Antennas ?? []).join(", ")}
+                onChange={(v) => {
+                  const list = v
+                    .split(",")
+                    .map((x) => x.trim())
+                    .filter((x) => x !== "");
+                  set({ ...s, Antennas: list.length ? list : undefined });
+                }}
+                placeholder="e.g. RX1, RX2 (X310 under mrc)"
+              />
             </div>
           )}
         />

--- a/web/src/components/DetailModal.tsx
+++ b/web/src/components/DetailModal.tsx
@@ -76,7 +76,11 @@ export function DetailField({
   return (
     <div>
       <p className="text-xs uppercase tracking-wider text-muted">{label}</p>
-      <p className={`text-sm mt-0.5 ${mono && !empty ? "font-mono" : ""}`}>
+      {/* whitespace-pre-line: several callers pass \n-joined lists (control
+          channels, neighbors, frequency bands) as one value — without this
+          the browser collapses every newline to a space and they render as an
+          unreadable single run of text. */}
+      <p className={`text-sm mt-0.5 whitespace-pre-line ${mono && !empty ? "font-mono" : ""}`}>
         {empty ? (
           emptyHint != null ? (
             <span className="text-muted italic">{emptyHint}</span>

--- a/web/src/panels/Systems.tsx
+++ b/web/src/panels/Systems.tsx
@@ -46,7 +46,14 @@ function formatNeighbor(n: NeighborDTO, idBase: "hex" | "dec"): string {
   const rfss = formatIdNumber(n.rfss, idBase) ?? String(n.rfss);
   const site = formatIdNumber(n.site, idBase) ?? String(n.site);
   let s = `RFSS ${rfss} / Site ${site}`;
-  if (n.downlink_hz) s += ` → ${(n.downlink_hz / 1e6).toFixed(6)} MHz`;
+  if (n.downlink_hz) {
+    s += ` → ${(n.downlink_hz / 1e6).toFixed(6)} MHz`;
+  } else if (n.channel_id != null && n.channel_number != null) {
+    // No resolved frequency yet (the neighbour's band plan hasn't been heard):
+    // show the raw channel coordinates like SDRtrunk's "CHANNEL:2-1754" so the
+    // row isn't blank while the IDEN_UP for that band is still awaited.
+    s += ` → CHANNEL ${n.channel_id}-${n.channel_number}`;
+  }
   return s;
 }
 


### PR DESCRIPTION
## Summary

Follow-up round driven by a new batch of operator captures (P25/DMR/TETRA voice, weak-signal IQ, DMO, DSD-FME interop tests). Ships the fixes that are verifiable now — MRC per-channel antennas, P25 web-panel readability + decode-health, replay-harness usability — and lands diagnostic tooling + precisely-localized findings for the two problems that need a deeper (or on-air) follow-up: the TETRA DMO decode ceiling and the DMR vocoder high-band deficit. No speculative changes to conformance-pinned code.

## Changes

- **soapyremote: per-channel RX antennas** (`antennas: [RX1, RX2]`). An X310 in MRC diversity needs a different antenna per RX channel, which can't live in the flat `args` string (a comma splits arguments — the operator's `antenna=RX1,RX2` parse error). New list applied per channel via a `SET_ANTENNA` RPC (opcode 600) after MAKE; validated (≤2, >1 requires `diversity: mrc`, no empties, rejects `antenna=` in args when set). Threaded through config → Spec → driver, the config builder, `docs/hardware.md` and `config.example.yaml`. Fake-server test asserts per-channel order. `rx_subdev_spec=A:0 B:0` (space) already parsed; documented.

- **P25 web panel + decode health.** DetailModal now renders `\n`-joined lists (frequency bands / neighbors / control channels) one per line instead of an unreadable blob (`whitespace-pre-line`). Neighbor sites show a downlink frequency resolved from the band plan (`base + number*spacing`, SDRTrunk parity) with a `CHANNEL id-num` fallback, and IDEN_UP now republishes topology so it fills in live. Fixed a bug where another system's `cc.lost` on the shared bus could latch a healthy system's decode chip blank (`decode: —`).

- **TETRA DMO colour-map diagnostic** (`TestTETRADMOColourScan`, `GT_TETRA_DMO_SCAN=1`). The operator's purpose-built 15aug capture decodes SCH/S at ~90% but TCH/S sits at the chance floor at every DM colour, and a 64-colour sweep shows several colours rising modestly at once — a marginal signal with no dominant colour, which `RecoverDMColourCode`'s dominance gate correctly refuses. Tooling to identify a descramble rule from a cleaner, known-colour, actually-talking capture. No model change (would be capture-fitting).

- **Replay harnesses.** `GT_TETRA_COLOUR` overrides the hardcoded extended colour in the TETRA multi-slot replay; `GT_DMR_ALLOW_EMPTY=1` turns a weak-signal 0/0 into a logged baseline instead of a hard fail; `replay -format` help documents cs16 (already accepted by the parser).

- **Docs.** `docs/vocoders.md`: `recordings.mbe_files` usage + the DSD-FME `-w` 8 kHz-header playback quirk (interop is frame-exact; the slow playback is upstream). `CLAUDE.md`: the DMO 15aug findings, the measured/localized AMBE+2 3600×2450 high-band deficit (in `params2450.go`, not synthesis/RF/post — DMR decode has 4–10× less energy above 1 kHz than mbelib on the same frames), and the DSD-FME interop verdict.

## Test plan

- [x] `make vet test` is green locally (164 packages)
- [x] `make integration` is green locally
- [x] Added/updated tests: per-channel antenna order (soapyremote fake server), antennas config validation, neighbour-downlink-from-band-plan (fixture with `FrequencyHz=0`), cross-system lock filter, DMO colour-scan diagnostic
- [ ] Smoke-tested against real hardware — **on-air gated, needs the operator**: MRC antennas on the X310; a cleaner known-colour DMO capture to close the descramble investigation. Offline capture replays were run for the DMO sweep and weak-signal baselines.

## Breaking changes

None. New config keys (`sdr.soapy_remote[].antennas`, `recordings.mbe_files` from the prior round) are additive and default off/empty.

## Docs / CHANGELOG

- [x] Updated `docs/hardware.md`, `config.example.yaml`, `docs/vocoders.md`, `CLAUDE.md`
- [ ] CHANGELOG bullet — n/a (repo has no `CHANGELOG.md`)

## Linked issues

Refs #1003 (DMO), #1062 (MRC diversity), #858 (P25 site decode quality). Nothing closed — the DMO and vocoder items are deliberately left open pending on-air / deeper follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PPZrPniaF5eyPeLErJZvni)_