### PR TITLE
docs site: add analytics + affiliate disclosures bottom sheet

### DIFF
--- a/docs/_includes/disclosure-popup.html
+++ b/docs/_includes/disclosure-popup.html
@@ -1,0 +1,64 @@
+{%- comment -%}
+  Site-wide disclosures sheet — analytics/usage statistics + affiliate links.
+  Rendered by default.html on every page, hidden until the promo engine
+  (assets/js/promos.js) reveals it. It is a NOTICE, not a consent gate: there
+  is no opt-out and no close ×, only an acknowledgement.
+
+  Behavior, all declarative (see the markup contract in promos.js):
+    - data-promo-trigger-time="0": shows immediately on page load.
+    - data-promo-persist="dismiss": unlike the other promos, the "seen" flag is
+      written only when the visitor clicks "I understand" — so the sheet
+      re-appears on EVERY page view until it is explicitly acknowledged.
+    - variant "sheet": full-width panel pinned to the bottom quarter of the
+      viewport, sliding up from the bottom edge (style.scss). Non-modal: no
+      backdrop, no scroll lock, no focus trap — the page above stays usable.
+
+  Wording notes (kept deliberately industry-standard):
+    - "As an Amazon Associate we earn from qualifying purchases." is the
+      identification statement the Amazon Associates Operating Agreement
+      requires verbatim (or substantially similar).
+    - The analytics sentence follows the common notice pattern: name the tool,
+      state what is collected and why, and an acknowledgement clause.
+  The funding link intentionally has NO data-cta-event: the engine treats any
+  [data-cta-event] click as an action that closes the promo, and following a
+  link must not count as acknowledgement.
+{%- endcomment -%}
+<div class="gt-promo gt-promo--sheet" id="gt-promo-disclosures" hidden
+     role="region" aria-labelledby="gt-promo-disclosures-title"
+     aria-describedby="gt-promo-disclosures-body"
+     data-promo="disclosures" data-promo-variant="sheet"
+     data-promo-trigger-time="0" data-promo-frequency="once"
+     data-promo-persist="dismiss">
+  <div class="gt-promo__card">
+    <div class="gt-promo__sheet-inner">
+      <div class="gt-promo__sheet-text">
+      <h2 class="gt-promo__title" id="gt-promo-disclosures-title">Disclosures</h2>
+      <div class="gt-promo__body" id="gt-promo-disclosures-body">
+        <p>
+          <strong>Analytics.</strong> This site uses Google Analytics to collect
+          site-usage statistics — such as which pages are visited, how long
+          visitors stay, and how they found the site — to measure site
+          performance and help us improve the documentation.
+        </p>
+        <p>
+          <strong>Affiliate links.</strong> As an Amazon Associate we earn from
+          qualifying purchases. Some hardware links on this site are affiliate
+          links: if you buy through them we may earn a commission at no
+          additional cost to you. This never changes which gear we recommend,
+          and the software stays free and open source either way.
+          <a href="{{ '/support.html' | relative_url }}">How GopherTrunk is funded &rarr;</a>
+        </p>
+        <p>
+          By continuing to use this site, you acknowledge these practices.
+        </p>
+      </div>
+      </div>
+      <div class="gt-promo__actions">
+        <button type="button" class="btn btn--primary"
+                data-promo-close data-promo-close-method="acknowledge">
+          I understand
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -10,6 +10,7 @@
     {%- include join-cta.html -%}
     {%- include footer.html -%}
     {%- include star-popup.html -%}
+    {%- include disclosure-popup.html -%}
     <script defer src="{{ '/assets/js/analytics.js' | relative_url }}"></script>
     <script defer src="{{ '/assets/js/site.js' | relative_url }}"></script>
     <script defer src="{{ '/assets/js/autolink.js' | relative_url }}"></script>

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -1965,6 +1965,56 @@ body.gt-promo-open { overflow: hidden; }
   animation: gt-promo-rise 0.24s ease-out both;
 }
 
