### PR TITLE
replay: live OpenWebRX+ pipeline — streaming JSONL events, -audio-out PCM, cf32 alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,24 @@ for tagged releases.
   is still pending — synthetic-green is not on-air-proven (#764/#771).
 
 ### Added
+- **`replay -in -` is now a full live pipeline stage for external IQ sources
+  (OpenWebRX+ hand-off, #314).** Three pieces complete the stdin→stdout
+  integration the offline pipe started: `-out-format jsonl` now **streams each
+  decoded event the moment it happens** (grants, locks, calls) instead of
+  batch-dumping at EOF — so an unbounded live pipe actually produces output —
+  with the trailing summary line still landing at stream end (file-based jsonl
+  output is byte-identical to before); a new **`-audio-out <path|->`** streams
+  decoded voice as continuous raw s16le mono 8 kHz PCM to a file, FIFO, or
+  stdout as calls decode (usable with or without `-record-voice`; wires the
+  production engine→composer→recorder voice path, digital voice included via
+  the recorder's decoded-PCM tap); and `-format` accepts **`cf32`/`fc32`** as
+  aliases for f32 — the SoapySDR/OpenWebRX+ spelling of interleaved float32
+  IQ. A channelized narrowband stream below the protocol's channel rate is
+  interpolated up by the existing DDC, so OWRX+ can hand off at 24/48 kHz.
+  Example:
+  `owrx-iq | gophertrunk replay -in - -format cf32 -sample-rate 48000
+  -protocol dmr-tier2 -freq 438900000 -audio-out - -out-format jsonl -out
+  events.jsonl`.
 - **P25 Multi-Block Trunking (AMBT) decode — full system discovery.** A PDU
   (DUID 0xC) on the control channel is now decoded as Multi-Block Trunking
   instead of being dropped as "non-control DUID": the AMBT forms of the

--- a/cmd/gophertrunk/replay.go
+++ b/cmd/gophertrunk/replay.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"time"
@@ -33,7 +34,7 @@ func runReplay(args []string) {
 	fs := flag.NewFlagSet("replay", flag.ExitOnError)
 	verboseFlag := fs.Bool("verbose-errors", false, "print full error chain + stack on failures")
 	in := fs.String("in", "", "raw IQ input file, or - for standard input (required). Piping stdin lets an external IQ source feed the decoder, e.g. `iq-source | gophertrunk replay -in - -format f32 -sample-rate 2400000` (issue #314). stdin is a one-way stream, so -auto-tune (which must seek) is not supported with -in -; use -tune-hz.")
-	format := fs.String("format", "u8", "sample format: u8 (rtl_sdr 8-bit unsigned interleaved IQ) | f32 (GNU Radio cfile, interleaved float32) | cs16/sc16 (interleaved little-endian int16 IQ, the .raw/.cs16 SDR capture format) | wav (2-channel 16-bit baseband WAV — SDRtrunk/SDR++/GopherTrunk narrowband recording; sample rate is read from the header)")
+	format := fs.String("format", "u8", "sample format: u8 (rtl_sdr 8-bit unsigned interleaved IQ) | f32 (GNU Radio cfile, interleaved float32; aliases cf32/fc32 — the SoapySDR/OpenWebRX+ spelling) | cs16/sc16 (interleaved little-endian int16 IQ, the .raw/.cs16 SDR capture format) | wav (2-channel 16-bit baseband WAV — SDRtrunk/SDR++/GopherTrunk narrowband recording; sample rate is read from the header)")
 	sampleRate := fs.Float64("sample-rate", 2_400_000, "IQ sample rate in Hz")
 	demod := fs.String("demod", "c4fm", "P25 Phase 1 demod mode: c4fm | cqpsk")
 	protocolFlag := fs.String("protocol", "p25p1", "decoder to run: p25p1 | p25-phase2 | dmr | dmr-tier2 | nxdn | dpmr | edacs | motorola | ltr | mpt1327 | tetra | ysf | dstar (aliases: dmr-tier3)")
@@ -53,6 +54,7 @@ func runReplay(args []string) {
 	out := fs.String("out", "", "write structured output to this file (default: stdout for non-text)")
 	recordVoice := fs.Bool("record-voice", false, "decode and record voice for the capture's grants, writing .wav/.raw/.json under -out-dir. Wires the production voice path (engine → composer → recorder) onto the decode, following each grant on the decoded (same) carrier. Best for conventional systems (DMR Tier II / IPSC, TETRA) whose voice rides the decoded carrier.")
 	outDir := fs.String("out-dir", "", "recordings directory for -record-voice (required with it)")
+	audioOut := fs.String("audio-out", "", "stream decoded voice audio as continuous raw signed 16-bit little-endian mono PCM at 8000 Hz to this file/FIFO, or - for stdout — so an external consumer (OpenWebRX+, aplay, sox) plays calls live instead of waiting for per-call WAVs (issue #314). Wires the same voice path as -record-voice (usable with or without it) and shares its constraints: requires -freq, no -auto-tune. With -audio-out -, give -out a file path so the decode result doesn't interleave with the PCM on stdout. Opening a FIFO blocks until a reader attaches.")
 	voiceHangtimeMs := fs.Int("voice-hangtime-ms", 3500, "end-of-transmission hangtime for -record-voice, in ms")
 	fs.Usage = func() {
 		fmt.Fprintln(fs.Output(), `gophertrunk replay — decode a raw IQ capture file offline (any protocol).
@@ -67,9 +69,16 @@ EXAMPLES:
   gophertrunk replay -in mt_anakie.bin -sample-rate 2048000 -demod c4fm -diag
 
   # Decode a raw IQ stream piped in on stdin (e.g. from OpenWebRX+ / rtl_sdr -),
-  # emitting decoded events to stdout as JSONL
+  # emitting each decoded event to stdout as a JSONL line the moment it happens
   iq-source | gophertrunk replay -in - -format f32 -sample-rate 2400000 \
                     -protocol p25p1 -tune-hz -12500 -out-format jsonl
+
+  # OpenWebRX+ hand-off: a single channelized cf32 stream on stdin (any rate ≥
+  # the protocol's channel rate is decimated, a narrower one is interpolated up),
+  # live voice PCM (s16le mono 8 kHz) on stdout, decoded events to a JSONL file
+  owrx-iq-source | gophertrunk replay -in - -format cf32 -sample-rate 48000 \
+                    -protocol dmr-tier2 -freq 438900000 \
+                    -audio-out - -out-format jsonl -out events.jsonl
 
   # Wideband cfile whose control channel is off-centre: auto-tune to 0 Hz
   gophertrunk replay -in mmr-s9.cfile -format f32 -sample-rate 2400000 -auto-tune
@@ -141,32 +150,77 @@ FLAGS:`)
 		Log:                  logger,
 	}
 
-	// Optional voice recording: wire the production voice path (engine → composer
-	// → recorder) onto the decode's grant bus + channelized-IQ tap, so grants
-	// become .wav/.raw/.json recordings. -auto-tune runs several candidate decodes
-	// internally, which would each drive the voice rig, so it is disallowed here —
-	// use -tune-hz for a fixed offset.
+	// Optional voice recording / live audio streaming: wire the production voice
+	// path (engine → composer → recorder) onto the decode's grant bus +
+	// channelized-IQ tap, so grants become .wav/.raw/.json recordings
+	// (-record-voice) and/or a continuous live PCM stream (-audio-out).
+	// -auto-tune runs several candidate decodes internally, which would each
+	// drive the voice rig, so it is disallowed here — use -tune-hz for a fixed
+	// offset.
 	var voiceRig *replayVoiceRig
-	if *recordVoice {
-		if *outDir == "" {
+	var audioSink *pcmStreamWriter
+	var audioFile *os.File
+	if *recordVoice || *audioOut != "" {
+		if *recordVoice && *outDir == "" {
 			rep.Fatalf(2, "-record-voice requires -out-dir")
 		}
 		if *autoTune {
-			rep.Fatalf(2, "-record-voice does not support -auto-tune; use -tune-hz for a fixed offset")
+			rep.Fatalf(2, "-record-voice/-audio-out do not support -auto-tune; use -tune-hz for a fixed offset")
 		}
 		if *freq == 0 {
-			rep.Fatalf(2, "-record-voice requires -freq (the carrier frequency in Hz): grants carry the decode frequency, and a grant with freq 0 is dropped by the engine (nothing records)")
+			rep.Fatalf(2, "-record-voice/-audio-out require -freq (the carrier frequency in Hz): grants carry the decode frequency, and a grant with freq 0 is dropped by the engine (no voice decodes)")
+		}
+		if *audioOut == "-" && *out == "" {
+			rep.Fatalf(2, "-audio-out - streams raw PCM on stdout, so the decode result needs its own destination: give -out a file path")
+		}
+		if *audioOut != "" {
+			w := os.Stdout
+			if *audioOut != "-" {
+				// os.Create also opens an existing FIFO for writing, blocking
+				// until the consumer attaches — the pipeline shape OWRX+ uses.
+				audioFile, err = os.Create(*audioOut)
+				if err != nil {
+					rep.Fatalf(1, "-audio-out: %v", err)
+				}
+				w = audioFile
+			}
+			audioSink = newPCMStreamWriter(w)
+		}
+		recDir := ""
+		if *recordVoice {
+			recDir = *outDir
 		}
 		ddcRate := *sampleRate
 		if target := ccdecoder.DDCTargetForProtocol(proto); *sampleRate != target {
 			ddcRate = target
 		}
-		voiceRig, err = setupReplayVoice(*outDir, ddcRate, time.Duration(*voiceHangtimeMs)*time.Millisecond, logger)
+		voiceRig, err = setupReplayVoice(recDir, ddcRate, time.Duration(*voiceHangtimeMs)*time.Millisecond, audioSink, logger)
 		if err != nil {
 			rep.Fatal(1, err)
 		}
 		cfg.Bus = voiceRig.bus
 		cfg.OnChannelIQ = voiceRig.onChannelIQ
+	}
+
+	// JSONL streams live: the output is opened up-front and every decoded event
+	// is written the moment it is observed, so an unbounded stdin pipe (an
+	// external IQ source that never EOFs; issue #314) delivers events as they
+	// happen instead of a batch dump when the pipe finally closes. The trailing
+	// summary line still lands at EOF, keeping the output byte-identical to the
+	// batch export for file inputs. -auto-tune stays on the batch path: it runs
+	// several candidate decodes whose failed attempts must not leak event lines.
+	var jsonlStreamer *siglab.JSONLEventStreamer
+	var jsonlOut *os.File
+	if of == siglab.FormatJSONL && !*autoTune {
+		w := os.Stdout
+		if *out != "" {
+			jsonlOut, err = os.Create(*out)
+			if err != nil {
+				rep.Fatalf(1, "create %s: %v", *out, err)
+			}
+			w = jsonlOut
+		}
+		jsonlStreamer = siglab.NewJSONLEventStreamer(w)
 	}
 
 	// Under -auto-tune, try the ranked carrier candidates and keep the best
@@ -176,6 +230,8 @@ FLAGS:`)
 	var res *siglab.Result
 	if *autoTune {
 		res, err = siglab.RunAutoTuneMulti(*in, cfg, 0)
+	} else if jsonlStreamer != nil {
+		res, err = siglab.RunStream(*in, cfg, jsonlStreamer.OnEvent)
 	} else {
 		res, err = siglab.Run(*in, cfg)
 	}
@@ -185,10 +241,32 @@ FLAGS:`)
 		// partial capture still flushes what it recorded.
 		voiceRig.finalize()
 	}
+	if audioFile != nil {
+		_ = audioFile.Close()
+	}
 	if err != nil {
 		rep.Fatal(1, err)
 	}
 
+	if jsonlStreamer != nil {
+		// The event lines already streamed; append the summary line and close.
+		w := io.Writer(os.Stdout)
+		if jsonlOut != nil {
+			w = jsonlOut
+		}
+		if serr := siglab.WriteJSONLSummary(w, res); serr != nil {
+			rep.Fatal(1, serr)
+		}
+		if serr := jsonlStreamer.Err(); serr != nil {
+			rep.Fatal(1, serr)
+		}
+		if jsonlOut != nil {
+			if cerr := jsonlOut.Close(); cerr != nil {
+				rep.Fatal(1, cerr)
+			}
+		}
+		return
+	}
 	if err := emitResult(res, of, *out); err != nil {
 		rep.Fatal(1, err)
 	}

--- a/cmd/gophertrunk/replay_audio.go
+++ b/cmd/gophertrunk/replay_audio.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"encoding/binary"
+	"io"
+	"sync"
+)
+
+// pcmStreamWriter implements composer.PCMSink (and the recorder's
+// voice.DecodedPCMSink, which has the same WritePCM shape) over an io.Writer,
+// encoding each chunk as raw signed 16-bit little-endian mono PCM. It is the
+// `replay -audio-out` live audio tap (issue #314): an external consumer
+// (OpenWebRX+, aplay, a FIFO) reads a continuous PCM stream at the composer's
+// PCM rate (8000 Hz) as calls decode, instead of waiting for per-call WAV
+// files to land on disk.
+//
+// It is wired at two points, mirroring the daemon's live-audio fan-out:
+// analog FM chains write PCM through the composer's main sink fan-out, while
+// digital protocols emit raw vocoder frames that only the recorder decodes —
+// so the recorder's decoded-PCM tap (SetDecodedPCMSink) carries digital voice
+// here. The two paths are disjoint per call (a call is either analog or
+// digital), so nothing is written twice.
+//
+// The first write error is retained and later chunks are dropped: a torn-down
+// downstream reader must not wedge or kill the decode (the composer already
+// ignores sink errors, so sticky-and-drop keeps the failure local and cheap).
+type pcmStreamWriter struct {
+	mu  sync.Mutex
+	w   io.Writer
+	buf []byte
+	err error
+}
+
+func newPCMStreamWriter(w io.Writer) *pcmStreamWriter {
+	return &pcmStreamWriter{w: w}
+}
+
+// WritePCM encodes samples as s16le and writes them through. The serial is
+// ignored: the replay rig decodes one carrier, so every call's audio belongs
+// on the one output stream.
+func (p *pcmStreamWriter) WritePCM(_ string, samples []int16) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.err != nil {
+		return p.err
+	}
+	if cap(p.buf) < 2*len(samples) {
+		p.buf = make([]byte, 2*len(samples))
+	}
+	buf := p.buf[:2*len(samples)]
+	for i, s := range samples {
+		binary.LittleEndian.PutUint16(buf[2*i:], uint16(s))
+	}
+	_, p.err = p.w.Write(buf)
+	return p.err
+}
+
+// Err reports the first write error, if any.
+func (p *pcmStreamWriter) Err() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.err
+}

--- a/cmd/gophertrunk/replay_audio_test.go
+++ b/cmd/gophertrunk/replay_audio_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+)
+
+// syncBuffer is a goroutine-safe bytes.Buffer: the voice rig writes PCM from
+// its own goroutines while the test inspects progress.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) Len() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Len()
+}
+
+// TestPCMStreamWriterEncodesS16LE pins the -audio-out wire format: raw signed
+// 16-bit little-endian mono, sample order preserved, no framing.
+func TestPCMStreamWriterEncodesS16LE(t *testing.T) {
+	var buf bytes.Buffer
+	w := newPCMStreamWriter(&buf)
+	if err := w.WritePCM("any-serial", []int16{0x0102, -2, 0, 0x7FFF, -0x8000}); err != nil {
+		t.Fatalf("WritePCM: %v", err)
+	}
+	want := []byte{
+		0x02, 0x01, // 0x0102
+		0xFE, 0xFF, // -2
+		0x00, 0x00, // 0
+		0xFF, 0x7F, // 32767
+		0x00, 0x80, // -32768
+	}
+	if !bytes.Equal(buf.Bytes(), want) {
+		t.Fatalf("encoded bytes = % X, want % X", buf.Bytes(), want)
+	}
+	// A second write appends — the stream is continuous, not per-call framed.
+	if err := w.WritePCM("other-serial", []int16{1}); err != nil {
+		t.Fatalf("WritePCM #2: %v", err)
+	}
+	if got := buf.Len(); got != len(want)+2 {
+		t.Fatalf("stream length after second write = %d, want %d", got, len(want)+2)
+	}
+}
+
+// countingErrWriter fails every write and counts attempts.
+type countingErrWriter struct{ calls int }
+
+func (e *countingErrWriter) Write(p []byte) (int, error) {
+	e.calls++
+	return 0, errors.New("downstream pipe gone")
+}
+
+// TestPCMStreamWriterErrorIsSticky pins the torn-pipe behaviour: after the
+// first write error the sink stops touching the writer (the decode must not
+// hammer a dead pipe) and keeps reporting the error.
+func TestPCMStreamWriterErrorIsSticky(t *testing.T) {
+	ew := &countingErrWriter{}
+	w := newPCMStreamWriter(ew)
+	if err := w.WritePCM("s", []int16{1, 2}); err == nil {
+		t.Fatal("expected the first write to surface the writer error")
+	}
+	if err := w.WritePCM("s", []int16{3}); err == nil {
+		t.Fatal("expected the sticky error on the second write")
+	}
+	if ew.calls != 1 {
+		t.Fatalf("underlying writer called %d times, want 1 (sticky error must stop writes)", ew.calls)
+	}
+	if w.Err() == nil {
+		t.Fatal("Err() should report the retained write error")
+	}
+}
+
+// TestSetupReplayVoiceStreamOnly pins the -audio-out-without--record-voice
+// shape: an empty outDir builds a decode-only rig (no recordings directory is
+// required or created) wired to the live PCM stream.
+func TestSetupReplayVoiceStreamOnly(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	var buf syncBuffer
+	rig, err := setupReplayVoice("", 48000, 100*time.Millisecond, newPCMStreamWriter(&buf), log)
+	if err != nil {
+		t.Fatalf("setupReplayVoice with empty outDir (stream-only): %v", err)
+	}
+	rig.finalize()
+}

