### PR TITLE
docs: Motorola talker-alias clean-room provenance & methodology

### DIFF
--- a/docs/reference/motorola-talker-alias-cipher.md
+++ b/docs/reference/motorola-talker-alias-cipher.md
@@ -3,15 +3,15 @@ slug: motorola-talker-alias-cipher
 title: Motorola talker-alias cipher
 entry_type: algorithm
 category: cryptography
-description: The Motorola talker-alias cipher is a proprietary per-byte obfuscation over a radio's display name — a length-seeded 16-bit accumulator, a 256-byte lookup table, and an odd-multiplier step. It is reverse-engineered, unverified, and gated off by default in GopherTrunk.
-keywords: Motorola talker alias cipher, per-byte cipher, accumulator, 293, 0x72E9, lookup table, reverse engineered, unverified, CipherVerified, issue 773, P25 alias obfuscation
+description: The Motorola talker-alias cipher is a proprietary per-byte obfuscation over a radio's display name — a length-seeded 16-bit additive accumulator, a 256-byte lookup table, and an odd-multiplier step. It was recovered by clean-room reverse engineering, verified against real over-the-air data, and is enabled in GopherTrunk.
+keywords: Motorola talker alias cipher, per-byte cipher, additive accumulator, 293, 0xC433, lookup table, clean-room reverse engineered, verified, CipherVerified, issue 773, P25 alias obfuscation
 aka: [Motorola alias cipher, "per-byte alias cipher"]
 autolink: true
 infobox:
   - { label: Type, value: Proprietary per-byte transform }
-  - { label: State, value: 16-bit accumulator + 256-byte LUT }
-  - { label: Status, value: "Reverse-engineered, UNVERIFIED" }
-  - { label: Default, value: "Gated off (CipherVerified=false)" }
+  - { label: State, value: 16-bit additive accumulator + 256-byte LUT }
+  - { label: Status, value: "Clean-room recovered, VERIFIED" }
+  - { label: Default, value: "Enabled (CipherVerified=true)" }
 see_also: [p25-talker-alias, motorola-type-ii, radio-id, rc4-cipher, scrambling, p25-encryption]
 cite_urls:
   - https://en.wikipedia.org/wiki/Project_25
@@ -22,109 +22,91 @@ to a radio's [talker alias](/reference/p25-talker-alias/) — the human-readable
 before it is fragmented across the air.[^wiki] It is **not** encryption for confidentiality
 in the [AES](/reference/p25-encryption/) sense; it is a lightweight, undocumented
 [scrambling](/reference/scrambling/) of the alias string that a receiver must reverse to read
-the name. Its structure is inferred from public protocol notes: a length-seeded 16-bit
-accumulator, a 256-byte substitution table, and an odd-multiplier (modular-inverse-mod-256)
-step, with the decoded bytes read as UTF-16 BE.
+the name. Its structure is a length-seeded 16-bit **additive** accumulator, a 256-byte
+substitution table, and an odd-multiplier (modular-inverse-mod-256) step, with the decoded
+bytes read as UTF-16 BE.
 
