### PR TITLE
capture: software-decimate IQ recordings for high-rate-floor SDRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,19 @@ for tagged releases.
   only — no code changes.
 
 ### Added
+- **Software decimation for IQ captures — record long grabs off a radio whose
+  hardware sample-rate floor is too high.** The USRP B210 cannot stream below
+  ~1 MS/s, so a single narrowband channel could only be captured as a huge
+  full-rate file. Captures can now be anti-alias decimated to `rate / N` on the
+  way to disk, reusing the same down-converter the live decode path uses (no new
+  DSP): `gophertrunk capture -decimate N` (full band, or `-bandwidth` for a
+  narrowband slice), the daemon's `--iq-capture …,decimate=N` (which also writes
+  a metadata sidecar with the reduced rate so the smaller file replays), and
+  `baseband.auto_record: { tap: wideband, decimate: N }`. A B210 at its 1 MS/s
+  floor with `decimate: 5` yields an alias-free 200 kS/s file — one fifth the
+  size, still wide enough to debug. `decimate` is a wideband-tap lever; a value
+  above 1 with `tap: ddc` (already narrowband) is rejected at config load. No
+  change to undecimated captures.
 - **Conventional scanner channels upload under their configured name.** A
   `scanner.conventional` channel's `label:` now travels on the call grant to
   Rdio Scanner and the other scan-type consumers (OpenMHz, Broadcastify Calls),

