### PR TITLE
daemon: log an effective decode-configuration summary at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **Startup configuration summary** — the daemon now logs an effective-config
+  snapshot at startup (`daemon: config summary` plus one `daemon: system
+  config` line per system) so an operator can confirm at a glance which decode
+  enhancements are actually engaged, instead of guessing from a `config.yaml`
+  full of "use the default" empty strings. Each per-system line lists the
+  enhancements relevant to that protocol (e.g. `traffic_lms`, `cma_equalizer`,
+  `soft_decision`, `dc_block`, `afc`, `interleaved_voice`, `demod`, `clock`)
+  with the on/off/mode resolved through the same parser the decode pipeline
+  uses, so the reported state matches how the receiver was actually built. The
+  global line covers `sample_rate`, input pre-decimation factor, `autotune`,
+  MRC `diversity` per endpoint, and the recording audio-shaping levers.
 - **Cross-protocol feature-parity series** (see
   [`docs/protocol-feature-parity.md`](docs/protocol-feature-parity.md) for the
   full matrix and A/B recipes). Everything decode-affecting is opt-in and off

--- a/cmd/gophertrunk/config_summary.go
+++ b/cmd/gophertrunk/config_summary.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/MattCheramie/GopherTrunk/internal/config"
+	nxdnrx "github.com/MattCheramie/GopherTrunk/internal/radio/nxdn/receiver"
+	p25phase1rx "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1/receiver"
+	p25phase2rx "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase2/receiver"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/tetra"
+	tetrarx "github.com/MattCheramie/GopherTrunk/internal/radio/tetra/receiver"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// logConfigSummary emits a one-time, human-readable snapshot of the effective
+// decode configuration at startup: a global line (SDR/recording levers) plus
+// one line per trunking system listing every decode "enhancement" relevant to
+// that system's protocol and whether it is actually on.
+//
+// The point is answerability: most per-system enhancement toggles are string
+// tri-states where "" means "use the per-protocol default", so an operator
+// reading config.yaml cannot tell whether, say, the TETRA traffic LMS
+// equalizer is running. This summary resolves each toggle through the SAME
+// parser the decode pipeline uses (tetra.ParseTrafficLMS,
+// p25phase2rx.ParseEqualizer, …) rather than testing the raw string for
+// emptiness, so the reported state matches what the receiver was actually
+// built with — including defaults.
+func (d *Daemon) logConfigSummary() {
+	d.log.Info("daemon: config summary", summarizeGlobal(d.cfg)...)
+	for _, s := range d.systems {
+		d.log.Info("daemon: system config",
+			"name", s.Name,
+			"protocol", s.Protocol.String(),
+			"control_channels", len(s.ControlChannels),
+			"enhancements", systemEnhancements(s),
+		)
+	}
+}
+
+// summarizeGlobal builds the slog key/value attrs for the daemon-wide decode
+// and recording levers that aren't per-system.
+func summarizeGlobal(cfg config.Config) []any {
+	attrs := []any{
+		"systems", len(cfg.Trunking.Systems),
+		"sample_rate_hz", cfg.SDR.SampleRate,
+	}
+
+	// input_sample_rate is a pre-decimation stage: the front end runs at the
+	// native rate and the daemon integer-decimates to sample_rate. Report the
+	// factor when it is actually engaged, "off" otherwise.
+	if cfg.SDR.SampleRate != 0 &&
+		cfg.SDR.InputSampleRate != 0 &&
+		cfg.SDR.InputSampleRate != cfg.SDR.SampleRate {
+		attrs = append(attrs,
+			"input_sample_rate_hz", cfg.SDR.InputSampleRate,
+			"predecimation_factor", cfg.SDR.InputSampleRate/cfg.SDR.SampleRate,
+		)
+	} else {
+		attrs = append(attrs, "input_predecimation", "off")
+	}
+
+	attrs = append(attrs, "autotune", cfg.SDR.Autotune)
+
+	// Spatial-diversity (MRC) combiner is per soapy_remote endpoint. List the
+	// endpoints that enable it so a multi-radio config is unambiguous.
+	var diversity []string
+	for _, sr := range cfg.SDR.SoapyRemote {
+		mode := strings.ToLower(strings.TrimSpace(sr.Diversity))
+		if mode == "" || mode == "none" {
+			continue
+		}
+		label := strings.TrimSpace(sr.Serial)
+		if label == "" {
+			label = strings.TrimSpace(sr.Addr)
+		}
+		diversity = append(diversity, label+":"+mode)
+	}
+	if len(diversity) > 0 {
+		sort.Strings(diversity)
+		attrs = append(attrs, "diversity", strings.Join(diversity, ","))
+	} else {
+		attrs = append(attrs, "diversity", "off")
+	}
+
+	// Recording / voice audio-shaping enhancements. spec_amplitude_enhance is a
+	// tri-state pointer that defaults ON when unset.
+	attrs = append(attrs,
+		"rec_enhance", cfg.Recordings.Enhance.Enabled,
+		"rec_normalize", cfg.Recordings.Normalize.Enabled,
+		"rec_fm_equalizer", cfg.Recordings.Equalizer.Enabled,
+		"rec_warm_dmr_audio", cfg.Recordings.WarmDMRAudio,
+		"rec_spec_amplitude_enhance",
+		cfg.Recordings.SpecAmplitudeEnhance == nil || *cfg.Recordings.SpecAmplitudeEnhance,
+	)
+
+	return attrs
+}
+
+// systemEnhancements renders the space-separated "key=value" list of decode
+// enhancements relevant to a system's protocol, with each tri-state resolved
+// through its real parser so the reported value is the effective one. Returns
+// "(none)" for protocols with no operator-tunable decode enhancements.
+func systemEnhancements(s trunking.System) string {
+	var parts []string
+	add := func(k, v string) { parts = append(parts, k+"="+v) }
+
+	switch s.Protocol {
+	case trunking.ProtocolP25:
+		demod, _ := p25phase1rx.ParseDemodMode(s.P25Phase1DemodMode)
+		add("demod", demod.String())
+		soft, _ := p25phase1rx.ParseSoftDecision(s.P25Phase1SoftDecision)
+		add("soft_decision", onOff(soft))
+
+	case trunking.ProtocolP25Phase2:
+		soft, _ := p25phase2rx.ParseSoftDecision(s.P25Phase2SoftDecision)
+		add("soft_decision", onOff(soft))
+		eq, _ := p25phase2rx.ParseEqualizer(s.P25Phase2Equalizer)
+		add("cma_equalizer", onOff(eq))
+		dc, _ := p25phase2rx.ParseDCBlock(s.P25Phase2DCBlock)
+		add("dc_block", onOff(dc))
+		clk, _ := p25phase2rx.ParseClockMode(s.P25Phase2ClockMode)
+		add("clock", p25Phase2ClockLabel(clk))
+
+	case trunking.ProtocolTETRA, trunking.ProtocolTETRADMO:
+		cc, _ := tetra.ParseChannelCoding(s.TETRAChannelCoding)
+		add("channel_coding", onOff(cc == tetra.ChannelCodingOn))
+		clk, _ := tetrarx.ParseClockMode(s.TETRAClockMode)
+		add("clock", tetraClockLabel(clk))
+		// The receiver's blind CMA equalizer is always wired on the TETRA
+		// pipeline (it roughly doubles CRC-clean yield on ISI-limited
+		// captures); the trained LMS equalizer is the additional opt-in lever.
+		add("cma_equalizer", "on")
+		lms, _ := tetra.ParseTrafficLMS(s.TETRATrafficLMS)
+		add("traffic_lms", onOff(lms))
+
+	case trunking.ProtocolDMR, trunking.ProtocolDMRTier2, trunking.ProtocolDMRTier1:
+		add("interleaved_voice", onOff(s.DMRInterleavedVoice))
+		if s.DMRColorCode != nil {
+			add("color_code", strconv.Itoa(int(*s.DMRColorCode)))
+		}
+
+	case trunking.ProtocolNXDN:
+		soft, _ := nxdnrx.ParseSoftDecision(s.NXDNSoftDecision)
+		add("soft_decision", onOff(soft))
+		afc, _ := nxdnrx.ParseAFC(s.NXDNAFC)
+		add("afc", onOff(afc))
+	}
+
+	if len(parts) == 0 {
+		return "(none)"
+	}
+	return strings.Join(parts, " ")
+}
+
+func onOff(on bool) string {
+	if on {
+		return "on"
+	}
+	return "off"
+}
+
+func p25Phase2ClockLabel(m p25phase2rx.ClockMode) string {
+	if m == p25phase2rx.ClockGardner {
+		return "gardner"
+	}
+	return "naive"
+}
+
+func tetraClockLabel(m tetrarx.ClockMode) string {
+	if m == tetrarx.ClockGardner {
+		return "gardner"
+	}
+	return "naive"
+}

