### PR TITLE
release: state minimum macOS version (12 Monterey) in the release notes (#1096)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -412,7 +412,7 @@ jobs:
 
             **Windows on ARM:** extract `gophertrunk-${{ steps.version.outputs.version }}-windows-arm64.zip` (no installer for arm64 yet — portable ZIP only). The web consoles live in the `gophertrunk-web\` subfolder inside the zip (`siglab\` and `configbuilder\` alongside the standard console).
 
-            **macOS:** extract `gophertrunk-${{ steps.version.outputs.version }}-darwin-arm64.tar.gz` (Apple Silicon) or `gophertrunk-${{ steps.version.outputs.version }}-darwin-amd64.tar.gz` (Intel) and run `./gophertrunk`. Builds are unsigned — right-click → Open the first time to bypass Gatekeeper.
+            **macOS 12 (Monterey) or later** (Apple Silicon or Intel): extract `gophertrunk-${{ steps.version.outputs.version }}-darwin-arm64.tar.gz` (Apple Silicon) or `gophertrunk-${{ steps.version.outputs.version }}-darwin-amd64.tar.gz` (Intel) and run `./gophertrunk`. Builds are unsigned — right-click → Open the first time to bypass Gatekeeper. On macOS 11 or older the binary aborts at launch with `dyld: Symbol not found: _SecTrustCopyCertificateChain` — update to macOS 12+ or run on a supported machine (see the [macOS install guide](https://github.com/MattCheramie/GopherTrunk/blob/main/docs/install-macos.md)).
 
             **Linux:** extract `gophertrunk-${{ steps.version.outputs.version }}-linux-amd64.tar.gz` (x86_64) or `gophertrunk-${{ steps.version.outputs.version }}-linux-arm64.tar.gz` (aarch64, e.g. Raspberry Pi 4/5) and run `./gophertrunk`. Single static binary; no system dependencies needed.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@ for tagged releases.
   `SecTrustCopyCertificateChain`), so on macOS 11 and older they abort at launch
   with `dyld: Symbol not found`. The requirement is now stated in the README,
   the [macOS install guide](docs/install-macos.md) (a Requirements callout plus
-  a troubleshooting row for the exact `dyld` error), and the
-  [downloads page](docs/downloads.md). Docs only — no behaviour change (issue
+  a troubleshooting row for the exact `dyld` error), the
+  [downloads page](docs/downloads.md), and the GitHub **release notes** shown on
+  every release (the download point of contact — the macOS line now states the
+  requirement and the `dyld` symptom). Docs only — no behaviour change (issue
   #1096).
 
 ### Fixed


### PR DESCRIPTION
## Summary

Issue #1096 asked for the minimum macOS version to be documented. Commit `e72c2cb` already added it to the README, the macOS install guide, the downloads page, and the CHANGELOG — but it missed the **GitHub release-notes body**, which is the actual download point of contact. The reporter grabbed `gophertrunk-v0.9.7-darwin-amd64` straight from a GitHub Release and hit `dyld: Symbol not found: _SecTrustCopyCertificateChain` on macOS 11, with no version requirement stated anywhere on that page.

## Changes

- `.github/workflows/release.yml`: the `**macOS:**` line in the auto-generated release notes now reads **"macOS 12 (Monterey) or later"**, names the exact `dyld` symptom seen on macOS 11 and older, and links to the macOS install guide.
- `CHANGELOG.md`: extended the existing `[Unreleased]` #1096 Docs entry to note the release-notes addition.

## Test plan

- [x] `make vet test` — n/a to Go code (no source changed). Validated the workflow YAML parses (`yaml.safe_load`).
- [ ] `make integration` — n/a.
- [x] Docs/release-notes review: the requirement + `dyld` symptom now appear on the release page alongside the download links; wording matches the README / downloads page / install guide.
- [ ] Smoke-tested against real hardware — n/a (docs only).

## Breaking changes

None.

## Docs / CHANGELOG

- [x] Updated the `## [Unreleased]` #1096 bullet in `CHANGELOG.md`.
- [x] README / `docs/` already carry the requirement (from `e72c2cb`); this PR only fills the release-notes gap.

## Linked issues

Refs #1096. Note there is also the reporter's PR #1097 (README + install-macos title tweaks), largely superseded by `e72c2cb`; this PR is complementary — it covers the one surface neither touched (the release notes). Closing #1096 can wait on whichever of these the maintainer prefers to land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UsMtTA3dePTCcGGdqGGfw

---
_Generated by [Claude Code](https://claude.ai/code/session_011UsMtTA3dePTCcGGdqGGfw)_