### PR TITLE
tetra: escape a wrong AFC alias latch instead of rejecting the truth forever

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -576,7 +576,50 @@ confirmation before any close-as-completed.
   distinct per-carrier phases (−157°/−87°/+20°) but the camped CC carries 71–94% of the
   cross-power so the scalar aligns it — and MRC on a 9 dB-down floor-limited branch is ~no-gain
   either way (the honest fix for run1/run2 is raising branch 0's gain, which run3 proved).
-- **A WebSocket handler that upgrades before validating cannot be backed off from.** The
+- **19 Aug X310 field log (10.5 h) — three verified failure modes, all fixed; and the real MRC
+  bottleneck on this rig turned out to be an INTER-BRANCH TIMING SKEW, now aligned in the
+  driver.** The operator swapped the antennas between RX1/RX2 mid-run: the ~5–10 dB branch
+  deficit FOLLOWED the swap ⇒ antenna/feedline, not the TwinRX. Findings, each with a
+  failing-first regression:
+  - **TETRA CC "locked but deaf" ~37 min total (12 min in one stretch, log ends in it): the
+    AFC's EMA can latch the wrong ±f_sym/4 alias bucket.** A decode-drought resync re-primes
+    `omegaEMA` from ONE weak block; `omegaAliasReject` (π/4 = 2250 Hz) then discards every
+    CORRECT estimate forever. BSCH survives the constant ~17°/sym residual (4-rotation search +
+    heavy FEC) while all SCH fails ⇒ `bsch_ok` ~100%, `sch_pdus=0` — and every BSCH stamps the
+    ONE activity heartbeat both the 1.5 s resync and 5 s CheckStale feed on, so no recovery
+    could fire (the #815 WARN is advisory). Fixes: (1) `carrierAFC.track` re-primes after 3
+    consecutive rejects that agree with each other (`afc_reprime_test.go`); (2) a second
+    payload heartbeat (`LastPayloadNano`, stamped on CRC-clean SCH/F, SCH/HD, or the SB's
+    SCH/HD-coded BNCH) drives `checkPayloadResync`: 12 s of signal with a live lock and no
+    payload forces a resync, 3 fruitless resyncs escalate to `MarkLost` → re-hunt (mirrored in
+    `widebandt2/tetra.go`). Also: a single mis-corrected BSCH could rewrite the locked MCC/MNC
+    (4 bogus "tetra cc locked" flaps, mcc=996 etc.) — identity CHANGES now need 2 consecutive
+    agreeing decodes, mirroring `colourConfirmThreshold`.
+  - **The MRC anchor flipped mid-stream on the 08:58 cc-hunt retune** (rearm set `refIdx=-1` →
+    bare argmax re-pick), and the applied gain random-walked to −34 dB with `calibrated=true`
+    (divergence bounds gated only the proposal). Fixes: rearm/`setSampleRate`/short-payloads
+    KEEP the anchor (dead-incumbent escape still works), every anchor change is logged,
+    `SetCenterFreq` short-circuits same-frequency retunes, and `clampMagnitude` floors the
+    APPLIED gain (smoothed branch only — the snap/mrc-static equivalence pin is untouched).
+    Differential safety is now also pinned at the driver's real α=0.1024 (200 kHz clamped
+    window; the τ comment claimed windows ≪ a burst — false at low rates, corrected).
+  - **The replay harness's "tracking" arms were silently STATIC** (`TrackingOptions{Alpha: 0}`
+    = one-shot), so the 17/18 Aug "tracking matches best branch" verdicts compared static to
+    static. Arms now derive α like `mrcTrackAlpha` and fatal on α=0.
+  - **The big one: branch 0 lagged branch 1 by a CONSTANT 2.60 samples (13 µs at 200 kS/s).**
+    Per-frequency coherence 0.99 with broadband ρ diluted to 0.78 is the signature of a pure
+    delay — it is why this rig's wideband coherence never exceeded ~0.8 in ANY session. A
+    scalar gain cannot represent a delay, so combining skewed branches decoded 22% FEWER BSCH
+    than the best branch alone (886 vs 1142 on the 19 Aug capture) — MRC was HURTING; the
+    identical combine after alignment scored exactly 1142/0. `soapyremote.branchAligner` now
+    measures the skew per stream/retune (0.65 s buffer, ±16-lag scan + parabolic fraction,
+    DC-removed, ρ≥0.1 latch gate) and delays the EARLY branch through an interpolating delay
+    line, resetting the calibrator on latch so it locks on the aligned stream. The harness
+    measures/reports the skew and carries a `wb-aligned-static` arm. Diagnose with
+    `TestDiversityCombinerReplay`: "inter-branch delay: other lags ref by N±f samples".
+    Open question for the next capture: whether the skew is per-stream (start skew) or fixed
+    (DDC group delay) — the aligner re-measures per stream either way. A post-fix long run
+    from the operator is still the on-air gate (#764/#771 discipline). The
   symbol/spectrum/diag/mixer handlers resolved the SDR serial AFTER `upgrader.Upgrade`, so an
   unknown device produced a successful 101 followed by a 1011 close. Browser clients reset
   their reconnect backoff in `onopen`, so a handshake that always succeeds makes `MAX_BACKOFF`

--- a/cmd/gophertrunk/diversity_replay_test.go
+++ b/cmd/gophertrunk/diversity_replay_test.go
@@ -49,11 +49,15 @@ type diversityCaptureMeta struct {
 //     the frozen constant was fine on this hardware and mrc-static is correct;
 //     walking phase gives the drift rate in degrees per second.
 //
-//  2. FOUR DECODE ARMS through identical downstream wiring — branch 0 alone,
-//     branch 1 alone, static combine, tracking combine — scored by CRC-clean
-//     BSCH count. Decode yield is the verdict, never EVM: a combiner can improve
-//     a constellation's look while decoding nothing, which this repo has
-//     measured before.
+//  2. EIGHT DECODE ARMS through identical downstream wiring — each branch
+//     alone, wideband static / tracking / blind-IRC combines, per-channel
+//     narrowband static / tracking combines, and a narrowband single-branch
+//     baseline — scored by CRC-clean BSCH count. Decode yield is the verdict,
+//     never EVM: a combiner can improve a constellation's look while decoding
+//     nothing, which this repo has measured before. The tracking arms pass the
+//     driver-derived alpha EXPLICITLY: TrackingOptions{Alpha: 0} means
+//     one-shot, so an omitted alpha silently measures static (which is what
+//     the 17/18 Aug 2026 A/B "tracking" verdicts actually did).
 //
 // GT_DIVERSITY_TUNE_HZ offsets the down-conversion onto the control channel.
 // Assertions are deliberately weak — this is a measurement instrument, and the
@@ -221,6 +225,42 @@ func TestDiversityCombinerReplay(t *testing.T) {
 	t.Logf("driver-equivalent coherence gates at this rate (%d-sample windows): lock >= %.3f, track >= %.3f",
 		window, diversity.TrackingOptions{}.LockGate(window), diversity.TrackingOptions{}.TrackGate(window))
 
+	// The tracking arms MUST pass the driver-derived alpha explicitly: a
+	// TrackingOptions with Alpha left at zero is ONE-SHOT (withDefaults keeps 0
+	// as the mrc-static freeze), so an "Alpha omitted" tracking arm silently
+	// measures static — which is exactly what the 17/18 Aug A/B verdicts did.
+	// Mirror of soapyremote's mrcTrackAlpha: actual window duration over the
+	// 200 ms tau.
+	const trackTauMs = 200.0
+	wbAlpha := float64(window) / meta.SampleRateHz * 1000 / trackTauMs
+	nbAlpha := float64(nbWindow) / nbRate * 1000 / trackTauMs
+	if wbAlpha <= 0 || nbAlpha <= 0 {
+		t.Fatalf("derived tracking alphas wb=%g nb=%g — zero would silently freeze the tracking arms into static", wbAlpha, nbAlpha)
+	}
+	if wbAlpha > 1 {
+		wbAlpha = 1
+	}
+	if nbAlpha > 1 {
+		nbAlpha = 1
+	}
+	t.Logf("tracking-arm alphas (tau %.0f ms): wb=%.4f nb=%.4f", trackTauMs, wbAlpha, nbAlpha)
+
+	// ---- Inter-branch timing skew ------------------------------------------
+	// A scalar MRC weight assumes the branches are TIME-ALIGNED. A constant
+	// inter-branch delay (start-of-stream skew, differing DDC group delay)
+	// makes the sum a comb filter: band-average power still looks fine, the
+	// per-frequency coherence is high, but the broadband |rho| is diluted and
+	// the combined SYMBOLS are smeared — on the 19 Aug 2026 X310 capture a
+	// 2.65-sample skew cost every combined arm ~22% of its CRC-clean BSCH
+	// versus the best branch alone. Measure it, report it, and run an aligned
+	// arm so the recoverable gain is a number instead of a suspicion.
+	lag, lagRho := interBranchLagSamples(wbRef, wbOther)
+	frac := interBranchFractionalDelay(wbRef, wbOther, lag, meta.SampleRateHz)
+	t.Logf("inter-branch delay: other lags ref by %d%+.2f samples (peak |rho|=%.3f at the integer lag) — "+
+		"a scalar combiner cannot represent a delay; wb-aligned-static shows what alignment recovers",
+		lag, frac, lagRho)
+	wbOtherAligned := shiftBranchFractional(wbOther, lag, frac)
+
 	// Wideband arms are combined then down-converted; narrowband arms are
 	// down-converted per branch and combined at the channel rate. Both are
 	// scored by the identical decoder so the combiner is the only variable.
@@ -236,7 +276,7 @@ func TestDiversityCombinerReplay(t *testing.T) {
 			diversity.NewTrackingCalibrator(2, diversity.TrackingOptions{WindowSamples: window, Alpha: 0})),
 			meta.SampleRateHz, tuneHz},
 		{"wb-tracking", combineWith(t, wbRef, wbOther,
-			diversity.NewTrackingCalibrator(2, diversity.TrackingOptions{WindowSamples: window})),
+			diversity.NewTrackingCalibrator(2, diversity.TrackingOptions{WindowSamples: window, Alpha: wbAlpha})),
 			meta.SampleRateHz, tuneHz},
 		// Blind IRC on the wideband stream. Expected to measure the same as
 		// wb-tracking: without a training sequence the channel estimate is a
@@ -244,7 +284,13 @@ func TestDiversityCombinerReplay(t *testing.T) {
 		// steered at a mixture (see internal/dsp/diversity/irc.go). Carried as
 		// an arm so that claim is checked against real air rather than assumed.
 		{"wb-irc-blind", combineWith(t, wbRef, wbOther,
-			diversity.NewIRCCalibrator(2, diversity.TrackingOptions{WindowSamples: window})),
+			diversity.NewIRCCalibrator(2, diversity.TrackingOptions{WindowSamples: window, Alpha: wbAlpha})),
+			meta.SampleRateHz, tuneHz},
+		// Static combine with the measured inter-branch delay removed first.
+		// The one new variable versus wb-static is the alignment, so the score
+		// difference IS the cost of the skew.
+		{"wb-aligned-static", combineWith(t, wbRef, wbOtherAligned,
+			diversity.NewTrackingCalibrator(2, diversity.TrackingOptions{WindowSamples: window, Alpha: 0})),
 			meta.SampleRateHz, tuneHz},
 		// The arms that matter for the wideband-limitation question: one gain
 		// per narrowband channel instead of one for the whole span.
@@ -252,7 +298,7 @@ func TestDiversityCombinerReplay(t *testing.T) {
 			diversity.NewTrackingCalibrator(2, diversity.TrackingOptions{WindowSamples: nbWindow, Alpha: 0})),
 			nbRate, 0},
 		{"nb-tracking", combineWith(t, nbRef, nbOther,
-			diversity.NewTrackingCalibrator(2, diversity.TrackingOptions{WindowSamples: nbWindow})),
+			diversity.NewTrackingCalibrator(2, diversity.TrackingOptions{WindowSamples: nbWindow, Alpha: nbAlpha})),
 			nbRate, 0},
 		{"nb-branch0-only", nb0, nbRate, 0},
 	}
