### PR TITLE
rtlsdr: recover RTL-SDR Blog V4 retune from a control-pipe stall (#753)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,22 @@ for tagged releases.
   #1096).
 
 ### Fixed
+- **RTL-SDR Blog V4 retunes no longer abort on an intermittent control-pipe
+  stall** (issue #753). The V4's R828D occasionally STALLs a demod control write
+  mid-run — most visibly the `SetI2CRepeater` toggle inside a `SetCenterFreq`
+  retune — surfacing as a raw `broken pipe` (`EPIPE`) on Linux/usbdevfs or
+  `usb: pipe stalled` on Windows/macOS and aborting the whole tune, even though
+  `rtl_test`/SDR++ tune the same dongle cleanly (libusb recovers a stalled
+  control pipe). GopherTrunk's native stack recovered such stalls only on the
+  open-time bring-up path (full device reset) and the tuner burst path; the
+  runtime demod/block/I2C control path had none. It now settles and retries once
+  on a control-pipe stall, armed only after bring-up completes (the cold-boot
+  reset envelope is unchanged) and bounded to a single retry so a persistent
+  stall still surfaces. A full device reset is deliberately not used at runtime —
+  it would tear down the live IQ stream mid-tune. Additive recovery path; no
+  config/behaviour change.
 - **`gophertrunk config` (terminal Config Builder) now defaults its Save path to
-  the file the daemon actually loads** (issue #1120). The earlier #1120 fix
+  the file the daemon actually loads** (issue #1120). The earlier #1120 fix The earlier #1120 fix
   taught `configbuilder.DefaultConfigPath` to follow the daemon's discovery, but
   the terminal builder's Save-As modal overrode it with the first auto-discovery
   candidate directory — `%APPDATA%\GopherTrunk` on Windows — so a freshly-built

--- a/internal/sdr/rtlsdr/purego/driver.go
+++ b/internal/sdr/rtlsdr/purego/driver.go
@@ -223,6 +223,12 @@ func openDevice(transport usb.Transport, desc usb.Descriptor, idx int) (*Device,
 		}
 	}
 
+	// Bring-up is complete: arm runtime control-pipe-stall recovery on the
+	// demod control path. Only now — before this, a control-pipe stall is the
+	// cold-boot latch the reset envelope above must handle, so the in-place
+	// settle-and-retry stays off during bring-up (issue #753).
+	demod.EnableControlStallRetry()
+
 	// RTL-SDR Blog V4: the R828D needs its 28.8 MHz crystal and per-band
 	// input switching (issue #264). Detect it from the USB descriptor
 	// strings (the V4 sources these from EEPROM) and arm the V4 path on

--- a/internal/sdr/rtlsdr/rtl2832u/ctrl_retry.go
+++ b/internal/sdr/rtlsdr/rtl2832u/ctrl_retry.go
@@ -1,0 +1,65 @@
+package rtl2832u
+
+import (
+	"errors"
+	"syscall"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/usb"
+)
+
+// controlStallSettle is the pause before retrying a control transfer that
+// stalled the pipe, giving the device firmware and the host USB stack a
+// moment to clear the STALL — the same recovery libusb performs implicitly,
+// which is why rtl_test / SDR++ tune a dongle that stalls GopherTrunk.
+const controlStallSettle = 5 * time.Millisecond
+
+// EnableControlStallRetry arms runtime control-pipe-stall recovery on the
+// demod / block / I2C control transfers. Call it once, AFTER bring-up
+// completes.
+//
+// During bring-up a control-pipe stall is the cold-boot latch that only a
+// full device reset clears, and the open-time retry envelope
+// (purego.runBringup) owns that — so the settle-and-retry here must stay off
+// until bring-up is done, or it would mask the stall the reset needs to see.
+// Once armed, an intermittent RUNTIME stall — most visibly the SetI2CRepeater
+// toggle inside a SetCenterFreq retune on the RTL-SDR Blog V4's R828D
+// (issue #753) — is settled and retried once in place instead of aborting the
+// whole tune. A full device reset is deliberately NOT used at runtime: it
+// would tear down the live IQ stream mid-tune.
+func (d *Demod) EnableControlStallRetry() {
+	d.mu.Lock()
+	d.stallRetry = true
+	d.mu.Unlock()
+}
+
+// isControlPipeStall reports whether err is a recoverable control-pipe STALL:
+// raw syscall.EPIPE on Linux/usbdevfs, usb.ErrPipeStalled on Windows/WinUSB
+// and macOS/IOKit.
+func isControlPipeStall(err error) bool {
+	return errors.Is(err, syscall.EPIPE) || errors.Is(err, usb.ErrPipeStalled)
+}
+
+// ctrlOut issues a vendor-OUT control transfer, settling and retrying ONCE on
+// a control-pipe stall when runtime recovery is armed (EnableControlStallRetry).
+// Callers hold d.mu. A stall that survives the single retry still surfaces, so
+// a genuinely wedged pipe is never hidden by silent looping.
+func (d *Demod) ctrlOut(bRequest uint8, wValue, wIndex uint16, data []byte, timeoutMs int) error {
+	err := d.t.ControlOut(bRequest, wValue, wIndex, data, timeoutMs)
+	if err != nil && d.stallRetry && isControlPipeStall(err) {
+		time.Sleep(controlStallSettle)
+		err = d.t.ControlOut(bRequest, wValue, wIndex, data, timeoutMs)
+	}
+	return err
+}
+
+// ctrlIn is the vendor-IN counterpart of ctrlOut, with the same
+// settle-and-retry-once recovery. Callers hold d.mu.
+func (d *Demod) ctrlIn(bRequest uint8, wValue, wIndex uint16, n, timeoutMs int) ([]byte, error) {
+	out, err := d.t.ControlIn(bRequest, wValue, wIndex, n, timeoutMs)
+	if err != nil && d.stallRetry && isControlPipeStall(err) {
+		time.Sleep(controlStallSettle)
+		out, err = d.t.ControlIn(bRequest, wValue, wIndex, n, timeoutMs)
+	}
+	return out, err
+}

--- a/internal/sdr/rtlsdr/rtl2832u/ctrl_retry_test.go
+++ b/internal/sdr/rtlsdr/rtl2832u/ctrl_retry_test.go
@@ -1,0 +1,103 @@
+package rtl2832u
+
+import (
+	"errors"
+	"syscall"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/usb"
+)
+
+// stallTransport is a minimal usb.Transport whose ControlOut stalls its
+// first stallOuts calls (with stallErr) and then succeeds. Everything else
+// is a benign no-op; ControlIn always succeeds (SetI2CRepeater's commit read).
+type stallTransport struct {
+	stallOuts int   // number of leading ControlOut calls that return stallErr
+	stallErr  error // the stall error to return
+	outCalls  int
+	inCalls   int
+}
+
+func (s *stallTransport) ControlOut(_ uint8, _, _ uint16, _ []byte, _ int) error {
+	s.outCalls++
+	if s.outCalls <= s.stallOuts {
+		return s.stallErr
+	}
+	return nil
+}
+
+func (s *stallTransport) ControlIn(_ uint8, _, _ uint16, n, _ int) ([]byte, error) {
+	s.inCalls++
+	return make([]byte, n), nil
+}
+
+func (s *stallTransport) ClaimInterface(int) error                                    { return nil }
+func (s *stallTransport) ReleaseInterface(int) error                                  { return nil }
+func (s *stallTransport) StartBulkIn(byte, int, int, func([]byte), func(error)) error { return nil }
+func (s *stallTransport) StopBulkIn() error                                           { return nil }
+func (s *stallTransport) Reset() error                                                { return nil }
+func (s *stallTransport) Close() error                                                { return nil }
+
+var _ usb.Transport = (*stallTransport)(nil)
+
+// TestSetI2CRepeater_RecoversFromControlPipeStall is the #753 regression: an
+// intermittent control-pipe STALL on the SetI2CRepeater demod write (the
+// RTL-SDR Blog V4's R828D mid-retune) must be settled and retried once when
+// runtime recovery is armed, instead of aborting the tune. Covers both the
+// Linux (syscall.EPIPE) and Windows/macOS (usb.ErrPipeStalled) stall forms.
+//
+// Fails first without the retry: the single stalled ControlOut surfaces
+// straight out of SetI2CRepeater.
+func TestSetI2CRepeater_RecoversFromControlPipeStall(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"linux-EPIPE", syscall.EPIPE},
+		{"pipe-stalled", usb.ErrPipeStalled},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := &stallTransport{stallOuts: 1, stallErr: tc.err}
+			d := New(tr)
+			d.EnableControlStallRetry() // armed post-bring-up
+
+			if err := d.SetI2CRepeater(true); err != nil {
+				t.Fatalf("SetI2CRepeater(true) = %v, want nil (should recover from a single control-pipe stall)", err)
+			}
+			if tr.outCalls != 2 {
+				t.Errorf("ControlOut called %d times, want 2 (one stall + one retry)", tr.outCalls)
+			}
+		})
+	}
+}
+
+// TestSetI2CRepeater_StallNotRetriedDuringBringup guards that recovery stays
+// OFF until EnableControlStallRetry is called: during bring-up a control-pipe
+// stall is the cold-boot latch the open-time reset envelope must see, so it
+// must surface, not be silently retried.
+func TestSetI2CRepeater_StallNotRetriedDuringBringup(t *testing.T) {
+	tr := &stallTransport{stallOuts: 1, stallErr: syscall.EPIPE}
+	d := New(tr) // NOT armed
+
+	if err := d.SetI2CRepeater(true); !errors.Is(err, syscall.EPIPE) {
+		t.Fatalf("SetI2CRepeater(true) = %v, want an EPIPE stall surfaced (no retry before bring-up completes)", err)
+	}
+	if tr.outCalls != 1 {
+		t.Errorf("ControlOut called %d times, want 1 (unarmed: no retry)", tr.outCalls)
+	}
+}
+
+// TestSetI2CRepeater_PersistentStallSurfaces guards the bound: a stall that
+// survives the single retry still surfaces (no silent looping on a wedged pipe).
+func TestSetI2CRepeater_PersistentStallSurfaces(t *testing.T) {
+	tr := &stallTransport{stallOuts: 2, stallErr: usb.ErrPipeStalled} // both attempts stall
+	d := New(tr)
+	d.EnableControlStallRetry()
+
+	if err := d.SetI2CRepeater(true); !errors.Is(err, usb.ErrPipeStalled) {
+		t.Fatalf("SetI2CRepeater(true) = %v, want the persistent stall surfaced", err)
+	}
+	if tr.outCalls != 2 {
+		t.Errorf("ControlOut called %d times, want 2 (one retry, then give up)", tr.outCalls)
+	}
+}

