### PR TITLE
blog: add series pages + nav for three new series

### DIFF
--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -167,6 +167,10 @@ groups:
         url: /blog/series/operator-cockpit/
       - title: "Series: Running It For Real"
         url: /blog/series/running-it-for-real/
+      - title: "Series: TETRA End to End"
+        url: /blog/series/tetra-end-to-end/
+      - title: "Series: Weak-Signal Engineering"
+        url: /blog/series/weak-signal-engineering/
       - title: Tutorials
         url: /blog/category/tutorials/
       - title: "Series: Signal Lab"
@@ -175,6 +179,8 @@ groups:
         url: /blog/series/rf-scope/
       - title: "Series: Crypto Lab"
         url: /blog/series/crypto-lab/
+      - title: "Series: The Analog Edge"
+        url: /blog/series/analog-edge/
       - title: Solution Postmortem
         url: /blog/category/solution-postmortem/
       - title: "Series: From the Issue Tracker"

--- a/docs/_posts/2026-08-18-analog-edge-01-where-software-ends.md
+++ b/docs/_posts/2026-08-18-analog-edge-01-where-software-ends.md
@@ -1,0 +1,267 @@
+---
+title: "The Analog Edge, Part 1: Where the Software Ends"
+description: The signal chain from antenna to ADC and why no code change can fix a problem on the analog side of it — an inventory of GopherTrunk issue-tracker bugs that turned out to live in the samples, and the map of a 14-part field guide to the front end.
+category: tutorials
+keywords: sdr signal chain, antenna to adc, rf front end basics, samples not software, sdr troubleshooting, front end overload, phase noise capture, trunking scanner rf, gophertrunk analog edge
+tags: [analog-edge, rf, front-end, sdr, hardware, tutorial]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "The Analog Edge"
+series_part: 1
+---
+
+*Part 1 of **The Analog Edge**, a 14-part field guide to the analog half of a
+GopherTrunk installation — everything between the tower and the first sample
+the software ever sees. The whole series exists because of one recurring
+operator: the one whose hardware scanner decodes a system cleanly while
+GopherTrunk, on the same antenna, produces garble. Over fourteen parts we walk
+that reader's marginal system through every analog cause, one at a time, until
+it's fixed. The motto we'll keep coming back to: **the decoder can only be as
+good as the samples — and half the hard bugs in the issue tracker were in the
+samples.***
+
+> **TL;DR:** Your signal passes through **antenna → feedline → filter/LNA →
+> tuner → ADC** before a single line of Go runs, and no code change can repair
+> damage done in that chain. The issue tracker proves it: the
+> [#764](https://github.com/MattCheramie/GopherTrunk/issues/764) "all taps go
+> dark at 10 MS/s" mystery was **front-end phase noise recorded into the
+> capture**; the "nineteen dibits" report was a capture **50% pinned to the ADC
+> rails**; a DMR two-slot fix is still waiting on air time because the only
+> capture supplied sits at **−75 dBFS with no frame sync**. GopherTrunk
+> surfaces the analog side with numbers — `gophertrunk_sdr_iq_power_dbfs`,
+> `gophertrunk_sdr_iq_clip_ratio`, demod SNR — and this series teaches you to
+> read them.
+
+**Key takeaways**
+
+- **The chain has a hard boundary at the ADC.** Everything before it is
+  physics you configure with hardware and gain; everything after it is
+  deterministic math. A fix on one side never fixes the other.
+- **The samples carry the damage forward, permanently.** Noise folded onto a
+  channel by an overloaded amplifier or a noisy oscillator is
+  indistinguishable, downstream, from a weak signal — the decoder cannot
+  subtract it back out.
+- **GopherTrunk's decode path is deliberately rate-invariant**, which is what
+  makes "works at 2.4 MS/s, fails at 10 MS/s" a statement about the *capture*,
+  not the DSP — the reasoning that closed #764.
+- **The instruments already exist.** dBFS gauges, clip ratios, decode error
+  rates, and demod SNR are exported today; the series is about which one to
+  read for which suspicion.
+
+## Cheat sheet
+
+| Stage | What goes wrong there | Where GopherTrunk shows it |
+|---|---|---|
+| Antenna | wrong band, wrong pattern, indoors | `gophertrunk_sdr_iq_power_dbfs` stuck near idle (≈ −45) |
+| Feedline & connectors | loss that adds straight to noise figure | Part 8; no direct meter — the math is the meter |
+| Filter / LNA | overload, intermod from strong neighbors | `gophertrunk_sdr_iq_clip_ratio` (`internal/metrics/prom.go`) |
+| Tuner / LO | phase noise, reciprocal mixing | demod SNR low while the FFT looks clean — [#764](https://github.com/MattCheramie/GopherTrunk/issues/764) |
+| ADC | clipping, rail-pinned samples | `iq_clip_ratio` sustained above ~0.002 |
+| Software | everything after the ADC | logs, tests, and the rest of this blog |
+
+## In this post
+
+- **The chain, end to end** — five analog stages and one bold line.
+- **Why a software fix never fixes the samples** — the one-way valve.
+- **The bugs that were in the samples** — the issue-tracker inventory.
+- **The reader we're writing for** — the marginal system we'll carry through
+  the series.
+- **The series map** — fourteen parts, front to back.
+
+## The chain, end to end
+
+Every recording GopherTrunk ever makes starts as a voltage on an antenna
+element. From there the signal runs a fixed gauntlet: down a length of coax
+(losing a little at every foot and every adapter), optionally through a filter
+and a low-noise amplifier (gaining level, and — if you're unlucky — gaining
+garbage), into the tuner chip where a local oscillator mixes it down to
+baseband, and finally into the ADC, which measures the waveform a few million
+times a second and emits numbers.
+
+That last step is the boundary this series is named for. Left of the ADC,
+you're doing RF engineering: antennas, cable, gain, oscillators. Right of it,
+you're doing arithmetic — and arithmetic is repeatable, testable, and
+replayable. GopherTrunk leans hard on that: the same capture replayed through
+the same code produces the same result, every time. Which is exactly why, when
+a symptom *survives* into offline replay, the suspect list collapses to one
+side of the line.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 210" width="680" height="210" role="img" aria-label="The receive signal chain drawn as five boxes: antenna, feedline, filter and LNA, tuner, and ADC, followed by a software box. A bold vertical line sits between the ADC and the software box, marking where the analog world ends and deterministic code begins. A caption under the analog side reads physics you configure, and under the software side reads math you can replay.">
+  <rect x="8" y="60" width="88" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="52" y="78" text-anchor="middle" fill="currentColor" font-size="10">antenna</text>
+  <text x="52" y="93" text-anchor="middle" fill="var(--fg-muted)" font-size="9">P7</text>
+  <line x1="96" y1="82" x2="112" y2="82" stroke="currentColor"/><polygon points="112,78 120,82 112,86" fill="currentColor"/>
+  <rect x="120" y="60" width="88" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="164" y="78" text-anchor="middle" fill="currentColor" font-size="10">feedline</text>
+  <text x="164" y="93" text-anchor="middle" fill="var(--fg-muted)" font-size="9">P8</text>
+  <line x1="208" y1="82" x2="224" y2="82" stroke="currentColor"/><polygon points="224,78 232,82 224,86" fill="currentColor"/>
+  <rect x="232" y="60" width="92" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="278" y="78" text-anchor="middle" fill="currentColor" font-size="10">filter / LNA</text>
+  <text x="278" y="93" text-anchor="middle" fill="var(--fg-muted)" font-size="9">P4, P9</text>
+  <line x1="324" y1="82" x2="340" y2="82" stroke="currentColor"/><polygon points="340,78 348,82 340,86" fill="currentColor"/>
+  <rect x="348" y="60" width="88" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="392" y="78" text-anchor="middle" fill="currentColor" font-size="10">tuner / LO</text>
+  <text x="392" y="93" text-anchor="middle" fill="var(--fg-muted)" font-size="9">P5</text>
+  <line x1="436" y1="82" x2="452" y2="82" stroke="currentColor"/><polygon points="452,78 460,82 452,86" fill="currentColor"/>
+  <rect x="460" y="60" width="72" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="496" y="78" text-anchor="middle" fill="currentColor" font-size="10">ADC</text>
+  <text x="496" y="93" text-anchor="middle" fill="var(--fg-muted)" font-size="9">P2, P4</text>
+  <line x1="548" y1="28" x2="548" y2="140" stroke="var(--accent)" stroke-width="3"/>
+  <text x="548" y="18" text-anchor="middle" fill="var(--accent)" font-size="10">software begins</text>
+  <line x1="532" y1="82" x2="556" y2="82" stroke="currentColor"/><polygon points="556,78 564,82 556,86" fill="currentColor"/>
+  <rect x="564" y="60" width="108" height="44" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="618" y="78" text-anchor="middle" fill="var(--accent)" font-size="10">GopherTrunk</text>
+  <text x="618" y="93" text-anchor="middle" fill="var(--fg-muted)" font-size="9">DDC → demod → FEC</text>
+  <text x="270" y="130" text-anchor="middle" fill="var(--fg-muted)" font-size="10">physics you configure — damage done here rides in the samples forever</text>
+  <text x="618" y="130" text-anchor="middle" fill="var(--fg-muted)" font-size="10">math you can replay</text>
+  <text x="340" y="168" text-anchor="middle" fill="var(--fg-muted)" font-size="10">a symptom that reproduces in offline replay lives LEFT of the line — that one rule closed #764</text>
+</svg>
+<figcaption>The receive chain with the series' one bold line: everything left of the ADC is analog, and this series is about that half.</figcaption>
+</figure>
+
+## Why a software fix never fixes the samples
+
+The ADC is a one-way valve for damage. Once a strong FM broadcast station has
+driven your LNA into intermodulation and splattered phantom energy across your
+control channel, the samples *contain* that energy — it has the same units,
+the same statistics, the same everything as real signal. Once a noisy local
+oscillator has smeared its phase jitter onto the carrier, the constellation
+the software receives is already blurred. There is no field in a complex
+sample that says "this part was added by your front end"; subtracting it back
+out is not hard, it's *impossible* in the general case.
+
+The reverse is just as true, and just as often missed: no antenna upgrade
+fixes a bug in the Viterbi decoder, and no LNA fixes a wrong CRC polynomial.
+The two sides fail independently and must be debugged independently. That's
+why GopherTrunk's discipline — replay everything, pin everything with a
+capture — matters so much. A capture freezes the analog side at the moment of
+failure, so the software side can be interrogated separately, forever. The
+project's own [capture-needs page]({{ '/decoder-capture-needs.html' | relative_url }})
+exists because "get the raw capture" is the single most repeated sentence in
+the tracker.
+
+## The bugs that were in the samples
+
+The motto isn't rhetoric; here is the inventory. Each of these arrived as a
+plausible software bug report, consumed real debugging effort on the software
+side, and resolved on the analog side:
+
+| The report | Where it actually lived | The full story |
+|---|---|---|
+| "All four P25 taps go dark at 10 MS/s" ([#764](https://github.com/MattCheramie/GopherTrunk/issues/764), [#771](https://github.com/MattCheramie/GopherTrunk/issues/771)) | front-end phase noise at the Airspy's native 10 MS/s clock, recorded into the capture — ~10 dB of demod SNR gone with no clipping anywhere | [Ten Megasamples]({{ '/blog/solution-postmortem/from-the-issue-tracker-05-ten-megasamples/' | relative_url }}) |
+| "The wideband DDC starves the demod of dibits" | the raw capture was 50% pinned to the ADC rails; the fix was turning the gain *down* | [Nineteen Dibits]({{ '/blog/solution-postmortem/from-the-issue-tracker-08-nineteen-dibits/' | relative_url }}) |
+| "Simulcast systems need the CQPSK demod" | the real fault was a gain value; the modulation myth had leaked into our own docs | [The LSM Myth]({{ '/blog/solution-postmortem/from-the-issue-tracker-07-lsm-myth/' | relative_url }}) |
+| DMR two-slot decode, awaiting on-air verification | the only IQ grab supplied is a dead capture — ~−75 dBFS RMS, carrier 11 kHz off, no frame sync to be found | the A/B still waits on a decodable capture |
+| TETRA control-channel sync losses over a 1-hour session | a weak front end (peak −44 dBFS) in the marginal-SNR regime; an equalizer now recovers it, but the RF condition is real | Part 7 of this series, and the signal-level fix it points at |
+
+Notice what the middle column has in common: **none of these were visible as
+bugs in the code**, because there were no bugs in the code to see. The
+symptom was real, the report was honest, and the samples were the problem.
+Ruling the analog side in or out *first* — with measurements, not vibes — is
+the skill this series teaches.
+
+## The reader we're writing for
+
+Here is the operator we'll carry through all fourteen parts. They have a
+hardware scanner — a purpose-built receiver with a tuned front end — that
+decodes the local trunked system flawlessly. They stood up GopherTrunk on an
+SDR dongle, pointed it at the same system from the same desk, and got a lock
+that comes and goes, audio that's garbled when it arrives, and a creeping
+suspicion that the software is broken.
+
+Sometimes it is! We keep a whole
+[postmortem series]({{ '/blog/solution-postmortem/from-the-issue-tracker-01-first-p25-lock/' | relative_url }})
+of times it was. But the hardware scanner's advantage is not better math — it
+is a band-filtered, purpose-tuned analog front end, against a wideband SDR
+whose front end you have to *stage yourself*. The gap between those two front
+ends is measured in exactly the numbers this series covers: headroom (Part 2),
+gain (Part 3), overload (Part 4), oscillator quality (Part 5), rate (Part 6),
+and the antenna system (Parts 7–9). Close the gap and the general-purpose SDR
+plus GopherTrunk usually *beats* the scanner, because the software half can do
+things no scanner firmware will. If you're still choosing hardware, start with
+[what you need for GopherTrunk]({{ '/what-do-i-need-for-gophertrunk/' | relative_url }})
+— this series assumes you have something plugged in already.
+
+## The series map
+
+Fourteen parts, in the order the signal (and the debugging) flows:
+
+| Part | Topic | The one thing you'll take away |
+|---|---|---|
+| 1 | Where the software ends | this post — the line, and the inventory |
+| 2 | dBFS | it's a headroom meter, not a quality meter |
+| 3 | Gain staging | never chase a software threshold |
+| 4 | Clipping, overload & intermod | gain can manufacture signals |
+| 5 | Phase noise & reciprocal mixing | carrier-clean but modulation-degraded |
+| 6 | Sample rate | the decode path doesn't care; the front end does |
+| 7 | Antennas | gain is a shape, not a magnitude |
+| 8 | Feedline & connectors | where dB go to die |
+| 9 | Filters & LNAs | amplify before loss, never after |
+| 10 | Capture discipline | a capture turns "sounds bad" into a test |
+| 11 | Two antennas — diversity & MRC | what a second branch buys and costs |
+| 12 | Front-end classes | shared LO vs independent PLLs |
+| 13 | Coherence, not dBFS | the scale-invariant health number |
+| 14 | The field checklist | is it RF or is it software? |
+
+Parts 2–6 are the desk work — numbers you can read tonight on the system you
+already have. Parts 7–9 are the hardware work. Parts 10–13 are the advanced
+kit: captures, diversity, and the health numbers that don't lie. Part 14
+folds it all into one triage flowchart. If you want the theory under the
+practice as we go, the [RF & SDR learning module]({{ '/learn/rf-sdr/' | relative_url }})
+runs a parallel track from first principles.
+
+## Where this goes next
+
+The first instrument every operator meets — and the first one that misleads
+them — is the dBFS meter. [Part 2]({{ '/blog/tutorials/analog-edge-02-dbfs/' | relative_url }})
+defines full scale precisely, separates peak from RMS, and shows why a signal
+peaking at −48 dBFS can be perfectly healthy while another at the *same*
+reading is 10 dB short of decodable — the exact pair of captures that closed
+#764. You'll leave with a table mapping every dBFS regime to a likely
+condition and an action.
+
+## FAQ
+
+**My hardware scanner works and GopherTrunk doesn't. Doesn't that prove the
+software is the problem?**
+It proves the *systems* differ, and the receiver front end is the biggest
+difference. A scanner ships a band-filtered, factory-staged analog chain; an
+SDR ships a wideband one you stage yourself. Before filing an issue, measure
+where the chains diverge: dBFS and clip ratio (Part 2, Part 4), then a gain
+sweep scored by decode quality (Part 3). If those come back clean, *then* it's
+software — and Part 10 shows how to capture the evidence.
+
+**How do I know if a problem is left or right of the ADC?**
+Replay. Record raw IQ at the moment of failure and play it back through
+`gophertrunk replay`. A symptom that reproduces from the file lives in the
+samples or the code — and since the code is deterministic and heavily
+regression-tested, the next question is whether a *known-good* capture of the
+same channel replays cleanly. That two-capture A/B is the exact experiment
+that resolved [#764](https://github.com/MattCheramie/GopherTrunk/issues/764).
+
+**Can't the DSP just clean up front-end damage?**
+Sometimes, partially. GopherTrunk ships equalizers that recover real losses
+from linear channel distortion, and soft-decision decoding buys margin. But
+those are mitigations with hard information-theoretic limits — noise folded
+into the channel is signal lost forever. The project's own notes on the TETRA
+equalizer say it plainly: it mitigates a weak front end but does not replace
+it — raise the signal level too.
+
+**Do I need new hardware to follow this series?**
+No. Parts 2–6 use only the metrics and logs a running daemon already exports,
+plus config changes. Hardware spending starts at Part 7, and Part 14 gives an
+explicit order to spend in — antenna first, coax second, filter/LNA third, a
+second dongle last.
+
+**Where do the numbers in this series come from?**
+From the repo: metric definitions in `internal/metrics/prom.go`, config
+guidance in `config.example.yaml`, and the measured postmortems in the issue
+tracker. Where a fact is general RF craft rather than GopherTrunk code (coax
+loss tables, antenna patterns), we present standard published figures and say
+so.
+
+## Series navigation
+
+**Part 1 of 14** · Next →
+[Part 2: dBFS — What the Number Means (& What It Doesn't)]({{ '/blog/tutorials/analog-edge-02-dbfs/' | relative_url }})

--- a/docs/_posts/2026-08-18-tetra-end-to-end-01-pi4-dqpsk-carrier.md
+++ b/docs/_posts/2026-08-18-tetra-end-to-end-01-pi4-dqpsk-carrier.md
@@ -1,0 +1,308 @@
+---
+title: "TETRA End to End, Part 1: π/4-DQPSK & the Shape of a TETRA Carrier"
+description: Why TETRA is not "European P25" — a 25 kHz carrier at 18000 symbols per second, dibits riding in phase transitions instead of amplitudes, a four-slot TDMA downlink that never stops transmitting, and the 144 kHz channel rate GopherTrunk's whole TETRA path is sized around.
+category: deep-dives
+keywords: tetra pi/4 dqpsk, differential qpsk demodulation, tetra 18000 symbols per second, tetra 25 khz channel, tdma continuous downlink, tetra gray mapping, tetra 144 khz channel rate, differential decode conj, gophertrunk tetra
+tags: [tetra-end-to-end, tetra, dqpsk, dsp, demodulation, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "TETRA End to End"
+series_part: 1
+---
+
+*Part 1 of **TETRA End to End**, a 14-part deep dive that follows one real
+25 kHz TETRA carrier — a live TMO cell, MCC 250 / MNC 13, captured by an
+operator and replayed through GopherTrunk hundreds of times — all the way from
+raw IQ to clear recorded voice. The
+[Protocol Decoders survey]({{ '/blog/deep-dives/protocol-decoders-07-tetra/' | relative_url }})
+gave TETRA one episode; this series gives it the full treatment, because almost
+everything hard we learned about decoding radio in the last year happened on
+this carrier. One villain recurs the whole way: the test that passes because
+both sides share the same bug — **green synthetic ≠ on-air correct**. This
+opener is about the physical layer everything else stands on: what a TETRA
+carrier actually looks like, and why information riding in phase *transitions*
+shapes every design decision downstream.*
+
+> **TL;DR:** TETRA is **π/4-DQPSK at 18000 symbols/s** in a 25 kHz channel —
+> not four-level FSK like the P25/DMR/NXDN family. Each symbol carries one
+> dibit in the **phase change** from the previous symbol, recovered as
+> `arg(s·conj(last))` (`internal/dsp/demod/dqpsk.go`), so no absolute carrier
+> phase is ever needed — a property the equalizer work in Parts 8–10 leans on
+> hard. The constellation rotates π/4 every symbol, so there is always a
+> transition to clock off. GopherTrunk channelizes TETRA to **144 kHz — 8
+> samples/symbol** (`ddcTargetForProtocol`, `internal/scanner/ccdecoder/ddc.go`)
+> where the C4FM family gets 48 kHz, and the receiver
+> (`internal/radio/tetra/receiver`) is an RRC matched filter → Gardner timing →
+> AFC → differential decode chain sized entirely from that rate.
+
+**Key takeaways**
+
+- **The dibit lives in the transition, not the symbol.** The demodulator
+  computes `s·conj(last)` and slices the phase delta into quadrants — a
+  constant phase rotation of the whole constellation cancels out. That one
+  property decides what is and isn't safe to put in front of this decoder.
+- **The constellation never sits still.** A π/4 rotation per symbol means
+  consecutive symbols always differ, giving timing recovery a transition to
+  lock to and leaving eight visible constellation points from two interleaved
+  QPSK sets.
+- **TETRA gets its own Gray map and its own channel rate.** `TetraBitsToDibits`
+  is deliberately separate from the C4FM `framing.DibitsToBits`, and the DDC
+  target is 144 kHz where every 4800-baud protocol gets 48 kHz.
+- **The downlink never stops.** A TETRA base station transmits continuously —
+  four TDMA slots per 56.67 ms frame — so the receiver is a stream processor,
+  not a burst hunter, and lock quality is measurable every single frame.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| Differential demod | `arg(s·conj(last)) − rotation` → dibit quadrant | `internal/dsp/demod/dqpsk.go` (`DQPSK.Decode`) |
+| π/4 wrapper + RRC | matched filter (α = 0.35) + rotation constant | `internal/dsp/demod/piover4_dqpsk.go` (`PiOver4DQPSK`) |
+| Bit↔dibit convention | TETRA Gray map, distinct from C4FM linear | `internal/radio/tetra/sync.go` (`TetraBitsToDibits`) |
+| Channel rate | 144 kHz for TETRA, 48 kHz for C4FM family | `internal/scanner/ccdecoder/ddc.go` (`ddcTargetForProtocol`) |
+| IQ → dibit chain | filter → timing → AFC → differential decode | `internal/radio/tetra/receiver/receiver.go` (`Receiver.Process`) |
+| Timing recovery | Gardner loop, the default clock mode | `receiver.go` (`ParseClockMode`, `ClockGardner`) |
+
+## In this post
+
+- **Not "European P25"** — the assumptions TETRA breaks, in one table.
+- **Information in the transition** — the differential decode and what it buys.
+- **A constellation that never sits still** — eight points, two QPSK sets, one Gray map.
+- **144 kHz or nothing** — why the channel rate is a per-protocol decision.
+- **The receiver in one pass** — the chain from IQ to dibits, and the hooks we'll use later.
+
+## Not "European P25"
+
+It's tempting to file TETRA as "the European trunking protocol" and assume the
+P25 machinery transfers. Almost none of it does. Every C4FM-family protocol in
+GopherTrunk — P25 Phase 1, DMR, NXDN, dPMR — is four-level FSK: an FM
+discriminator turns frequency into amplitude, and a slicer maps four amplitude
+levels to dibits. TETRA is a different animal on every axis that matters:
+
+| Axis | P25 Phase 1 (C4FM) | TETRA TMO |
+|---|---|---|
+| Modulation | 4-level FSK (frequency) | π/4-DQPSK (differential phase) |
+| Symbol rate | 4800 sym/s | 18000 sym/s |
+| Channel width | 12.5 kHz | 25 kHz |
+| Channel bit rate | 9.6 kbps | 36 kbps before slot muxing |
+| Downlink | bursty | continuous 4-slot TDMA |
+| GT channel rate | 48 kHz | 144 kHz |
+| Vocoder | IMBE (MBE family) | ACELP (EN 300 395-2) |
+
+The one that shapes this whole series is the first row. A C4FM slicer asks
+"what amplitude is this symbol?" — an absolute question. A TETRA demodulator
+asks "how far did the phase move since the *last* symbol?" — a relative one.
+The [demodulation primer]({{ '/blog/deep-dives/sdr-internals-06-demodulation/' | relative_url }})
+covers both families in the abstract; here we care about what the relative
+question buys and costs on a real carrier.
+
+## Information in the transition
+
+The core of the demodulator is a dozen lines. At each symbol time it multiplies
+the current symbol by the conjugate of the previous one — which subtracts their
+phases — removes the π/4 rotation offset, and slices the remaining phase delta
+into one of four quadrants:
+
+```go
+// internal/dsp/demod/dqpsk.go (shape) — Decode
+for i, s := range src {
+    // Phase delta: arg(s * conj(last)) − rotation.
+    ar := real(s)*real(d.last) + imag(s)*imag(d.last)
+    ai := imag(s)*real(d.last) - real(s)*imag(d.last)
+    phi := math.Atan2(float64(ai), float64(ar)) - d.rotation
+    /* … wrap to [-π, π) … */
+    switch {
+    case phi >= -math.Pi/4 && phi < math.Pi/4:
+        dst[i] = 0b00
+    case phi >= math.Pi/4 && phi < 3*math.Pi/4:
+        dst[i] = 0b01
+    /* … 0b11, 0b10 … */
+    }
+    d.last = s
+}
+```
+
+Read what is *not* in that loop: no carrier phase estimate, no phase-locked
+loop, no reference symbol. `d.last` is the only memory, initialized to `1+0i`.
+If the whole constellation arrives rotated by some unknown constant — because
+the LO started at an arbitrary phase, or a filter imposed a phase shift — the
+rotation appears in both `s` and `last` and **cancels in the conjugate
+product**. That is the deep reason differential modulation exists, and it is
+worth planting now because it becomes load-bearing later: any processing
+inserted before this decoder is safe *only if* it imposes a constant phase.
+A filter whose phase wanders symbol-to-symbol does not cancel in
+`s·conj(last)` and corrupts every dibit — the exact trap the equalizer work in
+Parts 8–10 had to design around, and a theme the
+[Weak-Signal Engineering series]({{ '/blog/series/weak-signal-engineering/' | relative_url }})
+develops in full.
+
+The cost of the relative question is error doubling: one bad symbol corrupts
+two transitions. TETRA's channel coding (Part 3) is budgeted for that.
+
+## A constellation that never sits still
+
+Plain DQPSK encodes dibits as phase deltas of 0°, ±90°, 180°. The 180° case is
+a problem: the trajectory passes through the origin, the envelope collapses,
+and timing recovery loses its reference. π/4-DQPSK fixes this by adding 45° to
+every transition — the four deltas become ±45° and ±135°, and consecutive
+symbols always land on *alternating* QPSK constellations, 45° apart. You see
+eight points on a scope, but only four transitions carry information.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 230" width="680" height="230" role="img" aria-label="A π/4-DQPSK constellation: eight points on a circle formed by two interleaved QPSK sets 45 degrees apart, one set drawn muted on the axes and the other set accented on the diagonals, with an arrow showing a plus-45-degree transition from an axis point to a diagonal point labelled dibit 00, and a second arrow showing a plus-135-degree transition labelled dibit 01">
+  <circle cx="170" cy="112" r="82" fill="none" stroke="var(--fg-muted)" stroke-dasharray="3 4"/>
+  <!-- set A (axes) -->
+  <circle cx="252" cy="112" r="5" fill="var(--fg-muted)"/><circle cx="88" cy="112" r="5" fill="var(--fg-muted)"/>
+  <circle cx="170" cy="30" r="5" fill="var(--fg-muted)"/><circle cx="170" cy="194" r="5" fill="var(--fg-muted)"/>
+  <!-- set B (diagonals) -->
+  <circle cx="228" cy="54" r="5" fill="var(--accent)"/><circle cx="112" cy="54" r="5" fill="var(--accent)"/>
+  <circle cx="112" cy="170" r="5" fill="var(--accent)"/><circle cx="228" cy="170" r="5" fill="var(--accent)"/>
+  <path d="M 248 104 A 82 82 0 0 0 234 60" fill="none" stroke="var(--accent)"/>
+  <polygon points="238,66 231,56 242,58" fill="var(--accent)"/>
+  <text x="268" y="76" fill="var(--accent)" font-size="10">+45° → dibit 00</text>
+  <path d="M 246 122 A 82 82 0 0 1 122 178" fill="none" stroke="currentColor"/>
+  <polygon points="130,172 118,180 128,182" fill="currentColor"/>
+  <text x="212" y="212" fill="currentColor" font-size="10">+135° → dibit 01</text>
+  <text x="440" y="52" fill="currentColor" font-size="11" font-weight="bold">two QPSK sets, 45° apart</text>
+  <text x="440" y="74" fill="var(--fg-muted)" font-size="10">even symbols land on one set,</text>
+  <text x="440" y="88" fill="var(--fg-muted)" font-size="10">odd symbols on the other — the</text>
+  <text x="440" y="102" fill="var(--fg-muted)" font-size="10">trajectory never crosses the origin</text>
+  <text x="440" y="130" fill="var(--fg-muted)" font-size="10">deltas: ±45°, ±135° — never 0°,</text>
+  <text x="440" y="144" fill="var(--fg-muted)" font-size="10">so every symbol is a transition</text>
+  <text x="440" y="158" fill="var(--fg-muted)" font-size="10">timing recovery can clock off</text>
+  <text x="440" y="186" fill="var(--fg-muted)" font-size="10">a constant rotation of ALL points</text>
+  <text x="440" y="200" fill="var(--fg-muted)" font-size="10">cancels in s·conj(last)</text>
+</svg>
+<figcaption>π/4-DQPSK: eight visible points from two interleaved QPSK sets, but only the four phase deltas carry dibits — and a constant rotation of everything cancels in the differential decode.</figcaption>
+</figure>
+
+The mapping from bit pairs to those deltas is TETRA's own Gray code, and
+GopherTrunk keeps it in exactly one place:
+
+```go
+// internal/radio/tetra/sync.go (shape)
+func TetraBitsToDibits(bits []uint8) []uint8 {
+    out := make([]uint8, len(bits)/2)
+    for i := range out {
+        b1, b2 := bits[2*i]&1, bits[2*i+1]&1
+        out[i] = (b1 << 1) | (b1 ^ b2) // TETRA Gray: 00→0, 01→1, 11→2, 10→3
+    }
+    return out
+}
+```
+
+`TetraBitsToDibits` and its inverse are the single source of truth, kept
+deliberately apart from the C4FM-linear `framing.DibitsToBits` — mixing the
+conventions produces garbage that looks exactly like a demod bug. One residual
+wrinkle: a leftover carrier-frequency offset advances the phase a constant
+amount per symbol, which shows up as the whole *dibit stream* rotated by an
+unknown 0..3. That's why every training-sequence correlator in Part 2 runs
+under all four rotations.
+
+## 144 kHz or nothing
+
+GopherTrunk channelizes every protocol to a fixed per-protocol rate, and the
+choice is made in one function:
+
+```go
+// internal/scanner/ccdecoder/ddc.go (shape)
+func ddcTargetForProtocol(p trunking.Protocol) float64 {
+    if p == trunking.ProtocolTETRA || p == trunking.ProtocolTETRADMO {
+        return tetraDDCTargetRateHz // 144_000
+    }
+    return ddcTargetRateHz // 48_000 — the 4800-baud C4FM family
+}
+```
+
+At 18000 sym/s, 144 kHz is exactly **8 samples per symbol**, and the receiver's
+Gardner loop, AFC, channel filter and AGC are all sized from that figure. The
+exported `DDCTargetForProtocol` exists so offline replay builds an *identical*
+down-converter — sizing a TETRA replay to the 48 kHz C4FM default would leave
+under 3 samples per symbol and the timing loop would never lock. The war story
+of what happens when a capture arrives *below* the channel rate (a 50 kHz
+recording that decoded to a plausible-but-wrong 16667 sym/s) is told in
+[Protocol Decoders Part 7]({{ '/blog/deep-dives/protocol-decoders-07-tetra/' | relative_url }});
+the standing rule is that the down-converter normalises in **both** directions
+so the receiver always sees its designed rate.
+
+## The receiver in one pass
+
+`internal/radio/tetra/receiver` composes the chain: optional channel-select
+filter (±15 kHz, because the 144 kHz passband is ±72 kHz and adjacent carriers
+leak in — measured to cut on-air symbol errors by an order of magnitude), the
+α = 0.35 RRC matched filter, symbol-timing recovery, AFC, then the differential
+decode. Timing defaults to Gardner (`ParseClockMode("")` returns
+`ClockGardner`), which the
+[timing-recovery deep dive]({{ '/blog/deep-dives/sdr-internals-07-symbol-timing-sync-recovery/' | relative_url }})
+covers in general form; the AFC runs *before* timing because a spinning
+constellation corrupts the Gardner metric. The whole thing is stateful and
+per-carrier: one `Receiver` per tuned frequency.
+
+Two hooks in `receiver.Options` are worth noticing now even though we won't use
+them for several parts: `SoftSink` emits the complex differential per symbol
+(the soft information Part 8 builds on), and `SymbolSink` emits the raw
+pre-differential symbols (the linear-channel domain the trained equalizer in
+the later parts needs). Both are nil by default, cost nothing when unused, and
+exist precisely because the differential product `s·conj(last)` destroys
+information a linear equalizer requires — a consequence of this part's central
+property, arriving early.
+
+### How that principle shaped the Go code
+
+- **One convention, one owner.** The Gray map lives only in
+  `TetraBitsToDibits`/`TetraDibitsToBits`; the rotation constant lives only in
+  `receiver.Rotation`. Nothing downstream re-derives either.
+- **Rates are named, not implied.** `SymbolRate`, `tetraDDCTargetRateHz` and the
+  8 sps product are constants with doc comments, so "the receiver's designed
+  rate" is a greppable fact rather than folklore.
+- **The demod is shared, parameterised.** `PiOver4DQPSK` serves both TETRA
+  (rotation π/4) and P25 Phase 2 H-DQPSK (π/8) — the same primitive, one
+  rotation argument apart, so a fix in the differential core lands in both.
+
+## Where this goes next
+
+A dibit stream at 18000/s is not yet a protocol — it's a firehose with no
+punctuation. [Part 2]({{ '/blog/deep-dives/tetra-end-to-end-02-bursts-slot-grid/' | relative_url }})
+adds the structure: the synchronisation and normal downlink bursts, the
+training sequences that mark them, the 255-dibit slot grid — and the hard-won
+lesson of `ndbSBSlotShift`, where anchoring that grid one slot wrong silently
+misfiles every traffic burst on the carrier.
+
+## FAQ
+
+**Why differential modulation at all — why not coherent QPSK?**
+Coherent QPSK needs a carrier-phase estimate, and a phase-recovery loop on a
+fading mobile channel is a liability: every cycle slip is a burst of errors.
+Differential encoding trades ~2–3 dB of sensitivity for never needing absolute
+phase — the receiver works the moment two consecutive symbols arrive, which
+also makes TDMA slot boundaries and late tune-ins cheap.
+
+**Does GopherTrunk ever see the eight constellation points?**
+Yes — the raw symbols exist between timing recovery and the differential
+decode, and `SymbolSink` exposes exactly that stream. The hard decode only ever
+looks at the transition, but the diagnostics panels and the trained equalizer
+(later in this series) both consume the raw-symbol view.
+
+**Why is the TETRA channel rate 144 kHz when the channel is only 25 kHz wide?**
+144 kHz is a processing rate, not a bandwidth: 8 samples per symbol at
+18000 sym/s. The occupied signal is ≈±12 kHz; the surplus passband is why the
+receiver optionally inserts its own ±15 kHz channel-select filter before the
+matched filter.
+
+**What happens if a capture was recorded at 50 kHz instead?**
+The down-converter interpolates it up to 144 kHz so the receiver still runs at
+8 samples/symbol. Feeding it raw gives ~2.78 samples/symbol, which rounds to 3
+and drifts the recovered clock ~7% — a plausible-looking symbol rate that never
+locks. That story is in
+[Protocol Decoders Part 7]({{ '/blog/deep-dives/protocol-decoders-07-tetra/' | relative_url }}).
+
+**Is the 0..3 dibit rotation from carrier offset a bug?**
+No — it's inherent. A residual CFO adds a constant phase per symbol, which the
+quadrant slicer reads as a constant dibit offset. The AFC removes most of it,
+and everything that correlates patterns (sync detectors, Part 2) searches all
+four rotations so a residual rotation can't hide a burst.
+
+## Series navigation
+
+**Part 1 of 14** · Next →
+[Part 2: The Burst Zoo & the Slot Grid]({{ '/blog/deep-dives/tetra-end-to-end-02-bursts-slot-grid/' | relative_url }})

--- a/docs/_posts/2026-08-18-weak-signal-engineering-01-marginal-regime.md
+++ b/docs/_posts/2026-08-18-weak-signal-engineering-01-marginal-regime.md
@@ -1,0 +1,281 @@
+---
+title: "Weak-Signal Engineering, Part 1: The Marginal Regime"
+description: Between full quieting and no signal lies the marginal regime — where a receiver locks but decodes only a fraction of what it hears — and this opener defines that regime with a real TETRA capture, previews the four levers that roughly doubled GopherTrunk's yield there, and sets the one verdict rule the whole series lives by.
+category: deep-dives
+keywords: weak signal decoding, marginal signal regime, in-channel snr, crc yield, control channel sync loss, tetra bsch decode, decode yield vs snr, blind equalizer, soft decision fec, gophertrunk weak-signal engineering
+tags: [weak-signal-engineering, dsp, tetra, snr, equalizer, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Weak-Signal Engineering"
+series_part: 1
+---
+
+*Part 1 of **Weak-Signal Engineering**, a 14-part deep dive into the regime
+where most real radio traffic actually lives: not full quieting, not silence,
+but the marginal middle — where a receiver locks and then decodes a fraction of
+what it hears. Over fourteen posts we work through the four levers that roughly
+doubled GopherTrunk's decode yield in that regime — blind equalization, trained
+equalization, soft-decision FEC, and diversity combining — and the measurement
+discipline that keeps each one honest. The series has a running thread: a single
+two-second capture of a struggling TETRA control channel, introduced below,
+whose yield number we move part by part.*
+
+> **TL;DR:** The **marginal regime** is where the receiver *locks* but decodes
+> only a fraction of the frames it demodulates. GopherTrunk's canonical example
+> is a real on-air capture (`testdata/tetra_cc_sync_loss_2s_144k.cs16` in
+> `internal/scanner/ccdecoder`): in-channel SNR ~**10 dB**, a solid lock, and
+> only ~**12%** of its BSCH synchronisation bursts CRC-clean — while a healthy
+> period on the *same site* measures ~18 dB and decodes ~100%. Four levers move
+> that number: a blind **`SnapshotCMA`** equalizer, a trained **`SnapshotLMS`**
+> equalizer, **soft-decision** channel decoding, and **diversity** combining.
+> And one rule governs all of them: **decode yield — CRC-valid frames per
+> opportunity — is the only trustworthy verdict.** EVM, SNR, and constellation
+> beauty are advisory at best and traps at worst.
+
+**Key takeaways**
+
+- **Marginal means "locks but under-decodes," not "weak."** A no-signal channel
+  is easy to diagnose; a channel that locks, decodes 12%, and thrashes the
+  resync logic is the hard case — and the common one.
+- **The regime is narrow in dB and wide in reality.** The gap between ~100%
+  yield and ~12% yield on our thread capture is about 8 dB of in-channel SNR —
+  the difference between a fixed antenna on a good day and the same antenna on
+  a bad one.
+- **Four levers, one method.** Equalize what is linear, train where you know
+  the transmitted symbols, keep reliability information the slicer would throw
+  away, and combine antennas where the math allows — each lever lands with a
+  failing-first test and, where possible, an operator-capture A/B.
+- **Yield is the verdict.** Every lever in this series is scored by CRC-valid
+  frames per opportunity on real captures, never by how pretty the
+  constellation got. Part 2 is entirely about why.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| The thread capture | ~2 s of a marginal on-air TETRA CC, 144 kHz cs16 | `internal/scanner/ccdecoder/testdata/tetra_cc_sync_loss_2s_144k.cs16` |
+| Yield harness | replay the fixture, count CRC-clean BSCH | `internal/scanner/ccdecoder/pipelines_tetra_equalizer_test.go` (`decodeCCBSCHYield`) |
+| Blind equalizer | invert linear ISI with no reference | `internal/dsp/equalizer/snapshot_cma.go` (`SnapshotCMA`) — Parts 4–6 |
+| Trained equalizer | train on the known midamble, freeze, apply | `internal/dsp/equalizer/snapshot_lms.go` (`SnapshotLMS`) — Part 7 |
+| Soft decisions | carry LLRs through depuncture + Viterbi | `internal/radio/framing/soft_tetra.go` (`DecodeRCPCTetraMotherSoft`) — Part 8 |
+| Diversity | combine two branches, gated by coherence | `internal/dsp/diversity` (`CrossStats`, `TrackingCalibrator`) — Parts 10–11 |
+
+## In this post
+
+- **What "marginal" actually means** — locked, demodulating, and losing.
+- **The capture that runs this series** — one bad night on system 250_013.
+- **Why real traffic lives here** — fringe sites, mobiles, band edges.
+- **Four levers, one method** — the series map.
+- **Yield is the only verdict** — the rule everything else obeys.
+
+## What "marginal" actually means
+
+Every receiver spec sheet implies a binary: above sensitivity you decode, below
+it you don't. Reality has a third state, and it is enormous. In the marginal
+regime the synchronisation machinery *works* — the correlator finds the training
+sequence, the timing loop tracks, the AFC pulls the carrier in — but the
+per-frame error correction loses more often than it wins. The receiver is
+locked, demodulating symbols at full rate, and throwing most of them away at
+the [CRC]({{ '/reference/crc-16-ccitt/' | relative_url }}).
+
+That state is qualitatively different from "no signal," and it fails in a
+qualitatively nastier way. A dead channel produces silence and an obvious
+diagnosis. A marginal channel produces *partial* everything: partial voice
+recordings, a control channel that follows some grants and misses others, and —
+worst — sync-tracking logic that keeps being fed just enough valid frames to
+believe the lock is real while the failure counters climb. On a TETRA control
+channel that pattern has a specific signature GopherTrunk operators have watched
+live: `bsch_fail` climbing, `sb_bursts` collapsing, repeated
+`tetra: dsp resync (signal-time decode drought)` lines, and finally the 5-second
+stale watchdog declaring the channel lost and sending the scanner back to the
+hunt. One reporter's one-hour session logged ~210 control-channel transitions
+and 11 hard sync losses that way — and the postmortem found *zero* correlation
+with CPU or call load. It was never compute starvation. It was this regime.
+
+## The capture that runs this series
+
+When that reporter's daemon lost sync, the `on_cc_sync_loss` auto-recorder did
+exactly what it exists to do: it grabbed IQ. The two-second slice checked into
+the repo is the series' thread capture, and its header comment is a complete
+character sketch:
+
+```go
+// internal/scanner/ccdecoder/pipelines_tetra_equalizer_test.go (shape)
+// marginalCCFixture is a ~2 s / 144 kHz cs16 slice of a real on-air TETRA
+// control channel captured by gophertrunk's on_cc_sync_loss auto-recorder
+// during a re-acquisition (system 250_013, CC 467.9125 MHz, Airspy). In-channel
+// SNR is ~10 dB (a healthy period on the same site measures ~18 dB) and the
+// π/4-DQPSK constellation is ISI-smeared. Replayed through the current CC path
+// it LOCKS but decodes only ~22 % of its BSCH synchronisation bursts — the
+// marginal-yield regime that produced the field's ~210 CC transitions/hour.
+const marginalCCFixture = "testdata/tetra_cc_sync_loss_2s_144k.cs16"
+```
+
+The numbers to hold onto: the full sync-loss capture decodes ~**22%** of its
+BSCH bursts; the two-second fixture slice, replayed through the baseline chain,
+manages ~**12%**. A healthy capture from the same site — same antenna, same
+Airspy, same software — measures ~**18 dB** in-channel and decodes ~**100%**.
+Two more facts matter because of what they rule out: the capture peaks at about
+−44 dBFS with no clipping (so this is not front-end overload), and the carrier
+sits ~3 kHz off centre, well within the AFC's pull-in. Nothing is *broken*.
+The channel is simply about 8 dB worse than it needs to be, and the
+[π/4-DQPSK]({{ '/reference/pi-4-dqpsk/' | relative_url }}) constellation is
+visibly smeared by inter-symbol interference on top of the noise.
+
+The harness that scores it is deliberately minimal — the same wiring as the
+production pipeline with exactly one variable exposed:
+
+```go
+// internal/scanner/ccdecoder/pipelines_tetra_equalizer_test.go (shape)
+// decodeCCBSCHYield hand-wires a TETRA control-channel receiver + decoder at the
+// 144 kHz channel rate with the equalizer toggled, feeds the IQ in chunks, and
+// returns the BSCH decode counts. The wiring mirrors newTETRAPipeline exactly
+// … EXCEPT that EnableEqualizer is a parameter — so a single fixture isolates
+// the equalizer as the only variable.
+func decodeCCBSCHYield(t *testing.T, iq []complex64, enableEqualizer bool) (ok, fail int64)
+```
+
+`ok / (ok + fail)` is the yield, and yield is the number this series moves.
+
+## Why real traffic lives here
+
+It would be comforting to treat the marginal regime as an edge case. It isn't —
+for structural reasons. Coverage planning puts sites where *most* users get a
+strong signal, which by construction leaves the fringe populated. Mobiles and
+handhelds spend their lives behind buildings, in vehicles, and at the bottom of
+the fade distribution. Band-edge channels pick up group-delay distortion from
+the very filters that protect them. And a scanner operator is usually *not* a
+subscriber standing where the coverage map is green — you are listening from
+one fixed antenna at whatever distance the geography dealt you.
+
+The practical consequence: the difference between a scanner that "mostly works"
+and one that feels professional is almost entirely how it behaves between
+roughly 8 and 18 dB of in-channel SNR. Above that band, everything decodes and
+the DSP is unheroic. Below it, no software can help and the fix is RF — better
+antenna, better siting, the territory of
+[The Analog Edge]({{ '/blog/series/analog-edge/' | relative_url }}), running
+concurrently with this series. In between is where engineering pays, and in
+between is exactly where our thread capture sits.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 220" width="680" height="220" role="img" aria-label="Decode yield versus in-channel SNR is a cliff: near zero yield at low SNR, a steep transition region, and a plateau near one hundred percent at high SNR. The marginal TETRA capture sits on the cliff face at ten decibels and twelve percent yield; the healthy capture from the same site sits on the plateau at eighteen decibels and one hundred percent. An arrow shows the series' four levers moving the cliff left, so the same ten decibel capture lands on the plateau.">
+  <line x1="50" y1="20" x2="50" y2="180" stroke="var(--fg-muted)"/>
+  <line x1="50" y1="180" x2="650" y2="180" stroke="var(--fg-muted)"/>
+  <text x="18" y="30" fill="var(--fg-muted)" font-size="9">yield</text>
+  <text x="18" y="42" fill="var(--fg-muted)" font-size="9">(CRC)</text>
+  <text x="44" y="34" text-anchor="end" fill="var(--fg-muted)" font-size="9">100%</text>
+  <text x="44" y="182" text-anchor="end" fill="var(--fg-muted)" font-size="9">0%</text>
+  <text x="590" y="198" fill="var(--fg-muted)" font-size="9">in-channel SNR (dB)</text>
+  <polyline points="60,176 160,172 240,160 300,130 350,80 400,44 470,32 640,30" fill="none" stroke="currentColor"/>
+  <polyline points="60,174 120,168 180,148 230,104 280,52 330,34 400,31 640,30" fill="none" stroke="var(--accent)" stroke-dasharray="5 3"/>
+  <circle cx="312" cy="120" r="5" fill="currentColor"/>
+  <text x="312" y="142" text-anchor="middle" fill="var(--fg-muted)" font-size="9">thread capture: ~10 dB, ~12%</text>
+  <circle cx="470" cy="32" r="5" fill="var(--accent)"/>
+  <text x="470" y="20" text-anchor="middle" fill="var(--accent)" font-size="9">healthy: ~18 dB, ~100%</text>
+  <line x1="360" y1="70" x2="300" y2="70" stroke="var(--accent)"/><polygon points="300,66 290,70 300,74" fill="var(--accent)"/>
+  <text x="370" y="74" fill="var(--accent)" font-size="9">the four levers move the cliff left</text>
+  <text x="350" y="214" text-anchor="middle" fill="var(--fg-muted)" font-size="10">the marginal regime is the cliff face — locked, demodulating, and losing at the CRC</text>
+</svg>
+<figcaption>Decode yield against in-channel SNR is a cliff, and the marginal regime is its face. The series' levers do not add signal — they move the cliff left, so the same 10 dB capture lands on the plateau.</figcaption>
+</figure>
+
+## Four levers, one method
+
+[SDR Internals Part 8]({{ '/blog/deep-dives/sdr-internals-08-equalization-diversity-fft/' | relative_url }})
+surveyed equalization and diversity in a single episode and promised each was
+"worth its own series." This is that series. The four levers, and where each
+one lives in the fourteen parts:
+
+| Lever | What it exploits | Measured effect | Parts |
+|---|---|---|---|
+| Blind equalization (`SnapshotCMA`) | PSK's constant envelope — no reference needed | CC fixture ~12% → ~100% BSCH; voice bursts 410 → 778 | 4, 5, 6 |
+| Trained equalization (`SnapshotLMS`) | known training sequences (midambles) | synthetic multipath: 13% → 0% payload bit-error | 7 |
+| Soft decisions | reliability the hard slicer discards | recovered ~70% of a marginal call's failed bursts | 8, 9 |
+| Diversity (MRC) | two antennas, coherence-gated combining | scored per-capture by CRC-clean BSCH | 10, 11 |
+
+The remaining parts are the method around the levers: Part 2 on the metrics
+that lie, Part 3 on what a linear channel is and is not, Part 12 on
+experimental design (how [#764](https://github.com/MattCheramie/GopherTrunk/issues/764)
+was proven to be the *signal's* fault, not the DSP's), Part 13 on the one
+GopherTrunk decode path that still has none of these levers, and Part 14 as the
+assembled playbook. The concurrently-running
+[TETRA End to End]({{ '/blog/series/tetra-end-to-end/' | relative_url }}) series
+is the protocol-level case study these levers were proven on; here we keep the
+treatment cross-protocol, because nothing in an FIR tap knows what a TETRA is.
+
+## Yield is the only verdict
+
+State the rule once, up front, because every later part leans on it: **the only
+trustworthy measure of a weak-signal lever is decode yield — CRC-valid frames
+per decode opportunity — on real captures.** Not EVM. Not SNR. Not how round the
+constellation looks. GopherTrunk learned this the expensive way: a
+numerically-unstable equalizer variant once collapsed differential EVM from 34%
+to 8% — a spectacular apparent win — while CRC yield stayed exactly **zero**.
+The signal got beautiful and carried no information. Part 2 dissects that
+failure and the related trap from
+[#764](https://github.com/MattCheramie/GopherTrunk/issues/764), where the
+*worse* capture had the *higher* wideband carrier SNR.
+
+The companion rule is the testing discipline this project has carried since
+[#771](https://github.com/MattCheramie/GopherTrunk/issues/771): every lever
+lands with a **failing-first regression test** — one that demonstrably fails
+against the old code — and, wherever an operator can supply one, an A/B on
+their own capture. A synthetic test that encodes and decodes with the same
+assumptions can pass forever while the air disagrees; the
+[postmortem series]({{ '/blog/solution-postmortem/from-the-issue-tracker-05-ten-megasamples/' | relative_url }})
+has already met that trap, and this series will keep meeting it. When we say
+the blind equalizer takes the thread capture from ~12% to ~100%, that claim is
+`TestTETRACCPipelineEqualizer`-shaped: same fixture, one boolean, two counts.
+
+## Where this goes next
+
+Before touching a single tap weight we have to fix the measurement problem,
+because a wrong metric will cheerfully steer months of work into a ditch.
+[Part 2]({{ '/blog/deep-dives/weak-signal-engineering-02-metrics-that-lie/' | relative_url }})
+is about the metrics that lie: what EVM actually measures and where it's
+measured, how an equalizer can make EVM collapse while decoding nothing, why
+the worse #764 capture had the better carrier SNR — and the short list of
+numbers you can actually trust.
+
+## FAQ
+
+**How do you measure "in-channel SNR" — isn't SNR one of the metrics you just said not to trust?**
+It's measured in the channel bandwidth after the channel-select filter, not on
+a wideband FFT — and it's *advisory*, useful for characterizing a capture and
+placing it on the cliff. The rule is narrower than "never look at SNR": never
+use SNR (or EVM) as the *verdict* on whether a change helped. The verdict is
+yield. See [noise and SNR]({{ '/learn/rf-sdr/noise-and-snr/' | relative_url }})
+for the measurement itself.
+
+**If the capture peaks at −44 dBFS, why not just add gain?**
+Raising front-end gain raises signal and noise together once you're past the
+point where the front end's own noise figure dominates — and the thread
+capture's ~10 dB is in-channel SNR, which more gain does not improve. The weak
+front-end level is a real RF condition worth fixing (better antenna, less
+feedline loss), but it is a separate problem from the ISI smear the equalizer
+addresses. The two compound; fixing either helps.
+
+**Is the marginal regime a TETRA thing?**
+No. TETRA is the case study because that's where the operator captures came
+from, but the regime is universal: the same locks-but-under-decodes behaviour
+shows up on P25 Phase 1 voice (Part 13's subject), DMR, and anything else with
+sync acquisition cheaper than payload FEC. The levers are protocol-agnostic —
+they operate on complex symbols and LLRs, not on protocol fields.
+
+**Why does the fixture decode ~12% when the full capture decodes ~22%?**
+The fixture is a two-second slice of the worst of it, chosen to be a compact,
+reproducible regression target. The full capture averages in some healthier
+seconds. Both numbers describe the same regime; the fixture's baseline is
+simply the harder version, which makes it the better test.
+
+**Couldn't the resync storm be fixed by making the sync logic more patient?**
+Patience was already correct: the investigation confirmed the signal-time
+resync design was untouched precisely because the losses had zero correlation
+with load. Tuning sync thresholds to tolerate a 12%-yield channel just delays
+the inevitable and slows recovery on genuinely dead channels. The fix that
+mattered raised the yield itself — which is the whole thesis of this series.
+
+## Series navigation
+
+**Part 1 of 14** · Next →
+[Part 2: Metrics That Lie — EVM vs CRC Yield]({{ '/blog/deep-dives/weak-signal-engineering-02-metrics-that-lie/' | relative_url }})

--- a/docs/_posts/2026-08-19-analog-edge-02-dbfs.md
+++ b/docs/_posts/2026-08-19-analog-edge-02-dbfs.md
@@ -1,0 +1,263 @@
+---
+title: "The Analog Edge, Part 2: dBFS — What the Number Means (& What It Doesn't)"
+description: A precise definition of dBFS for SDR operators — full scale, peak versus RMS, the readings GopherTrunk exports, and why two captures peaking at the same −48 dBFS can differ by 10 dB of usable signal, which makes dBFS a headroom meter and never a quality meter.
+category: tutorials
+keywords: dbfs meaning, dbfs sdr, adc full scale, peak vs rms, crest factor, iq power dbfs, clip ratio, sdr signal level, headroom meter, gophertrunk analog edge
+tags: [analog-edge, dbfs, adc, metrics, sdr, tutorial]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "The Analog Edge"
+series_part: 2
+---
+
+*Part 2 of **The Analog Edge**, a 14-part field guide to the analog half of a
+GopherTrunk installation. [Part 1]({{ '/blog/tutorials/analog-edge-01-where-software-ends/' | relative_url }})
+drew the line at the ADC and inventoried the tracker bugs that lived on the
+analog side of it. This part picks up the first instrument on that side of the
+line — the dBFS meter — for our running reader with the marginal system,
+because the very first thing they'll do is look at a level number and draw
+exactly the wrong conclusion from it. dBFS answers one question with total
+authority and a different question not at all, and telling those apart is the
+whole part.*
+
+> **TL;DR:** **dBFS is level relative to the ADC's full scale** — 0 dBFS is
+> the rail, everything real is negative, and the only thing the number
+> measures is **headroom**. GopherTrunk exports it as
+> `gophertrunk_sdr_iq_power_dbfs` (RMS over a ~1 s window: idle ≈ −45,
+> healthy ≈ −25) with `gophertrunk_sdr_iq_clip_ratio` beside it, because
+> **RMS averages away peak clipping** — the clip ratio is the authoritative
+> overload signal. And dBFS says nothing about quality: the two
+> [#764](https://github.com/MattCheramie/GopherTrunk/issues/764) captures
+> both peaked ≈ **−48 dBFS**, yet one locked at ~19.7 dB demod SNR and the
+> other sat undecodable at ~9.5 dB. Same meter reading, 10 dB of usable
+> signal apart.
+
+**Key takeaways**
+
+- **0 dBFS is a cliff, not a target.** Full scale is where the ADC stops
+  being a measuring instrument; every dB of margin below it is headroom
+  against clipping, and you want plenty.
+- **Peak and RMS are different numbers, and GopherTrunk's gauge is RMS.** A
+  high-crest signal can pin the rails on peaks while the average still reads
+  a merely-hot −5 dBFS — which is why the clip ratio exists as a separate,
+  authoritative metric.
+- **dBFS cannot rank two signals by decodability.** It measures how loud the
+  digitized waveform is, not how much of that loudness is *your channel*
+  versus noise, neighbors, and front-end artifacts.
+- **Learn the regimes, not a single magic number.** Idle ≈ −45, healthy
+  ≈ −25, > −3 clipping — those anchors come straight from the metric's own
+  help text, and the table below fills in the space between.
+
+## Cheat sheet
+
+| Concern | What it tells you | Where it lives |
+|---|---|---|
+| Mean level, per control SDR | RMS dBFS, ~1 s window, labelled per system | `gophertrunk_sdr_iq_power_dbfs` (`internal/metrics/prom.go`) |
+| Overload, authoritatively | fraction of samples pinned to the rail | `gophertrunk_sdr_iq_clip_ratio` — sustained > ~0.002 is overload |
+| Whole wideband capture | pre-DDC level per dongle serial | `gophertrunk_sdr_wideband_input_iq_power_dbfs` |
+| Wideband overload | a strong site burying weaker taps | `gophertrunk_sdr_wideband_input_clip_ratio` (issue #749) |
+| DC contamination | DC-bin power vs total; ≤ −20 dB is clean | `gophertrunk_sdr_iq_dc_ratio_db` |
+| The definition itself | full scale, headroom, clipping | [dBFS]({{ '/reference/dbfs/' | relative_url }}) in the Field Guide |
+
+## In this post
+
+- **What full scale actually is** — the ADC's rail and the sign convention.
+- **Peak vs RMS** — crest factor, and why the gauge needs a partner metric.
+- **Where GopherTrunk shows the number** — the gauges and their anchors.
+- **What dBFS cannot tell you** — the two −48 dBFS captures of #764.
+- **The regime table** — reading → likely condition → action.
+
+## What full scale actually is
+
+An ADC measures voltage against a fixed reference. Drive it with exactly that
+reference voltage and every bit of the sample is used — that's **full scale**,
+and we call it 0 dBFS. Everything smaller is expressed as decibels *below*
+that ceiling, so real-world readings are always negative: −20 dBFS is a
+waveform reaching a tenth of the rail voltage, −40 dBFS a hundredth. (If
+decibels themselves are shaky ground, the
+[decibels lesson]({{ '/learn/rf-sdr/decibels/' | relative_url }}) in the
+learning module is a fifteen-minute fix.)
+
+Two properties follow immediately. First, dBFS is a *digital* unit: it says
+where the waveform sits relative to this converter's rail, and nothing about
+absolute RF power at the antenna — the same station moves up and down the
+dBFS scale as you turn the gain knob. Second, 0 dBFS is not a maximum you
+approach for best results; it's the point where the ADC stops measuring and
+starts lying. A sample that *would have been* larger than full scale is
+recorded at the rail, its true value gone. That's clipping, and Part 4 is
+about how catastrophically it spreads across a band.
+
+## Peak vs RMS: why the gauge needs a partner
+
+"The level" is actually two numbers. **Peak** is the largest single sample in
+a window; **RMS** is the energy average. The gap between them is the signal's
+**crest factor**, and it varies enormously: a single constant-envelope carrier
+has a small crest factor, while a wideband capture full of independent
+carriers adds up like noise, with rare peaks far above its average.
+
+GopherTrunk's `gophertrunk_sdr_iq_power_dbfs` gauge is RMS over a roughly
+one-second window, and its own help text carries the warning that matters:
+
+```text
+gophertrunk_sdr_iq_power_dbfs   Mean IQ power on the control SDR in dBFS
+    (window ~= 1 s). Idle ≈ -45; healthy signal ≈ -25. This is RMS and
+    averages away peak clipping — watch iq_clip_ratio for the
+    authoritative overload signal.
+gophertrunk_sdr_iq_clip_ratio   Fraction of IQ samples pinned to the ADC
+    rail. 0 = no clipping; a sustained value above ~0.002 means front-end
+    overload — reduce gain or add attenuation, do not raise gain.
+```
+
+Read that pair as designed: a high-crest capture can clip on peaks while the
+RMS reads a merely "hot" −5 dBFS, so **the clip ratio, not the power gauge,
+is the overload verdict**. This is not a hypothetical — the
+[Nineteen Dibits postmortem]({{ '/blog/solution-postmortem/from-the-issue-tracker-08-nineteen-dibits/' | relative_url }})
+turned on a capture that was 50% rail-pinned while every downstream symptom
+pointed, convincingly, at software.
+
+## Where GopherTrunk shows the number
+
+Four gauges cover the level story end to end. Per decoded system, the
+narrowband `iq_power_dbfs` (labelled `"<system> @ <freq> MHz"`) tracks the
+channel actually feeding a decoder. Per dongle, the wideband pair —
+`wideband_input_iq_power_dbfs` and `wideband_input_clip_ratio` — measures the
+*whole capture before channelization*, which matters because every tap on a
+wideband dongle shares one gain: a strong site can overload the shared ADC
+and bury its weaker siblings, the issue #749 failure mode the
+`config.example.yaml` comments walk through. A tap sitting far below the
+wideband input power, or any sustained non-zero clip ratio, is also logged as
+a throttled WARN so you don't need a Prometheus dashboard to catch it.
+
+The anchors to memorize come from the help text: **idle ≈ −45 dBFS** (an
+antenna hearing only the noise floor), **healthy ≈ −25 dBFS**, and anything
+above **−3 dBFS** means clipping. Near-zero readings in the *other* direction
+— down at −70 and below — mean the chain is delivering essentially nothing:
+no antenna, gain at zero, or a dead cable. The DMR two-slot work from Part 1
+is still blocked on exactly such a capture: ~−75 dBFS RMS, no frame sync
+anywhere in it.
+
+## What dBFS cannot tell you
+
+Here is the part that saves you a week of mis-aimed debugging. In
+[#764](https://github.com/MattCheramie/GopherTrunk/issues/764), the reporter
+supplied two captures of the *same site* from the *same antenna*: one at
+2.5 MS/s, one at 10 MS/s. Both peaked at approximately **−48 dBFS** — neither
+clipped, neither was weak enough to suspect a dead branch. On the level
+meter, they are identical twins.
+
+Decoded, they are nothing alike. The 2.5 MS/s capture replays at ~19.7 dB
+demod SNR (EVM 7.4%) and locks; the 10 MS/s capture manages ~9.5 dB (EVM
+22.5%) and never locks. Ten decibels of usable signal separate two files the
+dBFS meter cannot distinguish — because the missing 10 dB wasn't *level*, it
+was signal *replaced by* front-end phase noise, sample for sample, at the
+same amplitude. The full detective story is in
+[Ten Megasamples]({{ '/blog/solution-postmortem/from-the-issue-tracker-05-ten-megasamples/' | relative_url }}),
+and Part 5 of this series retells its physics for operators.
+
+The moral generalizes: **dBFS is a headroom meter.** It tells you whether the
+ADC has room to represent the waveform without lying. It does not tell you
+what fraction of that waveform is your channel, whether the modulation
+survived the front end, or whether a decoder will lock. Quality questions
+belong to quality numbers — demod SNR, decode error rate, and ultimately CRC
+yield — which is a thread that runs all the way to Part 13's
+coherence-over-dBFS argument.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 230" width="680" height="230" role="img" aria-label="A vertical dBFS scale from 0 down to minus 80. The top region above minus 3 is marked clipping. Minus 25 is marked healthy. Minus 45 is marked idle noise. Below minus 70 is marked dead chain. Two markers sit together at minus 48: capture A, which decodes at 19.7 dB SNR, and capture B, which fails at 9.5 dB SNR, illustrating that the same dBFS reading cannot distinguish signal quality.">
+  <line x1="90" y1="20" x2="90" y2="210" stroke="var(--fg-muted)"/>
+  <line x1="86" y1="20" x2="94" y2="20" stroke="currentColor"/>
+  <text x="80" y="24" text-anchor="end" fill="currentColor" font-size="10">0 dBFS</text>
+  <rect x="90" y="20" width="180" height="12" fill="var(--accent)" opacity="0.35"/>
+  <text x="280" y="30" fill="var(--accent)" font-size="10">&gt; −3: clipping — the ADC is lying</text>
+  <line x1="86" y1="78" x2="94" y2="78" stroke="var(--fg-muted)"/>
+  <text x="80" y="82" text-anchor="end" fill="var(--fg-muted)" font-size="10">−25</text>
+  <text x="100" y="82" fill="currentColor" font-size="10">healthy signal (the gauge's own anchor)</text>
+  <line x1="86" y1="130" x2="94" y2="130" stroke="var(--fg-muted)"/>
+  <text x="80" y="134" text-anchor="end" fill="var(--fg-muted)" font-size="10">−48</text>
+  <circle cx="130" cy="126" r="4" fill="var(--accent)"/>
+  <text x="140" y="124" fill="currentColor" font-size="9">capture A: locks, demod SNR ≈ 19.7 dB</text>
+  <circle cx="130" cy="138" r="4" fill="none" stroke="var(--accent)"/>
+  <text x="140" y="142" fill="currentColor" font-size="9">capture B: no lock, demod SNR ≈ 9.5 dB — same meter reading</text>
+  <line x1="86" y1="118" x2="94" y2="118" stroke="var(--fg-muted)"/>
+  <text x="80" y="116" text-anchor="end" fill="var(--fg-muted)" font-size="10">−45</text>
+  <text x="100" y="108" fill="var(--fg-muted)" font-size="10">idle: antenna hears only the noise floor</text>
+  <line x1="86" y1="186" x2="94" y2="186" stroke="var(--fg-muted)"/>
+  <text x="80" y="190" text-anchor="end" fill="var(--fg-muted)" font-size="10">−75</text>
+  <text x="100" y="190" fill="var(--fg-muted)" font-size="10">dead chain — the unusable DMR capture from Part 1 lives here</text>
+  <text x="340" y="222" text-anchor="middle" fill="var(--fg-muted)" font-size="10">dBFS places you on this ladder and nothing more — quality lives in demod SNR, error rate, and CRC yield</text>
+</svg>
+<figcaption>The dBFS ladder with its anchors — and the #764 twins at −48 dBFS, identical on this meter and 10 dB apart in usable signal.</figcaption>
+</figure>
+
+## The regime table
+
+What to do with a reading, from the top of the ladder down:
+
+| `iq_power_dbfs` reads… | Likely condition | Action |
+|---|---|---|
+| above −3 | clipping — the ADC is saturated | reduce gain or add attenuation *now*; never raise gain (Part 4) |
+| −3 to −15 | hot; RMS may hide peak clipping | check `iq_clip_ratio`; if sustained > ~0.002, back the gain off |
+| −15 to −35 | the healthy band (anchor: −25) | leave it alone; judge by decode quality, not by pushing level higher |
+| −35 to −55 | workable but lean — both #764 captures peaked ≈ −48 here | fine *if* it decodes; if not, the deficit is SNR, not headroom — sweep gain against decode quality (Part 3), then look at antenna and rate (Parts 5–7) |
+| −55 to −70 | very weak; decoders will be marginal | more signal, not more software: gain staging first, then antenna/LNA (Parts 7, 9) |
+| below −70 | effectively dead: no antenna, gain 0, broken coax | fix the chain before reading anything else — no capture from here answers any question |
+
+Two habits complete the table. First, always read the clip ratio *with* the
+power gauge — the pair is designed as an instrument, and either one alone can
+mislead. Second, treat the healthy band as a plateau, not a slope: once
+you're clear of both the noise floor and the rails, adding level buys nothing
+and eventually costs plenty. The
+[SDR gain & overload]({{ '/reference/sdr-gain-overload/' | relative_url }})
+Field Guide entry condenses this into one page you can keep open.
+
+## Where this goes next
+
+If dBFS is a headroom meter, what should you actually *turn the gain knob*
+against? [Part 3]({{ '/blog/tutorials/analog-edge-03-gain-staging/' | relative_url }})
+answers with a cautionary tale from the tracker — an operator who raised
+front-end gain 17 dB to push a reading 0.2 dB past a software constant — and
+the method that replaces threshold-chasing entirely: sweep the ladder and
+score each rung by decode quality, the way `AutoGainSweep` does it.
+
+## FAQ
+
+**Is a stronger dBFS reading always better?**
+No. Between the noise floor and the rails there is a wide plateau where level
+changes decode quality not at all, and above it every extra dB eats headroom
+until peaks clip. The gauges' anchors — healthy ≈ −25, clipping > −3 — bracket
+that plateau. Once you're on it, the knob that matters is covered in Part 3,
+and it isn't level.
+
+**My waterfall looks strong but nothing decodes. How?**
+Because an FFT display and a decoder measure different things. A carrier can
+be tall in the spectrum while its *modulation* is degraded — by phase noise,
+intermod, or multipath — and #764 is the canonical case: the wideband FFT
+carrier SNR was actually *higher* in the capture that failed. Trust demod SNR
+and error rate over any picture of the band.
+
+**What's a normal reading with no antenna connected?**
+The gauge should drop toward its idle anchor or below — you're measuring the
+receiver's own noise. If it doesn't move when you disconnect the antenna,
+you were never measuring the antenna in the first place: suspect a stuck
+gain stage, a strong local interferer getting in past the connector, or a
+mislabeled device.
+
+**Why does GopherTrunk use RMS for the gauge instead of peak?**
+RMS over a ~1 s window is stable enough to alert on and matches how energy
+(and therefore SNR) accumulates. Peak alone is jumpy and dominated by single
+samples. The design splits the job: RMS for level, and a dedicated clip ratio
+for the rail — the one question where peaks are exactly what matters.
+
+**Does dBFS relate to dBm?**
+Only through your entire gain chain. dBm is absolute power at a reference
+point; dBFS is relative to one converter's full scale, after antenna, coax,
+LNA, and tuner gain have all had their say. Change any of them and the same
+dBm at the antenna lands at a different dBFS. That's why this series treats
+dBFS as a *staging* instrument, never a field-strength meter.
+
+## Series navigation
+
+**Part 2 of 14** · ←
+[Part 1: Where the Software Ends]({{ '/blog/tutorials/analog-edge-01-where-software-ends/' | relative_url }})
+· Next →
+[Part 3: Gain Staging — Never Chase a Software Threshold]({{ '/blog/tutorials/analog-edge-03-gain-staging/' | relative_url }})

--- a/docs/_posts/2026-08-19-tetra-end-to-end-02-bursts-slot-grid.md
+++ b/docs/_posts/2026-08-19-tetra-end-to-end-02-bursts-slot-grid.md
@@ -1,0 +1,327 @@
+---
+title: "TETRA End to End, Part 2: The Burst Zoo & the Slot Grid"
+description: How GopherTrunk finds structure in the 18000-dibit-per-second TETRA firehose — the synchronisation and normal downlink bursts, the three training sequences that mark them, the 255-dibit slot grid, and the one-slot anchor shift that silently misfiles every traffic burst when you get it wrong.
+category: deep-dives
+keywords: tetra burst structure, synchronisation burst sb, normal continuous downlink burst, tetra training sequences, tetra slot grid, tetra sync pdu, tetra multiframe, bsch colour code zero, ndbsbslotshift, gophertrunk tetra
+tags: [tetra-end-to-end, tetra, framing, tdma, sync, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "TETRA End to End"
+series_part: 2
+---
+
+*Part 2 of **TETRA End to End**, a 14-part deep dive into how GopherTrunk turns
+one real 25 kHz TETRA carrier — the MCC 250 / MNC 13 cell — into clear recorded
+voice. [Part 1]({{ '/blog/deep-dives/tetra-end-to-end-01-pi4-dqpsk-carrier/' | relative_url }})
+turned IQ into a dibit stream and planted
+the property everything leans on: information rides in phase transitions, so a
+residual carrier offset shows up as a constant 0..3 rotation of every dibit.
+Now we need punctuation. A TETRA downlink is a continuous stream of bursts on a
+rigid TDMA grid, and this part is about how GopherTrunk finds them: which burst
+carries what, how the training sequences are correlated, and the one-slot
+anchor lesson — `ndbSBSlotShift` — that only a real capture could teach.*
+
+> **TL;DR:** The TMO downlink alternates two burst shapes. The
+> **synchronisation burst (SB)** lays out freq-correction → **BSCH**(60
+> dibits) → sync training sequence(19) → broadcast(15) → **BNCH**(108); the
+> BSCH is always scrambled with colour 0, so a cold receiver can decode its
+> **SYNC PDU** (`tetra.ParseSyncPDU`) and learn the cell's colour code, frame
+> and multiframe counts. The **normal continuous downlink burst (NCDB)** puts
+> its data *around* the training sequence — BKN1 before, AACH halves either
+> side, BKN2 after (`internal/radio/tetra/traffic.go`). Bursts are found by
+> correlating three real ETSI training sequences under **all four dibit
+> rotations** (`SyncDetector`). The SB anchors the **255-dibit slot grid**,
+> but its training sequence sits late in the burst, so the anchor lands **one
+> NDB slot early** — `ndbSBSlotShift = 3` corrects it, verified against a real
+> same-carrier capture where grant timeslots finally lined up with decoded
+> slots.
+
+**Key takeaways**
+
+- **Two bursts carry the whole downlink.** SB for acquisition (BSCH + BNCH
+  around the long sync training sequence), NCDB for everything else (signalling
+  and traffic around the short normal training sequence).
+- **The BSCH is the bootstrap.** Scrambled with colour 0 by spec, it decodes
+  with zero configuration and hands over the colour code that unlocks every
+  other logical channel — Part 4 is entirely about that handoff.
+- **Correlation, not magic constants.** The training sequences are the real
+  EN 300 392-2 §9.4.4.3 bit arrays; placeholder constants once made lock
+  impossible on air, a postmortem told in
+  [From the Issue Tracker Part 17]({{ '/blog/solution-postmortem/from-the-issue-tracker-17-placeholder-constants/' | relative_url }}).
+- **The slot grid is anchored, and the anchor has an offset.** A burst's slot
+  number is `round((L − sbAnchor)/255)` — plus a shift of 3, because the SB's
+  training sequence position and the NDB's differ inside the slot. Get that
+  wrong and every burst files under the wrong timeslot with no error anywhere.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| Training sequences | real §9.4.4.3 bit arrays: NTS1/NTS2 (22b), extended (30b), STS (38b) | `internal/radio/tetra/sync.go` (`NormalTrainingSeq1`, `SyncTrainingSeq`) |
+| Sliding correlator | pattern match within tolerance, all four rotations | `sync.go` (`SyncDetector`, `rotateDibits`) |
+| SB geometry | BSCH `[L−60, L)`, BNCH `[L+34, L+142)` around the STS | `internal/radio/tetra/process.go` (`processSB`, `sbBSCHDibits`) |
+| NCDB geometry | BKN1 `[L−115, L−7)`, AACH halves, BKN2 `[L+19, L+127)` | `internal/radio/tetra/traffic.go`, `downlink.go` (`downlinkNCDB`) |
+| SYNC PDU | colour, TN/FN/MN, MCC/MNC from the BSCH | `internal/radio/tetra/sync_pdu.go` (`ParseSyncPDU`) |
+| Slot grid anchor | SB pins slot 1; each slot is 255 dibits | `traffic.go` (`slotOf`, `ndbSBSlotShift`) |
+
+## In this post
+
+- **The burst zoo** — SB and NCDB, and what each block inside them carries.
+- **Finding a burst** — three training sequences, four rotations, one detector shape.
+- **The SYNC PDU** — the bootstrap message a cold receiver can always read.
+- **The slot grid** — 255 dibits per slot, and time as frames and multiframes.
+- **The anchor lesson** — why the SB pins the grid one slot early.
+
+## The burst zoo
+
+TETRA numbers its downlink physical layer around two burst shapes, both 255
+dibits of slot but organised very differently. The **synchronisation downlink
+burst (SB)** is the acquisition burst, transmitted in slot 1 of frame 18 of
+every multiframe. Its layout, in dibits relative to the leading dibit `L` of
+its 19-dibit synchronisation training sequence (STS):
+
+```go
+// internal/radio/tetra/process.go (shape) — SB geometry
+// freq-correction → BSCH(60) → STS(19) → broadcast(15) → BNCH(108).
+// Relative to the STS leading dibit L: BSCH is [L-60, L), BNCH is [L+34, L+142).
+const (
+    stsDibits         = 19  // SyncTrainingDibits length
+    sbBSCHDibits      = 60  // BSCH block 1 (120 type-5 bits)
+    sbBroadcastDibits = 15  // broadcast block between STS and BNCH
+    sbBNCHDibits      = 108 // BNCH block 2 (216 type-5 bits, SCH/HD-coded)
+)
+```
+
+The BSCH half carries the SYNC PDU (below); the BNCH half carries SYSINFO —
+the cell's main carrier, band and access parameters, channel-coded like any
+SCH/HD block.
+
+The **normal continuous downlink burst (NCDB)** carries everything else:
+signalling on the control channel, traffic on a voice carrier. Its defining
+quirk is that the data does not follow the training sequence — it *surrounds*
+it:
+
+```go
+// internal/radio/tetra/traffic.go (shape) — NCDB layout, dibits relative to L
+//  BKN1 (block 1) : [L-115, L-7)   108 dibits (216 type-5 bits)
+//  AACH half 1    : [L-7,   L)       7 dibits ( 14 bits)
+//  training seq   : [L,     L+11)   11 dibits ( 22 bits)
+//  AACH half 2    : [L+11,  L+19)    8 dibits ( 16 bits)
+//  BKN2 (block 2) : [L+19,  L+127)  108 dibits (216 type-5 bits)
+```
+
+Any decoder that slices "N dibits after the training sequence" — the natural
+first implementation — misses BKN1 entirely and starts reading mid-AACH. Both
+the control-channel slot decoder (`downlinkNCDB` in `downlink.go`) and the
+traffic extractor are therefore built as rolling buffers with *look-back*: a
+training-sequence hit is queued as pending until the buffer holds the full
+`[L−115, L+127)` span, then the blocks are sliced around it. The 30-bit AACH
+split across the midamble is the slot's address label — its access-assignment
+element says what the slot is carrying — and it becomes the demux key for
+concurrent calls in Part 5.
+
+## Finding a burst: three sequences, four rotations
+
+Bursts are located by correlating known training sequences against the dibit
+stream. GopherTrunk stores the real ETSI EN 300 392-2 §9.4.4.3 sequences as
+bit arrays — normal 1 and 2 at 22 bits / 11 dibits, extended at 30 / 15, and
+the synchronisation sequence at 38 / 19 — and `SyncDetector` slides each over
+the stream reporting matches within a mismatch tolerance. Two details carry
+the weight:
+
+- **All four rotations, always.** Part 1's residual-CFO rotation means the
+  pattern may arrive uniformly rotated by 0..3, so every detector bank is
+  built as `NewSyncDetector(rotateDibits(pattern, r), tol)` for `r = 0..3` —
+  eight detectors for the two normal sequences, four for the STS.
+- **NTS1 vs NTS2 is a signal, not a duplicate.** A burst whose midamble matches
+  the *second* normal training sequence is a stolen half-slot (STCH) — urgent
+  signalling displacing speech — and the traffic extractor tags it
+  (`pendingHit.stolen`) rather than treating it as a weaker NTS1 match.
+
+The constants themselves have a scar. The original implementation shipped
+placeholder `uint64` "hex" values that were both truncated and matched no spec
+value, so the control channel correlated against sequences that never existed
+on air — lock was structurally impossible, while every synthetic test (built
+from the same wrong constants) passed. That is this series' villain making an
+early appearance;
+[From the Issue Tracker Part 17]({{ '/blog/solution-postmortem/from-the-issue-tracker-17-placeholder-constants/' | relative_url }})
+does the full autopsy, and the
+[training-sequence reference]({{ '/reference/tetra-training-sequences/' | relative_url }})
+lists the corrected values.
+
+## The SYNC PDU: what a cold receiver can read
+
+The BSCH exists so a receiver with zero configuration can bootstrap. By
+§8.2.5.2 it is always scrambled with colour code 0 — every other channel uses
+the cell's colour — so its 60 decoded type-1 bits are readable before you know
+anything about the cell. GopherTrunk parses them with the osmo-tetra-compatible
+field layout:
+
+```go
+// internal/radio/tetra/sync_pdu.go (shape)
+type SyncPDU struct {
+    ColourCode uint8  // 6-bit colour code          (bits  4..9)
+    TN         uint8  // timeslot number            (bits 10..11)
+    FN         uint8  // frame number               (bits 12..16)
+    MN         uint8  // multiframe number          (bits 17..22)
+    MCC        uint16 // mobile country code        (bits 31..40)
+    MNC        uint16 // mobile network code        (bits 41..54)
+}
+```
+
+Three of those fields — MCC, MNC, ColourCode — combine into the 30-bit
+extended colour code that seeds the scrambler for everything else on the cell
+(`SyncPDU.ExtendedColourCode`, Part 4's subject). The other three are *time*:
+TETRA counts a 4-slot frame, an 18-frame multiframe, and a 60-multiframe
+hyperframe (§4.5.2), and the SYNC PDU tells you where in that hierarchy you
+are. The decoder uses MN advancement as its sync-continuity heartbeat: rather
+than log thousands of sync bursts, it logs once per multiframe on an MN change
+and flags gaps — a monotonically advancing MN is the difference between "lock"
+and "the correlator fired on noise," a distinction that pays for itself again
+on DMO in Part 11.
+
+## The slot grid: 255 dibits, four slots, 56.67 ms
+
+Under the bursts is arithmetic. One slot is 255 dibits (510 bits); four slots
+make a 1020-dibit frame, which at 18000 dibits/s is 56.67 ms. On a voice
+carrier all four slots can carry independent calls, so a burst's timeslot
+number matters: it decides which call's recording a speech frame belongs to.
+
+The traffic extractor derives the slot from the SB. Its STS detectors watch
+the stream, and each hit pins `sbAnchor`; a later burst leading at dibit `L`
+is then slot `round((L − sbAnchor)/255) mod 4`, with rounding absorbing small
+intra-slot jitter. The anchor refreshes on every SB — once per multiframe — so
+slow clock drift can't accumulate.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 210" width="680" height="210" role="img" aria-label="A TETRA downlink timeline divided into 255-dibit slots. A synchronisation burst in the first slot carries its training sequence late in the burst, and an arrow shows its detected position landing one slot before the frame's TN1 traffic burst; the ndbSBSlotShift constant of 3 realigns the grid so subsequent bursts read as timeslots 1 through 4.">
+  <line x1="20" y1="90" x2="660" y2="90" stroke="var(--fg-muted)"/>
+  <line x1="20" y1="130" x2="660" y2="130" stroke="var(--fg-muted)"/>
+  <g stroke="var(--fg-muted)">
+    <line x1="20" y1="90" x2="20" y2="130"/><line x1="148" y1="90" x2="148" y2="130"/>
+    <line x1="276" y1="90" x2="276" y2="130"/><line x1="404" y1="90" x2="404" y2="130"/>
+    <line x1="532" y1="90" x2="532" y2="130"/><line x1="660" y1="90" x2="660" y2="130"/>
+  </g>
+  <text x="84" y="115" text-anchor="middle" fill="currentColor" font-size="10">SB (frame 18)</text>
+  <text x="212" y="115" text-anchor="middle" fill="currentColor" font-size="10">TN1 traffic</text>
+  <text x="340" y="115" text-anchor="middle" fill="currentColor" font-size="10">TN2</text>
+  <text x="468" y="115" text-anchor="middle" fill="currentColor" font-size="10">TN3</text>
+  <text x="596" y="115" text-anchor="middle" fill="currentColor" font-size="10">TN4</text>
+  <text x="84" y="80" text-anchor="middle" fill="var(--fg-muted)" font-size="9">255 dibits per slot</text>
+  <!-- STS position late in SB -->
+  <rect x="112" y="92" width="20" height="36" fill="var(--accent)" opacity="0.35"/>
+  <text x="122" y="56" text-anchor="middle" fill="var(--accent)" font-size="9">STS detected here</text>
+  <line x1="122" y1="60" x2="122" y2="88" stroke="var(--accent)"/>
+  <polygon points="118,84 122,92 126,84" fill="var(--accent)"/>
+  <!-- NTS position of TN1 burst -->
+  <rect x="200" y="92" width="20" height="36" fill="currentColor" opacity="0.25"/>
+  <text x="210" y="150" text-anchor="middle" fill="var(--fg-muted)" font-size="9">NTS midamble of TN1</text>
+  <path d="M 122 168 Q 166 190 206 168" fill="none" stroke="var(--accent)"/>
+  <polygon points="200,166 210,166 204,175" fill="var(--accent)"/>
+  <text x="166" y="200" text-anchor="middle" fill="var(--accent)" font-size="10">raw anchor lands one NDB slot early — ndbSBSlotShift = 3 (≡ −1 mod 4) realigns TN1</text>
+</svg>
+<figcaption>The SB anchors the 255-dibit slot grid, but its training sequence sits late in the burst — the detected anchor lands one NDB slot before TN1's midamble, and the shift constant absorbs the offset.</figcaption>
+</figure>
+
+## The anchor lesson: `ndbSBSlotShift`
+
+Here is the part no spec diagram hands you. The SB's training sequence is not
+where the NDB's is: the STS sits *late* in the SB (after the frequency
+correction and the whole BSCH block), while the NDB's midamble sits at the
+slot's centre. So the raw subtraction `(L − sbAnchor)/255` produces slot
+numbers that are internally consistent but globally off by one — every burst
+one slot after the SB reads as slot 0 instead of TN1.
+
+```go
+// internal/radio/tetra/traffic.go (shape) — slotOf
+const ndbSBSlotShift = 3 // (= −1 mod 4): a burst one slot after the anchor reads as TN1
+
+func (te *TrafficExtractor) slotOf(L int) uint8 {
+    if !te.haveAnchor {
+        return 0 // unknown until an SB is seen
+    }
+    si := (int(math.Round(float64(L-te.sbAnchor)/float64(ndbSlotDibits))) + ndbSBSlotShift) % 4
+    /* … */
+    return uint8(si) + 1
+}
+```
+
+What makes this a *lesson* rather than a constant is how it fails and how it
+was fixed. A wrong shift produces no error at any layer: the bursts decode,
+the CRCs pass, and every speech frame files under a mislabeled timeslot —
+which on a multi-call carrier means calls swap audio. Nothing synthetic
+catches it, because a synthetic fixture built from your own slot math is
+self-consistent by construction (the villain again). The value 3 was verified
+the only way it could be: against a reporter's real same-carrier capture,
+where the control channel's granted timeslots (`ts1`, `ts2`) finally lined up
+with the decoded slot tags once the shift was applied. And even then the code
+treats the slot number with suspicion — the doc comment in `traffic.go` is
+blunt that on real air the *AACH usage marker* is the reliable per-call demux
+key while the slot number is telemetry, a distinction Part 5 turns into
+routing.
+
+### How that principle shaped the Go code
+
+- **Geometry is a named constant set, not inline arithmetic.** `ndbBKN1Start`,
+  `ndbAACH1Start`, `sbBSCHDibits` and friends make each burst's layout a
+  reviewable table against the spec — and made the DMO geometry variant
+  (Part 11) a diff instead of a rewrite.
+- **Look-back is a buffer-management contract.** Both NCDB decoders keep a
+  trailing margin (`ndbTrimMargin`) plus any pending hit's look-back, so a
+  training hit near a chunk boundary never loses its BKN1.
+- **Anchoring is refreshed, never trusted forever.** The SB anchor updates
+  every multiframe and reports slot 0 ("unknown") until first seen — a
+  traffic-only carrier with no SB degrades to unlabeled bursts rather than
+  invented slots.
+
+## Where this goes next
+
+We can now slice a burst's 216 or 432 type-5 bits out of the stream — but
+type-5 bits are still scrambled, interleaved, punctured and convolved.
+[Part 3]({{ '/blog/deep-dives/tetra-end-to-end-03-channel-coding-crc/' | relative_url }})
+walks the channel-coding chain back to information bits: two RCPC mother
+codes, the Viterbi decoder, the interleavers — and the star exhibit, a CRC
+that is not an LFSR at all, whose wrong implementation silently dropped every
+on-air burst while all the synthetic tests stayed green.
+
+## FAQ
+
+**Why does the data surround the training sequence instead of following it?**
+A midamble halves the maximum distance between any data bit and the channel
+estimate the training sequence provides — both blocks sit within ~half a slot
+of it. It also means burst detection is naturally centred: once the midamble
+correlates, both blocks are at fixed offsets either side.
+
+**What happens between SBs — is the receiver blind for a whole multiframe?**
+No. The SB is only the *anchor and bootstrap*; every slot in between carries
+NCDBs the receiver decodes continuously. The once-per-multiframe cadence only
+bounds how often the slot-grid anchor and MN counter refresh.
+
+**Can the receiver lock without ever decoding a BSCH?**
+It can correlate training sequences and extract bursts, but it can't
+*descramble* anything beyond the BSCH itself without the colour code the SYNC
+PDU carries — so a "lock" without a BSCH decode is sync without comprehension.
+That failure mode (lock succeeds, no messages decode) is exactly what a broken
+scrambler looks like, and Part 4 tells that story twice.
+
+**Why tolerance-based correlation instead of exact match?**
+Real bursts arrive with bit errors, and an exact match would drop a burst
+whose midamble took one hit even though its FEC-protected payload is fully
+recoverable. The tolerances (2 for the 11-dibit normal sequences, 3 for the
+19-dibit STS) trade a manageable false-hit rate — the downstream CRCs reject
+impostors — for not losing marginal bursts. Part 13 shows what that false-hit
+rate means on a *silent* channel, and why counting raw hits is never evidence
+of traffic.
+
+**How does GopherTrunk know a burst is a stolen half-slot?**
+By which normal training sequence matched: NTS2 flags STCH (stolen) bursts,
+NTS1 marks ordinary ones. The extractor counts stolen bursts
+(`TrafficExtractor.StolenBursts`) so the composer's voice-path summary can
+report signalling-in-speech events.
+
+## Series navigation
+
+**Part 2 of 14** · ←
+[Part 1: π/4-DQPSK & the Shape of a TETRA Carrier]({{ '/blog/deep-dives/tetra-end-to-end-01-pi4-dqpsk-carrier/' | relative_url }})
+· Next →
+[Part 3: Channel Coding — RCPC, Viterbi & the CRC That Isn't an LFSR]({{ '/blog/deep-dives/tetra-end-to-end-03-channel-coding-crc/' | relative_url }})

--- a/docs/_posts/2026-08-19-weak-signal-engineering-02-metrics-that-lie.md
+++ b/docs/_posts/2026-08-19-weak-signal-engineering-02-metrics-that-lie.md
@@ -1,0 +1,296 @@
+---
+title: "Weak-Signal Engineering, Part 2: Metrics That Lie — EVM vs CRC Yield"
+description: Why error vector magnitude, wideband carrier SNR, and constellation beauty can all improve while a decoder recovers nothing — the equalizer whose EVM collapsed 34% to 8% with CRC stuck at zero, the #764 capture whose carrier SNR was higher on the worse file, and the short list of numbers you can actually trust.
+category: deep-dives
+keywords: evm trap, error vector magnitude, crc yield, decode yield metric, blind equalizer evm, wideband carrier snr, in-channel snr measurement, constellation quality, gophertrunk weak-signal engineering
+tags: [weak-signal-engineering, evm, metrics, dsp, tetra, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Weak-Signal Engineering"
+series_part: 2
+---
+
+*Part 2 of **Weak-Signal Engineering**, a 14-part deep dive into decoding the
+marginal regime — where a receiver locks but under-decodes, and four levers
+roughly doubled GopherTrunk's yield.
+[Part 1]({{ '/blog/deep-dives/weak-signal-engineering-01-marginal-regime/' | relative_url }})
+defined that regime and introduced the thread capture: a ~10 dB TETRA control
+channel that locks and decodes ~12% of its BSCH. Before we touch a single
+equalizer tap, this part fixes the measurement problem — because two of the
+most natural quality metrics in DSP have already, on this project, pointed
+confidently in the wrong direction. If the verdict number is wrong, every
+lever after it optimizes the wrong thing.*
+
+> **TL;DR:** **EVM is a trap in front of a blind equalizer, and wideband
+> carrier SNR is a trap in front of a phase-noise problem.** A
+> numerically-unstable CMA variant once drove differential EVM from **34% to
+> 8%** — textbook "constellation opened" — while CRC-valid frames stayed at
+> **zero**: blind CMA minimises *modulus error*, not *correctness*, and it has
+> spurious constant-modulus minima that look gorgeous and carry nothing. In
+> [#764](https://github.com/MattCheramie/GopherTrunk/issues/764), the capture
+> that decoded *worse* had the *higher* wideband FFT carrier SNR — carrier-clean
+> but modulation-degraded is the signature of reciprocal mixing. The numbers to
+> trust, in order: **CRC-valid frames per opportunity** (the verdict), then
+> demod-side in-channel SNR (advisory), then everything else (scenery). Rule of
+> the series: *never conclude an equalizer helps from EVM; decode to CRC.*
+
+**Key takeaways**
+
+- **Every metric is an answer to a specific question — and usually not yours.**
+  EVM answers "how far are symbols from the ideal grid?"; a decoder asks "were
+  the bits right?". Those correlate on well-behaved channels and diverge
+  exactly when you're doing something interesting.
+- **A blind equalizer can optimize the metric instead of the signal.** CMA's
+  cost is constant modulus; an output that is perfectly constant-modulus and
+  perfectly wrong scores perfectly. The 34%→8%-with-CRC-0 incident is pinned in
+  the `SnapshotLMS` doc comment so nobody re-learns it.
+- **Where you measure matters as much as what.** #764's wideband FFT said the
+  10 MS/s capture was *cleaner*; the in-channel demod said it was 10 dB worse.
+  Both were right — about different bandwidths.
+- **Yield needs a denominator.** "778 CRC-valid bursts" means nothing without
+  the opportunity count; GopherTrunk's harnesses always report `ok` and `fail`
+  together, and the ratio is the number.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| EVM, measured properly | reference-grid error vs ideal constellation | Signal Lab VSA — [signal-lab-07]({{ '/blog/tutorials/signal-lab-07-vsa-evm-modulation-quality/' | relative_url }}), [`/reference/error-vector-magnitude/`]({{ '/reference/error-vector-magnitude/' | relative_url }}) |
+| The EVM-trap record | doc-comment history: EVM 34%→8%, CRC 0 | `internal/dsp/equalizer/snapshot_lms.go` (package doc) |
+| What CMA optimizes | error proxy `\|y\|² − R²`, not bit correctness | `internal/dsp/equalizer/cma.go` (`Process`) |
+| The verdict harness | CRC-clean BSCH counts, one variable isolated | `internal/scanner/ccdecoder/pipelines_tetra_equalizer_test.go` (`decodeCCBSCHYield`) |
+| Voice-path verdict | CRC-valid TCH/S per burst opportunity | `internal/radio/tetra/tch.go` (`DecodeTCHSSoft` → `crcOK`) |
+| The carrier-SNR trap | wideband-clean, in-channel-degraded (#764) | `internal/scanner/ccdecoder/ddc_highrate_test.go` |
+
+## In this post
+
+- **What EVM actually measures** — and the assumptions riding along.
+- **Beauty with zero truth** — the equalizer that polished a corpse.
+- **The carrier-SNR trap** — #764's cleaner-but-worse capture.
+- **The numbers you can trust** — a short, ordered list.
+- **Instrumenting for yield** — what the harnesses report and why.
+
+## What EVM actually measures
+
+[Error vector magnitude]({{ '/reference/error-vector-magnitude/' | relative_url }})
+is the RMS distance between your received symbols and the nearest ideal
+constellation points, normalised to the constellation's scale. It is a fine
+instrument — [Signal Lab's VSA]({{ '/blog/tutorials/signal-lab-07-vsa-evm-modulation-quality/' | relative_url }})
+computes it, and on a *cooperative* signal it tracks decode quality closely
+enough that lab equipment vendors quote sensitivity in EVM.
+
+But look at what the definition smuggles in. EVM assumes the "nearest ideal
+point" is the *transmitted* point — that your symbols are merely perturbed, not
+relabeled. It assumes the reference grid itself is right: correct phase,
+correct scale, correct decision boundaries. On a marginal channel, after an
+adaptive stage that is allowed to rotate, scale, and reshape the signal, every
+one of those assumptions is up for negotiation. A symbol that lands crisply on
+the *wrong* ideal point contributes almost nothing to EVM and everything to the
+bit error rate. EVM measures *tidiness*. Decoders consume *identity*.
+
+On a differential modulation like
+[π/4-DQPSK]({{ '/reference/pi-4-dqpsk/' | relative_url }}) there's a further
+subtlety: you can compute EVM on the differentials (the `s·conj(prev)`
+products) rather than the raw symbols, which conveniently cancels any constant
+rotation. GopherTrunk's equalizer experiments did exactly that — and it still
+lied, which is the story that gives this post its title.
+
+## Beauty with zero truth
+
+The incident is preserved, deliberately, in the doc comment of the *trained*
+equalizer — because it is the reason the trained equalizer exists:
+
+```go
+// internal/dsp/equalizer/snapshot_lms.go (shape) — package history
+// CMA's cost J = E[(|y|²−R²)²] is satisfied by any equalizer output that has
+// the right modulus, so it has spurious minima and can converge to a
+// constant-modulus but WRONG solution — the failure the package history
+// records (a numerically-unstable CMA once drove differential EVM 34%→8%
+// while CRC stayed 0). Training to a known reference removes that ambiguity…
+```
+
+Unpack what happened. A blind CMA variant — since replaced — was inserted ahead
+of the TETRA differential decoder and evaluated the obvious way: measure
+differential EVM before and after. Before: 34%, a smeared mess. After: 8%,
+which for π/4-DQPSK is a genuinely clean-looking constellation. Anyone
+grading on appearance ships that change. But the CRC-valid frame count on the
+same capture was **zero**. Not reduced — zero. The equalizer had found an
+output that satisfied its cost function beautifully: constant modulus, tight
+clusters, and a time-varying relationship to the transmitted symbols that
+destroyed every single dibit on its way through the differential decode.
+
+The mechanism has two halves, and the series treats each in its own part.
+First, CMA's cost `J = E[(|y|² − R²)²]` genuinely does not mention
+correctness — any constant-modulus output is a candidate minimum, including
+spurious ones (Part 4). Second, an *adapting* filter in front of a
+*differential* decoder injects a time-varying phase that no differential can
+cancel (Part 5). Either half alone can make EVM improve while yield dies. The
+one-line lesson entered the project's permanent vocabulary: **never conclude an
+equalizer helps from EVM; decode to CRC.**
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 220" width="680" height="220" role="img" aria-label="Two panels compare metrics on the same capture. The left panel shows two constellations: a smeared one labeled before with EVM thirty-four percent, and a tight clean one labeled after with EVM eight percent — the metric says the equalizer helped. The right panel shows the verdict metric: a bar chart of CRC-valid frames, with the baseline bar small but nonzero and the after bar at exactly zero. The pretty constellation decoded nothing.">
+  <text x="170" y="18" text-anchor="middle" fill="currentColor" font-size="11">what EVM saw</text>
+  <text x="510" y="18" text-anchor="middle" fill="currentColor" font-size="11">what the CRC saw</text>
+  <circle cx="90" cy="90" r="52" fill="none" stroke="var(--fg-muted)"/>
+  <g fill="var(--fg-muted)">
+    <circle cx="122" cy="62" r="3"/><circle cx="105" cy="52" r="3"/><circle cx="66" cy="55" r="3"/><circle cx="55" cy="78" r="3"/>
+    <circle cx="52" cy="112" r="3"/><circle cx="78" cy="130" r="3"/><circle cx="115" cy="124" r="3"/><circle cx="128" cy="98" r="3"/>
+    <circle cx="98" cy="70" r="3"/><circle cx="72" cy="95" r="3"/><circle cx="95" cy="115" r="3"/><circle cx="112" cy="85" r="3"/>
+  </g>
+  <text x="90" y="164" text-anchor="middle" fill="var(--fg-muted)" font-size="9">before: EVM 34%</text>
+  <line x1="160" y1="90" x2="185" y2="90" stroke="currentColor"/><polygon points="185,86 195,90 185,94" fill="currentColor"/>
+  <circle cx="255" cy="90" r="52" fill="none" stroke="var(--fg-muted)"/>
+  <g fill="var(--accent)">
+    <circle cx="292" cy="53" r="3"/><circle cx="291" cy="55" r="3"/>
+    <circle cx="218" cy="53" r="3"/><circle cx="220" cy="55" r="3"/>
+    <circle cx="218" cy="127" r="3"/><circle cx="220" cy="125" r="3"/>
+    <circle cx="292" cy="127" r="3"/><circle cx="290" cy="125" r="3"/>
+    <circle cx="255" cy="38" r="3"/><circle cx="255" cy="142" r="3"/>
+    <circle cx="203" cy="90" r="3"/><circle cx="307" cy="90" r="3"/>
+  </g>
+  <text x="255" y="164" text-anchor="middle" fill="var(--accent)" font-size="9">after: EVM 8% — “fixed”</text>
+  <line x1="60" y1="200" x2="640" y2="200" stroke="var(--fg-muted)"/>
+  <rect x="440" y="120" width="60" height="60" fill="var(--fg-muted)"/>
+  <text x="470" y="196" text-anchor="middle" fill="var(--fg-muted)" font-size="9">baseline yield</text>
+  <rect x="560" y="179" width="60" height="1" fill="currentColor"/>
+  <text x="590" y="196" text-anchor="middle" fill="currentColor" font-size="9">after: CRC = 0</text>
+  <text x="530" y="110" text-anchor="middle" fill="currentColor" font-size="10">CRC-valid frames</text>
+</svg>
+<figcaption>The same change, two metrics: EVM collapsed 34% → 8% and declared victory; the CRC-valid frame count went to zero. Tidiness is not identity.</figcaption>
+</figure>
+
+## The carrier-SNR trap
+
+EVM is not the only metric with a blind spot.
+[#764](https://github.com/MattCheramie/GopherTrunk/issues/764) — the
+investigation the
+[Ten Megasamples postmortem]({{ '/blog/solution-postmortem/from-the-issue-tracker-05-ten-megasamples/' | relative_url }})
+narrates in full — turned on a pair of captures of the same site: one at
+2.5 MS/s that locked cleanly (demod SNR ≈19.7 dB, EVM 7.4%), one at 10 MS/s
+that never locked (≈9.5 dB, EVM 22.5%). The natural first move was a wideband
+FFT of both files to compare signal quality — and the FFT said the 10 MS/s
+capture had the *higher* carrier SNR. Cleaner file, by that measurement.
+Worse decode, by 10 dB.
+
+Both measurements were correct. A wideband FFT bin integrates the carrier's
+*power* against the noise floor around it; it is nearly blind to energy that
+stays close to the carrier. Oscillator phase noise — in that case, reciprocal
+mixing at the Airspy's native 10 MS/s clock — smears energy from the carrier
+onto its own modulation sidebands. Carrier-clean but modulation-degraded is
+that mechanism's exact signature, and only an *in-channel, demod-side*
+measurement sees it, because only the demodulator asks the question at the
+bandwidth where the damage lives. The proof that the deficit was baked into
+the samples (an independent 4:1 decimation replayed through the proven
+2.5 MS/s path reproduced the same ≈9.5 dB) is Part 12's subject; the metric
+lesson stands alone: **a measurement made in the wrong bandwidth answers a
+different question, confidently.**
+
+## The numbers you can trust
+
+The series' working hierarchy, from verdict to scenery:
+
+| Rank | Metric | Role | Caveat |
+|---|---|---|---|
+| 1 | CRC-valid frames / opportunities | **the verdict** | needs an honest denominator |
+| 2 | Payload bit-error rate vs known truth | verdict, synthetic only | only where truth is known (tests) |
+| 3 | In-channel demod SNR | advisory — places you on Part 1's cliff | not a verdict; measure post-channel-filter |
+| 4 | EVM | advisory — useful on *unprocessed* signals | never after a blind adaptive stage |
+| 5 | Wideband carrier SNR, dBFS | scenery — capture hygiene | blind to phase noise, says nothing about decode |
+
+Two design notes on rank 1. First, the *opportunity* count has to be honest:
+counting CRC passes per *detected* burst lets a change that suppresses burst
+detection look like a yield improvement. GopherTrunk's harnesses count
+`ok` and `fail` from the same detector so the denominator can't be gamed by
+the thing under test. Second, CRC yield inherits the CRC's own false-positive
+floor — a 16-bit check passes garbage at ~1/65536 — which is negligible at
+healthy yields but worth remembering when a sweep reports single-digit counts:
+Part 8 and the DMO colour-recovery story both lean on *dominance* over that
+chance floor, not mere non-zero counts.
+
+## Instrumenting for yield
+
+The principle only bites if the code makes yield cheap to read. Three places
+it shows up, all of which later parts use as scoreboards:
+
+```go
+// internal/radio/tetra/tch.go (shape) — the per-burst verdict
+func DecodeTCHSSoft(type5LLR []float32) (frameA, frameB []byte, crcOK bool, errs float32, ok bool)
+```
+
+Every TCH/S decode returns `crcOK` alongside the speech frames — the composer
+and the replay harnesses tally it per opportunity, which is how "soft-decision
+410 → 778 bursts" was ever a statement anyone could make. The CC-side
+equivalent is `decodeCCBSCHYield` from Part 1, which returns `(ok, fail)`
+with exactly one boolean of configuration difference between the two arms.
+And the periodic `tetra: decode status` line carries the same counters into
+production logs (`bsch_fail`, `sb_bursts`, and friends), so an operator's
+debug log *is* a yield instrument — the ~210-transitions-per-hour session was
+diagnosed from those lines alone, before any capture was replayed.
+
+### How that principle shaped the Go code
+
+- **Verdict functions return their own denominator.** Decoders return
+  `crcOK`/`ok` per call rather than logging aggregate percentages, so any
+  caller — test, composer, status line — can build an honest ratio over
+  exactly the population it cares about.
+- **A/B harnesses isolate one boolean.** `decodeCCBSCHYield` mirrors the
+  production pipeline except for the single parameter under test, so a yield
+  delta is attributable to one change, not to drifted wiring.
+- **The trap is documented where you'd re-fall into it.** The EVM incident
+  lives in the `SnapshotLMS` doc comment — the exact place someone evaluating
+  a new equalizer will be reading when they're tempted to grade it by EVM.
+
+## Where this goes next
+
+With the measurement rules fixed, we can finally look at the enemy itself.
+[Part 3]({{ '/blog/deep-dives/weak-signal-engineering-03-isi-linear-channel/' | relative_url }})
+is about inter-symbol interference and the linear channel model `y = h∗x + n`:
+what multipath and band-edge group delay actually do to a constellation, which
+impairments are invertible and which are not — and the one domain fact
+(a linear channel is only a convolution over *raw* symbols, never over
+differentials) that quietly dictates the architecture of every equalizer in
+the rest of the series.
+
+## FAQ
+
+**Is EVM ever the right metric?**
+Yes — on signals that haven't passed through an adaptive stage that could game
+it. For grading a capture's raw modulation quality, comparing antennas, or
+watching a transmitter drift, [Signal Lab's VSA]({{ '/blog/tutorials/signal-lab-07-vsa-evm-modulation-quality/' | relative_url }})
+EVM is exactly the tool. The rule is scoped: EVM must not be the *verdict on a
+decode-chain change*, because decode-chain changes can optimize it directly.
+
+**Why does CRC yield beat bit-error rate as the field verdict?**
+Because on-air you don't know the transmitted bits, so you can't count bit
+errors — the CRC is the only ground truth the air gives you. In synthetic
+tests, where truth is known, GopherTrunk does use payload bit-error
+(Part 7's 13% → 0% result is exactly that); the two verdicts are used where
+each is available.
+
+**Couldn't a change also game the CRC metric?**
+Only by actually decoding correctly — which is the point of using it. The two
+gameable edges are the denominator (fixed by counting opportunities from the
+same detector) and the CRC's chance floor (~1/65536 for a 16-bit check), which
+matters only for near-zero counts and is why marginal sweeps demand dominance,
+not presence.
+
+**What's "demod SNR" versus the FFT SNR my waterfall shows?**
+The waterfall number is carrier power over the noise floor in FFT-bin
+bandwidth — a wideband, pre-demod view. Demod SNR is estimated inside the
+decode chain, in the channel bandwidth, after filtering — it sees everything
+the decoder sees, including phase noise folded onto the modulation. #764 is
+the canonical case where they disagree by design.
+
+**Do I need special builds to read yield on my own system?**
+No. The TETRA decode-status debug line carries the burst and failure counters,
+and every capture-replay harness prints its `ok/fail` tallies. If you can
+reproduce a symptom in a capture, you already have a yield instrument —
+which is why the auto-recorders exist.
+
+## Series navigation
+
+**Part 2 of 14** · ←
+[Part 1: The Marginal Regime]({{ '/blog/deep-dives/weak-signal-engineering-01-marginal-regime/' | relative_url }})
+· Next →
+[Part 3: ISI & the Linear Channel — What an Equalizer Can & Can't Fix]({{ '/blog/deep-dives/weak-signal-engineering-03-isi-linear-channel/' | relative_url }})

--- a/docs/_posts/2026-08-20-analog-edge-03-gain-staging.md
+++ b/docs/_posts/2026-08-20-analog-edge-03-gain-staging.md
@@ -1,0 +1,268 @@
+---
+title: "The Analog Edge, Part 3: Gain Staging — Never Chase a Software Threshold"
+description: How to set SDR front-end gain the measured way — the operator who raised gain 17 dB to clear a software constant by 0.2 dB, the ladder method scored by decode quality, autogain's lock-then-error-rate-then-lower-gain tie-break, and the tenths-of-a-dB config trap.
+category: tutorials
+keywords: sdr gain staging, rtl-sdr gain setting, gain sweep decode quality, agc vs manual gain, tenths of a db, gain config trap, front end headroom, autogain sweep, gophertrunk analog edge
+tags: [analog-edge, gain, sdr, configuration, front-end, tutorial]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "The Analog Edge"
+series_part: 3
+---
+
+*Part 3 of **The Analog Edge**, a 14-part field guide to the analog half of a
+GopherTrunk installation. [Part 2]({{ '/blog/tutorials/analog-edge-02-dbfs/' | relative_url }})
+established dBFS as a headroom meter and nothing more — which leaves our
+reader with the marginal system holding a gain knob and no target to turn it
+toward. This part gives them one, by way of the tracker's best cautionary
+tale: an operator who cranked real RF gain to satisfy an arbitrary software
+constant, and what GopherTrunk changed so nobody ever has to do that again.
+The rule this part plants: gain is staged against decode quality, and any
+absolute threshold you find yourself chasing is a trap.*
+
+> **TL;DR:** An operator once raised front-end gain from **65.0 to 82.0 dB**
+> so a branch would read **−39.8 dBFS** and clear a **−40 dBFS** software
+> gate — by 0.2 dB. Seventeen decibels of real RF strain to move a number
+> past a constant. That gate is gone (its replacement, a scale-invariant
+> coherence check, is Part 13's story). The right method is a **ladder
+> sweep scored by decoding**: `AutoGainSweep`
+> (`internal/hunt/autogain.go`) decodes a dwell at each gain and `pickGain`
+> chooses by **lock first, then lowest error rate, then LOWER gain**. And
+> mind the config trap: GopherTrunk gain values are **tenths of a dB** —
+> `gain: "300"` is 30.0 dB, not 300.
+
+**Key takeaways**
+
+- **Any absolute-power gate is a gain-staging trap.** A threshold in dBFS
+  invites the operator to move the *number* instead of the *signal*, and the
+  same constant re-fires wrongly on the next front end. GopherTrunk now gates
+  DSP decisions on scale-invariant evidence instead.
+- **Sweep, don't reason.** The interaction between your antenna, your band,
+  and your tuner's gain ladder is empirical. Decode a short dwell at each
+  rung and let the error rate rank them.
+- **On a tie, take the lower gain.** Two gains that decode equally well are
+  not equally safe: the lower one leaves headroom before a strong neighbor
+  drives the front end into intermod — that preference is coded into
+  `pickGain`.
+- **The unit is tenths of a dB.** Coming from SDRTrunk/OP25/gqrx, multiply
+  your dB figure by ten. `gain: "496"` = 49.6 dB. This single conversion
+  error has produced entire bug reports.
+
+## Cheat sheet
+
+| Concern | What to do | Where it lives |
+|---|---|---|
+| Set gain in config | tenths of a dB, or `"auto"` for AGC | `sdr.devices[].gain` in `config.example.yaml` |
+| Discover the gain ladder | print each device's supported steps | `gophertrunk sdr list --probe` |
+| Sweep gains empirically | decode a dwell per rung, recommend one | `internal/hunt/autogain.go` (`AutoGainSweep`) |
+| Rank the rungs | lock → error rate → lower gain | `internal/hunt/autogain.go` (`pickGain`) |
+| Catch overload while sweeping | rail-pinned fraction, not RMS | `gophertrunk_sdr_iq_clip_ratio` (Part 2) |
+| The trap, in one page | tenths-of-dB + overload signatures | [SDR gain & overload]({{ '/reference/sdr-gain-overload/' | relative_url }}) |
+
+## In this post
+
+- **The 0.2 dB story** — seventeen decibels against a constant.
+- **Why absolute thresholds are traps** — and what replaced this one.
+- **The ladder method** — sweeping gain against decode quality.
+- **The tie-break that respects the front end** — `pickGain`'s ordering.
+- **The tenths-of-a-dB trap** — the config unit that bites migrators.
+- **AGC or fixed?** — the wideband shared-front-end rule.
+
+## The 0.2 dB story
+
+The diversity combiner used to gate its calibration on a simple check: the
+reference branch had to clear −40 dBFS before the gain estimate was trusted.
+Reasonable-sounding — don't calibrate on noise. But an operator with a
+healthy, decodable setup found diversity refusing to engage, read the code,
+and did the only thing the gate rewarded: raised the front-end gain from
+65.0 dB to 82.0 dB until the branch read −39.8 dBFS. They cleared the
+constant by 0.2 dB, at the price of 17 dB of added front-end strain —
+17 dB less headroom against every strong neighbor on the band, for zero
+improvement in the actual signal.
+
+Nothing about the RF was wrong. The *gate* was wrong, and it converted a
+software design flaw into an operator's gain problem. That's the defining
+signature of a gain-staging trap: the knob moves to satisfy the instrument
+instead of the signal.
+
+## Why absolute thresholds are traps
+
+The deep reason is the one Part 2 ended on: dBFS is relative to *this*
+converter behind *this* gain chain. A constant like −40 dBFS encodes an
+assumption about antenna, coax, LNA, tuner, and gain setting all at once —
+so it is wrong on every rig except the one it was tuned on, and it re-fires
+on the next front end forever. Any time you find yourself adjusting real RF
+gain to move a reading past a fixed number — a squelch you found in a config,
+a threshold you read in a forum post, a gate you found in source code — stop
+and ask what the threshold is a *proxy for*, and measure that instead.
+
+In GopherTrunk's case the question the gate was proxying was "is this gain
+estimate trustworthy?", and the honest answer is scale-invariant: the
+normalized cross-correlation between branches, which doesn't change when you
+turn the gain knob — the config comments say it outright: *raising gain to
+make diversity engage is never the answer*. That number, `|rho|` from
+`diversity.CrossStats`, is [Part 13]({{ '/blog/tutorials/analog-edge-13-coherence-not-dbfs/' | relative_url }})'s
+whole subject. Absolute power survives in that code for exactly one job —
+rejecting a digitally dead branch at −100 dBFS — because "the cable is
+unplugged" is the one condition a level *can* diagnose.
+
+## The ladder method
+
+So what do you turn the knob against? Decode quality, measured, per rung.
+Your tuner offers a discrete ladder of gains (print it with
+`gophertrunk sdr list --probe`); the interaction of that ladder with your
+antenna and your band is not something to reason about from first principles
+— it's something to *sweep*. The procedure, whether you run it by hand or
+let [autogain]({{ '/blog/deep-dives/the-hunt-05-autogain-autotune/' | relative_url }})
+do it:
+
+1. Pick the channel you actually care about — your control channel.
+2. At each gain rung, dwell a second or two and decode.
+3. Record: did it lock? what was the decode error rate? did anything clip
+   (`iq_clip_ratio`, not the RMS gauge)?
+4. Plot rung against error rate: you'll get the U-curve — errors high at low
+   gain (carrier buried in noise), a flat healthy bottom, errors rising again
+   at high gain (intermod from strong neighbors).
+5. Settle on the bottom of the U, biased toward its *low-gain* edge.
+
+The crucial discipline is step 3's scoring: decode quality, never level. A
+higher rung that lifts your carrier also lifts every neighbor and every
+intermod product; the level meter goes up while the decode gets worse. The
+sweep sees that; a power reading can't.
+
+## The tie-break that respects the front end
+
+GopherTrunk's automated version encodes the whole philosophy in one readable
+cascade. `AutoGainSweep` decodes a dwell at each rung through the same
+identify→decode path the live hunt uses, then `pickGain` ranks the outcomes:
+
+```go
+// internal/hunt/autogain.go (shape) — pickGain ordering
+b := scores[best]
+switch {
+case s.Locked != b.Locked:
+    if s.Locked { best = i }              // 1. a gain that LOCKS beats one that doesn't
+case s.ErrorRate != b.ErrorRate:
+    if s.ErrorRate < b.ErrorRate { best = i } // 2. lower decode error rate
+case s.GainTenthDB < b.GainTenthDB:
+    best = i                              // 3. lower gain (less front-end strain)
+}
+```
+
+Rule 3 is the one operators skip when staging by hand, and it's the one this
+series cares most about: **among gains that decode equally well, prefer the
+lower one.** The rungs at the bottom of the U are equal *today*; they are not
+equal the day a new pager transmitter lights up two channels over. The lower
+rung is carrying spare headroom against that day. Recommendations are
+advisory — the sweep applies nothing behind your back — so the number it
+hands you is a starting point you confirm, not a setting that moves itself.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 220" width="680" height="220" role="img" aria-label="A bar chart with a dashed horizontal gate line at minus 40 dBFS. A left bar at 65 dB gain reaches minus 43 dBFS, below the gate. A right bar at 82 dB gain reaches minus 39.8 dBFS, just above the gate. An arrow labelled plus 17 dB of real RF gain connects the bars, and a note explains the reading moved only 3.2 dB and the signal quality not at all — the gate, not the gain, was wrong.">
+  <line x1="60" y1="20" x2="60" y2="180" stroke="var(--fg-muted)"/>
+  <line x1="60" y1="180" x2="640" y2="180" stroke="var(--fg-muted)"/>
+  <text x="30" y="30" fill="var(--fg-muted)" font-size="9">dBFS</text>
+  <line x1="60" y1="70" x2="640" y2="70" stroke="var(--accent)" stroke-dasharray="6 4"/>
+  <text x="632" y="62" text-anchor="end" fill="var(--accent)" font-size="10">the −40 dBFS gate (a constant in software)</text>
+  <rect x="140" y="92" width="90" height="88" fill="none" stroke="currentColor"/>
+  <text x="185" y="86" text-anchor="middle" fill="currentColor" font-size="10">−43.0</text>
+  <text x="185" y="198" text-anchor="middle" fill="var(--fg-muted)" font-size="10">gain 65.0 dB</text>
+  <rect x="410" y="66" width="90" height="114" fill="none" stroke="var(--accent)"/>
+  <text x="455" y="60" text-anchor="middle" fill="var(--accent)" font-size="10">−39.8</text>
+  <text x="455" y="198" text-anchor="middle" fill="var(--fg-muted)" font-size="10">gain 82.0 dB</text>
+  <line x1="235" y1="120" x2="402" y2="120" stroke="currentColor"/><polygon points="402,116 410,120 402,124" fill="currentColor"/>
+  <text x="320" y="112" text-anchor="middle" fill="currentColor" font-size="10">+17 dB of real RF gain</text>
+  <text x="320" y="136" text-anchor="middle" fill="var(--fg-muted)" font-size="9">…to clear a constant by 0.2 dB — headroom spent, signal quality unchanged</text>
+  <text x="350" y="214" text-anchor="middle" fill="var(--fg-muted)" font-size="10">when a knob moves to satisfy a threshold instead of a signal, the threshold is the bug</text>
+</svg>
+<figcaption>The 0.2 dB story: 17 dB of front-end strain spent pushing a reading past a software constant. The constant was removed; the lesson stays.</figcaption>
+</figure>
+
+## The tenths-of-a-dB trap
+
+One more way gain goes wrong before the RF is even involved: the unit.
+GopherTrunk's `gain:` values are **tenths of a decibel**, matching the
+granularity real tuner ladders expose. From `config.example.yaml`:
+
+```yaml
+gain: "auto"   # TENTHS of a dB — NOT dB. "496" = 49.6 dB. SDRTrunk/
+               # OP25/gqrx users: multiply your dB figure by 10
+               # (32 dB → "320"). "auto" (AGC) is the safe default.
+```
+
+A migrator who carries `gain: "300"` over from a tool that means 300 tenths
+elsewhere gets 30.0 dB — or, in the other direction, someone intending 30 dB
+who writes `30` gets 3.0 dB and a dead-quiet capture. One of the tracker's
+documentation-scarred postmortems,
+[The LSM Myth]({{ '/blog/solution-postmortem/from-the-issue-tracker-07-lsm-myth/' | relative_url }}),
+pivots on exactly this: a system blamed on modulation modes for weeks, where
+the real fault was a gain value. Typical ladders for reference: RTL-SDR
+R820T 0–496, Airspy R2/Mini 0–500, HackRF One 0–560 — all in tenths, all
+printable with `--probe`.
+
+## AGC or fixed?
+
+For a single-channel dongle parked on one control channel, a fixed, swept-in
+gain is the predictable choice. The calculus changes on a wideband dongle
+hosting several taps, because every tap shares one gain: a fixed value chosen
+so the strongest site doesn't clip leaves weaker co-tenants flat at the ADC
+floor — and SNR lost at the converter is gone; no downstream AGC recovers it.
+The project's guidance (issue #749, written into `config.example.yaml`) is to
+**prefer `gain: "auto"` when one dongle hosts sites of differing strength**;
+the daemon even logs a startup WARN when a multi-tap wideband dongle is
+pinned to a fixed gain. If the input clip ratio is non-zero, lower the gain
+or add attenuation — never raise it. And a genuinely weak distant site may
+simply need its own dongle: no gain setting serves two sites 30 dB apart
+from one converter. The [AGC]({{ '/reference/automatic-gain-control/' | relative_url }})
+Field Guide entry and the
+[gain & AGC lesson]({{ '/learn/rf-sdr/gain-and-agc/' | relative_url }})
+cover the mechanism itself.
+
+## Where this goes next
+
+The ladder method's step 3 quietly assumed you can recognize overload when
+the sweep walks into it. [Part 4]({{ '/blog/tutorials/analog-edge-04-clipping-overload-intermod/' | relative_url }})
+makes that explicit: what clipping actually looks like in IQ, how an
+overdriven front end *manufactures* phantom signals through intermodulation,
+why the error-vs-gain curve turns back up, and why "no clipping" still
+doesn't clear the front end — the distinction #764 turned on.
+
+## FAQ
+
+**Is there one right gain for my dongle?**
+There's one right gain for your dongle *on this antenna, at this frequency,
+in this RF neighborhood* — which is why the answer is a sweep, not a lookup
+table. Re-sweep after any change to the chain: new antenna, new coax, added
+LNA, or even a new strong transmitter moving into the neighborhood.
+
+**Why prefer the lower gain when two rungs decode identically?**
+Headroom. The band you swept today is the quietest it will ever be — strong
+neighbors come and go, and the higher rung has already spent the margin
+you'll want when one appears. `pickGain` encodes that as its final
+tie-break; it costs nothing today and saves a re-stage later.
+
+**Should I just use `gain: "auto"` everywhere?**
+It's the safe default, and on multi-site wideband dongles it's actively
+recommended. The case for fixed gain is a single known channel where a sweep
+found a clearly better rung than AGC settles on, or where you want run-to-run
+reproducibility (captures for regression tests, A/B experiments — Part 10).
+When you do fix it, write down why and what the clip ratio read.
+
+**My squelch/threshold config has dBFS numbers in it. Are those traps too?**
+A threshold is a trap when it makes you adjust *RF gain* to satisfy it.
+Squelch on a settled, staged system is fine — it's downstream of a chain you
+already fixed. The rule of thumb: thresholds may respond to your staging;
+your staging must never respond to a threshold.
+
+**The sweep says gain 0 decodes best. Is that believable?**
+Yes, near a strong site — it means every higher rung was already degrading
+the decode through front-end compression or intermod, and it's a hint your
+system would benefit from attenuation or filtering rather than amplification
+(Part 9). Believe the decode; it has no incentive to lie.
+
+## Series navigation
+
+**Part 3 of 14** · ←
+[Part 2: dBFS — What the Number Means (& What It Doesn't)]({{ '/blog/tutorials/analog-edge-02-dbfs/' | relative_url }})
+· Next →
+[Part 4: Clipping, Overload & Intermod]({{ '/blog/tutorials/analog-edge-04-clipping-overload-intermod/' | relative_url }})

--- a/docs/_posts/2026-08-20-tetra-end-to-end-03-channel-coding-crc.md
+++ b/docs/_posts/2026-08-20-tetra-end-to-end-03-channel-coding-crc.md
@@ -1,0 +1,318 @@
+---
+title: "TETRA End to End, Part 3: Channel Coding — RCPC, Viterbi & the CRC That Isn't an LFSR"
+description: Walking TETRA's type-5 bits back to information — two K=5 RCPC mother codes, depuncturing into a shared 16-state Viterbi, the block interleavers, and the class-2 speech CRC that is a fixed parity-check matrix, whose LFSR misimplementation silently dropped every on-air voice burst while synthetic round-trips stayed green.
+category: deep-dives
+keywords: tetra channel coding, rcpc convolutional code, tetra viterbi decoder, tetra puncturing, tetra block interleaver, tetra crc tab_crc, parity check matrix crc, self-consistent test trap, type-1 type-5 bits, gophertrunk tetra
+tags: [tetra-end-to-end, tetra, fec, viterbi, crc, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "TETRA End to End"
+series_part: 3
+---
+
+*Part 3 of **TETRA End to End**, a 14-part deep dive into how GopherTrunk turns
+one real 25 kHz TETRA carrier into clear recorded voice.
+[Part 2]({{ '/blog/deep-dives/tetra-end-to-end-02-bursts-slot-grid/' | relative_url }})
+sliced the downlink into bursts and gave each one its 216 or 432 type-5 bits —
+still scrambled, interleaved, punctured and convolved. This part walks those
+bits back to information. It is also where the series' villain claims its most
+expensive victim: a CRC implemented as the "obvious" shift register when the
+spec meant a fixed parity-check matrix, a bug that dropped **every** on-air
+speech burst while every synthetic round-trip passed — because both sides of
+the round trip shared it.*
+
+> **TL;DR:** TETRA channel coding is ETSI's type-1 → type-5 pipeline: CRC +
+> tail bits + RCPC convolutional code + block interleave + scramble. There are
+> **two K=5 mother codes** — an R=1/4 for signalling channels
+> (`framing.EncodeRCPCTetraSigMother`, EN 300 392-2 §8.2.3.1) and an R=1/3 for
+> speech (`framing.EncodeRCPCTetraMother`, EN 300 395-2 §5.4.3) — both decoded
+> by 16-state Viterbi with erasure-aware depuncturing (`DepunctureMark`) and a
+> forced state-0 terminal. Signalling uses a genuine CRC-CCITT LFSR
+> (`0x1021`/`FFFF`/`FFFF`). The speech class-2 CRC does **not**: it is the
+> reference codec's `TAB_CRC` fixed parity-check matrix (`tchCRCTaps`,
+> `internal/radio/tetra/tch_tables.go`), and an earlier `G(X)=1+X³+X⁷`
+> approximation failed every real burst while passing every self-consistent
+> synthetic test.
+
+**Key takeaways**
+
+- **One pipeline, many channels.** BSCH, SCH/HD, SCH/HU and SCH/F are the same
+  `signalingEncode`/`signalingDecode` chain with different interleaver
+  constants; only AACH deviates (a (30,14) Reed-Muller block code, no
+  convolution).
+- **Two mother codes, one Viterbi shape.** Signalling is K=5 R=1/4 with four
+  generators; speech is K=5 R=1/3 with three. Same 16-state trellis
+  discipline, same tail-bit flush to state 0, separate primitives so the
+  polynomials can never cross-contaminate.
+- **Depuncturing is erasure marking, not guessing.** Punctured positions are
+  filled with `DepunctureMark` and the Viterbi cost accumulator skips them —
+  the decoder is *told* what was never transmitted.
+- **"CRC" is a claim about a spec, not an algorithm.** The class-2 speech
+  check is a parity-check matrix. Implementing it as a polynomial LFSR
+  produced a decoder that agreed perfectly with its own encoder and disagreed
+  with every base station on Earth.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| Signalling mother code | K=5 R=1/4, G₁..G₄ per §8.2.3.1 | `internal/radio/framing/rcpc_tetra_sig.go` (`EncodeRCPCTetraSigMother`) |
+| Speech mother code | K=5 R=1/3, G₁..G₃ per EN 300 395-2 §5.4.3 | `internal/radio/framing/rcpc_tetra.go` (`EncodeRCPCTetraMother`) |
+| Viterbi (speech) | 16 states, erasure-aware, state-0 terminal | `rcpc_tetra.go` (`DecodeRCPCTetraMother`) |
+| Puncture / depuncture | §5.4.3.2 formula, spec-verbatim tables | `rcpc_tetra.go` (`PunctureRCPCTetra`, `RCPCTetraPuncture23`) |
+| Signalling chain | CRC-16 + tail + RCPC 2/3 + interleave + scramble | `internal/radio/tetra/channel_coding.go` (`signalingDecode`) |
+| Speech class-2 CRC | fixed parity-check matrix (`TAB_CRC`) | `internal/radio/tetra/tch_tables.go` (`tchCRCTaps`), `tch.go` (`crcTCHClass2`) |
+
+## In this post
+
+- **The type-1 to type-5 pipeline** — ETSI's names for the stages, and the one chain five channels share.
+- **Two mother codes** — why signalling and speech convolve differently.
+- **Depuncture and Viterbi** — erasures, the trellis, and the state-0 constraint.
+- **The CRC that isn't an LFSR** — the class-2 parity-check matrix and the bug it hid.
+- **Naming the trap** — what this failure class looks like so you recognise it next time.
+
+## The type-1 to type-5 pipeline
+
+ETSI names the stages of every TETRA logical channel's coding chain: type-1
+bits are raw information, and each transform — block code, convolutional code,
+interleave, scramble — increments the number until type-5 is what's on air.
+GopherTrunk composes the whole signalling chain from framing primitives in one
+function pair:
+
+```go
+// internal/radio/tetra/channel_coding.go (shape)
+func signalingEncode(type1 []byte, interleaverK, interleaverA int, colourCode uint32) []byte {
+    withCRC := appendCRC16(type1)       // K1 + 16 (CRC-CCITT 0x1021, FFFF/FFFF)
+    type2 := appendTailBits(withCRC, 4) // K1 + 20 (K−1 zero tail bits)
+    type3 := encodeRCPCRate23(type2)    // × 3/2 (R=1/4 mother + 2/3 puncture)
+    type4 := framing.BlockInterleaveTetra(type3, interleaverK, interleaverA)
+    type5 := framing.ScrambleTetra(type4, colourCode)
+    return type5
+}
+```
+
+Decoding is the strict mirror: descramble, deinterleave, depuncture +
+Viterbi, strip tail, verify CRC — `signalingDecode` returns the info bits plus
+a pass/fail flag, and a failing CRC means "best Viterbi guess, do not trust."
+Every signalling channel is this chain with different interleaver constants:
+BSCH is 60 → 120, SCH/HD (also serving BNCH and STCH) 124 → 216, SCH/HU
+92 → 168, SCH/F 268 → 432. Only the AACH deviates — 14 bits in a (30,14)
+Reed-Muller code plus scramble, no convolution, because it must decode in
+every single slot cheaply (see the
+[RM(30,14) reference]({{ '/reference/tetra-rm-30-14/' | relative_url }})). The
+composition-over-monolith argument for this design is made in
+[Protocol Decoders Part 7]({{ '/blog/deep-dives/protocol-decoders-07-tetra/' | relative_url }});
+here we go a level deeper, into the primitives.
+
+## Two mother codes
+
+A detail the one-post survey glossed over: TETRA has **two** RCPC mother
+codes, from two different standards documents, and they are different codes.
+
+Every signalling channel uses the K=5, rate-1/4 code of EN 300 392-2
+§8.2.3.1 — four generator polynomials (G₁ = 0x13, G₂ = 0x1D, G₃ = 0x17,
+G₄ = 0x1B), punctured down to rate 2/3. The speech traffic channel uses the
+K=5, rate-1/3 code of EN 300 395-2 §5.4.3 — three generators:
+
+```go
+// internal/radio/framing/rcpc_tetra.go (shape) — the SPEECH mother code
+// G_1(D) = 1 + D + D^2 + D^3 + D^4  (0x1F)
+// G_2(D) = 1 + D + D^3 + D^4        (0x1B)
+// G_3(D) = 1 + D^2 + D^4            (0x15)
+func EncodeRCPCTetraMother(input []byte) []byte {
+    out := make([]byte, 3*len(input))
+    var d1, d2, d3, d4 byte
+    for i, in := range input {
+        bit := in & 1
+        out[3*i] = bit ^ d1 ^ d2 ^ d3 ^ d4
+        out[3*i+1] = bit ^ d1 ^ d3 ^ d4
+        out[3*i+2] = bit ^ d2 ^ d4
+        d4, d3, d2, d1 = d3, d2, d1, bit
+    }
+    return out
+}
+```
+
+Same 16-state structure, different outputs per input, different puncturing
+table families — so GopherTrunk keeps them as separate primitives
+(`rcpc_tetra_sig.go` vs `rcpc_tetra.go`) rather than one parameterised
+encoder. The speech code is punctured two ways within a single slot: rate 8/12
+over the class-1 bits and rate 8/18 over class 2 + CRC + tail
+(`RCPCTetraPuncture23` = `{1,2,4}` on period 6; `RCPCTetraPuncture818` on
+period 12, both verbatim from the spec) — unequal error protection, with the
+perceptually critical class-2 bits armoured hardest. Part 5 shows where those
+classes come from.
+
+## Depuncture and Viterbi
+
+Puncturing transmits only a subset of mother-code bits; the decoder's first
+job is to be honest about the holes. `DepunctureRCPCTetra` allocates the full
+mother-length buffer, fills it with `DepunctureMark`, and copies received bits
+into the puncture-map positions. The Viterbi then *skips* marked positions in
+its cost accumulator — an untransmitted bit contributes no evidence either
+way:
+
+```go
+// internal/radio/framing/rcpc_tetra.go (shape) — DecodeRCPCTetraMother
+for input := 0; input < 2; input++ {
+    g1 := byte(input^d1^d2^d3^d4) & 1
+    /* … g2, g3 … */
+    cost := pm[cur]
+    if rxG1 != DepunctureMark && g1 != rxG1 { cost++ }
+    if rxG2 != DepunctureMark && g2 != rxG2 { cost++ }
+    if rxG3 != DepunctureMark && g3 != rxG3 { cost++ }
+    /* … relax npm[next], record traceback … */
+}
+// Encoder is flushed to state 0 by the tail bits — pick state 0 unconditionally.
+final := 0
+```
+
+Two constraints do quiet work here. The four zero tail bits appended at encode
+time drive the encoder back to state 0, so the traceback starts from a *known*
+terminal state instead of the cheapest one — one more equation the received
+bits must satisfy. And the path metric comes back to the caller: 0 means a
+clean channel, small positive values mean corrected errors, and the traffic
+diagnostics histogram those metrics to grade a capture. The general theory —
+trellises, survivors, why convolutional codes like soft inputs — is in the
+[framing & FEC deep dive]({{ '/blog/deep-dives/sdr-internals-09-framing-fec/' | relative_url }});
+the soft-input version of this exact decoder
+(`DecodeRCPCTetraMotherSoft`) is Part 8's payoff.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 200" width="680" height="200" role="img" aria-label="The TETRA decode chain from type-5 to type-1: descramble, deinterleave, then depuncture where missing positions are filled with erasure marks, then a 16-state Viterbi decoder constrained to end in state zero, then the CRC check. A fork above the CRC stage contrasts the signalling CRC-16, a genuine LFSR, with the speech class-2 CRC, a fixed parity-check matrix.">
+  <rect x="8" y="80" width="96" height="42" rx="6" fill="none" stroke="currentColor"/>
+  <text x="56" y="98" text-anchor="middle" fill="currentColor" font-size="10">descramble</text>
+  <text x="56" y="112" text-anchor="middle" fill="var(--fg-muted)" font-size="9">type-5 → 4</text>
+  <line x1="104" y1="101" x2="126" y2="101" stroke="currentColor"/><polygon points="126,97 135,101 126,105" fill="currentColor"/>
+  <rect x="135" y="80" width="100" height="42" rx="6" fill="none" stroke="currentColor"/>
+  <text x="185" y="98" text-anchor="middle" fill="currentColor" font-size="10">deinterleave</text>
+  <text x="185" y="112" text-anchor="middle" fill="var(--fg-muted)" font-size="9">type-4 → 3</text>
+  <line x1="235" y1="101" x2="257" y2="101" stroke="currentColor"/><polygon points="257,97 266,101 257,105" fill="currentColor"/>
+  <rect x="266" y="80" width="106" height="42" rx="6" fill="none" stroke="currentColor"/>
+  <text x="319" y="98" text-anchor="middle" fill="currentColor" font-size="10">depuncture</text>
+  <text x="319" y="112" text-anchor="middle" fill="var(--fg-muted)" font-size="9">holes = erasures</text>
+  <line x1="372" y1="101" x2="394" y2="101" stroke="currentColor"/><polygon points="394,97 403,101 394,105" fill="currentColor"/>
+  <rect x="403" y="80" width="100" height="42" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="453" y="98" text-anchor="middle" fill="var(--accent)" font-size="10">Viterbi K=5</text>
+  <text x="453" y="112" text-anchor="middle" fill="var(--fg-muted)" font-size="9">ends in state 0</text>
+  <line x1="503" y1="101" x2="525" y2="101" stroke="currentColor"/><polygon points="525,97 534,101 525,105" fill="currentColor"/>
+  <rect x="534" y="80" width="138" height="42" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="603" y="98" text-anchor="middle" fill="var(--accent)" font-size="10">CRC gate</text>
+  <text x="603" y="112" text-anchor="middle" fill="var(--fg-muted)" font-size="9">pass ⇒ type-1 trusted</text>
+  <text x="603" y="34" text-anchor="middle" fill="var(--fg-muted)" font-size="9">signalling: CRC-CCITT LFSR (0x1021)</text>
+  <text x="603" y="48" text-anchor="middle" fill="var(--accent)" font-size="9">speech class 2: TAB_CRC parity matrix</text>
+  <line x1="603" y1="54" x2="603" y2="76" stroke="var(--fg-muted)" stroke-dasharray="3 3"/>
+  <text x="340" y="170" text-anchor="middle" fill="var(--fg-muted)" font-size="10">the same pipeline serves BSCH / SCH/HD / SCH/HU / SCH/F — only the interleaver constants and the CRC family change</text>
+</svg>
+<figcaption>Type-5 back to type-1: the shared decode pipeline, with the CRC stage forking between a genuine LFSR (signalling) and a fixed parity-check matrix (speech class 2).</figcaption>
+</figure>
+
+## The CRC that isn't an LFSR
+
+Now the star exhibit. The signalling CRC-16 is exactly what the name suggests —
+the textbook CRC-CCITT-FALSE shift register, polynomial `0x1021`, init
+`0xFFFF`, final XOR `0xFFFF` (`crcTetraK1Plus16`). So when the TCH/S speech
+channel called for "an 8-bit CRC over the 60 class-2 bits," the natural move
+was another polynomial register — and an early implementation used
+`G(X) = 1 + X³ + X⁷`.
+
+But EN 300 395-2 §5.5.1 does not define a cyclic code. It defines eight parity
+equations — the reference codec ships them as tables named `TAB_CRC1..8` — and
+GopherTrunk now implements them as exactly that:
+
+```go
+// internal/radio/tetra/tch.go (shape) — crcTCHClass2
+// Each CRC bit is the even parity (XOR) of the class-2 bits at the ranks in
+// tchCRCTaps — the ETSI reference's fixed parity-check matrix, NOT a G(X) LFSR.
+func crcTCHClass2(class2 []byte) []byte {
+    out := make([]byte, tchCRCBits)
+    for k := range tchCRCTaps {
+        var parity byte
+        for _, rank := range tchCRCTaps[k] {
+            parity ^= class2[rank-1] & 1 // ranks are 1-based
+        }
+        out[k] = parity
+    }
+    return out
+}
+```
+
+The failure mode of the LFSR version is what earns this bug its place in the
+series. Encode and decode shared the wrong CRC, so every synthetic round-trip
+— encode two speech frames, push them through the full chain, decode, compare
+— passed. Every self-test was green. Meanwhile on real air, where the base
+station computes the *spec's* CRC, every received TCH/S burst failed the check
+and was silently gated out: the multi-slot replay harness of that era recorded
+the symptom as CRC passes at "the ~1/256 chance floor" — indistinguishable
+from noise, on a capture whose signalling decoded perfectly. No error, no
+panic, just no voice.
+
+## Naming the trap
+
+This is the **self-consistent-synthetic trap**, and it is worth a name because
+it recurs: the training-sequence placeholder constants of Part 2, this CRC,
+the scrambler seed of Part 4, and a DMO descramble skip in Part 12 are all the
+same species. A round-trip test validates that your encoder and decoder agree
+with *each other* — it cannot validate that either agrees with the *world*.
+The full taxonomy, with the repo's countermeasures, is in
+[From the Issue Tracker Part 20]({{ '/blog/solution-postmortem/from-the-issue-tracker-20-self-consistent-trap/' | relative_url }}).
+For channel coding specifically the countermeasures are concrete: pin decoders
+against externally produced vectors (a real capture, a reference codec's
+output — Part 7's whole subject), and treat "synthetic passes, air fails" as a
+*diagnosis*, not a mystery. When voice doesn't decode but the vocoder's unit
+tests pass, suspect the channel coding — the chain between demod and vocoder —
+before either neighbour. That sentence, hard-earned here, is now standing
+guidance in the repo.
+
+## Where this goes next
+
+One stage of the pipeline got only a sentence: the scramble. It looks like the
+most trivial stage — XOR with a pseudo-random sequence — and it has produced
+more subtle failures than any other.
+[Part 4]({{ '/blog/deep-dives/tetra-end-to-end-04-scrambling-colour-codes/' | relative_url }})
+covers the LFSR, the 30-bit extended colour code that seeds it, and the two
+real bugs it hid — including why `NewScramblerTetra(0)` is emphatically not a
+no-op, the fact that sets up the DMO disaster of Part 12.
+
+## FAQ
+
+**Why does TETRA use two different convolutional codes?**
+They come from two documents with two jobs: EN 300 392-2 defines the air
+interface (signalling channels, R=1/4 mother), EN 300 395-2 defines the speech
+codec and its channel protection (R=1/3 mother with unequal error protection
+across bit classes). GopherTrunk mirrors the document boundary in its package
+layout — a decoder per spec, no shared polynomial tables to get subtly wrong.
+
+**What does the Viterbi path metric actually tell you?**
+For the hard decoder it's the count of received bits the surviving path had to
+disagree with — 0 is a clean burst, a handful is FEC doing its job, dozens
+means the burst is likely garbage even if the CRC accidentally passes. The
+replay harnesses histogram it per burst as a channel-quality profile.
+
+**Why force the Viterbi to end in state 0 instead of picking the best final state?**
+Because the encoder provably ends there — the four zero tail bits flush it.
+Honouring the constraint uses information the cheapest-final-state heuristic
+throws away, and on a marginal burst that difference decides whether the CRC
+sees the right bits.
+
+**Couldn't the class-2 CRC bug have been caught without a capture?**
+Only by an external reference: decoding a frame encoded by someone else's
+implementation, or checking the CRC of a known-good on-air burst. That's the
+general lesson — a codec bug that is symmetric under round-trip is invisible
+to any test you generate yourself. The conformance harnesses in Part 7 exist
+precisely to make external vectors routine.
+
+**Is the interleaver ever the thing that's wrong?**
+It's the same failure class — a wrong permutation applied consistently on both
+sides round-trips perfectly. The speech interleaver (`tchInterleave`, a 24×18
+matrix read column-wise) and the signalling `BlockInterleaveTetra` are pinned
+by tests against spec-derived positions, and the
+[block-interleaver reference]({{ '/reference/tetra-block-interleaver/' | relative_url }})
+documents the layouts.
+
+## Series navigation
+
+**Part 3 of 14** · ←
+[Part 2: The Burst Zoo & the Slot Grid]({{ '/blog/deep-dives/tetra-end-to-end-02-bursts-slot-grid/' | relative_url }})
+· Next →
+[Part 4: Scrambling & Colour Codes — Why Colour 0 Is Not a No-Op]({{ '/blog/deep-dives/tetra-end-to-end-04-scrambling-colour-codes/' | relative_url }})

--- a/docs/_posts/2026-08-20-weak-signal-engineering-03-isi-linear-channel.md
+++ b/docs/_posts/2026-08-20-weak-signal-engineering-03-isi-linear-channel.md
@@ -1,0 +1,292 @@
+---
+title: "Weak-Signal Engineering, Part 3: ISI & the Linear Channel — What an Equalizer Can & Can't Fix"
+description: The convolution model y = h∗x + n that every equalizer in this series inverts — what multipath and band-edge group delay do to π/4-DQPSK and C4FM symbols, which impairments are linear and therefore recoverable, which are not, and the raw-symbol-domain fact that dictates the architecture of Parts 5 and 7.
+category: deep-dives
+keywords: intersymbol interference, linear channel model, multipath distortion, group delay, channel convolution, differential decoding nonlinearity, equalizer limits, pi/4-dqpsk isi, gophertrunk weak-signal engineering
+tags: [weak-signal-engineering, isi, multipath, dsp, equalizer, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Weak-Signal Engineering"
+series_part: 3
+---
+
+*Part 3 of **Weak-Signal Engineering**, a 14-part deep dive into decoding the
+marginal regime, where a receiver locks but under-decodes.
+[Part 2]({{ '/blog/deep-dives/weak-signal-engineering-02-metrics-that-lie/' | relative_url }})
+fixed the measurement rules — yield is the verdict, EVM and carrier SNR are
+advisory at best. Now we can meet the enemy properly. The thread capture's
+constellation isn't just noisy; it's *smeared*, and smear is a different kind
+of damage with a different kind of cure. This part builds the linear channel
+model everything later inverts, draws the line between what an equalizer can
+and cannot fix, and lands the one domain fact that quietly shapes the design
+of every equalizer in the rest of the series.*
+
+> **TL;DR:** A dispersive channel is a **convolution**: `y = h∗x + n`, where
+> each received symbol is a weighted sum of the current symbol and its
+> neighbours — that weighted mixing is
+> **[inter-symbol interference]({{ '/reference/intersymbol-interference/' | relative_url }})**,
+> and because convolution is linear it is *invertible* by another filter. That
+> is the whole license an equalizer operates under. Multipath, simulcast
+> echoes, and band-edge **group delay** are linear — fixable. Phase noise,
+> clipping, and compression are **not** linear — no FIR can unmix them. And the
+> fact with teeth: the channel is a clean convolution only over **raw
+> symbols**. After the differential product `s·conj(prev)` the channel enters
+> *nonlinearly*, which is why GopherTrunk's receiver grew a raw-symbol
+> `SymbolSink` alongside its differential `SoftSink` — an equalizer must live
+> before, or be trained on, the raw-symbol domain.
+
+**Key takeaways**
+
+- **ISI is deterministic mixing, not noise.** Noise adds an unknowable random
+  vector to each symbol; ISI adds a *known-structure* combination of
+  neighbouring symbols. That structure is exactly what makes it removable —
+  and what makes more transmit power useless against it.
+- **Linear in, linear out — that's the whole test.** If the impairment can be
+  written as a fixed filter acting on the signal, another filter can undo it.
+  If it can't (phase noise, overload), the equalizer has nothing to grab.
+- **Differential decoding destroys the linearity.** `s[n]·conj(s[n−1])` is a
+  product of two filtered quantities; the channel taps enter it as cross-terms,
+  not as a convolution. Equalize before the differential, always.
+- **The thread capture is ISI-limited, not just SNR-limited.** Its ~10 dB
+  in-channel SNR should decode far better than 12% — the gap between "should"
+  and "does" is the smear, and it is the recoverable part.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| The channel model | `y = h∗x + n` — FIR channel, additive noise | [`/reference/intersymbol-interference/`]({{ '/reference/intersymbol-interference/' | relative_url }}), [`/reference/multipath-propagation/`]({{ '/reference/multipath-propagation/' | relative_url }}) |
+| Raw-symbol tap | post-timing/AFC symbols, pre-differential | `internal/radio/tetra/receiver/receiver.go` (`Options.SymbolSink`) |
+| Differential tap | `s·conj(prev)` per symbol — LLR source, *not* equalizer input | `receiver.go` (`Options.SoftSink`) |
+| Where the equalizer sits | between symbol timing and differential decode | `receiver.go` (`Options.EnableEqualizer`) |
+| Synthetic ISI channel | multipath fixture the equalizer tests decode through | `internal/dsp/equalizer/snapshot_cma_test.go` (`TestSnapshotCMARecoversISIChannel`) |
+| What's *not* linear | phase noise / reciprocal mixing (#764), overload | `internal/scanner/ccdecoder/ddc_highrate_test.go` |
+
+## In this post
+
+- **The channel as a filter** — echoes, convolution, and the two-ray picture.
+- **What smear does to symbols** — π/4-DQPSK and C4FM under a dispersive channel.
+- **Invertible vs. not** — the sorting rule for every impairment you'll meet.
+- **The differential domain is not linear** — the fact that shapes Parts 5 and 7.
+- **Reading the damage on the thread capture** — smear vs. noise, told apart.
+
+## The channel as a filter
+
+Radio between transmitter and antenna is astonishingly well modeled by one
+idea: the channel is a filter. Your antenna receives the direct wave plus
+delayed, attenuated copies —
+[multipath]({{ '/reference/multipath-propagation/' | relative_url }}) bounces
+off terrain and buildings, simulcast systems transmit deliberate copies from
+multiple towers, and even a single clean path picks up dispersion from every
+bandpass filter it crosses, including your own receiver's, whose
+[group delay]({{ '/reference/group-delay/' | relative_url }}) stops being flat
+near the band edge. Sum a few delayed copies and you have, exactly, a
+finite-impulse-response filter:
+
+`y[n] = h0·x[n] + h1·x[n−1] + … + hk·x[n−k] + noise[n]`
+
+— or compactly, `y = h∗x + n`. When the delay spread of `h` is a meaningful
+fraction of a symbol period, each received symbol contains echoes of its
+neighbours: inter-symbol interference. Two properties of this model do all the
+work in this series. It is **linear** — the channel treats a sum of inputs as
+the sum of its outputs — and it is (approximately, over short spans)
+**time-invariant**. Linear time-invariant systems compose: run `y` through a
+second filter `w`, and the result is `(w∗h)∗x`. If you can find a `w` such
+that `w∗h` is close to a pure delay, the smear is *gone* — not averaged down,
+not powered through: algebraically removed. Finding that `w`, blindly or with
+training, is Parts 4 through 7.
+
+## What smear does to symbols
+
+The two constellations GopherTrunk cares most about fail differently under the
+same channel. [π/4-DQPSK]({{ '/reference/pi-4-dqpsk/' | relative_url }})
+(TETRA) encodes data in the *phase difference* between consecutive symbols; a
+two-ray channel adds to each symbol a scaled, rotated copy of an earlier one,
+dragging each constellation point toward positions that depend on its
+*history*. The tight eight-point ring blooms into overlapping clusters — the
+"ISI-smeared" description on the thread capture's fixture comment is exactly
+this. [C4FM]({{ '/reference/c4fm/' | relative_url }}) (P25 Phase 1) is a
+four-level FSK: dispersion drags each symbol's frequency toward its
+neighbours', closing the four-level
+[eye]({{ '/reference/eye-diagram/' | relative_url }}) vertically until the
+slicer's thresholds cut through the blur. Same convolution, two dialects of
+damage — which is why the levers in this series are built protocol-agnostic,
+on complex symbols, and why P25's C4FM path *not* having them yet is a gap
+worth its own post (Part 13).
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 220" width="680" height="220" role="img" aria-label="A two-ray channel smearing a constellation. On the left, a transmitted impulse followed by a smaller delayed echo represents the channel impulse response h. In the middle, the clean eight-point pi over four DQPSK constellation. On the right, the received constellation: each point has bloomed into a cluster of points displaced by scaled rotated copies of neighbouring symbols, overlapping its neighbours. An arrow labeled convolution connects clean to smeared, and a dashed arrow labeled equalizer w points back.">
+  <text x="90" y="20" text-anchor="middle" fill="currentColor" font-size="11">channel h</text>
+  <line x1="30" y1="150" x2="150" y2="150" stroke="var(--fg-muted)"/>
+  <line x1="55" y1="150" x2="55" y2="60" stroke="currentColor"/>
+  <circle cx="55" cy="60" r="3" fill="currentColor"/>
+  <text x="55" y="52" text-anchor="middle" fill="var(--fg-muted)" font-size="9">direct</text>
+  <line x1="105" y1="150" x2="105" y2="105" stroke="var(--accent)"/>
+  <circle cx="105" cy="105" r="3" fill="var(--accent)"/>
+  <text x="105" y="97" text-anchor="middle" fill="var(--accent)" font-size="9">echo</text>
+  <text x="90" y="168" text-anchor="middle" fill="var(--fg-muted)" font-size="9">delay ≈ a symbol</text>
+  <circle cx="280" cy="110" r="58" fill="none" stroke="var(--fg-muted)"/>
+  <g fill="currentColor">
+    <circle cx="338" cy="110" r="4"/><circle cx="321" cy="69" r="4"/><circle cx="280" cy="52" r="4"/><circle cx="239" cy="69" r="4"/>
+    <circle cx="222" cy="110" r="4"/><circle cx="239" cy="151" r="4"/><circle cx="280" cy="168" r="4"/><circle cx="321" cy="151" r="4"/>
+  </g>
+  <text x="280" y="196" text-anchor="middle" fill="var(--fg-muted)" font-size="9">transmitted: 8 crisp points</text>
+  <line x1="352" y1="110" x2="392" y2="110" stroke="currentColor"/><polygon points="392,106 402,110 392,114" fill="currentColor"/>
+  <text x="377" y="98" text-anchor="middle" fill="var(--fg-muted)" font-size="9">∗ h</text>
+  <circle cx="530" cy="110" r="58" fill="none" stroke="var(--fg-muted)"/>
+  <g fill="var(--fg-muted)">
+    <circle cx="585" cy="104" r="3"/><circle cx="592" cy="116" r="3"/><circle cx="578" cy="121" r="3"/>
+    <circle cx="576" cy="66" r="3"/><circle cx="563" cy="75" r="3"/><circle cx="570" cy="58" r="3"/>
+    <circle cx="533" cy="48" r="3"/><circle cx="522" cy="58" r="3"/><circle cx="541" cy="60" r="3"/>
+    <circle cx="486" cy="72" r="3"/><circle cx="497" cy="62" r="3"/><circle cx="482" cy="84" r="3"/>
+    <circle cx="470" cy="108" r="3"/><circle cx="478" cy="120" r="3"/><circle cx="466" cy="96" r="3"/>
+    <circle cx="490" cy="148" r="3"/><circle cx="482" cy="136" r="3"/><circle cx="500" cy="156" r="3"/>
+    <circle cx="532" cy="170" r="3"/><circle cx="522" cy="160" r="3"/><circle cx="544" cy="162" r="3"/>
+    <circle cx="574" cy="150" r="3"/><circle cx="584" cy="138" r="3"/><circle cx="566" cy="140" r="3"/>
+  </g>
+  <text x="530" y="196" text-anchor="middle" fill="var(--fg-muted)" font-size="9">received: clusters bloom &amp; overlap</text>
+  <path d="M 470 40 C 420 14 360 14 330 36" fill="none" stroke="var(--accent)" stroke-dasharray="5 3"/>
+  <polygon points="336,30 326,39 340,41" fill="var(--accent)"/>
+  <text x="400" y="14" text-anchor="middle" fill="var(--accent)" font-size="9">equalizer w: w∗h ≈ delay</text>
+</svg>
+<figcaption>A two-ray channel is a two-tap FIR: each received symbol carries a scaled, rotated echo of its neighbour, blooming every constellation point into a history-dependent cluster. Because the damage is a convolution, a second filter can remove it.</figcaption>
+</figure>
+
+## Invertible vs. not
+
+The linearity test sorts every impairment in this series into two bins, and
+the sorting decides which series you're in:
+
+| Impairment | Linear? | Fixable by an equalizer? | Where it's covered |
+|---|---|---|---|
+| Multipath / simulcast echoes | yes — FIR channel | yes | Parts 4–7 |
+| Band-edge group delay | yes — allpass-ish filter | yes | Parts 4–7 |
+| Static frequency offset | yes (a rotation ramp) | AFC's job, not the equalizer's | [sdr-internals-07]({{ '/blog/deep-dives/sdr-internals-07-symbol-timing-sync-recovery/' | relative_url }}) |
+| Additive noise | additive, not filtering | no — equalizers slightly *enhance* it | soft decisions help: Part 8 |
+| Phase noise / reciprocal mixing | no — random multiplicative phase | **no** | Part 12, and [#764](https://github.com/MattCheramie/GopherTrunk/issues/764) |
+| Clipping / compression / intermod | no — memoryless nonlinearity | **no** | [The Analog Edge]({{ '/blog/series/analog-edge/' | relative_url }}) |
+
+The bottom two rows deserve emphasis because they are where effort goes to
+die. #764's ~10 dB deficit *looked* like something a cleverer decoder should
+recover — but reciprocal mixing multiplies the signal by a random phase
+process, and no fixed (or slowly-adapted) filter inverts a random process.
+Likewise a clipped front end has already discarded amplitude information
+irreversibly. The diagnostic discipline for telling these apart from linear
+smear — before spending a month on an equalizer that cannot work — is Part 12.
+The operator-side prevention (gain staging, overload hygiene) lives in the
+concurrent [Analog Edge]({{ '/blog/series/analog-edge/' | relative_url }})
+series. The rule of thumb: an equalizer buys you back what the *channel* mixed
+together; nothing buys back what the *hardware* threw away.
+
+## The differential domain is not linear
+
+Now the fact that dictates architecture. TETRA's receiver decodes
+π/4-DQPSK differentially: the information is in `d[n] = s[n]·conj(s[n−1])`.
+It is tempting to equalize `d` directly — the differentials are what the soft
+decoder consumes, they're already conveniently rotation-free, and the receiver
+already exports them. But substitute the channel model and watch the algebra
+break. If `s' = h∗s`, then
+
+`d'[n] = (h∗s)[n] · conj((h∗s)[n−1])`
+
+— every product of the form `h_i·conj(h_j)·s[n−i]·conj(s[n−1−j])` appears. The
+channel taps enter as *cross-terms in a product*, not as coefficients of a
+convolution. There is no filter `w` acting on `d'` that yields `d`, because
+the map from `d` to `d'` isn't a filter at all. The receiver's own doc comment
+states the consequence precisely:
+
+```go
+// internal/radio/tetra/receiver/receiver.go (shape) — Options
+// SymbolSink, when non-nil, receives the RAW post-timing/AFC/equalizer
+// complex symbols (before the differential decode) … Unlike the
+// SoftSink differential (a nonlinear product s·conj(last), in which the
+// channel is no longer a clean convolution), the symbol stream is where a
+// linear channel IS a convolution — so it is the input a training-sequence
+// equalizer … must train on and equalize per burst.
+SymbolSink func(symbols []complex64, baseIdx int)
+```
+
+This one fact fans out into three design decisions you'll watch land in later
+parts. The **blind** equalizer (`SnapshotCMA`) sits *inside the receiver*,
+between symbol-timing recovery and the differential decoder — before the
+nonlinearity (Parts 4–5). The **trained** equalizer (`SnapshotLMS`) runs in
+the burst extractor, which therefore needs the *raw symbols* carried down to
+it in parallel with the dibits — that's the `SymbolSink → StashSymbols` plumbing
+(Part 7, architecture in Part 9). And after either equalizer, the
+differentials are *re-derived* from equalized symbols rather than patched up
+in place. In every case the convolution is inverted where it still *is* a
+convolution.
+
+## Reading the damage on the thread capture
+
+Close the loop on our running capture with the sorting rule in hand. Its
+in-channel SNR is ~10 dB — low, but a differential QPSK with rate-compatible
+convolutional coding should do considerably better than 12% BSCH yield on
+noise alone. The constellation is smeared into history-dependent clusters, not
+uniformly fattened — noise fattens, ISI *structures*. It peaks at −44 dBFS
+with no clipping, ruling out the nonlinear bin. And the same site decodes
+~100% at ~18 dB through identical hardware, so the channel, not the rig, is
+the variable. Every sign points the same way: a real noise deficit (which
+soft decisions will help with in Part 8) *compounded by linear ISI* — which is
+the recoverable part, and which is why a blind equalizer will move this
+capture from ~12% to ~100% two parts from now. Diagnosis before surgery.
+
+## Where this goes next
+
+We now know the damage is a convolution and know where it must be inverted.
+The next question is *how to find the inverse filter when you don't know the
+channel* — no pilot, no preamble, nothing but the signal's own statistics.
+[Part 4]({{ '/blog/deep-dives/weak-signal-engineering-04-blind-cma/' | relative_url }})
+builds the Constant Modulus Algorithm from first principles: the Godard cost
+`J = E[(|y|²−R²)²]`, the stochastic-gradient tap update as GopherTrunk's
+`cma.go` actually implements it, why constant-envelope PSK suits it — and the
+spurious minima that make Part 2's EVM trap a structural hazard rather than
+bad luck.
+
+## FAQ
+
+**How do I tell ISI from noise on a live system, without a lab?**
+Shape and structure. Noise fattens every constellation cluster uniformly and
+isotropically; ISI blooms points into *patterned* sub-clusters (one per
+recent-symbol history) and often stretches them anisotropically. On the eye
+diagram, noise fuzzes the whole trace while ISI closes the eye with distinct
+crossing trajectories. GopherTrunk's constellation and eye panels
+([operator-cockpit-08]({{ '/blog/deep-dives/operator-cockpit-08-constellation-eye-symbol/' | relative_url }}))
+show both live.
+
+**If ISI is deterministic, why can't the decoder just power through with FEC?**
+FEC trades margin against random errors; ISI consumes that margin
+systematically, on every symbol, with errors correlated by the channel memory —
+the worst case for a convolutional code's error events. Removing structured
+distortion *before* the decoder and spending the code on what's left (noise)
+is strictly better, which is why the equalizer-plus-soft-decision combination
+in this series stacks rather than overlaps.
+
+**Why not equalize the wideband stream once, before channelization?**
+Because `h` is different for every carrier — each channel's multipath geometry
+and band-edge position differ — and a single wideband filter would need to be
+all of those inverses at once. Equalizers in GopherTrunk run per channel, at
+symbol rate, where the channel they're inverting is one channel. (The same
+physics limits wideband diversity combining to a scalar, a story Part 10
+tells.)
+
+**Does a stronger signal fix ISI?**
+No — and this is the cleanest way to recognize the regime. ISI scales *with*
+the signal: crank the gain and the echoes crank too, so yield plateaus well
+below 100% no matter what the S-meter says. If more signal doesn't move yield,
+stop shopping for antennas and start suspecting the channel (or Part 12's
+nonlinear impairments).
+
+**Is symbol-timing error a form of ISI?**
+Sampling off the symbol centre does mix neighbouring symbols through the pulse
+shape's skirts, so mistimed sampling *manufactures* ISI from a clean channel.
+That's why timing recovery ([sdr-internals-07]({{ '/blog/deep-dives/sdr-internals-07-symbol-timing-sync-recovery/' | relative_url }}))
+runs before the equalizer, and why the equalizer only gets credit for what
+timing can't fix: dispersion that exists even at the perfect sampling instant.
+
+## Series navigation
+
+**Part 3 of 14** · ←
+[Part 2: Metrics That Lie — EVM vs CRC Yield]({{ '/blog/deep-dives/weak-signal-engineering-02-metrics-that-lie/' | relative_url }})
+· Next →
+[Part 4: Blind Equalization — CMA From First Principles]({{ '/blog/deep-dives/weak-signal-engineering-04-blind-cma/' | relative_url }})

--- a/docs/_posts/2026-08-21-analog-edge-04-clipping-overload-intermod.md
+++ b/docs/_posts/2026-08-21-analog-edge-04-clipping-overload-intermod.md
@@ -1,0 +1,271 @@
+---
+title: "The Analog Edge, Part 4: Clipping, Overload & Intermod"
+description: What front-end overload actually looks like from the samples up — rail-pinned IQ, the clip ratio as the authoritative verdict, intermodulation products that manufacture phantom signals as gain rises, out-of-band overload from FM broadcast, and why a clean clip ratio still doesn't clear the front end.
+category: tutorials
+keywords: adc clipping, rail pinned samples, front end overload, intermodulation distortion, imd third order, clip ratio, fm broadcast overload, sdr desense, phantom signals, gophertrunk analog edge
+tags: [analog-edge, overload, intermod, adc, sdr, tutorial]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "The Analog Edge"
+series_part: 4
+---
+
+*Part 4 of **The Analog Edge**, a 14-part field guide to the analog half of a
+GopherTrunk installation. [Part 3]({{ '/blog/tutorials/analog-edge-03-gain-staging/' | relative_url }})
+ended with the ladder method's quiet assumption: that you can recognize
+overload when a gain sweep walks into it. This part makes overload concrete
+for our reader with the marginal system — because "too much gain" doesn't
+fail the way intuition says it should. It doesn't get loud; it gets
+*dishonest*. The samples start containing signals that were never on the
+air, and signals that were on the air stop surviving into the samples.*
+
+> **TL;DR:** Overload has two faces. **Clipping** is samples pinned to the
+> ADC rail — the [#881](https://github.com/MattCheramie/GopherTrunk/issues/881)
+> "nineteen dibits" capture was **50% rail-pinned** while every symptom
+> pointed at software —
+> and `gophertrunk_sdr_iq_clip_ratio` is the **authoritative** verdict
+> (sustained > ~0.002 = overloaded; the RMS gauge averages peaks away).
+> **Intermodulation** is subtler: a nonlinear front end *multiplies* strong
+> signals together, manufacturing phantom carriers (third-order products at
+> 2f₁−f₂ and 2f₂−f₁) that land in-band and raise the floor for everyone.
+> Both explain the up-slope of the decode-error U-curve. But the converse
+> fails: **a clean clip ratio does not clear the front end** — the
+> [#764](https://github.com/MattCheramie/GopherTrunk/issues/764) captures
+> peaked ≈ −48 dBFS, nowhere near the rails, and were still ruined upstream.
+
+**Key takeaways**
+
+- **Clipping destroys information non-locally.** A rail-pinned sample is a
+  hard nonlinearity, and its distortion products spray across the whole
+  capture bandwidth — one strong pager can garble every tap on a wideband
+  dongle.
+- **The clip ratio is the verdict; the power gauge is a hint.** RMS can read
+  a survivable −5 dBFS while peaks are flat-topping — which is exactly why
+  the metric pair exists (Part 2).
+- **Intermod means gain manufactures signals.** Third-order products grow
+  3 dB for every 1 dB of gain, so the phantom floor rises three times faster
+  than your wanted carrier — the mechanism behind the U-curve's right side.
+- **The overload you can't see is out-of-band.** An FM broadcast blaster
+  50 MHz away never appears in your capture, but it's compressing the same
+  LNA your control channel uses. Filters, not software, fix that (Part 9).
+
+## Cheat sheet
+
+| Concern | The test | Where it lives |
+|---|---|---|
+| Am I clipping? | sustained clip ratio > ~0.002 | `gophertrunk_sdr_iq_clip_ratio`, `gophertrunk_sdr_wideband_input_clip_ratio` (`internal/metrics/prom.go`) |
+| Is a strong site burying weak taps? | per-tap level far below wideband input power | issue #749 guidance in `config.example.yaml`; throttled WARN in the log |
+| Is this carrier real or intermod? | drop gain 10 dB — a real carrier drops 10, an IM3 product drops ~30 | [Intermodulation]({{ '/reference/intermodulation/' | relative_url }}) |
+| Where does compression start? | the amp's 1 dB compression point | [P1dB]({{ '/reference/1-db-compression-point/' | relative_url }}) |
+| Out-of-band blaster suspected | bandpass/broadcast-notch filter A/B | [SDR filters guide]({{ '/sdr-filters/' | relative_url }}) |
+| Optional RF amp making it worse | `rf_amp` is off by default for this reason | `sdr.devices[].rf_amp` note in `config.example.yaml` |
+
+## In this post
+
+- **What clipping is in the samples** — rails, flat tops, and spray.
+- **Reading the instruments** — clip ratio over power, always.
+- **Intermod: gain manufactures signals** — the 3-for-1 slope.
+- **The U-curve, explained end to end** — both slopes named.
+- **The overload you can't see** — out-of-band compression.
+- **Why "no clipping" is not a clean bill** — the #764 distinction.
+
+## What clipping is in the samples
+
+An ADC has a highest value it can write. When the waveform exceeds it, the
+converter writes that maximum — again and again — until the waveform comes
+back into range. In the time domain the sine peaks are sliced flat; in the
+IQ constellation, samples pile up in a box at the rails; in a histogram of
+sample values, two spikes grow at the extremes. GopherTrunk counts exactly
+that: the fraction of samples whose I or Q component sits at the rail.
+
+The damage is worse than "the loud parts are missing." Flat-topping is a
+hard nonlinearity, and nonlinearities create energy at new frequencies —
+harmonics and mixing products smeared across the entire capture bandwidth.
+That's why clipping is a *wideband* catastrophe: the strong signal that
+caused it usually survives well enough to look healthy, while every weaker
+channel in the capture inherits a raised, structured noise floor. On a
+multi-tap wideband dongle this is the issue #749 failure mode from Part 2:
+one hot site, and every weaker sibling drowns.
+
+The tracker's canonical case is the
+[Nineteen Dibits postmortem]({{ '/blog/solution-postmortem/from-the-issue-tracker-08-nineteen-dibits/' | relative_url }}):
+a meticulously argued software hypothesis, a chain of plausible evidence —
+and a raw capture that turned out to be 50% pinned to the rails. The fix was
+turning the gain down. No amount of reading the decoder would have found it;
+one look at the clip ratio did.
+
+## Reading the instruments
+
+Part 2 introduced the metric pair; overload is where the division of labor
+matters. The power gauge is RMS over ~1 s, and RMS *averages away* exactly
+the peaks that clip — a high-crest wideband capture can flat-top on pager
+bursts while the mean reads a merely-hot −5 dBFS. So the discipline is
+mechanical: **suspicion of overload is settled by the clip ratio and only
+the clip ratio.** Zero is the only comfortable reading; a sustained value
+above ~0.002 (one sample in 500) is the front end telling you it's being
+overdriven, and both the metric help text and the config comments give the
+same instruction — reduce gain or add attenuation, and do **not** raise
+gain: a hot neighbor is desensitizing the receiver, and more gain feeds the
+fire. On wideband dongles, watch the per-serial
+`wideband_input_clip_ratio`, which sees the whole capture *before*
+channelization — a tap can read clean while the shared converter is already
+in trouble.
+
+## Intermod: gain manufactures signals
+
+Clipping is overload's blunt face. The subtle face begins earlier, while
+every sample still looks legal. Real amplifiers are only approximately
+linear, and as input level approaches the amp's
+[1 dB compression point]({{ '/reference/1-db-compression-point/' | relative_url }}),
+the approximation fails gracefully — by *multiplying* signals together.
+Feed a slightly nonlinear stage two strong carriers at f₁ and f₂ and it
+emits **intermodulation products** at combinations of them. The third-order
+pair, 2f₁−f₂ and 2f₂−f₁, is the killer: those land *near the originals* —
+in-band, on top of whatever weak channel is unlucky enough to live there —
+and no filter after the nonlinearity can help, because the products are
+created inside your own front end.
+
+The growth rate is what makes gain so dangerous here. Raise the input of a
+nonlinear stage by 1 dB and its third-order products rise by **3 dB**. Turn
+your gain up 5 dB and every real carrier gains 5 while the phantom floor
+gains 15. This is the arithmetic behind the field observation that an
+overdriven SDR band looks *busier* — ghost carriers at arithmetic spacings,
+"stations" that vanish when you touch the gain. Which is also the field
+test: **drop gain 10 dB; a real signal drops ~10 dB, a third-order product
+drops ~30 dB.** Anything that falls off a cliff was never on the air.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 220" width="680" height="220" role="img" aria-label="Two spectrum sketches side by side. On the left, at moderate gain, two strong carriers f1 and f2 stand over a flat noise floor with a small wanted channel between them. On the right, at high gain, the same two carriers are larger and new third-order intermod products have appeared at 2f1 minus f2 and 2f2 minus f1, flanking the originals, and the noise floor has risen, burying the wanted channel. A note states that intermod products grow 3 dB for every 1 dB of gain.">
+  <line x1="30" y1="180" x2="320" y2="180" stroke="var(--fg-muted)"/>
+  <text x="175" y="200" text-anchor="middle" fill="var(--fg-muted)" font-size="10">moderate gain</text>
+  <polyline points="30,176 320,176" stroke="var(--fg-muted)" fill="none" stroke-dasharray="2 3"/>
+  <polyline points="110,176 116,70 122,176" fill="none" stroke="currentColor"/>
+  <text x="116" y="62" text-anchor="middle" fill="currentColor" font-size="9">f₁</text>
+  <polyline points="230,176 236,64 242,176" fill="none" stroke="currentColor"/>
+  <text x="236" y="56" text-anchor="middle" fill="currentColor" font-size="9">f₂</text>
+  <polyline points="170,176 176,140 182,176" fill="none" stroke="var(--accent)"/>
+  <text x="176" y="132" text-anchor="middle" fill="var(--accent)" font-size="9">your channel</text>
+  <line x1="360" y1="180" x2="650" y2="180" stroke="var(--fg-muted)"/>
+  <text x="505" y="200" text-anchor="middle" fill="var(--fg-muted)" font-size="10">high gain: same air, new signals</text>
+  <polyline points="360,160 650,160" stroke="var(--fg-muted)" fill="none" stroke-dasharray="2 3"/>
+  <text x="645" y="152" text-anchor="end" fill="var(--fg-muted)" font-size="9">floor up</text>
+  <polyline points="440,160 446,42 452,160" fill="none" stroke="currentColor"/>
+  <text x="446" y="34" text-anchor="middle" fill="currentColor" font-size="9">f₁</text>
+  <polyline points="560,160 566,38 572,160" fill="none" stroke="currentColor"/>
+  <text x="566" y="30" text-anchor="middle" fill="currentColor" font-size="9">f₂</text>
+  <polyline points="380,160 386,96 392,160" fill="none" stroke="var(--accent)"/>
+  <text x="386" y="88" text-anchor="middle" fill="var(--accent)" font-size="9">2f₁−f₂</text>
+  <polyline points="614,160 620,94 626,160" fill="none" stroke="var(--accent)"/>
+  <text x="620" y="86" text-anchor="middle" fill="var(--accent)" font-size="9">2f₂−f₁</text>
+  <polyline points="500,160 506,148 512,160" fill="none" stroke="var(--fg-muted)"/>
+  <text x="506" y="140" text-anchor="middle" fill="var(--fg-muted)" font-size="9">your channel, buried</text>
+  <text x="340" y="216" text-anchor="middle" fill="var(--fg-muted)" font-size="10">IM3 grows 3 dB per 1 dB of gain — the phantom floor outruns the signal you were trying to help</text>
+</svg>
+<figcaption>Two strong carriers through a front end pushed toward compression: third-order products appear beside them and the floor rises, three times faster than the gain that caused it.</figcaption>
+</figure>
+
+## The U-curve, explained end to end
+
+Part 3's ladder sweep produces a U-shaped curve of decode error against
+gain, and both slopes now have names. The **left slope** is thermal: too
+little gain and your carrier sits down in the receiver's own noise, so
+errors fall as gain lifts it clear. The **flat bottom** is the plateau where
+the channel's SNR is set by the air, not the knob. The **right slope** is
+this post: compression begins, intermod products bloom 3-for-1, the
+effective floor rises, and errors climb — often before a single sample
+clips. The clip ratio only catches the far end of the right slope; the
+decode error rate sees all of it, which is precisely why
+[autogain]({{ '/blog/deep-dives/the-hunt-05-autogain-autotune/' | relative_url }})
+scores rungs by decoding rather than by any level meter, and why its final
+tie-break walks *down* the ladder.
+
+## The overload you can't see
+
+Everything above assumed the aggressor is in your capture where you can at
+least look at it. Often it isn't. Your LNA and tuner amplify a wide swath of
+spectrum *before* any narrow filtering — so a 100 kW FM broadcast
+transmitter at 98 MHz, a paging blaster at 152 MHz, or a nearby cell site
+can compress the front end while sitting entirely outside your capture. The
+signature is desense that follows geography rather than tuning: everything
+is a little worse, the noise floor a little higher, the U-curve's bottom
+shifted left, and nothing visible to blame. If dropping gain helps *every*
+channel at once, or an attenuator paradoxically improves decode, think
+out-of-band. The remedy is analog by definition — a bandpass or
+broadcast-notch filter ahead of the first amplifier — and
+[Part 9]({{ '/blog/tutorials/analog-edge-09-filters-lnas/' | relative_url }})
+covers choosing one (the [filters guide]({{ '/sdr-filters/' | relative_url }})
+has the hardware). This is also why `rf_amp` ships **off** by default in
+`config.example.yaml`: the same amplifier that lowers your noise figure on
+a quiet band overloads first on a hot one.
+
+## Why "no clipping" is not a clean bill
+
+Now the distinction this part exists to draw. Clipping and intermod are
+*level-driven* failures: back the gain off and they retreat. It is tempting
+to conclude the converse — clip ratio zero, decode still bad, therefore the
+front end is innocent and the software is guilty. [#764](https://github.com/MattCheramie/GopherTrunk/issues/764)
+is the standing counterexample: both captures peaked around −48 dBFS,
+45 dB of headroom below the rails, no clipping, no plausible intermod — and
+the 10 MS/s capture was still missing ~10 dB of usable SNR that no software
+could restore. The front end has failure modes that leave the level
+statistics pristine, and the biggest of them — oscillator phase noise, the
+actual culprit in #764 — is [Part 5]({{ '/blog/tutorials/analog-edge-05-phase-noise-reciprocal-mixing/' | relative_url }})'s
+subject. Overload is the *first* front-end suspect because it's the easiest
+to test, not the only one. Clearing it narrows the search; it doesn't end
+it. The [front end & overload lesson]({{ '/learn/rf-sdr/front-end-and-overload/' | relative_url }})
+is a gentler companion to this whole part.
+
+## Where this goes next
+
+With clipping and intermod ruled out by instruments you now know how to
+read, our marginal reader is left with the strangest failure in the series:
+a carrier that looks *clean* on every meter and still won't decode.
+[Part 5]({{ '/blog/tutorials/analog-edge-05-phase-noise-reciprocal-mixing/' | relative_url }})
+retells the ten-megasamples lesson for operators — phase noise, reciprocal
+mixing, and the carrier-clean-but-modulation-degraded signature that fooled
+the wideband FFT itself.
+
+## FAQ
+
+**What clip ratio is acceptable?**
+Zero. The metric's own threshold for "overloaded" is a sustained ~0.002 —
+one sample in 500 — but that's an alarm level, not a budget. Brief blips
+during a nearby key-up are survivable; any *resting* non-zero value means
+your loudest neighbor owns your headroom, and the next strong burst garbles
+everything (Part 2's table applies: reduce gain, or add attenuation).
+
+**How can one pager channel ruin a P25 decode two megahertz away?**
+Two ways at once. If it clips the ADC, the distortion spray is
+capture-wide. If it merely compresses the LNA, its intermod products with
+other strong signals can land directly on your channel, and the compression
+itself desensitizes everything. Distance in frequency is no protection
+inside a nonlinear front end — only level (attenuation) or selectivity
+(filters) is.
+
+**Are those regular "carriers" every N kHz real?**
+Test them: drop gain 10 dB. Real carriers drop ~10 dB; third-order intermod
+drops ~30 dB and usually vanishes. Evenly spaced ghosts that appear only at
+high gain are your own front end mixing two strong stations. (Regular
+spikes that *don't* respond to gain at all are more likely your computer's
+own switching noise — a different Part 9 problem.)
+
+**Can GopherTrunk decode through mild clipping?**
+Sometimes — FEC exists, constant-envelope modulations tolerate amplitude
+abuse better than linear ones, and a barely-clipped strong signal often
+still locks. But you're spending decode margin on a self-inflicted wound,
+and the weaker channels in the same capture are spending far more. The
+gain that stops the clipping almost always decodes better everywhere.
+
+**My hardware scanner doesn't overload in the same spot. Why?**
+Selectivity. A scanner filters the band down before most of its gain; a
+wideband SDR amplifies nearly everything the antenna delivers and filters
+late, in software — after the damage. That's not a defect, it's the
+tradeoff that makes an SDR wideband, and it's why Part 9's filters exist:
+they buy back, externally, the selectivity a scanner has built in.
+
+## Series navigation
+
+**Part 4 of 14** · ←
+[Part 3: Gain Staging — Never Chase a Software Threshold]({{ '/blog/tutorials/analog-edge-03-gain-staging/' | relative_url }})
+· Next →
+[Part 5: Phase Noise & Reciprocal Mixing — The Ten-Megasamples Lesson]({{ '/blog/tutorials/analog-edge-05-phase-noise-reciprocal-mixing/' | relative_url }})

--- a/docs/_posts/2026-08-21-tetra-end-to-end-04-scrambling-colour-codes.md
+++ b/docs/_posts/2026-08-21-tetra-end-to-end-04-scrambling-colour-codes.md
@@ -1,0 +1,283 @@
+---
+title: "TETRA End to End, Part 4: Scrambling & Colour Codes — Why Colour 0 Is Not a No-Op"
+description: "Inside TETRA's scrambler — the 32-tap LFSR, the 30-bit extended colour code that seeds it, why colour 0 still produces a real scrambling sequence, and the two seed bugs that let a control channel lock perfectly while decoding nothing: a story that sets up the DMO 'encryption' misdiagnosis."
+category: deep-dives
+keywords: tetra scrambling, tetra colour code, extended colour code, tetra lfsr seed, newscramblertetra, bsch colour zero, tetra descramble bug, scrambler bit reversal, tetra 0xc0000000, gophertrunk tetra
+tags: [tetra-end-to-end, tetra, scrambling, lfsr, colour-code, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "TETRA End to End"
+series_part: 4
+---
+
+*Part 4 of **TETRA End to End**, a 14-part deep dive into how GopherTrunk turns
+one real 25 kHz TETRA carrier — the MCC 250 / MNC 13 cell — into clear recorded
+voice.
+[Part 3]({{ '/blog/deep-dives/tetra-end-to-end-03-channel-coding-crc/' | relative_url }})
+walked the channel-coding chain back to information bits and met the
+self-consistent-synthetic trap in its CRC disguise. This part is about the
+stage that looks least deserving of its own post — the scramble, a plain XOR —
+and has hidden more failures per line of code than anything else in the TETRA
+path. Two shipped bugs lived here, both invisible to round-trip tests, both
+producing the same eerie symptom: a control channel that locks flawlessly and
+decodes nothing. And one design fact — colour 0 is not the identity — is the
+fuse that detonates three parts from now, in DMO.*
+
+> **TL;DR:** TETRA scrambling XORs type-4 bits with a sequence from a
+> **32-tap LFSR** (EN 300 392-2 §8.2.5, connection polynomial eq. 8.40,
+> tap mask `0x82608EDB`), seeded by the 30-bit **extended colour code** —
+> MCC(10) ‖ MNC(14) ‖ colour(6) (`tetra.ExtendedColourCode`). The seed
+> construction is `reverseLow30(colour) | 0xC0000000`
+> (`framing.NewScramblerTetra`): the low 30 bits are the colour code
+> **bit-reversed**, the top two bits are the constant init `p(−31)=p(−30)=1`.
+> So **colour 0 seeds `0xC0000000` — a real, non-trivial sequence**, which is
+> why the BSCH (always colour 0) still descrambles explicitly. Two bugs hid
+> here: an LFSR shifted the wrong direction (diverging from spec at the second
+> output bit) and a seed that skipped the bit reversal — each let the BSCH
+> decode (colour 0 masked them) while every colour-scrambled channel failed.
+> Both are now pinned by a **real off-air BNCH block** that only descrambles
+> CRC-clean under the correct scrambler
+> (`internal/radio/tetra/scrambler_realair_test.go`).
+
+**Key takeaways**
+
+- **Scrambling is for the channel, not for secrecy.** It whitens each cell's
+  bits with a cell-unique sequence so a receiver on a frequency reuse boundary
+  doesn't accidentally decode the co-channel neighbour — colour codes are cell
+  identity, not encryption (that's TEA, a different layer entirely).
+- **Colour 0 is a sequence, not a skip.** The constant `0xC0000000` init means
+  `NewScramblerTetra(0)` generates real output — any code path that treats
+  colour 0 as "nothing to do" is wrong by construction.
+- **The BSCH's fixed colour is what makes bugs invisible.** Both shipped
+  scrambler bugs were no-ops *for the BSCH specifically*, so lock worked, the
+  SYNC PDU parsed, and the failure surfaced one layer up as "no messages."
+- **The regression guard is a captured burst, not a round-trip.** A real BNCH
+  block from a live cell (extended colour 262144845) is committed as the
+  on-air pin: it decodes CRC-clean only under the spec-correct scrambler.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| LFSR generator | 32-tap register, taps per eq. 8.40 (`0x82608EDB`) | `internal/radio/framing/scramble_tetra.go` (`ScramblerTetra.Next`) |
+| Seed construction | `reverseLow30(colour) \| 0xC0000000` per eq. 8.42 | `scramble_tetra.go` (`NewScramblerTetra`, `reverseLow30`) |
+| (De)scramble | XOR-symmetric, one helper for both directions | `scramble_tetra.go` (`ScrambleTetra`, `DescrambleTetra`) |
+| Extended colour code | MCC(10) ‖ MNC(14) ‖ colour(6) → 30 bits | `internal/radio/tetra/sync_pdu.go` (`SyncPDU.ExtendedColourCode`) |
+| Colour learning | BSCH (colour 0) → SYNC PDU → cell colour | `internal/radio/tetra/process.go` (`processSB` path) |
+| On-air regression pin | real BNCH block, CRC-clean only when correct | `internal/radio/tetra/scrambler_realair_test.go` |
+
+## In this post
+
+- **What scrambling is for** — colour codes as cell identity, and the bootstrap ladder.
+- **The LFSR and its seed** — eq. 8.40–8.42 as thirty lines of Go.
+- **Why colour 0 is not a no-op** — the constant bits that guarantee a sequence.
+- **Two bugs, one symptom** — the shift direction and the missing bit reversal.
+- **The shortcut that survives in TMO** — `if colour != 0`, and the fuse it lights for DMO.
+
+## What scrambling is for
+
+TETRA cells reuse frequencies, and a receiver near a boundary can hear two
+cells at once. Scrambling makes each cell's bits meaningless under any other
+cell's descrambler: every channel's type-4 bits are XORed with a pseudo-random
+sequence seeded by that cell's identity, so a co-channel neighbour's burst
+fails your CRC instead of silently decoding as a wrong message. It is
+whitening plus cell addressing — **not** encryption. (TETRA's actual
+encryption, TEA, operates on the payload above the MAC; see the
+[TEA reference]({{ '/reference/tetra-tea/' | relative_url }}). Confusing the
+two layers is exactly the misdiagnosis Part 12 unwinds.)
+
+The identity in question is the **extended colour code**: 30 bits packed as
+MCC(10) ‖ MNC(14) ‖ colour(6). Our running cell broadcasts MCC 250, MNC 13 —
+and a neighbouring cell of the same network pinned in the test suite uses base
+colour 13, packing to extended colour 262144845. The bootstrap ladder from
+Part 2 completes here: the BSCH is scrambled with colour 0 by spec (§8.2.5.2),
+a cold receiver decodes it with `NewScramblerTetra(0)`, reads MCC/MNC/colour
+from the SYNC PDU, calls `ExtendedColourCode()`, and from that moment every
+BNCH, SCH and traffic channel on the cell is descramblable. No operator
+configuration — the cell tells you its own key.
+
+## The LFSR and its seed
+
+The generator is thirty lines. The connection polynomial (eq. 8.40) becomes a
+tap mask; the recurrence (eq. 8.41) becomes popcount-parity of the masked
+state; the initialisation (eq. 8.42) becomes the seed layout:
+
+```go
+// internal/radio/framing/scramble_tetra.go (shape)
+const scrambleTetraTapMask uint32 = 0x82608EDB // c(x) taps, eq. 8.40
+
+func NewScramblerTetra(colourCode uint32) *ScramblerTetra {
+    return &ScramblerTetra{
+        state: reverseLow30(colourCode) | 0xC0000000, // e(1..30) reversed + p(−31)=p(−30)=1
+    }
+}
+
+func (s *ScramblerTetra) Next() byte {
+    v := s.state & scrambleTetraTapMask
+    bit := byte(popcount32(v) & 1)
+    s.state = (s.state << 1) | uint32(bit) // shift LEFT, insert at bit 0
+    return bit
+}
+```
+
+Every subtlety lives in the seed line. Eq. 8.42 demands state bit *i* hold
+e(*i*+1) — but the packed colour-code value carries e(1) in its **most**
+significant bit, so the low 30 bits must be bit-reversed on the way into the
+register (`reverseLow30`). And the top two bits are hardwired to 1: the spec's
+`p(−31) = p(−30) = 1`.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 200" width="680" height="200" role="img" aria-label="The TETRA scrambler seed layout: a 32-bit register whose top two bits are the constant ones from the spec initialisation, and whose low thirty bits hold the extended colour code bit-reversed. Below, the colour-zero case shows the register holding 0xC0000000 — still a real seed producing a real scrambling sequence.">
+  <rect x="30" y="40" width="80" height="40" fill="var(--accent)" opacity="0.3" stroke="var(--accent)"/>
+  <rect x="110" y="40" width="540" height="40" fill="none" stroke="currentColor"/>
+  <text x="70" y="64" text-anchor="middle" fill="var(--accent)" font-size="11">1 1</text>
+  <text x="70" y="30" text-anchor="middle" fill="var(--accent)" font-size="9">p(−31), p(−30) — constant</text>
+  <text x="380" y="64" text-anchor="middle" fill="currentColor" font-size="11">e(30) … e(2) e(1)   ← extended colour code, bit-reversed</text>
+  <text x="380" y="30" text-anchor="middle" fill="var(--fg-muted)" font-size="9">30 bits: MCC(10) ‖ MNC(14) ‖ colour(6), e(1) ends up in state bit 0</text>
+  <text x="30" y="98" fill="var(--fg-muted)" font-size="9">bit 31</text>
+  <text x="620" y="98" fill="var(--fg-muted)" font-size="9">bit 0</text>
+  <rect x="30" y="120" width="80" height="34" fill="var(--accent)" opacity="0.3" stroke="var(--accent)"/>
+  <rect x="110" y="120" width="540" height="34" fill="none" stroke="var(--fg-muted)"/>
+  <text x="70" y="141" text-anchor="middle" fill="var(--accent)" font-size="11">1 1</text>
+  <text x="380" y="141" text-anchor="middle" fill="var(--fg-muted)" font-size="11">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</text>
+  <text x="340" y="180" text-anchor="middle" fill="currentColor" font-size="10">colour 0 ⇒ state = 0xC0000000 — the two constant bits still drive the LFSR: a REAL sequence, not identity</text>
+</svg>
+<figcaption>The seed register: two hardwired 1s above thirty bit-reversed colour-code bits. At colour 0 the constants remain — the scrambler still scrambles.</figcaption>
+</figure>
+
+## Why colour 0 is not a no-op
+
+Look at the colour-0 row of that figure. Zero colour bits, but the register is
+`0xC0000000`, not zero — the two constant bits guarantee the LFSR never starts
+empty, so `NewScramblerTetra(0)` emits a genuine pseudo-random sequence. This
+is why the BSCH decoders *always* run the descramble: "scrambled with colour
+0" means XORed with a real 120-bit sequence, not left alone.
+
+The design intuition matters more than the trivia. If colour 0 were the
+identity, an all-zeros register would also be a fixed point of the LFSR and a
+degenerate cell configuration would transmit raw bits. The spec's constant
+init closes that. But it also means any code path written as "colour 0 ⇒
+nothing to descramble" is a landmine that *happens* not to explode wherever
+colour 0 never legitimately occurs — hold that thought for two sections.
+
+## Two bugs, one symptom
+
+Both shipped scrambler bugs produced the identical clinical picture: training
+sequences correlate, the BSCH decodes, the SYNC PDU parses, `cc.locked` goes
+true — and not one BNCH SYSINFO or SCH message ever decodes. Lock without
+comprehension.
+
+**Bug one: the shift direction** (issue #925). The original `Next()` shifted
+the register right and inserted the new bit at bit 31 — reversing the register
+relative to the tap convention, so the output sequence diverged from eq. 8.41
+at p(2). The second output bit was already wrong.
+
+**Bug two: the missing bit reversal.** The seed loaded the packed colour value
+raw, without `reverseLow30`. For the BSCH this is invisible — zero reversed is
+zero — and for every round-trip test it is invisible too, because encode and
+decode shared the reversed-wrong seed.
+
+Notice what both bugs have in common with Part 3's CRC: **colour 0 is a fixed
+point of the mistake**. The BSCH — the channel that produces the visible
+"lock" — was immune to both, so the health indicator stayed green while the
+payload channels rotted. And both were self-consistent under round-trip. The
+fix came with the only kind of test that can hold it: a real SCH/HD block
+captured off-air from a live BNCH — 108 dibits exactly as a real base station
+scrambled them, extended colour 262144845 — committed in
+`scrambler_realair_test.go`. It FEC-decodes CRC-clean under the corrected
+scrambler and fails under either bug. One captured burst does what a thousand
+synthetic round-trips cannot: it pins the implementation to the world.
+
+## The shortcut that survives in TMO
+
+With the scrambler correct, one optimisation crept into the traffic path and
+deserves a hard look, because it is the fuse for Part 12:
+
+```go
+// internal/radio/tetra/traffic.go (shape) — emit
+bits := TetraDibitsToBits(d)
+if te.colourCode != 0 {
+    bits = framing.DescrambleTetra(bits, te.colourCode)
+}
+te.onBurst(framing.PackBitsMSB(bits), te.softFrame(L), te.slotOf(L), te.usageOf(L))
+```
+
+"Descramble only when we have a colour" reads as sensible defensive coding —
+zero here really means *the extractor hasn't been told the colour yet*, and
+descrambling with a wrong guess would be worse than not descrambling. In TMO
+this is safe for a structural reason: a real cell's extended colour code packs
+MCC and MNC into the high 24 bits, and a live network's MCC/MNC are never both
+zero — so extended colour 0 never occurs on a TMO carrier, and the `!= 0`
+guard only ever gates the "colour unknown" startup window.
+
+But the guard *encodes the wrong idea* — it conflates "colour unknown" with
+"colour 0 needs no descramble," and the second half of that is false, as this
+whole post established. TETRA DMO, where radios legitimately operate at colour
+0 with no MNI, inherited this exact shortcut — and clear, unencrypted DMO
+voice arrived at the Viterbi still scrambled, producing a chance-floor CRC
+yield that got misread as encryption.
+[Part 12]({{ '/blog/deep-dives/tetra-end-to-end-12-dmo-descramble-colour/' | relative_url }})
+tells that story in full; the point to carry forward is that the bug was
+armed *here*, in a TMO-safe shortcut, years before DMO pulled the trigger.
+
+### How that principle shaped the Go code
+
+- **One generator, both directions.** `DescrambleTetra` is an alias of
+  `ScrambleTetra` because XOR is symmetric — there is no second implementation
+  to drift.
+- **The seed's invariants are in the doc comment.** `NewScramblerTetra`'s
+  comment spells out which bugs are invisible to which tests (BSCH as a
+  bit-reversal fixed point; round-trips sharing the seed) — the failure
+  analysis lives next to the line that can cause it.
+- **The on-air pin is data, not prose.** `realBNCHBlock` is a base64 constant
+  in the test file; any future scrambler "cleanup" that breaks spec
+  compliance fails CI against a burst a real base station transmitted.
+
+## Where this goes next
+
+The scrambler was the last stage between us and payload. 
+[Part 5]({{ '/blog/deep-dives/tetra-end-to-end-05-tchs-traffic-channel/' | relative_url }})
+finally decodes what the grants promised: TCH/S, the full-rate speech traffic
+channel — two 137-bit speech frames per slot, the class-0/1/2 bit
+sensitivity split, the AACH usage marker that routes concurrent same-carrier
+calls, and the replay harness that correlated decoded slots against the
+control channel's grant timeslots on real air.
+
+## FAQ
+
+**Is a colour code a security feature?**
+No. It's cell addressing — six bits of colour plus the network's MCC/MNC,
+public by definition (the cell broadcasts them in the clear on its BSCH).
+Anyone who can decode the BSCH can descramble the cell. Encryption in TETRA is
+TEA, a separate mechanism at a higher layer.
+
+**Why does the BSCH use colour 0 instead of the cell's colour?**
+Chicken and egg: the colour code is *learned from* the BSCH, so the BSCH must
+be decodable before you know it. Fixing its scrambler seed at colour 0 (still
+a real sequence — `0xC0000000`) gives every receiver a universal entry point.
+
+**How would I recognise a scrambler bug in the field?**
+The signature is precisely asymmetric: sync correlates and the BSCH/SYNC PDU
+decode (they're colour 0), the decoder reports lock, and the message counters
+for everything colour-scrambled — BNCH SYSINFO, SCH grants — sit at zero or at
+a CRC chance floor. Lock without messages means look at the scrambler seed
+path before anything else.
+
+**Why commit a captured burst instead of a longer synthetic test?**
+Because every synthetic test shares the implementation's assumptions — Part
+3's lesson. The committed BNCH block was scrambled by a real base station, so
+it checks GopherTrunk against the spec as deployed, not against itself. It
+turned two "works in tests, dead on air" bugs into ordinary red tests.
+
+**Does the `colourCode != 0` guard in the traffic extractor ever misfire in TMO?**
+Not on a real network — extended colour 0 requires MCC = MNC = colour = 0,
+which no live TMO cell broadcasts. The guard's real cost was conceptual: it
+taught the codebase that colour 0 means "skip," and the DMO path (where colour
+0 is routine) copied that lesson verbatim. Part 12 is the invoice.
+
+## Series navigation
+
+**Part 4 of 14** · ←
+[Part 3: Channel Coding — RCPC, Viterbi & the CRC That Isn't an LFSR]({{ '/blog/deep-dives/tetra-end-to-end-03-channel-coding-crc/' | relative_url }})
+· Next →
+[Part 5: TCH/S — From Traffic Burst to Speech Frame]({{ '/blog/deep-dives/tetra-end-to-end-05-tchs-traffic-channel/' | relative_url }})

--- a/docs/_posts/2026-08-21-weak-signal-engineering-04-blind-cma.md
+++ b/docs/_posts/2026-08-21-weak-signal-engineering-04-blind-cma.md
@@ -1,0 +1,297 @@
+---
+title: "Weak-Signal Engineering, Part 4: Blind Equalization — CMA From First Principles"
+description: The Constant Modulus Algorithm built from its cost function up — how the Godard gradient becomes a five-line tap update in GopherTrunk's cma.go, why constant-envelope PSK is the perfect prey, why the algorithm needs a noise floor to be well-posed, and where the spurious minima behind Part 2's EVM trap come from.
+category: deep-dives
+keywords: constant modulus algorithm, cma equalizer, blind equalization, godard cost function, stochastic gradient descent dsp, adaptive fir taps, pi/4-dqpsk equalizer, spurious minima, gophertrunk weak-signal engineering
+tags: [weak-signal-engineering, cma, equalizer, dsp, adaptive-filters, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Weak-Signal Engineering"
+series_part: 4
+---
+
+*Part 4 of **Weak-Signal Engineering**, a 14-part deep dive into decoding the
+marginal regime, where a receiver locks but under-decodes.
+[Part 3]({{ '/blog/deep-dives/weak-signal-engineering-03-isi-linear-channel/' | relative_url }})
+established that the smear on our thread capture is a convolution — invertible
+by another filter, if only we could find it. The catch: on a live control
+channel there's no training sequence conveniently aligned for us, no pilot, no
+known symbols at all from the receiver's point of view. This part is about
+finding the inverse filter *blind* — using nothing but a statistical property
+the transmitted signal is known to have — and about the exact price that
+bargain exacts, which Parts 5 and 6 then pay down.*
+
+> **TL;DR:** PSK-family signals leave the transmitter with **constant
+> modulus** — every symbol on one circle. A dispersive channel destroys that
+> property; the **Constant Modulus Algorithm** exploits it by adapting FIR taps
+> to minimise the Godard cost **`J = E[(|y|² − R²)²]`** by stochastic gradient
+> descent: `w ← w − μ·(|y|²−R²)·y·conj(x)`, five lines in
+> `internal/dsp/equalizer/cma.go`. It is genuinely blind — no reference, no
+> framing — which is why it can run inside a receiver that hasn't synchronised
+> yet. The costs: the cost function never mentions *correctness* (spurious
+> constant-modulus minima — Part 2's EVM trap is one), its output **phase is
+> unconstrained** (fatal before a differential decoder — Part 5), the update
+> scales with **|x|³** so normalisation is load-bearing (Part 6), and a
+> literally noise-free constant-modulus input is a **degenerate case** — which
+> is why GopherTrunk's synthetic equalizer tests deliberately add noise.
+
+**Key takeaways**
+
+- **CMA needs to know one thing about the signal, and PSK guarantees it.**
+  Constant envelope is a property of the *modulation*, known before any
+  decode. That's what makes blind operation possible on an unsynchronised
+  channel.
+- **The update is the cost's own gradient, one sample at a time.** No matrix
+  inversions, no block processing: an 11-tap FIR and a rank-1 update per
+  symbol. Cheap enough to leave on permanently.
+- **Center-spike initialisation makes it fail-safe.** Starting as a
+  pass-through means an unconverged (or unneeded) equalizer is a wire, not a
+  hazard — the "no regression on clean captures" half of every result.
+- **Blindness has structural costs, not tuning costs.** Spurious minima,
+  phase indifference, and scale sensitivity are properties of the cost
+  function itself. The next two parts are engineering around them, not
+  parameter-tweaking them away.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| The classic algorithm | Godard/CMA-2 cost, gradient, caveats | `internal/dsp/equalizer/cma.go` (`CMA`, `NewCMA`) |
+| Per-sample update | FIR output + `w −= μ·err·y·conj(x)` | `cma.go` (`Process`) |
+| Differential-safe wrapper | adapt always, apply frozen snapshots | `internal/dsp/equalizer/snapshot_cma.go` (`SnapshotCMA`) — Part 5 |
+| Failing-first ISI regression | multipath channel: hard decode fails raw, passes equalized | `snapshot_cma_test.go` (`TestSnapshotCMARecoversISIChannel`) |
+| No-harm guard | clean signal in ⇒ essentially unchanged out | `snapshot_cma_test.go` (`TestSnapshotCMAHarmlessOnCleanSignal`) |
+| Concept reference | CMA in the reference library | [`/reference/cma-equalizer/`]({{ '/reference/cma-equalizer/' | relative_url }}), [`/reference/adaptive-filter/`]({{ '/reference/adaptive-filter/' | relative_url }}) |
+
+## In this post
+
+- **The property the channel can't hide** — constant modulus as prior knowledge.
+- **From cost to update rule** — deriving the five lines in `cma.go`.
+- **Reading the real implementation** — history ring, error proxy, center spike.
+- **The fine print** — spurious minima, and why blind can mean confidently wrong.
+- **The degenerate case** — why the synthetic tests add noise on purpose.
+
+## The property the channel can't hide
+
+Everything blind equalization knows about the world fits in one sentence: *the
+transmitter emitted symbols of constant magnitude.* For
+[π/4-DQPSK]({{ '/reference/pi-4-dqpsk/' | relative_url }}), QPSK, and the rest
+of the PSK family, information rides entirely in phase; every transmitted
+symbol sits on one circle of radius R. A dispersive channel — Part 3's
+convolution — sums each symbol with scaled, rotated echoes of its neighbours,
+and a sum of vectors of fixed length has *variable* length. Magnitude spread
+at the receiver is therefore not noise-like bad luck; it is a **measurement of
+the ISI**. Squeeze the output magnitudes back onto one circle and you have —
+up to the fine print below — undone the mixing.
+
+That inversion of perspective is the elegant part: the modulation's most
+boring property (we deliberately put no information in amplitude) becomes the
+observable that lets a receiver learn the channel with no cooperation from the
+transmitter, no frame sync, and no decoded bits. Which is exactly what a
+control-channel receiver needs, since the equalizer has to help *before*
+decoding succeeds — on the thread capture, decoding mostly *isn't* succeeding.
+
+## From cost to update rule
+
+Formalise "squeeze onto one circle" and the algorithm falls out. Let `y[n]`
+be the equalizer output — an FIR over the received samples,
+`y = Σ_k w_k·x[n−k]`. Godard's CMA-2 cost penalises squared deviation of the
+squared modulus from a target `R²`:
+
+`J = E[(|y|² − R²)²]`
+
+Differentiate with respect to the conjugate taps (the Wirtinger convention
+that `lms.go`'s comments walk through for the trained case) and the gradient
+comes out proportional to `(|y|² − R²)·y·conj(x)`. Descend it one sample at a
+time — stochastic gradient, the same move LMS makes — and you get the whole
+algorithm. GopherTrunk's `cma.go` states it in its doc comment exactly as the
+math reads:
+
+```go
+// internal/dsp/equalizer/cma.go (shape) — the contract
+// Cost function and gradient (Godard / CMA-2):
+//
+//	J = E[(|y|^2 - R^2)^2]
+//	∂J/∂w*  ∝  (|y|^2 - R^2) · y · conj(x)
+//	w[n+1]  =  w[n]  -  μ · (|y|^2 - R^2) · y · conj(x)
+//
+// Pick R^2 so the equilibrium weight scaling matches the expected
+// constellation. For unit-magnitude PSK use R^2 = 1 …
+```
+
+Read the update rule's anatomy, because each factor earns its keep.
+`(|y|² − R²)` is the *signed* modulus error: outputs outside the circle push
+taps one way, inside the other, and on the circle the update vanishes.
+`y·conj(x)` steers the correction along the input history — the same
+directional term every adaptive FIR uses. And `μ` is the eternal step-size
+trade: fast convergence versus a noisy equilibrium. Notice what the rule never
+consults: a reference symbol, a decision, a frame boundary. That absence *is*
+the blindness — and it's also the door the failure modes walk through.
+
+## Reading the real implementation
+
+`Process` in `cma.go` is the derivation transcribed, plus the practicalities:
+a ring buffer for the input history, and manual complex arithmetic so the hot
+loop stays allocation-free:
+
+```go
+// internal/dsp/equalizer/cma.go (shape) — Process
+// Error proxy = |y|^2 - R^2.
+mag2 := yr*yr + yi*yi
+err := mag2 - c.target
+
+// Weight update: w_k -= μ · err · y · conj(x[n-k]).
+mu := c.stepSize
+/* … walk the history ring … */
+ur := yr*xr + yi*xi        // y·conj(x), real part
+ui := yi*xr - yr*xi        //            imag part
+c.taps[i] = complex(tr-mu*err*ur, ti-mu*err*ui)
+```
+
+Two constructor-time choices matter more than any parameter. First,
+**center-spike initialisation**: `NewCMA` sets `taps[N/2] = 1` with all others
+zero, so tap zero state is an identity filter with a fixed delay. An
+unconverged equalizer passes the signal through untouched — which is why
+`TestSnapshotCMAHarmlessOnCleanSignal` can demand a clean channel stay clean,
+and why enabling the equalizer fleet-wide was a defensible default rather than
+a gamble. Second, `Process` returns the error proxy `|y|²−R²` alongside the
+output: watch it settle toward zero and you are watching convergence, no
+decoded bits required.
+
+One more block in `cma.go` deserves a mention because it previews Part 5's
+theme. The constant-modulus cost is invariant to rotating *all* taps by a
+common phase — rotate every `w_k` by `e^{jθ}` and `|y|` doesn't change — so
+the gradient has a null direction and the tap phase random-walks, driven by
+noise. `cma.go` handles the symptom that bit first (a downstream carrier loop
+integrating the drift, [#492](https://github.com/MattCheramie/GopherTrunk/issues/492))
+by re-anchoring the centre tap to the positive real axis after each update.
+That keeps the output phase *slowly varying* — good enough for a coherent
+loop, and, as Part 5 will show in detail, *not* good enough for a
+differential decoder.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 210" width="680" height="210" role="img" aria-label="Three constellations showing CMA converging. Left: received symbols scattered at many radii around the unit circle, labeled ISI in, cost J large. Middle: partially converged, symbols pulled toward the circle. Right: converged, symbols sitting on the circle, cost near zero — with a note that the ring's rotation is unconstrained. Beneath, an arrow labeled per-sample tap updates, w minus mu times modulus error times y conj x, spans the three panels.">
+  <circle cx="115" cy="90" r="52" fill="none" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <g fill="currentColor">
+    <circle cx="140" cy="60" r="3"/><circle cx="90" cy="52" r="3"/><circle cx="150" cy="110" r="3"/><circle cx="82" cy="122" r="3"/>
+    <circle cx="115" cy="90" r="3"/><circle cx="170" cy="82" r="3"/><circle cx="62" cy="86" r="3"/><circle cx="126" cy="146" r="3"/>
+    <circle cx="103" cy="30" r="3"/><circle cx="155" cy="140" r="3"/>
+  </g>
+  <text x="115" y="168" text-anchor="middle" fill="var(--fg-muted)" font-size="9">ISI in: |y| spread wide, J large</text>
+  <circle cx="340" cy="90" r="52" fill="none" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <g fill="currentColor">
+    <circle cx="388" cy="76" r="3"/><circle cx="378" cy="122" r="3"/><circle cx="340" cy="40" r="3"/><circle cx="296" cy="66" r="3"/>
+    <circle cx="290" cy="106" r="3"/><circle cx="318" cy="136" r="3"/><circle cx="362" cy="46" r="3"/><circle cx="348" cy="140" r="3"/>
+  </g>
+  <text x="340" y="168" text-anchor="middle" fill="var(--fg-muted)" font-size="9">adapting: pulled toward the circle</text>
+  <circle cx="565" cy="90" r="52" fill="none" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <g fill="var(--accent)">
+    <circle cx="617" cy="90" r="3.5"/><circle cx="602" cy="53" r="3.5"/><circle cx="565" cy="38" r="3.5"/><circle cx="528" cy="53" r="3.5"/>
+    <circle cx="513" cy="90" r="3.5"/><circle cx="528" cy="127" r="3.5"/><circle cx="565" cy="142" r="3.5"/><circle cx="602" cy="127" r="3.5"/>
+  </g>
+  <text x="565" y="168" text-anchor="middle" fill="var(--accent)" font-size="9">converged: J ≈ 0 — rotation still free</text>
+  <line x1="60" y1="188" x2="620" y2="188" stroke="currentColor"/><polygon points="620,184 630,188 620,192" fill="currentColor"/>
+  <text x="340" y="202" text-anchor="middle" fill="var(--fg-muted)" font-size="10">per-sample updates: w ← w − μ·(|y|²−R²)·y·conj(x) — no reference symbols consulted, ever</text>
+</svg>
+<figcaption>CMA drives output magnitudes onto the modulation's known circle using only the modulus error — but nothing in the cost pins the ring's rotation, or guarantees the phases on it are the transmitted ones.</figcaption>
+</figure>
+
+## The fine print: spurious minima
+
+Here is where Part 2's trap stops being an anecdote and becomes a theorem-
+shaped fact. `J` is a fourth-order surface over the tap space, and it is *not*
+convex. Its global minima are the channel inverses we want (at arbitrary
+rotation and delay — all equally good). But it also has **local minima that
+satisfy constant modulus without inverting the channel** — tap vectors whose
+output sits beautifully on a circle while remaining a scrambled function of
+the transmitted symbols. A finite-length FIR trying to invert a channel it
+can't perfectly represent makes more of them, and noise plus a finite step
+size lets the descent wander into one and stay.
+
+Sit with what that means operationally: **CMA's own convergence diagnostics
+cannot distinguish success from a spurious minimum.** The error proxy settles
+near zero either way. EVM improves either way — that is precisely how a
+numerically-unstable variant printed 34%→8% while decoding *nothing*. The only
+external observer that can tell the difference is the decoder: CRC yield, the
+Part 2 verdict, measured through the whole chain. This is also the honest case
+for Part 7's trained equalizer: a known reference collapses the ambiguity —
+`e = d − y` is only zero at the *right* answer — which is why the midamble
+path exists even with a working blind path in production.
+
+## The degenerate case: why the tests add noise
+
+One last subtlety, discovered the practical way when a daemon-level synthetic
+TETRA test started exercising the CC equalizer. A synthesized, perfectly
+clean, perfectly constant-modulus input is a **degenerate input for CMA**: the
+modulus error is zero for the identity filter *and* for a continuum of other
+tap vectors that happen to preserve modulus on that pristine signal — the cost
+surface goes flat in directions that real signals would penalise, and the taps
+drift on numerical noise with nothing to anchor them. Blind CMA is well-defined
+only *against a noise floor*.
+
+So GopherTrunk's synthetic fixtures add one on purpose: the receiver-level
+clean-channel test runs at 30 dB SNR, and the daemon's synthetic TETRA CC test
+adds 40 dB AWGN — not to make the tests harder, but to make the algorithm's
+problem well-posed. It's a pleasing inversion of the usual instinct, and a
+small instance of the self-consistent-synthetic trap this project keeps
+guarding against: a test input can be *too* ideal to represent the air, and
+"add realistic impairment" is sometimes a correctness requirement, not
+pessimism.
+
+## Where this goes next
+
+We now have a filter that finds the channel inverse blind — and a cost
+function that is provably indifferent to output rotation. Between snapshots of
+adaptation, that indifference is fatal to exactly the decoder TETRA uses.
+[Part 5]({{ '/blog/deep-dives/weak-signal-engineering-05-snapshot-trick/' | relative_url }})
+is the snapshot trick: why a continuously-adapting CMA ahead of a differential
+decoder measures CRC **zero**, why frozen taps alone measure baseline, and how
+`SnapshotCMA`'s adapt-continuously-apply-frozen design gets both — taking the
+thread capture from ~12% to ~100% BSCH in the process.
+
+## FAQ
+
+**How many taps, and what step size, does GopherTrunk actually run?**
+The TETRA receiver's defaults are 11 taps, μ = 6e-3, refreshing the applied
+snapshot every 200 symbols (`DefaultEqualizerTaps` / `DefaultEqualizerMu` /
+`DefaultEqualizerSnapshot` in `internal/radio/tetra/receiver/receiver.go`),
+validated on the reporter captures and the synthetic multipath fixtures. At
+18k symbols/s, 11 symbol-spaced taps span ±5 symbols of channel memory —
+generous for the delay spreads a 25 kHz land-mobile channel serves up.
+
+**Why CMA-2 (squared modulus) instead of penalising |y| − R directly?**
+The squared form makes the cost a smooth polynomial in the taps — the gradient
+is algebraic (`err·y·conj(x)`), with no square roots or divisions per sample.
+The classic CMA(1,2)/CMA(2,2) family trades exactly these smoothness-vs-
+robustness properties; CMA-2 is the conventional choice for exactly this
+gradient simplicity.
+
+**Does CMA work on C4FM or QAM?**
+Not as-is. `cma.go`'s caveat list is explicit: on non-constant-modulus signals
+(FM-family, OQPSK, QAM) the cost isn't zero at the right answer. C4FM is
+four-level FSK demodulated through a discriminator — a different signal model,
+and part of why P25 Phase 1's equalizer story (Part 13) isn't a copy-paste of
+TETRA's. QAM needs modified costs or decision-directed
+[LMS]({{ '/reference/lms-algorithm/' | relative_url }}).
+
+**Could I detect a spurious minimum without running the decoder?**
+Not reliably from inside the equalizer — that's the sober conclusion of the
+34%→8% incident. Modulus error, EVM, even constellation appearance are all
+satisfied at spurious minima. Structural defenses exist (center-spike restarts
+make you start at the identity, Part 6's guards re-seed on divergence), but
+verification is external by nature: decode to CRC.
+
+**If blind equalization is this fragile, why not always train?**
+Training needs known symbols at known positions — which requires burst framing,
+which on a control channel you're still *acquiring* may not exist yet. Blind
+CMA works pre-sync, streaming, with no framing at all; that's an operating
+regime training can't reach. The two are complementary, not competing: blind
+in the receiver (Parts 5–6), trained in the extractor where midambles are
+locatable (Part 7).
+
+## Series navigation
+
+**Part 4 of 14** · ←
+[Part 3: ISI & the Linear Channel — What an Equalizer Can & Can't Fix]({{ '/blog/deep-dives/weak-signal-engineering-03-isi-linear-channel/' | relative_url }})
+· Next →
+[Part 5: The Snapshot Trick — Frozen Taps & Differential Decoders]({{ '/blog/deep-dives/weak-signal-engineering-05-snapshot-trick/' | relative_url }})

--- a/docs/_posts/2026-08-22-analog-edge-05-phase-noise-reciprocal-mixing.md
+++ b/docs/_posts/2026-08-22-analog-edge-05-phase-noise-reciprocal-mixing.md
@@ -1,0 +1,275 @@
+---
+title: "The Analog Edge, Part 5: Phase Noise & Reciprocal Mixing — The Ten-Megasamples Lesson"
+description: "The front-end failure no level meter can see: how oscillator phase noise smears modulation while leaving the carrier looking clean, retold for operators through the #764 verdict — same antenna, same signal, 10 dB of demod SNR gone at one sample rate and not the other."
+category: tutorials
+keywords: phase noise sdr, reciprocal mixing, local oscillator noise, carrier clean modulation degraded, demod snr vs fft snr, airspy 10 msps, evm degradation, sample rate signal quality, gophertrunk analog edge
+tags: [analog-edge, phase-noise, oscillator, sdr, debugging, tutorial]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "The Analog Edge"
+series_part: 5
+---
+
+*Part 5 of **The Analog Edge**, a 14-part field guide to the analog half of a
+GopherTrunk installation. [Part 4]({{ '/blog/tutorials/analog-edge-04-clipping-overload-intermod/' | relative_url }})
+closed with a warning: clearing clipping and intermod narrows the front-end
+search but doesn't end it, because the worst analog failure leaves every
+level statistic pristine. This part is that failure — the one that cost the
+project its longest hunt, [#764](https://github.com/MattCheramie/GopherTrunk/issues/764),
+and taught the signature our marginal reader most needs to recognize:
+**carrier-clean but modulation-degraded**. If your waterfall looks great and
+your decoder disagrees, this is the part to read twice.*
+
+> **TL;DR:** Your tuner's **local oscillator** is multiplied into every
+> sample, so its **phase noise** — tiny random jitter in when it crosses
+> zero — lands directly on the received phase. On a phase-modulated signal
+> that *is* the payload. The [#764](https://github.com/MattCheramie/GopherTrunk/issues/764)
+> verdict, from the reporter's own captures of one site on one antenna: at
+> **2.5 MS/s**, demod SNR ≈ **19.7 dB**, EVM 7.4%, locks; at **10 MS/s**,
+> demod SNR ≈ **9.5 dB**, EVM 22.5%, never locks. Neither clips (both peak
+> ≈ −48 dBFS), and the wideband FFT carrier SNR was actually **higher** at
+> 10 MS/s. An independent-resampler A/B pinned the deficit into the samples
+> themselves — the signature of **front-end phase noise / reciprocal
+> mixing** at the Airspy's native 10 MS/s clock. Operator rule: **prefer
+> rates your front end is clean at, and never trust an FFT to grade
+> modulation.**
+
+**Key takeaways**
+
+- **The LO's flaws are multiplied into every sample.** Mixing doesn't add
+  the oscillator's jitter, it *transfers* it — every received symbol
+  inherits the LO's phase wander, and no downstream filter can remove what
+  is now part of the signal.
+- **Carrier-clean but modulation-degraded is the tell.** Power metrics, the
+  waterfall, even wideband FFT SNR stay healthy while EVM balloons and
+  demod SNR collapses. It's the one front-end failure the whole level
+  toolkit of Parts 2–4 cannot see.
+- **Reciprocal mixing turns neighbors into noise.** A noisy LO also smears
+  every *strong nearby* signal's energy across your channel — the receiver
+  equivalent of everyone on the band shouting through your oscillator.
+- **The capture rate can change the analog front end.** Same chip, same
+  antenna, different sampling configuration, different oscillator
+  behavior — which is why "works at 2.5 MS/s, fails at 10 MS/s" can be a
+  true statement about *hardware*, not software.
+
+## Cheat sheet
+
+| Concern | What it tells you | Where it lives |
+|---|---|---|
+| The physics, one page | oscillator jitter → carrier skirts → reciprocal mixing | [Phase noise]({{ '/reference/phase-noise/' | relative_url }}) |
+| The full detective story | two real bugs, one red herring, one verdict | [Ten Megasamples]({{ '/blog/solution-postmortem/from-the-issue-tracker-05-ten-megasamples/' | relative_url }}) |
+| The quality number that matters | demod SNR / EVM from the actual receiver | `gophertrunk replay` metrics; the rate-invariance test in `internal/scanner/ccdecoder/ddc_highrate_test.go` |
+| Proving it's the samples | independent-resampler A/B, in depth | [Weak-Signal Engineering, Part 12]({{ '/blog/deep-dives/weak-signal-engineering-12-proving-signal/' | relative_url }}) |
+| Rate choice on Airspy hardware | which rates the front end favors | [Airspy rate selection]({{ '/reference/airspy-rate-selection/' | relative_url }}) |
+| Why levels can't see it | both #764 captures peaked ≈ −48 dBFS | Part 2's regime table |
+
+## In this post
+
+- **The symptom that didn't fit** — everything measured healthy, nothing
+  decoded.
+- **What phase noise actually does** — skirts, smear, and reciprocal
+  mixing.
+- **The verdict, in numbers** — the two-capture table.
+- **Why the wideband FFT lied** — integrated power vs symbol accuracy.
+- **What an operator does about it** — rates, A/Bs, and when to stop
+  blaming software.
+
+## The symptom that didn't fit
+
+Rewind the story to where an operator would have stood. Four P25 control
+channels on one Airspy R2. At 2.5 MS/s, the nearest tap decodes cleanly. To
+cover all four, the rate goes up to 10 MS/s — and every tap goes dark,
+*including the strong one that just worked*. Levels: fine, ≈ −48 dBFS peak,
+no clipping (Part 4's tests all pass). Waterfall: the carriers are right
+there, plainly visible. Two genuine software bugs were found and fixed along
+the way — a per-tap CPU blowup and a hardcoded channelizer bin count — and
+the symptom *survived them*, even in pure offline replay of the captures
+([#771](https://github.com/MattCheramie/GopherTrunk/issues/771)). Every
+level instrument in Parts 2–4 said "healthy"; the decoder said no. When your
+instruments and your outcome disagree that stubbornly, you're missing an
+instrument — and the missing one here measures *phase*.
+
+## What phase noise actually does
+
+A receiver tunes by multiplying the incoming spectrum against a local
+oscillator. In the idealized diagram the LO is a perfect sinusoid — a
+single infinitely thin spectral line. A real oscillator wobbles: each zero
+crossing arrives a few picoseconds early or late, at random. In the
+frequency domain that timing jitter becomes **skirts** — a pedestal of
+noise spreading out from the carrier line, described in dBc/Hz at various
+offsets (the [Field Guide entry]({{ '/reference/phase-noise/' | relative_url }})
+unpacks the units).
+
+Multiplication transfers those skirts onto everything the receiver hears,
+and that hurts you twice:
+
+- **Directly:** your wanted carrier is convolved with the LO's smear, so
+  each symbol's phase arrives with the oscillator's wander added. For a
+  phase-carrying modulation — P25's C4FM ultimately conveys frequency/phase
+  trajectories; TETRA's π/4-DQPSK is explicitly differential phase — that
+  wander is indistinguishable from noise *in exactly the dimension the data
+  lives in*.
+- **Reciprocally:** every *strong neighbor* in the front end's view is also
+  convolved with the skirts, and the edges of a strong neighbor's smear
+  land on your channel as broadband noise. This is **reciprocal mixing** —
+  a clean signal into a noisy oscillator produces the same in-channel floor
+  as a noisy signal into a clean oscillator. On a busy trunking band with
+  strong carriers everywhere, a modest LO can set your noise floor all by
+  itself.
+
+Note what neither mechanism touches: total power. The energy isn't removed,
+it's *relocated* — from crisp symbol positions into a blur around them.
+Every level metric of Parts 2–4 conserves; only symbol-accuracy metrics
+(EVM, demod SNR, error rate, CRC yield) see the loss.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 220" width="680" height="220" role="img" aria-label="Left: a clean local oscillator drawn as a single thin spectral line yields a tight four-point constellation. Right: a noisy local oscillator drawn with wide skirts around its line yields the same constellation smeared into arcs, with a note that total power is unchanged while symbol accuracy is destroyed. Underneath, a strong neighbor's skirt is shown overlapping the wanted channel, labelled reciprocal mixing.">
+  <line x1="30" y1="110" x2="300" y2="110" stroke="var(--fg-muted)"/>
+  <polyline points="150,110 155,20 160,110" fill="none" stroke="currentColor"/>
+  <text x="155" y="14" text-anchor="middle" fill="currentColor" font-size="9">clean LO</text>
+  <circle cx="245" cy="45" r="4" fill="var(--accent)"/><circle cx="275" cy="45" r="4" fill="var(--accent)"/>
+  <circle cx="245" cy="75" r="4" fill="var(--accent)"/><circle cx="275" cy="75" r="4" fill="var(--accent)"/>
+  <text x="260" y="98" text-anchor="middle" fill="var(--fg-muted)" font-size="9">tight symbols</text>
+  <line x1="380" y1="110" x2="650" y2="110" stroke="var(--fg-muted)"/>
+  <path d="M 460 110 Q 495 90 500 22 Q 505 90 540 110" fill="none" stroke="currentColor"/>
+  <polyline points="495,110 500,22 505,110" fill="none" stroke="currentColor"/>
+  <text x="500" y="14" text-anchor="middle" fill="currentColor" font-size="9">noisy LO: skirts</text>
+  <path d="M 585 38 A 22 22 0 0 1 605 52" fill="none" stroke="var(--accent)" stroke-width="3" opacity="0.7"/>
+  <path d="M 585 82 A 22 22 0 0 0 605 68" fill="none" stroke="var(--accent)" stroke-width="3" opacity="0.7"/>
+  <path d="M 565 52 A 22 22 0 0 0 565 68" fill="none" stroke="var(--accent)" stroke-width="3" opacity="0.7"/>
+  <text x="592" y="102" text-anchor="middle" fill="var(--fg-muted)" font-size="9">smeared symbols</text>
+  <text x="340" y="136" text-anchor="middle" fill="var(--fg-muted)" font-size="10">same total power on both sides — the energy moved from symbol positions into the blur</text>
+  <line x1="120" y1="196" x2="560" y2="196" stroke="var(--fg-muted)"/>
+  <path d="M 350 196 Q 385 176 390 152 Q 395 176 430 196" fill="none" stroke="currentColor"/>
+  <text x="390" y="146" text-anchor="middle" fill="currentColor" font-size="9">strong neighbor × noisy LO</text>
+  <polyline points="465,196 470,178 475,196" fill="none" stroke="var(--accent)"/>
+  <text x="500" y="176" fill="var(--accent)" font-size="9">your channel, under its skirt</text>
+  <text x="340" y="216" text-anchor="middle" fill="var(--fg-muted)" font-size="10">reciprocal mixing: the neighbor stays clean on the display while its smear becomes your noise floor</text>
+</svg>
+<figcaption>Phase noise relocates energy rather than removing it: the constellation smears, the neighbors' skirts land in your channel, and every level meter stays green.</figcaption>
+</figure>
+
+## The verdict, in numbers
+
+Here is #764 reduced to its evidence table — one site, one antenna, the
+reporter's own captures, replayed offline through the same code:
+
+| Measurement | 2.5 MS/s capture | 10 MS/s capture |
+|---|---|---|
+| Peak level | ≈ −48 dBFS | ≈ −48 dBFS |
+| Clipping | none | none |
+| Wideband FFT carrier SNR | high | **higher** |
+| Demod SNR | ≈ 19.7 dB | ≈ 9.5 dB |
+| EVM | 7.4% | 22.5% |
+| Control-channel lock | yes | no |
+
+The clincher was the independent-resampler experiment: decimate the
+10 MS/s file 4:1 with a resampler that isn't GopherTrunk's, feed the result
+to the proven 2.5 MS/s decode path, and the *same* ≈ 9.5 dB deficit comes
+out — so the missing 10 dB is baked into the captured samples, not
+introduced by our DDC. (One sentence here; the full methodology of proving
+"it's the samples" by rate-invariance and independent resamplers is
+[Weak-Signal Engineering, Part 12]({{ '/blog/deep-dives/weak-signal-engineering-12-proving-signal/' | relative_url }}).)
+Carrier-clean, modulation-degraded, level-innocent, rate-correlated: that
+constellation of facts points at the front end's oscillator behavior at the
+Airspy's native 10 MS/s clock — phase noise / reciprocal mixing recorded
+permanently into every sample.
+
+## Why the wideband FFT lied
+
+The most disorienting row of that table is the FFT one: the capture that
+*failed* had the **higher** wideband carrier SNR. It isn't a paradox once
+you know what each instrument integrates. An FFT bin sums power — and phase
+noise conserves power, merely relocating it within and around the channel.
+A tall, proud carrier in the waterfall is a statement about *energy*, not
+about whether that energy's phase trajectory still encodes symbols. The
+demodulator, meanwhile, is an interferometer: it compares each symbol's
+phase against where a clean symbol would be, and it feels every picosecond
+of LO jitter. Same signal, two instruments, opposite verdicts — and the
+decoder's is the one correlated with reality. This is the series' Part 2
+lesson escalated one level: first we learned dBFS can't grade quality; now
+even *spectral* SNR can't. Only demodulation-domain numbers grade
+modulation.
+
+## What an operator does about it
+
+You cannot fix an oscillator in YAML, but you have real levers:
+
+- **Prefer rates your front end is clean at.** The sampling configuration
+  is part of the analog design — clocking, decimation, and PLL settings
+  shift with it. If a lower rate covers your channels, take it; the
+  [Airspy rate-selection notes]({{ '/reference/airspy-rate-selection/' | relative_url }})
+  exist because of exactly this history. The decode path itself is
+  rate-invariant (Part 6), so rate choice is purely a front-end decision.
+- **A/B by capture, not by vibes.** Record the same channel at both
+  candidate rates, replay both, compare demod SNR/EVM/lock. Ten minutes,
+  and the answer is durable evidence instead of an impression.
+- **Weigh oscillator quality when buying.** Part of what separates SDR
+  tiers is exactly LO cleanliness under real clocking loads — worth as much
+  as any dB of gain on a phase-modulated trunking band. (Our
+  [hardware comparison]({{ '/airspy-vs-rtl-sdr-vs-hackrf/' | relative_url }})
+  is the buying-side companion.)
+- **Keep strong neighbors out of the front end.** Reciprocal mixing needs a
+  strong neighbor to reciprocate with; Part 9's filters reduce the supply.
+- **Stop blaming software once the signature matches.** Carrier-clean,
+  modulation-degraded, reproducible from a capture, correlated with a
+  front-end configuration change: that's an analog verdict. File the issue
+  *with the capture* (Part 10) — but point it at the right side of Part 1's
+  line.
+
+## Where this goes next
+
+This part leaned on a claim that deserves its own post: that GopherTrunk's
+decode path treats every capture rate identically, so rate-correlated
+symptoms indict the front end. [Part 6]({{ '/blog/tutorials/analog-edge-06-sample-rate/' | relative_url }})
+opens that up — how both down-converters normalize to one per-protocol
+channel rate, when higher rates genuinely help, what they cost, and the two
+log lines (`decode can't keep up with real time`, soapyremote `host_drops`)
+that look like driver bugs and are actually downstream signals.
+
+## FAQ
+
+**Is phase noise a defect in my SDR?**
+It's a budget line in every oscillator ever built — the question is degree,
+and price roughly tracks it. The operational point isn't "buy perfection,"
+it's that phase-noise behavior can differ between *configurations of the
+same device* (as #764 showed across sample rates), so measure your rig at
+the settings you actually run.
+
+**How do I check for this signature without lab gear?**
+With the decoder as the instrument. Capture the same channel under both
+configurations you're comparing, replay, and read demod SNR/EVM and lock.
+Carrier visible in the waterfall + healthy dBFS + collapsed demod SNR that
+follows one configuration is the fingerprint. No spectrum analyzer
+required — the receiver is a phase-accurate one already.
+
+**Could multipath or ISI produce the same "clean carrier, bad decode" look?**
+Yes, and that's a fair confounder — linear channel distortion also degrades
+EVM while conserving power. The discriminators: ISI is equalizable (and
+GopherTrunk's equalizers recovering most of the loss points that way),
+tends to follow *location and antenna*, and doesn't track front-end
+configuration. Phase noise follows the *hardware configuration* and no
+linear equalizer can undo it. The #764 deficit tracked the sample rate on
+one antenna — hardware.
+
+**Why did this take an independent resampler to prove?**
+Because the obvious A/B — decode the 10 MS/s capture through our own
+10 MS/s path — can't separate "the samples are bad" from "our high-rate
+path is bad." Decimating with a *third-party* resampler and replaying
+through the already-proven 2.5 MS/s path removes our high-rate code from
+the loop entirely. The deficit survived, so it lived in the samples. It's
+the same self-consistency discipline the project applies to synthetic
+tests, aimed at hardware.
+
+**Does this mean I should always run the lowest rate?**
+No — it means rate is a front-end quality choice, not a free coverage knob.
+Part 6 gives the full trade: what higher rates buy (more taps per dongle,
+wideband hunting), what they cost (front-end cleanliness, CPU, USB), and
+how to verify your hardware's clean rates empirically.
+
+## Series navigation
+
+**Part 5 of 14** · ←
+[Part 4: Clipping, Overload & Intermod]({{ '/blog/tutorials/analog-edge-04-clipping-overload-intermod/' | relative_url }})
+· Next →
+[Part 6: Sample Rate — The Decode Path Doesn't Care; the Front End Does]({{ '/blog/tutorials/analog-edge-06-sample-rate/' | relative_url }})

--- a/docs/_posts/2026-08-22-tetra-end-to-end-05-tchs-traffic-channel.md
+++ b/docs/_posts/2026-08-22-tetra-end-to-end-05-tchs-traffic-channel.md
@@ -1,0 +1,286 @@
+---
+title: "TETRA End to End, Part 5: TCH/S — From Traffic Burst to Speech Frame"
+description: Decoding TETRA's full-rate speech channel — two 137-bit frames per slot, the class-0/1/2 sensitivity split with its unequal error protection, the AACH usage marker that routes concurrent same-carrier calls, and the replay harness that correlated decoded timeslots against the control channel's grants on real air.
+category: deep-dives
+keywords: tetra tch/s decode, tetra speech traffic channel, 137 bit speech frame, tetra traffic extractor, aach usage marker, tetra class 2 bits, same carrier voice, tetra multislot replay, tetra voice chain composer, gophertrunk tetra
+tags: [tetra-end-to-end, tetra, tchs, voice, traffic, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "TETRA End to End"
+series_part: 5
+---
+
+*Part 5 of **TETRA End to End**, a 14-part deep dive into how GopherTrunk turns
+one real 25 kHz TETRA carrier into clear recorded voice.
+[Part 4]({{ '/blog/deep-dives/tetra-end-to-end-04-scrambling-colour-codes/' | relative_url }})
+finished the plumbing: with the scrambler seeded by the learned extended
+colour code, every channel on the cell descrambles. Now we cash the cheque.
+The control channel has issued a grant, a voice tap has retuned to the traffic
+carrier, and π/4-DQPSK bursts are streaming in at 18000 dibits a second — this
+part turns them into 137-bit speech frames, the currency the ACELP vocoder of
+Part 6 spends. Everything here is the hard-decision path; where it runs out of
+steam on a marginal signal is exactly where Part 8 picks up.*
+
+> **TL;DR:** One TCH/S slot carries **two 137-bit speech frames** coded
+> together into 432 type-5 bits (EN 300 395-2 §5.5). The 274 speech bits are
+> reordered into three sensitivity classes — class 0 (102, uncoded), class 1
+> (112, rate 8/12), class 2 (60 + CRC-8 + tail, rate 8/18) — through one
+> continuous K=5 mother stream, then 24×18 interleaved
+> (`internal/radio/tetra/tch.go`). `TrafficExtractor`
+> (`internal/radio/tetra/traffic.go`) finds each burst, descrambles it, tags
+> it with its TDMA slot and its **AACH downlink usage marker** — the reliable
+> per-call demux key on real air (`DLUsageTraffic`) — and the class-2 **CRC
+> gate** (~1/256 false-pass) isolates real speech from everything else. The
+> composer's `runTETRAVoiceChain` wires it to the recorder, which maps
+> `tetra` → `tetra-acelp`; `TestTETRAMultiSlotReplay` validated the whole
+> demux on real air by correlating decoded slots against the control channel's
+> grant timeslots.
+
+**Key takeaways**
+
+- **Speech bits are not created equal.** The 137-bit frame splits into three
+  classes by perceptual sensitivity: class 2 gets a CRC and the strongest
+  code, class 0 flies uncoded. The vocoder can survive class-0 errors; class-2
+  errors wreck the frame, so the CRC gates on exactly those.
+- **The CRC is the call's bouncer.** A non-speech burst descrambles to noise
+  and passes the 8-bit class-2 check only ~1/256 of the time — on a
+  single-call carrier that alone isolates the granted call's speech.
+- **Route by usage marker, not by slot number.** The AACH decodes in every
+  downlink slot and carries the call's usage marker; the slot number derived
+  from the SB anchor jitters on real air and is kept as telemetry only.
+- **The demux was verified against grants.** The multi-slot replay harness
+  prints a per-slot and per-marker activity timeline from a real capture and
+  cross-checks it against the control channel's granted timeslots — the
+  anti-self-consistency discipline applied to routing.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| TCH/S decode | 432 type-5 bits → 2 × 137-bit frames + CRC flag | `internal/radio/tetra/tch.go` (`DecodeTCHS`, `TCHSpeechFrames`) |
+| Class reorder | Table 5 type-2 order: class0 ‖ class1 ‖ class2 | `internal/radio/tetra/tch_tables.go` (`tchType2SpeechOrder`) |
+| Burst extraction | rolling buffer, NTS×4 rotations, BKN1+BKN2 | `internal/radio/tetra/traffic.go` (`TrafficExtractor`) |
+| Slot + marker tagging | SB-anchored slot, AACH usage marker | `traffic.go` (`slotOf`, `usageOf`), `aach.go` (`DLUsageTraffic`) |
+| Solo-tap voice chain | front end → receiver → extractor → recorder | `internal/voice/composer/tetra_voice.go` (`runTETRAVoiceChain`) |
+| Same-carrier demux | one tap, four slots, route by marker | `composer.go` (`followTETRASameCarrier`), `tetra_voice.go` (`tetraSlotDemux`) |
+| Real-air validation | per-slot timeline vs granted timeslots | `cmd/gophertrunk/tetra_multislot_replay_test.go` |
+
+## In this post
+
+- **Two frames per slot** — the TCH/S coding chain and the sensitivity classes.
+- **The CRC gate** — how 8 bits isolate a call.
+- **Extracting the burst** — the traffic extractor's rolling buffer, revisited with payload.
+- **Routing concurrent calls** — usage markers over slot numbers.
+- **From extractor to recorder** — the composer wiring, and the harness that proved it.
+
+## Two frames per slot
+
+The TCH/S encode chain (EN 300 395-2 §5.5) packs two 30 ms speech frames into
+each transmission slot. Its first move is the interesting one: the 274 speech
+bits (2 × 137) are *reordered* by `tchType2SpeechOrder` — a generated,
+spec-verbatim table — into three contiguous sensitivity classes. Class 0 is
+the 102 bits the ACELP decoder can shrug off; class 1 is 112 bits of middling
+sensitivity; class 2 is the 60 bits that must not be wrong — LSP indices, gain
+fields, the parameters whose corruption makes synthesis screech rather than
+hiss. Then unequal error protection, all through one continuous K=5 rate-1/3
+mother stream (Part 3's speech code):
+
+```go
+// internal/radio/tetra/tch.go (shape) — EncodeTCHS
+type2 := speechToType2(frameA, frameB)          // class0(102) ‖ class1(112) ‖ class2(60)
+conv := append(class1, class2...)
+conv = append(conv, crcTCHClass2(class2)...)    // CRC-8 over class 2 (the TAB_CRC matrix)
+conv = append(conv, make([]byte, tchTailBits)...) // 4-bit flush
+mother := framing.EncodeRCPCTetraMother(conv)   // 3 × 184 = 552
+
+c1 := framing.PunctureRCPCTetra(mother[:336], framing.RCPCTetraPeriod23,  framing.RCPCTetraPuncture23,  168) // rate 8/12
+c2 := framing.PunctureRCPCTetra(mother[336:], framing.RCPCTetraPeriod818, framing.RCPCTetraPuncture818, 162) // rate 8/18
+type3 := append(append(append(make([]byte, 0, 432), class0...), c1...), c2...) // 102+168+162
+return framing.PackBitsMSB(tchInterleave(type3)) // 24×18 matrix interleave
+```
+
+Class 0 is transmitted *uncoded* — straight into type-3 — while class 2 plus
+its CRC gets rate 8/18, more than twice the redundancy of class 1's 8/12. The
+budget goes where the ear needs it. `DecodeTCHS` is the exact mirror, ending
+with the class-2 CRC check and returning the two frames, the CRC verdict, and
+the Viterbi path metric. Full field-level detail lives in the
+[TCH/S speech-coding reference]({{ '/reference/tetra-tchs-speech-coding/' | relative_url }}).
+
+## The CRC gate
+
+`TCHSpeechFrames` wraps the decode with the policy: no CRC, no frames.
+
+```go
+// internal/radio/tetra/tch.go (shape)
+func TCHSpeechFrames(traffic []byte) [][]byte {
+    frameA, frameB, crcOK, _, ok := DecodeTCHS(traffic)
+    if !ok || !crcOK {
+        return nil // non-TCH/S burst, or too corrupted to trust
+    }
+    return [][]byte{framing.PackBitsMSB(frameA), framing.PackBitsMSB(frameB)}
+}
+```
+
+The gate does double duty. Its stated job is quality control — don't hand the
+vocoder a frame whose critical bits are wrong. Its second job is *isolation*:
+a voice carrier's other slots carry other calls' bursts and signalling, and any
+burst that isn't this chain's TCH/S speech descrambles to effectively random
+class-2 bits, passing an 8-bit check with probability ~1/256. On a solo tap
+(one call on the carrier) the CRC alone keeps foreign bursts out of the
+recording. The same 1/256 figure has a dark side, though — it is also the
+**chance floor**: a decoder that is systematically wrong (Part 3's CRC bug,
+Part 12's descramble skip) still "recovers" ~0.4% of bursts by luck, which
+looks exactly like a very weak signal. Knowing the floor is what lets a
+harness distinguish "marginal RF" from "broken decode."
+
+## Extracting the burst
+
+Part 2 introduced `TrafficExtractor` as geometry; now it earns its keep. Per
+detected normal-training-sequence hit it slices BKN1 + BKN2 (216 dibits → 432
+bits), descrambles with the cell's extended colour code, and emits a 54-byte
+frame — but the emission signature is where the routing story lives:
+
+```go
+// internal/radio/tetra/traffic.go (shape)
+func NewTrafficExtractor(colourCode uint32,
+    onBurst func(frame []byte, softType5 []float32, slot, usage uint8)) *TrafficExtractor
+```
+
+Four things per burst: the hard frame; a soft-decision LLR stream (`nil` on
+the hard-only path — Part 8's hook, already present in the signature); the
+SB-anchored TDMA slot; and the **AACH downlink usage marker**. The extractor
+also watches for NTS2 midambles — stolen half-slots (STCH) carrying urgent
+signalling in place of speech — and counts them for the voice-path summary.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 200" width="680" height="200" role="img" aria-label="The TETRA voice pipeline from grant to recording: the voice tap IQ passes through the 144 kHz front end into the receiver, the traffic extractor slices and descrambles each burst and tags it with slot and usage marker, the TCH/S decoder gates frames on the class-2 CRC, and CRC-valid 137-bit speech frames flow to the ACELP vocoder and recorder.">
+  <rect x="6" y="70" width="88" height="46" rx="6" fill="none" stroke="currentColor"/>
+  <text x="50" y="89" text-anchor="middle" fill="currentColor" font-size="10">voice tap IQ</text>
+  <text x="50" y="103" text-anchor="middle" fill="var(--fg-muted)" font-size="9">→ 144 kHz</text>
+  <line x1="94" y1="93" x2="114" y2="93" stroke="currentColor"/><polygon points="114,89 123,93 114,97" fill="currentColor"/>
+  <rect x="123" y="70" width="96" height="46" rx="6" fill="none" stroke="currentColor"/>
+  <text x="171" y="89" text-anchor="middle" fill="currentColor" font-size="10">receiver</text>
+  <text x="171" y="103" text-anchor="middle" fill="var(--fg-muted)" font-size="9">dibits @18k/s</text>
+  <line x1="219" y1="93" x2="239" y2="93" stroke="currentColor"/><polygon points="239,89 248,93 239,97" fill="currentColor"/>
+  <rect x="248" y="70" width="130" height="46" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="313" y="89" text-anchor="middle" fill="var(--accent)" font-size="10">TrafficExtractor</text>
+  <text x="313" y="103" text-anchor="middle" fill="var(--fg-muted)" font-size="9">slice · descramble · tag</text>
+  <line x1="378" y1="93" x2="398" y2="93" stroke="currentColor"/><polygon points="398,89 407,93 398,97" fill="currentColor"/>
+  <rect x="407" y="70" width="110" height="46" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="462" y="89" text-anchor="middle" fill="var(--accent)" font-size="10">DecodeTCHS</text>
+  <text x="462" y="103" text-anchor="middle" fill="var(--fg-muted)" font-size="9">class-2 CRC gate</text>
+  <line x1="517" y1="93" x2="537" y2="93" stroke="currentColor"/><polygon points="537,89 546,93 537,97" fill="currentColor"/>
+  <rect x="546" y="70" width="128" height="46" rx="6" fill="none" stroke="currentColor"/>
+  <text x="610" y="89" text-anchor="middle" fill="currentColor" font-size="10">2 × 137-bit frames</text>
+  <text x="610" y="103" text-anchor="middle" fill="var(--fg-muted)" font-size="9">→ ACELP → WAV + .raw</text>
+  <text x="313" y="146" text-anchor="middle" fill="var(--fg-muted)" font-size="9">per burst: slot (telemetry) + AACH usage marker (routing)</text>
+  <line x1="313" y1="118" x2="313" y2="136" stroke="var(--fg-muted)" stroke-dasharray="3 3"/>
+  <text x="462" y="146" text-anchor="middle" fill="var(--fg-muted)" font-size="9">CRC fail ⇒ dropped (~1/256 false pass)</text>
+  <line x1="462" y1="118" x2="462" y2="136" stroke="var(--fg-muted)" stroke-dasharray="3 3"/>
+  <text x="340" y="182" text-anchor="middle" fill="var(--fg-muted)" font-size="10">the hard-decision path — the softType5 hook in the onBurst signature is already waiting for Part 8</text>
+</svg>
+<figcaption>Grant to recording on the hard path: extract, descramble, tag, CRC-gate, then hand 137-bit frames to the vocoder.</figcaption>
+</figure>
+
+## Routing concurrent calls: markers over slots
+
+A TETRA carrier is four TDMA slots, and each can hold an independent call —
+so the extractor emits *every* NCDB it sees and something downstream must
+demultiplex. The obvious key is the slot number. It is also the wrong one, and
+the doc comment in `traffic.go` says so bluntly: on real air the SB anchor's
+intra-slot rounding jitters a call's bursts across adjacent slot numbers, and
+the grant's channel-allocation timeslot field doesn't map cleanly to the
+physical slot anyway. The reliable key is the **AACH**: it's present in every
+downlink slot, its 30-bit access-assignment names what the slot carries, and a
+call's usage marker matches the marker in its grant. `usageOf` recovers it per
+burst — the two AACH halves either side of the midamble, RM(30,14)-decoded
+under the cell colour, values ≥ `DLUsageTraffic` (4) meaning traffic — with a
+distance-gated soft fallback (`usageOfSoft`, `aachSoftMaxDist = 6`) so a
+marginal AACH doesn't drop a routable burst or, worse, invent a marker that
+leaks another call's speech into the recording.
+
+The composer routes accordingly. `onTETRATrafficBurst` keeps bursts whose
+marker matches the granted call's, and when either side lacks a marker it
+falls back to CRC-gated isolation rather than guessing. Concurrent
+same-carrier calls ride `followTETRASameCarrier` and a shared per-carrier
+`tetraSlotDemux`; slot numbers appear in logs and the replay harness's
+timeline, but no recording decision hangs on them.
+
+## From extractor to recorder — and the harness that proved it
+
+`runTETRAVoiceChain` (`internal/voice/composer/tetra_voice.go`) assembles the
+solo-tap chain: a channel-select + decimation front end to 144 kHz, the shared
+receiver with AFC, channel filter, Gardner timing (plus the equalizer and DC
+block that later parts justify), the extractor, and the boundary tracker that
+ends the call on hangtime. CRC-valid frames go to the recorder, which maps
+protocol `tetra` to the `tetra-acelp` vocoder and writes both the decoded WAV
+and a `.raw` sidecar of post-FEC frames — the same shape as the DMR and P25
+paths, told in full in the
+[composer deep dive]({{ '/blog/deep-dives/voice-coding-09-the-composer/' | relative_url }}).
+On teardown the chain drains the IQ still buffered in its channel
+(`drainTETRAIQ`) so a call's final bursts land in the recording instead of
+dying in a queue — the fix for recordings that ended a beat early.
+
+The validation is `TestTETRAMultiSlotReplay`
+(`cmd/gophertrunk/tetra_multislot_replay_test.go`), a skip-guarded harness:
+point `GT_TETRA_IQ` at a cs16 capture, give `GT_TETRA_IQ_RATE` and the cell's
+colour via `GT_TETRA_COLOUR` (the committed default, 262144876, is our running
+MCC 250 / MNC 13 cell), and it runs the real receiver + extractor, then prints
+per-slot and per-usage-marker activity timelines — CRC-valid bursts, speech
+seconds, active-second lists — to cross-check against the control channel's
+grants. That cross-check is the point: slot tagging and marker routing were
+accepted only when the decoded activity lined up with what the control channel
+*said* was granted, on the operator's own capture. It's also the harness that
+exposed the Part 3 CRC bug (everything at the 1/256 floor) and later carried
+the soft-decision and equalizer A/Bs — one instrument, reused every time the
+voice path changed.
+
+## Where this goes next
+
+We now hold 137-bit speech frames that passed their CRC. They are still just
+bits. [Part 6]({{ '/blog/deep-dives/tetra-end-to-end-06-clean-room-acelp/' | relative_url }})
+opens the black box at the end of the chain: the clean-room ACELP vocoder in
+pure Go — LSP dequantisation, adaptive and algebraic codebooks, fixed-point
+synthesis — that turns each frame into 240 samples of 8 kHz audio, bit-exact
+against the ETSI reference.
+
+## FAQ
+
+**Why two speech frames per slot instead of one?**
+The vocoder produces a 137-bit frame every 30 ms, but a call's TDMA slot comes
+around once per 56.67 ms frame. Coding two speech frames into each slot makes
+the arithmetic work: one slot per frame period carries the two speech frames
+generated in that period.
+
+**What happens to a burst whose CRC fails — is it silence in the recording?**
+It's simply not emitted on the hard path, and the vocoder's erased-frame
+concealment (Part 6) papers over isolated gaps. On a marginal signal where
+*most* bursts fail, recordings come out short and garbled — that symptom, and
+the ~70% of bursts the hard decoder was discarding on one reporter's captures,
+is exactly what Part 8's soft decision recovers.
+
+**Can encrypted calls leak into recordings?**
+No — TEA-encrypted traffic fails the class-2 CRC just like noise (the
+plaintext structure the CRC checks isn't there), so no decoded audio is
+produced. The raw bursts still exist upstream for out-of-band analysis.
+
+**Why does the extractor descramble but not TCH/S-decode?**
+Separation of trust: the extractor knows the carrier's colour code (one fact,
+learned once), while TCH/S decoding is per-call policy — CRC gating, marker
+matching, soft/hard selection — that belongs to the composer chain. The
+`.raw` sidecar gets descrambled type-5, the input any external TCH/S tool
+expects.
+
+**How do I run the replay harness on my own capture?**
+`GT_TETRA_IQ=<file.cs16> GT_TETRA_IQ_RATE=<hz> GT_TETRA_COLOUR=<extended>
+go test ./cmd/gophertrunk -run TestTETRAMultiSlotReplay -v` — plus
+`GT_TETRA_OUT=<dir>` for per-slot WAVs. The colour override matters: with the
+wrong extended colour the descramble is wrong and every count sits at the
+1/256 chance floor, indistinguishable from a dead signal.
+
+## Series navigation
+
+**Part 5 of 14** · ←
+[Part 4: Scrambling & Colour Codes — Why Colour 0 Is Not a No-Op]({{ '/blog/deep-dives/tetra-end-to-end-04-scrambling-colour-codes/' | relative_url }})
+· Next →
+[Part 6: A Clean-Room ACELP Vocoder in Pure Go]({{ '/blog/deep-dives/tetra-end-to-end-06-clean-room-acelp/' | relative_url }})

--- a/docs/_posts/2026-08-22-weak-signal-engineering-05-snapshot-trick.md
+++ b/docs/_posts/2026-08-22-weak-signal-engineering-05-snapshot-trick.md
@@ -1,0 +1,305 @@
+---
+title: "Weak-Signal Engineering, Part 5: The Snapshot Trick — Frozen Taps & Differential Decoders"
+description: Why a continuously-adapting CMA in front of a differential decoder scores exactly zero CRC-valid frames, why permanently frozen taps only ever match the baseline, and how SnapshotCMA's adapt-continuously-apply-frozen design resolves the dilemma — doubling TETRA voice yield and lifting the thread capture from twelve percent to one hundred.
+category: deep-dives
+keywords: snapshot cma, frozen equalizer taps, differential decoder phase, cma rotation invariance, pi/4-dqpsk differential decode, adaptive equalizer phase wander, tetra equalizer yield, blind equalizer differential safe, gophertrunk weak-signal engineering
+tags: [weak-signal-engineering, cma, equalizer, tetra, dsp, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Weak-Signal Engineering"
+series_part: 5
+---
+
+*Part 5 of **Weak-Signal Engineering**, a 14-part deep dive into decoding the
+marginal regime, where a receiver locks but under-decodes.
+[Part 4]({{ '/blog/deep-dives/weak-signal-engineering-04-blind-cma/' | relative_url }})
+built the Constant Modulus Algorithm and left one loose end swinging: CMA's
+cost is rotation-invariant, so nothing constrains its output phase while the
+taps adapt. This part is where that loose end meets TETRA's differential
+decoder — and where the naive combination measures exactly zero. The fix is a
+single structural idea, small enough to state in one sentence and consequential
+enough that it reappears, in different clothes, in Parts 7 and 11: adapt
+continuously, but apply a frozen snapshot. It is also the part where the
+thread capture finally moves.*
+
+> **TL;DR:** CMA's cost `J = E[(|y|²−R²)²]` doesn't change if every tap
+> rotates by a common phase, so an adapting CMA's output phase **wanders** —
+> and a time-varying phase does **not** cancel in the differential product
+> `s[n]·conj(s[n−1])`. Measured on real captures: streaming-adaptive CMA ahead
+> of the π/4-DQPSK differential decoder → **CRC 0**; taps frozen forever →
+> baseline (a stale inverse for a moving channel). **`SnapshotCMA`**
+> (`internal/dsp/equalizer/snapshot_cma.go`) keeps both tap sets: `wAdapt`
+> updates every sample, `wApply` — the filter actually applied — is a snapshot
+> of `wAdapt` refreshed every `snapEvery` symbols (default 200, on the order of
+> a 255-symbol TETRA burst). Between snapshots the filter is constant, so it
+> imposes only a constant phase — which the differential cancels; the one
+> straddling symbol per snapshot is absorbed by the FEC. Results: soft-decision
+> TCH/S bursts **410 → 778** (~1.9×) across six captures, and the thread
+> capture's CRC-clean BSCH from **~12% to ~100%**.
+
+**Key takeaways**
+
+- **The failure is structural, not a tuning problem.** No step size makes an
+  adapting filter phase-safe for a differential decoder — the phase wander is
+  a null direction of the cost itself. Slower adaptation just wanders slower.
+- **Differential decoding cancels constant phase, and only constant phase.**
+  `s·conj(prev)` is immune to any rotation that is the same on both symbols;
+  that exact algebraic property is what the frozen snapshot engineers for.
+- **Two tap sets, two jobs.** `wAdapt` tracks the channel and is never
+  applied; `wApply` filters the signal and never adapts. The design decouples
+  "stay current" from "stay coherent."
+- **The verdict came from CRC, at every step.** Each arm of the design space —
+  streaming, frozen, snapshot — was scored by decoded frames on real captures,
+  which is the only reason the middle option's failure (and the third option's
+  win) was visible at all.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| The differential-safe equalizer | adapt every sample, apply frozen snapshots | `internal/dsp/equalizer/snapshot_cma.go` (`SnapshotCMA.Process`) |
+| Plain CMA (the contrast) | applies its live, adapting taps — coherent-slicer use only | `internal/dsp/equalizer/cma.go` (`CMA`) |
+| Receiver wiring | equalizer between symbol timing and differential decode | `internal/radio/tetra/receiver/receiver.go` (`Options.EnableEqualizer`) |
+| Defaults | 11 taps, μ=6e-3, snapshot every 200 symbols | `receiver.go` (`DefaultEqualizerTaps/Mu/Snapshot`) |
+| Failing-first regression | multipath decode fails raw, passes equalized; clean stays clean | `snapshot_cma_test.go`, `receiver/receiver_equalizer_test.go` |
+| Thread-capture A/B | one boolean, ~12% vs ~100% BSCH on the fixture | `internal/scanner/ccdecoder/pipelines_tetra_equalizer_test.go` |
+| Re-sync hygiene | drop the stale channel estimate on re-acquisition | `snapshot_cma.go` (`Reset`) |
+
+## In this post
+
+- **The collision** — rotation invariance meets `s·conj(prev)`.
+- **Three arms, three verdicts** — streaming zero, frozen baseline, snapshot win.
+- **Inside `SnapshotCMA`** — two tap sets and a schedule.
+- **The numbers** — voice 410→778, and the thread capture at ~100%.
+- **The pattern beyond CMA** — where adapt-but-apply-frozen shows up next.
+
+## The collision: rotation invariance meets `s·conj(prev)`
+
+Two facts, each innocent alone. Fact one, from Part 4: rotate every CMA tap by
+`e^{jθ}` and `|y|` is untouched, so the cost gradient has a null direction
+along global phase. While the taps adapt, noise and ISI push them along that
+null direction freely — the output constellation's absolute rotation drifts,
+sample to sample. A slicer with its own carrier recovery shrugs; carrier loops
+exist to track slow rotation.
+
+Fact two: a differential decoder computes `d[n] = s[n]·conj(s[n−1])` and reads
+information from the *phase of the product*. Inject a time-varying rotation
+`θ[n]` and the product picks up `e^{j(θ[n]−θ[n−1])}` — the *derivative* of the
+wander. A constant phase cancels perfectly; a changing phase lands its
+per-sample increment directly onto the decision variable. π/4-DQPSK's decision
+regions are 90° wide (45° to the nearest wrong decision), and the wander's
+increment doesn't need to approach that to be fatal — it biases every single
+dibit in a correlated way, and the convolutional decoder, built for scattered
+errors, digests a systematic phase bias worst of all. The
+`snapshot_cma.go` doc comment records the empirical endpoint bluntly: feeding
+a continuously-adapting CMA to a differential decoder "empirically drives the
+decode to zero."
+
+Note that `cma.go`'s own centre-tap phase anchor (Part 4,
+[#492](https://github.com/MattCheramie/GopherTrunk/issues/492)) doesn't save
+you here: it pins the *equilibrium* phase, but every update still moves the
+taps — and therefore the output phase — between consecutive symbols. Slow,
+bounded wander is fine for a carrier loop and still poison for a differential.
+
+## Three arms, three verdicts
+
+The design space has two obvious corners and both were measured — by CRC
+yield, per Part 2, because EVM had already demonstrated it would cheerfully
+approve the zero-yield corner:
+
+| Arm | Phase between consecutive symbols | Channel tracking | CRC yield |
+|---|---|---|---|
+| Streaming-adaptive CMA | changes every sample | perfect | **0** |
+| Taps frozen once, forever | constant | none — estimate goes stale | baseline (no win) |
+| **Snapshot: adapt always, apply frozen** | constant between snapshots | refreshed every `snapEvery` | **the win** |
+
+The first row is the collision above. The second row fails softer but still
+fails: a channel is only *approximately* time-invariant, and an inverse
+estimated once decays as multipath geometry shifts — a frozen-at-startup
+equalizer converged on the wrong (or an old) channel is just a fixed wrong
+filter. The third row threads it: the *applied* filter is constant long enough
+for every burst to see a coherent channel, yet the *estimate* underneath never
+stops tracking. The one symbol that straddles a snapshot boundary sees a phase
+step — deliberately bounded engineering debt, one or two dibits per 200
+symbols, and exactly the kind of scattered error the FEC exists to absorb.
+
+## Inside `SnapshotCMA`
+
+The implementation is disarmingly small once the idea is stated. Two tap
+vectors and a counter:
+
+```go
+// internal/dsp/equalizer/snapshot_cma.go (shape)
+type SnapshotCMA struct {
+    wAdapt    []complex64 // adapts every sample (phase wanders — never applied directly)
+    wApply    []complex64 // frozen snapshot, applied to the output
+    buf       []complex64 // normalised input history
+    mu        float32     // CMA step size
+    snapEvery int         // samples between wApply <- wAdapt snapshots
+    /* … cumulative-mean normaliser state — Part 6 … */
+}
+```
+
+`Process` does both jobs on every sample — the output always comes from the
+frozen filter, the adaptation always lands on the tracking filter:
+
+```go
+// internal/dsp/equalizer/snapshot_cma.go (shape) — Process
+// Output uses the frozen filter (phase-coherent between snapshots).
+var y complex64
+for k := 0; k < n; k++ { y += e.wApply[k] * e.buf[n-1-k] }
+
+// Adapt the tracking filter by CMA(2,2): e = ya·(|ya|² − 1).
+var ya complex64
+for k := 0; k < n; k++ { ya += e.wAdapt[k] * e.buf[n-1-k] }
+ge := real(ya)*real(ya) + imag(ya)*imag(ya) - 1
+/* … w -= mu·e·conj(b), divergence guard — Part 6 … */
+
+if e.since++; e.since >= e.snapEvery {
+    copy(e.wApply, e.wAdapt)   // the snapshot
+    e.since = 0
+}
+```
+
+Both vectors start center-spike, so before first convergence the equalizer is
+a pass-through — the no-harm property, inherited from Part 4 and pinned by
+`TestSnapshotCMAHarmlessOnCleanSignal`. The receiver slots it between
+symbol-timing recovery and the differential decoder — before the
+nonlinearity, per Part 3's domain rule — behind one flag,
+`Options.EnableEqualizer`, with defaults (11 taps, μ = 6e-3,
+`snapEvery = 200`) sized so a snapshot interval is on the order of one
+255-symbol TETRA burst. And `Reset` exists for a reason worth naming: on a
+stream re-sync the channel estimate is stale by definition, and re-seeding to
+pass-through beats confidently applying yesterday's inverse to today's
+channel.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 220" width="680" height="220" role="img" aria-label="Timeline comparing output phase under three equalizer strategies. Top trace: streaming-adaptive CMA, phase wanders continuously, every differential corrupted, CRC zero. Middle trace: snapshot design — phase is a staircase, flat and constant across each burst-length interval with a small step at each snapshot refresh, and the differential decoder cancels the flat segments; snapshot instants are marked. Bottom band shows bursts aligned under the flat segments decoding cleanly.">
+  <text x="10" y="26" fill="currentColor" font-size="10">streaming-adaptive:</text>
+  <path d="M150,30 C190,12 220,52 260,34 C300,16 330,58 380,40 C430,22 460,60 520,38 C560,24 600,52 660,34" fill="none" stroke="currentColor"/>
+  <text x="410" y="16" fill="var(--fg-muted)" font-size="9">output phase θ[n] wanders every sample → dθ lands in every differential → CRC 0</text>
+  <text x="10" y="104" fill="var(--accent)" font-size="10">snapshot (wApply):</text>
+  <polyline points="150,116 270,116 270,104 400,104 400,120 530,120 530,108 660,108" fill="none" stroke="var(--accent)"/>
+  <g fill="var(--accent)">
+    <circle cx="270" cy="110" r="3"/><circle cx="400" cy="112" r="3"/><circle cx="530" cy="114" r="3"/>
+  </g>
+  <text x="270" y="94" text-anchor="middle" fill="var(--fg-muted)" font-size="9">snapshot</text>
+  <text x="400" y="94" text-anchor="middle" fill="var(--fg-muted)" font-size="9">snapshot</text>
+  <text x="530" y="94" text-anchor="middle" fill="var(--fg-muted)" font-size="9">snapshot</text>
+  <text x="410" y="140" fill="var(--fg-muted)" font-size="9">constant phase within each interval — cancels in s·conj(prev); one straddling symbol per step</text>
+  <g stroke="var(--fg-muted)" fill="none">
+    <rect x="160" y="160" width="100" height="26" rx="4"/>
+    <rect x="285" y="160" width="100" height="26" rx="4"/>
+    <rect x="415" y="160" width="100" height="26" rx="4"/>
+    <rect x="545" y="160" width="100" height="26" rx="4"/>
+  </g>
+  <text x="210" y="177" text-anchor="middle" fill="var(--fg-muted)" font-size="9">burst ✓</text>
+  <text x="335" y="177" text-anchor="middle" fill="var(--fg-muted)" font-size="9">burst ✓</text>
+  <text x="465" y="177" text-anchor="middle" fill="var(--fg-muted)" font-size="9">burst ✓</text>
+  <text x="595" y="177" text-anchor="middle" fill="var(--fg-muted)" font-size="9">burst ✓</text>
+  <text x="345" y="206" text-anchor="middle" fill="var(--fg-muted)" font-size="10">snapEvery ≈ a burst: each 255-symbol burst decodes through one constant filter</text>
+</svg>
+<figcaption>The snapshot turns a continuously-wandering output phase into a staircase: flat across each burst (which the differential cancels), stepping only at refresh instants (which the FEC absorbs).</figcaption>
+</figure>
+
+## The numbers
+
+The design earned its place with two yield results, both CRC-scored, both on
+real operator captures. On the **voice path** — the garbled same-carrier
+recordings that started the whole equalizer effort — inserting `SnapshotCMA`
+ahead of the differential decoder roughly doubled CRC-valid TCH/S burst yield
+across six captures: soft-decision **410 → 778** (~1.9×), including one call
+that went 4 → 207 and another 42 → 134, with no loss on already-clean
+captures. On the **control-channel path** — our thread capture — the story
+came full circle: the primary single-channel TETRA CC pipeline turned out to
+be the one TETRA CC path *not* running the equalizer (the voice composer and
+the wideband path already did). Enabling it lifted the marginal fixture from
+**~12% to ~100%** CRC-clean BSCH:
+
+```go
+// internal/scanner/ccdecoder/pipelines.go (shape) — newTETRAPipeline
+// Blind SnapshotCMA equalizer between symbol timing and the
+// differential decoder … On the reporter's ~10 dB re-acquisition
+// capture it lifts CRC-clean BSCH yield from ~12% to ~100%, which
+// is the difference between riding through a marginal dip and
+// dropping lock → re-hunt (the ~210 CC transitions/hour symptom).
+EnableEqualizer: true,
+```
+
+That second number is worth restating in operational terms: at ~12% BSCH the
+sync machinery starves, declares the channel lost, and re-hunts — the 210
+transitions per hour from Part 1. At ~100%, the same 10 dB channel just…
+decodes. The lever didn't add a single dB of signal; it moved the cliff. The
+full TETRA-side narrative of both fixes — voice and control channel — is told
+protocol-first in the concurrent
+[TETRA End to End]({{ '/blog/series/tetra-end-to-end/' | relative_url }})
+series; here the point is the transferable mechanism.
+
+## The pattern beyond CMA
+
+File the shape of this fix, because the series reuses it twice. The general
+statement: **when a downstream stage depends on a property being constant
+(here: phase between consecutive symbols), never feed it a filter that is
+changing — adapt an estimate on the side and apply it in frozen pieces sized
+to the downstream stage's coherence window.** Part 7's trained `SnapshotLMS`
+is the same principle with a better teacher: train on a burst's midamble,
+freeze, apply to that burst — the snapshot window shrinking from "every 200
+symbols" to "exactly one burst." And Part 11's diversity
+`TrackingCalibrator` is the instructive *contrast*: it adapts continuously
+ahead of the same differential decoder and is *safe*, because its reference
+branch pins the output phase structurally — the difference between a cost
+that can't see phase and an estimator whose phase is anchored is exactly the
+difference between needing the snapshot trick and not.
+
+## Where this goes next
+
+Two loose ends remain inside `Process`: the input normalisation the code
+quietly applied before every update, and the guard that re-seeds the tracking
+filter when the taps blow up. Both look like hygiene; both turned out to be
+the difference between the full win and CRC zero.
+[Part 6]({{ '/blog/deep-dives/weak-signal-engineering-06-normalisation-guards/' | relative_url }})
+is about why the CMA update's |x|³ scaling makes the normaliser part of the
+algorithm, why an EMA that tracks TDMA slot power is a moving target that
+converges to garbage, and why guards deserve tests of their own.
+
+## FAQ
+
+**Why not just re-derive the phase per burst instead of freezing taps?**
+That's essentially what a coherent receiver's carrier loop does, and it works
+for coherent slicers. But TETRA's decode chain is differential by design
+(robustness to exactly this class of ambiguity), and bolting a per-burst phase
+estimator onto a wandering equalizer adds an estimator — with its own failure
+modes — to fix a problem the snapshot removes structurally, for free.
+
+**How was `snapEvery = 200` chosen?**
+Jointly with μ, against captures and the synthetic multipath fixtures: long
+enough that a 255-symbol burst usually sees one filter (and the straddling
+cost is a dibit or two per 200 symbols), short enough that the applied inverse
+tracks a slowly-moving channel. The receiver exposes `EqualizerSnapshot` for
+tuning, but the default has survived every capture A/B so far.
+
+**Does the snapshot step ever land mid-burst and hurt?**
+It can and does — the straddling symbol is real. It is bounded by design: one
+symbol per `snapEvery`, carrying a phase step equal to the tap drift since the
+last snapshot, and the RCPC/Viterbi layer treats it as an isolated error. The
+measured results (410→778, ~12%→~100%) are net of this cost.
+
+**Is plain `CMA` now dead code?**
+No — it's the right tool ahead of a *coherent* slicer, where live taps plus
+the centre-tap phase anchor are fine and maximal tracking speed helps. The
+package deliberately keeps both: `CMA` for coherent chains, `SnapshotCMA` for
+differential ones. Using the former where the latter belongs is the
+documented, tested, career-limiting move.
+
+**What happens at re-sync or when the scanner retunes?**
+The pipeline calls `Reset`, returning both tap sets to center-spike
+pass-through and clearing the normaliser. A channel estimate is only valid
+for the channel it was learned on; carrying it across a retune would apply a
+confident wrong inverse exactly when the receiver is most fragile.
+
+## Series navigation
+
+**Part 5 of 14** · ←
+[Part 4: Blind Equalization — CMA From First Principles]({{ '/blog/deep-dives/weak-signal-engineering-04-blind-cma/' | relative_url }})
+· Next →
+[Part 6: Normalisation & Divergence Guards]({{ '/blog/deep-dives/weak-signal-engineering-06-normalisation-guards/' | relative_url }})

--- a/docs/_posts/2026-08-23-analog-edge-06-sample-rate.md
+++ b/docs/_posts/2026-08-23-analog-edge-06-sample-rate.md
@@ -1,0 +1,278 @@
+---
+title: "The Analog Edge, Part 6: Sample Rate — The Decode Path Doesn't Care; the Front End Does"
+description: Why GopherTrunk's decoders are deliberately rate-invariant — every capture rate is normalized to one per-protocol channel rate before the receiver ever runs — so a symptom that tracks the sample rate indicts the capture, plus what higher rates genuinely buy and the two warnings that mean the consumer fell behind.
+category: tutorials
+keywords: sdr sample rate choice, rate invariant dsp, downconverter channel rate, 48 khz channel rate, tetra 144 khz, decode cant keep up, host drops soapyremote, wideband sample rate tradeoff, gophertrunk analog edge
+tags: [analog-edge, sample-rate, dsp, sdr, performance, tutorial]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "The Analog Edge"
+series_part: 6
+---
+
+*Part 6 of **The Analog Edge**, a 14-part field guide to the analog half of a
+GopherTrunk installation. [Part 5]({{ '/blog/tutorials/analog-edge-05-phase-noise-reciprocal-mixing/' | relative_url }})
+kept leaning on one claim: that GopherTrunk's decode path treats a 2.4 MS/s
+capture and a 10 MS/s capture identically, so a symptom that follows the
+rate is a statement about the front end. Our marginal reader deserves to see
+why that claim is true rather than take it on faith — because it's the claim
+that decides which side of Part 1's line their next debugging hour goes to.
+This part opens the down-converters, then prices the rate knob honestly:
+what more megasamples buy, what they cost, and which scary log lines they
+tend to produce.*
+
+> **TL;DR:** Every capture, whatever its rate, is resampled to **one
+> per-protocol channel rate** before the receiver runs — **48 kHz** for the
+> 4800-baud C4FM family (P25/DMR/NXDN/…), **144 kHz** for TETRA's 18000-baud
+> π/4-DQPSK (`ddcTargetForProtocol`, `internal/scanner/ccdecoder/ddc.go`) —
+> and the receiver and AGC are sized from that *output* rate. So the decode
+> path is **rate-invariant** (pinned by `TestDownconverterSNRInvariantAcrossRate`),
+> and "locks at 2.4 MS/s, fails at 10 MS/s" points at the captured data
+> (Part 5), not the DSP. Mind the map though: the replay path's
+> single-channel `ccdecoder.Downconverter` and the wideband `DDCBank`
+> (`internal/dsp/tuner/ddc.go`) are **separate code paths** — the gap that
+> let [#764](https://github.com/MattCheramie/GopherTrunk/issues/764)'s first
+> "fix" miss [#771](https://github.com/MattCheramie/GopherTrunk/issues/771)'s
+> replay symptom. Higher rates buy coverage, and cost front-end cleanliness,
+> CPU, and USB; when the CPU loses, the WARNs (`decode can't keep up with
+> real time`, soapyremote `host_drops`) name a **downstream** problem, not a
+> driver bug.
+
+**Key takeaways**
+
+- **Rate-invariance is a designed property, not luck.** Normalizing every
+  input to the protocol's channel rate means one receiver tuning, one AGC
+  sizing, one set of constants — verified at 2.5 and 10 MS/s by test.
+- **That design is a diagnostic instrument.** If the DSP genuinely cannot
+  tell capture rates apart, then a rate-dependent failure that reproduces in
+  offline replay *must* live in the samples — the deduction that closed #764.
+- **The sample rate knob prices in three currencies:** front-end cleanliness
+  (Part 5's lesson), CPU per tap, and USB/network throughput. Spectrum
+  coverage is what you're buying; know what you're paying.
+- **Overrun warnings point downstream.** `sendOrDrop` sheds IQ only when the
+  consumer stops draining it — so when `host_drops` climbs, ask what got
+  slower on the decode side, not what's wrong with the driver.
+
+## Cheat sheet
+
+| Concern | The fact | Where it lives |
+|---|---|---|
+| Per-protocol channel rate | 48 kHz C4FM family, 144 kHz TETRA (incl. DMO) | `ddcTargetForProtocol` in `internal/scanner/ccdecoder/ddc.go` |
+| Rate invariance, pinned | same in-channel SNR at 10 MS/s native vs decimated 2.5 MS/s | `TestDownconverterSNRInvariantAcrossRate` (`internal/scanner/ccdecoder/ddc_highrate_test.go`) |
+| The two DDC paths | replay `-tune-hz` uses `ccdecoder.Downconverter`; multi-tap wideband uses `DDCBank` | `internal/scanner/ccdecoder/ddc.go` vs `internal/dsp/tuner/ddc.go` |
+| Rate limits per hardware | RTL caps at 3.2 MHz; 2.4 MS/s is its sweet spot; 10/20 MS/s need a wideband source | `sdr.sample_rate` comments in `config.example.yaml` |
+| Decode falling behind | IQ shed at the decode queue, WARN + metric | `internal/scanner/ccdecoder/decoder.go` (issue #402) |
+| Network source falling behind | oldest chunk shed, `host_drops` in the WARN | `sendOrDrop` in `internal/sdr/soapyremote/driver.go` |
+
+## In this post
+
+- **What rate-invariance means** — one funnel, one receiver.
+- **One channel rate per protocol** — the code that pins it.
+- **Two down-converters, two paths** — the map that saved #771.
+- **What higher rates buy, and what they cost** — the honest ledger.
+- **The warnings that mean "downstream"** — reading overruns correctly.
+
+## What rate-invariance means
+
+Think of the decode pipeline as a funnel. At the wide end, captures arrive
+at whatever rate your hardware produced: 2.4 MS/s from an RTL dongle,
+6 MS/s from a B210, 10 MS/s from an Airspy. At the funnel's neck, a digital
+down-converter (DDC) mixes the wanted channel to baseband, filters it, and
+resamples it to a **fixed channel rate** chosen by protocol. Everything
+after the neck — matched filter, timing recovery, AGC, slicer, FEC — sees
+only that fixed rate and is *sized from it*. The receiver literally has no
+input that tells it what the capture rate was.
+
+That's the whole claim. A well-implemented funnel neck (proper anti-alias
+filtering, exact rational resampling — the `Downconverter` uses a >60 dB
+stopband polyphase design) delivers the channel's contents *as captured*:
+whatever SNR the samples carried in-channel arrives at the receiver intact,
+whether the journey started at 2.5 or 10 MS/s. The project didn't leave
+that as an assertion: `TestDownconverterSNRInvariantAcrossRate` synthesizes
+a noisy channel, decodes it natively at 10 MS/s and decimated at 2.5 MS/s,
+and pins that the receiver sees the same in-channel SNR both ways.
+
+And that test is why the claim doubles as a diagnostic tool. When a decode
+works at one rate and fails at another *and the failure reproduces from a
+capture in offline replay*, the invariant funnel can't be the difference —
+the difference was already in the samples when they crossed Part 1's line.
+That deduction, plus Part 5's physics, is #764's entire resolution.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 210" width="680" height="210" role="img" aria-label="A funnel diagram. Three inputs at different sample rates — 2.4, 6, and 10 megasamples per second — converge into a digital down-converter box, which outputs one fixed per-protocol channel rate: 48 kilohertz for the C4FM family or 144 kilohertz for TETRA. A single receiver box follows, annotated that it is sized from the output rate and cannot tell capture rates apart. A note says a rate-dependent symptom that survives replay therefore lives in the samples.">
+  <text x="60" y="40" fill="currentColor" font-size="10">2.4 MS/s (RTL-SDR)</text>
+  <text x="60" y="86" fill="currentColor" font-size="10">6 MS/s (USRP)</text>
+  <text x="60" y="132" fill="currentColor" font-size="10">10 MS/s (Airspy)</text>
+  <line x1="190" y1="36" x2="268" y2="76" stroke="var(--fg-muted)"/><polygon points="264,72 274,79 266,82" fill="var(--fg-muted)"/>
+  <line x1="190" y1="82" x2="268" y2="88" stroke="var(--fg-muted)"/><polygon points="264,84 274,89 264,92" fill="var(--fg-muted)"/>
+  <line x1="190" y1="128" x2="268" y2="100" stroke="var(--fg-muted)"/><polygon points="264,96 274,97 266,104" fill="var(--fg-muted)"/>
+  <rect x="276" y="62" width="120" height="52" rx="6" fill="none" stroke="currentColor"/>
+  <text x="336" y="84" text-anchor="middle" fill="currentColor" font-size="10">DDC: mix, filter,</text>
+  <text x="336" y="98" text-anchor="middle" fill="currentColor" font-size="10">rational resample</text>
+  <line x1="396" y1="88" x2="424" y2="88" stroke="currentColor"/><polygon points="424,84 432,88 424,92" fill="currentColor"/>
+  <rect x="432" y="62" width="112" height="52" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="488" y="82" text-anchor="middle" fill="var(--accent)" font-size="10">one channel rate</text>
+  <text x="488" y="97" text-anchor="middle" fill="var(--fg-muted)" font-size="9">48 kHz C4FM · 144 kHz TETRA</text>
+  <line x1="544" y1="88" x2="572" y2="88" stroke="currentColor"/><polygon points="572,84 580,88 572,92" fill="currentColor"/>
+  <rect x="580" y="62" width="92" height="52" rx="6" fill="none" stroke="currentColor"/>
+  <text x="626" y="82" text-anchor="middle" fill="currentColor" font-size="10">receiver</text>
+  <text x="626" y="97" text-anchor="middle" fill="var(--fg-muted)" font-size="9">sized from output</text>
+  <text x="340" y="156" text-anchor="middle" fill="var(--fg-muted)" font-size="10">the receiver has no input that says what the capture rate was — it cannot treat rates differently</text>
+  <text x="340" y="182" text-anchor="middle" fill="var(--fg-muted)" font-size="10">so a symptom that tracks the rate AND survives offline replay was already in the samples (#764)</text>
+</svg>
+<figcaption>The rate funnel: any capture rate in, one per-protocol channel rate out, one receiver sized once — which is what turns "fails only at 10 MS/s" into evidence about the front end.</figcaption>
+</figure>
+
+## One channel rate per protocol
+
+The neck of the funnel is small enough to quote in full:
+
+```go
+// internal/scanner/ccdecoder/ddc.go (shape) — ddcTargetForProtocol
+// The 4800-baud C4FM family (P25 / DMR / NXDN / dPMR / YSF / D-STAR) and the
+// other ≤9600-baud protocols all channelize to ddcTargetRateHz; TETRA's
+// 18000-baud π/4-DQPSK needs a wider channel, so it gets
+// tetraDDCTargetRateHz — including TETRA DMO (Direct Mode).
+func ddcTargetForProtocol(p trunking.Protocol) float64 {
+    if p == trunking.ProtocolTETRA || p == trunking.ProtocolTETRADMO {
+        return tetraDDCTargetRateHz
+    }
+    return ddcTargetRateHz
+}
+```
+
+Two rates cover the roster: 48 kHz gives the 4800-baud family ten samples
+per symbol; TETRA's 18000-baud π/4-DQPSK gets 144 kHz — eight per symbol —
+because feeding it the C4FM target would leave under three samples per
+symbol and the timing loop would never lock (the exported
+`DDCTargetForProtocol` wrapper exists precisely so offline replay sizes its
+DDC to the *same* target the daemon uses). One subtlety worth knowing: the
+funnel normalizes in both directions. A narrowband capture recorded *below*
+the target is interpolated up to it, so the receiver always runs at its
+designed samples-per-symbol — interpolation can't create information the
+capture lacked, but it keeps the receiver's constants honest either way.
+
+## Two down-converters, two paths
+
+Rate-invariance holds *within* each path — but there are two. The
+single-channel `ccdecoder.Downconverter` serves replay's `-tune-hz` and the
+per-channel decoders; the multi-tap wideband `DDCBank` in
+`internal/dsp/tuner/ddc.go` serves `role: wideband` dongles, channelizing
+many taps out of one capture. They are separate implementations, and a fix
+to one does not touch the other — the exact gap that let #764's first fix
+(in the wideband path) leave #771's replay symptom (in the single-channel
+path) standing. The operator-level takeaway isn't the code layout, it's the
+debugging move it implies: when a wideband symptom needs isolating,
+re-testing the same capture through `gophertrunk replay -tune-hz` swaps in
+a different, simpler DDC — if the symptom follows the capture across *both*
+paths, the DDCs are exonerated together and the samples are indicted. The
+[Ten Megasamples postmortem]({{ '/blog/solution-postmortem/from-the-issue-tracker-05-ten-megasamples/' | relative_url }})
+runs that play in full.
+
+## What higher rates buy, and what they cost
+
+With invariance established, rate choice is purely a front-end and
+resources decision. The honest ledger:
+
+| | Higher rate (6–10+ MS/s) | Lower rate (≤ 2.4–3 MS/s) |
+|---|---|---|
+| Spectrum coverage | many taps / whole sub-band per dongle; wideband hunting | one system cluster per dongle |
+| Front-end cleanliness | configuration-dependent — measure it (Part 5; #764's 10 MS/s clock) | RTL's 2.4 MS/s sweet spot is well-trodden |
+| CPU | every tap's DDC runs against the full input rate | proportionally cheaper |
+| USB / network | 10 MS/s CS16 ≈ 40 MB/s sustained | comfortable on USB 2 |
+| Headroom coupling | one gain/ADC shared by everything in the capture (issue #749) | fewer co-tenants to stage around |
+
+The coverage upside is real — the entire
+[wideband multi-site architecture]({{ '/blog/deep-dives/the-hunt-09-wideband-multisite-p25/' | relative_url }})
+rides on it, and a [multi-dongle setup]({{ '/multi-dongle-sdr-setup/' | relative_url }})
+is the alternative spend. But each cost column has produced tracker
+traffic: Part 5 covered cleanliness; the shared-ADC column was Part 2 and
+Part 4; and CPU is next. For the underlying theory (Nyquist, aliasing, and
+why "more rate" never means "more fidelity per channel"), the
+[sample-rate lesson]({{ '/learn/rf-sdr/sample-rate-nyquist/' | relative_url }})
+and the [Field Guide entry]({{ '/reference/sample-rate/' | relative_url }})
+have you covered.
+
+## The warnings that mean "downstream"
+
+Raise the rate past what your host digests and GopherTrunk starts shedding
+— deliberately, at two designed points, each with a WARN that operators
+routinely read backwards.
+
+`ccdecoder: decode can't keep up with real time; dropping IQ at the decode
+queue (raise CPU / lower sample rate / shed load)` means exactly what it
+says: live IQ is arriving faster than the decode side consumes it, so
+chunks are dropped at the decode queue (counted in a dedicated metric,
+issue #402) rather than letting latency grow without bound.
+
+`soapyremote: SDR overruns — the host can't keep up with the configured
+sample rate…` with its `device_overflows` / `host_drops` counters is the
+network-source sibling. The driver's read loop *never* blocks on the DSP
+consumer — a blocked read stalls flow control and makes the radio itself
+drop samples in a way that shreds every channel at once — so when the
+bounded queue fills, `sendOrDrop` sheds the **oldest** queued chunk and
+counts it. Each shed is an IQ discontinuity that will glitch decodes.
+
+The reading discipline: `internal/sdr/soapyremote/` sheds only when the
+consumer stops draining, so a climbing `host_drops` is a symptom of
+something *downstream* getting slower — too many taps for the CPU, a new
+per-call workload, an over-ambitious rate — and the fix lives there (the
+companion ccdecoder WARN appearing too confirms CPU rather than network).
+The project has already had one hunt where an apparent "driver overrun bug"
+was a voice-chain CPU regression discovered exactly this way. Lower the
+rate, shed taps, or add CPU; the driver is the messenger.
+
+## Where this goes next
+
+Every part so far has staged the signal the antenna delivered. Starting
+with [Part 7]({{ '/blog/tutorials/analog-edge-07-antennas/' | relative_url }}),
+we improve what gets delivered in the first place — the antenna itself:
+which bands trunking actually lives in, why antenna "gain" is a shape
+rather than a magnitude (and can point that shape away from a close
+tower), polarization, and how to choose between a discone, a tuned
+vertical, and a yagi for a fixed system.
+
+## FAQ
+
+**If the decode path is rate-invariant, why does my system decode better at
+2.4 MS/s than at 8 MS/s?**
+Because invariance is precisely what localizes the difference to your front
+end and host: oscillator behavior at the higher clock (Part 5), a shared
+ADC now staging more spectrum (Parts 2–4), or shed IQ from an overloaded
+consumer (this part's WARNs). Capture at both rates and replay — if the gap
+reproduces from the files, it's the front end; if the live system lags but
+replay is clean, it's the host.
+
+**Does capturing at a higher rate improve per-channel quality?**
+No. The channel's information is set by its bandwidth and SNR at the
+antenna; the funnel delivers exactly that to the receiver regardless of
+capture rate. More rate widens the funnel's mouth (coverage), never the
+quality at its neck — and per Part 5 it can degrade the neck's contents if
+the front end is less clean at the higher clock.
+
+**What rate should I run an RTL-SDR at?**
+2.4 MS/s is the config's stated sweet spot, and RTL hardware caps at
+3.2 MHz (the top rates trade reliability for little). The interesting rate
+decisions arrive with hardware that offers real choices — Airspy, USRP,
+Lime — where the Part 5 A/B (capture at each candidate, replay, compare
+demod SNR) should settle it for your unit.
+
+**Are dropped chunks ever acceptable?**
+As a designed failure mode under transient load, yes — one bursty event
+during a scan storm is survivable, and shedding beats unbounded latency or
+device-side overflow storms. As a steady state, no: every shed chunk is an
+IQ discontinuity mid-decode. A `host_drops` counter that climbs whenever a
+voice call starts is telling you which workload to trim.
+
+**Why does TETRA get 144 kHz instead of 48 kHz?**
+Symbol rate. TETRA runs 18000 symbols/s against the C4FM family's 4800; at
+48 kHz it would get under 3 samples per symbol, below what the Gardner
+timing loop needs to lock. 144 kHz restores the designed 8 samples per
+symbol. Same funnel, protocol-appropriate neck.
+
+## Series navigation
+
+**Part 6 of 14** · ←
+[Part 5: Phase Noise & Reciprocal Mixing — The Ten-Megasamples Lesson]({{ '/blog/tutorials/analog-edge-05-phase-noise-reciprocal-mixing/' | relative_url }})
+· Next →
+[Part 7: Antennas for Trunking Bands]({{ '/blog/tutorials/analog-edge-07-antennas/' | relative_url }})

--- a/docs/_posts/2026-08-23-tetra-end-to-end-06-clean-room-acelp.md
+++ b/docs/_posts/2026-08-23-tetra-end-to-end-06-clean-room-acelp.md
@@ -1,0 +1,282 @@
+---
+title: "TETRA End to End, Part 6: A Clean-Room ACELP Vocoder in Pure Go"
+description: Inside GopherTrunk's pure-Go TETRA speech decoder — how a 137-bit ACELP frame becomes 240 samples of 8 kHz audio through LSP dequantisation, adaptive and algebraic codebooks, and a bit-exact fixed-point synthesis filter, and what clean-room means when the target is sample-for-sample agreement with a reference codec.
+category: deep-dives
+keywords: tetra acelp decoder, acelp vocoder go, en 300 395-2 speech codec, lsp dequantisation, algebraic codebook, adaptive codebook pitch, fixed point speech synthesis, 137 bit speech frame, bad frame indicator concealment, gophertrunk tetra
+tags: [tetra-end-to-end, tetra, acelp, vocoder, voice, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "TETRA End to End"
+series_part: 6
+---
+
+*Part 6 of **TETRA End to End**, a 14-part deep dive into how GopherTrunk turns
+one real 25 kHz TETRA carrier into clear recorded voice.
+[Part 5]({{ '/blog/deep-dives/tetra-end-to-end-05-tchs-traffic-channel/' | relative_url }})
+ended holding CRC-valid 137-bit speech frames — the traffic channel's whole
+output. Every other digital voice protocol GopherTrunk decodes speaks some MBE
+dialect, rendered by the vocoder family the
+[Voice Coding series]({{ '/blog/deep-dives/voice-coding-01-what-is-a-vocoder/' | relative_url }})
+dissected. TETRA speaks something else entirely: ACELP, the algebraic
+code-excited linear prediction family that also underlies GSM-EFR and G.729.
+GopherTrunk's implementation is pure Go, fixed-point, and bit-exact against
+the ETSI reference decoder — this part is how it works and what "clean-room"
+means when the acceptance test is sample-for-sample equality.*
+
+> **TL;DR:** `internal/voice/acelp` decodes one **137-bit** EN 300 395-2
+> speech frame into **240 samples of 8 kHz PCM** (30 ms). The frame is 23
+> quantiser indices (`bits2prm`): three split-VQ LSP indices dequantised by
+> `dLsp334` into the LPC filter, then four 60-sample subframes, each with a
+> pitch lag (20..143, 1/3-sample resolution), a 4-pulse **algebraic codebook**
+> index (`dD4i60`), and a 6-bit energy index (`decEner`, MA-predicted in the
+> log2 domain). Excitation = adaptive + algebraic vectors scaled by the
+> decoded gains, pushed through the `synFilt` LPC synthesis filter. All of it
+> runs on ported 16/32-bit **saturating fixed-point ops** (`ops.go`), because
+> bit-exactness lives or dies on overflow behaviour. The registry adapter
+> (`VocoderName = "tetra-acelp"`) applies the reference's `Post_Process`
+> saturating ×2 — omit it and the audio sits 6 dB under reference. Erased
+> frames (BFI) repeat the previous LSPs and parameters with decayed gains.
+
+**Key takeaways**
+
+- **ACELP is a source-filter model, not a spectral model.** MBE transmits a
+  description of the spectrum; ACELP transmits a recipe for the *excitation* —
+  pitch echo plus four algebraic pulses — and filters it through a
+  transmitted vocal-tract model. That's why its bit classes (Part 5) map so
+  cleanly to perceptual damage.
+- **Fixed-point is the spec, not an optimisation.** The reference codec
+  defines behaviour in saturating 16/32-bit arithmetic; matching it
+  sample-for-sample means porting the arithmetic, overflow flags and all.
+  Floating point would sound fine and match nothing.
+- **The decoder is honest about erasures.** A missing or CRC-failed frame
+  (BFI) doesn't glitch: LSPs and parameters repeat, energies decay — the
+  concealment the CRC gate of Part 5 relies on.
+- **One saturating ×2 is part of the codec.** The reference's `Post_Process`
+  doubles every output sample with saturation; GopherTrunk applies it in the
+  vocoder adapter so recordings match reference level exactly.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| Frame unpack | 137 bits → BFI + 23 indices (`bitWidths`) | `internal/voice/acelp/params.go` (`bits2prm`) |
+| LSP dequantise | 3 split-VQ indices (8+9+9 bits) → 10 LSPs | `params.go` (`dLsp334`), `lsp_tables.go` |
+| LPC interpolation | per-subframe filter from old/new LSPs | `internal/voice/acelp/lpc.go` (`intLpc4`, `lspAz`) |
+| Adaptive codebook | pitch prediction at 1/3-sample resolution | `internal/voice/acelp/codebook.go` (`predLt`, `inter32_1_3`) |
+| Algebraic codebook | 4 pulses from index/sign/shift + noise filter | `codebook.go` (`dD4i60`, `algebraicPulses`) |
+| Gain decode | 6-bit energy VQ, log2-domain MA prediction | `internal/voice/acelp/gain.go` (`enerPredictor.decEner`) |
+| Synthesis | excitation → speech through 1/A(z) | `internal/voice/acelp/syn.go` (`synFilt`) |
+| Registry adapter | `"tetra-acelp"`, 18-byte frames, Post_Process ×2 | `internal/voice/acelp/vocoder.go` (`NewVocoder`) |
+
+## In this post
+
+- **A different animal from MBE** — what ACELP transmits and why.
+- **Unpacking 137 bits** — the parameter layout of a frame.
+- **The excitation** — adaptive pitch, algebraic pulses, decoded gains.
+- **Synthesis in saturating fixed point** — why the basic ops are the codec.
+- **Erasures, the adapter, and what clean-room means here** — BFI concealment, the ×2, and provenance.
+
+## A different animal from MBE
+
+The [MBE model]({{ '/blog/deep-dives/voice-coding-02-the-mbe-model/' | relative_url }})
+that serves P25, DMR and NXDN transmits a *description of the output*: band
+energies, voicing decisions, a fundamental. ACELP transmits a *procedure for
+the input*: here is a filter approximating the vocal tract (the LPC
+coefficients, sent as line spectral pairs), and here is how to build the
+signal you should push through it — take an echo of what you excited the
+filter with a pitch period ago, add a handful of sharp pulses at coded
+positions, scale both. "Analysis-by-synthesis" means the *encoder* ran this
+exact decoder in a loop to pick the codebook entries whose output best matched
+the microphone; the decoder just replays the winning recipe. One consequence
+paid off in Part 5: parameters differ wildly in sensitivity — a wrong LSP or
+gain index corrupts the filter or energy trajectory for a whole frame (class
+2), while a mislocated excitation pulse is a click at worst (class 0).
+
+## Unpacking 137 bits
+
+`bits2prm` splits a frame into 23 indices whose widths are the codec's anatomy
+in one array:
+
+```go
+// internal/voice/acelp/params.go (shape)
+var bitWidths = [numParams]int{
+    8, 9, 9,        // split-VQ LSP indices (dico1..3)
+    8, 14, 1, 1, 6, // subframe 1: pitch, code, sign, shift, energy
+    5, 14, 1, 1, 6, // subframe 2
+    5, 14, 1, 1, 6, // subframe 3
+    5, 14, 1, 1, 6, // subframe 4
+}
+```
+
+26 bits of LSPs describe the vocal tract for the whole 30 ms; the remaining
+111 are four subframes of excitation recipe. The first subframe spends 8 bits
+on pitch to encode an absolute lag (20..143 samples with 1/3 fractions);
+subframes 2–4 spend 5, coding a delta around subframe 1's lag — pitch moves
+slowly, so relative coding is nearly free. `dLsp334` dequantises the three LSP
+indices against their codebooks and — with `intLpc4` — interpolates between
+last frame's LSPs and this frame's so the filter glides rather than steps at
+subframe boundaries.
+
+## The excitation: pitch echo plus four pulses
+
+Per subframe, the decoder builds 60 samples of excitation from two sources.
+The **adaptive codebook** is simply the recent excitation history replayed at
+the decoded lag: `predLt` reaches back `T0` samples (interpolating with
+`inter32_1_3` when the lag has a 1/3 fraction) — that recursion is what makes
+voiced speech periodic. The **algebraic codebook** adds the innovation — four
+pulses whose positions come from the 14-bit index, with a global sign and
+shift:
+
+```go
+// internal/voice/acelp/decoder.go (shape) — one subframe
+predLt(d.oldExc, excOff+iSubfr, int(T0), int(t0Frac), subfrLen) // adaptive vector
+
+ap3 := pondAi(aSub, d.fGamma3) // A(z/0.75)
+ap4 := pondAi(aSub, d.fGamma4) // A(z/0.85)
+/* … F[] = impulse response of ap3/ap4 weighting filter, + 0.8·pitch echo … */
+dD4i60(prm[base+sfCode], prm[base+sfSign], prm[base+sfShift], zeroF, 64, code)
+
+gainPit, gainCode := d.ener.decEner(prm[base+sfEnergy], bfi, aSub, excSub, code, subfrLen)
+for i := 0; i < subfrLen; i++ {
+    L := lMult0(d.oldExc[excOff+iSubfr+i], gainPit)
+    L = lMac0(L, code[i], gainCode)
+    d.oldExc[excOff+iSubfr+i] = int16(lShrR(L, 12)) // Q12 → Q0
+}
+synFilt(aSub, d.oldExc[excOff+iSubfr:], synth[iSubfr:iSubfr+subfrLen], subfrLen, d.memSyn[:], true)
+```
+
+Two refinements distinguish this from textbook CELP. The pulses aren't placed
+as raw impulses: `dD4i60` convolves them with `F[]`, a perceptual noise-shaping
+filter built per subframe from the bandwidth-expanded LPC (γ = 0.75/0.85) plus
+a fixed 0.8-gain pitch contribution — the innovation arrives pre-shaped to
+hide under the signal. And the gains aren't transmitted directly: `decEner`
+decodes one 6-bit index against an MA *prediction* of the pitch and code
+energies from the previous subframe, in the log2 domain — the codec bets that
+energy is predictable and only sends the correction. (That inter-subframe
+predictor is decoder state, which is why frame decoding is order-dependent and
+the conformance test of Part 7 must run whole files, not cherry-picked
+frames.)
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 210" width="680" height="210" role="img" aria-label="ACELP decoder block diagram: the adaptive codebook replays excitation history at the decoded pitch lag and the algebraic codebook produces four shaped pulses; each is scaled by its decoded gain and summed into the excitation, which feeds both the LPC synthesis filter producing 240 PCM samples and, recursively, back into the excitation history.">
+  <rect x="10" y="30" width="150" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="85" y="48" text-anchor="middle" fill="currentColor" font-size="10">adaptive codebook</text>
+  <text x="85" y="62" text-anchor="middle" fill="var(--fg-muted)" font-size="9">excitation @ lag T0 (1/3 res)</text>
+  <rect x="10" y="130" width="150" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="85" y="148" text-anchor="middle" fill="currentColor" font-size="10">algebraic codebook</text>
+  <text x="85" y="162" text-anchor="middle" fill="var(--fg-muted)" font-size="9">4 pulses, noise-shaped (dD4i60)</text>
+  <text x="216" y="45" text-anchor="middle" fill="var(--fg-muted)" font-size="9">× gain_pit</text>
+  <line x1="160" y1="52" x2="268" y2="94" stroke="currentColor"/><polygon points="260,92 274,97 264,84" fill="currentColor"/>
+  <text x="216" y="168" text-anchor="middle" fill="var(--fg-muted)" font-size="9">× gain_code</text>
+  <line x1="160" y1="152" x2="268" y2="110" stroke="currentColor"/><polygon points="264,120 274,107 260,112" fill="currentColor"/>
+  <circle cx="290" cy="102" r="14" fill="none" stroke="var(--accent)"/>
+  <text x="290" y="106" text-anchor="middle" fill="var(--accent)" font-size="12">+</text>
+  <line x1="304" y1="102" x2="352" y2="102" stroke="currentColor"/><polygon points="352,98 361,102 352,106" fill="currentColor"/>
+  <rect x="361" y="80" width="128" height="44" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="425" y="98" text-anchor="middle" fill="var(--accent)" font-size="10">LPC synthesis 1/A(z)</text>
+  <text x="425" y="112" text-anchor="middle" fill="var(--fg-muted)" font-size="9">synFilt, interpolated LSPs</text>
+  <line x1="489" y1="102" x2="537" y2="102" stroke="currentColor"/><polygon points="537,98 546,102 537,106" fill="currentColor"/>
+  <rect x="546" y="80" width="126" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="609" y="98" text-anchor="middle" fill="currentColor" font-size="10">240 samples / 30 ms</text>
+  <text x="609" y="112" text-anchor="middle" fill="var(--fg-muted)" font-size="9">8 kHz PCM (+ sat. ×2)</text>
+  <path d="M 290 116 Q 290 196 85 186 Q 30 182 24 78" fill="none" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <polygon points="20,86 24,72 30,85" fill="var(--fg-muted)"/>
+  <text x="290" y="200" text-anchor="middle" fill="var(--fg-muted)" font-size="9">excitation history feeds next subframe's adaptive codebook</text>
+</svg>
+<figcaption>The ACELP recipe: pitch echo plus shaped pulses, gain-scaled, summed, filtered — and written back into the history the next subframe will echo.</figcaption>
+</figure>
+
+## Synthesis in saturating fixed point
+
+The least glamorous file is the most load-bearing. `ops.go` ports the
+reference's basic operators — `addOp`, `sature`, `lMult0`, `lShrR`, the full
+16/32-bit saturating family, overflow flag included — and every block above is
+built exclusively from them. This is not retro affectation: the reference
+codec *defines* the decoder as sequences of these operations, and legal
+outputs are whatever they produce, saturation artifacts and all. A float
+implementation would sound indistinguishable and never match a single sample;
+matching sample-for-sample (Part 7's test is literally `mismatches != 0` →
+fail) requires the arithmetic to be the spec. The same discipline showed up on
+the C side of the fence with teeth: the reference tools themselves miscompute
+on LP64 hosts unless `Word32` is forced to 32 bits — every saturating op
+silently returns garbage — a trap Part 7 documents because it cost real time.
+
+## Erasures, the adapter, and what "clean-room" means here
+
+**Erasures.** When Part 5's CRC gate drops a burst, the vocoder still owes the
+recording 30 ms. On BFI the decoder repeats the previous frame's LSPs and
+quantiser parameters (`oldParm`, `oldT0`) while `decEner` decays the predicted
+energies — a fading echo of the last good frame instead of a click or a hole.
+A too-short input frame is treated as BFI automatically.
+
+**The adapter.** `vocoder.go` bridges to the
+[vocoder registry]({{ '/blog/deep-dives/voice-coding-01-what-is-a-vocoder/' | relative_url }}):
+`VocoderName = "tetra-acelp"`, `FrameSize()` of 18 bytes (137 bits packed
+MSB-first), registered in `voice.DefaultRegistry` at init so the recorder's
+`tetra → tetra-acelp` mapping resolves it by name. Its `Decode` applies the
+one post-step the raw decoder omits — the reference's `Post_Process`, a
+saturating multiply-by-two on every sample. That's not a tweak; skip it and
+GopherTrunk's output sits exactly 6 dB below the reference decoder's, which
+both fails conformance and makes TETRA recordings quiet next to every other
+protocol's.
+
+**Clean-room.** The phrase earns definition. This is a from-scratch Go
+implementation — no C compiled in, no cgo, no copied source — written to the
+EN 300 395-2 spec with the ETSI reference codec's *behaviour* as the
+acceptance target; the quantiser tables are the numeric constants the standard
+itself publishes. The package documentation is candid about provenance and
+posture: the reference implementation is ETSI-copyrighted, the algorithm
+family historically patent-encumbered (the core patents largely expired), and
+so the decoder lives in its own package behind an explicit vocoder
+registration, with the shipping posture documented in `docs/vocoders.md`
+rather than assumed. Honesty here is cheap; discovering a licensing problem
+after shipping is not.
+
+## Where this goes next
+
+"Bit-exact against the reference" has been asserted three times now without
+proof. [Part 7]({{ '/blog/deep-dives/tetra-end-to-end-07-etsi-conformance/' | relative_url }})
+supplies it: the two independent conformance passes — same bitstream into the
+ETSI reference decoder and GopherTrunk's, demanding identical PCM; and a real
+IQ capture through the whole chain, grant-correlated — plus the LP64 `Word32`
+trap in the reference build, and the chain-validation lesson that closes the
+loop on Part 3's CRC story.
+
+## FAQ
+
+**Why does TETRA use ACELP when everything else GopherTrunk decodes uses MBE?**
+Different lineages: the US land-mobile ecosystem standardised on DVSI's MBE
+family, while ETSI drew on the European telecom tradition that produced
+GSM-EFR and G.729 — ACELP was its state of the art at TETRA's design time, and
+at 4.567 kbit/s of speech data it fits TETRA's slot budget with room for the
+Part 5 protection.
+
+**Is 137 bits per 30 ms really enough for speech?**
+It's ~4.57 kbit/s, and yes — because so little of it is waveform. 26 bits
+model the vocal tract, and the rest is the excitation recipe the
+analysis-by-synthesis encoder chose. The result is characteristic codec
+speech: intelligible, speaker-recognisable, and unmistakably synthetic.
+
+**What sample rate and width does the decoder emit?**
+Signed 16-bit PCM at 8 kHz, 240 samples per frame. The recorder resamples or
+containers it the same way as every other vocoder's output — the registry
+interface hides the codec entirely.
+
+**How does concealment interact with the CRC gate upstream?**
+The gate turns "wrong bits" into "missing frame," and the decoder turns
+"missing frame" into a decayed repeat of the last good one. That pairing is
+deliberate: a wrong class-2 parameter can sound far worse than 30 ms of faded
+echo, so the system prefers erasure over corruption.
+
+**Could the vocoder be validated without the ETSI reference?**
+Only weakly — round-trip tests through GopherTrunk's own encoder would be
+Part 3's self-consistent trap wearing a codec costume. Sample-exact comparison
+against an independently built decoder is the strong form, and it's the entire
+subject of the next part.
+
+## Series navigation
+
+**Part 6 of 14** · ←
+[Part 5: TCH/S — From Traffic Burst to Speech Frame]({{ '/blog/deep-dives/tetra-end-to-end-05-tchs-traffic-channel/' | relative_url }})
+· Next →
+[Part 7: Conformance — Bit-Identical Against the ETSI Reference]({{ '/blog/deep-dives/tetra-end-to-end-07-etsi-conformance/' | relative_url }})

--- a/docs/_posts/2026-08-23-weak-signal-engineering-06-normalisation-guards.md
+++ b/docs/_posts/2026-08-23-weak-signal-engineering-06-normalisation-guards.md
@@ -1,0 +1,292 @@
+---
+title: "Weak-Signal Engineering, Part 6: Normalisation & Divergence Guards"
+description: The unglamorous half of a working blind equalizer — why the CMA update's cubic scaling in input amplitude makes normalisation part of the algorithm, how an EMA tracking a TDMA downlink's slot-to-slot power swings turned the full equalizer win into CRC zero, and why the divergence guard that re-seeds blown-up taps deserves a test of its own.
+category: deep-dives
+keywords: cma normalisation, adaptive filter divergence, equalizer divergence guard, tdma power swings, cumulative mean normalisation, ema normalisation trap, blind equalizer stability, adaptive dsp guards, gophertrunk weak-signal engineering
+tags: [weak-signal-engineering, cma, equalizer, stability, dsp, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Weak-Signal Engineering"
+series_part: 6
+---
+
+*Part 6 of **Weak-Signal Engineering**, a 14-part deep dive into decoding the
+marginal regime, where a receiver locks but under-decodes.
+[Part 5]({{ '/blog/deep-dives/weak-signal-engineering-05-snapshot-trick/' | relative_url }})
+delivered the headline mechanism — adapt continuously, apply frozen — and the
+headline numbers: TETRA voice bursts 410→778, the thread capture ~12%→~100%.
+This part is about the two lines of `SnapshotCMA` that made those numbers
+possible and that nobody would put on a slide: the input normaliser and the
+divergence guard. Both were discovered the hard way — one of them by watching
+the *entire* equalizer win evaporate to CRC zero over a choice of averaging
+window. The lesson generalises past CMA: in adaptive DSP, the reference frame
+and the failure handling are not packaging around the algorithm. They are the
+algorithm.*
+
+> **TL;DR:** The CMA tap update scales like **|x|³** in the input amplitude
+> (error `|y|²−R²` is quadratic, the steering term `y·conj(x)` adds another
+> power) — so the input's *scale* sets the effective step size and the
+> equilibrium. Normalising with a **local EMA** that tracks a TDMA downlink's
+> slot-to-slot power swings hands CMA a **moving modulus target**: measured
+> result, **CRC 0**, even though a global-RMS normalise on the same capture
+> gives the full win. `SnapshotCMA` therefore normalises by a
+> **cumulative-mean** power estimate — converging to the session RMS and then
+> staying put — and backs it with a **divergence guard**: if any tap's squared
+> magnitude exceeds `snapshotDivergeGuard = 9` (|tap| > 3), the tracking
+> filter re-seeds to center-spike pass-through, so one normalisation transient
+> or deep fade cannot poison every later snapshot. Constant references,
+> guarded recovery — both pinned by tests.
+
+**Key takeaways**
+
+- **An adaptive algorithm is only as good as its reference frame.** CMA
+  measures "modulus error" against R² = 1 *in normalised units* — if the
+  normaliser moves, the target moves, and the equalizer chases its own
+  denominator instead of the channel.
+- **TDMA is the worst case for local power tracking.** A downlink whose slots
+  swing power every 14.17 ms is precisely the signal that makes an EMA
+  normaliser oscillate — burst structure and adaptation dynamics interlock.
+- **Divergence is an operating condition, not an exception.** Deep fades and
+  transients *will* blow up a cubic-scaled update eventually; the design
+  question is only whether the filter recovers to neutral or keeps applying
+  garbage. The guard makes recovery structural.
+- **Guards get tests too.** The no-harm, recovery, and yield regressions pin
+  the guard and normaliser behaviour the same way they pin the taps — because
+  a silently disabled guard is indistinguishable from a working one until the
+  night it matters.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| Cumulative-mean normaliser | divide input by √(running mean power) — a constant-ish scale | `internal/dsp/equalizer/snapshot_cma.go` (`Process`: `cumSum`, `count`) |
+| Why not EMA | local tracking ⇒ moving modulus target ⇒ CRC 0 | `snapshot_cma.go` (doc comment) |
+| Divergence guard | re-seed tracking taps to pass-through at \|tap\| > 3 | `snapshot_cma.go` (`snapshotDivergeGuard = 9.0`) |
+| Guarded state only | guard hits `wAdapt`; frozen `wApply` unaffected until next snapshot | `snapshot_cma.go` (`Process`) |
+| Full-state reset | re-sync: taps, buffer, *and* normaliser state | `snapshot_cma.go` (`Reset`) |
+| Yield regressions | ISI recovery + clean-channel no-harm, CRC/bit-error scored | `snapshot_cma_test.go`, `internal/radio/tetra/receiver/receiver_equalizer_test.go` |
+
+## In this post
+
+- **Why CMA cares about scale at all** — the |x|³ update.
+- **The EMA trap** — a normaliser that danced with the TDMA frame.
+- **The cumulative mean** — boring on purpose.
+- **The divergence guard** — failing back to a wire.
+- **Guards are part of the algorithm** — the general lesson.
+
+## Why CMA cares about scale at all
+
+Nothing in Part 4's derivation looked scale-sensitive — until you count powers
+of the input. The update is `w ← w − μ·(|y|²−R²)·y·conj(x)`. With `y` linear
+in the input, the error factor is quadratic in input amplitude, and `y·conj(x)`
+contributes another power: the whole correction scales like **|x|³**. Feed the
+same equalizer a signal at half amplitude and the update shrinks 8×; at double
+amplitude it grows 8×. The input scale isn't a detail the algorithm tolerates —
+it *is* the effective step size, and it also decides where equilibrium lands,
+because CMA drives `|y|²` toward a fixed `R²` in whatever units the input
+arrives in.
+
+So every practical CMA normalises its input. `SnapshotCMA` bakes the
+normaliser into `Process` itself rather than trusting upstream AGC — the
+receiver's AGC settles at its own time constant for its own purposes, and
+"roughly unit power, eventually" is not the contract a cubic update wants.
+The normaliser's *form*, though, turned out to be a live design decision with
+a measured, catastrophic wrong answer.
+
+## The EMA trap: a normaliser that danced with the frame
+
+The reflexive choice is an exponential moving average of input power — track
+the level, divide it out, self-tuning, done. On a continuous carrier it even
+works. On a **TDMA downlink** it walked straight into the signal's structure:
+a TETRA base station's four-slot downlink can swing power slot to slot (this
+carrier's traffic loud, that idle period quieter), so a local EMA faithfully
+tracks a *stair-step* power profile. Divide by a stair-step and the
+"normalised" signal's modulus jumps at every slot boundary — which hands CMA a
+**moving modulus target**. The algorithm spends every slot re-converging
+toward a circle whose radius just changed, and its equilibrium never exists
+long enough to reach. The doc comment preserves the measured outcome:
+
+```go
+// internal/dsp/equalizer/snapshot_cma.go (shape) — doc
+// Input is normalised by a CUMULATIVE mean power estimate — a constant-ish
+// scale that converges to the whole-session RMS and stays put. This matters:
+// the CMA update scales with |x|³, and a *local* (EMA) normalisation that
+// tracks a bursty TDMA downlink's slot-to-slot power swings gives a moving
+// modulus target and CMA converges to garbage.
+```
+
+And "garbage" here is Part 2's currency: **CRC 0** — while the identical
+equalizer, on the identical capture, normalised by a single global RMS,
+delivered the full ~2× yield win. The entire difference between total failure
+and total success lived in the averaging window of a divisor. It's the EVM
+trap's quieter sibling: nothing in the equalizer's own diagnostics flags it,
+because the equalizer is dutifully minimising its cost — against a reference
+frame that won't hold still.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 220" width="680" height="220" role="img" aria-label="Three aligned traces over a TDMA downlink. Top: input power as a stair-step, slots alternating loud and quiet. Middle: an EMA normaliser tracking the stair-step, so the modulus target seen by CMA jumps at every slot boundary — labeled moving target, CRC zero. Bottom: the cumulative-mean normaliser as a nearly flat line converging to the session RMS — labeled constant target, full win.">
+  <text x="8" y="26" fill="var(--fg-muted)" font-size="9">input power</text>
+  <polyline points="90,44 170,44 170,26 250,26 250,50 330,50 330,30 410,30 410,46 490,46 490,28 570,28 570,44 650,44" fill="none" stroke="currentColor"/>
+  <text x="370" y="16" text-anchor="middle" fill="var(--fg-muted)" font-size="9">TDMA slots swing power every 14.17 ms</text>
+  <text x="8" y="96" fill="currentColor" font-size="9">EMA scale</text>
+  <polyline points="90,112 150,112 175,98 245,96 255,116 325,118 335,102 405,100 415,114 485,114 495,100 565,98 575,112 650,112" fill="none" stroke="currentColor"/>
+  <text x="370" y="88" text-anchor="middle" fill="currentColor" font-size="9">normaliser tracks the slots → modulus target moves → CMA chases it → CRC 0</text>
+  <text x="8" y="166" fill="var(--accent)" font-size="9">cumulative</text>
+  <text x="8" y="177" fill="var(--accent)" font-size="9">mean</text>
+  <path d="M90,186 C150,172 220,166 300,164 C420,162 540,162 650,162" fill="none" stroke="var(--accent)"/>
+  <text x="370" y="152" text-anchor="middle" fill="var(--accent)" font-size="9">converges to the session RMS, then stays put → constant R² → full ~2× yield win</text>
+  <text x="345" y="208" text-anchor="middle" fill="var(--fg-muted)" font-size="10">same equalizer, same capture — the averaging window of the divisor was the whole difference</text>
+</svg>
+<figcaption>On a slot-power-swinging TDMA downlink, an EMA normaliser hands CMA a target that moves at frame rate; the cumulative mean gives it one that converges and holds. Measured outcomes: CRC 0 versus the full win.</figcaption>
+</figure>
+
+## The cumulative mean: boring on purpose
+
+The fix is aggressively unsophisticated — a running mean over *everything seen
+so far*:
+
+```go
+// internal/dsp/equalizer/snapshot_cma.go (shape) — Process, the normaliser
+px := float64(real(x)*real(x) + imag(x)*imag(x))
+e.cumSum += px
+e.count++
+mean := e.cumSum / e.count
+if mean < 1e-9 { mean = 1e-9 }
+scale := float32(1 / math.Sqrt(mean))
+e.buf[n-1] = complex(real(x)*scale, imag(x)*scale)
+```
+
+Early in a stream it adapts quickly (small denominator); as `count` grows, each
+new slot's power moves the mean less and less, and the scale converges to the
+whole-session RMS and effectively freezes. That trajectory is exactly right
+for the job: CMA gets a *constant* reference frame in steady state — R² = 1
+means one thing all night — at the cost of the normaliser being deliberately
+sluggish about genuine long-term level changes. And that trade is safe
+precisely because of what's downstream: `Reset` clears `cumSum`/`count` along
+with the taps on every re-sync/retune, so the estimate never spans two
+different channels, and the divergence guard (next) catches the transient
+where a stale scale meets a step change in level. The design rhymes with
+Part 5 deliberately: *snapshot in time* (frozen taps) and *anchor in scale*
+(cumulative mean) are the same instinct — give the adaptive core references
+that hold still.
+
+## The divergence guard: failing back to a wire
+
+Even with a constant scale, a stochastic-gradient loop with cubic input
+scaling lives one bad interval from instability: a deep fade drops the input
+near zero (the normalised signal then rears up when it returns), a
+normalisation transient at stream start meets a hot slot, and the update takes
+a few huge steps. Left alone, blown-up taps don't just fail *now* — under the
+snapshot design they get copied into `wApply` at the next refresh and fail
+*for the rest of the stream*. Hence the guard, inline in the update loop:
+
+```go
+// internal/dsp/equalizer/snapshot_cma.go (shape) — the guard
+// snapshotDivergeGuard is the squared-tap-magnitude threshold at which the
+// tracking filter is re-seeded to a pass-through (|tap| > 3).
+const snapshotDivergeGuard = 9.0
+
+if mx > snapshotDivergeGuard { // taps blew up — re-seed to pass-through
+    for k := range e.wAdapt { e.wAdapt[k] = 0 }
+    e.wAdapt[n/2] = 1
+}
+```
+
+Three design choices, each carrying weight. **The threshold is far from
+normal operation**: a well-converged inverse for a plausible mobile channel
+keeps tap magnitudes near unity, so |tap| > 3 (9× energy) is unambiguous
+pathology, not a tuning knob that clips honest adaptation. **The guard
+re-seeds `wAdapt` only** — the frozen `wApply` keeps filtering with the last
+good snapshot while the tracking filter re-converges from pass-through, so a
+one-interval blow-up costs at most the staleness of one snapshot period.
+**And it fails toward neutral, not toward history**: the recovery state is
+the center-spike wire, whose worst case is "no equalization" — the baseline —
+rather than a re-application of whatever state preceded the blow-up. One bad
+patch cannot poison later snapshots; the doc comment says exactly that, and
+the capture sweeps that scored 410→778 ran with this guard armed.
+
+## Guards are part of the algorithm
+
+Zoom out, because this is the series' quietest recurring theme. The
+textbook presentation of an adaptive algorithm is the update rule; everything
+else is "implementation detail." The measured record says otherwise: on this
+one small struct, the *normaliser* was the difference between CRC 0 and a 2×
+win, and the *guard* is what makes an always-on deployment survivable. The
+same pattern reappears in Part 11's diversity calibrator — where a rejected
+measurement window **holds** the previous gains rather than falling back to
+passthrough, because the fallback *is itself* a phase step, and where the
+reference branch is pinned rather than re-elected per datagram. Different
+algorithm, same discipline: decide what must stay constant, decide what
+failure falls back to, and test both decisions as first-class behaviour.
+An adaptive algorithm without its guards isn't a leaner version of the same
+algorithm. It's a different, worse algorithm that usually behaves the same.
+
+### How that principle shaped the Go code
+
+- **References are state, so `Reset` owns them.** `cumSum`/`count` reset with
+  the taps — a channel estimate and its scale estimate live and die together,
+  never spanning a retune.
+- **The guard is in the hot loop, not a supervisor.** Divergence is detected
+  the same sample it happens (max tap magnitude tracked inside the update
+  walk), because a guard that runs "periodically" grants garbage a grace
+  period — and the next snapshot might land inside it.
+- **Every safety property has a regression.** No-harm on clean signals,
+  recovery on ISI, byte-identical off-state — the tests treat "does not make
+  things worse" as a feature with the same standing as "makes things better."
+
+## Where this goes next
+
+Blind CMA is now complete: cost, snapshot, references, guards — a lever that
+needs nothing from the signal but its envelope. But TETRA bursts *do* carry
+something better: a known training sequence at a known position, transmitted
+in the clear in every normal burst.
+[Part 7]({{ '/blog/deep-dives/weak-signal-engineering-07-trained-lms/' | relative_url }})
+takes the step from blind to trained: LMS on the midamble — train on the
+known symbols, freeze per burst, re-derive the soft decisions from equalized
+symbols — and the architectural consequence Part 3 foretold: the raw-symbol
+plumbing that had to be built before any of it could run.
+
+## FAQ
+
+**Why not just use the receiver's AGC as the normaliser?**
+The AGC serves the demodulator and settles at its own time constant; nothing
+guarantees the scale it delivers is constant on the timescale CMA's
+equilibrium needs, and coupling the equalizer's reference frame to another
+loop's dynamics invites exactly the interaction the EMA trap demonstrated.
+`SnapshotCMA` owning its normaliser makes its correctness self-contained.
+
+**Doesn't the cumulative mean go stale if the signal level genuinely changes?**
+Slowly, yes — by design. A genuine sustained level change (retune, gain
+change) should arrive with a `Reset` from the pipeline anyway; within one
+locked stream, slow staleness only means the effective μ drifts modestly,
+which the guard bounds in the worst case. The failure mode of the *responsive*
+alternative was total; the failure mode of the sluggish one is mild and
+bounded. Easy trade.
+
+**How was the EMA failure actually diagnosed?**
+By the series' standing rule: yield. The equalizer "worked" by its own
+telemetry (cost decreasing per slot), but the capture A/B showed CRC 0 with
+the EMA and the full win with a global-RMS normalise — same taps, same μ, same
+capture. Once the divisor was the only difference between the arms, the moving
+target explanation followed and the cumulative mean formalised it.
+
+**Why re-seed to pass-through instead of the last-good taps?**
+Because "last-good" is a guess about *why* the blow-up happened. If the
+channel genuinely changed, last-good taps are a confident wrong inverse; the
+wire is never confidently wrong, and `wApply` is still carrying the last
+snapshot regardless. Neutral recovery costs one re-convergence (a few hundred
+symbols at μ = 6e-3); wrong recovery can cost the stream.
+
+**Do other adaptive pieces of GopherTrunk follow this pattern?**
+Yes, deliberately. The diversity `TrackingCalibrator` (Part 11) holds gains on
+rejected windows and pins its reference branch; the autotune manager rejects
+implausible AFC measurements before averaging and gates its correction behind
+a warm-up. The shared shape — constant references, bounded failure, tested
+guards — is house style, learned mostly the expensive way.
+
+## Series navigation
+
+**Part 6 of 14** · ←
+[Part 5: The Snapshot Trick — Frozen Taps & Differential Decoders]({{ '/blog/deep-dives/weak-signal-engineering-05-snapshot-trick/' | relative_url }})
+· Next →
+[Part 7: Trained Equalization — LMS on the Midamble]({{ '/blog/deep-dives/weak-signal-engineering-07-trained-lms/' | relative_url }})

--- a/docs/_posts/2026-08-24-analog-edge-07-antennas.md
+++ b/docs/_posts/2026-08-24-analog-edge-07-antennas.md
@@ -1,0 +1,273 @@
+---
+title: "The Analog Edge, Part 7: Antennas for Trunking Bands"
+description: Antenna craft for trunked-radio monitoring — which bands the systems actually live in, why antenna gain is a radiation shape rather than free signal, polarization, when height beats gain, and how to choose between a discone, a tuned vertical, and a yagi for a fixed system.
+category: tutorials
+keywords: scanner antenna trunking, 800 mhz antenna, discone vs vertical, antenna gain pattern, vertical polarization lmr, antenna height vs gain, yagi for trunking, sdr antenna choice, gophertrunk analog edge
+tags: [analog-edge, antennas, rf, hardware, propagation, tutorial]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "The Analog Edge"
+series_part: 7
+---
+
+*Part 7 of **The Analog Edge**, a 14-part field guide to the analog half of a
+GopherTrunk installation. [Part 6]({{ '/blog/tutorials/analog-edge-06-sample-rate/' | relative_url }})
+finished the desk work: our reader with the marginal system has now staged
+gain, ruled out overload, checked the oscillator, and settled the rate — all
+without touching hardware. What's left is the hardware, starting where the
+signal does. The antenna is the one component that can *add* signal-to-noise
+ratio instead of merely preserving it, which is why it's the first dollar
+this series tells anyone to spend. It is also — on the evidence of the
+project's own weak captures — the dollar most often left unspent.*
+
+> **TL;DR:** Trunked systems live in a handful of bands — VHF-high, UHF,
+> and the 700/800/900 MHz cluster — and an antenna is only "good" *at a
+> frequency, in a direction*. **Gain is a shape, not a magnitude**: a
+> high-gain vertical buys its dB by flattening its pattern toward the
+> horizon, which is exactly wrong for a close, elevated tower. Match
+> **vertical polarization** (land-mobile is vertical; cross-polarization
+> costs real dB), put height before gain until feedline loss eats the
+> difference (Part 8), and choose by situation: **discone** to survey
+> everything, **tuned vertical** to monitor one band well, **yagi** to
+> reach one distant system. The tracker's marginal captures — the −44 dBFS
+> TETRA sessions, the −75 dBFS DMR file no decoder could use — are what
+> under-antennaed systems look like from the samples' side.
+
+**Key takeaways**
+
+- **The antenna is the only free SNR in the chain.** Every later stage —
+  LNA included — adds its own noise while amplifying; a better antenna
+  delivers more signal *and* no more noise. Nothing downstream can match
+  that trade.
+- **Gain redistributes; it doesn't create.** An antenna's dB come from
+  squeezing its radiation pattern toward the horizon. Whether that helps
+  depends entirely on where your towers are — including the close one a
+  flattened pattern can *miss*.
+- **Polarization is a silent tax.** Land-mobile trunking is vertically
+  polarized; a horizontally-mounted element or a random indoor wire pays a
+  large cross-polarization penalty before any other factor is counted.
+- **Buy for the band you actually monitor.** A wideband discone hears
+  everything adequately; a band-tuned vertical hears your system *well*.
+  Survey first, then specialize — the two-antenna strategy this series'
+  diversity parts (11–13) will formalize.
+
+## Cheat sheet
+
+| Concern | The short answer | Where to go deeper |
+|---|---|---|
+| Which antenna to buy | discone to survey, tuned vertical to camp, yagi to reach | [Best scanner antennas]({{ '/best-scanner-antenna/' | relative_url }}), [best SDR antennas]({{ '/best-sdr-antenna/' | relative_url }}) |
+| What "dBi/dBd" mean | gain relative to isotropic / dipole (dipole = 2.15 dBi) | [Antenna gain]({{ '/reference/antenna-gain/' | relative_url }}) |
+| Wideband survey antenna | the classic broadband vertical monitor antenna | [Discone]({{ '/reference/discone-antenna/' | relative_url }}) |
+| High-gain vertical mechanics | stacked elements, flattened elevation pattern | [Collinear]({{ '/reference/collinear-antenna/' | relative_url }}) |
+| One distant system | directional gain toward a single azimuth | [Yagi-Uda]({{ '/reference/yagi-uda-antenna/' | relative_url }}) |
+| Mounting, masts, grounding | doing the height part safely and legally | [Antenna mast & mounting guide]({{ '/antenna-mast-and-mounting-guide/' | relative_url }}) |
+| Whether it worked | level and decode metrics, before vs after | Parts 2–3 of this series — re-run the same measurements |
+
+## In this post
+
+- **The bands trunking lives in** — where to aim the whole exercise.
+- **Gain is a shape, not a magnitude** — patterns, and the close-tower trap.
+- **Polarization** — the cheapest dB you'll ever recover.
+- **Height beats gain — until it doesn't** — the feedline caveat.
+- **Choosing: discone, tuned vertical, or yagi** — a decision table.
+- **What the tracker's weak captures teach** — the evidence from our side.
+
+## The bands trunking lives in
+
+Antennas are frequency-selective, so the first question is never "which
+antenna?" but "which frequencies?" — and trunked radio concentrates into a
+few well-known neighborhoods (US-centric here; check your region's band
+plan):
+
+| Band | Rough range | Who you'll find there |
+|---|---|---|
+| VHF-high | 150–174 MHz | statewide/rural public safety, utilities |
+| UHF | 450–512 MHz | municipal systems, businesses; DMR and NXDN country |
+| 700 MHz | 769–806 MHz | modern P25 public-safety systems |
+| 800 MHz | 851–869 MHz | the classic trunking band — P25, EDACS, Motorola legacies |
+| 900 MHz | 935–940 MHz | business/industrial trunking, DMR |
+
+Look up your local systems before buying anything: a region whose activity
+sits entirely at 700/800 MHz wants a very different antenna than one on
+VHF. The wavelength spread is the point — a quarter-wave element is ~48 cm
+at 155 MHz and ~9 cm at 860 MHz, and no single passive element is optimal
+across that ratio. Wideband antennas exist by accepting compromise
+everywhere; tuned antennas excel by refusing it in one place. (For the
+propagation background — why 800 MHz is line-of-sight-ish while VHF bends
+farther — the [propagation lesson]({{ '/learn/rf-sdr/propagation/' | relative_url }})
+is the companion read.)
+
+## Gain is a shape, not a magnitude
+
+Antenna gain is the most mis-sold number in radio. An antenna is passive —
+it cannot amplify. A "6 dB gain" vertical delivers more signal from the
+horizon *by taking it from everywhere else*: picture the radiation pattern
+as a donut around the element that higher gain squashes flatter and wider.
+Those dB are real if your towers sit near the horizon. They are *negative*
+if a tower is close and elevated — a downtown high-rise site a kilometer
+away can sit meaningfully above a flattened pattern's main lobe, and
+operators genuinely see a cheap unity-gain whip beat an expensive high-gain
+collinear on exactly that one system. The
+[antenna gain]({{ '/reference/antenna-gain/' | relative_url }}) entry covers
+the units (dBi vs dBd — a half-wave dipole is the 2.15 dBi reference); the
+operational rule is simpler: **know your towers' directions and elevations
+before buying gain**, because gain is a bet on where the signal comes from.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 210" width="680" height="210" role="img" aria-label="Two elevation-pattern sketches. Left, a unity-gain vertical shows a plump rounded lobe reaching well above the horizon, and a nearby elevated tower sits inside the lobe. Right, a high-gain collinear shows a flattened lobe hugging the horizon; the same nearby tower now sits above the lobe and is missed, while a distant tower on the horizon is inside it. The caption states gain squeezes the pattern toward the horizon, helping distant sites and risking close elevated ones.">
+  <line x1="20" y1="160" x2="320" y2="160" stroke="var(--fg-muted)"/>
+  <text x="170" y="196" text-anchor="middle" fill="var(--fg-muted)" font-size="10">unity-gain whip: plump pattern</text>
+  <line x1="80" y1="160" x2="80" y2="120" stroke="currentColor" stroke-width="2"/>
+  <path d="M 80 158 Q 200 40 300 158" fill="none" stroke="currentColor"/>
+  <rect x="196" y="96" width="8" height="34" fill="var(--accent)"/>
+  <line x1="188" y1="96" x2="212" y2="96" stroke="var(--accent)"/>
+  <text x="200" y="88" text-anchor="middle" fill="var(--accent)" font-size="9">close, elevated tower — heard</text>
+  <line x1="360" y1="160" x2="660" y2="160" stroke="var(--fg-muted)"/>
+  <text x="510" y="196" text-anchor="middle" fill="var(--fg-muted)" font-size="10">high-gain collinear: flattened pattern</text>
+  <line x1="420" y1="160" x2="420" y2="104" stroke="currentColor" stroke-width="2"/>
+  <path d="M 420 158 Q 540 118 656 152" fill="none" stroke="currentColor"/>
+  <rect x="536" y="96" width="8" height="34" fill="var(--accent)"/>
+  <line x1="528" y1="96" x2="552" y2="96" stroke="var(--accent)"/>
+  <text x="540" y="88" text-anchor="middle" fill="var(--accent)" font-size="9">same tower — above the lobe</text>
+  <polyline points="648,142 652,128 656,142" fill="none" stroke="currentColor"/>
+  <text x="640" y="120" text-anchor="end" fill="currentColor" font-size="9">distant site on the horizon — helped</text>
+  <text x="340" y="30" text-anchor="middle" fill="var(--fg-muted)" font-size="10">the dB on the box are taken from above and below the horizon — gain is a bet on tower geometry</text>
+</svg>
+<figcaption>Two elevation patterns, one nearby elevated tower: the high-gain antenna's flattened lobe helps the distant site and can miss the close one. Gain redistributes; it never creates.</figcaption>
+</figure>
+
+## Polarization
+
+Land-mobile radio is **vertically polarized** — mobile whips point up, so
+the infrastructure does too. Receive with a matched vertical element and
+you collect the full field; turn the element horizontal and, in the
+textbook case, the cross-polarization loss is severe (tens of dB in free
+space; scattering in real environments softens it to "merely large").
+This is the cheapest audit in the series: telescopic antennas angled for
+looks, mag-mounts on their side on a windowsill, random lengths of wire
+draped where convenient — each is quietly paying a polarization tax on
+every tower at once. Stand the element vertical, with a decent ground
+plane under a mag-mount (a cookie sheet genuinely works), before spending
+anything. The [polarization]({{ '/reference/polarization/' | relative_url }})
+entry has the theory; the audit takes thirty seconds.
+
+## Height beats gain — until it doesn't
+
+At trunking frequencies, propagation is dominated by what stands between
+you and the tower. Height fixes obstruction directly: getting an antenna
+above the roofline changes the *path*, which routinely dwarfs any
+achievable pattern gain — going from an indoor desk antenna to a modest
+outdoor mount is frequently a 10–20 dB swing at UHF and up, whereas the
+best consumer verticals advertise 6–9 dB against a reference dipole. If
+you can only change one thing about a marginal installation, raise the
+antenna. Indoors, even a window facing the tower instead of an interior
+room can be the difference the decoder needed.
+
+The caveat that pairs with this part: every meter of height is a meter of
+coax, and at 800 MHz cheap coax charges by the meter — enough that a long
+run of the wrong cable can spend the entire height dividend before it
+reaches the tuner. That arithmetic (loss per cable class, and why receive
+loss before the first amplifier is especially costly) is precisely
+[Part 8]({{ '/blog/tutorials/analog-edge-08-feedline-connectors/' | relative_url }}),
+so plan mast and feedline as one decision — the
+[mast & mounting guide]({{ '/antenna-mast-and-mounting-guide/' | relative_url }})
+covers the mechanical and safety side.
+
+## Choosing: discone, tuned vertical, or yagi
+
+For a fixed monitoring installation, three archetypes cover nearly every
+case:
+
+| | Discone | Tuned vertical (¼-wave / collinear) | Yagi |
+|---|---|---|---|
+| Bandwidth | very wide (an octave-plus) | one band, done well | narrow, one band |
+| Gain | ~unity | unity (¼-wave) to ~6–9 dBd (collinear) | high, in one direction |
+| Pattern | omnidirectional | omnidirectional (flatter with gain) | one azimuth lobe |
+| Best for | surveying, hunting, many bands at once | camping on your area's main band | one distant/weak system |
+| Watch out | mediocre everywhere by design | close-elevated-tower trap above | must be aimed; everything else fades |
+
+The strategy that falls out: **survey wide, then camp tuned.** A discone
+plus [the hunt]({{ '/blog/deep-dives/the-hunt-01-what-discovery-means/' | relative_url }})
+tells you what's actually receivable at your site; once you know which
+system you care about, a vertical tuned to its band converts that
+discovery into decode margin. The yagi is the specialist's move — one
+distant system, direction known, everything else sacrificed. If you run
+more than one dongle, run more than one antenna philosophy at once (the
+[multi-dongle guide]({{ '/multi-dongle-sdr-setup/' | relative_url }}) covers
+the plumbing): discone on the hunting dongle, tuned vertical on the
+production system. Specific current models are kept in the
+[scanner antenna]({{ '/best-scanner-antenna/' | relative_url }}) and
+[SDR antenna]({{ '/best-sdr-antenna/' | relative_url }}) guides rather than
+here, so this post can age gracefully.
+
+## What the tracker's weak captures teach
+
+This series keeps its claims tied to the project's evidence, so: what does
+an under-antennaed system look like from the samples' side? Like the
+captures our decoders keep meeting. The TETRA control-channel sync-loss
+investigation ran on captures peaking around **−44 dBFS** — weak enough
+that the marginal-SNR regime caused hard sync losses, and the fix notes
+say it plainly: the equalizer mitigates a weak front end *but the residual
+condition is RF/gain/antenna — raise the signal level too*. The DMR
+two-slot verification from Part 1 is still parked on a **−75 dBFS** capture
+with no recoverable frame sync at all. In both cases sophisticated software
+(equalizers, soft decision) recovered real margin, and in both cases the
+notes end by pointing back across Part 1's line. The decoder can only be as
+good as the samples — and the antenna is where the samples are born. The
+[antennas lesson]({{ '/learn/rf-sdr/antennas/' | relative_url }}) makes a
+good deeper companion to this whole part.
+
+## Where this goes next
+
+A better antenna earns you dB at the top of the mast; the feedline decides
+how many survive the trip down. [Part 8]({{ '/blog/tutorials/analog-edge-08-feedline-connectors/' | relative_url }})
+follows the coax — loss per hundred feet by cable class at 800 MHz, why
+every adapter is a small tax, the SMA/BNC/N/F connector ecosystems, and why
+a dB lost *before* the first amplifier is the most expensive dB in the
+whole chain.
+
+## FAQ
+
+**Will a better antenna fix my garbled audio?**
+If the problem is signal-starvation, it's the single most effective fix
+available — and Parts 2–3 give you the before/after instruments to prove
+it (level regime, decode error rate, demod SNR). If your levels are already
+healthy and the decode error rate is low, your problem is elsewhere in this
+series, and a new antenna will disappoint. Measure first.
+
+**Is the antenna that came with my dongle good enough?**
+For strong local systems, sometimes. Structurally it's a short, often
+poorly-grounded whip at desk height — the polarization, ground-plane, and
+height mistakes bundled together. It's fine for *proving the software
+works*; treat it as the baseline the real antenna gets measured against.
+
+**Can one antenna cover VHF and 800 MHz?**
+A discone genuinely can, at the price of being merely adequate at both —
+that's its design contract. What can't cover both well is a *tuned*
+antenna: a vertical cut for 155 MHz is far off-resonance at 860 MHz. If
+you monitor two distant bands seriously, that's two antennas (and ideally
+two dongles) — not one compromise.
+
+**Do amplified ("active") antennas help?**
+They move Part 9's problem into the antenna housing: an amplifier helps
+only if it comes *before* significant loss and *after* adequate
+selectivity, and a wideband amp at the antenna also amplifies every pager
+and broadcast blaster in view (Part 4). Passive antenna + separate,
+chosen LNA where the math says it belongs (Part 9's whole subject —
+funnel: [best SDR LNAs]({{ '/best-sdr-lna/' | relative_url }})) beats an
+opaque bundled amp you can't reason about.
+
+**How do I verify a new antenna actually improved things?**
+Re-run the Part 2/Part 3 measurements you already know: same channel, same
+gain staging procedure, compare `iq_power_dbfs` regime, clip ratio, decode
+error rate at the chosen rung, and demod SNR on a replayed capture. A real
+upgrade shows up as decode-quality improvement at *equal or lower* gain —
+if you had to raise gain to see a difference, you measured the knob, not
+the antenna.
+
+## Series navigation
+
+**Part 7 of 14** · ←
+[Part 6: Sample Rate — The Decode Path Doesn't Care; the Front End Does]({{ '/blog/tutorials/analog-edge-06-sample-rate/' | relative_url }})
+· Next →
+[Part 8: Feedline & Connectors — Where dB Go to Die]({{ '/blog/tutorials/analog-edge-08-feedline-connectors/' | relative_url }})

--- a/docs/_posts/2026-08-24-tetra-end-to-end-07-etsi-conformance.md
+++ b/docs/_posts/2026-08-24-tetra-end-to-end-07-etsi-conformance.md
@@ -1,0 +1,292 @@
+---
+title: "TETRA End to End, Part 7: Conformance — Bit-Identical Against the ETSI Reference"
+description: "How GopherTrunk proves its TETRA voice path — two independent conformance passes against the ETSI EN 300 395-2 reference codec, one demanding sample-for-sample PCM equality on a shared bitstream and one replaying real IQ through the whole chain, plus the 64-bit Word32 build trap that makes the reference tools lie."
+category: deep-dives
+keywords: etsi reference codec, en 300 395-2 conformance, bit exact vocoder test, tetra acelp validation, word32 lp64 trap, scoder sdecoder, skip guarded test harness, whole chain validation, tetra replay capture, gophertrunk tetra
+tags: [tetra-end-to-end, tetra, conformance, testing, acelp, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "TETRA End to End"
+series_part: 7
+---
+
+*Part 7 of **TETRA End to End**, a 14-part deep dive into how GopherTrunk turns
+one real 25 kHz TETRA carrier into clear recorded voice.
+[Part 6]({{ '/blog/deep-dives/tetra-end-to-end-06-clean-room-acelp/' | relative_url }})
+closed with a promise: the pure-Go ACELP decoder is bit-exact against the ETSI
+reference, and that claim has proof. This part is the proof — and the method
+behind it, because the method is the real deliverable. This series' villain is
+the test that validates its own bugs; the antidote is an **external
+reference**, and TETRA voice has two independent ones: the ETSI reference C
+codec, and the air itself. Between them sits a build trap that makes the
+reference tools produce garbage on every modern 64-bit machine, and a
+diagnostic rule this repo now treats as standing guidance.*
+
+> **TL;DR:** Two independent conformance passes, both reproducible.
+> **Pass one** (`internal/voice/acelp/etsi_reference_test.go`,
+> `TestETSIReferenceConformance`): feed the *same* 137-bit-per-frame bitstream
+> to the ETSI `sdecoder` and to GopherTrunk's decoder and demand **zero
+> mismatched samples** — the decoder is fixed-point, so a faithful port
+> matches exactly. **Pass two**
+> (`cmd/gophertrunk/tetra_multislot_replay_test.go`,
+> `TestTETRAMultiSlotReplay`): replay a real cs16 IQ capture through DDC →
+> receiver → extractor → TCH/S → ACELP and correlate per-slot audio against
+> the control channel's grant timeslots. Both are **skip-guarded** behind env
+> vars because the ETSI vectors are copyrighted and captures are large.
+> The trap: the reference sources assume a 32-bit `Word32` (`typedef long`) —
+> on an LP64 host every saturating op silently returns garbage, so build the
+> tools with a 32-bit `Word32` (or `-m32`) before trusting a byte they emit.
+> The rule the passes enforce: **validate the whole chain against the
+> reference, not just parts** — when voice doesn't decode but the vocoder's
+> unit tests pass, suspect the channel coding.
+
+**Key takeaways**
+
+- **Bit-exactness is a binary verdict, and that's its value.** Fixed-point
+  codecs permit `mismatches == 0` as the pass condition — no perceptual
+  scoring, no tolerance tuning, no argument. One wrong saturating op fails
+  loudly at a specific frame.
+- **Two passes catch different lies.** The bitstream pass pins the vocoder in
+  isolation; the IQ replay pins everything *upstream* of it. Part 3's CRC bug
+  passed the first kind of scrutiny and only the second kind caught it.
+- **The reference itself can be built wrong.** ETSI's fixed-point basic ops
+  predate LP64; an unmodified 64-bit build produces confidently wrong
+  vectors. Verify your reference before you verify against your reference.
+- **Skip-guarded is not second-class.** Harnesses gated on `GT_ETSI_SERIAL` /
+  `GT_TETRA_IQ` keep copyrighted vectors and bulky captures out of the repo
+  while keeping the *procedure* executable by anyone — the reproducibility
+  lives in the test file, not the test data.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| Bitstream conformance | same serial file → GT vs ETSI PCM, 0 mismatches | `internal/voice/acelp/etsi_reference_test.go` (`TestETSIReferenceConformance`) |
+| Serial format | int16 LE, 138 words/frame: BFI + 137 bits | `etsi_reference_test.go` (doc comment) |
+| Level matching | reference `Post_Process` saturating ×2 | `etsi_reference_test.go` (`postProcessX2`) |
+| Whole-chain replay | real cs16 IQ → per-slot audio vs grants | `cmd/gophertrunk/tetra_multislot_replay_test.go` (`TestTETRAMultiSlotReplay`) |
+| Replay knobs | `GT_TETRA_IQ`, `GT_TETRA_IQ_RATE`, `GT_TETRA_COLOUR`, `GT_TETRA_OUT` | same file |
+| Reference build trap | `Word32` must be 32-bit; LP64 `long` breaks saturation | `etsi_reference_test.go` (build note) |
+
+## In this post
+
+- **Why conformance needed two passes** — what each can and cannot see.
+- **Pass one: the shared bitstream** — serial format, the ×2, and zero as the bar.
+- **The Word32 trap** — when the reference implementation isn't the reference.
+- **Pass two: the air** — replaying a capture through everything at once.
+- **The diagnostic rule** — chain validation as standing guidance.
+
+## Why conformance needed two passes
+
+A voice path is a chain: demod → burst extraction → descramble → channel
+decode → vocoder. Part 3 told the story of a bug that lived in the middle —
+the class-2 CRC — while the pieces on either side of it were provably fine.
+That episode fixed more than a CRC; it fixed the *testing model*. A unit test
+per stage, each validated against its own encoder, proves only that each
+stage agrees with itself. What's needed is external anchoring at two scopes:
+the most complex single component (the vocoder) pinned against an independent
+implementation, and the chain as a whole pinned against the only artifact
+that exercises every stage with real-world conventions at once — an off-air
+capture. Neither pass substitutes for the other. The bitstream pass would
+never notice a scrambler seed bug (it enters below the scrambler); the replay
+pass can't tell you *which* stage broke, only that one did. Together they
+triangulate.
+
+## Pass one: the shared bitstream
+
+The ETSI distribution ships a fixed-point encoder and decoder. The harness
+runs them once to produce two files, then holds GopherTrunk to their output:
+
+```
+scoder   in.pcm     serial.bin  synth_local.pcm   # ETSI reference encoder
+sdecoder serial.bin ref_out.pcm                   # ETSI reference decoder
+```
+
+`serial.bin` is the shared bitstream — int16 little-endian, **138 words per
+frame**: word 0 is the bad-frame indicator, words 1..137 are the coded speech
+bits, exactly the format the reference's `Bits2prm_Tetra` reads and
+GopherTrunk's `Decoder.Decode` consumes. `ref_out.pcm` is the reference
+decoder's 240-samples-per-frame output. The test walks both in lockstep:
+
+```go
+// internal/voice/acelp/etsi_reference_test.go (shape)
+dec := NewDecoder()
+for f := 0; f < nFrames; f++ {
+    bfi := serial[base] != 0
+    /* … unpack 137 bits … */
+    out := dec.Decode(bits, bfi)
+    for i, s := range out {
+        got := postProcessX2(s) // reference Post_Process: saturating ×2
+        if got != ref[f*pcmPerFrame+i] {
+            mismatches++ /* … track maxAbs, firstBadFrame … */
+        }
+    }
+}
+// pass condition: mismatches == 0
+```
+
+The bar is **zero**. Not "SNR above X," not "perceptually transparent" —
+identical int16s, every sample of every frame, BFI frames included. That bar
+is only reachable because the codec is defined in saturating fixed-point
+arithmetic (Part 6's point): determinism is the spec. And it's why the pass
+condition doubles as a diagnostic — `firstBadFrame` and `maxAbsDiff` in the
+failure log localise a divergence to the frame where some ported operator
+first disagreed, which during development repeatedly turned "the decoder is
+wrong somewhere" into "look at this one subframe's gain path." Note the test
+applies the `postProcessX2` itself: GopherTrunk's raw `Decoder` omits the
+reference's output doubling (the registry adapter applies it in production),
+so the harness levels the two before comparing.
+
+The vectors are not committed — ETSI's sources and outputs are copyrighted —
+so the test skips unless `GT_ETSI_SERIAL` and `GT_ETSI_REF` point at files you
+built yourself. The procedure is the artifact under version control.
+
+## The Word32 trap
+
+Which brings us to the trap, preserved as a build note in the test's doc
+comment because it burned real hours: the ETSI basic operators assume
+`Word32` is 32 bits, via `typedef long` — true under ILP32, false on every
+LP64 Linux/macOS host, where `long` is 64 bits. The consequence is not a
+crash. Saturation tests like "does this exceed the 32-bit range" simply never
+fire, so **every saturating operation returns unsaturated garbage** and the
+reference tools emit confidently wrong PCM. Diff GopherTrunk against *that*
+and you'd conclude the Go port is broken — or worse, "fix" the Go port into
+agreement with a miscompiled reference, manufacturing a self-consistent pair
+of wrong decoders. The villain, one meta-level up. The fix is mechanical
+(edit the typedef to `int`, or build `-m32`); the lesson is not: **a
+reference implementation is only a reference once you've verified the build
+assumptions it was written under.** Trust, then verify — in that order,
+applied to the yardstick itself.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 220" width="680" height="220" role="img" aria-label="The two conformance passes. Pass one: a shared serial bitstream from the ETSI encoder fans out to the ETSI reference decoder and to GopherTrunk's decoder, whose PCM outputs are compared for zero mismatches. Pass two: a real cs16 IQ capture flows through the full GopherTrunk chain of DDC, receiver, extractor, TCH/S and ACELP, and the per-slot audio is correlated against the control channel's grant timeslots.">
+  <text x="20" y="24" fill="var(--fg-muted)" font-size="11" font-weight="bold">Pass 1 — shared bitstream (vocoder in isolation)</text>
+  <rect x="20" y="36" width="110" height="40" rx="6" fill="none" stroke="currentColor"/>
+  <text x="75" y="53" text-anchor="middle" fill="currentColor" font-size="10">serial.bin</text>
+  <text x="75" y="67" text-anchor="middle" fill="var(--fg-muted)" font-size="9">BFI + 137 bits/frame</text>
+  <line x1="130" y1="46" x2="196" y2="40" stroke="currentColor"/><polygon points="188,36 202,40 190,46" fill="currentColor"/>
+  <line x1="130" y1="66" x2="196" y2="72" stroke="currentColor"/><polygon points="190,66 202,72 188,76" fill="currentColor"/>
+  <rect x="202" y="24" width="128" height="32" rx="6" fill="none" stroke="currentColor"/>
+  <text x="266" y="44" text-anchor="middle" fill="currentColor" font-size="10">ETSI sdecoder (32-bit!)</text>
+  <rect x="202" y="62" width="128" height="32" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="266" y="82" text-anchor="middle" fill="var(--accent)" font-size="10">acelp.Decoder + ×2</text>
+  <line x1="330" y1="40" x2="392" y2="52" stroke="currentColor"/><polygon points="384,50 398,55 386,58" fill="currentColor"/>
+  <line x1="330" y1="78" x2="392" y2="66" stroke="currentColor"/><polygon points="386,60 398,63 384,68" fill="currentColor"/>
+  <rect x="398" y="42" width="120" height="34" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="458" y="57" text-anchor="middle" fill="var(--accent)" font-size="10">compare PCM</text>
+  <text x="458" y="70" text-anchor="middle" fill="var(--fg-muted)" font-size="9">mismatches must be 0</text>
+  <text x="20" y="122" fill="var(--fg-muted)" font-size="11" font-weight="bold">Pass 2 — real capture (the whole chain)</text>
+  <rect x="20" y="134" width="90" height="40" rx="6" fill="none" stroke="currentColor"/>
+  <text x="65" y="151" text-anchor="middle" fill="currentColor" font-size="10">cs16 IQ</text>
+  <text x="65" y="165" text-anchor="middle" fill="var(--fg-muted)" font-size="9">GT_TETRA_IQ</text>
+  <line x1="110" y1="154" x2="130" y2="154" stroke="currentColor"/><polygon points="130,150 139,154 130,158" fill="currentColor"/>
+  <rect x="139" y="134" width="300" height="40" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="289" y="151" text-anchor="middle" fill="var(--accent)" font-size="10">DDC → receiver → extractor → TCH/S → ACELP</text>
+  <text x="289" y="165" text-anchor="middle" fill="var(--fg-muted)" font-size="9">every stage, real-air conventions</text>
+  <line x1="439" y1="154" x2="459" y2="154" stroke="currentColor"/><polygon points="459,150 468,154 459,158" fill="currentColor"/>
+  <rect x="468" y="134" width="190" height="40" rx="6" fill="none" stroke="currentColor"/>
+  <text x="563" y="151" text-anchor="middle" fill="currentColor" font-size="10">per-slot audio timeline</text>
+  <text x="563" y="165" text-anchor="middle" fill="var(--fg-muted)" font-size="9">correlated vs grant timeslots</text>
+  <text x="340" y="204" text-anchor="middle" fill="var(--fg-muted)" font-size="10">pass 1 pins the vocoder; pass 2 pins everything upstream of it — the CRC bug of Part 3 was only visible to pass 2</text>
+</svg>
+<figcaption>Two external anchors: sample-exact PCM equality on a shared bitstream, and grant-correlated audio from a real capture through the whole chain.</figcaption>
+</figure>
+
+## Pass two: the air
+
+The second pass is Part 5's replay harness wearing its conformance hat.
+`TestTETRAMultiSlotReplay` takes a real cs16 capture of a TETRA voice carrier
+(`GT_TETRA_IQ` + `GT_TETRA_IQ_RATE`), pushes it through the *production*
+chain — the same `ccdecoder.NewDownconverter`, the same receiver options, the
+same `TrafficExtractor` and `TCHSpeechFrames` and ACELP decode the daemon
+runs — and emits per-slot WAVs plus activity timelines. The conformance
+content is the correlation step: decoded speech must cluster on the timeslots
+the control channel granted, at the times it granted them, with CRC yields
+well off the 1/256 chance floor. A capture is the one test vector nobody on
+the implementation side could have accidentally shaped, which is why this
+pass caught what the unit tests could not: the class-2 CRC bug (all slots at
+the chance floor), and later the slot-anchor shift (activity on the wrong
+timeslots). It has since become the standing A/B instrument — the
+soft-decision work of
+[Part 8]({{ '/blog/deep-dives/tetra-end-to-end-08-soft-decision-tchs/' | relative_url }})
+and the equalizer work after it are all scored as CRC-yield deltas on this
+same harness, against the same captures.
+
+## The diagnostic rule
+
+The two passes compose into a decision procedure that is now standing
+guidance in the repo, verbatim: *when "voice doesn't decode" but the vocoder
+unit tests pass, suspect the channel coding (CRC / interleave / reorder), not
+the vocoder — validate the whole chain against the reference, not just
+parts.* The reasoning generalises. Pass one is cheap, deterministic, and
+absolute — once it holds, the vocoder is effectively eliminated as a suspect
+for any field symptom. So a field symptom with a green pass one *localises
+itself* to the chain between demod and vocoder. That inversion — conformance
+tests as suspect-elimination for future debugging, not just release gating —
+is what the harnesses actually bought. Every subsequent TETRA investigation
+in this series (soft decision, equalizers, DMO's false "encryption") started
+from "the vocoder is proven; where in the chain is the loss?" and was faster
+for it.
+
+### How that principle shaped the Go code
+
+- **Formats are documented at the test site.** The 138-word serial layout and
+  the Word32 build note live in the test's doc comment — the next person to
+  regenerate vectors gets the traps handed to them with the procedure.
+- **The comparison is production-honest.** The harness applies the same
+  `Post_Process` ×2 the registry adapter applies, so pass one certifies the
+  audio path as shipped, not a lab variant.
+- **One harness, many questions.** The replay test grew counters
+  (`trafficMarkedCRC`, soft-path yields, per-marker clustering) instead of
+  spawning sibling tests — every voice-path change since is an A/B on the
+  same instrument, so numbers stay comparable across months.
+
+## Where this goes next
+
+The chain is proven end to end — on a *clean* capture. The next problem is
+the marginal one: a same-carrier call where the hard-decision path threw away
+~70% of the bursts that were actually recoverable.
+[Part 8]({{ '/blog/deep-dives/tetra-end-to-end-08-soft-decision-tchs/' | relative_url }})
+follows the soft path — the receiver's `SoftSink` differentials through soft
+depuncture and Viterbi to `DecodeTCHSSoft` — and the ~2 dB that turned
+short, garbled recordings into complete ones.
+
+## FAQ
+
+**Why aren't the conformance vectors committed to the repo?**
+Because the ETSI reference sources and their outputs are ETSI-copyrighted.
+The harness is committed; the vectors are regenerated locally from the ETSI
+distribution by anyone who wants to run it. Reproducibility of the
+*procedure* is the goal — the test file documents the exact commands.
+
+**How would I know if I hit the Word32 trap?**
+The reference tools build clean and run without error — the tell is
+downstream: `synth_local.pcm` sounds wrong (harsh, clipped-then-not), and
+GopherTrunk "fails" conformance with enormous `maxAbsDiff` from frame 0.
+If a supposedly bit-exact port diverges immediately and hugely, audit the
+reference build before the port.
+
+**Does pass one cover the encoder too?**
+No — GopherTrunk only decodes (it's a receiver), so only `sdecoder`'s side is
+ported and pinned. The ETSI `scoder` is used solely to manufacture realistic
+serial files from PCM for the comparison.
+
+**What counts as passing pass two?**
+No single number — it's a correlation judgment made against the capture's own
+control channel: CRC-valid speech clustered on granted timeslots at granted
+times, yields far above the 1/256 floor, and per-usage-marker activity mapping
+one-to-one onto physical slots. The harness prints all of it; the operator's
+capture is the ground truth.
+
+**Is bit-exactness overkill when the output is lossy codec speech anyway?**
+It's the opposite of overkill — it's the cheapest strong claim available.
+Perceptual similarity requires listeners and thresholds; sample equality
+requires `==`. And only the exact form has the elimination power the
+diagnostic rule depends on: "close" leaves the vocoder a suspect forever.
+
+## Series navigation
+
+**Part 7 of 14** · ←
+[Part 6: A Clean-Room ACELP Vocoder in Pure Go]({{ '/blog/deep-dives/tetra-end-to-end-06-clean-room-acelp/' | relative_url }})
+· Next →
+[Part 8: Going Soft — Soft-Decision TCH/S]({{ '/blog/deep-dives/tetra-end-to-end-08-soft-decision-tchs/' | relative_url }})

--- a/docs/_posts/2026-08-24-weak-signal-engineering-07-trained-lms.md
+++ b/docs/_posts/2026-08-24-weak-signal-engineering-07-trained-lms.md
@@ -1,0 +1,322 @@
+---
+title: "Weak-Signal Engineering, Part 7: Trained Equalization — LMS on the Midamble"
+description: When the burst carries known symbols, stop guessing — how GopherTrunk trains a SnapshotLMS on each TETRA burst's midamble in the raw-symbol domain, freezes the taps, equalizes the payload with a FIR warm-up, and re-derives the soft LLRs, taking a synthetic multipath burst from 13% payload bit-error to zero while staying byte-identical when switched off.
+category: deep-dives
+keywords: lms equalizer, training sequence equalization, tetra midamble, snapshot lms, per-burst equalizer, raw symbol domain, wirtinger gradient conjugate, decision directed lms, gophertrunk weak-signal engineering
+tags: [weak-signal-engineering, lms, equalizer, tetra, dsp, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Weak-Signal Engineering"
+series_part: 7
+---
+
+*Part 7 of **Weak-Signal Engineering**, a 14-part deep dive into decoding the
+marginal regime, where a receiver locks but under-decodes.
+[Part 6]({{ '/blog/deep-dives/weak-signal-engineering-06-normalisation-guards/' | relative_url }})
+closed out the blind equalizer — cost, snapshot, references, guards — a lever
+that asks nothing of the signal but its envelope, and pays for that humility
+with spurious minima it cannot detect from inside. But most burst-mode radio
+protocols are not actually that coy: every TETRA normal burst carries a
+training sequence — a midamble of known symbols at a known position —
+broadcast in the clear, burst after burst. This part is about accepting the
+gift: train an equalizer on symbols you *know*, freeze it, and equalize the
+payload around them. It is also where Part 3's domain fact — the channel is
+only a convolution over raw symbols — stops being theory and starts dictating
+plumbing.*
+
+> **TL;DR:** **`SnapshotLMS`** (`internal/dsp/equalizer/snapshot_lms.go`) is
+> the trained counterpart to `SnapshotCMA`: adapt an
+> [LMS]({{ '/reference/lms-algorithm/' | relative_url }}) filter
+> (`w += μ·e·conj(x)`, `e = d − y`) on a burst's known **midamble**, freeze the
+> taps, apply them to the whole burst. Training kills blind CMA's ambiguity —
+> `e = d − y` is only zero at the *right* inverse, phase included. Because the
+> linear channel exists only in the **raw-symbol domain** (not in the
+> differential products), the TETRA `TrafficExtractor` carries raw symbols
+> down parallel to its dibits (`SymbolSink → StashSymbols`), trains on the
+> 11-dibit midamble against a reference built by differentially encoding the
+> ideal sequence **from a unit anchor**, equalizes BKN1..BKN2 with a taps-long
+> FIR **warm-up**, and **re-derives the soft LLRs** from equalized symbols —
+> hard frame untouched, byte-identical when off. Synthetic multipath:
+> payload bit-error **13% → 0%**, no harm on clean. Status honesty: a staged
+> lever — the capture A/B (`GT_TETRA_LMS=1`) is still pending, so production
+> composers run CMA only.
+
+**Key takeaways**
+
+- **Known symbols collapse the blind ambiguity.** CMA accepts any
+  constant-modulus output; LMS training accepts only the output that maps the
+  reference to itself. The 34%→8%-EVM-with-CRC-0 failure class is structurally
+  impossible against a good training sequence.
+- **The extractor trains, not the receiver — because only the extractor knows
+  where the midamble is.** Blind equalization lives in the framing-free
+  receiver stream; trained equalization needs burst geometry, so it lives
+  where bursts are found. Placement follows knowledge.
+- **Eleven dibits is a short teacher, so the lesson is repeated.** Five taps,
+  eighty passes over the midamble: sweeping a short reference many times is
+  how an LMS converges on so few known symbols.
+- **The result is real and the claim is scoped.** 13% → 0% is a synthetic,
+  failing-first regression through the real extractor; the on-air win is
+  unproven until an operator capture A/B says so. The lever is wired, opt-in,
+  and waiting — that's a status, not a victory lap.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| The LMS core | `e = d − y`; `w += μ·e·conj(x)` per sample | `internal/dsp/equalizer/lms.go` (`LMS.Process`) |
+| Train-then-freeze wrapper | `Train(rx, ref, passes)` → frozen `Equalize` | `internal/dsp/equalizer/snapshot_lms.go` (`SnapshotLMS`) |
+| Raw-symbol plumbing | symbols parallel to dibits, same `baseIdx` | `internal/radio/tetra/receiver/receiver.go` (`SymbolSink`) → `traffic.go` (`StashSymbols`) |
+| Per-burst orchestration | train on midamble, equalize span, re-derive LLRs | `internal/radio/tetra/traffic.go` (`equalizedBurstDiffs`, `softFrame`) |
+| The ideal reference | differentially encode NTS1/NTS2 from a unit anchor | `traffic.go` (`midambleRef`, `idealDiff`) |
+| Opt-in switch + defaults | 5 taps, 80 passes, μ = 0.02 | `traffic.go` (`EnableLMSEqualizer`, `defaultLMS*`) |
+| Failing-first regressions | 13%→0% payload bit-error; byte-identical off | `traffic_lms_test.go`, `snapshot_lms_test.go` |
+| DMO variant | rotation-0 DNBs only, different burst geometry | `internal/radio/tetra/dmo_equalizer.go` (`dmEqualizeDNBSoft`) |
+
+## In this post
+
+- **From blind to trained** — what a known reference buys.
+- **LMS, and the conjugate that almost got away** — the update rule's fine print.
+- **Where the trained equalizer must live** — receiver vs. extractor.
+- **One burst, start to finish** — reference, training, warm-up, re-derived LLRs.
+- **Results and honest status** — synthetic wins, pending air.
+
+## From blind to trained
+
+Part 4 ended with a sober admission: CMA's own diagnostics cannot distinguish
+the right channel inverse from a spurious constant-modulus impostor. The
+`SnapshotLMS` doc comment states the escape in one clause — training to a
+known reference "pins the true channel inverse (phase and all), not merely
+its modulus." The error `e = d − y` is zero *only* when the composite
+channel-plus-equalizer maps the known transmitted symbols back to themselves.
+No rotation ambiguity, no spurious minima worth the name, and convergence you
+can verify against ground truth per burst.
+
+The price is the information itself: you need known symbols at known
+positions, which means you need framing. TETRA obliges generously — the
+[training sequences]({{ '/reference/tetra-training-sequences/' | relative_url }})
+NTS1 and NTS2 sit mid-burst (a midamble, 11 dibits) in every normal downlink
+burst, and their whole reason for existing in the standard is exactly this:
+they are the part of the burst the receiver is *supposed* to already know.
+GopherTrunk's burst extractor was already correlating against them to find
+bursts at all; the trained equalizer just stops throwing away what the
+correlation proves it knows.
+
+## LMS, and the conjugate that almost got away
+
+The Least-Mean-Squares update is the oldest tool in the adaptive-filter
+drawer: FIR output `y = Σ w_k·x[n−k]`, error against the reference
+`e = d − y`, taps nudged along the gradient. `lms.go` carries the rule — and,
+in its comments, a war story that belongs in this series' trap collection:
+
+```go
+// internal/dsp/equalizer/lms.go (shape) — Process
+// Weight update: w_k += μ · e · conj(x[n-k]).
+//
+// For the non-Hermitian filter y = Σ_k w_k·x_k, Wirtinger calculus
+// gives ∂J/∂w_k* = −e·conj(x_k) with J = |d−y|², so steepest descent
+// is w_k += μ·e·conj(x_k). The conjugate is on x, NOT on e: the two
+// differ only in the sign of the imaginary cross-term, so a real-only
+// channel can't tell them apart — but on a COMPLEX channel the wrong
+// sign turns the update into ascent on the imaginary axis and the taps
+// diverge. (The earlier code computed x·conj(e), which is that wrong
+// sign; it survived only because the package tests used a real-valued
+// channel coefficient. See TestLMSConvergesOnComplexChannel.)
+```
+
+Savor that failure mode, because it is the self-consistent-synthetic trap in
+miniature: `x·conj(e)` and `e·conj(x)` agree exactly on any real-valued
+channel, so a test suite whose synthetic channels were all real passed
+forever while the update was, on any *complex* channel — i.e., any real one —
+gradient *ascent* in the imaginary direction. The fix came with a
+failing-first test whose channel coefficient is complex, and the lesson
+generalises: test inputs must span the dimensions your math can be wrong in.
+`SnapshotLMS` wraps this corrected core in the Part 5 pattern — `Train` runs
+`adapt.Process(rx[i], ref[i])` over the aligned pairs (repeating `passes`
+times), then `copy(e.apply, e.adapt.Taps())` freezes the result; `Equalize`
+is a plain frozen FIR. A held-constant filter imposes only a constant
+phase/scale, which the downstream differential cancels — the same safety
+argument as `SnapshotCMA`, with the snapshot window now exactly one burst.
+
+## Where the trained equalizer must live
+
+Here the two Part 3 threads braid together. The **blind** equalizer sits in
+the *receiver* — a continuous, framing-free stream is precisely where a
+reference-free algorithm belongs, and the receiver has no idea where bursts
+are. The **trained** equalizer inverts that logic: training requires knowing
+where the midamble sits, and the only component that knows is the
+`TrafficExtractor`, downstream of the dibit stream, *after* the nonlinear
+differential decode. But Part 3 proved the channel is only a convolution over
+**raw symbols** — equalizing differentials is algebra that doesn't exist.
+
+So the raw symbols have to travel. The receiver grew a `SymbolSink` — the
+symbol analog of the soft path's `SoftSink` — emitting the post-timing/AFC
+complex symbols aligned 1:1 with the dibits, same `baseIdx`; the extractor
+grew `StashSymbols` and a `symBuf` carried parallel to its dibit and soft
+buffers. (That three-buffer architecture — dibits, differentials, raw
+symbols, all index-aligned — is Part 9's subject in its own right.) The
+placement rule deserves its one-line form: **blind in the receiver, trained
+in the extractor — each equalizer lives where its information lives.**
+
+## One burst, start to finish
+
+`softFrame` — the function that builds each burst's 432-LLR soft frame —
+now tries the trained path first and falls back cleanly:
+
+```go
+// internal/radio/tetra/traffic.go (shape) — softFrame
+diffs := te.equalizedBurstDiffs(L)   // nil unless LMS enabled + symbols buffered
+if diffs == nil {
+    diffs = te.rawBurstDiffs(L)      // the pre-#1001 soft path, untouched
+}
+llr := softType5FromDiffs(diffs, 0)
+```
+
+Inside `equalizedBurstDiffs`, one burst's worth of work, in order. **Build
+the reference**: `midambleRef` picks NTS1 or NTS2 (whichever the received
+dibits match more closely), then differentially encodes the ideal dibits from
+a **unit anchor** — `out[0] = 1`, each next symbol the previous times the
+ideal differential. The anchor phase is arbitrary, and that's the point: a
+constant rotation cancels in the differential decode — the same invariance
+that makes frozen snapshots safe now makes the reference constructible
+without knowing the burst's absolute phase. **Train**: five taps swept eighty
+passes over the 11-symbol midamble (`defaultLMSTaps`, `defaultLMSPasses`) —
+a short teacher, repeated until the estimate converges — then freeze.
+**Equalize with a warm-up**: the span starts `taps` symbols *before* BKN1's
+differential anchor, so the FIR's delay line is full — past its transient —
+before the first payload symbol anyone will use:
+
+```go
+// internal/radio/tetra/traffic.go (shape) — equalizedBurstDiffs
+warm := te.lmsTaps
+spanStart := L + ndbBKN1Start - 1 - warm // one before BKN1 start, minus FIR warm-up
+te.lms.Reset()
+te.lms.Train(rx, ref, te.lmsPasses)
+span := te.lms.Equalize(te.lmsSpan[:0], te.symBuf[s0:s1])
+// diff for burst dibit m: span[i]·conj(span[i-1]), i = m - spanStart
+```
+
+**Re-derive, don't patch**: the 216 differentials for BKN1 and BKN2 are
+recomputed from *equalized* symbols and flow into the same
+`softType5FromDiffs` → descramble → soft depuncture → Viterbi chain as
+before. The hard frame never changes. If any precondition fails — equalizer
+off, no symbols stashed, span not fully buffered — the function returns nil
+and the burst decodes exactly as it would have in the previous release,
+pinned by `TestTrafficExtractorSoftUnchangedWithoutEqualizer`.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 210" width="680" height="210" role="img" aria-label="A TETRA normal burst laid out as blocks: payload block BKN1, the known eleven-dibit midamble in the centre, payload block BKN2. The trained equalizer flow is drawn around it: an arrow from the midamble down to a train box, LMS five taps eighty passes against the ideal reference built from a unit anchor; then freeze; then a frozen-taps arrow applying across a span that begins a warm-up region before BKN1 and runs through the end of BKN2; the output is re-derived differentials feeding the soft decoder.">
+  <rect x="30" y="40" width="90" height="34" rx="4" fill="none" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <text x="75" y="61" text-anchor="middle" fill="var(--fg-muted)" font-size="9">warm-up (taps)</text>
+  <rect x="120" y="40" width="180" height="34" rx="4" fill="none" stroke="currentColor"/>
+  <text x="210" y="61" text-anchor="middle" fill="currentColor" font-size="10">BKN1 — 108 dibits</text>
+  <rect x="300" y="40" width="80" height="34" rx="4" fill="none" stroke="var(--accent)"/>
+  <text x="340" y="55" text-anchor="middle" fill="var(--accent)" font-size="9">midamble</text>
+  <text x="340" y="68" text-anchor="middle" fill="var(--accent)" font-size="9">NTS1/2 · known</text>
+  <rect x="380" y="40" width="180" height="34" rx="4" fill="none" stroke="currentColor"/>
+  <text x="470" y="61" text-anchor="middle" fill="currentColor" font-size="10">BKN2 — 108 dibits</text>
+  <line x1="340" y1="74" x2="340" y2="108" stroke="var(--accent)"/><polygon points="336,108 340,118 344,108" fill="var(--accent)"/>
+  <rect x="240" y="118" width="200" height="36" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="340" y="133" text-anchor="middle" fill="var(--accent)" font-size="10">Train: LMS, 5 taps × 80 passes</text>
+  <text x="340" y="147" text-anchor="middle" fill="var(--fg-muted)" font-size="9">vs ideal ref from unit anchor</text>
+  <line x1="240" y1="136" x2="150" y2="136" stroke="currentColor"/><polygon points="150,132 140,136 150,140" fill="currentColor"/>
+  <rect x="40" y="118" width="100" height="36" rx="6" fill="none" stroke="currentColor"/>
+  <text x="90" y="133" text-anchor="middle" fill="currentColor" font-size="10">freeze taps</text>
+  <text x="90" y="147" text-anchor="middle" fill="var(--fg-muted)" font-size="9">one burst, one filter</text>
+  <path d="M90,118 C90,96 110,88 130,88 L555,88" fill="none" stroke="currentColor" stroke-dasharray="5 3"/>
+  <polygon points="555,84 565,88 555,92" fill="currentColor"/>
+  <text x="330" y="102" text-anchor="middle" fill="var(--fg-muted)" font-size="9">apply frozen FIR across warm-up + BKN1 + midamble + BKN2</text>
+  <line x1="565" y1="88" x2="600" y2="88" stroke="currentColor"/>
+  <text x="620" y="80" text-anchor="middle" fill="var(--fg-muted)" font-size="9">re-derived</text>
+  <text x="620" y="92" text-anchor="middle" fill="var(--fg-muted)" font-size="9">216 diffs</text>
+  <text x="620" y="104" text-anchor="middle" fill="var(--fg-muted)" font-size="9">→ soft decode</text>
+  <text x="340" y="192" text-anchor="middle" fill="var(--fg-muted)" font-size="10">train on what you know, freeze, equalize what you don't — the hard frame is never touched</text>
+</svg>
+<figcaption>Per burst: train a short LMS on the known midamble against a unit-anchored ideal reference, freeze the taps, equalize the whole burst with a taps-long warm-up, and re-derive the payload's soft differentials from equalized symbols.</figcaption>
+</figure>
+
+## Results — and honest status
+
+The synthetic verdict is clean and failing-first.
+`TestTrafficExtractorLMSRecoversMultipathBurst` pushes modulated bursts
+through a multipath channel and the *real* extractor: raw soft path **13%
+payload bit-error**, LMS path **0%** — and the no-harm and byte-identical-off
+companions hold (`TestTrafficExtractorLMSNoHarmOnCleanChannel`,
+`TestTrafficExtractorSoftUnchangedWithoutEqualizer`). At the package level,
+`TestSnapshotLMSBeatsBlindCMAOnBurst` pins the comparative claim: on a single
+burst-length reference, training beats blind — CMA simply cannot pin a
+channel from 11 symbols of nothing-but-envelope.
+
+The same lever is wired into TETRA's direct mode with two DMO-specific twists
+(`dmo_equalizer.go`): the DNB burst geometry differs, and it equalizes
+**rotation-0 bursts only** — a frozen constant-tap filter cannot invert the
+per-symbol phase *ramp* of a residual rotation, and at rotation 0 the soft
+decoder's de-rotation is a no-op, so the rotation-0-trained differentials
+slot straight in.
+
+And now the scoping, stated the way this project's
+[issue-closing discipline](https://github.com/MattCheramie/GopherTrunk/issues/764)
+demands. This is a **staged lever, not a verified win**: the production voice
+composer still runs blind CMA only, and `SnapshotLMS` in the traffic path is
+opt-in (`EnableLMSEqualizer` + `StashSymbols`), flipped on in the replay
+harness by `GT_TETRA_LMS=1` for capture A/Bs that compare soft CRC yield. On
+the first DMO capture it was tried against, it did not move the number (35 →
+32 CRC-valid — that capture's ceiling was elsewhere). A green synthetic
+through the real extractor is necessary evidence, not sufficient; the lever
+graduates when an operator capture shows the yield delta, and not before.
+
+## Where this goes next
+
+Twice now, the equalizers have ended their work by "re-deriving the soft
+LLRs" — and the phrase has gone unexamined. It's time. [Part 8]({{ '/blog/deep-dives/weak-signal-engineering-08-soft-decisions/' | relative_url }})
+descends into soft decisions themselves: what a log-likelihood ratio carries
+that a hard bit throws away, how LLRs survive descrambling, deinterleaving,
+and depuncturing to reach a soft Viterbi (`DecodeRCPCTetraMotherSoft`), the
+classic ~2 dB framing and the measured TETRA outcome — the ~70% of a marginal
+call's bursts that hard decisions failed and soft ones recovered.
+
+## FAQ
+
+**Why five taps for the trained equalizer when the blind one uses eleven?**
+The teacher is short. Eleven midamble symbols have to pin every tap; more
+taps on so few reference symbols under-determine the estimate and overfit
+noise, and the eighty passes already work the reference hard. The blind CMA,
+adapting over an unbounded stream, can afford the longer filter. Channel span
+you can model is bounded by reference you can train on.
+
+**Doesn't re-running Train per burst throw away what the last burst learned?**
+`te.lms.Reset()` per burst is deliberate: consecutive bursts on a moving
+channel (or from different transmitters — this is trunked radio) need not
+share an inverse, and a stale estimate is a confident wrong one, the same
+argument as Part 5's `Reset`-on-resync. The cost is re-convergence from
+center-spike each burst — which the 80 passes over the midamble pay for.
+
+**Why does the reference need an anchor symbol at all?**
+The midamble is *defined* as dibits — phase differences. To train in the
+raw-symbol domain you must integrate the differences into symbols, and
+integration needs a starting value. Any unit-modulus start works because the
+resulting constant rotation of the whole reference cancels in the downstream
+differential — the same invariance Part 5 leaned on, now used constructively.
+
+**Could the trained equalizer replace the blind one?**
+No — they cover different ground. `SnapshotCMA` improves the *receiver's*
+stream before any framing exists (it's part of why bursts are found at all on
+marginal captures); `SnapshotLMS` refines *found* bursts. The staged design
+runs both: blind in the receiver, trained per burst on top, each measured
+separately — which is exactly how the DMO A/B could report "CMA lifted DSB
+6→64; LMS didn't move TCH" on the same capture.
+
+**What would make the LMS lever graduate to on-by-default?**
+The same thing that graduated the CMA: an operator capture A/B where the only
+variable is the lever and the CRC yield moves. The harness exists
+(`GT_TETRA_LMS=1` in the multislot replay test, comparing
+`traffic_marked_crc_soft`), the fallback is byte-identical, and the synthetic
+regression guards the mechanism. What's missing is the capture where linear
+per-burst ISI is the binding constraint — Part 12 is, in part, about how to
+recognise one.
+
+## Series navigation
+
+**Part 7 of 14** · ←
+[Part 6: Normalisation & Divergence Guards]({{ '/blog/deep-dives/weak-signal-engineering-06-normalisation-guards/' | relative_url }})
+· Next →
+[Part 8: Soft Decisions — LLRs Through Depuncture & Viterbi]({{ '/blog/deep-dives/weak-signal-engineering-08-soft-decisions/' | relative_url }})

--- a/docs/_posts/2026-08-25-analog-edge-08-feedline-connectors.md
+++ b/docs/_posts/2026-08-25-analog-edge-08-feedline-connectors.md
@@ -1,0 +1,255 @@
+---
+title: "The Analog Edge, Part 8: Feedline & Connectors — Where dB Go to Die"
+description: Why the coax between your antenna and your SDR quietly costs more decode margin than any software setting — published loss figures per cable class at 800 MHz, the real price of every adapter, and why receive-side loss is worse than the half-your-power framing suggests.
+category: tutorials
+keywords: coax loss 800 mhz, rg-58 vs lmr-400, sdr feedline loss, coax cable for scanner antenna, sma bnc n connector, adapter loss, receive noise figure, feedline noise figure, gophertrunk analog edge
+tags: [analog-edge, coax, feedline, connectors, rf, hardware]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "The Analog Edge"
+series_part: 8
+---
+
+*Part 8 of **The Analog Edge**, a 14-part field guide to the analog half of a
+GopherTrunk system — the part no software update can fix.
+[Part 7]({{ '/blog/tutorials/analog-edge-07-antennas/' | relative_url }}) put a
+proper antenna on the mast and made the case that height beats gain — up to a
+point. This part is that point. Our running reader — hardware scanner clean,
+GopherTrunk garbled, on the same antenna — has forty feet of thin coax between
+that antenna and the dongle, and this part is about what those forty feet cost.
+The decoder can only be as good as the samples, and the samples can only be as
+good as what survives the feedline.*
+
+> **TL;DR:** Coax loss is frequency-dependent, cable-class-dependent, and — on
+> receive — **worse than it looks**, because every dB of loss *ahead of the
+> first amplifier* adds directly to the system's
+> [noise figure]({{ '/reference/noise-figure/' | relative_url }}). At 800/900 MHz,
+> RG-58 runs roughly **16 dB per 100 ft** while LMR-400 runs about **4 dB** —
+> a 40 ft run is the difference between ~6.5 dB and ~1.6 dB gone before the
+> tuner sees anything. Every adapter in the chain is another ~0.1–0.3 dB tax.
+> None of this shows up in any GopherTrunk log line, because by the time the
+> software runs, the dB are already dead.
+
+**Key takeaways**
+
+- **Receive loss is noise-figure loss, not just power loss.** "3 dB is half your
+  power" undersells it: 3 dB of coax before any amplification means every weak
+  signal arrives 3 dB closer to the noise floor, permanently.
+- **Cable class dominates everything else in the feedline.** The spread between
+  a thin pigtail and LMR-400 at 850 MHz is nearly a factor of eight in dB per
+  foot — no connector choice or careful routing recovers that.
+- **Adapters are a small tax paid per joint, forever.** A barrel, a
+  gender-changer, and an SMA-to-BNC stack is easily half a dB — and a stack of
+  adapters is also a stack of failure points that intermittent faults hide in.
+- **You cannot see feedline loss in software.** A lossy run just looks like a
+  weaker band. The fix for "everything is 6 dB down" is never in `config.yaml` —
+  which is exactly why this series exists.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| Cable loss classes | dB/100 ft by cable family, rises with frequency | table below; [coaxial cable]({{ '/reference/coaxial-cable/' | relative_url }}) |
+| Receive-side rule | pre-LNA loss adds dB-for-dB to system NF | [noise figure]({{ '/reference/noise-figure/' | relative_url }}) (Friis) |
+| Connector families | SMA / BNC / N / F / UHF ecosystems | [SMA]({{ '/reference/sma-connector/' | relative_url }}), [N-type]({{ '/reference/n-type-connector/' | relative_url }}), [PL-259]({{ '/reference/uhf-connector-pl259/' | relative_url }}) |
+| Adapter strategy | fewest joints; one good pigtail beats a stack | [SMA adapter kit]({{ '/reference/sma-adapter-kit/' | relative_url }}) |
+| Buying guidance | which coax and connectors for a GopherTrunk rig | [SDR cables & connectors guide]({{ '/sdr-cables-and-connectors/' | relative_url }}) |
+| The next lever | when to amplify instead of just losing less | Part 9 ([LNA]({{ '/reference/low-noise-amplifier/' | relative_url }})) |
+
+## In this post
+
+- **The receive-side rule** — why 3 dB of coax is worse than half your power.
+- **The cable classes** — published loss figures at trunking frequencies.
+- **Connectors and adapters** — the families, and the per-joint tax.
+- **Impedance, 50 Ω and 75 Ω** — what RG-6 does and doesn't cost you.
+- **A worked budget** — our reader's forty-foot run, in numbers.
+
+## The receive-side rule
+
+The framing everyone learns first is transmit-side: *3 dB of coax loss means
+half your power reaches the antenna.* True, and on receive it sounds almost
+tolerable — signals are tens of dB above the floor, what's 3 dB?
+
+The receive-side truth is harsher. Loss placed **before the first
+amplification stage** doesn't just shrink the signal; it raises the whole
+system's [noise figure]({{ '/reference/noise-figure/' | relative_url }})
+dB-for-dB. A passive 6 dB attenuation ahead of the tuner is mathematically a
+6 dB noise figure sitting in front of whatever noise figure the tuner already
+had — the Friis cascade formula says the first stage dominates, and a lossy
+cable is a first stage with gain of *minus* six. Every weak signal on the band
+arrives 6 dB closer to the noise floor, and no gain knob downstream can undo
+it: turning up the tuner amplifies the noise floor and the signal together.
+
+This is why the series keeps insisting the fix is not in software.
+[Part 3]({{ '/blog/tutorials/analog-edge-03-gain-staging/' | relative_url }})
+showed an operator raising gain 65 → 82 dB to chase a software constant;
+feedline loss is the physical version of the same trap — the dB you lose here
+are gone before any number GopherTrunk can display is even measured. A
+marginal TETRA control channel that decodes at 18 dB in-channel SNR and drops
+lock at 10 dB (the split we measured in the sync-loss captures) lives or dies
+inside exactly the margin a bad feedline eats.
+
+## The cable classes
+
+Loss per length rises with frequency, and trunking bands sit at the expensive
+end — 700/800/900 MHz costs roughly three times what VHF does on the same
+cable. The table uses typical published manufacturer figures at ~900 MHz,
+rounded; treat them as planning numbers, not datasheet gospel (actual loss
+varies by make and by how the cable has been treated).
+
+| Cable | Loss / 100 ft @ ~900 MHz | Loss / 100 ft @ ~150 MHz | Verdict for a trunking feed |
+|---|---|---|---|
+| RG-174 / RG-316 (thin pigtail) | ~30 dB | ~10 dB | inches only — a pigtail, never a run |
+| RG-58 | ~16 dB | ~6 dB | desk patch leads only |
+| RG-8X | ~11 dB | ~4.5 dB | short runs, portable rigs |
+| RG-6 (75 Ω TV coax) | ~6 dB | ~2.7 dB | surprisingly good — see below |
+| LMR-240 | ~8 dB | ~3 dB | good mid-weight choice |
+| LMR-400 | ~4 dB | ~1.5 dB | the default for a mast run |
+| LMR-600 | ~2.5 dB | ~1 dB | long runs, heavy and stiff |
+
+Two readings of that table matter. First, the **spread**: at 850 MHz, the same
+forty feet costs ~6.5 dB in RG-58 and ~1.6 dB in LMR-400. That 5 dB delta is
+larger than most antenna upgrades buy you, at a fraction of the price of a
+better SDR. Second, the **pigtail row**: RG-174 and RG-316 exist to make the
+last few inches to an SMA jack flexible, and they are fine at that length —
+but a 3 ft RG-174 "extension" at 850 MHz is already about a dB, which is why
+the [cables guide]({{ '/sdr-cables-and-connectors/' | relative_url }}) keeps
+repeating *pigtails are measured in inches*.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 210" width="680" height="210" role="img" aria-label="Cumulative feedline loss versus run length at 850 megahertz for two cable classes: RG-58 loses about 16 decibels per hundred feet, crossing 6 decibels around forty feet, while LMR-400 loses about 4 decibels per hundred feet and stays under 2 decibels at the same length; the gap between the two lines at forty feet is about 5 decibels of decode margin">
+  <line x1="55" y1="20" x2="55" y2="165" stroke="var(--fg-muted)"/>
+  <line x1="55" y1="165" x2="650" y2="165" stroke="var(--fg-muted)"/>
+  <text x="14" y="30" fill="var(--fg-muted)" font-size="9">loss</text>
+  <text x="14" y="42" fill="var(--fg-muted)" font-size="9">(dB)</text>
+  <text x="600" y="183" fill="var(--fg-muted)" font-size="9">run (ft)</text>
+  <text x="46" y="169" fill="var(--fg-muted)" font-size="9">0</text>
+  <text x="285" y="181" fill="var(--fg-muted)" font-size="9">40</text>
+  <text x="520" y="181" fill="var(--fg-muted)" font-size="9">80</text>
+  <line x1="292" y1="20" x2="292" y2="165" stroke="var(--fg-muted)" stroke-dasharray="3,4"/>
+  <polyline points="55,165 173,127 292,88 411,50 530,24" fill="none" stroke="currentColor"/>
+  <text x="440" y="38" fill="currentColor" font-size="10">RG-58 (~16 dB/100 ft)</text>
+  <polyline points="55,165 173,155 292,146 411,136 530,127 650,117" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <text x="470" y="112" fill="var(--accent)" font-size="10">LMR-400 (~4 dB/100 ft)</text>
+  <line x1="292" y1="88" x2="292" y2="146" stroke="var(--accent)"/>
+  <text x="300" y="122" fill="var(--accent)" font-size="10">~5 dB at 40 ft</text>
+  <text x="352" y="200" text-anchor="middle" fill="var(--fg-muted)" font-size="10">the gap is decode margin lost before any software runs — no gain setting downstream recovers it</text>
+</svg>
+<figcaption>Cumulative loss at ~850 MHz for a forty-to-eighty-foot mast run: cable class alone swings the budget by ~5 dB — more than most antenna upgrades.</figcaption>
+</figure>
+
+## Connectors and adapters
+
+Connector families are ecosystems, and the practical goal is to live in as few
+of them as possible:
+
+| Family | Where you meet it | At 800 MHz |
+|---|---|---|
+| [SMA]({{ '/reference/sma-connector/' | relative_url }}) | nearly every SDR (RTL-SDR, Airspy, HackRF) | excellent; small, torque-sensitive |
+| BNC | scanners, lab gear, older antennas | fine; quick-connect, less weatherproof |
+| [N-type]({{ '/reference/n-type-connector/' | relative_url }}) | base antennas, LMR-400 terminations, LNAs | excellent; the outdoor standard |
+| F | TV / RG-6 ecosystem | fine electrically; 75 Ω world |
+| [UHF / PL-259]({{ '/reference/uhf-connector-pl259/' | relative_url }}) | ham gear, CB-era antennas | avoid — non-constant impedance, worst of the lot up here |
+
+Each mated pair — every adapter, barrel, and gender-changer — costs roughly
+0.1–0.3 dB at UHF as a rule of thumb. One adapter is nothing. The failure mode
+is the *stack*: antenna (N) → N-to-UHF barrel → PL-259 jumper → SO-239-to-BNC
+→ BNC-to-SMA → dongle is five joints, plausibly over half a dB, and — worse
+than the loss — five places for a cold joint or loose coupling to produce the
+intermittent, weather-correlated flakiness that gets misfiled as a software
+bug. The discipline: terminate the run in the connector your radio actually
+wears, keep one good [adapter kit]({{ '/reference/sma-adapter-kit/' | relative_url }})
+for experiments, and solve any permanent mismatch with a purpose-made pigtail
+rather than a chain.
+
+## Impedance: the 75 Ω question
+
+RG-6 sits oddly in the table: it's 75 Ω TV coax, our gear is 50 Ω, and it
+still often wins. The mismatch between 75 and 50 Ω costs a fixed ~0.18 dB of
+reflection loss on receive — noise, essentially, next to the *per-foot* loss
+difference it buys back: RG-6 at ~6 dB/100 ft beats RG-58's ~16 by a wide
+margin, it's cheap everywhere, and quad-shield versions are well shielded. For
+a receive-only GopherTrunk feed, a long RG-6 run with an F-to-SMA pigtail at
+the radio end is a legitimate budget build; the
+[cables guide]({{ '/sdr-cables-and-connectors/' | relative_url }}) covers the
+parts. (Transmitting is a different story — this series is receive-only.)
+
+## A worked budget: the forty-foot run
+
+Back to our reader. The [Part 7]({{ '/blog/tutorials/analog-edge-07-antennas/' | relative_url }})
+antenna went up on the mast, and the hardware scanner — connected through
+twenty feet of the same old RG-58 — got cleaner. GopherTrunk, at the end of
+**forty** feet of RG-58 plus a three-adapter stack, barely moved. The budget
+explains it:
+
+| Segment | Loss @ ~850 MHz |
+|---|---|
+| 40 ft RG-58 | ~6.5 dB |
+| 3 adapters (N→BNC→SMA stack) | ~0.5 dB |
+| 3 ft RG-174 pigtail at the desk | ~1 dB |
+| **Total, before the tuner** | **~8 dB** |
+
+Eight dB of noise figure before the first transistor. Replacing the run with
+LMR-400 (~1.6 dB), terminating it in a single N-to-SMA pigtail (~0.3 dB with
+one joint), and retiring the desk pigtail brings the same path to ~2 dB — a
+**6 dB** improvement, which in [Part 2]({{ '/blog/tutorials/analog-edge-02-dbfs/' | relative_url }})'s
+terms moves a marginal channel from "drops lock under load" to "decodes."
+That's the entire gap between the 10 dB and 18 dB in-channel SNR regimes we
+measured on real TETRA sync-loss captures, bought with a spool of cable. No
+config key was harmed.
+
+## Where this goes next
+
+Losing less is the first lever; the second is *adding gain in the right
+place*. [Part 9]({{ '/blog/tutorials/analog-edge-09-filters-lnas/' | relative_url }})
+covers filters and LNAs — why an amplifier helps only when it sits *before*
+the loss, why the same LNA that rescues a quiet site wrecks a hot one, and the
+order-of-operations rules that keep Part 4's intermod problems from coming
+back with 20 dB more gain behind them.
+
+## FAQ
+
+**My run is only ten feet. Does any of this matter?**
+Less, but not zero: 10 ft of RG-58 at 850 MHz is ~1.6 dB plus your adapters.
+If your system decodes cleanly, spend nothing. If you're marginal — and this
+series' reader is — 2 dB is real margin, and the pigtail-stack audit is free.
+
+**Can GopherTrunk detect feedline loss?**
+No, and nothing can from the software side — a lossy feedline is
+indistinguishable from a quieter band. What you *can* do is compare: the same
+antenna through a short known-good jumper versus through your installed run,
+watching per-channel SNR or decode quality
+([the gain-sweep method]({{ '/blog/deep-dives/the-hunt-05-autogain-autotune/' | relative_url }})).
+A constant offset between the two is your feedline, in dB.
+
+**Is "low-loss" coax ever a bad idea?**
+Only practically: LMR-400 is stiff, heavy, and hates tight bends, so it's
+wrong for the last flexible half-meter to the radio. The standard pattern is a
+low-loss trunk run terminated in N, then a short flexible pigtail (RG-316,
+inches) to SMA. One joint, best of both.
+
+**Why is PL-259 singled out?**
+The UHF connector predates the idea of constant impedance — through the
+connector body the line isn't 50 Ω, which matters little at HF/VHF and
+increasingly at 800 MHz. It's also not weatherproof by design. On a trunking
+feed there is always a better choice (N outdoors, SMA at the radio).
+
+**Should I trust the printed loss figures on cheap cable?**
+Trust the class, verify the sample: no-name "RG-58" varies widely, and a
+damaged or ancient run can be far worse than any table. The A/B in the second
+FAQ answers what *your* cable does, which is the only number that matters —
+tables are for choosing what to buy, measurements are for judging what you have.
+
+**Does weather really change coax loss?**
+Water does. Coax that has wicked moisture through an unsealed outdoor joint
+can double its loss and never recover — foam-dielectric cables are especially
+vulnerable. Seal outdoor connectors (self-amalgamating tape), drip-loop the
+run, and treat a system that got worse after a storm as a feedline suspect
+first ([mounting guide]({{ '/antenna-mast-and-mounting-guide/' | relative_url }})).
+
+## Series navigation
+
+**Part 8 of 14** · ←
+[Part 7: Antennas for Trunking Bands]({{ '/blog/tutorials/analog-edge-07-antennas/' | relative_url }})
+· Next →
+[Part 9: Filters & LNAs — Adding Gain Without Adding Garbage]({{ '/blog/tutorials/analog-edge-09-filters-lnas/' | relative_url }})

--- a/docs/_posts/2026-08-25-tetra-end-to-end-08-soft-decision-tchs.md
+++ b/docs/_posts/2026-08-25-tetra-end-to-end-08-soft-decision-tchs.md
@@ -1,0 +1,324 @@
+---
+title: "TETRA End to End, Part 8: Going Soft — Soft-Decision TCH/S"
+description: Why hard-decision decoding threw away roughly seventy percent of a marginal same-carrier TETRA call's traffic bursts, and how the soft path — receiver differentials carried in lockstep through the traffic extractor into a soft Viterbi — recovers them without touching the hard contract.
+category: deep-dives
+keywords: tetra soft decision, tch/s soft decode, llr viterbi decoding, soft depuncture rcpc, pi/4-dqpsk soft information, softsink differentials, tetra traffic extractor, soft decision coding gain, gophertrunk tetra
+tags: [tetra-end-to-end, tetra, soft-decision, viterbi, dsp, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "TETRA End to End"
+series_part: 8
+---
+
+*Part 8 of **TETRA End to End**, a 14-part deep dive into how GopherTrunk turns
+one real 25 kHz TETRA carrier into clear recorded voice.
+[Part 7]({{ '/blog/deep-dives/tetra-end-to-end-07-etsi-conformance/' | relative_url }})
+closed the conformance loop — bit-identical PCM against the ETSI reference codec,
+twice over — so the vocoder and the channel coding are proven. And yet a marginal
+same-carrier call still came out short and garbled. The chain was correct; it was
+also throwing away information at the very first decision it made. This part is
+about keeping that information: the soft-decision TCH/S path, which carries the
+demodulator's *confidence* all the way into the Viterbi decoder instead of
+flattening it into bits at the slicer.*
+
+> **TL;DR:** Hard-decision TCH/S decoding failed **~70%** of a marginal
+> same-carrier call's bursts — every slicer decision discarded how *sure* the
+> demod was. The soft path keeps that confidence: the receiver's **`SoftSink`**
+> emits the complex π/4-DQPSK differential `s·conj(prev)` per symbol, the
+> **`TrafficExtractor`** carries it in strict lockstep with the dibits
+> (**`StashSoft`**, `softBuf`), `softType5FromDiffs` turns each differential into
+> two per-bit LLRs, `framing.DescrambleTetraSoft` applies the colour-code sign
+> flips, and **`tetra.DecodeTCHSSoft`** runs soft depuncture + soft Viterbi
+> (`framing.DecodeRCPCTetraMotherSoft`) to the same class-2 CRC gate. The
+> composer tries soft first and falls back to the hard `TCHSpeechFrames` when no
+> soft info was stashed — the hard path is byte-identical to before.
+
+**Key takeaways**
+
+- **A hard slicer is an information shredder.** The differential's angle says
+  *which* dibit; its magnitude and distance from the decision boundary say *how
+  confident*. Hard decision keeps the first and burns the second — exactly the
+  part a Viterbi decoder can spend.
+- **The soft information is the differential itself.** For π/4-DQPSK the two
+  on-air bits' LLRs are the imaginary and real parts of `s·conj(prev)` — no
+  separate estimator, the demod already computed it.
+- **Lockstep or nothing.** `softBuf` is either exactly parallel to the dibit
+  buffer or empty; on any misalignment the extractor drops the soft path for
+  that burst rather than decode with shifted LLRs. Misaligned soft data is worse
+  than none.
+- **The CRC is still the gate.** `TCHSpeechFramesSoft` returns nil on a class-2
+  CRC failure exactly like the hard gate — soft decision recovers more real
+  bursts; it never admits fake ones.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| Soft emission | per-symbol complex differential, 1:1 with dibits | `internal/radio/tetra/receiver/receiver.go` (`Options.SoftSink`) |
+| Soft carry | stash differentials for the next `Process` call | `internal/radio/tetra/traffic.go` (`TrafficExtractor.StashSoft`) |
+| Lockstep buffer | `softBuf` strictly parallel to `buf`, or empty | `internal/radio/tetra/traffic.go` (`Process`, `softFrame`) |
+| Diff → LLR | rotation-aware differential to per-bit LLRs | `internal/radio/tetra/process.go` (`softType5FromDiffs`) |
+| Soft descramble | colour-code sign flips in the LLR domain | `internal/radio/framing/soft_tetra.go` (`DescrambleTetraSoft`) |
+| Soft TCH/S decode | soft deinterleave → depuncture → Viterbi → CRC | `internal/radio/tetra/tch.go` (`DecodeTCHSSoft`) |
+| Composer fallback | soft first, hard `TCHSpeechFrames` otherwise | `internal/voice/composer/tetra_voice.go` (`decodeTETRASpeech`) |
+| Soft AACH rescue | soft RM(30,14) recovers a marginal usage marker | `internal/radio/tetra/traffic.go` (`usageOfSoft`) |
+
+## In this post
+
+- **What hard decision costs** — the ~70% figure and where it comes from.
+- **The differential is the soft information** — LLRs for free from the demod.
+- **Carrying LLRs in lockstep** — the stash bridge and its alignment contract.
+- **The soft decode chain, step for step** — `DecodeTCHSSoft` mirrors the hard chain.
+- **Fallback, CRC gates, and the AACH bonus** — where soft helps beyond speech.
+
+## What hard decision costs
+
+[Part 5]({{ '/blog/deep-dives/tetra-end-to-end-05-tchs-traffic-channel/' | relative_url }})
+built the hard-decision TCH/S path: slice each burst's BKN1+BKN2, descramble,
+deinterleave, depuncture, Viterbi, check the class-2 CRC. On a clean carrier it
+works. On a *marginal* same-carrier call — the voice riding the same 25 kHz
+carrier as the control channel, at the edge of the receiver's budget — it failed
+roughly **70% of the call's bursts**, and the recordings came out short and
+garbled. The vocoder was fine; Part 7 proved that. The bursts were real; the
+training-sequence correlator found them. The losses happened inside the FEC.
+
+The reason is the first decision the pipeline makes. The demodulator produces a
+complex differential per symbol, and the slicer quantizes it to one of four
+dibits. A symbol sitting dead-center in its decision region and a symbol
+grazing the boundary produce the *same* dibit — the slicer reports the verdict
+and destroys the confidence. A convolutional decoder is precisely the machine
+that can spend that confidence: a Viterbi search weighing each received bit by
+its reliability will happily overrule two shaky bits on the strength of twelve
+solid ones. Feeding it hard bits forces every bit to count equally, and the
+textbook cost of that is about **2 dB** of coding gain — which, at the margin
+this call lived at, is the difference between 30% yield and a usable recording.
+The general theory — LLRs, why the gain concentrates exactly at the margin —
+lives in
+[Weak-Signal Engineering Part 8]({{ '/blog/deep-dives/weak-signal-engineering-08-soft-decisions/' | relative_url }});
+this post is the TETRA case that motivated it.
+
+## The differential is the soft information
+
+The elegant part of doing this for π/4-DQPSK is that the soft information costs
+nothing to produce. The demod already forms `s·conj(prev)` for every symbol —
+that *is* the differential decode from
+[Part 1]({{ '/blog/deep-dives/tetra-end-to-end-01-pi4-dqpsk-carrier/' | relative_url }}).
+And in that complex number, the two on-air bits' log-likelihood ratios are
+simply the imaginary and real components. The receiver exposes it behind one
+optional callback:
+
+```go
+// internal/radio/tetra/receiver/receiver.go (shape) — Options
+// SoftSink, when non-nil, receives the complex π/4-DQPSK differential
+// (s·conj(last)) for each symbol, aligned 1:1 with the dibits emitted
+// to DibitSink and carrying the same baseIdx. It is the soft
+// information for soft-decision channel decoding (the two on-air bits'
+// LLRs are Im and Re of the differential). Emitted just before the
+// matching DibitSink call. nil ⇒ no soft emission, zero overhead.
+SoftSink func(diffs []complex64, baseIdx int)
+```
+
+`softType5FromDiffs` (in `process.go`) does the conversion, taking a rotation
+parameter because the constellation can sit at any of four residual rotations —
+its hard-slice is defined to equal the hard dibit path exactly, so the two
+streams can never disagree about *which* bits, only about how much to trust
+them. The convention throughout `framing/soft_tetra.go` is **LLR > 0 ⇒ bit 0**,
+magnitude = reliability, and an exact 0.0 is an erasure — which is also what
+soft depuncturing inserts for the bits the puncturing pattern never transmitted.
+That is strictly more honest than the hard path, which has to *guess* a value
+for punctured positions.
+
+## Carrying LLRs in lockstep
+
+The receiver's `DibitSink` contract predates all of this, and half the callers
+(tests, hard-only paths) neither know nor care about soft data. So the soft
+stream rides a stash bridge instead of a changed signature: `SoftSink` fires
+just before the matching `DibitSink` call with the same `baseIdx`, the pipeline
+stashes the differentials, and the extractor picks them up on its next
+`Process`:
+
+```go
+// internal/radio/tetra/traffic.go (shape) — the lockstep contract
+func (te *TrafficExtractor) StashSoft(diffs []complex64, baseIdx int) {
+    te.pendingSoft = diffs
+    te.pendingSoftBase = baseIdx
+}
+
+// Process: append the stashed differentials ONLY when they match this dibit
+// block (same base + length) AND softBuf is already in lockstep with buf;
+// otherwise drop the soft path (reset to empty) rather than risk misalignment.
+if te.pendingSoft != nil && te.pendingSoftBase == baseIdx &&
+    len(te.pendingSoft) == len(dibits) && len(te.softBuf) == len(te.buf) {
+    te.softBuf = append(te.softBuf, te.pendingSoft...)
+} else {
+    te.softBuf = te.softBuf[:0]
+}
+```
+
+The invariant is all-or-nothing: `softBuf` is either **exactly** `len(buf)` or
+empty. Every trim that drops dibits from the rolling buffer drops the same
+count of differentials, and any mismatch anywhere collapses the soft path to
+empty for that stretch. That severity is deliberate. LLRs shifted by even one
+symbol are confidently wrong about every bit — a decoder fed misaligned soft
+data does worse than the hard path it was meant to improve. A burst whose soft
+span is not fully covered simply decodes hard-only; `softFrame` returns nil and
+nothing downstream notices. The same stash-bridge pattern carries the raw
+pre-differential symbols (`StashSymbols` / `symBuf`) for the trained equalizer
+we meet in Part 9 —
+[Weak-Signal Engineering Part 9]({{ '/blog/deep-dives/weak-signal-engineering-09-parallel-buffers/' | relative_url }})
+generalizes the whole parallel-buffer design.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 220" width="680" height="220" role="img" aria-label="The hard and soft decode paths fork at the demodulator's differential output. The hard path slices each differential to a dibit and runs hard descramble, depuncture and Viterbi. The soft path keeps the complex differential, converts it to two per-bit LLRs, descrambles in the sign domain, and runs soft depuncture and soft Viterbi. Both paths end at the same class-2 CRC gate; the soft path recovers marginal bursts the hard path drops.">
+  <rect x="8" y="86" width="128" height="48" rx="6" fill="none" stroke="currentColor"/>
+  <text x="72" y="106" text-anchor="middle" fill="currentColor" font-size="11">differential</text>
+  <text x="72" y="120" text-anchor="middle" fill="var(--fg-muted)" font-size="9">s·conj(prev)</text>
+  <line x1="136" y1="98" x2="170" y2="60" stroke="var(--fg-muted)"/><polygon points="166,58 178,54 172,66" fill="var(--fg-muted)"/>
+  <line x1="136" y1="122" x2="170" y2="160" stroke="var(--accent)"/><polygon points="172,154 178,166 164,162" fill="var(--accent)"/>
+  <rect x="180" y="26" width="120" height="48" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="240" y="46" text-anchor="middle" fill="var(--fg-muted)" font-size="10">hard slice</text>
+  <text x="240" y="60" text-anchor="middle" fill="var(--fg-muted)" font-size="9">dibit, confidence lost</text>
+  <rect x="180" y="146" width="120" height="48" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="240" y="166" text-anchor="middle" fill="var(--accent)" font-size="10">softType5FromDiffs</text>
+  <text x="240" y="180" text-anchor="middle" fill="var(--fg-muted)" font-size="9">2 LLRs per symbol</text>
+  <line x1="300" y1="50" x2="334" y2="50" stroke="var(--fg-muted)"/><polygon points="334,46 344,50 334,54" fill="var(--fg-muted)"/>
+  <line x1="300" y1="170" x2="334" y2="170" stroke="var(--accent)"/><polygon points="334,166 344,170 334,174" fill="var(--accent)"/>
+  <rect x="344" y="26" width="150" height="48" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="419" y="46" text-anchor="middle" fill="var(--fg-muted)" font-size="10">hard Viterbi</text>
+  <text x="419" y="60" text-anchor="middle" fill="var(--fg-muted)" font-size="9">DecodeRCPCTetraMother</text>
+  <rect x="344" y="146" width="150" height="48" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="419" y="166" text-anchor="middle" fill="var(--accent)" font-size="10">soft Viterbi</text>
+  <text x="419" y="180" text-anchor="middle" fill="var(--fg-muted)" font-size="9">DecodeRCPCTetraMotherSoft</text>
+  <line x1="494" y1="50" x2="540" y2="98" stroke="var(--fg-muted)"/><polygon points="536,96 546,104 532,106" fill="var(--fg-muted)"/>
+  <line x1="494" y1="170" x2="540" y2="124" stroke="var(--accent)"/><polygon points="534,116 546,118 540,130" fill="var(--accent)"/>
+  <rect x="548" y="86" width="124" height="48" rx="6" fill="none" stroke="currentColor"/>
+  <text x="610" y="106" text-anchor="middle" fill="currentColor" font-size="11">class-2 CRC</text>
+  <text x="610" y="120" text-anchor="middle" fill="var(--fg-muted)" font-size="9">same gate for both</text>
+  <text x="340" y="212" text-anchor="middle" fill="var(--fg-muted)" font-size="10">the fork keeps confidence alive on the accent path — the ~2 dB the marginal call was missing</text>
+</svg>
+<figcaption>Hard and soft paths fork at the differential and rejoin at the class-2 CRC gate; only the soft path carries the demod's confidence into the Viterbi search.</figcaption>
+</figure>
+
+## The soft decode chain, step for step
+
+`DecodeTCHSSoft` mirrors the hard `DecodeTCHS` from Part 5 step for step, in
+the LLR domain. Same 24×18 deinterleave permutation, same split into class-0 /
+class-1 / class-2 regions, same rate-8/12 and rate-8/18 depuncture geometry —
+just twinned functions operating on `float32` reliabilities instead of bits:
+
+```go
+// internal/radio/tetra/tch.go (shape) — DecodeTCHSSoft
+type3 := tchDeinterleaveSoft(type5LLR[:tchType3Bits])
+class0 := type3[:tchClass0Bits]
+c1 := type3[tchClass0Bits : tchClass0Bits+tchClass1Coded]
+c2 := type3[tchClass0Bits+tchClass1Coded:]
+
+m1 := framing.DepunctureRCPCTetraSoft(c1, framing.RCPCTetraPeriod23,
+    framing.RCPCTetraPuncture23, 3*tchClass1Bits)
+m2 := framing.DepunctureRCPCTetraSoft(c2, framing.RCPCTetraPeriod818,
+    framing.RCPCTetraPuncture818, 3*(tchClass2Bits+tchCRCBits+tchTailBits))
+conv, metric := framing.DecodeRCPCTetraMotherSoft(append(m1, m2...), tchConvIn)
+// …class-2 CRC check is HARD and identical to DecodeTCHS
+```
+
+Two details are worth pausing on. First, the uncoded class-0 bits have no FEC
+to spend reliability on, so `hardSliceLLR` just slices them — soft decision
+only pays where a decoder exists to weigh evidence. Second, the class-2 CRC
+check at the end is the *hard* check from
+[Part 3]({{ '/blog/deep-dives/tetra-end-to-end-03-channel-coding-crc/' | relative_url }})
+— the fixed parity-check matrix, not an LFSR — computed over the Viterbi's hard
+output. Soft decision changes how hard the decoder fights for a burst; it does
+not change what counts as winning. On the reporter's marginal capture that
+combination took the same bursts the hard path dropped and recovered most of
+them — and when Part 9's equalizer later stacked on top, the soft path is the
+stream it multiplied.
+
+### How that principle shaped the Go code
+
+- **Opt-in at every layer.** `SoftSink` nil means zero overhead; no `StashSoft`
+  means `softBuf` stays empty and the extractor is byte-identical to the
+  pre-soft code. Every test that predates the feature still passes untouched.
+- **Twinned functions, not flags.** `tchDeinterleaveSoft`,
+  `DepunctureRCPCTetraSoft`, `DecodeRCPCTetraMotherSoft`, `DecodeTCHSSoft` —
+  each hard function has a soft twin with the same geometry constants, so the
+  two chains cannot drift apart structurally.
+- **The scrambler moves into the sign domain.** Descrambling XORs a keystream
+  bit; in LLRs that is a sign flip. `DescrambleTetraSoft` applies exactly the
+  flips `DescrambleTetra` applies, keyed by the same extended colour code from
+  [Part 4]({{ '/blog/deep-dives/tetra-end-to-end-04-scrambling-colour-codes/' | relative_url }}).
+
+## Fallback, CRC gates, and the AACH bonus
+
+The composer's voice chain (`decodeTETRASpeech` in
+`internal/voice/composer/tetra_voice.go`) tries soft first and falls back:
+
+```go
+// internal/voice/composer/tetra_voice.go (shape)
+if softType5 != nil {
+    frames = tetra.TCHSpeechFramesSoft(softType5)
+} else {
+    frames = tetra.TCHSpeechFrames(frame)
+}
+```
+
+The onBurst callback signature carries both — `frame []byte, softType5
+[]float32` — so a burst whose soft span got dropped by the lockstep guard
+degrades to the hard decode of that one burst, not a lost burst. And the soft
+buffer earned a second job while it was there: the AACH usage marker — the
+per-slot call identifier that demultiplexes concurrent same-carrier calls —
+rides a small RM(30,14) block that frequently fails hard decode under load.
+`usageOfSoft` re-decodes it from the same differentials, gated by
+`aachSoftMaxDist = 6`: the soft maximum-likelihood codeword must sit within 6
+bits of the hard-sliced word, so a rescued marker is a genuinely marginal burst
+re-decided, never a low-confidence guess that could route another call's speech
+into this recording. Once the LLRs are flowing, every marginal decode in the
+burst becomes cheaper to save.
+
+## Where this goes next
+
+Soft decision recovered the bursts the noise was costing us — and exposed what
+noise wasn't. The residual garble on the reporter's concurrent-load captures
+had structure: a smeared constellation that no amount of per-bit confidence can
+fix, because the *symbols themselves* were dragged off their positions by the
+channel. [Part 9]({{ '/blog/deep-dives/tetra-end-to-end-09-equalizer-voice-path/' | relative_url }})
+puts a blind equalizer between timing recovery and the differential decoder —
+and explains why the obvious way to do that corrupts every dibit, and the
+snapshot trick that doesn't.
+
+## FAQ
+
+**Where do the LLRs actually come from — is there a separate estimator?**
+No. The demod already computes the complex differential `s·conj(prev)` for
+every symbol; for π/4-DQPSK the two transmitted bits' LLRs are its imaginary
+and real parts. `softType5FromDiffs` reshuffles and signs them per the
+rotation; nothing new is measured.
+
+**Why is the soft path allowed to silently fall back to hard?**
+Because misaligned soft data is worse than none. The lockstep contract
+(`softBuf` exactly parallel or empty) means any chunk boundary hiccup degrades
+one burst to the hard decode instead of decoding it with shifted LLRs — which
+would be confidently wrong about every bit and *raise* the error rate.
+
+**Does soft decision ever pass a burst the hard CRC would reject?**
+The gate is identical — the class-2 parity-check over the Viterbi's hard
+output. Soft decision finds better codeword paths through the trellis, so more
+*real* bursts reach the gate intact; a random or foreign burst still passes
+only at the ~1/256 chance floor either way.
+
+**How much did it actually recover?**
+The marginal same-carrier call that motivated it was losing ~70% of its bursts
+hard-only. Soft decision recovered the bulk of those, and it compounds with
+Part 9's equalizer — the 410→778 CRC-valid figure across six captures is
+measured on the soft stream.
+
+**Why hard-slice the class-0 bits instead of keeping them soft?**
+Class 0 is uncoded — there is no decoder downstream to spend the reliability.
+An LLR only buys something when a code constrains which bit patterns are
+possible; for uncoded bits the sign is all the information there is.
+
+## Series navigation
+
+**Part 8 of 14** · ←
+[Part 7: Conformance — Bit-Identical Against the ETSI Reference]({{ '/blog/deep-dives/tetra-end-to-end-07-etsi-conformance/' | relative_url }})
+· Next →
+[Part 9: The Equalizer on the Voice Path]({{ '/blog/deep-dives/tetra-end-to-end-09-equalizer-voice-path/' | relative_url }})

--- a/docs/_posts/2026-08-25-weak-signal-engineering-08-soft-decisions.md
+++ b/docs/_posts/2026-08-25-weak-signal-engineering-08-soft-decisions.md
@@ -1,0 +1,337 @@
+---
+title: "Weak-Signal Engineering, Part 8: Soft Decisions — LLRs Through Depuncture & Viterbi"
+description: Why hard-slicing a marginal symbol throws away the information the FEC needs most, how GopherTrunk carries per-bit log-likelihood ratios through descramble, deinterleave, depuncture, and a correlation-metric Viterbi, and the measured TETRA outcome that justified the whole soft path.
+category: deep-dives
+keywords: soft decision decoding, log likelihood ratio, soft viterbi decoder, depuncturing erasures, rcpc soft decode, tetra tch/s soft, coding gain weak signal, llr sign convention, gophertrunk weak-signal engineering
+tags: [weak-signal-engineering, soft-decision, viterbi, llr, fec, tetra, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Weak-Signal Engineering"
+series_part: 8
+---
+
+*Part 8 of **Weak-Signal Engineering**, a 14-part series on decoding the
+marginal regime — where the receiver locks but only a fraction of frames
+survive. [Part 7]({{ '/blog/deep-dives/weak-signal-engineering-07-trained-lms/' | relative_url }})
+trained an LMS equalizer on the TETRA midamble and re-derived cleaner symbols
+from the known reference. Both equalizer parts ended the same way: with better
+*symbols*. This part is about what happens after the symbol — the moment the
+receiver decides a bit. Hard-slice it and you discard exactly the information a
+convolutional decoder is built to exploit. Carry the confidence instead, and
+bursts that failed every hard CRC start passing. On the marginal same-carrier
+calls that motivated this work, hard decoding was dropping ~70% of the speech
+bursts; the soft path is how they came back.*
+
+> **TL;DR:** A hard slicer collapses each received symbol to a bit and throws
+> away *how sure it was*. GopherTrunk instead carries a **log-likelihood ratio**
+> per bit — sign is the decision, magnitude is the confidence, **0 is an
+> erasure** — from the demodulator's π/4-DQPSK differential (the receiver's
+> `SoftSink`; the two on-air bits' LLRs are the Im and Re of `s·conj(last)`)
+> all the way into the FEC. Every hard channel-coding primitive has a soft
+> mirror in `internal/radio/framing/soft_tetra.go`: `DescrambleTetraSoft` flips
+> LLR signs, `DepunctureRCPCTetraSoft` fills punctured positions with 0.0
+> erasures, and `DecodeRCPCTetraMotherSoft` runs the same 16-state K=5 trellis
+> with a correlation branch metric `L·(2g−1)` instead of Hamming distance.
+> `tetra.DecodeTCHSSoft` chains them for voice; the composer prefers it
+> whenever LLRs exist and falls back to the hard gate when they don't.
+
+**Key takeaways**
+
+- **The bits the FEC needs help with are the bits the slicer is least sure
+  about.** Hard decisions weight a near-threshold symbol exactly as heavily as
+  a full-quieting one; the Viterbi then defends wrong-but-confident-looking
+  bits. LLRs let weak evidence count weakly.
+- **An erasure is the limiting case, and puncturing already forces it on you.**
+  A punctured position was never transmitted; the soft depuncture writes 0.0 —
+  literally "no information" — and the trellis metric skips it for free. Hard
+  decoders need a sentinel; soft decoders get erasures by construction.
+- **The soft Viterbi is the same trellis, cheaper to reason about.** Same
+  states, same polynomials, same traceback as the hard
+  `DecodeRCPCTetraMother` — only the branch cost changes, so conformance
+  arguments carry over.
+- **The measured verdict, not the textbook one, closed the case.** The
+  classic framing says soft decisions buy ~2 dB of coding gain; what mattered
+  here is that a marginal call failing ~70% of its bursts under hard decoding
+  produced short, garbled recordings — and decoded as real speech soft.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| LLR convention | sign = bit, magnitude = confidence, 0 = erasure | `internal/radio/framing/soft_tetra.go` (package doc) |
+| Soft source | per-symbol differential `s·conj(last)` → LLR pair | `internal/radio/tetra/receiver/receiver.go` (`Options.SoftSink`) |
+| Soft descramble | PN bit 1 ⇒ flip the LLR sign | `soft_tetra.go` (`DescrambleTetraSoft`) |
+| Soft depuncture | punctured positions filled with 0.0 erasures | `soft_tetra.go` (`DepunctureRCPCTetraSoft`) |
+| Soft Viterbi | correlation metric on the K=5 R=1/3 trellis | `soft_tetra.go` (`DecodeRCPCTetraMotherSoft`) |
+| Voice chain | deinterleave → depuncture → Viterbi → CRC | `internal/radio/tetra/tch.go` (`DecodeTCHSSoft`, `TCHSpeechFramesSoft`) |
+| Preference & fallback | soft when LLRs exist, hard otherwise | `internal/voice/composer/tetra_voice.go` (`decodeTETRASpeech`) |
+
+## In this post
+
+- **What a hard slicer throws away** — confidence, and why the FEC wanted it.
+- **The LLR contract** — one convention, held end to end.
+- **Erasures and soft depuncture** — puncturing's natural home.
+- **The correlation-metric Viterbi** — same trellis, different cost.
+- **The measured outcome** — ~70% of a marginal call's bursts, recovered.
+
+## What a hard slicer throws away
+
+Picture two received symbols on a marginal TETRA carrier. One lands dead centre
+of its decision region — the demodulator would bet the house on it. The other
+lands a hair from the boundary — noise alone could have put it on either side.
+A hard slicer emits the same thing for both: one confident-looking bit. From
+that moment on, every downstream stage treats the coin-flip bit and the
+certain bit as equals.
+
+Now hand those bits to a convolutional decoder. The Viterbi algorithm is a
+maximum-likelihood sequence estimator: it picks the codeword closest to what
+was received. With hard bits, "closest" is Hamming distance, and a wrong
+near-threshold bit costs the correct path exactly as much as a wrong
+full-confidence bit would — the decoder ends up defending evidence that was
+never really there. That is precisely backwards. The bits most likely to be
+wrong are the ones the FEC most needs to override, and they arrive stripped
+of the one attribute — low confidence — that would have let it.
+
+This is the reliability-limited regime, distinct from the ISI-limited regime
+of [Part 3]({{ '/blog/deep-dives/weak-signal-engineering-03-isi-linear-channel/' | relative_url }}):
+the symbols are not smeared by the channel, they are simply noisy, and no
+equalizer can help. The lever here is keeping the confidence attached to each
+bit. (The two levers stack — the equalized symbols from
+[Part 7]({{ '/blog/deep-dives/weak-signal-engineering-07-trained-lms/' | relative_url }})
+feed *re-derived LLRs*, not re-sliced bits, into this same path.)
+
+## The LLR contract
+
+GopherTrunk's soft information is a per-bit **log-likelihood ratio** (see the
+[reference page]({{ '/reference/log-likelihood-ratio/' | relative_url }})) held
+to one convention across every soft primitive, stated once in
+`internal/radio/framing/soft_tetra.go`: **LLR > 0 ⇒ bit 0, LLR < 0 ⇒ bit 1,
+and magnitude is reliability — 0 is an erasure, no information at all.** The
+soft Viterbi's surviving path is scale-invariant, so the LLRs never need
+normalising; any consistent scaling works.
+
+Where do LLRs come from? For π/4-DQPSK they fall out of the demodulator
+almost for free. The receiver's `SoftSink` emits the complex differential
+`s·conj(last)` for every symbol, aligned one-to-one with the hard dibits and
+carrying the same `baseIdx` — and the two on-air bits' LLRs are simply the
+imaginary and real parts of that differential. A symbol near a decision
+boundary produces a small component; a clean symbol produces a large one. The
+demodulator always knew the confidence; the hard path just never wrote it down.
+
+Even the scrambler respects the convention. XOR-ing a bit with the scrambling
+PN sequence becomes a conditional sign flip of its LLR:
+
+```go
+// internal/radio/framing/soft_tetra.go (shape) — DescrambleTetraSoft
+s := NewScramblerTetra(colourCode)
+out := make([]float32, len(in))
+for i, v := range in {
+    if s.Next() == 1 {
+        out[i] = -v // PN bit 1 inverts the bit, hence the LLR sign
+    } else {
+        out[i] = v
+    }
+}
+```
+
+Same LFSR as the hard `DescrambleTetra`, same colour-code seeding — the
+magnitude (the confidence) passes through untouched, because scrambling
+changes what the bit *is*, not how sure we are of it.
+
+## Erasures and soft depuncture
+
+TETRA's traffic channel uses a rate-compatible punctured convolutional code:
+a K=5 rate-1/3 mother code with positions deleted before transmission to hit
+the target rate. The receiver must re-inflate the stream to mother length
+before the trellis — and the punctured positions were *never sent*, so there
+is genuinely nothing to put there.
+
+The hard decoder needs a special sentinel value for this. The soft decoder
+gets it for free, because "no information" already has a number:
+
+```go
+// internal/radio/framing/soft_tetra.go (shape) — DepunctureRCPCTetraSoft
+out := make([]float32, motherLen) // zero-valued = erasure
+for j := 1; j <= len(punctured); j++ {
+    blockIdx := (j - 1) / t
+    offset := j - t*blockIdx
+    k := period*blockIdx + puncture[offset-1]
+    if k-1 < motherLen {
+        out[k-1] = punctured[j-1]
+    }
+}
+```
+
+A 0.0 LLR contributes exactly zero to every branch metric, so a punctured
+position neither helps nor hurts any path — which is the correct treatment of
+a bit that never existed. The same mechanism handles a received bit the demod
+had *no* confidence in: as its LLR magnitude shrinks toward zero it smoothly
+becomes an erasure. Erasures are not a special case in the soft domain; they
+are the limiting case of low confidence, and the code reflects that by having
+no erasure branch at all.
+
+## The correlation-metric Viterbi
+
+The soft trellis decoder is deliberately the *same machine* as the hard one —
+same 16 states, same generator polynomials (`g1=in^d1^d2^d3^d4`,
+`g2=in^d1^d3^d4`, `g3=in^d2^d4`), same forced-to-zero tail and traceback. The
+only change is the branch cost: instead of counting Hamming mismatches, each
+expected mother bit `g` is correlated against its received LLR `L` as
+`L·(2g−1)` — a match lowers the path metric, a mismatch raises it by an amount
+proportional to how confident the demod was, and an erasure contributes
+nothing:
+
+```go
+// internal/radio/framing/soft_tetra.go (shape) — DecodeRCPCTetraMotherSoft
+for input := 0; input < 2; input++ {
+    g1 := (input ^ d1 ^ d2 ^ d3 ^ d4) & 1
+    g2 := (input ^ d1 ^ d3 ^ d4) & 1
+    g3 := (input ^ d2 ^ d4) & 1
+    cost := pm[cur]
+    cost += rxG1 * float32(2*g1-1)
+    cost += rxG2 * float32(2*g2-1)
+    cost += rxG3 * float32(2*g3-1)
+    /* … keep the minimum-cost survivor per next state … */
+}
+```
+
+The minimum-cost path is the maximum-likelihood sequence, weighted by the
+demodulator's actual confidence in every bit. `tetra.DecodeTCHSSoft` chains
+the pieces for a voice burst, mirroring the hard chain step for step in the
+LLR domain: soft deinterleave → split the class-0/class-1/class-2 regions →
+soft depuncture each into the mother stream → soft Viterbi → the same hard
+class-2 CRC check as before. The uncoded class-0 bits carry no FEC, so their
+LLRs are hard-sliced straight through — softness only pays where there is a
+decoder to spend it.
+
+That final CRC matters for the series' standing rule
+([Part 2]({{ '/blog/deep-dives/weak-signal-engineering-02-metrics-that-lie/' | relative_url }})):
+the verdict on whether soft decoding *helped* is CRC-valid frames per
+opportunity, judged by exactly the same gate the hard path uses.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 220" width="680" height="220" role="img" aria-label="Two number lines of received symbol values. The top line shows hard slicing: a single threshold splits the axis into bit 0 and bit 1, and two received samples on opposite sides — one far from the threshold, one touching it — both emit full-confidence bits. The bottom line shows the LLR view: confidence grows with distance from zero, the far sample carries a large LLR, the near sample carries a tiny LLR close to the erasure point at zero, so the Viterbi can override it.">
+  <text x="12" y="26" fill="currentColor" font-size="10">hard slicer: every bit looks equally certain</text>
+  <line x1="60" y1="60" x2="620" y2="60" stroke="var(--fg-muted)"/>
+  <line x1="340" y1="42" x2="340" y2="78" stroke="currentColor"/>
+  <text x="340" y="36" text-anchor="middle" fill="currentColor" font-size="9">threshold</text>
+  <text x="180" y="52" text-anchor="middle" fill="var(--fg-muted)" font-size="9">bit 0</text>
+  <text x="500" y="52" text-anchor="middle" fill="var(--fg-muted)" font-size="9">bit 1</text>
+  <circle cx="130" cy="60" r="5" fill="currentColor"/>
+  <text x="130" y="80" text-anchor="middle" fill="var(--fg-muted)" font-size="9">clean symbol → "0"</text>
+  <circle cx="332" cy="60" r="5" fill="currentColor"/>
+  <text x="300" y="80" text-anchor="middle" fill="var(--fg-muted)" font-size="9">coin flip → also "0"</text>
+  <text x="12" y="122" fill="currentColor" font-size="10">LLR: confidence rides along, zero is an erasure</text>
+  <line x1="60" y1="164" x2="620" y2="164" stroke="var(--fg-muted)"/>
+  <rect x="60" y="150" width="280" height="28" fill="var(--accent)" opacity="0.25"/>
+  <rect x="340" y="150" width="280" height="28" fill="var(--fg-muted)" opacity="0.18"/>
+  <line x1="340" y1="146" x2="340" y2="182" stroke="currentColor"/>
+  <text x="340" y="198" text-anchor="middle" fill="currentColor" font-size="9">LLR = 0 (erasure)</text>
+  <circle cx="130" cy="164" r="5" fill="var(--accent)"/>
+  <text x="130" y="142" text-anchor="middle" fill="var(--accent)" font-size="9">large +LLR: trust it</text>
+  <circle cx="332" cy="164" r="5" fill="var(--accent)"/>
+  <text x="270" y="142" text-anchor="middle" fill="var(--accent)" font-size="9">tiny +LLR: FEC may override</text>
+  <text x="120" y="216" fill="var(--fg-muted)" font-size="9">LLR &gt; 0 ⇒ bit 0</text>
+  <text x="480" y="216" fill="var(--fg-muted)" font-size="9">LLR &lt; 0 ⇒ bit 1</text>
+</svg>
+<figcaption>A hard threshold makes a coin-flip symbol indistinguishable from a certain one; the LLR keeps the distance to the boundary, and zero — the erasure — is just its limiting case.</figcaption>
+</figure>
+
+## The measured outcome
+
+The textbook framing says soft-decision decoding is worth roughly 2 dB of
+coding gain over hard decisions in Gaussian noise — meaningful, but abstract.
+What landed the change was a concrete failure: on a marginal same-carrier
+TETRA call, the hard-decision TCH/S gate was failing **about 70% of the
+call's bursts**, and the recordings came out short and garbled. Same RF, same
+symbols, LLRs carried instead of bits: the bursts passed the class-2 CRC and
+the call decoded as continuous speech. `TestSoftDecisionLocksWhereHardFails`
+(`internal/radio/tetra/receiver/soft_e2e_test.go`) pins the effect end to end
+at the receiver level, and its companion `TestSoftDecisionCleanStillLocks`
+pins the no-harm side.
+
+The composer's preference logic is the last piece, and it encodes the safety
+rule this series keeps returning to — the soft path must be additive:
+
+```go
+// internal/voice/composer/tetra_voice.go (shape) — decodeTETRASpeech
+// Prefer soft-decision TCH/S when the extractor supplied the burst's LLRs:
+// the soft Viterbi's ~2 dB coding gain recovers real speech bursts the
+// hard-decision gate drops on a marginal same-carrier signal. Fall back to
+// the hard gate when no soft info is available (never worse than before).
+var frames [][]byte
+if softType5 != nil {
+    frames = tetra.TCHSpeechFramesSoft(softType5)
+} else {
+    frames = tetra.TCHSpeechFrames(frame)
+}
+```
+
+No LLRs stashed ⇒ the hard path runs untouched, byte for byte. How that
+opt-in property is engineered — the parallel buffers, the stash bridge, and
+the tests that pin "no sinks wired ⇒ identical output" — is the next part.
+For the TETRA-side case narrative of this same lever, see the concurrent
+[TETRA End to End, Part 8]({{ '/blog/deep-dives/tetra-end-to-end-08-soft-decision-tchs/' | relative_url }}).
+
+### How that principle shaped the Go code
+
+- **Every soft primitive mirrors a hard one, by name.** `DescrambleTetraSoft`,
+  `BlockDeinterleaveTetraSoft`, `DepunctureRCPCTetraSoft`,
+  `DecodeRCPCTetraMotherSoft` — same file layout, same index math, same
+  constants. A conformance argument made once for the hard chain transfers.
+- **One convention, zero normalisation.** Sign/magnitude/erasure is stated in
+  one package doc and relied on everywhere; because the Viterbi survivor is
+  scale-invariant, no stage rescales LLRs and no stage can get the scaling
+  wrong.
+- **The verdict gate did not move.** Soft or hard, a burst becomes speech only
+  by passing the identical class-2 CRC — so the yield comparison between the
+  two paths is honest by construction.
+
+## Where this goes next
+
+Soft decisions only work if the LLRs survive the trip from demodulator to
+decoder — through a burst extractor that was designed around hard dibits.
+[Part 9]({{ '/blog/deep-dives/weak-signal-engineering-09-parallel-buffers/' | relative_url }})
+covers the architecture that made it landable: `SoftSink` and `SymbolSink`
+buffers carried strictly parallel to the dibit buffer, a stash bridge keyed by
+`baseIdx`, and the byte-identical opt-out property that let risky DSP ship
+without endangering a single working configuration.
+
+## FAQ
+
+**Where do the LLRs physically come from — does the demodulator run twice?**
+No. The π/4-DQPSK differential `s·conj(last)` is computed once; the hard path
+slices it into a dibit and the `SoftSink` hands the same complex value out as
+a pair of LLRs (Im and Re). The soft information was always present in the
+demodulator — the change is refusing to discard it.
+
+**Is soft decoding slower?**
+The trellis work is the same order — 16 states, two branches per state, three
+metric terms per branch, float adds instead of integer XOR/popcount. The cost
+that actually shows up is carrying the parallel float32 buffers, and that is
+only paid when a caller wires the sinks (Part 9).
+
+**Why does class 0 get hard-sliced even on the soft path?**
+Class-0 bits are uncoded — there is no decoder downstream to spend their
+confidence. An LLR only earns its keep where a trellis or an erasure-aware
+stage can weigh it; for an uncoded bit the sign is all there is.
+
+**Does soft decoding fix an ISI-smeared channel?**
+No. If the constellation is smeared by multipath or band-edge group delay,
+the LLRs faithfully report high confidence in *wrong* bits. Equalize first
+([Parts 4–7]({{ '/blog/deep-dives/weak-signal-engineering-04-blind-cma/' | relative_url }})),
+then let soft decisions handle the residual noise. The levers stack; they do
+not substitute.
+
+**Is ~2 dB worth the engineering?**
+On the yield cliff of [Part 1]({{ '/blog/deep-dives/weak-signal-engineering-01-marginal-regime/' | relative_url }}),
+2 dB is the difference between a call that decodes and one that doesn't —
+the marginal regime is exactly where small dB moves produce large yield moves.
+The 70%-of-bursts recovery is that cliff, measured.
+
+## Series navigation
+
+**Part 8 of 14** · ←
+[Part 7: Trained Equalization — LMS on the Midamble]({{ '/blog/deep-dives/weak-signal-engineering-07-trained-lms/' | relative_url }})
+· Next →
+[Part 9: Parallel Buffers — SymbolSink, SoftSink & Opt-In Soft Paths]({{ '/blog/deep-dives/weak-signal-engineering-09-parallel-buffers/' | relative_url }})

--- a/docs/_posts/2026-08-26-analog-edge-09-filters-lnas.md
+++ b/docs/_posts/2026-08-26-analog-edge-09-filters-lnas.md
@@ -1,0 +1,264 @@
+---
+title: "The Analog Edge, Part 9: Filters & LNAs — Adding Gain Without Adding Garbage"
+description: When a low-noise amplifier actually helps, why its position in the chain matters more than its gain figure, how bandpass and FM-notch filters buy back headroom on a hot band, and the decision rules for ordering filter, LNA, and coax so you don't amplify your own problems.
+category: tutorials
+keywords: sdr lna placement, low noise amplifier antenna, friis noise figure, fm broadcast notch filter, sdr bandpass filter, bias tee sdr, lna overload intermod, filter before or after lna, gophertrunk analog edge
+tags: [analog-edge, lna, filters, noise-figure, rf, hardware]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "The Analog Edge"
+series_part: 9
+---
+
+*Part 9 of **The Analog Edge**, a 14-part field guide to the analog half of a
+GopherTrunk system. [Part 8]({{ '/blog/tutorials/analog-edge-08-feedline-connectors/' | relative_url }})
+audited our marginal reader's feedline and found ~8 dB dying in forty feet of
+RG-58 and an adapter stack. New cable clawed back six of them. This part is
+about the next lever — active gain — and its sharp edge: an LNA in the wrong
+place amplifies nothing useful, and an LNA on a hot band manufactures the
+exact intermod garbage [Part 4]({{ '/blog/tutorials/analog-edge-04-clipping-overload-intermod/' | relative_url }})
+taught you to recognize. Gain is easy; *clean* gain is placement and
+filtering.*
+
+> **TL;DR:** An [LNA]({{ '/reference/low-noise-amplifier/' | relative_url }})
+> helps exactly in proportion to how much loss comes **after** it, because the
+> Friis cascade makes the first stage's
+> [noise figure]({{ '/reference/noise-figure/' | relative_url }}) dominate the
+> system. Mast-mounted LNA ahead of the coax: the run's loss nearly vanishes
+> from the noise budget. Desk-mounted LNA after the coax: you amplify signal
+> and accumulated noise together and gain almost nothing. The tax is dynamic
+> range — every dB of LNA gain is a dB less headroom against the FM
+> broadcast / pager blowtorches, so on a hot band the LNA needs a
+> [filter]({{ '/sdr-filters/' | relative_url }}) riding with it. Power rides
+> the coax via a [bias tee]({{ '/reference/bias-tee/' | relative_url }})
+> (`bias_tee: true` on the device block for SDRs that provide one).
+
+**Key takeaways**
+
+- **Placement beats specification.** A mediocre LNA at the antenna outperforms
+  an excellent LNA at the desk, because loss *after* amplification barely
+  counts while loss *before* it counts dB-for-dB.
+- **Gain without filtering is a bet that your band is quiet.** An LNA lifts
+  every FM broadcast, pager, and cellular carrier in its passband along with
+  your target; if the sum approaches the front end's limits, you've traded
+  noise floor for intermod.
+- **Filters spend dB to buy headroom.** A bandpass or FM-notch filter has
+  insertion loss — position decides whether that loss costs noise figure
+  (before the LNA) or almost nothing (after it), and overload decides which
+  you need.
+- **The decode-quality sweep is still the referee.** Whether an LNA/filter
+  combination netted out positive is answered the same way as gain staging in
+  [Part 3]({{ '/blog/tutorials/analog-edge-03-gain-staging/' | relative_url }}):
+  by decode error rate, never by how loud the waterfall got.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| LNA fundamentals | sub-1 dB NF first stage; sets the cascade | [low-noise amplifier]({{ '/reference/low-noise-amplifier/' | relative_url }}), [best SDR LNAs]({{ '/best-sdr-lna/' | relative_url }}) |
+| Friis cascade | why stage 1 dominates system NF | [noise figure]({{ '/reference/noise-figure/' | relative_url }}) |
+| FM broadcast notch | kills the 88–108 MHz blowtorch before it intermods | [FM broadcast filter]({{ '/reference/fm-broadcast-filter/' | relative_url }}), [SDR filters guide]({{ '/sdr-filters/' | relative_url }}) |
+| Band-specific filtering | bandpass / cavity for one service band | [cavity filter]({{ '/reference/cavity-filter/' | relative_url }}) |
+| Powering a mast LNA | DC up the coax | [bias tee]({{ '/reference/bias-tee/' | relative_url }}); `bias_tee` in the `sdr` device blocks (`config.example.yaml`) |
+| Judging the result | decode error rate across a gain sweep | [autogain, The Hunt Part 5]({{ '/blog/deep-dives/the-hunt-05-autogain-autotune/' | relative_url }}) |
+
+## In this post
+
+- **Why the first stage wins** — the Friis rule in operator terms.
+- **LNA at the antenna vs at the dongle** — the same part, two outcomes.
+- **The overload tax** — when gain makes decoding worse.
+- **Filters: notch, bandpass, and where they go** — order-of-operations rules.
+- **Bias tees and powering** — DC up the coax without surprises.
+
+## Why the first stage wins
+
+The Friis noise cascade says the system noise figure is dominated by the first
+stage, with every later stage's contribution divided by the gain in front of
+it. You don't need the formula to use the consequence:
+
+- **Loss before the first amplifier counts in full.** Part 8's 6.5 dB of RG-58
+  ahead of a bare dongle is 6.5 dB of system noise figure.
+- **Loss after ~20 dB of low-noise gain barely counts.** The same 6.5 dB of
+  coax *behind* a 20 dB LNA contributes a fraction of a dB to the cascade.
+
+That asymmetry is the entire placement argument. A typical SDR-grade LNA has a
+noise figure under 1 dB and ~20 dB of gain; put it at the antenna and the
+system noise figure becomes "about 1 dB, plus a little" almost regardless of
+the feedline behind it. The coax run stops being a noise problem and becomes a
+mere plumbing problem.
+
+## LNA at the antenna vs at the dongle
+
+Same amplifier, two different systems:
+
+| Configuration | Approx. system NF | What actually happened |
+|---|---|---|
+| antenna → 40 ft RG-58 (~6.5 dB) → tuner (NF ~6 dB) | ~12.5 dB | baseline: coax + tuner both count in full |
+| antenna → 40 ft RG-58 → **LNA at desk** → tuner | ~7.5 dB | the coax's 6.5 dB still leads the cascade |
+| antenna → **LNA at mast** → 40 ft RG-58 → tuner | ~1.5 dB | coax and tuner both hide behind the LNA's gain |
+
+The desk-mounted LNA looks busy — the waterfall brightens, dBFS rises — but
+most of what it amplified was a signal already degraded by the run. Six dB of
+the improvement you paid for never existed. The mast-mounted unit changes the
+system class. This is also the honest way to read
+[Part 8]({{ '/blog/tutorials/analog-edge-08-feedline-connectors/' | relative_url }})'s
+budget: replacing cable and adding a mast LNA attack the same dB from two
+sides, and the LNA is usually the bigger single win — *if* the band lets you
+spend the headroom.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 220" width="680" height="220" role="img" aria-label="Two receive chains compared. Top chain: antenna into forty feet of lossy coax, then an LNA at the desk, then the tuner — the loss sits before the amplifier and the system noise figure stays high. Bottom chain: antenna into an LNA at the mast, then the same coax, then the tuner — the loss sits after the amplifier and the system noise figure is set by the LNA alone, about 1.5 dB.">
+  <text x="10" y="30" fill="var(--fg-muted)" font-size="10">LNA at the desk</text>
+  <rect x="10" y="40" width="88" height="36" rx="6" fill="none" stroke="currentColor"/>
+  <text x="54" y="62" text-anchor="middle" fill="currentColor" font-size="10">antenna</text>
+  <line x1="98" y1="58" x2="128" y2="58" stroke="currentColor"/><polygon points="128,54 138,58 128,62" fill="currentColor"/>
+  <rect x="138" y="40" width="150" height="36" rx="6" fill="none" stroke="currentColor"/>
+  <text x="213" y="56" text-anchor="middle" fill="currentColor" font-size="10">40 ft coax</text>
+  <text x="213" y="70" text-anchor="middle" fill="var(--fg-muted)" font-size="9">−6.5 dB, counts in full</text>
+  <line x1="288" y1="58" x2="318" y2="58" stroke="currentColor"/><polygon points="318,54 328,58 318,62" fill="currentColor"/>
+  <rect x="328" y="40" width="96" height="36" rx="6" fill="none" stroke="currentColor"/>
+  <text x="376" y="56" text-anchor="middle" fill="currentColor" font-size="10">LNA</text>
+  <text x="376" y="70" text-anchor="middle" fill="var(--fg-muted)" font-size="9">too late</text>
+  <line x1="424" y1="58" x2="454" y2="58" stroke="currentColor"/><polygon points="454,54 464,58 454,62" fill="currentColor"/>
+  <rect x="464" y="40" width="88" height="36" rx="6" fill="none" stroke="currentColor"/>
+  <text x="508" y="62" text-anchor="middle" fill="currentColor" font-size="10">tuner</text>
+  <text x="600" y="62" fill="var(--fg-muted)" font-size="10">NF ≈ 7.5 dB</text>
+  <text x="10" y="128" fill="var(--fg-muted)" font-size="10">LNA at the mast</text>
+  <rect x="10" y="138" width="88" height="36" rx="6" fill="none" stroke="currentColor"/>
+  <text x="54" y="160" text-anchor="middle" fill="currentColor" font-size="10">antenna</text>
+  <line x1="98" y1="156" x2="128" y2="156" stroke="currentColor"/><polygon points="128,152 138,156 128,160" fill="currentColor"/>
+  <rect x="138" y="138" width="96" height="36" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="186" y="154" text-anchor="middle" fill="var(--accent)" font-size="10">LNA first</text>
+  <text x="186" y="168" text-anchor="middle" fill="var(--fg-muted)" font-size="9">NF &lt;1 dB, +20 dB</text>
+  <line x1="234" y1="156" x2="264" y2="156" stroke="currentColor"/><polygon points="264,152 274,156 264,160" fill="currentColor"/>
+  <rect x="274" y="138" width="150" height="36" rx="6" fill="none" stroke="currentColor"/>
+  <text x="349" y="154" text-anchor="middle" fill="currentColor" font-size="10">40 ft coax</text>
+  <text x="349" y="168" text-anchor="middle" fill="var(--fg-muted)" font-size="9">−6.5 dB, hidden by gain</text>
+  <line x1="424" y1="156" x2="454" y2="156" stroke="currentColor"/><polygon points="454,152 464,156 454,160" fill="currentColor"/>
+  <rect x="464" y="138" width="88" height="36" rx="6" fill="none" stroke="currentColor"/>
+  <text x="508" y="160" text-anchor="middle" fill="currentColor" font-size="10">tuner</text>
+  <text x="600" y="154" fill="var(--accent)" font-size="10">NF ≈ 1.5 dB</text>
+  <text x="340" y="208" text-anchor="middle" fill="var(--fg-muted)" font-size="10">same parts, ~6 dB apart — placement, not specification, sets the system noise figure</text>
+</svg>
+<figcaption>The Friis rule in one picture: loss ahead of the LNA counts in full; loss behind it hides under the gain. The mast chain wins by ~6 dB with identical parts.</figcaption>
+</figure>
+
+## The overload tax
+
+Here is the trade nobody prints on the LNA's box: **every dB of gain ahead of
+the tuner is a dB less headroom inside it.** The LNA doesn't know which
+carrier you want. It lifts the 100 kW FM broadcast transmitter at 98.7, the
+paging blowtorch at 152.48, and the neighbor's cellular uplink right along
+with your 851 MHz control channel — and
+[Part 4]({{ '/blog/tutorials/analog-edge-04-clipping-overload-intermod/' | relative_url }})
+showed what happens when the *sum* gets big: intermod products that look like
+phantom carriers, a rail-pinned ADC behind a deceptively normal FFT
+([the nineteen-dibits postmortem]({{ '/blog/solution-postmortem/from-the-issue-tracker-08-nineteen-dibits/' | relative_url }})),
+and a decode error rate that *rises* with gain on the far side of
+[Part 3]({{ '/blog/tutorials/analog-edge-03-gain-staging/' | relative_url }})'s
+U-curve.
+
+The operator-level rule: **an LNA is a rural instrument by default.** On a
+quiet band it's nearly free noise figure. In an urban RF environment it must
+arrive with a filter, and you should expect to *reduce* the tuner's own gain
+after installing it — re-run the gain ladder from Part 3 and let decode
+quality, not dBFS, pick the new operating point. Remember the standing rule
+from [#764](https://github.com/MattCheramie/GopherTrunk/issues/764): neither
+of those captures clipped, and the front end was still the problem — "no
+clipping" does not clear an overloaded or noisy chain, and a brighter
+waterfall proves nothing.
+
+## Filters: notch, bandpass, and where they go
+
+A filter spends a little in-band insertion loss (typically 0.5–3 dB depending
+on type) to remove out-of-band power before it can do harm. The two workhorses
+for a trunking rig, both covered with buying picks in the
+[SDR filters guide]({{ '/sdr-filters/' | relative_url }}):
+
+- **FM broadcast notch** ([reference]({{ '/reference/fm-broadcast-filter/' | relative_url }})) —
+  kills 88–108 MHz, which is the single most common overload source feeding a
+  wideband antenna. Cheap, nearly universal benefit for anything above VHF.
+- **Bandpass for your service band** — e.g. a 700–900 MHz pass for a trunking
+  rig, or a proper [cavity filter]({{ '/reference/cavity-filter/' | relative_url }})
+  when one specific neighbor is the problem. Narrower is better protection and
+  less flexibility.
+
+Position is a decision rule, not a dogma:
+
+| Situation | Order | Why |
+|---|---|---|
+| Quiet band, weak target | antenna → LNA → filter → coax | filter's insertion loss hides behind the LNA's gain; NF stays minimal |
+| Hot band (FM/pager towers in sight) | antenna → **filter** → LNA → coax | the LNA itself is what overloads; it must be protected even at the cost of NF |
+| Overload only at the tuner, LNA clean | antenna → LNA → coax → filter → tuner | spend the loss where it's cheapest |
+
+The first row is the textbook default; the second is the one that saves urban
+installs. If you're unsure which regime you're in, the test from Part 4
+applies: insert 10 dB of [attenuation]({{ '/reference/attenuator/' | relative_url }})
+at the tuner — if signals *appear* or decode *improves*, you're overloaded
+somewhere, and the filter goes in front of whatever stage the attenuator just
+rescued.
+
+## Bias tees and powering
+
+A mast-mounted LNA needs DC, and running a second cable up the mast defeats
+the purpose. A [bias tee]({{ '/reference/bias-tee/' | relative_url }}) injects
+supply voltage onto the coax's center conductor; the LNA end extracts it, and
+the RF rides through both ways. Many SDRs can source this directly — the
+device blocks in `config.example.yaml` expose it as `bias_tee: true`
+(RTL-SDR Blog [V3/V4]({{ '/rtl-sdr-blog-v3-vs-v4/' | relative_url }}) have one
+built in; on `sdr.soapy_remote` devices it's best-effort, driver-dependent). Two cautions: a DC short anywhere in the run (some antennas
+are DC-grounded by design) will make the dongle fold back its supply — check
+the antenna's spec before enabling it; and an inline component that *doesn't*
+pass DC (most filters don't) must sit on the radio side of the injection
+point, not between the bias tee and the LNA.
+
+## Where this goes next
+
+The chain from antenna to ADC is now as good as we can make it: the right
+antenna (Part 7), low-loss feed (Part 8), clean gain in the right order (this
+part). Before we spend money on a *second* antenna, we need the skill that
+turns any remaining mystery into evidence:
+[Part 10]({{ '/blog/tutorials/analog-edge-10-capture-discipline/' | relative_url }})
+covers capture discipline — the formats, sidecars, and tap points that let a
+"sounds bad" complaint become a replayable file, which is the tracker's most
+repeated request and the reason half its hard bugs ever got solved.
+
+## FAQ
+
+**Do I need an LNA at all with a modern SDR?**
+Maybe not. If your feedline is short and low-loss and your decode is clean, an
+LNA buys you nothing but overload risk. The LNA's case is strongest with long
+runs (it neutralizes the coax) and weak signals. Fix the feedline first —
+Part 8 is cheaper than [any amplifier]({{ '/best-sdr-lna/' | relative_url }}).
+
+**How much LNA gain should I buy?**
+Enough to bury the losses behind it — 15–20 dB covers any sane feedline. More
+gain than that subtracts straight from overload headroom without improving
+noise figure, since the cascade is already dominated by the first stage.
+
+**Filter first or LNA first?**
+Quiet band: LNA first (its gain hides the filter's insertion loss). Hot band:
+filter first, because the LNA is the stage being overloaded and a fried noise
+budget beats a spur farm. When in doubt, run the attenuator test from Part 4
+and see which stage the overload lives in.
+
+**Will GopherTrunk tell me my LNA is helping?**
+Indirectly and honestly: sweep tuner gain and compare decode error rate before
+and after, the same way [autogain]({{ '/blog/deep-dives/the-hunt-05-autogain-autotune/' | relative_url }})
+scores gains. Expect the optimal tuner gain to *drop* after adding an LNA. If
+error rate at the new optimum didn't improve, the LNA is amplifying a problem —
+or sitting in the wrong place.
+
+**Can I power a mast LNA through a splitter or a second receiver?**
+Treat DC paths explicitly. Splitters, filters, and some antennas block or
+short DC, and a bias-tee feed that works through one path can vanish through
+another. One injection point, one extraction point, and check every inline
+component's DC behavior — "LNA stopped amplifying after I added a filter" is
+almost always a starved bias tee.
+
+## Series navigation
+
+**Part 9 of 14** · ←
+[Part 8: Feedline & Connectors — Where dB Go to Die]({{ '/blog/tutorials/analog-edge-08-feedline-connectors/' | relative_url }})
+· Next →
+[Part 10: Capture Discipline — cfile, cs16, SigMF & Metadata]({{ '/blog/tutorials/analog-edge-10-capture-discipline/' | relative_url }})

--- a/docs/_posts/2026-08-26-tetra-end-to-end-09-equalizer-voice-path.md
+++ b/docs/_posts/2026-08-26-tetra-end-to-end-09-equalizer-voice-path.md
@@ -1,0 +1,294 @@
+---
+title: "TETRA End to End, Part 9: The Equalizer on the Voice Path"
+description: How a blind CMA equalizer with frozen-snapshot taps, inserted between symbol timing and the differential decoder, roughly doubled CRC-valid TCH/S yield on real concurrent-load TETRA captures — and why the naive way of wiring it drives the decode to exactly zero.
+category: deep-dives
+keywords: cma equalizer, blind equalization tetra, snapshot cma frozen taps, differential decoder equalizer, isi multipath tetra, crc yield vs evm, lms training sequence equalizer, pi/4-dqpsk equalization, gophertrunk tetra
+tags: [tetra-end-to-end, tetra, equalizer, cma, dsp, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "TETRA End to End"
+series_part: 9
+---
+
+*Part 9 of **TETRA End to End**, a 14-part deep dive into how GopherTrunk turns
+one real 25 kHz TETRA carrier into clear recorded voice.
+[Part 8]({{ '/blog/deep-dives/tetra-end-to-end-08-soft-decision-tchs/' | relative_url }})
+stopped throwing away the demod's confidence, and the marginal same-carrier call
+got dramatically better — but not clean. What remained was not noise: the
+π/4-DQPSK constellation on the reporter's concurrent-load captures was *smeared*,
+each symbol dragged by its neighbours. That is a linear channel — multipath,
+band-edge group delay, ISI — and no amount of per-bit confidence fixes it,
+because the symbols themselves are in the wrong places. This part inverts the
+channel: a blind equalizer on the voice path, and the one design constraint that
+makes it survivable in front of a differential decoder.*
+
+> **TL;DR:** The residual garble after soft decision was **linear channel / ISI**
+> smearing the constellation — not front-end degradation. A blind CMA equalizer
+> (**`equalizer.SnapshotCMA`**, wired via the receiver's `EnableEqualizer` in the
+> voice composer) between symbol-timing recovery and the differential decoder
+> roughly **doubled** CRC-valid TCH/S yield across six captures — soft-decision
+> **410→778** (~1.9×), one call **4→207**, another **42→134** — with no loss on
+> already-clean captures. The load-bearing design: **adapt a tracking filter
+> continuously, apply a FROZEN snapshot** refreshed every 200 symbols, because
+> CMA's phase wanders as it adapts and a time-varying phase does not cancel in
+> `s·conj(prev)` — streaming-adaptive CMA drives CRC yield to exactly **zero**.
+> The trained sibling **`SnapshotLMS`** (per-burst midamble training in the
+> `TrafficExtractor`) is staged behind `GT_TETRA_LMS` for capture A/B.
+
+**Key takeaways**
+
+- **CRC yield is the only trustworthy metric; EVM is a trap.** A
+  numerically-unstable CMA variant once showed differential EVM collapsing
+  34%→8% while CRC-valid bursts stayed **0**. Blind CMA minimises *modulus*,
+  not correctness — never conclude an equalizer helps from EVM.
+- **Never feed a continuously-adapting equalizer to a differential decoder.**
+  CMA's cost is rotation-invariant, so its output phase wanders with the taps;
+  the wandering phase corrupts every `s·conj(prev)`. Frozen snapshots impose
+  only a constant phase, which the differential cancels.
+- **Normalise by a constant, not a local EMA.** The CMA update scales with
+  |x|³; an EMA tracking the TDMA downlink's slot-to-slot power swings gives a
+  moving modulus target and CMA converges to garbage. Cumulative-mean
+  normalisation plus a divergence guard keeps it sane.
+- **The equalizer can only help.** Center-spike initialisation means the output
+  is the unmodified input until CMA converges — clean captures measure no
+  regression.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| Blind equalizer | CMA(2,2) tracking + frozen applied snapshot | `internal/dsp/equalizer/snapshot_cma.go` (`SnapshotCMA`) |
+| Receiver wiring | insert between timing recovery and diff decode | `internal/radio/tetra/receiver/receiver.go` (`Options.EnableEqualizer`) |
+| Defaults | 11 taps, µ=6e-3, snapshot every 200 symbols | `receiver.go` (`DefaultEqualizerTaps` / `Mu` / `Snapshot`) |
+| Voice-chain enable | composer turns it on for every TETRA follow | `internal/voice/composer/tetra_voice.go` (`EnableEqualizer: true`) |
+| Divergence guard | re-seed to pass-through if taps blow up | `snapshot_cma.go` (`snapshotDivergeGuard`) |
+| Trained sibling | per-burst midamble-trained LMS, frozen taps | `internal/dsp/equalizer/snapshot_lms.go` (`SnapshotLMS`) |
+| LMS wiring | train on NTS midamble, re-derive soft LLRs | `internal/radio/tetra/traffic.go` (`EnableLMSEqualizer`, `equalizedBurstDiffs`) |
+| Proof | ISI recovery + clean-channel no-harm + capture sweep | `snapshot_cma_test.go`, `receiver_equalizer_test.go`, `traffic_lms_test.go` |
+
+## In this post
+
+- **Diagnosing ISI, not noise** — why the residual garble had structure.
+- **Why plain CMA kills a differential decoder** — the phase-wander failure.
+- **The snapshot trick** — adapt continuously, apply frozen.
+- **Normalisation and the divergence guard** — the two quiet failure modes.
+- **The trained sibling: LMS on the midamble** — staged, not yet default.
+
+## Diagnosing ISI, not noise
+
+After Part 8, the reporter's concurrent-load captures still garbled. The
+tempting diagnosis was the one
+[#764](https://github.com/MattCheramie/GopherTrunk/issues/764) taught us —
+front-end degradation baked into the captured samples. But the signature was
+different. A signal-limited capture is *noisy*: the constellation is a fuzzy
+cloud centered on the right points. These captures showed points dragged into
+crescents and smears — each received symbol a weighted sum of its neighbours.
+That is a **linear channel**: multipath reflections, band-edge group delay from
+the channel filter, ISI. The distinction matters because the remedies are
+disjoint — you cannot equalize thermal noise, and you cannot out-gain ISI. The
+general taxonomy is
+[Weak-Signal Engineering Part 3]({{ '/blog/deep-dives/weak-signal-engineering-03-isi-linear-channel/' | relative_url }});
+here it meant one thing: the fix was a filter, and it had to be *blind*,
+because a voice follow has no training preamble before the speech starts.
+
+## Why plain CMA kills a differential decoder
+
+The classic blind equalizer is CMA — the constant modulus algorithm.
+π/4-DQPSK symbols all sit on the unit circle, so drive an adaptive FIR to make
+its output's modulus constant and it must be inverting whatever smeared the
+ring: `J = E[(|y|² − R²)²]`. The package's plain `CMA` does exactly this and
+works fine ahead of a *coherent* slicer.
+
+Ahead of a differential decoder it is fatal, and the reason is worth engraving.
+CMA's cost function only sees modulus — it is **rotation-invariant**. Nothing
+constrains the equalizer's output phase, so as the taps adapt, that phase
+wanders freely. A coherent receiver's carrier loop tracks the wander out. But
+the differential decode forms `s[n]·conj(s[n−1])`, and a phase that *changes
+between consecutive symbols* does not cancel there — it adds directly to the
+decision angle of every dibit. Measured, not argued: wiring the
+continuously-adapting CMA into the TETRA voice path produced **CRC yield 0**.
+Frozen taps produced baseline. The failure is structural, not a tuning issue —
+[Weak-Signal Engineering Part 4]({{ '/blog/deep-dives/weak-signal-engineering-04-blind-cma/' | relative_url }})
+derives it from the cost function.
+
+## The snapshot trick
+
+The resolution is to separate adapting from applying:
+
+```go
+// internal/dsp/equalizer/snapshot_cma.go (shape) — Process
+// Output uses the frozen filter (phase-coherent between snapshots).
+var y complex64
+for k := 0; k < n; k++ {
+    y += e.wApply[k] * e.buf[n-1-k]
+}
+// Adapt the tracking filter by CMA(2,2): e = ya·(|ya|² − 1).
+var ya complex64
+for k := 0; k < n; k++ {
+    ya += e.wAdapt[k] * e.buf[n-1-k]
+}
+/* … CMA tap update on wAdapt, divergence guard … */
+if e.since++; e.since >= e.snapEvery {
+    copy(e.wApply, e.wAdapt) // refresh the frozen snapshot
+    e.since = 0
+}
+```
+
+`wAdapt` updates every sample and its phase wanders — it is never applied.
+`wApply` is a snapshot of it refreshed every `snapEvery` samples (200 by
+default, ≫ a 255-symbol burst's data span) and is the filter the output
+actually sees. Held fixed, `wApply` imposes only a *constant* phase and scale —
+exactly what the differential decode cancels by construction — while still
+inverting the channel. The one symbol per snapshot that straddles the refresh
+sees a phase step; the FEC absorbs a dibit or two per 200. And because
+`wApply` starts as a center spike, the pre-convergence output is the unmodified
+input: on a clean capture the equalizer is a near-noop, which is why the sweep
+measured **no loss** where there was nothing to fix. The pattern is general
+enough that it earned its own theory post —
+[Weak-Signal Engineering Part 5]({{ '/blog/deep-dives/weak-signal-engineering-05-snapshot-trick/' | relative_url }}).
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 210" width="680" height="210" role="img" aria-label="Block diagram of the snapshot CMA equalizer. The normalised input feeds two FIR filters in parallel: a tracking filter whose taps adapt on every sample by the CMA rule and whose output phase wanders, and an applied filter whose taps are a frozen copy refreshed every two hundred symbols. Only the frozen filter's output goes to the differential decoder, so between snapshots the decoder sees a constant phase that cancels in s times conjugate of previous s.">
+  <rect x="8" y="80" width="120" height="48" rx="6" fill="none" stroke="currentColor"/>
+  <text x="68" y="100" text-anchor="middle" fill="currentColor" font-size="10">input symbols</text>
+  <text x="68" y="114" text-anchor="middle" fill="var(--fg-muted)" font-size="9">cumulative-mean norm</text>
+  <line x1="128" y1="92" x2="168" y2="52" stroke="var(--fg-muted)"/><polygon points="164,50 176,48 168,60" fill="var(--fg-muted)"/>
+  <line x1="128" y1="116" x2="168" y2="156" stroke="var(--accent)"/><polygon points="170,150 176,162 162,158" fill="var(--accent)"/>
+  <rect x="178" y="20" width="180" height="52" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="268" y="40" text-anchor="middle" fill="var(--fg-muted)" font-size="10">wAdapt — tracks every sample</text>
+  <text x="268" y="56" text-anchor="middle" fill="var(--fg-muted)" font-size="9">phase wanders: NEVER applied</text>
+  <rect x="178" y="140" width="180" height="52" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="268" y="160" text-anchor="middle" fill="var(--accent)" font-size="10">wApply — frozen snapshot</text>
+  <text x="268" y="176" text-anchor="middle" fill="var(--fg-muted)" font-size="9">constant phase between copies</text>
+  <line x1="268" y1="72" x2="268" y2="132" stroke="var(--fg-muted)" stroke-dasharray="4 3"/><polygon points="264,132 268,142 272,132" fill="var(--fg-muted)"/>
+  <text x="282" y="106" fill="var(--fg-muted)" font-size="9">copy every 200 symbols</text>
+  <line x1="358" y1="166" x2="404" y2="166" stroke="var(--accent)"/><polygon points="404,162 414,166 404,170" fill="var(--accent)"/>
+  <rect x="414" y="140" width="150" height="52" rx="6" fill="none" stroke="currentColor"/>
+  <text x="489" y="160" text-anchor="middle" fill="currentColor" font-size="10">differential decode</text>
+  <text x="489" y="176" text-anchor="middle" fill="var(--fg-muted)" font-size="9">s·conj(prev) — constant phase cancels</text>
+  <line x1="564" y1="166" x2="606" y2="166" stroke="currentColor"/><polygon points="606,162 616,166 606,170" fill="currentColor"/>
+  <text x="644" y="162" text-anchor="middle" fill="currentColor" font-size="10">dibits +</text>
+  <text x="644" y="176" text-anchor="middle" fill="currentColor" font-size="10">LLRs</text>
+  <text x="330" y="205" text-anchor="middle" fill="var(--fg-muted)" font-size="10">adapt continuously, apply frozen — the only wiring of blind CMA a differential decoder survives</text>
+</svg>
+<figcaption>SnapshotCMA keeps two tap sets: the tracking filter adapts every sample, the applied filter is a frozen copy — so the differential decoder only ever sees a constant phase.</figcaption>
+</figure>
+
+## Normalisation and the divergence guard
+
+Two quieter failure modes cost real time before the yield numbers appeared,
+and both are pinned by `snapshot_cma_test.go`.
+
+**Normalisation.** The CMA tap update scales with |x|³, so the input must be
+normalised toward unit power for the `R² = 1` target to mean anything. The
+obvious choice — a local EMA power estimate — is wrong for TETRA specifically:
+the TDMA downlink's power swings slot to slot, an EMA tracks the swings, and a
+*moving* modulus target makes CMA converge to garbage (CRC 0, again, even
+though a global-RMS normalise gave the full win). `SnapshotCMA` instead divides
+by a **cumulative mean** — `cumSum/count`, converging to the whole-session RMS
+and then staying put. A constant scale is a constant target.
+
+**Divergence.** A normalisation transient or a deep fade can blow the tracking
+taps up; without a guard, one bad patch poisons every later snapshot. The guard
+is blunt and effective — if any tap's squared magnitude exceeds
+`snapshotDivergeGuard` (|tap| > 3), the tracking filter re-seeds to a center
+spike and starts over. The applied filter keeps its last sane snapshot in the
+meantime. The general pattern is
+[Weak-Signal Engineering Part 6]({{ '/blog/deep-dives/weak-signal-engineering-06-normalisation-guards/' | relative_url }}).
+
+The verdict metric for all of it: **CRC-valid TCH/S bursts**, never EVM
+([Weak-Signal Engineering Part 2]({{ '/blog/deep-dives/weak-signal-engineering-02-metrics-that-lie/' | relative_url }})
+is the full indictment). Across the six reporter captures: soft-decision yield
+**410→778** (~1.9×), one call **4→207**, another **42→134**, clean captures
+unchanged. The composer enables it for every TETRA voice follow
+(`EnableEqualizer: true` in `runTETRAVoiceChain`), alongside the voice-only
+`EnableDCBlock` — a distinction Part 10 returns to on the control-channel side.
+
+## The trained sibling: LMS on the midamble
+
+Blind CMA pins only the modulus; a *training sequence* pins the channel inverse
+exactly, phase and all. Every TETRA burst carries a known 11-dibit midamble
+(NTS1/NTS2), and the #1001 follow-up wires a trained equalizer around it:
+`TrafficExtractor.EnableLMSEqualizer` trains an `equalizer.SnapshotLMS` on each
+burst's midamble, freezes the taps (the same differential-safety principle),
+equalizes the BKN1..BKN2 span with a taps-long FIR warm-up, and **re-derives the
+soft LLRs from the equalized symbols** — the hard frame is untouched:
+
+```go
+// internal/radio/tetra/traffic.go (shape) — equalizedBurstDiffs
+ref := te.midambleRef(L, ntsLen)         // ideal midamble from a unit anchor
+rx := te.symBuf[m0 : m0+ntsLen+1]        // raw symbols via StashSymbols
+te.lms.Reset()
+te.lms.Train(rx, ref, te.lmsPasses)      // 80 passes over 11 dibits
+span := te.lms.Equalize(te.lmsSpan[:0], te.symBuf[s0:s1])
+/* … differential-decode consecutive equalized symbols → 216 diffs … */
+```
+
+The subtlety: the linear channel is a clean convolution only in the **raw
+symbol** domain — `s·conj(prev)` is a nonlinear product in which it is not —
+so the extractor carries raw symbols down a second parallel buffer
+(`SymbolSink → StashSymbols`, the symbol analog of Part 8's soft bridge). The
+reference is differentially encoded from an arbitrary unit anchor, because a
+constant start-phase rotation cancels downstream — the same property that makes
+frozen snapshots safe. `traffic_lms_test.go` pins synthetic multipath through
+the real extractor at raw **13% → 0%** payload bit-error with no harm on clean.
+It is opt-in and soft-path-only: production composers still run CMA alone, and
+`GT_TETRA_LMS=1` in `TestTETRAMultiSlotReplay` runs the capture A/B (compare
+`traffic_marked_crc_soft`) that gates flipping it on.
+[Weak-Signal Engineering Part 7]({{ '/blog/deep-dives/weak-signal-engineering-07-trained-lms/' | relative_url }})
+owns the trained-equalization theory.
+
+## Where this goes next
+
+The voice path now stacks three levers on a marginal carrier: soft decisions,
+a blind equalizer, and a staged trained one. But the *control channel* — the
+thing every voice follow depends on — was quietly running with none of them in
+one specific configuration, and a reporter's one-hour session showed exactly
+what that costs: ~210 control-channel transitions and 11 hard sync losses.
+[Part 10]({{ '/blog/deep-dives/tetra-end-to-end-10-control-channel-sync-loss/' | relative_url }})
+reads that session's forensics, rules out the compute theory, and finds the one
+TETRA CC path that wasn't running SnapshotCMA.
+
+## FAQ
+
+**How do I know my garble is ISI and not a weak signal?**
+Look at the constellation and the yield pattern. Noise fuzzes points
+symmetrically and degrades everything at once; ISI smears points into
+structured crescents and hits the differential decode hardest. Practically: if
+the equalizer roughly doubles CRC yield, it was ISI; if nothing moves, revisit
+gain and antenna ([#764](https://github.com/MattCheramie/GopherTrunk/issues/764)'s
+lesson — the equalizer mitigates a channel, not a front end).
+
+**Why not just use the LMS equalizer everywhere and skip CMA?**
+Different niches. CMA is framing-free — it runs in the receiver on the
+continuous stream with no idea where bursts sit, which is what the control
+channel and the pre-lock voice path need. LMS needs the midamble location, so
+it lives in the extractor, per burst. And LMS is still gated on a capture A/B
+(`GT_TETRA_LMS=1`) before it becomes a production default.
+
+**What does the equalizer cost on a clean signal?**
+Measurably nothing but CPU. Center-spike initialisation makes the
+pre-convergence output the unmodified input, and on a clean ring CMA's gradient
+is near zero, so the taps stay near pass-through.
+`TestReceiverEqualizerCleanChannelNoHarm` pins it — with one caveat: a
+literally noise-free constant-modulus synthetic is a degenerate CMA input, so
+the test adds 30 dB AWGN to be a fair fixture.
+
+**Why 200 symbols between snapshots?**
+It must be long against a burst (so each 255-dibit burst's data span sees one
+constant filter — the straddling symbol is FEC noise) and short against the
+channel's drift. 200 at 18 ksym/s refreshes ~90×/s, plenty for the slowly
+varying multipath these captures show, and converges within a few hundred
+symbols from cold.
+
+**Could the equalizer hide a real RF problem?**
+It can mask moderate ISI from a bad antenna path, which is why the health
+metrics still surface the underlying quality. The rule stands: raise the
+signal too. An equalizer buys back the linear channel, never the noise floor.
+
+## Series navigation
+
+**Part 9 of 14** · ←
+[Part 8: Going Soft — Soft-Decision TCH/S]({{ '/blog/deep-dives/tetra-end-to-end-08-soft-decision-tchs/' | relative_url }})
+· Next →
+[Part 10: The Control Channel Under Stress — Sync Loss & the CC Equalizer]({{ '/blog/deep-dives/tetra-end-to-end-10-control-channel-sync-loss/' | relative_url }})

--- a/docs/_posts/2026-08-26-weak-signal-engineering-09-parallel-buffers.md
+++ b/docs/_posts/2026-08-26-weak-signal-engineering-09-parallel-buffers.md
@@ -1,0 +1,341 @@
+---
+title: "Weak-Signal Engineering, Part 9: Parallel Buffers — SymbolSink, SoftSink & Opt-In Soft Paths"
+description: The architecture pattern that let equalizers and soft-decision FEC land safely — LLR differentials and raw symbols carried strictly parallel to the hard dibit buffer, a stash bridge keyed by base index, and a byte-identical opt-out pinned by failing-first tests.
+category: deep-dives
+keywords: opt-in dsp architecture, parallel soft buffer, symbol sink, soft sink, byte-identical fallback, stash bridge, tetra traffic extractor, safe dsp refactoring, gophertrunk weak-signal engineering
+tags: [weak-signal-engineering, architecture, soft-decision, dsp, tetra, testing, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Weak-Signal Engineering"
+series_part: 9
+---
+
+*Part 9 of **Weak-Signal Engineering**, a 14-part series on decoding the
+marginal regime — where the receiver locks but only a fraction of frames
+survive. [Part 8]({{ '/blog/deep-dives/weak-signal-engineering-08-soft-decisions/' | relative_url }})
+carried per-bit LLRs through depuncture and a correlation-metric Viterbi and
+recovered the ~70% of marginal bursts the hard gate was dropping. But that
+post glossed over a harder question: how do you thread new soft and equalized
+data through a burst extractor that a fleet of working configurations already
+depends on — without risking any of them? This is the engineering-process
+part of the series: the parallel-buffer pattern, the stash bridge, the
+fallback ladder, and the one property that made every risky DSP change in
+Parts 4–8 landable: **no sinks wired ⇒ byte-identical legacy behaviour.***
+
+> **TL;DR:** New DSP information travels in **parallel buffers, never in
+> modified ones**. The TETRA receiver's `Options.SoftSink` (complex
+> differentials — the LLR source) and `Options.SymbolSink` (raw
+> pre-differential symbols — the equalizer's training domain) fire just before
+> the matching `DibitSink` call, aligned 1:1 and keyed by the same `baseIdx`.
+> The `tetra.TrafficExtractor` stashes them (`StashSoft` / `StashSymbols`)
+> into `softBuf` / `symBuf` held **strictly parallel** to its hard dibit
+> buffer, and `softFrame` walks a fallback ladder: equalized differentials →
+> raw differentials → nil (hard-only). A nil sink costs zero; a caller that
+> never stashes is **byte-identical** to the pre-soft code — a property pinned
+> by regression tests, not asserted in a comment.
+
+**Key takeaways**
+
+- **Additive, not intrusive.** The hard `DibitSink` contract never changed
+  through four generations of DSP upgrades. Soft LLRs and raw symbols ride
+  beside the dibits, so every existing caller compiles, runs, and produces the
+  same bytes.
+- **The two sinks exist because the two domains are different.** LLRs live in
+  the differential domain (right for the FEC); a linear channel is only a
+  convolution in the raw-symbol domain (right for a trained equalizer —
+  [Part 3]({{ '/blog/deep-dives/weak-signal-engineering-03-isi-linear-channel/' | relative_url }})'s
+  fact, made structural).
+- **Fallback is a ladder, and every rung is total.** Equalized-soft → soft →
+  hard: a burst missing its symbol span falls to raw LLRs; a burst missing
+  LLRs falls to the hard frame; nothing errors, nothing is silently worse
+  than the old code.
+- **"Byte-identical opt-out" is a testable claim.** Tests literally run the
+  extractor with and without sinks and compare outputs — which is what lets a
+  blind equalizer or a soft Viterbi land on a Tuesday without an on-air
+  regression risk.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| Soft source | differentials `s·conj(last)`, 1:1 with dibits | `internal/radio/tetra/receiver/receiver.go` (`Options.SoftSink`) |
+| Symbol source | raw post-timing/AFC symbols, 1:1 with dibits | `receiver.go` (`Options.SymbolSink`) |
+| Stash bridge | hold one call's soft/symbols for the next `Process` | `internal/radio/tetra/traffic.go` (`StashSoft`, `StashSymbols`) |
+| Parallel buffers | `softBuf`/`symBuf` strictly parallel to `buf` | `traffic.go` (`TrafficExtractor`) |
+| Fallback ladder | equalized diffs → raw diffs → nil | `traffic.go` (`softFrame`, `equalizedBurstDiffs`, `rawBurstDiffs`) |
+| Composer rung | soft frames when LLRs exist, else hard | `internal/voice/composer/tetra_voice.go` (`decodeTETRASpeech`) |
+| Opt-out pin | no sinks ⇒ identical output | `traffic_lms_test.go` (`TestTrafficExtractorSoftUnchangedWithoutEqualizer`), `dmo_equalizer_test.go` (`TestExtractDMBurstsEqualizedNoSymbolsUnchanged`) |
+
+## In this post
+
+- **The constraint** — risky DSP over a working fleet.
+- **Two sinks, one dibit contract** — why the receiver grew callbacks, not flags.
+- **The stash bridge** — how `baseIdx` keeps three buffers in lockstep.
+- **The fallback ladder** — total functions all the way down.
+- **Byte-identical opt-out** — the property, and the tests that pin it.
+
+## The constraint: risky DSP over a working fleet
+
+Every lever in this series so far — blind CMA
+([Part 4]({{ '/blog/deep-dives/weak-signal-engineering-04-blind-cma/' | relative_url }})),
+frozen snapshots ([Part 5]({{ '/blog/deep-dives/weak-signal-engineering-05-snapshot-trick/' | relative_url }})),
+trained LMS ([Part 7]({{ '/blog/deep-dives/weak-signal-engineering-07-trained-lms/' | relative_url }})),
+soft FEC ([Part 8]({{ '/blog/deep-dives/weak-signal-engineering-08-soft-decisions/' | relative_url }})) —
+is exactly the kind of change that breaks working systems. Adaptive filters
+have failure modes that only appear on air. Soft paths double the data flowing
+through a burst extractor. And the extractor in question,
+`tetra.TrafficExtractor`, sits in the live voice path of every TETRA
+configuration in the field.
+
+The classic responses are both bad. Fork the extractor into a "v2" and you
+maintain two decoders that drift apart. Thread the new data through the
+existing types — change `DibitSink` to carry a struct of dibits-plus-LLRs —
+and every caller changes, every test fixture changes, and the diff that lands
+a 2 dB decoding improvement also touches thirty files that had nothing wrong
+with them. GopherTrunk took a third route, and it is the reason four
+generations of demod-side upgrades landed without a single change to the hard
+contract: **new information travels beside the old, in buffers that may
+simply not exist.**
+
+## Two sinks, one dibit contract
+
+The receiver's options grew two optional callbacks. Neither changes what
+`DibitSink` receives; both are documented as zero-overhead when nil:
+
+```go
+// internal/radio/tetra/receiver/receiver.go (shape) — Options
+// SoftSink, when non-nil, receives the complex π/4-DQPSK differential
+// (s·conj(last)) for each symbol, aligned 1:1 with the dibits emitted
+// to DibitSink and carrying the same baseIdx. … Emitted just before the
+// matching DibitSink call. nil ⇒ no soft emission, zero overhead.
+SoftSink func(diffs []complex64, baseIdx int)
+// SymbolSink, when non-nil, receives the RAW post-timing/AFC/equalizer
+// complex symbols (before the differential decode) … Unlike the SoftSink
+// differential (a nonlinear product s·conj(last), in which the channel is
+// no longer a clean convolution), the symbol stream is where a linear
+// channel IS a convolution — so it is the input a training-sequence
+// equalizer … must train on and equalize per burst.
+SymbolSink func(symbols []complex64, baseIdx int)
+```
+
+Why two? Because the two consumers need different domains, and the difference
+is mathematical, not organisational. The soft Viterbi wants the differential —
+that is where the on-air bits' LLRs live. But the trained LMS equalizer of
+Part 7 *cannot* work there: the differential `s·conj(prev)` is a nonlinear
+product of two channel-affected symbols, and a linear channel stops being a
+clean convolution the moment you form it. The equalizer must see the raw
+symbols. One stream cannot serve both, so both are emitted — each 1:1 with
+the dibits, each tagged with the same `baseIdx`, each skippable.
+
+The wiring at a call site is one closure per sink, as in the control-channel
+pipeline:
+
+```go
+// internal/scanner/ccdecoder/pipelines.go (shape) — newTETRAPipeline
+rx := tetrarx.New(tetrarx.Options{
+    SampleRateHz: opts.SampleRateHz,
+    DibitSink: func(dibits []uint8, baseIdx int) {
+        opts.tapDibits(dibits, baseIdx)
+        cc.Process(dibits, baseIdx)
+    },
+    // Soft differentials for soft-decision channel decoding, stashed
+    // just before the matching DibitSink → Process call.
+    SoftSink: func(diffs []complex64, baseIdx int) {
+        cc.StashSoft(diffs, baseIdx)
+    },
+    /* … ClockMode, EnableAFC, EnableChannelFilter, EnableEqualizer … */
+})
+```
+
+## The stash bridge
+
+The sinks fire *before* the matching `DibitSink` call, and the extractor's
+`Process` runs *inside* that call — so the soft data for a chunk of dibits
+must be parked somewhere until the dibits arrive. That is the stash bridge:
+
+```go
+// internal/radio/tetra/traffic.go (shape) — the stash half
+func (te *TrafficExtractor) StashSoft(diffs []complex64, baseIdx int) {
+    te.pendingSoft = diffs
+    te.pendingSoftBase = baseIdx
+}
+
+func (te *TrafficExtractor) StashSymbols(syms []complex64, baseIdx int) {
+    te.pendingSym = syms
+    te.pendingSymBase = baseIdx
+}
+```
+
+Each stash holds exactly one pending chunk, keyed by the `baseIdx` the next
+`Process` call will deliver — and `Process` consumes it once, appending to
+`softBuf`/`symBuf` in lockstep with the hard `buf`. The invariant the whole
+design rests on is blunt: `len(softBuf)` is either **zero** (a caller that
+never stashes) or **exactly `len(buf)`** — and the same for `symBuf`. There
+is no partially-soft state. Both parallel buffers share `buf`'s base offset
+(`bufBase`) and are trimmed together, so an index into the dibit buffer is an
+index into its soft twin, forever. Everything runs on the receiver's single
+`Process` goroutine, so the bridge needs no locks — sequencing does the work.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 230" width="680" height="230" role="img" aria-label="Block diagram of the parallel-buffer pattern. The receiver emits three aligned streams per chunk: SymbolSink raw symbols, SoftSink differentials, and DibitSink hard dibits, all sharing one baseIdx. The two optional streams pass through StashSymbols and StashSoft into symBuf and softBuf, held parallel to the hard dibit buffer buf inside the TrafficExtractor. A fallback ladder on the right reads equalized differentials first, then raw differentials, then falls to hard-only decode.">
+  <rect x="8" y="76" width="110" height="60" rx="6" fill="none" stroke="currentColor"/>
+  <text x="63" y="100" text-anchor="middle" fill="currentColor" font-size="10">receiver</text>
+  <text x="63" y="114" text-anchor="middle" fill="var(--fg-muted)" font-size="8">one Process goroutine</text>
+  <line x1="118" y1="90" x2="180" y2="52" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <line x1="118" y1="106" x2="180" y2="106" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <line x1="118" y1="122" x2="180" y2="160" stroke="currentColor"/>
+  <text x="149" y="44" fill="var(--fg-muted)" font-size="8">SymbolSink (opt)</text>
+  <text x="132" y="99" fill="var(--fg-muted)" font-size="8">SoftSink (opt)</text>
+  <text x="138" y="156" fill="currentColor" font-size="8">DibitSink</text>
+  <rect x="182" y="34" width="120" height="34" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="242" y="55" text-anchor="middle" fill="var(--fg-muted)" font-size="9">StashSymbols</text>
+  <rect x="182" y="88" width="120" height="34" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="242" y="109" text-anchor="middle" fill="var(--fg-muted)" font-size="9">StashSoft</text>
+  <rect x="330" y="24" width="150" height="52" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="405" y="45" text-anchor="middle" fill="var(--accent)" font-size="10">symBuf []complex64</text>
+  <text x="405" y="62" text-anchor="middle" fill="var(--fg-muted)" font-size="8">len 0 or len(buf)</text>
+  <rect x="330" y="86" width="150" height="52" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="405" y="107" text-anchor="middle" fill="var(--accent)" font-size="10">softBuf []complex64</text>
+  <text x="405" y="124" text-anchor="middle" fill="var(--fg-muted)" font-size="8">len 0 or len(buf)</text>
+  <rect x="330" y="148" width="150" height="52" rx="6" fill="none" stroke="currentColor"/>
+  <text x="405" y="169" text-anchor="middle" fill="currentColor" font-size="10">buf (hard dibits)</text>
+  <text x="405" y="186" text-anchor="middle" fill="var(--fg-muted)" font-size="8">the unchanged contract</text>
+  <line x1="302" y1="51" x2="330" y2="51" stroke="var(--fg-muted)"/>
+  <line x1="302" y1="105" x2="330" y2="105" stroke="var(--fg-muted)"/>
+  <line x1="248" y1="160" x2="330" y2="171" stroke="currentColor"/>
+  <rect x="516" y="76" width="156" height="96" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="594" y="96" text-anchor="middle" fill="var(--accent)" font-size="10">softFrame ladder</text>
+  <text x="594" y="114" text-anchor="middle" fill="var(--fg-muted)" font-size="9">1. equalizedBurstDiffs</text>
+  <text x="594" y="130" text-anchor="middle" fill="var(--fg-muted)" font-size="9">2. rawBurstDiffs</text>
+  <text x="594" y="146" text-anchor="middle" fill="var(--fg-muted)" font-size="9">3. nil → hard-only</text>
+  <line x1="480" y1="112" x2="516" y2="112" stroke="var(--accent)"/>
+  <text x="340" y="222" text-anchor="middle" fill="var(--fg-muted)" font-size="10">no sinks wired ⇒ softBuf and symBuf stay empty ⇒ byte-identical to the pre-soft extractor</text>
+</svg>
+<figcaption>Three streams, one index space: the optional symbol and soft buffers ride strictly parallel to the hard dibit buffer, and the fallback ladder degrades one rung at a time.</figcaption>
+</figure>
+
+## The fallback ladder
+
+When a burst is ready to emit, `softFrame` builds its 432-LLR type-5 stream —
+or declines to, one rung at a time:
+
+```go
+// internal/radio/tetra/traffic.go (shape) — softFrame
+func (te *TrafficExtractor) softFrame(L int) []float32 {
+    if len(te.softBuf) != len(te.buf) {
+        return nil // no LLRs were ever stashed: hard-only caller
+    }
+    // Prefer the training-sequence-equalized differentials when the
+    // equalizer is enabled and this burst's raw symbol span is fully
+    // buffered; otherwise use the receiver's raw differentials.
+    diffs := te.equalizedBurstDiffs(L)
+    if diffs == nil {
+        diffs = te.rawBurstDiffs(L)
+    }
+    if diffs == nil {
+        return nil
+    }
+    llr := softType5FromDiffs(diffs, 0)
+    if te.colourCode != 0 {
+        llr = framing.DescrambleTetraSoft(llr, te.colourCode)
+    }
+    return llr
+}
+```
+
+Read the rungs. `equalizedBurstDiffs` returns nil whenever
+`EnableLMSEqualizer` was never called, no symbols were stashed, or this
+particular burst's symbol span (including the FIR warm-up) is not fully
+buffered — so the equalizer is a no-op unless *both* halves of its opt-in are
+in play. `rawBurstDiffs` returns nil when the soft buffer doesn't cover the
+burst. And a nil `softFrame` simply means the burst is emitted hard-only —
+`onBurst` always carries the hard frame beside the (possibly nil) soft one,
+and the composer's `decodeTETRASpeech` completes the ladder: soft frames when
+`softType5 != nil`, the hard `TCHSpeechFrames` gate otherwise. Every rung is
+a total function; a degraded input degrades the output by one rung, never to
+an error and never below the pre-soft baseline.
+
+## Byte-identical opt-out — the property, and its tests
+
+The claim "a caller that never stashes is unchanged" is cheap to write in a
+doc comment and worth little there. What makes it load-bearing is that it is
+*pinned*: `TestTrafficExtractorSoftUnchangedWithoutEqualizer`
+(`internal/radio/tetra/traffic_lms_test.go`) runs the extractor over the same
+burst stream with and without the new machinery and requires identical soft
+output, and `TestExtractDMBurstsEqualizedNoSymbolsUnchanged`
+(`dmo_equalizer_test.go`) does the same for the Direct Mode path — alongside
+the improvement pins (`TestTrafficExtractorLMSRecoversMultipathBurst`:
+synthetic multipath through the real extractor, raw 13% → 0% payload
+bit-error) and the no-harm pins (`TestTrafficExtractorLMSNoHarmOnCleanChannel`).
+
+That triple — *improves the bad case, doesn't touch the clean case, is
+byte-identical when off* — is the shape of every safely-landable DSP change
+in this series, and the parallel-buffer pattern is what makes the third leg
+provable rather than hoped-for. Compare the alternative: had LLRs been woven
+into the dibit type, "off" would not be a state the type system could even
+express, and the only evidence of safety would be a full re-run of every
+on-air configuration.
+
+### How that principle shaped the Go code
+
+- **nil is the feature flag.** No config knob decides whether soft decoding
+  happens — wiring a sink does. The zero value of the system is the legacy
+  system, so the safest state is also the default state.
+- **Invariants over checks.** `softBuf` is empty or exactly parallel — the
+  extractor maintains that in one place (`Process`) instead of length-checking
+  at every use, and `softFrame`'s single guard is the whole enforcement.
+- **The ladder lives in one function.** Fallback priority is not scattered
+  across call sites; `softFrame` is the only place that ranks equalized over
+  raw over nothing, so the policy is readable — and changeable — in one diff.
+
+## Where this goes next
+
+Everything so far has squeezed more out of one antenna. The next two parts
+add a second one.
+[Part 10]({{ '/blog/deep-dives/weak-signal-engineering-10-mrc-calibration/' | relative_url }})
+opens the diversity pair: maximal-ratio combining, why one wideband complex
+gain is both the opportunity and the caveat, and the coherence-gated
+calibration — `CrossStats`, `|rho| = γ/(1+γ)`, and the DC-removal detail that
+turns out to be load-bearing — that decides when combining can be trusted at
+all.
+
+## FAQ
+
+**Why sinks and stashes instead of returning richer values from the receiver?**
+The receiver's emission points and the extractor's consumption points are on
+opposite sides of an existing callback boundary crossed by many other callers.
+Callbacks that default to nil extend that boundary without moving it; a richer
+return type would move it for everyone, including the callers that want
+nothing new.
+
+**What stops the soft buffer drifting out of alignment with the dibits?**
+Sequencing plus a hard invariant. Sinks fire immediately before their matching
+`DibitSink` call on the same goroutine, the stash is consumed exactly once by
+the next `Process`, both buffers share the same base offset and trims, and
+`softFrame` refuses to operate unless `len(softBuf) == len(buf)`. Misalignment
+degrades to hard-only decode; it cannot silently mis-map LLRs.
+
+**Does an unwired sink really cost nothing?**
+Yes — a nil callback is never invoked, no soft or symbol slices are
+allocated, and the parallel buffers stay empty. The cost exists only for
+callers that opted in, which is what lets the control-channel, voice, and DMO
+paths each choose independently.
+
+**Why does the composer get its own fallback rung?**
+Because the extractor can produce a hard frame with no soft twin (early
+bursts, trimmed windows). The composer deciding "soft if present, hard
+otherwise" per burst means one degraded burst degrades alone rather than
+switching the whole call's mode.
+
+**Could this pattern carry other data — say, per-burst quality metrics?**
+That is exactly its shape: anything aligned 1:1 with the dibits and keyed by
+`baseIdx` can ride a third parallel buffer without touching the hard
+contract. The pattern's cost is one invariant per buffer; its payoff is that
+"off" remains the identity function.
+
+## Series navigation
+
+**Part 9 of 14** · ←
+[Part 8: Soft Decisions — LLRs Through Depuncture & Viterbi]({{ '/blog/deep-dives/weak-signal-engineering-08-soft-decisions/' | relative_url }})
+· Next →
+[Part 10: Diversity I — MRC & Coherence-Gated Calibration]({{ '/blog/deep-dives/weak-signal-engineering-10-mrc-calibration/' | relative_url }})

--- a/docs/_posts/2026-08-27-analog-edge-10-capture-discipline.md
+++ b/docs/_posts/2026-08-27-analog-edge-10-capture-discipline.md
@@ -1,0 +1,271 @@
+---
+title: "The Analog Edge, Part 10: Capture Discipline — cfile, cs16, SigMF & Metadata"
+description: "Why \"get the raw capture\" is the most repeated sentence in the GopherTrunk issue tracker, the IQ formats and sidecar metadata that make a capture usable, the tap points that decide what a recording can prove, and how a good capture turns a complaint into a regression test."
+category: tutorials
+keywords: sdr iq capture, cfile format, cs16 raw iq, sigmf metadata, capture sample rate, iq recording sidecar, replay capture gophertrunk, pre-combine diversity capture, gophertrunk analog edge
+tags: [analog-edge, capture, iq, formats, metadata, workflow]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "The Analog Edge"
+series_part: 10
+---
+
+*Part 10 of **The Analog Edge**, a 14-part field guide to the analog half of a
+GopherTrunk system. [Part 9]({{ '/blog/tutorials/analog-edge-09-filters-lnas/' | relative_url }})
+finished the hardware chain — antenna, feedline, filter, LNA, in the right
+order. Our marginal reader's system is better, but one symptom survives, and
+we've reached the point where arguing about it is worthless. This part is
+about the skill that settles arguments: recording the actual samples. Half the
+hard bugs in this project's tracker were "in the samples" — and every one of
+them was solved the day someone captured them.*
+
+> **TL;DR:** A useful capture is **raw IQ, at the same rate and gain as the
+> failure, with a sidecar that says what it is**. GopherTrunk's formats:
+> `.cfile` (GNU Radio float32, 8 bytes/sample), **cs16** (int16, 4
+> bytes/sample — the default for `baseband.auto_record`), and `u8` (rtl_sdr
+> native); none embeds rate or frequency, so a `.metadata.json` sidecar
+> (`sample_rate_hz`, `center_freq_hz`) is **mandatory**, and `gophertrunk
+> capture` writes one automatically (plus an optional SigMF sidecar via
+> `-bundle -sigmf`). Tap point decides what a capture can prove: post-demod
+> audio proves nothing for phase modulations, post-combine IQ can't evaluate a
+> combiner, and only `diversity_capture`'s pre-combine tap answers diversity
+> questions. Done right, a capture becomes a skip-gated regression test in
+> `samples/` that keeps the bug fixed forever.
+
+**Key takeaways**
+
+- **Audio is not a capture.** For TETRA (π/4-DQPSK), P25, DMR, NXDN — anything
+  carrying information in phase or 4-level amplitude — an MP3/WAV of demodulated
+  audio has already destroyed the evidence. It must be IQ.
+- **Capture the failure, not a nicer version of it.** Same sample rate, same
+  gain, same antenna. The [#764](https://github.com/MattCheramie/GopherTrunk/issues/764)
+  deficit only existed in 10 MS/s captures — a "cleaner" 2.5 MS/s recording
+  would have proven the bug didn't exist.
+- **A capture without a sidecar is a puzzle, not evidence.** Headerless IQ has
+  no rate, no center frequency, no provenance; the loader can't even guess.
+  `sample_rate_hz` and `center_freq_hz` are the two non-negotiable fields.
+- **The tap point is part of the experiment design.** Wideband tap, per-channel
+  `ddc` tap, pre-combine branch tap — each answers different questions, and
+  picking the wrong one produces a file that answers none.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| One-shot manual capture | live SDR → `.cfile`/cs16 + metadata sidecar | `gophertrunk capture` (`cmd/gophertrunk/capture.go`) |
+| Event-driven capture | auto-record IQ on sync loss, encrypted grant, … | `baseband.auto_record` (`config.example.yaml`) |
+| Replay a capture | run any capture through the real decode path | `gophertrunk replay -in <f> -format u8\|f32\|cs16\|wav` |
+| Shrink for sharing | post-DDC narrowband WAV of the exact decoded stream | `replay -record-ddc` |
+| SigMF interop | emit a `.sigmf-meta` sidecar for external tooling | `gophertrunk capture -bundle <p> -sigmf` (`internal/gtbundle/sigmf.go`) |
+| Pre-combine diversity tap | per-branch IQ before the MRC combiner | `sdr.soapy_remote[].diversity_capture` (`internal/sdr/soapyremote/branchcapture.go`) |
+| What each decoder needs | per-protocol format / rate / duration / pass bar | [decoder capture needs]({{ '/decoder-capture-needs.html' | relative_url }}), `samples/*/README.md` |
+
+## In this post
+
+- **Why the tracker keeps asking for captures** — evidence vs anecdote.
+- **The formats** — cfile, cs16, u8, WAV, and what each costs.
+- **The sidecar** — metadata that makes a file mean something.
+- **Tap points** — wideband, ddc, and the pre-combine rule.
+- **From capture to regression test** — how a file keeps a bug fixed.
+
+## Why the tracker keeps asking for captures
+
+"Please attach the raw capture" is the most repeated sentence in this
+project's issue tracker, and it isn't bureaucracy. A symptom report is a
+description of one observer's decode chain on one afternoon. A capture is the
+*input itself* — replayable through any build, any branch, any candidate fix,
+forever. The difference decided every hard case this series has drawn on: the
+[ten-megasamples investigation]({{ '/blog/solution-postmortem/from-the-issue-tracker-05-ten-megasamples/' | relative_url }})
+lived and died by the reporter's own `.cfile`s (the ~10 dB deficit was *in the
+captured samples*, provable only by replaying them); the
+[rail-pinned ADC]({{ '/blog/solution-postmortem/from-the-issue-tracker-08-nineteen-dibits/' | relative_url }})
+overturned a beautifully argued hypothesis because the raw capture was 50%
+pinned to the rails; and the DMR two-slot work stalled for lack of one — the
+only IQ grab available was a dead file at ~−75 dBFS RMS with no frame sync,
+which could confirm nothing. A capture converts "it sounds bad on my system"
+into a question with a reproducible answer. No capture, no verdict — that's
+the project's [#764/#771 discipline]({{ '/blog/solution-postmortem/from-the-issue-tracker-05-ten-megasamples/' | relative_url }}),
+and it applies to your own debugging as much as to bug reports.
+
+One rule above all: **capture the failure**. Same sample rate, same gain, same
+antenna, same time of day if the symptom is load-dependent. The #764 deficit
+existed only at 10 MS/s; a capture taken at the rate that *works* would have
+been evidence for the wrong conclusion.
+
+## The formats
+
+All of GopherTrunk's production pipelines start at complex IQ baseband. The
+formats it reads and writes, per the
+[decoder capture needs]({{ '/decoder-capture-needs.html' | relative_url }}) page:
+
+| Format | Encoding | Size @ 2.4 MS/s | Notes |
+|---|---|---|---|
+| `.cfile` / f32 | interleaved float32 I,Q | ~19 MB/s | GNU Radio native; largest, lossless |
+| cs16 (`.raw`/`.bin`) | interleaved little-endian int16 | ~9.6 MB/s | `auto_record` default; full SDR dynamic range |
+| u8 | interleaved uint8 | ~4.8 MB/s | rtl_sdr native 8-bit |
+| baseband WAV | 2-ch 16-bit, header carries rate | small (channel rate) | post-DDC narrowband; SDRtrunk/SDR++-compatible |
+
+None of the headerless formats embeds sample rate or center frequency — see
+the sidecar section, which is not optional. And repeat the audio caveat from
+`samples/README.md` until it's reflex: **an MP3/WAV of demodulated audio is
+useless for phase modulations** — TETRA's π/4-DQPSK constellation is gone the
+moment an FM discriminator touches it, and 128 kbps MP3 blurs 4-level FSK
+enough to collapse the matched filter. IQ or nothing.
+
+The manual tool is one command:
+
+```
+gophertrunk capture -freq 851000000 -sample-rate 2400000 -gain 297 \
+    -seconds 30 -format cs16 -out cc-fail.raw -protocol p25 \
+    -source "roof discone, marginal after 18:00"
+```
+
+That writes the IQ plus a `.metadata.json` sidecar, and `-bundle out.gtb.tar.gz
+-sigmf` additionally packages capture + metadata (+ a carved narrowband slice)
+with a SigMF `.sigmf-meta` sidecar so inspectrum, GNU Radio, and sigmf-python
+can open it (`internal/gtbundle/sigmf.go` maps u8→`cu8`, f32→`cf32_le`). For
+failures you can't predict, `baseband.auto_record` fires automatically —
+`on_cc_sync_loss`, `on_encrypted`, `on_concurrent_calls`, `on_emergency` — and
+its `tap: ddc` option records the small channelized stream (144 kHz for TETRA)
+instead of the fat wideband, which is how the TETRA sync-loss investigation
+got its 11 perfectly-timed captures without anyone touching a keyboard.
+
+## The sidecar
+
+A headerless IQ file is a bag of numbers. The sidecar makes it evidence. The
+committed example in `samples/p25/p25-450875-cc.metadata.json` shows the shape:
+
+```json
+{
+  "source": "OTA RTL-SDR @ 450.500 MHz center, 2 MSPS; control channel at -625 kHz",
+  "sample_rate_hz": 48000,
+  "center_freq_hz": 449875000,
+  "expected": { "demod_mode": "c4fm", "nac": "0x2C1", "min_tsbk": 28, "...": "..." }
+}
+```
+
+`sample_rate_hz` and `center_freq_hz` are the two fields nothing can proceed
+without. `source` is provenance — antenna, gain, conditions — which future-you
+will not remember. And `expected` is the ambitious part: pass bars that turn
+the file into a graded test (more below). Write the sidecar *at capture time*;
+a `.cfile` found three weeks later with no note about its rate is, in
+practice, garbage — every replay of it begins with guessing.
+
+## Tap points: what a capture can prove
+
+Where you tap the chain determines what questions the file can answer:
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 210" width="680" height="210" role="img" aria-label="The GopherTrunk signal chain with its three IQ tap points marked: the wideband tap after the SDR captures everything including front-end behavior; the ddc tap after the downconverter captures one small channelized stream; and the pre-combine diversity tap sits before the MRC combiner, the only place a combiner question can be answered. Audio output at the far end is marked as not a capture.">
+  <rect x="8" y="80" width="80" height="40" rx="6" fill="none" stroke="currentColor"/>
+  <text x="48" y="104" text-anchor="middle" fill="currentColor" font-size="10">SDR</text>
+  <line x1="88" y1="100" x2="116" y2="100" stroke="currentColor"/><polygon points="116,96 126,100 116,104" fill="currentColor"/>
+  <rect x="126" y="80" width="100" height="40" rx="6" fill="none" stroke="currentColor"/>
+  <text x="176" y="98" text-anchor="middle" fill="currentColor" font-size="10">combiner</text>
+  <text x="176" y="112" text-anchor="middle" fill="var(--fg-muted)" font-size="9">(diversity rigs)</text>
+  <line x1="226" y1="100" x2="254" y2="100" stroke="currentColor"/><polygon points="254,96 264,100 254,104" fill="currentColor"/>
+  <rect x="264" y="80" width="90" height="40" rx="6" fill="none" stroke="currentColor"/>
+  <text x="309" y="104" text-anchor="middle" fill="currentColor" font-size="10">DDC</text>
+  <line x1="354" y1="100" x2="382" y2="100" stroke="currentColor"/><polygon points="382,96 392,100 382,104" fill="currentColor"/>
+  <rect x="392" y="80" width="110" height="40" rx="6" fill="none" stroke="currentColor"/>
+  <text x="447" y="104" text-anchor="middle" fill="currentColor" font-size="10">demod + FEC</text>
+  <line x1="502" y1="100" x2="530" y2="100" stroke="currentColor"/><polygon points="530,96 540,100 530,104" fill="currentColor"/>
+  <rect x="540" y="80" width="80" height="40" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="580" y="98" text-anchor="middle" fill="var(--fg-muted)" font-size="10">audio</text>
+  <text x="580" y="112" text-anchor="middle" fill="var(--fg-muted)" font-size="9">not a capture</text>
+  <line x1="106" y1="80" x2="106" y2="46" stroke="var(--accent)"/><circle cx="106" cy="42" r="4" fill="var(--accent)"/>
+  <text x="106" y="30" text-anchor="middle" fill="var(--accent)" font-size="9">pre-combine tap (diversity_capture)</text>
+  <line x1="240" y1="120" x2="240" y2="158" stroke="currentColor"/><circle cx="240" cy="162" r="4" fill="currentColor"/>
+  <text x="240" y="180" text-anchor="middle" fill="var(--fg-muted)" font-size="9">wideband tap (auto_record)</text>
+  <line x1="372" y1="120" x2="372" y2="158" stroke="currentColor"/><circle cx="372" cy="162" r="4" fill="currentColor"/>
+  <text x="372" y="180" text-anchor="middle" fill="var(--fg-muted)" font-size="9">ddc tap (small, channelized)</text>
+  <text x="340" y="203" text-anchor="middle" fill="var(--fg-muted)" font-size="10">every tap answers questions about what is UPSTREAM of it — and nothing about what it already baked in</text>
+</svg>
+<figcaption>A tap proves things about its upstream only: a post-combine capture has one combiner baked in, and audio has baked in the entire receiver.</figcaption>
+</figure>
+
+The subtle case is diversity. On a two-antenna MRC rig
+(coming in [Part 11]({{ '/blog/tutorials/analog-edge-11-diversity-mrc/' | relative_url }})),
+the combiner lives *in the driver* — so `baseband.auto_record`, the iqtap
+brokers, and the scope taps are all downstream of it. A capture from any of
+them has one particular combiner already applied and **cannot be replayed
+through a different one**: it answers nothing about whether tracking beats
+static, or whether the second antenna contributes at all. The one tap that
+can is `sdr.soapy_remote[].diversity_capture`, which dumps each branch
+straight after de-interleave — `<prefix>.br0.cs16`, `<prefix>.br1.cs16`, plus
+a `<prefix>.diversity.json` sidecar. Its alignment rule is worth internalizing
+as a general principle: a datagram that didn't carry every branch is dropped
+from **both** files and counted (`dropped_datagrams`), never written short,
+because one short write silently desynchronizes the pair and quietly
+invalidates every conclusion drawn afterwards. An unaligned multi-channel
+capture is worse than no capture — it looks like evidence.
+
+## From capture to regression test
+
+The end state of a good capture is not an attachment on an issue — it's a
+fixture. Drop the file in `samples/<protocol>/` with its `.metadata.json`, and
+the skip-gated integration tests pick it up automatically; the sidecar's
+`expected` block *is* the pass bar. The committed P25 example was graded EVM
+12.7% / SNR 14.5 dB / 36 TSBKs with zero CRC failures on the day it was
+measured, and its sidecar pins floors below those values — so any future demod
+regression fails a test naming the exact capture that caught it. The
+per-protocol `samples/*/README.md` files document each decoder's acceptance
+criteria, and the [decoder capture needs]({{ '/decoder-capture-needs.html' | relative_url }})
+page lists which decoders are still *blocked* waiting for a real capture
+(with format, rate, and duration specified — e.g. TETRA wants ≥72 kHz because
+a 48 kHz capture can't lock the 18 ksym/s symbol timing). This is the quiet
+payoff of capture discipline: your bad afternoon becomes everyone's permanent
+regression test.
+
+## Where this goes next
+
+With capture discipline in hand, we can finally buy hardware that raises
+questions only captures can answer.
+[Part 11]({{ '/blog/tutorials/analog-edge-11-diversity-mrc/' | relative_url }})
+adds a second antenna: what diversity and maximal-ratio combining actually buy
+on a fading trunking band, what GopherTrunk's `diversity: mrc` mode does with
+the two streams, and the one log figure that tells you whether the pair is
+earning its coax.
+
+## FAQ
+
+**How long should a capture be?**
+Long enough to contain the failure plus context — the per-protocol guidance in
+[decoder capture needs]({{ '/decoder-capture-needs.html' | relative_url }}) runs
+5–30 s (TETRA asks for ≥30 s including an idle window for noise-floor
+profiling). For intermittent symptoms, `baseband.auto_record` with the right
+trigger beats any manual attempt.
+
+**cs16 or cfile?**
+cs16 at half the size is the practical default and what `auto_record` writes;
+f32 `.cfile` is the GNU Radio interchange format. Both are lossless for
+16-bit-class SDRs. Avoid u8 for marginal-signal work unless the source is
+already 8-bit (RTL-SDR) — you can't add back dynamic range that was never
+digitized.
+
+**My capture is 2 GB. How do I share it?**
+Carve the channel: `replay -record-ddc` writes the post-DDC narrowband stream
+as a small 2-channel WAV that decodes identically (`replay -format wav`), and
+`capture -bundle` packages a narrowband slice with metadata. A 10-second
+channelized fixture is usually a few MB and reproduces the same decode.
+
+**Does GopherTrunk read SigMF?**
+It emits, not reads: `capture -bundle -sigmf` writes a `.sigmf-meta` sidecar
+(SigMF 1.0.0, minimal global + captures objects) so external tooling can open
+GopherTrunk captures. Internally the `.metadata.json` sidecar remains the
+native contract — it carries decode expectations SigMF has no fields for.
+
+**What gain should I capture at?**
+The gain the failure happens at — that's the whole point. If you also have
+time for a second capture at a stepped-down gain, take it; a pair of captures
+bracketing the symptom let the replayer separate overload effects from
+signal-limited effects, which is exactly how the
+[rail-pinning diagnosis]({{ '/blog/solution-postmortem/from-the-issue-tracker-08-nineteen-dibits/' | relative_url }})
+was settled.
+
+## Series navigation
+
+**Part 10 of 14** · ←
+[Part 9: Filters & LNAs — Adding Gain Without Adding Garbage]({{ '/blog/tutorials/analog-edge-09-filters-lnas/' | relative_url }})
+· Next →
+[Part 11: Two Antennas — Diversity & MRC From the Operator's Seat]({{ '/blog/tutorials/analog-edge-11-diversity-mrc/' | relative_url }})

--- a/docs/_posts/2026-08-27-tetra-end-to-end-10-control-channel-sync-loss.md
+++ b/docs/_posts/2026-08-27-tetra-end-to-end-10-control-channel-sync-loss.md
@@ -1,0 +1,287 @@
+---
+title: "TETRA End to End, Part 10: The Control Channel Under Stress — Sync Loss & the CC Equalizer"
+description: "Reading a one-hour field session's eleven hard control-channel sync losses: why the compute theory was wrong, how a signal-time resync budget survives CPU starvation, and the one TETRA control path that wasn't running the equalizer — lifting a marginal capture from twelve percent to full BSCH yield."
+category: deep-dives
+keywords: tetra control channel sync loss, bsch decode yield, cc equalizer, signal-time resync, stale watchdog marklost, control channel re-hunt, marginal snr tetra, cma control channel, gophertrunk tetra
+tags: [tetra-end-to-end, tetra, control-channel, equalizer, reliability, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "TETRA End to End"
+series_part: 10
+---
+
+*Part 10 of **TETRA End to End**, a 14-part deep dive into how GopherTrunk turns
+one real 25 kHz TETRA carrier into clear recorded voice.
+[Part 9]({{ '/blog/deep-dives/tetra-end-to-end-09-equalizer-voice-path/' | relative_url }})
+put a snapshot-frozen CMA equalizer on the voice path and roughly doubled TCH/S
+yield. This part turns the same forensic discipline on the thing every voice
+follow depends on: the control channel itself. A reporter's one-hour session
+logged ~210 control-channel transitions and eleven hard sync losses, each one
+tearing down the site and re-hunting. The obvious suspect was CPU load. The
+data said otherwise — and pointed at the one TETRA control path in the whole
+codebase that wasn't running the equalizer we'd already shipped everywhere
+else.*
+
+> **TL;DR:** Eleven hard CC sync losses in one hour, each preceded by
+> **`bsch_fail`** climbing and **`sb_bursts`** collapsing, then repeated
+> `tetra: dsp resync (signal-time decode drought)`, then the 5 s stale watchdog
+> (`ControlChannel.CheckStale` → **`MarkLost`**) and a re-hunt. **Not compute:**
+> all 11 losses occurred with ~0 concurrent voice follows, and the 704
+> `decode_overruns` were one bursty event — zero correlation with load. The
+> captures split cleanly by in-channel SNR: healthy ≈**18 dB** replays at BSCH
+> **147/0**; a `cc_sync_loss` capture at ≈**10 dB** locks but decodes only
+> ~**22%** of its BSCH. The primary single-channel **`newTETRAPipeline`** was
+> the one TETRA CC path *not* running `SnapshotCMA`; enabling it lifts the
+> marginal fixture from ~**12% to ~100%** CRC-clean BSCH — pinned by
+> `pipelines_tetra_equalizer_test.go` against
+> `testdata/tetra_cc_sync_loss_2s_144k.cs16`.
+
+**Key takeaways**
+
+- **Correlate before you fix.** The sync losses had zero correlation with call
+  or CPU load — every loss happened at ~0 concurrent follows. A compute fix
+  would have been engineering against a phantom.
+- **Measure resync budgets in signal time, not wall clock.** A descheduled
+  goroutine processes no samples, so a sample-count budget never advances
+  during starvation — destructive resets fire only on genuine decode droughts.
+- **A marginal lock is a yield problem, not a lock problem.** The ~10 dB
+  capture *locks*; it just decodes 22% of its sync bursts, and the resulting
+  drought-resync storm is what eventually drops the lock.
+- **The equalizer mitigates; it does not replace RF.** The residual −44 dBFS
+  peak is a weak front end — an antenna/gain condition the equalizer rides
+  through but the operator should still fix.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| CC pipeline | receiver + `tetra.ControlChannel`, now with CMA | `internal/scanner/ccdecoder/pipelines.go` (`newTETRAPipeline`) |
+| Stale watchdog | 5 s of nothing decoded ⇒ `cc.lost`, re-hunt | `internal/radio/tetra/control.go` (`CheckStale`, `MarkLost`) |
+| DSP resync | reset timing/AFC on a *signal-time* decode drought | `pipelines.go` (`tetraResyncTimeout`, 1.5 s of samples) |
+| Health counters | `sb_bursts`, `bsch_fail`, `decode_overruns` … | `pipelines.go` (decode-status line), `control.go` stats |
+| Loss auto-capture | records IQ around each sync loss | `on_cc_sync_loss` (daemon capture hook) |
+| The A/B proof | equalizer off ~12% vs on ~100% BSCH, same fixture | `pipelines_tetra_equalizer_test.go` (`TestTETRACCEqualizerABIsolatesCause`) |
+| Ship gate | the LIVE pipeline must reach the healthy regime | `pipelines_tetra_equalizer_test.go` (`TestTETRACCEqualizerLiftsMarginalBSCHYield`) |
+| Marginal fixture | real 2 s / 144 kHz cs16 from a re-acquisition | `internal/scanner/ccdecoder/testdata/tetra_cc_sync_loss_2s_144k.cs16` |
+
+## In this post
+
+- **Anatomy of a sync loss** — the counter signature before every drop.
+- **Ruling out the compute theory** — what the correlations actually said.
+- **Signal-time resync** — the watchdog design that starvation can't trip.
+- **The path that missed the equalizer** — and the A/B that pins causation.
+- **What the equalizer doesn't fix** — the −44 dBFS residual.
+
+## Anatomy of a sync loss
+
+The reporter's session ran a TETRA site for an hour and logged ~210
+`control_channel_transitions` with eleven hard losses, each auto-captured by
+the `on_cc_sync_loss` hook — which is why this post gets to be forensic instead
+of speculative. Every loss followed the same script. First `bsch_fail` starts
+climbing while `sb_bursts` collapses: the receiver still sees the carrier, but
+the once-a-second BSCH synchronisation bursts stop surviving their CRC. Then
+the log fills with `tetra: dsp resync (signal-time decode drought)` — the
+pipeline concluding, repeatedly, that its symbol timing must be off and
+resetting to center. Each reset is destructive (it discards a *converged*
+Gardner timing loop and AFC), so a receiver that was marginally decoding gets
+knocked back to acquisition over and over — the storm. Finally the 5 s stale
+watchdog fires:
+
+```go
+// internal/radio/tetra/control.go (shape) — the backstop
+// CheckStale declares the control channel lost (publishes cc.lost via
+// MarkLost) when nothing has decoded within the timeout.
+func (c *ControlChannel) CheckStale(now time.Time, timeout time.Duration) {
+    /* … lock-free heartbeat read … */
+    c.MarkLost() // cc.lost ⇒ the cchunt supervisor leaves StateLocked, re-hunts
+}
+```
+
+`tetraLockStaleTimeout` is 5 s — generous, about five missed multiframes at the
+~1 s BSCH cadence — so a healthy carrier never trips it. After each re-lock the
+session also logged a
+[#815](https://github.com/MattCheramie/GopherTrunk/issues/815) carrier warning,
+the post-relock breadcrumb that these captures were being acquired off-center
+(~−3 kHz).
+
+## Ruling out the compute theory
+
+Eleven losses under a scanner that also decodes voice invites the load theory:
+the CC goroutine starves under concurrent calls, decode falls behind, watchdog
+fires. Two numbers killed it. **All eleven losses occurred with approximately
+zero concurrent voice follows** — the site was quiet when it dropped. And the
+session's 704 `decode_overruns` turned out to be one bursty event, not a
+background rate — no correlation in time with any loss.
+
+## Signal-time resync: a watchdog starvation can't trip
+
+That mattered doubly, because the *resync design itself* had already been
+hardened against starvation, and the data confirmed the design rather than
+implicating it. The drought detector is measured in **signal time**:
+
+```go
+// internal/scanner/ccdecoder/pipelines.go (shape)
+// tetraResyncTimeout … is expressed as a duration but measured against
+// PROCESSED-SIGNAL time, not wall clock: checkResync counts the post-DDC IQ
+// samples actually fed to the receiver since the last decode and compares
+// them against a sample budget (tetraResyncTimeout × the channel rate).
+const tetraResyncTimeout = 1500 * time.Millisecond
+```
+
+A wall-clock window ages out while a descheduled goroutine sits idle, firing a
+destructive reset that discards a still-good lock — the field captures from the
+earlier multislot investigation showed ~46 such starvation resyncs before the
+change. A sample budget is immune: no samples processed, no budget consumed.
+So when *this* session showed resync storms, they were real decode droughts on
+real signal — the receiver processing 1.5 s of carrier without one CRC-clean
+decode. The question became: why does a locked receiver stop decoding?
+
+## The path that missed the equalizer
+
+The auto-captures answered it. They split cleanly by in-channel SNR: a healthy
+`concurrent` capture measures ≈**18 dB** and replays at BSCH **147/0** — 100%.
+A `cc_sync_loss` capture measures ≈**10 dB**, *locks*, but decodes only
+~**22%** of its BSCH, with the constellation visibly ISI-smeared. Ten dB is the
+marginal regime — and Part 9 had already shipped the tool for exactly this
+signature. The embarrassment was the wiring: the voice composer ran
+`SnapshotCMA`; the wideband-T2 TETRA path ran it (its comment even claimed it
+mirrored the ccdecoder settings); the primary single-channel
+**`newTETRAPipeline`** — the path that hour-long session was running — did
+not. One flag closed the gap:
+
+```go
+// internal/scanner/ccdecoder/pipelines.go (shape) — newTETRAPipeline
+rx := tetrarx.New(tetrarx.Options{
+    SampleRateHz: opts.SampleRateHz,
+    DibitSink:    func(d []uint8, base int) { opts.tapDibits(d, base); cc.Process(d, base) },
+    SoftSink:     func(diffs []complex64, base int) { cc.StashSoft(diffs, base) },
+    ClockMode:    tetraClockMode, GardnerGain: 0.005,
+    EnableAFC:           true,
+    EnableChannelFilter: true,
+    // On the reporter's ~10 dB re-acquisition capture it lifts CRC-clean BSCH
+    // yield from ~12% to ~100% — the difference between riding through a
+    // marginal dip and dropping lock → re-hunt. EnableDCBlock stays OFF —
+    // reserved for the voice receivers.
+    EnableEqualizer: true,
+})
+```
+
+The proof is deliberately two tests, because they pin different claims.
+`TestTETRACCEqualizerABIsolatesCause` hand-wires two chains that differ *only*
+in `EnableEqualizer` and runs both over the same marginal fixture
+(`testdata/tetra_cc_sync_loss_2s_144k.cs16`, a real 2 s slice from one of the
+session's own auto-captures): off ≈12% BSCH yield, on ≈100%, with guards at
+both ends (`okOn >= 4*okOff`, on-yield ≥ 90%, off-yield ≤ 40% so the fixture
+stays honestly marginal). Because nothing else varies, the improvement cannot
+be chunking, noise, or timing — it is the equalizer. The second,
+`TestTETRACCEqualizerLiftsMarginalBSCHYield`, drives the *live*
+`newTETRAPipeline` — whatever it is currently configured to do — and requires
+the healthy regime. It was red before the flag and green after: the failing-first
+ship gate, so the wiring can never silently regress back out.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 220" width="680" height="220" role="img" aria-label="Timeline of one control-channel sync loss. In the healthy region BSCH bursts decode about once per second. Then in-channel SNR dips to about ten decibels: bsch_fail climbs, sb_bursts collapse, and repeated destructive DSP resyncs fire on decode droughts. After five seconds with no decode the stale watchdog publishes cc.lost and the supervisor re-hunts. A second lane shows the same dip with the equalizer enabled: BSCH yield stays near one hundred percent and no watchdog fires.">
+  <line x1="40" y1="80" x2="660" y2="80" stroke="var(--fg-muted)"/>
+  <text x="14" y="60" fill="var(--fg-muted)" font-size="9">without</text>
+  <text x="14" y="72" fill="var(--fg-muted)" font-size="9">equalizer</text>
+  <g stroke="currentColor"><line x1="60" y1="72" x2="60" y2="80"/><line x1="90" y1="72" x2="90" y2="80"/><line x1="120" y1="72" x2="120" y2="80"/><line x1="150" y1="72" x2="150" y2="80"/></g>
+  <text x="105" y="98" text-anchor="middle" fill="var(--fg-muted)" font-size="9">BSCH ~1/s, clean</text>
+  <rect x="180" y="46" width="300" height="44" rx="4" fill="none" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <text x="330" y="40" text-anchor="middle" fill="var(--fg-muted)" font-size="9">SNR dips to ~10 dB — ISI smears the constellation</text>
+  <g stroke="currentColor"><line x1="205" y1="72" x2="205" y2="80"/><line x1="292" y1="72" x2="292" y2="80"/><line x1="401" y1="72" x2="401" y2="80"/></g>
+  <text x="330" y="98" text-anchor="middle" fill="var(--fg-muted)" font-size="9">bsch_fail ↑ · sb_bursts ↓ · dsp resync ×N</text>
+  <line x1="480" y1="52" x2="480" y2="80" stroke="currentColor"/>
+  <text x="482" y="50" fill="currentColor" font-size="9">5 s drought</text>
+  <circle cx="540" cy="80" r="5" fill="currentColor"/>
+  <text x="540" y="66" text-anchor="middle" fill="currentColor" font-size="9">MarkLost → re-hunt</text>
+  <line x1="40" y1="170" x2="660" y2="170" stroke="var(--fg-muted)"/>
+  <text x="14" y="150" fill="var(--accent)" font-size="9">with</text>
+  <text x="14" y="162" fill="var(--accent)" font-size="9">equalizer</text>
+  <g stroke="var(--accent)"><line x1="60" y1="162" x2="60" y2="170"/><line x1="90" y1="162" x2="90" y2="170"/><line x1="120" y1="162" x2="120" y2="170"/><line x1="150" y1="162" x2="150" y2="170"/><line x1="205" y1="162" x2="205" y2="170"/><line x1="245" y1="162" x2="245" y2="170"/><line x1="285" y1="162" x2="285" y2="170"/><line x1="325" y1="162" x2="325" y2="170"/><line x1="365" y1="162" x2="365" y2="170"/><line x1="405" y1="162" x2="405" y2="170"/><line x1="450" y1="162" x2="450" y2="170"/><line x1="495" y1="162" x2="495" y2="170"/><line x1="540" y1="162" x2="540" y2="170"/><line x1="585" y1="162" x2="585" y2="170"/><line x1="630" y1="162" x2="630" y2="170"/></g>
+  <text x="350" y="190" text-anchor="middle" fill="var(--accent)" font-size="9">same dip, ~100% BSCH — the lock rides through; no watchdog, no re-hunt</text>
+  <text x="350" y="212" text-anchor="middle" fill="var(--fg-muted)" font-size="10">one flag on the one path that lacked it: the difference between a marginal dip and a site teardown</text>
+</svg>
+<figcaption>The same ~10 dB dip, with and without the CC equalizer: the un-equalized lane decays into a resync storm and a watchdog teardown; the equalized lane decodes through it.</figcaption>
+</figure>
+
+### How that principle shaped the Go code
+
+- **The watchdog stack stayed untouched.** Signal-time resync, the 5 s
+  backstop, `MarkLost` — all correct, all confirmed by the data. The fix went
+  where the evidence pointed: decode yield, not lifecycle.
+- **`EnableDCBlock` stays off the CC path.** The DC blocker is a voice-receiver
+  tool (per `receiver.go`); the control channel's steady-state decode must not
+  be disturbed by a filter it doesn't need. Parity of *settings* across paths
+  is checked per-flag, not wholesale.
+- **Synthetic fixtures got noisier on purpose.** Blind CMA is well-defined only
+  against a noise floor — a literally noise-free constant-modulus input is a
+  degenerate case. The full-daemon `TestDaemonCCDecodesTETRA` now adds 40 dB
+  AWGN so the equalizer sees a fair fixture (the same reason the clean-channel
+  receiver test adds 30 dB).
+
+## What the equalizer doesn't fix
+
+The auto-captures peak at **−44 dBFS** with no clipping. That is a weak front
+end — an RF, gain, or antenna condition, the same class of finding as
+[#764](https://github.com/MattCheramie/GopherTrunk/issues/764) — and the
+equalizer *mitigates* it by spending the remaining SNR more efficiently; it
+does not replace the missing decibels. The operator guidance is unchanged and
+belongs to another series: stage the gain properly
+([The Analog Edge Part 3]({{ '/blog/tutorials/analog-edge-03-gain-staging/' | relative_url }}))
+and, when a symptom straddles the boundary, run the is-it-RF-or-software
+checklist ([The Analog Edge Part 14]({{ '/blog/tutorials/analog-edge-14-field-checklist/' | relative_url }})).
+A control channel that arrives at 18 dB doesn't need rescuing; the equalizer's
+job is to make 10 dB survivable, not to make −44 dBFS a lifestyle.
+
+## Where this goes next
+
+That closes the TMO arc: one carrier, from constellation to conformant voice,
+hardened at both the traffic and control layers. The next three parts leave the
+network behind entirely.
+[Part 11]({{ '/blog/deep-dives/tetra-end-to-end-11-dmo-direct-mode/' | relative_url }})
+starts the DMO detour — TETRA's infrastructure-less direct mode, where two
+radios talk peer-to-peer with no control channel at all, and where GopherTrunk
+had to read the burst geometry from the spec and prove it against captures one
+constant at a time.
+
+## FAQ
+
+**Why does a resync storm make things worse instead of better?**
+Reset-to-center is destructive: it throws away a converged Gardner timing loop
+and AFC state. On a genuinely off-lock receiver that's the fast path back. On a
+marginally-*decoding* receiver it re-runs acquisition over and over, turning a
+22%-yield channel into a 0%-yield one for the acquisition window each time.
+That's why the trigger had to be a genuine signal-time drought.
+
+**Why didn't the CC path have the equalizer already?**
+Sequencing, honestly. The equalizer shipped on the voice path (Part 9) where
+the garble was, and on the wideband-T2 path that copied those settings. The
+primary single-channel pipeline predated both and nothing forced the audit
+until the sync-loss session did. The ship-gate test now makes the setting
+regression-proof.
+
+**Is ~210 transitions/hour normal for a marginal site?**
+It was the *symptom* here, not a baseline. Post-fix, the marginal regime that
+caused most transitions decodes at ~100% BSCH, so the dips no longer cascade
+into teardowns. Residual transitions on a weak install are an RF condition to
+fix at the antenna, not a software rate to accept.
+
+**What is `on_cc_sync_loss` and should I enable it?**
+A daemon hook that auto-records IQ around each control-channel loss. It's the
+reason this investigation had eleven captures instead of eleven anecdotes — on
+any system showing unexplained transitions, enable it. The fixture in the
+repo's testdata is literally one of its outputs.
+
+**Could this have been the #764 front-end problem again?**
+It shares the weak-signal setting (−44 dBFS) but not the mechanism: #764's
+deficit was baked into the captured samples (phase noise at the Airspy's 10
+MS/s clock), invariant to decode-path changes. Here an A/B on the *same
+capture* moves yield 12%→100% — by definition a decode-path gap, with an RF
+condition underneath that still deserves fixing.
+
+## Series navigation
+
+**Part 10 of 14** · ←
+[Part 9: The Equalizer on the Voice Path]({{ '/blog/deep-dives/tetra-end-to-end-09-equalizer-voice-path/' | relative_url }})
+· Next →
+[Part 11: DMO I — Direct Mode & the DSB/DNB Geometry]({{ '/blog/deep-dives/tetra-end-to-end-11-dmo-direct-mode/' | relative_url }})

--- a/docs/_posts/2026-08-27-weak-signal-engineering-10-mrc-calibration.md
+++ b/docs/_posts/2026-08-27-weak-signal-engineering-10-mrc-calibration.md
@@ -1,0 +1,310 @@
+---
+title: "Weak-Signal Engineering, Part 10: Diversity I — MRC & Coherence-Gated Calibration"
+description: "Maximal-ratio combining from two receive branches, the wideband-scalar caveat that bounds what one complex gain can deliver, and the scale-invariant coherence gate — |rho| = γ/(1+γ), a noise floor you can compute, and the DC-removal detail that turns out to be load-bearing."
+category: deep-dives
+keywords: maximal ratio combining, diversity combining sdr, coherence gate, normalised cross-correlation, complex gain calibration, dc offset correlator, scale-invariant threshold, dual receiver combining, gophertrunk weak-signal engineering
+tags: [weak-signal-engineering, diversity, mrc, coherence, calibration, dsp, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Weak-Signal Engineering"
+series_part: 10
+---
+
+*Part 10 of **Weak-Signal Engineering**, a 14-part series on decoding the
+marginal regime — where the receiver locks but only a fraction of frames
+survive. [Part 9]({{ '/blog/deep-dives/weak-signal-engineering-09-parallel-buffers/' | relative_url }})
+closed out the single-antenna levers with the architecture that let them land
+safely. This part adds hardware: a second receive branch, combined
+coherently so the SNRs add. But combining two streams that are *not* seeing
+the same signal is worse than useless — it cancels — so the real engineering
+is in the gate that decides when calibration can be trusted. That gate is a
+normalised cross-correlation, it is scale-invariant by design, and getting
+there meant deleting an absolute-power threshold that had already pushed one
+operator into a 17 dB gain hike to satisfy a software constant.*
+
+> **TL;DR:** GopherTrunk's `diversity.MRC` combines branches as
+> `y = Σ conj(h_k)·x_k / Σ|h_k|²` — in pilot mode the complex gains `h_k` come
+> from a calibrator, and the output SNR of a correct combine is the **sum** of
+> the branch SNRs. The calibration question — "are these two receivers seeing
+> the same signal through a constant complex gain?" — is answered by
+> `diversity.CrossStats`: a single-pass, multi-chunk accumulator whose
+> `Coherence()` is the normalised cross-correlation |rho| and whose `Gain()`
+> is the least-squares `h = cov(x,ref)/var(ref)`. |rho| = γ/(1+γ) at equal
+> per-branch SNR γ makes thresholds interpretable (0.5 ≈ 0 dB, 0.35 ≈
+> −2.7 dB) against a noise-only floor near sqrt(π/4N). **Every statistic is a
+> DC-removed covariance** — an uncentred correlator on two noise branches
+> sharing LO-leakage DC reports |rho| → 1 and calibrates confidently on
+> nothing (`TestCrossStatsRejectsCommonDCOffset`). Absolute power survives
+> only as a −100 dBFS digitally-dead-branch reject.
+
+**Key takeaways**
+
+- **MRC is optimal only when the gains are right — and destructive when they
+  are wrong.** Two equal-power branches combined in anti-phase cancel. The
+  combiner is the easy part; the calibration gate is the product.
+- **Gate on coherence, never on absolute power.** An operator raised
+  front-end gain 65.0 → 82.0 dB to clear a −40 dBFS calibration gate by
+  0.2 dB. Any dBFS threshold is a gain-staging trap that re-fires on the next
+  front end; |rho| asks the actual question and is immune to gain.
+- **DC removal in the correlator is load-bearing, not hygiene.** Shared LO
+  leakage is perfectly common-mode; uncentred, it makes independent noise look
+  perfectly correlated exactly in the weak-signal regime the gate protects.
+- **One scalar gain serves the whole wideband stream — know the caveat.**
+  Antennas metres apart give each carrier its own phase; a scalar aligns the
+  loudest and can partially cancel others. Coherence stuck around 0.3–0.5 is
+  that signature, and per-channel combining is honestly not built.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| Combiner | `y = Σ conj(h_k)x_k / Σ|h_k|²`, power or pilot mode | `internal/dsp/diversity/mrc.go` (`MRC`, `SetGain`) |
+| Statistics | single-pass DC-removed covariances across chunks | `internal/dsp/diversity/crossstats.go` (`CrossStats.Accumulate`) |
+| Quality gate | normalised cross-correlation \|rho\| in [0,1] | `crossstats.go` (`Coherence`) |
+| Gain estimate | least-squares `h = cov(x,ref)/var(ref)` | `crossstats.go` (`Gain`) |
+| Dead-branch reject | −100 dBFS linear AC-power floor | `internal/dsp/diversity/tracking.go` (`TrackingOptions.MinBranchPower`) |
+| DC-offset pin | shared DC over independent noise ⇒ \|rho\| ≤ 0.05 | `crossstats_test.go` (`TestCrossStatsRejectsCommonDCOffset`) |
+| Operator surface | per-branch health line, WARNs that name the fix | `internal/sdr/soapyremote/mrc.go` (`diversityReporter.observe`) |
+
+## In this post
+
+- **Why a second antenna helps** — and how MRC spends it.
+- **The wideband-scalar caveat** — the honest bound on one complex gain.
+- **Coherence, the scale-invariant gate** — |rho|, its SNR mapping, its floor.
+- **The gain-staging trap** — the −40 dBFS gate and why it had to die.
+- **DC removal is load-bearing** — the failure the centred correlator prevents.
+
+## Why a second antenna helps — and how MRC spends it
+
+Fading is not uniform in space. Two antennas a few wavelengths apart see
+partially independent channels: when one sits in a multipath null, the other
+usually doesn't. A selection combiner (`diversity.Selection`) picks the
+stronger branch and buys you the better of two rolls. Maximal-ratio combining
+does better: weight each branch by the conjugate of its complex channel gain,
+sum, and — in AWGN with correct gains — the output SNR is the *sum* of the
+branch SNRs. Two equal branches: +3 dB. On the yield cliff of
+[Part 1]({{ '/blog/deep-dives/weak-signal-engineering-01-marginal-regime/' | relative_url }}),
+3 dB is a different regime.
+
+```go
+// internal/dsp/diversity/mrc.go (shape) — pilot-mode combine
+//   y[i] = ( sum_k  conj(h_k) · x_k[i] ) / sum_k |h_k|^2
+if m.usePilot {
+    for k := 0; k < m.branches; k++ {
+        h := m.gains[k]
+        weights[k] = complex(real(h), -imag(h)) // conj(h)
+        denom += float64(real(h))*float64(real(h)) + float64(imag(h))*float64(imag(h))
+    }
+}
+```
+
+The conjugate is the whole trick: multiplying branch k by `conj(h_k)` rotates
+its signal component back into phase alignment with every other branch, so
+signals add coherently (amplitudes sum) while the independent noises add
+incoherently (powers sum). That is also the failure mode in one sentence:
+**get the phase wrong by 180° and the same machinery subtracts your signal.**
+The docstring in `mrc.go` is explicit that the combiner is "sensitive to
+phase mis-alignment: with two equal-power branches in anti-phase, MRC cancels
+the signal." Everything else in this post exists to make sure the `h_k`
+handed to `SetGain` deserve to be trusted.
+
+## The wideband-scalar caveat
+
+Before the math, the honest scope. GopherTrunk combines the **wideband
+stream** — the full multi-megahertz capture, before any per-channel DDC — so
+one complex scalar per branch has to serve every carrier in the band at once.
+That is exact only if the branches differ by a frequency-flat constant:
+same antenna feed split two ways, or co-located antennas into a
+frequency-locked front end.
+
+Two antennas metres apart break the assumption. Each carrier arrives from its
+own direction, so each gets its own inter-antenna phase difference set by
+geometry; a single scalar aligns whichever carrier dominates the estimate and
+*partially cancels* others. The signature is a coherence that no amount of
+tracking improves — stuck around 0.3–0.5 while both branches are healthy.
+The fix for that regime would be combining after the per-channel DDC, one
+gain per narrowband channel — a much larger change, and not built. The
+`diversityReporter` health line says as much in its WARN text: widely
+separated antennas give each carrier its own phase, which one wideband
+complex gain cannot align. Surfacing that number instead of silently
+underperforming is arguably the bigger contribution — the operator-seat view
+of these log lines lives in the concurrent
+[Analog Edge series]({{ '/blog/series/analog-edge/' | relative_url }}).
+
+## Coherence: the scale-invariant gate
+
+The question a calibrator must answer is not "is the signal strong?" but
+"are these two branches related by a constant complex gain?" The statistic
+that answers it is the normalised cross-correlation
+
+|rho| = |Σ x·conj(ref)| / sqrt(Σ|ref|² · Σ|x|²)
+
+computed over DC-removed samples. `CrossStats` accumulates the six needed
+sums in a single pass across arbitrarily many stream chunks, so a
+calibration window can span many datagrams:
+
+```go
+// internal/dsp/diversity/crossstats.go (shape)
+type CrossStats struct {
+    n                int
+    sumRefR, sumRefI float64 // Σ ref
+    sumXR, sumXI     float64 // Σ x
+    sumRefRef        float64 // Σ |ref|²
+    sumXX            float64 // Σ |x|²
+    sumXRefR         float64 // Re Σ x·conj(ref)
+    sumXRefI         float64 // Im Σ x·conj(ref)
+}
+
+func (s *CrossStats) Coherence() float64 // |rho| in [0,1]
+func (s *CrossStats) Gain() (complex64, bool) // h = cov(x,ref)/var(ref)
+```
+
+Three properties make |rho| the right gate. **It is scale-invariant** —
+multiply either branch by any gain and it does not move, so no front-end
+knob can game it. **It maps to SNR**: for a common signal in independent
+noise at equal per-branch SNR γ, |rho| = γ/(1+γ), so a threshold of 0.5
+means "0 dB per branch" and 0.35 means "about −2.7 dB" — thresholds you can
+reason about instead of tune (`TestCrossStatsCoherenceTracksSNR` pins the
+mapping). **It has a computable floor**: two branches of pure independent
+noise over N samples sit near sqrt(π/4N) — about 0.03 at N = 1000 — so you
+know how much coherence is "none" for any window length
+(`TestCrossStatsIndependentNoiseFloor`). And the same accumulation yields the
+least-squares gain `h = cov(x,ref)/var(ref)`, so the gate and the estimate it
+gates come from one measurement of one window.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 220" width="680" height="220" role="img" aria-label="A curve of coherence magnitude rho against per-branch SNR in dB, rising from near zero through 0.35 at about minus 2.7 dB and 0.5 at 0 dB toward 1 at high SNR. Two horizontal threshold lines mark the track gate at 0.35 and the lock gate at 0.5, and a shaded band near the bottom marks the noise-only floor around square root of pi over 4N.">
+  <line x1="60" y1="20" x2="60" y2="180" stroke="var(--fg-muted)"/>
+  <line x1="60" y1="180" x2="640" y2="180" stroke="var(--fg-muted)"/>
+  <text x="30" y="30" fill="var(--fg-muted)" font-size="9">|rho|</text>
+  <text x="30" y="44" fill="var(--fg-muted)" font-size="9">1.0</text>
+  <text x="600" y="196" fill="var(--fg-muted)" font-size="9">per-branch SNR</text>
+  <text x="140" y="196" fill="var(--fg-muted)" font-size="9">−10 dB</text>
+  <text x="330" y="196" fill="var(--fg-muted)" font-size="9">0 dB</text>
+  <text x="480" y="196" fill="var(--fg-muted)" font-size="9">+10 dB</text>
+  <polyline points="70,172 120,166 170,152 220,136 270,118 330,104 390,78 450,58 510,46 570,40 630,37" fill="none" stroke="currentColor"/>
+  <rect x="60" y="168" width="580" height="12" fill="var(--fg-muted)" opacity="0.25"/>
+  <text x="470" y="176" fill="var(--fg-muted)" font-size="8">noise-only floor ≈ sqrt(π/4N)</text>
+  <line x1="60" y1="104" x2="640" y2="104" stroke="var(--accent)" stroke-dasharray="5 4"/>
+  <text x="66" y="98" fill="var(--accent)" font-size="9">lock gate 0.5 (= 0 dB): |rho| = γ/(1+γ)</text>
+  <line x1="60" y1="126" x2="640" y2="126" stroke="var(--accent)" stroke-dasharray="2 4"/>
+  <text x="66" y="140" fill="var(--accent)" font-size="9">track gate 0.35 (≈ −2.7 dB)</text>
+  <circle cx="330" cy="104" r="4" fill="var(--accent)"/>
+  <text x="350" y="214" text-anchor="middle" fill="var(--fg-muted)" font-size="10">the gate reads SNR off the stream itself — no front-end gain setting can move it</text>
+</svg>
+<figcaption>|rho| = γ/(1+γ) turns coherence thresholds into SNR statements: 0.5 is 0 dB per branch, 0.35 is −2.7 dB, and the noise-only floor is computable from the window length alone.</figcaption>
+</figure>
+
+## The gain-staging trap the gate replaced
+
+The gate was not always coherence. An earlier design refused to calibrate
+until the reference branch cleared **−40 dBFS** — a sane-sounding "make sure
+there's signal" check. Then a field report showed what any absolute-power
+gate eventually does: an operator raised front-end gain from 65.0 to 82.0 dB
+— a 17 dB hike chosen not for RF reasons but to push a number past a software
+constant — and landed at −39.8 dBFS, clearing the gate by 0.2 dB. The radio
+was fine; the threshold was the problem, and it would have re-fired on the
+next front end with a different full-scale mapping. This is the same lesson
+the [Analog Edge series]({{ '/blog/series/analog-edge/' | relative_url }})
+teaches from the operator's seat: never chase a software threshold with a
+gain knob.
+
+Absolute power survives in exactly one place, doing the one job it is fit
+for: `MinBranchPower` defaults to 1e-10 — **−100 dBFS**, where one CS16 LSB
+is −90.3 dBFS — and rejects only a *digitally dead* branch: all zeros, a
+receiver that never digitised, a server that delivered one channel of a
+two-channel request. There |rho| is 0/0 and genuinely has no opinion. The
+docstring is explicit that this is deliberately far below any signal level,
+"not a signal-presence test, because an absolute power threshold is exactly
+the gain-staging trap this design exists to remove."
+
+## DC removal is load-bearing
+
+The subtlest line in `crossstats.go` is the one that makes every statistic a
+*centred* covariance rather than a raw sum. It reads like numerical hygiene.
+It is not — it is the difference between a gate and a hazard.
+
+Both receivers of a shared front end carry LO leakage and converter DC
+offset, and that offset is perfectly **common-mode**: identical on both
+branches, always. Feed two branches of pure independent noise plus a common
+DC into an *uncentred* correlator and the DC term dominates every sum — the
+correlator reports |rho| → 1 and hands back `h = dc1/dc0`. The system would
+conclude the branches are perfectly coherent, "calibrate" on the ratio of
+two leakage terms, and start coherently combining noise — precisely in the
+weak-signal regime where the signal is too small to out-vote the DC, which
+is precisely the regime the gate exists to protect.
+
+`TestCrossStatsRejectsCommonDCOffset` pins the defence with a hostile
+fixture: two branches of independent noise sharing a DC offset **20× the
+noise amplitude** must read |rho| ≤ 0.05, and the branch AC power must read
+~the noise power, not the ~544× figure the DC would contribute. The cost of
+the fix is two extra running sums per branch (the per-branch means), folded
+into the same single pass. `RefPower` and `BranchPower` are AC powers for
+the same reason: a branch carrying nothing but DC reads zero, "which is the
+correct reading for a receiver that is not delivering signal."
+
+### How that principle shaped the Go code
+
+- **One accumulator answers both questions.** `Gain()` and `Coherence()`
+  derive from the same six sums over the same window, so the estimate can
+  never be graded by a different measurement than produced it.
+- **Chunk-tolerant by construction.** `Accumulate` folds arbitrary-length
+  chunks and truncates a ragged pair to the shorter length, so the window
+  schedule is owned by the caller and a torn final datagram skews nothing.
+- **The thresholds carry their own justification.** 0.5 and 0.35 are not
+  tuned magic — they are γ/(1+γ) statements pinned by a test, which is why
+  they can be documented as dB and reasoned about at 2 a.m.
+
+## Where this goes next
+
+`CrossStats` grades one window. The harder question is time: on front ends
+with independent PLLs the true branch phase *walks*, so a constant measured
+once decays — but Part 5 taught that a continuously-adapting filter ahead of
+a differential decoder is fatal. 
+[Part 11]({{ '/blog/deep-dives/weak-signal-engineering-11-tracking-mrc/' | relative_url }})
+resolves the apparent contradiction: why `TrackingCalibrator` is structurally
+safe where CMA was not, the hold-don't-fallback rule, the step clamp, and the
+capture A/B — four decode arms scored by CRC-clean BSCH — that decides
+whether tracking earns default-on.
+
+## FAQ
+
+**How much does a second branch actually buy?**
+With correct gains in AWGN, the combined SNR is the sum of branch SNRs — +3 dB
+for two equal branches, more when the branches fade independently and one
+would otherwise be in a null. With *wrong* gains it can cost everything: MRC
+in anti-phase cancels. That asymmetry is why the gate is conservative and why
+an uncalibrated combiner passes the reference branch through untouched.
+
+**Why does GopherTrunk combine wideband instead of per channel?**
+The combiner lives in the SDR driver, ahead of channelisation, so every
+downstream consumer benefits without knowing diversity exists. The price is
+the frequency-flat assumption — one scalar per branch. Co-located antennas on
+a locked front end fit it; widely separated antennas don't, and the coherence
+figure is what tells you which situation you are in.
+
+**What does a coherence stuck at 0.3–0.5 mean when both branches look healthy?**
+Usually the wideband-scalar caveat: the branches see the same band but with
+per-carrier phase differences one scalar cannot align — separated antennas,
+or mixed polarisations. It is not a gain problem; the health-line WARN says
+so explicitly, because raising RF gain is the reflex that never helps here.
+
+**Could the DC problem be solved by a DC-blocking filter before the correlator?**
+A high-pass helps the stream, but the correlator cannot assume every caller
+runs one, and residual DC after an imperfect block still biases a raw
+correlator. Centring inside `CrossStats` costs two sums and makes the
+statistic correct regardless of what upstream did — an invariant, not a
+configuration.
+
+**Is selection diversity ever the better choice?**
+Selection (`diversity.Selection`) needs no phase calibration at all, so it is
+immune to every failure mode in this post — at the cost of the coherent gain.
+When coherence gates keep holding on your hardware, the better of two
+branches beats a combine you cannot trust.
+
+## Series navigation
+
+**Part 10 of 14** · ←
+[Part 9: Parallel Buffers — SymbolSink, SoftSink & Opt-In Soft Paths]({{ '/blog/deep-dives/weak-signal-engineering-09-parallel-buffers/' | relative_url }})
+· Next →
+[Part 11: Diversity II — Tracking Without Breaking the Differential]({{ '/blog/deep-dives/weak-signal-engineering-11-tracking-mrc/' | relative_url }})

--- a/docs/_posts/2026-08-28-analog-edge-11-diversity-mrc.md
+++ b/docs/_posts/2026-08-28-analog-edge-11-diversity-mrc.md
@@ -1,0 +1,287 @@
+---
+title: "The Analog Edge, Part 11: Two Antennas — Diversity & MRC From the Operator's Seat"
+description: What a second antenna and maximal-ratio combining actually buy on a fading trunking band, how to configure GopherTrunk's diversity mode and read its health log line, and the coherence signature that tells you when two antennas cannot be combined with one wideband gain.
+category: tutorials
+keywords: antenna diversity sdr, maximal ratio combining, mrc sdr, two antenna receiver, diversity combining trunking, soapy remote diversity, coherence log line, multipath fading scanner, gophertrunk analog edge
+tags: [analog-edge, diversity, mrc, antennas, sdr, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "The Analog Edge"
+series_part: 11
+---
+
+*Part 11 of **The Analog Edge**, a 14-part field guide to the analog half of a
+GopherTrunk system. [Part 10]({{ '/blog/tutorials/analog-edge-10-capture-discipline/' | relative_url }})
+gave us capture discipline — including the one pre-combine tap that makes this
+part's claims checkable. Our marginal reader's system now decodes most of the
+day, but fades still eat calls when trucks park in the Fresnel zone. The next
+purchase isn't a better antenna; it's a **second** one. This part is the
+operator's view of diversity and maximal-ratio combining: what to configure,
+what the log line means, and the one number that says whether the pair is
+working. The algorithm internals live in Weak-Signal Engineering — here we
+stay in the operator's seat.*
+
+> **TL;DR:** Two antennas fade differently, and a coherent combiner
+> (**MRC** — maximal-ratio combining) can add their SNRs instead of picking
+> one. In GopherTrunk this is `diversity: "mrc"` on an `sdr.soapy_remote`
+> device with two RX channels (ports selected via `antennas: [RX1, RX2]`).
+> The combiner aligns the branches with **one complex gain across the whole
+> wideband stream** — exact only when the branches differ by a frequency-flat
+> constant, which co-located antennas satisfy and metres-apart antennas on a
+> busy band do not. The health line's `coherence` figure is the verdict:
+> ~0.7+ combining well; **stuck at 0.3–0.5 is the wideband-scalar signature**,
+> not a gain problem. `mrc` tracks a drifting front end; `mrc-static` freezes
+> after one estimate. A/B them offline against your own `diversity_capture`
+> with `TestDiversityCombinerReplay` — decode yield is the verdict, never EVM.
+
+**Key takeaways**
+
+- **Diversity buys fade insurance, not raw gain.** Two antennas rarely fade
+  together; MRC's output SNR approaches the *sum* of the branch SNRs when the
+  branches cohere — the win shows up on the marginal calls, not the strong ones.
+- **One complex scalar combines the whole band.** That's cheap and right for a
+  shared-mast pair; it is structurally unable to align every carrier when the
+  antennas are far apart, because each carrier then has its own phase difference.
+- **`coherence` in the log line is the health number.** It's scale-invariant —
+  raising RF gain never moves it — and the WARN messages name the actual fix
+  (antenna, band, polarization, clocking), not a gain knob.
+- **Captures decide the mode.** The pre-combine `diversity_capture` from
+  Part 10 replayed through the four-arm harness (each branch alone, static,
+  tracking) is the only honest A/B; tracking-as-default is gated on exactly that.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| Enable diversity | open RX0+RX1, combine into one stream | `sdr.soapy_remote[].diversity: "mrc"` (`config.example.yaml`) |
+| Antenna ports | select each channel's RX port | `sdr.soapy_remote[].antennas: [RX1, RX2]` |
+| The combiner | coherent MRC with tracked branch gain | `internal/sdr/soapyremote/mrc.go` (`mrcCombiner`), `internal/dsp/diversity` |
+| Health report | per-branch dBFS, coherence, gain, phase every 30 s | `diversityReporter` (`mrc.go`, issue [#1062](https://github.com/MattCheramie/GopherTrunk/issues/1062)) |
+| Pre-combine capture | per-branch IQ for offline A/B | `diversity_capture` / `diversity_capture_seconds` |
+| Offline A/B harness | four decode arms scored by CRC-clean BSCH | `TestDiversityCombinerReplay` (`cmd/gophertrunk/diversity_replay_test.go`) |
+| Hardware for two channels | dual-RX SDRs and multi-dongle alternatives | [multi-dongle setup guide]({{ '/multi-dongle-sdr-setup/' | relative_url }}) |
+
+## In this post
+
+- **What a second antenna buys** — fading, multipath, and the MRC idea.
+- **Configuring it** — the YAML, the ports, and what to expect at startup.
+- **Reading the health line** — dBFS per branch, coherence, and the WARNs.
+- **The wideband-scalar limit** — why antenna placement is part of the DSP.
+- **`mrc` vs `mrc-static`** — and the capture-driven way to choose.
+
+## What a second antenna buys
+
+A trunking band fade is local: multipath from buildings and traffic carves
+nulls that move with the scatterers, and a null at one antenna is usually not
+a null at an antenna half a wavelength away. [Selection
+diversity]({{ '/reference/antenna-diversity/' | relative_url }}) — switch to
+the better branch — already removes most deep fades. MRC goes further: weight
+each branch by its channel gain and sum *coherently*, so both antennas
+contribute even when neither is best; in white noise with aligned branches the
+output SNR is the sum of the branch SNRs (up to 3 dB for an equal pair, more
+than that in effect during fades, which is when it matters). The catch is the
+word *coherently*: the branches must be phase-aligned before they can add, and
+estimating that alignment from the stream itself — continuously, without
+disturbing the decoders downstream — is the whole trick. How GopherTrunk's
+calibrator does it (coherence-gated least squares, then a slow tracking loop
+that is provably safe ahead of a differential demodulator) is
+[Weak-Signal Engineering Part 10]({{ '/blog/deep-dives/weak-signal-engineering-10-mrc-calibration/' | relative_url }})
+and [Part 11]({{ '/blog/deep-dives/weak-signal-engineering-11-tracking-mrc/' | relative_url }});
+from the operator's seat you only need what the knobs do and what the log says.
+
+## Configuring it
+
+Diversity rides the SoapyRemote driver, on hardware with two RX channels fed
+from the same clock — a USRP B210, an X310 with TwinRX cards, and friends (see
+the [multi-dongle guide]({{ '/multi-dongle-sdr-setup/' | relative_url }}) for
+what qualifies; two independent RTL dongles do not — they don't share a clock):
+
+```yaml
+# config.yaml — sdr section (shape; see config.example.yaml)
+soapy_remote:
+  - addr: "192.168.1.60:55132"
+    driver: "uhd"
+    role: control
+    format: "CS16"
+    diversity: "mrc"          # "" | "mrc" | "mrc-static"
+    antennas: [RX1, RX2]      # RX port per channel, checked against the device
+    diversity_capture: ""     # set a path prefix for the Part 10 pre-combine dump
+    diversity_capture_seconds: 0   # 1..60 (0 = 5 s)
+```
+
+Three notes from the field. `antennas` exists because a comma-separated
+antenna can't live in the flat `args` string — and port names are
+device-specific (a B210 has `TX/RX` and `RX2`; a TwinRX has `RX1` and `RX2`),
+so a config moved between rigs fails loudly rather than silently keeping a
+driver default (that silent-default failure was a real bug, and both branches
+must be *gained* — an ungained second channel is a dead branch). At startup
+the very first datagram logs a health line, so an operator enabling `mrc`
+sees both branches' levels immediately rather than 30 seconds later. And
+until the calibrator's first estimate is accepted, the combiner passes the
+reference branch through verbatim — enabling diversity never makes you
+*worse* than your primary antenna while it's warming up.
+
+## Reading the health line
+
+Every 30 seconds (`mrcHealthInterval`), the `diversityReporter` prints one
+line — INFO when healthy, WARN with a named fix when not:
+
+```
+INFO soapyremote: MRC diversity branches addr=… branch_dbfs="ch0=-31.2 ch1=-33.8"
+     reference_branch=0 calibrated=true coherence=0.78 branch_gain_db=-2.1
+     branch_phase_deg=41.3 mode=mrc updates=412 holds=9
+```
+
+| Field | What to read from it |
+|---|---|
+| `branch_dbfs` | both branches alive and within ~20 dB of each other; a branch >20 dB below the reference is declared **dead** with a WARN naming the antenna/gain fix |
+| `coherence` | the health number — the normalised cross-correlation of the last calibration window; see below |
+| `branch_gain_db` / `branch_phase_deg` | the measured branch imbalance; the *phase* field is Part 12's hardware-class instrument |
+| `updates` / `holds` | accepted vs gate-rejected calibration windows; climbing holds against flat updates = the branches aren't seeing the same signal |
+| `calibrated` | false forever + windows completing = the not-coherent WARN below |
+
+Two WARNs matter. **Dead branch** (`ch1` missing or ≥20 dB down): a
+disconnected antenna, an ungained channel, or a server that honored only one
+channel of the two-channel request — before [#1062](https://github.com/MattCheramie/GopherTrunk/issues/1062)
+this was invisible and just looked like a weak single receiver. **Not
+coherent** (both branches alive, `calibrated=false` after windows have
+completed): the two receivers are not seeing the same signal through a
+constant complex gain, and the WARN says explicitly that raising RF gain will
+NOT help — the gate is scale-invariant
+([Part 13]({{ '/blog/tutorials/analog-edge-13-coherence-not-dbfs/' | relative_url }})
+is entirely about why). Check band, polarization, co-location, and the front
+end's `clock_source` instead.
+
+## The wideband-scalar limit
+
+Here is the design fact that makes antenna *placement* part of the DSP. The
+combiner aligns branches with **one complex gain applied to the whole
+wideband stream**. That is exact only if the branches differ by a
+frequency-flat constant — true when both antennas are effectively at the same
+point (same mast, stacked). Put the antennas metres apart and every carrier in
+the band acquires its *own* phase difference, set by geometry and direction of
+arrival: the scalar aligns whichever carrier dominates the calibration window
+and partially cancels others.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 210" width="680" height="210" role="img" aria-label="Two antennas feeding two receiver branches into a combiner that applies a single complex gain to align branch one with branch zero before summing. Below, an inset shows the failure case: with widely separated antennas, three carriers across the band each arrive with a different phase difference, so no single complex gain can align all of them and coherence sticks around 0.3 to 0.5.">
+  <rect x="10" y="30" width="86" height="34" rx="6" fill="none" stroke="currentColor"/>
+  <text x="53" y="51" text-anchor="middle" fill="currentColor" font-size="10">antenna A</text>
+  <rect x="10" y="86" width="86" height="34" rx="6" fill="none" stroke="currentColor"/>
+  <text x="53" y="107" text-anchor="middle" fill="currentColor" font-size="10">antenna B</text>
+  <line x1="96" y1="47" x2="150" y2="47" stroke="currentColor"/><polygon points="150,43 160,47 150,51" fill="currentColor"/>
+  <line x1="96" y1="103" x2="150" y2="103" stroke="currentColor"/><polygon points="150,99 160,103 150,107" fill="currentColor"/>
+  <rect x="160" y="30" width="96" height="34" rx="6" fill="none" stroke="currentColor"/>
+  <text x="208" y="51" text-anchor="middle" fill="currentColor" font-size="10">branch 0 (ref)</text>
+  <rect x="160" y="86" width="96" height="34" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="208" y="101" text-anchor="middle" fill="var(--accent)" font-size="10">branch 1</text>
+  <text x="208" y="114" text-anchor="middle" fill="var(--fg-muted)" font-size="9">× one complex gain h</text>
+  <line x1="256" y1="47" x2="316" y2="70" stroke="currentColor"/>
+  <line x1="256" y1="103" x2="316" y2="80" stroke="currentColor"/>
+  <circle cx="326" cy="75" r="12" fill="none" stroke="currentColor"/>
+  <text x="326" y="79" text-anchor="middle" fill="currentColor" font-size="12">+</text>
+  <line x1="338" y1="75" x2="392" y2="75" stroke="currentColor"/><polygon points="392,71 402,75 392,79" fill="currentColor"/>
+  <rect x="402" y="58" width="120" height="34" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="462" y="79" text-anchor="middle" fill="var(--accent)" font-size="10">combined stream</text>
+  <text x="546" y="70" fill="var(--fg-muted)" font-size="9">co-located pair:</text>
+  <text x="546" y="82" fill="var(--fg-muted)" font-size="9">coherence ~0.7+</text>
+  <line x1="20" y1="140" x2="660" y2="140" stroke="var(--fg-muted)" stroke-dasharray="3,4"/>
+  <text x="24" y="158" fill="var(--fg-muted)" font-size="9">metres-apart antennas, busy band:</text>
+  <text x="290" y="163" fill="currentColor" font-size="10">carrier 1: Δφ = 15°</text>
+  <text x="290" y="178" fill="currentColor" font-size="10">carrier 2: Δφ = 130°</text>
+  <text x="290" y="193" fill="currentColor" font-size="10">carrier 3: Δφ = −80°</text>
+  <text x="470" y="170" fill="var(--accent)" font-size="10">one h cannot align all three</text>
+  <text x="470" y="185" fill="var(--accent)" font-size="10">→ coherence stuck ~0.3–0.5</text>
+</svg>
+<figcaption>MRC aligns the branches with one wideband complex gain — exact for a co-located pair, structurally impossible when each carrier has its own phase difference.</figcaption>
+</figure>
+
+The signature is a wideband `coherence` stuck around **0.3–0.5 that no amount
+of tracking improves**. That is not a fault and not a gain problem; it's the
+architecture's honest report that your antennas are too far apart for a
+wideband combine. The correct fix at that point — combining *after* the
+per-channel DDC, one gain per narrowband channel — is a much larger change
+and is **not built**; the coherence figure existing in the health line is
+what makes the limitation visible instead of silent. Operator guidance:
+mount the diversity pair on the same mast, same band, same polarization, and
+save the widely-spaced-antennas idea for a second independent SDR instead.
+
+## `mrc` vs `mrc-static`
+
+Both modes calibrate the same way; they differ in what happens after the
+first accepted estimate. `mrc` keeps re-estimating (a slow ~200 ms tracking
+loop) — right when the two RX channels sit on hardware whose relative phase
+can drift. `mrc-static` freezes after one estimate — the classic one-shot
+calibration, right when the front end shares one LO and the branch phase
+genuinely is a constant. Which hardware you have is
+[Part 12]({{ '/blog/tutorials/analog-edge-12-front-end-classes/' | relative_url }})'s
+whole subject (and the log's `branch_phase_deg` answers it without buying
+anything). When in doubt: record a `diversity_capture`
+([Part 10]({{ '/blog/tutorials/analog-edge-10-capture-discipline/' | relative_url }}))
+and run the offline A/B —
+
+```
+GT_DIVERSITY_CAPTURE=<prefix>.diversity.json go test ./cmd/gophertrunk \
+    -run TestDiversityCombinerReplay -v
+```
+
+— which prints a windowed coherence/gain/**phase** trace and decodes four
+arms through identical downstream wiring: branch 0 alone, branch 1 alone,
+static combine, tracking combine, scored by CRC-clean decode count. Yield is
+the verdict, never EVM — the repo has measured a combiner "improving" a
+constellation while decoding nothing. If neither combined arm beats your
+better branch alone, the second antenna isn't paying for its coax on that
+signal, and that's worth knowing before winter.
+
+## Where this goes next
+
+The `mrc` vs `mrc-static` choice is really a question about what's inside
+your radio: one synthesizer or two.
+[Part 12]({{ '/blog/tutorials/analog-edge-12-front-end-classes/' | relative_url }})
+sorts front ends into those two classes — shared LO versus independent PLLs —
+and shows how `branch_phase_deg` identifies yours from the log line alone,
+no capture required.
+
+## FAQ
+
+**Will diversity help my weak-signal problem?**
+It helps *fading* — the calls that come and go. It does not fix a system
+that's uniformly 10 dB short; that's Parts 7–9 territory (antenna, feedline,
+LNA). If your marginal channel fails steadily rather than intermittently, fix
+the single-antenna chain first — it's cheaper and helps every hour of the day.
+
+**Can I do diversity with two RTL-SDR dongles?**
+Not coherent MRC — the branches must share a sampling clock and be delivered
+sample-aligned, which the SoapyRemote dual-channel path provides and two free-
+running dongles do not. Two dongles are still great for coverage (separate
+control + voice, or two bands): see the
+[multi-dongle guide]({{ '/multi-dongle-sdr-setup/' | relative_url }}).
+
+**What coherence number should I expect?**
+Healthy co-located pair on a live band: roughly 0.6–0.9 depending on how much
+correlated signal the window holds (the mapping to per-branch SNR is
+[Part 13]({{ '/blog/tutorials/analog-edge-13-coherence-not-dbfs/' | relative_url }})).
+Stuck at 0.3–0.5: wideband-scalar limit — antennas too separated. Near zero
+with both branches alive: different bands/polarizations or a clocking problem.
+
+**Does enabling `mrc` risk making things worse?**
+Before calibration the combiner passes the reference branch through, and a
+window that fails its quality gates *holds* the previous weights rather than
+lurching — so the designed floor is "your primary antenna, as-is." The honest
+answer beyond design intent is your own four-arm A/B, which is exactly what
+the harness exists for.
+
+**Which branch is the reference?**
+Branch 0 by default; the driver re-selects only if the reference goes
+genuinely dead (persistently ~20 dB below a challenger) — deliberately sticky,
+because swapping the phase anchor mid-stream is itself a glitch. An early
+version re-picked the loudest branch every datagram while uncalibrated, and an
+ordinary ~1 dB crossover between two healthy receivers kept swapping the
+anchor — since fixed.
+
+## Series navigation
+
+**Part 11 of 14** · ←
+[Part 10: Capture Discipline — cfile, cs16, SigMF & Metadata]({{ '/blog/tutorials/analog-edge-10-capture-discipline/' | relative_url }})
+· Next →
+[Part 12: Front-End Classes — Shared LO vs Independent PLLs]({{ '/blog/tutorials/analog-edge-12-front-end-classes/' | relative_url }})

--- a/docs/_posts/2026-08-28-tetra-end-to-end-11-dmo-direct-mode.md
+++ b/docs/_posts/2026-08-28-tetra-end-to-end-11-dmo-direct-mode.md
@@ -1,0 +1,269 @@
+---
+title: "TETRA End to End, Part 11: DMO I — Direct Mode & the DSB/DNB Geometry"
+description: "TETRA without a network: how Direct Mode reuses the trunked physical layer with different burst layouts, how GopherTrunk derived the DSB and DNB block geometry from the spec's bit tables, and why one pair of offsets was confirmed by a sharp CRC optimum rather than trusted from another project."
+category: deep-dives
+keywords: tetra dmo, direct mode operation, dsb dnb burst geometry, en 300 396-2, dm-sync pdu, sch/s decode, osmo-tetra-dmo, tetra burst slicing, gophertrunk tetra
+tags: [tetra-end-to-end, tetra, dmo, protocol, dsp, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "TETRA End to End"
+series_part: 11
+---
+
+*Part 11 of **TETRA End to End**, a 14-part deep dive into how GopherTrunk turns
+one real 25 kHz TETRA carrier into clear recorded voice.
+[Part 10]({{ '/blog/deep-dives/tetra-end-to-end-10-control-channel-sync-loss/' | relative_url }})
+hardened the trunked-mode control channel and closed the TMO arc. Now the
+detour the series has been building toward: an operator pointed GopherTrunk at
+438.9 MHz, where two handheld radios were talking **directly to each other** —
+no repeater, no site, no control channel. That is TETRA DMO, Direct Mode
+Operation, and almost nothing in the trunked ingestion path applies to it. Over
+the next three parts we take DMO from "an undocumented-in-practice mode read
+out of the spec" to a production daemon pipeline — including the wrong verdict
+we published along the way and had to retract.*
+
+> **TL;DR:** DMO (ETSI **EN 300 396-2**) reuses the TMO physical layer this
+> series already built — same π/4-DQPSK at 18 ksym/s, same 25 kHz channels and
+> 255-symbol slots, same training sequences, same scrambler polynomial — but
+> with its **own burst field layouts**: the **DSB** (sync burst: frequency
+> correction + SCH/S + sync train + BKN2) and **DNB** (normal burst: BKN1 +
+> normal train + BKN2). `internal/radio/tetra/dmo.go` slices them by geometry
+> derived from the spec's Tables 15/16, and the DNB offsets **−108/+11**
+> (`dmDNBBKN1Start`/`dmDNBBKN2Start`) were *confirmed by a sharp TCH/S-CRC
+> optimum* on a real capture — osmo-tetra-dmo's TMO-copied −115/+19 measures
+> worse. The DM-SYNC PDU reuses the TMO SYNC-PDU layout, so **`ParseSyncPDU`**
+> decodes it unchanged; with the receiver's blind CMA equalizer, CRC-valid
+> SCH/S on the first capture went **6 → 64**.
+
+**Key takeaways**
+
+- **DMO is the same radio with different framing.** Modulation, slot length,
+  training sequences, scrambler polynomial — all shared with TMO. Only the
+  burst field layout and the protocol on top differ, so the receiver, the
+  correlators, and the channel-coding chains are all reused.
+- **Derive geometry from the spec, then confirm it on air.** The block offsets
+  come from halving EN 300 396-2's bit tables into dibits — and the −108/+11
+  DNB answer was validated by scanning offsets against real CRC yield, where
+  the correct geometry shows a sharp optimum.
+- **The sync path is TMO in a trench coat.** A DSB's SCH/S is scrambled with
+  colour 0 and coded exactly like TMO's BSCH, and the DM-SYNC PDU matches the
+  TMO SYNC-PDU field layout — `DecodeBSCH` and `ParseSyncPDU` both just work.
+- **Honest scope, stated in the source.** `dmo.go`'s package comment says
+  plainly what is and isn't validated — the #764/#771 discipline applied to a
+  brand-new mode.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| Burst geometry | DSB/DNB block offsets in dibits, from Tables 15/16 | `internal/radio/tetra/dmo.go` (`dmDNBBKN1Start` = −108, `dmDNBBKN2Start` = +11) |
+| Burst extraction | correlate training sequences, slice blocks | `dmo.go` (`ExtractDMBursts`, `ExtractDMBurstsSoft`) |
+| Burst record | kind, lead index, rotation, hard + soft blocks | `dmo.go` (`DMBurst`) |
+| SCH/S decode | DSB block 1 → 60 type-1 bits, colour-0 scramble | `internal/radio/tetra/dmo_decode.go` (`DecodeDMSCHS` → `DecodeBSCH`) |
+| SCH/H decode | DSB block 2 → 124 type-1 bits | `dmo_decode.go` (`DecodeDMSCHH` → `DecodeSCHHD`) |
+| SYNC PDU | frame/slot numbering, MNI, colour — TMO layout | `internal/radio/tetra/sync_pdu.go` (`ParseSyncPDU`) |
+| Trained equalizer | per-burst LMS on rotation-0 DNBs (opt-in) | `internal/radio/tetra/dmo_equalizer.go` (`ExtractDMBurstsEqualized`) |
+| Replay harness | skip-guarded capture A/B | `cmd/gophertrunk/tetra_dmo_replay_test.go` (`TestTETRADMOReplay`) |
+
+## In this post
+
+- **What direct mode is** — and why the trunked ingestion path can't touch it.
+- **Shared physical layer, different bursts** — what carries over from TMO.
+- **Deriving the geometry** — bit tables to dibit offsets, and the −108/+11 proof.
+- **Locking onto a DSB** — SCH/S, the DM-SYNC PDU, and the first capture's numbers.
+- **What was honestly not yet known** — the scope statement that paid off.
+
+## What direct mode is
+
+Everything in this series so far assumed infrastructure: a base station
+transmitting a continuous downlink, a control channel to camp, grants to
+follow. DMO deletes all of it. Two (or more) radios share one 25 kHz channel
+directly: a transmitting radio keys up, sends a **Direct Mode Synchronisation
+Burst (DSB)** so listeners can acquire, then a train of **Direct Mode Normal
+Bursts (DNB)** carrying the call — and when the PTT releases, the channel is
+*silent*. No carrier, no heartbeat, nothing to stay locked to.
+
+That inverts the receiver's job. The TMO `ControlChannel` state machine
+expects a persistent carrier and slices the TMO burst geometry; pointed at a
+DMO channel it produces the operator-visible symptom we'll dissect in Part 13
+(`sch_pdus=0`, endless `sync gap` / `dsp resync`). So DMO gets its own layer:
+stateless extractors over the demodulated dibit stream (`ExtractDMBursts` and
+its soft/equalized variants), designed offline-first so every decision could be
+validated against captures before any daemon wiring existed.
+
+## Shared physical layer, different bursts
+
+The good news, verified in `dmo_test.go` against EN 300 396-2 §9.4.3.3
+equations 63/64/66: DMO reuses the TMO physical layer nearly wholesale. Same
+π/4-DQPSK at 18 ksym/s ([Part 1]({{ '/blog/deep-dives/tetra-end-to-end-01-pi4-dqpsk-carrier/' | relative_url }})),
+same 255-symbol / 14.167 ms timeslots and 4-slot frame / 18-frame multiframe
+([Part 2]({{ '/blog/deep-dives/tetra-end-to-end-02-bursts-slot-grid/' | relative_url }})),
+the **same** normal and synchronisation training sequences, and the same 32-tap
+scrambler polynomial with colour 0 for the DSB's signalling — exactly like
+TMO's BSCH ([Part 4]({{ '/blog/deep-dives/tetra-end-to-end-04-scrambling-colour-codes/' | relative_url }})).
+Even the channel coding turned out to be no new code family at all: SCH/S is
+bit-for-bit the TMO BSCH chain, SCH/H is TMO's SCH/HD, SCH/F and TCH/S likewise
+([Part 3]({{ '/blog/deep-dives/tetra-end-to-end-03-channel-coding-crc/' | relative_url }})'s
+machinery, reused whole).
+
+What differs is the **field layout inside the burst** — where the blocks sit
+relative to the training sequence — and that is the entire content of
+`dmo.go`'s geometry section.
+
+## Deriving the geometry
+
+EN 300 396-2 specifies burst contents as bit-number tables. GopherTrunk works
+in dibits (one per π/4-DQPSK symbol), so the derivation is mechanical — halve
+the bit numbers — and recorded verbatim in the source so the next reader can
+re-check it against the spec:
+
+```go
+// internal/radio/tetra/dmo.go (shape) — geometry, relative to the training
+// sequence lead dibit L, derived by halving EN 300 396-2 Tables 15/16:
+//   DSB: freq-corr dibits 7..46 (40) · SCH/S 47..106 (60) ·
+//        sync train 107..125 (19, lead L=107) · BKN2 126..233 (108)
+//   DNB: BKN1 7..114 (108) · normal train 115..125 (11, lead L=115) ·
+//        BKN2 126..233 (108)
+const (
+    dmDSBFreqCorrStart = -100 // L-100 .. L-60
+    dmDSBBKN1Start     = -60  // SCH/S, 60 dibits
+    dmDSBBKN2Start     = 19
+    dmDNBBKN1Start     = -108 // L-108 .. L
+    dmDNBBKN2Start     = 11   // L+11 .. L+119
+)
+```
+
+The DNB pair deserves the emphasis it gets, because there was a competing
+answer in the wild: osmo-tetra-dmo slices DNBs at **−115/+19** — the TMO NCDB
+offsets from [Part 5]({{ '/blog/deep-dives/tetra-end-to-end-05-tchs-traffic-channel/' | relative_url }}),
+copied across. The DMO tables say −108/+11 (a DNB has no AACH halves flanking
+its midamble). Rather than trust either reading, the offsets were confirmed
+empirically: slicing a real capture's DNBs across candidate offsets, the
+TCH/S-CRC yield shows a **sharp optimum exactly at −108/+11**, and the
+TMO-copied geometry is measurably worse. A CRC-protected payload is a wonderful
+instrument — the correct geometry is not marginally better, it is a spike.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 210" width="680" height="210" role="img" aria-label="Field layouts of the two DMO bursts drawn as horizontal bars in dibits relative to the training-sequence lead L. The DSB has a 40-dibit frequency-correction field, a 60-dibit SCH/S block, a 19-dibit synchronisation training sequence, and a 108-dibit BKN2 block. The DNB has a 108-dibit BKN1 block starting at L minus 108, an 11-dibit normal training sequence, and a 108-dibit BKN2 block starting at L plus 11. The training sequences are highlighted as the anchors everything is measured from.">
+  <text x="10" y="40" fill="currentColor" font-size="11">DSB</text>
+  <rect x="60" y="26" width="88" height="26" fill="none" stroke="var(--fg-muted)"/>
+  <text x="104" y="43" text-anchor="middle" fill="var(--fg-muted)" font-size="9">freq corr · 40</text>
+  <rect x="148" y="26" width="132" height="26" fill="none" stroke="currentColor"/>
+  <text x="214" y="43" text-anchor="middle" fill="currentColor" font-size="9">SCH/S (BKN1) · 60</text>
+  <rect x="280" y="26" width="44" height="26" fill="var(--accent)" opacity="0.85"/>
+  <text x="302" y="43" text-anchor="middle" fill="currentColor" font-size="8">sync·19</text>
+  <rect x="324" y="26" width="238" height="26" fill="none" stroke="currentColor"/>
+  <text x="443" y="43" text-anchor="middle" fill="currentColor" font-size="9">BKN2 · 108</text>
+  <line x1="280" y1="58" x2="280" y2="66" stroke="var(--accent)"/>
+  <text x="280" y="78" text-anchor="middle" fill="var(--accent)" font-size="9">L (sync train lead)</text>
+  <text x="10" y="130" fill="currentColor" font-size="11">DNB</text>
+  <rect x="60" y="116" width="238" height="26" fill="none" stroke="currentColor"/>
+  <text x="179" y="133" text-anchor="middle" fill="currentColor" font-size="9">BKN1 · 108 — starts at L−108</text>
+  <rect x="298" y="116" width="26" height="26" fill="var(--accent)" opacity="0.85"/>
+  <text x="311" y="133" text-anchor="middle" fill="currentColor" font-size="8">11</text>
+  <rect x="324" y="116" width="238" height="26" fill="none" stroke="currentColor"/>
+  <text x="443" y="133" text-anchor="middle" fill="currentColor" font-size="9">BKN2 · 108 — starts at L+11</text>
+  <line x1="298" y1="148" x2="298" y2="156" stroke="var(--accent)"/>
+  <text x="298" y="168" text-anchor="middle" fill="var(--accent)" font-size="9">L (normal train lead)</text>
+  <text x="340" y="196" text-anchor="middle" fill="var(--fg-muted)" font-size="10">−108/+11, from Tables 15/16 — confirmed by a sharp TCH/S-CRC optimum; the TMO-copied −115/+19 measures worse</text>
+</svg>
+<figcaption>The two DMO bursts in dibits relative to the training-sequence lead: the DSB carries frequency correction and SCH/S ahead of its sync train; the DNB is two 108-dibit blocks around an 11-dibit midamble at −108/+11.</figcaption>
+</figure>
+
+## Locking onto a DSB
+
+Detection reuses the TMO trick: correlate each training sequence under all four
+residual constellation rotations, record which rotation matched in
+`DMBurst.Rotation`, and de-rotate the sliced blocks by `(4−Rotation)&3` before
+decoding. From there the DSB's signalling path is TMO in a trench coat:
+
+```go
+// internal/radio/tetra/dmo_decode.go (shape) — DecodeDMSCHS
+// Per EN 300 396-2 §8.2.5.2 a DSB's SCH/S is scrambled with colour code 0,
+// so this is the DMO analog of the TMO BSCH decode.
+func DecodeDMSCHS(b DMBurst) (type1 []byte, crcOK bool) {
+    if b.Kind != DMBurstSync || len(b.SCHS) != dmSCHSDibits {
+        return nil, false
+    }
+    return DecodeBSCH(dmDerotatedBits(b.SCHS, b.Rotation))
+}
+```
+
+And the 60 type-1 bits it yields are a **DM-SYNC PDU** that reuses the TMO
+SYNC-PDU field layout — so `ParseSyncPDU`, written for trunked mode, decodes it
+unchanged: colour 0, timeslot and frame numbers, MNI with MCC/MNC = 0 for a
+radio-to-radio call. On the operator's first capture
+(`tetra_dmo_test2_20sec_cs16_144k`, 438.9 MHz, cs16 at 144 kHz), replayed
+through `TestTETRADMOReplay`, the frame counter advances monotonically across
+bursts — a genuine lock, not a correlator coincidence. The yield numbers also
+re-ran Part 9's lesson in miniature: with the receiver's blind CMA equalizer
+(the harness default), CRC-valid SCH/S went **6 → 64** — `DecodeDMSCHS` at
+64/68 and `DecodeDMSCHH` at 62/68 — the same ISI-inversion lever, working on a
+mode it had never seen. A per-burst trained LMS variant also exists for DNBs
+(`ExtractDMBurstsEqualized`, rotation-0 bursts only, since a frozen filter
+cannot invert a residual per-symbol phase ramp), pinned at 12% → 0% synthetic
+payload error in `dmo_equalizer_test.go` and staged behind `GT_TETRA_DMO_LMS`.
+
+## What was honestly not yet known
+
+`dmo.go`'s package comment, at the point this part describes, said the quiet
+part in writing: burst detection and block slicing only; the DM call-control
+protocol (EN 300 396-3 — who is calling whom) not wired; and *nothing yet
+validated against a real DMO capture* for the voice path. The signalling
+decoded beautifully. The TCH/S speech in those same captures sat stubbornly at
+the CRC chance floor — roughly 1 in 256 bursts passing, exactly what random
+bits produce. Every synthetic round-trip passed. And the first conclusion drawn
+from that split was wrong in a way this series has warned about since
+[Part 3]({{ '/blog/deep-dives/tetra-end-to-end-03-channel-coding-crc/' | relative_url }}):
+a green synthetic is not proof, and a self-consistent bug hides on both sides
+of a round-trip.
+
+## Where this goes next
+
+The chance floor got read as air-interface encryption — a plausible verdict for
+a professional radio system, published in the issue, and **wrong**.
+[Part 12]({{ '/blog/deep-dives/tetra-end-to-end-12-dmo-descramble-colour/' | relative_url }})
+tells the #1003 arc honestly: the reporter's codeplug proving the radios were
+clear, the one-line descramble skip that Part 4 foreshadowed, the failing-first
+regression that finally caught it — and the second capture where the voice
+descrambles with a colour code the signalling never advertised.
+
+## FAQ
+
+**Is DMO just TETRA's version of talk-around/simplex?**
+Functionally yes — radios talking directly on a channel without
+infrastructure, common for fireground and coverage-hole use. But it is a fully
+specified TETRA mode (EN 300 396) with its own burst types, sync procedure,
+and call-control protocol, not merely a carrier with no repeater.
+
+**Why couldn't the existing TMO decoder be adapted instead of writing new extractors?**
+The TMO `ControlChannel` assumes a continuous downlink and slices TMO burst
+geometry at fixed positions in a persistent stream. DMO is bursty and silent
+between transmissions, with different block offsets. Stateless per-burst
+extractors fit that shape and — critically — could be validated offline against
+captures before any live wiring existed.
+
+**How was −108/+11 confirmed if another open-source project uses −115/+19?**
+By measurement, not authority. Slicing a real capture's DNBs across candidate
+offsets and counting CRC-valid TCH/S shows a sharp optimum at −108/+11 —
+which also matches a fresh reading of Tables 15/16. The lesson generalizes:
+when two sources disagree, a CRC-protected payload is the tiebreaker.
+
+**Why does the DSB use colour code 0 for its signalling?**
+By spec (§8.2.5.2): the sync burst must be decodable by a radio that knows
+nothing yet, so its SCH/S and SCH/H are scrambled with the fixed colour-0 seed
+— the same bootstrap logic as TMO's BSCH. Remember from Part 4 that colour 0 is
+*not* a no-op — a fact about to become the whole plot of Part 12.
+
+**Can I try this on my own DMO radios?**
+Yes — record cs16 IQ of a transmission and run
+`GT_TETRA_DMO_IQ=<file> GT_TETRA_DMO_RATE=144000 go test ./cmd/gophertrunk
+-run TestTETRADMOReplay -v`. Part 14 catalogs the whole harness, including the
+colour and equalizer knobs the next two parts introduce.
+
+## Series navigation
+
+**Part 11 of 14** · ←
+[Part 10: The Control Channel Under Stress — Sync Loss & the CC Equalizer]({{ '/blog/deep-dives/tetra-end-to-end-10-control-channel-sync-loss/' | relative_url }})
+· Next →
+[Part 12: DMO II — The 'Encrypted' Verdict That Was a Descramble Skip]({{ '/blog/deep-dives/tetra-end-to-end-12-dmo-descramble-colour/' | relative_url }})

--- a/docs/_posts/2026-08-28-weak-signal-engineering-11-tracking-mrc.md
+++ b/docs/_posts/2026-08-28-weak-signal-engineering-11-tracking-mrc.md
@@ -1,0 +1,333 @@
+---
+title: "Weak-Signal Engineering, Part 11: Diversity II — Tracking Without Breaking the Differential"
+description: "Why independent-PLL front ends make a frozen diversity calibration decay, and how TrackingCalibrator re-estimates the branch gain continuously yet stays safe ahead of a differential decoder — the anchored phase, the hold-don't-fallback rule, the step clamp, and the four-arm capture A/B."
+category: deep-dives
+keywords: tracking calibrator, diversity phase drift, independent pll front end, differential decoder phase, one-pole smoothing, mrc static vs tracking, coherence hold, capture a/b testing, gophertrunk weak-signal engineering
+tags: [weak-signal-engineering, diversity, mrc, tracking, dsp, testing, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Weak-Signal Engineering"
+series_part: 11
+---
+
+*Part 11 of **Weak-Signal Engineering**, a 14-part series on decoding the
+marginal regime — where the receiver locks but only a fraction of frames
+survive. [Part 10]({{ '/blog/deep-dives/weak-signal-engineering-10-mrc-calibration/' | relative_url }})
+built the coherence-gated calibration that decides when two branches can be
+combined at all. It left one assumption standing: that the branch gain, once
+measured, stays put. On some hardware it does. On a USRP with two TwinRX
+daughterboards it does not — the relative phase is random at every LO lock
+and walks afterwards. So the calibration must track. But
+[Part 5]({{ '/blog/deep-dives/weak-signal-engineering-05-snapshot-trick/' | relative_url }})
+spent an entire post on why a continuously-adapting filter ahead of a
+differential decoder corrupts every dibit. This part is about why tracking
+MRC survives that rule — and the claim is measured, not asserted.*
+
+> **TL;DR:** `diversity.TrackingCalibrator` re-estimates the branch gain from
+> each ~2 ms `CrossStats` window and smooths one-pole with α = 0.01 (τ ≈
+> 200 ms). It is safe ahead of a differential decoder for a **structural**
+> reason CMA lacked: the reference branch's weight is pinned to exactly
+> `1+0j`, so the output phase is ANCHORED to the reference branch's own —
+> only the estimate *error* can move it, and `arg(y/x0) ≈ −ε·|h|²/(1+|h|²)`,
+> zero at convergence. `TestTrackingCalibratorIsDifferentialSafe` bounds the
+> per-window output phase step against the 45° π/4-DQPSK decision spacing. A
+> rejected window **holds** the previous gains — never falls back to
+> passthrough, because a mid-stream fallback is itself a phase step.
+> `mrc-static` (α = 0) is the one-shot escape hatch: the first accepted
+> window is snapped, not smoothed, bit-identical to a one-shot least-squares
+> calibration. The verdict instrument is `TestDiversityCombinerReplay`: four
+> decode arms scored by CRC-clean BSCH — and tracking-as-default is **not yet
+> verified on air**.
+
+**Key takeaways**
+
+- **Hardware class decides whether a constant is a lie.** Shared-LO
+  front ends (one AD9361, a B210) have genuinely fixed branch phase;
+  separate daughterboards with independent PLLs are frequency-locked but
+  phase-random per lock, walking after. Tracking is required for the second
+  class and a variance-reducing no-op for the first.
+- **The CMA lesson does not transfer — structurally.** CMA's cost is
+  rotation-invariant, so nothing constrains its output phase. Here `h₀ ≡ 1+0j`
+  anchors the output to the reference branch; only estimate error perturbs
+  it, and that error is gated, damped by α, and hard-clamped.
+- **Hold, never fall back.** Dropping to passthrough mid-stream is a large
+  phase discontinuity — the exact failure class being avoided. A rejected
+  window keeps the previous gains; a clamped |h| cannot diverge the way CMA
+  taps can, so holding is safe where CMA needed a re-seed.
+- **Yield is the verdict, and the on-air verdict is still open.** The replay
+  harness scores each-branch-alone, static, and tracking by CRC-clean BSCH.
+  Until an operator's own capture shows tracking winning, it is a lever, not
+  a default.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| Tracking loop | window estimate → gate → one-pole → clamp | `internal/dsp/diversity/tracking.go` (`TrackingCalibrator.Observe`) |
+| Phase anchor | reference weight pinned to `1+0j` | `tracking.go` (`estimate`, `applied[0]`) |
+| Gates | lock 0.5, track 0.35, dead branch −100 dBFS | `tracking.go` (`TrackingOptions.withDefaults`) |
+| Step clamp | ≤ 0.05 rad (~2.9°) phase, ≤ 1.25× magnitude per update | `tracking.go` (`clampStep`, `trackingMaxStepRad`) |
+| Differential safety | per-window output phase step ≤ 1° measured | `tracking_test.go` (`TestTrackingCalibratorIsDifferentialSafe`) |
+| One-shot mode | α = 0 snaps the first window, then freezes | `tracking.go` (`estimate`), `mrc.go` in `internal/sdr/soapyremote` (`mrc-static`) |
+| Capture A/B | four arms scored by CRC-clean BSCH | `cmd/gophertrunk/diversity_replay_test.go` (`TestDiversityCombinerReplay`) |
+| Pre-combine tap | per-branch cs16 files, alignment invariant | `internal/sdr/soapyremote/branchcapture.go` (`branchRecorder`) |
+
+## In this post
+
+- **Why a frozen constant decays** — two front-end classes, one config knob.
+- **Anchored, not rotation-invariant** — the structural difference from CMA.
+- **The window loop** — estimate, gate, smooth, clamp.
+- **Holds, not fallbacks** — and the reference-flapping fix.
+- **The four-arm A/B** — how the verdict gets decided, and what's still open.
+
+## Why a frozen constant decays
+
+A one-shot calibration measures `h` once and applies it forever. Whether that
+is correct is a property of the *front end*, not the algorithm. On a
+shared-LO, single-chip design — an AD9361-class device, both receive chains
+clocked and mixed from one synthesizer — the branch-to-branch phase is fixed
+trace skew plus a power-up divider phase, and it genuinely does not move
+while the synthesizer stays locked. Freeze away.
+
+Now put the branches on separate daughterboards with independent PLLs — the
+reported configuration was `rx_subdev_spec=B:0 A:0` on a TwinRX pair. The
+PLLs are frequency-locked to a common reference, so there is no beat note;
+but the relative phase is **random at each lock and walks afterwards**. A
+constant measured at t=0 is a little wrong at t=10 s and arbitrarily wrong
+eventually. The tracking calibrator's docstring compresses it: "a constant
+measured once decays."
+
+Because the hardware class decides, the config exposes both:
+`diversity: mrc` tracks; `diversity: mrc-static` (α = 0) snaps the first
+accepted window and freezes — and the field instrument for choosing is
+`branch_phase_deg` in the periodic MRC health line
+(`internal/sdr/soapyremote/mrc.go`): constant ⇒ shared-LO, walking ⇒
+independent PLLs. The operator-seat reading of that line is covered in
+[The Analog Edge, Part 11]({{ '/blog/tutorials/analog-edge-11-diversity-mrc/' | relative_url }});
+this post owns the algorithm.
+
+## Anchored, not rotation-invariant
+
+Part 5's rule was absolute: never feed a continuously-adapting filter to a
+differential decoder, because a time-varying output phase does not cancel in
+`s·conj(prev)`. Streaming-adaptive CMA ahead of a differential decode
+measured CRC 0 — not degraded, zero. So why is a calibrator that updates
+every 2 ms window acceptable?
+
+Because the failure was never "adaptation" — it was **unconstrained phase**.
+CMA's constant-modulus cost is rotation-invariant: rotate every tap by any
+angle and the cost is identical, so the output phase is a free parameter that
+wanders as the taps adapt. The tracking combiner has no such freedom. The
+reference branch's weight is pinned to exactly `1+0j`, so the combined output
+phase is anchored to the reference branch's own phase. Write the second
+branch as `x1 = h·x0 + n` and let the estimate carry an error,
+`ĥ = h·e^{jε}`. Then
+
+y = (x0 + conj(ĥ)·x1) / (1+|ĥ|²)  ⇒  arg(y/x0) ≈ −ε·|h|²/(1+|h|²)
+
+— at most about ε/2, and **exactly zero when the estimate is right**. The
+only phase motion the differential decoder can ever see is the motion of the
+estimate *error*, and three mechanisms bound it: the coherence gate keeps
+garbage windows out, the one-pole scales each accepted step by α = 0.01, and
+`clampStep` hard-limits any single update to 0.05 rad (~2.9°) of phase and
+1.25× of magnitude regardless of what slipped through.
+
+And per this series' discipline, the claim is measured, not argued:
+
+```go
+// internal/dsp/diversity/tracking_test.go (shape) — TestTrackingCalibratorIsDifferentialSafe
+// Per-window residual phase relative to the reference branch. The step
+// between consecutive windows is what a differential decode actually sees.
+for i := window * 2; i+window <= n; i += window { // skip the lock window
+    cur := residualPhaseDeg(y[i:i+window], refN[i:i+window])
+    /* … track the max step between consecutive windows … */
+}
+// pi/4-DQPSK decisions are 45° apart. Anything approaching a degree here
+// would already be suspicious; the design budget is hundredths.
+if maxStep > 1.0 {
+    t.Errorf("max per-window output phase step %.3f°, want <=1° (45° decision spacing)", maxStep)
+}
+```
+
+At a 2 ms window and α = 0.01 the per-burst perturbation is a hundredth of a
+degree against a 45° decision spacing — four orders of magnitude of margin.
+
+## The window loop: estimate, gate, smooth, clamp
+
+`Observe` accumulates branch chunks into `CrossStats` until `WindowSamples`
+(default 8192) is reached, then runs one decision:
+
+```go
+// internal/dsp/diversity/tracking.go (shape) — estimate
+gate := c.opts.TrackCoherence          // 0.35 once calibrated…
+if !c.calibrated {
+    gate = c.opts.LockCoherence        // …0.5 for the FIRST estimate
+}
+/* … per branch: reject dead power, reject non-finite / out-of-bounds h,
+   take worst-branch coherence … */
+if worst < gate {
+    c.hold(worst)
+    return false
+}
+for k := 1; k < c.branches; k++ {
+    if !c.calibrated {
+        // First accepted window: snap. No smoothing and no clamp, so this
+        // is bit-identical to a one-shot least-squares calibration on the
+        // same window.
+        c.applied[k] = proposed[k]
+        continue
+    }
+    target := smoothGain(c.applied[k], proposed[k], c.opts.Alpha)
+    c.applied[k] = clampStep(c.applied[k], target)
+}
+```
+
+Every constant earns its value. The **lock gate is stricter than the track
+gate** (0.5 vs 0.35) because the first estimate is what a one-shot
+calibration lives with forever, while a tracking update's error averages away
+over ~1/α windows. The **window is 8192 samples**, not one datagram, because
+at |rho| = 0.35 a 184-sample window estimates phase to about 9.5° while an
+8192-sample window gets ~1.2°. The **time constant τ ≈ 200 ms** sits far
+above one TETRA burst (14 ms, so intra-burst phase is effectively constant)
+and far below the drift rate of two independently-locked PLLs. The
+**divergence bounds** on |h|² (1/1024 … 1024, i.e. ±30 dB) reject estimates
+past the point where the weaker branch contributes nothing anyway — far more
+likely numerical garbage than measurement. And the **first accepted window is
+snapped, not smoothed**, so `mrc` and `mrc-static` start bit-identically —
+`TestTrackingFirstUpdateMatchesStaticCalibrate` pins it.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 220" width="680" height="220" role="img" aria-label="Timeline of branch phase versus time on an independent-PLL front end. The true branch phase walks steadily upward. A frozen static calibration is a horizontal line that diverges from the walking phase, with the growing gap shaded as decode-degrading error. The tracking estimate follows the walking phase closely in small clamped steps, with two hold intervals marked where incoherent windows kept the previous gain instead of falling back.">
+  <line x1="50" y1="20" x2="50" y2="180" stroke="var(--fg-muted)"/>
+  <line x1="50" y1="180" x2="640" y2="180" stroke="var(--fg-muted)"/>
+  <text x="20" y="30" fill="var(--fg-muted)" font-size="9">branch</text>
+  <text x="20" y="42" fill="var(--fg-muted)" font-size="9">phase</text>
+  <text x="600" y="196" fill="var(--fg-muted)" font-size="9">time</text>
+  <polyline points="60,150 130,142 200,131 270,123 340,110 410,100 480,86 550,74 630,64" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="632" y="58" text-anchor="end" fill="currentColor" font-size="9">true phase (walks)</text>
+  <line x1="60" y1="150" x2="630" y2="150" stroke="var(--fg-muted)" stroke-dasharray="6 4"/>
+  <text x="628" y="164" text-anchor="end" fill="var(--fg-muted)" font-size="9">mrc-static: frozen at first lock</text>
+  <polyline points="60,150 130,145 200,134 270,126 340,113 410,113 480,89 550,77 630,67" fill="none" stroke="var(--accent)" stroke-width="1.5"/>
+  <text x="330" y="212" text-anchor="middle" fill="var(--accent)" font-size="9">tracking: one-pole steps, ≤2.9° per update</text>
+  <rect x="340" y="104" width="70" height="18" fill="none" stroke="var(--accent)" stroke-dasharray="3 3"/>
+  <text x="375" y="98" text-anchor="middle" fill="var(--accent)" font-size="8">hold (|rho| &lt; 0.35)</text>
+  <line x1="550" y1="74" x2="550" y2="150" stroke="var(--fg-muted)" stroke-dasharray="2 3"/>
+  <text x="556" y="120" fill="var(--fg-muted)" font-size="8">static's growing error</text>
+</svg>
+<figcaption>On independent-PLL hardware the true branch phase walks; the frozen calibration's error grows without bound while tracking follows in clamped, gated steps — and holds rather than falling back when a window is incoherent.</figcaption>
+</figure>
+
+## Holds, not fallbacks — and the flapping fix
+
+What happens when a window fails a gate? The obvious answer — drop back to
+reference-only passthrough until coherence returns — is wrong, and the
+docstring says why: "falling back mid-stream is itself a large phase step,
+the exact failure class being avoided." A stale-but-bounded weight is
+strictly better than a step. So a rejected window **holds**: gains stay,
+`holds` increments, and `TestTrackingCalibratorHoldsOnIncoherentWindow`
+pins that pure-noise windows neither move the gains nor drop the combiner to
+passthrough. This is a deliberate divergence from `SnapshotCMA`'s
+re-seed-to-passthrough guard
+([Part 6]({{ '/blog/deep-dives/weak-signal-engineering-06-normalisation-guards/' | relative_url }})),
+and the difference is principled: CMA's taps can diverge without bound, so a
+poisoned filter must be reset; a clamped |h| cannot, so it is safe to keep.
+The `Counters()` pair makes the state legible — a climbing hold count against
+a flat update count is the signature of two receivers not seeing the same
+signal.
+
+A related fix from the same review: while uncalibrated, the reference branch
+was re-chosen by `argmax` of branch power on **every datagram**. Two healthy
+receivers routinely cross within ~1 dB, so the phase anchor itself swapped
+branches mid-stream — a discontinuity injected by the very machinery meant to
+prevent one. The reference is now chosen stably rather than per-datagram.
+
+## The four-arm A/B — and what is still open
+
+Every claim above is synthetic-pinned, and this series has a name for
+trusting that alone: the self-consistent-synthetic trap. The on-air verdict
+needs pre-combine truth, which is why the capture tap exists where it does —
+`branchRecorder` (`internal/sdr/soapyremote/branchcapture.go`) dumps each
+branch to its own headerless cs16 file *before* the combiner, with an
+alignment invariant: a datagram that did not carry every branch is dropped
+from **both** files and counted, never written short, because one short
+write silently desynchronises the pair and invalidates every later
+conclusion. Every other IQ tap in GopherTrunk sits downstream of the
+combiner and can answer nothing about it.
+
+`TestDiversityCombinerReplay` (`cmd/gophertrunk/diversity_replay_test.go`,
+driven by `GT_DIVERSITY_CAPTURE=<prefix>.diversity.json`) then does two
+things. It prints a windowed coherence/gain/**phase** trace with an explicit
+verdict line — flat phase ⇒ "a frozen calibration is sufficient here";
+walking ⇒ "tracking is doing real work", in degrees per second. And it
+decodes four arms through the identical TETRA BSCH scorer:
+
+```go
+// cmd/gophertrunk/diversity_replay_test.go (shape) — the four arms
+arms := []struct{ name string; iq []complex64 }{
+    {"branch0-only", br0},
+    {"branch1-only", br1},
+    {"static-combine", combineWith(t, br0, br1,
+        diversity.NewTrackingCalibrator(2, diversity.TrackingOptions{WindowSamples: window, Alpha: 0}))},
+    {"tracking-combine", combineWith(t, br0, br1,
+        diversity.NewTrackingCalibrator(2, diversity.TrackingOptions{WindowSamples: window}))},
+}
+// "CRC-clean BSCH count is the verdict. Do NOT conclude anything from EVM…"
+```
+
+Each branch alone, one-shot static, and tracking — scored by CRC-clean BSCH,
+per [Part 2]({{ '/blog/deep-dives/weak-signal-engineering-02-metrics-that-lie/' | relative_url }})'s
+rule that a combiner can improve every intermediate metric while decoding
+nothing. The honest status line: **tracking-as-default is not yet verified on
+air.** The harness, the tap, and the verdict criteria are all in the tree;
+the gate is an operator's own capture showing the tracking arm winning.
+
+## Where this goes next
+
+Diversity closes the lever list. What remains is the discipline that decides
+*which* lever a symptom actually calls for — and the sharpest example in the
+project's history is a signal that decoded at one capture rate and not
+another. [Part 12]({{ '/blog/deep-dives/weak-signal-engineering-12-proving-signal/' | relative_url }})
+turns [#764](https://github.com/MattCheramie/GopherTrunk/issues/764) into a
+worked example of experimental design: find the invariant your DSP
+guarantees, isolate it with an independent implementation, and prove the
+deficit lives in the samples before you touch the code.
+
+## FAQ
+
+**If tracking is safe and degrades to static behaviour on stable hardware, why keep `mrc-static` at all?**
+As the explicit escape hatch and the A/B control. α = 0 freezes the first
+accepted window — bit-identical to a one-shot least-squares calibration — so
+an operator on shared-LO hardware can rule the tracking loop out of any
+comparison, and the replay harness gets its static arm from the same code
+path rather than a second implementation.
+
+**Doesn't holding stale gains during a long fade apply a wrong calibration?**
+It applies a *bounded* one. |h| is clamped within ±30 dB and the phase error
+grows only as fast as the hardware drifts — while the alternative, a
+passthrough fallback, injects an immediate large phase step into a live
+differential decode. When the fade lifts, gated windows resume and the
+one-pole walks the estimate back.
+
+**How do I know which front-end class I have without capturing anything?**
+Watch `branch_phase_deg` in the periodic `soapyremote: MRC diversity
+branches` log line. Essentially constant across minutes ⇒ shared LO, and
+`mrc-static` is sufficient; walking ⇒ independent PLLs, and tracking is doing
+real work. The replay harness prints the same verdict from a capture.
+
+**Why is the window's coherence taken from the worst branch?**
+One incoherent branch is enough to make the joint estimate untrustworthy —
+combining a good branch with a garbage-calibrated one can cancel signal. The
+gate is only as strong as its weakest input, so that is what it measures.
+
+**What would change if the branches sat on separate dongles with free-running clocks?**
+Everything — free-running LOs differ in *frequency*, so the branch phase
+spins continuously rather than walking, and no per-window scalar tracker
+holds. This design assumes a common reference (frequency lock); without one
+you need per-sample frequency alignment first, which is a different machine.
+
+## Series navigation
+
+**Part 11 of 14** · ←
+[Part 10: Diversity I — MRC & Coherence-Gated Calibration]({{ '/blog/deep-dives/weak-signal-engineering-10-mrc-calibration/' | relative_url }})
+· Next →
+[Part 12: Proving It's the Signal — Rate Invariance & Independent Resamplers]({{ '/blog/deep-dives/weak-signal-engineering-12-proving-signal/' | relative_url }})

--- a/docs/_posts/2026-08-29-analog-edge-12-front-end-classes.md
+++ b/docs/_posts/2026-08-29-analog-edge-12-front-end-classes.md
@@ -1,0 +1,256 @@
+---
+title: "The Analog Edge, Part 12: Front-End Classes — Shared LO vs Independent PLLs"
+description: Why two receive channels on one chip keep a constant relative phase while two daughterboards with their own synthesizers lock at a random phase and walk afterwards, how that hardware class decides between mrc and mrc-static, and how the branch_phase_deg log field identifies your class without recording anything.
+category: tutorials
+keywords: shared lo sdr, independent pll phase drift, twinrx phase coherence, b210 dual channel phase, mrc static vs tracking, branch phase deg, rx subdev spec, frequency locked phase random, gophertrunk analog edge
+tags: [analog-edge, diversity, hardware, pll, usrp, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "The Analog Edge"
+series_part: 12
+---
+
+*Part 12 of **The Analog Edge**, a 14-part field guide to the analog half of a
+GopherTrunk system. [Part 11]({{ '/blog/tutorials/analog-edge-11-diversity-mrc/' | relative_url }})
+put two antennas on the mast and left one question open: `mrc` or
+`mrc-static`? The answer isn't a preference — it's a property of the silicon
+between your two RX ports. This part sorts diversity-capable front ends into
+two classes, shows why one of them makes a frozen calibration constant decay,
+and hands you the field instrument that identifies your class from a log line
+alone. Our marginal reader, now shopping for a dual-channel radio, gets to
+make this choice on evidence.*
+
+> **TL;DR:** Two front-end classes. **Shared LO** (one chip, one synthesizer —
+> a B210's AD9361 driving both channels): branch-to-branch phase is fixed
+> trace skew plus a power-up divider phase, genuinely constant while the
+> synthesizer stays locked — a one-shot calibration (`mrc-static`) is correct.
+> **Independent PLLs** (separate daughterboards — an X310 with two TwinRX
+> cards, `rx_subdev_spec=B:0 A:0`): frequency-locked to a common reference so
+> there's no beat, but the relative phase is **random at each lock and walks
+> afterwards** — a constant measured once decays, and tracking (`mrc`) is
+> required. The no-capture instrument is **`branch_phase_deg`** in the 30 s
+> MRC health line: constant ⇒ shared LO; walking ⇒ independent PLLs. Either
+> way, every retune re-randomizes the phase, which is why the calibrator
+> resets on retune.
+
+**Key takeaways**
+
+- **"Frequency-locked" is not "phase-locked."** A common 10 MHz reference
+  guarantees the two synthesizers don't drift apart in frequency; it says
+  nothing about the phase each PLL settles at, or how that phase creeps with
+  temperature afterwards.
+- **The hardware class decides the software mode.** A constant needs measuring
+  once; a walk needs following. Choosing `mrc-static` on TwinRX-class hardware
+  gives you a combiner that slowly rotates out of alignment — worst case
+  toward cancellation.
+- **`branch_phase_deg` answers it for free.** Watch the health line across a
+  few intervals: flat within a degree or two ⇒ shared LO; a steady walk ⇒
+  independent PLLs. No capture, no test gear.
+- **Tracking is deliberately slow and clamped.** The `mrc` loop smooths over
+  ~200 ms and bounds each update, so it follows thermal drift without ever
+  stepping the phase fast enough to disturb the decoders — the design proof
+  lives in [Weak-Signal Engineering Part 11]({{ '/blog/deep-dives/weak-signal-engineering-11-tracking-mrc/' | relative_url }}).
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| The two modes | tracking vs one-shot frozen calibration | `sdr.soapy_remote[].diversity: "mrc"` / `"mrc-static"` |
+| Static = alpha 0 | first accepted window snapped, then frozen | `internal/dsp/diversity/tracking.go` (`TrackingOptions.Alpha`) |
+| Tracking loop | 2 ms windows, ~200 ms time constant, clamped steps | `internal/sdr/soapyremote/mrc.go` (`mrcCalWindowMs`, `mrcTrackTauMs`) |
+| Field instrument | relative branch phase in the health line | `branch_phase_deg` (`diversityReporter`, `mrc.go`) |
+| Retune behavior | drop the estimate — a new lock is a new phase | `TrackingCalibrator.Reset` (`tracking.go`) |
+| Offline drift trace | windowed phase trace + °/s from your capture | `TestDiversityCombinerReplay` (`cmd/gophertrunk/diversity_replay_test.go`) |
+| Differential safety | why tracking can't corrupt π/4-DQPSK decoding | [WSE Part 11]({{ '/blog/deep-dives/weak-signal-engineering-11-tracking-mrc/' | relative_url }}), `TestTrackingCalibratorIsDifferentialSafe` |
+
+## In this post
+
+- **Class 1: shared LO** — one synthesizer, one constant.
+- **Class 2: independent PLLs** — locked in frequency, free in phase.
+- **The field instrument** — reading `branch_phase_deg` like a pro.
+- **What each class needs from software** — static snap vs clamped tracking.
+- **The decision table** — symptom → class → mode.
+
+## Class 1: shared LO — one synthesizer, one constant
+
+In a single-chip dual-RX front end — the AD9361 in a USRP B210 is the
+canonical example — both receive channels are mixed down by *the same* local
+oscillator. The phase relationship between channel 0 and channel 1 is set by
+fixed board trace skew plus whatever phase the chip's internal dividers
+powered up in: an arbitrary constant, but a **constant**, for as long as the
+synthesizer stays locked. Measure it once and you're done — which is exactly
+what `mrc-static` does. In GopherTrunk's calibrator, static mode is literally
+tracking with `Alpha: 0` (`internal/dsp/diversity/tracking.go`): the first
+window that passes the quality gates is **snapped** — no smoothing, no clamp —
+making it bit-identical to a one-shot least-squares calibration on that
+window. Both modes therefore *start* identically; they differ only in whether
+the estimate is ever revisited.
+
+One constant caveat even here: that divider phase is re-rolled every time the
+synthesizer re-locks. Power cycle, retune, sample-rate change — new constant.
+This is why `TrackingCalibrator.Reset` is called on every retune in both
+modes: the old measurement isn't stale, it's *about different hardware state*.
+
+## Class 2: independent PLLs — locked in frequency, free in phase
+
+Now put the two channels on separate daughterboards, each with its own
+synthesizer — an X310 carrying two TwinRX cards, selected with
+`rx_subdev_spec=B:0 A:0` in the device `args`. Both PLLs discipline
+themselves to the same 10 MHz reference, so their *frequencies* are identical
+— no beat note, ever. But a PLL locks its output phase wherever its own loop
+settles: **random at each lock**, and then **walking** afterwards as
+temperature moves each synthesizer's components independently. The walk is
+slow — this is drift, not modulation — but it never stops.
+
+For a combiner, that difference is fatal to a frozen constant. `mrc-static`
+on this hardware measures a perfect alignment at minute zero, and then the
+true phase strolls away from it: the coherent sum degrades smoothly, and if
+the walk carries the branches toward anti-phase, MRC's coherent addition
+turns into partial cancellation — a diversity rig that's *worse* than one
+antenna, with nothing in `branch_dbfs` to show for it. The fix isn't a better
+initial measurement; it's a loop that keeps measuring. That's `mrc`.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 210" width="680" height="210" role="img" aria-label="Relative branch phase versus time for the two front-end classes. The shared-LO trace is a flat horizontal line at a constant phase offset, annotated as one chip, one synthesizer, where mrc-static is correct. The independent-PLL trace starts at a different random phase after each lock and walks steadily away over minutes, annotated as two synthesizers on a common reference, where tracking mrc is required. A dashed vertical line marks a retune, after which both traces jump to new random values.">
+  <line x1="55" y1="20" x2="55" y2="165" stroke="var(--fg-muted)"/>
+  <line x1="55" y1="165" x2="650" y2="165" stroke="var(--fg-muted)"/>
+  <text x="10" y="30" fill="var(--fg-muted)" font-size="9">relative</text>
+  <text x="10" y="42" fill="var(--fg-muted)" font-size="9">phase (°)</text>
+  <text x="590" y="182" fill="var(--fg-muted)" font-size="9">time (min)</text>
+  <line x1="380" y1="20" x2="380" y2="165" stroke="var(--fg-muted)" stroke-dasharray="3,4"/>
+  <text x="380" y="14" text-anchor="middle" fill="var(--fg-muted)" font-size="9">retune (new LO lock)</text>
+  <polyline points="55,70 380,70" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <polyline points="380,110 650,110" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <text x="140" y="60" fill="var(--accent)" font-size="10">shared LO: constant (new constant per lock)</text>
+  <polyline points="55,140 120,133 190,124 260,112 320,97 380,86" fill="none" stroke="currentColor"/>
+  <polyline points="380,45 440,52 500,63 560,76 620,92 650,101" fill="none" stroke="currentColor"/>
+  <text x="90" y="155" fill="currentColor" font-size="10">independent PLLs: random start, then walks</text>
+  <text x="352" y="200" text-anchor="middle" fill="var(--fg-muted)" font-size="10">flat trace ⇒ mrc-static is enough · walking trace ⇒ a frozen constant decays, track it</text>
+</svg>
+<figcaption>The two classes in one plot: a shared LO holds a constant between locks; independent PLLs re-roll the phase at every lock and walk between them.</figcaption>
+</figure>
+
+## The field instrument: `branch_phase_deg`
+
+You don't need a capture, a scope, or a datasheet to classify your radio. The
+MRC health line from [Part 11]({{ '/blog/tutorials/analog-edge-11-diversity-mrc/' | relative_url }})
+prints `branch_phase_deg` — the phase of the currently applied branch gain —
+every 30 seconds. Watch it across a few intervals:
+
+- **Constant** (jitters within a degree or two, no direction): shared-LO
+  behavior. `mrc-static` is sufficient; `mrc` costs nothing extra (on this
+  hardware every window re-measures the same constant and the smoothing is a
+  variance-reducing no-op).
+- **Walking** (a consistent drift, degrees per minute): independent PLLs.
+  Tracking is doing real work; `mrc-static` would decay.
+
+For a quantitative answer, the offline harness turns your own
+`diversity_capture` into a drift measurement: `TestDiversityCombinerReplay`
+prints a windowed phase trace and, when the phase walks, the drift rate in
+degrees per second. Flat trace ⇒ the frozen constant was fine on this
+hardware; walking trace ⇒ the number tells you how fast `mrc-static` would
+have rotted. That trace is the primary deliverable of the harness — the
+four decode arms are the verdict, the phase trace is the explanation.
+
+## What each class needs from software
+
+The operator-level view of what `mrc` does with a walking phase, in three
+properties (the proofs and the expensive lessons behind them are
+[WSE Part 11]({{ '/blog/deep-dives/weak-signal-engineering-11-tracking-mrc/' | relative_url }})'s
+subject):
+
+- **Slow on purpose.** Estimates accumulate over 2 ms windows and smooth with
+  a ~200 ms time constant (`mrcCalWindowMs`, `mrcTrackTauMs`) — far slower
+  than any burst, far faster than thermal drift. The loop follows the walk
+  without ever moving fast enough to look like modulation.
+- **Clamped on purpose.** One accepted update may move the applied phase at
+  most ~2.9° (`trackingMaxStepRad`), a bound that holds regardless of sample
+  rate or a freak calibration window. A rejected window *holds* the previous
+  gains — it never drops back to passthrough mid-stream, because that step
+  would itself be the glitch the design exists to avoid.
+- **Anchored on purpose.** The reference branch's weight is pinned to exactly
+  1+0j, so the combiner's output phase is anchored to the reference antenna's
+  own signal — the property that makes this safe *ahead of* GopherTrunk's
+  differential TETRA demodulator, pinned by
+  `TestTrackingCalibratorIsDifferentialSafe`.
+
+### How that principle shaped the Go code
+
+- **Static is a special case of tracking, not a second implementation.**
+  `mrc-static` is the same `TrackingCalibrator` with `Alpha: 0`
+  (`TrackingOptions`, `tracking.go`) — one code path, so the two modes cannot
+  drift apart, and any capture-verified fix to one is automatically a fix to
+  the other.
+- **The first window is snapped in both modes.** Before the first accepted
+  estimate there is nothing to smooth *toward*, so the code snaps it raw —
+  which is what makes the static/tracking A/B fair: both arms start from a
+  bit-identical calibration and diverge only in what happens next.
+- **Retunes reset, rejections hold.** `Reset()` on a retune (a new LO lock is
+  new hardware state) but *hold* on a rejected window (falling back to
+  passthrough mid-stream is itself a phase step) — two different failure
+  classes, two deliberately different responses.
+
+## The decision table
+
+| What you observe | Hardware class | Mode | Notes |
+|---|---|---|---|
+| `branch_phase_deg` flat across intervals | shared LO (B210-class) | `mrc-static` or `mrc` | both fine; static is the minimal choice |
+| `branch_phase_deg` walking steadily | independent PLLs (TwinRX-class) | `mrc` | a frozen constant decays toward cancellation |
+| Phase jumps only at retunes/restarts | either (that's the re-lock) | keep current mode | expected in both classes; calibrator resets itself |
+| Combined decode slowly degrades over an hour, recovers on restart | independent PLLs on `mrc-static` | switch to `mrc` | the restart re-measured the constant — classic decay signature |
+| `coherence` stuck 0.3–0.5, phase noisy | not a class problem | — | wideband-scalar limit from [Part 11]({{ '/blog/tutorials/analog-edge-11-diversity-mrc/' | relative_url }}): antennas too far apart |
+| Capture replay shows °/s drift figure | independent PLLs | `mrc` | `TestDiversityCombinerReplay`'s phase trace, quantified |
+
+## Where this goes next
+
+Twice now, a log field has answered a hardware question that used to need
+test equipment — `coherence` in Part 11, `branch_phase_deg` here. That's not
+an accident; it's a design rule with a history: the one time this project
+gated a DSP decision on an *absolute level* instead, an operator raised their
+front-end gain 17 dB to satisfy a software constant.
+[Part 13]({{ '/blog/tutorials/analog-edge-13-coherence-not-dbfs/' | relative_url }})
+tells that story and unpacks the scale-invariant number that replaced the
+gate — the most transferable idea in this series.
+
+## FAQ
+
+**My two channels share a reference clock. Isn't that enough for `mrc-static`?**
+No — that's precisely the trap. A shared reference locks *frequency*, so the
+phase difference doesn't spin; but each PLL still settles at a random phase
+per lock and creeps with temperature. Shared *reference* is class 2; shared
+*LO* — one synthesizer physically driving both mixers — is class 1.
+
+**Which class is my radio?**
+One RF chip driving both RX ports (B210, and other AD9361/AD9364-family
+duals): shared LO. Separate daughterboards or separate full receive chains
+per channel (X310 + TwinRX, `rx_subdev_spec` selecting two boards):
+independent PLLs. When documentation is ambiguous, `branch_phase_deg` over
+ten minutes settles it empirically.
+
+**Is there any reason to prefer `mrc-static` when both work?**
+It's the minimal, fully-deterministic choice: one measurement, then a fixed
+linear combine — nothing adapts at runtime, which some operators prefer for
+auditability, and it's the natural A/B baseline. On shared-LO hardware the
+tracking mode converges to the same constant anyway, so the practical
+difference is philosophical.
+
+**How fast does the TwinRX-class phase actually walk?**
+It's thermal, so it depends on your enclosure and airflow — the honest answer
+is your own number: run `TestDiversityCombinerReplay` on a
+`diversity_capture` and read the °/s off the phase trace. The tracking loop's
+~200 ms time constant is orders of magnitude faster than any thermal walk, so
+`mrc` has margin to spare in either case.
+
+**Does any of this matter for a single-channel rig?**
+The modes don't, but the lesson does: "calibrate once" is only valid when the
+thing you measured is physically constant. The same reasoning shows up across
+GopherTrunk — per-dongle crystal offsets are *tracked* as running averages
+([autotune]({{ '/blog/deep-dives/the-hunt-05-autogain-autotune/' | relative_url }}))
+for exactly the same reason.
+
+## Series navigation
+
+**Part 12 of 14** · ←
+[Part 11: Two Antennas — Diversity & MRC From the Operator's Seat]({{ '/blog/tutorials/analog-edge-11-diversity-mrc/' | relative_url }})
+· Next →
+[Part 13: Coherence, Not dBFS — Scale-Invariant Health]({{ '/blog/tutorials/analog-edge-13-coherence-not-dbfs/' | relative_url }})

--- a/docs/_posts/2026-08-29-tetra-end-to-end-12-dmo-descramble-colour.md
+++ b/docs/_posts/2026-08-29-tetra-end-to-end-12-dmo-descramble-colour.md
@@ -1,0 +1,295 @@
+---
+title: "TETRA End to End, Part 12: DMO II — The 'Encrypted' Verdict That Was a Descramble Skip"
+description: "The honest retelling of issue #1003: how a colour-0 descramble shortcut inherited from trunked mode made clear DMO voice look encrypted, why the synthetic round-trips couldn't catch it, and how the colour code the voice actually scrambles with turned out not to be the one the signalling advertises."
+category: deep-dives
+keywords: tetra dmo encrypted, colour code descramble, scrambler seed 0xc0000000, self-consistent bug, failing-first regression, recoverdmcolourcode, dm colour code, tea0 clear voice, gophertrunk tetra
+tags: [tetra-end-to-end, tetra, dmo, scrambling, debugging, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "TETRA End to End"
+series_part: 12
+---
+
+*Part 12 of **TETRA End to End**, a 14-part deep dive into how GopherTrunk turns
+one real 25 kHz TETRA carrier into clear recorded voice.
+[Part 11]({{ '/blog/deep-dives/tetra-end-to-end-11-dmo-direct-mode/' | relative_url }})
+ended on a split verdict: DMO signalling decoding at 90%+, DMO speech stuck at
+the CRC chance floor, and a published conclusion — "the voice is encrypted" —
+that felt reasonable and was wrong. This part is the correction, told in the
+order it actually happened, because the *shape* of the mistake is the valuable
+part: a one-line shortcut that was perfectly safe in trunked mode, silently
+lethal in direct mode, and invisible to every test that scrambled and
+descrambled with the same code. [Part 4]({{ '/blog/deep-dives/tetra-end-to-end-04-scrambling-colour-codes/' | relative_url }})
+planted the warning — colour 0 is not a no-op. Here is where the bill came
+due.*
+
+> **TL;DR:** The "encrypted" DMO voice was **clear all along**. The reporter's
+> CPS codeplug proved it — TEA0, no key, colour code 0 — and the real cause was
+> `DMBurstTCHSpeech`/`DMBurstTCHSpeechSoft` **skipping descrambling at
+> `colour==0`**, a shortcut inherited from TMO `traffic.go` where an extended
+> colour code is never 0. TETRA scrambling is non-identity at colour 0
+> (`NewScramblerTetra(0)` seeds the LFSR to **0xC0000000**, §8.2.5.2 eq. 8.42),
+> so a clear colour-0 DNB went into the Viterbi still scrambled — producing the
+> uniform ~1/256 chance floor misread as encryption. The fix descrambles
+> **unconditionally**; the failing-first regression scrambles the encode side
+> unconditionally too, so colour-0 rounds now catch the asymmetry. Then a
+> second capture showed voice descrambling at colour **3** while the signalling
+> advertises 0 — `tch_crc` **1/269 → 35/269**, 70 speech frames, 2.1 s of PCM —
+> so **`RecoverDMColourCode`** learns the traffic colour by maximising
+> CRC-valid TCH/S under a dominance gate, instead of hardcoding a bit offset
+> that one capture cannot pin.
+
+**Key takeaways**
+
+- **"Encrypted" is a conclusion of last resort.** A uniform chance floor under
+  every decode hypothesis is *also* the signature of a systematically wrong
+  transform — scrambling, geometry, interleave. Rule those out with known-clear
+  traffic before reaching for the encryption verdict.
+- **A shortcut's safety is contextual.** `if colour != 0 { descramble }` was
+  provably safe in TMO, where the extended colour code embeds a nonzero MNI. In
+  DMO, where 0 is a *common configured value*, the same line is a decode
+  killer.
+- **Self-consistent tests pass on both sides of a bug.** Round-trips that
+  scrambled and descrambled with the same conditional couldn't fail. The
+  regression now models the *transmitter* faithfully — scramble always — so the
+  receiver's skip has nothing to hide behind.
+- **When a field can't be pinned, learn it from the payload.** The DM colour's
+  exact SCH/H bit offset is ambiguous on one capture; hardcoding a guess is the
+  same trap again. Brute-forcing 0..63 against CRC yield is self-verifying.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| The fix | descramble TCH/S unconditionally, colour 0 included | `internal/radio/tetra/dmo_decode.go` (`DMBurstTCHSpeech`, `DMBurstTCHSpeechSoft`) |
+| The seed rule | colour 0 seeds the LFSR to 0xC0000000 | `internal/radio/framing/scramble_tetra.go` (`NewScramblerTetra`, §8.2.5.2 eq. 8.42) |
+| The inherited shortcut | TMO's `colour != 0` guard, safe only in TMO | `internal/radio/tetra/traffic.go` (`emit`) |
+| Failing-first regression | encode side scrambles unconditionally | `internal/radio/tetra/dmo_decode_test.go` (`TestDMTCHSpeechRoundTrip`) |
+| Colour recovery | argmax CRC-valid TCH/S over colours 0..63 | `dmo_decode.go` (`RecoverDMColourCode`) |
+| Confidence gate | ≥6 CRC-valid and ≥3× the runner-up | `dmo_decode.go` (`dmColourMinCRC`, `dmColourDominance`) |
+| Recovery regression | synthetic pin of the recovery + gate | `dmo_decode_test.go` (`TestRecoverDMColourCode`) |
+| Capture harness | replay, colour override, clear-assertion verdict | `cmd/gophertrunk/tetra_dmo_replay_test.go` (`GT_TETRA_DMO_COLOUR`, `GT_TETRA_DMO_CLEAR`) |
+
+## In this post
+
+- **The wrong verdict** — what the chance floor looked like from inside.
+- **The evidence that overturned it** — a codeplug is ground truth.
+- **The one-line cause** — an inherited shortcut and a non-identity seed.
+- **Why the tests couldn't see it** — the self-consistent trap, again.
+- **The second capture's twist** — voice at colour 3, signalling at colour 0.
+- **Learning the colour from the payload** — `RecoverDMColourCode` and its gate.
+
+## The wrong verdict
+
+On the first capture, `TestTETRADMOReplay` decoded DSB signalling at better
+than 90% and TCH/S speech at almost exactly **1/256** — the probability that
+random class-2 bits pass an 8-bit CRC. Uniform, colourless, hypothesis-proof:
+sweeping decode parameters moved nothing. For a professional radio system,
+"air-interface encryption" fit that shape, and the issue said so. The error
+wasn't in the observation — it was in the *space of hypotheses*. A chance floor
+means the decoder's output is uncorrelated with the payload; encryption causes
+that, but so does any systematically wrong transform applied to every burst.
+The two are indistinguishable from yield alone, which is why the distinction
+has to come from outside the decoder.
+
+## The evidence that overturned it
+
+It did: the reporter pulled the radios' CPS codeplug. Channels
+`DMO_438.900`/`DMO_438.800`, **TEA0** — clear, no encryption — Security Class
+1, `NO_KG`, colour code **0**. That is exactly the known-clear evidence the
+original analysis had said would be required to distinguish the cases, and it
+flipped the problem statement completely: a clear transmission at the chance
+floor is a **decode defect, full stop**. The replay harness now encodes that
+logic — `GT_TETRA_DMO_CLEAR=1` flips its VERDICT line so a persistent floor on
+an asserted-clear capture is reported as "a defect to keep chasing, NOT
+encryption."
+
+## The one-line cause
+
+With "encrypted" off the table, the transform audit found it fast, and Part 4
+readers already know the shape. TETRA's scrambler is **non-identity at colour
+0**: `NewScramblerTetra(0)` seeds the LFSR to `0xC0000000` per §8.2.5.2
+eq. 8.42 — which is precisely why every BSCH and SCH/S decoder in the codebase
+descrambles *unconditionally*. That is how the DSB signalling on this very
+capture decoded: colour-0 descramble applied, CRCs pass. But the DMO voice
+path had inherited TMO `traffic.go`'s optimization:
+
+```go
+// internal/radio/tetra/traffic.go (shape) — the TMO shortcut, safe THERE only
+if te.colourCode != 0 {
+    bits = framing.DescrambleTetra(bits, te.colourCode)
+}
+```
+
+In TMO this is fine — the extended colour code embeds the network's MNI and is
+never 0 in practice. In DMO, 0 is the spec default and a common codeplug value,
+so a clear colour-0 DNB sailed into the Viterbi **still scrambled** — random
+in, random out, ~1/256 through the CRC. The fix deletes the guard on both DMO
+TCH/S paths:
+
+```go
+// internal/radio/tetra/dmo_decode.go (shape) — DMBurstTCHSpeech, fixed
+// The descramble is UNCONDITIONAL — including at colour 0. TETRA scrambling
+// is non-identity at colour 0 (seed 0xC0000000), so a clear (TEA0) colour-0
+// DMO transmitter still scrambles TCH/S (issue #1003).
+type5 = framing.DescrambleTetra(type5, colour)
+return TCHSpeechFrames(framing.PackBitsMSB(type5))
+```
+
+## Why the tests couldn't see it
+
+The uncomfortable question: an earlier sweep had explicitly tried "with and
+without a colour-0 descramble" and measured no difference. How? Because the
+synthetic round-trips **scrambled and descrambled through the same
+conditional** — at colour 0 the encoder skipped scrambling and the decoder
+skipped descrambling, so both variants round-tripped perfectly. The test was
+self-consistent with the bug on both sides — the same failure class as the
+class-2 CRC episode in
+[Part 3]({{ '/blog/deep-dives/tetra-end-to-end-03-channel-coding-crc/' | relative_url }})
+and the SoapyRemote opcode story, dissected as a pattern in
+[From the Issue Tracker #20]({{ '/blog/solution-postmortem/from-the-issue-tracker-20-self-consistent-trap/' | relative_url }}).
+The repaired regression models the *air*, not the code under test:
+`dmo_decode_test.go` now scrambles the encode side **unconditionally** — real
+transmitter behaviour — so the colour-0 iterations are failing-first. Verified
+both ways: old code decodes 0 frames at colour 0; fixed code decodes the 2
+CRC-valid frames the fixture carries.
+
+## The second capture's twist
+
+The operator then recorded a fresh on-air A/B
+(`10aug_dmo_test_bw144_cs16.raw`, 438.9 MHz, replayed with
+`GT_TETRA_DMO_RATE=144000`). Signalling: pristine — `dsb_schs_crc=44/45`,
+distinct frame numbers advancing. Voice at the advertised colour 0:
+`tch_crc=1/269`. Still the floor — but this time the sweep was unambiguous.
+At **colour 3**: `tch_crc=35/269`, `speech_frames=70`, **2.1 s of PCM**, voice
+activity across seconds 1–8 of the capture. Every other colour stayed at the
+floor (and the staged LMS equalizer didn't move it — 35→32 — this was never an
+equalization problem). So the signal is neither weak nor encrypted: it is
+clear voice whose TCH/S descrambles with a **different colour code than the
+signalling advertises**. The SYNC PDU says 0; the speech says 3.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 210" width="680" height="210" role="img" aria-label="Bar chart of CRC-valid TCH/S bursts out of 269 for DM colour codes zero through fifteen on the second capture. Every colour sits at the chance floor of one to three bursts except colour three, which spikes to thirty-five — the dominance the recovery gate requires before trusting a colour.">
+  <line x1="50" y1="20" x2="50" y2="160" stroke="var(--fg-muted)"/>
+  <line x1="50" y1="160" x2="650" y2="160" stroke="var(--fg-muted)"/>
+  <text x="18" y="30" fill="var(--fg-muted)" font-size="9">tch_crc</text>
+  <text x="18" y="42" fill="var(--fg-muted)" font-size="9">of 269</text>
+  <text x="44" y="52" text-anchor="end" fill="var(--fg-muted)" font-size="9">35</text>
+  <line x1="46" y1="48" x2="50" y2="48" stroke="var(--fg-muted)"/>
+  <text x="44" y="152" text-anchor="end" fill="var(--fg-muted)" font-size="9">0</text>
+  <g fill="var(--fg-muted)">
+    <rect x="62" y="157" width="24" height="3"/><rect x="98" y="154" width="24" height="6"/>
+    <rect x="134" y="157" width="24" height="3"/>
+    <rect x="206" y="154" width="24" height="6"/><rect x="242" y="157" width="24" height="3"/>
+    <rect x="278" y="157" width="24" height="3"/><rect x="314" y="154" width="24" height="6"/>
+    <rect x="350" y="157" width="24" height="3"/><rect x="386" y="157" width="24" height="3"/>
+    <rect x="422" y="154" width="24" height="6"/><rect x="458" y="157" width="24" height="3"/>
+    <rect x="494" y="157" width="24" height="3"/><rect x="530" y="154" width="24" height="6"/>
+    <rect x="566" y="157" width="24" height="3"/><rect x="602" y="157" width="24" height="3"/>
+  </g>
+  <rect x="170" y="48" width="24" height="112" fill="var(--accent)"/>
+  <text x="182" y="40" text-anchor="middle" fill="var(--accent)" font-size="10">colour 3: 35</text>
+  <text x="74" y="176" text-anchor="middle" fill="var(--fg-muted)" font-size="9">0</text>
+  <text x="110" y="176" text-anchor="middle" fill="var(--fg-muted)" font-size="9">1</text>
+  <text x="146" y="176" text-anchor="middle" fill="var(--fg-muted)" font-size="9">2</text>
+  <text x="182" y="176" text-anchor="middle" fill="var(--accent)" font-size="9">3</text>
+  <text x="218" y="176" text-anchor="middle" fill="var(--fg-muted)" font-size="9">4</text>
+  <text x="254" y="176" text-anchor="middle" fill="var(--fg-muted)" font-size="9">5</text>
+  <text x="290" y="176" text-anchor="middle" fill="var(--fg-muted)" font-size="9">6</text>
+  <text x="326" y="176" text-anchor="middle" fill="var(--fg-muted)" font-size="9">7</text>
+  <text x="362" y="176" text-anchor="middle" fill="var(--fg-muted)" font-size="9">8</text>
+  <text x="398" y="176" text-anchor="middle" fill="var(--fg-muted)" font-size="9">9</text>
+  <text x="434" y="176" text-anchor="middle" fill="var(--fg-muted)" font-size="9">10</text>
+  <text x="470" y="176" text-anchor="middle" fill="var(--fg-muted)" font-size="9">11</text>
+  <text x="506" y="176" text-anchor="middle" fill="var(--fg-muted)" font-size="9">12</text>
+  <text x="542" y="176" text-anchor="middle" fill="var(--fg-muted)" font-size="9">13</text>
+  <text x="578" y="176" text-anchor="middle" fill="var(--fg-muted)" font-size="9">14</text>
+  <text x="614" y="176" text-anchor="middle" fill="var(--fg-muted)" font-size="9">15</text>
+  <text x="350" y="200" text-anchor="middle" fill="var(--fg-muted)" font-size="10">one radio, one keystream: the true colour spikes 35 vs ≤3 — everything else is the ~1/256 chance floor</text>
+</svg>
+<figcaption>CRC-valid TCH/S per colour on the 10aug capture: colour 3 dominates at 35 of 269 while every other colour sits at the chance floor — the dominance RecoverDMColourCode's gate requires.</figcaption>
+</figure>
+
+## Learning the colour from the payload
+
+Where does colour 3 live on the air? Not in the SCH/S — that block is *always*
+colour-0 scrambled and reads 0 by construction. It is carried in the DSB
+SCH/H's DM-SYNC SYSINFO (EN 300 396-3) — but on a single capture where the
+value is 3, only the field's two least-significant bits light up, and several
+candidate bit offsets fit. An empirical scan found **no unique 6-bit window**.
+Hardcoding one guess would be the self-consistent trap with a new coat of
+paint: a wrong offset that happens to read 3 on this capture would decode this
+capture and silently fail every other network. So the colour is **learned from
+the payload** instead:
+
+```go
+// internal/radio/tetra/dmo_decode.go (shape) — RecoverDMColourCode
+// Picks the colour (0..63) that yields the most CRC-valid speech frames
+// across the given DNBs — soft decode with hard fallback, same as production.
+for c := 0; c < 64; c++ {
+    for i := range bursts { /* count CRC-valid TCH/S at colour c */ }
+}
+confident = best >= dmColourMinCRC && best >= dmColourDominance*max(second, 1)
+return uint32(bestC), best, confident
+```
+
+The confidence gate is the honest part: the winner must clear **6** CRC-valid
+bursts *and* beat the runner-up **3×**. On the 10aug capture that is 35 vs ≤3 —
+no contest. On an encrypted call or a dead capture, nothing clears the gate and
+the caller keeps its configured default rather than trusting a chance-floor
+winner. `TestTETRADMOReplay` now auto-recovers when `GT_TETRA_DMO_COLOUR` is
+unset — on 10aug it recovers colour 3 and produces the full 35/70/2.1 s result
+with no manual override — and `TestRecoverDMColourCode` pins the synthetic.
+
+## Where this goes next
+
+Offline, DMO now locks, recovers its colour, and decodes clear voice. But
+"offline" is carrying weight in that sentence: everything so far runs in a
+replay harness against files.
+[Part 13]({{ '/blog/deep-dives/tetra-end-to-end-13-dmo-pipeline-grants/' | relative_url }})
+wires DMO into the production daemon — a new protocol, a streaming extractor,
+sticky locks and edge-triggered grants — and immediately pays for a lesson in
+false-alarm statistics when the first on-air run grants on an empty channel
+230 ms after startup.
+
+## FAQ
+
+**How could professional radios scramble voice with a colour the signalling doesn't advertise?**
+The honest answer is: unresolved. The SYNC PDU self-consistently reads
+MNI=0/colour=0 (GopherTrunk's offsets match osmo-tetra-dmo's scrambler-init
+derivation), yet the traffic keystream is colour 3's. Whether it is a codeplug
+quirk, a vendor interpretation, or a field GT still mis-locates, the payload
+is the arbiter — which is exactly why recovery scores CRC yield instead of
+trusting any parsed field.
+
+**Isn't brute-forcing 64 colours expensive?**
+Bounded and cheap where it matters: 64 candidate decodes over a ~20-burst
+batch, once. The expensive version — re-running it on every arriving burst —
+did briefly exist in the live voice chain and starved its own IQ tap; Part 13
+covers the cost cap that fixed it.
+
+**Why does the gate demand 3× dominance instead of just taking the max?**
+Because a marginal signal produces *partial* keystream artifacts: several
+colours rise modestly at once, none dominant. One radio scrambling with one
+colour cannot produce that pattern — so a non-dominant winner means "signal
+too poor to trust," and latching it would misdescramble a later, better
+transmission. Part 14 shows a real capture where the gate correctly refuses.
+
+**Did the LMS equalizer help at all here?**
+No — 35→32, i.e. noise. That is itself diagnostic: the losses on this capture
+weren't linear-channel ISI (Part 9's regime); they were a wrong keystream. An
+equalizer cannot fix a descramble, and the fact that it didn't move confirmed
+the transform hypothesis over the channel hypothesis.
+
+**What would this bug have looked like with encryption actually present?**
+Nearly identical yields — that's the point. The differences: a codeplug
+declaring a key (not TEA0/`NO_KG`), *no* colour clearing the dominance gate at
+any value, and no colour sweep spike. Clear-but-misdescrambled and encrypted
+separate only through evidence outside the decoder plus the sweep's shape.
+
+## Series navigation
+
+**Part 12 of 14** · ←
+[Part 11: DMO I — Direct Mode & the DSB/DNB Geometry]({{ '/blog/deep-dives/tetra-end-to-end-11-dmo-direct-mode/' | relative_url }})
+· Next →
+[Part 13: DMO III — A Production Pipeline: Grid Votes, Grants & Noise]({{ '/blog/deep-dives/tetra-end-to-end-13-dmo-pipeline-grants/' | relative_url }})

--- a/docs/_posts/2026-08-29-weak-signal-engineering-12-proving-signal.md
+++ b/docs/_posts/2026-08-29-weak-signal-engineering-12-proving-signal.md
@@ -1,0 +1,296 @@
+---
+title: "Weak-Signal Engineering, Part 12: Proving It's the Signal — Rate Invariance & Independent Resamplers"
+description: "Experimental design as an engineering skill, with issue #764 as the worked example — how an independent 4:1 resampler proved a ten-dB decode deficit was baked into the captured samples, how clipping was ruled out, and how a unit test now pins the invariant the experiment relied on."
+category: deep-dives
+keywords: rate invariance decode, independent resampler control, capture rate snr deficit, phase noise reciprocal mixing, ruling out clipping, ddc linearity, experimental design dsp, issue 764 mt anakie, gophertrunk weak-signal engineering
+tags: [weak-signal-engineering, debugging, ddc, phase-noise, capture, testing, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Weak-Signal Engineering"
+series_part: 12
+---
+
+*Part 12 of **Weak-Signal Engineering**, a 14-part series on decoding the
+marginal regime — where the receiver locks but only a fraction of frames
+survive. [Part 11]({{ '/blog/deep-dives/weak-signal-engineering-11-tracking-mrc/' | relative_url }})
+finished the lever list: equalize, go soft, diversify. This part is about the
+skill that decides whether any of those levers is even the right tool —
+because the most expensive mistake in weak-signal work is fixing the DSP when
+the problem is in the samples. The worked example is
+[#764](https://github.com/MattCheramie/GopherTrunk/issues/764): a P25 control
+channel that locked from a 2.5 MS/s capture and failed from a 10 MS/s capture
+of the same site, same antenna, same day. Every instinct says "the decoder
+mishandles the higher rate." The experiment said otherwise, and the way it
+said it — an independent resampler as a control — is the template.*
+
+> **TL;DR:** The Mt Anakie carrier (−812.5 kHz offset) replays at demod SNR
+> ≈19.7 dB / EVM 7.4% from the 2.5 MS/s capture (locks) but ≈9.5 dB / EVM
+> 22.5% from the 10 MS/s capture (no lock). The decisive control: decimate
+> the 10 MS/s file 4:1 with an **independent resampler** and replay it
+> through the proven 2.5 MS/s path — it reproduces the **same ≈9.5 dB**, so
+> the ~10 dB deficit is baked into the captured samples, not GopherTrunk's
+> DDC. Neither capture clips (both peak ≈−48 dBFS), and the wideband FFT
+> *carrier* SNR is actually **higher** at 10 MS/s — carrier-clean but
+> modulation-degraded is the signature of front-end **phase noise /
+> reciprocal mixing** at the Airspy's native 10 MS/s clock.
+> `TestDownconverterSNRInvariantAcrossRate`
+> (`internal/scanner/ccdecoder/ddc_highrate_test.go`) pins the invariant the
+> whole argument leans on: a noisy channel reaches the receiver at the same
+> in-channel SNR whether decoded natively at 10 MS/s or decimated to
+> 2.5 MS/s.
+
+**Key takeaways**
+
+- **Find the invariant your DSP guarantees, then test the symptom against
+  it.** GopherTrunk's decode path is rate-invariant by construction — both
+  down-converters normalise to the per-protocol channel rate and the
+  receiver/AGC are sized from that output rate. A symptom that *follows the
+  capture rate* therefore points at the captured data, not the steady-state
+  DSP.
+- **The control must be independent of the code under suspicion.** Decimating
+  with the suspect DDC and getting the same answer proves nothing — a shared
+  bug produces a shared answer. `dsp.NewResampler` shares no code with the
+  `ccdecoder.Downconverter`, which is what gives the 4:1 control its force.
+- **Rule out the boring explanations with numbers.** Overload was excluded
+  because both captures peak ≈−48 dBFS — 48 dB of headroom is not clipping.
+  Without that measurement, "the wider front end overloaded" survives forever
+  as a plausible story.
+- **Carrier-clean but modulation-degraded is a diagnosis, not a paradox.**
+  Reciprocal mixing smears each strong neighbour's energy across the channel
+  in proportion to the LO's phase-noise skirt — the carrier *peak* stays
+  pretty while the modulation drowns. That reading sent the fix to the
+  operator's sample-rate choice, not to a year of DSP archaeology.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| Rate invariance | DDC normalises any input rate to the channel rate | `internal/scanner/ccdecoder/ddc.go` (`Downconverter`, `DDCTargetRateHz`) |
+| The invariant's pin | same in-channel SNR at 10 MS/s and decimated 2.5 MS/s | `internal/scanner/ccdecoder/ddc_highrate_test.go` (`TestDownconverterSNRInvariantAcrossRate`) |
+| Independent control | polyphase 4:1 decimation, zero shared DDC code | `internal/dsp` (`NewResampler(1, 4, 64, 8.6)`) |
+| Level pin | DDC output level identical across capture rates | `ddc_highrate_test.go` (`TestDownconverterC4FMLevelRateInvariant`) |
+| Alias pin | wideband neighbours rejected at both rates | `ddc_highrate_test.go` (`TestDownconverterRejectsWidebandNeighbours`) |
+| The postmortem | the #764/#771 story at narrative length | [From the Issue Tracker, Part 5]({{ '/blog/solution-postmortem/from-the-issue-tracker-05-ten-megasamples/' | relative_url }}) |
+
+## In this post
+
+- **A symptom that follows the capture rate** — the #764 report.
+- **The invariant** — why the decode path cannot care about capture rate.
+- **The decisive experiment** — an independent resampler as the control.
+- **Ruling out the alternatives** — clipping, then the FFT surprise.
+- **Pinning it forever** — the regression test, and the generalized recipe.
+
+## A symptom that follows the capture rate
+
+The report was clean and reproducible: a P25 control channel at −812.5 kHz
+from centre (Mt Anakie) locks every time when replayed from a 2.5 MS/s
+Airspy capture, and never locks from a 10 MS/s capture — offline, from
+files, no live radio in the loop. Measured at the demod: **≈19.7 dB SNR /
+7.4% EVM** from the 2.5 MS/s file, **≈9.5 dB / 22.5% EVM** from the 10 MS/s
+file. Ten dB is not a subtle difference; it is the whole marginal regime of
+[Part 1]({{ '/blog/deep-dives/weak-signal-engineering-01-marginal-regime/' | relative_url }})
+crossed in one config change.
+
+The natural hypothesis — the one the issue was filed under — is that the
+decoder mishandles the higher rate: a decimation filter with wrong cutoff, an
+AGC sized for the wrong bandwidth, an alias folding in. It is a *good*
+hypothesis; an earlier "fix" for this very issue had already been merged
+once on weaker evidence, which is how the project learned the verification
+discipline it now enforces. The question is how to test it in a way that can
+actually lose.
+
+## The invariant: the decode path cannot care
+
+Start from what the code guarantees. Every capture, at whatever rate, meets
+a down-converter that mixes the target channel to baseband and resamples it
+to a fixed per-protocol channel rate — 48 kHz for the 4800-baud C4FM family,
+144 kHz for TETRA. The receiver, its filters, and its AGC are all sized from
+that *output* rate. Nothing downstream of the DDC ever sees the capture
+rate. So the decode path is **rate-invariant by design**: if the DDC is
+correct, a given over-the-air signal must produce the same in-channel SNR —
+and the same decode — whether it was captured at 2.5 or 10 MS/s.
+
+That converts the vague "maybe the decoder mishandles 10 MS/s" into a sharp
+dichotomy. Either the DDC violates its invariant (a real, findable bug), or
+the two captures do not contain the same signal quality (an RF fact). No
+third option. The experiment's only job is to tell those two apart.
+
+## The decisive experiment: an independent resampler
+
+Here is the move worth stealing. Take the *failing* 10 MS/s file. Decimate
+it 4:1 to 2.5 MS/s using a resampler that shares **no code** with the DDC
+under suspicion — `dsp.NewResampler`, the general polyphase resampler from a
+different package. Now replay the result through the 2.5 MS/s path that is
+*proven* good by the passing capture. Two possible outcomes, each decisive:
+
+- **It decodes.** The signal quality was in the file all along, and the
+  10 MS/s DDC path is destroying it. Bug found; go fix the DDC.
+- **It fails the same way.** The proven-good path, fed the independently
+  decimated samples, still sees ≈9.5 dB — so the deficit is *in the
+  samples*, and no amount of DDC work can recover what the front end never
+  delivered.
+
+It failed the same way: **the same ≈9.5 dB**, through a path with zero
+shared code. That single measurement moved the entire investigation out of
+GopherTrunk and into the capture hardware. The independence is what makes
+the logic sound — decimating with the suspect DDC itself would have been
+circular, the same self-consistency failure this series keeps naming (a
+synthetic test that scrambles and descrambles with the same wrong code
+passes forever; a fake server that switches on the same wrong constant as
+the client validates nothing).
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 230" width="680" height="230" role="img" aria-label="Block diagram of the rate-invariance experiment. The failing ten-megasample capture feeds two paths: the native ten-megasample DDC path, and an independent four-to-one polyphase resampler followed by the proven two-and-a-half-megasample DDC path. Both paths measure about nine and a half dB in-channel SNR, so an equals sign joins them and the conclusion box says the deficit is in the captured samples, not the DDC.">
+  <rect x="8" y="86" width="140" height="52" rx="6" fill="none" stroke="currentColor"/>
+  <text x="78" y="107" text-anchor="middle" fill="currentColor" font-size="10">10 MS/s capture</text>
+  <text x="78" y="123" text-anchor="middle" fill="var(--fg-muted)" font-size="8">the failing file, peak ≈−48 dBFS</text>
+  <line x1="148" y1="98" x2="196" y2="56" stroke="currentColor"/><polygon points="192,58 202,52 196,64" fill="currentColor"/>
+  <line x1="148" y1="126" x2="196" y2="168" stroke="var(--accent)"/><polygon points="192,164 202,172 194,174" fill="var(--accent)"/>
+  <rect x="204" y="30" width="180" height="48" rx="6" fill="none" stroke="currentColor"/>
+  <text x="294" y="50" text-anchor="middle" fill="currentColor" font-size="10">native 10 MS/s DDC path</text>
+  <text x="294" y="66" text-anchor="middle" fill="var(--fg-muted)" font-size="8">Downconverter → 48 kHz</text>
+  <rect x="204" y="146" width="180" height="48" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="294" y="164" text-anchor="middle" fill="var(--accent)" font-size="10">independent 4:1 resampler</text>
+  <text x="294" y="180" text-anchor="middle" fill="var(--fg-muted)" font-size="8">dsp.NewResampler(1, 4, 64, 8.6)</text>
+  <line x1="384" y1="170" x2="420" y2="170" stroke="var(--accent)"/><polygon points="416,166 426,170 416,174" fill="var(--accent)"/>
+  <rect x="428" y="146" width="150" height="48" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="503" y="164" text-anchor="middle" fill="var(--accent)" font-size="10">proven 2.5 MS/s path</text>
+  <text x="503" y="180" text-anchor="middle" fill="var(--fg-muted)" font-size="8">the one that locks</text>
+  <line x1="384" y1="54" x2="596" y2="54" stroke="currentColor"/><polygon points="592,50 602,54 592,58" fill="currentColor"/>
+  <line x1="578" y1="170" x2="596" y2="170" stroke="var(--accent)"/><polygon points="592,166 602,170 592,174" fill="var(--accent)"/>
+  <text x="626" y="58" text-anchor="middle" fill="currentColor" font-size="10">≈9.5 dB</text>
+  <text x="626" y="174" text-anchor="middle" fill="var(--accent)" font-size="10">≈9.5 dB</text>
+  <line x1="626" y1="70" x2="626" y2="152" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <text x="640" y="115" fill="var(--fg-muted)" font-size="12">=</text>
+  <text x="340" y="222" text-anchor="middle" fill="var(--fg-muted)" font-size="10">same SNR through zero shared code ⇒ the ~10 dB deficit is in the samples, not the DDC</text>
+</svg>
+<figcaption>The control that settled #764: the failing capture, decimated by an independent resampler and replayed through the proven path, reproduces the same ≈9.5 dB — so the deficit travels with the samples.</figcaption>
+</figure>
+
+## Ruling out the alternatives
+
+"It's in the samples" narrows to a family of causes, and the same
+measurement-first discipline sorts them.
+
+**Overload / intermod?** No. Both captures peak at ≈**−48 dBFS** — nearly
+50 dB of digital headroom, with no clipping in either file. A wider front
+end admitting more total power *can* drive intermodulation, which is why
+this had to be checked rather than dismissed; but IMD products of an
+unclipped, −48 dBFS-peak stream are not a 10 dB in-channel deficit.
+
+**Just more noise bandwidth?** That is not how it works — noise *density* is
+what matters, and the DDC's channel filter passes the same 48 kHz either
+way. The invariant test below is exactly this statement made executable.
+
+**The surprise:** the wideband FFT **carrier** SNR — carrier peak over the
+adjacent noise floor — was actually *higher* in the 10 MS/s capture. A
+capture whose carrier looks better while its demodulated constellation is
+10 dB worse is the fingerprint of **phase noise / reciprocal mixing**: the
+LO's phase-noise skirt, integrating differently at the Airspy's native
+10 MS/s clock configuration, lets every strong neighbour smear energy across
+the victim channel. The carrier spike survives (it's narrowband and strong);
+the modulation — which lives in precise phase transitions — drowns. The RF
+physics of that mechanism gets its own operator-level treatment in
+[The Analog Edge, Part 5]({{ '/blog/tutorials/analog-edge-05-phase-noise-reciprocal-mixing/' | relative_url }});
+what matters here is the diagnostic shape: *carrier-clean but
+modulation-degraded means the impairment is multiplicative in phase, and no
+linear equalizer, soft decoder, or combiner will fix it.* The levers of
+Parts 4–11 are the wrong aisle. The fix was operational: capture at the rate
+where the front end is clean.
+
+## Pinning it forever — and the recipe
+
+An investigation that ends in a conversation evaporates. This one ended in a
+test that makes the invariant executable:
+
+```go
+// internal/scanner/ccdecoder/ddc_highrate_test.go (shape) — TestDownconverterSNRInvariantAcrossRate
+symbols := c4fmSymbols(9600, 0x764) // ~2 s of C4FM at the #764 seed
+clean10 := c4fmChannel(symbols, offsetHz, 10_000_000, sigAmp) // −812.5 kHz: Mt Anakie
+noise10 := whiteNoise(len(clean10), noiseAmp, 0x5151)
+
+// Native 10 MS/s path.
+sigHi := cmplxRMS(NewDownconverterWithOffset(10_000_000, DDCTargetRateHz, offsetHz).Process(nil, clean10))
+noiHi := cmplxRMS(NewDownconverterWithOffset(10_000_000, DDCTargetRateHz, offsetHz).Process(nil, noise10))
+
+// Independent 4:1 decimation to 2.5 MS/s, then the proven 2.5 MS/s path.
+clean25 := dsp.NewResampler(1, 4, 64, 8.6).Process(nil, clean10)
+/* … same for noise, then the 2.5 MS/s Downconverter … */
+
+ratio := snrHi / snrLo
+if ratio < 0.8 || ratio > 1.25 {
+    t.Errorf("in-channel SNR not rate-invariant: … the DDC must neither create nor hide an SNR deficit (issue #764)")
+}
+```
+
+Note the trick that makes the measurement exact: the DDC is linear, so
+`DDC(signal+noise) = DDC(signal) + DDC(noise)` — the test runs signal and
+noise through separately and reads post-DDC SNR directly from the two RMS
+values, no estimator needed. Companion tests pin the level
+(`TestDownconverterC4FMLevelRateInvariant`) and alias rejection
+(`TestDownconverterRejectsWidebandNeighbours`) across the same rate pair. If
+anyone ever makes the DDC rate-sensitive, the #764 argument stops being true
+and these tests say so before a reporter does.
+
+The generalized recipe, applicable far beyond one issue:
+
+1. **State the invariant** your pipeline guarantees (here: in-channel SNR is
+   capture-rate-invariant). If you can't state one, that's the first bug.
+2. **Build the experiment that isolates it** — route the failing input
+   through the proven path so only one variable moves.
+3. **Use an independent implementation for the cross-check.** Shared code
+   shares bugs; independence is what converts "consistent" into "correct."
+4. **Rule out the boring causes with numbers**, not plausibility (−48 dBFS
+   peak is a fact; "probably overload" is a mood).
+5. **Leave the invariant pinned in the suite**, named after the issue.
+
+## Where this goes next
+
+The recipe's honest corollary: sometimes the investigation proves the code
+*is* the weak link — and the fix still can't land, because there is nothing
+to A/B it against.
+[Part 13]({{ '/blog/deep-dives/weak-signal-engineering-13-p25-c4fm-gap/' | relative_url }})
+is that case: P25 Phase 1 C4FM voice, the one decode path in GopherTrunk
+with neither an equalizer nor soft FEC — diagnosed structurally, fix
+sketched, and deliberately unfixed until a real weak-signal capture exists
+to measure it against.
+
+## FAQ
+
+**Why not just trust the demod SNR numbers and skip the experiment?**
+Because they don't localise. ≈9.5 dB at the demod is consistent with *both*
+"the DDC damaged the samples" and "the samples arrived damaged." The
+independent-resampler control is what separates the two — it holds the
+decode path fixed and moves only the provenance of the samples.
+
+**Couldn't the resampler itself have introduced the deficit?**
+Then the control would have *failed the other way* on the healthy file — and
+the pinned tests run the same resampler on synthetic signal-plus-noise and
+require SNR preservation within 0.8–1.25×. The control is validated by the
+same suite that uses it.
+
+**What made phase noise the conclusion rather than just 'unknown RF'?**
+The conjunction of three measurements: no clipping (−48 dBFS peaks), *higher*
+wideband carrier SNR at 10 MS/s, and a 10 dB in-channel modulation deficit
+that survives independent decimation. Additive noise can't produce that
+pattern; a multiplicative phase impairment does, and the rate-dependence
+matches a clock-configuration-dependent LO skirt.
+
+**Does this mean higher capture rates are bad?**
+No — it means capture rate is a front-end operating point, not a free
+parameter, and some hardware is cleaner at some clocks. The decode path
+genuinely does not care. Measure your own front end: capture the same
+carrier at both rates and compare demod SNR, exactly as #764 did.
+
+**Where does the #764/#771 story continue?**
+The full postmortem — including the first "fix" that closed the issue
+without verification, and the policy that grew out of it — is
+[From the Issue Tracker, Part 5]({{ '/blog/solution-postmortem/from-the-issue-tracker-05-ten-megasamples/' | relative_url }}).
+This post extracts the reusable method; that one tells the cautionary tale.
+
+## Series navigation
+
+**Part 12 of 14** · ←
+[Part 11: Diversity II — Tracking Without Breaking the Differential]({{ '/blog/deep-dives/weak-signal-engineering-11-tracking-mrc/' | relative_url }})
+· Next →
+[Part 13: The Odd Path Out — P25 Phase 1 C4FM]({{ '/blog/deep-dives/weak-signal-engineering-13-p25-c4fm-gap/' | relative_url }})

--- a/docs/_posts/2026-08-30-analog-edge-13-coherence-not-dbfs.md
+++ b/docs/_posts/2026-08-30-analog-edge-13-coherence-not-dbfs.md
@@ -1,0 +1,265 @@
+---
+title: "The Analog Edge, Part 13: Coherence, Not dBFS — Scale-Invariant Health"
+description: The story of an operator who raised front-end gain seventeen decibels to push a number past a software constant, and the scale-invariant cross-correlation that replaced the gate — why coherence answers the question a calibrator actually asks, and why DC removal inside it is load-bearing.
+category: tutorials
+keywords: normalised cross correlation, coherence gate sdr, scale invariant signal quality, dbfs threshold trap, mrc calibration gate, dc offset correlator, rho snr mapping, gain staging trap, gophertrunk analog edge
+tags: [analog-edge, coherence, dbfs, calibration, dsp, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "The Analog Edge"
+series_part: 13
+---
+
+*Part 13 of **The Analog Edge**, a 14-part field guide to the analog half of a
+GopherTrunk system. [Part 12]({{ '/blog/tutorials/analog-edge-12-front-end-classes/' | relative_url }})
+classified front ends by watching `branch_phase_deg` — a log field standing in
+for test equipment. This part is about the number that made the whole
+diversity stack honest, and the incident that forced it into existence. Back
+in [Part 3]({{ '/blog/tutorials/analog-edge-03-gain-staging/' | relative_url }})
+we promised the full story of the operator who raised gain 65 → 82 dB to
+clear a software constant by 0.2 dB. Here it is — and the scale-invariant
+replacement is the most transferable idea this series has to offer.*
+
+> **TL;DR:** MRC calibration used to be gated on the reference branch clearing
+> **−40 dBFS** — so an operator raised front-end gain from 65.0 to 82.0 dB
+> purely to push a meter past a constant (landing at −39.8 dBFS, clearing it
+> by 0.2 dB). Any absolute-power gate is a gain-staging trap that re-fires on
+> the next front end. The replacement is the **normalised cross-correlation**
+> `|rho| = |Σ x1·conj(x0)| / sqrt(Σ|x0|²·Σ|x1|²)` (`diversity.CrossStats`),
+> which is scale-invariant and answers the question the calibrator actually
+> has: *are these two receivers seeing the same signal?* The mapping
+> `|rho| = γ/(1+γ)` makes thresholds interpretable — **0.50 ≈ 0 dB** per-branch
+> SNR, **0.35 ≈ −2.7 dB** — against a noise-only floor near `sqrt(π/4N)`.
+> Inside the correlator, **DC removal is load-bearing, not hygiene**; absolute
+> power survives only as a −100 dBFS digitally-dead-branch reject.
+
+**Key takeaways**
+
+- **An absolute dBFS gate makes operators tune the radio to the software.**
+  The 17 dB gain raise bought nothing but intermod risk — the number it chased
+  measured *level*, and the decision needed *evidence*. Every absolute
+  threshold quietly re-fires when the hardware changes.
+- **Coherence is the question, so measure the question.** "Are these branches
+  the same signal through a constant complex gain?" has a direct statistic,
+  and it reads the same at any gain setting — which is why the not-coherent
+  WARN can honestly say raising gain will not help.
+- **The γ/(1+γ) mapping turns a unitless number into dB.** A threshold of 0.5
+  isn't folklore; it's "0 dB per-branch SNR," chosen on a scale where the
+  noise floor for N samples is computable.
+- **An uncentred correlator lies confidently.** Shared LO leakage is
+  common-mode DC on both branches; without DC removal, two branches of pure
+  independent noise read |rho| → 1 — a calibrator would lock onto nothing, in
+  exactly the weak-signal regime the gate exists to protect.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| The statistic | DC-removed normalised cross-correlation over a window | `internal/dsp/diversity/crossstats.go` (`CrossStats.Coherence`) |
+| The gain beside it | least-squares branch gain from the same sums | `CrossStats.Gain` (`h = cov(x,ref)/var(ref)`) |
+| Thresholds | lock 0.50 (≈0 dB), track 0.35 (≈−2.7 dB) | `internal/sdr/soapyremote/mrc.go` (`mrcCoherenceLockGate`, `mrcCoherenceTrackGate`) |
+| DC-removal proof | common DC must not read as correlation | `TestCrossStatsRejectsCommonDCOffset` (`crossstats_test.go`) |
+| The power floor that remains | reject a digitally dead branch only | `MinBranchPower` 1e-10 ≈ −100 dBFS (`tracking.go`) |
+| Operator surface | `coherence` in the 30 s MRC health line | `diversityReporter` (`mrc.go`), [Part 11]({{ '/blog/tutorials/analog-edge-11-diversity-mrc/' | relative_url }}) |
+| The deep dive | full calibration design + measurements | [WSE Part 10]({{ '/blog/deep-dives/weak-signal-engineering-10-mrc-calibration/' | relative_url }}) |
+
+## In this post
+
+- **The 0.2 dB incident** — how a threshold turns into a tuning target.
+- **The scale-invariant question** — what coherence measures.
+- **Reading |rho| in dB** — the γ/(1+γ) mapping and the noise floor.
+- **DC removal is load-bearing** — the trap inside the correlator.
+- **The general moral** — gating decisions on evidence, not level.
+
+## The 0.2 dB incident
+
+The old MRC calibration logic refused to estimate branch gains until the
+reference branch's level cleared −40 dBFS. Reasonable-sounding — "don't
+calibrate on noise" — and wrong in a way that only shows up in the field. An
+operator with a healthy but conservatively-gained front end saw diversity
+refuse to engage, read the number it wanted, and did the only thing the gate
+rewarded: raised RF gain from 65.0 dB to 82.0 dB. They landed at −39.8 dBFS —
+clearing the constant by 0.2 dB — and diversity engaged. Nothing about their
+signal had improved. They had spent 17 dB of front-end headroom — the same
+headroom [Part 4]({{ '/blog/tutorials/analog-edge-04-clipping-overload-intermod/' | relative_url }})
+showed protecting you from intermod — to move a meter past a line in the
+source code.
+
+That is the anatomy of every absolute-power gate: it couples a *decision*
+(can I trust this estimate?) to a *level* (how hot is the ADC running?), and
+operators respond to what's rewarded. [Part 2]({{ '/blog/tutorials/analog-edge-02-dbfs/' | relative_url }})
+made the case that dBFS is a headroom meter, not a quality meter — the
+[#764](https://github.com/MattCheramie/GopherTrunk/issues/764) captures both
+peaked ≈−48 dBFS and differed by 10 dB of usable SNR. A gate on dBFS is that
+category error, compiled in. And it re-fires on every new front end: the
+constant that a USRP clears at gain 65 needs 82 on the next radio, and
+whatever an RTL-SDR needs is nobody's guess. The fix was to delete the
+question the gate was asking and ask the real one.
+
+## The scale-invariant question
+
+What the calibrator actually needs to know is: *are these two receivers
+seeing the same signal through a constant complex gain?* That question has a
+direct statistic — the normalised cross-correlation of the two branches over
+an accumulation window:
+
+```go
+// internal/dsp/diversity/crossstats.go (shape)
+// Gain()      the least-squares complex gain  h = cov(x,ref)/var(ref)
+// Coherence() the normalised cross-correlation |rho| in [0,1]
+//
+// Coherence is the quality gate. It answers "are these two receivers seeing
+// the same signal through a constant complex gain?" … and — unlike an
+// absolute power threshold — it is SCALE-INVARIANT.
+func (s *CrossStats) Coherence() float64
+```
+
+Scale-invariance is the whole point: multiply either branch by any constant —
+turn any gain knob anywhere — and |rho| does not move, because the
+denominator normalises both branches' energy away. The statistic reads the
+*relationship* between the branches, not their level. This is why the
+not-coherent WARN from [Part 11]({{ '/blog/tutorials/analog-edge-11-diversity-mrc/' | relative_url }})
+can state flatly that raising RF gain will not help — mathematically, it
+can't. The same accumulated sums also yield the branch gain `h` itself, so
+the gate and the estimate come from one pass over one window: if |rho| says
+the window is trustworthy, `h` from that window is the calibration.
+
+## Reading |rho| in dB
+
+A unitless 0-to-1 number invites folklore thresholds. What keeps this one
+honest is that it maps to something physical: for two branches carrying a
+common signal in independent noise at equal per-branch SNR γ,
+
+**|rho| = γ / (1 + γ)**
+
+So 0.50 is γ=1 — **0 dB** per-branch SNR. 0.35 is about **−2.7 dB**. And two
+branches of pure independent noise over N samples don't read zero — they read
+near `sqrt(π/4N)`, about **0.03 at N=1000**: the floor any threshold must
+clear. GopherTrunk's gates sit exactly on this scale: the *first* estimate (a
+one-shot calibration lives with it forever) must clear **0.50**; subsequent
+tracking updates, whose errors average away, need only **0.35**
+(`mrcCoherenceLockGate`, `mrcCoherenceTrackGate`).
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 210" width="680" height="210" role="img" aria-label="Coherence magnitude rho plotted against per-branch SNR in decibels, following the curve gamma over one plus gamma: rho rises from near zero at minus ten decibels through 0.35 at about minus 2.7 decibels and 0.5 at zero decibels, saturating toward one above ten decibels. The two gate thresholds at 0.35 and 0.5 are marked with horizontal dashed lines, and the noise-only floor near 0.03 is marked along the bottom.">
+  <line x1="60" y1="15" x2="60" y2="165" stroke="var(--fg-muted)"/>
+  <line x1="60" y1="165" x2="650" y2="165" stroke="var(--fg-muted)"/>
+  <text x="14" y="25" fill="var(--fg-muted)" font-size="9">|rho|</text>
+  <text x="560" y="182" fill="var(--fg-muted)" font-size="9">per-branch SNR (dB)</text>
+  <text x="52" y="180" fill="var(--fg-muted)" font-size="9">−10</text>
+  <text x="244" y="180" fill="var(--fg-muted)" font-size="9">0</text>
+  <text x="432" y="180" fill="var(--fg-muted)" font-size="9">+10</text>
+  <text x="622" y="180" fill="var(--fg-muted)" font-size="9">+20</text>
+  <text x="40" y="169" fill="var(--fg-muted)" font-size="9">0</text>
+  <text x="40" y="29" fill="var(--fg-muted)" font-size="9">1</text>
+  <polyline points="60,152 155,131 199,116 250,95 345,59 440,38 535,29 650,26" fill="none" stroke="currentColor" stroke-width="2"/>
+  <line x1="60" y1="95" x2="250" y2="95" stroke="var(--accent)" stroke-dasharray="4,4"/>
+  <line x1="250" y1="95" x2="250" y2="165" stroke="var(--accent)" stroke-dasharray="4,4"/>
+  <circle cx="250" cy="95" r="4" fill="var(--accent)"/>
+  <text x="66" y="90" fill="var(--accent)" font-size="9">lock gate 0.50 ⇔ 0 dB</text>
+  <line x1="60" y1="116" x2="199" y2="116" stroke="var(--accent)" stroke-dasharray="4,4"/>
+  <circle cx="199" cy="116" r="4" fill="var(--accent)"/>
+  <text x="66" y="130" fill="var(--accent)" font-size="9">track gate 0.35 ⇔ −2.7 dB</text>
+  <line x1="60" y1="161" x2="650" y2="161" stroke="var(--fg-muted)" stroke-dasharray="2,5"/>
+  <text x="470" y="156" fill="var(--fg-muted)" font-size="9">noise-only floor ≈ sqrt(π/4N) (~0.03 at N=1000)</text>
+  <text x="352" y="202" text-anchor="middle" fill="var(--fg-muted)" font-size="10">|rho| = γ/(1+γ): every threshold on this curve is a statement in dB — and no gain knob moves a point along it</text>
+</svg>
+<figcaption>The γ/(1+γ) curve makes coherence thresholds interpretable: 0.5 means 0 dB per-branch SNR, 0.35 means −2.7 dB, and the noise-only floor is computable.</figcaption>
+</figure>
+
+Absolute power didn't vanish entirely — it survives as exactly one check, at
+a level no gain-staging decision will ever brush against: a branch below
+`MinBranchPower` (1e-10 linear, ≈**−100 dBFS**, where one CS16 LSB is
+−90.3 dBFS) is *digitally dead* — all zeros, a receiver that never digitised —
+and there |rho| is 0/0. That's not a signal-presence test; it's a
+divide-by-zero guard, which is all absolute power was ever qualified to be.
+
+## DC removal is load-bearing
+
+One trap hides inside the statistic itself, and it's worth knowing because it
+generalizes. Every sum in `CrossStats` is a **DC-removed** covariance, not a
+raw correlation — and that's not numerical hygiene. Both receivers of a
+shared front end carry LO leakage and converter DC offset, and that offset is
+perfectly **common-mode**: identical on both branches, always. Feed two
+branches of pure independent noise plus a shared DC into an *uncentred*
+correlator and it reports |rho| → 1 — mathematically correct, the DC really
+is perfectly correlated — and hands back `h = dc1/dc0`. A calibrator gated on
+that would confidently lock onto *nothing*, in exactly the weak-signal regime
+the gate exists to protect, and the combined output would be two noise floors
+aligned by their LO leakage. `TestCrossStatsRejectsCommonDCOffset` pins the
+trap shut: the centred statistic reads that same input as the noise it is.
+The cost of correctness is one extra running sum per branch. The cost of the
+bug would have been invisible.
+
+## The general moral
+
+The series keeps meeting the same lesson wearing different clothes, so here
+it is stated once, plainly: **never gate a DSP decision on an absolute
+level; gate it on scale-invariant evidence.** Gain sweeps are scored by
+decode error rate, not power
+([The Hunt Part 5]({{ '/blog/deep-dives/the-hunt-05-autogain-autotune/' | relative_url }})).
+Equalizers are judged by CRC yield, not EVM (the
+[metrics-that-lie]({{ '/blog/deep-dives/weak-signal-engineering-02-metrics-that-lie/' | relative_url }})
+problem). Calibration is gated on coherence, not dBFS. In every case the
+absolute number was easier to compute and already on hand — and in every case
+it measured the radio's *configuration* when the decision needed the
+*signal's* testimony. When you find yourself adjusting hardware to satisfy a
+software number, stop and ask what question the number was standing in for.
+The full design that came out of this incident — window sizing, the hold-
+don't-fallback rule, and what the gates measured on real captures — is
+[Weak-Signal Engineering Part 10]({{ '/blog/deep-dives/weak-signal-engineering-10-mrc-calibration/' | relative_url }}).
+
+## Where this goes next
+
+That's the last new instrument this series needed. Everything is now on the
+bench: dBFS read correctly, gain staged by decode quality, overload and phase
+noise recognized on sight, feedline and LNA budgets done in dB, captures that
+prove things, diversity with honest health numbers.
+[Part 14]({{ '/blog/tutorials/analog-edge-14-field-checklist/' | relative_url }})
+folds all of it into one field checklist — the is-it-RF-or-is-it-software
+triage tree — and closes the story of the reader whose hardware scanner used
+to win.
+
+## FAQ
+
+**Isn't a coherence gate just a threshold too? Why is 0.5 better than −40 dBFS?**
+Both are thresholds; they differ in what they measure. |rho|=0.5 is a
+statement about the *signal* (0 dB per-branch SNR) that reads identically on
+any hardware at any gain. −40 dBFS is a statement about the *ADC's operating
+point*, which the operator controls — so it selects for operators who turn
+the knob, not for trustworthy estimates.
+
+**What coherence should I see on a healthy system?**
+Track the mapping: branches at 5 dB SNR cohere at ~0.76, at 10 dB ~0.91. A
+co-located pair on a live trunking band typically reads 0.6–0.9. The two
+diagnostic regimes are near-floor (~0.03–0.1: branches see different signals
+— band, polarization, clocking) and stuck mid-range (~0.3–0.5: the
+wideband-scalar limit from [Part 11]({{ '/blog/tutorials/analog-edge-11-diversity-mrc/' | relative_url }})).
+
+**Could the DC trap really happen, or is it theoretical?**
+It's the default outcome, not an edge case: *every* zero-IF front end leaks
+some LO, so the common-mode DC is always present, and the trap fires
+strongest precisely when there's the least real signal to out-correlate it.
+That's why the test pins it and why "hygiene" is the wrong word — remove the
+centring and the diversity stack fails quietly on weak signals only.
+
+**Where else does GopherTrunk apply this rule?**
+Anywhere a decision used to want a power gate: autogain optimizes decode
+error rate across the sweep; the MRC dead-branch check sits at −100 dBFS
+(existence, not quality); and the equalizer work is validated exclusively by
+CRC-clean decode counts on captures. The
+[diagnostic playbook]({{ '/reference/diagnostic-playbook/' | relative_url }})
+collects the field-facing versions.
+
+**I'm not running diversity. What do I take from this part?**
+The trap generalizes to *your own* debugging: any time you're pushing gain,
+rate, or thresholds to make a dashboard number cross a line, you're gating on
+level. Ask instead for scale-invariant evidence — decode rate, CRC yield,
+sync margin — the numbers that can't be flattered by a knob.
+
+## Series navigation
+
+**Part 13 of 14** · ←
+[Part 12: Front-End Classes — Shared LO vs Independent PLLs]({{ '/blog/tutorials/analog-edge-12-front-end-classes/' | relative_url }})
+· Next →
+[Part 14: The Field Checklist — Is It RF or Is It Software?]({{ '/blog/tutorials/analog-edge-14-field-checklist/' | relative_url }})

--- a/docs/_posts/2026-08-30-tetra-end-to-end-13-dmo-pipeline-grants.md
+++ b/docs/_posts/2026-08-30-tetra-end-to-end-13-dmo-pipeline-grants.md
@@ -1,0 +1,279 @@
+---
+title: "TETRA End to End, Part 13: DMO III — A Production Pipeline: Grid Votes, Grants & Noise"
+description: "Wiring DMO into the daemon as a first-class protocol — streaming burst extraction, sticky locks, edge-triggered grants — and the first on-air run's humbling lesson: a loose correlator false-alarms eighteen times a second, and only a learned slot-grid vote separates a real transmission from an idle channel."
+category: deep-dives
+keywords: tetra dmo pipeline, dmslotgrid residue voting, false alarm rate correlator, edge triggered grant, sticky cc lock, dmo voice chain, streaming burst extractor, dnb qualification, gophertrunk tetra
+tags: [tetra-end-to-end, tetra, dmo, daemon, statistics, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "TETRA End to End"
+series_part: 13
+---
+
+*Part 13 of **TETRA End to End**, a 14-part deep dive into how GopherTrunk turns
+one real 25 kHz TETRA carrier into clear recorded voice.
+[Part 12]({{ '/blog/deep-dives/tetra-end-to-end-12-dmo-descramble-colour/' | relative_url }})
+got clear DMO voice decoding offline — colour recovered, speech frames out, PCM
+rendered. This part promotes all of it from a replay harness to the production
+daemon: a real protocol name in the config, a real pipeline behind the scanner,
+a real voice chain into the recorder. And it includes the most instructive bug
+of the whole DMO arc — the first live run granted a call on a **silent
+channel** 230 milliseconds after startup, then ignored the operator's actual
+transmission entirely. The root cause was not a typo. It was a statistics
+lesson the offline path never had to learn.*
+
+> **TL;DR:** DMO is now a first-class daemon protocol: **`ProtocolTETRADMO`**
+> (`tetra-dmo`/`dmo` in `internal/trunking/site.go`, 144 kHz DDC target, an
+> entry in the `factories` map), decoded by **`newTETRADMOPipeline`** driving a
+> streaming **`tetra.DMStreamExtractor`**, with a **sticky** `KindCCLocked`
+> (never `cc.lost` on inter-PTT silence) and an **edge-triggered** `tetra-dmo`
+> grant into **`composer.runTETRADMOVoiceChain`**. The first on-air run exposed
+> that a raw DNB detection is *not* evidence of traffic: an 11-dibit training
+> match at tolerance 2 under 8 filters fires by chance **~18×/s** on an idle
+> channel (529 of 4¹¹ sequences match), so **`tetra.DMSlotGrid`** now votes DNB
+> leads onto the 255-dibit slot residue — one radio on one clock concentrates
+> on one residue; noise is uniform over all 255 — and only **qualified** DNBs
+> count toward the grant, the colour recovery, or the drought. The grant also
+> now requires the lock it was always named after, and the re-arm drought is
+> evaluated from `Process`, not just from bursts.
+
+**Key takeaways**
+
+- **A loose detector needs a qualifier, not a tighter threshold.** Tolerance 2
+  is right for catching marginal real bursts; the fix isn't tolerance 1, it's
+  a second, orthogonal test — timing structure — that noise cannot fake.
+- **The operator's own log carried the proof.** `dnb_total` climbing
+  1076→4541 in 185 s is 18.7/s — the predicted false-alarm rate to the first
+  decimal — while `dsb_schs_crc` sat frozen at 46. Numbers first, then code.
+- **Learn constants; don't derive them from the spec when a wrong value fails
+  silently.** The grid's traffic residue is voted from the stream, never
+  computed from a DSB→DNB offset — a wrong hardcoded offset would quietly stop
+  DMO granting forever, which is worse than over-granting.
+- **A brute force that starves its own input is a self-inflicted outage.** The
+  voice chain's uncapped 64-colour recovery was ≈450k Viterbi decodes per
+  call — enough to drop 5904 chunks of the very IQ it was decoding.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| Protocol registration | enum, `"tetra-dmo"`, parse, validate | `internal/trunking/site.go` (`ProtocolTETRADMO`) |
+| Channel rate | DMO shares TETRA's 144 kHz DDC target | `internal/scanner/ccdecoder/ddc.go` (`ddcTargetForProtocol`) |
+| Control pipeline | lock, colour, grant off the dibit stream | `internal/scanner/ccdecoder/pipelines_dmo.go` (`newTETRADMOPipeline`) |
+| Streaming extractor | bounded window, dedup, lead-ordered emit | `internal/radio/tetra/dmo_stream.go` (`DMStreamExtractor`) |
+| Noise gate | residue voting on the 255-dibit slot grid | `internal/radio/tetra/dmo_grid.go` (`DMSlotGrid`) |
+| Grant policy | lock required, 4 qualified DNBs, 3 s re-arm | `pipelines_dmo.go` (`maybeGrant`, `dmoGrantMinDNB`, `dmoGrantRearm`) |
+| Voice chain | buffer → colour → retroactive decode → ACELP | `internal/voice/composer/tetra_dmo_voice.go` (`runTETRADMOVoiceChain`) |
+| Failing-first pins | idle-channel, lock-gate, re-arm regressions | `pipelines_dmo_test.go`, `dmo_grid_test.go` |
+
+## In this post
+
+- **Registering a protocol** — the three touchpoints that make `tetra-dmo` real.
+- **A pipeline for a channel that's usually silent** — sticky locks, streaming extraction.
+- **The noise-grant post-mortem** — 18 false DNBs a second, and four compounding bugs.
+- **The slot-grid vote** — residue statistics that noise can't fake.
+- **The voice chain's own lessons** — cost caps and honest logging.
+
+## Registering a protocol
+
+Making `protocol: tetra-dmo` mean something takes three touchpoints.
+`internal/trunking/site.go` adds `ProtocolTETRADMO` to the enum, `String()`,
+`ParseProtocol` (accepting `tetra-dmo`, `tetra_dmo`, `tetradmo`, and plain
+`dmo`), and `Validate`. `ccdecoder/ddc.go` teaches `ddcTargetForProtocol` that
+DMO, like TMO TETRA, needs the 144 kHz channel rate. And the `factories` map in
+`pipelines.go` routes the protocol to `newTETRADMOPipeline`. That last hop is
+the one that fixes the operator-visible symptom from Part 11: before it, a DMO
+capture fell through to the TMO control-channel path and produced the
+`sch_pdus=0` / `sync gap` / `dsp resync` churn of a state machine waiting for a
+downlink that will never come.
+
+## A pipeline for a channel that's usually silent
+
+`newTETRADMOPipeline` reuses the TMO receiver knobs wholesale — Gardner clock,
+AFC, channel filter, `SoftSink`, and the blind CMA equalizer, which for DMO is
+*required*, not optional (Part 11's 6→64 SCH/S lift). But it cannot reuse the
+TMO decode loop, so the receiver feeds `tetra.DMStreamExtractor` — a bounded
+sliding-window adapter over the stateless `ExtractDMBurstsSoft` from Part 11
+that re-scans a 384-dibit retained tail each pass and emits every DSB/DNB
+exactly once, in lead order, deduped by absolute lead index. Offline and live
+paths therefore share the framing code bit-for-bit, which is what
+`TestDMStreamExtractorMatchesWholeSlice` (chunk-invariance) pins.
+
+Lifecycle is where DMO diverges hardest. The lock — published on the first
+CRC-valid SCH/S with a parseable SYNC PDU — is **sticky**: the pipeline never
+publishes `cc.lost`, because inter-PTT silence is the *normal state* of a DMO
+channel, and re-hunting a camped frequency every quiet gap is exactly the churn
+the TMO watchdog exists to cause. And with no control channel to announce
+calls, grants are **inferred from traffic**: a rising edge of DNB activity
+publishes one `tetra-dmo` grant (GroupID 0 — DMO carries no talkgroup), re-armed
+only after a 3 s traffic drought. Which brings us to the run where all of that
+logic met the air.
+
+## The noise-grant post-mortem
+
+First live run: the daemon granted and opened a recording **~230 ms after
+startup** on a silent channel — then never granted again. The operator's real
+10-second PTT locked cleanly (`dsb_schs_crc=46/54`) and produced nothing. Four
+bugs compounded, but the root is worth doing the arithmetic in public. The DNB
+correlator matches an 11-dibit training sequence at Hamming tolerance 2, under
+8 matched filters (2 sequences × 4 rotations). The number of 11-dibit sequences
+within distance 2 of a pattern is:
+
+```go
+// internal/radio/tetra/dmo_grid.go (shape) — the arithmetic, in the comment
+//   Σ_{k≤2} C(11,k)·3^k = 1 + 33 + 495 = 529
+// so p ≈ 529/4^11 ≈ 1.26e-4 per position per filter, ≈ 1.0e-3 across the
+// eight filters, and at 18 000 dibit/s that is ≈ 18 spurious DNB
+// "detections" per second off an idle channel.
+```
+
+**Eighteen false DNBs per second, on noise.** The operator's log confirms it to
+the first decimal: `dnb_total` climbed 1076→4541 over 185 s — 18.7/s — while
+`dsb_schs_crc` sat frozen. Against that rate: `dmoGrantMinDNB=4` tripped in
+~0.22 s of startup noise; `maybeGrant` never actually checked `p.locked`
+(despite its counter being *named* `dnbSinceLock`); the 3 s re-arm drought
+could never elapse against a 55 ms mean inter-arrival; and the drought check
+lived only inside the DNB branch, so on a truly silent channel it could not
+run at all — the grant latched for the life of the daemon. A detector loose
+enough to catch marginal real bursts is, by the same coin, a noise generator.
+The fix had to make noise and traffic *statistically distinguishable*.
+
+## The slot-grid vote
+
+The discriminator is timing structure. A real transmission comes from **one
+radio on one clock**, so every burst it emits lands on the 255-dibit timeslot
+grid — all its DNB leads share a single residue mod 255. Noise hits are uniform
+over all 255 residues. `tetra.DMSlotGrid` votes recent leads onto that ring:
+
+```go
+// internal/scanner/ccdecoder/pipelines_dmo.go (shape) — onBurst, DNB branch
+p.dnbTotal++
+p.maybeRearmGrant(now)
+if !p.grid.Observe(b.Lead) {
+    return // correlator false alarm: counts nowhere below
+}
+p.dnbQualified++
+p.dnbSinceLock++
+p.recoverColour(b)
+p.maybeGrant() // requires p.locked AND dmoGrantMinDNB qualified bursts
+```
+
+The sizing is Poisson arithmetic, written into the constants' comments: a 1 s
+window (`dmGridWindow=18000` dibits) holds ~18 noise leads spread over 255
+residues, so the expected count agreeing with any residue within ±1 is ~0.21 —
+requiring `dmGridMinTrain=6` in agreement makes a false latch a ~1.4×10⁻⁶
+event per detection, about **once per 11 hours**, while a real train at ~17
+bursts/s latches in ~340 ms. Three design points matter beyond the math. The
+residue is **learned, never hardcoded** — a spec-derived DSB→DNB lead offset
+that was wrong would silently stop DMO granting forever, a worse failure than
+over-granting. The latch is **centred** on the agreeing leads and tracks slow
+symbol slips (`dmGridDriftAdjust`), so jitter doesn't strand half a real train
+outside the tolerance band. And the latch is **dropped when the train ends**
+(`dmGridTrainGap`, 16 slots): without that, the ~0.2/s of noise landing on the
+latched residue keeps a finished transmission "alive" and the grant never
+re-arms. All of it is pinned failing-first —
+`TestTETRADMOPipelineIgnoresIdleChannel`, `…GrantsOnlyAfterLock`, and
+`…RearmsBetweenTransmissions` all fail against the old code — and the test
+fixture itself got more honest: `buildDMODibitStream` now lays synthetic bursts
+on a true 255-dibit slot grid, because the old arbitrary-filler layout was not
+a faithful transmitter and could never have caught this.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 210" width="680" height="210" role="img" aria-label="Histogram of DNB training-sequence lead residues modulo 255. Noise detections form a low uniform floor across all residues at roughly one per residue per minute, while a real transmission's bursts stack into a single tall spike at one residue — the residue the slot grid latches. A dashed line marks the six-agreeing-leads latch threshold.">
+  <line x1="50" y1="20" x2="50" y2="160" stroke="var(--fg-muted)"/>
+  <line x1="50" y1="160" x2="650" y2="160" stroke="var(--fg-muted)"/>
+  <text x="16" y="30" fill="var(--fg-muted)" font-size="9">leads in</text>
+  <text x="16" y="42" fill="var(--fg-muted)" font-size="9">1 s window</text>
+  <text x="620" y="178" fill="var(--fg-muted)" font-size="9">residue mod 255</text>
+  <g fill="var(--fg-muted)">
+    <rect x="60" y="154" width="5" height="6"/><rect x="92" y="157" width="5" height="3"/>
+    <rect x="121" y="154" width="5" height="6"/><rect x="160" y="157" width="5" height="3"/>
+    <rect x="198" y="154" width="5" height="6"/><rect x="233" y="157" width="5" height="3"/>
+    <rect x="269" y="157" width="5" height="3"/><rect x="305" y="154" width="5" height="6"/>
+    <rect x="352" y="157" width="5" height="3"/><rect x="390" y="154" width="5" height="6"/>
+    <rect x="431" y="157" width="5" height="3"/><rect x="466" y="157" width="5" height="3"/>
+    <rect x="503" y="154" width="5" height="6"/><rect x="541" y="157" width="5" height="3"/>
+    <rect x="578" y="154" width="5" height="6"/><rect x="616" y="157" width="5" height="3"/>
+  </g>
+  <rect x="330" y="36" width="8" height="124" fill="var(--accent)"/>
+  <text x="334" y="28" text-anchor="middle" fill="var(--accent)" font-size="10">real train: ~17/s on ONE residue</text>
+  <line x1="50" y1="112" x2="650" y2="112" stroke="var(--fg-muted)" stroke-dasharray="5 4"/>
+  <text x="646" y="106" text-anchor="end" fill="var(--fg-muted)" font-size="9">latch threshold: 6 agreeing leads</text>
+  <text x="200" y="146" fill="var(--fg-muted)" font-size="9">noise: ~18/s spread uniformly (~0.21 per residue band)</text>
+  <text x="350" y="200" text-anchor="middle" fill="var(--fg-muted)" font-size="10">one radio, one clock, one residue — the vote separates traffic from noise with no decode at all</text>
+</svg>
+<figcaption>DNB lead residues mod 255: correlator noise is uniform across the ring while a real transmission stacks on a single residue — six agreeing leads latch it, and everything off-residue is discarded.</figcaption>
+</figure>
+
+## The voice chain's own lessons
+
+`composer.runTETRADMOVoiceChain` — dispatched from `handleStart` on
+`proto == "tetra-dmo"`, riding one same-carrier IQ tap — re-runs the extractor,
+decodes DNBs via `DMBurstTCHSpeechSoft` with a hard fallback, and hands
+137-bit frames to the recorder under the `tetra-dmo` → `tetra-acelp` vocoder
+mapping. Because the grant fires at 4 qualified DNBs and colour recovery needs
+~20, the chain buffers early bursts and decodes them **retroactively** once the
+colour lands, so no leading speech is lost. The same first run taught it two
+more lessons. Re-running the 64-colour brute force on *every* arriving burst
+from buffer size 20 to 120 is `64·Σ(20..120)` ≈ **450,000 Viterbi decodes per
+call** — the chain starved its own IQ tap (`dropped_chunks=5904`); recovery is
+now capped at 6 batch-boundary passes over a bounded, slot-grid-qualified
+scoring window, while the full buffer is kept for the retroactive decode. And
+`flush()` used to set `colourKnown = true` even when giving up, so a call that
+decoded nothing logged `colour=0 colour_known=true` — indistinguishable from a
+successful recovery of colour 0, and guaranteed to send the next debugger after
+the wrong thing. A separate `colourRecovered` flag now keeps the log honest.
+For operators, the status line's split counters are the takeaway:
+**`dnb_qualified` is the number that means traffic; `dnb_total` is a noise
+meter**, and a large gap between them is normal, not a fault.
+
+## Where this goes next
+
+The pipeline is wired, the statistics are honest, and every regression that
+bit us now fails first. What remains is the discipline this series has repeated
+since Part 3: none of it is *verified* until the operator's own capture goes
+through the full daemon and an intelligible recording lands.
+[Part 14]({{ '/blog/deep-dives/tetra-end-to-end-14-testing-open-questions/' | relative_url }})
+closes the series with the whole test lattice — synthetic, capture harness,
+pipeline, daemon — and an unvarnished list of what is still open, including
+the on-air gate that keeps [#1003](https://github.com/MattCheramie/GopherTrunk/issues/1003)
+from being declared done.
+
+## FAQ
+
+**Why not just tighten the correlator tolerance instead of adding a grid?**
+Because tolerance 2 is doing a job: a marginal real burst with two damaged
+midamble dibits still detects. Tightening it trades recall for precision
+inside one weak test. The grid adds an *independent* test — timing structure —
+that costs real bursts nothing and that noise fails by construction.
+
+**Could the grid reject a real transmission?**
+Only a pathological one. A real train latches after ~6 bursts (~340 ms) and
+the drift tracker follows symbol slips; the tolerance band absorbs jitter. The
+deliberate trade is the ~0.5 s of grant latency (latch + 4 qualified DNBs) —
+the buffered voice chain means no speech is lost to it.
+
+**Why does the grant carry GroupID 0?**
+DMO's air interface carries no talkgroup in what GT currently decodes — the
+call-control PDUs (EN 300 396-3) are not yet parsed. Recordings therefore file
+under group 0. It's in Part 14's open-questions list.
+
+**What happens on a very short PTT — shorter than colour recovery needs?**
+The grant can fire before the colour is known (hint 0), and the voice chain
+recovers independently: it buffers everything, tries the pipeline's
+`colourSink` hint (verified before adoption), then its own capped brute force,
+then falls back to colour 0 at flush. A short clear call decodes; a short
+encrypted one yields BFIs and hangs up normally.
+
+**Is the DMO path now considered verified on air?**
+No. Locks, colour recovery, and grants have all run live; the end-to-end gate —
+a clear capture through the full daemon producing an intelligible recording —
+is still open, and the project's verification discipline (#764/#771) says the
+issue stays open until it lands. Part 14 states exactly what's left.
+
+## Series navigation
+
+**Part 13 of 14** · ←
+[Part 12: DMO II — The 'Encrypted' Verdict That Was a Descramble Skip]({{ '/blog/deep-dives/tetra-end-to-end-12-dmo-descramble-colour/' | relative_url }})
+· Next →
+[Part 14: Testing TETRA Without a Network — & What's Still Open]({{ '/blog/deep-dives/tetra-end-to-end-14-testing-open-questions/' | relative_url }})

--- a/docs/_posts/2026-08-30-weak-signal-engineering-13-p25-c4fm-gap.md
+++ b/docs/_posts/2026-08-30-weak-signal-engineering-13-p25-c4fm-gap.md
@@ -1,0 +1,319 @@
+---
+title: "Weak-Signal Engineering, Part 13: The Odd Path Out — P25 Phase 1 C4FM"
+description: "A diagnosis, not a fix — why P25 Phase 1 C4FM voice is the one decode path in GopherTrunk with neither an equalizer nor soft-decision FEC, what the Astro Spectra report showed, and the baseline harness waiting on the one thing that lets a fix land: a real weak-signal capture."
+category: deep-dives
+keywords: p25 phase 1 c4fm, weak signal voice decode, fm discriminator receiver, imbe hard fec, missing equalizer, cqpsk fse equalizer, capture request p25, baseline metrics harness, gophertrunk weak-signal engineering
+tags: [weak-signal-engineering, p25, c4fm, imbe, equalizer, capture, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Weak-Signal Engineering"
+series_part: 13
+---
+
+*Part 13 of **Weak-Signal Engineering**, a 14-part series on decoding the
+marginal regime — where the receiver locks but only a fraction of frames
+survive. [Part 12]({{ '/blog/deep-dives/weak-signal-engineering-12-proving-signal/' | relative_url }})
+showed how to prove a deficit lives in the samples before touching the code.
+This part is the mirror case: a deficit that almost certainly lives in the
+code — structurally, visibly — and still goes unfixed, on purpose. P25
+Phase 1 C4FM voice is the one decode path in GopherTrunk that has **neither**
+of the two levers that roughly doubled TETRA's marginal yield: no channel
+equalizer, no soft-decision FEC. An operator's hardware radio decodes a
+marginal call cleanly; GopherTrunk recovers a handful of frames on the same
+antenna. We know why. We know the fix. And per the discipline this series
+has enforced since Part 1, no change lands without a capture to measure it
+against. This post is honest about being a roadmap — that's the point.*
+
+> **TL;DR:** The default P25 Phase 1 **C4FM** voice receiver
+> (`internal/radio/p25/phase1/receiver/receiver.go`) is FM discriminator →
+> fixed matched filter (`demod.P25C4FMRxTaps`) → `CoarseAFC` →
+> Mueller-Müller timing → AGC → 4-level slicer → **hard** Golay/Hamming IMBE
+> FEC — no equalizer, no soft decisions. The opt-in CQPSK/LSM path has a T/2
+> fractionally-spaced blind equalizer (the `fse` field in `cqpsk.go`), and
+> P25 Phase 2 wires one too; C4FM Phase 1 is the odd path out. An operator
+> whose Astro Spectra decodes a marginal Phase 1 call cleanly gets ~4–5 IMBE
+> frames from GopherTrunk on the same antenna — consistent with the missing
+> levers, and also too short to even qualify for the autotune fold
+> (`minAutotuneLDUs = 5` in `composer/p25p1_voice.go`). The fix is
+> unverifiable without a real weak C4FM **voice** capture, so the tree holds
+> a baseline harness instead: drop a `.cfile` + metadata into `samples/p25/`
+> and `TestReplayP25RealCaptureMetrics` measures pre-FEC EVM / SNR /
+> FSW-margin as the number to improve.
+
+**Key takeaways**
+
+- **The gap is structural, not a bug.** Every stage of the C4FM chain does
+  its job; the chain is simply missing the two stages — equalization and
+  soft FEC — that the marginal regime demands. Nothing to patch; something
+  to build.
+- **The evidence is a differential diagnosis, not a stack trace.** A hardware
+  radio decoding what GopherTrunk cannot, on the same antenna, bounds the
+  problem: the information is in the RF; the software discards it somewhere.
+  The chain inventory says where.
+- **The levers are proven — next door.** A blind CMA/FSE equalizer already
+  runs on the opt-in CQPSK/LSM path, and equalizer + soft decisions
+  approximately doubled TETRA's marginal yield (Parts 4–8). The port is
+  scoped; the measurement isn't.
+- **Refusing to fix without a capture is the discipline, not an excuse.**
+  A green synthetic is not proof of an on-air fix — the project has been
+  burned by exactly that. The harness, the README ask, and the metadata
+  format all exist so the day the capture arrives, the A/B starts
+  immediately.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| C4FM voice chain | discriminator → MF → AFC → M&M → slicer, all hard | `internal/radio/p25/phase1/receiver/receiver.go` (`DemodC4FM` branch) |
+| The equalizer next door | T/2 fractionally-spaced blind CMA on LSM | `internal/radio/p25/phase1/receiver/cqpsk.go` (`fse *equalizer.FSE`) |
+| Hard IMBE FEC | Golay/Hamming with no soft inputs | `internal/radio/p25/phase1` voice frame path; see [IMBE channel coding]({{ '/reference/imbe-channel-coding/' | relative_url }}) |
+| Short-call brush | <5 LDUs ⇒ autotune fold skipped | `internal/voice/composer/p25p1_voice.go` (`minAutotuneLDUs`) |
+| Baseline harness | EVM / SNR / FSW-margin / NID / TSBK from a real capture | `cmd/gophertrunk/p25_realcapture_metrics_test.go` (`TestReplayP25RealCaptureMetrics`) |
+| The ask | what to capture and how to annotate it | `samples/p25/README.md` (weak-signal voice section) |
+
+## In this post
+
+- **The report** — hardware decodes, we get 4–5 frames.
+- **The chain, stage by stage** — where confidence goes to die.
+- **The levers exist next door** — CQPSK's FSE, Phase 2, and the TETRA 2×.
+- **Why no fix has landed** — the capture discipline, applied to ourselves.
+- **The harness is waiting** — what to record and what happens next.
+
+## The report: hardware decodes, we get 4–5 frames
+
+The report that opened this investigation is the most useful kind: a
+controlled comparison an operator ran without meaning to. A marginal P25
+Phase 1 voice call — fringe site, real terrain — decodes cleanly on a
+hardware Astro Spectra. The same call, same antenna, through GopherTrunk:
+**about 4–5 IMBE frames** recovered, out of a call's worth. Not silence — a
+lock that produces almost nothing, which is the marginal regime's signature
+from [Part 1]({{ '/blog/deep-dives/weak-signal-engineering-01-marginal-regime/' | relative_url }})
+in its purest form.
+
+The hardware radio is the bound that matters. It proves the information
+survives the antenna; whatever is lost is lost inside the software. (A
+small aside the numbers brush against: at 9 frames per LDU, 4–5 frames is
+well under the `minAutotuneLDUs = 5` threshold in `composer/p25p1_voice.go`,
+so such a call is also treated as too short to trust for the per-dongle
+autotune fold — a correct guard, but a reminder of how little the chain is
+extracting from these calls.)
+
+Commercial subscriber radios earn their weak-signal behaviour with exactly
+the machinery this series has been building: adaptive equalization and
+soft-decision error correction. So the first question is an inventory: what
+does GopherTrunk's C4FM voice path actually run?
+
+## The chain, stage by stage
+
+The receiver's own doc comment lays it out:
+
+```go
+// internal/radio/p25/phase1/receiver/receiver.go (shape) — the C4FM branch
+//	DemodC4FM (default):
+//	    → FM discriminator (internal/dsp/demod.FM)
+//	    → spec P25 C4FM matched filter (internal/dsp/demod.C4FM
+//	      with demod.P25C4FMRxTaps — raised-cosine, not RRC)
+//	    → coarse AFC: residual carrier-offset removal
+//	      (internal/dsp/demod.CoarseAFC)
+//	    → Mueller-Müller symbol clock recovery (sync.MuellerMuller)
+//	    → 4-level slicer → C4FM symbol → 0..3 dibit
+//	      (internal/dsp/demod.C4FM, phase1.SymbolToDibit)
+```
+
+Downstream of the dibits, the IMBE voice frames go through
+[Golay]({{ '/reference/golay-code/' | relative_url }}) and
+[Hamming]({{ '/reference/hamming-code/' | relative_url }}) decoding — hard
+bits in, hard corrections out (the frame anatomy is
+[Voice Coding, Part 5]({{ '/blog/deep-dives/voice-coding-05-imbe-fec-deinterleave/' | relative_url }})'s
+territory). Now audit the chain against this series:
+
+- **No equalizer, anywhere.** Between timing recovery and the slicer there is
+  no stage that inverts ISI. Multipath smear on the 4-level eye —
+  [Part 3]({{ '/blog/deep-dives/weak-signal-engineering-03-isi-linear-channel/' | relative_url }})'s
+  invertible impairment — goes uninverted, straight into symbol decisions.
+- **A hard slicer feeding hard FEC.** The 4-level slicer collapses each
+  symbol to a dibit and discards its distance from the thresholds — exactly
+  the confidence the FEC needed
+  ([Part 8]({{ '/blog/deep-dives/weak-signal-engineering-08-soft-decisions/' | relative_url }})).
+  The Golay/Hamming decoders then correct a bounded number of
+  equally-weighted errors, defending coin-flip bits as firmly as certain
+  ones.
+
+Neither absence is a defect in what exists — the chain is a clean,
+well-tested implementation of the classical C4FM receiver. It is simply a
+fair-weather design, and the marginal regime is not fair weather.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 220" width="680" height="220" role="img" aria-label="The P25 Phase 1 C4FM voice chain drawn as solid blocks: FM discriminator, matched filter, coarse AFC, Mueller-Muller timing, four-level slicer, and hard Golay and Hamming IMBE FEC. Two dashed accent blocks show where the missing stages would insert: an equalizer between timing recovery and the slicer, and soft LLRs replacing the hard bits into the FEC. A caption row notes the CQPSK path already has the equalizer.">
+  <rect x="6" y="60" width="92" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="52" y="79" text-anchor="middle" fill="currentColor" font-size="9">FM</text>
+  <text x="52" y="92" text-anchor="middle" fill="currentColor" font-size="9">discriminator</text>
+  <line x1="98" y1="82" x2="112" y2="82" stroke="currentColor"/>
+  <rect x="112" y="60" width="86" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="155" y="79" text-anchor="middle" fill="currentColor" font-size="9">matched filter</text>
+  <text x="155" y="92" text-anchor="middle" fill="var(--fg-muted)" font-size="8">P25C4FMRxTaps</text>
+  <line x1="198" y1="82" x2="212" y2="82" stroke="currentColor"/>
+  <rect x="212" y="60" width="76" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="250" y="79" text-anchor="middle" fill="currentColor" font-size="9">CoarseAFC</text>
+  <line x1="288" y1="82" x2="302" y2="82" stroke="currentColor"/>
+  <rect x="302" y="60" width="90" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="347" y="79" text-anchor="middle" fill="currentColor" font-size="9">Mueller-Müller</text>
+  <text x="347" y="92" text-anchor="middle" fill="var(--fg-muted)" font-size="8">timing + AGC</text>
+  <rect x="404" y="40" width="104" height="36" rx="6" fill="none" stroke="var(--accent)" stroke-dasharray="5 4"/>
+  <text x="456" y="55" text-anchor="middle" fill="var(--accent)" font-size="9">equalizer</text>
+  <text x="456" y="68" text-anchor="middle" fill="var(--accent)" font-size="8">MISSING (CMA/FSE)</text>
+  <line x1="392" y1="82" x2="520" y2="82" stroke="currentColor"/>
+  <rect x="520" y="60" width="72" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="556" y="79" text-anchor="middle" fill="currentColor" font-size="9">4-level</text>
+  <text x="556" y="92" text-anchor="middle" fill="currentColor" font-size="9">slicer</text>
+  <line x1="592" y1="82" x2="606" y2="82" stroke="currentColor"/>
+  <rect x="606" y="60" width="68" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="640" y="79" text-anchor="middle" fill="currentColor" font-size="9">hard IMBE</text>
+  <text x="640" y="92" text-anchor="middle" fill="currentColor" font-size="9">FEC</text>
+  <rect x="540" y="128" width="134" height="36" rx="6" fill="none" stroke="var(--accent)" stroke-dasharray="5 4"/>
+  <text x="607" y="143" text-anchor="middle" fill="var(--accent)" font-size="9">soft decisions</text>
+  <text x="607" y="156" text-anchor="middle" fill="var(--accent)" font-size="8">MISSING (LLRs → FEC)</text>
+  <line x1="607" y1="128" x2="618" y2="106" stroke="var(--accent)" stroke-dasharray="3 3"/>
+  <line x1="456" y1="76" x2="456" y2="82" stroke="var(--accent)" stroke-dasharray="3 3"/>
+  <text x="340" y="196" text-anchor="middle" fill="var(--fg-muted)" font-size="10">the opt-in CQPSK/LSM path already runs a T/2 fractionally-spaced CMA equalizer (cqpsk.go's fse field);</text>
+  <text x="340" y="210" text-anchor="middle" fill="var(--fg-muted)" font-size="10">the default C4FM voice path has neither lever — the two that ~2×'d TETRA's marginal yield</text>
+</svg>
+<figcaption>Every solid block works; the dashed blocks are the diagnosis. C4FM Phase 1 voice is the one path missing both marginal-regime levers.</figcaption>
+</figure>
+
+## The levers exist next door
+
+What makes this a roadmap rather than a research question is that both
+missing stages already exist in the same codebase, proven on neighbouring
+paths.
+
+The equalizer: the opt-in `DemodCQPSK`/LSM receiver carries a **T/2
+fractionally-spaced blind equalizer** — `fse *equalizer.FSE` in `cqpsk.go`,
+built as `equalizer.NewFSE(cqpskFSESymbolSpan, cqpskFSEStep, 1.0,
+cqpskFSELeak)` with a 6-symbol span, CMA step 0.025, and a leak of 5e-4
+pulling the fractional taps back toward a delta when the signal is already
+clean. Its constants were tuned to open the constellation within a few
+hundred symbols of lead-in and its comments record precisely why
+fractional spacing matters: a T/2 equalizer corrects channel shape a
+symbol-spaced one cannot (the story of how that path was proven is
+[From the Issue Tracker, Part 6]({{ '/blog/solution-postmortem/from-the-issue-tracker-06-cqpsk-four-acts/' | relative_url }})).
+P25 **Phase 2** wires an equalizer as well. C4FM Phase 1 voice is,
+literally, the odd path out.
+
+The yield claim: on TETRA, the same two levers — a blind snapshot equalizer
+([Part 5]({{ '/blog/deep-dives/weak-signal-engineering-05-snapshot-trick/' | relative_url }}))
+plus soft TCH/S
+([Part 8]({{ '/blog/deep-dives/weak-signal-engineering-08-soft-decisions/' | relative_url }})) —
+roughly **doubled** CRC-valid yield on ISI-smeared and weak captures. The
+physics does not care about the trunking protocol. There is every structural
+reason to expect the C4FM port to move the number, and no measured reason
+yet — which is exactly the distinction the next section is about.
+
+## Why no fix has landed
+
+The temptation is obvious: port the FSE onto the C4FM branch, add an LLR
+track to the Golay/Hamming decoders, run the synthetic sweep, merge. The
+project has a rule against it, written in scar tissue. Issue #764 was closed
+twice on fixes that looked right and tested green against synthetic
+fixtures; the symptom was still live both times
+([Part 12]({{ '/blog/deep-dives/weak-signal-engineering-12-proving-signal/' | relative_url }})
+tells the eventual resolution). A synthetic channel exercises the code you
+wrote through the impairments you *imagined*; the operator's hill, trees,
+and fading exercise the ones you didn't. A green synthetic is necessary.
+It is not proof.
+
+So the standard here is explicit: baseline a real weak C4FM voice capture,
+apply one lever, and A/B LDU/IMBE yield against that capture — decode yield
+as the verdict, per
+[Part 2]({{ '/blog/deep-dives/weak-signal-engineering-02-metrics-that-lie/' | relative_url }}).
+Until such a capture exists, the port would be unverifiable, and an
+unverifiable fix is how a project accumulates confident-looking code that
+solves imagined problems. Diagnosed, scoped, and deliberately parked is the
+honest state — and saying so publicly is part of the method.
+
+## The harness is waiting
+
+Everything that can be built without the capture has been. The measurement
+harness, `TestReplayP25RealCaptureMetrics`
+(`cmd/gophertrunk/p25_realcapture_metrics_test.go`, tag `integration`),
+replays any capture dropped into `samples/p25/` through the real receiver
+and reports the baseline numbers — pre-FEC EVM and estimated SNR from the
+demod taps (`metrics.EVMC4FM` / `metrics.SNRResidualC4FM` on the soft eye
+for C4FM; constellation variants for CQPSK), the FSW sync-margin
+distribution, and NID/TSBK yields — with optional bounds in the metadata
+sidecar so a capture can also serve as a permanent regression:
+
+```go
+// cmd/gophertrunk/p25_realcapture_metrics_test.go (shape) — expected bounds
+MaxEVMPct float64 `json:"max_evm_pct"`
+MinSNRdB  float64 `json:"min_snr_db"`
+/* … EVM + SNR from the demod taps, FSW sync-margin distribution,
+   NID trusted/failed, TSBK decoded/CRC-failed … */
+```
+
+The pipeline is validated end to end: a live UHF C4FM control-channel
+capture already graded through it (EVM ≈ 12.7%, SNR ≈ 14.5 dB, NID
+trusted 31/failed 0 — see the committed metadata sidecar in `samples/p25/`).
+What's missing is the *voice* capture, and `samples/p25/README.md` spells
+out the ask: tune the **granted voice frequency** (not the control channel)
+during a call that is genuinely **weak or multipath-degraded** — a clean,
+strong call will not exercise the missing equalizer — record C4FM (and
+LSM/CQPSK separately if the site runs it), note the reference radio's
+result in `tool_cross_check`, set `"expected": {"demod_mode": "c4fm"}` with
+the quality bounds left out, and drop the `.cfile` + `.metadata.json` pair
+in. The binary stays git-ignored; the sidecar is committed. From that
+moment the sequence is mechanical: baseline it, port the `cqpsk.go`
+equalizer onto the C4FM branch or add soft inputs to the IMBE FEC — the
+capture decides which lever first — and A/B the LDU/IMBE yield. If you have
+the RF conditions the report described, this is the single highest-leverage
+recording you can contribute.
+
+## Where this goes next
+
+That is the last lever and the last case study. What remains is to fold
+fourteen parts into something you can use at the bench:
+[Part 14]({{ '/blog/deep-dives/weak-signal-engineering-14-playbook/' | relative_url }})
+is the playbook — the decision tree from symptom to lever, the testing
+discipline stack, and the thread capture's final scorecard.
+
+## FAQ
+
+**Why did the C4FM path end up the under-equipped one?**
+History, not judgment. C4FM is the default and oldest Phase 1 path, built
+when the goal was correct decode of viable signals; the CQPSK path was built
+later, against simulcast distortion that *forced* an equalizer into the
+design. The marginal-voice use case arrived last, and it is the one that
+indicts the original chain.
+
+**Couldn't the operator just use the CQPSK receiver for the weak site?**
+No — the modulation on air is C4FM, and the CQPSK path's linear demod
+expects LSM's phase trajectory (see
+[From the Issue Tracker, Part 7]({{ '/blog/solution-postmortem/from-the-issue-tracker-07-lsm-myth/' | relative_url }})
+for why the two are not interchangeable). The equalizer must come to the
+C4FM chain, not the signal to the equalizer.
+
+**Which lever would likely land first?**
+Whichever the capture indicts. High pre-FEC EVM with visible eye smear says
+ISI — port the equalizer. A clean-ish eye with FEC failures clustered at low
+sync margins says reliability — add soft decisions. That triage being
+readable from the baseline numbers is exactly why the harness reports EVM,
+SNR, and FSW margin rather than a single verdict.
+
+**Is a capture from a different weak site as good as the reporter's?**
+Nearly. The essential property is a *marginal C4FM voice call* — ideally
+with a hardware radio's contemporaneous decode noted as the cross-check, so
+"the information was present" is anchored to that specific recording rather
+than assumed.
+
+**Why publish a diagnosis before the fix exists?**
+Because the bottleneck is the capture, and captures come from operators.
+A precise public statement of what is missing, why, and exactly what
+recording unblocks it is the fastest path to the fix — faster than quietly
+shipping an unverifiable one.
+
+## Series navigation
+
+**Part 13 of 14** · ←
+[Part 12: Proving It's the Signal — Rate Invariance & Independent Resamplers]({{ '/blog/deep-dives/weak-signal-engineering-12-proving-signal/' | relative_url }})
+· Next →
+[Part 14: The Weak-Signal Playbook]({{ '/blog/deep-dives/weak-signal-engineering-14-playbook/' | relative_url }})

--- a/docs/_posts/2026-08-31-analog-edge-14-field-checklist.md
+++ b/docs/_posts/2026-08-31-analog-edge-14-field-checklist.md
@@ -1,0 +1,253 @@
+---
+title: "The Analog Edge, Part 14: The Field Checklist — Is It RF or Is It Software?"
+description: "The whole series folded into one triage flow — dBFS, clipping, gain sweep, rate A/B, capture, coherence — a decision tree for splitting radio problems from software problems, the order to spend hardware money in, and the send-off for the marginal system that started it all."
+category: tutorials
+keywords: sdr troubleshooting checklist, rf or software problem, decode triage flowchart, sdr gain sweep checklist, iq capture debugging, scanner reception troubleshooting, hardware upgrade order sdr, gophertrunk analog edge
+tags: [analog-edge, checklist, troubleshooting, rf, workflow]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "The Analog Edge"
+series_part: 14
+---
+
+*Part 14 — the finale — of **The Analog Edge**. Thirteen posts ago we met a
+reader whose hardware scanner decoded a system cleanly while GopherTrunk, on
+the same antenna, produced garble — and we made a promise: the causes were on
+the analog side, and they could be eliminated one measurement at a time.
+[Part 13]({{ '/blog/tutorials/analog-edge-13-coherence-not-dbfs/' | relative_url }})
+delivered the last instrument, the scale-invariant health number. This part is
+the whole series folded into a single field checklist — and the close of that
+reader's story. The motto we planted in
+[Part 1]({{ '/blog/tutorials/analog-edge-01-where-software-ends/' | relative_url }})
+has earned its repetition by now: **the decoder can only be as good as the
+samples — and half the hard bugs in the issue tracker were in the samples.***
+
+> **TL;DR:** Triage in a fixed order, cheapest measurement first:
+> **dBFS** (headroom, not quality — [Part 2]({{ '/blog/tutorials/analog-edge-02-dbfs/' | relative_url }}))
+> → **clipping/histogram** ([Part 4]({{ '/blog/tutorials/analog-edge-04-clipping-overload-intermod/' | relative_url }}))
+> → **gain ladder scored by decode quality** ([Part 3]({{ '/blog/tutorials/analog-edge-03-gain-staging/' | relative_url }}))
+> → **sample-rate A/B** ([Parts 5–6]({{ '/blog/tutorials/analog-edge-05-phase-noise-reciprocal-mixing/' | relative_url }}))
+> → **raw capture** ([Part 10]({{ '/blog/tutorials/analog-edge-10-capture-discipline/' | relative_url }}))
+> → **coherence** on diversity rigs ([Parts 11–13]({{ '/blog/tutorials/analog-edge-11-diversity-mrc/' | relative_url }})).
+> The RF-vs-software verdict comes from one experiment: **replay the capture** —
+> a symptom that reproduces offline from the file is in the samples (RF side);
+> one that doesn't is downstream (software/load side). Spend money in order:
+> antenna → feedline → filter/LNA → second device. And when you file an issue,
+> file it **with the capture** — that's the difference between an anecdote and
+> a fix.
+
+**Key takeaways**
+
+- **The chain has an address for every symptom.** Uniformly weak → antenna/
+  feedline (Parts 7–8). Worse as gain rises → overload (Part 4). Rate-dependent
+  → front-end cleanliness (Part 5). Intermittent fades → diversity (Part 11).
+  Nothing in this list is fixed in `config.yaml`.
+- **Replay is the judge.** GopherTrunk's decode is rate-invariant and
+  deterministic on a given file — so an offline replay that reproduces the
+  failure convicts the samples, and one that decodes cleanly acquits them.
+- **Buy hardware in noise-figure order.** Antenna placement, then feedline,
+  then LNA/filter, then a second device — each step is cheaper than the next
+  and its gain compounds through everything downstream.
+- **A capture attached to an issue is a contribution.** Every decoder
+  validated this year was closed by an operator's capture becoming a
+  regression test — the [decoder capture needs]({{ '/decoder-capture-needs.html' | relative_url }})
+  page lists what's still waiting.
+
+## Cheat sheet
+
+| Symptom | First suspect | Measure with | Part |
+|---|---|---|---|
+| Everything weak, all channels | antenna / feedline | dBFS tiles + a known-good jumper A/B | [7]({{ '/blog/tutorials/analog-edge-07-antennas/' | relative_url }})–[8]({{ '/blog/tutorials/analog-edge-08-feedline-connectors/' | relative_url }}) |
+| Worse when gain goes up | overload / intermod | sample histogram, [attenuator test]({{ '/reference/sdr-gain-overload/' | relative_url }}) | [4]({{ '/blog/tutorials/analog-edge-04-clipping-overload-intermod/' | relative_url }}) |
+| Decodes at one rate, not another | front-end phase noise | capture at both rates, replay A/B | [5]({{ '/blog/tutorials/analog-edge-05-phase-noise-reciprocal-mixing/' | relative_url }})–[6]({{ '/blog/tutorials/analog-edge-06-sample-rate/' | relative_url }}) |
+| Comes and goes with traffic/weather | fading / feedline moisture | time-of-day log review; diversity | [8]({{ '/blog/tutorials/analog-edge-08-feedline-connectors/' | relative_url }}), [11]({{ '/blog/tutorials/analog-edge-11-diversity-mrc/' | relative_url }}) |
+| Diversity not helping | branch health / placement | `coherence`, `branch_phase_deg` log fields | [11]({{ '/blog/tutorials/analog-edge-11-diversity-mrc/' | relative_url }})–[13]({{ '/blog/tutorials/analog-edge-13-coherence-not-dbfs/' | relative_url }}) |
+| CPU warnings, drops under load | downstream consumer, not RF | `decode can't keep up with real time` WARN, `host_drops` | [6]({{ '/blog/tutorials/analog-edge-06-sample-rate/' | relative_url }}) |
+| Anything you can't classify | the samples | **capture it**, replay it | [10]({{ '/blog/tutorials/analog-edge-10-capture-discipline/' | relative_url }}) |
+
+## In this post
+
+- **The triage ladder** — six measurements in cost order.
+- **The verdict experiment** — replay decides RF vs software.
+- **The buying order** — where the next dollar does the most work.
+- **Filing an issue that gets fixed** — the capture contract.
+- **The reader's system, fixed** — the thread, resolved.
+
+## The triage ladder
+
+Run these in order; each step is cheaper than the one after it, and each
+step's result tells you whether to continue or stop and fix.
+
+1. **Read dBFS as headroom.** Healthy sits around −25 dBFS peak with no
+   clipping; −48 dBFS peak is lean but can still be a perfectly decodable
+   signal (one of [#764](https://github.com/MattCheramie/GopherTrunk/issues/764)'s
+   captures was), and ~−75 dBFS RMS is a dead input (the DMR investigation's
+   unusable capture). dBFS out of range points at gain or a broken feed; dBFS
+   *in* range clears nothing else — move on.
+2. **Check for rail-pinning.** The sample histogram tells you what the FFT
+   hides — the [nineteen-dibits capture]({{ '/blog/solution-postmortem/from-the-issue-tracker-08-nineteen-dibits/' | relative_url }})
+   was 50% pinned behind a plausible-looking waterfall. Pinned → turn gain
+   down and re-test; the [overload reference]({{ '/reference/sdr-gain-overload/' | relative_url }})
+   has the full signature list.
+3. **Run the gain ladder, scored by decode.** Sweep gain and watch decode
+   error rate — never power — exactly as
+   [autogain]({{ '/blog/deep-dives/the-hunt-05-autogain-autotune/' | relative_url }})
+   does: prefer a lock, then lower error rate, then *lower* gain. While
+   you're in the config: `gain: "300"` is 30.0 dB — the
+   [tenths-of-dB trap]({{ '/blog/solution-postmortem/from-the-issue-tracker-07-lsm-myth/' | relative_url }})
+   is still the cheapest bug in the tracker.
+4. **A/B the sample rate.** If the symptom tracks the rate — decodes at
+   2.4 MS/s, garbles at 10 — the decode path is acquitted in advance (it
+   normalises everything to the per-protocol channel rate) and your front
+   end's cleanliness at the higher clock is the suspect. Capture at both
+   rates and replay.
+5. **Capture the failure.** Same rate, same gain, same antenna, sidecar
+   written at capture time ([Part 10]({{ '/blog/tutorials/analog-edge-10-capture-discipline/' | relative_url }})).
+   From here on you're doing science instead of remembering.
+6. **On diversity rigs, read the health line.** Dead branch → antenna/gain.
+   `coherence` near floor → branches see different signals. Stuck 0.3–0.5 →
+   antennas too far apart for the wideband combine. Walking
+   `branch_phase_deg` → use `mrc`, not `mrc-static`
+   ([Part 12]({{ '/blog/tutorials/analog-edge-12-front-end-classes/' | relative_url }})).
+
+## The verdict experiment
+
+Every path above converges on one experiment, because one experiment settles
+the question this series is named for:
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 230" width="680" height="230" role="img" aria-label="Decision tree for splitting RF problems from software problems. Start: capture the failing signal as raw IQ. Replay it offline through gophertrunk replay. If the symptom reproduces from the file, the problem is in the samples — follow the RF branch: check headroom and clipping, then gain staging, then rate cleanliness, then antenna and feedline. If the replay decodes cleanly, the problem is downstream — follow the software and load branch: check CPU warnings, dropped chunks, and configuration, and file an issue with the capture attached.">
+  <rect x="250" y="10" width="180" height="36" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="340" y="26" text-anchor="middle" fill="var(--accent)" font-size="10">capture the failure (raw IQ</text>
+  <text x="340" y="39" text-anchor="middle" fill="var(--accent)" font-size="10">+ sidecar, at the failing settings)</text>
+  <line x1="340" y1="46" x2="340" y2="70" stroke="currentColor"/><polygon points="336,70 340,80 344,70" fill="currentColor"/>
+  <rect x="255" y="80" width="170" height="32" rx="6" fill="none" stroke="currentColor"/>
+  <text x="340" y="100" text-anchor="middle" fill="currentColor" font-size="10">replay it offline — does it reproduce?</text>
+  <line x1="255" y1="96" x2="150" y2="130" stroke="currentColor"/><polygon points="148,126 142,136 156,133 " fill="currentColor"/>
+  <line x1="425" y1="96" x2="530" y2="130" stroke="currentColor"/><polygon points="524,133 538,136 532,126" fill="currentColor"/>
+  <text x="185" y="118" fill="var(--fg-muted)" font-size="9">yes → it's in the samples</text>
+  <text x="440" y="118" fill="var(--fg-muted)" font-size="9">no → it's downstream</text>
+  <rect x="30" y="136" width="230" height="52" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="145" y="152" text-anchor="middle" fill="var(--accent)" font-size="10">RF side (Parts 2–9, 11–13)</text>
+  <text x="145" y="166" text-anchor="middle" fill="var(--fg-muted)" font-size="9">headroom → clipping → gain ladder →</text>
+  <text x="145" y="179" text-anchor="middle" fill="var(--fg-muted)" font-size="9">rate A/B → antenna / feedline / LNA</text>
+  <rect x="420" y="136" width="230" height="52" rx="6" fill="none" stroke="currentColor"/>
+  <text x="535" y="152" text-anchor="middle" fill="currentColor" font-size="10">software / load side</text>
+  <text x="535" y="166" text-anchor="middle" fill="var(--fg-muted)" font-size="9">CPU WARNs, host_drops, config —</text>
+  <text x="535" y="179" text-anchor="middle" fill="var(--fg-muted)" font-size="9">file the issue WITH the capture</text>
+  <text x="340" y="216" text-anchor="middle" fill="var(--fg-muted)" font-size="10">the replay is deterministic on a file — whichever way it answers, you've halved the search space with one command</text>
+</svg>
+<figcaption>One experiment splits the world: a failure that replays from the file is in the samples; one that doesn't is downstream of them.</figcaption>
+</figure>
+
+Replay the capture through the same decode the daemon runs
+(`gophertrunk replay -in fail.raw -format cs16 -sample-rate … -protocol …`).
+**Reproduces offline** → the problem rode in with the samples: work the RF
+branch, and note the offline replay just eliminated CPU, USB, scheduling, and
+every live-only variable in one step — this is exactly how #764's deficit was
+pinned to the capture itself. **Decodes cleanly offline** → the samples are
+fine and the live system is dropping or starving something: look for the
+`ccdecoder: decode can't keep up with real time` WARN and `soapyremote: SDR
+overruns … host_drops` (both are *downstream* signals — the consumer stopped
+draining, not the driver), and check what got slower recently. Either way,
+you now hold the file that proves it.
+
+## The buying order
+
+When the triage says "hardware," spend in this order — each item multiplies
+the value of everything after it, and the early items are embarrassingly
+cheap compared to a new SDR:
+
+| Priority | Upgrade | Why this order | Guide |
+|---|---|---|---|
+| 1 | Antenna (and its placement) | sets the signal everything else can only degrade | [scanner antennas]({{ '/best-scanner-antenna/' | relative_url }}), [SDR antennas]({{ '/best-sdr-antenna/' | relative_url }}), [mast & mounting]({{ '/antenna-mast-and-mounting-guide/' | relative_url }}) |
+| 2 | Feedline + connectors | recovers dB you already paid for; pure noise figure | [cables & connectors]({{ '/sdr-cables-and-connectors/' | relative_url }}), Part 8 |
+| 3 | Filter and/or mast LNA | buys NF or headroom — *after* the run is worth amplifying | [LNAs]({{ '/best-sdr-lna/' | relative_url }}), [filters]({{ '/sdr-filters/' | relative_url }}), Part 9 |
+| 4 | Second device / diversity | coverage or fade insurance, at 2× complexity | [multi-dongle]({{ '/multi-dongle-sdr-setup/' | relative_url }}), Parts 11–12 |
+
+A better SDR is deliberately absent from the top of that list: an upgraded
+receiver behind a bad antenna and 8 dB of RG-58 receives the same garbage
+with more dynamic range. The [what-do-I-need guide]({{ '/what-do-i-need-for-gophertrunk/' | relative_url }})
+walks complete builds in the same spirit.
+
+## Filing an issue that gets fixed
+
+If the triage lands on something GopherTrunk should handle better, file it —
+but file it with the capture. The pattern that closes issues in this tracker
+is always the same: symptom description, the sidecar-equipped IQ file (or an
+`auto_record` grab), and the settings that produced it. From there the
+maintainers' side of the contract kicks in: the capture becomes a
+failing-first test, the fix makes it pass, and the file stays in `samples/`
+so the bug can never quietly return — that's the
+[#764/#771 discipline]({{ '/blog/solution-postmortem/from-the-issue-tracker-05-ten-megasamples/' | relative_url }}),
+and it's also why several decoders are *currently blocked* waiting on
+nothing but a capture: the
+[decoder capture needs]({{ '/decoder-capture-needs.html' | relative_url }})
+page is effectively a wish list where one good recording from your antenna
+closes a validation that no amount of code can. An issue without a capture
+can still be triaged; an issue with one can be *finished*.
+
+## The reader's system, fixed
+
+So what was wrong with the system that started this series — hardware scanner
+clean, GopherTrunk garbled, same antenna? Three things, none of them in
+software, every one of them found by a measurement from this checklist. The
+gain was parked 17 dB hot from an old attempt to satisfy a threshold; the
+ladder (step 3) walked it back down the U-curve and the histogram stopped
+brushing the rails. The dongle sat at the end of forty feet of RG-58 and an
+adapter stack — ~8 dB of noise figure the scanner, on its shorter run, never
+paid; LMR-400 and one pigtail bought six of them back (Part 8). And the last
+stubborn garble tracked the sample rate: a capture at each rate, replayed
+side by side, showed the deficit baked into the high-rate samples — the
+Part 5 signature — and the config moved to the rate the front end runs clean
+at. No single villain, which is the honest shape of most marginal systems:
+three small analog taxes that only ever showed up in software, as a decoder
+doing exactly what it was told with samples that were 10 dB worse than they
+needed to be. The scanner doesn't win anymore.
+
+That's the series. The chain from antenna to ADC is measurable end to end
+with the instruments you already have — a dBFS tile, a histogram, a gain
+ladder, a replay command, two log fields — and every hard problem along it
+converts into a file that proves what it was. The decoder can only be as good
+as the samples. Now you know how to make the samples good.
+
+## FAQ
+
+**What's the single fastest check when a system goes bad suddenly?**
+dBFS, ten seconds. A level that dropped off a cliff is a broken feed
+(connector, water, bias-tee supply); a level that's normal points onward.
+Sudden-onset problems are overwhelmingly physical — check what the weather
+did before you check what you upgraded.
+
+**How do I A/B two setups fairly?**
+Change one thing, and score with a scale-invariant number — decode error
+rate, CRC-clean count, sync margin — never "the waterfall looks better."
+Where possible, capture once and replay through both configurations; the
+file removes time-of-day and traffic variance from the comparison.
+
+**My symptom is intermittent and I can never catch it. Now what?**
+Let the daemon catch it: `baseband.auto_record` triggers on the events that
+matter (`on_cc_sync_loss`, `on_encrypted`, `on_concurrent_calls`) with a
+cooldown, writing replay-ready files with sidecars. The TETRA sync-loss
+investigation was built entirely on eleven such automatic captures.
+
+**When is it actually a GopherTrunk bug?**
+When the capture replays badly *and* a reference decoder (or a hardware
+radio on the same samples) does better — that gap is real and reportable.
+Plenty of tracker history is exactly this shape, and it's the productive
+kind of report: the capture that demonstrates the gap is the same file the
+fix gets tested against.
+
+**Do I need all fourteen parts to use the checklist?**
+No — the ladder above is self-contained, and each step links the part that
+explains it when a step's result surprises you. If you read only one part in
+full, make it [Part 10]({{ '/blog/tutorials/analog-edge-10-capture-discipline/' | relative_url }}):
+capture discipline is the skill the other thirteen lean on.
+
+## Series navigation
+
+**Part 14 of 14** · ←
+[Part 13: Coherence, Not dBFS — Scale-Invariant Health]({{ '/blog/tutorials/analog-edge-13-coherence-not-dbfs/' | relative_url }})
+· This is the finale — back to the [series index]({{ '/blog/series/analog-edge/' | relative_url }}).
+
+*Where to next? Your front end is clean and your samples are trustworthy — put them to work finding systems you didn't know were there in [**The Hunt**]({{ '/blog/series/the-hunt/' | relative_url }}).*

--- a/docs/_posts/2026-08-31-tetra-end-to-end-14-testing-open-questions.md
+++ b/docs/_posts/2026-08-31-tetra-end-to-end-14-testing-open-questions.md
@@ -1,0 +1,261 @@
+---
+title: "TETRA End to End, Part 14: Testing TETRA Without a Network — & What's Still Open"
+description: The finale — the four-layer test lattice that lets a TETRA stack be developed with no network in range, from synthetic round-trips through skip-guarded capture harnesses to full-daemon integration, and an unvarnished list of what is verified, what is staged, and what stays open until on-air evidence lands.
+category: deep-dives
+keywords: tetra testing, capture replay harness, skip-guarded tests, synthetic iq round trip, self-consistent test trap, dmo colour scan, integration testing sdr, on-air verification, gophertrunk tetra
+tags: [tetra-end-to-end, tetra, testing, verification, dmo, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "TETRA End to End"
+series_part: 14
+---
+
+*Part 14 — the finale — of **TETRA End to End**. Thirteen posts ago we started
+with a π/4-DQPSK constellation on a 25 kHz carrier and a promise: every claim
+pinned by a test or a capture. Since then we've built the slot grid, the
+channel coding, the scrambler, TCH/S, a clean-room ACELP vocoder proven
+bit-identical against the ETSI reference, soft decisions, two equalizers, a
+hardened control channel, and a DMO path that went from "reads the spec" to a
+production pipeline — pausing once to retract a wrong verdict in public. This
+close-out is about the machinery that made that pace survivable: the **test
+lattice** that lets a TETRA stack be developed hundreds of kilometers from the
+nearest TETRA network — and, in the same breath, the honest list of what that
+lattice cannot prove and what therefore remains open.*
+
+> **TL;DR:** TETRA in GopherTrunk is tested in four layers, each catching what
+> the previous one can't: **synthetic round-trips** (fast, but blind to
+> self-consistent bugs unless the encode side models the *air* — the colour-0
+> and slot-grid lessons); **skip-guarded capture harnesses**
+> (`TestTETRAMultiSlotReplay`, `TestTETRADMOReplay`,
+> `TestTETRADMOColourScan` — activated by `GT_TETRA_DMO_IQ`,
+> `GT_TETRA_DMO_RATE`, `GT_TETRA_DMO_COLOUR`, `GT_TETRA_DMO_CLEAR`,
+> `GT_TETRA_DMO_SCAN`, `GT_TETRA_LMS`, `GT_TETRA_DMO_LMS`); **pipeline tests on
+> modulated IQ** (`pipelines_dmo_test.go`, the CC equalizer A/B); and
+> **full-daemon integration** (`TestDaemonDecodesTETRADMO`, under
+> `make integration`). Still open, stated plainly: the
+> [#1003](https://github.com/MattCheramie/GopherTrunk/issues/1003) on-air A/B
+> through the full daemon; DMO call-control (recordings file under group 0);
+> and the 15aug lesson — a colour scan with **no dominant winner means a
+> marginal signal, not a broken guesser**, and the descramble must never be
+> bent to fit a 33%-yield colour.
+
+**Key takeaways**
+
+- **Each test layer exists because the one below it lied at least once.**
+  Round-trips passed through the colour-0 bug; only an encode side that
+  scrambles unconditionally — modeling the transmitter, not the code under
+  test — made it fail first.
+- **Skip-guarded harnesses turn operators into the lab.** A test that skips
+  without `GT_TETRA_DMO_IQ` costs CI nothing, yet gives anyone with a capture
+  a one-command, fully instrumented replay — every major TETRA finding in this
+  series arrived through one.
+- **A refusal can be a correct answer.** `RecoverDMColourCode` declining to
+  pick a colour on the 15aug capture wasn't a bug — the scan's shape (several
+  modest risers, no 3× dominance) is physically impossible for one radio with
+  one keystream, so the gate correctly diagnosed a marginal signal.
+- **Green everything ≠ done.** The DMO daemon path passes synthetic, capture,
+  pipeline, and integration layers — and #1003 stays open anyway, because the
+  one test that counts is a recording an operator can listen to.
+
+## Cheat sheet
+
+| Layer | What it proves | Where it lives |
+|---|---|---|
+| Vocoder conformance | bit-identical PCM vs the ETSI reference | `internal/voice/acelp/etsi_reference_test.go` |
+| Synthetic round-trips | coding chains invert; encode models the air | `internal/radio/tetra/dmo_decode_test.go`, `tch_test.go` |
+| TMO capture harness | grant-correlated multislot voice, LMS A/B | `cmd/gophertrunk/tetra_multislot_replay_test.go` (`GT_TETRA_LMS`) |
+| DMO capture harness | lock, colour, TCH/S yield, verdict line | `cmd/gophertrunk/tetra_dmo_replay_test.go` (`TestTETRADMOReplay`) |
+| Colour diagnostics | full 64-colour yield map | `tetra_dmo_replay_test.go` (`TestTETRADMOColourScan`, `GT_TETRA_DMO_SCAN=1`) |
+| Pipeline on modulated IQ | lock + colour + grant from synthesized bursts | `internal/scanner/ccdecoder/pipelines_dmo_test.go` |
+| CC equalizer proof | 12%→100% BSCH on a real marginal fixture | `pipelines_tetra_equalizer_test.go` |
+| Full daemon | config → DDC → pipeline → lock, no shortcuts | `cmd/gophertrunk/integration_cc_tetra_dmo_test.go` (`make integration`) |
+
+## In this post
+
+- **The lattice, bottom to top** — four layers and the failure each one owns.
+- **Making synthetics honest** — the two fixture repairs that mattered.
+- **The capture harness as an instrument** — env vars, verdict lines, A/B knobs.
+- **The 15aug capture: reading a refusal** — when no colour dominates.
+- **The open list** — what stays unverified, and the gate for each item.
+
+## The lattice, bottom to top
+
+The bottom layer is **conformance and round-trips**: `etsi_reference_test.go`
+feeds the same 137-bit stream to GopherTrunk's ACELP and the ETSI reference
+codec and demands bit-identical PCM
+([Part 7]({{ '/blog/deep-dives/tetra-end-to-end-07-etsi-conformance/' | relative_url }}));
+encode/decode pairs pin every coding chain. Fast, deterministic, runs on every
+`make vet test`. Its blind spot is the one this series hit twice: a bug on
+*both* sides of a round-trip is invisible.
+
+The second layer is **skip-guarded capture harnesses** — ordinary `go test`
+functions that skip unless an environment variable points at real IQ. The third
+is **pipeline tests on modulated IQ**: synthesize actual bursts, modulate them,
+and drive the *production* pipeline object — `TestTETRADMOPipelineLocksAndGrants`
+asserts lock, colour-3 recovery, and a grant from IQ in;
+`TestTETRACCEqualizerLiftsMarginalBSCHYield` holds the live TMO pipeline to the
+healthy regime on a real marginal fixture
+([Part 10]({{ '/blog/deep-dives/tetra-end-to-end-10-control-channel-sync-loss/' | relative_url }})).
+The top layer is **full-daemon integration** under `make integration`:
+`TestDaemonDecodesTETRADMO` boots the daemon from a `protocol: tetra-dmo`
+config and requires the whole path — DDC, pipeline, bus — to lock, with no
+hand-wired shortcuts. Above all four sits the layer no test framework
+provides: an operator, a radio, and the air.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 218" width="680" height="218" role="img" aria-label="The TETRA test lattice drawn as five stacked layers. From bottom to top: synthetic round-trips and ETSI conformance, skip-guarded capture harnesses driven by environment variables, pipeline tests on modulated IQ, full-daemon integration under make integration, and at the top on-air verification by an operator — the only layer that can close an issue. Annotations on the right name the failure class each layer catches that the layer below cannot.">
+  <rect x="60" y="176" width="440" height="32" rx="5" fill="none" stroke="currentColor"/>
+  <text x="280" y="196" text-anchor="middle" fill="currentColor" font-size="10">synthetic round-trips · ETSI conformance (every make vet test)</text>
+  <text x="512" y="196" fill="var(--fg-muted)" font-size="9">fast; blind to self-consistent bugs</text>
+  <rect x="85" y="138" width="390" height="32" rx="5" fill="none" stroke="currentColor"/>
+  <text x="280" y="158" text-anchor="middle" fill="currentColor" font-size="10">skip-guarded capture harnesses (GT_TETRA_* env vars)</text>
+  <text x="512" y="158" fill="var(--fg-muted)" font-size="9">real air, offline decoders</text>
+  <rect x="110" y="100" width="340" height="32" rx="5" fill="none" stroke="currentColor"/>
+  <text x="280" y="120" text-anchor="middle" fill="currentColor" font-size="10">pipeline tests on modulated IQ</text>
+  <text x="512" y="120" fill="var(--fg-muted)" font-size="9">production objects, synthetic RF</text>
+  <rect x="135" y="62" width="290" height="32" rx="5" fill="none" stroke="currentColor"/>
+  <text x="280" y="82" text-anchor="middle" fill="currentColor" font-size="10">full daemon (make integration)</text>
+  <text x="512" y="82" fill="var(--fg-muted)" font-size="9">wiring: config → DDC → bus</text>
+  <rect x="160" y="24" width="240" height="32" rx="5" fill="var(--accent)" opacity="0.15" stroke="var(--accent)"/>
+  <text x="280" y="44" text-anchor="middle" fill="var(--accent)" font-size="10">on-air A/B — the operator loop</text>
+  <text x="512" y="44" fill="var(--accent)" font-size="9">the only layer that closes an issue</text>
+  <text x="280" y="215" text-anchor="middle" fill="var(--fg-muted)" font-size="10">each layer exists because the one below it passed while the system was wrong (#764/#771)</text>
+</svg>
+<figcaption>The four automated layers of the TETRA test lattice, and the fifth — on-air verification — that no green run below it can substitute for.</figcaption>
+</figure>
+
+## Making synthetics honest
+
+Two fixture repairs from the DMO arc are worth restating as method, because
+they generalize past TETRA. First: **the encode side must model the
+transmitter, not the code under test.** The colour-0 descramble skip
+([Part 12]({{ '/blog/deep-dives/tetra-end-to-end-12-dmo-descramble-colour/' | relative_url }}))
+survived a targeted sweep because the synthetic encoder shared the decoder's
+conditional; `dmo_decode_test.go` now scrambles unconditionally — real-air
+behaviour — and the colour-0 rounds became the failing-first regression.
+Second: **synthetic timing must be as structured as real timing.** The noise-grant
+bug ([Part 13]({{ '/blog/deep-dives/tetra-end-to-end-13-dmo-pipeline-grants/' | relative_url }}))
+was uncatchable while `buildDMODibitStream` laid bursts at arbitrary filler
+offsets; a fixture transmitter that keeps the 255-dibit slot grid is what lets
+the `DMSlotGrid` regressions mean anything. The same honesty shows up smaller:
+blind CMA is degenerate on a noise-free constant-modulus input, so the daemon's
+synthetic TETRA test adds 40 dB AWGN on purpose. A fixture flattered is a bug
+deferred — the full pattern catalog is in
+[From the Issue Tracker #20]({{ '/blog/solution-postmortem/from-the-issue-tracker-20-self-consistent-trap/' | relative_url }}).
+
+## The capture harness as an instrument
+
+The harness layer deserves its manual, because it is how operators and the
+project collaborate. Everything keys off environment variables, so the tests
+cost CI nothing and cost an operator one shell line:
+
+```go
+// cmd/gophertrunk/tetra_dmo_replay_test.go (shape) — the skip guard
+path := os.Getenv("GT_TETRA_DMO_IQ")
+if path == "" {
+    t.Skip("set GT_TETRA_DMO_IQ (cs16 IQ) + GT_TETRA_DMO_RATE to run the DMO replay")
+}
+```
+
+The knobs, as of this series' close: `GT_TETRA_DMO_IQ` / `GT_TETRA_DMO_RATE`
+select the capture; `GT_TETRA_DMO_COLOUR` pins the DM colour (unset ⇒
+auto-recovery); `GT_TETRA_DMO_CLEAR=1` asserts the capture is known-clear,
+flipping the VERDICT line so a chance floor reads as a decode defect, never
+encryption; `GT_TETRA_DMO_SCAN=1` runs `TestTETRADMOColourScan`, the full
+64-colour yield map; `GT_TETRA_DMO_LMS=1` A/Bs the per-burst trained equalizer
+on DMO, as `GT_TETRA_LMS=1` does for TMO in `TestTETRAMultiSlotReplay`
+(compare `traffic_marked_crc_soft` across runs). The reproduction line for the
+Part 12 result is one command:
+`GT_TETRA_DMO_IQ=<10aug .raw> GT_TETRA_DMO_RATE=144000 GT_TETRA_DMO_CLEAR=1
+go test ./cmd/gophertrunk -run TestTETRADMOReplay -v`. Every headline number in
+Parts 9–13 — 410→778, 12%→100%, 6→64, 1/269→35/269 — is re-derivable this way
+from the operator's own files. That reproducibility *is* the series' method.
+
+## The 15aug capture: reading a refusal
+
+The most recent capture is the best closing exhibit, because its result is a
+**correct refusal**. The operator recorded a purpose-built vector — 25 s of
+clear, colour-0, *silent* PTT
+(`dmo_test_15aug/25sec_ptt_then_off_30sec_cs16_144khz.raw`). Signalling: DSB
+SCH/S at ~90% (105/117). Voice: near the chance floor at **every** colour. The
+colour scan shows several colours rising modestly at once — 28→140, 57→74,
+30→46 of 831 DNBs — rather than one dominating. One radio scrambling with one
+keystream *cannot* produce that shape, so `RecoverDMColourCode`'s dominance
+gate refuses to pick (140 < 3×74) — which the operator experienced as "the
+colour guesser is broken" and which is actually the gate working: a marginal
+signal with partial-keystream artifacts, not a recoverable colour. The
+receiver's side of the ledger is already maxed — the CMA equalizer lifts DSB
+77→105 and TCH 80→140; LMS doesn't move it — and the SYNC PDU's extended-colour
+parse matches osmo-tetra-dmo's scrambler-init offsets, so that path isn't the
+gap. The conclusions are procedural: a silent PTT is a poor test vector
+(DTX/comfort-noise frames), the next capture must be known-colour and
+*actually talking* — and above all, **do not bend the descramble to fit a
+33%-yield non-dominant colour**. That would be the self-consistent trap,
+volume three.
+
+## The open list
+
+What this series leaves open, each with its closing gate:
+
+- **The #1003 on-air A/B.** A clear DMO capture through the *full daemon*
+  (`protocol: tetra-dmo`) must land an intelligible recording. Known sharp
+  edges for whoever runs it: recordings file under group **0** (no talkgroup
+  on the air), colour recovery needs ~20 qualified DNBs (a very short first
+  PTT grants before the colour is known — the voice chain re-recovers), and
+  the grant lands ~0.5 s into a transmission by design. `dnb_qualified` is the
+  traffic number; `dnb_total` is a noise meter.
+- **DMO call control.** EN 300 396-3's source/destination/group PDUs are not
+  yet decoded — attribution and group filing wait on it.
+- **The trained LMS as a production default.** Staged on both TMO and DMO
+  soft paths, pinned synthetically (13%→0% and 12%→0% payload error), gated on
+  capture A/Bs that so far say "no harm, no clear win."
+- **A decisive DMO voice capture.** The 15aug refusal stands until a
+  known-colour, talking capture either recovers cleanly or fails informatively.
+
+That is the honest ledger. The arc it closes is real, though: one carrier,
+followed from a rotating constellation to a conformant vocoder to recorded
+clear voice — TMO hardened end to end, DMO taken from spec-reading to a
+production pipeline — with every claim along the way carrying either a test, a
+capture, or an explicit "not yet verified." The villain of the series never
+changed: the green test that wasn't evidence. The method never changed either:
+make it fail first, then make it pass, then make the air agree.
+
+## FAQ
+
+**Can I develop against this stack with no TETRA network in range?**
+Yes — that's the lattice's whole point. The bottom three layers need no RF at
+all, and the capture harnesses run on files. What you cannot do without air is
+*close* anything: on-air verification is a distinct layer, not a formality.
+
+**Why environment variables instead of test flags or fixtures in the repo?**
+Captures are large, operator-owned, and often sensitive, so they can't live in
+testdata. Env-var skip guards keep the tests permanently wired into `go test`
+(no bit-rot) while making CI cost zero and operator activation trivial.
+
+**How do I contribute a capture that actually helps?**
+Record cs16 IQ at a known rate, note everything the radio's config declares
+(colour, security class, frequency), and prefer a *talking* transmission —
+the 15aug lesson is that silent PTT vectors mostly exercise DTX frames. Then
+run the relevant harness and file the full log output; the verdict lines are
+written to be pasted into issues.
+
+**What would make the colour-scan gate pick wrongly?**
+Very little, by construction — it needs 6 CRC-valid bursts *and* 3× dominance,
+and wrong colours live at the ~1/256 floor. The realistic failure is the one
+observed: a signal too marginal for any colour to dominate, where the gate
+refuses. Trusting a non-dominant winner is exactly what the gate exists to
+prevent.
+
+**Is TMO TETRA "done"?**
+The decode path is verified end to end — conformant vocoder, capture-proven
+soft/equalized TCH/S, a control channel that rides through the marginal
+regime. Open engineering remains around the edges (LMS default, symbol-scope
+pooling), but nothing in the TMO voice path currently waits on evidence.
+
+## Series navigation
+
+**Part 14 of 14** · ←
+[Part 13: DMO III — A Production Pipeline: Grid Votes, Grants & Noise]({{ '/blog/deep-dives/tetra-end-to-end-13-dmo-pipeline-grants/' | relative_url }})
+· This is the finale — back to the [series index]({{ '/blog/series/tetra-end-to-end/' | relative_url }}).
+
+*Where to next? The equalizers, soft decisions, and metric discipline this series applied to one protocol are a general toolkit — see how they generalize in [Weak-Signal Engineering]({{ '/blog/series/weak-signal-engineering/' | relative_url }}), which owns the theory these TETRA posts kept pointing at.*

--- a/docs/_posts/2026-08-31-weak-signal-engineering-14-playbook.md
+++ b/docs/_posts/2026-08-31-weak-signal-engineering-14-playbook.md
@@ -1,0 +1,295 @@
+---
+title: "Weak-Signal Engineering, Part 14: The Weak-Signal Playbook"
+description: "The finale — the whole method folded into one decision tree from symptom to lever: measure in-channel SNR and yield, classify the channel as ISI-limited, reliability-limited, fading-limited, or signal-limited, apply the matching lever, and hold every change to the failing-first, capture-A/B, yield-verdict discipline."
+category: deep-dives
+keywords: weak signal decision tree, decode yield verdict, equalize or go soft, diversity or fix rf, dsp testing discipline, failing-first regression, capture a/b, marginal signal playbook, gophertrunk weak-signal engineering
+tags: [weak-signal-engineering, playbook, dsp, testing, methodology, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Weak-Signal Engineering"
+series_part: 14
+---
+
+*Part 14 — the finale — of **Weak-Signal Engineering**. Thirteen posts ago we
+met a capture that locked and then decoded almost nothing: ~10 dB in-channel
+SNR, 22% of its BSCH bursts CRC-clean, a resync storm eating the rest. Along
+the way we learned which metrics lie, inverted linear channels blind and
+trained, froze taps in front of differential decoders, carried confidence
+through the FEC, combined two antennas without breaking anything, and — twice
+— proved a deficit wasn't ours to fix. That capture now decodes ~100% of its
+BSCH. This closing part compresses the whole method into the thing you
+actually need at the bench: a decision tree from symptom to lever, the
+testing discipline that makes each lever safe to pull, and an honest list of
+what is still open.*
+
+> **TL;DR:** The playbook is four questions asked in order. **Is it
+> signal-limited?** — measure in-channel SNR and dBFS headroom; if the
+> samples don't contain the call, no DSP recovers it (fix RF, get captures —
+> [#764](https://github.com/MattCheramie/GopherTrunk/issues/764)'s lesson).
+> **Is it ISI-limited?** — a smeared constellation at decent SNR is a linear,
+> invertible channel: equalize (`SnapshotCMA` blind in the receiver,
+> `SnapshotLMS` trained in the extractor). **Is it reliability-limited?** —
+> clean-ish symbols failing hard CRC gates want soft decisions
+> (`DecodeRCPCTetraMotherSoft` and friends). **Is it fading-limited?** — a
+> second branch and coherence-gated MRC (`CrossStats`,
+> `TrackingCalibrator`). Every lever lands the same way: a failing-first
+> test, a byte-identical opt-out, a capture A/B where one exists, and
+> **decode yield as the only verdict**. On the thread capture the CC-path
+> equalizer alone took CRC-clean BSCH from ~12% to ~100%; the same
+> equalizer nearly doubled voice TCH/S (410→778) across six captures, and
+> soft decisions recovered the ~70% of marginal bursts the hard gate
+> dropped.
+
+**Key takeaways**
+
+- **Classify before you fix.** The four regimes — signal-, ISI-,
+  reliability-, and fading-limited — have distinct fingerprints and
+  *disjoint* fixes. The costliest failure mode in this series was always
+  applying a real lever to the wrong regime.
+- **Yield is the only verdict; everything else is advisory.** EVM collapsed
+  34%→8% on an equalizer that decoded zero frames. CRC-valid frames per
+  opportunity is the number that cannot flatter you.
+- **The discipline stack is what made the levers safe**: failing-first
+  regressions, byte-identical opt-outs, capture A/Bs against operators' own
+  recordings, and structural guards against the self-consistent-synthetic
+  trap.
+- **The method transfers.** Nothing in the four questions is
+  TETRA-specific — the same triage indicts the P25 C4FM path (Part 13) and
+  will grade its fix when the capture arrives.
+
+## Cheat sheet
+
+| Regime | The lever that matches it | Where it lives |
+|---|---|---|
+| Signal-limited (deficit survives an independent-path control) | fix RF, capture rate, gain staging — not DSP | [Part 12]({{ '/blog/deep-dives/weak-signal-engineering-12-proving-signal/' | relative_url }}), `internal/scanner/ccdecoder/ddc_highrate_test.go` |
+| ISI-limited (smeared constellation at decent SNR) | blind `SnapshotCMA` / trained `SnapshotLMS` | `internal/dsp/equalizer/`, [Parts 4–7]({{ '/blog/deep-dives/weak-signal-engineering-04-blind-cma/' | relative_url }}) |
+| Reliability-limited (symbols mostly right, hard CRCs failing) | soft LLRs through depuncture + Viterbi | `internal/radio/framing/soft_tetra.go`, [Part 8]({{ '/blog/deep-dives/weak-signal-engineering-08-soft-decisions/' | relative_url }}) |
+| Fading-limited (yield swings with time / position) | coherence-gated MRC across two branches | `internal/dsp/diversity/`, [Parts 10–11]({{ '/blog/deep-dives/weak-signal-engineering-10-mrc-calibration/' | relative_url }}) |
+| Any ("improved" metrics, unchanged yield) | distrust the metric — decode to CRC | [Part 2]({{ '/blog/deep-dives/weak-signal-engineering-02-metrics-that-lie/' | relative_url }}) |
+| Any (green synthetic, live symptom) | operator capture A/B before closing | [Part 12]({{ '/blog/deep-dives/weak-signal-engineering-12-proving-signal/' | relative_url }}), `CONTRIBUTING.md` |
+
+## In this post
+
+- **The four questions** — the decision tree, in order.
+- **The levers, ranked by cost** — what each one demands before it pays.
+- **The discipline stack** — how a risky lever becomes a safe landing.
+- **The thread capture, closed out** — the scorecard.
+- **What's still open** — the honest punch list.
+
+## The four questions
+
+Ask them in order — each one is cheaper to answer than the one after it, and
+a wrong answer early wastes every step later.
+
+**1. Is it signal-limited?** Measure before theorising: in-channel SNR at
+the demod (not wideband carrier SNR — [Part 2]({{ '/blog/deep-dives/weak-signal-engineering-02-metrics-that-lie/' | relative_url }})
+showed the wideband number grading the *worse* #764 capture higher), peak
+dBFS for headroom, and where possible the
+[Part 12]({{ '/blog/deep-dives/weak-signal-engineering-12-proving-signal/' | relative_url }})
+control: route the failing samples through a proven path via an independent
+resampler. If the deficit travels with the samples, stop — no equalizer,
+soft decoder, or combiner manufactures information the front end never
+delivered. The fix is on the other side of the ADC: gain staging, capture
+rate, antenna, filtering — the territory of
+[The Analog Edge]({{ '/blog/series/analog-edge/' | relative_url }}).
+
+**2. Is it ISI-limited?** Decent SNR but a smeared constellation — multipath,
+band-edge group delay, simulcast — is a *linear* channel, and linear is
+invertible ([Part 3]({{ '/blog/deep-dives/weak-signal-engineering-03-isi-linear-channel/' | relative_url }})).
+Equalize: blind `SnapshotCMA` in the streaming receiver where no reference
+exists, trained `SnapshotLMS` in the burst extractor where a midamble does.
+The confirmation is never the constellation looking rounder — it is yield
+moving when the equalizer is enabled on the same capture.
+
+**3. Is it reliability-limited?** Symbols mostly land in the right region
+but hard CRC gates keep failing — noise, not smear, is eating the margin.
+Go soft: carry LLRs through descramble, deinterleave, depuncture, and the
+correlation-metric Viterbi, and let erasures be erasures
+([Part 8]({{ '/blog/deep-dives/weak-signal-engineering-08-soft-decisions/' | relative_url }})).
+This lever stacks with the previous one — equalized symbols feed re-derived
+LLRs, not re-sliced bits.
+
+**4. Is it fading-limited?** Yield that swings with time or antenna position
+while the average SNR looks adequate means the channel spends part of its
+time in a null. One antenna cannot fix a null it is standing in; a second
+branch, coherence-gated and MRC-combined
+([Parts 10–11]({{ '/blog/deep-dives/weak-signal-engineering-10-mrc-calibration/' | relative_url }})),
+buys the odds that somewhere on your roof the signal still exists.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 250" width="680" height="250" role="img" aria-label="The weak-signal decision tree. Start at measure SNR and yield. First branch: deficit survives an independent-path control means signal-limited, go fix RF and capture. Otherwise, smeared constellation at decent SNR means ISI-limited, equalize. Otherwise, hard CRC failures on mostly-correct symbols means reliability-limited, go soft. Otherwise, yield swinging with time means fading-limited, add a diversity branch. Every leaf feeds one verdict box: decode yield on the same capture.">
+  <rect x="250" y="8" width="180" height="36" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="340" y="24" text-anchor="middle" fill="var(--accent)" font-size="10">measure: in-channel SNR,</text>
+  <text x="340" y="37" text-anchor="middle" fill="var(--accent)" font-size="10">dBFS headroom, yield</text>
+  <line x1="340" y1="44" x2="340" y2="58" stroke="currentColor"/><polygon points="336,56 340,64 344,56" fill="currentColor"/>
+  <rect x="20" y="64" width="150" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="95" y="82" text-anchor="middle" fill="currentColor" font-size="9">deficit survives the</text>
+  <text x="95" y="95" text-anchor="middle" fill="currentColor" font-size="9">independent-path control?</text>
+  <rect x="190" y="64" width="140" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="260" y="82" text-anchor="middle" fill="currentColor" font-size="9">constellation smeared</text>
+  <text x="260" y="95" text-anchor="middle" fill="currentColor" font-size="9">at decent SNR?</text>
+  <rect x="350" y="64" width="140" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="420" y="82" text-anchor="middle" fill="currentColor" font-size="9">symbols right, hard</text>
+  <text x="420" y="95" text-anchor="middle" fill="currentColor" font-size="9">CRC gates failing?</text>
+  <rect x="510" y="64" width="150" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="585" y="82" text-anchor="middle" fill="currentColor" font-size="9">yield swings with</text>
+  <text x="585" y="95" text-anchor="middle" fill="currentColor" font-size="9">time / position?</text>
+  <line x1="95" y1="108" x2="95" y2="128" stroke="currentColor"/><polygon points="91,126 95,134 99,126" fill="currentColor"/>
+  <line x1="260" y1="108" x2="260" y2="128" stroke="currentColor"/><polygon points="256,126 260,134 264,126" fill="currentColor"/>
+  <line x1="420" y1="108" x2="420" y2="128" stroke="currentColor"/><polygon points="416,126 420,134 424,126" fill="currentColor"/>
+  <line x1="585" y1="108" x2="585" y2="128" stroke="currentColor"/><polygon points="581,126 585,134 589,126" fill="currentColor"/>
+  <rect x="20" y="134" width="150" height="42" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="95" y="151" text-anchor="middle" fill="currentColor" font-size="9">SIGNAL-limited</text>
+  <text x="95" y="165" text-anchor="middle" fill="var(--fg-muted)" font-size="8">fix RF / rate / gain — no DSP</text>
+  <rect x="190" y="134" width="140" height="42" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="260" y="151" text-anchor="middle" fill="currentColor" font-size="9">ISI-limited</text>
+  <text x="260" y="165" text-anchor="middle" fill="var(--fg-muted)" font-size="8">SnapshotCMA / SnapshotLMS</text>
+  <rect x="350" y="134" width="140" height="42" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="420" y="151" text-anchor="middle" fill="currentColor" font-size="9">RELIABILITY-limited</text>
+  <text x="420" y="165" text-anchor="middle" fill="var(--fg-muted)" font-size="8">LLRs → soft Viterbi</text>
+  <rect x="510" y="134" width="150" height="42" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="585" y="151" text-anchor="middle" fill="currentColor" font-size="9">FADING-limited</text>
+  <text x="585" y="165" text-anchor="middle" fill="var(--fg-muted)" font-size="8">coherence-gated MRC</text>
+  <line x1="95" y1="176" x2="320" y2="210" stroke="var(--accent)"/>
+  <line x1="260" y1="176" x2="330" y2="210" stroke="var(--accent)"/>
+  <line x1="420" y1="176" x2="350" y2="210" stroke="var(--accent)"/>
+  <line x1="585" y1="176" x2="360" y2="210" stroke="var(--accent)"/>
+  <rect x="240" y="210" width="200" height="32" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="340" y="230" text-anchor="middle" fill="var(--accent)" font-size="10">verdict: decode yield, same capture</text>
+</svg>
+<figcaption>Four questions in cost order, four disjoint levers — and every branch terminates at the same verdict box: CRC-valid frames per opportunity on the capture that showed the symptom.</figcaption>
+</figure>
+
+## The levers, ranked by what they cost
+
+- **Blind snapshot equalization** (Parts 4–6) costs CPU and two hard-won
+  rules: frozen taps in front of anything differential, and a constant
+  normalisation reference with a divergence guard. It needs no reference
+  symbols and no new data plumbing — the cheapest real lever.
+- **Trained equalization** (Part 7) costs the raw-symbol plumbing
+  (`SymbolSink`/`StashSymbols`) and works only where a known training
+  sequence exists — but it pins the true channel inverse, phase included,
+  which blind CMA cannot on a short reference.
+- **Soft decisions** (Part 8) cost a parallel float32 stream and a soft
+  mirror of the channel-coding chain — paid once per protocol, then every
+  marginal burst benefits.
+- **Diversity** (Parts 10–11) is the only lever that costs *hardware* — a
+  second coherent receive branch — plus the calibration machinery to avoid
+  combining into a cancellation. It is also the only lever that helps a flat
+  fade.
+- The meta-lever is [Part 9]({{ '/blog/deep-dives/weak-signal-engineering-09-parallel-buffers/' | relative_url }})'s
+  pattern — parallel buffers with byte-identical opt-outs — which is what
+  kept the other four's risk off the working fleet.
+
+## The discipline stack
+
+Every lever above landed through the same gauntlet, and the gauntlet is the
+part most worth stealing:
+
+1. **Failing-first.** A regression test that fails against the old code and
+   passes with the change — no reproduction, no fix.
+2. **Byte-identical opt-out.** Off must be the identity function, and a test
+   must compare the bytes (`TestTrafficExtractorSoftUnchangedWithoutEqualizer`
+   is the template).
+3. **No-harm on clean.** The lever must not tax the signals that already
+   decode (`TestSnapshotCMAHarmlessOnCleanSignal`,
+   `TestTrafficExtractorLMSNoHarmOnCleanChannel`).
+4. **Capture A/B.** Where an operator capture exists, the lever is graded on
+   it — `TestDiversityCombinerReplay`'s four arms, the
+   `pipelines_tetra_equalizer_test.go` fixture — because a green synthetic
+   is not proof of an on-air fix.
+5. **Yield verdicts only.** Every harness in this series prints CRC-valid
+   counts and says, in as many words, not to conclude anything from EVM.
+6. **Guards against self-consistency.** Encode-side behaviour pinned to
+   real-air behaviour, cross-checks through independent implementations,
+   opcode constants pinned to upstream literals — because a test that
+   shares its assumption with the code validates nothing.
+
+## The thread capture, closed out
+
+The capture introduced in
+[Part 1]({{ '/blog/deep-dives/weak-signal-engineering-01-marginal-regime/' | relative_url }})
+— a TETRA control channel that locks at ~10 dB in-channel SNR — decoded
+~22% of its BSCH in the live session that produced it, with a
+destructive-resync storm; the pinned 2-second fixture
+(`testdata/tetra_cc_sync_loss_2s_144k.cs16`) baselines at ~12% through the
+bare pipeline. Enabling the receiver's `SnapshotCMA` on that one remaining
+un-equalized CC path lifted it to **~100% CRC-clean BSCH** — pinned by
+`pipelines_tetra_equalizer_test.go`. One lever, matched to its regime,
+recovered essentially everything the channel had to give; the residual
+−44 dBFS front end remains an RF condition the equalizer mitigates but does
+not replace — question 1 never goes away.
+
+The same levers, scored on their own ground: the equalizer roughly doubled
+CRC-valid voice TCH/S across the six concurrent-load captures
+(soft-decision counts 410→778, with single calls going 4→207); soft
+decisions recovered the ~70% of a marginal call's bursts the hard gate
+dropped; and on the DMO capture the receiver equalizer lifted CRC-valid
+SCH/S from 6 to 64. Different paths, different protocols, one pattern:
+classify, lever, yield.
+
+## What's still open
+
+An honest playbook ends with its open items, each parked at a named gate:
+
+- **Trained LMS in production TETRA voice** — staged and synthetic-pinned;
+  gated on the `GT_TETRA_LMS=1` capture A/B showing it beats
+  CMA-plus-soft on air.
+- **Tracking MRC as the diversity default** — differential-safe by measured
+  construction; gated on `TestDiversityCombinerReplay` on an operator's own
+  pre-combine capture showing the tracking arm winning.
+- **P25 Phase 1 C4FM voice** — the odd path out
+  ([Part 13]({{ '/blog/deep-dives/weak-signal-engineering-13-p25-c4fm-gap/' | relative_url }}));
+  gated on a real weak C4FM voice capture landing in `samples/p25/`.
+- **Per-channel diversity combining** — the answer to the wideband-scalar
+  caveat; unbuilt, and honestly scoped as a much larger change.
+
+Every one of them is blocked on evidence, not effort — which is the series'
+thesis restated: in the marginal regime, the scarce resource is not clever
+DSP, it is a measurement you can trust.
+
+## FAQ
+
+**Where do I start when a system decodes badly and I know nothing else?**
+Question 1, always: in-channel SNR at the demod and peak dBFS. Five minutes
+of measurement sorts most cases into "the samples are fine, work the DSP
+levers" or "no DSP will save this" — and the second answer, found early, is
+the biggest time-saver in this series.
+
+**How do the levers combine on one channel?**
+Equalize first (it operates on symbols), decode soft second (it operates on
+the equalized symbols' LLRs), diversify beneath both (it operates on the
+wideband stream before any of this). They are complementary regimes, not
+alternatives — the TETRA voice path today runs all of: CMA in the receiver,
+soft TCH/S in the decoder, and optionally a second branch under MRC.
+
+**What single habit most improves weak-signal debugging?**
+Refusing any verdict that isn't decode yield on the capture that showed the
+symptom. Every trap this series named — the EVM collapse, the flattering
+wideband SNR, the self-consistent synthetic — is a version of accepting a
+proxy because it was easier to obtain.
+
+**Is any of this specific to Go or to GopherTrunk?**
+The identifiers are; the method isn't. The four regimes, the yield rule, the
+frozen-snapshot constraint ahead of differential decoders, the
+independent-implementation cross-check — all of it transfers to any SDR
+stack. GopherTrunk's contribution is having the tests in the tree so each
+claim stays pinned.
+
+**What should I contribute if I want to move an open item?**
+Captures, over code. A weak C4FM P25 voice call, a pre-combine diversity
+pair from `diversity_capture`, or a marginal TETRA call with
+`GT_TETRA_LMS` A/B numbers each unblocks a parked lever — the analysis
+machinery for all three is already merged and waiting.
+
+## Series navigation
+
+**Part 14 of 14** · ←
+[Part 13: The Odd Path Out — P25 Phase 1 C4FM]({{ '/blog/deep-dives/weak-signal-engineering-13-p25-c4fm-gap/' | relative_url }})
+· This is the finale — back to the [series index]({{ '/blog/series/weak-signal-engineering/' | relative_url }}).
+
+*Where to next? The theory you've just finished has a protocol-length case
+study — watch every lever land on one real network in
+[TETRA End to End]({{ '/blog/series/tetra-end-to-end/' | relative_url }}) — or
+cross to the other side of the ADC, where question 1 lives, with
+[The Analog Edge]({{ '/blog/series/analog-edge/' | relative_url }}).*

--- a/docs/blog/series/analog-edge.md
+++ b/docs/blog/series/analog-edge.md
@@ -1,0 +1,62 @@
+---
+layout: page
+title: "The Analog Edge: everything between the antenna and the ADC"
+description: A 14-part operator's field guide to the analog half of an SDR scanner — dBFS, gain staging, clipping and intermod, phase noise, sample-rate choice, antennas, feedline, filters and LNAs, capture discipline, and diversity — because the decoder can only be as good as the samples.
+keywords: sdr gain staging, dbfs meaning, sdr overload intermod, phase noise reciprocal mixing, scanner antenna guide, coax loss 800 mhz, sdr lna filter, iq capture sigmf, antenna diversity mrc, gophertrunk analog edge
+nav_group: Blog
+permalink: /blog/series/analog-edge/
+---
+
+**The Analog Edge** is a 14-part field guide to the half of a scanner that
+software can't fix: everything between the antenna and the ADC. The
+[issue tracker]({{ '/blog/series/from-the-issue-tracker/' | relative_url }})
+keeps teaching the same lesson — half the hard bugs were **in the samples**, not
+in the code — and this series turns those postmortems into working knowledge:
+what dBFS actually measures, how to stage gain without chasing a software
+threshold, what clipping, intermod and phase noise each look like from the
+decoder's side, which sample rate to run, and how antennas, feedline, filters
+and LNAs decide your noise floor before
+[GopherTrunk](https://github.com/MattCheramie/GopherTrunk) sees a single sample.
+
+It is the operator's companion to two concurrent series: where
+[Weak-Signal Engineering]({{ '/blog/series/weak-signal-engineering/' | relative_url }})
+explains the algorithms that recover a marginal signal, The Analog Edge is about
+**not being marginal in the first place** — and about capturing honest evidence
+(pre-combine IQ, sidecar metadata) when you are. One thread runs the length of
+the series: a system that decodes cleanly on a hardware scanner but garbles in
+software, and the analog-side causes eliminated one part at a time.
+
+Every post reads three ways: a **TL;DR + cheat-sheet** for skimmers, **bold
+headers, tables, and diagrams** for the medium read, and full prose with real
+measurements for the deep read.
+
+New here? Start with
+[What hardware do I need?]({{ '/what-do-i-need-for-gophertrunk/' | relative_url }})
+for the shopping list, then come back for how to make it sing.
+
+{%- assign parts = site.posts | where: "series", "The Analog Edge" | sort: "series_part" -%}
+{%- if parts and parts.size > 0 -%}
+<ol class="post-list series-list">
+  {%- for post in parts -%}
+    <li class="post-card">
+      <a class="post-card__link" href="{{ post.url | relative_url }}">
+        <h2 class="post-card__title">{{ post.title }}</h2>
+      </a>
+      <p class="post-card__meta">
+        <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%B %-d, %Y" }}</time>
+        <span class="category-chip">Tutorials</span>
+      </p>
+      {%- if post.description -%}
+        <p class="post-card__desc">{{ post.description }}</p>
+      {%- endif -%}
+    </li>
+  {%- endfor -%}
+</ol>
+{%- else -%}
+<p class="post-list__empty">No posts in this series yet — check back soon.</p>
+{%- endif -%}
+
+<p class="blog-feed-link">
+  See all <a href="{{ '/blog/category/tutorials/' | relative_url }}">tutorials</a>
+  or subscribe via <a href="{{ '/feed.xml' | relative_url }}">RSS</a>.
+</p>

--- a/docs/blog/series/tetra-end-to-end.md
+++ b/docs/blog/series/tetra-end-to-end.md
@@ -1,0 +1,62 @@
+---
+layout: page
+title: "TETRA End to End: from a π/4-DQPSK carrier to clear recorded voice"
+description: A 14-part deep dive into GopherTrunk's TETRA stack — bursts and slot grids, RCPC channel coding, scrambling and colour codes, a clean-room ACELP vocoder conformed bit-identical against the ETSI reference, soft-decision TCH/S, the equalizers, and the full Direct Mode (DMO) saga.
+keywords: tetra decoder, pi/4-dqpsk, tetra burst slot grid, rcpc viterbi, tetra scrambling colour code, acelp vocoder, etsi en 300 395-2, tetra dmo direct mode, soft decision tch/s, gophertrunk tetra
+nav_group: Blog
+permalink: /blog/series/tetra-end-to-end/
+---
+
+**TETRA End to End** is a 14-part deep dive into the
+[GopherTrunk](https://github.com/MattCheramie/GopherTrunk) TETRA stack — the
+whole path from a raw 25 kHz π/4-DQPSK carrier to clear voice in a WAV file.
+Where [Protocol Decoders]({{ '/blog/series/protocol-decoders/' | relative_url }})
+gave TETRA one survey episode, this series walks every layer at full depth:
+bursts and the slot grid, RCPC channel coding and the CRC that isn't an LFSR,
+scrambling and colour codes, the traffic channel, a **clean-room ACELP vocoder**
+conformed bit-identical against the ETSI reference codec, the soft-decision and
+equalizer upgrades that roughly doubled marginal-signal yield, and the
+three-part **Direct Mode (DMO)** saga — including the "encrypted" verdict that
+turned out to be a descramble bug.
+
+It is also a series about verification discipline. The recurring villain is the
+self-consistent synthetic test — the round-trip that validates its own bug — and
+the recurring hero is the reporter's capture. Where
+[Weak-Signal Engineering]({{ '/blog/series/weak-signal-engineering/' | relative_url }})
+owns the cross-protocol theory of equalizers, soft decisions and diversity, this
+series is its flagship case study, protocol by protocol layer.
+
+Every post reads three ways: a **TL;DR + cheat-sheet** for skimmers, **bold
+headers, tables, and diagrams** for the medium read, and full prose with real
+code for the deep read.
+
+New here? Start with the
+[Digital Trunking]({{ '/learn/digital-trunking/' | relative_url }}) module for
+how a trunked system is laid out, then come back for the TETRA specifics.
+
+{%- assign parts = site.posts | where: "series", "TETRA End to End" | sort: "series_part" -%}
+{%- if parts and parts.size > 0 -%}
+<ol class="post-list series-list">
+  {%- for post in parts -%}
+    <li class="post-card">
+      <a class="post-card__link" href="{{ post.url | relative_url }}">
+        <h2 class="post-card__title">{{ post.title }}</h2>
+      </a>
+      <p class="post-card__meta">
+        <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%B %-d, %Y" }}</time>
+        <span class="category-chip">Deep dives</span>
+      </p>
+      {%- if post.description -%}
+        <p class="post-card__desc">{{ post.description }}</p>
+      {%- endif -%}
+    </li>
+  {%- endfor -%}
+</ol>
+{%- else -%}
+<p class="post-list__empty">No posts in this series yet — check back soon.</p>
+{%- endif -%}
+
+<p class="blog-feed-link">
+  See all <a href="{{ '/blog/category/deep-dives/' | relative_url }}">deep dives</a>
+  or subscribe via <a href="{{ '/feed.xml' | relative_url }}">RSS</a>.
+</p>

--- a/docs/blog/series/weak-signal-engineering.md
+++ b/docs/blog/series/weak-signal-engineering.md
@@ -1,0 +1,64 @@
+---
+layout: page
+title: "Weak-Signal Engineering: decoding the calls at the edge"
+description: A 14-part deep dive into how GopherTrunk roughly doubled its decode yield on marginal signals — blind and trained equalization, frozen-snapshot taps ahead of differential decoders, soft-decision FEC, diversity combining with coherence-gated calibration, and the metrics that lie along the way.
+keywords: weak signal decoding, blind equalizer cma, lms equalizer training sequence, soft decision viterbi llr, diversity combining mrc, coherence cross correlation, evm trap crc yield, differential decoder phase, isi multipath equalization, gophertrunk weak signal
+nav_group: Blog
+permalink: /blog/series/weak-signal-engineering/
+---
+
+**Weak-Signal Engineering** is a 14-part deep dive into the marginal regime —
+the space between full quieting and no signal, where a receiver **locks but
+doesn't decode**, and where most real traffic actually lives. Across one year of
+issue-tracker work, [GopherTrunk](https://github.com/MattCheramie/GopherTrunk)
+roughly **doubled** its decode yield there with four levers: blind equalization
+(CMA with frozen snapshots), trained equalization (LMS on known midambles),
+soft-decision FEC, and diversity combining. This series is the cross-protocol
+theory and engineering of those levers — what each one can and cannot fix, the
+traps between them, and the tests that keep them honest.
+
+Where [SDR Internals]({{ '/blog/series/sdr-internals/' | relative_url }}) gave
+equalization and diversity one survey episode, this series goes lever by lever.
+The concurrent
+[TETRA End to End]({{ '/blog/series/tetra-end-to-end/' | relative_url }}) series
+is its flagship case study, and
+[The Analog Edge]({{ '/blog/series/analog-edge/' | relative_url }}) covers the
+other side of the ADC — because the first weak-signal question is always whether
+the deficit is in the channel or baked into the samples. One discipline runs the
+length of the series: **CRC-valid frames are the only trustworthy verdict**;
+EVM, SNR and constellation beauty are advisory at best and traps at worst.
+
+Every post reads three ways: a **TL;DR + cheat-sheet** for skimmers, **bold
+headers, tables, and diagrams** for the medium read, and full prose with real
+code for the deep read.
+
+New here? Start with the
+[DSP]({{ '/learn/dsp/' | relative_url }}) learning module for the vocabulary,
+then come back for the engineering.
+
+{%- assign parts = site.posts | where: "series", "Weak-Signal Engineering" | sort: "series_part" -%}
+{%- if parts and parts.size > 0 -%}
+<ol class="post-list series-list">
+  {%- for post in parts -%}
+    <li class="post-card">
+      <a class="post-card__link" href="{{ post.url | relative_url }}">
+        <h2 class="post-card__title">{{ post.title }}</h2>
+      </a>
+      <p class="post-card__meta">
+        <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%B %-d, %Y" }}</time>
+        <span class="category-chip">Deep dives</span>
+      </p>
+      {%- if post.description -%}
+        <p class="post-card__desc">{{ post.description }}</p>
+      {%- endif -%}
+    </li>
+  {%- endfor -%}
+</ol>
+{%- else -%}
+<p class="post-list__empty">No posts in this series yet — check back soon.</p>
+{%- endif -%}
+
+<p class="blog-feed-link">
+  See all <a href="{{ '/blog/category/deep-dives/' | relative_url }}">deep dives</a>
+  or subscribe via <a href="{{ '/feed.xml' | relative_url }}">RSS</a>.
+</p>


### PR DESCRIPTION
Landing pages and nav entries for TETRA End to End (deep-dives),
The Analog Edge (tutorials), and Weak-Signal Engineering (deep-dives),
each a 14-part daily series running 2026-08-18 through 2026-08-31.
Posts follow in a separate commit.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011MGmwWMGYtqZgQqxj7BNfs