--- a/cmd/gophertrunk/config_summary_test.go
+++ b/cmd/gophertrunk/config_summary_test.go
@@ -1,0 +1,209 @@
+package main
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/config"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TestLogConfigSummaryEmitsPerSystemLine proves the wiring: logConfigSummary
+// emits the global line plus one "system config" line carrying the effective
+// enhancements string per system.
+func TestLogConfigSummaryEmitsPerSystemLine(t *testing.T) {
+	var buf bytes.Buffer
+	d := &Daemon{
+		log: slog.New(slog.NewTextHandler(&buf, nil)),
+		systems: []trunking.System{
+			{
+				Name: "MetroTETRA", Protocol: trunking.ProtocolTETRA,
+				ControlChannels: []uint32{450_000_000},
+				TETRATrafficLMS: "on",
+			},
+		},
+	}
+	d.cfg.SDR.SampleRate = 2_400_000
+
+	d.logConfigSummary()
+
+	out := buf.String()
+	for _, want := range []string{
+		"daemon: config summary",
+		"daemon: system config",
+		"MetroTETRA",
+		"traffic_lms=on",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("log output missing %q\n---\n%s", want, out)
+		}
+	}
+}
+
+// TestSystemEnhancementsResolvesEffectiveState is the failing-first regression
+// for the startup config summary: the effective on/off it reports must come
+// from the receiver parsers (so "" means the per-protocol DEFAULT), not from
+// testing the raw config string for emptiness. The two TETRA systems below
+// differ only in tetra_traffic_lms — the exact "is LMS on?" question the
+// summary exists to answer — and an empty string must read "off" while the
+// DMR default (interleaved_voice unset ⇒ on for Tier III) must read "on".
+func TestSystemEnhancementsResolvesEffectiveState(t *testing.T) {
+	cc := []uint32{450_000_000}
+
+	tests := []struct {
+		name string
+		sys  trunking.System
+		want []string // substrings that must appear
+		deny []string // substrings that must NOT appear
+	}{
+		{
+			name: "tetra default: lms off, channel_coding + cma on",
+			sys:  trunking.System{Name: "T", Protocol: trunking.ProtocolTETRA, ControlChannels: cc},
+			want: []string{"traffic_lms=off", "channel_coding=on", "cma_equalizer=on", "clock=gardner"},
+		},
+		{
+			name: "tetra with lms on",
+			sys: trunking.System{
+				Name: "T", Protocol: trunking.ProtocolTETRA, ControlChannels: cc,
+				TETRATrafficLMS: "on",
+			},
+			want: []string{"traffic_lms=on"},
+			deny: []string{"traffic_lms=off"},
+		},
+		{
+			name: "tetra-dmo also reports lms",
+			sys: trunking.System{
+				Name: "D", Protocol: trunking.ProtocolTETRADMO, ControlChannels: cc,
+				TETRATrafficLMS: "true",
+			},
+			want: []string{"traffic_lms=on"},
+		},
+		{
+			name: "p25 phase1 default: c4fm, soft off",
+			sys:  trunking.System{Name: "P", Protocol: trunking.ProtocolP25, ControlChannels: cc},
+			want: []string{"demod=c4fm", "soft_decision=off"},
+		},
+		{
+			name: "p25 phase1 cqpsk + soft",
+			sys: trunking.System{
+				Name: "P", Protocol: trunking.ProtocolP25, ControlChannels: cc,
+				P25Phase1DemodMode: "lsm", P25Phase1SoftDecision: "1",
+			},
+			want: []string{"demod=cqpsk", "soft_decision=on"},
+		},
+		{
+			name: "p25 phase2 equalizer + dc block on",
+			sys: trunking.System{
+				Name: "P2", Protocol: trunking.ProtocolP25Phase2, ControlChannels: cc,
+				P25Phase2Equalizer: "cma", P25Phase2DCBlock: "on",
+			},
+			want: []string{"cma_equalizer=on", "dc_block=on", "soft_decision=off", "clock=gardner"},
+		},
+		{
+			name: "dmr tier3 default: interleaved on",
+			sys:  trunking.System{Name: "M", Protocol: trunking.ProtocolDMR, ControlChannels: cc, DMRInterleavedVoice: true},
+			want: []string{"interleaved_voice=on"},
+		},
+		{
+			name: "dmr tier2 with color code pinned",
+			sys: trunking.System{
+				Name: "M2", Protocol: trunking.ProtocolDMRTier2, ControlChannels: cc,
+				DMRInterleavedVoice: false, DMRColorCode: func() *uint8 { v := uint8(7); return &v }(),
+			},
+			want: []string{"interleaved_voice=off", "color_code=7"},
+		},
+		{
+			name: "nxdn afc on, soft default off",
+			sys: trunking.System{
+				Name: "N", Protocol: trunking.ProtocolNXDN, ControlChannels: cc,
+				NXDNAFC: "on",
+			},
+			want: []string{"afc=on", "soft_decision=off"},
+		},
+		{
+			name: "edacs has no tunable decode enhancements",
+			sys:  trunking.System{Name: "E", Protocol: trunking.ProtocolEDACS, ControlChannels: cc},
+			want: []string{"(none)"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := systemEnhancements(tt.sys)
+			for _, w := range tt.want {
+				if !strings.Contains(got, w) {
+					t.Errorf("systemEnhancements() = %q, want substring %q", got, w)
+				}
+			}
+			for _, d := range tt.deny {
+				if strings.Contains(got, d) {
+					t.Errorf("systemEnhancements() = %q, must not contain %q", got, d)
+				}
+			}
+		})
+	}
+}
+
+// TestSummarizeGlobalReportsLevers pins the daemon-wide summary attrs: the
+// pre-decimation factor, autotune, MRC diversity per endpoint, and the
+// recording audio enhancements (including the spec_amplitude_enhance tri-state
+// pointer that defaults ON when unset).
+func TestSummarizeGlobalReportsLevers(t *testing.T) {
+	kv := func(attrs []any) map[string]any {
+		m := map[string]any{}
+		for i := 0; i+1 < len(attrs); i += 2 {
+			k, _ := attrs[i].(string)
+			m[k] = attrs[i+1]
+		}
+		return m
+	}
+
+	t.Run("predecimation engaged + mrc + spec_amp default on", func(t *testing.T) {
+		cfg := config.Config{}
+		cfg.SDR.SampleRate = 2_500_000
+		cfg.SDR.InputSampleRate = 10_000_000
+		cfg.SDR.Autotune = true
+		cfg.SDR.SoapyRemote = []config.SoapyRemoteConfig{
+			{Serial: "x310", Diversity: "mrc"},
+			{Addr: "1.2.3.4:5", Diversity: "none"}, // must be skipped
+		}
+		m := kv(summarizeGlobal(cfg))
+
+		if got := m["predecimation_factor"]; got != uint32(4) {
+			t.Errorf("predecimation_factor = %v, want 4", got)
+		}
+		if got := m["autotune"]; got != true {
+			t.Errorf("autotune = %v, want true", got)
+		}
+		if got, _ := m["diversity"].(string); got != "x310:mrc" {
+			t.Errorf("diversity = %q, want %q", got, "x310:mrc")
+		}
+		// SpecAmplitudeEnhance nil ⇒ defaults ON.
+		if got := m["rec_spec_amplitude_enhance"]; got != true {
+			t.Errorf("rec_spec_amplitude_enhance = %v, want true (default)", got)
+		}
+	})
+
+	t.Run("no predecimation, no diversity, spec_amp forced off", func(t *testing.T) {
+		off := false
+		cfg := config.Config{}
+		cfg.SDR.SampleRate = 2_400_000
+		cfg.Recordings.SpecAmplitudeEnhance = &off
+		m := kv(summarizeGlobal(cfg))
+
+		if got, _ := m["input_predecimation"].(string); got != "off" {
+			t.Errorf("input_predecimation = %q, want %q", got, "off")
+		}
+		if _, ok := m["predecimation_factor"]; ok {
+			t.Errorf("predecimation_factor should be absent when disabled")
+		}
+		if got, _ := m["diversity"].(string); got != "off" {
+			t.Errorf("diversity = %q, want %q", got, "off")
+		}
+		if got := m["rec_spec_amplitude_enhance"]; got != false {
+			t.Errorf("rec_spec_amplitude_enhance = %v, want false", got)
+		}
+	})
+}

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -3084,6 +3084,11 @@ func (d *Daemon) Run(ctx context.Context) error {
 		"systems", len(d.systems),
 		"voice_devices", len(d.voicePool.Devices()),
 	)
