### PR TITLE
p25: decode Multi-Block Trunking (AMBT) for full system discovery; log hygiene + per-call diagnostic IQ containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,57 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **P25 Multi-Block Trunking (AMBT) decode — full system discovery.** A PDU
+  (DUID 0xC) on the control channel is now decoded as Multi-Block Trunking
+  instead of being dropped as "non-control DUID": the AMBT forms of the
+  Network Status Broadcast (0x3B — the WACN, with explicit downlink AND
+  uplink channels), RFSS Status Broadcast (0x3A) and Adjacent Site Status
+  Broadcast (0x3C — neighbours with explicit uplinks) all feed the same
+  topology model as their TSBK twins. Systems (notably Motorola) that
+  broadcast their neighbour list only in AMBT form went from one neighbour
+  and "No Network Status Broadcast yet" to the full SDRTrunk-equivalent
+  picture. Field layouts cross-checked against SDRTrunk's `AMBTC*` classes
+  and OP25's `process_PDU` (header CRC-CCITT16 + data CRC-32 both enforced).
+- **Systems panel: full site discovery view.** The detail modal now shows
+  NAC and LRA, the camped site's decoded primary + secondary control channels
+  (with uplinks), and neighbour rows carry channel coordinates, downlink AND
+  uplink frequencies, and the CFVA status flags (`[valid,active]`) —
+  matching SDRTrunk's Neighbor Sites output. The `/api/v1/systems` DTO gains
+  `nac`, `lra`, `primary_control_channel`, `secondary_control_channels`, and
+  per-neighbour `lra`/`uplink_hz`/`status`.
+- **Per-call diagnostic IQ containers** (`baseband.voice_iq_debug` +
+  `baseband.auto_record.on_voice_grant`). Every voice call can now write the
+  exact channelised IQ stream its decode chain consumed to a per-call
+  `*_voice.cs16` + `.metadata.json` pair (system/talkgroup/source/frequency/
+  rate; replayable directly), while `on_voice_grant` fires the existing CC
+  auto-recorder for the control-channel context — the metadata + CC-IQ +
+  voice-IQ triplet requested for offline DSP debugging of hopped voice
+  channels. Concurrent calls get independent files; a slow disk truncates
+  the capture (recorded in the sidecar) rather than corrupting it.
+- **`p25_quiet_noncontrol_duid`** per-system config knob silences the
+  per-frame "non-control DUID" debug line (TDU spam on a busy CC). Default
+  off (line keeps firing); log hygiene only.
+
+### Fixed
+- **TSBK Secondary Control Channel Broadcast (0x39) layout.** Channel B was
+  read one byte early (splicing service class A into the channel field),
+  producing a phantom secondary CC; both service classes were dropped. Now
+  matches SDRTrunk's bit offsets, pinned by a literal-vector test.
+- **Adjacent Site Status Broadcast (0x3C)** now captures the CFVA flags and
+  system service class into the decoded struct (previously log-only).
+- **"channel iq power very low" WARN no longer fires against a decoding
+  channel.** A DMR Tier III CC decoding every C_ALOHA at −56 dBFS drew the
+  "carrier likely outside the captured passband" WARN every 5 s — an
+  absolute-dBFS gate contradicting live decode evidence. Any channel whose
+  protocol decode counter advanced recently is healthy whatever its power
+  gauge reads; never-decoding channels keep the repeating WARN.
+- **Wideband per-channel DEBUG diagnostics are parked in steady state.** The
+  per-second "channel decode activity" / "channel iq power" lines (DMR IPSC:
+  one of each per channel per second, forever) now log immediately on a
+  state change and otherwise summarise every 30 s with deltas covering the
+  parked span. Likewise the DMR Tier III per-CSBK debug line: an unchanged
+  repeating Aloha beacon summarises every 10 s with a suppressed-repeat
+  count instead of ~16 identical lines per second.
 - **Startup configuration summary** — the daemon now logs an effective-config
   snapshot at startup (`daemon: config summary` plus one `daemon: system
   config` line per system) so an operator can confirm at a glance which decode

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,26 @@ confirmation before any close-as-completed.
 
 ## DSP / replay notes (so the next investigation starts ahead)
 
+- **P25 discovery: a PDU (DUID 0xC) on the control channel is Multi-Block
+  Trunking, not noise — GT now decodes AMBT (`mbt.go`).** The operator's "only 1
+  neighbor site, no WACN" report was this: their system broadcasts Network
+  Status / Adjacent Status (with explicit downlink+uplink channels) only in AMBT
+  form, and GT logged every one as `non-control DUID duid=PDU` and dropped it.
+  MBT blocks reuse the TSBK 98-dibit trellis coding; the header ends in the same
+  augmented CRC-CCITT16 as a TSBK trailer, the data blocks in a CRC-32 (OP25
+  `process_PDU` is the validation reference; SDRTrunk AMBTC* classes the field
+  layouts). An explicit uplink channel resolves as plain base+spacing —
+  NO tx offset (uplink channel numbers already encode the uplink frequency).
+  Also fixed in the same pass: TSBK SCCB (0x39) read channel B one byte early
+  (`p[4:6]` vs the correct `p[5:7]`) and its round-trip test passed because the
+  assembler encoded the same wrong layout — pin parsers with LITERAL byte
+  vectors cross-checked against an independent decoder, not just round-trips.
+- **Never gate a per-channel health WARN on absolute dBFS when decode evidence
+  exists.** The widebandt2 "channel iq power very low" WARN fired every 5 s on a
+  Tier III CC decoding every C_ALOHA at −56 dBFS. Any channel whose decode
+  counter advanced within `lowPowerDecodeGrace` is healthy whatever its power
+  gauge reads. Same family as the MRC dBFS-gate lesson below.
+
 - `gophertrunk replay -tune-hz` uses the single-channel
   `ccdecoder.Downconverter` (`internal/scanner/ccdecoder/ddc.go`), **not** the
   multi-tap wideband `DDCBank` (`internal/dsp/tuner/ddc.go`). They are separate

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -968,6 +968,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 			LTRManchesterMode:       sys.LTRManchesterMode,
 			P25Phase1DemodMode:      sys.P25Phase1DemodMode,
 			P25Phase1SoftDecision:   sys.P25Phase1SoftDecision,
+			P25QuietNonControlDUID:  sys.P25QuietNonControlDUID,
 			P25Phase2TrellisMode:    sys.P25Phase2TrellisMode,
 			P25Phase2RSMode:         sys.P25Phase2RSMode,
 			P25Phase2InterleaveMode: sys.P25Phase2InterleaveMode,
