### PR TITLE
composer: mute the analog FM chain while the scanner reports squelch closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Fixed
+- **Conventional/analog scanner recordings no longer end in a loud multi-second
+  noise tail** (issue #1090). The scanner-side hangtime debounce (#1091) fixed
+  when a call *ends*, but for the whole hangtime window the composer's FM chain
+  kept demodulating carrier-less receiver noise — loud out of an FM
+  discriminator regardless of RF level — and the audio AGC amplified it toward
+  full scale. The scanner now publishes its live, debounced squelch decision and
+  the FM chain follows it: while squelch is closed the audio AGC freezes and the
+  recorded/streamed PCM fades to silence within ~10 ms, resuming when real
+  activity returns. No config changes; analog-trunk voice channels
+  (Motorola/LTR/MPT 1327) are unaffected.
+
 ### Security
 - **Bumped the Go toolchain to 1.25.13 and `golang.org/x/net` to v0.55.0** to
   clear the CVEs govulncheck reports against the pinned toolchain: seven Go

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -1605,6 +1605,14 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 				return nil, fmt.Errorf("daemon: conv scanner: %w", err)
 			}
 			d.convScan = cs
+			// Gate the composer's FM chain on the scanner's live squelch
+			// decision so the hangtime tail records as silence instead of
+			// AGC-boosted receiver noise (issue #1090). Set here (not in
+			// buildComposer's Options) because the composer is built
+			// before the scanner exists.
+			if d.composer != nil {
+				d.composer.SetSquelchState(cs)
+			}
 		}
 	}
 

--- a/internal/scanner/conventional/scanner.go
+++ b/internal/scanner/conventional/scanner.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
@@ -209,6 +210,52 @@ type Scanner struct {
 	// scanner state changes (hold / resume) but not across daemon
 	// restarts.
 	lockedOut map[int]bool
+	// squelchState publishes beginDwell's live per-chunk squelch
+	// decision for SquelchOpen (one of the squelch* constants).
+	// Atomic because the composer's FM chain polls it from its own
+	// goroutine on every IQ chunk.
+	squelchState atomic.Int32
+}
+
+// squelchState values published by beginDwell and read by SquelchOpen.
+const (
+	// squelchNoDwell: no dwell in progress — there is no live squelch
+	// decision to report (SquelchOpen returns ok=false).
+	squelchNoDwell int32 = iota
+	// squelchClosed: dwelling, and the hangtime countdown is running —
+	// the channel is squelch-closed (only receiver noise on the air).
+	squelchClosed
+	// squelchOpenState: dwelling with activity present (carrier + tone
+	// where gated), i.e. real audio is expected on the channel.
+	squelchOpenState
+)
+
+// SquelchOpen reports the scanner's live per-chunk squelch decision for
+// its device, so the composer's FM voice chain can gate audio on it
+// (issue #1090 follow-up). beginDwell's hangtime debounce only decides
+// when the call ENDS; during the hangtime window the FM chain used to
+// keep demodulating pure receiver noise — and the audio AGC actively
+// amplified it toward full scale — producing the loud audible tail the
+// reporter measured. The published state follows the same debounced
+// decision the countdown uses, so a brief blip that cannot reset the
+// countdown cannot pop through the recording either.
+//
+// ok=false means there is no live decision for this serial (not this
+// scanner's device, or no dwell in progress). Callers must treat that
+// as "no gating available" — never as "squelch closed" — so every
+// non-conventional analog chain stays ungated.
+func (s *Scanner) SquelchOpen(deviceSerial string) (open, ok bool) {
+	if deviceSerial != s.opts.DeviceSerial {
+		return false, false
+	}
+	switch s.squelchState.Load() {
+	case squelchOpenState:
+		return true, true
+	case squelchClosed:
+		return false, true
+	default:
+		return false, false
+	}
 }
 
 // New constructs a Scanner. Channels may be empty when the operator
