### PR TITLE
docs: consumer two-way radio buyer's guides (walkie-talkies, GMRS mobile, CB) + 30 Field Guide pages

### DIFF
--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -229,6 +229,15 @@ groups:
         url: /best-handheld-ham-radios/
       - title: "All ham radios (Field Guide)"
         url: /reference/#ham-radios
+      - heading: Two-way radios
+      - title: Best walkie-talkies
+        url: /best-walkie-talkies/
+      - title: Best GMRS mobile radios
+        url: /best-gmrs-mobile-radios/
+      - title: Best CB radios
+        url: /best-cb-radios/
+      - title: "All two-way radios (Field Guide)"
+        url: /reference/#two-way-radios
       - heading: SDRs & receivers
       - title: Best SDR for GopherTrunk
         url: /best-sdr-for-gophertrunk/

--- a/docs/_data/reference.yml
+++ b/docs/_data/reference.yml
@@ -881,7 +881,7 @@ domains:
         blurb: Walkie-talkies, GMRS mobile rigs, and CB radios — consumer two-way services that need no exam (GMRS takes a $35 no-test FCC license; FRS and CB are license-free). Listening is free with any of them or an SDR + GopherTrunk.
         entries:
           - { slug: rocky-talkie-mountain-radio, title: Rocky Talkie Mountain Radio, type: hardware }
-          - { slug: rocky-talkie-5-watt, title: Rocky Talkie 5 Watt Radio, type: hardware }
+          - { slug: rocky-talkie-5-watt, title: Rocky Talkie Expedition Radio (5 Watt), type: hardware }
           - { slug: midland-gxt1000vp4, title: Midland GXT1000VP4, type: hardware }
           - { slug: motorola-talkabout-t800, title: Motorola Talkabout T800, type: hardware }
           - { slug: baofeng-uv-5g-plus, title: Baofeng UV-5G Plus, type: hardware }
@@ -902,9 +902,9 @@ domains:
           - { slug: btech-gmrs-50x1, title: BTECH GMRS-50X1, type: hardware }
           - { slug: cobra-29-lx, title: Cobra 29 LX, type: hardware }
           - { slug: cobra-29-ltd-classic, title: Cobra 29 LTD Classic, type: hardware }
-          - { slug: uniden-bearcat-880, title: Uniden Bearcat 880, type: hardware }
+          - { slug: uniden-bearcat-880, title: Uniden Bearcat 880FM, type: hardware }
           - { slug: uniden-bearcat-980ssb, title: Uniden Bearcat 980SSB, type: hardware }
-          - { slug: president-mckinley, title: President McKinley USA, type: hardware }
+          - { slug: president-mckinley, title: President McKinley II, type: hardware }
           - { slug: uniden-pro505xl, title: Uniden PRO505XL, type: hardware }
           - { slug: cobra-75-all-road, title: Cobra 75 All Road, type: hardware }
           - { slug: midland-75-822, title: Midland 75-822, type: hardware }

--- a/docs/_data/reference.yml
+++ b/docs/_data/reference.yml
@@ -876,6 +876,41 @@ domains:
           - { slug: kenwood-th-f6a, title: Kenwood TH-F6A, type: hardware }
           - { slug: yaesu-vx-8dr, title: Yaesu VX-8DR, type: hardware }
 
+      - id: two-way-radios
+        label: Consumer two-way radios (FRS, GMRS & CB)
+        blurb: Walkie-talkies, GMRS mobile rigs, and CB radios — consumer two-way services that need no exam (GMRS takes a $35 no-test FCC license; FRS and CB are license-free). Listening is free with any of them or an SDR + GopherTrunk.
+        entries:
+          - { slug: rocky-talkie-mountain-radio, title: Rocky Talkie Mountain Radio, type: hardware }
+          - { slug: rocky-talkie-5-watt, title: Rocky Talkie 5 Watt Radio, type: hardware }
+          - { slug: midland-gxt1000vp4, title: Midland GXT1000VP4, type: hardware }
+          - { slug: motorola-talkabout-t800, title: Motorola Talkabout T800, type: hardware }
+          - { slug: baofeng-uv-5g-plus, title: Baofeng UV-5G Plus, type: hardware }
+          - { slug: baofeng-gm-15-pro, title: Baofeng GM-15 Pro, type: hardware }
+          - { slug: btech-gmrs-pro, title: BTECH GMRS-PRO, type: hardware }
+          - { slug: wouxun-kg-935g, title: Wouxun KG-935G, type: hardware }
+          - { slug: garmin-rino-755t, title: Garmin Rino 755t, type: hardware }
+          - { slug: motorola-talkabout-mr350r, title: Motorola Talkabout MR350R, type: hardware }
+          - { slug: midland-mxt575, title: Midland MXT575, type: hardware }
+          - { slug: midland-mxt500, title: Midland MXT500, type: hardware }
+          - { slug: midland-mxt275, title: Midland MXT275, type: hardware }
+          - { slug: wouxun-kg-1000g-plus, title: Wouxun KG-1000G Plus, type: hardware }
+          - { slug: wouxun-kg-xs20g, title: Wouxun KG-XS20G, type: hardware }
+          - { slug: radioddity-db20-g, title: Radioddity DB20-G, type: hardware }
+          - { slug: btech-gmrs-50pro, title: BTECH GMRS-50PRO, type: hardware }
+          - { slug: midland-mxt115, title: Midland MXT115, type: hardware }
+          - { slug: midland-mxt400, title: Midland MXT400, type: hardware }
+          - { slug: btech-gmrs-50x1, title: BTECH GMRS-50X1, type: hardware }
+          - { slug: cobra-29-lx, title: Cobra 29 LX, type: hardware }
+          - { slug: cobra-29-ltd-classic, title: Cobra 29 LTD Classic, type: hardware }
+          - { slug: uniden-bearcat-880, title: Uniden Bearcat 880, type: hardware }
+          - { slug: uniden-bearcat-980ssb, title: Uniden Bearcat 980SSB, type: hardware }
+          - { slug: president-mckinley, title: President McKinley USA, type: hardware }
+          - { slug: uniden-pro505xl, title: Uniden PRO505XL, type: hardware }
+          - { slug: cobra-75-all-road, title: Cobra 75 All Road, type: hardware }
+          - { slug: midland-75-822, title: Midland 75-822, type: hardware }
+          - { slug: cobra-2000-gtl, title: Cobra 2000 GTL, type: hardware }
+          - { slug: uniden-grant-xl, title: Uniden Grant XL, type: hardware }
+
       - id: rf-front-end
         label: RF front-end & components
         blurb: The components between the antenna and the receiver — amplifiers, filters, mixers, connectors, and references.

--- a/docs/_data/reference.yml
+++ b/docs/_data/reference.yml
@@ -894,7 +894,7 @@ domains:
           - { slug: midland-mxt500, title: Midland MXT500, type: hardware }
           - { slug: midland-mxt275, title: Midland MXT275, type: hardware }
           - { slug: wouxun-kg-1000g-plus, title: Wouxun KG-1000G Plus, type: hardware }
-          - { slug: wouxun-kg-xs20g, title: Wouxun KG-XS20G, type: hardware }
+          - { slug: wouxun-kg-xs20g, title: Wouxun KG-XS20G Plus, type: hardware }
           - { slug: radioddity-db20-g, title: Radioddity DB20-G, type: hardware }
           - { slug: btech-gmrs-50pro, title: BTECH GMRS-50PRO, type: hardware }
           - { slug: midland-mxt115, title: Midland MXT115, type: hardware }

--- a/docs/best-cb-radios.md
+++ b/docs/best-cb-radios.md
@@ -1,0 +1,258 @@
+---
+layout: page
+title: "The 10 Best CB Radios (2026 Buyer's Guide)"
+description: "The best CB radios of 2026, ranked — Uniden Bearcat 880FM, President McKinley II, Bearcat 980SSB, Cobra 29 LTD and 29 LX, Cobra 75 All Road and more — with honest grades, AM vs FM vs SSB explained, and used-classic picks."
+keywords: best CB radio, best CB radio 2026, best CB radio for truckers, CB radio buying guide, AM FM SSB CB radio, best SSB CB radio, CB radio for off-road, do I need a license for CB radio, Uniden Bearcat 880FM, President McKinley II, cheap CB radio, CB channel 19
+permalink: /best-cb-radios/
+nav_group: Hardware
+affiliate: true
+faq:
+  - q: "What is the best CB radio in 2026?"
+    a: "The Uniden Bearcat 880FM. AM/FM dual mode, NOAA weather with alerts, the best display in the class, and a built-in SWR calibration meter that makes it the easiest first install — all for around $130–150. Nothing else covers as many buyers as well."
+  - q: "Do I need a license for a CB radio?"
+    a: "No. CB is 'licensed by rule' under FCC Part 95D — no exam, no fee, no paperwork for anyone. The legal limits are 4 watts carrier on AM and FM and 12 watts PEP on single sideband, across 40 channels at 26.965–27.405 MHz."
+  - q: "What is the best SSB CB radio?"
+    a: "The President McKinley II FCC — owner consensus puts its receiver and noise blanker at the top of the current class, and it's the only current rig with all three legal modes (AM/FM/SSB). The Uniden Bearcat 980SSB gets you sideband for roughly $50 less if you can live with its sunlight-shy display."
+  - q: "What CB channel do truckers use?"
+    a: "Channel 19 (27.185 MHz) is the de-facto highway and trucker channel nationwide; channel 9 is reserved for emergencies and motorist assistance. Both conventions are worth knowing before you key up."
+  - q: "Is AM, FM, or SSB better on CB?"
+    a: "AM is what everyone actually talks on, channel 19 included. FM (legal since 2021) is quieter between radios that both have it, but AM-only radios can't hear it. SSB roughly doubles range with 12 W PEP — and only works station-to-station when both ends have SSB. Buy AM/FM for the highway, add SSB if you'll seek out other SSB operators."
+---
+
+# The 10 Best CB Radios (2026 Buyer's Guide)
+
+**The best CB radio is the one matched to where you'll actually talk** — a
+trucker living on channel 19 needs different iron than an off-roader running
+trail comms or a hobbyist chasing distant stations on sideband. The good news
+frames everything below: **CB is completely license-free** — "licensed by
+rule" under FCC Part 95D, no exam, no fee — with legal limits of **4 W on
+AM/FM and 12 W PEP on SSB** across 40 channels at 27 MHz. **FM on CB has only
+been legal since 2021**, so a radio's revision date now matters: current
+production is increasingly AM/FM, while older AM-only stock still sits on
+shelves.
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Best overall:** [Uniden Bearcat 880FM](/reference/uniden-bearcat-880/)
+(~$130–150, AM/FM, easiest install). **Best features for the price:**
+[President McKinley II](/reference/president-mckinley/) — the only AM/FM/SSB
+rig, class-best receiver (~$180–230). **Most affordable:**
+[Uniden PRO505XL](/reference/uniden-pro505xl/) (~$50–65, reported
+discontinued — while stock lasts). **Best used/classic:**
+[Uniden Grant XL](/reference/uniden-grant-xl/) (~$50–250, eBay) — the
+[Cobra 2000 GTL](/reference/cobra-2000-gtl/) is the grander base but now
+collector-priced. **Know the conventions:** channel 19 = highway, channel 9 =
+emergency. And whatever you buy, **the antenna and its SWR tuning matter more
+than the radio.**
+</div>
+
+## Quick picks
+
+<div class="pick-cards" markdown="0">
+<div class="pick-card pick-card--top">
+<span class="pick-card__badge">Best overall</span>
+<h3>Uniden Bearcat 880FM</h3>
+<p class="pick-card__price">around $130–150</p>
+<p>AM/FM, NOAA weather with alerts, the class-best display, and a built-in SWR meter that makes the hardest part of a CB install trivial. The one to buy if you're not sure.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0C8QDQMKK?tag=gophertrunk-20" rel="nofollow sponsored noopener">Bearcat 880FM on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/uniden-bearcat-880/">Bearcat 880FM details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Best features for the price</span>
+<h3>President McKinley II</h3>
+<p class="pick-card__price">around $180–230</p>
+<p>The only current CB with AM, FM, and 12 W PEP SSB — wrapped around the best receiver and noise blanker in the class, with 12/24 V supply and an automatic SWR check.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0CGRZC8CX?tag=gophertrunk-20" rel="nofollow sponsored noopener">McKinley II on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/president-mckinley/">McKinley II details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Most affordable</span>
+<h3>Uniden PRO505XL</h3>
+<p class="pick-card__price">around $50–65</p>
+<p>The $60 trail beater: tiny, simple, legal 4 W AM. Dealer-reported discontinued — new stock remains, so it keeps this badge exactly as long as it lasts.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B005ZLB0E4?tag=gophertrunk-20" rel="nofollow sponsored noopener">PRO505XL on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/uniden-pro505xl/">PRO505XL details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Best used/classic buy</span>
+<h3>Uniden Grant XL</h3>
+<p class="pick-card__price">around $50–250 used</p>
+<p>The classic SSB workhorse — superb audio, 1990s build quality, every CB shop knows it. eBay and hamfests only; check the clarifier for mods before paying.</p>
+<a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=Uniden+Grant+XL" rel="nofollow noopener">Find on eBay &rarr;</a>
+<p class="pick-card__note"><a href="/reference/uniden-grant-xl/">Grant XL details</a></p>
+</div>
+</div>
+
+## How we grade
+
+Every radio here is judged on the same six criteria: **RF performance**
+(receiver quality and selectivity, transmit audio), **Coverage &amp; modes**
+(AM/FM/SSB, NOAA weather), **Power &amp; duty** (output within the service's
+legal limit, thermal behavior), **Usability &amp; programming** (controls,
+menus, install aids like SWR metering), **Ecosystem &amp; support** (service,
+parts, accessories, community), and **Value** (what the street price buys).
+No star ratings, no invented scores — table grades run
+Excellent/Good/Fair/Basic, and the two vintage rigs also get a prose
+used-market viability check. The same rubric runs our
+[best walkie-talkies](/best-walkie-talkies/) and
+[best GMRS mobile radios](/best-gmrs-mobile-radios/) guides — and our ham
+guides ([best ham base stations](/best-ham-radio-base-stations/) and
+kin) — so grades are comparable across all of them.
+
+## The top 10, ranked
+
+### 1. Uniden Bearcat 880FM — best overall
+
+Good **RF performance**, the best **Usability** in CB — 7-color display,
+backlit controls, and a built-in SWR meter that makes it the easiest first
+install — plus AM/FM and NOAA alerts at ~$140. It supersedes the AM-only
+Bearcat 880; don't pay old-stock prices for the original.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0C8QDQMKK?tag=gophertrunk-20" rel="nofollow sponsored noopener">880FM on Amazon &rarr;</a> · [Bearcat 880FM review](/reference/uniden-bearcat-880/)
+
+### 2. President McKinley II — best features for the price
+
+Excellent **RF performance** — owner consensus calls its receiver and noise
+blanker the best in the current SSB class — and unmatched **Coverage &amp;
+modes**: the only current rig with AM, FM, *and* 12 W PEP SSB, plus weather,
+automatic SWR check, and a rare 12/24 V supply. Price is the only thing
+keeping it at #2.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0CGRZC8CX?tag=gophertrunk-20" rel="nofollow sponsored noopener">McKinley II on Amazon &rarr;</a> · [McKinley II review](/reference/president-mckinley/)
+
+### 3. Uniden Bearcat 980SSB — cheapest ticket to sideband
+
+The lowest-priced mainstream SSB rig, feature-dense with weather, SWR
+calibration, and talkback — strong **Value**. **Usability** holds it back: the
+most-cited complaint is a display that washes out in direct sunlight, and the
+internal speaker is weak. No FM.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B007B5ZAES?tag=gophertrunk-20" rel="nofollow sponsored noopener">980SSB on Amazon &rarr;</a> · [980SSB review](/reference/uniden-bearcat-980ssb/)
+
+### 4. Cobra 29 LTD Classic — the trucker standard
+
+Fifty-plus years of the 29 line buys the best **Ecosystem &amp; support** in
+CB — every shop can tune and repair it, and the mic/mod aftermarket is
+unmatched. Now AM/FM, ~$105–140. Dated receiver filtering and no weather
+channels keep it off the podium.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0BVGTZCLB?tag=gophertrunk-20" rel="nofollow sponsored noopener">29 LTD on Amazon &rarr;</a> · [29 LTD Classic review](/reference/cobra-29-ltd-classic/)
+
+### 5. Cobra 29 LX — the 29 with weather and a modern face
+
+The same proven 29 platform plus NOAA alerts, a 4-color LCD, and Radio Check
+diagnostics. **Value** is the rub: ~$60 over the LTD for mostly display and
+weather — worth it on the road, skippable otherwise. (No Bluetooth — that's
+the 29 LX MAX.)
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0FDBPJ4FS?tag=gophertrunk-20" rel="nofollow sponsored noopener">29 LX on Amazon &rarr;</a> · [29 LX review](/reference/cobra-29-lx/)
+
+### 6. Cobra 75 All Road — best when there's no dash space
+
+The whole radio in a wireless IP66 handset with a hideaway box — **Usability**
+no full-size rig can match in a modern truck or Jeep. AM/FM and weather
+aboard; the trade is a small handset speaker, a battery to charge, and
+adequate-not-excellent receive.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0BYL3NV6L?tag=gophertrunk-20" rel="nofollow sponsored noopener">75 All Road on Amazon &rarr;</a> · [75 All Road review](/reference/cobra-75-all-road/)
+
+### 7. Midland 75-822 — the 2-in-1 nothing else does
+
+A handheld on AA batteries that slides into a mobile adapter for full 4 W
+into a real antenna — unique **Coverage** flexibility plus 10 NOAA channels.
+Handheld-to-handheld range is ~1 mile (27 MHz physics, not Midland's fault),
+and it's AM-only.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B00000K2YR?tag=gophertrunk-20" rel="nofollow sponsored noopener">75-822 on Amazon &rarr;</a> · [75-822 review](/reference/midland-75-822/)
+
+### 8. Uniden PRO505XL — most affordable
+
+~$60 of honest radio: tiny, simple, reliable, legal 4 W AM. **RF performance**
+is basic (noisy receive at highway speed) and there's no weather or SWR
+metering — and it's dealer-reported discontinued, so this is a
+while-stock-lasts pick.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B005ZLB0E4?tag=gophertrunk-20" rel="nofollow sponsored noopener">PRO505XL on Amazon &rarr;</a> · [PRO505XL review](/reference/uniden-pro505xl/)
+
+### 9. Uniden Grant XL — best used/classic buy
+
+Vintage SSB the sane way: one of the best-sounding AM/SSB mobiles ever,
+~$50–250 used, serviceable at any CB shop. Used-market viability is good *if*
+you check for the near-universal clarifier-unlock mods (R174/D52 area) and
+swapped finals — unlocked units void Part 95 compliance. Thin sold-price
+data; buy on service history.
+<a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=Uniden+Grant+XL" rel="nofollow noopener">Find on eBay &rarr;</a> · [Grant XL review](/reference/uniden-grant-xl/)
+
+### 10. Cobra 2000 GTL — the golden-age base, at collector prices
+
+The legendary AM/SSB base station: frequency counter, dual meters, and a
+receiver still spoken of with reverence. It ranks last only on **Value** —
+asks now run $525–980 (budget ~$450–800), every example is 35–45 years old,
+and a recap plus realignment is practically assumed. Buy it as a collector,
+not a commuter.
+<a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=Cobra+2000+GTL" rel="nofollow noopener">Find on eBay &rarr;</a> · [2000 GTL review](/reference/cobra-2000-gtl/)
+
+## Full comparison
+
+| Radio | RF | Coverage &amp; modes | Usability | Value | ~$ price |
+|---|---|---|---|---|---|
+| [Bearcat 880FM](/reference/uniden-bearcat-880/) | Good | Good | **Excellent** | **Excellent** | ~$130–150 |
+| [President McKinley II](/reference/president-mckinley/) | **Excellent** | **Excellent** | Good | Good | ~$180–230 |
+| [Bearcat 980SSB](/reference/uniden-bearcat-980ssb/) | Good | Good | Fair | **Excellent** | ~$150–210 |
+| [Cobra 29 LTD Classic](/reference/cobra-29-ltd-classic/) | Fair | Fair | Good | Good | ~$105–140 |
+| [Cobra 29 LX](/reference/cobra-29-lx/) | Fair | Good | Good | Fair | ~$150–190 |
+| [Cobra 75 All Road](/reference/cobra-75-all-road/) | Fair | Good | **Excellent** | Good | ~$130–200 |
+| [Midland 75-822](/reference/midland-75-822/) | Fair | Good | Good | Good | ~$90–130 |
+| [Uniden PRO505XL](/reference/uniden-pro505xl/) | Basic | Basic | Good | **Excellent** | ~$50–65 |
+| [Uniden Grant XL](/reference/uniden-grant-xl/) | Good | Fair | Fair | Good | ~$50–250 used |
+| [Cobra 2000 GTL](/reference/cobra-2000-gtl/) | **Excellent** | Fair | Good | Fair | ~$450–800+ used |
+
+> **The antenna is the radio.** On 27 MHz, antenna quality and
+> [SWR tuning](/reference/standing-wave-ratio/) swing performance far more
+> than any difference between these rigs — a $60 radio into a well-tuned
+> antenna beats a $200 radio into a bad one. Tune at install, every time.
+
+## AM vs FM vs SSB — the honest version
+
+**AM is where the people are.** Channel 19 highway traffic is AM and will be
+for years, because installed radios don't upgrade themselves. **FM** (legal
+since the FCC's 2021 rule change) is noticeably quieter between two radios
+that both have it — great for a convoy or trail group buying new gear
+together, inaudible to the AM-only radio in the next truck. **SSB** is the
+range play: 12 W PEP concentrated into a narrow signal can double
+station-to-station distance — *and it only works when both ends run SSB.*
+Buying a [980SSB](/reference/uniden-bearcat-980ssb/) or
+[McKinley II](/reference/president-mckinley/) doesn't extend your reach to
+channel 19; it opens a second, longer-range world (by convention, channels
+36–40 LSB) populated by hobbyists who sought it out. Match the radio to the
+people you'll talk to: **truckers** want AM/FM and shop-serviceability
+([29 LTD](/reference/cobra-29-ltd-classic/), [880FM](/reference/uniden-bearcat-880/)),
+**off-roaders** want compact and weather-capable
+([75 All Road](/reference/cobra-75-all-road/), [PRO505XL](/reference/uniden-pro505xl/),
+[75-822](/reference/midland-75-822/)), and **hobbyists** want SSB
+([McKinley II](/reference/president-mckinley/), or a vintage
+[Grant XL](/reference/uniden-grant-xl/)).
+
+## How to choose
+
+- **First CB, want it easy?** [Bearcat 880FM](/reference/uniden-bearcat-880/) —
+  the built-in SWR meter alone earns it.
+- **Serious about range and receive?**
+  [McKinley II](/reference/president-mckinley/); the
+  [980SSB](/reference/uniden-bearcat-980ssb/) if the budget stops $50 short.
+- **Trucker who wants the standard?**
+  [29 LTD Classic](/reference/cobra-29-ltd-classic/); the
+  [29 LX](/reference/cobra-29-lx/) if you want weather alerts.
+- **No dash space?** [Cobra 75 All Road](/reference/cobra-75-all-road/).
+  **Multiple vehicles?** [Midland 75-822](/reference/midland-75-822/).
+- **Sixty bucks, done?** [PRO505XL](/reference/uniden-pro505xl/) — while
+  stock lasts.
+- **Vintage itch?** [Grant XL](/reference/uniden-grant-xl/) for the wallet,
+  [2000 GTL](/reference/cobra-2000-gtl/) for the shelf of honor.
+
+## Bottom line
+
+The **[Bearcat 880FM](/reference/uniden-bearcat-880/)** is the best CB for
+most people in 2026; the **[McKinley II](/reference/president-mckinley/)** is
+the enthusiast's rig; the **[PRO505XL](/reference/uniden-pro505xl/)** is the
+budget answer while it lasts; and a checked-out
+**[Grant XL](/reference/uniden-grant-xl/)** is the smart classic. If your
+real need is short-range group comms rather than highway culture, UHF serves
+it better — see [best walkie-talkies](/best-walkie-talkies/) and
+[best GMRS mobile radios](/best-gmrs-mobile-radios/), graded on the same
+rubric. And if what you actually want is *real* HF range — hundreds or
+thousands of miles, legally — CB's 4 watts will always frustrate you: get
+licensed and see [best ham radio base stations](/best-ham-radio-base-stations/)
+(or start portable with [best handheld ham radios](/best-handheld-ham-radios/)).

--- a/docs/best-gmrs-mobile-radios.md
+++ b/docs/best-gmrs-mobile-radios.md
@@ -1,0 +1,260 @@
+---
+layout: page
+title: "The 10 Best GMRS Mobile &amp; Base Radios (2026 Buyer's Guide)"
+description: "The best GMRS mobile and base radios of 2026, ranked — Midland MXT575, Wouxun KG-1000G Plus, BTECH GMRS-50PRO, Radioddity DB20-G and more — with honest grades, the $35 no-test license explained, and why repeater access beats raw wattage."
+keywords: best GMRS mobile radio, best GMRS mobile radio 2026, best GMRS base station, 50 watt GMRS radio, GMRS repeater radio, gmrs license, Midland MXT575, Wouxun KG-1000G Plus, BTECH GMRS-50PRO, Radioddity DB20-G, GMRS radio for overlanding, GMRS split tones
+permalink: /best-gmrs-mobile-radios/
+nav_group: Hardware
+affiliate: true
+faq:
+  - q: "What is the best GMRS mobile radio in 2026?"
+    a: "The Midland MXT575. Fifty legal watts, repeater support with split tones on current units, NOAA weather, and the cleanest install in the class — every control lives in the microphone, so the radio itself hides behind the dash. Around $350–400."
+  - q: "Do I need a license for a GMRS mobile radio?"
+    a: "To transmit, yes — but it's the easiest license in radio: $35 to the FCC, valid 10 years, no test, and one license covers your immediate family. Apply online through the FCC ULS and you get a callsign. Listening requires no license at all."
+  - q: "Is 50 watts worth it on GMRS?"
+    a: "Not for simplex — vehicle-to-vehicle UHF is terrain-limited to roughly 1–5 miles regardless of wattage. The real payoff is repeater access: 50 watts and a proper roof-mounted antenna reach distant repeater inputs reliably, and a well-sited repeater extends range to 20–50+ miles."
+  - q: "What are GMRS split tones and why do they matter?"
+    a: "A split-tone repeater uses a different CTCSS/DCS tone on its input than its output. Radios that can only set one tone per channel — older Midlands like the classic MXT115 and original MXT275 — are locked out of those repeaters entirely. Every import in this guide and current Midland 50-watt models support split tones."
+  - q: "Are Chinese GMRS radios like Wouxun and Radioddity legal?"
+    a: "The ones in this guide, yes. All ten radios hold genuine FCC Part 95E grants — the imports are certified because transmit is locked to the GMRS channels, while their wide VHF/UHF coverage is receive-only. 'Import' does not mean uncertified here."
+---
+
+# The 10 Best GMRS Mobile &amp; Base Radios (2026 Buyer's Guide)
+
+**A GMRS mobile is the cheapest way to put real, legal wattage in a vehicle**
+— and the license is the easiest in radio: **$35 to the FCC, good for 10
+years, no test, covering your immediate family**, so one fee outfits the
+whole convoy. Listening requires no license at all — which is why, before
+spending radio money, a
+[$30 RTL-SDR running free GopherTrunk](/reference/rtl-sdr/) is the smart
+first move: it monitors and records your local GMRS traffic and repeater
+activity, so you buy for the repeaters that actually exist near you.
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Best overall:** [Midland MXT575](/reference/midland-mxt575/) (~$350–400,
+50 W, everything in the mic). **Best features for the price:**
+[Wouxun KG-1000G Plus](/reference/wouxun-kg-1000g-plus/) (~$390 — 999
+channels, wideband RX, repeater pairing). **Most affordable:**
+[Radioddity DB20-G](/reference/radioddity-db20-g/) (~$110–130, 20 W, split
+tones, CHIRP). **Best used/classic:**
+[BTECH GMRS-50X1](/reference/btech-gmrs-50x1/) (~$80–160 used). The range
+secret isn't wattage — it's **repeater access with split tones**, explained
+below. All ten radios hold genuine **Part 95E** grants.
+</div>
+
+## Quick picks
+
+<div class="pick-cards" markdown="0">
+<div class="pick-card pick-card--top">
+<span class="pick-card__badge">Best overall</span>
+<h3>Midland MXT575</h3>
+<p class="pick-card__price">around $350–400</p>
+<p>Fifty legal watts with every control in the microphone — the cleanest full-power install in GMRS. Split tones on current units, NOAA weather, Midland support.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B09PF9KCKH?tag=gophertrunk-20" rel="nofollow sponsored noopener">MXT575 on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/midland-mxt575/">MXT575 details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Best features for the price</span>
+<h3>Wouxun KG-1000G Plus</h3>
+<p class="pick-card__price">around $390</p>
+<p>999 channels, wideband receive, detachable faceplate, CHIRP, and two units pair as a full duplex repeater. The enthusiast pick — keep a spare mic.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/s?k=Wouxun+KG-1000G+Plus&tag=gophertrunk-20" rel="nofollow sponsored noopener">Search on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/wouxun-kg-1000g-plus/">KG-1000G Plus details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Most affordable</span>
+<h3>Radioddity DB20-G</h3>
+<p class="pick-card__price">around $110–130</p>
+<p>20 W, ~500 channels, split tones, wideband receive, and CHIRP with a genuine Part 95E grant — nothing else this cheap does the whole repeater job.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B096533TR6?tag=gophertrunk-20" rel="nofollow sponsored noopener">DB20-G on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/radioddity-db20-g/">DB20-G details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Best used/classic buy</span>
+<h3>BTECH GMRS-50X1</h3>
+<p class="pick-card__price">around $80–160 used</p>
+<p>The first cheap 50-watt Part 95E mobile: split tones, huge receive coverage, CHIRP. Superseded twice — which is why it's a used bargain with known, testable quirks.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0932TH6T9?tag=gophertrunk-20" rel="nofollow sponsored noopener">Renewed on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/btech-gmrs-50x1/">GMRS-50X1 details</a></p>
+</div>
+</div>
+
+## Why repeaters beat wattage
+
+Get the physics straight before the shopping. Vehicle-to-vehicle UHF simplex
+is terrain-limited: **roughly 1–5 miles real-world, regardless of wattage** —
+50 W over 15 W buys margin, not miracles. The step change is a **GMRS
+repeater**: a machine on a tower or hilltop that rebroadcasts you, extending
+usable range to **20–50+ miles**. Using one takes three things: a radio with
+the 467 MHz repeater inputs (all ten here have them, with one classic-Midland
+asterisk), programmable [CTCSS](/reference/ctcss/)/[DCS](/reference/dcs/)
+tones — ideally **split tones**, since many club repeaters transmit-encode a
+different tone than they receive-decode, and a radio without split tones is
+locked out — and enough power and antenna to open the input reliably, which
+is where 50 W and a proper roof mount actually earn their money.
+
+One more honesty item: **every radio in this guide holds a genuine FCC Part
+95E grant**, imports included. Wouxun, Radioddity, and BTECH are certified
+because their transmit is locked to the GMRS channels; the wide VHF/UHF
+coverage they advertise is receive-only, and that's what keeps the grant
+legal. "Import" does not mean "uncertified" here — but an unlock hack that
+opens transmit does void the certification, and we don't recommend it.
+
+## How we grade
+
+Every radio is judged on the same six criteria: **RF performance** (receiver
+quality/selectivity, transmit audio), **Coverage &amp; modes** (channels,
+repeater support, NOAA weather, receive coverage), **Power &amp; duty**
+(output within the 50 W legal limit, thermal behavior), **Usability &amp;
+programming** (controls, menus, app/CHIRP/software support), **Ecosystem
+&amp; support** (firmware, service, parts, accessories, community), and
+**Value** (what the street price buys). No star ratings, no invented scores —
+table grades run Excellent/Good/Fair/Basic, and aftermarket radios get a
+used-market viability check. The same rubric runs our
+[best walkie-talkies](/best-walkie-talkies/) and
+[best CB radios](/best-cb-radios/) guides — and the ham guides
+([base stations](/best-ham-radio-base-stations/),
+[mobiles](/best-mobile-ham-radios/),
+[handhelds](/best-handheld-ham-radios/)) — so grades are comparable across
+all of them.
+
+## The top 10, ranked
+
+### 1. Midland MXT575 — best overall
+
+Full 50 W, the cleanest install in the class (everything lives in the mic —
+the radio hides behind the dash), split tones on current units, NOAA, and
+real **Ecosystem &amp; support**. Docked only on **Usability &amp;
+programming** depth: Midland-software-only, no CHIRP, rigid repeater
+memories. No GPS — no Midland MXT has it.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B09PF9KCKH?tag=gophertrunk-20" rel="nofollow sponsored noopener">MXT575 on Amazon &rarr;</a> · [MXT575 review](/reference/midland-mxt575/)
+
+### 2. Wouxun KG-1000G Plus — best features for the price
+
+The most feature-complete Part 95E mobile made: 999 channels, full split
+tones, wideband receive with FM broadcast, detachable faceplate, CHIRP, and
+repeater pairing — **Coverage &amp; modes** and **Usability** winners. The
+documented mic/PTT failure pattern (keep a spare mic) and dealer-only
+distribution keep it at #2.
+<a class="btn btn--buy" href="https://www.amazon.com/s?k=Wouxun+KG-1000G+Plus&tag=gophertrunk-20" rel="nofollow sponsored noopener">Search on Amazon &rarr;</a> · [KG-1000G Plus review](/reference/wouxun-kg-1000g-plus/)
+
+### 3. BTECH GMRS-50PRO — the tech-forward 50-watter
+
+Best spec-per-dollar in the 50 W class: real GPS (the only one here),
+Bluetooth app programming with OTA firmware, IP54, split tones, ~$285. What
+holds it at #3 is **Ecosystem &amp; support** by no fault of its own — a 2025
+launch means the long-term record is short.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0DT7KC686?tag=gophertrunk-20" rel="nofollow sponsored noopener">GMRS-50PRO on Amazon &rarr;</a> · [GMRS-50PRO review](/reference/btech-gmrs-50pro/)
+
+### 4. Midland MXT500 — the 50 W Midland with a control head
+
+Same power and repeater chops as the MXT575 in a conventional body with an
+IP66 rating. It gives up nothing on **Power &amp; duty** — but at
+Wouxun-Plus money with no wideband receive, no CHIRP, and a small display,
+**Value** is what keeps it off the podium.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B09PFBWV55?tag=gophertrunk-20" rel="nofollow sponsored noopener">MXT500 on Amazon &rarr;</a> · [MXT500 review](/reference/midland-mxt500/)
+
+### 5. Radioddity DB20-G — most affordable
+
+~$110–130 for 20 W, ~500 channels, split tones, wideband scan, and CHIRP —
+unbeatable **Value**, and a genuine Part 95E grant (it's a re-badged Anytone
+AT-779UV). Small speaker, fan noise, dense menus, and no NOAA standby alert
+are the tradeoffs; hardwire past the included cigarette-lighter plug.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B096533TR6?tag=gophertrunk-20" rel="nofollow sponsored noopener">DB20-G on Amazon &rarr;</a> · [DB20-G review](/reference/radioddity-db20-g/)
+
+### 6. Wouxun KG-XS20G Plus — the best-built compact
+
+20 W with the class's best build: IP65 body, IP55 mic, split tones, wideband
+receive, $200. (Retailers now fulfill all KG-XS20G orders with the Plus.) It
+grades **Excellent** on build but sits mid-pack on **Value** — squeezed
+between the $120 DB20-G and the $390 KG-1000G Plus.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B09WQK5FGN?tag=gophertrunk-20" rel="nofollow sponsored noopener">KG-XS20G Plus on Amazon &rarr;</a> · [KG-XS20G Plus review](/reference/wouxun-kg-xs20g/)
+
+### 7. Midland MXT275 — the easiest install
+
+The long-running mic-centric best-seller: 15 W, hideaway body, NOAA, ~$150–180.
+Two documented limits: **split tones only on the newer USB-C revision**, and
+narrowband TX that reads quiet into wideband repeaters — fine for convoys,
+a real strike for serious repeater work.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B07FN2FBML?tag=gophertrunk-20" rel="nofollow sponsored noopener">MXT275 on Amazon &rarr;</a> · [MXT275 review](/reference/midland-mxt275/)
+
+### 8. BTECH GMRS-50X1 — best used/classic buy
+
+The first cheap 50 W Part 95E mobile, superseded twice (GMRS-50V2, then
+50PRO) — which makes a tested used unit at ~$80–160 the most radio per used
+dollar here. Known, testable quirks: the early settings-byte bug (CHIRP
+#7761) and channel-to-channel power variance. Amazon carries it Renewed-only;
+eBay is the other half of the market.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0932TH6T9?tag=gophertrunk-20" rel="nofollow sponsored noopener">Renewed on Amazon &rarr;</a> · [GMRS-50X1 review](/reference/btech-gmrs-50x1/)
+
+### 9. Midland MXT115 — the name-brand entry point
+
+~$130–150 for a simple 15 W dash-mount with NOAA. **No split tones on the
+classic model** — disqualifying if your local repeaters use them — and it's
+mid-transition to the IP67 MXT115P (verify repeater transmit on early 115P
+stock; its initial FCC grant reportedly lacked the 467 MHz inputs).
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B01MUGZ5XC?tag=gophertrunk-20" rel="nofollow sponsored noopener">MXT115 on Amazon &rarr;</a> · [MXT115 review](/reference/midland-mxt115/)
+
+### 10. Midland MXT400 — the used Midland, eyes open
+
+Discontinued (Midland's own support site says so) and superseded by the
+MXT500 on every axis: narrowband-only TX, no NOAA, split tones only via the
+hard-to-find DBR1 cable. At ~$100–180 used it's a cheap 40 W simplex radio —
+test transmit on channels 15–22 first (a documented firmware bug).
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B01N0X0LHF?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check listing on Amazon &rarr;</a> · [MXT400 review](/reference/midland-mxt400/)
+
+## Full comparison
+
+| Radio | RF | Coverage &amp; modes | Usability | Value | ~$ price |
+|---|---|---|---|---|---|
+| [Midland MXT575](/reference/midland-mxt575/) | **Excellent** | Good | Good | Good | ~$350–400 |
+| [Wouxun KG-1000G Plus](/reference/wouxun-kg-1000g-plus/) | **Excellent** | **Excellent** | **Excellent** | Good | ~$390 |
+| [BTECH GMRS-50PRO](/reference/btech-gmrs-50pro/) | Good | **Excellent** | **Excellent** | **Excellent** | ~$285 |
+| [Midland MXT500](/reference/midland-mxt500/) | **Excellent** | Good | Good | Fair | ~$350–400 |
+| [Radioddity DB20-G](/reference/radioddity-db20-g/) | Good | Good | Good | **Excellent** | ~$110–130 |
+| [Wouxun KG-XS20G Plus](/reference/wouxun-kg-xs20g/) | Good | Good | Good | Good | ~$200 |
+| [Midland MXT275](/reference/midland-mxt275/) | Fair | Fair | Good | Good | ~$150–180 |
+| [BTECH GMRS-50X1](/reference/btech-gmrs-50x1/) | Fair | Good | Fair | Good | ~$80–160 used |
+| [Midland MXT115](/reference/midland-mxt115/) | Fair | Fair | Good | Fair | ~$130–150 |
+| [Midland MXT400](/reference/midland-mxt400/) | Fair | Basic | Basic | Fair | ~$100–180 used |
+
+> **Scout before you spend.** GMRS is analog FM at 462/467 MHz — squarely in
+> a [$30 RTL-SDR](/reference/rtl-sdr/)'s range. Free GopherTrunk monitors and
+> records every local GMRS channel and repeater at once, so a week of
+> listening tells you which repeaters are alive, whether they use split
+> tones, and whether the $35 license is worth it — before you buy a radio.
+> Listening needs no license; only transmitting does.
+
+## How to choose
+
+- **Want it clean, powerful, and done?**
+  [MXT575](/reference/midland-mxt575/) — the mic-centric install fits any
+  dash.
+- **The household radio enthusiast?**
+  [KG-1000G Plus](/reference/wouxun-kg-1000g-plus/) — 999 channels, repeater
+  pairing, CHIRP. Budget a spare mic.
+- **GPS position sharing on trail runs?**
+  [GMRS-50PRO](/reference/btech-gmrs-50pro/) — the only real GPS in the
+  class.
+- **First radio, tight budget?** [DB20-G](/reference/radioddity-db20-g/) at
+  ~$120 does the whole repeater job.
+- **Open vehicle, real weather?**
+  [KG-XS20G Plus](/reference/wouxun-kg-xs20g/) — IP65 at $200.
+- **Used bargain hunter?** A tested
+  [GMRS-50X1](/reference/btech-gmrs-50x1/) beats a used
+  [MXT400](/reference/midland-mxt400/) on every spec that matters.
+
+## Bottom line
+
+The **[Midland MXT575](/reference/midland-mxt575/)** is the best GMRS mobile
+for most people in 2026 — maximum legal power, minimum install drama. The
+**[Wouxun KG-1000G Plus](/reference/wouxun-kg-1000g-plus/)** is the
+feature king, the **[DB20-G](/reference/radioddity-db20-g/)** the budget
+gateway, and a used **[GMRS-50X1](/reference/btech-gmrs-50x1/)** the smart
+classic. Need handhelds for the same family license? See
+[best walkie-talkies](/best-walkie-talkies/). Hauling on the highway instead?
+[Best CB radios](/best-cb-radios/) — no license at all. And if GMRS starts
+feeling small — you want more bands, more power, real antennas — the ham
+ticket is the next step: same honest rubric in
+[best mobile ham radios](/best-mobile-ham-radios/).

--- a/docs/best-gmrs-mobile-radios.md
+++ b/docs/best-gmrs-mobile-radios.md
@@ -85,21 +85,20 @@ below. All ten radios hold genuine **Part 95E** grants.
 Get the physics straight before the shopping. Vehicle-to-vehicle UHF simplex
 is terrain-limited: **roughly 1–5 miles real-world, regardless of wattage** —
 50 W over 15 W buys margin, not miracles. The step change is a **GMRS
-repeater**: a machine on a tower or hilltop that rebroadcasts you, extending
-usable range to **20–50+ miles**. Using one takes three things: a radio with
-the 467 MHz repeater inputs (all ten here have them, with one classic-Midland
-asterisk), programmable [CTCSS](/reference/ctcss/)/[DCS](/reference/dcs/)
-tones — ideally **split tones**, since many club repeaters transmit-encode a
-different tone than they receive-decode, and a radio without split tones is
-locked out — and enough power and antenna to open the input reliably, which
-is where 50 W and a proper roof mount actually earn their money.
+repeater** on a tower or hilltop, which extends usable range to **20–50+
+miles**. Using one takes three things: the 467 MHz repeater inputs (all ten
+radios here have them, with one classic-Midland asterisk), programmable
+[CTCSS](/reference/ctcss/)/[DCS](/reference/dcs/) tones — ideally **split
+tones**, since many club repeaters encode a different tone than they decode,
+and a radio without split tones is locked out — and enough power and antenna
+to open the input reliably, which is where 50 W and a proper roof mount
+actually earn their money.
 
 One more honesty item: **every radio in this guide holds a genuine FCC Part
-95E grant**, imports included. Wouxun, Radioddity, and BTECH are certified
-because their transmit is locked to the GMRS channels; the wide VHF/UHF
-coverage they advertise is receive-only, and that's what keeps the grant
-legal. "Import" does not mean "uncertified" here — but an unlock hack that
-opens transmit does void the certification, and we don't recommend it.
+95E grant**, imports included — Wouxun, Radioddity, and BTECH are certified
+because transmit is locked to the GMRS channels, and their wide VHF/UHF
+coverage is receive-only. "Import" does not mean "uncertified" here. (An
+unlock hack that opens transmit voids the certification; skip it.)
 
 ## How we grade
 

--- a/docs/best-walkie-talkies.md
+++ b/docs/best-walkie-talkies.md
@@ -23,12 +23,12 @@ faq:
 
 **The best walkie-talkie is mostly a licensing decision wearing a hardware
 disguise.** Every radio below transmits on the same 22 UHF channels; what
-separates them is which FCC service they're certified under — license-free
+separates them is the FCC service they're certified under — license-free
 **FRS** at 2 W, or **GMRS** at 5 W with repeater access for a **$35,
-no-test license** that covers your whole immediate family. Get that choice
-right and the radio picks itself. And before buying anything: listening is
-free — a [$30 RTL-SDR running free GopherTrunk](/reference/rtl-sdr/) will
-tell you what's actually on the air in your area.
+no-test license** covering your immediate family. Get that choice right
+and the radio picks itself. And listening is free either way — a
+[$30 RTL-SDR running free GopherTrunk](/reference/rtl-sdr/) will tell you
+what's actually on the air near you before you spend a dollar.
 
 <div class="tldr" markdown="1">
 <span class="tldr__label">Key takeaways</span>
@@ -87,20 +87,19 @@ channel frequencies** — so a license-free FRS radio talks directly to a
 GMRS radio on channels 1–22. The differences are power and privileges:
 
 - **FRS (Part 95B)** is **license-free** for anyone: up to 2 W on channels
-  1–7 and 15–22 (0.5 W on 8–14), with a fixed antenna required. The 2017
-  rules raised FRS from 0.5 W to 2 W, which is why a modern FRS radio like
-  the [Rocky Talkie Mountain Radio](/reference/rocky-talkie-mountain-radio/)
+  1–7 and 15–22 (0.5 W on 8–14), fixed antenna required. The 2017 rules
+  raised FRS from 0.5 W to 2 W — why a modern FRS radio like the
+  [Rocky Talkie Mountain Radio](/reference/rocky-talkie-mountain-radio/)
   embarrasses old blister-pack sets.
 - **GMRS (Part 95E)** requires the license — **$35 to the FCC, valid 10
-  years, no test, and one license covers your immediate family** — and buys
-  5 W handhelds (50 W mobiles), removable antennas, and the big one:
-  **repeater use**, where a well-sited machine on the 467 MHz inputs
-  stretches range from a couple of miles to tens.
+  years, no test, one license for your immediate family** — and buys 5 W
+  handhelds (50 W mobiles), removable antennas, and the big one:
+  **repeater use**, which stretches range from a couple of miles to tens.
 - Older "hybrid FRS/GMRS" radios (the
   [Midland GXT1000VP4](/reference/midland-gxt1000vp4/) design era, the used
   [Motorola MR350R](/reference/motorola-talkabout-mr350r/)) were
-  grandfathered; anything new that's over 2 W or repeater-capable is GMRS
-  and needs the license.
+  grandfathered; anything new over 2 W or repeater-capable is GMRS and
+  needs the license.
 
 Two more truths the boxes won't tell you. **"Privacy codes" are
 [CTCSS/DCS squelch tones](/reference/ctcss/)** — they hide other people's
@@ -166,8 +165,8 @@ mid-table; for mountain use it's untouchable.
 
 Absurd **Value**: ~$35 buys honest Part 95E certification, 5 W, repeater
 channels, ~999 memories, scanner receive, a 2500 mAh USB-C battery, and
-CHIRP support. Graded down on **RF performance** (front end overloads near
-strong transmitters) and the Baofeng QC lottery.
+CHIRP support. Graded down on **RF performance** (the front end overloads
+in RF-dense areas) and the Baofeng QC lottery.
 <a class="btn btn--buy" href="https://www.amazon.com/dp/B0D2DJBD3L?tag=gophertrunk-20" rel="nofollow sponsored noopener">UV-5G Plus on Amazon &rarr;</a> · [UV-5G Plus review](/reference/baofeng-uv-5g-plus/)
 
 ### 6. Baofeng GM-15 Pro — most affordable
@@ -180,10 +179,10 @@ buy it anyway.
 
 ### 7. Midland GXT1000VP4 — the family default
 
-Ubiquitous, dead simple, with NOAA alerts and AA fallback — good
-**Usability** for the least technical users. Graded honestly: "36 miles"
-is fantasy, "50 channels" is 22 + presets, measured output falls short of
-5 W, and there are **no repeater channels** — the pre-2017 design shows.
+Ubiquitous, dead simple, NOAA alerts, AA fallback — good **Usability** for
+the least technical users. Graded honestly: "36 miles" is fantasy, "50
+channels" is 22 + presets, measured output falls short of 5 W, and there
+are **no repeater channels** — the pre-2017 design shows.
 <a class="btn btn--buy" href="https://www.amazon.com/dp/B001WMFYH4?tag=gophertrunk-20" rel="nofollow sponsored noopener">GXT1000VP4 on Amazon &rarr;</a> · [GXT1000VP4 review](/reference/midland-gxt1000vp4/)
 
 ### 8. Motorola Talkabout T800 — FRS with a party trick
@@ -228,11 +227,11 @@ everywhere.
 | [Motorola MR350R](/reference/motorola-talkabout-mr350r/) | Basic | Fair | Good | Good | ~$19–30 used |
 
 > **Buy the license before the fifth radio.** The $35 GMRS license costs
-> less than one mid-range handheld, covers your entire immediate family for
-> a decade, and unlocks the only real range multiplier in consumer radio —
-> repeaters. And spend $30 first on an [RTL-SDR](/reference/rtl-sdr/) with
-> free GopherTrunk to hear whether your local repeaters and channels carry
-> any traffic at all. Listening needs no license; only transmitting does.
+> less than one mid-range handheld, covers your immediate family for a
+> decade, and unlocks the only real range multiplier in consumer radio —
+> repeaters. Spend $30 first on an [RTL-SDR](/reference/rtl-sdr/) with free
+> GopherTrunk to hear whether your local repeaters carry any traffic at
+> all. Listening needs no license; only transmitting does.
 
 ## How to choose
 

--- a/docs/best-walkie-talkies.md
+++ b/docs/best-walkie-talkies.md
@@ -1,0 +1,275 @@
+---
+layout: page
+title: "The 10 Best Walkie-Talkies (FRS &amp; GMRS, 2026 Buyer's Guide)"
+description: "The best walkie-talkies of 2026, ranked — Rocky Talkie Expedition Radio, BTECH GMRS-PRO, Wouxun KG-935G, the honest Baofeng budget picks, and the used classics — with FRS vs GMRS explained and the $35 license question answered plainly."
+keywords: best walkie talkies, best walkie talkie 2026, best FRS radio, best GMRS handheld, FRS vs GMRS, gmrs license, do walkie talkies need a license, walkie talkie range, Rocky Talkie Expedition, BTECH GMRS-PRO, Wouxun KG-935G, long range walkie talkie, walkie talkie buying guide
+permalink: /best-walkie-talkies/
+nav_group: Hardware
+affiliate: true
+faq:
+  - q: "What is the best walkie-talkie in 2026?"
+    a: "The Rocky Talkie Expedition Radio (formerly the 5 Watt Radio): 5 W GMRS with repeater channels, genuine IP67 waterproofing, NOAA weather, and days of cold-rated battery in a UX anyone can run. It needs the $35 GMRS license to transmit; the license-free runner-up is its FRS sibling, the Mountain Radio."
+  - q: "Do walkie-talkies need a license?"
+    a: "FRS radios (2 W max, fixed antenna) are license-free for everyone in the US. GMRS radios — anything 5 W, repeater-capable, or with a detachable antenna — require the FCC's GMRS license: $35, valid 10 years, no test, and one license covers your immediate family. Listening never requires a license."
+  - q: "What's the real range of a walkie-talkie?"
+    a: "In terrain and trees, roughly half a mile to two miles for FRS and one to three miles for a 5 W GMRS handheld — more with elevation, and tens of miles through a GMRS repeater. The '36-mile' and '35-mile' box claims are mountaintop-to-mountaintop marketing, not terrestrial reality."
+  - q: "What's the cheapest good walkie-talkie?"
+    a: "The Baofeng GM-15 Pro, around $25–35 per radio: a legitimately FCC-certified, repeater-capable 5 W GMRS handheld with NOAA weather and USB-C. It needs the $35 GMRS license to transmit; the cheapest license-free route is any modern 2 W FRS pair."
+  - q: "Are old walkie-talkies like the Motorola MR350R worth buying used?"
+    a: "As $20 beaters, yes — with dead battery packs assumed and AAs in your pocket. As a primary radio, no: a new Baofeng GM-15 Pro costs about the same and adds real 5 W, repeater channels, and USB-C. The used buy that actually holds value is the Garmin Rino 755t, the GPS-navigator radio nothing ever replaced."
+---
+
+# The 10 Best Walkie-Talkies (FRS &amp; GMRS, 2026 Buyer's Guide)
+
+**The best walkie-talkie is mostly a licensing decision wearing a hardware
+disguise.** Every radio below transmits on the same 22 UHF channels; what
+separates them is which FCC service they're certified under — license-free
+**FRS** at 2 W, or **GMRS** at 5 W with repeater access for a **$35,
+no-test license** that covers your whole immediate family. Get that choice
+right and the radio picks itself. And before buying anything: listening is
+free — a [$30 RTL-SDR running free GopherTrunk](/reference/rtl-sdr/) will
+tell you what's actually on the air in your area.
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Best overall:** [Rocky Talkie Expedition Radio](/reference/rocky-talkie-5-watt/)
+(~$165–180 — the renamed 5 Watt Radio). **Best features for the price:**
+[BTECH GMRS-PRO](/reference/btech-gmrs-pro/) (~$150, GPS + texting + IP67).
+**Most affordable:** [Baofeng GM-15 Pro](/reference/baofeng-gm-15-pro/)
+(~$25–35, repeater-capable). **Best used/classic:**
+[Garmin Rino 755t](/reference/garmin-rino-755t/) (~$400–550 used, the
+GPS-radio nothing replaced). **The license rule:** FRS is free; GMRS is $35,
+10 years, no test, family-wide. Range claims on boxes are fantasy — think
+0.5–3 real miles, or tens via a GMRS repeater.
+</div>
+
+## Quick picks
+
+<div class="pick-cards" markdown="0">
+<div class="pick-card pick-card--top">
+<span class="pick-card__badge">Best overall</span>
+<h3>Rocky Talkie Expedition Radio</h3>
+<p class="pick-card__price">around $165–180 per radio</p>
+<p>The renamed 5 Watt Radio: 5 W GMRS, repeater channels, NOAA, IP67 submersion tested per unit, and days of cold-rated battery — the rugged consumer GMRS radio to beat.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0F4Q8CYP4?tag=gophertrunk-20" rel="nofollow sponsored noopener">Expedition Radio on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/rocky-talkie-5-watt/">Expedition Radio details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Best features for the price</span>
+<h3>BTECH GMRS-PRO</h3>
+<p class="pick-card__price">around $150</p>
+<p>GPS position sharing, off-grid texting, Bluetooth, IP67, NOAA alerts, and full repeater support — the most feature-dense GMRS handheld made.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0B4BLZ67Z?tag=gophertrunk-20" rel="nofollow sponsored noopener">GMRS-PRO on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/btech-gmrs-pro/">GMRS-PRO details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Most affordable</span>
+<h3>Baofeng GM-15 Pro</h3>
+<p class="pick-card__price">around $25–35 per radio</p>
+<p>The cheapest legitimately certified, repeater-capable 5 W GMRS radio — NOAA weather and USB-C included. Ignore the "8W" listings; the certified spec is 5 W.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0B3DRG9GC?tag=gophertrunk-20" rel="nofollow sponsored noopener">GM-15 Pro on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/baofeng-gm-15-pro/">GM-15 Pro details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Best used/classic buy</span>
+<h3>Garmin Rino 755t</h3>
+<p class="pick-card__price">around $400–550 used</p>
+<p>A 5 W GMRS radio fused with a real Garmin GPS navigator, with peer position mapping no current product duplicates. Discontinued, used-market only — verify the battery.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/s?k=garmin+rino+755t&tag=gophertrunk-20" rel="nofollow sponsored noopener">Find a Rino 755t &rarr;</a>
+<p class="pick-card__note"><a href="/reference/garmin-rino-755t/">Rino 755t details</a></p>
+</div>
+</div>
+
+## FRS vs GMRS in plain English
+
+Since the FCC's **2017 reorganization**, FRS and GMRS **share the same 22
+channel frequencies** — so a license-free FRS radio talks directly to a
+GMRS radio on channels 1–22. The differences are power and privileges:
+
+- **FRS (Part 95B)** is **license-free** for anyone: up to 2 W on channels
+  1–7 and 15–22 (0.5 W on 8–14), with a fixed antenna required. The 2017
+  rules raised FRS from 0.5 W to 2 W, which is why a modern FRS radio like
+  the [Rocky Talkie Mountain Radio](/reference/rocky-talkie-mountain-radio/)
+  embarrasses old blister-pack sets.
+- **GMRS (Part 95E)** requires the license — **$35 to the FCC, valid 10
+  years, no test, and one license covers your immediate family** — and buys
+  5 W handhelds (50 W mobiles), removable antennas, and the big one:
+  **repeater use**, where a well-sited machine on the 467 MHz inputs
+  stretches range from a couple of miles to tens.
+- Older "hybrid FRS/GMRS" radios (the
+  [Midland GXT1000VP4](/reference/midland-gxt1000vp4/) design era, the used
+  [Motorola MR350R](/reference/motorola-talkabout-mr350r/)) were
+  grandfathered; anything new that's over 2 W or repeater-capable is GMRS
+  and needs the license.
+
+Two more truths the boxes won't tell you. **"Privacy codes" are
+[CTCSS/DCS squelch tones](/reference/ctcss/)** — they hide other people's
+chatter from you, not yours from them. And **range claims are fantasy**:
+"36 miles" and "35 miles" are summit-to-summit numbers; in real terrain
+expect **0.5–2 miles from FRS, 1–3 miles from 5 W GMRS**, and real
+distance only through a repeater.
+
+## How we grade
+
+Every radio here is judged on the same six criteria: **RF performance**
+(receiver quality and selectivity, transmit audio), **Coverage &amp; modes**
+(channels and services, repeater capability, NOAA weather), **Power &amp;
+duty** (output within the service's legal limit, thermal behavior),
+**Usability &amp; programming** (controls, menus, app/CHIRP/software
+support), **Ecosystem &amp; support** (firmware, service, parts,
+accessories, community), and **Value** (what the street price buys). No
+star ratings, no invented scores — table grades run
+Excellent/Good/Fair/Basic, and the used classics get a prose used-market
+viability check. The same rubric runs our
+[best GMRS mobile radios](/best-gmrs-mobile-radios/) and
+[best CB radios](/best-cb-radios/) guides — and the ham guides
+([base stations](/best-ham-radio-base-stations/),
+[mobiles](/best-mobile-ham-radios/),
+[handhelds](/best-handheld-ham-radios/)) — so grades are comparable across
+all of them.
+
+## The top 10, ranked
+
+### 1. Rocky Talkie Expedition Radio — best overall
+
+Formerly the 5 Watt Radio, renamed — same lineage. Excellent **Power &amp;
+duty** (a true 5 W, days of cold-rated battery), IP67 submersion-tested
+build, repeater channels, NOAA, and the best **Usability** in GMRS.
+**Value** is its only soft grade — you pay for the build.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0F4Q8CYP4?tag=gophertrunk-20" rel="nofollow sponsored noopener">Expedition Radio on Amazon &rarr;</a> · [Expedition Radio review](/reference/rocky-talkie-5-watt/)
+
+### 2. BTECH GMRS-PRO — best features for the price
+
+Unmatched **Coverage &amp; modes** for the money: GPS position sharing,
+off-grid texting, Bluetooth, IP67, NOAA alerts, FM radio, repeaters — at
+$150. Held from #1 by app-only programming (no keypad, no CHIRP) and
+texting that only works with compatible BTECH radios.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0B4BLZ67Z?tag=gophertrunk-20" rel="nofollow sponsored noopener">GMRS-PRO on Amazon &rarr;</a> · [GMRS-PRO review](/reference/btech-gmrs-pro/)
+
+### 3. Wouxun KG-935G — the GMRS power user's radio
+
+The best **RF performance** and pure-radio **Usability** here: a receiver
+that survives RF-dense areas, praised transmit audio, 999 named memories,
+full keypad, IP66. No GPS/texting gadgets, mostly specialty-dealer
+distribution; the newer 935G Plus (~$20–40 more) adds USB-C.
+<a class="btn btn--buy" href="https://www.amazon.com/s?k=wouxun+kg-935g&tag=gophertrunk-20" rel="nofollow sponsored noopener">KG-935G on Amazon &rarr;</a> · [KG-935G review](/reference/wouxun-kg-935g/)
+
+### 4. Rocky Talkie Mountain Radio — best license-free radio
+
+The FRS Expedition: 2 W (the legal max), shatterproof screen, carabiner
+leash, 3–5 day cold-rated battery, USB-C — **no license, ever**. Basic
+**Coverage** (no NOAA, no repeaters — FRS can't) and a steep $110 keep it
+mid-table; for mountain use it's untouchable.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0F4PYGJHQ?tag=gophertrunk-20" rel="nofollow sponsored noopener">Mountain Radio on Amazon &rarr;</a> · [Mountain Radio review](/reference/rocky-talkie-mountain-radio/)
+
+### 5. Baofeng UV-5G Plus — the value GMRS workhorse
+
+Absurd **Value**: ~$35 buys honest Part 95E certification, 5 W, repeater
+channels, ~999 memories, scanner receive, a 2500 mAh USB-C battery, and
+CHIRP support. Graded down on **RF performance** (front end overloads near
+strong transmitters) and the Baofeng QC lottery.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0D2DJBD3L?tag=gophertrunk-20" rel="nofollow sponsored noopener">UV-5G Plus on Amazon &rarr;</a> · [UV-5G Plus review](/reference/baofeng-uv-5g-plus/)
+
+### 6. Baofeng GM-15 Pro — most affordable
+
+The cheapest legal seat at the GMRS table: certified, repeater-capable,
+NOAA-equipped, USB-C, ~$25–35 (the certified spec is 5 W — ignore "8W"
+listings). Smaller battery, no IP rating, clunky menus; at this price,
+buy it anyway.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0B3DRG9GC?tag=gophertrunk-20" rel="nofollow sponsored noopener">GM-15 Pro on Amazon &rarr;</a> · [GM-15 Pro review](/reference/baofeng-gm-15-pro/)
+
+### 7. Midland GXT1000VP4 — the family default
+
+Ubiquitous, dead simple, with NOAA alerts and AA fallback — good
+**Usability** for the least technical users. Graded honestly: "36 miles"
+is fantasy, "50 channels" is 22 + presets, measured output falls short of
+5 W, and there are **no repeater channels** — the pre-2017 design shows.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B001WMFYH4?tag=gophertrunk-20" rel="nofollow sponsored noopener">GXT1000VP4 on Amazon &rarr;</a> · [GXT1000VP4 review](/reference/midland-gxt1000vp4/)
+
+### 8. Motorola Talkabout T800 — FRS with a party trick
+
+License-free 2 W FRS whose Bluetooth app enables off-grid texting and
+location pins between T800s — unique in the blister-pack class. The app is
+flaky and unmaintained, availability shows end-of-life signals (the T470
+is the current fallback), and it's splash-only IPX4.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B07HRSP2ZV?tag=gophertrunk-20" rel="nofollow sponsored noopener">T800 on Amazon &rarr;</a> · [T800 review](/reference/motorola-talkabout-t800/)
+
+### 9. Garmin Rino 755t — best used/classic buy
+
+The only serious GPS-navigator/radio hybrid ever made: 5 W GMRS with peer
+position mapping, IPX7, discontinued with no successor. Used-market
+viability: holds ~$400–550 on thin data, firmware support has ended, and
+the buy hinges on battery, touchscreen, and gasket condition — checklist
+in the review.
+<a class="btn btn--buy" href="https://www.amazon.com/s?k=garmin+rino+755t&tag=gophertrunk-20" rel="nofollow sponsored noopener">Find a Rino 755t &rarr;</a> · [Rino 755t review](/reference/garmin-rino-755t/)
+
+### 10. Motorola Talkabout MR350R — the $20 beater
+
+The late-2000s family radio, now $19–30 used on eBay with deep supply.
+Used-market viability: assume dead NiMH packs (run it on AAs), check PTT
+wear and corrosion, and expect FRS-class range despite the "35-mile" box.
+Honest cheap comms — but a new GM-15 Pro at the same money beats it
+everywhere.
+<a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=Motorola+MR350R" rel="nofollow noopener">Find on eBay &rarr;</a> · [MR350R review](/reference/motorola-talkabout-mr350r/)
+
+## Full comparison
+
+| Radio | RF | Coverage &amp; modes | Usability | Value | ~$ price |
+|---|---|---|---|---|---|
+| [Rocky Talkie Expedition](/reference/rocky-talkie-5-watt/) | Good | Good | **Excellent** | Good | ~$165–180 |
+| [BTECH GMRS-PRO](/reference/btech-gmrs-pro/) | Good | **Excellent** | Good | **Excellent** | ~$150 |
+| [Wouxun KG-935G](/reference/wouxun-kg-935g/) | **Excellent** | Good | **Excellent** | Good | ~$150–170 |
+| [Rocky Talkie Mountain](/reference/rocky-talkie-mountain-radio/) | Good | Basic | **Excellent** | Fair | ~$110 |
+| [Baofeng UV-5G Plus](/reference/baofeng-uv-5g-plus/) | Fair | Good | Fair | **Excellent** | ~$30–40 |
+| [Baofeng GM-15 Pro](/reference/baofeng-gm-15-pro/) | Fair | Good | Basic | **Excellent** | ~$25–35 |
+| [Midland GXT1000VP4](/reference/midland-gxt1000vp4/) | Basic | Fair | Good | Good | ~$70–90/pair |
+| [Motorola T800](/reference/motorola-talkabout-t800/) | Basic | Fair | Good | Fair | ~$90–110/pair |
+| [Garmin Rino 755t](/reference/garmin-rino-755t/) | Good | Good | Good | Fair | ~$400–550 used |
+| [Motorola MR350R](/reference/motorola-talkabout-mr350r/) | Basic | Fair | Good | Good | ~$19–30 used |
+
+> **Buy the license before the fifth radio.** The $35 GMRS license costs
+> less than one mid-range handheld, covers your entire immediate family for
+> a decade, and unlocks the only real range multiplier in consumer radio —
+> repeaters. And spend $30 first on an [RTL-SDR](/reference/rtl-sdr/) with
+> free GopherTrunk to hear whether your local repeaters and channels carry
+> any traffic at all. Listening needs no license; only transmitting does.
+
+## How to choose
+
+- **Backcountry, worst-case weather, gloves?**
+  [Rocky Talkie Expedition Radio](/reference/rocky-talkie-5-watt/) — or the
+  license-free [Mountain Radio](/reference/rocky-talkie-mountain-radio/) if
+  the $35 license is a nonstarter.
+- **Group coordination with maps and messages?**
+  [BTECH GMRS-PRO](/reference/btech-gmrs-pro/) new, or the used
+  [Garmin Rino 755t](/reference/garmin-rino-755t/) for full-navigator
+  position mapping.
+- **You'll actually work repeaters and want a real receiver?**
+  [Wouxun KG-935G](/reference/wouxun-kg-935g/).
+- **Tight budget, still want it legal and repeater-capable?**
+  [Baofeng GM-15 Pro](/reference/baofeng-gm-15-pro/), or the
+  [UV-5G Plus](/reference/baofeng-uv-5g-plus/) for ~$10 more.
+- **Radios for the least technical family members?**
+  [Midland GXT1000VP4](/reference/midland-gxt1000vp4/) — with the range
+  honesty above.
+- **A drawer of beaters for camp?** Used
+  [MR350Rs](/reference/motorola-talkabout-mr350r/) at $20 each, AAs in
+  pocket.
+
+## Bottom line
+
+The **[Rocky Talkie Expedition Radio](/reference/rocky-talkie-5-watt/)** is
+the best walkie-talkie for most buyers in 2026 — and yes, it's the radio
+formerly named the 5 Watt. The **[BTECH
+GMRS-PRO](/reference/btech-gmrs-pro/)** packs the most capability per
+dollar, the **[GM-15 Pro](/reference/baofeng-gm-15-pro/)** is the cheapest
+honest ticket in, and a clean **[Rino
+755t](/reference/garmin-rino-755t/)** is the classic that never got a
+successor. Need range beyond any handheld? A 50 W rig in the truck:
+[best GMRS mobile radios](/best-gmrs-mobile-radios/) — or the license-free
+highway standby, [best CB radios](/best-cb-radios/). And if GMRS starts
+feeling small, the ham ticket is the next step up:
+[best handheld ham radios](/best-handheld-ham-radios/). The listening side
+stays free either way — a
+[$30 SDR running GopherTrunk](/reference/rtl-sdr/) monitors and records it
+all, no license required.

--- a/docs/best-walkie-talkies.md
+++ b/docs/best-walkie-talkies.md
@@ -238,18 +238,17 @@ everywhere.
 
 - **Backcountry, worst-case weather, gloves?**
   [Rocky Talkie Expedition Radio](/reference/rocky-talkie-5-watt/) — or the
-  license-free [Mountain Radio](/reference/rocky-talkie-mountain-radio/) if
-  the $35 license is a nonstarter.
+  license-free [Mountain Radio](/reference/rocky-talkie-mountain-radio/).
 - **Group coordination with maps and messages?**
   [BTECH GMRS-PRO](/reference/btech-gmrs-pro/) new, or the used
   [Garmin Rino 755t](/reference/garmin-rino-755t/) for full-navigator
   position mapping.
-- **You'll actually work repeaters and want a real receiver?**
+- **Repeater work and a real receiver?**
   [Wouxun KG-935G](/reference/wouxun-kg-935g/).
-- **Tight budget, still want it legal and repeater-capable?**
+- **Tight budget, still legal and repeater-capable?**
   [Baofeng GM-15 Pro](/reference/baofeng-gm-15-pro/), or the
   [UV-5G Plus](/reference/baofeng-uv-5g-plus/) for ~$10 more.
-- **Radios for the least technical family members?**
+- **Least technical family members?**
   [Midland GXT1000VP4](/reference/midland-gxt1000vp4/) — with the range
   honesty above.
 - **A drawer of beaters for camp?** Used
@@ -267,8 +266,8 @@ honest ticket in, and a clean **[Rino
 755t](/reference/garmin-rino-755t/)** is the classic that never got a
 successor. Need range beyond any handheld? A 50 W rig in the truck:
 [best GMRS mobile radios](/best-gmrs-mobile-radios/) — or the license-free
-highway standby, [best CB radios](/best-cb-radios/). And if GMRS starts
-feeling small, the ham ticket is the next step up:
+highway standby, [best CB radios](/best-cb-radios/). Outgrown GMRS? The
+no-code ham ticket is the next step up:
 [best handheld ham radios](/best-handheld-ham-radios/). The listening side
 stays free either way — a
 [$30 SDR running GopherTrunk](/reference/rtl-sdr/) monitors and records it

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -72,6 +72,12 @@ Amateur radio transceivers ranked with an honest rubric — no star ratings — 
 - [Best mobile ham radios]({{ '/best-mobile-ham-radios/' | absolute_url }}): the 10 best vehicle-mount rigs ranked, from budget dual-banders to the Yaesu FTM-500DR, including discontinued do-everything classics.
 - [Best handheld ham radios]({{ '/best-handheld-ham-radios/' | absolute_url }}): the 10 best HTs ranked, from the Baofeng UV-5R to the Kenwood TH-D75A, including used-market classics.
 
+## Consumer two-way radio buyer's guides
+FRS/GMRS walkie-talkies, GMRS mobile rigs, and CB radios ranked with the same honest rubric — no star ratings. GMRS takes a $35 no-test FCC license; FRS and CB are license-free.
+- [Best walkie-talkies]({{ '/best-walkie-talkies/' | absolute_url }}): the 10 best FRS and GMRS handhelds ranked, from the Baofeng GM-15 Pro to the Rocky Talkie 5 Watt, including discontinued classics.
+- [Best GMRS mobile radios]({{ '/best-gmrs-mobile-radios/' | absolute_url }}): the 10 best GMRS mobile and base rigs ranked, from the Radioddity DB20-G to the Midland MXT575 and Wouxun KG-1000G Plus.
+- [Best CB radios]({{ '/best-cb-radios/' | absolute_url }}): the 10 best CB radios ranked, from the Uniden PRO505XL to the Bearcat 880 and President McKinley, including collector classics.
+
 ## SDR hardware for GopherTrunk (buyer's guides)
 The receivers, antennas, cables, and accessories to run GopherTrunk, with honest picks and Amazon links.
 - [Best SDR for GopherTrunk]({{ '/best-sdr-for-gophertrunk/' | absolute_url }}): RTL-SDR, NESDR, Airspy, and HackRF compared for P25/DMR/NXDN decoding.

--- a/docs/reference/baofeng-gm-15-pro.md
+++ b/docs/reference/baofeng-gm-15-pro.md
@@ -1,0 +1,131 @@
+---
+slug: baofeng-gm-15-pro
+title: Baofeng GM-15 Pro
+entry_type: hardware
+category: two-way-radios
+description: "The Baofeng GM-15 Pro is the cheapest repeater-capable GMRS handheld — Part 95E certified, 5 W (ignore the '8W' listings), NOAA weather, USB-C — at around $25–35 a radio, with Baofeng's usual QC and menu caveats."
+keywords: Baofeng GM-15 Pro, GM-15 Pro review, cheapest GMRS radio, budget GMRS handheld, Baofeng GMRS, GM15 Pro 8W, gmrs license, GMRS repeater radio, cheap walkie talkie, best walkie talkie under 50, NOAA walkie talkie
+aka: [GM-15 Pro, GM15 Pro, Baofeng GM15]
+autolink: true
+affiliate: true
+product:
+  name: "Baofeng GM-15 Pro"
+  brand: Baofeng
+  category: GMRS walkie-talkie (handheld pair)
+  lowPrice: "25"
+  highPrice: "60"
+  url: https://www.amazon.com/dp/B0B3DRG9GC?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: Handheld GMRS walkie-talkie }
+  - { label: Service, value: "GMRS (FCC Part 95E — FCC ID 2AJGM-GM15PRO)" }
+  - { label: Channels, value: "22 GMRS + 8 repeater channels; NOAA; ~220 RX memories" }
+  - { label: Power, value: "5 W official (ignore \"8W\" marketing)" }
+  - { label: License, value: "GMRS — $35 FCC, 10 years, no test" }
+  - { label: Price, value: "around $25–35 single, $45–60 2-pack" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B0B3DRG9GC?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [baofeng-uv-5g-plus, midland-gxt1000vp4, wouxun-kg-935g, btech-gmrs-pro, baofeng-uv-5r, rtl-sdr]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "The 10 best walkie-talkies", url: /best-walkie-talkies/ }
+cite_urls:
+  - https://www.baofengradio.com/products/gm-15-pro
+  - https://www.radioddity.com/products/baofeng-gm-15-pro
+faq:
+  - q: "Do I need a license for the Baofeng GM-15 Pro?"
+    a: "To transmit, yes — it's a GMRS radio, so the FCC's GMRS license applies: $35, valid 10 years, no test, one license covering your immediate family. Listening, including its NOAA and scanner receive, needs no license."
+  - q: "Is the Baofeng GM-15 Pro really 8 watts?"
+    a: "No. Several Amazon listings market it as '8W,' but the certified, official spec is 5 W (0.5 W low power) — which is also the GMRS handheld legal maximum. Treat any 8 W claim on this radio as marketing."
+  - q: "Can the Baofeng GM-15 Pro use GMRS repeaters?"
+    a: "Yes — it carries the standard 22 GMRS channels plus the 8 repeater channels. At its price, that makes it the cheapest legitimate way onto a local GMRS repeater."
+  - q: "Is the Baofeng GM-15 Pro waterproof?"
+    a: "No. It has no IP rating — rain-shower survival is luck, not spec. For wet use, an IP67 radio like the BTECH GMRS-PRO or Rocky Talkie Expedition Radio is the honest recommendation."
+  - q: "What's the range of the Baofeng GM-15 Pro?"
+    a: "Like every 5 W UHF handheld: roughly 1–3 miles in typical terrain, more with elevation or open line of sight, and much more through a repeater. Ignore double-digit-mile box claims on any walkie-talkie."
+---
+**The Baofeng GM-15 Pro** is the price floor of legitimate GMRS: **around
+$25–35 for a single kit**, and under $60 for a pair, buys a **Part 95E
+certified (FCC ID 2AJGM-GM15PRO)**, repeater-capable, NOAA-equipped 5 W
+handheld with USB-C charging.[^baofeng] Nothing else legal on GMRS costs
+less and does more. It is also thoroughly a Baofeng: confusing listings
+(including bogus "8W" claims), clunky menus, small battery, no
+waterproofing, and unit-to-unit QC variance.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0B3DRG9GC?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Our most-affordable pick.** Real Part 95E certification, **5 W** (the
+"8W" Amazon listings are marketing — the certified spec is 5 W), **all 8
+repeater channels**, NOAA weather scan, ~220 scanner-receive memories,
+USB-C. **Transmitting needs the $35 no-test GMRS license** (10 years,
+family-wide). Trade-offs: 1500 mAh battery, no IP rating, SKU sprawl,
+Baofeng menus. Rankings: [best walkie-talkies](/best-walkie-talkies/).
+</div>
+
+## Overview
+
+If the [UV-5G Plus](/reference/baofeng-uv-5g-plus/) is Baofeng's GMRS
+flagship, the GM-15 Pro is its loss-leader — and for many buyers the
+smarter purchase. The certification is the headline: **FCC Part 95E, FCC
+ID 2AJGM-GM15PRO**, a real grant that makes this radio legal to transmit
+on GMRS with the license (**$35, 10 years, no test, covers your immediate
+family** — listening is free). At this price most of the competition is
+either FRS-only or gray-market.
+
+Capability-wise it hits the points that matter: **22 GMRS channels plus
+the 8 repeater channels**, NOAA weather scan and receive, and roughly 220
+receive-only scanner memories covering 136–174 and 400–512 MHz. The
+1500 mAh battery charges over **USB-C**, and kits typically include a
+programming cable and sometimes a spare antenna.
+
+Now the Baofeng tax. Amazon's listings for this radio are a **SKU sprawl**
+of colors, kit contents, and power claims — several advertise "8W," which
+is not the certified spec; the official figure is **5 W**, which is also
+the legal handheld limit, so treat 8 W as fiction twice over. The menus
+are cryptic (CHIRP support is community-reported for this model — verify
+your CHIRP build before counting on it), the battery is small next to the
+UV-5G Plus's 2500 mAh, there's no IP rating, and QC varies by unit. At
+$30, you can afford to know all that and buy it anyway.
+
+## Channels, power &amp; battery
+
+- **Service:** GMRS, **Part 95E certified, FCC ID 2AJGM-GM15PRO** —
+  license required to transmit.
+- **Power:** **5 W** official (0.5 W low); ignore "8W" listings.
+- **Channels:** 22 GMRS + 8 repeater channels;
+  [CTCSS/DCS privacy tones](/reference/ctcss/).
+- **Receive extras:** NOAA weather scan; ~220 scanner memories,
+  136–174 / 400–512 MHz receive-only.
+- **Battery:** 1500 mAh Li-ion, **USB-C**.
+- **Durability:** no IP rating; keep it dry.
+- **Range:** 1–3 miles typical terrain, repeaters extend to tens of miles.
+
+## GopherTrunk alternative
+
+FRS/GMRS lives at 462/467 MHz as analog narrowband FM — trivially within a
+~$30 [RTL-SDR](/reference/rtl-sdr/)'s reach. Running free GopherTrunk, that
+dongle monitors and **records** every FRS/GMRS channel and local repeater
+output simultaneously, so you can scout whether anyone's actually on the
+air near you — a sensible check before even a $30 radio, and definitely
+before the $35 license. The GM-15 Pro then handles the half GopherTrunk
+can't: transmitting. They're complements, not competitors. SDR-curious?
+See [Learn RF &amp; SDR](/learn/rf-sdr/).
+
+## Who it's for
+
+- **Buy the GM-15 Pro** if you want the cheapest legal seat at the GMRS
+  table — glovebox radios, kid radios, spares, or a first repeater-capable
+  handheld to learn on.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B0B3DRG9GC?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [Baofeng UV-5G Plus](/reference/baofeng-uv-5g-plus/)** instead
+  for a bigger battery, color screen, and firmer CHIRP support for ~$10
+  more.
+- **Spend up** to a [Wouxun KG-935G](/reference/wouxun-kg-935g/) or
+  [BTECH GMRS-PRO](/reference/btech-gmrs-pro/) when receiver quality,
+  waterproofing, or UX start to matter. Full rankings:
+  [best walkie-talkies](/best-walkie-talkies/).
+
+## Sources
+
+[^baofeng]: [Baofeng GM-15 Pro product page](https://www.baofengradio.com/products/gm-15-pro) — Baofeng, on Part 95E certification, official 5 W output, repeater channels, NOAA weather, scanner receive, and USB-C charging. Also listed at [Radioddity](https://www.radioddity.com/products/baofeng-gm-15-pro).

--- a/docs/reference/baofeng-uv-5g-plus.md
+++ b/docs/reference/baofeng-uv-5g-plus.md
@@ -1,0 +1,135 @@
+---
+slug: baofeng-uv-5g-plus
+title: Baofeng UV-5G Plus
+entry_type: hardware
+category: two-way-radios
+description: "The Baofeng UV-5G Plus is a legitimately Part 95E-certified 5 W GMRS handheld with repeater channels, USB-C, a 2500 mAh battery, and CHIRP support for around $30–40 — absurd value with classic Baofeng QC and UX caveats."
+keywords: Baofeng UV-5G Plus, UV-5G Plus review, Baofeng GMRS radio, cheap GMRS handheld, GMRS repeater radio, gmrs license, is Baofeng legal on GMRS, CHIRP Baofeng GMRS, best budget walkie talkie, UV-5G Plus vs UV-5R, USB-C walkie talkie
+aka: [UV-5G Plus, UV5G Plus]
+autolink: true
+affiliate: true
+product:
+  name: "Baofeng UV-5G Plus"
+  brand: Baofeng
+  category: GMRS walkie-talkie (handheld)
+  lowPrice: "30"
+  highPrice: "70"
+  url: https://www.amazon.com/dp/B0D2DJBD3L?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: Handheld GMRS walkie-talkie }
+  - { label: Service, value: "GMRS (FCC Part 95E — FCC ID 2AJGM-5GPLUS)" }
+  - { label: Channels, value: "30 GMRS channels + ~999 memories; wide RX + NOAA" }
+  - { label: Power, value: "5 W (GMRS handheld max)" }
+  - { label: License, value: "GMRS — $35 FCC, 10 years, no test" }
+  - { label: Price, value: "around $30–40 single, $55–70 2-pack" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B0D2DJBD3L?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [baofeng-gm-15-pro, baofeng-uv-5r, wouxun-kg-935g, btech-gmrs-pro, rocky-talkie-5-watt, rtl-sdr]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "The 10 best walkie-talkies", url: /best-walkie-talkies/ }
+cite_urls:
+  - https://www.baofengradio.com/products/uv-5g-plus-5w-gmrs-radio
+  - https://www.radioddity.com/products/baofeng-uv-5g-plus
+faq:
+  - q: "Do I need a license for the Baofeng UV-5G Plus?"
+    a: "To transmit, yes — it's a GMRS radio, and GMRS requires the FCC license: $35, valid 10 years, no test, covering your immediate family. Listening (including its VHF/UHF scanner receive and NOAA channels) requires no license at all."
+  - q: "Is the Baofeng UV-5G Plus legal on GMRS?"
+    a: "Yes — unlike Baofeng's gray-market ham radios that people illegally program for GMRS, the UV-5G Plus carries a real FCC Part 95E certification (FCC ID 2AJGM-5GPLUS) and ships GMRS-locked. Used as shipped with a GMRS license, it's fully legal."
+  - q: "Does the UV-5G Plus work with GMRS repeaters?"
+    a: "Yes. It includes the GMRS repeater channels (467 MHz inputs paired to the 462 MHz outputs) plus programmable memories for tones and splits — the cheapest reliable route onto a local GMRS repeater."
+  - q: "Can I program the UV-5G Plus with CHIRP?"
+    a: "Yes, CHIRP supports it, which makes setting up repeater tones and channel names far easier than the on-radio menus. Note the honest caveat: the same unlock culture can make Baofengs transmit out-of-band, which is illegal — leave it in its shipped GMRS-locked state."
+  - q: "Is the Baofeng UV-5G Plus waterproof?"
+    a: "No — it carries no meaningful IP rating. Treat it as a fair-weather or in-vehicle radio; for wet environments spend up on an IP67 radio like the BTECH GMRS-PRO or Rocky Talkie Expedition Radio."
+---
+**The Baofeng UV-5G Plus** is the value outlier in GMRS: **around $30–40**
+buys a **5 W, repeater-capable** handheld with a **legitimate FCC Part 95E
+certification (FCC ID 2AJGM-5GPLUS)**, a 2500 mAh battery, **USB-C**
+charging, a color screen, and CHIRP programmability.[^baofeng] That
+certification matters — this is Baofeng playing by the rules, unlike the
+gray-market [UV-5R](/reference/baofeng-uv-5r/) crowd illegally keyed up on
+GMRS. What $35 doesn't buy: consistency. The Baofeng QC lottery and cryptic
+menus are part of the deal.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0D2DJBD3L?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The most radio per dollar on this site.** 5 W GMRS, **repeater channels**,
+~999 memories, VHF/UHF scanner receive + NOAA, USB-C, big battery — for
+Baofeng money. **Honestly certified** Part 95E, ships GMRS-locked.
+**Transmitting needs the $35 no-test GMRS license** (10 years, covers
+family). Caveats: unit-to-unit QC variance, a mediocre front end in
+RF-dense areas, classic Baofeng menus, **no waterproofing**. Rankings:
+[best walkie-talkies](/best-walkie-talkies/).
+</div>
+
+## Overview
+
+Baofeng's ham radios earned a reputation as the radios people *illegally*
+use on GMRS. The UV-5G Plus is the legitimate answer: certified under
+**Part 95E**, shipped locked to GMRS transmit, and sold as Baofeng's
+mainstream GMRS handheld through Radioddity and Amazon. Transmitting still
+requires the **GMRS license — $35, 10 years, no test, covers your immediate
+family**; receive (its wideband VHF/UHF scanner side included) is free to
+anyone.
+
+The spec sheet reads like a $100 radio's. **5 W** — the handheld legal max.
+The **8 repeater channels** plus roughly 999 programmable memories for
+custom tone/split combinations, so it'll follow you across every open GMRS
+repeater in the state. Wideband receive covers VHF/UHF (receive-only) plus
+NOAA weather. The 2500 mAh pack charges over **USB-C**, and a 1.9" color
+display replaces the old Baofeng segment LCD. **CHIRP** support means you
+program it from a PC in minutes.
+
+The honest half of the ledger: Baofeng's quality control is a lottery —
+audio, squelch behavior, and spurious-emission cleanliness vary between
+units. The receiver front end overloads more easily than a Wouxun's near
+strong transmitters. The menus are classic Baofeng-cryptic without CHIRP.
+And the same unlock culture that makes CHIRP handy also makes these radios
+easy to modify for out-of-band transmit — which is illegal; keep it in its
+shipped GMRS-locked state.
+
+## Channels, power &amp; battery
+
+- **Service:** GMRS, **Part 95E certified, FCC ID 2AJGM-5GPLUS** — a real
+  grant, stated because much of the import market can't say the same.
+- **Power:** 5 W max.
+- **Channels:** 30 GMRS channels (simplex + repeater) + ~999 memories;
+  [CTCSS/DCS tones](/reference/ctcss/) programmable per channel.
+- **Receive:** wideband VHF/UHF scanner receive + NOAA weather.
+- **Battery:** 2500 mAh Li-ion, **USB-C**.
+- **Programming:** on-radio keypad or **CHIRP**.
+- **Durability:** no meaningful IP rating — not a wet-weather radio.
+
+## GopherTrunk alternative
+
+The UV-5G Plus's scanner receive hints at a hobby GopherTrunk serves fully:
+FRS/GMRS is analog narrowband FM at 462/467 MHz, and a ~$30
+[RTL-SDR](/reference/rtl-sdr/) running free GopherTrunk monitors **all** the
+channels at once, records every transmission with timestamps, and shows you
+which local repeaters actually carry traffic — worth checking before you
+program splits into this radio, or even before spending the $35 on a
+license. GopherTrunk can't transmit; it's the free receive-and-log
+companion, not a replacement. The learning path lives at
+[Learn RF &amp; SDR](/learn/rf-sdr/).
+
+## Who it's for
+
+- **Buy the UV-5G Plus** if you want maximum GMRS capability per dollar —
+  repeaters, memories, scanner receive — and you're comfortable with CHIRP
+  and the occasional QC roll of the dice.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B0D2DJBD3L?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [Baofeng GM-15 Pro](/reference/baofeng-gm-15-pro/)** instead if
+  you just want the cheapest repeater-capable GMRS radio and don't need the
+  big battery or color screen.
+- **Spend up** to a [Wouxun KG-935G](/reference/wouxun-kg-935g/) for a real
+  receiver and sane menus, or a
+  [Rocky Talkie Expedition Radio](/reference/rocky-talkie-5-watt/) for
+  IP67 ruggedness. Full rankings:
+  [best walkie-talkies](/best-walkie-talkies/).
+
+## Sources
+
+[^baofeng]: [Baofeng UV-5G Plus product page](https://www.baofengradio.com/products/uv-5g-plus-5w-gmrs-radio) — Baofeng, on Part 95E certification, 5 W output, repeater capability, memory channels, wideband receive, and USB-C charging. Also listed at [Radioddity](https://www.radioddity.com/products/baofeng-uv-5g-plus).

--- a/docs/reference/btech-gmrs-50pro.md
+++ b/docs/reference/btech-gmrs-50pro.md
@@ -1,0 +1,145 @@
+---
+slug: btech-gmrs-50pro
+title: BTECH GMRS-50PRO
+entry_type: hardware
+category: two-way-radios
+description: "The BTECH GMRS-50PRO is the tech-forward 50-watt GMRS mobile — real onboard GPS, Bluetooth app programming, color screens on radio and mic, IP54 sealing, and split tones for around $285. The only GPS radio in its class."
+keywords: BTECH GMRS-50PRO, GMRS-50PRO review, GMRS radio with GPS, 50 watt GMRS mobile radio, Bluetooth GMRS radio, gmrs license, GMRS repeater radio, best GMRS mobile radio 2026, BTECH GMRS mobile, GMRS radio app programming, GMRS-50PRO vs MXT575
+aka: [GMRS-50PRO, BTech GMRS-50PRO]
+autolink: true
+affiliate: true
+product:
+  name: "BTECH GMRS-50PRO"
+  brand: BTECH
+  category: GMRS mobile radio
+  lowPrice: "280"
+  highPrice: "290"
+  url: https://www.amazon.com/dp/B0DT7KC686?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: "GMRS mobile radio (GPS + Bluetooth)" }
+  - { label: Service, value: "GMRS TX; dual-band VHF/UHF RX/scan" }
+  - { label: Power, value: "50 W (5/25/50 selectable)" }
+  - { label: Repeater, value: "Yes — full split tones" }
+  - { label: License, value: "GMRS — $35 FCC, no test, covers family" }
+  - { label: Price, value: "around $285" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B0DT7KC686?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [btech-gmrs-50x1, wouxun-kg-1000g-plus, midland-mxt575, radioddity-db20-g, btech-gmrs-pro, rtl-sdr]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "Best GMRS mobile & base radios", url: /best-gmrs-mobile-radios/ }
+cite_urls:
+  - https://baofengtech.com/product/gmrs-50pro/
+  - https://www.miklor.com/COM/Review_GMRS50PRO.php
+faq:
+  - q: "Do I need a license for the BTECH GMRS-50PRO?"
+    a: "To transmit, yes — a GMRS license: $35 to the FCC, good for 10 years, no test, and one license covers your immediate family. Its dual-band VHF/UHF coverage is receive/scan only, and listening needs no license."
+  - q: "Does the BTECH GMRS-50PRO really have GPS?"
+    a: "Yes — real onboard GPS with position sharing and navigation features, and it's the only radio in the GMRS mobile class that does. No Midland MXT has GPS, despite occasional confusion."
+  - q: "How do you program the GMRS-50PRO?"
+    a: "The headline way is Bluetooth: BTECH's free iOS/Android app edits channels, tones and scan lists, pushes firmware updates over the air, and clones radios. Wired programming options exist too for traditionalists."
+  - q: "Is the GMRS-50PRO reliable long-term?"
+    a: "Honest answer: too early to say. It launched in early 2025, so the forum track record is short. BTECH's firmware support has been active and responsive, but the platform simply hasn't had years in the field like the Midlands and Wouxuns."
+  - q: "Does the GMRS-50PRO work with GMRS repeaters?"
+    a: "Yes — full split-tone support, and its 50 watts are constant across GMRS channels 15–30, a pointed fix for the channel-to-channel power variance of its GMRS-50X1 grandparent."
+---
+**The BTECH GMRS-50PRO** is the spec-sheet bully of the 50-watt GMRS class:
+real **onboard GPS** (the only one here that has it), **Bluetooth app
+programming** with over-the-air firmware updates, color screens on both the
+radio and the speaker-mic, IP54 sealing, and split tones — for around
+**$285**, undercutting both 50-watt Midlands and the Wouxun by
+$65–115.[^btech] The catch is the one thing money can't buy: a track record.
+It launched in early 2025.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0DT7KC686?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Best spec-per-dollar in the 50 W class.** 50 W (5/25/50 selectable, constant
+across GMRS 15–30), GPS position sharing, Bluetooth app programming + OTA
+firmware, dual-band VHF/UHF receive/scan, NOAA with automatic alerts, split
+tones, IP54, color TFT + color-screen mic. **Genuine Part 95E grant** — TX
+locked to GMRS. The honest caveat: **the platform is new (2025)** and the
+long-term reliability record is short. **GMRS license to transmit: $35, 10
+years, no test, covers your immediate family.** Rankings:
+[best GMRS mobile radios](/best-gmrs-mobile-radios/).
+</div>
+
+## Overview
+
+The GMRS-50PRO is BTECH's third-generation 50-watt GMRS mobile, after the
+[GMRS-50X1](/reference/btech-gmrs-50x1/) and the GMRS-50V2 (which remains on
+sale as the cheaper option). Each generation has been a response to the last
+one's complaints: the V2 fixed the X1's power consistency and receive
+filtering; the PRO adds the modern layer — GPS, Bluetooth, a color TFT, and a
+firmware pipeline with an actual changelog that gets actual updates.
+
+The GPS deserves emphasis because the market is confused about it: **no
+Midland MXT has GPS**. If position sharing between vehicles on a trail run is
+what you want, this is the one radio in the class that genuinely does it.
+
+Certification is the real thing: a genuine FCC Part 95E grant, with transmit
+locked to the GMRS channels and the dual-band VHF/UHF coverage
+**receive-only** — the standard legal shape for certified import GMRS gear.
+
+**License note:** transmitting requires a GMRS license — $35 to the
+[FCC](/reference/fcc/), valid 10 years, no test, covering your immediate
+family. Listening and scanning require none.
+
+## Channels, power &amp; repeater use
+
+- **Power:** 50 W with 5/25/50 selectable levels — and constant output across
+  GMRS channels 15–30, a deliberate fix for the X1-era variance.
+- **Repeaters:** full [CTCSS](/reference/ctcss/)/[DCS](/reference/dcs/)
+  support including **split tones**.
+- **Receive:** dual-band VHF/UHF receive and scan; NOAA weather with
+  automatic alerts.
+- **GPS:** onboard, with position sharing and navigation features.
+- **Programming:** Bluetooth via the free BTECH GMRS Programmer app
+  (iOS/Android) — channels, tones, scan lists, OTA firmware, radio cloning —
+  plus wired options.
+- **Build:** IP54 weatherized; SO-239 antenna jack for standard
+  [PL-259](/reference/uhf-connector-pl259/) feedline.
+
+## The honest caveats
+
+Three things keep this from being an automatic buy. First, **it's new**: an
+early-2025 release means the forum history is thin, and radios earn trust in
+years, not spec sheets — the Midlands and the
+[Wouxun KG-1000G Plus](/reference/wouxun-kg-1000g-plus/) have field records
+this platform simply doesn't yet. Second, the **app-centric workflow** is the
+whole point and also the friction: if you fundamentally distrust
+phone-mediated radio programming, this design will annoy you daily. Third,
+**BTECH menu depth** — the interface is powerful and correspondingly deep,
+with a learning curve to match. In exchange you get the most modern
+programming experience in GMRS and a vendor that ships firmware fixes rather
+than new SKUs.
+
+## GopherTrunk alternative
+
+FRS and GMRS are analog narrowband [FM](/reference/frequency-modulation/) at
+462/467 MHz — easy targets for a ~$30 [RTL-SDR](/reference/rtl-sdr/). Free
+GopherTrunk turns that dongle into a monitor that records all local FRS/GMRS
+simplex and repeater activity, so before spending $285 you'll know whether
+your area's repeaters are alive and whether the $35 license is worth it.
+GopherTrunk cannot transmit — it's the scouting and logging complement to a
+radio like this, not a replacement.
+[Download GopherTrunk](/downloads.html) and listen before you buy.
+
+## Who it's for
+
+- **Buy the GMRS-50PRO** if you want maximum features per dollar in a 50 W
+  GMRS mobile — especially GPS position sharing for trail runs — and you're
+  comfortable being an early-ish adopter with app-based programming.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B0DT7KC686?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [Wouxun KG-1000G Plus](/reference/wouxun-kg-1000g-plus/)** instead
+  for the proven enthusiast platform with 999 channels and repeater pairing.
+- **Skip it** for the [Midland MXT575](/reference/midland-mxt575/) if you want
+  an established appliance with US-brand support, or BTECH's own handheld
+  [GMRS-PRO](/reference/btech-gmrs-pro/) if the GPS-and-app formula appeals in
+  a portable. Full rankings:
+  [best GMRS mobile radios](/best-gmrs-mobile-radios/).
+
+## Sources
+
+[^btech]: [BTECH GMRS-50PRO product page](https://baofengtech.com/product/gmrs-50pro/) — BTECH, on the 50 W selectable output, GPS, Bluetooth app programming, IP54 rating, NOAA alerts, and Part 95E certification; see also the [Miklor GMRS-50PRO review](https://www.miklor.com/COM/Review_GMRS50PRO.php).

--- a/docs/reference/btech-gmrs-50x1.md
+++ b/docs/reference/btech-gmrs-50x1.md
@@ -84,7 +84,9 @@ the GMRS-50V2's redesigned board exists specifically to fix the 50X1's
 ~40 W on some channels from a good unit; measure if you can.
 
 Where to buy: **Amazon lists it only as a "Renewed" unit** — the button above
-goes there — and **eBay is the other, often cheaper, half of the used
+goes there — and
+**<a href="https://www.ebay.com/sch/i.html?_nkw=BTECH+GMRS-50X1" rel="nofollow noopener">eBay</a>
+is the other, often cheaper, half of the used
 market** (~$80 sold for a used unit with mic; $150–160 typical asks;
 new-old-stock occasionally surfaces around $99–115 at liquidation sellers,
 though those listings can be stale).

--- a/docs/reference/btech-gmrs-50x1.md
+++ b/docs/reference/btech-gmrs-50x1.md
@@ -1,0 +1,149 @@
+---
+slug: btech-gmrs-50x1
+title: BTECH GMRS-50X1
+entry_type: hardware
+category: two-way-radios
+description: "The BTECH GMRS-50X1 was the first cheap 50-watt Part 95E GMRS mobile — now discontinued and superseded twice (GMRS-50V2, then GMRS-50PRO). A used-market buy at roughly $80–160, with known settings-byte and power-variance gotchas to test for."
+keywords: BTECH GMRS-50X1, GMRS-50X1 review, used GMRS mobile radio, 50 watt GMRS radio, GMRS-50X1 CHIRP, GMRS-50X1 vs GMRS-50V2, gmrs license, cheap 50 watt GMRS, GMRS repeater radio, used GMRS radio buying guide, BTECH GMRS mobile
+aka: [GMRS-50X1, BTech GMRS-50X1]
+autolink: true
+affiliate: true
+product:
+  name: "BTECH GMRS-50X1"
+  brand: BTECH
+  category: GMRS mobile radio (discontinued)
+  itemCondition: used
+  lowPrice: "80"
+  highPrice: "160"
+  url: https://www.amazon.com/dp/B0932TH6T9?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: "GMRS mobile radio (discontinued, superseded twice)" }
+  - { label: Service, value: "GMRS TX; RX/scan 136–174 / 400–520 MHz" }
+  - { label: Power, value: "50 W nominal (real output varies by channel)" }
+  - { label: Repeater, value: "Yes — split tones" }
+  - { label: License, value: "GMRS — $35 FCC, no test, covers family" }
+  - { label: Price, value: "around $80–160 used (thin data)" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B0932TH6T9?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">Renewed on Amazon &rarr;</a>" }
+see_also: [btech-gmrs-50pro, midland-mxt400, wouxun-kg-1000g-plus, radioddity-db20-g, baofeng-uv-5r, rtl-sdr]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "Best GMRS mobile & base radios", url: /best-gmrs-mobile-radios/ }
+cite_urls:
+  - https://baofengtech.com/product/gmrs-50x1/
+  - https://shop.mygmrs.com/products/btech-gmrs-50v2-50w-gmrs-radio
+faq:
+  - q: "Is the BTECH GMRS-50X1 discontinued?"
+    a: "Effectively, yes — BTECH still hosts the product page, but retail channels sell its successors: the GMRS-50V2 (redesigned board, constant 50 W output, better receive filtering), and now the GMRS-50PRO. The 50X1 is two generations old and lives on the used market."
+  - q: "How much is a used BTECH GMRS-50X1 worth?"
+    a: "Roughly $80–160, with wide variance — one used unit with mic sold around $80, other listings run $150–160, and full packages with antennas ask more in forum classifieds. The data is thin, so check current sold listings. Amazon carries it only as a Renewed listing."
+  - q: "Do I need a license for the BTECH GMRS-50X1?"
+    a: "To transmit, yes — a GMRS license: $35 to the FCC, good for 10 years, no test, and it covers your immediate family. Its wide 136–174/400–520 MHz coverage is receive-only, and listening needs no license."
+  - q: "Does the GMRS-50X1 really put out 50 watts?"
+    a: "Not always. Real-world output famously varies by channel — expect around 40 W on some. The successor GMRS-50V2's 'constant 50W on GMRS' marketing is an implicit admission. Measure output if you can before buying used."
+  - q: "What should I check before buying a used GMRS-50X1?"
+    a: "Verify it programs cleanly with CHIRP (early units shipped with out-of-range settings bytes — CHIRP bug #7761 — causing failed reads/writes), test transmit on GMRS channels 15–30 with a second radio (some units stop keying on GMRS after reprogramming while FRS still works), check the mic, and prefer packages with the PC04 cable."
+---
+**The BTECH GMRS-50X1** was a genuinely important radio: the first cheap
+50-watt GMRS mobile with a real Part 95E grant, huge 136–174/400–520 MHz
+receive coverage, and CHIRP support.[^btech] BTECH has since superseded it
+**twice** — the GMRS-50V2 fixed its power consistency and receive filtering,
+and the [GMRS-50PRO](/reference/btech-gmrs-50pro/) is the current platform —
+so today the 50X1 is a used-market buy at roughly **$80–160**, with wide
+variance and thin sold-price data.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0932TH6T9?tag=gophertrunk-20" rel="nofollow sponsored noopener">Renewed on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Our best used/classic GMRS buy — the most capability per used dollar.**
+50 W nominal (real output varies by channel — measure it), split tones, wide
+receive/scan plus FM broadcast and NOAA, CHIRP support, genuine Part 95E
+grant. **Amazon carries it Renewed-only; eBay is the other half of the
+market.** Test before buying: the early settings-byte bug (CHIRP #7761) and
+the stops-keying-on-GMRS-after-reprogramming failure are both documented.
+**GMRS license to transmit: $35, 10 years, no test, covers family.**
+Rankings: [best GMRS mobile radios](/best-gmrs-mobile-radios/).
+</div>
+
+## Overview
+
+When the 50X1 launched, "50 watts, certified, cheap" was a category of one,
+and it built the template BTECH still follows: maximum legal GMRS power, a
+wide receive-only scan range (that receive-only lock on transmit is exactly
+what keeps an import's Part 95E grant legal), split
+[CTCSS](/reference/ctcss/)/[DCS](/reference/dcs/) tones, and open programming
+via CHIRP. The 5-row display and fixed (non-detachable) face are dated now,
+the menus were always clunky, and the speaker-mic was the era's weak point —
+but the fundamentals still cover everything a repeater user needs.
+
+Why it was discontinued is worth knowing because it's your used-buying map:
+the GMRS-50V2's redesigned board exists specifically to fix the 50X1's
+**inconsistent power output** and audio filtering, and the marketing line
+"constant 50 W on GMRS" is an implicit admission that the 50X1 wasn't. Expect
+~40 W on some channels from a good unit; measure if you can.
+
+Where to buy: **Amazon lists it only as a "Renewed" unit** — the button above
+goes there — and **eBay is the other, often cheaper, half of the used
+market** (~$80 sold for a used unit with mic; $150–160 typical asks;
+new-old-stock occasionally surfaces around $99–115 at liquidation sellers,
+though those listings can be stale).
+
+**License note:** GMRS transmit requires a license — $35 to the
+[FCC](/reference/fcc/), valid 10 years, no test, one license covering your
+immediate family. Listening across all that receive coverage requires none.
+
+## Buying used: what to check
+
+The 50X1's known failure modes are specific, documented, and testable:
+
+1. **Verify it programs cleanly before buying.** Early units shipped with
+   out-of-range settings bytes — CHIRP bug #7761 — whose symptom is failed
+   programming reads/writes. It's fixable via CHIRP, but a radio that won't
+   read cleanly is telling you something.
+2. **Test transmit on GMRS 15–30 with a second radio.** There are documented
+   cases of 50X1s that stop keying up on GMRS channels after CHIRP
+   reprogramming while FRS channels still work. Don't just watch the TX
+   indicator — confirm with a receiver.
+3. **Measure power output if possible.** Some units run well under 50 W on
+   some channels.
+4. **Check the microphone.** BTECH mics of that era were the weak point;
+   confirm the included one works.
+5. **Prefer packages with the PC04 programming cable.**
+
+Used-market viability, plainly: parts and factory support for a
+two-generations-old import are thin, but CHIRP keeps it programmable forever,
+the failure modes are known, and at $80–120 a tested unit is the most radio
+per used dollar in GMRS — which is why it edges the
+[Midland MXT400](/reference/midland-mxt400/) (narrowband-only, no NOAA, no
+out-of-box split tones) as our used pick.
+
+## GopherTrunk alternative
+
+FRS and GMRS are analog narrowband [FM](/reference/frequency-modulation/) at
+462/467 MHz — trivial for a ~$30 [RTL-SDR](/reference/rtl-sdr/) running free
+GopherTrunk, which monitors and records all local FRS/GMRS simplex and
+repeater activity. Before hunting used listings, let a dongle tell you
+whether your local repeaters are active enough to justify 50 used watts —
+and afterward, it's the second radio you use to verify a 50X1 actually keys
+up on GMRS 15–30. GopherTrunk cannot transmit; it complements the radio.
+[Download GopherTrunk](/downloads.html) and listen first.
+
+## Who it's for
+
+- **Buy a used GMRS-50X1** if you want maximum certified wattage and receive
+  coverage for double-digit money, and you can test-drive the unit (or buy
+  Renewed with a return window) against the checklist above.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B0932TH6T9?tag=gophertrunk-20" rel="nofollow sponsored noopener">Renewed on Amazon &rarr;</a>
+- **Buy the [GMRS-50PRO](/reference/btech-gmrs-50pro/)** instead if you want
+  the current platform — GPS, Bluetooth, constant output — with a warranty,
+  for ~$285 new.
+- **Skip it** for the [Wouxun KG-1000G Plus](/reference/wouxun-kg-1000g-plus/)
+  if you want the proven enthusiast 50-watter new, or a
+  [Radioddity DB20-G](/reference/radioddity-db20-g/) if 20 new watts beat 50
+  used ones for you. Full rankings:
+  [best GMRS mobile radios](/best-gmrs-mobile-radios/).
+
+## Sources
+
+[^btech]: [BTECH GMRS-50X1 product page](https://baofengtech.com/product/gmrs-50x1/) — BTECH, on the 50 W nominal output, receive coverage, split tones, and Part 95E certification; successor: [BTECH GMRS-50V2 — myGMRS shop](https://shop.mygmrs.com/products/btech-gmrs-50v2-50w-gmrs-radio), whose constant-output redesign frames the 50X1's known power variance.

--- a/docs/reference/btech-gmrs-pro.md
+++ b/docs/reference/btech-gmrs-pro.md
@@ -1,0 +1,133 @@
+---
+slug: btech-gmrs-pro
+title: BTECH GMRS-PRO
+entry_type: hardware
+category: two-way-radios
+description: "The BTECH GMRS-PRO packs GPS, off-grid text messaging, Bluetooth, IP67 waterproofing, and app-based programming into a 5 W repeater-capable GMRS handheld for around $150 — the most feature-dense consumer GMRS radio made."
+keywords: BTECH GMRS-PRO, GMRS-PRO review, GMRS radio with GPS, GMRS text messaging radio, best GMRS handheld, gmrs license, waterproof GMRS radio, IP67 walkie talkie, Bluetooth walkie talkie, GMRS repeater radio, walkie talkie with location sharing
+aka: [GMRS-PRO, BTech GMRS Pro]
+autolink: true
+affiliate: true
+product:
+  name: "BTECH GMRS-PRO"
+  brand: BTECH
+  category: GMRS walkie-talkie (handheld)
+  lowPrice: "140"
+  highPrice: "160"
+  url: https://www.amazon.com/dp/B0B4BLZ67Z?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: "Handheld GMRS walkie-talkie with GPS + Bluetooth" }
+  - { label: Service, value: "GMRS (FCC Part 95E)" }
+  - { label: Channels, value: "GMRS simplex + repeater channels; NOAA + FM radio" }
+  - { label: Power, value: "5 W (GMRS handheld max)" }
+  - { label: License, value: "GMRS — $35 FCC, 10 years, no test" }
+  - { label: Price, value: around $150 }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B0B4BLZ67Z?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [wouxun-kg-935g, rocky-talkie-5-watt, baofeng-uv-5g-plus, garmin-rino-755t, btech-uv-pro, rtl-sdr]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "The 10 best walkie-talkies", url: /best-walkie-talkies/ }
+cite_urls:
+  - https://baofengtech.com/product/gmrs-pro/
+faq:
+  - q: "Do I need a license for the BTECH GMRS-PRO?"
+    a: "To transmit, yes — GMRS requires the FCC license: $35, valid 10 years, no test, and one license covers your immediate family. Listening requires none. The radio is properly Part 95E certified, so used as shipped it's fully legal."
+  - q: "How does texting work on the BTECH GMRS-PRO?"
+    a: "The radio has GPS and a digital data mode that sends short text messages and location pins over GMRS — but only to other GMRS-PRO and compatible BTECH radios. It is not SMS and won't message a phone directly; both ends need compatible hardware."
+  - q: "Is the BTECH GMRS-PRO waterproof?"
+    a: "Yes — IP67, rated for submersion, which is rare at this price and a class above the splash ratings on most consumer walkie-talkies."
+  - q: "How do you program the BTECH GMRS-PRO?"
+    a: "Through BTECH's phone app over Bluetooth, which works offline in the field. There's no full keypad and no CHIRP support — the app is genuinely easier than Baofeng menu-diving, but keypad-oriented users find the dependence annoying."
+  - q: "Can the BTECH GMRS-PRO use repeaters?"
+    a: "Yes — full GMRS repeater support alongside the simplex channels, plus NOAA weather with alerts and an FM broadcast receiver. It's a complete modern GMRS feature set."
+---
+**The BTECH GMRS-PRO** is the most feature-dense consumer GMRS handheld you
+can buy: **GPS with radio-to-radio location sharing and off-grid text
+messaging, Bluetooth, IP67 submersibility, NOAA alerts, FM radio, and full
+repeater support**, all Part 95E certified at **around $150**.[^btech] The
+catch is philosophical as much as technical: it's programmed from a phone
+app rather than a keypad, and its texting only speaks to compatible BTECH
+radios.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0B4BLZ67Z?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Our best-features-for-the-price pick.** GPS + texting + compass + Bluetooth
++ **IP67** + repeaters + NOAA in one $150 radio — nothing else in consumer
+GMRS matches the density. **Transmitting needs the GMRS license: $35 to the
+FCC, no test, 10 years, covers your family.** Honest limits: texting/location
+is BTECH-to-BTECH only, app programming (no CHIRP, no full keypad), and the
+receiver is good-not-great next to a [Wouxun](/reference/wouxun-kg-935g/).
+Rankings: [best walkie-talkies](/best-walkie-talkies/).
+</div>
+
+## Overview
+
+BTECH (Baofeng Tech, the US operation — a different animal from bare-import
+Baofeng) aimed the GMRS-PRO at the gap between blister-pack simplicity and
+ham-grade complexity, and largely hit it. It's a **Part 95E certified GMRS**
+radio, so the usual terms apply: **$35 FCC license, 10 years, no test, one
+license for the immediate family** to transmit; nothing at all to listen.
+
+The headline features actually work together. Onboard **GPS** feeds a
+digital position-sharing system, so a hunting party or trail crew sees each
+other's pins; the same data channel carries short **text messages** — all
+radio-to-radio over GMRS, no cell service involved, but **only between
+GMRS-PRO and compatible BTECH models**. An onboard compass, NOAA weather
+with alerts, an FM broadcast receiver, and dual-channel monitoring round it
+out. The body is **IP67 submersible** — real waterproofing, matched in this
+class only by the [Rocky Talkie Expedition
+Radio](/reference/rocky-talkie-5-watt/). Charging is USB-C.
+
+Programming is the love-it-or-hate-it part. There's no full DTMF keypad and
+no CHIRP; channels, tones, and repeater splits are configured through
+BTECH's phone **app** over Bluetooth, which works offline. For most buyers
+the app is genuinely easier than any radio's menu tree. For keypad-oriented
+power users it's a dependency they didn't ask for — those buyers want the
+[Wouxun KG-935G](/reference/wouxun-kg-935g/), which also edges the GMRS-PRO
+on raw receiver and audio performance.
+
+## Channels, power &amp; battery
+
+- **Service:** GMRS, Part 95E certified — **license required to transmit**.
+- **Power:** 5 W, the handheld legal max.
+- **Channels:** GMRS simplex + **repeater channels**, dual-channel monitor,
+  [CTCSS/DCS tones](/reference/ctcss/) set via app.
+- **Data:** GPS location sharing + text messaging (BTECH-compatible radios
+  only); Bluetooth for the app, headsets, and VOX.
+- **Receive extras:** NOAA weather with alerts; FM broadcast radio.
+- **Durability:** **IP67** submersible.
+- **Charging:** USB-C.
+- **Programming:** BTECH app (offline-capable); no CHIRP, no full keypad.
+
+## GopherTrunk alternative
+
+Before committing to a $150 radio and a $35 license, hear the band first.
+FRS/GMRS is analog narrowband FM at 462/467 MHz — comfortably inside a ~$30
+[RTL-SDR](/reference/rtl-sdr/)'s tuning range — and free GopherTrunk will
+monitor and **record** every channel and local repeater output at once. An
+evening of logging tells you which repeaters are alive and how crowded the
+simplex channels get. GopherTrunk is receive-only: it scouts, logs, and
+archives, and the GMRS-PRO does the talking. Start with
+[Learn RF &amp; SDR](/learn/rf-sdr/) if SDR listening is new to you.
+
+## Who it's for
+
+- **Buy the GMRS-PRO** if you want the deepest feature set in consumer GMRS
+  — especially group position-sharing — and everyone in your group can run
+  compatible radios.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B0B4BLZ67Z?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [Wouxun KG-935G](/reference/wouxun-kg-935g/)** instead if you'd
+  trade GPS and texting for a keypad, better receiver, and the best
+  pure-radio UX in GMRS.
+- **Skip it** for a [Rocky Talkie Expedition
+  Radio](/reference/rocky-talkie-5-watt/) if ruggedness and simplicity beat
+  features, or a [Baofeng UV-5G Plus](/reference/baofeng-uv-5g-plus/) at a
+  fifth the price if budget rules. Full rankings:
+  [best walkie-talkies](/best-walkie-talkies/).
+
+## Sources
+
+[^btech]: [BTECH GMRS-PRO product page](https://baofengtech.com/product/gmrs-pro/) — BTECH, on Part 95E certification, GPS/texting/location sharing, Bluetooth and app programming, IP67 rating, NOAA alerts, and repeater support.

--- a/docs/reference/cobra-2000-gtl.md
+++ b/docs/reference/cobra-2000-gtl.md
@@ -1,0 +1,146 @@
+---
+slug: cobra-2000-gtl
+title: Cobra 2000 GTL
+entry_type: hardware
+category: two-way-radios
+description: "The Cobra 2000 GTL is the legendary AM/SSB base station of CB's golden age — frequency counter, dual meters, matching speaker — now collector-priced at roughly $450–800+ used, eBay and hamfests only, with a recap practically assumed."
+keywords: Cobra 2000 GTL, Cobra 2000 GTL for sale, Cobra 2000 GTL review, vintage CB base station, classic CB radio, AM SSB base station CB, Cobra 2000 recap, CB base station radio, Dynascan Cobra, used CB radio buying guide
+aka: [2000 GTL, Cobra 2000]
+autolink: true
+affiliate: true
+product:
+  name: "Cobra 2000 GTL"
+  brand: Cobra
+  category: CB radio (vintage AM/SSB base station)
+  seller: eBay
+  itemCondition: used
+  lowPrice: "525"
+  highPrice: "980"
+  url: "https://www.ebay.com/sch/i.html?_nkw=Cobra+2000+GTL"
+infobox:
+  - { label: Type, value: "Vintage AM/SSB base station (AC-powered)" }
+  - { label: Service, value: "CB — 40 channels, 26.965–27.405 MHz" }
+  - { label: Modes, value: "AM/SSB — no FM, no weather" }
+  - { label: Power, value: "4 W AM / 12 W PEP SSB; built-in AC supply" }
+  - { label: Extras, value: "Frequency counter, clock, dual meters (SWR/MOD + S/RF), matching speaker" }
+  - { label: License, value: "None (CB) — licensed by rule, Part 95D" }
+  - { label: Price, value: "around $450–800+ used (collector asks to ~$980)" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.ebay.com/sch/i.html?_nkw=Cobra+2000+GTL\" rel=\"nofollow noopener\">Find on eBay &rarr;</a>" }
+see_also: [uniden-grant-xl, cobra-29-ltd-classic, president-mckinley, uniden-bearcat-980ssb, single-sideband, rtl-sdr]
+related_reading:
+  - { title: "The 10 best CB radios", url: /best-cb-radios/ }
+  - { title: "Best HF SDRs (to listen on 27 MHz)", url: /best-hf-sdr/ }
+cite_urls:
+  - https://www.rigpix.com/cbfreeband/cobra_2000gtl.htm
+  - https://cbradiomagazine.com/cobra-2000-gtl-am-ssb-cb-radio-review/
+faq:
+  - q: "How much is a Cobra 2000 GTL worth today?"
+    a: "Collector money. Recent asks run $525 to $980-plus for clean complete examples, and even the matching external speaker alone sells for $50–125. Those are asking prices, not confirmed solds — budget roughly $450–800 for a good working example and pay the top of the band only for serviced, unmodified units with the speaker."
+  - q: "Is the Cobra 2000 GTL still a good radio?"
+    a: "The receiver is still the legend — quiet, sensitive, famous for pulling out far-off stations — and the big-radio ergonomics have never been matched in CB. But every example is 35–45 years old: assume it needs a recap and realignment unless the seller can prove the work was done."
+  - q: "What should I check before buying a Cobra 2000 GTL?"
+    a: "Dried electrolytic capacitors are the number-one issue, including the hard-to-find ones inside the slug-tuned RF/IF coils on humid-stored units. Verify the frequency counter displays and tracks (its board commonly needs its own recap), check AGC on strong signals, sweep the clarifier on SSB receive, confirm the meter lamps, and ask whether the radio is unmodified — channel mods and 'peaked' radios lower collector value."
+  - q: "Do I need a license for a Cobra 2000 GTL?"
+    a: "No — CB is licensed by rule under FCC Part 95D, and the 2000 GTL was type-accepted in its day at the legal 4 W AM / 12 W PEP SSB. One caveat: a unit that's been channel-modded or peaked beyond legal limits no longer complies, which hurts both legality and collector value."
+  - q: "Does the Cobra 2000 GTL have FM or weather channels?"
+    a: "Neither — it predates both features. It's a 40-channel AM/SSB base station from the era before the FCC's 2021 FM authorization and before NOAA reception became a CB checkbox. What it has instead: a built-in frequency counter, clock, dual meters, and that receiver."
+---
+**The Cobra 2000 GTL** was the flagship base station of CB's golden age — the
+Dynascan-era AM/SSB console with a built-in **frequency counter**, clock,
+dual meters, and a matching external speaker, whose receiver is still
+described as the quietest and most sensitive Cobra ever put on 11
+meters.[^rigpix] It's been **out of production for decades**: the used
+market — eBay, Reverb, hamfests — is where it lives, and it has crossed into
+**collector pricing**: recent asks run **$525–980**, with roughly **$450–800**
+the working band for a good clean example.[^cbmag]
+
+<a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=Cobra+2000+GTL" rel="nofollow noopener">Find on eBay &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The definitive CB base station — bought with a checklist, not a click.**
+Legendary quiet receiver, 4 W AM / 12 W PEP SSB, AC-powered console with
+frequency counter and dual meters. **Used/collector market only**, asks
+$525–980 (asks, not solds — budget ~$450–800). **Assume a recap**: dried
+electrolytics — including the nasty ones inside the slug-tuned coils — are
+the signature faults. Matching speaker adds real value; unmodified beats
+"peaked." **License-free** (Part 95D). Full rankings:
+[best CB radios](/best-cb-radios/).
+</div>
+
+## Overview
+
+Base stations were where 1980s CB makers showed off, and the 2000 GTL was the
+show-off's show-off: a wide AC-powered console with full-size knobs, an
+**S/RF meter and a separate SWR/MOD meter**, a **built-in frequency counter**
+(a real luxury then), a clock, and the matching dynamic speaker that
+completes the set. Under it all sits the receiver the radio is remembered
+for — quiet, sensitive, the "picks out far-off stations" rig of a thousand
+forum testimonials — plus clean 4 W AM and 12 W PEP
+[SSB](/reference/single-sideband/) transmit.
+
+Be clear about what buying one means in 2026: this is a **collector purchase
+with a service plan**, not a daily commodity. Prices have climbed into
+genuine collector territory — and note our figures are **asking** prices;
+confirmed sold data is thin. The matching speaker alone trades for $50–125,
+so its presence or absence moves the price of the whole set.
+
+**License note:** CB needs no license (Part 95D, licensed by rule), and the
+2000 GTL was Part 95 type-accepted in its day. A caveat vintage buyers must
+hear: many surviving units have been **channel-modded or "peaked"** — those
+modifications void the type acceptance, make the radio non-compliant to
+transmit, and *lower* collector value. Original and stock is worth more in
+every sense.
+
+## Buying used: what to check
+
+This is the section that matters. Every 2000 GTL is 35–45 years old, and the
+faults cluster predictably:[^cbmag]
+
+1. **Dried or leaky electrolytic capacitors** — the number-one issue, and
+   the cause of the bizarre intermittent faults these radios are known for.
+   Assume any un-serviced unit needs a **full recap (~$30 in parts plus an
+   afternoon) and a realignment**; price accordingly.
+2. **Capacitors inside the slug-tuned RF/IF coils** — fail on units stored
+   in humidity, are harder to source, and are a notorious troubleshooting
+   trap. Ask where the radio lived.
+3. **The frequency counter/clock board** commonly needs its own recap —
+   verify the counter displays and actually tracks the channel selector.
+4. **Function checks:** AGC behavior on strong signals, SSB receive with a
+   clarifier sweep, meter lamps, channel-selector feel.
+5. **Provenance:** unmodified beats modified; **matching speaker present**
+   adds real value and is commonly missing.
+
+Working for you: a huge community that has fixed all of this a thousand
+times, and simple through-hole construction. Working against you: no factory
+support, and parts donors are themselves getting expensive.
+
+## GopherTrunk alternative
+
+Our honest note, as on every CB page: **GopherTrunk is not the tool for 11
+meters.** CB is 27 MHz analog AM/[SSB](/reference/single-sideband/) — below
+an [RTL-SDR](/reference/rtl-sdr/)'s native range without direct sampling or
+an [upconverter](/reference/upconverter/), and analog voice is outside
+GopherTrunk's trunking/digital focus. If you want a modern companion for a
+vintage base shack, an [HF-capable SDR](/best-hf-sdr/) gives you a waterfall
+view of the band a 1980s console never had — but it listens only. The
+channel map is in our [scanner frequencies reference](/scanner-frequencies/).
+
+## Who it's for
+
+- **Buy the 2000 GTL** if you're a collector or home-base hobbyist who wants
+  the definitive golden-age console and can service it (or pay someone who
+  can).
+  <a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=Cobra+2000+GTL" rel="nofollow noopener">Find on eBay &rarr;</a>
+- **Buy the [Uniden Grant XL](/reference/uniden-grant-xl/)** instead for
+  vintage SSB money-sanity — same-era sideband for a tenth the price — or a
+  new [President McKinley II](/reference/president-mckinley/) for modern SSB
+  that just works.
+- **Not a trucker radio** — it's AC-powered and desk-sized. For the cab,
+  see the [29 LTD Classic](/reference/cobra-29-ltd-classic/). Full rankings:
+  [best CB radios](/best-cb-radios/).
+
+## Sources
+
+[^rigpix]: [Cobra 2000 GTL — RigPix](https://www.rigpix.com/cbfreeband/cobra_2000gtl.htm) — specifications: 40-channel AM/SSB, 4 W / 12 W PEP, AC-powered base architecture, frequency counter, and meters.
+[^cbmag]: [Cobra 2000 GTL AM/SSB CB radio review — CB Radio Magazine](https://cbradiomagazine.com/cobra-2000-gtl-am-ssb-cb-radio-review/) — on the receiver's reputation, the matching speaker, aging electrolytics and coil-capacitor failures, and used-market condition checks.

--- a/docs/reference/cobra-29-ltd-classic.md
+++ b/docs/reference/cobra-29-ltd-classic.md
@@ -1,0 +1,132 @@
+---
+slug: cobra-29-ltd-classic
+title: Cobra 29 LTD Classic
+entry_type: hardware
+category: two-way-radios
+description: "The Cobra 29 LTD Classic is the longest-running CB radio in America — the de-facto trucker standard, now AM/FM, with an analog meter, knob-per-function controls, and every CB shop able to service it, for around $105–140."
+keywords: Cobra 29 LTD Classic, Cobra 29 LTD review, Cobra 29 LTD Classic CB radio, best trucker CB radio, classic CB radio, AM FM CB radio 2026, CB radio no license, Cobra 29 vs Bearcat 880, peak and tune CB, channel 19 CB radio
+aka: [29 LTD, Cobra 29 LTD, 29 LTD Classic]
+autolink: true
+affiliate: true
+product:
+  name: "Cobra 29 LTD Classic"
+  brand: Cobra
+  category: CB radio (full-size mobile)
+  lowPrice: "105"
+  highPrice: "140"
+  url: https://www.amazon.com/dp/B0BVGTZCLB?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: Full-size mobile CB }
+  - { label: Service, value: "CB — 40 channels, 26.965–27.405 MHz" }
+  - { label: Modes, value: "AM/FM (current revision; older stock AM-only)" }
+  - { label: Power, value: "4 W (legal max), 12 V DC" }
+  - { label: Extras, value: "SWR calibration, RF/Dynamike gain, PA, instant Ch 9 — no weather" }
+  - { label: License, value: "None (CB) — licensed by rule, Part 95D" }
+  - { label: Price, value: around $105–140 }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B0BVGTZCLB?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [cobra-29-lx, uniden-bearcat-880, cobra-2000-gtl, uniden-grant-xl, rtl-sdr, standing-wave-ratio]
+related_reading:
+  - { title: "The 10 best CB radios", url: /best-cb-radios/ }
+  - { title: "Scanner frequencies (incl. CB channels)", url: /scanner-frequencies/ }
+cite_urls:
+  - https://www.cobra.com/products/29ltd
+faq:
+  - q: "Do I need a license for the Cobra 29 LTD Classic?"
+    a: "No. CB is license-free — 'licensed by rule' under FCC Part 95D, with no exam or fee. The legal limit is 4 watts carrier on AM and FM, which is exactly what the 29 LTD puts out."
+  - q: "Is the Cobra 29 LTD Classic still worth buying in 2026?"
+    a: "Yes — it's still the de-facto trucker standard. The current revision adds FM alongside AM, the transmit audio is strong, and every CB shop in the country can tune or repair one. What you give up versus newer rigs: no weather channels, no SSB, and dated receiver filtering."
+  - q: "Does the Cobra 29 LTD have weather channels?"
+    a: "No — NOAA weather reception is the Cobra 29 LX's job, for roughly $50–60 more. The LTD Classic keeps the traditional feature set: SWR calibration, RF gain, Dynamike, PA, and instant channel 9."
+  - q: "Does the Cobra 29 LTD Classic do FM?"
+    a: "Current production does. Cobra refreshed the 29 LTD to AM/FM around 2023 after the FCC legalized FM on CB in 2021. Older AM-only units are still on shelves and in listings, so check before buying if FM matters."
+  - q: "What's the range of a Cobra 29 LTD?"
+    a: "A legal 4-watt CB realistically talks a few miles vehicle-to-vehicle. Antenna choice and SWR tuning dominate — a well-tuned antenna on a 29 LTD will outperform a poorly tuned one on any radio at any price. Use the built-in SWR calibration during install."
+---
+**The Cobra 29 LTD Classic** is the longest-running CB model in the United
+States — the 29 line has been the trucker standard for over fifty years, and
+this is the radio the phrase "peak and tune" was built around.[^cobra] The
+current revision adds **FM alongside AM** (legal on CB since 2021), keeps the
+analog needle meter and knob-per-function layout, and costs around
+**$105–140** — the cheapest way into a full-size, shop-serviceable CB.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0BVGTZCLB?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The de-facto trucker standard.** Fifty-plus years of the 29 line means
+strong transmit audio, a huge mic and mod aftermarket, and a repair bench in
+every truck stop. **AM/FM on current stock** (older units AM-only — check the
+box). **No weather channels** — the [29 LX](/reference/cobra-29-lx/) adds
+those for ~$60 more. **No license required** (Part 95D, licensed by rule).
+**~$105–140.** Where it ranks: [best CB radios](/best-cb-radios/).
+</div>
+
+## Overview
+
+Radios survive fifty years in production for exactly one reason: they keep
+earning it. The 29 LTD's case is simple — **every CB shop in America knows
+this radio.** They stock parts for it, they can align it, and the aftermarket
+around it (power mics, echo boards, the whole peak-and-tune culture) is bigger
+than for any other CB ever made. When a trucker asks the shop counter "what
+should I get," this is still the default answer.
+
+The design philosophy is a knob per function: volume, squelch, RF gain,
+Dynamike mic gain, SWR calibration, PA switch, instant channel 9, dimmer. No
+menus, no soft keys, an analog needle meter. After the FCC's 2021 rule change,
+Cobra refreshed the LTD to **AM/FM dual mode** (~2023); as with the LX,
+**AM-only older stock still circulates**, so verify the revision if FM
+matters. There are **no weather channels** — Cobra reserves NOAA reception for
+the [29 LX](/reference/cobra-29-lx/).
+
+**License note:** CB needs none — it's licensed by rule under FCC Part 95D.
+Legal output is 4 W carrier on AM/FM; the 29 LTD is certified to exactly that.
+
+## Modes, features &amp; honest weaknesses
+
+- **40 channels**, 4 W AM/FM (current revision), Part 95D certified.
+- **SWR calibration** built in — tune your antenna at install
+  ([why SWR matters](/reference/standing-wave-ratio/)); antenna tuning is the
+  single biggest performance factor on CB, full stop.
+- RF gain, Dynamike, PA output, instant Ch 9, dimmer, analog S/RF meter.
+- Full-size chassis, 12 V DC.
+
+The honest knocks: the receiver filtering is dated next to current
+President and Uniden SSB rigs — on a noisy highway the
+[McKinley II](/reference/president-mckinley/) hears more; there are no weather
+channels; the chassis is large for modern interiors; and long-time owners say
+build quality has slipped from the vintage Dynascan-era units (which is partly
+why clean old [Cobra 2000 GTL](/reference/cobra-2000-gtl/) base stations now
+fetch collector money). None of that changes what the LTD is: the proven
+baseline everything else gets measured against.
+
+## GopherTrunk alternative
+
+We'll be straight: **CB is not GopherTrunk territory.** GopherTrunk decodes
+trunked and digital systems; CB is 27 MHz analog
+[AM](/reference/amplitude-modulation/)/SSB, which sits below an
+[RTL-SDR](/reference/rtl-sdr/)'s native tuning range unless you resort to
+[direct sampling](/reference/direct-sampling/) or an
+[upconverter](/reference/upconverter/) — and even then you'd want different
+software. If you want to hear what's on channel 19 around you before buying, a
+CB-capable scanner or an [HF SDR](/best-hf-sdr/) is the listening tool; the
+channel list is in our [scanner frequencies reference](/scanner-frequencies/).
+Talking takes a transmitter — that's this radio's job.
+
+## Who it's for
+
+- **Buy the 29 LTD Classic** if you want the proven trucker standard, the
+  biggest service and accessory ecosystem in CB, and the classic bench-mod
+  platform — at the lowest full-size price.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B0BVGTZCLB?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [29 LX](/reference/cobra-29-lx/)** instead for NOAA weather alerts
+  and the modern 4-color display, or the
+  [Bearcat 880FM](/reference/uniden-bearcat-880/) for a slicker mid-size rig
+  with built-in SWR metering.
+- **Skip it** if you want SSB's extra range — that's the
+  [McKinley II](/reference/president-mckinley/) or the vintage
+  [Grant XL](/reference/uniden-grant-xl/) route. Full rankings:
+  [best CB radios](/best-cb-radios/).
+
+## Sources
+
+[^cobra]: [Cobra 29 LTD Classic product page](https://www.cobra.com/products/29ltd) — Cobra Electronics, on the AM/FM refresh, SWR calibration, Dynamike gain, instant channel 9, and the 29 line's history.

--- a/docs/reference/cobra-29-lx.md
+++ b/docs/reference/cobra-29-lx.md
@@ -1,0 +1,139 @@
+---
+slug: cobra-29-lx
+title: Cobra 29 LX
+entry_type: hardware
+category: two-way-radios
+description: "The Cobra 29 LX is the classic 29-series trucker CB with a modern face — AM/FM on current stock, NOAA weather alerts, a 4-color LCD, and built-in SWR calibration for around $150–190. No Bluetooth on the plain LX; that's the LX MAX."
+keywords: Cobra 29 LX, Cobra 29 LX review, Cobra 29 LX CB radio, best CB radio for truckers, Cobra 29 LX vs 29 LTD, CB radio with weather channels, AM FM CB radio, do I need a license for CB radio, Cobra 29 LX Bluetooth, CB radio SWR calibration, trucker CB radio
+aka: [29 LX, Cobra 29LX]
+autolink: true
+affiliate: true
+product:
+  name: "Cobra 29 LX"
+  brand: Cobra
+  category: CB radio (full-size mobile)
+  lowPrice: "150"
+  highPrice: "190"
+  url: https://www.amazon.com/dp/B0FDBPJ4FS?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: Full-size mobile CB }
+  - { label: Service, value: "CB — 40 channels, 26.965–27.405 MHz" }
+  - { label: Modes, value: "AM/FM (current revision; older stock AM-only)" }
+  - { label: Power, value: "4 W (legal max), 12 V DC" }
+  - { label: Extras, value: "NOAA weather + alerts, SWR calibration, 4-color LCD, PA" }
+  - { label: License, value: "None (CB) — licensed by rule, Part 95D" }
+  - { label: Price, value: around $150–190 }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B0FDBPJ4FS?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [cobra-29-ltd-classic, uniden-bearcat-880, cobra-75-all-road, president-mckinley, rtl-sdr, standing-wave-ratio]
+related_reading:
+  - { title: "The 10 best CB radios", url: /best-cb-radios/ }
+  - { title: "Scanner frequencies (incl. CB channels)", url: /scanner-frequencies/ }
+cite_urls:
+  - https://www.cobra.com/products/29lx
+faq:
+  - q: "Do I need a license for the Cobra 29 LX?"
+    a: "No. CB is licensed by rule under FCC Part 95D — no exam, no fee, no paperwork. The legal limits are 4 watts carrier on AM/FM (12 W PEP on SSB radios, which the 29 LX is not). Just install it, tune the antenna, and talk."
+  - q: "Does the Cobra 29 LX have Bluetooth?"
+    a: "No — the plain 29 LX has no Bluetooth. Cobra put Bluetooth on the older 29 LX BT (now mostly leftover and eBay stock) and on the current 29 LX MAX, which runs around $220 and adds app pairing and hands-free calling. If Bluetooth matters, buy the LX MAX, not the LX."
+  - q: "Does the Cobra 29 LX do FM?"
+    a: "Current production does — the 29 line was refreshed with AM/FM dual mode after the FCC legalized FM on CB in 2021. Older AM-only 29 LX stock is still in the retail channel, so check the box or listing before buying if FM matters to you."
+  - q: "What's the difference between the Cobra 29 LX and the 29 LTD Classic?"
+    a: "Same core radio. The LX adds NOAA weather channels with alerts, a selectable 4-color LCD, and Radio Check diagnostics for roughly $50–60 more. The LTD Classic keeps the analog needle meter and classic layout at around $105–140. If you don't need weather channels, the LTD is the better value."
+  - q: "What's the range of the Cobra 29 LX?"
+    a: "Like every legal 4-watt CB, figure a few miles vehicle-to-vehicle — terrain and, above all, antenna quality and SWR tuning matter far more than the radio. The built-in SWR calibration helps you get that tuning right without a separate meter."
+---
+**The Cobra 29 LX** is the classic Cobra 29 trucker radio wearing a modern
+face: the same full-size chassis and transmit audio the 29 line built fifty
+years of reputation on, plus **NOAA weather channels with emergency alerts**, a
+selectable **4-color LCD**, built-in **SWR calibration**, and — on current
+stock — **AM/FM dual mode** now that FM on CB is legal.[^cobra] Street price
+runs around **$150–190**.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0FDBPJ4FS?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The 29 with weather channels and a modern display.** Classic 29-series RF
+and mic audio, NOAA alerts, 4-color LCD, SWR calibration, Radio Check
+diagnostics. **AM/FM on the current revision** — older AM-only stock still
+circulates, so check the box. **No Bluetooth** — that's the 29 LX MAX (~$220).
+**No license needed** — CB is licensed by rule (Part 95D). **~$150–190**;
+the [29 LTD Classic](/reference/cobra-29-ltd-classic/) is the same radio minus
+weather for ~$60 less. Full rankings: [best CB radios](/best-cb-radios/).
+</div>
+
+## Overview
+
+The 29 LX exists because the 29 LTD Classic is deliberately frozen in time.
+Cobra took the proven 29 platform — the radio every truck stop and CB shop in
+America knows how to tune and repair — and gave it the things a 1970s design
+never had: a backlit LCD you can set to blue, red, green, or amber to match a
+modern dash, **NOAA weather reception with alert wake-up**, auto-scan, and a
+Radio Check diagnostic mode that reports battery voltage, RF output, and
+antenna condition without extra test gear.
+
+After the FCC legalized **FM on CB in 2021**, Cobra refreshed the line with
+AM/FM dual mode. That matters at the parts counter: **older AM-only 29 LX
+units are still in the channel**, so if FM matters to you, confirm the
+revision before checkout. On the air, AM remains what truckers on
+[channel 19](/scanner-frequencies/) actually use; FM is quieter for local
+chatter between radios that both have it.
+
+**One thing the 29 LX does not have: Bluetooth.** Cobra's naming invites the
+mistake — Bluetooth lives on the older **29 LX BT** (now leftover/eBay stock)
+and the current **29 LX MAX** (~$220, app pairing and hands-free calling). If
+a listing implies the plain LX pairs with your phone, it's wrong.
+
+**License note:** none needed. CB is "licensed by rule" under FCC Part 95D —
+no exam, no fee. Legal power is 4 W carrier on AM/FM.
+
+## Modes &amp; features
+
+- **40 channels**, 26.965–27.405 MHz; **4 W** AM/FM (FM on current revision).
+- **NOAA weather channels + emergency alerts** — the headline feature over the
+  29 LTD, and genuinely useful on the road.
+- **SWR calibration** built in — tune your antenna (the single biggest factor
+  in CB performance; see [SWR](/reference/standing-wave-ratio/)) without a
+  separate meter.
+- RF gain, Dynamike mic gain, PA output, instant channel 9, auto-scan,
+  Radio Check diagnostics, 4-color selectable LCD with dimmer.
+- Full-size mobile chassis, 12 V DC — measure your dash space before buying;
+  this is a big radio by modern pickup-interior standards.
+
+The trade-offs are the honest ones: you're paying roughly **$60 over a
+29 LTD Classic** for the display, weather, and diagnostics on what is
+otherwise the same transmitter and receiver, the stock mic is merely adequate
+(power-mic upgrades are a whole aftermarket), and the footprint fights modern
+interiors. If dash space is the problem, the
+[Cobra 75 All Road](/reference/cobra-75-all-road/) puts the whole radio in a
+handset.
+
+## GopherTrunk alternative
+
+Here's the honest version: **GopherTrunk is not the tool for CB.** CB lives at
+27 MHz [AM](/reference/amplitude-modulation/)/SSB — below an
+[RTL-SDR](/reference/rtl-sdr/)'s native VHF tuning range unless you use
+direct-sampling mode or an [upconverter](/reference/upconverter/), and analog
+AM/SSB voice is outside GopherTrunk's trunking and digital-decode focus. If
+you just want to *listen* to channel 19 before buying, a scanner that covers
+CB or an [HF-capable SDR](/best-hf-sdr/) does that; our
+[scanner frequencies reference](/scanner-frequencies/) has the full 40-channel
+list. To *talk*, you need a real CB like this one.
+
+## Who it's for
+
+- **Buy the 29 LX** if you want the traditional trucker 29 with weather
+  alerts, a readable modern display, and built-in SWR tuning.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B0FDBPJ4FS?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [29 LTD Classic](/reference/cobra-29-ltd-classic/)** instead to
+  save ~$60 if you don't need weather channels, or the
+  [Bearcat 880FM](/reference/uniden-bearcat-880/) for the best display and
+  built-in SWR metering in the mid-size class.
+- **Skip it** if you want SSB range — the
+  [President McKinley II](/reference/president-mckinley/) or
+  [Bearcat 980SSB](/reference/uniden-bearcat-980ssb/) are the sideband rigs.
+  Full rankings: [best CB radios](/best-cb-radios/).
+
+## Sources
+
+[^cobra]: [Cobra 29 LX product page](https://www.cobra.com/products/29lx) — Cobra Electronics, on the AM/FM refresh, NOAA weather with alerts, 4-color LCD, SWR calibration, and Radio Check diagnostics.

--- a/docs/reference/cobra-75-all-road.md
+++ b/docs/reference/cobra-75-all-road.md
@@ -1,0 +1,133 @@
+---
+slug: cobra-75-all-road
+title: Cobra 75 All Road
+entry_type: hardware
+category: two-way-radios
+description: "The Cobra 75 All Road packs an entire AM/FM CB into a wireless, IP66 handset — near-zero dash footprint, NOAA weather, and a hideaway transceiver box, for around $130–200. The modern successor to the classic 75 WX ST."
+keywords: Cobra 75 All Road, Cobra 75 All Road review, handset CB radio, no dash space CB radio, wireless CB handset, Cobra 75 WX ST replacement, AM FM CB radio, CB radio for Jeep, compact CB radio 2026, CB radio no license
+aka: [75 All Road, Cobra 75AR]
+autolink: true
+affiliate: true
+product:
+  name: "Cobra 75 All Road"
+  brand: Cobra
+  category: CB radio (remote-handset mobile)
+  lowPrice: "130"
+  highPrice: "200"
+  url: https://www.amazon.com/dp/B0BYL3NV6L?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: Remote-handset mobile CB (wireless handset + hideaway box) }
+  - { label: Service, value: "CB — 40 channels, 26.965–27.405 MHz" }
+  - { label: Modes, value: "AM/FM" }
+  - { label: Power, value: "4 W (legal max), 12 V DC transceiver box" }
+  - { label: Extras, value: "IP66 handset, NOAA weather + alerts, instant Ch 9/19, NB/ANL — no SWR meter" }
+  - { label: License, value: "None (CB) — licensed by rule, Part 95D" }
+  - { label: Price, value: around $130–200 }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B0BYL3NV6L?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [uniden-pro505xl, midland-75-822, cobra-29-lx, uniden-bearcat-880, standing-wave-ratio, rtl-sdr]
+related_reading:
+  - { title: "The 10 best CB radios", url: /best-cb-radios/ }
+  - { title: "Scanner frequencies (incl. CB channels)", url: /scanner-frequencies/ }
+cite_urls:
+  - https://www.cobra.com/products/75-allroad
+faq:
+  - q: "Do I need a license for the Cobra 75 All Road?"
+    a: "No. CB is licensed by rule under FCC Part 95D — no exam, no fee. The 75 All Road transmits the legal 4 watts on AM and FM."
+  - q: "How does the Cobra 75 All Road mount in a vehicle?"
+    a: "A small hideaway transceiver box wires to 12 V and your antenna behind the dash or under a seat; the entire radio interface lives in the handset, which pairs wirelessly to the box and charges over USB. Dash footprint is effectively zero — that's the whole point."
+  - q: "Is the Cobra 75 All Road handset waterproof?"
+    a: "The handset carries an IP66 rating — dust-tight and protected against powerful water jets — so rain, spray, and trail dust are fine. It's not rated for submersion. The transceiver box should still be mounted out of the weather."
+  - q: "Does the Cobra 75 All Road do FM?"
+    a: "Yes — it's a dual-mode AM/FM CB, one of the 2023-generation radios built after the FCC legalized FM on CB in 2021. FM is noticeably quieter for local car-to-car use; AM remains what channel 19 runs."
+  - q: "What replaced the Cobra 75 WX ST?"
+    a: "This radio — the 75 All Road is Cobra's 2023 replacement for the long-lived 75 WX ST handset CB. The big changes: the handset went wireless (and needs charging), it gained FM and an IP66 rating, and the digital noise-canceling mic was updated."
+---
+**The Cobra 75 All Road** solves the problem every modern vehicle has: no
+place to put a CB. The entire radio lives in a **wireless, IP66-rated
+handset** that pairs to a small hideaway transceiver box, so the dash
+footprint is effectively zero.[^cobra] It's the 2023 successor to the
+long-lived 75 WX ST, adds **AM/FM dual mode** and NOAA weather, and streets
+around **$130–200** (MSRP $199.95).
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0BYL3NV6L?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The no-dash-space CB.** Whole radio in a wireless IP66 handset; hideaway
+12 V box takes the antenna. AM/FM, NOAA weather + alerts, digital
+noise-canceling mic, instant Ch 9/19. **Trade-offs:** small handset speaker
+(use the external-speaker jack on the highway), one more battery to charge,
+and receive performance a class below the
+[29 series](/reference/cobra-29-lx/) or
+[McKinley](/reference/president-mckinley/). **No SWR meter** — tune the
+antenna with an external one. **License-free** (Part 95D). **~$130–200.**
+Full rankings: [best CB radios](/best-cb-radios/).
+</div>
+
+## Overview
+
+Cobra's 75-series handset CBs have been the answer to "my truck has nowhere
+to mount a radio" since the 1990s, and the All Road is that idea rebuilt for
+2023-era vehicles. The transceiver — a small box — hides behind the dash or
+under a seat, wired to 12 V and the antenna. Everything you touch is the
+handset: channel display with frequency readout, scan, instant channels 9
+and 19, Local/DX switch, noise blanker and ANL, and a **digital
+noise-canceling mic**. The handset pairs **wirelessly** to the box and
+charges over USB, and its **IP66 rating** shrugs off rain and trail dust —
+a real upgrade for open Jeeps and side-by-sides.
+
+The honest ledger has three entries on the debit side. First, the handset
+speaker is small: at highway noise you'll want the external-speaker jack
+fed to a real speaker. Second, wireless means **another battery to keep
+charged** — the old wired 75 WX ST never had a dead handset. Third, receive
+performance is adequate rather than excellent; this is a convenience-first
+radio, not a [29-series](/reference/cobra-29-ltd-classic/) or
+[McKinley](/reference/president-mckinley/) competitor on a noisy band. There's
+also **no SWR metering**, so tune your antenna with an external meter at
+install — on CB, [antenna tuning](/reference/standing-wave-ratio/) is the
+single biggest performance factor regardless of radio.
+
+**License note:** none required — CB is licensed by rule under FCC Part 95D,
+with 4 W the legal carrier limit on AM and FM. FM on CB has been legal since
+2021, and the All Road is one of the first Cobras designed for it.
+
+## Modes &amp; features
+
+- **40 channels**, 4 W **AM/FM**, Part 95D certified.
+- **Wireless handset**: full controls + frequency display, USB-charged,
+  **IP66** dust/water protection.
+- **NOAA weather + alerts**, instant Ch 9/19, scan, Local/DX, NB/ANL,
+  digital noise-canceling mic.
+- Hideaway 12 V transceiver box; external-speaker jack. No SWR meter.
+
+## GopherTrunk alternative
+
+Full disclosure from the people who make free decoding software:
+**GopherTrunk is not a CB tool.** CB sits at 27 MHz in analog
+[AM](/reference/amplitude-modulation/)/[FM](/reference/frequency-modulation/) —
+below an [RTL-SDR](/reference/rtl-sdr/)'s native range without
+direct-sampling mode or an [upconverter](/reference/upconverter/), and
+analog voice on 27 MHz is outside GopherTrunk's trunking/digital focus. Want
+to hear what your local channel 19 sounds like before buying? A CB-capable
+scanner or an [HF SDR](/best-hf-sdr/) does the listening; the channel list
+is in our [scanner frequencies reference](/scanner-frequencies/). For
+talking from a dashless modern truck, this is the hardware that fits.
+
+## Who it's for
+
+- **Buy the 75 All Road** if your vehicle has no radio real estate — modern
+  pickups, Jeeps, lease vehicles you can't drill — or you want a CB you can
+  move between vehicles with just a box swap.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B0BYL3NV6L?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [Midland 75-822](/reference/midland-75-822/)** instead if you'd
+  rather have a handheld that *becomes* a mobile (and works away from the
+  truck), or the [PRO505XL](/reference/uniden-pro505xl/) if the budget is
+  $60 and you have somewhere to bolt it.
+- **Skip it** for a [Bearcat 880FM](/reference/uniden-bearcat-880/) or
+  [29 LX](/reference/cobra-29-lx/) if you have the dash space — more
+  receiver, more speaker, built-in SWR metering. Full rankings:
+  [best CB radios](/best-cb-radios/).
+
+## Sources
+
+[^cobra]: [Cobra 75 All Road product page](https://www.cobra.com/products/75-allroad) — Cobra Electronics, on the wireless IP66 handset, hideaway transceiver, AM/FM dual mode, NOAA weather with alerts, and digital noise-canceling mic.

--- a/docs/reference/garmin-rino-755t.md
+++ b/docs/reference/garmin-rino-755t.md
@@ -1,0 +1,145 @@
+---
+slug: garmin-rino-755t
+title: Garmin Rino 755t
+entry_type: hardware
+category: two-way-radios
+description: "The Garmin Rino 755t is the discontinued 5 W GMRS radio + full GPS navigator hybrid with peer position reporting — the hunting-party classic nothing replaced. Used-market only, holding roughly $400–550, with battery and touchscreen checks essential."
+keywords: Garmin Rino 755t, Rino 755t review, Garmin Rino used, GPS walkie talkie, GMRS radio with GPS, Rino 755t discontinued, hunting radio GPS, position reporting radio, Garmin Rino 750, gmrs license, used Rino buying guide
+aka: [Rino 755t, Garmin Rino]
+autolink: true
+affiliate: true
+product:
+  name: "Garmin Rino 755t"
+  brand: Garmin
+  category: GMRS radio + GPS navigator (handheld, discontinued)
+  itemCondition: used
+  lowPrice: "400"
+  highPrice: "550"
+  url: https://www.amazon.com/s?k=garmin+rino+755t&tag=gophertrunk-20
+infobox:
+  - { label: Type, value: "Hybrid GMRS radio + GPS navigator (discontinued)" }
+  - { label: Service, value: "GMRS (5 W) — simplex; no repeater offsets" }
+  - { label: Channels, value: "FRS/GMRS channels + Rino position reporting; NOAA" }
+  - { label: Power, value: "5 W GMRS" }
+  - { label: License, value: "GMRS — $35 FCC, 10 years, no test" }
+  - { label: Price, value: "around $400–550 used (thin data — verify)" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/s?k=garmin+rino+755t&tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">Find on Amazon &rarr;</a>" }
+see_also: [btech-gmrs-pro, motorola-talkabout-t800, rocky-talkie-5-watt, motorola-talkabout-mr350r, wouxun-kg-935g, rtl-sdr]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "The 10 best walkie-talkies", url: /best-walkie-talkies/ }
+cite_urls:
+  - https://www.garmin.com/en-US/p/534007/
+  - https://www.garmin.com/en-US/blog/fish-and-hunt/introducing-rino-750-755t-rugged-gps-navigator-two-way-radio/
+faq:
+  - q: "Is the Garmin Rino 755t discontinued?"
+    a: "Yes — Garmin lists it as a discontinued product with no direct successor in the Rino line; Garmin's current backcountry push is inReach satellite messengers, which are not FRS/GMRS radios. That's why used 755t units hold their value: nothing replaced it."
+  - q: "Do I need a license for the Garmin Rino 755t?"
+    a: "To transmit at its full 5 W on the GMRS channels, yes — the FCC's GMRS license: $35, 10 years, no test, covering your immediate family. Listening and GPS use require nothing."
+  - q: "How much is a used Garmin Rino 755t worth?"
+    a: "Roughly $400–550 based on forum and classified sales — but the data is thin (individual forum sales, not deep eBay comps), so spot-check current sold listings before paying. A healthy battery or the AA adapter justifies the top of the range."
+  - q: "Can the Garmin Rino 755t use GMRS repeaters?"
+    a: "No — the Rino 7xx series works simplex only, with no repeater offset support. Its range multiplier is instead the peer position reporting: every transmission shares your GPS position with other Rinos on the channel."
+  - q: "What should I check before buying a used Rino 755t?"
+    a: "Battery first — the Li-ion packs are now 8–10 years old, replacements are scarce, and swollen packs are common. Then touchscreen response and edge delamination, peeling rubber grips and gaskets (which compromise the IPX7 seal), micro-USB port corrosion, a fast outdoor GPS fix, and an actual transmit test against another radio."
+---
+**The Garmin Rino 755t** is the radio Garmin never replaced: a genuine
+**5 W GMRS transceiver fused with a full Garmin GPS navigator** — 3"
+multi-touch screen, TOPO US maps, barometric altimeter, 8 MP camera — whose
+party trick, **peer position reporting**, puts every teammate's position on
+your map with each transmission.[^garmin] Discontinued and succeeded by
+nothing (Garmin pivoted to inReach satellite messengers, a different
+category), it holds **roughly $400–550 used** — though that figure rests on
+thin forum-sale data, so verify current sold prices. The used market — eBay
+and hunting-forum classifieds — is where this radio lives now.
+
+<a class="btn btn--buy" href="https://www.amazon.com/s?k=garmin+rino+755t&tag=gophertrunk-20" rel="nofollow sponsored noopener">Find on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Our best used/classic pick — the only serious GPS-nav + radio ever made.**
+5 W GMRS (**$35 no-test license to transmit**), simplex only — no repeater
+support — plus IPX7, NOAA/Active Weather, and Rino-to-Rino position polling
+that hunting parties still organize around. **Used only, ~$400–550 on thin
+data**; firmware support has ended. The whole buying game is condition:
+aging batteries, touchscreens, and Garmin-era rubber. Rankings:
+[best walkie-talkies](/best-walkie-talkies/).
+</div>
+
+## Overview
+
+Every other radio in our [walkie-talkie guide](/best-walkie-talkies/) is a
+radio first. The Rino 755t is a **navigator and a radio as one instrument**,
+and for hunting parties, SAR-adjacent volunteers, and big-property crews
+that combination has never been duplicated: transmit and your position rides
+along, so every compatible Rino plots you on its topo map; poll a partner
+and their position comes back. No cell coverage, no subscription, no phone.
+
+The radio side is **5 W GMRS** — so transmitting at full power takes the
+**$35, no-test, 10-year GMRS license** (family-covered) — sharing the
+standard FRS/GMRS channels, with NOAA and Garmin's Active Weather on the
+receive side. The honest limitation: the Rino 7xx line is **simplex only**,
+with no repeater offset support, so a modern $35
+[Baofeng](/reference/baofeng-uv-5g-plus/) reaches repeaters this $450
+classic can't. The navigator side was flagship-grade for its era: 3"
+transflective multi-touch, preloaded TOPO US 100K, barometric
+altimeter/compass, 8 MP geotagging camera, **IPX7** water resistance.
+
+Why cover a discontinued unit? Because demand never left. Garmin ended the
+line without a successor, firmware updates have stopped, and used prices
+have held remarkably — which makes buying one a condition inspection first
+and a price negotiation second.
+
+## Buying used: what to check
+
+The 755t's aging faults are predictable; work the list:[^garminblog]
+
+1. **Battery pack** — the number-one issue. These Li-ion packs are 8–10
+   years old; check for swelling and weak runtime. OEM replacements are
+   scarce, so a unit with a healthy pack or the AA-adapter accessory is
+   worth a real premium.
+2. **Touchscreen** — verify responsiveness across the whole surface and
+   look for delamination or bubbling at the edges.
+3. **Rubber grips and gaskets** — Garmin rubber of this era peels and turns
+   sticky, and failed gaskets void the IPX7 seal in practice.
+4. **Micro-USB port** — wear and corrosion under the weather flap.
+5. **Function test** — a fast GPS fix outdoors, and an actual transmit
+   check against a second radio; RF finals do fail.
+6. **Software expectations** — BaseCamp-era map transfer still works but
+   assume no further firmware; ask what the seller last synced.
+
+Pricing seen in the wild: ~$450 used, ~$475 "excellent with case," ~$550
+with a spare-battery kit; the sibling **Rino 750** (same radio, no camera
+or preloaded topo) runs less and is the sensible fallback if 755t listings
+are thin — which they often are.
+
+## GopherTrunk alternative
+
+The Rino's voice channels are ordinary analog FM at 462/467 MHz — easy
+work for a ~$30 [RTL-SDR](/reference/rtl-sdr/) running free GopherTrunk,
+which will monitor and **record** all local FRS/GMRS activity while your
+party is afield (the Rino's position bursts log as data squawks). It's
+also the cheap way to survey channel congestion around a hunting lease
+before season. GopherTrunk cannot transmit and has no GPS — it complements
+the Rinos as a base-camp ear, nothing more. Curious about the listening
+side? [Learn RF &amp; SDR](/learn/rf-sdr/).
+
+## Who it's for
+
+- **Buy a used Rino 755t** if radio-to-radio position mapping is the
+  feature you actually need — no current product does it with a real
+  navigator attached — and you can inspect before paying.
+  <a class="btn btn--buy" href="https://www.amazon.com/s?k=garmin+rino+755t&tag=gophertrunk-20" rel="nofollow sponsored noopener">Find on Amazon &rarr;</a>
+- **Buy a [BTECH GMRS-PRO](/reference/btech-gmrs-pro/)** instead for new,
+  supported GPS position-sharing and texting at a third of the used-Rino
+  price — minus the full mapping navigator.
+- **Skip it** if you just need tough group comms:
+  [Rocky Talkie Expedition Radio](/reference/rocky-talkie-5-watt/), and a
+  phone handles the maps. Full rankings:
+  [best walkie-talkies](/best-walkie-talkies/).
+
+## Sources
+
+[^garmin]: [Garmin Rino 755t product page](https://www.garmin.com/en-US/p/534007/) — Garmin, listing the 755t as discontinued, with specifications: 5 W GMRS, position reporting, touchscreen, TOPO mapping, camera, and IPX7 rating.
+[^garminblog]: [Introducing Rino 750 & 755t — Garmin blog](https://www.garmin.com/en-US/blog/fish-and-hunt/introducing-rino-750-755t-rugged-gps-navigator-two-way-radio/) — Garmin's launch overview of the Rino 7xx line: the radio/navigator hybrid design, peer position polling, and the 750/755t differences.

--- a/docs/reference/midland-75-822.md
+++ b/docs/reference/midland-75-822.md
@@ -1,0 +1,132 @@
+---
+slug: midland-75-822
+title: Midland 75-822
+entry_type: hardware
+category: two-way-radios
+description: "The Midland 75-822 is the only mainstream CB that's both a handheld and a mobile — AA-powered walkie by hand, full 4 W mobile via its cigarette-lighter adapter and an external antenna — with 10 NOAA weather channels, around $90–130."
+keywords: Midland 75-822, Midland 75-822 review, handheld CB radio, portable CB radio, CB radio handheld mobile combo, emergency CB radio, CB radio glovebox, CB radio weather channels, best handheld CB, CB radio no license
+aka: [75-822, Midland 75822]
+autolink: true
+affiliate: true
+product:
+  name: "Midland 75-822"
+  brand: Midland
+  category: CB radio (handheld/mobile 2-in-1)
+  lowPrice: "90"
+  highPrice: "130"
+  url: https://www.amazon.com/dp/B00000K2YR?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: "Handheld + mobile 2-in-1 CB" }
+  - { label: Service, value: "CB — 40 channels, 26.965–27.405 MHz" }
+  - { label: Modes, value: "AM only" }
+  - { label: Power, value: "4 W Hi / Lo switchable; 6× AA or 12 V via mobile adapter" }
+  - { label: Extras, value: "10 NOAA weather channels, 5 memories, dual watch, scan, headset jack" }
+  - { label: License, value: "None (CB) — licensed by rule, Part 95D" }
+  - { label: Price, value: around $90–130 }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B00000K2YR?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [cobra-75-all-road, uniden-pro505xl, uniden-bearcat-880, cobra-29-ltd-classic, antenna, rtl-sdr]
+related_reading:
+  - { title: "The 10 best CB radios", url: /best-cb-radios/ }
+  - { title: "Scanner frequencies (incl. CB channels)", url: /scanner-frequencies/ }
+cite_urls:
+  - https://midlandusa.com/products/75-822cb-radio
+faq:
+  - q: "Do I need a license for the Midland 75-822?"
+    a: "No. CB is license-free by rule under FCC Part 95D — no exam, no fee. The 75-822 transmits up to the legal 4-watt AM limit with a Hi/Lo power switch to stretch battery life."
+  - q: "What's the range of the Midland 75-822 as a handheld?"
+    a: "Poor — expect around a mile handheld-to-handheld with the rubber-duck antenna. That's physics, not Midland: 27 MHz wavelengths are about 11 meters, and no pocket antenna is efficient there. Slide it into the mobile adapter with a real external antenna and it performs like any 4 W mobile CB — a few miles."
+  - q: "How does the Midland 75-822 convert to a mobile CB?"
+    a: "The included mobile adapter slides onto the radio, replacing the battery pack: it takes cigarette-lighter power and a standard external CB antenna connection. Full 4 watts into a proper roof or fender antenna — a real mobile, not a compromise."
+  - q: "Does the Midland 75-822 have weather channels?"
+    a: "Yes — 10 NOAA weather channels, which combined with AA power is why it makes such a good glovebox emergency radio: it receives weather and CB even when the truck's electrical system is dead."
+  - q: "Does the Midland 75-822 do FM or SSB?"
+    a: "No — AM only. Midland has never issued an FM refresh of this decades-old design. For FM you want a current mobile like the Bearcat 880FM or Cobra 75 All Road; for SSB, the Bearcat 980SSB or President McKinley II."
+---
+**The Midland 75-822** does a trick no other mainstream CB does: it's a
+**handheld and a mobile in one radio**. In your hand it runs on 6 AA
+batteries with a rubber-duck antenna; slide on the included mobile adapter
+and it takes cigarette-lighter power and a real external antenna, putting the
+full legal **4 watts** into proper metal.[^midland] Add **10 NOAA weather
+channels** and it's the definitive glovebox emergency CB, around **$90–130**.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B00000K2YR?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The only handheld that becomes a real mobile.** AA-powered walkie for the
+trail; cigarette-lighter + external antenna for the truck — full 4 W either
+way. **10 NOAA weather channels**, 5 memories, dual watch, scan. **Handheld
+range is ~1 mile** — a 27 MHz physics problem, not a defect; the mobile
+adapter is where it earns its keep. **AM only, no FM refresh.** Eats AAs.
+**License-free** (Part 95D). **~$90–130.** Full rankings:
+[best CB radios](/best-cb-radios/).
+</div>
+
+## Overview
+
+Midland has kept this decades-old design in production for a simple reason:
+nothing else does its job. Off-roaders who ride in different vehicles every
+weekend, delivery drivers in rotating trucks, and anyone building an
+emergency kit all have the same problem — a hard-mounted CB lives in *one*
+vehicle. The 75-822 lives in your bag. Sliding on the **mobile adapter**
+swaps the battery pack for cigarette-lighter power and a standard
+[antenna](/reference/antenna/) connection, and suddenly it's a legitimate 4 W
+mobile driving a real roof-mounted antenna.
+
+Set expectations correctly for handheld use: **27 MHz hates short
+antennas.** A quarter-wave at CB frequencies is nearly nine feet; a
+rubber duck is a severe compromise, so figure about **a mile**
+handheld-to-handheld. That's physics, and it applies to every handheld CB
+ever made — it's why "handheld CB" is a tiny category while handheld
+[GMRS](/best-walkie-talkies/) thrives at 462 MHz. The 75-822's answer is the
+adapter: don't judge it as a walkie-talkie, judge it as a mobile CB that can
+leave the truck.
+
+The rest of the feature set is honest and useful: **10 NOAA weather
+channels** (with AA power, it works when the vehicle battery doesn't — the
+emergency-kit case in one line), 5 channel memories, dual watch, scan, Hi/Lo
+transmit power to stretch batteries, a backlit LCD, and a headset jack. The
+knocks: it **eats AA batteries** in earnest use, and it's **AM only** — no
+FM refresh ever came, and there's no SSB.
+
+**License note:** none — CB is licensed by rule under FCC Part 95D. No exam,
+no fee; 4 W AM is the legal carrier limit and the 75-822's Hi setting.
+
+## Modes &amp; features
+
+- **40 channels**, 4 W **AM only** (Hi/Lo switch), Part 95D certified.
+- **True 2-in-1**: 6× AA handheld with rubber duck, or mobile adapter →
+  12 V cigarette-lighter power + external CB antenna at full power.
+- **10 NOAA weather channels**, 5 memories, dual watch, scan, backlit LCD,
+  headset jack. About 3.5&quot; tall as a handheld.
+
+## GopherTrunk alternative
+
+The straight answer from a software project: **GopherTrunk doesn't do CB.**
+CB is 27 MHz analog [AM](/reference/amplitude-modulation/) — under an
+[RTL-SDR](/reference/rtl-sdr/)'s native tuning range unless you use
+direct-sampling mode or an [upconverter](/reference/upconverter/), and analog
+AM voice is outside GopherTrunk's trunked/digital scope. If you want to know
+whether anyone in your area still talks on CB before buying, a scanner with
+CB coverage or an [HF-capable SDR](/best-hf-sdr/) is the listening tool —
+the 40-channel map is in our
+[scanner frequencies reference](/scanner-frequencies/). For an emergency
+radio that *transmits*, the 75-822 is the one that works in any vehicle.
+
+## Who it's for
+
+- **Buy the 75-822** if you split time across vehicles, want a glovebox
+  emergency radio with weather reception, or refuse to hard-mount anything.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B00000K2YR?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [Cobra 75 All Road](/reference/cobra-75-all-road/)** instead if
+  the radio stays in one dashless vehicle — its hideaway box + wireless
+  handset is the cleaner permanent install — or the
+  [PRO505XL](/reference/uniden-pro505xl/) if $60 and a bracket solve your
+  problem.
+- **Skip it** for a hard-mounted [Bearcat 880FM](/reference/uniden-bearcat-880/)
+  if you never leave the truck — better receiver, better speaker, FM, and
+  built-in SWR metering. Full rankings: [best CB radios](/best-cb-radios/).
+
+## Sources
+
+[^midland]: [Midland 75-822 product page](https://midlandusa.com/products/75-822cb-radio) — Midland Radio, on the handheld/mobile 2-in-1 design, mobile adapter, 10 NOAA weather channels, Hi/Lo power, memories, and dual watch.

--- a/docs/reference/midland-gxt1000vp4.md
+++ b/docs/reference/midland-gxt1000vp4.md
@@ -1,0 +1,129 @@
+---
+slug: midland-gxt1000vp4
+title: Midland GXT1000VP4
+entry_type: hardware
+category: two-way-radios
+description: "The Midland GXT1000VP4 is the ubiquitous ~$70–90 GMRS walkie-talkie pair — NOAA weather alerts, AA fallback, dead-simple UX — but its '36-mile range' is fantasy, it has no repeater channels, and real output falls short of 5 W."
+keywords: Midland GXT1000VP4, GXT1000VP4 review, Midland walkie talkie, Midland GXT1000 range, 36 mile walkie talkie, GMRS radio, gmrs license, do Midland radios need a license, NOAA weather radio, best walkie talkie for family, walkie talkie 2 pack
+aka: [GXT1000VP4, GXT1000, Midland GXT1000]
+autolink: true
+affiliate: true
+product:
+  name: "Midland GXT1000VP4"
+  brand: Midland
+  category: GMRS walkie-talkie (handheld pair)
+  lowPrice: "70"
+  highPrice: "90"
+  url: https://www.amazon.com/dp/B001WMFYH4?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: Handheld GMRS walkie-talkie (sold in pairs) }
+  - { label: Service, value: "GMRS (hybrid-era design, FCC Part 95)" }
+  - { label: Channels, value: "22 GMRS + 28 privacy-preset \"extra\" channels" }
+  - { label: Power, value: "\"5 W\" claimed; ~1.5–3 W commonly measured" }
+  - { label: License, value: "GMRS — $35 FCC, 10 years, no test" }
+  - { label: Price, value: "around $70–90 per 2-pack" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B001WMFYH4?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [motorola-talkabout-t800, baofeng-gm-15-pro, rocky-talkie-5-watt, motorola-talkabout-mr350r, midland-mxt275, rtl-sdr]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "The 10 best walkie-talkies", url: /best-walkie-talkies/ }
+cite_urls:
+  - https://midlandusa.com/products/gxt1000vp4-gmrs-walkie-talkie-2-pack
+faq:
+  - q: "Do I need a license for the Midland GXT1000VP4?"
+    a: "To transmit, yes — Midland sells it as a GMRS radio, and GMRS requires the FCC license: $35, 10 years, no test, covering your immediate family. Listening requires nothing. If you want to skip the license entirely, buy a modern 2 W FRS radio instead."
+  - q: "Is the Midland GXT1000VP4 really a 36-mile radio?"
+    a: "No. The 36-mile figure is optimistic line-of-sight marketing — mountaintop to mountaintop. On the ground, in trees and terrain, expect roughly half a mile to two miles, similar to any UHF handheld. No consumer walkie-talkie delivers double-digit miles terrestrially."
+  - q: "Does the GXT1000VP4 have 50 channels?"
+    a: "Marketing math. It has the 22 standard FRS/GMRS channels plus 28 'extra' channels that are just the same frequencies with privacy codes preset. They only talk to radios using matching settings — they are not additional frequencies."
+  - q: "Can the Midland GXT1000VP4 use GMRS repeaters?"
+    a: "No — and that's its biggest functional gap in 2026. It's a pre-2017-style hybrid design with no repeater channels, so you're limited to simplex range. Repeater-capable radios like the Baofeng GM-15 Pro cost less than this pair."
+  - q: "Is the Midland GXT1000VP4 waterproof?"
+    a: "Splash-resistant only (JIS4) — rain and spray are fine, submersion is not. It also uses drop-in-cradle NiMH packs or 4 AA batteries rather than USB-C charging, which dates it against newer designs."
+---
+**The Midland GXT1000VP4** is the walkie-talkie America actually buys: a
+**~$70–90 pair** with NOAA weather alerts, an AA-battery fallback, and a UX a
+grandparent masters in a minute — over 13,000 Amazon ratings deep and still in
+production alongside Midland's newer GXT67 Pro.[^midland] It's also a radio
+whose box promises **"36 miles" and "50 channels,"** and neither survives
+contact with physics or arithmetic. Buy it for what it is: cheap, ubiquitous,
+simple — not long-ranged, and **not repeater-capable**.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B001WMFYH4?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The default family radio, honestly graded.** Dead-simple, NOAA weather +
+alerts, SOS siren, runs on its NiMH packs or **4×AA** in a pinch. **Sold as
+GMRS, so transmitting takes the $35 no-test FCC license** (10 years, covers
+the family). The catches: **"36 miles" is fantasy** (think 0.5–2 real miles),
+"50 channels" is 22 + presets, output measures well under the 5 W claim, **no
+repeater channels**, cradle charging, splash-only JIS4. Rankings:
+[best walkie-talkies](/best-walkie-talkies/).
+</div>
+
+## Overview
+
+The GXT1000VP4 predates the FCC's 2017 FRS/GMRS reorganization and it shows:
+it's a **hybrid-era design** sold under GMRS rules, meaning transmitting
+legally requires the **GMRS license — $35 to the FCC, valid 10 years, no
+test, one license for your immediate family**. (Listening needs nothing.)
+Nothing about the license is hard; it's a web form and a fee.
+
+What the design's age costs you is capability. There are **no repeater
+channels** — the single feature that separates modern GMRS from FRS-with-a-
+license — so a GXT1000VP4 is limited to the same simplex, terrain-bound range
+as any handheld. Midland claims ~5 W; community measurements commonly land
+around **1.5–3 W** (treat that as approximate, but directionally it's well
+documented). And the "50 channels" are the 22 real FRS/GMRS frequencies plus
+28 presets with [privacy codes](/reference/ctcss/) baked in — squelch tones,
+not new spectrum and not privacy.
+
+What the design's age gets you is the reason it sells: drop-in charging
+cradles, **4×AA fallback** when the NiMH packs die (they will), weather
+alerts that actually wake the radio, whisper mode, vibrate, an SOS siren,
+and a feature set your least technical relative can run. There is no CHIRP,
+no USB-C, no app — and for its buyers, that's fine.
+
+## Channels, power &amp; battery
+
+- **Service:** GMRS (pre-2017 hybrid design) — **$35 GMRS license to
+  transmit**; interoperates with all FRS/GMRS radios on channels 1–22.
+- **Power:** ~5 W claimed input; **~1.5–3 W typical measured output**
+  (community figures, approximate).
+- **Channels:** 22 standard + 28 privacy-preset "extras"; 142 privacy codes.
+- **No repeater capability** — simplex only.
+- **Weather:** NOAA weather receive **with alert** — genuinely good.
+- **Battery:** NiMH packs in a drop-in dual cradle, or 4×AA per radio.
+- **Durability:** JIS4 splash-resistant; not submersible.
+- **Range:** expect **0.5–2 miles** terrestrial, more with elevation; the
+  36-mile figure is line-of-sight marketing.
+
+## GopherTrunk alternative
+
+Want to know what FRS/GMRS actually sounds like in your neighborhood — and
+whether anyone's within range at all? FRS/GMRS is analog narrowband FM at
+462/467 MHz, dead center in a ~$30 [RTL-SDR](/reference/rtl-sdr/)'s coverage.
+Free GopherTrunk will watch every channel simultaneously, record what it
+hears, and show you whether a local GMRS repeater is active — worth knowing
+before you pick a no-repeater radio like this one. GopherTrunk is
+receive-only; it scouts and logs, the Midlands talk. Start with
+[Learn RF &amp; SDR](/learn/rf-sdr/) if the SDR side is new.
+
+## Who it's for
+
+- **Buy the GXT1000VP4** for family camping, caravans, and property use where
+  simplicity, AA fallback, and weather alerts matter more than range or
+  repeaters — and budget the $35 license.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B001WMFYH4?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy a [Baofeng GM-15 Pro](/reference/baofeng-gm-15-pro/)** instead if you
+  want real 5 W and repeater channels for *less* money — with a clunkier UX.
+- **Skip the license entirely** with a 2 W FRS radio: the
+  [Motorola T800](/reference/motorola-talkabout-t800/) or the rugged
+  [Rocky Talkie Mountain Radio](/reference/rocky-talkie-mountain-radio/).
+  Full rankings: [best walkie-talkies](/best-walkie-talkies/).
+
+## Sources
+
+[^midland]: [Midland GXT1000VP4 product page](https://midlandusa.com/products/gxt1000vp4-gmrs-walkie-talkie-2-pack) — Midland USA, on channels, privacy codes, NOAA weather/alert features, JIS4 rating, battery options, and GMRS licensing.

--- a/docs/reference/midland-mxt115.md
+++ b/docs/reference/midland-mxt115.md
@@ -1,0 +1,147 @@
+---
+slug: midland-mxt115
+title: Midland MXT115
+entry_type: hardware
+category: two-way-radios
+description: "The Midland MXT115 is the entry point to name-brand GMRS mobiles — 15 watts, NOAA weather, around $130–150 — now being superseded by the MXT115P. No split tones on the classic model, and early MXT115P stock needs a repeater-capability check."
+keywords: Midland MXT115, MXT115 review, MXT115P, entry level GMRS mobile radio, 15 watt GMRS radio, cheap GMRS mobile, gmrs license, GMRS repeater radio, MicroMobile MXT115, MXT115 split tones, best budget GMRS radio
+aka: [MXT115, MXT115P, MicroMobile MXT115]
+autolink: true
+affiliate: true
+product:
+  name: "Midland MXT115"
+  brand: Midland
+  category: GMRS mobile radio
+  lowPrice: "130"
+  highPrice: "150"
+  url: https://www.amazon.com/dp/B01MUGZ5XC?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: "GMRS mobile radio (dash-mount head + mic)" }
+  - { label: Service, value: "GMRS — 15 channels + 8 repeater channels" }
+  - { label: Power, value: "15 W" }
+  - { label: Repeater, value: "Repeater channels yes — NO split tones (classic)" }
+  - { label: License, value: "GMRS — $35 FCC, no test, covers family" }
+  - { label: Price, value: "around $130–150" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B01MUGZ5XC?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [midland-mxt275, radioddity-db20-g, midland-mxt500, wouxun-kg-xs20g, midland-gxt1000vp4, rtl-sdr]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "Best GMRS mobile & base radios", url: /best-gmrs-mobile-radios/ }
+cite_urls:
+  - https://midlandusa.com/products/mxt115-micromobile-gmrs-two-way-radio
+  - https://midlandusa.com/products/mxt115p-micromobile-gmrs-two-way-radio
+faq:
+  - q: "Do I need a license for the Midland MXT115?"
+    a: "To transmit, yes — a GMRS license: $35 to the FCC, valid 10 years, no test, and it covers your immediate family. Listening requires no license."
+  - q: "Does the Midland MXT115 support repeater split tones?"
+    a: "No — the classic MXT115 cannot do split tones, which locks it out of repeaters that use different encode and decode tones. That's its biggest limitation for repeater work; the newer MXT115P and the import 20-watt radios can."
+  - q: "What is the difference between the MXT115 and the MXT115P?"
+    a: "The MXT115P is Midland's next-generation replacement with an IP67 body. One caveat: reporting suggests the 115P's initial July 2025 FCC grant covered only the 462 MHz main channels, with the 467 MHz repeater inputs added by permissive change in June 2026 — so verify repeater transmit on early 115P stock before buying."
+  - q: "What is the range of the Midland MXT115?"
+    a: "Roughly 1–5 miles vehicle-to-vehicle in real terrain — UHF simplex is terrain-limited. Through a GMRS repeater it can reach 20–50+ miles, but note the classic MXT115's lack of split tones limits which repeaters it can use."
+  - q: "Is the MXT115 being discontinued?"
+    a: "It's in transition. Midland lists both the MXT115 and the new MXT115P, and classic MXT115 stock is thinning at some retailers. If classic availability dries up, the MXT115P (or the 5-watt MXT105) is the successor in the same family."
+---
+**The Midland MXT115** is the cheapest way into a name-brand GMRS mobile: 15
+watts, a small dash-mount head with a real dial and a separate mic, NOAA
+weather, around **$130–150**.[^midland] It's also a radio in transition —
+Midland's next-generation **MXT115P** is arriving alongside it — and it
+carries the classic 15-watt-Midland limitations you should walk in knowing:
+**no split tones** and narrowband transmit.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B01MUGZ5XC?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Entry-level Midland, honest limits.** 15 W, 15 GMRS + 8 repeater channels,
+142 privacy codes, NOAA Scan + Alert, multicolor LCD. **No split tones on the
+classic MXT115** — it's locked out of split-tone repeaters — and its
+narrowband TX runs quiet into wideband repeaters. **Successor watch:** the
+IP67 **MXT115P** is replacing it; verify repeater transmit on early 115P
+stock (its initial FCC grant reportedly lacked the 467 MHz inputs). **GMRS
+license to transmit: $35, 10 years, no test, covers your immediate family.**
+Rankings: [best GMRS mobile radios](/best-gmrs-mobile-radios/).
+</div>
+
+## Overview
+
+Unlike the mic-centric [MXT275](/reference/midland-mxt275/), the MXT115 is a
+conventional miniature mobile: a small head with a channel dial and a
+multicolor LCD, a standard fist mic, a USB charging port, and a mag-mount
+antenna in the box. For a family that wants a permanent radio in the second
+vehicle without studying anything, it's the definition of adequate — simple,
+name-brand, weather-alert-capable, with a genuine FCC Part 95E grant.
+
+**The transition matters if you're buying today.** Midland lists both the
+classic MXT115 and the new **MXT115P** ("Next Generation," IP67-rated), and
+classic stock is thinning at some retailers. One flag from secondary
+reporting, unverified against FCC records directly but worth acting on: the
+115P's initial July 2025 grant covered only the 462 MHz main channels, with
+the 467 MHz repeater inputs added by permissive change in **June 2026**. If
+that's right, **early 115P stock may not transmit on repeater inputs at
+all** — so if you buy the P, confirm repeater transmit capability on the
+specific unit before you rely on it. If classic MXT115 availability dies, the
+family substitutes are the MXT115P itself or the 5-watt MXT105.
+
+**License note:** GMRS transmit requires a license — $35 to the
+[FCC](/reference/fcc/), 10 years, no exam, covering your immediate family.
+Listening needs nothing.
+
+## Channels, power &amp; repeater use
+
+- **Power:** 15 W.
+- **Channels:** 15 GMRS + the 8 repeater channels, 142 privacy codes.
+- **Repeaters:** the big asterisk. The classic MXT115 has the repeater
+  channels but **no split tones** — repeaters using a different
+  [CTCSS](/reference/ctcss/)/[DCS](/reference/dcs/) encode tone than their
+  decode tone are simply unreachable. Check your local repeater's tone setup
+  before assuming this radio can use it.
+- **TX audio:** narrowband, like the MXT275 — the documented "quiet into
+  wideband repeaters" complaint applies here too.
+- **Weather:** NOAA Weather Scan + Alert.
+- **Antenna:** the 15 W Midlands historically use a small SMA-type radio-side
+  connector (not the SO-239 of the MXT400/500/575) with included
+  cable/adapters — verify the connector on current stock before buying
+  mounts.
+
+## The value question
+
+At $130–150 the MXT115's real competition is the
+[Radioddity DB20-G](/reference/radioddity-db20-g/): roughly the same money
+for 20 W, ~500 channels, wideband receive, CHIRP, and — decisively — **split
+tones**. The Midland's counterargument is legitimate: NOAA standby alerts
+(the DB20-G has none), a simpler interface, US-brand support, and
+plug-and-play tone compatibility with Midland handhelds like the
+[GXT1000VP4](/reference/midland-gxt1000vp4/). If your use is family simplex
+plus one open-tone repeater, the MXT115 is fine. If repeaters are the point,
+its tone limitation is disqualifying — spend the same money on the DB20-G or
+step up to the [MXT500](/reference/midland-mxt500/).
+
+## GopherTrunk alternative
+
+FRS and GMRS are analog narrowband [FM](/reference/frequency-modulation/) at
+462/467 MHz — right in a ~$30 [RTL-SDR](/reference/rtl-sdr/)'s range. Free
+GopherTrunk on a dongle monitors and records local FRS/GMRS traffic and
+repeater activity, which is especially useful *before buying this particular
+radio*: it will tell you whether your local repeaters use split tones — the
+one thing the classic MXT115 can't do. Scout first, then choose the radio to
+match. GopherTrunk is receive-only and complements any of these radios.
+[Download GopherTrunk](/downloads.html) to start.
+
+## Who it's for
+
+- **Buy the MXT115** if you want the cheapest name-brand GMRS mobile for
+  family simplex and NOAA alerts, and your repeater needs are zero or
+  same-tone-simple.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B01MUGZ5XC?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [Radioddity DB20-G](/reference/radioddity-db20-g/)** instead if
+  repeaters matter — same money, split tones, more watts.
+- **Skip it** for the [MXT275](/reference/midland-mxt275/) if you like Midland
+  but want the hideaway install (and, on the current revision, split tones).
+  Considering the MXT115P? Verify repeater TX on early stock first. Full
+  rankings: [best GMRS mobile radios](/best-gmrs-mobile-radios/).
+
+## Sources
+
+[^midland]: [Midland MXT115 MicroMobile product page](https://midlandusa.com/products/mxt115-micromobile-gmrs-two-way-radio) — Midland Radio, on the 15 W output, channel/privacy-code counts, NOAA weather, and included accessories; successor: [Midland MXT115P product page](https://midlandusa.com/products/mxt115p-micromobile-gmrs-two-way-radio).

--- a/docs/reference/midland-mxt275.md
+++ b/docs/reference/midland-mxt275.md
@@ -1,0 +1,139 @@
+---
+slug: midland-mxt275
+title: Midland MXT275
+entry_type: hardware
+category: two-way-radios
+description: "The Midland MXT275 is the best-selling all-controls-in-mic GMRS mobile — 15 watts, hideaway body, NOAA weather, around $150–180. Split tones only on the newer USB-C revision, and its narrowband transmit runs quiet into wideband repeaters."
+keywords: Midland MXT275, MXT275 review, GMRS mobile radio, MicroMobile MXT275, 15 watt GMRS radio, gmrs license, MXT275 split tones, MXT275 vs MXT575, overlanding GMRS radio, GMRS radio install, best GMRS radio under 200
+aka: [MXT275, MicroMobile MXT275]
+autolink: true
+affiliate: true
+product:
+  name: "Midland MXT275"
+  brand: Midland
+  category: GMRS mobile radio
+  lowPrice: "150"
+  highPrice: "200"
+  url: https://www.amazon.com/dp/B07FN2FBML?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: "GMRS mobile radio (all-controls-in-mic)" }
+  - { label: Service, value: "GMRS — 15 channels + 8 repeater channels" }
+  - { label: Power, value: "15 W" }
+  - { label: Repeater, value: "Yes — split tones on USB-C revision only" }
+  - { label: License, value: "GMRS — $35 FCC, no test, covers family" }
+  - { label: Price, value: "around $150–180" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B07FN2FBML?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [midland-mxt575, midland-mxt115, radioddity-db20-g, wouxun-kg-xs20g, btech-gmrs-pro, rtl-sdr]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "Best GMRS mobile & base radios", url: /best-gmrs-mobile-radios/ }
+cite_urls:
+  - https://midlandusa.com/products/mxt275-micromobile-two-way-radio
+faq:
+  - q: "Do I need a license for the Midland MXT275?"
+    a: "To transmit, yes — a GMRS license: $35 to the FCC, valid 10 years, no test required, and one license covers your immediate family. Listening requires no license."
+  - q: "Does the Midland MXT275 support repeater split tones?"
+    a: "Only the newer USB-C revision does. Original MXT275 revisions cannot do split tones, which locks them out of repeaters that use different encode and decode tones — if you're buying used or old stock, verify the revision first."
+  - q: "Why do people say the MXT275 sounds quiet on repeaters?"
+    a: "Its transmit is narrowband (±2.5 kHz deviation). Into a wideband repeater that reads as weak, quiet audio — the classic 'others could barely hear me' complaint — and tone decode on the repeater end can occasionally be erratic. It's a documented characteristic, not a defect in your unit."
+  - q: "What is the range of the Midland MXT275?"
+    a: "Simplex, plan on roughly 1–5 miles in real terrain — UHF is line-of-sight-limited, and 15 watts doesn't change that much. Through a GMRS repeater it can cover 20–50+ miles, which is the real reason to buy a repeater-capable mobile."
+  - q: "Can I program the MXT275 with CHIRP?"
+    a: "No — it isn't CHIRP-programmable, and it has no channel labels or multi-repeater presets per channel. It's a set-the-channel-and-talk radio; if you want deep programmability, look at the Radioddity DB20-G."
+---
+**The Midland MXT275** is the radio that proved the all-controls-in-mic idea:
+a 15-watt hideaway box with every control, the display, and the speaker in the
+microphone, sold in volume since about 2018.[^midland] It is the simplest
+credible GMRS mobile install there is — around **$150–180** — with two honest
+caveats: split tones only arrived with the newer USB-C revision, and its
+narrowband transmit runs quiet into wideband repeaters.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B07FN2FBML?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The easiest real GMRS install, with known limits.** 15 W, 15 GMRS + 8
+repeater channels, 142 privacy codes, NOAA Scan + Alert, tiny footprint.
+**Split tones on the current USB-C revision only** — older units can't, and
+that locks them out of many club repeaters. **Narrowband TX** means quiet
+audio into wideband repeaters (the classic complaint). No CHIRP, no channel
+labels. **GMRS license to transmit: $35, 10 years, no test, covers family.**
+Rankings: [best GMRS mobile radios](/best-gmrs-mobile-radios/).
+</div>
+
+## Overview
+
+The MXT275 has been a best-seller for the better part of a decade for one
+reason: it makes a permanent vehicle radio feel like plugging in a phone
+charger. The main body hides anywhere; the RJ45-corded mic is the whole user
+interface. Overlanders have run them for years, and the consensus is that they
+just keep working, with clear audio at highway speed. Midland later scaled the
+same design up to 50 watts as the [MXT575](/reference/midland-mxt575/).
+
+The current revision programs and charges over USB-C, and — this matters —
+**only that newer revision supports split tones**. Buying used or old stock
+means verifying which revision you're getting, because the original ones
+cannot be upgraded into split-tone repeater service.
+
+**License note:** transmitting on GMRS takes a license — $35 to the
+[FCC](/reference/fcc/), 10 years, no exam, one license covering your immediate
+family. Listening needs nothing.
+
+## Channels, power &amp; repeater use
+
+- **Power:** 15 W — plenty for simplex convoy work, adequate for reasonably
+  close repeaters.
+- **Channels:** 15 GMRS channels plus the 8 repeater channels, 142 privacy
+  codes.
+- **Repeaters:** [CTCSS](/reference/ctcss/)/[DCS](/reference/dcs/) tones, with
+  **split tones on the USB-C revision only**. There are no channel labels and
+  no way to preset multiple repeaters on one channel.
+- **Weather:** NOAA Weather Scan + Alert.
+- **Antenna:** the 15 W Midlands historically use a small SMA-type radio-side
+  connector with included cable/adapters rather than the SO-239 of the
+  MXT400/500/575 — verify the connector on the current revision before buying
+  mounts and [feedline](/reference/coax-feedline/).
+
+## The narrowband-audio complaint
+
+The MXT275's transmit is narrowband — ±2.5 kHz deviation — and this is the
+root of the most common owner complaint: **weak, quiet-sounding audio into
+wideband repeaters**, and occasionally erratic tone decode on the repeater
+end. Your signal is there; it just modulates half as far as the wideband
+radios on the same machine expect. For family simplex use nobody notices. For
+serious repeater work it's a real strike, and it's the main reason to spend up
+to the [MXT575](/reference/midland-mxt575/) (wide/narrow selectable) or look
+at a 20 W import like the [Radioddity DB20-G](/reference/radioddity-db20-g/)
+or [Wouxun KG-XS20G Plus](/reference/wouxun-kg-xs20g/), both of which also do
+split tones at or below this price. The MXT275 holds a genuine Part 95E
+grant, as does everything we recommend.
+
+## GopherTrunk alternative
+
+FRS and GMRS live at 462/467 MHz as analog narrowband
+[FM](/reference/frequency-modulation/) — easy work for a ~$30
+[RTL-SDR](/reference/rtl-sdr/). Running free GopherTrunk, it monitors and
+records every local FRS/GMRS channel and repeater at once, so before you buy
+the MXT275 (or pay the $35 license) you can find out what's actually active
+around you — including whether the local repeaters your radio would need split
+tones for are worth chasing. GopherTrunk is receive-only; it complements a
+transmitting radio, never replaces it.
+[Download GopherTrunk](/downloads.html) and have a listen first.
+
+## Who it's for
+
+- **Buy the MXT275** if you want the simplest permanent GMRS install for
+  family, trail, and convoy use — and buy the current USB-C revision.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B07FN2FBML?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [MXT575](/reference/midland-mxt575/)** instead if repeaters are
+  the point — 50 W and selectable wideband fix this radio's two limits while
+  keeping the mic-centric design.
+- **Skip it** for the [Radioddity DB20-G](/reference/radioddity-db20-g/) if
+  you'd trade Midland polish for 20 W, wideband receive, and CHIRP at around
+  $120. Full rankings:
+  [best GMRS mobile radios](/best-gmrs-mobile-radios/).
+
+## Sources
+
+[^midland]: [Midland MXT275 MicroMobile product page](https://midlandusa.com/products/mxt275-micromobile-two-way-radio) — Midland Radio, on the integrated control mic design, 15 W output, channel/privacy-code counts, repeater channels, and NOAA weather.

--- a/docs/reference/midland-mxt400.md
+++ b/docs/reference/midland-mxt400.md
@@ -85,9 +85,10 @@ things had become the line's loudest complaints.
 
 Where to buy is part of the honest story: an Amazon listing for the MXT400
 still exists, but it's residual third-party stock — check it for price
-gouging. **The practical market for this radio is eBay and the used channels**,
-which is also where the $100–180 figure comes from (against an original
-$249.99 MSRP).
+gouging. **The practical market for this radio is
+<a href="https://www.ebay.com/sch/i.html?_nkw=Midland+MXT400" rel="nofollow noopener">eBay</a>
+and the used channels**, which is also where the $100–180 figure comes from
+(against an original $249.99 MSRP).
 
 **License note:** transmitting on GMRS requires a license — $35 to the
 [FCC](/reference/fcc/), valid 10 years, no test, covering your immediate

--- a/docs/reference/midland-mxt400.md
+++ b/docs/reference/midland-mxt400.md
@@ -1,0 +1,153 @@
+---
+slug: midland-mxt400
+title: Midland MXT400
+entry_type: hardware
+category: two-way-radios
+description: "The Midland MXT400 was the 40-watt MicroMobile GMRS flagship before the MXT500 replaced it — discontinued, narrowband-only, no NOAA, and now a used-market radio at roughly $100–180 with a known channel 15–22 transmit bug to test for."
+keywords: Midland MXT400, MXT400 review, MXT400 discontinued, used GMRS mobile radio, 40 watt GMRS radio, MXT400 vs MXT500, gmrs license, MicroMobile MXT400, MXT400 programming, MXT400 split tones, cheap used GMRS radio
+aka: [MXT400, MicroMobile MXT400]
+autolink: true
+affiliate: true
+product:
+  name: "Midland MXT400"
+  brand: Midland
+  category: GMRS mobile radio (discontinued)
+  itemCondition: used
+  lowPrice: "100"
+  highPrice: "180"
+  url: https://www.amazon.com/dp/B01N0X0LHF?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: "GMRS mobile radio (discontinued 2022)" }
+  - { label: Service, value: "GMRS — 15 channels + 8 repeater channels" }
+  - { label: Power, value: "40 W (narrowband-only TX)" }
+  - { label: Repeater, value: "Yes — split tones only via DBR1 cable + software" }
+  - { label: License, value: "GMRS — $35 FCC, no test, covers family" }
+  - { label: Price, value: "around $100–180 used (thin data)" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B01N0X0LHF?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">Check listing on Amazon &rarr;</a>" }
+see_also: [midland-mxt500, btech-gmrs-50x1, midland-mxt575, midland-mxt115, radioddity-db20-g, rtl-sdr]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "Best GMRS mobile & base radios", url: /best-gmrs-mobile-radios/ }
+cite_urls:
+  - https://support.midlandusa.com/hc/en-us/articles/26844933665559-MXT400-Programming-Software-and-Instructions-Discontinued
+  - https://www.buytwowayradios.com/midland-mxt400.html
+faq:
+  - q: "Is the Midland MXT400 discontinued?"
+    a: "Yes — confirmed by Midland's own support site, which files it under Discontinued Mobile Radios. It was superseded in 2022 by the MXT500, which fixed its three headline flaws: 40 W became 50 W, narrowband-only became selectable wideband, and NOAA weather was added."
+  - q: "How much is a used Midland MXT400 worth?"
+    a: "Roughly $100–180 depending on condition and accessories, based on observed eBay listings — but the sold-comps data is thin, so treat that range as a guide, not gospel. Original MSRP was $249.99. A leftover third-party Amazon listing exists; check it against eBay pricing for gouging."
+  - q: "Do I need a license for the Midland MXT400?"
+    a: "To transmit, yes — a GMRS license: $35 to the FCC, valid 10 years, no test, covering your immediate family. Listening requires no license, used radio or not."
+  - q: "What should I check before buying a used MXT400?"
+    a: "Test transmit on channels 15–22 first — there's a documented firmware glitch where the radio refuses to TX on those channels without a reboot, and Midland support couldn't fix it. Also bench-test on a ~30 A supply, ask about programming history, confirm the fan runs, and ask whether the DBR1 cable is included."
+  - q: "Can the MXT400 do repeater split tones?"
+    a: "Not out of the box. Split CTCSS/DCS tones are only possible via the optional DBR1 programming cable and Midland's software — and that cable is no longer easy to buy, which is why used listings that include it are worth more."
+---
+**The Midland MXT400** was the MicroMobile flagship until 2022: 40 watts of
+name-brand GMRS in a simple, tough package. It is now **discontinued —
+confirmed by Midland's own support site** — and superseded by the
+[MXT500](/reference/midland-mxt500/), which fixed its three defining flaws
+(40 W → 50 W, narrowband-only → selectable wideband, no NOAA →
+NOAA).[^midland] Today it's a used-market radio at roughly **$100–180**,
+though the sold-price data is thin enough that you should treat that range as
+a sketch.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B01N0X0LHF?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check listing on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**A cheap used 40-watter with eyes-open flaws.** 15 GMRS + 8 repeater
+channels, Part 95E certified, Midland build. **Narrowband-only TX** (quiet
+into wideband repeaters), **no NOAA**, and **split tones only via the
+optional DBR1 cable + software**. A residual third-party Amazon listing
+exists, but **eBay and the used market are the practical way to buy one** —
+and used pricing (~$100–180) is thin-data territory. **Test TX on channels
+15–22 before paying** — a documented firmware bug. **GMRS license to
+transmit: $35, 10 years, no test, covers family.** Rankings:
+[best GMRS mobile radios](/best-gmrs-mobile-radios/).
+</div>
+
+## Overview
+
+The MXT400 earned its following honestly: it was the first serious-wattage
+Midland GMRS mobile, built simply — a basic segment display, a
+non-detachable face, an SO-239 jack for standard
+[PL-259](/reference/uhf-connector-pl259/) feedline — and it kept working.
+But its design choices aged into its chief complaints. Transmit is
+**narrowband-only**, so it always sounded quiet into wideband repeaters
+(there's no wide/narrow toggle to fix it, unlike everything Midland has made
+since). There's **no weather receive at all**. And repeater flexibility is
+locked behind the optional DBR1 programming cable and Midland's software —
+without them, no split [CTCSS](/reference/ctcss/)/[DCS](/reference/dcs/)
+tones, period. Midland retired it in 2022 precisely because those three
+things had become the line's loudest complaints.
+
+Where to buy is part of the honest story: an Amazon listing for the MXT400
+still exists, but it's residual third-party stock — check it for price
+gouging. **The practical market for this radio is eBay and the used channels**,
+which is also where the $100–180 figure comes from (against an original
+$249.99 MSRP).
+
+**License note:** transmitting on GMRS requires a license — $35 to the
+[FCC](/reference/fcc/), valid 10 years, no test, covering your immediate
+family. Listening needs nothing, on this or any radio.
+
+## Buying used: what to check
+
+This is the section that matters, because the MXT400's failure modes are
+specific and testable:
+
+1. **Test transmit on channels 15–22 before money changes hands.** There's a
+   documented case of an MXT400 refusing to TX on channels 15–22 without a
+   reboot — a firmware glitch Midland support could not fix. Since 15–22 are
+   the main repeater-adjacent channels, a unit with this bug is badly
+   compromised. Key up on them, every one.
+2. **Ask about programming history.** Programming-software/firmware version
+   mismatches cause errors; ask the seller whether it's been programmed, and
+   with what.
+3. **Bench-test on a real supply.** At 40 W it draws heavy current — use a
+   supply good for ~30 A continuous. Weak supplies cause resets that look
+   like radio faults.
+4. **Ask whether the DBR1 cable is included.** It's required for split tones
+   and no longer easy to buy — a package with the cable is worth real extra
+   money.
+5. **Confirm the fan runs.**
+
+Priced against the alternatives: a used
+[BTECH GMRS-50X1](/reference/btech-gmrs-50x1/) in the same $80–160 band
+brings 50 W, split tones, wideband receive, and CHIRP — a stronger used buy
+unless Midland simplicity is specifically what you want. And a **new**
+[Radioddity DB20-G](/reference/radioddity-db20-g/) at ~$120 with a warranty
+undercuts most MXT400 listings while doing split tones out of the box.
+
+## GopherTrunk alternative
+
+FRS and GMRS are analog narrowband [FM](/reference/frequency-modulation/) at
+462/467 MHz — easy pickings for a ~$30 [RTL-SDR](/reference/rtl-sdr/)
+running free GopherTrunk, which monitors and records local FRS/GMRS and
+repeater activity. That's doubly useful when you're eyeing a used MXT400: a
+week of recordings tells you whether your local repeaters need split tones
+(which this radio only does with the elusive DBR1 cable) before you bid.
+GopherTrunk is receive-only — it complements a transmitting radio, never
+replaces one. [Download GopherTrunk](/downloads.html) and scout the band
+first.
+
+## Who it's for
+
+- **Buy a used MXT400** if you want cheap name-brand 40-watt simplex power,
+  the seller lets you test channels 15–22, and NOAA/split tones aren't on
+  your list.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B01N0X0LHF?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check listing on Amazon &rarr;</a>
+- **Buy the [MXT500](/reference/midland-mxt500/)** instead if you can spend
+  new-radio money — it exists specifically to fix everything wrong with this
+  one.
+- **Skip it** for a used [BTECH GMRS-50X1](/reference/btech-gmrs-50x1/) (more
+  radio for the same used money) or a new
+  [Radioddity DB20-G](/reference/radioddity-db20-g/) (warranty, split tones,
+  ~$120). Full rankings:
+  [best GMRS mobile radios](/best-gmrs-mobile-radios/).
+
+## Sources
+
+[^midland]: [MXT400 Programming Software and Instructions (Discontinued) — Midland support](https://support.midlandusa.com/hc/en-us/articles/26844933665559-MXT400-Programming-Software-and-Instructions-Discontinued) — Midland's own support site confirming discontinued status and the DBR1 cable/software requirement for split tones; dealer archive: [Midland MXT400 — Buy Two Way Radios](https://www.buytwowayradios.com/midland-mxt400.html) with the 40 W/narrowband/no-NOAA specifications.

--- a/docs/reference/midland-mxt500.md
+++ b/docs/reference/midland-mxt500.md
@@ -1,0 +1,146 @@
+---
+slug: midland-mxt500
+title: Midland MXT500
+entry_type: hardware
+category: two-way-radios
+description: "The Midland MXT500 is Midland's 50-watt GMRS mobile with a conventional control head and an IP66-rated body — up to 128 channels, NOAA weather, and repeater split tones on current firmware, around $350–400."
+keywords: Midland MXT500, MXT500 review, 50 watt GMRS mobile radio, GMRS repeater radio, MicroMobile MXT500, MXT500 vs MXT575, gmrs license, best GMRS mobile radio 2026, IP66 GMRS radio, Midland MicroMobile, GMRS mobile for jeep
+aka: [MXT500, MicroMobile MXT500]
+autolink: true
+affiliate: true
+product:
+  name: "Midland MXT500"
+  brand: Midland
+  category: GMRS mobile radio
+  lowPrice: "350"
+  highPrice: "400"
+  url: https://www.amazon.com/dp/B09PFBWV55?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: "GMRS mobile radio (control head + mic)" }
+  - { label: Service, value: "GMRS — up to 128 channels incl. 8 repeater" }
+  - { label: Power, value: "50 W (legal maximum)" }
+  - { label: Repeater, value: "Yes — split tones on current firmware" }
+  - { label: License, value: "GMRS — $35 FCC, no test, covers family" }
+  - { label: Price, value: "around $350–400" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B09PFBWV55?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [midland-mxt575, midland-mxt400, wouxun-kg-1000g-plus, btech-gmrs-50pro, midland-mxt275, rtl-sdr]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "Best GMRS mobile & base radios", url: /best-gmrs-mobile-radios/ }
+cite_urls:
+  - https://midlandusa.com/products/mxt500-micromobile%C2%AEtwo-way-radio
+faq:
+  - q: "Do I need a license for the Midland MXT500?"
+    a: "To transmit, yes — a GMRS license: $35 paid to the FCC, valid 10 years, no test, and it covers your immediate family. Listening to GMRS requires no license."
+  - q: "What is the difference between the MXT500 and the MXT575?"
+    a: "Same 50-watt GMRS family, different ergonomics. The MXT500 has a conventional control head with a separate microphone and an IP66-rated body; the MXT575 puts every control and the speaker in the mic with a hideaway main unit. Pick by your dashboard, not by specs."
+  - q: "Is the Midland MXT500 waterproof?"
+    a: "The body carries an IP66 rating — sealed against dust and strong water jets — which is unusual in this class and welcome in open vehicles like Jeeps and side-by-sides. It is not rated for submersion."
+  - q: "Does the MXT500 have GPS?"
+    a: "No. Neither the MXT500 nor the MXT575 has GPS — no Midland MXT does. The only GMRS mobile in our roster with real GPS is the BTECH GMRS-50PRO."
+  - q: "Does the MXT500 work with GMRS repeaters?"
+    a: "Yes — it has the 8 repeater channels and, on current firmware, split-tone support for repeaters that use different encode and decode tones. Very early units may need Midland's firmware update, so verify split tones if you buy old stock."
+---
+**The Midland MXT500** is the conventional-control-head half of Midland's
+50-watt pair: same MicroMobile family as the
+[MXT575](/reference/midland-mxt575/), but with knobs on a real faceplate, a
+separate microphone, and an **IP66-rated body** that shrugs off dust and water
+jets.[^midland] For Jeeps, side-by-sides, and anyone who wants full legal
+power without living inside a mic-mounted menu, it's the Midland to get —
+around **$350–400**.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B09PFBWV55?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The 50 W Midland with a real control head.** Up to 128 channels and 154
+privacy codes on current firmware, 8 repeater channels with **split tones**,
+NOAA Scan + Alert, IP66 body. **No GPS, no wideband receive, no CHIRP** —
+programming is USB-C with Midland's software only. It costs
+Wouxun-KG-1000G-Plus money with fewer features; you're paying for the Midland
+badge and the sealed body. **GMRS license required to transmit: $35, 10 years,
+no test, covers your immediate family.** Rankings:
+[best GMRS mobile radios](/best-gmrs-mobile-radios/).
+</div>
+
+## Overview
+
+Launched in January 2022 alongside the MXT575, the MXT500 was the fix for the
+discontinued [MXT400](/reference/midland-mxt400/)'s three headline flaws: it
+brought the line to the full 50 W, made wide/narrow transmit selectable, and
+added NOAA weather. As of 2026 it's still current on Midland's site and in
+their software-support list; Midland's next-gen "P" refresh has so far touched
+the entry models (the MXT115P is confirmed), with no MXT500 successor
+announced.
+
+The design split with the 575 is purely ergonomic. The MXT500 gives you a
+compact head unit with a channel dial and buttons plus a standard fist mic —
+familiar, glanceable, and easier to share between drivers. The 575 hides the
+radio entirely and puts everything in the mic. Same family, same power, same
+repeater behavior; choose by dashboard.
+
+**License note:** GMRS transmit requires a license — $35 to the
+[FCC](/reference/fcc/), good for 10 years, no exam, covering your immediate
+family. One fee outfits the whole convoy. Listening is license-free.
+
+## Channels, power &amp; repeater use
+
+- **Power:** 50 W, the GMRS legal maximum.
+- **Channels:** up to 128 channels and 154 privacy codes on current firmware,
+  including the 8 repeater channels; wide/narrow selectable transmit.
+- **Repeaters:** [CTCSS](/reference/ctcss/)/[DCS](/reference/dcs/) encode and
+  decode with **split tones on current firmware** — the feature that unlocks
+  club repeaters using different TX and RX tones. As with the 575, very early
+  units may need Midland's firmware update.
+- **Weather:** NOAA Weather Scan + Alert.
+- **Build:** IP66-rated body — a genuine differentiator for open cabs.
+- **Antenna:** SO-239 jack on the radio; NMO mag-mount antenna in the box.
+
+Remember what the wattage is for: UHF simplex is terrain-limited to roughly
+1–5 miles no matter the power. The 50 W and a proper roof-mounted antenna earn
+their money reaching a **repeater** input, where range stretches to 20–50+
+miles.
+
+## Where it falls short
+
+Judged against the import competition, the MXT500 is expensive for its
+feature set. The [Wouxun KG-1000G Plus](/reference/wouxun-kg-1000g-plus/)
+costs about the same and adds 999 memories, wideband VHF/UHF receive, FM
+broadcast, a detachable faceplate, and CHIRP support; the
+[BTECH GMRS-50PRO](/reference/btech-gmrs-50pro/) undercuts it by ~$100 and
+adds GPS and Bluetooth app programming. The Midland answer is a small display
+with limited channel labeling, **no receive coverage beyond GMRS and
+weather**, and programming locked to Midland's own USB-C software. What you
+get in exchange is the sealed body, the plug-and-play match with Midland
+handhelds like the [GXT1000VP4](/reference/midland-gxt1000vp4/), and Midland's
+US-based warranty and support — worth real money to plenty of buyers, just be
+clear that's the trade.
+
+## GopherTrunk alternative
+
+FRS and GMRS are analog narrowband [FM](/reference/frequency-modulation/) at
+462/467 MHz, comfortably inside an [RTL-SDR](/reference/rtl-sdr/)'s tuning
+range. Before spending $400, spend ~$30: a dongle running free GopherTrunk
+monitors and records local FRS/GMRS simplex and repeater activity, so you
+learn which repeaters are alive near you — and whether the license and a
+50-watt radio are worth it — with real evidence instead of coverage-map hope.
+GopherTrunk can't transmit; it complements the MXT500 rather than replacing
+it. [Download GopherTrunk](/downloads.html) and scout first.
+
+## Who it's for
+
+- **Buy the MXT500** if you want 50 legal watts behind a conventional control
+  head with a weather-sealed body and name-brand support.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B09PFBWV55?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [MXT575](/reference/midland-mxt575/)** instead if dash space is
+  tight and you'd rather have everything in the mic.
+- **Skip it** for the [Wouxun KG-1000G Plus](/reference/wouxun-kg-1000g-plus/)
+  if features-per-dollar decide it, or the
+  [BTECH GMRS-50PRO](/reference/btech-gmrs-50pro/) for GPS and app-driven
+  programming at ~$285. Full rankings:
+  [best GMRS mobile radios](/best-gmrs-mobile-radios/).
+
+## Sources
+
+[^midland]: [Midland MXT500 MicroMobile product page](https://midlandusa.com/products/mxt500-micromobile%C2%AEtwo-way-radio) — Midland Radio, on the 50 W output, IP66 rating, channel/privacy-code counts, repeater channels, and NOAA weather features.

--- a/docs/reference/midland-mxt575.md
+++ b/docs/reference/midland-mxt575.md
@@ -1,0 +1,154 @@
+---
+slug: midland-mxt575
+title: Midland MXT575
+entry_type: hardware
+category: two-way-radios
+description: "The Midland MXT575 is the 50-watt flagship of the MicroMobile GMRS line — every control and the speaker live in the microphone, so the radio itself hides behind the dash. Around $350–400, repeater-capable with split tones on current units."
+keywords: Midland MXT575, MXT575 review, best GMRS mobile radio, 50 watt GMRS radio, GMRS repeater radio, MicroMobile MXT575, gmrs license, Midland GMRS mobile, MXT575 vs MXT500, overlanding radio, GMRS radio for trucks, MXT575 split tones
+aka: [MXT575, MicroMobile MXT575]
+autolink: true
+affiliate: true
+product:
+  name: "Midland MXT575"
+  brand: Midland
+  category: GMRS mobile radio
+  lowPrice: "350"
+  highPrice: "400"
+  url: https://www.amazon.com/dp/B09PF9KCKH?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: "GMRS mobile radio (all-controls-in-mic)" }
+  - { label: Service, value: "GMRS — 15 channels + 8 repeater channels" }
+  - { label: Power, value: "50 W (legal maximum)" }
+  - { label: Repeater, value: "Yes — split tones on current units" }
+  - { label: License, value: "GMRS — $35 FCC, no test, covers family" }
+  - { label: Price, value: "around $350–400" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B09PF9KCKH?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [midland-mxt500, midland-mxt275, wouxun-kg-1000g-plus, btech-gmrs-50pro, radioddity-db20-g, rtl-sdr]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "Best GMRS mobile & base radios", url: /best-gmrs-mobile-radios/ }
+cite_urls:
+  - https://midlandusa.com/products/mxt575-micromobile%C2%AEtwo-way-radio
+faq:
+  - q: "Do I need a license for the Midland MXT575?"
+    a: "To transmit, yes — a GMRS license: $35 to the FCC, good for 10 years, no test, and one license covers your immediate family. Apply online through the FCC ULS. Listening requires no license at all."
+  - q: "What is the range of the Midland MXT575?"
+    a: "Vehicle to vehicle, expect roughly 1–5 miles in real terrain — UHF simplex is terrain-limited regardless of wattage. The real range upgrade is a GMRS repeater: through a well-sited repeater the MXT575's 50 watts can carry 20–50+ miles."
+  - q: "Does the Midland MXT575 have GPS?"
+    a: "No. No Midland MXT radio has GPS, despite occasional marketing confusion. If you want GPS position sharing in a GMRS mobile, the BTECH GMRS-50PRO is the one radio in this class that actually has it."
+  - q: "Does the MXT575 support repeater split tones?"
+    a: "Current units do — Midland added split-tone support to the MXT275/500/575 generation. Very early production may need Midland's firmware update, so if you buy used or old stock, verify split tones before counting on a club repeater."
+  - q: "Is the MXT575 CHIRP-compatible?"
+    a: "No. Programming is over USB-C with Midland's own software only. If CHIRP support matters to you, look at the Wouxun KG-1000G Plus or Radioddity DB20-G instead."
+---
+**The Midland MXT575** is the current flagship of Midland's MicroMobile GMRS
+line, and its defining trick is that the *radio* disappears: all 50 watts live
+in a hideaway black box, while every control, the display, and the speaker sit
+in the microphone.[^midland] For a modern vehicle with no spare dash real
+estate, it is the cleanest full-power GMRS install you can buy — around
+**$350–400**.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B09PF9KCKH?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Our best-overall GMRS mobile.** 50 W (the legal max), 15 GMRS + 8 repeater
+channels, NOAA weather scan and alert, and the tidiest install story in the
+class — everything is in the mic. **Split tones on current units** (very early
+stock may need a firmware update). **No GPS** — no Midland MXT has it.
+**Programming is Midland-software-only**, not CHIRP. Transmitting needs a
+**GMRS license: $35, 10 years, no test, covers your immediate family**.
+Where it ranks: [best GMRS mobile radios](/best-gmrs-mobile-radios/).
+</div>
+
+## Overview
+
+Launched in summer 2022 and still Midland's flagship as of 2026, the MXT575
+pairs the full 50-watt legal limit with the all-controls-in-mic design Midland
+proved on the cheaper [MXT275](/reference/midland-mxt275/). The main unit is a
+"black box" you bolt under a seat or behind the dash; one RJ45-corded mic
+carries the display, channel controls, speaker, and PTT. The upside is obvious
+in any tight modern interior. The tradeoff is just as plain: everything hangs
+on that one mic and its cord, and there's no conventional control head to fall
+back on. If you'd rather have knobs on a real faceplate, the same-money
+[MXT500](/reference/midland-mxt500/) is the same radio family in a
+conventional body.
+
+Midland began refreshing the MicroMobile line with "P" models in 2025 (the
+MXT115P is confirmed), but no MXT575 successor has been announced — the 575 is
+still front and center on Midland's site.
+
+**License note:** transmitting on GMRS requires a license — $35 to the
+[FCC](/reference/fcc/), valid 10 years, no exam, and one license covers your
+immediate family, which makes it the cheapest legal way to put real wattage in
+a family convoy. Listening requires nothing.
+
+## Channels, power &amp; repeater use
+
+- **Power:** 50 W — the GMRS legal maximum.
+- **Channels:** 15 GMRS channels plus the 8 repeater channels (467 MHz
+  inputs), with wide/narrow selectable transmit.
+- **Repeaters:** programmable [CTCSS](/reference/ctcss/)/[DCS](/reference/dcs/)
+  tones including **split tones** on current units — Midland added split-tone
+  and wideband support to this generation, and very early units may need
+  Midland's firmware update to get it. Split tones matter: many club repeaters
+  use a different encode tone than their decode tone, and a radio that can't do
+  that is locked out.
+- **Weather:** NOAA Weather Scan + Alert.
+- **Antenna:** an NMO mag-mount antenna ships in the box; the radio side is
+  SO-239 for a standard [PL-259](/reference/uhf-connector-pl259/) feedline.
+- **No GPS.** Despite recurring marketing confusion, neither the MXT575 nor
+  the MXT500 has GPS — in this roster only the
+  [BTECH GMRS-50PRO](/reference/btech-gmrs-50pro/) does.
+
+Keep expectations honest on range: 50 watts simplex still means roughly 1–5
+miles in real terrain, because UHF range is line-of-sight-limited. What the
+wattage genuinely buys is margin — and the ability to reach a **repeater**
+input reliably, where usable range jumps to 20–50+ miles.
+
+## Quirks worth knowing
+
+The MXT575 holds a genuine FCC Part 95E grant and Midland's brand support is a
+real asset, but owner reports cluster on a few things. A **squelch/static
+blast at vehicle startup** and alternator-speed whine show up in forum
+threads; Midland points at low-voltage or loose power wiring, and the fix is
+wiring direct to the battery rather than an accessory circuit. There are
+scattered channel-stability complaints on myGMRS. And the repeater memory
+model is rigid — you can't store multiple repeaters on the same channel with
+different tones, which enthusiasts bump into fast. Programming is via USB-C
+and **Midland's own software only** — no CHIRP — and channel naming is
+essentially absent. If those limits chafe, the
+[Wouxun KG-1000G Plus](/reference/wouxun-kg-1000g-plus/) exists precisely for
+you.
+
+## GopherTrunk alternative
+
+FRS and GMRS are analog narrowband [FM](/reference/frequency-modulation/) at
+462/467 MHz — squarely inside a cheap SDR's range. A ~$30
+[RTL-SDR](/reference/rtl-sdr/) running free GopherTrunk monitors and records
+your local FRS/GMRS traffic and GMRS repeater activity, so you can scout
+what's actually active — and whether a local repeater is worth the $35
+license — *before* spending $400 on radios. GopherTrunk cannot transmit, so it
+complements the MXT575 rather than replacing it; but as a scouting tool and a
+base-station recorder for the family fleet, it's the free half of the setup.
+[Download GopherTrunk](/downloads.html) and listen first.
+
+## Who it's for
+
+- **Buy the MXT575** if you want maximum legal power with the cleanest
+  possible install — overlanders, trucks, and any vehicle where dash space is
+  the constraint.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B09PF9KCKH?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [MXT500](/reference/midland-mxt500/)** instead if you prefer a
+  conventional control head (and an IP66 body) for the same money.
+- **Skip it** for the [Wouxun KG-1000G Plus](/reference/wouxun-kg-1000g-plus/)
+  if you want 999 channels, wideband receive, and CHIRP — more features for
+  similar money, less brand polish. On a budget, the 20 W
+  [Radioddity DB20-G](/reference/radioddity-db20-g/) does the repeater job for
+  a third of the price. Full rankings:
+  [best GMRS mobile radios](/best-gmrs-mobile-radios/).
+
+## Sources
+
+[^midland]: [Midland MXT575 MicroMobile product page](https://midlandusa.com/products/mxt575-micromobile%C2%AEtwo-way-radio) — Midland Radio, on the 50 W output, all-controls-in-mic design, repeater channels, NOAA weather, and included NMO antenna.

--- a/docs/reference/motorola-talkabout-mr350r.md
+++ b/docs/reference/motorola-talkabout-mr350r.md
@@ -1,0 +1,135 @@
+---
+slug: motorola-talkabout-mr350r
+title: Motorola Talkabout MR350R
+entry_type: hardware
+category: two-way-radios
+description: "The Motorola Talkabout MR350R is the discontinued pre-2017 hybrid FRS/GMRS walkie-talkie that sold by the million — now a $19–30 eBay radio whose '35-mile range' was always fantasy. What it's honestly worth used, and what to check first."
+keywords: Motorola MR350R, MR350R review, Motorola Talkabout MR350R, 35 mile walkie talkie, used walkie talkie, cheap walkie talkie eBay, FRS GMRS hybrid radio, MR350R battery, MR350R discontinued, do old Motorola radios need a license, walkie talkie range truth
+aka: [MR350R, Talkabout MR350R, Motorola MR350]
+autolink: true
+affiliate: true
+product:
+  name: "Motorola Talkabout MR350R"
+  brand: Motorola
+  category: FRS/GMRS walkie-talkie (discontinued)
+  seller: eBay
+  itemCondition: used
+  lowPrice: "19"
+  highPrice: "52"
+  url: "https://www.ebay.com/sch/i.html?_nkw=Motorola+MR350R"
+infobox:
+  - { label: Type, value: "Pre-2017 hybrid FRS/GMRS handheld (discontinued)" }
+  - { label: Service, value: "FRS/GMRS hybrid — GMRS channels need a license" }
+  - { label: Channels, value: "22 channels + 121 privacy codes; NOAA" }
+  - { label: Power, value: "~1–1.5 W on GMRS channels (unverified)" }
+  - { label: License, value: "GMRS — $35 FCC — for full power; ch 8–14 license-free" }
+  - { label: Price, value: "around $19–30 single, $37–52/pair used" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.ebay.com/sch/i.html?_nkw=Motorola+MR350R\" rel=\"nofollow noopener\">Find on eBay &rarr;</a>" }
+see_also: [motorola-talkabout-t800, midland-gxt1000vp4, garmin-rino-755t, baofeng-gm-15-pro, rocky-talkie-mountain-radio, rtl-sdr]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "The 10 best walkie-talkies", url: /best-walkie-talkies/ }
+cite_urls:
+  - https://www.ebay.com/p/1200002972
+faq:
+  - q: "Do I need a license for the Motorola MR350R?"
+    a: "It depends how you use it. The MR350R is a pre-2017 hybrid: channels 8–14 are license-free FRS, while its higher-power operation on the GMRS-power channels requires the $35, no-test GMRS license under today's rules. Practically, many families used these unlicensed for years — but that's the legal line."
+  - q: "Is the Motorola MR350R really a 35-mile radio?"
+    a: "No — that number was line-of-sight marketing even when new. Real-world output is roughly 1–1.5 W on the GMRS channels, and terrestrial range is the usual 0.5–2 miles in terrain and trees. Nothing about buying one used changes the physics."
+  - q: "Is the Motorola MR350R still made?"
+    a: "No — it was discontinued in the mid-2010s when Motorola's T-series Talkabouts replaced the MR line (the T470/T475 are the nearest current descendants). It survives as a very cheap, very plentiful eBay radio."
+  - q: "Are used MR350R batteries any good?"
+    a: "Assume not. The NiMH packs are a decade or more old and usually exhausted — budget $10–15 for third-party replacements or run the radios on 3 AA batteries each, which is the model's redeeming feature. Always verify a used unit powers up on AAs."
+  - q: "What is a used Motorola MR350R worth?"
+    a: "About $19–30 for a single radio and $37–52 for a pair — pairs with the charging cradle sit at the top of the range. eBay supply is plentiful, so don't pay collector prices for a mass-market radio."
+---
+**The Motorola Talkabout MR350R** was the walkie-talkie of the late-2000s
+family road trip — a **"35-mile"** hybrid FRS/GMRS pair sold by the million
+and discontinued in the mid-2010s when Motorola's T-series took over.[^ebay]
+Today it's an **eBay radio, around $19–30 each or $37–52 a pair**, and the
+honest review is simple: the 35-mile claim was always fantasy (~1–1.5 W and
+FRS-class real range), the NiMH packs are almost certainly dead, and the AA
+fallback is what keeps these usable at all. Out of production means the used
+market — eBay, thrift stores, garage sales — is the only market.
+
+<a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=Motorola+MR350R" rel="nofollow noopener">Find on eBay &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Dirt-cheap used group comms — with era-appropriate expectations.** 22
+channels + 121 [privacy codes](/reference/ctcss/), NOAA with alert, iVOX
+hands-free, **3×AA fallback** (the killer feature at this age). Under
+today's rules its GMRS-power channels need the **$35 no-test GMRS license**;
+channels 8–14 stay license-free FRS. Expect **0.5–2 real miles**, dead NiMH
+packs, and missing cradles. A new [Baofeng
+GM-15 Pro](/reference/baofeng-gm-15-pro/) outperforms it for similar money.
+Rankings: [best walkie-talkies](/best-walkie-talkies/).
+</div>
+
+## Overview
+
+The MR350R predates the FCC's 2017 reorganization, which is the key to
+understanding what it is. Pre-2017, "FRS/GMRS hybrid" radios straddled both
+services in one box; the 2017 rules grandfathered them while requiring new
+radios to pick a side. Under today's rules the MR350R's **channels 8–14 are
+license-free FRS**, and its higher-power operation on the GMRS channels
+requires the **GMRS license — $35, no test, 10 years, family-covered**.
+Measured against its own box, the radio was always modest: roughly **1–1.5 W**
+on the GMRS channels (Motorola never published a clean figure; treat that as
+approximate), and the famous **"35 miles"** was line-of-sight marketing —
+plan on the same 0.5–2 terrestrial miles as every other handheld here.
+**No repeater capability**, splash resistance at best, and a mono LCD.
+
+So why buy one in 2026? Price and pragmatism. At $20–25 a radio you can
+outfit a whole campground, the controls are familiar to anyone who's touched
+a Talkabout, NOAA weather alert is aboard, and the **3×AA fallback** means a
+radio with a dead pack still works. It's the beater-radio answer — and it's
+also why our actual recommendation for most people is a **new**
+[Baofeng GM-15 Pro](/reference/baofeng-gm-15-pro/) at similar money: real
+5 W, repeater channels, USB-C, and a warranty.
+
+## Buying used: what to check
+
+Two decades of MR350R units are on eBay; the good ones share a checklist:
+
+1. **Assume the NiMH packs are dead.** They almost always are. Third-party
+   replacements run ~$10–15, or run on AAs — confirm the radio powers up on
+   AA batteries before anything else.
+2. **Battery-compartment corrosion** from leaked alkalines — inspect the
+   contacts; green fuzz is a walk-away or a deep-discount lever.
+3. **PTT and buttons** — membrane wear causes intermittent keying; test
+   transmit and receive in *both* directions between a pair.
+4. **Cradle and wall wart** — many eBay lots are radio-only, which is
+   priced in; a complete pair with the drop-in charger justifies the
+   $45–52 top of the range.
+5. **Belt clips and battery-door tabs** — the classic breakage points.
+6. **Speaker** — foam rot causes crackle and low audio; do a voice test,
+   not just a power-on test.
+
+## GopherTrunk alternative
+
+Everything an MR350R says goes out as analog narrowband FM at 462/467 MHz —
+exactly what a ~$30 [RTL-SDR](/reference/rtl-sdr/) running free GopherTrunk
+receives, records, and timestamps. If you're resurrecting a drawer of these
+for a campout or property, the SDR is the cheap way to check each unit
+actually transmits (see the checklist above) and to monitor how busy your
+local shared channels are. GopherTrunk can't transmit — it's the free
+listening-and-logging side of the hobby, not a replacement for the radios.
+Start at [Learn RF &amp; SDR](/learn/rf-sdr/).
+
+## Who it's for
+
+- **Buy used MR350Rs** if you need many cheap, familiar radios for
+  short-range family or event use, you'll run them on AAs, and you've read
+  the checklist above.
+  <a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=Motorola+MR350R" rel="nofollow noopener">Find on eBay &rarr;</a>
+- **Buy a new [Baofeng GM-15 Pro](/reference/baofeng-gm-15-pro/)** instead
+  for similar money — genuinely 5 W, repeater-capable, USB-C, warrantied.
+- **Skip it** for a [Motorola T800](/reference/motorola-talkabout-t800/) if
+  you want a current-generation license-free Talkabout, or see the full
+  rankings: [best walkie-talkies](/best-walkie-talkies/).
+
+## Sources
+
+[^ebay]: [Motorola Talkabout MR350R — eBay product listing](https://www.ebay.com/p/1200002972) — representative used-market listing documenting the discontinued model's channels, privacy codes, NOAA features, battery options, and typical sold condition/pricing; Motorola no longer maintains a product page for the MR-series.

--- a/docs/reference/motorola-talkabout-t800.md
+++ b/docs/reference/motorola-talkabout-t800.md
@@ -1,0 +1,136 @@
+---
+slug: motorola-talkabout-t800
+title: Motorola Talkabout T800
+entry_type: hardware
+category: two-way-radios
+description: "The Motorola Talkabout T800 is a license-free 2 W FRS walkie-talkie with a unique trick — Bluetooth off-grid text messaging and location sharing via the Talkabout app — sold ~$90–110/pair, but with late-life availability and a famously flaky app."
+keywords: Motorola Talkabout T800, T800 review, Motorola T800 walkie talkie, off grid text messaging radio, FRS radio, license free walkie talkie, Motorola Talkabout app, walkie talkie with app, T800 discontinued, Motorola T470, FRS vs GMRS
+aka: [Talkabout T800, Motorola T800]
+autolink: true
+affiliate: true
+product:
+  name: "Motorola Talkabout T800"
+  brand: Motorola
+  category: FRS walkie-talkie (handheld pair)
+  lowPrice: "90"
+  highPrice: "110"
+  url: https://www.amazon.com/dp/B07HRSP2ZV?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: "Handheld FRS walkie-talkie with Bluetooth data" }
+  - { label: Service, value: "FRS (FCC Part 95B)" }
+  - { label: Channels, value: "22 FRS channels + privacy codes" }
+  - { label: Power, value: "2 W (0.5 W on channels 8–14)" }
+  - { label: License, value: "None (FRS — license-free)" }
+  - { label: Price, value: "around $90–110 per 2-pack (stock thinning)" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B07HRSP2ZV?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [rocky-talkie-mountain-radio, midland-gxt1000vp4, motorola-talkabout-mr350r, garmin-rino-755t, btech-gmrs-pro, rtl-sdr]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "The 10 best walkie-talkies", url: /best-walkie-talkies/ }
+cite_urls:
+  - https://www.motorolasolutions.com/en_us/products/two-way-radios/consumer-two-way-radios/t800.html
+faq:
+  - q: "Do I need a license for the Motorola Talkabout T800?"
+    a: "No. It's an FRS radio under FCC Part 95B — license-free for anyone in the US. That's also its power ceiling: 2 W max, 0.5 W on channels 8–14, fixed antenna, no repeaters."
+  - q: "How does the Motorola T800's off-grid texting work?"
+    a: "Each T800 pairs to a phone over Bluetooth, and the Talkabout app sends short text messages and location pins between T800 users as data bursts over the FRS channels — no cell service needed. It only works T800-to-T800 with the app on both ends, and users widely report the app as flaky and effectively unmaintained."
+  - q: "Is the Motorola T800 discontinued?"
+    a: "Signals conflict as of 2026: Motorola still lists it and Amazon still sells it, but at least one distributor marks it discontinued and specialty-dealer stock looks late-life. Treat it as a buy-while-available radio; Motorola's current T470 is the closest ongoing alternative (without the Bluetooth texting)."
+  - q: "Is the Motorola T800 waterproof?"
+    a: "No — IPX4 splash resistance only. Rain is fine; drops in creeks are not. If you need real waterproofing in a consumer handheld, look at IP67 radios like the Rocky Talkie Expedition Radio or BTECH GMRS-PRO."
+  - q: "What is the real range of the Motorola T800?"
+    a: "It's a 2 W FRS radio, so the same as its peers: roughly 0.5–2 miles in terrain and trees, more with line of sight. The texting feature rides the same RF, so message range is similar to voice range."
+---
+**The Motorola Talkabout T800** is the one blister-pack FRS radio with a
+genuinely novel trick: pair it to your phone over Bluetooth and the Talkabout
+app turns the radio into a data modem, sending **off-grid text messages and
+location pins** between T800s over the FRS channels — no cell coverage
+required.[^moto] It's license-free, around **$90–110 a pair**, and carries two
+honest asterisks: the app that enables its signature feature is widely
+reported as flaky and unmaintained, and the radio itself shows **end-of-life
+signals** at distributors even while Motorola still lists it.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B07HRSP2ZV?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**FRS with a party trick — buy with eyes open.** License-free Part 95B, 2 W,
+NOAA weather, decent dot-matrix screen. The Bluetooth **texting/location
+sharing is unique** in this class but T800-to-T800 only, and the phone app is
+its weak link. **Availability is conflicting** — Motorola lists it, one
+distributor calls it discontinued; if it vanishes, the **Motorola T470** is
+the current-production fallback (minus the texting). Splash-only IPX4,
+unimpressive battery. Rankings: [best walkie-talkies](/best-walkie-talkies/).
+</div>
+
+## Overview
+
+Strip away the Bluetooth and the T800 is an ordinary modern FRS handheld:
+**Part 95B, license-free**, 2 W on the high-power channels and the mandated
+0.5 W on channels 8–14, fixed antenna, no repeater capability — because FRS
+never has any of those things. It adds NOAA weather receive, a nicer
+backlit dot-matrix display than most of the blister-pack class, and runs on a
+NiMH pack (~14 h) or 3×AA (~25 h).
+
+The reason to pick it over a cheaper FRS pair is the app ecosystem — and
+that's also the reason to hesitate. Off-grid group texting and shared map
+pins between hunting partners or a ski group is a real capability nothing
+else in the blister-pack world offers. But it only works **radio-to-radio
+between T800s**, both ends need the Talkabout app running, and long-term
+owner reports converge on the same complaint: the app is buggy and Motorola
+has effectively stopped maintaining it. If the data features are your whole
+reason to buy, a [Garmin Rino 755t](/reference/garmin-rino-755t/) (used) or a
+[BTECH GMRS-PRO](/reference/btech-gmrs-pro/) does position-sharing more
+robustly — with a GMRS license.
+
+**Availability, stated plainly:** as of mid-2026 Motorola's consumer pages
+still carry the T800 and Amazon stocks it, but at least one distributor marks
+it discontinued and specialty-dealer inventory looks late-life. We flag that
+rather than hide it. If it drops out of stock, Motorola's current **Talkabout
+T470** (IPX4, NOAA, rechargeable) is the drop-in substitute — without the
+Bluetooth texting that makes the T800 interesting.
+
+## Channels, power &amp; battery
+
+- **Service:** FRS, Part 95B — **license-free**; talks to any FRS/GMRS radio
+  on the 22 shared channels.
+- **Power:** 2 W (0.5 W on channels 8–14, per FRS rules). No repeaters.
+- **Data:** Bluetooth link to the Talkabout app — off-grid texting and
+  location sharing, T800-to-T800 only.
+- **Weather:** NOAA weather receive.
+- **Battery:** NiMH pack ~14 h or 3×AA ~25 h.
+- **Durability:** **IPX4** splash resistance (Motorola's sheet describes
+  IPx4-class weatherproofing); not submersible.
+- **Range:** 0.5–2 miles typical terrestrial; [privacy
+  codes](/reference/ctcss/) are squelch tones, not encryption.
+
+## GopherTrunk alternative
+
+The T800's channels are ordinary analog narrowband FM at 462/467 MHz, which a
+~$30 [RTL-SDR](/reference/rtl-sdr/) running free GopherTrunk receives with
+ease. Before buying any FRS pair, an afternoon of monitoring tells you how
+crowded your local shared channels are — and afterward, GopherTrunk will
+record and timestamp your group's traffic (the data bursts, being
+Motorola-proprietary, just log as noise). It cannot transmit and never
+replaces the radios; it's the free listening-and-logging side. New to SDR?
+Start at [Learn RF &amp; SDR](/learn/rf-sdr/).
+
+## Who it's for
+
+- **Buy the T800** if off-grid texting between a small fixed group is worth a
+  premium and you accept the app's rough edges — and buy soon, given the
+  availability signals.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B07HRSP2ZV?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy a [Rocky Talkie Mountain Radio](/reference/rocky-talkie-mountain-radio/)**
+  instead for a tougher, longer-running license-free radio without the
+  gimmick, or a [Midland GXT1000VP4](/reference/midland-gxt1000vp4/) pair for
+  less money.
+- **Skip it** if you want position sharing that's actually dependable — the
+  used [Garmin Rino 755t](/reference/garmin-rino-755t/) or the
+  [BTECH GMRS-PRO](/reference/btech-gmrs-pro/) (both GMRS-licensed) do it
+  properly. Full rankings: [best walkie-talkies](/best-walkie-talkies/).
+
+## Sources
+
+[^moto]: [Motorola Talkabout T800 product page](https://www.motorolasolutions.com/en_us/products/two-way-radios/consumer-two-way-radios/t800.html) — Motorola Solutions, on FRS certification, Bluetooth/Talkabout app messaging and location sharing, NOAA weather, battery options, and weatherproofing.

--- a/docs/reference/president-mckinley.md
+++ b/docs/reference/president-mckinley.md
@@ -1,0 +1,133 @@
+---
+slug: president-mckinley
+title: President McKinley II
+entry_type: hardware
+category: two-way-radios
+description: "The President McKinley II FCC is the best-equipped CB on sale — AM/FM/SSB with 12 W PEP sideband, the class-leading receiver and noise blanker, automatic SWR check, and rare 12/24 V supply, for around $180–230."
+keywords: President McKinley II, President McKinley review, President McKinley CB radio, best SSB CB radio 2026, AM FM SSB CB radio, McKinley vs Bearcat 980SSB, CB radio best receiver, 24 volt CB radio, CB radio no license, compact SSB CB
+aka: [McKinley USA, President McKinley, McKinley II FCC]
+autolink: true
+affiliate: true
+product:
+  name: "President McKinley II FCC"
+  brand: President Electronics
+  category: CB radio (compact mobile, AM/FM/SSB)
+  lowPrice: "180"
+  highPrice: "230"
+  url: https://www.amazon.com/dp/B0CGRZC8CX?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: Compact mobile CB }
+  - { label: Service, value: "CB — 40 channels, 26.965–27.405 MHz" }
+  - { label: Modes, value: "AM/FM/SSB (USB/LSB)" }
+  - { label: Power, value: "4 W AM/FM / 12 W PEP SSB; 12/24 V supply" }
+  - { label: Extras, value: "NOAA weather + alerts, automatic SWR check, ASC squelch, VOX, front-firing speaker" }
+  - { label: License, value: "None (CB) — licensed by rule, Part 95D" }
+  - { label: Price, value: around $180–230 }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B0CGRZC8CX?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [uniden-bearcat-980ssb, uniden-bearcat-880, uniden-grant-xl, cobra-29-ltd-classic, single-sideband, rtl-sdr]
+related_reading:
+  - { title: "The 10 best CB radios", url: /best-cb-radios/ }
+  - { title: "Best HF SDRs (to listen on 27 MHz)", url: /best-hf-sdr/ }
+cite_urls:
+  - https://president-electronics.us/CB-Radios-Ham-Radios/AM-SSB-transceivers/MC-KINLEY-USA
+faq:
+  - q: "Do I need a license for the President McKinley II?"
+    a: "No. CB is licensed by rule under FCC Part 95D — no exam, no fee. The 'FCC' in the model name simply marks the US-certified variant; legal limits are 4 W carrier on AM/FM and 12 W PEP on SSB."
+  - q: "What's the difference between the President McKinley and the McKinley II?"
+    a: "The McKinley II FCC is the current model and adds FM — legal on CB since the FCC's 2021 rule change — on top of the original's AM/SSB. Original McKinley USA stock (AM/SSB only) still circulates; buy the II unless you find a bargain and don't care about FM."
+  - q: "Is the President McKinley II better than the Uniden Bearcat 980SSB?"
+    a: "In everything but price. Owner consensus rates the McKinley's receiver and noise blanker the best in the current SSB class, the display is readable in sunlight where the 980SSB's washes out, the front-firing speaker is usable without an external, and it adds FM. The 980SSB is cheaper and has talkback."
+  - q: "Can I run the McKinley II in a semi truck with a 24-volt system?"
+    a: "Yes — it accepts 12 and 24 V supplies, which is rare among CBs and one reason it's popular in heavy trucks and European-style HGVs. Most competitors are 12 V only."
+  - q: "What's the range of the President McKinley II on SSB?"
+    a: "With 12 W PEP SSB, a tuned antenna, and decent conditions, roughly double what a 4 W AM radio manages — but only to stations that also run SSB. On AM/FM it's a normal 4 W CB where the antenna, not the radio, sets your range."
+---
+**The President McKinley II FCC** is the best-equipped CB you can buy new:
+the only current rig with **all three legal modes — AM, FM, and SSB** (4 W
+carrier, 12 W PEP sideband), wrapped around what owners consistently rate the
+**best receiver and noise blanker in the current SSB class**.[^president] Add
+an automatic SWR check, a rare **12/24 V supply**, and a compact chassis, and
+it's our "best features for the price" pick at around **$180–230** (2026
+pricing floats — verify at checkout).
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0CGRZC8CX?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The current default for a serious SSB mobile.** Class-best receiver and
+noise blanker (owner rankings: McKinley &gt; Washington &gt; Uniden 980),
+AM/FM/SSB, automatic SWR check, ASC auto-squelch, sunlight-readable display,
+front-firing speaker you can actually hear, **12/24 V** for heavy trucks.
+**Costs more than the [980SSB](/reference/uniden-bearcat-980ssb/)** and skips
+trucker niceties like talkback. **License-free** (Part 95D). **~$180–230.**
+Full rankings: [best CB radios](/best-cb-radios/).
+</div>
+
+## Overview
+
+President builds CBs the way ham manufacturers build transceivers, and the
+McKinley is where that shows. The parts of a radio you can't see on a spec
+sheet — receiver selectivity on a noisy highway, a noise blanker that
+actually blanks ignition hash, squelch that opens for voices and not for
+alternator whine — are where owners consistently rank it first in the current
+SSB class. The **ASC automatic squelch** means you set it once; hi-cut, NB,
+and ANL filters handle the rest.
+
+The **McKinley II FCC** is the current version, adding **FM** (legal on CB
+since 2021) to the original McKinley USA's AM/SSB. Original-version stock
+still circulates; the II is the one to buy. Practical touches follow the same
+engineering-first pattern: an **automatic SWR check** warns you of a bad
+antenna every time you transmit, the **front-firing loudspeaker** is genuinely
+usable without an external speaker (rare in this hobby), the display stays
+readable in sunlight (the 980SSB's does not), and the **12/24 V supply**
+covers heavy trucks that competitors can't. VOX is aboard for hands-free.
+
+What you give up versus the trucker-culture rigs: no talkback, and the
+clarifier is locked to legal receive-side behavior — hobbyists who want an
+unlocked clarifier complain, and we count that a feature, not a flaw (an
+unlocked clarifier that slides your transmit frequency is non-compliant; see
+our [Grant XL](/reference/uniden-grant-xl/) page for how that ends).
+
+**License note:** none — CB is licensed by rule under FCC Part 95D. 4 W
+AM/FM, 12 W PEP SSB, 40 channels; the McKinley II is certified to exactly
+that.
+
+## Modes &amp; features
+
+- **40 channels**, 4 W **AM/FM** / **12 W PEP [SSB](/reference/single-sideband/)**
+  (USB/LSB), Part 95D certified.
+- **NOAA weather + alerts**, large LCD, **automatic SWR check**, ASC
+  automatic squelch, VOX.
+- Hi-cut / noise blanker / ANL filters, clarifier, RF power and mic gain.
+- Compact DIN-ish chassis, front-firing speaker, **12/24 V DC**.
+
+## GopherTrunk alternative
+
+The honest note we put on every CB page: **GopherTrunk doesn't decode CB, and
+we won't pretend it does.** CB is 27 MHz analog AM/FM/SSB — below an
+[RTL-SDR](/reference/rtl-sdr/)'s native tuning range without
+[direct sampling](/reference/direct-sampling/) or an
+[upconverter](/reference/upconverter/), and analog sideband voice is outside
+GopherTrunk's trunking/digital wheelhouse. To scout whether anyone near you
+runs SSB before spending McKinley money, an [HF-capable SDR](/best-hf-sdr/)
+is the right listening tool, and the 40-channel map is in our
+[scanner frequencies reference](/scanner-frequencies/). Talking back requires
+the transmitter.
+
+## Who it's for
+
+- **Buy the McKinley II** if you're a trucker or serious hobbyist who wants
+  the best current SSB mobile — the receiver, the noise blanker, and all
+  three modes justify the premium.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B0CGRZC8CX?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [Bearcat 980SSB](/reference/uniden-bearcat-980ssb/)** instead to
+  get SSB for ~$50 less with talkback — accepting the weaker display and
+  blanker — or the [Bearcat 880FM](/reference/uniden-bearcat-880/) if you
+  don't need sideband at all.
+- **Skip it** for a [29 LTD Classic](/reference/cobra-29-ltd-classic/) if
+  your world is AM on channel 19 and shop-serviceability matters more than
+  receive performance. Full rankings: [best CB radios](/best-cb-radios/).
+
+## Sources
+
+[^president]: [President McKinley USA product page](https://president-electronics.us/CB-Radios-Ham-Radios/AM-SSB-transceivers/MC-KINLEY-USA) — President Electronics USA, on AM/SSB (FM on the McKinley II FCC), 12 W PEP, 12/24 V supply, automatic SWR check, ASC, VOX, and filtering.

--- a/docs/reference/radioddity-db20-g.md
+++ b/docs/reference/radioddity-db20-g.md
@@ -1,0 +1,144 @@
+---
+slug: radioddity-db20-g
+title: Radioddity DB20-G
+entry_type: hardware
+category: two-way-radios
+description: "The Radioddity DB20-G is the budget king of GMRS mobiles — 20 watts, ~500 channels, split tones, wideband receive, and CHIRP support with a genuine Part 95E grant for around $110–130. A re-badged Anytone AT-779UV."
+keywords: Radioddity DB20-G, DB20-G review, cheap GMRS mobile radio, budget GMRS radio, 20 watt GMRS radio, GMRS repeater radio, gmrs license, Anytone AT-779UV, Retevis RA25, CHIRP GMRS mobile, best GMRS radio under 150, GMRS mobile for car
+aka: [DB20-G, Anytone AT-779UV, Retevis RA25]
+autolink: true
+affiliate: true
+product:
+  name: "Radioddity DB20-G"
+  brand: Radioddity
+  category: GMRS mobile radio
+  lowPrice: "110"
+  highPrice: "130"
+  url: https://www.amazon.com/dp/B096533TR6?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: "GMRS mobile radio (micro-mobile)" }
+  - { label: Service, value: "GMRS TX — ~500 memories; wideband VHF/UHF RX" }
+  - { label: Power, value: "20 W" }
+  - { label: Repeater, value: "Yes — 9+ repeater channels with split tones" }
+  - { label: License, value: "GMRS — $35 FCC, no test, covers family" }
+  - { label: Price, value: "around $110–130" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B096533TR6?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [wouxun-kg-xs20g, midland-mxt275, wouxun-kg-1000g-plus, btech-gmrs-50pro, baofeng-uv-5r, rtl-sdr]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "Best GMRS mobile & base radios", url: /best-gmrs-mobile-radios/ }
+cite_urls:
+  - https://www.radioddity.com/products/radioddity-db20g
+faq:
+  - q: "Do I need a license for the Radioddity DB20-G?"
+    a: "To transmit, yes — a GMRS license: $35 to the FCC, valid 10 years, no test, covering your immediate family. Its wide VHF/UHF coverage is receive/scan only, and listening requires no license."
+  - q: "Is the Radioddity DB20-G legal for GMRS?"
+    a: "Yes — it carries a genuine FCC Part 95E grant because transmit is locked to the GMRS channels. An unlock hack circulates online; using it voids the certification and makes transmissions illegal, so we don't recommend it."
+  - q: "Is the DB20-G the same radio as the Anytone AT-779UV?"
+    a: "Electrically, yes — FCC filings show the Radioddity DB20-G and Retevis RA25 are re-badged Anytone AT-779UV variants. If one is out of stock, the others are literally the same radio."
+  - q: "Does the DB20-G have NOAA weather alerts?"
+    a: "Not the standby-alert kind. You can program and scan the NOAA weather frequencies for listening, but there's no dedicated weather-alert function like the Midland and Wouxun radios have — verify against the manual if alerts matter to you."
+  - q: "Should I hardwire the DB20-G or use the cigarette-lighter plug?"
+    a: "It ships with a cigarette-lighter plug, which is convenient but voltage-sag-prone. For reliable full power on transmit, hardwire it to switched power or the battery."
+---
+**The Radioddity DB20-G** is the cheapest way into a real, repeater-capable,
+legally certified GMRS mobile: 20 watts, roughly 500 memory channels, split
+tones, wideband receive, and CHIRP support for around **$110–130** — often
+less with Radioddity's frequent coupons.[^radioddity] It's a re-badged
+**Anytone AT-779UV** (the Retevis RA25 is the same radio too), and it's tiny:
+the whole thing is barely bigger than its own display.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B096533TR6?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Our most-affordable pick — and not by a little.** 20 W, ~500 memories, 9+
+customizable repeater channels with **split tones**, 136–174/400–470 MHz
+receive/scan, **CHIRP support**, genuine **Part 95E grant**. Caveats: small
+speaker, fan noise, dense ham-style menus, no standby NOAA alert, and a
+cigarette-lighter power plug you should replace with hardwiring. **GMRS
+license to transmit: $35, 10 years, no test, covers your immediate family.**
+Rankings: [best GMRS mobile radios](/best-gmrs-mobile-radios/).
+</div>
+
+## Overview
+
+At a third the price of a 50-watt Midland, the DB20-G covers the core of what
+a GMRS mobile is for: talking simplex to your convoy and reliably working
+local repeaters, with programmable
+[CTCSS](/reference/ctcss/)/[DCS](/reference/dcs/) tones including the split
+tones many club machines require. On top of that it scans and receives
+136–174 and 400–470 MHz — receive-only, which is what keeps its FCC Part 95E
+grant legal. Be aware an unlock hack circulates online to open up transmit;
+using it voids the certification and puts you outside the rules, and we're
+not going to pretend otherwise.
+
+It's honest about what it is: a ham-radio-derived micro-mobile (the Anytone
+DNA shows in the dense menus) wearing a GMRS certification. That heritage cuts
+both ways, as below.
+
+**License note:** GMRS transmit requires a license — $35 to the
+[FCC](/reference/fcc/), valid 10 years, no exam, one license covering your
+immediate family. Listening and scanning need nothing.
+
+## Channels, power &amp; repeater use
+
+- **Power:** 20 W. Hardwire it — the included **cigarette-lighter plug** is
+  convenient but voltage-sag-prone, and sagging supply voltage costs you
+  transmit power.
+- **Memories:** ~500 channels, with 9+ customizable repeater channels and
+  **split tones**.
+- **Receive/scan:** 136–174 / 400–470 MHz.
+- **Weather:** no dedicated NOAA standby alert — you can program and scan the
+  weather frequencies, but there's no Midland/Wouxun-style alert function.
+  Verify against the manual if weather alerting is a must.
+- **Programming:** **CHIRP**, RT Systems, or Radioddity's CPS — the best
+  software story in the budget class.
+- **Antenna:** reported as an SO-239 pigtail on the back — verify the
+  connector on your unit before ordering mounts and
+  [feedline](/reference/coax-feedline/).
+
+## Where the money went (and didn't)
+
+The compromises are all livable but real. The **speaker is small and low** —
+in a loud vehicle you'll want the external-speaker jack. The **fan is
+audible**. The menu system is ham-clone dense; budget an evening with CHIRP
+and the manual rather than expecting Midland-style simplicity. And QC and
+support are thinner than Midland or Wouxun — Radioddity's support is
+responsive by budget-brand standards, but this is still an importer-backed
+radio, not a US-brand warranty program. None of that changes the headline:
+nothing else this cheap is repeater-capable, split-tone-capable,
+CHIRP-programmable, and certified. If the budget stretches, the
+[Wouxun KG-XS20G Plus](/reference/wouxun-kg-xs20g/) buys weather sealing and
+nicer build at the same 20 W, and the
+[KG-1000G Plus](/reference/wouxun-kg-1000g-plus/) buys 50 W and everything
+else.
+
+## GopherTrunk alternative
+
+FRS and GMRS are analog narrowband [FM](/reference/frequency-modulation/) at
+462/467 MHz — squarely in a ~$30 [RTL-SDR](/reference/rtl-sdr/)'s wheelhouse,
+and the dongle costs a quarter of even this radio. Free GopherTrunk monitors
+and records every local FRS/GMRS channel and repeater at once, so you can
+find out what's active near you — and whether the repeaters are worth the $35
+license — before buying anything that transmits. GopherTrunk is receive-only;
+pair it with the DB20-G rather than instead of it.
+[Download GopherTrunk](/downloads.html) and scout your area first.
+
+## Who it's for
+
+- **Buy the DB20-G** if you want the cheapest certified path to real GMRS —
+  first radio for a convoy, a second vehicle, or a budget repeater setup —
+  and you don't mind menus with a learning curve.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B096533TR6?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [Wouxun KG-XS20G Plus](/reference/wouxun-kg-xs20g/)** instead if
+  the radio will live in the weather — same power, IP65 sealing.
+- **Skip it** for the [Wouxun KG-1000G Plus](/reference/wouxun-kg-1000g-plus/)
+  or [Midland MXT575](/reference/midland-mxt575/) if you need 50 W for fringe
+  repeater work. Full rankings:
+  [best GMRS mobile radios](/best-gmrs-mobile-radios/).
+
+## Sources
+
+[^radioddity]: [Radioddity DB20-G product page](https://www.radioddity.com/products/radioddity-db20g) — Radioddity, on the 20 W output, ~500 channels, repeater/split-tone support, wideband receive/scan, programming options, and Part 95E certification.

--- a/docs/reference/rocky-talkie-5-watt.md
+++ b/docs/reference/rocky-talkie-5-watt.md
@@ -1,0 +1,136 @@
+---
+slug: rocky-talkie-5-watt
+title: Rocky Talkie Expedition Radio
+entry_type: hardware
+category: two-way-radios
+description: "The Rocky Talkie Expedition Radio (formerly the 5 Watt Radio) is a 5 W GMRS handheld with IP67 submersion, NOAA weather, repeater channels, and days of cold-rated battery — the best rugged consumer GMRS radio, around $165–180."
+keywords: Rocky Talkie Expedition Radio, Rocky Talkie 5 Watt Radio, Rocky Talkie 5 Watt review, Rocky Talkie Expedition review, best GMRS handheld, GMRS walkie talkie, GMRS license, gmrs license cost, waterproof walkie talkie, GMRS repeater radio, backcountry radio, best walkie talkie 2026
+aka: [Rocky Talkie 5 Watt Radio, Expedition Radio, Rocky Talkie 5 Watt]
+autolink: true
+affiliate: true
+product:
+  name: "Rocky Talkie Expedition Radio"
+  brand: Rocky Talkie
+  category: GMRS walkie-talkie (handheld)
+  lowPrice: "165"
+  highPrice: "360"
+  url: https://www.amazon.com/dp/B0F4Q8CYP4?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: Handheld GMRS walkie-talkie }
+  - { label: Service, value: "GMRS (FCC Part 95E)" }
+  - { label: Channels, value: "22 GMRS + 8 repeater channels, 121 privacy codes" }
+  - { label: Power, value: "5 W (GMRS handheld max)" }
+  - { label: License, value: "GMRS — $35 FCC, 10 years, no test" }
+  - { label: Price, value: "around $165–180/radio" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B0F4Q8CYP4?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [rocky-talkie-mountain-radio, btech-gmrs-pro, wouxun-kg-935g, baofeng-uv-5g-plus, midland-mxt575, rtl-sdr]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "The 10 best walkie-talkies", url: /best-walkie-talkies/ }
+cite_urls:
+  - https://rockytalkie.com/products/expedition-radio
+faq:
+  - q: "Is the Rocky Talkie Expedition Radio the same as the 5 Watt Radio?"
+    a: "Yes — Rocky Talkie renamed its 5 Watt Radio line the Expedition Radio. Same product family: 5 W GMRS, IP67 waterproofing, NOAA weather, repeater channels. If a review or listing says 'Rocky Talkie 5 Watt,' this is the current version of that radio."
+  - q: "Do I need a license for the Rocky Talkie Expedition Radio?"
+    a: "To transmit, yes — it's a GMRS radio, so you need the FCC's GMRS license: $35, valid 10 years, no test, and one license covers your immediate family. Listening requires no license. The license-free alternative is Rocky Talkie's own FRS Mountain Radio."
+  - q: "Is the Rocky Talkie Expedition Radio waterproof?"
+    a: "Yes, genuinely — IP67, rated for 1 m submersion, and Rocky Talkie says every unit is individually tested. That's a real step up from the splash-resistant Mountain Radio and from most consumer GMRS radios."
+  - q: "Can the Expedition Radio use GMRS repeaters?"
+    a: "Yes. It includes the 8 GMRS repeater channels, which transmit on the 467 MHz inputs and listen on 462 MHz — the single biggest range multiplier in consumer radio if your area has an open repeater. Check what's active locally before assuming coverage."
+  - q: "What's the range of the Rocky Talkie Expedition Radio?"
+    a: "Terrain decides: expect roughly 1–3 miles in forested or rolling ground, much more with elevation or true line of sight, and tens of miles through a well-sited GMRS repeater. 5 W helps at the margins, but no handheld beats the terrain between you."
+---
+**The Rocky Talkie Expedition Radio** — Rocky Talkie renamed its **5 Watt
+Radio**; this is the same product line under its current name — is the rugged
+one to beat in consumer GMRS: **5 W**, all **8 repeater channels**, NOAA
+weather, and an **IP67** body Rocky Talkie submersion-tests individually,
+wrapped in the same shatterproof-screen, carabiner-and-leash format that made
+the [Mountain Radio](/reference/rocky-talkie-mountain-radio/) a backcountry
+staple.[^rt] Figure **around $165–180 per radio**, plus the $35 GMRS license.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0F4Q8CYP4?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Our best-overall walkie-talkie.** Formerly the **5 Watt Radio**, now the
+**Expedition Radio** — search either name, same radio. **5 W GMRS with
+repeater access**, **IP67** (1 m submersion), **NOAA weather**, 4–6 day
+cold-rated USB-C battery. **Transmitting needs the GMRS license: $35 to the
+FCC, 10 years, no test, covers your immediate family.** Pricier than a
+feature-stuffed [Wouxun](/reference/wouxun-kg-935g/) or Baofeng — you're paying
+for build. Rankings: [best walkie-talkies](/best-walkie-talkies/).
+</div>
+
+## Overview
+
+Where the Mountain Radio is deliberately minimal FRS, the Expedition Radio is
+Rocky Talkie's **Part 95E-certified GMRS** flagship — which changes three
+things that matter. Power rises to the 5 W handheld legal max. The 8 GMRS
+**repeater channels** appear, so one well-placed repeater can carry your group
+across a valley system no simplex handheld could. And NOAA weather channels
+come along for storm planning. The cost of entry is the GMRS license:
+**$35 to the FCC, good for 10 years, no test**, and it covers your immediate
+family — one license, every radio in the household.
+
+The hardware is the pitch. **IP67** means survives-a-creek-dunking, not
+survives-drizzle, and Rocky Talkie says each unit is individually tested at
+1 m. The 1800 mAh Li-ion pack is cold-rated at 4–6 days of typical use and
+charges over USB-C; the screen is shatterproof LED; the armor, carabiner, and
+backup leash carry over from the Mountain Radio. What it deliberately isn't:
+a tinkerer's radio. There's no keypad, no CHIRP support, and channel setup
+happens on-radio with dual-channel monitoring and 121 privacy codes — Rocky
+Talkie's bet is that a guide, patroller, or family wants repeater capability
+*without* a Baofeng menu tree, and the market has largely agreed.
+
+## Channels, power &amp; battery
+
+- **Service:** GMRS, FCC Part 95E certified — **license required to
+  transmit** ($35/10 yr/no test); listening is license-free.
+- **Power:** 5 W max — the GMRS handheld ceiling.
+- **Channels:** 22 GMRS channels + **8 repeater channels**, 121
+  [CTCSS/DCS privacy codes](/reference/ctcss/) (squelch tones, not
+  encryption), dual-channel monitoring.
+- **Weather:** NOAA weather channels.
+- **Battery:** 1800 mAh Li-ion, 4–6 days claimed, cold-rated, **USB-C**.
+- **Durability:** **IP67** (1 m submersion, individually tested),
+  shatterproof LED screen, rubber armor, carabiner + leash.
+- **Interoperability:** talks to any FRS or GMRS radio on the 22 shared
+  channels — your license-free
+  [Mountain Radio](/reference/rocky-talkie-mountain-radio/) partners included.
+
+Against the spec-sheet competition it's honestly outgunned: a
+[Wouxun KG-935G](/reference/wouxun-kg-935g/) has a keypad, 999 channels, and
+5.5 W for similar money, and a [BTECH GMRS-PRO](/reference/btech-gmrs-pro/)
+adds GPS and texting for less. None of them match the Expedition's
+waterproofing, cold battery, or gloves-on simplicity — pick your priority.
+
+## GopherTrunk alternative
+
+Before you spend $35 on the license and $350 on a pair, find out what GMRS
+looks like where you live. FRS/GMRS is analog narrowband FM at 462/467 MHz,
+and a ~$30 [RTL-SDR](/reference/rtl-sdr/) running free GopherTrunk monitors
+and **records** all of it — including whether that local GMRS repeater you're
+counting on actually carries traffic. Scouting the band first is the cheapest
+buying decision you'll make. GopherTrunk cannot transmit, so it complements
+the radios rather than replacing them; the receive-only path starts at
+[Learn RF &amp; SDR](/learn/rf-sdr/).
+
+## Who it's for
+
+- **Buy the Expedition Radio** if you want the best-built GMRS handheld for
+  mountains, water, and weather — and simple enough to hand to anyone in the
+  family your license covers.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B0F4Q8CYP4?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [Mountain Radio](/reference/rocky-talkie-mountain-radio/)**
+  instead if you want the same build license-free and don't need repeaters,
+  weather, or submersion.
+- **Skip it** for a [BTECH GMRS-PRO](/reference/btech-gmrs-pro/) (GPS +
+  texting, ~$150) or [Wouxun KG-935G](/reference/wouxun-kg-935g/) (power-user
+  UX) if features-per-dollar outrank ruggedness. Full rankings:
+  [best walkie-talkies](/best-walkie-talkies/).
+
+## Sources
+
+[^rt]: [Rocky Talkie Expedition Radio product page](https://rockytalkie.com/products/expedition-radio) — Rocky Talkie, on the renamed 5 Watt line, GMRS certification, 5 W output, repeater channels, IP67 individual testing, NOAA weather, and battery ratings.

--- a/docs/reference/rocky-talkie-mountain-radio.md
+++ b/docs/reference/rocky-talkie-mountain-radio.md
@@ -1,0 +1,133 @@
+---
+slug: rocky-talkie-mountain-radio
+title: Rocky Talkie Mountain Radio
+entry_type: hardware
+category: two-way-radios
+description: "The Rocky Talkie Mountain Radio is a license-free 2 W FRS walkie-talkie built for climbing and backcountry skiing — outstanding cold-weather battery life, shatterproof screen, carabiner leash system, USB-C — at a premium ~$110 per radio."
+keywords: Rocky Talkie Mountain Radio, Rocky Talkie review, Rocky Talkie Mountain Radio review, best FRS radio, FRS walkie talkie, license free walkie talkie, climbing radio, backcountry ski radio, walkie talkie for skiing, FRS vs GMRS, do I need a license for FRS, walkie talkie range
+aka: [Mountain Radio, Rocky Talkie FRS]
+autolink: true
+affiliate: true
+product:
+  name: "Rocky Talkie Mountain Radio"
+  brand: Rocky Talkie
+  category: FRS walkie-talkie (handheld)
+  lowPrice: "110"
+  highPrice: "220"
+  url: https://www.amazon.com/dp/B0F4PYGJHQ?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: Handheld FRS walkie-talkie }
+  - { label: Service, value: "FRS (FCC Part 95B)" }
+  - { label: Channels, value: "22 FRS channels + privacy tones" }
+  - { label: Power, value: "2 W (FRS legal max); fixed antenna" }
+  - { label: License, value: "None (FRS — license-free)" }
+  - { label: Price, value: "around $110/radio (~$220 2-pack)" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B0F4PYGJHQ?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [rocky-talkie-5-watt, motorola-talkabout-t800, midland-gxt1000vp4, btech-gmrs-pro, rtl-sdr, ctcss]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "The 10 best walkie-talkies", url: /best-walkie-talkies/ }
+cite_urls:
+  - https://rockytalkie.com/products/mountain-radio
+  - https://www.outdoorgearlab.com/reviews/camping-and-hiking/walkie-talkies/rocky-talkie-mountain-radio
+faq:
+  - q: "Do I need a license for the Rocky Talkie Mountain Radio?"
+    a: "No. It's an FRS radio, certified under FCC Part 95B, which is license-free for anyone in the US (and license-free in Canada too). Turn it on and talk. Only its GMRS sibling, the Expedition Radio, requires the $35 GMRS license."
+  - q: "What's the real range of the Rocky Talkie Mountain Radio?"
+    a: "Ridge-to-ridge line of sight can genuinely run many miles, which is where '35+ mile' style marketing comes from. Terrestrially, expect roughly half a mile to two miles in forest or rolling terrain, and more when one party is high above the other — physics, not build quality, sets FRS range."
+  - q: "Is the Rocky Talkie Mountain Radio waterproof?"
+    a: "It's splash- and snow-resistant (Rocky Talkie cites an IP56-class rating), which handles storms and dropped-in-snow abuse. It is not submersible — for a dunk-proof IP67 body you want the Expedition Radio."
+  - q: "Does the Mountain Radio have NOAA weather channels?"
+    a: "No — NOAA weather receive is reserved for Rocky Talkie's GMRS Expedition Radio. The Mountain Radio keeps to the 22 FRS channels with privacy tones, by design a simpler, license-free tool."
+  - q: "Is the Rocky Talkie Mountain Radio worth $110?"
+    a: "For climbers and backcountry skiers, usually yes: the cold-rated 3–5 day battery, shatterproof screen, and carabiner/leash attachment survive use that kills blister-pack radios. For campground or neighborhood use, a ~$35 Baofeng GM-15 Pro or a Midland pair does the job for far less."
+---
+**The Rocky Talkie Mountain Radio** is what happens when climbers, not a
+consumer-electronics division, design a walkie-talkie: a license-free **2 W FRS**
+handheld with a cold-rated 3–5 day battery, a shatterproof LED screen, thermoplastic
+armor, and a carabiner-plus-leash attachment system that keeps it on your harness
+instead of at the bottom of a couloir.[^rt] At **around $110 per radio** it is
+easily the most expensive way to buy 2 watts — and for mountain use, the money is
+in exactly the right places.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0F4PYGJHQ?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The best license-free radio for the mountains.** FRS under FCC Part 95B —
+**no license, ever**, for anyone in the US. **2 W** (the FRS legal maximum),
+fixed antenna, USB-C charging, and battery life measured in **days, in the
+cold**. What you give up: **no NOAA weather, no repeaters**, and FRS-physics
+range regardless of the marketing. **~$110/radio.** Where it ranks:
+[best walkie-talkies](/best-walkie-talkies/).
+</div>
+
+## Overview
+
+Rocky Talkie sells two radios; this is the simple one. The Mountain Radio is
+certified under **FCC Part 95B (FRS)**, which means anyone can transmit with it,
+no paperwork — the 2017 FCC rules that raised FRS to 2 W are the reason a modern
+FRS radio like this is dramatically more capable than the old blister-pack
+half-watt sets. Its **fixed antenna and 2 W ceiling are legal requirements** of
+the service, not corner-cutting.
+
+The design brief is obvious in hand: two buttons and a dial you can run in
+gloves, a screen that shrugs off rock strikes, a Li-ion pack that Rocky Talkie
+rates at 3–5 days even in freezing temperatures, and the signature carabiner
+with a backup leash. Reviewers at OutdoorGearLab and the climbing community
+consistently land on the same verdict — nothing survives real alpine use
+better.[^ogl] The trade: it's **feature-light**. No NOAA weather receive (that
+lives on the [Expedition Radio](/reference/rocky-talkie-5-watt/)), no repeater
+capability (FRS never has it), no keypad, no CHIRP or computer programming —
+it's a locked consumer FRS radio, deliberately.
+
+## Channels, power &amp; battery
+
+- **Service:** FRS, Part 95B — license-free in the US and Canada.
+- **Power:** 2 W max on channels 1–7 and 15–22; FRS rules cap channels 8–14 at
+  0.5 W for every radio.
+- **Channels:** the 22 shared FRS/GMRS channels with [CTCSS/DCS privacy
+  tones](/reference/ctcss/) — squelch filters, not encryption.
+- **Interoperability:** talks directly to any FRS or GMRS radio on channels
+  1–22, including GMRS handhelds like the
+  [BTECH GMRS-PRO](/reference/btech-gmrs-pro/).
+- **Battery:** Li-ion, 3–5 days claimed in cold conditions, charged over
+  **USB-C** — the same cable as your headlamp and phone.
+- **Durability:** splash/snow-resistant (IP56-class per Rocky Talkie — not
+  submersible), shatterproof screen, functional from a harness in gloves.
+
+Range honesty, because Rocky Talkie's own "35+ mile" line-of-sight figure needs
+context: that's summit-to-summit. In trees, drainages, or town, plan on **0.5–2
+miles**, stretching to several when you hold elevation over your partner. Every
+FRS radio obeys the same physics; this one just keeps working at −20 °C.
+
+## GopherTrunk alternative
+
+FRS and GMRS are analog narrowband FM at 462/467 MHz — squarely inside a cheap
+SDR's range. A ~$30 [RTL-SDR](/reference/rtl-sdr/) running free GopherTrunk
+will monitor and **record** every FRS/GMRS channel in your area at once, so you
+can hear how busy the shared channels are around your trailhead or resort
+before you buy radios — and log traffic while you're out. What it can't do is
+transmit: GopherTrunk is a receive-only complement to a radio like this, never
+a replacement. If you're new to the listening side, start with
+[Learn RF &amp; SDR](/learn/rf-sdr/).
+
+## Who it's for
+
+- **Buy the Mountain Radio** if you climb, ski, or hunt in real weather and
+  want the toughest license-free radio made — and you'd rather pay for battery
+  and build than for features.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B0F4PYGJHQ?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [Rocky Talkie Expedition Radio](/reference/rocky-talkie-5-watt/)**
+  instead for 5 W, NOAA weather, IP67 submersion, and repeater access — once
+  you have the $35 GMRS license.
+- **Skip it** if the radios live in a glovebox: a
+  [Midland GXT1000VP4](/reference/midland-gxt1000vp4/) pair or a
+  [Baofeng GM-15 Pro](/reference/baofeng-gm-15-pro/) costs a third as much.
+  Full rankings: [best walkie-talkies](/best-walkie-talkies/).
+
+## Sources
+
+[^rt]: [Rocky Talkie Mountain Radio product page](https://rockytalkie.com/products/mountain-radio) — Rocky Talkie, on FRS certification, 2 W output, battery ratings, USB-C charging, and the carabiner/leash attachment system.
+[^ogl]: [Rocky Talkie Mountain Radio review — OutdoorGearLab](https://www.outdoorgearlab.com/reviews/camping-and-hiking/walkie-talkies/rocky-talkie-mountain-radio) — independent field testing of durability, cold-weather battery life, and real-world range.

--- a/docs/reference/uniden-bearcat-880.md
+++ b/docs/reference/uniden-bearcat-880.md
@@ -1,0 +1,136 @@
+---
+slug: uniden-bearcat-880
+title: Uniden Bearcat 880FM
+entry_type: hardware
+category: two-way-radios
+description: "The Uniden Bearcat 880FM is our best-overall CB radio — AM/FM dual mode, NOAA weather with alerts, a 7-color display, and a built-in SWR calibration meter that makes first-time installs easy, for around $130–150. It supersedes the AM-only Bearcat 880."
+keywords: Uniden Bearcat 880FM, Bearcat 880 review, Uniden Bearcat 880, best CB radio 2026, best CB radio overall, AM FM CB radio, CB radio with SWR meter, CB radio weather channels, Bearcat 880 vs Cobra 29, CB radio no license, off-road CB radio
+aka: [Bearcat 880, Bearcat 880FM, BC880]
+autolink: true
+affiliate: true
+product:
+  name: "Uniden Bearcat 880FM"
+  brand: Uniden
+  category: CB radio (mid-size mobile)
+  lowPrice: "130"
+  highPrice: "150"
+  url: https://www.amazon.com/dp/B0C8QDQMKK?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: Mid-size mobile CB }
+  - { label: Service, value: "CB — 40 channels, 26.965–27.405 MHz" }
+  - { label: Modes, value: "AM/FM" }
+  - { label: Power, value: "4 W (legal max), 12 V DC" }
+  - { label: Extras, value: "NOAA weather + alerts, SWR meter, 7-color display, talkback, PA" }
+  - { label: License, value: "None (CB) — licensed by rule, Part 95D" }
+  - { label: Price, value: around $130–150 }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B0C8QDQMKK?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [uniden-bearcat-980ssb, cobra-29-lx, cobra-29-ltd-classic, president-mckinley, uniden-pro505xl, rtl-sdr]
+related_reading:
+  - { title: "The 10 best CB radios", url: /best-cb-radios/ }
+  - { title: "Scanner frequencies (incl. CB channels)", url: /scanner-frequencies/ }
+cite_urls:
+  - https://uniden.com/products/bearcat-880fm
+  - https://uniden.com/products/bearcat-880
+faq:
+  - q: "Do I need a license for the Uniden Bearcat 880FM?"
+    a: "No. CB is license-free by rule under FCC Part 95D — no exam, no fee. Legal power is 4 watts carrier on AM and FM, and the 880FM is certified to that limit."
+  - q: "What's the difference between the Bearcat 880 and the Bearcat 880FM?"
+    a: "The 880FM is the direct successor: same mid-size chassis and feature set — weather, 7-color display, SWR metering — plus FM transmit and receive, legal on CB since 2021. The original AM-only 880 is drying up in the retail channel and remaining old stock is often priced erratically; buy the 880FM."
+  - q: "Does the Bearcat 880FM have a built-in SWR meter?"
+    a: "Yes — an antenna SWR calibration meter is built in, which is the feature that makes it the easiest first CB install in its class. You tune your antenna against the radio's own meter instead of buying and wiring a separate SWR meter."
+  - q: "Is the Bearcat 880FM good for off-roading?"
+    a: "It's our default pick for off-roaders and RVers: mid-size (though deeper than photos suggest — measure your mount), a bright 7-color display readable at a glance, weather alerts, and the built-in SWR meter for trail-side antenna checks. Budget for an external speaker; the internal one is mediocre."
+  - q: "Does the Bearcat 880FM have SSB?"
+    a: "No — AM and FM only. If you want SSB's 12 W PEP and longer range, step to the Uniden Bearcat 980SSB or the President McKinley II, and remember SSB only helps when the station on the other end has it too."
+---
+**The Uniden Bearcat 880FM** is our **best-overall CB radio**: AM/FM dual
+mode, **NOAA weather with alerts**, the best display and backlighting in its
+class, and — the killer feature for first-timers — a **built-in SWR antenna
+calibration meter** that turns the hardest part of any CB install into a
+two-minute job.[^uniden880fm] It's the direct successor to the AM-only
+Bearcat 880, which it supersedes,[^uniden880] and it streets around
+**$130–150**.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0C8QDQMKK?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Best overall CB for most people.** Strong receiver for an AM/FM rig, NOAA
+weather + alerts, 7-color LCD with backlit knobs, talkback, noise-canceling
+mic, and **built-in SWR metering** — the easiest install in the class.
+**Buy the 880FM, not the old 880** — the AM-only original is superseded and
+leftover stock is priced erratically. **No SSB** — that's the
+[980SSB](/reference/uniden-bearcat-980ssb/)'s job. **License-free**
+(Part 95D). **~$130–150.** Full rankings: [best CB radios](/best-cb-radios/).
+</div>
+
+## Overview
+
+Most CB radios are designed for people who already own three of them. The
+Bearcat 880FM is designed for the person installing their first one — and
+that's why it wins our top slot. The **7-color selectable LCD with backlit
+knobs and buttons** is the most readable front panel in the class. **NOAA
+weather with alerts** covers the road-trip case. And the built-in **SWR
+calibration meter** means the step everyone skips — tuning the antenna, which
+matters more than the radio itself
+([why](/reference/standing-wave-ratio/)) — happens right on the front panel,
+no separate meter, no borrowed gear.
+
+It also isn't just a pretty face: the receiver is strong for an AM-class rig,
+and you get RF gain, mic gain, **talkback**, a noise-canceling mic,
+wireless-mic compatibility, and PA output.
+
+**On the 880 vs 880FM:** the original AM-only Bearcat 880 has been
+**superseded**. Dealers are marking it unavailable, and lingering old stock
+shows up at silly prices (we've seen $259 — old-MSRP inflation, not a signal
+of value). The 880FM is the same class and feature set plus FM, at the normal
+price. There is no reason to seek out the non-FM original.
+
+**License note:** none. CB is licensed by rule (FCC Part 95D) — 4 W carrier
+on AM/FM, no paperwork, ever. FM on CB has been legal since the FCC's 2021
+rule update.
+
+## Modes &amp; features
+
+- **40 channels**, 4 W **AM/FM**, Part 95D certified, 12 V DC.
+- **NOAA weather channels with alert wake-up.**
+- **Built-in SWR calibration meter** plus radio diagnostics.
+- 7-color LCD, backlit controls, RF gain + mic gain, talkback,
+  noise-canceling mic, wireless-mic compatible, PA.
+- Mid-size chassis — but **deeper than photos suggest**; measure your dash
+  cavity before ordering.
+
+Honest weaknesses: the **internal speaker is mediocre** — nearly everyone ends
+up adding an external speaker; and there are long-term owner reports of
+display burnout on Uniden's 7-color screens. Neither moves it off the top
+spot at this price.
+
+## GopherTrunk alternative
+
+Straight talk: **GopherTrunk doesn't do CB.** CB is 27 MHz analog
+[AM](/reference/amplitude-modulation/)/[FM](/reference/frequency-modulation/)/SSB —
+below an [RTL-SDR](/reference/rtl-sdr/)'s native tuning range without
+direct-sampling tricks or an [upconverter](/reference/upconverter/), and
+analog voice at 27 MHz is outside GopherTrunk's trunking/digital focus. If you
+only want to *listen* first, a scanner with CB coverage or an
+[HF-capable SDR](/best-hf-sdr/) will hear channel 19; the full CB channel
+list is in our [scanner frequencies reference](/scanner-frequencies/). To key
+up, you need the real radio.
+
+## Who it's for
+
+- **Buy the Bearcat 880FM** if you want the best all-around CB for truck,
+  Jeep, or RV — the easiest install, the best display, weather alerts, and
+  AM/FM for ~$140.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B0C8QDQMKK?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [Bearcat 980SSB](/reference/uniden-bearcat-980ssb/)** or
+  [President McKinley II](/reference/president-mckinley/) instead if you want
+  SSB's 12 W PEP range, or the [Cobra 29 LTD](/reference/cobra-29-ltd-classic/)
+  if you want the traditional trucker platform every shop can service.
+- **Skip it** for a [PRO505XL](/reference/uniden-pro505xl/) if you just need a
+  cheap trail beater. Full rankings: [best CB radios](/best-cb-radios/).
+
+## Sources
+
+[^uniden880fm]: [Uniden Bearcat 880FM product page](https://uniden.com/products/bearcat-880fm) — Uniden America, on AM/FM dual mode, NOAA weather with alerts, the 7-color display, SWR calibration meter, talkback, and wireless-mic compatibility.
+[^uniden880]: [Uniden Bearcat 880 product page](https://uniden.com/products/bearcat-880) — the original AM-only model the 880FM supersedes.

--- a/docs/reference/uniden-bearcat-980ssb.md
+++ b/docs/reference/uniden-bearcat-980ssb.md
@@ -1,0 +1,132 @@
+---
+slug: uniden-bearcat-980ssb
+title: Uniden Bearcat 980SSB
+entry_type: hardware
+category: two-way-radios
+description: "The Uniden Bearcat 980SSB is the cheapest route into SSB CB from a mainstream brand — 4 W AM plus 12 W PEP sideband, NOAA weather, SWR calibration and talkback for around $150–210. Its weak spot: a display that washes out in sunlight."
+keywords: Uniden Bearcat 980SSB, Bearcat 980SSB review, best SSB CB radio, cheap SSB CB radio, CB radio with sideband, 12 watt SSB CB, Bearcat 980 vs President McKinley, CB radio license free, CB SSB range, AM SSB CB radio
+aka: [Bearcat 980, 980SSB, BC980SSB]
+autolink: true
+affiliate: true
+product:
+  name: "Uniden Bearcat 980SSB"
+  brand: Uniden
+  category: CB radio (full-size mobile, AM/SSB)
+  lowPrice: "150"
+  highPrice: "210"
+  url: https://www.amazon.com/dp/B007B5ZAES?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: Full-size mobile CB }
+  - { label: Service, value: "CB — 40 channels, 26.965–27.405 MHz" }
+  - { label: Modes, value: "AM/SSB (USB/LSB) — no FM" }
+  - { label: Power, value: "4 W AM / 12 W PEP SSB (legal max), 12 V DC" }
+  - { label: Extras, value: "NOAA weather + alerts, SWR calibration, clarifier, talkback, PA" }
+  - { label: License, value: "None (CB) — licensed by rule, Part 95D" }
+  - { label: Price, value: around $150–210 (spread varies widely) }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B007B5ZAES?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [president-mckinley, uniden-bearcat-880, uniden-grant-xl, cobra-2000-gtl, single-sideband, rtl-sdr]
+related_reading:
+  - { title: "The 10 best CB radios", url: /best-cb-radios/ }
+  - { title: "Best HF SDRs (to listen on 27 MHz)", url: /best-hf-sdr/ }
+cite_urls:
+  - https://uniden.com/products/bearcat-980ssb
+faq:
+  - q: "Do I need a license for the Uniden Bearcat 980SSB?"
+    a: "No — CB is licensed by rule under FCC Part 95D, no exam or fee. The legal limits the 980SSB is built to are 4 watts carrier on AM and 12 watts PEP on single sideband."
+  - q: "What does SSB get you on a CB radio?"
+    a: "Range. SSB concentrates the legal 12 W PEP into a narrower signal, so station-to-station distance can be double or more what 4 W AM manages. The catch: the radio on the other end must also have SSB and be on the same sideband — SSB-to-AM doesn't work. Most trucker traffic on channel 19 remains AM."
+  - q: "Is the Bearcat 980SSB better than the President McKinley II?"
+    a: "It's cheaper; the McKinley II is better. Owner consensus puts the McKinley's receiver and noise blanker ahead, its display stays readable in sunlight where the 980SSB's washes out, and it adds FM. The 980SSB counters with talkback, trucker-friendly features, and a lower typical price."
+  - q: "Does the Bearcat 980SSB do FM?"
+    a: "No — it's AM/SSB only. Uniden never issued an FM refresh of the 980. If FM matters, the Bearcat 880FM (no SSB) or President McKinley II (AM/FM/SSB) are the current options."
+  - q: "What's the clarifier on the Bearcat 980SSB for?"
+    a: "Fine-tuning received SSB voices. Sideband has no carrier for the radio to lock to, so a station a few hertz off sounds like a duck until you trim the clarifier. It only affects receive on a stock, legal radio."
+---
+**The Uniden Bearcat 980SSB** is the cheapest route into
+[single sideband](/reference/single-sideband/) CB from a mainstream brand:
+**4 W AM plus 12 W PEP SSB**, NOAA weather with alerts, SWR calibration,
+talkback, and Uniden's 7-color display, typically around
+**$150–210** — pricing on this model is unusually spread across retailers, so
+shop around.[^uniden] Its one famous flaw: that display is nearly unreadable
+in direct sunlight.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B007B5ZAES?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Cheapest mainstream ticket to SSB range.** 12 W PEP sideband is the legal
+range king on CB — but only when both ends have SSB. Feature-dense: NOAA
+weather + alerts, SWR calibration, clarifier, talkback, noise-canceling mic.
+**Weaknesses:** display washes out in sunlight (the
+[McKinley II](/reference/president-mckinley/) is readable), weaker noise
+blanker, internal speaker near-useless. **No FM.** **License-free**
+(Part 95D). **~$150–210.** Full rankings: [best CB radios](/best-cb-radios/).
+</div>
+
+## Overview
+
+Everything else in the current mainstream CB lineup tops out at 4 watts of
+AM or FM. The 980SSB and the President McKinley II are the two rigs that
+unlock CB's legal high ground — **12 W PEP on
+[single sideband](/reference/single-sideband/)** — and the 980SSB is the
+cheaper of the pair. When conditions cooperate, SSB roughly doubles your
+station-to-station range over AM. The honest caveat that belongs in every SSB
+pitch: **it takes SSB on both ends.** Channel 19 trucker traffic is AM; SSB
+is for hobbyists, base-to-mobile pairs, and groups who standardize on it
+(channels 36–40 LSB by convention).
+
+Around the sideband core, Uniden packed the trucker feature list: **NOAA
+weather with alerts**, built-in **SWR calibration**, RF and mic gain,
+**talkback**, a clarifier for tuning in SSB voices, noise-canceling mic,
+wireless-mic compatibility, and PA. On paper it's the most feature-dense
+radio in the class.
+
+The catches are real, and they're why it isn't our SSB pick. The most-cited
+owner complaint: the **display washes out in direct sunlight and off-axis** —
+a genuine problem in the exact dash-top spot most people mount a CB. The
+noise blanker trails the McKinley's, early production had QC grumbles, and
+the internal speaker is weak enough that an external speaker is
+near-mandatory. One more flag: Uniden has been thinning its CB line (the 880
+went to 880FM, the [PRO505XL](/reference/uniden-pro505xl/) is
+dealer-reported discontinued), so verify stock when you shop.
+
+**License note:** none needed — CB is licensed by rule (Part 95D). 4 W AM /
+12 W PEP SSB are the legal ceilings; there's no FM here (that 2021-legalized
+mode never came to the 980).
+
+## Modes &amp; features
+
+- **40 channels**, 4 W AM / **12 W PEP SSB (USB/LSB)**, Part 95D certified.
+- **NOAA weather + alerts**, 7-color display, SWR calibration.
+- Clarifier, RF gain + mic gain, talkback, noise-canceling mic,
+  wireless-mic compatible, PA. Full-size chassis, 12 V DC.
+
+## GopherTrunk alternative
+
+Being honest about our own software: **GopherTrunk is the wrong tool for
+CB.** It's built for trunked and digital systems; CB is 27 MHz analog
+AM/[SSB](/reference/single-sideband/), below an
+[RTL-SDR](/reference/rtl-sdr/)'s native range without direct sampling or an
+[upconverter](/reference/upconverter/). If you want to hear whether anyone
+around you even runs SSB before spending $200 — a fair question — an
+[HF-capable SDR](/best-hf-sdr/) with general SSB software will demodulate
+27 MHz sideband, and our
+[scanner frequencies reference](/scanner-frequencies/) lists all 40 channels.
+GopherTrunk won't decode CB, and we won't pretend otherwise.
+
+## Who it's for
+
+- **Buy the 980SSB** if you want SSB range at the lowest mainstream price and
+  you can mount it low or shaded where the display stays readable.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B007B5ZAES?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [President McKinley II](/reference/president-mckinley/)** instead
+  if you can spend more — better receiver, better noise blanker,
+  sunlight-readable display, and FM on top of AM/SSB.
+- **Skip SSB entirely** if your traffic is channel 19 and trail comms — the
+  [Bearcat 880FM](/reference/uniden-bearcat-880/) is the better everyday rig.
+  Vintage-minded? The [Grant XL](/reference/uniden-grant-xl/) is the classic
+  used SSB mobile. Full rankings: [best CB radios](/best-cb-radios/).
+
+## Sources
+
+[^uniden]: [Uniden Bearcat 980SSB product page](https://uniden.com/products/bearcat-980ssb) — Uniden America, on AM/SSB modes, 12 W PEP sideband, NOAA weather with alerts, SWR calibration, clarifier, and talkback.

--- a/docs/reference/uniden-grant-xl.md
+++ b/docs/reference/uniden-grant-xl.md
@@ -1,0 +1,148 @@
+---
+slug: uniden-grant-xl
+title: Uniden Grant XL
+entry_type: hardware
+category: two-way-radios
+description: "The Uniden Grant XL is the classic AM/SSB mobile CB — 1990s Uniden build quality, superb transmit audio, and every CB shop knows it. Used market only at roughly $50–250 depending on condition and mods; check the clarifier before you pay."
+keywords: Uniden Grant XL, Uniden Grant XL for sale, Grant XL review, vintage SSB CB radio, classic CB radio, AM SSB mobile CB, Grant XL clarifier mod, used CB radio buying guide, best used CB radio, cheap SSB CB
+aka: [Grant XL, Uniden Grant]
+autolink: true
+affiliate: true
+product:
+  name: "Uniden Grant XL"
+  brand: Uniden
+  category: CB radio (vintage AM/SSB mobile)
+  seller: eBay
+  itemCondition: used
+  lowPrice: "50"
+  highPrice: "250"
+  url: "https://www.ebay.com/sch/i.html?_nkw=Uniden+Grant+XL"
+infobox:
+  - { label: Type, value: "Vintage AM/SSB mobile CB" }
+  - { label: Service, value: "CB — 40 channels, 26.965–27.405 MHz" }
+  - { label: Modes, value: "AM/SSB (USB/LSB) — no FM, no weather" }
+  - { label: Power, value: "4 W AM / 12 W PEP SSB, 12 V DC" }
+  - { label: Extras, value: "Analog meter, clarifier, RF gain, ANL, PA" }
+  - { label: License, value: "None (CB) — licensed by rule, Part 95D" }
+  - { label: Price, value: "around $50–250 used (condition and mods swing it — thin data)" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.ebay.com/sch/i.html?_nkw=Uniden+Grant+XL\" rel=\"nofollow noopener\">Find on eBay &rarr;</a>" }
+see_also: [cobra-2000-gtl, uniden-bearcat-980ssb, president-mckinley, cobra-29-ltd-classic, single-sideband, rtl-sdr]
+related_reading:
+  - { title: "The 10 best CB radios", url: /best-cb-radios/ }
+  - { title: "Best HF SDRs (to listen on 27 MHz)", url: /best-hf-sdr/ }
+cite_urls:
+  - https://www.rigpix.com/cbfreeband/uniden_grantxl.htm
+  - https://www.cbradioclub.com/mobile-reviews/91-uniden-grant-xl.html
+faq:
+  - q: "How much should I pay for a Uniden Grant XL?"
+    a: "Typical eBay range is about $50–150 for working examples, with clean, serviced, or new-old-stock units pushing $150–250. The data is thin and the cult reputation has inflated asks — condition and modifications swing prices hard, so judge each listing on service history, not the model name."
+  - q: "Why was the Uniden Grant XL discontinued?"
+    a: "Production ended in the late 1990s. Per Uniden by way of the owner community, the semiconductors it was built on stopped being made and SSB demand didn't justify a redesign — so there was never a Grant XL II. That scarcity is a big part of the cult reputation."
+  - q: "What is the Grant XL clarifier mod and should I care?"
+    a: "The single biggest thing to check on a used unit. A large fraction have been modified to unlock the clarifier so it slides transmit frequency as well as receive — look for a jumper replacing R174, clipped wires near R174, or removed D52/R44/R100/R139. An unlocked clarifier voids the radio's Part 95 type acceptance, is often sloppily done, and makes 'needs realignment' the safe assumption."
+  - q: "Is the Uniden Grant XL still a good SSB radio?"
+    a: "Many operators call it one of the best-sounding AM/SSB mobiles ever, and 1990s Uniden build quality means 30-year-old units are still daily-driven. It's also simple to service and every CB shop knows it. What you give up is everything modern: no FM, no weather, no SWR calibration, incandescent backlighting."
+  - q: "Do I need a license for a Uniden Grant XL?"
+    a: "No — CB is licensed by rule under FCC Part 95D. The Grant XL was type-accepted at the legal 4 W AM / 12 W PEP SSB. But note the flip side: a unit with an unlocked clarifier or swapped 'peaked' finals no longer complies with Part 95 — stock examples are the ones worth owning."
+---
+**The Uniden Grant XL** is the classic
+[SSB](/reference/single-sideband/) workhorse of the CB world: a 1990s AM/SSB
+mobile from the same chassis lineage as the President Grant and Cobra
+148 GTL, regarded by many operators as **one of the best-sounding AM/SSB
+mobiles ever made**.[^cbclub] Production ended in the late 1990s — the
+semiconductors literally stopped being made — so the used market (eBay,
+hamfests, forums) is where it lives, at roughly **$50–250** depending
+heavily on condition and mods.[^rigpix] Our **best used/classic buy** among
+CBs — the [Cobra 2000 GTL](/reference/cobra-2000-gtl/) is the grander radio,
+but it's collector-priced.
+
+<a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=Uniden+Grant+XL" rel="nofollow noopener">Find on eBay &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Vintage SSB on the cheap — if you check the clarifier.** 4 W AM / 12 W PEP
+SSB, superb transmit audio, 1990s Uniden build that's still daily-driven,
+and every CB shop can service it. **Used only, ~$50–250** (thin sold data;
+mods and condition swing it hard). **The buying game is the clarifier**:
+unlocked-clarifier mods (R174 jumpered, D52 removed) are everywhere, void
+Part 95 compliance, and often mean sloppy work. **License-free** (Part 95D)
+— on a stock radio. Full rankings: [best CB radios](/best-cb-radios/).
+</div>
+
+## Overview
+
+Ask an old-school CB shop what SSB mobile to hunt down used and the Grant XL
+comes up unprompted. The recipe: clean, punchy transmit audio on AM and
+sideband, a receiver that holds its own, dead-simple through-hole
+construction every tech knows, and Uniden's 1990s build quality — thirty-year-
+old examples are still in daily service. There are no modern conveniences at
+all: analog meter, incandescent backlighting, clarifier, RF gain, ANL, PA,
+and that's the list. No FM (it predates the 2021 authorization), no weather,
+no SWR calibration.
+
+The market is small and cult-driven, which cuts both ways. Working examples
+have sold around **$50–75**; clean, serviced, or new-old-stock units push
+**$150–250**. We'll flag it plainly: **sold-price data is thin**, asks have
+inflated with the radio's reputation, and two listings at the same price can
+be a bargain and a money pit. Condition, originality, and service history
+are the whole price.
+
+**License note:** CB requires no license — licensed by rule under FCC
+Part 95D, 4 W AM / 12 W PEP SSB, and the Grant XL was type-accepted to
+exactly that. The catch on this particular radio is below.
+
+## Buying used: what to check
+
+The Grant XL's aging story is really a **modification story** — a huge
+fraction of survivors have been worked on, and the hotspot is the
+clarifier:[^cbclub]
+
+1. **The clarifier unlock.** The most common Grant XL mod opens the
+   clarifier so it slides **transmit** frequency along with receive
+   ("freebanding" prep). Look for a **jumper replacing R174**, clipped wires
+   near R174, or removed **D52 / R44 / R100 / R139**. Say it plainly: an
+   unlocked clarifier **voids the radio's Part 95 type acceptance** — it's
+   not legal to transmit with — and the work is often sloppily done.
+   Stock-clarifier examples are worth more and buy you fewer surprises.
+2. **Clarifier off-center on AM** — needing the knob well off 12 o'clock to
+   sound right means the radio needs realignment.
+3. **The final transistor.** Confirm stock vs swapped; a blown-and-replaced
+   final is common on "peaked" radios, and swapped finals are another
+   compliance and reliability flag.
+4. **Budget a shop alignment** on any unit of unknown history, and check
+   mic-jack wear and the channel-selector detent.
+
+Working for you: every CB shop knows this radio, and parts radios are still
+cheap. Working against you: no factory support since the 1990s, and the
+modified-to-stock ratio gets worse every year.
+
+## GopherTrunk alternative
+
+Honesty from the software side: **GopherTrunk can't decode CB and isn't
+meant to.** CB is 27 MHz analog AM/[SSB](/reference/single-sideband/), below
+an [RTL-SDR](/reference/rtl-sdr/)'s native tuning range without direct
+sampling or an [upconverter](/reference/upconverter/), and analog sideband
+voice is outside GopherTrunk's trunking/digital focus. If you want to check
+whether your area has SSB activity before hunting the used market, an
+[HF-capable SDR](/best-hf-sdr/) is the honest listening tool; the channel
+list lives in our [scanner frequencies reference](/scanner-frequencies/).
+
+## Who it's for
+
+- **Buy the Grant XL** if you want vintage sideband on the cheap — a
+  hobbyist's or trucker's classic that a $100 bill and a shop alignment turn
+  into a daily driver.
+  <a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=Uniden+Grant+XL" rel="nofollow noopener">Find on eBay &rarr;</a>
+- **Buy the [Cobra 2000 GTL](/reference/cobra-2000-gtl/)** instead if you
+  want the golden-age base-station experience and have collector money, or a
+  new [President McKinley II](/reference/president-mckinley/) /
+  [Bearcat 980SSB](/reference/uniden-bearcat-980ssb/) for warrantied SSB
+  with modern filtering.
+- **Skip vintage entirely** if you won't budget for service — an unserviced
+  30-year-old radio is a project, not a purchase. Full rankings:
+  [best CB radios](/best-cb-radios/).
+
+## Sources
+
+[^rigpix]: [Uniden Grant XL — RigPix](https://www.rigpix.com/cbfreeband/uniden_grantxl.htm) — specifications: 40-channel AM/SSB, 4 W / 12 W PEP, clarifier, RF gain, ANL, PA, and the late-1990s end of production.
+[^cbclub]: [Uniden Grant XL owner review — CB Radio Club](https://www.cbradioclub.com/mobile-reviews/91-uniden-grant-xl.html) — on the radio's audio reputation, build quality, the prevalence of clarifier unlock mods (R174/D52 area) and swapped finals, and used-market condition checks.

--- a/docs/reference/uniden-pro505xl.md
+++ b/docs/reference/uniden-pro505xl.md
@@ -1,0 +1,133 @@
+---
+slug: uniden-pro505xl
+title: Uniden PRO505XL
+entry_type: hardware
+category: two-way-radios
+description: "The Uniden PRO505XL is the cheapest name-brand CB radio — a tiny 4 W AM-only mobile around $50–65 that fits Jeeps and side-by-sides nothing else fits. Dealer-reported discontinued, but new stock remains while it lasts."
+keywords: Uniden PRO505XL, PRO505XL review, cheapest CB radio, best budget CB radio, small CB radio for Jeep, compact CB radio, AM CB radio, CB radio under 100, Uniden PRO505XL discontinued, off-road CB radio, CB radio no license
+aka: [PRO505XL, PRO 505XL, Uniden 505]
+autolink: true
+affiliate: true
+product:
+  name: "Uniden PRO505XL"
+  brand: Uniden
+  category: CB radio (compact mobile)
+  lowPrice: "50"
+  highPrice: "65"
+  url: https://www.amazon.com/dp/B005ZLB0E4?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: Compact mobile CB }
+  - { label: Service, value: "CB — 40 channels, 26.965–27.405 MHz" }
+  - { label: Modes, value: "AM only" }
+  - { label: Power, value: "4 W (legal max), 12 V DC" }
+  - { label: Extras, value: "Instant Ch 9, PA, S/RF meter, external-speaker jack — no weather, no SWR meter" }
+  - { label: License, value: "None (CB) — licensed by rule, Part 95D" }
+  - { label: Price, value: around $50–65 (while stock lasts) }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B005ZLB0E4?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [uniden-bearcat-880, midland-75-822, cobra-75-all-road, cobra-29-ltd-classic, standing-wave-ratio, rtl-sdr]
+related_reading:
+  - { title: "The 10 best CB radios", url: /best-cb-radios/ }
+  - { title: "Scanner frequencies (incl. CB channels)", url: /scanner-frequencies/ }
+cite_urls:
+  - https://uniden.com/products/pro505xl
+faq:
+  - q: "Do I need a license for the Uniden PRO505XL?"
+    a: "No. CB is licensed by rule under FCC Part 95D — no exam, no fee, nothing to file. The PRO505XL transmits the legal 4-watt AM limit out of the box."
+  - q: "Is the Uniden PRO505XL discontinued?"
+    a: "Dealer-reported, yes — at least one major CB retailer lists it discontinued and sold out, though Uniden hasn't made an official statement we've seen, and several dealers still hold new stock around $60. Treat it as a while-stock-lasts buy; the PRO520XL is the closest same-chassis alternative."
+  - q: "Does the PRO505XL have weather channels or an SWR meter?"
+    a: "Neither. No NOAA weather, no SWR metering — you'll need a separate SWR meter (or a friend's) to tune your antenna at install, which you should absolutely still do. At this price, those omissions are the deal."
+  - q: "What's the range of the Uniden PRO505XL?"
+    a: "The same as any legal 4 W AM CB with the same antenna: realistically a few miles vehicle-to-vehicle. The radio is not the limiting factor on CB — antenna quality and SWR tuning are. A $60 radio into a good tuned antenna beats a $200 radio into a bad one."
+  - q: "Is the PRO505XL good for a Jeep or side-by-side?"
+    a: "That's exactly its niche. At about 7.5 by 4.9 inches it fits roll cages, consoles, and dashes nothing else fits, it's cheap enough to not mourn on the trail, and trail comms don't need more than AM channel traffic. Budget for an external speaker — the internal one is tinny."
+---
+**The Uniden PRO505XL** is the cheapest name-brand CB radio: a genuinely tiny
+**4 W AM-only** mobile that streets around **$50–65** and fits in Jeeps,
+side-by-sides, and consoles nothing else fits.[^uniden] One honest caveat up
+front: it's **dealer-reported discontinued** — new stock remains at around
+$60 while it lasts, and it keeps our "most affordable" pick exactly that
+long.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B005ZLB0E4?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The $60 trail beater.** 40 channels, legal 4 W AM, very compact
+(7.5&quot;&times;4.9&quot;), simple and reliable. **No weather channels, no
+SWR meter, no FM** — you'll need a separate meter to tune the antenna.
+**Reported discontinued** (dealer-listed, not officially confirmed) — a
+while-stock-lasts buy. **License-free** (Part 95D). Want more radio? The
+[Bearcat 880FM](/reference/uniden-bearcat-880/) is the step up. Full
+rankings: [best CB radios](/best-cb-radios/).
+</div>
+
+## Overview
+
+Every roster needs the radio you can bolt into a trail rig, forget about, and
+not mourn when a branch takes the antenna. The PRO505XL is that radio, and it
+has been for years: **dirt cheap, very small, and simple** — up/down channel
+buttons, a backlit LCD, squelch and volume, instant channel 9, a PA function,
+an S/RF meter, and an external-speaker jack. That's the whole list, and for
+trail comms and glovebox-emergency duty, it's enough.
+
+The engineering honesty: at this price the filtering is bare-bones, so
+receive is noisy at highway speed — ignition hash and adjacent-channel splatter
+that a [Bearcat 880FM](/reference/uniden-bearcat-880/) or
+[McKinley II](/reference/president-mckinley/) would suppress comes through.
+The internal speaker is tinny (external speaker money is well spent). And
+with **no built-in SWR meter**, you need a separate meter at install time —
+skipping [antenna tuning](/reference/standing-wave-ratio/) is the number-one
+way people conclude "CB doesn't work."
+
+**On the discontinuation:** a major CB dealer lists the PRO505XL as
+discontinued and sold out, while others still hold new stock (~$60). Uniden
+hasn't said so officially that we've found, so we're flagging it plainly
+rather than calling it dead: **buy it while stock lasts, or don't wait.**
+Uniden's own PRO520XL shares the compact Pro-series chassis and adds ANL if
+the 505 dries up — though it's an aging model too.
+
+**License note:** none. CB is licensed by rule (FCC Part 95D) — no exam, no
+fee. 4 W AM is the legal carrier limit, and that's what this radio makes.
+It's AM-only: no FM (2021's newly legal mode) and no SSB.
+
+## What you get — and don't
+
+- **40 channels**, 4 W **AM only**, Part 95D certified, 12 V DC.
+- Backlit LCD, instant Ch 9, PA, S/RF meter, external-speaker jack,
+  up/down channel buttons.
+- Very compact: **7.5&quot; &times; 4.9&quot;** — the fits-anywhere CB.
+- **Not** included: NOAA weather, SWR metering, FM, SSB, noise-canceling
+  mic. That's the $60 trade, stated plainly.
+
+## GopherTrunk alternative
+
+We make free monitoring software, so here's the disclosure: **GopherTrunk
+can't help you with CB.** CB is 27 MHz analog
+[AM](/reference/amplitude-modulation/) — below an
+[RTL-SDR](/reference/rtl-sdr/)'s native tuning range unless you use
+direct-sampling mode or an [upconverter](/reference/upconverter/), and analog
+AM voice is outside GopherTrunk's trunked/digital focus. If you want to hear
+your local channel 19 before spending even $60, a scanner with CB coverage or
+an [HF-capable SDR](/best-hf-sdr/) is the listening path — channel list in
+our [scanner frequencies reference](/scanner-frequencies/). To transmit on
+the trail, this radio *is* the budget answer.
+
+## Who it's for
+
+- **Buy the PRO505XL** if you want the cheapest real CB for a trail rig,
+  work truck, or emergency kit — and buy soon, since stock is a question
+  mark.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B005ZLB0E4?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [Midland 75-822](/reference/midland-75-822/)** instead if you
+  move between vehicles — it's a handheld that converts to a mobile — or the
+  [Cobra 75 All Road](/reference/cobra-75-all-road/) if the problem is dash
+  space rather than budget.
+- **Spend up** to the [Bearcat 880FM](/reference/uniden-bearcat-880/) (~$140)
+  for weather, FM, a real display, and built-in SWR metering — it's the
+  better radio for anyone not optimizing purely for price. Full rankings:
+  [best CB radios](/best-cb-radios/).
+
+## Sources
+
+[^uniden]: [Uniden PRO505XL product page](https://uniden.com/products/pro505xl) — Uniden America, on the 40-channel 4 W AM feature set, compact chassis, instant channel 9, and PA function. Discontinuation status is dealer-reported (retailer listings), not an official Uniden announcement.

--- a/docs/reference/wouxun-kg-1000g-plus.md
+++ b/docs/reference/wouxun-kg-1000g-plus.md
@@ -1,0 +1,146 @@
+---
+slug: wouxun-kg-1000g-plus
+title: Wouxun KG-1000G Plus
+entry_type: hardware
+category: two-way-radios
+description: "The Wouxun KG-1000G Plus is the most feature-complete Part 95E GMRS mobile — 50 watts, 999 channels, split tones, wideband receive, a detachable faceplate, and repeater pairing, around $390. The enthusiast pick, with a known mic/PTT weak point."
+keywords: Wouxun KG-1000G Plus, KG-1000G Plus review, best GMRS mobile radio, 50 watt GMRS radio, GMRS repeater radio, Wouxun GMRS mobile, gmrs license, KG-1000G vs MXT575, GMRS radio with CHIRP, detachable faceplate GMRS, GMRS base station radio
+aka: [KG-1000G Plus, KG1000G Plus, Wouxun KG-1000G]
+autolink: true
+affiliate: true
+product:
+  name: "Wouxun KG-1000G Plus"
+  brand: Wouxun
+  category: GMRS mobile radio
+  lowPrice: "300"
+  highPrice: "390"
+  url: "https://www.amazon.com/s?k=Wouxun+KG-1000G+Plus&tag=gophertrunk-20"
+infobox:
+  - { label: Type, value: "GMRS mobile radio (detachable faceplate)" }
+  - { label: Service, value: "GMRS TX — 999 channels; wideband VHF/UHF RX" }
+  - { label: Power, value: "50 W (four power levels)" }
+  - { label: Repeater, value: "Yes — full split tones; pairs as a repeater" }
+  - { label: License, value: "GMRS — $35 FCC, no test, covers family" }
+  - { label: Price, value: "around $390 new (~$300 refurb/used)" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/s?k=Wouxun+KG-1000G+Plus&tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">Search on Amazon &rarr;</a>" }
+see_also: [midland-mxt575, btech-gmrs-50pro, wouxun-kg-xs20g, radioddity-db20-g, wouxun-kg-935g, rtl-sdr]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "Best GMRS mobile & base radios", url: /best-gmrs-mobile-radios/ }
+cite_urls:
+  - https://www.buytwowayradios.com/wouxun-kg-1000g-plus.html
+faq:
+  - q: "Do I need a license for the Wouxun KG-1000G Plus?"
+    a: "To transmit, yes — a GMRS license: $35 to the FCC, good for 10 years, no test, covering your immediate family. Its wide VHF/UHF coverage is receive-only, and listening needs no license at all."
+  - q: "Is the Wouxun KG-1000G Plus legal for GMRS?"
+    a: "Yes. It holds a genuine FCC Part 95E grant — transmit is locked to the GMRS channels, which is exactly what keeps an import with wideband receive certified. 'Import' does not mean uncertified here."
+  - q: "Does the KG-1000G Plus work with CHIRP?"
+    a: "Yes — CHIRP added KG-1000G support around 2024, alongside Wouxun's own CPS software. Note the CPS has been reported to write bad values for a couple of fields (Rpt-Dly/Ring), so many owners prefer CHIRP."
+  - q: "What is the known weak point of the KG-1000G Plus?"
+    a: "The microphone. Mic/PTT button failures are documented across owner forums — reportedly acknowledged by Wouxun engineering — so a spare mic is a sensible line item. The radio itself has a strong reputation."
+  - q: "Can the KG-1000G Plus be used as a repeater?"
+    a: "Yes — two units can be paired to form a full duplex GMRS repeater, and the radio ships with a remote-head kit and extension cable for flexible mounting. That combination is unique in this class."
+---
+**The Wouxun KG-1000G Plus** is the GMRS mobile the enthusiast community
+actually recommends to each other: 50 watts, **999 memory channels**, full
+split-tone support, wideband VHF/UHF receive with FM broadcast and NOAA, a
+**detachable remote-mountable faceplate**, and the party trick nothing else
+here matches — pair two of them and you have a full duplex GMRS
+repeater.[^btwr] Around **$390 new**, ~$300 refurbished, sold almost entirely
+through specialty dealers.
+
+<a class="btn btn--buy" href="https://www.amazon.com/s?k=Wouxun+KG-1000G+Plus&tag=gophertrunk-20" rel="nofollow sponsored noopener">Search on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Best features for the price in the 50 W class.** 999 channels, split tones,
+136–174/400–470 MHz receive + FM broadcast + 7 NOAA channels, dual watch,
+remote head kit in the box, CHIRP support, repeater pairing — a genuine
+**Part 95E grant** (TX locked to GMRS; the wide coverage is receive-only).
+**Known weak point: the mic** — PTT failures are documented, keep a spare.
+Mostly a dealer-channel radio; Amazon listings are marketplace resellers at a
+markup. **GMRS license to transmit: $35, 10 years, no test, covers family.**
+Rankings: [best GMRS mobile radios](/best-gmrs-mobile-radios/).
+</div>
+
+## Overview
+
+The Plus superseded the original KG-1000G in late 2022 (the non-Plus is still
+sold at ~$300 and remains a fine cheaper substitute — same family). Where the
+Midlands are appliances, the KG-1000G Plus is a *radio*: four power levels up
+to the 50 W legal max, dual watch with simultaneous dual-mode receive, DTMF,
+and a channel map deep enough to store every repeater you'll ever meet with
+its own tones — the exact flexibility the
+[MXT575](/reference/midland-mxt575/)'s one-repeater-per-channel model lacks.
+The detachable faceplate with the included extension cable solves the
+tight-dash problem the mic-centric Midlands solve, but without giving up a
+real control head.
+
+It's certified honestly: a genuine FCC Part 95E grant, with transmit locked to
+the GMRS channels. The wide 136–174/400–470 MHz coverage is **receive-only**,
+which is precisely what keeps the grant legal — worth saying plainly, because
+"Chinese import" and "uncertified" are not synonyms in this class.
+
+**License note:** transmitting requires a GMRS license — $35 to the
+[FCC](/reference/fcc/), valid 10 years, no test, and one license covers your
+immediate family. Listening, including all that wideband receive, requires
+none.
+
+## Channels, power &amp; repeater use
+
+- **Power:** 50 W max, four selectable levels.
+- **Memories:** 999 channels with full
+  [CTCSS](/reference/ctcss/)/[DCS](/reference/dcs/) encode/decode including
+  **split tones**.
+- **Receive:** 136–174 and 400–470 MHz, FM broadcast, 7 NOAA weather
+  channels; dual watch.
+- **Repeater use:** everything a club repeater can ask of it — and two units
+  pair as a full duplex repeater, remote head kit and cable included.
+- **Programming:** Wouxun CPS or **CHIRP** (support landed ~2024).
+- **Antenna:** SO-239 for standard
+  [PL-259](/reference/uhf-connector-pl259/) feedline.
+
+## Known issues, honestly
+
+The pattern to know about is the **microphone**: mic/PTT button failures are
+documented across owner forums, reportedly acknowledged by Wouxun engineering.
+The radio's transmit audio is otherwise praised, so the practical advice is
+unglamorous — budget for a spare mic. Beyond that: Wouxun's CPS software has
+been reported to write bad values for some fields (Rpt-Dly/Ring — another
+reason CHIRP support matters), and there are scattered reports of
+external-speaker routing quirks and power dropouts on repeater channels.
+Distribution is the last quirk: this is a BuyTwoWayRadios/myGMRS
+specialty-dealer radio, and there is **no confirmed first-party Amazon
+listing** — anything the search above surfaces is a marketplace reseller,
+likely at a markup, so compare against dealer pricing before clicking buy.
+
+## GopherTrunk alternative
+
+GMRS and FRS are analog narrowband [FM](/reference/frequency-modulation/) at
+462/467 MHz — dead center in a ~$30 [RTL-SDR](/reference/rtl-sdr/)'s range.
+Before dropping $390 (and before paying the $35 license), run free GopherTrunk
+on a dongle for a week: it monitors and records all local FRS/GMRS simplex and
+repeater activity, which tells you whether the repeaters that justify a radio
+this capable actually have users near you. GopherTrunk cannot transmit — it's
+the scouting-and-logging complement to the KG-1000G Plus, not a substitute.
+[Download GopherTrunk](/downloads.html) and listen before you buy.
+
+## Who it's for
+
+- **Buy the KG-1000G Plus** if you're the household's radio person: repeater
+  hopping, 999 memories, wideband listening, maybe a repeater build of your
+  own. It's the most radio per dollar in the 50 W GMRS class.
+  <a class="btn btn--buy" href="https://www.amazon.com/s?k=Wouxun+KG-1000G+Plus&tag=gophertrunk-20" rel="nofollow sponsored noopener">Search on Amazon &rarr;</a>
+- **Buy the [BTECH GMRS-50PRO](/reference/btech-gmrs-50pro/)** instead if GPS,
+  Bluetooth app programming, and a modern firmware pipeline appeal more than
+  channel depth — it's ~$100 cheaper.
+- **Skip it** for the [Midland MXT575](/reference/midland-mxt575/) if you want
+  an appliance with US-brand support and don't care about receive coverage or
+  deep programming, or the compact 20 W
+  [Wouxun KG-XS20G Plus](/reference/wouxun-kg-xs20g/) if 50 W is overkill.
+  Full rankings: [best GMRS mobile radios](/best-gmrs-mobile-radios/).
+
+## Sources
+
+[^btwr]: [Wouxun KG-1000G Plus — Buy Two Way Radios](https://www.buytwowayradios.com/wouxun-kg-1000g-plus.html) — dealer product page: 50 W output and power levels, 999 channels, split tones, wideband receive, remote head kit, repeater pairing, and Part 95E certification.

--- a/docs/reference/wouxun-kg-935g.md
+++ b/docs/reference/wouxun-kg-935g.md
@@ -1,0 +1,135 @@
+---
+slug: wouxun-kg-935g
+title: Wouxun KG-935G
+entry_type: hardware
+category: two-way-radios
+description: "The Wouxun KG-935G is widely considered the best pure-GMRS handheld experience — 5.5 W, all repeater channels, 999 memories, big color screen, sane menus, IP66 — around $150–170 from specialty dealers, with a newer Plus variant alongside it."
+keywords: Wouxun KG-935G, KG-935G review, best GMRS handheld, Wouxun GMRS radio, KG-935G Plus, GMRS repeater radio, gmrs license, GMRS radio with keypad, premium GMRS handheld, Wouxun vs Baofeng GMRS, GMRS superheterodyne
+aka: [KG-935G, KG935G]
+autolink: true
+affiliate: true
+product:
+  name: "Wouxun KG-935G"
+  brand: Wouxun
+  category: GMRS walkie-talkie (handheld)
+  lowPrice: "150"
+  highPrice: "170"
+  url: https://www.amazon.com/s?k=wouxun+kg-935g&tag=gophertrunk-20
+infobox:
+  - { label: Type, value: Handheld GMRS walkie-talkie }
+  - { label: Service, value: "GMRS (FCC Part 95E)" }
+  - { label: Channels, value: "GMRS + all 8 repeater channels; 999 memories; NOAA" }
+  - { label: Power, value: "5.5 W max" }
+  - { label: License, value: "GMRS — $35 FCC, 10 years, no test" }
+  - { label: Price, value: "around $150–170" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/s?k=wouxun+kg-935g&tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">Find on Amazon &rarr;</a>" }
+see_also: [btech-gmrs-pro, rocky-talkie-5-watt, baofeng-uv-5g-plus, baofeng-gm-15-pro, wouxun-kg-1000g-plus, rtl-sdr]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "The 10 best walkie-talkies", url: /best-walkie-talkies/ }
+cite_urls:
+  - https://www.buytwowayradios.com/wouxun-kg-935g.html
+faq:
+  - q: "Do I need a license for the Wouxun KG-935G?"
+    a: "To transmit, yes — it's a legitimately Part 95E certified GMRS radio, and GMRS takes the FCC's $35, no-test, 10-year license that covers your immediate family. Listening requires nothing. Wouxun's G-series certification is real, unlike gray-market Wouxun ham models pressed into GMRS service."
+  - q: "Is the Wouxun KG-935G better than a Baofeng GMRS radio?"
+    a: "In receiver quality, transmit audio, and day-to-day usability, yes — that's what the 3–5× price buys. In raw feature count per dollar, no. The honest framing: Baofeng for budget, Wouxun for the radio you'll enjoy using daily."
+  - q: "What's the difference between the KG-935G and the KG-935G Plus?"
+    a: "The Plus (2023) is the upgraded successor sold alongside the original — roughly $20–40 more for a USB-C battery, Wouxun's Channel Wizard, and other refinements. The original remains in production and remains excellent; if the prices are close, the Plus's USB-C alone is worth it."
+  - q: "Can I program the Wouxun KG-935G with CHIRP?"
+    a: "Wouxun's factory software is the standard route, and it works well. CHIRP has reportedly added KG-935G support in recent builds — verify your CHIRP version supports it before counting on it; the full DTMF keypad also makes on-radio programming practical."
+  - q: "Is the Wouxun KG-935G waterproof?"
+    a: "It's IP66 — protected against powerful water jets and heavy rain, but not rated for submersion. That's tougher than nearly all consumer walkie-talkies, one notch below the IP67 dunk-proof class."
+---
+**The Wouxun KG-935G** is the radio GMRS regulars recommend to each other:
+a **5.5 W**, all-repeater-channels handheld with a big color screen, sane
+menus, per-channel names and non-standard tones across **999 memories**, a
+full DTMF keypad, IP66 weatherproofing, and receive/audio quality a class
+above the Baofeng tier — for **around $150–170** from specialty
+dealers.[^btwr] It's the best pure *radio* experience in GMRS; what it
+skips are the gadgets (no GPS, no texting, no Bluetooth).
+
+<a class="btn btn--buy" href="https://www.amazon.com/s?k=wouxun+kg-935g&tag=gophertrunk-20" rel="nofollow sponsored noopener">Find on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The GMRS power user's handheld.** Legitimately Part 95E certified, 5.5 W,
+all 8 repeater channels, dual watch with VHF/UHF receive, NOAA alerts, FM
+radio, flashlight, **the best screen and menus in GMRS**. **Transmitting
+needs the $35 no-test GMRS license.** Know before buying: the **KG-935G
+Plus** (~$20–40 more) adds USB-C and Channel Wizard; the original's drop-in
+charger is its most dated trait. Mostly sold by specialty dealers, not
+Amazon. Rankings: [best walkie-talkies](/best-walkie-talkies/).
+</div>
+
+## Overview
+
+Wouxun's G-series occupies the slot import GMRS needed filling: **real FCC
+Part 95E certification** (transmitting takes the **$35, no-test, 10-year
+GMRS license** that covers your immediate family) with performance that
+justifies costing 3–5× a Baofeng. Community consensus is unusually
+consistent here — the KG-935G's receiver holds up in RF-dense areas where
+budget front ends fold, its transmit audio is repeatedly praised, and its
+1.4" color screen with per-channel names, tones, and settings is the
+closest GMRS gets to a modern UX.
+
+The capability list is deep where it counts: **all 8 GMRS repeater
+channels** plus 999 programmable memories that accept non-standard
+[CTCSS/DCS tones](/reference/ctcss/), dual watch across UHF **and** VHF
+receive, NOAA weather with alert, an FM broadcast receiver, a full DTMF
+keypad, even a flashlight. **IP66** means driven rain and hose-spray
+survival — one honest notch below submersible.
+
+Two buying notes. First, the **KG-935G Plus** (2023) sits alongside the
+original at ~$20–40 more, adding a USB-C battery, Wouxun's Channel Wizard,
+and other refinements — the original uses a drop-in charger, its most
+dated feature. Second, distribution: Wouxun GMRS radios sell primarily
+through specialty dealers like Buy Two Way Radios and myGMRS rather than
+Amazon — there's no stable Amazon listing for this exact model, hence the
+search link above. Factory programming software is standard; CHIRP support
+has reportedly landed in recent builds (verify your build).
+
+## Channels, power &amp; battery
+
+- **Service:** GMRS, Part 95E certified — **license required to transmit**;
+  listening is free.
+- **Power:** 5.5 W max.
+- **Channels:** GMRS simplex + all 8 repeater channels; **999 memories**
+  with per-channel names and non-standard tones.
+- **Receive:** dual watch, UHF + VHF receive, NOAA with alert, FM radio.
+- **Controls:** full DTMF keypad, 1.4" color screen, flashlight.
+- **Durability:** **IP66** — heavy weather yes, submersion no.
+- **Battery:** Li-ion pack with drop-in charger (USB-C arrives on the
+  Plus).
+
+## GopherTrunk alternative
+
+A radio this repeater-focused deserves a scouting pass first: FRS/GMRS is
+analog narrowband FM at 462/467 MHz, squarely in a ~$30
+[RTL-SDR](/reference/rtl-sdr/)'s range, and free GopherTrunk will watch
+every channel and repeater output simultaneously, recording what it hears.
+You'll know which local repeaters carry real traffic — and whether the $35
+license is worth it — before spending $150 on hardware. GopherTrunk cannot
+transmit; it's the free monitoring companion to a radio like this, never
+the replacement. The receive side starts at
+[Learn RF &amp; SDR](/learn/rf-sdr/).
+
+## Who it's for
+
+- **Buy the KG-935G** if you'll actually *use* GMRS — repeaters, travel,
+  daily carry — and want the best receiver, audio, and UX in the service
+  (consider the Plus for USB-C).
+  <a class="btn btn--buy" href="https://www.amazon.com/s?k=wouxun+kg-935g&tag=gophertrunk-20" rel="nofollow sponsored noopener">Find on Amazon &rarr;</a>
+- **Buy the [BTECH GMRS-PRO](/reference/btech-gmrs-pro/)** instead for the
+  same money if GPS position-sharing and texting matter more than keypad
+  control.
+- **Skip it** for a [Baofeng UV-5G Plus](/reference/baofeng-uv-5g-plus/) if
+  the budget says $35, or a
+  [Rocky Talkie Expedition Radio](/reference/rocky-talkie-5-watt/) if IP67
+  ruggedness outranks features. Full rankings:
+  [best walkie-talkies](/best-walkie-talkies/).
+
+## Sources
+
+[^btwr]: [Wouxun KG-935G at Buy Two Way Radios](https://www.buytwowayradios.com/wouxun-kg-935g.html) — dealer listing with specifications: Part 95E certification, 5.5 W output, repeater channels, 999 memories, dual watch, NOAA alert, IP66 rating, and pricing.

--- a/docs/reference/wouxun-kg-xs20g.md
+++ b/docs/reference/wouxun-kg-xs20g.md
@@ -1,0 +1,145 @@
+---
+slug: wouxun-kg-xs20g
+title: Wouxun KG-XS20G Plus
+entry_type: hardware
+category: two-way-radios
+description: "The Wouxun KG-XS20G Plus is the compact 20-watt GMRS mobile with real weather sealing — IP65 body, split tones, wideband receive, and Part 95E certification for around $200. Retailers now fulfill all KG-XS20G orders with the Plus."
+keywords: Wouxun KG-XS20G Plus, KG-XS20G review, compact GMRS mobile radio, 20 watt GMRS radio, GMRS repeater radio, gmrs license, waterproof GMRS mobile, Wouxun GMRS, best small GMRS radio, GMRS radio for side by side, KG-XS20G Plus review
+aka: [KG-XS20G, KG-XS20G Plus, Wouxun KG-XS20G]
+autolink: true
+affiliate: true
+product:
+  name: "Wouxun KG-XS20G Plus"
+  brand: Wouxun
+  category: GMRS mobile radio
+  lowPrice: "190"
+  highPrice: "200"
+  url: https://www.amazon.com/dp/B09WQK5FGN?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: "GMRS mobile radio (compact)" }
+  - { label: Service, value: "GMRS TX — 30 channels; wideband VHF/UHF RX" }
+  - { label: Power, value: "20 W (two power levels)" }
+  - { label: Repeater, value: "Yes — full split tones" }
+  - { label: License, value: "GMRS — $35 FCC, no test, covers family" }
+  - { label: Price, value: "around $200" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B09WQK5FGN?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [wouxun-kg-1000g-plus, radioddity-db20-g, midland-mxt275, wouxun-kg-935g, btech-gmrs-50pro, rtl-sdr]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "Best GMRS mobile & base radios", url: /best-gmrs-mobile-radios/ }
+cite_urls:
+  - https://www.buytwowayradios.com/wouxun-kg-xs20g.html
+faq:
+  - q: "What's the difference between the KG-XS20G and the KG-XS20G Plus?"
+    a: "The Plus superseded the original in November 2022, adding display themes and a night mode. Retailers — including Buy Two Way Radios — now fulfill KG-XS20G orders with the Plus, so the Plus is what you'll actually receive. Same radio family, same class."
+  - q: "Do I need a license for the Wouxun KG-XS20G Plus?"
+    a: "To transmit, yes — a GMRS license: $35 to the FCC, valid 10 years, no test, and it covers your immediate family. Its VHF/UHF wideband coverage is receive-only, and listening needs no license."
+  - q: "Is the KG-XS20G Plus waterproof?"
+    a: "It's the most weather-sealed radio in its class: an IP65-rated body (dust-tight, protected against water jets) with an IP55 microphone. That makes it a natural fit for open vehicles — but it's not rated for submersion."
+  - q: "Does the KG-XS20G Plus support repeater split tones?"
+    a: "Yes — full CTCSS/DCS encode and decode including split tones, which is what many club repeaters require and what the similarly priced classic Midland 15-watt radios can't do."
+  - q: "Can I program the KG-XS20G Plus with CHIRP?"
+    a: "Plan on Wouxun's CPS software — CHIRP support for the XS20G wasn't confirmed in our research, so CPS is the safe assumption. Its 30 GMRS channels are simple enough to program from the front panel too."
+---
+**The Wouxun KG-XS20G Plus** is the compact middle path of the GMRS mobile
+market: 20 watts in a small, genuinely weather-sealed chassis — **IP65 body,
+IP55 mic** — with full split-tone repeater support, wideband receive, and a
+real Part 95E grant for about **$200**.[^btwr] One naming note up front: the
+Plus superseded the original KG-XS20G in late 2022, and retailers now fulfill
+KG-XS20G orders with the Plus — same family, and the Plus is what arrives.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B09WQK5FGN?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The best-built radio under $250 in this class.** 20 W, 30 GMRS channels
+(incl. the 8 repeater channels) with **split tones**, RX-only
+136–174/400–470 MHz plus NOAA and FM broadcast, IP65 sealing. **Genuine Part
+95E grant** — TX locked to GMRS, the wide coverage is receive-only. Plan on
+Wouxun's CPS for programming (CHIRP unconfirmed). Sold mainly through
+specialty dealers. **GMRS license to transmit: $35, 10 years, no test, covers
+your immediate family.** Rankings:
+[best GMRS mobile radios](/best-gmrs-mobile-radios/).
+</div>
+
+## Overview
+
+Wouxun's big [KG-1000G Plus](/reference/wouxun-kg-1000g-plus/) is the
+enthusiast flagship; the KG-XS20G Plus is the same engineering culture shrunk
+to fit. The head doesn't detach and the channel map is organized around the 30
+GMRS slots rather than 999 memories, but the parts that matter for repeater
+work — full [CTCSS](/reference/ctcss/)/[DCS](/reference/dcs/) encode/decode
+**including split tones** — are all here, at $200. The top-firing speaker
+does honest work and there's a 3.5 mm jack for an external speaker when the
+vehicle gets loud.
+
+What you're really paying for over a
+[Radioddity DB20-G](/reference/radioddity-db20-g/) is the build: the IP65
+body and IP55 mic make this the natural pick for side-by-sides, tractors, and
+open Jeeps, where the DB20-G's bare little chassis would live a short life.
+
+**License note:** GMRS transmit requires a license — $35 to the
+[FCC](/reference/fcc/), good 10 years, no exam, covering your immediate
+family. Listening — including the wideband receive — is license-free.
+
+## Channels, power &amp; repeater use
+
+- **Power:** 20 W, two selectable levels.
+- **Channels:** 30 GMRS channels including the 8 repeater channels.
+- **Repeaters:** full tone support with **split tones** — many club repeaters
+  use different encode and decode tones, and this radio handles them where the
+  classic 15 W Midlands can't.
+- **Receive:** 136–174 / 400–470 MHz (receive-only), NOAA weather, FM
+  broadcast.
+- **Build:** IP65 body, IP55 microphone; compact non-detachable head.
+- **Programming:** Wouxun CPS (CHIRP support unconfirmed for this model —
+  assume CPS).
+- **Antenna:** SO-239 jack for standard
+  [PL-259](/reference/uhf-connector-pl259/) feedline.
+
+Range honesty applies here as everywhere: 20 W simplex is still 1–5 miles in
+real terrain, because UHF is terrain-limited. The wattage question is really a
+repeater question — can you open the local machine's 467 MHz input reliably?
+For most in-town and near-repeater use, 20 W with a decent roof-mounted
+antenna can; at the fringe, the 50 W radios buy margin.
+
+## The 20-watt question
+
+The honest knock on the XS20G Plus is arithmetic. It costs about $85 more
+than a DB20-G with the same 20 W, and about $190 less than a KG-1000G Plus
+with 50 W and every feature — so it has to justify itself on build quality
+and sealing, which it genuinely does, or it gets squeezed from both sides.
+Distribution is dealer-centric (Buy Two Way Radios is the primary channel)
+with a thin Amazon presence — the confirmed listing above is sold as the
+"KG-XS20G Plus." If your vehicle is enclosed and dry, the DB20-G's value is
+hard to beat; if it's open to the weather, this is the one that survives.
+
+## GopherTrunk alternative
+
+FRS and GMRS are analog narrowband [FM](/reference/frequency-modulation/) at
+462/467 MHz — comfortably within a ~$30 [RTL-SDR](/reference/rtl-sdr/)'s
+range. Free GopherTrunk on a dongle monitors and records local FRS/GMRS
+simplex and repeater traffic, which answers the buying question this page
+can't: is there anyone *near you* worth talking to, and is the local repeater
+alive? Scout first, then license, then buy. GopherTrunk can't transmit — it
+complements the radio, never replaces it.
+[Download GopherTrunk](/downloads.html) to start listening tonight.
+
+## Who it's for
+
+- **Buy the KG-XS20G Plus** if your radio lives in the weather — open
+  vehicles, farm equipment, marine-adjacent duty — and you want real split-tone
+  repeater capability in a compact package.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B09WQK5FGN?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [Radioddity DB20-G](/reference/radioddity-db20-g/)** instead if
+  the vehicle is enclosed and you'd rather pocket the $85 — same power, same
+  split tones, CHIRP support.
+- **Skip it** for the [Wouxun KG-1000G Plus](/reference/wouxun-kg-1000g-plus/)
+  if fringe-repeater work demands 50 W. Handheld more your style? See the
+  [Wouxun KG-935G](/reference/wouxun-kg-935g/). Full rankings:
+  [best GMRS mobile radios](/best-gmrs-mobile-radios/).
+
+## Sources
+
+[^btwr]: [Wouxun KG-XS20G — Buy Two Way Radios](https://www.buytwowayradios.com/wouxun-kg-xs20g.html) — dealer product page (now fulfilled as the KG-XS20G Plus): 20 W output, 30 channels, split tones, IP65/IP55 ratings, wideband receive, and Part 95E certification.


### PR DESCRIPTION
## Summary

Follow-up to #1116 (ham radio guides): adds the same top-10 treatment for consumer two-way radios — FRS/GMRS walkie-talkies, GMRS mobile/base rigs, and CB radios — 3 buyer's guides plus an individual Field Guide page for every radio, with the shared six-criteria qualitative rubric and honest licensing notes for each service.

## Changes

- Three top-10 guides: `/best-walkie-talkies/`, `/best-gmrs-mobile-radios/`, `/best-cb-radios/` — house structure (thesis → TL;DR → pick cards → How we grade → ranked top 10 → graded comparison table → How to choose → Bottom line), with Best overall / Best features for the price / Most affordable / Best used-classic picks per list.
- 30 product pages under `docs/reference/` in a new `two-way-radios` Field Guide category (10 per list, incl. 2 aftermarket-only classics each: Garmin Rino 755t, Motorola MR350R, Midland MXT400, BTECH GMRS-50X1, Cobra 2000 GTL, Uniden Grant XL).
- Amazon links carry `tag=gophertrunk-20` with web-research-confirmed ASINs only (search URLs where none confirmed); models Amazon doesn't carry get untagged eBay search links (`rel="nofollow noopener"`); used gear emits `UsedCondition` Product JSON-LD via the existing seller/itemCondition schema support.
- Service-honest content: GMRS $35 no-test license stated on every GMRS page, FRS/CB license-free by rule, 2021 CB FM legalization, Part 95 certification called out on import gear, fantasy range claims debunked, CB pages explicitly do not claim GopherTrunk decodes 27 MHz AM/SSB.
- Registration: `_data/reference.yml` category + entries, `_data/nav.yml` "Two-way radios" heading, `docs/llms.txt` section.

## Test plan

- [x] Local Jekyll build + both docs CI scripts pass: `check_site_pages.py` (all pages in sitemap.xml and `/sitemap/`) and `check_internal_links.py` (all internal links resolve)
- [x] Source-level checks: every Amazon href tagged + `rel="nofollow sponsored noopener"`; eBay hrefs untagged + `rel="nofollow noopener"`; reference.yml ↔ page bijection; 5-pair FAQ per page; no star ratings/aggregateRating anywhere
- [ ] `make vet test` — n/a (docs-only change, no Go code touched)
- [ ] `make integration` — n/a
- [ ] Hardware smoke test — n/a

## Breaking changes

none

## Docs / CHANGELOG

- [ ] CHANGELOG bullet — n/a (site content, not the application)
- [x] `docs/` updated (this PR is entirely docs-site content)

## Linked issues

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P4WkHNzqEqLWZzzmCvsiJ1

---
_Generated by [Claude Code](https://claude.ai/code/session_01P4WkHNzqEqLWZzzmCvsiJ1)_