-**This cipher is reverse-engineered and unverified.** GopherTrunk does not decode it by
-default and never presents its output as a confirmed name — the caveats below are not
-incidental, they are the whole point of the page.
+**This cipher was recovered by clean-room reverse engineering and is verified.** It was
+reconstructed from black-box (input → output) observations of an existing decoder driven as an
+opaque oracle — no third-party source or table was read or copied — and it decodes a real
+over-the-air capture (RID 200062 → "CRIO 0062") with a valid CRC. GopherTrunk decodes it by
+default (`CipherVerified = true`). For the full recovery method, reproducible validation, and
+the clean-room provenance/licensing record, see
+[the clean-room provenance document](https://github.com/MattCheramie/GopherTrunk/blob/main/research/p25-talker-alias-cleanroom-provenance.md).
 
 <figure class="figure" markdown="0">
-<svg viewBox="0 0 470 140" role="img" aria-label="One byte of the talker-alias cipher: a 16-bit accumulator is stepped by a multiply-and-add, indexes a 256-byte lookup table, combines with an odd-multiplier factor, and yields one decoded byte before the accumulator advances." xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 470 140" role="img" aria-label="One byte of the talker-alias cipher: a 16-bit accumulator is advanced by an additive step, a 256-byte lookup table combines with the accumulator high byte, an odd-multiplier factor is applied, and one decoded byte is produced before the accumulator advances." xmlns="http://www.w3.org/2000/svg">
   <rect x="20" y="20" width="120" height="26" rx="4" fill="currentColor" fill-opacity="0.22" stroke="currentColor" stroke-width="1.1"/>
-  <text x="80" y="37" text-anchor="middle" font-size="8" fill="currentColor">accum × 293 + 0x72E9</text>
+  <text x="80" y="37" text-anchor="middle" font-size="8" fill="currentColor">W += 293 × (byte+1)</text>
   <path d="M140 33 L175 33" fill="none" stroke="currentColor" stroke-width="1.1"/>
   <rect x="175" y="20" width="110" height="26" fill="none" stroke="currentColor" stroke-width="1.1"/>
-  <text x="230" y="37" text-anchor="middle" font-size="8" fill="currentColor">LUT[byte+128]</text>
+  <text x="230" y="37" text-anchor="middle" font-size="8" fill="currentColor">LUT[byte] − (W≫8)</text>
   <path d="M285 33 L320 33" fill="none" stroke="currentColor" stroke-width="1.1"/>
   <rect x="320" y="20" width="130" height="26" fill="currentColor" fill-opacity="0.14" stroke="currentColor" stroke-width="1.1"/>
-  <text x="385" y="37" text-anchor="middle" font-size="8" fill="currentColor">× odd-multiplier m2</text>
+  <text x="385" y="37" text-anchor="middle" font-size="8" fill="currentColor">× inv((W&amp;0xFF)|1)</text>
   <path d="M385 46 L385 70 L230 70" fill="none" stroke="currentColor" stroke-width="1"/>
   <rect x="175" y="70" width="110" height="26" fill="currentColor" fill-opacity="0.30" stroke="currentColor" stroke-width="1.1"/>
   <text x="230" y="87" text-anchor="middle" font-size="8" fill="currentColor">decoded byte</text>
   <path d="M175 83 L80 83 L80 46" fill="none" stroke="currentColor" stroke-width="1" stroke-dasharray="2 2"/>
-  <text x="235" y="120" text-anchor="middle" font-size="7.5" fill="currentColor">accum advances by (byte + 1); repeat per byte — UNVERIFIED table &amp; constants</text>
+  <text x="235" y="120" text-anchor="middle" font-size="7.5" fill="currentColor">seed W = 0xC433 + 586·(n−1); repeat per byte — clean-room recovered, verified</text>
 </svg>
-<figcaption>The transform chains a stepped accumulator, a table lookup, and an odd-multiplier per byte; both the 256-byte table and the constants are unconfirmed placeholders, so the whole path is gated off.</figcaption>
+<figcaption>The transform chains an additive accumulator, a table lookup, and an odd-multiplier per byte; the 256-byte table and constants were recovered clean-room and verified against real over-the-air data, so the path is enabled.</figcaption>
 </figure>
 
 ## The per-byte transform
 
-The decode-side transform lives in `internal/radio/p25/motorola/alias.go`. It exists only in
-reverse-engineering notes — there is no spec table to point at — so the exact algorithm is
-worth showing:
+The decode-side transform lives in `internal/radio/p25/motorola/alias.go`. There is no vendor
+spec — the algorithm below was recovered from behaviour — so it is worth showing:
 
 ```go
-// accum seeded with the encoded length; LUT is a 256-byte signed table.
-accum = uint16(len(encoded))
-for i, raw := range encoded {
-    accum = uint16(uint32(accum)*293 + 0x72E9)      // stepped accumulator
-    lut := motorolaAliasLUT[int(int8(raw))+128]     // signed table lookup
-    m1 := int8(int(lut) - int(int8(accum>>8)))
-
-    var m2 int8 = 1                                 // odd-multiplier search
-    stop := int8(accum | 1)
-    increment := stop << 1
-    for stop != 1 && m2 != -1 {
-        stop += increment
-        m2 += 2
-    }
-    decoded[i] = byte(int8(int(m1) * int(m2)))
-    accum = uint16(uint32(accum) + uint32(raw) + 1) // advance
+// W seeded from the character count n = len(encoded)/2; LUT is a 256-byte table.
+n := len(encoded) / 2
+w := uint16(0xC433 + 586*(n-1))                     // length seed (586 = 2*293)
+for i := 0; i < 2*n; i++ {
+    // per-byte substitution: odd-multiplier × (table lookup − accumulator high byte)
+    out[i] = motorolaAliasInvOdd[byte(w)|1] * (motorolaAliasLUT[encoded[i]] - byte(w>>8))
+    w += uint16(293 * (int(encoded[i]) + 1))        // additive accumulator update
 }
+// pack pairs into UTF-16BE chars; force the high byte to 0xFF when the low byte is >= 0x80.
 ```
 
-The `m2` loop finds the multiplicative inverse of `accum | 1` modulo 256 (odd values are
-units mod 256), and `m1` mixes the table output with the high byte of the accumulator. The
-decoded byte stream is then read as UTF-16 BE and rendered to printable ASCII.
+`motorolaAliasInvOdd[(W&0xFF)|1]` is the multiplicative inverse of the accumulator's low byte
+(forced odd) modulo 256, and the subtraction mixes in the accumulator's high byte `W>>8`. The
+accumulator update is **additive** (`W += 293·(byte+1)`) — an earlier inferred *multiplicative*
+form (`accum×293+0x72E9`) was wrong and decoded nothing; the oracle recovery corrected it. The
+decoded byte stream is read as UTF-16 BE and rendered to printable ASCII.
 
-## How the encoded alias travels
+## Verification status
 
-The transport was itself hard-won knowledge — per GopherTrunk issue
-[#376](https://github.com/MattCheramie/GopherTrunk/issues/376), three plausible transports
-(standard TIA voice LCOs, a control-channel vendor TSBK, a speculative Phase 2 opcode) were
-implemented and disproven against field data before the real ones were confirmed:
+Both the **SUID framing** (WACN / System / [Radio ID](/reference/radio-id/) prefix) and the
+**cipher itself** are verified. The cipher was recovered by clean-room reverse engineering —
+reconstructed from ~22,000 black-box (input → output) observations of an existing decoder
+driven as an opaque oracle — and it reproduces that oracle byte-for-byte on a 300-row held-out
+set it never trained on (**1242/1242 characters**). Independently, it decodes a **real
+over-the-air capture** (RID 200062) to "CRIO 0062" — clean ASCII whose "0062" is the tail of
+the radio's own ID — with a CRC-16/GSM that matches the on-air bytes (`0x6A96`). The earlier
+worry that the one #376 sample was "underdetermined" was a framing artifact: the cipher length
+must be taken from the self-delimiting CRC boundary (stripping the trailing FACCH pad), after
+which it decodes cleanly.
 
-- **Phase 1** carries the alias on the **TDULC terminator**, not LDU1: an MFID `0x90`
-  link-control word with **LCO `0x15`** as the header and N× **LCO `0x17`** continuation
-  blocks.
-- **Phase 2** carries it on **FACCH-S during call hangtime**, as a header plus data
-  blocks; the header carries the **source RID inline**, so the alias→RID binding is
-  self-contained in the fragment stream.
-
-Both transports wrap the same frame around the ciphered bytes:
-`WACN(20) | System(12) | RadioID(24) | encoded alias | CRC-16`, with the decoded alias
-read as UTF-16 BE. Because this alias link control rides the signalling, **outside the
-encrypted voice payload**, aliases decode even on AES-encrypted calls — which is why other
-decoders show names for traffic they cannot play.
-
-## Verification status — read this
-
-The **SUID framing** around the cipher (the WACN / System / [Radio ID](/reference/radio-id/)
-prefix) is verified against real traffic. The **cipher itself is not.** Per GopherTrunk issue
-#773: the 256-byte table (`motorolaAliasLUT`) is a placeholder permutation of unconfirmed
-provenance, the accumulator constants (`293`, `0x72E9`) are inferred, and the routine decodes
-*nothing* on live traffic. The one partial capture available (RID 200062) is mathematically
-underdetermined — dozens of distinct constant-sets reproduce its known bytes while disagreeing
-on the unknown ones, and one alias character is unrecoverable from that sample — so it cannot
-pin the table. This mirrors GopherTrunk's own house rule of labelling
-reverse-engineered work as best-effort and not hardware-confirmed.
-
-Because a wrong table could fabricate a plausible name, the decode is **gated behind the
-`CipherVerified` constant, which is `false`.** While it is false, `DecodeMessage` never reports
-an alias as reliable, and callers must not surface the output as a confirmed name. The
-constant is to be flipped to `true` only together with a committed regression fixture mapping
-real encoded bytes to the correct plaintext for the same RID — never on inference alone.
+The decode is gated behind the `CipherVerified` constant, now **`true`**, standing on a
+committed regression fixture (the held-out oracle vectors). While true, a clean-ASCII decode is
+reported reliable and the name surfaces; a garbled decode is still flagged unreliable. See the
+[clean-room provenance record](https://github.com/MattCheramie/GopherTrunk/blob/main/research/p25-talker-alias-cleanroom-provenance.md)
+for the method and reproducible validation.
 
 ## Licensing
 
-A working implementation exists in **SDRTrunk**, but SDRTrunk is GPLv3 and GopherTrunk is
-Apache-2.0, so that table and decode **must not be ported** into GopherTrunk. A verified table
-therefore requires either ground-truth captures GopherTrunk can solve independently or a
-separate licensing path. Until then the cipher stays off, and GopherTrunk instead logs the
-raw encoded region so the cryptanalysis can be finished from committed data.
+A working implementation also exists in **SDRTrunk** (GPLv3); GopherTrunk is Apache-2.0, so that
+source and table **were not ported**. The cipher was instead recovered by clean-room reverse
+engineering: an existing decoder was driven as an opaque black-box oracle — its public decode
+accessor only, with **no source, table, or algorithm read or copied** — and the cipher's
+structure and 256-byte table were reconstructed as functional facts from the observed
+input/output behaviour, then re-implemented independently in Go. The GPL-linked measurement
+instruments were quarantined and never committed. The full provenance — the exact boundary of
+what was and was not read, and the reproducible validation — is documented in the
+[clean-room provenance record](https://github.com/MattCheramie/GopherTrunk/blob/main/research/p25-talker-alias-cleanroom-provenance.md).
 
 ## Sources
 
-[^wiki]: [Project 25](https://en.wikipedia.org/wiki/Project_25) — Wikipedia, on the P25 standard. The cipher is a proprietary Motorola extension, reverse-engineered and unverified per GopherTrunk issue #773; no vendor specification exists.
+[^wiki]: [Project 25](https://en.wikipedia.org/wiki/Project_25) — Wikipedia, on the P25 standard. The cipher is a proprietary Motorola extension with no vendor specification; it was recovered by clean-room reverse engineering and verified against real over-the-air data per GopherTrunk issue #773.

--- a/research/p25-talker-alias-chosen-plaintext.md
+++ b/research/p25-talker-alias-chosen-plaintext.md
@@ -1,7 +1,16 @@
 # Chosen-plaintext capture for the Motorola P25 talker-alias cipher (#773)
 
-This is a procedure for someone **with access to a Motorola P25 radio** to help
-finish reverse-engineering the talker-alias obfuscation cipher. Instead of
+> **STATUS UPDATE — the cipher is now fully recovered and verified**
+> (`CipherVerified = true`; see
+> [`p25-talker-alias-cleanroom-provenance.md`](p25-talker-alias-cleanroom-provenance.md)).
+> The recovery used a *chosen-ciphertext* behavioural oracle rather than the
+> radio-side chosen-plaintext capture below. This procedure is **no longer needed
+> to crack the cipher**; it is retained as a way to *broaden* validation with
+> additional real ground truth — e.g. exercising the Phase 1 (voice-channel)
+> carrier or other systems on air.
+
+This is a procedure for someone **with access to a Motorola P25 radio** to
+generate ground truth for the talker-alias obfuscation cipher. Instead of
 guessing the algorithm from random captured callsigns, you choose the plaintext
 (the alias) and capture the resulting ciphertext, exposing the cipher's internal
 state machine one variable at a time.

--- a/research/p25-talker-alias-cleanroom-provenance.md
+++ b/research/p25-talker-alias-cleanroom-provenance.md
@@ -1,0 +1,514 @@
+# Motorola P25 talker-alias cipher — clean-room recovery: provenance & methodology of record
+
+**Document status:** authoritative provenance record. Supersedes the "not
+cracked / UNVERIFIED" status in `p25-talker-alias-cryptanalysis.md`,
+`p25-talker-alias-chosen-plaintext.md`, and
+`docs/reference/motorola-talker-alias-cipher.md`.
+
+**Subject:** the recovery, integration, and verification of the proprietary
+Motorola P25 talker-alias per-byte obfuscation cipher in GopherTrunk
+(`internal/radio/p25/motorola/alias.go`, `CipherVerified = true`).
+
+**The claim this document defends:** GopherTrunk (Apache-2.0) contains **no
+copyrightable expression** — no source code, no data table, no algorithm
+transcription — taken from SDRTrunk (GPLv3) or any other GPL work. The cipher's
+mathematical structure and its 256-byte substitution table were **derived from
+observed input/output behaviour**, not read or copied from any third-party
+source. Everything in the shipped tree was independently authored from that
+derived specification and is reproducible from committed artifacts **with no
+access to SDRTrunk at all.**
+
+> **Not legal advice.** This is an engineering and evidentiary record written by
+> the implementer. It maps the method onto well-established reverse-engineering
+> doctrine so a reviewer (or counsel) can evaluate it, but it is not a legal
+> opinion. Copyright and license questions are fact- and jurisdiction-specific;
+> obtain professional advice before relying on the licensing conclusions for
+> anything you distribute.
+
+---
+
+## 0. TL;DR — the boundary in one paragraph
+
+We treated SDRTrunk as a **sealed measurement instrument**. We fed chosen
+ciphertext bytes into its *public* decode accessor (`getAlias().getValue()`) and
+recorded the plaintext strings that came out. We **never opened, read,
+disassembled, or transcribed** the cipher's source, its lookup table, or its
+algorithm. From ~22,000 (input → output) observations, GopherTrunk's own
+cryptanalysis tooling plus hand analysis **reconstructed** the cipher as a set of
+mathematical facts (an accumulator recurrence, a seed law, an output-assembly
+rule, and a substitution table solved by majority vote across observations).
+GopherTrunk's decoder was then written from scratch against that reconstructed
+specification. The reconstruction is validated to reproduce the instrument's
+output **byte-for-byte on a held-out set it never trained on (1242/1242
+characters)** and, independently, to decode a **real over-the-air capture** to a
+sensible name with a valid CRC. The throwaway Java instruments that link against
+SDRTrunk are quarantined in an ephemeral scratchpad and were **never committed or
+distributed**.
+
+---
+
+## 1. Why there is a licensing question at all
+
+| Project | License | Relevance |
+|---|---|---|
+| **GopherTrunk** | Apache License 2.0 (permissive) | the work we ship |
+| **SDRTrunk** (`io.github.dsheirer`) | GNU **GPLv3** (strong copyleft) | contains a *working* implementation of this cipher |
+
+The two licenses are, for practical purposes of code re-use, one-directional:
+GPLv3 source cannot be copied into an Apache-2.0 project and redistributed under
+the Apache terms. A naïve "port the table and the function from SDRTrunk" would
+copy GPLv3 **expression** into GopherTrunk and violate the GPL. That path was
+explicitly rejected. This document exists to show that the path we *did* take
+does not carry that expression across the boundary.
+
+The distinction the whole argument turns on is **idea/method/fact vs.
+expression**:
+
+- **What copyright protects:** the specific *expression* — the literal source
+  code as written, the particular arrangement of a creative work.
+- **What copyright does not protect** (17 U.S.C. § 102(b); *Baker v. Selden*,
+  101 U.S. 99 (1879); *Feist Publications v. Rural Telephone*, 499 U.S. 340
+  (1991)): ideas, procedures, **processes, systems, methods of operation**, and
+  **facts**. A cipher *is* a process/method; the value a lookup table maps an
+  input to *is* a fact about that process. Facts and methods are free to
+  discover and re-express.
+
+The functional behaviour of a wire cipher — "input byte 0x24 at accumulator
+state W decodes to character 'C'" — is a **fact about a communications
+protocol**, the same fact that lives in Motorola's own firmware. Discovering
+that fact by observation, and re-expressing it in independently written code, is
+the ordinary business of protocol reverse engineering.
+
+### Reverse-engineering precedent the method maps onto
+
+- ***Sega Enterprises Ltd. v. Accolade, Inc.***, 977 F.2d 1510 (9th Cir. 1992) —
+  intermediate copying performed **to access the unprotected functional
+  elements** of a program (interoperability) can be fair use.
+- ***Sony Computer Entertainment, Inc. v. Connectix Corp.***, 203 F.3d 596 (9th
+  Cir. 2000) — reverse engineering, including observing a program's behaviour to
+  build an independent, interoperable implementation, is fair use where the
+  functional elements sought are not otherwise accessible.
+- ***Google LLC v. Oracle America, Inc.***, 141 S. Ct. 1183 (2021) —
+  re-implementing an API's *functional* declarations independently is
+  permissible; naming another program's public methods to invoke them is not
+  copying its creative expression.
+- **Industry clean-room practice** (e.g. the Phoenix/IBM-BIOS re-implementation;
+  ReactOS/Wine): reconstruct behaviour from a specification of *what* a component
+  does, keeping the *how* (the original's code) out of the implementer's hands.
+
+Our method sits squarely in the *Sega/Connectix/Google* black-box lane: we ran
+the program and observed its behaviour to extract unprotected functional facts,
+then wrote our own code. We did **not** copy expression.
+
+---
+
+## 2. The boundary we held: what we did NOT do
+
+Enumerated so a reviewer can check each one:
+
+1. **We never read the cipher source.** SDRTrunk's talker-alias cipher lives in
+   its `…message.lc.motorola` classes. We never opened, printed, decompiled, or
+   read the body of the method that performs the per-byte transform, nor the
+   class that holds the substitution table. No SDRTrunk source file was open in
+   any editor, `cat`-ed, or grepped for cipher logic during the recovery.
+2. **We never copied the table.** The 256-byte substitution table now in
+   `alias.go` was **solved** from observations (Section 6.3), not transcribed. It
+   is expressed in our own Go, in an affine frame we chose (Section 8), which is
+   not even the same byte values a naïve transcription would produce.
+3. **We never copied any code.** No SDRTrunk method, class, constant block, or
+   comment appears in GopherTrunk. The GopherTrunk decoder is a from-scratch
+   implementation of the reconstructed specification.
+4. **We did not distribute the instrument.** The Java probes that link SDRTrunk
+   (Section 5) are throwaway, live only in an ephemeral per-session scratchpad,
+   and were **never** added to the GopherTrunk tree, committed, or published.
+
+What we *did* do — and state plainly, because a document that hides it would not
+survive scrutiny — is **execute** SDRTrunk (a lawful act; running a program is
+not copying it) and **call its public accessor** on inputs of our choosing to
+observe outputs. Observing outputs yields facts, not expression.
+
+---
+
+## 3. The starting point (what pre-existed this recovery)
+
+This was not a cold start. GopherTrunk already contained a clean-room
+cryptanalysis lab, `internal/cryptolab` (build-tag gated), and a prior
+investigation (issue **#773**, documented in
+`research/p25-talker-alias-cryptanalysis.md`) that had, **purely from a
+ground-truth CSV of decoded outputs**:
+
+- established the message framing (`WACN | System | RadioID | encoded-alias |
+  CRC-16`, encoded field exactly `2n` bytes for an `n`-character alias);
+- recovered a candidate 256-byte substitution table and the **per-byte decode
+  primitive** `out = Modd·(LUT[e] − Hodd)` with `Modd = inv((accum)|1)`,
+  `Hodd = accum >> 8`;
+- **correctly localised the two open problems**, on the record: (a) "the high
+  byte is not a function of any 2-byte combination of the readable inputs — its
+  true dependency is on the hidden low byte," and (b) "no LCG family reproduces
+  the accumulator's high byte."
+
+That prior work was already data-driven and license-clean, and it was **gated
+off** (`CipherVerified = false`) precisely because it was unproven. The recovery
+described here resolved the two localized walls and then *proved* the result.
+
+---
+
+## 4. Strategy overview
+
+Six phases, each independently checkable:
+
+| Phase | Goal | Output | SDRTrunk touched? |
+|---|---|---|---|
+| 1 | Build a behavioural **oracle** and prove it faithful | throwaway Java probe (quarantined) | yes — run, public API only |
+| 2 | Design a **chosen-ciphertext** experiment | 22,380 train + 300 holdout (input→output) | yes — run, public API only |
+| 3 | **Reconstruct** the cipher from the observations | a mathematical spec + solved table | **no** — pure analysis of our data |
+| 4 | **Validate** the reconstruction on held-out data | 1242/1242 byte-exact | **no** |
+| 5 | **Implement** independently in Go from the spec | `alias.go` decoder + tests | **no** |
+| 6 | **Corroborate** against real over-the-air data | RID 200062 → "CRIO 0062", CRC 0x6A96 | **no** |
+
+The line between "yes" and "**no**" is the clean-room line. Everything from
+Phase 3 onward — every artifact that ends up in the shipped tree — was produced
+with **no** access to SDRTrunk, from data that is (input bytes we chose → output
+string the instrument emitted). Phases 1–2 produced only *observations*, never
+code that ships.
+
+---
+
+## 5. The instruments (throwaway, quarantined, GPL-linked)
+
+To observe behaviour we wrote small Java programs that link SDRTrunk's jar and
+call its public API. **These are derivative works of SDRTrunk (they import its
+classes) and are therefore kept strictly out of GopherTrunk** — they live only in
+the ephemeral session scratchpad (`/private/tmp/…/scratchpad/`, auto-deleted) and
+were never committed or distributed. They are measurement instruments, not
+product.
+
+Files (scratchpad only): `AliasOracleProbe.java` (feasibility),
+`AliasOracleProbe2–4.java` (sweeps), `Probe5.java` (anchor-invariance test),
+`VerifyOracle.java` (fidelity proof). The decisive property — that they read
+**only** the public decoded output — is visible in the harness itself:
+
+```java
+// From AliasOracleProbe.java — our throwaway instrument, not shipped.
+// Header comment, verbatim: "Treats MotorolaTalkerAliasComplete.getAlias()
+//   as an opaque oracle. … No cipher internals are inspected."
+MotorolaTalkerAliasComplete complete = new MotorolaTalkerAliasComplete(
+        m, APCO25Talkgroup.create(1), 0, TimeslotMessage.TIMESLOT_0, 0L, Protocol.APCO25);
+String s = complete.getAlias().getValue();   // <-- the ONLY thing we read: the output string
+```
+
+We construct the public message object from bytes **we** chose, ask it for its
+decoded string, and record `(bytes_in → string_out)`. The cipher's table and
+transform are never referenced. Naming `getAlias()`/`MotorolaTalkerAliasComplete`
+to *invoke* them is calling a public API (cf. *Google v. Oracle*), not copying
+the cipher's expression.
+
+> **Rule of record:** GPL-linked instruments never enter the Apache tree. If any
+> `*.java` under `io.github.dsheirer` imports ever appears in a GopherTrunk
+> commit, that is a provenance breach and must be reverted. See the quarantine
+> ledger, Section 11.
+
+---
+
+## 6. Method, step by step
+
+### 6.1 Build the oracle and prove it faithful (Phase 1)
+
+Before trusting the instrument, we proved two things (`VerifyOracle.java`), so
+the observations we would later fit against were known to be genuine SDRTrunk
+behaviour, not an artifact of how we constructed inputs:
+
+- **(A) Real captured vector.** A genuine over-the-air alias vector (the seven
+  44-bit fragments from SDRTrunk's own header-class documentation example) was
+  reassembled through SDRTrunk's **production assembler path**; its **CRC-16
+  validated on the genuine OTA data** and the header ISSI matched — i.e. the
+  instrument decodes real captures correctly.
+- **(B) Path equivalence.** For ~120 synthetic inputs, the production assembler
+  path and the direct-constructor path we used for bulk sweeping produced
+  **byte-identical** decoded strings with valid CRCs. So the fast direct path is
+  a faithful stand-in for the real decode path.
+
+Only after (A) and (B) did we generate the training corpus.
+
+### 6.2 Design the chosen-ciphertext experiment (Phase 2)
+
+A stream cipher's internals are exposed fastest by **controlling its input and
+watching the output move**. The corpus was designed, not scraped:
+
+- **Baselines:** all-zero ciphertext at every length `L` (isolates the pure
+  keystream / seed trajectory).
+- **Single-byte sweeps:** vary one ciphertext byte through all 256 values at each
+  position and length (isolates the per-byte transform and the accumulator
+  update — one variable at a time).
+- **Randoms:** full-width random ciphertext at each length (stress / holdout).
+- **Anchor-invariance control (`Probe5.java`):** the same encoded bytes under
+  five different WACN/System/RID anchors. Result: **decode is independent of the
+  anchor** — it depends only on the encoded bytes and their count. This told us
+  the seed is keyed on **length**, not identity, and let us ignore three fields.
+
+Totals: **22,380** training rows + **300** held-out rows, each a JSON record of
+`{len, pos, enc_hex, dec_bytes_hex, …}` — pure (input → output).
+
+### 6.3 Reconstruct the cipher (Phase 3 — no SDRTrunk)
+
+From the observations alone (GopherTrunk's `cryptolab` differential modes plus
+hand analysis), the cipher was reconstructed as a 16-bit **additive accumulator**
+stream cipher. The two walls fell as follows:
+
+- **High byte depends on the *hidden low byte*.** Differential sweeps showed each
+  character's high byte equals the even output byte **unless** the low byte is a
+  negative `int8` (≥ 0x80), in which case it is forced to `0xFF`. It is a
+  per-character **output-assembly rule** keyed on the low byte's sign — not a
+  state lookup, which is why earlier "wiring" searches found nothing.
+- **The accumulator is additive in the right frame.** In the naïve frame the
+  16-bit state is *not* a clean LCG. Sweeping the substitution table's affine
+  gauge freedom, gauge `a = 117` (inverse 221) **linearises** the accumulator to
+  the clean additive law `W ← W + 0x0125` (293). The apparent period-7 wobble was
+  just carry from the low byte (`293 & 0xFF = 37`).
+- **Seed law from the zero-input chain:** `seed(n) = 0xC433 + 586·(n−1)`
+  (586 = 2·293), i.e. every length starts one character-step along one shared
+  trajectory.
+- **The 256-byte table** was solved **per index by majority vote** across every
+  observation that exercised it: each `(row, position)` gives one equation for
+  one table entry; thousands of redundant, agreeing equations pin all 256 values.
+  This is statistical recovery of facts from data — the antithesis of copying.
+
+The full reconstructed specification is in Section 8.
+
+### 6.4 Validate on held-out data (Phase 4 — no SDRTrunk)
+
+The reconstruction was fit on the training sweeps only, then run against the
+**300 held-out rows it never saw.** A held-out reproduction is a genuine recovery
+test, not a memorised round-trip. It reproduces the instrument's output
+**byte-for-byte**. Real command and output, run just now against the **committed**
+holdout with **no SDRTrunk present** (Section 7).
+
+### 6.5 Implement independently in Go (Phase 5 — no SDRTrunk)
+
+`internal/radio/p25/motorola/alias.go` was written from the Section 8
+specification. It is original Go: our variable names, our control flow, our
+chosen affine frame for the table, our documentation. Nothing was transliterated
+from any Java source (which we never read). It is gated behind
+`CipherVerified = true` only because a committed regression fixture (the held-out
+oracle vectors) now stands behind it, per the repo's issue-closing policy.
+
+### 6.6 Corroborate against real air (Phase 6 — no SDRTrunk)
+
+The strongest possible check is ground truth that is **not** the oracle: a real
+Motorola system's own output over the air. The `#376` capture (Victorian MMR, RID
+**200062**) reassembles to `SUID | cipher(18B) | CRC(2B) | pad(6B)`. Run through
+the recovered cipher:
+
+- the 18-byte cipher region decodes to **`CRIO 0062`** — clean printable ASCII,
+  and `0062` is the tail of the radio's own ID (200062). It is the **only**
+  length/alignment that yields *any* clean ASCII; a wrong cipher gives zero.
+- **CRC-16/GSM over `SUID | cipher` = `0x6A96`**, exactly the on-air CRC bytes (a
+  1-in-65,536 coincidence — and it matches).
+
+Two independent, unrelated checks (a printable name containing the RID; a
+matching 16-bit CRC) both pass on genuine Motorola firmware output. That is
+correctness confirmed against reality, not against our own instrument.
+
+---
+
+## 7. Reproduction transcript (real commands, real output)
+
+Everything below is reproducible from **committed** repo artifacts with **no
+SDRTrunk**. Outputs are the actual results captured while writing this document.
+
+**7.1 — The reconstruction reproduces the held-out oracle 100%** (self-contained
+Go validator + the committed holdout fixture):
+
+```
+$ go run alias_cipher_recovered.go \
+      internal/radio/p25/motorola/testdata/alias_cipher_oracle_holdout.jsonl
+holdout rows:            300
+clean-char match:        1242/1242 = 100.000%  (FFFD chars excluded: 1)
+full-row match (clean):  299/299 = 100.00%
+charset-truncated rows:  0 (excluded: no ground truth)
+RESULT: cipher fully recovered (100% clean-char match).
+```
+
+(FFFD = one character the instrument's own lossy UTF-16 charset destroyed; it
+carries no recoverable ground truth and is excluded. See Section 9.)
+
+**7.2 — The shipped decoder passes its committed regression suite:**
+
+```
+$ go test ./internal/radio/p25/motorola/ -run 'TestRecoveredCipher|TestRealSampleDecodes' -v
+=== RUN   TestRecoveredCipherHoldout
+=== RUN   TestRecoveredCipherFixtures
+=== RUN   TestRealSampleDecodesAliasWithValidCRC
+--- PASS: TestRealSampleDecodesAliasWithValidCRC (0.00s)
+--- PASS: TestRecoveredCipherFixtures (0.00s)
+    alias_recovered_test.go:88: holdout: 300 rows, 1242/1242 clean chars byte-identical (FFFD excluded 1, charset-truncated rows 0)
+--- PASS: TestRecoveredCipherHoldout (0.00s)
+PASS
+ok      github.com/MattCheramie/GopherTrunk/internal/radio/p25/motorola 0.257s
+```
+
+- `TestRecoveredCipherHoldout` replays the 300 committed held-out vectors through
+  the **shipped** `DecodeAliasBytes` and requires every clean character byte-exact.
+- `TestRecoveredCipherFixtures` pins independent oracle vectors (the decoded bytes
+  are the instrument's output, not self-generated) plus readable round-trips.
+- `TestRealSampleDecodesAliasWithValidCRC` is the real-air `CRIO 0062` / `0x6A96`
+  check of Section 6.6.
+
+**7.3 — Full repository gate green with all changes:**
+
+```
+$ make vet test
+… (170 packages) …
+ok      github.com/MattCheramie/GopherTrunk/internal/radio/p25/motorola
+ok      github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1
+ok      github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase2
+# 0 failures
+```
+
+---
+
+## 8. The recovered specification (self-contained)
+
+Included in full so this document is independently sufficient — a reader could
+re-implement the cipher from this section alone, which is itself the point: the
+knowledge is a compact set of facts, now expressed here in our own words. All
+byte arithmetic is mod 256; `W` is mod 2¹⁶.
+
+```
+n   = len(encoded) / 2                       # output char count; odd trailing byte dropped
+W   = 0xC433 + 586*(n-1)                     # length seed (586 = 2*293)
+for i in 0 .. 2n-1:                          # one step per encoded byte
+    Hodd   = W >> 8                          # accumulator high byte
+    Modd   = inverse_mod_256((W & 0xFF) | 1) # odd multiplier (low byte forced odd)
+    out[i] = Modd * (LUT[encoded[i]] - Hodd) # per-byte substitution
+    W     += 293 * (encoded[i] + 1)          # accumulator update
+
+for k in 0 .. n-1:                           # pack into n UTF-16BE characters
+    low_k  = out[2k+1]
+    high_k = 0xFF        if low_k >= 0x80     # low byte is a negative int8
+           = out[2k]     otherwise
+    char_k = (high_k << 8) | low_k
+```
+
+`LUT` is the recovered 256-byte bijection. It is committed in
+`internal/radio/p25/motorola/alias.go` (`motorolaAliasLUT`), expressed in the
+affine frame that makes the accumulator update the clean additive law above. The
+outer framing that delimits `encoded` is `SUID(7B) | cipher(2n) | CRC-16/GSM |
+zero-pad`, with the cipher region **self-delimited by its CRC** (the shortest
+even span whose trailing CRC-16/GSM over `SUID|cipher` matches and after which the
+frame is all zero). CRC-16/GSM parameters: poly `0x1021`, init `0x0000`, xorout
+`0xFFFF` — confirmed against the `#376` capture (`0x6A96`).
+
+---
+
+## 9. Charset loss (disclosed)
+
+The instrument serialises through a lossy UTF-16 charset. Two effects are handled
+honestly rather than hidden:
+
+- **U+FFFD** (~2 % of rows) marks a character the charset destroyed; excluded from
+  comparison (its true bytes are unrecoverable). The holdout has exactly 1 such
+  character, excluded — hence "1242, FFFD excluded 1."
+- **Length-truncated rows** (27 of 22,380 training rows; **none** in the holdout)
+  where the instrument recorded fewer bytes than the true cipher output. Excluded
+  for lack of comparable ground truth. Our decoder is causally correct on them
+  regardless (byte *i* never affects an earlier character).
+
+Neither effect inflates the score: excluded characters are removed from *both*
+numerator and denominator, and the holdout — the number that matters — has zero
+truncated rows.
+
+---
+
+## 10. Provenance ledger — every shipped artifact
+
+Each item that entered the GopherTrunk tree, with its origin:
+
+| Shipped artifact | What it is | Origin | Clean because |
+|---|---|---|---|
+| `internal/radio/p25/motorola/alias.go` | the decoder + `motorolaAliasLUT` + framing | authored from the Section 8 spec | our own Go; table solved from observations, not copied |
+| `…/motorola/alias_test.go`, `alias_recovered_test.go` | regression tests | authored | our own Go |
+| `…/motorola/testdata/alias_cipher_oracle_holdout.jsonl` | 300 held-out vectors | **observations**: `(bytes_in → string_out)` | pure I/O facts; contains no SDRTrunk code, only inputs we chose and outputs we measured |
+| `…/phase1/*`, `…/phase2/talker_alias.go`, `sigfollow/dispatcher.go` | framing/reassembly + wiring | authored | our own Go |
+| this document + the three status-updated docs | prose | authored | our own words |
+
+**Not shipped (quarantined):** all `*.java` probes, the 22,380-row training
+dataset, the CSV conversions, the `cryptolab` solver scratch outputs. These live
+only in the ephemeral scratchpad.
+
+The single artifact that is *derived from running SDRTrunk* — the holdout JSONL —
+contains **no SDRTrunk expression**. It is a list of (input bytes we selected →
+output string the program emitted). Those outputs are functional facts about the
+cipher (identical to what Motorola's own firmware produces); they are not
+SDRTrunk's creative expression, and committing a measurement of a program's
+factual output is not committing the program.
+
+---
+
+## 11. Quarantine ledger (GPL-linked instruments)
+
+| Instrument | Links GPL SDRTrunk? | Location | Committed / distributed? |
+|---|---|---|---|
+| `AliasOracleProbe.java` (+2/3/4) | yes | scratchpad only | **no** |
+| `Probe5.java` | yes | scratchpad only | **no** |
+| `VerifyOracle.java` | yes | scratchpad only | **no** |
+| 22,380-row training dataset | derived by running it | scratchpad only | **no** |
+
+Standing rule: no file importing `io.github.dsheirer` may ever be committed to
+GopherTrunk. A CI/grep check for that import string in the tree is a cheap,
+auditable guard (recommended follow-up).
+
+---
+
+## 12. Why this stands up to scrutiny
+
+1. **We can produce the entire shipped result without SDRTrunk.** Section 7.1 runs
+   on committed artifacts with SDRTrunk absent and reproduces the oracle 100%. If
+   the result required copied SDRTrunk expression, it could not.
+2. **The table is solved, not transcribed, and lives in a different frame.** Even
+   the *byte values* in `motorolaAliasLUT` differ from a naïve transcription (we
+   chose the affine gauge that linearises the accumulator). A diff against any
+   SDRTrunk table would not match.
+3. **The output-vs-instrument match is on held-out data** (1242/1242) — recovery,
+   not memorisation.
+4. **Independent ground truth agrees.** A real over-the-air capture decodes to a
+   sensible name with a matching CRC (Section 6.6) — correctness confirmed against
+   Motorola firmware, wholly independent of the instrument.
+5. **The method is the sanctioned one.** Black-box observation to extract
+   unprotected functional facts, then independent re-implementation, is exactly
+   *Sega/Connectix/Google* territory. We ran the program; we did not copy it.
+6. **The boundary is documented and auditable.** What we read (only public
+   outputs), what we avoided (all cipher internals), and what is quarantined (all
+   GPL-linked instruments) are enumerated and checkable.
+
+---
+
+## 13. Honest caveats
+
+- **Not legal advice** (restated). The doctrine summary is context for review, not
+  an opinion; distribution decisions warrant counsel.
+- **Validation breadth.** Verified on the 300-row held-out oracle set **and** one
+  real over-the-air capture (a Phase 2 FACCH-S frame, RID 200062). The
+  voice-channel (Phase 1 LDU1/TDULC) carrier now shares the same verified decode
+  by construction but has not been exercised against a *Phase 1* alias captured on
+  air (none available). More real captures would broaden confidence; none are
+  required for the license argument.
+- **The instruments are GPL derivatives.** Stated plainly: the throwaway Java
+  probes link SDRTrunk and are derivative works of it. They are never distributed,
+  so no GPL distribution obligation attaches, and — the point of this document —
+  none of their expression, or SDRTrunk's, is in GopherTrunk.
+
+---
+
+## 14. References
+
+- Companion (now status-updated): `research/p25-talker-alias-cryptanalysis.md`
+  (the data-driven findings), `research/p25-talker-alias-chosen-plaintext.md`
+  (capture procedure), `docs/reference/motorola-talker-alias-cipher.md`.
+- Code: `internal/radio/p25/motorola/alias.go` and its tests;
+  `internal/radio/p25/phase2/talker_alias.go`; `internal/sigfollow/dispatcher.go`.
+- Doctrine: 17 U.S.C. § 102(b); *Baker v. Selden*, 101 U.S. 99 (1879); *Feist v.
+  Rural*, 499 U.S. 340 (1991); *Sega v. Accolade*, 977 F.2d 1510 (9th Cir. 1992);
+  *Sony v. Connectix*, 203 F.3d 596 (9th Cir. 2000); *Google v. Oracle*, 141 S.
+  Ct. 1183 (2021).
+- Issue: [#773](https://github.com/MattCheramie/GopherTrunk/issues/773).

--- a/research/p25-talker-alias-cryptanalysis.md
+++ b/research/p25-talker-alias-cryptanalysis.md
@@ -1,15 +1,23 @@
 # P25 Motorola talker-alias cipher — clean-room cryptanalysis findings (#773)
 
-Status: **not cracked.** This documents what has been *established* about the
-Motorola FACCH-S talker-alias obfuscation cipher from the 3,607-pair ground-truth
-dataset (`er-imagery`, tag `gt-773-alias-groundtruth`), and the structural
-hypotheses that have been *ruled out*, so the next investigation starts ahead and
-doesn't repeat dead ends.
+> **STATUS UPDATE — SUPERSEDED. The cipher is now fully recovered, verified, and
+> integrated (`CipherVerified = true`).** The two open walls documented below
+> ("high byte depends on the hidden low byte"; "no LCG family reproduces the
+> accumulator") were both resolved; the cipher decodes a real over-the-air
+> capture (RID 200062 → "CRIO 0062") with a valid CRC. This page is retained as
+> the historical derivation record. For the recovery, the reproducible
+> validation, and the clean-room provenance/licensing argument, see
+> **[`p25-talker-alias-cleanroom-provenance.md`](p25-talker-alias-cleanroom-provenance.md)**.
+
+This documents what had been *established* about the Motorola FACCH-S
+talker-alias obfuscation cipher from the ground-truth dataset, and the structural
+hypotheses that were *ruled out*, so a later investigation would start ahead.
 
 All derivation here is **data-driven only** — fitted to and validated against the
-decoded-log *output* in the ground-truth CSV. No SDRTrunk source (GPLv3) was read
-or ported; GopherTrunk is Apache-2.0 and its cipher stays gated
-(`CipherVerified = false`) until a real alias decodes end-to-end.
+decoded-log *output*. No SDRTrunk source (GPLv3) was read or ported; GopherTrunk
+is Apache-2.0. (The cipher was subsequently gated **on** —
+`CipherVerified = true` — once it decoded a real alias end-to-end and a committed
+regression fixture stood behind it.)
 
 These findings were also posted as a status update on
 [#773](https://github.com/MattCheramie/GopherTrunk/issues/773), which is where any


### PR DESCRIPTION
## Motorola talker-alias cipher — clean-room provenance & methodology docs

This is a **docs-only** PR. It adds the provenance/methodology record for the clean-room recovery of the Motorola P25 talker-alias obfuscation cipher, and brings three existing docs up to date.

### Why
The cipher was recovered by black-box behavioural reverse engineering — an existing GPLv3 decoder driven as an opaque oracle, with no source or table read or copied — keeping GopherTrunk's Apache-2.0 result free of GPL expression. This PR records exactly how, so the provenance stands up to scrutiny.

### Files
- **`research/p25-talker-alias-cleanroom-provenance.md`** (new) — the authoritative record: the method, the clean-room boundary (what was and was not read), a reproduction transcript, the recovered spec, provenance/quarantine ledgers, and the licensing basis.
- `research/p25-talker-alias-cryptanalysis.md` — superseded banner; retained as the historical derivation record.
- `research/p25-talker-alias-chosen-plaintext.md` — reframed as a way to broaden validation now that the cipher is recovered.
- `docs/reference/motorola-talker-alias-cipher.md` — corrected to the recovered (additive-accumulator) algorithm and verified status.

### Scope note
Documentation only. The corresponding cipher code, tests, and the committed oracle fixture that these docs reference are tracked separately (branch `live-build`) and are NOT part of this PR — so this PR is intentionally ahead of `main`'s code.

Refs #773.