+	// Effective decode-configuration snapshot so an operator can confirm at a
+	// glance which enhancements (LMS/CMA equalizers, soft-decision, DC block,
+	// AFC, interleaved voice, …) are actually engaged, instead of guessing from
+	// a config.yaml full of "use the default" empty strings.
+	d.logConfigSummary()
 	// Catch the single-SDR-control-only setup early: trunking systems
 	// declared but no `role: voice` SDR means every grant will drop at
 	// HandleGrant. Warn once at startup so the operator sees it before


### PR DESCRIPTION
Operators can't tell from config.yaml whether a decode enhancement is
actually engaged: most per-system levers (tetra_traffic_lms, the P25
Phase 2 CMA equalizer, soft-decision, dc_block, nxdn_afc, dmr
interleaved voice, the P25 demod/clock modes, ...) are string tri-states
where "" means "use the per-protocol default", so an empty value is
indistinguishable from off vs on. There was no single place that reported
the resolved state.

Add a one-time startup summary logged in Daemon.Run right after the
"gophertrunk starting" line: a global "daemon: config summary" line
(sample_rate, input pre-decimation factor, autotune, MRC diversity per
endpoint, recording audio-shaping levers) plus one "daemon: system
config" line per system listing the enhancements relevant to that
protocol. Each tri-state is resolved through the SAME parser the decode
pipeline uses (tetra.ParseTrafficLMS, p25phase2rx.ParseEqualizer,
resolveDMRInterleavedVoice, ...) rather than testing the raw string for
emptiness, so the reported on/off/mode matches how the receiver was
actually built, including defaults.

Pinned by config_summary_test.go: effective-state resolution per
protocol (the "is LMS on?" case where "" reads off and the DMR
interleaved default reads on), the global lever attrs, and the Run-time
wiring that emits a per-system line.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011EFgfGZF38PjZRAfu1HrFU