--- a/internal/sdr/rtlsdr/rtl2832u/i2c.go
+++ b/internal/sdr/rtlsdr/rtl2832u/i2c.go
@@ -44,7 +44,7 @@ func (d *Demod) I2CWrite(i2cAddr uint8, data []byte) error {
 
 func (d *Demod) i2cWriteLocked(i2cAddr uint8, data []byte) error {
 	index := uint16(BlockIIC)<<8 | 0x10
-	if err := d.t.ControlOut(0, uint16(i2cAddr), index, data, CtrlTimeoutMs); err != nil {
+	if err := d.ctrlOut(0, uint16(i2cAddr), index, data, CtrlTimeoutMs); err != nil {
 		return fmt.Errorf("rtl2832u: I2CWrite addr=0x%02x: %w", i2cAddr, err)
 	}
 	return nil
@@ -68,7 +68,7 @@ func (d *Demod) I2CRead(i2cAddr uint8, n int) ([]byte, error) {
 
 func (d *Demod) i2cReadLocked(i2cAddr uint8, n int) ([]byte, error) {
 	index := uint16(BlockIIC) << 8
-	out, err := d.t.ControlIn(0, uint16(i2cAddr), index, n, CtrlTimeoutMs)
+	out, err := d.ctrlIn(0, uint16(i2cAddr), index, n, CtrlTimeoutMs)
 	if err != nil {
 		return nil, fmt.Errorf("rtl2832u: I2CRead addr=0x%02x: %w", i2cAddr, err)
 	}

--- a/internal/sdr/rtlsdr/rtl2832u/transport.go
+++ b/internal/sdr/rtlsdr/rtl2832u/transport.go
@@ -24,6 +24,12 @@ type Demod struct {
 	ifHz  int32
 	ppm   int
 	repON bool // last value pushed to SetI2CRepeater
+
+	// stallRetry arms the runtime control-pipe-stall recovery in ctrlOut/
+	// ctrlIn. Off until EnableControlStallRetry is called (post-bring-up),
+	// so the cold-boot bring-up path keeps surfacing a stall to the open-time
+	// reset envelope. Guarded by mu (set under the lock, read under it).
+	stallRetry bool
 }
 
 // New wraps the given transport. The caller is responsible for opening
@@ -73,7 +79,7 @@ func (d *Demod) ReadBlockReg(block uint8, addr uint16, n int) ([]byte, error) {
 
 func (d *Demod) readBlockRegLocked(block uint8, addr uint16, n int) ([]byte, error) {
 	index := uint16(block) << 8
-	out, err := d.t.ControlIn(0, addr, index, n, CtrlTimeoutMs)
+	out, err := d.ctrlIn(0, addr, index, n, CtrlTimeoutMs)
 	if err != nil {
 		return nil, fmt.Errorf("rtl2832u: read block=%d addr=0x%04x: %w", block, addr, err)
 	}
@@ -93,7 +99,7 @@ func (d *Demod) WriteBlockReg(block uint8, addr, val uint16, n int) error {
 func (d *Demod) writeBlockRegLocked(block uint8, addr, val uint16, n int) error {
 	index := uint16(block)<<8 | 0x10
 	data := encodeWriteVal(val, n)
-	if err := d.t.ControlOut(0, addr, index, data, CtrlTimeoutMs); err != nil {
+	if err := d.ctrlOut(0, addr, index, data, CtrlTimeoutMs); err != nil {
 		return fmt.Errorf("rtl2832u: write block=%d addr=0x%04x val=0x%04x: %w", block, addr, val, err)
 	}
 	return nil
@@ -113,7 +119,7 @@ func (d *Demod) ReadDemodReg(page uint8, addr uint16, n int) ([]byte, error) {
 func (d *Demod) readDemodRegLocked(page uint8, addr uint16, n int) ([]byte, error) {
 	wValue := (addr << 8) | 0x20
 	wIndex := uint16(page)
-	out, err := d.t.ControlIn(0, wValue, wIndex, n, CtrlTimeoutMs)
+	out, err := d.ctrlIn(0, wValue, wIndex, n, CtrlTimeoutMs)
 	if err != nil {
 		return nil, fmt.Errorf("rtl2832u: read demod page=%d addr=0x%02x: %w", page, addr, err)
 	}
@@ -136,7 +142,7 @@ func (d *Demod) writeDemodRegLocked(page uint8, addr, val uint16, n int) error {
 	wValue := (addr << 8) | 0x20
 	wIndex := uint16(0x10) | uint16(page)
 	data := encodeWriteVal(val, n)
-	if err := d.t.ControlOut(0, wValue, wIndex, data, CtrlTimeoutMs); err != nil {
+	if err := d.ctrlOut(0, wValue, wIndex, data, CtrlTimeoutMs); err != nil {
 		return fmt.Errorf("rtl2832u: write demod page=%d addr=0x%02x val=0x%04x: %w", page, addr, val, err)
 	}
 	// Commit. Required by the RTL2832U register interface — without it


### PR DESCRIPTION
## Summary

The RTL-SDR Blog V4's R828D intermittently STALLs a demod control write mid-run — most visibly the `SetI2CRepeater` toggle inside a `SetCenterFreq` retune — which surfaces as a raw `broken pipe` (`EPIPE`) on Linux/usbdevfs or `usb: pipe stalled` on Windows/macOS and aborts the whole tune (issue #753). `rtl_test`/SDR++ tune the same dongle cleanly because libusb recovers a stalled control pipe. GopherTrunk's native stack recovered such stalls only on the open-time bring-up path (full device reset) and the tuner burst path; the runtime demod/block/I2C control path had **none**.

This fix was originally merged as **#922** but was dropped from the tree by a later history re-import — `EnableControlStallRetry` is absent from current `main`, and the control path calls `d.t.ControlOut` directly with no recovery. This PR restores it, reconstructed against the current code structure.

## Changes

- `internal/sdr/rtlsdr/rtl2832u/ctrl_retry.go` (new): `Demod.ctrlOut`/`ctrlIn` wrappers that settle (`5ms`) and retry **once** on a control-pipe stall (`EPIPE || usb.ErrPipeStalled`), plus `EnableControlStallRetry` and the `isControlPipeStall` helper.
- `transport.go` / `i2c.go`: route all six demod/block/I2C control transfers through the wrappers (unchanged when recovery is disarmed — existing golden tests are byte-identical).
- `purego/driver.go`: call `demod.EnableControlStallRetry()` **after** bring-up completes.
- `ctrl_retry_test.go` (new): failing-first regression + guards.
- `CHANGELOG.md`: `[Unreleased] → Fixed` entry.

## Design notes

- **Armed only post-bring-up.** During bring-up a control-pipe stall is the cold-boot latch that only a full device reset clears, and the open-time retry envelope owns that — so the in-place settle-and-retry stays off until bring-up is done, leaving the cold-boot path unchanged.
- **Bounded to one retry**, so a genuinely wedged pipe still surfaces (no silent looping).
- **No runtime full reset** — it would tear down the live IQ stream mid-tune.

## Test plan

- [x] `make vet test` scope for the touched tree is green: full `go test ./internal/sdr/rtlsdr/...` passes; `go build ./...` and `go vet` clean.
- [ ] `make integration` — n/a (USB register logic; no daemon/DSP/replay path).
- [x] Failing-first regression `TestSetI2CRepeater_RecoversFromControlPipeStall` — verified it fails without the retry, surfacing the exact `write demod page=1 addr=0x01 val=0x0018: broken pipe` from the original report, and passes with it. Guards: `TestSetI2CRepeater_StallNotRetriedDuringBringup`, `TestSetI2CRepeater_PersistentStallSurfaces`.
- [ ] Smoke-tested against real hardware — **no.** Needs an RTL-SDR Blog V4 to confirm the retune no longer aborts. The original reporter (@viric) declined to test; this fix stands on its own for all V4 users, but on-hardware confirmation from any V4 owner is still the close criterion.

## Breaking changes

None. Additive recovery path; no config/CLI/REST/gRPC/default-behaviour change (recovery is a no-op unless a control transfer actually stalls).

## Docs / CHANGELOG

- [x] Added a `## [Unreleased]` bullet to `CHANGELOG.md`.
- [ ] README / `docs/` — n/a.

## Linked issues

Refs #753 — kept as `Refs` (not `Closes`) per the verify-before-close policy: unit-verified and it restores the previously-merged #922 behavior, but not yet confirmed on a physical V4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UsMtTA3dePTCcGGdqGGfw

---
_Generated by [Claude Code](https://claude.ai/code/session_011UsMtTA3dePTCcGGdqGGfw)_