@@ -2333,6 +2334,11 @@ func (d *Daemon) buildComposer(cfg config.Config, log *slog.Logger) error {
 				Enabled:  cfg.Recordings.Equalizer.Enabled,
 				Taps:     cfg.Recordings.Equalizer.Taps,
 				StepSize: cfg.Recordings.Equalizer.StepSize,
+			},
+			VoiceIQDebug: composer.VoiceIQDebugConfig{
+				Enabled:  cfg.Baseband.VoiceIQDebug.Enabled,
+				Dir:      cfg.Baseband.VoiceIQDebug.Dir,
+				MaxBytes: int64(cfg.Baseband.VoiceIQDebug.MaxMB) << 20,
 			},
 		})
 		if err != nil {

--- a/cmd/gophertrunk/iqautorecord.go
+++ b/cmd/gophertrunk/iqautorecord.go
@@ -243,7 +243,7 @@ func (a *iqAutoRecorder) Run(ctx context.Context, sub *events.Subscription) erro
 		"cooldown", a.cooldown, "on_concurrent_calls", a.cfg.OnConcurrentCalls,
 		"on_no_voice_device", a.cfg.OnNoVoiceDevice,
 		"on_encrypted", a.cfg.OnEncrypted, "on_emergency", a.cfg.OnEmergency,
-		"on_cc_sync_loss", a.cfg.OnCCSyncLoss)
+		"on_cc_sync_loss", a.cfg.OnCCSyncLoss, "on_voice_grant", a.cfg.OnVoiceGrant)
 	for {
 		select {
 		case <-ctx.Done():
@@ -346,6 +346,13 @@ func (a *iqAutoRecorder) classify(g trunking.Grant, concurrent int) string {
 		return "encrypted"
 	case a.cfg.OnConcurrentCalls > 0 && concurrent >= a.cfg.OnConcurrentCalls:
 		return "concurrent"
+	case a.cfg.OnVoiceGrant:
+		// Per-grant control-channel context capture — pairs with
+		// baseband.voice_iq_debug's per-call voice capture to form the
+		// diagnostic-container triplet. The shared cooldown keeps a grant
+		// burst from spawning a capture storm; the CC context of
+		// back-to-back grants overlaps anyway.
+		return "voice_grant"
 	default:
 		return ""
 	}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1124,6 +1124,10 @@ trunking:
   #     # p25_phase1_soft_decision: "on"  # per-bit soft Viterbi on the
   #     #                               # C4FM TSBK trellis (marginal-
   #     #                               # signal gain; C4FM sites only)
+  #     # p25_quiet_noncontrol_duid: true # silence the per-frame
+  #     #                               # "non-control DUID" debug line
+  #     #                               # (TDU spam on a busy CC); decode
+  #     #                               # behaviour unchanged
   #
   #   - name: "Legacy-P25-Phase2"
   #     protocol: p25
@@ -1494,6 +1498,26 @@ broadcast:
 #                                #   loses sync — captures the re-acquisition IQ,
 #                                #   ideal for debugging sync-loss / slow warm-up
 #                                #   lock (pair with tap: ddc for small files)
+#     on_voice_grant: true       # fire a CC-context capture on every voice grant
+#                                #   (rate-limited by cooldown) — the control-
+#                                #   channel half of the per-call diagnostic
+#                                #   container; pair with voice_iq_debug below
+#
+#   # Per-call voice-channel IQ debug captures — the voice half of the
+#   # "diagnostic container" workflow. Every voice call writes the exact
+#   # channelised IQ stream its decode chain consumed to
+#   # <dir>/<UTC>_<system>_tg<group>_<freq>_<rate>_voice.cs16 plus a
+#   # .metadata.json sidecar (system/talkgroup/source/frequency/rate), so a
+#   # hopped voice channel's raw samples are on disk the moment a decode
+#   # sounds wrong — replayable directly via `gophertrunk replay` / siglab.
+#   # Concurrent calls each get their own files. Heavy on disk when the
+#   # voice taps run at a full SDR rate (physical voice tuner) rather than
+#   # the channelised 48 kHz of a wideband-derived virtual tap.
+#   voice_iq_debug:
+#     enabled: true
+#     dir: "../iq/voice-debug/"
+#     max_mb: 512                # per-call size cap (0 = default 512 MB);
+#                                #   the sidecar notes truncation when hit
 
 # User-interface tabs. Every navigation tab shows by default in both the
 # web UI and the terminal TUI. If you run GopherTrunk for one main task

--- a/docs/specs/p25-tsbk-opcodes.md
+++ b/docs/specs/p25-tsbk-opcodes.md
@@ -100,3 +100,28 @@ decoder parses it (`ParseUnitToUnitAnswerRequest`) and publishes a
 standard one: a field decode of a Motorola 0x05 with the standard layout
 produced garbage IDs (`src=0`, `target=0x3C0000`), so vendor 0x05 is left
 unhandled until its real layout is reversed.
+
+## Multi-Block Trunking (MBT / AMBT) — PDUs on the control channel
+
+A P25 control channel also carries trunking signalling in **PDU frames**
+(DUID 0xC): a 12-octet PDU header block plus N data blocks, each 196 bits
+with the *same* ½-rate trellis + interleave channel coding as a TSBK block.
+Two formats matter (OP25 `p25p1_fdma::process_PDU` is the validation
+reference; SDRTrunk's `AMBTC*` classes pin the field layouts):
+
+- **AMBT** (Alternate MBT, format `0x17`, SAP 61): the opcode rides in header
+  octet 7, and header octets 3-5 / 8-9 carry message fields. Decoded by
+  `mbt.go` → `dispatchMBT` for `NET_STS_BCST` (0x3B — the WACN, plus explicit
+  downlink *and* uplink channels), `RFSS_STS_BCST` (0x3A) and `ADJ_STS_BCST`
+  (0x3C — neighbours with explicit uplinks). Many systems (notably Motorola)
+  broadcast most or all of their neighbour list **only** this way.
+- **Unconfirmed MBT** (format `0x15`): opcode in data block 0; layouts differ.
+  Recognised and counted, not yet decoded.
+
+Validation: the header ends in the same augmented CRC-CCITT16 as a TSBK
+trailer (`framing.CRCCCITTAugmented(header) == 0`); the concatenated data
+blocks end in a 4-octet CRC-32 (poly 0x04C11DB7, init 0, final XOR — see
+`mbtCRC32`). An **explicit uplink channel number resolves as plain
+base + number × spacing with NO transmit offset** — the uplink channel number
+already encodes the uplink frequency (verified against SDRTrunk output:
+channel 2-3430 on a 440 MHz/6.25 kHz band = 461.4375 MHz).

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -220,6 +220,14 @@ func (s *Server) overlayTopology(dto *SystemDTO) {
 	if snap, ok := tp.Topology(dto.Name); ok {
 		dto.Neighbors = neighborsFromTopology(snap)
 		dto.FrequencyBands = bandPlanFromTopology(snap)
+		dto.PrimaryControlChannel, dto.SecondaryControlChannels = siteChannelsFromTopology(snap)
+		if snap.NAC != 0 {
+			dto.NAC = snap.NAC
+			dto.NACHex = trunking.IDHex(uint64(snap.NAC))
+		}
+		if snap.LRA != 0 {
+			dto.LRA = snap.LRA
+		}
 		// TETRA has no WACN/RFSS/Site; its live identity (MCC/MNC/Location Area +
 		// colour code) rides the same topology snapshot. Surface it so the Systems
 		// panel can render a protocol-appropriate identity block instead of four

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -124,6 +124,20 @@ type SystemDTO struct {
 	RFSSHex     string `json:"rfss_hex,omitempty"`
 	SiteHex     string `json:"site_hex,omitempty"`
 
+	// NAC and LRA of the camped site, decoded live (P25). Zero until heard.
+	NAC    uint16 `json:"nac,omitempty"`
+	NACHex string `json:"nac_hex,omitempty"`
+	LRA    uint8  `json:"lra,omitempty"`
+
+	// PrimaryControlChannel / SecondaryControlChannels are the camped site's
+	// advertised control channels (RFSS/Network Status and Secondary Control
+	// Channel broadcasts), overlaid live from the topology snapshot with the
+	// same band-plan frequency resolution as the network report. Nil/empty
+	// until decoded. Surfaced so the Systems panel matches SDRTrunk's
+	// "Current Site" block instead of showing only the configured frequency.
+	PrimaryControlChannel    *SiteChannelDTO  `json:"primary_control_channel,omitempty"`
+	SecondaryControlChannels []SiteChannelDTO `json:"secondary_control_channels,omitempty"`
+
 	// TETRA network identity decoded live from the control channel
 	// (MLE-SYSINFO / D-NWRK-BROADCAST), overlaid from the SiteTracker topology —
 	// the TETRA analogue of WACN/SystemID/RFSS/Site. TETRA has no WACN/RFSS/Site
@@ -197,12 +211,61 @@ type SystemDTO struct {
 type NeighborDTO struct {
 	RFSS          uint8  `json:"rfss"`
 	Site          uint8  `json:"site"`
+	LRA           uint8  `json:"lra,omitempty"`
 	ChannelID     uint8  `json:"channel_id,omitempty"`
 	ChannelNumber uint16 `json:"channel_number,omitempty"`
 	DownlinkHz    uint32 `json:"downlink_hz,omitempty"`
 	UplinkHz      uint32 `json:"uplink_hz,omitempty"`
 	RFSSHex       string `json:"rfss_hex,omitempty"`
 	SiteHex       string `json:"site_hex,omitempty"`
+	// Status is the human-readable CFVA flag summary from the adjacent-status
+	// broadcast (e.g. "valid,active"); empty when never observed, "none" when
+	// observed all-clear.
+	Status string `json:"status,omitempty"`
+}
+
+// SiteChannelDTO is one advertised control channel of the camped site
+// (primary or secondary), with band-plan-resolved frequencies.
+type SiteChannelDTO struct {
+	ChannelID     uint8  `json:"channel_id,omitempty"`
+	ChannelNumber uint16 `json:"channel_number,omitempty"`
+	DownlinkHz    uint32 `json:"downlink_hz,omitempty"`
+	UplinkHz      uint32 `json:"uplink_hz,omitempty"`
+}
+
+// siteChannelsFromTopology extracts the camped site's primary and secondary
+// control channels from a topology snapshot, reusing ReportFromTopology so the
+// frequency resolution matches the network report exactly.
+func siteChannelsFromTopology(snap *trunking.TopologySnapshot) (*SiteChannelDTO, []SiteChannelDTO) {
+	if snap == nil {
+		return nil, nil
+	}
+	r := trunking.ReportFromTopology(snap)
+	if len(r.Sites) == 0 {
+		return nil, nil
+	}
+	site := r.Sites[0]
+	var primary *SiteChannelDTO
+	if p := site.PrimaryCC; p.ChannelID != 0 || p.ChannelNumber != 0 || p.DownlinkHz != 0 {
+		primary = &SiteChannelDTO{
+			ChannelID: p.ChannelID, ChannelNumber: p.ChannelNumber,
+			DownlinkHz: p.DownlinkHz, UplinkHz: p.UplinkHz,
+		}
+	}
+	var secondary []SiteChannelDTO
+	for _, c := range site.SecondaryCC {
+		secondary = append(secondary, SiteChannelDTO{
+			ChannelID: c.ChannelID, ChannelNumber: c.ChannelNumber,
+			DownlinkHz: c.DownlinkHz, UplinkHz: c.UplinkHz,
+		})
+	}
+	sort.Slice(secondary, func(i, j int) bool {
+		if secondary[i].ChannelID != secondary[j].ChannelID {
+			return secondary[i].ChannelID < secondary[j].ChannelID
+		}
+		return secondary[i].ChannelNumber < secondary[j].ChannelNumber
+	})
+	return primary, secondary
 }
 
 // neighborsFromTopology converts a live topology snapshot's neighbours into
@@ -222,12 +285,14 @@ func neighborsFromTopology(snap *trunking.TopologySnapshot) []NeighborDTO {
 		out = append(out, NeighborDTO{
 			RFSS:          n.RFSS,
 			Site:          n.Site,
+			LRA:           n.LRA,
 			ChannelID:     n.Channel.ChannelID,
 			ChannelNumber: n.Channel.ChannelNumber,
 			DownlinkHz:    n.Channel.DownlinkHz,
 			UplinkHz:      n.Channel.UplinkHz,
 			RFSSHex:       trunking.IDHex(uint64(n.RFSS)),
 			SiteHex:       trunking.IDHex(uint64(n.Site)),
+			Status:        n.StatusFlags,
 		})
 	}
 	sort.Slice(out, func(i, j int) bool {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -222,6 +222,26 @@ type BasebandConfig struct {
 	// self-describing (`.metadata.json` sidecar) so they drop straight into
 	// `replay`/siglab — the event-driven debugging hook the operator asked for.
 	AutoRecord BasebandAutoRecordConfig `yaml:"auto_record"`
+	// VoiceIQDebug writes each voice call's channelised IQ (exactly the
+	// stream the voice chain decodes) plus a self-describing metadata
+	// sidecar to per-call files — the voice half of the "diagnostic
+	// container" workflow (pair with auto_record.on_voice_grant for the
+	// control-channel half). Off by default; heavy on disk when the voice
+	// taps run at a full SDR rate rather than a channelised 48 kHz.
+	VoiceIQDebug VoiceIQDebugConfig `yaml:"voice_iq_debug"`
+}
+
+// VoiceIQDebugConfig configures per-call voice-channel IQ debug captures.
+type VoiceIQDebugConfig struct {
+	// Enabled turns the per-call voice IQ tee on. When false: zero cost.
+	Enabled bool `yaml:"enabled"`
+	// Dir is the directory per-call captures (and their metadata sidecars)
+	// are written into. Required when Enabled.
+	Dir string `yaml:"dir"`
+	// MaxMB caps one call's capture size in megabytes; the capture stops
+	// (and the sidecar notes truncation) when reached, so a stuck call or a
+	// full-SDR-rate tap cannot fill the disk. 0 defaults to 512 MB.
+	MaxMB int `yaml:"max_mb"`
 }
 
 // BasebandAutoRecordConfig configures event-triggered raw-IQ capture of the
@@ -255,6 +275,13 @@ type BasebandAutoRecordConfig struct {
 	OnEncrypted bool `yaml:"on_encrypted"`
 	// OnEmergency fires on an emergency-flagged grant.
 	OnEmergency bool `yaml:"on_emergency"`
+	// OnVoiceGrant fires a control-channel capture on EVERY voice grant, so a
+	// per-call voice-IQ debug capture (baseband.voice_iq_debug) has a paired
+	// control-channel context capture — the "diagnostic container" workflow:
+	// grant metadata + CC IQ + voice-channel IQ per call. Rate-limited by the
+	// shared Cooldown, so a burst of grants shares one CC capture (the CC
+	// context overlaps anyway).
+	OnVoiceGrant bool `yaml:"on_voice_grant"`
 	// OnCCSyncLoss fires when a locked control channel suddenly loses sync
 	// (events.KindCCLost, which only fires after a genuine lock — never for a
 	// hunt that never locked). It captures the seconds AFTER the loss, i.e. the
@@ -1462,6 +1489,15 @@ type SystemConfig struct {
 	// every block). C4FM only — CQPSK/LSM sites decode hard regardless.
 	// Ignored for non-P25-Phase-1 protocols.
 	P25Phase1SoftDecision string `yaml:"p25_phase1_soft_decision"`
+	// P25QuietNonControlDUID silences the per-frame "non-control DUID"
+	// debug log line on this system's P25 Phase 1 control channel. The
+	// line fires for every TDU (and other non-TSDU) frame the CC decodes —
+	// many times per second on a busy system — and buries a debug log an
+	// operator is using to chase something else. Default false keeps the
+	// line (it is genuinely useful when first identifying an unknown
+	// carrier); set true to quiet it. Diagnostic-log hygiene only: decode
+	// behaviour is unchanged either way.
+	P25QuietNonControlDUID bool `yaml:"p25_quiet_noncontrol_duid"`
 	// DMRInterleavedVoice overrides the 2-slot interleaved voice decoder.
 	// A DMR carrier is 2-slot TDMA, so the demodulated stream interleaves
 	// both timeslots' bursts; the interleaved decoder pulls each call's own

--- a/internal/config/config_validate.go
+++ b/internal/config/config_validate.go
@@ -824,6 +824,14 @@ func (c Config) validateBaseband() []error {
 		// No automatic trigger set is allowed: it leaves the feature armed for
 		// the manual API trigger only (still a valid, useful configuration).
 	}
+	if v := c.Baseband.VoiceIQDebug; v.Enabled {
+		if v.Dir == "" {
+			errs = append(errs, fmt.Errorf("baseband.voice_iq_debug: dir required when enabled"))
+		}
+		if v.MaxMB < 0 {
+			errs = append(errs, fmt.Errorf("baseband.voice_iq_debug: max_mb must not be negative"))
+		}
+	}
 	return errs
 }
 

--- a/internal/configbuilder/advanced.go
+++ b/internal/configbuilder/advanced.go
@@ -18,7 +18,7 @@ var AdvancedFields = map[string][]string{
 		// LTR
 		"LTRFCSMode", "LTRManchesterMode",
 		// P25 Phase 1
-		"P25Phase1DemodMode",
+		"P25Phase1DemodMode", "P25QuietNonControlDUID",
 		// P25 Phase 2
 		"P25Phase2TrellisMode", "P25Phase2RSMode", "P25Phase2InterleaveMode",
 		"P25Phase1SoftDecision",

--- a/internal/configbuilder/fieldmeta.go
+++ b/internal/configbuilder/fieldmeta.go
@@ -217,6 +217,7 @@ var fieldMetas = map[string]FieldMeta{
 	"SystemConfig.P25Phase2Equalizer":      {Label: "P25 Ph2 equalizer", Help: "Blind CMA adaptive equalizer on the traffic-channel symbol stream; removes residual inter-symbol interference (multipath / timing / RRC mismatch) ahead of the differential decode. off (default) or on. Helps ISI-limited channels; neutral on purely AWGN-limited ones. P25 Phase 2 only."},
 	"SystemConfig.P25Phase2DCBlock":        {Label: "P25 Ph2 DC block", Help: "DC-removal high-pass on the traffic-channel receiver; strips a zero-IF front end's LO-leakage spur from an on-channel voice DDC (the same stage the P25 Phase 1 and TETRA voice receivers run). off (default) or on. P25 Phase 2 only."},
 	"SystemConfig.P25Phase1SoftDecision":   {Label: "P25 Ph1 soft decision", Help: "Per-bit soft Viterbi on the control channel's TSBK trellis, driven by the C4FM 4-level soft symbols; recovers coding gain the hard slicer discards on marginal signals (CRC still corroborates every block). off (default) or on. C4FM sites only — CQPSK/LSM decodes hard regardless. P25 Phase 1 only."},
+	"SystemConfig.P25QuietNonControlDUID":  {Label: "P25 quiet non-control DUID", Help: "Silence the per-frame 'non-control DUID' debug log line (TDU spam on a busy control channel). Log hygiene only — decode behaviour is unchanged. P25 Phase 1 only."},
 	"SystemConfig.P25Phase2ClockMode":      {Label: "P25 Ph2 clock", Help: "Symbol-timing recovery: gardner (default, live SDR) or naive (fixtures). P25 Phase 2 only."},
 	"SystemConfig.DMRInterleavedVoice":     {Label: "DMR interleaved voice", Help: "Override the 2-slot interleaved DMR voice decoder. Unset = on for DMR Tier II conventional & Tier III (single-slot only for Tier I direct-mode); set true/false to force. DMR only."},
 	"SystemConfig.DMRColorCode":            {Label: "DMR colour code", Help: "Pin a conventional DMR (IPSC / linked-repeater) system to one colour code (0-15). Bursts on any other colour code are dropped, keeping a co-channel system off the call log. Unset = accept every colour code (read off air). Conventional DMR (dmr-tier2 / dmr-tier1) only."},
@@ -458,8 +459,14 @@ var fieldMetas = map[string]FieldMeta{
 	"BasebandAutoRecordConfig.OnEncrypted":       {Label: "On encrypted", Help: "Fire on a grant flagged encrypted."},
 	"BasebandAutoRecordConfig.OnEmergency":       {Label: "On emergency", Help: "Fire on an emergency-flagged grant."},
 	"BasebandAutoRecordConfig.OnCCSyncLoss":      {Label: "On CC sync loss", Help: "Fire when a locked control channel suddenly loses sync — captures the re-acquisition IQ, ideal for debugging sync-loss / slow warm-up lock. Pair with the ddc tap for small files."},
+	"BasebandAutoRecordConfig.OnVoiceGrant":      {Label: "On voice grant", Help: "Fire a control-channel context capture on every voice grant (rate-limited by the cooldown) — the CC half of the per-call diagnostic container; pair with baseband.voice_iq_debug for the voice-channel half."},
 	"BasebandAutoRecordConfig.Tap":               {Help: "What IQ to capture: wideband (default, full-rate SDR — large files) or ddc (narrowband channelised stream at the pipeline rate, e.g. 144 kHz for TETRA — far smaller and directly replayable).", Options: opts("", "wideband (default)", "ddc", "ddc")},
 	"BasebandAutoRecordConfig.Decimate":          {Help: "Software-decimation factor for the wideband tap: record at SDR-rate / N (anti-aliased), shrinking the file by N. 0/1 = full rate. The fix for a radio (e.g. USRP B210) whose hardware sample-rate floor is far above the bandwidth a channel needs. Only valid with tap: wideband."},
+
+	"BasebandConfig.VoiceIQDebug": {Label: "Voice IQ debug", Help: "Per-call voice-channel IQ debug captures: each voice call's exact channelised IQ stream plus a metadata sidecar, written to per-call files — the voice half of the diagnostic-container workflow (pair with auto_record's on_voice_grant)."},
+	"VoiceIQDebugConfig.Enabled":  {Help: "Turn per-call voice-channel IQ captures on. Off costs nothing."},
+	"VoiceIQDebugConfig.Dir":      {Help: "Directory per-call captures (and their .metadata.json sidecars) are written into."},
+	"VoiceIQDebugConfig.MaxMB":    {Label: "Max MB", Help: "Per-call capture size cap in megabytes; the sidecar notes truncation when hit. 0 = default 512 MB."},
 
 	// ---- Paging ------------------------------------------------------------
 	"PagingConfig.POCSAG":               {Label: "POCSAG", Help: "POCSAG channels, each pinning one SDR to a paging frequency."},

--- a/internal/configbuilder/webschema_test.go
+++ b/internal/configbuilder/webschema_test.go
@@ -61,12 +61,16 @@ var webRoundTripAllow = map[string][]string{
 	// Event-driven raw-IQ auto-record (baseband.auto_record) — a debug/research
 	// capture hook. Round-trips through the BasebandConfig index signature;
 	// editable in the TUI and raw YAML. A bespoke web editor is a follow-up.
-	"BasebandConfig": {"AutoRecord"},
+	"BasebandConfig": {"AutoRecord", "VoiceIQDebug"},
 	"BasebandAutoRecordConfig": {
 		"Enabled", "Dir", "Format", "Seconds", "Cooldown",
 		"OnConcurrentCalls", "OnNoVoiceDevice", "OnEncrypted", "OnEmergency",
-		"OnCCSyncLoss", "Decimate",
+		"OnCCSyncLoss", "OnVoiceGrant", "Decimate",
 	},
+	// Per-call voice-channel IQ debug captures (baseband.voice_iq_debug) —
+	// same debug/research posture as auto_record: round-trips through the
+	// BasebandConfig index signature; editable in the TUI and raw YAML.
+	"VoiceIQDebugConfig": {"Enabled", "Dir", "MaxMB"},
 }
 
 // TestConfigSchemaCoveredByWebBuilder fails when a config.Config field has no

--- a/internal/radio/dmr/tier3/control.go
+++ b/internal/radio/dmr/tier3/control.go
@@ -66,6 +66,13 @@ type ControlChannel struct {
 	// handleBroadcast. Single-threaded with the IQ pump.
 	chanFreqLogged bool
 
+	// CSBK debug-log parking (handleCSBK): an unchanged repeat of the
+	// last-logged (opcode, FID, cc) is summarised at csbkRepeatLogInterval
+	// instead of logged per burst. Single-threaded with the IQ pump.
+	lastCSBKLog csbkLogKey
+	csbkLogAt   time.Time
+	csbkRepeats int
+
 	// topo accumulates the system topology (identity + adjacent sites) for the
 	// hunt/discovery layer; read via Topology().
 	topo topologyModel
@@ -206,6 +213,18 @@ func (c *ControlChannel) decodeInfoBlock(b *dmr.Burst) ([]byte, bool) {
 	return InfoBitsToBytes(bits), true
 }
 
+// csbkLogKey identifies a CSBK for debug-log parking: the same
+// (opcode, FID, cc) repeating is one beacon, not new information.
+type csbkLogKey struct {
+	opcode CSBKOpcode
+	fid    uint8
+	cc     uint8
+}
+
+// csbkRepeatLogInterval is how often an unchanged repeating CSBK (the idle
+// Aloha beacon) is summarised in the debug log.
+const csbkRepeatLogInterval = 10 * time.Second
+
 func (c *ControlChannel) handleCSBK(cc uint8, csbk CSBK) {
 	// Dispatch on FID before opcode: a vendor CSBK is routed to the
 	// vendor handler so its opcode is not misread against the
@@ -214,11 +233,27 @@ func (c *ControlChannel) handleCSBK(cc uint8, csbk CSBK) {
 		c.handleVendorCSBK(vendor, cc, csbk)
 		return
 	}
-	// Log every standard CSBK so the control-channel stream is visible
-	// in the debug log the way a reference decoder (dsd-neo) shows it —
-	// the dominant Aloha beacon is otherwise consumed silently once the
-	// CC is locked, which made GopherTrunk look idle.
-	c.log.Debug("dmr/tier3: csbk", "opcode", csbk.Opcode, "fid", csbk.FID, "cc", cc)
+	// Log standard CSBKs so the control-channel stream is visible in the
+	// debug log the way a reference decoder (dsd-neo) shows it — the
+	// dominant Aloha beacon is otherwise consumed silently once the CC is
+	// locked, which made GopherTrunk look idle. But an idle CC repeats the
+	// SAME beacon ~16×/s forever, which buried a debug log in thousands of
+	// identical lines (field report: 2177 C_ALOHA lines in two minutes).
+	// Park the repeats: any opcode/FID/cc CHANGE logs immediately; an
+	// unchanged repeat logs at csbkRepeatLogInterval with the suppressed
+	// count, so the stream stays visibly alive without the flood.
+	key := csbkLogKey{opcode: csbk.Opcode, fid: csbk.FID, cc: cc}
+	if key != c.lastCSBKLog || c.now().Sub(c.csbkLogAt) >= csbkRepeatLogInterval {
+		if c.csbkRepeats > 0 {
+			c.log.Debug("dmr/tier3: csbk", "opcode", csbk.Opcode, "fid", csbk.FID, "cc", cc,
+				"repeats_suppressed", c.csbkRepeats)
+		} else {
+			c.log.Debug("dmr/tier3: csbk", "opcode", csbk.Opcode, "fid", csbk.FID, "cc", cc)
+		}
+		c.lastCSBKLog, c.csbkLogAt, c.csbkRepeats = key, c.now(), 0
+	} else {
+		c.csbkRepeats++
+	}
 	switch csbk.Opcode {
 	case OpAloha:
 		sysID := ParseAloha(csbk.Payload).SystemID

--- a/internal/radio/dmr/tier3/csbk_log_parking_test.go
+++ b/internal/radio/dmr/tier3/csbk_log_parking_test.go
@@ -1,0 +1,55 @@
+package tier3
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// TestCSBKDebugLogParksRepeats pins the Tier III debug-log parking: an idle
+// CC repeating the same C_ALOHA ~16×/s must not produce one debug line per
+// burst (field report: 2177 identical lines in two minutes). The first
+// occurrence logs immediately, unchanged repeats are summarised at
+// csbkRepeatLogInterval with the suppressed count, and any opcode change
+// logs immediately again.
+func TestCSBKDebugLogParksRepeats(t *testing.T) {
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	bus := events.NewBus(64)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+	go func() {
+		for range sub.C {
+		}
+	}()
+	clock := time.Unix(1_700_000_000, 0)
+	cc := New(Options{Bus: bus, Log: log, SystemName: "T3", FrequencyHz: 440_262_500,
+		Now: func() time.Time { return clock }})
+
+	aloha := CSBK{Opcode: OpAloha}
+	// 200 identical Alohas over ~12 s of virtual time (60 ms apart).
+	for i := 0; i < 200; i++ {
+		cc.handleCSBK(0, aloha)
+		clock = clock.Add(60 * time.Millisecond)
+	}
+	lines := strings.Count(buf.String(), "dmr/tier3: csbk")
+	// 12 s span at a 10 s summary cadence: first line + ~1 summary.
+	if lines > 3 {
+		t.Fatalf("csbk debug lines = %d over 200 identical beacons, want <= 3 (parked)", lines)
+	}
+	if !strings.Contains(buf.String(), "repeats_suppressed") {
+		t.Fatal("expected a parked summary line carrying repeats_suppressed")
+	}
+
+	// An opcode change must log immediately.
+	buf.Reset()
+	cc.handleCSBK(0, CSBK{Opcode: OpAhoy})
+	if !strings.Contains(buf.String(), "dmr/tier3: csbk") {
+		t.Fatal("opcode change did not log immediately")
+	}
+}

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"math"
 	"sort"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -51,6 +52,10 @@ type ControlChannel struct {
 	carrierOffsetHz func() float64
 	locked          bool
 	lastNAC         uint16
+	// quietNonControlDUID suppresses the per-frame "non-control DUID"
+	// debug line (Options.QuietNonControlDUID) — an operator-facing log
+	// hygiene knob for busy control channels.
+	quietNonControlDUID bool
 	// lastSiteLog dedupes the concise site-configuration log line so an
 	// established site logs once and re-logs only when its identity / primary
 	// control channel materially changes (see logSiteIdentity).
@@ -222,6 +227,15 @@ type CCStats struct {
 	// resolved but NetStatusSeen == 0 is the normal shape of a system that
 	// names its site via registrations but withholds the WACN-bearing NSB.
 	LocRegSeen int64
+	// MBT (multi-block trunking, DUID 0xC on the CC) outcomes. MBTDecoded
+	// counts complete MBT messages that cleared the header CRC16 + data
+	// CRC32 and reached dispatchMBT; MBTHeaderFailed / MBTDataCRCFailed
+	// split the failure modes. Systems that carry their neighbour list /
+	// WACN only in AMBT form show MBTDecoded > 0 with NetStatusSeen /
+	// AdjacentSeen advancing from the MBT path.
+	MBTDecoded       int64
+	MBTHeaderFailed  int64
+	MBTDataCRCFailed int64
 }
 
 // TSBKErrorRate returns the percentage (0..100) of decode-attempted TSBK
@@ -307,11 +321,23 @@ func (c *ControlChannel) TopologySnapshot() *trunking.TopologySnapshot {
 		ref := trunking.TopoNeighborRef{
 			RFSS:          n.RFSS,
 			Site:          n.Site,
+			LRA:           n.LRA,
+			SystemID:      uint32(n.SystemID),
 			ChannelID:     n.ChannelID,
 			ChannelNumber: n.ChannelNumber,
+			StatusFlags:   cfvaString(n.CFVA, n.CFVAKnown),
 		}
 		if hz, err := c.bandPlan.Frequency(n.ChannelID, n.ChannelNumber); err == nil {
 			ref.FrequencyHz = hz
+		}
+		if n.UplinkID != 0 || n.UplinkNumber != 0 {
+			ref.UplinkChannelID, ref.UplinkChannelNumber = n.UplinkID, n.UplinkNumber
+			// An explicit uplink channel number already encodes the uplink
+			// frequency in plain base+spacing terms — no transmit offset is
+			// applied (matches SDRTrunk's AMBT downlink/uplink resolution).
+			if hz, err := c.bandPlan.Frequency(n.UplinkID, n.UplinkNumber); err == nil {
+				ref.UplinkHz = hz
+			}
 		}
 		t.Neighbors = append(t.Neighbors, ref)
 	}
@@ -329,6 +355,32 @@ func (c *ControlChannel) TopologySnapshot() *trunking.TopologySnapshot {
 		return nil
 	}
 	return t
+}
+
+// cfvaString renders the adjacent-site CFVA flags as a short summary for
+// the topology snapshot ("" when the flags were never observed; "none"
+// when observed all-clear — a distinction the API keeps visible).
+func cfvaString(cfva uint8, known bool) string {
+	if !known {
+		return ""
+	}
+	var parts []string
+	if cfva&CFVAConventional != 0 {
+		parts = append(parts, "conventional")
+	}
+	if cfva&CFVAFailure != 0 {
+		parts = append(parts, "failure")
+	}
+	if cfva&CFVAValid != 0 {
+		parts = append(parts, "valid")
+	}
+	if cfva&CFVAActive != 0 {
+		parts = append(parts, "active")
+	}
+	if len(parts) == 0 {
+		return "none"
+	}
+	return strings.Join(parts, ",")
 }
 
 // channelRef resolves a (band-plan ID, channel number) pair into a
@@ -356,6 +408,9 @@ func (c *ControlChannel) Stats() CCStats {
 		RFSSStatusSeen:    atomic.LoadInt64(&c.stats.RFSSStatusSeen),
 		AdjacentSeen:      atomic.LoadInt64(&c.stats.AdjacentSeen),
 		LocRegSeen:        atomic.LoadInt64(&c.stats.LocRegSeen),
+		MBTDecoded:        atomic.LoadInt64(&c.stats.MBTDecoded),
+		MBTHeaderFailed:   atomic.LoadInt64(&c.stats.MBTHeaderFailed),
+		MBTDataCRCFailed:  atomic.LoadInt64(&c.stats.MBTDataCRCFailed),
 	}
 }
 
@@ -393,6 +448,16 @@ type pendingHit struct {
 	fswStart   int    // absolute index of the frame's first FSW dibit
 	strip      bool   // status-symbol stripping the alignment search chose
 	nac        uint16 // NAC the NID decoded to (for dispatch)
+
+	// PDU (DUID 0xC) continuation state — the multi-block trunking path.
+	// A PDU frame reuses the TSBK block coding (98-dibit trellis blocks),
+	// so blocksDone/nextStart drive it too; pdu selects resumeMBTBlocks
+	// over resumeTSBKBlocks, mbtHeader holds the CRC-validated header once
+	// block 0 decodes, and mbtData accumulates the following data blocks.
+	pdu       bool
+	mbtHave   bool
+	mbtHeader MBTHeader
+	mbtData   []byte
 }
 
 // FSWFallbackToleranceDefault is the wider frame-sync-word tolerance the
@@ -455,6 +520,14 @@ type Options struct {
 	// preserves the C4FM default in the voice chain — and is what the
 	// existing replay / unit tests pass.
 	P25Phase1DemodMode string
+
+	// QuietNonControlDUID suppresses the per-frame "non-control DUID"
+	// debug log line (config `p25_quiet_noncontrol_duid`). On a busy
+	// control channel TDU/PDU frames arrive many times per second and the
+	// line buries a debug log an operator is using to chase something
+	// else. Default false keeps the line (it is genuinely useful when
+	// first identifying an unknown carrier).
+	QuietNonControlDUID bool
 
 	// FSWFallbackTolerance opts the FSW correlator into a wider fallback
 	// tolerance (see FSWFallbackToleranceDefault). Zero (the default, and what
@@ -542,6 +615,7 @@ func New(opts Options) *ControlChannel {
 		bandPlan:              bp,
 		now:                   now,
 		carrierOffsetHz:       opts.CarrierOffsetHz,
+		quietNonControlDUID:   opts.QuietNonControlDUID,
 		fswTol:                fswTol,
 		aliasAsm:              NewTalkerAliasAssembler(now),
 		diagSeen:              make(map[uint32]int),
@@ -742,8 +816,15 @@ func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
 	kept := c.pending[:0]
 	for _, ph := range c.pending {
 		if ph.cont {
-			// Resume the data unit's remaining TSBK blocks (issue #402).
-			if c.resumeTSBKBlocks(&ph) {
+			// Resume the data unit's remaining blocks (issue #402); a PDU
+			// continuation resumes its MBT header/data blocks instead.
+			more := false
+			if ph.pdu {
+				more = c.resumeMBTBlocks(&ph)
+			} else {
+				more = c.resumeTSBKBlocks(&ph)
+			}
+			if more {
 				kept = append(kept, ph)
 			}
 			continue
@@ -816,9 +897,35 @@ func (c *ControlChannel) parseFrame(buf []uint8, nidStart int, fswRot uint8, req
 			"at_boundary", atSearchBoundary(best.delta, c.nidSearchSpan),
 			"err_pattern", formatErrPattern(best.errPattern))
 	}
+	if best.nid.DUID == DUIDPacketDataUnit {
+		// A PDU on the control channel is (usually) Multi-Block Trunking —
+		// the AMBT carrier of the WACN-bearing Network Status Broadcast and
+		// of Adjacent Status Broadcasts with explicit uplinks. Decode its
+		// blocks with the same trellis machinery as the TSDU path; the
+		// header CRC16 + data CRC32 gate acceptance. It does not lock the
+		// channel — only a TSDU proves a control channel.
+		ph := pendingHit{
+			cont:      true,
+			pdu:       true,
+			rot:       best.rot,
+			strip:     best.strip,
+			nac:       best.nid.NAC,
+			fswStart:  (nidStart + best.delta - len(FrameSyncWord)) + c.bufBase,
+			nextStart: best.tsbkStart + c.bufBase,
+		}
+		if c.resumeMBTBlocks(&ph) {
+			return ph, true
+		}
+		return pendingHit{}, false
+	}
 	if best.nid.DUID != DUIDTrunkingSignaling {
-		// Some non-control DUID — record but don't lock.
-		c.log.Debug("non-control DUID", "duid", best.nid.DUID, "nac", best.nid.NAC)
+		// Some non-control DUID — record but don't lock. The per-frame
+		// debug line is suppressible via Options.QuietNonControlDUID: on a
+		// busy CC these frames arrive many times per second and bury a
+		// debug log an operator is using to chase something else.
+		if !c.quietNonControlDUID {
+			c.log.Debug("non-control DUID", "duid", best.nid.DUID, "nac", best.nid.NAC)
+		}
 		return pendingHit{}, false
 	}
 	if !c.locked || c.lastNAC != best.nid.NAC {
@@ -964,6 +1071,111 @@ func (c *ControlChannel) resumeTSBKBlocks(ph *pendingHit) bool {
 		}
 	}
 	return false // reached maxTSBKBlocks
+}
+
+// resumeMBTBlocks decodes the blocks of a PDU (DUID 0xC) data unit — the
+// Multi-Block Trunking path. Block 0 is the 12-octet PDU header (validated
+// by its CCITT-16 CRC); the following BlocksToFollow blocks are data,
+// validated as a train by their trailing CRC-32, then dispatched. Returns
+// true when blocks remain undecoded for want of buffered dibits, mirroring
+// resumeTSBKBlocks' contract so Process can keep the continuation pending.
+func (c *ControlChannel) resumeMBTBlocks(ph *pendingHit) bool {
+	for {
+		start := ph.nextStart - c.bufBase
+		if start < 0 {
+			return false // buffer trimmed past it (shouldn't happen) — drop
+		}
+		if start+tsbkBlockSpan > len(c.buf) {
+			return true // next block not buffered yet — resume later
+		}
+		fswStart := ph.fswStart - c.bufBase
+		channel, next := gatherFrameDibits(c.buf, start, 98, fswStart, ph.strip)
+		info, metric := DecodeMBTBlockChannel(rotateDibits(channel, ph.rot))
+		if !ph.mbtHave {
+			h, err := ParseMBTHeader(info)
+			if err != nil {
+				atomic.AddInt64(&c.stats.MBTHeaderFailed, 1)
+				c.log.Debug("p25: MBT PDU header failed", "err", err,
+					"metric", metric, "nac", ph.nac)
+				return false
+			}
+			if !h.IsTrunkingControl() {
+				// A genuine (non-trunking) data PDU on this carrier — not
+				// an error, just not signalling. Skip its blocks.
+				c.log.Debug("p25: non-trunking PDU ignored",
+					"sap", h.SAP, "format", h.Format, "nac", ph.nac)
+				return false
+			}
+			if h.BlocksToFollow == 0 || int(h.BlocksToFollow) > maxMBTDataBlocks {
+				c.log.Debug("p25: MBT blocks-to-follow out of range",
+					"blocks", h.BlocksToFollow, "nac", ph.nac)
+				return false
+			}
+			ph.mbtHeader, ph.mbtHave = h, true
+			ph.mbtData = make([]byte, 0, int(h.BlocksToFollow)*12)
+		} else {
+			ph.mbtData = append(ph.mbtData, info...)
+			if len(ph.mbtData) >= int(ph.mbtHeader.BlocksToFollow)*12 {
+				c.dispatchMBT(ph.mbtHeader, ph.mbtData, ph.nac)
+				return false
+			}
+		}
+		ph.blocksDone++
+		ph.nextStart = next + c.bufBase
+	}
+}
+
+// dispatchMBT validates a complete MBT's data-block CRC-32 and routes the
+// AMBT broadcast opcodes into the same network model the TSBK forms feed.
+// data is the concatenation of the message's 12-octet data blocks.
+func (c *ControlChannel) dispatchMBT(h MBTHeader, data []byte, nac uint16) {
+	if err := ValidateMBTData(data); err != nil {
+		atomic.AddInt64(&c.stats.MBTDataCRCFailed, 1)
+		c.log.Debug("p25: MBT data CRC failed",
+			"opcode", h.Opcode, "blocks", h.BlocksToFollow, "nac", nac)
+		return
+	}
+	atomic.AddInt64(&c.stats.MBTDecoded, 1)
+	c.lastActivityNano.Store(c.now().UnixNano())
+	if h.Format != MBTFormatAlternate {
+		// Unconfirmed MBT (0x15) carries its opcode and fields inside the
+		// data blocks with different layouts; census it until a capture
+		// justifies decoding it (#764/#771 discipline: no spec-guessing).
+		c.log.Debug("p25: unconfirmed MBT not decoded",
+			"opcode_raw", data[0]&0x3F, "blocks", h.BlocksToFollow, "nac", nac)
+		return
+	}
+	switch h.Opcode {
+	case OpNetworkStatusBroadcast:
+		atomic.AddInt64(&c.stats.NetStatusSeen, 1)
+		n := ParseMBTNetworkStatusBroadcast(h, data)
+		c.log.Debug("p25: MBT network status broadcast", "nac", nac,
+			"wacn", n.WACN, "sysid", n.SystemID,
+			"channel", fmt.Sprintf("%d-%d", n.ChannelID, n.ChannelNumber),
+			"uplink", fmt.Sprintf("%d-%d", n.UplinkID, n.UplinkNumber))
+		c.netModel.ApplyMBTNetworkStatus(n)
+		c.publishSiteUpdate()
+	case OpRFSSStatusBroadcast:
+		atomic.AddInt64(&c.stats.RFSSStatusSeen, 1)
+		r := ParseMBTRFSSStatusBroadcast(h, data)
+		c.log.Debug("p25: MBT RFSS status broadcast", "nac", nac,
+			"sysid", r.SystemID, "rfss", r.RFSS, "site", r.Site,
+			"channel", fmt.Sprintf("%d-%d", r.ChannelID, r.ChannelNumber))
+		c.netModel.ApplyMBTRFSSStatus(r)
+		c.publishSiteUpdate()
+	case OpAdjacentSiteStatusBroadcast:
+		atomic.AddInt64(&c.stats.AdjacentSeen, 1)
+		a := ParseMBTAdjacentSiteStatusBroadcast(h, data)
+		c.log.Debug("p25: MBT adjacent site broadcast", "nac", nac,
+			"sysid", a.SystemID, "rfss", a.RFSS, "site", a.Site,
+			"channel", fmt.Sprintf("%d-%d", a.ChannelID, a.ChannelNumber),
+			"uplink", fmt.Sprintf("%d-%d", a.UplinkID, a.UplinkNumber))
+		c.netModel.ApplyMBTAdjacentSite(a)
+		c.publishSiteUpdate()
+	default:
+		c.log.Debug("p25: unhandled AMBT opcode",
+			"opcode", h.Opcode, "mfid", h.MFID, "blocks", h.BlocksToFollow, "nac", nac)
+	}
 }
 
 // nidGuess is one evaluated NID-alignment hypothesis: the NID read from

--- a/internal/radio/p25/phase1/mbt.go
+++ b/internal/radio/p25/phase1/mbt.go
@@ -1,0 +1,293 @@
+package phase1
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
+
+// Multi-Block Trunking (MBT) — trunking signalling carried in a PDU
+// (DUID 0xC) on the control channel instead of a TSDU. Many systems
+// (notably Motorola) broadcast their richest network data — Network
+// Status with WACN, Adjacent Status with explicit downlink AND uplink
+// channels, RFSS Status — only in the Alternate MBT (AMBT) format, so a
+// decoder that drops DUID 0xC as "non-control" never surfaces most
+// neighbour sites or (on some systems) the WACN at all. That was the
+// operator-reported gap: SDRTrunk lists 12 neighbours with uplinks in
+// 15 s while GT showed one and "No Network Status Broadcast yet",
+// while the very frames carrying that data were logged as
+// `non-control DUID duid=PDU` spam.
+//
+// Channel coding is identical to the TSDU: each block is 196 bits,
+// 1/2-rate trellis coded and interleaved exactly like a TSBK, so the
+// receive chain reuses the deinterleave → Viterbi pipeline. What
+// differs is the block content: a 12-octet PDU header protected by the
+// same augmented CRC-CCITT16 the TSBK trailer uses, followed by
+// BlocksToFollow 12-octet data blocks whose concatenation ends in a
+// 4-octet CRC-32.
+//
+// Layouts are cross-checked against two independent decoders — OP25's
+// p25p1_fdma::process_PDU (header/format/SAP/opcode extraction, both
+// CRC algorithms) and SDRTrunk's PDUHeader / AMBTCHeader / AMBTC*
+// message classes (per-field bit offsets) — so this is not a working
+// model.
+
+// MBT PDU header formats (5-bit PDU_FORMAT field, header octet 0 low 5
+// bits) that carry trunking control, per OP25 process_PDU.
+const (
+	MBTFormatUnconfirmed = 0x15 // Unconfirmed MBT: opcode in data block 0
+	MBTFormatAlternate   = 0x17 // Alternate MBT (AMBT): opcode in header octet 7
+)
+
+// MBTSAPTrunkingControl is the PDU Service Access Point value for
+// trunking control signalling (61); any other SAP is user data, not MBT.
+const MBTSAPTrunkingControl = 0x3D
+
+// maxMBTDataBlocks bounds how many data blocks an MBT message may carry.
+// AMBT trunking broadcasts use 1-2 data blocks; the cap keeps a corrupt
+// BlocksToFollow from stalling the frame parser on a block train that
+// never arrives.
+const maxMBTDataBlocks = 3
+
+// ErrMBTHeaderCRC is returned when the PDU header block fails its
+// CRC-CCITT16 check.
+var ErrMBTHeaderCRC = errors.New("p25/phase1: MBT PDU header CRC check failed")
+
+// ErrMBTDataCRC is returned when the concatenated data blocks fail
+// their trailing CRC-32 check.
+var ErrMBTDataCRC = errors.New("p25/phase1: MBT data block CRC-32 check failed")
+
+// MBTHeader is the decoded 12-octet PDU header of a trunking MBT.
+// Field offsets per SDRTrunk PDUHeader/AMBTCHeader and OP25:
+//
+//	octet 0     : bits 4..0 = format (0x17 AMBT / 0x15 unconfirmed)
+//	octet 1     : bits 5..0 = SAP (61 = trunking control)
+//	octet 2     : MFID
+//	octets 3-5  : AMBT: message-specific (LRA / System ID for the
+//	              status broadcasts); plain PDU: logical link ID
+//	octet 6     : bits 6..0 = blocks to follow
+//	octet 7     : bits 5..0 = opcode (AMBT only)
+//	octets 8-9  : AMBT: two message-specific data octets
+//	octets 10-11: header CRC (CCITT-16, validated by ParseMBTHeader)
+type MBTHeader struct {
+	Format         uint8
+	SAP            uint8
+	MFID           uint8
+	BlocksToFollow uint8
+	Opcode         Opcode // AMBT opcode (octet 7); meaningless for 0x15
+	Raw            [12]byte
+}
+
+// IsTrunkingControl reports whether this header carries trunking
+// signalling this decoder understands (SAP 61, AMBT or unconfirmed MBT).
+func (h MBTHeader) IsTrunkingControl() bool {
+	return h.SAP == MBTSAPTrunkingControl &&
+		(h.Format == MBTFormatAlternate || h.Format == MBTFormatUnconfirmed)
+}
+
+// ParseMBTHeader decodes and CRC-checks a 12-octet PDU header block.
+// The partially-parsed header is returned even on CRC failure so
+// callers can log it.
+func ParseMBTHeader(info []byte) (MBTHeader, error) {
+	if len(info) != 12 {
+		return MBTHeader{}, fmt.Errorf("%w, got %d", ErrTSBKInfoLength, len(info))
+	}
+	var h MBTHeader
+	copy(h.Raw[:], info)
+	h.Format = info[0] & 0x1F
+	h.SAP = info[1] & 0x3F
+	h.MFID = info[2]
+	h.BlocksToFollow = info[6] & 0x7F
+	h.Opcode = Opcode(info[7] & 0x3F)
+	if framing.CRCCCITTAugmented(info) != 0 {
+		return h, ErrMBTHeaderCRC
+	}
+	return h, nil
+}
+
+// AssembleMBTHeader is the inverse of ParseMBTHeader; for tests. raw37
+// and raw89 fill the message-specific header octets 3-5 and 8-9.
+func AssembleMBTHeader(h MBTHeader, raw35 [3]byte, raw89 [2]byte) []byte {
+	out := make([]byte, 12)
+	out[0] = h.Format & 0x1F
+	out[1] = h.SAP & 0x3F
+	out[2] = h.MFID
+	copy(out[3:6], raw35[:])
+	out[6] = h.BlocksToFollow & 0x7F
+	out[7] = byte(h.Opcode) & 0x3F
+	copy(out[8:10], raw89[:])
+	binary.BigEndian.PutUint16(out[10:12], framing.CRCCCITTAugmented(out))
+	return out
+}
+
+// DecodeMBTBlockChannel runs the shared TSBK channel pipeline —
+// deinterleave → 1/2-rate trellis Viterbi → repack — over 98 channel
+// dibits and returns the 12 info octets plus the Viterbi path metric
+// (0 = clean). PDU blocks use exactly the TSBK block coding; only the
+// CRC conventions differ, and those are checked by the callers
+// (ParseMBTHeader / ValidateMBTData).
+func DecodeMBTBlockChannel(channel []uint8) ([]byte, int) {
+	coding := DeinterleaveTSBK(channel)
+	infoDibits, metric := DecodeTrellis(coding)
+	info := make([]byte, 12)
+	for i := 0; i < 12; i++ {
+		info[i] = (infoDibits[4*i+0] << 6) |
+			(infoDibits[4*i+1] << 4) |
+			(infoDibits[4*i+2] << 2) |
+			infoDibits[4*i+3]
+	}
+	return info, metric
+}
+
+// mbtCRC32 is the P25 packet CRC-32 (poly 0x04C11DB7, init 0, final
+// XOR 0xFFFFFFFF, MSB-first, non-reflected) over the first bitLen bits
+// of buf — the algorithm OP25 applies to a PDU's concatenated data
+// blocks (translated there from p25craft.py).
+func mbtCRC32(buf []byte, bitLen int) uint32 {
+	const g = 0x04C11DB7
+	var crc uint64
+	for i := 0; i < bitLen; i++ {
+		crc <<= 1
+		b := uint64((buf[i/8] >> (7 - (i % 8))) & 1)
+		if ((crc>>32)^b)&1 != 0 {
+			crc ^= g
+		}
+	}
+	return uint32(crc&0xFFFFFFFF) ^ 0xFFFFFFFF
+}
+
+// ValidateMBTData verifies the CRC-32 that terminates an MBT's data
+// blocks: computed over all data octets except the last 4, compared to
+// the last 4 octets. data is the concatenation of the BlocksToFollow
+// 12-octet blocks.
+func ValidateMBTData(data []byte) error {
+	if len(data) < 4 || len(data)%12 != 0 {
+		return fmt.Errorf("%w (len %d)", ErrMBTDataCRC, len(data))
+	}
+	want := binary.BigEndian.Uint32(data[len(data)-4:])
+	if mbtCRC32(data, (len(data)-4)*8) != want {
+		return ErrMBTDataCRC
+	}
+	return nil
+}
+
+// appendMBTDataCRC32 stamps the trailing CRC-32 into the last 4 octets
+// of data (in place) so tests can build valid block trains.
+func appendMBTDataCRC32(data []byte) {
+	binary.BigEndian.PutUint32(data[len(data)-4:],
+		mbtCRC32(data, (len(data)-4)*8))
+}
+
+// MBTNetworkStatusBroadcast is the AMBT form of opcode 0x3B. Unlike the
+// TSBK form it carries explicit downlink AND uplink channels for the
+// system's control channel. Offsets per SDRTrunk
+// AMBTCNetworkStatusBroadcast:
+//
+//	header octets 3   : LRA
+//	header octets 4-5 : System ID (12 bits)
+//	block0 octets 0-2 : WACN (20 bits, top of the 24)
+//	block0 octet 3-4  : downlink channel (4-bit band + 12-bit number)
+//	block0 octet 5-6  : uplink channel   (4-bit band + 12-bit number)
+//	block0 octet 7    : system service class
+type MBTNetworkStatusBroadcast struct {
+	LRA           uint8
+	SystemID      uint16
+	WACN          uint32
+	ChannelID     uint8
+	ChannelNumber uint16
+	UplinkID      uint8
+	UplinkNumber  uint16
+	ServiceClass  uint8
+}
+
+// ParseMBTNetworkStatusBroadcast decodes an AMBT 0x3B from its header
+// and first data block.
+func ParseMBTNetworkStatusBroadcast(h MBTHeader, block0 []byte) MBTNetworkStatusBroadcast {
+	dl := binary.BigEndian.Uint16(block0[3:5])
+	ul := binary.BigEndian.Uint16(block0[5:7])
+	return MBTNetworkStatusBroadcast{
+		LRA:           h.Raw[3],
+		SystemID:      uint16(h.Raw[4]&0x0F)<<8 | uint16(h.Raw[5]),
+		WACN:          uint32(block0[0])<<12 | uint32(block0[1])<<4 | uint32(block0[2])>>4,
+		ChannelID:     uint8(dl >> 12),
+		ChannelNumber: dl & 0x0FFF,
+		UplinkID:      uint8(ul >> 12),
+		UplinkNumber:  ul & 0x0FFF,
+		ServiceClass:  block0[7],
+	}
+}
+
+// MBTAdjacentSiteStatusBroadcast is the AMBT form of opcode 0x3C, with
+// the neighbour's explicit downlink and uplink channels. Offsets per
+// SDRTrunk AMBTCAdjacentStatusBroadcast:
+//
+//	header octet 3    : LRA
+//	header octets 4-5 : System ID (12 bits)
+//	header octet 8    : RFSS ID
+//	header octet 9    : Site ID
+//	block0 octets 0-1 : downlink channel (4-bit band + 12-bit number)
+//	block0 octets 2-3 : uplink channel   (4-bit band + 12-bit number)
+type MBTAdjacentSiteStatusBroadcast struct {
+	LRA           uint8
+	SystemID      uint16
+	RFSS, Site    uint8
+	ChannelID     uint8
+	ChannelNumber uint16
+	UplinkID      uint8
+	UplinkNumber  uint16
+}
+
+// ParseMBTAdjacentSiteStatusBroadcast decodes an AMBT 0x3C from its
+// header and first data block.
+func ParseMBTAdjacentSiteStatusBroadcast(h MBTHeader, block0 []byte) MBTAdjacentSiteStatusBroadcast {
+	dl := binary.BigEndian.Uint16(block0[0:2])
+	ul := binary.BigEndian.Uint16(block0[2:4])
+	return MBTAdjacentSiteStatusBroadcast{
+		LRA:           h.Raw[3],
+		SystemID:      uint16(h.Raw[4]&0x0F)<<8 | uint16(h.Raw[5]),
+		RFSS:          h.Raw[8],
+		Site:          h.Raw[9],
+		ChannelID:     uint8(dl >> 12),
+		ChannelNumber: dl & 0x0FFF,
+		UplinkID:      uint8(ul >> 12),
+		UplinkNumber:  ul & 0x0FFF,
+	}
+}
+
+// MBTRFSSStatusBroadcast is the AMBT form of opcode 0x3A. Offsets per
+// SDRTrunk AMBTCRFSSStatusBroadcast:
+//
+//	header octet 3    : LRA
+//	header octets 4-5 : System ID (12 bits)
+//	block0 octet 0    : RFSS ID
+//	block0 octet 1    : Site ID
+//	block0 octets 2-3 : downlink channel (4-bit band + 12-bit number)
+//	block0 octets 4-5 : uplink channel   (4-bit band + 12-bit number)
+type MBTRFSSStatusBroadcast struct {
+	LRA           uint8
+	SystemID      uint16
+	RFSS, Site    uint8
+	ChannelID     uint8
+	ChannelNumber uint16
+	UplinkID      uint8
+	UplinkNumber  uint16
+}
+
+// ParseMBTRFSSStatusBroadcast decodes an AMBT 0x3A from its header and
+// first data block.
+func ParseMBTRFSSStatusBroadcast(h MBTHeader, block0 []byte) MBTRFSSStatusBroadcast {
+	dl := binary.BigEndian.Uint16(block0[2:4])
+	ul := binary.BigEndian.Uint16(block0[4:6])
+	return MBTRFSSStatusBroadcast{
+		LRA:           h.Raw[3],
+		SystemID:      uint16(h.Raw[4]&0x0F)<<8 | uint16(h.Raw[5]),
+		RFSS:          block0[0],
+		Site:          block0[1],
+		ChannelID:     uint8(dl >> 12),
+		ChannelNumber: dl & 0x0FFF,
+		UplinkID:      uint8(ul >> 12),
+		UplinkNumber:  ul & 0x0FFF,
+	}
+}

--- a/internal/radio/p25/phase1/mbt_test.go
+++ b/internal/radio/p25/phase1/mbt_test.go
@@ -1,0 +1,261 @@
+package phase1
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// TestParseSecondaryControlChannelBroadcastLayout pins the 0x39 payload
+// layout against SDRTrunk's SecondaryControlChannelBroadcast bit offsets
+// (RFSS 16-23, SITE 24-31, CH A 32-47, SC A 48-55, CH B 56-71, SC B
+// 72-79). The previous working model read channel B from payload bytes
+// 4-5 — one byte early, splicing service class A into the channel field —
+// and its round-trip test passed because the assembler encoded the same
+// wrong layout. A literal byte vector cannot be fooled that way: this
+// test fails against the old parser (channel B = 7-0x02D phantom).
+func TestParseSecondaryControlChannelBroadcastLayout(t *testing.T) {
+	// RFSS 1, Site 1, chan A 2-1692 (0x69C), SC A 0x70,
+	// chan B 2-3342 (0xD0E), SC B 0x50.
+	p := [8]byte{0x01, 0x01, 0x26, 0x9C, 0x70, 0x2D, 0x0E, 0x50}
+	s := ParseSecondaryControlChannelBroadcast(p)
+	if s.RFSS != 1 || s.Site != 1 {
+		t.Errorf("RFSS/Site = %d/%d, want 1/1", s.RFSS, s.Site)
+	}
+	if s.ChannelAID != 2 || s.ChannelANumber != 1692 {
+		t.Errorf("channel A = %d-%d, want 2-1692", s.ChannelAID, s.ChannelANumber)
+	}
+	if s.ServiceClassA != 0x70 {
+		t.Errorf("service class A = %#x, want 0x70", s.ServiceClassA)
+	}
+	if s.ChannelBID != 2 || s.ChannelBNumber != 3342 {
+		t.Errorf("channel B = %d-%d, want 2-3342 (old layout read bytes 4-5: 7-45)", s.ChannelBID, s.ChannelBNumber)
+	}
+	if s.ServiceClassB != 0x50 {
+		t.Errorf("service class B = %#x, want 0x50", s.ServiceClassB)
+	}
+	if back := AssembleSecondaryControlChannelBroadcast(s); back != p {
+		t.Errorf("assemble round-trip = %x, want %x", back, p)
+	}
+}
+
+// TestParseAdjacentSiteStatusBroadcastCFVA pins that the 0x3C parser
+// captures the CFVA flags (byte 1 high nibble) and system service class
+// (byte 7) — previously read only for a diagnostic log line, never into
+// the struct — without disturbing the identity/channel fields.
+func TestParseAdjacentSiteStatusBroadcastCFVA(t *testing.T) {
+	// LRA 0, CFVA valid+active (0x3), sysid 0x2C2, RFSS 1, Site 7,
+	// channel 2-1754 (0x6DA), service class 0x70.
+	p := [8]byte{0x00, 0x32, 0xC2, 0x01, 0x07, 0x26, 0xDA, 0x70}
+	a := ParseAdjacentSiteStatusBroadcast(p)
+	if a.SystemID != 0x2C2 || a.RFSS != 1 || a.Site != 7 {
+		t.Errorf("identity = sysid %#x rfss %d site %d, want 0x2C2/1/7", a.SystemID, a.RFSS, a.Site)
+	}
+	if a.ChannelID != 2 || a.ChannelNumber != 1754 {
+		t.Errorf("channel = %d-%d, want 2-1754", a.ChannelID, a.ChannelNumber)
+	}
+	if a.CFVA != CFVAValid|CFVAActive {
+		t.Errorf("CFVA = %#x, want valid|active (0x3)", a.CFVA)
+	}
+	if a.ServiceClass != 0x70 {
+		t.Errorf("service class = %#x, want 0x70", a.ServiceClass)
+	}
+	if back := AssembleAdjacentSiteStatusBroadcast(a); back != p {
+		t.Errorf("assemble round-trip = %x, want %x", back, p)
+	}
+}
+
+// buildAMBTAdjacentFrame builds one on-air FSW + NID(PDU) + header block +
+// data block frame carrying an AMBT Adjacent Site Status Broadcast.
+func buildAMBTAdjacentFrame(nac uint16, lra uint8, sysid uint16, rfss, site uint8, dlID uint8, dlNum uint16, ulID uint8, ulNum uint16) []uint8 {
+	header := AssembleMBTHeader(MBTHeader{
+		Format: MBTFormatAlternate, SAP: MBTSAPTrunkingControl,
+		BlocksToFollow: 1, Opcode: OpAdjacentSiteStatusBroadcast,
+	}, [3]byte{lra, byte(sysid >> 8 & 0x0F), byte(sysid)}, [2]byte{rfss, site})
+	block := make([]byte, 12)
+	block[0] = dlID<<4 | byte(dlNum>>8&0x0F)
+	block[1] = byte(dlNum)
+	block[2] = ulID<<4 | byte(ulNum>>8&0x0F)
+	block[3] = byte(ulNum)
+	appendMBTDataCRC32(block)
+
+	frame := make([]uint8, 0, 24+32+2*98)
+	frame = append(frame, FrameSyncWord[:]...)
+	bits := EncodeNIDBits(nac, DUIDPacketDataUnit)
+	for i := 0; i < 32; i++ {
+		frame = append(frame, (bits[2*i]<<1)|bits[2*i+1])
+	}
+	frame = append(frame, EncodeTSBKChannel(header)...)
+	frame = append(frame, EncodeTSBKChannel(block)...)
+	return frame
+}
+
+// TestControlChannelDecodesAMBTAdjacentStatus pins the Multi-Block
+// Trunking path end-to-end: a PDU (DUID 0xC) on the control channel
+// carrying an AMBT Adjacent Site Status Broadcast must yield a neighbour
+// — with its explicit uplink resolved — in the topology snapshot. Before
+// the MBT path existed these frames were logged as "non-control DUID"
+// and dropped, which is why systems that broadcast their neighbour list
+// only in AMBT form showed one neighbour where SDRTrunk listed twelve.
+// The stream is delivered in 19-dibit batches so the multi-block PDU
+// continuation across Process calls is exercised too.
+func TestControlChannelDecodesAMBTAdjacentStatus(t *testing.T) {
+	bus := events.NewBus(32)
+	defer bus.Close()
+	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Ost", FrequencyHz: 450_125_000,
+		Now: func() time.Time { return time.Unix(1_700_000_000, 0).UTC() }})
+	// Band 2: base 440 MHz, 6.25 kHz spacing (the operator's system).
+	cc.bandPlan.Apply(IdentifierUpdate{ChannelID: 2, BaseHz: 440_000_000, SpacingHz: 6_250, TxOffsetHz: -6_400_000})
+
+	// Neighbour site 7: downlink 2-1754 → 450.9625 MHz, uplink 2-3430 →
+	// 461.4375 MHz (the operator's SDRTrunk ground truth).
+	onAir := InjectControlStatusSymbols(buildAMBTAdjacentFrame(
+		0x2C1, 0, 0x2C2, 1, 7, 2, 1754, 2, 3430))
+	stream := make([]uint8, 10+len(onAir)+16)
+	copy(stream[10:], onAir)
+	for i := 0; i < len(stream); i += 19 {
+		end := min(i+19, len(stream))
+		cc.Process(stream[i:end], i)
+	}
+
+	snap := cc.TopologySnapshot()
+	if snap == nil {
+		t.Fatal("TopologySnapshot nil after an AMBT adjacent broadcast")
+	}
+	if len(snap.Neighbors) != 1 {
+		t.Fatalf("neighbors = %+v, want exactly the AMBT-announced site", snap.Neighbors)
+	}
+	n := snap.Neighbors[0]
+	if n.RFSS != 1 || n.Site != 7 {
+		t.Errorf("neighbor identity = rfss %d site %d, want 1/7", n.RFSS, n.Site)
+	}
+	if n.ChannelID != 2 || n.ChannelNumber != 1754 || n.FrequencyHz != 450_962_500 {
+		t.Errorf("neighbor downlink = %d-%d @ %d, want 2-1754 @ 450962500", n.ChannelID, n.ChannelNumber, n.FrequencyHz)
+	}
+	if n.UplinkChannelID != 2 || n.UplinkChannelNumber != 3430 || n.UplinkHz != 461_437_500 {
+		t.Errorf("neighbor uplink = %d-%d @ %d, want 2-3430 @ 461437500", n.UplinkChannelID, n.UplinkChannelNumber, n.UplinkHz)
+	}
+	// The AMBT names the system ID; it must vote into the camped identity.
+	if snap.SystemID != 0x2C2 {
+		t.Errorf("SystemID = %#x, want 0x2C2 (voted from the adjacent broadcast)", snap.SystemID)
+	}
+	if got := cc.Stats(); got.MBTDecoded != 1 || got.AdjacentSeen != 1 {
+		t.Errorf("stats = MBTDecoded %d AdjacentSeen %d, want 1/1", got.MBTDecoded, got.AdjacentSeen)
+	}
+}
+
+// TestControlChannelDecodesAMBTNetworkStatus pins the AMBT Network
+// Status Broadcast (0x3B in a PDU): the WACN must reach the topology
+// snapshot. This is the "No Network Status Broadcast yet" fix for
+// systems that carry the WACN only in AMBT form.
+func TestControlChannelDecodesAMBTNetworkStatus(t *testing.T) {
+	bus := events.NewBus(32)
+	defer bus.Close()
+	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Ost", FrequencyHz: 450_125_000,
+		Now: func() time.Time { return time.Unix(1_700_000_000, 0).UTC() }})
+
+	header := AssembleMBTHeader(MBTHeader{
+		Format: MBTFormatAlternate, SAP: MBTSAPTrunkingControl,
+		BlocksToFollow: 1, Opcode: OpNetworkStatusBroadcast,
+	}, [3]byte{0x00, 0x02, 0xC2}, [2]byte{})
+	block := make([]byte, 12)
+	// WACN 0xBEE00 in the top 20 bits of octets 0-2.
+	block[0], block[1], block[2] = 0xBE, 0xE0, 0x00
+	// Downlink 2-1620, uplink 2-3310.
+	block[3], block[4] = 0x26, 0x54
+	block[5], block[6] = 0x2C, 0xEE
+	block[7] = 0x70
+	appendMBTDataCRC32(block)
+
+	frame := make([]uint8, 0, 24+32+2*98)
+	frame = append(frame, FrameSyncWord[:]...)
+	bits := EncodeNIDBits(0x2C1, DUIDPacketDataUnit)
+	for i := 0; i < 32; i++ {
+		frame = append(frame, (bits[2*i]<<1)|bits[2*i+1])
+	}
+	frame = append(frame, EncodeTSBKChannel(header)...)
+	frame = append(frame, EncodeTSBKChannel(block)...)
+
+	onAir := InjectControlStatusSymbols(frame)
+	stream := make([]uint8, 10+len(onAir)+16)
+	copy(stream[10:], onAir)
+	cc.Process(stream, 0)
+
+	snap := cc.TopologySnapshot()
+	if snap == nil {
+		t.Fatal("TopologySnapshot nil after an AMBT network status broadcast")
+	}
+	if snap.WACN != 0xBEE00 || snap.SystemID != 0x2C2 {
+		t.Errorf("identity = WACN %#x SystemID %#x, want 0xBEE00/0x2C2", snap.WACN, snap.SystemID)
+	}
+	if got := cc.Stats(); got.MBTDecoded != 1 || got.NetStatusSeen != 1 {
+		t.Errorf("stats = MBTDecoded %d NetStatusSeen %d, want 1/1", got.MBTDecoded, got.NetStatusSeen)
+	}
+}
+
+// TestMBTDataCRCRejectsCorruption proves a corrupted data block cannot
+// dispatch: the CRC-32 gate must reject it (a trellis-surviving wrong
+// payload must not inject a phantom neighbour).
+func TestMBTDataCRCRejectsCorruption(t *testing.T) {
+	block := make([]byte, 12)
+	block[0], block[1] = 0x26, 0xDA
+	appendMBTDataCRC32(block)
+	if err := ValidateMBTData(block); err != nil {
+		t.Fatalf("valid block train rejected: %v", err)
+	}
+	block[1] ^= 0x01
+	if err := ValidateMBTData(block); err == nil {
+		t.Fatal("corrupted block train passed the CRC-32 gate")
+	}
+}
+
+// TestNetworkModelMergesNeighborForms pins the TSBK/AMBT merge: the two
+// adjacent-status forms carry complementary fields (CFVA + service class
+// vs explicit uplink), and observing both must yield one neighbour with
+// both halves, whichever order they arrive in.
+func TestNetworkModelMergesNeighborForms(t *testing.T) {
+	var m NetworkModel
+	m.ApplyMBTAdjacentSite(MBTAdjacentSiteStatusBroadcast{
+		SystemID: 0x2C2, RFSS: 1, Site: 7,
+		ChannelID: 2, ChannelNumber: 1754, UplinkID: 2, UplinkNumber: 3430,
+	})
+	m.ApplyAdjacentSite(AdjacentSiteStatusBroadcast{
+		SystemID: 0x2C2, RFSS: 1, Site: 7,
+		ChannelID: 2, ChannelNumber: 1754,
+		CFVA: CFVAValid | CFVAActive, ServiceClass: 0x70,
+	})
+	snap := m.Snapshot()
+	if len(snap.Neighbors) != 1 {
+		t.Fatalf("neighbors = %+v, want one merged entry", snap.Neighbors)
+	}
+	n := snap.Neighbors[0]
+	if n.UplinkID != 2 || n.UplinkNumber != 3430 {
+		t.Errorf("merged uplink = %d-%d, want 2-3430 (TSBK form must not clobber it)", n.UplinkID, n.UplinkNumber)
+	}
+	if !n.CFVAKnown || n.CFVA != CFVAValid|CFVAActive || n.ServiceClass != 0x70 {
+		t.Errorf("merged flags = known %v cfva %#x sc %#x, want valid|active + 0x70", n.CFVAKnown, n.CFVA, n.ServiceClass)
+	}
+}
+
+// TestQuietNonControlDUIDSuppressesLog pins the p25_quiet_noncontrol_duid
+// knob: with it set, the per-frame "non-control DUID" debug line (fired for
+// every TDU on a busy CC — the operator-reported debug-log flood) stays
+// silent; without it the historical line still fires.
+func TestQuietNonControlDUIDSuppressesLog(t *testing.T) {
+	for _, quiet := range []bool{false, true} {
+		var buf bytes.Buffer
+		log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+		bus := events.NewBus(8)
+		cc := New(Options{Bus: bus, Log: log, SystemName: "S", QuietNonControlDUID: quiet})
+		cc.Process(buildLockedStreamWithTSBK(10, 0x293, DUIDTerminator, TSBK{LB: true}), 0)
+		bus.Close()
+		got := strings.Contains(buf.String(), "non-control DUID")
+		if got == quiet {
+			t.Errorf("quiet=%v: non-control DUID logged=%v, want %v", quiet, got, !quiet)
+		}
+	}
+}

--- a/internal/radio/p25/phase1/network.go
+++ b/internal/radio/p25/phase1/network.go
@@ -33,12 +33,25 @@ type Channel struct {
 	ChannelNumber uint16
 }
 
-// NeighborSite is one adjacent site a radio may roam to.
+// NeighborSite is one adjacent site a radio may roam to. ChannelID/
+// ChannelNumber name the neighbour's control-channel downlink; Uplink*
+// are set only when an explicit-channel broadcast (the AMBT form of
+// 0x3C) named the uplink — zero otherwise, in which case the uplink is
+// derived downstream from the band plan's transmit offset. CFVA and
+// ServiceClass come from the TSBK form (the AMBT form doesn't carry
+// them); CFVAKnown distinguishes "flags all zero" from "never seen".
 type NeighborSite struct {
 	RFSS          uint8
 	Site          uint8
+	LRA           uint8
+	SystemID      uint16
 	ChannelID     uint8
 	ChannelNumber uint16
+	UplinkID      uint8
+	UplinkNumber  uint16
+	CFVA          uint8
+	CFVAKnown     bool
+	ServiceClass  uint8
 }
 
 // NetworkConfig is a snapshot of the accumulated system topology.
@@ -198,14 +211,79 @@ func (m *NetworkModel) ApplySecondaryControlChannelExplicit(s SecondaryControlCh
 // SDRtrunk, which corroborate System ID from adjacent broadcasts). RFSS/Site
 // are deliberately NOT voted: they describe the neighbour, not the camped site.
 func (m *NetworkModel) ApplyAdjacentSite(a AdjacentSiteStatusBroadcast) {
+	m.upsertNeighbor(NeighborSite{
+		RFSS: a.RFSS, Site: a.Site, LRA: a.LRA, SystemID: a.SystemID,
+		ChannelID: a.ChannelID, ChannelNumber: a.ChannelNumber,
+		CFVA: a.CFVA, CFVAKnown: true, ServiceClass: a.ServiceClass,
+	})
+}
+
+// ApplyMBTAdjacentSite folds the AMBT form of the Adjacent Site Status
+// Broadcast (0x3C carried in a multi-block PDU) in. It is the only form
+// that names the neighbour's explicit uplink channel; many systems
+// broadcast most or all of their neighbour list ONLY this way, which is
+// why the TSBK-only decoder surfaced one neighbour where SDRTrunk
+// listed twelve.
+func (m *NetworkModel) ApplyMBTAdjacentSite(a MBTAdjacentSiteStatusBroadcast) {
+	m.upsertNeighbor(NeighborSite{
+		RFSS: a.RFSS, Site: a.Site, LRA: a.LRA, SystemID: a.SystemID,
+		ChannelID: a.ChannelID, ChannelNumber: a.ChannelNumber,
+		UplinkID: a.UplinkID, UplinkNumber: a.UplinkNumber,
+	})
+}
+
+// upsertNeighbor merges one adjacent-site observation into the
+// neighbour table, keyed by (RFSS, Site). The TSBK and AMBT forms carry
+// complementary fields (CFVA/service class vs explicit uplink), so a
+// merge keeps whichever half the new observation lacks instead of
+// clobbering it with zeros.
+func (m *NetworkModel) upsertNeighbor(n NeighborSite) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.ensure()
-	if a.SystemID != 0 {
-		m.sysidVotes[a.SystemID]++
+	if n.SystemID != 0 {
+		// Every site of a P25 system shares one System ID, so an adjacent
+		// site names our own — often the only System ID source on systems
+		// that never emit 0x3B/0x3A. RFSS/Site are deliberately NOT voted:
+		// they describe the neighbour, not the camped site.
+		m.sysidVotes[n.SystemID]++
 	}
-	key := neighborKey{RFSS: a.RFSS, Site: a.Site}
-	m.neighborData[key] = NeighborSite{RFSS: a.RFSS, Site: a.Site, ChannelID: a.ChannelID, ChannelNumber: a.ChannelNumber}
+	key := neighborKey{RFSS: n.RFSS, Site: n.Site}
+	if old, ok := m.neighborData[key]; ok {
+		if n.UplinkID == 0 && n.UplinkNumber == 0 {
+			n.UplinkID, n.UplinkNumber = old.UplinkID, old.UplinkNumber
+		}
+		if !n.CFVAKnown {
+			n.CFVA, n.CFVAKnown, n.ServiceClass = old.CFVA, old.CFVAKnown, old.ServiceClass
+		}
+		if n.LRA == 0 {
+			n.LRA = old.LRA
+		}
+		if n.SystemID == 0 {
+			n.SystemID = old.SystemID
+		}
+	}
+	m.neighborData[key] = n
+}
+
+// ApplyMBTNetworkStatus folds the AMBT form of the Network Status
+// Broadcast (0x3B in a multi-block PDU) in — on some systems the ONLY
+// carrier of the WACN.
+func (m *NetworkModel) ApplyMBTNetworkStatus(n MBTNetworkStatusBroadcast) {
+	m.ApplyNetworkStatus(NetworkStatusBroadcast{
+		LRA: n.LRA, WACN: n.WACN, SystemID: n.SystemID,
+		ChannelID: n.ChannelID, ChannelNumber: n.ChannelNumber,
+		ServiceClass: uint16(n.ServiceClass),
+	})
+}
+
+// ApplyMBTRFSSStatus folds the AMBT form of the RFSS Status Broadcast
+// (0x3A in a multi-block PDU) in.
+func (m *NetworkModel) ApplyMBTRFSSStatus(r MBTRFSSStatusBroadcast) {
+	m.ApplyRFSSStatus(RFSSStatusBroadcast{
+		LRA: r.LRA, SystemID: r.SystemID, RFSS: r.RFSS, Site: r.Site,
+		ChannelID: r.ChannelID, ChannelNumber: r.ChannelNumber,
+	})
 }
 
 // Snapshot returns a deep copy of the accumulated topology. Identity fields

--- a/internal/radio/p25/phase1/opcodes.go
+++ b/internal/radio/p25/phase1/opcodes.go
@@ -539,31 +539,41 @@ type RFSSStatusBroadcast struct {
 }
 
 // SecondaryControlChannelBroadcast (opcode 0x39) announces alternate
-// control-channel frequencies for the site. Working-model payload
-// layout:
+// control-channel frequencies for the site. Payload layout per
+// TIA-102.AABC / SDRTrunk's SecondaryControlChannelBroadcast (bit
+// offsets 16.. relative to the TSBK, i.e. payload octets):
 //
 //	byte 0    : RFSS ID
 //	byte 1    : Site ID
-//	bytes 2-3 : secondary control channel A
-//	bytes 4-5 : secondary control channel B (zero when only one)
-//	bytes 6-7 : system service class
+//	bytes 2-3 : secondary control channel A (4-bit ID + 12-bit number)
+//	byte 4    : system service class A
+//	bytes 5-6 : secondary control channel B (4-bit ID + 12-bit number)
+//	byte 7    : system service class B
+//
+// The previous working model read channel B from bytes 4-5 — one byte
+// early, splicing service class A into the channel field and producing a
+// phantom secondary CC; the round-trip test passed because the assembler
+// encoded the same wrong layout (the self-consistent-synthetic trap).
 type SecondaryControlChannelBroadcast struct {
 	RFSS, Site                     uint8
 	ChannelAID, ChannelBID         uint8
 	ChannelANumber, ChannelBNumber uint16
+	ServiceClassA, ServiceClassB   uint8
 }
 
 // ParseSecondaryControlChannelBroadcast decodes payload for opcode 0x39.
 func ParseSecondaryControlChannelBroadcast(p [8]byte) SecondaryControlChannelBroadcast {
 	cA := binary.BigEndian.Uint16(p[2:4])
-	cB := binary.BigEndian.Uint16(p[4:6])
+	cB := binary.BigEndian.Uint16(p[5:7])
 	return SecondaryControlChannelBroadcast{
 		RFSS:           p[0],
 		Site:           p[1],
 		ChannelAID:     uint8(cA >> 12),
 		ChannelANumber: cA & 0x0FFF,
+		ServiceClassA:  p[4],
 		ChannelBID:     uint8(cB >> 12),
 		ChannelBNumber: cB & 0x0FFF,
+		ServiceClassB:  p[7],
 	}
 }
 
@@ -572,7 +582,9 @@ func AssembleSecondaryControlChannelBroadcast(s SecondaryControlChannelBroadcast
 	var p [8]byte
 	p[0], p[1] = s.RFSS, s.Site
 	binary.BigEndian.PutUint16(p[2:4], uint16(s.ChannelAID&0x0F)<<12|s.ChannelANumber&0x0FFF)
-	binary.BigEndian.PutUint16(p[4:6], uint16(s.ChannelBID&0x0F)<<12|s.ChannelBNumber&0x0FFF)
+	p[4] = s.ServiceClassA
+	binary.BigEndian.PutUint16(p[5:7], uint16(s.ChannelBID&0x0F)<<12|s.ChannelBNumber&0x0FFF)
+	p[7] = s.ServiceClassB
 	return p
 }
 
@@ -625,13 +637,24 @@ func AssembleSecondaryControlChannelBroadcastExplicit(s SecondaryControlChannelB
 	return p
 }
 
+// CFVA flag bits of an Adjacent Site Status Broadcast (byte 1 high
+// nibble). Bit positions per TIA-102.AABC / SDRTrunk's
+// AdjacentStatusBroadcast (message bits 24-27 = payload byte 1 bits 7-4).
+const (
+	CFVAConventional uint8 = 0x08 // C: site operates a conventional channel
+	CFVAFailure      uint8 = 0x04 // F: site is in failure condition
+	CFVAValid        uint8 = 0x02 // V: information is valid (site polled OK)
+	CFVAActive       uint8 = 0x01 // A: site has active RFSS network connection
+)
+
 // AdjacentSiteStatusBroadcast (opcode 0x3C) announces a neighbouring
 // site a radio may roam to. Payload layout per TIA-102.AABF — it shares
 // the RFSS Status Broadcast field layout, except byte 1's high nibble
-// carries the CFVA (conventional/failsoft/valid/active) flags rather
+// carries the CFVA (conventional/failure/valid/active) flags rather
 // than reserved bits, and it still names the neighbour's System ID:
 //
 //	byte 0    : LRA (Location Registration Area)
+//	byte 1    : high nibble CFVA flags; low nibble = System ID high bits
 //	bytes 1-2 : System ID (12 bits, low nibble of byte 1 + byte 2)
 //	byte 3    : RFSS ID
 //	byte 4    : Site ID
@@ -639,10 +662,12 @@ func AssembleSecondaryControlChannelBroadcastExplicit(s SecondaryControlChannelB
 //	byte 7    : system service class
 type AdjacentSiteStatusBroadcast struct {
 	LRA           uint8
+	CFVA          uint8  // 4-bit flags, see CFVA* constants
 	SystemID      uint16 // 12-bit
 	RFSS, Site    uint8
 	ChannelID     uint8
 	ChannelNumber uint16
+	ServiceClass  uint8
 }
 
 // ParseAdjacentSiteStatusBroadcast decodes payload for opcode 0x3C.
@@ -650,11 +675,13 @@ func ParseAdjacentSiteStatusBroadcast(p [8]byte) AdjacentSiteStatusBroadcast {
 	ch := binary.BigEndian.Uint16(p[5:7])
 	return AdjacentSiteStatusBroadcast{
 		LRA:           p[0],
+		CFVA:          p[1] >> 4,
 		SystemID:      uint16(p[1]&0x0F)<<8 | uint16(p[2]),
 		RFSS:          p[3],
 		Site:          p[4],
 		ChannelID:     uint8(ch >> 12),
 		ChannelNumber: ch & 0x0FFF,
+		ServiceClass:  p[7],
 	}
 }
 
@@ -662,11 +689,12 @@ func ParseAdjacentSiteStatusBroadcast(p [8]byte) AdjacentSiteStatusBroadcast {
 func AssembleAdjacentSiteStatusBroadcast(a AdjacentSiteStatusBroadcast) [8]byte {
 	var p [8]byte
 	p[0] = a.LRA
-	p[1] = uint8(a.SystemID>>8) & 0x0F
+	p[1] = a.CFVA<<4 | uint8(a.SystemID>>8)&0x0F
 	p[2] = uint8(a.SystemID)
 	p[3] = a.RFSS
 	p[4] = a.Site
 	binary.BigEndian.PutUint16(p[5:7], uint16(a.ChannelID&0x0F)<<12|a.ChannelNumber&0x0FFF)
+	p[7] = a.ServiceClass
 	return p
 }
 

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -333,6 +333,7 @@ func newP25Phase1Pipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 		BandPlan:              bandPlan,
 		Rotations:             rotations,
 		P25Phase1DemodMode:    opts.System.P25Phase1DemodMode,
+		QuietNonControlDUID:   opts.System.P25QuietNonControlDUID,
 		P25Phase2Trellis:      uint8(p2Trellis),
 		P25Phase2RS:           uint8(p2RS),
 		P25Phase2Interleave:   uint8(p2Interleave),

--- a/internal/scanner/widebandt2/engine.go
+++ b/internal/scanner/widebandt2/engine.go
@@ -419,6 +419,24 @@ type engineChannel struct {
 	// activity (delta > 0). Set per protocol in buildChannel.
 	decoded     func() uint64
 	lastDecoded uint64
+	// lastDecodeAt is when the channel last showed a positive decode delta.
+	// It gates the low-power WARN: a channel with live decode evidence within
+	// lowPowerDecodeGrace is healthy whatever its absolute dBFS reads, so the
+	// "carrier likely outside the passband" WARN must not fire against it.
+	lastDecodeAt time.Time
+
+	// Parked-diagnostics state: the per-window DEBUG lines log immediately on
+	// a state change and otherwise summarise at parkedLogInterval instead of
+	// repeating every window (the IPSC log-spam fix). lastLogCnt is the
+	// counter snapshot at the last EMITTED activity line (deltas in that line
+	// cover everything since, so nothing is lost while parked); activityCls
+	// is the class of that line; pwDebugLogAt/lastLoggedDbFS drive the power
+	// line the same way.
+	lastLogCnt     tier2.Counters
+	activityCls    int
+	activityLogAt  time.Time
+	pwDebugLogAt   time.Time
+	lastLoggedDbFS float64
 }
 
 // fixedGainTenthDB interprets a configured gain string the same way the
@@ -766,6 +784,7 @@ func buildChannel(sys trunking.System, ch ChannelConfig, outRateHz float64, bus 
 			// #356 follow-up). The wideband path previously left this unset,
 			// so grants always defaulted to c4fm regardless of the CC's mode.
 			P25Phase1DemodMode:    demodStr,
+			QuietNonControlDUID:   sys.P25QuietNonControlDUID,
 			P25Phase2Trellis:      p2Trellis,
 			P25Phase2RS:           p2RS,
 			P25Phase2Interleave:   p2Interleave,
@@ -1175,6 +1194,43 @@ const noSyncHintDbFS = -45.0
 // tripping it; a real mistuned transmission holds for seconds.
 const strongNoSyncWindowsNeeded = 3
 
+// lowPowerDecodeGrace suppresses the "iq power very low" WARN for a channel
+// that produced protocol decodes (CSBKs / TSBKs / FEC passes) this recently.
+// Absolute dBFS is a gain-staging number, not a health verdict: a Tier III /
+// P25 control channel decoding every beacon at -56 dBFS is healthy, and
+// warning "carrier likely outside the captured passband" against live decode
+// evidence is exactly the absolute-power trap (never gate on dBFS — gate on
+// decode/coherence). The grace covers short inter-decode gaps so the WARN
+// doesn't flap between beacons.
+const lowPowerDecodeGrace = 15 * time.Second
+
+// parkedLogInterval is the cadence of the per-channel DEBUG diagnostics
+// ("channel iq power" / "channel decode activity") once a channel's state is
+// steady. Both lines used to repeat every iqpower.Window (~1 s) per channel
+// forever, which buried a debug log in identical lines (field report: DMR
+// IPSC "endless spam"). A steady channel now logs a summary at this cadence;
+// any state change (activity class flip, power step) still logs immediately.
+const parkedLogInterval = 30 * time.Second
+
+// parkedPowerStepDb is the change in per-channel power (dB) that counts as a
+// state change and re-triggers an immediate "channel iq power" DEBUG line
+// while parked.
+const parkedPowerStepDb = 3.0
+
+// activityClass buckets a window's decode-activity deltas so the parked
+// DEBUG summary can log immediately on a state transition (idle → syncing →
+// decoding and back) while staying quiet through a steady state.
+func activityClass(syncDelta, fecPassDelta, beaconDelta uint64) int {
+	switch {
+	case fecPassDelta > 0 || beaconDelta > 0:
+		return 2 // decoding
+	case syncDelta > 0:
+		return 1 // sync but no FEC
+	default:
+		return 0 // idle
+	}
+}
+
 // maybeLogDiagnostics flushes per-channel signal-power and decode-activity
 // diagnostics once per iqpower.Window. It runs inline on the Run pump
 // goroutine — the same goroutine that fed the tap sinks this window — so
@@ -1246,6 +1302,7 @@ func (e *Engine) maybeLogDiagnostics(now time.Time) {
 			total := ec.decoded()
 			if delta := total - ec.lastDecoded; delta > 0 {
 				ec.lastDecoded = total
+				ec.lastDecodeAt = now
 				e.bus.Publish(events.Event{
 					Kind:      events.KindChannelPower,
 					Timestamp: now,
@@ -1261,8 +1318,15 @@ func (e *Engine) maybeLogDiagnostics(now time.Time) {
 				})
 			}
 		}
+		// A channel with recent protocol decodes is healthy whatever its
+		// absolute dBFS says — never warn "outside the passband / mistuned"
+		// against live decode evidence (the Tier III CC field report: WARN
+		// every 5 s at -56 dBFS while decoding every C_ALOHA). Absolute
+		// power is a gain-staging number; decode output is the verdict.
+		decodingRecently := !ec.lastDecodeAt.IsZero() &&
+			now.Sub(ec.lastDecodeAt) <= lowPowerDecodeGrace
 
-		if dbfs < iqpower.LowPowerThresholdDbFS {
+		if dbfs < iqpower.LowPowerThresholdDbFS && !decodingRecently {
 			// Conventional-DMR carriers (tier2Cnt != nil) legitimately drop to
 			// no carrier between transmissions — an idle repeater is normal,
 			// not a mistune. Treating each idle window like a failed always-on
@@ -1306,8 +1370,18 @@ func (e *Engine) maybeLogDiagnostics(now time.Time) {
 				ec.lowPowerWarned = true
 			}
 		} else if debug {
-			e.log.Debug("widebandt2: channel iq power",
-				"freq_hz", ec.freqHz, "system", ec.sysName, "proto", ec.protoTag, "dbfs", dbfs)
+			// Parked power line: a steady channel logs a summary every
+			// parkedLogInterval instead of every window; a real power step
+			// (≥ parkedPowerStepDb) logs immediately. Kills the per-second
+			// identical-line flood while keeping transitions visible.
+			if ec.pwDebugLogAt.IsZero() ||
+				math.Abs(dbfs-ec.lastLoggedDbFS) >= parkedPowerStepDb ||
+				now.Sub(ec.pwDebugLogAt) >= parkedLogInterval {
+				e.log.Debug("widebandt2: channel iq power",
+					"freq_hz", ec.freqHz, "system", ec.sysName, "proto", ec.protoTag, "dbfs", dbfs)
+				ec.pwDebugLogAt = now
+				ec.lastLoggedDbFS = dbfs
+			}
 		}
 
 		// Per-window decode-activity deltas (Tier II conventional / Tier I).
@@ -1321,14 +1395,27 @@ func (e *Engine) maybeLogDiagnostics(now time.Time) {
 			syncDelta := c.SyncHits - ec.lastCnt.SyncHits
 			fecPassDelta := c.FECPass - ec.lastCnt.FECPass
 			if debug {
-				e.log.Debug("widebandt2: channel decode activity",
-					"freq_hz", ec.freqHz, "system", ec.sysName,
-					"sync_hits", syncDelta,
-					"bursts", c.Bursts-ec.lastCnt.Bursts,
-					"fec_pass", fecPassDelta,
-					"fec_fail", c.FECFail-ec.lastCnt.FECFail,
-					"beacons", c.Beacons-ec.lastCnt.Beacons,
-					"locks_total", c.Locks)
+				// Parked activity line: log immediately when the channel's
+				// activity CLASS changes (idle ↔ syncing ↔ decoding), else
+				// summarise at parkedLogInterval with deltas covering
+				// everything since the last emitted line — so a steady
+				// channel is one line per interval, not one per second, and
+				// no counts are lost while parked.
+				cls := activityClass(syncDelta, fecPassDelta, c.Beacons-ec.lastCnt.Beacons)
+				if ec.activityLogAt.IsZero() || cls != ec.activityCls ||
+					now.Sub(ec.activityLogAt) >= parkedLogInterval {
+					e.log.Debug("widebandt2: channel decode activity",
+						"freq_hz", ec.freqHz, "system", ec.sysName,
+						"sync_hits", c.SyncHits-ec.lastLogCnt.SyncHits,
+						"bursts", c.Bursts-ec.lastLogCnt.Bursts,
+						"fec_pass", c.FECPass-ec.lastLogCnt.FECPass,
+						"fec_fail", c.FECFail-ec.lastLogCnt.FECFail,
+						"beacons", c.Beacons-ec.lastLogCnt.Beacons,
+						"locks_total", c.Locks)
+					ec.activityLogAt = now
+					ec.activityCls = cls
+					ec.lastLogCnt = c
+				}
 			}
 			ec.lastCnt = c
 

--- a/internal/scanner/widebandt2/engine_diag_parked_test.go
+++ b/internal/scanner/widebandt2/engine_diag_parked_test.go
@@ -1,0 +1,64 @@
+package widebandt2
+
+import (
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr/tier2"
+)
+
+// countDiagDebugLines drives `windows` diagnostics flushes spaced `step`
+// apart and returns how many "channel decode activity" and "channel iq
+// power" DEBUG lines were emitted.
+func countDiagDebugLines(t *testing.T, ec *engineChannel, windows int, step time.Duration, chanIQ, wbIQ []complex64) (activity, power int) {
+	t.Helper()
+	handler, recs, mu := newRecordingHandler()
+	e := &Engine{log: slog.New(handler), channels: []*engineChannel{ec}, now: time.Now}
+	base := time.Unix(1_700_000_000, 0)
+	e.maybeLogDiagnostics(base) // seeds lastDiagAt (no flush)
+	for i := 1; i <= windows; i++ {
+		ec.pwr.Add(chanIQ)
+		e.widebandPwr.Add(wbIQ)
+		e.maybeLogDiagnostics(base.Add(time.Duration(i) * step))
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	for _, r := range *recs {
+		if r.level != slog.LevelDebug {
+			continue
+		}
+		switch {
+		case strings.Contains(r.msg, "channel decode activity"):
+			activity++
+		case r.msg == "widebandt2: channel iq power":
+			power++
+		}
+	}
+	return activity, power
+}
+
+// TestSteadyChannelDiagnosticsPark pins the DMR IPSC log-spam fix: a channel
+// in a steady state (same activity class, stable power) must log its
+// per-channel DEBUG diagnostics at parkedLogInterval, not every window. The
+// field report was one "channel decode activity" + one "channel iq power"
+// line per channel per second, forever. 40 windows spaced 2 s apart span
+// 80 s — with parking that's ceil(80/30)+1 = at most 4 of each line, without
+// it 40.
+func TestSteadyChannelDiagnosticsPark(t *testing.T) {
+	const n = 4096
+	cc := tier2.New(tier2.Options{SystemName: "IPSC", FrequencyHz: 443_237_500})
+	ec := &engineChannel{freqHz: 443_237_500, sysName: "IPSC", protoTag: "dmr-tier2", tier2Cnt: cc}
+
+	activity, power := countDiagDebugLines(t, ec, 40, 2*time.Second, loudIQ(n), loudIQ(n))
+	if activity == 0 || power == 0 {
+		t.Fatalf("parked diagnostics must still log periodically (activity=%d power=%d)", activity, power)
+	}
+	if activity > 5 {
+		t.Fatalf("steady-state activity DEBUG lines = %d over 80 s, want <= 5 (parked at %v cadence, not per window)", activity, parkedLogInterval)
+	}
+	if power > 5 {
+		t.Fatalf("steady-state power DEBUG lines = %d over 80 s, want <= 5 (parked at %v cadence, not per window)", power, parkedLogInterval)
+	}
+}

--- a/internal/scanner/widebandt2/engine_lowpower_decoding_test.go
+++ b/internal/scanner/widebandt2/engine_lowpower_decoding_test.go
@@ -1,0 +1,99 @@
+package widebandt2
+
+import (
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// runDiagWindows drives `windows` diagnostics flushes on ec (6 s apart, past
+// the 5 s WARN throttle) and returns the captured records. Like
+// countLowPowerWarns but with a live bus so channels with a decode counter
+// can publish their power events.
+func runDiagWindows(t *testing.T, ec *engineChannel, windows int, chanIQ, wbIQ []complex64) []capturedRecord {
+	t.Helper()
+	handler, recs, mu := newRecordingHandler()
+	bus := events.NewBus(64)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+	go func() {
+		for range sub.C {
+		}
+	}()
+	e := &Engine{log: slog.New(handler), bus: bus, channels: []*engineChannel{ec}, now: time.Now}
+	base := time.Unix(1_700_000_000, 0)
+	e.maybeLogDiagnostics(base) // seeds lastDiagAt (no flush)
+	for i := 1; i <= windows; i++ {
+		ec.pwr.Add(chanIQ)
+		e.widebandPwr.Add(wbIQ)
+		e.maybeLogDiagnostics(base.Add(time.Duration(i) * 6 * time.Second))
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	return append([]capturedRecord(nil), (*recs)...)
+}
+
+// TestLowPowerDecodingControlChannelIsSilent pins the Tier III field report:
+// a control channel decoding every C_ALOHA beacon at -56 dBFS got the
+// "channel iq power very low — carrier likely outside the captured passband"
+// WARN every 5 s, against live decode evidence. Absolute dBFS is a
+// gain-staging number, not a health verdict — a channel with a positive
+// decode delta must never draw the low-power WARN (it gets the DEBUG power
+// line instead). Before the fix this counts `windows` WARNs.
+func TestLowPowerDecodingControlChannelIsSilent(t *testing.T) {
+	const n = 4096
+	var lifetime uint64
+	ec := &engineChannel{
+		freqHz:   440_262_500,
+		sysName:  "FireT3",
+		protoTag: "dmr-tier3",
+		// Each diagnostics window sees fresh decodes, like a CC emitting
+		// C_ALOHA every 60 ms.
+		decoded: func() uint64 { lifetime += 17; return lifetime },
+	}
+
+	recs := runDiagWindows(t, ec, 4, quietIQ(n), loudIQ(n))
+	warns, powerDebugs := 0, 0
+	for _, r := range recs {
+		if r.level == slog.LevelWarn && strings.Contains(r.msg, "iq power very low") {
+			warns++
+		}
+		if r.level == slog.LevelDebug && r.msg == "widebandt2: channel iq power" {
+			powerDebugs++
+		}
+	}
+	if warns != 0 {
+		t.Fatalf("low-power WARNs = %d, want 0 (a decoding control channel is healthy whatever its absolute dBFS)", warns)
+	}
+	if powerDebugs == 0 {
+		t.Fatalf("expected at least one DEBUG power line for a decoding low-power channel (power stays visible without the WARN)")
+	}
+}
+
+// TestLowPowerNonDecodingControlChannelStillWarns pins the counterpart: the
+// same control channel with a decode counter that never moves keeps the
+// repeating WARN — silence with no decodes at the floor is a genuine fault.
+func TestLowPowerNonDecodingControlChannelStillWarns(t *testing.T) {
+	const n = 4096
+	ec := &engineChannel{
+		freqHz:   440_262_500,
+		sysName:  "FireT3",
+		protoTag: "dmr-tier3",
+		decoded:  func() uint64 { return 0 },
+	}
+
+	recs := runDiagWindows(t, ec, 4, quietIQ(n), loudIQ(n))
+	warns := 0
+	for _, r := range recs {
+		if r.level == slog.LevelWarn && strings.Contains(r.msg, "iq power very low") {
+			warns++
+		}
+	}
+	if warns != 4 {
+		t.Fatalf("low-power WARNs = %d, want 4 (a never-decoding control channel at the floor keeps warning)", warns)
+	}
+}

--- a/internal/trunking/network_report.go
+++ b/internal/trunking/network_report.go
@@ -53,10 +53,14 @@ type ReportChannel struct {
 func (c ReportChannel) empty() bool { return c == ReportChannel{} }
 
 // ReportNeighbor is an adjacent site advertised by a control channel.
+// StatusFlags is the human-readable CFVA summary from the adjacent-status
+// broadcast ("" when never observed, "none" when observed all-clear).
 type ReportNeighbor struct {
-	RFSS    uint8
-	Site    uint8
-	Channel ReportChannel
+	RFSS        uint8
+	Site        uint8
+	LRA         uint8
+	Channel     ReportChannel
+	StatusFlags string
 }
 
 // ReportBand is one P25 IDEN_UP band-plan slot.
@@ -145,7 +149,11 @@ func renderSite(w io.Writer, s ReportSite) {
 	})
 	for _, n := range neighbors {
 		line := fmt.Sprintf("NEIGHBOR RFSS:%s SITE:%s CHANNEL", hexDec(uint64(n.RFSS)), hexDec(uint64(n.Site)))
-		fmt.Fprintf(w, "  %s\n", channelLine(line, n.Channel))
+		out := channelLine(line, n.Channel)
+		if n.StatusFlags != "" {
+			out += " STATUS:[" + strings.ToUpper(strings.ReplaceAll(n.StatusFlags, ",", " ")) + "]"
+		}
+		fmt.Fprintf(w, "  %s\n", out)
 	}
 }
 
@@ -282,11 +290,25 @@ func ReportFromTopology(t *TopologySnapshot) NetworkReport {
 		site.SecondaryCC = append(site.SecondaryCC, conv(s.ChannelID, s.ChannelNumber, s.FrequencyHz, s.UplinkHz))
 	}
 	for _, n := range t.Neighbors {
+		// An explicit uplink (the P25 AMBT adjacent-status form) wins; a
+		// pair-only explicit uplink resolves via plain base + number*spacing
+		// (no transmit offset — the uplink channel number already encodes the
+		// uplink frequency). Otherwise conv derives it from the band-plan
+		// transmit offset as before.
+		upHz := n.UplinkHz
+		if upHz == 0 && n.UplinkChannelNumber != 0 {
+			if b, ok := bands[n.UplinkChannelID]; ok && b.BaseHz != 0 && b.SpacingHz != 0 {
+				if hz := b.BaseHz + uint64(n.UplinkChannelNumber)*uint64(b.SpacingHz); hz > 0 && hz <= math.MaxUint32 {
+					upHz = uint32(hz)
+				}
+			}
+		}
 		site.Neighbors = append(site.Neighbors, ReportNeighbor{
-			RFSS: n.RFSS,
-			Site: n.Site,
-			// TopoNeighborRef carries no explicit uplink; it comes from the band plan.
-			Channel: conv(n.ChannelID, n.ChannelNumber, n.FrequencyHz, 0),
+			RFSS:        n.RFSS,
+			Site:        n.Site,
+			LRA:         n.LRA,
+			Channel:     conv(n.ChannelID, n.ChannelNumber, n.FrequencyHz, upHz),
+			StatusFlags: n.StatusFlags,
 		})
 	}
 	r.Sites = []ReportSite{site}

--- a/internal/trunking/site.go
+++ b/internal/trunking/site.go
@@ -368,6 +368,11 @@ type System struct {
 	// default); "on" / "true" / "1" → soft. C4FM only. Parsed via
 	// p25phase1rx.ParseSoftDecision by the ccdecoder connector.
 	P25Phase1SoftDecision string
+	// P25QuietNonControlDUID silences the per-frame "non-control DUID"
+	// debug log line on this system's P25 Phase 1 control channel
+	// (mirrors config.SystemConfig.P25QuietNonControlDUID). Log hygiene
+	// only; decode behaviour is unchanged.
+	P25QuietNonControlDUID bool
 
 	// P25Phase2TrellisMode enables the 4-state ½-rate trellis FEC
 	// decoder on the P25 Phase 2 MAC PDU window. Recognised values

--- a/internal/trunking/topology.go
+++ b/internal/trunking/topology.go
@@ -72,9 +72,21 @@ type TopoChannelRef struct {
 type TopoNeighborRef struct {
 	RFSS          uint8  `json:"rfss" yaml:"rfss"`
 	Site          uint8  `json:"site" yaml:"site"`
+	LRA           uint8  `json:"lra,omitempty" yaml:"lra,omitempty"`
+	SystemID      uint32 `json:"system_id,omitempty" yaml:"system_id,omitempty"`
 	ChannelID     uint8  `json:"channel_id,omitempty" yaml:"channel_id,omitempty"`
 	ChannelNumber uint16 `json:"channel_number,omitempty" yaml:"channel_number,omitempty"`
 	FrequencyHz   uint32 `json:"frequency_hz,omitempty" yaml:"frequency_hz,omitempty"`
+	// Uplink* name the neighbour's explicit uplink channel when the broadcast
+	// carried one (the P25 AMBT adjacent-status form); zero otherwise, in
+	// which case the uplink is derived from the band plan's transmit offset.
+	UplinkChannelID     uint8  `json:"uplink_channel_id,omitempty" yaml:"uplink_channel_id,omitempty"`
+	UplinkChannelNumber uint16 `json:"uplink_channel_number,omitempty" yaml:"uplink_channel_number,omitempty"`
+	UplinkHz            uint32 `json:"uplink_hz,omitempty" yaml:"uplink_hz,omitempty"`
+	// StatusFlags is a short human-readable summary of the neighbour's CFVA
+	// flags from the TSBK adjacent-status form (e.g. "valid,active"),
+	// empty when the flags were never observed.
+	StatusFlags string `json:"status_flags,omitempty" yaml:"status_flags,omitempty"`
 }
 
 // TopoBandPlanSlot is one entry of a P25-style band plan (IDEN_UP): a channel

--- a/internal/voice/composer/composer.go
+++ b/internal/voice/composer/composer.go
@@ -169,6 +169,10 @@ type Options struct {
 	// TouchInterval is how often the chain pings Engine.Touch while
 	// audio is flowing (default 1 s).
 	TouchInterval time.Duration
+	// VoiceIQDebug enables per-call voice-channel IQ debug captures (the
+	// diagnostic-container workflow, see voice_iq_debug.go). Off by
+	// default; zero cost when disabled.
+	VoiceIQDebug VoiceIQDebugConfig
 	// VoiceHangtime is the universal end-of-transmission window applied
 	// to every voice chain: once voice has been decoding, the chain ends
 	// the call this long after the last decoded voice frame (rather than
@@ -284,19 +288,20 @@ type Composer struct {
 	engine EngineHooks
 	log    *slog.Logger
 
-	iqHz       uint32
-	pcmHz      uint32
-	bw         uint32
-	touchEvery time.Duration
-	hangtime   time.Duration
-	splitTx    bool
-	eqCfg      EqualizerConfig
-	deemphCfg  DeEmphasisConfig
-	lpfCfg     AudioLPFConfig
-	agcCfg     AudioAGCConfig
-	resampCfg  AudioResamplerConfig
-	autotune   *autotune.Registry
-	cryptoSink cryptocap.Sink
+	iqHz         uint32
+	voiceIQDebug VoiceIQDebugConfig
+	pcmHz        uint32
+	bw           uint32
+	touchEvery   time.Duration
+	hangtime     time.Duration
+	splitTx      bool
+	eqCfg        EqualizerConfig
+	deemphCfg    DeEmphasisConfig
+	lpfCfg       AudioLPFConfig
+	agcCfg       AudioAGCConfig
+	resampCfg    AudioResamplerConfig
+	autotune     *autotune.Registry
+	cryptoSink   cryptocap.Sink
 	// squelch is the optional conventional-scanner squelch feed for the
 	// FM chain (issue #1090). Guarded by mu: the daemon sets it after
 	// construction (SetSquelchState) and each chain reads it once at
@@ -405,6 +410,7 @@ func New(opts Options) (*Composer, error) {
 		engine:       opts.Engine,
 		log:          log,
 		iqHz:         opts.IQSampleRate,
+		voiceIQDebug: opts.VoiceIQDebug,
 		pcmHz:        opts.PCMSampleRate,
 		bw:           opts.VoiceBandwidthHz,
 		touchEvery:   opts.TouchInterval,
@@ -620,6 +626,12 @@ func (c *Composer) handleStart(parent context.Context, cs trunking.CallStart) {
 		if r := exact.SampleRateExactHz(); r > 0 {
 			rateHzF = r
 		}
+	}
+	// Diagnostic-container voice capture: tee the exact IQ stream this
+	// call's chain will decode into a per-call file (voice_iq_debug.go).
+	// Lossless toward the chain; disk side is best-effort.
+	if c.voiceIQDebug.Enabled {
+		iqCh = c.teeVoiceIQ(chainCtx, iqCh, cs, rateHzF)
 	}
 	ch := &chain{cancel: cancel, done: make(chan struct{})}
 	c.mu.Lock()

--- a/internal/voice/composer/voice_iq_debug.go
+++ b/internal/voice/composer/voice_iq_debug.go
@@ -1,0 +1,250 @@
+package composer
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// Per-call voice-channel IQ debug capture — the voice half of the
+// "diagnostic container" workflow (the operator's feature request: a
+// metadata + control-IQ + voice-IQ triplet per call, so a hopped voice
+// channel's raw samples are on disk the moment a decode sounds wrong).
+// When enabled, handleStart tees each call's channelised IQ — EXACTLY the
+// stream the voice chain decodes, at the same rate — into
+// `<dir>/<UTC>_<system>_tg<group>_<freq>_<rate>_voice.cs16` plus a
+// self-describing `.metadata.json` sidecar (siglab schema, so the file
+// drops straight into `gophertrunk replay` / siglab). The control-channel
+// half is baseband.auto_record with on_voice_grant.
+//
+// The tee is lossless toward the decode chain (the chain sees the same
+// chunks with the same backpressure); the DISK side is the best-effort
+// one. A writer that cannot keep up stops the capture and marks the
+// sidecar truncated rather than dropping chunks mid-file — a gap silently
+// desynchronises the stream and every later DSP conclusion is wrong with
+// nothing to show for it (the diversity-capture alignment lesson).
+
+// VoiceIQDebugConfig mirrors config.VoiceIQDebugConfig for the composer.
+type VoiceIQDebugConfig struct {
+	Enabled bool
+	Dir     string
+	// MaxBytes caps one call's capture; 0 defaults to
+	// voiceIQDebugDefaultMaxBytes.
+	MaxBytes int64
+}
+
+// voiceIQDebugDefaultMaxBytes bounds one call's capture when the config
+// doesn't: 512 MB (~45 min of 48 kHz cs16, ~55 s of 2.4 MS/s cs16).
+const voiceIQDebugDefaultMaxBytes = 512 << 20
+
+// voiceIQDebugQueue is the writer goroutine's chunk queue depth. At the
+// channelised 48 kHz a chunk is a few ms of IQ, so this rides out normal
+// filesystem latency; when the queue fills the capture ends (truncated),
+// never stalls the decode chain.
+const voiceIQDebugQueue = 256
+
+// teeVoiceIQ wraps in with a per-call IQ capture. The returned channel
+// delivers the same chunks with the same semantics; the capture goroutine
+// owns the file and closes it when the input channel closes or ctx ends.
+func (c *Composer) teeVoiceIQ(ctx context.Context, in <-chan []complex64, cs trunking.CallStart, rateHz float64) <-chan []complex64 {
+	maxBytes := c.voiceIQDebug.MaxBytes
+	if maxBytes <= 0 {
+		maxBytes = voiceIQDebugDefaultMaxBytes
+	}
+	w, err := newVoiceIQDebugWriter(c.voiceIQDebug.Dir, cs, rateHz, maxBytes, c.log)
+	if err != nil {
+		c.log.Warn("composer: voice IQ debug capture failed to open; call decodes without capture",
+			"system", cs.Grant.System, "group", cs.Grant.GroupID, "err", err)
+		return in
+	}
+	out := make(chan []complex64)
+	go func() {
+		defer close(out)
+		defer w.close()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case chunk, ok := <-in:
+				if !ok {
+					return
+				}
+				w.offer(chunk)
+				select {
+				case <-ctx.Done():
+					return
+				case out <- chunk:
+				}
+			}
+		}
+	}()
+	return out
+}
+
+// voiceIQDebugWriter owns one call's capture file + sidecar.
+type voiceIQDebugWriter struct {
+	path     string
+	metaPath string
+	meta     *siglab.Metadata
+	log      *slog.Logger
+	queue    chan []complex64
+	done     chan struct{}
+
+	// samples is written by the disk goroutine and read after done closes;
+	// truncated is shared between the chain-side offer and the disk
+	// goroutine, hence atomic.
+	samples   int64
+	truncated atomic.Bool
+}
+
+// newVoiceIQDebugWriter opens the capture files and starts the disk
+// goroutine. The sidecar is written immediately (so a crashed daemon still
+// leaves a replayable pair) and rewritten at close with the final counts.
+func newVoiceIQDebugWriter(dir string, cs trunking.CallStart, rateHz float64, maxBytes int64, log *slog.Logger) (*voiceIQDebugWriter, error) {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, err
+	}
+	at := cs.StartedAt
+	if at.IsZero() {
+		at = time.Now()
+	}
+	base := fmt.Sprintf("%s_%s_tg%d_%d_%.0f_voice",
+		at.UTC().Format("20060102T150405.000"),
+		sanitizeFileToken(cs.Grant.System), cs.Grant.GroupID,
+		cs.Grant.FrequencyHz, rateHz)
+	base = strings.ReplaceAll(base, ".", "_") // keep one extension dot
+	w := &voiceIQDebugWriter{
+		path:     filepath.Join(dir, base+".cs16"),
+		metaPath: filepath.Join(dir, base+".metadata.json"),
+		log:      log,
+		queue:    make(chan []complex64, voiceIQDebugQueue),
+		done:     make(chan struct{}),
+	}
+	w.meta = &siglab.Metadata{
+		Protocol:     cs.Grant.Protocol,
+		Source:       "gophertrunk voice_iq_debug (per-call voice-channel IQ)",
+		SampleRateHz: rateHz,
+		CenterFreqHz: cs.Grant.FrequencyHz,
+		Format:       siglab.FormatS16.String(),
+		System: map[string]string{
+			"system":     cs.Grant.System,
+			"talkgroup":  strconv.FormatUint(uint64(cs.Grant.GroupID), 10),
+			"source_id":  strconv.FormatUint(uint64(cs.Grant.SourceID), 10),
+			"timeslot":   strconv.Itoa(int(cs.Grant.Timeslot)),
+			"rfss":       strconv.Itoa(int(cs.Grant.RFSSID)),
+			"site":       strconv.Itoa(int(cs.Grant.SiteID)),
+			"nac":        strconv.Itoa(int(cs.Grant.NAC)),
+			"device":     cs.DeviceSerial,
+			"granted_at": at.UTC().Format(time.RFC3339Nano),
+			"encrypted":  strconv.FormatBool(cs.Grant.Encrypted),
+			"emergency":  strconv.FormatBool(cs.Grant.Emergency),
+		},
+	}
+	f, err := os.Create(w.path)
+	if err != nil {
+		return nil, err
+	}
+	if err := siglab.WriteMetadata(w.metaPath, w.meta); err != nil {
+		log.Warn("composer: voice IQ debug metadata write failed", "path", w.metaPath, "err", err)
+	}
+	go w.run(f, maxBytes)
+	return w, nil
+}
+
+// offer hands a chunk to the disk goroutine without ever blocking the
+// decode chain. The chunk is copied (the producer may reuse its buffer).
+// A full queue trips truncation: the writer stops accepting and the
+// sidecar records it, keeping the on-disk stream gap-free up to that
+// point.
+func (w *voiceIQDebugWriter) offer(chunk []complex64) {
+	if w.truncatedNow() {
+		return
+	}
+	cp := append([]complex64(nil), chunk...)
+	select {
+	case w.queue <- cp:
+	default:
+		w.markTruncated("writer backlog")
+	}
+}
+
+func (w *voiceIQDebugWriter) truncatedNow() bool {
+	select {
+	case <-w.done:
+		return true
+	default:
+		return w.truncated.Load()
+	}
+}
+
+func (w *voiceIQDebugWriter) markTruncated(reason string) {
+	if !w.truncated.Swap(true) {
+		w.log.Warn("composer: voice IQ debug capture truncated", "path", w.path, "reason", reason)
+	}
+}
+
+// close ends the capture: drains what is queued, closes the file, and
+// rewrites the sidecar with the final sample count / truncation flag.
+func (w *voiceIQDebugWriter) close() {
+	close(w.queue)
+	<-w.done
+	w.meta.System["samples"] = strconv.FormatInt(w.samples, 10)
+	if w.truncated.Load() {
+		w.meta.System["truncated"] = "true"
+	}
+	if err := siglab.WriteMetadata(w.metaPath, w.meta); err != nil {
+		w.log.Warn("composer: voice IQ debug metadata rewrite failed", "path", w.metaPath, "err", err)
+	}
+	w.log.Info("composer: voice IQ debug capture closed",
+		"path", w.path, "samples", w.samples, "truncated", w.truncated.Load())
+}
+
+// run is the disk goroutine: encodes queued chunks as cs16 until the queue
+// closes or the byte cap is hit.
+func (w *voiceIQDebugWriter) run(f *os.File, maxBytes int64) {
+	defer close(w.done)
+	defer f.Close()
+	bw := bufio.NewWriterSize(f, 1<<16)
+	enc := siglab.NewCaptureWriter(bw, siglab.FormatS16)
+	var written int64
+	for chunk := range w.queue {
+		if w.truncated.Load() {
+			continue // drain without writing once truncated
+		}
+		if written+int64(len(chunk)*4) > maxBytes {
+			w.markTruncated("max_mb cap")
+			continue
+		}
+		if err := enc.Write(chunk); err != nil {
+			w.markTruncated("write error: " + err.Error())
+			continue
+		}
+		written += int64(len(chunk) * 4)
+		w.samples += int64(len(chunk))
+	}
+	if err := bw.Flush(); err != nil {
+		w.markTruncated("flush error: " + err.Error())
+	}
+}
+
+// sanitizeFileToken keeps a config-supplied name filesystem-safe.
+func sanitizeFileToken(s string) string {
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_':
+			return r
+		default:
+			return '-'
+		}
+	}, s)
+}

--- a/internal/voice/composer/voice_iq_debug_test.go
+++ b/internal/voice/composer/voice_iq_debug_test.go
@@ -1,0 +1,111 @@
+package composer
+
+import (
+	"context"
+	"encoding/binary"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+	"log/slog"
+)
+
+// TestTeeVoiceIQWritesPerCallCapture pins the diagnostic-container voice
+// capture: the tee must (1) pass every chunk through to the chain unchanged
+// and in order, (2) write those exact samples as cs16 to a per-call file,
+// and (3) leave a siglab metadata sidecar carrying the grant's parameters
+// (system, talkgroup, source, frequency, rate) so the file drops straight
+// into replay/siglab.
+func TestTeeVoiceIQWritesPerCallCapture(t *testing.T) {
+	dir := t.TempDir()
+	c := &Composer{
+		log:          slog.Default(),
+		voiceIQDebug: VoiceIQDebugConfig{Enabled: true, Dir: dir},
+	}
+	cs := trunking.CallStart{
+		Grant: trunking.Grant{
+			System: "Ost", Protocol: "p25", GroupID: 204, SourceID: 1234,
+			FrequencyHz: 450_962_500, RFSSID: 1, SiteID: 7, NAC: 0x2C1,
+		},
+		DeviceSerial: "VOICE-1",
+		StartedAt:    time.Unix(1_700_000_000, 0).UTC(),
+	}
+
+	in := make(chan []complex64, 4)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	out := c.teeVoiceIQ(ctx, in, cs, 48_000)
+
+	want := []complex64{0.5 + 0i, 0 - 0.25i, -0.125 + 0.75i, 1 + 0i}
+	in <- want[:2]
+	in <- want[2:]
+	close(in)
+
+	var got []complex64
+	for chunk := range out {
+		got = append(got, chunk...)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("chain received %d samples, want %d (the tee must be lossless toward the chain)", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("chain sample %d = %v, want %v", i, got[i], want[i])
+		}
+	}
+
+	// The writer closes asynchronously after out closes; poll briefly for the
+	// final sidecar rewrite (it carries the samples count).
+	files, _ := filepath.Glob(filepath.Join(dir, "*_voice.cs16"))
+	if len(files) != 1 {
+		t.Fatalf("capture files = %v, want exactly one *_voice.cs16", files)
+	}
+	metaPath := strings.TrimSuffix(files[0], ".cs16") + ".metadata.json"
+	deadline := time.Now().Add(2 * time.Second)
+	var meta *siglab.Metadata
+	for {
+		m, err := siglab.LoadMetadata(metaPath)
+		if err == nil && m.System["samples"] != "" {
+			meta = m
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("metadata sidecar never finalised (err=%v, meta=%+v)", err, m)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if meta.Protocol != "p25" || meta.SampleRateHz != 48_000 || meta.CenterFreqHz != 450_962_500 {
+		t.Errorf("metadata = proto %q rate %v center %d, want p25/48000/450962500", meta.Protocol, meta.SampleRateHz, meta.CenterFreqHz)
+	}
+	if meta.System["system"] != "Ost" || meta.System["talkgroup"] != "204" || meta.System["source_id"] != "1234" {
+		t.Errorf("metadata system fields = %+v", meta.System)
+	}
+	if meta.System["samples"] != "4" {
+		t.Errorf("metadata samples = %q, want 4", meta.System["samples"])
+	}
+	if meta.System["truncated"] == "true" {
+		t.Error("capture marked truncated on a trivially small stream")
+	}
+
+	// The cs16 body must be the exact samples, int16-scaled.
+	raw, err := os.ReadFile(files[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(raw) != len(want)*4 {
+		t.Fatalf("capture bytes = %d, want %d (4 per sample)", len(raw), len(want)*4)
+	}
+	for i, s := range want {
+		re := int16(binary.LittleEndian.Uint16(raw[4*i:]))
+		im := int16(binary.LittleEndian.Uint16(raw[4*i+2:]))
+		if math.Abs(float64(re)-float64(real(s))*32767) > 1 ||
+			math.Abs(float64(im)-float64(imag(s))*32767) > 1 {
+			t.Errorf("sample %d = (%d,%d), want ~(%v,%v)", i, re, im, real(s)*32767, imag(s)*32767)
+		}
+	}
+}

--- a/web/src/App.panels.test.tsx
+++ b/web/src/App.panels.test.tsx
@@ -288,10 +288,11 @@ describe("App panel mounting (issue #290 regression)", () => {
     expect(
       within(dialog).getByText("Network identity (decoded live)"),
     ).toBeInTheDocument();
-    // Four identity fields all share the same hunt-state hint.
+    // All six identity fields (WACN, System ID, RFSS, Site, NAC, LRA)
+    // share the same hunt-state hint.
     expect(
       within(dialog).getAllByText("Hunting control channel"),
-    ).toHaveLength(4);
+    ).toHaveLength(6);
     // No em-dash fallback inside the modal — every empty cell now
     // carries an explanatory hint.
     expect(within(dialog).queryByText("—")).toBeNull();

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -27,6 +27,14 @@ export interface SystemDTO {
   system_id?: number;
   rfss?: number;
   site?: number;
+  // NAC and LRA of the camped site, decoded live (P25). Absent until heard.
+  nac?: number;
+  lra?: number;
+  // The camped site's advertised control channels (primary + secondaries),
+  // decoded live from RFSS/Network Status and Secondary Control Channel
+  // broadcasts. Absent until decoded.
+  primary_control_channel?: SiteChannelDTO;
+  secondary_control_channels?: SiteChannelDTO[];
   // TETRA network identity decoded live from the control channel (MLE-SYSINFO /
   // D-NWRK-BROADCAST). TETRA has no WACN/RFSS/Site, so the P25 fields above stay
   // zero and the UI shows these instead. MCC+MNC form the Mobile Network Identity
@@ -53,12 +61,25 @@ export interface SystemDTO {
 export interface NeighborDTO {
   rfss: number;
   site: number;
+  lra?: number;
   channel_id?: number;
   channel_number?: number;
   downlink_hz?: number;
   uplink_hz?: number;
   rfss_hex?: string;
   site_hex?: string;
+  // Human-readable CFVA flag summary from the adjacent-status broadcast
+  // (e.g. "valid,active"); absent when never observed.
+  status?: string;
+}
+
+// SiteChannelDTO mirrors api.SiteChannelDTO — one advertised control channel
+// of the camped site with band-plan-resolved frequencies.
+export interface SiteChannelDTO {
+  channel_id?: number;
+  channel_number?: number;
+  downlink_hz?: number;
+  uplink_hz?: number;
 }
 
 // BandPlanSlotDTO mirrors api.BandPlanSlotDTO — one P25 IDEN_UP frequency-band

--- a/web/src/panels/Systems.tsx
+++ b/web/src/panels/Systems.tsx
@@ -15,6 +15,7 @@ import type {
   DMRBandPlanLearnedDTO,
   EventDTO,
   NeighborDTO,
+  SiteChannelDTO,
   SiteDTO,
   SystemDTO,
   SystemHuntStatusDTO,
@@ -46,13 +47,32 @@ function formatNeighbor(n: NeighborDTO, idBase: "hex" | "dec"): string {
   const rfss = formatIdNumber(n.rfss, idBase) ?? String(n.rfss);
   const site = formatIdNumber(n.site, idBase) ?? String(n.site);
   let s = `RFSS ${rfss} / Site ${site}`;
+  if (n.channel_id || n.channel_number) {
+    s += ` · CH ${n.channel_id ?? 0}-${n.channel_number ?? 0}`;
+  }
   if (n.downlink_hz) {
     s += ` → ${(n.downlink_hz / 1e6).toFixed(6)} MHz`;
-  } else if (n.channel_id != null && n.channel_number != null) {
-    // No resolved frequency yet (the neighbour's band plan hasn't been heard):
-    // show the raw channel coordinates like SDRtrunk's "CHANNEL:2-1754" so the
-    // row isn't blank while the IDEN_UP for that band is still awaited.
-    s += ` → CHANNEL ${n.channel_id}-${n.channel_number}`;
+    if (n.uplink_hz) {
+      s += ` / ↑ ${(n.uplink_hz / 1e6).toFixed(6)} MHz`;
+    }
+  }
+  // CFVA flags from the adjacent-status broadcast — SDRtrunk shows these as
+  // STATUS:[VALID INFORMATION] etc.; "none" means observed all-clear.
+  if (n.status) {
+    s += ` [${n.status}]`;
+  }
+  return s;
+}
+
+// formatSiteChannel renders one advertised control channel of the camped site
+// ("CH 2-1620 → 450.125000 MHz / ↑ 460.687500 MHz").
+function formatSiteChannel(c: SiteChannelDTO): string {
+  let s = `CH ${c.channel_id ?? 0}-${c.channel_number ?? 0}`;
+  if (c.downlink_hz) {
+    s += ` → ${(c.downlink_hz / 1e6).toFixed(6)} MHz`;
+    if (c.uplink_hz) {
+      s += ` / ↑ ${(c.uplink_hz / 1e6).toFixed(6)} MHz`;
+    }
   }
   return s;
 }
@@ -381,10 +401,43 @@ export function Systems() {
                     value={formatIdNumber(selected.site ?? null, idBase)}
                     emptyHint={hint}
                   />
+                  <DetailField
+                    label="NAC"
+                    mono
+                    value={formatIdNumber(selected.nac ?? null, idBase)}
+                    emptyHint={hint}
+                  />
+                  <DetailField
+                    label="LRA"
+                    mono
+                    value={formatIdNumber(selected.lra ?? null, idBase)}
+                    emptyHint={hint}
+                  />
                 </div>
               </div>
             );
           })()}
+          {selected.primary_control_channel ||
+          (selected.secondary_control_channels &&
+            selected.secondary_control_channels.length > 0) ? (
+            <div>
+              <p className="text-xs uppercase tracking-wider text-muted mb-2">
+                Site control channels (decoded live)
+              </p>
+              <DetailField
+                label="Primary / secondaries → downlink / uplink"
+                mono
+                value={[
+                  ...(selected.primary_control_channel
+                    ? [`PRI ${formatSiteChannel(selected.primary_control_channel)}`]
+                    : []),
+                  ...(selected.secondary_control_channels ?? []).map(
+                    (c) => `SEC ${formatSiteChannel(c)}`,
+                  ),
+                ].join("\n")}
+              />
+            </div>
+          ) : null}
           {(() => {
             const bp = selected.dmr_band_plan;
             if (!bp) return null;
@@ -424,7 +477,7 @@ export function Systems() {
                 Neighbor sites ({selected.neighbors.length})
               </p>
               <DetailField
-                label="RFSS / Site → downlink"
+                label="RFSS / Site · channel → downlink / uplink"
                 mono
                 value={selected.neighbors
                   .map((n) => formatNeighbor(n, idBase))


### PR DESCRIPTION
One field report, four fixes:

P25 system discovery (the "only 1 neighbor site / no WACN" gap):
- Decode PDU (DUID 0xC) frames on the control channel as Multi-Block
  Trunking instead of dropping them as "non-control DUID". AMBT forms of
  NET_STS_BCST (WACN + explicit downlink/uplink), RFSS_STS_BCST and
  ADJ_STS_BCST (neighbours with explicit uplinks) feed the same topology
  model as their TSBK twins; header CRC-CCITT16 + data CRC-32 gate
  acceptance. Layouts cross-checked against SDRTrunk AMBTC* and OP25
  process_PDU. Blocks reuse the TSBK trellis/deinterleave chain.
- Fix TSBK SCCB (0x39) layout: channel B was read one byte early
  (phantom secondary CC); capture both service classes. Pinned with a
  literal byte vector so a self-consistent round-trip can't hide it.
- ADJ_STS_BCST now captures CFVA flags + service class into the struct.
- Thread NAC/LRA, primary + secondary CCs, and per-neighbour
  LRA/uplink/status through topology -> report -> API DTO -> web Systems
  panel (uplinks and [valid,active] flags now render like SDRTrunk).

Log hygiene:
- Suppress the "channel iq power very low" WARN for any channel whose
  protocol decode counter advanced recently: absolute dBFS is a
  gain-staging number, not a health verdict (Tier III CC decoded every
  C_ALOHA at -56 dBFS while being told its carrier was off-passband).
- Park steady-state per-channel DEBUG diagnostics: "channel decode
  activity" / "channel iq power" log on state change, else summarise
  every 30 s (was one line per channel per second, forever — the DMR
  IPSC log flood). Same for the DMR Tier III per-CSBK line: unchanged
  repeating Aloha beacons summarise every 10 s with a suppressed count.
- New per-system knob p25_quiet_noncontrol_duid silences the per-frame
  non-control-DUID debug line (TDU spam); default keeps it.

Diagnostic IQ containers (per-call voice + CC capture triplet):
- baseband.voice_iq_debug tees each voice call's exact channelised IQ
  into <ts>_<system>_tg<n>_<freq>_<rate>_voice.cs16 plus a siglab
  .metadata.json sidecar (system/talkgroup/source/freq/rate) —
  replayable directly; lossless toward the decode chain, truncating
  (and saying so) rather than gapping when the disk can't keep up.
- baseband.auto_record.on_voice_grant fires the existing CC
  auto-recorder per grant (cooldown-limited) for the CC-context half.

Refs the Discord field report (P25 discovery asked "at least 4 times",
IPSC log spam, Tier3 low-power WARN anomaly, PDU/TDU log knob,
diagnostic-container feature request).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01441kmr2Ei9tEvEWz61w22h