### PR TITLE
web+api+config: serve recordings stored with relative paths (relative -config UI bug)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,20 @@ for tagged releases.
   #1096).
 
 ### Fixed
+- **Web History: "recording is unavailable (it may have been swept by
+  retention)" while the WAV was on disk the whole time.** A daemon started with
+  a relative `-config` path (e.g. `gophertrunk -config config.yaml`) resolved
+  `recordings.dir` — and every other config-relative path — against the
+  *relative* config directory, so the call log stored cwd-relative
+  `recording_path` rows and `GET /api/v1/calls/{id}/audio`'s absolute-path
+  guard 404'd every playback of a file that was right there. Three fixes:
+  `config.Load` now absolutizes the resolve base so stored paths are always
+  absolute; the audio endpoint resolves a relative stored path (rows written
+  before the fix) against the daemon's working directory — the directory the
+  recorder wrote it under — before validating; and the web player now surfaces
+  the daemon's own error detail (`no recording for this call` / `recording
+  unavailable` / `recording file is gone`) instead of unconditionally guessing
+  retention, so the next mismatch is diagnosable from the screenshot.
 - **macOS: transient RTL-SDR control-transfer aborts during bring-up are now
   retried instead of failing the open** (issue #1135). On a Mac with two dongles
   on one bus, a control `DeviceRequest` during device bring-up intermittently

--- a/internal/api/call_audio_relative_test.go
+++ b/internal/api/call_audio_relative_test.go
@@ -1,0 +1,94 @@
+package api
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/storage"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TestCallAudioEndpointServesRelativeRecordingPath pins the "recording is
+// unavailable while the file is right there" UI bug: a daemon started with a
+// relative -config path used to store a cwd-relative recordings dir, so every
+// call row's recording_path was relative and handleCallAudio's absolute-path
+// guard 404'd it even though os.Open would have succeeded. A relative stored
+// path must be resolved against the daemon's working directory — the same
+// directory the recorder wrote it under — and served.
+func TestCallAudioEndpointServesRelativeRecordingPath(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	bus := events.NewBus(8)
+	defer bus.Close()
+	db, err := storage.Open(filepath.Join(dir, "calls.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	cl, err := storage.NewCallLog(db, bus, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cl.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go cl.Run(ctx)
+
+	// The recording exists on disk, reachable via the cwd-relative path the
+	// old config resolution produced.
+	relPath := filepath.Join("recordings", "Alpha", "700", "call.wav")
+	if err := os.MkdirAll(filepath.Dir(relPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	want := []byte("RIFF....WAVEfmt fake-pcm-bytes")
+	if err := os.WriteFile(relPath, want, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	startedAt := time.Now().UTC().Truncate(time.Microsecond)
+	call := trunking.CallStart{
+		Grant:        trunking.Grant{System: "Alpha", Protocol: "tetra", GroupID: 700, FrequencyHz: 467_912_500},
+		DeviceSerial: "cc:same-carrier:1",
+		StartedAt:    startedAt,
+	}
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: call})
+	bus.Publish(events.Event{Kind: events.KindCallComplete, Payload: trunking.CallComplete{
+		Grant: call.Grant, DeviceSerial: call.DeviceSerial,
+		StartedAt: startedAt, EndedAt: startedAt.Add(2 * time.Second), AudioPath: relPath,
+	}})
+
+	var id int64
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		rows, _ := db.History(context.Background(), storage.HistoryFilter{Limit: 10})
+		if len(rows) == 1 && rows[0].HasRecording {
+			id = rows[0].ID
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if id == 0 {
+		t.Fatal("setup: call row with HasRecording never appeared")
+	}
+
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, History: HistoryFromStorage(db)})
+	defer teardown()
+
+	resp := mustGet(t, base+"/api/v1/calls/"+strconv.FormatInt(id, 10)+"/audio")
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("relative-path audio status = %d, want 200 (file exists at %s)",
+			resp.StatusCode, filepath.Join(dir, relPath))
+	}
+	got, _ := io.ReadAll(resp.Body)
+	if string(got) != string(want) {
+		t.Errorf("body = %q, want %q", got, want)
+	}
+}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -396,6 +396,17 @@ func (s *Server) handleCallAudio(w http.ResponseWriter, r *http.Request) {
 		s.writeError(w, http.StatusNotFound, "no recording for this call")
 		return
 	}
+	// Rows written while recordings.dir resolved to a relative path (a
+	// relative -config invocation, before config.Load absolutized the resolve
+	// base) store cwd-relative recording paths. The recorder wrote them
+	// relative to the daemon's working directory, so resolving against the
+	// same cwd is exactly what makes the file reachable — without this every
+	// such row 404'd as "unavailable" while the file was on disk.
+	if !filepath.IsAbs(path) {
+		if abs, err := filepath.Abs(path); err == nil {
+			path = abs
+		}
+	}
 	// The path is daemon-generated, but validate defensively before opening:
 	// an absolute audio file, no traversal, actually a regular file. This keeps
 	// the endpoint from ever serving a non-recording even if the row is bad.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2165,7 +2165,18 @@ func Load(path string) (Config, error) {
 	// land under the operator's chosen data root regardless of platform
 	// or current working directory. Absolute and env-expanded-to-absolute
 	// paths pass through untouched (see resolvePaths).
-	cfg.resolvePaths(filepath.Dir(path))
+	//
+	// The base itself must be absolutized first: a relative -config path
+	// (`gophertrunk -config config.yaml`) makes filepath.Dir relative, and
+	// resolving against a relative base leaves every field relative — the
+	// recorder then stores relative recording_path rows, which the audio
+	// endpoint's absolute-path guard rejects (the "recording is unavailable
+	// while the file exists" UI bug).
+	base := filepath.Dir(path)
+	if abs, err := filepath.Abs(base); err == nil {
+		base = abs
+	}
+	cfg.resolvePaths(base)
 	if err := cfg.Validate(); err != nil {
 		return cfg, fmt.Errorf("config %s: %w", path, err)
 	}

--- a/internal/config/resolvepaths_test.go
+++ b/internal/config/resolvepaths_test.go
@@ -75,6 +75,45 @@ trunking:
 	}
 }
 
+// TestLoadAnchorsRelativeConfigPathToAbsolute pins the "recording is
+// unavailable while the file is right there" UI bug: a daemon started with a
+// relative -config path (`gophertrunk -config config.yaml`) resolved
+// config-relative fields against the RELATIVE config dir, so recordings.dir —
+// and therefore every recording_path stored in the call log — stayed relative,
+// and the audio endpoint's absolute-path guard 404'd every playback. The
+// resolve base must itself be absolutized first.
+func TestLoadAnchorsRelativeConfigPathToAbsolute(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.MkdirAll("config", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	yaml := `
+recordings:
+  dir: "recordings"
+`
+	if err := writeFile(filepath.Join("config", "config.yaml"), yaml); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(filepath.Join("config", "config.yaml"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !filepath.IsAbs(cfg.Recordings.Dir) {
+		t.Fatalf("recordings.dir = %q, want absolute", cfg.Recordings.Dir)
+	}
+	// Anchored under the cwd's config dir (Getwd, not the TempDir string,
+	// so a symlinked temp root compares consistently).
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(cwd, "config", "recordings")
+	if cfg.Recordings.Dir != want {
+		t.Errorf("recordings.dir = %q, want %q", cfg.Recordings.Dir, want)
+	}
+}
+
 // TestLoadExpandsEnvThenAbsolute verifies an env var expanding to an
 // absolute path is NOT re-anchored to the config dir.
 func TestLoadExpandsEnvThenAbsolute(t *testing.T) {

--- a/web/src/components/RecordingPlayer.test.tsx
+++ b/web/src/components/RecordingPlayer.test.tsx
@@ -68,4 +68,29 @@ describe("RecordingPlayer", () => {
     );
     expect(document.querySelector("audio")).not.toBeInTheDocument();
   });
+
+  it("surfaces the daemon's own error detail instead of guessing retention", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          ({
+            ok: false,
+            status: 404,
+            json: async () => ({ error: "recording file is gone" }),
+            blob: async () => new Blob(),
+          }) as unknown as Response,
+      ),
+    );
+
+    render(<RecordingPlayer cfg={cfg} callId={9} />);
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /recording file is gone/i,
+      ),
+    );
+    // The speculative retention hint must not override the server's reason.
+    expect(screen.getByRole("alert")).not.toHaveTextContent(/retention/i);
+  });
 });

--- a/web/src/components/RecordingPlayer.tsx
+++ b/web/src/components/RecordingPlayer.tsx
@@ -43,10 +43,22 @@ export function RecordingPlayer({
     })
       .then(async (res) => {
         if (!res.ok) {
+          // Surface the daemon's own {"error": "..."} detail when present:
+          // the server distinguishes "no recording for this call" /
+          // "recording unavailable" / "recording file is gone", and showing
+          // only a guessed retention message hid a path-validation bug where
+          // the file was on disk the whole time.
+          let detail = "";
+          try {
+            const body = (await res.json()) as { error?: string };
+            if (typeof body?.error === "string") detail = body.error;
+          } catch {
+            // non-JSON error body — fall through to the generic message
+          }
           throw new Error(
             res.status === 404
-              ? "recording is unavailable (it may have been swept by retention)"
-              : `recording request failed (${res.status})`,
+              ? `recording is unavailable (${detail || "it may have been swept by retention"})`
+              : `recording request failed (${res.status}${detail ? `: ${detail}` : ""})`,
           );
         }
         const blob = await res.blob();


### PR DESCRIPTION
A daemon started with a relative -config path (gophertrunk -config
config.yaml) resolved recordings.dir — and every other config-relative
path — against the RELATIVE config directory, so the call log stored
cwd-relative recording_path rows and GET /api/v1/calls/{id}/audio's
absolute-path guard 404'd every playback while the WAV sat on disk. The
web player mapped every 404 to "recording is unavailable (it may have
been swept by retention)", which is the reported symptom.

Three fixes:
- config.Load absolutizes the resolvePaths base, so all resolved paths
  (and therefore all newly stored recording_path rows) are absolute
  regardless of how -config was spelled.
- handleCallAudio resolves a relative stored path (rows written before
  this fix) against the daemon's working directory — the directory the
  recorder wrote it under — before the defensive validation, so existing
  call logs play without a migration.
- RecordingPlayer surfaces the daemon's own {"error": ...} detail (no
  recording for this call / recording unavailable / recording file is
  gone) instead of unconditionally guessing retention, so the next
  mismatch is diagnosable from a screenshot.

Regression tests (both fail without the fix):
- TestLoadAnchorsRelativeConfigPathToAbsolute (internal/config)
- TestCallAudioEndpointServesRelativeRecordingPath (internal/api)
- RecordingPlayer.test.tsx: server error detail shown, retention hint
  not substituted for it.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017ZbuW7gjiK8LVm5odLGzZd