### PR TITLE
Re-land the two #1121 changes that never reached its merged branch: unfollowed_reason (#356) + conventional talkgroup_id (#1105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Added
+- **`unfollowed_reason` on observed calls** (issue #356). Calls the control
+  channel announces but no voice tuner follows now say *why* in
+  `/api/v1/calls/active`: `no voice SDR configured`, `voice frequency outside
+  every voice device's tuning window`, or `all voice tuners busy with
+  higher-priority calls`. On a single wideband SDR whose IQ window misses the
+  system's voice channels, every call shows as "observed" — which operators
+  read as "the talkgroup has no voice"; the field makes the coverage gap (or
+  tuner shortage) visible instead. Omitted for followed calls. Diagnostic
+  only — grant handling and the decode path are unchanged. *(Re-landed: this
+  was described in PR #1121 but the commit never made it onto the merged
+  branch.)*
+- **`scanner.conventional[].talkgroup_id`** (issue #1105). Optional fixed
+  talkgroup ID a conventional channel surfaces under (API, call log, and
+  scan-type upload consumers — Rdio Scanner, OpenMHz, Broadcastify Calls)
+  instead of the positional synthetic `0x80000000 | list-index` default,
+  which silently shifts when channels are reordered/inserted/removed and
+  breaks `talkgroup_file` roster rows. Config validation rejects two channels
+  resolving to the same effective ID. Unset keeps today's positional
+  behaviour. *(Re-landed: described in PR #1121 but the commit never made it
+  onto the merged branch.)*
+
 ### Docs
 - **Documented the minimum macOS version (12 Monterey).** macOS binaries link
   against system APIs that first shipped in macOS 12 (e.g.

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -1639,6 +1639,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 					ActivityDebounce:    msToDuration(ch.ActivityDebounceMs, 0),
 					SquelchHysteresisDb: ch.SquelchHysteresisDb,
 					Priority:            ch.Priority,
+					TalkgroupID:         ch.TalkgroupID,
 					Tone: conventional.ToneConfig{
 						Mode:    ch.Tone.Mode,
 						CTCSSHz: ch.Tone.CTCSSHz,

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1210,6 +1210,12 @@ scanner:
   #     squelch_dbfs: -48
   #     hangtime_ms: 1500
   #     priority: 4
+  #     # Optional fixed talkgroup ID for the API / call log / scan-type
+  #     # upload consumers (Rdio Scanner, OpenMHz, Broadcastify Calls).
+  #     # Unset = a positional synthetic ID (0x80000000 | list index) that
+  #     # SHIFTS when channels are reordered/inserted/removed — pin an
+  #     # explicit ID to keep talkgroup_file roster rows durable (#1105).
+  #     # talkgroup_id: 2147500000
   #     # Optional CTCSS / DCS sub-audible squelch gate. With tone
   #     # gating set the scanner only opens when both the carrier is
   #     # present AND the configured tone is detected, so adjacent-

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -271,9 +271,10 @@ func TestActiveCallsReportsEngineSnapshot(t *testing.T) {
 		// A second talkgroup is up on the system but no tuner is following it
 		// (control-channel-observed only, nil Device).
 		observed: []*trunking.ActiveCall{{
-			Grant:     trunking.Grant{System: "Alpha", Protocol: "p25", GroupID: 5678, FrequencyHz: 851_012_500},
-			Talkgroup: &trunking.TalkGroup{ID: 5678, AlphaTag: "PD-DISP"},
-			StartedAt: time.Now().UTC(),
+			Grant:            trunking.Grant{System: "Alpha", Protocol: "p25", GroupID: 5678, FrequencyHz: 851_012_500},
+			Talkgroup:        &trunking.TalkGroup{ID: 5678, AlphaTag: "PD-DISP"},
+			StartedAt:        time.Now().UTC(),
+			UnfollowedReason: trunking.UnfollowedAllBusy,
 		}},
 	}
 	base, teardown := mkServer(t, ServerOptions{Bus: bus, Engine: engine})
@@ -299,6 +300,15 @@ func TestActiveCallsReportsEngineSnapshot(t *testing.T) {
 	observed, ok := byTG[5678]
 	if !ok || observed.Following || observed.DeviceSerial != "" || observed.Talkgroup.AlphaTag != "PD-DISP" {
 		t.Errorf("observed call = %+v, want following=false with empty device", observed)
+	}
+	// #356: the observed call says WHY no tuner is following it; a followed
+	// call never carries the field.
+	if observed.UnfollowedReason != trunking.UnfollowedAllBusy {
+		t.Errorf("observed unfollowed_reason = %q, want %q",
+			observed.UnfollowedReason, trunking.UnfollowedAllBusy)
+	}
+	if followed.UnfollowedReason != "" {
+		t.Errorf("followed unfollowed_reason = %q, want empty", followed.UnfollowedReason)
 	}
 }
 

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -835,6 +835,12 @@ type ActiveCallDTO struct {
 	// talkgroups up on the system, not only the ones being decoded. An
 	// unfollowed call has an empty DeviceSerial.
 	Following bool `json:"following"`
+	// UnfollowedReason says why no tuner is following this call (issue #356):
+	// "no voice SDR configured", "voice frequency outside every voice
+	// device's tuning window", or "all voice tuners busy with higher-priority
+	// calls". Omitted for followed calls, and empty while a grant is still
+	// being allocated.
+	UnfollowedReason string `json:"unfollowed_reason,omitempty"`
 }
 
 func activeCallToDTO(ac *trunking.ActiveCall, following bool) ActiveCallDTO {
@@ -842,7 +848,7 @@ func activeCallToDTO(ac *trunking.ActiveCall, following bool) ActiveCallDTO {
 	if ac.Device != nil {
 		serial = ac.Device.Serial
 	}
-	return ActiveCallDTO{
+	dto := ActiveCallDTO{
 		Grant:        grantToDTO(ac.Grant),
 		Talkgroup:    talkgroupToDTO(ac.Talkgroup),
 		DeviceSerial: serial,
@@ -850,6 +856,10 @@ func activeCallToDTO(ac *trunking.ActiveCall, following bool) ActiveCallDTO {
 		LastHeardAt:  ac.LastHeardAt,
 		Following:    following,
 	}
+	if !following {
+		dto.UnfollowedReason = ac.UnfollowedReason
+	}
+	return dto
 }
 
 // CallStartDTO / CallEndDTO mirror the trunking event payloads.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -549,6 +549,14 @@ type ConvChannelConfig struct {
 	// Default 3 dB; 0 = default.
 	SquelchHysteresisDb float64 `yaml:"squelch_hysteresis_db"`
 	Priority            int     `yaml:"priority"` // 1..10, 0 = unset
+	// TalkgroupID pins the synthetic talkgroup ID this channel surfaces
+	// under (API, call log, scan-type upload consumers such as Rdio
+	// Scanner / OpenMHz / Broadcastify Calls). Unset (0) keeps the
+	// positional default `0x80000000 | list-index`, which silently shifts
+	// when channels are reordered/inserted/removed — set an explicit ID
+	// to make talkgroup_file roster rows durable across list edits.
+	// Issue #1105.
+	TalkgroupID uint32 `yaml:"talkgroup_id"`
 	// Tone is the optional CTCSS / DCS sub-audible squelch gate.
 	// Zero / "none" disables tone gating (default).
 	Tone ConvToneConfig `yaml:"tone"`

--- a/internal/config/config_validate.go
+++ b/internal/config/config_validate.go
@@ -691,6 +691,26 @@ func (c Config) validateScanner() []error {
 			errs = append(errs, err)
 		}
 	}
+	// Two channels resolving to the same effective talkgroup ID would fold
+	// into one synthetic call at the engine, which keys on (system, GroupID)
+	// — reject the collision loudly instead. The effective ID is the explicit
+	// talkgroup_id override, or the positional 0x80000000|index default, so
+	// this also catches an override colliding with another channel's default.
+	// Issue #1105.
+	seen := map[uint32]int{}
+	for i, ch := range c.Scanner.Conventional {
+		gid := ch.TalkgroupID
+		if gid == 0 {
+			gid = 0x80000000 | uint32(i)
+		}
+		if j, dup := seen[gid]; dup {
+			errs = append(errs, fmt.Errorf(
+				"scanner.conventional[%d]: effective talkgroup id %d collides with scanner.conventional[%d] — set distinct talkgroup_id values",
+				i, gid, j))
+			continue
+		}
+		seen[gid] = i
+	}
 	return errs
 }
 

--- a/internal/config/conv_talkgroup_id_test.go
+++ b/internal/config/conv_talkgroup_id_test.go
@@ -1,0 +1,57 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestConvChannelTalkgroupIDCollisionRejected pins the #1105 validation rule:
+// two conventional channels resolving to the same effective talkgroup ID —
+// whether two identical explicit talkgroup_id values, or an explicit value
+// colliding with another channel's positional 0x80000000|index default — are
+// a config error, because the engine folds synthetic calls keyed on
+// (system, GroupID). Fails against a config package without the check (the
+// collision validated clean and the two channels silently shared one call
+// identity).
+func TestConvChannelTalkgroupIDCollisionRejected(t *testing.T) {
+	errText := func(c Config) string {
+		var b strings.Builder
+		for _, err := range c.validateScanner() {
+			b.WriteString(err.Error())
+			b.WriteString("\n")
+		}
+		return b.String()
+	}
+
+	// Two identical explicit IDs collide.
+	c := Config{}
+	c.Scanner.Conventional = []ConvChannelConfig{
+		{Label: "A", FrequencyHz: 100_000_000, TalkgroupID: 42},
+		{Label: "B", FrequencyHz: 200_000_000, TalkgroupID: 42},
+	}
+	if got := errText(c); !strings.Contains(got, "collides") {
+		t.Errorf("identical explicit IDs: errors = %q, want a collision error", got)
+	}
+
+	// An explicit ID equal to another channel's positional default collides
+	// too: channel index 1's default is 0x80000000|1.
+	c = Config{}
+	c.Scanner.Conventional = []ConvChannelConfig{
+		{Label: "A", FrequencyHz: 100_000_000, TalkgroupID: 0x80000001},
+		{Label: "B", FrequencyHz: 200_000_000}, // positional default 0x80000001
+	}
+	if got := errText(c); !strings.Contains(got, "collides") {
+		t.Errorf("explicit vs positional default: errors = %q, want a collision error", got)
+	}
+
+	// Distinct effective IDs validate clean.
+	c = Config{}
+	c.Scanner.Conventional = []ConvChannelConfig{
+		{Label: "A", FrequencyHz: 100_000_000, TalkgroupID: 42},
+		{Label: "B", FrequencyHz: 200_000_000},
+		{Label: "C", FrequencyHz: 300_000_000, TalkgroupID: 43},
+	}
+	if got := errText(c); got != "" {
+		t.Errorf("distinct IDs: unexpected errors = %q", got)
+	}
+}

--- a/internal/configbuilder/fieldmeta.go
+++ b/internal/configbuilder/fieldmeta.go
@@ -369,6 +369,7 @@ var fieldMetas = map[string]FieldMeta{
 	"ConvChannelConfig.ActivityDebounceMs":  {Label: "Activity debounce (ms)", Help: "Minimum sustained above-squelch time that resets the hangtime countdown, so a brief blip can't hold the channel open. Default 50 ms."},
 	"ConvChannelConfig.SquelchHysteresisDb": {Label: "Squelch hysteresis (dB)", Help: "Level margin below the squelch threshold before a signal counts as gone while a call is active. Default 3 dB."},
 	"ConvChannelConfig.Priority":            {Help: "Scan priority 1–10 (higher wins). 0 = unset."},
+	"ConvChannelConfig.TalkgroupID":         {Label: "Talkgroup ID", Help: "Fixed talkgroup ID this channel surfaces under (API, call log, Rdio Scanner / OpenMHz / Broadcastify uploads). 0 = positional default (0x80000000 | list index), which shifts when the channel list is edited — pin an ID to keep talkgroup_file roster rows durable."},
 	"ConvChannelConfig.Tone":                {Help: "Optional CTCSS/DCS sub-audible squelch gate."},
 	"ConvToneConfig.Mode":                   {Help: "Sub-audible gate: none, ctcss, or dcs.", Options: opts("", "none", "none", "none", "ctcss", "ctcss", "dcs", "dcs")},
 	"ConvToneConfig.CTCSSHz":                {Label: "CTCSS (Hz)", Help: "Target CTCSS frequency (50–300 Hz). Required when mode is ctcss."},

--- a/internal/scanner/conventional/scanner.go
+++ b/internal/scanner/conventional/scanner.go
@@ -63,6 +63,12 @@ type Channel struct {
 	// engine's preemption logic respects it relative to other
 	// conv-scanner channels.
 	Priority int
+	// TalkgroupID, when non-zero, is the fixed talkgroup ID this
+	// channel's synthetic calls surface under instead of the
+	// positional 0x80000000|index default — so the ID survives scan-
+	// list reordering and talkgroup_file roster rows stay valid.
+	// Issue #1105.
+	TalkgroupID uint32
 	// Tone is the optional CTCSS / DCS gate. When set, the
 	// scanner only declares "carrier present" while BOTH the
 	// IQ-power squelch is open AND the configured sub-audible
@@ -555,11 +561,16 @@ func (s *Scanner) beginDwell(idx int, ch Channel, stream <-chan []complex64, str
 	s.lastBreakAt[idx] = now
 	s.mu.Unlock()
 
-	// Synthesize a Grant. GroupID is derived from the channel index
-	// so each conv channel surfaces as a distinct talkgroup in the
+	// Synthesize a Grant. GroupID defaults to a channel-index-derived
+	// value so each conv channel surfaces as a distinct talkgroup in the
 	// API + call log; bit 31 set so it can't collide with a real
-	// trunked GroupID (which are 24/28-bit fields in practice).
-	gid := uint32(0x80000000) | uint32(idx)
+	// trunked GroupID (which are 24/28-bit fields in practice). An
+	// explicit talkgroup_id pins the ID so it survives scan-list
+	// reordering (#1105); config validation rejects collisions.
+	gid := ch.TalkgroupID
+	if gid == 0 {
+		gid = uint32(0x80000000) | uint32(idx)
+	}
 	g := trunking.Grant{
 		System:      s.opts.SystemName,
 		Protocol:    "fm-conv",

--- a/internal/scanner/conventional/talkgroup_id_test.go
+++ b/internal/scanner/conventional/talkgroup_id_test.go
@@ -1,0 +1,54 @@
+package conventional
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestConvScannerUsesExplicitTalkgroupID pins the #1105 talkgroup_id override:
+// a channel with TalkgroupID set surfaces its synthetic calls under that fixed
+// ID instead of the positional 0x80000000|index default — so the ID survives
+// scan-list reordering and any talkgroup_file roster rows stay valid. Fails
+// against the pre-override scanner, which always emitted 0x80000001 for the
+// second channel.
+func TestConvScannerUsesExplicitTalkgroupID(t *testing.T) {
+	tuner := &fakeTuner{}
+	iq := &fakeIQ{
+		tuner: tuner,
+		chunks: map[uint32][][]complex64{
+			200_000_000: {
+				loudChunk(256), loudChunk(256), loudChunk(256),
+			},
+		},
+	}
+	eng := &fakeEngine{}
+	s, err := New(Options{
+		Tuner: tuner, IQ: iq, Engine: eng, Recorder: fakeRecorder{},
+		DeviceSerial: "CONV-1",
+		SystemName:   "test",
+		Channels: []Channel{
+			{Label: "A", FrequencyHz: 100_000_000, SquelchDbFS: -10},
+			{Label: "B", FrequencyHz: 200_000_000, SquelchDbFS: -10,
+				Hangtime: 50 * time.Millisecond, TalkgroupID: 2_147_500_000},
+		},
+		MinDwellPerChannel: 30 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_ = s.Run(ctx)
+
+	if eng.startCount() == 0 {
+		t.Fatal("squelch never fired (no HandleSyntheticCall)")
+	}
+	if eng.starts[0].GroupID != 2_147_500_000 {
+		t.Errorf("group id = %d, want the explicit talkgroup_id 2147500000 (positional default would be %#x)",
+			eng.starts[0].GroupID, 0x80000001)
+	}
+	if eng.starts[0].GroupLabel != "B" {
+		t.Errorf("group label = %q, want B", eng.starts[0].GroupLabel)
+	}
+}

--- a/internal/trunking/engine.go
+++ b/internal/trunking/engine.go
@@ -943,6 +943,7 @@ func (e *Engine) HandleGrant(g Grant) {
 					"grant", g.String())
 			})
 			e.log.Debug("dropping grant: no voice SDR", "grant", g.String())
+			e.setObservedReason(g, UnfollowedNoVoiceSDR)
 			return
 		}
 		if !e.pool.HasCapableDevice(g.FrequencyHz) {
@@ -954,6 +955,7 @@ func (e *Engine) HandleGrant(g Grant) {
 					"grant", g.String())
 			})
 			e.log.Debug("dropping grant: no voice device covers frequency", "grant", g.String())
+			e.setObservedReason(g, UnfollowedNoCoverage)
 			return
 		}
 		// A capable device exists, none is free (step 1 failed) and
@@ -964,6 +966,7 @@ func (e *Engine) HandleGrant(g Grant) {
 	}
 	if !CanPreempt(victim.Grant, victim.Talkgroup, g, tg) {
 		e.log.Info("no voice device available for grant", "grant", g.String())
+		e.setObservedReason(g, UnfollowedAllBusy)
 		// Signal the overload so the IQ auto-recorder can capture the carrier
 		// at the instant the system had more calls than voice tuners. Payload
 		// is the grant that went unserved.
@@ -1275,6 +1278,27 @@ func (e *Engine) ActiveCalls() []*ActiveCall {
 	return out
 }
 
+// Unfollowed-call reasons surfaced on control-channel-observed calls via
+// ActiveCall.UnfollowedReason / the API's unfollowed_reason field (issue #356).
+// The strings are operator-facing and mirror the corresponding drop-site logs.
+const (
+	UnfollowedNoVoiceSDR = "no voice SDR configured"
+	UnfollowedNoCoverage = "voice frequency outside every voice device's tuning window"
+	UnfollowedAllBusy    = "all voice tuners busy with higher-priority calls"
+)
+
+// setObservedReason stamps (or clears, with reason "") the unfollowed-reason
+// diagnostic on grant g's system-activity tracker entry. A no-op for grants
+// observeCall skipped (data calls, individual calls) — those never surface in
+// ObservedCalls, so they carry no reason.
+func (e *Engine) setObservedReason(g Grant, reason string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if ac, ok := e.observed[observedKey(g)]; ok {
+		ac.UnfollowedReason = reason
+	}
+}
+
 // observeCall upserts the system-activity tracker entry for grant g. Called
 // for every voice grant HandleGrant accepts, whether or not a tuner follows it.
 func (e *Engine) observeCall(g Grant, tg *TalkGroup) {
@@ -1334,6 +1358,10 @@ func (e *Engine) startCall(d *VoiceDevice, g Grant, tg *TalkGroup) {
 	e.mu.Lock()
 	e.calls[d.Serial] = ac
 	e.mu.Unlock()
+	// A tuner is following the call now — clear any stale unfollowed-reason
+	// stamped by an earlier drop of the same call's repeat grants, so the
+	// diagnostic never outlives the condition it described. Issue #356.
+	e.setObservedReason(g, "")
 	e.bus.Publish(events.Event{
 		Kind: events.KindCallStart,
 		// Publish ac.Grant, not the caller's g: Bind stamped it with a

--- a/internal/trunking/unfollowed_reason_test.go
+++ b/internal/trunking/unfollowed_reason_test.go
@@ -1,0 +1,140 @@
+package trunking
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// windowedFakeTuner is a fakeVoiceTuner whose wideband IQ window covers only
+// frequencies canTune reports true for — the virtual voice-tap shape that
+// produces the issue #356 "every call is observed" symptom when the window
+// misses the system's voice channels.
+type windowedFakeTuner struct {
+	fakeVoiceTuner
+	canTune func(hz uint32) bool
+}
+
+func (w *windowedFakeTuner) CanTune(hz uint32) bool { return w.canTune(hz) }
+
+// TestObservedCallReasonAllBusy pins that a call observed while every voice
+// tuner is serving an equal-priority call carries the "all voice tuners busy"
+// reason (issue #356): the diagnostic that distinguishes a busy system from a
+// decode failure.
+func TestObservedCallReasonAllBusy(t *testing.T) {
+	e, _, bus, _ := mkEngine(t, 1) // ONE voice tuner
+	defer bus.Close()
+
+	e.HandleGrant(Grant{System: "X", Protocol: "p25", GroupID: 100, FrequencyHz: 851_000_000})
+	e.HandleGrant(Grant{System: "X", Protocol: "p25", GroupID: 200, FrequencyHz: 851_012_500})
+
+	observed := e.ObservedCalls()
+	if len(observed) != 1 {
+		t.Fatalf("observed = %d, want 1", len(observed))
+	}
+	if got := observed[0].UnfollowedReason; got != UnfollowedAllBusy {
+		t.Errorf("UnfollowedReason = %q, want %q", got, UnfollowedAllBusy)
+	}
+	// The followed call must NOT carry a reason.
+	for _, ac := range e.ActiveCalls() {
+		if ac.UnfollowedReason != "" {
+			t.Errorf("followed call carries UnfollowedReason %q, want empty", ac.UnfollowedReason)
+		}
+	}
+}
+
+// TestObservedCallReasonNoVoiceSDR pins the zero-voice-device shape: trunking
+// configured with no `role: voice` SDR at all.
+func TestObservedCallReasonNoVoiceSDR(t *testing.T) {
+	e, _, bus, _ := mkEngine(t, 0)
+	defer bus.Close()
+
+	e.HandleGrant(Grant{System: "X", Protocol: "p25", GroupID: 100, FrequencyHz: 851_000_000})
+
+	observed := e.ObservedCalls()
+	if len(observed) != 1 {
+		t.Fatalf("observed = %d, want 1", len(observed))
+	}
+	if got := observed[0].UnfollowedReason; got != UnfollowedNoVoiceSDR {
+		t.Errorf("UnfollowedReason = %q, want %q", got, UnfollowedNoVoiceSDR)
+	}
+}
+
+// TestObservedCallReasonCoverageGap pins the wideband-tap shape from the
+// issue #356 report: a voice device exists but its IQ window excludes the
+// grant's frequency, so the call can never be followed and must say so.
+func TestObservedCallReasonCoverageGap(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	tap := &windowedFakeTuner{canTune: func(hz uint32) bool { return false }}
+	pool := NewVoicePool([]*VoiceDevice{{Tuner: tap, Serial: "TAP-1"}})
+	e, err := NewEngine(EngineOptions{
+		Bus: bus, VoicePool: pool, Talkgroups: NewTalkgroupDB(),
+		CallTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e.HandleGrant(Grant{System: "X", Protocol: "p25", GroupID: 100, FrequencyHz: 851_000_000})
+
+	observed := e.ObservedCalls()
+	if len(observed) != 1 {
+		t.Fatalf("observed = %d, want 1", len(observed))
+	}
+	if got := observed[0].UnfollowedReason; got != UnfollowedNoCoverage {
+		t.Errorf("UnfollowedReason = %q, want %q", got, UnfollowedNoCoverage)
+	}
+}
+
+// TestUnfollowedReasonClearedWhenTunerFollows pins the clear-on-follow rule:
+// once a tuner frees up and a repeat grant binds the previously-observed call,
+// the stale reason must not survive on the tracker entry.
+func TestUnfollowedReasonClearedWhenTunerFollows(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	pool, _ := mkPool(1)
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+	e, err := NewEngine(EngineOptions{
+		Bus: bus, VoicePool: pool, Talkgroups: NewTalkgroupDB(),
+		CallTimeout: time.Second, Now: clk.Now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// TG 1 takes the only tuner; TG 2 is observed with the busy reason.
+	e.HandleGrant(Grant{System: "X", Protocol: "p25", GroupID: 1, FrequencyHz: 851_000_000, At: clk.t})
+	clk.t = clk.t.Add(800 * time.Millisecond)
+	e.HandleGrant(Grant{System: "X", Protocol: "p25", GroupID: 2, FrequencyHz: 851_012_500, At: clk.t})
+	if obs := e.ObservedCalls(); len(obs) != 1 || obs[0].UnfollowedReason != UnfollowedAllBusy {
+		t.Fatalf("observed = %+v, want one entry with the all-busy reason", obs)
+	}
+
+	// TG 1 goes stale and the watchdog frees the tuner; TG 2's tracker entry
+	// (refreshed 800 ms in) survives the same sweep.
+	clk.t = clk.t.Add(1200 * time.Millisecond)
+	e.runWatchdog()
+	if got := len(e.ActiveCalls()); got != 0 {
+		t.Fatalf("active after watchdog = %d, want 0", got)
+	}
+
+	// The repeat grant now binds — the call is followed and the reason clears.
+	e.HandleGrant(Grant{System: "X", Protocol: "p25", GroupID: 2, FrequencyHz: 851_012_500, At: clk.t})
+	if got := len(e.ActiveCalls()); got != 1 {
+		t.Fatalf("active = %d, want 1 (tuner freed)", got)
+	}
+	if obs := e.ObservedCalls(); len(obs) != 0 {
+		t.Fatalf("observed = %+v, want none (call is followed)", obs)
+	}
+	e.mu.Lock()
+	ac := e.observed[observedKey(Grant{System: "X", GroupID: 2})]
+	e.mu.Unlock()
+	if ac == nil {
+		t.Fatal("tracker entry for TG 2 vanished")
+	}
+	if ac.UnfollowedReason != "" {
+		t.Errorf("UnfollowedReason = %q after follow, want empty", ac.UnfollowedReason)
+	}
+}

--- a/internal/trunking/voicepool.go
+++ b/internal/trunking/voicepool.go
@@ -73,6 +73,16 @@ type ActiveCall struct {
 	// Phase 1) populate them. Issue #878 follow-up.
 	EVMPct *float64
 	SNRDb  *float64
+	// UnfollowedReason says WHY no voice tuner is following this call, for
+	// entries known only from the control channel (Device == nil). Set at the
+	// engine's grant-drop sites (no voice SDR configured / frequency outside
+	// every voice device's tuning window / all tuners busy), cleared the
+	// moment a tuner does follow the call. Diagnostic only — on a single
+	// wideband SDR whose IQ window doesn't cover the voice channels, every
+	// call surfaces as "observed", which operators read as "GopherTrunk says
+	// the talkgroup has no voice"; this field makes the actual cause visible
+	// in the API. Empty for followed calls. Issue #356.
+	UnfollowedReason string
 }
 
 // NewVoicePool returns a pool over the supplied devices. The order of

--- a/web/configbuilder/src/api/types.ts
+++ b/web/configbuilder/src/api/types.ts
@@ -247,6 +247,7 @@ export interface ConvChannelConfig {
   ActivityDebounceMs: number;
   SquelchHysteresisDb: number;
   Priority: number;
+  TalkgroupID: number;
   Tone: ConvToneConfig;
 }
 

--- a/web/configbuilder/src/sections/simple.tsx
+++ b/web/configbuilder/src/sections/simple.tsx
@@ -465,6 +465,7 @@ export function ScannerSection() {
             ActivityDebounceMs: 0,
             SquelchHysteresisDb: 0,
             Priority: 0,
+            TalkgroupID: 0,
             Tone: { Mode: "", CTCSSHz: 0, DCSCode: "" },
           })}
           itemTitle={(ch) => ch.Label || "channel"}
@@ -489,6 +490,7 @@ export function ScannerSection() {
                 <NumberField label="Activity debounce (ms)" value={ch.ActivityDebounceMs} onChange={(x) => setCh({ ...ch, ActivityDebounceMs: x })} />
                 <NumberField label="Squelch hysteresis (dB)" step={0.1} value={ch.SquelchHysteresisDb} onChange={(x) => setCh({ ...ch, SquelchHysteresisDb: x })} />
                 <NumberField label="Priority" value={ch.Priority} onChange={(x) => setCh({ ...ch, Priority: x })} />
+                <NumberField label="Talkgroup ID (0 = positional)" value={ch.TalkgroupID} onChange={(x) => setCh({ ...ch, TalkgroupID: x })} />
               </div>
               <div className="grid gap-3 sm:grid-cols-2">
                 <SelectField


### PR DESCRIPTION
## Summary

An audit of merged PRs against the tree (prompted by the #753 discovery that the #922-described stall-retry commit never landed) found **one more PR with the same defect: #1121**. Its body describes three changes, but its merged head carried only one commit (the #1120 config-path fix — 2 files, +100/−2). The other two described changes — the `unfollowed_reason` diagnostic promised to the #356 reporter, and the `scanner.conventional[].talkgroup_id` override for #1105 — were never pushed, so `main` claims them (PR body + issue comments) without containing them. This PR re-lands both, implemented to the #1121 spec. Audit scope, for the record: all 1,002 merged PRs are accounted for in `main`'s history, and a sweep of every closed PR body's named regression tests against the tree at each PR's own merge commit flags only #922 (already re-landed via #1130) and #1121 (this PR) — the earlier "history re-import dropped it" theory was wrong; in both cases the described commit was simply never on the merged branch.

## Changes

- **`unfollowed_reason` on observed calls (#356).** The engine stamps why a control-channel-announced call has no tuner following it, at the three grant-drop sites: `no voice SDR configured`, `voice frequency outside every voice device's tuning window`, `all voice tuners busy with higher-priority calls` (`internal/trunking/engine.go`, new `ActiveCall.UnfollowedReason`); cleared the moment a tuner follows the call. Surfaced as `unfollowed_reason` (omitempty) on `/api/v1/calls/active` (`internal/api/types.go`), omitted for followed calls. Diagnostic only — no change to grant handling or the decode path.
- **`scanner.conventional[].talkgroup_id` (#1105).** Optional fixed talkgroup ID a conventional channel surfaces under (API, call log, Rdio Scanner / OpenMHz / Broadcastify uploads) instead of the positional `0x80000000 | list-index` synthetic, which shifts when the channel list is edited and breaks `talkgroup_file` roster rows. Unset keeps the positional default. Config validation rejects two channels resolving to the same effective ID (the engine keys synthetic calls on `(system, GroupID)`). Threaded config → `conventional.Channel` → `beginDwell`; FieldMeta + web-builder `types.ts`/editor field; `config.example.yaml` documents the key.
- CHANGELOG `[Unreleased]` → `Added` bullets for both, each noting the re-land.

## Test plan

- [x] `make vet test` is green locally
- [ ] `make integration` is green locally (if the change touches the daemon) — n/a (a diagnostic field and config/ID plumbing; no daemon/DSP/replay behaviour change)
- [x] Added or updated tests where appropriate — failing-first for both: `TestObservedCallReasonAllBusy` / `NoVoiceSDR` / `CoverageGap` + `TestUnfollowedReasonClearedWhenTunerFollows` (`internal/trunking/unfollowed_reason_test.go`), the extended `TestActiveCallsReportsEngineSnapshot` JSON pin, `TestConvScannerUsesExplicitTalkgroupID` (fails against the old always-positional scanner), and `TestConvChannelTalkgroupIDCollisionRejected` (explicit-vs-explicit and explicit-vs-positional collisions). Web change verified with `npm run typecheck` (which caught the builder's `makeNew` needing the field) + the configbuilder vitest suite (47 pass).
- [ ] Smoke-tested against real hardware (if SDR / USB / vocoder code changed) — n/a (no SDR/USB/vocoder code)

## Breaking changes

None. `unfollowed_reason` is a new omitempty field; `talkgroup_id` defaults to the current positional value when unset; the collision validation only rejects configs that would already have folded two channels into one call identity.

## Docs / CHANGELOG

- [x] Added a `## [Unreleased]` bullet to `CHANGELOG.md` if this is user-visible
- [x] Updated `README.md` or `docs/` if operator-facing behaviour changed — `config.example.yaml` documents `talkgroup_id`; no README change needed

## Linked issues

Refs #356, Refs #1105 (Refs, not Closes, per the verify-before-close policy — #356 additionally awaits the reporter's build/config/log data; #1105 is already closed by its reporter on the label half, this completes the ID-durability half its thread was promised)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WiC3fdNKUzyVv1aui8tHR9

---
_Generated by [Claude Code](https://claude.ai/code/session_01WiC3fdNKUzyVv1aui8tHR9)_