@@ -495,6 +542,11 @@ func (s *Scanner) scanWindow(ctx context.Context, idx int, ch Channel, stream <-
 // publishing CallEnd.
 func (s *Scanner) beginDwell(idx int, ch Channel, stream <-chan []complex64, streamCtx context.Context, cancel context.CancelFunc) {
 	defer cancel()
+	// Squelch just broke in scanWindow, so the dwell starts open; every
+	// exit path (hangtime, stream error, ctx cancel) clears the
+	// published state so SquelchOpen reports ok=false between dwells.
+	s.squelchState.Store(squelchOpenState)
+	defer s.squelchState.Store(squelchNoDwell)
 
 	now := s.opts.Now()
 	s.mu.Lock()
@@ -584,6 +636,16 @@ func (s *Scanner) beginDwell(idx int, ch Channel, stream <-chan []complex64, str
 					s.endDwell(idx, trunking.EndReasonNormal)
 					return
 				}
+			}
+			// Publish the debounced decision for the composer's FM
+			// chain: open exactly while the countdown is NOT running.
+			// A blip inside the debounce window leaves belowSince set,
+			// so it can't unmute the recording any more than it can
+			// reset the countdown.
+			if belowSince.IsZero() {
+				s.squelchState.Store(squelchOpenState)
+			} else {
+				s.squelchState.Store(squelchClosed)
 			}
 		}
 	}

--- a/internal/scanner/conventional/scanner_test.go
+++ b/internal/scanner/conventional/scanner_test.go
@@ -416,6 +416,105 @@ func TestConvScannerBriefBlipsDoNotHoldSquelchOpen(t *testing.T) {
 	}
 }
 
