### PR TITLE
tetra: stop transient AFC alias spikes and fake #815 wrong-site warnings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -690,7 +690,33 @@ confirmation before any close-as-completed.
     `widebandt2/tetra.go`). Also: a single mis-corrected BSCH could rewrite the locked MCC/MNC
     (4 bogus "tetra cc locked" flaps, mcc=996 etc.) — identity CHANGES now need 2 consecutive
     agreeing decodes, mirroring `colourConfirmThreshold`.
-  - **The MRC anchor flipped mid-stream on the 08:58 cc-hunt retune** (rearm set `refIdx=-1` →
+  - **"AFC spikes to −5 kHz" on a locked, centred TETRA CC = the 19 Aug re-prime escape
+  hatch FIRING FALSELY on an alias-class transient — fixed with a confidence gate, and
+  the #815 wrong-site WARN now requires persistence.** A reporter filmed the mixer panel's
+  carrier readout jittering ±400 Hz then spiking to ~−5 kHz; the log's #815 WARN said
+  `offset_hz=5004` on a carrier really ~500 Hz off. 5004 = 504 + 4500 and f_sym/4 = 4500 Hz:
+  the spike is EXACTLY one AFC alias bucket, not a carrier move. Mechanism: the per-block raw
+  estimate is coarse (spectral centroid) + fine (4×Δφ, unambiguous only within ±f_sym/8 =
+  ±2250 Hz), so ANY transient coarse bias > 2250 Hz (a neighbour's skirts through the
+  channel-filter edge while the wanted carrier fades) lands the raw estimate exactly ±4500 Hz
+  off — and three such consecutive blocks (~170 ms) tripped the 19 Aug clustered-reject
+  re-prime, slamming a long-corroborated EMA into the wrong bucket (SCH fails ~100% there;
+  BSCH survives via per-burst SB correction, so the lock looks healthy). The two failure
+  modes are the SAME signature at different ages: a wrong one-block seed (19 Aug) needs a
+  FAST escape, a transient on an established track needs a HOLD. Fix (`afc.go`): `track`
+  counts accepted blocks since the last prime (`accSincePrime`); an alias-class reject
+  cluster (cluster mean ≡ EMA mod π/2, `aliasClassOffset`) on an established track
+  (≥16 accepted blocks) needs `omegaReprimeStreakEstablished`=18 blocks (~1 s) to re-prime,
+  while fresh tracks and non-alias clusters keep the fast 3-block escape; a wrong slow
+  re-prime self-heals fast (it leaves a fresh track) and `checkPayloadResync` bounds the
+  worst case. Pinned failing-first by `afc_alias_transient_test.go` (old code jumps to
+  4950 Hz after exactly 3 alias blocks). Companion fix (`ccdecoder/decoder.go`): the #815
+  WARN diagnosed a persistent condition from ONE per-chunk instantaneous sample, so every
+  sub-second estimator blip produced a scary wrong-site WARN — the "fake triggering of freq
+  offset" report; it now requires the total offset to sit over threshold continuously for
+  `carrierOffsetWarnPersist` (10 s, test-overridable field), with the excursion clock reset
+  on dips and on pipeline teardown. Pinned by `TestDecoderCarrierOffsetWarnRequiresPersistence`.
+- **The MRC anchor flipped mid-stream on the 08:58 cc-hunt retune** (rearm set `refIdx=-1` →
     bare argmax re-pick), and the applied gain random-walked to −34 dB with `calibrated=true`
     (divergence bounds gated only the proposal). Fixes: rearm/`setSampleRate`/short-payloads
     KEEP the anchor (dead-incumbent escape still works), every anchor change is logged,

--- a/internal/radio/tetra/receiver/afc.go
+++ b/internal/radio/tetra/receiver/afc.go
@@ -57,6 +57,17 @@ type carrierAFC struct {
 	// omegaReprimeStreak of them the EMA is re-primed from their mean.
 	rejStreak int
 	rejMean   float64
+
+	// accSincePrime counts accepted blocks since the EMA was last (re)primed,
+	// saturating at omegaEstablishedBlocks. It is the track's confidence: a
+	// fresh seed (post-Reset, or just after a re-prime) has none, an EMA that
+	// hundreds of accepted estimates have corroborated has earned trust. The
+	// re-prime escape hatch reads it to pick between the fast streak (fresh
+	// track — a wrong one-block seed must be corrected at once) and the slow
+	// one (established track — an alias-class reject cluster is far more
+	// likely a transiently biased coarse stage than a carrier that really
+	// stepped exactly ±n·f_sym/4).
+	accSincePrime int
 }
 
 // afcBlockSymbols is the feed-forward re-estimation window in symbols.
@@ -90,6 +101,31 @@ const omegaRejectClusterTol = omegaAliasReject / 2
 // EMA (~3 × 57 ms ≈ 170 ms of signal). A single accepted block in between
 // zeroes the streak, so sporadic outliers can never trip it.
 const omegaReprimeStreak = 3
+
+// omegaEstablishedBlocks is how many accepted blocks (~16 × 57 ms ≈ 0.9 s)
+// corroborate the EMA before the track counts as established. Below it the
+// escape hatch stays fast — the EMA may still be a wrong one-block seed and
+// omegaReprimeStreak clustered rejects must fix it at once (the 19 Aug latch).
+// At or above it the EMA has real evidence behind it, and an alias-class
+// reject cluster must clear the omegaReprimeStreakEstablished bar instead.
+const omegaEstablishedBlocks = 16
+
+// omegaReprimeStreakEstablished is the reject streak an ALIAS-CLASS cluster
+// (cluster mean ≡ EMA mod π/2 — see aliasClassOffset) needs to re-prime an
+// ESTABLISHED track (~18 × 57 ms ≈ 1 s). An alias-class cluster is ambiguous:
+// it reads the same whether the EMA latched the wrong ±f_sym/4 bucket (rejects
+// are the correct carrier) or a fading neighbour transiently biased the coarse
+// stage past its ±f_sym/8 wrap so the rejects themselves are one bucket off —
+// the failure a reporter filmed as "AFC spikes to -5 kHz" on a locked, centred
+// CC (logged 5004 ≈ 504 + 4500 Hz), where the old unconditional 3-block streak
+// let a ~200 ms transient slam a long-corroborated EMA into the wrong bucket
+// and fail every SCH burst until it re-primed back. Duration disambiguates: a
+// coarse-bias transient passes in well under a second, a genuinely moved
+// carrier does not. Non-alias clusters (a real off-grid jump) and fresh tracks
+// keep the fast streak; and if a slow re-prime ever picks wrong, the fresh
+// track it leaves behind fast-corrects omegaReprimeStreak blocks later, while
+// the payload-drought resync (checkPayloadResync) bounds the true worst case.
+const omegaReprimeStreakEstablished = 18
 
 func newCarrierAFC(sps int) *carrierAFC {
 	if sps < 1 {
@@ -236,17 +272,26 @@ func (a *carrierAFC) Process(dst, matched, wide []complex64) []complex64 {
 // consecutive clustered rejects re-prime the EMA from their mean — the
 // escape hatch for a wrong first-block seed that would otherwise reject
 // every correct estimate forever (19 Aug field log: −3630 Hz latched for
-// 12 minutes while BSCH decoded and SCH sat at zero).
+// 12 minutes while BSCH decoded and SCH sat at zero). The streak the hatch
+// needs scales with the track's earned confidence: on an ESTABLISHED track
+// (accSincePrime full) an alias-class cluster — one that reads as an exact
+// ±f_sym/4 step — must persist omegaReprimeStreakEstablished blocks, so a
+// sub-second coarse-bias transient can no longer spike a corroborated EMA
+// into the wrong bucket ("AFC spikes to -5 kHz" field report).
 func (a *carrierAFC) track(rawOmega float64) {
 	if !a.omegaPrimed {
 		a.omegaEMA = rawOmega
 		a.omegaPrimed = true
 		a.rejStreak = 0
+		a.accSincePrime = 0
 		return
 	}
 	if math.Abs(rawOmega-a.omegaEMA) < omegaAliasReject {
 		a.omegaEMA += omegaEMAAlpha * (rawOmega - a.omegaEMA)
 		a.rejStreak = 0
+		if a.accSincePrime < omegaEstablishedBlocks {
+			a.accSincePrime++
+		}
 		return
 	}
 	if a.rejStreak > 0 && math.Abs(rawOmega-a.rejMean) < omegaRejectClusterTol {
@@ -256,10 +301,31 @@ func (a *carrierAFC) track(rawOmega float64) {
 		a.rejStreak = 1
 		a.rejMean = rawOmega
 	}
-	if a.rejStreak >= omegaReprimeStreak {
+	need := omegaReprimeStreak
+	if a.accSincePrime >= omegaEstablishedBlocks && aliasClassOffset(a.rejMean-a.omegaEMA) {
+		need = omegaReprimeStreakEstablished
+	}
+	if a.rejStreak >= need {
 		a.omegaEMA = a.rejMean
 		a.rejStreak = 0
+		a.accSincePrime = 0
 	}
+}
+
+// aliasClassOffset reports whether an EMA-to-cluster delta is an exact
+// ±f_sym/4 alias step: congruent to 0 modulo π/2 rad/symbol within
+// omegaRejectClusterTol. That is the signature of the fine estimator wrapping
+// (its window is ±π/4) under a coarse-stage bias — as opposed to a carrier
+// that genuinely moved to an off-grid frequency.
+func aliasClassOffset(d float64) bool {
+	const bucket = math.Pi / 2
+	r := math.Mod(d, bucket) // (−π/2, π/2), sign of d
+	if r > bucket/2 {
+		r -= bucket
+	} else if r < -bucket/2 {
+		r += bucket
+	}
+	return math.Abs(r) < omegaRejectClusterTol
 }
 
 // OffsetHz reports the most recent per-symbol offset estimate in Hz.
@@ -273,6 +339,7 @@ func (a *carrierAFC) Reset() {
 	a.omegaPrimed = false
 	a.rejStreak = 0
 	a.rejMean = 0
+	a.accSincePrime = 0
 }
 
 func conjf(c complex64) complex64 { return complex(real(c), -imag(c)) }

--- a/internal/radio/tetra/receiver/afc_alias_transient_test.go
+++ b/internal/radio/tetra/receiver/afc_alias_transient_test.go
@@ -1,0 +1,98 @@
+package receiver
+
+import (
+	"math"
+	"testing"
+)
+
+// emaHz reads the smoothed EMA in Hz — the value Process derotates by and
+// OffsetHz reports after the next block (track itself never touches a.omega).
+func emaHz(a *carrierAFC) float64 { return a.omegaEMA * SymbolRate / (2 * math.Pi) }
+
+// establishTrack primes a carrierAFC at trueHz and feeds it enough accepted
+// per-block estimates (small realistic jitter) to corroborate the track past
+// omegaEstablishedBlocks — the state a control channel reaches within ~1 s of
+// locking.
+func establishTrack(a *carrierAFC, trueHz float64) {
+	a.track(omegaFromHz(trueHz))
+	for i := 0; i <= omegaEstablishedBlocks; i++ {
+		jitterHz := float64((i%3)-1) * 90 // −90/0/+90 Hz block-to-block jitter
+		a.track(omegaFromHz(trueHz + jitterHz))
+	}
+}
+
+// TestAFCEstablishedTrackHoldsThroughAliasTransient pins the field failure a
+// reporter filmed on a locked, centred TETRA CC: "sometimes AFC spikes to huge
+// numbers like -5 kHz". The per-block raw estimate is coarse+fine, and any
+// transient coarse-stage bias > f_sym/8 (a neighbour's skirts through the
+// channel-filter edge while the wanted carrier fades) lands the raw estimate
+// EXACTLY one ±f_sym/4 = ±4500 Hz alias bucket off (the logged spike was
+// 5004 ≈ 504 + 4500 Hz). Three such consecutive blocks (~170 ms) used to trip
+// the 19 Aug re-prime escape hatch and slam a long-established EMA into the
+// wrong bucket — a wrong-bucket derotation that fails every SCH burst until
+// the correct estimates re-prime it back. An established track must HOLD
+// through an alias-class transient several times the old streak length, and
+// keep accepting correct estimates afterwards.
+func TestAFCEstablishedTrackHoldsThroughAliasTransient(t *testing.T) {
+	const trueHz = 450.0
+	a := newCarrierAFC(8)
+	establishTrack(a, trueHz)
+
+	// ~340 ms of coherent alias-bucket estimates — twice the fresh-track
+	// escape streak, the shape of a sub-second coarse-bias transient.
+	for i := 0; i < 2*omegaReprimeStreak; i++ {
+		jitterHz := float64((i%3)-1) * 70
+		a.track(omegaFromHz(trueHz + 4500 + jitterHz))
+		if got := emaHz(a); math.Abs(got-trueHz) > 300 {
+			t.Fatalf("established EMA jumped to %.0f Hz after %d alias blocks, want to hold ~%.0f", got, i+1, trueHz)
+		}
+	}
+
+	// The transient passes; correct estimates must be accepted (not treated
+	// as a new outlier cluster) and keep tracking.
+	for i := 0; i < 5; i++ {
+		a.track(omegaFromHz(trueHz + 60))
+	}
+	if got := emaHz(a); math.Abs(got-trueHz) > 300 {
+		t.Fatalf("EMA did not resume tracking after the transient: %.0f Hz, want ~%.0f", got, trueHz)
+	}
+}
+
+// TestAFCEstablishedTrackEscapesSustainedAliasShift pins the bound on the
+// hold: the re-prime escape hatch must still exist on an established track —
+// a carrier genuinely sitting one alias bucket away for over a second
+// (adjacent-site takeover, oscillator step) re-primes rather than being
+// rejected forever, which would recreate the 19 Aug "locked but deaf" latch.
+func TestAFCEstablishedTrackEscapesSustainedAliasShift(t *testing.T) {
+	const trueHz = 450.0
+	a := newCarrierAFC(8)
+	establishTrack(a, trueHz)
+
+	shifted := trueHz + 4500
+	for i := 0; i < 2*omegaReprimeStreakEstablished; i++ {
+		jitterHz := float64((i%3)-1) * 70
+		a.track(omegaFromHz(shifted + jitterHz))
+	}
+	if got := emaHz(a); math.Abs(got-shifted) > 300 {
+		t.Fatalf("EMA never re-primed onto a sustained alias-bucket shift: %.0f Hz, want ~%.0f", got, shifted)
+	}
+}
+
+// TestAFCEstablishedTrackFastReprimeOnNonAliasJump pins that the slow gate is
+// alias-class only: a rejected cluster that is NOT an alias of the tracked
+// value (here +3000 Hz — 1500 Hz from the nearest π/2 bucket step, well past
+// omegaRejectClusterTol) is a genuine carrier move, and keeps the fast
+// omegaReprimeStreak escape even on an established track.
+func TestAFCEstablishedTrackFastReprimeOnNonAliasJump(t *testing.T) {
+	const trueHz = 450.0
+	a := newCarrierAFC(8)
+	establishTrack(a, trueHz)
+
+	jumped := trueHz + 3000
+	for i := 0; i < omegaReprimeStreak; i++ {
+		a.track(omegaFromHz(jumped))
+	}
+	if got := emaHz(a); math.Abs(got-jumped) > 300 {
+		t.Fatalf("non-alias jump did not fast re-prime: %.0f Hz, want ~%.0f", got, jumped)
+	}
+}

--- a/internal/scanner/ccdecoder/decoder.go
+++ b/internal/scanner/ccdecoder/decoder.go
@@ -199,6 +199,19 @@ const zeroIFHealthErrPct = 20
 // iqClipLog / iqDCLog 30 s cadence so a stuck adjacent-channel lock logs steadily.
 const carrierOffsetWarnInterval = 30 * time.Second
 
+// carrierOffsetWarnPersist is how long the total offset must sit continuously
+// over the WARN threshold before the first #815 line is emitted. The condition
+// the WARN diagnoses — locked onto an adjacent site's carrier, or a grossly
+// mistuned oscillator — is persistent by nature, but the sampled AFC estimate
+// is not: a TETRA field report ("fake triggering of freq offset … sometimes AFC
+// spikes to huge numbers like -5 kHz") showed the receiver's smoothed estimate
+// transiently latching one ±f_sym/4 = 4500 Hz alias bucket off (logged
+// offset_hz=5004 on a carrier really ~500 Hz off) for well under a second,
+// and the old per-chunk instantaneous check turned each such blip into a
+// scary wrong-site WARN. 10 s cannot be crossed by an estimator transient,
+// while a genuine adjacent-site lock still warns shortly after acquisition.
+const carrierOffsetWarnPersist = 10 * time.Second
+
 // The decode queue between the lightweight IQ forwarder and the decode goroutine
 // (issue #402) is bounded by a wall-clock SAMPLE BUDGET, not a fixed count of
 // chunks. The SDR driver drops the instant its own delivery channel backs up, so
@@ -374,9 +387,15 @@ type Decoder struct {
 	// WARN to one line per carrierOffsetWarnInterval while the offset stays
 	// over threshold; it resets to zero when the offset falls back under
 	// threshold so a fresh excursion re-warns at once (owned by the pump
-	// goroutine). Issue #815.
-	carrierOffsetWarnHz int
-	lastOffsetWarnAt    time.Time
+	// goroutine). carrierOffsetWarnPersist is how long the offset must stay
+	// continuously over threshold before the first WARN (defaulted from the
+	// const; a field so tests can drive the check without waiting real
+	// seconds), with offsetOverWarnSince marking when the current excursion
+	// began. Issue #815.
+	carrierOffsetWarnHz      int
+	carrierOffsetWarnPersist time.Duration
+	lastOffsetWarnAt         time.Time
+	offsetOverWarnSince      time.Time
 
 	// zeroIF* back the issue #402 dc_avoid nudge: while locked at zero-IF
 	// (loOffsetHz == 0), the decoder measures the TSBK error rate over
@@ -572,6 +591,7 @@ func New(opts Options) (*Decoder, error) {
 	if d.carrierOffsetWarnHz <= 0 {
 		d.carrierOffsetWarnHz = defaultCarrierOffsetWarnHz
 	}
+	d.carrierOffsetWarnPersist = carrierOffsetWarnPersist
 	d.zeroIFHealthWindow = zeroIFHealthWindow
 	d.ddcRec = newDDCRecorder(opts.DDCRecordDir, log)
 	for _, s := range opts.Systems {
@@ -888,6 +908,11 @@ func (d *Decoder) clearActiveLocked() {
 	// re-baselines against its own fresh TSBK counters instead of
 	// diffing against the torn-down pipeline's totals.
 	d.zeroIFHealthAt = time.Time{}
+	// Drop the issue #815 offset-excursion clock too: a stale excursion from
+	// a torn-down lock must not let the next acquisition warn instantly
+	// before its own carrierOffsetWarnPersist has elapsed.
+	d.offsetOverWarnSince = time.Time{}
+	d.lastOffsetWarnAt = time.Time{}
 	if d.activeAt != "" && d.metrics != nil {
 		d.metrics.ClearIQPowerDbFS(d.activeAt)
 		d.metrics.ClearIQDCRatioDb(d.activeAt)
@@ -1158,11 +1183,15 @@ func (d *Decoder) sampleAutotuneLocked() {
 // AFCOffsetHz: with autotune off (the default) applied is 0 and the total is the
 // raw residual; with autotune on, a large genuine offset is folded into applied,
 // so summing the two still catches an adjacent-channel lock autotune would
-// otherwise hide by chasing the wrong carrier (issue #815). Advisory only — it
-// never retunes; it tells the operator the locked carrier sits far from the
-// configured frequency, so the reported site identity may belong to a stronger
-// neighbouring site bleeding through (or the front-end oscillator is mistuned).
-// Caller holds d.mu.
+// otherwise hide by chasing the wrong carrier (issue #815). The offset must sit
+// over threshold continuously for d.carrierOffsetWarnPersist before the first
+// WARN: the condition diagnosed is persistent, but the sampled estimate can
+// transiently spike an alias bucket off (the "-5 kHz AFC spikes" field report),
+// and a per-chunk instantaneous check turned each blip into a wrong-site WARN.
+// Advisory only — it never retunes; it tells the operator the locked carrier
+// sits far from the configured frequency, so the reported site identity may
+// belong to a stronger neighbouring site bleeding through (or the front-end
+// oscillator is mistuned). Caller holds d.mu.
 func (d *Decoder) checkCarrierOffsetLocked() {
 	if !d.locked.Load() {
 		return
@@ -1176,10 +1205,17 @@ func (d *Decoder) checkCarrierOffsetLocked() {
 		total = -total
 	}
 	if total < d.carrierOffsetWarnHz {
-		d.lastOffsetWarnAt = time.Time{} // re-arm so a fresh excursion warns at once
+		d.lastOffsetWarnAt = time.Time{} // re-arm so a fresh excursion warns anew
+		d.offsetOverWarnSince = time.Time{}
 		return
 	}
 	now := time.Now()
+	if d.offsetOverWarnSince.IsZero() {
+		d.offsetOverWarnSince = now
+	}
+	if now.Sub(d.offsetOverWarnSince) < d.carrierOffsetWarnPersist {
+		return
+	}
 	if !d.lastOffsetWarnAt.IsZero() && now.Sub(d.lastOffsetWarnAt) < carrierOffsetWarnInterval {
 		return
 	}

--- a/internal/scanner/ccdecoder/decoder_test.go
+++ b/internal/scanner/ccdecoder/decoder_test.go
@@ -2125,6 +2125,10 @@ func newOffsetTestDecoder(t *testing.T, buf *bytes.Buffer) *Decoder {
 	t.Cleanup(func() { d.Close() })
 	setActiveSystem(d, "Geelong")
 	d.activeFreqHz = 420_075_000
+	// Persistence 0 so the threshold/throttle pins below fire on the first
+	// over-threshold tick; TestDecoderCarrierOffsetWarnRequiresPersistence
+	// covers the persistence gate itself.
+	d.carrierOffsetWarnPersist = 0
 	return d
 }
 
@@ -2313,6 +2317,10 @@ func TestDecoderWarnsOnLargeCarrierOffsetEndToEnd(t *testing.T) {
 			t.Fatalf("New: %v", err)
 		}
 		defer d.Close()
+		// The pump runs in simulated signal time here, so the wall-clock
+		// persistence gate would keep a genuinely sustained offset silent;
+		// zero it to pin the measurement + threshold path.
+		d.carrierOffsetWarnPersist = 0
 		sub := bus.Subscribe()
 		defer sub.Close()
 
@@ -2441,6 +2449,49 @@ func TestDecoderCarrierOffsetWarnThrottled(t *testing.T) {
 	}
 }
 
+// TestDecoderCarrierOffsetWarnRequiresPersistence pins the fix for the "fake
+// triggering of freq offset" field report: the receiver's smoothed AFC estimate
+// can transiently spike one ±f_sym/4 alias bucket off (a TETRA operator's log
+// showed offset_hz=5004 on a carrier really ~500 Hz off, gone within seconds),
+// and the per-chunk instantaneous check turned each blip into a wrong-site
+// WARN. The offset must now sit over threshold continuously for
+// carrierOffsetWarnPersist before the first WARN; dipping under threshold
+// resets the excursion clock.
+func TestDecoderCarrierOffsetWarnRequiresPersistence(t *testing.T) {
+	var buf bytes.Buffer
+	d := newOffsetTestDecoder(t, &buf)
+	d.carrierOffsetWarnPersist = time.Hour // nothing in this test may outlast it
+	pipe := &fakeAFCPipeline{offsetHz: 5004}
+	d.active = pipe
+	d.locked.Store(true)
+
+	// A transient spike: over threshold for a few ticks, then back under.
+	for i := 0; i < 5; i++ {
+		d.checkCarrierOffsetLocked()
+	}
+	if strings.Contains(buf.String(), carrierOffsetWarnMsg) {
+		t.Fatalf("transient spike warned before the persistence window elapsed; log: %q", buf.String())
+	}
+	pipe.offsetHz = 400
+	d.checkCarrierOffsetLocked()
+	if !d.offsetOverWarnSince.IsZero() {
+		t.Fatalf("excursion clock not reset when the offset fell back under threshold")
+	}
+
+	// A genuinely sustained excursion warns once the window has elapsed:
+	// backdate the excursion start rather than sleeping.
+	pipe.offsetHz = 12500
+	d.checkCarrierOffsetLocked() // starts the excursion clock
+	if strings.Contains(buf.String(), carrierOffsetWarnMsg) {
+		t.Fatalf("sustained excursion warned before the persistence window elapsed; log: %q", buf.String())
+	}
+	d.offsetOverWarnSince = time.Now().Add(-2 * time.Hour)
+	d.checkCarrierOffsetLocked()
+	if n := strings.Count(buf.String(), carrierOffsetWarnMsg); n != 1 {
+		t.Fatalf("sustained over-threshold offset past the window: warns = %d, want 1 (log: %q)", n, buf.String())
+	}
+}
+
 // TestDecoderCarrierOffsetWarnHzConfigurable confirms Options.CarrierOffsetWarnHz
 // overrides the default threshold, and that zero falls back to the default.
 func TestDecoderCarrierOffsetWarnHzConfigurable(t *testing.T) {
@@ -2466,6 +2517,7 @@ func TestDecoderCarrierOffsetWarnHzConfigurable(t *testing.T) {
 	}
 	defer d2.Close()
 	setActiveSystem(d2, "Geelong")
+	d2.carrierOffsetWarnPersist = 0
 	d2.active = &fakeAFCPipeline{offsetHz: 12500}
 	d2.locked.Store(true)
 	d2.checkCarrierOffsetLocked()


### PR DESCRIPTION
A reporter's locked, centred TETRA CC (carrier ~500 Hz off) showed the AFC
readout jittering and "sometimes spiking to huge numbers like -5 kHz", with
the #815 wrong-site WARN firing at offset_hz=5004. 5004 = 504 + 4500 Hz and
f_sym/4 = 4500 Hz: the spike is exactly one alias bucket of the two-stage
estimator, not a carrier move. Any transient coarse-stage bias past the fine
estimator's ±f_sym/8 wrap (a neighbour's skirts through the channel-filter
edge while the wanted carrier fades) lands the per-block raw estimate exactly
one ±4500 Hz bucket off, and three such consecutive blocks (~170 ms) tripped
the clustered-reject re-prime escape hatch, slamming a long-corroborated EMA
into the wrong bucket — failing every SCH burst until it re-primed back.

carrierAFC.track now scales the escape hatch with the track's earned
confidence: an alias-class reject cluster (cluster mean congruent to the EMA
mod pi/2) on an established track (>= omegaEstablishedBlocks accepted blocks)
must persist omegaReprimeStreakEstablished (~1 s) before re-priming, so a
sub-second coarse-bias transient holds instead of spiking. Fresh tracks — the
wrong one-block seed the escape hatch exists for — and non-alias clusters
(a genuine off-grid carrier move) keep the fast 3-block escape, and a wrong
slow re-prime self-heals fast because it leaves a fresh track behind.
Failing-first: TestAFCEstablishedTrackHoldsThroughAliasTransient jumps to
4950 Hz after exactly 3 alias blocks on the old code.

The #815 WARN diagnosed a persistent condition (adjacent-site lock, gross
mistune) from one instantaneous per-chunk sample, so every sub-second
estimator blip produced a scary wrong-site warning. checkCarrierOffsetLocked
now requires the total offset to sit over threshold continuously for
carrierOffsetWarnPersist (10 s, test-overridable) before the first WARN,
resetting the excursion clock on dips and on pipeline teardown. Pinned by
TestDecoderCarrierOffsetWarnRequiresPersistence.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JDFrCQNrHAycf8Us3xzHNJ