### PR TITLE
docs: fill Field Guide gaps from the TETRA/DSP/diversity work (17 new entries)

### DIFF
--- a/docs/_data/reference.yml
+++ b/docs/_data/reference.yml
@@ -96,6 +96,7 @@ domains:
           - { slug: receiver-sensitivity, title: Receiver sensitivity (MDS), type: term }
           - { slug: desensitization, title: Desensitization, type: term }
           - { slug: blocking-dynamic-range, title: Blocking, type: term }
+          - { slug: reciprocal-mixing, title: Reciprocal mixing, type: term }
           - { slug: bit-error-rate, title: Bit error rate (BER), type: term }
           - { slug: eb-n0, title: Eb/N0, type: term }
           - { slug: error-vector-magnitude, title: Error vector magnitude (EVM), type: term }
@@ -300,6 +301,7 @@ domains:
           - { slug: polyphase-filter-bank, title: Polyphase filter bank, type: algorithm }
           - { slug: channelizer, title: Channelizer, type: algorithm }
           - { slug: resampler, title: Resampler, type: algorithm }
+          - { slug: fractional-delay-filter, title: Fractional-delay filter, type: algorithm }
 
       - id: synchronization
         label: Synchronization, carrier & timing
@@ -329,6 +331,8 @@ domains:
           - { slug: lms-algorithm, title: Least mean squares (LMS), type: algorithm }
           - { slug: rls-algorithm, title: Recursive least squares (RLS), type: algorithm }
           - { slug: cma-equalizer, title: CMA equalizer, type: algorithm }
+          - { slug: fractionally-spaced-equalizer, title: Fractionally-spaced equalizer (FSE), type: algorithm }
+          - { slug: snapshot-equalization, title: Snapshot equalization, type: algorithm }
           - { slug: zero-forcing-equalizer, title: Zero-forcing equalizer, type: algorithm }
           - { slug: mmse-equalizer, title: MMSE equalizer, type: algorithm }
           - { slug: decision-feedback-equalizer, title: Decision-feedback equalizer (DFE), type: algorithm }
@@ -413,9 +417,13 @@ domains:
         blurb: The algorithms that track parameters, decide whether a signal is present, and locate emitters in space.
         entries:
           - { slug: kalman-filter, title: Kalman filter, type: algorithm }
+          - { slug: channel-estimation, title: Channel estimation, type: term }
+          - { slug: coherence, title: Coherence (normalized cross-correlation), type: term }
           - { slug: energy-detection, title: Energy detection, type: algorithm }
           - { slug: cfar-detection, title: CFAR detection, type: algorithm }
           - { slug: beamforming, title: Beamforming, type: algorithm }
+          - { slug: maximal-ratio-combining, title: Maximal-ratio combining (MRC), type: algorithm }
+          - { slug: interference-rejection-combining, title: Interference rejection combining (IRC), type: algorithm }
           - { slug: music-algorithm, title: MUSIC algorithm, type: algorithm }
           - { slug: esprit-algorithm, title: ESPRIT algorithm, type: algorithm }
           - { slug: multilateration, title: Multilateration (MLAT), type: algorithm }
@@ -550,6 +558,8 @@ domains:
           - { slug: tetra-llc, title: TETRA LLC, type: term }
           - { slug: tetra-logical-channels, title: TETRA logical channels, type: term }
           - { slug: tetra-mac-pdu, title: TETRA MAC PDU, type: term }
+          - { slug: tetra-mobile-network-identity, title: TETRA mobile network identity (MNI), type: term }
+          - { slug: tetra-sync-pdu, title: TETRA SYNC PDU, type: term }
           - { slug: tetra-traffic-slot-mapping, title: TETRA traffic slot mapping, type: term }
 
       - id: land-mobile-trunking
@@ -1073,10 +1083,12 @@ domains:
           - { slug: sigmf, title: SigMF (Signal Metadata Format), type: technology }
           - { slug: iq-file-format, title: IQ file format, type: term }
           - { slug: cfile-format, title: cfile format, type: term }
+          - { slug: cs16-format, title: cs16 format, type: term }
           - { slug: wav-iq-recording, title: WAV IQ recording, type: term }
           - { slug: vita-49, title: VITA 49 (VRT), type: technology }
           - { slug: spyserver-protocol, title: SpyServer protocol, type: technology }
           - { slug: soapyremote, title: SoapyRemote, type: technology }
+          - { slug: ka9q-radio, title: ka9q-radio, type: technology }
           - { slug: network-iq-streaming, title: Network IQ streaming, type: concept }
           - { slug: iq-recording-playback, title: IQ recording & playback, type: concept }
           - { slug: zeromq-sdr, title: ZeroMQ for SDR, type: technology }
@@ -1273,6 +1285,7 @@ domains:
           - { slug: end-to-end-testing, title: End-to-end testing, type: concept }
           - { slug: test-driven-development, title: Test-driven development (TDD), type: concept }
           - { slug: mocking, title: Mocking, type: concept }
+          - { slug: self-consistent-test-trap, title: Self-consistent test trap, type: concept }
           - { slug: code-coverage, title: Code coverage, type: concept }
           - { slug: ci-cd, title: CI/CD, type: concept }
           - { slug: build-systems, title: Build systems, type: concept }
@@ -1565,6 +1578,9 @@ domains:
           - { slug: signal-signatures, title: Signal-quality signatures, type: term }
           - { slug: audio-pipeline-tells, title: Audio-pipeline tells, type: term }
           - { slug: carrier-offset-adjacent-lock, title: Carrier offset & adjacent-channel lock, type: term }
+          - { slug: afc-alias-traps, title: AFC alias traps, type: term }
+          - { slug: equalizer-gotchas, title: Equalizer gotchas, type: term }
+          - { slug: mrc-diversity-gotchas, title: MRC diversity gotchas, type: term }
       - id: fn-protocol
         label: Protocol facts the specs hide
         blurb: On-air realities that standards documents omit, bury, or state ambiguously — validated the hard way against real captures.
@@ -1573,3 +1589,4 @@ domains:
           - { slug: p25-onair-constants, title: P25 on-air constants, type: term }
           - { slug: dmr-grant-field-gotchas, title: DMR grant-field gotchas, type: term }
           - { slug: tetra-lock-facts, title: TETRA lock facts, type: term }
+          - { slug: tetra-dmo-facts, title: TETRA DMO facts, type: term }