--- a/cmd/gophertrunk/capture.go
+++ b/cmd/gophertrunk/capture.go
@@ -43,6 +43,7 @@ func runCapture(args []string) {
 	format := fs.String("format", "f32", "capture sample format: u8 | f32 | cs16 (f32 = GNU Radio cfile; cs16 = headerless 16-bit raw)")
 	centerHz := fs.Uint("center", 0, "narrowband slice centre in Hz (default: -freq); with -bandwidth, carves a channel from the captured wideband without retuning")
 	bandwidthHz := fs.Uint("bandwidth", 0, "narrowband slice bandwidth in Hz; when > 0 the capture is decimated to ~this rate around -center (must fit inside -freq ± sample-rate/2)")
+	decimate := fs.Uint("decimate", 0, "integer software-decimation factor: record the full band anti-alias decimated to sample-rate/decimate (a manageable long capture off a source like the USRP B210 whose hardware rate floor is ~1 MS/s). Mutually exclusive with -bandwidth")
 	protocol := fs.String("protocol", "", "protocol name written to the metadata sidecar (enables `test`; see `gophertrunk gen -list`)")
 	source := fs.String("source", "", "free-text provenance written to the metadata sidecar")
 	tune := fs.Float64("tune", 0, "fine software tune offset in Hz written to the metadata sidecar")
@@ -72,6 +73,11 @@ EXAMPLES:
   # a 2.4 MS/s grab centred there — a shareable .raw a fraction of the full size
   gophertrunk capture -freq 467913000 -sample-rate 2400000 -seconds 30 \
     -center 467913000 -bandwidth 50000 -format cs16 -out cc.raw
+
+  # USRP B210 (hardware rate floor ~1 MS/s): record the full band but software-
+  # decimate ×5 → an alias-free 200 kS/s file, a fifth the size, still replayable
+  gophertrunk capture -freq 467913000 -sample-rate 1000000 -seconds 60 \
+    -decimate 5 -format cs16 -protocol tetra -out cc.raw
 
   # List the SDRs this binary can capture from
   gophertrunk capture -list
@@ -164,7 +170,18 @@ FLAGS:`)
 	var ddc *ccdecoder.Downconverter
 	recRate := float64(*sampleRate)
 	recCenter := uint32(*freq)
-	if *bandwidthHz > 0 {
+	if *bandwidthHz > 0 && *decimate > 1 {
+		rep.Fatalf(2, "-bandwidth and -decimate are mutually exclusive (both decimate; pick one)")
+	}
+	if *decimate > 1 {
+		// Full-band integer decimation: keep the whole captured span, just at
+		// a lower rate. Same down-converter as the -bandwidth slice, targeted
+		// at sample-rate/decimate with no tuning offset (centre stays -freq).
+		ddc = ccdecoder.NewDownconverter(float64(*sampleRate), float64(*sampleRate)/float64(*decimate))
+		recRate = ddc.OutRateHz()
+		fmt.Printf("capture: software decimation ×%d → %.1f kHz effective rate\n",
+			*decimate, recRate/1e3)
+	} else if *bandwidthHz > 0 {
 		center := uint32(*centerHz)
 		if center == 0 {
 			center = uint32(*freq)

--- a/cmd/gophertrunk/iqautorecord.go
+++ b/cmd/gophertrunk/iqautorecord.go
@@ -68,6 +68,11 @@ type iqAutoRecorder struct {
 	cooldown time.Duration
 	dir      string
 	seconds  int
+	// decimate is the integer software-decimation factor for the wideband
+	// tap: the capture is anti-alias filtered and written at SDR-rate /
+	// decimate. 0/1 records the full rate. Ignored for the ddc tap (already
+	// narrowband; config validation rejects decimate > 1 with tap: ddc).
+	decimate int
 	log      *slog.Logger
 
 	// ddc lazily resolves the control decoder for the "ddc" tap (nil when the
@@ -123,6 +128,7 @@ func newIQAutoRecorder(cfg config.BasebandAutoRecordConfig, system, protocol, se
 		cooldown: cooldown,
 		dir:      cfg.Dir,
 		seconds:  cfg.Seconds,
+		decimate: cfg.Decimate,
 		ddc:      ddc,
 		log:      log.With("component", "iq-autorecord", "serial", serial),
 		now:      time.Now,
@@ -160,7 +166,11 @@ func (a *iqAutoRecorder) defaultCapture(ctx context.Context, path string, format
 	if a.broker == nil {
 		return 0, 0, fmt.Errorf("iq-autorecord: no broker")
 	}
-	samples, _, drops, err := captureIQToFile(ctx, a.broker, path, format, seconds)
+	// Wideband tap: optionally software-decimate to shrink the capture
+	// (SDR-rate / decimate). nil ddc when decimate <= 1 keeps the full-rate
+	// path byte-identical to before.
+	ddc := newCaptureDecimator(a.broker.SampleRateHz(), a.decimate)
+	samples, _, drops, err := captureIQToFile(ctx, a.broker, path, format, seconds, ddc)
 	return samples, drops, err
 }
 
@@ -390,6 +400,11 @@ func (a *iqAutoRecorder) runCapture(ctx context.Context, reason, system, protoco
 	} else if a.broker != nil {
 		centerHz = a.broker.CenterHz()
 		rateHz = a.broker.SampleRateHz()
+		// Software decimation lowers the on-disk rate; stamp the metadata +
+		// filename with the reduced rate so the capture replays correctly.
+		if dec := newCaptureDecimator(rateHz, a.decimate); dec != nil {
+			rateHz = uint32(dec.OutRateHz() + 0.5)
+		}
 	}
 	if system == "" {
 		system = a.system

--- a/cmd/gophertrunk/iqautorecord_test.go
+++ b/cmd/gophertrunk/iqautorecord_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/MattCheramie/GopherTrunk/internal/config"
 	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/iqtap"
 	"github.com/MattCheramie/GopherTrunk/internal/siglab"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
@@ -143,6 +144,70 @@ func TestAutoRecordDDCTapMetadata(t *testing.T) {
 	}
 	if m.Format != "cs16" {
 		t.Errorf("metadata format = %q, want cs16", m.Format)
+	}
+}
+
+// TestAutoRecordWidebandDecimateMetadata pins that a wideband tap with
+// decimate: N stamps the reduced rate (SDR-rate / N) into the filename and the
+// metadata sidecar, so the smaller capture replays at the right rate. Without
+// the decimation wiring the metadata carries the full 1 MHz SDR rate and this
+// fails.
+func TestAutoRecordWidebandDecimateMetadata(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.BasebandAutoRecordConfig{
+		Enabled: true, Dir: dir, Seconds: 1, Format: "cs16", Tap: "wideband", Decimate: 5,
+	}
+	// A broker seeded to a 1 MHz SDR rate + centre (the B210-at-its-floor case).
+	broker := iqtap.New(rateOnlyDevice{}, 0, nil)
+	broker.Seed(467_913_000, 1_000_000)
+	a := newIQAutoRecorder(cfg, "SITE", "tetra", "B210", broker, nil, nil)
+	if a == nil {
+		t.Fatal("newIQAutoRecorder returned nil")
+	}
+	// Stub the actuation — this test asserts the runCapture rate math, not the
+	// stream; the transform itself is covered by TestCaptureEncoderDecimates.
+	a.capture = func(_ context.Context, path string, _ siglab.SampleFormat, _ int) (int64, uint64, error) {
+		return 10, 0, os.WriteFile(path, []byte("iq"), 0o644)
+	}
+	now := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	a.now = func() time.Time { return now }
+	a.runCapture(context.Background(), "manual", "SITE", "tetra", now)
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	var capName, metaPath string
+	for _, e := range entries {
+		switch {
+		case strings.HasSuffix(e.Name(), ".cs16"):
+			capName = e.Name()
+		case strings.HasSuffix(e.Name(), ".metadata.json"):
+			metaPath = filepath.Join(dir, e.Name())
+		}
+	}
+	if capName == "" {
+		t.Fatalf("no capture written; dir has %v", entries)
+	}
+	if !strings.Contains(capName, "200000hz") {
+		t.Errorf("filename %q does not carry the decimated rate 200000hz (1 MHz / 5)", capName)
+	}
+	b, err := os.ReadFile(metaPath)
+	if err != nil {
+		t.Fatalf("read metadata: %v", err)
+	}
+	var m struct {
+		SampleRateHz float64 `json:"sample_rate_hz"`
+		CenterFreqHz uint32  `json:"center_freq_hz"`
+	}
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("parse metadata: %v", err)
+	}
+	if m.SampleRateHz != 200000 {
+		t.Errorf("metadata sample_rate_hz = %v, want 200000 (1 MHz decimated by 5)", m.SampleRateHz)
+	}
+	if m.CenterFreqHz != 467_913_000 {
+		t.Errorf("metadata center_freq_hz = %d, want 467913000", m.CenterFreqHz)
 	}
 }
 

--- a/cmd/gophertrunk/iqcapture.go
+++ b/cmd/gophertrunk/iqcapture.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/MattCheramie/GopherTrunk/internal/scanner/ccdecoder"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr/iqtap"
 	"github.com/MattCheramie/GopherTrunk/internal/siglab"
 )
@@ -27,6 +30,15 @@ type iqCaptureSpec struct {
 	Path    string
 	Seconds int
 	Format  string // "f32", "u8", or "cs16"
+	// Decimate is the integer software-decimation factor applied to the
+	// recorded stream: the capture is anti-alias filtered and written at
+	// SDR-rate / Decimate, cutting the file size (and effective bandwidth)
+	// by the same factor. 0 or 1 records the full SDR rate (the historical
+	// behaviour). This is the remedy for a source like the USRP B210 whose
+	// hardware sample-rate floor (~1 MS/s) is far above the bandwidth a
+	// single narrowband channel needs — record at the floor, decimate in
+	// software to a manageable long capture.
+	Decimate int
 }
 
 // parseIQCaptureSpec parses "serial=<s>,path=<file>,seconds=<n>[,format=u8|f32]".
@@ -67,6 +79,12 @@ func parseIQCaptureSpec(s string) (iqCaptureSpec, error) {
 			default:
 				return iqCaptureSpec{}, fmt.Errorf("iq-capture: format must be u8, f32, or cs16, got %q", v)
 			}
+		case "decimate":
+			n, err := strconv.Atoi(v)
+			if err != nil || n < 1 {
+				return iqCaptureSpec{}, fmt.Errorf("iq-capture: decimate must be an integer >= 1, got %q", v)
+			}
+			spec.Decimate = n
 		default:
 			return iqCaptureSpec{}, fmt.Errorf("iq-capture: unknown key %q", k)
 		}
@@ -89,6 +107,12 @@ func parseIQCaptureSpec(s string) (iqCaptureSpec, error) {
 // counter and surfaced once at the end so the operator knows the
 // capture is incomplete — drops are NOT retried (the primary IQ
 // stream is what the daemon needs unimpeded). Issue #402 diagnostic.
+//
+// When spec.Decimate > 1 the recorded stream is anti-alias decimated to
+// SDR-rate / Decimate before it hits disk, and a self-describing
+// `.metadata.json` sidecar is written next to the capture (carrying the
+// reduced rate + centre) so the smaller file replays correctly without the
+// operator having to remember the decimation factor.
 func runIQCapture(ctx context.Context, broker *iqtap.Broker, spec iqCaptureSpec, log *slog.Logger) error {
 	if broker == nil {
 		return fmt.Errorf("iq-capture: no broker for serial %q", spec.Serial)
@@ -98,11 +122,52 @@ func runIQCapture(ctx context.Context, broker *iqtap.Broker, spec iqCaptureSpec,
 	if err != nil {
 		return fmt.Errorf("iq-capture: %w", err)
 	}
+
+	// Build the software decimator from the SDR rate the broker is streaming.
+	// A factor of 0/1 is a no-op (nil ddc = byte-identical to the old path).
+	baseRate := broker.SampleRateHz()
+	ddc := newCaptureDecimator(baseRate, spec.Decimate)
+	recRate := baseRate
+	if ddc != nil {
+		recRate = uint32(ddc.OutRateHz() + 0.5)
+	}
+
 	log.Info("iq-capture: started",
 		"serial", spec.Serial, "path", spec.Path,
-		"seconds", spec.Seconds, "format", spec.Format)
-	samples, bytesPerSample, drops, capErr := captureIQToFile(ctx, broker, spec.Path, format, spec.Seconds)
+		"seconds", spec.Seconds, "format", spec.Format,
+		"decimate", max(spec.Decimate, 1), "record_rate_hz", recRate)
+	samples, bytesPerSample, drops, capErr := captureIQToFile(ctx, broker, spec.Path, format, spec.Seconds, ddc)
+	if capErr == nil && ddc != nil {
+		// Only decimated captures get a sidecar: their on-disk rate differs
+		// from the configured sdr.sample_rate, so the file is unusable for
+		// replay without it. A full-rate capture keeps the historical
+		// no-sidecar behaviour (the operator supplies metadata explicitly).
+		meta := &siglab.Metadata{
+			Source:       fmt.Sprintf("gophertrunk iq-capture (decimate %d)", spec.Decimate),
+			SampleRateHz: float64(recRate),
+			CenterFreqHz: broker.CenterHz(),
+			Format:       format.String(),
+		}
+		metaPath := strings.TrimSuffix(spec.Path, filepath.Ext(spec.Path)) + ".metadata.json"
+		if werr := siglab.WriteMetadata(metaPath, meta); werr != nil {
+			log.Warn("iq-capture: metadata sidecar write failed", "path", metaPath, "err", werr)
+		}
+	}
 	return finishIQCapture(log, spec, samples, bytesPerSample, drops, capErr)
+}
+
+// newCaptureDecimator returns a down-converter that anti-alias decimates a
+// baseRateHz stream by an integer factor, or nil when no decimation is wanted
+// (factor <= 1, or an unknown base rate). It reuses ccdecoder.Downconverter —
+// the same rational-resample path the `gophertrunk capture -bandwidth` slice
+// and the live receiver DDC use — so a decimated capture has the identical
+// >60 dB anti-alias shaping and no third DDC implementation is introduced
+// (CLAUDE.md #764/#771: keep the DDC paths from diverging).
+func newCaptureDecimator(baseRateHz uint32, factor int) *ccdecoder.Downconverter {
+	if factor <= 1 || baseRateHz == 0 {
+		return nil
+	}
+	return ccdecoder.NewDownconverter(float64(baseRateHz), float64(baseRateHz)/float64(factor))
 }
 
 // captureIQToFile owns the full lifecycle of one raw-IQ capture: create the
@@ -114,7 +179,11 @@ func runIQCapture(ctx context.Context, broker *iqtap.Broker, spec iqCaptureSpec,
 //
 // Shared by the `--iq-capture` CLI flag (runIQCapture) and the event-driven
 // IQ auto-recorder, so both produce byte-identical captures.
-func captureIQToFile(ctx context.Context, broker *iqtap.Broker, path string, format siglab.SampleFormat, seconds int) (samples int64, bytesPerSample int, drops uint64, err error) {
+//
+// A non-nil ddc anti-alias decimates every chunk before it is encoded, so the
+// file lands at the down-converter's output rate (software decimation). A nil
+// ddc is a byte-identical pass-through of the historical full-rate path.
+func captureIQToFile(ctx context.Context, broker *iqtap.Broker, path string, format siglab.SampleFormat, seconds int, ddc *ccdecoder.Downconverter) (samples int64, bytesPerSample int, drops uint64, err error) {
 	_, bytesPerSample = format.Decoder()
 	f, err := os.Create(path)
 	if err != nil {
@@ -123,7 +192,7 @@ func captureIQToFile(ctx context.Context, broker *iqtap.Broker, path string, for
 
 	sub := broker.Subscribe()
 	defer sub.Close()
-	enc := siglab.NewCaptureWriter(f, format)
+	enc := newCaptureEncoder(f, format, ddc)
 
 	// Safety timer as an explicit select arm: the broker pauses fan-out when no
 	// primary StreamIQ session is running, so a receive-then-check deadline
@@ -144,10 +213,11 @@ func captureIQToFile(ctx context.Context, broker *iqtap.Broker, path string, for
 				if !ok {
 					return errors.New("iq-capture: broker closed before capture finished")
 				}
-				if werr := enc.Write(chunk); werr != nil {
+				n, werr := enc.write(chunk)
+				if werr != nil {
 					return fmt.Errorf("write: %w", werr)
 				}
-				samples += int64(len(chunk))
+				samples += int64(n)
 				if time.Now().After(deadline) {
 					return nil
 				}
@@ -162,6 +232,42 @@ func captureIQToFile(ctx context.Context, broker *iqtap.Broker, path string, for
 		streamErr = closeErr
 	}
 	return samples, bytesPerSample, sub.Dropped(), streamErr
+}
+
+// captureEncoder streams complex64 chunks to disk in a chosen sample format,
+// optionally anti-alias decimating each chunk first so a capture can be
+// recorded at a fraction of the SDR rate. A nil ddc makes write a
+// pass-through: byte-identical to encoding through siglab.CaptureWriter
+// directly, so an undecimated capture is unchanged.
+type captureEncoder struct {
+	enc     *siglab.CaptureWriter
+	ddc     *ccdecoder.Downconverter // nil ⇒ no decimation
+	scratch []complex64              // reused decimation output buffer
+}
+
+// newCaptureEncoder wraps w with the chosen format and optional decimator.
+func newCaptureEncoder(w io.Writer, format siglab.SampleFormat, ddc *ccdecoder.Downconverter) *captureEncoder {
+	return &captureEncoder{enc: siglab.NewCaptureWriter(w, format), ddc: ddc}
+}
+
+// write encodes one chunk, decimating it first when a down-converter is set,
+// and returns the number of samples actually written (post-decimation, so the
+// caller's running total reflects the on-disk length rather than the input).
+func (c *captureEncoder) write(chunk []complex64) (int, error) {
+	out := chunk
+	if c.ddc != nil {
+		out = c.ddc.Process(c.scratch, chunk)
+		c.scratch = out
+	}
+	if len(out) == 0 {
+		// A short input chunk can leave the polyphase decimator with no
+		// output this round; the samples are carried in its filter history.
+		return 0, nil
+	}
+	if err := c.enc.Write(out); err != nil {
+		return 0, err
+	}
+	return len(out), nil
 }
 
 func finishIQCapture(log *slog.Logger, spec iqCaptureSpec, samples int64, bytesPerSample int, drops uint64, runErr error) error {

--- a/cmd/gophertrunk/iqcapture_test.go
+++ b/cmd/gophertrunk/iqcapture_test.go
@@ -160,7 +160,7 @@ func TestCaptureEncoderDecimates(t *testing.T) {
 		chunkLen = 4096
 	)
 	// Decimated Nyquist is baseRate/factor/2 = 100 kHz.
-	inBandHz := 20_000.0  // passes
+	inBandHz := 20_000.0   // passes
 	outBandHz := 300_000.0 // rejected (> 100 kHz)
 
 	run := func(toneHz float64) (writtenSamples int, meanMag float64) {

--- a/cmd/gophertrunk/iqcapture_test.go
+++ b/cmd/gophertrunk/iqcapture_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"math"
 	"strings"
 	"testing"
@@ -34,6 +35,26 @@ func TestParseIQCaptureSpec(t *testing.T) {
 			name: "u8 format",
 			in:   "serial=ABC,path=x.bin,seconds=5,format=u8",
 			want: iqCaptureSpec{Serial: "ABC", Path: "x.bin", Seconds: 5, Format: "u8"},
+		},
+		{
+			name: "decimate factor parsed",
+			in:   "serial=ABC,path=x.cs16,seconds=5,format=cs16,decimate=5",
+			want: iqCaptureSpec{Serial: "ABC", Path: "x.cs16", Seconds: 5, Format: "cs16", Decimate: 5},
+		},
+		{
+			name:    "decimate zero rejected",
+			in:      "serial=A,path=x,seconds=1,decimate=0",
+			wantErr: "decimate",
+		},
+		{
+			name:    "decimate negative rejected",
+			in:      "serial=A,path=x,seconds=1,decimate=-2",
+			wantErr: "decimate",
+		},
+		{
+			name:    "decimate non-integer rejected",
+			in:      "serial=A,path=x,seconds=1,decimate=2.5",
+			wantErr: "decimate",
 		},
 		{
 			name: "whitespace around keys + values is trimmed",
@@ -101,6 +122,124 @@ func TestParseIQCaptureSpec(t *testing.T) {
 				t.Errorf("spec = %+v, want %+v", got, tc.want)
 			}
 		})
+	}
+}
+
+// TestCaptureEncoderPassThroughIsByteIdentical pins that a nil decimator makes
+// captureEncoder.write byte-for-byte identical to encoding through
+// siglab.CaptureWriter directly — an undecimated capture must be unchanged.
+func TestCaptureEncoderPassThroughIsByteIdentical(t *testing.T) {
+	chunk := []complex64{
+		complex(0.1, -0.2), complex(0.3, 0.4), complex(-0.5, 0.6), complex(0.7, -0.8),
+	}
+	var buf bytes.Buffer
+	enc := newCaptureEncoder(&buf, siglab.FormatF32, nil)
+	n, err := enc.write(chunk)
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if n != len(chunk) {
+		t.Errorf("written = %d, want %d (pass-through writes every sample)", n, len(chunk))
+	}
+	want := siglab.EncodeCapture(chunk, siglab.FormatF32)
+	if !bytes.Equal(buf.Bytes(), want) {
+		t.Errorf("pass-through bytes differ from siglab.EncodeCapture (len %d vs %d)", buf.Len(), len(want))
+	}
+}
+
+// TestCaptureEncoderDecimates is the failing-first regression for software
+// decimation: with a down-converter set, captureEncoder must (1) write ~1/N of
+// the input samples and (2) preserve an in-band tone while rejecting an
+// out-of-band one (the anti-alias filter). Without the decimation wiring the
+// encoder writes every sample at the full rate and this fails.
+func TestCaptureEncoderDecimates(t *testing.T) {
+	const (
+		baseRate = 1_000_000.0
+		factor   = 5
+		total    = 40000 // input samples
+		chunkLen = 4096
+	)
+	// Decimated Nyquist is baseRate/factor/2 = 100 kHz.
+	inBandHz := 20_000.0  // passes
+	outBandHz := 300_000.0 // rejected (> 100 kHz)
+
+	run := func(toneHz float64) (writtenSamples int, meanMag float64) {
+		var buf bytes.Buffer
+		ddc := newCaptureDecimator(uint32(baseRate), factor)
+		if ddc == nil {
+			t.Fatal("newCaptureDecimator returned nil for factor 5")
+		}
+		enc := newCaptureEncoder(&buf, siglab.FormatF32, ddc)
+		phase := 0.0
+		dPhase := 2 * math.Pi * toneHz / baseRate
+		for off := 0; off < total; off += chunkLen {
+			n := chunkLen
+			if off+n > total {
+				n = total - off
+			}
+			chunk := make([]complex64, n)
+			for i := range chunk {
+				chunk[i] = complex(float32(math.Cos(phase)), float32(math.Sin(phase)))
+				phase += dPhase
+			}
+			w, err := enc.write(chunk)
+			if err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			writtenSamples += w
+		}
+		// Decode the written f32 bytes back to complex64.
+		dec, bytesPer := siglab.FormatF32.Decoder()
+		out := make([]complex64, buf.Len()/bytesPer)
+		dec(buf.Bytes(), out)
+		// Skip the filter warm-up (first taps-worth) before measuring energy.
+		const warm = 200
+		var sum float64
+		var cnt int
+		for i := warm; i < len(out); i++ {
+			sum += math.Hypot(float64(real(out[i])), float64(imag(out[i])))
+			cnt++
+		}
+		if cnt > 0 {
+			meanMag = sum / float64(cnt)
+		}
+		return writtenSamples, meanMag
+	}
+
+	written, inMag := run(inBandHz)
+	// ~1/5 of the input, allowing a few samples of filter-state slack.
+	wantApprox := total / factor
+	if written < wantApprox-16 || written > wantApprox+16 {
+		t.Errorf("decimated sample count = %d, want ~%d (input %d / %d)", written, wantApprox, total, factor)
+	}
+	if inMag < 0.7 || inMag > 1.3 {
+		t.Errorf("in-band tone mean magnitude = %.3f, want ~1.0 (passband should be flat)", inMag)
+	}
+
+	_, outMag := run(outBandHz)
+	if outMag > 0.1 {
+		t.Errorf("out-of-band tone mean magnitude = %.3f, want < 0.1 (anti-alias stopband)", outMag)
+	}
+}
+
+// TestNewCaptureDecimatorPassThrough confirms factor <= 1 (and an unknown base
+// rate) yields no decimator, so the capture stays on the full-rate path.
+func TestNewCaptureDecimatorPassThrough(t *testing.T) {
+	if d := newCaptureDecimator(1_000_000, 1); d != nil {
+		t.Error("factor 1 should yield no decimator (full-rate pass-through)")
+	}
+	if d := newCaptureDecimator(1_000_000, 0); d != nil {
+		t.Error("factor 0 should yield no decimator")
+	}
+	if d := newCaptureDecimator(0, 5); d != nil {
+		t.Error("unknown base rate should yield no decimator")
+	}
+	d := newCaptureDecimator(1_000_000, 5)
+	if d == nil {
+		t.Fatal("factor 5 should yield a decimator")
+	}
+	if got := d.OutRateHz(); math.Abs(got-200_000) > 1 {
+		t.Errorf("OutRateHz = %.1f, want 200000 (1 MHz / 5)", got)
 	}
 }
 

--- a/cmd/gophertrunk/main.go
+++ b/cmd/gophertrunk/main.go
@@ -171,7 +171,7 @@ func runDaemon(args []string) {
 	// IQ capture diagnostic — taps a live SDR's iqtap broker and writes
 	// raw IQ samples to a file for offline analysis. Used to capture a
 	// reproducible fixture for replay (issue #402).
-	iqCapture := fs.String("iq-capture", "", "capture raw IQ from a live SDR for offline analysis (issue #402). Format: serial=<s>,path=<file>,seconds=<n>[,format=u8|f32] (default format=f32, GNU Radio cfile)")
+	iqCapture := fs.String("iq-capture", "", "capture raw IQ from a live SDR for offline analysis (issue #402). Format: serial=<s>,path=<file>,seconds=<n>[,format=u8|f32|cs16][,decimate=<n>] (default format=f32, GNU Radio cfile; decimate>1 anti-alias decimates the recording to sdr.sample_rate/n and writes a metadata sidecar)")
 	_ = fs.Parse(args)
 
 	// Resolve verbose-error reporting from the flag now (config folds in

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1449,6 +1449,12 @@ broadcast:
 #                                #   smaller and directly replayable). For a
 #                                #   same-carrier TETRA site the ddc tap holds all
 #                                #   four voice timeslots of the control carrier.
+#     decimate: 5                # wideband tap only: anti-alias decimate the
+#                                #   capture to sdr.sample_rate / N (0/1 = full
+#                                #   rate). The fix for a radio (e.g. USRP B210)
+#                                #   whose hardware rate floor (~1 MS/s) is far
+#                                #   above the bandwidth a channel needs — record
+#                                #   at the floor, decimate to a small long file.
 #     seconds: 8                 # capture length per trigger
 #     cooldown: 10s              # min gap between automatic triggers
 #     on_concurrent_calls: 2     # fire at N+ concurrent calls (0 = off)

--- a/docs/reference/decimation.md
+++ b/docs/reference/decimation.md
@@ -75,6 +75,20 @@ a channel to baseband, the signal is low-pass filtered and decimated down to the
 channel rate (48 kHz for 4800-baud C4FM, 144 kHz for TETRA), so the demodulator always runs
 at a fixed, low rate regardless of the capture rate.
 
+The same down-converter also decimates **captures** on demand, so a long recording need not be
+stored at the radio's full rate. Some SDRs cannot stream a low rate at all — the USRP B210's
+hardware sample-rate floor is ~1 MS/s, far above what a single narrowband channel needs — so
+GopherTrunk records at the hardware rate and decimates in software:
+
+- `gophertrunk capture -decimate N` records the full band at `sample-rate / N` (or
+  `-bandwidth <hz>` to carve a narrowband slice).
+- `--iq-capture …,decimate=N` decimates a live-daemon grab and writes a metadata sidecar with
+  the reduced rate.
+- `baseband.auto_record: { tap: wideband, decimate: N }` decimates event-triggered captures.
+
+Each anti-alias filters before downsampling, so a 1 MS/s B210 stream becomes an alias-free
+200 kS/s file at `decimate: 5` — one fifth the size, still wide enough to replay and debug.
+
 ## Relevance to SDR
 
 Decimation is what makes running [many channels](/reference/digital-down-converter/) from one

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -271,6 +271,18 @@ type BasebandAutoRecordConfig struct {
 	//     tap holds all four voice timeslots of the control carrier — exactly the
 	//     channel worth sharing when a hard-to-decode call fires a trigger.
 	Tap string `yaml:"tap"`
+	// Decimate is the integer software-decimation factor applied to the
+	// wideband tap: the capture is anti-alias filtered and written at
+	// SDR-rate / Decimate, cutting the file size (and effective bandwidth) by
+	// the same factor while the metadata sidecar records the reduced rate so
+	// it still replays. 0 or 1 records the full SDR rate (the default). This
+	// is the remedy for a source like the USRP B210 whose hardware
+	// sample-rate floor (~1 MS/s) is far above the bandwidth a single
+	// narrowband channel needs — run the radio at the floor and decimate in
+	// software to a manageable long capture. Only valid with the wideband tap
+	// (the ddc tap is already narrowband); a value > 1 with tap: ddc is
+	// rejected at config load.
+	Decimate int `yaml:"decimate"`
 }
 
 // TapDDC reports whether triggered captures tap the narrowband DDC output rather

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -462,6 +462,10 @@ func TestValidate(t *testing.T) {
 		{"auto_record tap ddc ok", Config{Baseband: BasebandConfig{AutoRecord: BasebandAutoRecordConfig{Enabled: true, Dir: "iq", Seconds: 8, Tap: "ddc", OnConcurrentCalls: 2}}}, false},
 		{"auto_record tap wideband ok", Config{Baseband: BasebandConfig{AutoRecord: BasebandAutoRecordConfig{Enabled: true, Dir: "iq", Seconds: 8, Tap: "wideband"}}}, false},
 		{"auto_record bad tap", Config{Baseband: BasebandConfig{AutoRecord: BasebandAutoRecordConfig{Enabled: true, Dir: "iq", Seconds: 8, Tap: "narrowband"}}}, true},
+		{"auto_record wideband decimate ok", Config{Baseband: BasebandConfig{AutoRecord: BasebandAutoRecordConfig{Enabled: true, Dir: "iq", Seconds: 8, Tap: "wideband", Decimate: 5, OnConcurrentCalls: 2}}}, false},
+		{"auto_record decimate default tap ok", Config{Baseband: BasebandConfig{AutoRecord: BasebandAutoRecordConfig{Enabled: true, Dir: "iq", Seconds: 8, Decimate: 4}}}, false},
+		{"auto_record negative decimate", Config{Baseband: BasebandConfig{AutoRecord: BasebandAutoRecordConfig{Enabled: true, Dir: "iq", Seconds: 8, Decimate: -1}}}, true},
+		{"auto_record decimate with ddc tap rejected", Config{Baseband: BasebandConfig{AutoRecord: BasebandAutoRecordConfig{Enabled: true, Dir: "iq", Seconds: 8, Tap: "ddc", Decimate: 5}}}, true},
 		{"auto_record bad cooldown", Config{Baseband: BasebandConfig{AutoRecord: BasebandAutoRecordConfig{Enabled: true, Dir: "iq", Seconds: 8, Cooldown: "soon", OnEncrypted: true}}}, true},
 		{"auto_record negative concurrent", Config{Baseband: BasebandConfig{AutoRecord: BasebandAutoRecordConfig{Enabled: true, Dir: "iq", Seconds: 8, OnConcurrentCalls: -1}}}, true},
 	}

--- a/internal/config/config_validate.go
+++ b/internal/config/config_validate.go
@@ -766,6 +766,15 @@ func (c Config) validateBaseband() []error {
 		default:
 			errs = append(errs, fmt.Errorf("baseband.auto_record: tap must be wideband|ddc, got %q", a.Tap))
 		}
+		if a.Decimate < 0 {
+			errs = append(errs, fmt.Errorf("baseband.auto_record: decimate must not be negative"))
+		}
+		if a.Decimate > 1 && a.TapDDC() {
+			// The ddc tap is already channelised to the pipeline rate
+			// (48/144 kHz); decimating it further would break the recorded
+			// channel's samples-per-symbol. Decimation is a wideband-tap lever.
+			errs = append(errs, fmt.Errorf("baseband.auto_record: decimate is only valid with tap: wideband (the ddc tap is already narrowband)"))
+		}
 		if _, err := a.CooldownDuration(); err != nil {
 			errs = append(errs, fmt.Errorf("baseband.auto_record: cooldown %q: %w", a.Cooldown, err))
 		}

--- a/internal/configbuilder/fieldmeta.go
+++ b/internal/configbuilder/fieldmeta.go
@@ -449,6 +449,7 @@ var fieldMetas = map[string]FieldMeta{
 	"BasebandAutoRecordConfig.OnEmergency":       {Label: "On emergency", Help: "Fire on an emergency-flagged grant."},
 	"BasebandAutoRecordConfig.OnCCSyncLoss":      {Label: "On CC sync loss", Help: "Fire when a locked control channel suddenly loses sync — captures the re-acquisition IQ, ideal for debugging sync-loss / slow warm-up lock. Pair with the ddc tap for small files."},
 	"BasebandAutoRecordConfig.Tap":               {Help: "What IQ to capture: wideband (default, full-rate SDR — large files) or ddc (narrowband channelised stream at the pipeline rate, e.g. 144 kHz for TETRA — far smaller and directly replayable).", Options: opts("", "wideband (default)", "ddc", "ddc")},
+	"BasebandAutoRecordConfig.Decimate":          {Help: "Software-decimation factor for the wideband tap: record at SDR-rate / N (anti-aliased), shrinking the file by N. 0/1 = full rate. The fix for a radio (e.g. USRP B210) whose hardware sample-rate floor is far above the bandwidth a channel needs. Only valid with tap: wideband."},
 
 	// ---- Paging ------------------------------------------------------------
 	"PagingConfig.POCSAG":               {Label: "POCSAG", Help: "POCSAG channels, each pinning one SDR to a paging frequency."},

--- a/internal/configbuilder/webschema_test.go
+++ b/internal/configbuilder/webschema_test.go
@@ -65,7 +65,7 @@ var webRoundTripAllow = map[string][]string{
 	"BasebandAutoRecordConfig": {
 		"Enabled", "Dir", "Format", "Seconds", "Cooldown",
 		"OnConcurrentCalls", "OnNoVoiceDevice", "OnEncrypted", "OnEmergency",
-		"OnCCSyncLoss",
+		"OnCCSyncLoss", "Decimate",
 	},
 }
 


### PR DESCRIPTION
Some radios cannot stream a low sample rate — the USRP B210's hardware
floor is ~1 MS/s, far above the bandwidth a single narrowband channel
needs — so a long capture could only be stored as a huge full-rate file.

Captures can now be anti-alias decimated to rate/N on the way to disk,
reusing ccdecoder.Downconverter (the same rational-resample path the
`capture -bandwidth` slice and the live receiver DDC use) so no third DDC
implementation is introduced (CLAUDE.md #764/#771):

  - `gophertrunk capture -decimate N` — full band at sample-rate/N
    (mutually exclusive with -bandwidth, which carves a narrowband slice).
  - `--iq-capture …,decimate=N` — decimates a live-daemon grab and writes
    a metadata sidecar with the reduced rate so the smaller file replays.
  - `baseband.auto_record: { tap: wideband, decimate: N }` — decimates
    event-triggered captures; filename + metadata carry the reduced rate.

A B210 at its 1 MS/s floor with decimate:5 yields an alias-free 200 kS/s
file, a fifth the size, still wide enough to replay and debug. `decimate`
is a wideband-tap lever; a value >1 with tap: ddc (already narrowband) is
rejected at config load. Undecimated captures are byte-identical to before.

Tests (failing-first): captureEncoder decimation preserves an in-band tone
and rejects an out-of-band one at 1/N the sample count; spec + config
validation; auto_record wideband metadata stamps the decimated rate.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019gkK9y9USNoyS6BdVq8QqU