### PR TITLE
Six operator-reported fixes: history search, the 30 s shutdown, RPC tracing, console labelling, diversity measurement, sidecar driver

### DIFF
--- a/cmd/gophertrunk/import_writer.go
+++ b/cmd/gophertrunk/import_writer.go
@@ -14,6 +14,7 @@ import (
 	"unicode"
 
 	"github.com/MattCheramie/GopherTrunk/internal/config"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 	"gopkg.in/yaml.v3"
 )
 
@@ -236,13 +237,17 @@ func collapseTrailingDuplicateWord(name string) string {
 }
 
 // buildTalkgroupCSV produces the Trunk-Recorder-style CSV that the
-// daemon's internal/trunking.TalkgroupDB.LoadCSV understands. Column
-// order matches the loader's case-insensitive lookups.
+// daemon's internal/trunking.TalkgroupDB.LoadCSV understands.
+//
+// The column order comes from trunking.TalkgroupCSVHeader, shared with the
+// label exporter that writes the same file shape from the live catalogue. A
+// second copy of the list here would drift silently: LoadCSV matches columns
+// by name, so it keeps accepting both spellings and nothing fails until an
+// operator diffs two files that should have been interchangeable.
 func buildTalkgroupCSV(sys parsedSystem) ([]byte, error) {
 	var buf bytes.Buffer
 	w := csv.NewWriter(&buf)
-	headers := []string{"Decimal", "Hex", "Mode", "Alpha Tag", "Description", "Tag", "Group", "Priority", "Lockout", "Scan"}
-	if err := w.Write(headers); err != nil {
+	if err := w.Write(trunking.TalkgroupCSVHeader); err != nil {
 		return nil, err
 	}
 	for _, tg := range sys.Talkgroups {

--- a/internal/trunking/csvwrite.go
+++ b/internal/trunking/csvwrite.go
@@ -16,15 +16,19 @@ import (
 // lock-in. Round-trip tests pin every column against the matching LoadCSV, so
 // a column that stops loading fails here first.
 
-// talkgroupCSVHeader matches what the import writer emits, so a file exported
-// from a running daemon is interchangeable with one produced by `import`.
-var talkgroupCSVHeader = []string{
+// TalkgroupCSVHeader is the Trunk-Recorder-style column order LoadCSV reads.
+// Exported because `gophertrunk import` writes the same file from a different
+// source type: sharing the header is what keeps a file exported from a running
+// daemon interchangeable with one the importer produced. Two copies of this
+// list can drift apart silently — the wire format is only checkable against
+// LoadCSV, which accepts either.
+var TalkgroupCSVHeader = []string{
 	"Decimal", "Hex", "Mode", "Alpha Tag", "Description", "Tag", "Group",
 	"Priority", "Lockout", "Scan",
 }
 
-// ridCSVHeader lists the columns RIDDB.LoadCSV reads, in catalogue order.
-var ridCSVHeader = []string{
+// RIDCSVHeader lists the columns RIDDB.LoadCSV reads, in catalogue order.
+var RIDCSVHeader = []string{
 	"Decimal", "Alias", "Description", "Tag", "Group", "Owner",
 	"Priority", "Lockout", "Watch", "Icon",
 }
@@ -34,7 +38,7 @@ var ridCSVHeader = []string{
 // zero-length.
 func WriteTalkgroupCSV(w io.Writer, tgs []*TalkGroup) error {
 	cw := csv.NewWriter(w)
-	if err := cw.Write(talkgroupCSVHeader); err != nil {
+	if err := cw.Write(TalkgroupCSVHeader); err != nil {
 		return fmt.Errorf("trunking: write talkgroup csv header: %w", err)
 	}
 	sorted := sortedByID(tgs, func(tg *TalkGroup) uint32 { return tg.ID })
@@ -62,7 +66,7 @@ func WriteTalkgroupCSV(w io.Writer, tgs []*TalkGroup) error {
 // WriteRIDCSV writes rids as a rid_alias_file, sorted by id.
 func WriteRIDCSV(w io.Writer, rids []*RID) error {
 	cw := csv.NewWriter(w)
-	if err := cw.Write(ridCSVHeader); err != nil {
+	if err := cw.Write(RIDCSVHeader); err != nil {
 		return fmt.Errorf("trunking: write rid csv header: %w", err)
 	}
 	sorted := sortedByID(rids, func(r *RID) uint32 { return r.ID })

--- a/internal/trunking/csvwrite_test.go
+++ b/internal/trunking/csvwrite_test.go
@@ -82,7 +82,12 @@ func TestWriteRIDCSVRoundTripsThroughLoadCSV(t *testing.T) {
 
 // The header has to match what `gophertrunk import` writes, or a file exported
 // from a running daemon is not interchangeable with an imported one.
-func TestTalkgroupCSVHeaderMatchesTheImporter(t *testing.T) {
+// The header is the file's contract with LoadCSV, which matches columns by
+// name and would silently keep accepting a renamed one. `gophertrunk import`
+// writes the same shape from its own parsed type and now shares
+// TalkgroupCSVHeader rather than keeping a second copy, so this literal is the
+// one place the spelling is pinned for both.
+func TestTalkgroupCSVHeaderIsTheTrunkRecorderSpelling(t *testing.T) {
 	var buf bytes.Buffer
 	if err := WriteTalkgroupCSV(&buf, nil); err != nil {
 		t.Fatal(err)

--- a/web/src/panels/History.tsx
+++ b/web/src/panels/History.tsx
@@ -17,8 +17,8 @@ import {
 } from "../store/shared";
 
 // History reads /api/v1/calls/history with the same filter shape the
-// daemon accepts: limit, system, group_id. Read-only in this pass;
-// retention-sweep button lands in the mutation pass.
+// daemon accepts: limit, system, group_id. The response envelope is
+// {"calls":[...]} — reading any other key yields a silently empty table.
 export function History() {
   const cfg = useShared(selectClientConfig);
   const canMutate = useShared(selectCanMutate);

--- a/web/src/panels/Talkgroups.tsx
+++ b/web/src/panels/Talkgroups.tsx
@@ -19,9 +19,9 @@ import {
 
 const POLL_INTERVAL_MS = 15_000;
 
-// Talkgroups is read-only in this PR. Priority / lockout / scan
-// mutations (PATCH /api/v1/talkgroups/{id}) land in the mutation pass
-// that introduces the daemon-write capability gate UI.
+// Mutations (PATCH /api/v1/talkgroups/{id}) are gated on the daemon's
+// write capability: naming fields persist to the labels table, while
+// priority / lockout / scan stay in the daemon's memory until restart.
 export function Talkgroups() {
   const cfg = useShared(selectClientConfig);
   const canMutate = useShared(selectCanMutate);


### PR DESCRIPTION
## Summary

An operator reported six separate things in one message, plus a 7z of logs from a 17 Aug X310 dual-antenna MRC run. Three of them turned out to be diagnosable to a specific line from the evidence in hand; the rest needed building. This PR carries all six, one logical change per commit.

The through-line worth reading first: two of these bugs were invisible because the failure mode was *silence*. The History panel returned an empty list rather than an error, and the shutdown stall was returned as `context.DeadlineExceeded` into a code path that counts that as a clean exit.

## Changes

**Call history search by talkgroup returned nothing** (`46a5d36`, `55c59f9`)
- The daemon answers `/api/v1/calls/history` with `{"calls":[…]}`; the SPA client read `r.rows` and fell back to `[]`. The panel had rendered "No calls in the daemon's call log for this filter" for every query since the file was written — the filter, the handler and the SQL were all correct. The RID panel works because `ridHistory` reads `calls` off the same table.
- Also: the API DTO dropped `algorithm_id`, `key_id` and `source_alpha`, which the storage row carries and the SPA's TypeScript already declared, so the Source column and encryption badge could never populate.

**Ctrl-C took a fixed 30 s** (`fcbd1ad`, `4777d2d`)
- `Daemon.Close` stops the HTTP server first, and `http.Server.Shutdown` waits for active non-hijacked requests without cancelling their `r.Context()`. The SSE / live-audio / siglab handlers only leave when their request context is cancelled or the bus closes — and `bus.Close()` runs at the very end of teardown, ~90 lines later. So any attached subscriber pinned the whole window.
- The window had already been widened 5 s → 30 s to "cut user-visible connection drops", which made the pause 6× longer without making anything drain. That is why this kept coming back.
- `api.Server` now closes a `stopStreams` channel at the top of `shutdown()`; the 30 s becomes a cap for a handler that misses the signal, and reaching it WARNs instead of passing as a clean exit.
- Two more teardown stalls were hiding behind it: `GRPCServer.Stop` was an unbounded `GracefulStop` (an open `StreamAudio` waits forever), and the soapyremote / rtl_tcp read loops checked `ctx.Done()` only *between* reads before parking in `io.ReadFull` behind a 30 s deadline — a quiet server being the normal state at shutdown.

**`soapyremote` verbose RPC debug** (`43112c9`)
- New `sdr.soapy_remote[].verbose_debug` traces every control-channel RPC with its opcode name and decoded argument list, so a server-side `~SoapyRPCUnpacker: Unconsumed payload bytes N` can be lined up against what the client actually sent. A hex dump alone would not have caught the `SET_ANTENNA`-was-600 bug this repo already has a scar from; the decoded arguments are the part that does.

**Name radios and talkgroups from the console, and keep the names** (`bed6658`)
- `PATCH /api/v1/rids/{id}` used to 404 for a radio absent from `rid_alias_file` — i.e. exactly the radios worth naming — and `PATCH /api/v1/talkgroups/{id}` had no name field at all. Both now create the catalogue entry, and with `storage.path` set the names persist to a new `labels` table layered over the alias files at startup.
- A synthesised talkgroup is deliberately **not** tagged `Discovered`: `DeleteDiscovered` would otherwise sweep away the operator's name behind their back.
- `GET /api/v1/labels/export` emits a CSV that loads straight back into `rid_alias_file` / `talkgroup_file`, so the store is a convenience rather than lock-in.

**Diversity: an instrument, not a shipped mode** (`4a3ff31`)
- Their log shows the tracking calibrator frozen for the last 11 minutes of the run (`updates` stuck at 6682, `holds` climbing ~6055 per interval) with wideband coherence at 0.01–0.23 against a 0.35 gate — the exact failure `mrc.go`'s own KNOWN LIMITATION comment predicts for antennas metres apart. It stayed INFO the whole time; it WARNs now.
- The replay harness measures narrowband (post-DDC) coherence alongside wideband and scores eight arms instead of four. That comparison is the number that decides whether per-channel combining is worth the architecture change.
- `IRCCalibrator` lands as an offline arm. One correction to the RFC it came from: with a blind reference the residual `e₀ = x₀ − h₀·x₀` is identically zero, so `R_nn` is rank-deficient by construction and no spatial null can form. Measured, blind IRC is **0.0 dB** over MRC on the synthetic co-channel scene; the same code given a training sequence measures **+23.6 dB**. A training sequence exists only after the DDC — which is where the per-channel combining points too.

**Sidecar driver, and a pool-construction bug it uncovered** (`26f6f2d`)
- `daemon.go`'s pool gate read `SDR.Devices || Baseband.Replay || SDR.RTLTCP`, and the network drivers are registered *inside* that block — so a config whose only source is `sdr.soapy_remote` or `sdr.ka9q_radio` registered no driver at all and the daemon started quietly with no radio. Pre-existing; it blocks the sidecar, so it is fixed first in the same commit.
- `internal/sdr/sidecar` mounts an external IQ producer (a UHD/RFNoC daemon, say) as a virtual tuner over a FIFO, TCP or UDP, steered by a 5-byte control protocol. Several defects in the proposal it came from are fixed rather than transcribed: `unsafe.Pointer` bit-punning → `math.Float32frombits`; sub-sample remainders carried across short reads (one 1-byte short read would otherwise swap I/Q for the rest of the stream); `io.ReadFull` replaced with a datagram loop on UDP, where it silently concatenates fragments of different datagrams; a defined AGC sentinel for the negative-gain case; drop-oldest backpressure; and a 1 s ctx-bounded read so the new driver cannot reintroduce the shutdown tail fixed above.

**Follow-ups from the above** (`46d5f79`, `95bacf8`)
- The label exporter and `gophertrunk import` each kept their own copy of the talkgroup CSV header. `LoadCSV` matches columns by name, so a rename would keep loading and nothing would fail until someone diffed two files meant to be interchangeable — and the test that claimed to cover this compared the exporter against a literal in its own package, unable to see the importer at all. The header is shared now, so the drift is structurally impossible.
- Two panel comments that described the code as it no longer is.

## Test plan

- [x] `make vet test` is green locally — 166 packages, `-race -count=1`, exit 0
- [x] `make integration` is green locally — exit 0, `cmd/gophertrunk` in 82 s
- [x] Added or updated tests where appropriate
- [ ] Smoke-tested against real hardware (if SDR / USB / vocoder code changed) — **no**, see below

Every bug fix here ships with a test that fails against the old code, verified by reverting the non-test files and re-running:

| | before | after |
|---|---|---|
| `TestShutdownDoesNotWaitOutTheWindowForAnSSEClient` | 10 s+ (timeout) | 0.04 s |
| `TestDaemonShutdownWithStreamingClientsAttached` (integration) | 20 s+ (timeout) | 0.09 s |
| `TestStreamIQStopsPromptlyOnContextCancelWhileServerIsQuiet` (×2 drivers) | 5 s+ (timeout) | 0.1 s |
| `TestCallHistoryEndpointCarriesEncryptionAndSourceAlias` | build failure on the missing fields | pass |
| `TestUpdateRIDLiveOnlyCreatesCatalogueEntry` | 404 | 200 |
| `TestPoolBuiltForRemoteOnlyConfigs` | no driver registered | registered |

Also run: `tsc --noEmit` on the `web` and `configbuilder` SPAs, and the full 358-test vitest suite. Per the note added to CLAUDE.md on `main` last week, `npm test` alone is not evidence a web change builds — vitest transpiles with esbuild and never typechecks.

`cmd/gophertrunk/integration_test.go` used to give `Run` 3 s and then move on silently if it had not returned. That is why a 30 s shutdown stall never failed CI. It asserts now.

**Not verified on hardware, and this matters for three of the six.** There is no SDR on this machine. The `soapyremote` tracer, the sidecar driver and everything under diversity are green on synthetic tests only, which per #764 / #771 is not the same as being right on air:

- **Diversity is deliberately inert.** No default changes; the new calibrator is an offline harness arm. Deciding what to ship needs a `diversity_capture` from the reporter's X310 — the three files it writes are the only pre-combine capture that can be replayed through a different combiner.
- **The sidecar has no real counterpart yet.** It is tested against a fake sidecar over loopback TCP and a temp FIFO. The UHD daemon on the other end is still to be written.
- **The RPC tracer** wants one run against their SoapySDRServer to confirm the decoded argument list lines up with what the server reports as unconsumed.

## Breaking changes

None. Two new optional config keys (`sdr.soapy_remote[].verbose_debug`, `sdr.sidecar[]`), both defaulting off/absent. The RID PATCH endpoint changes a 404 into a create, which is the requested behaviour change and is documented; no existing successful request changes its result. Label persistence is inactive without `storage.path`, in which case mutations stay in memory exactly as before.

## Docs / CHANGELOG

- [x] Added `## [Unreleased]` bullets to `CHANGELOG.md`
- [x] Updated `docs/` — `radio-ids.md` (the 404 and "mutations live in memory only" were both stated as the contract and are now wrong), `hardware.md`, `live-edits.md`, and a new `docs/reference/sdr-sidecar.md` pinning the sidecar wire format
- [x] Recorded the findings in `CLAUDE.md`, including why MMSE-IRC cannot work blind — the one most likely to be re-attempted otherwise

## Linked issues

Refs #1062 — the diversity work is measurement and an offline arm; the issue stays open until the on-air A/B lands.

Nothing here is marked `Closes`. The history and shutdown fixes are verified locally and could be, but the reporter has not confirmed any of it on their own system yet.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExioM3ti3ZxEwwDqQYjbng)_