### PR TITLE
config: lower the sdr.sample_rate floor to 200 kHz

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -496,6 +496,27 @@ confirmation before any close-as-completed.
   real work, in °/s) and decodes four arms — each branch alone, static, tracking — scored by
   CRC-clean BSCH. **Yield is the verdict, never EVM.** Tracking-as-default is NOT yet verified
   on air; that A/B on the operator's own capture is the gate.
+- **The A/B ran on the operator's first pre-combine capture (17 Aug, X310 `rx_subdev_spec=B:0
+  A:0`, internal clock, TETRA CC 467.9125 MHz, 250 kS/s, 30 s, 0 dropped datagrams) — the X310
+  dual-daughterboard stream over SoapyRemote IS coherent, no external oscillator sync needed.**
+  Wideband coherence median 0.658, narrowband (post-DDC 144 k) 0.713; branch phase ~145° walking
+  only −0.22°/s (frozen constant decays over minutes, so tracking is right, but static is fine
+  over any one calibration). Decode arms: branch0 885 / branch1 896 / wb-static 898 /
+  wb-tracking 898 / nb arms 896 CRC-clean BSCH — MRC ≥ best branch (no harm) but this capture
+  sits at its ~96% BSCH ceiling, so it CANNOT demonstrate a real gain; a weak-signal capture
+  (BSCH well below ceiling on each branch alone) is what closes the tracking-as-default gate.
+  Two calibrated readings of the same capture disagree by design, don't chase them: the live
+  health line logged coherence 0.28–0.55 / branch_gain −11..−17 dB where the offline harness
+  measures 0.66 / −6.4 dB power ratio — the driver's per-window LS estimate is biased low by
+  noise (the logged gain IS the MRC weight, ∝ ρ·√(P₀/P₁), not a power ratio). Related bug found
+  and fixed in the same pass: `mrcTrackAlpha` derived the loop coefficient from the NOMINAL 2 ms
+  window while `mrcCalWindowSamples` clamps to ≥4096 samples, so at 250 kHz (16.4 ms windows)
+  the tracking 1/e time was silently ~1.6 s instead of the documented 200 ms — alpha now follows
+  the actual window duration (`TestMRCTrackAlphaHonorsClampedWindow`). Operator-visible symptom
+  ruled OUT as a regression: the "bad" web constellation at 250 kHz is the honest π/4-DQPSK
+  symbol plot (the `symbol_proto` fix stopped TETRA rigs drawing the flattering raw-IQ ring of a
+  wrong P25 receiver) of a marginal signal plus ~400 Hz carrier offset (≈8° differential
+  rotation); the same run decoded ~96% BSCH and recorded voice.
 - **MMSE-IRC cannot work blind, and that is a property of the estimator, not of one
   formula.** The reporter's #1062 RFC proposes IRC to null a directional interferer that MRC
   amplifies. Two separate problems, and only the first is fixable inside the algorithm. (1) The

--- a/cmd/gophertrunk/preflight.go
+++ b/cmd/gophertrunk/preflight.go
@@ -34,6 +34,22 @@ func preflight(cfg config.Config) ([]string, error) {
 		{"storage.path (parent)", parentDir(cfg.Storage.Path)},
 		{"storage.cc_cache_file (parent)", parentDir(cfg.Storage.CCCacheFile)},
 	}
+	for i, s := range cfg.SDR.SoapyRemote {
+		if s.DiversityCapture == "" {
+			continue
+		}
+		// The value is a filename prefix; a trailing separator means the
+		// operator named the directory itself (the branch recorder then
+		// generates a timestamped basename inside it).
+		dir := parentDir(s.DiversityCapture)
+		if strings.HasSuffix(s.DiversityCapture, string(os.PathSeparator)) || strings.HasSuffix(s.DiversityCapture, "/") {
+			dir = filepath.Clean(s.DiversityCapture)
+		}
+		dirs = append(dirs, struct {
+			label string
+			path  string
+		}{fmt.Sprintf("sdr.soapy_remote[%d].diversity_capture (parent)", i), dir})
+	}
 	for _, d := range dirs {
 		if d.path == "" {
 			continue

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -243,9 +243,10 @@ retention:
   interval: "1h"      # how often the sweeper runs
 
 sdr:
-  # 225000–20000000 Hz. 2_400_000 is the RTL-SDR sweet spot; RTL dongles
-  # cap at 3.2 MHz. Higher rates (e.g. 10_000_000 / 20_000_000) are only
-  # usable with a wideband source like soapy_remote (USRP, LimeSDR, …).
+  # 200000–20000000 Hz. 2_400_000 is the RTL-SDR sweet spot; RTL dongles
+  # enforce their own ~225 kHz floor and cap at 3.2 MHz. Rates outside
+  # that window (e.g. a narrow 200_000 capture, or 10_000_000 wideband)
+  # are only usable with a source like soapy_remote (USRP, LimeSDR, …).
   sample_rate: 2_400_000
   # watchdog_interval_ms: periodic USB-disconnect watchdog cadence
   # (default 30000 = 30 s). Catches dongles that vanish from the bus

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -606,7 +606,7 @@ type PowerLogConfig struct {
 
 type SDRConfig struct {
 	// SampleRate is the IQ rate (Hz) every tuner is programmed to.
-	// Default 2_400_000 (2.4 MS/s). Valid range 225_000..20_000_000; the
+	// Default 2_400_000 (2.4 MS/s). Valid range 200_000..20_000_000; the
 	// RTL2832U quantizes to its 28.4 fixed-point divisor so the streamed
 	// rate may differ slightly (see Device.ActualSampleRate). Note that
 	// RTL2832U hardware still caps at 3.2 MHz at the device level (the

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2099,4 +2099,18 @@ func (c *Config) resolvePaths(base string) {
 		c.Trunking.Systems[i].TalkgroupFile = resolve(c.Trunking.Systems[i].TalkgroupFile)
 		c.Trunking.Systems[i].RIDAliasFile = resolve(c.Trunking.Systems[i].RIDAliasFile)
 	}
+	for i := range c.SDR.SoapyRemote {
+		p := c.SDR.SoapyRemote[i].DiversityCapture
+		if p == "" {
+			continue
+		}
+		r := resolve(p)
+		// filepath.Join strips a trailing separator, but the branch recorder
+		// uses it to tell "directory to drop timestamped captures into" from
+		// "filename prefix" — keep the operator's intent visible.
+		if strings.HasSuffix(p, "/") || strings.HasSuffix(p, string(os.PathSeparator)) {
+			r += string(os.PathSeparator)
+		}
+		c.SDR.SoapyRemote[i].DiversityCapture = r
+	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -605,4 +606,32 @@ func TestWebConfigIDBase(t *testing.T) {
 
 func writeFile(path, data string) error {
 	return writeFileImpl(path, []byte(data))
+}
+
+// TestResolvePathsDiversityCapture pins two properties of the
+// sdr.soapy_remote[].diversity_capture prefix: it is anchored to the config
+// file's directory like every other output path (it used to be the one path
+// resolved against the daemon's CWD), and a trailing separator — the
+// operator's "drop captures into this directory" spelling — survives
+// resolution so the branch recorder can still tell directory from filename
+// prefix (filepath.Join would silently strip it).
+func TestResolvePathsDiversityCapture(t *testing.T) {
+	c := Config{SDR: SDRConfig{SoapyRemote: []SoapyRemoteConfig{
+		{DiversityCapture: "mrc_autocaptures/"},
+		{DiversityCapture: "captures/cap1"},
+		{DiversityCapture: ""},
+	}}}
+	c.resolvePaths(filepath.Join("/", "etc", "gt"))
+
+	want0 := filepath.Join("/", "etc", "gt", "mrc_autocaptures") + string(os.PathSeparator)
+	if got := c.SDR.SoapyRemote[0].DiversityCapture; got != want0 {
+		t.Errorf("trailing-separator prefix resolved to %q, want %q", got, want0)
+	}
+	want1 := filepath.Join("/", "etc", "gt", "captures", "cap1")
+	if got := c.SDR.SoapyRemote[1].DiversityCapture; got != want1 {
+		t.Errorf("file prefix resolved to %q, want %q", got, want1)
+	}
+	if got := c.SDR.SoapyRemote[2].DiversityCapture; got != "" {
+		t.Errorf("empty prefix became %q", got)
+	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -79,6 +79,11 @@ func TestValidate(t *testing.T) {
 		{"path_template unknown token", Config{Recordings: RecordingsConfig{PathTemplate: "{system}/{quarter}"}}, true},
 		{"path_template absolute", Config{Recordings: RecordingsConfig{PathTemplate: "/abs/{system}"}}, true},
 		{"bad sample rate", Config{SDR: SDRConfig{SampleRate: 100}}, true},
+		// Narrow captures from wideband sources: 200 kHz is the floor
+		// (issue: operator's 200 MHz/1000 exact-decimation TETRA capture);
+		// RTL dongles enforce their own 225 001 Hz floor at open instead.
+		{"narrow sample rate 200k", Config{SDR: SDRConfig{SampleRate: 200_000}}, false},
+		{"sample rate below 200k", Config{SDR: SDRConfig{SampleRate: 199_999}}, true},
 		// Wideband soapy_remote sources (issue #550): rates above the RTL
 		// 3.2 MHz hardware cap are valid config, bounded at 20 MHz.
 		{"wideband sample rate 10M", Config{SDR: SDRConfig{SampleRate: 10_000_000}}, false},

--- a/internal/config/config_validate.go
+++ b/internal/config/config_validate.go
@@ -89,8 +89,15 @@ func (c Config) ValidateSection(section string) []error {
 
 func (c Config) validateSDR() []error {
 	var errs []error
-	if c.SDR.SampleRate != 0 && (c.SDR.SampleRate < 225_000 || c.SDR.SampleRate > 20_000_000) {
-		errs = append(errs, errors.New("sdr.sample_rate must be between 225 kHz and 20 MHz"))
+	// The 200 kHz floor is for the config layer only — narrow single-channel
+	// captures from wideband sources (USRP/Lime/…, e.g. 200 MHz/1000 exact
+	// decimation) are legitimate. RTL dongles still enforce their own
+	// hardware floor (225 001 Hz, rtl2832u.MinSampleRateHz) at open. For
+	// TETRA note 240/256/288/300 kHz hit the 144 kHz DDC target exactly,
+	// while 250 kHz lands on the approximate 53/92 ratio (144 021.7 Hz,
+	// +0.015% — proven fine on air).
+	if c.SDR.SampleRate != 0 && (c.SDR.SampleRate < 200_000 || c.SDR.SampleRate > 20_000_000) {
+		errs = append(errs, errors.New("sdr.sample_rate must be between 200 kHz and 20 MHz"))
 	}
 	seenSerials := make(map[string]int, len(c.SDR.Devices))
 	for i, d := range c.SDR.Devices {

--- a/internal/config/config_validate.go
+++ b/internal/config/config_validate.go
@@ -7,7 +7,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -357,13 +356,10 @@ func validateSoapyFields(i int, s SoapyRemoteConfig) error {
 			return fmt.Errorf("sdr.soapy_remote[%d]: diversity_capture_seconds is %d (want 1..60; two CS16 branches are tens of MB/s)", i, s.DiversityCaptureSeconds)
 		}
 	}
-	if s.DiversityCapture != "" {
-		// Fail at config load, not several hundred MB into a stream.
-		dir := filepath.Dir(s.DiversityCapture)
-		if fi, err := os.Stat(dir); err != nil || !fi.IsDir() {
-			return fmt.Errorf("sdr.soapy_remote[%d]: diversity_capture directory %q does not exist", i, dir)
-		}
-	}
+	// diversity_capture's directory is auto-created (preflight up front, and
+	// the branch recorder lazily for non-daemon entrypoints) like every other
+	// output directory in the config, so a missing directory is not an error
+	// here. Validation must stay side-effect free, so no MkdirAll either.
 	// stream_mtu is in bytes; 0 means SoapyRemote's default (1500). Reject
 	// values that can't be a real endpoint MTU — too small to hold a useful
 	// frame, or above the driver's 4 MiB per-transfer read guard.

--- a/internal/config/marshal_test.go
+++ b/internal/config/marshal_test.go
@@ -93,7 +93,7 @@ func TestWriteConfigFile(t *testing.T) {
 
 	// Invalid config is never written.
 	bad := Default()
-	bad.SDR.SampleRate = 100 // below the 225 kHz floor
+	bad.SDR.SampleRate = 100 // below the 200 kHz floor
 	if _, err := WriteConfigFile(filepath.Join(dir, "bad.yaml"), bad, 0, true); err == nil {
 		t.Fatalf("expected validation error for bad config")
 	}

--- a/internal/configbuilder/fieldmeta.go
+++ b/internal/configbuilder/fieldmeta.go
@@ -91,7 +91,7 @@ var fieldMetas = map[string]FieldMeta{
 	"RadioReferenceConfig.Password": {Help: "Your RadioReference.com account password (required with username for premium browse/import/verify). Can come from GOPHERTRUNK_RR_PASS instead — prefer the env var to keeping the secret in config.yaml."},
 
 	// ---- SDR ---------------------------------------------------------------
-	"SDRConfig.SampleRate":          {Label: "Sample rate", Hz: true, Help: "IQ rate every tuner is programmed to (225 kHz–20 MHz). RTL dongles cap ~3.2 MHz; higher needs a wideband soapy_remote source. Primary CPU-load lever."},
+	"SDRConfig.SampleRate":          {Label: "Sample rate", Hz: true, Help: "IQ rate every tuner is programmed to (200 kHz–20 MHz). RTL dongles enforce their own ~225 kHz floor and cap ~3.2 MHz; higher needs a wideband soapy_remote source. Primary CPU-load lever."},
 	"SDRConfig.Devices":             {Help: "Locally-attached USB SDR dongles, selected by serial."},
 	"SDRConfig.RTLTCP":              {Label: "rtl_tcp sources", Help: "Remote rtl_tcp endpoints mounted as virtual tuners. Plaintext — trusted networks / tunnels only."},
 	"SDRConfig.SoapyRemote":         {Label: "SoapyRemote sources", Help: "Remote SoapySDRServer endpoints (USRP, Lime, bladeRF, HackRF, Airspy, RTL) mounted as virtual tuners. Plaintext — trusted networks / tunnels only."},

--- a/internal/configbuilder/sections.go
+++ b/internal/configbuilder/sections.go
@@ -25,7 +25,7 @@ func Sections() []SectionMeta {
 			"The trunked radio networks to follow. Each system needs a unique name, a protocol, and at least one control-channel frequency. Add systems by hand, by browsing RadioReference.com, or by importing a RadioReference PDF/CSV.",
 			"Trunking Systems", docsBase + "hunt.html"},
 		{"sdr", "SDR", "SDR",
-			"Sample rate (225 kHz–20 MHz) every tuner is programmed to, plus local devices and remote (rtl_tcp / SoapySDR) sources. P25 trunking needs separate control and voice dongles (distinct serials).",
+			"Sample rate (200 kHz–20 MHz) every tuner is programmed to, plus local devices and remote (rtl_tcp / SoapySDR) sources. P25 trunking needs separate control and voice dongles (distinct serials).",
 			"SDR Hardware", docsBase + "hardware.html"},
 		{"api", "API", "API & Web",
 			"HTTP/gRPC listen addresses and access control. allow_mutations lets the web UI write changes (talkgroup edits, settings, this builder's saves).",

--- a/internal/sdr/soapyremote/branchcapture.go
+++ b/internal/sdr/soapyremote/branchcapture.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"time"
 )
 
 // branchRecorder dumps the PRE-COMBINE per-branch IQ of a diversity stream.
@@ -125,7 +126,7 @@ func (d *device) startBranchCapture(rateHz float64) {
 	d.mu.Unlock()
 	d.mrc.rec = rec
 	d.log.Info("soapyremote: diversity capture armed — dumping pre-combine per-branch IQ",
-		"prefix", d.capturePrefix, "seconds", secs, "branches", d.rxChannelCount())
+		"prefix", rec.prefix, "seconds", secs, "branches", d.rxChannelCount())
 }
 
 // branchCaptureMaxBytes caps a capture independently of the configured seconds,
@@ -133,11 +134,40 @@ func (d *device) startBranchCapture(rateHz float64) {
 // 50 MB/s.
 const branchCaptureMaxBytes = 1 << 30 // 1 GiB per branch
 
+// resolveCapturePrefix turns a directory-style prefix — trailing separator, or
+// naming an existing directory — into a timestamped file prefix inside that
+// directory. Without this, "mrc_autocaptures/" + ".br0.cs16" produces HIDDEN
+// dot-files (an operator shipped a capture nobody could see with plain ls).
+// A plain filename prefix passes through untouched.
+func resolveCapturePrefix(prefix string, now time.Time) string {
+	isDir := os.IsPathSeparator(prefix[len(prefix)-1])
+	if !isDir {
+		if fi, err := os.Stat(prefix); err == nil && fi.IsDir() {
+			isDir = true
+		}
+	}
+	if !isDir {
+		return prefix
+	}
+	return filepath.Join(prefix, "diversity_"+now.UTC().Format("20060102T150405Z"))
+}
+
 // newBranchRecorder opens the per-branch files under prefix. budgetSamples
 // bounds the capture per branch; <=0 means the byte cap alone applies.
 func newBranchRecorder(prefix string, branches int, budgetSamples int64, log *slog.Logger) (*branchRecorder, error) {
 	if branches < 1 {
 		return nil, fmt.Errorf("soapyremote: branch capture needs at least one branch")
+	}
+	if prefix == "" {
+		return nil, fmt.Errorf("soapyremote: branch capture needs a file prefix")
+	}
+	prefix = resolveCapturePrefix(prefix, time.Now())
+	// Auto-create the directory like every other output path (the config
+	// validator no longer hard-fails on a missing one). Cheap and idempotent.
+	if dir := filepath.Dir(prefix); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return nil, fmt.Errorf("soapyremote: branch capture dir %s: %w", dir, err)
+		}
 	}
 	r := &branchRecorder{
 		log:           log,

--- a/internal/sdr/soapyremote/branchcapture_test.go
+++ b/internal/sdr/soapyremote/branchcapture_test.go
@@ -7,7 +7,9 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 )
 
 // readCS16 decodes a headerless cs16 branch file back to complex64.
@@ -264,5 +266,74 @@ func TestBranchCaptureArmsOncePerDevice(t *testing.T) {
 	d.mrc.rec.finish()
 	if got := readCS16(t, prefix+".br0.cs16"); len(got) != len(ch0) {
 		t.Errorf("captured %d samples, want %d", len(got), len(ch0))
+	}
+}
+
+// TestBranchRecorderCreatesMissingDirectory pins the auto-create contract: the
+// config validator no longer hard-fails on a missing diversity_capture
+// directory, so the recorder must create it like every other output path.
+// Fails against the old code with "no such file or directory".
+func TestBranchRecorderCreatesMissingDirectory(t *testing.T) {
+	prefix := filepath.Join(t.TempDir(), "does", "not", "exist", "cap")
+	rec, err := newBranchRecorder(prefix, 2, 0, testLogger())
+	if err != nil {
+		t.Fatalf("newBranchRecorder: %v", err)
+	}
+	rec.finish()
+	if _, err := os.Stat(prefix + ".br0.cs16"); err != nil {
+		t.Errorf("branch file not created under auto-created dir: %v", err)
+	}
+}
+
+// TestBranchRecorderDirectoryPrefixIsNotHidden pins the operator-visible
+// naming: a diversity_capture value that names a DIRECTORY (trailing slash, or
+// an existing dir) must produce a timestamped basename inside it — not
+// prefix+".br0.cs16", which yields hidden dot-files. An operator shipped a
+// capture as ".br0.cs16"/".br1.cs16"/".diversity.json" that plain ls could not
+// see; this fails against the old code.
+func TestBranchRecorderDirectoryPrefixIsNotHidden(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		prefix func(dir string) string
+	}{
+		{"trailing separator", func(dir string) string { return dir + string(os.PathSeparator) }},
+		{"existing directory", func(dir string) string { return dir }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			rec, err := newBranchRecorder(tc.prefix(dir), 2, 0, testLogger())
+			if err != nil {
+				t.Fatalf("newBranchRecorder: %v", err)
+			}
+			rec.finish()
+			ents, err := os.ReadDir(dir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(ents) == 0 {
+				t.Fatal("no capture files written into the directory")
+			}
+			for _, e := range ents {
+				if strings.HasPrefix(e.Name(), ".") {
+					t.Errorf("hidden capture file %q — directory prefix must get a generated basename", e.Name())
+				}
+				if !strings.HasPrefix(e.Name(), "diversity_") {
+					t.Errorf("capture file %q does not carry the generated diversity_<timestamp> basename", e.Name())
+				}
+			}
+		})
+	}
+}
+
+// TestResolveCapturePrefixPassthrough: a plain filename prefix is untouched, so
+// existing configs keep their exact output names.
+func TestResolveCapturePrefixPassthrough(t *testing.T) {
+	now := time.Date(2026, 8, 17, 20, 23, 23, 0, time.UTC)
+	if got := resolveCapturePrefix("captures/cap1", now); got != "captures/cap1" {
+		t.Errorf("plain prefix rewritten to %q", got)
+	}
+	want := filepath.Join("captures", "diversity_20260817T202323Z")
+	if got := resolveCapturePrefix("captures"+string(os.PathSeparator), now); got != want {
+		t.Errorf("directory prefix resolved to %q, want %q", got, want)
 	}
 }

--- a/internal/sdr/soapyremote/mrc.go
+++ b/internal/sdr/soapyremote/mrc.go
@@ -120,20 +120,33 @@ const (
 const mrcTrackTauMs = 200.0
 
 // mrcTrackAlpha is the one-pole coefficient implied by the window and the time
-// constant. Deriving it keeps the two constants honest: change the window and
-// the loop bandwidth stays where the comment says it is.
-func mrcTrackAlpha(mode diversityMode) float64 {
+// constant. It must be derived from the ACTUAL window duration — window
+// samples over the stream rate — not the nominal mrcCalWindowMs: at low
+// stream rates the min-samples clamp stretches the window (250 kHz → 4096
+// samples = 16.4 ms), and an alpha still assuming 2 ms would make the loop's
+// 1/e time ~1.6 s instead of the documented 200 ms — 8× too slow, exactly on
+// the narrow-capture rigs whose independently-locked PLLs need the tracking.
+func mrcTrackAlpha(mode diversityMode, window int, rateHz float64) float64 {
 	if mode == diversityMRCStatic {
 		return 0 // one-shot: freeze the first accepted window
 	}
-	return mrcCalWindowMs / mrcTrackTauMs
+	windowMs := mrcCalWindowMs
+	if rateHz > 0 && window > 0 {
+		windowMs = float64(window) / rateHz * 1000
+	}
+	alpha := windowMs / mrcTrackTauMs
+	if alpha > 1 {
+		alpha = 1
+	}
+	return alpha
 }
 
-// mrcCalOptions builds the calibrator options for a mode and window.
-func mrcCalOptions(mode diversityMode, window int) diversity.TrackingOptions {
+// mrcCalOptions builds the calibrator options for a mode and window. rateHz is
+// the stream rate the window was sized for (0 = unknown, nominal alpha).
+func mrcCalOptions(mode diversityMode, window int, rateHz float64) diversity.TrackingOptions {
 	return diversity.TrackingOptions{
 		WindowSamples:  window,
-		Alpha:          mrcTrackAlpha(mode),
+		Alpha:          mrcTrackAlpha(mode, window, rateHz),
 		LockCoherence:  mrcCoherenceLockGate,
 		TrackCoherence: mrcCoherenceTrackGate,
 		MinBranchPower: mrcBranchFloorPower,
@@ -257,7 +270,7 @@ func newMRCCombiner(format sampleFormat, mode diversityMode, rateHz float64) *mr
 	window := mrcCalWindowSamples(rateHz)
 	return &mrcCombiner{
 		window:   window,
-		cal:      diversity.NewTrackingCalibrator(diversityChannels, mrcCalOptions(mode, window)),
+		cal:      diversity.NewTrackingCalibrator(diversityChannels, mrcCalOptions(mode, window, rateHz)),
 		mode:     mode,
 		format:   format,
 		channels: diversityChannels,
@@ -354,7 +367,7 @@ func (m *mrcCombiner) setSampleRate(rateHz float64) {
 		return
 	}
 	m.window = want
-	m.cal = diversity.NewTrackingCalibrator(diversityChannels, mrcCalOptions(m.mode, want))
+	m.cal = diversity.NewTrackingCalibrator(diversityChannels, mrcCalOptions(m.mode, want, rateHz))
 	m.refIdx = -1
 	m.refDeadDatagrams = 0
 }

--- a/internal/sdr/soapyremote/mrc_test.go
+++ b/internal/sdr/soapyremote/mrc_test.go
@@ -521,14 +521,41 @@ func TestDiversityReporterStaysQuietWhileCalibrationKeepsUpdating(t *testing.T) 
 }
 
 // TestMRCTrackAlphaMatchesDocumentedTimeConstant pins that the loop bandwidth is
-// derived from the window and the stated time constant rather than hardcoded, so
-// changing the window cannot silently move it.
+// derived from the ACTUAL window duration and the stated time constant rather
+// than hardcoded, so neither changing the window nor the min-samples clamp can
+// silently move it.
 func TestMRCTrackAlphaMatchesDocumentedTimeConstant(t *testing.T) {
-	if got, want := mrcTrackAlpha(diversityMRCTracking), mrcCalWindowMs/mrcTrackTauMs; got != want {
+	// Unclamped rate: 2 MHz gives a 4096-sample window ≈ the nominal 2 ms, so
+	// alpha stays at the historical 0.01.
+	rate := 2_048_000.0
+	if got, want := mrcTrackAlpha(diversityMRCTracking, mrcCalWindowSamples(rate), rate), mrcCalWindowMs/mrcTrackTauMs; got != want {
 		t.Errorf("tracking alpha = %v, want %v", got, want)
 	}
-	if got := mrcTrackAlpha(diversityMRCStatic); got != 0 {
+	if got := mrcTrackAlpha(diversityMRCStatic, mrcCalWindowSamples(rate), rate); got != 0 {
 		t.Errorf("static alpha = %v, want 0 (one-shot)", got)
+	}
+}
+
+// TestMRCTrackAlphaHonorsClampedWindow is the low-rate regression (operator's
+// 250 kHz narrow TETRA capture): the min-samples clamp stretches the 2 ms
+// window to 4096 samples = 16.384 ms, and alpha must follow the ACTUAL
+// duration or the loop's 1/e time silently becomes ~1.6 s instead of the
+// documented 200 ms. Fails against the old nominal-constant derivation
+// (which returned 0.01 here).
+func TestMRCTrackAlphaHonorsClampedWindow(t *testing.T) {
+	const rate = 250_000.0
+	window := mrcCalWindowSamples(rate)
+	if window != mrcCalWindowMinSamples {
+		t.Fatalf("expected the min-samples clamp to engage at %v Hz, got window %d", rate, window)
+	}
+	got := mrcTrackAlpha(diversityMRCTracking, window, rate)
+	want := float64(window) / rate * 1000 / mrcTrackTauMs // ≈ 0.0819
+	if got != want {
+		t.Errorf("tracking alpha at %v Hz = %v, want %v (actual window duration / tau)", rate, got, want)
+	}
+	// Unknown rate: fall back to the nominal derivation rather than guessing.
+	if got, want := mrcTrackAlpha(diversityMRCTracking, mrcCalWindowDefaultSamples, 0), mrcCalWindowMs/mrcTrackTauMs; got != want {
+		t.Errorf("unknown-rate alpha = %v, want nominal %v", got, want)
 	}
 }
 

--- a/web/src/panels/Constellation.tsx
+++ b/web/src/panels/Constellation.tsx
@@ -196,11 +196,14 @@ export function Constellation() {
         : "symbols";
 
   // Ideal cluster markers depend on the active source: clusters on the
-  // diagonals for CQPSK symbols, levels on the real axis for the C4FM
-  // soft-level view, none for the raw vector scope / IQ ring.
+  // diagonals for CQPSK/π4-DQPSK symbols, levels on the real axis for the
+  // 4-level-FSK protocols (C4FM soft-level view, DMR), none for the raw
+  // vector scope / IQ ring.
   const markers = useMemo<IQPoint[]>(() => {
     if (source !== "symbols") return [];
-    return effectiveProto === "p25-c4fm" ? C4FM_MARKERS : CQPSK_MARKERS;
+    return effectiveProto === "p25-c4fm" || effectiveProto === "dmr"
+      ? C4FM_MARKERS
+      : CQPSK_MARKERS;
   }, [source, effectiveProto]);
   const optsRef = useRef<RenderOpts>({
     dcBlock,
@@ -499,7 +502,14 @@ export function Constellation() {
             </select>
             {proto === "auto" && (
               <span className="text-muted">
-                ·&nbsp;{effectiveProto === "p25-c4fm" ? "C4FM" : "CQPSK"}
+                ·&nbsp;
+                {effectiveProto === "p25-c4fm"
+                  ? "C4FM"
+                  : effectiveProto === "tetra"
+                    ? "π/4-DQPSK"
+                    : effectiveProto === "dmr"
+                      ? "4FSK"
+                      : "CQPSK"}
               </span>
             )}
           </label>


### PR DESCRIPTION
The 225 kHz floor was inherited from librtlsdr's hardware minimum, but the
config layer serves every source type: narrow single-channel captures from
wideband sources (e.g. a USRP's exact 200 MHz/1000 decimation to 200 kHz)
are legitimate and an operator's 250 kS/s TETRA run decodes fine end to end.
RTL dongles still enforce their own 225 001 Hz floor at device open, so
nothing an RTL can't do is silently accepted.

Refs the 17 Aug X310 narrow-capture session (see CLAUDE.md DSP notes).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013vPFwxSQif5KNfuehWbEs9