### PR TITLE
docs: document minimum macOS version (12 Monterey)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Docs
+- **Documented the minimum macOS version (12 Monterey).** macOS binaries link
+  against system APIs that first shipped in macOS 12 (e.g.
+  `SecTrustCopyCertificateChain`), so on macOS 11 and older they abort at launch
+  with `dyld: Symbol not found`. The requirement is now stated in the README,
+  the [macOS install guide](docs/install-macos.md) (a Requirements callout plus
+  a troubleshooting row for the exact `dyld` error), and the
+  [downloads page](docs/downloads.md). Docs only — no behaviour change (issue
+  #1096).
+
 ### Fixed
 - **Conventional/analog scanner recordings no longer end in a loud multi-second
   noise tail** (issue #1090). The scanner-side hangtime debounce (#1091) fixed

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Rad1o), Airspy R2 / Mini, and Airspy HF+ dongles, has no C
 dependencies at build or runtime (no `librtlsdr` / `libhackrf` /
 `libairspy` / `libairspyhf` / `libusb` / `libasound2` /
 `libmp3lame`), and ships as a single ~10 MB static binary for Linux,
-macOS, and Windows.
+macOS 12 (Monterey) or later, and Windows.
 
 Completed calls stream to Broadcastify Calls, RdioScanner, OpenMHz,
 and live Icecast / ShoutCast mountpoints out of the box. Why does

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -41,7 +41,7 @@ variables persist into this page's scope after the include.
       <a class="btn btn--primary" href="{{ rel_url }}/gophertrunk-{{ ver }}-darwin-arm64.tar.gz">Apple Silicon (.tar.gz)</a>
       <a class="btn btn--primary" href="{{ rel_url }}/gophertrunk-{{ ver }}-darwin-amd64.tar.gz">Intel (.tar.gz)</a>
     </div>
-    <p class="download-card__note">Full walkthrough: <a href="{{ '/install-macos.html' | relative_url }}">macOS install guide</a>. Builds are unsigned — right-click → Open the first time, or run <code>xattr -dr com.apple.quarantine gophertrunk</code>.</p>
+    <p class="download-card__note">Requires macOS 12 (Monterey) or later. Full walkthrough: <a href="{{ '/install-macos.html' | relative_url }}">macOS install guide</a>. Builds are unsigned — right-click → Open the first time, or run <code>xattr -dr com.apple.quarantine gophertrunk</code>.</p>
   </div>
 
   <div class="download-card" data-platform="windows">
@@ -93,6 +93,10 @@ The daemon walks `$GOPHERTRUNK_CONFIG` → `~/.config/gophertrunk/config.yaml` �
 For a systemd-managed install, copy [`gophertrunk.service`](https://github.com/MattCheramie/GopherTrunk/blob/main/docs/gophertrunk.service) to `/etc/systemd/system/` and follow the install header.
 
 ### macOS
+
+Requires **macOS 12 (Monterey) or later** (Apple Silicon or Intel). On
+older releases the binary aborts at launch with `dyld: Symbol not
+found` — see the [macOS install guide]({{ '/install-macos.html' | relative_url }}#troubleshooting).
 
 ```sh
 VERSION={{ ver }}

--- a/docs/install-macos.md
+++ b/docs/install-macos.md
@@ -13,6 +13,12 @@ GopherTrunk on macOS is a single static binary that talks to RTL-SDR
 dongles through IOKit — no kext, no `librtlsdr`, no Homebrew formula
 to chase.
 
+> **Requirements:** macOS **12 (Monterey) or later**, on Apple Silicon
+> or Intel. The binaries link against system APIs (e.g.
+> `SecTrustCopyCertificateChain`) that first shipped in macOS 12, so
+> earlier releases (Big Sur 11 and older) abort at launch with
+> `dyld: Symbol not found` — see [Troubleshooting](#troubleshooting).
+
 ## 1. Download the tarball
 
 Go to the **[GopherTrunk releases page]** and grab the asset matching
@@ -194,6 +200,7 @@ manually if you want a clean slate.
 | Symptom                                                  | Likely cause                                                                  |
 | -------------------------------------------------------- | ----------------------------------------------------------------------------- |
 | `cannot be opened because the developer cannot be verified` | Quarantine xattr still attached — re-run the `xattr -dr` from step 3, or right-click → Open. |
+| `dyld: Symbol not found: _SecTrustCopyCertificateChain` (then `zsh: abort`) | Your macOS is older than 12 (Monterey). GopherTrunk binaries require **macOS 12 or later** — check with `sw_vers` and update, or run on a supported machine. |
 | `command not found: gophertrunk`                         | Binary isn't on `PATH` — re-check step 2, or run from the install path directly. |
 | `sdr list` prints nothing                                | Another RTL-SDR app (SDR++, GQRX) is holding the device — close it and retry. |
 | `sdr list` still prints nothing with every other SDR app closed | Re-run with `RTLSDR_DEBUG_USB=1 gophertrunk sdr list 2> trace.log`. Attach `trace.log`, `sw_vers`, and `system_profiler SPUSBDataType \| grep -A 10 "Vendor ID"` to a new issue — the trace tells us which IOKit class matched and which properties were readable. |


### PR DESCRIPTION
## Summary

macOS binaries link against system APIs that first shipped in macOS 12 (e.g. `SecTrustCopyCertificateChain`), so on macOS 11 (Big Sur) and older they abort at launch with `dyld: Symbol not found: _SecTrustCopyCertificateChain` → `zsh: abort`. The requirement was undocumented, so operators on older Macs hit the crash with no explanation of why. This documents the macOS 12 (Monterey) minimum in the places users look before installing.

## Changes

- **`README.md`** — platform line now reads "macOS 12 (Monterey) or later".
- **`docs/install-macos.md`** — added a **Requirements** callout near the top (macOS 12+, Apple Silicon or Intel) and a **Troubleshooting** row mapping the exact `dyld: Symbol not found: _SecTrustCopyCertificateChain` error to the version requirement.
- **`docs/downloads.md`** — the macOS download card and the macOS quick-start section now state the macOS 12 minimum, with a link to the install guide's troubleshooting anchor.
- **`CHANGELOG.md`** — `### Docs` bullet under `[Unreleased]`.

## Test plan

- [x] `make vet test` is green locally — n/a, docs-only change, no Go code touched.
- [ ] `make integration` is green locally (if the change touches the daemon) — n/a.
- [ ] Added or updated tests where appropriate — n/a, documentation only.
- [ ] Smoke-tested against real hardware — n/a.

The minimum version (12.0) is derived from the issue's own crash output: the binary reports it "was built for Mac OS X 12.0", and `SecTrustCopyCertificateChain` is a macOS 12.0 API.

## Breaking changes

none — documentation only, no config keys, flags, endpoints, or behaviour changed.

## Docs / CHANGELOG

- [x] Added a `## [Unreleased]` bullet to `CHANGELOG.md` (under `### Docs`).
- [x] Updated `README.md` and `docs/`.

## Linked issues

Refs #1096

(Using `Refs` rather than `Closes` per the repo's issue-closing policy — leaving the maintainer to close once satisfied. Note the reporter stated #1096 was their final contact, so there's no verification loop; the stated minimum is drawn directly from their crash output.)

Supersedes the reporter's minimal 2-line PR #1097 with the same requirement documented more completely (requirements callout + troubleshooting row + downloads page + CHANGELOG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RxJ39b1rKn2rPb5hSCLZsb

---
_Generated by [Claude Code](https://claude.ai/code/session_01RxJ39b1rKn2rPb5hSCLZsb)_