@@ -291,6 +337,110 @@ func TestDiversityCombinerReplay(t *testing.T) {
 type windowedCalibrator interface {
 	Observe(branches [][]complex64) diversity.ObserveResult
 	Combine(branches [][]complex64) ([]complex64, error)
+}
+
+// interBranchLagSamples scans integer lags for the delay of `other` relative
+// to `ref` (positive = other lags), returning the |rho|-maximising lag. Uses
+// the first ~5 s so a 30 s capture stays cheap; a start-of-stream or DDC group
+// delay skew is constant, so any span measures it.
+func interBranchLagSamples(ref, other []complex64) (bestLag int, bestRho float64) {
+	n := len(ref)
+	if len(other) < n {
+		n = len(other)
+	}
+	if n > 1<<20 {
+		n = 1 << 20
+	}
+	r, o := ref[:n], other[:n]
+	var pr, po float64
+	for i := 0; i < n; i++ {
+		pr += float64(real(r[i]))*float64(real(r[i])) + float64(imag(r[i]))*float64(imag(r[i]))
+		po += float64(real(o[i]))*float64(real(o[i])) + float64(imag(o[i]))*float64(imag(o[i]))
+	}
+	norm := math.Sqrt(pr * po)
+	if norm == 0 {
+		return 0, 0
+	}
+	const maxLag = 16
+	for lag := -maxLag; lag <= maxLag; lag++ {
+		var cr, ci float64
+		for i := 0; i < n-maxLag; i++ {
+			var a, b complex64
+			if lag >= 0 {
+				a, b = r[i], o[i+lag]
+			} else {
+				a, b = r[i-lag], o[i]
+			}
+			// conj(a)·b
+			cr += float64(real(a))*float64(real(b)) + float64(imag(a))*float64(imag(b))
+			ci += float64(real(a))*float64(imag(b)) - float64(imag(a))*float64(real(b))
+		}
+		if rho := math.Hypot(cr, ci) / norm; rho > bestRho {
+			bestRho, bestLag = rho, lag
+		}
+	}
+	return bestLag, bestRho
+}
+
+// interBranchFractionalDelay refines the integer lag with the residual
+// fractional delay, estimated from the cross-correlation magnitudes at the
+// neighbouring lags via parabolic interpolation. rateHz is unused beyond
+// documentation; the return is in samples, in (-1, 1).
+func interBranchFractionalDelay(ref, other []complex64, lag int, _ float64) float64 {
+	rhoAt := func(l int) float64 {
+		n := len(ref)
+		if len(other) < n {
+			n = len(other)
+		}
+		if n > 1<<20 {
+			n = 1 << 20
+		}
+		var cr, ci float64
+		const guard = 20
+		for i := 0; i < n-guard; i++ {
+			var a, b complex64
+			if l >= 0 {
+				a, b = ref[i], other[i+l]
+			} else {
+				a, b = ref[i-l], other[i]
+			}
+			cr += float64(real(a))*float64(real(b)) + float64(imag(a))*float64(imag(b))
+			ci += float64(real(a))*float64(imag(b)) - float64(imag(a))*float64(real(b))
+		}
+		return math.Hypot(cr, ci)
+	}
+	ym, y0, yp := rhoAt(lag-1), rhoAt(lag), rhoAt(lag+1)
+	den := ym - 2*y0 + yp
+	if den == 0 {
+		return 0
+	}
+	f := 0.5 * (ym - yp) / den
+	if f > 0.99 || f < -0.99 || math.IsNaN(f) {
+		return 0
+	}
+	return f
+}
+
+// shiftBranchFractional advances `x` by lag+frac samples (positive = x lagged
+// and is pulled earlier), using linear interpolation for the fractional part —
+// adequate here because the channel occupies ≲6% of the stream rate. The
+// result keeps len(x); the tail is zero-padded.
+func shiftBranchFractional(x []complex64, lag int, frac float64) []complex64 {
+	out := make([]complex64, len(x))
+	f := float32(frac)
+	for i := range out {
+		j := i + lag
+		if f >= 0 {
+			if j >= 0 && j+1 < len(x) {
+				out[i] = x[j]*(1-complex(f, 0)) + x[j+1]*complex(f, 0)
+			}
+		} else {
+			if j-1 >= 0 && j < len(x) {
+				out[i] = x[j]*(1+complex(f, 0)) - x[j-1]*complex(f, 0)
+			}
+		}
+	}
+	return out
 }
 
 func combineWith(t *testing.T, br0, br1 []complex64, cal windowedCalibrator) []complex64 {

--- a/internal/dsp/diversity/tracking.go
+++ b/internal/dsp/diversity/tracking.go
@@ -302,7 +302,15 @@ func (c *TrackingCalibrator) estimate() bool {
 			continue
 		}
 		target := smoothGain(c.applied[k], proposed[k], c.opts.Alpha)
-		c.applied[k] = clampStep(c.applied[k], target)
+		// The divergence bounds at line ~284 gate only the per-window PROPOSAL;
+		// the smoothed APPLIED gain is a vector blend, so a run of proposals with
+		// adverse phase can random-walk its magnitude toward zero even though
+		// every proposal was in-bounds (a 19 Aug field log showed the applied
+		// weight at −34 dB with calibrated=true — the combiner had silently
+		// degenerated to single-branch). Clamp the applied magnitude into the
+		// same bounds, preserving phase; the floor deliberately overrides the
+		// per-step ratio clamp when recovering from below it.
+		c.applied[k] = clampMagnitude(clampStep(c.applied[k], target))
 	}
 	for k := 0; k < c.branches; k++ {
 		c.mrc.SetGain(k, c.applied[k])
@@ -382,6 +390,30 @@ func smoothGain(cur, target complex64, a float64) complex64 {
 		real(cur)*(1-ar)+real(target)*ar,
 		imag(cur)*(1-ar)+imag(target)*ar,
 	)
+}
+
+// clampMagnitude bounds |h| into the divergence window
+// [√trackingDivergeFloorSq, √trackingDivergeCeilSq] (±30.1 dB), preserving
+// phase. Applied to the smoothed gain only — the snap path stays bit-identical
+// to a one-shot least-squares calibration (whose proposal already passed
+// finiteWithin).
+func clampMagnitude(h complex64) complex64 {
+	magSq := float64(real(h))*float64(real(h)) + float64(imag(h))*float64(imag(h))
+	if magSq >= trackingDivergeFloorSq && magSq <= trackingDivergeCeilSq {
+		return h
+	}
+	mag := math.Sqrt(magSq)
+	if mag == 0 {
+		// No phase to preserve; seed at the floor on the real axis so the next
+		// smoothed update can move it.
+		return complex(float32(math.Sqrt(trackingDivergeFloorSq)), 0)
+	}
+	want := math.Sqrt(trackingDivergeFloorSq)
+	if magSq > trackingDivergeCeilSq {
+		want = math.Sqrt(trackingDivergeCeilSq)
+	}
+	s := float32(want / mag)
+	return complex(real(h)*s, imag(h)*s)
 }
 
 // clampStep bounds how far one update may move the applied gain: at most

--- a/internal/dsp/diversity/tracking_floor_test.go
+++ b/internal/dsp/diversity/tracking_floor_test.go
@@ -1,0 +1,51 @@
+package diversity
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+)
+
+// TestTrackingAppliedGainMagnitudeFloor is the regression for the 19 Aug field
+// log's branch_gain_db=-34.3 with calibrated=true: the divergence bounds gate
+// only the per-window PROPOSAL, while the smoothed APPLIED gain is a vector
+// blend that can random-walk its magnitude below the -30 dB floor — at which
+// point the second branch contributes nothing and the combiner has silently
+// degenerated to single-branch. The applied gain must never sit below the
+// divergence floor after an accepted update (and never above the ceiling).
+func TestTrackingAppliedGainMagnitudeFloor(t *testing.T) {
+	const window = 4096
+	rng := rand.New(rand.NewSource(505))
+	ref := genSignal(rng, window)
+	x := addNoise(rng, rotate(ref, 0.4), 0.2)
+
+	c := NewTrackingCalibrator(2, TrackingOptions{WindowSamples: window, Alpha: 0.2})
+	c.Observe([][]complex64{ref, x})
+	if !c.Calibrated() {
+		t.Fatal("did not calibrate on clean data")
+	}
+
+	// Poison the applied weight to -40 dB — the state a long adverse-phase
+	// random walk reaches — keeping its phase.
+	ph := math.Atan2(float64(imag(c.applied[1])), float64(real(c.applied[1])))
+	c.applied[1] = complex(float32(0.01*math.Cos(ph)), float32(0.01*math.Sin(ph)))
+
+	// One accepted good window must pull it back inside the divergence bounds
+	// immediately — the floor overrides the per-step ratio clamp, which alone
+	// would need many windows to climb 10 dB.
+	ref2 := genSignal(rng, window)
+	x2 := addNoise(rng, rotate(ref2, 0.4), 0.2)
+	res := c.Observe([][]complex64{ref2, x2})
+	if !res.Updated {
+		t.Fatal("clean window was not accepted")
+	}
+	g := c.Gains()[1]
+	magSq := float64(real(g))*float64(real(g)) + float64(imag(g))*float64(imag(g))
+	if magSq < trackingDivergeFloorSq {
+		t.Errorf("applied |gain| = %.1f dB after an accepted update, want >= %.1f dB (the divergence floor)",
+			10*math.Log10(magSq), 10*math.Log10(trackingDivergeFloorSq))
+	}
+	if magSq > trackingDivergeCeilSq {
+		t.Errorf("applied |gain| = %.1f dB above the divergence ceiling", 10*math.Log10(magSq))
+	}
+}

--- a/internal/dsp/diversity/tracking_test.go
+++ b/internal/dsp/diversity/tracking_test.go
@@ -214,35 +214,51 @@ func TestTrackingGatesScaleWithWindow(t *testing.T) {
 // reference branch by h_0 == 1, so a weight update may only perturb it by the
 // (damped, clamped) estimate error.
 func TestTrackingCalibratorIsDifferentialSafe(t *testing.T) {
-	const n = 1 << 18
-	const window = 4096
-	rng := rand.New(rand.NewSource(202))
-	ref := genSignal(rng, n)
-	// Constant channel: any residual output-phase motion is the loop's own.
-	x := addNoise(rng, rotate(ref, 1.05), 0.3)
-	refN := addNoise(rng, ref, 0.3)
-
-	c := NewTrackingCalibrator(2, TrackingOptions{WindowSamples: window, Alpha: TrackingDefaultAlpha})
-	y := feed(t, c, refN, x, window)
-
-	// Per-window residual phase relative to the reference branch. The step
-	// between consecutive windows is what a differential decode actually sees.
-	var prev float64
-	var maxStep float64
-	first := true
-	for i := window * 2; i+window <= n; i += window { // skip the lock window
-		cur := residualPhaseDeg(y[i:i+window], refN[i:i+window])
-		if !first {
-			if d := math.Abs(cur - prev); d > maxStep {
-				maxStep = d
-			}
-		}
-		prev, first = cur, false
+	// The soapyremote driver derives alpha from the ACTUAL window duration
+	// against a 200 ms tau (mrcTrackAlpha; this package cannot import the
+	// driver). At a 200 kHz stream the window clamps to 4096 samples = 20.48 ms
+	// ⇒ alpha = 0.1024 — 10× the package default, and the alpha the 19 Aug
+	// field run actually ran. Differential safety must hold at both.
+	cases := []struct {
+		name  string
+		alpha float64
+	}{
+		{"defaultAlpha", TrackingDefaultAlpha},
+		{"driver200kHzAlpha", 0.1024},
 	}
-	// pi/4-DQPSK decisions are 45° apart. Anything approaching a degree here
-	// would already be suspicious; the design budget is hundredths.
-	if maxStep > 1.0 {
-		t.Errorf("max per-window output phase step %.3f°, want <=1° (45° decision spacing)", maxStep)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			const n = 1 << 18
+			const window = 4096
+			rng := rand.New(rand.NewSource(202))
+			ref := genSignal(rng, n)
+			// Constant channel: any residual output-phase motion is the loop's own.
+			x := addNoise(rng, rotate(ref, 1.05), 0.3)
+			refN := addNoise(rng, ref, 0.3)
+
+			c := NewTrackingCalibrator(2, TrackingOptions{WindowSamples: window, Alpha: tc.alpha})
+			y := feed(t, c, refN, x, window)
+
+			// Per-window residual phase relative to the reference branch. The step
+			// between consecutive windows is what a differential decode actually sees.
+			var prev float64
+			var maxStep float64
+			first := true
+			for i := window * 2; i+window <= n; i += window { // skip the lock window
+				cur := residualPhaseDeg(y[i:i+window], refN[i:i+window])
+				if !first {
+					if d := math.Abs(cur - prev); d > maxStep {
+						maxStep = d
+					}
+				}
+				prev, first = cur, false
+			}
+			// pi/4-DQPSK decisions are 45° apart. Anything approaching a degree here
+			// would already be suspicious; the design budget is hundredths.
+			if maxStep > 1.0 {
+				t.Errorf("alpha=%g: max per-window output phase step %.3f°, want <=1° (45° decision spacing)", tc.alpha, maxStep)
+			}
+		})
 	}
 }
 

