### PR TITLE
docs(#1131): cross-reference the macOS variant to the merged #1135/#1137 abort-retry fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,11 +43,15 @@ for tagged releases.
 
 ### Fixed
 - **macOS: transient RTL-SDR control-transfer aborts during bring-up are now
-  retried instead of failing the open** (issue #1135). On a Mac with two dongles
-  on one bus, a control `DeviceRequest` during device bring-up intermittently
-  returns IOKit `kIOReturnAborted`, so `sdr list --probe` failed on one dongle or
-  the other at random and the daemon skipped `cc_hunt` when the second SDR would
-  not open. Two problems, both fixed: the abort was mapped to the wrong sentinel
+  retried instead of failing the open** (issue #1135; also the macOS variant
+  reported on #1131). On a Mac with two dongles on one bus, a control
+  `DeviceRequest` during device bring-up intermittently returns IOKit
+  `kIOReturnAborted`, so `sdr list --probe` failed on one dongle or the other at
+  random and the daemon skipped `cc_hunt` when the second SDR would not open.
+  This is the macOS analog of the #1131 Windows composite-dongle fix below —
+  same "second identical dongle won't open" symptom, a different root cause
+  (a transient IOKit abort, not the WinUSB VID/PID child-node collision), and
+  `sdr list --probe` reaches it through the same bring-up envelope as the daemon. Two problems, both fixed: the abort was mapped to the wrong sentinel
   and surfaced as the misleading `usb: DeviceRequest OUT: usb: bulk-IN not
   active` (it is now a dedicated `usb: transfer aborted`); and the open-time
   reset-and-retry envelope did not treat it as recoverable, so a transient killed


### PR DESCRIPTION
## Summary

Follow-up for **#1131**. The reporter of #1131 filed a follow-up comment reporting the *identical* "second RTL-SDR dongle won't open" symptom on **macOS** — which is a different root cause from #1131's Windows composite-device bug (fixed separately in #1132). That macOS variant is the transient IOKit `kIOReturnAborted` during bring-up, and its fix already landed in **#1137** (Refs #1135), now merged to `main`.

This PR is docs-only: it points the `CHANGELOG.md` #1135 entry at the #1131 macOS variant so a reader of either issue lands on the right fix. There is no remaining *code* work for #1131 — both root causes (Windows composite child-node collision, macOS transient abort) are fixed and merged.

## Changes

- `CHANGELOG.md`: the macOS abort-retry entry now names the #1131 macOS variant and explains it is the macOS analog of the #1131 Windows composite-dongle fix (same symptom, different root cause; `sdr list --probe` reaches it through the same bring-up envelope as the daemon).

## Test plan

- [x] `make vet test` is green locally (no code change; docs only)
- [ ] `make integration` — n/a
- [x] Added or updated tests where appropriate — n/a (documentation only)
- [ ] Smoke-tested against real hardware — n/a (documentation only; the code fix's hardware gate is tracked on #1135/#1131)

## Breaking changes

None.

## Docs / CHANGELOG

- [x] `CHANGELOG.md` updated

## Linked issues

Refs #1131, Refs #1135. (`Refs`, not `Closes`: #1131's Windows fix still awaits the reporter's on-hardware verification, and the macOS fix awaits `rd0fun`'s confirmation on their rig, per the verify-before-close policy.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)