### PR TITLE
rtlsdr(macos): reset-retry transient control-transfer aborts on bring-up (#1135)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,19 @@ for tagged releases.
   #1096).
 
 ### Fixed
+- **macOS: transient RTL-SDR control-transfer aborts during bring-up are now
+  retried instead of failing the open** (issue #1135). On a Mac with two dongles
+  on one bus, a control `DeviceRequest` during device bring-up intermittently
+  returns IOKit `kIOReturnAborted`, so `sdr list --probe` failed on one dongle or
+  the other at random and the daemon skipped `cc_hunt` when the second SDR would
+  not open. Two problems, both fixed: the abort was mapped to the wrong sentinel
+  and surfaced as the misleading `usb: DeviceRequest OUT: usb: bulk-IN not
+  active` (it is now a dedicated `usb: transfer aborted`); and the open-time
+  reset-and-retry envelope did not treat it as recoverable, so a transient killed
+  the open instead of being retried like the existing cold-boot stall/timeout
+  classes. A failure that survives every retry now carries a macOS hint pointing
+  at USB power / bus contention (give each dongle its own powered port). No
+  effect on Linux or Windows.
 - **Windows: two identical RTL-SDR composite dongles can now open concurrently**
   (issue #1131). The WinUSB composite-device fallback located the Interface 0
   (`&MI_00`) child function node by VID/PID only, so with two identical

--- a/docs/install-macos.md
+++ b/docs/install-macos.md
@@ -205,6 +205,7 @@ manually if you want a clean slate.
 | `sdr list` prints nothing                                | Another RTL-SDR app (SDR++, GQRX) is holding the device — close it and retry. |
 | `sdr list` still prints nothing with every other SDR app closed | Re-run with `RTLSDR_DEBUG_USB=1 gophertrunk sdr list 2> trace.log`. Attach `trace.log`, `sw_vers`, and `system_profiler SPUSBDataType \| grep -A 10 "Vendor ID"` to a new issue — the trace tells us which IOKit class matched and which properties were readable. |
 | `usb: claim interface failed`                            | Same — IOKit hands the dongle to whoever opened it first.                     |
+| `usb: bulk-IN not active` / `usb: transfer aborted` during probe or bring-up, especially with two dongles | IOKit aborted a control transfer mid-bring-up (`kIOReturnAborted`). Bring-up now resets and retries this transient automatically; if it survives every retry it's usually marginal USB power or bus contention. Give each dongle its own powered port — avoid bus-powered hubs and daisy-chained extensions — and retry `gophertrunk sdr list --probe`. |
 | Audio plays as silence                                   | `audio.enabled: false` by default — set `true` in config. CoreAudio is the default backend on Darwin. |
 | LaunchAgent says `Load failed: 5: Input/output error`    | plist syntax error — `plutil -lint ~/Library/LaunchAgents/org.gophertrunk.daemon.plist` will show the line. |
 

--- a/internal/sdr/rtlsdr/purego/driver.go
+++ b/internal/sdr/rtlsdr/purego/driver.go
@@ -405,10 +405,13 @@ func runBringup(demod *rtl2832u.Demod) (tuners.Tuner, error) {
 // write probe" case), ErrDeviceGone (the chip dropped off the bus
 // mid-bringup), ErrTimeout (Windows/WinUSB cold-boot — same root cause
 // as the Linux EPIPE, but WinUsb_ControlTransfer surfaces it as
-// ERROR_SEM_TIMEOUT instead of stalling the pipe), or ErrPipeStalled
+// ERROR_SEM_TIMEOUT instead of stalling the pipe), ErrPipeStalled
 // (Windows/WinUSB clone-dongle cold-boot — the chip latches the first
 // USB_SYSCTL write and then NAKs the next identical write with
-// ERROR_GEN_FAILURE). The retry is bounded to four resets per Open
+// ERROR_GEN_FAILURE), or ErrTransferAborted (macOS/IOKit kIOReturnAborted
+// on a control request — the transient issue #1135 hit during bring-up
+// with two dongles on one Mac, where the same probe/open succeeds on a
+// fresh handle a moment later). The retry is bounded to four resets per Open
 // (200ms + 400ms + 800ms + 1200ms exponential backoff between passes)
 // so even if all four resets are wasted on a non-cold-boot stall the
 // cost is capped at ~2.6s of sleep before the original error surfaces.
@@ -422,7 +425,8 @@ func isBringupResetable(err error) bool {
 	return errors.Is(err, syscall.EPIPE) ||
 		errors.Is(err, usb.ErrDeviceGone) ||
 		errors.Is(err, usb.ErrTimeout) ||
-		errors.Is(err, usb.ErrPipeStalled)
+		errors.Is(err, usb.ErrPipeStalled) ||
+		errors.Is(err, usb.ErrTransferAborted)
 }
 
 // withTransportDiagnostics appends a USB diagnostic dump to err when the
@@ -507,6 +511,16 @@ func tunerBringupHint(err error) string {
 			" `gophertrunk sdr doctor` reports WinUSB bound to interface 0." +
 			" Avoid USB hubs and powered extension cables." +
 			" See https://gophertrunk.org/install-windows.html#troubleshooting)"
+	}
+	if errors.Is(err, usb.ErrTransferAborted) {
+		return " (hint: macOS aborted a USB control transfer mid-bring-up" +
+			" (IOKit kIOReturnAborted) — bring-up already resets and retries" +
+			" this transient (issue #1135), so a failure that survives every" +
+			" retry points at marginal USB power or bus contention. With two" +
+			" or more dongles on one Mac, give each its own powered port" +
+			" (avoid bus-powered hubs and daisy-chained extensions) and" +
+			" retry `gophertrunk sdr list --probe`." +
+			" See https://gophertrunk.org/install-macos.html#troubleshooting)"
 	}
 	return ""
 }

--- a/internal/sdr/rtlsdr/purego/driver_test.go
+++ b/internal/sdr/rtlsdr/purego/driver_test.go
@@ -592,6 +592,80 @@ func TestOpenDevice_BringupPipeStalledFiveTimes_ReturnsHintError(t *testing.T) {
 	}
 }
 
+// Regression for issue #1135: on macOS with two RTL-SDR dongles on one
+// bus, a control transfer during bring-up intermittently returns
+// kIOReturnAborted (surfaced as usb.ErrTransferAborted). It is a transient
+// — the same probe/open succeeds on a fresh handle a moment later — so the
+// bring-up envelope must reset and retry it, exactly like the EPIPE /
+// ErrPipeStalled cold-boot classes, instead of surfacing it immediately
+// (which is why the reporter's `sdr list --probe` failed on one dongle or
+// the other at random). Before the fix ErrTransferAborted did not exist:
+// the abort was mislabelled "usb: bulk-IN not active" AND was absent from
+// isBringupResetable, so openDevice returned after pass 1 with zero resets.
+func TestOpenDevice_BringupTransferAborted_TriggersFullReset(t *testing.T) {
+	m := usb.NewMockTransport()
+	m.Script = []usb.CtrlExchange{
+		warmupUSBSysctlExchange(nil),                    // pass 1: warmup OK
+		warmupUSBSysctlExchange(usb.ErrTransferAborted), // pass 1: InitBaseband step 0 aborts
+		warmupUSBSysctlExchange(nil),                    // pass 2: warmup OK (post-reset)
+		warmupUSBSysctlExchange(usb.ErrClosed),          // pass 2: non-resetable terminator
+	}
+	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-bringup-aborted-retry"}
+	_, err := openDevice(m, desc, 0)
+	if err == nil {
+		t.Fatal("openDevice succeeded; expected init-baseband terminator to fail the test")
+	}
+	if !strings.Contains(err.Error(), "init baseband") {
+		t.Errorf("err = %v, want substring \"init baseband\" (proves the retry reached InitBaseband)", err)
+	}
+	if m.ResetCalls != 1 {
+		t.Errorf("ResetCalls = %d, want 1 (one reset between the two bring-up attempts)", m.ResetCalls)
+	}
+	if m.ClaimCalls != 2 {
+		t.Errorf("ClaimCalls = %d, want 2 (initial claim + post-reset re-claim)", m.ClaimCalls)
+	}
+}
+
+// When the macOS control-transfer abort recurs on every bring-up pass, the
+// surfaced error must carry the multi-dongle / USB-power hint pointing at
+// issue #1135 — and must NOT still read as the misleading "bulk-IN not
+// active". Bounded to four resets per Open call.
+func TestOpenDevice_BringupTransferAbortedFiveTimes_ReturnsHintError(t *testing.T) {
+	m := usb.NewMockTransport()
+	m.Script = []usb.CtrlExchange{
+		warmupUSBSysctlExchange(nil),
+		warmupUSBSysctlExchange(usb.ErrTransferAborted),
+		warmupUSBSysctlExchange(nil),
+		warmupUSBSysctlExchange(usb.ErrTransferAborted),
+		warmupUSBSysctlExchange(nil),
+		warmupUSBSysctlExchange(usb.ErrTransferAborted),
+		warmupUSBSysctlExchange(nil),
+		warmupUSBSysctlExchange(usb.ErrTransferAborted),
+		warmupUSBSysctlExchange(nil),
+		warmupUSBSysctlExchange(usb.ErrTransferAborted),
+	}
+	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-bringup-aborted-fail"}
+	_, err := openDevice(m, desc, 0)
+	if err == nil {
+		t.Fatal("openDevice succeeded; expected ErrTransferAborted-five-times to fail open")
+	}
+	if !errors.Is(err, usb.ErrTransferAborted) {
+		t.Errorf("err = %v, want errors.Is(err, usb.ErrTransferAborted)", err)
+	}
+	if strings.Contains(err.Error(), "bulk-IN not active") {
+		t.Errorf("err = %v, must not read as \"bulk-IN not active\" — that mislabelled a control-transfer abort (issue #1135)", err)
+	}
+	if !strings.Contains(err.Error(), "issue #1135") {
+		t.Errorf("err = %v, want substring \"issue #1135\" (proves the macOS multi-dongle hint was appended)", err)
+	}
+	if m.ResetCalls != 4 {
+		t.Errorf("ResetCalls = %d, want 4 (bounded envelope: four resets, five attempts)", m.ResetCalls)
+	}
+	if m.ClaimCalls != 5 {
+		t.Errorf("ClaimCalls = %d, want 5 (initial claim + four post-reset re-claims)", m.ClaimCalls)
+	}
+}
+
 // Regression: when ErrTimeout recurs on every bring-up pass (warmup
 // swallowed, then InitBaseband step 0 times out), the surfaced error
 // must carry the Windows-aware hint that points at the WinUSB / Zadig

--- a/internal/sdr/rtlsdr/usb/usb.go
+++ b/internal/sdr/rtlsdr/usb/usb.go
@@ -169,6 +169,20 @@ var (
 	// halt via [Transport.Reset] and retry once.
 	ErrPipeStalled = errors.New("usb: pipe stalled")
 
+	// ErrTransferAborted is returned when a control (or interface) request
+	// is aborted by the host stack mid-flight rather than stalled or timed
+	// out. Maps to macOS/IOKit kIOReturnAborted (0xe00002eb) on a
+	// synchronous DeviceRequest — the transient the reporter of issue #1135
+	// hit during bring-up on a Mac with two RTL-SDR dongles, where the same
+	// probe/open succeeds on a fresh handle a moment later. It is transient
+	// and reset-recoverable, so the open-time bring-up envelope resets and
+	// retries on it (see isBringupResetable in purego/driver.go). It is NOT
+	// a bulk-IN condition: StopBulkIn's "no active stream" case stays
+	// ErrBulkInactive, which this used to be conflated with — an abort on a
+	// control transfer then surfaced as the misleading "usb: bulk-IN not
+	// active".
+	ErrTransferAborted = errors.New("usb: transfer aborted")
+
 	// ErrClosed is returned by methods invoked after Close.
 	ErrClosed = errors.New("usb: transport closed")
 )

--- a/internal/sdr/rtlsdr/usb/usb_darwin_iokit.go
+++ b/internal/sdr/rtlsdr/usb/usb_darwin_iokit.go
@@ -345,7 +345,17 @@ func translateIOReturn(rc uintptr) error {
 		// tuner burst-write retry (isI2CBurstStall) recover on macOS.
 		return ErrPipeStalled
 	case kIOReturnAborted:
-		return ErrBulkInactive
+		// A request the host stack aborted mid-flight. On the bulk-IN
+		// path this is the normal StopBulkIn/AbortPipe cancellation, but
+		// bulkLoop reads the raw rc there and never routes through here —
+		// so every translateIOReturn caller is a control / interface /
+		// reset op. For those an abort is a transient the bring-up
+		// envelope can reset-and-retry, so surface the dedicated
+		// ErrTransferAborted rather than ErrBulkInactive, whose meaning is
+		// "StopBulkIn called with no active stream" (issue #1135 — the
+		// abort used to be mislabelled "usb: bulk-IN not active" on a
+		// control DeviceRequest, and was not treated as resetable).
+		return ErrTransferAborted
 	case kIOReturnExclusive:
 		return fmt.Errorf("usb: device already opened by another process (kIOReturnExclusive)")
 	default:

--- a/internal/sdr/rtlsdr/usb/usb_darwin_test.go
+++ b/internal/sdr/rtlsdr/usb/usb_darwin_test.go
@@ -38,6 +38,35 @@ func TestKIOUSBPipeStalledValue(t *testing.T) {
 	}
 }
 
+// TestTranslateIOReturn_AbortedMapsToErrTransferAborted pins the fix for
+// issue #1135: on macOS with two RTL-SDR dongles on one bus, a control
+// DeviceRequest during bring-up intermittently returns kIOReturnAborted
+// (0xe00002eb). It used to map to ErrBulkInactive, so the failure surfaced
+// as the misleading "usb: DeviceRequest OUT: usb: bulk-IN not active" AND
+// was not recognised as reset-recoverable by the bring-up envelope
+// (isBringupResetable), so the open aborted instead of retrying the
+// transient. It must now map to the dedicated ErrTransferAborted and must
+// NOT be ErrBulkInactive, whose meaning is "StopBulkIn called with no
+// active stream". This is the macOS analog of the #1038 stall-mapping fix.
+func TestTranslateIOReturn_AbortedMapsToErrTransferAborted(t *testing.T) {
+	got := translateIOReturn(kIOReturnAborted)
+	if !errors.Is(got, ErrTransferAborted) {
+		t.Fatalf("translateIOReturn(0x%08x) = %v, want errors.Is(err, ErrTransferAborted) so the bring-up envelope resets and retries the transient", uint32(kIOReturnAborted), got)
+	}
+	if errors.Is(got, ErrBulkInactive) {
+		t.Fatalf("translateIOReturn(0x%08x) = %v, must not be ErrBulkInactive — a control-transfer abort is not a bulk-IN-inactive condition (issue #1135)", uint32(kIOReturnAborted), got)
+	}
+}
+
+// TestKIOReturnAbortedValue guards the constant against a typo: the whole
+// #1135 fix hinges on it matching the kern_return IOKit actually returns.
+func TestKIOReturnAbortedValue(t *testing.T) {
+	const want = 0xE00002EB // sys_iokit | sub_iokit_common | 0x2eb
+	if kIOReturnAborted != want {
+		t.Fatalf("kIOReturnAborted = 0x%08x, want 0x%08x", uint32(kIOReturnAborted), uint32(want))
+	}
+}
+
 // These tests pin compile-time invariants (UUIDs, struct sizes,
 // vtable indices) that don't depend on IOKit actually loading at
 // runtime. The real IOKit transport's behavior is verified on


### PR DESCRIPTION
## Summary

On macOS with two RTL-SDR dongles on one bus, a control `DeviceRequest` during device bring-up intermittently returns IOKit `kIOReturnAborted` (`0xe00002eb`). The reporter's `sdr list --probe` failed on one dongle or the other at random, and the daemon skipped `scanner.cc_hunt` when the second SDR would not open (issue #1135). This is the macOS companion to the Windows two-dongle fix in #1131.

## Changes

Two conflated problems, both fixed:

- **Misleading error / wrong sentinel.** `translateIOReturn` mapped `kIOReturnAborted` to `ErrBulkInactive`, so a control-transfer abort surfaced as `usb: DeviceRequest OUT: usb: bulk-IN not active`. The bulk-IN loop reads the raw `rc` and never routes through `translateIOReturn`, so every caller of it is a control / interface / reset op — none wants bulk-inactive semantics. It now returns a dedicated `usb.ErrTransferAborted`; `ErrBulkInactive` keeps its sole meaning ("StopBulkIn called with no active stream").
- **Not treated as recoverable.** The open-time reset+retry envelope (`isBringupResetable`) did not include the abort, so a transient killed the open instead of being retried like the existing EPIPE / `ErrTimeout` / `ErrPipeStalled` cold-boot classes. `ErrTransferAborted` joins that set (bounded to the same four resets per Open), and `tunerBringupHint` gains a macOS multi-dongle / USB-power hint for the case where it recurs through every retry.
- Docs: a macOS troubleshooting row for the symptom, and a `CHANGELOG.md` `[Unreleased]` entry.

## Test plan

- [x] `make vet test` is green locally
- [ ] `make integration` — n/a (no daemon/DSP/replay path changed; this is the USB bring-up layer)
- [x] Added tests where appropriate — **failing-first, verified**:
  - `TestOpenDevice_BringupTransferAborted_TriggersFullReset` and `...FiveTimes_ReturnsHintError` (cross-platform, via the mock transport) — assert the envelope resets+retries on `ErrTransferAborted` and surfaces the #1135 hint. Both fail against the pre-fix `isBringupResetable` (`ResetCalls = 0`).
  - `TestTranslateIOReturn_AbortedMapsToErrTransferAborted` + a constant guard (darwin) — assert the mapping is `ErrTransferAborted` and **not** `ErrBulkInactive`.
- [ ] Smoke-tested against real hardware — **not done; no Mac + two-dongle rig available.** This is the on-air/hardware gate for the issue (per the repo's verify-before-close policy). The reporter (`rd0fun`) has the exact rig; asked on the issue to confirm both dongles probe/open on a build with this change.

## Breaking changes

None. New sentinel `usb.ErrTransferAborted` is additive; `ErrBulkInactive` semantics are unchanged. Linux and Windows code paths are untouched.

## Docs / CHANGELOG

- [x] Added a `## [Unreleased]` bullet to `CHANGELOG.md` (user-visible macOS fix)
- [x] Updated `docs/install-macos.md` (troubleshooting row)

## Linked issues

Refs #1135

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5YFbSs2koFyDDqSdkH78s)_