--- a/internal/radio/tetra/control.go
+++ b/internal/radio/tetra/control.go
@@ -94,6 +94,15 @@ type ControlChannel struct {
 	// one crosses colourConfirmThreshold. See LearnColourCode.
 	colourConfirmed bool
 	colourTally     map[uint32]int
+	// pendingLock/pendingLockVotes gate an identity CHANGE on an already-locked
+	// channel behind lockIdentityConfirmThreshold consecutive agreeing BSCH
+	// decodes, exactly like the colour code's confirmation above: BSCH FEC can
+	// mis-correct a marginal burst to a valid-but-wrong codeword, and a single
+	// such burst used to rewrite MCC/MNC/LA wholesale, publish cc.locked and
+	// push a bogus site identity (19 Aug field log: four one-burst flaps to
+	// mcc=996/mnc=3941 and friends). See maybeLock.
+	pendingLock      LockState
+	pendingLockVotes int
 	// mainCarrier is the cell's own carrier number, learned from the
 	// broadcast SYSINFO. With the tuned control-channel frequency it lets a
 	// grant's carrier number resolve to Hz relative to this carrier, without a
@@ -1193,10 +1202,20 @@ func (c *ControlChannel) LastActivityNano() int64 {
 	return c.lastActivityNano.Load()
 }
 
+// lockIdentityConfirmThreshold is how many CONSECUTIVE BSCH decodes must agree
+// on a changed cell identity before an already-locked channel adopts it. Same
+// rationale as colourConfirmThreshold: the BSCH FEC can mis-correct a marginal
+// burst to a valid-but-wrong codeword, and MCC/MNC come from the same 60-bit
+// payload — one such burst must not rewrite the site identity. The first lock
+// stays immediate (there is nothing to protect yet), and a genuine identity
+// change (e.g. an LA rehome) confirms in ~2 s at the ~1/s BSCH cadence.
+const lockIdentityConfirmThreshold = 2
+
 func (c *ControlChannel) maybeLock(s LockState) {
 	c.noteActivity()
 	c.mu.Lock()
 	if c.locked && c.last == s {
+		c.pendingLockVotes = 0 // agreement with the active identity breaks any pending streak
 		c.mu.Unlock()
 		return
 	}
@@ -1206,9 +1225,28 @@ func (c *ControlChannel) maybeLock(s LockState) {
 		s.MNC = c.last.MNC
 		s.LocationArea = c.last.LocationArea
 		if c.last == s {
+			c.pendingLockVotes = 0
 			c.mu.Unlock()
 			return
 		}
+	}
+	// An identity CHANGE on a locked channel needs consecutive corroboration;
+	// a single CRC-passing but FEC-mis-corrected BSCH must not rewrite it.
+	if c.locked {
+		if c.pendingLock == s && c.pendingLockVotes > 0 {
+			c.pendingLockVotes++
+		} else {
+			c.pendingLock = s
+			c.pendingLockVotes = 1
+		}
+		if c.pendingLockVotes < lockIdentityConfirmThreshold {
+			c.log.Debug("tetra: cc identity change pending confirmation",
+				"freq", s.FrequencyHz, "mcc", s.MCC, "mnc", s.MNC, "la", s.LocationArea,
+				"active_mcc", c.last.MCC, "active_mnc", c.last.MNC, "system", c.systemName)
+			c.mu.Unlock()
+			return
+		}
+		c.pendingLockVotes = 0
 	}
 	c.locked = true
 	c.last = s
@@ -1236,6 +1274,9 @@ func (c *ControlChannel) MarkLost() {
 		return
 	}
 	c.locked = false
+	// A stale pending identity must not corroborate a burst decoded after the
+	// loss; a fresh first lock adopts immediately anyway.
+	c.pendingLockVotes = 0
 	c.bus.Publish(events.Event{Kind: events.KindCCLost, Payload: c.last})
 }
 

--- a/internal/radio/tetra/control.go
+++ b/internal/radio/tetra/control.go
@@ -174,6 +174,18 @@ type ControlChannel struct {
 	// lost when the carrier goes silent. Atomic so the decode hot path
 	// (noteActivity) never contends on mu. Zero until the first decode.
 	lastActivityNano atomic.Int64
+
+	// lastPayloadNano is the Unix-nanos timestamp of the most recent CRC-clean
+	// SCH payload block (SCH/F or SCH/HD, including the sync burst's BNCH) — a
+	// SECOND, stricter heartbeat alongside lastActivityNano. The distinction
+	// matters because the two decode chains fail independently: the SB burst's
+	// BSCH survives a wrong AFC alias latch (4-rotation search + heavy FEC)
+	// while every SCH block fails CRC, so a channel can look "alive" to
+	// lastActivityNano for minutes while decoding nothing useful (the 19 Aug
+	// field log: bsch_ok ~100%, sch_pdus=0 for 12 min). The pipeline's
+	// payload-drought check watches this stamp to force a resync/re-hunt out
+	// of that state. Zero until the first payload decode.
+	lastPayloadNano atomic.Int64
 }
 
 // StashSoft records the soft per-symbol differentials for the dibit
@@ -1110,6 +1122,24 @@ func (c *ControlChannel) publishTalker(gssi, src uint32) {
 // Lock-free (atomic) so it adds no contention to the hot path.
 func (c *ControlChannel) noteActivity() {
 	c.lastActivityNano.Store(c.now().UnixNano())
+}
+
+// notePayloadActivity stamps the payload heartbeat: a CRC-clean SCH block
+// proves the whole SCH decode chain (AFC residual, colour code, FEC, CRC) is
+// healthy, which a surviving BSCH alone does not (see lastPayloadNano). A
+// payload decode is also ordinary activity, so the plain heartbeat is stamped
+// too.
+func (c *ControlChannel) notePayloadActivity() {
+	c.lastPayloadNano.Store(c.now().UnixNano())
+	c.noteActivity()
+}
+
+// LastPayloadNano returns the Unix-nano timestamp of the most recent
+// CRC-clean SCH payload decode, or 0 before the first. A lock-free atomic
+// read for the pipeline's payload-drought check (the "locked but deaf"
+// escape: sync bursts decoding, zero SCH for a long budget).
+func (c *ControlChannel) LastPayloadNano() int64 {
+	return c.lastPayloadNano.Load()
 }
 
 // CheckStale declares the control channel lost (publishes cc.lost via MarkLost)

--- a/internal/radio/tetra/control_lock_identity_test.go
+++ b/internal/radio/tetra/control_lock_identity_test.go
@@ -1,0 +1,145 @@
+package tetra
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// lockStateOf reads the active lock identity under the mutex (in-package).
+func lockStateOf(c *ControlChannel) LockState {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.last
+}
+
+// drainLockEvents returns the KindCCLocked payloads currently queued.
+func drainLockEvents(sub *events.Subscription) []LockState {
+	var got []LockState
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindCCLocked {
+				if s, ok := ev.Payload.(LockState); ok {
+					got = append(got, s)
+				}
+			}
+		default:
+			return got
+		}
+	}
+}
+
+// TestMaybeLockSingleBogusBSCHDoesNotRewriteIdentity is the regression for the
+// 19 Aug field flaps: a single CRC-passing but FEC-mis-corrected BSCH carried
+// a garbage identity (mcc=996 mnc=3941) and rewrote the locked site identity
+// wholesale — publishing a bogus cc.locked and site update, corrected only by
+// the next good burst. One differing burst must not change anything; neither
+// must a different bogus burst later (votes are consecutive).
+func TestMaybeLockSingleBogusBSCHDoesNotRewriteIdentity(t *testing.T) {
+	cc, bus := debugCC(t, io.Discard, slog.LevelInfo)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	a := LockState{FrequencyHz: 412_000_000, MCC: 250, MNC: 13}
+	cc.maybeLock(a)
+	if got := drainLockEvents(sub); len(got) != 1 || got[0] != a {
+		t.Fatalf("first lock: got events %v, want exactly [%v]", got, a)
+	}
+
+	// One bogus burst: no event, identity unchanged.
+	b := LockState{FrequencyHz: 412_000_000, MCC: 996, MNC: 3941, LocationArea: 13121}
+	cc.maybeLock(b)
+	if got := drainLockEvents(sub); len(got) != 0 {
+		t.Fatalf("single bogus BSCH published cc.locked: %v", got)
+	}
+	if lockStateOf(cc) != a {
+		t.Fatalf("single bogus BSCH rewrote the identity: %+v", lockStateOf(cc))
+	}
+
+	// The real identity resumes, then a DIFFERENT bogus burst appears once:
+	// the earlier bogus vote must not corroborate it.
+	cc.maybeLock(a)
+	c2 := LockState{FrequencyHz: 412_000_000, MCC: 88, MNC: 4698}
+	cc.maybeLock(c2)
+	if got := drainLockEvents(sub); len(got) != 0 {
+		t.Fatalf("scattered bogus BSCHs published cc.locked: %v", got)
+	}
+	if lockStateOf(cc) != a {
+		t.Fatalf("scattered bogus BSCHs rewrote the identity: %+v", lockStateOf(cc))
+	}
+}
+
+// TestMaybeLockIdentityChangeConfirmsOnSecondAgreeingBSCH pins that a GENUINE
+// identity change (two consecutive agreeing bursts, e.g. an LA rehome) is
+// adopted and published exactly once.
+func TestMaybeLockIdentityChangeConfirmsOnSecondAgreeingBSCH(t *testing.T) {
+	cc, bus := debugCC(t, io.Discard, slog.LevelInfo)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	a := LockState{FrequencyHz: 412_000_000, MCC: 250, MNC: 13}
+	b := LockState{FrequencyHz: 412_000_000, MCC: 250, MNC: 13, LocationArea: 7}
+	cc.maybeLock(a)
+	drainLockEvents(sub)
+
+	cc.maybeLock(b)
+	cc.maybeLock(b)
+	if got := drainLockEvents(sub); len(got) != 1 || got[0] != b {
+		t.Fatalf("confirmed identity change: got events %v, want exactly [%v]", got, b)
+	}
+	if lockStateOf(cc) != b {
+		t.Fatalf("identity after confirmation = %+v, want %+v", lockStateOf(cc), b)
+	}
+}
+
+// TestMaybeLockInterveningActiveIdentityResetsVotes pins the CONSECUTIVE
+// requirement: bogus, real, bogus must never accumulate to the threshold.
+func TestMaybeLockInterveningActiveIdentityResetsVotes(t *testing.T) {
+	cc, bus := debugCC(t, io.Discard, slog.LevelInfo)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	a := LockState{FrequencyHz: 412_000_000, MCC: 250, MNC: 13}
+	b := LockState{FrequencyHz: 412_000_000, MCC: 996, MNC: 3941}
+	cc.maybeLock(a)
+	drainLockEvents(sub)
+
+	cc.maybeLock(b)
+	cc.maybeLock(a) // the active identity re-asserts itself
+	cc.maybeLock(b)
+	if got := drainLockEvents(sub); len(got) != 0 {
+		t.Fatalf("non-consecutive bogus bursts were adopted: %v", got)
+	}
+	if lockStateOf(cc) != a {
+		t.Fatalf("identity = %+v, want %+v", lockStateOf(cc), a)
+	}
+}
+
+// TestMaybeLockFrequencyOnlyLockUnaffected pins the grant-path merge: a
+// frequency-only LockState (MCC=0, as publishGrantFromMAC produces) on an
+// already-identified lock publishes nothing and changes nothing — the
+// identity-vote gate must not turn it into a pending change either.
+func TestMaybeLockFrequencyOnlyLockUnaffected(t *testing.T) {
+	cc, bus := debugCC(t, io.Discard, slog.LevelInfo)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	a := LockState{FrequencyHz: 412_000_000, MCC: 250, MNC: 13, LocationArea: 5}
+	cc.maybeLock(a)
+	drainLockEvents(sub)
+
+	cc.maybeLock(LockState{FrequencyHz: 412_000_000})
+	if got := drainLockEvents(sub); len(got) != 0 {
+		t.Fatalf("frequency-only lock published: %v", got)
+	}
+	if lockStateOf(cc) != a {
+		t.Fatalf("frequency-only lock changed the identity: %+v", lockStateOf(cc))
+	}
+}

--- a/internal/radio/tetra/control_payload_test.go
+++ b/internal/radio/tetra/control_payload_test.go
@@ -1,0 +1,56 @@
+package tetra
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+)
+
+// buildBSCHOnlySBStream is buildCleanSBStream with an idle (all-zero) BNCH:
+// the BSCH decodes and stamps the ordinary activity heartbeat, but no SCH
+// block decodes — the "locked but deaf" ingredient (on air, a wrong AFC alias
+// latch produces exactly this: BSCH survives, every SCH fails CRC).
+func buildBSCHOnlySBStream(t *testing.T, cc6 uint8, mcc, mnc uint16) []uint8 {
+	t.Helper()
+	syncInfo := make([]byte, 60)
+	putBits(syncInfo, 4, 6, uint32(cc6))
+	putBits(syncInfo, 31, 10, uint32(mcc))
+	putBits(syncInfo, 41, 14, uint32(mnc))
+	bschDibits := TetraBitsToDibits(EncodeBSCH(syncInfo))
+
+	var s []uint8
+	s = append(s, make([]uint8, 50)...)
+	s = append(s, bschDibits...)
+	s = append(s, SyncTrainingDibits()...)
+	s = append(s, make([]uint8, sbBroadcastDibits)...)
+	s = append(s, make([]uint8, 108)...) // BNCH idle: must not decode
+	s = append(s, make([]uint8, 300)...)
+	return s
+}
+
+// TestPayloadHeartbeatStampsOnSCHDecode pins the payload/activity heartbeat
+// split the pipeline's payload-drought check depends on: a BSCH-only sync
+// burst stamps the ordinary activity heartbeat but NOT the payload one, while
+// a full sync burst whose BNCH (SCH/HD-coded) decodes stamps both.
+func TestPayloadHeartbeatStampsOnSCHDecode(t *testing.T) {
+	cc, bus := debugCC(t, io.Discard, slog.LevelInfo)
+	defer bus.Close()
+
+	cc.Process(buildBSCHOnlySBStream(t, 0x2D, 3, 5), 0)
+	if cc.LastActivityNano() == 0 {
+		t.Fatal("BSCH-only burst did not stamp the activity heartbeat")
+	}
+	if cc.LastPayloadNano() != 0 {
+		t.Fatal("BSCH-only burst stamped the payload heartbeat — the drought check could never fire in the field failure state")
+	}
+
+	cc2, bus2 := debugCC(t, io.Discard, slog.LevelInfo)
+	defer bus2.Close()
+	cc2.Process(buildCleanSBStream(t, 0x2D, 3, 5, cleanSysinfoPDU()), 0)
+	if cc2.LastPayloadNano() == 0 {
+		t.Fatal("a CRC-clean BNCH (SCH/HD) decode did not stamp the payload heartbeat")
+	}
+	if cc2.LastActivityNano() == 0 {
+		t.Fatal("payload decode did not also stamp the activity heartbeat")
+	}
+}