+// TestConvScannerPublishesSquelchState pins the SquelchOpen feed the
+// composer's FM chain gates on (issue #1090 follow-up): ok=false
+// outside a dwell and for foreign serials; open while activity is
+// present; closed — never flickering open — through a blip-peppered
+// hangtime tail (the published state must follow the debounced
+// decision, or a lone blip would pop through the recording); and back
+// to ok=false once the call releases.
+func TestConvScannerPublishesSquelchState(t *testing.T) {
+	tuner := &fakeTuner{}
+	const hangtime = 300 * time.Millisecond
+	// ~60 ms of sustained loud (squelch open), then the same
+	// [29 silent, 1 loud] blip cadence as the debounce regression
+	// above: the countdown runs, blips can't reset it, and the gate
+	// must stay closed until release.
+	queue := [][]complex64{}
+	for i := 0; i < 30; i++ {
+		queue = append(queue, loudChunk(256))
+	}
+	for r := 0; r < 80; r++ {
+		for i := 0; i < 29; i++ {
+			queue = append(queue, make([]complex64, 256)) // silence
+		}
+		queue = append(queue, loudChunk(256)) // 1-chunk blip
+	}
+	iq := &fakeIQ{
+		tuner:  tuner,
+		chunks: map[uint32][][]complex64{200_000_000: queue},
+	}
+	eng := &fakeEngine{}
+	s, err := New(Options{
+		Tuner: tuner, IQ: iq, Engine: eng, Recorder: fakeRecorder{},
+		DeviceSerial: "CONV-SQ",
+		SystemName:   "test",
+		Channels: []Channel{
+			{Label: "B", FrequencyHz: 200_000_000, SquelchDbFS: -10, Hangtime: hangtime},
+		},
+		MinDwellPerChannel: 20 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := s.SquelchOpen("CONV-SQ"); ok {
+		t.Error("SquelchOpen reported ok=true before any dwell")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = s.Run(ctx) }()
+
+	poll := func(deadline time.Duration, fn func() bool) bool {
+		end := time.Now().Add(deadline)
+		for time.Now().Before(end) {
+			if fn() {
+				return true
+			}
+			time.Sleep(time.Millisecond)
+		}
+		return false
+	}
+
+	// Phase 1: sustained signal — the gate must read open.
+	if !poll(2*time.Second, func() bool {
+		open, ok := s.SquelchOpen("CONV-SQ")
+		return ok && open
+	}) {
+		t.Fatal("SquelchOpen never reported open during sustained signal")
+	}
+	if open, ok := s.SquelchOpen("OTHER-SERIAL"); open || ok {
+		t.Error("SquelchOpen for a foreign serial must report (false, false)")
+	}
+
+	// Phase 2: the blip-peppered tail — closed, and NEVER open again
+	// (a lone blip inside the debounce window must not unmute) until
+	// the dwell releases on hangtime (ok=false).
+	if !poll(2*time.Second, func() bool {
+		open, ok := s.SquelchOpen("CONV-SQ")
+		return ok && !open
+	}) {
+		t.Fatal("SquelchOpen never reported closed once the signal dropped")
+	}
+	sawOpenDuringTail := false
+	if !poll(2*time.Second, func() bool {
+		open, ok := s.SquelchOpen("CONV-SQ")
+		if ok && open {
+			sawOpenDuringTail = true
+		}
+		return !ok
+	}) {
+		t.Fatal("dwell never released (SquelchOpen still ok=true after hangtime)")
+	}
+	if sawOpenDuringTail {
+		t.Error("gate re-opened on a single-chunk blip during the hangtime tail; must follow the debounced decision")
+	}
+	if eng.normalEndCount() == 0 {
+		t.Error("call never released on hangtime")
+	}
+}
+
 func TestConvScannerHoldAndResume(t *testing.T) {
 	s, err := New(Options{
 		Tuner: &fakeTuner{}, IQ: &fakeIQ{tuner: &fakeTuner{}}, Engine: &fakeEngine{}, Recorder: fakeRecorder{},

--- a/internal/voice/composer/composer.go
+++ b/internal/voice/composer/composer.go
@@ -112,6 +112,22 @@ type Devices interface {
 	FindBySerial(serial string) IQSource
 }
 
+// SquelchState is the optional live squelch feed the conventional
+// scanner exposes (issue #1090). The analog FM chain polls it per IQ
+// chunk: while the scanner reports the channel squelch-closed (the
+// hangtime tail — carrier gone, countdown running) the chain freezes
+// the audio AGC and mutes its PCM output, instead of demodulating pure
+// receiver noise and AGC-boosting it into the recording as a loud
+// multi-second squelch crash.
+type SquelchState interface {
+	// SquelchOpen reports the current squelch decision for deviceSerial.
+	// ok=false means the provider has no live decision for this serial
+	// (not a conventional-scanner dwell); the chain must then stay
+	// ungated — analog-trunk voice channels (Motorola/LTR/MPT 1327)
+	// share runFMChain but have no scanner-side squelch.
+	SquelchOpen(deviceSerial string) (open, ok bool)
+}
+
 // PCMSink is the subset of voice.Recorder we touch. Recorder.WritePCM
 // matches this signature exactly.
 type PCMSink interface {
@@ -211,6 +227,13 @@ type Options struct {
 	// analysis. Nil (default) disables the capture at zero cost — no frame
 	// extraction runs for it. See internal/voice/cryptocap.
 	CryptoSink cryptocap.Sink
+	// Squelch, when non-nil, gates the analog FM chain's audio on the
+	// conventional scanner's live squelch decision (issue #1090). The
+	// daemon builds the composer before the scanner, so it wires this
+	// via SetSquelchState instead; the option exists for callers (and
+	// tests) that have the provider up front. Nil leaves every chain
+	// ungated — identical to the pre-gate behavior.
+	Squelch SquelchState
 }
 
 // DeEmphasisConfig holds runtime knobs for the post-FM-demod
@@ -274,6 +297,11 @@ type Composer struct {
 	resampCfg  AudioResamplerConfig
 	autotune   *autotune.Registry
 	cryptoSink cryptocap.Sink
+	// squelch is the optional conventional-scanner squelch feed for the
+	// FM chain (issue #1090). Guarded by mu: the daemon sets it after
+	// construction (SetSquelchState) and each chain reads it once at
+	// start.
+	squelch SquelchState
 
 	// drainCoord, when the sink supports it (the recorder does), lets the
 	// composer tell the recorder that a call's voice chain has fully drained
@@ -389,6 +417,7 @@ func New(opts Options) (*Composer, error) {
 		resampCfg:    opts.AudioResampler,
 		autotune:     opts.Autotune,
 		cryptoSink:   opts.CryptoSink,
+		squelch:      opts.Squelch,
 		chains:       make(map[string]*chain),
 		tetraDemuxes: make(map[string]*tetraSlotDemux),
 		runDone:      make(chan struct{}),
@@ -403,6 +432,20 @@ func New(opts Options) (*Composer, error) {
 	}
 	c.sub = opts.Bus.Subscribe()
 	return c, nil
+}
+
+// SetSquelchState wires the conventional scanner's live squelch
+// decision into the analog FM chain after construction (issue #1090) —
+// the daemon builds the composer before the scanner, so it cannot pass
+// the provider through Options. Each chain reads the provider once at
+// start, so calls made before the chain's CallStart take effect;
+// in the daemon both happen during single-threaded construction,
+// before Run delivers any event. A nil provider (or one reporting
+// ok=false for a serial) leaves chains ungated.
+func (c *Composer) SetSquelchState(sq SquelchState) {
+	c.mu.Lock()
+	c.squelch = sq
+	c.mu.Unlock()
 }
 
 // Run drains CallStart / CallEnd events until ctx cancels, spawning /
@@ -884,6 +927,22 @@ func (c *Composer) runFMChain(ctx context.Context, serial string, iqCh <-chan []
 	// (issue #492 footprint reduction).
 	var eqScratch []complex64
 
+	// Squelch-tail gate (issue #1090). While the conventional scanner
+	// reports the channel squelch-closed (hangtime countdown running,
+	// only receiver noise on the air), the chain keeps running — the
+	// decimators/filters stay warm and the PCM timeline stays continuous
+	// for the recorder and live stream — but the audio AGC is frozen
+	// (adapting on demodulated noise is what rode the gain up to the
+	// loud audible tail) and the written PCM is replaced by a short
+	// fade-out into silence. muteFade/muteStep carry the fade across
+	// chunk boundaries: PCM chunks here are ~a dozen samples, well
+	// under the ~10 ms ramp.
+	c.mu.Lock()
+	squelch := c.squelch
+	c.mu.Unlock()
+	var muteFade, muteStep float32
+	squelchWasOpen := true
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -896,6 +955,12 @@ func (c *Composer) runFMChain(ctx context.Context, serial string, iqCh <-chan []
 			if !ok {
 				emitTail()
 				return
+			}
+			squelchOpen := true
+			if squelch != nil {
+				if open, ok := squelch.SquelchOpen(serial); ok {
+					squelchOpen = open
+				}
 			}
 			bt.observe(iq)
 			decimated := fe.Process(nil, iq)
@@ -917,7 +982,11 @@ func (c *Composer) runFMChain(ctx context.Context, serial string, iqCh <-chan []
 			if audioLPF != nil {
 				audio = audioLPF.Process(audio, audio)
 			}
-			if agc != nil {
+			// Freeze the AGC while squelch-closed: its output is about
+			// to be muted anyway, and letting the envelope follower
+			// adapt on demodulated noise poisons the level estimate for
+			// the next over inside the hangtime window.
+			if agc != nil && squelchOpen {
 				audio = agc.Process(audio, audio)
 			}
 			var pcm []int16
@@ -929,6 +998,29 @@ func (c *Composer) runFMChain(ctx context.Context, serial string, iqCh <-chan []
 			} else {
 				pcm = decimateAndConvert(audio, decim2)
 			}
+			if !squelchOpen {
+				if squelchWasOpen {
+					// Entering the tail: fade from the last written
+					// sample to zero over ~10 ms — an abrupt mute
+					// clicks just like the chain-end cut emitTail
+					// covers.
+					muteFade = float32(lastSample)
+					n := int(c.pcmHz / 100)
+					if n < 8 {
+						n = 8
+					}
+					muteStep = muteFade / float32(n)
+				}
+				for i := range pcm {
+					muteFade -= muteStep
+					if muteFade*muteStep <= 0 {
+						// Reached (or crossed) zero: hold silence.
+						muteFade, muteStep = 0, 0
+					}
+					pcm[i] = int16(muteFade)
+				}
+			}
+			squelchWasOpen = squelchOpen
 			if c.sink != nil && len(pcm) > 0 {
 				// Plain WritePCM (no CallID fence) is correct here: an
 				// analog FM chain keys on a stable per-channel physical

--- a/internal/voice/composer/composer_test.go
+++ b/internal/voice/composer/composer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"math"
+	"math/rand"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -95,6 +96,14 @@ func (r *recordingSink) total(serial string) int {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return len(r.pcm[serial])
+}
+
+func (r *recordingSink) pcmCopy(serial string) []int16 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]int16, len(r.pcm[serial]))
+	copy(out, r.pcm[serial])
+	return out
 }
 
 func (r *recordingSink) rawFrames(serial string) [][]byte {
@@ -464,6 +473,173 @@ func TestComposerTailFadeOnCallEnd(t *testing.T) {
 	// Final sample must be 0 (linear ramp ends at zero).
 	if pcm[len(pcm)-1] != 0 {
 		t.Errorf("tail final sample = %d, want 0", pcm[len(pcm)-1])
+	}
+}
+
+// stubSquelch is a settable SquelchState for FM-chain gating tests.
+type stubSquelch struct {
+	mu   sync.Mutex
+	open bool
+	ok   bool
+}
+
+func (s *stubSquelch) SquelchOpen(string) (bool, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.open, s.ok
+}
+
+func (s *stubSquelch) set(open, ok bool) {
+	s.mu.Lock()
+	s.open = open
+	s.ok = ok
+	s.mu.Unlock()
+}
+
+// noiseChunk models what the receiver delivers during the squelch
+// tail: carrier-less wideband noise. Its in-band portion survives the
+// chain's front-end LPF with a random phase walk, and an FM
+// discriminator turns random phase into LOUD audio no matter how weak
+// the RF is (phase steps don't scale with amplitude) — which is
+// exactly why the un-gated tail was audible. Deterministic via the
+// caller's seeded rng; amplitude 0.01 ≈ -40 dBFS, far below any real
+// carrier.
+func noiseChunk(n int, rng *rand.Rand) []complex64 {
+	out := make([]complex64, n)
+	for i := range out {
+		out[i] = complex(float32(rng.NormFloat64())*0.01, float32(rng.NormFloat64())*0.01)
+	}
+	return out
+}
+
+func maxAbsPCM(pcm []int16) int {
+	m := 0
+	for _, v := range pcm {
+		a := int(v)
+		if a < 0 {
+			a = -a
+		}
+		if a > m {
+			m = a
+		}
+	}
+	return m
+}
+
+// mkComposerSquelch builds a composer with the audio AGC enabled (the
+// stage that rode the gain up on tail noise) and the given squelch
+// provider wired via Options.
+func mkComposerSquelch(t *testing.T, src *fakeSource, sq SquelchState) (*events.Bus, *recordingSink, func()) {
+	t.Helper()
+	bus := events.NewBus(8)
+	sink := &recordingSink{}
+	c, err := New(Options{
+		Bus:           bus,
+		Devices:       &fakeDevices{src: map[string]IQSource{"VOICE-1": src}},
+		Sink:          sink,
+		Engine:        &fakeEngine{},
+		IQSampleRate:  2_400_000,
+		PCMSampleRate: 8000,
+		TouchInterval: 30 * time.Millisecond,
+		AudioAGC:      AudioAGCConfig{Enabled: true},
+		Squelch:       sq,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go c.Run(ctx)
+	teardown := func() {
+		cancel()
+		c.Close()
+		bus.Close()
+	}
+	return bus, sink, teardown
+}
+
+// TestComposerFMChainMutesSquelchClosedTail is the regression for issue
+// #1090's real audible mechanism. The scanner-side hangtime debounce
+// (#1091) only decides when the call ENDS; for the whole hangtime
+// window runFMChain kept demodulating carrier-less receiver noise —
+// which is loud out of an FM discriminator no matter how weak the RF —
+// and the audio AGC actively amplified it, so every recording ended in
+// a multi-second squelch crash. With the gate, the same noise input
+// records as silence (after a short fade) while the scanner reports
+// squelch-closed. The open-gate phase in the middle is the
+// counterfactual that proves the muted phase's input would otherwise
+// have been loud.
+func TestComposerFMChainMutesSquelchClosedTail(t *testing.T) {
+	src := newFakeSource()
+	sq := &stubSquelch{open: true, ok: true}
+	bus, sink, teardown := mkComposerSquelch(t, src, sq)
+	defer teardown()
+
+	publishStartFM(bus, "VOICE-1")
+	waitFor(t, time.Second, func() bool {
+		src.mu.Lock()
+		defer src.mu.Unlock()
+		return len(src.chs) > 0
+	})
+	rng := rand.New(rand.NewSource(1090))
+
+	// Phase 1 (squelch open): demodulated noise is LOUD — this is
+	// the ungated behavior the reporter measured during the tail.
+	for range 5 {
+		src.SendIQ(noiseChunk(4096, rng))
+	}
+	waitFor(t, time.Second, func() bool { return sink.total("VOICE-1") >= 40 })
+	openEnd := sink.total("VOICE-1")
+	if got := maxAbsPCM(sink.pcmCopy("VOICE-1")[:openEnd]); got < 1000 {
+		t.Fatalf("open-gate demodulated noise peaked at %d; expected loud (>1000) — test signal too quiet to prove the gate matters", got)
+	}
+
+	// Phase 2 (squelch closed): identical input must now record as
+	// silence once the ~10 ms fade (80 samples at 8 kHz) has run out.
+	sq.set(false, true)
+	for range 40 {
+		src.SendIQ(noiseChunk(4096, rng))
+		time.Sleep(2 * time.Millisecond)
+	}
+	waitFor(t, 2*time.Second, func() bool { return sink.total("VOICE-1") >= openEnd+300 })
+	pcm := sink.pcmCopy("VOICE-1")
+	// Skip the fade window plus slack for open-gate chunks that were
+	// already in flight when the gate flipped.
+	tail := pcm[openEnd+160:]
+	if got := maxAbsPCM(tail); got != 0 {
+		t.Fatalf("squelch-closed tail is audible: peak |pcm| = %d over %d samples, want 0 (issue #1090: the FM chain must mute while the scanner reports squelch closed)", got, len(tail))
+	}
+	// The fade must actually decay — the first muted samples may be
+	// non-zero, but nothing in the tail may exceed the last open-gate
+	// level.
+	if got, lim := maxAbsPCM(pcm[openEnd:openEnd+160]), maxAbsPCM(pcm[:openEnd]); got > lim {
+		t.Errorf("mute fade overshoots: peak %d exceeds open-gate peak %d", got, lim)
+	}
+}
+
+// TestComposerFMChainIgnoresSquelchWithoutDecision pins the ok=false
+// contract: a provider with no live decision for the serial (any
+// non-conventional analog chain — Motorola/LTR/MPT 1327 voice — or a
+// scanner between dwells) must leave the chain ungated and the audio
+// flowing.
+func TestComposerFMChainIgnoresSquelchWithoutDecision(t *testing.T) {
+	src := newFakeSource()
+	sq := &stubSquelch{open: false, ok: false} // closed-looking, but no decision
+	bus, sink, teardown := mkComposerSquelch(t, src, sq)
+	defer teardown()
+
+	publishStartFM(bus, "VOICE-1")
+	waitFor(t, time.Second, func() bool {
+		src.mu.Lock()
+		defer src.mu.Unlock()
+		return len(src.chs) > 0
+	})
+	rng := rand.New(rand.NewSource(1090))
+	for range 5 {
+		src.SendIQ(noiseChunk(4096, rng))
+	}
+	waitFor(t, time.Second, func() bool { return sink.total("VOICE-1") >= 40 })
+	if got := maxAbsPCM(sink.pcmCopy("VOICE-1")); got < 1000 {
+		t.Fatalf("chain muted on ok=false: peak |pcm| = %d, want ungated loud audio (>1000)", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

The #1091 debounce/hysteresis fix was verified on air against KP4-DH and the loud 2–4 s trailing tail is **not** gone — the reporter traced why: `beginDwell`'s hangtime logic only decides when the call *ends*, while `runFMChain` keeps demodulating carrier-less receiver noise (loud out of an FM discriminator regardless of RF level) for the whole hangtime window, and the audio AGC's envelope follower actively amplifies it toward full scale. This PR gives the FM chain visibility into the scanner's live squelch decision so the tail records as silence instead.

## Changes

- `internal/scanner/conventional`: the scanner publishes its live per-chunk squelch decision (`Scanner.SquelchOpen`, an atomic read). The published state follows the same **debounced** decision the hangtime countdown uses, so a single-chunk blip can no more unmute the recording than it can reset the countdown; between dwells it reports "no decision".
- `internal/voice/composer`: new `SquelchState` interface, polled per IQ chunk by `runFMChain`. While squelch is closed the chain keeps running (filters warm, PCM timeline continuous for the recorder and live stream) but **freezes the audio AGC** (no adaptation on demodulated noise) and replaces the written PCM with a ~10 ms fade-out into silence. `ok=false` (analog-trunk voice channels, no scanner dwell) leaves the chain ungated — byte-identical to before.
- `cmd/gophertrunk`: wires scanner → composer via `SetSquelchState` (the composer is constructed before the scanner exists).
- `CHANGELOG.md`: Unreleased "Fixed" bullet.

## Test plan

- [x] `make vet test` is green locally
- [x] `make integration` is green locally (if the change touches the daemon)
- [x] Added or updated tests where appropriate
  - `TestComposerFMChainMutesSquelchClosedTail` — failing-first regression: drives wideband noise through the real chain with the AGC enabled; against the ungated code it fails with peak |pcm| ≈ 3946 in the tail (the measured symptom), with the gate the tail is silent. An open-gate phase on the same input proves the muted phase would otherwise be loud.
  - `TestConvScannerPublishesSquelchState` — pins the scanner-side feed: open/closed/no-dwell transitions, blip immunity during the tail, foreign serials.
  - `TestComposerFMChainIgnoresSquelchWithoutDecision` — pins the `ok=false` ungated contract.
- [ ] Smoke-tested against real hardware (if SDR / USB / vocoder code changed) — needs the reporter's on-air A/B against KP4-DH (146.670 MHz); synthetic-only so far per the verify-before-close policy.

## Breaking changes

None. No config keys, flags, or endpoints change; behavior changes only for `fm-conv` calls while the scanner reports squelch closed. Analog-trunk (Motorola/LTR/MPT 1327) chains and all digital chains are untouched.

## Docs / CHANGELOG

- [x] Added a `## [Unreleased]` bullet to `CHANGELOG.md` if this is user-visible
- [ ] Updated `README.md` or `docs/` if operator-facing behaviour changed — n/a (no new knobs)

## Linked issues

Refs #1090 (not `Closes` — awaiting the reporter's on-air verification per the issue-closing policy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzNzkuCvo3xXmt3YKTVcUi

---
_Generated by [Claude Code](https://claude.ai/code/session_01TzNzkuCvo3xXmt3YKTVcUi)_