### PR TITLE
docs: shortwave radio buyer's guides (portables, emergency, desktop classics) + 30 Field Guide pages

### DIFF
--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -238,6 +238,15 @@ groups:
         url: /best-cb-radios/
       - title: "All two-way radios (Field Guide)"
         url: /reference/#two-way-radios
+      - heading: Shortwave & emergency
+      - title: Best shortwave radios
+        url: /best-shortwave-radios/
+      - title: Best emergency radios
+        url: /best-emergency-radios/
+      - title: Best desktop shortwave receivers
+        url: /best-desktop-shortwave-receivers/
+      - title: "All shortwave radios (Field Guide)"
+        url: /reference/#shortwave-radios
       - heading: SDRs & receivers
       - title: Best SDR for GopherTrunk
         url: /best-sdr-for-gophertrunk/

--- a/docs/_data/reference.yml
+++ b/docs/_data/reference.yml
@@ -911,6 +911,41 @@ domains:
           - { slug: cobra-2000-gtl, title: Cobra 2000 GTL, type: hardware }
           - { slug: uniden-grant-xl, title: Uniden Grant XL, type: hardware }
 
+      - id: shortwave-radios
+        label: Shortwave & emergency radios
+        blurb: Portable and desktop shortwave receivers plus emergency crank/solar radios — all listen-only, no license ever. The same listen-first philosophy GopherTrunk applies to VHF/UHF, on the HF bands.
+        entries:
+          - { slug: tecsun-pl-990, title: Tecsun PL-990, type: hardware }
+          - { slug: tecsun-pl-880, title: Tecsun PL-880, type: hardware }
+          - { slug: tecsun-pl-330, title: Tecsun PL-330, type: hardware }
+          - { slug: sangean-ats-909x2, title: Sangean ATS-909X2, type: hardware }
+          - { slug: xhdata-d-808, title: XHDATA D-808, type: hardware }
+          - { slug: cc-skywave-ssb-2, title: C.Crane CC Skywave SSB 2, type: hardware }
+          - { slug: eton-elite-executive, title: Eton Elite Executive, type: hardware }
+          - { slug: qodosen-dx-286, title: Qodosen DX-286, type: hardware }
+          - { slug: sony-icf-sw7600gr, title: Sony ICF-SW7600GR, type: hardware }
+          - { slug: tecsun-pl-660, title: Tecsun PL-660, type: hardware }
+          - { slug: midland-er310, title: Midland ER310, type: hardware }
+          - { slug: midland-er210, title: Midland ER210, type: hardware }
+          - { slug: kaito-ka500, title: Kaito KA500, type: hardware }
+          - { slug: eton-frx3-plus, title: "Eton FRX3+", type: hardware }
+          - { slug: sangean-mmr-88, title: Sangean MMR-88, type: hardware }
+          - { slug: fospower-a1, title: FosPower A1, type: hardware }
+          - { slug: runningsnail-md-092, title: RunningSnail MD-092, type: hardware }
+          - { slug: eton-scorpion-ii, title: Eton Scorpion II, type: hardware }
+          - { slug: eton-fr500, title: Eton FR500 Solarlink, type: hardware }
+          - { slug: grundig-fr200, title: Grundig FR200, type: hardware }
+          - { slug: drake-r8b, title: Drake R8B, type: hardware }
+          - { slug: icom-ic-r75, title: Icom IC-R75, type: hardware }
+          - { slug: aor-ar7030, title: AOR AR7030, type: hardware }
+          - { slug: jrc-nrd-545, title: JRC NRD-545, type: hardware }
+          - { slug: kenwood-r-5000, title: Kenwood R-5000, type: hardware }
+          - { slug: sony-icf-2010, title: Sony ICF-2010, type: hardware }
+          - { slug: lowe-hf-150, title: Lowe HF-150, type: hardware }
+          - { slug: grundig-satellit-800, title: Grundig Satellit 800, type: hardware }
+          - { slug: icom-ic-r8600, title: Icom IC-R8600, type: hardware }
+          - { slug: eton-elite-750, title: Eton Elite 750, type: hardware }
+
       - id: rf-front-end
         label: RF front-end & components
         blurb: The components between the antenna and the receiver — amplifiers, filters, mixers, connectors, and references.

--- a/docs/best-desktop-shortwave-receivers.md
+++ b/docs/best-desktop-shortwave-receivers.md
@@ -1,0 +1,251 @@
+---
+layout: page
+title: "The 10 Best Desktop Shortwave Receivers (Classic &amp; Current, 2026)"
+description: "The best desktop shortwave receivers of 2026, ranked honestly — Drake R8B, AOR AR7030, JRC NRD-545, Icom IC-R8600 and more. Eight used classics, two current models, and the truth: a $200 SDR ended this category."
+keywords: best desktop shortwave receiver, best tabletop shortwave receiver 2026, Drake R8B, AOR AR7030, JRC NRD-545, Icom IC-R8600, classic shortwave receivers, used shortwave receiver buying guide, is shortwave radio still worth it, shortwave receiver vs SDR
+permalink: /best-desktop-shortwave-receivers/
+nav_group: Hardware
+affiliate: true
+faq:
+  - q: "What is the best desktop shortwave receiver in 2026?"
+    a: "The Drake R8B — a used classic, because the category is effectively extinct. Its selectable-sideband synchronous AM detection is widely rated the best ever put in a tabletop and its broadcast audio is still the reference. Expect roughly $550–1,100 on eBay, and verify against sold listings; asks skew high."
+  - q: "Are tabletop shortwave receivers still made?"
+    a: "Barely. The Icom IC-R8600 (~$2,750) is the only true full-size communications receiver in production, and the Eton Elite 750 (~$400–500, late-lifecycle) is the last affordable big knob radio. Everything else on any serious list is a discontinued classic bought used."
+  - q: "Is a used classic receiver better than a modern SDR?"
+    a: "On raw performance per dollar, no — a ~$200 HF SDR rivals or beats a $1,000+ legacy tabletop and adds a spectrum waterfall. You buy a classic for knobs, filters, audio, and build quality, as a deliberate choice. Our best HF SDR guide covers the modern route."
+  - q: "What's the cheapest good classic shortwave receiver?"
+    a: "The Sony ICF-2010 at roughly $150–350 used (run the 1620 kHz front-end test before buying), or the Icom IC-R75 at $300–500 if you want a true tabletop — the R75 is the best-documented price band and the best value of the serious classics."
+  - q: "Do I need a license for a shortwave receiver?"
+    a: "No — never. These are receivers, and listening is license-free everywhere in the US: no FCC registration, exam, or paperwork of any kind. Spend the money you saved on a wire antenna; it matters more than the radio."
+---
+
+# The 10 Best Desktop Shortwave Receivers (Classic &amp; Current, 2026)
+
+**Let's start with the truth most buyer's guides bury: this product category
+is effectively extinct.** Software-defined radio killed it — a ~$200 SDR
+rivals or beats a $1,000+ legacy tabletop on raw performance and adds a
+spectrum waterfall no knob radio can draw, while cheap DSP silicon made
+$100–300 portables good enough to erase the low end. So this guide inverts
+the usual ratio: **eight of our ten picks are discontinued classics bought
+used**, and only two are current production. You buy a classic in 2026 for
+ergonomics, audio, build quality, and the pleasure of real knobs and filters
+— not because it outperforms a modern [HF SDR](/best-hf-sdr/). That's a
+legitimate choice; we just refuse to dress it up as a performance one. Two
+more truths up front: **listening is license-free everywhere in the US — no
+FCC anything, ever** — and on shortwave, **$20 of wire antenna out a window
+improves reception more than a $200 radio upgrade**.
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Best overall:** [Drake R8B](/reference/drake-r8b/) (~$550–1,100 used,
+eBay) — the best sync AM and broadcast audio ever put in a tabletop. **Best
+features for the price:** [Icom IC-R75](/reference/icom-ic-r75/) (~$300–500
+used). **Most affordable:** [Sony ICF-2010](/reference/sony-icf-2010/)
+(~$150–350 used). **Best current production:**
+[Icom IC-R8600](/reference/icom-ic-r8600/) (~$2,750 new) — the only true
+tabletop still made. Every classic price leans on asking data: **check eBay
+sold listings before paying.** The bands are quieter than the genre's heyday
+— and the honest modern alternative is a [$200 HF SDR](/best-hf-sdr/).
+</div>
+
+## Quick picks
+
+<div class="pick-cards" markdown="0">
+<div class="pick-card pick-card--top">
+<span class="pick-card__badge">Best overall</span>
+<h3>Drake R8B</h3>
+<p class="pick-card__price">around $550–1,100 used</p>
+<p>The consensus #1 classic: selectable-sideband sync AM rated the best ever, five bandwidths standard, and the finest program audio of the breed. The last receiver Drake made.</p>
+<a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=drake+r8b" rel="nofollow noopener">Find on eBay &rarr;</a>
+<p class="pick-card__note"><a href="/reference/drake-r8b/">Drake R8B details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Best features for the price</span>
+<h3>Icom IC-R75</h3>
+<p class="pick-card__price">around $300–500 used</p>
+<p>The value classic: twin passband tuning, two filter slots, famous stability, and the best-documented used prices of any serious tabletop. Weak sync and muffled stock audio are the trade.</p>
+<a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=icom+ic-r75" rel="nofollow noopener">Find on eBay &rarr;</a>
+<p class="pick-card__note"><a href="/reference/icom-ic-r75/">IC-R75 details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Most affordable</span>
+<h3>Sony ICF-2010</h3>
+<p class="pick-card__price">around $150–350 used</p>
+<p>The all-time-classic gateway: benchmark selectable-sideband sync in a big portable. Run the 1620 kHz front-end-FET test before buying — it's the whole game.</p>
+<a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=sony+icf-2010" rel="nofollow noopener">Find on eBay &rarr;</a>
+<p class="pick-card__note"><a href="/reference/sony-icf-2010/">ICF-2010 details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Best current production</span>
+<h3>Icom IC-R8600</h3>
+<p class="pick-card__price">around $2,750 new</p>
+<p>The only true full-size communications receiver still made: 10 kHz–3 GHz SDR architecture, touchscreen waterfall, digital voice decode, and a warranty — a rarity here.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0891RNWGZ?tag=gophertrunk-20" rel="nofollow sponsored noopener">IC-R8600 on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/icom-ic-r8600/">IC-R8600 details</a></p>
+</div>
+</div>
+
+## How we grade
+
+Every receiver is judged on the same six criteria: **RF performance**
+(sensitivity, selectivity, sync/SSB quality, image rejection), **Coverage
+&amp; modes** (LW/MW/SW/FM/Air, SSB), **Power &amp; endurance** (power
+sources, battery operation where offered), **Usability** (tuning feel,
+controls, display, memories), **Ecosystem &amp; support** (availability,
+service, parts, community knowledge base), and **Value** (what the used or
+street price buys). No star ratings, no invented scores — table grades run
+Excellent/Good/Fair/Basic, and every used-market model gets a viability
+note: typical prices, known failure points, parts reality. **A standing
+hedge on prices:** most classic "prices" are asking prices, thinnest on the
+AR7030, ask-heavy on the NRD-545 and Satellit 800 — always check eBay
+*sold* listings before paying. The same rubric runs our
+[best shortwave radios](/best-shortwave-radios/) (portables) and
+[best emergency radios](/best-emergency-radios/) guides, so grades are
+comparable.
+
+## The top 10, ranked
+
+### 1. Drake R8B — best overall
+
+**RF performance** and program audio still define the class: the best sync
+detector ever fitted to a tabletop, five bandwidths standard, passband
+offset and notch. **Usability** quirks (light tuning knob, divisive green
+display) are the only demerits. Used-market viability is good — the two
+faults (tuning encoder, PSU electrolytics) are documented and fixable, and
+the community keeps them alive. ~$550–1,100; asks skew ambitious.
+<a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=drake+r8b" rel="nofollow noopener">Find on eBay &rarr;</a> · [Drake R8B review](/reference/drake-r8b/)
+
+### 2. AOR AR7030 — the performance king
+
+Arguably the best front end of any classic — legendary dynamic range — with
+superb audio and up to six filters. Two things keep it off the top:
+**Usability** (the notorious menu-plus-required-remote interface) and the
+thinnest market data here — asks run high-three to low-four figures with no
+confirmed solds; verify hard. Watch for the LCD-fade fault and confirm the
+remote.
+<a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=aor+ar7030" rel="nofollow noopener">Find on eBay &rarr;</a> · [AR7030 review](/reference/aor-ar7030/)
+
+### 3. JRC NRD-545 — the DSP knob-twiddler's dream
+
+Bandwidth variable in 10 Hz steps, working ECSS sync, and commercial-marine
+build. Early-generation DSP artifacts and slightly synthetic audio make it
+polarizing, and JRC prestige keeps asks ($1,200–2,000+) above what thin sold
+data supports — hedge accordingly. Check the CR2032 battery and CCFL
+backlight.
+<a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=jrc+nrd-545" rel="nofollow noopener">Find on eBay &rarr;</a> · [NRD-545 review](/reference/jrc-nrd-545/)
+
+### 4. Icom IC-R8600 — best current production
+
+The one real new tabletop: 10 kHz–3 GHz, IC-7300-derived front end,
+touchscreen waterfall, P25/NXDN/D-STAR decode, warranty. No true sync AM
+(DSP tools instead), and yes — a $200 SDR gets you much of the HF
+performance. **Value** at $2,750 is the only thing holding it at #4.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0891RNWGZ?tag=gophertrunk-20" rel="nofollow sponsored noopener">IC-R8600 on Amazon &rarr;</a> · [IC-R8600 review](/reference/icom-ic-r8600/)
+
+### 5. Icom IC-R75 — best features for the price
+
+The cheapest serious classic (~$300–500, the best-corroborated band here):
+twin PBT, filter slots, rock stability, excellent SSB/utility performance.
+Muffled stock audio and a sync detector widely called poor keep it out of
+the top tier — as pure feature-per-dollar, nothing used touches it.
+<a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=icom+ic-r75" rel="nofollow noopener">Find on eBay &rarr;</a> · [IC-R75 review](/reference/icom-ic-r75/)
+
+### 6. Kenwood R-5000 — the dependable all-rounder
+
+The best all-round 1980s Japanese tabletop: excellent SSB, fine optional
+filters, honest audio, ~$450–700. No sync AM, and it's the
+highest-maintenance radio here — the PLL "dot problem", keybounce caps, and
+scarce displays make service history the whole negotiation.
+<a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=kenwood+r-5000" rel="nofollow noopener">Find on eBay &rarr;</a> · [R-5000 review](/reference/kenwood-r-5000/)
+
+### 7. Grundig Satellit 800 — the budget Drake
+
+Drake-designed (SW8-based), with top-of-the-heap sync and the best audio of
+the affordable classics at ~$300–550 (asks). The QC lottery is real — prefer
+2003+ serials, ask about the 2L41 choke — which is what keeps a
+dollars-per-performance winner at #7.
+<a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=grundig+satellit+800" rel="nofollow noopener">Find on eBay &rarr;</a> · [Satellit 800 review](/reference/grundig-satellit-800/)
+
+### 8. Sony ICF-2010 — most affordable
+
+The honorary member: a large portable, on every classic list anyway, with
+benchmark sync at ~$150–350. Dated audio, 100 Hz SSB steps, and the famous
+blown-front-end-FET risk (demand the 1620 kHz test) hold it here — as an
+entry ticket to real sync detection, nothing is cheaper.
+<a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=sony+icf-2010" rel="nofollow noopener">Find on eBay &rarr;</a> · [ICF-2010 review](/reference/sony-icf-2010/)
+
+### 9. Lowe HF-150 — the compact cult classic
+
+Two knobs, superb natural audio, dual-mode sync, near-zero repair incidence
+— the best-sounding small classic. Minimal filtering (no notch/PBT) and a
+thin, UK-skewed market (~$250–450) cap the ranking; check the battery boxes
+for corrosion.
+<a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=lowe+hf-150" rel="nofollow noopener">Find on eBay &rarr;</a> · [HF-150 review](/reference/lowe-hf-150/)
+
+### 10. Eton Elite 750 — the last affordable new knob radio
+
+In production (late-lifecycle — verify stock, and dodge the documented scam
+deep-discount listings) at ~$400–500. A pleasant program listener with
+big-radio audio — but no sync, no PBT, mediocre SSB. It ranks because it's
+new, warrantied, and buyable, not because it out-receives anything above it.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B08BVSCY8G?tag=gophertrunk-20" rel="nofollow sponsored noopener">Elite 750 on Amazon &rarr;</a> · [Elite 750 review](/reference/eton-elite-750/)
+
+## Full comparison
+
+| Receiver | RF | Sync AM | Usability | Value | Used/new price |
+|---|---|---|---|---|---|
+| [Drake R8B](/reference/drake-r8b/) | **Excellent** | **Best in class** | Good | Good | ~$550–1,100 used (thin solds) |
+| [AOR AR7030](/reference/aor-ar7030/) | **Excellent** | Good (het quirk) | Fair | Good | high $100s–low $1,000s (asks only) |
+| [JRC NRD-545](/reference/jrc-nrd-545/) | **Excellent** | Good (working ECSS) | Good | Fair | ~$1,200–2,000+ used (asks) |
+| [Icom IC-R8600](/reference/icom-ic-r8600/) | **Excellent** | None (DSP tools) | **Excellent** | Fair | ~$2,750 new |
+| [Icom IC-R75](/reference/icom-ic-r75/) | Good | Basic (poor lock) | Good | **Excellent** | ~$300–500 used |
+| [Kenwood R-5000](/reference/kenwood-r-5000/) | Good | None | Good | Good | ~$450–700 used (asks) |
+| [Grundig Satellit 800](/reference/grundig-satellit-800/) | Good | **Excellent** | Good | **Excellent** | ~$300–550 used (asks) |
+| [Sony ICF-2010](/reference/sony-icf-2010/) | Good | **Excellent** | Good | **Excellent** | ~$150–350 used |
+| [Lowe HF-150](/reference/lowe-hf-150/) | Good | Good (dual-mode) | Good | Good | ~$250–450 used (thin, UK-skewed) |
+| [Eton Elite 750](/reference/eton-elite-750/) | Fair | None | Good | Fair | ~$400–500 new |
+
+> **The antenna outranks every row of this table.** On shortwave, $20 of
+> wire out a window improves reception more than moving up two spots in the
+> rankings — string the wire before you bid. And every price marked "asks"
+> means exactly that: check eBay **sold** listings, not asking prices,
+> before money moves.
+
+## How to choose
+
+- **Want the definitive classic listening experience?**
+  [Drake R8B](/reference/drake-r8b/) — sync and audio nothing else matches.
+- **Chasing raw performance and at peace with menus?**
+  [AOR AR7030](/reference/aor-ar7030/); knob-twiddler with DSP leanings,
+  [JRC NRD-545](/reference/jrc-nrd-545/).
+- **First classic on a real budget?** [Icom IC-R75](/reference/icom-ic-r75/)
+  for a tabletop, [Sony ICF-2010](/reference/sony-icf-2010/) for the
+  cheapest sync, [Grundig Satellit 800](/reference/grundig-satellit-800/)
+  for big audio.
+- **Must be new, with a warranty?**
+  [Icom IC-R8600](/reference/icom-ic-r8600/) if the budget is serious,
+  [Eton Elite 750](/reference/eton-elite-750/) if it isn't.
+- **Honest with yourself about wanting performance, not nostalgia?** Skip
+  the whole list and read [best SDR for HF](/best-hf-sdr/) — that's where
+  the performance-per-dollar went.
+- **Want a radio you can carry?** Our
+  [best shortwave radios](/best-shortwave-radios/) guide covers the
+  portables that inherited this market.
+
+## Bottom line
+
+The **[Drake R8B](/reference/drake-r8b/)** is the best desktop shortwave
+receiver you can buy in 2026, and the fact that it went out of production in
+2004 tells you everything about the category. The
+**[IC-R75](/reference/icom-ic-r75/)** is the smart cheap seat, the
+**[ICF-2010](/reference/sony-icf-2010/)** the cheapest real sync, and the
+**[IC-R8600](/reference/icom-ic-r8600/)** the one door still open at the
+dealer. Around this guide: [portables](/best-shortwave-radios/) for the
+same bands in your hand, [emergency radios](/best-emergency-radios/) for
+when the grid is the story, and [HF SDRs](/best-hf-sdr/) for the honest
+modern answer. Classic-iron romantics should also see the transmitting side
+of the same era — the [Kenwood TS-940S](/reference/kenwood-ts-940s/) and
+[Yaesu FT-1000MP](/reference/yaesu-ft-1000mp/) in our
+[best ham radio base stations](/best-ham-radio-base-stations/) guide — but
+remember the asymmetry: **talking back needs a license; listening never
+does.**

--- a/docs/best-emergency-radios.md
+++ b/docs/best-emergency-radios.md
@@ -1,0 +1,243 @@
+---
+layout: page
+title: "The 10 Best Emergency Radios (Crank, Solar &amp; Weather, 2026)"
+description: "The best emergency radios of 2026, ranked — Midland ER310, Sangean MMR-88, Kaito KA500, Eton FRX3+, FosPower A1 and more — with the honest SAME-vs-tone-alert explainer, measured crank runtimes, and which ones actually receive shortwave."
+keywords: best emergency radio, best emergency radio 2026, best hand crank radio, crank weather radio, NOAA weather radio, solar emergency radio, emergency radio with shortwave, SAME weather alert radio, Midland ER310, emergency radio buying guide
+permalink: /best-emergency-radios/
+nav_group: Hardware
+affiliate: true
+faq:
+  - q: "What is the best emergency radio in 2026?"
+    a: "The Midland ER310. Its 2600 mAh replaceable battery, 6× AA backup, honest platform behavior, and huge retail footprint make it the crank radio we'd hand to anyone, at around $70. Pair it with a $30 plugged-in SAME desktop radio, which is what actually wakes you for warnings."
+  - q: "Do any hand-crank radios have SAME alerting?"
+    a: "None in this guide — and effectively none on the market. Every crank radio marketed with 'weather alert' does 1050 Hz tone-alert standby: it wakes for any warning across the whole NOAA transmitter's multi-county footprint. SAME county filtering lives in dedicated desktop units like the Midland WR120."
+  - q: "How long does a crank radio really run per minute of cranking?"
+    a: "Measured figures run 3–9 minutes of radio per minute of cranking: about 9 for the Midland ER310, 5 for the Sangean MMR-88, and 3 at full volume for the RunningSnail platform. Crank-to-phone charging is effectively useless — testing couldn't get phones to register charging at all."
+  - q: "Which emergency radios have shortwave?"
+    a: "Only three here: the Kaito KA500 (the one current-production pick, ~$50–65) and the discontinued Eton FR500 and Grundig FR200 on the used market. Everything else is AM/FM/weather-band only. Note the FR200 has shortwave but no weather band at all."
+  - q: "Is a crank radio better than a weather alert radio?"
+    a: "They do different jobs. A plugged-in SAME desktop radio is what reliably wakes you for a warning in your county; a crank radio keeps you informed after the grid goes down and doubles as flashlight and power bank. Most households should own one of each, not either-or."
+---
+
+# The 10 Best Emergency Radios (Crank, Solar &amp; Weather, 2026)
+
+**Start with the uncomfortable truth: none of these radios does SAME alerting.**
+Every crank radio sold as a "weather alert radio" — including every one below —
+does **1050 Hz tone-alert standby**: it sits muted on a NOAA weather channel
+(seven frequencies, 162.400–162.550 MHz) and wakes when the National Weather
+Service sends the attention tone before *any* watch or warning in the
+transmitter's whole footprint, which can span many counties. Real **SAME**
+radios decode the digital county code and alarm only for the counties you
+program — and they're $30 plugged-in desktop units, not crank gadgets. So for
+*actually being woken for a tornado warning*, a SAME desktop radio beats
+everything here. The crank radio's job is different and still essential:
+**staying informed after the grid goes down**, plus flashlight and power-bank
+duty. The right answer for most households is one of each.
+
+Second truth, from measured tests rather than box copy: **a minute of cranking
+buys 3–9 minutes of radio**, solar panels are trickle *maintainers* that won't
+revive a dead battery, and crank-to-phone charging is marketing — testing
+couldn't get phones to register a charge at all. Buy the battery, keep it
+topped up, and treat the crank as the deep reserve. And since these are all
+receivers: **listening is license-free everywhere in the US** — no FCC
+anything, ever.
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Best overall:** [Midland ER310](/reference/midland-er310/) (~$70 — big
+replaceable battery, AA backup, everywhere in stock). **Best features for the
+price:** [Kaito KA500](/reference/kaito-ka500/) (~$50–65 — the only sub-$60
+crank radio with real shortwave, 5-way power). **Most affordable:**
+[FosPower A1](/reference/fospower-a1/) (~$27–35 — but no alert standby at
+all). **Best used/classic buy:** [Grundig FR200](/reference/grundig-fr200/)
+(~$19–52 — indestructible crank shortwave, **no weather band**). No crank
+radio does SAME — budget $30 for a plugged-in SAME desktop unit too.
+</div>
+
+## Quick picks
+
+<div class="pick-cards" markdown="0">
+<div class="pick-card pick-card--top">
+<span class="pick-card__badge">Best overall</span>
+<h3>Midland ER310</h3>
+<p class="pick-card__price">around $70</p>
+<p>The default for a reason: 2600 mAh replaceable battery (~32 h of radio), 6× AA backup, tone-alert standby, 130-lumen flashlight — and honest measured behavior.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B015QIC1PW?tag=gophertrunk-20" rel="nofollow sponsored noopener">ER310 on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/midland-er310/">ER310 details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Best features for the price</span>
+<h3>Kaito KA500</h3>
+<p class="pick-card__price">around $50–65</p>
+<p>The only current sub-$60 crank radio with real shortwave, plus 5-way power: crank, tilting solar, NiMH pack, 3× AA, and USB/AC. Rough edges, unmatched breadth.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B003A21DQA?tag=gophertrunk-20" rel="nofollow sponsored noopener">KA500 on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/kaito-ka500/">KA500 details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Most affordable</span>
+<h3>FosPower A1</h3>
+<p class="pick-card__price">around $27–35</p>
+<p>The budget class done competently — 4-way power, AAA backup, lifetime warranty. The catch: no alert standby of any kind. Pair it with alerting handled elsewhere.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B07FKYHTWP?tag=gophertrunk-20" rel="nofollow sponsored noopener">A1 on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/fospower-a1/">FosPower A1 details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Best used/classic buy</span>
+<h3>Grundig FR200</h3>
+<p class="pick-card__price">around $19–52 used</p>
+<p>The iconic early-2000s crank shortwave radio — simple enough that 20-year-old units still work, with a $10 swappable battery pack. No weather band, and say it twice.</p>
+<a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=grundig+fr200" rel="nofollow noopener">Find on eBay &rarr;</a>
+<p class="pick-card__note"><a href="/reference/grundig-fr200/">FR200 details</a></p>
+</div>
+</div>
+
+## How we grade
+
+Every radio here is judged on the same six criteria we use across the radio
+guides: **RF performance** (receiver sensitivity and audio for the class),
+**Coverage &amp; modes** (AM/FM/WX/shortwave, alert standby), **Power &amp;
+endurance** (battery size, crank and solar reality, backup options),
+**Usability** (tuning, controls, presets, form factor), **Ecosystem &amp;
+support** (availability, warranty, parts, community knowledge), and **Value**.
+No star ratings, no invented scores — table grades run
+Excellent/Good/Fair/Basic, and the two discontinued classics get a used-market
+viability note. The same rubric runs our
+[best shortwave radios](/best-shortwave-radios/) and
+[best desktop shortwave receivers](/best-desktop-shortwave-receivers/) guides,
+so grades are comparable across all three.
+
+## The top 10, ranked
+
+### 1. Midland ER310 — best overall
+
+The best **Power &amp; endurance** in the class — 2600 mAh, *replaceable*,
+~32 h of radio, plus a 6× AA fallback — with strong **Ecosystem** (Midland,
+Best Buy, REI, Amazon) and honest measured behavior: ~1 min crank ≈ 9 min of
+radio. Tone alert, not SAME; no shortwave; Micro-USB.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B015QIC1PW?tag=gophertrunk-20" rel="nofollow sponsored noopener">ER310 on Amazon &rarr;</a> · [ER310 review](/reference/midland-er310/)
+
+### 2. Sangean MMR-88 — the quality pick
+
+The best **RF performance** and build here: a genuinely good DSP receiver, 19
+presets, IPX3, and a crank figure (~1:5) that's *lower* than rivals claim and
+holds up under measurement. The 850 mAh battery and no AA option are what keep
+it from #1.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B00OJZOOLI?tag=gophertrunk-20" rel="nofollow sponsored noopener">MMR-88 on Amazon &rarr;</a> · [MMR-88 review](/reference/sangean-mmr-88/)
+
+### 3. Kaito KA500 — best features for the price
+
+Unmatched **Coverage &amp; modes**: the only current radio here with real
+shortwave (3.2–22 MHz), and the only 5-way power system. **Usability** is the
+cost — a flimsy analog dial, a tiny 600 mAh NiMH pack (replaceable), and
+rough-edged build.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B003A21DQA?tag=gophertrunk-20" rel="nofollow sponsored noopener">KA500 on Amazon &rarr;</a> · [KA500 review](/reference/kaito-ka500/)
+
+### 4. Eton FRX3+ — best bedside radio
+
+The alarm-clock form factor is the feature: digital tuning, a real alarm,
+glow-in-the-dark locator, aux/headphone jacks, 2600 mAh. Eton's 1 min ≈
+10–15 min crank claim is the roster's most optimistic — independent FRX tests
+land nearer 5–10. Commonly sold as the Red Cross ARCFRX3-WXR variant.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B00HSHH5DI?tag=gophertrunk-20" rel="nofollow sponsored noopener">FRX3+ on Amazon &rarr;</a> · [FRX3+ review](/reference/eton-frx3-plus/)
+
+### 5. Midland ER210 — best for the glovebox
+
+The ER310 platform in a compact body for ~$15 less. The trades are exactly the
+two things you'd want in a long outage — a smaller 2000 mAh battery and no AA
+backup — which is why it's the *second* radio, not the first.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B015QICDD2?tag=gophertrunk-20" rel="nofollow sponsored noopener">ER210 on Amazon &rarr;</a> · [ER210 review](/reference/midland-er210/)
+
+### 6. FosPower A1 — most affordable
+
+The budget class done competently: 4-way power, AAA backup, decent lights, a
+lifetime warranty, ~$30. The dealbreaker to know: **no alert standby at all** —
+plain weather-band listening only. Fine as the everywhere-radio; never your
+only warning path.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B07FKYHTWP?tag=gophertrunk-20" rel="nofollow sponsored noopener">A1 on Amazon &rarr;</a> · [FosPower A1 review](/reference/fospower-a1/)
+
+### 7. RunningSnail MD-092 — the budget power bank
+
+A 4000 mAh battery — the biggest here and double the A1's — makes it the
+budget group's most realistic phone top-up. Measured platform crank ratio is
+~1:3 at volume; alert standby is confirmed only on the MD-092P variant; QC
+variance is the budget-brand tax.
+<a class="btn btn--buy" href="https://www.amazon.com/s?k=RunningSnail+MD-092&tag=gophertrunk-20" rel="nofollow sponsored noopener">MD-092 on Amazon &rarr;</a> · [MD-092 review](/reference/runningsnail-md-092/)
+
+### 8. Eton Scorpion II — best for the trail
+
+IPX4 splashproof — the class's best formal rating — with rubber armor and a
+real carabiner. The 800 mAh battery (smallest here) and tinny speaker hold it
+at #8: buy it for ruggedness, not runtime.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B01BHLQHXE?tag=gophertrunk-20" rel="nofollow sponsored noopener">Scorpion II on Amazon &rarr;</a> · [Scorpion II review](/reference/eton-scorpion-ii/)
+
+### 9. Grundig FR200 — best used/classic buy
+
+The iconic crank shortwave radio at the lowest price in this guide (~$19–35
+working), with the architecture that ages best: a $10 swappable AA-size NiMH
+pack and almost nothing else to fail. **Used-market viability: excellent** —
+plentiful, cheap, simple. The hard caveat: **no weather band, no alerts,
+period**.
+<a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=grundig+fr200" rel="nofollow noopener">Find on eBay &rarr;</a> · [FR200 review](/reference/grundig-fr200/)
+
+### 10. Eton FR500 Solarlink — the classic flagship, eyes open
+
+AM/FM/shortwave/WX-with-alert in one crank box — a band set nothing current
+matches except the KA500. **Used-market viability: fair** — ~$30–70 on thin
+eBay data, with a checklist practically assumed: dead NiMH pack, gearbox wear,
+and the Eton sticky-coating cleanup.
+<a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=eton+fr500+solarlink" rel="nofollow noopener">Find on eBay &rarr;</a> · [FR500 review](/reference/eton-fr500/)
+
+## Full comparison
+
+| Radio | Alerting | Shortwave? | Power &amp; endurance | Value | ~$ price |
+|---|---|---|---|---|---|
+| [Midland ER310](/reference/midland-er310/) | Good (tone) | No | **Excellent** | **Excellent** | ~$70 |
+| [Sangean MMR-88](/reference/sangean-mmr-88/) | Good (tone) | No | Fair | **Excellent** | ~$50 |
+| [Kaito KA500](/reference/kaito-ka500/) | Good (tone) | **Yes** | **Excellent** | Good | ~$50–65 |
+| [Eton FRX3+](/reference/eton-frx3-plus/) | Good (tone) | No | Good | Good | ~$55–65 |
+| [Midland ER210](/reference/midland-er210/) | Good (tone) | No | Good | Good | ~$50–60 |
+| [FosPower A1](/reference/fospower-a1/) | **Basic — none** | No | Good | **Excellent** | ~$27–35 |
+| [RunningSnail MD-092](/reference/runningsnail-md-092/) | Fair (P variant) | No | Good | **Excellent** | ~$30–40 |
+| [Eton Scorpion II](/reference/eton-scorpion-ii/) | Good (tone) | No | Basic | Fair | ~$50 |
+| [Grundig FR200](/reference/grundig-fr200/) | Basic — none | **Yes** | Fair | Good | ~$19–52 used |
+| [Eton FR500](/reference/eton-fr500/) | Good (tone) | **Yes** | Fair | Good | ~$30–70 used |
+
+> **Buy the system, not the gadget.** A $30 plugged-in SAME desktop radio does
+> the waking; the crank radio does the aftermath; and a
+> [$30 RTL-SDR](/reference/rtl-sdr/) running free GopherTrunk covers the third
+> leg while the grid is up — monitoring and recording the local public-safety
+> and utility channels where the real information moves. Our
+> [scanner frequencies guide](/scanner-frequencies/) lists what to program.
+> All of it is license-free listening.
+
+## How to choose
+
+- **One radio for the house?** [ER310](/reference/midland-er310/) — battery,
+  AA fallback, availability.
+- **Care about receiver quality?** [MMR-88](/reference/sangean-mmr-88/) — the
+  one reviewers keep.
+- **Want shortwave in the same box?** [KA500](/reference/kaito-ka500/) new;
+  [FR500](/reference/eton-fr500/) or [FR200](/reference/grundig-fr200/) used —
+  and see our full [best shortwave radios](/best-shortwave-radios/) guide if
+  listening, not alerting, is the real goal.
+- **Nightstand duty?** [FRX3+](/reference/eton-frx3-plus/) — it's also an
+  alarm clock.
+- **Car and kit multiples on a budget?** [FosPower A1](/reference/fospower-a1/)
+  or the bigger-batteried [MD-092](/reference/runningsnail-md-092/) — with
+  alerting handled by something else.
+- **Backpack, boat, job site?** [Scorpion II](/reference/eton-scorpion-ii/) —
+  the only real IPX4 here.
+
+## Bottom line
+
+The **[Midland ER310](/reference/midland-er310/)** is the emergency radio for
+most people in 2026, the **[KA500](/reference/kaito-ka500/)** buys the most
+capability per dollar, the **[FosPower A1](/reference/fospower-a1/)** is the
+honest budget floor, and a **[Grundig FR200](/reference/grundig-fr200/)** is
+the classic worth hunting used — alongside, always, a plugged-in SAME desktop
+radio doing the actual alerting. If the crank got you curious about what else
+is out there on the bands, the same rubric and honesty run our
+[best shortwave radios](/best-shortwave-radios/) and
+[best desktop shortwave receivers](/best-desktop-shortwave-receivers/) guides —
+and for exploring HF on a computer, [best HF SDR](/best-hf-sdr/). The listening
+side is free either way: no license, ever.

--- a/docs/best-shortwave-radios.md
+++ b/docs/best-shortwave-radios.md
@@ -1,0 +1,256 @@
+---
+layout: page
+title: "The 10 Best Shortwave Radios (2026 Buyer's Guide)"
+description: "The best shortwave radios of 2026, ranked — Tecsun PL-990, Sangean ATS-909X2, XHDATA D-808, PL-330 and more — with honest grades, an SSB column, used-classic picks, and a straight answer on what's still on the bands."
+keywords: best shortwave radio, best shortwave radio 2026, portable shortwave radio, shortwave radio with SSB, Tecsun PL-990, Sangean ATS-909X2, XHDATA D-808, Tecsun PL-330, is shortwave radio still worth it, shortwave radio buying guide
+permalink: /best-shortwave-radios/
+nav_group: Hardware
+affiliate: true
+faq:
+  - q: "What is the best shortwave radio in 2026?"
+    a: "The Tecsun PL-990. Triple-conversion RF, real SSB with 10 Hz tuning, 3150 memories, and the best audio of any current portable make it the most complete shortwave radio in production, around $225–270. The PL-880 delivers most of it for ~$100 less."
+  - q: "Is shortwave radio still worth it in 2026?"
+    a: "Yes, with honest expectations. VOA's shortwave was largely shut down in 2025 and the BBC left North American shortwave decades ago, but state broadcasters, big US private stations, pirates, time signals, utility traffic, and ham SSB keep the bands genuinely alive — just quieter than the hobby's heyday."
+  - q: "What is the best cheap shortwave radio?"
+    a: "The Tecsun PL-330, around $60–90 — a pocketable radio with real SSB and 10 Hz fine tuning. Its main flaw is soft-mute on weak signals. The XHDATA D-808 (~$70–90) adds a VHF air band and RDS and is the best-features-for-the-price pick."
+  - q: "Do I need SSB on a shortwave radio?"
+    a: "If you want to hear hams, utility/aero/marine traffic, or anything beyond broadcast stations — yes, and as broadcasters retreat that traffic is an ever-bigger share of what's worth hearing. Note the Qodosen DX-286 has no SSB at all: it's a superb broadcast-only receiver, not a ham-band listener."
+  - q: "Do I need a license to listen to shortwave?"
+    a: "No. Listening is license-free everywhere in the US — no FCC anything, ever. Only transmitting requires a license; if you catch the bug and want to talk back, that's the amateur radio path — see our ham base station guide."
+---
+
+# The 10 Best Shortwave Radios (2026 Buyer's Guide)
+
+**First, the honest part.** The shortwave bands of 2026 are not the shortwave
+bands of 1985: VOA's transmitters were largely shut down in March 2025 (its
+status is still contested in court, but the wind-down of relay stations has
+continued), the BBC left North American shortwave back in 2001, and Radio
+Australia, Radio Netherlands, and most of Deutsche Welle went years earlier.
+What remains is real — state broadcasters with geopolitical motives (China,
+Romania, Turkey, Cuba), big US private and religious stations (WRMI, WWCR),
+pirates, time stations, utility/aero/marine traffic, and ham SSB — but North
+American English-language content is a shrinking slice, and no radio on this
+page will change that. Two things every buyer should know before spending a
+dollar: **listening is license-free everywhere in the US — no FCC anything,
+ever** — and on shortwave, **a $20 wire antenna out a window improves
+reception more than a $200 radio upgrade**. Buy the radio second.
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Best overall:** [Tecsun PL-990](/reference/tecsun-pl-990/) (~$225–270).
+**Best features for the price:** [XHDATA D-808](/reference/xhdata-d-808/)
+(~$70–90 — SSB + airband + RDS). **Most affordable:**
+[Tecsun PL-330](/reference/tecsun-pl-330/) (~$60–90, real SSB). **Best
+used/classic:** [Tecsun PL-660](/reference/tecsun-pl-660/) (~$90–140 — a
+sync detector better than anything Tecsun ships today). Wildcard: the
+[Eton Elite Executive](/reference/eton-elite-executive/) is being cleared
+out as low as $40–60 — sync + SSB + airband while stock lasts. The 2026
+bands are quieter but not empty; SSB capability matters more than ever.
+</div>
+
+## Quick picks
+
+<div class="pick-cards" markdown="0">
+<div class="pick-card pick-card--top">
+<span class="pick-card__badge">Best overall</span>
+<h3>Tecsun PL-990</h3>
+<p class="pick-card__price">around $225–270</p>
+<p>Triple-conversion RF, 10 Hz SSB tuning, 3150 memories, and the best audio in a current portable — plus Bluetooth and microSD playback. The radio the category is measured against.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B08KL77Q4H?tag=gophertrunk-20" rel="nofollow sponsored noopener">PL-990 on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/tecsun-pl-990/">PL-990 details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Best features for the price</span>
+<h3>XHDATA D-808</h3>
+<p class="pick-card__price">around $70–90</p>
+<p>SSB, VHF air band, FM with RDS, longwave, and an antenna jack under $90, with near-flagship sensitivity. Know the 2023-revision/Sihuadon-rebrand lottery and buy from a high-turnover seller.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0BL266J33?tag=gophertrunk-20" rel="nofollow sponsored noopener">D-808 on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/xhdata-d-808/">D-808 details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Most affordable</span>
+<h3>Tecsun PL-330</h3>
+<p class="pick-card__price">around $60–90</p>
+<p>The value benchmark: a shirt-pocket radio with real SSB and 10 Hz fine tuning, ETM+, and a swappable battery. Soft-mute on weak signals is the one flaw you accept.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0921HN6QM?tag=gophertrunk-20" rel="nofollow sponsored noopener">PL-330 on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/tecsun-pl-330/">PL-330 details</a></p>
+</div>
+<div class="pick-card">
+<span class="pick-card__badge">Best used/classic buy</span>
+<h3>Tecsun PL-660</h3>
+<p class="pick-card__price">around $90–140 used/NOS</p>
+<p>Discontinued ~2024, and its sync detector is still better than anything Tecsun ships today. Classic capability before the prices go collector-crazy — check the power-up fault first.</p>
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B004H9C4JK?tag=gophertrunk-20" rel="nofollow sponsored noopener">PL-660 on Amazon &rarr;</a>
+<p class="pick-card__note"><a href="/reference/tecsun-pl-660/">PL-660 details</a></p>
+</div>
+</div>
+
+## How we grade
+
+Every radio here is judged on the same six criteria: **RF performance**
+(sensitivity, selectivity, sync/SSB quality, image rejection), **Coverage
+&amp; modes** (LW/MW/SW/FM/Air/WX bands and SSB), **Power &amp; endurance**
+(battery life and power sources), **Usability** (tuning feel, controls,
+display, memories, soft-mute behavior), **Ecosystem &amp; support**
+(availability, service, parts, community knowledge base), and **Value**
+(what the street — or used — price buys). No star ratings, no invented
+scores: table grades run Excellent/Good/Fair/Basic, and used-market models
+also get a prose viability check — typical sold prices, known failure
+points, what to test before paying. The same rubric runs our
+[best emergency radios](/best-emergency-radios/) and
+[best desktop shortwave receivers](/best-desktop-shortwave-receivers/)
+guides, and the ham and two-way guides like
+[best ham radio base stations](/best-ham-radio-base-stations/), so grades
+are comparable across all of them.
+
+## The top 10, ranked
+
+### 1. Tecsun PL-990 — best overall
+
+**Excellent RF performance** (triple conversion — real image rejection),
+the best audio in a current portable, refined 10 Hz SSB, 3150 memories, and
+Bluetooth/microSD extras. No official sync detector and lingering Tecsun
+soft-mute/firmware quirks are the honest asterisks on the crown.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B08KL77Q4H?tag=gophertrunk-20" rel="nofollow sponsored noopener">PL-990 on Amazon &rarr;</a> · [PL-990 review](/reference/tecsun-pl-990/)
+
+### 2. Sangean ATS-909X2 — the big-radio flagship
+
+Arguably class-leading FM with RDS, very good MW, a real **air band with
+squelch**, SSB, and the best display and ergonomics in the segment. The old
+"deaf on the whip" complaint is largely resolved in the X2. What keeps it at
+#2: ~$289–350 pricing and heavier battery draw than the Tecsuns.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B08MSXX6LH?tag=gophertrunk-20" rel="nofollow sponsored noopener">ATS-909X2 on Amazon &rarr;</a> · [ATS-909X2 review](/reference/sangean-ats-909x2/)
+
+### 3. Tecsun PL-880 — the listening-pleasure pick
+
+Legendary big-speaker audio, lovely 10 Hz SSB tuning, five SSB bandwidths —
+still in production a dozen years on because nothing matches it for program
+listening at ~$150–170. The hidden-feature/firmware lottery and soft-mute
+are known Tecsun quirks; the hidden sync isn't worth using.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B00GJ51NVA?tag=gophertrunk-20" rel="nofollow sponsored noopener">PL-880 on Amazon &rarr;</a> · [PL-880 review](/reference/tecsun-pl-880/)
+
+### 4. XHDATA D-808 — best features for the price
+
+SSB + VHF airband + RDS + LW + antenna jack under $90, with sensitivity the
+community long compared to the PL-660 class — unmatched **Value**. The
+caveats are the variant lottery (2023 board revision, Sihuadon rebrand) and
+mushy buttons, not performance.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0BL266J33?tag=gophertrunk-20" rel="nofollow sponsored noopener">D-808 on Amazon &rarr;</a> · [D-808 review](/reference/xhdata-d-808/)
+
+### 5. C.Crane CC Skywave SSB 2 — the travel radio
+
+The only pocket radio with SSB, a scannable air band, *and* NOAA weather
+alerts — and ~70 hours on two AA cells is class-leading **Power &amp;
+endurance**. Thin speaker audio and a premium ~$169 price are what a shirt
+pocket costs.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0CBW768RF?tag=gophertrunk-20" rel="nofollow sponsored noopener">Skywave SSB 2 on Amazon &rarr;</a> · [Skywave SSB 2 review](/reference/cc-skywave-ssb-2/)
+
+### 6. Tecsun PL-330 — most affordable
+
+Real SSB with 10 Hz fine tuning, ETM+, an antenna jack, and a swappable
+BL-5C battery at ~$60–90 — the value benchmark for a first shortwave radio.
+Soft-mute on weak signals is its top complaint (tune 1–2 kHz off as a
+workaround), and stick to the primary Amazon listing — grey-market
+duplicates exist.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0921HN6QM?tag=gophertrunk-20" rel="nofollow sponsored noopener">PL-330 on Amazon &rarr;</a> · [PL-330 review](/reference/tecsun-pl-330/)
+
+### 7. Qodosen DX-286 — the sensitivity outlier
+
+The TEF6686 car-radio DSP makes it the weak-signal champion of the budget
+class and a superb FM/MW DX machine, with desktop-grade RF controls. It
+ranks #7 for one reason: **no SSB** (no airband or weather either) — a
+broadcast-only radio, however brilliant, misses the traffic that
+increasingly carries the hobby.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0D3V3H356?tag=gophertrunk-20" rel="nofollow sponsored noopener">DX-286 on Amazon &rarr;</a> · [DX-286 review](/reference/qodosen-dx-286/)
+
+### 8. Eton Elite Executive — the last-chance value pick
+
+Community-reported discontinued-with-stock (no formal Eton statement), and
+the clearance math is absurd: sync + SSB + airband + RDS as low as $40–60
+from reseller dumps, ~$130 for remaining Amazon stock. Volatile pricing,
+Eton QC reputation, and a wasting-asset warranty keep a screaming deal at
+#8 — verify the live price before you click.
+<a class="btn btn--buy" href="https://www.amazon.com/s?k=Eton+Elite+Executive&amp;tag=gophertrunk-20" rel="nofollow sponsored noopener">Find on Amazon &rarr;</a> · [Elite Executive review](/reference/eton-elite-executive/)
+
+### 9. Tecsun PL-660 — best used/classic buy
+
+Discontinued ~2024, and its selectable-sideband sync detector remains better
+than anything Tecsun currently ships — plus SSB and a basic airband, at
+~$90–140 used/NOS before collector pricing arrives. The used-market
+viability check: insist on a power-up video (the dead-display power-board
+fault), verify the frequency readout against WWV, sweep the BFO, prefer
+late production.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B004H9C4JK?tag=gophertrunk-20" rel="nofollow sponsored noopener">PL-660 on Amazon &rarr;</a> · [PL-660 review](/reference/tecsun-pl-660/)
+
+### 10. Sony ICF-SW7600GR — the reference classic
+
+Still the best synchronous detector ever shipped in a portable, with
+rock-solid AGC and bulletproof build — but its sensitivity is now matched by
+$80 DSP radios, and at ~$200–350 used (mint $400+, thin volatile market)
+you're paying collector money for the sync and the legend. Viability check:
+the ~28 aging SMD electrolytics, whip pivot, battery-bay corrosion, a
+both-sidebands sync test — and don't pay GR money for a non-GR SW7600.
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B00006IS4X?tag=gophertrunk-20" rel="nofollow sponsored noopener">SW7600GR on Amazon &rarr;</a> · [ICF-SW7600GR review](/reference/sony-icf-sw7600gr/)
+
+## Full comparison
+
+| Radio | RF | SSB | Coverage &amp; modes | Value | ~$ price |
+|---|---|---|---|---|---|
+| [Tecsun PL-990](/reference/tecsun-pl-990/) | **Excellent** | **Yes** | Good | Good | ~$225–270 |
+| [Sangean ATS-909X2](/reference/sangean-ats-909x2/) | Good | **Yes** | **Excellent** | Good | ~$289–350 |
+| [Tecsun PL-880](/reference/tecsun-pl-880/) | Good | **Yes** | Good | Good | ~$150–170 |
+| [XHDATA D-808](/reference/xhdata-d-808/) | Good | **Yes** | Good | **Excellent** | ~$70–90 |
+| [CC Skywave SSB 2](/reference/cc-skywave-ssb-2/) | Good | **Yes** | **Excellent** | Good | ~$169 |
+| [Tecsun PL-330](/reference/tecsun-pl-330/) | Good | **Yes** | Fair | **Excellent** | ~$60–90 |
+| [Qodosen DX-286](/reference/qodosen-dx-286/) | **Excellent** | No | Basic | Good | ~$80–150 |
+| [Eton Elite Executive](/reference/eton-elite-executive/) | Good | **Yes** (+ sync) | Good | **Excellent** (at dump price) | ~$40–130, volatile |
+| [Tecsun PL-660](/reference/tecsun-pl-660/) | Good | **Yes** (+ sync) | Good | Good | ~$90–140 used |
+| [Sony ICF-SW7600GR](/reference/sony-icf-sw7600gr/) | Good | **Yes** (+ sync) | Fair | Fair | ~$200–350 used |
+
+> **Antenna first, radio second.** Every radio in this table hears more with
+> $20 of wire out a window than the next model up hears from its whip — and
+> most of them have the external antenna jack to prove it. And remember what
+> licensing you need for any of this: none. Listening is license-free
+> everywhere in the US.
+
+## How to choose
+
+- **Best all-around radio, money no serious object?**
+  [PL-990](/reference/tecsun-pl-990/) — or the
+  [ATS-909X2](/reference/sangean-ats-909x2/) if class-leading FM and a
+  squelched airband beat triple-conversion SW for you.
+- **First shortwave radio?** [PL-330](/reference/tecsun-pl-330/) at ~$70, or
+  the [D-808](/reference/xhdata-d-808/) for airband and RDS at ~$85.
+- **It lives in a carry-on or go-bag?**
+  [CC Skywave SSB 2](/reference/cc-skywave-ssb-2/) — and if what you really
+  want is crank/solar and SAME alerting, that's the
+  [best emergency radios](/best-emergency-radios/) list.
+- **Broadcast/FM/MW DX only, maximum sensitivity?**
+  [DX-286](/reference/qodosen-dx-286/) — knowing it has no SSB.
+- **Sync detector on a budget?** Gamble on the
+  [Elite Executive](/reference/eton-elite-executive/) clearance, or buy the
+  used [PL-660](/reference/tecsun-pl-660/) properly checked.
+- **Knobs-and-filters romantic, desk not backpack?** The classic receivers —
+  Drake, Icom, AOR — live in
+  [best desktop shortwave receivers](/best-desktop-shortwave-receivers/).
+- **Want a waterfall instead of a whip?** An SDR on a computer tunes the
+  same spectrum with a spectrum display no portable can draw — see
+  [best HF SDR](/best-hf-sdr/) and the
+  [RTL-SDR](/reference/rtl-sdr/) direct-sampling route.
+
+## Bottom line
+
+The **[Tecsun PL-990](/reference/tecsun-pl-990/)** is the best shortwave
+radio for most people in 2026; the **[D-808](/reference/xhdata-d-808/)** is
+the most radio per dollar; the **[PL-330](/reference/tecsun-pl-330/)** is
+the cheapest credible start; and a checked-out
+**[PL-660](/reference/tecsun-pl-660/)** is the smart classic. Buy any of
+them with 2026 eyes: the bands are quieter than the genre's heyday, the wire
+antenna is the real upgrade, and listening is free of licenses forever. The
+siblings of this guide cover the rest of the territory —
+[best emergency radios](/best-emergency-radios/) for crank/solar/SAME
+preparedness, [best desktop shortwave receivers](/best-desktop-shortwave-receivers/)
+for the classic big iron, and [best HF SDR](/best-hf-sdr/) for the
+computer-side path. And if listening turns into wanting to talk back, that's
+a license and a transceiver: start at
+[best ham radio base stations](/best-ham-radio-base-stations/).

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -78,6 +78,12 @@ FRS/GMRS walkie-talkies, GMRS mobile rigs, and CB radios ranked with the same ho
 - [Best GMRS mobile radios]({{ '/best-gmrs-mobile-radios/' | absolute_url }}): the 10 best GMRS mobile and base rigs ranked, from the Radioddity DB20-G to the Midland MXT575 and Wouxun KG-1000G Plus.
 - [Best CB radios]({{ '/best-cb-radios/' | absolute_url }}): the 10 best CB radios ranked, from the Uniden PRO505XL to the Bearcat 880 and President McKinley, including collector classics.
 
+## Shortwave & emergency radio buyer's guides
+Portable and desktop shortwave receivers plus emergency crank/solar radios, ranked with the same honest rubric — all listen-only, no license ever.
+- [Best shortwave radios]({{ '/best-shortwave-radios/' | absolute_url }}): the 10 best portable shortwave receivers ranked, from the Tecsun PL-330 to the PL-990 and Sangean ATS-909X2, including discontinued classics.
+- [Best emergency radios]({{ '/best-emergency-radios/' | absolute_url }}): the 10 best crank/solar emergency radios ranked, with honest notes on tone alerts vs NOAA SAME and real crank runtimes.
+- [Best desktop shortwave receivers]({{ '/best-desktop-shortwave-receivers/' | absolute_url }}): the classic tabletop receivers worth buying used — Drake R8B, Icom IC-R75 — plus the few still made new.
+
 ## SDR hardware for GopherTrunk (buyer's guides)
 The receivers, antennas, cables, and accessories to run GopherTrunk, with honest picks and Amazon links.
 - [Best SDR for GopherTrunk]({{ '/best-sdr-for-gophertrunk/' | absolute_url }}): RTL-SDR, NESDR, Airspy, and HackRF compared for P25/DMR/NXDN decoding.

--- a/docs/reference/aor-ar7030.md
+++ b/docs/reference/aor-ar7030.md
@@ -131,6 +131,13 @@ paying anything.** Serviceability is the weakest of the classics: AOR UK is
 gone and a small circle of UK specialists services them — harder to keep
 alive than the Japanese sets.
 
+**Used-market viability:** the trickiest of the classics. Supply is
+UK-skewed, the scarce part (the display) is the failure-prone part, and the
+specialist service base is a small circle rather than a scene. None of that
+argues against ownership — it argues for buying a documented, working,
+remote-complete example at a verified-sold price rather than the first ask
+you see.
+
 ## GopherTrunk alternative
 
 Software-defined radio is what ended this product category — a ~$200 HF SDR

--- a/docs/reference/aor-ar7030.md
+++ b/docs/reference/aor-ar7030.md
@@ -1,0 +1,163 @@
+---
+slug: aor-ar7030
+title: AOR AR7030
+entry_type: hardware
+category: shortwave-radios
+description: "The AOR AR7030 is the classic tabletop shortwave receiver with arguably the best front end ever — legendary dynamic range and low-distortion audio behind famously divisive menu-and-remote ergonomics — used-market only, with thin ask-based pricing to verify."
+keywords: AOR AR7030, AR7030 review, AR7030 Plus, AR7030 for sale, best shortwave receiver dynamic range, classic tabletop receiver, John Thorpe receiver, AR7030 LCD problem, used shortwave receiver, is shortwave radio still worth it
+aka: [AR7030, AR7030 Plus, AR-7030]
+autolink: true
+affiliate: true
+product:
+  name: "AOR AR7030"
+  brand: AOR
+  category: Desktop shortwave receiver (classic)
+  seller: eBay
+  itemCondition: used
+  lowPrice: "700"
+  highPrice: "1300"
+  url: "https://www.ebay.com/sch/i.html?_nkw=aor+ar7030"
+infobox:
+  - { label: Type, value: "Classic tabletop shortwave receiver" }
+  - { label: Bands, value: "0–32 MHz" }
+  - { label: SSB / Sync, value: "Excellent SSB; sync AM works well (known low-level heterodyne quirk)" }
+  - { label: Power, value: "AC mains" }
+  - { label: License, value: "None — receiver" }
+  - { label: Price, value: "used; asks run high-three to low-four figures — verify sold listings" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.ebay.com/sch/i.html?_nkw=aor+ar7030\" rel=\"nofollow noopener\">Find on eBay &rarr;</a>" }
+see_also: [drake-r8b, jrc-nrd-545, lowe-hf-150, kenwood-r-5000, single-sideband, rtl-sdr]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "Best desktop shortwave receivers", url: /best-desktop-shortwave-receivers/ }
+cite_urls:
+  - https://mwcircle.org/legacy-receiver-reviews/receiver-review-aor-ar-7030-2/
+  - https://www.radiomuseum.org/r/aor_ar7030.html
+  - http://www.aorusa.com/support/bulletin_ar7030.html
+  - https://www.universal-radio.com/catalog/commrxvr/3396.html
+faq:
+  - q: "Is the AOR AR7030 the best classic shortwave receiver?"
+    a: "It's usually called the best pure performer of the classics — legendary dynamic range and strong-signal handling, superb low-distortion audio, up to six filters — while the Drake R8B is called the better listener's radio. The trade is ergonomics: a menu-driven single-knob interface that effectively requires the infrared remote."
+  - q: "How much does a used AR7030 cost?"
+    a: "Honest answer: the data is thin. Asking prices generally sit in the high three figures to low four figures, with the Plus variant and boxed-with-remote units at the top — but those are asks, not sales. Check eBay completed/sold listings yourself before paying; it originally listed at $1,150–1,269 new."
+  - q: "What is the AR7030's known weak point?"
+    a: "The LCD display — fade and outright failure are the notorious AR7030 fault, and replacement displays are the scarce part. Always ask for a photo of the lit display before buying, and ask about the SMD capacitor replacements (C22–27) documented in AOR's service bulletins."
+  - q: "Why does the AR7030 need its remote control?"
+    a: "The front panel is a minimalist menu-driven design with a single knob; full comfortable operation was designed around the infrared remote. A unit missing its working remote is significantly crippled — confirm it's present and functional before money changes hands."
+  - q: "Do I need a license for an AR7030?"
+    a: "No. It's receive-only, and listening is license-free everywhere in the US — no FCC anything, ever."
+---
+**The AOR AR7030** is the classic tabletop that performance chasers pick:
+designed by John Thorpe (ex-Lowe), built by AOR UK from 1996 to 2008, and
+crowned WRTH "Best Tabletop Receiver 1996/97".[^mwcircle] Its **dynamic range
+and strong-signal handling are its calling card — arguably the best front end
+of any classic** — wrapped in the most divisive ergonomics of the era. It's
+long out of production; the used market (eBay, UK second-hand dealers, SWL
+classifieds) is where it lives.
+
+<a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=aor+ar7030" rel="nofollow noopener">Find on eBay &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The best pure performer of the classic tabletops** — legendary dynamic
+range, continuously variable passband shift, up to 6 filters, superb
+low-distortion audio. **The catch is ergonomics:** menu-driven single-knob UI
+that all but requires the IR remote. **Pricing is the thinnest of any classic
+here** — asks run high-three to low-four figures, but verify eBay *sold*
+listings before believing any number. **Known fault: LCD fade/failure**, and
+replacements are scarce. **No license to listen — ever.** Where it ranks:
+[best desktop shortwave receivers](/best-desktop-shortwave-receivers/).
+</div>
+
+## Overview
+
+Every "greatest tabletop" list puts the AR7030 in the top three alongside the
+[Drake R8B](/reference/drake-r8b/) and [JRC NRD-545](/reference/jrc-nrd-545/),
+and the usual split is: the Drake is the best *listener's* radio, the AOR the
+best *performer*.[^mwcircle] The 0–32 MHz front end shrugs off strong-signal
+environments that make lesser receivers fold — big antennas, nearby
+broadcasters, crowded evening bands — and behind it sit continuously variable
+passband shift, provision for up to six filters, and audio with strikingly low
+distortion. The sync detector works well, with one known quirk: a low-level
+heterodyne that the passband shift tunes away.
+
+Then there's the interface. A minimalist panel, a single knob, menus — and an
+**infrared remote that is effectively required for comfortable full
+operation**. This is the famous Marmite ergonomic controversy: some owners
+find the system elegant, others never make peace with it. There is no
+middle opinion, so try to handle one (or watch operation videos) before
+committing serious money.
+
+Two honesty notes. First, the bands: major Western broadcasters have left
+shortwave, and what remains — international broadcasters, time signals,
+utility traffic, ham [SSB](/reference/single-sideband/), pirates — is real
+but quieter than when this radio was designed. Second, the antenna: **$20 of
+wire out a window improves reception more than a $200 radio upgrade**, and
+ironically the AR7030's great front end is exactly what lets it exploit a
+serious antenna without overloading.
+
+**Listening note:** receiving is license-free everywhere in the US — no FCC
+registration, exam, or paperwork, ever.
+
+## Bands, modes &amp; features
+
+- **Coverage:** 0–32 MHz.
+- **Modes:** [AM](/reference/amplitude-modulation/), sync AM, SSB, CW, Data,
+  FM.
+- **Selectivity:** continuously variable passband shift, up to 6 filters
+  (fit-out varies — the Plus variant, from late 1997, adds more).
+- **Control:** menu-driven single-knob panel + IR remote. **Power:** AC mains.
+
+## Buying used: what to check
+
+The AR7030 is the hardest classic here to buy well — thin market data, scarce
+parts, UK-centric supply:[^bulletins]
+
+1. **The LCD.** Display fade and failure are *the* notorious AR7030 fault,
+   and replacement displays are the scarce part. Demand a photo of the lit
+   display; walk away from a dim one unless it's priced as a parts unit.
+2. **Service history.** AOR technical bulletins document SMD capacitor
+   replacements (C22–27) — ask specifically whether that work has been done.
+3. **The remote.** Confirm the IR remote is present and working. The radio is
+   crippled without it.
+4. **Clock/memory battery** and **which filter fit-out** you're buying (Plus
+   vs base changes the value materially).
+
+On price, hedge hard: our research found active eBay and UK-dealer listings
+but **no confirmed sold prices** — asks generally sit in the high three
+figures to low four figures, Plus and boxed-with-remote units at the top, and
+asks are not sales. **Check eBay completed/sold listings before quoting or
+paying anything.** Serviceability is the weakest of the classics: AOR UK is
+gone and a small circle of UK specialists services them — harder to keep
+alive than the Japanese sets.
+
+## GopherTrunk alternative
+
+Software-defined radio is what ended this product category — a ~$200 HF SDR
+rivals a four-figure legacy tabletop and adds a waterfall display no knob
+radio can draw. The AR7030's one enduring edge, strong-signal handling, is
+also the one thing cheap SDRs genuinely struggle with, which is why it keeps
+its cult. Still: buying one today is a deliberate knobs-and-filters choice
+over performance-per-dollar. The modern path is an
+[HF-capable SDR](/best-hf-sdr/) or an [RTL-SDR](/reference/rtl-sdr/) in
+direct-sampling mode; GopherTrunk itself stays in its VHF/UHF scanner lane —
+same listen-first philosophy, free.
+
+## Who it's for
+
+- **Buy the AR7030** if you want the best-performing classic front end ever
+  sold, you've made peace with the remote-driven interface, and you'll verify
+  the display and service history first.
+  <a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=aor+ar7030" rel="nofollow noopener">Find on eBay &rarr;</a>
+- **Buy the [Drake R8B](/reference/drake-r8b/)** instead for the better
+  listener's radio with normal ergonomics, or the
+  [Lowe HF-150](/reference/lowe-hf-150/) for the same British design lineage
+  in a simple, cheap package.
+- **Allergic to project radios?** See the current-production
+  [Icom IC-R8600](/reference/icom-ic-r8600/). Full rankings:
+  [best desktop shortwave receivers](/best-desktop-shortwave-receivers/).
+
+## Sources
+
+[^mwcircle]: [Receiver review: AOR AR7030 — Medium Wave Circle](https://mwcircle.org/legacy-receiver-reviews/receiver-review-aor-ar-7030-2/) — performance verdict, dynamic-range reputation, ergonomic controversy, WRTH award; production history corroborated by [Radiomuseum](https://www.radiomuseum.org/r/aor_ar7030.html) and the [Universal Radio archive](https://www.universal-radio.com/catalog/commrxvr/3396.html).
+[^bulletins]: [AR7030 technical bulletins — AOR USA](http://www.aorusa.com/support/bulletin_ar7030.html) — documented service items including the C22–27 SMD capacitor replacements referenced in the buying checklist.

--- a/docs/reference/cc-skywave-ssb-2.md
+++ b/docs/reference/cc-skywave-ssb-2.md
@@ -1,0 +1,141 @@
+---
+slug: cc-skywave-ssb-2
+title: C.Crane CC Skywave SSB 2
+entry_type: hardware
+category: shortwave-radios
+description: "The C.Crane CC Skywave SSB 2 is the most capable travel radio per cubic inch — SSB, scannable VHF air band, NOAA weather with alert, and ~70 hours on two AA cells, around $169. The only true pocket radio with this feature set."
+keywords: CC Skywave SSB 2 review, C.Crane Skywave SSB 2, best travel shortwave radio, pocket shortwave radio with SSB, shortwave radio with NOAA weather, emergency travel radio, Skywave SSB 2 vs PL-330, AA battery shortwave radio, air band portable radio, is shortwave radio still worth it
+aka: [Skywave SSB 2, CC Skywave SSB-2]
+autolink: true
+affiliate: true
+product:
+  name: "C.Crane CC Skywave SSB 2"
+  brand: C.Crane
+  category: Travel shortwave receiver (pocket)
+  lowPrice: "169"
+  highPrice: "169"
+  url: https://www.amazon.com/dp/B0CBW768RF?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: "Pocket travel receiver (DSP)" }
+  - { label: Bands, value: "MW / FM / SW / NOAA weather + alert / scannable VHF Air (no LW)" }
+  - { label: SSB, value: "Yes — with fine tuning; no sync detector" }
+  - { label: Power, value: "2×AA, ~70 h battery life" }
+  - { label: License, value: "None — receiver" }
+  - { label: Price, value: "around $169" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B0CBW768RF?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [tecsun-pl-330, xhdata-d-808, midland-er310, sangean-mmr-88, shortwave-broadcast, single-sideband]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "Best shortwave radios", url: /best-shortwave-radios/ }
+cite_urls:
+  - https://radiojayallen.com/c-crane-skywave-ssb-2/
+  - https://the-weather.com/c-crane-cc-skywave-ssb-2-review/
+faq:
+  - q: "Is the CC Skywave SSB 2 worth $169?"
+    a: "If size and battery economics matter, yes — it's the only radio in its pocket class with SSB, a scannable air band, and NOAA weather alerts, and it runs ~70 hours on two AA cells. If you don't travel with it, a Tecsun PL-330 or XHDATA D-808 does the shortwave core for half the money."
+  - q: "What's the difference between the Skywave SSB and the Skywave SSB 2?"
+    a: "The SSB 2 added an external shortwave antenna connection (it ships with a wire antenna adapter) and largely addressed the QC and overload complaints reported on the original Skywave SSB — don't hold the first version's gripes against the 2."
+  - q: "Does the Skywave SSB 2 have NOAA weather alerts?"
+    a: "Yes — all NOAA weather channels plus an alert function, alongside MW/FM/SW and the scannable VHF air band. Note it's a weather-alert travel radio, not a crank/solar emergency radio; for that class see our emergency-radio guide."
+  - q: "How long does the Skywave SSB 2 run on batteries?"
+    a: "Around 70 hours on two AA cells — class-leading, and the reason preparedness-minded buyers like it: AA batteries are the world's easiest resupply."
+  - q: "Do I need a license to listen to shortwave, air band, or weather radio?"
+    a: "No — listening is license-free everywhere in the US, no FCC anything, ever. And on shortwave, the included wire antenna out a hotel window will do more for reception than any radio upgrade — a $20 wire beats a $200 radio swap."
+---
+**The C.Crane CC Skywave SSB 2** is the most capable radio per cubic inch in
+this roster: a true pocket set with [SSB](/reference/single-sideband/), a
+**scannable VHF air band**, **NOAA weather with alert**, MW/FM/SW coverage,
+and about **70 hours on two AA cells** — the class-leading battery economics
+of the segment.[^rja] At around **$169** it costs real money for a small
+radio, and it's worth it for exactly one kind of buyer: the one who carries
+it.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0CBW768RF?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The travel radio, full stop.** SSB + scannable airband + NOAA weather
+alerts in a shirt pocket, ~70 h on 2×AA. The SSB 2 added an external SW
+antenna connection and fixed the original's QC gripes. **No LW, no sync,
+thin small-speaker audio** — use earbuds. **~$169.** **License-free
+listening**; the included wire antenna out a hotel window is the real
+performance feature. Where it ranks:
+[best shortwave radios](/best-shortwave-radios/).
+</div>
+
+## Overview
+
+C.Crane designed the Skywave line around a question no one else was asking:
+what's the most listening capability that fits in a shirt pocket and runs on
+batteries you can buy at a gas station? The SSB 2 is the mature answer. MW,
+FM, shortwave with SSB and fine tuning, all NOAA weather channels with alert,
+and a VHF air band you can actually scan. Nothing else this size does that
+list — the [PL-330](/reference/tecsun-pl-330/) is its size but has no air or
+weather band; the [D-808](/reference/xhdata-d-808/) has air but no weather
+and is a size class up.[^weather]
+
+The "2" matters. The original Skywave SSB drew QC and overload complaints;
+the SSB 2 largely addressed them — don't hold the first version's reputation
+against this one — and added an external shortwave antenna connection, with
+a wire antenna adapter in the box. That last addition is the philosophically
+correct one: **on shortwave, $20 of wire out a window improves reception more
+than a $200 radio upgrade**, and C.Crane ships the wire.
+
+The honest costs: the tiny speaker is thin and struggles in a noisy room
+(earbuds transform it), there's **no longwave**, no sync detector, and $169
+is premium money for a pocket radio. The battery story is the rebuttal —
+~70 hours from two AA cells, the world's easiest batteries to resupply, which
+is why this radio shows up in so many go-bags. If what you actually want is a
+crank/solar emergency radio, that's a different tool — see the
+[Midland ER310](/reference/midland-er310/) and our emergency roster — but as
+a *weather-aware travel receiver* the Skywave SSB 2 has no peer.
+
+**Listening is license-free everywhere in the US — no FCC anything, ever** —
+shortwave, airband, and weather radio alike. And the 2026 shortwave bands
+deserve honest framing: the big Western broadcasters have mostly left, so
+what a traveler hears now is state broadcasters, US private stations, time
+signals, pirates, and ham SSB — which is exactly why the SSB button on this
+radio earns its place.
+
+## Bands, modes &amp; features
+
+- **Coverage:** MW, FM, SW, NOAA weather (all channels, with alert),
+  scannable VHF air band. **No LW.**
+- **SSB:** yes, with fine tuning. No sync detector.
+- **Memories:** 400.
+- **Power:** 2×AA, ~70 h — class-leading; ideal preparedness economics.
+- **Connections:** external SW antenna connection (wire antenna adapter
+  included).
+- **Size:** true pocket/travel class — the smallest radio in our roster.
+- No Bluetooth, no recording.
+
+## GopherTrunk alternative
+
+Shortwave is HF AM/SSB — not GopherTrunk's trunking/digital domain, and
+GopherTrunk does not decode it. The computer-side route into the same
+spectrum is an HF-capable SDR ([best HF SDR](/best-hf-sdr/)) or a ~$30
+[RTL-SDR](/reference/rtl-sdr/) in direct-sampling mode, with a
+[waterfall](/reference/waterfall-display/) no portable can draw — GopherTrunk
+itself stays in its VHF/UHF scanner lane, same listen-first philosophy, free.
+But the Skywave's whole argument is the opposite case: an SDR needs a
+computer and power, and this radio's job is a hotel nightstand or a power
+outage, 70 hours deep into a pair of AAs.
+
+## Who it's for
+
+- **Buy the Skywave SSB 2** if it will live in a carry-on or go-bag — the
+  only pocket radio with SSB, airband, and weather alerts, on batteries you
+  can buy anywhere.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B0CBW768RF?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [XHDATA D-808](/reference/xhdata-d-808/)** instead if it will
+  mostly stay home — half the price, bigger speaker, SSB and airband (no
+  weather), or the [PL-330](/reference/tecsun-pl-330/) for the cheapest SSB.
+- **Want crank/solar and SAME alerting instead?** That's the emergency-radio
+  category — start with the [Midland ER310](/reference/midland-er310/). Full
+  shortwave rankings: [best shortwave radios](/best-shortwave-radios/).
+
+## Sources
+
+[^rja]: [C.Crane CC Skywave SSB 2 review — RadioJayAllen](https://radiojayallen.com/c-crane-skywave-ssb-2/) — feature set, the SSB 2's external antenna addition and QC improvements over the original, and comparative standing in the travel class.
+[^weather]: [CC Skywave SSB 2 review — The-Weather.com](https://the-weather.com/c-crane-cc-skywave-ssb-2-review/) — pricing, NOAA weather/alert operation, and battery-life figures.

--- a/docs/reference/drake-r8b.md
+++ b/docs/reference/drake-r8b.md
@@ -131,6 +131,12 @@ listings skew ambitious. **Check eBay sold listings, not asking prices,
 before you pay.** Drake is gone, but the DrakeR8 groups.io community and
 independent techs keep these alive, with parts via donor units.
 
+**Used-market viability:** among the best of any classic. The faults are
+few and specific, the fixes documented, and demand stays deep enough that a
+well-bought R8B has historically held its money — which is also why a
+patient buyer beats an eager one. The VHF converter is the accessory that
+moves price most; confirm whether it's fitted rather than "available".
+
 ## GopherTrunk alternative
 
 SDRs are what killed this product category: a ~$200 HF SDR rivals or beats a

--- a/docs/reference/drake-r8b.md
+++ b/docs/reference/drake-r8b.md
@@ -1,0 +1,163 @@
+---
+slug: drake-r8b
+title: Drake R8B
+entry_type: hardware
+category: shortwave-radios
+description: "The Drake R8B is the consensus best classic tabletop shortwave receiver ever made — benchmark selectable-sideband sync AM, five bandwidths, and the best program-listening audio in the class — used-market only at roughly $550–1,100."
+keywords: Drake R8B, Drake R8B review, Drake R8B for sale, best tabletop shortwave receiver, classic shortwave receiver, Drake R8B sync detector, used shortwave receiver, Drake R8B encoder repair, R8B vs AR7030, is shortwave radio still worth it
+aka: [R8B, Drake R-8B]
+autolink: true
+affiliate: true
+product:
+  name: "Drake R8B"
+  brand: Drake
+  category: Desktop shortwave receiver (classic)
+  seller: eBay
+  itemCondition: used
+  lowPrice: "550"
+  highPrice: "1100"
+  url: "https://www.ebay.com/sch/i.html?_nkw=drake+r8b"
+infobox:
+  - { label: Type, value: "Classic tabletop shortwave receiver" }
+  - { label: Bands, value: "100 kHz–30 MHz (optional VHF converter: 35–55/108–174 MHz)" }
+  - { label: SSB / Sync, value: "SSB, CW, RTTY, FM; selectable-sideband sync AM — best in class" }
+  - { label: Power, value: "AC mains" }
+  - { label: License, value: "None — receiver" }
+  - { label: Price, value: "around $550–1,100 used" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.ebay.com/sch/i.html?_nkw=drake+r8b\" rel=\"nofollow noopener\">Find on eBay &rarr;</a>" }
+see_also: [aor-ar7030, jrc-nrd-545, icom-ic-r75, grundig-satellit-800, shortwave-broadcast, rtl-sdr]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "Best desktop shortwave receivers", url: /best-desktop-shortwave-receivers/ }
+cite_urls:
+  - https://www.universal-radio.com/catalog/commrxvr/0082.html
+  - https://mwcircle.org/legacy-receiver-reviews/receiver-review-drake-r8b/
+  - https://en.wikipedia.org/wiki/R._L._Drake_Company
+faq:
+  - q: "Is the Drake R8B the best shortwave receiver ever made?"
+    a: "For broadcast listening, that's the enduring consensus. Its selectable-sideband synchronous AM detector is widely rated the best ever put in a tabletop, the five standard bandwidths plus passband offset carve up crowded bands, and nothing in the classic era sounds better on program audio. Pure-performance rivals (AOR AR7030, JRC NRD-545) match or beat it on specs; none beat it as a listener's radio."
+  - q: "How much does a used Drake R8B cost?"
+    a: "Roughly $550–1,100 depending on condition and accessories — forum consensus calls $500 a good buy, near-mint units ask around $850, and one eBay sale with the VHF converter closed at $1,125. Asks skew ambitious (it briefly traded above its new price after discontinuation), so check eBay sold listings before paying."
+  - q: "What goes wrong with a Drake R8B?"
+    a: "Two known faults: the optical tuning encoder gets dirty and intermittent, making the frequency jump while you tune (a documented ~$50 replacement fixes it), and the power-supply electrolytics fail with age — sometimes catastrophically while the radio sits idle. Ask about recap history and encoder behavior before buying."
+  - q: "Do I need a license to use a Drake R8B?"
+    a: "No. It's a receiver — listening is license-free everywhere in the US, no FCC paperwork of any kind, ever."
+  - q: "Is a Drake R8B better than a modern SDR?"
+    a: "On raw performance per dollar, no — a ~$200 HF SDR rivals or beats it and adds a spectrum waterfall. You buy an R8B for what an SDR can't sell: real knobs, the best sync detector and program audio of the classic era, and a self-contained box with no computer attached."
+---
+**The Drake R8B** is the classic tabletop shortwave receiver — the last radio
+R.L. Drake built (1997–2004) and the one nearly every "greatest receiver" list
+puts on top.[^universal] Its selectable-sideband **synchronous AM detector is
+widely rated the best ever fitted to a tabletop**, its audio is the standard
+for program listening, and it has been out of production for two decades: the
+used market — eBay, estate sales, SWL classifieds — is where it lives, at
+roughly **$550–1,100**.
+
+<a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=drake+r8b" rel="nofollow noopener">Find on eBay &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The consensus #1 classic SWL tabletop — best sync detection and best
+broadcast audio of the breed.** 100 kHz–30 MHz, AM/SSB/CW/RTTY/FM, five
+bandwidths standard, passband offset, notch, 1,000 memories. **Used only,
+~$550–1,100** — asks skew high, so verify against eBay sold listings. **The
+buying game is the encoder and the power-supply caps** (both documented,
+fixable faults). **No license to listen — ever.** Where it ranks: our
+[best desktop shortwave receivers](/best-desktop-shortwave-receivers/) guide
+(spoiler: #1).
+</div>
+
+## Overview
+
+In 1997 the R8B was the final refinement of Drake's R8 line, and it closed out
+American tabletop receiver manufacturing on a high: 100 kHz–30 MHz coverage,
+five bandwidth filters standard (6.0/4.0/2.3/1.8/0.5 kHz) where rivals made
+you buy them, passband offset, a notch filter, 1,000 memories, and the
+detector that made its name — **selectable-sideband synchronous AM**, which
+locks onto a broadcast carrier and lets you pick the cleaner sideband when
+interference or selective fading chews on the other one.[^mwcircle] For music
+and voice off the [shortwave broadcast](/reference/shortwave-broadcast/)
+bands, nothing in the classic era sounds better.
+
+It isn't flawless: the lime-green LED display divides opinion, the tuning knob
+is light and flywheel-less, and the ergonomics trail the Japanese competition.
+Owners forgive all of it the moment a weak signal locks in sync.
+
+Be honest with yourself about the bands, too. The big Western broadcasters
+have largely left shortwave; what remains — international broadcasters, time
+stations, utility and HF traffic, ham [SSB](/reference/single-sideband/),
+pirates — is real but quieter than the R8B's own heyday. And the oldest truth
+in the hobby still holds: **$20 of wire antenna out a window improves
+reception more than a $200 radio upgrade.** Budget for the wire before you
+bid on the radio.
+
+**Listening note:** receiving is license-free everywhere in the US. No FCC
+anything, ever — plug in, tune, listen.
+
+## Bands, modes &amp; features
+
+- **Coverage:** 100 kHz–30 MHz; an optional VHF converter adds 35–55 and
+  108–174 MHz.
+- **Modes:** [AM](/reference/amplitude-modulation/),
+  [SSB](/reference/single-sideband/), CW, RTTY, FM — plus the benchmark
+  selectable-sideband sync AM.
+- **Selectivity:** five bandwidths standard (6.0/4.0/2.3/1.8/0.5 kHz),
+  passband offset, notch.
+- **Memories:** 1,000. **Power:** AC mains. Built in Ohio, the last of the
+  line.[^drake]
+
+## Buying used: what to check
+
+The R8B's aging faults are few and well documented — this is one of the
+safer classics to buy, if you ask the right questions:[^universal]
+
+1. **The tuning encoder.** The signature R8B fault: a dirty or worn optical
+   encoder makes the frequency jump around while tuning. The fix is a
+   documented ~$50 replacement encoder (PN ENA1J-B28-L00128L). Ask the seller
+   to tune slowly across a band and report any skips.
+2. **Power-supply electrolytics.** They fail with age — sometimes
+   catastrophically while the radio sits idle. Ask whether it's been recapped,
+   by whom, and when; price an un-recapped unit accordingly.
+3. **Filters and sync.** Step through all five bandwidths and confirm sync
+   locks on *both* sidebands.
+4. **Display segments.** Check every digit of the green LED display lights.
+
+On price: forum consensus calls **$500 a good buy**, near-mint examples ask
+around **$850**, and one eBay sale with the VHF converter closed at
+**$1,125**. Those numbers mix asks with thin confirmed sales — the R8B
+briefly traded *above* its $1,379 new price after discontinuation, so
+listings skew ambitious. **Check eBay sold listings, not asking prices,
+before you pay.** Drake is gone, but the DrakeR8 groups.io community and
+independent techs keep these alive, with parts via donor units.
+
+## GopherTrunk alternative
+
+SDRs are what killed this product category: a ~$200 HF SDR rivals or beats a
+$1,000 legacy tabletop on raw performance and draws a spectrum waterfall no
+knob radio can. Buying an R8B today is a deliberate choice of knobs, filters,
+and the best sync-AM audio ever made over performance-per-dollar — a valid
+choice, but make it with open eyes. The modern way to explore the same
+spectrum is an [HF-capable SDR](/best-hf-sdr/) or an
+[RTL-SDR](/reference/rtl-sdr/) in direct-sampling mode on a computer.
+GopherTrunk itself stays in its VHF/UHF scanner lane — but it's the same
+listen-first philosophy, free.
+
+## Who it's for
+
+- **Buy the R8B** if you want the definitive classic broadcast listener's
+  receiver — the best sync and audio of the era — and you'll verify encoder
+  and recap history first.
+  <a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=drake+r8b" rel="nofollow noopener">Find on eBay &rarr;</a>
+- **Buy the [AOR AR7030](/reference/aor-ar7030/)** instead if you chase raw
+  front-end performance, or the [JRC NRD-545](/reference/jrc-nrd-545/) for
+  DSP-era flexibility.
+- **Spending less?** The [Icom IC-R75](/reference/icom-ic-r75/) is the value
+  classic at ~$300–500. Full rankings:
+  [best desktop shortwave receivers](/best-desktop-shortwave-receivers/).
+
+## Sources
+
+[^universal]: [Drake R8B — Universal Radio archive](https://www.universal-radio.com/catalog/commrxvr/0082.html) — specifications, bandwidth set, sync detection, memories, production status, and original pricing.
+[^mwcircle]: [Receiver review: Drake R8B — Medium Wave Circle](https://mwcircle.org/legacy-receiver-reviews/receiver-review-drake-r8b/) — the reference legacy review: sync detector quality, audio, ergonomic criticisms, used-market standing.
+[^drake]: [R.L. Drake Company — Wikipedia](https://en.wikipedia.org/wiki/R._L._Drake_Company) — company history and the R8B's place as the end of the American tabletop receiver line.

--- a/docs/reference/eton-elite-750.md
+++ b/docs/reference/eton-elite-750.md
@@ -124,6 +124,14 @@ anything, ever.
   used-classic route (or a hybrid like Tecsun's H-501x) becomes the answer —
   our [guide](/best-desktop-shortwave-receivers/) tracks the state of play.
 
+Who is it actually for? Someone who wants a handsome, room-filling radio on
+the shelf, tuned to international broadcasters in the evening, without
+learning a used-market checklist or connecting anything to a computer. For
+that listener it delivers, and the warranty is worth something real. For
+anyone who says "DX", "utility", or "weak signal" in their first sentence,
+it's the wrong radio — and this site would rather tell you that than sell
+you it.
+
 ## GopherTrunk alternative
 
 The Elite 750 exists because some people rightly want a radio that looks and

--- a/docs/reference/eton-elite-750.md
+++ b/docs/reference/eton-elite-750.md
@@ -1,0 +1,157 @@
+---
+slug: eton-elite-750
+title: Eton Elite 750
+entry_type: hardware
+category: shortwave-radios
+description: "The Eton Elite 750 is the last affordable big new knob radio — 100 kHz–30 MHz plus FM and AIR with SSB and a rotating MW antenna, around $400–500 new — a pleasant program listener, not a DXer's machine: no sync, no PBT, and a late-lifecycle warning."
+keywords: Eton Elite 750, Elite 750 review, Grundig Satellit 750, Eton Elite 750 price, new shortwave radio 2026, tabletop shortwave radio new, Elite 750 vs Satellit 800, Elite 750 SSB, shortwave radio with air band, is shortwave radio still worth it
+aka: [Elite 750, Grundig Satellit 750, Tecsun S-2000]
+autolink: true
+affiliate: true
+product:
+  name: "Eton Elite 750"
+  brand: Eton
+  category: Desktop shortwave receiver (current production)
+  lowPrice: "300"
+  highPrice: "500"
+  url: "https://www.amazon.com/dp/B08BVSCY8G?tag=gophertrunk-20"
+infobox:
+  - { label: Type, value: "Tabletop-style shortwave receiver (current, late-lifecycle)" }
+  - { label: Bands, value: "100 kHz–30 MHz + FM + AIR band" }
+  - { label: SSB / Sync, value: "SSB (mediocre); no synchronous detection, no PBT" }
+  - { label: Power, value: "Batteries or AC adapter" }
+  - { label: License, value: "None — receiver" }
+  - { label: Price, value: "around $400–500 list, frequently discounted ~$100" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B08BVSCY8G?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [grundig-satellit-800, sony-icf-2010, icom-ic-r8600, drake-r8b, shortwave-broadcast, rtl-sdr]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "Best desktop shortwave receivers", url: /best-desktop-shortwave-receivers/ }
+cite_urls:
+  - https://www.qsl.net/n9ewo/s750.html
+  - https://radiojayallen.com/grundig-satellit-750tecsun-s-2000-another-look/
+  - https://www.dxengineering.com/parts/eon-nelite750
+faq:
+  - q: "Is the Eton Elite 750 still being made?"
+    a: "As of August 2026 it's still sold new at Amazon, DX Engineering, and Adorama, and remains in Eton's Elite line — but there are clearance signals (Universal Radio no longer stocks it), so treat it as in production but late-lifecycle and verify availability when you buy."
+  - q: "Is the Eton Elite 750 the same as the Grundig Satellit 800?"
+    a: "No — and the visual resemblance misleads. The Elite 750 is the Grundig Satellit 750 rebadged (Tecsun S-2000 hardware), and it lacks the Satellit 800's Drake-designed synchronous detector, passband tuning, and selectable AGC. Reviewers put it 'not in the same ballpark' as the 800."
+  - q: "Does the Eton Elite 750 have SSB?"
+    a: "Yes, but reviewers rate its SSB mediocre — fine for casually tuning ham nets, frustrating for serious utility or DX work. There's no synchronous AM detection at all. It's a program listener's radio, not a DXer's."
+  - q: "Why are some Eton Elite 750 listings so cheap?"
+    a: "Beware: deep-discount Elite 750 listings circulating online include outright scam storefronts (a recurring RadioReference forum warning). Buy from Amazon directly or an established dealer like DX Engineering or Adorama, and treat too-good prices as the red flag they are."
+  - q: "Do I need a license for the Eton Elite 750?"
+    a: "No. It's a receiver — listening is license-free everywhere in the US, with no FCC anything, ever."
+---
+**The Eton Elite 750** is the last big *affordable* knob radio you can buy
+new: a 100 kHz–30 MHz tabletop-style set with FM and the AIR band, SSB, a
+360° rotating MW ferrite antenna, 1,000 memories, and big-radio audio, at
+around **$400–500 list and frequently discounted by about $100**.[^dxe] It's
+the Grundig Satellit 750 rebadged — and the honest review is that it wears
+the Satellit name without the Satellit 800's receiver.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B08BVSCY8G?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**A listener's radio, not a DXer's — and the only affordable new
+tabletop-style set with a warranty.** 100 kHz–30 MHz + FM + AIR, SSB
+(mediocre), rotating MW antenna, 1,000 memories, good speaker. **No sync
+AM, no passband tuning, no selectable AGC** — a big step down from the
+Satellit 800/Drake lineage it visually imitates. **Late-lifecycle:** still
+sold new (Amazon, DX Engineering, Adorama) but with clearance signals —
+and **scam deep-discount listings circulate; buy from real dealers.** **No
+license to listen — ever.** Where it ranks:
+[best desktop shortwave receivers](/best-desktop-shortwave-receivers/).
+</div>
+
+## Overview
+
+Strip away the Satellit styling and the Elite 750 is Tecsun S-2000 hardware
+wearing Eton badges: a big, handsome, analog-hearted receiver whose real
+strengths are the speaker, the coverage (longwave through 30 MHz, FM, and
+the aviation band), the fun of the rotating medium-wave ferrite on top, and
+the simple pleasure of a large radio with real controls.[^n9ewo] As a
+bedside/den program listener for international broadcasters and MW DXing,
+reviewers rate it pleasant and genuinely likeable.
+
+What it is *not* is an heir to the [Grundig Satellit
+800](/reference/grundig-satellit-800/) it resembles. There's **no
+synchronous detection, no passband tuning, no selectable AGC** — the three
+tools that separate a DX receiver from a nice radio — SSB performance is
+mediocre, and reviews note some birdies and images. radiojayallen and N9EWO
+put it plainly: "not in the same ballpark" as the 800.[^jayallen] Its honest
+role in 2026 is different and still real: **the only affordable
+tabletop-style shortwave radio you can buy new, with a warranty and Amazon
+availability**, in a market where everything better is either used-classic
+or $2,750.
+
+Two cautions and two truths. Caution one: it's **late-lifecycle** — still
+in Eton's line and sold by real dealers, but Universal Radio has dropped it
+and clearance signals are circulating; verify stock when you buy. Caution
+two: **deep-discount scam listings** for this model circulate (a recurring
+RadioReference warning) — buy from Amazon proper, DX Engineering, or
+Adorama, and treat a too-good price as the tell. The truths: today's
+[shortwave bands](/reference/shortwave-broadcast/) are quieter than the
+genre's heyday — the major Western broadcasters are gone; international
+broadcasters, time signals, utility traffic, ham
+[SSB](/reference/single-sideband/), and pirates remain — and **a $20 wire
+antenna out a window will improve reception more than a $200 radio
+upgrade**, on this radio especially.
+
+**Listening note:** receiving is license-free everywhere in the US — no FCC
+anything, ever.
+
+## Bands, modes &amp; features
+
+- **Coverage:** 100 kHz–30 MHz + FM + AIR band.
+- **Modes:** [AM](/reference/amplitude-modulation/), SSB (mediocre), FM —
+  **no sync AM, no PBT, no selectable AGC**.
+- **Antenna:** 360° rotating MW ferrite on top — genuinely useful for
+  medium-wave nulls.
+- **Memories:** 1,000. **Audio:** big-radio speaker, its best feature.
+- **Power:** batteries or AC adapter.
+
+## Buying notes
+
+- **Price:** ~$400–500 list, frequently ~$100 off at legitimate dealers;
+  used and refurbished units are common and cheap.
+- **Where:** Amazon, DX Engineering (part EON-NELITE750), Adorama. Avoid
+  unknown storefronts with deep discounts — scam listings for this exact
+  model are documented.
+- **Timing:** late-lifecycle. If it disappears from dealers, the
+  used-classic route (or a hybrid like Tecsun's H-501x) becomes the answer —
+  our [guide](/best-desktop-shortwave-receivers/) tracks the state of play.
+
+## GopherTrunk alternative
+
+The Elite 750 exists because some people rightly want a radio that looks and
+works like a radio — because on raw performance, SDRs ended this category. A
+~$200 [HF-capable SDR](/best-hf-sdr/), or a ~$30
+[RTL-SDR](/reference/rtl-sdr/) in direct-sampling mode, outperforms it on
+shortwave and adds a waterfall view of the whole band on a screen. Buying
+the Elite 750 is a deliberate choice of speaker, knobs, and
+computer-free listening over performance-per-dollar — a fair choice, made
+honestly. GopherTrunk itself stays in its VHF/UHF scanner lane; it's the
+same listen-first philosophy, free.
+
+## Who it's for
+
+- **Buy the Elite 750** if you want a big, new, warrantied knob radio for
+  program listening and casual band-cruising — and you're buying from a real
+  dealer.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B08BVSCY8G?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy a used [Grundig Satellit 800](/reference/grundig-satellit-800/)**
+  instead for similar money with the real Drake sync detector — if you'll
+  take on the used-market checklist.
+- **Serious about DX?** A used [Sony ICF-2010](/reference/sony-icf-2010/)
+  costs less and out-DXes it; the [Icom IC-R8600](/reference/icom-ic-r8600/)
+  is the no-compromise new box. Full rankings:
+  [best desktop shortwave receivers](/best-desktop-shortwave-receivers/).
+
+## Sources
+
+[^n9ewo]: [Grundig Satellit 750 / Tecsun S-2000 review — N9EWO](https://www.qsl.net/n9ewo/s750.html) — the platform's detailed technical review: SSB quality, missing sync/PBT/AGC, birdies, audio verdict.
+[^jayallen]: [Grundig Satellit 750 / Tecsun S-2000 — another look — radiojayallen](https://radiojayallen.com/grundig-satellit-750tecsun-s-2000-another-look/) — the "not in the same ballpark as the Satellit 800" comparison and program-listener verdict.
+[^dxe]: [Eton Elite 750 (EON-NELITE750) — DX Engineering](https://www.dxengineering.com/parts/eon-nelite750) — current new availability and pricing (August 2026).

--- a/docs/reference/eton-elite-executive.md
+++ b/docs/reference/eton-elite-executive.md
@@ -1,0 +1,141 @@
+---
+slug: eton-elite-executive
+title: Eton Elite Executive
+entry_type: hardware
+category: shortwave-radios
+description: "The Eton Elite Executive is 2026's last-chance value pick — SSB, synchronous detection, VHF air band, and FM RDS in one portable, with community-reported discontinuation dumping prices as low as $40–60 while stock lasts."
+keywords: Eton Elite Executive review, Eton Elite Executive discontinued, shortwave radio with sync detector, cheap shortwave radio with SSB, Eton shortwave radio 2026, Elite Executive price, portable shortwave with air band, synchronous detection portable, is shortwave radio still worth it, last chance radio deals
+aka: [Elite Executive, Eton Executive Elite]
+autolink: true
+affiliate: true
+product:
+  name: "Eton Elite Executive"
+  brand: Eton
+  category: Portable shortwave receiver
+  lowPrice: "40"
+  highPrice: "130"
+  url: https://www.amazon.com/s?k=Eton+Elite+Executive&tag=gophertrunk-20
+infobox:
+  - { label: Type, value: "Portable shortwave receiver (DSP)" }
+  - { label: Bands, value: "LW / MW / SW / FM (RDS) / VHF Air" }
+  - { label: SSB, value: "Yes — plus synchronous detection with selectable sideband" }
+  - { label: Power, value: "4×AA" }
+  - { label: License, value: "None — receiver" }
+  - { label: Price, value: "around $40–130 (volatile — discontinued-with-stock, Aug 2026)" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/s?k=Eton+Elite+Executive&tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">Find on Amazon &rarr;</a>" }
+see_also: [xhdata-d-808, sangean-ats-909x2, sony-icf-sw7600gr, tecsun-pl-660, shortwave-broadcast, single-sideband]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "Best shortwave radios", url: /best-shortwave-radios/ }
+cite_urls:
+  - https://www.universal-radio.com/catalog/portable/0063.html
+  - https://radiojayallen.com/eton-elite-executive-am-fm-sw-air-radio/
+  - https://forums.radioreference.com/threads/eton-elite-executive.487716/
+faq:
+  - q: "Is the Eton Elite Executive discontinued?"
+    a: "Community reporting says yes — since April 2025, inventory has been dumped to eBay resellers at $40–50 while Amazon asked ~$130 for remaining stock. Eton has issued no formal end-of-life statement that we could find, so treat the status as community-inferred and the stock as a wasting asset. Check live availability before relying on any price."
+  - q: "Why buy the Eton Elite Executive in 2026?"
+    a: "Because at the dump price the feature list is absurd: SSB, a real synchronous detector with selectable sideband, VHF air band, FM with RDS, and an external antenna jack — sync + SSB + air under $60 exists nowhere else new. It's a last-chance value pick, not a long-term platform."
+  - q: "Does the Eton Elite Executive have a sync detector?"
+    a: "Yes — selectable-sideband synchronous detection, and it's the only radio on our current-production roster with one. It's good-not-Sony: the used ICF-SW7600GR remains the reference sync implementation in a portable."
+  - q: "What are the Eton Elite Executive's weaknesses?"
+    a: "Eton's QC reputation (sticky coatings on earlier Etons, backlight and encoder quirks), merely average audio, and now the volatility of a discontinued product: price swings from $40 to $130 depending on where remaining stock sits, and warranty support is a question mark going forward."
+  - q: "Do I need a license to listen to shortwave or air band?"
+    a: "No — listening is license-free everywhere in the US, no FCC anything, ever. Put the savings into $20 of wire antenna out a window; on shortwave that beats a $200 radio upgrade."
+---
+**The Eton Elite Executive** is 2026's strangest bargain: a portable with
+[SSB](/reference/single-sideband/), **selectable-sideband synchronous
+detection** (the only radio on the current roster that has it), a VHF air
+band, FM with RDS, and an external antenna jack — being cleared out, per
+community reporting, at **$40–60 from eBay resellers** while Amazon asks
+around **$130** for remaining stock.[^rr] Eton has issued no formal
+end-of-life statement, but the April-2025 inventory dump speaks for itself:
+this is a **last-chance value pick**, and the price you see today may not
+exist next month.
+
+<a class="btn btn--buy" href="https://www.amazon.com/s?k=Eton+Elite+Executive&tag=gophertrunk-20" rel="nofollow sponsored noopener">Find on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Sync + SSB + airband + RDS for under $60 is absurd value — while it
+lasts.** Community-confirmed discontinued-with-stock (no formal Eton EOL
+statement); pricing is bimodal and volatile: ~$40–60 via reseller dumps,
+~$130 for remaining Amazon stock, as of August 2026. **Known Eton gripes:**
+QC reputation, average audio, sync that's good-not-Sony. **License-free
+listening**; a $20 wire out the window is still the best upgrade. Where it
+ranks: [best shortwave radios](/best-shortwave-radios/).
+</div>
+
+## Overview
+
+On paper the Elite Executive was always the feature king of the mid-price
+class: LW through SW plus FM with RDS and a VHF air band, SSB, roughly 700
+memories, 4×AA power, an external antenna jack, and a sewn leather case —
+and above all **synchronous detection with selectable sideband**, the
+fading-fighting feature that vanished from current production everywhere
+else.[^rja] Sensitivity is decent, the size is right, and at its old ~$180
+list it was a reasonable-if-quirky buy.
+
+At $40–60 it is a different proposition entirely. The 2025 inventory dump —
+tracked in community threads since April 2025 — put new-in-box units on eBay
+for less than a [PL-330](/reference/tecsun-pl-330/), with Amazon's remaining
+stock still priced near $130. **Both prices are real and both are volatile**;
+quote-date August 2026, verify at checkout. The hedges you should carry into
+the purchase: Eton hasn't formally confirmed the discontinuation (retailer
+pages at Universal Radio and DX Engineering still listed it at research
+time), warranty support on a wound-down product is a question mark, and
+Eton's QC reputation — sticky rubberized coatings on earlier models,
+backlight and encoder quirks — was earned. The audio is average and the sync
+implementation is good-not-Sony; the used
+[ICF-SW7600GR](/reference/sony-icf-sw7600gr/) remains the reference.
+
+The category constants: **listening is license-free everywhere in the US —
+no FCC anything, ever.** And the antenna rule pays double at dump pricing —
+**a $20 wire antenna out a window improves shortwave reception more than a
+$200 radio upgrade**, so a $50 Elite Executive plus wire embarrasses much
+more expensive setups. The 2026 bands are leaner than the brochures ever
+admitted — the sync detector matters precisely because what remains
+(distant state broadcasters, pirates, weak DX) is the fading, marginal stuff
+sync was invented for.
+
+## Bands, modes &amp; features
+
+- **Coverage:** LW, MW, SW, FM with RDS, VHF air band.
+- **SSB:** yes. **Sync:** selectable-sideband synchronous detection — unique
+  on our current-production roster.
+- **Memories:** ~700.
+- **Power:** 4×AA.
+- **Connections:** external antenna jack; sewn leather case included.
+- No Bluetooth, no recording, no weather band.
+
+## GopherTrunk alternative
+
+Shortwave is HF AM/SSB — not GopherTrunk's trunking/digital domain, and
+GopherTrunk does not decode it. The computer-side path into the same
+spectrum is an HF-capable SDR ([best HF SDR](/best-hf-sdr/)) or a ~$30
+[RTL-SDR](/reference/rtl-sdr/) in direct-sampling mode — and an SDR's
+software demodulators do what sync detection does and more, with a
+[waterfall](/reference/waterfall-display/) beside it. GopherTrunk itself
+stays in its VHF/UHF scanner lane — same listen-first philosophy, free. At
+the Elite Executive's dump price, though, a standalone radio with hardware
+sync for $50 is a fair riposte to the whole argument.
+
+## Who it's for
+
+- **Buy the Elite Executive** if you catch it at the dump price and want the
+  richest feature set — sync included — that new money can currently buy.
+  Move fast and verify the live price; stock is a wasting asset.
+  <a class="btn btn--buy" href="https://www.amazon.com/s?k=Eton+Elite+Executive&tag=gophertrunk-20" rel="nofollow sponsored noopener">Find on Amazon &rarr;</a>
+- **Buy the [XHDATA D-808](/reference/xhdata-d-808/)** instead if you want a
+  supported, in-production radio with SSB and airband at similar street
+  money, or the [Sangean ATS-909X2](/reference/sangean-ats-909x2/) for the
+  full-size flagship version of this feature list.
+- **Sync purist?** The used [Sony ICF-SW7600GR](/reference/sony-icf-sw7600gr/)
+  is still the reference implementation. Full rankings:
+  [best shortwave radios](/best-shortwave-radios/).
+
+## Sources
+
+[^rr]: [Eton Elite Executive discontinuation thread — RadioReference forums](https://forums.radioreference.com/threads/eton-elite-executive.487716/) — community tracking of the April-2025 inventory dump, eBay reseller pricing, and remaining-stock Amazon pricing; discontinuation is community-inferred, not an official Eton statement.
+[^rja]: [Eton Elite Executive review — RadioJayAllen](https://radiojayallen.com/eton-elite-executive-am-fm-sw-air-radio/) — feature set, sync/SSB assessment, sensitivity, and the Eton QC caveats; specs corroborated by the [Universal Radio catalog page](https://www.universal-radio.com/catalog/portable/0063.html).

--- a/docs/reference/eton-fr500.md
+++ b/docs/reference/eton-fr500.md
@@ -1,0 +1,139 @@
+---
+slug: eton-fr500
+title: Eton FR500 Solarlink
+entry_type: hardware
+category: shortwave-radios
+description: "The Eton FR500 Solarlink is the discontinued feature-flagship crank radio — AM/FM/shortwave/NOAA weather with alert, crank, solar, and phone-charge output in one big box. Used-market only at roughly $30–70 on eBay, with a NiMH pack and sticky-coating checklist to work through."
+keywords: Eton FR500 review, Eton FR500 Solarlink, FR500 for sale, discontinued emergency radio, used crank radio, crank radio with shortwave, emergency shortwave radio, Eton sticky coating fix, NiMH pack replacement, vintage emergency radio
+aka: [FR500, Solarlink FR500, Eton Solarlink]
+autolink: true
+affiliate: true
+product:
+  name: "Eton FR500 Solarlink"
+  brand: Eton
+  category: Emergency crank/solar radio with shortwave (discontinued)
+  seller: eBay
+  itemCondition: used
+  lowPrice: "30"
+  highPrice: "70"
+  url: "https://www.ebay.com/sch/i.html?_nkw=eton+fr500+solarlink"
+infobox:
+  - { label: Type, value: "Emergency crank/solar radio with shortwave (discontinued)" }
+  - { label: Bands, value: "AM (500–1700) / FM / shortwave / 7 NOAA WX" }
+  - { label: Alerts, value: "Weather alert (tone type) — not SAME" }
+  - { label: Power, value: "Crank to internal NiMH pack, solar, AC adapter — pre-USB-C era" }
+  - { label: License, value: "None — receiver" }
+  - { label: Price, value: "around $30–70 used (thin data)" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.ebay.com/sch/i.html?_nkw=eton+fr500+solarlink\" rel=\"nofollow noopener\">Find on eBay &rarr;</a>" }
+see_also: [grundig-fr200, kaito-ka500, eton-frx3-plus, midland-er310, shortwave-broadcast, whip-antenna]
+related_reading:
+  - { title: "Best emergency radios", url: /best-emergency-radios/ }
+cite_urls:
+  - https://www.universal-radio.com/catalog/portable/4500.html
+  - https://swling.com/db/2011/01/eton-fr500/
+  - https://swling.com/blog/2018/08/etons-solution-for-sticky-radios/
+faq:
+  - q: "Is the Eton FR500 still made?"
+    a: "No — it's confirmed discontinued twice over: Amazon's own legacy listing is titled 'Discontinued by Manufacturer' and Universal Radio archives it as replaced by the FR600. The used market — eBay, estate sales, SWL classifieds — is where it lives, at roughly $30–70."
+  - q: "Does the Eton FR500 have shortwave?"
+    a: "Yes — alongside AM, FM, and all 7 NOAA weather channels with a tone-type alert, which made it the feature-flagship crank radio of its day. The shortwave is real but basic; a length of wire clipped to the antenna helps more than anything else."
+  - q: "What should I check before buying a used FR500?"
+    a: "Four things: whether the internal NiMH pack still holds charge (assume it doesn't and price a replacement in), whether the radio plays on crank alone (if not, walk away — the dynamo or charge board is bad), gearbox noise while cranking, and how far the rubberized coating has gone sticky."
+  - q: "How do you fix a sticky Eton radio?"
+    a: "The soft-touch coating on 2000s Eton radios hydrolyzes into goo with age. Eton's own recommendation is Purple Power degreaser; 91% isopropyl alcohol and Goo-Gone also work. It's cosmetic — but ask sellers for close-up photos before bidding."
+  - q: "Does the FR500 do SAME weather alerting?"
+    a: "No — its weather alert is the 1050 Hz tone type, waking for any warning across the whole NOAA transmitter's footprint. No crank radio of its era (or this one) decodes SAME county codes; a plugged-in SAME desktop radio does that job."
+---
+**The Eton FR500 Solarlink** was the feature flagship of the crank-radio world:
+AM, FM, real **shortwave**, and all 7 NOAA weather channels with alert, plus
+crank, solar, lights, siren, and a phone-charge output in one 1.9 lb box.[^universal]
+It has been **discontinued for years** — Amazon's own legacy listing says so in
+the title — and the used market is where it lives, at roughly **$30–70 on eBay**
+(thin data; verify current listings).
+
+<a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=eton+fr500+solarlink" rel="nofollow noopener">Find on eBay &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The full-band-set crank radio, used-only — buy it with the checklist, not
+nostalgia alone.** AM/FM/SW/WX in one crank box is a combination nothing
+current matches except the [Kaito KA500](/reference/kaito-ka500/). **The known
+faults are the buying game:** a near-certainly-dead NiMH pack, crank-gearbox
+wear, and the classic Eton sticky-coating degradation (Purple Power cleans it).
+**Tone alert, not SAME; ~$30–70 used, prices are scattered and data is thin.**
+**Listening is license-free** — no FCC anything, ever. Where it ranks:
+[best emergency radios](/best-emergency-radios/).
+</div>
+
+## Overview
+
+In the late-2000s crank-radio boom, the FR500 was the one with everything: a
+7.75 × 8.5-inch chassis carrying AM (500–1700 kHz), FM,
+[shortwave](/reference/shortwave-broadcast/), and the full NOAA weather band
+with alert; four white LEDs plus a red flasher behind a magnifying lens; a
+siren; and a cell-phone charge output years before that was standard. Power ran
+crank-dynamo-to-NiMH-pack, solar panel, or AC adapter — all pre-USB-C
+(Mini-USB/DC-barrel era). Even when new, reviews flagged construction and
+durability complaints — crank feel, plastic quality — and the shortwave, while
+real, is basic whip-antenna reception.[^swling] Its value today is honest
+nostalgia plus the band set: no current crank radio except the KA500 hears
+shortwave at all, and none matches this spread in one box.
+
+Universal Radio's archive records it replaced by the FR600; no dealer sells it
+new. eBay, estate sales, and SWL classifieds are the market.
+
+## Buying used: what to check
+
+This is the section that matters. A 15-plus-year-old FR500 has four known
+failure points; work through them before money changes hands:
+
+1. **The NiMH pack — assume it's dead.** Near-certain on a unit this old.
+   Confirm it's the standard replaceable NiMH assembly and price a replacement
+   into the deal. The key test: ask whether the radio **runs on crank alone** —
+   a working dynamo will drive the radio even with a dead pack. If it won't,
+   suspect the dynamo or charge board and walk away.
+2. **The crank gearbox.** Spin it and listen for grinding or clicking —
+   stripped plastic gears are the classic wear item. Output should light the
+   LEDs within seconds.
+3. **The sticky coating.** The era's rubberized soft-touch finish hydrolyzes
+   into goo with age — the signature Eton ailment. It cleans off with Purple
+   Power degreaser (Eton's own recommendation), 91% isopropyl, or
+   Goo-Gone,[^sticky] but ask for close-up photos first and price heavy cases
+   accordingly.
+4. **The rest:** telescopic-antenna segments intact, siren working, no
+   battery-compartment corrosion, and ideally the proprietary-barrel AC
+   adapter included.
+
+Pricing runs roughly **$30–70** by condition and completeness — but the data
+is thin, with only scattered live listings; treat any asking price against a
+fresh eBay search rather than a book value.
+
+## GopherTrunk alternative
+
+An SDR needs a computer and power — a crank radio's entire purpose is working
+without either, so GopherTrunk is no substitute for an FR500. It's the
+grid-up half of the same kit: a [$30 RTL-SDR](/reference/rtl-sdr/) running
+free GopherTrunk monitors and records your local public-safety and utility
+channels — the traffic that carries ground truth in an emergency. Our
+[emergency scanner frequencies](/scanner-frequencies/) guide lists what to
+program; the FR500 is the no-infrastructure fallback that also, uniquely for
+its class, hears the world on shortwave.
+
+## Who it's for
+
+- **Buy the FR500** if you want the maximum band set ever put in a crank
+  radio and you enjoy bringing old gear back to life with the checklist above.
+  <a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=eton+fr500+solarlink" rel="nofollow noopener">Find on eBay &rarr;</a>
+- **Buy the [Grundig FR200](/reference/grundig-fr200/)** instead for the
+  simpler, cheaper, better-aging classic — accepting that it has no weather
+  band at all.
+- **Want new with warranty?** The [Kaito KA500](/reference/kaito-ka500/) is
+  the current crank-plus-shortwave radio, and the
+  [Midland ER310](/reference/midland-er310/) the overall pick. Full rankings:
+  [best emergency radios](/best-emergency-radios/).
+
+## Sources
+
+[^universal]: [Eton FR500 — Universal Radio archive](https://www.universal-radio.com/catalog/portable/4500.html) — archived dealer page: full specifications, band coverage, power system, dimensions, and the note that the FR600 replaced it.
+[^swling]: [Eton FR500 — The SWLing Post archive](https://swling.com/db/2011/01/eton-fr500/) — shortwave-listener record of the FR500's capabilities and era context.
+[^sticky]: [Eton's solution for sticky radios — The SWLing Post](https://swling.com/blog/2018/08/etons-solution-for-sticky-radios/) — Eton's recommended Purple Power fix for the degraded rubberized coating, plus community alternatives.

--- a/docs/reference/eton-frx3-plus.md
+++ b/docs/reference/eton-frx3-plus.md
@@ -1,0 +1,133 @@
+---
+slug: eton-frx3-plus
+title: "Eton FRX3+"
+entry_type: hardware
+category: shortwave-radios
+description: "The Eton FRX3+ is the classic Red Cross-branded multi-power emergency radio — AM/FM/NOAA weather with digital tuning and alert standby, crank turbine, solar, 2600 mAh battery, and an alarm-clock form factor for around $55–65. No SAME, no shortwave."
+keywords: Eton FRX3+ review, Eton FRX3 Plus, Red Cross emergency radio, ARCFRX3-WXR, hand crank weather radio, emergency crank radio, NOAA weather alert radio, solar emergency radio, bedside emergency radio, Eton sticky coating
+aka: [FRX3+, FRX3 Plus, ARCFRX3-WXR, American Red Cross FRX3+]
+autolink: true
+affiliate: true
+product:
+  name: "Eton FRX3+"
+  brand: Eton
+  category: Emergency crank/solar weather radio
+  lowPrice: "55"
+  highPrice: "65"
+  url: https://www.amazon.com/dp/B00HSHH5DI?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: "Emergency crank/solar radio (alarm-clock form factor)" }
+  - { label: Bands, value: "AM / FM / 7 NOAA WX, digital tuning — no shortwave" }
+  - { label: Alerts, value: "Weather alert standby — not SAME" }
+  - { label: Power, value: "Crank turbine, solar, 2600 mAh Li-polymer, DC/USB input (Micro-USB era)" }
+  - { label: License, value: "None — receiver" }
+  - { label: Price, value: "around $55–65" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B00HSHH5DI?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [midland-er310, sangean-mmr-88, eton-scorpion-ii, eton-fr500, grundig-fr200, kaito-ka500]
+related_reading:
+  - { title: "Best emergency radios", url: /best-emergency-radios/ }
+cite_urls:
+  - https://etoncorp.com/
+  - https://products.redcross.ca/products/frx3-multi-powered-weather-alert-radio
+faq:
+  - q: "Does the Eton FRX3+ have SAME alerting?"
+    a: "No. Its weather-alert standby is the 1050 Hz tone type: it wakes for any watch or warning in the whole NOAA transmitter's coverage area, with no county filtering or event display. A plugged-in SAME desktop radio is what does that job."
+  - q: "How long does the FRX3+ run per minute of cranking?"
+    a: "Eton claims 1 minute of turbine cranking gives 10–15 minutes of radio or light — the most optimistic claim in the class. Independent tests of the FRX family generally land nearer 5–10 minutes at modest volume. Either way, the 2600 mAh battery (about 35 hours of radio) is the real power source."
+  - q: "Is the Amazon FRX3+ listing the Red Cross version?"
+    a: "Yes — the widely sold Amazon listing is the American Red Cross-branded ARCFRX3-WXR variant of the FRX3+. It is the same radio with Red Cross branding; Eton has long produced the Red Cross line."
+  - q: "Does the Eton FRX3+ receive shortwave?"
+    a: "No — AM, FM, and NOAA weather only, with digital tuning. For shortwave in a crank radio, look at the Kaito KA500 (current) or the discontinued Eton FR500 and Grundig FR200 on the used market."
+  - q: "Do Eton radios really get sticky with age?"
+    a: "The rubberized coating on many Eton products of this era hydrolyzes into a sticky film after years — it's reported on FRX units too, though less than on the 2000s classics. It cleans off with Purple Power degreaser or 91% isopropyl; it's cosmetic, not functional."
+---
+**The Eton FRX3+** is the bedside pick of the crank-radio class — an
+alarm-clock-styled multi-power unit with digitally tuned AM/FM and all 7 NOAA
+weather channels (plus Environment Canada's), weather-alert standby, a hand
+turbine crank, solar panel, and a 2600 mAh battery, long sold in American Red
+Cross branding for around $55–65.[^eton] No SAME decoding, no shortwave.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B00HSHH5DI?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The crank radio that earns a nightstand.** Real alarm clock, glow-in-the-dark
+locator, digital tuning, headphone and aux jacks — livability features the rest
+of the class skips. **Tone-alert standby, not SAME**: a plugged-in $30 SAME
+desktop radio still beats it for actually waking you to the right warning.
+**Crank claims run optimistic** — Eton says 1 min ≈ 10–15 min; independent FRX
+tests land nearer 5–10. **2600 mAh ≈ 35 h of radio. ~$55–65**, commonly as the
+Red Cross ARCFRX3-WXR variant. **Listening is license-free** — no FCC anything,
+ever. Ranked in [best emergency radios](/best-emergency-radios/).
+</div>
+
+## Overview
+
+Eton has built the American Red Cross radio line for years, and the FRX3+ is
+its centerpiece: the emergency radio designed to live in the bedroom rather
+than the closet. The form factor is the point — it stands up like a small alarm
+clock, has an actual alarm, a backlit display, digital tuning with presets
+instead of a drifting analog dial, a glow-in-the-dark locator ring for finding
+it in a blackout, and both headphone and aux jacks. Power is the full
+multi-source spread: hand **turbine** crank, a solar panel on top, a 2600 mAh
+Li-polymer cell (~35 hours of radio, 3–5 hours to charge), and a DC/USB input
+from the Micro-USB era — no USB-C. An LED flashlight and red flashing beacon
+cover the blackout basics, and a USB port lends the battery to your phone for a
+partial top-up.
+
+The Amazon listing most buyers land on is the **Red Cross-branded ARCFRX3-WXR**
+variant — same radio, humanitarian branding.[^redcross]
+
+## Alerting: tone standby, not SAME
+
+The FRX3+'s alert function is **tone-alert standby**: parked silently on a NOAA
+weather channel, it wakes when the National Weather Service transmits the
+1050 Hz attention tone before *any* watch or warning in the transmitter's
+footprint — which can span many counties, so expect occasional alarms for
+weather that isn't yours. It is **not SAME**: it cannot filter to your county
+or display the event type. The honest hierarchy applies here as everywhere: a
+plugged-in SAME desktop radio is what reliably wakes you to the *right*
+warning; the FRX3+'s job is the aftermath — staying informed once the grid is
+down, with an alarm clock and flashlight thrown in. Its bedside form factor at
+least means it's plugged in and charged when that moment comes.
+
+## Crank reality and the sticky-coating caveat
+
+Eton's claim of **1 minute of cranking ≈ 10–15 minutes of runtime** is the most
+optimistic in the roster; independent tests of the FRX family generally land
+nearer **5–10 minutes at modest volume**. Plan around the battery, treat the
+turbine as the reserve tier, and treat the solar panel as a maintainer. One
+Eton-specific caveat: the rubberized soft-touch coating on many Eton radios of
+this era slowly hydrolyzes into a sticky film with age. It's reported on FRX
+units too, though far less than on the 2000s classics like the
+[FR200](/reference/grundig-fr200/) — and it cleans off with Purple Power
+degreaser or 91% isopropyl. Cosmetic, not functional.
+
+## GopherTrunk alternative
+
+An SDR needs a computer and power — an emergency radio's entire job is working
+without either, so GopherTrunk isn't a substitute for an FRX3+. It's the
+other half of a complete preparedness setup: a
+[$30 RTL-SDR](/reference/rtl-sdr/) running free GopherTrunk monitors, records,
+and logs your local public-safety and utility traffic while the infrastructure
+is up — the channels where you hear what's actually happening, not just the
+forecast. Our [emergency scanner frequencies](/scanner-frequencies/) guide
+lists what to program; the FRX3+ is the zero-infrastructure fallback beside it.
+
+## Who it's for
+
+- **Buy the FRX3+** as the bedside/kitchen emergency radio — the one that's
+  charged and within reach because it's also your alarm clock.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B00HSHH5DI?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [Midland ER310](/reference/midland-er310/)** instead for the bigger
+  replaceable battery and AA fallback, or the
+  [Sangean MMR-88](/reference/sangean-mmr-88/) for the best-built receiver in
+  the class.
+- **Need rugged over homey?** The [Eton Scorpion II](/reference/eton-scorpion-ii/)
+  is the same brand's IPX4 carabiner take. Full rankings:
+  [best emergency radios](/best-emergency-radios/).
+
+## Sources
+
+[^eton]: [Eton Corporation](https://etoncorp.com/) — manufacturer's FRX3+ product information: bands, digital tuning, turbine crank, solar, 2600 mAh battery, lighting and alarm features.
+[^redcross]: [FRX3 multi-powered weather alert radio — Red Cross store](https://products.redcross.ca/products/frx3-multi-powered-weather-alert-radio) — the Red Cross-branded FRX3 line: alert function, multi-power sources, and emergency feature set.

--- a/docs/reference/eton-scorpion-ii.md
+++ b/docs/reference/eton-scorpion-ii.md
@@ -1,0 +1,133 @@
+---
+slug: eton-scorpion-ii
+title: Eton Scorpion II
+entry_type: hardware
+category: shortwave-radios
+description: "The Eton Scorpion II is the rugged outdoors pick among emergency radios — IPX4 splashproof with rubberized armor and an aluminum carabiner, digital AM/FM/NOAA weather, crank and solar, around $50. Tiny 800 mAh battery; no SAME, no shortwave."
+keywords: Eton Scorpion II review, Eton Scorpion 2, rugged emergency radio, IPX4 emergency radio, carabiner radio, hiking emergency radio, hand crank weather radio, NOAA weather radio, crank solar radio, backpacking radio
+aka: [Scorpion II, NSP101WXGR, Eton Scorpion 2]
+autolink: true
+affiliate: true
+product:
+  name: "Eton Scorpion II"
+  brand: Eton
+  category: Rugged emergency crank/solar weather radio
+  lowPrice: "35"
+  highPrice: "55"
+  url: https://www.amazon.com/dp/B01BHLQHXE?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: "Rugged emergency crank/solar radio" }
+  - { label: Bands, value: "Digital AM / FM / NOAA WX — no shortwave" }
+  - { label: Alerts, value: "Weather alerts on WX band — not SAME" }
+  - { label: Power, value: "Crank, built-in solar, 800 mAh Li-ion, Micro-USB" }
+  - { label: License, value: "None — receiver" }
+  - { label: Price, value: "around $50 (renewed ~$35)" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B01BHLQHXE?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [sangean-mmr-88, midland-er210, eton-frx3-plus, fospower-a1, runningsnail-md-092, midland-er310]
+related_reading:
+  - { title: "Best emergency radios", url: /best-emergency-radios/ }
+cite_urls:
+  - https://www.lowes.com/pd/Eton-Eton-Scorpion-II-Rugged-Multipowered-Portable-Emergency-Weather-Radio-and-Flashlight/5000299503
+  - https://www.dxengineering.com/parts/eon-nsp101wxgr
+faq:
+  - q: "Is the Eton Scorpion II waterproof?"
+    a: "It's IPX4 splashproof — the best formal water rating in the current crank-radio class — with rubberized armor around the body. That means it shrugs off rain and spray from any direction; it is not submersible."
+  - q: "Does the Eton Scorpion II have SAME alerting?"
+    a: "No. It receives NOAA weather-band alerts but does not decode SAME county codes — no crank radio in this class does. For county-filtered alerts that can wake you, add a plugged-in SAME desktop radio at home."
+  - q: "How long does the Scorpion II's battery last?"
+    a: "The 800 mAh cell is the smallest in the current roster — hours of listening, not days, and phone charging from it is strictly an emergency dribble. It's built for clip-to-a-pack ruggedness, not runtime; charge it before every trip."
+  - q: "Can the Scorpion II charge my phone?"
+    a: "Barely. The USB-A output works, but with 800 mAh behind it you'd add a few percent to a modern phone. If power-bank duty matters, the RunningSnail MD-092's 4000 mAh or Midland ER310's 2600 mAh serve that job far better."
+  - q: "Does the Eton Scorpion II receive shortwave?"
+    a: "No — digital-tuned AM, FM, and NOAA weather only. For a crank radio with shortwave, the Kaito KA500 is the current option; either way, listening is license-free everywhere in the US."
+---
+**The Eton Scorpion II** is the emergency radio built to leave the house: IPX4
+splashproof — the best formal water rating in the current crank class —
+rubberized armor, an aluminum carabiner, even a bottle opener, wrapped around a
+digitally tuned AM/FM/NOAA weather receiver with crank and solar charging for
+around $50.[^lowes] The trade is the smallest battery in the roster (800 mAh),
+and like all of its class it does **no SAME decoding** and has **no shortwave**.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B01BHLQHXE?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Buy it for ruggedness, not runtime.** IPX4 plus armor makes it the one crank
+radio genuinely at home clipped to a pack in the rain. **The 800 mAh cell is
+the catch:** hours of listening, near-useless phone charging, and only a few
+minutes of radio per minute of cranking — charge it before every trip.
+**Weather alerts are the tone type, not SAME** — a plugged-in SAME desktop
+radio still owns the wake-you-up job at home. **~$50 new, ~$35 renewed; sold at
+Lowe's and Home Depot, not just Amazon. Listening is license-free** — no FCC
+anything, ever. Ranked in [best emergency radios](/best-emergency-radios/).
+</div>
+
+## Overview
+
+Most crank radios are shelf furniture; the Scorpion II (Eton model NSP101WXGR)
+is trail gear. The rubberized exoskeleton and **IPX4** rating — protected
+against splashing water from any direction — make it the only unit in the
+current roster with real outdoor credentials, and the aluminum carabiner means
+it actually attaches to a pack instead of rattling in a pocket. Digital tuning
+covers AM, FM, and the NOAA weather band; a 0.5 W LED flashlight handles camp
+chores. Power comes from the hand crank, a built-in solar strip, and an
+internal 800 mAh Li-ion charged over Micro-USB — no USB-C. It's widely stocked
+at Lowe's, Home Depot, and DX Engineering as well as Amazon, where renewed
+units run about $35.[^dxe]
+
+Reviewers' consistent knock is the small, tinny speaker — physics, given the
+sealed rugged shell — and the battery below.
+
+## The 800 mAh trade
+
+The Scorpion II's cell is the smallest in the current crank-radio field: a
+third of a [Midland ER310](/reference/midland-er310/)'s, a fifth of a
+[RunningSnail MD-092](/reference/runningsnail-md-092/)'s. In practice that
+means hours of listening rather than days, phone charging that's strictly an
+emergency dribble, and no AA fallback to lean on. The crank yields a few
+minutes of listening per minute of effort (no independent measured figure
+exists for this model; the whole class behaves this way), and the small solar
+strip is a maintainer. The discipline is simple: top it up via USB before
+every trip, and treat crank and sun as the reserve. If your radio lives on a
+shelf instead of a pack strap, nearly everything else in the roster out-runs
+it — but none of them takes weather like this one.
+
+## Alerting: tone alerts, not SAME
+
+The Scorpion II receives NOAA weather-band alerts of the 1050 Hz tone variety —
+**not SAME**. No crank radio in this class decodes the digital county codes
+that let a radio alarm only for *your* county; that job belongs to a plugged-in
+SAME desktop unit at home. On the trail, the honest workflow is checking the
+forecast loop on the weather band at camp — which the Scorpion II's digital
+tuner makes quick — rather than expecting it to interrupt you.
+
+## GopherTrunk alternative
+
+An SDR needs a computer and power; a radio you clip to a backpack needs
+neither — so GopherTrunk is no substitute for a Scorpion II. It's the
+home-side complement: a [$30 RTL-SDR](/reference/rtl-sdr/) running free
+GopherTrunk monitors and records your local public-safety, utility, and
+weather channels while the grid is up — the traffic that tells you what's
+really happening in an event. Our
+[emergency scanner frequencies](/scanner-frequencies/) guide covers what to
+program; the Scorpion II is the take-it-with-you fallback for when you're out
+of range of all that.
+
+## Who it's for
+
+- **Buy the Scorpion II** if your emergency radio rides on a pack, a boat, or
+  a job site — anywhere the IPX4 shell earns its keep.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B01BHLQHXE?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [Sangean MMR-88](/reference/sangean-mmr-88/)** instead for a
+  better receiver and IPX3 in a house-first radio, or the
+  [Midland ER310](/reference/midland-er310/) for triple the battery plus AA
+  fallback.
+- **On a tight budget?** The [FosPower A1](/reference/fospower-a1/) and
+  [RunningSnail MD-092](/reference/runningsnail-md-092/) cost less and store
+  more — with none of the ruggedness. Full rankings:
+  [best emergency radios](/best-emergency-radios/).
+
+## Sources
+
+[^lowes]: [Eton Scorpion II — Lowe's](https://www.lowes.com/pd/Eton-Eton-Scorpion-II-Rugged-Multipowered-Portable-Emergency-Weather-Radio-and-Flashlight/5000299503) — retail listing: rugged multi-powered design, band coverage, flashlight, and current availability in big-box distribution.
+[^dxe]: [Eton NSP101WXGR Scorpion II — DX Engineering](https://www.dxengineering.com/parts/eon-nsp101wxgr) — specifications: IPX4 splashproof rating, crank/solar/USB power, 800 mAh battery, carabiner and bottle-opener hardware.

--- a/docs/reference/fospower-a1.md
+++ b/docs/reference/fospower-a1.md
@@ -1,0 +1,133 @@
+---
+slug: fospower-a1
+title: FosPower A1
+entry_type: hardware
+category: shortwave-radios
+description: "The FosPower A1 (2000 mAh) is the budget emergency radio done competently — AM/FM/NOAA weather, crank, solar, AAA backup, and a lifetime warranty for around $27–35. Critical caveat: no weather-alert standby at all — plain weather band only."
+keywords: FosPower A1 review, FosPower emergency radio, cheap emergency radio, budget crank radio, hand crank weather radio, NOAA weather radio, emergency radio under 30, solar crank radio, FosPower A1 2000mAh, emergency radio with flashlight
+aka: [FosPower A1 2000mAh, FosPower Model A1]
+autolink: true
+affiliate: true
+product:
+  name: "FosPower A1 (2000 mAh)"
+  brand: FosPower
+  category: Emergency crank/solar weather radio (budget)
+  lowPrice: "27"
+  highPrice: "35"
+  url: https://www.amazon.com/dp/B07FKYHTWP?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: "Budget emergency crank/solar radio" }
+  - { label: Bands, value: "AM / FM / NOAA WX (162.400–162.550 MHz) — no shortwave" }
+  - { label: Alerts, value: "None — plain weather band only, no alert standby" }
+  - { label: Power, value: "Crank, small solar, 2000 mAh Li-ion, 3× AAA backup, USB input" }
+  - { label: License, value: "None — receiver" }
+  - { label: Price, value: "around $27–35" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B07FKYHTWP?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [runningsnail-md-092, midland-er210, midland-er310, sangean-mmr-88, eton-scorpion-ii, kaito-ka500]
+related_reading:
+  - { title: "Best emergency radios", url: /best-emergency-radios/ }
+cite_urls:
+  - https://fospower.com/emergency-supplies/model-a1-2-000mah-emergency-solar-hand-crank-noaa-weather-radio
+faq:
+  - q: "Does the FosPower A1 have weather alerts?"
+    a: "No — and this is the A1's most important limitation. It tunes the NOAA weather band, but it has no alert standby mode of any kind: you only hear a warning if you're already listening. Every Midland, Sangean, Eton, and Kaito in this class at least offers tone-alert standby."
+  - q: "Is the FosPower A1 worth it?"
+    a: "As a $30 grid-down listening radio, flashlight, and modest power bank — yes, it's the budget class done competently, with a limited lifetime warranty that's unusual at the price. As a weather-alerting device — no, because it has no alert mode at all."
+  - q: "How long does the FosPower A1 run on a charge?"
+    a: "FosPower claims up to 100 hours of playtime from the 2000 mAh cell — a low-volume best case. Real-world listening at normal volume is much shorter; treat the crank and solar as keep-alive top-ups, not primary charging."
+  - q: "Can the FosPower A1 charge my phone?"
+    a: "Partially. The USB-A output draws on the 2000 mAh cell, which is roughly half a modern phone charge in theory and less in practice. It's an emergency top-up for calls, not a real power bank."
+  - q: "Does the FosPower A1 receive shortwave?"
+    a: "No — AM (520–1710 kHz), FM, and the NOAA weather frequencies only. The cheapest current crank radio with real shortwave is the Kaito KA500 at roughly twice the price. Listening to all of it is license-free."
+---
+**The FosPower A1** is the budget Amazon best-seller of the emergency-radio
+class done competently: AM/FM/NOAA weather, 4-way power (crank, solar, 2000 mAh
+cell, 3× AAA), a bright zoom flashlight, an SOS siren, and a limited lifetime
+warranty for around $27–35.[^fospower] One caveat towers over the rest: it has
+**no weather-alert standby at all** — plain weather-band listening only.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B07FKYHTWP?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The cheapest competent kit radio — but it will never wake you.** No alert
+mode of any kind: you hear a warning only if you're already listening. Every
+other radio in our roster at least does 1050 Hz tone-alert standby, and a $30
+plugged-in SAME desktop radio does the wake-you-up job properly. **What $30
+buys:** grid-down AM/FM/WX listening, a 1 W flashlight, a partial phone top-up
+from 2000 mAh, AAA fallback, and a lifetime warranty. **Crank and solar are
+keep-alive only. No shortwave. Listening is license-free** — no FCC anything,
+ever. See [best emergency radios](/best-emergency-radios/).
+</div>
+
+## Overview
+
+FosPower's A1 is what the sub-$35 crank radio looks like when someone sweats
+the details: a 2000 mAh (7400 mWh) Li-ion cell that doubles as a small power
+bank, a **3× AAA backup bay** most budget rivals skip, a 1 W zoomable
+flashlight plus a 4-LED reading light, and a loud SOS siren with flashing
+beacon. It sells in several colors, gets a 4.6/5 average across a very large
+Amazon review base, and — genuinely unusual at this price — carries FosPower's
+**limited lifetime warranty**. Marketing claims IPX3 splash resistance, though
+that rating doesn't appear on the published spec sheet; treat it as
+rain-tolerant, not proven. Charging input is Micro-USB on older stock; USB-C is
+not confirmed on current listings, so don't count on it.
+
+The receiver covers AM 520–1710 kHz, FM, and the seven NOAA weather
+frequencies (162.400–162.550 MHz). Critics' consistent knocks: mediocre AM
+sensitivity, lightweight build, and the alerting gap below.
+
+## The alerting gap: read this before buying
+
+The A1 is the only radio in our emergency roster with **no alert standby mode
+whatsoever**. It tunes the weather band, but it cannot sit muted and wake when
+the National Weather Service transmits the 1050 Hz attention tone — the
+baseline feature every Midland, Sangean, Eton, and Kaito here offers. With the
+A1, you hear a tornado warning only if the radio is on and you're listening.
+
+Frame it honestly and the A1 still makes sense: no crank radio does
+[SAME](/best-emergency-radios/) county-filtered alerting anyway, and the
+household answer for being woken is a plugged-in SAME desktop unit regardless.
+The A1's job is everything *after* the sirens — grid-down listening, light,
+and a phone top-up — and at that job, $30 buys a lot. Just never let it be
+your only warning path.
+
+## Power reality
+
+The "up to 100 hours playtime" claim is a low-volume best case from the
+2000 mAh cell. No independent crank-minutes measurement exists for the A1, and
+none is needed to set expectations: across this entire class, cranking buys
+minutes of radio per minute of effort and the small solar panel is a
+maintainer, not a charger — assume the same here. The USB-A output gives a
+phone a partial emergency top-up. The AAA bay is the underrated feature: a $4
+pack of alkalines is worth more than an afternoon of cranking, and it's what
+keeps a years-old unit useful after the Li-ion fades.
+
+## GopherTrunk alternative
+
+An SDR needs a computer and power; a $30 crank radio's entire purpose is
+working without either — so GopherTrunk is no substitute for an A1. It's
+the complement, at nearly the same price: a
+[$30 RTL-SDR](/reference/rtl-sdr/) running free GopherTrunk monitors and
+records your local public-safety and utility channels while the grid is up —
+the traffic that actually tells you what's happening during an event. Our
+[emergency scanner frequencies](/scanner-frequencies/) guide lists what to
+listen to; the A1 is the zero-infrastructure fallback that lives in the same
+kit.
+
+## Who it's for
+
+- **Buy the A1** to put a competent radio-flashlight-siren in every car and
+  kit at the lowest real price — with your alerting handled elsewhere.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B07FKYHTWP?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [RunningSnail MD-092](/reference/runningsnail-md-092/)** instead
+  for double the battery (4000 mAh) at a similar street price, or the
+  [Midland ER210](/reference/midland-er210/) to add real tone-alert standby
+  for ~$20 more.
+- **Skip it** if the radio must be able to wake you — that's any Midland here,
+  plus a SAME desktop unit at home. Full rankings:
+  [best emergency radios](/best-emergency-radios/).
+
+## Sources
+
+[^fospower]: [FosPower Model A1 2000 mAh emergency radio](https://fospower.com/emergency-supplies/model-a1-2-000mah-emergency-solar-hand-crank-noaa-weather-radio) — FosPower: band coverage, 4-way power system, 2000 mAh capacity, lighting and siren features, and warranty terms.

--- a/docs/reference/grundig-fr200.md
+++ b/docs/reference/grundig-fr200.md
@@ -1,0 +1,142 @@
+---
+slug: grundig-fr200
+title: Grundig FR200
+entry_type: hardware
+category: shortwave-radios
+description: "The Grundig FR200 is the iconic early-2000s crank shortwave radio — AM/FM plus two shortwave bands, a swappable AA-size NiMH pack, and no-frills durability that keeps 20-year-old units working. Used-only at roughly $19–52. Critical: no NOAA weather band, no solar."
+keywords: Grundig FR200 review, Grundig FR200, Eton FR200, FR200 for sale, crank shortwave radio, used emergency radio, vintage crank radio, hand crank radio, shortwave emergency radio, does the FR200 have weather band, sticky Grundig coating
+aka: [FR200, Eton FR200, Grundig FR-200]
+autolink: true
+affiliate: true
+product:
+  name: "Grundig FR200"
+  brand: Grundig
+  category: Crank shortwave radio (discontinued)
+  seller: eBay
+  itemCondition: used
+  lowPrice: "19"
+  highPrice: "52"
+  url: "https://www.ebay.com/sch/i.html?_nkw=grundig+fr200"
+infobox:
+  - { label: Type, value: "Crank shortwave radio (discontinued)" }
+  - { label: Bands, value: "AM / FM / 2 analog SW bands — NO NOAA weather band" }
+  - { label: Alerts, value: "None" }
+  - { label: Power, value: "Crank to swappable 3×AA-size NiMH pack, 3× AA alkalines, 4.5 V DC — no solar, no USB" }
+  - { label: License, value: "None — receiver" }
+  - { label: Price, value: "around $19–52 used" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.ebay.com/sch/i.html?_nkw=grundig+fr200\" rel=\"nofollow noopener\">Find on eBay &rarr;</a>" }
+see_also: [eton-fr500, kaito-ka500, midland-er310, shortwave-broadcast, single-sideband, whip-antenna]
+related_reading:
+  - { title: "Best emergency radios", url: /best-emergency-radios/ }
+cite_urls:
+  - https://www.universal-radio.com/catalog/portable/2200.html
+  - https://www.eham.net/reviews/view-product?id=2573
+  - https://swling.com/blog/2012/12/mikes-solution-for-sticky-radios/
+faq:
+  - q: "Does the Grundig FR200 have a weather band?"
+    a: "No — and many buyers assume otherwise. The classic FR200 is AM/FM/shortwave only, with no NOAA weather reception and no alert function of any kind. It's a shortwave classic, not a weather radio; if alerting matters, that job belongs to a different radio entirely."
+  - q: "Is the Grundig FR200 still worth buying?"
+    a: "As a cheap, nearly indestructible crank shortwave radio, yes — working units run about $19–35 used, owners report 20-year-old examples still going, and the swappable AA-size battery pack ages far better than sealed-lithium designs. Just don't buy it expecting weather alerts or phone charging."
+  - q: "What battery does the FR200 use?"
+    a: "A removable 3-cell AA-size NiMH pack in the battery bay, charged by the crank — and the same bay runs plain AA alkalines, or a 4.5 V DC adapter. A dead pack is about a $10 fix, which is exactly why these age so well."
+  - q: "What should I check before buying a used FR200?"
+    a: "Battery-bay corrosion first (leaked alkalines are the most common killer), then crank the dynamo for 30–60 seconds and listen for gear grinding, check the analog dial-cord tuning tracks the whole dial without slipping, and ask about the sticky-coating state. Listings with the canvas bag and DC adapter are worth a premium."
+  - q: "Is shortwave radio still worth listening to in 2026?"
+    a: "Quieter than the FR200's heyday — most major Western broadcasters have left the bands — but international broadcasters, time signals, ham SSB, and utility traffic are still there, and listening is license-free everywhere in the US. A $20 wire antenna out a window improves it more than any radio upgrade."
+---
+**The Grundig FR200** (later sold as the Eton FR200) is the iconic early-2000s
+crank radio: AM, FM, and **two analog shortwave bands** in a dead-simple,
+nearly indestructible package whose crank-plus-swappable-AA-pack architecture
+ages better than anything sealed-lithium built since.[^universal] It's long
+discontinued — used units run about **$19–52** — and one fact must be said
+loudly: the classic FR200 has **no NOAA weather band at all**.
+
+<a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=grundig+fr200" rel="nofollow noopener">Find on eBay &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**A shortwave classic, not a weather radio.** No WX band, no alerts, no solar,
+no USB, no phone charging — AM/FM/SW, a crank, a swappable battery, and an LED
+light, period. **That simplicity is why 20-year-old units still work**, and why
+it's the cheapest entry in our whole emergency roster at ~$19–35 for working
+examples. **The used checklist is short:** battery-bay corrosion, gearbox
+grind, dial-cord slip, sticky coating. **Listening is license-free** — no FCC
+anything, ever — and a $20 wire antenna out a window beats a $200 radio
+upgrade on shortwave. Where it ranks:
+[best emergency radios](/best-emergency-radios/).
+</div>
+
+## Overview
+
+Before the crank-radio category filled with lithium cells and USB ports, the
+FR200 defined it: a chunky ABS box with an analog dial covering AM, FM, and two
+[shortwave](/reference/shortwave-broadcast/) bands, a fold-out crank driving a
+removable **3-cell AA-size NiMH pack**, a white LED emergency light, and a
+canvas carry bag. The same battery bay runs three ordinary AA alkalines, or a
+4.5 V DC adapter. That's the whole feature list — no solar, no siren, no USB
+anything — and it's precisely why eHam owner reviews remain affectionate two
+decades on: there is almost nothing to fail, and what can fail (the pack) costs
+about $10 to swap.[^eham] The receiver itself is surprisingly decent for the
+money on AM and shortwave.
+
+Say it again, because listings and buyers routinely get it wrong: **no weather
+band on the standard FR200**. Some variant listings and the related Tecsun
+Green-88 platform mention WX, but the classic FR200 is AM/FM/SW only, with no
+alert function of any kind. If being warned matters, that's a job for a
+plugged-in SAME desktop radio — a $30 appliance that out-alerts every crank
+radio ever made — with the FR200 as the grid-down listening companion.
+
+## Buying used: what to check
+
+FR200s are cheap and plentiful — working units around **$19–35**, open-box or
+complete examples up to **~$52**, as-is parts units under $15 — so be picky:
+
+1. **Battery-bay corrosion.** Leaked alkalines are the most common FR200
+   killer. Open the bay and look before anything else; walk away from green
+   fuzz on the contacts.
+2. **The crank gearbox.** Crank 30–60 seconds: the radio should play, and you
+   should hear smooth whirring, not grinding. FR200 gearboxes are sturdier
+   than later models', but 20-year-old grease dries out and stiffens.
+3. **The NiMH pack.** Assume it's tired; it's a user-swappable $10 part (or
+   just run alkalines), so a dead pack is a bargaining chip, not a
+   disqualifier.
+4. **Dial-cord tuning.** The analog needle should track the full dial without
+   slipping or sticking — dial-cord wear is the FR200's fiddliest repair.
+5. **Sticky coating.** The era's rubberized finish hydrolyzes into goo; Purple
+   Power degreaser, 91% isopropyl, or Goo-Gone remove it.[^sticky] Anecdotally
+   the yellow and green finishes survive better — ask for photos either way.
+
+Prefer listings with the canvas bag and DC adapter; both are cheap tells of a
+cared-for unit.
+
+## GopherTrunk alternative
+
+An SDR needs a computer and power; the FR200's whole point — cranking its way
+through a blackout — is needing neither, so GopherTrunk is no substitute.
+It's the grid-up half of the kit: a [$30 RTL-SDR](/reference/rtl-sdr/) running
+free GopherTrunk monitors and records your local public-safety and utility
+channels, where the real information is during an event — see our
+[emergency scanner frequencies](/scanner-frequencies/) guide for what to
+program. The FR200 covers the other side: infrastructure-free listening,
+including the [shortwave bands](/reference/shortwave-broadcast/) no modern
+crank radio but the KA500 touches.
+
+## Who it's for
+
+- **Buy the FR200** as the cheapest working classic in the class — a
+  crank shortwave radio simple enough to still be running in another twenty
+  years.
+  <a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=grundig+fr200" rel="nofollow noopener">Find on eBay &rarr;</a>
+- **Buy the [Eton FR500](/reference/eton-fr500/)** instead if your classic
+  needs the weather band and the full feature set — with a longer used-buying
+  checklist.
+- **Want new, with weather alerts?** The [Kaito KA500](/reference/kaito-ka500/)
+  is today's crank-plus-shortwave pick and the
+  [Midland ER310](/reference/midland-er310/) the overall one. Full rankings:
+  [best emergency radios](/best-emergency-radios/).
+
+## Sources
+
+[^universal]: [Grundig FR200 — Universal Radio archive](https://www.universal-radio.com/catalog/portable/2200.html) — archived dealer page: band coverage (AM/FM/2× SW, no WX), crank-to-NiMH power system, AA and DC operation, and discontinuation.
+[^eham]: [Grundig FR200 owner reviews — eHam.net](https://www.eham.net/reviews/view-product?id=2573) — long-term owner consensus on receiver quality, durability, and the aging behavior of the crank/AA-pack design.
+[^sticky]: [Mike's solution for sticky radios — The SWLing Post](https://swling.com/blog/2012/12/mikes-solution-for-sticky-radios/) — community-verified remedies for the degraded rubberized coating on Grundig/Eton radios of this era.

--- a/docs/reference/grundig-satellit-800.md
+++ b/docs/reference/grundig-satellit-800.md
@@ -1,0 +1,157 @@
+---
+slug: grundig-satellit-800
+title: Grundig Satellit 800
+entry_type: hardware
+category: shortwave-radios
+description: "The Grundig Satellit 800 Millennium is the budget classic tabletop shortwave receiver — Drake-designed with excellent selectable-sideband sync and big-speaker audio — used-market only at roughly $300–550 asks, with a QC lottery that favors 2003+ units."
+keywords: Grundig Satellit 800, Satellit 800 review, Satellit 800 for sale, Satellit 800 Millennium, Drake SW8, Tecsun HAM-2000, budget classic shortwave receiver, Satellit 800 2L41 choke, used shortwave receiver, is shortwave radio still worth it
+aka: [Satellit 800, Satellit 800 Millennium, Tecsun HAM-2000]
+autolink: true
+affiliate: true
+product:
+  name: "Grundig Satellit 800 Millennium"
+  brand: Grundig
+  category: Desktop shortwave receiver (classic)
+  seller: eBay
+  itemCondition: used
+  lowPrice: "300"
+  highPrice: "550"
+  url: "https://www.ebay.com/sch/i.html?_nkw=grundig+satellit+800"
+infobox:
+  - { label: Type, value: "Classic tabletop/portable-hybrid shortwave receiver" }
+  - { label: Bands, value: "100 kHz–30 MHz + FM + 118–137 MHz AIR" }
+  - { label: SSB / Sync, value: "SSB; selectable-sideband sync rated \"top of the heap\" (Drake DNA)" }
+  - { label: Power, value: "D cells or AC" }
+  - { label: License, value: "None — receiver" }
+  - { label: Price, value: "around $300–550 used (ask-based — verify sold listings)" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.ebay.com/sch/i.html?_nkw=grundig+satellit+800\" rel=\"nofollow noopener\">Find on eBay &rarr;</a>" }
+see_also: [drake-r8b, sony-icf-2010, eton-elite-750, lowe-hf-150, shortwave-broadcast, rtl-sdr]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "Best desktop shortwave receivers", url: /best-desktop-shortwave-receivers/ }
+cite_urls:
+  - https://radiojayallen.com/grundig-satellit-800/
+  - https://mwcircle.org/legacy-receiver-reviews/receiver-review-grundig-satellit-800-millennium/
+  - https://www.universal-radio.com/catalog/portable/0800.html
+faq:
+  - q: "Is the Grundig Satellit 800 a real Drake?"
+    a: "Effectively yes — it was designed by R.L. Drake (based on the Drake SW8) for Lextronix/Etón and built in China by Tecsun (sold in Asia as the Tecsun HAM-2000). The Drake DNA shows in the part that matters: a selectable-sideband synchronous detector reviewers rated 'top of the heap'."
+  - q: "How much is a used Satellit 800?"
+    a: "eBay asking prices run around $300–550, with boxed or new-old-stock units higher. Those are asks, not confirmed sales — and condition plus production vintage matter a lot (post-2003 units are preferred) — so check eBay sold listings before paying."
+  - q: "What goes wrong with the Satellit 800?"
+    a: "The known killer is the 2L41 RF choke on the PLL synthesizer board — when it fails the radio dies or won't tune, and the fix is well documented. Beyond that: an early-production QC lottery (wobbly knobs, fit and finish, synthesizer noise, unfiltered wall-wart PSU), tuning-encoder wear, D-cell battery-bay corrosion, and display segments/backlight."
+  - q: "Why do people say to buy a 2003-or-later Satellit 800?"
+    a: "Early production suffered a genuine quality-control lottery — wobbly knobs, fit/finish issues, synthesizer and digital noise, and a noisy unfiltered wall-wart supply. Later serials are markedly better built, so ask the seller for the production date before bidding."
+  - q: "Do I need a license to listen with a Satellit 800?"
+    a: "No. Listening is license-free everywhere in the US — no FCC registration or paperwork, ever. Receivers like this never require anything."
+---
+**The Grundig Satellit 800 Millennium** is the budget classic: a $499 radio
+(shipped in 2000, sold through about 2005) that R.L. Drake designed —
+it's based on the Drake SW8, built in China by Tecsun — and that carries
+genuine Drake DNA where it counts: a **selectable-sideband synchronous
+detector rated "top of the heap"** and the best audio of any late-era
+affordable tabletop.[^jayallen] It's long discontinued; the used market —
+eBay, estate sales, SWL classifieds — is where it lives, with asks around
+**$300–550**.
+
+<a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=grundig+satellit+800" rel="nofollow noopener">Find on eBay &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The most performance per used dollar of any classic here — with a QC
+lottery attached.** Drake-designed sync and big-speaker audio that "blows
+away" contemporary portables; 100 kHz–30 MHz plus FM and VHF AIR; runs on D
+cells or AC. **Below the big four on refinement, above them on
+dollars-per-performance.** **Used ~$300–550 (asks — verify sold listings);
+prefer 2003+ serials** and ask about the 2L41 choke fix. **No license to
+listen — ever.** Where it ranks:
+[best desktop shortwave receivers](/best-desktop-shortwave-receivers/).
+</div>
+
+## Overview
+
+The Satellit 800 is what happened when Drake engineering met a $499 price
+target: three AM bandwidths (6.0/4.0/2.3 kHz), the celebrated sync detector,
+dual clocks, a huge display, and a big speaker whose audio reviewers said
+"blows away" the portables of its day.[^mwcircle] Physically it's a giant —
+a tabletop/portable hybrid that runs on D cells or AC — and its coverage is
+broader than most classics: 100 kHz–30 MHz plus FM and the 118–137 MHz air
+band.
+
+The honest half of the review is build quality. Reviewers (radiojayallen,
+N9EWO, MW Circle) uniformly call the *receiver* excellent for the money and
+uniformly dock the *radio* for QC: wobbly knobs, inconsistent fit and
+finish, synthesizer/digital noise on early units, and a noisy unfiltered
+wall-wart supply. That's why it ranks below the
+[Drake R8B](/reference/drake-r8b/)-tier classics on refinement while beating
+all of them on dollars-per-performance — and why production vintage matters
+so much when buying (below).
+
+Frame the hobby honestly too: the major Western broadcasters have left
+[shortwave](/reference/shortwave-broadcast/), and what remains —
+international broadcasters, time signals, utility/HF traffic, ham
+[SSB](/reference/single-sideband/), pirates — is quieter than the bands this
+radio was designed for. The classic advice is unchanged: **a $20 wire
+antenna out a window improves reception more than a $200 radio upgrade.**
+
+**Listening note:** receiving is license-free everywhere in the US — no FCC
+anything, ever.
+
+## Bands, modes &amp; features
+
+- **Coverage:** 100 kHz–30 MHz + FM + 118–137 MHz AIR band.
+- **Modes:** [AM](/reference/amplitude-modulation/), SSB, and
+  selectable-sideband sync AM (the Drake party trick).
+- **Selectivity:** three AM bandwidths — 6.0/4.0/2.3 kHz.
+- **Extras:** dual clocks, huge display, big-speaker audio.
+- **Power:** D cells or AC (early wall-warts are noisy — see below).
+
+## Buying used: what to check
+
+The Satellit 800's checklist is half component-aging, half
+birth-lottery:[^jayallen]
+
+1. **The 2L41 RF choke.** The known killer: this choke on the PLL
+   synthesizer board fails and the radio dies or stops tuning. The fix is
+   documented; ask whether it's been done.
+2. **Production date — prefer 2003+ serials.** Early units drew the QC
+   lottery: wobbly knobs, fit/finish problems, synthesizer/digital noise,
+   and the unfiltered wall-wart PSU. Ask for the date before bidding.
+3. **Tuning encoder wear** — tune slowly across a band and listen for skips.
+4. **Battery-bay corrosion** — it takes D cells; inspect the bay.
+5. **Display segments and backlight** — get a lit photo.
+
+Asks run **$300–550** (an observed $515 ask; boxed/NOS higher), but those
+are asking prices — condition and vintage swing real value a lot, so **check
+eBay sold listings first**. Serviceability is decent: the SW8 heritage means
+Drake-literate techs can work on it, with parts via donor units.
+
+## GopherTrunk alternative
+
+SDRs ended this product category — a ~$200 HF SDR out-receives the Satellit
+800 and draws a waterfall besides — and the Satellit 800's own builder,
+Tecsun, pivoted to the DSP portables that erased the low end. A used
+Satellit 800 today is a deliberate choice of room-filling audio, Drake sync,
+and a radio-shaped radio over performance-per-dollar. The modern route is an
+[HF-capable SDR](/best-hf-sdr/) or an [RTL-SDR](/reference/rtl-sdr/) in
+direct-sampling mode on a computer; GopherTrunk itself stays in its VHF/UHF
+scanner lane — the same listen-first philosophy, free.
+
+## Who it's for
+
+- **Buy the Satellit 800** if you want Drake-grade sync and the best audio
+  in the affordable-classic class, and you'll hold out for a 2003+ unit with
+  a known choke/encoder history.
+  <a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=grundig+satellit+800" rel="nofollow noopener">Find on eBay &rarr;</a>
+- **Buy the [Drake R8B](/reference/drake-r8b/)** instead if the budget
+  stretches — it's the real thing the 800 approximates.
+- **Tempted by its modern lookalike?** Read our
+  [Eton Elite 750](/reference/eton-elite-750/) review first — it imitates
+  the 800's looks, not its sync. Full rankings:
+  [best desktop shortwave receivers](/best-desktop-shortwave-receivers/).
+
+## Sources
+
+[^jayallen]: [Grundig Satellit 800 — radiojayallen](https://radiojayallen.com/grundig-satellit-800/) — Drake design lineage, sync/audio verdict, QC criticisms, the 2L41 choke fault, and production-vintage guidance.
+[^mwcircle]: [Receiver review: Grundig Satellit 800 Millennium — Medium Wave Circle](https://mwcircle.org/legacy-receiver-reviews/receiver-review-grundig-satellit-800-millennium/) — performance standing versus the top-tier classics; specifications corroborated by the [Universal Radio archive](https://www.universal-radio.com/catalog/portable/0800.html).

--- a/docs/reference/grundig-satellit-800.md
+++ b/docs/reference/grundig-satellit-800.md
@@ -127,6 +127,13 @@ are asking prices — condition and vintage swing real value a lot, so **check
 eBay sold listings first**. Serviceability is decent: the SW8 heritage means
 Drake-literate techs can work on it, with parts via donor units.
 
+**Used-market viability:** good, with the lottery caveat. Plenty were sold,
+so supply is steady and prices stay reasonable; the SW8-derived design keeps
+Drake-literate techs in play, and the one killer fault (the 2L41 choke) has
+a documented fix. The variable isn't age so much as birth date — which is
+why the production-date question does more work here than on any other
+classic.
+
 ## GopherTrunk alternative
 
 SDRs ended this product category — a ~$200 HF SDR out-receives the Satellit

--- a/docs/reference/icom-ic-r75.md
+++ b/docs/reference/icom-ic-r75.md
@@ -1,0 +1,155 @@
+---
+slug: icom-ic-r75
+title: Icom IC-R75
+entry_type: hardware
+category: shortwave-radios
+description: "The Icom IC-R75 is the best-value classic tabletop shortwave receiver — 30 kHz–60 MHz, twin passband tuning, rock-stable SSB — used-market only at roughly $300–500, with a famously poor sync detector and muffled stock audio as the trade-offs."
+keywords: Icom IC-R75, IC-R75 review, IC-R75 for sale, used shortwave receiver, best value shortwave receiver, tabletop communications receiver, IC-R75 sync detector, IC-R75 filters, Kiwa audio mod, is shortwave radio still worth it
+aka: [IC-R75, R75, ICR75]
+autolink: true
+affiliate: true
+product:
+  name: "Icom IC-R75"
+  brand: Icom
+  category: Desktop shortwave receiver (classic)
+  seller: eBay
+  itemCondition: used
+  lowPrice: "300"
+  highPrice: "500"
+  url: "https://www.ebay.com/sch/i.html?_nkw=icom+ic-r75"
+infobox:
+  - { label: Type, value: "Classic tabletop communications receiver" }
+  - { label: Bands, value: "30 kHz–60 MHz (includes 6 m)" }
+  - { label: SSB / Sync, value: "Excellent SSB/CW with twin PBT; sync AM present but poor" }
+  - { label: Power, value: "External 13.8 V DC (PSU usually supplied)" }
+  - { label: License, value: "None — receiver" }
+  - { label: Price, value: "around $300–500 used" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.ebay.com/sch/i.html?_nkw=icom+ic-r75\" rel=\"nofollow noopener\">Find on eBay &rarr;</a>" }
+see_also: [drake-r8b, kenwood-r-5000, jrc-nrd-545, icom-ic-r8600, single-sideband, rtl-sdr]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "Best desktop shortwave receivers", url: /best-desktop-shortwave-receivers/ }
+cite_urls:
+  - https://swling.com/blog/2016/03/the-icom-ic-r75-is-being-discontinued/
+  - https://mwcircle.org/legacy-receiver-reviews/receiver-review-icom-ic-r75/
+  - https://www.universal-radio.com/catalog/commrxvr/0175.html
+faq:
+  - q: "Is the Icom IC-R75 still worth buying?"
+    a: "As the value classic, yes. At roughly $300–500 used it's the cheapest serious tabletop here, with excellent SSB/CW performance, twin passband tuning, and famous stability. Its known weaknesses — muffled stock audio and a sync detector that loses lock — are the price of the discount."
+  - q: "How much is a used IC-R75?"
+    a: "Typically $300–500. Confirmed sales sit at the low end (~$315 on eBay, $325 on CanuckAudioMart in 2025); units loaded with optional filters and the UT-106 DSP board fetch more. It's the most affordable serious classic in the category."
+  - q: "Does the IC-R75 have a good sync detector?"
+    a: "No — its synchronous AM detector is widely called poor and prone to losing lock, the R75's best-known weakness. If sync AM is your priority, look at a Drake R8B or even a Sony ICF-2010 instead; the R75's strength is SSB, CW, and utility listening."
+  - q: "What should I check before buying a used IC-R75?"
+    a: "Which optional filters and whether the UT-106 DSP board are installed (they set the price), the supplied 13.8 V power supply (a known weak point for hum), LCD backlight at full brightness (it ages), and front-panel button feel. Ask about any Kiwa audio modification — a common and worthwhile upgrade."
+  - q: "Do I need a license to listen to shortwave on an IC-R75?"
+    a: "No. Receiving is license-free everywhere in the US — no FCC registration, exam, or paperwork of any kind. Only transmitting requires a license."
+---
+**The Icom IC-R75** is the value pick among classic tabletop shortwave
+receivers: a triple-conversion set covering **30 kHz–60 MHz** — uniquely
+reaching 6 m — that Icom kept in production from 1999 all the way to
+2016.[^swling] It's been discontinued for a decade now, so the used market —
+eBay, hamfests, SWL classifieds — is where it lives, and at roughly
+**$300–500** it's the cheapest serious classic in the category.
+
+<a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=icom+ic-r75" rel="nofollow noopener">Find on eBay &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The best-value classic — a superb SSB/utility receiver, not a top-tier
+broadcast set.** Twin passband tuning, two optional filter slots, famously
+stable, 30 kHz–60 MHz. **Known trade-offs:** muffled stock audio (Kiwa mods
+were a cottage industry) and a **sync detector widely called poor**. **Used
+only, ~$300–500** — the best-documented price band of any classic here.
+**No license to listen — ever.** Where it ranks:
+[best desktop shortwave receivers](/best-desktop-shortwave-receivers/).
+</div>
+
+## Overview
+
+The R75 outlived every rival on this list — a 17-year production run that
+ended only in March 2016 — and that longevity is why it's the easiest classic
+to actually buy: units are plentiful, prices are honest, and parts commonality
+with IC-706-era Icoms keeps service realistic.[^swling] The receiver itself
+is a known quantity: triple conversion, **twin passband tuning (PBT)** for
+carving interference off both sides of a signal, two slots for optional Icom
+CR/FL crystal filters, an optional UT-106 audio-DSP board (marginal, but most
+used units include it), and stability good enough that utility and digital-mode
+listeners made it a standard.[^mwcircle]
+
+The honest ledger has two debits. Stock audio is the classic Icom "muffled"
+sound — aftermarket Kiwa audio mods were literally a cottage industry — and
+the **synchronous AM detector is widely called poor**, dropping lock where a
+Drake holds on. That's why the community ranks it the best *value* classic
+rather than a top performer: buy it for [SSB](/reference/single-sideband/),
+CW, and utility DX, not for rich broadcast audio.
+
+About those bands: the big Western broadcasters have mostly left shortwave.
+What's still out there — international broadcasters, time signals, HF utility
+traffic, ham SSB, the odd pirate — is real but quieter than the genre's
+heyday, and the R75's utility/SSB strengths actually fit the modern bands
+well. Either way, **a $20 wire antenna out a window will do more for your
+reception than a $200 fancier radio** — string the wire first.
+
+**Listening note:** receiving is license-free everywhere in the US. No FCC
+anything, ever.
+
+## Bands, modes &amp; features
+
+- **Coverage:** 30 kHz–60 MHz — the only classic here that reaches 6 m.
+- **Modes:** [AM](/reference/amplitude-modulation/), SSB, CW, RTTY, sync AM
+  (weak), FM on some versions.
+- **Selectivity:** triple conversion, twin PBT, two optional filter slots,
+  optional UT-106 AF-DSP.
+- **Power:** external 13.8 V — check the supplied PSU (see below).
+
+## Buying used: what to check
+
+The R75's huge production run makes it low-drama, but four checks set the
+price and the experience:[^universal]
+
+1. **The power supply.** It runs from external 13.8 V, and the supplied PSU
+   is a known weak point (hum). Confirm one is included and clean.
+2. **The fit-out.** Optional CR/FL filters and the UT-106 DSP board are what
+   separate a $300 unit from a $500 one — get the exact inventory in writing.
+3. **LCD backlight.** It ages; verify it at 100% brightness.
+4. **Front-panel buttons** — check the feel on every one, and ask whether a
+   Kiwa audio mod has been done (a plus, not a red flag).
+
+Confirmed sales cluster at the low end — about **$315** on eBay and **$325**
+on CanuckAudioMart in 2025 — with loaded units toward $500. Few classics have
+this well-corroborated a price band, but check current eBay sold listings
+anyway. Serviceability is the best of the classics: enormous production run,
+shared Icom parts, active community.
+
+## GopherTrunk alternative
+
+The product category the R75 belongs to was ended by software-defined radio:
+a ~$200 HF SDR matches or beats a legacy tabletop and adds a spectrum
+waterfall no knob radio can draw. A used R75 today is a deliberate
+knobs-and-filters choice — and at ~$300–500 it's the cheapest way to make
+that choice — but the modern path to the same spectrum is an
+[HF-capable SDR](/best-hf-sdr/) or an [RTL-SDR](/reference/rtl-sdr/) in
+direct-sampling mode. GopherTrunk itself stays in its VHF/UHF scanner lane;
+it's simply the same listen-first philosophy, free.
+
+## Who it's for
+
+- **Buy the IC-R75** if you want the cheapest serious classic tabletop —
+  especially for SSB, CW, and utility listening — and can live without good
+  sync AM.
+  <a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=icom+ic-r75" rel="nofollow noopener">Find on eBay &rarr;</a>
+- **Buy the [Drake R8B](/reference/drake-r8b/)** instead if broadcast audio
+  and sync detection matter most, or the
+  [Kenwood R-5000](/reference/kenwood-r-5000/) for the all-round 1980s
+  Japanese alternative.
+- **Want new with a warranty?** The [Icom IC-R8600](/reference/icom-ic-r8600/)
+  is the one real current tabletop. Full rankings:
+  [best desktop shortwave receivers](/best-desktop-shortwave-receivers/).
+
+## Sources
+
+[^swling]: [The Icom IC-R75 is being discontinued — The SWLing Post (2016)](https://swling.com/blog/2016/03/the-icom-ic-r75-is-being-discontinued/) — discontinuation announcement closing the 1999–2016 production run.
+[^mwcircle]: [Receiver review: Icom IC-R75 — Medium Wave Circle](https://mwcircle.org/legacy-receiver-reviews/receiver-review-icom-ic-r75/) — performance verdict: excellent SSB/utility work, mediocre stock audio, poor sync detector, best-value standing.
+[^universal]: [Icom IC-R75 — Universal Radio archive](https://www.universal-radio.com/catalog/commrxvr/0175.html) — specifications, twin PBT, filter options, UT-106 DSP, power requirements, original pricing.

--- a/docs/reference/icom-ic-r75.md
+++ b/docs/reference/icom-ic-r75.md
@@ -123,6 +123,12 @@ this well-corroborated a price band, but check current eBay sold listings
 anyway. Serviceability is the best of the classics: enormous production run,
 shared Icom parts, active community.
 
+**Used-market viability:** the best of any classic here. Seventeen years of
+production means deep supply on eBay at any given moment, honest prices, and
+eHam owner reviews that run solidly positive for the money. Where a Drake or
+AOR purchase is a months-long hunt, a good R75 is usually a weeks-long one —
+and if you buy badly, you're out $300, not $1,300.
+
 ## GopherTrunk alternative
 
 The product category the R75 belongs to was ended by software-defined radio:

--- a/docs/reference/icom-ic-r8600.md
+++ b/docs/reference/icom-ic-r8600.md
@@ -120,6 +120,15 @@ Antenna Farm all stock it).[^gigaparts] Two practical points:
 2. **Used units** run about $2,000–2,400 and are low-risk — this is modern
    Icom hardware, not a 30-year-old classic.
 
+Who actually buys one? Three groups, in practice: HF listeners who want
+classic-tabletop operation with modern DSP and none of the used-market
+checklist; monitoring enthusiasts who want one box that covers shortwave in
+the evening and public-safety/aviation VHF-UHF the rest of the day; and
+owners of classic receivers who want a reference-grade modern set beside
+them. For all three, the fact that it's *supported* — firmware, warranty,
+dealers who answer the phone — is worth real money in a category where the
+alternative is a 25-year-old radio and a soldering iron.
+
 ## GopherTrunk alternative
 
 The IC-R8600 *is* an SDR — Icom just built the computer in. That's exactly

--- a/docs/reference/icom-ic-r8600.md
+++ b/docs/reference/icom-ic-r8600.md
@@ -1,0 +1,152 @@
+---
+slug: icom-ic-r8600
+title: Icom IC-R8600
+entry_type: hardware
+category: shortwave-radios
+description: "The Icom IC-R8600 is the only true full-size communications receiver still in production — 10 kHz–3 GHz SDR architecture, touchscreen spectrum/waterfall, P25/NXDN/D-STAR decode — around $2,750 new."
+keywords: Icom IC-R8600, IC-R8600 review, IC-R8600 price, wideband receiver, current production tabletop receiver, best communications receiver 2026, 10 kHz to 3 GHz receiver, IC-R8600 vs SDR, shortwave receiver new, is shortwave radio still worth it
+aka: [IC-R8600, R8600, ICR8600]
+autolink: true
+affiliate: true
+product:
+  name: "Icom IC-R8600"
+  brand: Icom
+  category: Wideband communications receiver (current production)
+  lowPrice: "2700"
+  highPrice: "2800"
+  url: "https://www.amazon.com/dp/B0891RNWGZ?tag=gophertrunk-20"
+infobox:
+  - { label: Type, value: "Wideband tabletop communications receiver (SDR architecture)" }
+  - { label: Bands, value: "10 kHz–3 GHz" }
+  - { label: SSB / Sync, value: "SSB/CW/AM/FM/WFM/FSK + digital decode; no true sync AM (twin PBT + DSP NR/notch instead)" }
+  - { label: Power, value: "External DC" }
+  - { label: License, value: "None — receiver" }
+  - { label: Price, value: "around $2,750 new ($2,749.95 dealer street)" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B0891RNWGZ?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [drake-r8b, jrc-nrd-545, icom-ic-r75, eton-elite-750, rtl-sdr, waterfall-display]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "Best desktop shortwave receivers", url: /best-desktop-shortwave-receivers/ }
+cite_urls:
+  - https://www.icomamerica.com/lineup/products/IC-R8600/
+  - https://www.gigaparts.com/icom-ic-r8600-10khz-3ghz-wideband-receiver-w-multiple-digital-mode-decode.html
+faq:
+  - q: "Is the Icom IC-R8600 still in production?"
+    a: "Yes — as of August 2026 it's sold new by multiple authorized dealers (GigaParts, DX Engineering, HRO, Universal, The Antenna Farm), and it's the only true full-size communications receiver still being made. Dealer street price is about $2,750."
+  - q: "Does the IC-R8600 have synchronous AM detection?"
+    a: "No true sync-AM mode — Icom gives you twin passband tuning and DSP noise reduction/notch instead. If classic selectable-sideband sync is the feature you're chasing, that's the used-classic territory of the Drake R8B; the R8600 attacks the same problems with DSP."
+  - q: "What digital modes does the IC-R8600 decode?"
+    a: "P25, NXDN, D-STAR, dPMR, and DCR, alongside SSB/CW/AM/FM/WFM/FSK across 10 kHz–3 GHz. It also outputs I/Q for use as a front end with PC SDR software — it's a software-defined receiver in a tabletop shell."
+  - q: "Is the IC-R8600 worth it over a $200 SDR?"
+    a: "Honestly: a ~$200 HF SDR gets you much of the HF performance, which even the R8600's fans concede. What the Icom adds is a genuinely strong front end derived from the IC-7300/7610 line, 3 GHz coverage, built-in digital voice decode, a touchscreen waterfall, and a self-contained box that needs no computer — you're paying for integration and the front end."
+  - q: "Do I need a license for an IC-R8600?"
+    a: "No. It's receive-only, and listening is license-free everywhere in the US — no FCC anything, ever. (The US '-02' version is cellular-blocked as federal law requires; unblocked units are sold only to qualified buyers.)"
+---
+**The Icom IC-R8600** is the last one standing: the **only true full-size
+communications receiver still in production**, a 10 kHz–3 GHz
+software-defined design with a 4.3-inch color touchscreen spectrum/waterfall
+and built-in digital voice decode.[^icom] It's a current model with a
+warranty and dealer support — a rarity worth stating plainly in a category
+that's otherwise a used market — at a dealer street price of about
+**$2,750**.[^gigaparts]
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0891RNWGZ?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The one real current tabletop — and the best new receiver money can buy,
+because it's effectively the only one.** 10 kHz–3 GHz, SDR architecture with
+an IC-7300/7610-derived front end, touchscreen waterfall, P25/NXDN/D-STAR/
+dPMR/DCR decode, I/Q output. **No true sync AM** — twin PBT and DSP tools
+instead. **~$2,750 street** (Amazon marketplace pricing often runs above the
+$2,749.95 dealer street — compare before buying). **No license to listen —
+ever.** Where it ranks:
+[best desktop shortwave receivers](/best-desktop-shortwave-receivers/).
+</div>
+
+## Overview
+
+When SWLing Post surveyed the tabletop market, the survivors were "a handful
+of expensive wideband receivers" — and this is the one they meant. The
+IC-R8600 is what the tabletop receiver became after SDR won: a
+software-defined receiver wearing a knob radio's body. The front end is
+derived from Icom's IC-7300/7610 transceiver line (RMDR-class numbers), the
+display is a live spectrum scope and [waterfall](/reference/waterfall-display/),
+tuning runs from 10 kHz to 3 GHz, and it decodes P25, NXDN, D-STAR, dPMR,
+and DCR digital voice on top of the analog modes. A rock-stable TCXO and an
+I/Q output — feed it to PC SDR software and it's a $2,750 front end — round
+out the spec.[^icom]
+
+The consensus verdict is easy to summarize because there's no competition:
+it's the best new tabletop you can buy, its HF performance is genuinely
+strong, and it doubles as a serious VHF/UHF monitor. The honest criticisms:
+the price, average internal-speaker audio, the lack of a true sync-AM mode
+(twin passband tuning and DSP noise reduction/notch stand in), and — from
+the purists — the observation that a $200 SDR delivers much of the HF
+performance. All true. You're paying for the front end, the 3 GHz sweep,
+the decoders, and a box that works without a computer.
+
+Two standing notes for any shortwave purchase. The bands are quieter than
+the brochures of old: major Western broadcasters have left shortwave, and
+what remains — international broadcasters, time stations, utility/HF
+traffic, ham [SSB](/reference/single-sideband/), pirates — is real but
+thinner. And **$20 of wire antenna out a window improves HF reception more
+than a $200 radio upgrade** — even under a receiver this good.
+
+**Listening note:** receiving is license-free everywhere in the US — no FCC
+registration, exam, or paperwork, ever.
+
+## Bands, modes &amp; features
+
+- **Coverage:** 10 kHz–3 GHz. (US "-02" version is cellular-blocked;
+  unblocked units sell to qualified buyers only.)
+- **Modes:** SSB, CW, [AM](/reference/amplitude-modulation/), FM, WFM, FSK;
+  digital decode for **P25, NXDN, D-STAR, dPMR, DCR**.
+- **DSP tools:** twin PBT, noise reduction, notch — no true sync AM.
+- **Display:** 4.3" color touchscreen spectrum/waterfall.
+- **Extras:** I/Q output for PC SDR use; TCXO stability. **Power:** external
+  DC.
+
+## Buying notes
+
+No used-market minefield here — it's current production with warranty and
+authorized-dealer support (GigaParts, DX Engineering, HRO, Universal, The
+Antenna Farm all stock it).[^gigaparts] Two practical points:
+
+1. **Compare Amazon against dealer street.** Third-party/marketplace pricing
+   on Amazon often runs above the **$2,749.95** dealer street price — the
+   dealer number is the honest one.
+2. **Used units** run about $2,000–2,400 and are low-risk — this is modern
+   Icom hardware, not a 30-year-old classic.
+
+## GopherTrunk alternative
+
+The IC-R8600 *is* an SDR — Icom just built the computer in. That's exactly
+why the honest comparison stings: a ~$200 [HF-capable SDR](/best-hf-sdr/) or
+even a ~$30 [RTL-SDR](/reference/rtl-sdr/) in direct-sampling mode delivers
+much of the HF experience, waterfall included, on a screen you already own.
+What the Icom sells is the front end, 3 GHz coverage, built-in decoders, and
+computer-free operation. On the VHF/UHF side, its P25/NXDN decoding overlaps
+GopherTrunk's home turf — GopherTrunk plus a cheap dongle does trunk-tracking
+the R8600 can't, records every call, and costs nothing: the same
+listen-first philosophy, free.
+
+## Who it's for
+
+- **Buy the IC-R8600** if you want the best self-contained receiver in
+  current production — one box, DC to 3 GHz, warranty — and the price is
+  acceptable.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B0891RNWGZ?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy a classic** — [Drake R8B](/reference/drake-r8b/) or
+  [JRC NRD-545](/reference/jrc-nrd-545/) — if HF-only knobs-and-filters
+  romance is the actual goal; you'll save four figures.
+- **Budget buyer?** A used [Icom IC-R75](/reference/icom-ic-r75/) (~$300–500)
+  or an [HF SDR](/best-hf-sdr/) covers the shortwave bands for far less.
+  Full rankings:
+  [best desktop shortwave receivers](/best-desktop-shortwave-receivers/).
+
+## Sources
+
+[^icom]: [Icom IC-R8600 product page — Icom America](https://www.icomamerica.com/lineup/products/IC-R8600/) — specifications: coverage, modes, digital decode list, touchscreen scope, I/Q output, TCXO.
+[^gigaparts]: [Icom IC-R8600 — GigaParts](https://www.gigaparts.com/icom-ic-r8600-10khz-3ghz-wideband-receiver-w-multiple-digital-mode-decode.html) — current-production availability and the $2,749.95 dealer street price (August 2026).

--- a/docs/reference/jrc-nrd-545.md
+++ b/docs/reference/jrc-nrd-545.md
@@ -1,0 +1,159 @@
+---
+slug: jrc-nrd-545
+title: JRC NRD-545
+entry_type: hardware
+category: shortwave-radios
+description: "The JRC NRD-545 is the first mainstream DSP-IF tabletop shortwave receiver — bandwidth variable in 10 Hz steps, working ECSS sync, commercial-marine build — used-market only with ask-based prices around $1,200–2,000 that need sold-listing verification."
+keywords: JRC NRD-545, NRD-545 review, NRD-545 for sale, JRC receiver, DSP shortwave receiver, classic tabletop receiver, NRD-545 vs NRD-535, NRD-545 DSP noise, used shortwave receiver, is shortwave radio still worth it
+aka: [NRD-545, NRD545, JRC NRD-545 DSP]
+autolink: true
+affiliate: true
+product:
+  name: "JRC NRD-545"
+  brand: JRC
+  category: Desktop shortwave receiver (classic)
+  seller: eBay
+  itemCondition: used
+  lowPrice: "1200"
+  highPrice: "2000"
+  url: "https://www.ebay.com/sch/i.html?_nkw=jrc+nrd-545"
+infobox:
+  - { label: Type, value: "Classic tabletop shortwave receiver (DSP-IF)" }
+  - { label: Bands, value: "100 kHz–30 MHz (optional CHE-199 converter to 2 GHz)" }
+  - { label: SSB / Sync, value: "Excellent SSB; ECSS/sync that genuinely works, selectable sideband" }
+  - { label: Power, value: "AC mains" }
+  - { label: License, value: "None — receiver" }
+  - { label: Price, value: "asks around $1,200–2,000 used — verify sold listings" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.ebay.com/sch/i.html?_nkw=jrc+nrd-545\" rel=\"nofollow noopener\">Find on eBay &rarr;</a>" }
+see_also: [drake-r8b, aor-ar7030, icom-ic-r75, icom-ic-r8600, single-sideband, rtl-sdr]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "Best desktop shortwave receivers", url: /best-desktop-shortwave-receivers/ }
+cite_urls:
+  - https://www.universal-radio.com/catalog/commrxvr/1545.html
+  - https://www.eham.net/reviews/view-product?id=1281
+faq:
+  - q: "Is the JRC NRD-545 a good receiver?"
+    a: "It's a polarizing top-three classic. Praised: silky flexibility (bandwidth variable in 10 Hz steps — effectively a thousand filters), quiet circuitry, commercial-marine build, and a sync/ECSS detector that genuinely works. Criticized: early-generation DSP artifacts and a slightly synthetic audio character. The knob-twiddler's dream; the Drake R8B and AOR AR7030 sound better on program audio."
+  - q: "How much does a used NRD-545 cost?"
+    a: "eBay asking prices commonly run $1,200–2,000, with top examples asking around $3,000 — but those are asks, kept high by JRC prestige, and confirmed sales are thin. Check eBay sold listings before treating any of those numbers as the market. It listed around $1,800 new."
+  - q: "What are the NRD-545's 'DSP noises'?"
+    a: "The 545 was the first mainstream tabletop with a DSP IF, and its early-generation processing can produce audible artifacts — overload birdies and a slightly synthetic character — that split owner opinion from excellent to poor. Test strong-signal behavior on any unit you're evaluating."
+  - q: "What should I check before buying an NRD-545?"
+    a: "The CR2032 memory-backup battery (replacing it means pulling the front panel; dead battery means no memories), the CCFL-backlit LCD (dim for the first minutes from cold is normal, but it must reach full brightness), DSP behavior on strong signals, and whether the CHE-199 converter is fitted. Its modular plug-in boards make board-swap repair feasible, though JRC no longer supports it."
+  - q: "Do I need a license to use an NRD-545?"
+    a: "No — it's a receiver, and listening is license-free everywhere in the US. No FCC anything, ever."
+---
+**The JRC NRD-545** (1998–2008) is the classic that saw the future coming: the
+first mainstream tabletop with a **DSP IF**, its bandwidth continuously
+variable in 10 Hz steps — effectively a thousand filters — plus DSP notch,
+noise reduction, passband shift, and an **ECSS/sync detector that genuinely
+works**.[^universal] Japan Radio Company built it to commercial-marine
+standards on plug-in modular boards. It's long discontinued; the used market —
+eBay, estate sales, SWL classifieds — is where it lives, with **asks commonly
+$1,200–2,000**.
+
+<a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=jrc+nrd-545" rel="nofollow noopener">Find on eBay &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The ultimate knob-twiddler's DSP classic** — 10 Hz-step variable bandwidth,
+working selectable-sideband sync, JRC marine build. **Polarizing:** early-DSP
+artifacts ("DSP noises", overload birdies) and slightly synthetic audio split
+owners; the R8B and AR7030 sound better on program material. **Prices are
+ask-based** — JRC prestige keeps asks at $1,200–2,000+, confirmed sales are
+thin, so check eBay *sold* listings. **Checklist: CR2032 battery, CCFL
+backlight, strong-signal DSP behavior.** **No license to listen — ever.**
+Rankings: [best desktop shortwave receivers](/best-desktop-shortwave-receivers/).
+</div>
+
+## Overview
+
+Where the [Drake R8B](/reference/drake-r8b/) perfected the analog tabletop
+and the [AOR AR7030](/reference/aor-ar7030/) perfected the front end, the
+NRD-545 replaced the filter drawer with mathematics. Dial in *any* bandwidth
+in 10 Hz steps; shift the passband, notch a heterodyne, run noise reduction —
+all in DSP, a decade before SDRs made that ordinary. Add JRC's commercial
+heritage (this is the consumer cousin of marine-radio hardware), a quiet
+circuit, and sync detection with selectable sideband that actually holds
+lock, and you have a permanent top-three classic.[^eham]
+
+You also have the era's most polarizing radio. First-generation DSP has a
+sound: owners report "DSP noises", birdies under strong-signal overload, and
+an audio character best described as slightly synthetic. eHam reviews run
+from excellent to poor at the extremes — the consensus lands on *the ultimate
+knob-twiddler's radio*, with the Drake and AOR ahead of it for pure program
+listening. Decide which listener you are before you pay JRC prices.
+
+And be realistic about what you'll point it at: the major Western
+broadcasters have left shortwave, and today's bands — international
+broadcasters, time stations, utility/HF traffic, ham
+[SSB](/reference/single-sideband/), pirates — are quieter than the 545's
+launch year. The cheapest upgrade remains the oldest one: **a $20 wire
+antenna out a window beats a $200 radio upgrade**, on this or any receiver.
+
+**Listening note:** receiving is license-free everywhere in the US. No FCC
+paperwork of any kind, ever.
+
+## Bands, modes &amp; features
+
+- **Coverage:** 100 kHz–30 MHz; the optional CHE-199 converter extends to
+  2 GHz.
+- **Modes:** [AM](/reference/amplitude-modulation/), FM, CW, SSB, RTTY, plus
+  ECSS/sync with selectable sideband.
+- **Selectivity:** DSP IF — bandwidth variable in 10 Hz steps (~1,000
+  "filters"), DSP notch/NR/passband shift.
+- **Build:** commercial-marine grade, plug-in modular boards. **Power:** AC
+  mains.
+
+## Buying used: what to check
+
+JRC build quality means fewer horror stories than most classics, but the
+checklist is specific:[^universal]
+
+1. **CR2032 memory battery.** Dead battery = no memories, and replacement is
+   a front-panel-off job. Ask when it was last changed.
+2. **The CCFL-backlit LCD.** Dim for the first minutes from cold is *normal*
+   — but verify it reaches full brightness after warm-up (CCFLs age). Ask for
+   a warmed-up display photo. The 545 has far better display longevity than
+   the NRD-525/535's failure-prone fluorescents, but check anyway.
+3. **DSP behavior on strong signals.** Verify no overload misbehavior — this
+   is where the "DSP noises" debate lives, and units vary in how much it
+   bothers you.
+4. **Converter and options** — is the CHE-199 fitted?
+
+The modular boards make board-swap repair feasible via donor units; JRC
+itself no longer supports the radio. On price, **hedge hard**: asks of
+$1,200–2,000 (to ~$3,000 for top examples) are propped up by JRC prestige,
+and confirmed sold prices are thin. **Check eBay sold listings before
+believing any ask.**
+
+## GopherTrunk alternative
+
+Here's the irony: the NRD-545's DSP IF was the road that led straight to the
+SDRs that killed this whole category. A ~$200 HF SDR now does everything the
+545's DSP does — variable bandwidth, notch, NR — plus a spectrum waterfall,
+for a tenth of the ask. Buying a 545 today is a deliberate choice of knobs,
+marine-grade build, and tactile operating over performance-per-dollar. The
+modern path is an [HF-capable SDR](/best-hf-sdr/) or an
+[RTL-SDR](/reference/rtl-sdr/) in direct-sampling mode; GopherTrunk itself
+stays in its VHF/UHF scanner lane — the same listen-first philosophy, free.
+
+## Who it's for
+
+- **Buy the NRD-545** if infinitely adjustable filtering under real knobs is
+  the point, you've heard (and accepted) first-generation DSP audio, and
+  you'll verify the battery, backlight, and strong-signal behavior first.
+  <a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=jrc+nrd-545" rel="nofollow noopener">Find on eBay &rarr;</a>
+- **Buy the [Drake R8B](/reference/drake-r8b/)** instead for better program
+  audio at similar-or-less money, or the [AOR AR7030](/reference/aor-ar7030/)
+  for the stronger front end.
+- **Want DSP flexibility with a warranty?** That's literally the
+  [Icom IC-R8600](/reference/icom-ic-r8600/). Full rankings:
+  [best desktop shortwave receivers](/best-desktop-shortwave-receivers/).
+
+## Sources
+
+[^universal]: [JRC NRD-545 — Universal Radio archive](https://www.universal-radio.com/catalog/commrxvr/1545.html) — specifications: DSP IF with 10 Hz-step bandwidths, ECSS, modular construction, CHE-199 converter, production dates, original pricing.
+[^eham]: [JRC NRD-545 reviews — eHam.net](https://www.eham.net/reviews/view-product?id=1281) — the owner-review spread from excellent to poor: DSP-artifact criticisms, build-quality praise, and the knob-twiddler consensus.

--- a/docs/reference/jrc-nrd-545.md
+++ b/docs/reference/jrc-nrd-545.md
@@ -129,6 +129,12 @@ $1,200–2,000 (to ~$3,000 for top examples) are propped up by JRC prestige,
 and confirmed sold prices are thin. **Check eBay sold listings before
 believing any ask.**
 
+**Used-market viability:** good hardware, tricky pricing. The marine-grade
+build and modular boards mean survivors are usually healthy survivors, and
+board swaps from donor units are a realistic repair path. The risk is
+overpaying: prestige asks well above thin sold data make the NRD-545 the
+classic where patience pays the largest dividend.
+
 ## GopherTrunk alternative
 
 Here's the irony: the NRD-545's DSP IF was the road that led straight to the

--- a/docs/reference/kaito-ka500.md
+++ b/docs/reference/kaito-ka500.md
@@ -1,0 +1,130 @@
+---
+slug: kaito-ka500
+title: Kaito KA500
+entry_type: hardware
+category: shortwave-radios
+description: "The Kaito KA500 Voyager is the only sub-$60 crank radio with real shortwave — AM/FM/SW 3.2–22 MHz/NOAA weather, 5-way power with a tilting solar panel, around $50–65. Tone alert only (not SAME), basic analog tuning."
+keywords: Kaito KA500 review, Kaito KA500, Kaito Voyager, emergency shortwave radio, crank shortwave radio, hand crank radio with shortwave, solar emergency radio, NOAA weather radio, best emergency radio 2026, KA500 vs ER310, is shortwave radio still worth it
+aka: [KA500, Kaito Voyager, KA-500]
+autolink: true
+affiliate: true
+product:
+  name: "Kaito KA500 Voyager"
+  brand: Kaito
+  category: Emergency crank/solar radio with shortwave
+  lowPrice: "49"
+  highPrice: "65"
+  url: https://www.amazon.com/dp/B003A21DQA?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: "Emergency crank/solar radio with shortwave" }
+  - { label: Bands, value: "AM / FM / SW 3.2–22 MHz (2 bands, analog) / 7 NOAA WX" }
+  - { label: Alerts, value: "1050 Hz tone alert standby — not SAME" }
+  - { label: Power, value: "5-way: crank, tilting solar, ~600 mAh NiMH (replaceable), 3× AA, USB/AC input" }
+  - { label: License, value: "None — receiver" }
+  - { label: Price, value: "around $50–65 by color" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B003A21DQA?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [midland-er310, eton-fr500, grundig-fr200, sangean-mmr-88, shortwave-broadcast, whip-antenna]
+related_reading:
+  - { title: "Best emergency radios", url: /best-emergency-radios/ }
+cite_urls:
+  - https://kaito.us/products/kaito-ka500-voyager-solar-crank-emergency-weather-alert-radio-bundle-with-case
+  - https://commonsensehome.com/kaito-ka500-review/
+  - https://swling.com/blog/2008/12/review-of-the-kaito-ka-500-self-powered-radio/
+faq:
+  - q: "Does the Kaito KA500 have shortwave?"
+    a: "Yes — two analog shortwave bands covering roughly 3.2–9 MHz and 9–22 MHz, which makes it the cheapest current crank radio with real shortwave. Expect basic whip-antenna reception with a slightly flimsy analog dial, not a hobbyist receiver."
+  - q: "Does the Kaito KA500 have SAME weather alerting?"
+    a: "No. Its Alert switch is 1050 Hz tone-alert standby, waking for any watch or warning across the whole NOAA transmitter's footprint. It cannot filter by county — for that you need a dedicated SAME desktop radio."
+  - q: "How is the KA500 powered?"
+    a: "Five ways: hand crank, a tilting 180-degree solar panel, a small replaceable ~600 mAh NiMH pack, 3× AA batteries, and a USB/AC input (adapter often not included). The AA option is a real strength — store-bought batteries beat crank blisters."
+  - q: "Is shortwave radio still worth it in 2026?"
+    a: "It's quieter than its heyday — most major Western broadcasters have left the bands — but international broadcasters, time signals, ham SSB, and utility traffic remain, and in a wide-area emergency shortwave still crosses continents with no infrastructure. Listening is license-free."
+  - q: "What are the KA500's known weaknesses?"
+    a: "Reviewers consistently flag the flimsy analog tuning (slipping or stuck needle), reports of crank arms snapping on older stock, the tiny 600 mAh NiMH pack that fades after a few hundred cycles (replaceable, and genuine spares are sold), and inconsistent solar runtimes. Buy it for the bands and power flexibility, not refinement."
+---
+**The Kaito KA500 Voyager** is the only crank radio under $60 that receives real
+**shortwave** — two analog SW bands spanning 3.2–22 MHz alongside AM, FM, and all
+7 NOAA weather channels — with the widest power flexibility in the class: crank,
+tilting solar panel, replaceable NiMH pack, 3× AA, and a USB/AC input.[^kaito]
+It runs around $50–65 depending on color, and like every radio in this roster it
+does **tone alert only — not SAME**.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B003A21DQA?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Buy it for the band list and the five power sources, not for refinement.**
+The shortwave is real but basic — whip antenna, analog dial reviewers call
+flimsy — and a $20 wire antenna out a window will improve SW reception more than
+any radio upgrade at this price. **Tone-alert standby, not SAME** — a plugged-in
+SAME desktop radio is still what reliably wakes you. **~600 mAh NiMH pack is
+tiny but replaceable; the 3× AA fallback is the feature that ages well.**
+**~$50–65** (yellow is usually cheapest). **Listening is license-free** — no FCC
+anything, ever. See where it ranks: [best emergency radios](/best-emergency-radios/).
+</div>
+
+## Overview
+
+The KA500 has been the go-bag shortwave radio for over a decade, sold in about
+six colors through Kaito, Walmart, and Amazon. Its pitch is breadth: no other
+current sub-$60 crank radio covers AM, FM, [shortwave](/reference/shortwave-broadcast/),
+and NOAA weather, and none matches its **5-way power** — hand-crank dynamo,
+a 180° tilting solar panel (genuinely better sun-angle capture than the fixed
+panels on rivals), an internal replaceable NiMH pack, three AAs, and a 5 V
+input. Rounding it out: a 5-LED reading lamp, flashlight, red SOS beacon, and a
+USB output for token phone top-ups. The case is impact- and water-*resistant*
+ABS with no formal IP rating — keep it out of the pool.
+
+## Shortwave on a crank radio: what to expect
+
+The two analog bands (SW1 3.2–9 MHz, SW2 9–22 MHz) cover the major broadcast
+segments. Reception off the built-in [whip](/reference/whip-antenna/) is basic,
+and the analog dial is the KA500's most-criticized part — reviewers describe
+tuning that slips or sticks.[^csh] The honest 2026 framing: the shortwave bands
+are quieter than their heyday, with most big Western broadcasters gone, but
+international broadcasters, time stations, and ham [SSB](/reference/single-sideband/)
+traffic remain — and in a wide-area disaster, shortwave is the one band that
+crosses continents with zero local infrastructure. Cheap force multiplier: clip
+20 feet of wire to the whip and hang it out a window; it will do more for
+reception than $200 of radio upgrade.
+
+## Alerting and power reality
+
+The Alert switch is **1050 Hz tone-alert standby** — it wakes for any watch or
+warning across the entire NOAA transmitter's coverage, no county filtering, no
+event display. **Not SAME**; pair it with a plugged-in SAME desktop unit if
+being woken matters. On power: long-term owners report the ~600 mAh NiMH pack
+degrades after a few hundred cycles (it's replaceable and genuine spares are
+sold), solar runtimes are inconsistent, and the radio is something of a battery
+hog.[^swling] Older stock had reports of crank arms snapping, though multi-year
+owners also report none. The 3× AA fallback is the quiet hero — a $5 pack of
+alkalines outlasts any amount of cranking.
+
+## GopherTrunk alternative
+
+An SDR needs a computer and power; the KA500's whole point is needing neither —
+so free software is no substitute here. Where GopherTrunk fits the same
+preparedness kit is on the infrastructure side: a
+[$30 RTL-SDR](/reference/rtl-sdr/) monitors and records your local public-safety
+and utility channels, which carry the ground truth a forecast loop doesn't. Our
+[emergency scanner frequencies](/scanner-frequencies/) guide covers what to
+listen to when things go wrong; the KA500 is the no-power fallback that rides
+beside that setup — and the only one in this class that also hears the world.
+
+## Who it's for
+
+- **Buy the KA500** if your emergency radio should also hear shortwave and run
+  on anything — sun, crank, AAs, or USB — and you can live with rough edges.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B003A21DQA?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [Midland ER310](/reference/midland-er310/)** instead if you'd trade
+  shortwave for a bigger battery and tighter build quality.
+- **Want the classic SW crank radios?** The discontinued
+  [Eton FR500](/reference/eton-fr500/) and [Grundig FR200](/reference/grundig-fr200/)
+  cover the used market. Full rankings:
+  [best emergency radios](/best-emergency-radios/).
+
+## Sources
+
+[^kaito]: [Kaito KA500 Voyager product page](https://kaito.us/products/kaito-ka500-voyager-solar-crank-emergency-weather-alert-radio-bundle-with-case) — Kaito USA: band coverage, 5-way power system, tilting solar panel, lighting features, and alert function.
+[^csh]: [Kaito KA500 review — Common Sense Home](https://commonsensehome.com/kaito-ka500-review/) — long-term owner testing: tuning-mechanism complaints, battery and solar behavior, and durability notes.
+[^swling]: [Review of the Kaito KA-500 — The SWLing Post](https://swling.com/blog/2008/12/review-of-the-kaito-ka-500-self-powered-radio/) — shortwave-listener perspective on receiver performance and the self-powered design's real-world limits.

--- a/docs/reference/kenwood-r-5000.md
+++ b/docs/reference/kenwood-r-5000.md
@@ -127,6 +127,12 @@ change hands at **$450–700**, but that band is built from asking prices —
 check eBay sold listings before you pay. Working for you: excellent
 documentation and one of the most active repair scenes of any classic.
 
+**Used-market viability:** high maintenance, high support. Every known
+fault has a documented fix, commercial repair exists, and the recap/dot-fix
+knowledge base is deep — so a serviced R-5000 is a safe long-term keeper,
+and an unserviced one is a known-quantity project rather than a mystery.
+Price the difference between the two accordingly; it's real money.
+
 ## GopherTrunk alternative
 
 SDRs ended the tabletop-receiver category: a ~$200 HF SDR outruns the R-5000

--- a/docs/reference/kenwood-r-5000.md
+++ b/docs/reference/kenwood-r-5000.md
@@ -1,0 +1,157 @@
+---
+slug: kenwood-r-5000
+title: Kenwood R-5000
+entry_type: hardware
+category: shortwave-radios
+description: "The Kenwood R-5000 is the dependable 1980s Japanese tabletop shortwave receiver — excellent SSB, great optional filters, no sync AM — used at roughly $450–700, and the highest-maintenance classic on our list with the famous PLL 'dot problem' to check for."
+keywords: Kenwood R-5000, R-5000 review, R-5000 for sale, Kenwood shortwave receiver, R-5000 dot problem, classic tabletop receiver, used shortwave receiver, R-5000 recap, first serious shortwave receiver, is shortwave radio still worth it
+aka: [R-5000, R5000]
+autolink: true
+affiliate: true
+product:
+  name: "Kenwood R-5000"
+  brand: Kenwood
+  category: Desktop shortwave receiver (classic)
+  seller: eBay
+  itemCondition: used
+  lowPrice: "450"
+  highPrice: "700"
+  url: "https://www.ebay.com/sch/i.html?_nkw=kenwood+r-5000"
+infobox:
+  - { label: Type, value: "Classic tabletop shortwave receiver" }
+  - { label: Bands, value: "100 kHz–30 MHz (VC-20 option adds 108–174 MHz)" }
+  - { label: SSB / Sync, value: "Excellent SSB; no synchronous detection" }
+  - { label: Power, value: "Internal AC supply (runs hot; DCK-2 12 V kit preferred)" }
+  - { label: License, value: "None — receiver" }
+  - { label: Price, value: "around $450–700 used (ask-based — verify sold listings)" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.ebay.com/sch/i.html?_nkw=kenwood+r-5000\" rel=\"nofollow noopener\">Find on eBay &rarr;</a>" }
+see_also: [icom-ic-r75, drake-r8b, sony-icf-2010, kenwood-ts-940s, single-sideband, rtl-sdr]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "Best desktop shortwave receivers", url: /best-desktop-shortwave-receivers/ }
+cite_urls:
+  - https://www.universal-radio.com/catalog/commrxvr/r5000.html
+  - https://mwcircle.org/legacy-receiver-reviews/receiver-review-kenwood-r-5000/
+faq:
+  - q: "Is the Kenwood R-5000 a good first classic receiver?"
+    a: "It's frequently recommended as exactly that — the best all-round 1980s Japanese tabletop, a step below the Drake R8B / AOR AR7030 / JRC NRD-545 tier but cheaper, with excellent SSB, great optional filters, and superb documentation. The caveat: it's the highest-maintenance radio on our list, so buy a serviced example or budget for the work."
+  - q: "What is the Kenwood R-5000 'dot problem'?"
+    a: "The signature R-5000 fault: conductive aging potting compound on the PLL board makes the PLL unlock — the display shows dots and the radio behaves as if the dial is turning. It's a well-documented fix, and commercial repair (e.g. Jahnke Electronics) exists. Always ask whether the dot fix has been done."
+  - q: "How much should I pay for an R-5000?"
+    a: "Working, clean units typically run $450–700; eBay asks range from $250 for rough examples to $1,300 for pristine ones. Those are asking prices — well populated but not confirmed sales — so check eBay sold listings, and pay top money only for a unit with the dot fix, a recap, and alignment history."
+  - q: "Does the R-5000 have synchronous AM detection?"
+    a: "No — that's its main spec gap against the Drake R8B and other top classics. What it does have: excellent SSB, dual conversion with fine optional YK-series filters, IF shift, a notch, 100 memories, and better-than-average audio for a Japanese set of its era."
+  - q: "Do I need a license to listen with an R-5000?"
+    a: "No. Listening is license-free everywhere in the US — no FCC registration or exam, ever. Only transmitting requires a license, and this radio doesn't transmit."
+---
+**The Kenwood R-5000** is the dependable classic — Kenwood's last dedicated
+shortwave receiver (introduced 1986/87, built until about 1996) and the radio
+most often recommended as a *first* serious used tabletop.[^universal] It
+sits a step below the Drake/AOR/JRC tier in every ranking but costs less:
+figure roughly **$450–700** for a clean working unit on the used market —
+eBay, hamfests, SWL classifieds — which is the only place it lives.
+
+<a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=kenwood+r-5000" rel="nofollow noopener">Find on eBay &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The best all-round 1980s Japanese tabletop — and the highest-maintenance
+classic on our list.** Excellent SSB, good dynamic range, fine optional
+YK filters, IF shift and notch; **no sync AM**. **Used ~$450–700**
+(ask-based — check sold listings). **The buying game:** the PLL "dot
+problem", keybounce from dried capacitors, scarce replacement displays, and
+heat from the internal AC supply — all documented, with an active repair
+scene. **No license to listen — ever.** Where it ranks:
+[best desktop shortwave receivers](/best-desktop-shortwave-receivers/).
+</div>
+
+## Overview
+
+The R-5000 is what Japan Inc. tabletop engineering looked like at its
+confident peak: dual conversion covering 100 kHz–30 MHz, excellent
+[SSB](/reference/single-sideband/), good dynamic range, IF shift, a notch
+filter, 100 memories, dual clocks with a timer, and slots for Kenwood's
+excellent optional YK-series crystal filters that turn it into a genuinely
+selective DX machine.[^mwcircle] Audio is better than average for the
+breed. The VC-20 option adds 108–174 MHz VHF. What it never got is
+**synchronous AM detection** — the one spec that keeps it out of the
+top tier against the [Drake R8B](/reference/drake-r8b/).
+
+It shares DNA and an era with the [TS-940S](/reference/kenwood-ts-940s/)
+transceiver, including the era's liabilities: nearly forty-year-old
+electrolytics, a PLL with a famous aging fault, and an internal AC supply
+that runs the radio hot. None of that is a reason not to buy one — it's the
+frame for how to buy one, below.
+
+Also frame the hobby honestly: the major Western broadcasters have left
+shortwave, and what remains — international broadcasters, time signals,
+utility/HF traffic, ham SSB, pirates — is real but quieter than the R-5000's
+1980s heyday. Whatever you buy, remember that **a $20 wire antenna out a
+window improves reception more than a $200 radio upgrade**.
+
+**Listening note:** receiving is license-free everywhere in the US — no FCC
+anything, ever.
+
+## Bands, modes &amp; features
+
+- **Coverage:** 100 kHz–30 MHz; VC-20 option adds 108–174 MHz.
+- **Modes:** [AM](/reference/amplitude-modulation/), SSB, CW, FM, FSK — no
+  sync AM.
+- **Selectivity:** dual conversion, optional YK-series filters, IF shift,
+  notch.
+- **Extras:** 100 memories, dual clocks/timer. **Power:** internal AC supply
+  (hot); DCK-2 12 V DC kit preferred.
+
+## Buying used: what to check
+
+**This is the highest-maintenance radio on our list** — well documented,
+very fixable, but go in with the checklist:[^universal]
+
+1. **The "dot problem."** Conductive aging potting goo on the PLL board makes
+   the PLL unlock: the display shows dots and the radio acts as if the dial
+   is turning. It's the signature R-5000 fault, the fix is well documented,
+   and commercial repair (e.g. Jahnke Electronics) exists. Ask if it's been
+   done — this is question one.
+2. **Keybounce.** Dried electrolytics cause keypad misreads and double
+   entries; recap kits are available.
+3. **The display.** Fluorescent display failures happen and **replacements
+   are scarce** — get a photo of every segment lit.
+4. **Heat.** The internal AC supply cooks the radio over decades; prefer
+   units run on the DCK-2 12 V kit or an external supply.
+5. **Recap and alignment history.** A full recap is common at this age;
+   priced-in if absent.
+
+Asks run $250 (rough) to $1,300 (pristine); clean working units typically
+change hands at **$450–700**, but that band is built from asking prices —
+check eBay sold listings before you pay. Working for you: excellent
+documentation and one of the most active repair scenes of any classic.
+
+## GopherTrunk alternative
+
+SDRs ended the tabletop-receiver category: a ~$200 HF SDR outruns the R-5000
+on raw numbers, adds the sync detection Kenwood never fitted, and draws a
+waterfall besides. Buying an R-5000 in 2026 is a deliberate choice of real
+knobs, a proper tuning feel, and 1980s build over performance-per-dollar —
+an honorable choice, made knowingly. The modern route is an
+[HF-capable SDR](/best-hf-sdr/) or an [RTL-SDR](/reference/rtl-sdr/) in
+direct-sampling mode; GopherTrunk itself stays in its VHF/UHF scanner lane —
+the same listen-first philosophy, free.
+
+## Who it's for
+
+- **Buy the R-5000** if you want a first serious classic with excellent SSB
+  and a huge knowledge base, and you'll insist on dot-fix/recap history (or
+  enjoy doing the work yourself).
+  <a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=kenwood+r-5000" rel="nofollow noopener">Find on eBay &rarr;</a>
+- **Buy the [Icom IC-R75](/reference/icom-ic-r75/)** instead for similar
+  money with modern-era reliability, or stretch to the
+  [Drake R8B](/reference/drake-r8b/) if sync AM and broadcast audio matter.
+- **Want portable-classic instead of tabletop?** The
+  [Sony ICF-2010](/reference/sony-icf-2010/) is the gateway classic. Full
+  rankings: [best desktop shortwave receivers](/best-desktop-shortwave-receivers/).
+
+## Sources
+
+[^universal]: [Kenwood R-5000 — Universal Radio archive](https://www.universal-radio.com/catalog/commrxvr/r5000.html) — specifications: coverage, modes, YK filter options, VC-20 converter, memories, power arrangements, original pricing.
+[^mwcircle]: [Receiver review: Kenwood R-5000 — Medium Wave Circle](https://mwcircle.org/legacy-receiver-reviews/receiver-review-kenwood-r-5000/) — performance verdict, standing among the classics, known aging faults including the PLL dot problem.

--- a/docs/reference/lowe-hf-150.md
+++ b/docs/reference/lowe-hf-150.md
@@ -117,7 +117,10 @@ recommendation:[^universal]
 3. **Sync lock in both modes** — verify selectable and double sideband both
    lock.
 4. **What's in the box.** The SP-150 speaker, PR-150 preselector, and keypad
-   drive the price; get the inventory in writing.
+   drive the price; get the inventory in writing. A complete station with
+   speaker and preselector is a different purchase — and a different
+   price — from a bare radio, and the late-1997 Europa variant carries its
+   own following.
 
 Price honestly: typical asks run **$250–450**, one new-old-stock example
 asked ~$750 — but the data is thin, supply is mostly UK (radioworld.co.uk
@@ -125,6 +128,12 @@ and similar dealers), and US listings are sparse. **Check eBay sold listings
 and be patient**; the right unit may take months to surface. Serviceability
 is good: a simple, well-understood discrete design, though Lowe itself no
 longer services them.
+
+**Used-market viability:** mechanically the safest classic here — the
+owner-survey reliability record is near-spotless and the discrete design is
+easy to service — but commercially the thinnest after the AR7030. US supply
+is sparse and UK dealers set the tone, so shipping, patience, and a saved
+eBay search are part of the purchase.
 
 ## GopherTrunk alternative
 

--- a/docs/reference/lowe-hf-150.md
+++ b/docs/reference/lowe-hf-150.md
@@ -1,0 +1,156 @@
+---
+slug: lowe-hf-150
+title: Lowe HF-150
+entry_type: hardware
+category: shortwave-radios
+description: "The Lowe HF-150 is the British cult-classic compact tabletop shortwave receiver — superb natural audio, dual-mode synchronous AM, two-knob simplicity in an extruded aluminum case — used-market only at roughly $250–450, with thin, UK-skewed supply."
+keywords: Lowe HF-150, HF-150 review, HF-150 for sale, Lowe Electronics receiver, compact shortwave receiver, British shortwave receiver, HF-150 sync, classic tabletop receiver, used shortwave receiver, is shortwave radio still worth it
+aka: [HF-150, HF150, Lowe HF-150 Europa]
+autolink: true
+affiliate: true
+product:
+  name: "Lowe HF-150"
+  brand: Lowe
+  category: Desktop shortwave receiver (classic)
+  seller: eBay
+  itemCondition: used
+  lowPrice: "250"
+  highPrice: "450"
+  url: "https://www.ebay.com/sch/i.html?_nkw=lowe+hf-150"
+infobox:
+  - { label: Type, value: "Classic compact tabletop shortwave receiver" }
+  - { label: Bands, value: "30 kHz–30 MHz" }
+  - { label: SSB / Sync, value: "SSB; dual-mode synchronous AM (selectable/double sideband)" }
+  - { label: Power, value: "Internal batteries or AC" }
+  - { label: License, value: "None — receiver" }
+  - { label: Price, value: "around $250–450 used (thin, UK-skewed market)" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.ebay.com/sch/i.html?_nkw=lowe+hf-150\" rel=\"nofollow noopener\">Find on eBay &rarr;</a>" }
+see_also: [aor-ar7030, sony-icf-2010, drake-r8b, kenwood-r-5000, single-sideband, rtl-sdr]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "Best desktop shortwave receivers", url: /best-desktop-shortwave-receivers/ }
+cite_urls:
+  - https://mwcircle.org/legacy-receiver-reviews/receiver-review-lowe-hf-150/
+  - https://www.radiomuseum.org/r/lowe_hf_150hf15.html
+  - https://www.universal-radio.com/catalog/commrxvr/0150.html
+  - https://swling.com/blog/2025/01/a-timeless-receiver-going-old-school-with-the-lowe-hf-150/
+faq:
+  - q: "Is the Lowe HF-150 still a good receiver?"
+    a: "Yes — SWLing Post ran a 'timeless receiver' retrospective on it as recently as 2025, and owner surveys report near-zero repair incidence. Its combination of natural audio, dual-mode sync AM, and two-knob simplicity in a small aluminum case is why it's remembered as 'the little receiver that embarrassed big ones'."
+  - q: "How much does a used HF-150 cost?"
+    a: "Roughly $250–450 in typical used condition, with accessories (SP-150 speaker, PR-150 preselector, keypad) carrying their own premiums and one new-old-stock example asking around $750. Honest caveat: the market is thin and UK-skewed — US listings are sparse — so verify against eBay sold listings before paying."
+  - q: "What is the HF-150's known fault?"
+    a: "Battery-box corrosion — the known killer. Running on AC with alkaline cells left fitted corrodes the twin battery boxes. Always inspect (or get photos of) both compartments before buying. Beyond that, owner-reported failures are remarkably rare for a 1990s radio."
+  - q: "Does the HF-150 have a keypad?"
+    a: "Not as shipped — direct frequency entry came from an optional accessory keypad. Quirk worth knowing: keypad entry tunes slightly low, so you nudge the knob a touch to zero-beat. Stock operation is two knobs and a handful of buttons, which is precisely its charm."
+  - q: "Do I need a license to use a Lowe HF-150?"
+    a: "No — listening is license-free everywhere in the US, with no FCC paperwork of any kind, ever."
+---
+**The Lowe HF-150** is the British cult classic: a compact 30 kHz–30 MHz
+tabletop (1991/92–1999) in an extruded anodized-aluminum case, famous for
+superb natural audio, **dual-mode synchronous AM**, and a two-knob interface
+with nothing to configure — "the little receiver that embarrassed big
+ones".[^mwcircle] Lowe Electronics still exists but left radio manufacturing
+long ago; the used market — eBay, UK second-hand dealers, SWL classifieds —
+is where the HF-150 lives, at roughly **$250–450**.
+
+<a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=lowe+hf-150" rel="nofollow noopener">Find on eBay &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The compact classic: audio, sync, simplicity, build — and near-zero repair
+incidence in owner surveys.** 30 kHz–30 MHz, AM/SSB, dual-mode sync
+(selectable or double sideband), battery or AC. **No notch, no PBT, minimal
+filtering** — it wins by sounding wonderful, not by carving up pileups.
+**Used ~$250–450, but the market is thin and UK-skewed** — verify sold
+listings. **The one killer fault to check: battery-box corrosion.** **No
+license to listen — ever.** Where it ranks:
+[best desktop shortwave receivers](/best-desktop-shortwave-receivers/).
+</div>
+
+## Overview
+
+Most classic tabletops compete on feature count. The HF-150 competed on
+restraint: two knobs, a small display, a solid extruded-aluminum shell that
+fits a bookshelf, and inside it a receiver whose **audio quality and sync
+detection out-listened radios twice its size and price**.[^mwcircle] The
+sync detector runs in two modes — selectable sideband or double sideband —
+and the whole radio runs on internal batteries or AC, making it the rare
+classic tabletop you can carry to the garden. SWLing Post was still
+celebrating it as a "timeless receiver" in 2025, and owner surveys report
+almost no failures — extraordinary for 30-year-old gear.[^swling]
+
+Know what you're not getting: no notch, no passband tuning, minimal
+filtering, no keypad as shipped (an optional accessory added one — and it
+tunes slightly low, so nudge the knob to zero-beat). On a big antenna it can
+overload without the matching PR-150 preselector. This is a listener's
+radio, not a DX-contest weapon — pair it with realistic expectations about
+2026's [shortwave bands](/reference/shortwave-broadcast/), where the major
+Western broadcasters are gone and what remains (international broadcasters,
+time signals, utility traffic, ham [SSB](/reference/single-sideband/),
+pirates) is quieter than the HF-150's launch era. And as ever: **a $20 wire
+antenna out a window does more for reception than a $200 radio upgrade.**
+
+**Listening note:** receiving is license-free everywhere in the US — no FCC
+anything, ever.
+
+## Bands, modes &amp; features
+
+- **Coverage:** 30 kHz–30 MHz.
+- **Modes:** [AM](/reference/amplitude-modulation/), SSB, and dual-mode sync
+  AM (selectable/double sideband).
+- **Interface:** two knobs, minimalist; optional keypad accessory.
+- **Build/power:** extruded anodized-aluminum case; internal batteries or AC.
+- **Accessories that matter:** SP-150 speaker, PR-150 preselector, keypad —
+  each carries its own used-market premium.
+
+## Buying used: what to check
+
+The shortest checklist of any classic here — which is itself the
+recommendation:[^universal]
+
+1. **Battery-box corrosion — the known killer.** Owners who ran AC with
+   alkalines still fitted corroded the twin battery boxes. Inspect both
+   compartments, or get clear photos, before anything else.
+2. **The keypad mounting**, if an optional/aftermarket keypad is fitted.
+3. **Sync lock in both modes** — verify selectable and double sideband both
+   lock.
+4. **What's in the box.** The SP-150 speaker, PR-150 preselector, and keypad
+   drive the price; get the inventory in writing.
+
+Price honestly: typical asks run **$250–450**, one new-old-stock example
+asked ~$750 — but the data is thin, supply is mostly UK (radioworld.co.uk
+and similar dealers), and US listings are sparse. **Check eBay sold listings
+and be patient**; the right unit may take months to surface. Serviceability
+is good: a simple, well-understood discrete design, though Lowe itself no
+longer services them.
+
+## GopherTrunk alternative
+
+SDRs are what ended the tabletop receiver as a product category — a ~$200 HF
+SDR beats any classic on raw performance and adds a waterfall the HF-150's
+little display never dreamed of. But the HF-150 is arguably the purest
+version of the counter-argument: you buy it *because* it's two knobs and a
+speaker and no computer anywhere. Make that choice knowingly. The modern
+path is an [HF-capable SDR](/best-hf-sdr/) or an
+[RTL-SDR](/reference/rtl-sdr/) in direct-sampling mode; GopherTrunk itself
+stays in its VHF/UHF scanner lane — the same listen-first philosophy, free.
+
+## Who it's for
+
+- **Buy the HF-150** if you want the best-sounding small classic — sync AM,
+  natural audio, zero menus — and you'll check those battery boxes first.
+  <a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=lowe+hf-150" rel="nofollow noopener">Find on eBay &rarr;</a>
+- **Buy the [AOR AR7030](/reference/aor-ar7030/)** instead for the same
+  designer's (John Thorpe) maximalist statement — the best classic front end,
+  at the cost of the ergonomics.
+- **Tighter budget?** The [Sony ICF-2010](/reference/sony-icf-2010/) gets
+  you benchmark sync for less. Full rankings:
+  [best desktop shortwave receivers](/best-desktop-shortwave-receivers/).
+
+## Sources
+
+[^mwcircle]: [Receiver review: Lowe HF-150 — Medium Wave Circle](https://mwcircle.org/legacy-receiver-reviews/receiver-review-lowe-hf-150/) — performance verdict: audio, dual-mode sync, minimalism, overload caveat; production history corroborated by [Radiomuseum](https://www.radiomuseum.org/r/lowe_hf_150hf15.html).
+[^universal]: [Lowe HF-150 — Universal Radio archive](https://www.universal-radio.com/catalog/commrxvr/0150.html) — specifications, accessories (SP-150, PR-150, keypad), power options, original pricing.
+[^swling]: [A timeless receiver: going old-school with the Lowe HF-150 — The SWLing Post (2025)](https://swling.com/blog/2025/01/a-timeless-receiver-going-old-school-with-the-lowe-hf-150/) — the 2025 retrospective and owner-reliability picture behind the "near-zero repair incidence" claim.

--- a/docs/reference/midland-er210.md
+++ b/docs/reference/midland-er210.md
@@ -1,0 +1,128 @@
+---
+slug: midland-er210
+title: Midland ER210
+entry_type: hardware
+category: shortwave-radios
+description: "The Midland ER210 is the compact glovebox version of the ER310 — AM/FM/NOAA weather with tone-alert standby, crank and solar charging, a 2000 mAh battery and 130-lumen flashlight for around $50–60. No SAME, no shortwave, no AA backup."
+keywords: Midland ER210 review, Midland ER210, ER210 vs ER310, compact emergency radio, hand crank weather radio, NOAA weather radio, emergency crank radio, glovebox emergency radio, solar crank radio, weather alert radio
+aka: [ER210, Midland ER-210]
+autolink: true
+affiliate: true
+product:
+  name: "Midland ER210"
+  brand: Midland
+  category: Emergency crank/solar weather radio (compact)
+  lowPrice: "50"
+  highPrice: "60"
+  url: https://www.amazon.com/dp/B015QICDD2?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: "Compact emergency crank/solar radio" }
+  - { label: Bands, value: "AM / FM / NOAA WX — no shortwave" }
+  - { label: Alerts, value: "1050 Hz tone alert standby — not SAME" }
+  - { label: Power, value: "Crank, solar, 2000 mAh Li-ion (replaceable), Micro-USB — no AA backup" }
+  - { label: License, value: "None — receiver" }
+  - { label: Price, value: "around $50–60" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B015QICDD2?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [midland-er310, sangean-mmr-88, fospower-a1, eton-scorpion-ii, runningsnail-md-092, midland-gxt1000vp4]
+related_reading:
+  - { title: "Best emergency radios", url: /best-emergency-radios/ }
+cite_urls:
+  - https://midlandusa.com/products/er210-compact-emergency-crank-wx-radio
+  - https://support.midlandusa.com/hc/en-us/articles/33019123031319
+faq:
+  - q: "What is the difference between the Midland ER210 and ER310?"
+    a: "Same platform, smaller package. The ER210 has a 2000 mAh battery to the ER310's 2600 mAh, and it drops the ER310's 6× AA backup entirely. You save roughly $15 and some bulk; you give up the longest runtime and the run-on-store-bought-batteries fallback."
+  - q: "Does the Midland ER210 have SAME alerting?"
+    a: "No. It has 1050 Hz tone-alert standby, which wakes for any watch or warning across the whole NOAA transmitter's coverage area — no county filtering, no event display. For reliable wake-you-up alerting, add a plugged-in SAME desktop radio."
+  - q: "Can the ER210 charge a phone?"
+    a: "From a charged battery, a partial top-up via USB-A. From the crank, effectively no — same platform behavior as the ER310, where testing could not substantiate crank-to-phone charging. Treat the crank as radio-and-flashlight power only."
+  - q: "How many weather channels does the ER210 scan?"
+    a: "Seven — NOAA Weather Radio uses 7 channels between 162.400 and 162.550 MHz. Some retail copy claims 10 weather channels; that is a marketing error, since only 7 NOAA channels exist."
+  - q: "Does the ER210 receive shortwave?"
+    a: "No — AM, FM, and NOAA weather only. In current production the Kaito KA500 is the crank radio that adds real shortwave; listening to any of it is license-free."
+---
+**The Midland ER210** is the ER310's compact sibling — the glovebox and
+bug-out-bag pick, with the same AM/FM/NOAA weather coverage, tone-alert standby,
+crank-and-solar charging, and a 130-lumen SOS flashlight in a smaller body for
+around $50–60.[^midland] The trade: a smaller 2000 mAh battery and **no AA
+backup**. Like every crank radio in its class it does **no SAME decoding** and
+has **no shortwave**.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B015QICDD2?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The ER310 for people short on space, minus its two best insurance policies.**
+Same tone-alert standby (not SAME — a plugged-in SAME desktop radio is still what
+actually wakes you), same honest crank reality: minutes of radio per minute of
+cranking, solar as a maintainer, crank-to-phone charging not worth counting on.
+**2000 mAh, replaceable, Micro-USB, no AA fallback. ~$50–60, price varies by
+retailer. Listening is license-free** — no FCC anything, ever. Ranked in
+[best emergency radios](/best-emergency-radios/).
+</div>
+
+## Overview
+
+Midland sells the ER210 as the compact half of its emergency line, and that's
+exactly how to shop it: everything that makes the
+[ER310](/reference/midland-er310/) the default pick — solid receiver, loud
+speaker for the size, clean controls, a backlit clock/alarm LCD, the 130-lumen
+Cree flashlight with SOS beacon — in a package that actually fits a glovebox or
+a day pack. The battery is a replaceable 2000 mAh Li-ion (Midland's spec; one
+Amazon listing says 2200 mAh) rated for roughly 25–32 hours of radio, charged
+via Micro-USB — not USB-C.
+
+What you give up versus the ER310 matters in exactly the scenario you're buying
+for: the **6× AA fallback is gone**, so when the internal cell is flat and the
+sun isn't out, the crank is your only option. For a bedside or kitchen-shelf
+radio we'd spend the extra ~$15; for a second radio that lives in the car, the
+ER210's size wins.
+
+## Alerting: tone alert, not SAME
+
+The ER210's Weather Alert mode is **1050 Hz tone-alert standby**: muted on a
+NOAA channel, it wakes when the National Weather Service transmits the attention
+tone ahead of *any* watch or warning in the transmitter's coverage area — which
+can span many counties and produce middle-of-the-night alarms for weather that
+will never reach you. It is **not SAME**: no county filtering, no event-type
+display. A $30 plugged-in SAME desktop radio remains the honest answer for
+being woken by the right warning; the ER210's job is the aftermath — staying
+informed once the power and cell networks are down, and moonlighting as a
+flashlight. One spec-sheet note: ignore retail copy claiming "10 weather
+channels" — NOAA Weather Radio uses 7, and the ER210 scans them all.[^manual]
+
+## Power reality
+
+Same platform truths as the ER310: the crank buys **minutes of radio per minute
+of cranking**, the solar panel is a *maintainer* that keeps a charged battery
+topped up rather than reviving a dead one, and crank-to-phone charging failed to
+register in hands-on testing of the platform. The USB-A output from a fully
+charged 2000 mAh cell gives a phone a modest top-up — smaller than the ER310's,
+and with no AA tier behind it. Keep it charged; that's the whole plan.
+
+## GopherTrunk alternative
+
+One honest line: an SDR needs a computer and power, and an emergency radio's
+whole point is working without either — so GopherTrunk doesn't replace an
+ER210. It complements one: before the storm, a
+[$30 RTL-SDR](/reference/rtl-sdr/) running free GopherTrunk monitors and records
+your local public-safety and utility channels, which tell you far more during an
+event than the forecast loop alone. Start with our
+[emergency scanner frequencies](/scanner-frequencies/) list to know what's worth
+programming; keep the ER210 as the no-infrastructure fallback in the same kit.
+
+## Who it's for
+
+- **Buy the ER210** as the compact kit radio — car, office drawer, bug-out bag —
+  or as the second radio beside a home-based ER310.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B015QICDD2?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [ER310](/reference/midland-er310/)** instead for home base: bigger
+  battery plus the AA fallback the ER210 lacks, for about $15 more.
+- **Tighter budget?** The [FosPower A1](/reference/fospower-a1/) runs ~$30 —
+  but has no alert standby at all. Full rankings and the SAME-vs-tone explainer:
+  [best emergency radios](/best-emergency-radios/).
+
+## Sources
+
+[^midland]: [Midland ER210 product page](https://midlandusa.com/products/er210-compact-emergency-crank-wx-radio) — Midland USA: bands, Weather Scan + Alert, crank/solar/USB charging, replaceable 2000 mAh battery, flashlight and clock features.
+[^manual]: [Midland ER210 owner's guide](https://support.midlandusa.com/hc/en-us/articles/33019123031319) — Midland support: full operating documentation, weather-channel scanning, and alert-mode behavior.

--- a/docs/reference/midland-er310.md
+++ b/docs/reference/midland-er310.md
@@ -1,0 +1,130 @@
+---
+slug: midland-er310
+title: Midland ER310
+entry_type: hardware
+category: shortwave-radios
+description: "The Midland ER310 is the default emergency crank radio — AM/FM/NOAA weather with tone-alert standby, a replaceable 2600 mAh battery, solar trickle, AA backup, and a 130-lumen flashlight, around $70. No SAME decoding and no shortwave."
+keywords: Midland ER310 review, Midland ER310, best emergency radio 2026, hand crank radio, crank weather radio, NOAA weather radio, emergency crank radio, solar emergency radio, ER310 vs ER210, weather alert radio, emergency radio with flashlight
+aka: [ER310, Midland ER-310]
+autolink: true
+affiliate: true
+product:
+  name: "Midland ER310"
+  brand: Midland
+  category: Emergency crank/solar weather radio
+  lowPrice: "60"
+  highPrice: "80"
+  url: https://www.amazon.com/dp/B015QIC1PW?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: "Emergency crank/solar radio" }
+  - { label: Bands, value: "AM / FM / 7 NOAA WX — no shortwave" }
+  - { label: Alerts, value: "1050 Hz tone alert standby — not SAME" }
+  - { label: Power, value: "Crank, solar, 2600 mAh Li-ion (replaceable), 6× AA backup, Micro-USB" }
+  - { label: License, value: "None — receiver" }
+  - { label: Price, value: around $70 }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B015QIC1PW?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [midland-er210, kaito-ka500, sangean-mmr-88, eton-frx3-plus, fospower-a1, midland-gxt1000vp4]
+related_reading:
+  - { title: "Best emergency radios", url: /best-emergency-radios/ }
+cite_urls:
+  - https://midlandusa.com/products/er310-portable-emergency-crank-weather-radio
+  - https://the-gadgeteer.com/2022/08/15/midland-er310-emergency-crank-weather-radio-review-4-ways-to-power-it-up/
+faq:
+  - q: "Does the Midland ER310 have SAME alerting?"
+    a: "No. The ER310 has 1050 Hz tone-alert standby: it wakes for any watch or warning anywhere in the NOAA transmitter's coverage area, which can span many counties. Only a dedicated SAME desktop radio (Midland's own WR120, for example) filters alerts to the counties you program."
+  - q: "How long does the Midland ER310 run on a full crank?"
+    a: "A hands-on review measured about one minute of cranking for roughly nine minutes of radio at modest volume. Cranking is a last resort — the 2600 mAh battery, good for around 32 hours of radio, is the real power source."
+  - q: "Can the ER310 charge my phone?"
+    a: "From a charged battery, partially — the USB-A output can give a phone a meaningful top-up. From crank power alone, treat it as no: a reviewer could not get two different phones to register charging from the crank at all."
+  - q: "Does the Midland ER310 receive shortwave?"
+    a: "No — AM, FM, and the 7 NOAA weather channels only. If you want shortwave in a crank radio, the Kaito KA500 is the cheapest current option, and the discontinued Eton FR500 and Grundig FR200 cover it used."
+  - q: "Is the ER310 waterproof?"
+    a: "Midland publishes no IP rating for it. Treat it as rain-tolerant at best, not waterproof — if you need a formal splash rating in this class, the Eton Scorpion II carries IPX4 and the Sangean MMR-88 IPX3."
+---
+**The Midland ER310** is the default emergency crank radio — the best-documented,
+most widely stocked unit in the class, with AM/FM and all 7 NOAA weather channels,
+tone-alert standby, a replaceable 2600 mAh battery, solar trickle, AA backup, and
+a 130-lumen flashlight, for around $70.[^midland] It does **not** decode
+[SAME](#alerting-what-the-er310-actually-does) alerts and it has **no shortwave** —
+know both before buying.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B015QIC1PW?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The best all-around crank radio, honestly framed.** Tone-alert standby, not
+SAME — a plugged-in $30 SAME desktop radio is still the thing that reliably wakes
+you for a tornado warning; the ER310's job is staying informed *after* the grid
+goes down. **Real numbers:** ~1 min crank ≈ ~9 min radio, solar is a maintainer
+not a charger, crank-to-phone charging is effectively useless.[^gadgeteer]
+**~$70. No shortwave. Listening is license-free** — no FCC anything, ever. It's
+our **best overall** pick in [best emergency radios](/best-emergency-radios/).
+</div>
+
+## Overview
+
+Midland's ER310 earned its default status the boring way: a bigger battery than
+most rivals (2600 mAh Li-ion, roughly 32 hours of radio, and — rare in this
+class — **replaceable**), a 6× AA fallback when every rechargeable option is
+exhausted, and a retail footprint (Midland direct, Best Buy, REI, Amazon) that
+means it's actually in stock when a hurricane is on the map. The 130-lumen Cree
+flashlight with an SOS beacon is genuinely useful; the ultrasonic dog whistle is
+marketing. Charging is Micro-USB — not USB-C; the newer ER310PRO sibling moved
+to USB-C and Bluetooth, but the base ER310 stays in the line.
+
+## Alerting: what the ER310 actually does
+
+The ER310's "Weather Alert" is **1050 Hz tone-alert standby**: it sits muted on a
+NOAA channel and wakes when the National Weather Service sends the attention tone
+before *any* watch or warning in the transmitter's whole footprint — which can
+mean 2 a.m. wake-ups for a flood warning 80 miles away. It is **not SAME**: it
+cannot filter by county or display the event type. For the actually-being-woken
+job, a plugged-in SAME desktop unit beats every crank radio made; the right
+household setup is one of those **plus** a crank radio, not instead of one. The
+ER310's auto-scan-to-strongest-channel feature at least makes setup foolproof.
+
+## Power &amp; the crank-radio reality check
+
+The Gadgeteer's hands-on testing put honest numbers on the marketing:[^gadgeteer]
+
+- **Crank:** about **1 minute of cranking ≈ 9 minutes of radio** at modest
+  volume. Fine for news; miserable as a primary power plan.
+- **Solar:** a *maintainer*. Midland's own guidance is that the panel is not
+  intended to charge the battery from a low or discharged state — it keeps a
+  charged radio topped up on a windowsill.
+- **Phone charging:** from the charged 2600 mAh cell, a real partial top-up via
+  USB-A. From crank power, the reviewer could not get two different phones to
+  register charging *at all*. Ignore every crank-charges-your-phone claim in
+  this category.
+
+The practical drill: keep it charged via Micro-USB, keep six AAs in the kit, and
+treat crank and solar as the deep-reserve tier they are.
+
+## GopherTrunk alternative
+
+An SDR needs a computer and wall power — the ER310's entire reason to exist is
+working without either, so free software isn't a substitute here. Where
+[GopherTrunk](/) and a [$30 RTL-SDR](/reference/rtl-sdr/) *do* fit emergency
+preparedness is before and after the blackout: scanning your local public-safety,
+utility, and [NOAA weather](/scanner-frequencies/) frequencies so you know what's
+actually happening beyond the forecast loop. Our
+[scanner frequencies guide](/scanner-frequencies/) lists what to monitor in an
+emergency; the ER310 is the battery-independent fallback that sits beside that
+setup, not instead of it.
+
+## Who it's for
+
+- **Buy the ER310** if you want one dependable crank radio for the kit and would
+  rather pay ~$15 extra for the bigger replaceable battery and AA fallback.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B015QIC1PW?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [ER210](/reference/midland-er210/)** instead for the glovebox — same
+  platform, smaller and cheaper, no AA backup.
+- **Buy the [Kaito KA500](/reference/kaito-ka500/)** if you want shortwave in a
+  crank radio, or the [Sangean MMR-88](/reference/sangean-mmr-88/) for the best
+  receiver quality in the class. Full rankings:
+  [best emergency radios](/best-emergency-radios/).
+
+## Sources
+
+[^midland]: [Midland ER310 product page](https://midlandusa.com/products/er310-portable-emergency-crank-weather-radio) — Midland USA: bands, tone-alert and Weather Scan features, 2600 mAh replaceable battery, AA backup, solar and crank charging, 130-lumen flashlight.
+[^gadgeteer]: [Midland ER310 review — The Gadgeteer](https://the-gadgeteer.com/2022/08/15/midland-er310-emergency-crank-weather-radio-review-4-ways-to-power-it-up/) — measured crank runtime (~1 min crank ≈ 9 min radio), solar-as-maintainer behavior, and the failed crank-to-phone charging test.

--- a/docs/reference/midland-er310.md
+++ b/docs/reference/midland-er310.md
@@ -104,7 +104,7 @@ treat crank and solar as the deep-reserve tier they are.
 
 An SDR needs a computer and wall power — the ER310's entire reason to exist is
 working without either, so free software isn't a substitute here. Where
-[GopherTrunk](/) and a [$30 RTL-SDR](/reference/rtl-sdr/) *do* fit emergency
+GopherTrunk and a [$30 RTL-SDR](/reference/rtl-sdr/) *do* fit emergency
 preparedness is before and after the blackout: scanning your local public-safety,
 utility, and [NOAA weather](/scanner-frequencies/) frequencies so you know what's
 actually happening beyond the forecast loop. Our

--- a/docs/reference/qodosen-dx-286.md
+++ b/docs/reference/qodosen-dx-286.md
@@ -1,0 +1,142 @@
+---
+slug: qodosen-dx-286
+title: Qodosen DX-286
+entry_type: hardware
+category: shortwave-radios
+description: "The Qodosen DX-286 is the sensitivity giant-killer of budget shortwave — an NXP TEF6686 car-radio DSP that pulls in on the whip what other portables need a wire for. Broadcast only: it has no SSB, no air band, no weather."
+keywords: Qodosen DX-286 review, TEF6686 radio, most sensitive shortwave portable, Qodosen DX-286 vs XHDATA D-808, shortwave radio without SSB, FM DX radio, MW DX portable, best budget shortwave radio 2026, DX-286 antenna jack, longwave receiver
+aka: [DX-286, Qodosen DX286]
+autolink: true
+affiliate: true
+product:
+  name: "Qodosen DX-286"
+  brand: Qodosen
+  category: Portable shortwave receiver (compact)
+  lowPrice: "80"
+  highPrice: "150"
+  url: https://www.amazon.com/dp/B0D3V3H356?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: "Compact receiver (NXP TEF6686 car-radio DSP)" }
+  - { label: Bands, value: "LW / MW / SW (broadcast AM only) / FM (RDS/RBDS)" }
+  - { label: SSB, value: "No — broadcast AM only; no air band, no weather band" }
+  - { label: Power, value: "18650 Li-ion" }
+  - { label: License, value: "None — receiver" }
+  - { label: Price, value: "around $80–150 (volatile small-vendor pricing)" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B0D3V3H356?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [xhdata-d-808, tecsun-pl-330, tecsun-pl-880, shortwave-broadcast, broadcast-am, rtl-sdr]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "Best shortwave radios", url: /best-shortwave-radios/ }
+cite_urls:
+  - https://swling.com/blog/2025/01/qodosen-dx-286-first-impressions/
+  - https://radiodiscussions.com/threads/qodosen-dx-286-review-and-performance-comparisons.773716/
+  - https://www.eham.net/reviews/view-product/15897
+faq:
+  - q: "Does the Qodosen DX-286 have SSB?"
+    a: "No — and this is the single most important fact about it. The DX-286 receives broadcast AM only on shortwave: no SSB, no air band, no weather band. Ham nets, utility traffic, and marine/aero HF are out of reach. If SSB matters, buy a Tecsun PL-330 or XHDATA D-808 instead."
+  - q: "Why is the DX-286 so sensitive?"
+    a: "It's built on the NXP TEF6686, a car-radio DSP tuner chip designed to pull weak stations onto a moving whip antenna. In a portable it's a giant-killer: community comparisons repeatedly show it hearing on its whip what bigger radios need a wire antenna for, and it's a superb FM and MW DX machine."
+  - q: "Is the Qodosen DX-286 good for FM and MW DX?"
+    a: "Excellent — arguably its best use case. FM with RDS/RBDS decoding, unusually deep RF controls (attenuator, LNA switch, ferrite/whip switching for LW/MW), and an SNR/RSSI display make it a serious band-scanning tool at a budget price."
+  - q: "What are the DX-286's downsides?"
+    a: "No SSB is the dealbreaker axis; beyond that, a quirky menu-driven UI with a real learning curve, a small speaker, volatile small-vendor pricing (~$80–150 depending on seller and promo), and a niche brand with thinner warranty and support than Tecsun."
+  - q: "Do I need a license to listen to shortwave?"
+    a: "No — listening is license-free everywhere in the US, no FCC anything, ever. And even with the DX-286's famous whip sensitivity, the old rule holds: $20 of wire out a window improves shortwave reception more than a $200 radio upgrade — this radio just needs the wire less often."
+---
+**The Qodosen DX-286** is the sensitivity story of the budget class: a
+compact portable built around the NXP **TEF6686 car-radio DSP** — silicon
+designed to drag weak stations onto a moving car whip — that repeatedly
+beats much bigger radios on weak-signal shortwave and ranks among the best
+FM/MW DX machines at any price near it.[^swling] Now the fact that decides
+whether you should buy it: **it has no SSB.** No air band, no weather band
+either — this is a *broadcast* receiver, brilliantly executed.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0D3V3H356?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The whip-antenna giant-killer — for broadcast listening only.** The TEF6686
+front end pulls in on the whip what rivals need a wire for; superb FM/MW DX;
+unusually deep RF controls (attenuator, LNA, antenna switching) for the
+class. **No SSB, no airband, no weather** — ham and utility HF are out of
+reach. ~$80–150, volatile small-vendor pricing. **License-free listening.**
+Where it ranks: [best shortwave radios](/best-shortwave-radios/).
+</div>
+
+## Overview
+
+Released mid-2024, the DX-286 is what happens when a small vendor builds a
+portable around automotive tuner silicon instead of the usual SiLabs
+portable chips. The TEF6686 is the whole story: community comparisons keep
+producing the same verdict — it "pulls in on the whip what other budget
+radios need a wire antenna for," embarrassing physically larger sets on
+weak-signal shortwave and turning in FM and MW DX performance that made it
+an instant cult radio.[^radiodisc]
+
+The supporting cast is unusually serious for the price: an **external
+antenna jack**, an **attenuator**, an **LNA (AMP) switch**, and
+**ferrite/whip antenna switching for LW and MW** — RF plumbing you normally
+see on desktop receivers — plus an SNR/RSSI readout, RDS/RBDS on FM, and
+1000 memories across 100 pages. Owners' costs: a quirky, menu-driven UI with
+a genuine learning curve, a small speaker, and the realities of a niche
+brand — a thinner supply chain than Tecsun's (stock and price fluctuate,
+roughly $80–150 by seller and promo) and warranty support you shouldn't
+count on.
+
+And the axis that decides the purchase: **no SSB**. On shortwave the DX-286
+receives broadcast AM only. The sensitivity is real, but it cannot tune ham
+nets, utility/aero/marine HF, or anything else on
+[single sideband](/reference/single-sideband/) — the non-broadcast traffic
+that increasingly carries the hobby as the 2026 broadcast schedule thins
+(VOA's shortwave was gutted in 2025; the BBC left North America long ago).
+If your listening is [broadcast](/reference/broadcast-am/) stations, FM/MW
+DX, and band-scanning, none of that matters and this radio is a bargain. If
+you'll ever want the hams, buy a [PL-330](/reference/tecsun-pl-330/) or
+[D-808](/reference/xhdata-d-808/) instead.
+
+The category constants: **listening is license-free everywhere in the US —
+no FCC anything, ever.** And even the whip-sensitivity champion obeys the
+antenna rule — **$20 of wire out a window still improves shortwave reception
+more than a $200 radio upgrade**; the DX-286 just needs it less often, and
+its attenuator means the wire won't overload it when you do.
+
+## Bands, modes &amp; features
+
+- **Coverage:** LW, MW, SW (broadcast AM only), FM with RDS/RBDS.
+- **SSB: none.** No air band, no weather band, no sync.
+- **Receiver:** NXP TEF6686 car-radio DSP — the class sensitivity leader.
+- **RF controls:** external antenna jack, attenuator, LNA (AMP) switch,
+  ferrite/whip switching for LW/MW, SNR/RSSI display.
+- **Memories:** 1000 in 100 pages.
+- **Power:** 18650 Li-ion.
+- No Bluetooth, no recording.
+
+## GopherTrunk alternative
+
+Shortwave is HF AM/SSB — not GopherTrunk's trunking/digital domain, and
+GopherTrunk does not decode it. The computer-side answer overlaps the
+DX-286's one gap neatly: an HF-capable SDR ([best HF SDR](/best-hf-sdr/)) or
+a ~$30 [RTL-SDR](/reference/rtl-sdr/) in direct-sampling mode demodulates
+SSB in software *and* draws a [waterfall](/reference/waterfall-display/) of
+the whole band — so a DX-286 for the porch and an SDR for the desk is a
+genuinely complementary pair. GopherTrunk itself stays in its VHF/UHF
+scanner lane — same listen-first philosophy, free.
+
+## Who it's for
+
+- **Buy the DX-286** if you're a broadcast listener or FM/MW/SW DXer chasing
+  maximum sensitivity per dollar and you know — eyes open — that SSB isn't
+  on the menu.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B0D3V3H356?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [XHDATA D-808](/reference/xhdata-d-808/)** instead for SSB plus
+  airband at the same money, or the [Tecsun PL-330](/reference/tecsun-pl-330/)
+  for the cheapest 10 Hz SSB tuning.
+- **Skip it** if ham nets and utility HF are the point — no firmware will
+  ever add SSB to this chip. Full rankings:
+  [best shortwave radios](/best-shortwave-radios/).
+
+## Sources
+
+[^swling]: [Qodosen DX-286 first impressions — SWLing Post](https://swling.com/blog/2025/01/qodosen-dx-286-first-impressions/) — the TEF6686 architecture, RF-control feature set, release timeline, and weak-signal performance.
+[^radiodisc]: [Qodosen DX-286 review and performance comparisons — RadioDiscussions](https://radiodiscussions.com/threads/qodosen-dx-286-review-and-performance-comparisons.773716/) — head-to-head sensitivity comparisons against larger portables; owner consensus corroborated by [eHam reviews](https://www.eham.net/reviews/view-product/15897).

--- a/docs/reference/runningsnail-md-092.md
+++ b/docs/reference/runningsnail-md-092.md
@@ -1,0 +1,128 @@
+---
+slug: runningsnail-md-092
+title: RunningSnail MD-092
+entry_type: hardware
+category: shortwave-radios
+description: "The RunningSnail MD-092 is the high-capacity budget emergency radio — AM/FM/NOAA weather with a 4000 mAh battery (the biggest in its class), crank, solar, and a motion-sensor reading lamp for around $30–40. Tone alert on the P variant; no SAME, no shortwave."
+keywords: RunningSnail MD-092 review, RunningSnail emergency radio, MD-092, budget emergency radio, 4000mAh emergency radio, hand crank weather radio, NOAA weather radio, crank radio power bank, solar emergency radio, cheap crank radio
+aka: [MD-092, MD-092P, RunningSnail MD092]
+autolink: true
+affiliate: true
+product:
+  name: "RunningSnail MD-092"
+  brand: RunningSnail
+  category: Emergency crank/solar weather radio (budget, high capacity)
+  lowPrice: "30"
+  highPrice: "40"
+  url: "https://www.amazon.com/s?k=RunningSnail+MD-092&tag=gophertrunk-20"
+infobox:
+  - { label: Type, value: "Budget emergency crank/solar radio (high capacity)" }
+  - { label: Bands, value: "AM / FM / NOAA WX — no shortwave" }
+  - { label: Alerts, value: "Tone alert standby on MD-092P variant — not SAME" }
+  - { label: Power, value: "Crank, 1 W solar, 4000 mAh Li-ion, USB (Micro-USB on most stock)" }
+  - { label: License, value: "None — receiver" }
+  - { label: Price, value: "around $30–40" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/s?k=RunningSnail+MD-092&tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [fospower-a1, midland-er210, midland-er310, sangean-mmr-88, eton-scorpion-ii, kaito-ka500]
+related_reading:
+  - { title: "Best emergency radios", url: /best-emergency-radios/ }
+cite_urls:
+  - https://www.manualslib.com/manual/4011395/Runningsnail-Md-092p.html
+faq:
+  - q: "Does the RunningSnail MD-092 have weather alerts?"
+    a: "The MD-092P variant's manual documents an 'AL' weather-alert standby button — 1050 Hz tone alert, not SAME. Alert standby on the base MD-092 is not confirmed, so check the specific listing. No version filters alerts by county; only a SAME desktop radio does that."
+  - q: "How big is the MD-092's battery?"
+    a: "4000 mAh (14,800 mWh) — the largest in the current budget crank-radio field, and roughly double the FosPower A1 or Midland ER210. That makes it the most realistic phone top-up of the budget group, though still only a partial charge."
+  - q: "How long does the MD-092 run per minute of cranking?"
+    a: "Family testing of the same platform measured about 3 minutes of full-volume radio per cranking stint at roughly 120 rpm — a ratio near 1:3, well below marketing claims. Charge it via USB and treat the crank as a last resort."
+  - q: "Does the RunningSnail MD-092 receive shortwave?"
+    a: "No — AM, FM, and NOAA weather only. RunningSnail's newer Bluetooth model adds shortwave, but that's a different radio. In this roster the Kaito KA500 is the budget crank radio with real shortwave."
+  - q: "Is the MD-092 reliable?"
+    a: "Mostly — it has an enormous install base and strong Amazon reviews, but the recurring budget-brand complaints are QC variance: dead-on-arrival units and inconsistent crank feel. Buy from a returnable listing and test everything on day one."
+---
+**The RunningSnail MD-092** is the budget crank radio for people who count
+milliamp-hours: AM/FM/NOAA weather plus a **4000 mAh** battery — the biggest in
+the current class and double what the similar-priced FosPower carries — with
+crank, a 1 W solar panel, a 3-mode flashlight, and a clever motion-sensor
+reading lamp for around $30–40.[^manual] No shortwave, and alerting is tone
+standby on the MD-092P variant — **not SAME**.
+
+<a class="btn btn--buy" href="https://www.amazon.com/s?k=RunningSnail+MD-092&tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The budget power-bank play.** 4000 mAh (14,800 mWh) is the most realistic
+phone top-up in the budget group and days of radio listening. **Measured crank
+reality on this platform: ~3 minutes of full-volume radio per stint — about
+1:3**, well under the marketing; solar is trickle-only. **Alert standby is
+confirmed on the MD-092P variant only** (1050 Hz tone — not SAME; a plugged-in
+SAME desktop radio still owns the wake-you-up job). **QC variance is the tax**
+on budget brands — test it on arrival. **~$30–40. Listening is license-free** —
+no FCC anything, ever. Ranked in [best emergency radios](/best-emergency-radios/).
+</div>
+
+## Overview
+
+RunningSnail claims an install base in the tens of millions, and the MD-092 is
+the current core of the line: a soap-bar-sized unit whose spec sheet reads like
+the FosPower A1's with the battery doubled. The 4000 mAh cell is the honest
+headline — enough for days of intermittent listening and the only battery in
+the budget group that makes USB-A phone charging more than a gesture (still a
+partial charge, not a full one). The 1 W flashlight has three modes, the 4-LED
+reading lamp has a genuinely useful motion-sensor trigger for blackout
+hallways, and an SOS alarm rounds out the kit. Listings claim IPX3 splash
+resistance, unverified on any spec sheet; most stock still charges via
+Micro-USB, with USB-C only on newer models — don't assume it.
+
+Two buying notes: the brand has also sold under "DaringSnail" on some listings,
+and Amazon listings for this radio churn — which is why our button links a
+search rather than a listing that may not name the model.
+
+## Alerting: check your variant
+
+The **MD-092P** manual documents an "AL" weather-alert standby button — park it
+muted on a NOAA channel and it wakes for the 1050 Hz attention tone.[^manual]
+Alert standby on the base MD-092 is **not confirmed**, so check the specific
+listing before relying on it. Either way it is **not SAME**: the tone fires for
+any watch or warning across the whole transmitter's multi-county footprint,
+with no filtering and no event display. Same hierarchy as everywhere in this
+class: a $30 plugged-in SAME desktop radio is what reliably wakes you; the
+MD-092's job is after the grid drops — listening, light, and stored power.
+
+## Power reality: the honest 1:3
+
+Family testing of this platform put cranking at roughly **120 rpm for about
+3 minutes of full-volume radio per stint** — near a 1:3 ratio and well below
+marketing claims. The 1 W solar panel is a trickle maintainer. The plan that
+works: charge the 4000 mAh cell via USB before storm season, and treat crank
+and solar as the reserve tier. The recurring budget-brand caveat applies —
+Amazon reviews are strong in aggregate, but dead-on-arrival units and
+inconsistent crank feel show up often enough that you should test the crank,
+both lights, all bands, and the USB output the day it arrives.
+
+## GopherTrunk alternative
+
+An SDR needs a computer and power — the MD-092's reason to exist is working
+without either, so GopherTrunk doesn't replace it. For the same $30 you'd
+spend here, a [RTL-SDR](/reference/rtl-sdr/) running free GopherTrunk covers
+the other half of preparedness: monitoring and recording your local
+public-safety and utility channels while the infrastructure is up — the
+traffic that tells you what's actually happening. Our
+[emergency scanner frequencies](/scanner-frequencies/) guide lists what to
+program; the MD-092 is the no-power fallback in the same kit.
+
+## Who it's for
+
+- **Buy the MD-092** if your budget pick should double as the kit's biggest
+  battery — and prefer a listing that says MD-092P if alert standby matters.
+  <a class="btn btn--buy" href="https://www.amazon.com/s?k=RunningSnail+MD-092&tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [FosPower A1](/reference/fospower-a1/)** instead for the lifetime
+  warranty at the same price — accepting no alert mode and half the battery.
+- **Spend up** to the [Midland ER310](/reference/midland-er310/) for the
+  name-brand platform with AA fallback, or the
+  [Sangean MMR-88](/reference/sangean-mmr-88/) for the best receiver in the
+  class. Full rankings: [best emergency radios](/best-emergency-radios/).
+
+## Sources
+
+[^manual]: [RunningSnail MD-092P manual — ManualsLib](https://www.manualslib.com/manual/4011395/Runningsnail-Md-092p.html) — official user manual: band coverage, 4000 mAh battery, crank/solar/USB power, lighting features, and the "AL" weather-alert standby function on the P variant.

--- a/docs/reference/sangean-ats-909x2.md
+++ b/docs/reference/sangean-ats-909x2.md
@@ -1,0 +1,141 @@
+---
+slug: sangean-ats-909x2
+title: Sangean ATS-909X2
+entry_type: hardware
+category: shortwave-radios
+description: "The Sangean ATS-909X2 is the big-radio alternative to Tecsun's flagships — LW/MW/SW/FM with RDS plus a real VHF air band with squelch, SSB, 1674 memories, and the best FM section in a portable, around $289–350."
+keywords: Sangean ATS-909X2 review, ATS-909X2 vs PL-990, best shortwave radio with air band, Sangean shortwave radio, ATS-909X2 whip sensitivity, portable shortwave radio 2026, shortwave radio with RDS, SSB portable receiver, ATS-909X2 price, worldband radio
+aka: [ATS-909X2, Sangean 909X2]
+autolink: true
+affiliate: true
+product:
+  name: "Sangean ATS-909X2"
+  brand: Sangean
+  category: Portable shortwave receiver
+  lowPrice: "289"
+  highPrice: "350"
+  url: https://www.amazon.com/dp/B08MSXX6LH?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: "Portable shortwave receiver (DSP, flagship class)" }
+  - { label: Bands, value: "LW / MW / SW / FM (RDS) / VHF Air with squelch" }
+  - { label: SSB, value: "Yes — USB/LSB with fine steps; no sync detector" }
+  - { label: Power, value: "4×AA with smart in-radio NiMH charging" }
+  - { label: License, value: "None — receiver" }
+  - { label: Price, value: "around $289–350" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B08MSXX6LH?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [tecsun-pl-990, tecsun-pl-880, xhdata-d-808, eton-elite-executive, shortwave-broadcast, single-sideband]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "Best shortwave radios", url: /best-shortwave-radios/ }
+cite_urls:
+  - https://us.sangean.com/product/ats-909x2-graphite
+  - https://www.qsl.net/n9ewo/ats909x2.html
+  - https://radiojayallen.com/sangean-ats-909x2-am-lw-fm-sw-air-radio/
+faq:
+  - q: "Is the Sangean ATS-909X2 better than the Tecsun PL-990?"
+    a: "Different strengths. The 909X2 has arguably the best FM section in any portable, very good MW, RDS, a real air band with squelch, and superb ergonomics. The PL-990 answers with triple-conversion SW, better battery economics, and Bluetooth/microSD. For shortwave-first listeners we rank the PL-990 ahead; for FM/MW DX and airband, the Sangean."
+  - q: "Is the ATS-909X2 deaf on the whip antenna?"
+    a: "That reputation belongs to the older ATS-909X. Independent reviews (N9EWO, RadioJayAllen) judge the X2's whip sensitivity on shortwave competitive with other portables — the debate is largely resolved, though the radio still rewards an external antenna, as every portable does."
+  - q: "Does the ATS-909X2 have SSB?"
+    a: "Yes — USB and LSB with fine tuning steps, good enough for ham nets and utility listening. There is no synchronous detector."
+  - q: "How long do batteries last in the ATS-909X2?"
+    a: "It runs on four AA cells with smart in-radio NiMH charging, and battery draw is noticeably heavier than the Tecsun flagships — plan on rechargeables or the mains adapter for serious use. It's the biggest and heaviest radio in our portable roster at about 1 lb 13 oz with batteries."
+  - q: "Do I need a license to listen to shortwave or air band?"
+    a: "No. Listening is license-free everywhere in the US — no FCC anything, ever — and that covers the air band too. Only transmitting requires a license."
+---
+**The Sangean ATS-909X2** is the one flagship portable that isn't a Tecsun —
+and it wins categories the Tecsuns don't enter: arguably class-leading FM with
+RDS, very good MW, a genuine **VHF air band with squelch**, a big crisp
+display, and the best ergonomics in the segment.[^sangean] Add
+[SSB](/reference/single-sideband/), 1674 memories, and 4×AA power with smart
+charging, and it's a complete answer at around **$289–350**.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B08MSXX6LH?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The top of the portable market, non-Tecsun division.** Class-leading FM
+(RDS), very good MW, real airband with squelch, SSB, 1674 memories, superb
+controls. **The old "deaf on the whip" complaint is largely fixed** in the X2
+per independent measurement. Heavier battery draw than Tecsuns; ~1 lb 13 oz.
+**~$289–350.** **License-free listening**; $20 of wire out a window is still
+the best upgrade. Where it ranks:
+[best shortwave radios](/best-shortwave-radios/).
+</div>
+
+## Overview
+
+Sangean's flagship line has always been the "serious tool" alternative to
+Tecsun's hobbyist charm, and the X2 is the most complete one yet. The display
+is the best in the class — big, informative, with 42 world time zones — the
+buttons and dual-speed tuning knob feel like lab equipment, and the 1674
+memories are organized into three banks that make sense. FM performance is the
+sleeper headline: with RDS station data and sensitivity reviewers call
+arguably class-leading, it doubles as a first-rate FM DX machine. The **air
+band is real, not a checkbox**: it has squelch, which makes unattended
+airport-frequency monitoring actually pleasant — none of the Tecsun flagships
+cover air at all.[^rja]
+
+The elephant in every 909-series review is **whip sensitivity on shortwave**.
+The older ATS-909X was widely called "deaf on the whip," and the criticism
+still gets repeated reflexively. On the X2 it is largely resolved: N9EWO and
+RadioJayAllen both measure whip SW sensitivity competitive with other
+portables.[^n9ewo] The honest residue: like every portable, it rewards an
+external antenna (an ANT-60 reel ships with some SKUs — though one report
+notes degradation with the ANT-60 plugged in), and its battery draw is
+noticeably heavier than the Tecsuns' single 18650 — budget for NiMH AAs and
+use the smart in-radio charging.
+
+The category constants: **listening is license-free everywhere in the US — no
+FCC anything, ever** — airband included. And even at flagship prices, the
+antenna rule holds: **$20 of wire out a window improves shortwave reception
+more than a $200 radio upgrade**. The 2026 bands are honest-but-quieter — the
+big Western broadcasters have mostly gone, and what remains (state
+broadcasters, US private stations, pirates, time signals, ham SSB) rewards
+exactly the SSB capability and external antenna jack this radio has. Its
+class-leading FM/MW is a hedge the shrinking SW schedule can't touch.
+
+## Bands, modes &amp; features
+
+- **Coverage:** LW, MW, SW, FM 64–108 MHz with RDS, **VHF air band with
+  squelch**.
+- **SSB:** USB/LSB with fine tuning steps; auto-bandwidth DSP. No sync.
+- **Memories:** 1674 in 3 banks; 42 world time zones.
+- **Power:** 4×AA with smart in-radio NiMH charging; heavier draw than the
+  18650 Tecsuns.
+- **Connections:** external antenna jack (ANT-60 wire reel included on some
+  SKUs).
+- **Size:** the biggest of the roster — ~8 × 5.25 × 1.5 in, ~1 lb 13 oz with
+  batteries. No Bluetooth, no recording.
+
+## GopherTrunk alternative
+
+Shortwave is HF AM/SSB — not GopherTrunk's trunking/digital domain, and
+GopherTrunk does not decode it. The computer-side way into the same spectrum
+is an HF-capable SDR ([best HF SDR](/best-hf-sdr/)) or a ~$30
+[RTL-SDR](/reference/rtl-sdr/) in direct-sampling mode, which draws a
+[waterfall](/reference/waterfall-display/) of the whole band that no portable
+can. GopherTrunk stays in its VHF/UHF scanner lane — the same listen-first
+philosophy, free — and it's worth noting the 909X2's airband is the one place
+the two worlds brush: for serious VHF airband monitoring with logging, an SDR
+and [scanner software](/scanner-frequencies/) is the deeper tool.
+
+## Who it's for
+
+- **Buy the ATS-909X2** if you want flagship shortwave *plus* the best FM/RDS
+  in a portable and a real squelched air band — the do-everything big radio.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B08MSXX6LH?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [Tecsun PL-990](/reference/tecsun-pl-990/)** instead for a
+  shortwave-first flagship with triple conversion and better battery
+  economics, or the [XHDATA D-808](/reference/xhdata-d-808/) for SSB + airband
+  at a quarter of the price.
+- **Skip it** if airband and FM don't matter — the
+  [PL-880](/reference/tecsun-pl-880/) does the core shortwave job for ~$150.
+  Full rankings: [best shortwave radios](/best-shortwave-radios/).
+
+## Sources
+
+[^sangean]: [Sangean ATS-909X2 product page](https://us.sangean.com/product/ats-909x2-graphite) — coverage, air band with squelch, memory system, RDS, world clock, and AA charging.
+[^n9ewo]: [Sangean ATS-909X2 review — N9EWO](https://www.qsl.net/n9ewo/ats909x2.html) — whip-sensitivity measurements vs the 909X, battery-draw notes, and the ANT-60 observation.
+[^rja]: [Sangean ATS-909X2 review — RadioJayAllen](https://radiojayallen.com/sangean-ats-909x2-am-lw-fm-sw-air-radio/) — FM/MW performance assessment, ergonomics, and comparative standing among flagship portables.

--- a/docs/reference/sangean-mmr-88.md
+++ b/docs/reference/sangean-mmr-88.md
@@ -1,0 +1,132 @@
+---
+slug: sangean-mmr-88
+title: Sangean MMR-88
+entry_type: hardware
+category: shortwave-radios
+description: "The Sangean MMR-88 is the quality pick among emergency crank radios — a genuinely good DSP receiver, IPX3 build reviewers call tank-like, honest crank figures, around $50. Tone alert only (not SAME), small 850 mAh battery, no shortwave."
+keywords: Sangean MMR-88 review, Sangean MMR-88, best emergency radio 2026, crank weather radio, emergency hand crank radio, NOAA weather radio, DSP emergency radio, IPX3 emergency radio, MMR-88 vs ER310, solar crank radio
+aka: [MMR-88, Sangean MMR88]
+autolink: true
+affiliate: true
+product:
+  name: "Sangean MMR-88"
+  brand: Sangean
+  category: Emergency crank/solar weather radio
+  lowPrice: "50"
+  highPrice: "70"
+  url: https://www.amazon.com/dp/B00OJZOOLI?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: "Emergency crank/solar radio (DSP tuner)" }
+  - { label: Bands, value: "AM / FM / 7 NOAA WX, 19 presets — no shortwave" }
+  - { label: Alerts, value: "1050 Hz tone alert standby — not SAME" }
+  - { label: Power, value: "Crank, small solar, 850 mAh Li-ion, Micro-USB — no AA option" }
+  - { label: License, value: "None — receiver" }
+  - { label: Price, value: "around $50" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B00OJZOOLI?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [midland-er310, midland-er210, eton-frx3-plus, kaito-ka500, eton-scorpion-ii, fospower-a1]
+related_reading:
+  - { title: "Best emergency radios", url: /best-emergency-radios/ }
+cite_urls:
+  - https://www.sangean.com/en/product/mmr-88-fcc-yellow
+  - https://radiojayallen.com/sangean-mmr-88-emergency-radio/
+faq:
+  - q: "Is the Sangean MMR-88 the best emergency radio?"
+    a: "It's the best-built receiver in the class — reviewers call it tank-like, and its DSP tuner and audio outclass same-priced crank radios. The trade is the small 850 mAh battery and no AA option, which is why the bigger-batteried Midland ER310 edges it as the overall pick."
+  - q: "How long does the MMR-88 run on a full crank?"
+    a: "About 5 minutes of listening per minute of cranking, per radiojayallen's measurement. That's a lower claim than competitors advertise — and it holds up under testing, which reviewers respect more than optimistic marketing."
+  - q: "Does the Sangean MMR-88 have SAME alerting?"
+    a: "No. It has 1050 Hz tone-alert standby, which wakes for any watch or warning in the whole NOAA transmitter's coverage area — no county filtering. Pair it with a plugged-in SAME desktop radio if being woken to the right warning matters."
+  - q: "Is the MMR-88 waterproof?"
+    a: "It's rated IPX3 — protected against spray up to 60 degrees off vertical. That's genuine splash resistance in the rain, and one of only two formal ratings in this class (the Eton Scorpion II's IPX4 is the other), but it is not submersible."
+  - q: "Can the MMR-88 charge a phone?"
+    a: "Nominally. There's a USB output, but with only 850 mAh behind it you'd get a small emergency top-up at best. The MMR-88 is a radio you keep charged, not a power bank — buy a RunningSnail MD-092 or Midland ER310 if power-bank duty matters."
+---
+**The Sangean MMR-88** is the quality pick of the emergency crank class: a
+genuinely good DSP-tuned AM/FM/NOAA receiver in a build reviewers call "built
+like a tank," with an IPX3 splash rating, honest crank figures, and a street
+price around $50.[^sangean] The trades are real — a small 850 mAh battery, no
+AA option — and like every crank radio here it's **tone alert only, not SAME**,
+with **no shortwave**.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B00OJZOOLI?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The one you buy for the radio, not the gadget list.** Best receiver and audio
+per dollar in the class, DSP tuning with 19 presets, IPX3, siren and SOS strobe.
+**Honest crank math:** ~1 min crank ≈ ~5 min of listening — a lower claim than
+rivals advertise, and one that actually holds up in measurement.[^rja]
+**Small 850 mAh battery, Micro-USB, no AA fallback** — keep it charged; it's not
+a power bank. **Tone alert, not SAME** — a plugged-in SAME desktop still owns
+the wake-you-up job. **~$50. Listening is license-free** — no FCC anything,
+ever. Ranked in [best emergency radios](/best-emergency-radios/).
+</div>
+
+## Overview
+
+Most crank radios are gadgets that happen to contain a radio. The MMR-88 is a
+radio that happens to crank — Sangean is a serious receiver maker, and it
+shows. The DSP tuner pulls in AM (520–1710 kHz), FM, and all 7 NOAA weather
+channels with sensitivity and audio that embarrass same-priced competition, and
+19 memory presets replace the dial-scrubbing the budget units force on you. The
+body earns the "tank" cliché: dense, rubber-armored, and formally rated
+**IPX3** against spray — one of only two real ingress ratings in the current
+crank-radio field. An LED flashlight with strobe/SOS modes and an emergency
+siren round out the kit.
+
+The design's one big trade is energy storage: an internal **850 mAh** Li-ion —
+a third the capacity of a [Midland ER310](/reference/midland-er310/) — charged
+via Micro-USB (no USB-C), with **no AA fallback**. Sangean spent the budget on
+the receiver, not the battery. Understand that and buy accordingly: this is a
+radio you keep topped up, not a power reservoir.
+
+## Alerting: tone standby, not SAME
+
+The MMR-88's alert mode is **1050 Hz tone-alert standby** — muted on a weather
+channel, it wakes when the National Weather Service sends the attention tone
+ahead of *any* watch or warning in the transmitter's whole footprint, counties
+away included. It is **not SAME**: no FIPS county filtering, no event-type
+display. For actually being woken to a tornado warning for *your* county, a $30
+plugged-in SAME desktop radio beats every crank radio made; the MMR-88's role
+is what comes after — grid-down listening with the best audio in the class.
+
+## Power reality: the honest 1:5
+
+radiojayallen's measurement — about **1 minute of cranking for 5 minutes of
+listening** — is *lower* than what competitors advertise, and that's the point:
+it's a claim that survives testing.[^rja] The small solar panel is a trickle
+maintainer, and the USB output with 850 mAh behind it makes phone charging
+nominal at best. In practice the MMR-88 wants to live on a shelf near a USB
+charger, with the crank and solar as the deep reserve. If your priority is
+maximum stored energy rather than receiver quality, the
+[RunningSnail MD-092](/reference/runningsnail-md-092/)'s 4000 mAh or the
+ER310's 2600 mAh plus AAs serve that mission better.
+
+## GopherTrunk alternative
+
+One honest line: an SDR needs a computer and power, and the MMR-88's whole
+point is needing neither — GopherTrunk doesn't compete here. It
+complements: while the infrastructure is up, a
+[$30 RTL-SDR](/reference/rtl-sdr/) running free GopherTrunk monitors and
+records your local public-safety, utility, and weather channels — the traffic
+that tells you what's actually happening in an emergency. Start with our
+[emergency scanner frequencies](/scanner-frequencies/) guide for what to
+program; keep the MMR-88 charged beside it as the works-without-anything
+fallback.
+
+## Who it's for
+
+- **Buy the MMR-88** if you want the best-sounding, best-built radio in the
+  crank class and your power plan is "keep it charged."
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B00OJZOOLI?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [Midland ER310](/reference/midland-er310/)** instead if runtime and
+  the AA fallback outrank receiver refinement — that's why it's our overall
+  pick.
+- **Need shortwave too?** The [Kaito KA500](/reference/kaito-ka500/) adds it
+  for similar money, with rougher edges. Full rankings and the SAME explainer:
+  [best emergency radios](/best-emergency-radios/).
+
+## Sources
+
+[^sangean]: [Sangean MMR-88 product page](https://www.sangean.com/en/product/mmr-88-fcc-yellow) — Sangean: DSP tuner, band coverage, 19 presets, IPX3 rating, 850 mAh battery, crank/solar/USB power, flashlight and siren.
+[^rja]: [Sangean MMR-88 emergency radio review — radiojayallen](https://radiojayallen.com/sangean-mmr-88-emergency-radio/) — measured crank runtime (~1 min ≈ 5 min listening), receiver and audio assessment, and the ~$50 typical street price.

--- a/docs/reference/sony-icf-2010.md
+++ b/docs/reference/sony-icf-2010.md
@@ -1,0 +1,152 @@
+---
+slug: sony-icf-2010
+title: Sony ICF-2010
+entry_type: hardware
+category: shortwave-radios
+description: "The Sony ICF-2010 is the all-time classic shortwave portable — the first affordable receiver with selectable-sideband synchronous detection, still benchmark-grade — used-market only at roughly $150–350, with the famous blown-front-end-FET test to run before buying."
+keywords: Sony ICF-2010, ICF-2010 review, ICF-2010 for sale, ICF-2001D, classic shortwave radio, sync detector portable, ICF-2010 FET repair, ICF-2010 1620 kHz test, used shortwave receiver, is shortwave radio still worth it
+aka: [ICF-2010, ICF-2001D, Sony 2010]
+autolink: true
+affiliate: true
+product:
+  name: "Sony ICF-2010"
+  brand: Sony
+  category: Shortwave receiver (classic desktop-class portable)
+  seller: eBay
+  itemCondition: used
+  lowPrice: "150"
+  highPrice: "350"
+  url: "https://www.ebay.com/sch/i.html?_nkw=sony+icf-2010"
+infobox:
+  - { label: Type, value: "Classic desktop-class portable shortwave receiver" }
+  - { label: Bands, value: "150 kHz–30 MHz + FM + 116–136 MHz AIR" }
+  - { label: SSB / Sync, value: "SSB/CW (100 Hz steps); selectable-sideband sync — still benchmark-grade" }
+  - { label: Power, value: "Batteries (D + AA memory cells) or AC adapter" }
+  - { label: License, value: "None — receiver" }
+  - { label: Price, value: "around $150–350 used (huge condition spread)" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.ebay.com/sch/i.html?_nkw=sony+icf-2010\" rel=\"nofollow noopener\">Find on eBay &rarr;</a>" }
+see_also: [grundig-satellit-800, lowe-hf-150, drake-r8b, eton-elite-750, shortwave-broadcast, rtl-sdr]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "Best desktop shortwave receivers", url: /best-desktop-shortwave-receivers/ }
+cite_urls:
+  - https://radiojayallen.com/sony-icf-2010-an-all-time-classic/
+faq:
+  - q: "Why is the Sony ICF-2010 so famous?"
+    a: "It was the first affordable receiver with selectable-sideband synchronous AM detection — a feature that's still benchmark-grade forty years on — and it stayed in production from 1985 to about 2002, one of the longest runs of any receiver. Every high-end portable since has been measured against it."
+  - q: "How do I test an ICF-2010 for a blown front end?"
+    a: "The classic test: tune from 1620.0 to 1620.1 kHz and listen — the background hiss should audibly DROP as the radio switches ranges. No drop means the front-end FET is blown (usually static through the external antenna jack). The fix is cheap and well documented — an MPF102-class JFET, with repair kits sold on eBay."
+  - q: "How much is a used ICF-2010 worth?"
+    a: "Honest sold prices run about $150–350 — clean tested units ask $180–250, rough or untested ones go lower, and collectors pay far more for boxed examples (a sealed unit sold near $982). The condition spread is huge because blown-front-end units circulate widely; always ask for the 1620 kHz test result."
+  - q: "Is the ICF-2010 a portable or a desktop radio?"
+    a: "Technically a large portable — but it appears on every classic-receiver list alongside the tabletops, and it's the traditional gateway into serious shortwave listening, which is why it's the one non-tabletop in our desktop guide."
+  - q: "Do I need a license to use an ICF-2010?"
+    a: "No. It only receives, and listening is license-free everywhere in the US — no FCC anything, ever."
+---
+**The Sony ICF-2010** is the most beloved shortwave radio ever made — the
+1985 breakthrough that put **selectable-sideband synchronous detection**,
+still benchmark-grade today, into an affordable receiver, and stayed in
+production for some 17 years (as the ICF-2001D in export markets).[^jayallen]
+Technically it's a large portable, not a tabletop — it's the one honorary
+member of our desktop list — and it's been discontinued for over two decades:
+the used market is where it lives, at an honest **$150–350**.
+
+<a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=sony+icf-2010" rel="nofollow noopener">Find on eBay &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The all-time classic and the traditional gateway into serious SWLing.**
+150 kHz–30 MHz plus FM and VHF AIR, 32 direct-access memories, and *the*
+sync detector — the standard of comparison for every high-end portable
+since. **Used only, ~$150–350** with a huge condition spread. **The buying
+game is one test:** the 1620 kHz hiss check for a blown front-end FET (the
+signature fault, cheaply fixable). **No license to listen — ever.** Where it
+ranks: [best desktop shortwave receivers](/best-desktop-shortwave-receivers/).
+</div>
+
+## Overview
+
+Radio reviewers call the ICF-2010 "the standard of comparison", and it earned
+the title the direct way: for two decades, every new high-end portable was
+judged against it and most lost.[^jayallen] The feature that mattered was
+sync — lock the carrier, pick the cleaner sideband, and selective fading's
+garble turns back into program audio. Sony got it so right in 1985 that the
+detector still holds its own against anything short of a
+[Drake R8B](/reference/drake-r8b/). Around it: 150 kHz–30 MHz coverage plus
+FM and the 116–136 MHz air band, SSB/CW, wide/narrow AM filters, and 32
+memories on direct-access buttons — press one, get a station, a UI some
+modern radios still haven't matched.
+
+Judged by 2026 standards it shows its age: 100 Hz tuning steps with muting
+artifacts on [SSB](/reference/single-sideband/), dated audio, and a famous
+fragility (below). And judge the bands honestly too — the big Western
+broadcasters are gone from shortwave, and what remains (international
+broadcasters, time signals, utility traffic, ham SSB, pirates) is quieter
+than the 2010's golden years. It's still the cheapest ticket into classic
+sync-equipped listening, and the perennial truth applies double at this
+price: **a $20 wire antenna out a window improves reception more than a $200
+radio upgrade** — just read the FET warning below before you connect one.
+
+**Listening note:** receiving is license-free everywhere in the US — no FCC
+registration, exam, or paperwork, ever.
+
+## Bands, modes &amp; features
+
+- **Coverage:** 150 kHz–30 MHz + FM + 116–136 MHz AIR band.
+- **Modes:** [AM](/reference/amplitude-modulation/), SSB, CW; wide/narrow AM
+  filters; the benchmark selectable-sideband sync.
+- **Memories:** 32, on direct-access buttons.
+- **Power:** D cells plus AA memory-backup cells, or AC adapter.
+
+## Buying used: what to check
+
+The 2010's faults are famous, specific, and mostly cheap to fix — which is
+why untested units are a gamble and tested ones carry a premium:[^jayallen]
+
+1. **The blown front-end FET — THE fault.** Static through the external
+   antenna jack kills the input FET and with it most of the sensitivity;
+   such units circulate widely. **The test:** tuning from 1620.0 to
+   1620.1 kHz, the hiss should audibly *drop*; no drop = blown FET. The fix
+   is a cheap MPF102-class JFET (kits sold on eBay). Ask every seller for
+   this test result — it's the whole price of the radio.
+2. **Memory-battery contacts.** The AA backup-cell contacts corrode or lose
+   contact, and the radio "dies" or dumps its memories; removing all
+   batteries resets a hung CPU. Ask for battery-bay photos.
+3. **Pushbuttons** — intermittent keys are common; work every one.
+4. **Battery-bay corrosion** and the **headphone jack**.
+
+Clean tested units ask $180–250; rough ones go lower (EU mixed-condition
+listings median around €120), and collectors pay near $1,000 for sealed
+boxed examples. The hobbyist repair ecosystem is superb — this is one
+classic you can realistically fix yourself.
+
+## GopherTrunk alternative
+
+The ICF-2010's descendants aren't radios — they're SDRs. A ~$200 HF SDR (or
+even a ~$30 [RTL-SDR](/reference/rtl-sdr/) in direct-sampling mode) delivers
+sync-grade carrier handling in software plus a waterfall view of the whole
+band, which is exactly why this product category faded away. Buying a 2010
+today is a deliberate choice: the button-per-memory UI, the speaker, the
+history, the object. The modern route is our
+[best HF SDR guide](/best-hf-sdr/); GopherTrunk itself stays in its VHF/UHF
+scanner lane — the same listen-first philosophy, free.
+
+## Who it's for
+
+- **Buy the ICF-2010** if you want the all-time classic and the cheapest
+  entry into benchmark sync detection — and you'll demand the 1620 kHz test
+  first.
+  <a class="btn btn--buy" href="https://www.ebay.com/sch/i.html?_nkw=sony+icf-2010" rel="nofollow noopener">Find on eBay &rarr;</a>
+- **Buy the [Grundig Satellit 800](/reference/grundig-satellit-800/)**
+  instead for big-radio audio and Drake-derived sync in a tabletop-size
+  package, or the [Lowe HF-150](/reference/lowe-hf-150/) for a compact true
+  tabletop with dual-mode sync.
+- **Want a new radio with a warranty?** The
+  [Eton Elite 750](/reference/eton-elite-750/) is the last big new knob
+  radio — without sync. Full rankings:
+  [best desktop shortwave receivers](/best-desktop-shortwave-receivers/).
+
+## Sources
+
+[^jayallen]: [Sony ICF-2010 — an all-time classic — radiojayallen](https://radiojayallen.com/sony-icf-2010-an-all-time-classic/) — production history (1985–2002/03), the sync detector's benchmark standing, known faults including the front-end FET and memory-battery issues, and used-market context.

--- a/docs/reference/sony-icf-2010.md
+++ b/docs/reference/sony-icf-2010.md
@@ -121,6 +121,13 @@ listings median around €120), and collectors pay near $1,000 for sealed
 boxed examples. The hobbyist repair ecosystem is superb — this is one
 classic you can realistically fix yourself.
 
+**Used-market viability:** excellent, with one asterisk. Supply is deep
+(that 17-year production run), the repair ecosystem is the best of any
+radio on our list, and parts kits are a few dollars — but the number of
+blown-front-end units in circulation means the *untested* market is a
+minefield. A seller who answers the 1620 kHz question is selling a radio; a
+seller who won't is selling a lottery ticket.
+
 ## GopherTrunk alternative
 
 The ICF-2010's descendants aren't radios — they're SDRs. A ~$200 HF SDR (or

--- a/docs/reference/sony-icf-sw7600gr.md
+++ b/docs/reference/sony-icf-sw7600gr.md
@@ -1,0 +1,155 @@
+---
+slug: sony-icf-sw7600gr
+title: Sony ICF-SW7600GR
+entry_type: hardware
+category: shortwave-radios
+description: "The Sony ICF-SW7600GR is the benchmark travel shortwave portable of two decades — reference-grade synchronous detection, SSB, bulletproof build — discontinued since ~2018 and now a used-market buy at roughly $200–350."
+keywords: Sony ICF-SW7600GR review, ICF-SW7600GR for sale, best sync detector portable, used shortwave radio buying guide, Sony shortwave radio discontinued, ICF-SW7600GR vs SW7600, SW7600GR capacitor repair, classic shortwave portable, synchronous detection, collector shortwave radio
+aka: [ICF-SW7600GR, SW7600GR, Sony 7600GR]
+autolink: true
+affiliate: true
+product:
+  name: "Sony ICF-SW7600GR"
+  brand: Sony
+  category: Portable shortwave receiver (discontinued classic)
+  itemCondition: used
+  lowPrice: "200"
+  highPrice: "350"
+  url: https://www.amazon.com/dp/B00006IS4X?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: "Classic travel shortwave receiver (dual conversion)" }
+  - { label: Bands, value: "LW/MW/SW 150–29999 kHz / FM" }
+  - { label: SSB, value: "Yes — plus reference-grade sync detection, selectable sideband" }
+  - { label: Power, value: "4×AA" }
+  - { label: License, value: "None — receiver" }
+  - { label: Price, value: "around $200–350 used (mint/boxed $400+; thin, volatile market)" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B00006IS4X?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [tecsun-pl-660, eton-elite-executive, tecsun-pl-990, kenwood-ts-940s, shortwave-broadcast, single-sideband]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "Best shortwave radios", url: /best-shortwave-radios/ }
+cite_urls:
+  - https://www.universal-radio.com/catalog/portable/0360.html
+  - https://mwcircle.org/legacy-receiver-reviews/receiver-review-sony-icf-sw7600gr/
+  - https://swling.com/blog/2018/02/sony-could-halt-production-of-shortwave-radios-in-february/
+  - http://stephan.win31.de/sony76-2.htm
+faq:
+  - q: "Is the Sony ICF-SW7600GR still worth buying?"
+    a: "As the reference sync-detector portable, yes — for the right buyer at the right price. Its selectable-sideband synchronous detection and rock-solid AGC are still unmatched in a portable. But its raw sensitivity is now matched by $80 DSP radios, so at $200–350 used you're paying for the sync, the build, and the legend — not for spec-sheet performance."
+  - q: "When did Sony stop making the ICF-SW7600GR?"
+    a: "Sony halted shortwave radio production circa February 2018, with sporadic final batches after; the SW7600GR had run since 2001. It's aftermarket-only now — Amazon's legacy listing carries intermittent third-party offers at collector prices, and eBay is the practical market."
+  - q: "What should I check before buying a used ICF-SW7600GR?"
+    a: "The known aging fault is SMD electrolytic capacitors (~28 of them) — symptoms are low or no audio, falling signal strength, and tuning trouble; ask if it's been recapped. Also check the whip's base pivot, battery-bay corrosion from leaked AAs, that sync locks on both sidebands, and that SSB is on-frequency."
+  - q: "What's the difference between the ICF-SW7600 and the SW7600GR?"
+    a: "Generations apart. The GR (2001–2018) is the last and best of the family; cheap listings around $50 are usually the older SW7600 or SW7600G being passed off at a glance. Verify the GR suffix on the cabinet before paying GR money — and the bargains run the other way, too."
+  - q: "Do I need a license to listen to shortwave?"
+    a: "No — listening is license-free everywhere in the US, no FCC anything, ever. And this radio's external antenna jack (which also powers Sony active antennas like the AN-LP1) is the cheap upgrade path: $20 of wire out a window beats a $200 radio swap."
+---
+**The Sony ICF-SW7600GR** was the benchmark travel portable for two decades —
+2001 to Sony's exit from shortwave radio production around February 2018 —
+and one feature keeps it relevant in 2026: **selectable-sideband synchronous
+detection that is still the reference implementation in a portable**, backed
+by rock-solid AGC and bulletproof build quality.[^mwc] It is aftermarket-only
+now: clean units run roughly **$200–350**, boxed/mint examples $400+ (one
+January 2026 completed sale at $424.72), and the market is thin, volatile,
+and drifting collector-ward.[^eol]
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B00006IS4X?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The reference sync portable — buy it for the sync, not the spec sheet.**
+Discontinued since ~2018; used ~$200–350 (mint $400+), thin/volatile pricing.
+**Its sensitivity is now matched by $80 DSP radios** — the AGC, sync, and
+build are what you're paying for. **The buying game is condition:** ~28 aging
+SMD electrolytics, whip pivot, battery-bay corrosion, and a sideband-lock
+test — and don't pay GR money for a non-GR SW7600. **License-free
+listening.** Where it ranks: [best shortwave radios](/best-shortwave-radios/).
+</div>
+
+## Overview
+
+The 7600 family was Sony's flat, coat-pocket travel line, and the GR was its
+final, fully-evolved form: dual conversion, LW through 30 MHz plus FM,
+[SSB](/reference/single-sideband/) via a clarifier, and the synchronous
+detector that made its name — lock it to a fading broadcast carrier, pick
+the cleaner sideband, and interference and selective fading simply calm
+down in a way DSP soft-mute-era radios still don't match. The AGC is
+famously composed, the build is bulletproof, and the external antenna jack
+even powers Sony's active antennas (AN-LP1).[^univ]
+
+Be honest about what 2026 money buys, though. 100 memories is quaint. There
+is no fine-tune knob — 1 kHz steps plus an SSB clarifier where a modern
+Tecsun gives 10 Hz steps. The speaker is mediocre. And raw sensitivity that
+was premium in 2005 is now **matched by $80 DSP portables** like the
+[XHDATA D-808](/reference/xhdata-d-808/). You buy a GR for the sync, the
+AGC, the ergonomics of a legend — and increasingly as a collectible.
+
+**Listening is license-free everywhere in the US — no FCC anything, ever** —
+and the antenna rule is older than this radio: **$20 of wire out a window
+improves shortwave reception more than a $200 radio upgrade.** On the 2026
+bands — leaner since VOA's 2025 shortwave shutdown, with state
+broadcasters, US private stations, pirates, and time signals carrying the
+schedule — a sync detector is precisely the tool for the marginal, fading
+signals that remain.
+
+## Buying used: what to check
+
+Amazon's legacy listing still exists with **intermittent third-party offers
+at collector prices** — worth checking, but eBay and the SWL classifieds are
+the practical market. The GR's aging faults are well documented:[^caps]
+
+1. **SMD electrolytic capacitors** — the known fault of the 7600 family,
+   roughly 28 of them. Symptoms: low or no audio, falling signal strength,
+   tuning trouble. The GR (2001+) is later and better-built than the SW7600,
+   but age is age — ask whether it has been recapped, and listen for weak
+   audio in any demo video.
+2. **Telescopic whip** — check the base screw and pivot for looseness and
+   the segments for bends.
+3. **Battery bay** — 4×AA radios that sat in drawers grow alkaline
+   corrosion; ask for photos of the contacts and the serial.
+4. **Function test** — verify **sync locks on both sidebands**, SSB is
+   on-frequency, and all display/backlight segments work.
+5. **Identity check** — cheap listings (~$50) are usually the much older
+   non-GR ICF-SW7600 or SW7600G at a glance-alike price. Verify the **GR**
+   suffix before paying GR money; the actual bargains run the other
+   direction.
+
+Original box and AC adapter add value. Priced against a recap and an
+unknown history, a $250 "works great" attic unit and a $350 recapped,
+tested one can be the same deal.
+
+## GopherTrunk alternative
+
+Shortwave is HF AM/SSB — not GopherTrunk's trunking/digital domain, and
+GopherTrunk does not decode it. It's worth saying plainly: **software-defined
+radios are what ended this product category** — an HF-capable SDR
+([best HF SDR](/best-hf-sdr/)) or a ~$30 [RTL-SDR](/reference/rtl-sdr/) in
+direct-sampling mode does synchronous detection in software and draws a
+[waterfall](/reference/waterfall-display/) beside it. A GR today is a
+deliberate choice of a self-contained legend over performance-per-dollar.
+GopherTrunk stays in its VHF/UHF scanner lane — same listen-first
+philosophy, free.
+
+## Who it's for
+
+- **Buy the ICF-SW7600GR** if you want the best synchronous detector ever
+  shipped in a portable and you'll vet condition like a collector — because
+  at these prices, you are one.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B00006IS4X?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [Tecsun PL-660](/reference/tecsun-pl-660/)** instead for a
+  cheaper used classic with sync *and* a fine-tune-friendly SSB — the better
+  value story right now — or the
+  [Eton Elite Executive](/reference/eton-elite-executive/) for new-with-sync
+  at clearance money while stock lasts.
+- **Want modern performance instead of a legend?** A
+  [PL-990](/reference/tecsun-pl-990/) outperforms it everywhere except sync.
+  Full rankings: [best shortwave radios](/best-shortwave-radios/).
+
+## Sources
+
+[^mwc]: [Receiver review: Sony ICF-SW7600GR — Medium Wave Circle](https://mwcircle.org/legacy-receiver-reviews/receiver-review-sony-icf-sw7600gr/) — sync/AGC assessment, strengths and dated points by modern standards.
+[^eol]: [Sony could halt production of shortwave radios in February — SWLing Post](https://swling.com/blog/2018/02/sony-could-halt-production-of-shortwave-radios-in-february/) — Sony's ~Feb 2018 exit from shortwave radio production.
+[^univ]: [Sony ICF-SW7600GR — Universal Radio catalog](https://www.universal-radio.com/catalog/portable/0360.html) — specifications: coverage, sync, SSB, memories, antenna jack, and AA power.
+[^caps]: [Sony ICF-SW7600 family capacitor repairs](http://stephan.win31.de/sony76-2.htm) — the SMD electrolytic aging fault (~28 caps), symptoms, and repair notes.

--- a/docs/reference/tecsun-pl-330.md
+++ b/docs/reference/tecsun-pl-330.md
@@ -1,0 +1,143 @@
+---
+slug: tecsun-pl-330
+title: Tecsun PL-330
+entry_type: hardware
+category: shortwave-radios
+description: "The Tecsun PL-330 is the best cheap shortwave radio with SSB — a pocketable DSP receiver with 10 Hz fine tuning, ETM+, and a swappable BL-5C battery for around $60–90. Soft-mute on weak signals is its one real flaw."
+keywords: Tecsun PL-330 review, best cheap shortwave radio, shortwave radio under 100, pocket shortwave radio with SSB, PL-330 soft mute, PL-330 firmware 3308, Tecsun PL-330 vs XHDATA D-808, portable SSB receiver, is shortwave radio still worth it, budget shortwave radio 2026
+aka: [PL-330, Tecsun PL330]
+autolink: true
+affiliate: true
+product:
+  name: "Tecsun PL-330"
+  brand: Tecsun
+  category: Portable shortwave receiver (compact)
+  lowPrice: "60"
+  highPrice: "90"
+  url: https://www.amazon.com/dp/B0921HN6QM?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: "Compact DSP shortwave receiver (SiLabs)" }
+  - { label: Bands, value: "LW / MW / SW / FM" }
+  - { label: SSB, value: "Yes — USB/LSB with 10 Hz fine tuning + ETM+" }
+  - { label: Power, value: "BL-5C Li-ion (cheap, swappable); USB-C on recent units" }
+  - { label: License, value: "None — receiver" }
+  - { label: Price, value: "around $60–90" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B0921HN6QM?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [xhdata-d-808, qodosen-dx-286, tecsun-pl-880, cc-skywave-ssb-2, shortwave-broadcast, single-sideband]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "Best shortwave radios", url: /best-shortwave-radios/ }
+cite_urls:
+  - https://www.tecsun-radios.com/product/pl330-radio-receiver/
+  - https://www.qsl.net/n9ewo/pl330.html
+  - https://swling.com/blog/2021/04/dan-reviews-the-tecsun-pl-330-portable-shortwave-radio/
+faq:
+  - q: "Is the Tecsun PL-330 the best budget shortwave radio?"
+    a: "It's our most-affordable pick and the value benchmark for a pocket radio with SSB. Around $60–90 buys 10 Hz SSB fine tuning, ETM+ auto-scanning, an antenna jack, and a swappable BL-5C battery. Its rivals: the XHDATA D-808 adds airband for slightly more; the Qodosen DX-286 is more sensitive but has no SSB."
+  - q: "What is the PL-330 soft-mute problem?"
+    a: "On weak or fading signals the DSP clamps the audio down, which makes marginal stations pumping and unpleasant — the top community complaint about this radio. The standard workaround is tuning 1–2 kHz off-channel; later firmware improves it but doesn't eliminate it."
+  - q: "Does the PL-330 have SSB?"
+    a: "Yes — USB and LSB with 10 Hz fine tuning, remarkable at this price. There's no official sync detector (a hidden sync-like mode appeared in later firmware, but it's unofficial and not worth buying the radio for)."
+  - q: "Which PL-330 firmware should I look for?"
+    a: "2026-dated units ship firmware 3308; 3306 and 3307 are common in the channel. Later is generally better behaved, but you can't reliably choose at checkout — the firmware lottery is a known Tecsun quirk. Buy from a high-turnover seller for the best odds of recent stock."
+  - q: "Is shortwave still worth listening to in 2026?"
+    a: "Yes, honestly framed: the big Western broadcasters have mostly left (VOA's shortwave was gutted in 2025), but state broadcasters, US private stations, pirates, time stations, utility traffic, and ham SSB remain — and listening is license-free everywhere in the US. A $20 wire antenna out a window helps a $70 radio hear most of it."
+---
+**The Tecsun PL-330** is the value benchmark for shortwave in 2026: a genuinely
+pocketable DSP receiver with real [SSB](/reference/single-sideband/) — 10 Hz
+fine tuning included — ETM+ auto-scanning, an external antenna jack, and a
+cheap, swappable BL-5C battery, for around **$60–90**.[^tecsun] It is the
+radio to buy when you're not yet sure the hobby will stick, and the one flaw
+you accept for the price is Tecsun's soft-mute on weak signals.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0921HN6QM?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Most affordable real shortwave radio — and it has SSB.** ~$60–90 for 10 Hz
+SSB tuning, ETM+, 850 memories, an antenna jack, and a swappable battery in a
+shirt-pocket radio. **Soft-mute on weak signals is the top complaint**
+(workaround: tune 1–2 kHz off). Firmware varies between units (3308 is
+current). **License-free listening**; the $20 wire-antenna upgrade beats any
+radio swap. Where it ranks: [best shortwave radios](/best-shortwave-radios/).
+</div>
+
+## Overview
+
+The PL-330 is what happened when Tecsun put its flagship tuning interface into
+an ultralight. At ~5.5 × 3.4 × 1 inches it disappears into a jacket pocket,
+yet it carries the same 10 Hz SSB fine-tune step as the
+[PL-880](/reference/tecsun-pl-880/), ETM+ (auto-scan-and-store that files
+stations by band into its 850 memories), LW/MW/SW/FM coverage, and a 3.5 mm
+antenna jack. The battery choice is quietly brilliant: the BL-5C is the old
+Nokia phone cell — a few dollars anywhere, so you carry a charged spare
+instead of babysitting a built-in pack. Recent revisions charge over USB-C
+(early units were micro-USB).[^n9ewo]
+
+The compromises are honest ones. The speaker is small and tinny — use
+headphones for anything serious. And **soft-mute is the top complaint on this
+radio specifically**: on weak, fading signals the DSP pumps the audio level,
+which is exactly the kind of signal a shortwave DXer chases. The standard
+community workaround is tuning 1–2 kHz off-channel; later firmware (2026
+units ship 3308) behaves better, but which firmware you receive is a lottery
+you can't fully control at checkout.[^swling] There is no sync detector — a
+hidden sync-like mode appeared in later firmware, but it's unofficial and not
+a buying reason.
+
+A note on buying: the PL-330 has attracted **grey-market duplicate listings**
+on Amazon under separate ASINs. Use the primary listing linked here; the
+duplicates are third-party imports where warranty and firmware vintage are
+anyone's guess.
+
+The category constants: **listening is license-free everywhere in the US — no
+FCC anything, ever.** And precisely because the PL-330 is cheap, the antenna
+truth matters most here: **$20 of wire clipped to the whip or plugged into the
+jack and run out a window improves reception more than upgrading to a $200
+radio.** The 2026 bands are contracted — VOA's shortwave was gutted in 2025,
+the BBC left North America decades ago — but what remains (state
+broadcasters, US private stations, pirates, time stations, ham SSB) is
+exactly what a $70 SSB-capable radio plus wire can hear.
+
+## Bands, modes &amp; features
+
+- **Coverage:** LW, MW, SW, FM.
+- **SSB:** USB/LSB, 10 Hz fine tuning — the cheapest radio here with proper
+  SSB.
+- **Tuning aids:** ETM+ auto-scan/store, 850 memories.
+- **Receiver:** SiLabs DSP, selectable bandwidths.
+- **Power:** BL-5C Li-ion, swappable; USB-C charging on recent revisions.
+- **Connections:** 3.5 mm external antenna jack. No Bluetooth, no recording,
+  no airband, no weather band — the [D-808](/reference/xhdata-d-808/) and
+  [CC Skywave SSB 2](/reference/cc-skywave-ssb-2/) cover those.
+
+## GopherTrunk alternative
+
+Shortwave is HF AM/SSB — outside GopherTrunk's trunking/digital domain, and
+GopherTrunk does not decode it. For a computer-side path at PL-330 money, a
+~$30 [RTL-SDR](/reference/rtl-sdr/) in direct-sampling mode tunes the same HF
+spectrum with a [waterfall](/reference/waterfall-display/) a portable can't
+draw; a step up is a purpose-built HF SDR ([best HF SDR](/best-hf-sdr/)).
+GopherTrunk itself stays in its VHF/UHF scanner lane — same listen-first
+philosophy, free. The PL-330's counter-argument is complete independence: no
+computer, no mains power, a spare battery in your pocket.
+
+## Who it's for
+
+- **Buy the PL-330** if you want the cheapest credible entry into shortwave
+  with SSB — for a first radio, a travel spare, or a go-bag, it's the obvious
+  pick.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B0921HN6QM?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [XHDATA D-808](/reference/xhdata-d-808/)** instead if ~$15 more
+  for airband, RDS, and a bigger speaker appeals, or the
+  [Qodosen DX-286](/reference/qodosen-dx-286/) if raw sensitivity matters more
+  to you than SSB (it has none).
+- **Upgrade later** to the [PL-880](/reference/tecsun-pl-880/) or
+  [PL-990](/reference/tecsun-pl-990/) once the hobby sticks. Full rankings:
+  [best shortwave radios](/best-shortwave-radios/).
+
+## Sources
+
+[^tecsun]: [Tecsun PL-330 product page](https://www.tecsun-radios.com/product/pl330-radio-receiver/) — coverage, SSB fine tuning, ETM+, memories, and battery/charging details.
+[^n9ewo]: [Tecsun PL-330 review — N9EWO](https://www.qsl.net/n9ewo/pl330.html) — soft-mute behavior, firmware variance, speaker assessment, and long-term ownership notes.
+[^swling]: [Dan Robinson reviews the Tecsun PL-330 — SWLing Post](https://swling.com/blog/2021/04/dan-reviews-the-tecsun-pl-330-portable-shortwave-radio/) — comparative standing in the compact class and the off-tuning workaround for soft-mute.

--- a/docs/reference/tecsun-pl-660.md
+++ b/docs/reference/tecsun-pl-660.md
@@ -1,0 +1,152 @@
+---
+slug: tecsun-pl-660
+title: Tecsun PL-660
+entry_type: hardware
+category: shortwave-radios
+description: "The Tecsun PL-660 is the beloved discontinued all-rounder — SSB, VHF air band, and a synchronous detector better than anything Tecsun ships today — now a used/NOS buy at roughly $90–140, before prices go collector-crazy."
+keywords: Tecsun PL-660 review, Tecsun PL-660 discontinued, PL-660 for sale, used shortwave radio, PL-660 sync detector, PL-660 vs PL-880, PL-660 display fault, best used shortwave radio, shortwave radio with air band, PL-660 buying guide
+aka: [PL-660, Tecsun PL660]
+autolink: true
+affiliate: true
+product:
+  name: "Tecsun PL-660"
+  brand: Tecsun
+  category: Portable shortwave receiver (discontinued)
+  itemCondition: used
+  lowPrice: "90"
+  highPrice: "140"
+  url: https://www.amazon.com/dp/B004H9C4JK?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: "Portable shortwave receiver (PLL dual conversion, non-DSP)" }
+  - { label: Bands, value: "LW / MW / SW / FM / VHF Air" }
+  - { label: SSB, value: "Yes (BFO clarifier) — plus selectable-sideband sync detection" }
+  - { label: Power, value: "4×AA with in-radio charging" }
+  - { label: License, value: "None — receiver" }
+  - { label: Price, value: "around $90–140 used/NOS (thin data — check sold listings)" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B004H9C4JK?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [sony-icf-sw7600gr, tecsun-pl-880, xhdata-d-808, eton-elite-executive, shortwave-broadcast, single-sideband]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "Best shortwave radios", url: /best-shortwave-radios/ }
+cite_urls:
+  - https://www.tecsun-radios.com/product/pl660-radio-receiver/
+  - https://www.blogordie.com/2026/03/re-viewing-radios-tecsun-pl-660/
+  - https://swling.com/blog/2025/01/jeff-rediscovers-the-tecsun-pl-660/
+  - https://www.hfunderground.com/board/index.php?topic=35291.0
+faq:
+  - q: "Is the Tecsun PL-660 discontinued?"
+    a: "Yes — produced from about 2011 to 2024, and multiple UK retailers now mark it Discontinued; it was one of Tecsun's most recently retired models. New-old-stock and used units still circulate at roughly $90–140, and Amazon carries third-party NOS listings."
+  - q: "Why do people still hunt for the PL-660?"
+    a: "Its synchronous detector — selectable sideband, and by broad community consensus better than anything Tecsun ships today. The 2025–26 re-reviews (SWLing Post, Blog or Die!) reach the same verdict: the sync alone keeps this radio relevant."
+  - q: "What should I check before buying a used PL-660?"
+    a: "The known failure is a dead display or no power-up traced in some units to a partially-desoldered power-board component — insist on video of it powering up and tuning. Also verify the frequency readout against WWV (some units read ~5 kHz off), sweep the BFO knob for dead spots, and check the battery bay for corrosion since it charges NiMH in-radio."
+  - q: "Is the PL-660 better than the PL-880?"
+    a: "Different animals. The PL-880 (still in production) has better audio, DSP bandwidths, and 10 Hz SSB steps. The PL-660 answers with a real sync detector and a VHF air band — neither of which the PL-880 has. As a used buy under $140, the PL-660 is the character pick."
+  - q: "Do I need a license to listen to shortwave or air band?"
+    a: "No — listening is license-free everywhere in the US, no FCC anything, ever. Put the money into the antenna instead: $20 of wire out a window improves shortwave reception more than a $200 radio upgrade."
+---
+**The Tecsun PL-660** is the discontinued all-rounder people are quietly
+buying up before the prices notice: [SSB](/reference/single-sideband/) with a
+BFO clarifier, a basic VHF air band, 2000 memories — and a
+**selectable-sideband synchronous detector better than anything Tecsun ships
+today**, which is the reason the 2025–26 re-reviews keep landing on the same
+verdict: still worth hunting.[^blog] Produced ~2011–2024 and now marked
+discontinued by retailers, it runs roughly **$90–140 used/NOS** — classic
+capability without (yet) collector pricing.[^swling]
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B004H9C4JK?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Our best used/classic buy — the sync detector is the whole reason.**
+Discontinued ~2024; used/NOS roughly $90–140 (thin data — check sold
+listings). Sync + SSB + airband under $140 beats the collector-priced Sony
+on value. **The buying game:** the dead-display/power-board fault, ~5 kHz
+frequency-offset units, BFO dead spots — insist on a power-up video, and
+prefer late production (less soft-mute). **License-free listening**; $20 of
+wire is the real upgrade. Where it ranks:
+[best shortwave radios](/best-shortwave-radios/).
+</div>
+
+## Overview
+
+The PL-660 comes from the last generation before DSP-on-a-chip took over:
+PLL dual conversion, two honest analog-style bandwidths, and tuning behavior
+with a character DSP radios don't have. The beloved part is the **sync
+detector** — lock a fading broadcast carrier, choose the cleaner sideband,
+and listen as selective fading stops chewing the audio. Community consensus
+is blunt: it's better than anything in Tecsun's current line, including the
+flagships, and it is the main reason people still hunt this radio. Jeff at
+the SWLing Post "rediscovered" it in 2025; Blog or Die!'s March-2026
+re-review reached the same conclusion.[^swling]
+
+The rest of the package holds up as an all-rounder: LW/MW/SW/FM plus a basic
+VHF air band, SSB with a BFO clarifier (not the 10 Hz digital steps of the
+[PL-880](/reference/tecsun-pl-880/) — sweep-and-settle tuning of the old
+school), 2000 memories, and 4×AA power with in-radio NiMH charging. Known
+weaknesses: only two bandwidths, soft-mute on early units (later production
+improved it — prefer late units and ask the purchase year), an erratic
+backlight quirk, and an airband that's basic reception, no squelch
+sophistication.
+
+**Listening is license-free everywhere in the US — no FCC anything, ever** —
+and the PL-660's antenna jack plus **$20 of wire out a window will improve
+reception more than a $200 radio upgrade**, on 2026's leaner bands
+especially. What remains out there — state broadcasters, US private
+stations, pirates, time stations, ham SSB — is heavy on exactly the fading,
+marginal signals a sync detector was built for.
+
+## Buying used: what to check
+
+Amazon carries live third-party NOS listings (linked above); eBay and the
+SWL classifieds are the practical market, and sold listings are the honest
+price guide — the data is thin. The known faults:[^hfu]
+
+1. **Dead display / no power-up** — the PL-660's signature failure, traced
+   in some units to a partially-desoldered power-board component, with
+   several "died after months or years" reports on record. **Insist on
+   video of the radio powering up and tuning** before money moves.
+2. **Frequency-display offset** — some units read ~5 kHz off on AM/SSB (LW
+   too). Verify against WWV or a known station.
+3. **BFO dead spots** — some units go silent at certain BFO knob positions;
+   have the seller sweep it across its range in SSB.
+4. **Battery bay** — it charges NiMH in-radio, so ask what batteries lived
+   in it and check the contacts for corrosion; check the whip while you're
+   at it.
+5. **Production year** — later units have less soft-mute; ask when it was
+   bought. NOS with a box is worth a premium; an untested attic unit is
+   priced as a gamble on fault #1.
+
+## GopherTrunk alternative
+
+Shortwave is HF AM/SSB — not GopherTrunk's trunking/digital domain, and
+GopherTrunk does not decode it. The computer-side path is an HF-capable SDR
+([best HF SDR](/best-hf-sdr/)) or a ~$30 [RTL-SDR](/reference/rtl-sdr/) in
+direct-sampling mode — software sync detection, SSB, and a
+[waterfall](/reference/waterfall-display/) a portable can't draw; SDRs are,
+frankly, why radios like this went out of production, and buying one today
+is a deliberate choice of knobs and character over performance-per-dollar.
+GopherTrunk itself stays in its VHF/UHF scanner lane — same listen-first
+philosophy, free.
+
+## Who it's for
+
+- **Buy the PL-660** if you want the best sync-per-dollar in the used market
+  — the stronger value story than the collector-priced Sony, while prices
+  are still sane.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B004H9C4JK?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [Sony ICF-SW7600GR](/reference/sony-icf-sw7600gr/)** instead if
+  you want the reference sync implementation and will pay collector money
+  for it, or the [Eton Elite Executive](/reference/eton-elite-executive/)
+  for new-with-sync at clearance prices while stock lasts.
+- **Want a supported, current radio?** The
+  [PL-880](/reference/tecsun-pl-880/) or [D-808](/reference/xhdata-d-808/)
+  cover the modern bases — minus the sync. Full rankings:
+  [best shortwave radios](/best-shortwave-radios/).
+
+## Sources
+
+[^blog]: [Re-viewing radios: Tecsun PL-660 — Blog or Die! (March 2026)](https://www.blogordie.com/2026/03/re-viewing-radios-tecsun-pl-660/) — the 2026 re-review verdict: the sync detector outclasses current Tecsun production.
+[^swling]: [Jeff rediscovers the Tecsun PL-660 — SWLing Post (2025)](https://swling.com/blog/2025/01/jeff-rediscovers-the-tecsun-pl-660/) — the case for hunting one used; discontinuation corroborated by [Nevada Radio's listing](https://www.nevadaradio.co.uk/tecsun-pl-660-shortwave-receiver-vhf-airband) and specs by [Tecsun's product page](https://www.tecsun-radios.com/product/pl660-radio-receiver/).
+[^hfu]: [PL-660 dead-display reports — HFUnderground forum](https://www.hfunderground.com/board/index.php?topic=35291.0) — the power-board/no-power-up failure mode behind the used-buying checklist.

--- a/docs/reference/tecsun-pl-880.md
+++ b/docs/reference/tecsun-pl-880.md
@@ -1,0 +1,141 @@
+---
+slug: tecsun-pl-880
+title: Tecsun PL-880
+entry_type: hardware
+category: shortwave-radios
+description: "The Tecsun PL-880 is the enthusiast-favorite portable shortwave radio — legendary speaker audio, SSB with 10 Hz steps, multiple bandwidths, and 18650 power for around $150–170, a decade-plus into production."
+keywords: Tecsun PL-880 review, PL-880 vs PL-990, best shortwave radio under 200, portable shortwave radio with SSB, Tecsun PL-880 hidden features, shortwave radio audio quality, worldband receiver, is shortwave radio still worth it, PL-880 firmware, shortwave listening
+aka: [PL-880, Tecsun PL880]
+autolink: true
+affiliate: true
+product:
+  name: "Tecsun PL-880"
+  brand: Tecsun
+  category: Portable shortwave receiver
+  lowPrice: "150"
+  highPrice: "170"
+  url: https://www.amazon.com/dp/B00GJ51NVA?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: "Portable shortwave receiver (dual conversion + DSP)" }
+  - { label: Bands, value: "LW / MW / SW 1711–29999 kHz / FM 64–108 MHz" }
+  - { label: SSB, value: "Yes — 10 Hz steps, 5 SSB bandwidths; hidden sync only (poor)" }
+  - { label: Power, value: "18650 Li-ion, USB charging" }
+  - { label: License, value: "None — receiver" }
+  - { label: Price, value: "around $150–170" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B00GJ51NVA?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [tecsun-pl-990, tecsun-pl-330, tecsun-pl-660, xhdata-d-808, shortwave-broadcast, single-sideband]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "Best shortwave radios", url: /best-shortwave-radios/ }
+cite_urls:
+  - https://www.tecsun-radios.com/product/pl880-radio-receiver/
+  - https://www.qsl.net/n9ewo/pl880.html
+  - https://www.eham.net/reviews/detail/11457
+faq:
+  - q: "Is the Tecsun PL-880 still worth buying in 2026?"
+    a: "Yes. Introduced in 2013 and still in production, it remains the enthusiast favorite for listening pleasure — the big-speaker audio and 10 Hz SSB fine tuning haven't aged. The PL-990 beats it on refinement and triple-conversion RF, but at ~$100 more the delta is modest."
+  - q: "What are the PL-880 hidden features?"
+    a: "Undocumented settings reached by long-pressing keys — most usefully a soft-mute threshold adjustment that partly defeats the muting on weak signals, plus others that vary by firmware version (e.g. 8820). Which ones your unit has is a known Tecsun firmware lottery; the community wikis document them."
+  - q: "Does the PL-880 have a sync detector?"
+    a: "Not officially. A hidden sync mode exists and is widely judged barely usable. If synchronous detection matters, look at the used Tecsun PL-660 or Sony ICF-SW7600GR — sync is their whole surviving argument."
+  - q: "PL-880 or PL-990 — which should I buy?"
+    a: "PL-880 if you want 90% of the experience for ~$100 less and don't care about Bluetooth/microSD or triple conversion. PL-990 if you want the best current Tecsun, better image rejection, and the refined tuning. Both have SSB; neither has official sync."
+  - q: "Do I need a license for a shortwave radio?"
+    a: "No — listening is license-free everywhere in the US, no FCC anything, ever. And before upgrading the radio, upgrade the antenna: $20 of wire out a window does more for shortwave reception than a $200 radio swap."
+---
+**The Tecsun PL-880** is the portable that shortwave enthusiasts buy for
+*listening pleasure*: a larger speaker with genuinely legendary audio,
+[SSB](/reference/single-sideband/) with 10 Hz fine tuning, four AM and five SSB
+bandwidths, and 3050 memories, running off a single 18650 cell.[^tecsun]
+Introduced in 2013 and still in production in 2026, it sells for around
+**$150–170** — the sweet spot between the flagship
+[PL-990](/reference/tecsun-pl-990/) and the budget DSP crowd.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B00GJ51NVA?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The best-sounding portable per dollar.** Big-speaker audio, 10 Hz SSB
+tuning, 5 SSB bandwidths, 18650 power — **~$150–170**, still in production a
+decade on. **Known quirks:** soft-mute on weak signals (partly defeatable via
+hidden settings), a firmware lottery between units, and a hidden sync mode
+that's barely usable. **License-free listening**; a $20 wire antenna out the
+window is the real upgrade. Where it ranks:
+[best shortwave radios](/best-shortwave-radios/).
+</div>
+
+## Overview
+
+Twelve years is geologic time for a consumer radio, and the PL-880 is still
+here because it nailed the thing spec sheets don't measure: **it is pleasant
+to listen to**. The speaker is the largest and best-voiced in its class, the
+fine-tuning knob makes SSB feel analog, and the dual-conversion front end plus
+DSP filtering gives you four AM and five SSB bandwidths to carve interference
+away. For program listening — the international broadcasters, the US private
+stations, MW DX at night — it is the radio people keep even after buying
+something newer.[^n9ewo]
+
+The quirks are equally well documented. **Soft-mute** — the DSP clamping audio
+on weak, fading signals — is the classic Tecsun complaint, and the PL-880's
+famous **hidden features** (undocumented long-press settings, including a
+soft-mute threshold adjustment) are the community's workaround. Which hidden
+features your unit has depends on its firmware version (8820 is a known good
+one) — the **firmware lottery** is real, and two PL-880s bought a year apart
+can behave differently. The hidden sync mode is widely judged not worth using;
+MW performance is good rather than great. None of these are dealbreakers at
+the price; all of them are worth knowing before you compare it to a radio
+$100 cheaper on a store shelf.
+
+The standing category truths apply: **listening is license-free everywhere in
+the US — no FCC anything, ever** — and the PL-880's external SW antenna jack
+is the most important feature on it, because **$20 of wire out a window
+improves shortwave reception more than a $200 radio upgrade**. The 2026 bands
+are quieter than the brochure-era ones (VOA's shortwave was gutted in 2025;
+the BBC left North America long ago), but state broadcasters, US private
+stations, pirates, time stations, and ham SSB keep an SSB-capable radio like
+this one busy — see [shortwave broadcasting](/reference/shortwave-broadcast/)
+for the landscape.
+
+## Bands, modes &amp; features
+
+- **Coverage:** LW, MW, SW 1711–29999 kHz continuous, FM 64–108 MHz.
+- **SSB:** USB/LSB with 10 Hz fine-tune steps and five selectable bandwidths —
+  among the nicest SSB tuning on any portable.
+- **Bandwidths:** 4 AM / 5 SSB, DSP-filtered.
+- **Memories:** 3050 with ETM auto-store.
+- **Power:** single 18650 Li-ion, USB charging.
+- **Connections:** SW external antenna jack, line-out. No Bluetooth, no
+  recording — the [PL-990](/reference/tecsun-pl-990/) adds those.
+- **Size:** large portable, ~7.75 × 4.15 × 1.45 in.
+
+## GopherTrunk alternative
+
+Shortwave is HF AM/SSB, which is not GopherTrunk's trunking/digital domain —
+GopherTrunk does not decode it. If you'd rather explore the same spectrum on a
+computer, an HF-capable SDR ([best HF SDR](/best-hf-sdr/)) or a ~$30
+[RTL-SDR](/reference/rtl-sdr/) in direct-sampling mode gives you a
+[waterfall](/reference/waterfall-display/) of the whole band and one-click
+recording — things no portable can do. GopherTrunk itself stays in its
+VHF/UHF scanner lane; it just shares the philosophy: listen first, free. The
+PL-880 is the other answer — no computer, no software, superb audio from a
+windowsill.
+
+## Who it's for
+
+- **Buy the PL-880** if audio quality and SSB tuning feel matter more to you
+  than the last word in RF architecture — it's the listening-pleasure pick of
+  the roster.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B00GJ51NVA?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [PL-990](/reference/tecsun-pl-990/)** instead for triple
+  conversion, Bluetooth/microSD and the refined flagship package, or the
+  [XHDATA D-808](/reference/xhdata-d-808/) if you want SSB plus airband for
+  half the money.
+- **Skip it** for the [PL-330](/reference/tecsun-pl-330/) if you want a
+  pocketable SSB starter at ~$70 — you can always trade up. Full rankings:
+  [best shortwave radios](/best-shortwave-radios/).
+
+## Sources
+
+[^tecsun]: [Tecsun PL-880 product page](https://www.tecsun-radios.com/product/pl880-radio-receiver/) — coverage, dual-conversion + DSP architecture, bandwidth counts, memories, and 18650 power.
+[^n9ewo]: [Tecsun PL-880 review — N9EWO](https://www.qsl.net/n9ewo/pl880.html) — long-term evaluation: audio quality, soft-mute and hidden-feature behavior, firmware variance, MW performance, and hidden-sync assessment; owner consensus corroborated by [eHam reviews](https://www.eham.net/reviews/detail/11457).

--- a/docs/reference/tecsun-pl-990.md
+++ b/docs/reference/tecsun-pl-990.md
@@ -1,0 +1,153 @@
+---
+slug: tecsun-pl-990
+title: Tecsun PL-990
+entry_type: hardware
+category: shortwave-radios
+description: "The Tecsun PL-990 is the current flagship portable shortwave radio — triple-conversion LW/MW/SW/FM coverage, real SSB with 10 Hz tuning, 3150 memories, 18650 power, and Bluetooth/microSD playback for around $225–270."
+keywords: Tecsun PL-990 review, Tecsun PL-990x, best shortwave radio 2026, portable shortwave radio, shortwave radio with SSB, Tecsun flagship portable, PL-990 vs PL-880, is shortwave radio still worth it, shortwave receiver, worldband radio
+aka: [PL-990, PL-990x, Tecsun PL990]
+autolink: true
+affiliate: true
+product:
+  name: "Tecsun PL-990"
+  brand: Tecsun
+  category: Portable shortwave receiver
+  lowPrice: "225"
+  highPrice: "270"
+  url: https://www.amazon.com/dp/B08KL77Q4H?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: "Portable shortwave receiver (triple conversion + DSP)" }
+  - { label: Bands, value: "LW 100–519 kHz / MW 520–1710 kHz / SW 1711–29999 kHz / FM 64–108 MHz" }
+  - { label: SSB, value: "Yes — USB/LSB with 10 Hz fine tuning; no sync detector" }
+  - { label: Power, value: "18650 Li-ion, USB charging" }
+  - { label: License, value: "None — receiver" }
+  - { label: Price, value: "around $225–270" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B08KL77Q4H?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [tecsun-pl-880, sangean-ats-909x2, tecsun-pl-330, sony-icf-sw7600gr, shortwave-broadcast, single-sideband]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "Best shortwave radios", url: /best-shortwave-radios/ }
+cite_urls:
+  - https://www.tecsun-radios.com/product/pl990x-radio-receiver/
+  - https://radiojayallen.com/tecsun-pl-990x-am-sw-lw-mp-bluetooth-mp3-player/
+  - https://swling.com/blog/2025/03/usagm-shutdowns-a-roundup-of-reports-and-reactions/
+faq:
+  - q: "Is the Tecsun PL-990 the best portable shortwave radio?"
+    a: "For most buyers in 2026, yes — it's our best-overall pick. Triple-conversion RF, the best audio of any current Tecsun, real SSB with 10 Hz steps, and 3150 memories make it the most complete current-production portable. If $250 is too steep, the PL-880 gives up surprisingly little for around $100 less."
+  - q: "Does the Tecsun PL-990 have SSB?"
+    a: "Yes — upper and lower sideband with 10 Hz fine tuning, which makes ham nets, utility traffic, and marine/aero HF listenable. It does not have an official synchronous detector; early units hid an unofficial sync mode of debatable quality, so don't buy it for sync."
+  - q: "What's the difference between the PL-990 and PL-990x?"
+    a: "The PL-990x is the export version sold by Anon-Co with minor firmware differences; the US Kaito-distributed PL990 is the same radio. Performance is equivalent — buy on price and warranty, not the suffix."
+  - q: "Is shortwave radio still worth it in 2026?"
+    a: "Yes, with honest expectations. VOA's shortwave operations were gutted in 2025 and the BBC left North American shortwave decades ago, but state broadcasters, US private/religious stations, pirates, time stations, utility traffic, and ham SSB keep the bands alive. SSB radios like the PL-990 hear the most of what remains."
+  - q: "Do I need a license to listen to shortwave?"
+    a: "No. Listening is license-free everywhere in the US — no FCC anything, ever. Only transmitting requires a license, and the PL-990 is a receiver only."
+---
+**The Tecsun PL-990** is the flagship of the current portable shortwave world:
+a triple-conversion receiver (analog high-IF plus DSP), real
+[SSB](/reference/single-sideband/) with 10 Hz fine tuning, 3150 memories, and
+the best speaker audio Tecsun has ever put in a portable — plus a Bluetooth
+speaker mode and microSD MP3 playback for the hotel room.[^tecsun] At around
+**$225–270** it is the radio the rest of this category gets measured against.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B08KL77Q4H?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Best overall portable shortwave radio in 2026.** Triple conversion, real SSB
+with 10 Hz steps, 3150 memories, 18650 power, and the best-sounding speaker in
+a current Tecsun. **No official sync detector** — don't buy it expecting one.
+**~$225–270.** Listening is **license-free** — and on shortwave, $20 of wire
+out a window will improve it more than any radio upgrade. Where it ranks:
+[best shortwave radios](/best-shortwave-radios/).
+</div>
+
+## Overview
+
+The PL-990 (and its export twin, the PL-990x sold by Anon-Co) is what Tecsun's
+two decades of portable-building add up to. The receiver is **triple
+conversion** — an analog high first IF ahead of the DSP — which buys image
+rejection and overload resistance that single-chip DSP portables can't match.
+The tuning system is the most refined in the line: a proper weighted main
+knob, a separate fine-tune knob, 10 Hz resolution in SSB, and 3150 memories
+with ETM auto-store. The speaker is the other headline: reviewers consistently
+call it the best-sounding current Tecsun, and it doubles as a **Bluetooth
+speaker** with **microSD MP3 playback** (playback only — it does not
+record).[^rja]
+
+Two honesty notes before the checkout button. First, there is **no official
+synchronous detector**: early units carried a hidden, unofficial sync mode of
+debatable quality, and Tecsun does not spec one — if sync matters to you, that
+is what the used [Sony ICF-SW7600GR](/reference/sony-icf-sw7600gr/) and
+[Tecsun PL-660](/reference/tecsun-pl-660/) are for. Second, Tecsun's
+long-running quirks persist at flagship price: **soft-mute** behavior on weak,
+fading signals still annoys some listeners (much improved over older firmware,
+not gone), and the **firmware lottery** — units shipping with different hidden
+features depending on production run — is a recurring Tecsun theme the
+community documents better than the factory does.
+
+And the standing truth of this whole category: **listening is license-free
+everywhere in the US — no FCC anything, ever** — and on the HF bands, a $20
+wire antenna run out a window improves reception more than a $200 radio
+upgrade. The PL-990 has a 3.5 mm external antenna jack precisely so you can
+prove that to yourself.
+
+## What's still on the bands
+
+Buy any 2026 shortwave radio with open eyes: VOA's shortwave infrastructure
+was largely shut down in March 2025 (litigation has kept its status fluid),
+and the BBC abandoned North American shortwave back in 2001.[^swling] What
+remains is real but quieter than the hobby's heyday — Chinese, Romanian,
+Turkish, Cuban and religious broadcasters, big US private stations (WRMI,
+WWCR), pirates, time stations, and the non-broadcast draw that increasingly
+carries the hobby: **ham SSB, CW, and utility traffic**. That last group is
+why the PL-990's excellent SSB matters more now than ever, and why it also
+moonlights as a strong MW/FM DX machine.
+
+## Bands, modes &amp; features
+
+- **Coverage:** LW 100–519 kHz, MW 520–1710 kHz, SW 1711–29999 kHz continuous,
+  FM 64–108 MHz.
+- **SSB:** USB/LSB with 10 Hz fine tuning — ham nets, utility, marine/aero HF.
+- **Receiver:** triple conversion (analog high IF + DSP), multiple selectable
+  bandwidths.
+- **Memories:** 3150 with ETM+ auto-tuning storage.
+- **Power:** single 18650 Li-ion, USB charging.
+- **Extras:** Bluetooth speaker mode, microSD MP3 playback (no recording),
+  3.5 mm external antenna jack, line audio out.
+- **Size:** large portable, about 7.9 × 5.6 × 1.7 in — a desk radio you can
+  pack, not a shirt-pocket travel set (that's the
+  [CC Skywave SSB 2](/reference/cc-skywave-ssb-2/)).
+
+## GopherTrunk alternative
+
+Shortwave is HF AM/SSB — not GopherTrunk's trunking/digital territory, and
+GopherTrunk does not decode it. The modern computer-side way to explore the
+same spectrum is an HF-capable SDR (see [best HF SDR](/best-hf-sdr/)) or a
+~$30 [RTL-SDR](/reference/rtl-sdr/) in direct-sampling mode: you get a
+[waterfall](/reference/waterfall-display/) view of the whole band that no
+portable can draw, and recording is a mouse click. GopherTrunk itself stays in
+its VHF/UHF scanner lane — same listen-first philosophy, free — while the
+PL-990's case is the opposite one: no computer, no power cord, just a radio on
+a windowsill.
+
+## Who it's for
+
+- **Buy the PL-990** if you want the best current-production portable and
+  you'll actually use SSB — it's our best-overall pick, with the audio and
+  ergonomics to be the radio you reach for daily.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B08KL77Q4H?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [PL-880](/reference/tecsun-pl-880/)** instead if ~$100 in savings
+  matters more than the last 10% of refinement, or the
+  [Sangean ATS-909X2](/reference/sangean-ats-909x2/) if you want airband and
+  class-leading FM in the same price bracket.
+- **Skip it** for a [PL-330](/reference/tecsun-pl-330/) (~$70, most of the SSB
+  capability, a third the price) if you're not sure the hobby will stick.
+  Full rankings: [best shortwave radios](/best-shortwave-radios/).
+
+## Sources
+
+[^tecsun]: [Tecsun PL-990x product page](https://www.tecsun-radios.com/product/pl990x-radio-receiver/) — coverage, triple-conversion architecture, SSB fine tuning, memory count, 18650 power, and Bluetooth/microSD playback.
+[^rja]: [Tecsun PL-990x review — RadioJayAllen](https://radiojayallen.com/tecsun-pl-990x-am-sw-lw-mp-bluetooth-mp3-player/) — audio quality, ergonomics, and comparative standing among current portables.
+[^swling]: [USAGM shutdowns: a roundup — SWLing Post](https://swling.com/blog/2025/03/usagm-shutdowns-a-roundup-of-reports-and-reactions/) — the March 2025 VOA/USAGM shortwave shutdowns and their contested aftermath.

--- a/docs/reference/xhdata-d-808.md
+++ b/docs/reference/xhdata-d-808.md
@@ -1,0 +1,142 @@
+---
+slug: xhdata-d-808
+title: XHDATA D-808
+entry_type: hardware
+category: shortwave-radios
+description: "The XHDATA D-808 is the bang-for-buck king of shortwave portables — SSB, VHF air band, FM with RDS, and near-flagship sensitivity for around $70–90. Know the 2023 board revision and the Sihuadon rebrand before you buy."
+keywords: XHDATA D-808 review, Sihuadon D-808, best shortwave radio under 100, D-808 vs PL-330, shortwave radio with SSB and air band, XHDATA D-808 2023 version, budget shortwave radio 2026, portable SSB receiver, D-808 USB-C, is shortwave radio still worth it
+aka: [D-808, Sihuadon D-808, XHDATA D808]
+autolink: true
+affiliate: true
+product:
+  name: "XHDATA D-808"
+  brand: XHDATA
+  category: Portable shortwave receiver (compact)
+  lowPrice: "70"
+  highPrice: "90"
+  url: https://www.amazon.com/dp/B0BL266J33?tag=gophertrunk-20
+infobox:
+  - { label: Type, value: "Compact DSP shortwave receiver (SiLabs 4735)" }
+  - { label: Bands, value: "LW 153–513 kHz / MW / SW 1711–29999 kHz / FM 64–108 (RDS) / Air 118–137 MHz" }
+  - { label: SSB, value: "Yes — USB/LSB; no sync detector" }
+  - { label: Power, value: "2000 mAh 18650, USB charge (USB-C on 2023 revision)" }
+  - { label: License, value: "None — receiver" }
+  - { label: Price, value: "around $70–90" }
+  - { label: Buy, value: "<a class=\"btn btn--buy\" href=\"https://www.amazon.com/dp/B0BL266J33?tag=gophertrunk-20\" rel=\"nofollow sponsored noopener\">View on Amazon &rarr;</a>" }
+see_also: [tecsun-pl-330, qodosen-dx-286, cc-skywave-ssb-2, tecsun-pl-660, shortwave-broadcast, single-sideband]
+related_lessons:
+  - { title: "Learn RF & SDR", url: /learn/rf-sdr/ }
+related_reading:
+  - { title: "Best shortwave radios", url: /best-shortwave-radios/ }
+cite_urls:
+  - https://www.xhdata.com.cn/products/d-808-radio
+  - https://radiojayallen.com/xhtata-d-808-am-fm-sw-ssb-airband-portable-radio/
+  - https://www.eham.net/reviews/view-product?id=15715
+faq:
+  - q: "Is the XHDATA D-808 worth it in 2026?"
+    a: "Yes — it's our best-features-for-the-price pick. Around $70–90 buys SSB, a VHF air band, FM with RDS, LW, an external antenna jack, and sensitivity the community long compared to the Tecsun PL-660 class. Nothing else bundles that list at the price."
+  - q: "What changed in the 2023 XHDATA D-808 revision?"
+    a: "A board revision moved to chip inductors and USB-C charging; users report the new version is quieter and less loud than the original. Same feature set. You generally can't pick your revision at checkout — it's part of the brand/revision lottery on this model."
+  - q: "Is the Sihuadon D-808 the same radio as the XHDATA D-808?"
+    a: "Yes — same maker, different brand label, with minor cosmetic and port/backlight differences between production runs. 'Which D-808 will I get' is a fair question; buy from a high-turnover seller and check the listing photos for USB-C if that matters to you."
+  - q: "Does the D-808 have SSB and air band?"
+    a: "Both — USB/LSB on shortwave plus VHF air 118–137 MHz, which is the combination that made its reputation. No synchronous detector and no NOAA weather band (the CC Skywave SSB 2 adds weather alerts at about twice the price)."
+  - q: "Do I need a license to use a D-808?"
+    a: "No — it's a receiver, and listening is license-free everywhere in the US, no FCC anything, ever. Spend the license money you don't need on $20 of wire antenna instead; it will do more for shortwave reception than any radio upgrade."
+---
+**The XHDATA D-808** has been the bang-for-buck king of shortwave portables
+for years, and 2026 hasn't changed that: around **$70–90** buys
+[SSB](/reference/single-sideband/), a **VHF air band**, FM with RDS, longwave,
+an external antenna jack, and weak-signal sensitivity the community long
+compared to radios costing twice as much.[^xhdata] The catch isn't
+performance — it's the **revision-and-rebrand lottery**: 2023-revision boards
+and Sihuadon-labeled units differ in ports, backlight, and audio character.
+
+<a class="btn btn--buy" href="https://www.amazon.com/dp/B0BL266J33?tag=gophertrunk-20" rel="nofollow sponsored noopener">Check price on Amazon &rarr;</a>
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Best features for the price in the whole roster.** SSB + airband + RDS + LW
++ antenna jack under $90, with near-flagship sensitivity. **Know the lottery:**
+the 2023 board revision (chip inductors, USB-C) is reported quieter/less loud
+than the original, and the same radio ships as XHDATA or Sihuadon. No sync,
+no weather band, mushy buttons. **License-free listening**; a $20 wire out the
+window is the real upgrade. Where it ranks:
+[best shortwave radios](/best-shortwave-radios/).
+</div>
+
+## Overview
+
+The D-808 is built around the SiLabs 4735 DSP chip, and it extracts more from
+that silicon than almost anyone else has: reviewers spent years measuring it
+against the beloved [Tecsun PL-660](/reference/tecsun-pl-660/) on weak-signal
+shortwave and calling it competitive — from a radio that cost half as much.
+The filter set is unusually deep for the price ("number of filters amazing,"
+as one eHam reviewer put it), the 18650 battery runs for ages on USB
+charging, and the feature list — SSB, air band 118–137 MHz, RDS on FM, LW —
+reads like a radio twice its price.[^eham]
+
+What you give up: the buttons are mushy, some units show a slight SSB warble,
+there's no sync detector, and the speaker is serviceable rather than good.
+And then there's the **which-one-will-I-get question**, which is genuine on
+this model. Around 2023 the board was revised — chip inductors, USB-C
+charging instead of micro-USB — and users report the new version is quieter
+and less loud than the original.[^rja] The same radio also ships under the
+maker's **Sihuadon** brand with backlight and port differences between runs.
+None of these variants is bad; you just can't fully choose at checkout, so
+buy from a high-turnover seller and read the listing photos.
+
+The category constants apply with extra force at this price: **listening is
+license-free everywhere in the US — no FCC anything, ever** — and the
+D-808's antenna jack is your best friend, because **$20 of wire out a window
+improves shortwave reception more than a $200 radio upgrade**. The 2026 bands
+are leaner than the hobby's heyday (VOA's shortwave was gutted in 2025), but
+state broadcasters, US private stations, pirates, time stations, and ham SSB
+give an $80 SSB radio plenty to chew on — and the airband gives it a second
+career at the airport fence.
+
+## Bands, modes &amp; features
+
+- **Coverage:** LW 153–513 kHz, MW, SW 1711–29999 kHz, FM 64–108 MHz with
+  RDS, **VHF air 118–137 MHz**.
+- **SSB:** USB/LSB. No sync detector, no NOAA weather band.
+- **Receiver:** SiLabs 4735 DSP, unusually deep bandwidth/filter options for
+  the class.
+- **Memories:** 500.
+- **Power:** 2000 mAh 18650, USB charging — USB-C on the 2023 revision,
+  micro-USB earlier.
+- **Connections:** external antenna jack.
+- **Variants:** XHDATA and Sihuadon labels; pre/post-2023 boards. Avoid the
+  bundle listings (walkie-talkie combos) — buy the radio alone.
+
+## GopherTrunk alternative
+
+Shortwave is HF AM/SSB — outside GopherTrunk's trunking/digital domain, and
+GopherTrunk does not decode it. At D-808 money the computer-side comparison is
+direct: a ~$30 [RTL-SDR](/reference/rtl-sdr/) in direct-sampling mode tunes
+the same HF spectrum with a [waterfall](/reference/waterfall-display/) no
+portable can draw, and a dedicated HF SDR ([best HF SDR](/best-hf-sdr/)) does
+it properly. GopherTrunk itself stays in its VHF/UHF scanner lane — same
+listen-first philosophy, free — and for the D-808's airband specifically, an
+SDR plus [local frequencies](/scanner-frequencies/) is the deeper monitoring
+tool.
+
+## Who it's for
+
+- **Buy the D-808** if you want the most radio per dollar in the category —
+  SSB, airband, and RDS under $90 makes it the default recommendation for a
+  capable first shortwave radio.
+  <a class="btn btn--buy" href="https://www.amazon.com/dp/B0BL266J33?tag=gophertrunk-20" rel="nofollow sponsored noopener">View on Amazon &rarr;</a>
+- **Buy the [Tecsun PL-330](/reference/tecsun-pl-330/)** instead for finer
+  SSB tuning (10 Hz steps) and ETM+ in a smaller package, or the
+  [CC Skywave SSB 2](/reference/cc-skywave-ssb-2/) if you also want NOAA
+  weather alerts and AA power for travel/preparedness.
+- **Skip it** for the [Qodosen DX-286](/reference/qodosen-dx-286/) only if raw
+  broadcast sensitivity is everything and you'll never use SSB — the DX-286
+  has none. Full rankings: [best shortwave radios](/best-shortwave-radios/).
+
+## Sources
+
+[^xhdata]: [XHDATA D-808 product page](https://www.xhdata.com.cn/products/d-808-radio) — coverage, SSB, air band, DSP chip, battery, and current-production status.
+[^rja]: [XHDATA D-808 review — RadioJayAllen](https://radiojayallen.com/xhtata-d-808-am-fm-sw-ssb-airband-portable-radio/) — the 2023 board revision (chip inductors, USB-C) and reported audio/loudness change, plus performance assessment.
+[^eham]: [XHDATA D-808 owner reviews — eHam](https://www.eham.net/reviews/view-product?id=15715) — owner consensus on sensitivity, filters, and value; gripes on button feel and SSB warble.


### PR DESCRIPTION
## Summary

Third round in the buyer's-guide series (ham #1116, two-way #1117): adds the top-10 treatment for shortwave listening — portable receivers, emergency crank/solar radios, and desktop/classic tabletop receivers — 3 guides plus a Field Guide page for every radio, with the shared six-criteria rubric adapted for receivers (no license angle: these are listen-only).

## Changes

- Three top-10 guides: `/best-shortwave-radios/`, `/best-emergency-radios/`, `/best-desktop-shortwave-receivers/` — house structure with per-category picks; the desktop list deliberately inverts the aftermarket ratio (8 eBay-only classics like the Drake R8B and Icom IC-R75, plus the Icom IC-R8600 and Eton Elite 750 as the two current-production entries), framed honestly as a category SDRs ended.
- 30 product pages under `docs/reference/` in a new `shortwave-radios` category, including full used-buying checklists on every classic (R8B encoder/PSU caps, R-5000 "dot problem", ICF-2010 front-end FET test, Eton sticky-coating remedy, etc.).
- Honesty mandates carried throughout: the 2026 state of shortwave broadcasting stated up front (hedged, sourced); SAME-vs-1050 Hz tone-alert distinction and measured crank runtimes on every emergency page (no model in the roster does SAME decoding); SSB capability stated per model (the Qodosen DX-286 has none); no fantasy range/runtime claims.
- Link rules unchanged: research-confirmed ASINs with `tag=gophertrunk-20` (tagged search URLs where no ASIN confirmed), untagged eBay search links only for the 10 models Amazon doesn't carry, `UsedCondition`/eBay-seller Product JSON-LD on used gear.
- Registration: `_data/reference.yml` category + 30 entries, `_data/nav.yml` "Shortwave & emergency" heading, `docs/llms.txt` section.

## Test plan

- [x] Local Jekyll build + both docs CI scripts pass on the final tree: `check_site_pages.py` and `check_internal_links.py` (435,498 internal links, all resolve)
- [x] Source-level checks: Amazon tag + `rel="nofollow sponsored noopener"` on every Amazon href; eBay hrefs untagged with `rel="nofollow noopener"`; reference.yml ↔ page bijection; 5-pair FAQ per page; no star ratings/aggregateRating
- [x] Rendered Product JSON-LD spot-validated (UsedCondition/eBay seller on classics)
- [ ] `make vet test` — n/a (docs-only change)
- [ ] `make integration` — n/a
- [ ] Hardware smoke test — n/a

## Breaking changes

none

## Docs / CHANGELOG

- [ ] CHANGELOG bullet — n/a (site content, not the application)
- [x] `docs/` updated (this PR is entirely docs-site content)

## Linked issues

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P4WkHNzqEqLWZzzmCvsiJ1

---
_Generated by [Claude Code](https://claude.ai/code/session_01P4WkHNzqEqLWZzzmCvsiJ1)_