### PR TITLE
config: default `gophertrunk config` Save-As to the daemon's config file (#1120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ for tagged releases.
   #1096).
 
 ### Fixed
+- **`gophertrunk config` (terminal Config Builder) now defaults its Save path to
+  the file the daemon actually loads** (issue #1120). The earlier #1120 fix
+  taught `configbuilder.DefaultConfigPath` to follow the daemon's discovery, but
+  the terminal builder's Save-As modal overrode it with the first auto-discovery
+  candidate directory — `%APPDATA%\GopherTrunk` on Windows — so a freshly-built
+  config was written where the daemon never reads it when the installer seeds the
+  config under `<Documents>\GopherTrunk\config`. Save-As now proposes, in order:
+  the file currently open, an operator-supplied `-config-dir`, then the
+  discovered/`$GOPHERTRUNK_CONFIG` file. No behaviour change when `-config-dir`
+  is set or a file is already open.
 - **Conventional/analog scanner recordings no longer end in a loud multi-second
   noise tail** (issue #1090). The scanner-side hangtime debounce (#1091) fixed
   when a call *ends*, but for the whole hangtime window the composer's FM chain

--- a/cmd/gophertrunk/config_tui.go
+++ b/cmd/gophertrunk/config_tui.go
@@ -47,8 +47,10 @@ FLAGS:`)
 	}
 
 	dirs := []string{}
+	dirExplicit := false
 	if d := strings.TrimSpace(*configDir); d != "" {
 		dirs = []string{d}
+		dirExplicit = true
 	} else {
 		dirs = config.CandidateDirs()
 	}
@@ -63,7 +65,7 @@ FLAGS:`)
 	if f := strings.TrimSpace(*cfgFile); f != "" {
 		initial = configbuilder.ExpandConfigPath(f)
 	}
-	m := configtui.New(dirs, rrAuth, importParseFunc(), initial)
+	m := configtui.New(dirs, dirExplicit, rrAuth, importParseFunc(), initial)
 	if _, err := tea.NewProgram(m, tea.WithAltScreen()).Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "config tui: %v\n", err)
 		os.Exit(1)

