### PR TITLE
soapyremote: use the second receiver under MRC diversity (#1062)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,28 @@ for tagged releases.
   call-priority metadata to TETRA alongside P25 and DMR.
 
 ### Fixed
+- **SoapyRemote MRC diversity now actually uses the second receiver.** On a real
+  USRP B210 the first cut streamed only RX0: RX1 stayed dark, and disconnecting
+  RX0's antenna dropped the whole stream to the noise floor even with a good
+  antenna on RX1 (issue #1062). Three defects, all in the diversity path only:
+  **(1)** gain and frequency correction were programmed on channel 0 only, on the
+  theory that the phase calibration's complex gain absorbs a branch imbalance —
+  it does not absorb an *unconfigured* receiver, which comes up at the driver
+  default (0 dB on UHD) and is then discarded by the maximal-ratio |h|² weight.
+  Every open RX channel is now gained and corrected. **(2)** The phase
+  calibration was hardwired to anchor on branch 0, so a silent RX0 never cleared
+  the calibration floor and the combiner sat in passthrough emitting RX0's noise;
+  it now anchors on whichever branch is actually receiving, so one live receiver
+  is enough. **(3)** The datagram was split into equal per-channel blocks, but
+  SoapyRemote sends the first N-1 channels as full-stride blocks and shortens
+  only the last one to the header's `elems` count — on any short transfer that
+  slid branch 1 into the tail of branch 0, de-aligning the branches and anchoring
+  the calibration on garbage. The stride is now derived from the header. Also
+  new: a per-branch level line at stream start and every 30 s, which turns into a
+  WARN when a branch is dead or the remote delivers fewer channels than
+  requested, so a dark receiver is visible in GopherTrunk's own log instead of
+  requiring `SoapySDRServer`'s UHD debug output. Single-channel streams are
+  unaffected. Still experimental pending an on-air A/B.
 - **TETRA DMO no longer grants and opens a recording on an idle channel, and now
   grants for every real transmission.** On air, `protocol: tetra-dmo` started a
   call and a recording session about 230 ms after the daemon came up — before any

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -845,6 +845,24 @@ needs, RX1 on channel 0 and RX2 on channel 1:
 (only one RX channel is opened otherwise). Setting both `antennas:` and
 `antenna=` in `args` is rejected — pick one.
 
+**Checking that both diversity branches are alive.** Under `diversity: mrc`
+GopherTrunk logs a per-branch line when the stream starts and every 30 s
+afterwards:
+
+```
+soapyremote: MRC diversity branches addr=… branch_dbfs="ch0=-31.2 ch1=-33.8" reference_branch=0 calibrated=true
+```
+
+Both branches should sit within a few dB of each other. If one is far down, the
+line becomes a WARN naming the dead branch — that is an antenna, connector, or
+per-channel-gain problem on that receiver, not a decode problem. A WARN about
+receiving fewer channels than requested means the remote streamed only one
+channel despite the 2-channel request: check the device really has a second RX
+channel and that the `SoapySDRServer` accepted the request (its debug log is in
+the diagnostics note below). Note that the second receiver is gained
+automatically — `gain:` is applied to every open RX channel, so a diversity
+branch is never left at the driver default.
+
 Two operational notes from that deployment:
 
 - **Prefer a manually chosen gain over AGC.** On UHD front ends, dial in the
@@ -866,7 +884,8 @@ classifies every carrier, and streams the inventory to
 
 **Limitations:**
 
-- Receive only, single channel (channel 0).
+- Receive only. One RX channel (channel 0), or channels 0 and 1 combined into
+  one stream with `diversity: mrc`.
 - The IQ stream uses SoapyRemote's in-order **TCP** transport
   (`stream_protocol: tcp`), which opens two sockets to the server (a stream
   socket and a status socket, matching `SoapySDRServer`'s setup). UDP

--- a/internal/sdr/soapyremote/driver.go
+++ b/internal/sdr/soapyremote/driver.go
@@ -24,7 +24,11 @@
 // a fake server in the tests; validate against live hardware before release.
 //
 // Limitations:
-//   - Single channel (channel 0), receive only.
+//   - Receive only. One RX channel (channel 0) by default; `diversity: mrc`
+//     opens channels 0 and 1 and combines them into one stream (see mrc.go).
+//     Every per-channel setting (frequency, rate, gain, frequency correction)
+//     is programmed on both — an unconfigured second receiver is a branch that
+//     contributes nothing (issue #1062).
 //   - SetPPM / SetBiasTee are best-effort: SoapySDR has no universal call for
 //     either, so they map to setFrequencyCorrection / writeSetting and silently
 //     no-op when the underlying driver doesn't support them.
@@ -298,9 +302,8 @@ func (d *device) rxChannelCount() int {
 
 // perRXChannel issues an RPC once per active RX channel — channel 0 only in the
 // single-channel default, channels 0 and 1 under MRC diversity so the shared-LO
-// second receiver is tuned/rated identically to the reference. Stops at the
-// first error. (Gain is deliberately left channel-0-only: the MRC calibration
-// estimates a complex gain, so a per-channel amplitude difference is absorbed.)
+// second receiver is configured identically to the reference. Stops at the first
+// error.
 func (d *device) perRXChannel(build func(p *packer, ch int32)) error {
 	for ch := 0; ch < d.rxChannelCount(); ch++ {
 		ch := int32(ch)
@@ -309,6 +312,24 @@ func (d *device) perRXChannel(build func(p *packer, ch int32)) error {
 		}
 	}
 	return nil
+}
+
+// perSecondaryRXChannel runs fn for every diversity branch past the reference
+// (nothing at all in the single-channel default). A failure on a secondary
+// branch is reported but not fatal: the reference receiver still works, and
+// downgrading one branch beats refusing to tune at all. It is logged at WARN
+// rather than swallowed — an unconfigured second receiver is precisely the
+// silent failure behind issue #1062.
+func (d *device) perSecondaryRXChannel(what string, fn func(ch int32) error) {
+	for ch := 1; ch < d.rxChannelCount(); ch++ {
+		if err := fn(int32(ch)); err != nil {
+			if errors.Is(err, errClosed) {
+				return
+			}
+			d.log.Warn("soapyremote: diversity branch not fully configured — that receiver will contribute little or nothing to the combine",
+				"addr", d.addr, "channel", ch, "setting", what, "err", err)
+		}
+	}
 }
 
 func (d *device) Info() sdr.Info { return d.info }
@@ -430,13 +451,30 @@ func (d *device) ActualSampleRate() (uint32, error) {
 	return uint32(math.Round(rate)), nil
 }
 
+// SetGain programs the gain on every active RX channel. Under MRC diversity the
+// second receiver must be gained too: a SoapySDR RX channel comes up at the
+// driver's default (0 dB on a UHD device), so leaving RX1 alone left it tens of
+// dB below RX0 — far enough down that the maximal-ratio weight |h|² made it
+// contribute nothing, which reads on air as "RX1 is dark" (issue #1062). The
+// combiner's complex-gain estimate absorbs a *small* branch imbalance; it cannot
+// conjure signal out of a receiver that was never gained.
 func (d *device) SetGain(tenthDB int) error {
+	if err := d.applyGain(0, tenthDB); err != nil {
+		return err
+	}
+	d.perSecondaryRXChannel("gain", func(ch int32) error { return d.applyGain(ch, tenthDB) })
+	return nil
+}
+
+// applyGain programs one RX channel's gain: AGC when tenthDB is negative,
+// otherwise manual gain in dB.
+func (d *device) applyGain(ch int32, tenthDB int) error {
 	if tenthDB < 0 {
 		// Automatic gain control.
 		return d.rpcVoid(func(p *packer) {
 			p.call(callSetGainMode)
 			p.char(dirRX)
-			p.i32(0)
+			p.i32(ch)
 			p.boolean(true)
 		})
 	}
@@ -449,24 +487,34 @@ func (d *device) SetGain(tenthDB int) error {
 	_ = d.rpcBestEffort("disable agc", func(p *packer) {
 		p.call(callSetGainMode)
 		p.char(dirRX)
-		p.i32(0)
+		p.i32(ch)
 		p.boolean(false)
 	})
 	return d.rpcVoid(func(p *packer) {
 		p.call(callSetGain)
 		p.char(dirRX)
-		p.i32(0)
+		p.i32(ch)
 		p.f64(float64(tenthDB) / 10.0) // GopherTrunk tenths-dB → SoapySDR dB
 	})
 }
 
+// SetPPM applies the frequency correction to every active RX channel. Both
+// branches share one LO, but SoapySDR's correction is a per-channel setting, so
+// correcting only channel 0 would leave the branches tuned to different
+// frequencies — a slow relative rotation the frozen phase constant cannot track.
 func (d *device) SetPPM(ppm int) error {
-	return d.rpcBestEffort("ppm", func(p *packer) {
-		p.call(callSetFrequencyCorrection)
-		p.char(dirRX)
-		p.i32(0)
-		p.f64(float64(ppm))
-	})
+	for ch := 0; ch < d.rxChannelCount(); ch++ {
+		ch := int32(ch)
+		if err := d.rpcBestEffort("ppm", func(p *packer) {
+			p.call(callSetFrequencyCorrection)
+			p.char(dirRX)
+			p.i32(ch)
+			p.f64(float64(ppm))
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (d *device) SetBiasTee(enable bool) error {
@@ -582,7 +630,9 @@ func (d *device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 	// device_overflows=0. Size from the delivered rate (best-effort probe; 0 on
 	// failure → default depth) and the samples-per-datagram the MTU/format imply.
 	rate, _ := d.ActualSampleRate()
-	samplesPerChunk := (d.mtu - streamHeaderSize) / d.format.bytesPerSample()
+	// Per-channel samples: a multi-channel datagram splits the same MTU across
+	// the branches, and the combiner emits one branch's worth downstream.
+	samplesPerChunk := (d.mtu - streamHeaderSize) / (d.format.bytesPerSample() * d.rxChannelCount())
 	out := make(chan []complex64, streamBufferDepth(rate, samplesPerChunk))
 	// Re-arm the MRC calibration for this fresh stream so it re-estimates the
 	// phase constant rather than reusing a stale one from a prior stream.
@@ -887,6 +937,7 @@ func (d *device) streamLoop(ctx context.Context, dataConn net.Conn, streamID int
 
 	throttle := newOverrunThrottle(d.log, d.addr)
 	defer throttle.maybeWarn(true) // flush any trailing counts on teardown
+	health := newDiversityReporter(d.log, d.addr)
 
 	hdr := make([]byte, streamHeaderSize)
 	// Flow-control state: lastRecv tracks the next sequence we expect; lastAck
@@ -953,7 +1004,10 @@ func (d *device) streamLoop(ctx context.Context, dataConn net.Conn, streamID int
 		if d.mrc != nil {
 			// MRC diversity: de-interleave RX0/RX1, phase-coherently combine
 			// into one branch. Emits the reference branch until calibrated.
-			samples = d.mrc.combine(payload)
+			// h.elems is the valid sample count per channel — the block stride
+			// is derived from it (see deinterleave).
+			samples = d.mrc.combine(payload, int(h.elems))
+			health.observe(d.mrc)
 		} else {
 			samples = d.format.convert(payload)
 		}

--- a/internal/sdr/soapyremote/driver_test.go
+++ b/internal/sdr/soapyremote/driver_test.go
@@ -36,8 +36,15 @@ type fakeSoapyServer struct {
 	// SETUP_STREAM ([0] normally, [0,1] under MRC diversity).
 	setupChannels []int
 
-	// samples streamed per datagram once activated.
+	// samples streamed per datagram once activated. Under a multi-channel
+	// stream this is the whole payload — one contiguous block per channel, in
+	// channel order — and streamElems is the count of VALID samples per channel
+	// (the datagram header's elems field). Upstream always sends the first N-1
+	// channels as full stride-sized blocks and shortens only the last one, so
+	// streamElems < the per-channel stride models a short transfer. Zero means
+	// single-channel: elems = len(streamSamples).
 	streamSamples []complex64
+	streamElems   int
 
 	// failGainMode makes SET_GAIN_MODE reply with a remote exception, mimicking
 	// a UHD front-end with no AGC ("set_rx_agc() is not supported"). Issue #542.
@@ -72,11 +79,25 @@ type antennaSet struct {
 
 type recordedCall struct {
 	id        int32
+	ch        int32 // RX channel the call addressed
 	freqHz    float64
 	gainDB    float64
 	gainAuto  bool
+	ppm       float64
 	actFlags  int32
 	actTimeNs int64
+}
+
+// channelsFor returns, in call order, the RX channels the server saw a given
+// call addressed to. Used to pin that a setting reaches every diversity branch.
+func (s *fakeSoapyServer) channelsFor(id int32) []int32 {
+	var out []int32
+	for _, c := range s.recorded() {
+		if c.id == id {
+			out = append(out, c.ch)
+		}
+	}
+	return out
 }
 
 func newFakeSoapyServer(t *testing.T) *fakeSoapyServer {
@@ -233,11 +254,15 @@ func (s *fakeSoapyServer) handleRPC(conn net.Conn) {
 		switch id {
 		case callSetFrequency:
 			_, _ = u.char()
-			_, _ = u.i32()
+			rec.ch, _ = u.i32()
 			rec.freqHz, _ = u.f64()
+		case callSetFrequencyCorrection:
+			_, _ = u.char()
+			rec.ch, _ = u.i32()
+			rec.ppm, _ = u.f64()
 		case callSetSampleRate:
 			_, _ = u.char()
-			_, _ = u.i32()
+			rec.ch, _ = u.i32()
 			rec.freqHz, _ = u.f64()
 			s.mu.Lock()
 			s.lastSetRateHz = rec.freqHz
@@ -254,11 +279,11 @@ func (s *fakeSoapyServer) handleRPC(conn net.Conn) {
 			reply = func(p *packer) { p.f64(rate) }
 		case callSetGain:
 			_, _ = u.char()
-			_, _ = u.i32()
+			rec.ch, _ = u.i32()
 			rec.gainDB, _ = u.f64()
 		case callSetGainMode:
 			_, _ = u.char()
-			_, _ = u.i32()
+			rec.ch, _ = u.i32()
 			rec.gainAuto, _ = u.boolean()
 			if s.failGainMode {
 				reply = func(p *packer) {
@@ -409,10 +434,14 @@ func (s *fakeSoapyServer) startDataServer(activate <-chan struct{}) (string, <-c
 		seq := uint32(0)
 		for {
 			payload := encodeCS16(s.streamSamples)
+			elems := s.streamElems
+			if elems == 0 {
+				elems = len(s.streamSamples)
+			}
 			hdr := encodeStreamHeader(streamHeader{
 				bytes:    uint32(streamHeaderSize + len(payload)),
 				sequence: seq,
-				elems:    int32(len(s.streamSamples)),
+				elems:    int32(elems),
 			})
 			if _, err := streamConn.Write(append(hdr, payload...)); err != nil {
 				return
@@ -527,6 +556,104 @@ func TestOpenAndSetters(t *testing.T) {
 	}
 	if !sawGainAuto {
 		t.Error("SET_GAIN_MODE(auto=true) not recorded")
+	}
+}
+
+// TestSetGainReachesEveryDiversityChannel is the root-cause regression for the
+// #1062 field report ("RX2B stays dark; pull the RX2A antenna and everything
+// drops to the noise floor"). Gain used to be programmed on channel 0 only, on
+// the theory that the MRC calibration's complex gain absorbs a branch
+// imbalance. It does not absorb an *unconfigured* receiver: a SoapySDR RX
+// channel comes up at the driver default (0 dB on UHD), leaving RX1 tens of dB
+// down, which the |h|² maximal-ratio weight then discards entirely. Every RX
+// channel in the stream must be gained.
+func TestSetGainReachesEveryDiversityChannel(t *testing.T) {
+	srv := newFakeSoapyServer(t)
+	drv := New([]Spec{{Addr: srv.Addr(), Format: "CS16", Diversity: "mrc"}}, testLogger())
+	dev, err := drv.Open(0)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer dev.Close()
+
+	if err := dev.SetGain(400); err != nil { // 40.0 dB
+		t.Fatalf("SetGain: %v", err)
+	}
+	gained := map[int32]bool{}
+	for _, c := range srv.recorded() {
+		if c.id == callSetGain && c.gainDB == 40.0 {
+			gained[c.ch] = true
+		}
+	}
+	for ch := int32(0); ch < diversityChannels; ch++ {
+		if !gained[ch] {
+			t.Errorf("SET_GAIN(40 dB) never reached RX channel %d (channels gained: %v) — that branch stays at the device default and contributes nothing", ch, srv.channelsFor(callSetGain))
+		}
+	}
+
+	// AGC must likewise be armed on both receivers.
+	if err := dev.SetGain(-1); err != nil {
+		t.Fatalf("SetGain(AGC): %v", err)
+	}
+	auto := map[int32]bool{}
+	for _, c := range srv.recorded() {
+		if c.id == callSetGainMode && c.gainAuto {
+			auto[c.ch] = true
+		}
+	}
+	for ch := int32(0); ch < diversityChannels; ch++ {
+		if !auto[ch] {
+			t.Errorf("SET_GAIN_MODE(auto) never reached RX channel %d", ch)
+		}
+	}
+}
+
+// TestSetGainSingleChannelStaysChannelZero pins that the per-channel fan-out is
+// diversity-only: an ordinary single-channel device must still see exactly one
+// gain call, on channel 0.
+func TestSetGainSingleChannelStaysChannelZero(t *testing.T) {
+	srv := newFakeSoapyServer(t)
+	drv := New([]Spec{{Addr: srv.Addr(), Format: "CS16"}}, testLogger())
+	dev, err := drv.Open(0)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer dev.Close()
+
+	if err := dev.SetGain(400); err != nil {
+		t.Fatalf("SetGain: %v", err)
+	}
+	if got := srv.channelsFor(callSetGain); len(got) != 1 || got[0] != 0 {
+		t.Errorf("single-channel SET_GAIN channels = %v, want [0]", got)
+	}
+}
+
+// TestSetPPMReachesEveryDiversityChannel: SoapySDR's frequency correction is a
+// per-channel setting even on a shared-LO front end, so correcting only channel
+// 0 leaves the branches tuned apart — a slow relative rotation that a frozen
+// phase constant cannot track.
+func TestSetPPMReachesEveryDiversityChannel(t *testing.T) {
+	srv := newFakeSoapyServer(t)
+	drv := New([]Spec{{Addr: srv.Addr(), Format: "CS16", Diversity: "mrc"}}, testLogger())
+	dev, err := drv.Open(0)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer dev.Close()
+
+	if err := dev.SetPPM(3); err != nil {
+		t.Fatalf("SetPPM: %v", err)
+	}
+	corrected := map[int32]bool{}
+	for _, c := range srv.recorded() {
+		if c.id == callSetFrequencyCorrection && c.ppm == 3 {
+			corrected[c.ch] = true
+		}
+	}
+	for ch := int32(0); ch < diversityChannels; ch++ {
+		if !corrected[ch] {
+			t.Errorf("SET_FREQUENCY_CORRECTION never reached RX channel %d (channels: %v)", ch, srv.channelsFor(callSetFrequencyCorrection))
+		}
 	}
 }
 
@@ -716,6 +843,7 @@ func TestStreamIQDiversity(t *testing.T) {
 	ch := []complex64{complex(0.5, -0.5), complex(0.25, 0.25), complex(-0.3, 0.4)}
 	// One datagram = [ch0 block][ch1 block], ch1 == ch0.
 	srv.streamSamples = append(append([]complex64{}, ch...), ch...)
+	srv.streamElems = len(ch) // valid samples per channel
 
 	drv := New([]Spec{{Addr: srv.Addr(), Format: "CS16", Diversity: "mrc"}}, testLogger())
 	dev, err := drv.Open(0)
@@ -753,6 +881,109 @@ func TestStreamIQDiversity(t *testing.T) {
 	}
 }
 
+// TestStreamIQDiversityRecoversWhenRX0IsDead is the end-to-end regression for
+// the #1062 field symptom: "disconnect the antenna from RX2A and the signal
+// drops entirely to the noise floor despite a secondary antenna fully connected
+// to RX2B." StaticCalibrator anchors its phase estimate on branch 0, and the
+// first cut hardwired branch 0 as the reference — so a silent RX0 never cleared
+// the calibration floor, the combiner stayed in passthrough, and it emitted
+// RX0's noise while RX1 carried a perfectly good signal. The reference must be
+// whichever branch is actually receiving.
+func TestStreamIQDiversityRecoversWhenRX0IsDead(t *testing.T) {
+	srv := newFakeSoapyServer(t)
+	// RX0: disconnected antenna — noise floor at ~-60 dBFS, well under the
+	// calibration floor. RX1: a real signal.
+	dead := []complex64{complex(1e-3, -1e-3), complex(-1e-3, 1e-3), complex(1e-3, 1e-3)}
+	live := []complex64{complex(0.5, -0.5), complex(0.25, 0.25), complex(-0.3, 0.4)}
+	srv.streamSamples = append(append([]complex64{}, dead...), live...)
+	srv.streamElems = len(live)
+
+	drv := New([]Spec{{Addr: srv.Addr(), Format: "CS16", Diversity: "mrc"}}, testLogger())
+	dev, err := drv.Open(0)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer dev.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	out, err := dev.StreamIQ(ctx)
+	if err != nil {
+		t.Fatalf("StreamIQ: %v", err)
+	}
+
+	select {
+	case got, ok := <-out:
+		if !ok {
+			t.Fatal("stream channel closed before any data")
+		}
+		if len(got) != len(live) {
+			t.Fatalf("combined chunk len = %d, want %d (one branch)", len(got), len(live))
+		}
+		// The combined stream must carry RX1's signal, not RX0's noise. Compare
+		// power: the old behaviour emitted the dead branch verbatim (~-60 dBFS).
+		if p := refPowerDbFS(got); p < mrcCalFloorDbFS {
+			t.Errorf("combined power = %.1f dBFS with a dead RX0 and a live RX1; want the live branch (≥ %.1f dBFS). The combiner is still anchored on RX0.", p, mrcCalFloorDbFS)
+		}
+		for i, want := range live {
+			if absDiff(got[i], want) > 2e-2 {
+				t.Errorf("combined sample %d = %v, want ~%v (the live branch)", i, got[i], want)
+			}
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for combined IQ")
+	}
+}
+
+// TestStreamIQDiversityShortLastChannel pins the datagram layout against
+// upstream (common/SoapyStreamEndpoint.cpp): the per-channel blocks are
+// contiguous but NOT equal — the first N-1 channels are always full _buffSize
+// blocks and only the LAST channel is shortened to the header's elems count. A
+// naive N-equal-blocks split slides branch 1 into the tail of branch 0 on every
+// short transfer, so the branches stop being time-aligned and the phase
+// calibration anchors on garbage. Here ch0's block has a stale trailing sample
+// past the 3 valid ones; both branches carry the same signal, so a correct
+// split recovers it exactly and a misaligned one does not.
+func TestStreamIQDiversityShortLastChannel(t *testing.T) {
+	srv := newFakeSoapyServer(t)
+	sig := []complex64{complex(0.5, -0.5), complex(0.25, 0.25), complex(-0.3, 0.4)}
+	stale := complex64(complex(-0.9, 0.9)) // buffer tail past the valid samples
+	// [ch0: 3 valid + 1 stale][ch1: 3 valid], elems = 3.
+	srv.streamSamples = append(append(append([]complex64{}, sig...), stale), sig...)
+	srv.streamElems = len(sig)
+
+	drv := New([]Spec{{Addr: srv.Addr(), Format: "CS16", Diversity: "mrc"}}, testLogger())
+	dev, err := drv.Open(0)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer dev.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	out, err := dev.StreamIQ(ctx)
+	if err != nil {
+		t.Fatalf("StreamIQ: %v", err)
+	}
+
+	select {
+	case got, ok := <-out:
+		if !ok {
+			t.Fatal("stream channel closed before any data")
+		}
+		if len(got) != len(sig) {
+			t.Fatalf("combined chunk len = %d, want %d (elems per channel)", len(got), len(sig))
+		}
+		for i, want := range sig {
+			if absDiff(got[i], want) > 2e-3 {
+				t.Errorf("combined sample %d = %v, want ~%v — the branches are not time-aligned, so the block stride is being read wrong", i, got[i], want)
+			}
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for combined IQ")
+	}
+}
+
 // TestStreamIQDiversityTimedActivate is the regression for MRC on a UHD X310:
 // a multi-channel streamer rejects an immediate start ("Invalid recv stream
 // command - stream now on multiple channels in a single streamer will fail to
@@ -767,6 +998,7 @@ func TestStreamIQDiversityTimedActivate(t *testing.T) {
 	srv.rejectImmediateMultiChannel = true
 	ch := []complex64{complex(0.5, -0.5), complex(0.25, 0.25)}
 	srv.streamSamples = append(append([]complex64{}, ch...), ch...)
+	srv.streamElems = len(ch) // valid samples per channel
 
 	drv := New([]Spec{{Addr: srv.Addr(), Format: "CS16", Diversity: "mrc"}}, testLogger())
 	dev, err := drv.Open(0)
@@ -856,6 +1088,7 @@ func TestStreamIQDiversityNoHardwareClock(t *testing.T) {
 	srv.failHardwareTime = true
 	ch := []complex64{complex(0.5, -0.5), complex(0.25, 0.25)}
 	srv.streamSamples = append(append([]complex64{}, ch...), ch...)
+	srv.streamElems = len(ch) // valid samples per channel
 
 	drv := New([]Spec{{Addr: srv.Addr(), Format: "CS16", Diversity: "mrc"}}, testLogger())
 	dev, err := drv.Open(0)

--- a/internal/sdr/soapyremote/mrc.go
+++ b/internal/sdr/soapyremote/mrc.go
@@ -2,7 +2,9 @@ package soapyremote
 
 import (
 	"fmt"
+	"log/slog"
 	"math"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -42,6 +44,16 @@ const diversityActivateLead = 200 * time.Millisecond
 // Heuristic bootstrap — see mrcCombiner. Issue #1062.
 const mrcCalFloorDbFS = -40.0
 
+// mrcBranchDeadMarginDb is how far below the reference branch a diversity
+// branch may sit before it is reported as dead. A branch this far down
+// contributes essentially nothing to a maximal-ratio combine (MRC weights by
+// |h|²), so it is almost always a disconnected antenna, an unset per-channel
+// gain, or a front-end that never digitised the second receiver — all operator-
+// fixable, and all previously invisible from GopherTrunk's own logs. Issue
+// #1062: the reporter had to read SoapySDRServer's UHD debug output to discover
+// their B210's RX2B was dark.
+const mrcBranchDeadMarginDb = 20.0
+
 // mrcCombiner turns a two-branch (RX0/RX1) SoapyRemote stream into one
 // phase-coherently combined []complex64 via diversity.StaticCalibrator.
 //
@@ -61,16 +73,40 @@ const mrcCalFloorDbFS = -40.0
 // power-floor bootstrap is a safe stand-in because the phase constant is
 // identical whatever high-SNR window anchors it.
 //
+// Reference selection. StaticCalibrator anchors the phase on branch 0, so the
+// first cut hardwired RX0 as the reference — which made the whole stream only as
+// good as RX0. If RX0 was dead (antenna off, or its gain never applied) no
+// window ever cleared the floor, calibration never fired, and the combiner sat
+// in passthrough emitting RX0's noise while a perfectly good RX1 was ignored:
+// exactly the "pull the RX2A antenna and everything drops to the noise floor"
+// report in #1062. The reference is now the STRONGEST branch of the window,
+// re-evaluated while uncalibrated and frozen once the constant locks (the
+// branches are handed to StaticCalibrator permuted so the chosen reference is
+// its index 0). Which branch anchors the phase is arbitrary — the combine is
+// symmetric — so this costs nothing and makes a single live receiver sufficient.
+//
 // Concurrency. combine() runs only on the single stream goroutine.
 // requestRecalibrate() may be called from any goroutine (e.g. SetCenterFreq on
 // the control socket); it just arms an atomic flag that the next combine()
 // consumes, keeping all StaticCalibrator access on the stream goroutine with no
-// lock around the DSP.
+// lock around the DSP. health() is likewise stream-goroutine only.
 type mrcCombiner struct {
 	cal      *diversity.StaticCalibrator
 	format   sampleFormat
 	channels int
 	rearm    atomic.Bool
+
+	// refIdx is the branch anchoring the phase: argmax power while uncalibrated,
+	// frozen at calibration. ordered is the scratch permutation handed to the
+	// calibrator (ordered[0] == branches[refIdx]).
+	refIdx  int
+	ordered [][]complex64
+
+	// Diagnostics, refreshed every combine(): per-branch mean power and how the
+	// last payload split. See health().
+	powDbFS   []float64
+	gotBranch int
+	shortSpan bool
 }
 
 func newMRCCombiner(format sampleFormat) *mrcCombiner {
@@ -78,7 +114,48 @@ func newMRCCombiner(format sampleFormat) *mrcCombiner {
 		cal:      diversity.NewStaticCalibrator(diversityChannels),
 		format:   format,
 		channels: diversityChannels,
+		ordered:  make([][]complex64, diversityChannels),
+		powDbFS:  make([]float64, diversityChannels),
 	}
+}
+
+// mrcHealth is a snapshot of the combiner's per-branch state for the operator-
+// facing diagnostic line.
+type mrcHealth struct {
+	powDbFS    []float64 // per-branch mean power; math.Inf(-1) when absent
+	refIdx     int       // branch anchoring the phase
+	calibrated bool
+	branches   int  // branches recovered from the last payload
+	want       int  // branches requested
+	deadBranch int  // first branch >mrcBranchDeadMarginDb below the reference, else -1
+	degenerate bool // the payload did not carry every requested channel
+}
+
+// health snapshots the last combine() for logging. Stream goroutine only.
+func (m *mrcCombiner) health() mrcHealth {
+	h := mrcHealth{
+		powDbFS:    append([]float64(nil), m.powDbFS...),
+		refIdx:     m.refIdx,
+		calibrated: m.cal.Calibrated(),
+		branches:   m.gotBranch,
+		want:       m.channels,
+		deadBranch: -1,
+		degenerate: m.gotBranch != m.channels,
+	}
+	if m.gotBranch != m.channels || m.refIdx >= len(m.powDbFS) {
+		return h
+	}
+	ref := m.powDbFS[m.refIdx]
+	for i, p := range m.powDbFS {
+		if i == m.refIdx {
+			continue
+		}
+		if ref-p > mrcBranchDeadMarginDb {
+			h.deadBranch = i
+			break
+		}
+	}
+	return h
 }
 
 // requestRecalibrate arms a calibration reset to be applied by the next
@@ -86,26 +163,153 @@ func newMRCCombiner(format sampleFormat) *mrcCombiner {
 // divider phase, invalidating the previous constant.
 func (m *mrcCombiner) requestRecalibrate() { m.rearm.Store(true) }
 
-// combine de-interleaves one multi-channel payload, takes the one-time phase
-// calibration once the reference branch carries signal, and returns the combined
-// single-branch stream. An empty/degenerate payload yields the reference branch.
-func (m *mrcCombiner) combine(payload []byte) []complex64 {
+// combine de-interleaves one multi-channel payload (elems = the header's valid
+// sample count per channel), takes the one-time phase calibration once a branch
+// carries signal, and returns the combined single-branch stream. A payload that
+// does not carry every requested channel is passed through as-is rather than
+// force-split into fake branches.
+func (m *mrcCombiner) combine(payload []byte, elems int) []complex64 {
 	if m.rearm.Swap(false) {
 		m.cal.Reset()
+		m.refIdx = 0
 	}
-	branches := m.format.deinterleave(payload, m.channels)
-	if !m.cal.Calibrated() && refPowerDbFS(branches[0]) >= mrcCalFloorDbFS {
-		// A silent/short reference is rejected inside Calibrate; ignore the
-		// error and retry on the next window (stay in reference passthrough).
-		_ = m.cal.Calibrate(branches)
+	branches := m.format.deinterleave(payload, m.channels, elems)
+	m.gotBranch = len(branches)
+	for i := range m.powDbFS {
+		m.powDbFS[i] = math.Inf(-1)
 	}
-	out, err := m.cal.Combine(branches)
+	for i, b := range branches {
+		if i < len(m.powDbFS) {
+			m.powDbFS[i] = refPowerDbFS(b)
+		}
+	}
+	if len(branches) != m.channels {
+		// The server did not deliver every channel (see deinterleave). Emitting
+		// the payload verbatim keeps the stream a valid single-receiver time
+		// series; the health line reports the shortfall.
+		if len(branches) == 0 {
+			return nil
+		}
+		m.refIdx = 0
+		return branches[0]
+	}
+	if !m.cal.Calibrated() {
+		// Anchor on whichever branch is actually receiving, so one live
+		// receiver is enough (issue #1062).
+		m.refIdx = argmaxFloat(m.powDbFS)
+		if m.powDbFS[m.refIdx] >= mrcCalFloorDbFS {
+			// A silent/short reference is rejected inside Calibrate; ignore the
+			// error and retry on the next window (stay in passthrough).
+			_ = m.cal.Calibrate(m.order(branches))
+		}
+	}
+	out, err := m.cal.Combine(m.order(branches))
 	if err != nil {
 		// Shape guard (should not happen — branches are equal-length): fall
 		// back to the reference branch verbatim rather than drop the chunk.
-		return branches[0]
+		return branches[m.refIdx]
 	}
 	return out
+}
+
+// order returns branches permuted so the reference branch is index 0, which is
+// the branch StaticCalibrator anchors its phase estimate on. The scratch slice
+// is reused across chunks; it only holds slice headers, not sample copies.
+func (m *mrcCombiner) order(branches [][]complex64) [][]complex64 {
+	m.ordered[0] = branches[m.refIdx]
+	n := 1
+	for i, b := range branches {
+		if i == m.refIdx {
+			continue
+		}
+		m.ordered[n] = b
+		n++
+	}
+	return m.ordered
+}
+
+// argmaxFloat returns the index of the largest value (0 for an empty slice).
+func argmaxFloat(v []float64) int {
+	best := 0
+	for i := 1; i < len(v); i++ {
+		if v[i] > v[best] {
+			best = i
+		}
+	}
+	return best
+}
+
+// mrcHealthInterval throttles the per-branch diversity report. The first
+// datagram of a stream always reports, so an operator enabling `diversity: mrc`
+// sees both branches' levels immediately rather than 30 s later.
+const mrcHealthInterval = 30 * time.Second
+
+// diversityReporter surfaces the MRC combiner's per-branch state to the
+// operator, rate-limited. Before this, a diversity branch that never digitised
+// (disconnected antenna, ungained receiver, a server that honoured only one
+// channel of the request) was invisible from GopherTrunk's side: the combined
+// stream simply looked like a weak single receiver. Issue #1062.
+//
+// Not safe for concurrent use; streamLoop owns one.
+type diversityReporter struct {
+	log      *slog.Logger
+	addr     string
+	interval time.Duration
+	now      func() time.Time
+
+	last time.Time
+}
+
+func newDiversityReporter(log *slog.Logger, addr string) *diversityReporter {
+	return &diversityReporter{log: log, addr: addr, interval: mrcHealthInterval, now: time.Now}
+}
+
+// observe logs one line per interval describing both branches. A branch that is
+// missing from the payload or is mrcBranchDeadMarginDb below the reference is a
+// WARN naming the fix; a healthy pair is INFO.
+func (r *diversityReporter) observe(m *mrcCombiner) {
+	now := r.now()
+	if !r.last.IsZero() && now.Sub(r.last) < r.interval {
+		return
+	}
+	r.last = now
+	h := m.health()
+	attrs := []any{
+		"addr", r.addr,
+		"branch_dbfs", formatBranchPowers(h.powDbFS),
+		"reference_branch", h.refIdx,
+		"calibrated", h.calibrated,
+	}
+	switch {
+	case h.degenerate:
+		r.log.Warn("soapyremote: MRC diversity got "+strconv.Itoa(h.branches)+" of "+strconv.Itoa(h.want)+" channels in the stream — the remote is not delivering the second receiver, so there is no diversity gain. Check that the device has a second RX channel and that the server accepted the 2-channel stream request.",
+			append(attrs, "channels_delivered", h.branches, "channels_requested", h.want)...)
+	case h.deadBranch >= 0:
+		r.log.Warn("soapyremote: MRC diversity branch is dead — it sits more than "+strconv.Itoa(int(mrcBranchDeadMarginDb))+" dB below the reference receiver and contributes nothing to the combine. Check that antenna's connection, and that this RX channel is gained (sdr.soapy_remote[].antennas selects its port).",
+			append(attrs, "dead_branch", h.deadBranch)...)
+	default:
+		r.log.Info("soapyremote: MRC diversity branches", attrs...)
+	}
+}
+
+// formatBranchPowers renders per-branch mean power for a log line, e.g.
+// "ch0=-31.2 ch1=-33.8" (a branch with no samples renders as "silent").
+func formatBranchPowers(pow []float64) string {
+	var b strings.Builder
+	for i, p := range pow {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString("ch")
+		b.WriteString(strconv.Itoa(i))
+		b.WriteByte('=')
+		if math.IsInf(p, -1) {
+			b.WriteString("silent")
+			continue
+		}
+		b.WriteString(strconv.FormatFloat(p, 'f', 1, 64))
+	}
+	return b.String()
 }
 
 // refPowerDbFS is the mean power of a branch in dBFS (0 dBFS = unit amplitude),

--- a/internal/sdr/soapyremote/mrc_test.go
+++ b/internal/sdr/soapyremote/mrc_test.go
@@ -1,8 +1,12 @@
 package soapyremote
 
 import (
+	"bytes"
+	"log/slog"
 	"math"
+	"strings"
 	"testing"
+	"time"
 )
 
 // approxEqual reports whether two complex64 slices match within tol per part.
@@ -34,7 +38,7 @@ func TestDeinterleaveTwoChannelCS16(t *testing.T) {
 	// Contiguous per-channel blocks: [ch0...][ch1...].
 	payload := encodeCS16(append(append([]complex64{}, ch0...), ch1...))
 
-	got := formatCS16.deinterleave(payload, 2)
+	got := formatCS16.deinterleave(payload, 2, len(ch0))
 	if len(got) != 2 {
 		t.Fatalf("branches = %d, want 2", len(got))
 	}
@@ -49,7 +53,7 @@ func TestDeinterleaveTwoChannelCS16(t *testing.T) {
 func TestDeinterleaveSingleChannelIsConvert(t *testing.T) {
 	x := []complex64{complex(0.5, -0.5), complex(0.25, 0.25)}
 	payload := encodeCS16(x)
-	got := formatCS16.deinterleave(payload, 1)
+	got := formatCS16.deinterleave(payload, 1, len(x))
 	if len(got) != 1 || !approxEqualC(got[0], x, 1e-3) {
 		t.Fatalf("single-channel deinterleave = %v, want one branch %v", got, x)
 	}
@@ -65,7 +69,7 @@ func TestMRCCombinerAlignsRotatedBranch(t *testing.T) {
 	payload := encodeCS16(append(append([]complex64{}, ch0...), ch1...))
 
 	m := newMRCCombiner(formatCS16)
-	out := m.combine(payload)
+	out := m.combine(payload, len(ch0))
 
 	if !m.cal.Calibrated() {
 		t.Fatal("combiner did not calibrate on a signal-bearing window")
@@ -85,7 +89,7 @@ func TestMRCCombinerPassthroughBelowFloor(t *testing.T) {
 	payload := encodeCS16(append(append([]complex64{}, ch0...), ch1...))
 
 	m := newMRCCombiner(formatCS16)
-	out := m.combine(payload)
+	out := m.combine(payload, len(ch0))
 
 	if m.cal.Calibrated() {
 		t.Error("combiner calibrated on a below-floor (noise) window; want deferred")
@@ -106,7 +110,7 @@ func TestMRCCombinerRecalibrateOnRequest(t *testing.T) {
 
 	// First lock: ch1 == ch0. Calibrates h1 = 1.
 	pA := encodeCS16(append(append([]complex64{}, ref...), ref...))
-	_ = m.combine(pA)
+	_ = m.combine(pA, len(ref))
 	if !m.cal.Calibrated() {
 		t.Fatal("did not calibrate on first window")
 	}
@@ -115,12 +119,157 @@ func TestMRCCombinerRecalibrateOnRequest(t *testing.T) {
 	m.requestRecalibrate()
 	ch1 := scaleC(ref, complex(-1, 0))
 	pB := encodeCS16(append(append([]complex64{}, ref...), ch1...))
-	out := m.combine(pB)
+	out := m.combine(pB, len(ref))
 
 	// With a fresh estimate (h1 = -1) the branches add in phase → ≈ ref.
 	// With a STALE h1 = 1 they would cancel to ≈ 0.
 	if !approxEqualC(out, ref, 2e-3) {
 		t.Errorf("recalibrated output = %v, want ≈ %v (stale gain would cancel to ~0)", out, ref)
+	}
+}
+
+// TestDeinterleaveShortLastChannel pins the upstream block layout: the stride is
+// derived from (total-elems), NOT assumed equal. The first N-1 channels always
+// occupy a full stride-sized block; only the last is shortened to elems. An
+// equal split would return ch0's stale tail as branch 1's first sample.
+func TestDeinterleaveShortLastChannel(t *testing.T) {
+	ch0 := []complex64{complex(0.5, -0.5), complex(0.25, 0.25), complex(-0.3, 0.4)}
+	stale := complex64(complex(-0.9, 0.9))
+	ch1 := []complex64{complex(0.1, 0.2), complex(-0.2, 0.3), complex(0.4, -0.1)}
+	payload := encodeCS16(append(append(append([]complex64{}, ch0...), stale), ch1...))
+
+	got := formatCS16.deinterleave(payload, 2, len(ch1))
+	if len(got) != 2 {
+		t.Fatalf("branches = %d, want 2", len(got))
+	}
+	if !approxEqualC(got[0], ch0, 1e-3) {
+		t.Errorf("branch 0 = %v, want %v (stale tail past elems must be dropped)", got[0], ch0)
+	}
+	if !approxEqualC(got[1], ch1, 1e-3) {
+		t.Errorf("branch 1 = %v, want %v (block stride, not an equal split)", got[1], ch1)
+	}
+}
+
+// TestDeinterleaveSingleChannelPayloadUnderMultiChannelRequest: when the server
+// delivers only one channel's worth of samples (elems == the whole payload)
+// under a 2-channel request, that payload is a valid single-receiver time
+// series. Report one branch rather than force-splitting it into two half-length
+// fakes, so the caller can surface the shortfall instead of combining nonsense.
+func TestDeinterleaveSingleChannelPayloadUnderMultiChannelRequest(t *testing.T) {
+	x := []complex64{complex(0.5, -0.5), complex(0.25, 0.25), complex(-0.3, 0.4), complex(0.1, 0.1)}
+	got := formatCS16.deinterleave(encodeCS16(x), 2, len(x))
+	if len(got) != 1 {
+		t.Fatalf("branches = %d, want 1 (single-channel payload)", len(got))
+	}
+	if !approxEqualC(got[0], x, 1e-3) {
+		t.Errorf("branch 0 = %v, want the payload verbatim %v", got[0], x)
+	}
+}
+
+// TestMRCCombinerAnchorsOnTheLiveBranch is the #1062 field regression at the
+// combiner level: with RX0 disconnected (noise) and RX1 carrying signal, the
+// combiner must anchor its calibration on RX1 and emit RX1's signal. Anchoring
+// on branch 0 unconditionally leaves it in passthrough forever, emitting noise.
+func TestMRCCombinerAnchorsOnTheLiveBranch(t *testing.T) {
+	dead := []complex64{complex(1e-3, -1e-3), complex(-1e-3, 1e-3), complex(1e-3, 1e-3)}
+	live := []complex64{complex(0.5, 0.2), complex(0.3, -0.4), complex(-0.2, 0.35)}
+	payload := encodeCS16(append(append([]complex64{}, dead...), live...))
+
+	m := newMRCCombiner(formatCS16)
+	out := m.combine(payload, len(live))
+
+	if !m.cal.Calibrated() {
+		t.Fatal("combiner did not calibrate on a window where RX1 carries signal")
+	}
+	if h := m.health(); h.refIdx != 1 {
+		t.Errorf("reference branch = %d, want 1 (the live receiver)", h.refIdx)
+	}
+	if p := refPowerDbFS(out); p < mrcCalFloorDbFS {
+		t.Fatalf("combined power = %.1f dBFS, want the live branch — a dead RX0 must not silence the stream", p)
+	}
+	if !approxEqualC(out, live, 2e-2) {
+		t.Errorf("combined = %v, want ≈ the live branch %v", out, live)
+	}
+}
+
+// TestMRCCombinerHealthFlagsDeadBranch: a branch far below the reference is
+// reported so an operator can see it in GopherTrunk's own log rather than in
+// SoapySDRServer's UHD debug output.
+func TestMRCCombinerHealthFlagsDeadBranch(t *testing.T) {
+	live := []complex64{complex(0.5, 0.2), complex(0.3, -0.4), complex(-0.2, 0.35)}
+	dead := scaleC(live, complex(1e-3, 0)) // 60 dB down
+	m := newMRCCombiner(formatCS16)
+	_ = m.combine(encodeCS16(append(append([]complex64{}, live...), dead...)), len(live))
+
+	h := m.health()
+	if h.deadBranch != 1 {
+		t.Errorf("deadBranch = %d, want 1", h.deadBranch)
+	}
+	if h.degenerate {
+		t.Error("degenerate = true, want false (both channels were delivered)")
+	}
+
+	// Two healthy branches must NOT trip it.
+	m2 := newMRCCombiner(formatCS16)
+	_ = m2.combine(encodeCS16(append(append([]complex64{}, live...), live...)), len(live))
+	if h2 := m2.health(); h2.deadBranch != -1 {
+		t.Errorf("deadBranch = %d on two equal branches, want -1", h2.deadBranch)
+	}
+}
+
+// TestMRCCombinerSingleChannelPayloadPassesThrough: a server that honours only
+// one channel of the 2-channel request must yield that receiver verbatim (and
+// be flagged), not a spliced half-and-half stream.
+func TestMRCCombinerSingleChannelPayloadPassesThrough(t *testing.T) {
+	x := []complex64{complex(0.5, 0.2), complex(0.3, -0.4), complex(-0.2, 0.35), complex(0.1, 0.1)}
+	m := newMRCCombiner(formatCS16)
+	out := m.combine(encodeCS16(x), len(x))
+
+	if !approxEqualC(out, x, 1e-3) {
+		t.Errorf("out = %v, want the payload verbatim %v", out, x)
+	}
+	h := m.health()
+	if !h.degenerate || h.branches != 1 {
+		t.Errorf("health = %+v, want degenerate with 1 branch delivered", h)
+	}
+}
+
+// TestDiversityReporterWarnsOncePerInterval: the first datagram always reports
+// (so enabling diversity shows both branch levels immediately), a dead branch
+// reports at WARN, and the line is throttled thereafter.
+func TestDiversityReporterWarnsOncePerInterval(t *testing.T) {
+	live := []complex64{complex(0.5, 0.2), complex(0.3, -0.4), complex(-0.2, 0.35)}
+	dead := scaleC(live, complex(1e-3, 0))
+	payload := encodeCS16(append(append([]complex64{}, live...), dead...))
+	m := newMRCCombiner(formatCS16)
+	_ = m.combine(payload, len(live))
+
+	var buf bytes.Buffer
+	r := newDiversityReporter(slog.New(slog.NewTextHandler(&buf, nil)), "10.0.0.5:55132")
+	now := time.Unix(1700000000, 0)
+	r.now = func() time.Time { return now }
+
+	r.observe(m)
+	first := buf.String()
+	if !strings.Contains(first, "level=WARN") || !strings.Contains(first, "dead_branch=1") {
+		t.Errorf("first report = %q, want a WARN naming the dead branch", first)
+	}
+	if !strings.Contains(first, "ch0=") || !strings.Contains(first, "ch1=") {
+		t.Errorf("first report = %q, want per-branch levels", first)
+	}
+
+	buf.Reset()
+	now = now.Add(mrcHealthInterval / 2)
+	r.observe(m)
+	if buf.Len() != 0 {
+		t.Errorf("reported again inside the throttle interval: %q", buf.String())
+	}
+
+	buf.Reset()
+	now = now.Add(mrcHealthInterval)
+	r.observe(m)
+	if buf.Len() == 0 {
+		t.Error("no report after the throttle interval elapsed")
 	}
 }
 

--- a/internal/sdr/soapyremote/stream.go
+++ b/internal/sdr/soapyremote/stream.go
@@ -124,25 +124,67 @@ func (f sampleFormat) convert(buf []byte) []complex64 {
 }
 
 // deinterleave splits one multi-channel stream payload into one []complex64 per
-// channel. The datagram header's elems field is the sample count *per channel*,
-// so an n-channel payload holds n equal, channel-contiguous blocks laid out as
-// [ch0: elems samples][ch1: elems samples]…, matching SoapyRemote's
-// SoapyStreamEndpoint (each SoapySDR per-channel buffer maps to a contiguous
-// region of the transfer). channels<=1 is exactly convert().
+// channel, given the header's elems field. channels<=1 is exactly convert().
 //
-// ASSUMPTION flagged for on-air validation (issue #1062): the per-channel block
-// layout (contiguous blocks, ch0 first) is transcribed from the SoapyRemote
-// endpoint convention and has NOT yet been confirmed against a live dual-RX
-// server. If a real B210 A/B shows the branches transposed or sample-interleaved,
-// this function is the single place to change — nothing downstream depends on the
-// layout. A ragged tail (payload not a whole multiple of channels·bytesPerSample)
-// is dropped so the branches stay sample-aligned.
-func (f sampleFormat) deinterleave(buf []byte, channels int) [][]complex64 {
+// Layout (common/SoapyStreamEndpoint.cpp, confirmed against upstream). Each
+// channel occupies its own contiguous block at
+//
+//	offset_c = HEADER_SIZE + c·_buffSize·elemSize
+//
+// so the blocks are channel-contiguous and ch0 comes first — but they are NOT
+// equal-length in general. The endpoint always sends the first N-1 channels as
+// FULL _buffSize blocks and shortens only the LAST channel to the sample count
+// actually read, which is the count the header carries:
+//
+//	totalElems = (numChans-1)·_buffSize + elems
+//
+// So elems is the number of VALID samples in every channel (readStream returns
+// the same count for all of them) and _buffSize is the block stride; the tail of
+// each earlier block past elems is stale buffer, not IQ. That makes the stride
+// derivable from the payload without knowing the negotiated MTU:
+//
+//	stride = (totalElems - elems) / (numChans - 1)
+//
+// Splitting the payload into N equal blocks instead (the pre-#1062-fix
+// behaviour) is only correct while every transfer is full; on any short
+// transfer it slides branch 1 into the tail of branch 0, so the two branches
+// stop being time-aligned and the phase calibration anchors on garbage.
+//
+// Degenerate payloads are reported honestly rather than force-split, so the
+// caller can surface them instead of combining nonsense:
+//   - totalElems == elems under a multi-channel request means the server
+//     delivered a SINGLE channel; one branch is returned (the payload is a
+//     valid single-channel time series).
+//   - any other unresolvable shape falls back to the equal split, which at
+//     least preserves the branch count.
+//
+// Callers detect both cases by comparing len(result) against the channel count
+// and the returned branch length against elems.
+func (f sampleFormat) deinterleave(buf []byte, channels, elems int) [][]complex64 {
 	if channels <= 1 {
 		return [][]complex64{f.convert(buf)}
 	}
 	bps := f.bytesPerSample()
-	perCh := (len(buf) / bps) / channels // whole samples per channel
+	total := len(buf) / bps
+	if elems > 0 && elems <= total {
+		if elems == total {
+			// Only one channel's worth of samples arrived.
+			return [][]complex64{f.convert(buf[:elems*bps])}
+		}
+		if rest := total - elems; rest%(channels-1) == 0 {
+			if stride := rest / (channels - 1); stride >= elems {
+				out := make([][]complex64, channels)
+				for c := 0; c < channels; c++ {
+					start := c * stride * bps
+					out[c] = f.convert(buf[start : start+elems*bps])
+				}
+				return out
+			}
+		}
+	}
+	// Unresolvable shape: equal blocks, dropping any ragged tail so the
+	// branches stay the same length.
+	perCh := total / channels
 	blockBytes := perCh * bps
 	out := make([][]complex64, channels)
 	for c := 0; c < channels; c++ {


### PR DESCRIPTION
## Summary

On a real USRP B210, `diversity: mrc` streamed only RX0 — RX1 stayed dark, and disconnecting RX0's antenna dropped the whole stream to the noise floor even with a good antenna on RX1 (field report in #1062). Three independent defects, all confined to the diversity path, each of which alone is enough to produce that symptom.

The reporter's own root-cause theory (that `setupStreamTCP` issues two sequential single-channel setups) doesn't hold — the driver already sends one `SETUP_STREAM` with `[0,1]`, and the two `get_converter … Num inputs: 1` lines in their `SoapySDRServer` log are UHD instantiating one converter *per channel*, which is what a 2-channel streamer looks like. The stream was genuinely 2-channel; what was wrong was on this side of it.

## Changes

- **Gain and frequency correction now reach every open RX channel.** They were programmed on channel 0 only, on the theory that the phase calibration's complex gain absorbs a per-branch amplitude difference. It absorbs an *imbalance*, not an *unconfigured receiver*: a SoapySDR RX channel comes up at the driver default (0 dB on UHD), leaving RX1 tens of dB down, which the maximal-ratio |h|² weight then discards entirely. A failure on a secondary branch warns instead of aborting the tune, so enabling MRC can't break tuning outright.
- **The phase calibration anchors on whichever branch is receiving.** `StaticCalibrator` anchors on branch 0, and the driver hardwired branch 0 as the reference — so a silent RX0 never cleared the calibration floor, the combiner sat in passthrough, and it emitted RX0's noise while RX1 carried signal. The reference is now the strongest branch of the window (re-evaluated while uncalibrated, frozen at calibration, branches handed to the calibrator permuted). Which branch anchors the phase is arbitrary, so this costs nothing and makes one live receiver sufficient.
- **The datagram block stride is derived, not assumed.** The payload was split into N equal per-channel blocks. Upstream (`common/SoapyStreamEndpoint.cpp`) always sends the first N-1 channels as full `_buffSize` blocks and shortens only the **last** channel to the header's `elems` count — so on any short transfer the equal split slid branch 1 into the tail of branch 0, de-aligning the branches and anchoring the calibration on garbage. Now `stride = (totalElems - elems) / (numChans - 1)`, with no MTU assumption. A payload carrying only one channel is reported as one branch and passed through verbatim rather than force-split into two half-length fakes.
- **Per-branch diagnostics.** A level line at stream start and every 30 s (`branch_dbfs="ch0=-31.2 ch1=-33.8" reference_branch=0 calibrated=true`), escalating to WARN when a branch sits >20 dB below the reference or the remote delivers fewer channels than requested. The reporter had to read `SoapySDRServer`'s UHD debug output to discover RX2B was dark; that state is now in GopherTrunk's own log.
- Stream buffer depth now divides by the channel count (a multi-channel datagram splits one MTU across the branches).
- `docs/hardware.md`: how to read the new branch line, plus a corrected limitations note; CHANGELOG entry.

## Test plan

- [x] `make vet test` is green locally (165 packages, exit 0)
- [ ] `make integration` — n/a, no daemon/DSP/replay path touched
- [x] Added or updated tests where appropriate
- [ ] Smoke-tested against real hardware — **not possible here; no dual-RX B210.** This is what the reporter's A/B settles (see below).

Every new test fails against the pre-fix code, verified by reverting each behaviour in turn:

| Test | Pre-fix failure |
|---|---|
| `TestSetGainReachesEveryDiversityChannel` | `SET_GAIN(40 dB) never reached RX channel 1 (channels gained: [0])` |
| `TestSetPPMReachesEveryDiversityChannel` | `SET_FREQUENCY_CORRECTION never reached RX channel 1` |
| `TestStreamIQDiversityRecoversWhenRX0IsDead` | `combined power = -57.2 dBFS with a dead RX0 and a live RX1` |
| `TestMRCCombinerAnchorsOnTheLiveBranch` | `combiner did not calibrate on a window where RX1 carries signal` |
| `TestStreamIQDiversityShortLastChannel` | branches time-misaligned; combined samples are garbage |
| `TestDeinterleaveShortLastChannel` | branch 1 starts with ch0's stale tail sample |
| `TestMRCCombinerSingleChannelPayloadPassesThrough` | a single-channel payload silently combined into a corrupt half-length stream |

Also: `TestSetGainSingleChannelStaysChannelZero` pins that the per-channel fan-out is diversity-only, and `TestDiversityReporterWarnsOncePerInterval` covers the new log line and its throttle. The fake server now models the real per-channel `elems` convention, so the diversity tests exercise the wire layout instead of mirroring the old assumption.

## Breaking changes

None. Single-channel streams are byte-identical — the per-channel fan-out only iterates past channel 0 when `diversity: mrc` is set, and the de-interleave is a no-op at one channel. No config keys, flags, or endpoints changed.

## Docs / CHANGELOG

- [x] Added a `## [Unreleased]` bullet to `CHANGELOG.md`
- [x] Updated `docs/hardware.md` (reading the branch-health line; corrected the single-channel limitation)

## Linked issues

Refs #1062 — staying open until the reporter's on-air A/B on the B210 confirms RX1 is contributing. The remaining open question from their report is the server-side `~SoapyRPCUnpacker: Unconsumed payload bytes 9` notice: every RPC frame this driver sends matches upstream's `ClientHandler.cpp` unpack order field-for-field, and the handler completes, so it isn't the cause of the dark channel — worth chasing separately if it persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K4UM4EWKRmxfREjxXAZ7Uu

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4UM4EWKRmxfREjxXAZ7Uu)_