### PR TITLE
web: fix three TS6133 errors that broke `make web-build`, and typecheck the SPAs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,38 @@ jobs:
         run: npm test
         working-directory: web
 
+  # web-typecheck runs `tsc --noEmit` over every SPA in web/. Vitest
+  # transpiles with esbuild and never typechecks, so web-test above is
+  # green on code that `npm run build` (tsc --noEmit && vite build)
+  # rejects — which is how three TS6133 errors in
+  # web/src/api/reconnectingSocket.test.ts reached main and broke
+  # `make web-build` for operators. The only job that caught them was
+  # "Windows installer (PR)", which isn't a required check, so the PR
+  # merged red and the breakage looked like CI had passed.
+  #
+  # Matrixed per SPA: each has its own package.json/tsconfig, and
+  # rfscope/cryptolab are built by NO workflow at all (release.yml and
+  # installer.yml build only web, configbuilder and siglab), so this is
+  # their sole CI coverage. `npm install`, not `npm ci` — rfscope has no
+  # package-lock.json.
+  web-typecheck:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        spa: [web, web/configbuilder, web/siglab, web/rfscope, web/cryptolab]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install deps
+        run: npm install --no-audit --no-fund
+        working-directory: ${{ matrix.spa }}
+      - name: Typecheck
+        run: npm run typecheck
+        working-directory: ${{ matrix.spa }}
+
   # govulncheck enumerates known CVEs that affect the direct +
   # transitive dependency graph. Failing this job blocks merge — a
   # known-vulnerable dep means the operator has to either upgrade

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -512,3 +512,17 @@ confirmation before any close-as-completed.
   setting it once and never revisiting. `web/src/api/reconnectingSocket.ts` now owns the logic
   the four clients had each copied — including the `onerror`+`onclose` double-bind that
   scheduled two timers per failure while remembering only one handle.
+- **A green `ci.yml` does not mean the web console builds.** `npm test` (vitest) transpiles
+  with esbuild and never typechecks, so the SPA jobs in `ci.yml` pass on code that
+  `npm run build` (`tsc --noEmit && vite build`, i.e. `make web-build`/`make dist`) rejects.
+  Three `TS6133` unused-parameter errors in `web/src/api/reconnectingSocket.test.ts` landed on
+  main that way and broke the build for an operator. The only job that caught them was
+  **"Windows installer (PR)"** — which is not a required check, so the PR merged red and it
+  read as "CI passed". Two things follow: **when a web change is in the diff, run
+  `cd web && npm run typecheck` (or `make web-build`) before pushing** — `npm test` alone is
+  not sufficient evidence; and check a PR's non-required jobs, not just the required ones.
+  `ci.yml`'s `web-typecheck` job now runs `tsc --noEmit` across all five SPAs (`web`,
+  `configbuilder`, `siglab`, `rfscope`, `cryptolab` — the last two are built by no other
+  workflow). Note `tsconfig.json` sets `noUnusedLocals`/`noUnusedParameters`, so an unused
+  parameter needs a leading underscore (`_fn`), and test files are inside `include: ["src"]`
+  and are typechecked like production code.

--- a/web/src/api/reconnectingSocket.test.ts
+++ b/web/src/api/reconnectingSocket.test.ts
@@ -50,7 +50,7 @@ describe("openReconnectingSocket", () => {
     const waits: number[] = [];
     const spy = vi
       .spyOn(window, "setTimeout")
-      .mockImplementation(((fn: () => void, ms?: number) => {
+      .mockImplementation(((_fn: () => void, ms?: number) => {
         waits.push(ms ?? 0);
         return 0 as unknown as number;
       }) as typeof window.setTimeout);
@@ -91,7 +91,7 @@ describe("openReconnectingSocket", () => {
     const waits: number[] = [];
     const spy = vi
       .spyOn(window, "setTimeout")
-      .mockImplementation(((fn: () => void, ms?: number) => {
+      .mockImplementation(((_fn: () => void, ms?: number) => {
         waits.push(ms ?? 0);
         return 0 as unknown as number;
       }) as typeof window.setTimeout);
@@ -125,7 +125,7 @@ describe("openReconnectingSocket", () => {
     const waits: number[] = [];
     const spy = vi
       .spyOn(window, "setTimeout")
-      .mockImplementation(((fn: () => void, ms?: number) => {
+      .mockImplementation(((_fn: () => void, ms?: number) => {
         waits.push(ms ?? 0);
         return 0 as unknown as number;
       }) as typeof window.setTimeout);


### PR DESCRIPTION
`make web-build` failed for an operator with

    src/api/reconnectingSocket.test.ts(53,29): error TS6133: 'fn' is declared but its value is never read.

three times over, in the setTimeout mocks of reconnectingSocket.test.ts. The
tsconfig sets noUnusedParameters and `include: ["src"]`, so a test file's unused
parameter is an error like any other; the mocks only read `ms`, and `fn` is there
purely to shape the signature. Prefix it `_fn`, which is the exemption TypeScript
recognises.

The more useful half is why this reached main. It did NOT pass CI: the "Windows
installer (PR)" job failed on exactly these three lines, on both runs of #1101.
That job isn't a required check, so the PR merged red and it read as a green CI.
Meanwhile ci.yml's own `web-test` job runs `npm test` — vitest transpiles with
esbuild and never typechecks — so the one web job people watch cannot fail on a
type error at all. The gap is structural: `npm run build` (tsc --noEmit && vite
build) is the only thing that typechecks, and outside a release/installer run
nothing in ci.yml invokes it.

Add a `web-typecheck` job running `tsc --noEmit` per SPA. It is matrixed over all
five (web, configbuilder, siglab, rfscope, cryptolab) rather than just web:
release.yml and installer.yml build only the first three, so rfscope and cryptolab
had no typecheck coverage anywhere. `npm install`, not `npm ci`, because rfscope
ships no package-lock.json.

Verified: `npx tsc --noEmit` reproduces the three errors before the fix and is
clean after; `npm test` 345/345 in 58 files; `npm run build` completes (the vite
build empties web/dist, so restore the tracked .gitkeep after running it); the
matrix's five typechecks all pass locally; `go vet ./...` clean (no Go touched).

Refs #1101

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015eRhwsL6BgW8k5D7YXR6ST