### PR TITLE
web: fix Events ordering and call-recording playback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -346,6 +346,38 @@ confirmation before any close-as-completed.
       `GT_TETRA_DMO_SCAN=1` + the same MCC/MNC to see whether a colour now dominates). If a colour
       dominates with MNI 250/1 where none did at MNI 0, that is the confirmation; if it still doesn't,
       the next suspect is the MNI value itself or DNB geometry — NOT encryption (the radios are TEA0).
+  8. **20aug on-air run — "bogus DMO recordings that end at a timeout, not PTT release" is DIAGNOSED to
+      the composer voice chain, NOT the control pipeline.** The operator's `dmo_test_20aug` run (X310,
+      MRC on / single antenna / no cavity — their own caveat: a poor vector) shows the two DMO decode
+      paths disagree sharply, and the recording symptom is a second-order effect of the voice chain's
+      colour handling — pinned by the run's `debug.log`:
+      - The control **pipeline** (`newTETRADMOPipeline`) decodes fine: locks, `RecoverDMColourCode`
+        → **colour 39**, and `tch_crc` climbs to ~200 CRC-valid TCH/S across one PTT window.
+      - The separate composer **voice chain** (`runTETRADMOVoiceChain`) produced a **silent** recording
+        for that same PTT: grant fired at `colour_hint=0` (before the pipeline finished recovery), the
+        chain buffered 242 DNBs, its buffer hit `dmoVoiceColourMax=120` and the give-up path fell back
+        to **colour 0** (`d.colour = d.baseMNI`) BEFORE it ever adopted the pipeline's 39 — so all 242
+        DNBs decoded as **BFI**, `speech_frames=0 colour_recovered=false`. `tryAdoptLiveColour` never
+        cleared afterward either: its local re-verification (≥2 CRC-valid at the hinted colour on the
+        chain's OWN bursts) kept failing even though the pipeline's bursts decode at 39 — i.e. the voice
+        chain's receiver is producing bursts the pipeline's is not. Prime suspect for the divergence:
+        the voice chain runs `EnableDCBlock: true` while the CC pipeline runs it **off** (`receiver.go`
+        / the CC-path note above) — try `EnableDCBlock:false` in `tetra_dmo_voice.go` and A/B.
+      - **Why it "ends at a timeout":** zero real speech frames ⇒ `boundaryTracker.onVoice` is never
+        called ⇒ the call is torn down by hangtime as `reason=timeout` (~7 s) instead of at PTT release.
+        DMO decodes no explicit release PDU, so even a GOOD DMO call ends on hangtime — but a decoding
+        call keeps refreshing liveness and runs to the real tail; a BFI-only call dies at the first
+        hangtime. So the fix for BOTH the bogus audio and the early cut is the same: make the voice
+        chain actually decode (adopt the pipeline's colour instead of falling back to 0 / re-verifying
+        with a divergent receiver).
+      - **Not fixed this round (on-air-gated, #764/#771):** the calls that started AFTER the pipeline
+        knew the colour (`colour_hint=39`) yielded only 2–4 speech frames, but the pipeline decoded ~0
+        new `tch_crc` in those same windows too — weak for BOTH paths on this contaminated capture, so
+        they don't isolate a voice-chain bug. Needs a clean, known-colour, actually-talking DMO capture
+        (single antenna, MRC OFF, cavity filter) to A/B a voice-chain fix. The web-side symptom (a
+        silent ~0.1 s WAV still published to History) is inherent: the recorder only drops `dataBytes==0`
+        or `StatProvider` zero-voice calls, and ACELP is neither, so a 2-frame call becomes a tiny
+        bogus row. Staged, not shipped.
 - **TETRA individual/private-call SRC is restored across mid-call PDUs via a callID→source
   binding; cold-start group-vs-individual classification stays capture-gated.** ETSI compresses
   the SSIs out of mid-call and traffic-channel signalling (§14): once a call is set up, a

--- a/web/src/components/RecordingPlayer.test.tsx
+++ b/web/src/components/RecordingPlayer.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { RecordingPlayer } from "./RecordingPlayer";
+
+const cfg = { baseURL: "http://localhost:8080", token: null };
+
+describe("RecordingPlayer", () => {
+  beforeEach(() => {
+    // jsdom lacks the object-URL APIs; stub them so the component can run.
+    vi.stubGlobal("URL", {
+      ...URL,
+      createObjectURL: vi.fn(() => "blob:mock-url"),
+      revokeObjectURL: vi.fn(),
+    });
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("fetches the recording with the bearer token and plays the blob", async () => {
+    const blob = new Blob([new Uint8Array([1, 2, 3])], { type: "audio/wav" });
+    // A minimal Response stand-in: jsdom's real Response.blob() is unreliable,
+    // and the component only touches ok/status/blob().
+    const fetchMock = vi.fn(
+      async (_url: string, _init?: RequestInit) =>
+        ({ ok: true, status: 200, blob: async () => blob }) as unknown as Response,
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <RecordingPlayer cfg={{ baseURL: "http://localhost:8080", token: "sekret" }} callId={5202} />,
+    );
+
+    await waitFor(() =>
+      expect(document.querySelector("audio")).toBeInTheDocument(),
+    );
+    // The <audio> plays the object URL, never the raw API URL — so a media
+    // element quirk / missing auth header can't silently kill playback.
+    expect(document.querySelector("audio")?.getAttribute("src")).toBe(
+      "blob:mock-url",
+    );
+    // The fetch carried the Authorization header the bare element can't.
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("http://localhost:8080/api/v1/calls/5202/audio");
+    expect(init?.headers).toMatchObject({
+      Authorization: "Bearer sekret",
+    });
+  });
+
+  it("shows a visible message instead of a dead player when the recording is gone", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          ({
+            ok: false,
+            status: 404,
+            blob: async () => new Blob(),
+          }) as unknown as Response,
+      ),
+    );
+
+    render(<RecordingPlayer cfg={cfg} callId={9} />);
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(/unavailable/i),
+    );
+    expect(document.querySelector("audio")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/RecordingPlayer.tsx
+++ b/web/src/components/RecordingPlayer.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useRef, useState } from "react";
+import type { ClientConfig } from "../api/client";
+
+// RecordingPlayer plays back one finished call's recording.
+//
+// It deliberately does NOT point a bare <audio src> at the API URL. That is the
+// same failure #598 documents for the live stream: a media element pointed at
+// the daemon endpoint can fail silently in Chrome (the operator sees a dead
+// "0:00 / 0:00" player and no playback), and — on an auth-gated daemon — a bare
+// <audio>/<a download> cannot attach the Authorization header, so both 401 with
+// no visible error. Instead we fetch the finite recording through fetch() (which
+// carries the bearer token), materialise it as an object URL, and hand THAT to
+// the <audio> element. The whole file is small (seconds of 8 kHz mono PCM), so a
+// one-shot fetch is cheap and sidesteps every range/streaming quirk; a failed
+// fetch surfaces as a visible message rather than a silent dead player.
+export function RecordingPlayer({
+  cfg,
+  callId,
+}: {
+  cfg: ClientConfig;
+  callId: number;
+}) {
+  const [objURL, setObjURL] = useState<string | null>(null);
+  const [ext, setExt] = useState<"wav" | "mp3">("wav");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  // Track the current object URL so the cleanup revokes exactly what is live,
+  // even across a callId change that starts a second fetch.
+  const urlRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    const controller = new AbortController();
+    const headers: Record<string, string> = {};
+    if (cfg.token) headers["Authorization"] = `Bearer ${cfg.token}`;
+
+    fetch(`${cfg.baseURL}/api/v1/calls/${callId}/audio`, {
+      headers,
+      credentials: "include",
+      signal: controller.signal,
+    })
+      .then(async (res) => {
+        if (!res.ok) {
+          throw new Error(
+            res.status === 404
+              ? "recording is unavailable (it may have been swept by retention)"
+              : `recording request failed (${res.status})`,
+          );
+        }
+        const blob = await res.blob();
+        if (cancelled) return;
+        const url = URL.createObjectURL(blob);
+        urlRef.current = url;
+        setExt(blob.type === "audio/mpeg" ? "mp3" : "wav");
+        setObjURL(url);
+        setLoading(false);
+      })
+      .catch((e: unknown) => {
+        if (cancelled || (e instanceof DOMException && e.name === "AbortError"))
+          return;
+        setError(e instanceof Error ? e.message : "recording failed to load");
+        setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+      if (urlRef.current) {
+        URL.revokeObjectURL(urlRef.current);
+        urlRef.current = null;
+      }
+    };
+  }, [cfg, callId]);
+
+  if (error) {
+    return (
+      <p className="text-xs text-err" role="alert">
+        {error}
+      </p>
+    );
+  }
+  if (loading || !objURL) {
+    return <p className="text-xs text-muted">Loading recording…</p>;
+  }
+  return (
+    <>
+      <audio controls preload="metadata" className="w-full" src={objURL} />
+      <a
+        className="inline-block text-xs text-accent hover:underline mt-1"
+        href={objURL}
+        download={`call-${callId}.${ext}`}
+      >
+        Download recording
+      </a>
+    </>
+  );
+}

--- a/web/src/panels/Events.test.tsx
+++ b/web/src/panels/Events.test.tsx
@@ -56,6 +56,24 @@ describe("Events panel", () => {
     expect(screen.getByRole("button", { name: "Pause" })).toBeInTheDocument();
   });
 
+  it("orders rows by event timestamp, not store arrival order", () => {
+    // Regression: an event that ARRIVES late but carries an older wall-clock
+    // timestamp (e.g. an audio.state re-pushed on a state change) used to float
+    // to the top because the panel reverse()d the store's arrival order. It must
+    // sort below the newer-timestamped events instead ("13:54 above 16:34" bug).
+    const newer: EventDTO = { kind: "call.release", timestamp: "2026-08-20T16:34:15Z", payload: { g: 1 } };
+    const staleLateArrival: EventDTO = { kind: "audio.state", timestamp: "2026-08-20T13:54:57Z", payload: { backend_enabled: false } };
+    // Arrival order in the store: the stale-timestamp event arrives LAST.
+    setStore([newer, staleLateArrival]);
+    render(<Events />);
+
+    const kinds = screen
+      .getAllByText(/call\.release|audio\.state/)
+      .map((el) => el.textContent);
+    expect(kinds[0]).toBe("call.release"); // newest timestamp on top
+    expect(kinds[1]).toBe("audio.state"); // stale timestamp sinks below
+  });
+
   it("keeps a manual pause when an expanded event is collapsed", async () => {
     const user = userEvent.setup();
     render(<Events />);

--- a/web/src/panels/Events.tsx
+++ b/web/src/panels/Events.tsx
@@ -27,11 +27,18 @@ export function Events() {
   // when running, mirror the live store ring.
   const visible = paused ? (snapshot ?? events) : events;
 
-  // Group identical events (when enabled), then newest (most-recently-active)
-  // first — reverse so the latest is at the top, the mobile-friendly read order.
-  // Search is applied by the DataTable on top of the grouped rows.
+  // Group identical events (when enabled) into representative rows. Ordering is
+  // NOT done here: the DataTable owns it, defaulting to the "ts" column sorted
+  // descending (newest first) below. Relying on the store's arrival order and a
+  // .reverse() was the "13:54 shown above 16:34" bug — a re-emitted or late
+  // event (e.g. an audio.state pushed on a state change) lands at the end of the
+  // arrival ring but carries an older wall-clock timestamp, so reversing arrival
+  // order floated it to the top. Sorting on the representative timestamp instead
+  // keeps the view in true chronological order regardless of arrival order, and
+  // still puts a still-firing grouped event on top (its representative is the
+  // most-recent occurrence, so its timestamp == lastTimestamp).
   const ordered = useMemo<GroupedEvent[]>(() => {
-    const groups = grouped
+    return grouped
       ? groupEvents(visible)
       : visible.map((e) => ({
           event: e,
@@ -39,7 +46,6 @@ export function Events() {
           firstTimestamp: e.timestamp,
           lastTimestamp: e.timestamp,
         }));
-    return groups.slice().reverse();
   }, [visible, grouped]);
 
   const columns: Column<GroupedEvent>[] = useMemo(
@@ -150,6 +156,8 @@ export function Events() {
         rows={ordered}
         columns={columns}
         rowKey={(g, i) => `${contentKey(g.event)}-${i}`}
+        defaultSortKey="ts"
+        defaultSortDirection="desc"
         searchable
         searchAccessor={(g) =>
           `${g.event.kind} ${g.event.timestamp} ${JSON.stringify(g.event.payload ?? "")}`

--- a/web/src/panels/History.tsx
+++ b/web/src/panels/History.tsx
@@ -6,6 +6,7 @@ import { Column, DataTable } from "../components/DataTable";
 import { ConfirmModal } from "../components/ConfirmModal";
 import { DetailField, DetailModal } from "../components/DetailModal";
 import { RIDLink } from "../components/RIDLink";
+import { RecordingPlayer } from "../components/RecordingPlayer";
 import { CallHealth } from "../components/SignalHealth";
 import { PageHeader } from "../components/ui/PageHeader";
 import type { CallRow } from "../api/types";
@@ -432,19 +433,7 @@ export function History() {
               <p className="text-xs uppercase tracking-wider text-muted mb-1">
                 Recording
               </p>
-              <audio
-                controls
-                preload="none"
-                className="w-full"
-                src={`${cfg.baseURL}/api/v1/calls/${selected.id}/audio`}
-              />
-              <a
-                className="inline-block text-xs text-accent hover:underline mt-1"
-                href={`${cfg.baseURL}/api/v1/calls/${selected.id}/audio`}
-                download
-              >
-                Download recording
-              </a>
+              <RecordingPlayer cfg={cfg} callId={selected.id} />
             </div>
           )}
         </DetailModal>


### PR DESCRIPTION
Events tab: order rows by event timestamp instead of store arrival order.
The panel reverse()d the live ring, so an event that arrives late but
carries an older wall-clock timestamp (e.g. an audio.state re-pushed on a
state change) floated to the top — the operator's "13:54 shown above
16:34". Sort the grouped rows on their representative timestamp (newest
first by default), which stays chronological regardless of arrival order
and still keeps a still-firing grouped event on top.

History playback: replace the bare <audio src=API-URL> with a
RecordingPlayer that fetches the finite recording through fetch() into an
object URL and plays THAT. A media element pointed straight at the daemon
endpoint can fail silently in Chrome (the same class of failure #598
documents for the live stream) and, on an auth-gated daemon, can neither
attach the bearer token nor show why it 401'd — the operator just sees a
dead 0:00/0:00 player. The blob path carries the Authorization header,
loads the small file in one shot (sidestepping range/streaming quirks and
showing the real duration), and surfaces a failure as visible text.

Also records the 20aug DMO diagnosis in CLAUDE.md: the "bogus recordings
that end at a timeout" is the composer voice chain falling back to colour
0 (BFI-only) while the control pipeline decodes at the recovered colour;
staged, on-air-gated per #764/#771.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AaTZZrj29TarstFvQk2xcr