### PR TITLE
Open-issue review: Windows config path, observed-call reason, conventional talkgroup_id (#1120, #356, #1105)

### DIFF
--- a/internal/configbuilder/paths.go
+++ b/internal/configbuilder/paths.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/MattCheramie/GopherTrunk/internal/config"
 	"github.com/MattCheramie/GopherTrunk/internal/pathutil"
 )
 
@@ -18,10 +19,24 @@ func ExpandConfigPath(p string) string {
 
 // DefaultConfigPath picks a sensible default config.yaml location:
 //  1. $GOPHERTRUNK_CONFIG (the Windows installer sets this);
-//  2. ./config.yaml when the cwd is writable;
-//  3. <os.UserConfigDir()>/GopherTrunk/config.yaml otherwise.
+//  2. an existing config the daemon would auto-discover — so editing
+//     goes to the file actually in use;
+//  3. ./config.yaml when the cwd is writable;
+//  4. <os.UserConfigDir()>/GopherTrunk/config.yaml otherwise.
+//
+// Step 2 is what keeps `gophertrunk config` in sync with the daemon
+// (issue #1120). Without it the two disagree: on a fresh Windows
+// install the daemon discovers the installer-seeded
+// <Documents>\GopherTrunk\config\config.yaml, while this builder
+// defaulted straight to %APPDATA%\GopherTrunk\config.yaml — so a
+// freshly-built config was written somewhere the daemon never loaded
+// it. Reusing config.Discover here resolves the builder's default to
+// the same file the daemon reads on startup.
 func DefaultConfigPath() string {
 	if p := os.Getenv("GOPHERTRUNK_CONFIG"); p != "" {
+		return p
+	}
+	if p := config.Discover(); p != "" {
 		return p
 	}
 	if cwdWritable() {

--- a/internal/configbuilder/paths_test.go
+++ b/internal/configbuilder/paths_test.go
@@ -1,0 +1,83 @@
+package configbuilder
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// redirectUserDirs points os.UserConfigDir / os.UserHomeDir at a fresh
+// tempdir for the duration of the test, returning the tempdir. Mirrors
+// the helper in internal/config's discover_test so these builder tests
+// stay hermetic and cross-platform.
+func redirectUserDirs(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("APPDATA", dir)
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+	return dir
+}
+
+func mustWrite(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// TestDefaultConfigPath_HonorsEnvVar keeps the highest-precedence rule:
+// $GOPHERTRUNK_CONFIG wins verbatim, even over a discoverable config.
+func TestDefaultConfigPath_HonorsEnvVar(t *testing.T) {
+	redirectUserDirs(t)
+	want := filepath.Join(t.TempDir(), "explicit.yaml")
+	t.Setenv("GOPHERTRUNK_CONFIG", want)
+
+	if got := DefaultConfigPath(); got != want {
+		t.Errorf("DefaultConfigPath() = %q, want %q (env var must win)", got, want)
+	}
+}
+
+// TestDefaultConfigPath_PrefersDiscoveredConfig is the #1120 regression.
+// The daemon auto-discovers a config the installer seeded under the
+// data-root config/ subfolder (<Documents>\GopherTrunk\config on
+// Windows). The builder must default to that same file rather than a
+// second, un-loaded location — otherwise a freshly-built config lands
+// where the daemon never reads it.
+//
+// Fails against the old DefaultConfigPath (which skipped straight to the
+// cwd / UserConfigDir heuristic and returned a different path); passes
+// once Discover is consulted first.
+func TestDefaultConfigPath_PrefersDiscoveredConfig(t *testing.T) {
+	t.Setenv("GOPHERTRUNK_CONFIG", "")
+	home := redirectUserDirs(t)
+	// Run from a writable, config-free cwd so the old code's
+	// "./config.yaml when cwd is writable" branch would fire and
+	// produce a path that is NOT the discovered file.
+	t.Chdir(t.TempDir())
+
+	seeded := filepath.Join(home, "Documents", "GopherTrunk", "config", "config.yaml")
+	mustWrite(t, seeded, "log:\n")
+
+	got := DefaultConfigPath()
+	if got != seeded {
+		t.Errorf("DefaultConfigPath() = %q, want %q (must default to the config the daemon discovers)", got, seeded)
+	}
+}
+
+// TestDefaultConfigPath_FallsBackWhenNothingDiscovered keeps the
+// no-config behaviour: with nothing to discover and a writable cwd, the
+// builder still offers ./config.yaml as the create-here default.
+func TestDefaultConfigPath_FallsBackWhenNothingDiscovered(t *testing.T) {
+	t.Setenv("GOPHERTRUNK_CONFIG", "")
+	redirectUserDirs(t)
+	t.Chdir(t.TempDir())
+
+	if got := DefaultConfigPath(); got != "./config.yaml" {
+		t.Errorf("DefaultConfigPath() = %q, want %q (writable cwd, nothing discovered)", got, "./config.yaml")
+	}
+}


### PR DESCRIPTION
Three small, independent changes from an open-issue review, on one branch.

## Summary

1. **#1120 — Windows config file inconsistency.** `gophertrunk config` wrote to a location the daemon never loaded (`%APPDATA%\GopherTrunk\config.yaml` vs the installer-seeded `<Documents>\GopherTrunk\config\config.yaml`), so a freshly-built config had no effect.
2. **#356 — observed calls read as "no voice".** A voice grant the control channel announces but that no tuner follows is shown as "observed"; on a single wideband SDR whose window doesn't cover the voice channels, *every* call surfaces this way, which reads as "GopherTrunk says the talkgroup has no voice."
3. **#1105 — conventional channel IDs aren't stable.** Conventional channels upload to scan-type consumers (Rdio Scanner, OpenMHz, Broadcastify Calls) under a positional synthetic talkgroup ID (`0x80000000 | list-index`) that shifts when channels are reordered/inserted/removed, breaking any `talkgroup_file` roster mapping.

## Changes

- **#1120** — `internal/configbuilder/paths.go`: `DefaultConfigPath()` consults `config.Discover()` before the cwd / `UserConfigDir` fallbacks, so the builder defaults to the file the daemon reads. `$GOPHERTRUNK_CONFIG` still wins.
- **#356** — `internal/trunking/{voicepool,engine}.go`: attach a reason to an observed call at the drop site (`no voice SDR configured` / `voice frequency outside every voice device's tuning window` / `all voice tuners busy with higher-priority calls`), cleared when a tuner follows it; `internal/api/types.go` surfaces it as `unfollowed_reason` (omitted for followed calls). Diagnostic only — no change to grant handling or the decode path.
- **#1105** — new optional `scanner.conventional[].talkgroup_id`: when set, the channel surfaces under that fixed ID instead of the positional default. Threaded config → `conventional.Channel` → `beginDwell`; config validation rejects two channels resolving to the same effective ID (the engine keys a synthetic call on `(system, GroupID)`). FieldMeta + web-builder `types.ts` entries, `config.example.yaml`, CHANGELOG. (Option 1 of the issue — label → `talkgroupLabel` — already landed in e8782cb.)

## Test plan

- [x] `make vet test` is green locally
- [ ] `make integration` — n/a (no daemon/DSP/replay behaviour change; #356 is diagnostic, #1105 is a synthetic-ID plumbing/config change)
- [x] Added or updated tests — every change has failing-first regressions (config path returns `./config.yaml` vs the discovered file; observed reason empty vs the expected string; conventional grant emits the positional ID and validation accepts colliding IDs without the fix)
- [ ] Smoke-tested against real hardware — n/a (config plumbing, a diagnostic field, and a synthetic-ID override; no SDR/DSP/vocoder code)

## Breaking changes

none. All three are additive or restore intended behaviour. `talkgroup_id` defaults to the current positional value when unset; `unfollowed_reason` is a new omitempty field; the config-path change only alters the default when `$GOPHERTRUNK_CONFIG` is unset and a config is already discoverable.

## Docs / CHANGELOG

- `## [Unreleased]` bullet added for `talkgroup_id`; `config.example.yaml` documents the new key. #1120 restores intended behaviour and #356 adds a diagnostic field (no doc change needed).

## Linked issues

Refs #1120
Refs #356
Refs #1105

<!-- All kept as Refs, not Closes, per the repo's verify-before-close policy:
     #1120's fresh-install path is best confirmed on the reporter's machine;
     #356's original bug is already fixed (#427) and this only adds a diagnostic
     for a distinct, still-unreproduced report; #1105's option-1 half is verified
     but the reporter offered to test the stable-ID piece against their setup. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)