### PR TITLE
scanner: carry conventional channel label to scan-consumer uploads (#1105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,15 @@ for tagged releases.
   only — no code changes.
 
 ### Added
+- **Conventional scanner channels upload under their configured name.** A
+  `scanner.conventional` channel's `label:` now travels on the call grant to
+  Rdio Scanner and the other scan-type consumers (OpenMHz, Broadcastify Calls),
+  so it appears as the talkgroup label instead of the opaque positional
+  synthetic ID (`0x80000000|idx`). The per-channel label takes precedence over
+  the numeric-ID `talkgroup_file` roster lookup, so no CSV entry is needed — and
+  a pure conventional-scanner deployment with no trunked system gets readable
+  channel names too. No config changes; channels with no `label:` are unchanged
+  (issue #1105).
 - **`sdr.sidecar` mounts an external IQ producer as a virtual tuner.** A sidecar
   is any process that owns a radio and streams raw IQ over a FIFO, TCP or UDP —
   a UHD/RFNoC program, a GNU Radio flowgraph, a vendor tool with no SoapySDR

--- a/internal/broadcast/broadcast.go
+++ b/internal/broadcast/broadcast.go
@@ -186,6 +186,13 @@ func callFromEvent(cc trunking.CallComplete) *Call {
 		c.TalkgroupTag = cc.Talkgroup.Tag
 		c.TalkgroupGroup = cc.Talkgroup.Group
 	}
+	// A label carried on the grant itself (e.g. the conventional
+	// scanner's per-channel label, #1105) takes precedence over the
+	// numeric-ID roster lookup: it's the operator's explicit name for
+	// this channel and needs no talkgroup_file entry.
+	if cc.Grant.GroupLabel != "" {
+		c.TalkgroupLabel = cc.Grant.GroupLabel
+	}
 	return c
 }
 

--- a/internal/broadcast/broadcast_test.go
+++ b/internal/broadcast/broadcast_test.go
@@ -162,3 +162,38 @@ func TestCallFromEvent(t *testing.T) {
 		t.Fatalf("duration = %v, want ~3s", c.Duration())
 	}
 }
+
+// TestCallFromEventGrantLabel covers #1105: a label carried on the grant
+// itself (e.g. the conventional scanner's per-channel label) becomes the
+// upload's talkgroupLabel even when no talkgroup-roster entry exists, and
+// takes precedence over a roster entry when both are present.
+func TestCallFromEventGrantLabel(t *testing.T) {
+	// No roster entry: the synthetic conventional GID resolves to no
+	// TalkGroup, so before #1105 the label was empty. It must now come
+	// from the grant.
+	noRoster := callFromEvent(trunking.CallComplete{
+		Grant: trunking.Grant{
+			System:     "Scanner",
+			Protocol:   "fm-conv",
+			GroupID:    0x80000000,
+			GroupLabel: "KP4-DH",
+		},
+	})
+	if noRoster.TalkgroupLabel != "KP4-DH" {
+		t.Fatalf("grant label (no roster): got %q, want KP4-DH", noRoster.TalkgroupLabel)
+	}
+
+	// Roster entry present too: the per-grant label wins.
+	withRoster := callFromEvent(trunking.CallComplete{
+		Grant: trunking.Grant{
+			System:     "Scanner",
+			Protocol:   "fm-conv",
+			GroupID:    0x80000001,
+			GroupLabel: "V2M Simplex",
+		},
+		Talkgroup: &trunking.TalkGroup{ID: 0x80000001, AlphaTag: "Roster Name"},
+	})
+	if withRoster.TalkgroupLabel != "V2M Simplex" {
+		t.Fatalf("grant label (with roster): got %q, want V2M Simplex", withRoster.TalkgroupLabel)
+	}
+}