+/* Disclosure sheet: full-width panel pinned to the bottom quarter of the
+   viewport, sliding up from the bottom edge. Non-modal — no backdrop, no
+   scroll lock, the page above stays usable — and it carries no close ×: the
+   only dismissal is its acknowledge button (promos.js writes the seen flag on
+   dismiss for data-promo-persist="dismiss", so it returns every page view
+   until acknowledged). min-height keeps the content reachable on short
+   viewports where 25vh would clip it; the card scrolls if it still must. */
+.gt-promo--sheet {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1100;
+  height: 25vh;
+  min-height: 14rem;
+}
+.gt-promo--sheet .gt-promo__card {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  overflow-y: auto;
+  border-left: 0;
+  border-right: 0;
+  border-bottom: 0;
+  border-radius: 0;
+  text-align: left;
+  padding: 1rem 0;
+  padding-bottom: max(1rem, env(safe-area-inset-bottom));
+  animation: gt-promo-slide-up 0.3s ease-out both;
+}
+/* Text beside the acknowledge button on wide screens (so the button stays
+   above the 25vh fold), stacking on narrow ones; margin:auto centers the pair
+   vertically without clipping when the content is taller than the sheet. */
+.gt-promo--sheet .gt-promo__sheet-inner {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75rem 2rem;
+  width: 100%;
+  max-width: var(--maxw);
+  margin: auto;
+  padding: 0 1.5rem;
+}
+.gt-promo--sheet .gt-promo__sheet-text { flex: 1 1 34rem; min-width: 0; }
+.gt-promo--sheet .gt-promo__title { font-size: 1.05rem; margin-bottom: 0.35rem; }
+.gt-promo--sheet .gt-promo__body { font-size: 0.88rem; margin-bottom: 0; }
+.gt-promo--sheet .gt-promo__body p { margin: 0 0 0.4rem; }
+.gt-promo--sheet .gt-promo__body p:last-child { margin-bottom: 0; }
+.gt-promo--sheet .gt-promo__actions { justify-content: flex-start; flex: 0 0 auto; }
+
 /* Fly-out: edge-anchored panel that slides in from the right. */
 .gt-promo--flyout {
   position: fixed;
@@ -1996,9 +2046,14 @@ body.gt-promo-open { overflow: hidden; }
   from { transform: translateX(100%); }
   to   { transform: none; }
 }
+@keyframes gt-promo-slide-up {
+  from { transform: translateY(100%); }
+  to   { transform: none; }
+}
 @media (prefers-reduced-motion: reduce) {
   .gt-promo--popup .gt-promo__card,
   .gt-promo--popin .gt-promo__card,
+  .gt-promo--sheet .gt-promo__card,
   .gt-promo--flyout .gt-promo__card { animation: none; }
 }
 @media (max-width: 600px) {

--- a/docs/assets/js/promos.js
+++ b/docs/assets/js/promos.js
@@ -17,6 +17,12 @@
  *   data-promo-trigger-time="<ms>"                    show after N ms (optional)
  *   data-promo-trigger-scroll="<0..1>"                show at scroll fraction (optional)
  *   data-promo-frequency="once|session|always"        dedup scope (default once)
+ *   data-promo-persist="show|dismiss"                 when the seen flag is
+ *                                                     written: on reveal (default)
+ *                                                     or only on dismissal — for
+ *                                                     notices that must re-appear
+ *                                                     on every page view until
+ *                                                     explicitly acknowledged
  *   data-promo-fallback="inline"                      if the modal is suppressed
  *                                                     (content/ad blocker), relocate
  *                                                     the card to the page midpoint
@@ -98,6 +104,8 @@
     this.scrollAt = parseFloat(el.getAttribute('data-promo-trigger-scroll'));
     this.isModal = this.variant === 'popup';
     this.fallback = el.getAttribute('data-promo-fallback') || '';
+    this.persist = el.getAttribute('data-promo-persist') || 'show';
+    this.debugShown = false;
     this.shown = false;
     this.inlined = false;
     this.closed = false;
@@ -151,9 +159,12 @@
     opts = opts || {};
 
     // Write the seen flag on show (not on interaction) so an ignored or
-    // reloaded promo does not re-appear. The QA override skips this so repeated
-    // debug loads keep working.
-    if (!opts.debug) markSeen(this.id, this.frequency);
+    // reloaded promo does not re-appear. persist="dismiss" promos instead
+    // write it in close() — they re-appear on every page view until the
+    // visitor dismisses them. The QA override skips this so repeated debug
+    // loads keep working.
+    this.debugShown = !!opts.debug;
+    if (!opts.debug && this.persist !== 'dismiss') markSeen(this.id, this.frequency);
 
     var el = this.el;
     el.removeAttribute('hidden');
@@ -322,6 +333,9 @@
   Promo.prototype.close = function (method) {
     if (this.closed || !this.shown) return;
     this.closed = true;
+
+    // persist="dismiss": the dismissal (acknowledgement) is what's remembered.
+    if (this.persist === 'dismiss' && !this.debugShown) markSeen(this.id, this.frequency);
 
     var el = this.el;
     el.setAttribute('hidden', '');


### PR DESCRIPTION
A site-wide disclosures notice built on the existing promo system
(assets/js/promos.js): a full-width panel pinned to the bottom quarter
of the viewport that slides up from the bottom edge on every page view
until the visitor clicks "I understand". Notice-only by design — no
opt-out, no close button, no Escape dismissal — covering the site's
Google Analytics usage statistics and Amazon Associates affiliate
links, using the Operating Agreement's required identification
statement ("As an Amazon Associate we earn from qualifying purchases").

Engine: new declarative data-promo-persist="dismiss" writes the seen
flag on dismissal instead of on reveal, so the notice re-appears each
page view until acknowledged; acknowledgment is tracked through the
existing promo_dismiss event. CSS: new gt-promo--sheet variant
(25vh, slide-up animation, reduced-motion safe, non-modal) with the
acknowledge button beside the text on wide screens so it stays above
the fold, and an internally scrolling card on narrow ones.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AeCFbfJT9GcqgNiSYXipcD