### PR TITLE
docs: register ham radio Field Guide category, nav, and schema support

### DIFF
--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -220,6 +220,15 @@ groups:
         url: /how-to-program-a-police-scanner/
       - title: "All scanner models (Field Guide)"
         url: /reference/#consumer-scanners
+      - heading: Ham radios
+      - title: Best base stations
+        url: /best-ham-radio-base-stations/
+      - title: Best mobile ham radios
+        url: /best-mobile-ham-radios/
+      - title: Best handheld ham radios
+        url: /best-handheld-ham-radios/
+      - title: "All ham radios (Field Guide)"
+        url: /reference/#ham-radios
       - heading: SDRs & receivers
       - title: Best SDR for GopherTrunk
         url: /best-sdr-for-gophertrunk/

--- a/docs/_data/reference.yml
+++ b/docs/_data/reference.yml
@@ -841,6 +841,41 @@ domains:
           - { slug: whistler-ws1065, title: Whistler WS1065, type: hardware }
           - { slug: whistler-ws1040, title: Whistler WS1040, type: hardware }
 
+      - id: ham-radios
+        label: Ham radio transceivers
+        blurb: Amateur radio transceivers — base stations, mobiles, and handhelds — for two-way work on the ham bands. Transmitting takes an FCC license; listening (with these or an SDR + GopherTrunk) does not.
+        entries:
+          - { slug: icom-ic-7300, title: Icom IC-7300, type: hardware }
+          - { slug: yaesu-ftdx10, title: Yaesu FTDX10, type: hardware }
+          - { slug: icom-ic-7610, title: Icom IC-7610, type: hardware }
+          - { slug: yaesu-ft-991a, title: Yaesu FT-991A, type: hardware }
+          - { slug: kenwood-ts-590sg, title: Kenwood TS-590SG, type: hardware }
+          - { slug: icom-ic-718, title: Icom IC-718, type: hardware }
+          - { slug: xiegu-g90, title: Xiegu G90, type: hardware }
+          - { slug: yaesu-ft-891, title: Yaesu FT-891, type: hardware }
+          - { slug: kenwood-ts-940s, title: Kenwood TS-940S, type: hardware }
+          - { slug: yaesu-ft-1000mp, title: Yaesu FT-1000MP, type: hardware }
+          - { slug: yaesu-ftm-500dr, title: Yaesu FTM-500DR, type: hardware }
+          - { slug: yaesu-ftm-300dr, title: Yaesu FTM-300DR, type: hardware }
+          - { slug: icom-id-5100a, title: Icom ID-5100A, type: hardware }
+          - { slug: icom-ic-2730a, title: Icom IC-2730A, type: hardware }
+          - { slug: anytone-at-d578uviii, title: AnyTone AT-D578UVIII Plus, type: hardware }
+          - { slug: btech-uv-25x2, title: BTECH UV-25X2, type: hardware }
+          - { slug: qyt-kt-8900d, title: QYT KT-8900D, type: hardware }
+          - { slug: icom-ic-706mkiig, title: Icom IC-706MkIIG, type: hardware }
+          - { slug: yaesu-ft-857d, title: Yaesu FT-857D, type: hardware }
+          - { slug: kenwood-tm-v71a, title: Kenwood TM-V71A, type: hardware }
+          - { slug: kenwood-th-d75a, title: Kenwood TH-D75A, type: hardware }
+          - { slug: icom-id-52a, title: Icom ID-52A, type: hardware }
+          - { slug: yaesu-ft-5dr, title: Yaesu FT-5DR, type: hardware }
+          - { slug: yaesu-ft-60r, title: Yaesu FT-60R, type: hardware }
+          - { slug: anytone-at-d878uvii-plus, title: AnyTone AT-D878UVII Plus, type: hardware }
+          - { slug: btech-uv-pro, title: BTECH UV-PRO, type: hardware }
+          - { slug: baofeng-bf-f8hp, title: Baofeng BF-F8HP, type: hardware }
+          - { slug: baofeng-uv-5r, title: Baofeng UV-5R, type: hardware }
+          - { slug: kenwood-th-f6a, title: Kenwood TH-F6A, type: hardware }
+          - { slug: yaesu-vx-8dr, title: Yaesu VX-8DR, type: hardware }
+
       - id: rf-front-end
         label: RF front-end & components
         blurb: The components between the antenna and the receiver — amplifiers, filters, mixers, connectors, and references.

--- a/docs/_includes/affiliate-disclosure.html
+++ b/docs/_includes/affiliate-disclosure.html
@@ -8,6 +8,8 @@
   <strong>Reader-supported.</strong> GopherTrunk is free, open-source software. Some
   hardware links on this page go to Amazon with our Associates tag
   (<code>gophertrunk-20</code>); if you buy through them we may earn a small
-  commission at no extra cost to you. It never changes which gear we recommend, and
+  commission at no extra cost to you. Links to out-of-production gear may go to
+  eBay searches instead; we have no affiliate relationship with eBay and earn
+  nothing there. It never changes which gear we recommend, and
   the software stays free either way. <a href="{{ '/support.html' | relative_url }}">How GopherTrunk is funded &rarr;</a>
 </p>

--- a/docs/_includes/product-schema.html
+++ b/docs/_includes/product-schema.html
@@ -10,6 +10,8 @@
       lowPrice: "579"                                           # optional, for a range
       highPrice: "699"                                          # optional, for a range
       url: https://www.amazon.com/dp/XXXXXXXXXX?tag=gophertrunk-20   # affiliate offer
+      seller: Amazon                                           # optional, defaults Amazon ("eBay" for aftermarket-only gear)
+      itemCondition: used                                      # optional; "used" marks out-of-production gear sold on the used market
 
   Honesty rule: NO review or aggregateRating is emitted — we do not fabricate
   ratings. Offers carry a real price (or price range) and the affiliate URL only.
@@ -35,10 +37,15 @@
     {%- if pr.price %}"price": {{ pr.price | jsonify }},{% endif %}
     {%- endif -%}
     "priceCurrency": {{ pr.currency | default: "USD" | jsonify }},
+    {%- if pr.itemCondition == "used" -%}
+    "itemCondition": "https://schema.org/UsedCondition",
+    "availability": "https://schema.org/LimitedAvailability"
+    {%- else -%}
     "availability": "https://schema.org/InStock"
+    {%- endif -%}
     {%- if pr.url -%},
     "url": {{ pr.url | jsonify }},
-    "seller": { "@type": "Organization", "name": "Amazon" }
+    "seller": { "@type": "Organization", "name": {{ pr.seller | default: "Amazon" | jsonify }} }
     {%- endif -%}
   }
 }

--- a/docs/best-ham-radio-base-stations.md
+++ b/docs/best-ham-radio-base-stations.md
@@ -22,13 +22,13 @@ faq:
 # The 10 Best Ham Radio Base Stations (2026 Buyer's Guide)
 
 **The best base station is the one that matches how you'll actually operate** —
-a contester's dream is a ragchewer's overkill, and the "best receiver ever
-measured" is wasted on someone who mostly wants local repeaters. One rule frames
+a contester's dream is a ragchewer's overkill, and the best receiver ever
+measured is wasted on someone who mostly wants local repeaters. One rule frames
 everything below: **transmitting on the ham bands requires an FCC amateur
-license (Part 97 — Technician class minimum; General for most HF), while
-listening requires none** — so if you're not licensed yet, a
-[$30 RTL-SDR running free GopherTrunk](/best-sdr-for-gophertrunk/) lets you
-hear what's active locally before you spend transceiver money.
+license (Part 97 — Technician class minimum; General for most HF); listening
+requires none** — so before spending transceiver money, a
+[$30 RTL-SDR running free GopherTrunk](/best-sdr-for-gophertrunk/) will tell
+you what's active in your area.
 
 <div class="tldr" markdown="1">
 <span class="tldr__label">Key takeaways</span>
@@ -50,7 +50,7 @@ still buyable new right now.
 <span class="pick-card__badge">Best overall</span>
 <h3>Icom IC-7300</h3>
 <p class="pick-card__price">around $1,040 (~$940 after rebate)</p>
-<p>The direct-sampling SDR that redefined the entry-level base station: touchscreen waterfall, built-in tuner, one-cable FT8. In run-out as the MK2 arrives — new stock is real and rebated.</p>
+<p>The direct-sampling SDR that redefined the entry-level base station: touchscreen waterfall, built-in tuner, one-cable FT8. In run-out as the MK2 arrives — new stock is real.</p>
 <a class="btn btn--buy" href="https://www.amazon.com/dp/B01M10HJXW?tag=gophertrunk-20" rel="nofollow sponsored noopener">IC-7300 on Amazon &rarr;</a>
 <p class="pick-card__note"><a href="/reference/icom-ic-7300/">IC-7300 details</a></p>
 </div>
@@ -125,9 +125,9 @@ else.
 ### 4. Yaesu FT-991A — best features for the price
 
 Unmatched **Coverage &amp; modes**: HF to 70 cm, all modes, plus C4FM Fusion —
-no other radio here does repeaters and DX in one box. Middling **RF
-performance** (an average superhet in an SDR era) and its May 2026
-discontinuation keep it off the podium; buy it while sell-through stock lasts.
+no other radio here does repeaters and DX in one box. Average **RF
+performance** and its May 2026 discontinuation keep it off the podium; buy it
+while sell-through stock lasts.
 <a class="btn btn--buy" href="https://www.amazon.com/dp/B01MDU5VYH?tag=gophertrunk-20" rel="nofollow sponsored noopener">FT-991A on Amazon &rarr;</a> · [FT-991A review](/reference/yaesu-ft-991a/)
 
 ### 5. Kenwood TS-590SG — the CW/contest receiver bargain
@@ -158,23 +158,22 @@ support** hold it at #7.
 
 A true second receiver, filter banks, and contest pedigree for ~$600–1,200
 used — **RF performance** and features that still compete, which is why it
-outranks a brand-new IC-718. The caveats are structural: eBay/hamfest only,
-aging caps, lamps, and relays, no factory support, and thin sold-price data —
-verify current listings.
+outranks a brand-new IC-718. The caveats: eBay/hamfest only, aging caps and
+relays, no factory support, and thin sold-price data — verify current listings.
 <a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=yaesu+ft-1000mp" rel="nofollow noopener">Find on eBay &rarr;</a> · [FT-1000MP review](/reference/yaesu-ft-1000mp/)
 
 ### 9. Kenwood TS-940S — the classic-station centerpiece
 
-A silky analog receiver, superb audio, and battleship build for ~$400–800 used
-— strong **Value** for a second/classic station. It sits below the FT-1000MP
-on features (single receiver) and on its signature aging faults: power-supply
-recaps and the "dots display" PLL fix are practically assumed.
+A silky analog receiver, superb audio, and battleship build for ~$400–800
+used. It sits below the FT-1000MP on features (single receiver) and on its
+signature aging faults: power-supply recaps and the "dots display" PLL fix are
+practically assumed.
 <a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=kenwood+ts-940s" rel="nofollow noopener">Find on eBay &rarr;</a> · [TS-940S review](/reference/kenwood-ts-940s/)
 
 ### 10. Icom IC-718 — the honest budget classic, wrong price
 
 Simple, tough, and beloved — but discontinued, and at ~$930 new-old-stock its
-1999-era receiver, missing 6 m/FM/tuner/USB, is outclassed by a used IC-7300
+1999-era receiver (no 6 m, FM, tuner, or USB) is outclassed by a used IC-7300
 for the same money. **Value** at NOS pricing puts it last; at $400–550 used
 it's still a fine first radio.
 <a class="btn btn--buy" href="https://www.amazon.com/dp/B007G03B5I?tag=gophertrunk-20" rel="nofollow sponsored noopener">IC-718 on Amazon &rarr;</a> · [IC-718 review](/reference/icom-ic-718/)

--- a/docs/best-ham-radio-base-stations.md
+++ b/docs/best-ham-radio-base-stations.md
@@ -1,0 +1,235 @@
+---
+layout: page
+title: "The 10 Best Ham Radio Base Stations (2026 Buyer's Guide)"
+description: "The best ham radio base stations of 2026, ranked — Icom IC-7300, Yaesu FTDX10, IC-7610, FT-991A, Kenwood TS-590SG, Xiegu G90 and more — with honest grades, used-classic picks, and the free SDR-listening angle."
+keywords: best ham radio base station, best ham radio base station 2026, best HF transceiver, HF base station, Icom IC-7300, Yaesu FTDX10, Yaesu FT-991A, Xiegu G90, best first ham radio, ham radio buying guide
+permalink: /best-ham-radio-base-stations/
+nav_group: Hardware
+affiliate: true
+faq:
+  - q: "What is the best ham radio base station in 2026?"
+    a: "The Icom IC-7300. A decade after it mainstreamed the direct-sampling SDR receiver, nothing near its ~$1,040 price matches its touchscreen waterfall, built-in tuner, one-cable digital modes, and community support. It's in run-out ahead of the IC-7300MK2, but new rebated stock is still widely available."
+  - q: "What is the best all-in-one ham base station?"
+    a: "The Yaesu FT-991A — HF through 70 cm, every analog mode plus C4FM System Fusion, in one 100 W box. It was discontinued in May 2026, so it's a last-call buy while dealer sell-through stock lasts; nothing in current production replaces it."
+  - q: "What is the cheapest real HF base station?"
+    a: "The Xiegu G90, around $450. You get 20 W SSB/CW, a usable SDR receiver with a small waterfall, and a famously wide-range built-in tuner. It's the cheapest radio we'd actually recommend for getting on HF."
+  - q: "Do I need a license for a ham base station?"
+    a: "To transmit, yes — an FCC amateur license under Part 97, Technician class minimum (General unlocks most HF). Listening requires no license at all: a ~$30 RTL-SDR running free GopherTrunk hears your local ham activity before you spend anything on a transceiver."
+  - q: "Are vintage rigs like the TS-940S or FT-1000MP worth buying?"
+    a: "Yes, with eyes open. A used FT-1000MP (~$600–1,200) buys true dual-receive contest iron; a TS-940S (~$400–800) buys a silky analog classic. Both are eBay/hamfest-only with well-documented aging faults — budget for service, and buy from sellers who can show it's been done."
+---
+
+# The 10 Best Ham Radio Base Stations (2026 Buyer's Guide)
+
+**The best base station is the one that matches how you'll actually operate** —
+a contester's dream is a ragchewer's overkill, and the "best receiver ever
+measured" is wasted on someone who mostly wants local repeaters. One rule frames
+everything below: **transmitting on the ham bands requires an FCC amateur
+license (Part 97 — Technician class minimum; General for most HF), while
+listening requires none** — so if you're not licensed yet, a
+[$30 RTL-SDR running free GopherTrunk](/best-sdr-for-gophertrunk/) lets you
+hear what's active locally before you spend transceiver money.
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Best overall:** [Icom IC-7300](/reference/icom-ic-7300/) (~$1,040, run-out
+stock with rebate). **Best features for the price:**
+[Yaesu FT-991A](/reference/yaesu-ft-991a/) — HF-to-70 cm plus
+[C4FM](/reference/c4fm/), discontinued May 2026, last-call while stock lasts.
+**Most affordable:** [Xiegu G90](/reference/xiegu-g90/) (~$450, 20 W). **Best
+used/classic:** [Yaesu FT-1000MP](/reference/yaesu-ft-1000mp/) (~$600–1,200,
+eBay). **Best receiver:** [FTDX10](/reference/yaesu-ftdx10/). 2026 shake-up:
+the IC-7300MK2 is coming and the FT-991A is bowing out — both originals are
+still buyable new right now.
+</div>
+
+## Quick picks
+
+<div class="pick-cards" markdown="0">
+<div class="pick-card pick-card--top">
+<span class="pick-card__badge">Best overall</span>
+<h3>Icom IC-7300</h3>
+<p class="pick-card__price">around $1,040 (~$940 after rebate)</p>
+<p>The direct-sampling SDR that redefined the entry-level base station: touchscreen waterfall, built-in tuner, one-cable FT8. In run-out as the MK2 arrives — new stock is real and rebated.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B01M10HJXW?tag=gophertrunk-20" rel="nofollow sponsored noopener">IC-7300 on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/icom-ic-7300/">IC-7300 details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Best features for the price</span>
+<h3>Yaesu FT-991A</h3>
+<p class="pick-card__price">around $1,370–1,400</p>
+<p>HF + 6 m + 2 m + 70 cm, all modes plus C4FM Fusion, in one box. Discontinued May 2026 — a genuine last-call buy while dealer stock lasts.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B01MDU5VYH?tag=gophertrunk-20" rel="nofollow sponsored noopener">FT-991A on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/yaesu-ft-991a/">FT-991A details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Most affordable</span>
+<h3>Xiegu G90</h3>
+<p class="pick-card__price">around $450</p>
+<p>20 W of HF with a real waterfall and a built-in tuner that matches almost anything. The cheapest radio we'd actually put on the air.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B08X6Z6KN2?tag=gophertrunk-20" rel="nofollow sponsored noopener">G90 on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/xiegu-g90/">G90 details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Best used/classic buy</span>
+<h3>Yaesu FT-1000MP</h3>
+<p class="pick-card__price">around $600–1,200 used</p>
+<p>The last great analog Yaesu: a true dual receiver, filter banks, and contest pedigree for mid-range-modern money. eBay and hamfests only.</p>
+<a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=yaesu+ft-1000mp" rel="nofollow noopener">Find on eBay &rarr;</a>
+<p class="pick-card__note"><a href="/reference/yaesu-ft-1000mp/">FT-1000MP details</a></p>
+</div>
+</div>
+
+## How we grade
+
+Every radio here is judged on the same six criteria: **RF performance**
+(receiver dynamic range and filtering, transmit audio), **Coverage &amp; modes**
+(bands, FM/SSB/CW, digital voice), **Power &amp; duty** (output and thermal
+behavior), **Usability &amp; programming** (front panel, menus, CHIRP/software
+support), **Ecosystem &amp; support** (firmware, service, parts, community), and
+**Value** (what the street price actually buys). No star ratings, no invented
+scores — table grades run Excellent/Good/Fair/Basic, and vintage rigs also get
+a used-market viability check: typical sold prices, known failure points, parts
+availability. The same rubric runs our
+[best mobile ham radios](/best-mobile-ham-radios/) and
+[best handheld ham radios](/best-handheld-ham-radios/) guides, so grades are
+comparable across all three.
+
+## The top 10, ranked
+
+### 1. Icom IC-7300 — best overall
+
+Excellent **RF performance** from the direct-sampling receiver, the best
+**Usability** in the class (touchscreen waterfall, one-cable digital), and
+unbeatable **Value** at ~$1,040 with a decade-deep **Ecosystem** of guides and
+presets. It's in run-out ahead of the IC-7300MK2 — buy the rebated original or
+wait for the MK2's connectivity, but the recommendation stands while new stock
+is real.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B01M10HJXW?tag=gophertrunk-20" rel="nofollow sponsored noopener">IC-7300 on Amazon &rarr;</a> · [IC-7300 review](/reference/icom-ic-7300/)
+
+### 2. Yaesu FTDX10 — best receiver under $2,000
+
+Top-tier **RF performance** — flagship-class close-in dynamic range (top-5
+Sherwood territory) plus superb CW facilities. What keeps it at #2 is
+**Usability**: buried menus and a less-loved interface than the Icom, at a
+higher price.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B09WG52PP6?tag=gophertrunk-20" rel="nofollow sponsored noopener">FTDX10 on Amazon &rarr;</a> · [FTDX10 review](/reference/yaesu-ftdx10/)
+
+### 3. Icom IC-7610 — the serious-operator upgrade
+
+Excellent everything: dual independent direct-sampling receivers for split
+pileups and SO2V, RX antenna ports, built-in LAN remote. Only **Value** holds
+it here — at ~$3,500 it's superb for serious HF work and overkill for everyone
+else.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B078KKL7R6?tag=gophertrunk-20" rel="nofollow sponsored noopener">IC-7610 on Amazon &rarr;</a> · [IC-7610 review](/reference/icom-ic-7610/)
+
+### 4. Yaesu FT-991A — best features for the price
+
+Unmatched **Coverage &amp; modes**: HF to 70 cm, all modes, plus C4FM Fusion —
+no other radio here does repeaters and DX in one box. Middling **RF
+performance** (an average superhet in an SDR era) and its May 2026
+discontinuation keep it off the podium; buy it while sell-through stock lasts.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B01MDU5VYH?tag=gophertrunk-20" rel="nofollow sponsored noopener">FT-991A on Amazon &rarr;</a> · [FT-991A review](/reference/yaesu-ft-991a/)
+
+### 5. Kenwood TS-590SG — the CW/contest receiver bargain
+
+Elite **RF performance** — long a top Sherwood performer with best-in-class QSK
+CW and a dedicated RX antenna port. **Usability** is what keeps it at #5: no
+built-in scope or waterfall at ~$1,840 is a hard sell outside the CW/contest
+crowd it serves brilliantly.
+<a class="btn btn--buy" href="https://www.amazon.com/s?k=kenwood+ts-590sg+ham+radio&tag=gophertrunk-20" rel="nofollow sponsored noopener">TS-590SG on Amazon &rarr;</a> · [TS-590SG review](/reference/kenwood-ts-590sg/)
+
+### 6. Yaesu FT-891 — best value 100 watts
+
+Outstanding **Value** and strong **Power &amp; duty**: a full 100 W and a
+genuinely good receiver for ~$650. **Usability** caps it — 100+ menus behind a
+tiny screen, no internal tuner, no USB audio — but as pure radio-per-dollar
+nothing new beats it.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B01LZHA0I4?tag=gophertrunk-20" rel="nofollow sponsored noopener">FT-891 on Amazon &rarr;</a> · [FT-891 review](/reference/yaesu-ft-891/)
+
+### 7. Xiegu G90 — most affordable
+
+The cheapest real HF station: ~$450 for 20 W, a working waterfall, and a
+wide-range internal tuner that forgives beginner antennas — huge **Value**.
+**Power &amp; duty** (the 20 W SSB ceiling) and importer-level **Ecosystem &amp;
+support** hold it at #7.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B08X6Z6KN2?tag=gophertrunk-20" rel="nofollow sponsored noopener">G90 on Amazon &rarr;</a> · [G90 review](/reference/xiegu-g90/)
+
+### 8. Yaesu FT-1000MP — best used/classic buy
+
+A true second receiver, filter banks, and contest pedigree for ~$600–1,200
+used — **RF performance** and features that still compete, which is why it
+outranks a brand-new IC-718. The caveats are structural: eBay/hamfest only,
+aging caps, lamps, and relays, no factory support, and thin sold-price data —
+verify current listings.
+<a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=yaesu+ft-1000mp" rel="nofollow noopener">Find on eBay &rarr;</a> · [FT-1000MP review](/reference/yaesu-ft-1000mp/)
+
+### 9. Kenwood TS-940S — the classic-station centerpiece
+
+A silky analog receiver, superb audio, and battleship build for ~$400–800 used
+— strong **Value** for a second/classic station. It sits below the FT-1000MP
+on features (single receiver) and on its signature aging faults: power-supply
+recaps and the "dots display" PLL fix are practically assumed.
+<a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=kenwood+ts-940s" rel="nofollow noopener">Find on eBay &rarr;</a> · [TS-940S review](/reference/kenwood-ts-940s/)
+
+### 10. Icom IC-718 — the honest budget classic, wrong price
+
+Simple, tough, and beloved — but discontinued, and at ~$930 new-old-stock its
+1999-era receiver, missing 6 m/FM/tuner/USB, is outclassed by a used IC-7300
+for the same money. **Value** at NOS pricing puts it last; at $400–550 used
+it's still a fine first radio.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B007G03B5I?tag=gophertrunk-20" rel="nofollow sponsored noopener">IC-718 on Amazon &rarr;</a> · [IC-718 review](/reference/icom-ic-718/)
+
+## Full comparison
+
+| Radio | RF | Coverage &amp; modes | Usability | Value | ~$ price |
+|---|---|---|---|---|---|
+| [Icom IC-7300](/reference/icom-ic-7300/) | **Excellent** | Good | **Excellent** | **Excellent** | ~$1,040 |
+| [Yaesu FTDX10](/reference/yaesu-ftdx10/) | **Excellent** | Good | Good | Good | ~$1,700 |
+| [Icom IC-7610](/reference/icom-ic-7610/) | **Excellent** | Good | **Excellent** | Fair | ~$3,500 |
+| [Yaesu FT-991A](/reference/yaesu-ft-991a/) | Fair | **Excellent** | Good | **Excellent** | ~$1,370 |
+| [Kenwood TS-590SG](/reference/kenwood-ts-590sg/) | **Excellent** | Good | Fair | Good | ~$1,840 |
+| [Yaesu FT-891](/reference/yaesu-ft-891/) | Good | Good | Fair | **Excellent** | ~$650 |
+| [Xiegu G90](/reference/xiegu-g90/) | Fair | Fair | Fair | **Excellent** | ~$450 |
+| [Yaesu FT-1000MP](/reference/yaesu-ft-1000mp/) | Good | Fair | Good | Good | ~$600–1,200 used |
+| [Kenwood TS-940S](/reference/kenwood-ts-940s/) | Good | Fair | Good | Good | ~$400–800 used |
+| [Icom IC-718](/reference/icom-ic-718/) | Basic | Basic | Good | Fair | ~$930 NOS |
+
+> **Buy the station, not the spec sheet.** A top-five Sherwood receiver won't
+> save a bad antenna, and 100 W into a compromised wire loses to 20 W into a
+> resonant one. Antenna first, radio second — and before either, spend $30 on an
+> [RTL-SDR](/reference/rtl-sdr/) with free GopherTrunk to hear what your area
+> actually carries. Listening needs no license; only transmitting does.
+
+## How to choose
+
+- **First real HF station, want it to just work?**
+  [IC-7300](/reference/icom-ic-7300/) — buy the run-out stock while the rebate
+  lasts.
+- **One radio for HF *and* local repeaters *and* digital voice?**
+  [FT-991A](/reference/yaesu-ft-991a/), now, before sell-through stock is gone.
+- **CW operator or contester chasing receiver numbers?**
+  [FTDX10](/reference/yaesu-ftdx10/) for the scope-and-DR combo,
+  [TS-590SG](/reference/kenwood-ts-590sg/) if you don't need a waterfall.
+- **Split pileups, SO2V, remote operation?** [IC-7610](/reference/icom-ic-7610/).
+- **Tight budget?** [G90](/reference/xiegu-g90/) at ~$450, or stretch to the
+  100 W [FT-891](/reference/yaesu-ft-891/) at ~$650.
+- **Classic-station romantic?** [FT-1000MP](/reference/yaesu-ft-1000mp/) for
+  contest iron, [TS-940S](/reference/kenwood-ts-940s/) for analog silk — both
+  used-only, both wanting service history.
+- **Not licensed yet?** Listen first:
+  [$30 RTL-SDR + GopherTrunk](/best-sdr-for-gophertrunk/).
+
+## Bottom line
+
+The **[IC-7300](/reference/icom-ic-7300/)** is the best base station for most
+people in 2026 — even in run-out, nothing near its price matches the whole
+package. The **[FT-991A](/reference/yaesu-ft-991a/)** is the do-everything
+last-call, the **[G90](/reference/xiegu-g90/)** the cheapest real ticket to HF,
+and a clean **[FT-1000MP](/reference/yaesu-ft-1000mp/)** the smart classic.
+Need the rig for the car or the trail instead? See
+[best mobile ham radios](/best-mobile-ham-radios/) and
+[best handheld ham radios](/best-handheld-ham-radios/) — same rubric, same
+honesty. And whatever you buy, remember the receive side is free: a
+[$30 SDR running GopherTrunk](/best-sdr-for-gophertrunk/) monitors, records,
+and logs your local ham bands — no license, no transceiver, no excuses.

--- a/docs/best-ham-radio-base-stations.md
+++ b/docs/best-ham-radio-base-stations.md
@@ -101,10 +101,9 @@ comparable across all three.
 
 Excellent **RF performance** from the direct-sampling receiver, the best
 **Usability** in the class (touchscreen waterfall, one-cable digital), and
-unbeatable **Value** at ~$1,040 with a decade-deep **Ecosystem** of guides and
-presets. It's in run-out ahead of the IC-7300MK2 — buy the rebated original or
-wait for the MK2's connectivity, but the recommendation stands while new stock
-is real.
+unbeatable **Value** at ~$1,040 with a decade-deep **Ecosystem**. In run-out
+ahead of the IC-7300MK2 — the recommendation stands while new rebated stock is
+real.
 <a class="btn btn--buy" href="https://www.amazon.com/dp/B01M10HJXW?tag=gophertrunk-20" rel="nofollow sponsored noopener">IC-7300 on Amazon &rarr;</a> · [IC-7300 review](/reference/icom-ic-7300/)
 
 ### 2. Yaesu FTDX10 — best receiver under $2,000
@@ -217,8 +216,6 @@ it's still a fine first radio.
 - **Classic-station romantic?** [FT-1000MP](/reference/yaesu-ft-1000mp/) for
   contest iron, [TS-940S](/reference/kenwood-ts-940s/) for analog silk — both
   used-only, both wanting service history.
-- **Not licensed yet?** Listen first:
-  [$30 RTL-SDR + GopherTrunk](/best-sdr-for-gophertrunk/).
 
 ## Bottom line
 
@@ -227,9 +224,8 @@ people in 2026 — even in run-out, nothing near its price matches the whole
 package. The **[FT-991A](/reference/yaesu-ft-991a/)** is the do-everything
 last-call, the **[G90](/reference/xiegu-g90/)** the cheapest real ticket to HF,
 and a clean **[FT-1000MP](/reference/yaesu-ft-1000mp/)** the smart classic.
-Need the rig for the car or the trail instead? See
+Need the rig for the car or the trail instead? Same rubric, same honesty:
 [best mobile ham radios](/best-mobile-ham-radios/) and
-[best handheld ham radios](/best-handheld-ham-radios/) — same rubric, same
-honesty. And whatever you buy, remember the receive side is free: a
-[$30 SDR running GopherTrunk](/best-sdr-for-gophertrunk/) monitors, records,
-and logs your local ham bands — no license, no transceiver, no excuses.
+[best handheld ham radios](/best-handheld-ham-radios/). And the receive side is
+free: a [$30 SDR running GopherTrunk](/best-sdr-for-gophertrunk/) monitors,
+records, and logs your local ham bands — no license, no transceiver required.

--- a/docs/best-handheld-ham-radios.md
+++ b/docs/best-handheld-ham-radios.md
@@ -1,0 +1,222 @@
+---
+layout: page
+title: "The 10 Best Handheld Ham Radios (2026 Buyer's Guide)"
+description: "The best handheld ham radios (HTs) in 2026, ranked — Kenwood TH-D75A, Yaesu FT-5DR, AnyTone AT-D878UVII Plus, Icom ID-52A, the honest Baofeng verdict, and the classic used buys."
+keywords: best handheld ham radio, best ham HT 2026, best handheld ham radios 2026, Kenwood TH-D75A, Yaesu FT-5DR, AnyTone AT-D878UVII Plus, Icom ID-52A, Baofeng UV-5R review, best DMR handheld, best D-STAR handheld, first ham radio
+permalink: /best-handheld-ham-radios/
+nav_group: Hardware
+affiliate: true
+faq:
+  - q: "What is the best handheld ham radio in 2026?"
+    a: "The Kenwood TH-D75A. Its tri-band transmitter (including 220 MHz), full APRS KISS TNC, D-STAR, and SSB/CW wideband receive make it the most capable HT in production. At around $720 it isn't the best value — that's the Yaesu FT-5DR or AnyTone AT-D878UVII Plus depending on your local digital mode."
+  - q: "What is the best first ham radio?"
+    a: "For a radio that will last, the analog Yaesu FT-60R (~$180) — nearly indestructible, simple, and CHIRP-programmable. For the cheapest possible start, a Baofeng UV-5R (~$25) works with real caveats about emissions and quality control."
+  - q: "Should I buy a DMR, D-STAR, or C4FM handheld?"
+    a: "Buy the mode your local repeaters actually use — no current handheld does more than one of the three. Check repeater directories, or listen first with a $30 RTL-SDR running free GopherTrunk to see which digital mode is genuinely active in your area."
+  - q: "Do I need a license to use a handheld ham radio?"
+    a: "To transmit, yes — an FCC amateur license (Part 97), Technician class minimum. Listening requires no license at all, on any of these radios or on an SDR."
+  - q: "Are Baofeng radios any good?"
+    a: "As $25–60 beaters, yes. But independent lab tests found many UV-5R-family units exceeding FCC spurious-emission limits, quality control is a lottery, and the certification history is messy — Baofeng's own FCC-compliant GT-5R variant exists because of it. Buy one as a spare or loaner, not as your only radio."
+---
+
+# The 10 Best Handheld Ham Radios (2026 Buyer's Guide)
+
+**The best handheld ham radio is the one that speaks your area's mode.** DMR,
+D-STAR and C4FM repeaters don't interoperate, and no current HT transmits more
+than one of the three — so find out what's active locally *before* buying, not
+after. And know the legal line up front: **transmitting on the ham bands
+requires an FCC amateur license (Part 97 — Technician class minimum); listening
+requires none.**
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Best overall:** [Kenwood TH-D75A](/reference/kenwood-th-d75a/) — tri-band,
+D-STAR, the definitive APRS, SSB/CW receive. **Best features for the price:**
+[AnyTone AT-D878UVII Plus](/reference/anytone-at-d878uvii-plus/) — the hobbyist
+DMR standard, ~$250. **Most affordable:** [Baofeng UV-5R](/reference/baofeng-uv-5r/)
+— ~$25, with honest caveats. **Best used/classic buy:**
+[Kenwood TH-F6A](/reference/kenwood-th-f6a/) — 220 MHz plus all-mode receive
+for ~$240 used. Not sure which digital mode your area runs? A $30
+[RTL-SDR](/reference/rtl-sdr/) + free GopherTrunk will tell you —
+[listen first](/best-sdr-for-gophertrunk/).
+</div>
+
+## Quick picks
+
+<div class="pick-cards" markdown="0">
+<div class="pick-card pick-card--top">
+<span class="pick-card__badge">Best overall</span>
+<h3>Kenwood TH-D75A</h3>
+<p class="pick-card__price">around $720</p>
+<p>The most capable HT in production: tri-band TX with 220 MHz, D-STAR, a full APRS KISS TNC, and SSB/CW wideband receive. Weak battery life is the one real flaw.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/s?k=Kenwood+TH-D75A&tag=gophertrunk-20" rel="nofollow sponsored noopener">TH-D75A on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/kenwood-th-d75a/">TH-D75A details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Best features for the price</span>
+<h3>AnyTone AT-D878UVII Plus</h3>
+<p class="pick-card__price">around $250</p>
+<p>The de-facto hobbyist DMR handheld: dual timeslot DMR + FM, APRS, GPS, Bluetooth, ~7 W, and the biggest support community in the class.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B08ZYXHZWW?tag=gophertrunk-20" rel="nofollow sponsored noopener">AT-D878UVII on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/anytone-at-d878uvii-plus/">AT-D878UVII Plus details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Most affordable</span>
+<h3>Baofeng UV-5R</h3>
+<p class="pick-card__price">around $25</p>
+<p>The $25 beater that made ham radio accessible to millions — bought with the emissions, QC and certification caveats understood.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B007UYKG4E?tag=gophertrunk-20" rel="nofollow sponsored noopener">UV-5R on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/baofeng-uv-5r/">UV-5R details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Best used/classic buy</span>
+<h3>Kenwood TH-F6A</h3>
+<p class="pick-card__price">around $200–275 used</p>
+<p>Tri-band TX with 220 MHz plus 0.1–1,300 MHz all-mode receive — a niche only the $720 TH-D75A ever re-filled. Cheaper and lower-risk than the VX-8DR.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0097CQ4AW?tag=gophertrunk-20" rel="nofollow sponsored noopener">TH-F6A on Amazon (used) &rarr;</a>
+<p class="pick-card__note"><a href="/reference/kenwood-th-f6a/">TH-F6A details</a></p>
+</div>
+</div>
+
+## How we grade
+
+Every radio here is judged on the same six criteria we use across our
+[base station](/best-ham-radio-base-stations/) and
+[mobile](/best-mobile-ham-radios/) guides: **RF performance** (receiver dynamic
+range and filtering, transmit audio), **Coverage &amp; modes** (bands, FM/SSB/CW,
+digital — DMR, C4FM, D-STAR, APRS), **Power &amp; duty** (output and thermal
+behavior), **Usability &amp; programming** (front panel, menus, CHIRP and
+software support), **Ecosystem &amp; support** (firmware, service, parts,
+community), and **Value** (what the street price actually buys). No stars, no
+scores out of ten — grades of Excellent/Good/Fair/Basic in the
+[comparison table](#full-comparison), and plain words about what each radio
+gets wrong.
+
+## The top 10, ranked
+
+### 1. Kenwood TH-D75A — best overall
+
+Untouchable on **Coverage &amp; modes**: tri-band TX with 220 MHz, D-STAR, the
+definitive APRS with KISS TNC, and the only SSB/CW-capable receiver in a
+production HT — with the best **RF performance** of the group. **Power &amp;
+duty** is its weak criterion: the 1,100 mAh battery drains fast.
+<a class="btn btn--buy" href="https://www.amazon.com/s?k=Kenwood+TH-D75A&tag=gophertrunk-20" rel="nofollow sponsored noopener">Find on Amazon &rarr;</a> · [Full review](/reference/kenwood-th-d75a/)
+
+### 2. Yaesu FT-5DR — the value flagship
+
+The best **Value** in the top half: C4FM + APRS + GPS + Bluetooth + IPX7
+submersibility at ~$380, half a TH-D75A. **Usability &amp; programming** is the
+tax — Yaesu's menus and a fiddly touch screen have a real learning curve.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B09GS924GT?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a> · [Full review](/reference/yaesu-ft-5dr/)
+
+### 3. AnyTone AT-D878UVII Plus — best features for the price
+
+If your area runs DMR this is the buy: **Ecosystem &amp; support** is its
+superpower (huge community, shared codeplugs, constant firmware), with APRS,
+GPS and ~7 W thrown in at ~$250. **RF performance** is mid-grade — expect
+intermod in RF-dense areas.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B08ZYXHZWW?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a> · [Full review](/reference/anytone-at-d878uvii-plus/)
+
+### 4. Icom ID-52A — the outdoor D-STAR pick
+
+The best **Usability** of any digital HT — a superb color UI in a genuinely
+waterproof IP67 body — and excellent D-STAR. Loses points on **Coverage &amp;
+modes**: no APRS TNC, no 220 MHz. The family is transitioning to the ID-52A
+PLUS; both are covered in the review.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0DC8MSVJ4?tag=gophertrunk-20" rel="nofollow sponsored noopener">ID-52A PLUS on Amazon &rarr;</a> · [Full review](/reference/icom-id-52a/)
+
+### 5. Yaesu FT-60R — the indestructible analog
+
+Twenty-two years in production for a reason: top-tier **Power &amp; duty** and
+**Usability** (dead simple, mature CHIRP), with front-end selectivity that
+embarrasses everything cheaper. **Coverage &amp; modes** is deliberately Basic
+— analog FM only.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B004P4PDAO?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a> · [Full review](/reference/yaesu-ft-60r/)
+
+### 6. BTECH UV-PRO — budget feature king
+
+IP67 + GPS + APRS + Bluetooth TNC + USB-C for ~$165 is remarkable **Value**;
+the app-first setup is genuinely newcomer-friendly. **RF performance** is
+SoC-class — it overloads near strong transmitters — and deep config needs the
+phone app.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0DBW24N8M?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a> · [Full review](/reference/btech-uv-pro/)
+
+### 7. Kenwood TH-F6A — best used/classic buy
+
+Discontinued ~2017, still unmatched used: 5 W on 220 MHz plus all-mode
+0.1–1,300 MHz receive for ~$200–275, with parts and CHIRP support intact —
+strong **Value** and unique **Coverage** for the money. Check battery health
+and plastics; eBay and hamfests are the real market.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0097CQ4AW?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check Amazon (used) &rarr;</a> · [Full review](/reference/kenwood-th-f6a/)
+
+### 8. Baofeng BF-F8HP — the sorted Baofeng
+
+The "UV-5R 3rd gen": 8 W, bigger battery, better antenna, US-based BTECH
+support — the best **Value** route into the platform at ~$60. It inherits the
+platform's Basic **RF performance** wholesale.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B00MAULSOK?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a> · [Full review](/reference/baofeng-bf-f8hp/)
+
+### 9. Yaesu VX-8DR — the unrepeated quad-bander
+
+Quad-band 50/144/222/430 TX, submersible, APRS — **Coverage** nothing since has
+matched. Ranked below the TH-F6A on **Ecosystem &amp; support**: the GPS and
+Bluetooth modules are scarce and the flaky BU-1 was a weak point even new;
+treat the aged gaskets' waterproofing as expired. eBay-only.
+<a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=Yaesu+VX-8DR" rel="nofollow noopener">Find on eBay &rarr;</a> · [Full review](/reference/yaesu-vx-8dr/)
+
+### 10. Baofeng UV-5R — most affordable, caveats included
+
+At ~$25 it earns its place on **Value** alone — as a beater, spare or loaner.
+**RF performance** is the worst here (lab-documented spurious emissions on many
+units, QC lottery, wide-open front end); prefer the FCC-compliant GT-5R
+variant.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B007UYKG4E?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a> · [Full review](/reference/baofeng-uv-5r/)
+
+## Full comparison
+
+| Radio | RF | Coverage &amp; modes | Usability | Value | ~$ price |
+|---|---|---|---|---|---|
+| [Kenwood TH-D75A](/reference/kenwood-th-d75a/) | **Excellent** | **Excellent** | Good | Good | ~$720 |
+| [Yaesu FT-5DR](/reference/yaesu-ft-5dr/) | Good | Excellent | Fair | **Excellent** | ~$380 |
+| [AnyTone AT-D878UVII Plus](/reference/anytone-at-d878uvii-plus/) | Fair | Good | Fair | **Excellent** | ~$250 |
+| [Icom ID-52A](/reference/icom-id-52a/) | Good | Good | **Excellent** | Good | ~$580–750 |
+| [Yaesu FT-60R](/reference/yaesu-ft-60r/) | Good | Basic | **Excellent** | Good | ~$180 |
+| [BTECH UV-PRO](/reference/btech-uv-pro/) | Fair | Good | Good | **Excellent** | ~$165 |
+| [Kenwood TH-F6A](/reference/kenwood-th-f6a/) | Good | Good | Fair | Good | ~$240 used |
+| [Baofeng BF-F8HP](/reference/baofeng-bf-f8hp/) | Basic | Basic | Fair | Good | ~$60 |
+| [Yaesu VX-8DR](/reference/yaesu-vx-8dr/) | Good | Good | Fair | Fair | ~$300 used |
+| [Baofeng UV-5R](/reference/baofeng-uv-5r/) | Basic | Basic | Fair | Good | ~$25 |
+
+> **Listen before you spend.** A $720 D-STAR radio is a paperweight if every
+> active repeater in your county runs DMR. A $30 [RTL-SDR](/reference/rtl-sdr/)
+> running free GopherTrunk will show you — and record — exactly what's on the
+> air locally before you commit to a mode, and no license is needed to listen.
+> Start with [best SDR for GopherTrunk](/best-sdr-for-gophertrunk/).
+
+## How to choose
+
+- **APRS, packet, or 220 MHz?** [TH-D75A](/reference/kenwood-th-d75a/) new, or
+  a used [TH-F6A](/reference/kenwood-th-f6a/) on a budget.
+- **Local repeaters run DMR?** [AT-D878UVII Plus](/reference/anytone-at-d878uvii-plus/).
+  **C4FM?** [FT-5DR](/reference/yaesu-ft-5dr/). **D-STAR?**
+  [ID-52A](/reference/icom-id-52a/) (outdoors) or TH-D75A (data modes).
+- **First real radio, analog area?** [FT-60R](/reference/yaesu-ft-60r/) — it
+  will outlive your interest and your next three radios.
+- **Budget APRS/off-grid kit?** [BTECH UV-PRO](/reference/btech-uv-pro/).
+- **Cheapest possible start or a go-bag spare?**
+  [UV-5R](/reference/baofeng-uv-5r/) (ideally the GT-5R variant) or the
+  better-sorted [BF-F8HP](/reference/baofeng-bf-f8hp/).
+- **Collector with a 6 m itch?** A used [VX-8DR](/reference/yaesu-vx-8dr/) —
+  eyes open on modules and gaskets.
+
+## Bottom line
+
+The **Kenwood TH-D75A** is the best handheld ham radio of 2026 — nothing else
+combines its bands, modes and receiver — but most people are better served
+buying the mode their area actually uses: the **FT-5DR** for C4FM, the
+**AT-D878UVII Plus** for DMR, the **FT-60R** where analog still rules. Need a
+shack rig or something for the car instead? See our
+[best ham radio base stations](/best-ham-radio-base-stations/) and
+[best mobile ham radios](/best-mobile-ham-radios/) guides — and whatever you
+buy, remember transmitting takes a Technician license while
+[listening with an SDR](/best-sdr-for-gophertrunk/) is free.

--- a/docs/best-mobile-ham-radios.md
+++ b/docs/best-mobile-ham-radios.md
@@ -1,0 +1,228 @@
+---
+layout: page
+title: "The 10 Best Mobile Ham Radios (2026 Buyer's Guide)"
+description: "The best mobile ham radios of 2026, ranked — Yaesu FTM-500DR, AnyTone AT-D578UVIII Plus, Icom ID-5100A, budget picks and used classics like the FT-857D — with honest grades for RF, modes, usability, and value."
+keywords: best mobile ham radio, best mobile ham radio 2026, dual band mobile radio, C4FM mobile, DMR mobile radio, D-STAR mobile, Yaesu FTM-500DR, AnyTone AT-D578UVIII, cheap mobile ham radio, used mobile ham radio
+permalink: /best-mobile-ham-radios/
+nav_group: Hardware
+affiliate: true
+faq:
+  - q: "What is the best mobile ham radio in 2026?"
+    a: "The Yaesu FTM-500DR — 50 W on 2m/70cm, C4FM Fusion, dual receive, GPS/APRS, Bluetooth, and the best audio in the class via its AESS dual-speaker system. Yaesu shipped the FTM-510DR successor in 2025, so buy the 500DR while genuine new stock lasts at ~$500."
+  - q: "What is the best DMR mobile radio?"
+    a: "The AnyTone AT-D578UVIII Plus. Tri-band transmit, a ~500,000-contact database, APRS on both FM and DMR, and Bluetooth for around $460 — more features per dollar than anything else in a mobile."
+  - q: "What is the cheapest mobile ham radio worth buying?"
+    a: "The QYT KT-8900D at around $100 puts 20+ watts in a vehicle and programs with CHIRP. It is beater-grade — power often measures below spec and QC is a lottery — so the better-sorted BTECH UV-25X2 at ~$130 is worth the extra if you can stretch."
+  - q: "Are used mobile ham radios a good buy?"
+    a: "Often the best buy. A Kenwood TM-V71A at $250–350 used is near-bulletproof with cross-band repeat; a Yaesu FT-857D at $500–750 used is still the smallest 100 W HF-to-UHF radio ever made. Check the known failure points before paying — our individual reviews list them."
+  - q: "Do I need a license to use a mobile ham radio?"
+    a: "To transmit, yes — an FCC amateur license, Technician class minimum (Part 97). Listening requires no license at all, and a $30 RTL-SDR running free GopherTrunk lets you monitor every local repeater before you buy or test anything."
+---
+
+# The 10 Best Mobile Ham Radios (2026 Buyer's Guide)
+
+**The best mobile ham radio is the one that speaks your area's digital
+language.** VHF/UHF mobiles split into camps — [C4FM](/reference/c4fm/)
+Fusion, [DMR](/reference/dmr/), [D-STAR](/reference/d-star/), and plain
+analog FM — and a flagship in the wrong camp loses to a $130 radio in the
+right one. Find out what your local repeaters actually run first (a $30
+[RTL-SDR](/reference/rtl-sdr/) with free GopherTrunk will tell you), then buy
+from the list below. And the ground rule: **transmitting on ham bands requires
+an FCC amateur license — Technician class minimum under Part 97; listening
+requires none.**
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Best overall:** [Yaesu FTM-500DR](/reference/yaesu-ftm-500dr/) — top-tier
+audio, C4FM, GPS/[APRS](/reference/aprs/), ~$500 while new stock lasts.
+**Best features for the price:**
+[AnyTone AT-D578UVIII Plus](/reference/anytone-at-d578uviii/) — tri-band DMR,
+dual APRS, ~$460. **Most affordable:** [QYT KT-8900D](/reference/qyt-kt-8900d/)
+(~$100, beater-grade). **Best used/classic buy:**
+[Yaesu FT-857D](/reference/yaesu-ft-857d/) — HF-to-UHF in one tiny box,
+$500–750 used. Sleeper value: a used
+[Kenwood TM-V71A](/reference/kenwood-tm-v71a/) at ~$300.
+</div>
+
+## Quick picks
+
+<div class="pick-cards" markdown="0">
+<div class="pick-card pick-card--top">
+<span class="pick-card__badge">Best overall</span>
+<h3>Yaesu FTM-500DR</h3>
+<p class="pick-card__price">around $500</p>
+<p>50 W 2m/70cm, C4FM Fusion, dual receive, GPS/APRS, Bluetooth, and the best audio in the class. Late-life (FTM-510DR is the successor) but the best all-arounder while new stock lasts.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0CLSGMLPC?tag=gophertrunk-20" rel="nofollow sponsored noopener">FTM-500DR on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/yaesu-ftm-500dr/">FTM-500DR details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Best features for the price</span>
+<h3>AnyTone AT-D578UVIII Plus</h3>
+<p class="pick-card__price">around $460</p>
+<p>Tri-band DMR flagship: FM + DMR, APRS on both, Bluetooth, air-band RX, and a 500,000-contact database. The default hams' DMR mobile.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B09CG83Q3Z?tag=gophertrunk-20" rel="nofollow sponsored noopener">AT-D578UVIII on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/anytone-at-d578uviii/">AT-D578UVIII details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Most affordable</span>
+<h3>QYT KT-8900D</h3>
+<p class="pick-card__price">around $100</p>
+<p>The cheapest way to put 20+ watts in a vehicle. Quad-standby display, CHIRP-programmable, beater-grade QC — know what you're buying.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B01MYY5JWF?tag=gophertrunk-20" rel="nofollow sponsored noopener">KT-8900D on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/qyt-kt-8900d/">KT-8900D details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Best used/classic buy</span>
+<h3>Yaesu FT-857D</h3>
+<p class="pick-card__price">$500–750 used</p>
+<p>The smallest 100 W HF-to-UHF mobile ever made, discontinued with no successor. CHIRP-supported and still the do-everything classic — check the finals and display before paying.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B01MFFYPON?tag=gophertrunk-20" rel="nofollow sponsored noopener">FT-857D on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/yaesu-ft-857d/">FT-857D details</a> · used market: eBay/hamfests</p>
+</div>
+</div>
+
+## How we grade
+
+Every radio here is judged on the same six criteria we use across our
+[base station](/best-ham-radio-base-stations/) and
+[handheld](/best-handheld-ham-radios/) guides: **RF performance** (receiver
+dynamic range and filtering, transmit audio), **Coverage &amp; modes** (bands,
+FM/SSB/CW, digital — DMR, C4FM, D-STAR, APRS), **Power &amp; duty** (output
+and thermal behavior), **Usability &amp; programming** (front panel, menus,
+CHIRP/software support), **Ecosystem &amp; support** (firmware, service,
+parts, community), and **Value** (what the street price buys). No star
+ratings, no scores — just Excellent/Good/Fair/Basic grades and plain talk
+about trade-offs, including used-market viability for the discontinued
+classics.
+
+## The top 10, ranked
+
+### 1. Yaesu FTM-500DR — best overall
+
+The complete package: **RF performance** (the AESS audio and a solid
+receiver) plus **Coverage &amp; modes** (C4FM, dual receive, GPS/APRS,
+Bluetooth) with no real weakness. Late-life — the FTM-510DR succeeded it in
+2025 — but still the best buy at ~$500 while new stock is real.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0CLSGMLPC?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a> · [Full review](/reference/yaesu-ftm-500dr/)
+
+### 2. AnyTone AT-D578UVIII Plus — best features for the price
+
+Unmatched on **Coverage &amp; modes** (tri-band, DMR + FM, APRS both ways,
+air-band RX) and **Value**; docked on **Usability &amp; programming** for the
+quirky Windows-only CPS and on **RF performance** at crowded sites, where the
+front end trails Icom and Yaesu.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B09CG83Q3Z?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a> · [Full review](/reference/anytone-at-d578uviii/)
+
+### 3. Yaesu FTM-300DR — the value Fusion
+
+Discontinued (Yaesu "Legacy") but new-old-stock is still ~$400, and its
+**Coverage &amp; modes** beat the 500DR in one spot: independent C4FM decode
+on both receivers. The small non-touch screen is the trade.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B08884HN79?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a> · [Full review](/reference/yaesu-ftm-300dr/)
+
+### 4. Icom ID-5100A — the D-STAR mobile
+
+The de-facto D-STAR rig: **Usability** wins with the huge 5.5" touchscreen
+and DR-mode repeater databases, and **RF performance** is quiet, clean Icom.
+Its 2014 DNA (resistive screen, D-PRS instead of FM APRS) keeps it from
+ranking higher.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B00K5BNHT0?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a> · [Full review](/reference/icom-id-5100a/)
+
+### 5. Icom IC-2730A — best pure-FM mobile in production
+
+**RF performance** is the whole pitch: a clean, sensitive receiver with true
+dual receive and air-band RX for ~$330, still in production. **Coverage &amp;
+modes** is deliberately Basic — no digital, no APRS — so buy it for the RF,
+not the spec sheet.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B00QOR05EY?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a> · [Full review](/reference/icom-ic-2730a/)
+
+### 6. Kenwood TM-V71A — the bulletproof used bargain
+
+Discontinued ~2021, near-bulletproof used at $250–350: superb receiver,
+best-in-class cross-band repeat, built-in EchoLink sysop mode. **Value**
+carries it; no APRS or digital keeps it mid-pack.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0084QI38S?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a> · [Full review](/reference/kenwood-tm-v71a/)
+
+### 7. Yaesu FT-857D — best used/classic buy
+
+The smallest 100 W HF-to-UHF mobile ever made, with no successor since
+production ended around 2019–2020. **Coverage &amp; modes** is unmatched here
+(160 m to 70cm, all modes); **Usability** (menu maze) and aging PA
+finals/display are the known costs. $500–750 used.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B01MFFYPON?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a> · [Full review](/reference/yaesu-ft-857d/)
+
+### 8. Icom IC-706MkIIG — the original shack-in-a-box
+
+The FT-857D's mission for $100–150 less used ($400–650) — strong **Value**,
+but memories are front-panel-only (no CHIRP, no RT Systems), and the display
+backlight and band-switch relay are the aging points to check. eBay
+territory.
+<a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=Icom+IC-706MkIIG" rel="nofollow noopener">Find on eBay &rarr;</a> · [Full review](/reference/icom-ic-706mkiig/)
+
+### 9. BTECH UV-25X2 — the budget mobile that's fine
+
+25 W, dual watch, CHIRP-standard programming, and honest **Value** at ~$130.
+**RF performance** is the class weakness — front-end overload near strong
+transmitters — so it's an entry rig or backup, not a metro-site primary.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B06XD3CQ6H?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a> · [Full review](/reference/btech-uv-25x2/)
+
+### 10. QYT KT-8900D — most affordable
+
+~$100 for 20+ real-ish watts and a handy quad-standby display. **Value** is
+why it's here; **RF performance** (below-spec power, marginal spectral purity
+on some units, QC lottery) is why it's last. A beater, knowingly bought.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B01MYY5JWF?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a> · [Full review](/reference/qyt-kt-8900d/)
+
+## Full comparison
+
+| Radio | RF | Coverage &amp; modes | Usability | Value | ~$ price |
+|---|---|---|---|---|---|
+| [Yaesu FTM-500DR](/reference/yaesu-ftm-500dr/) | **Excellent** | Excellent | **Excellent** | Good | ~$500 |
+| [AnyTone AT-D578UVIII Plus](/reference/anytone-at-d578uviii/) | Good | **Excellent** | Fair | **Excellent** | ~$460 |
+| [Yaesu FTM-300DR](/reference/yaesu-ftm-300dr/) | **Excellent** | Excellent | Good | **Excellent** | ~$400 NOS |
+| [Icom ID-5100A](/reference/icom-id-5100a/) | **Excellent** | Good | Good | Good | ~$465 |
+| [Icom IC-2730A](/reference/icom-ic-2730a/) | **Excellent** | Basic | **Excellent** | Good | ~$330 |
+| [Kenwood TM-V71A](/reference/kenwood-tm-v71a/) | **Excellent** | Fair | Good | **Excellent** | ~$300 used |
+| [Yaesu FT-857D](/reference/yaesu-ft-857d/) | Good | **Excellent** | Fair | Good | ~$600 used |
+| [Icom IC-706MkIIG](/reference/icom-ic-706mkiig/) | Good | **Excellent** | Fair | Good | ~$500 used |
+| [BTECH UV-25X2](/reference/btech-uv-25x2/) | Fair | Basic | Good | Good | ~$130 |
+| [QYT KT-8900D](/reference/qyt-kt-8900d/) | Basic | Basic | Fair | Good | ~$100 |
+
+> **Match the camp before the radio.** A $500 Fusion flagship is the wrong buy
+> in a DMR town — the digital networks don't interoperate. Before spending
+> anything, listen: a ~$30 [RTL-SDR](/reference/rtl-sdr/) running free
+> GopherTrunk decodes and logs your local repeaters (no license needed to
+> listen; Technician minimum to transmit), so you buy into the network your
+> neighbors actually use. See
+> [best SDR for GopherTrunk](/best-sdr-for-gophertrunk/).
+
+## How to choose
+
+- **Want one radio that does everything well?**
+  [FTM-500DR](/reference/yaesu-ftm-500dr/) — or the
+  [FTM-300DR](/reference/yaesu-ftm-300dr/) NOS to save ~$100.
+- **Your area runs DMR?**
+  [AnyTone AT-D578UVIII Plus](/reference/anytone-at-d578uviii/), no contest.
+- **D-STAR country?** [Icom ID-5100A](/reference/icom-id-5100a/).
+- **Just want superb analog FM, new?**
+  [Icom IC-2730A](/reference/icom-ic-2730a/).
+- **Best radio per dollar, any condition?** A used
+  [Kenwood TM-V71A](/reference/kenwood-tm-v71a/) at ~$300.
+- **Want HF from the driver's seat?** A used
+  [FT-857D](/reference/yaesu-ft-857d/) or
+  [IC-706MkIIG](/reference/icom-ic-706mkiig/) — or a new
+  [Yaesu FT-891](/reference/yaesu-ft-891/) if you can live with HF/6m only.
+- **Hard budget cap?** [BTECH UV-25X2](/reference/btech-uv-25x2/) at ~$130,
+  or the [QYT KT-8900D](/reference/qyt-kt-8900d/) at ~$100 if it must be
+  under $110.
+
+## Bottom line
+
+The **[Yaesu FTM-500DR](/reference/yaesu-ftm-500dr/)** is the best mobile ham
+radio for most operators in 2026 — while genuine new stock lasts — with the
+**[AnyTone AT-D578UVIII Plus](/reference/anytone-at-d578uviii/)** taking the
+crown anywhere DMR rules, and a used
+**[TM-V71A](/reference/kenwood-tm-v71a/)** embarrassing radios twice its
+price. Building out the rest of the shack? See our guides to the
+[best base station ham radios](/best-ham-radio-base-stations/) and the
+[best handheld ham radios](/best-handheld-ham-radios/).

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -66,6 +66,12 @@ Consumer scanner hardware (Uniden, Whistler) compared honestly against a free SD
 - [Digital vs analog scanners]({{ '/digital-vs-analog-scanner/' | absolute_url }}): what you can still hear on an analog radio in 2026.
 - [P25 scanners]({{ '/p25-scanner/' | absolute_url }}): what Phase I/II and simulcast mean for buyers.
 
+## Ham radio buyer's guides
+Amateur radio transceivers ranked with an honest rubric — no star ratings — plus classic used-market picks. Transmitting requires an FCC amateur license; listening does not.
+- [Best ham radio base stations]({{ '/best-ham-radio-base-stations/' | absolute_url }}): the 10 best HF base stations ranked, from the Xiegu G90 to the Icom IC-7610, including classic used rigs.
+- [Best mobile ham radios]({{ '/best-mobile-ham-radios/' | absolute_url }}): the 10 best vehicle-mount rigs ranked, from budget dual-banders to the Yaesu FTM-500DR, including discontinued do-everything classics.
+- [Best handheld ham radios]({{ '/best-handheld-ham-radios/' | absolute_url }}): the 10 best HTs ranked, from the Baofeng UV-5R to the Kenwood TH-D75A, including used-market classics.
+
 ## SDR hardware for GopherTrunk (buyer's guides)
 The receivers, antennas, cables, and accessories to run GopherTrunk, with honest picks and Amazon links.
 - [Best SDR for GopherTrunk]({{ '/best-sdr-for-gophertrunk/' | absolute_url }}): RTL-SDR, NESDR, Airspy, and HackRF compared for P25/DMR/NXDN decoding.

--- a/docs/reference/anytone-at-d578uviii.md
+++ b/docs/reference/anytone-at-d578uviii.md
@@ -1,0 +1,135 @@
+---
+slug: anytone-at-d578uviii
+title: AnyTone AT-D578UVIII Plus
+entry_type: hardware
+category: ham-radios
+description: "The AnyTone AT-D578UVIII Plus is the default DMR mobile ham radio — tri-band 2m/1.25m/70cm, 50 W, analog FM + DMR Tier I/II, GPS with true FM and DMR APRS, Bluetooth, and a 500,000-contact database, around $460 in 2026."
+keywords: AnyTone AT-D578UVIII Plus, AT-D578UVIII review, best DMR mobile radio, DMR mobile ham radio, tri-band mobile radio, 220 MHz mobile, DMR APRS radio, AnyTone mobile, hotspot DMR radio, best mobile ham radio 2026
+aka: [AT-D578UVIII, D578UVIII, D578]
+autolink: true
+affiliate: true
+product:
+  name: "AnyTone AT-D578UVIII Plus"
+  brand: AnyTone
+  category: Mobile ham transceiver
+  lowPrice: "430"
+  highPrice: "500"
+  url: https://www.amazon.com/dp/B09CG83Q3Z?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: Tri-band mobile transceiver }
+  - { label: Bands, value: "2m / 1.25m / 70cm" }
+  - { label: Modes, value: "FM, DMR Tier I/II" }
+  - { label: Power, value: "50 W VHF / ~25 W 220 / 45 W UHF" }
+  - { label: Programming, value: "AnyTone CPS (free, Windows; no CHIRP)" }
+  - { label: Price, value: around $460 }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B09CG83Q3Z?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [yaesu-ftm-500dr, icom-id-5100a, btech-uv-25x2, yaesu-ftm-300dr, rtl-sdr, dmr]
+related_lessons:
+  - { title: "What is trunked radio?", url: /learn/digital-trunking/ }
+related_reading:
+  - { title: "Best SDR for GopherTrunk", url: /best-sdr-for-gophertrunk/ }
+cite_urls:
+  - https://www.anytone.net/video/products-detail-935418
+  - https://www.bridgecomsystems.com/products/anytone-at-d578uviii-plus-tri-band-amateur-dmr-mobile-radio
+faq:
+  - q: "Is the AnyTone AT-D578UVIII Plus the best DMR mobile?"
+    a: "For hams, it is the default: a huge digital-ID contact database with caller info on screen, APRS on both analog FM and DMR, tri-band transmit including 220 MHz, Bluetooth, and constant firmware development. Its receiver front end trails Icom and Yaesu on crowded RF sites — that is the honest trade."
+  - q: "Does the AT-D578UVIII Plus do APRS?"
+    a: "Yes, both kinds: true FM APRS transmit and receive via its built-in GPS, plus DMR APRS. Among digital mobiles this dual-APRS support is a genuine differentiator."
+  - q: "Which AT-D578 variant should I buy?"
+    a: "The family is confusing — there are III Plus, III Pro, and dual-band Plus variants. The III Plus is the tri-band amateur DMR flagship covered here; check the listing carefully so you get the tri-band amateur model."
+  - q: "Can I program the AT-D578UVIII with CHIRP?"
+    a: "No — DMR codeplug radios are outside CHIRP's scope. You use AnyTone's free D578UV CPS, which is Windows-only and quirky but capable. Budget an evening to learn codeplug basics."
+  - q: "Do I need a license for the AT-D578UVIII Plus?"
+    a: "Transmitting requires an FCC amateur license (Part 97, Technician minimum) — and on DMR you'll also register for a DMR ID. Listening requires no license; a $30 RTL-SDR with free GopherTrunk decodes and records local DMR traffic so you can scout the network first."
+---
+**The AnyTone AT-D578UVIII Plus** is the default [DMR](/reference/dmr/) mobile
+for hams: **tri-band** transmit on 2m, 1.25m, and 70cm, analog FM plus **DMR
+Tier I/II**, a built-in GPS doing **both true FM [APRS](/reference/aprs/) and
+DMR APRS**, Bluetooth audio and PTT, air-band receive, and a contact database
+around **500,000 digital IDs** that puts a name on every caller.[^anytone] At
+roughly $430–500 it delivers more features per dollar than anything else on the
+mobile list — which is exactly why it's our **best-features-for-the-price**
+pick.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B09CG83Q3Z?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Best features for the price** in our
+[mobile top 10](/best-mobile-ham-radios/). FM + **DMR Tier I/II**
+(MOTOTRBO-compatible), **tri-band** with 50 W VHF / 45 W UHF (about 25 W on
+220 MHz per spec sheets — verify against the current manual), ~4,000 channels,
+10,000 talkgroups, ~500,000-contact database, **FM + DMR APRS**, Bluetooth,
+air-band RX, roaming, hotspot-friendly. Trade-offs: Windows-only quirky CPS,
+occasional firmware regressions, loud fan, and a front end below Icom/Yaesu on
+crowded sites. **~$460.** Ham license required to transmit; none to listen.
+</div>
+
+## Overview
+
+AnyTone's D578 is what happens when a Chinese OEM iterates fast on what hams
+actually ask for. The **III Plus** — mind the variant soup of III Pro and
+dual-band models — is the tri-band amateur DMR flagship: color TFT, detachable
+faceplate, digital voice recording, roaming between repeaters, and friendly
+behavior with Pi-Star-style hotspots. TX draw is a modest ~11–12 A.
+
+The community's verdict is consistent. In its favor: the huge digital-ID
+database showing callsign and name for every DMR caller, a genuinely loud
+speaker, APRS on both analog and DMR, and constant firmware development. Against
+it: the CPS is Windows-only and quirky, firmware updates occasionally introduce
+regressions, the fan is loud, menus run deep, and the receiver front end —
+decent as it is — sits below Icom and Yaesu when a crowded commercial site is
+hammering the input. One more honest note: analog **cross-band repeat is not a
+supported feature** (a single-band repeater mode has appeared in some firmware,
+but it is firmware-dependent — don't buy on it).
+
+## Modes &amp; features
+
+- **Analog FM and [DMR](/reference/dmr/) Tier I/II**, MOTOTRBO-compatible —
+  the dominant amateur digital mode in many regions, and the one with the
+  cheapest ecosystem.
+- **Tri-band transmit:** 50 W on 2m, ~25 W on 220 MHz (spec-sheet figure —
+  check the current manual), 45 W on 70cm; **air-band receive** on top.
+- **GPS with true FM [APRS](/reference/aprs/) TX/RX plus DMR APRS** — rare
+  even among flagships.
+- ~4,000 channels, 10,000 talkgroups, ~500,000 digital contacts, Bluetooth
+  audio + PTT, voice recording, roaming, hotspot-friendly.
+
+## Programming
+
+No CHIRP — DMR codeplug radios are out of CHIRP's scope. The free **AnyTone
+D578UV CPS** (Windows-only) is the tool; it is quirky but complete, and the
+DMR community publishes shareable codeplugs for most metro areas. Budget an
+evening for codeplug concepts (talkgroups, zones, receive groups) if DMR is
+new to you.
+
+## GopherTrunk alternative
+
+GopherTrunk **receives; it cannot transmit** — it will never key up a DMR
+talkgroup for you. What it does brilliantly is scout: a ~$30
+[RTL-SDR](/reference/rtl-sdr/) running free GopherTrunk **decodes and records
+DMR** (and P25, NXDN, and more), so you can watch your local repeaters and
+confirm which talkgroups actually carry traffic before building a $460
+codeplug around them — with logs and timestamps no transceiver keeps.
+Listening needs no license; transmitting on ham bands requires an FCC amateur
+license (Part 97, Technician minimum). Pick hardware from
+[best SDR for GopherTrunk](/best-sdr-for-gophertrunk/).
+
+## Who it's for
+
+- **Buy the AT-D578UVIII Plus** if DMR is your area's digital mode and you
+  want the most radio per dollar — database, dual APRS, tri-band, Bluetooth —
+  and can live with a quirky Windows CPS.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B09CG83Q3Z?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [Yaesu FTM-500DR](/reference/yaesu-ftm-500dr/)** for
+  [C4FM](/reference/c4fm/) country and better RF refinement, or the
+  [Icom ID-5100A](/reference/icom-id-5100a/) for
+  [D-STAR](/reference/d-star/).
+- **Spend less** with the [BTECH UV-25X2](/reference/btech-uv-25x2/) if you
+  only need analog FM.
+- Full rankings: [the 10 best mobile ham radios](/best-mobile-ham-radios/).
+
+## Sources
+
+[^anytone]: [AnyTone AT-D578UVIII factory product page](https://www.anytone.net/video/products-detail-935418) and [BridgeCom Systems AT-D578UVIII Plus listing](https://www.bridgecomsystems.com/products/anytone-at-d578uviii-plus-tri-band-amateur-dmr-mobile-radio) — manufacturer and primary US distributor, on tri-band coverage, DMR Tier I/II, APRS, database capacities, and pricing.

--- a/docs/reference/anytone-at-d878uvii-plus.md
+++ b/docs/reference/anytone-at-d878uvii-plus.md
@@ -1,0 +1,128 @@
+---
+slug: anytone-at-d878uvii-plus
+title: AnyTone AT-D878UVII Plus
+entry_type: hardware
+category: ham-radios
+description: "The AnyTone AT-D878UVII Plus is the de-facto hobbyist DMR handheld — dual-band DMR Tier I/II plus analog FM with APRS, GPS, Bluetooth and a 500,000-contact database, from around $250."
+keywords: AnyTone AT-D878UVII Plus, AT-D878UVII review, best DMR handheld 2026, DMR ham radio, hotspot radio, DMR Tier 2 HT, AnyTone DMR, APRS DMR handheld, BridgeCom AnyTone, DMR codeplug radio
+aka: [AT-D878UVII Plus, D878UVII, AnyTone 878]
+autolink: true
+affiliate: true
+product:
+  name: "AnyTone AT-D878UVII Plus"
+  brand: AnyTone
+  category: Ham handheld transceiver
+  lowPrice: "250"
+  highPrice: "350"
+  url: https://www.amazon.com/dp/B08ZYXHZWW?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: Dual-band DMR handheld transceiver }
+  - { label: Bands, value: "TX 144/430 MHz" }
+  - { label: Modes, value: "DMR Tier I/II, analog FM; APRS (analog TX/RX + DMR)" }
+  - { label: Power, value: "~7 W VHF / 6 W UHF" }
+  - { label: Programming, value: "AnyTone CPS (Windows; no CHIRP)" }
+  - { label: Price, value: "around $250 (to ~$350 in bundles)" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B08ZYXHZWW?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [kenwood-th-d75a, yaesu-ft-5dr, btech-uv-pro, baofeng-bf-f8hp, rtl-sdr, dmr]
+related_lessons:
+  - { title: "Analog vs. digital voice", url: /learn/rf-sdr/digital-voice/ }
+  - { title: "Legal & ethical monitoring", url: /learn/rf-sdr/legal-ethical/ }
+related_reading:
+  - { title: "Police scanner vs GopherTrunk", url: /police-scanner-vs-sdr/ }
+cite_urls:
+  - https://www.anytone.net/pro_info102.html
+faq:
+  - q: "Is the AnyTone AT-D878UVII Plus the best DMR handheld?"
+    a: "For hobbyist DMR in North America it's the default choice — the community, tutorials, firmware cadence and 500,000-contact database handling are unmatched at the price. Commercial rigs from Motorola or Hytera are built better but cost far more and program worse for ham use."
+  - q: "Does the AT-D878UVII Plus do APRS?"
+    a: "Yes, unusually well for the price: analog APRS transmit and receive plus DMR positioning, with built-in GPS. Full packet/KISS work is still Kenwood TH-D75A territory."
+  - q: "Can I program the AnyTone 878 with CHIRP?"
+    a: "No — DMR codeplug radios are outside CHIRP's scope. You'll use AnyTone's free Windows-only CPS, and the CPS version must match the radio's firmware version, which is a chronic annoyance."
+  - q: "What's the difference between the $250 and $350 listings?"
+    a: "Bundles. Around $250 buys the radio; ~$350 buys BridgeCom-style packages with training courses and accessories. Newer hardware revisions also ship a 3,100 mAh battery with a USB-C charge port — worth checking for."
+  - q: "Do I need a license to use the AT-D878UVII Plus?"
+    a: "Transmitting on the ham bands requires an FCC amateur license (Technician minimum) — and for DMR you'll also register for a free DMR ID. Listening requires no license."
+---
+**The AnyTone AT-D878UVII Plus** is the de-facto standard hobbyist
+[DMR](/reference/dmr/) handheld in North America: dual-band 144/430 MHz,
+DMR Tier I/II plus analog FM, [APRS](/reference/aprs/) on both analog and DMR,
+built-in GPS and Bluetooth, and codeplug capacity for a **500,000-contact**
+digital ID database — from around $250.[^anytone] If your local repeaters or
+hotspot run DMR, this is the radio the room will tell you to buy.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B08ZYXHZWW?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Best features for the price** in [our handheld top 10](/best-handheld-ham-radios/).
+DMR + FM + APRS + GPS + Bluetooth + ~7 W and a huge support ecosystem for
+~$250. The costs: AnyTone's **Windows-only CPS** has a real learning curve and
+firmware/CPS version-matching is a chronic annoyance; the receiver front end is
+mid-grade (intermod in RF-dense areas); build quality is
+good-for-a-Chinese-brand, below Yaesu/Icom/Kenwood. No C4FM or D-STAR.
+Transmitting requires an FCC Technician license; listening doesn't.
+</div>
+
+## Overview
+
+DMR came to ham radio from the commercial world, and it shows: talkgroups,
+color codes, dual timeslots and codeplugs are alien territory for a new
+operator. The 878's genius is the ecosystem that grew around it — BridgeCom's
+training material, countless YouTube walkthroughs, shared codeplugs for most US
+metros, and constant firmware updates. That community, more than any spec, is
+why it became the standard.
+
+The hardware holds its end up: ~7 W VHF / 6 W UHF, strong transmit audio, a
+1.77-inch color display, 4,000 channels and 10,000 talkgroups, voice recording,
+and recent revisions with a 3,100 mAh battery that charges over USB-C on the
+pack itself. Analog APRS transmit *and* receive at this price is genuinely
+rare. The weak points are equally consistent: a mid-grade front end that
+intermods near strong transmitters, slow GPS lock, no published IP rating
+despite "rugged" marketing, and some firmware builds offering AES/ARC4
+encryption options — which are not legal on US amateur bands, so leave them
+off.
+
+## Modes &amp; features
+
+- **[DMR](/reference/dmr/) Tier I/II** (dual timeslot) + analog FM.
+- **[APRS](/reference/aprs/)** — analog TX/RX and DMR positioning, with
+  built-in **GPS**.
+- **500,000-contact** digital ID database; 10,000 talkgroups; 4,000 channels.
+- **Bluetooth** with PTT accessory support; voice recording; roger beeps.
+- **~7 W VHF / 6 W UHF**; 3,100 mAh USB-C battery on current revisions.
+
+## Programming
+
+AnyTone's free CPS (Windows only) is mandatory for DMR codeplug work, and the
+CPS version must match the radio's firmware — mismatches are the most common
+new-owner failure. **No CHIRP**: DMR codeplug radios are out of its scope.
+Budget an evening with a walkthrough video for your first codeplug, or start
+from a shared local one.
+
+## GopherTrunk alternative
+
+GopherTrunk receives; it cannot transmit, so it's not a substitute for the 878.
+But it happens to be very good at DMR *reception* — a ~$30
+[RTL-SDR](/reference/rtl-sdr/) running free GopherTrunk decodes
+[DMR](/reference/dmr/) traffic, follows talkgroups, and records and logs every
+call. Before buying a DMR radio and building a codeplug, listen for a week: you
+will learn which talkgroups are actually active on your local repeaters, and
+whether DMR (rather than [C4FM](/reference/c4fm/) or
+[D-STAR](/reference/d-star/)) is the mode worth buying into. Start at
+[best SDR for GopherTrunk](/best-sdr-for-gophertrunk/).
+
+## Who it's for
+
+- **Buy the AT-D878UVII Plus** if your area (or your hotspot plans) run DMR —
+  it's the most radio and the most community support you can get near $250.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B08ZYXHZWW?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [Yaesu FT-5DR](/reference/yaesu-ft-5dr/)** instead for C4FM areas,
+  or the [Kenwood TH-D75A](/reference/kenwood-th-d75a/) /
+  [Icom ID-52A](/reference/icom-id-52a/) for D-STAR.
+- **Skip DMR entirely** if your local scene is analog — a
+  [Yaesu FT-60R](/reference/yaesu-ft-60r/) is simpler and tougher. Full
+  rankings: [best handheld ham radios](/best-handheld-ham-radios/).
+
+## Sources
+
+[^anytone]: [AnyTone AT-D878UVII Plus product page](https://www.anytone.net/pro_info102.html) — AnyTone, on DMR Tier I/II and analog FM, APRS positioning, GPS/Bluetooth, contact database capacity, and output power.

--- a/docs/reference/baofeng-bf-f8hp.md
+++ b/docs/reference/baofeng-bf-f8hp.md
@@ -1,0 +1,130 @@
+---
+slug: baofeng-bf-f8hp
+title: Baofeng BF-F8HP
+entry_type: hardware
+category: ham-radios
+description: "The Baofeng BF-F8HP is the 8-watt 'UV-5R 3rd gen' — the same dirt-cheap dual-band platform with more power, a bigger battery, a better antenna and US-based BTECH support, for around $60."
+keywords: Baofeng BF-F8HP, BF-F8HP review, BF-F8HP vs UV-5R, 8 watt Baofeng, cheap ham handheld, budget dual band radio, Baofeng 8W, CHIRP Baofeng, beater ham radio
+aka: [BF-F8HP]
+autolink: true
+affiliate: true
+product:
+  name: "Baofeng BF-F8HP"
+  brand: Baofeng
+  category: Ham handheld transceiver
+  lowPrice: "40"
+  highPrice: "70"
+  url: https://www.amazon.com/dp/B00MAULSOK?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: Dual-band handheld transceiver }
+  - { label: Bands, value: "TX 136–174 / 400–520 MHz" }
+  - { label: Modes, value: Analog FM only }
+  - { label: Power, value: "8/4/1 W tri-power" }
+  - { label: Programming, value: "CHIRP (mature driver)" }
+  - { label: Price, value: around $60 }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B00MAULSOK?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [baofeng-uv-5r, btech-uv-pro, yaesu-ft-60r, anytone-at-d878uvii-plus, rtl-sdr, ctcss]
+related_lessons:
+  - { title: "Analog vs. digital voice", url: /learn/rf-sdr/digital-voice/ }
+  - { title: "Legal & ethical monitoring", url: /learn/rf-sdr/legal-ethical/ }
+related_reading:
+  - { title: "Police scanner vs GopherTrunk", url: /police-scanner-vs-sdr/ }
+cite_urls:
+  - https://baofengtech.com/product/bf-f8hp/
+faq:
+  - q: "Is the BF-F8HP better than the UV-5R?"
+    a: "Yes, meaningfully, for about $35 more: 8 W tri-power instead of 4–5, a 2,100 mAh battery, a better stock antenna, and US-based BTECH support with a one-year warranty. It's still the same UV-5R platform underneath — same weak front end, same hostile menus."
+  - q: "Does 8 watts really make a difference?"
+    a: "Less than you'd hope. 8 W vs 5 W is about 2 dB — barely noticeable — and the radio runs hot at full power. Antenna height and quality matter far more than the extra watts."
+  - q: "Does the BF-F8HP work with CHIRP?"
+    a: "Yes — a mature CHIRP driver (select BF-F8HP). CHIRP is effectively mandatory: the front-panel menu experience is hostile without it. Buy a genuine-FTDI programming cable; counterfeits are rampant."
+  - q: "Is the BF-F8HP waterproof or digital?"
+    a: "Neither. No IP rating, analog FM only, no GPS or Bluetooth. For those features near this price bracket, look at the BTECH UV-PRO (~$165)."
+  - q: "Do I need a license to use a BF-F8HP?"
+    a: "Transmitting on the ham bands requires an FCC amateur license (Technician class minimum) — and note this radio will happily transmit outside the ham bands, which is not legal without the relevant authorization. Listening requires no license."
+---
+**The Baofeng BF-F8HP** is what BTECH markets as the "UV-5R 3rd generation": the
+same ubiquitous dual-band budget platform as the
+[UV-5R](/reference/baofeng-uv-5r/), upgraded to **8 W** tri-power, a 2,100 mAh
+battery, a better stock antenna and US-based BTECH support with a one-year
+warranty — for around $60.[^btech] It is the sensible way to buy a Baofeng, and
+it is still a Baofeng.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B00MAULSOK?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The "better UV-5R."** More power, better battery and antenna, real US
+support, same dirt-cheap accessory ecosystem, mature CHIRP driver. It also
+inherits the platform's faults wholesale: a **wide-open front end** that
+intermods near strong transmitters, mediocre selectivity, mushy squelch, and
+menus that are hostile without CHIRP. The 8 W advantage over 5 W is marginal
+in practice and runs hot. **~$60.** Transmitting requires an FCC Technician
+license; listening requires none.
+</div>
+
+## Overview
+
+The BF-F8HP exists because the UV-5R's weakest points — anemic stock battery,
+poor stock antenna, no accountable support — were cheap to fix. BTECH fixed
+them, stamped a tri-power 8 W final on it, and sells the result as a "full kit"
+with antenna, earpiece and charger under a US warranty umbrella. For a
+glovebox, go-bag or loaner radio, that package at $60 is genuinely hard to
+argue with.
+
+What it doesn't fix is the platform. The receiver is the same wide-open design:
+park near a paging transmitter or broadcast site and it collapses into
+intermod a [Yaesu FT-60R](/reference/yaesu-ft-60r/) shrugs off. Selectivity is
+mediocre, the squelch is mushy, and the menu system remains an exercise in
+memorizing two-digit codes. BTECH cites Part 90 certification carried over
+from the UV-5R family — if the certification status matters to you, verify the
+grant for the specific unit, a caution the whole Baofeng family has earned
+(see the [UV-5R page](/reference/baofeng-uv-5r/) for that story). Note also the
+newer **BF-F8HP PRO** is a separate model (10 W tri-band, GPS, USB-C) that has
+begun superseding this one technologically.
+
+## Modes &amp; features
+
+- **Analog FM only** on 136–174 / 400–520 MHz — no digital voice, GPS or
+  Bluetooth.
+- **8/4/1 W tri-power**; expect heat at 8 W and a barely-audible real-world
+  gain over 5 W.
+- **2,100 mAh Li-ion** — noticeably better endurance than a stock UV-5R.
+- **[CTCSS](/reference/ctcss/)/[DCS](/reference/dcs/)**, FM broadcast receive,
+  128 channels, LED flashlight.
+- **No IP rating** — keep it out of the rain.
+
+## Programming
+
+**CHIRP** has a mature BF-F8HP driver and is the community-standard way to
+program it — realistically the only pleasant way. Buy a programming cable with
+a genuine FTDI chip; counterfeit cables are the single most common Baofeng
+setup failure.
+
+## GopherTrunk alternative
+
+GopherTrunk can't transmit, so it doesn't replace even a $60 HT. But if the
+BF-F8HP appeals as a cheap way *into* radio, consider that a ~$30
+[RTL-SDR](/reference/rtl-sdr/) running free GopherTrunk is the cheap way into
+*listening*: it monitors local repeaters and digital traffic the Baofeng can't
+decode ([DMR](/reference/dmr/), [C4FM](/reference/c4fm/),
+[D-STAR](/reference/d-star/)), and records and logs everything. Listen first,
+find out what's active, then buy the transmitter that matches — see
+[best SDR for GopherTrunk](/best-sdr-for-gophertrunk/).
+
+## Who it's for
+
+- **Buy the BF-F8HP** as a beater, loaner, go-bag or first-experiment radio —
+  it's the best-sorted version of the cheapest viable HT platform.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B00MAULSOK?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [Yaesu FT-60R](/reference/yaesu-ft-60r/)** (~$180) instead the
+  moment the radio matters — the front end and build quality are a different
+  class.
+- **Spend $165** on a [BTECH UV-PRO](/reference/btech-uv-pro/) for APRS, GPS
+  and IP67, or **$25** on a bare [UV-5R](/reference/baofeng-uv-5r/) if even $60
+  is too much. Full rankings:
+  [best handheld ham radios](/best-handheld-ham-radios/).
+
+## Sources
+
+[^btech]: [Baofeng BF-F8HP product page](https://baofengtech.com/product/bf-f8hp/) — BTECH, on tri-power output, battery and kit contents, frequency coverage, and warranty/support terms.

--- a/docs/reference/baofeng-uv-5r.md
+++ b/docs/reference/baofeng-uv-5r.md
@@ -1,0 +1,133 @@
+---
+slug: baofeng-uv-5r
+title: Baofeng UV-5R
+entry_type: hardware
+category: ham-radios
+description: "The Baofeng UV-5R is the $25 dual-band handheld that made ham radio accessible to millions — an honest review covering the spurious-emissions lab findings, the QC lottery, the FCC certification mess, and the GT-5R compliant variant."
+keywords: Baofeng UV-5R, UV-5R review, cheapest ham radio, is the UV-5R legal, Baofeng FCC certification, UV-5R spurious emissions, GT-5R, budget ham handheld, CHIRP UV-5R, Baofeng problems
+aka: [UV-5R, UV5R]
+autolink: true
+affiliate: true
+product:
+  name: "Baofeng UV-5R"
+  brand: Baofeng
+  category: Ham handheld transceiver
+  lowPrice: "20"
+  highPrice: "30"
+  url: https://www.amazon.com/dp/B007UYKG4E?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: Dual-band handheld transceiver }
+  - { label: Bands, value: "TX 136–174 / 400–480(520) MHz" }
+  - { label: Modes, value: Analog FM only }
+  - { label: Power, value: "4–5 W nominal (variants claim 8 W)" }
+  - { label: Programming, value: "CHIRP (its flagship radio)" }
+  - { label: Price, value: around $25 }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B007UYKG4E?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [baofeng-bf-f8hp, btech-uv-pro, yaesu-ft-60r, kenwood-th-f6a, rtl-sdr, fcc]
+related_lessons:
+  - { title: "Analog vs. digital voice", url: /learn/rf-sdr/digital-voice/ }
+  - { title: "Legal & ethical monitoring", url: /learn/rf-sdr/legal-ethical/ }
+related_reading:
+  - { title: "Police scanner vs GopherTrunk", url: /police-scanner-vs-sdr/ }
+cite_urls:
+  - https://baofengtech.com/product/uv-5r/
+faq:
+  - q: "Is the Baofeng UV-5R legal to use?"
+    a: "Owning and listening: yes, no license needed. Transmitting on ham bands: legal with an FCC amateur license (Technician minimum). The murky part is the hardware itself — the original Part 90 certification didn't cover typical amateur/consumer use, many clones ship with no valid grant, and the FCC's 2018 enforcement advisory targeted exactly this class of import radio. Baofeng's GT-5R is the explicitly FCC-compliant variant."
+  - q: "Why do people say the UV-5R is 'dirty'?"
+    a: "Independent lab tests from the mid-2010s onward (ARRL among others) found many UV-5R-family units exceeding FCC spurious-emission limits — transmitting measurable harmonics outside their intended frequency, especially on VHF at high power. Quality varies unit to unit; some are clean, some aren't, and you can't tell from the outside."
+  - q: "What is the difference between the UV-5R and the GT-5R?"
+    a: "The GT-5R is Baofeng's own answer to the criticism: an explicitly FCC-compliant version of the UV-5R with cleaned-up emissions and TX locked to the amateur bands. Its existence is Baofeng conceding the point. If you want a UV-5R in 2026, the GT-5R is the defensible one to buy."
+  - q: "Is the UV-5R a good first ham radio?"
+    a: "It's a good first $25. As a beater, go-bag spare or classroom radio it has real value, and CHIRP makes it usable. As your only radio it will frustrate you — deaf receiver near strong signals, QC lottery, hostile menus. A Yaesu FT-60R is the better first real radio if the budget reaches $180."
+  - q: "Which UV-5R variant should I buy?"
+    a: "They're legion — UV-5R v2+, UV-5RA, UV-5RE, UV-5R+ are cosmetic shells of the same radio, while '8W', 'Plus' and UV-5RH-style models share the name but not the internals. For a known quantity, buy the classic kit or the GT-5R, and assume any '8 W' claim is optimistic."
+---
+**The Baofeng UV-5R** is the most-cloned handheld on Earth and, at around
+**$25**, the radio that made ham radio accessible to millions.[^baofeng] It is
+also a radio whose family has repeatedly **failed independent spurious-emission
+lab tests**, whose quality control is a lottery, and whose FCC certification
+story is messy enough that Baofeng itself sells a cleaned-up variant. Both
+halves of that sentence are true, and an honest review has to hold them
+together.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B007UYKG4E?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**A $25 beater with caveats — buy it as exactly that.** Dual-band analog FM,
+CHIRP's flagship radio, an enormous accessory ecosystem. The caveats are real:
+**many units exceed FCC spurious-emission limits** (ARRL and other lab
+findings), the **QC lottery** ("buy two" is a running joke), and a
+**certification mess** the FCC's 2018 enforcement advisory targeted. The
+**GT-5R** is Baofeng's FCC-compliant fix — buy that variant. Transmitting
+requires an FCC amateur license (Technician minimum); listening requires none.
+</div>
+
+## Overview
+
+Since roughly 2012 the UV-5R has been the answer to "what's the cheapest way to
+transmit?" — 136–174 and 400–480 (or 520) MHz, 4–5 W nominal, 128 channels, an
+1,800 mAh battery, a flashlight, and a street price that dips near $20 on
+sale. It spawned a giant ecosystem of batteries, antennas and cases, and made
+CHIRP a household name. A radio you can afford to lose, lend or leave in a kit
+has genuine value, and pretending otherwise is snobbery.
+
+The problems are equally documented. **Emissions**: independent lab tests
+(ARRL and others, mid-2010s onward) found many UV-5R-family units exceeding
+FCC spurious-emission limits, especially on VHF at high power — and it varies
+unit to unit, so a clean review sample proves nothing about yours.
+**QC**: frequency drift, deaf receivers and failed finals are common enough
+that "buy two" is the standing advice. **Certification**: the original Part 90
+grant never covered how most consumers actually use the radio, countless clones
+ship with no valid grant at all, and the [FCC](/reference/fcc/)'s 2018
+Enforcement Advisory took aim at precisely this class of import. Baofeng's
+answer was the **GT-5R** — an explicitly FCC-compliant UV-5R with cleaned-up
+emissions and TX locked to the amateur bands
+(<a href="https://www.amazon.com/dp/B08VNM1CX4?tag=gophertrunk-20" rel="nofollow sponsored noopener">GT-5R on Amazon</a>) —
+and its existence is Baofeng conceding every point above. **Receiver**: the
+wide-open front end overloads next to any strong transmitter.
+
+## Modes &amp; features
+
+- **Analog FM only**; no digital, GPS, Bluetooth or IP rating.
+- **4–5 W nominal** (variant "8 W" claims are marketing; the internals vary).
+- **128 channels**, [CTCSS](/reference/ctcss/)/[DCS](/reference/dcs/), FM
+  broadcast receive, flashlight.
+- **Variant chaos**: UV-5RA/RE/R+ are cosmetic shells; "Plus"/UV-5RH-style
+  successors share the name, not the internals.
+
+## Programming
+
+The UV-5R is arguably **CHIRP's flagship radio** — programming it any other way
+is masochism. The one gotcha is the USB cable: counterfeit chips are rampant,
+so buy a genuine-FTDI cable.
+
+## GopherTrunk alternative
+
+Here's the budget math worth knowing: GopherTrunk receives only and can't
+replace even a $25 transmitter — but for the *listening* half of the hobby, a
+~$30 [RTL-SDR](/reference/rtl-sdr/) running free GopherTrunk beats the UV-5R
+hollow. It hears the digital modes ([DMR](/reference/dmr/),
+[C4FM](/reference/c4fm/), [D-STAR](/reference/d-star/), even
+[trunked systems](/reference/trunked-radio/)) the Baofeng can't, and it records
+and logs every transmission. Run both for under $60: the SDR to learn what's
+active, the UV-5R to talk on it once you're licensed. See
+[best SDR for GopherTrunk](/best-sdr-for-gophertrunk/).
+
+## Who it's for
+
+- **Buy a UV-5R** — ideally the
+  <a href="https://www.amazon.com/dp/B08VNM1CX4?tag=gophertrunk-20" rel="nofollow sponsored noopener">FCC-compliant GT-5R variant</a> —
+  as a beater, go-bag spare, loaner or classroom radio, with the caveats above
+  understood.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B007UYKG4E?tag=gophertrunk-20" rel="nofollow sponsored noopener">UV-5R on Amazon &rarr;</a>
+- **Spend $60** on the [BF-F8HP](/reference/baofeng-bf-f8hp/) for the sorted
+  version of this platform, or **$180** on a
+  [Yaesu FT-60R](/reference/yaesu-ft-60r/) for a radio that will outlive them
+  both.
+- **Full rankings**: [best handheld ham radios](/best-handheld-ham-radios/).
+
+## Sources
+
+[^baofeng]: [Baofeng UV-5R product page](https://baofengtech.com/product/uv-5r/) — BTECH/Baofeng, on frequency coverage, output power, battery, and kit contents. Emissions, QC and certification history summarized from independent lab findings (ARRL, mid-2010s onward) and the FCC's 2018 Enforcement Advisory on non-compliant import radios.

--- a/docs/reference/btech-uv-25x2.md
+++ b/docs/reference/btech-uv-25x2.md
@@ -1,0 +1,127 @@
+---
+slug: btech-uv-25x2
+title: BTECH UV-25X2
+entry_type: hardware
+category: ham-radios
+description: "The BTECH UV-25X2 is a 25 W mini dual-band mobile ham radio the size of a paperback — analog 2m/70cm FM, CHIRP-programmable, around $130. The unbeatable entry price for a real mobile, with the front-end limits of its class."
+keywords: BTECH UV-25X2, UV-25X2 review, cheap mobile ham radio, mini mobile ham radio, budget dual band mobile, 25 watt mobile radio, CHIRP mobile radio, Baofeng mobile radio, best mobile ham radio 2026
+aka: [UV-25X2]
+autolink: true
+affiliate: true
+product:
+  name: "BTECH UV-25X2"
+  brand: BTECH
+  category: Mobile ham transceiver
+  lowPrice: "120"
+  highPrice: "140"
+  url: https://www.amazon.com/dp/B06XD3CQ6H?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: Mini dual-band mobile transceiver }
+  - { label: Bands, value: "2m / 70cm (dual watch)" }
+  - { label: Modes, value: "FM only (no digital)" }
+  - { label: Power, value: "25 W max" }
+  - { label: Programming, value: "CHIRP (standard route) / BTECH cable" }
+  - { label: Price, value: around $130 }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B06XD3CQ6H?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [qyt-kt-8900d, icom-ic-2730a, kenwood-tm-v71a, anytone-at-d578uviii, rtl-sdr]
+related_lessons:
+  - { title: "What is trunked radio?", url: /learn/digital-trunking/ }
+related_reading:
+  - { title: "Best SDR for GopherTrunk", url: /best-sdr-for-gophertrunk/ }
+cite_urls:
+  - https://baofengtech.com/product/uv-25x2/
+faq:
+  - q: "Is the BTECH UV-25X2 a good first mobile ham radio?"
+    a: "Yes, if the budget stops near $130. It's a real 25 W dual-band mobile with easy CHIRP programming and good transmit audio. Just know the trade: the receiver front end overloads near strong transmitters, so in an RF-dense metro a $330 Icom IC-2730A is a meaningfully better radio."
+  - q: "How many watts does the UV-25X2 put out?"
+    a: "Up to 25 W — enough for reliable repeater work and most simplex, at well under 10 A of draw, so it can even run from a cigarette-lighter plug. It is not a 50 W flagship and doesn't pretend to be."
+  - q: "Does the UV-25X2 do DMR or APRS?"
+    a: "No. It is analog FM only — no digital voice modes, no GPS, no APRS modem. For DMR in this general price universe you'd step up to the AnyTone AT-D578UVIII Plus at around $460."
+  - q: "Does CHIRP support the UV-25X2?"
+    a: "Yes — CHIRP is the standard way to program it, via the BTECH UV-25X2 driver. Second-generation units want a current CHIRP build, so update CHIRP before fighting the cable."
+  - q: "Do I need a license to use the UV-25X2?"
+    a: "To transmit, yes — an FCC amateur license (Part 97, Technician class minimum). Listening requires none, and a $30 RTL-SDR running free GopherTrunk hears the same repeaters and records them too."
+---
+**The BTECH UV-25X2** is a **25-watt mini mobile** about the size of a
+paperback: analog 2m/70cm FM, dual watch, 200 memories, and easy CHIRP
+programming for around **$130**.[^btech] It is the unbeatable entry price for a
+real mobile radio — with the receiver limits of its class, which we'll be
+blunt about below.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B06XD3CQ6H?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The budget mobile that's actually fine.** 25 W on 2m/70cm, dual watch with
+synchronized display, good TX audio, **CHIRP is the standard programming
+route**, draws little enough to run off a cigarette plug, and works as a tiny
+base with a small power supply. **Analog FM only** — no digital, no GPS/APRS.
+Known trade-offs: **front-end overload near strong transmitters**, warm PA and
+fan at duty, cryptic Baofeng-style menus, receiver birdies. **~$130**, second
+generation in production. License to transmit (Technician+); none to listen.
+</div>
+
+## Overview
+
+BTECH (BaofengTech) positioned the UV-25X2 as the mobile answer to the handheld
+Baofeng phenomenon, and it delivers the same bargain: real transmit power, a
+DTMF mic, VFO plus 200 memories with frequency-or-name display, dual watch
+with synchronized display modes, and receive coverage of 136–174 and 400–520
+MHz. There is no detachable faceplate — the whole radio is already small enough
+to mount anywhere — no GPS or APRS, no digital modes, and no cross-band repeat.
+Running well under 10 A at full power, it is equally at home under a dash or on
+a desk with a modest power supply.
+
+The honest part: this class of radio earns its price at the receiver. Expect
+**overload and desense near strong transmitters** — a busy commercial hilltop
+or downtown RF soup will punch through its front end in a way an Icom or
+Kenwood shrugs off — plus some receiver birdies, a PA and fan that run warm at
+25 W duty, and a menu system that is Baofeng-style cryptic until CHIRP saves
+you. It is not the rig for an RF-dense metro site; it is a terrific first
+mobile, beater, or backup everywhere else.
+
+## Modes &amp; coverage
+
+- **Analog FM only** on amateur 2m/70cm — no [DMR](/reference/dmr/),
+  [D-STAR](/reference/d-star/), or [C4FM](/reference/c4fm/), and no
+  [APRS](/reference/aprs/).
+- **RX 136–174 / 400–520 MHz**, dual watch across any mix.
+- 200 memories, DTMF mic, multiple display modes.
+
+## Programming
+
+**CHIRP is the standard way to program the UV-25X2** — free, mature driver,
+and far saner than the front panel. Second-generation units need a current
+CHIRP build, so update first. BTECH also sells a factory-software cable if you
+prefer their tooling.
+
+## GopherTrunk alternative
+
+GopherTrunk **receives; it cannot transmit** — even a $130 mobile does
+something GopherTrunk never will. But the pairing is natural at this budget: a
+~$30 [RTL-SDR](/reference/rtl-sdr/) running free GopherTrunk costs a quarter of
+the UV-25X2 and lets you **hear everything first** — which repeaters are alive,
+what digital modes your area runs — and it records and logs every call, which
+no transceiver does. If you're pre-license, that's the whole game: listening
+requires no license at all, while transmitting on ham bands requires an FCC
+amateur license (Part 97, Technician class minimum). Scout with the SDR, buy
+the transmitter you actually need. Hardware picks:
+[best SDR for GopherTrunk](/best-sdr-for-gophertrunk/).
+
+## Who it's for
+
+- **Buy the UV-25X2** as a first mobile, a beater truck radio, or a compact
+  base on a budget — anywhere the RF environment is ordinary and $130 is the
+  right spend.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B06XD3CQ6H?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [Icom IC-2730A](/reference/icom-ic-2730a/)** (~$330) when you
+  outgrow the front end — it is the receiver this radio isn't.
+- **Buy the [QYT KT-8900D](/reference/qyt-kt-8900d/)** only if even $130 is too
+  much — it's cheaper and rougher still.
+- **Buy the [AnyTone AT-D578UVIII Plus](/reference/anytone-at-d578uviii/)** if
+  what you actually want is [DMR](/reference/dmr/).
+- The whole field, ranked: [best mobile ham radios](/best-mobile-ham-radios/).
+
+## Sources
+
+[^btech]: [BTECH UV-25X2 product page](https://baofengtech.com/product/uv-25x2/) — BaofengTech, on the 25 W output, dual-watch display modes, frequency coverage, and second-generation status.

--- a/docs/reference/btech-uv-pro.md
+++ b/docs/reference/btech-uv-pro.md
@@ -1,0 +1,130 @@
+---
+slug: btech-uv-pro
+title: BTECH UV-PRO
+entry_type: hardware
+category: ham-radios
+description: "The BTECH UV-PRO is an IP67 dual-band ham handheld with GPS, APRS, Bluetooth, USB-C charging and phone-app programming for around $165 — the feature-per-dollar standout of the budget HT class."
+keywords: BTECH UV-PRO, UV-PRO review, best budget ham handheld, IP67 ham radio, APRS handheld cheap, Bluetooth ham radio, USB-C ham handheld, BTECH review, Vero VR-N76, off-grid radio
+aka: [UV-PRO]
+autolink: true
+affiliate: true
+product:
+  name: "BTECH UV-PRO"
+  brand: BTECH
+  category: Ham handheld transceiver
+  lowPrice: "160"
+  highPrice: "170"
+  url: https://www.amazon.com/dp/B0DBW24N8M?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: Dual-band handheld transceiver }
+  - { label: Bands, value: "TX 144/430 MHz; RX incl. AM air band, NOAA, FM broadcast" }
+  - { label: Modes, value: "Analog FM; APRS TX/RX; radio-to-radio text" }
+  - { label: Power, value: "~5–6 W (advertised figures vary)" }
+  - { label: Programming, value: "BTECH phone app over Bluetooth (no CHIRP as of 2026)" }
+  - { label: Price, value: around $165 }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B0DBW24N8M?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [baofeng-bf-f8hp, baofeng-uv-5r, yaesu-ft-60r, yaesu-ft-5dr, rtl-sdr, aprs]
+related_lessons:
+  - { title: "Analog vs. digital voice", url: /learn/rf-sdr/digital-voice/ }
+  - { title: "Legal & ethical monitoring", url: /learn/rf-sdr/legal-ethical/ }
+related_reading:
+  - { title: "Police scanner vs GopherTrunk", url: /police-scanner-vs-sdr/ }
+cite_urls:
+  - https://baofengtech.com/product/uv-pro/
+faq:
+  - q: "Does the BTECH UV-PRO do APRS?"
+    a: "Yes — APRS transmit and receive with built-in GPS, plus a Bluetooth KISS-style TNC that popular phone APRS and off-grid messaging apps can use. That combination under $170 is the radio's headline feature."
+  - q: "How many watts is the UV-PRO?"
+    a: "Treat it as roughly 5–6 W. Some marketing copy says 'up to 10 W' for the platform, but that figure likely belongs to the UV-50PRO sibling — don't buy on the 10 W claim."
+  - q: "Can I program the UV-PRO with CHIRP?"
+    a: "Not as of our 2026 research — there's an open CHIRP new-model request, and BTECH itself routes owners to its phone app over Bluetooth for programming. Re-verify at chirpmyradio.com if CHIRP support is a dealbreaker."
+  - q: "Is the UV-PRO waterproof?"
+    a: "Yes — IP67 rated, which is remarkable at the price. It also charges over USB-C from its 2,600 mAh battery."
+  - q: "Do I need a license to use the UV-PRO?"
+    a: "Transmitting on 144/430 MHz requires an FCC amateur license (Technician class minimum). Listening — including its AM air band, NOAA and FM broadcast receive — requires none."
+---
+**The BTECH UV-PRO** packs IP67 waterproofing, built-in **GPS and
+[APRS](/reference/aprs/)**, Bluetooth, USB-C charging and an AM air band
+scanner into a dual-band 144/430 MHz handheld for around **$165** — a feature
+list that undercuts radios costing twice as much.[^btech] The catch that
+defines it: it's an **app-first** radio, configured over Bluetooth from BTECH's
+phone app rather than from the front panel or CHIRP.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0DBW24N8M?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The feature-per-dollar standout of the budget class.** IP67 + GPS + APRS +
+Bluetooth TNC + USB-C under $170; phone-app setup that newcomers genuinely find
+easy. The trades: **app dependence** for deep configuration, a SoC-class
+receiver that overloads near strong transmitters, no digital voice
+([DMR](/reference/dmr/)/[C4FM](/reference/c4fm/)/[D-STAR](/reference/d-star/)),
+mixed audio reports, and fast-moving firmware that changes behavior between
+versions. Output is realistically ~5–6 W despite some "10 W" marketing.
+Transmitting needs an FCC Technician license; listening needs none.
+</div>
+
+## Overview
+
+The UV-PRO is built on the Vero VR-N76 platform and has become the darling of
+the preparedness and APRS-messaging crowd for one reason: its Bluetooth link
+exposes a KISS-style TNC that phone apps can drive, turning the radio plus a
+phone into an off-grid position-reporting and text-messaging system. Add
+radio-to-radio text without any infrastructure, NOAA weather alerts, an AM air
+band scanner, and a 2,600 mAh USB-C battery in an IP67 body, and it's easy to
+see why it sells.
+
+The honest counterweight: this is a software-defined-on-a-chip budget radio.
+The front end overloads near strong transmitters like the rest of its class,
+speaker and transmit audio reports are mixed, and firmware evolves fast enough
+that behavior genuinely changes between versions. Traditionalists who want
+knobs, menus and CHIRP will chafe at doing everything through a phone. And
+despite the connected feel, there's no digital voice mode of any kind.
+
+## Modes &amp; features
+
+- **Analog FM** on 144/430 MHz, ~5–6 W realistic output (hedge the platform's
+  "10 W" marketing — that figure likely belongs to the UV-50PRO sibling).
+- **[APRS](/reference/aprs/) TX/RX** with built-in **GPS**, plus a
+  BLE KISS-style TNC used by phone APRS and off-grid mesh/text apps.
+- **Radio-to-radio text messaging** with no infrastructure.
+- **Receive extras**: AM air band scanning, NOAA weather alerts, FM broadcast.
+- **IP67** waterproof; 2,600 mAh Li-ion with **USB-C** charging.
+
+## Programming
+
+The primary method — per BTECH itself — is the **BTECH programming app**
+(iOS/Android) over Bluetooth, and it's genuinely one of the easiest setups in
+ham radio for a newcomer. **CHIRP does not support it** as of our research
+date (an open new-model request exists); re-check chirpmyradio.com if that
+matters to you, and expect the app to remain the deep-configuration path
+either way.
+
+## GopherTrunk alternative
+
+GopherTrunk receives only — no transmitter, so no substitute for a UV-PRO. Its
+role is upstream of the purchase: a ~$30 [RTL-SDR](/reference/rtl-sdr/) running
+free GopherTrunk shows you what's live on your local repeaters — analog FM,
+[APRS](/reference/aprs/) activity, or a digital mode this radio can't do — and
+records and logs all of it, which no HT will. If your area turns out to run
+DMR, the money is better spent on an
+[AT-D878UVII Plus](/reference/anytone-at-d878uvii-plus/). Hardware picks:
+[best SDR for GopherTrunk](/best-sdr-for-gophertrunk/).
+
+## Who it's for
+
+- **Buy the UV-PRO** if you want APRS + GPS + waterproofing on a budget, you're
+  comfortable configuring from a phone, or off-grid text/position reporting is
+  the goal.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B0DBW24N8M?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [Yaesu FT-60R](/reference/yaesu-ft-60r/)** instead for a
+  traditional, tougher, CHIRP-programmable analog HT with a far better front
+  end (~$180).
+- **Spend up** to a [Yaesu FT-5DR](/reference/yaesu-ft-5dr/) for digital voice
+  plus deeper APRS, or **down** to a
+  [Baofeng BF-F8HP](/reference/baofeng-bf-f8hp/) if you only need a beater.
+  Full rankings: [best handheld ham radios](/best-handheld-ham-radios/).
+
+## Sources
+
+[^btech]: [BTECH UV-PRO product page](https://baofengtech.com/product/uv-pro/) — BTECH, on APRS/GPS, Bluetooth programming and TNC features, IP67 rating, USB-C charging, and receive coverage.

--- a/docs/reference/icom-ic-2730a.md
+++ b/docs/reference/icom-ic-2730a.md
@@ -1,0 +1,132 @@
+---
+slug: icom-ic-2730a
+title: Icom IC-2730A
+entry_type: hardware
+category: ham-radios
+description: "The Icom IC-2730A is a 50 W analog 2m/70cm mobile ham radio with true simultaneous dual receive, wideband RX including air band, and Icom build quality — the consensus no-nonsense FM mobile, around $330 in 2026."
+keywords: Icom IC-2730A, IC-2730A review, best analog mobile ham radio, dual band mobile transceiver, dual receive mobile radio, 2m 70cm mobile radio, Icom FM mobile, CHIRP mobile radio, best mobile ham radio 2026
+aka: [IC-2730A, IC-2730]
+autolink: true
+affiliate: true
+product:
+  name: "Icom IC-2730A"
+  brand: Icom
+  category: Mobile ham transceiver
+  lowPrice: "330"
+  highPrice: "360"
+  url: https://www.amazon.com/dp/B00QOR05EY?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: Dual-band mobile transceiver }
+  - { label: Bands, value: "2m / 70cm (true dual receive)" }
+  - { label: Modes, value: "FM only (no digital)" }
+  - { label: Power, value: "50 / 15 / 5 W" }
+  - { label: Programming, value: "CHIRP / CS-2730 / RT Systems" }
+  - { label: Price, value: around $330 }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B00QOR05EY?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [icom-id-5100a, kenwood-tm-v71a, btech-uv-25x2, yaesu-ftm-300dr, rtl-sdr, police-scanner]
+related_lessons:
+  - { title: "What is trunked radio?", url: /learn/digital-trunking/ }
+related_reading:
+  - { title: "Best SDR for GopherTrunk", url: /best-sdr-for-gophertrunk/ }
+cite_urls:
+  - https://www.icomamerica.com/lineup/products/IC-2730A/
+faq:
+  - q: "Is the Icom IC-2730A still in production?"
+    a: "Yes — as of August 2026 it is current on both Icom America's and Icom Japan's lineup pages and stocked new at the major dealers, typically around $330."
+  - q: "Does the IC-2730A have digital modes or APRS?"
+    a: "No. It is analog FM only — no D-STAR, no DMR, no C4FM, and no GPS or APRS modem. You are paying for RF quality and true dual receive, not features. For digital, look at the ID-5100A (D-STAR) or AnyTone AT-D578UVIII Plus (DMR)."
+  - q: "Can the IC-2730A receive the air band?"
+    a: "Yes — its wideband receive covers 118–174 MHz including AM air band, plus 375–550 MHz. Transmit is amateur 2m/70cm only."
+  - q: "Does CHIRP support the IC-2730A?"
+    a: "Yes, CHIRP has an IC-2730 driver, and Icom's CS-2730 software and RT Systems are also available. Programming this radio is easy by any route."
+  - q: "Do I need a license for the IC-2730A?"
+    a: "To transmit, yes — an FCC amateur license, Technician class or above (Part 97). Listening needs no license, on this radio or on a $30 RTL-SDR running free GopherTrunk."
+---
+**The Icom IC-2730A** is the consensus pick for a no-nonsense analog dual-band
+mobile: **50 watts on 2m and 70cm**, **true simultaneous dual receive**
+(including V/V and U/U), wideband receive down to the AM air band, and Icom
+build quality — with no digital modes, no GPS, and no gimmicks.[^icom] Still in
+production in 2026 at around $330, it is the radio you buy when you want the RF
+done right and nothing else.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B00QOR05EY?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The best pure-FM mobile.** Clean, sensitive receiver; loud audio; **true dual
+receive** in any band combination; wideband RX 118–174 / 375–550 MHz including
+air band AM; dead-simple operation; **CHIRP-supported**. **No digital voice, no
+[APRS](/reference/aprs/), no GPS** — that's the deal. Remote-head-only design
+(separation cable included, but mounting brackets cost extra). **~$330**, in
+production. Transmitting needs an FCC ham license (Technician+); listening
+doesn't.
+</div>
+
+## Overview
+
+The IC-2730A is a remote-head-only design: the controller separates from the RF
+deck, and the separation cable comes in the box. The catch every buyer should
+know up front is that the **mounting hardware for the head costs extra** — the
+MBF-1 and MBA-2 brackets are add-ons — and some controls split between the head
+and the DTMF microphone, which takes a little adjustment.
+
+What you get for the money is Icom's RF: a clean, sensitive receiver that holds
+up where budget imports desense, loud audio, and a large backlit LCD (not color,
+not touch) that is legible at a glance. **True simultaneous dual receive**
+covers V/V and U/U as well as V/U — genuinely two receivers, not dual watch.
+It holds 1,000 memories, transmits 50/15/5 W on both bands at ~13 A full-power
+draw, and offers an optional VS-3 Bluetooth headset via the optional UT-133A
+module. No GPS, no APRS modem, no cross-band repeat, no digital voice.
+
+That last line is the whole trade: rigs like the
+[AnyTone AT-D578UVIII Plus](/reference/anytone-at-d578uviii/) pile on features
+for similar money, but none of the budget feature-radios match this receiver.
+You pay Icom for RF quality, not a spec sheet.
+
+## Modes &amp; coverage
+
+- **Analog FM only** on amateur 2m and 70cm — no
+  [D-STAR](/reference/d-star/), [DMR](/reference/dmr/), or
+  [C4FM](/reference/c4fm/).
+- **Wideband receive:** 118–174 MHz (including **AM air band**) and 375–550
+  MHz — handy for monitoring public safety and aviation between QSOs, within
+  the limits of an FM mobile's scanning. For serious monitoring, a
+  [police scanner](/reference/police-scanner/) or an SDR does it better.
+- **True dual receive** with independent volume/squelch per band.
+
+## Programming
+
+Every route works, and all are painless:
+
+1. **CHIRP** (free) — the IC-2730 driver is mature; this is the easy path.
+2. **Icom CS-2730** — Icom's own software.
+3. **RT Systems** — the paid, polished option.
+
+## GopherTrunk alternative
+
+GopherTrunk **receives only — it cannot transmit** — so it is no substitute for
+the IC-2730A's half of a QSO. It is the smart first step, though: before
+spending $330, a ~$30 [RTL-SDR](/reference/rtl-sdr/) running free GopherTrunk
+lets you hear every local repeater and see how active your area's 2m/70cm
+scene really is — and unlike any mobile, it **records, logs, and timestamps**
+what it hears, covering the digital modes this radio skips. Listening requires
+no license; transmitting on the ham bands requires an FCC amateur license
+(Part 97, Technician class minimum). Dongle recommendations are in
+[best SDR for GopherTrunk](/best-sdr-for-gophertrunk/).
+
+## Who it's for
+
+- **Buy the IC-2730A** if you want the best-behaved analog FM mobile — a
+  commuter/repeater rig with a receiver that holds up in RF-dense areas — and
+  you don't need digital voice or APRS.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B00QOR05EY?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [ID-5100A](/reference/icom-id-5100a/)** for the same Icom RF plus
+  [D-STAR](/reference/d-star/) and a touchscreen, ~$130 more.
+- **Buy a used [Kenwood TM-V71A](/reference/kenwood-tm-v71a/)** for similar
+  analog quality plus cross-band repeat at a lower used price, or a
+  [BTECH UV-25X2](/reference/btech-uv-25x2/) if $330 is out of reach.
+- Full field: [the 10 best mobile ham radios](/best-mobile-ham-radios/).
+
+## Sources
+
+[^icom]: [Icom IC-2730A product page](https://www.icomamerica.com/lineup/products/IC-2730A/) — Icom America, on the 50/15/5 W output, simultaneous dual receive, 118–174 / 375–550 MHz wideband receive, remote-head design, and options.

--- a/docs/reference/icom-ic-706mkiig.md
+++ b/docs/reference/icom-ic-706mkiig.md
@@ -1,0 +1,135 @@
+---
+slug: icom-ic-706mkiig
+title: Icom IC-706MkIIG
+entry_type: hardware
+category: ham-radios
+description: "The Icom IC-706MkIIG is the original do-everything mobile ham radio — HF through 70cm, all modes, 100 W — long discontinued and now a used-market classic around $400–650 on eBay. What to check before buying one."
+keywords: Icom IC-706MkIIG, IC-706MkIIG review, IC-706 used, HF mobile radio, all mode mobile transceiver, shack in a box, used ham radio buying guide, IC-706MkIIG problems, classic ham radio, best used mobile ham radio
+aka: [IC-706MkIIG, IC-706Mk2G, IC-706]
+autolink: true
+affiliate: true
+product:
+  name: "Icom IC-706MkIIG"
+  brand: Icom
+  category: Mobile ham transceiver (used)
+  lowPrice: "400"
+  highPrice: "650"
+  seller: eBay
+  itemCondition: used
+  url: "https://www.ebay.com/sch/i.html?_nkw=Icom+IC-706MkIIG"
+infobox:
+  - { label: Type, value: All-mode HF/VHF/UHF mobile (discontinued) }
+  - { label: Bands, value: "HF + 6m + 2m + 70cm" }
+  - { label: Modes, value: "SSB, CW, AM, FM, RTTY" }
+  - { label: Power, value: "100 W HF/6m, 50 W 2m, 20 W 70cm" }
+  - { label: Programming, value: "Front panel only (no CHIRP, no RT Systems)" }
+  - { label: Price, value: "around $400–650 used" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.ebay.com/sch/i.html?_nkw=Icom+IC-706MkIIG\" rel=\"nofollow noopener\">Find on eBay &rarr;</a>" }
+see_also: [yaesu-ft-857d, kenwood-tm-v71a, icom-ic-2730a, yaesu-ftm-500dr, rtl-sdr, single-sideband]
+related_lessons:
+  - { title: "What is trunked radio?", url: /learn/digital-trunking/ }
+related_reading:
+  - { title: "Best SDR for GopherTrunk", url: /best-sdr-for-gophertrunk/ }
+cite_urls:
+  - https://www.universal-radio.com/catalog/hamhf/3450.html
+faq:
+  - q: "Is the Icom IC-706MkIIG still worth buying?"
+    a: "As a used classic, yes — around $400–650 buys HF-through-70cm all-mode capability with a huge installed base and good serviceability. Check the display backlight, band switching, and pots before paying, and know that memories can only be programmed from the front panel."
+  - q: "When was the IC-706MkIIG discontinued?"
+    a: "Icom confirmed the production stop, with forum records dating it to roughly 2009–2010 (no formal year was published). It was functionally succeeded by the IC-7000 and then the IC-7100. No new stock remains — this is strictly a used purchase."
+  - q: "Can I program the IC-706MkIIG from a computer?"
+    a: "No. The IC-706 series predates Icom's CI-V extended memory commands, so neither CHIRP nor RT Systems can write its memories — programming is front-panel only. CAT control of frequency and mode over the serial port works fine for logging and digital modes."
+  - q: "What are the known problems with a used IC-706MkIIG?"
+    a: "The used-buyer guides consistently flag a dim or failing display backlight (and display driver issues), band-switching relay wear, PA thermal stress on units run hard mobile, crackly volume and squelch pots, and the DDS birdies inherent to the design. Optional FL-series filters and the UT-106 DSP add real value if included."
+  - q: "Do I need a license to use an IC-706MkIIG?"
+    a: "To transmit, yes — an FCC amateur license (Part 97; Technician grants limited HF privileges, General opens most of it). Listening requires no license at all."
+---
+**The Icom IC-706MkIIG** is the original "do-everything" mobile:
+**HF + 6m + 2m + 70cm, all modes** — [SSB](/reference/single-sideband/), CW,
+AM, FM, RTTY — with 100 watts on HF/6m in a box small enough for a dashboard,
+built from 1998 onward.[^universal] It has been **discontinued since roughly
+2009–2010**, no new-old-stock channel remains, and it is not carried on Amazon
+— today it lives on the **used market**: eBay, hamfests, and the QRZ swapmeet,
+typically at **$400–650** depending on condition and included filters.
+
+<a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=Icom+IC-706MkIIG" rel="nofollow noopener">Find on eBay &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The classic all-band mobile, used-only.** 100 W HF/6m, 50 W 2m, 20 W 70cm,
+all modes, detachable faceplate, 107 memories, enormous installed base.
+**~$400–650 used** (estimated from listing spread — check sold prices).
+Known aging points: **display backlight/driver, band-switch relay wear, PA
+thermal stress, scratchy pots.** **No PC memory programming at all** — front
+panel only. No digital voice, no GPS/[APRS](/reference/aprs/). Transmitting
+needs an FCC ham license; listening needs none.
+</div>
+
+## Overview
+
+Before "shack in a box" was a category, the IC-706 created it, and the MkIIG
+was its definitive form: rugged, simple-for-its-class front panel, a
+detachable faceplate with the separation cable standard, and coverage from 160
+meters to 70cm in every mode. TX draw is about 20 A at 100 W, so a mobile
+install needs proper wiring. Optional FL-series CW/SSB filters and the UT-106
+DSP were the era's upgrades and add real value to a used unit that includes
+them. There is no digital voice, no GPS/APRS, and no cross-band repeat — this
+is a 1998 design, and its strength is RF versatility, not features.
+
+**Used-market viability, honestly:** the installed base is enormous and the
+radio is still very serviceable, which is why it endures. The failure points
+every used-buyer guide cites: a **dim or failing display backlight** and
+display driver issues, **band-switching relay wear** (listen for flaky band
+changes), **PA thermal stress** in high-duty mobile use, **crackly volume and
+squelch pots**, and the DDS birdies inherent to the design. Prices are
+estimated from current listing spread — check eBay *sold* listings before
+agreeing on a number.
+
+## The one buying consideration people miss
+
+**The IC-706MkIIG cannot be PC-programmed.** The series predates Icom's CI-V
+extended memory commands, so its 107 memories cannot be written over the serial
+port — not by CHIRP, and not by RT Systems either. Every memory goes in
+through the front panel. CAT control of frequency and mode works fine for
+logging software and digital-mode operation, but if you are used to loading a
+codeplug in five minutes, this radio will make you earn it. For many buyers
+that is the deciding line between this and a
+[Yaesu FT-857D](/reference/yaesu-ft-857d/), which CHIRP supports.
+
+## Modes &amp; coverage
+
+- **HF (160–10 m) + 6m + 2m + 70cm**, all-mode:
+  [SSB](/reference/single-sideband/), CW, AM,
+  [FM](/reference/frequency-modulation/), RTTY.
+- **100 W HF/6m, 50 W 2m, 20 W 70cm.**
+- 107 memories, detachable faceplate, optional DSP and crystal filters.
+
+## GopherTrunk alternative
+
+GopherTrunk **receives; it cannot transmit** — no SDR replaces a 100-watt
+all-mode transceiver. But before hunting a used classic, a ~$30
+[RTL-SDR](/reference/rtl-sdr/) running free GopherTrunk is the zero-risk way
+to survey your local VHF/UHF activity — repeaters, digital modes, what's
+actually worth chasing — and it records and logs everything it hears, which no
+transceiver of any vintage does. Listening requires no license; transmitting
+on ham bands requires an FCC amateur license (Part 97, Technician class
+minimum — General for most HF). Hardware picks:
+[best SDR for GopherTrunk](/best-sdr-for-gophertrunk/).
+
+## Who it's for
+
+- **Buy a used IC-706MkIIG** if you want proven HF-to-70cm all-mode capability
+  at the lowest classic-rig price, you'll test the display and band switching
+  before paying, and front-panel programming doesn't scare you.
+  <a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=Icom+IC-706MkIIG" rel="nofollow noopener">Find on eBay &rarr;</a>
+- **Buy a used [Yaesu FT-857D](/reference/yaesu-ft-857d/)** instead for the
+  same do-everything mission with CHIRP support and built-in DSP — at a
+  $100–150 premium.
+- **Buy new** — an [FTM-500DR](/reference/yaesu-ftm-500dr/) or
+  [IC-2730A](/reference/icom-ic-2730a/) — if VHF/UHF FM is all you actually
+  operate; the mobile-HF mission is what justifies a 706.
+- The full field: [the 10 best mobile ham radios](/best-mobile-ham-radios/).
+
+## Sources
+
+[^universal]: [Icom IC-706MkIIG archive page](https://www.universal-radio.com/catalog/hamhf/3450.html) — Universal Radio, on the all-mode HF/6m/2m/70cm coverage, power output by band, memories, and options (FL-series filters, UT-106 DSP).

--- a/docs/reference/icom-ic-718.md
+++ b/docs/reference/icom-ic-718.md
@@ -110,6 +110,12 @@ filters, no 6 m, no FM, no tuner, no USB, and a receiver that a strong
 neighboring signal can walk over. Every gripe was forgivable at $600. At $930
 NOS they aren't — which is the honest core of this review.
 
+If you do shop used, the options matter more than cosmetics: a unit with the
+**UT-106 DSP board** (fitted to many later radios) and an optional **CW
+filter** is meaningfully better on the air than a bare one, and those boards
+are harder to source separately than the radios are. Ask specifically; sellers
+often don't know what's inside.
+
 ## Programming &amp; software
 
 CI-V CAT works with the standard ecosystem (WSJT-X, fldigi, loggers) through a

--- a/docs/reference/icom-ic-718.md
+++ b/docs/reference/icom-ic-718.md
@@ -1,0 +1,149 @@
+---
+slug: icom-ic-718
+title: Icom IC-718
+entry_type: hardware
+category: ham-radios
+description: "The Icom IC-718 is the archetypal budget HF transceiver — 100W, 160–10m, simple and nearly unbreakable — now discontinued after a 25-year run, with new-old-stock around $930 and used units at $400–550."
+keywords: Icom IC-718, IC-718 review, IC-718 discontinued, budget HF transceiver, cheap HF radio, first HF radio, beginner ham radio HF, IC-718 vs IC-7300, 100 watt HF transceiver, used IC-718 price
+aka: [IC-718, "718"]
+autolink: true
+affiliate: true
+product:
+  name: "Icom IC-718"
+  brand: Icom
+  category: Ham radio base station (HF transceiver)
+  lowPrice: "900"
+  highPrice: "930"
+  url: https://www.amazon.com/dp/B007G03B5I?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: "HF base transceiver (superhet)" }
+  - { label: Bands, value: "160–10 m TX; 0.030–30 MHz RX (no 6 m)" }
+  - { label: Modes, value: "SSB, CW, RTTY, AM (no FM)" }
+  - { label: Power, value: "100 W (40 W AM), adjustable to 2 W" }
+  - { label: Programming, value: "CI-V CAT (no USB — needs an interface)" }
+  - { label: Price, value: "around $930 new-old-stock; $400–550 used" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B007G03B5I?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [icom-ic-7300, xiegu-g90, yaesu-ft-891, kenwood-ts-940s, rtl-sdr, antenna-tuner]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "Best ham radio base stations", url: /best-ham-radio-base-stations/ }
+cite_urls:
+  - https://www.icomamerica.com/lineup/products/IC-718/
+faq:
+  - q: "Is the Icom IC-718 discontinued?"
+    a: "Yes — Icom Japan lists it as a discontinued product after a roughly 25-year run that started in 1999. US dealers were still shipping remaining new stock into mid-2026, so what you're buying now is new-old-stock or used."
+  - q: "Is the IC-718 still worth buying in 2026?"
+    a: "At the ~$930 new-old-stock price, honestly, no — a used IC-7300 costs about the same and is better in every measurable way. At $400–550 used, the IC-718 remains a fine simple first HF radio that's easy to use and hard to break."
+  - q: "Does the IC-718 have a built-in antenna tuner?"
+    a: "No. It expects a matched antenna or an external tuner (Icom's AT-180 or an LDG autotuner are the usual pairings). It also has no 6 meters, no FM, and no spectrum display — it's deliberately minimal."
+  - q: "Can the IC-718 do FT8 and digital modes?"
+    a: "Yes, but not out of the box — it predates USB, so you need a CI-V CAT cable plus a soundcard interface. Once cabled it runs FT8/RTTY fine at 100 W (dial the power back for long transmissions)."
+  - q: "Do I need a license to use the IC-718?"
+    a: "Transmitting requires an FCC amateur license (Part 97 — Technician minimum, though HF voice privileges mostly come with General). Listening on its 0.030–30 MHz general-coverage receiver requires no license at all."
+---
+**The Icom IC-718** spent 25 years as the archetypal budget first HF rig: 100 W
+on 160–10 m, a knob, a keypad, an amber display, and almost nothing to
+misunderstand or break.[^icom] Icom Japan now lists it **discontinued**, and
+that changes the buying math: at the ~$930 new-old-stock price it competes
+head-on with a *used* [IC-7300](/reference/icom-ic-7300/) — and loses. At
+$400–550 used, it's still one of the most honest radios ever sold.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B007G03B5I?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Simple, tough, and beloved — but buy it used, not NOS.** 100 W SSB/CW/RTTY/AM
+on 160–10 m; **no 6 m, no FM, no tuner, no USB, no scope**. The 1999-era receiver
+is merely adequate without optional filters. **Discontinued** (Icom Japan);
+remaining new stock runs **~$930**, where a used
+[IC-7300](/reference/icom-ic-7300/) is the smarter spend — the IC-718's sweet
+spot is **$400–550 used**. **Part 97 license to transmit; none to listen.**
+Rankings: [best ham radio base stations](/best-ham-radio-base-stations/).
+</div>
+
+## Overview
+
+Launched in 1999, the IC-718 was designed to be the cheapest *serious* HF
+transceiver on the market, and it held that role for a generation: the radio
+elmers handed to new Generals, the club-station workhorse, the field-day
+loaner that always came back working. The recipe is a single-conversion
+[superheterodyne](/reference/superheterodyne-receiver/) (64.455 MHz first IF),
+a big front-firing speaker, and a control set you can learn in an afternoon.
+Many later units carry the optional UT-106 DSP board, and optional CW filters
+help a lot — without them, selectivity and dynamic range are distinctly
+last-century.
+
+The 2026 situation is what moves it down our list. With production ended, US
+dealer new-old-stock sits around $929 — a price the radio grew into during the
+post-2022 price rises, not one it was designed for (it was a $600–700 radio for
+most of its life). Spend that money on a used IC-7300 and you get direct
+sampling, a waterfall, a tuner, 6 m, and USB. Spend $450 on a *used* IC-718 and
+you get exactly what it always was: a simple, repairable, hard-to-kill first
+radio with a huge supply of used units and parts knowledge.
+
+**License note:** you need an FCC amateur license to transmit (Part 97;
+Technician at minimum, with General unlocking most HF phone). Listening needs
+none — the general-coverage receiver hears everything from
+[shortwave broadcast](/reference/shortwave-broadcast/) up.
+
+## Bands, modes &amp; power
+
+- **TX:** 160–10 m, **100 W** (40 W AM), adjustable down to 2 W.
+  **No 6 meters.**
+- **RX:** 0.030–30 MHz general coverage.
+- **Modes:** [SSB](/reference/single-sideband/), [CW](/reference/morse-code/),
+  RTTY, AM. **No FM.**
+- **Tuner:** none built in — pair it with an
+  [external tuner](/reference/antenna-tuner/) (AT-180, LDG) or a matched
+  antenna.
+- **I/O:** CI-V CAT jack; no USB, no soundcard — digital modes need a cheap
+  CI-V cable plus an audio interface. 13.8 V DC at ~20 A; the fan cycles
+  audibly.
+
+## What owners praise and gripe about
+
+The praise is character: easy to use, easy to repair, a front-mounted speaker
+that sounds better than radios costing triple, and a "works forever" service
+record. The gripes are architecture: mediocre selectivity without the optional
+filters, no 6 m, no FM, no tuner, no USB, and a receiver that a strong
+neighboring signal can walk over. Every gripe was forgivable at $600. At $930
+NOS they aren't — which is the honest core of this review.
+
+## Programming &amp; software
+
+CI-V CAT works with the standard ecosystem (WSJT-X, fldigi, loggers) through a
+CT-17 or an inexpensive USB CI-V cable. There's no memory-programming story
+worth having — CHIRP isn't meaningful for an HF radio like this — and no
+firmware updates to chase. That's part of the appeal: nothing to maintain.
+
+## GopherTrunk alternative
+
+GopherTrunk receives; it cannot transmit — so it's not an IC-718 substitute,
+it's the step before one. A ~$30 [RTL-SDR](/reference/rtl-sdr/) running free
+GopherTrunk lets you hear your local ham activity — repeaters, digital voice,
+band openings — and **records and logs all of it**, before you commit to a
+transceiver or a license. If a $930 budget is the constraint, a used rig plus
+an SDR for monitoring beats NOS 1999 architecture. Dongle picks:
+[best SDR for GopherTrunk](/best-sdr-for-gophertrunk/); HF-focused receivers:
+[best HF SDR](/best-hf-sdr/).
+
+## Who it's for
+
+- **Buy the IC-718 used ($400–550)** as a rugged, dead-simple first HF radio or
+  backup rig — with the optional CW filter if you can find one.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B007G03B5I?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Skip the new-old-stock price** — at ~$930, a used
+  [IC-7300](/reference/icom-ic-7300/) is better in every way, and a new
+  [Xiegu G90](/reference/xiegu-g90/) (~$450) adds a tuner and waterfall if 20 W
+  is enough.
+- **Want 100 W new for less?** The [FT-891](/reference/yaesu-ft-891/) (~$650).
+  Full rankings: [best ham radio base stations](/best-ham-radio-base-stations/).
+
+> **Amazon note.** With production ended, the IC-718's Amazon listing may be
+> third-party and intermittent — check price and availability against the big
+> ham dealers before assuming the button is the best deal.
+
+## Sources
+
+[^icom]: [Icom IC-718 product page](https://www.icomamerica.com/lineup/products/IC-718/) — Icom America, on band coverage, modes, power, and the CI-V interface; Icom Japan's site lists the IC-718 among discontinued products.

--- a/docs/reference/icom-ic-7300.md
+++ b/docs/reference/icom-ic-7300.md
@@ -1,0 +1,158 @@
+---
+slug: icom-ic-7300
+title: Icom IC-7300
+entry_type: hardware
+category: ham-radios
+description: "The Icom IC-7300 is the 100W direct-sampling HF/6m SDR transceiver that redefined the entry-level ham base station — touchscreen waterfall, built-in tuner, one-cable digital modes — now in run-out as the IC-7300MK2 arrives."
+keywords: Icom IC-7300, IC-7300 review, IC-7300 vs IC-7300MK2, best HF transceiver, direct sampling transceiver, HF SDR transceiver, Icom IC-7300 discontinued, IC-7300 FT8, ham radio base station, 100 watt HF radio, IC-7300 price 2026
+aka: [IC-7300, "7300"]
+autolink: true
+affiliate: true
+product:
+  name: "Icom IC-7300"
+  brand: Icom
+  category: Ham radio base station (HF/6m transceiver)
+  lowPrice: "940"
+  highPrice: "1040"
+  url: https://www.amazon.com/dp/B01M10HJXW?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: "HF/6m base transceiver (direct-sampling SDR)" }
+  - { label: Bands, value: "160–6 m TX; 0.030–74.8 MHz RX" }
+  - { label: Modes, value: "SSB, CW, RTTY, AM, FM" }
+  - { label: Power, value: "100 W (25 W AM)" }
+  - { label: Programming, value: "USB CAT + audio codec, SD card, CI-V" }
+  - { label: Price, value: "around $1,040 (~$940 after rebate)" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B01M10HJXW?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [yaesu-ftdx10, icom-ic-7610, yaesu-ft-991a, xiegu-g90, rtl-sdr, direct-sampling]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "Best ham radio base stations", url: /best-ham-radio-base-stations/ }
+cite_urls:
+  - https://www.icomamerica.com/lineup/products/IC-7300/
+faq:
+  - q: "Is the Icom IC-7300 still worth buying in 2026?"
+    a: "Yes — while new stock lasts. Icom has announced the IC-7300MK2 (HDMI, USB-C, native LAN remote) and the original is out of production, but US dealers still sell new units around $1,040 with an active rebate. Nothing near the price matches its receiver, waterfall, and ten years of community knowledge."
+  - q: "Is the IC-7300 discontinued?"
+    a: "Effectively, yes. UK dealers already list it as no longer in production and the IC-7300MK2 is its announced successor, but as of August 2026 major US dealers still have new run-out stock with an Icom rebate. Treat it as a last-call buy at a good price, not a dead product."
+  - q: "Does the IC-7300 do FT8 and digital modes?"
+    a: "Very well. A single USB cable carries both CAT control and the built-in audio codec, so WSJT-X, fldigi, and friends work with no external interface — one reason it became the default first HF rig. There's also an SD slot for recording and screen captures."
+  - q: "Does the IC-7300 cover VHF and UHF?"
+    a: "No. It transmits 160 through 6 meters and receives 0.030–74.8 MHz general coverage. For 2 m/70 cm repeaters in the same box, look at the Yaesu FT-991A; for local monitoring only, a ~$30 RTL-SDR running free GopherTrunk covers VHF/UHF."
+  - q: "Do I need a license to use the IC-7300?"
+    a: "To transmit, yes — an FCC amateur license (Part 97, Technician class minimum, with General unlocking most HF). Listening requires no license at all, on this radio or on a cheap SDR running GopherTrunk."
+---
+**The Icom IC-7300** is the radio that mainstreamed the
+[direct-sampling](/reference/direct-sampling/) SDR receiver, and a decade on it is
+still the default answer to "what's my first real HF base station?" — 100 W on
+160–6 m, a 4.3-inch touchscreen with a real-time spectrum scope and
+[waterfall](/reference/waterfall-display/), a built-in
+[antenna tuner](/reference/antenna-tuner/), and one-cable USB digital modes for
+around $1,040.[^icom] Icom has announced its successor, the **IC-7300MK2**, so the
+original is now a run-out buy — still widely available new from US dealers, often
+with a rebate.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B01M10HJXW?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Our best-overall base station** in
+[best ham radio base stations](/best-ham-radio-base-stations/). **Direct-sampling
+SDR receiver** with the touchscreen scope that changed the market, **built-in
+tuner**, **one-cable FT8**. **160–6 m, 100 W** — no VHF/UHF (that's the
+[FT-991A](/reference/yaesu-ft-991a/)'s job). **End of production:** the IC-7300MK2
+is coming, but new run-out stock is real and rebated at **~$940–1,040**.
+**Transmitting needs an FCC license; listening doesn't** — try a
+[$30 RTL-SDR + GopherTrunk](/best-sdr-for-gophertrunk/) first.
+</div>
+
+## Overview
+
+When the IC-7300 shipped, a real-time spectrum scope was flagship money. Icom put
+an RF [direct-sampling](/reference/direct-sampling/) receiver — the ADC digitizes
+the band directly, no conventional mixer chain — behind 15 discrete band-pass
+filters and a color touchscreen, and sold it at an entry-level price. The result
+has been *the* recommended first HF rig for ten years, with an enormous install
+base: presets, mods, YouTube walkthroughs, and working WSJT-X configs for
+everything you'd ever plug into it.
+
+The 2026 wrinkle is the **IC-7300MK2** transition. Icom has announced the
+successor (it adds HDMI out, USB-C, and native LAN remote), and UK dealers already
+list the original as no longer in production — yet US dealers still carry new
+stock with an active Icom rebate. That makes this an honest last-call buy, not a
+trap: if the MK2's connectivity matters to you, wait; if you want the proven radio
+at its best-ever effective price, the run-out IC-7300 is still the value king.
+Used units commonly run $700–900.
+
+One licensing note before the specs: **transmitting on the ham bands requires an
+FCC amateur license** (Part 97 — Technician class at minimum, General for most HF
+privileges). **Listening requires none**, on this radio or anything else.
+
+## Bands, modes &amp; power
+
+- **TX:** 160 through 6 meters, **100 W** SSB/CW/RTTY/FM (25 W AM). UK/EU
+  versions add 4 m.
+- **RX:** 0.030–74.8 MHz general coverage — [shortwave
+  broadcast](/reference/shortwave-broadcast/), utilities, and the ham bands.
+- **Modes:** [SSB](/reference/single-sideband/), [CW](/reference/morse-code/),
+  RTTY, AM, FM. No digital voice — this is a classic HF operating radio, not a
+  DMR/Fusion box.
+- **Tuner:** built-in automatic antenna tuner. Single SO-239 antenna jack — no
+  dedicated RX antenna port, one of the few spec-sheet gaps.
+- **Power draw:** 13.8 V DC at ~21 A on transmit; budget a 25 A supply.
+
+## Receiver &amp; interface
+
+The receiver is the story. The direct-sampling front end plus the touchscreen
+scope/waterfall means you *see* the band and pounce, instead of tuning blind. In
+genuinely brutal contest-superstation environments the front end can overload
+where the [IC-7610](/reference/icom-ic-7610/) and flagships hold up — the built-in
+digi-sel and attenuator mitigate it — and the fan is audible on long digital
+transmissions, but neither is a real-world complaint for most stations. The
+reliability record over a decade is very good.
+
+Digital modes are where it spoiled everyone: **one USB cable** carries CAT control
+and a built-in audio codec, so [FT8](/reference/ft8/) via WSJT-X, fldigi, and
+logger integration need no external interface. An SD card slot records QSOs and
+screen captures.
+
+## Programming &amp; software
+
+CI-V CAT control works with effectively everything — WSJT-X, fldigi, N1MM,
+Win4Icom, RT Systems. CHIRP-next currently lists IC-7300 memory support, though
+that's of limited value on an HF rig (most owners use the SD card or RT Systems)
+and worth verifying against the current CHIRP model list if it matters to you.
+Firmware updates load from the SD card.
+
+A note on the Amazon listing: like most current ham gear on Amazon, the IC-7300
+is carried as reseller **bundles** (the confirmed listing pairs the radio with a
+pocket reference card; others add a microphone). The radio is the same unit
+dealers sell — just read what's in the box.
+
+## GopherTrunk alternative
+
+GopherTrunk **receives; it cannot transmit** — so it is not a substitute for the
+IC-7300. It is the smart *precursor*. A ~$30 [RTL-SDR](/reference/rtl-sdr/)
+running free GopherTrunk lets you monitor local repeaters and digital ham traffic
+before you spend a dollar on a transceiver or a license: you learn what's actually
+active in your area, and it **records and logs** activity in a way no transceiver
+does. Listen first, then buy the rig that matches what you heard. See
+[best SDR for GopherTrunk](/best-sdr-for-gophertrunk/) for the hardware
+short-list, and [best HF SDR](/best-hf-sdr/) if HF listening is the goal.
+
+## Who it's for
+
+- **Buy the IC-7300** if you want the best all-around HF/6m base station under
+  $1,500 — first rig or forever rig — and buy it while run-out stock and the
+  rebate last.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B01M10HJXW?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Wait for the IC-7300MK2** if HDMI/USB-C/LAN remote are must-haves, or step up
+  to the [IC-7610](/reference/icom-ic-7610/) for dual receivers. Want VHF/UHF and
+  [C4FM](/reference/c4fm/) in the same box? [FT-991A](/reference/yaesu-ft-991a/).
+- **Spend less** with the [Xiegu G90](/reference/xiegu-g90/) (~$450, 20 W) or the
+  [FT-891](/reference/yaesu-ft-891/) (~$650, 100 W, no tuner). Full rankings:
+  [best ham radio base stations](/best-ham-radio-base-stations/).
+
+## Sources
+
+[^icom]: [Icom IC-7300 product page](https://www.icomamerica.com/lineup/products/IC-7300/) — Icom America, on the RF direct-sampling receiver, 15 band-pass filters, real-time touchscreen scope/waterfall, built-in ATU, band coverage, and power specs.

--- a/docs/reference/icom-ic-7610.md
+++ b/docs/reference/icom-ic-7610.md
@@ -1,0 +1,146 @@
+---
+slug: icom-ic-7610
+title: Icom IC-7610
+entry_type: hardware
+category: ham-radios
+description: "The Icom IC-7610 is a 100W HF/6m base transceiver with dual independent direct-sampling SDR receivers, a 7-inch touchscreen, and built-in LAN remote — the serious contester's step up from the IC-7300, around $3,500."
+keywords: Icom IC-7610, IC-7610 review, IC-7610 vs IC-7300, dual receiver HF transceiver, direct sampling SDR transceiver, SO2V radio, contest HF radio, best HF base station, Icom HF transceiver 2026, IC-7610 price
+aka: [IC-7610, "7610"]
+autolink: true
+affiliate: true
+product:
+  name: "Icom IC-7610"
+  brand: Icom
+  category: Ham radio base station (HF/6m transceiver)
+  lowPrice: "3500"
+  highPrice: "3900"
+  url: https://www.amazon.com/dp/B078KKL7R6?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: "HF/6m base transceiver (dual direct-sampling SDR)" }
+  - { label: Bands, value: "160–6 m" }
+  - { label: Modes, value: "SSB, CW, RTTY, PSK31, AM, FM" }
+  - { label: Power, value: "100 W" }
+  - { label: Programming, value: "USB ×2, LAN remote (RS-BA1), SD card, CI-V" }
+  - { label: Price, value: "around $3,500" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B078KKL7R6?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [icom-ic-7300, yaesu-ftdx10, kenwood-ts-590sg, yaesu-ft-991a, rtl-sdr, direct-sampling]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "Best ham radio base stations", url: /best-ham-radio-base-stations/ }
+cite_urls:
+  - https://www.icomamerica.com/lineup/products/IC-7610/
+faq:
+  - q: "What does the IC-7610 add over the IC-7300?"
+    a: "A second, fully independent direct-sampling receiver (true dual watch for split pileups and SO2V contesting), DIGI-SEL preselectors on both receivers, a 7-inch screen with dual-band scope, two antenna jacks plus RX in/out, dual USB, an external display output, and a built-in LAN remote server. It's the same recipe, scaled up for serious operating."
+  - q: "Is the IC-7610 worth $3,500?"
+    a: "If you work split pileups, contest SO2V, or need RX antenna switching and remote operation, yes — it's widely regarded as the best value in its bracket for serious HF work. If you mostly ragchew and chase casual DX, an IC-7300 at less than a third of the price does 90% of it."
+  - q: "Does the IC-7610 cover VHF/UHF?"
+    a: "No — it's HF plus 6 meters only, at 100 W. For 2 m/70 cm in one box look at the Yaesu FT-991A, or monitor VHF/UHF for free with an RTL-SDR running GopherTrunk."
+  - q: "Is the IC-7610 still in production?"
+    a: "Yes. Introduced in 2017, it remains a current Icom America lineup product in 2026, with street price around $3,500 and Icom rebates moving it around."
+  - q: "Do I need a license to operate the IC-7610?"
+    a: "Transmitting requires an FCC amateur license (Part 97 — Technician at minimum, General for most HF privileges). Listening requires none, and its general-coverage receive works out of the box."
+---
+**The Icom IC-7610** is the step-up radio for people who outgrew watching one
+frequency at a time: **two fully independent
+[direct-sampling](/reference/direct-sampling/) SDR receivers**, each behind its
+own DIGI-SEL preselector, driving a 7-inch touchscreen with a dual-band scope and
+[waterfall](/reference/waterfall-display/).[^icom] It transmits 100 W on 160–6 m,
+tunes itself, and carries the station-integration extras the
+[IC-7300](/reference/icom-ic-7300/) lacks — two antenna jacks plus RX in/out,
+dual USB, DVI display out, and a built-in LAN remote server — for around $3,500.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B078KKL7R6?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The serious-operator upgrade.** True **dual watch** from two independent
+direct-sampling receivers (~100 dB RMDR class) makes split pileups and SO2V
+contesting native, not a workaround. **7-inch dual-band scope, RX antenna in/out,
+LAN remote built in.** The costs: **~$3,500**, an audible fan in a quiet shack,
+and no VHF/UHF. Still in production. **Transmitting takes a Part 97 license;
+listening takes none.** Where it ranks:
+[best ham radio base stations](/best-ham-radio-base-stations/).
+</div>
+
+## Overview
+
+The IC-7610 is what happens when the IC-7300's recipe gets built for contest
+weekends instead of first stations. Since 2017 it has been the default
+"step-up-from-7300" answer, and in 2026 it's still a current Icom product —
+widely regarded as the best value in its price bracket for serious HF work.
+
+The headline is **true dual receive**: two independent RF direct-sampling
+receivers, not a main-plus-glimpse sub. You listen to the DX on one and your own
+transmit frequency on the other, watch both on the dual-band scope, and work the
+split like the big guns do. DIGI-SEL preselectors on both receivers keep strong
+adjacent signals from folding the band over — the contest-environment weakness
+the 7300 is known for is exactly what this radio fixes, with roughly 100 dB-class
+close-in dynamic range.
+
+Ergonomics are classic Icom — a big touchscreen plus real knobs — though the menu
+tree runs deeper than the 7300's, and early units went through a firmware
+maturation period. The one recurring community gripe is mundane: the **fan runs
+frequently and audibly** in a quiet shack. Reliability is otherwise regarded as
+good.
+
+## Bands, modes &amp; power
+
+- **TX:** 160–6 m, **100 W**, [SSB](/reference/single-sideband/),
+  [CW](/reference/morse-code/), RTTY, PSK31, AM, FM. No VHF/UHF.
+- **Receivers:** 2× independent direct-sampling SDR, DIGI-SEL preselection on
+  both, true dual watch.
+- **Antennas:** 2× SO-239 plus dedicated **RX in/out** — Beverages, loops, and
+  external preamps welcome (a port the [FTDX10](/reference/yaesu-ftdx10/) and
+  IC-7300 both lack).
+- **I/O:** dual USB, **LAN with built-in RS-BA1 remote server**, DVI external
+  display, SD card slot. 13.8 V DC.
+- **Tuner:** built-in ATU.
+
+## Operating &amp; station integration
+
+This is the most connectable radio in its class. The LAN port runs Icom's remote
+server natively — operate the station from the house, or the other coast —
+without a shack PC in the loop. The DVI output mirrors the scope onto a monitor,
+and SO2V contesters get the two receivers plus two USB audio paths that loggers
+like N1MM expect. If your operating is 90% casual, all of this is capability
+you're paying for and not using; that's the honest case for staying with a 7300.
+
+**License note:** transmitting here needs an FCC amateur license (Part 97,
+Technician minimum — realistically General, since this radio lives on HF).
+Listening needs no license at all.
+
+## Programming &amp; software
+
+CI-V CAT plus the built-in RS-BA1 server give it full third-party support —
+WSJT-X, N1MM, fldigi, Win4Icom, logging suites. CHIRP isn't a target here (no
+confirmed support, and nothing about an HF contest radio needs it). Firmware
+updates continue and have meaningfully improved the radio since launch.
+
+## GopherTrunk alternative
+
+GopherTrunk cannot transmit, so nothing here replaces an IC-7610 — but it's the
+right first spend. A ~$30 [RTL-SDR](/reference/rtl-sdr/) running free GopherTrunk
+shows you what's actually on the air near you — repeaters, digital voice, band
+activity — and **records and logs** it all, before you commit flagship money or
+even a license fee. It's also the honest answer for the family member who "just
+wants to listen": full receive, zero cost beyond the dongle. Hardware guidance
+lives at [best SDR for GopherTrunk](/best-sdr-for-gophertrunk/) and
+[best HF SDR](/best-hf-sdr/).
+
+## Who it's for
+
+- **Buy the IC-7610** if you work split pileups, contest SO2V, run RX antennas,
+  or operate remotely — the dual receivers and station I/O are worth every dollar
+  to that operator.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B078KKL7R6?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [IC-7300](/reference/icom-ic-7300/)** if that paragraph didn't
+  describe you — same DNA, under a third of the price.
+- **Consider the [FTDX10](/reference/yaesu-ftdx10/)** for flagship-class dynamic
+  range on a single receiver at half the money. Full rankings:
+  [best ham radio base stations](/best-ham-radio-base-stations/).
+
+## Sources
+
+[^icom]: [Icom IC-7610 product page](https://www.icomamerica.com/lineup/products/IC-7610/) — Icom America, on the dual independent direct-sampling receivers, DIGI-SEL preselectors, 7-inch dual-band scope, antenna/RX-in-out complement, LAN remote server, and built-in ATU.

--- a/docs/reference/icom-ic-7610.md
+++ b/docs/reference/icom-ic-7610.md
@@ -82,8 +82,16 @@ close-in dynamic range.
 Ergonomics are classic Icom — a big touchscreen plus real knobs — though the menu
 tree runs deeper than the 7300's, and early units went through a firmware
 maturation period. The one recurring community gripe is mundane: the **fan runs
-frequently and audibly** in a quiet shack. Reliability is otherwise regarded as
-good.
+frequently and audibly** in a quiet shack — a persistent eHam theme worth
+knowing if your operating position doubles as a quiet office. Reliability is
+otherwise regarded as good.
+
+On price: R&L had it at $3,499.95 in August 2026, with historical list prices
+reaching ~$3,900 before Icom's rolling rebates — so shop the rebate cycle
+rather than the sticker. The used market runs **$2,600–3,000**, and a clean
+used 7610 is one of the better ways into flagship-class HF: unlike vintage
+iron, it's a current-production radio with ongoing firmware support, so a used
+unit gives up nothing but the warranty.
 
 ## Bands, modes &amp; power
 

--- a/docs/reference/icom-id-5100a.md
+++ b/docs/reference/icom-id-5100a.md
@@ -1,0 +1,136 @@
+---
+slug: icom-id-5100a
+title: Icom ID-5100A
+entry_type: hardware
+category: ham-radios
+description: "The Icom ID-5100A Deluxe is the de-facto D-STAR mobile ham radio — 50 W on 2m/70cm, a big 5.5-inch touchscreen head, built-in GPS with D-PRS, and DR-mode repeater databases, still in production in 2026."
+keywords: Icom ID-5100A, ID-5100A review, D-STAR mobile radio, best D-STAR radio, dual band mobile ham radio, touchscreen ham radio, Icom mobile transceiver, ID-5100A Deluxe, D-STAR DR mode, best mobile ham radio 2026
+aka: [ID-5100A, ID-5100]
+autolink: true
+affiliate: true
+product:
+  name: "Icom ID-5100A Deluxe"
+  brand: Icom
+  category: Mobile ham transceiver
+  lowPrice: "450"
+  highPrice: "480"
+  url: https://www.amazon.com/dp/B00K5BNHT0?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: Dual-band mobile transceiver }
+  - { label: Bands, value: "2m / 70cm (dual watch)" }
+  - { label: Modes, value: "FM, D-STAR DV (DR mode)" }
+  - { label: Power, value: "50 / 15 / 5 W" }
+  - { label: Programming, value: "CHIRP / CS-5100 + SD card / RT Systems" }
+  - { label: Price, value: around $465 }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B00K5BNHT0?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [icom-ic-2730a, yaesu-ftm-500dr, anytone-at-d578uviii, yaesu-ftm-300dr, rtl-sdr, d-star]
+related_lessons:
+  - { title: "What is trunked radio?", url: /learn/digital-trunking/ }
+related_reading:
+  - { title: "Best SDR for GopherTrunk", url: /best-sdr-for-gophertrunk/ }
+cite_urls:
+  - https://www.icomamerica.com/lineup/products/ID-5100A/
+faq:
+  - q: "Is the Icom ID-5100A still in production?"
+    a: "Yes. As of 2026 it is still current on Icom America's lineup and stocked new at the major ham dealers — remarkable for a radio introduced in 2014. The Deluxe package runs around $450–480, varying with Icom promos and rebates."
+  - q: "Is the ID-5100A the best D-STAR mobile?"
+    a: "It is the de-facto D-STAR mobile: the big 5.5-inch touchscreen, DR mode with huge repeater databases, GPS, and gateway/terminal modes for internet-linked D-STAR make it the standard choice. Its age shows in the dim resistive touchscreen and monochrome UI, but nothing else in a mobile does D-STAR better."
+  - q: "Does the ID-5100A do APRS?"
+    a: "Not FM APRS. It does D-PRS position reporting over D-STAR, which reaches APRS via gateways but is not the same thing — FM APRS users should look at the Yaesu FTM-500DR/300DR or the AnyTone AT-D578UVIII Plus instead."
+  - q: "Can I program the ID-5100A with CHIRP?"
+    a: "Yes — CHIRP supports the ID-5100 in clone mode, including D-STAR fields with some caveats. Icom's CS-5100 software with the SD card and RT Systems are the other options."
+  - q: "Do I need a license to use the ID-5100A?"
+    a: "Transmitting requires an FCC amateur license (Part 97, Technician class minimum). Listening requires none — and a $30 RTL-SDR running free GopherTrunk can tell you whether D-STAR is even active in your area before you spend the money."
+---
+**The Icom ID-5100A** is the de-facto **[D-STAR](/reference/d-star/) mobile**: a
+50-watt 2m/70cm transceiver controlled entirely from a large **5.5-inch
+touchscreen head**, with DR-mode repeater databases, built-in GPS, and
+internet-linked D-STAR via its gateway and access-point modes.[^icom]
+Introduced in 2014 and — unusually — **still in production in 2026**, the Deluxe
+package runs around $465 and remains the standard answer when the question is
+"which mobile for D-STAR?"
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B00K5BNHT0?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The D-STAR mobile.** 50/15/5 W on 2m/70cm, FM + **D-STAR DV** with DR-mode
+repeater lists, a **5.5-inch touchscreen** head (the RF deck hides under a
+seat), dual watch, built-in GPS with **D-PRS** (not FM
+[APRS](/reference/aprs/)), and terminal/access-point modes for internet-linked
+D-STAR. **CHIRP-supported.** Quiet, clean Icom receiver. The 2014 DNA shows:
+resistive touchscreen, monochrome UI, one D-STAR decode at a time. **~$465.**
+Transmitting needs a ham license; listening doesn't.
+</div>
+
+## Overview
+
+The ID-5100A is a head-only design: the big resistive touchscreen controller
+mounts on the dash while the RF deck mounts remotely (the separation cable is
+included). That makes it one of the cleanest mobile installs in ham radio — and
+also means there is **no speaker in the control head**, so plan for the body
+speaker's location or an external one.
+
+The receiver is classic Icom: quiet and clean. Dual watch covers V/V, U/U, and
+V/U, though only **one D-STAR decode runs at a time**. You get 1,000 memories,
+voice recording to microSD, optional Bluetooth (the UT-133A module, standard in
+some Deluxe bundles) with Android app control, and ~13 A of draw at full power.
+No cross-band repeat.
+
+Its age is the honest knock. The resistive touchscreen is dim in sunlight and
+doesn't pinch or scroll like a phone; the monochrome UI feels a decade old; and
+Icom's DR-mode setup menus intimidate newcomers. None of that has dislodged it,
+because nothing else in the mobile market does D-STAR this completely.
+
+## Modes &amp; features
+
+- **Analog FM and [D-STAR](/reference/d-star/) DV**, with **DR mode** driving
+  repeater selection from a database that covers essentially every D-STAR
+  repeater — the feature that makes D-STAR usable on the road.
+- **Built-in GPS with D-PRS** position reporting over D-STAR. To be clear:
+  **D-PRS is not FM [APRS](/reference/aprs/)** — if the local APRS network on
+  144.39 is what you want, buy a [Yaesu FTM-500DR](/reference/yaesu-ftm-500dr/)
+  or [AnyTone AT-D578UVIII Plus](/reference/anytone-at-d578uviii/) instead.
+- **DV Gateway / terminal and access-point modes** — internet-linked D-STAR
+  through a phone or PC when no repeater is in range.
+- Wide dual-watch coverage, 1,000 memories, microSD voice recording, optional
+  Bluetooth with app control.
+
+## Programming
+
+Well-served, and the friendliest of the digital mobiles here:
+
+1. **CHIRP** — supported (ID-5100 driver, clone mode; D-STAR fields with
+   caveats). Free.
+2. **Icom CS-5100** software plus the SD card.
+3. **RT Systems** for the polished paid option.
+
+## GopherTrunk alternative
+
+GopherTrunk **receives; it cannot transmit** — it is not a substitute for an
+ID-5100A. It is, however, the cheap way to answer the question this radio poses:
+*is D-STAR actually active where you live?* A ~$30
+[RTL-SDR](/reference/rtl-sdr/) running free GopherTrunk monitors your local
+repeaters and digital ham traffic, and records and logs what it hears, so you
+know which digital network your area really uses before committing $465 to
+Icom's camp. Listening needs no license at all; transmitting on ham bands
+requires an FCC amateur license (Part 97, Technician minimum). See
+[best SDR for GopherTrunk](/best-sdr-for-gophertrunk/) to pick a dongle.
+
+## Who it's for
+
+- **Buy the ID-5100A** if D-STAR is active in your area and you want the
+  definitive mobile for it, with the best-integrated repeater database in the
+  business.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B00K5BNHT0?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [IC-2730A](/reference/icom-ic-2730a/)** for the same Icom RF quality
+  minus digital, about $130 cheaper.
+- **Buy the [AnyTone AT-D578UVIII Plus](/reference/anytone-at-d578uviii/)** if
+  your area runs [DMR](/reference/dmr/), or a
+  [Yaesu FTM-500DR](/reference/yaesu-ftm-500dr/) for
+  [C4FM](/reference/c4fm/) and true FM APRS.
+- Rankings and rivals: [the 10 best mobile ham radios](/best-mobile-ham-radios/).
+
+## Sources
+
+[^icom]: [Icom ID-5100A product page](https://www.icomamerica.com/lineup/products/ID-5100A/) — Icom America, on D-STAR DV/DR mode, the 5.5-inch touchscreen controller, GPS and D-PRS, gateway/terminal modes, and power specifications.

--- a/docs/reference/icom-id-52a.md
+++ b/docs/reference/icom-id-52a.md
@@ -1,0 +1,130 @@
+---
+slug: icom-id-52a
+title: Icom ID-52A
+entry_type: hardware
+category: ham-radios
+description: "The Icom ID-52A is a dual-band D-STAR handheld with an IP67 waterproof body, a big color display, GPS and Bluetooth — now transitioning to the ID-52A PLUS with enhanced terminal-mode features."
+keywords: Icom ID-52A, ID-52A review, ID-52A PLUS, D-STAR handheld, IP67 ham radio, waterproof ham handheld, Icom D-STAR HT, best D-STAR radio 2026, dual band handheld ham radio
+aka: [ID-52A, ID-52A PLUS, ID-52]
+autolink: true
+affiliate: true
+product:
+  name: "Icom ID-52A"
+  brand: Icom
+  category: Ham handheld transceiver
+  lowPrice: "580"
+  highPrice: "750"
+  url: https://www.amazon.com/dp/B0DC8MSVJ4?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: Dual-band handheld transceiver }
+  - { label: Bands, value: "TX 144/430 MHz; RX 0.5–579 MHz" }
+  - { label: Modes, value: "FM, D-STAR DV/DR; AM/FM/WFM receive" }
+  - { label: Power, value: 5 W }
+  - { label: Programming, value: "Icom CS-52/CS-52PLUS, RT Systems (no CHIRP)" }
+  - { label: Price, value: "around $580 (original) / $700–750 (PLUS)" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B0DC8MSVJ4?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">ID-52A PLUS on Amazon &rarr;</a>" }
+see_also: [kenwood-th-d75a, yaesu-ft-5dr, yaesu-ft-60r, kenwood-th-f6a, rtl-sdr, d-star]
+related_lessons:
+  - { title: "Analog vs. digital voice", url: /learn/rf-sdr/digital-voice/ }
+  - { title: "Legal & ethical monitoring", url: /learn/rf-sdr/legal-ethical/ }
+related_reading:
+  - { title: "Police scanner vs GopherTrunk", url: /police-scanner-vs-sdr/ }
+cite_urls:
+  - https://www.icomamerica.com/lineup/products/ID-52APLUS/
+faq:
+  - q: "What is the difference between the ID-52A and the ID-52A PLUS?"
+    a: "Same radio family. The PLUS is Icom's 2024 refresh with enhanced Terminal and Access Point (DV gateway) features and USB-C-era conveniences; Icom America's lineup now lists the PLUS. Remaining new stock of the original still sells for around $580, the PLUS for $700–750."
+  - q: "Is the ID-52A waterproof?"
+    a: "Yes — IP67, rated for 1 m of water for 30 minutes. That's a real advantage over the Kenwood TH-D75A (IP54/55, splash-resistant only) if your D-STAR radio lives outdoors."
+  - q: "Does the ID-52A do APRS?"
+    a: "Not conventional APRS — there's no packet TNC. It reports position via D-PRS over D-STAR instead. If APRS is your priority, the Kenwood TH-D75A is the clear pick."
+  - q: "Does the ID-52A work with CHIRP?"
+    a: "No. Program it with Icom's free CS-52 (CS-52PLUS for the PLUS) software, RT Systems, or by editing the microSD card contents directly."
+  - q: "Do I need a license to use the ID-52A?"
+    a: "Transmitting on the ham bands requires an FCC amateur license (Technician class or higher). Listening — and this radio's 0.5–579 MHz receiver with air band is good at it — requires none."
+---
+**The Icom ID-52A** is the [D-STAR](/reference/d-star/) handheld built for the
+outdoors: dual-band 144/430 MHz at 5 W, a genuinely waterproof **IP67** body,
+the first large color display on a D-STAR HT, wideband 0.5–579 MHz receive with
+AM air band, and GPS plus Bluetooth built in.[^icom] The family is currently
+transitioning: the original ID-52A (~$580 while stock lasts) is being superseded
+by the **ID-52A PLUS** (~$700–750), Icom's 60th-anniversary refresh with
+enhanced terminal-mode and DV-gateway features.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0DC8MSVJ4?tag=gophertrunk-20" rel="nofollow sponsored noopener">ID-52A PLUS on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The best D-STAR handheld for hard outdoor use.** IP67 waterproofing (the
+[TH-D75A](/reference/kenwood-th-d75a/) is only splash-resistant), a superb color
+UI, easy reflector access, and a bigger stock battery (1,880 mAh) than Kenwood's.
+**No APRS TNC** — position goes out as D-PRS over D-STAR — no 220 MHz, and
+D-STAR is its only digital mode. **~$580 for remaining original stock, $700–750
+for the PLUS.** Transmitting takes an FCC Technician license; listening doesn't.
+</div>
+
+## Overview
+
+Where Kenwood's [TH-D75A](/reference/kenwood-th-d75a/) is the data-mode Swiss
+Army knife, the ID-52A is the D-STAR radio you can drop in a creek. Icom gave it
+a 2.3-inch color transflective LCD (readable in sunlight), simultaneous V/V,
+U/U and V/U dual watch, 1,000 memories, a microSD slot, and one of the cleanest
+D-STAR implementations in the business — repeater lists, reflector linking and
+the share-picture function all work the way the manual says they do.
+
+The PLUS transition matters mostly for terminal and access-point operation
+(working D-STAR gateways over the internet with no local repeater): the PLUS
+enhances those features, and it's what Icom America's lineup page now lists.
+Buying the original at a discount is a fine move if you mainly use local
+repeaters; buy the PLUS if gateway operation is the point. One era-specific
+annoyance on pre-PLUS units: charging is Micro-USB, which owners rightly
+dislike.
+
+## Modes &amp; features
+
+- **[D-STAR](/reference/d-star/) DV/DR** with easy reflector access; PLUS adds
+  enhanced Terminal/Access Point modes.
+- **Wideband RX 0.5–579 MHz** — AM, FM and WFM including the air band.
+- **IP67** — 1 m / 30 min submersion rating, the best waterproofing in the
+  current D-STAR field.
+- **GPS and Bluetooth** built in; **D-PRS** position reporting (no conventional
+  [APRS](/reference/aprs/) TNC).
+- **5 W** on 144/430 MHz; BP-272 1,880 mAh battery (3,150 mAh BP-307 optional).
+
+## Programming
+
+Icom's free CS-52 software (CS-52PLUS for the PLUS) handles memories and
+settings over USB or by writing the microSD card directly; RT Systems covers it
+too. **CHIRP does not support it** — plan on Icom's tools.
+
+## GopherTrunk alternative
+
+GopherTrunk receives; it can't transmit, so it is no substitute for an ID-52A.
+What it *is* good for is finding out whether $600+ of D-STAR hardware will have
+anyone to talk to. A ~$30 [RTL-SDR](/reference/rtl-sdr/) running free GopherTrunk
+lets you monitor your local repeaters and digital ham traffic — recording and
+logging every transmission, which no HT does — so you know whether
+[D-STAR](/reference/d-star/), [DMR](/reference/dmr/) or [C4FM](/reference/c4fm/)
+is the live mode in your area before you commit to one. Start with
+[best SDR for GopherTrunk](/best-sdr-for-gophertrunk/).
+
+## Who it's for
+
+- **Buy the ID-52A** if you want D-STAR in a waterproof, sunlight-readable,
+  field-first package — SOTA, backpacking, marine environments.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B0DC8MSVJ4?tag=gophertrunk-20" rel="nofollow sponsored noopener">ID-52A PLUS on Amazon &rarr;</a>
+- **Buy the [Kenwood TH-D75A](/reference/kenwood-th-d75a/)** instead if APRS,
+  packet/Winlink, 220 MHz or SSB/CW receive matter more than waterproofing.
+- **Skip both** if your area runs DMR or C4FM — see the
+  [AT-D878UVII Plus](/reference/anytone-at-d878uvii-plus/) and
+  [FT-5DR](/reference/yaesu-ft-5dr/), and the full rankings in
+  [best handheld ham radios](/best-handheld-ham-radios/).
+
+> **Buying note.** The button links the confirmed **ID-52A PLUS** (60th
+> Anniversary Edition) listing. Remaining new stock of the original ID-52A
+> sells through ham dealers around $580; on Amazon,
+> <a href="https://www.amazon.com/s?k=icom+id-52a&tag=gophertrunk-20" rel="nofollow sponsored noopener">search current ID-52A listings</a>.
+
+## Sources
+
+[^icom]: [Icom ID-52A PLUS product page](https://www.icomamerica.com/lineup/products/ID-52APLUS/) — Icom America, on D-STAR DV/DR and terminal modes, 0.5–579 MHz receive, IP67 rating, GPS/Bluetooth, and the PLUS refresh.

--- a/docs/reference/kenwood-th-d75a.md
+++ b/docs/reference/kenwood-th-d75a.md
@@ -1,0 +1,132 @@
+---
+slug: kenwood-th-d75a
+title: Kenwood TH-D75A
+entry_type: hardware
+category: ham-radios
+description: "The Kenwood TH-D75A is the flagship tri-band (144/220/430 MHz) D-STAR handheld with a full APRS KISS TNC, SSB/CW wideband receive, GPS, Bluetooth and USB-C — the best-equipped ham HT you can buy in 2026."
+keywords: Kenwood TH-D75A, TH-D75A review, best ham handheld 2026, tri-band ham HT, D-STAR handheld, APRS handheld radio, KISS TNC HT, 220 MHz handheld, Kenwood D-STAR APRS radio, TH-D74 successor
+aka: [TH-D75A, TH-D75]
+autolink: true
+affiliate: true
+product:
+  name: "Kenwood TH-D75A"
+  brand: Kenwood
+  category: Ham handheld transceiver
+  lowPrice: "700"
+  highPrice: "740"
+  url: https://www.amazon.com/s?k=Kenwood+TH-D75A&tag=gophertrunk-20
+infobox:
+  - { label: Type, value: Tri-band handheld transceiver }
+  - { label: Bands, value: "TX 144/220/430 MHz; RX 0.1–524 MHz" }
+  - { label: Modes, value: "FM, D-STAR (DV/DR); SSB/CW receive; APRS" }
+  - { label: Power, value: "5 W (5/2/0.5/0.05 W steps)" }
+  - { label: Programming, value: "Kenwood MCP-D75, CHIRP (reported), RT Systems" }
+  - { label: Price, value: around $720 }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/s?k=Kenwood+TH-D75A&tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">Find on Amazon &rarr;</a>" }
+see_also: [icom-id-52a, yaesu-ft-5dr, kenwood-th-f6a, anytone-at-d878uvii-plus, rtl-sdr, d-star]
+related_lessons:
+  - { title: "Analog vs. digital voice", url: /learn/rf-sdr/digital-voice/ }
+  - { title: "Legal & ethical monitoring", url: /learn/rf-sdr/legal-ethical/ }
+related_reading:
+  - { title: "Police scanner vs GopherTrunk", url: /police-scanner-vs-sdr/ }
+cite_urls:
+  - https://www.kenwood.com/usa/com/amateur/th-d75a/
+faq:
+  - q: "Is the Kenwood TH-D75A worth the price?"
+    a: "If you use APRS or D-STAR seriously, yes — nothing else combines a tri-band transmitter, a real KISS TNC, SSB/CW wideband receive, GPS, Bluetooth and USB-C in one handheld. If you only need FM voice, a Yaesu FT-60R does that job for around $180."
+  - q: "Does the TH-D75A do DMR or C4FM?"
+    a: "No. Its digital voice mode is D-STAR only. For DMR, look at the AnyTone AT-D878UVII Plus; for C4FM System Fusion, the Yaesu FT-5DR. No current handheld covers more than one of the three digital voice families."
+  - q: "Do I need a license to use the TH-D75A?"
+    a: "To transmit, yes — an FCC amateur license, Technician class minimum. Listening requires no license at all, and its 0.1–524 MHz multimode receiver makes it a genuinely good listening radio too."
+  - q: "How is the TH-D75A's battery life?"
+    a: "It's the radio's most common complaint. The 1,100 mAh KNB-75LA pack plus a color display and GPS means short field endurance; most owners carry a spare pack or a USB-C power bank, since it charges over USB-C."
+  - q: "Is the TH-D75A waterproof?"
+    a: "It carries an IP54/55 dust and splash rating — fine in rain, not submersible. If you need a dunkable D-STAR handheld, the Icom ID-52A is IP67 rated."
+---
+**The Kenwood TH-D75A** is the flagship of current ham handhelds: the only
+tri-band (144/220/430 MHz) [D-STAR](/reference/d-star/) HT in production, with a
+full built-in 1200/9600 bps [APRS](/reference/aprs/) TNC (KISS mode included), a
+0.1–524 MHz multimode receiver that hears **SSB and CW**, plus GPS, Bluetooth,
+microSD and USB-C.[^kenwood] It replaced the TH-D74A in 2024 and costs around
+$720.
+
+<a class="btn btn--buy" href="https://www.amazon.com/s?k=Kenwood+TH-D75A&tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The best-equipped ham handheld you can buy** — our top overall pick in
+[best handheld ham radios](/best-handheld-ham-radios/). Tri-band 5 W TX including
+**220 MHz**, [D-STAR](/reference/d-star/) with terminal/access-point mode, the
+definitive [APRS](/reference/aprs/) implementation (KISS TNC, digipeater), and
+SSB/CW wideband receive. **Weak spot: battery life** — the 1,100 mAh pack drains
+fast with GPS and the color screen on. **~$720.** No DMR or C4FM. Transmitting
+needs an FCC amateur license (Technician minimum); listening needs none.
+</div>
+
+## Overview
+
+Kenwood builds one handheld, and it builds it for the operator who wants
+everything. The TH-D75A is the direct successor to the much-loved TH-D74A and the
+only current-production HT that transmits on the 220 MHz band alongside 2 m and
+70 cm. Its receiver is the other headline: dual watch (including two D-STAR
+signals at once), coverage from 100 kHz to 524 MHz, and demodulation of SSB and
+CW — no other current HT hears sideband. A transflective color TFT, 1,000+
+memories, and a microSD slot for logging and recording round out a spec sheet
+that reads like three radios in one.
+
+The honest trade-offs: it is around $720, it does **no** [DMR](/reference/dmr/)
+or [C4FM](/reference/c4fm/), its IP54/55 rating is splash-resistant rather than
+submersible, and the 1,100 mAh battery is undersized for the hardware it feeds —
+the number-one owner complaint. USB-C charging softens that in the field.
+
+## Modes &amp; features
+
+- **[D-STAR](/reference/d-star/) DV/DR**, including Reflector Terminal and
+  Access Point modes over USB-C — work reflectors with no local repeater.
+- **[APRS](/reference/aprs/) done properly**: built-in 1200/9600 bps TNC, KISS
+  mode for packet and Winlink, and standalone digipeater operation. This is the
+  APRS benchmark every other HT is measured against.
+- **Wideband multimode RX**: 0.1–524 MHz with AM, FM, **SSB and CW**, IF
+  filtering, and dual watch.
+- **GPS, Bluetooth, microSD, USB-C** (charging, audio and programming) built in.
+- **5 W** output with 5/2/0.5/0.05 W steps; IP54/55 dust/splash resistance.
+
+## Programming
+
+Kenwood's free MCP-D75 software is the official route, and RT Systems sells the
+usual polished alternative. CHIRP's tracker reports working memory
+download/upload support for the TH-D75 — but verify current driver status before
+counting on it, as coverage of Kenwood's newest models has been a moving target.
+Memories also move via the microSD card.
+
+## GopherTrunk alternative
+
+GopherTrunk can't replace the TH-D75A — it receives only, and this radio's whole
+point is transmitting on three bands. But before spending $720, it's worth
+knowing what's actually on the air near you. A ~$30 [RTL-SDR](/reference/rtl-sdr/)
+running free GopherTrunk monitors local repeaters and digital ham traffic,
+records and logs what it hears, and tells you whether your area has active
+D-STAR before you buy into the mode — see
+[best SDR for GopherTrunk](/best-sdr-for-gophertrunk/). Listen first, license,
+then buy the rig that matches the traffic.
+
+## Who it's for
+
+- **Buy the TH-D75A** if APRS, packet, or D-STAR is your thing, if you want
+  220 MHz, or if you simply want the most capable receiver ever put in a ham HT.
+  <a class="btn btn--buy" href="https://www.amazon.com/s?k=Kenwood+TH-D75A&tag=gophertrunk-20" rel="nofollow sponsored noopener">Find on Amazon &rarr;</a>
+- **Buy the [Icom ID-52A](/reference/icom-id-52a/)** instead for D-STAR in an
+  IP67 waterproof body, or the [Yaesu FT-5DR](/reference/yaesu-ft-5dr/) for C4FM
+  plus APRS at roughly half the price.
+- **Skip it** if you just need FM voice — a [Yaesu FT-60R](/reference/yaesu-ft-60r/)
+  costs a quarter as much. Full rankings:
+  [best handheld ham radios](/best-handheld-ham-radios/).
+
+> **Amazon note.** Kenwood sells the TH-D75A mainly through ham dealers
+> (GigaParts, DX Engineering, HRO, R&L), so the button above is a tagged Amazon
+> search rather than a single listing — check dealer pricing too; instant
+> rebates around $50 are common.
+
+## Sources
+
+[^kenwood]: [Kenwood TH-D75A product page](https://www.kenwood.com/usa/com/amateur/th-d75a/) — Kenwood USA, on tri-band TX, D-STAR DV/DR and terminal modes, APRS TNC, 0.1–524 MHz SSB/CW receive, GPS, Bluetooth, USB-C, and IP54/55 rating.

--- a/docs/reference/kenwood-th-f6a.md
+++ b/docs/reference/kenwood-th-f6a.md
@@ -1,0 +1,135 @@
+---
+slug: kenwood-th-f6a
+title: Kenwood TH-F6A
+entry_type: hardware
+category: ham-radios
+description: "The Kenwood TH-F6A is a discontinued tri-band (144/220/440 MHz) handheld with all-mode 0.1–1,300 MHz receive — still the best used-market buy for 220 MHz and wideband listening at around $200–275."
+keywords: Kenwood TH-F6A, TH-F6A review, TH-F6A used price, tri-band handheld 220 MHz, discontinued Kenwood HT, all-mode receive handheld, SSB receive HT, best used ham handheld, TH-F6A vs TH-D75A
+aka: [TH-F6A, TH-F6]
+autolink: true
+affiliate: true
+product:
+  name: "Kenwood TH-F6A"
+  brand: Kenwood
+  category: Ham handheld transceiver
+  lowPrice: "200"
+  highPrice: "275"
+  itemCondition: used
+  url: https://www.amazon.com/dp/B0097CQ4AW?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: "Tri-band handheld transceiver (discontinued ~2017)" }
+  - { label: Bands, value: "TX 144/220/440 MHz; RX 0.1–1,300 MHz" }
+  - { label: Modes, value: "FM TX; AM/SSB/CW receive" }
+  - { label: Power, value: "5 W (all three bands)" }
+  - { label: Programming, value: "CHIRP, Kenwood MCP-F6F7, RT Systems" }
+  - { label: Price, value: "around $200–275 used" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B0097CQ4AW?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">Check Amazon (used) &rarr;</a>" }
+see_also: [kenwood-th-d75a, yaesu-vx-8dr, yaesu-ft-60r, baofeng-uv-5r, rtl-sdr, police-scanner]
+related_lessons:
+  - { title: "Analog vs. digital voice", url: /learn/rf-sdr/digital-voice/ }
+  - { title: "Legal & ethical monitoring", url: /learn/rf-sdr/legal-ethical/ }
+related_reading:
+  - { title: "Police scanner vs GopherTrunk", url: /police-scanner-vs-sdr/ }
+cite_urls:
+  - https://www.dxengineering.com/parts/kwd-th-f6a
+  - https://swling.com/blog/2017/02/the-versatile-kenwood-th-f6a/
+faq:
+  - q: "Is the Kenwood TH-F6A still worth buying used?"
+    a: "Yes, for the right buyer. Nothing else that small does 5 W on 220 MHz plus 0.1–1,300 MHz all-mode receive at a $200–275 used price. If you don't care about 220 MHz or SSB receive, a new radio serves you better."
+  - q: "When was the TH-F6A discontinued?"
+    a: "Kenwood ended production circa 2016–2017 (one dealer note dates it to May 2017). Its tri-band niche went unfilled until Kenwood's own TH-D75A arrived in 2024."
+  - q: "What should I check when buying a used TH-F6A?"
+    a: "Battery health first — the PB-42L pack is a consumable now, though 2,000 mAh clones are plentiful and cheap. Also check belt clip and case plastics for wear, and confirm the seller includes a charger; it charges via barrel jack."
+  - q: "Does the TH-F6A do any digital modes?"
+    a: "No — FM transmit only, no D-STAR, DMR, C4FM, GPS or Bluetooth. Its party trick is on the receive side: AM, SSB and CW across 0.1–1,300 MHz."
+  - q: "Do I need a license to use a TH-F6A?"
+    a: "Transmitting requires an FCC amateur license (Technician class minimum). Listening requires none — and as a wideband all-mode listening radio it remains a classic."
+---
+**The Kenwood TH-F6A** is the little tri-bander that never got a successor for
+seven years: 5 W transmit on **144, 220 and 440 MHz**, plus a dual-channel
+0.1–1,300 MHz receiver that demodulates **AM, SSB and CW** — a wideband
+listening classic in a shirt-pocket radio.[^dxe] Kenwood discontinued it around
+2017; today it lives on the used market at roughly **$200–275**, buoyed by the
+220 MHz cult following.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0097CQ4AW?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check Amazon (used) &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Our pick for best used/classic handheld buy.** Nothing else this small does
+5 W on 220 MHz *and* all-mode wideband receive at this price — its niche was
+only re-filled by the $720 [TH-D75A](/reference/kenwood-th-d75a/). FM transmit
+only: no digital modes, GPS or Bluetooth. **Used-market realities**: unknown
+battery health, worn plastics, no IP rating. The Amazon listing is third-party/
+used and often unavailable — **eBay and hamfests are the real market.**
+Transmitting needs an FCC Technician license; listening needs none.
+</div>
+
+## Overview
+
+For a decade the TH-F6A was the answer to two different questions: "what
+handheld covers 220 MHz?" and "what handheld can *hear* everything?" Its
+receive side is the remarkable half — dual-channel coverage from 100 kHz to
+1.3 GHz with AM, SSB and CW demodulation and a ferrite bar antenna for medium
+wave, in an era when SSB receive in an HT was unheard of. Add 435 memories, an
+internal battery meter, and a tough little chassis, and it earned the loyal
+following that keeps used prices firm.
+
+**Used-market viability** is the question now, and it's good with eyes open.
+Typical sold prices run ~$200–275 on eBay, hamfests and swap boards (observed
+asks: $215–$250+, clean boxed examples higher). Known failure points are age,
+not design: the PB-42L battery is a consumable (2,000 mAh clones are plentiful
+and cheap), belt clips break, front-panel plastics scratch, and the display is
+small and dim by modern standards. Every core part you actually need — battery,
+antenna, programming cable — is still easy to source. Buying used means
+unknown battery health, so price a replacement pack into your offer.
+
+## Modes &amp; features
+
+- **TX**: analog FM, 5 W on all of 144/220/440 MHz — still the only compact
+  used HT that does 220 at full power.
+- **RX**: 0.1–1,300 MHz dual-channel, **AM/SSB/CW** included; bar antenna for
+  MW broadcast.
+- **No digital anything** — no D-STAR/DMR/C4FM, GPS, Bluetooth or IP rating.
+- **PB-42L Li-ion** (1,550 mAh stock; clone packs to 2,000 mAh); barrel-jack
+  charging; 435 memories.
+
+## Programming
+
+**CHIRP supports it** via the mature TH-F6/TH-F7 driver; Kenwood's legacy
+MCP-F6F7 software and RT Systems' KRS-F6 also work. Cables remain easy to
+find.
+
+## GopherTrunk alternative
+
+Half the TH-F6A's appeal is its receiver — and that half GopherTrunk can
+genuinely replace. A ~$30 [RTL-SDR](/reference/rtl-sdr/) running free
+GopherTrunk covers the same VHF/UHF listening with a waterfall, decodes the
+digital modes the Kenwood never could ([DMR](/reference/dmr/),
+[C4FM](/reference/c4fm/), [D-STAR](/reference/d-star/)), and records and logs
+every transmission. What it can't do is transmit — so the honest split is: buy
+the SDR for monitoring today
+([best SDR for GopherTrunk](/best-sdr-for-gophertrunk/)), and hunt a clean
+TH-F6A when you specifically want 220 MHz transmit in your pocket.
+
+## Who it's for
+
+- **Buy a used TH-F6A** if you want 220 MHz in a compact HT, love wideband
+  all-mode listening, or want a classic that still earns its keep — check
+  battery and plastics before paying.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B0097CQ4AW?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check Amazon (used) &rarr;</a>
+- **Buy the [Kenwood TH-D75A](/reference/kenwood-th-d75a/)** new (~$720) for
+  the modern version of this exact niche — tri-band with 220, plus D-STAR,
+  APRS and SSB/CW receive.
+- **Skip it** if 220 MHz means nothing to you — a new
+  [Yaesu FT-60R](/reference/yaesu-ft-60r/) costs less than most clean TH-F6As.
+  Full rankings: [best handheld ham radios](/best-handheld-ham-radios/).
+
+> **Buying note.** The Amazon page above is a legacy listing — offers are
+> third-party and used, and it frequently shows unavailable. The practical
+> market for this radio is **eBay, hamfests and the QRZ swapmeet**; accessories
+> (batteries, cables, cases) are still actively sold on Amazon.
+
+## Sources
+
+[^dxe]: [Kenwood TH-F6A at DX Engineering](https://www.dxengineering.com/parts/kwd-th-f6a) and [The versatile Kenwood TH-F6A](https://swling.com/blog/2017/02/the-versatile-kenwood-th-f6a/) — The SWLing Post — on tri-band 5 W transmit, 0.1–1,300 MHz AM/SSB/CW receive, discontinuation timing, and the radio's listening pedigree.

--- a/docs/reference/kenwood-tm-v71a.md
+++ b/docs/reference/kenwood-tm-v71a.md
@@ -1,0 +1,140 @@
+---
+slug: kenwood-tm-v71a
+title: Kenwood TM-V71A
+entry_type: hardware
+category: ham-radios
+description: "The Kenwood TM-V71A is one of the most reliable FM mobile ham radios ever sold — 50 W 2m/70cm, true dual receive, cross-band repeat, and EchoLink sysop mode — discontinued circa 2021 and now a $250–350 used-market bargain."
+keywords: Kenwood TM-V71A, TM-V71A review, TM-V71A used, cross-band repeat mobile, EchoLink radio, dual band mobile ham radio, most reliable ham radio, Kenwood mobile discontinued, best used mobile ham radio, CHIRP Kenwood
+aka: [TM-V71A, TM-V71]
+autolink: true
+affiliate: true
+product:
+  name: "Kenwood TM-V71A"
+  brand: Kenwood
+  category: Mobile ham transceiver (used)
+  lowPrice: "250"
+  highPrice: "350"
+  itemCondition: used
+  url: https://www.amazon.com/dp/B0084QI38S?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: Dual-band mobile transceiver (discontinued) }
+  - { label: Bands, value: "2m / 70cm (true dual receive)" }
+  - { label: Modes, value: "FM only — plus cross-band repeat, EchoLink sysop" }
+  - { label: Power, value: "50 / 10 / 5 W" }
+  - { label: Programming, value: "CHIRP / Kenwood MCP-2A / RT Systems" }
+  - { label: Price, value: "around $250–350 used" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B0084QI38S?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [icom-ic-2730a, yaesu-ft-857d, icom-ic-706mkiig, btech-uv-25x2, rtl-sdr, aprs]
+related_lessons:
+  - { title: "What is trunked radio?", url: /learn/digital-trunking/ }
+related_reading:
+  - { title: "Best SDR for GopherTrunk", url: /best-sdr-for-gophertrunk/ }
+cite_urls:
+  - https://www.universal-radio.com/catalog/fm_txvrs/0071a.html
+  - https://www.rigpix.com/kenwood/tmv71a.htm
+faq:
+  - q: "Is the Kenwood TM-V71A discontinued?"
+    a: "Yes. Kenwood halted production around 2021, citing parts unavailability (dealer notices went out in July 2021), and has since exited the amateur FM-mobile segment entirely — the TM-D710GA is gone too. A legacy third-party Amazon listing survives, but realistically it's a used/eBay purchase now."
+  - q: "Is a used TM-V71A reliable?"
+    a: "It is the community's shorthand for reliable — one of the most dependable FM mobiles ever sold, with very few known failure modes. The main used-buying cautions are worn microphones and missing mounting brackets, not the radio itself."
+  - q: "Does the TM-V71A do cross-band repeat?"
+    a: "Yes — best-in-class cross-band repeat is a headline feature, along with a built-in EchoLink sysop mode with dedicated memories and DTMF features. Those two capabilities are why it remains the standard rig for EchoLink nodes and event work."
+  - q: "Does the TM-V71A have APRS or digital modes?"
+    a: "No — analog FM only, no GPS or APRS (that was the TM-D710 line's job) and no digital voice. If you want APRS in a mobile, look at the Yaesu FTM-500DR/300DR or AnyTone AT-D578UVIII Plus."
+  - q: "Do I need a license to use the TM-V71A?"
+    a: "Transmitting requires an FCC amateur license (Part 97, Technician class minimum) — and running cross-band repeat or an EchoLink node comes with its own control-operator responsibilities. Listening requires no license."
+---
+**The Kenwood TM-V71A** is one of the most reliable FM mobiles ever sold: a
+50-watt 2m/70cm rig with **true dual receive**, **best-in-class cross-band
+repeat**, a built-in **EchoLink sysop mode**, and 1,000 alphanumeric
+memories.[^refs] Kenwood ended production **circa 2021** and then left the
+amateur FM-mobile market entirely, so the V71A is now a used-market buy — and
+at a typical **$250–350**, arguably the best radio-per-dollar on this entire
+list.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0084QI38S?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Buy-it-for-life build, bargain used price.** 50/10/5 W on both bands, true
+dual receive (V+V/U+U/V+U), **cross-band repeat**, **EchoLink sysop mode**,
+1,000 memories, five PM profiles, detachable faceplate with reversible
+amber/green display, **CHIRP-supported**. **Discontinued ~2021 (parts
+shortage); used market only** — ~$250–350, trending up as supply dries.
+**Near-bulletproof:** the used-buying cautions are worn mics and missing
+brackets, not failures. No APRS/GPS, no digital voice. License to transmit;
+none to listen.
+</div>
+
+## Overview
+
+The TM-V71A was Kenwood's last pure-FM dual-band mobile, and it went out at
+the top: a superb receiver, honest 50 watts, and the two features that made it
+an institution — **cross-band repeat** good enough to be the reference
+implementation, and a dedicated **EchoLink sysop mode** (special memories and
+DTMF handling) that made it *the* standard hardware for EchoLink nodes. Five
+programmable PM profiles let one radio serve several operators or roles; the
+faceplate detaches (the PG-5F/DFK-3D separation kit was always an extra); the
+dot-matrix display flips between amber and green. TX draw is ~13 A.
+
+What it doesn't do: no GPS or [APRS](/reference/aprs/) — that was the
+TM-D710 line's job — no digital voice, and a monochrome display that looked
+dated even in 2015. The speaker fires down or back in some mounts, so plan
+audio placement.
+
+**Used-market viability, honestly:** this is the easiest used buy on our
+mobile list. The community regards the V71A as **near-bulletproof** — very few
+known failure modes across a long production run. Check that the microphone
+isn't worn out, that the mounting bracket and (if you need it) separation kit
+are included, and that's genuinely most of the checklist. Mid-2025 eBay solds
+ran about $247–260; clean units are trending higher in 2026 as supply dries up
+(the upper bound is an estimate — check current sold listings).
+
+## Modes &amp; features
+
+- **Analog FM** on 2m/70cm with **true dual receive** — V+V, U+U, or V+U.
+- **Cross-band repeat** — a headline feature and still best-in-class; extend a
+  handheld's reach through the mobile at a trailhead or event.
+- **EchoLink sysop mode** built in, with dedicated memories and DTMF features.
+- **1,000 memories** with alphanumeric tags, five PM profiles, PC programming
+  port.
+
+## Programming
+
+1. **CHIRP** (free) — mature TM-V71A driver.
+2. **Kenwood MCP-2A** — Kenwood's free software, still downloadable.
+3. **RT Systems** — the paid option.
+
+## GopherTrunk alternative
+
+GopherTrunk **receives; it cannot transmit** — it cannot run a cross-band
+repeater or an EchoLink node, which is precisely what people buy V71As for.
+What it can do is tell you whether that purchase makes sense: a ~$30
+[RTL-SDR](/reference/rtl-sdr/) running free GopherTrunk monitors every local
+repeater — analog and digital — and records and logs the traffic, so you know
+how active your area is before hunting a used classic. Listening requires no
+license; transmitting on ham bands requires an FCC amateur license (Part 97,
+Technician class minimum). Dongle picks:
+[best SDR for GopherTrunk](/best-sdr-for-gophertrunk/).
+
+## Who it's for
+
+- **Buy a used TM-V71A** if you want a dependable-forever FM mobile, cross-band
+  repeat, or an EchoLink node rig — at $250–350 it's the value sleeper of the
+  whole mobile field.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B0084QI38S?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy a new [Icom IC-2730A](/reference/icom-ic-2730a/)** for the closest
+  in-production equivalent (minus cross-band repeat and EchoLink mode).
+- **Buy a [Yaesu FTM-500DR](/reference/yaesu-ftm-500dr/)** or
+  [AnyTone AT-D578UVIII Plus](/reference/anytone-at-d578uviii/) if you need
+  digital voice or APRS.
+- Full rankings: [the 10 best mobile ham radios](/best-mobile-ham-radios/).
+
+> **Amazon note.** The TM-V71A is out of production; the Amazon listing is a
+> legacy third-party one that may show used units or no stock. The primary
+> market is eBay, hamfests, and the QRZ swapmeet — compare against recent
+> sold prices.
+
+## Sources
+
+[^refs]: [Universal Radio TM-V71A archive page](https://www.universal-radio.com/catalog/fm_txvrs/0071a.html) and [RigPix TM-V71A entry](https://www.rigpix.com/kenwood/tmv71a.htm) — archived references documenting the TM-V71A's dual receive, cross-band repeat, EchoLink sysop mode, 1,000 memories, and power specifications.

--- a/docs/reference/kenwood-ts-590sg.md
+++ b/docs/reference/kenwood-ts-590sg.md
@@ -1,0 +1,144 @@
+---
+slug: kenwood-ts-590sg
+title: Kenwood TS-590SG
+entry_type: hardware
+category: ham-radios
+description: "The Kenwood TS-590SG is a 100W HF/6m base transceiver with legendary close-in receiver dynamic range and best-in-class QSK CW — the contester's and CW operator's pick, with no built-in spectrum scope, around $1,840."
+keywords: Kenwood TS-590SG, TS-590SG review, TS-590SG vs IC-7300, best CW transceiver, QSK full break-in, HF contest radio, Kenwood HF base station, close-in dynamic range, TS-590SG price 2026, Kenwood ham radio
+aka: [TS-590SG, TS-590]
+autolink: true
+affiliate: true
+product:
+  name: "Kenwood TS-590SG"
+  brand: Kenwood
+  category: Ham radio base station (HF/6m transceiver)
+  lowPrice: "1800"
+  highPrice: "1840"
+  url: "https://www.amazon.com/s?k=kenwood+ts-590sg+ham+radio&tag=gophertrunk-20"
+infobox:
+  - { label: Type, value: "HF/6m base transceiver (down-conversion superhet)" }
+  - { label: Bands, value: "160–6 m TX; 0.13–30 + 50–54 MHz RX" }
+  - { label: Modes, value: "SSB, CW, FSK, AM, FM" }
+  - { label: Power, value: "100 W" }
+  - { label: Programming, value: "USB CAT + audio; free ARCP-590G PC control" }
+  - { label: Price, value: "around $1,840" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/s?k=kenwood+ts-590sg+ham+radio&tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [yaesu-ftdx10, icom-ic-7300, icom-ic-7610, kenwood-ts-940s, rtl-sdr, superheterodyne-receiver]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "Best ham radio base stations", url: /best-ham-radio-base-stations/ }
+cite_urls:
+  - https://www.kenwood.com/usa/com/amateur/ts-590sg/
+faq:
+  - q: "Is the Kenwood TS-590SG still worth buying in 2026?"
+    a: "For CW operators and contesters, absolutely — its close-in dynamic range has been a top Sherwood performer for years and its QSK full break-in is best in class. For everyone else, the missing built-in spectrum scope is the deal-breaker at this price: an IC-7300 costs less and shows you the band."
+  - q: "Does the TS-590SG have a spectrum scope or waterfall?"
+    a: "Not on the radio — it has a conventional segmented LCD. Kenwood's free ARCP-590G software puts a scope on a connected PC, but there is no built-in panadapter. That's the single biggest reason buyers pass on an otherwise superb receiver."
+  - q: "What's the difference between the TS-590S and TS-590SG?"
+    a: "The SG is the 2014 refresh of the 2010 TS-590S — improved local oscillator and refinements throughout. The SG is the one still in production; used TS-590S units sell for less and remain excellent CW radios."
+  - q: "Why isn't the TS-590SG sold directly on Amazon?"
+    a: "Amazon carries accessories for it (manuals, cables) but not the radio itself under a confirmed listing — our button is a tagged search. The reliable sources are the major ham dealers (DX Engineering, R&L, GigaParts and the like)."
+  - q: "Do I need a license for the TS-590SG?"
+    a: "To transmit, yes — an FCC amateur license under Part 97, Technician class minimum (General for most of HF). Listening needs no license; its general-coverage receiver tunes 130 kHz–30 MHz plus 6 meters."
+---
+**The Kenwood TS-590SG** is the radio you buy with your ears instead of your
+eyes: **legendary close-in receiver dynamic range** — long a top performer on the
+Sherwood table — and **best-in-class QSK full break-in CW**, in a 100 W HF/6m
+package that has been Kenwood's mid-range workhorse since 2014.[^kw] What it
+doesn't have is a spectrum scope on the radio, and at around $1,840 that's the
+whole argument, both ways.
+
+<a class="btn btn--buy" href="https://www.amazon.com/s?k=kenwood+ts-590sg+ham+radio&tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The CW operator's and contester's pick.** Down-conversion receiver with narrow
+roofing filters on the crowded bands = elite close-in dynamic range; **QSK
+break-in that CW operators call the best made**; rock-solid reliability; a
+dedicated RX antenna input. **No built-in scope or waterfall** — a PC runs the
+free ARCP-590G scope, but in the SDR era that's the deal-breaker for many at
+**~$1,840**. **Part 97 license to transmit; none to listen.** See the full
+rankings in [best ham radio base stations](/best-ham-radio-base-stations/).
+</div>
+
+## Overview
+
+The TS-590SG is the 2014 refresh of the 2010 TS-590S, and in 2026 it's still
+Kenwood's only current mid-range HF base — a long production run that tells you
+how right they got the fundamentals. On the crowded bands (160/80/40/20/15 m in
+narrow modes) it switches to a **down-conversion
+[superheterodyne](/reference/superheterodyne-receiver/)** architecture: an
+11.374 MHz first IF with 500 Hz and 2.7 kHz roofing filters doing real
+selection before the 32-bit DSP. That's the same design philosophy that makes
+the [FTDX10](/reference/yaesu-ftdx10/) measure so well, and it's why a
+weekend-contest 40 m, wall-to-wall with kilowatts, stays copyable on this radio
+when cheaper front ends fold.
+
+The catch is the front panel: a conventional segmented LCD, no scope, no
+[waterfall](/reference/waterfall-display/). Kenwood's free ARCP-590G software
+draws a scope on a connected PC, but there is no panadapter in the box. The
+community's verdict has been stable for a decade: *buy it for CW and
+contesting; skip it if you want to see the band.* We agree.
+
+**License note:** transmitting requires an FCC amateur license (Part 97,
+Technician minimum; General for most HF). Listening — on this or any receiver —
+requires none.
+
+## Bands, modes &amp; power
+
+- **TX:** 160–6 m, **100 W**, [SSB](/reference/single-sideband/),
+  [CW](/reference/morse-code/), FSK, AM, FM.
+- **RX:** 0.13–30 MHz general coverage plus 50–54 MHz.
+- **Receiver:** down-conversion superhet with 500 Hz/2.7 kHz roofing filters on
+  the contest bands (up-conversion elsewhere), 32-bit IF DSP, **dedicated RX
+  antenna input** — a port the IC-7300 and FTDX10 both lack.
+- **Tuner:** built-in ATU. **CW:** full QSK break-in, widely called the best in
+  any current radio.
+- **I/O:** USB audio + CAT, a real COM port for legacy station gear. 13.8 V DC
+  at ~20.5 A.
+
+## What owners praise and gripe about
+
+Praise: the receiver, the QSK, clean transmit audio, and a reliability record
+that borders on boring. Gripes: the dated two-line display and austere UI, audio
+from a small top-firing speaker, and — above all — no panadapter at a price
+where every SDR competitor ships one. Nothing on the gripe list touches
+performance; all of it touches experience.
+
+## Programming &amp; software
+
+Kenwood's PC ecosystem is free and genuinely good: **ARCP-590G** for control and
+the PC scope, **ARHP-590G** for remote operation over a network. USB carries
+CAT and audio for WSJT-X and [FT8](/reference/ft8/). CHIRP has live-mode Kenwood
+support that covers the TS-590 family — though verify the current CHIRP-next
+model list before counting on it; in practice HF operators here live in ARCP,
+N1MM, and RT Systems anyway. Amazon carries only accessories for this radio (our
+button is a tagged search); buy the radio itself from a ham dealer.
+
+## GopherTrunk alternative
+
+GopherTrunk is receive-only and won't key a transmitter — it complements a
+TS-590SG rather than replacing it. Before you spend $1,840, a ~$30
+[RTL-SDR](/reference/rtl-sdr/) running free GopherTrunk tells you what's active
+locally and **records/logs everything it hears**, which no transceiver does. And
+after you buy: an SDR makes a fine panadapter-adjacent band monitor for exactly
+the scope this radio lacks. Hardware picks:
+[best SDR for GopherTrunk](/best-sdr-for-gophertrunk/) and, for HF listening
+specifically, [best HF SDR](/best-hf-sdr/).
+
+## Who it's for
+
+- **Buy the TS-590SG** if you're a CW operator or contester who values dynamic
+  range, QSK, and an RX antenna port over a waterfall.
+  <a class="btn btn--buy" href="https://www.amazon.com/s?k=kenwood+ts-590sg+ham+radio&tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [FTDX10](/reference/yaesu-ftdx10/)** for comparable receiver
+  performance *with* a modern touchscreen scope at a similar price, or the
+  [IC-7300](/reference/icom-ic-7300/) for less money and the best UI.
+- **Nostalgic for big Kenwood iron?** The vintage
+  [TS-940S](/reference/kenwood-ts-940s/) is the classic-station route. Rankings:
+  [best ham radio base stations](/best-ham-radio-base-stations/).
+
+## Sources
+
+[^kw]: [Kenwood TS-590SG product page](https://www.kenwood.com/usa/com/amateur/ts-590sg/) — JVCKENWOOD USA, on the down-conversion receiver with 500 Hz/2.7 kHz roofing filters, 32-bit IF DSP, band coverage, built-in ATU, RX antenna input, and the ARCP-590G/ARHP-590G software.

--- a/docs/reference/kenwood-ts-590sg.md
+++ b/docs/reference/kenwood-ts-590sg.md
@@ -106,6 +106,13 @@ from a small top-firing speaker, and — above all — no panadapter at a price
 where every SDR competitor ships one. Nothing on the gripe list touches
 performance; all of it touches experience.
 
+Value math worth running: used TS-590SGs go for **$1,100–1,300**, and the older
+TS-590S — the 2010 original this radio refines — sells for less still while
+keeping the same fundamental receiver design. For a CW operator on a budget, a
+used 590S is one of the quiet bargains of the hobby; for everyone else, the
+gap between a used SG and a new one is small enough that the warranty usually
+wins.
+
 ## Programming &amp; software
 
 Kenwood's PC ecosystem is free and genuinely good: **ARCP-590G** for control and

--- a/docs/reference/kenwood-ts-940s.md
+++ b/docs/reference/kenwood-ts-940s.md
@@ -1,0 +1,153 @@
+---
+slug: kenwood-ts-940s
+title: Kenwood TS-940S
+entry_type: hardware
+category: ham-radios
+description: "The Kenwood TS-940S is the 1985 flagship HF transceiver that still anchors classic stations — silky analog receiver, battleship build, built-in AC supply — used-market only at roughly $400–800, with well-documented aging faults to check first."
+keywords: Kenwood TS-940S, TS-940S review, TS-940S for sale, vintage HF transceiver, classic ham radio, TS-940S dots display, TS-940S power supply repair, used HF radio, Kenwood flagship 1985, TS-940S buying guide
+aka: [TS-940S, TS-940, TS-940S AT]
+autolink: true
+affiliate: true
+product:
+  name: "Kenwood TS-940S"
+  brand: Kenwood
+  category: Ham radio base station (vintage HF transceiver)
+  seller: eBay
+  itemCondition: used
+  lowPrice: "400"
+  highPrice: "800"
+  url: "https://www.ebay.com/sch/i.html?_nkw=kenwood+ts-940s"
+infobox:
+  - { label: Type, value: "Vintage HF base transceiver (analog superhet)" }
+  - { label: Bands, value: "160–10 m TX; 0.15–30 MHz RX" }
+  - { label: Modes, value: "SSB, CW, AM, FM, FSK" }
+  - { label: Power, value: "100 W+ (40 W AM); built-in AC supply" }
+  - { label: Programming, value: "None as shipped (optional IF-10 serial kit)" }
+  - { label: Price, value: "around $400–800 used" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.ebay.com/sch/i.html?_nkw=kenwood+ts-940s\" rel=\"nofollow noopener\">Find on eBay &rarr;</a>" }
+see_also: [yaesu-ft-1000mp, kenwood-ts-590sg, icom-ic-718, icom-ic-7300, rtl-sdr, superheterodyne-receiver]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "Best ham radio base stations", url: /best-ham-radio-base-stations/ }
+cite_urls:
+  - https://www.rigpix.com/kenwood/ts940s.htm
+  - https://www.w3afc.com/uploads/1/3/2/2/132249121/ts-940_troubleshooting_hints_and_updated_adjustment_procedures-_version_8.00_wip.pdf
+faq:
+  - q: "Is the Kenwood TS-940S still a good radio?"
+    a: "As a classic-station centerpiece, yes — the analog receiver is still praised as silky, the audio is superb, and the build is battleship-grade. As your only radio it's a project: expect to deal with (or pay for) recapping and connector reflow on a 40-year-old flagship."
+  - q: "What is the TS-940S 'dots display' problem?"
+    a: "The signature TS-940 fault: the frequency display shows a row of dots instead of digits, meaning the PLL has unlocked. It traces to the PLL/VCO boards, failing board connectors, and cold solder joints; the standard fix is a resolder and VCO re-peak, and it's well documented in the W3AFC troubleshooting guide."
+  - q: "How much should I pay for a TS-940S?"
+    a: "Roughly $400–800 depending on condition and whether it's the AT (internal tuner) version — a TS-940S AT sold on eBay for $574 in July 2026, and serviced units with accessories ask around $800. Pay the top of the range only for a recapped, serviced example from a known tech."
+  - q: "What should I check before buying a TS-940S?"
+    a: "Power supply health (aging electrolytics — recap kits are a cottage industry), the dots display/PLL fault, dial drift or erratic frequency (same PLL/VCO and connector issues), and the internal tuner on AT units. Assume an unserviced unit needs a recap and connector reflow, and price accordingly."
+  - q: "Do I need a license to use a TS-940S?"
+    a: "To transmit, yes — an FCC amateur license (Part 97, Technician minimum; General for most HF phone). Listening on its 150 kHz–30 MHz general-coverage receiver requires no license."
+---
+**The Kenwood TS-940S** was Kenwood's flagship from 1985 to about 1991 and it
+still earns its bench space: a triple-conversion analog
+[superheterodyne](/reference/superheterodyne-receiver/) whose receiver owners
+describe as *silky*, superb transmit and receive audio, a heavy cast chassis, and
+a built-in AC supply — no external 13.8 V brick, just a power cord.[^rigpix]
+It has been **out of production for over three decades**: the used market —
+eBay, hamfests, QRZ swapmeet — is where it lives, at roughly **$400–800**.
+
+<a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=kenwood+ts-940s" rel="nofollow noopener">Find on eBay &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The classic-Kenwood station centerpiece — buy it serviced or budget to
+service it.** Silky analog receiver with VBT/Slope Tune IF shaping, 100 W+,
+built-in AC supply, ~18 kg of 1985 flagship build. **Used only, ~$400–800**
+(a TS-940S AT sold for $574 in July 2026). **Known faults are the whole buying
+game:** aging power-supply electrolytics, the "dots display" PLL fault, dial
+drift, and AT-tuner issues — all well documented, all fixable. **Part 97
+license to transmit; none to listen.** Where it ranks:
+[best ham radio base stations](/best-ham-radio-base-stations/).
+</div>
+
+## Overview
+
+In 1985 the TS-940S was the radio the others were measured against, and the
+things that made it flagship-grade are the things that survive: conservative
+ratings (100 W+ output), Kenwood's VBT and Slope Tune analog IF shaping that
+lets you carve a passband by feel, optional crystal filters, a fluorescent
+display flanked by real meters, and a chassis built like a transformer vault.
+The AT version adds a built-in antenna tuner. There is no computer interface as
+shipped (an optional IF-10 kit added vintage serial control), no scope, and no
+DSP — this is deliberate, tactile, analog operating.
+
+Superseded by the TS-950 around 1991, it's been used-market-only ever since.
+No dealer sells it new; parts are hobbyist and aftermarket (eBay capacitor kits
+are literally a cottage industry). That's not a warning against buying one —
+it's the frame for *how* to buy one, below.
+
+**License note:** transmitting requires an FCC amateur license (Part 97,
+Technician minimum, General for most HF privileges). Listening requires none.
+
+## Bands, modes &amp; power
+
+- **TX:** 160–10 m, **100 W+** (rated conservatively; 40 W AM).
+- **RX:** 150 kHz–30 MHz general coverage.
+- **Modes:** [SSB](/reference/single-sideband/), [CW](/reference/morse-code/),
+  AM, FM, FSK.
+- **Receiver:** triple-conversion analog superhet, VBT/Slope Tune IF shaping,
+  optional filters.
+- **Power:** built-in **AC supply** — no external 13.8 V needed. Weight ~18 kg.
+
+## Buying used: what to check
+
+This is the section that matters. The TS-940S's aging faults are unusually
+well documented — the W3AFC troubleshooting guide is excellent — and they
+cluster in four places:[^w3afc]
+
+1. **Internal power supply / electrolytics.** Forty-year-old capacitors are the
+   number-one issue; recap kits are widely sold, and some owners swap in modern
+   switching supplies. Ask whether a recap has been done, by whom, and when.
+2. **The "dots display" fault.** A row of dots instead of a frequency readout
+   means the PLL has unlocked — the signature TS-940 ailment, traced to the
+   PLL/VCO boards, failing connectors, and cold solder joints. The standard fix
+   is a connector reflow/resolder and VCO re-peak.
+3. **Dial drift or erratic frequency** — the same PLL/VCO and board-connector
+   roots as the dots fault, same fixes.
+4. **The AT tuner** on AT versions — exercise it across bands before money
+   changes hands.
+
+Pricing follows service history: a TS-940S AT sold on eBay for **$574** in July
+2026; asking prices run to **~$800** for serviced units with accessories
+(EU sales €650–1,000). A "recapped, reflowed, serviced by a known tech" example
+is worth the top of the range; an unserviced attic unit should be priced with a
+recap and reflow already subtracted. Working against you: no factory support.
+Working for you: through-hole construction, superb documentation, and a
+community that has fixed all of this a thousand times.
+
+## GopherTrunk alternative
+
+GopherTrunk receives; it can't transmit — so it's no substitute for a
+TS-940S, but it's the ideal sidekick to one. A ~$30
+[RTL-SDR](/reference/rtl-sdr/) running free GopherTrunk shows you what's active
+locally — and **records and logs** it — before you hunt the used market, and
+afterward it gives your analog classic the one thing it never had: a modern
+[waterfall](/reference/waterfall-display/) view of the band beside it. Start
+with [best SDR for GopherTrunk](/best-sdr-for-gophertrunk/) or, for HF
+listening, [best HF SDR](/best-hf-sdr/).
+
+## Who it's for
+
+- **Buy the TS-940S** if you want a classic-station centerpiece with a silky
+  analog receiver and you're comfortable owning (or commissioning) vintage
+  service work.
+  <a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=kenwood+ts-940s" rel="nofollow noopener">Find on eBay &rarr;</a>
+- **Buy the [FT-1000MP](/reference/yaesu-ft-1000mp/)** instead if your classic
+  leanings run to contest iron with dual receive, or the modern
+  [TS-590SG](/reference/kenwood-ts-590sg/) for today's Kenwood receiver in a
+  supported radio.
+- **Not a project person?** A used [IC-7300](/reference/icom-ic-7300/) costs
+  similar money serviced-equivalent and just works. Full rankings:
+  [best ham radio base stations](/best-ham-radio-base-stations/).
+
+## Sources
+
+[^rigpix]: [Kenwood TS-940S — RigPix](https://www.rigpix.com/kenwood/ts940s.htm) — specifications: bands, modes, power, receiver architecture, built-in AC supply, and the AT tuner variant.
+[^w3afc]: [TS-940 Troubleshooting Hints and Updated Adjustment Procedures (W3AFC, v8.00)](https://www.w3afc.com/uploads/1/3/2/2/132249121/ts-940_troubleshooting_hints_and_updated_adjustment_procedures-_version_8.00_wip.pdf) — the standard service reference for the power supply/recap work, the "dots display" PLL fault, and drift/connector repairs.

--- a/docs/reference/kenwood-ts-940s.md
+++ b/docs/reference/kenwood-ts-940s.md
@@ -83,6 +83,13 @@ No dealer sells it new; parts are hobbyist and aftermarket (eBay capacitor kits
 are literally a cottage industry). That's not a warning against buying one —
 it's the frame for *how* to buy one, below.
 
+Don't expect modern conveniences: there's no scope, no DSP, and computer
+control exists only through the optional IF-10 serial kit, so logging and
+digital modes mean audio cables and manual frequency entry. Owners who love
+this radio love it *because* of that — operating one is all knobs, meters, and
+receiver — and it pairs naturally with a modern SDR doing the watching (more
+on that below).
+
 **License note:** transmitting requires an FCC amateur license (Part 97,
 Technician minimum, General for most HF privileges). Listening requires none.
 

--- a/docs/reference/qyt-kt-8900d.md
+++ b/docs/reference/qyt-kt-8900d.md
@@ -1,0 +1,125 @@
+---
+slug: qyt-kt-8900d
+title: QYT KT-8900D
+entry_type: hardware
+category: ham-radios
+description: "The QYT KT-8900D is the cheapest way to put 20+ watts of 2m/70cm FM in a vehicle — a ~$100 quad-standby mini mobile that CHIRP programs, with the QC lottery and marginal spectral purity of its class."
+keywords: QYT KT-8900D, KT-8900D review, cheapest mobile ham radio, budget dual band mobile, quad standby mobile radio, mini mobile transceiver, Chinese mobile ham radio, CHIRP KT8900D, best cheap ham radio 2026
+aka: [KT-8900D, KT8900D]
+autolink: true
+affiliate: true
+product:
+  name: "QYT KT-8900D"
+  brand: QYT
+  category: Mobile ham transceiver
+  lowPrice: "90"
+  highPrice: "110"
+  url: https://www.amazon.com/dp/B01MYY5JWF?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: Mini dual-band mobile transceiver }
+  - { label: Bands, value: "2m / 70cm (quad standby)" }
+  - { label: Modes, value: "FM only (no digital)" }
+  - { label: Power, value: "~25 W VHF / ~20 W UHF (claimed)" }
+  - { label: Programming, value: "CHIRP (community standard) / QYT software" }
+  - { label: Price, value: around $100 }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B01MYY5JWF?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [btech-uv-25x2, icom-ic-2730a, kenwood-tm-v71a, rtl-sdr, police-scanner]
+related_lessons:
+  - { title: "What is trunked radio?", url: /learn/digital-trunking/ }
+related_reading:
+  - { title: "Best SDR for GopherTrunk", url: /best-sdr-for-gophertrunk/ }
+cite_urls:
+  - https://www.twowayradio.us/product/qyt-kt-8900d-25w-vehicle-mounted-two-way-radio-mini-mobile-radio/
+faq:
+  - q: "Is the QYT KT-8900D any good?"
+    a: "As a ~$100 beater or backup, yes — it's the cheapest way to put 20+ watts in a vehicle, and CHIRP programs it easily. As a primary rig for demanding use, no: measured power often lands below spec, spectral purity is marginal on some units, and QC is a lottery. Buy it knowing exactly what it is."
+  - q: "What is quad standby on the KT-8900D?"
+    a: "The display shows four frequencies at once and the radio watches all four, receiving whichever goes active (one at a time). It's genuinely handy for keeping a couple of repeaters plus two simplex channels in view."
+  - q: "Does the KT-8900D work with CHIRP?"
+    a: "Yes — CHIRP has a KT8900D driver and is the community-standard way to program it (the radio is also sold rebadged as the CRT 279 UV). QYT's factory software exists but CHIRP is the saner route."
+  - q: "Is there a GMRS version of the KT-8900D?"
+    a: "Yes, and that's a buying trap: a GMRS-labeled variant exists under a separate listing. For ham use, make sure you're buying the amateur 2m/70cm model, not the GMRS one."
+  - q: "Do I need a license for the KT-8900D?"
+    a: "Transmitting on ham bands requires an FCC amateur license (Part 97, Technician minimum). Listening requires no license — and a $30 RTL-SDR with free GopherTrunk is a better listening tool than this radio anyway."
+---
+**The QYT KT-8900D** is the cheapest way to put **20-plus watts** of 2m/70cm FM
+in a vehicle: a palm-sized mobile with a **quad-standby** display, 200
+memories, and CHIRP support for around **$100**.[^qyt] It earns a slot on our
+mobile list as the **most affordable** pick — and it keeps that slot only
+because we're upfront that this is a beater-grade radio, not a primary rig.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B01MYY5JWF?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The most affordable real mobile.** ~25 W VHF / ~20 W UHF claimed, quad-watch
+display, 200 memories, palm-sized, under 10 A draw, **CHIRP-programmable**.
+**~$90–110** (Amazon pricing fluctuates). The honest ledger: measured power
+often below spec, **marginal spurious/harmonic performance on some units**,
+receiver desense near strong signals, tinny speaker, QC lottery, display
+washes out in sunlight. **Don't buy the GMRS-labeled variant by mistake.**
+Fine as a beater/backup; not for demanding use. License to transmit; none to
+listen.
+</div>
+
+## Overview
+
+QYT's long-running budget mobile does one thing genuinely well: it puts real
+mobile power in a vehicle for handheld money. The **quad standby** display —
+four frequencies visible, one active at a time — is its signature feature and
+is legitimately handy for watching two repeaters and two simplex channels at
+once. The chassis is tiny, draw is under 10 A, receive covers 136–174 and
+400–480 MHz, and there is no detachable face, no GPS/APRS, no digital modes,
+and no cross-band repeat.
+
+Now the part most listings skip. Community and lab-test experience with
+QYT-class radios is consistent: **measured output often lands below the claimed
+spec**, and **spurious-emission and harmonic performance is marginal on some
+units** — a recurring lab complaint for QYT and its rebadged clones, and your
+responsibility as the licensee. Add receiver desense near strong signals, a
+tinny speaker, a "D" display that washes out in sunlight, and build-quality
+roulette between units. Prices float around $90–110 on Amazon. One more trap:
+a **GMRS-labeled variant** of this radio exists under a separate listing —
+make sure you buy the amateur 2m/70cm model.
+
+## Modes &amp; coverage
+
+- **Analog FM only** — no [DMR](/reference/dmr/), [D-STAR](/reference/d-star/),
+  [C4FM](/reference/c4fm/), or [APRS](/reference/aprs/).
+- **Quad standby** across RX 136–174 / 400–480 MHz; 200 memories.
+- Claimed ~25 W VHF / ~20 W UHF — treat as optimistic.
+
+## Programming
+
+**CHIRP** is the community standard (KT8900D driver; the radio is also sold
+rebadged as the CRT 279 UV). QYT's own Windows software exists, but CHIRP is
+the saner, better-documented path and rescues you from the front-panel menus.
+
+## GopherTrunk alternative
+
+GopherTrunk **receives; it cannot transmit** — the KT-8900D's one clear win.
+But if what draws you to a $100 radio is mostly *listening*, stop: a ~$30
+[RTL-SDR](/reference/rtl-sdr/) running free GopherTrunk out-receives this
+radio's desense-prone front end, covers the digital modes it can't touch, and
+**records and logs every call**. Monitor your local repeaters free, figure out
+what's active, and then decide whether the transmitter you buy should be this
+one or something better. Listening requires no license; transmitting on ham
+bands requires an FCC amateur license (Part 97, Technician class minimum).
+See [best SDR for GopherTrunk](/best-sdr-for-gophertrunk/).
+
+## Who it's for
+
+- **Buy the KT-8900D** as a glovebox backup, a farm-truck beater, a first
+  experiment, or a loaner — uses where $100 and "mostly works" is the right
+  call.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B01MYY5JWF?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [BTECH UV-25X2](/reference/btech-uv-25x2/)** (~$130) for a
+  noticeably better-sorted radio in the same budget class.
+- **Buy the [Icom IC-2730A](/reference/icom-ic-2730a/)** (~$330) or a used
+  [Kenwood TM-V71A](/reference/kenwood-tm-v71a/) when the radio is your
+  primary — the receiver difference is not subtle.
+- Everything ranked: [the 10 best mobile ham radios](/best-mobile-ham-radios/).
+
+## Sources
+
+[^qyt]: [QYT KT-8900D dealer reference page](https://www.twowayradio.us/product/qyt-kt-8900d-25w-vehicle-mounted-two-way-radio-mini-mobile-radio/) — on the quad-standby display, claimed power output, frequency coverage, and mini-mobile form factor (QYT's own site is intermittently available).

--- a/docs/reference/xiegu-g90.md
+++ b/docs/reference/xiegu-g90.md
@@ -1,0 +1,147 @@
+---
+slug: xiegu-g90
+title: Xiegu G90
+entry_type: hardware
+category: ham-radios
+description: "The Xiegu G90 is a 20W HF SDR transceiver with a famously wide-range built-in antenna tuner and a working waterfall for around $450 — the cheapest real path onto HF and a POTA favorite."
+keywords: Xiegu G90, Xiegu G90 review, budget HF transceiver, cheapest HF radio, 20 watt HF radio, POTA radio, portable HF transceiver, G90 antenna tuner, first HF radio, best budget ham radio 2026
+aka: [G90]
+autolink: true
+affiliate: true
+product:
+  name: "Xiegu G90"
+  brand: Xiegu
+  category: Ham radio base station (HF transceiver)
+  lowPrice: "445"
+  highPrice: "450"
+  url: https://www.amazon.com/dp/B08X6Z6KN2?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: "HF transceiver (SDR, detachable face)" }
+  - { label: Bands, value: "160–10 m TX; 0.5–30 MHz RX" }
+  - { label: Modes, value: "SSB, CW, AM (10 m FM varies by firmware)" }
+  - { label: Power, value: "20 W" }
+  - { label: Programming, value: "CHIRP, Icom-style CAT; no USB soundcard" }
+  - { label: Price, value: "around $450" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B08X6Z6KN2?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [icom-ic-7300, yaesu-ft-891, icom-ic-718, rtl-sdr, antenna-tuner, waterfall-display]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "Best ham radio base stations", url: /best-ham-radio-base-stations/ }
+cite_urls:
+  - https://www.radioddity.com/products/xiegu-g90-hf-transceiver
+faq:
+  - q: "Is the Xiegu G90 a good first HF radio?"
+    a: "Yes — it's the cheapest radio we'd actually recommend for getting on HF. Around $450 buys 20 W SSB/CW, a genuinely usable SDR receiver with a small waterfall, and a built-in tuner that matches almost anything. Its limits are real (20 W, tiny screen, no USB audio), but nothing else does this much for this little."
+  - q: "Is 20 watts enough for SSB?"
+    a: "Usually, with honest caveats. CW and FT8 at 20 W work the world; SSB in poor conditions is work, and you'll lose some pileups to 100 W stations. POTA activators run G90s daily because the wide-range tuner plus 20 W into a wire gets contacts made."
+  - q: "How good is the G90's built-in antenna tuner?"
+    a: "It's the radio's killer feature — famously wide-range, happily matching end-feds, whips, and compromised portable wires that would stop the narrow tuners in radios costing three times more. Expect some relay clatter while it tunes."
+  - q: "Does the Xiegu G90 do FT8?"
+    a: "Yes, but it needs help: there's no built-in USB soundcard, so digital modes require an external audio interface (Xiegu's CE-19 expansion or a third-party dongle) plus CAT. Budget another $30–60 and some cabling patience."
+  - q: "Do I need a license to use the G90?"
+    a: "To transmit, yes — an FCC amateur license (Part 97, Technician minimum; General for most HF phone). Listening requires no license, and a $30 RTL-SDR running free GopherTrunk is an even cheaper way to start listening."
+---
+**The Xiegu G90** is the cheapest real ticket onto HF: around $450 buys a 20 W
+SSB/CW transceiver with a 24-bit SDR architecture, a small but working spectrum
+[waterfall](/reference/waterfall-display/), and — the killer feature — a built-in
+[antenna tuner](/reference/antenna-tuner/) with a matching range the community
+summarizes as "it'll tune a wet noodle."[^rd] It gives up power, screen size,
+and refinement to the Japanese rigs, and it doesn't care: nothing near its price
+does half as much.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B08X6Z6KN2?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Most affordable pick** in
+[best ham radio base stations](/best-ham-radio-base-stations/). **~$450** buys
+160–10 m at **20 W**, a usable SDR receiver with waterfall, a detachable
+faceplate, and a **wide-range internal tuner** that matches the compromise
+antennas beginners and POTA operators actually have. The trades: 20 W ceiling,
+1.8-inch screen, no USB soundcard (FT8 needs a dongle), strong-signal overload
+vs the big rigs, importer-level support. **Part 97 license to transmit; none to
+listen** — a [$30 RTL-SDR + GopherTrunk](/best-sdr-for-gophertrunk/) is the
+zero-commitment way to scout first.
+</div>
+
+## Overview
+
+Xiegu introduced the G90 in 2019 and it has been the eHam budget favorite since:
+a Chinese-built HF rig, sold in the US through Radioddity, that undercuts
+everything from Japan by half while delivering the two things a new HF operator
+actually needs — a receiver good enough to hear real DX, and a tuner forgiving
+enough to work with whatever wire they managed to hang. The detachable faceplate
+and ~8 A draw make it equally at home as a desk base, a trail radio, or a truck
+rig.
+
+Honesty about the ceiling: **20 W** is a real constraint on SSB when conditions
+sag — [CW](/reference/morse-code/) and [FT8](/reference/ft8/) shrug it off, but
+phone operators will lose pileups to 100 W stations. The 1.8-inch screen shows a
+functional ~48 kHz waterfall, not an [IC-7300](/reference/icom-ic-7300/)
+panorama. The receiver is genuinely usable but more prone to strong-signal
+overload and birdies than the Japanese rigs. Firmware and QC vary batch to batch
+in typical Xiegu fashion, and support means the importer, not a national service
+network. Every one of those trades is priced in — twice over.
+
+**License note:** transmitting takes an FCC amateur license (Part 97 —
+Technician class minimum, General for most HF voice). Listening takes none.
+
+## Bands, modes &amp; power
+
+- **TX:** 160–10 m ham bands, **20 W**. **RX:** 0.5–30 MHz.
+- **Modes:** [SSB](/reference/single-sideband/), CW, AM. Some sellers list 10 m
+  FM — treat that as firmware-dependent and verify on your unit. No digital
+  voice.
+- **Architecture:** 24-bit SDR (digital IF) with spectrum/waterfall display.
+- **Tuner:** built-in, famously wide-range — end-feds, whips, and compromise
+  portable antennas are its home turf.
+- **Power:** 13.8 V DC at ~8 A max — small-battery friendly.
+
+## What owners praise and gripe about
+
+Praise: astonishing capability per dollar, the tuner, a receiver that hears what
+it should, and a form factor that goes anywhere — it's arguably *the* POTA
+radio. Gripes: the 20 W ceiling on SSB, the tiny screen, fan and tuner-relay
+noise, no native USB audio, and the batch-to-batch firmware/QC variability that
+comes with the price. None of the gripes are surprises; all of them are
+documented in a very large, very active owner community.
+
+## Programming &amp; software
+
+CAT control uses an Icom-like protocol subset, so most logger/digimode software
+talks to it. **CHIRP lists G90 support** for memory programming. The missing
+piece is audio: there's **no built-in USB soundcard**, so FT8 and friends need
+the CE-19 expansion port with an external interface or a third-party dongle.
+Firmware updates come through Xiegu/Radioddity tools and are worth applying —
+they've fixed real issues over the years.
+
+## GopherTrunk alternative
+
+GopherTrunk receives; it can't transmit — so it isn't a G90 substitute even at
+a tenth the price. It *is* the cheaper first step. A ~$30
+[RTL-SDR](/reference/rtl-sdr/) running free GopherTrunk lets you monitor local
+repeaters and digital ham traffic, **recording and logging** everything, so you
+learn what's active before licensing or buying. If your G90 budget is genuinely
+the limit, spend $30 first and put the rest toward antenna wire — the antenna
+matters more than the radio. Picks:
+[best SDR for GopherTrunk](/best-sdr-for-gophertrunk/) and
+[best HF SDR](/best-hf-sdr/).
+
+## Who it's for
+
+- **Buy the G90** as your first HF radio, your POTA/portable rig, or the
+  cheapest way to find out whether HF grabs you — knowing you may upgrade the
+  radio later and keep it as the field unit.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B08X6Z6KN2?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Spend up** to the [FT-891](/reference/yaesu-ft-891/) (~$650) for 100 W in a
+  similar footprint (minus the tuner), or the
+  [IC-7300](/reference/icom-ic-7300/) (~$1,040) for the full base-station
+  experience.
+- **Skip the [IC-718](/reference/icom-ic-718/)** at new-old-stock prices — the
+  G90 outclasses it for half the money. Rankings:
+  [best ham radio base stations](/best-ham-radio-base-stations/).
+
+## Sources
+
+[^rd]: [Xiegu G90 — Radioddity product page](https://www.radioddity.com/products/xiegu-g90-hf-transceiver) — the US importer, on the 24-bit SDR architecture, 20 W output, 0.5–30 MHz receive, built-in wide-range ATU, detachable faceplate, and CE-19 digital-mode expansion.

--- a/docs/reference/xiegu-g90.md
+++ b/docs/reference/xiegu-g90.md
@@ -107,6 +107,14 @@ noise, no native USB audio, and the batch-to-batch firmware/QC variability that
 comes with the price. None of the gripes are surprises; all of them are
 documented in a very large, very active owner community.
 
+The detachable faceplate deserves its own mention: with the head remoted, the
+body tucks under a seat or into a pack frame, which is why G90s turn up as
+truck rigs and bicycle-mobile stations as often as desk radios. Between that,
+the ~8 A draw, and the tuner, it's the rare radio where the "base station"
+label undersells it — it's really a go-anywhere HF station that happens to be
+cheap. Watch Radioddity's coupon churn before paying sticker; the street price
+moves.
+
 ## Programming &amp; software
 
 CAT control uses an Icom-like protocol subset, so most logger/digimode software

--- a/docs/reference/yaesu-ft-1000mp.md
+++ b/docs/reference/yaesu-ft-1000mp.md
@@ -93,7 +93,7 @@ Technician minimum, General for most HF). Listening takes none.
 ## Bands, modes &amp; power
 
 - **TX:** 160–10 m; **100 W** (original/Field), **200 W PEP** (Mark V, with
-  75 W class-A mode). **RX:** 100 kHz–30 MHz.
+  75 W class-A mode). **RX:** 100 kHz–30 MHz.[^rigpix]
 - **Modes:** [SSB](/reference/single-sideband/), [CW](/reference/morse-code/),
   AM, FM, AFSK.
 - **Receivers:** quad-conversion superhet main + genuine sub receiver;

--- a/docs/reference/yaesu-ft-1000mp.md
+++ b/docs/reference/yaesu-ft-1000mp.md
@@ -123,7 +123,17 @@ repairability, and prices reward patience. Expect originals toward the **$600**
 end, clean 200 W Mark Vs toward and above **$1,200**, with an $800 like-new
 Mark V Field (with filters) as a recent reference listing — but aggregate
 sold-price data is genuinely thin, so **check current eBay sold listings**
-before anchoring on any number, ours included.
+before anchoring on any number, ours included. Filters move value too: units
+loaded with the optional Collins mechanical filters are worth a real premium,
+because sourcing them separately now is its own treasure hunt.
+
+## Programming &amp; software
+
+Station integration is vintage but workable: Yaesu CAT over **RS-232** is
+still supported by N1MM and Ham Radio Deluxe legacy drivers, so contest
+logging and basic frequency control work with a cheap USB-serial adapter.
+There's no soundcard, no CHIRP support, and no firmware to update — digital
+modes mean an external audio interface, the same as every radio of its era.
 
 ## GopherTrunk alternative
 

--- a/docs/reference/yaesu-ft-1000mp.md
+++ b/docs/reference/yaesu-ft-1000mp.md
@@ -1,0 +1,155 @@
+---
+slug: yaesu-ft-1000mp
+title: Yaesu FT-1000MP
+entry_type: hardware
+category: ham-radios
+description: "The Yaesu FT-1000MP is the last great analog Yaesu — a contest/DX legend with a true dual receiver, filter banks, and tank build, produced 1996–2006 across three variants and now used-market only at roughly $600–1,200."
+keywords: Yaesu FT-1000MP, FT-1000MP review, FT-1000MP Mark V, Mark V Field, vintage contest HF transceiver, dual receive HF radio, classic ham radio, used HF transceiver, FT-1000MP for sale, FT-1000MP buying guide
+aka: [FT-1000MP, "FT-1000MP Mark V", "Mark V Field"]
+autolink: true
+affiliate: true
+product:
+  name: "Yaesu FT-1000MP"
+  brand: Yaesu
+  category: Ham radio base station (vintage HF transceiver)
+  seller: eBay
+  itemCondition: used
+  lowPrice: "600"
+  highPrice: "1200"
+  url: "https://www.ebay.com/sch/i.html?_nkw=yaesu+ft-1000mp"
+infobox:
+  - { label: Type, value: "Vintage HF contest transceiver (quad-conversion superhet)" }
+  - { label: Bands, value: "160–10 m TX; 0.1–30 MHz RX" }
+  - { label: Modes, value: "SSB, CW, AM, FM, AFSK" }
+  - { label: Power, value: "100 W (200 W PEP Mark V)" }
+  - { label: Programming, value: "Vintage CAT over RS-232 (N1MM/HRD legacy drivers)" }
+  - { label: Price, value: "around $600–1,200 used, by variant" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.ebay.com/sch/i.html?_nkw=yaesu+ft-1000mp\" rel=\"nofollow noopener\">Find on eBay &rarr;</a>" }
+see_also: [kenwood-ts-940s, yaesu-ftdx10, icom-ic-7610, kenwood-ts-590sg, rtl-sdr, superheterodyne-receiver]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "Best ham radio base stations", url: /best-ham-radio-base-stations/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Yaesu_FT-1000MP
+  - https://www.rigpix.com/yaesu/ft1000mp.htm
+faq:
+  - q: "Is the Yaesu FT-1000MP still worth buying?"
+    a: "For a classic contest/DX station, yes — the true dual receiver, filter banks, and build quality still deliver competitive CW and SSB performance, and it has a deserved cult following. Buy a clean example knowing you're taking on 20-to-30-year-old electronics with no factory support."
+  - q: "What's the difference between the FT-1000MP, Mark V, and Mark V Field?"
+    a: "The original (1996) is 100 W with an internal AC supply; the Mark V (2000) is the 200 W PEP version with a 75 W class-A mode and a variable RF front-end filter, but needs the external FP-29 30 V supply; the Mark V Field (2002) returns to 100 W with the internal supply. Clean 200 W Mark Vs command the top prices."
+  - q: "How much does a used FT-1000MP cost?"
+    a: "Roughly $600–1,200 by variant and condition — originals toward the low end, clean Mark V 200 W units toward and above the top; a like-new Mark V Field with filters was listed at $800 on eHam classifieds. Aggregate sold-price data is thin, so check current eBay sold listings before treating any figure as gospel."
+  - q: "What should I check before buying an FT-1000MP?"
+    a: "Aging electrolytics in the supply and audio, dim or failing display backlighting, worn band-data switches and relays, EDSP settings loss from a dead backup battery, reference-oscillator drift wanting TCXO service, and burned-out meter lamps. On a Mark V, confirm the scarce FP-29 supply is included and healthy."
+  - q: "Do I need a license to use an FT-1000MP?"
+    a: "To transmit, yes — an FCC amateur license (Part 97, Technician minimum; General for most HF phone). Listening on its 100 kHz–30 MHz receiver requires none."
+---
+**The Yaesu FT-1000MP** is "the last great analog Yaesu" — the contest and DX
+flagship family of 1996–2006, with a **genuine second receiver** for split
+pileups, banks of selectable roofing and crystal filters (Collins mechanical
+options included), Yaesu's EDSP, and a front panel built for two-handed
+operating.[^wiki] Long **out of production**, it lives on the used market —
+eBay, hamfests, QRZ swapmeet — at roughly **$600–1,200** depending on variant
+and condition, and it remains one of the best-value serious stations in the
+hobby.
+
+<a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=yaesu+ft-1000mp" rel="nofollow noopener">Find on eBay &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Our best used/classic buy** in
+[best ham radio base stations](/best-ham-radio-base-stations/). **True dual
+receive** — main plus a real sub receiver — filter banks, tank build, and
+still-competitive CW/SSB performance for the price of a mid-range modern rig.
+Three variants: original (100 W, internal AC supply), **Mark V** (200 W PEP,
+needs the external FP-29 supply), **Mark V Field** (100 W, internal supply).
+**Used only, roughly $600–1,200** — sold-price data is thin, so verify against
+current listings. **Part 97 license to transmit; none to listen.**
+</div>
+
+## Overview
+
+Before SDRs, the way to own a pileup was two receivers and better filters than
+the other guy, and the FT-1000MP delivered both. The **quad-conversion
+[superheterodyne](/reference/superheterodyne-receiver/)** main receiver rides
+selectable filter banks; the **sub receiver is a real receiver**, not a
+glimpse — you sit on the DX with one ear and your transmit frequency with the
+other, exactly the workflow the modern [IC-7610](/reference/icom-ic-7610/)
+sells today. Add the shuttle-jog tuning ring, a built-in tuner, and an
+analog-rich panel where everything important is a knob, and you have the radio
+a generation of contesters won with.
+
+The family: the **original FT-1000MP** (1996, 100 W, internal AC supply); the
+**Mark V** (2000, 200 W PEP with a 75 W class-A mode and a variable RF
+front-end filter, powered by the external FP-29 30 V supply); and the
+**Mark V Field** (2002, back to 100 W with the internal supply). Production
+ended around 2006–07. No scope, no waterfall, no USB — this is analog
+operating with DSP assistance, and its cult following likes it that way.
+
+**License note:** transmitting takes an FCC amateur license (Part 97 —
+Technician minimum, General for most HF). Listening takes none.
+
+## Bands, modes &amp; power
+
+- **TX:** 160–10 m; **100 W** (original/Field), **200 W PEP** (Mark V, with
+  75 W class-A mode). **RX:** 100 kHz–30 MHz.
+- **Modes:** [SSB](/reference/single-sideband/), [CW](/reference/morse-code/),
+  AM, FM, AFSK.
+- **Receivers:** quad-conversion superhet main + genuine sub receiver;
+  selectable roofing/crystal filter banks with Collins mechanical options;
+  EDSP.
+- **Tuner:** built-in ATU. **Supply:** internal AC (original/Field); external
+  FP-29 (Mark V).
+
+## Buying used: what to check
+
+Yaesu factory support has ended, so you and an independent tech are the service
+department. The known aging points, all documented by the owner community:
+
+1. **Electrolytic capacitors** in the power supply and audio chains — the
+   universal vintage-rig tax.
+2. **Display backlighting** dimming or failing, plus front-end and meter lamps
+   burned out.
+3. **Band-data switch and relay wear** — exercise every band and antenna path
+   during inspection.
+4. **EDSP settings loss** from a dead backup battery, and **reference
+   oscillator drift** wanting TCXO service on a radio this age.
+5. **Mark V specifics:** confirm the **FP-29 supply** is present and healthy —
+   it's scarce and expensive on its own.
+
+The good news: this is through-hole-era construction with excellent
+repairability, and prices reward patience. Expect originals toward the **$600**
+end, clean 200 W Mark Vs toward and above **$1,200**, with an $800 like-new
+Mark V Field (with filters) as a recent reference listing — but aggregate
+sold-price data is genuinely thin, so **check current eBay sold listings**
+before anchoring on any number, ours included.
+
+## GopherTrunk alternative
+
+GopherTrunk receives and records; it cannot transmit — so it complements a
+classic station rather than replacing it. Before hunting the used market, a
+~$30 [RTL-SDR](/reference/rtl-sdr/) running free GopherTrunk tells you what's
+active in your area and **logs everything it hears**; after the FT-1000MP
+arrives, the SDR gives your all-analog legend the band
+[waterfall](/reference/waterfall-display/) it predates. Hardware picks:
+[best SDR for GopherTrunk](/best-sdr-for-gophertrunk/) and
+[best HF SDR](/best-hf-sdr/).
+
+## Who it's for
+
+- **Buy the FT-1000MP** if you want real contest/DX iron — dual receive,
+  filters, build — at used-market prices and can live with vintage upkeep.
+  <a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=yaesu+ft-1000mp" rel="nofollow noopener">Find on eBay &rarr;</a>
+- **Buy the [TS-940S](/reference/kenwood-ts-940s/)** for a cheaper,
+  single-receiver classic with its own devoted following, or the modern
+  [FTDX10](/reference/yaesu-ftdx10/) for today's Yaesu receiver with support
+  and a warranty.
+- **Need dual receive with modern everything?** That's the
+  [IC-7610](/reference/icom-ic-7610/). Full rankings:
+  [best ham radio base stations](/best-ham-radio-base-stations/).
+
+## Sources
+
+[^wiki]: [Yaesu FT-1000MP — Wikipedia](https://en.wikipedia.org/wiki/Yaesu_FT-1000MP) — on the family history and variants (original, Mark V, Mark V Field), dual-receiver architecture, EDSP, and production run.
+[^rigpix]: [Yaesu FT-1000MP — RigPix](https://www.rigpix.com/yaesu/ft1000mp.htm) — specifications: bands, modes, power by variant, quad-conversion receiver, filter options, and supply arrangements.

--- a/docs/reference/yaesu-ft-5dr.md
+++ b/docs/reference/yaesu-ft-5dr.md
@@ -1,0 +1,128 @@
+---
+slug: yaesu-ft-5dr
+title: Yaesu FT-5DR
+entry_type: hardware
+category: ham-radios
+description: "The Yaesu FT-5DR is a C4FM System Fusion handheld with built-in APRS, GPS, Bluetooth, true dual-band receive and IPX7 submersion rating — the most feature-dense ham HT under $400."
+keywords: Yaesu FT-5DR, FT-5DR review, C4FM handheld, System Fusion HT, best C4FM radio 2026, APRS handheld, IPX7 ham radio, WiRES-X node radio, Yaesu digital handheld, FT3DR successor
+aka: [FT-5DR, FT5DR, FT-5D]
+autolink: true
+affiliate: true
+product:
+  name: "Yaesu FT-5DR"
+  brand: Yaesu
+  category: Ham handheld transceiver
+  lowPrice: "370"
+  highPrice: "400"
+  url: https://www.amazon.com/dp/B09GS924GT?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: Dual-band handheld transceiver }
+  - { label: Bands, value: "TX 144/430 MHz; RX 0.5–999.9 MHz" }
+  - { label: Modes, value: "C4FM (System Fusion II), FM; APRS" }
+  - { label: Power, value: 5 W }
+  - { label: Programming, value: "Yaesu ADMS-14, RT Systems (no CHIRP)" }
+  - { label: Price, value: around $380 }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B09GS924GT?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [kenwood-th-d75a, icom-id-52a, yaesu-ft-60r, yaesu-vx-8dr, rtl-sdr, c4fm]
+related_lessons:
+  - { title: "Analog vs. digital voice", url: /learn/rf-sdr/digital-voice/ }
+  - { title: "Legal & ethical monitoring", url: /learn/rf-sdr/legal-ethical/ }
+related_reading:
+  - { title: "Police scanner vs GopherTrunk", url: /police-scanner-vs-sdr/ }
+cite_urls:
+  - https://yaesu.com/product-detail.aspx?Model=FT5DR&CatName=VHF%2FUHF+Handhelds
+faq:
+  - q: "Is the Yaesu FT-5DR still in production?"
+    a: "Yes — as of 2026 it is Yaesu's current flagship digital handheld, with active firmware updates (most recently November 2025). It replaced the FT3DR, which is now discontinued."
+  - q: "Does the FT-5DR do APRS?"
+    a: "Yes — a built-in 1200/9600 bps APRS modem with GPS. It's a solid implementation, though less deep than the Kenwood TH-D75A's (no KISS TNC for packet or Winlink work)."
+  - q: "Is the FT-5DR waterproof?"
+    a: "Yes — IPX7, rated submersible to 1 m for 30 minutes. That plus APRS, GPS, Bluetooth and C4FM at around $380 is the radio's whole argument."
+  - q: "Can I program the FT-5DR with CHIRP?"
+    a: "No — like Yaesu's other C4FM radios it isn't CHIRP-supported. Use Yaesu's free ADMS-14 software via microSD or USB, or RT Systems."
+  - q: "Do I need a ham license for the FT-5DR?"
+    a: "To transmit, yes — FCC amateur license, Technician class minimum. Listening needs no license, and its 0.5–999.9 MHz receiver with AM air band makes it a capable scanner-substitute on analog traffic."
+---
+**The Yaesu FT-5DR** is the most feature-dense ham handheld under $400:
+[C4FM](/reference/c4fm/) ([System Fusion II](/reference/system-fusion-ysf/))
+digital voice plus FM, built-in [APRS](/reference/aprs/) with GPS, Bluetooth,
+true dual-band simultaneous receive, a color touch screen, and an **IPX7**
+submersible body — roughly half the price of a
+[TH-D75A](/reference/kenwood-th-d75a/).[^yaesu] It replaced the FT3DR and is
+Yaesu's current digital flagship HT.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B09GS924GT?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The value flagship.** APRS + GPS + Bluetooth + C4FM + IPX7 + 999.9 MHz
+wideband receive for **around $380** — feature-for-dollar the strongest spec
+sheet in [our handheld top 10](/best-handheld-ham-radios/). The catch is
+Yaesu's **menu system**: a steep learning curve and a small, fiddly resistive
+touch screen. C4FM only — no [DMR](/reference/dmr/) or
+[D-STAR](/reference/d-star/). Transmitting requires an FCC amateur license
+(Technician minimum); listening requires none.
+</div>
+
+## Overview
+
+Yaesu's digital HT line has iterated fast — FT1DR, FT2DR, FT3DR, now FT-5DR —
+and each generation piled on features while holding the price near $400. The
+FT-5DR lands with true dual-band simultaneous receive (V+V, U+U or V+U),
+wideband coverage from 0.5 to 999.9 MHz including AM air band, a 2,200 mAh
+battery with solid endurance, 900+ memories, and a microSD slot for memories,
+GPS logs and voice recording. It can also act as a portable **WiRES-X** digital
+node, linking a local simplex frequency into Yaesu's internet-connected rooms.
+
+The trade-offs are consistent Yaesu: the menu tree is deep and unintuitive
+until it clicks, the resistive touch screen is small and fiddly, Bluetooth is
+finicky with non-Yaesu headsets, and the APRS implementation — while genuinely
+useful — lacks the KISS TNC that makes the Kenwood the packet operator's
+choice. And C4FM's ecosystem, strong in many US regions, is smaller than DMR's
+in others: check what your local repeaters actually run before picking a
+digital mode.
+
+## Modes &amp; features
+
+- **[C4FM](/reference/c4fm/) System Fusion II** + analog FM, with AMS
+  auto-mode-select switching per received signal.
+- **[APRS](/reference/aprs/)** 1200/9600 bps modem with built-in **GPS**.
+- **True dual receive** — two bands (or two channels on one band) at once.
+- **IPX7** — submersible 1 m / 30 min.
+- **WiRES-X** portable digital node capability; **Bluetooth**; microSD.
+- **5 W** TX; charges via supplied cradle or 12 V (USB is data only).
+
+## Programming
+
+Yaesu's free ADMS-14 programmer moves memories over microSD or USB, and
+RT Systems sells the usual alternative. **CHIRP does not support it** — Yaesu's
+C4FM radios generally aren't covered.
+
+## GopherTrunk alternative
+
+GopherTrunk receives only — it can't transmit, so it doesn't replace an
+FT-5DR. Where it earns its keep is *before* the purchase: a ~$30
+[RTL-SDR](/reference/rtl-sdr/) running free GopherTrunk shows you what your
+local repeaters actually carry — [C4FM](/reference/c4fm/), DMR, D-STAR or plain
+FM — and records and logs the traffic so you can gauge real activity, not
+directory listings. That's exactly the data that decides between this radio,
+an [AT-D878UVII Plus](/reference/anytone-at-d878uvii-plus/) and an
+[ID-52A](/reference/icom-id-52a/). See
+[best SDR for GopherTrunk](/best-sdr-for-gophertrunk/) for the hardware.
+
+## Who it's for
+
+- **Buy the FT-5DR** if your area runs System Fusion, or if you want the most
+  radio per dollar — APRS, GPS and waterproofing included — and can live with
+  Yaesu menus.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B09GS924GT?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [Kenwood TH-D75A](/reference/kenwood-th-d75a/)** instead for
+  serious APRS/packet work or D-STAR, or the
+  [Icom ID-52A](/reference/icom-id-52a/) for D-STAR with IP67 ruggedness.
+- **Skip the digital premium** entirely with a
+  [Yaesu FT-60R](/reference/yaesu-ft-60r/) if your local scene is analog FM.
+  Full rankings: [best handheld ham radios](/best-handheld-ham-radios/).
+
+## Sources
+
+[^yaesu]: [Yaesu FT-5DR product page](https://yaesu.com/product-detail.aspx?Model=FT5DR&CatName=VHF%2FUHF+Handhelds) — Yaesu, on C4FM/FM, APRS and GPS, dual-band simultaneous receive, IPX7 rating, WiRES-X node capability, and wideband receive coverage.

--- a/docs/reference/yaesu-ft-60r.md
+++ b/docs/reference/yaesu-ft-60r.md
@@ -1,0 +1,127 @@
+---
+slug: yaesu-ft-60r
+title: Yaesu FT-60R
+entry_type: hardware
+category: ham-radios
+description: "The Yaesu FT-60R is the legendary analog dual-band ham handheld — in production for over two decades, nearly indestructible, CHIRP-programmable, and still the default 'first real HT' recommendation at around $180."
+keywords: Yaesu FT-60R, FT-60R review, best first ham radio, dual band FM handheld, most durable ham HT, analog ham handheld, Field Day radio, CHIRP compatible radio, Yaesu FT-60R vs Baofeng
+aka: [FT-60R, FT-60]
+autolink: true
+affiliate: true
+product:
+  name: "Yaesu FT-60R"
+  brand: Yaesu
+  category: Ham handheld transceiver
+  lowPrice: "170"
+  highPrice: "190"
+  url: https://www.amazon.com/dp/B004P4PDAO?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: Dual-band handheld transceiver }
+  - { label: Bands, value: "TX 144/430 MHz; RX 108–520, 700–999.99 MHz" }
+  - { label: Modes, value: "Analog FM only; AM air band receive" }
+  - { label: Power, value: 5 W }
+  - { label: Programming, value: "CHIRP (mature driver), ADMS-1J, RT Systems" }
+  - { label: Price, value: around $180 }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B004P4PDAO?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [yaesu-ft-5dr, baofeng-bf-f8hp, baofeng-uv-5r, btech-uv-pro, rtl-sdr, ctcss]
+related_lessons:
+  - { title: "Analog vs. digital voice", url: /learn/rf-sdr/digital-voice/ }
+  - { title: "Legal & ethical monitoring", url: /learn/rf-sdr/legal-ethical/ }
+related_reading:
+  - { title: "Police scanner vs GopherTrunk", url: /police-scanner-vs-sdr/ }
+cite_urls:
+  - https://www.yaesu.com/product-detail.aspx?Model=FT-60R
+faq:
+  - q: "Is the Yaesu FT-60R still worth buying in 2026?"
+    a: "Yes, if your local scene is analog FM. It has been in production for over twenty years because nothing at the price matches its durability, front-end selectivity and dead-simple operation. It has no digital modes, GPS or Bluetooth — that's the trade, and for many hams it's the right one."
+  - q: "What's the difference between an FT-60R and a Baofeng UV-5R?"
+    a: "About $155, and you can hear it. The FT-60R's receiver holds up next to strong transmitters where the Baofeng's wide-open front end collapses into intermod, its transmit is clean, and the hardware survives years of abuse. The UV-5R is the beater you don't mind losing; the FT-60R is the radio you keep."
+  - q: "Does the FT-60R work with CHIRP?"
+    a: "Yes — one of CHIRP's most mature drivers. You'll need a USB programming cable with the 4-conductor plug. Yaesu's ADMS-1J and RT Systems software also cover it."
+  - q: "Is the FT-60R waterproof?"
+    a: "No formal IP rating — it's weather-resistant and famously survives hard field use, but it isn't submersible. For a rated body, look at the IPX7 FT-5DR or IP67 BTECH UV-PRO."
+  - q: "Do I need a license to use an FT-60R?"
+    a: "Transmitting requires an FCC amateur license (Technician class minimum). Listening requires none — and its 108–520 MHz receive with AM air band covers a lot of listening."
+---
+**The Yaesu FT-60R** is the cockroach of ham radio, and that's a compliment: an
+analog dual-band 144/430 MHz handheld introduced in 2004 and **still sold new
+22 years later**, because it survives the drops, rain and glovebox summers that
+kill fancier rigs.[^yaesu] 5 W, 1,000 memories, wide receive with AM air band,
+around $180 — and not one digital feature anywhere on it.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B004P4PDAO?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The perennial "first real HT."** Legendary durability, a front end with real
+selectivity (night-and-day next to a [UV-5R](/reference/baofeng-uv-5r/) near
+strong transmitters), dead-simple controls, mature
+CHIRP support, and a cheap, plentiful battery ecosystem. **Analog FM only** —
+no [DMR](/reference/dmr/), [C4FM](/reference/c4fm/), [D-STAR](/reference/d-star/),
+GPS or Bluetooth — and no formal waterproof rating. **~$180.** Transmitting
+takes an FCC Technician license; listening takes none.
+</div>
+
+## Overview
+
+Every club has the same story: the FT-60R someone dropped off a roof, left in
+the rain at Field Day, and is still using. The polycarbonate case, mechanical
+simplicity and conservative RF design have kept this radio the default
+recommendation for a new ham's first serious handheld for two decades. It does
+one job — analog FM voice on 2 m and 70 cm — and does it with a receiver that
+stays quiet next to paging and broadcast transmitters where Baofeng-class
+radios fold up, plus clean, well-regarded transmit audio.
+
+The spec sheet is honest about its age: the stock FNB-83 battery is 1,400 mAh
+NiMH (spares and clones are cheap and everywhere, and an AA tray exists), the
+display is monochrome, and dual watch is a fast scanner rather than two true
+receivers. There is no IP rating — its toughness is reputation, not
+certification. And in a digital era it will never decode a digital repeater.
+
+## Modes &amp; features
+
+- **Analog FM** on 144/430 MHz at 5 W; [CTCSS](/reference/ctcss/) and
+  [DCS](/reference/dcs/) tone signalling, plus Enhanced Paging (EPCS).
+- **Receive 108–520 and 700–999.99 MHz** (cellular blocked) including AM air
+  band and NOAA weather scan.
+- **1,000 memories** with alphanumeric tags.
+- **Battery ecosystem**: NiMH FNB-83 stock, cheap spares, FBA-25 AA tray for
+  emergencies.
+- **No** digital voice, GPS, Bluetooth, APRS or USB — deliberately.
+
+## Programming
+
+The FT-60R is fully supported by **CHIRP** — one of its longest-standing,
+most mature drivers — over a 4-conductor USB programming cable. Yaesu's
+ADMS-1J and RT Systems software work too, and the front-panel keypad plus
+sensible menus make manual entry genuinely practical, which is more than most
+HTs can claim.
+
+## GopherTrunk alternative
+
+GopherTrunk can't transmit, so it doesn't replace an FT-60R — but it answers
+the question that should precede any radio purchase: *what's actually on the
+air here?* A ~$30 [RTL-SDR](/reference/rtl-sdr/) running free GopherTrunk
+monitors your local repeaters and digital traffic, and records and logs every
+transmission — so you'll know whether your area is analog-FM country (where the
+FT-60R is all you need) or has gone digital (where it isn't) before you spend a
+dollar on a transceiver. Hardware picks:
+[best SDR for GopherTrunk](/best-sdr-for-gophertrunk/).
+
+## Who it's for
+
+- **Buy the FT-60R** as a first licensed radio, a Field Day/go-bag workhorse,
+  or the HT you hand to a new operator — anywhere analog FM is the traffic and
+  durability is the priority.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B004P4PDAO?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [Yaesu FT-5DR](/reference/yaesu-ft-5dr/)** instead if your
+  repeaters run C4FM or you want APRS/GPS — it's the same brand's digital
+  flagship at ~$380.
+- **Spend less** on a [Baofeng BF-F8HP](/reference/baofeng-bf-f8hp/) (~$60) or
+  [UV-5R](/reference/baofeng-uv-5r/) (~$25) if you just want a beater — with
+  the front-end and QC caveats on those pages. Full rankings:
+  [best handheld ham radios](/best-handheld-ham-radios/).
+
+## Sources
+
+[^yaesu]: [Yaesu FT-60R product page](https://www.yaesu.com/product-detail.aspx?Model=FT-60R) — Yaesu, on dual-band FM coverage, 5 W output, wide receiver range, 1,000 memories, and CTCSS/DCS signalling.

--- a/docs/reference/yaesu-ft-857d.md
+++ b/docs/reference/yaesu-ft-857d.md
@@ -1,0 +1,139 @@
+---
+slug: yaesu-ft-857d
+title: Yaesu FT-857D
+entry_type: hardware
+category: ham-radios
+description: "The Yaesu FT-857D is the smallest 100 W HF-to-UHF mobile ever made — discontinued around 2019–2020 and now a used-market classic at $500–750. What it does, what fails with age, and what to check before buying."
+keywords: Yaesu FT-857D, FT-857D review, FT-857D used, HF mobile radio, all mode mobile transceiver, shack in a box, FT-857D discontinued, FT-857D problems, best used mobile ham radio, SOTA radio
+aka: [FT-857D, FT-857]
+autolink: true
+affiliate: true
+product:
+  name: "Yaesu FT-857D"
+  brand: Yaesu
+  category: Mobile ham transceiver (used)
+  lowPrice: "500"
+  highPrice: "750"
+  itemCondition: used
+  url: https://www.amazon.com/dp/B01MFFYPON?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: All-mode HF/VHF/UHF mobile (discontinued) }
+  - { label: Bands, value: "HF + 6m + 2m + 70cm" }
+  - { label: Modes, value: "SSB, CW, AM, FM, digital via CAT" }
+  - { label: Power, value: "100 W HF/6m, 50 W 2m, 20 W 70cm" }
+  - { label: Programming, value: "CHIRP / ADMS-4B / RT Systems" }
+  - { label: Price, value: "around $500–750 used" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B01MFFYPON?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [icom-ic-706mkiig, kenwood-tm-v71a, yaesu-ftm-500dr, yaesu-ft-891, rtl-sdr, single-sideband]
+related_lessons:
+  - { title: "What is trunked radio?", url: /learn/digital-trunking/ }
+related_reading:
+  - { title: "Best SDR for GopherTrunk", url: /best-sdr-for-gophertrunk/ }
+cite_urls:
+  - https://www.dxengineering.com/parts/ysu-ft-857d
+  - https://www.universal-radio.com/catalog/hamhf/1857.html
+faq:
+  - q: "Is the Yaesu FT-857D discontinued?"
+    a: "Yes — Yaesu ended production in the 2019–2020 window (dealer announcements clustered in 2019, one source says April 2020; the exact month is uncertain). No successor shares its form factor: the FT-891 covers HF/6m only, and the FT-991A is a bigger base/portable. In practice it is a used/eBay purchase today."
+  - q: "Is a used FT-857D still worth buying in 2026?"
+    a: "Yes, if you actually want HF-to-UHF in one tiny box — nothing new replaces it. It holds value unusually well at roughly $500–750 used. Check the PA output on all bands and the display for striping before you pay, and know finals parts are tightening as stock ages."
+  - q: "What are the known problems with a used FT-857D?"
+    a: "Two headline agers: PA finals failures — especially units run hard at 100 W mobile or into poor SWR — and the cosmetic display striping/fading fault that develops with age. Beyond that: menu-heavy operation on a tiny screen, mediocre stock TX audio until you set the mic EQ, and an audible fan."
+  - q: "Does CHIRP support the FT-857D?"
+    a: "Yes — CHIRP has an FT-857/857D driver with live and clone modes, and Yaesu's ADMS-4B and RT Systems also work. Unlike the rival IC-706MkIIG, this radio is fully PC-programmable."
+  - q: "Do I need a license to use the FT-857D?"
+    a: "To transmit, yes — an FCC amateur license (Part 97; Technician minimum, General for most HF privileges). Listening requires no license at all."
+---
+**The Yaesu FT-857D** is the **smallest 100-watt HF-to-UHF mobile ever made**:
+HF + 6m at 100 W, 2m at 50 W, 70cm at 20 W, **all modes**, with a detachable
+front panel and built-in DSP.[^dealers] Yaesu ended production around
+2019–2020 and shipped no true successor, so the 857D **holds its value
+unusually well** — figure **$500–750 used**, and treat it as a used/eBay
+purchase even though a stale Amazon bundle listing lingers.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B01MFFYPON?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Our best used/classic mobile buy** in the
+[mobile top 10](/best-mobile-ham-radios/). The "shack-in-a-box" benchmark for
+mobile, portable, and SOTA HF; the "D" adds 60 m and bundled DSP; 200
+memories; **CHIRP-supported**. **Discontinued 2019–2020, used market only in
+practice** — ~$500–750, clean late units with DSP options push higher. Buy
+smart: **check the PA finals and look for display striping.** No GPS/APRS, no
+digital voice. Transmitting needs a ham license; listening doesn't.
+</div>
+
+## Overview
+
+For seventeen-odd years the FT-857D was the answer to "one radio, every band,
+under the seat": SSB, CW, AM, FM, and digital via CAT, from 160 m to 70cm, in
+a chassis you can palm. The YSK-857 separation kit puts the front panel on the
+dash; optional narrow Collins CW/SSB filters sharpen the receiver; TX draw is
+about 22 A at 100 W, so wire it properly. There is no GPS or
+[APRS](/reference/aprs/), no digital voice, and no cross-band repeat.
+
+The operating experience is the acknowledged tax: 100-plus menus behind a tiny
+screen and multi-function knobs, stock TX audio that stays mediocre until you
+set the mic EQ, and an audible fan. Nobody buys an 857D for ergonomics; they
+buy it because nothing else does this much in this little space — which is
+still true in 2026, since the FT-891 dropped VHF/UHF and the FT-991A grew into
+a base rig.
+
+**Used-market viability, honestly:** the two agers every used-buyer guide
+flags are **PA finals failures** — especially on units run hard at 100 W
+mobile or into poor SWR — and the cosmetic **display "striping"/fading** fault
+that develops with age. Ask for photos of the display powered on, verify rated
+output on every band into a dummy load if you can, and price accordingly:
+**parts availability for the finals is tightening** as stock ages. Clean
+late-production units with the DSP options fitted command the top of the
+range (asks up to ~$900 have been observed; ~$500–750 is the typical band).
+
+## Modes &amp; coverage
+
+- **HF (incl. 60 m on the "D") + 6m at 100 W, 2m at 50 W, 70cm at 20 W.**
+- **All modes:** [SSB](/reference/single-sideband/), CW, AM,
+  [FM](/reference/frequency-modulation/), and digital modes via CAT control.
+- Built-in DSP, 200 memories, detachable panel (YSK-857), optional Collins
+  filters.
+
+## Programming
+
+Fully PC-programmable — a real edge over the rival
+[IC-706MkIIG](/reference/icom-ic-706mkiig/):
+
+1. **CHIRP** (free) — FT-857/857D driver, live and clone modes.
+2. **Yaesu ADMS-4B** or **RT Systems** as alternatives.
+
+## GopherTrunk alternative
+
+GopherTrunk **receives; it cannot transmit** — it will not work a SOTA summit
+for you. Where it earns its keep is before and beside the purchase: a ~$30
+[RTL-SDR](/reference/rtl-sdr/) running free GopherTrunk shows you what is
+actually active on your local VHF/UHF — repeaters, digital modes, traffic
+worth chasing — before you spend $600 on a classic, and it records and logs
+every call, which no transceiver does. Listening requires no license;
+transmitting on ham bands requires an FCC amateur license (Part 97, Technician
+class minimum). See [best SDR for GopherTrunk](/best-sdr-for-gophertrunk/).
+
+## Who it's for
+
+- **Buy a used FT-857D** if you want the do-everything HF-to-UHF mobile that
+  still has no modern equal, and you'll verify finals and display before
+  paying. It is our best used/classic buy among mobiles.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B01MFFYPON?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy a used [IC-706MkIIG](/reference/icom-ic-706mkiig/)** to save $100–150
+  on the same mission, accepting front-panel-only programming.
+- **Buy a new [Yaesu FT-891](/reference/yaesu-ft-891/)** if HF/6m mobile is
+  the real goal and you can give up 2m/70cm — it's the closest living
+  relative.
+- Full rankings: [the 10 best mobile ham radios](/best-mobile-ham-radios/).
+
+> **Amazon note.** The FT-857D is out of production. The Amazon listing is a
+> legacy third-party installation bundle whose availability is sporadic — the
+> real market is used: eBay, hamfests, and the QRZ swapmeet. Compare any
+> Amazon price against recent eBay sold listings before buying.
+
+## Sources
+
+[^dealers]: [DX Engineering FT-857D archive listing](https://www.dxengineering.com/parts/ysu-ft-857d) and [Universal Radio FT-857D archive page](https://www.universal-radio.com/catalog/hamhf/1857.html) — dealer references documenting the FT-857D's all-mode HF/VHF/UHF coverage, power by band, DSP, and discontinued status.

--- a/docs/reference/yaesu-ft-891.md
+++ b/docs/reference/yaesu-ft-891.md
@@ -1,0 +1,144 @@
+---
+slug: yaesu-ft-891
+title: Yaesu FT-891
+entry_type: hardware
+category: ham-radios
+description: "The Yaesu FT-891 packs a full 100W of HF/6m into a 4.5-pound body for around $650 — the POTA and field-ops favorite with a surprisingly strong receiver, no internal tuner, and legendary menu depth."
+keywords: Yaesu FT-891, FT-891 review, best value 100 watt HF radio, compact HF transceiver, POTA radio, field HF radio, FT-891 vs G90, FT-891 vs FT-991A, cheap 100W ham radio, Yaesu HF transceiver 2026
+aka: [FT-891, FT891]
+autolink: true
+affiliate: true
+product:
+  name: "Yaesu FT-891"
+  brand: Yaesu
+  category: Ham radio base station (HF/6m transceiver)
+  lowPrice: "640"
+  highPrice: "700"
+  url: https://www.amazon.com/dp/B01LZHA0I4?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: "Compact HF/6m transceiver (mobile form, base use)" }
+  - { label: Bands, value: "160–6 m" }
+  - { label: Modes, value: "SSB, CW, AM, FM" }
+  - { label: Power, value: "100 W" }
+  - { label: Programming, value: "CHIRP / RT Systems ADMS-13; USB CAT (no USB audio)" }
+  - { label: Price, value: "around $640–700" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B01LZHA0I4?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [xiegu-g90, icom-ic-7300, yaesu-ft-991a, icom-ic-718, rtl-sdr, antenna-tuner]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "Best ham radio base stations", url: /best-ham-radio-base-stations/ }
+cite_urls:
+  - https://www.dxengineering.com/parts/ysu-ft-891
+faq:
+  - q: "Is the Yaesu FT-891 good as a base station?"
+    a: "Yes — it's marketed as a mobile but hugely used as a compact base and field radio, and it earns a spot on our base-station list. You give up an internal tuner, USB audio, and screen real estate; you keep a full 100 W and a receiver that measures noticeably well for the class."
+  - q: "Does the FT-891 have a built-in antenna tuner?"
+    a: "No. Pair it with Yaesu's FC-50 or an LDG autotuner, or use resonant antennas. That's the biggest practical difference versus the Xiegu G90, whose wide-range internal tuner is its party trick — the FT-891 answers with five times the power."
+  - q: "Can the FT-891 do FT8?"
+    a: "Yes, with an external audio interface. USB provides CAT control only — there's no built-in soundcard — so digital modes need Yaesu's SCU-17 or a third-party interface. Once cabled, 100 W of FT8 works fine (most operators run less)."
+  - q: "FT-891 or Xiegu G90 — which should I buy?"
+    a: "FT-891 if you want 100 W and the better receiver for about $200 more, and you have (or will buy) a tuner. G90 if your antennas are compromised wires, your battery is small, or $450 is the budget. Both are POTA legends; the 891 wins on radio, the G90 on convenience per dollar."
+  - q: "Do I need a license to use the FT-891?"
+    a: "Transmitting requires an FCC amateur license (Part 97 — Technician minimum, General for most HF phone). Listening requires none — and a ~$30 RTL-SDR with free GopherTrunk will let you hear your local bands before you buy anything."
+---
+**The Yaesu FT-891** is the community's standing answer to "best value 100 W
+radio, period": a full **100 W on 160–6 m** from a 4.5-pound,
+mobile-form-factor body that mostly lives on desks and picnic tables, for around
+$640–700.[^dxe] The receiver measures noticeably well for the class, the build
+is bulletproof — and the price is paid in menus, a small screen, and the
+absence of an internal tuner and USB audio.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B01LZHA0I4?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The value-per-watt king.** ~$650 buys **100 W**, a strong receiver with
+effective DSP and [noise blanker](/reference/noise-blanker/), and a detachable
+head — the POTA/field-ops darling that doubles as a budget base. The trades:
+**no internal [tuner](/reference/antenna-tuner/)**, **no USB soundcard** (FT8
+needs an interface), 100+ menus behind a small mono display, audible fan.
+Still in production while the [FT-991A](/reference/yaesu-ft-991a/) bows out.
+**Part 97 license to transmit; none to listen.** Rankings:
+[best ham radio base stations](/best-ham-radio-base-stations/).
+</div>
+
+## Overview
+
+Yaesu sells the FT-891 as a mobile; hams overwhelmingly use it as a compact
+base and field radio, which is why it belongs on a base-station list. Since
+2016 it has been the default recommendation for "most radio for the least
+money": a triple-conversion
+[superheterodyne](/reference/superheterodyne-receiver/) (69.45 MHz first IF,
+3 kHz roofing filter) with 32-bit IF DSP whose real-world receive performance —
+strong dynamic range, an effective noise blanker and DSP noise reduction —
+embarrasses radios costing more. Notably, it's the survivor of Yaesu's 2026
+lineup shake-up: still in production with no discontinuation indications, while
+the FT-991A ends its run.
+
+What you give up is comfort. The monochrome dot-matrix display is cramped for
+base use and its spectrum sweep is basic. Settings live in **more than a hundred
+menus** — "menu hell" is the accepted term — which is fine once configured and
+maddening while configuring. There's no internal tuner (budget for an FC-50 or
+LDG), no built-in USB soundcard, the fan is audible, and some owners report TX
+pop/relay clicks. None of that stops it being the best pure radio under $1,000.
+
+**License note:** transmitting needs an FCC amateur license (Part 97 —
+Technician minimum; most HF phone comes with General). Listening needs none.
+
+## Bands, modes &amp; power
+
+- **TX:** 160–6 m, **100 W**, [SSB](/reference/single-sideband/),
+  [CW](/reference/morse-code/), AM, FM.
+- **Receiver:** triple-conversion superhet, 3 kHz roofing filter, 32-bit DSP —
+  noticeably good for the class.
+- **Display:** small monochrome dot-matrix with a basic spectrum sweep;
+  detachable head for mobile/field mounting.
+- **Tuner:** none — external FC-50/LDG or resonant antennas.
+- **I/O:** USB CAT (control only — **no USB audio**; digital modes need an
+  SCU-17 or third-party interface). 13.8 V DC at ~23 A: a real 25 A supply or a
+  serious battery.
+
+## What owners praise and gripe about
+
+Praise: full power in a tiny box, the receiver, the toughness — this is the rig
+that lives in backpacks and truck cabs and keeps working. It's a
+[POTA](/reference/aprs/) -era phenomenon: cheap enough to risk outdoors, good
+enough to win pileups from a picnic table. Gripes: the menus, the screen, the
+missing tuner and USB audio, the fan. The pattern is consistent — everything
+wrong with it is ergonomic, everything right with it is RF.
+
+## Programming &amp; software
+
+**CHIRP lists FT-891 support** for memory programming, and RT Systems' ADMS-13
+covers it commercially — more useful here than on most HF rigs since field
+operators lean on memories. CAT over USB drives WSJT-X, N1MM, and loggers;
+remember audio needs the external interface. Firmware updates arrive via USB.
+
+## GopherTrunk alternative
+
+GopherTrunk is receive-only — it can't transmit, so it won't replace an FT-891.
+It's the $30 reconnaissance step: an [RTL-SDR](/reference/rtl-sdr/) running free
+GopherTrunk monitors your local repeaters and digital traffic and **records and
+logs everything**, telling you what's worth chasing before you buy a
+transceiver, a tuner, and a power supply. It also keeps listening at home while
+your FT-891 is in the field. Hardware picks:
+[best SDR for GopherTrunk](/best-sdr-for-gophertrunk/); HF-specific listening:
+[best HF SDR](/best-hf-sdr/).
+
+## Who it's for
+
+- **Buy the FT-891** if you want the most transmit-and-receive capability per
+  dollar in the hobby and you'll tolerate menus and buy a tuner — first HF
+  radio, field rig, or budget base.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B01LZHA0I4?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [Xiegu G90](/reference/xiegu-g90/)** (~$450) instead if a
+  wide-range internal tuner and lower battery draw matter more than 100 W.
+- **Spend up** to the [IC-7300](/reference/icom-ic-7300/) for the touchscreen
+  waterfall, internal tuner, and one-cable digital modes in a true base
+  package. Rankings:
+  [best ham radio base stations](/best-ham-radio-base-stations/).
+
+## Sources
+
+[^dxe]: [Yaesu FT-891 — DX Engineering product/spec page](https://www.dxengineering.com/parts/ysu-ft-891) — on the 160–6 m coverage, 100 W output, triple-conversion receiver with 3 kHz roofing filter and 32-bit IF DSP, detachable front panel, and current street price. (Yaesu's own site uses session-style URLs that don't cite cleanly.)

--- a/docs/reference/yaesu-ft-891.md
+++ b/docs/reference/yaesu-ft-891.md
@@ -102,11 +102,19 @@ Technician minimum; most HF phone comes with General). Listening needs none.
 ## What owners praise and gripe about
 
 Praise: full power in a tiny box, the receiver, the toughness — this is the rig
-that lives in backpacks and truck cabs and keeps working. It's a
-[POTA](/reference/aprs/) -era phenomenon: cheap enough to risk outdoors, good
-enough to win pileups from a picnic table. Gripes: the menus, the screen, the
-missing tuner and USB audio, the fan. The pattern is consistent — everything
-wrong with it is ergonomic, everything right with it is RF.
+that lives in backpacks and truck cabs and keeps working. It's a POTA-era
+phenomenon: cheap enough to risk outdoors, good enough to win pileups from a
+picnic table. Gripes: the menus, the screen, the missing tuner and USB audio,
+the fan. The pattern is consistent — everything wrong with it is ergonomic,
+everything right with it is RF.
+
+Price-wise it's a moving target in a good way: recent US street runs
+$639.95–699.95 (EU ~€725) and Yaesu's frequent rebates regularly shave more
+off. Budget realistically, though — the out-the-door cost of an FT-891
+*station* includes a tuner (~$100–200 unless your antennas are resonant), a
+digital-modes interface if you want FT8, and a 25 A supply. Even fully kitted
+it undercuts everything above it on this list, which is exactly why it stays
+recommended year after year.
 
 ## Programming &amp; software
 

--- a/docs/reference/yaesu-ft-991a.md
+++ b/docs/reference/yaesu-ft-991a.md
@@ -108,6 +108,14 @@ UI**, the **narrow internal tuner range**, **fan noise** on digital modes, and
 the receiver being merely good in an era when similar money buys direct-sampling.
 None of these killed its popularity, because nothing else does its job.
 
+The discontinuation sharpens the used-market question too. Used FT-991As run
+**$900–1,100**, and with production ended that supply is what the "one radio
+for everything" niche will live on — so a new unit at $1,370 with a three-year
+warranty is arguably the better deal than a used one at $1,000, a calculus that
+flips for most radios. If Fusion doesn't matter to you and repeaters are an
+afterthought, though, don't pay the coverage premium at all: the money goes
+further on a dedicated HF rig.
+
 ## Programming &amp; software
 
 The VHF/UHF side gives it real memory-programming needs, and it's covered:

--- a/docs/reference/yaesu-ft-991a.md
+++ b/docs/reference/yaesu-ft-991a.md
@@ -1,0 +1,142 @@
+---
+slug: yaesu-ft-991a
+title: Yaesu FT-991A
+entry_type: hardware
+category: ham-radios
+description: "The Yaesu FT-991A is the all-band shack-in-a-box: HF, 6m, 2m and 70cm with SSB/CW/AM/FM plus C4FM System Fusion in one 100W radio. Discontinued May 2026 — dealer stock remains, making it a last-call buy."
+keywords: Yaesu FT-991A, FT-991A review, FT-991A discontinued, shack in a box ham radio, all band all mode transceiver, HF VHF UHF transceiver, C4FM System Fusion radio, FT-991A vs IC-7300, best all-in-one ham radio, FT-991A price 2026
+aka: [FT-991A, FT991A]
+autolink: true
+affiliate: true
+product:
+  name: "Yaesu FT-991A"
+  brand: Yaesu
+  category: Ham radio base station (HF/VHF/UHF all-mode transceiver)
+  lowPrice: "1370"
+  highPrice: "1400"
+  url: https://www.amazon.com/dp/B01MDU5VYH?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: "All-band all-mode base transceiver" }
+  - { label: Bands, value: "HF + 6 m + 2 m + 70 cm" }
+  - { label: Modes, value: "SSB, CW, AM, FM + C4FM System Fusion" }
+  - { label: Power, value: "100 W HF/6 m; 50 W VHF/UHF" }
+  - { label: Programming, value: "USB CAT + audio; CHIRP / RT Systems / ADMS" }
+  - { label: Price, value: "around $1,370–1,400 while stock lasts" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B01MDU5VYH?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [icom-ic-7300, yaesu-ft-891, yaesu-ftdx10, xiegu-g90, c4fm, system-fusion-ysf, rtl-sdr]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "Best ham radio base stations", url: /best-ham-radio-base-stations/ }
+cite_urls:
+  - https://www.dxengineering.com/parts/ysu-ft-991a
+faq:
+  - q: "Is the Yaesu FT-991A discontinued?"
+    a: "Yes — its discontinuation was reported in May 2026 after a roughly nine-year run. Major dealers still sell new sell-through stock around $1,370–1,400 as of August 2026, so it's a last-call buy: nothing else currently sold new covers HF through 70 cm, all modes plus C4FM Fusion, in one box."
+  - q: "Should I still buy the FT-991A in 2026?"
+    a: "If you want one radio for HF DX, local FM repeaters, and C4FM digital, yes — buy while dealer stock lasts, because no in-production radio replaces it. If you only operate HF, an IC-7300 gives you a better receiver and scope for less money."
+  - q: "Does the FT-991A do C4FM System Fusion and DMR?"
+    a: "It does C4FM System Fusion natively, including WIRES-X. It does not do DMR or D-STAR — no radio in this class decodes every digital voice mode. For monitoring DMR alongside everything else, a ~$30 RTL-SDR running free GopherTrunk covers it."
+  - q: "Can the FT-991A work satellites?"
+    a: "With workarounds. It covers 2 m and 70 cm all-mode, which is the right hardware, but it has a single receiver and no full duplex — so you can't hear your own downlink while transmitting. Casual FM birds are workable; serious satellite operators want a full-duplex setup."
+  - q: "Do I need a license to use the FT-991A?"
+    a: "Transmitting on any ham band requires an FCC amateur license (Part 97 — Technician class minimum; Technician alone already unlocks its 2 m/70 cm sides). Listening requires no license at all."
+---
+**The Yaesu FT-991A** is the last true **shack-in-a-box**: HF through 70 cm — 160
+through 6 meters at 100 W, 2 m and 70 cm at 50 W — with every analog mode plus
+native [C4FM](/reference/c4fm/) [System Fusion](/reference/system-fusion-ysf/)
+digital voice and WIRES-X, in a single compact radio with a touchscreen and a
+built-in tuner.[^dxe] Yaesu **discontinued it in May 2026** after a nine-year
+run; dealers still have new stock around $1,370–1,400, and no current-production
+radio replaces what it does.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B01MDU5VYH?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Best features for the price** in
+[best ham radio base stations](/best-ham-radio-base-stations/) — unmatched
+band/mode coverage per dollar: **HF + 6 m + 2 m + 70 cm, all modes, plus C4FM
+Fusion.** **Discontinued May 2026, sell-through stock remains** — a genuine
+last-call buy. The trades: an average (non-SDR) receiver, a slow sweeping scope,
+menu-heavy UI, no full duplex for satellites. **~$1,370–1,400 new while it
+lasts.** **Part 97 license to transmit; none to listen** — scout your local
+repeaters first with a [$30 RTL-SDR + GopherTrunk](/best-sdr-for-gophertrunk/).
+</div>
+
+## Overview
+
+For nine years the FT-991A answered a question no other single radio did: "what
+if I want HF DX *and* my local repeaters *and* digital voice, with one antenna
+jack per side and one power cable?" It transmits from 160 m to 70 cm, does
+[SSB](/reference/single-sideband/)/[CW](/reference/morse-code/)/AM/FM everywhere
+that makes sense, and speaks C4FM Fusion natively — which made it the default
+"only radio" for small shacks, apartments, and field setups.
+
+Now the honest part. **Yaesu discontinued the FT-991A in May 2026** (reported by
+simonthewizard on May 20). This is sell-through, not vaporware: R&L had it at
+$1,369.95 and DX Engineering at $1,399.95 in August 2026. We keep it as our
+"best features for the price" pick *while that stock lasts*, because its
+coverage-per-dollar is still unmatched — but know you're buying a discontinued
+radio, and used prices (~$900–1,100) will be the story from here.
+
+Technically it's a triple-conversion
+[superheterodyne](/reference/superheterodyne-receiver/) with a 3 kHz roofing
+filter and 32-bit IF DSP — a competent conventional design, not an SDR. The
+3.5-inch touchscreen's sweeping spectrum scope is genuinely useful but slow next
+to the fluid waterfalls on the [IC-7300](/reference/icom-ic-7300/) and
+[FTDX10](/reference/yaesu-ftdx10/), and by Sherwood-table standards the receiver
+is average for the price. You're paying for breadth, not receiver figures.
+
+## Bands, modes &amp; systems
+
+- **HF + 6 m:** 100 W, all modes, with the built-in ATU (note its narrow ~3:1
+  matching range — resonant-ish antennas only).
+- **2 m + 70 cm:** 50 W, FM and all-mode — repeaters, simplex, and
+  SSB/CW weak-signal VHF work.
+- **[C4FM](/reference/c4fm/) System Fusion** digital voice with **WIRES-X**
+  linking. No [DMR](/reference/dmr/), no [D-STAR](/reference/d-star/).
+- **Satellites:** possible with workarounds, but a single receiver and no full
+  duplex means you can't hear your downlink while transmitting.
+- **I/O:** USB CAT + audio for one-cable digital modes; 13.8 V DC at ~23 A.
+
+## What owners praise and gripe about
+
+Praise: the coverage, obviously; solid transmit audio; a body compact enough to
+take to the field. Gripes are consistent and worth knowing: the **menu-heavy
+UI**, the **narrow internal tuner range**, **fan noise** on digital modes, and
+the receiver being merely good in an era when similar money buys direct-sampling.
+None of these killed its popularity, because nothing else does its job.
+
+## Programming &amp; software
+
+The VHF/UHF side gives it real memory-programming needs, and it's covered:
+**CHIRP** supports the FT-991/991A memory map, along with RT Systems and Yaesu's
+ADMS software. CAT over USB drives WSJT-X and loggers, and the built-in USB audio
+codec means FT8 needs no external interface.
+
+## GopherTrunk alternative
+
+GopherTrunk receives — it can't transmit — so it doesn't replace an FT-991A. Use
+it to decide whether you need one. A ~$30 [RTL-SDR](/reference/rtl-sdr/) running
+free GopherTrunk monitors your local 2 m/70 cm repeaters and digital traffic
+(including modes the FT-991A *doesn't* decode, like [DMR](/reference/dmr/)) and
+**records and logs every transmission** — so before spending $1,400 on
+last-call stock you'll know exactly what's active in your area. See
+[best SDR for GopherTrunk](/best-sdr-for-gophertrunk/) to pick the dongle.
+
+## Who it's for
+
+- **Buy the FT-991A** if you want one radio for everything — HF, repeaters, and
+  Fusion — and buy it now, while new sell-through stock exists.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B01MDU5VYH?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [IC-7300](/reference/icom-ic-7300/)** if you're really an HF operator
+  — better receiver, better scope, less money — and add a cheap FM mobile for
+  repeaters later.
+- **Buy the [FT-891](/reference/yaesu-ft-891/)** (~$650) if "compact 100 W HF"
+  was the part you wanted and VHF/UHF wasn't. Compare them all:
+  [best ham radio base stations](/best-ham-radio-base-stations/).
+
+## Sources
+
+[^dxe]: [Yaesu FT-991A — DX Engineering product/spec page](https://www.dxengineering.com/parts/ysu-ft-991a) — on the HF/6 m/2 m/70 cm coverage, output power, C4FM System Fusion with WIRES-X, triple-conversion receiver with 32-bit IF DSP, touchscreen scope, and internal ATU. (Yaesu's own site uses session-style URLs that don't cite cleanly; the May 2026 discontinuation was reported by simonthewizard.com.)

--- a/docs/reference/yaesu-ftdx10.md
+++ b/docs/reference/yaesu-ftdx10.md
@@ -113,6 +113,14 @@ like the IC-7300 there's no separate receive-antenna input for a Beverage or
 loop — a real omission at this level, and one the
 [TS-590SG](/reference/kenwood-ts-590sg/) actually covers.
 
+A word on the "fire sale" chatter: Yaesu's $300 rebate (running through August
+31, 2026) spawned a groups.io thread speculating the FTDX10 is being cleared
+out. We found **no discontinuation announcement** — Yaesu runs rolling rebates
+the way Icom does, and this one simply makes an exceptional receiver cheaper.
+Treat the rumor as a rumor; treat the ~$1,400 net price as the real story. If
+Yaesu ever does replace it, the resale floor on a radio with these measured
+numbers will stay firm — receivers this good don't depreciate like features do.
+
 ## Programming &amp; software
 
 Yaesu CAT over USB drives WSJT-X, N1MM, Win4Yaesu and the rest of the standard

--- a/docs/reference/yaesu-ftdx10.md
+++ b/docs/reference/yaesu-ftdx10.md
@@ -1,0 +1,150 @@
+---
+slug: yaesu-ftdx10
+title: Yaesu FTDX10
+entry_type: hardware
+category: ham-radios
+description: "The Yaesu FTDX10 is a 100W HF/6m hybrid-SDR base transceiver with near-flagship close-in receiver dynamic range — essentially FTDX101 receive performance for half the money, around $1,700 (less after rebate)."
+keywords: Yaesu FTDX10, FTDX10 review, FTDX-10, best HF receiver, hybrid SDR transceiver, Sherwood receiver rankings, FTDX10 vs IC-7300, HF base station, 100 watt HF transceiver, Yaesu HF radio 2026
+aka: [FTDX10, FTDX-10]
+autolink: true
+affiliate: true
+product:
+  name: "Yaesu FTDX10"
+  brand: Yaesu
+  category: Ham radio base station (HF/6m transceiver)
+  lowPrice: "1400"
+  highPrice: "1700"
+  url: https://www.amazon.com/dp/B09WG52PP6?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: "HF/6m base transceiver (hybrid SDR)" }
+  - { label: Bands, value: "160–6 m" }
+  - { label: Modes, value: "SSB, CW, AM, FM" }
+  - { label: Power, value: "100 W" }
+  - { label: Programming, value: "USB CAT + audio; touchscreen menus" }
+  - { label: Price, value: "around $1,700 (~$1,400 after rebate)" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B09WG52PP6?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [icom-ic-7300, icom-ic-7610, kenwood-ts-590sg, yaesu-ft-891, rtl-sdr, superheterodyne-receiver]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "Best ham radio base stations", url: /best-ham-radio-base-stations/ }
+cite_urls:
+  - https://www.dxengineering.com/parts/ysu-ftdx-10
+faq:
+  - q: "Is the Yaesu FTDX10 receiver really that good?"
+    a: "Yes — its close-in dynamic range figures rank among the best ever measured in its price class (top-5 on the Sherwood table), using the same hybrid narrow-band-SDR plus direct-sampling architecture as the flagship FTDX101 for roughly half the money. If receiver performance is your first criterion, this is the sub-$2,000 radio to beat."
+  - q: "FTDX10 or IC-7300 — which should I buy?"
+    a: "The FTDX10 has the measurably better receiver and superior CW facilities; the IC-7300 has the slicker touchscreen, easier menus, a bigger community, and costs several hundred dollars less. Contesters and CW operators lean FTDX10; almost everyone else is happier with the 7300."
+  - q: "Is the FTDX10 discontinued?"
+    a: "No. A groups.io thread speculated about a fire sale when Yaesu ran a $300 rebate through August 2026, but there is no discontinuation announcement — it remains a current-production radio. The rebate just makes a very good receiver cheaper."
+  - q: "Does the FTDX10 have a built-in antenna tuner?"
+    a: "Yes — a high-speed internal ATU with 100 tuning memories, plus a 5-inch color touchscreen with Yaesu's 3DSS spectrum display and selectable roofing filters (500 Hz and 3 kHz standard, 300 Hz optional)."
+  - q: "Do I need a ham license for the FTDX10?"
+    a: "To transmit, yes — FCC Part 97, Technician minimum (General for most HF). Just listening needs no license; a ~$30 RTL-SDR with free GopherTrunk is the cheap way to scout the bands first."
+---
+**The Yaesu FTDX10** buys you a genuinely flagship-class receiver for mid-range
+money: a **hybrid SDR** front end (narrow-band SDR plus direct sampling, the same
+architecture as the FTDX101) whose close-in dynamic range ranks among the best
+ever measured near its price — essentially FTDX101 receive for half the
+cost.[^dxe] It runs 100 W on 160–6 m with a 5-inch touchscreen, Yaesu's 3DSS
+spectrum display, and a fast built-in tuner, for around $1,700 (about $1,400
+after the current rebate).
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B09WG52PP6?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The receiver-performance pick** among sub-$2,000 base stations — top-tier
+close-in dynamic range, excellent CW facilities, roofing filters at a real 9 MHz
+IF. **100 W, 160–6 m, built-in ATU, touchscreen.** The trade: Yaesu's menus and
+ergonomics are less loved than the [IC-7300](/reference/icom-ic-7300/)'s, and it
+costs more. **~$1,700 (~$1,400 after rebate), in production** — the "fire sale"
+rumor is just a rebate. **License to transmit (Part 97, Technician+); none to
+listen** — see where it ranks in
+[best ham radio base stations](/best-ham-radio-base-stations/).
+</div>
+
+## Overview
+
+Introduced in late 2020, the FTDX10 is Yaesu's answer to "I want the FTDX101's
+receiver without the FTDX101's price." Instead of pure direct sampling like the
+[IC-7300](/reference/icom-ic-7300/), it pairs a direct-sampling path with a
+narrow-band SDR: down-conversion to a 9 MHz IF through real roofing filters
+(500 Hz and 3 kHz standard, 300 Hz optional) behind 15 band-pass filters. On a
+crowded contest weekend with a kilowatt neighbor 2 kHz up, that architecture is
+exactly what keeps the band listenable — and it's why the FTDX10 sits in the top
+five of the Sherwood close-in dynamic-range table, ahead of radios costing far
+more.
+
+The honest counterweight: Yaesu's user interface. Settings live deeper in menus
+than Icom buries them, the touchscreen is less slick than the 7300's, early
+production runs drew main-dial torque and encoder complaints, and a series of
+firmware rounds were needed to settle AGC/popping quirks. None of it affects what
+comes out of the speaker — but if you value fluency over figures, the Icom feels
+nicer to drive.
+
+Worth stating plainly: **you need an FCC amateur license (Part 97, Technician
+class minimum) to transmit** with it. **Listening is license-free** — and cheaper
+ways to listen exist (below).
+
+## Bands, modes &amp; power
+
+- **TX:** 160–6 m, **100 W**, [SSB](/reference/single-sideband/),
+  [CW](/reference/morse-code/), AM, FM.
+- **Receiver:** hybrid SDR — narrow-band SDR with 9 MHz IF roofing filters plus a
+  direct-sampling path; 15 band-pass filters. Single receiver, no dedicated RX
+  antenna port.
+- **Display:** 5-inch color touchscreen with the 3DSS three-dimensional spectrum
+  display and [waterfall](/reference/waterfall-display/).
+- **Tuner:** built-in high-speed ATU with 100 channel memories.
+- **Digital modes:** USB CAT + audio make it FT8-friendly out of the box with
+  WSJT-X and N1MM.
+
+## Receiver &amp; operating
+
+CW operators get first-class treatment — full break-in, memory keyer, zero-in
+tuning, and the narrow roofing filters doing real selection before the DSP ever
+sees the signal. That combination of measured dynamic range and CW facilities is
+why this radio shows up at serious contest stations as the "second radio" that
+outperforms the main one.
+
+Weaknesses beyond the UI: front-panel jack placement annoys some operators, and
+like the IC-7300 there's no separate receive-antenna input for a Beverage or
+loop — a real omission at this level, and one the
+[TS-590SG](/reference/kenwood-ts-590sg/) actually covers.
+
+## Programming &amp; software
+
+Yaesu CAT over USB drives WSJT-X, N1MM, Win4Yaesu and the rest of the standard
+stack. CHIRP is not a use case here — there's no confirmed CHIRP support and no
+real need for it on a pure HF radio; memory management happens on the radio or
+through CAT software. Firmware updates (which have meaningfully improved this
+radio since launch) load over USB.
+
+## GopherTrunk alternative
+
+GopherTrunk is receive-only — it will never key up, so it cannot replace the
+FTDX10. What it can do is make sure you buy the *right* radio. A ~$30
+[RTL-SDR](/reference/rtl-sdr/) running free GopherTrunk monitors your local
+repeaters and digital ham traffic and **records and logs everything**, so before
+spending $1,700 you know whether your area's activity justifies it — and
+unlicensed listeners get the full experience minus the PTT. Start with
+[best SDR for GopherTrunk](/best-sdr-for-gophertrunk/); if weak-signal HF
+listening is the draw, see [best HF SDR](/best-hf-sdr/).
+
+## Who it's for
+
+- **Buy the FTDX10** if receiver performance and CW are your priorities and
+  you'll trade some menu friction for measurably better close-in dynamic range
+  than anything near the price.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B09WG52PP6?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [IC-7300](/reference/icom-ic-7300/)** instead for a friendlier radio
+  at a lower price, or the [IC-7610](/reference/icom-ic-7610/) if you need true
+  dual receivers for split pileups.
+- **Buy the [TS-590SG](/reference/kenwood-ts-590sg/)** if you want elite CW/RX
+  performance and don't care about a built-in scope. Rankings and rubric:
+  [best ham radio base stations](/best-ham-radio-base-stations/).
+
+## Sources
+
+[^dxe]: [Yaesu FTDX10 — DX Engineering product/spec page](https://www.dxengineering.com/parts/ysu-ftdx-10) — on the hybrid SDR architecture, 9 MHz IF roofing filters, 3DSS touchscreen display, built-in high-speed ATU, output power, and current price/rebate. (Yaesu's own site uses session-style URLs that don't cite cleanly.)

--- a/docs/reference/yaesu-ftm-300dr.md
+++ b/docs/reference/yaesu-ftm-300dr.md
@@ -1,0 +1,136 @@
+---
+slug: yaesu-ftm-300dr
+title: Yaesu FTM-300DR
+entry_type: hardware
+category: ham-radios
+description: "The Yaesu FTM-300DR is a discontinued but still-available 50 W 2m/70cm C4FM System Fusion mobile with true dual receive, built-in GPS and APRS, and Bluetooth — the best value in the Fusion mobile lineup while new-old-stock lasts."
+keywords: Yaesu FTM-300DR, FTM-300DR review, C4FM mobile radio, System Fusion mobile radio, dual receive mobile ham radio, APRS mobile radio, FTM-300DR discontinued, FTM-300DR vs FTM-500DR, best mobile ham radio 2026
+aka: [FTM-300DR, FTM-300]
+autolink: true
+affiliate: true
+product:
+  name: "Yaesu FTM-300DR"
+  brand: Yaesu
+  category: Mobile ham transceiver
+  lowPrice: "300"
+  highPrice: "430"
+  url: https://www.amazon.com/dp/B08884HN79?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: Dual-band mobile transceiver (discontinued — NOS remains) }
+  - { label: Bands, value: "2m / 70cm (true dual receive)" }
+  - { label: Modes, value: "FM, C4FM System Fusion (AMS)" }
+  - { label: Power, value: "50 / 25 / 5 W" }
+  - { label: Programming, value: "microSD / ADMS-11 / RT Systems (no CHIRP)" }
+  - { label: Price, value: "around $400 NOS, $300–380 used" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B08884HN79?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [yaesu-ftm-500dr, icom-id-5100a, anytone-at-d578uviii, kenwood-tm-v71a, rtl-sdr, aprs]
+related_lessons:
+  - { title: "What is trunked radio?", url: /learn/digital-trunking/ }
+related_reading:
+  - { title: "Best SDR for GopherTrunk", url: /best-sdr-for-gophertrunk/ }
+cite_urls:
+  - https://www.yaesu.com/product-detail.aspx?Model=FTM-300DR&CatName=Legacy
+faq:
+  - q: "Is the Yaesu FTM-300DR discontinued?"
+    a: "Yes. Yaesu's own site now files the FTM-300DR under its Legacy category, with the end of production landing somewhere around 2024–2025 (Yaesu never announced a formal date). New-old-stock is still on dealer shelves and Amazon, and it remains a fully supported, current-feeling radio."
+  - q: "Is the FTM-300DR still worth buying in 2026?"
+    a: "Yes, at new-old-stock prices around $400 it is arguably the best value in the entire System Fusion lineup: true dual-band receive with independent C4FM decode, GPS and APRS standard, and rock-solid RF. Just don't pay more than FTM-500DR money for it."
+  - q: "What's the difference between the FTM-300DR and FTM-500DR?"
+    a: "The 500DR adds the AESS dual-speaker audio system, a bigger 2.4-inch display with the funnel layout, and a head-mounted speaker. The 300DR counters with true independent dual receive (both bands can decode C4FM) at roughly $100 less. Audio and screen aside, they are close siblings."
+  - q: "Does the FTM-300DR work with CHIRP?"
+    a: "No — CHIRP does not support it. Program it via the microSD card, Yaesu's free ADMS-11 software, or RT Systems."
+  - q: "Do I need a ham license for the FTM-300DR?"
+    a: "To transmit, yes — an FCC amateur license (Technician class minimum, Part 97). Listening is license-free, and a $30 RTL-SDR with free GopherTrunk will let you hear the same repeaters before you buy anything."
+---
+**The Yaesu FTM-300DR** is a 50-watt 2m/70cm mobile with analog FM and **C4FM
+[System Fusion](/reference/system-fusion-ysf/)**, **true dual receive** with
+independent decode on both bands, built-in GPS with full
+[APRS](/reference/aprs/), and Bluetooth.[^yaesu] Yaesu has quietly
+**discontinued** it — the model now lives on Yaesu's "Legacy" page — but
+new-old-stock is still on dealer and Amazon shelves around $400, and at that
+price the community regards it as **the best value in the Fusion mobile lineup**.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B08884HN79?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The value Fusion mobile.** 50 W on 2m/70cm, FM + [C4FM](/reference/c4fm/) with
+auto mode select, and — unlike the pricier
+[FTM-500DR](/reference/yaesu-ftm-500dr/) — **true dual receive that decodes
+digital on both bands**. GPS + [APRS](/reference/aprs/) 1200/9600 standard,
+Bluetooth, detachable head, microSD cloning. **Discontinued (Yaesu "Legacy"),
+but NOS remains** — around $400 new, $300–380 used. **No CHIRP.** Small 1.8"
+non-touch display is the main compromise. Transmitting needs a ham license;
+listening doesn't.
+</div>
+
+## Overview
+
+The FTM-300DR was the middle child of Yaesu's Fusion mobile line and outlived
+that role: it packs nearly all of the flagship's capability into a smaller,
+cheaper box. You get 50/25/5 W on both bands, a detachable front panel
+(separation kit approach), roughly 999 memories per band, a band scope, microSD
+backup and cloning, WiRES-X portable node capability, and ~13 A maximum draw.
+There is no cross-band repeat.
+
+Its party trick is **true dual receive** — V+V, U+U, or V+U — with *independent*
+decode, so it can sit on two C4FM channels at once, something the FTM-500DR
+cannot do. RF is, in the community's words, rock solid. The compromises are
+physical: a small 1.8-inch color TFT that is not a touchscreen, a speaker in the
+body rather than the head (remote-head installs want an external speaker), Yaesu
+menu conventions that take learning, and the usual Yaesu Bluetooth pairing
+quirks.
+
+**Production status, plainly:** Yaesu's own site files the FTM-300DR under
+**Legacy**, with production ending somewhere around 2024–2025 — no formal date
+was ever announced, so treat the year as approximate. New-old-stock is still
+listed at the major ham dealers and Amazon. NOS at ~$400 is a fair deal; used
+units run about $300–380 (a range estimated from listing spread, so check
+recent sold prices).
+
+## Modes &amp; features
+
+- **Analog FM and [C4FM System Fusion](/reference/system-fusion-ysf/)** with AMS
+  auto mode select — and independent digital decode on both receivers.
+- **Built-in GPS + [APRS](/reference/aprs/)** at 1200/9600 bps, standard.
+- **Bluetooth**, band scope, microSD clone/backup, detachable front panel,
+  WiRES-X portable digital node.
+- The same honest network caveat as every Fusion radio: C4FM trails
+  [DMR](/reference/dmr/) and [D-STAR](/reference/d-star/) in many regions —
+  confirm your local repeaters actually run Fusion first.
+
+## Programming
+
+No CHIRP support. Use the **microSD card**, Yaesu's free **ADMS-11** PC
+software, or the paid **RT Systems** package.
+
+## GopherTrunk alternative
+
+GopherTrunk **receives only — it cannot transmit** — so it doesn't replace an
+FTM-300DR. What it does is tell you whether to buy one. A ~$30
+[RTL-SDR](/reference/rtl-sdr/) running free GopherTrunk monitors your local
+repeaters and digital traffic, so you can see whether Fusion, DMR, or D-STAR is
+what's actually on the air in your area before spending $400 — and it records
+and logs every transmission, which no transceiver does. No license is needed to
+listen; transmitting requires an FCC amateur license (Part 97, Technician
+minimum). Hardware picks are in
+[best SDR for GopherTrunk](/best-sdr-for-gophertrunk/).
+
+## Who it's for
+
+- **Buy the FTM-300DR** if you want Fusion, GPS/APRS, and genuine dual-band
+  digital receive at the best price in the lineup — while NOS lasts.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B08884HN79?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [FTM-500DR](/reference/yaesu-ftm-500dr/)** for the bigger display and
+  the AESS speaker system if the ~$100 premium doesn't sting.
+- **Skip both** for the [AnyTone AT-D578UVIII Plus](/reference/anytone-at-d578uviii/)
+  in DMR country or the [Icom ID-5100A](/reference/icom-id-5100a/) for D-STAR.
+- Full rankings: [the 10 best mobile ham radios](/best-mobile-ham-radios/).
+
+> **Amazon note.** The FTM-300DR is discontinued, so the Amazon listing is
+> remaining new-old-stock and third-party sellers — check the price against the
+> big ham dealers before clicking buy.
+
+## Sources
+
+[^yaesu]: [Yaesu FTM-300DR product page (Legacy category)](https://www.yaesu.com/product-detail.aspx?Model=FTM-300DR&CatName=Legacy) — Yaesu, confirming the model's move to Legacy status and documenting dual-receive C4FM, GPS/APRS, Bluetooth, and power specifications.

--- a/docs/reference/yaesu-ftm-500dr.md
+++ b/docs/reference/yaesu-ftm-500dr.md
@@ -1,0 +1,145 @@
+---
+slug: yaesu-ftm-500dr
+title: Yaesu FTM-500DR
+entry_type: hardware
+category: ham-radios
+description: "The Yaesu FTM-500DR is a 50 W 2m/70cm C4FM System Fusion mobile ham radio with dual receive, built-in GPS and APRS, Bluetooth, and Yaesu's AESS dual-speaker audio — the best all-around FM/digital mobile while new stock lasts."
+keywords: Yaesu FTM-500DR, FTM-500DR review, best mobile ham radio, C4FM mobile radio, System Fusion mobile, dual band mobile transceiver, APRS mobile radio, Yaesu mobile radio 2026, FTM-500DR vs FTM-300DR, ham radio for car
+aka: [FTM-500DR, FTM-500]
+autolink: true
+affiliate: true
+product:
+  name: "Yaesu FTM-500DR"
+  brand: Yaesu
+  category: Mobile ham transceiver
+  lowPrice: "480"
+  highPrice: "550"
+  url: https://www.amazon.com/dp/B0CLSGMLPC?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: Dual-band mobile transceiver }
+  - { label: Bands, value: "2m / 70cm (dual receive)" }
+  - { label: Modes, value: "FM, C4FM System Fusion (AMS)" }
+  - { label: Power, value: "50 / 25 / 5 W" }
+  - { label: Programming, value: "microSD / ADMS-14 / RT Systems (no CHIRP)" }
+  - { label: Price, value: around $500 }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B0CLSGMLPC?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [yaesu-ftm-300dr, anytone-at-d578uviii, icom-id-5100a, icom-ic-2730a, rtl-sdr, aprs]
+related_lessons:
+  - { title: "What is trunked radio?", url: /learn/digital-trunking/ }
+related_reading:
+  - { title: "Best SDR for GopherTrunk", url: /best-sdr-for-gophertrunk/ }
+cite_urls:
+  - https://www.yaesu.com/product-detail.aspx?Model=FTM-510DRASP&CatName=VHF%2FUHF+Mobile+Transceivers
+  - https://www.dxengineering.com/parts/ysu-ftm-500dr
+faq:
+  - q: "Is the Yaesu FTM-500DR still worth buying in 2026?"
+    a: "Yes, while genuine new stock lasts. Yaesu released the FTM-510DR in 2025 as its direct successor, and dealers now treat the 500DR as late-life — but the radio itself is unchanged and remains the best all-around 2m/70cm mobile at its price. If 500DR stock dries up or prices converge, buy the 510DR instead."
+  - q: "Does the FTM-500DR do APRS?"
+    a: "Yes — full APRS with a built-in GPS and a 1200/9600 bps modem, one of the best APRS implementations in any mobile. It beacons, receives, and displays stations without any external hardware."
+  - q: "Can I program the FTM-500DR with CHIRP?"
+    a: "No. CHIRP does not support it. You program it via the microSD card, Yaesu's free ADMS-14 software, or the paid RT Systems ADMS-14 package."
+  - q: "Does the FTM-500DR decode both bands in C4FM at once?"
+    a: "No. It receives two bands at once (V+U, V+V, or U+U), but only one band decodes C4FM digital at a time — a common gripe on an otherwise excellent dual-receive radio."
+  - q: "Do I need a license to use the FTM-500DR?"
+    a: "To transmit, yes — an FCC amateur license, Technician class or higher (Part 97). Listening requires no license at all; you can legally monitor the same repeaters with the radio, or for about $30 with an RTL-SDR running free GopherTrunk."
+---
+**The Yaesu FTM-500DR** is a 50-watt 2m/70cm mobile transceiver that does analog FM
+and **C4FM [System Fusion](/reference/system-fusion-ysf/)** digital, receives two
+bands at once, and packs in built-in GPS, full [APRS](/reference/aprs/), Bluetooth,
+a band scope, and Yaesu's signature **AESS dual-speaker audio**.[^yaesu] It is the
+best all-around VHF/UHF mobile you can bolt into a vehicle — with one honest
+caveat: Yaesu shipped its successor, the **FTM-510DR**, in 2025, so the 500DR is a
+late-life buy.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0CLSGMLPC?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Our best-overall mobile pick** in the [top 10 mobile ham radios](/best-mobile-ham-radios/).
+**50 W on 2m and 70cm**, FM + [C4FM](/reference/c4fm/) with auto mode select, **dual
+receive**, GPS + [APRS](/reference/aprs/) built in, Bluetooth, detachable color-display
+head. **The AESS dual-speaker audio is its signature** — widely praised TX and RX
+audio. **~$500 new while stock lasts**; the FTM-510DR (around $650) is the 2025
+successor. **No CHIRP** — program via microSD or ADMS-14. Transmitting needs a ham
+license; listening doesn't.
+</div>
+
+## Overview
+
+The FTM-500DR sits at the top of Yaesu's classic Fusion mobile line, above the
+[FTM-300DR](/reference/yaesu-ftm-300dr/). The headline is audio: a front-panel
+speaker in the detachable control head plus a body speaker form the **AESS**
+acoustic system, and the community consensus is that both its transmit and receive
+audio are excellent. The high-visibility 2.4-inch color TFT uses a "funnel"
+heads-up layout that is genuinely readable at a glance while driving, and the
+menus are far cleaner than the old FTM-400's — though there is **no touchscreen**,
+which some buyers expected at this price.
+
+RF is what you'd expect from Yaesu's flagship mobile: a solid receiver, 50/25/5 W
+on both bands, and dual receive in any combination (V+U, V+V, U+U). Memory
+management runs to roughly 1,100 channels with microSD backup and cloning, and the
+radio can act as a portable WiRES-X digital node. There is no cross-band repeat.
+Budget ~13–15 A of 13.8 V supply at full power.
+
+**The late-life note, plainly:** Yaesu's 2025 **FTM-510DR** adds a "Super-DX"
+receive preamp mode and ASP digital audio processing, and it now occupies Yaesu's
+current mobile page while dealers move the 500DR to special-order status. Yaesu
+has not published a formal discontinuation date, and new 500DR stock is still
+real at Amazon and the big ham dealers. While that stock is genuinely new and
+~$150 cheaper than the 510DR, the 500DR remains the smarter buy; once it's gone,
+move on to the successor rather than paying scalper prices.
+
+## Modes &amp; features
+
+- **Analog FM and [C4FM System Fusion](/reference/system-fusion-ysf/)** with AMS
+  (auto mode select) — the radio follows whatever the repeater is doing. Note only
+  **one band decodes C4FM at a time** on dual receive.
+- **Built-in GPS and full [APRS](/reference/aprs/)** with a 1200/9600 bps modem —
+  beaconing, messaging and station lists with zero outboard boxes. One of the best
+  APRS implementations in any mobile.
+- **Bluetooth** for headsets (pairing is picky about which headsets — a known
+  gripe), **band scope**, microSD logging/cloning, and WiRES-X portable digital
+  node capability.
+- **Honest mode caveat:** Fusion is a distant third digital network behind
+  [DMR](/reference/dmr/) and [D-STAR](/reference/d-star/) in many regions. Check
+  what your local repeaters actually run before you pick your digital camp — the
+  [GopherTrunk alternative](#gophertrunk-alternative) below is the free way to do
+  exactly that.
+
+## Programming
+
+CHIRP does **not** support the FTM-500DR. Three paths, easiest first:
+
+1. **microSD card** — export, edit, and clone the whole configuration.
+2. **Yaesu ADMS-14** — Yaesu's free PC programmer.
+3. **RT Systems ADMS-14** — the paid, more polished third-party option.
+
+## GopherTrunk alternative
+
+GopherTrunk **receives; it cannot transmit**, so it is not a substitute for the
+FTM-500DR — but it is the smartest thing to run *before* you buy it. A ~$30
+[RTL-SDR](/reference/rtl-sdr/) running free GopherTrunk lets you monitor your
+local repeaters and digital ham traffic and see whether the Fusion, DMR, or
+D-STAR side of town is actually active — before you commit $500 to a digital
+camp. It also **records and logs** everything it hears, which no mobile
+transceiver does. Listening requires no license; transmitting on ham bands
+requires an FCC Technician (or higher) license under Part 97. See
+[the best SDRs for GopherTrunk](/best-sdr-for-gophertrunk/) for hardware that
+pairs well.
+
+## Who it's for
+
+- **Buy the FTM-500DR** if you want the best overall FM/C4FM mobile — top-tier
+  audio, dual receive, GPS/APRS, Bluetooth — and can still get it at ~$500 new.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B0CLSGMLPC?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [FTM-300DR](/reference/yaesu-ftm-300dr/)** for most of the same Fusion
+  feature set around $400 in new-old-stock, or the FTM-510DR if 500DR stock is gone.
+- **Buy the [AnyTone AT-D578UVIII Plus](/reference/anytone-at-d578uviii/)** instead
+  if your area runs [DMR](/reference/dmr/), or the
+  [Icom ID-5100A](/reference/icom-id-5100a/) for [D-STAR](/reference/d-star/).
+- Still comparing? See the full
+  [best mobile ham radios guide](/best-mobile-ham-radios/).
+
+## Sources
+
+[^yaesu]: [Yaesu VHF/UHF mobile lineup — FTM-510DR/ASP product page](https://www.yaesu.com/product-detail.aspx?Model=FTM-510DRASP&CatName=VHF%2FUHF+Mobile+Transceivers) — Yaesu, showing the FTM-510DR as the current-line successor; and [DX Engineering FTM-500DR listing](https://www.dxengineering.com/parts/ysu-ftm-500dr) — dealer status, specifications, and pricing for the FTM-500DR.

--- a/docs/reference/yaesu-vx-8dr.md
+++ b/docs/reference/yaesu-vx-8dr.md
@@ -1,0 +1,140 @@
+---
+slug: yaesu-vx-8dr
+title: Yaesu VX-8DR
+entry_type: hardware
+category: ham-radios
+description: "The Yaesu VX-8DR is a discontinued quad-band (50/144/222/430 MHz) submersible APRS handheld — a cult classic never repeated, living on the used market at roughly $250–400."
+keywords: Yaesu VX-8DR, VX-8DR review, quad band handheld, VX-8DR used price, discontinued Yaesu HT, 6 meter handheld, submersible ham radio, APRS handheld classic, VX-8DR vs FT-5DR, BU-1 Bluetooth
+aka: [VX-8DR, VX-8]
+autolink: true
+affiliate: true
+product:
+  name: "Yaesu VX-8DR"
+  brand: Yaesu
+  category: Ham handheld transceiver
+  lowPrice: "250"
+  highPrice: "400"
+  seller: eBay
+  itemCondition: used
+  url: https://www.ebay.com/sch/i.html?_nkw=Yaesu+VX-8DR
+infobox:
+  - { label: Type, value: "Quad-band handheld transceiver (discontinued ~2015)" }
+  - { label: Bands, value: "TX 50/144/222/430 MHz; RX 0.5–999 MHz" }
+  - { label: Modes, value: "Analog FM; APRS 1200/9600" }
+  - { label: Power, value: "5 W (1.5 W on 222 MHz)" }
+  - { label: Programming, value: "ADMS-VX8, RT Systems; CHIRP partial" }
+  - { label: Price, value: "roughly $250–400 used" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.ebay.com/sch/i.html?_nkw=Yaesu+VX-8DR\" rel=\"nofollow noopener\">Find on eBay &rarr;</a>" }
+see_also: [yaesu-ft-5dr, kenwood-th-f6a, kenwood-th-d75a, yaesu-ft-60r, rtl-sdr, aprs]
+related_lessons:
+  - { title: "Analog vs. digital voice", url: /learn/rf-sdr/digital-voice/ }
+  - { title: "Legal & ethical monitoring", url: /learn/rf-sdr/legal-ethical/ }
+related_reading:
+  - { title: "Police scanner vs GopherTrunk", url: /police-scanner-vs-sdr/ }
+cite_urls:
+  - https://www.universal-radio.com/catalog/ht/0008.html
+  - https://www.dxengineering.com/parts/ysu-vx-8dr
+faq:
+  - q: "Why do people still hunt for the Yaesu VX-8DR?"
+    a: "Because its combination — quad-band transmit including 6 m and 220, submersible body, built-in APRS, dual independent receivers — has never been repeated. Yaesu's own successor line (FT1DR through today's FT-5DR) dropped 6 m and 220."
+  - q: "What does a used VX-8DR cost?"
+    a: "Roughly $250–400 on eBay depending on condition and whether the coveted accessories (FGPS-2 GPS, BU-1 Bluetooth module, CD-41 cradle) are included — but recent sold-comp data is thin, so check current eBay sold listings before treating any number as firm."
+  - q: "Does the VX-8DR have GPS and Bluetooth?"
+    a: "Only as add-on modules — the FGPS-2 GPS and BU-1 Bluetooth were optional, both are long discontinued, and both are now scarce and expensive used. The BU-1 was flaky even when new, with pairing quirks and limited headset compatibility."
+  - q: "Is a used VX-8DR still waterproof?"
+    a: "Treat the IPX57 submersible rating as expired. The gaskets on any surviving unit are 10–15 years old; unless it has been resealed, don't dunk it."
+  - q: "Do I need a license to use a VX-8DR?"
+    a: "Transmitting requires an FCC amateur license (Technician class minimum). Listening — including its 0.5–999 MHz dual receive with broadcast and air band — requires none."
+---
+**The Yaesu VX-8DR** is the quad-bander nobody ever built again: 5 W on **50,
+144 and 430 MHz** plus 1.5 W on **222 MHz**, a submersible IPX57 body,
+built-in [APRS](/reference/aprs/) with a 1200/9600 bps modem, dual independent
+receivers spanning 0.5–999 MHz — even a barometric sensor.[^univ] Discontinued
+circa 2015, it survives as a cult classic on the used market at roughly
+**$250–400**, and its successor line never restored 6 m or 220.
+
+<a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=Yaesu+VX-8DR" rel="nofollow noopener">Find on eBay &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The unrepeated quad-band classic** — beloved by SOTA and backpacking
+operators. The used-market catches are real: **GPS and Bluetooth were add-on
+modules**, both long discontinued and now scarce (the BU-1 Bluetooth was flaky
+even new); **waterproofing gaskets are 10–15 years old**, so treat IPX57 as
+expired; batteries are aging; and sold-comp pricing data is thin — verify
+before you bid. Out of production: **eBay, hamfests and the QRZ swapmeet** are
+where it lives. Transmitting needs an FCC Technician license; listening needs
+none.
+</div>
+
+## Overview
+
+Between 2008 and roughly 2015 the VX-8DR was Yaesu's do-everything flagship,
+and its spec sheet still reads like a dare: four transmit bands (very few HTs
+ever offered 6 m *and* 220), two genuinely independent receivers, wideband
+coverage including AM/FM broadcast and air band, submersible construction, and
+APRS built in — with position data from the optional FGPS-2 GPS mounted in the
+speaker-mic or at the antenna base. The APRS-flagship torch passed down the
+FT1DR → FT2DR → FT3DR line to today's
+[FT-5DR](/reference/yaesu-ft-5dr/), which added [C4FM](/reference/c4fm/) and a
+color screen but dropped two bands along the way.
+
+**Used-market viability**: this is a buy-with-eyes-open radio. Asking prices
+run roughly $250–400 depending on condition and accessories — a 2022 forum
+sale at $375 with extras marks the upper band — but recent sold-comp data is
+thin, so spot-check eBay sold listings yourself. The known failure points:
+the **FGPS-2 and BU-1 modules are discontinued and scarce** (and the BU-1
+Bluetooth was flaky when new — pairing quirks, limited headset compatibility);
+**submersion gaskets are past their life** — assume the IPX57 rating is
+expired unless the unit has been resealed; FNB-102LI batteries are aging
+(clones exist); and the proprietary screw-on antenna/GPS connector limits your
+options. A unit bundled with the modules and cradle is worth the premium.
+
+## Modes &amp; features
+
+- **TX**: analog FM on 50/144/222/430 MHz — 5 W except 1.5 W on 222.
+- **[APRS](/reference/aprs/)** 1200/9600 bps modem built in (GPS optional via
+  FGPS-2).
+- **RX**: 0.5–999 MHz with **dual independent receivers**; AM/FM broadcast and
+  air band.
+- **IPX57 submersible when new** (3 ft / 30 min) — treat as expired on any
+  used example; barometric sensor; 900+ memories.
+- **No digital voice** — analog and APRS only.
+
+## Programming
+
+Yaesu's ADMS-VX8 or RT Systems software over the proprietary CT-131/USB cable
+is the dependable route. **CHIRP support is partial** — the VX-8 family appears
+but has historically had clone-mode quirks and doesn't cover APRS settings, so
+verify the current driver state before counting on it.
+
+## GopherTrunk alternative
+
+GopherTrunk receives only, so it can't replace the thing that makes a VX-8DR
+worth hunting — quad-band transmit. But if what draws you is the *receiver*
+half (dual wideband RX, broadcast, air band), a ~$30
+[RTL-SDR](/reference/rtl-sdr/) running free GopherTrunk does that job better on
+every axis except portability: waterfall display, digital decode
+([DMR](/reference/dmr/), [C4FM](/reference/c4fm/),
+[D-STAR](/reference/d-star/)), and recording/logging of everything it hears.
+Monitor first with the SDR
+([best SDR for GopherTrunk](/best-sdr-for-gophertrunk/)), and save the used-
+market hunt for when you specifically need those four transmit bands.
+
+## Who it's for
+
+- **Buy a used VX-8DR** if you want 6 m and 220 in one pocket radio and accept
+  the aging-hardware realities — ideally a bundle with the GPS/Bluetooth
+  modules included.
+  <a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=Yaesu+VX-8DR" rel="nofollow noopener">Find on eBay &rarr;</a>
+- **Buy the [Yaesu FT-5DR](/reference/yaesu-ft-5dr/)** new (~$380) for the
+  modern APRS Yaesu — C4FM, color screen, current IPX7 gaskets — minus 6 m
+  and 220.
+- **Consider the [Kenwood TH-F6A](/reference/kenwood-th-f6a/)** (~$200–275
+  used) if 220 MHz matters but 6 m doesn't — it's our overall used-classic
+  pick, being cheaper with fewer scarce-parts risks. Full rankings:
+  [best handheld ham radios](/best-handheld-ham-radios/).
+
+## Sources
+
+[^univ]: [Yaesu VX-8DR at Universal Radio](https://www.universal-radio.com/catalog/ht/0008.html) and [DX Engineering's VX-8DR reference page](https://www.dxengineering.com/parts/ysu-vx-8dr) — on quad-band output, APRS modem, dual receive, IPX57 submersion rating, and the optional FGPS-2/BU-1 modules.


### PR DESCRIPTION
Groundwork for the ham radio buyer's guides: a ham-radios reference
category (30 transceivers), a Ham radios nav heading under Hardware,
an llms.txt buyer's-guide section, optional seller/itemCondition in the
Product JSON-LD for used-market gear, and an eBay sentence in the
affiliate disclosure (no eBay affiliate relationship).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01P4WkHNzqEqLWZzzmCvsiJ1