--- a/cmd/gophertrunk/replay_voice.go
+++ b/cmd/gophertrunk/replay_voice.go
@@ -136,7 +136,16 @@ type replayVoiceRig struct {
 // setupReplayVoice builds and starts the engine/composer/recorder rig writing to
 // outDir. rateHz is the expected channelized (DDC output) rate; the source also
 // refines it from the first IQ chunk.
-func setupReplayVoice(outDir string, rateHz float64, hangtime time.Duration, log *slog.Logger) (*replayVoiceRig, error) {
+//
+// An empty outDir runs the recorder in decode-only mode (no files are written)
+// — the `-audio-out`-without-`-record-voice` shape, where the caller only wants
+// the live PCM stream. audio, when non-nil, receives every decoded call's PCM
+// as a continuous raw s16le stream (issue #314): it is fanned into the
+// composer's main sink (analog FM chains write PCM there) AND wired as the
+// recorder's decoded-PCM tap (digital protocols emit raw vocoder frames that
+// only the recorder decodes — without the tap, digital audio never reaches a
+// WritePCM-only sink; the same wiring the daemon uses for live browser audio).
+func setupReplayVoice(outDir string, rateHz float64, hangtime time.Duration, audio *pcmStreamWriter, log *slog.Logger) (*replayVoiceRig, error) {
 	bus := events.NewBus(1024)
 	src := newReplayVoiceSource(rateHz)
 
@@ -152,23 +161,35 @@ func setupReplayVoice(outDir string, rateHz float64, hangtime time.Duration, log
 		bus.Close()
 		return nil, fmt.Errorf("replay voice: engine: %w", err)
 	}
+	// An empty outDir puts the recorder in its decode-only mode: every call
+	// still builds its per-protocol vocoder (digital voice still decodes and
+	// reaches the decoded-PCM tap below), it just never writes WAV/raw/json.
 	rec, err := voice.NewRecorder(voice.RecorderOptions{
 		Bus:                bus,
 		Log:                log,
 		OutDir:             outDir,
 		SampleRate:         8000,
-		WriteRaw:           true,
-		WriteCallJSON:      true,
+		WriteRaw:           outDir != "",
+		WriteCallJSON:      outDir != "",
 		VocoderForProtocol: voice.DefaultVocoderForProtocol(),
 	})
 	if err != nil {
 		bus.Close()
 		return nil, fmt.Errorf("replay voice: recorder: %w", err)
 	}
+	// The composer type-asserts its sink for the raw-frame / drain-coordination
+	// extensions, so the multi-sink shape must be the daemon's fanoutSink (which
+	// forwards them to the recorder) — a naive tee would silently drop every
+	// IMBE/AMBE frame (the issue #356 failure class).
+	var sink composer.PCMSink = rec
+	if audio != nil {
+		sink = fanoutSink{rec, audio}
+		rec.SetDecodedPCMSink(audio)
+	}
 	comp, err := composer.New(composer.Options{
 		Bus:           bus,
 		Devices:       replayVoiceDevices{src: src},
-		Sink:          rec,
+		Sink:          sink,
 		Engine:        engine,
 		Log:           log,
 		IQSampleRate:  uint32(rateHz + 0.5),

--- a/cmd/gophertrunk/replay_voice_test.go
+++ b/cmd/gophertrunk/replay_voice_test.go
@@ -88,7 +88,10 @@ func TestReplayRecordVoiceEndToEnd(t *testing.T) {
 	if target := ccdecoder.DDCTargetForProtocol(proto); rate != target {
 		ddcRate = target
 	}
-	rig, err := setupReplayVoice(outDir, ddcRate, 3500*time.Millisecond, log)
+	// Also exercise the -audio-out live PCM tap (issue #314): decoded voice
+	// must stream continuously alongside the recordings.
+	var audioBuf syncBuffer
+	rig, err := setupReplayVoice(outDir, ddcRate, 3500*time.Millisecond, newPCMStreamWriter(&audioBuf), log)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,4 +121,8 @@ func TestReplayRecordVoiceEndToEnd(t *testing.T) {
 		t.Fatal("replay -record-voice produced no non-empty .wav — conventional DMR voice did not record (#1036)")
 	}
 	t.Logf("recorded %d wav(s), e.g. %s", len(wavs), filepath.Base(wavs[0]))
+	if audioBuf.Len() == 0 {
+		t.Fatal("voice recorded to WAV but the -audio-out live PCM stream carried no bytes — the decoded-PCM tap is not wired (#314)")
+	}
+	t.Logf("live audio stream carried %d PCM bytes", audioBuf.Len())
 }

--- a/internal/siglab/cs16_test.go
+++ b/internal/siglab/cs16_test.go
@@ -31,6 +31,18 @@ func TestParseSampleFormatCS16(t *testing.T) {
 	}
 }
 
+// TestParseSampleFormatCF32 pins the cf32/fc32 aliases for interleaved float32
+// IQ — the SoapySDR / OpenWebRX+ spelling of the format OWRX+ pipes into
+// `replay -in -` (issue #314).
+func TestParseSampleFormatCF32(t *testing.T) {
+	for _, s := range []string{"cf32", "fc32", "CF32", "f32", "float32", "cfile"} {
+		f, err := ParseSampleFormat(s)
+		if err != nil || f != FormatF32 {
+			t.Fatalf("ParseSampleFormat(%q) = %v, %v; want FormatF32", s, f, err)
+		}
+	}
+}
+
 // TestEncodeCaptureCS16RoundTrip encodes known IQ as cs16, decodes it back
 // through the format's own decoder, and asserts the samples survive within
 // 16-bit quantisation. It also confirms cs16 is exactly half the size of f32

--- a/internal/siglab/decode.go
+++ b/internal/siglab/decode.go
@@ -69,7 +69,10 @@ func ParseSampleFormat(s string) (SampleFormat, error) {
 	switch strings.ToLower(strings.TrimSpace(s)) {
 	case "u8", "":
 		return FormatU8, nil
-	case "f32", "float32", "cfile":
+	case "f32", "float32", "cfile", "cf32", "fc32":
+		// cf32/fc32 are the SoapySDR / OpenWebRX+ spellings of interleaved
+		// little-endian float32 IQ — the format OWRX+ emits when piping a
+		// channelized stream into `replay -in -` (issue #314).
 		return FormatF32, nil
 	case "wav", "sw16", "s16":
 		return FormatWAV, nil

--- a/internal/siglab/export.go
+++ b/internal/siglab/export.go
@@ -90,17 +90,58 @@ func WriteResult(w io.Writer, r *Result, f Format) error {
 
 // writeJSONL emits one JSON line per captured event followed by a summary
 // line. The summary reuses the Result with its (already-streamed) Events
-// elided so the trailing object stays compact.
+// elided so the trailing object stays compact. It shares the line encoding
+// with JSONLEventStreamer / WriteJSONLSummary so the batch export and the
+// live per-event stream can never drift apart.
 func writeJSONL(w io.Writer, r *Result) error {
-	enc := json.NewEncoder(w)
+	s := NewJSONLEventStreamer(w)
 	for _, ev := range r.Events {
-		if err := enc.Encode(jsonlLine{Type: "event", Event: &ev}); err != nil {
-			return err
-		}
+		s.OnEvent(ev)
 	}
+	if err := s.Err(); err != nil {
+		return err
+	}
+	return WriteJSONLSummary(w, r)
+}
+
+// JSONLEventStreamer writes captured events as JSONL {"type":"event",…} lines
+// the moment they are observed. Its OnEvent method has the RunStream /
+// RunReaderStream sink signature, so a caller decoding a live, unbounded IQ
+// stream (`replay -in -` fed by an external radio front-end; issue #314) gets
+// each decoded event on the pipe as it happens instead of a batch dump that
+// only appears when the stream finally closes. Events are delivered from the
+// engine's single collector goroutine, so OnEvent needs no locking. The first
+// write error is retained (Err) and later events are dropped — a torn-down
+// downstream pipe must not wedge the decode.
+type JSONLEventStreamer struct {
+	enc *json.Encoder
+	err error
+}
+
+// NewJSONLEventStreamer builds a streamer over w. Pair it with
+// WriteJSONLSummary at EOF for output byte-identical to FormatJSONL's batch
+// export.
+func NewJSONLEventStreamer(w io.Writer) *JSONLEventStreamer {
+	return &JSONLEventStreamer{enc: json.NewEncoder(w)}
+}
+
+// OnEvent encodes one event line. Matches the RunStream onEvent signature.
+func (s *JSONLEventStreamer) OnEvent(ev EventRecord) {
+	if s.err != nil {
+		return
+	}
+	s.err = s.enc.Encode(jsonlLine{Type: "event", Event: &ev})
+}
+
+// Err reports the first write error, if any.
+func (s *JSONLEventStreamer) Err() error { return s.err }
+
+// WriteJSONLSummary writes the trailing {"type":"summary",…} line for r, with
+// the (already-streamed) Events elided so the object stays compact.
+func WriteJSONLSummary(w io.Writer, r *Result) error {
 	summary := *r
 	summary.Events = nil
-	return enc.Encode(jsonlLine{Type: "summary", Summary: &summary})
+	return json.NewEncoder(w).Encode(jsonlLine{Type: "summary", Summary: &summary})
 }
 
 type jsonlLine struct {

--- a/internal/siglab/export_stream_test.go
+++ b/internal/siglab/export_stream_test.go
@@ -1,0 +1,114 @@
+package siglab
+
+import (
+	"bytes"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TestJSONLStreamerMatchesBatchExport pins that streaming events live through
+// JSONLEventStreamer + WriteJSONLSummary produces output byte-identical to the
+// batch FormatJSONL export — the contract that lets `replay -out-format jsonl`
+// stream live on a pipe (issue #314) without changing what file-based callers
+// parse.
+func TestJSONLStreamerMatchesBatchExport(t *testing.T) {
+	var live bytes.Buffer
+	streamer := NewJSONLEventStreamer(&live)
+	res, _, err := SynthesizeAndAnalyze(
+		SynthOptions{Protocol: trunking.ProtocolP25, Format: FormatF32},
+		Config{},
+		streamer.OnEvent,
+	)
+	if err != nil {
+		t.Fatalf("SynthesizeAndAnalyze: %v", err)
+	}
+	if err := streamer.Err(); err != nil {
+		t.Fatalf("streamer error: %v", err)
+	}
+	if err := WriteJSONLSummary(&live, res); err != nil {
+		t.Fatalf("WriteJSONLSummary: %v", err)
+	}
+
+	var batch bytes.Buffer
+	if err := WriteResult(&batch, res, FormatJSONL); err != nil {
+		t.Fatalf("WriteResult(FormatJSONL): %v", err)
+	}
+	if !bytes.Equal(live.Bytes(), batch.Bytes()) {
+		t.Fatalf("live-streamed JSONL differs from batch export:\nlive:\n%s\nbatch:\n%s",
+			live.String(), batch.String())
+	}
+	if len(res.Events) == 0 {
+		t.Fatal("fixture produced no events; the comparison proved nothing")
+	}
+}
+
+// gatedEOFReader serves its data normally, then BLOCKS before returning EOF
+// until release is closed — modelling a live pipe that has delivered samples
+// but not hung up. It lets the test below distinguish "events are delivered as
+// they are decoded" from "events only appear once the stream closes".
+type gatedEOFReader struct {
+	data    *bytes.Reader
+	release <-chan struct{}
+	timeout time.Duration
+}
+
+func (g *gatedEOFReader) Read(p []byte) (int, error) {
+	n, err := g.data.Read(p)
+	if err != io.EOF {
+		return n, err
+	}
+	select {
+	case <-g.release:
+	case <-time.After(g.timeout):
+	}
+	return n, io.EOF
+}
+
+// TestRunReaderStreamDeliversEventsBeforeEOF pins the live-pipe contract behind
+// `replay -in - -out-format jsonl` (issue #314): onEvent fires while the input
+// stream is still open. A batch implementation that buffers events until EOF
+// would time out here.
+func TestRunReaderStreamDeliversEventsBeforeEOF(t *testing.T) {
+	iq, meta, err := Synthesize(SynthOptions{Protocol: trunking.ProtocolP25, Format: FormatF32})
+	if err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+	proto, err := ParseProtocolCLI(meta.Protocol)
+	if err != nil {
+		t.Fatalf("ParseProtocolCLI(%q): %v", meta.Protocol, err)
+	}
+	cfg := Config{
+		Protocol:     proto,
+		SystemName:   "stream-test",
+		SampleRateHz: meta.SampleRateHz,
+		Format:       FormatF32,
+	}
+
+	release := make(chan struct{})
+	var once sync.Once
+	gotEvent := make(chan struct{})
+	onEvent := func(EventRecord) {
+		once.Do(func() {
+			close(gotEvent)
+			close(release) // first event seen while EOF is held back: let the stream end
+		})
+	}
+	r := &gatedEOFReader{
+		data:    bytes.NewReader(EncodeCapture(iq, FormatF32)),
+		release: release,
+		timeout: 30 * time.Second,
+	}
+	res, err := RunReaderStream(r, "gated-pipe", cfg, onEvent)
+	if err != nil {
+		t.Fatalf("RunReaderStream: %v", err)
+	}
+	select {
+	case <-gotEvent:
+	default:
+		t.Fatalf("no event was delivered while the stream was still open (events=%d after EOF) — live streaming is broken for unbounded pipes (#314)", len(res.Events))
+	}
+}


### PR DESCRIPTION
## Summary

Completes the OpenWebRX+ stdin/stdout integration on top of the offline pipe from #1050, matching the interface the reporter confirmed on #314: OWRX+ emits a **single channelized cf32 IQ stream** at whatever rate is needed, and wants **voice and/or data output split across stdout and a pipe to a file**. Today `-out-format jsonl` only emits at EOF (an unbounded live pipe produces no output, ever), there is no way to stream decoded voice audio, and the `cf32` spelling isn't accepted.

## Changes

- **`-out-format jsonl` streams live** (non-`-auto-tune`): each decoded event is written as its `{"type":"event",…}` line the moment it is observed, with the `{"type":"summary",…}` line still landing at stream end. File-based jsonl output stays **byte-identical** to the previous batch export. `-auto-tune` keeps the batch path — its failed candidate decodes must not leak event lines.
  - `internal/siglab/export.go`: `JSONLEventStreamer` (live per-event sink with the `RunStream` callback signature; sticky write error so a torn pipe can't wedge the decode) + `WriteJSONLSummary`; the batch `writeJSONL` is refactored onto both so the two paths cannot drift.
- **New `replay -audio-out <path|->`**: streams decoded voice as continuous raw **s16le mono 8 kHz PCM** to a file, FIFO, or stdout as calls decode — usable with or without `-record-voice`. Mirrors the daemon's live-audio fan-out: analog FM PCM via the composer's `fanoutSink` (so the recorder's raw-frame / drain-coordination type-asserts keep working — the #356 failure class), digital voice via the recorder's decoded-PCM tap (`SetDecodedPCMSink`). Without `-record-voice` the recorder runs in its existing decode-only mode (no files). Validation: requires `-freq`, rejects `-auto-tune` (same as `-record-voice`), and `-audio-out -` requires `-out <file>` so the decode result can't interleave with PCM on stdout.
  - `cmd/gophertrunk/replay_audio.go` (new): `pcmStreamWriter` — `composer.PCMSink` / `voice.DecodedPCMSink` over an `io.Writer`.
  - `cmd/gophertrunk/replay_voice.go`: `setupReplayVoice` takes the optional audio tap; empty `outDir` selects decode-only mode.
  - `cmd/gophertrunk/replay.go`: flag, validation, live-jsonl wiring, OWRX+ usage example.
- **`-format cf32` / `fc32`** accepted as aliases for f32 (`internal/siglab/decode.go`) — the SoapySDR/OpenWebRX+ spelling the reporter named.

No new work was needed for the hand-off rate: the production DDC already interpolates a sub-target channelized stream up to the protocol's channel rate (48 kHz C4FM family / 144 kHz TETRA), so OWRX+ can hand off at 24–48 kHz. Full pipeline shape (also in `replay -h`):

```
owrx-iq-source | gophertrunk replay -in - -format cf32 -sample-rate 48000 \
                  -protocol dmr-tier2 -freq 438900000 \
                  -audio-out - -out-format jsonl -out events.jsonl
```

## Test plan

- [x] `make vet test` is green locally
- [x] `make integration` — n/a (no daemon-path change; `replay`/siglab only)
- [x] Added or updated tests where appropriate:
  - `TestJSONLStreamerMatchesBatchExport` — live-streamed lines + summary byte-identical to the batch `FormatJSONL` export.
  - `TestRunReaderStreamDeliversEventsBeforeEOF` — a gated reader holds EOF back until an event arrives; a batch implementation times out (the live-pipe contract).
  - `TestPCMStreamWriterEncodesS16LE` / `TestPCMStreamWriterErrorIsSticky` — wire format and torn-pipe behaviour.
  - `TestSetupReplayVoiceStreamOnly` — the `-audio-out`-without-`-record-voice` rig builds with no recordings directory.
  - `TestParseSampleFormatCF32` — the format aliases.
  - `TestReplayRecordVoiceEndToEnd` (capture-gated, `GT_DMR_IQ`) now also asserts the live PCM stream carries bytes whenever WAVs record.
- [x] Smoke-tested: synthesized P25 capture piped into `replay -in - -format cf32 -out-format jsonl` emits the `cc.locked` event line immediately and the summary at EOF; all `-audio-out` validation paths exercised. **Not yet verified against a real OWRX+ hand-off** — that A/B is with the #314 reporter, per the verify-before-close policy (hence `Refs`, not `Closes`).

## Breaking changes

None. `-out-format jsonl` to a file produces byte-identical output; jsonl to stdout gains incremental delivery (same lines, same order). All new flags/aliases are additive.

## Docs / CHANGELOG

- [x] Added a `## [Unreleased]` bullet to `CHANGELOG.md`
- [x] `replay -h` usage/examples updated (operator-facing surface for this feature)

## Linked issues

Refs #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MevYf1R1QFtbydrrTRhosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01MevYf1R1QFtbydrrTRhosP)_