--- a/docs/reference/afc-alias-traps.md
+++ b/docs/reference/afc-alias-traps.md
@@ -1,0 +1,90 @@
+---
+slug: afc-alias-traps
+title: AFC alias traps
+entry_type: term
+category: fn-diagnostics
+description: "AFC alias traps are the ways a frequency estimator's alias structure silently breaks a lock: a wrong alias bucket that rejects every correct estimate, a transient that re-primes an established track, and a WARN that fires on one bad sample."
+keywords: AFC, automatic frequency control, alias bucket, fourth-power estimator, re-prime, locked but deaf, payload heartbeat, resync, carrier offset warn, frequency spike, TETRA AFC
+aka: [AFC alias bucket traps, frequency estimator aliasing]
+infobox:
+  - { label: Type, value: DSP + diagnostics facts }
+  - { label: Key rule, value: "A 4th-power estimator is only unambiguous within ±f_sym/8" }
+  - { label: Signature, value: "Sync ~100%, payload 0% — locked but deaf" }
+  - { label: Tell, value: "A reported offset error that is an exact multiple of f_sym/4" }
+see_also: [automatic-frequency-control, tetra-lock-facts, carrier-offset-adjacent-lock, frequency-locked-loop, signal-signatures, pi-4-dqpsk]
+related_reading:
+  - { title: "From the Issue Tracker, Part 18: The Stall That Wasn't", url: /blog/solution-postmortem/from-the-issue-tracker-18-the-stall-that-wasnt/ }
+cite_urls:
+  - https://github.com/MattCheramie/GopherTrunk/issues/815
+  - https://github.com/MattCheramie/GopherTrunk/issues/940
+---
+
+**AFC alias traps** are the failure modes that follow from one structural fact of
+[automatic frequency control](/reference/automatic-frequency-control/) on PSK signals: the
+fine estimator is only unambiguous within a fraction of the symbol rate, so every estimate
+it produces is really "the true offset, modulo an alias spacing". For
+[π/4-DQPSK](/reference/pi-4-dqpsk/), raising the per-symbol differential phase to the 4th
+power collapses the data — but wraps at 2π, leaving the offset recoverable only within
+±f_sym/8 (±2,250 Hz at TETRA's 18,000 sym/s) and aliased in steps of f_sym/4 (4,500 Hz).
+Everything below is a consequence of what happens when the tracking loop lands in the wrong
+alias bucket — and each mode carries a distinct signature GopherTrunk now checks for.
+
+## The wrong-bucket latch: "locked but deaf"
+
+An EMA-tracked AFC guards itself by rejecting per-block estimates far from its current
+track. That guard is also a trap: if the track is ever primed from one bad block — say, a
+decode-drought resync re-seeding from a weak burst — the loop latches a bucket ±4,500 Hz
+off and then *rejects every correct estimate forever*, because they all disagree with the
+track by exactly the alias spacing. The cruel part is what stays working: TETRA's BSCH
+survives the resulting ~17°/symbol residual (its sync burst gets per-burst frequency
+correction and heavy FEC), while every SCH payload fails. The signature is unmistakable
+once named: **`bsch_ok` ~100%, `sch_pdus` = 0** — a receiver that is provably synchronised
+and decodes nothing. One field log showed 37 minutes of this across a 10.5-hour session,
+unrecoverable because every decoded BSCH stamped the only activity heartbeat that both
+resync mechanisms fed on.
+
+Two fixes, both required: a clustered-reject escape (three consecutive rejected estimates
+that *agree with each other* re-prime the track) and an independent **payload heartbeat** —
+a liveness timestamp stamped only by CRC-clean *payload* decodes, driving a forced resync
+after 12 s of signal with a live lock and no payload, escalating to a full re-hunt after
+three fruitless resyncs. Sync proving itself is not evidence the receiver works; only
+payload is.
+
+## The transient re-prime: the same signature, younger
+
+The clustered-reject escape created its own trap. Any transient bias larger than the
+unambiguous range — a neighbouring carrier's skirts leaking through the channel-filter edge
+while the wanted signal fades — lands the raw estimate exactly one alias bucket off, and
+three such blocks (~170 ms) tripped the escape, slamming a long-corroborated track into the
+wrong bucket. An operator filmed the mixer panel's carrier readout spiking to ~−5,004 Hz on
+a carrier really ~500 Hz off: **5,004 = 504 + 4,500** — the reported "spike" was the alias
+spacing itself, the tell that this is an estimator artifact and not a carrier move. The
+resolution distinguishes track *age*: a fresh track keeps the fast 3-block escape (a wrong
+seed must be escapable quickly), while an established track (≥16 accepted blocks) demands
+an 18-block (~1 s) streak before an alias-class cluster may re-prime it. A wrongly-held
+transient self-heals; a wrongly-accepted one costs minutes.
+
+## One bad sample is not a condition
+
+The companion diagnostic trap: a wrong-site WARN that fired whenever a single per-chunk
+offset sample crossed a threshold, so every sub-second estimator blip produced a scary
+"carrier offset 5 kHz — check your site" report. A warning that diagnoses a *persistent*
+condition must observe persistence: the offset now has to sit over threshold continuously
+for 10 s, with the excursion clock reset on dips. The general rule travels well beyond AFC:
+alarm on integrated evidence, never on one sample of a noisy estimator.
+
+## Symptom table
+
+| Symptom | Looks like | Actually | Fix / check |
+|---|---|---|---|
+| Sync ~100%, payload 0%, forever | Encryption, dead channel | AFC latched a wrong alias bucket; correct estimates rejected | Clustered-reject re-prime + payload heartbeat ([#940](https://github.com/MattCheramie/GopherTrunk/issues/940)) |
+| Reported offset error ≈ n × f_sym/4 | Oscillator jump | Alias-class estimator artifact | Recognise the spacing; check track age before re-priming |
+| Carrier readout spikes ~±4.5 kHz then recovers | RF instability | Transient coarse bias through the filter edge | Established-track hold (~1 s streak) before re-prime ([#815](https://github.com/MattCheramie/GopherTrunk/issues/815)) |
+| Wrong-site WARNs during normal operation | Neighbour interference | Threshold on one instantaneous sample | Require 10 s persistence before warning |
+| Resyncs fire but never help | CPU starvation | Resyncs re-seed from the same wrong regime | Escalate to full re-hunt after N fruitless resyncs |
+
+## Provenance
+
+- [#940](https://github.com/MattCheramie/GopherTrunk/issues/940) — the 4th-power estimator's ±2,250 Hz ambiguity, the coarse-acquisition stage, and the pre-matched-filter rule (see also [TETRA lock facts](/reference/tetra-lock-facts/)).
+- [#815](https://github.com/MattCheramie/GopherTrunk/issues/815) — the carrier-offset WARN and its false triggers; the −5,004 Hz alias spike diagnosis.
+- 19 Aug field log — the 37-minute "locked but deaf" stretches, the payload heartbeat, and the track-age re-prime rules, each pinned by a failing-first regression.

--- a/docs/reference/antenna-diversity.md
+++ b/docs/reference/antenna-diversity.md
@@ -11,7 +11,7 @@ infobox:
   - { label: Type, value: Multi-antenna technique }
   - { label: Combats, value: Multipath / fading dropouts }
   - { label: Methods, value: Selection, switched, EGC, MRC }
-see_also: [mimo, multipath-propagation, rayleigh-fading, rician-fading, beamforming, antenna-gain]
+see_also: [mimo, maximal-ratio-combining, interference-rejection-combining, coherence, multipath-propagation, rayleigh-fading, rician-fading, beamforming, antenna-gain]
 cite_urls:
   - https://en.wikipedia.org/wiki/Antenna_diversity
   - https://en.wikipedia.org/wiki/Diversity_combining
@@ -109,9 +109,13 @@ foundation that [MIMO](/reference/mimo/) generalizes into spatial multiplexing. 
 radio, base-station **voting** receivers are a form of selection diversity across geographically
 separate sites. For an SDR listener, diversity requires multiple coherent (or at least
 independently sampled) front ends; a phase-coherent array such as KrakenSDR can implement MRC in
-software. GopherTrunk is a single-stream decoder — it processes one [I/Q](/reference/iq-data/)
-capture at a time and does not combine multiple antennas — so diversity is relevant to the
-broader RF context and to hardware choices rather than something GT itself performs.
+software. GopherTrunk performs receive diversity itself on dual-channel SoapyRemote devices
+(an X310 with two daughterboards, a B210): `diversity: mrc` opens both RX channels and
+combines them with software
+[maximal-ratio combining](/reference/maximal-ratio-combining/), calibrated from measured
+inter-branch [coherence](/reference/coherence/) rather than signal level. The field lessons
+that came with making that work on real hardware are collected in
+[MRC diversity gotchas](/reference/mrc-diversity-gotchas/).
 
 ## Sources
 

--- a/docs/reference/automatic-frequency-control.md
+++ b/docs/reference/automatic-frequency-control.md
@@ -11,7 +11,7 @@ infobox:
   - { label: Type, value: Frequency-tracking loop }
   - { label: Corrects, value: Residual carrier offset (dynamic) }
   - { label: Symptom it removes, value: Rotating constellation }
-see_also: [ppm-frequency-correction, costas-loop, demodulation, constellation-diagram, frequency-locked-loop, frequency-stability, phase-noise]
+see_also: [ppm-frequency-correction, costas-loop, demodulation, constellation-diagram, frequency-locked-loop, frequency-stability, phase-noise, afc-alias-traps]
 related_lessons:
   - { title: "Tuning for a clean lock", url: /learn/rf-sdr/tuning-with-scopes/ }
 cite_urls:

--- a/docs/reference/cfile-format.md
+++ b/docs/reference/cfile-format.md
@@ -11,7 +11,7 @@ infobox:
   - { label: Type, value: Raw IQ recording (headerless) }
   - { label: Sample, value: "2× little-endian float32 (I,Q) = 8 bytes" }
   - { label: Origin, value: GNU Radio file sink }
-see_also: [iq-file-format, sample-format, file-source-sink, sigmf, interleaved-iq, iq-recording-playback]
+see_also: [iq-file-format, cs16-format, sample-format, file-source-sink, sigmf, interleaved-iq, iq-recording-playback]
 cite_urls:
   - https://wiki.gnuradio.org/index.php/File_Sink
   - https://en.wikipedia.org/wiki/GNU_Radio

--- a/docs/reference/channel-estimation.md
+++ b/docs/reference/channel-estimation.md
@@ -1,0 +1,102 @@
+---
+slug: channel-estimation
+title: Channel estimation
+entry_type: term
+category: estimation-array
+description: Channel estimation measures the complex gain, phase, and delay a radio channel applies to a signal — from known training symbols or blindly from statistics — so a receiver can invert or exploit the channel.
+keywords: channel estimation, channel estimate, least squares, pilot symbols, training sequence, midamble, channel state information, CSI, blind estimation, equalizer training
+aka: [channel estimate, CSI estimation]
+autolink: true
+infobox:
+  - { label: Type, value: Receiver estimation step }
+  - { label: Estimates, value: Complex channel gain(s) h }
+  - { label: From, value: Training symbols, pilots, or signal statistics }
+  - { label: Feeds, value: Equalizers, MRC, IRC, coherent demod }
+see_also: [tetra-training-sequences, adaptive-filter, lms-algorithm, maximal-ratio-combining, interference-rejection-combining, mmse-equalizer, coherence]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Channel_state_information
+  - https://en.wikipedia.org/wiki/Least_squares
+---
+
+**Channel estimation** is the receiver's measurement of what the radio channel did to the
+signal — the complex gain, phase rotation, delay spread, or full impulse response between
+transmitter and receiver — so that later stages can undo it or exploit it.[^wiki] Almost
+every coherent technique stands on a channel estimate: an
+[equalizer](/reference/adaptive-filter/) needs one to invert
+[ISI](/reference/intersymbol-interference/),
+[maximal-ratio combining](/reference/maximal-ratio-combining/) needs one per branch to
+co-phase and weight, and
+[interference rejection combining](/reference/interference-rejection-combining/) needs one
+just to define what the interference *is*.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="A transmitted burst containing known training symbols passes through an unknown channel; the receiver compares the received training region against the known symbols to solve for the channel estimate h." xmlns="http://www.w3.org/2000/svg">
+  <rect x="20" y="46" width="150" height="26" rx="4" fill="none" stroke="currentColor" stroke-width="1.3"/>
+  <rect x="72" y="46" width="44" height="26" fill="currentColor" fill-opacity="0.2"/>
+  <text x="94" y="63" font-size="8" fill="currentColor" text-anchor="middle">known</text>
+  <text x="95" y="88" font-size="8.5" fill="currentColor" text-anchor="middle">burst with training symbols</text>
+  <line x1="175" y1="59" x2="225" y2="59" stroke="currentColor" stroke-width="1.2" marker-end="url(#cear)"/>
+  <rect x="228" y="42" width="66" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.3" stroke-dasharray="4 3"/>
+  <text x="261" y="63" font-size="9" fill="currentColor" text-anchor="middle">channel h?</text>
+  <line x1="297" y1="59" x2="347" y2="59" stroke="currentColor" stroke-width="1.2" marker-end="url(#cear)"/>
+  <rect x="350" y="42" width="90" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/>
+  <text x="395" y="58" font-size="8.5" fill="currentColor" text-anchor="middle">solve h from</text>
+  <text x="395" y="70" font-size="8.5" fill="currentColor" text-anchor="middle">received vs known</text>
+  <defs><marker id="cear" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Because the receiver knows what the training region should have been, the difference between sent and received solves directly for the channel.</figcaption>
+</figure>
+
+## How it works
+
+The workhorse is **least squares against known symbols**. If the receiver knows the
+transmitted training block `s` and observes `x = h·s + n`, the LS estimate is
+`ĥ = Σ x·conj(s) / Σ |s|²` — a correlation against the known pattern, normalised. Its
+accuracy improves with training length N (the estimate's phase error shrinks roughly as
+`1/√(SNR·N)`), which is the quantitative reason standards spend airtime on pilots: GSM and
+[TETRA](/reference/tetra/) put a known midamble
+([training sequence](/reference/tetra-training-sequences/)) in the middle of every burst,
+OFDM systems scatter pilot subcarriers across the grid, and P25/DMR receivers can treat
+their [frame sync words](/reference/frame-synchronization/) as free training. An **MMSE**
+refinement folds in noise statistics; interpolation extends pilot estimates across time and
+frequency as the channel changes.
+
+When no training exists, **blind estimation** falls back on statistics — the constant
+modulus of a PSK constellation (as the [CMA equalizer](/reference/cma-equalizer/) does),
+cyclostationarity, or cross-correlation between diversity branches. Blind estimates are
+cheaper in airtime but structurally weaker: they converge slower, leave ambiguities a
+statistic cannot see (a blind estimate cannot recover absolute phase), and — critically —
+they are **contaminated by interference**, because a correlation cannot tell the wanted
+signal from a co-channel one and returns a power-weighted blend of both channels. That
+single limitation is why blind IRC fails while trained IRC works.
+
+## In practice
+
+Three habits separate estimates that hold up from ones that mislead:
+
+- **Remove DC before correlating.** Two receiver branches share LO leakage; an uncentred
+  cross-correlation on independent noise plus a common DC term reports near-perfect
+  [coherence](/reference/coherence/) and "estimates" the ratio of the DC offsets —
+  confidently measuring nothing.
+- **Gate on the estimate's own error, not on signal level.** The projected phase error
+  `√((1−ρ²)/(2Nρ²))` from measured coherence ρ and window length N says whether an estimate
+  is trustworthy, independent of gain staging or bandwidth.
+- **Track when the channel moves.** A one-shot estimate is only right while the hardware
+  holds still; independent PLLs, tuner retunes, and fading all demand re-estimation with
+  smoothing.
+
+## Relevance to SDR
+
+In GopherTrunk the same LS machinery appears at two scales. Per diversity *branch*, the
+SoapyRemote MRC combiner estimates one complex gain per ~2 ms window against a reference
+branch (`internal/dsp/diversity/tracking.go`), coherence-gated and smoothed — a wideband,
+frequency-flat channel estimate. Per *burst*, the TETRA traffic extractor trains a short
+FIR channel inverse on the burst's known midamble
+([snapshot equalization](/reference/snapshot-equalization/) via `SnapshotLMS`), a
+frequency-selective estimate valid for one burst. Both illustrate the same trade: training
+symbols buy an estimate that interference and noise cannot silently corrupt, and where no
+training exists, every downstream conclusion inherits the blind estimate's blind spots.
+
+## Sources
+
+[^wiki]: [Channel state information](https://en.wikipedia.org/wiki/Channel_state_information) — Wikipedia, on estimating channel properties from training-based and blind methods and their use in coherent receivers.

--- a/docs/reference/cma-equalizer.md
+++ b/docs/reference/cma-equalizer.md
@@ -11,7 +11,7 @@ infobox:
   - { label: Type, value: Blind adaptive equalizer }
   - { label: Counteracts, value: Multipath / intersymbol interference }
   - { label: Blind, value: No training sequence required }
-see_also: [adaptive-filter, lms-algorithm, decision-feedback-equalizer, costas-loop, multipath-propagation, constellation-diagram]
+see_also: [adaptive-filter, lms-algorithm, decision-feedback-equalizer, snapshot-equalization, fractionally-spaced-equalizer, costas-loop, multipath-propagation, constellation-diagram]
 related_lessons:
   - { title: "Tuning for a clean lock", url: /learn/rf-sdr/tuning-with-scopes/ }
 related_reading:
@@ -89,12 +89,16 @@ phase tracker is run alongside to de-rotate the now-open eye.
 ## Relevance to SDR
 
 Blind equalisation matters in reflective urban and mobile channels — land-mobile trunking
-(P25, DMR, NXDN), broadcast, and microwave links — where echoes smear symbols into
+(P25, DMR, NXDN, TETRA), broadcast, and microwave links — where echoes smear symbols into
 neighbours. Many of these waveforms are constant-envelope or near-constant-modulus, making
-them natural CMA candidates. GopherTrunk targets narrowband C4FM/PSK signals whose symbol
-rates keep intersymbol interference modest, so its decode chain leans on matched filtering
-and timing/carrier recovery rather than a full adaptive equaliser; CMA is the technique you
-would reach for if multipath in a given deployment became severe enough to close the eye.
+them natural CMA candidates. GopherTrunk ships blind CMA in two places: its TETRA receiver
+paths run `SnapshotCMA` — CMA applied as frozen per-burst snapshots so it stays safe ahead
+of the [differential decoder](/reference/differential-decoding/) (see
+[snapshot equalization](/reference/snapshot-equalization/)) — which roughly doubled
+CRC-valid voice frames on marginal captures; and the P25 CQPSK/LSM path runs a T/2 CMA
+[fractionally-spaced equalizer](/reference/fractionally-spaced-equalizer/). The
+C4FM-family decoders, whose symbol rates keep intersymbol interference modest, still lean
+on matched filtering and timing/carrier recovery alone.
 
 ## Sources
 

--- a/docs/reference/coherence.md
+++ b/docs/reference/coherence.md
@@ -1,0 +1,102 @@
+---
+slug: coherence
+title: Coherence (normalized cross-correlation)
+entry_type: term
+category: estimation-array
+description: "Coherence is the normalized cross-correlation between two signals — a scale-invariant 0-to-1 measure of how much of them is the same underlying signal, readable directly as a per-branch SNR."
+keywords: coherence, normalized cross-correlation, correlation coefficient, rho, diversity branches, phase alignment, common signal, SNR estimate, DC offset, bandwidth dilution
+aka: [normalized cross-correlation, complex correlation coefficient]
+infobox:
+  - { label: Type, value: Similarity statistic }
+  - { label: Range, value: "0 (unrelated) to 1 (identical up to gain)" }
+  - { label: SNR reading, value: "|ρ| = γ/(1+γ) for equal branch SNR γ" }
+  - { label: Noise-only floor, value: "≈ √(π/4N) for N samples" }
+see_also: [signal-to-noise-ratio, maximal-ratio-combining, channel-estimation, preamble-correlation, dc-offset, dbfs]
+related_reading:
+  - { title: "The Analog Edge, Part 13: Coherence, Not dBFS", url: /blog/tutorials/analog-edge-13-coherence-not-dbfs/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Pearson_correlation_coefficient
+  - https://en.wikipedia.org/wiki/Coherence_(signal_processing)
+---
+
+**Coherence** — the magnitude of the **normalized cross-correlation** between two complex
+signals — measures how much of them is the *same underlying signal*, on a scale from 0
+(statistically unrelated) to 1 (identical up to a complex gain), independent of how loud
+either one is.[^wiki] For two diversity branches it is computed as
+
+`|ρ| = |Σ x₁·conj(x₀)| / √(Σ|x₀|² · Σ|x₁|²)`
+
+— the cross-power between the branches, normalised by each branch's own power. That
+normalisation is the point: gain, attenuation, and front-end scaling all cancel, so ρ
+answers "do these two streams carry one signal?" where an absolute level in
+[dBFS](/reference/dbfs/) can only answer "is this stream loud?".
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="A curve of coherence versus per-branch SNR rising from zero through 0.5 at 0 dB toward 1, with the noise-only floor marked near zero coherence." xmlns="http://www.w3.org/2000/svg">
+  <line x1="50" y1="112" x2="430" y2="112" stroke="currentColor" stroke-opacity="0.4"/>
+  <line x1="50" y1="112" x2="50" y2="20" stroke="currentColor" stroke-opacity="0.4"/>
+  <path d="M50 106 C 130 104 170 92 240 66 C 300 44 370 32 430 28" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <line x1="240" y1="66" x2="240" y2="112" stroke="currentColor" stroke-opacity="0.35" stroke-dasharray="3 3"/>
+  <line x1="50" y1="66" x2="240" y2="66" stroke="currentColor" stroke-opacity="0.35" stroke-dasharray="3 3"/>
+  <text x="44" y="69" font-size="8" fill="currentColor" text-anchor="end">0.5</text>
+  <text x="240" y="124" font-size="8" fill="currentColor" text-anchor="middle">0 dB</text>
+  <text x="44" y="30" font-size="8" fill="currentColor" text-anchor="end">1.0</text>
+  <text x="60" y="100" font-size="7.5" fill="currentColor">noise floor √(π/4N)</text>
+  <text x="240" y="136" font-size="8.5" fill="currentColor" text-anchor="middle">per-branch SNR γ →</text>
+  <text x="30" y="70" font-size="8.5" fill="currentColor" text-anchor="middle" transform="rotate(-90 30 70)">|ρ|</text>
+</svg>
+<figcaption>|ρ| = γ/(1+γ): coherence 0.5 means each branch sits at 0 dB SNR, and the noise-only floor √(π/4N) is where N samples of pure independent noise land by chance.</figcaption>
+</figure>
+
+## Reading the number
+
+Three anchor facts turn ρ from an abstract statistic into an instrument:
+
+- **It is an SNR meter.** For two branches carrying one signal at equal per-branch SNR γ,
+  `|ρ| = γ/(1+γ)`: coherence 0.50 means 0 dB per branch, 0.35 means about −2.7 dB. A
+  threshold on ρ is therefore a threshold on
+  [signal-to-noise ratio](/reference/signal-to-noise-ratio/), stated in a form no gain knob
+  can game.
+- **It has a chance floor.** N samples of *independent* noise produce `|ρ| ≈ √(π/4N)` just
+  from finite averaging — about 0.014 for N = 4096. A measured ρ is meaningful only well
+  above that floor, and the floor falls as 1/√N, so longer windows buy resolution.
+- **It carries an error bar.** The phase of ρ estimates the inter-branch phase, with a
+  standard error of roughly `√((1−ρ²)/(2Nρ²))` — small-looking coherence over a long window
+  can still pin phase to a few degrees, which is why gates on the *projected error* behave
+  where fixed ρ thresholds do not.
+
+## Two traps
+
+**DC offsets fake coherence.** Both receivers of one front end share
+[LO leakage](/reference/dc-offset/), and a common DC term correlates perfectly with itself:
+an uncentred correlator fed two branches of independent noise plus common DC reports
+`|ρ| → 1` and returns the ratio of the DC offsets as a "channel estimate" — in exactly the
+weak-signal regime where the number matters most. Subtract each branch's mean before
+correlating; in a correlator this is load-bearing, not hygiene.
+
+**Bandwidth dilutes wideband coherence.** Only the hertz actually carrying the common
+signal contribute cross-power, so for in-channel power fractions f₀, f₁ of each branch,
+`ρ_wb ≈ ρ_ch·√(f₀·f₁)`. A perfectly coherent narrowband carrier inside a wide noisy capture
+can legitimately measure ρ ≈ 0.16 wideband — and a fixed 0.5 threshold then silently makes
+"coherent enough" depend on the configured capture bandwidth and each branch's noise floor.
+Compare coherence measured before and after the
+[DDC](/reference/digital-down-converter/) to separate "the branches disagree" from "the
+bandwidth is diluting".
+
+## Relevance to SDR
+
+GopherTrunk's diversity combiner is built on this statistic
+(`internal/dsp/diversity/crossstats.go`): [MRC](/reference/maximal-ratio-combining/)
+calibration is gated on the phase error projected from ρ rather than on any absolute level,
+after an absolute −40 dBFS gate proved to be a gain-staging trap — an operator once raised
+front-end gain 65 → 82 dB purely to push a number past a software constant. The same
+statistic diagnoses hardware: per-frequency coherence near 1 with diluted broadband ρ is the
+signature of a pure inter-branch delay (fixed by a
+[fractional-delay filter](/reference/fractional-delay-filter/), not a gain), and a coherence
+that no tracking improves marks the wideband-scalar limit of single-gain combining. The
+operator-facing symptoms are catalogued in
+[MRC diversity gotchas](/reference/mrc-diversity-gotchas/).
+
+## Sources
+
+[^wiki]: [Pearson correlation coefficient](https://en.wikipedia.org/wiki/Pearson_correlation_coefficient) — Wikipedia, on the normalised correlation statistic, its scale invariance, and its sampling behaviour.

--- a/docs/reference/cs16-format.md
+++ b/docs/reference/cs16-format.md
@@ -1,0 +1,82 @@
+---
+slug: cs16-format
+title: cs16 format
+entry_type: term
+category: sdr-data-streaming
+description: "cs16 is a raw IQ recording and streaming format: headerless interleaved little-endian 16-bit signed I,Q pairs — half the size of float32 cfiles, and the native sample format of many SDR front ends."
+keywords: cs16, sc16, int16 IQ, interleaved IQ, raw IQ capture, complex short, SDR recording format, SoapySDR CS16, gophertrunk replay, 16-bit samples
+aka: [cs16, sc16, complex int16, ci16]
+autolink: true
+infobox:
+  - { label: Type, value: Raw IQ recording (headerless) }
+  - { label: Sample, value: "2× little-endian int16 (I,Q) = 4 bytes" }
+  - { label: Full scale, value: "±32767 → 0 dBFS" }
+  - { label: Metadata, value: "None — rate and frequency travel separately" }
+see_also: [cfile-format, iq-data, iq-file-format, sigmf, wav-iq-recording, dbfs]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Raw_image_format
+  - https://github.com/pothosware/SoapySDR/wiki
+---
+
+**cs16** ("complex signed 16-bit", also written **sc16**) is a raw
+[IQ](/reference/iq-data/) format: an interleaved stream of little-endian 16-bit signed
+integers, `I₀ Q₀ I₁ Q₁ …`, with no header, no metadata, and nothing else in the
+file.[^soapy] One complex sample costs 4 bytes — half the size of the float32
+[cfile](/reference/cfile-format/) — and because 12–16-bit
+[ADCs](/reference/analog-to-digital-converter/) produce integer samples natively, cs16 is
+often a bit-exact record of what the hardware delivered rather than a converted copy.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 110" role="img" aria-label="A byte stream divided into repeating four-byte groups, each holding a little-endian 16-bit I value then a 16-bit Q value, with no header before the first sample." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" stroke-width="1.2" fill="none">
+    <rect x="24" y="40" width="52" height="28"/><rect x="76" y="40" width="52" height="28"/>
+    <rect x="132" y="40" width="52" height="28"/><rect x="184" y="40" width="52" height="28"/>
+    <rect x="240" y="40" width="52" height="28"/><rect x="292" y="40" width="52" height="28"/>
+  </g>
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <text x="50" y="58">I₀</text><text x="102" y="58">Q₀</text><text x="158" y="58">I₁</text><text x="210" y="58">Q₁</text><text x="266" y="58">I₂</text><text x="318" y="58">Q₂</text>
+  </g>
+  <text x="352" y="58" font-size="10" fill="currentColor">…</text>
+  <text x="24" y="32" font-size="8" fill="currentColor">byte 0 — no header</text>
+  <text x="184" y="86" font-size="8.5" fill="currentColor" text-anchor="middle">each box = one little-endian int16 (2 bytes); one complex sample = 4 bytes</text>
+</svg>
+<figcaption>File offset zero is already sample data: everything you need to know about the capture — rate, centre frequency, scaling — has to travel alongside the file.</figcaption>
+</figure>
+
+## Conventions
+
+- **Scaling.** Full scale is ±32767, which maps to 0 [dBFS](/reference/dbfs/); consumers
+  typically divide by 32768 to get ±1.0 floats. A capture's peak level in dBFS is
+  meaningful and portable — one reason integer captures are convenient evidence when
+  overload or gain staging is in question.
+- **Endianness and order.** Little-endian, I before Q, is the near-universal convention
+  (matching SoapySDR's `CS16` stream format and USRP `sc16` wire format), but nothing in
+  the file enforces it — a byte-swapped or IQ-swapped read produces plausible-looking
+  garbage, so trust but verify with a spectrum sanity check.
+- **No metadata.** Sample rate and centre frequency must be carried in a sidecar file, the
+  filename, or a note. [SigMF](/reference/sigmf/) exists precisely to formalise this; a
+  bare `.cs16`/`.raw` file depends on discipline.
+
+Against its neighbours: a [cfile](/reference/cfile-format/) (float32) spends twice the
+bytes to preserve processing headroom beyond the ADC's range — worthwhile for *processed*
+signals, moot for raw captures of a 12-bit front end. 8-bit formats
+(rtl_sdr's unsigned `u8`) halve the size again at the cost of dynamic range. A 2-channel
+16-bit [WAV](/reference/wav-iq-recording/) is cs16 plus a 44-byte header that documents the
+sample rate — a big usability win the raw format trades away for simplicity.
+
+## Relevance to SDR
+
+cs16 is GopherTrunk's workhorse capture format: `gophertrunk replay -in capture.raw
+-format cs16 -sample-rate …` replays one, the repository's regression fixtures
+(`testdata/*.cs16`) and operators' field captures use it, and the pre-combine
+`diversity_capture` tap writes one headerless cs16 file per receiver branch plus a JSON
+sidecar carrying the metadata the format itself omits. The half-size-of-float economy is
+the reason: a 30-second two-branch capture at 250 kS/s is ~120 MB in float32 and ~60 MB in
+cs16, with nothing lost — the samples were 16-bit integers on the wire anyway. The habits
+that make headerless captures useful later are the same ones this format demands: record
+the sample rate, centre frequency, gain, and device alongside every file, at capture time,
+every time.
+
+## Sources
+
+[^soapy]: [SoapySDR wiki](https://github.com/pothosware/SoapySDR/wiki) — Pothosware, on the CS16 complex-int16 stream format and its role as a native SDR sample type.

--- a/docs/reference/equalizer-gotchas.md
+++ b/docs/reference/equalizer-gotchas.md
@@ -1,0 +1,102 @@
+---
+slug: equalizer-gotchas
+title: Equalizer gotchas
+entry_type: term
+category: fn-diagnostics
+description: "Equalizer gotchas are the rules that separate an adaptive equalizer that raises decode yield from one that silently zeroes it: never adapt ahead of a differential decoder, judge by CRC yield not EVM, normalise by a constant, and never test blind CMA on noise-free input."
+keywords: equalizer, CMA, LMS, differential decoder, frozen taps, EVM trap, CRC yield, normalisation, divergence guard, rotation, raw symbols, TETRA equalizer
+aka: [adaptive equalizer gotchas, CMA gotchas]
+infobox:
+  - { label: Type, value: DSP facts }
+  - { label: Key rule, value: Never feed an adapting equalizer to a differential decoder }
+  - { label: Trap, value: "EVM improves while CRC yield stays zero" }
+  - { label: Verdict metric, value: CRC-valid frames, nothing else }
+see_also: [snapshot-equalization, cma-equalizer, lms-algorithm, differential-decoding, error-vector-magnitude, pi-4-dqpsk, tetra-lock-facts, signal-signatures]
+related_reading:
+  - { title: "Weak-Signal Engineering, Part 4: Blind CMA", url: /blog/deep-dives/weak-signal-engineering-04-blind-cma/ }
+  - { title: "Weak-Signal Engineering, Part 5: The Snapshot Trick — Frozen Taps & Differential Decoders", url: /blog/deep-dives/weak-signal-engineering-05-snapshot-trick/ }
+  - { title: "Weak-Signal Engineering, Part 6: Normalisation Guards", url: /blog/deep-dives/weak-signal-engineering-06-normalisation-guards/ }
+  - { title: "Weak-Signal Engineering, Part 7: Trained LMS", url: /blog/deep-dives/weak-signal-engineering-07-trained-lms/ }
+cite_urls:
+  - https://github.com/MattCheramie/GopherTrunk/issues/1001
+  - https://github.com/MattCheramie/GopherTrunk/issues/1003
+---
+
+**Equalizer gotchas** are the rules GopherTrunk learned bringing adaptive equalization into
+its TETRA paths — where a [blind CMA](/reference/cma-equalizer/) roughly doubled voice
+yield on marginal captures, but only after several variants that looked plausible, measured
+well on the wrong metric, and decoded exactly nothing. Each rule below is structural, not a
+tuning preference, and each is pinned by a test that fails against the broken variant.
+
+## Never feed a continuously-adapting equalizer to a differential decoder
+
+The CMA cost depends only on output magnitude, so nothing constrains its output phase — as
+the taps adapt, the phase wanders. A
+[differential decoder](/reference/differential-decoding/) cancels any *constant* rotation
+in `s·conj(prev)`, but a phase moving between the two symbols of a pair corrupts every
+dibit: streaming-adaptive CMA ahead of TETRA's
+[π/4-DQPSK](/reference/pi-4-dqpsk/) differential decode scored **CRC 0**. Permanently
+frozen taps only ever reproduce the unequalized baseline. The resolution — adapt a tracking
+filter continuously, apply a frozen snapshot per burst — is its own article:
+[snapshot equalization](/reference/snapshot-equalization/).
+
+## EVM is a trap; CRC yield is the only trustworthy verdict
+
+Blind CMA minimises *modulus*, not correctness, and its cost surface has spurious
+constant-modulus minima. A numerically unstable variant once showed differential
+[EVM](/reference/error-vector-magnitude/) collapsing 34% → 8% — a spectacular-looking
+win — while CRC-valid frames stayed at **zero**. The rule generalises past equalizers: any
+DSP change whose success metric is a statistic of the waveform can be gamed by a transform
+that improves the statistic and destroys the information. Decode all the way to CRC and
+count valid frames; nothing shallower is evidence.
+
+## Normalise by a constant, not a local average
+
+The CMA update scales with |x|³, so the normaliser is part of the loop. An EMA that tracks
+a [TDMA](/reference/tdma/) downlink's slot-to-slot power swings hands the equalizer a
+*moving* modulus target, and it converges to garbage — CRC 0 even though a global-RMS
+normalise on the same capture gives the full win. Use a cumulative-mean (effectively
+constant) normaliser, and pair it with a divergence guard that re-seeds the tracking filter
+to pass-through if a transient or deep fade blows the taps up, so one bad patch cannot
+poison later snapshots.
+
+## Blind CMA is degenerate on noise-free input
+
+A literally noise-free constant-modulus signal gives the CMA cost nothing to grade — every
+input already sits on the circle, and the update direction is meaningless. This is a
+*test-design* gotcha: a synthetic clean-channel fixture must add noise (GopherTrunk's add
+30–40 dB AWGN) or the test exercises a degenerate case no real signal presents. A perfectly
+clean synthetic passing proves nothing about the equalizer; see the
+[self-consistent test trap](/reference/self-consistent-test-trap/) for the wider family.
+
+## A frozen filter cannot invert a rotation ramp
+
+TETRA burst decoding tries four carrier rotations; a burst decoded at non-zero residual
+rotation has a per-symbol phase *ramp*, and a constant-tap filter cannot represent one. The
+DMO trained equalizer therefore equalizes only rotation-0 bursts, where the de-rotation is
+a no-op and the trained taps slot straight in. If an equalizer helps on most bursts and
+zeroes a minority, check whether the minority share a residual rotation.
+
+## Train in the raw-symbol domain, not the differential domain
+
+The linear channel is a clean convolution only over the *raw* transmitted symbols;
+`s·conj(prev)` is a nonlinear product of two channel outputs, and an equalizer trained on
+differentials is fitting a model that does not hold. GopherTrunk's traffic extractor
+carries raw symbols down parallel to its dibit and soft buffers precisely so the
+midamble-trained `SnapshotLMS` can run before the differential decode and re-derive the
+[soft LLRs](/reference/log-likelihood-ratio/) from equalized symbols.
+
+## Symptom table
+
+| Symptom | Looks like | Actually | Fix / check |
+|---|---|---|---|
+| Equalizer on, CRC drops to 0 | Broken equalizer maths | Adapting taps ahead of a differential decoder | Apply frozen snapshots ([snapshot equalization](/reference/snapshot-equalization/)) |
+| EVM improves dramatically, decode unchanged/worse | Big win | Spurious constant-modulus minimum | Score CRC yield; distrust waveform statistics |
+| Equalizer converges to garbage only on TDMA signals | Signal-dependent bug | EMA normaliser tracking slot power | Cumulative-mean normalisation + divergence guard |
+| Clean-channel unit test passes, real air fails | Coverage gap | Noise-free constant-modulus input is degenerate | Add AWGN to synthetic fixtures |
+| Helps most bursts, zeroes some | Flaky | Non-zero residual rotation vs frozen taps | Equalize rotation-0 only, or de-rotate first |
+
+## Provenance
+
+- [#1001](https://github.com/MattCheramie/GopherTrunk/issues/1001) — the TETRA equalizer thread: SnapshotCMA on the receiver paths (voice yield 410→778 across six captures; a marginal control-channel fixture ~12%→~100% BSCH) and the midamble-trained SnapshotLMS follow-up.
+- [#1003](https://github.com/MattCheramie/GopherTrunk/issues/1003) — the DMO path: rotation-0-only trained equalization, and the receiver-CMA lift on direct-mode signalling (CRC-valid SCH/S 6→64 on the first on-air capture).

--- a/docs/reference/fractional-delay-filter.md
+++ b/docs/reference/fractional-delay-filter.md
@@ -1,0 +1,92 @@
+---
+slug: fractional-delay-filter
+title: Fractional-delay filter
+entry_type: algorithm
+category: filtering-multirate
+description: A fractional-delay filter delays a sampled signal by a non-integer number of samples, interpolating between samples so two streams can be aligned to a fraction of a sample period.
+keywords: fractional delay, interpolating delay line, Farrow structure, sinc interpolation, sample alignment, inter-branch skew, timing alignment, Lagrange interpolation, delay estimation, parabolic interpolation
+aka: [fractional delay line, interpolating delay line]
+autolink: true
+infobox:
+  - { label: Type, value: Interpolating FIR structure }
+  - { label: Delays by, value: A non-integer number of samples }
+  - { label: Common forms, value: "Windowed-sinc FIR, Lagrange, Farrow" }
+  - { label: Used for, value: Timing recovery, branch alignment, beam steering }
+see_also: [resampler, fir-filter, clock-recovery, matched-filter, coherence, maximal-ratio-combining]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Interpolation
+  - https://en.wikipedia.org/wiki/Whittaker%E2%80%93Shannon_interpolation_formula
+---
+
+**A fractional-delay filter** delays a sampled signal by a non-integer number of samples —
+2.60 samples, say — by interpolating new sample values *between* the ones that were
+captured.[^wiki] An integer delay is free (read the buffer later), but the moment two
+streams must be aligned to a fraction of a sample period, a filter has to reconstruct what
+the signal was doing between sampling instants. The
+[sampling theorem](/reference/nyquist-theorem/) guarantees this is possible for a
+band-limited signal: the ideal fractional delay is a shifted sinc, and practical filters are
+finite approximations of it.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="Two sample streams offset by a fraction of a sample period; the early stream passes through an interpolating delay filter and emerges aligned with the late one." xmlns="http://www.w3.org/2000/svg">
+  <g fill="currentColor"><circle cx="40" cy="42" r="2.6"/><circle cx="80" cy="30" r="2.6"/><circle cx="120" cy="46" r="2.6"/><circle cx="160" cy="34" r="2.6"/></g>
+  <g fill="currentColor" fill-opacity="0.45"><circle cx="52" cy="90" r="2.6"/><circle cx="92" cy="78" r="2.6"/><circle cx="132" cy="94" r="2.6"/><circle cx="172" cy="82" r="2.6"/></g>
+  <text x="100" y="18" font-size="8.5" fill="currentColor" text-anchor="middle">branch 0 (early)</text>
+  <text x="112" y="112" font-size="8.5" fill="currentColor" text-anchor="middle">branch 1 (late by 0.3 samples)</text>
+  <line x1="185" y1="42" x2="235" y2="58" stroke="currentColor" stroke-width="1.2" marker-end="url(#fdar)"/>
+  <rect x="238" y="46" width="104" height="30" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/>
+  <text x="290" y="65" font-size="9" fill="currentColor" text-anchor="middle">delay by 0.3</text>
+  <line x1="345" y1="61" x2="395" y2="61" stroke="currentColor" stroke-width="1.2" marker-end="url(#fdar)"/>
+  <text x="424" y="64" font-size="9" fill="currentColor" text-anchor="middle">aligned</text>
+  <defs><marker id="fdar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Delaying the early stream by the measured fractional offset re-times its samples onto the other stream's grid, so the two can be summed sample-for-sample.</figcaption>
+</figure>
+
+## How it works
+
+The ideal delay-by-D filter has impulse response `sinc(n − D)` — for integer D that
+collapses to a single unit tap, for fractional D it spreads over all n and must be
+truncated. Practical structures trade accuracy for cost:
+
+- **Windowed-sinc FIR.** Take a dozen or so taps of the shifted sinc under a window;
+  accurate across most of the band, with the usual FIR latency.
+- **Lagrange / polynomial interpolation.** Fit a low-order polynomial through neighbouring
+  samples and read it off at the fractional position. Linear interpolation is the 1st-order
+  case — cheap, but it low-pass filters the signal noticeably.
+- **Farrow structure.** Factors a polynomial interpolator so the fractional delay is a
+  runtime *parameter* rather than baked into the taps — the standard choice inside
+  [timing-recovery](/reference/clock-recovery/) loops, where the delay changes every symbol.
+
+A fractional-delay filter is a [resampler](/reference/resampler/) evaluated at a constant
+offset: same mathematics, different intent. Where a resampler changes the rate, a
+fractional delay keeps the rate and moves the sampling *phase*.
+
+## Measuring the delay to apply
+
+Alignment jobs pair the filter with an estimator. Cross-correlating the two streams over a
+range of integer lags finds the coarse offset; fitting a parabola through the correlation
+peak and its two neighbours refines it to a fraction of a sample. The frequency-domain
+signature of a pure delay is distinctive and worth recognising: per-frequency
+[coherence](/reference/coherence/) stays near 1 while broadband coherence is diluted (each
+frequency sees a different phase slope, so the wideband average partially cancels), and
+group delay is flat.
+
+## Relevance to SDR
+
+Fractional delays are everywhere timing matters: inside every symbol-timing loop, in
+beamforming (a steering delay per element), and in multi-channel alignment. GopherTrunk's
+sharpest lesson came from diversity combining: on an X310 with two daughterboards, branch 0
+lagged branch 1 by a *constant 2.60 samples* (13 µs at 200 kS/s), and since a single complex
+gain cannot represent a delay, [MRC](/reference/maximal-ratio-combining/) on the skewed
+branches decoded 22% *fewer* CRC-clean frames than the best branch alone — the combiner was
+hurting. The SoapyRemote driver now measures the skew per stream (±16-lag correlation scan
+with parabolic refinement, DC-removed, latched behind a coherence gate) and delays the early
+branch through an interpolating delay line (`internal/sdr/soapyremote/align.go`); the
+identical combine after alignment matched the best branch exactly. The diagnostic — "other
+lags ref by N±f samples" — is printed by the diversity replay harness, and the wider story
+lives in [MRC diversity gotchas](/reference/mrc-diversity-gotchas/).
+
+## Sources
+
+[^wiki]: [Whittaker–Shannon interpolation formula](https://en.wikipedia.org/wiki/Whittaker%E2%80%93Shannon_interpolation_formula) — Wikipedia, on ideal sinc reconstruction between samples, the basis of fractional-delay filtering.

--- a/docs/reference/fractionally-spaced-equalizer.md
+++ b/docs/reference/fractionally-spaced-equalizer.md
@@ -1,0 +1,83 @@
+---
+slug: fractionally-spaced-equalizer
+title: Fractionally-spaced equalizer (FSE)
+entry_type: algorithm
+category: equalization
+description: A fractionally-spaced equalizer places its taps closer than one symbol apart — typically T/2 — so it can synthesize the receive matched filter, correct pulse-shape mismatch, and shrug off sampling-phase errors a symbol-spaced equalizer cannot.
+keywords: fractionally spaced equalizer, FSE, T/2 equalizer, symbol-spaced equalizer, matched filter synthesis, pulse shape mismatch, CMA, timing phase, adaptive equalizer, P25 CQPSK
+aka: [FSE, T/2 equalizer, fractionally spaced equalizer]
+autolink: true
+infobox:
+  - { label: Type, value: Adaptive equalizer structure }
+  - { label: Tap spacing, value: "A fraction of a symbol (usually T/2)" }
+  - { label: Advantage, value: Synthesizes the matched filter; timing-phase insensitive }
+  - { label: Cost, value: 2× taps, needs a leakage term against tap drift }
+see_also: [cma-equalizer, adaptive-filter, matched-filter, root-raised-cosine-filter, cqpsk, snapshot-equalization]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Equalization_(communications)
+  - https://en.wikipedia.org/wiki/Blind_equalization
+---
+
+**A fractionally-spaced equalizer** (**FSE**) is an [adaptive
+equalizer](/reference/adaptive-filter/) whose taps are spaced *closer than one symbol
+apart* — most commonly half a symbol, "T/2" — so it operates on two or more samples per
+symbol instead of one.[^wiki] The extra resolution is not a luxury: a symbol-spaced
+equalizer can only correct the channel as seen *at* the symbol instants, which makes it
+blind to anything happening between them — the shape of the pulse itself, and the exact
+sampling phase. An FSE sees the waveform between symbols too, and that lets it do jobs a
+symbol-spaced filter structurally cannot.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="A symbol waveform sampled once per symbol misses the pulse shape between symbol instants; sampling twice per symbol lets the equalizer taps see and correct the shape itself." xmlns="http://www.w3.org/2000/svg">
+  <path d="M20 80 C 50 20 80 20 110 80 C 140 130 170 130 200 80 C 230 30 260 30 290 80 C 320 125 350 125 380 80" fill="none" stroke="currentColor" stroke-width="1.3" stroke-opacity="0.7"/>
+  <g fill="currentColor"><circle cx="65" cy="35" r="3"/><circle cx="155" cy="117" r="3"/><circle cx="245" cy="42" r="3"/><circle cx="335" cy="114" r="3"/></g>
+  <g fill="currentColor" fill-opacity="0.5"><circle cx="110" cy="80" r="3"/><circle cx="200" cy="80" r="3"/><circle cx="290" cy="80" r="3"/><circle cx="380" cy="80" r="3"/></g>
+  <text x="65" y="24" font-size="8" fill="currentColor" text-anchor="middle">on-time (T)</text>
+  <text x="203" y="98" font-size="8" fill="currentColor">midpoint (T/2)</text>
+  <text x="230" y="134" font-size="8.5" fill="currentColor" text-anchor="middle">two tap phases per symbol see the pulse, not just its symbol-instant values</text>
+</svg>
+<figcaption>Symbol-spaced taps touch only the dark samples; the T/2 taps also weight the midpoints, giving the equalizer authority over the pulse shape between decisions.</figcaption>
+</figure>
+
+## How it works
+
+The FSE is an FIR filter running at 2× the symbol rate whose output is read once per
+symbol; adaptation (LMS against training, or blind
+[CMA](/reference/cma-equalizer/)) updates the T/2-spaced taps exactly as it would
+symbol-spaced ones. The structural wins:
+
+- **It synthesizes the receive [matched filter](/reference/matched-filter/) implicitly.**
+  The optimal receiver front end is matched filter + symbol-rate sampler; a T/2 FSE spans
+  both roles, so if the receiver's fixed filter is matched to the *wrong* pulse, the FSE
+  quietly learns the correction. A symbol-spaced equalizer cannot — the mismatch lives
+  between its taps.
+- **It is insensitive to sampling phase.** Symbol-spaced equalization degrades with timing
+  offset because aliasing of the (excess-bandwidth) pulse folds differently at each phase;
+  T/2 sampling keeps the excess band un-aliased, so residual timing error becomes just
+  another linear distortion the taps absorb.
+- **It equalizes before decimation**, so channel nulls that land between symbol-rate alias
+  points remain correctable.
+
+The costs are 2× the taps and one genuine trap: fractional spacing enlarges the blind cost
+function's null space — tap combinations that leave the output modulus unchanged — so on a
+clean channel the taps can random-walk. A small **leakage** term (`w ← (1−leak)·w` each
+update) shrinks unexcited taps toward zero: real ISI sustains taps, noise alone does not.
+
+## Relevance to SDR
+
+GopherTrunk's FSE (`internal/dsp/equalizer/fse.go`) exists because of a pulse-mismatch bug
+class no symbol-spaced filter could fix: the P25 [CQPSK](/reference/cqpsk/)/LSM receiver
+matched-filters with a [root-raised-cosine](/reference/root-raised-cosine-filter/), but a
+real P25 [C4FM](/reference/c4fm/) transmitter shapes a different (CPM) pulse — the outer
+±1800 Hz rails arrive under-shot and the constellation closes, and a symbol-spaced CMA
+cannot open it (issue #492). The T/2 blind FSE consumes the timing loop's on-time sample
+*and* the half-symbol-earlier midpoint interpolant, corrects the pulse mismatch and any
+multipath ISI, and runs ahead of the carrier loop (the CMA cost is rotation-invariant, with
+the centre tap phase-pinned so tap drift is not read as a frequency offset). It is always-on
+for P25 CQPSK/LSM. Note the contrast with the TETRA paths, where the differential decoder
+imposes its own constraint and the equalizers are applied as frozen snapshots — see
+[snapshot equalization](/reference/snapshot-equalization/).
+
+## Sources
+
+[^wiki]: [Equalization (communications)](https://en.wikipedia.org/wiki/Equalization_(communications)) — Wikipedia, on adaptive equalizer structures including fractionally-spaced designs and their timing-phase insensitivity.

--- a/docs/reference/interference-rejection-combining.md
+++ b/docs/reference/interference-rejection-combining.md
@@ -1,0 +1,97 @@
+---
+slug: interference-rejection-combining
+title: Interference rejection combining (IRC)
+entry_type: algorithm
+category: estimation-array
+description: Interference rejection combining (IRC) is MMSE diversity combining that uses the measured noise-plus-interference covariance to steer a spatial null at a directional interferer that MRC would amplify.
+keywords: interference rejection combining, IRC, MMSE-IRC, noise covariance, spatial null, co-channel interference, diversity combining, MRC, channel estimation, LTE receiver
+aka: [IRC, MMSE-IRC, interference rejection combiner]
+autolink: true
+infobox:
+  - { label: Type, value: MMSE diversity combiner }
+  - { label: Weights, value: "w = R_nn⁻¹ h (normalised)" }
+  - { label: Beats MRC when, value: A directional interferer dominates }
+  - { label: Catch, value: Needs a clean channel estimate — blind IRC fails }
+see_also: [maximal-ratio-combining, antenna-diversity, mmse-equalizer, beamforming, channel-estimation, coherence]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Diversity_combining
+  - https://en.wikipedia.org/wiki/Beamforming
+---
+
+**Interference rejection combining** (**IRC**) is the diversity combiner to reach for when
+the enemy is not noise but another transmitter: instead of weighting branches by signal
+strength like [maximal-ratio combining](/reference/maximal-ratio-combining/), it measures
+the spatial covariance of everything that is *not* the wanted signal and inverts it, which
+steers a null toward a directional interferer while keeping gain on the wanted
+direction.[^wiki] It is the standard uplink combiner in LTE and 5G base stations, where
+co-channel interference from neighbouring cells, not thermal noise, sets the floor.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 150" role="img" aria-label="A two-antenna receiver pattern with a main lobe pointed at the wanted signal and a deep notch steered toward an interferer arriving from a different direction." xmlns="http://www.w3.org/2000/svg">
+  <path d="M80 120 C 120 20 210 20 240 78 C 250 96 244 110 232 116 C 260 104 300 96 340 118" fill="none" stroke="currentColor" stroke-width="1.4"/>
+  <line x1="80" y1="120" x2="340" y2="120" stroke="currentColor" stroke-opacity="0.35"/>
+  <circle cx="150" cy="120" r="3" fill="currentColor"/><circle cx="270" cy="120" r="3" fill="currentColor"/>
+  <line x1="160" y1="98" x2="160" y2="34" stroke="currentColor" stroke-width="1.1" stroke-dasharray="4 3" marker-end="url(#ircar)"/>
+  <text x="160" y="24" font-size="9" fill="currentColor" text-anchor="middle">wanted signal</text>
+  <line x1="237" y1="98" x2="237" y2="120" stroke="currentColor" stroke-width="1.1" stroke-dasharray="4 3"/>
+  <line x1="237" y1="60" x2="237" y2="96" stroke="currentColor" stroke-width="1.1" marker-end="url(#ircar2)"/>
+  <text x="237" y="50" font-size="9" fill="currentColor" text-anchor="middle">interferer → null</text>
+  <text x="210" y="140" font-size="8.5" fill="currentColor" text-anchor="middle">two antennas, one null to spend</text>
+  <defs>
+    <marker id="ircar" markerWidth="8" markerHeight="8" refX="3" refY="6" orient="auto"><path d="M0 6 L3 0 L6 6 z" fill="currentColor"/></marker>
+    <marker id="ircar2" markerWidth="8" markerHeight="8" refX="3" refY="6" orient="0"><path d="M0 0 L3 6 L6 0 z" fill="currentColor"/></marker>
+  </defs>
+</svg>
+<figcaption>With N antennas the combiner has N−1 spatial degrees of freedom to spend: IRC spends one on a null toward the interferer, which MRC would instead amplify along with the branch it is loudest on.</figcaption>
+</figure>
+
+## How it works
+
+Model branch *k* as `x_k = h_k·s + n_k`, where `n_k` now contains both noise *and* the
+interference. Collect the interference-plus-noise covariance matrix `R_nn` across branches
+(the interferer makes its off-diagonal terms large and structured, unlike white noise) and
+form the [MMSE](/reference/mmse-equalizer/) weights
+
+`w = R_nn⁻¹ h`, scaled so `wᴴh = 1`.
+
+When `R_nn` is diagonal — pure independent noise — this collapses to exactly MRC, so IRC is
+a strict generalisation, not a rival. When one interferer dominates, `R_nn⁻¹` de-emphasises
+the spatial direction the interferer arrives from: the weights place a null there, the same
+mathematics as adaptive [beamforming](/reference/beamforming/) with N−1 degrees of freedom
+for N antennas. A small diagonal loading term keeps the inversion stable when the estimate
+window is short.
+
+## Why blind IRC fails
+
+The formula hides a dependency that decides whether IRC works at all: `R_nn` is the
+covariance of the *residual* after the wanted signal is removed, and removing the wanted
+signal requires knowing `h` — a clean
+[channel estimate](/reference/channel-estimation/). With a co-channel interferer present, a
+blind least-squares estimate of `h` is contaminated: the cross-correlation between branches
+contains `h_wanted·P_signal + h_interf·P_interf`, so the estimator returns a power-weighted
+*blend* of the two directions, and the null gets steered at a mixture that is neither.
+GopherTrunk measured this directly on a synthetic two-branch co-channel scene
+(`internal/dsp/diversity/irc_test.go`): a true branch gain of 0.95∠40° read back as
+0.32∠1°, blind IRC gained **0.0 dB** over MRC, and the *identical* code handed a training
+sequence gained **+23.6 dB**. Cellular IRC works because every uplink burst carries known
+reference symbols; a blind wideband combiner has none. There is also a subtle degeneracy to
+avoid: estimating the residual against the reference *branch* rather than the combined
+output forces that branch's residual to zero by construction, zeroing a row and column of
+`R_nn` so no null can form.
+
+## Relevance to SDR
+
+For an SDR listener, IRC is the answer to a specific and recognisable failure: a strong
+directional interferer (a paging transmitter, an adjacent site) that gets *worse* when MRC
+diversity is enabled, because MRC faithfully weights the branch the interferer is loudest
+on. The catch is the training requirement — in a trunking receiver, known symbols (a
+[training sequence](/reference/tetra-training-sequences/) or
+[frame sync](/reference/frame-synchronization/)) exist only per narrowband channel, after
+the [DDC](/reference/digital-down-converter/), which is also where per-channel combining has
+to live anyway. GopherTrunk therefore ships `IRCCalibrator`
+(`internal/dsp/diversity/irc.go`) as an offline replay-harness arm for capture analysis, not
+as a live driver mode: the measured blind-vs-trained gap above is the documented reason.
+
+## Sources
+
+[^wiki]: [Diversity combining](https://en.wikipedia.org/wiki/Diversity_combining) — Wikipedia, on combining schemes and the MMSE/optimum combining generalisation of MRC under interference.

--- a/docs/reference/ka9q-radio.md
+++ b/docs/reference/ka9q-radio.md
@@ -1,0 +1,90 @@
+---
+slug: ka9q-radio
+title: ka9q-radio
+entry_type: technology
+category: sdr-data-streaming
+description: "ka9q-radio is Phil Karn's multicast SDR system: one radiod process channelizes a front end once and publishes every channel as IP multicast streams that any number of consumers on the LAN can receive independently."
+keywords: ka9q-radio, radiod, Phil Karn, KA9Q, multicast SDR, IP multicast IQ, RTP streams, channelizer, SSRC, mDNS discovery, network SDR
+aka: [ka9q-radio, radiod, KA9Q radio]
+autolink: true
+infobox:
+  - { label: Type, value: Multicast SDR server }
+  - { label: Author, value: Phil Karn, KA9Q }
+  - { label: Transport, value: RTP over IP multicast }
+  - { label: Model, value: "Channelize once, consume many times" }
+see_also: [soapyremote, rtl-tcp, network-iq-streaming, channelizer, phil-karn, spyserver-protocol]
+external:
+  - { title: "ka9q-radio on GitHub", url: "https://github.com/ka9q/ka9q-radio" }
+cite_urls:
+  - https://github.com/ka9q/ka9q-radio
+  - https://en.wikipedia.org/wiki/Phil_Karn
+---
+
+**ka9q-radio** is [Phil Karn](/reference/phil-karn/)'s answer to a structural waste in
+networked SDR: most protocols ship the *whole* digitized passband to each client, which
+then throws away everything but one channel.[^gh] ka9q-radio inverts that. A single
+`radiod` process owns the front end, channelizes the entire passband **once** with an
+efficient FFT-based [channelizer](/reference/channelizer/), and publishes each channel —
+hundreds at a time, if asked — as its own RTP stream on an **IP multicast** group. Any
+number of consumers on the LAN then subscribe to just the channels they want, and adding a
+listener costs the network nothing it was not already carrying.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 160" role="img" aria-label="One SDR front end feeds a radiod process that fans out many channel streams onto a multicast network, where several independent consumers each subscribe to the channels they want." xmlns="http://www.w3.org/2000/svg">
+  <rect x="20" y="62" width="64" height="30" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/>
+  <text x="52" y="81" font-size="9" fill="currentColor" text-anchor="middle">SDR</text>
+  <line x1="84" y1="77" x2="126" y2="77" stroke="currentColor" stroke-width="1.2" marker-end="url(#kqar)"/>
+  <rect x="130" y="52" width="86" height="50" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/>
+  <text x="173" y="73" font-size="9" fill="currentColor" text-anchor="middle">radiod</text>
+  <text x="173" y="88" font-size="7.5" fill="currentColor" text-anchor="middle">channelize once</text>
+  <line x1="216" y1="62" x2="286" y2="34" stroke="currentColor" stroke-width="1.1" marker-end="url(#kqar)"/>
+  <line x1="216" y1="77" x2="286" y2="77" stroke="currentColor" stroke-width="1.1" marker-end="url(#kqar)"/>
+  <line x1="216" y1="92" x2="286" y2="122" stroke="currentColor" stroke-width="1.1" marker-end="url(#kqar)"/>
+  <text x="251" y="48" font-size="7.5" fill="currentColor" text-anchor="middle">multicast groups</text>
+  <g stroke="currentColor" stroke-width="1.2" fill="none">
+    <rect x="290" y="20" width="140" height="26" rx="4"/><rect x="290" y="64" width="140" height="26" rx="4"/><rect x="290" y="108" width="140" height="26" rx="4"/>
+  </g>
+  <g font-size="8" fill="currentColor" text-anchor="middle">
+    <text x="360" y="36">decoder A (one channel)</text><text x="360" y="80">decoder B (another)</text><text x="360" y="124">recorder (several)</text>
+  </g>
+  <defs><marker id="kqar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>The front end is digitized and channelized exactly once; every consumer subscribes to ready-made channels instead of re-tuning its own copy of the passband.</figcaption>
+</figure>
+
+## How it works
+
+`radiod` reads the hardware (RX888, Airspy, RTL-SDR, and others), runs the passband through
+a fast-convolution filter bank, and maintains one demodulator instance per configured
+channel — each with its own frequency, bandwidth, and mode (IQ, USB, FM, …). Each channel's
+output goes out as RTP on a multicast group, identified by an **SSRC** (by convention, the
+channel's frequency in Hz), alongside a *status* multicast group carrying metadata —
+sample rate, output socket, signal levels — as typed key/value pairs. Control uses the same
+status group: a consumer can create or re-tune channels remotely by sending commands to it.
+Service discovery rides mDNS, so streams have names like `hf.local` rather than bare
+multicast addresses. The consumer-side toolbox (`monitor`, `pcmrecord`, digital-decoder
+front ends) is deliberately small and composable in the Unix style.
+
+Contrast the models: [rtl_tcp](/reference/rtl-tcp/) ships one client the raw passband;
+[SoapyRemote](/reference/soapyremote/) gives one client remote *control* of a device plus
+its stream; [SpyServer](/reference/spyserver-protocol/) multiplexes clients but demodulates
+per client on the server. ka9q-radio alone makes the channel — not the device — the shared
+network product, which is what lets one antenna on a rooftop serve a whole shack (or a
+whole club) of independent decoders.
+
+## Relevance to SDR
+
+For a trunking scanner the model is a natural fit: a trunked system *is* a set of known
+channels, and a radiod instance can carry the control channel and every voice channel of a
+site simultaneously from one front end. GopherTrunk consumes ka9q-radio natively
+(`internal/sdr/ka9qradio/`, config key `ka9q_radio`): each configured `{addr, ssrc}` pair
+appears to the scanner as a virtual tuner — the driver resolves the status group via mDNS,
+learns the channel's data socket, sample rate, and encoding from a status poll, and can
+re-tune the channel through radiod's command interface. The practical wins are physical:
+`radiod` runs on a small computer at the antenna, the samples cross the LAN instead of
+lossy coax, and several GopherTrunk instances (or GopherTrunk plus other ka9q consumers)
+share one front end without contending for USB.
+
+## Sources
+
+[^gh]: [ka9q-radio](https://github.com/ka9q/ka9q-radio) — Phil Karn, KA9Q, on the multicast channelize-once architecture, radiod, and the RTP/status stream design.

--- a/docs/reference/lms-algorithm.md
+++ b/docs/reference/lms-algorithm.md
@@ -11,7 +11,7 @@ infobox:
   - { label: Type, value: Stochastic-gradient adaptive algorithm }
   - { label: Update, value: "w += μ·e·x*" }
   - { label: Complexity, value: O(N) per sample }
-see_also: [adaptive-filter, rls-algorithm, cma-equalizer, mmse-equalizer, fir-filter, constellation-diagram]
+see_also: [adaptive-filter, rls-algorithm, cma-equalizer, mmse-equalizer, snapshot-equalization, fir-filter, constellation-diagram]
 cite_urls:
   - https://en.wikipedia.org/wiki/Least_mean_squares_filter
   - https://en.wikipedia.org/wiki/Bernard_Widrow
@@ -84,10 +84,14 @@ cancellers. In a radio receiver an LMS equalizer trims residual
 [SNR](/reference/signal-to-noise-ratio/) at the decision slicer, often running
 decision-directed once a training sequence has pulled it near lock. The blind
 [CMA](/reference/cma-equalizer/) equalizer is an LMS-style stochastic-gradient rule with a
-constant-modulus cost instead of a reference error. GopherTrunk's land-mobile decoders
-(P25, DMR, NXDN) lean on [matched filtering](/reference/matched-filter/) and timing/carrier
-recovery rather than a full LMS equalizer, so LMS is best understood here as the general
-adaptive-filter primitive the wider RF world runs on.
+constant-modulus cost instead of a reference error. GopherTrunk runs LMS in exactly the
+trained role described above: its TETRA traffic path trains a short LMS equalizer on each
+burst's known [midamble](/reference/tetra-training-sequences/) and applies the frozen taps
+to that one burst (`SnapshotLMS` — see
+[snapshot equalization](/reference/snapshot-equalization/)), while the C4FM-family decoders
+(P25, DMR, NXDN) still lean on [matched filtering](/reference/matched-filter/) and
+timing/carrier recovery, whose modest symbol rates keep ISI small enough to skip
+equalization.
 
 ## Sources
 

--- a/docs/reference/maximal-ratio-combining.md
+++ b/docs/reference/maximal-ratio-combining.md
@@ -1,0 +1,108 @@
+---
+slug: maximal-ratio-combining
+title: Maximal-ratio combining (MRC)
+entry_type: algorithm
+category: estimation-array
+description: Maximal-ratio combining (MRC) co-phases the branches of a diversity receiver and weights each by its own signal quality before summing, making the output SNR the sum of the branch SNRs.
+keywords: maximal ratio combining, MRC, diversity combining, coherent combining, branch weights, channel estimate, receive diversity, antenna diversity, equal gain combining, selection combining
+aka: [MRC, maximum ratio combining, ratio squarer]
+autolink: true
+infobox:
+  - { label: Type, value: Coherent diversity combiner }
+  - { label: Output SNR, value: Sum of the branch SNRs }
+  - { label: Needs, value: A complex channel estimate per branch }
+  - { label: Optimal in, value: Additive white noise (no interference) }
+see_also: [antenna-diversity, interference-rejection-combining, coherence, channel-estimation, beamforming, rayleigh-fading, mimo]
+related_reading:
+  - { title: "The Analog Edge, Part 11: Two Antennas — Diversity & MRC From the Operator's Seat", url: /blog/tutorials/analog-edge-11-diversity-mrc/ }
+  - { title: "Weak-Signal Engineering, Part 11: Tracking MRC", url: /blog/deep-dives/weak-signal-engineering-11-tracking-mrc/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Maximal-ratio_combining
+  - https://en.wikipedia.org/wiki/Diversity_combining
+---
+
+**Maximal-ratio combining** (**MRC**) is the optimal way to merge the branches of a
+[diversity](/reference/antenna-diversity/) receiver when the impairment is additive noise:
+rotate each branch so the copies add in phase, weight each by its own signal quality, and
+sum.[^wiki] The result is stronger than any single branch — the combined
+[SNR](/reference/signal-to-noise-ratio/) is the *sum* of the branch SNRs — and a branch deep
+in a [fade](/reference/rayleigh-fading/) still contributes its share instead of being thrown
+away, which is what separates MRC from simply selecting the best antenna.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 160" role="img" aria-label="Two receiver branches with different phases and amplitudes are each multiplied by the conjugate of their channel estimate, then summed, producing one output whose SNR is the sum of the branch SNRs." xmlns="http://www.w3.org/2000/svg">
+  <text x="30" y="48" font-size="9" fill="currentColor">x₀</text>
+  <text x="30" y="118" font-size="9" fill="currentColor">x₁</text>
+  <line x1="45" y1="44" x2="115" y2="44" stroke="currentColor" stroke-width="1.2" marker-end="url(#mrcar)"/>
+  <line x1="45" y1="114" x2="115" y2="114" stroke="currentColor" stroke-width="1.2" marker-end="url(#mrcar)"/>
+  <rect x="118" y="28" width="88" height="32" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/>
+  <text x="162" y="48" font-size="9" fill="currentColor" text-anchor="middle">× conj(h₀)</text>
+  <rect x="118" y="98" width="88" height="32" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/>
+  <text x="162" y="118" font-size="9" fill="currentColor" text-anchor="middle">× conj(h₁)</text>
+  <line x1="206" y1="44" x2="280" y2="72" stroke="currentColor" stroke-width="1.2" marker-end="url(#mrcar)"/>
+  <line x1="206" y1="114" x2="280" y2="86" stroke="currentColor" stroke-width="1.2" marker-end="url(#mrcar)"/>
+  <circle cx="295" cy="79" r="14" fill="none" stroke="currentColor" stroke-width="1.3"/>
+  <text x="295" y="83" font-size="12" fill="currentColor" text-anchor="middle">Σ</text>
+  <line x1="309" y1="79" x2="375" y2="79" stroke="currentColor" stroke-width="1.3" marker-end="url(#mrcar)"/>
+  <text x="415" y="76" font-size="9" fill="currentColor" text-anchor="middle">SNR = γ₀ + γ₁</text>
+  <defs><marker id="mrcar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Each branch is multiplied by the conjugate of its channel estimate — co-phasing it and scaling it by its own strength — before the sum, so every branch contributes in proportion to its quality.</figcaption>
+</figure>
+
+## How it works
+
+If branch *k* receives `x_k = h_k·s + n_k` — the transmitted signal `s` through a complex
+channel gain `h_k`, plus independent noise of equal power — the MRC output is
+
+`y = Σ conj(h_k)·x_k / Σ |h_k|²`.
+
+Multiplying by `conj(h_k)` does two jobs at once: it rotates every branch to a common phase
+(so the signal copies add coherently, amplitude-on-amplitude) and it weights each branch by
+`|h_k|` (so a strong branch counts more than a weak one). Signal amplitudes then add
+linearly while the independent noises add only in power, and the combined SNR works out to
+exactly `γ₀ + γ₁ + …` — the "maximal ratio" that no other linear weighting can beat under
+additive white noise. Two equal branches gain 3 dB even with no fading; under
+[Rayleigh fading](/reference/rayleigh-fading/) the real win is the diversity order, because
+both branches must fade *simultaneously* before the output does.
+
+The price is the `h_k` themselves: MRC needs a complex
+[channel estimate](/reference/channel-estimation/) per branch, which means either a training
+sequence or a blind estimator, and a full coherent receiver chain per antenna. The cheaper
+combining rules — selection, switched, equal-gain — exist precisely to avoid that cost; see
+[antenna diversity](/reference/antenna-diversity/) for the family.
+
+## Limits worth knowing
+
+- **MRC assumes the impairment is noise.** Against a directional co-channel interferer it
+  is actively wrong — it weights the branch where the interferer is *loudest* the most.
+  Nulling interference instead requires
+  [interference rejection combining](/reference/interference-rejection-combining/).
+- **A single complex weight is frequency-flat.** Combining a wideband stream with one
+  scalar per branch is exact only if the branches differ by a frequency-flat constant.
+  Antennas metres apart give each carrier its own phase difference, so a scalar aligns
+  whichever carrier dominates the cross-power and partially cancels the rest; the fix is
+  combining per channel, after the [DDC](/reference/digital-down-converter/).
+- **A delay is not a gain.** A constant inter-branch timing skew dilutes broadband
+  [coherence](/reference/coherence/) even though per-frequency coherence stays near 1, and
+  no scalar weight can represent it — the branches must be time-aligned first (see
+  [fractional-delay filter](/reference/fractional-delay-filter/)).
+
+## Relevance to SDR
+
+MRC is the receive-side workhorse of Wi-Fi, cellular and [MIMO](/reference/mimo/) systems,
+and it is exactly what a dual-channel SDR front end (USRP with two daughterboards, a
+dual-channel AD9361) makes possible in software. GopherTrunk implements wideband MRC in its
+SoapyRemote driver (`internal/dsp/diversity/mrc.go`, enabled with `diversity: mrc` or
+`mrc-static` on a two-channel device): branch gains are estimated by least squares against a
+reference branch, gated on measured [coherence](/reference/coherence/) rather than absolute
+level, and either frozen once (`mrc-static`, right for shared-LO front ends) or tracked
+continuously (`mrc`, right for independent-PLL daughterboards). The reference branch's
+weight is pinned to `1+0j`, which anchors the output phase and keeps the combiner safe ahead
+of [differential decoders](/reference/differential-decoding/). The practical
+lessons — coherence gates, skew alignment, and when MRC cannot help — are collected in
+[MRC diversity gotchas](/reference/mrc-diversity-gotchas/).
+
+## Sources
+
+[^wiki]: [Maximal-ratio combining](https://en.wikipedia.org/wiki/Maximal-ratio_combining) — Wikipedia, on conjugate-weight combining and the summed-SNR optimality result.

--- a/docs/reference/mrc-diversity-gotchas.md
+++ b/docs/reference/mrc-diversity-gotchas.md
@@ -1,0 +1,113 @@
+---
+slug: mrc-diversity-gotchas
+title: MRC diversity gotchas
+entry_type: term
+category: fn-diagnostics
+description: "MRC diversity gotchas are the calibration truths that decide whether two-antenna combining helps or hurts: gate on coherence not dBFS, remove DC before correlating, align inter-branch delay, and read branch_phase_deg to learn your hardware class."
+keywords: mrc, diversity combining, coherence gate, dbfs gate, dc offset correlation, inter-branch skew, branch alignment, branch_phase_deg, tracking calibrator, pre-combine capture, x310, twinrx
+aka: [diversity combining gotchas, MRC calibration gotchas]
+infobox:
+  - { label: Type, value: DSP + calibration facts }
+  - { label: Key rule, value: "Gate on coherence, never on absolute dBFS" }
+  - { label: Trap, value: A common DC offset fakes perfect coherence }
+  - { label: Field instrument, value: branch_phase_deg — constant vs walking }
+see_also: [maximal-ratio-combining, coherence, fractional-delay-filter, interference-rejection-combining, channel-estimation, dc-offset, usrp-soapyremote-notes, signal-signatures]
+related_reading:
+  - { title: "The Analog Edge, Part 11: Two Antennas — Diversity & MRC From the Operator's Seat", url: /blog/tutorials/analog-edge-11-diversity-mrc/ }
+  - { title: "Weak-Signal Engineering, Part 10: MRC Calibration", url: /blog/deep-dives/weak-signal-engineering-10-mrc-calibration/ }
+  - { title: "Weak-Signal Engineering, Part 11: Tracking MRC", url: /blog/deep-dives/weak-signal-engineering-11-tracking-mrc/ }
+  - { title: "The Analog Edge, Part 13: Coherence, Not dBFS", url: /blog/tutorials/analog-edge-13-coherence-not-dbfs/ }
+cite_urls:
+  - https://github.com/MattCheramie/GopherTrunk/issues/1062
+---
+
+**MRC diversity gotchas** are the calibration truths GopherTrunk learned wiring
+[maximal-ratio combining](/reference/maximal-ratio-combining/) into a real two-antenna rig
+(an X310 with TwinRX daughterboards, over three weeks of operator field logs). Each one was
+paid for with a session where the combiner confidently did the wrong thing — and each now
+has a regression test and a diagnostic signature.
+
+## Gate on coherence, never on absolute level
+
+The first calibration gate was "reference branch above −40 [dBFS](/reference/dbfs/)" — and
+an operator raised front-end gain from 65 dB to 82 dB purely to push a number past a
+software constant (landing at −39.8 dBFS, clearing it by 0.2 dB). Any absolute-power gate
+is a gain-staging trap that re-fires on the next front end. The scale-invariant question is
+measured [coherence](/reference/coherence/): `|ρ| = γ/(1+γ)` reads directly as per-branch
+SNR, and the thing calibration actually needs bounded — the channel estimate's phase
+error — is computable from ρ and the window length as `√((1−ρ²)/(2Nρ²))`. GopherTrunk's
+gates now bound that projected error (defaults 0.10/0.16 rad), which also cured a subtler
+bandwidth trap: wideband ρ is diluted by every hertz of noise-only bandwidth
+(`ρ_wb ≈ ρ_ch·√(f₀f₁)`), so a fixed 0.50 threshold had made "coherent enough" depend on the
+configured capture bandwidth. On one capture the control channel decoded 1,425 CRC-clean
+BSCH from a branch while wideband ρ sat at ~0.16 and the old gate refused to calibrate —
+with a WARN whose advice ("raising RF gain will not help") was exactly wrong in that regime.
+
+## DC removal in the correlator is load-bearing
+
+Both receivers of one front end share [LO leakage](/reference/dc-offset/). An uncentred
+correlator fed two branches of *independent noise* plus a common DC term reports
+`|ρ| → 1` and freezes the branch gain at the ratio of the DC offsets — confidently
+calibrating on nothing, in exactly the weak-signal regime the gate exists to protect.
+Subtract each branch's mean before every cross-correlation
+(pinned by `TestCrossStatsRejectsCommonDCOffset`).
+
+## A delay is not a gain
+
+The biggest single finding: branch 0 lagged branch 1 by a **constant 2.60 samples**
+(13 µs at 200 kS/s), and a scalar weight cannot represent a delay — combining the skewed
+branches decoded **22% fewer** CRC-clean BSCH than the best branch alone (886 vs 1,142).
+MRC was hurting. The signature is unmistakable once known: per-frequency coherence ~0.99
+while broadband ρ dilutes to ~0.78, and no amount of gain or tracking improves it. The
+driver now measures the skew per stream and delays the early branch through an
+interpolating [fractional-delay filter](/reference/fractional-delay-filter/); the identical
+combine after alignment scored exactly 1,142. The replay harness prints
+"inter-branch delay: other lags ref by N±f samples".
+
+## Read `branch_phase_deg` to learn your hardware class
+
+The MRC health log's `branch_phase_deg` is the no-capture field instrument. **Constant**
+phase ⇒ a shared-LO front end (single-chip AD9361 class): a one-shot calibration is
+correct — use `mrc-static`. **Walking** phase ⇒ independent PLLs per branch (TwinRX class:
+frequency-locked to a common reference, random relative phase per lock, drifting after):
+a frozen constant decays over minutes — use tracking `mrc`. The 17 Aug capture measured a
+~145° inter-branch phase walking only −0.22°/s: coherent enough that static works within
+one session, drifty enough that tracking is the right default.
+
+## Keep the anchor and the applied gain honest
+
+Details that each produced a silent wrong state: the reference branch was once re-picked by
+argmax on *every* datagram while uncalibrated, so a ~1 dB crossover between healthy
+receivers swapped the phase anchor mid-stream; a control-channel retune cleared the anchor
+and let it flip mid-run; and divergence bounds gated only the *proposed* gain, letting the
+applied gain random-walk to −34 dB with `calibrated=true` still asserted. The rules that
+came out: the anchor survives rearm/retune, every anchor change is logged, a rejected
+window **holds** the previous gains (falling back to passthrough mid-stream is itself a
+huge phase step), and the applied gain is floored. A calibration that locks once and then
+holds every window afterwards now WARNs — one field log had `updates` frozen for eleven
+minutes while the line said INFO.
+
+## Capture pre-combine, or the capture answers nothing
+
+The combiner lives in the driver, so every downstream tap — `baseband.auto_record`, iqtap,
+scopes — records a stream with one combiner already baked in, which can never be replayed
+through another. `diversity_capture` taps both branches straight after de-interleave into
+one headerless [cs16](/reference/cs16-format/) file per branch plus a metadata sidecar, and
+enforces the alignment invariant: a datagram missing any branch is dropped from *both*
+files, never written short, because one short write silently desynchronises the pair.
+Verdicts come from the replay harness's decode arms scored by CRC yield — never from EVM.
+
+## Symptom table
+
+| Symptom | Looks like | Actually | Fix / check |
+|---|---|---|---|
+| Calibration never engages on a decodable signal | Weak signal, bad antenna | Fixed ρ threshold diluted by capture bandwidth | Phase-error gates; compare narrowband vs wideband ρ ([#1062](https://github.com/MattCheramie/GopherTrunk/issues/1062)) |
+| Perfect coherence, garbage gains, weak signal | Great link | Common DC offset faking ρ→1 | DC-remove in the correlator |
+| MRC decodes *worse* than one branch | "MRC doesn't work" | Constant inter-branch delay | Look for per-frequency ρ ≈ 1 vs low broadband ρ; align first |
+| Coherence stuck ~0.3–0.5, tracking never helps | Calibration bug | Wideband-scalar limit: antennas metres apart, per-carrier phases differ | Known limitation; per-channel combining after the DDC is the real fix |
+| Operator raises gain to satisfy the combiner | Procedure | A software constant being gamed | Any absolute-dBFS gate is a bug; gate on coherence |
+
+## Provenance
+
+- [#1062](https://github.com/MattCheramie/GopherTrunk/issues/1062) — the IRC RFC and the blind-estimate contamination finding.
+- Operator field logs, 17–19 Aug (X310 / TwinRX): the dBFS gain-staging trap, bandwidth-diluted ρ, the 2.60-sample skew, anchor flips, the frozen-`updates` WARN, and the antenna-swap test that pinned a branch deficit to feedline rather than receiver.

--- a/docs/reference/reciprocal-mixing.md
+++ b/docs/reference/reciprocal-mixing.md
@@ -1,0 +1,88 @@
+---
+slug: reciprocal-mixing
+title: Reciprocal mixing
+entry_type: term
+category: rf-metrics
+description: Reciprocal mixing is receiver self-degradation in which the local oscillator's phase noise convolves onto received signals, raising the in-channel noise floor — a deficit no later DSP stage can remove.
+keywords: reciprocal mixing, phase noise, local oscillator, LO phase noise, noise floor, blocking, close-in dynamic range, oscillator quality, mixer, weak signal reception
+aka: [reciprocal mixing noise]
+autolink: true
+infobox:
+  - { label: Type, value: Receiver impairment }
+  - { label: Cause, value: LO phase noise convolved onto received signals }
+  - { label: Signature, value: Carrier-clean but modulation-degraded }
+  - { label: Fix, value: A cleaner oscillator — not gain, not DSP }
+see_also: [phase-noise, local-oscillator, mixer-rf, intermodulation, desensitization, blocking-dynamic-range, error-vector-magnitude]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Phase_noise
+  - https://en.wikipedia.org/wiki/Superheterodyne_receiver
+---
+
+**Reciprocal mixing** is the receiver degrading *itself*: every signal entering the
+[mixer](/reference/mixer-rf/) is convolved with the
+[local oscillator](/reference/local-oscillator/)'s [phase-noise](/reference/phase-noise/)
+skirts, so each received carrier comes out wearing a copy of the LO's noise
+pedestal.[^wiki] A strong signal near the tuned channel then splashes noise *into* the
+channel — the classic blocking mechanism — but the wanted signal also smears **its own**
+modulation with the LO's close-in jitter. Either way the damage is done at the mixer: the
+noise is multiplied into the samples, and no amount of filtering, decimation, or clever
+demodulation downstream can take it back out.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 150" role="img" aria-label="A spectrum with a strong nearby signal whose skirts, inherited from the local oscillator's phase noise, spread over the weak wanted channel and raise its floor." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="120" x2="430" y2="120" stroke="currentColor" stroke-opacity="0.4"/>
+  <path d="M60 118 C 150 112 200 100 250 60 L 258 30 L 266 60 C 316 100 366 112 430 118" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/>
+  <line x1="120" y1="118" x2="120" y2="82" stroke="currentColor" stroke-width="2"/>
+  <rect x="100" y="76" width="40" height="44" fill="none" stroke="currentColor" stroke-opacity="0.5" stroke-dasharray="3 3"/>
+  <text x="120" y="68" font-size="8.5" fill="currentColor" text-anchor="middle">wanted (weak)</text>
+  <text x="258" y="22" font-size="8.5" fill="currentColor" text-anchor="middle">strong neighbour</text>
+  <text x="185" y="106" font-size="8" fill="currentColor" text-anchor="middle">LO skirts land here</text>
+  <text x="230" y="140" font-size="8.5" fill="currentColor" text-anchor="middle">the neighbour's spread is a mirror of the LO's own phase-noise shape</text>
+</svg>
+<figcaption>The strong signal is clean on the air; the skirts that bury the weak channel are the receiver's own oscillator noise, transferred onto it in the mixer.</figcaption>
+</figure>
+
+## How it works
+
+An ideal LO is a spectral line; mixing with it translates every input frequency crisply. A
+real LO carries phase-noise sidebands falling away from the carrier (measured in dBc/Hz at
+each offset), and mixing is multiplication in time — convolution in frequency — so every
+received signal is smeared by that sideband shape. Two consequences follow:
+
+- **Nearby strong signals raise the floor.** The in-channel noise contributed by a blocker
+  at offset Δf is the blocker's power times the LO's phase noise at Δf (integrated over the
+  channel). This, not front-end overload, is what limits many receivers'
+  close-in [blocking dynamic range](/reference/blocking-dynamic-range/): past a certain
+  blocker level, more RF filtering does not help and more gain makes it worse.
+- **The wanted signal degrades itself.** Close-in LO jitter rotates the constellation
+  symbol-to-symbol. Heavily averaged measurements — a spectrum-analyzer carrier peak, a
+  long FFT — can still look clean while
+  [EVM](/reference/error-vector-magnitude/) and demodulated SNR are poor. **Carrier-clean
+  but modulation-degraded is the reciprocal-mixing signature**, and it is how the effect is
+  told apart from [intermodulation](/reference/intermodulation/) or clipping, which show up
+  in the amplitude domain.
+
+The oscillator's quality — crystal reference, PLL loop bandwidth, synthesizer architecture,
+and in an SDR the sample-clock/PLL configuration at a given rate — sets the effect's size.
+Nothing after the mixer can reduce it.
+
+## Relevance to SDR
+
+Reciprocal mixing is the standing explanation for a class of SDR mysteries where a *capture*
+is bad in a way no DSP setting changes. GopherTrunk's canonical case (issue #764): the same
+TETRA site captured on the same Airspy decoded at ~19.7 dB demod SNR from a 2.5 MS/s
+capture but ~9.5 dB from a 10 MS/s capture — neither clipping, and the wideband FFT carrier
+SNR actually *higher* at 10 MS/s. Decimating the 10 MS/s file 4:1 with an independent
+resampler and replaying it through the proven 2.5 MS/s path reproduced the same ~9.5 dB,
+proving the ~10 dB deficit was baked into the captured samples: front-end phase noise at the
+device's native 10 MS/s clock, not the decoder
+(pinned by `TestDownconverterSNRInvariantAcrossRate` in
+`internal/scanner/ccdecoder/ddc_highrate_test.go`). The practical rules that follow: prefer
+the sample rate at which your hardware's clocking is clean, verify a "weak signal" problem
+against a capture at a different rate before blaming the decoder, and treat
+carrier-clean-but-modulation-degraded as an oscillator finding — a
+[gain](/reference/sdr-gain-overload/) change will not fix it.
+
+## Sources
+
+[^wiki]: [Phase noise](https://en.wikipedia.org/wiki/Phase_noise) — Wikipedia, on oscillator phase-noise sidebands and their transfer onto received signals in mixing (reciprocal mixing).

--- a/docs/reference/self-consistent-test-trap.md
+++ b/docs/reference/self-consistent-test-trap.md
@@ -1,0 +1,102 @@
+---
+slug: self-consistent-test-trap
+title: Self-consistent test trap
+entry_type: concept
+category: testing-delivery
+description: The self-consistent test trap is a round-trip test whose encoder and decoder share the same wrong constant, table, or convention — so the test passes either way and cannot see the very bug it exists to catch.
+keywords: self-consistent test, round-trip test, encode decode test, shared constant bug, test independence, ground truth, reference implementation, synthetic fixtures, protocol testing, false green
+aka: [round-trip trap, self-consistent synthetic trap]
+autolink: true
+infobox:
+  - { label: Type, value: Testing anti-pattern }
+  - { label: Shape, value: Encoder and decoder share the mistaken assumption }
+  - { label: Symptom, value: Green tests, broken against the real world }
+  - { label: Antidote, value: An independent source of truth }
+see_also: [unit-testing, integration-testing, golden-test-vectors, mocking, testing-dsp-without-hardware, tetra-lock-facts]
+related_reading:
+  - { title: "From the Issue Tracker, Part 20: The Self-Consistent Trap — Round-Trip Tests That Validate Their Own Bugs", url: /blog/solution-postmortem/from-the-issue-tracker-20-self-consistent-trap/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Software_testing
+  - https://en.wikipedia.org/wiki/Test_oracle
+---
+
+**The self-consistent test trap** is the failure mode of round-trip testing: encode
+something, decode it back, assert you got the original — and never notice that the encoder
+and decoder *share* the wrong constant, the wrong table, or the wrong convention, so the
+mistake cancels itself out.[^oracle] The test is real, the assertions are strict, the suite
+is green, and the code is wrong in a way this test can never see, because a round trip is
+blind to any error it makes twice. It is a test-oracle problem in disguise: the decoder is
+being graded by an oracle that inherited its own misconceptions.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 150" role="img" aria-label="A round-trip test where data flows from an encoder to a decoder and back to an assertion that passes, while both encoder and decoder draw from the same shared wrong constant underneath." xmlns="http://www.w3.org/2000/svg">
+  <rect x="40" y="30" width="100" height="30" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/>
+  <text x="90" y="49" font-size="9" fill="currentColor" text-anchor="middle">encoder</text>
+  <rect x="200" y="30" width="100" height="30" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/>
+  <text x="250" y="49" font-size="9" fill="currentColor" text-anchor="middle">decoder</text>
+  <rect x="360" y="30" width="80" height="30" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/>
+  <text x="400" y="49" font-size="9" fill="currentColor" text-anchor="middle">PASS ✓</text>
+  <line x1="140" y1="45" x2="196" y2="45" stroke="currentColor" stroke-width="1.2" marker-end="url(#scar)"/>
+  <line x1="300" y1="45" x2="356" y2="45" stroke="currentColor" stroke-width="1.2" marker-end="url(#scar)"/>
+  <rect x="130" y="100" width="180" height="28" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2" stroke-dasharray="4 3"/>
+  <text x="220" y="118" font-size="9" fill="currentColor" text-anchor="middle">shared wrong constant</text>
+  <line x1="105" y1="62" x2="160" y2="98" stroke="currentColor" stroke-width="1" stroke-dasharray="3 3"/>
+  <line x1="335" y1="62" x2="280" y2="98" stroke="currentColor" stroke-width="1" stroke-dasharray="3 3"/>
+  <defs><marker id="scar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>The assertion checks that decode inverts encode — which stays true no matter what the shared constant says. The bug lives below the round trip, where no assertion looks.</figcaption>
+</figure>
+
+## How it bites
+
+The trap recurs wherever a codebase implements both directions of a transform, and
+GopherTrunk's issue tracker documents it in several independent dresses:
+
+- **A skipped step, skipped twice.** The TETRA direct-mode voice path skipped descrambling
+  at colour code 0 — wrong, since colour-0 scrambling is non-identity — but the synthetic
+  tests scrambled *and* descrambled consistently at colour 0, so they passed either way and
+  real on-air traffic decoded at the chance floor, misread as encryption (#1003).
+- **A wrong constant, mirrored in the fake.** A SoapyRemote RPC call used opcode 600 where
+  the protocol says 501 — and the fake test server switched on *the same constant*, so both
+  sides moved together and every unit test passed while real hardware silently ignored the
+  call.
+- **A wrong table, validated against itself.** Placeholder TETRA sync-training constants
+  correlated perfectly against signals synthesized *from those constants*, and never once
+  against real air (#553).
+- **An estimator grading its own homework.** A blind channel estimate contaminated by
+  interference "verified" an interference-rejection combiner on synthetic scenes built from
+  the same estimate's assumptions.
+
+The common thread: the test's ground truth was manufactured by the code under test, so the
+test measured self-consistency — a property even wrong code has.
+
+## Escaping it
+
+The antidote is always the same in structure — **inject an independent source of truth** —
+and comes in escalating strengths:
+
+1. **Independent references.** Decode fixtures produced by a different implementation
+   (a reference codec, another project's decoder, upstream protocol literals), or check
+   constants against the spec's numbers rather than your own header. This is
+   [golden test vectors](/reference/golden-test-vectors/) with the emphasis on *whose gold*.
+2. **Asymmetric fixtures.** Make the encode side unconditional where reality is
+   unconditional — GopherTrunk's regression now scrambles on encode *always*, so a decoder
+   that skips descrambling fails the test the way it fails the air.
+3. **Consumption asserts.** A fake server that requires every request byte to be consumed
+   catches argument-shape drift a switch-on-shared-constants fake cannot.
+4. **Reality gates.** For signal-processing code, no synthetic pass closes the loop: the
+   change is not verified until it works against a capture of the real phenomenon. A green
+   round trip is a necessary condition, never a sufficient one.
+
+## In the bigger picture
+
+Round-trip tests remain excellent — fast, deterministic, great at catching *asymmetric*
+regressions — and none of this argues for deleting them. The discipline is knowing what
+they cannot certify: any property both directions share. [Unit tests](/reference/unit-testing/)
+isolate code from its collaborators; this trap is what happens when a test fails to isolate
+code from its *assumptions*. Budget at least one test per transform whose expected values
+were produced by something that is not your code.
+
+## Sources
+
+[^oracle]: [Test oracle](https://en.wikipedia.org/wiki/Test_oracle) — Wikipedia, on the problem of obtaining correct expected outputs independently of the system under test.

--- a/docs/reference/snapshot-equalization.md
+++ b/docs/reference/snapshot-equalization.md
@@ -1,0 +1,102 @@
+---
+slug: snapshot-equalization
+title: Snapshot equalization
+entry_type: algorithm
+category: equalization
+description: "Snapshot equalization adapts an equalizer's taps continuously but applies only frozen copies of them, so each burst sees a constant filter — the design that makes adaptive equalization safe ahead of a differential decoder."
+keywords: snapshot equalization, frozen taps, SnapshotCMA, SnapshotLMS, differential decoder, phase wander, CMA rotation invariance, burst equalization, TETRA equalizer, adapt and freeze
+aka: [frozen-tap equalization, snapshot CMA, snapshot LMS]
+autolink: true
+infobox:
+  - { label: Type, value: Equalizer application strategy }
+  - { label: Rule, value: "Adapt continuously, apply a frozen snapshot" }
+  - { label: Solves, value: Phase wander ahead of differential decoders }
+  - { label: In GopherTrunk, value: SnapshotCMA (blind) and SnapshotLMS (trained) }
+see_also: [cma-equalizer, lms-algorithm, differential-decoding, adaptive-filter, pi-4-dqpsk, log-likelihood-ratio, equalizer-gotchas]
+related_reading:
+  - { title: "Weak-Signal Engineering, Part 5: The Snapshot Trick — Frozen Taps & Differential Decoders", url: /blog/deep-dives/weak-signal-engineering-05-snapshot-trick/ }
+  - { title: "TETRA End to End, Part 9: The Equalizer and the Voice Path", url: /blog/deep-dives/tetra-end-to-end-09-equalizer-voice-path/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Blind_equalization
+  - https://en.wikipedia.org/wiki/Differential_coding
+---
+
+**Snapshot equalization** is a way of *applying* an adaptive equalizer, not a new way of
+adapting one: a tracking filter adapts continuously in the background, but the signal is
+filtered through a **frozen copy** of the taps, refreshed only between bursts, so every
+burst sees one constant filter.[^wiki] The design exists to resolve a genuine dilemma that
+appears whenever an adaptive equalizer feeds a
+[differential decoder](/reference/differential-decoding/) — and both horns of the dilemma
+score exactly zero.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 150" role="img" aria-label="A tracking equalizer adapts continuously along the top path while frozen snapshots of its taps are copied down at intervals to the apply filter that actually processes each burst." xmlns="http://www.w3.org/2000/svg">
+  <rect x="30" y="26" width="150" height="30" rx="5" fill="none" stroke="currentColor" stroke-width="1.3" stroke-dasharray="4 3"/>
+  <text x="105" y="45" font-size="9" fill="currentColor" text-anchor="middle">tracking taps (adapt always)</text>
+  <rect x="30" y="94" width="150" height="30" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/>
+  <text x="105" y="113" font-size="9" fill="currentColor" text-anchor="middle">applied taps (frozen)</text>
+  <line x1="105" y1="58" x2="105" y2="92" stroke="currentColor" stroke-width="1.2" marker-end="url(#snar)"/>
+  <text x="112" y="78" font-size="8" fill="currentColor">copy between bursts</text>
+  <line x1="182" y1="109" x2="242" y2="109" stroke="currentColor" stroke-width="1.2" marker-end="url(#snar)"/>
+  <g stroke="currentColor" stroke-width="1.2" fill="none">
+    <rect x="246" y="99" width="52" height="20" rx="3"/><rect x="304" y="99" width="52" height="20" rx="3"/><rect x="362" y="99" width="52" height="20" rx="3"/>
+  </g>
+  <text x="330" y="93" font-size="8" fill="currentColor" text-anchor="middle">each burst sees one constant filter</text>
+  <defs><marker id="snar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>The tracking filter follows the channel; the applied filter never moves mid-burst, so the equalizer's phase is constant across every differential pair.</figcaption>
+</figure>
+
+## The dilemma it resolves
+
+A blind [CMA equalizer](/reference/cma-equalizer/)'s cost depends only on output
+*magnitude*, so nothing constrains its output phase: as the taps adapt, the phase wanders.
+A differential decoder recovers each symbol as `s·conj(previous)`, which cancels any
+*constant* rotation perfectly — that is the point of
+[π/4-DQPSK](/reference/pi-4-dqpsk/) — but a phase that moves *between* the two symbols of a
+pair does not cancel; it corrupts every dibit. Measured on real TETRA captures, a
+streaming-adaptive CMA ahead of the differential decoder scored **zero** CRC-valid frames.
+The obvious retreat — freeze the taps permanently — only ever reproduces the unequalized
+baseline, because a frozen filter cannot follow the channel. Adapt-continuously,
+apply-frozen takes the third path: within a burst the applied filter is constant (its
+rotation cancels differentially, the same property that makes any constant offset
+harmless), while between bursts the snapshot refreshes from the tracker. Refresh every
+several bursts' worth of symbols; the single symbol pair straddling a refresh is absorbed by
+the FEC.
+
+## What else it needs to work
+
+Field-tested supporting rules, each learned from a variant that failed:
+
+- **Normalise by a constant, not a local average.** The CMA update scales with |x|³; an EMA
+  that tracks a TDMA downlink's slot-to-slot power swings gives a moving modulus target and
+  the equalizer converges to garbage. Use a cumulative-mean (effectively global) normaliser.
+- **Guard against divergence.** A normalisation transient or deep fade can blow the
+  tracking taps up; re-seed the tracker to pass-through when tap magnitude explodes, so one
+  bad patch cannot poison later snapshots.
+- **Judge by decoded output, never by [EVM](/reference/error-vector-magnitude/).** Blind
+  CMA minimises modulus, not correctness — one unstable variant showed differential EVM
+  collapsing 34% → 8% while CRC-valid frames stayed at zero. CRC yield is the verdict.
+
+These and their siblings are collected in
+[equalizer gotchas](/reference/equalizer-gotchas/).
+
+## Relevance to SDR
+
+GopherTrunk ships two snapshot equalizers (`internal/dsp/equalizer/`).
+**`SnapshotCMA`** — blind, in the TETRA receiver's stream path — roughly *doubled*
+CRC-valid voice frames across a set of marginal captures (410 → 778) and lifted a
+control-channel fixture from ~12% to ~100% clean BSCH, with no loss on clean signal.
+**`SnapshotLMS`** — trained, in the traffic extractor — goes further where framing is
+known: it trains on each burst's
+[midamble](/reference/tetra-training-sequences/) from the raw (pre-differential) symbols,
+freezes, equalizes that one burst, and re-derives the
+[soft-decision](/reference/soft-decision/) LLRs from the equalized symbols. The raw-symbol
+detail matters: the channel is a clean convolution only in the raw symbol domain —
+`s·conj(prev)` is a nonlinear product — so the trained equalizer must run before the
+differential decode. The same discipline transfers to any burst waveform with a
+differential slicer downstream.
+
+## Sources
+
+[^wiki]: [Blind equalization](https://en.wikipedia.org/wiki/Blind_equalization) — Wikipedia, on blind adaptive equalizers and the phase indeterminacy of constant-modulus cost functions.

--- a/docs/reference/soapyremote.md
+++ b/docs/reference/soapyremote.md
@@ -11,7 +11,7 @@ infobox:
   - { label: Type, value: Network transport for SoapySDR }
   - { label: Exposes, value: Any SoapySDR device as a remote device }
   - { label: Server, value: SoapySDRServer daemon }
-see_also: [soapysdr, network-iq-streaming, rtl-tcp, spyserver-protocol, gnuradio]
+see_also: [soapysdr, network-iq-streaming, rtl-tcp, ka9q-radio, spyserver-protocol, gnuradio]
 cite_urls:
   - https://github.com/pothosware/SoapyRemote/wiki
   - https://github.com/pothosware/SoapySDR/wiki

--- a/docs/reference/tetra-dmo-facts.md
+++ b/docs/reference/tetra-dmo-facts.md
@@ -1,0 +1,106 @@
+---
+slug: tetra-dmo-facts
+title: TETRA DMO facts
+entry_type: term
+category: fn-protocol
+description: "TETRA DMO facts are the direct-mode truths GopherTrunk verified on air: the DNB payload geometry, why the DM colour code must be recovered empirically with the network MNI folded in, and why a raw burst detection is not evidence of traffic."
+keywords: tetra dmo, direct mode, DSB, DNB, DM colour code, colour recovery, MNI, slot grid, dnb_qualified, burst correlator false positives, EN 300 396, osmo-tetra-dmo
+aka: [TETRA direct mode facts, DMO bring-up facts]
+infobox:
+  - { label: Type, value: Protocol + DSP facts }
+  - { label: Key rule, value: "DNB payload geometry is −108/+11, not TMO's −115/+19" }
+  - { label: Trap, value: "The DM colour code is not on the air — recover it empirically" }
+  - { label: Noise meter, value: "dnb_total ≈ 18/s on an idle channel; dnb_qualified means traffic" }
+see_also: [tetra-dmo, direct-mode-operation, tetra-lock-facts, tetra-mobile-network-identity, tetra-sync-pdu, tetra-scrambler, tetra-extended-colour-code]
+related_reading:
+  - { title: "From the Issue Tracker, Part 22: Two Pipelines", url: /blog/solution-postmortem/from-the-issue-tracker-22-two-pipelines/ }
+cite_urls:
+  - https://github.com/MattCheramie/GopherTrunk/issues/1003
+  - https://github.com/MattCheramie/GopherTrunk/issues/764
+---
+
+**TETRA DMO facts** are the direct-mode truths that separate a
+[TETRA DMO](/reference/tetra-dmo/) receiver that decodes real radios from one that only
+passes its own tests. GopherTrunk's DMO bring-up (issue
+[#1003](https://github.com/MattCheramie/GopherTrunk/issues/1003)) ran through a false
+"encrypted" verdict, a noise-driven grant storm, and a colour-recovery blind spot before
+clear voice decoded — and each wrong turn left behind a fact worth keeping.
+
+## The DNB payload geometry is −108/+11, and it was measured, not assumed
+
+A Direct Mode Normal Burst's two payload blocks sit at
+`BKN1 [L−108, L)` and `BKN2 [L+11, L+119)` dibits relative to the training-sequence lead
+`L`. The TMO-copied geometry (−115/+19, which osmo-tetra-dmo uses) is measurably worse: on
+a real capture the TCH/S CRC yield has a *sharp* optimum at −108/+11. The general lesson —
+when two layouts are plausible, sweep and let CRC yield vote — recurs throughout DMO work.
+
+## "Encrypted" was a descramble bug: colour 0 still scrambles
+
+The first on-air verdict was "traffic is encrypted": every speech CRC sat at the ~1/256
+chance floor while signalling decoded fine. The radios were in fact clear (TEA0). The bug:
+the DMO voice path inherited a TMO `if colour != 0` shortcut and skipped descrambling at
+colour 0 — but TETRA [scrambling](/reference/tetra-scrambler/) is non-identity at colour 0
+(the LFSR seeds to `0xC0000000`). Synthetic round-trips scrambled *and* descrambled
+consistently, so they passed either way — the
+[self-consistent test trap](/reference/self-consistent-test-trap/). The regression now
+scrambles unconditionally on encode, the way the air does.
+
+## The DM colour code is not recoverable from the air — sweep for it
+
+The SCH/S is always colour-0-scrambled, so it always *reads* colour 0; the colour field's
+exact bit offset in the DSB SCH/H is ambiguous on available captures, and hardcoding a
+guessed offset is the same trap again. GopherTrunk instead recovers the colour empirically:
+decode candidate colours and keep the one that maximises CRC-valid TCH/S, behind a
+**dominance gate** (best ≥ 3× runner-up) that refuses a chance-floor winner. On the
+verifying capture the true colour won 35 CRC-valid frames against ≤3 for every other — an
+unambiguous verdict with no manual override.
+
+## The colour sweep needs the network MNI folded in
+
+On one operator's Motorola network (MCC 250 / MNC 1) the sweep found *no* dominant colour:
+several candidates rose modestly at once — a pattern one radio scrambling with one label
+cannot produce. The cause was upstream of the sweep: TETRA seeds the scrambler from the
+full 30-bit [extended colour code](/reference/tetra-extended-colour-code/), and a sweep
+over colours 0–63 with an implicit MNI of 0 can never reach an MNI≠0 network's seed. The
+DMO SCH/S carries MNI 0 *on air* (correct parsing, not a bug), so the real
+[mobile network identity](/reference/tetra-mobile-network-identity/) must come from
+configuration (`tetra_mcc`/`tetra_mnc`), folded into every candidate seed.
+
+## A raw DNB detection is not evidence of traffic
+
+The DNB correlator is an 11-dibit training match at tolerance 2 under 8 filters, so about
+1 in a thousand random dibit positions matches by chance — **~18 false DNBs per second** on
+an idle channel at TETRA's dibit rate. The first live run granted a recording on a silent
+channel 230 ms after startup. The qualifier that separates traffic from noise is *timing
+structure*: one transmitter on one clock puts every burst on a single residue modulo the
+255-dibit timeslot, while noise is uniform over all 255. GopherTrunk votes DNB leads onto
+that slot grid, latches the agreeing residue (learned, never spec-derived — a wrong
+hardcoded offset would silently kill granting), tracks symbol slips, and drops the latch
+when the train ends so residual noise cannot keep a finished transmission "alive". In the
+decode-status line, **`dnb_total` is a noise meter and `dnb_qualified` is the number that
+means traffic** — a large gap between them is normal, not a fault.
+
+## Operating quirks a DMO listener should expect
+
+DMO grants carry **no talkgroup** (call-control is not decoded), so recordings file under
+group 0. The channel lock is *sticky* across inter-PTT silence — frame-number liveness from
+the [DM-SYNC PDU](/reference/tetra-sync-pdu/), not decode rate, keeps a camped channel from
+being re-hunted. Colour recovery needs ~20 bursts, so a very short first transmission may
+grant before the colour is known (the voice chain re-recovers it retroactively so leading
+speech is kept). And with no release PDU on the air, even a healthy DMO call ends on
+hangtime rather than at the moment of PTT release.
+
+## Symptom table
+
+| Symptom | Looks like | Actually | Fix / check |
+|---|---|---|---|
+| Signalling decodes, speech at CRC chance floor | Encryption | Colour-0 descramble skip, or wrong colour/MNI seed | Descramble unconditionally; sweep colours with the configured MNI ([#1003](https://github.com/MattCheramie/GopherTrunk/issues/1003)) |
+| Colour sweep: several modest winners, none dominant | Weak signal / "guessing broken" | Wrong MNI in every candidate seed | Set `tetra_mcc`/`tetra_mnc` and re-sweep |
+| Grants and recordings on a silent channel | Real traffic | Chance DNB correlations (~18/s) driving the grant | Slot-grid qualification; watch `dnb_qualified`, not `dnb_total` |
+| `dnb_total` climbs steadily with no calls | Decoder bug | Normal correlator false-positive rate | Nothing — that counter is a noise meter |
+| Recording ends "at a timeout", not at PTT release | Teardown bug | DMO has no release PDU; BFI-only calls die at first hangtime | Expect hangtime endings; zero speech frames means a decode problem upstream |
+
+## Provenance
+
+- [#1003](https://github.com/MattCheramie/GopherTrunk/issues/1003) — the DMO thread end to end: the geometry sweep, the colour-0 descramble fix, empirical colour recovery, the MNI fold, the slot-grid grant qualifier, and the on-air captures behind each.
+- [#764](https://github.com/MattCheramie/GopherTrunk/issues/764) — the verification discipline (a green synthetic is not an on-air verdict) that shaped every step above.

--- a/docs/reference/tetra-dmo.md
+++ b/docs/reference/tetra-dmo.md
@@ -12,7 +12,7 @@ infobox:
   - { label: Bursts, value: "DSB (sync) + DNB (normal)" }
   - { label: Physical layer, value: "Reused from TMO (π/4-DQPSK)" }
   - { label: Spec, value: "ETSI EN 300 396-2 §9.4.3" }
-see_also: [tetra, direct-mode-operation, tetra-burst-formats, tetra-logical-channels, tetra-tchs-speech-coding, tetra-scrambler, pi-4-dqpsk, tdma]
+see_also: [tetra, direct-mode-operation, tetra-dmo-facts, tetra-sync-pdu, tetra-mobile-network-identity, tetra-burst-formats, tetra-logical-channels, tetra-tchs-speech-coding, tetra-scrambler, pi-4-dqpsk, tdma]
 cite_urls:
   - https://en.wikipedia.org/wiki/Terrestrial_Trunked_Radio
   - https://en.wikipedia.org/wiki/Direct_mode_operation

--- a/docs/reference/tetra-extended-colour-code.md
+++ b/docs/reference/tetra-extended-colour-code.md
@@ -12,7 +12,7 @@ infobox:
   - { label: Layout, value: "MCC(10) || MNC(14) || colour(6)" }
   - { label: Learned from, value: BSCH / MAC-SYNC }
   - { label: Spec, value: EN 300 392-2 §8.2.5.2 }
-see_also: [tetra-scrambler, color-code, tetra-logical-channels, tetra-mac-pdu, control-channel, tetra, tetra-burst-formats, tetra-cmce-mle-pdu]
+see_also: [tetra-scrambler, tetra-mobile-network-identity, tetra-sync-pdu, color-code, tetra-logical-channels, tetra-mac-pdu, control-channel, tetra, tetra-burst-formats, tetra-cmce-mle-pdu]
 cite_urls:
   - https://en.wikipedia.org/wiki/Terrestrial_Trunked_Radio
   - https://en.wikipedia.org/wiki/Mobile_country_code

--- a/docs/reference/tetra-lock-facts.md
+++ b/docs/reference/tetra-lock-facts.md
@@ -11,7 +11,7 @@ infobox:
   - { label: Key rule, value: Training sequences are counted in bits (22/30/38) }
   - { label: Trap, value: Colour code 0 still scrambles (LFSR seed 0xC0000000) }
   - { label: Proof of sync, value: Correlation hits at exactly 1020-dibit frame cadence }
-see_also: [tetra, tetra-training-sequences, tetra-scrambler, tetra-extended-colour-code, pi-4-dqpsk, gray-code, automatic-frequency-control, dibit, dmr-grant-field-gotchas, signal-signatures]
+see_also: [tetra, tetra-training-sequences, tetra-scrambler, tetra-extended-colour-code, pi-4-dqpsk, gray-code, automatic-frequency-control, afc-alias-traps, tetra-dmo-facts, dibit, dmr-grant-field-gotchas, signal-signatures]
 related_reading:
   - { title: "From the Issue Tracker, Part 17: Placeholder Constants — The TETRA Sync That Never Existed", url: /blog/solution-postmortem/from-the-issue-tracker-17-placeholder-constants/ }
 cite_urls:

--- a/docs/reference/tetra-mobile-network-identity.md
+++ b/docs/reference/tetra-mobile-network-identity.md
@@ -1,0 +1,85 @@
+---
+slug: tetra-mobile-network-identity
+title: TETRA mobile network identity (MNI)
+entry_type: term
+category: trunked-radio
+description: "The TETRA mobile network identity (MNI) is the MCC + MNC pair that globally names a TETRA network — and, because it seeds the scrambler, a receiver that assumes MNI 0 on a real network cannot descramble its traffic."
+keywords: TETRA MNI, mobile network identity, mobile country code, mobile network code, MCC, MNC, extended colour code, scrambler seed, DMO colour recovery, EN 300 392-1
+aka: [MNI, mobile network identity, MCC/MNC]
+autolink: true
+infobox:
+  - { label: Composition, value: "MCC (10 bits) + MNC (14 bits)" }
+  - { label: Names, value: One TETRA network, globally }
+  - { label: Broadcast in, value: SYNC PDU / SYSINFO }
+  - { label: Consequence, value: Part of every scrambler seed except the BSCH's }
+see_also: [tetra, tetra-extended-colour-code, tetra-sync-pdu, tetra-scrambler, tetra-dmo, color-code]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Terrestrial_Trunked_Radio
+  - https://en.wikipedia.org/wiki/Mobile_country_code
+---
+
+**The TETRA mobile network identity** (**MNI**) is the pair of numbers that names a
+[TETRA](/reference/tetra/) network globally: a 10-bit **mobile country code** (MCC), drawn
+from the same ITU country-code plan cellular uses, and a 14-bit **mobile network code**
+(MNC) assigned within that country.[^mcc] Every TETRA cell broadcasts its MNI in the
+[SYNC PDU](/reference/tetra-sync-pdu/) and SYSINFO, radios are provisioned with the MNI of
+their home network, and roaming and authentication decisions key on it. For a listener the
+MNI is more than a label, because TETRA folds it into the physical layer: it is the upper
+24 bits of the scrambling seed.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="The 30-bit extended colour code drawn as three concatenated fields — 10-bit MCC and 14-bit MNC forming the MNI, then the 6-bit colour code — feeding the scrambler seed." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" stroke-width="1.2" fill="none">
+    <rect x="30" y="36" width="120" height="32"/><rect x="150" y="36" width="168" height="32"/><rect x="318" y="36" width="72" height="32"/>
+  </g>
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <text x="90" y="56">MCC (10)</text><text x="234" y="56">MNC (14)</text><text x="354" y="56">colour (6)</text>
+  </g>
+  <path d="M30 76 L318 76" stroke="currentColor" stroke-opacity="0.5"/>
+  <path d="M30 72 L30 80 M318 72 L318 80" stroke="currentColor" stroke-opacity="0.5"/>
+  <text x="174" y="92" font-size="8.5" fill="currentColor" text-anchor="middle">mobile network identity (MNI)</text>
+  <text x="230" y="110" font-size="8.5" fill="currentColor" text-anchor="middle">all 30 bits together: the extended colour code that seeds the scrambler</text>
+</svg>
+<figcaption>The MNI is the network's name and two-thirds of its scrambling seed: same bits, two jobs.</figcaption>
+</figure>
+
+## Why it matters to a receiver
+
+TETRA scrambles every logical channel except the BSCH with the 30-bit
+[extended colour code](/reference/tetra-extended-colour-code/) — `MCC | MNC | colour`,
+MSB-first (EN 300 392-2 §8.2.5.2). The 6-bit colour code distinguishes neighbouring cells
+*within* a network; the MNI distinguishes networks. The practical consequence: knowing the
+colour code alone is not enough to descramble anything. A receiver that searches colour
+codes 0–63 while silently assuming MNI 0 is only exploring 64 seeds out of 2³⁰, and on any
+real network — whose MNI is never 0 — the true seed is simply not in its search space.
+Every candidate then decodes at the CRC chance floor, several rise modestly at once by
+coincidence, and none dominates: a pattern easy to misread as a weak signal or as
+encryption.
+
+In trunked mode this blind spot cannot open, because the always-decodable BSCH hands over
+the real MCC/MNC before anything else is attempted. In
+[direct mode](/reference/tetra-dmo/) it can and did: the DMO SCH/S carries MNI 0 *on air*
+(that is correct parsing, not a bug — both osmo-tetra-dmo and GopherTrunk agree), so
+direct-mode traffic scrambled with a real MNI gives the receiver no over-the-air way to
+learn it. GopherTrunk hit exactly this on a Motorola DMO network operating with MCC 250 /
+MNC 1: its empirical colour recovery — sweep candidate colours, keep the one that maximises
+CRC-valid speech — found no dominant winner until the configured MNI was folded into every
+candidate seed (`baseMNI | c`). The failing-first regression
+(`TestRecoverDMColourCodeNonZeroMNI`) scrambles with the independent osmo-derived seed for
+MCC 250 / MNC 1 / colour 7 and shows the MNI-0 sweep finding nothing while the MNI-folded
+sweep recovers the exact seed.
+
+## Relevance to SDR
+
+For trunked TETRA, GopherTrunk needs no MNI configuration — the cold-start chain
+(BSCH → SYNC PDU → extended colour code) learns it. For DMO, the `tetra_mcc` and
+`tetra_mnc` system-config keys supply the network MNI, which threads through the DMO
+pipeline and voice chain into colour recovery and the descramble seed. Diagnostic rule of
+thumb for any TETRA decode that sits at the chance floor with healthy sync: before
+concluding "encrypted", confirm the full 30-bit seed — colour *and* MNI — is right. The
+DMO-side story, including the colour sweep's dominance gate and the on-air captures that
+exposed the blind spot, is told in [TETRA DMO facts](/reference/tetra-dmo-facts/).
+
+## Sources
+
+[^mcc]: [Mobile country code](https://en.wikipedia.org/wiki/Mobile_country_code) — Wikipedia, on the ITU country-code plan and per-country network codes that TETRA's MCC/MNC fields reuse.

--- a/docs/reference/tetra-sync-pdu.md
+++ b/docs/reference/tetra-sync-pdu.md
@@ -1,0 +1,87 @@
+---
+slug: tetra-sync-pdu
+title: TETRA SYNC PDU
+entry_type: term
+category: trunked-radio
+description: "The TETRA SYNC PDU is the MAC broadcast carried by the always-decodable BSCH: colour code, timeslot, frame and multiframe number, MCC and MNC — everything a cold receiver needs to build the cell's scrambling code and slot grid."
+keywords: TETRA SYNC PDU, DM-SYNC, BSCH, colour code, frame number, multiframe number, timeslot number, MCC, MNC, extended colour code, EN 300 392-2, cold start
+aka: [SYNC PDU, DM-SYNC PDU, TETRA synchronisation PDU]
+autolink: true
+infobox:
+  - { label: Carried by, value: BSCH (block 1 of the sync burst) }
+  - { label: Scrambled with, value: Colour code 0 — always decodable }
+  - { label: Fields, value: "Colour, TN, FN, MN, MCC, MNC" }
+  - { label: Spec, value: ETSI EN 300 392-2 §21.4.4.2 }
+see_also: [tetra, tetra-extended-colour-code, tetra-mobile-network-identity, tetra-logical-channels, tetra-burst-formats, tetra-dmo, tetra-scrambler]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Terrestrial_Trunked_Radio
+  - https://www.etsi.org/deliver/etsi_en/300300_300399/30039202/03.04.01_60/en_30039202v030401p.pdf
+---
+
+**The TETRA SYNC PDU** is the small MAC broadcast that bootstraps every
+[TETRA](/reference/tetra/) receiver: carried on the BSCH (block 1 of the synchronisation
+downlink burst) and always scrambled with colour code 0, it is the one message a cold
+receiver — with no configuration at all — can decode, and it carries exactly the fields
+needed to unlock everything else.[^etsi] Once the SYNC PDU is in hand, the receiver knows
+the cell's scrambling identity and its position in time, and every other
+[logical channel](/reference/tetra-logical-channels/) becomes decodable.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="The 60-bit SYNC PDU laid out as labelled fields: colour code, timeslot number, frame number, multiframe number, a reserved gap, mobile country code, and mobile network code." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" stroke-width="1.2" fill="none">
+    <rect x="20" y="40" width="18" height="30"/><rect x="38" y="40" width="52" height="30"/><rect x="90" y="40" width="24" height="30"/><rect x="114" y="40" width="42" height="30"/><rect x="156" y="40" width="50" height="30"/><rect x="206" y="40" width="52" height="30"/><rect x="258" y="40" width="80" height="30"/><rect x="338" y="40" width="102" height="30"/>
+  </g>
+  <g font-size="8" fill="currentColor" text-anchor="middle">
+    <text x="64" y="59">colour (6)</text><text x="102" y="59">TN</text><text x="135" y="59">FN (5)</text><text x="181" y="59">MN (6)</text><text x="232" y="59">…</text><text x="298" y="59">MCC (10)</text><text x="389" y="59">MNC (14)</text>
+  </g>
+  <text x="20" y="32" font-size="8" fill="currentColor">bit 0</text>
+  <text x="440" y="32" font-size="8" fill="currentColor" text-anchor="end">bit 59</text>
+  <text x="230" y="92" font-size="8.5" fill="currentColor" text-anchor="middle">MCC | MNC | colour concatenate into the 30-bit extended colour code that seeds the scrambler</text>
+</svg>
+<figcaption>Sixty type-1 bits, MSB-first: identity on the right, timing in the middle — the two halves of a cold start.</figcaption>
+</figure>
+
+## What the fields buy
+
+- **Colour code (6 bits), MCC (10), MNC (14)** — concatenated MSB-first these form the
+  30-bit [extended colour code](/reference/tetra-extended-colour-code/) that seeds the
+  [scrambler](/reference/tetra-scrambler/) for every channel *except* the BSCH itself.
+  This is the deliberate bootstrap: the BSCH stays at colour 0 so anyone can read it, and
+  hands over the key to the rest. (Colour 0 is still real scrambling — the seed is
+  non-zero — a fact that has bitten more than one implementation.)
+- **Timeslot number (2 bits), frame number (5), multiframe number (6)** — the cell's
+  position in the [TDMA](/reference/tdma/) hierarchy: 4 timeslots per frame, 18 frames per
+  multiframe, with frame 18 reserved for control. A receiver that decodes two SYNC PDUs and
+  sees FN advancing at the right cadence has proof of a genuine time lock, which makes FN
+  advance a useful *liveness* signal long before payload decodes.
+
+## One layout, two modes
+
+The direct-mode variant — the **DM-SYNC PDU**, broadcast in the DSB of a
+[TETRA DMO](/reference/tetra-dmo/) transmission (EN 300 396-3) — reuses the same field
+layout, so a single parser serves both trunked and direct mode. GopherTrunk's
+`ParseSyncPDU` (`internal/radio/tetra/sync_pdu.go`) decodes the 60 type-1 bits for either;
+its bit offsets are byte-for-byte identical to the osmo-tetra reference parser. Two DMO
+caveats are worth knowing: on air the DMO SCH/S carries MNI 0 (MCC = MNC = 0), so a
+direct-mode network's real [mobile network identity](/reference/tetra-mobile-network-identity/)
+cannot be learned from this PDU; and the DM colour code that scrambles DMO *traffic* is not
+recoverable from the SCH/S either — both must come from configuration or empirical
+recovery.
+
+## Relevance to SDR
+
+The SYNC PDU is the hinge of GopherTrunk's TETRA cold start: hunt a carrier, decode BSCH at
+colour 0, parse the SYNC PDU, form the extended colour code, and only then do
+BNCH/SCH/F/SCH/HD decode — no operator-supplied colour needed. Two hard-won operational
+rules attach to it. First, *confirm identity changes*: a single mis-corrected BSCH can
+decode with a wrong-but-CRC-valid MCC/MNC, so GopherTrunk requires two consecutive agreeing
+SYNC PDUs before rewriting a locked cell identity (the alternative was bogus "cc locked
+mcc=996" flaps). Second, *FN liveness is the lock heartbeat* for camped channels — a DMO
+channel between transmissions stays "locked" on the strength of advancing frame numbers
+rather than decode rate, so inter-PTT silence does not trigger a re-hunt. The bring-up traps
+around this PDU's neighbours are collected in
+[TETRA lock facts](/reference/tetra-lock-facts/).
+
+## Sources
+
+[^etsi]: [ETSI EN 300 392-2 (TETRA Voice plus Data, Air Interface)](https://www.etsi.org/deliver/etsi_en/300300_300399/30039202/03.04.01_60/en_30039202v030401p.pdf) — ETSI, §21.4.4.2 SYNC PDU field layout and §8.2.5.2 scrambling-code formation.


### PR DESCRIPTION
A full inventory sweep of the Field Guide against the recent engineering
work (SnapshotCMA/SnapshotLMS, the DMO pipeline, diversity MRC, the AFC
alias fixes) found none of its core concepts had pages. Add, in house
format and registered in reference.yml:

- Diversity & estimation: maximal-ratio combining, interference rejection
  combining (and why it cannot work blind), channel estimation, coherence
  (normalized cross-correlation, incl. bandwidth dilution and the DC trap).
- DSP: fractional-delay filter (branch alignment), fractionally-spaced
  equalizer, snapshot equalization (frozen taps ahead of differential
  decoders), reciprocal mixing (the #764 carrier-clean-but-degraded
  signature).
- TETRA: SYNC PDU / DM-SYNC field layout, mobile network identity (MNI)
  and the MNI-0 colour-recovery blind spot.
- Data & tooling: cs16 format, ka9q-radio.
- Software dev: the self-consistent test trap (round-trip tests that
  validate their own bugs).
- Field Notes: MRC diversity gotchas, equalizer gotchas, TETRA DMO facts,
  AFC alias traps — symptom tables + provenance in the tetra-lock-facts
  style.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PB2D1u3E8tKQhruiEQCLW3