--- a/internal/radio/tetra/downlink.go
+++ b/internal/radio/tetra/downlink.go
@@ -231,6 +231,10 @@ func (c *ControlChannel) decodeDownlinkSlot(bkn1, aach1, aach2, bkn2 []uint8, bk
 	// correlator noise (AACH itself fails to decode) out of the failure count.
 	if recovered > 0 {
 		c.addStat(&c.stats.SCHPDUs, int64(recovered))
+		// Payload heartbeat: a CRC-clean SCH block is what distinguishes a
+		// genuinely decoding channel from the BSCH-only "locked but deaf" state
+		// (wrong AFC alias latch) the payload-drought check escapes.
+		c.notePayloadActivity()
 	} else if aachOK && aa.IsControlChannel() {
 		c.addStat(&c.stats.SCHPDUsFail, 1)
 	}

--- a/internal/radio/tetra/process.go
+++ b/internal/radio/tetra/process.go
@@ -377,6 +377,11 @@ func (c *ControlChannel) decodeSB(p *processState, L int) {
 		if !ok {
 			continue
 		}
+		// Payload heartbeat: the BNCH is SCH/HD-coded, so a CRC-clean decode
+		// here proves the SCH chain exactly like an NDB-slot block does — and
+		// fails with it under a wrong AFC alias latch (the differential residual
+		// that BSCH's heavier FEC survives).
+		c.notePayloadActivity()
 		if pdu, err := ParsePDU(framing.PackBitsMSB(recovered)); err == nil {
 			if sb, ok := pdu.AsSystemBroadcast(); ok {
 				ls.LocationArea = sb.LocationArea

--- a/internal/radio/tetra/receiver/afc.go
+++ b/internal/radio/tetra/receiver/afc.go
@@ -43,6 +43,20 @@ type carrierAFC struct {
 	// bad block cannot poison the track.
 	omegaEMA    float64
 	omegaPrimed bool
+
+	// rejStreak/rejMean track CONSECUTIVE rejected raw estimates that agree
+	// with each other. The outlier reject above has a failure mode the 19 Aug
+	// field log hit for ~37 minutes: after a Reset() the EMA is seeded from a
+	// single block, and a weak-signal seed can land in the wrong ±f_sym/4
+	// alias bucket — after which every CORRECT estimate differs from the EMA
+	// by more than omegaAliasReject and is rejected forever (BSCH still
+	// decodes via the per-burst SB correction, so no watchdog fires). A run of
+	// rejects that cluster tightly with EACH OTHER is the signature of a wrong
+	// latch (or a genuine carrier jump), not of ISI outliers — ISI aliasing is
+	// sporadic and interleaved with accepted blocks — so after
+	// omegaReprimeStreak of them the EMA is re-primed from their mean.
+	rejStreak int
+	rejMean   float64
 }
 
 // afcBlockSymbols is the feed-forward re-estimation window in symbols.
@@ -64,6 +78,18 @@ const omegaEMAAlpha = 0.08
 // real carrier cannot slew that far in one ~57 ms block, so only alias jumps and
 // gross transients are rejected.
 const omegaAliasReject = math.Pi / 4
+
+// omegaRejectClusterTol is how tightly consecutive rejected estimates must
+// agree with each other to count as one cluster (evidence of a wrong EMA
+// latch rather than scattered ISI outliers). Half the reject window: tight
+// enough that noise-scattered aliases restart the cluster, wide enough that
+// the fine estimator's jitter around the true carrier does not.
+const omegaRejectClusterTol = omegaAliasReject / 2
+
+// omegaReprimeStreak is how many consecutive clustered rejects re-prime the
+// EMA (~3 × 57 ms ≈ 170 ms of signal). A single accepted block in between
+// zeroes the streak, so sporadic outliers can never trip it.
+const omegaReprimeStreak = 3
 
 func newCarrierAFC(sps int) *carrierAFC {
 	if sps < 1 {
@@ -186,13 +212,9 @@ func (a *carrierAFC) Process(dst, matched, wide []complex64) []complex64 {
 		// Smooth the net estimate across blocks: strip the per-block jitter that
 		// spins the constellation and swings the reported offset, while the mean
 		// (seeded from the first block, so a real multi-kHz offset is acquired at
-		// once) still follows slow carrier drift. Reject alias-sized outliers.
-		if !a.omegaPrimed {
-			a.omegaEMA = rawOmega
-			a.omegaPrimed = true
-		} else if math.Abs(rawOmega-a.omegaEMA) < omegaAliasReject {
-			a.omegaEMA += omegaEMAAlpha * (rawOmega - a.omegaEMA)
-		}
+		// once) still follows slow carrier drift. Reject alias-sized outliers,
+		// but escape a wrong latch when the rejects agree with each other.
+		a.track(rawOmega)
 		// Finish derotating the block to the smoothed net (coarse is already
 		// removed, so apply the remainder).
 		a.derotate(block, a.omegaEMA-coarse)
@@ -207,6 +229,39 @@ func (a *carrierAFC) Process(dst, matched, wide []complex64) []complex64 {
 	return dst
 }
 
+// track folds one per-block raw estimate into the smoothed EMA. Accepted
+// estimates (within omegaAliasReject of the EMA) update it and clear any
+// reject streak. Rejected estimates accumulate into a cluster while they
+// agree with each other (omegaRejectClusterTol); omegaReprimeStreak
+// consecutive clustered rejects re-prime the EMA from their mean — the
+// escape hatch for a wrong first-block seed that would otherwise reject
+// every correct estimate forever (19 Aug field log: −3630 Hz latched for
+// 12 minutes while BSCH decoded and SCH sat at zero).
+func (a *carrierAFC) track(rawOmega float64) {
+	if !a.omegaPrimed {
+		a.omegaEMA = rawOmega
+		a.omegaPrimed = true
+		a.rejStreak = 0
+		return
+	}
+	if math.Abs(rawOmega-a.omegaEMA) < omegaAliasReject {
+		a.omegaEMA += omegaEMAAlpha * (rawOmega - a.omegaEMA)
+		a.rejStreak = 0
+		return
+	}
+	if a.rejStreak > 0 && math.Abs(rawOmega-a.rejMean) < omegaRejectClusterTol {
+		a.rejStreak++
+		a.rejMean += (rawOmega - a.rejMean) / float64(a.rejStreak)
+	} else {
+		a.rejStreak = 1
+		a.rejMean = rawOmega
+	}
+	if a.rejStreak >= omegaReprimeStreak {
+		a.omegaEMA = a.rejMean
+		a.rejStreak = 0
+	}
+}
+
 // OffsetHz reports the most recent per-symbol offset estimate in Hz.
 func (a *carrierAFC) OffsetHz(symRate float64) float64 { return a.omega * symRate / (2 * math.Pi) }
 
@@ -216,6 +271,8 @@ func (a *carrierAFC) Reset() {
 	a.wideBuf = a.wideBuf[:0]
 	a.omegaEMA = 0
 	a.omegaPrimed = false
+	a.rejStreak = 0
+	a.rejMean = 0
 }
 
 func conjf(c complex64) complex64 { return complex(real(c), -imag(c)) }

--- a/internal/radio/tetra/receiver/afc_reprime_test.go
+++ b/internal/radio/tetra/receiver/afc_reprime_test.go
@@ -1,0 +1,194 @@
+package receiver
+
+import (
+	"io"
+	"log/slog"
+	"math"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/tetra"
+)
+
+// omegaFromHz converts a carrier offset in Hz to rad/symbol at the TETRA
+// symbol rate, matching carrierAFC.OffsetHz's inverse.
+func omegaFromHz(hz float64) float64 { return hz * 2 * math.Pi / SymbolRate }
+
+// TestAFCTrackClusteredRejectsReprime pins the escape hatch at the unit
+// level: an EMA latched in the wrong ±f_sym/4 alias bucket (the 19 Aug field
+// state: −3630 Hz reported while the true carrier sat near 0) re-primes after
+// omegaReprimeStreak consecutive rejected estimates that agree with each
+// other, instead of rejecting the correct estimate forever.
+func TestAFCTrackClusteredRejectsReprime(t *testing.T) {
+	a := newCarrierAFC(8)
+	a.omegaEMA = omegaFromHz(-3630)
+	a.omegaPrimed = true
+
+	// True carrier ~0 Hz: every raw estimate lands near 0, > omegaAliasReject
+	// away from the latched EMA. Small jitter keeps the cluster realistic.
+	raws := []float64{omegaFromHz(40), omegaFromHz(-60), omegaFromHz(25)}
+	for i, r := range raws {
+		a.track(r)
+		if i < len(raws)-1 && math.Abs(a.omegaEMA-omegaFromHz(-3630)) > 1e-9 {
+			t.Fatalf("EMA moved before the streak completed (after %d rejects): %f", i+1, a.omegaEMA)
+		}
+	}
+	if gotHz := a.OffsetHz(SymbolRate); math.Abs(gotHz) > 100 {
+		t.Fatalf("EMA did not re-prime from the reject cluster: reporting %.0f Hz, want ~0", gotHz)
+	}
+}
+
+// TestAFCTrackSporadicOutlierHolds pins the anti-flap side: sporadic or
+// scattered alias-sized outliers — the ISI condition the EMA reject exists
+// for — must NOT re-prime the mean.
+func TestAFCTrackSporadicOutlierHolds(t *testing.T) {
+	alias := omegaFromHz(4500)
+
+	// Sporadic: outliers interleaved with accepted estimates. Each accepted
+	// block zeroes the streak, so the mean must hold at ~0.
+	a := newCarrierAFC(8)
+	a.track(0) // prime at 0
+	for _, r := range []float64{0, alias, 0, -alias, 0, alias, 0} {
+		a.track(r)
+	}
+	if got := a.OffsetHz(SymbolRate); math.Abs(got) > 50 {
+		t.Fatalf("sporadic outliers moved the EMA: %.0f Hz, want ~0", got)
+	}
+
+	// Scattered: consecutive rejects that do NOT agree with each other
+	// (alternating alias buckets) restart the cluster each time and must
+	// never reach omegaReprimeStreak.
+	b := newCarrierAFC(8)
+	b.track(0)
+	for i := 0; i < 6; i++ {
+		if i%2 == 0 {
+			b.track(alias)
+		} else {
+			b.track(-alias)
+		}
+	}
+	if got := b.OffsetHz(SymbolRate); math.Abs(got) > 50 {
+		t.Fatalf("scattered outliers re-primed the EMA: %.0f Hz, want ~0", got)
+	}
+}
+
+// TestAFCEscapesWrongAliasSeed drives the full block pipeline: a clean,
+// perfectly-centred π/4-DQPSK stream through a carrierAFC whose EMA has been
+// poisoned into the wrong alias bucket (what a one-block weak-signal seed
+// after Reset() produced in the field). Before the escape hatch the latch is
+// permanent — every correct per-block estimate differs by ~3630 Hz >
+// omegaAliasReject and is discarded; this test fails on that code.
+func TestAFCEscapesWrongAliasSeed(t *testing.T) {
+	const (
+		sps   = 8
+		span  = 8
+		alpha = 0.35
+	)
+	dibits := make([]uint8, 0, 12000)
+	lcg := uint32(424242)
+	for i := 0; i < 12000; i++ {
+		lcg = lcg*1664525 + 1013904223
+		dibits = append(dibits, uint8((lcg>>16)&3))
+	}
+	iq := demod.ModulatePiOver4DQPSK(dibits, sps, span, alpha, math.Pi/4)
+
+	a := newCarrierAFC(sps)
+	a.omegaEMA = omegaFromHz(-3630)
+	a.omegaPrimed = true
+
+	dst := make([]complex64, 0, len(iq))
+	const chunk = 4096
+	for i := 0; i < len(iq); i += chunk {
+		end := i + chunk
+		if end > len(iq) {
+			end = len(iq)
+		}
+		// The pre-matched (wide) stream is the same clean block here — at zero
+		// true CFO the coarse stage reads ~0 from it, exactly the estimates the
+		// wrong latch keeps rejecting.
+		dst = a.Process(dst, iq[i:end], iq[i:end])
+	}
+
+	if got := a.OffsetHz(SymbolRate); math.Abs(got) > 300 {
+		t.Fatalf("AFC still latched at %.0f Hz on a centred stream — the wrong alias seed was never escaped", got)
+	}
+}
+
+// TestReceiverRecoversFromAliasLatchedAFC is the receiver-level regression for
+// the 19 Aug field failure: the production 144 kHz Gardner+AFC+channel-filter
+// path, its AFC poisoned into the wrong alias bucket mid-stream (as a
+// decode-drought resync's one-block re-prime did on air), must recover and
+// lock on a clean centred control channel instead of staying "locked but
+// deaf" forever.
+func TestReceiverRecoversFromAliasLatchedAFC(t *testing.T) {
+	const (
+		controlFreqHz        = 412_062_500
+		colourCode           = uint32(0x12345)
+		locationArea  uint16 = 0x42
+		sps                  = 8
+		span                 = 8
+		alpha                = 0.35
+		gardnerGain          = 0.005
+		sampleRateHz         = 144_000.0
+	)
+
+	dibits := buildTETRASCHHDDibits(120, colourCode, locationArea)
+	iq := demod.ModulatePiOver4DQPSK(dibits, sps, span, alpha, math.Pi/4)
+
+	bus := events.NewBus(64)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := tetra.New(tetra.Options{
+		Bus:         bus,
+		Log:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		SystemName:  "TETRASite",
+		FrequencyHz: controlFreqHz,
+	})
+	cc.SetChannelCoding(tetra.ChannelCodingOn)
+	cc.SetExpectedChannel(tetra.ChannelSCHHD)
+	cc.SetColourCode(colourCode)
+
+	rx := New(Options{
+		SampleRateHz:        sampleRateHz,
+		ClockMode:           ClockGardner,
+		GardnerGain:         gardnerGain,
+		EnableAFC:           true,
+		EnableChannelFilter: true,
+		DibitSink:           func(d []uint8, b int) { cc.Process(d, b) },
+		SoftSink:            func(diffs []complex64, b int) { cc.StashSoft(diffs, b) },
+	})
+
+	// Poison the AFC the way the field failure did: latched in the wrong
+	// ±4500 Hz alias bucket while the true carrier is centred.
+	rx.afc.omegaEMA = omegaFromHz(-3630)
+	rx.afc.omegaPrimed = true
+
+	const chunk = 4096
+	for i := 0; i < len(iq); i += chunk {
+		end := i + chunk
+		if end > len(iq) {
+			end = len(iq)
+		}
+		rx.Process(iq[i:end])
+	}
+
+	locked := false
+drain:
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindCCLocked {
+				locked = true
+			}
+		default:
+			break drain
+		}
+	}
+	if !locked {
+		t.Fatalf("no cc.locked on a centred stream with an alias-latched AFC "+
+			"(afc reporting %.0f Hz): the escape hatch did not fire", rx.afc.OffsetHz(SymbolRate))
+	}
+}

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -742,6 +742,33 @@ const (
 // storm) is no longer needed and has been removed.
 const tetraResyncTimeout = 1500 * time.Millisecond
 
+// tetraPayloadResyncTimeout is the SIGNAL-TIME budget for the second, stricter
+// drought check: how long a LOCKED control channel may keep decoding sync
+// bursts while producing zero CRC-clean SCH payload blocks before the pipeline
+// treats the decode chain itself as wedged and forces the same destructive
+// reset-to-centre as checkResync. The two droughts are distinct failure
+// classes: checkResync fires when NOTHING decodes (off-lock), while this fires
+// on the "locked but deaf" state the 19 Aug field log sat in for ~37 minutes —
+// a wrong AFC alias latch leaves a constant differential residual that the
+// SB burst's heavily-coded BSCH survives (feeding the activity heartbeat, so
+// checkResync and CheckStale can never fire) while every SCH block fails CRC.
+// A real TETRA control channel carries SYSINFO/signalling continuously (a BNCH
+// on every sync burst, SCH on the NDB slots), so 12 s of BSCH-alive/SCH-dead
+// is always pathological, yet the budget is long enough (8× the ordinary
+// resync window) that a marginal #1001-class signal decoding even one SCH
+// block per 12 s never trips it.
+//
+// tetraPayloadResyncMaxAttempts caps the escape: if this many consecutive
+// payload-forced resyncs each burn a full budget without a single payload
+// decode, the reset alone is not fixing it (e.g. the re-primed AFC keeps
+// re-latching the same wrong alias on a weak carrier) — declare the lock lost
+// so the cchunt supervisor re-hunts and retunes, which re-acquires from cold.
+// ~36-48 s worst case to a re-hunt, against the field's 12-minute stucks.
+const (
+	tetraPayloadResyncTimeout     = 12 * time.Second
+	tetraPayloadResyncMaxAttempts = 3
+)
+
 type tetraPipeline struct {
 	rx             *tetrarx.Receiver
 	cc             *tetra.ControlChannel
@@ -760,11 +787,19 @@ type tetraPipeline struct {
 	// clock without advancing the sample count. See tetraResyncTimeout.
 	samplesSinceDecode int64
 	lastSeenActivity   int64 // cc heartbeat nano last observed; a change ⇒ a decode landed since
+	// Payload-drought trigger (the "locked but deaf" escape): like the pair
+	// above but watching the stricter payload heartbeat, with an attempt
+	// counter that escalates to MarkLost when resets alone don't recover.
+	// See tetraPayloadResyncTimeout.
+	samplesSincePayload int64
+	lastSeenPayload     int64
+	payloadResyncStreak int
 }
 
 func (p *tetraPipeline) Process(iq []complex64) {
 	p.rx.Process(iq)
 	p.checkResync(len(iq))
+	p.checkPayloadResync(len(iq))
 	p.checkLockStale()
 	p.maybeLogStatus()
 }
@@ -822,11 +857,64 @@ func (p *tetraPipeline) checkResync(n int) {
 	// Reset the budget first so the next reset needs another full window (throttle
 	// + reacquire window), then reacquire the symbol timing from centre.
 	p.samplesSinceDecode = 0
+	// The DSP was just reset, so the payload drought (if any) restarts too —
+	// the two checks must never both fire on one window.
+	p.samplesSincePayload = 0
 	p.rx.Reset()
 	p.cc.ResyncReset()
 	if p.log != nil {
 		p.log.Debug("tetra: dsp resync (signal-time decode drought; reacquiring symbol timing from centre)",
 			"system", p.system)
+	}
+}
+
+// checkPayloadResync is the escape from the "locked but deaf" state: the
+// control channel keeps decoding sync bursts (so checkResync and CheckStale
+// stay satisfied) while producing zero CRC-clean SCH payload for a full
+// tetraPayloadResyncTimeout of processed signal. Same signal-time discipline
+// as checkResync (immune to CPU starvation), watching the stricter payload
+// heartbeat. Each firing forces the same destructive reset-to-centre (which
+// re-primes the AFC — see the 19 Aug alias-latch field failure); after
+// tetraPayloadResyncMaxAttempts consecutive fruitless resets it declares the
+// lock lost so the cchunt supervisor re-hunts and retunes from cold.
+func (p *tetraPipeline) checkPayloadResync(n int) {
+	pay := p.cc.LastPayloadNano()
+	if pay != p.lastSeenPayload {
+		// A payload block decoded since the last check: the chain is healthy.
+		p.lastSeenPayload = pay
+		p.samplesSincePayload = 0
+		p.payloadResyncStreak = 0
+		return
+	}
+	if !p.cc.Locked() {
+		// Unlocked channels are the hunt supervisor's problem; accumulating here
+		// would just pile destructive resets onto a channel with no signal.
+		p.samplesSincePayload = 0
+		return
+	}
+	if p.rateHz <= 0 {
+		return
+	}
+	p.samplesSincePayload += int64(n)
+	if p.samplesSincePayload < int64(tetraPayloadResyncTimeout.Seconds()*p.rateHz) {
+		return
+	}
+	p.samplesSincePayload = 0
+	p.payloadResyncStreak++
+	if p.payloadResyncStreak >= tetraPayloadResyncMaxAttempts {
+		p.payloadResyncStreak = 0
+		if p.log != nil {
+			p.log.Warn("tetra: payload drought persists across resyncs (sync bursts decoding, no SCH payload) — declaring lock lost to force a re-hunt",
+				"system", p.system, "attempts", tetraPayloadResyncMaxAttempts)
+		}
+		p.cc.MarkLost()
+		return
+	}
+	p.rx.Reset()
+	p.cc.ResyncReset()
+	if p.log != nil {
+		p.log.Debug("tetra: dsp resync (payload drought; sync bursts still decoding but no SCH payload)",
+			"system", p.system, "attempt", p.payloadResyncStreak)
 	}
 }
 

--- a/internal/scanner/ccdecoder/pipelines_tetra_payload_test.go
+++ b/internal/scanner/ccdecoder/pipelines_tetra_payload_test.go
@@ -1,0 +1,130 @@
+package ccdecoder
+
+import (
+	"strings"
+	"testing"
+)
+
+// feedNoDecodeBSCHAlive drives n samples of undecodable signal while keeping
+// the ORDINARY activity heartbeat looking fresh — the 19 Aug field condition:
+// SB/BSCH keeps decoding (feeding noteActivity, so checkResync and CheckStale
+// never fire) while every SCH payload block fails CRC. The white-box
+// lastSeenActivity decrement is the same trick TestTETRAResyncDecodeClearsBudget
+// uses to simulate "a decode landed since the last check".
+func feedNoDecodeBSCHAlive(p *tetraPipeline, n int64) {
+	const chunk = 100_000
+	for n > 0 {
+		c := n
+		if c > chunk {
+			c = chunk
+		}
+		p.lastSeenActivity = p.cc.LastActivityNano() - 1 // pretend a BSCH just decoded
+		feedNoDecode(p, c)
+		n -= c
+	}
+}
+
+// payloadBudget returns the payload-drought sample budget for the pipeline.
+func payloadBudget(p *tetraPipeline) int64 {
+	return int64(tetraPayloadResyncTimeout.Seconds() * p.rateHz)
+}
+
+// TestTETRAPayloadDroughtForcesResync is the regression for the 19 Aug "locked
+// but deaf" field failure: a locked control channel whose sync bursts keep
+// decoding (activity heartbeat alive) but which produces zero CRC-clean SCH
+// payload must NOT sit there forever — after a full payload budget of
+// processed signal the pipeline forces a resync. Fails against the old code,
+// where the surviving BSCH satisfied every watchdog and nothing ever fired
+// (the field log sat in this state for 12 minutes at a stretch).
+func TestTETRAPayloadDroughtForcesResync(t *testing.T) {
+	p, buf, _ := newResyncTestPipeline(t)
+	budget := payloadBudget(p)
+
+	// Just under the budget: nothing may fire (neither the ordinary resync —
+	// BSCH is alive — nor the payload one).
+	feedNoDecodeBSCHAlive(p, budget-1)
+	if strings.Contains(buf.String(), "dsp resync") {
+		t.Fatalf("a resync fired before the payload budget was reached\n%s", buf.String())
+	}
+
+	// Crossing the budget fires exactly one payload-drought resync.
+	feedNoDecodeBSCHAlive(p, 1)
+	if got := strings.Count(buf.String(), "tetra: dsp resync (payload drought"); got != 1 {
+		t.Fatalf("want exactly one payload-drought resync after a full budget, got %d\n%s", got, buf.String())
+	}
+	if strings.Contains(buf.String(), "signal-time decode drought") {
+		t.Fatalf("the ordinary decode-drought resync fired despite a live BSCH heartbeat\n%s", buf.String())
+	}
+}
+
+// TestTETRAPayloadDroughtEscalatesToLost pins the escalation: when the
+// destructive reset alone does not recover payload decode (e.g. the re-primed
+// AFC re-latches the same wrong alias on a weak carrier), the third
+// consecutive fruitless budget declares the lock lost so the cchunt
+// supervisor re-hunts and retunes from cold — bounding the field's 12-minute
+// stucks at ~36 s.
+func TestTETRAPayloadDroughtEscalatesToLost(t *testing.T) {
+	p, buf, _ := newResyncTestPipeline(t)
+	budget := payloadBudget(p)
+
+	// Feed in 100k chunks, so each firing consumes up to one chunk of
+	// overshoot past its budget — pad each attempt by a chunk.
+	const chunkPad = 100_000
+	feedNoDecodeBSCHAlive(p, 2*(budget+chunkPad))
+	if got := strings.Count(buf.String(), "tetra: dsp resync (payload drought"); got != 2 {
+		t.Fatalf("want two payload-drought resyncs after two budgets, got %d\n%s", got, buf.String())
+	}
+	if !p.cc.Locked() {
+		t.Fatal("lock lost before the escalation threshold")
+	}
+
+	feedNoDecodeBSCHAlive(p, budget+chunkPad)
+	if !strings.Contains(buf.String(), "payload drought persists across resyncs") {
+		t.Fatalf("third fruitless budget did not escalate\n%s", buf.String())
+	}
+	if p.cc.Locked() {
+		t.Fatal("escalation did not declare the lock lost")
+	}
+}
+
+// TestTETRAPayloadDecodeClearsBudgetAndStreak pins the recovery branch: a
+// payload decode (the payload heartbeat advancing past the value the check
+// last saw) clears both the accumulated budget and the resync streak.
+func TestTETRAPayloadDecodeClearsBudgetAndStreak(t *testing.T) {
+	p, _, _ := newResyncTestPipeline(t)
+	budget := payloadBudget(p)
+
+	feedNoDecodeBSCHAlive(p, budget-1)
+	if p.samplesSincePayload == 0 {
+		t.Fatal("payload budget did not accumulate during the drought")
+	}
+	p.payloadResyncStreak = 1 // as if one drought reset already fired
+
+	// A payload block decodes: heartbeat now differs from what the check saw.
+	p.lastSeenPayload = p.cc.LastPayloadNano() - 1
+	p.Process(nil)
+	if p.samplesSincePayload != 0 {
+		t.Fatalf("a payload decode did not clear the budget: %d", p.samplesSincePayload)
+	}
+	if p.payloadResyncStreak != 0 {
+		t.Fatalf("a payload decode did not clear the resync streak: %d", p.payloadResyncStreak)
+	}
+}
+
+// TestTETRAPayloadBudgetHeldWhileUnlocked pins the hunt-time guard: an
+// unlocked channel accumulates no payload budget (re-acquisition is the hunt
+// supervisor's job; piling destructive resets onto a signal-less channel
+// helps nothing).
+func TestTETRAPayloadBudgetHeldWhileUnlocked(t *testing.T) {
+	p, buf, _ := newResyncTestPipeline(t)
+	p.cc.MarkLost()
+	buf.Reset()
+
+	feedNoDecodeBSCHAlive(p, payloadBudget(p)+1)
+	if p.samplesSincePayload != 0 {
+		t.Fatalf("payload budget accumulated while unlocked: %d", p.samplesSincePayload)
+	}
+	if strings.Contains(buf.String(), "payload drought") {
+		t.Fatalf("payload-drought machinery fired while unlocked\n%s", buf.String())
+	}
+}

--- a/internal/scanner/ccdecoder/pipelines_tetra_payload_test.go
+++ b/internal/scanner/ccdecoder/pipelines_tetra_payload_test.go
@@ -3,7 +3,18 @@ package ccdecoder
 import (
 	"strings"
 	"testing"
+	"time"
 )
+
+// pinPipelineClock freezes the pipeline's wall clock at the heartbeat's own
+// timestamp so the 5 s CheckStale watchdog never fires during a long feed —
+// these tests simulate BSCH liveness by rewinding lastSeenActivity, which
+// keeps checkResync fed but does not refresh the REAL heartbeat timestamp,
+// and under -race a multi-second feed would otherwise cross the wall-clock
+// stale timeout and MarkLost mid-test.
+func pinPipelineClock(p *tetraPipeline) {
+	p.now = func() time.Time { return time.Unix(0, p.cc.LastActivityNano()) }
+}
 
 // feedNoDecodeBSCHAlive drives n samples of undecodable signal while keeping
 // the ORDINARY activity heartbeat looking fresh — the 19 Aug field condition:
@@ -38,6 +49,7 @@ func payloadBudget(p *tetraPipeline) int64 {
 // (the field log sat in this state for 12 minutes at a stretch).
 func TestTETRAPayloadDroughtForcesResync(t *testing.T) {
 	p, buf, _ := newResyncTestPipeline(t)
+	pinPipelineClock(p)
 	budget := payloadBudget(p)
 
 	// Just under the budget: nothing may fire (neither the ordinary resync —
@@ -65,6 +77,7 @@ func TestTETRAPayloadDroughtForcesResync(t *testing.T) {
 // stucks at ~36 s.
 func TestTETRAPayloadDroughtEscalatesToLost(t *testing.T) {
 	p, buf, _ := newResyncTestPipeline(t)
+	pinPipelineClock(p)
 	budget := payloadBudget(p)
 
 	// Feed in 100k chunks, so each firing consumes up to one chunk of
@@ -92,6 +105,7 @@ func TestTETRAPayloadDroughtEscalatesToLost(t *testing.T) {
 // last saw) clears both the accumulated budget and the resync streak.
 func TestTETRAPayloadDecodeClearsBudgetAndStreak(t *testing.T) {
 	p, _, _ := newResyncTestPipeline(t)
+	pinPipelineClock(p)
 	budget := payloadBudget(p)
 
 	feedNoDecodeBSCHAlive(p, budget-1)
@@ -117,6 +131,7 @@ func TestTETRAPayloadDecodeClearsBudgetAndStreak(t *testing.T) {
 // helps nothing).
 func TestTETRAPayloadBudgetHeldWhileUnlocked(t *testing.T) {
 	p, buf, _ := newResyncTestPipeline(t)
+	pinPipelineClock(p)
 	p.cc.MarkLost()
 	buf.Reset()
 

--- a/internal/scanner/widebandt2/tetra.go
+++ b/internal/scanner/widebandt2/tetra.go
@@ -26,6 +26,14 @@ const (
 	tetraResyncTimeout      = 1500 * time.Millisecond
 	tetraLockStaleTimeout   = 5 * time.Second
 	tetraStaleCheckInterval = 1 * time.Second
+	// Payload-drought escape, mirrored from ccdecoder (see that package's
+	// tetraPayloadResyncTimeout for the full rationale): a locked channel
+	// decoding sync bursts but zero CRC-clean SCH payload for this much signal
+	// is "locked but deaf" (e.g. a wrong AFC alias latch) and gets the same
+	// destructive reset; after tetraPayloadResyncMaxAttempts fruitless resets
+	// the lock is declared lost so the supervisor re-hunts.
+	tetraPayloadResyncTimeout     = 12 * time.Second
+	tetraPayloadResyncMaxAttempts = 3
 )
 
 // channelOutRateHz is the per-tap output rate a channel's protocol needs. TETRA
@@ -68,11 +76,18 @@ type tetraChannelReceiver struct {
 	samplesSinceDecode int64
 	lastSeenActivity   int64
 	lastStale          time.Time
+
+	// Payload-drought trigger, mirrored from ccdecoder.tetraPipeline (the
+	// "locked but deaf" escape — sync bursts decoding, zero SCH payload).
+	samplesSincePayload int64
+	lastSeenPayload     int64
+	payloadResyncStreak int
 }
 
 func (t *tetraChannelReceiver) Process(iq []complex64) {
 	t.rx.Process(iq)
 	t.checkResync(len(iq))
+	t.checkPayloadResync(len(iq))
 	t.checkLockStale()
 }
 
@@ -98,11 +113,56 @@ func (t *tetraChannelReceiver) checkResync(n int) {
 		return
 	}
 	t.samplesSinceDecode = 0
+	// The DSP was just reset, so the payload drought (if any) restarts too.
+	t.samplesSincePayload = 0
 	t.rx.Reset()
 	t.cc.ResyncReset()
 	if t.log != nil {
 		t.log.Debug("widebandt2: tetra dsp resync (signal-time decode drought; reacquiring symbol timing from centre)",
 			"system", t.system)
+	}
+}
+
+// checkPayloadResync mirrors ccdecoder.tetraPipeline.checkPayloadResync: the
+// escape from the "locked but deaf" state where sync bursts keep the ordinary
+// heartbeat fed while every SCH payload block fails CRC (a wrong AFC alias
+// latch). Signal-time budget; escalates to MarkLost after
+// tetraPayloadResyncMaxAttempts fruitless resets so the supervisor re-hunts.
+func (t *tetraChannelReceiver) checkPayloadResync(n int) {
+	pay := t.cc.LastPayloadNano()
+	if pay != t.lastSeenPayload {
+		t.lastSeenPayload = pay
+		t.samplesSincePayload = 0
+		t.payloadResyncStreak = 0
+		return
+	}
+	if !t.cc.Locked() {
+		t.samplesSincePayload = 0
+		return
+	}
+	if t.rateHz <= 0 {
+		return
+	}
+	t.samplesSincePayload += int64(n)
+	if t.samplesSincePayload < int64(tetraPayloadResyncTimeout.Seconds()*t.rateHz) {
+		return
+	}
+	t.samplesSincePayload = 0
+	t.payloadResyncStreak++
+	if t.payloadResyncStreak >= tetraPayloadResyncMaxAttempts {
+		t.payloadResyncStreak = 0
+		if t.log != nil {
+			t.log.Warn("widebandt2: tetra payload drought persists across resyncs (sync bursts decoding, no SCH payload) — declaring lock lost to force a re-hunt",
+				"system", t.system, "attempts", tetraPayloadResyncMaxAttempts)
+		}
+		t.cc.MarkLost()
+		return
+	}
+	t.rx.Reset()
+	t.cc.ResyncReset()
+	if t.log != nil {
+		t.log.Debug("widebandt2: tetra dsp resync (payload drought; sync bursts still decoding but no SCH payload)",
+			"system", t.system, "attempt", t.payloadResyncStreak)
 	}
 }
 

--- a/internal/scanner/widebandt2/tetra_payload_test.go
+++ b/internal/scanner/widebandt2/tetra_payload_test.go
@@ -1,0 +1,106 @@
+package widebandt2
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	tetra "github.com/MattCheramie/GopherTrunk/internal/radio/tetra"
+	tetrarx "github.com/MattCheramie/GopherTrunk/internal/radio/tetra/receiver"
+)
+
+// buildArmingSBDibits assembles a clean TETRA sync burst (BSCH decodes, BNCH
+// idle) from exported tetra symbols — enough to lock the control channel and
+// stamp its ACTIVITY heartbeat without ever stamping the PAYLOAD one. Mirrors
+// ccdecoder's buildArmingSBStream.
+func buildArmingSBDibits() []uint8 {
+	setBits := func(bits []byte, off, n int, v uint32) {
+		for i := 0; i < n; i++ {
+			bits[off+i] = byte((v >> uint(n-1-i)) & 1)
+		}
+	}
+	syncInfo := make([]byte, 60)
+	setBits(syncInfo, 4, 6, 0x2D)
+	setBits(syncInfo, 31, 10, 3)
+	setBits(syncInfo, 41, 14, 5)
+	bschDibits := tetra.TetraBitsToDibits(tetra.EncodeBSCH(syncInfo))
+
+	var s []uint8
+	s = append(s, make([]uint8, 50)...)
+	s = append(s, bschDibits...)
+	s = append(s, tetra.SyncTrainingDibits()...)
+	s = append(s, make([]uint8, 15)...)
+	s = append(s, make([]uint8, 108)...)
+	s = append(s, make([]uint8, 300)...)
+	return s
+}
+
+// TestWidebandTETRAPayloadDroughtForcesResyncAndEscalates mirrors the
+// ccdecoder payload-drought tests on the wideband tap: a locked channel whose
+// sync bursts keep the activity heartbeat fresh but which decodes no SCH
+// payload fires the payload resync per budget, and the third fruitless budget
+// declares the lock lost (the 19 Aug "locked but deaf" escape).
+func TestWidebandTETRAPayloadDroughtForcesResyncAndEscalates(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	bus := events.NewBus(8)
+	t.Cleanup(bus.Close)
+
+	cc := tetra.New(tetra.Options{
+		Bus: bus, Log: logger, SystemName: "Test", FrequencyHz: 412_000_000,
+	})
+	cc.SetChannelCoding(tetra.ChannelCodingOn)
+	rx := tetrarx.New(tetrarx.Options{
+		SampleRateHz: tetraChannelRateHz,
+		ClockMode:    tetrarx.ClockGardner,
+		GardnerGain:  0.005,
+		DibitSink:    func(d []uint8, b int) { cc.Process(d, b) },
+	})
+	rcv := &tetraChannelReceiver{
+		rx: rx, cc: cc, log: logger, system: "Test",
+		rateHz: tetraChannelRateHz, now: time.Now,
+	}
+
+	cc.Process(buildArmingSBDibits(), 0)
+	if !cc.Locked() {
+		t.Fatal("control channel did not lock on the arming burst")
+	}
+	rcv.Process(nil)
+	buf.Reset()
+
+	budget := int64(tetraPayloadResyncTimeout.Seconds() * rcv.rateHz)
+	const chunk = 100_000
+	feed := func(n int64) {
+		iq := make([]complex64, chunk)
+		for i := range iq {
+			iq[i] = complex(0.01, 0.01)
+		}
+		for n > 0 {
+			c := n
+			if c > chunk {
+				c = chunk
+			}
+			rcv.lastSeenActivity = cc.LastActivityNano() - 1 // BSCH stays "alive"
+			rcv.Process(iq[:c])
+			n -= c
+		}
+	}
+
+	feed(2*(budget+chunk))
+	if got := strings.Count(buf.String(), "payload drought; sync bursts still decoding"); got != 2 {
+		t.Fatalf("want two payload-drought resyncs, got %d\n%s", got, buf.String())
+	}
+	if !cc.Locked() {
+		t.Fatal("lock lost before the escalation threshold")
+	}
+	feed(budget + chunk)
+	if !strings.Contains(buf.String(), "payload drought persists across resyncs") {
+		t.Fatalf("third fruitless budget did not escalate\n%s", buf.String())
+	}
+	if cc.Locked() {
+		t.Fatal("escalation did not declare the lock lost")
+	}
+}

--- a/internal/scanner/widebandt2/tetra_payload_test.go
+++ b/internal/scanner/widebandt2/tetra_payload_test.go
@@ -94,7 +94,7 @@ func TestWidebandTETRAPayloadDroughtForcesResyncAndEscalates(t *testing.T) {
 		}
 	}
 
-	feed(2*(budget+chunk))
+	feed(2 * (budget + chunk))
 	if got := strings.Count(buf.String(), "payload drought; sync bursts still decoding"); got != 2 {
 		t.Fatalf("want two payload-drought resyncs, got %d\n%s", got, buf.String())
 	}

--- a/internal/scanner/widebandt2/tetra_payload_test.go
+++ b/internal/scanner/widebandt2/tetra_payload_test.go
@@ -61,7 +61,12 @@ func TestWidebandTETRAPayloadDroughtForcesResyncAndEscalates(t *testing.T) {
 	})
 	rcv := &tetraChannelReceiver{
 		rx: rx, cc: cc, log: logger, system: "Test",
-		rateHz: tetraChannelRateHz, now: time.Now,
+		rateHz: tetraChannelRateHz,
+		// Pin the wall clock to the heartbeat's own timestamp so the 5 s
+		// CheckStale watchdog never fires during a long feed (under -race the
+		// budget feed takes multiple wall-clock seconds while the REAL
+		// heartbeat timestamp is never refreshed).
+		now: func() time.Time { return time.Unix(0, cc.LastActivityNano()) },
 	}
 
 	cc.Process(buildArmingSBDibits(), 0)

--- a/internal/sdr/soapyremote/align.go
+++ b/internal/sdr/soapyremote/align.go
@@ -1,0 +1,207 @@
+package soapyremote
+
+import "math"
+
+// branchAligner removes a CONSTANT inter-branch timing skew before the MRC
+// combine. A scalar complex gain assumes the branches are time-aligned; a
+// constant delay between them (start-of-stream skew, differing DDC group
+// delay between daughterboards) turns the coherent sum into a comb filter —
+// band-average power still looks fine, per-frequency coherence stays high,
+// but broadband |rho| is diluted and the combined SYMBOLS are smeared. On the
+// operator's 19 Aug 2026 X310 capture, branch 0 lagged branch 1 by a constant
+// 2.60 samples (13 µs at 200 kS/s): every scalar-combined arm decoded ~22%
+// FEWER CRC-clean BSCH than the best branch alone, while the same combine
+// after delay alignment matched it exactly (see
+// cmd/gophertrunk/diversity_replay_test.go's wb-aligned-static arm).
+//
+// Operation: while unmeasured, it accumulates a per-branch sample buffer;
+// once full it scans integer lags ±alignMaxLag for the |rho|-maximising delay
+// of branch 1 relative to branch 0, refines the fraction by parabolic
+// interpolation of the neighbouring lags, and LATCHES the result — exactly
+// once per measurement cycle, like the phase anchor, because changing a delay
+// mid-stream is itself a discontinuity. From then on process() delays the
+// EARLY branch by the measured amount through a small per-branch delay line
+// (linear interpolation for the fraction — the channel occupies a few percent
+// of the stream rate, where a linear interpolator is transparent). A
+// measurement whose peak |rho| does not clear alignMinRho (no coherent signal
+// yet) is discarded and re-accumulated. Stream-goroutine only.
+type branchAligner struct {
+	measured bool
+	// delaySamples/delayFrac: the branch delayed and by how much. delayIdx is
+	// -1 while nothing needs delaying (measured a zero skew, or unmeasured).
+	delayIdx     int
+	delaySamples int
+	delayFrac    float64
+	dline        []complex64 // last delaySamples+1 samples of the delayed branch
+
+	buf0, buf1 []complex64 // measurement accumulation (nil once measured)
+}
+
+const (
+	// alignMeasureSamples is the per-branch buffer the delay estimate is
+	// computed from: 2^17 samples (0.65 s at 200 kS/s, 2 MB total) gives a
+	// noise-only |rho| floor of ~0.0025 — alignMinRho sits 40× above it.
+	alignMeasureSamples = 1 << 17
+	// alignMaxLag bounds the scan; a skew beyond ±16 samples is not a subtle
+	// DSP-chain difference but a broken stream, and combining is hopeless
+	// anyway.
+	alignMaxLag = 16
+	// alignMinRho is the minimum peak coherence to latch a measurement: below
+	// it there is no coherent signal to align on, and latching a noise-driven
+	// ±16-sample delay would be worse than none. Discard and re-accumulate.
+	alignMinRho = 0.1
+)
+
+func newBranchAligner() *branchAligner { return &branchAligner{delayIdx: -1} }
+
+// reset drops the latched delay and measurement state; the next process()
+// starts a fresh measurement. Call when the stream restarts (a start-of-
+// stream skew is per-stream) or on a retune (cheap, and conservative about
+// hardware that re-times its DSP chain on an LO change).
+func (a *branchAligner) reset() {
+	a.measured = false
+	a.delayIdx = -1
+	a.delaySamples = 0
+	a.delayFrac = 0
+	a.dline = nil
+	a.buf0, a.buf1 = nil, nil
+}
+
+// process aligns one two-branch datagram in place (the delayed branch's slice
+// is REPLACED, not mutated). Returns the measured total delay and true the
+// one time a measurement latches, so the caller can log it.
+func (a *branchAligner) process(branches [][]complex64) (latched bool, delay float64, peakRho float64) {
+	if len(branches) != 2 {
+		return false, 0, 0
+	}
+	if !a.measured {
+		a.buf0 = append(a.buf0, branches[0]...)
+		a.buf1 = append(a.buf1, branches[1]...)
+		if len(a.buf0) < alignMeasureSamples || len(a.buf1) < alignMeasureSamples {
+			return false, 0, 0
+		}
+		lag, frac, rho := estimateBranchDelay(a.buf0, a.buf1)
+		a.buf0, a.buf1 = nil, nil
+		if rho < alignMinRho {
+			// No coherent signal yet: re-accumulate rather than latch noise.
+			return false, 0, 0
+		}
+		a.measured = true
+		total := float64(lag) + frac // delay of branch 1 relative to branch 0
+		// Delay the EARLY branch so both see the wavefront at the same index.
+		switch {
+		case total > 0.01: // branch 1 lags ⇒ branch 0 is early
+			a.configureDelay(0, total)
+		case total < -0.01: // branch 0 lags ⇒ branch 1 is early
+			a.configureDelay(1, -total)
+		default:
+			a.delayIdx = -1 // aligned already; nothing to do
+		}
+		latched, delay, peakRho = true, total, rho
+	}
+	if a.delayIdx >= 0 {
+		branches[a.delayIdx] = a.applyDelay(branches[a.delayIdx])
+	}
+	return latched, delay, peakRho
+}
+
+func (a *branchAligner) configureDelay(idx int, total float64) {
+	a.delayIdx = idx
+	a.delaySamples = int(total)
+	a.delayFrac = total - float64(a.delaySamples)
+	a.dline = make([]complex64, a.delaySamples+1)
+}
+
+// applyDelay emits x delayed by delaySamples+delayFrac, carrying the tail
+// across datagrams: with dline = the previous (delaySamples+1) samples and
+// ext = dline ++ x, y[i] = (1-f)·ext[i+1] + f·ext[i].
+func (a *branchAligner) applyDelay(x []complex64) []complex64 {
+	ext := make([]complex64, 0, len(a.dline)+len(x))
+	ext = append(ext, a.dline...)
+	ext = append(ext, x...)
+	f := float32(a.delayFrac)
+	y := make([]complex64, len(x))
+	for i := range y {
+		y[i] = ext[i+1]*complex(1-f, 0) + ext[i]*complex(f, 0)
+	}
+	copy(a.dline, ext[len(ext)-len(a.dline):])
+	return y
+}
+
+// estimateBranchDelay returns the integer lag (positive = branch 1 lags
+// branch 0), a parabolic fractional refinement in (-1, 1), and the peak
+// normalised |rho| at the integer lag. Inputs are DC-removed before
+// correlating — two branches sharing LO leakage would otherwise report a
+// confident lag-0 on nothing (the CrossStats lesson).
+func estimateBranchDelay(b0, b1 []complex64) (lag int, frac float64, rho float64) {
+	n := len(b0)
+	if len(b1) < n {
+		n = len(b1)
+	}
+	if n <= 2*alignMaxLag+2 {
+		return 0, 0, 0
+	}
+	x0 := removeDC(b0[:n])
+	x1 := removeDC(b1[:n])
+
+	var p0, p1 float64
+	for i := 0; i < n; i++ {
+		p0 += float64(real(x0[i]))*float64(real(x0[i])) + float64(imag(x0[i]))*float64(imag(x0[i]))
+		p1 += float64(real(x1[i]))*float64(real(x1[i])) + float64(imag(x1[i]))*float64(imag(x1[i]))
+	}
+	norm := math.Sqrt(p0 * p1)
+	if norm == 0 {
+		return 0, 0, 0
+	}
+
+	mags := make([]float64, 2*alignMaxLag+1)
+	best := 0.0
+	for l := -alignMaxLag; l <= alignMaxLag; l++ {
+		var cr, ci float64
+		for i := 0; i < n-alignMaxLag; i++ {
+			var a, b complex64
+			if l >= 0 {
+				a, b = x0[i], x1[i+l]
+			} else {
+				a, b = x0[i-l], x1[i]
+			}
+			// conj(a)·b
+			cr += float64(real(a))*float64(real(b)) + float64(imag(a))*float64(imag(b))
+			ci += float64(real(a))*float64(imag(b)) - float64(imag(a))*float64(real(b))
+		}
+		m := math.Hypot(cr, ci)
+		mags[l+alignMaxLag] = m
+		if r := m / norm; r > best {
+			best, lag = r, l
+		}
+	}
+	rho = best
+
+	// Parabolic refinement on the correlation magnitudes around the peak.
+	k := lag + alignMaxLag
+	if k > 0 && k < len(mags)-1 {
+		ym, y0, yp := mags[k-1], mags[k], mags[k+1]
+		den := ym - 2*y0 + yp
+		if den != 0 {
+			f := 0.5 * (ym - yp) / den
+			if f > -0.99 && f < 0.99 && !math.IsNaN(f) {
+				frac = f
+			}
+		}
+	}
+	return lag, frac, rho
+}
+
+func removeDC(x []complex64) []complex64 {
+	var sr, si float64
+	for _, z := range x {
+		sr += float64(real(z))
+		si += float64(imag(z))
+	}
+	m := complex(float32(sr/float64(len(x))), float32(si/float64(len(x))))
+	out := make([]complex64, len(x))
+	for i, z := range x {
+		out[i] = z - m
+	}
+	return out
+}

--- a/internal/sdr/soapyremote/align_test.go
+++ b/internal/sdr/soapyremote/align_test.go
@@ -1,0 +1,145 @@
+package soapyremote
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+)
+
+// delayedCopy returns x delayed by an integer+fractional sample count via the
+// same linear interpolation model the aligner inverts (adequate: the test
+// signals are heavily oversampled, like a 25 kHz channel in a 200 kHz stream).
+func delayedCopy(x []complex64, total float64) []complex64 {
+	d := int(total)
+	f := float32(total - float64(d))
+	out := make([]complex64, len(x))
+	for i := range out {
+		j := i - d
+		if j-1 >= 0 && j < len(x) {
+			out[i] = x[j]*(1-complex(f, 0)) + x[j-1]*complex(f, 0)
+		}
+	}
+	return out
+}
+
+// lowpassSignal is a random signal whose energy sits well inside the band a
+// fractional linear interpolator handles transparently — a 4-sample moving
+// average over random phases, mimicking an oversampled channel.
+func lowpassSignal(rng *rand.Rand, n int, amp float64) []complex64 {
+	raw := mrcSignal(rng, n+4, amp)
+	out := make([]complex64, n)
+	for i := range out {
+		var s complex64
+		for k := 0; k < 4; k++ {
+			s += raw[i+k]
+		}
+		out[i] = s * 0.25
+	}
+	return out
+}
+
+func corrAtZero(a, b []complex64) float64 {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	var cr, ci, pa, pb float64
+	for i := 0; i < n; i++ {
+		cr += float64(real(a[i]))*float64(real(b[i])) + float64(imag(a[i]))*float64(imag(b[i]))
+		ci += float64(real(a[i]))*float64(imag(b[i])) - float64(imag(a[i]))*float64(real(b[i]))
+		pa += float64(real(a[i]))*float64(real(a[i])) + float64(imag(a[i]))*float64(imag(a[i]))
+		pb += float64(real(b[i]))*float64(real(b[i])) + float64(imag(b[i]))*float64(imag(b[i]))
+	}
+	if pa == 0 || pb == 0 {
+		return 0
+	}
+	return math.Hypot(cr, ci) / math.Sqrt(pa*pb)
+}
+
+// TestEstimateBranchDelay pins the measurement: sign convention (positive =
+// branch 1 lags branch 0), integer + fractional recovery, and the DC-removal
+// guard (two branches of independent noise sharing a DC offset must not read
+// as coherent — the CrossStats lesson).
+func TestEstimateBranchDelay(t *testing.T) {
+	rng := rand.New(rand.NewSource(11))
+	x := lowpassSignal(rng, alignMeasureSamples, 0.4)
+
+	for _, want := range []float64{2.6, 3.0, -1.4} {
+		b1 := delayedCopy(x, want)
+		if want < 0 {
+			b1 = delayedCopy(x, 0)
+			x2 := delayedCopy(x, -want) // branch 0 lags instead
+			lag, frac, rho := estimateBranchDelay(x2, b1)
+			if got := float64(lag) + frac; math.Abs(got-want) > 0.15 || rho < 0.9 {
+				t.Errorf("delay %.1f: measured %.2f (rho %.2f)", want, got, rho)
+			}
+			continue
+		}
+		lag, frac, rho := estimateBranchDelay(x, b1)
+		if got := float64(lag) + frac; math.Abs(got-want) > 0.15 || rho < 0.9 {
+			t.Errorf("delay %.1f: measured %.2f (rho %.2f)", want, got, rho)
+		}
+	}
+
+	// Independent noise + common DC: must not clear the latch gate.
+	n0 := mrcNoise(rng, make([]complex64, alignMeasureSamples), 0.1)
+	n1 := mrcNoise(rng, make([]complex64, alignMeasureSamples), 0.1)
+	for i := range n0 {
+		n0[i] += complex(0.3, 0.3)
+		n1[i] += complex(0.3, 0.3)
+	}
+	if _, _, rho := estimateBranchDelay(n0, n1); rho >= alignMinRho {
+		t.Errorf("independent noise with common DC measured rho=%.2f — the DC guard failed", rho)
+	}
+}
+
+// TestMRCCombinerAlignsSkewedBranches is the failing-first regression for the
+// 19 Aug field capture: branch 1 is a 2.6-sample-delayed copy of branch 0
+// (the measured X310 skew), which a scalar combine turns into a comb filter.
+// The combiner must measure the skew, delay the early branch, recalibrate on
+// the aligned stream, and emit output that matches the (aligned) signal —
+// combining must stop being WORSE than the best branch alone.
+func TestMRCCombinerAlignsSkewedBranches(t *testing.T) {
+	rng := rand.New(rand.NewSource(12))
+	const skew = 2.6
+	const datagram = 184
+
+	m := newMRCCombiner(formatCS16, diversityMRCTracking, 0)
+
+	// Enough datagrams to fill the measurement buffer, latch, recalibrate and
+	// emit a stretch of aligned output.
+	total := alignMeasureSamples + 12*mrcTestWindow
+	x := lowpassSignal(rng, total+8, 0.4)
+	b1full := delayedCopy(x, skew)
+
+	var outTail, refTail []complex64
+	for pos := 0; pos+datagram <= total; pos += datagram {
+		ch0 := x[pos : pos+datagram]
+		ch1 := b1full[pos : pos+datagram]
+		out := m.combine(twoBranchPayload(ch0, ch1), datagram)
+		if pos > alignMeasureSamples+8*mrcTestWindow {
+			outTail = append(outTail, out...)
+			refTail = append(refTail, ch1...) // the DELAYED timeline both branches now share
+		}
+	}
+
+	if !m.align.measured {
+		t.Fatal("combiner never measured the inter-branch delay")
+	}
+	if m.align.delayIdx != 0 {
+		t.Fatalf("delayed branch = %d, want 0 (the early branch)", m.align.delayIdx)
+	}
+	if got := float64(m.align.delaySamples) + m.align.delayFrac; math.Abs(got-skew) > 0.2 {
+		t.Fatalf("measured delay %.2f samples, want ~%.1f", got, skew)
+	}
+	if !m.cal.Calibrated() {
+		t.Fatal("combiner did not recalibrate after alignment")
+	}
+	// The aligned combine of a delayed-copy pair is the signal itself (up to
+	// scale): correlation with the shared timeline must be near-perfect. The
+	// UNALIGNED scalar combine of a 2.6-sample skew has a deep in-band comb
+	// notch and measures well below this bar — the failing-first assertion.
+	if rho := corrAtZero(outTail, refTail); rho < 0.995 {
+		t.Fatalf("combined output correlation with the aligned signal = %.3f, want >= 0.995 (comb-filtered?)", rho)
+	}
+}

--- a/internal/sdr/soapyremote/driver.go
+++ b/internal/sdr/soapyremote/driver.go
@@ -246,6 +246,7 @@ func (d *Driver) Open(idx int) (sdr.Device, error) {
 		// the rate. It is not programmed yet at Open; StreamIQ re-sizes the window
 		// once the delivered rate is known.
 		dev.mrc = newMRCCombiner(format, divMode, 0)
+		dev.mrc.log = d.log
 		dev.capturePrefix = spec.DiversityCapture
 		dev.captureSeconds = spec.DiversityCaptureSeconds
 	}
@@ -499,6 +500,17 @@ func (d *device) getAntenna(ch int32) (string, error) {
 }
 
 func (d *device) SetCenterFreq(hz uint32) error {
+	// A retune to the frequency the device is already on needs no RPC and — more
+	// importantly for diversity — no recalibration: the LO does not re-lock, so
+	// the frozen RX0↔RX1 phase constant is still valid. The cc-hunt supervisor
+	// re-issues the same frequency when it re-locks the same carrier; before
+	// this guard each such call reset a perfectly good MRC calibration.
+	d.mu.Lock()
+	same := hz != 0 && d.centerHz == hz
+	d.mu.Unlock()
+	if same {
+		return nil
+	}
 	if err := d.perRXChannel(func(p *packer, ch int32) {
 		p.call(callSetFrequency)
 		p.char(dirRX)

--- a/internal/sdr/soapyremote/driver_samefreq_test.go
+++ b/internal/sdr/soapyremote/driver_samefreq_test.go
@@ -1,0 +1,56 @@
+package soapyremote
+
+import "testing"
+
+// TestSetCenterFreqSameFrequencySkipsRetuneAndRecalibrate: re-issuing the
+// frequency the device is already on (the cc-hunt supervisor does this when it
+// re-locks the same carrier) must be a no-op — no SET_FREQUENCY RPC, and no MRC
+// recalibration: the LO never re-locks, so the frozen branch-phase constant is
+// still valid. Before this guard, every same-carrier re-hunt reset a perfectly
+// good calibration (and, before the anchor was made sticky, flipped it).
+func TestSetCenterFreqSameFrequencySkipsRetuneAndRecalibrate(t *testing.T) {
+	srv := newFakeSoapyServer(t)
+	drv := New([]Spec{{Addr: srv.Addr(), Format: "CS16", Diversity: "mrc"}}, testLogger())
+	devIf, err := drv.Open(0)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer devIf.Close()
+	dev := devIf.(*device)
+
+	if err := dev.SetCenterFreq(851_000_000); err != nil {
+		t.Fatalf("SetCenterFreq(first): %v", err)
+	}
+	dev.mrc.rearm.Store(false) // consume the legitimate first-tune rearm
+	countFreqCalls := func() int {
+		n := 0
+		for _, c := range srv.recorded() {
+			if c.id == callSetFrequency && c.freqHz == 851_000_000 {
+				n++
+			}
+		}
+		return n
+	}
+	first := countFreqCalls()
+	if first == 0 {
+		t.Fatal("first tune issued no SET_FREQUENCY")
+	}
+
+	if err := dev.SetCenterFreq(851_000_000); err != nil {
+		t.Fatalf("SetCenterFreq(repeat): %v", err)
+	}
+	if got := countFreqCalls(); got != first {
+		t.Errorf("repeat tune to the same frequency issued %d extra SET_FREQUENCY RPCs, want 0", got-first)
+	}
+	if dev.mrc.rearm.Load() {
+		t.Error("repeat tune to the same frequency re-armed MRC recalibration — the LO did not re-lock")
+	}
+
+	// A genuinely different frequency still tunes and re-arms.
+	if err := dev.SetCenterFreq(852_000_000); err != nil {
+		t.Fatalf("SetCenterFreq(new): %v", err)
+	}
+	if !dev.mrc.rearm.Load() {
+		t.Error("a real retune did not re-arm MRC recalibration")
+	}
+}

--- a/internal/sdr/soapyremote/mrc.go
+++ b/internal/sdr/soapyremote/mrc.go
@@ -270,6 +270,11 @@ type mrcCombiner struct {
 	refIdx  int
 	ordered [][]complex64
 
+	// align removes the constant inter-branch timing skew a scalar gain cannot
+	// represent (see branchAligner). Measured once per stream/retune, before
+	// the calibrator sees any samples of the aligned stream.
+	align *branchAligner
+
 	// refDeadDatagrams counts consecutive datagrams in which the incumbent
 	// reference looked dead relative to a challenger; see mrcRefDeadDatagrams.
 	refDeadDatagrams int
@@ -308,6 +313,7 @@ func newMRCCombiner(format sampleFormat, mode diversityMode, rateHz float64) *mr
 		refIdx:   -1,
 		ordered:  make([][]complex64, diversityChannels),
 		powDbFS:  make([]float64, diversityChannels),
+		align:    newBranchAligner(),
 	}
 }
 
@@ -408,7 +414,10 @@ func (m *mrcCombiner) setSampleRate(rateHz float64) {
 	// A window re-size drops the gain estimate but, like the rearm path in
 	// combine(), deliberately KEEPS the anchor: the stream rate says nothing
 	// about which antenna is better, and moving the anchor is a phase step.
+	// The delay alignment IS re-measured — a fresh stream has a fresh
+	// start-of-stream skew.
 	m.refDeadDatagrams = 0
+	m.align.reset()
 }
 
 // requestRecalibrate arms a calibration reset to be applied by the next
@@ -431,9 +440,13 @@ func (m *mrcCombiner) combine(payload []byte, elems int) []complex64 {
 		// (±180° phase + several dB amplitude step) on every cc-hunt retune —
 		// observed in the 19 Aug field log at the 08:58 sync loss. A kept
 		// anchor that is genuinely dead still escapes via the uncalibrated
-		// dead-incumbent path in selectReference.
+		// dead-incumbent path in selectReference. The delay alignment is
+		// re-measured (cheap: ~0.65 s of passthrough-equivalent combining at
+		// 200 kS/s) in case the hardware re-times its DSP chain on an LO
+		// change; the anchor is NOT.
 		m.cal.Reset()
 		m.refDeadDatagrams = 0
+		m.align.reset()
 	}
 	branches := m.format.deinterleave(payload, m.channels, elems)
 	// Tap the branches BEFORE anything is done to them, so a capture is exactly
@@ -462,6 +475,23 @@ func (m *mrcCombiner) combine(payload []byte, elems int) []complex64 {
 			m.refIdx = 0
 		}
 		return branches[0]
+	}
+	// Remove the constant inter-branch timing skew BEFORE the calibrator sees
+	// the samples: a scalar gain cannot represent a delay, and combining
+	// skewed branches decodes WORSE than the best branch alone (19 Aug field
+	// capture: 2.60 samples of skew cost ~22% of CRC-clean BSCH; aligned, the
+	// combine matched the best branch). The capture tap above stays RAW so an
+	// offline replay can re-derive the skew independently.
+	if latched, delay, rho := m.align.process(branches); latched {
+		// Any gain locked during the measurement was estimated on the SKEWED
+		// stream; restart calibration so both tracking and static modes lock
+		// on the aligned one. The reset coincides with the alignment's own
+		// one-time timeline step, so it adds no extra discontinuity.
+		m.cal.Reset()
+		if m.log != nil {
+			m.log.Info("soapyremote: MRC inter-branch delay measured — delaying the early branch to align the combine",
+				"delay_samples", round2(delay), "peak_rho", round2(rho))
+		}
 	}
 	m.selectReference()
 	if m.refIdx < 0 {

--- a/internal/sdr/soapyremote/mrc.go
+++ b/internal/sdr/soapyremote/mrc.go
@@ -269,6 +269,12 @@ type mrcCombiner struct {
 	// reference looked dead relative to a challenger; see mrcRefDeadDatagrams.
 	refDeadDatagrams int
 
+	// log, when non-nil, reports anchor changes. Every refIdx change is a phase
+	// discontinuity into the downstream differential decoder, so it must be
+	// visible in the log rather than only inferable from the 30 s health line
+	// (the 19 Aug field flip was silent). Nil in tests that don't care.
+	log *slog.Logger
+
 	// Diagnostics, refreshed every combine(): per-branch mean power and how the
 	// last payload split. See health().
 	powDbFS   []float64
@@ -394,7 +400,9 @@ func (m *mrcCombiner) setSampleRate(rateHz float64) {
 	opts := mrcCalOptions(m.mode, want, rateHz)
 	m.lockGate = opts.LockGate(want)
 	m.cal = diversity.NewTrackingCalibrator(diversityChannels, opts)
-	m.refIdx = -1
+	// A window re-size drops the gain estimate but, like the rearm path in
+	// combine(), deliberately KEEPS the anchor: the stream rate says nothing
+	// about which antenna is better, and moving the anchor is a phase step.
 	m.refDeadDatagrams = 0
 }
 
@@ -410,8 +418,16 @@ func (m *mrcCombiner) requestRecalibrate() { m.rearm.Store(true) }
 // force-split into fake branches.
 func (m *mrcCombiner) combine(payload []byte, elems int) []complex64 {
 	if m.rearm.Swap(false) {
+		// A retune invalidates the GAIN estimate (new LO lock ⇒ new relative
+		// phase), so the calibrator restarts — but it does NOT change which
+		// antenna is the better anchor, so refIdx is deliberately KEPT. The old
+		// code un-latched it to -1 here, and the next datagram's bare argmax
+		// re-pick handed the differential decoder an unlogged anchor flip
+		// (±180° phase + several dB amplitude step) on every cc-hunt retune —
+		// observed in the 19 Aug field log at the 08:58 sync loss. A kept
+		// anchor that is genuinely dead still escapes via the uncalibrated
+		// dead-incumbent path in selectReference.
 		m.cal.Reset()
-		m.refIdx = -1
 		m.refDeadDatagrams = 0
 	}
 	branches := m.format.deinterleave(payload, m.channels, elems)
@@ -430,11 +446,16 @@ func (m *mrcCombiner) combine(payload []byte, elems int) []complex64 {
 	if len(branches) != m.channels {
 		// The server did not deliver every channel (see deinterleave). Emitting
 		// the payload verbatim keeps the stream a valid single-receiver time
-		// series; the health line reports the shortfall.
+		// series; the health line reports the shortfall. A held anchor is NOT
+		// rewritten by one short payload — that would be a silent anchor move
+		// (see the rearm comment above); it is only seeded when nothing was
+		// anchored yet.
 		if len(branches) == 0 {
 			return nil
 		}
-		m.refIdx = 0
+		if m.refIdx < 0 {
+			m.refIdx = 0
+		}
 		return branches[0]
 	}
 	m.selectReference()
@@ -468,6 +489,10 @@ func (m *mrcCombiner) selectReference() {
 	if m.refIdx < 0 {
 		m.refIdx = best
 		m.refDeadDatagrams = 0
+		if m.log != nil {
+			m.log.Info("soapyremote: MRC phase anchor latched",
+				"reference_branch", best, "branch_dbfs", formatBranchPowers(m.powDbFS))
+		}
 		return
 	}
 	// Only a persistently dead incumbent moves the anchor.
@@ -477,6 +502,11 @@ func (m *mrcCombiner) selectReference() {
 	}
 	m.refDeadDatagrams++
 	if m.refDeadDatagrams >= mrcRefDeadDatagrams {
+		if m.log != nil {
+			m.log.Info("soapyremote: MRC phase anchor moved off a dead reference — expect one decode discontinuity",
+				"old_reference", m.refIdx, "reference_branch", best,
+				"branch_dbfs", formatBranchPowers(m.powDbFS))
+		}
 		m.refIdx = best
 		m.refDeadDatagrams = 0
 		m.cal.Reset() // the anchor changed; the old estimate means nothing

--- a/internal/sdr/soapyremote/mrc.go
+++ b/internal/sdr/soapyremote/mrc.go
@@ -127,10 +127,15 @@ const (
 	mrcCalWindowDefaultSamples = 8192
 )
 
-// mrcTrackTauMs is the tracking loop's 1/e time constant. 200 ms is roughly 14
-// TETRA bursts: far slower than one burst, so the phase a burst sees is
-// effectively constant, and far faster than the relative drift of two
-// independently-locked front-end PLLs.
+// mrcTrackTauMs is the tracking loop's 1/e time constant: far faster than the
+// relative drift of two independently-locked front-end PLLs, slow enough that
+// the per-window applied-phase step stays deep inside the π/4-DQPSK decision
+// margin. NOTE the per-burst-constancy argument is per-STEP, not per-tau: at a
+// clamped low-rate window (200 kHz → 4096 samples = 20.48 ms) one window is
+// ~1.5 TETRA bursts and alpha reaches ~0.10, so what protects a burst is the
+// bounded per-window step (α × the gated estimate error, hard-clamped by
+// trackingMaxStepRad) — pinned by TestTrackingCalibratorIsDifferentialSafe's
+// driver200kHzAlpha subtest in internal/dsp/diversity.
 const mrcTrackTauMs = 200.0
 
 // mrcTrackAlpha is the one-pole coefficient implied by the window and the time

--- a/internal/sdr/soapyremote/mrc_anchor_test.go
+++ b/internal/sdr/soapyremote/mrc_anchor_test.go
@@ -1,0 +1,132 @@
+package soapyremote
+
+import (
+	"bytes"
+	"log/slog"
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+// anchorFixture calibrates a combiner with branch 1 as the louder (and hence
+// anchored) branch: ch1 carries the signal, ch0 a quieter rotated copy.
+func anchorFixture(t *testing.T, m *mrcCombiner) (ch0, ch1 []complex64) {
+	t.Helper()
+	rng := rand.New(rand.NewSource(7))
+	ch1 = mrcSignal(rng, mrcTestWindow, 0.4)
+	ch0 = scaleC(ch1, complex(0, 0.2)) // −6 dB, +90°
+	m.combine(twoBranchPayload(ch0, ch1), len(ch1))
+	if h := m.health(); h.refIdx != 1 {
+		t.Fatalf("fixture: reference = %d, want 1 (the louder branch)", h.refIdx)
+	}
+	if !m.cal.Calibrated() {
+		t.Fatal("fixture: combiner did not calibrate")
+	}
+	return ch0, ch1
+}
+
+// TestMRCCombinerKeepsReferenceAcrossRearm is the failing-first regression for
+// the 19 Aug 08:58 field event: a cc-hunt retune (requestRecalibrate) used to
+// un-latch the anchor to -1, and the next datagram's bare argmax re-pick
+// flipped the reference mid-stream — an unlogged ±180° phase + several dB
+// amplitude discontinuity into the differential decoder. A retune invalidates
+// the GAIN (new LO lock), never the choice of anchor: after a rearm the
+// reference must stay where it was, even when the other branch is momentarily
+// louder (the field condition after the operator's antenna swap).
+func TestMRCCombinerKeepsReferenceAcrossRearm(t *testing.T) {
+	m := newMRCCombiner(formatCS16, diversityMRCTracking, 0)
+	anchorFixture(t, m)
+
+	m.requestRecalibrate()
+	// Post-retune datagrams: branch 0 now ~6 dB louder than the incumbent
+	// reference — far below the dead-incumbent margin, so the anchor must hold.
+	rng := rand.New(rand.NewSource(8))
+	for i := 0; i < 8; i++ {
+		ch0 := mrcSignal(rng, 256, 0.4)
+		ch1 := scaleC(ch0, complex(0.2, 0))
+		m.combine(twoBranchPayload(ch0, ch1), 256)
+		if h := m.health(); h.refIdx != 1 {
+			t.Fatalf("reference flipped to %d after a rearm (datagram %d) — a retune must not move the phase anchor", h.refIdx, i)
+		}
+	}
+}
+
+// TestMRCCombinerRearmEscapesDeadReference pins the escape that keeps the kept
+// anchor safe: when the incumbent reference is genuinely dead (>20 dB down)
+// after a rearm, the uncalibrated dead-incumbent path still moves the anchor
+// within mrcRefDeadDatagrams datagrams.
+func TestMRCCombinerRearmEscapesDeadReference(t *testing.T) {
+	m := newMRCCombiner(formatCS16, diversityMRCTracking, 0)
+	anchorFixture(t, m)
+
+	m.requestRecalibrate()
+	rng := rand.New(rand.NewSource(9))
+	for i := 0; i < mrcRefDeadDatagrams+1; i++ {
+		ch0 := mrcSignal(rng, 256, 0.4)
+		dead := mrcNoise(rng, make([]complex64, 256), 1e-4) // ~ -80 dBFS: >20 dB down
+		m.combine(twoBranchPayload(ch0, dead), 256)
+	}
+	if h := m.health(); h.refIdx != 0 {
+		t.Fatalf("reference = %d, want 0: a genuinely dead incumbent must still be escaped after a rearm", h.refIdx)
+	}
+}
+
+// TestMRCCombinerSetSampleRateKeepsReference: a stream-rate change re-sizes the
+// estimation window and drops the gain estimate, but says nothing about which
+// antenna is better — the anchor must survive it.
+func TestMRCCombinerSetSampleRateKeepsReference(t *testing.T) {
+	m := newMRCCombiner(formatCS16, diversityMRCTracking, 0)
+	anchorFixture(t, m)
+
+	m.setSampleRate(2_400_000)
+	if h := m.health(); h.refIdx != 1 {
+		t.Fatalf("reference = %d after setSampleRate, want 1 (kept)", h.refIdx)
+	}
+}
+
+// TestMRCCombinerDegeneratePayloadDoesNotMoveAnchor is failing-first for the
+// short-payload stomp: a datagram that delivers only one channel used to
+// unconditionally rewrite refIdx to 0, silently moving a held anchor. It must
+// pass the payload through without touching the anchor.
+func TestMRCCombinerDegeneratePayloadDoesNotMoveAnchor(t *testing.T) {
+	m := newMRCCombiner(formatCS16, diversityMRCTracking, 0)
+	_, ch1 := anchorFixture(t, m)
+
+	out := m.combine(encodeCS16(ch1[:64]), 64) // single-channel payload
+	if !approxEqualC(out, ch1[:64], 1e-3) {
+		t.Fatal("degenerate payload was not passed through verbatim")
+	}
+	if h := m.health(); h.refIdx != 1 {
+		t.Fatalf("reference = %d after a degenerate payload, want 1 (a short datagram must not move the anchor)", h.refIdx)
+	}
+}
+
+// TestMRCCombinerLogsReferenceChange: every anchor movement is a decode
+// discontinuity, so both the initial latch and a dead-incumbent move must be
+// visible in the log (the 19 Aug field flip was silent — only inferable from
+// two 30 s health lines).
+func TestMRCCombinerLogsReferenceChange(t *testing.T) {
+	buf := &bytes.Buffer{}
+	m := newMRCCombiner(formatCS16, diversityMRCTracking, 0)
+	m.log = slog.New(slog.NewTextHandler(buf, nil))
+
+	rng := rand.New(rand.NewSource(10))
+	live := mrcSignal(rng, 256, 0.4)
+	dead := mrcNoise(rng, make([]complex64, 256), 1e-4)
+
+	m.combine(twoBranchPayload(dead, live), 256)
+	if !strings.Contains(buf.String(), "MRC phase anchor latched") {
+		t.Fatalf("initial anchor latch was not logged\n%s", buf.String())
+	}
+	buf.Reset()
+
+	for i := 0; i < mrcRefDeadDatagrams; i++ {
+		m.combine(twoBranchPayload(live, dead), 256) // incumbent (1) now dead
+	}
+	if h := m.health(); h.refIdx != 0 {
+		t.Fatalf("fixture: anchor did not move off the dead incumbent (ref=%d)", h.refIdx)
+	}
+	if !strings.Contains(buf.String(), "MRC phase anchor moved") {
+		t.Fatalf("anchor move was not logged\n%s", buf.String())
+	}
+}


### PR DESCRIPTION
A 19 Aug field log showed the CC receiver 'locked but deaf' for ~37 min
total (12 min in one stretch): after a decode-drought resync, the AFC's
EMA re-primed from a single weak-signal block into the wrong ±f_sym/4
alias bucket (−3630 Hz), and the π/4 alias-reject then discarded every
CORRECT per-block estimate as an outlier — permanently. The constant
~17°/symbol differential residual let SB/BSCH keep decoding (4-rotation
search + heavy FEC) while every SCH block failed CRC, so sch_pdus=0,
sysinfo=0, grants=0, and no watchdog fired.

carrierAFC now tracks consecutive rejected estimates that agree with
each other (within half the reject window): three in a row re-prime the
EMA from their mean (~170 ms). Sporadic/scattered ISI outliers cannot
trip it — any accepted block zeroes the streak, and alternating alias
buckets restart the cluster.

TestAFCEscapesWrongAliasSeed and TestReceiverRecoversFromAliasLatchedAFC
fail against the old code with exactly the field signature (latched at
−3630 Hz, no lock); TestAFCReportedOffsetStableUnderMultipath stays
green at -count=20.

Refs the 19 Aug X310 MRC field log.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ViDLCTFvNeYiey1Mwj6zHh