### PR TITLE
motorola: correct stale "NOT yet wired" package doc (Refs #1143)

### DIFF
--- a/internal/radio/motorola/motorola.go
+++ b/internal/radio/motorola/motorola.go
@@ -17,23 +17,28 @@
 //	             with linear and table-backed strategies.
 //	control.go   Control-channel state machine ingesting OSWs and
 //	             emitting cc.locked / grant events on the bus.
+//	process.go   Bit-stream adapter: sync correlation, optional
+//	             BCH(64,16,11) OSW FEC (BCHMode, default BCHOn), and
+//	             OSW reassembly feeding the control state machine.
+//
+// The IQ → bit front end lives in the receiver subpackage
+// (internal/radio/motorola/receiver): an FM-discriminator + Gaussian
+// matched-filter MSK demodulator at 3600 baud, wired to this package
+// by ccdecoder.newMotorolaPipeline. So live SmartZone control-channel
+// decode off an SDR is fully wired end to end (IQ → MSK bits →
+// BCH-corrected OSWs → grants); on-air captures generally want the
+// default BCH FEC (motorola_bch_mode: on) rather than the legacy
+// raw-32-bit BCHOff mode.
 //
 // What's NOT yet wired (honest deferrals so a contributor can pick
 // these up):
 //
-//   - The MSK demodulator that turns IQ from a 3600-baud control
-//     channel into the bits this package consumes. The DSP package
-//     has FM / C4FM / H-DQPSK; MSK is a special-case CPFSK that fits
-//     in the same shape.
-//   - BCH(64,16,11) decoder for the OSW FEC. The information-bit
-//     parser here assumes the upstream caller has already corrected
-//     errors.
 //   - Type I sub-band decoding. Type II is the modern variant and
 //     the focus here; Type I support layers on top.
 //   - Vendor-specific opcode coverage. The opcode list focuses on
 //     the SmartZone subset that carries voice grants and system
 //     identification.
 //
-// All of the above slot into the existing engine + recorder + composer
+// Both of the above slot into the existing engine + recorder + composer
 // pipeline through events.KindGrant once they ship.
 package motorola


### PR DESCRIPTION
## Summary

The `internal/radio/motorola` package header documented the MSK demodulator and the BCH(64,16,11) OSW decoder as unimplemented "deferrals," but both have since shipped. That stale comment led a user (#1143) to conclude that Motorola Type II / SmartZone control-channel decode off an SDR isn't implemented, when in fact it is wired end to end.

## Changes

- Rewrite the package doc in `internal/radio/motorola/motorola.go`:
  - Move the **MSK demodulator** out of "NOT yet wired" — the IQ→bit front end lives in `internal/radio/motorola/receiver` (FM discriminator + Gaussian matched filter at 3600 baud) and is wired to this package by `ccdecoder.newMotorolaPipeline`.
  - Move the **BCH(64,16,11) OSW FEC** out of "NOT yet wired" — it's implemented in `process.go` (`BCHMode`, default `BCHOn`); add `process.go` to the "what's wired" list.
  - Note that on-air captures generally want the default BCH FEC (`motorola_bch_mode: on`) rather than the legacy raw-32-bit `BCHOff` mode.
  - Leave the two genuine deferrals (Type I sub-band decoding, vendor-specific opcode coverage).

No behaviour change — documentation comment only.

## Test plan

- [x] `make vet test` is green locally (`go vet` + tests pass for `internal/radio/motorola/...`; comment-only change)
- [ ] `make integration` — n/a (no daemon/DSP change)
- [ ] Added or updated tests — n/a (comment-only; no behaviour change to cover)
- [ ] Smoke-tested against real hardware — n/a

## Breaking changes

none

## Docs / CHANGELOG

- [ ] CHANGELOG — n/a (internal code comment; not user-visible behaviour)
- [ ] README / docs — n/a

## Linked issues

Refs #1143

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JNZkVreDGDtQRWtMQLSN1T

---
_Generated by [Claude Code](https://claude.ai/code/session_01JNZkVreDGDtQRWtMQLSN1T)_