### PR TITLE
rtlsdr/winusb: select composite child by serial so identical dongles open concurrently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,25 @@ for tagged releases.
   #1096).
 
 ### Fixed
+- **Windows: two identical RTL-SDR composite dongles can now open concurrently**
+  (issue #1131). The WinUSB composite-device fallback located the Interface 0
+  (`&MI_00`) child function node by VID/PID only, so with two identical
+  RTL2832U dongles (same `0bda:2838`) every open resolved to the *same* child:
+  the daemon opened the first dongle, and opening the second re-resolved to the
+  first dongle's child — `WinUsb_Initialize` then failed with
+  `ERROR_NOT_ENOUGH_MEMORY` ("Not enough memory resources…", WinUSB's report of
+  a second concurrent open) behind a misleading `current driver: usbccgp`
+  verdict, and the daemon warned `configured SDR not present on the bus`.
+  Sequential opens never collide, which is why both dongles passed
+  `sdr doctor` and `sdr list --probe` and each worked alone. Child selection is
+  now keyed by serial: each `&MI_00` candidate is linked to its composite
+  parent (whose instance ID carries the serial) via `DEVPKEY_Device_Parent`,
+  and the child whose parent matches the descriptor's serial is opened —
+  falling back to the old first-match only when no serial (or no parent link)
+  is available, and refusing to open a provably different dongle otherwise.
+  `sdr doctor`'s per-row composite-child driver verdict is serial-keyed the
+  same way, and an in-use child now surfaces an explicit "device is already
+  open" error instead of blaming the driver binding.
 - **RTL-SDR Blog V4 retunes no longer abort on an intermittent control-pipe
   stall** (issue #753). The V4's R828D occasionally STALLs a demod control write
   mid-run — most visibly the `SetI2CRepeater` toggle inside a `SetCenterFreq`

--- a/internal/sdr/rtlsdr/usb/child.go
+++ b/internal/sdr/rtlsdr/usb/child.go
@@ -72,6 +72,68 @@ func effectiveCompositeService(parentService, childService string, childFound bo
 	return parentService
 }
 
+// compositeChildCandidate is one Interface 0 (&MI_00) child function node
+// found by the composite-device walk, paired with the instance ID of its
+// composite PARENT devnode ("" when the parent could not be resolved). The
+// serial that tells two identical dongles apart lives on the parent — a child
+// instance ID carries only a bus-position discriminator — so the parent link
+// is what makes serial-aware selection possible.
+type compositeChildCandidate struct {
+	InstanceID       string
+	ParentInstanceID string
+}
+
+// serialFromInstanceID returns the final "\"-separated component of a device
+// instance ID. For a USB composite parent ("USB\VID_0BDA&PID_2838\90000002")
+// that is the dongle serial — or the system-synthesized "7&xxxx&0&port"
+// discriminator when no serial is programmed. Either form also appears
+// verbatim (modulo case) as the serial field of the parent's device-interface
+// path, so it compares directly against Descriptor.Serial.
+func serialFromInstanceID(id string) string {
+	if i := strings.LastIndexByte(id, '\\'); i >= 0 {
+		return id[i+1:]
+	}
+	return ""
+}
+
+// pickInterfaceZeroChild selects which &MI_00 child belongs to the dongle
+// with the given serial, returning its index or -1.
+//
+// Policy (issue #1131 — two identical composite dongles on one bus):
+//  1. no serial to match → first candidate (callers without a serial can do
+//     no better; this is the pre-#1131 behaviour);
+//  2. a candidate whose parent's serial matches → that candidate;
+//  3. no candidate's parent resolved → first candidate (zero information —
+//     behave as before rather than break single-dongle rigs on stacks where
+//     the parent lookup fails);
+//  4. otherwise → -1: at least one parent DID resolve and none matched, so
+//     "the first one" is provably some other dongle. Returning it anyway is
+//     the #1131 failure: with that dongle already open, WinUsb_Initialize on
+//     its child fails ERROR_NOT_ENOUGH_MEMORY; with it closed, the caller
+//     silently opens the wrong radio.
+func pickInterfaceZeroChild(cands []compositeChildCandidate, serial string) int {
+	if len(cands) == 0 {
+		return -1
+	}
+	if serial == "" {
+		return 0
+	}
+	anyResolved := false
+	for i, c := range cands {
+		if c.ParentInstanceID == "" {
+			continue
+		}
+		anyResolved = true
+		if strings.EqualFold(serialFromInstanceID(c.ParentInstanceID), serial) {
+			return i
+		}
+	}
+	if !anyResolved {
+		return 0
+	}
+	return -1
+}
+
 // firstInterfaceGUID returns the first non-empty entry from a child node's
 // DeviceInterfaceGUIDs (REG_MULTI_SZ) registry value. Zadig/libwdi normally
 // writes exactly one; we tolerate blank padding entries. ok is false when the

--- a/internal/sdr/rtlsdr/usb/child_test.go
+++ b/internal/sdr/rtlsdr/usb/child_test.go
@@ -69,6 +69,77 @@ func TestEffectiveCompositeService(t *testing.T) {
 	}
 }
 
+func TestSerialFromInstanceID(t *testing.T) {
+	tests := []struct {
+		id   string
+		want string
+	}{
+		{`USB\VID_0BDA&PID_2838\90000002`, "90000002"},
+		{`USB\VID_0BDA&PID_2838\7&227E3EE8&0&2`, "7&227E3EE8&0&2"}, // no programmed serial
+		{`no-backslash`, ""},
+		{``, ""},
+	}
+	for _, tt := range tests {
+		if got := serialFromInstanceID(tt.id); got != tt.want {
+			t.Errorf("serialFromInstanceID(%q) = %q, want %q", tt.id, got, tt.want)
+		}
+	}
+}
+
+// TestPickInterfaceZeroChildTwoIdenticalDongles is the issue #1131 regression:
+// two RTL2832U composite dongles share VID/PID, so a first-match child lookup
+// hands every Open the SAME &MI_00 child. The daemon opens dongle A, then
+// Open(serial=B) resolves to A's child again — WinUsb_Initialize on the
+// already-owned handle fails with ERROR_NOT_ENOUGH_MEMORY and the second
+// device never opens, even though both pass `sdr list --probe` (sequential
+// opens never collide). Selection must follow the serial on the parent node.
+func TestPickInterfaceZeroChildTwoIdenticalDongles(t *testing.T) {
+	cands := []compositeChildCandidate{
+		{InstanceID: `USB\VID_0BDA&PID_2838&MI_00\7&AAAA&0&0000`, ParentInstanceID: `USB\VID_0BDA&PID_2838\90000002`},
+		{InstanceID: `USB\VID_0BDA&PID_2838&MI_00\7&BBBB&0&0000`, ParentInstanceID: `USB\VID_0BDA&PID_2838\00000001`},
+	}
+	if got := pickInterfaceZeroChild(cands, "00000001"); got != 1 {
+		t.Fatalf("pickInterfaceZeroChild(serial=00000001) = %d, want 1 (issue #1131: first-match opens the wrong dongle)", got)
+	}
+	if got := pickInterfaceZeroChild(cands, "90000002"); got != 0 {
+		t.Fatalf("pickInterfaceZeroChild(serial=90000002) = %d, want 0", got)
+	}
+}
+
+func TestPickInterfaceZeroChild(t *testing.T) {
+	twoDongles := []compositeChildCandidate{
+		{InstanceID: `USB\VID_0BDA&PID_2838&MI_00\7&AAAA&0&0000`, ParentInstanceID: `USB\VID_0BDA&PID_2838\90000002`},
+		{InstanceID: `USB\VID_0BDA&PID_2838&MI_00\7&BBBB&0&0000`, ParentInstanceID: `USB\VID_0BDA&PID_2838\00000001`},
+	}
+	tests := []struct {
+		name   string
+		cands  []compositeChildCandidate
+		serial string
+		want   int
+	}{
+		{"no candidates", nil, "00000001", -1},
+		{"no serial keeps first-match behaviour", twoDongles, "", 0},
+		{"case-insensitive serial match", []compositeChildCandidate{
+			{InstanceID: `USB\VID_0BDA&PID_2838&MI_00\7&AAAA&0&0000`, ParentInstanceID: `USB\VID_0BDA&PID_2838\ABCDEF01`},
+		}, "abcdef01", 0},
+		{"synthesized id (serial-less dongle) matches path serial", []compositeChildCandidate{
+			{InstanceID: `USB\VID_0BDA&PID_2838&MI_00\7&AAAA&0&0000`, ParentInstanceID: `USB\VID_0BDA&PID_2838\7&227E3EE8&0&2`},
+		}, "7&227e3ee8&0&2", 0},
+		{"no parent resolved anywhere → first (no information)", []compositeChildCandidate{
+			{InstanceID: `USB\VID_0BDA&PID_2838&MI_00\7&AAAA&0&0000`},
+			{InstanceID: `USB\VID_0BDA&PID_2838&MI_00\7&BBBB&0&0000`},
+		}, "00000001", 0},
+		{"parents resolved but none match → -1, never the wrong dongle", twoDongles, "55555555", -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pickInterfaceZeroChild(tt.cands, tt.serial); got != tt.want {
+				t.Errorf("pickInterfaceZeroChild(serial=%q) = %d, want %d", tt.serial, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFirstInterfaceGUID(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/sdr/rtlsdr/usb/child_windows.go
+++ b/internal/sdr/rtlsdr/usb/child_windows.go
@@ -35,20 +35,26 @@ var errNoWinUSBChild = errors.New("winusb: no Interface 0 child found")
 // exists but is bound to something else (libusbK, the in-box DVB driver, ...)
 // we still return childService (with an empty path) so the doctor can give an
 // accurate hint. Returns errNoWinUSBChild when no &MI_00 child for VID:PID is
-// present.
+// present, or when children exist but all provably belong to OTHER dongles.
 //
-// NOTE: matching is by VID/PID + &MI_00 only; the dongle serial lives on the
-// parent, not the child instance ID. Two *identical* composite dongles would
-// be indistinguishable here — an acceptable limitation today (the pool already
-// disambiguates by serial at the List layer, and the single-interface path is
-// unaffected).
-func findInterfaceZeroChild(vid, pid uint16) (childService, childPath string, err error) {
+// serial disambiguates identical composite dongles (issue #1131): the serial
+// lives on the composite PARENT node, not the child instance ID, so each
+// candidate child is linked to its parent via DEVPKEY_Device_Parent and
+// pickInterfaceZeroChild matches the parent's serial against the caller's.
+// Without that, two identical dongles both resolved to the FIRST &MI_00 child:
+// the daemon held dongle A open, Open(serial=B) re-resolved to A's child, and
+// WinUsb_Initialize failed with ERROR_NOT_ENOUGH_MEMORY — while sequential
+// `sdr list --probe` opens never collided. serial may be "" (first match wins,
+// the old behaviour).
+func findInterfaceZeroChild(vid, pid uint16, serial string) (childService, childPath string, err error) {
 	devSet, err := windows.SetupDiGetClassDevsEx(nil, "USB", 0, windows.DIGCF_PRESENT|windows.DIGCF_ALLCLASSES, 0, "")
 	if err != nil {
 		return "", "", fmt.Errorf("winusb: SetupDiGetClassDevsEx(USB): %w", err)
 	}
 	defer windows.SetupDiDestroyDeviceInfoList(devSet)
 
+	var cands []compositeChildCandidate
+	var infos []*windows.DevInfoData
 	for i := 0; ; i++ {
 		devInfo, e := windows.SetupDiEnumDeviceInfo(devSet, i)
 		if e != nil {
@@ -62,23 +68,57 @@ func findInterfaceZeroChild(vid, pid uint16) (childService, childPath string, er
 		if !hasMI || v != vid || p != pid || !isInterfaceZero(instID) {
 			continue
 		}
-		// Matched the Interface 0 child. Read its bound kernel service.
-		svc := ""
-		if val, e := windows.SetupDiGetDeviceRegistryProperty(devSet, devInfo, windows.SPDRP_SERVICE); e == nil {
-			svc, _ = val.(string)
-		}
-		if !strings.EqualFold(svc, "winusb") {
-			// Child exists but isn't WinUSB-bound: report the service (no
-			// openable path) so the doctor hint is accurate.
-			return svc, "", nil
-		}
-		path, e := childInterfacePath(devSet, devInfo, instID)
-		if e != nil {
-			return svc, "", e
-		}
-		return svc, path, nil
+		cands = append(cands, compositeChildCandidate{
+			InstanceID:       instID,
+			ParentInstanceID: parentInstanceID(devSet, devInfo),
+		})
+		infos = append(infos, devInfo)
 	}
-	return "", "", errNoWinUSBChild
+	idx := pickInterfaceZeroChild(cands, serial)
+	if idx < 0 {
+		return "", "", errNoWinUSBChild
+	}
+	devInfo := infos[idx]
+	// Read the matched child's bound kernel service.
+	svc := ""
+	if val, e := windows.SetupDiGetDeviceRegistryProperty(devSet, devInfo, windows.SPDRP_SERVICE); e == nil {
+		svc, _ = val.(string)
+	}
+	if !strings.EqualFold(svc, "winusb") {
+		// Child exists but isn't WinUSB-bound: report the service (no
+		// openable path) so the doctor hint is accurate.
+		return svc, "", nil
+	}
+	path, e := childInterfacePath(devSet, devInfo, cands[idx].InstanceID)
+	if e != nil {
+		return svc, "", e
+	}
+	return svc, path, nil
+}
+
+// devpkeyDeviceParent is DEVPKEY_Device_Parent from the Windows SDK's
+// devpkey.h — the instance ID of a devnode's parent. x/sys/windows wraps
+// SetupDiGetDeviceProperty but ships no predefined DEVPROPKEYs, so the one
+// key needed here is defined locally.
+var devpkeyDeviceParent = windows.DEVPROPKEY{
+	FmtID: windows.DEVPROPGUID{
+		Data1: 0x4340a6c5, Data2: 0x93fa, Data3: 0x4706,
+		Data4: [8]byte{0x97, 0x2c, 0x7b, 0x64, 0x80, 0x08, 0xa5, 0xa7},
+	},
+	PID: 8,
+}
+
+// parentInstanceID resolves the instance ID of a devnode's parent (for an
+// &MI_00 child function node: the composite parent, whose last path component
+// is the dongle serial). Best-effort — returns "" on any failure and
+// pickInterfaceZeroChild's no-information fallback keeps the old behaviour.
+func parentInstanceID(devSet windows.DevInfo, devInfo *windows.DevInfoData) string {
+	val, err := windows.SetupDiGetDeviceProperty(devSet, devInfo, &devpkeyDeviceParent)
+	if err != nil {
+		return ""
+	}
+	s, _ := val.(string)
+	return s
 }
 
 // childInterfacePath resolves the CreateFile-openable device-interface path for

--- a/internal/sdr/rtlsdr/usb/diag_windows.go
+++ b/internal/sdr/rtlsdr/usb/diag_windows.go
@@ -109,9 +109,10 @@ func (w *winDriverInspector) Inspect(vid, pid uint16) ([]DriverBinding, error) {
 		// USB composite parent — the SDR's real driver lives on its Interface 0
 		// (&MI_00) child. Report the child's binding so a correctly
 		// WinUSB-bound composite dongle reads OK instead of a false BAD (and a
-		// wrong-driver child still gets an accurate hint).
+		// wrong-driver child still gets an accurate hint). Keyed by serial so
+		// each row of a multi-dongle rig reports its OWN child's binding.
 		if strings.EqualFold(service, "usbccgp") {
-			if childSvc, _, derr := findInterfaceZeroChild(v, p); derr == nil && childSvc != "" {
+			if childSvc, _, derr := findInterfaceZeroChild(v, p, serial); derr == nil && childSvc != "" {
 				service = effectiveCompositeService(service, childSvc, true)
 			}
 		}

--- a/internal/sdr/rtlsdr/usb/usb_windows.go
+++ b/internal/sdr/rtlsdr/usb/usb_windows.go
@@ -230,16 +230,31 @@ func (w *winEnumerator) Open(d Descriptor) (Transport, error) {
 	// WinUSB-capable SDR lives on the Interface 0 (&MI_00) child function node.
 	// Find and open that child before surfacing the bind failure — this lets a
 	// correctly-bound RTL-SDR V4 (and other composite dongles) open without the
-	// user having to chase the right entry in Zadig. Store the child path in the
-	// returned transport's descriptor so Reset() re-opens the child, not the
-	// parent.
-	if _, childPath, derr := findInterfaceZeroChild(d.VID, d.PID); derr == nil && childPath != "" {
-		if ch, cif, cerr := createAndInitWinUSB(childPath); cerr == nil {
+	// user having to chase the right entry in Zadig. The lookup is keyed by
+	// d.Serial as well as VID/PID so two identical dongles each resolve to
+	// their OWN child (issue #1131). Store the child path in the returned
+	// transport's descriptor so Reset() re-opens the child, not the parent.
+	if _, childPath, derr := findInterfaceZeroChild(d.VID, d.PID, d.Serial); derr == nil && childPath != "" {
+		ch, cif, cerr := createAndInitWinUSB(childPath)
+		if cerr == nil {
 			cd := d
 			cd.Path = childPath
 			debugLogf("winusb", "Open child WinUsb_Initialize ok iface=0x%x", cif)
 			return MaybeWrapDebug(&winTransport{fileHandle: ch, ifaceHandle: cif, desc: cd}, cd), nil
 		}
+		// The right child WAS found, so driver binding is not the problem —
+		// surface the child's own failure instead of the misleading
+		// "current driver: usbccgp" verdict below. ERROR_NOT_ENOUGH_MEMORY
+		// from WinUsb_Initialize is how WinUSB reports a second concurrent
+		// open of a device some other handle already owns.
+		if errors.Is(cerr, windows.ERROR_NOT_ENOUGH_MEMORY) {
+			return nil, fmt.Errorf(
+				"winusb: device VID_%04X&PID_%04X serial=%q is already open (WinUsb_Initialize on Interface 0 child returned ERROR_NOT_ENOUGH_MEMORY — WinUSB allows one open handle per device; close the other program or session using this dongle): %w",
+				d.VID, d.PID, d.Serial, cerr)
+		}
+		return nil, fmt.Errorf(
+			"winusb: WinUsb_Initialize failed on Interface 0 child of VID_%04X&PID_%04X serial=%q (path %q): %w",
+			d.VID, d.PID, d.Serial, childPath, cerr)
 	}
 	svc, descr := lookupBoundDriver(d.Path)
 	return nil, fmt.Errorf(


### PR DESCRIPTION
## Summary

Two identical RTL-SDR composite dongles on Windows can't be opened by the daemon at the same time (issue #1131): the second open fails `WinUsb_Initialize` with `ERROR_NOT_ENOUGH_MEMORY` behind a misleading `current driver: usbccgp` verdict — even though both dongles pass `sdr doctor` and `sdr list --probe` and each works alone. Root cause: the composite-device fallback located the Interface 0 (`&MI_00`) child function node by **VID/PID only**, so with two identical dongles (both `0bda:2838`) every open resolved to the *same* child. The daemon held dongle A open; `Open(serial=B)` re-resolved to A's child, and `WinUsb_Initialize` on the already-owned device failed with `ERROR_NOT_ENOUGH_MEMORY` (WinUSB's report of a second concurrent open — one handle per device). Sequential probe opens never collide, which is exactly why every individual test passed. The limitation was even documented as a `NOTE:` in `child_windows.go` — this PR removes it.

## Changes

- `findInterfaceZeroChild` now takes the descriptor's **serial** and links each `&MI_00` candidate to its composite **parent** devnode via `DEVPKEY_Device_Parent` (defined locally; `x/sys/windows` wraps `SetupDiGetDeviceProperty` but ships no predefined keys). The parent instance ID's last component is the dongle serial — or the system-synthesized `7&xxxx&0&port` discriminator for serial-less dongles, which also matches the interface-path serial field — so it compares directly against `Descriptor.Serial`.
- Selection policy is a pure, cross-platform-testable function `pickInterfaceZeroChild` (`child.go`): no serial → first match (old behaviour); serial match on a resolved parent → that child; **no** parent resolvable anywhere → first match (zero information, don't regress single-dongle rigs); parents resolved but none matching → no child, because "the first one" is provably a different dongle.
- `winEnumerator.Open` passes `d.Serial`, and when the correctly-selected child itself fails `WinUsb_Initialize`, the error now reports the **child's** failure instead of the misleading parent `usbccgp` driver verdict — with an explicit "device is already open (one WinUSB handle per device)" message for `ERROR_NOT_ENOUGH_MEMORY`.
- `sdr doctor` (`winDriverInspector.Inspect`) keys the composite-child driver verdict by serial too, so each row of a multi-dongle rig reports its *own* child's binding.
- CHANGELOG entry under `[Unreleased]` → `Fixed`.

## Test plan

- [x] `make vet test` is green locally
- [ ] `make integration` is green locally (if the change touches the daemon) — n/a (USB transport layer only; daemon untouched)
- [x] Added or updated tests where appropriate — **failing-first**: `TestPickInterfaceZeroChildTwoIdenticalDongles` reproduces the exact #1131 scenario (serials `90000002` / `00000001`, shared VID/PID) and fails against the old first-match policy (`pickInterfaceZeroChild(serial=00000001) = 0, want 1`), passes with the fix. `TestPickInterfaceZeroChild` pins the full policy (no-serial compat, case-insensitivity, serial-less synthesized IDs, no-information fallback, refuse-wrong-dongle) and `TestSerialFromInstanceID` the parsing. Cross-compiled `GOOS=windows` for amd64 + arm64, `go vet` clean on both.
- [ ] Smoke-tested against real hardware (if SDR / USB / vocoder code changed) — **not yet**: the selection policy is unit-pinned, but the two-dongle daemon start needs a Windows machine with two identical WinUSB-bound composite RTL-SDRs. The #1131 reporter has exactly this rig; asking them to verify on this build (see issue thread).

## Breaking changes

None. Single-dongle behaviour is unchanged (with one candidate and a matching — or unresolvable — parent, selection is identical to before), callers passing no serial keep first-match, and non-composite dongles never enter this path.

## Docs / CHANGELOG

- [x] Added a `## [Unreleased]` bullet to `CHANGELOG.md`
- [ ] Updated `README.md` or `docs/` — n/a (no operator-facing behaviour change; error messages only got more accurate)

## Linked issues

Refs #1131 (not `Closes` — per the verify-before-close policy, the fix is unit-verified but awaits the reporter's confirmation on real two-dongle hardware).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127ZTgUwub7zR3ppDLdwv3p

---
_Generated by [Claude Code](https://claude.ai/code/session_0127ZTgUwub7zR3ppDLdwv3p)_