--- a/internal/scanner/conventional/scanner.go
+++ b/internal/scanner/conventional/scanner.go
@@ -564,6 +564,7 @@ func (s *Scanner) beginDwell(idx int, ch Channel, stream <-chan []complex64, str
 		System:      s.opts.SystemName,
 		Protocol:    "fm-conv",
 		GroupID:     gid,
+		GroupLabel:  ch.Label, // #1105: surface the channel's configured name to scan consumers
 		SourceID:    0,
 		FrequencyHz: ch.FrequencyHz,
 		At:          now,

--- a/internal/scanner/conventional/scanner_test.go
+++ b/internal/scanner/conventional/scanner_test.go
@@ -356,6 +356,14 @@ func TestConvScannerBreaksSquelchAndEndsOnHangtime(t *testing.T) {
 	if eng.starts[0].Protocol != "fm-conv" {
 		t.Errorf("protocol = %q, want fm-conv", eng.starts[0].Protocol)
 	}
+	// #1105: the grant carries the channel's configured label and the
+	// positional synthetic GID (channel B is index 1 -> 0x80000000|1).
+	if eng.starts[0].GroupLabel != "B" {
+		t.Errorf("group label = %q, want B", eng.starts[0].GroupLabel)
+	}
+	if eng.starts[0].GroupID != 0x80000001 {
+		t.Errorf("group id = %#x, want 0x80000001", eng.starts[0].GroupID)
+	}
 }
 
 // TestConvScannerBriefBlipsDoNotHoldSquelchOpen is the regression for

--- a/internal/trunking/grant.go
+++ b/internal/trunking/grant.go
@@ -14,9 +14,19 @@ import (
 // IdentifierUpdate band-plan TSBKs, DMR/NXDN from the configured System).
 // If FrequencyHz is zero, the engine logs and drops the grant.
 type Grant struct {
-	System      string // System name, matches trunking.System.Name
-	Protocol    string // "p25" / "dmr" / "nxdn"
-	GroupID     uint32 // talkgroup or destination subscriber address
+	System   string // System name, matches trunking.System.Name
+	Protocol string // "p25" / "dmr" / "nxdn"
+	GroupID  uint32 // talkgroup or destination subscriber address
+	// GroupLabel is an optional human-readable name for the call's
+	// talkgroup/destination, set at grant time by sources that already
+	// know it (e.g. the conventional scanner's per-channel label, issue
+	// #1105). When non-empty it takes precedence over the numeric-ID
+	// talkgroup-roster lookup on the broadcast/upload path, so a
+	// conventional channel surfaces under its configured label instead
+	// of the opaque synthetic 0x80000000|idx GroupID in Rdio Scanner and
+	// other scan-type consumers. Empty on grants whose label (if any)
+	// comes only from the roster.
+	GroupLabel  string
 	SourceID    uint32 // originator (subscriber unit)
 	FrequencyHz uint32 // voice channel frequency
 	ChannelID   uint8  // raw channel ID (P25 band-plan ID, DMR LCN high)


### PR DESCRIPTION
## Summary

Conventional (`fm-conv`) scanner channels uploaded to Rdio Scanner and the other scan-type consumers (OpenMHz, Broadcastify Calls) under only the opaque positional synthetic talkgroup ID `0x80000000|idx`, with no name — so multi-channel conventional setups showed generic 10-digit numbers instead of recognizable channel names. This threads the per-channel `label:` through to those uploads (issue #1105, proposed direction 1).

## Changes

- **`internal/trunking/grant.go`** — add an optional `GroupLabel string` field to `trunking.Grant`. It travels whole on the `CallStart`/`CallComplete` events, so no extra plumbing is needed to reach the broadcast path.
- **`internal/scanner/conventional/scanner.go`** — populate `GroupLabel` from `ch.Label` in `beginDwell` when synthesizing the grant.
- **`internal/broadcast/broadcast.go`** — in `callFromEvent`, a non-empty `Grant.GroupLabel` sets `TalkgroupLabel`, taking precedence over the numeric-ID `talkgroup_file` roster lookup. No roster/CSV entry is required, and a pure conventional-scanner deployment (no trunked system) now gets readable names too.
- **Tests** — `TestCallFromEventGrantLabel` (grant label wins with and without a roster entry) and extended conventional-scanner assertions (`GroupLabel == ch.Label`, synthetic GID). Both fail against the pre-change code.
- **`CHANGELOG.md`** — `## [Unreleased]` → `### Added` bullet.

## Test plan

- [x] `make vet test` is green locally
- [ ] `make integration` is green locally (if the change touches the daemon) — n/a, no daemon/DSP/replay path touched
- [x] Added or updated tests where appropriate
- [ ] Smoke-tested against real hardware — n/a (no SDR/USB/vocoder code changed). Reporter (v2maldo) offered to test against their KP4-DH / V2M Simplex conventional channels once there's a build.

## Breaking changes

None. `GroupLabel` is a new optional field, empty on every existing grant path; a channel with no `label:` behaves exactly as before. Only the label shown in scan-consumer UIs changes, and only for conventional channels that set a label.

## Docs / CHANGELOG

- [x] Added a `## [Unreleased]` bullet to `CHANGELOG.md`
- [ ] Updated `README.md` / `docs/` — n/a; the `scanner.conventional[].label` config key already exists and is documented, this just extends where its value is used.

## Linked issues

Refs #1105

<!-- Note on scope: this is direction (1) from the issue — the "generic number with no name" fix. The synthetic-ID stability directions (2) an explicit `talkgroup_id:` override and (3) a hashed stable ID are deliberately left out; they address the separate CSV-roster fragility and can follow if the operator wants durable per-channel roster metadata. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QenGtbo5sD3nV3SicFSFVb)_