--- a/internal/configtui/modal.go
+++ b/internal/configtui/modal.go
@@ -206,11 +206,7 @@ type saveModal struct {
 func newSaveModal(m *Model) modal {
 	ti := textinput.New()
 	ti.Prompt = "path: "
-	def := configbuilder.DefaultConfigPath()
-	if len(m.dirs) > 0 {
-		def = joinPath(m.dirs[0], "config.yaml")
-	}
-	ti.SetValue(def)
+	ti.SetValue(m.defaultSavePath())
 	ti.CursorEnd()
 	ti.Focus()
 	return &saveModal{input: ti}

--- a/internal/configtui/model.go
+++ b/internal/configtui/model.go
@@ -35,9 +35,10 @@ type Model struct {
 	talkgroups map[string][]configbuilder.TalkgroupCSVRow
 
 	// injected deps
-	dirs   []string
-	rrAuth radioreference.Auth
-	parse  ParseFunc
+	dirs        []string
+	dirExplicit bool // dirs came from an operator -config-dir, not auto-discovery
+	rrAuth      radioreference.Auth
+	parse       ParseFunc
 
 	width, height int
 	focus         focusZone
@@ -57,21 +58,24 @@ type Model struct {
 	quitting bool
 }
 
-// New builds the model. dirs is the allowed config directories; rrAuth the
-// RadioReference creds; parse the injected import parser; initialPath an
-// optional file to open at start.
-func New(dirs []string, rrAuth radioreference.Auth, parse ParseFunc, initialPath string) Model {
+// New builds the model. dirs is the allowed config directories; dirExplicit
+// says whether they came from an operator-supplied -config-dir (as opposed to
+// the auto-discovery candidate list), which decides where Save-As defaults;
+// rrAuth the RadioReference creds; parse the injected import parser;
+// initialPath an optional file to open at start.
+func New(dirs []string, dirExplicit bool, rrAuth radioreference.Auth, parse ParseFunc, initialPath string) Model {
 	ti := textinput.New()
 	ti.Prompt = "› "
 	m := Model{
-		cfg:        config.Default(),
-		defaults:   config.Default(),
-		talkgroups: map[string][]configbuilder.TalkgroupCSVRow{},
-		dirs:       dirs,
-		rrAuth:     rrAuth,
-		parse:      parse,
-		focus:      zoneSections,
-		input:      ti,
+		cfg:         config.Default(),
+		defaults:    config.Default(),
+		talkgroups:  map[string][]configbuilder.TalkgroupCSVRow{},
+		dirs:        dirs,
+		dirExplicit: dirExplicit,
+		rrAuth:      rrAuth,
+		parse:       parse,
+		focus:       zoneSections,
+		input:       ti,
 	}
 	m.revalidate()
 	if initialPath != "" {
@@ -121,6 +125,28 @@ func (m *Model) revalidate() {
 }
 
 func (m *Model) pushErr(s string) { m.errs = append(m.errs, s) }
+
+// defaultSavePath is the path the Save-As modal proposes. Precedence:
+//
+//  1. the file currently open — save back to what you were editing;
+//  2. an operator-constrained -config-dir → <dir>/config.yaml;
+//  3. configbuilder.DefaultConfigPath() — the file the daemon actually
+//     discovers ($GOPHERTRUNK_CONFIG, then auto-discovery, then cwd).
+//
+// Step 3 is the #1120 fix: without it the builder defaulted to dirs[0],
+// which under auto-discovery is %APPDATA%\GopherTrunk on Windows — a
+// location the daemon does not load when the installer seeds the config
+// under <Documents>\GopherTrunk\config, so a freshly-built config was
+// written somewhere the daemon never read it.
+func (m *Model) defaultSavePath() string {
+	if m.path != "" {
+		return m.path
+	}
+	if m.dirExplicit && len(m.dirs) > 0 {
+		return joinPath(m.dirs[0], "config.yaml")
+	}
+	return configbuilder.DefaultConfigPath()
+}
 
 // loadPath reads + parses a config file into the draft (without Load's
 // validation, so an invalid file can be opened to fix), loads its talkgroup

--- a/internal/configtui/model_test.go
+++ b/internal/configtui/model_test.go
@@ -2,6 +2,7 @@ package configtui
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -12,7 +13,7 @@ import (
 )
 
 func newTestModel() Model {
-	m := New([]string{"/tmp"}, radioreference.Auth{}, nil, "")
+	m := New([]string{"/tmp"}, true, radioreference.Auth{}, nil, "")
 	m.width, m.height = 120, 40
 	return m
 }
@@ -147,7 +148,7 @@ func TestImportModal(t *testing.T) {
 		return config.SystemConfig{Name: "Imp", Protocol: "p25", ControlChannels: []uint32{851_000_000}},
 			[]configbuilder.TalkgroupCSVRow{{Decimal: 7}}, nil
 	}
-	m := New([]string{"/tmp"}, radioreference.Auth{}, parse, "")
+	m := New([]string{"/tmp"}, true, radioreference.Auth{}, parse, "")
 	m.width, m.height = 120, 40
 	m = gotoSection(m, "trunking")
 	m = send(m, "enter") // Systems list
@@ -178,9 +179,62 @@ func TestRRModalNoCreds(t *testing.T) {
 	}
 }
 
+// TestDefaultSavePath_PrefersDiscoveredOverCandidateDir is the #1120
+// regression. Under auto-discovery (no operator -config-dir) the Save-As
+// modal must default to the file the daemon actually loads — resolved via
+// configbuilder.DefaultConfigPath — not to dirs[0], which on Windows is
+// %APPDATA%\GopherTrunk, a location the daemon does not read when the
+// installer seeds the config under <Documents>\GopherTrunk\config.
+//
+// Fails against the old newSaveModal (which unconditionally overrode the
+// default with joinPath(m.dirs[0], "config.yaml")).
+func TestDefaultSavePath_PrefersDiscoveredOverCandidateDir(t *testing.T) {
+	// The file the daemon discovers (highest-precedence discovery input).
+	want := filepath.Join(t.TempDir(), "config.yaml")
+	t.Setenv("GOPHERTRUNK_CONFIG", want)
+
+	// Simulate the auto-discovery candidate list with an AppData-style dir
+	// first, exactly as config.CandidateDirs() yields on Windows.
+	appData := filepath.Join("appdata", "GopherTrunk")
+	m := New([]string{appData, "documents"}, false /* dirExplicit */, radioreference.Auth{}, nil, "")
+
+	if got := (&m).defaultSavePath(); got != want {
+		t.Errorf("defaultSavePath() = %q, want %q (must follow the daemon's discovery, not dirs[0])", got, want)
+	}
+	if got := (&m).defaultSavePath(); got == filepath.Join(appData, "config.yaml") {
+		t.Errorf("defaultSavePath() defaulted to dirs[0] %q — the #1120 override is back", got)
+	}
+}
+
+// TestDefaultSavePath_HonorsExplicitDir keeps an operator-supplied
+// -config-dir winning over discovery.
+func TestDefaultSavePath_HonorsExplicitDir(t *testing.T) {
+	t.Setenv("GOPHERTRUNK_CONFIG", filepath.Join(t.TempDir(), "elsewhere.yaml"))
+	dir := t.TempDir()
+	m := New([]string{dir}, true /* dirExplicit */, radioreference.Auth{}, nil, "")
+	want := filepath.Join(dir, "config.yaml")
+	if got := (&m).defaultSavePath(); got != want {
+		t.Errorf("defaultSavePath() = %q, want %q (explicit -config-dir must win)", got, want)
+	}
+}
+
+// TestDefaultSavePath_SavesBackToOpenFile keeps the open file as the
+// highest-precedence save default.
+func TestDefaultSavePath_SavesBackToOpenFile(t *testing.T) {
+	dir := t.TempDir()
+	open := filepath.Join(dir, "opened.yaml")
+	if _, err := config.WriteConfigFile(open, config.Default(), 0, true); err != nil {
+		t.Fatal(err)
+	}
+	m := New([]string{"appdata"}, false, radioreference.Auth{}, nil, open)
+	if got := (&m).defaultSavePath(); got != open {
+		t.Errorf("defaultSavePath() = %q, want %q (must save back to the open file)", got, open)
+	}
+}
+
 func TestSaveReloadRoundTrip(t *testing.T) {
 	dir := t.TempDir()
-	m := New([]string{dir}, radioreference.Auth{}, nil, "")
+	m := New([]string{dir}, true, radioreference.Auth{}, nil, "")
 	m.width, m.height = 120, 40
 	m.cfg.Trunking.Systems = []config.SystemConfig{{
 		Name: "Metro", Protocol: "p25", ControlChannels: []uint32{851_037_500},
@@ -201,7 +255,7 @@ func TestSaveReloadRoundTrip(t *testing.T) {
 	}
 
 	// Reload into a fresh model and confirm the system + talkgroups survive.
-	m2 := New([]string{dir}, radioreference.Auth{}, nil, "")
+	m2 := New([]string{dir}, true, radioreference.Auth{}, nil, "")
 	(&m2).loadPath(path)
 	if len(m2.cfg.Trunking.Systems) != 1 || m2.cfg.Trunking.Systems[0].Name != "Metro" {
 		t.Fatalf("system did not round-trip: %+v", m2.cfg.Trunking.Systems)
@@ -217,7 +271,7 @@ func TestOpenModalFileOps(t *testing.T) {
 	if _, err := config.WriteConfigFile(dir+"/a.yaml", config.Default(), 0, true); err != nil {
 		t.Fatal(err)
 	}
-	m := New([]string{dir}, radioreference.Auth{}, nil, "")
+	m := New([]string{dir}, true, radioreference.Auth{}, nil, "")
 	m.width, m.height = 120, 40
 
 	m = send(m, "o") // open modal lists a.yaml


### PR DESCRIPTION
## Summary

On Windows, `gophertrunk config` (the terminal Config Builder) saved a freshly-built `config.yaml` to `%APPDATA%\GopherTrunk\config.yaml`, but the daemon loads the installer-seeded `<Documents>\GopherTrunk\config\config.yaml` — so operators built a config the daemon never read (issue #1120). An earlier fix (`75a43ca`) taught `configbuilder.DefaultConfigPath()` to follow the daemon's discovery, but the terminal builder's Save-As modal computed that value and then **unconditionally overrode it** with the first auto-discovery candidate directory (`%APPDATA%\GopherTrunk` on Windows), so the fix never reached this path.

## Changes

- `internal/configtui/model.go`: add a `dirExplicit` field + `New` parameter (does `dirs` come from an operator `-config-dir`, or from the auto-discovery candidate list?) and a new `defaultSavePath()` method with a clear precedence: **(1)** the file currently open → **(2)** an operator-supplied `-config-dir` → **(3)** `configbuilder.DefaultConfigPath()` (the discovered / `$GOPHERTRUNK_CONFIG` file the daemon loads).
- `internal/configtui/modal.go`: `newSaveModal` now proposes `m.defaultSavePath()` instead of the unconditional `dirs[0]/config.yaml` override.
- `cmd/gophertrunk/config_tui.go`: pass `dirExplicit=true` only when the operator supplied `-config-dir`.
- `internal/configtui/model_test.go`: failing-first regression + precedence tests; updated existing `New(...)` call sites for the new signature.
- `CHANGELOG.md`: `[Unreleased] → Fixed` entry.

## Test plan

- [x] `make vet test` scope for the touched packages is green (`internal/configtui`, `internal/configbuilder`); full `go build ./...` and `go vet` pass.
- [ ] `make integration` — n/a (no daemon/DSP/replay change).
- [x] Added tests. `TestDefaultSavePath_PrefersDiscoveredOverCandidateDir` is the #1120 regression — verified failing-first: against the old override it returns `appdata/GopherTrunk/config.yaml` (the exact reported symptom) and passes only with the fix. Plus `TestDefaultSavePath_HonorsExplicitDir` and `TestDefaultSavePath_SavesBackToOpenFile`.
- [ ] Smoke-tested against real hardware — n/a (no SDR/USB/vocoder code). **Not yet verified on the reporter's Windows install** — see Linked issues.

## Breaking changes

None for operators. (Internal only: `configtui.New` gains a `dirExplicit` parameter; all in-tree callers updated.)

## Docs / CHANGELOG

- [x] Added a `## [Unreleased]` bullet to `CHANGELOG.md`.
- [ ] `README.md` / `docs/` — n/a (no operator-facing behaviour beyond the corrected default; the existing config-discovery docs remain accurate).

## Linked issues

Refs #1120 — kept as `Refs` (not `Closes`) per the repo's verify-before-close policy: the fix is unit-verified but not yet confirmed on the reporter's Windows install. Closing awaits their confirmation that `gophertrunk config` now defaults to (and saves back to) the file the daemon loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UsMtTA3dePTCcGGdqGGfw

---
_Generated by [Claude Code](https://claude.ai/code/session_011UsMtTA3dePTCcGGdqGGfw)_