### PR TITLE
recorders: FLAC as a first-class container for IQ captures and voice recordings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,35 @@ confirmation before any close-as-completed.
 
 ## DSP / replay notes (so the next investigation starts ahead)
 
+- **FLAC is now a first-class container on every recorder that had a container at all**,
+  with ONE shared stereo encode core (`baseband.FLACIQEncoder` — `siglab.IQContainer`
+  delegates to it) and a mono voice twin (`voice.FlacWriter`): `capture -format wav|flac`
+  and the API staged capture route through `siglab.IQContainer` (both used to silently
+  write a mislabeled/garbage body — the streaming `EncodeCapture` has NO container case
+  and falls through to u8, so gen/synth now reject wav/flac at the boundary);
+  `baseband.record[].format: flac` covers both taps (wideband + ddc) and the replay
+  `FileDriver` mounts .flac back as a virtual tuner (content-sniffed via the fLaC
+  marker, never the extension); `recordings.format: flac` switches per-call voice
+  recordings, and the WHOLE downstream chain reads either container via content
+  sniffing (`voice.ReadAudioSamples`): loudness normalize rewrites flac-in/flac-out,
+  broadcast MP3 transcode, the `/calls/{id}/audio` handler (audio/flac + .flac in its
+  extension allowlist), the retention sweeper, and the web RecordingPlayer's download
+  name. `FlacWriter.DataBytes()` reports UNCOMPRESSED PCM bytes so the recorder's
+  duration/dead-key math is container-independent. Not converted (deliberately):
+  `diversity_capture` stays cs16 (branch-alignment invariant + offline harness),
+  `hunt -survey-capture` stays f32.
+- **A P25 "MBT data CRC failed" line whose identity fields match a decoded broadcast
+  is TWO different PDU frames, not a contradiction**: every field the failure line
+  prints (opcode/blocks/nac) comes from the HEADER block, which carries its own
+  CCITT-16 and decoded clean — only a data block failed its CRC-32 (RF residual
+  errors; the broadcast repeats, so a clean copy usually logs nearby). The CRC span
+  was re-verified byte-for-byte against OP25 `process_PDU` (single-block AMBT
+  included), so do NOT chase a parser bug from that log pair alone; the line now
+  carries the worst data-block Viterbi metric + an explanatory cause. Related naming
+  rule now enforced in code: never render a vendor TSBK or an undecoded AMBT opcode
+  through the standard `Opcode.String()` OSP map (it mislabels — MFID 0x90 opcode
+  0x00 reads GRP_V_CH_GRANT); `ambtOpcodeLabel` names only the decoded AMBT forms.
+
 - **P25 discovery: a PDU (DUID 0xC) on the control channel is Multi-Block
   Trunking, not noise — GT now decodes AMBT (`mbt.go`).** The operator's "only 1
   neighbor site, no WACN" report was this: their system broadcasts Network

--- a/cmd/gophertrunk/capture.go
+++ b/cmd/gophertrunk/capture.go
@@ -40,7 +40,7 @@ func runCapture(args []string) {
 	ppm := fs.Int("ppm", 0, "frequency-correction in PPM")
 	seconds := fs.Float64("seconds", 10, "capture length in seconds (required, > 0)")
 	out := fs.String("out", "capture.cfile", "output capture path")
-	format := fs.String("format", "f32", "capture sample format: u8 | f32 | cs16 (f32 = GNU Radio cfile; cs16 = headerless 16-bit raw)")
+	format := fs.String("format", "f32", "capture sample format: u8 | f32 | cs16 | wav | flac (f32 = GNU Radio cfile; cs16 = headerless 16-bit raw; wav = cs16 body in a RIFF container; flac = lossless compressed cs16, typically 30-50% smaller)")
 	centerHz := fs.Uint("center", 0, "narrowband slice centre in Hz (default: -freq); with -bandwidth, carves a channel from the captured wideband without retuning")
 	bandwidthHz := fs.Uint("bandwidth", 0, "narrowband slice bandwidth in Hz; when > 0 the capture is decimated to ~this rate around -center (must fit inside -freq ± sample-rate/2)")
 	decimate := fs.Uint("decimate", 0, "integer software-decimation factor: record the full band anti-alias decimated to sample-rate/decimate (a manageable long capture off a source like the USRP B210 whose hardware rate floor is ~1 MS/s). Mutually exclusive with -bandwidth")
@@ -317,13 +317,13 @@ func openCaptureDevice(serial string) (sdr.Device, sdr.Info, error) {
 	return dev, chosen, nil
 }
 
-// captureWriterDepth is how many encoded chunks captureStream buffers between
-// the IQ-drain goroutine and the disk-writer goroutine. A storage-latency
-// spike up to this many chunks is absorbed here instead of stalling the drain
-// — which, on a live SDR, would make the driver shed whole IQ chunks
-// (NotifyIQDrop), punching time gaps into the capture that slip a downstream
-// decoder's symbol clock. Each entry is one post-DDC encoded chunk (a few KB
-// for a narrowband slice), so this is trivial memory.
+// captureWriterDepth is how many sample chunks captureStreamSink buffers
+// between the IQ-drain goroutine and the disk-writer goroutine. A
+// storage-latency spike up to this many chunks is absorbed here instead of
+// stalling the drain — which, on a live SDR, would make the driver shed whole
+// IQ chunks (NotifyIQDrop), punching time gaps into the capture that slip a
+// downstream decoder's symbol clock. Each entry is one post-DDC chunk (tens
+// of KB for a narrowband slice), so this is trivial memory.
 const captureWriterDepth = 256
 
 // captureBufWriter is the disk write-buffer size. Batching many small chunk
@@ -341,6 +341,12 @@ const captureBufWriter = 1 << 20 // 1 MiB
 // of recorded (post-DDC) IQ, which the caller FFTs for the carrier-offset
 // warning.
 func captureToFile(ctx context.Context, path string, format siglab.SampleFormat, src <-chan []complex64, rate uint32, seconds float64, ddc *ccdecoder.Downconverter) (int64, []complex64, error) {
+	// Container formats need a header up front and a finalize step, so they
+	// take the IQContainer path; the headerless formats keep the historical
+	// byte-stream path below.
+	if format == siglab.FormatWAV || format == siglab.FormatFLAC {
+		return captureContainerToFile(ctx, path, format, src, rate, seconds, ddc)
+	}
 	f, err := os.Create(path)
 	if err != nil {
 		return 0, nil, fmt.Errorf("create %s: %w", path, err)
@@ -358,6 +364,37 @@ func captureToFile(ctx context.Context, path string, format siglab.SampleFormat,
 	return written, probe, loopErr
 }
 
+// captureContainerToFile is captureToFile for the container formats (wav,
+// flac): the chunks stream through siglab.IQContainer, which owns the header
+// and the finalize step (RIFF length patch / FLAC STREAMINFO), so a
+// `capture -format wav|flac` file is a real container rather than a
+// mislabeled headerless body.
+func captureContainerToFile(ctx context.Context, path string, format siglab.SampleFormat, src <-chan []complex64, rate uint32, seconds float64, ddc *ccdecoder.Downconverter) (int64, []complex64, error) {
+	// The container header carries the ON-DISK rate: the decimated slice rate
+	// when a -bandwidth/-decimate DDC is set, the full input rate otherwise.
+	diskRate := rate
+	if ddc != nil {
+		diskRate = uint32(ddc.OutRateHz() + 0.5)
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return 0, nil, fmt.Errorf("create %s: %w", path, err)
+	}
+	cont, err := siglab.NewIQContainer(f, format, int(diskRate))
+	if err != nil {
+		f.Close()
+		return 0, nil, fmt.Errorf("container %s: %w", path, err)
+	}
+	written, probe, loopErr := captureStreamSink(ctx, cont.Write, src, rate, seconds, ddc)
+	if ferr := cont.Finalize(); ferr != nil && loopErr == nil {
+		loopErr = fmt.Errorf("finalize: %w", ferr)
+	}
+	if cerr := f.Close(); cerr != nil && loopErr == nil {
+		loopErr = cerr
+	}
+	return written, probe, loopErr
+}
+
 // captureStream is the format-encode + write loop behind captureToFile,
 // decoupled from the file so it is testable with any io.Writer.
 //
@@ -368,8 +405,19 @@ func captureToFile(ctx context.Context, path string, format siglab.SampleFormat,
 // driver drops whole IQ chunks (non-blocking, silent), corrupting the capture.
 // Decoupling keeps the drain running so a transient stall costs latency, not
 // samples. The stateful DDC stays on the drain goroutine (it must run in
-// order); only the encoded bytes cross to the writer.
+// order); only copied sample chunks cross to the writer, which encodes them.
 func captureStream(ctx context.Context, w io.Writer, format siglab.SampleFormat, src <-chan []complex64, rate uint32, seconds float64, ddc *ccdecoder.Downconverter) (int64, []complex64, error) {
+	return captureStreamSink(ctx, func(samples []complex64) error {
+		_, err := w.Write(siglab.EncodeCapture(samples, format))
+		return err
+	}, src, rate, seconds, ddc)
+}
+
+// captureStreamSink is the drain/write loop behind captureStream and the
+// container path: the writer goroutine consumes copied sample chunks and
+// hands them to sink (a byte encoder + io.Writer, or an IQContainer), so a
+// stalled sink costs latency, never samples.
+func captureStreamSink(ctx context.Context, sink func([]complex64) error, src <-chan []complex64, rate uint32, seconds float64, ddc *ccdecoder.Downconverter) (int64, []complex64, error) {
 	probe := make([]complex64, 0, captureProbeSamples)
 
 	// Stop once seconds worth of INPUT samples have been read; the written
@@ -382,13 +430,13 @@ func captureStream(ctx context.Context, w io.Writer, format siglab.SampleFormat,
 	timer := time.NewTimer(time.Duration(seconds*float64(time.Second)) + 5*time.Second)
 	defer timer.Stop()
 
-	writerCh := make(chan []byte, captureWriterDepth)
+	writerCh := make(chan []complex64, captureWriterDepth)
 	writeErrCh := make(chan error, 1)
 	writerDone := make(chan struct{})
 	go func() {
 		defer close(writerDone)
 		for b := range writerCh {
-			if _, werr := w.Write(b); werr != nil {
+			if werr := sink(b); werr != nil {
 				select {
 				case writeErrCh <- werr:
 				default:
@@ -441,9 +489,10 @@ loop:
 				probe = append(probe, take...)
 			}
 			// Fresh buffer per chunk: it is handed to the writer goroutine, so
-			// it must not alias the reused ddcBuf. siglab.EncodeCapture allocates
-			// a new buffer per call, which the cross-goroutine handoff needs.
-			buf := siglab.EncodeCapture(samples, format)
+			// it must not alias the reused ddcBuf or the src-owned chunk.
+			// Encoding happens on the writer goroutine (sink), keeping the
+			// drain to a copy.
+			buf := append([]complex64(nil), samples...)
 			select {
 			case writerCh <- buf:
 			case werr := <-writeErrCh:

--- a/cmd/gophertrunk/capture_test.go
+++ b/cmd/gophertrunk/capture_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -264,5 +265,129 @@ func TestSerialsOf(t *testing.T) {
 	got := serialsOf([]sdr.Info{{Serial: "AAA"}, {Serial: "BBB"}})
 	if got != "AAA, BBB" {
 		t.Errorf("serialsOf = %q, want \"AAA, BBB\"", got)
+	}
+}
+
+// feedIQChunks streams a deterministic low-amplitude waveform (n chunks of
+// size samples) so container round-trip tests can compare decoded samples
+// without hitting the int16 clamp feedChunks' large values would.
+func feedIQChunks(n, size int) (<-chan []complex64, []complex64) {
+	src := make(chan []complex64, n)
+	all := make([]complex64, 0, n*size)
+	for i := 0; i < n; i++ {
+		chunk := make([]complex64, size)
+		for j := range chunk {
+			k := i*size + j
+			chunk[j] = complex(float32(k%97)/200, -float32(k%89)/200)
+		}
+		all = append(all, chunk...)
+		src <- chunk
+	}
+	close(src)
+	return src, all
+}
+
+// TestCaptureToFileFLACIsRealFLAC is the failing-first regression for the
+// `capture -format flac` defect: the streaming encoder had no FLAC case and
+// silently fell through to the u8 encoder, leaving a file that was neither
+// FLAC nor decodable. The container path must produce a real FLAC stream that
+// losslessly decodes back to the captured samples.
+func TestCaptureToFileFLACIsRealFLAC(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cap.flac")
+	src, all := feedIQChunks(4, 300)
+	written, _, err := captureToFile(context.Background(), path, siglab.FormatFLAC, src, 1000, 1.0, nil)
+	if err != nil {
+		t.Fatalf("captureToFile: %v", err)
+	}
+	if written != int64(len(all)) {
+		t.Fatalf("written = %d, want %d", written, len(all))
+	}
+
+	head := make([]byte, 4)
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if _, err := f.Read(head); err != nil || string(head) != "fLaC" {
+		f.Close()
+		t.Fatalf("file starts with %q (err %v), want the fLaC stream marker", head, err)
+	}
+	f.Close()
+
+	// Decode through siglab's own reader path (the same one replay uses) and
+	// require lossless int16 round-trip of every sample.
+	got, rate, err := readContainerSW16(t, path)
+	if err != nil {
+		t.Fatalf("decode flac capture: %v", err)
+	}
+	if rate != 1000 {
+		t.Errorf("container rate = %d, want 1000", rate)
+	}
+	compareSW16(t, got, all)
+}
+
+// TestCaptureToFileWAVHasRIFFHeader is the companion regression for
+// `capture -format wav`, which used to write a headerless sw16 body under a
+// wav label (so siglab's reader ate the first 11 samples as a fake header).
+func TestCaptureToFileWAVHasRIFFHeader(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cap.wav")
+	src, all := feedIQChunks(4, 300)
+	written, _, err := captureToFile(context.Background(), path, siglab.FormatWAV, src, 1000, 1.0, nil)
+	if err != nil {
+		t.Fatalf("captureToFile: %v", err)
+	}
+	if written != int64(len(all)) {
+		t.Fatalf("written = %d, want %d", written, len(all))
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if len(b) < 44 || string(b[0:4]) != "RIFF" || string(b[8:12]) != "WAVE" {
+		t.Fatalf("capture is not a RIFF/WAVE file (got %d bytes, head %q)", len(b), b[:min(len(b), 12)])
+	}
+	if len(b) != 44+len(all)*4 {
+		t.Errorf("file size = %d, want %d (44-byte header + 4 bytes/sample)", len(b), 44+len(all)*4)
+	}
+	got, rate, err := readContainerSW16(t, path)
+	if err != nil {
+		t.Fatalf("decode wav capture: %v", err)
+	}
+	if rate != 1000 {
+		t.Errorf("container rate = %d, want 1000", rate)
+	}
+	compareSW16(t, got, all)
+}
+
+// readContainerSW16 decodes a wav/flac IQ capture back to complex64 through
+// siglab's reader (RunReader would drag in a whole analysis; DecodeCaptureFile
+// is enough for sample fidelity).
+func readContainerSW16(t *testing.T, path string) ([]complex64, uint32, error) {
+	t.Helper()
+	return siglab.DecodeContainerFile(path)
+}
+
+// compareSW16 requires got to equal want through the sw16 quantization
+// (float → int16 ×32768 with clamp → float /32768).
+func compareSW16(t *testing.T, got, want []complex64) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("decoded %d samples, want %d", len(got), len(want))
+	}
+	quant := func(v float32) float32 {
+		x := math.Round(float64(v) * 32768)
+		if x > 32767 {
+			x = 32767
+		}
+		if x < -32768 {
+			x = -32768
+		}
+		return float32(int16(x)) / 32768
+	}
+	for i := range want {
+		w := complex(quant(real(want[i])), quant(imag(want[i])))
+		if got[i] != w {
+			t.Fatalf("sample %d = %v, want %v", i, got[i], w)
+		}
 	}
 }

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -1572,9 +1572,10 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 					CarrierOffsetWarnHz: int(cfg.SDR.CarrierOffsetWarnHz),
 					// A baseband record entry with tap: ddc on this control
 					// serial tees the narrowband channelized stream (the DDC
-					// output the decoder sees) to WAV — small, shareable, and
-					// replayable with `replay -format wav`.
-					DDCRecordDir: ddcRecordDirForSerial(cfg, controlEntry.Info.Serial),
+					// output the decoder sees) to WAV or FLAC — small,
+					// shareable, and replayable with `replay -format wav|flac`.
+					DDCRecordDir:    ddcRecordDirForSerial(cfg, controlEntry.Info.Serial),
+					DDCRecordFormat: ddcRecordFormatForSerial(cfg, controlEntry.Info.Serial),
 					// Same-carrier voice-tap buffer depth (issue #402); 0 → the
 					// decoder's built-in default.
 					VoiceTapBufferChunks: cfg.Recordings.VoiceTapBufferChunks,
@@ -2155,6 +2156,7 @@ func (d *Daemon) buildRecorderAndVoiceDecoder(cfg config.Config, log *slog.Logge
 			Bus:           d.bus,
 			Log:           log,
 			OutDir:        cfg.Recordings.Dir,
+			Format:        recordingsFormat(cfg),
 			SampleRate:    cfg.Recordings.SampleRate,
 			WriteRaw:      cfg.Recordings.WriteRaw,
 			WriteMBE:      cfg.Recordings.MBEFiles,
@@ -4966,17 +4968,40 @@ func (s sitesProvider) Topology(system string) (*trunking.TopologySnapshot, bool
 	return s.t.Topology(system)
 }
 
-// ddcRecordDirForSerial returns the recording directory for a baseband
-// record entry with tap: ddc on the given serial, or "" if none is
-// configured. This drives ccdecoder.Options.DDCRecordDir so the narrowband
-// DDC output is teed at the decoder rather than by wrapping the raw device.
-func ddcRecordDirForSerial(cfg config.Config, serial string) string {
+// recordingsFormat normalises recordings.format ("" → wav) for the voice
+// recorder's container dispatch.
+func recordingsFormat(cfg config.Config) string {
+	f := strings.ToLower(strings.TrimSpace(cfg.Recordings.Format))
+	if f == "" {
+		return "wav"
+	}
+	return f
+}
+
+// ddcRecordForSerial returns the recording directory and container format
+// for a baseband record entry with tap: ddc on the given serial, or ("", "")
+// if none is configured. This drives ccdecoder.Options.DDCRecordDir/Format so
+// the narrowband DDC output is teed at the decoder rather than by wrapping
+// the raw device.
+func ddcRecordForSerial(cfg config.Config, serial string) (dir, format string) {
 	for _, r := range cfg.Baseband.Record {
 		if r.Serial == serial && r.TapDDC() {
-			return r.Dir
+			return r.Dir, r.RecordFormat()
 		}
 	}
-	return ""
+	return "", ""
+}
+
+// ddcRecordDirForSerial / ddcRecordFormatForSerial are struct-literal-friendly
+// accessors over ddcRecordForSerial.
+func ddcRecordDirForSerial(cfg config.Config, serial string) string {
+	dir, _ := ddcRecordForSerial(cfg, serial)
+	return dir
+}
+
+func ddcRecordFormatForSerial(cfg config.Config, serial string) string {
+	_, format := ddcRecordForSerial(cfg, serial)
+	return format
 }
 
 // wrapBasebandRecorders replaces the Device of every pool entry whose
@@ -4987,7 +5012,7 @@ func (d *Daemon) wrapBasebandRecorders(cfg config.Config, log *slog.Logger) {
 	if len(cfg.Baseband.Record) == 0 || d.pool == nil {
 		return
 	}
-	dirBySerial := make(map[string]string, len(cfg.Baseband.Record))
+	recBySerial := make(map[string]config.BasebandRecordConfig, len(cfg.Baseband.Record))
 	for _, r := range cfg.Baseband.Record {
 		if r.TapDDC() {
 			// Narrowband DDC-output recording is teed at the control-channel
@@ -4995,9 +5020,9 @@ func (d *Daemon) wrapBasebandRecorders(cfg config.Config, log *slog.Logger) {
 			// device — the device only ever sees the wideband SDR stream.
 			continue
 		}
-		dirBySerial[r.Serial] = r.Dir
+		recBySerial[r.Serial] = r
 	}
-	if len(dirBySerial) == 0 {
+	if len(recBySerial) == 0 {
 		return
 	}
 	rate := cfg.SDR.SampleRate
@@ -5005,14 +5030,15 @@ func (d *Daemon) wrapBasebandRecorders(cfg config.Config, log *slog.Logger) {
 		rate = sdr.DefaultSampleRateHz
 	}
 	for _, e := range d.pool.Entries() {
-		dir, ok := dirBySerial[e.Info.Serial]
+		rc, ok := recBySerial[e.Info.Serial]
 		if !ok {
 			continue
 		}
-		rec := baseband.NewRecordingDevice(e.Device, dir, log)
+		rec := baseband.NewRecordingDevice(e.Device, rc.Dir, rc.RecordFormat(), log)
 		_ = rec.SetSampleRate(rate)
 		e.Device = rec
-		log.Info("baseband recording enabled", "serial", e.Info.Serial, "dir", dir)
+		log.Info("baseband recording enabled", "serial", e.Info.Serial,
+			"dir", rc.Dir, "format", rc.RecordFormat())
 	}
 }
 

--- a/cmd/gophertrunk/gen.go
+++ b/cmd/gophertrunk/gen.go
@@ -82,6 +82,11 @@ FLAGS:`)
 	if err != nil {
 		rep.Fatal(2, err)
 	}
+	// gen writes through the pure byte encoder, which has no container
+	// support — a wav/flac request would silently produce a mislabeled body.
+	if sampleFormat == siglab.FormatWAV || sampleFormat == siglab.FormatFLAC {
+		rep.Fatalf(2, "-format %s is a live-capture container format; gen supports u8, f32, or cs16", sampleFormat)
+	}
 	mpTaps, err := parseMultipath(*multipath)
 	if err != nil {
 		fs.Usage()

--- a/cmd/gophertrunk/main.go
+++ b/cmd/gophertrunk/main.go
@@ -171,7 +171,7 @@ func runDaemon(args []string) {
 	// IQ capture diagnostic — taps a live SDR's iqtap broker and writes
 	// raw IQ samples to a file for offline analysis. Used to capture a
 	// reproducible fixture for replay (issue #402).
-	iqCapture := fs.String("iq-capture", "", "capture raw IQ from a live SDR for offline analysis (issue #402). Format: serial=<s>,path=<file>,seconds=<n>[,format=u8|f32|cs16][,decimate=<n>] (default format=f32, GNU Radio cfile; decimate>1 anti-alias decimates the recording to sdr.sample_rate/n and writes a metadata sidecar)")
+	iqCapture := fs.String("iq-capture", "", "capture raw IQ from a live SDR for offline analysis (issue #402). Format: serial=<s>,path=<file>,seconds=<n>[,format=u8|f32|cs16|wav|flac][,decimate=<n>] (default format=f32, GNU Radio cfile; decimate>1 anti-alias decimates the recording to sdr.sample_rate/n and writes a metadata sidecar)")
 	_ = fs.Parse(args)
 
 	// Resolve verbose-error reporting from the flag now (config folds in

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -180,6 +180,9 @@ storage:
 recordings:
   dir: "../recordings"
   sample_rate: 8000
+  # format: flac             # wav (default, 16-bit mono PCM) | flac (lossless,
+  #                          #   ~half the size for speech; web playback, loudness
+  #                          #   normalization and MP3 uploads all read it the same)
   # Recording name + folder layout. Both are optional {token} templates.
   # filename_template builds the basename (no extension); empty uses the default
   # "{date}_{time}_{tg}" — e.g. 20260810_230041_1005479 — which drops the
@@ -1463,6 +1466,9 @@ broadcast:
 #     - serial: "00000001"
 #       dir: "../iq/"
 #       tap: wideband            # or: ddc (small narrowband channel recording)
+#       format: wav              # wav (default, SDRtrunk-compatible RIFF/WAVE)
+#                                # | flac (lossless, ~30–50% smaller; replays
+#                                #   and mounts back as a tuner identically)
 #   replay:
 #     - file: "../iq/00000001_20260521T120000Z.wav"
 #       serial: "replay-01"

--- a/internal/api/capture.go
+++ b/internal/api/capture.go
@@ -168,6 +168,15 @@ func (s *Server) handleSiglabCapture(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// The container formats (wav/flac) need the on-disk rate for their header
+	// before the first sample lands, so they require a streaming device.
+	isContainer := format == siglab.FormatWAV || format == siglab.FormatFLAC
+	if isContainer && outRate == 0 {
+		s.writeError(w, http.StatusBadGateway,
+			"siglab: capture: a wav/flac capture needs the device sample rate up front (start or resume a scan on this SDR)")
+		return
+	}
+
 	// Stream encoded IQ straight to the staged file: peak memory is one chunk
 	// (plus the DDC's FIR state for a narrowband slice), independent of duration.
 	id := randomID(16)
@@ -177,13 +186,36 @@ func (s *Server) handleSiglabCapture(w http.ResponseWriter, r *http.Request) {
 		s.writeError(w, http.StatusInternalServerError, "siglab: stage capture: "+err.Error())
 		return
 	}
-	bw := bufio.NewWriterSize(f, 1<<20)
-	enc := siglab.NewCaptureWriter(bw, format)
+	// Headerless formats stream through the byte encoder; wav/flac go through
+	// the IQContainer, which owns the header + finalize (RIFF length patch /
+	// FLAC STREAMINFO) — a staged "wav"/"flac" capture used to get a headerless
+	// (or, for flac, mis-encoded) body under a container label.
+	var (
+		bw      *bufio.Writer
+		enc     *siglab.CaptureWriter
+		cont    *siglab.IQContainer
+		samples func() int64
+		write   func([]complex64) error
+	)
+	if isContainer {
+		cont, err = siglab.NewIQContainer(f, format, int(outRate))
+		if err != nil {
+			f.Close()
+			_ = os.Remove(path)
+			s.writeError(w, http.StatusInternalServerError, "siglab: stage capture: "+err.Error())
+			return
+		}
+		samples, write = cont.Samples, cont.Write
+	} else {
+		bw = bufio.NewWriterSize(f, 1<<20)
+		enc = siglab.NewCaptureWriter(bw, format)
+		samples, write = enc.Samples, enc.Write
+	}
 	sink := func(chunk []complex64) error {
 		if ddc != nil {
 			chunk = ddc.Process(chunk)
 		}
-		return enc.Write(chunk)
+		return write(chunk)
 	}
 
 	// A capture runs for up to req.Seconds and Shutdown would wait it out, so
@@ -191,7 +223,12 @@ func (s *Server) handleSiglabCapture(w http.ResponseWriter, r *http.Request) {
 	capCtx, capCancel := s.streamCtx(r.Context())
 	defer capCancel()
 	gotRate, gotCenter, capErr := s.capture.CaptureStream(capCtx, req.Serial, req.Seconds, sink)
-	flushErr := bw.Flush()
+	var flushErr error
+	if cont != nil {
+		flushErr = cont.Finalize()
+	} else {
+		flushErr = bw.Flush()
+	}
 	if cerr := f.Close(); cerr != nil && flushErr == nil {
 		flushErr = cerr
 	}
@@ -205,7 +242,7 @@ func (s *Server) handleSiglabCapture(w http.ResponseWriter, r *http.Request) {
 		s.writeError(w, http.StatusInternalServerError, "siglab: stage capture: "+flushErr.Error())
 		return
 	}
-	if enc.Samples() == 0 {
+	if samples() == 0 {
 		_ = os.Remove(path)
 		s.writeError(w, http.StatusBadGateway, "siglab: capture produced no samples")
 		return
@@ -213,8 +250,12 @@ func (s *Server) handleSiglabCapture(w http.ResponseWriter, r *http.Request) {
 
 	// A full-band grab keeps the tuner's authoritative rate/centre from the
 	// stream; a narrowband slice keeps its decimated rate + requested centre.
-	if req.BandwidthHz == 0 {
+	// A container grab keeps the pre-capture rate its header was written with.
+	if req.BandwidthHz == 0 && !isContainer {
 		outRate, outCenter = gotRate, gotCenter
+	}
+	if req.BandwidthHz == 0 && isContainer {
+		outCenter = gotCenter
 	}
 
 	meta := &siglab.Metadata{
@@ -237,7 +278,7 @@ func (s *Server) handleSiglabCapture(w http.ResponseWriter, r *http.Request) {
 		Path:         path,
 		Format:       format,
 		SampleRateHz: float64(outRate),
-		Size:         enc.Samples() * int64(bytesPerSample(format)),
+		Size:         stagedCaptureSize(path, samples(), format),
 		Created:      time.Now(),
 	}
 	s.siglab.putCapture(c)
@@ -247,6 +288,16 @@ func (s *Server) handleSiglabCapture(w http.ResponseWriter, r *http.Request) {
 		Metadata:    meta,
 		DownloadURL: fmt.Sprintf("/api/v1/siglab/captures/%s/download", id),
 	})
+}
+
+// stagedCaptureSize reports a staged capture's size: the real on-disk size
+// when it can be statted (the only truthful number for a compressed flac),
+// falling back to the uncompressed samples × bytes-per-sample estimate.
+func stagedCaptureSize(path string, samples int64, format siglab.SampleFormat) int64 {
+	if fi, err := os.Stat(path); err == nil {
+		return fi.Size()
+	}
+	return samples * int64(bytesPerSample(format))
 }
 
 // handleSiglabCaptureDownload streams a staged capture's raw bytes as a file
@@ -273,6 +324,8 @@ func (s *Server) handleSiglabCaptureDownload(w http.ResponseWriter, r *http.Requ
 		ext = "raw"
 	case siglab.FormatWAV:
 		ext = "wav"
+	case siglab.FormatFLAC:
+		ext = "flac"
 	}
 	w.Header().Set("Content-Type", "application/octet-stream")
 	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s.%s", c.ID, ext))

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -420,7 +420,7 @@ func (s *Server) handleCallAudio(w http.ResponseWriter, r *http.Request) {
 	// the endpoint from ever serving a non-recording even if the row is bad.
 	ext := strings.ToLower(filepath.Ext(path))
 	if !filepath.IsAbs(path) || strings.Contains(path, "..") ||
-		(ext != ".wav" && ext != ".mp3") {
+		(ext != ".wav" && ext != ".mp3" && ext != ".flac") {
 		s.writeError(w, http.StatusNotFound, "recording unavailable")
 		return
 	}
@@ -436,9 +436,12 @@ func (s *Server) handleCallAudio(w http.ResponseWriter, r *http.Request) {
 		s.writeError(w, http.StatusNotFound, "recording unavailable")
 		return
 	}
-	if ext == ".mp3" {
+	switch ext {
+	case ".mp3":
 		w.Header().Set("Content-Type", "audio/mpeg")
-	} else {
+	case ".flac":
+		w.Header().Set("Content-Type", "audio/flac")
+	default:
 		w.Header().Set("Content-Type", "audio/wav")
 	}
 	http.ServeContent(w, r, filepath.Base(path), fi.ModTime(), f)

--- a/internal/api/handlers_siglab.go
+++ b/internal/api/handlers_siglab.go
@@ -551,6 +551,13 @@ func (s *Server) handleSiglabSynthesize(w http.ResponseWriter, r *http.Request) 
 		s.writeError(w, http.StatusBadRequest, "siglab: "+err.Error())
 		return
 	}
+	// The synth path stages via the pure byte encoder, which has no container
+	// support — a wav/flac request would silently produce a mislabeled body.
+	if format == siglab.FormatWAV || format == siglab.FormatFLAC {
+		s.writeError(w, http.StatusBadRequest,
+			"siglab: synth format must be u8, f32, or cs16 (wav/flac are live-capture container formats)")
+		return
+	}
 	taps, err := parseSiglabMultipath(req.Multipath)
 	if err != nil {
 		s.writeError(w, http.StatusBadRequest, "siglab: "+err.Error())

--- a/internal/broadcast/broadcast.go
+++ b/internal/broadcast/broadcast.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/loudness"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+	"github.com/MattCheramie/GopherTrunk/internal/voice"
 	"github.com/MattCheramie/GopherTrunk/internal/voice/mp3"
 )
 
@@ -87,7 +88,7 @@ type Call struct {
 	PatchedGroups []uint32
 	StartedAt     time.Time
 	EndedAt       time.Time
-	AudioPath     string // .wav on disk written by the recorder
+	AudioPath     string // recording on disk written by the recorder (.wav or .flac)
 	SampleRate    int
 
 	// normalize, when Enabled, loudness-normalizes the audio in memory
@@ -117,20 +118,31 @@ func (c *Call) MP3() ([]byte, error) {
 	if c.normalize.Enabled {
 		c.mp3Data, c.mp3Err = encodeNormalizedMP3(c.AudioPath, c.normalize.Params)
 	} else {
-		c.mp3Data, _, c.mp3Err = mp3.EncodeWAVFile(c.AudioPath)
+		c.mp3Data, c.mp3Err = encodeMP3(c.AudioPath)
 	}
 	return c.mp3Data, c.mp3Err
 }
 
-// encodeNormalizedMP3 reads the WAV at path, applies a single linear
-// loudness-normalization gain in memory (leaving the file untouched), and
-// MP3-encodes the result. When the audio is too short or quiet to measure,
-// it encodes the samples unchanged.
-func encodeNormalizedMP3(path string, p loudness.NormalizeParams) ([]byte, error) {
-	samples, rate, err := mp3.ReadWAV(path)
+// encodeMP3 reads the recording at path (WAV or FLAC — the recorder's
+// container choice) and MP3-encodes it unchanged.
+func encodeMP3(path string) ([]byte, error) {
+	samples, rate, err := voice.ReadAudioSamples(path)
 	if err != nil {
 		return nil, err
 	}
+	return mp3.Encode(samples, int(rate))
+}
+
+// encodeNormalizedMP3 reads the recording at path (WAV or FLAC), applies a
+// single linear loudness-normalization gain in memory (leaving the file
+// untouched), and MP3-encodes the result. When the audio is too short or
+// quiet to measure, it encodes the samples unchanged.
+func encodeNormalizedMP3(path string, p loudness.NormalizeParams) ([]byte, error) {
+	samples, rate32, err := voice.ReadAudioSamples(path)
+	if err != nil {
+		return nil, err
+	}
+	rate := int(rate32)
 	fs := make([]float64, len(samples))
 	for i, s := range samples {
 		fs[i] = float64(s) / 32768.0

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -353,6 +353,20 @@ type BasebandRecordConfig struct {
 	//     wideband, and directly replayable with `replay -format wav`. This is
 	//     the "record the DDC output" tap for sharing a hard-to-decode channel.
 	Tap string `yaml:"tap"`
+	// Format selects the recording container: "wav" (default — the canonical
+	// two-channel 16-bit RIFF/WAVE, SDRtrunk-compatible) or "flac" (the
+	// lossless compressed twin, typically 30–50% smaller; replays and mounts
+	// back as a virtual tuner exactly like wav).
+	Format string `yaml:"format"`
+}
+
+// RecordFormat returns the normalised recording container ("wav" or "flac").
+func (b BasebandRecordConfig) RecordFormat() string {
+	f := strings.ToLower(strings.TrimSpace(b.Format))
+	if f == "" {
+		return "wav"
+	}
+	return f
 }
 
 // TapDDC reports whether this record entry taps the narrowband DDC output
@@ -1922,10 +1936,15 @@ type StorageConfig struct {
 	CCCacheFile string `yaml:"cc_cache_file"`
 }
 
-// RecordingsConfig configures the per-call WAV recorder.
+// RecordingsConfig configures the per-call voice recorder.
 type RecordingsConfig struct {
 	Dir        string `yaml:"dir"`
 	SampleRate uint32 `yaml:"sample_rate"`
+	// Format selects the per-call recording container: "wav" (default —
+	// 16-bit mono PCM RIFF/WAVE) or "flac" (lossless FLAC, typically about
+	// half the size for speech; plays natively in browsers and feeds the
+	// same normalization / MP3-upload / web-playback paths).
+	Format string `yaml:"format"`
 	// Enhance is the opt-in "sound-good" voice enhancement chain. When
 	// enabled it band-limits decoded digital voice to the telephone band,
 	// warms the bright software-AMBE+2 timbre, runs the AGC to a louder

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -718,3 +718,41 @@ func TestResolvePathsDiversityCapture(t *testing.T) {
 		t.Errorf("empty prefix became %q", got)
 	}
 }
+
+// TestValidateRecordingFormats pins the two new container-format keys:
+// recordings.format (per-call voice recordings) and baseband.record[].format
+// (baseband IQ recordings) accept wav/flac and reject anything else.
+func TestValidateRecordingFormats(t *testing.T) {
+	base := func() Config {
+		var c Config
+		c.SDR.Devices = []DeviceConfig{{Serial: "A"}}
+		return c
+	}
+
+	c := base()
+	c.Recordings.Format = "flac"
+	if errs := c.validateRecordings(); len(errs) != 0 {
+		t.Fatalf("recordings.format flac rejected: %v", errs)
+	}
+	c.Recordings.Format = "mp3"
+	if errs := c.validateRecordings(); len(errs) == 0 {
+		t.Fatal("recordings.format mp3 should be rejected")
+	}
+
+	c = base()
+	c.Baseband.Record = []BasebandRecordConfig{{Serial: "A", Dir: "x", Format: "flac"}}
+	if errs := c.validateBaseband(); len(errs) != 0 {
+		t.Fatalf("baseband.record format flac rejected: %v", errs)
+	}
+	c.Baseband.Record[0].Format = "ogg"
+	if errs := c.validateBaseband(); len(errs) == 0 {
+		t.Fatal("baseband.record format ogg should be rejected")
+	}
+	if got := c.Baseband.Record[0].RecordFormat(); got != "ogg" {
+		t.Fatalf("RecordFormat() = %q, want the raw value back", got)
+	}
+	c.Baseband.Record[0].Format = ""
+	if got := c.Baseband.Record[0].RecordFormat(); got != "wav" {
+		t.Fatalf("RecordFormat() default = %q, want wav", got)
+	}
+}

--- a/internal/config/config_validate.go
+++ b/internal/config/config_validate.go
@@ -599,6 +599,11 @@ func (c Config) validateRecordings() []error {
 	if c.Recordings.SampleRate != 0 && (c.Recordings.SampleRate < 4000 || c.Recordings.SampleRate > 48_000) {
 		return []error{fmt.Errorf("recordings.sample_rate %d outside 4000..48000", c.Recordings.SampleRate)}
 	}
+	switch strings.ToLower(strings.TrimSpace(c.Recordings.Format)) {
+	case "", "wav", "flac":
+	default:
+		return []error{fmt.Errorf("recordings.format must be wav|flac, got %q", c.Recordings.Format)}
+	}
 	if c.Recordings.VoiceTapBufferChunks != 0 && (c.Recordings.VoiceTapBufferChunks < 1 || c.Recordings.VoiceTapBufferChunks > 1024) {
 		return []error{fmt.Errorf("recordings.voice_tap_buffer_chunks %d outside 1..1024", c.Recordings.VoiceTapBufferChunks)}
 	}
@@ -773,6 +778,11 @@ func (c Config) validateBaseband() []error {
 		case "", "wideband", "ddc":
 		default:
 			errs = append(errs, fmt.Errorf("baseband.record[%d]: tap must be wideband|ddc", i))
+		}
+		switch strings.ToLower(strings.TrimSpace(r.Format)) {
+		case "", "wav", "flac":
+		default:
+			errs = append(errs, fmt.Errorf("baseband.record[%d]: format must be wav|flac, got %q", i, r.Format))
 		}
 	}
 	for i, r := range c.Baseband.Replay {

--- a/internal/configbuilder/fieldmeta.go
+++ b/internal/configbuilder/fieldmeta.go
@@ -290,7 +290,8 @@ var fieldMetas = map[string]FieldMeta{
 	"StorageConfig.CCCacheFile": {Label: "CC cache file", Help: "JSON cache the control-channel hunter uses to skip dead frequencies. Empty disables it."},
 
 	// ---- Recordings --------------------------------------------------------
-	"RecordingsConfig.Dir":                  {Label: "Directory", Help: "Output directory for per-call WAV recordings."},
+	"RecordingsConfig.Dir":                  {Label: "Directory", Help: "Output directory for per-call voice recordings."},
+	"RecordingsConfig.Format":               {Label: "Format", Help: "Recording container: wav (16-bit mono PCM) or flac (lossless, ~half the size for speech; browsers play it natively, and normalization/MP3 uploads read it the same).", Options: opts("", "wav (default)", "flac", "flac")},
 	"RecordingsConfig.SampleRate":           {Label: "Sample rate", Help: "Recorder PCM rate (4000–48000 Hz). Match audio.sample_rate to avoid a resample stage."},
 	"RecordingsConfig.WriteRaw":             {Help: "Also write the raw (un-equalized) audio alongside the processed WAV."},
 	"RecordingsConfig.MBEFiles":             {Label: "dsd-fme MBE files", Help: "Also write a dsd-fme-playable MBE sidecar per call — .imb for P25 Phase 1 IMBE, .amb for DMR/NXDN/P25 Phase 2 AMBE+2 — so recordings decode offline with `dsd-fme -r <file>`. Protocols dsd-fme can't play (TETRA, ProVoice, analog) produce no file."},
@@ -444,6 +445,7 @@ var fieldMetas = map[string]FieldMeta{
 	"BasebandRecordConfig.Serial": {Help: "SDR serial whose IQ stream is recorded."},
 	"BasebandRecordConfig.Dir":    {Label: "Directory", Help: "Directory the IQ recordings are written into."},
 	"BasebandRecordConfig.Tap":    {Help: "What to record: wideband (raw SDR IQ) or ddc (narrowband channel the decoder sees).", Options: opts("", "wideband (default)", "ddc", "ddc")},
+	"BasebandRecordConfig.Format": {Help: "Recording container: wav (canonical two-channel 16-bit RIFF/WAVE, SDRtrunk-compatible) or flac (lossless, ~30–50% smaller; replays and mounts back identically).", Options: opts("", "wav (default)", "flac", "flac")},
 	"BasebandReplayConfig.File":   {Help: "Path to the baseband WAV recording to replay."},
 	"BasebandReplayConfig.Serial": {Help: "Virtual device serial the pool reports. Empty generates one."},
 	"BasebandReplayConfig.Role":   {Help: "Pool role: control / voice / auto.", Options: roleOpts()},

--- a/internal/radio/p25/phase1/ambt_label_test.go
+++ b/internal/radio/p25/phase1/ambt_label_test.go
@@ -1,0 +1,30 @@
+package phase1
+
+import "testing"
+
+// TestAMBTOpcodeLabel pins the AMBT log-naming rule: only the decoded
+// standard broadcasts get a mnemonic; every other opcode — and any vendor
+// MFID — renders numerically so an AMBT/ISP opcode is never mislabeled with
+// a TSBK OSP name that does not apply.
+func TestAMBTOpcodeLabel(t *testing.T) {
+	cases := []struct {
+		h    MBTHeader
+		want string
+	}{
+		{MBTHeader{Opcode: OpNetworkStatusBroadcast}, "NET_STS_BCST"},
+		{MBTHeader{Opcode: OpRFSSStatusBroadcast}, "RFSS_STS_BCST"},
+		{MBTHeader{Opcode: OpAdjacentSiteStatusBroadcast}, "ADJ_STS_BCST"},
+		// An AMBT opcode GT does not decode must NOT borrow a TSBK OSP name
+		// (0x00 would otherwise read GRP_V_CH_GRANT).
+		{MBTHeader{Opcode: 0x00}, "AMBT(0x00)"},
+		{MBTHeader{Opcode: 0x05}, "AMBT(0x05)"},
+		// A vendor MFID makes even a "known" opcode value vendor-defined.
+		{MBTHeader{MFID: 0x90, Opcode: OpNetworkStatusBroadcast}, "AMBT(0x3B)"},
+	}
+	for _, tc := range cases {
+		if got := ambtOpcodeLabel(tc.h); got != tc.want {
+			t.Errorf("ambtOpcodeLabel(mfid=0x%02X op=0x%02X) = %q, want %q",
+				tc.h.MFID, uint8(tc.h.Opcode), got, tc.want)
+		}
+	}
+}

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -463,6 +463,11 @@ type pendingHit struct {
 	mbtHave   bool
 	mbtHeader MBTHeader
 	mbtData   []byte
+	// mbtMetric is the worst (highest) data-block Viterbi metric seen for
+	// this PDU — logged with a data CRC failure so a corrupt block is
+	// distinguishable from a layout bug in the record (a high metric means
+	// the trellis itself was marginal: RF residual errors, not parsing).
+	mbtMetric int
 }
 
 // FSWFallbackToleranceDefault is the wider frame-sync-word tolerance the
@@ -1120,8 +1125,11 @@ func (c *ControlChannel) resumeMBTBlocks(ph *pendingHit) bool {
 			ph.mbtData = make([]byte, 0, int(h.BlocksToFollow)*12)
 		} else {
 			ph.mbtData = append(ph.mbtData, info...)
+			if metric > ph.mbtMetric {
+				ph.mbtMetric = metric
+			}
 			if len(ph.mbtData) >= int(ph.mbtHeader.BlocksToFollow)*12 {
-				c.dispatchMBT(ph.mbtHeader, ph.mbtData, ph.nac)
+				c.dispatchMBT(ph.mbtHeader, ph.mbtData, ph.nac, ph.mbtMetric)
 				return false
 			}
 		}
@@ -1132,12 +1140,21 @@ func (c *ControlChannel) resumeMBTBlocks(ph *pendingHit) bool {
 
 // dispatchMBT validates a complete MBT's data-block CRC-32 and routes the
 // AMBT broadcast opcodes into the same network model the TSBK forms feed.
-// data is the concatenation of the message's 12-octet data blocks.
-func (c *ControlChannel) dispatchMBT(h MBTHeader, data []byte, nac uint16) {
+// data is the concatenation of the message's 12-octet data blocks; metric is
+// the worst data-block Viterbi metric (for the failure diagnostic).
+func (c *ControlChannel) dispatchMBT(h MBTHeader, data []byte, nac uint16, metric int) {
 	if err := ValidateMBTData(data); err != nil {
 		atomic.AddInt64(&c.stats.MBTDataCRCFailed, 1)
+		// Everything identifying this line (opcode, blocks, nac) comes from
+		// the HEADER block, which passed its own CCITT-16 — only a data
+		// block is corrupt. So this line next to a decoded broadcast with
+		// the same identity is two different PDU frames, not one frame
+		// both failing and passing (the header repeats every broadcast).
+		// The Viterbi metric says how marginal the failing block was.
 		c.log.Debug("p25: MBT data CRC failed",
-			"opcode", h.Opcode, "blocks", h.BlocksToFollow, "nac", nac)
+			"opcode", ambtOpcodeLabel(h), "blocks", h.BlocksToFollow,
+			"metric", metric, "nac", nac,
+			"cause", "corrupt data block (header decoded clean; identity fields above are the header's)")
 		return
 	}
 	atomic.AddInt64(&c.stats.MBTDecoded, 1)
@@ -1179,8 +1196,24 @@ func (c *ControlChannel) dispatchMBT(h MBTHeader, data []byte, nac uint16) {
 		c.publishSiteUpdate()
 	default:
 		c.log.Debug("p25: unhandled AMBT opcode",
-			"opcode", h.Opcode, "mfid", h.MFID, "blocks", h.BlocksToFollow, "nac", nac)
+			"opcode", ambtOpcodeLabel(h), "mfid", h.MFID, "blocks", h.BlocksToFollow, "nac", nac)
 	}
+}
+
+// ambtOpcodeLabel names an AMBT header opcode for logging. Only the AMBT
+// forms GT decodes get a mnemonic; everything else renders numerically —
+// rendering an arbitrary AMBT (or inbound ISP) opcode through the TSBK OSP
+// String() map would mislabel it with a standard name that does not apply,
+// the same hazard logUnhandledTSBK documents for vendor opcodes. A vendor
+// MFID always renders numerically for the same reason.
+func ambtOpcodeLabel(h MBTHeader) string {
+	if h.MFID == 0 {
+		switch h.Opcode {
+		case OpNetworkStatusBroadcast, OpRFSSStatusBroadcast, OpAdjacentSiteStatusBroadcast:
+			return h.Opcode.String()
+		}
+	}
+	return fmt.Sprintf("AMBT(0x%02X)", uint8(h.Opcode))
 }
 
 // nidGuess is one evaluated NID-alignment hypothesis: the NID read from
@@ -1774,7 +1807,12 @@ func (c *ControlChannel) dispatchVendorTSBK(t TSBK, nac uint16) {
 	// test can name and reverse any alias-bearing transport we don't yet
 	// decode, while the per-frame detail stays at Debug.
 	c.logUnhandledTSBK(t, nac)
-	c.log.Debug("p25: vendor tsbk", "mfid", t.MFID, "opcode", t.Opcode, "nac", nac)
+	// Numeric opcode only: Opcode.String() is the STANDARD OSP mnemonic map,
+	// so naming a vendor opcode through it mislabels (MFID 0x90 opcode 0x00
+	// would log as GRP_V_CH_GRANT) — the exact hazard logUnhandledTSBK's doc
+	// records.
+	c.log.Debug("p25: vendor tsbk", "mfid", t.MFID,
+		"opcode", fmt.Sprintf("0x%02X", uint8(t.Opcode)), "nac", nac)
 }
 
 // diagnostic key namespaces for diagSeen — the high byte separates

--- a/internal/scanner/ccdecoder/ddcrecord.go
+++ b/internal/scanner/ccdecoder/ddcrecord.go
@@ -25,25 +25,27 @@ import (
 // retune to a different protocol/rate), so each recording holds one
 // contiguous channelized stream at one rate.
 type ddcRecorder struct {
-	dir string
-	log *slog.Logger
+	dir    string
+	format string // "wav" (default) or "flac"
+	log    *slog.Logger
 
-	w      *baseband.IQWriter
+	w      baseband.IQRecorderWriter
 	path   string
 	system string
 	rate   uint32
 }
 
 // newDDCRecorder returns a recorder writing into dir, or nil if dir is empty
-// (the zero-cost disabled case).
-func newDDCRecorder(dir string, log *slog.Logger) *ddcRecorder {
+// (the zero-cost disabled case). format selects the container ("wav" default,
+// "flac" for the lossless compressed twin).
+func newDDCRecorder(dir, format string, log *slog.Logger) *ddcRecorder {
 	if strings.TrimSpace(dir) == "" {
 		return nil
 	}
 	if log == nil {
 		log = slog.Default()
 	}
-	return &ddcRecorder{dir: dir, log: log}
+	return &ddcRecorder{dir: dir, format: format, log: log}
 }
 
 // write appends one channelized chunk, opening or rolling the WAV as needed.
@@ -85,10 +87,11 @@ func (r *ddcRecorder) roll(system string, rate uint32) {
 		r.dir = ""
 		return
 	}
-	name := fmt.Sprintf("%s_%s_%dhz.wav", ddcRecSanitize(system),
-		time.Now().UTC().Format("20060102T150405Z"), rate)
+	name := fmt.Sprintf("%s_%s_%dhz.%s", ddcRecSanitize(system),
+		time.Now().UTC().Format("20060102T150405Z"), rate,
+		baseband.IQRecordingExt(r.format))
 	path := filepath.Join(r.dir, name)
-	w, err := baseband.NewIQWriter(path, rate)
+	w, err := baseband.NewIQRecorderWriter(path, rate, r.format)
 	if err != nil {
 		r.log.Warn("ccdecoder: cannot open DDC recording; recording disabled",
 			"path", path, "err", err)

--- a/internal/scanner/ccdecoder/ddcrecord_test.go
+++ b/internal/scanner/ccdecoder/ddcrecord_test.go
@@ -20,7 +20,7 @@ func tone(n int) []complex64 {
 // pipeline rate and captures the channelized samples it is handed.
 func TestDDCRecorderWritesWav(t *testing.T) {
 	dir := t.TempDir()
-	r := newDDCRecorder(dir, nil)
+	r := newDDCRecorder(dir, "", nil)
 	if r == nil {
 		t.Fatal("newDDCRecorder returned nil for a non-empty dir")
 	}
@@ -48,7 +48,7 @@ func TestDDCRecorderWritesWav(t *testing.T) {
 // starts a fresh file, so each recording holds one contiguous rate/system.
 func TestDDCRecorderRollsOnRateChange(t *testing.T) {
 	dir := t.TempDir()
-	r := newDDCRecorder(dir, nil)
+	r := newDDCRecorder(dir, "", nil)
 	r.write("Site_A", 144000, tone(100))
 	r.write("Site_A", 48000, tone(100)) // rate change → roll
 	r.write("Site_B", 48000, tone(100)) // system change → roll
@@ -63,7 +63,7 @@ func TestDDCRecorderRollsOnRateChange(t *testing.T) {
 // TestDDCRecorderDisabled confirms an empty dir yields a nil recorder whose
 // methods are safe no-ops (the zero-cost disabled path).
 func TestDDCRecorderDisabled(t *testing.T) {
-	var r *ddcRecorder = newDDCRecorder("", nil)
+	var r *ddcRecorder = newDDCRecorder("", "", nil)
 	if r != nil {
 		t.Fatal("newDDCRecorder(\"\") should return nil")
 	}
@@ -75,7 +75,7 @@ func TestDDCRecorderDisabled(t *testing.T) {
 // TestDDCRecorderIgnoresEmptyAndZeroRate guards the write fast-paths.
 func TestDDCRecorderIgnoresEmptyAndZeroRate(t *testing.T) {
 	dir := t.TempDir()
-	r := newDDCRecorder(dir, nil)
+	r := newDDCRecorder(dir, "", nil)
 	r.write("S", 144000, nil) // empty samples → no file
 	r.write("S", 0, tone(10)) // zero rate → no file
 	r.close()
@@ -84,4 +84,31 @@ func TestDDCRecorderIgnoresEmptyAndZeroRate(t *testing.T) {
 		t.Fatalf("expected no recordings, got %v", matches)
 	}
 	_ = os.RemoveAll(dir)
+}
+
+// TestDDCRecorderWritesFLAC confirms the format option produces a real FLAC
+// recording at the pipeline rate with a .flac extension.
+func TestDDCRecorderWritesFLAC(t *testing.T) {
+	dir := t.TempDir()
+	r := newDDCRecorder(dir, "flac", nil)
+	if r == nil {
+		t.Fatal("newDDCRecorder returned nil for a non-empty dir")
+	}
+	r.write("Main_Site_1", 144000, tone(5000))
+	r.close()
+
+	matches, _ := filepath.Glob(filepath.Join(dir, "*.flac"))
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 .flac recording, got %d (%v)", len(matches), matches)
+	}
+	info, err := baseband.ReadIQRecordingInfo(matches[0])
+	if err != nil {
+		t.Fatalf("ReadIQRecordingInfo: %v", err)
+	}
+	if info.SampleRate != 144000 {
+		t.Errorf("recording rate = %d, want 144000", info.SampleRate)
+	}
+	if info.Samples != 5000 {
+		t.Errorf("recording samples = %d, want 5000", info.Samples)
+	}
 }

--- a/internal/scanner/ccdecoder/decoder.go
+++ b/internal/scanner/ccdecoder/decoder.go
@@ -342,6 +342,9 @@ type Options struct {
 	// the SDR rate. Empty (the default) disables it at zero cost. Driven by a
 	// baseband record entry with tap: ddc.
 	DDCRecordDir string
+	// DDCRecordFormat selects the DDC recording container: "wav" (default)
+	// or "flac" (lossless compressed). Driven by the record entry's format.
+	DDCRecordFormat string
 	// VoiceTapBufferChunks sizes the per-consumer same-carrier voice-tap
 	// buffer (how many post-DDC IQ chunks queue before a lagging voice consumer
 	// drops, issue #402). 0 selects the built-in default. Driven by
@@ -593,7 +596,7 @@ func New(opts Options) (*Decoder, error) {
 	}
 	d.carrierOffsetWarnPersist = carrierOffsetWarnPersist
 	d.zeroIFHealthWindow = zeroIFHealthWindow
-	d.ddcRec = newDDCRecorder(opts.DDCRecordDir, log)
+	d.ddcRec = newDDCRecorder(opts.DDCRecordDir, opts.DDCRecordFormat, log)
 	for _, s := range opts.Systems {
 		d.systems[s.Name] = s
 	}

--- a/internal/sdr/baseband/baseband_test.go
+++ b/internal/sdr/baseband/baseband_test.go
@@ -150,7 +150,7 @@ func TestRecordingDeviceTeesToWav(t *testing.T) {
 		info:   sdr.Info{Serial: "00000111"},
 		chunks: [][]complex64{iqTone(1000), iqTone(1000), iqTone(500)},
 	}
-	rec := NewRecordingDevice(inner, dir, nil)
+	rec := NewRecordingDevice(inner, dir, "", nil)
 	if err := rec.SetSampleRate(2_400_000); err != nil {
 		t.Fatalf("SetSampleRate: %v", err)
 	}

--- a/internal/sdr/baseband/driver.go
+++ b/internal/sdr/baseband/driver.go
@@ -46,7 +46,7 @@ func (d *FileDriver) Name() string { return FileDriverName }
 func (d *FileDriver) Enumerate() ([]sdr.Info, error) {
 	var out []sdr.Info
 	for i, spec := range d.specs {
-		if _, err := ReadIQWavInfo(spec.Path); err != nil {
+		if _, err := ReadIQRecordingInfo(spec.Path); err != nil {
 			continue
 		}
 		out = append(out, sdr.Info{
@@ -67,7 +67,7 @@ func (d *FileDriver) Open(idx int) (sdr.Device, error) {
 		return nil, fmt.Errorf("baseband: replay index %d out of range", idx)
 	}
 	spec := d.specs[idx]
-	info, err := ReadIQWavInfo(spec.Path)
+	info, err := ReadIQRecordingInfo(spec.Path)
 	if err != nil {
 		return nil, fmt.Errorf("baseband: %s: %w", spec.Path, err)
 	}
@@ -125,8 +125,13 @@ func (d *replayDevice) SetSampleRate(hz uint32) error {
 }
 
 // StreamIQ replays the recording, metered to the configured rate, and
-// loops on EOF when Loop is set.
+// loops on EOF when Loop is set. FLAC recordings (sniffed from the stream
+// marker) are decoded through the FLAC replay path; everything else is
+// treated as the canonical baseband WAV.
 func (d *replayDevice) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
+	if isFLACRecording(d.path) {
+		return d.streamFLAC(ctx)
+	}
 	f, err := os.Open(d.path)
 	if err != nil {
 		return nil, err
@@ -187,6 +192,81 @@ func (d *replayDevice) StreamIQ(ctx context.Context) (<-chan []complex64, error)
 					return
 				}
 			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+		}
+	}()
+	return out, nil
+}
+
+// streamFLAC replays a FLAC baseband recording, decoding frames on the fly
+// and metering chunks to the configured rate, looping on EOF when Loop is
+// set (by reopening the stream — the mewkiz parser is forward-only).
+func (d *replayDevice) streamFLAC(ctx context.Context) (<-chan []complex64, error) {
+	f, err := os.Open(d.path)
+	if err != nil {
+		return nil, err
+	}
+	stream, err := flacIQStream(f)
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+	d.mu.Lock()
+	rate := d.rate
+	d.mu.Unlock()
+	if rate == 0 {
+		rate = d.wavRate
+	}
+	if rate == 0 {
+		rate = sdr.DefaultSampleRateHz
+	}
+
+	out := make(chan []complex64, 8)
+	go func() {
+		defer close(out)
+		defer func() { f.Close() }()
+		ticker := time.NewTicker(time.Second) // reset per chunk below
+		defer ticker.Stop()
+		for {
+			fr, err := stream.ParseNext()
+			if err != nil {
+				if !d.loop {
+					return
+				}
+				// EOF (or a truncated tail): reopen from the top.
+				f.Close()
+				nf, oerr := os.Open(d.path)
+				if oerr != nil {
+					return
+				}
+				ns, serr := flacIQStream(nf)
+				if serr != nil {
+					nf.Close()
+					return
+				}
+				f, stream = nf, ns
+				continue
+			}
+			if len(fr.Subframes) != 2 {
+				return
+			}
+			l, q := fr.Subframes[0].Samples, fr.Subframes[1].Samples
+			n := len(l)
+			chunk := make([]complex64, n)
+			for i := 0; i < n; i++ {
+				chunk[i] = complex(float32(int16(l[i]))/32768, float32(int16(q[i]))/32768)
+			}
+			select {
+			case out <- chunk:
+			case <-ctx.Done():
+				return
+			}
+			// Meter to real time: one FLAC frame's worth of samples per tick.
+			ticker.Reset(time.Duration(float64(time.Second) * float64(n) / float64(rate)))
 			select {
 			case <-ctx.Done():
 				return

--- a/internal/sdr/baseband/flac.go
+++ b/internal/sdr/baseband/flac.go
@@ -1,0 +1,281 @@
+package baseband
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/mewkiz/flac"
+	"github.com/mewkiz/flac/frame"
+	"github.com/mewkiz/flac/meta"
+)
+
+// flacIQBlockSize matches siglab's IQ container block size so both FLAC IQ
+// writers produce identically-framed streams.
+const flacIQBlockSize = 4096
+
+// FLACIQEncoder losslessly encodes 16-bit I/Q pairs into a two-channel FLAC
+// stream (I in the left channel, Q in the right) — the FLAC twin of the
+// two-channel 16-bit RIFF/WAVE layout IQWriter emits, typically 30–50%
+// smaller thanks to linear prediction on the continuous baseband waveform.
+//
+// It is the shared encode core for every FLAC IQ writer in the tree: the
+// file-owning FLACIQWriter below and siglab's IQContainer both feed it int16
+// pairs, so the two paths cannot drift apart. Callers do their own
+// float→int16 conversion (the packages differ deliberately: baseband scales
+// ×32767, siglab ×32768) and must call Finalize once — it flushes the last
+// partial block and patches the STREAMINFO (sample count + MD5) via a seek,
+// but never closes the underlying writer.
+type FLACIQEncoder struct {
+	enc   *flac.Encoder
+	left  []int32
+	right []int32
+}
+
+// NewFLACIQEncoder starts a two-channel 16-bit FLAC stream on ws at the given
+// IQ sample rate. ws must be positioned at offset 0 of a fresh stream.
+func NewFLACIQEncoder(ws io.WriteSeeker, sampleRate uint32) (*FLACIQEncoder, error) {
+	if sampleRate == 0 {
+		return nil, errors.New("baseband: FLAC IQ sample rate must be > 0")
+	}
+	info := &meta.StreamInfo{
+		SampleRate:    sampleRate,
+		NChannels:     2,
+		BitsPerSample: 16,
+	}
+	enc, err := flac.NewEncoder(nopCloserWriteSeeker{ws}, info)
+	if err != nil {
+		return nil, fmt.Errorf("baseband: init flac encoder: %w", err)
+	}
+	// Analyse each block for the best fixed/LPC predictor so the stream is
+	// actually compressed rather than stored verbatim.
+	enc.EnablePredictionAnalysis(true)
+	return &FLACIQEncoder{
+		enc:   enc,
+		left:  make([]int32, 0, flacIQBlockSize),
+		right: make([]int32, 0, flacIQBlockSize),
+	}, nil
+}
+
+// WriteI16 appends one I/Q sample pair, flushing a FLAC frame whenever a full
+// block has accumulated.
+func (e *FLACIQEncoder) WriteI16(i, q int16) error {
+	e.left = append(e.left, int32(i))
+	e.right = append(e.right, int32(q))
+	if len(e.left) >= flacIQBlockSize {
+		return e.flushBlock()
+	}
+	return nil
+}
+
+// Finalize flushes the pending partial block and closes the FLAC stream,
+// patching the STREAMINFO via a seek on the underlying writer. It does NOT
+// close the writer — the caller owns its lifetime.
+func (e *FLACIQEncoder) Finalize() error {
+	if len(e.left) > 0 {
+		if err := e.flushBlock(); err != nil {
+			return err
+		}
+	}
+	if err := e.enc.Close(); err != nil {
+		return fmt.Errorf("baseband: finalize flac: %w", err)
+	}
+	return nil
+}
+
+// flushBlock encodes the pending L/R samples as one FLAC frame and resets the
+// block buffers. Subframes start verbatim; the encoder's prediction analysis
+// upgrades them to fixed/LPC predictors.
+func (e *FLACIQEncoder) flushBlock() error {
+	n := len(e.left)
+	if n == 0 {
+		return nil
+	}
+	hdr := frame.Header{
+		HasFixedBlockSize: true,
+		BlockSize:         uint16(n),
+		SampleRate:        e.enc.Info.SampleRate,
+		Channels:          frame.ChannelsLR,
+		BitsPerSample:     16,
+	}
+	// Copy the pending samples: WriteFrame decorrelates in place and reverts,
+	// but the slices are reused for the next block, so hand it fresh backing.
+	left := make([]int32, n)
+	right := make([]int32, n)
+	copy(left, e.left)
+	copy(right, e.right)
+	fr := &frame.Frame{
+		Header: hdr,
+		Subframes: []*frame.Subframe{
+			{SubHeader: frame.SubHeader{Pred: frame.PredVerbatim}, Samples: left, NSamples: n},
+			{SubHeader: frame.SubHeader{Pred: frame.PredVerbatim}, Samples: right, NSamples: n},
+		},
+	}
+	if err := e.enc.WriteFrame(fr); err != nil {
+		return fmt.Errorf("baseband: encode flac frame: %w", err)
+	}
+	e.left = e.left[:0]
+	e.right = e.right[:0]
+	return nil
+}
+
+// nopCloserWriteSeeker hides an underlying Close from the FLAC encoder so
+// enc.Close patches the STREAMINFO without closing the caller's file.
+type nopCloserWriteSeeker struct{ ws io.WriteSeeker }
+
+func (w nopCloserWriteSeeker) Write(p []byte) (int, error) { return w.ws.Write(p) }
+func (w nopCloserWriteSeeker) Seek(offset int64, whence int) (int64, error) {
+	return w.ws.Seek(offset, whence)
+}
+
+// FLACIQWriter is the FLAC twin of IQWriter: it streams complex64 IQ to a
+// two-channel 16-bit FLAC file with the same clamp/scale (floatToI16) as the
+// WAV writer, so a flac baseband recording decodes to the same int16 samples
+// a wav one carries.
+type FLACIQWriter struct {
+	f            *os.File
+	enc          *FLACIQEncoder
+	bytesWritten uint32 // PCM payload bytes (pre-compression), mirroring IQWriter
+	closed       bool
+}
+
+// NewFLACIQWriter creates (or truncates) path and starts the FLAC stream.
+func NewFLACIQWriter(path string, sampleRate uint32) (*FLACIQWriter, error) {
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, err
+	}
+	enc, err := NewFLACIQEncoder(f, sampleRate)
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+	return &FLACIQWriter{f: f, enc: enc}, nil
+}
+
+// Write appends a block of IQ samples, clamped and scaled exactly like
+// IQWriter.Write.
+func (w *FLACIQWriter) Write(samples []complex64) error {
+	if w.closed {
+		return errors.New("baseband: FLAC IQ writer is closed")
+	}
+	for _, s := range samples {
+		if err := w.enc.WriteI16(floatToI16(real(s)), floatToI16(imag(s))); err != nil {
+			return err
+		}
+	}
+	w.bytesWritten += uint32(iqWavBlockAlign * len(samples))
+	return nil
+}
+
+// BytesWritten reports the uncompressed IQ payload bytes written so far
+// (int16 pairs, i.e. what the equivalent WAV body would hold) — the
+// compressed on-disk size is smaller.
+func (w *FLACIQWriter) BytesWritten() uint32 { return w.bytesWritten }
+
+// Close finalizes the FLAC stream and closes the file.
+func (w *FLACIQWriter) Close() error {
+	if w.closed {
+		return nil
+	}
+	w.closed = true
+	if err := w.enc.Finalize(); err != nil {
+		w.f.Close()
+		return err
+	}
+	return w.f.Close()
+}
+
+// IQRecorderWriter is the writer contract shared by the wav (IQWriter) and
+// flac (FLACIQWriter) baseband recorders.
+type IQRecorderWriter interface {
+	Write(samples []complex64) error
+	BytesWritten() uint32
+	Close() error
+}
+
+// NewIQRecorderWriter opens a baseband IQ recording at path in the given
+// container format: "wav" (or "") for the canonical two-channel RIFF/WAVE,
+// "flac" for the lossless compressed twin.
+func NewIQRecorderWriter(path string, sampleRate uint32, format string) (IQRecorderWriter, error) {
+	switch format {
+	case "", "wav":
+		return NewIQWriter(path, sampleRate)
+	case "flac":
+		return NewFLACIQWriter(path, sampleRate)
+	default:
+		return nil, fmt.Errorf("baseband: unknown IQ recording format %q (want wav or flac)", format)
+	}
+}
+
+// IQRecordingExt returns the filename extension (without dot) for a baseband
+// recording format accepted by NewIQRecorderWriter.
+func IQRecordingExt(format string) string {
+	if format == "flac" {
+		return "flac"
+	}
+	return "wav"
+}
+
+// isFLACRecording sniffs the 4-byte "fLaC" stream marker so the replay driver
+// picks the right decoder from the file itself rather than its extension.
+func isFLACRecording(path string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	var magic [4]byte
+	if _, err := io.ReadFull(f, magic[:]); err != nil {
+		return false
+	}
+	return string(magic[:]) == "fLaC"
+}
+
+// flacIQStream opens a FLAC stream over r and validates it carries the
+// two-channel 16-bit I/Q layout the baseband writers emit.
+func flacIQStream(r io.Reader) (*flac.Stream, error) {
+	stream, err := flac.New(r)
+	if err != nil {
+		return nil, fmt.Errorf("baseband: open flac recording: %w", err)
+	}
+	if stream.Info == nil {
+		return nil, errors.New("baseband: flac recording has no STREAMINFO")
+	}
+	if stream.Info.NChannels != iqWavChannels {
+		return nil, fmt.Errorf("baseband: flac recording has %d channels, IQ recordings need 2", stream.Info.NChannels)
+	}
+	if stream.Info.BitsPerSample != iqWavBitsPerSample {
+		return nil, fmt.Errorf("baseband: flac recording is %d-bit, IQ recordings need 16-bit", stream.Info.BitsPerSample)
+	}
+	return stream, nil
+}
+
+// readIQFLACInfo parses a FLAC baseband recording's STREAMINFO into the same
+// shape ReadIQWavInfo returns for WAV recordings.
+func readIQFLACInfo(path string) (IQWavInfo, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return IQWavInfo{}, err
+	}
+	defer f.Close()
+	stream, err := flacIQStream(f)
+	if err != nil {
+		return IQWavInfo{}, err
+	}
+	return IQWavInfo{
+		SampleRate: stream.Info.SampleRate,
+		Channels:   uint16(stream.Info.NChannels),
+		Samples:    int(stream.Info.NSamples),
+	}, nil
+}
+
+// ReadIQRecordingInfo describes a baseband recording (WAV or FLAC) without
+// loading its samples, sniffing the container from the file content.
+func ReadIQRecordingInfo(path string) (IQWavInfo, error) {
+	if isFLACRecording(path) {
+		return readIQFLACInfo(path)
+	}
+	return ReadIQWavInfo(path)
+}

--- a/internal/sdr/baseband/flac_test.go
+++ b/internal/sdr/baseband/flac_test.go
@@ -1,0 +1,197 @@
+package baseband
+
+import (
+	"context"
+	"math"
+	"path/filepath"
+	"testing"
+
+	"github.com/mewkiz/flac"
+)
+
+// rampIQ builds a deterministic low-amplitude complex ramp long enough to
+// span multiple FLAC blocks.
+func rampIQ(n int) []complex64 {
+	out := make([]complex64, n)
+	for i := range out {
+		out[i] = complex(
+			float32(0.5*math.Sin(2*math.Pi*float64(i)/97)),
+			float32(0.5*math.Cos(2*math.Pi*float64(i)/89)),
+		)
+	}
+	return out
+}
+
+// TestFLACIQWriterRoundTrip pins the FLAC baseband recording end to end:
+// write a ramp through FLACIQWriter, then decode the file with the upstream
+// FLAC parser and require bit-exact int16 samples against the writer's own
+// clamp/scale — the same contract IQWriter's WAV body carries.
+func TestFLACIQWriterRoundTrip(t *testing.T) {
+	const rate = 48_000
+	iq := rampIQ(10_000) // > 2 blocks of 4096
+
+	path := filepath.Join(t.TempDir(), "rec.flac")
+	w, err := NewFLACIQWriter(path, rate)
+	if err != nil {
+		t.Fatalf("NewFLACIQWriter: %v", err)
+	}
+	if err := w.Write(iq); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if got, want := w.BytesWritten(), uint32(len(iq)*iqWavBlockAlign); got != want {
+		t.Errorf("BytesWritten = %d, want %d", got, want)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	stream, err := flac.ParseFile(path)
+	if err != nil {
+		t.Fatalf("flac.ParseFile: %v", err)
+	}
+	if stream.Info.SampleRate != rate {
+		t.Errorf("sample rate = %d, want %d", stream.Info.SampleRate, rate)
+	}
+	if stream.Info.NChannels != 2 || stream.Info.BitsPerSample != 16 {
+		t.Errorf("stream is %d-ch %d-bit, want 2-ch 16-bit",
+			stream.Info.NChannels, stream.Info.BitsPerSample)
+	}
+	var got int
+	for {
+		fr, err := stream.ParseNext()
+		if err != nil {
+			break
+		}
+		l, q := fr.Subframes[0].Samples, fr.Subframes[1].Samples
+		for i := range l {
+			wantI := floatToI16(real(iq[got]))
+			wantQ := floatToI16(imag(iq[got]))
+			if int16(l[i]) != wantI || int16(q[i]) != wantQ {
+				t.Fatalf("sample %d = (%d,%d), want (%d,%d)", got, l[i], q[i], wantI, wantQ)
+			}
+			got++
+		}
+	}
+	if got != len(iq) {
+		t.Fatalf("decoded %d samples, want %d", got, len(iq))
+	}
+}
+
+// TestReadIQRecordingInfoSniffsContainer proves the replay driver's
+// content-based sniffing describes both containers identically.
+func TestReadIQRecordingInfoSniffsContainer(t *testing.T) {
+	dir := t.TempDir()
+	iq := rampIQ(5000)
+
+	wavPath := filepath.Join(dir, "rec.wav")
+	ww, err := NewIQWriter(wavPath, 25_000)
+	if err != nil {
+		t.Fatalf("NewIQWriter: %v", err)
+	}
+	if err := ww.Write(iq); err != nil {
+		t.Fatalf("wav Write: %v", err)
+	}
+	if err := ww.Close(); err != nil {
+		t.Fatalf("wav Close: %v", err)
+	}
+
+	flacPath := filepath.Join(dir, "rec.flac")
+	fw, err := NewFLACIQWriter(flacPath, 25_000)
+	if err != nil {
+		t.Fatalf("NewFLACIQWriter: %v", err)
+	}
+	if err := fw.Write(iq); err != nil {
+		t.Fatalf("flac Write: %v", err)
+	}
+	if err := fw.Close(); err != nil {
+		t.Fatalf("flac Close: %v", err)
+	}
+
+	for _, path := range []string{wavPath, flacPath} {
+		info, err := ReadIQRecordingInfo(path)
+		if err != nil {
+			t.Fatalf("ReadIQRecordingInfo(%s): %v", path, err)
+		}
+		if info.SampleRate != 25_000 || info.Channels != 2 || info.Samples != len(iq) {
+			t.Errorf("%s: info = %+v, want rate 25000 / 2 ch / %d samples", path, info, len(iq))
+		}
+	}
+}
+
+// TestFileDriverReplaysFLACRecording mounts a FLAC baseband recording through
+// the replay FileDriver and requires the streamed IQ to match the recorded
+// ramp through the writer's quantization — the same virtual-tuner path a WAV
+// recording takes.
+func TestFileDriverReplaysFLACRecording(t *testing.T) {
+	iq := rampIQ(6000)
+	path := filepath.Join(t.TempDir(), "rec.flac")
+	w, err := NewFLACIQWriter(path, 200_000) // fast replay metering
+	if err != nil {
+		t.Fatalf("NewFLACIQWriter: %v", err)
+	}
+	if err := w.Write(iq); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	drv := NewFileDriver([]ReplaySpec{{Path: path, Loop: false}})
+	infos, err := drv.Enumerate()
+	if err != nil || len(infos) != 1 {
+		t.Fatalf("Enumerate = %v, %v; want 1 recording", infos, err)
+	}
+	dev, err := drv.Open(0)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer dev.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch, err := dev.StreamIQ(ctx)
+	if err != nil {
+		t.Fatalf("StreamIQ: %v", err)
+	}
+	var got []complex64
+	for chunk := range ch {
+		got = append(got, chunk...)
+	}
+	if len(got) != len(iq) {
+		t.Fatalf("streamed %d samples, want %d", len(got), len(iq))
+	}
+	for i, s := range got {
+		want := complex(
+			float32(floatToI16(real(iq[i])))/32768,
+			float32(floatToI16(imag(iq[i])))/32768,
+		)
+		if s != want {
+			t.Fatalf("sample %d = %v, want %v", i, s, want)
+		}
+	}
+}
+
+// TestNewIQRecorderWriterDispatch pins the format dispatch and the loud
+// failure on an unknown format.
+func TestNewIQRecorderWriterDispatch(t *testing.T) {
+	dir := t.TempDir()
+	if w, err := NewIQRecorderWriter(filepath.Join(dir, "a.wav"), 1000, ""); err != nil {
+		t.Fatalf("default format: %v", err)
+	} else {
+		if _, ok := w.(*IQWriter); !ok {
+			t.Errorf("default format writer = %T, want *IQWriter", w)
+		}
+		w.Close()
+	}
+	if w, err := NewIQRecorderWriter(filepath.Join(dir, "b.flac"), 1000, "flac"); err != nil {
+		t.Fatalf("flac format: %v", err)
+	} else {
+		if _, ok := w.(*FLACIQWriter); !ok {
+			t.Errorf("flac format writer = %T, want *FLACIQWriter", w)
+		}
+		w.Close()
+	}
+	if _, err := NewIQRecorderWriter(filepath.Join(dir, "c.x"), 1000, "mp3"); err == nil {
+		t.Fatal("unknown format should error")
+	}
+}

--- a/internal/sdr/baseband/recorder.go
+++ b/internal/sdr/baseband/recorder.go
@@ -17,20 +17,23 @@ import (
 // normal consumer unchanged. A fresh WAV is opened each time StreamIQ
 // is called and closed when that stream ends.
 type RecordingDevice struct {
-	inner sdr.Device
-	dir   string
-	log   *slog.Logger
+	inner  sdr.Device
+	dir    string
+	format string // "wav" (default) or "flac"
+	log    *slog.Logger
 
 	mu   sync.Mutex
 	rate uint32
 }
 
-// NewRecordingDevice wraps inner so its IQ is recorded into dir.
-func NewRecordingDevice(inner sdr.Device, dir string, log *slog.Logger) *RecordingDevice {
+// NewRecordingDevice wraps inner so its IQ is recorded into dir. format
+// selects the recording container ("wav" default, "flac" for the lossless
+// compressed twin).
+func NewRecordingDevice(inner sdr.Device, dir, format string, log *slog.Logger) *RecordingDevice {
 	if log == nil {
 		log = slog.Default()
 	}
-	return &RecordingDevice{inner: inner, dir: dir, log: log}
+	return &RecordingDevice{inner: inner, dir: dir, format: format, log: log}
 }
 
 // Inner returns the wrapped device.
@@ -82,8 +85,8 @@ func (r *RecordingDevice) StreamIQ(ctx context.Context) (<-chan []complex64, err
 			"dir", r.dir, "err", err)
 		return in, nil
 	}
-	path := filepath.Join(r.dir, recordingName(r.inner.Info().Serial))
-	w, err := NewIQWriter(path, rate)
+	path := filepath.Join(r.dir, recordingName(r.inner.Info().Serial, r.format))
+	w, err := NewIQRecorderWriter(path, rate, r.format)
 	if err != nil {
 		r.log.Warn("baseband: cannot open recording; streaming unrecorded",
 			"path", path, "err", err)
@@ -117,13 +120,14 @@ func (r *RecordingDevice) StreamIQ(ctx context.Context) (<-chan []complex64, err
 	return out, nil
 }
 
-// recordingName builds a per-stream filename: serial + UTC timestamp.
-func recordingName(serial string) string {
+// recordingName builds a per-stream filename: serial + UTC timestamp, with
+// the extension matching the recording format.
+func recordingName(serial, format string) string {
 	s := sanitize(serial)
 	if s == "" {
 		s = "sdr"
 	}
-	return s + "_" + time.Now().UTC().Format("20060102T150405Z") + ".wav"
+	return s + "_" + time.Now().UTC().Format("20060102T150405Z") + "." + IQRecordingExt(format)
 }
 
 // sanitize strips path-hostile characters from a serial.

--- a/internal/siglab/container.go
+++ b/internal/siglab/container.go
@@ -2,14 +2,15 @@ package siglab
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"io"
 	"os"
 
 	"github.com/mewkiz/flac"
-	"github.com/mewkiz/flac/frame"
-	"github.com/mewkiz/flac/meta"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/baseband"
 )
 
 // IQContainer streams complex64 IQ to an *os.File in a chosen on-disk container:
@@ -37,11 +38,9 @@ type IQContainer struct {
 	cw      *CaptureWriter
 	dataLen uint32 // wav: body bytes written (for the RIFF length patch)
 
-	// FLAC.
-	enc       *flac.Encoder
-	blockSize int
-	left      []int32 // I samples pending in the current block
-	right     []int32 // Q samples pending in the current block
+	// FLAC: the shared two-channel encode core (also behind the baseband
+	// recorder's FLACIQWriter), fed siglab-normalised int16 pairs.
+	enc *baseband.FLACIQEncoder
 
 	samples int64
 }
@@ -49,7 +48,6 @@ type IQContainer struct {
 const (
 	iqWavHeaderSize = 44
 	iqWavBlockAlign = 4 // 2 channels × 16-bit
-	flacBlockSize   = 4096
 )
 
 // NewIQContainer creates a container writer over f for the given format.
@@ -72,25 +70,13 @@ func NewIQContainer(f *os.File, format SampleFormat, sampleRateHz int) (*IQConta
 		if sampleRateHz <= 0 {
 			return nil, fmt.Errorf("siglab: flac container needs a positive sample rate, got %d", sampleRateHz)
 		}
-		info := &meta.StreamInfo{
-			SampleRate:    uint32(sampleRateHz),
-			NChannels:     2,
-			BitsPerSample: 16,
-		}
-		// Hand the encoder a WriteSeeker that is NOT a Closer: it patches the
-		// STREAMINFO via Seek on Close but leaves closing the file to our caller
-		// (uniform with the other formats — Finalize never closes f).
-		enc, err := flac.NewEncoder(writeSeekerNoCloser{f}, info)
+		// The shared encoder patches the STREAMINFO via Seek on Finalize but
+		// never closes f — uniform with the other formats (the caller owns f).
+		enc, err := baseband.NewFLACIQEncoder(f, uint32(sampleRateHz))
 		if err != nil {
 			return nil, fmt.Errorf("siglab: init flac encoder: %w", err)
 		}
-		// Analyse each verbatim block for the best fixed/LPC predictor so the
-		// stream is actually compressed (not stored verbatim).
-		enc.EnablePredictionAnalysis(true)
 		c.enc = enc
-		c.blockSize = flacBlockSize
-		c.left = make([]int32, 0, flacBlockSize)
-		c.right = make([]int32, 0, flacBlockSize)
 	default:
 		c.bw = bufio.NewWriterSize(f, 1<<16)
 		c.cw = NewCaptureWriter(c.bw, format)
@@ -106,12 +92,11 @@ func (c *IQContainer) Write(iq []complex64) error {
 	switch c.format {
 	case FormatFLAC:
 		for _, s := range iq {
-			c.left = append(c.left, int32(floatToI16(real(s))))
-			c.right = append(c.right, int32(floatToI16(imag(s))))
-			if len(c.left) >= c.blockSize {
-				if err := c.flushFLACBlock(); err != nil {
-					return err
-				}
+			// siglab's own float→int16 normalisation (×32768), so a flac dump
+			// losslessly matches the cs16 body — the baseband recorder feeds
+			// the same core its ×32767 samples instead.
+			if err := c.enc.WriteI16(floatToI16(real(s)), floatToI16(imag(s))); err != nil {
+				return err
 			}
 		}
 	default: // headerless and wav both stream through the CaptureWriter
@@ -135,17 +120,9 @@ func (c *IQContainer) Samples() int64 { return c.samples }
 func (c *IQContainer) Finalize() error {
 	switch c.format {
 	case FormatFLAC:
-		if len(c.left) > 0 {
-			if err := c.flushFLACBlock(); err != nil {
-				return err
-			}
-		}
-		// enc.Close patches the STREAMINFO (sample count + MD5) via a seek on f;
-		// it does not close f itself.
-		if err := c.enc.Close(); err != nil {
-			return fmt.Errorf("siglab: finalize flac: %w", err)
-		}
-		return nil
+		// Finalize flushes the pending block and patches the STREAMINFO
+		// (sample count + MD5) via a seek on f; it does not close f itself.
+		return c.enc.Finalize()
 	case FormatWAV:
 		if err := c.bw.Flush(); err != nil {
 			return err
@@ -154,43 +131,6 @@ func (c *IQContainer) Finalize() error {
 	default:
 		return c.bw.Flush()
 	}
-}
-
-// flushFLACBlock encodes the pending L/R samples as one FLAC frame and resets
-// the block buffers. The prediction method is left verbatim; the encoder's
-// prediction analysis (enabled in the constructor) upgrades it to a fixed/LPC
-// predictor per subframe.
-func (c *IQContainer) flushFLACBlock() error {
-	n := len(c.left)
-	if n == 0 {
-		return nil
-	}
-	hdr := frame.Header{
-		HasFixedBlockSize: true,
-		BlockSize:         uint16(n),
-		SampleRate:        c.enc.Info.SampleRate,
-		Channels:          frame.ChannelsLR,
-		BitsPerSample:     16,
-	}
-	// Copy the pending samples: WriteFrame decorrelates in place and reverts,
-	// but the slices are reused for the next block, so hand it fresh backing.
-	left := make([]int32, n)
-	right := make([]int32, n)
-	copy(left, c.left)
-	copy(right, c.right)
-	fr := &frame.Frame{
-		Header: hdr,
-		Subframes: []*frame.Subframe{
-			{SubHeader: frame.SubHeader{Pred: frame.PredVerbatim}, Samples: left, NSamples: n},
-			{SubHeader: frame.SubHeader{Pred: frame.PredVerbatim}, Samples: right, NSamples: n},
-		},
-	}
-	if err := c.enc.WriteFrame(fr); err != nil {
-		return fmt.Errorf("siglab: encode flac frame: %w", err)
-	}
-	c.left = c.left[:0]
-	c.right = c.right[:0]
-	return nil
 }
 
 // flacSW16Reader lazily decodes a FLAC stream into the headerless interleaved
@@ -244,17 +184,40 @@ func (fr *flacSW16Reader) Read(p []byte) (int, error) {
 	return n, nil
 }
 
-// writeSeekerNoCloser exposes an *os.File's Write+Seek to the FLAC encoder
-// without exposing Close, so the encoder patches the STREAMINFO on finalize but
-// never closes the file — the IQContainer's caller owns that.
-type writeSeekerNoCloser struct{ f *os.File }
-
-func (w writeSeekerNoCloser) Write(p []byte) (int, error) { return w.f.Write(p) }
-func (w writeSeekerNoCloser) Seek(offset int64, whence int) (int64, error) {
-	return w.f.Seek(offset, whence)
+// DecodeContainerFile reads a wav or flac IQ capture (as written by
+// IQContainer) back to complex64 samples plus the container's sample rate,
+// sniffing the container from the file content. Small-file convenience for
+// tests and tools; the replay engine streams instead.
+func DecodeContainerFile(path string) ([]complex64, uint32, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, 0, err
+	}
+	var (
+		body []byte
+		rate uint32
+	)
+	switch {
+	case len(b) >= 4 && string(b[0:4]) == "fLaC":
+		fr, r, err := newFLACSW16Reader(bytes.NewReader(b))
+		if err != nil {
+			return nil, 0, err
+		}
+		body, err = io.ReadAll(fr)
+		if err != nil && err != io.EOF {
+			return nil, 0, err
+		}
+		rate = r
+	case len(b) >= iqWavHeaderSize && string(b[0:4]) == "RIFF":
+		rate = binary.LittleEndian.Uint32(b[24:28])
+		body = b[iqWavHeaderSize:]
+	default:
+		return nil, 0, fmt.Errorf("siglab: %s is neither a RIFF/WAVE nor a FLAC capture", path)
+	}
+	out := make([]complex64, len(body)/iqWavBlockAlign)
+	decodeSW16(body[:len(out)*iqWavBlockAlign], out)
+	return out, rate, nil
 }
-
-// writeIQWavHeader writes the 44-byte canonical two-channel 16-bit RIFF/WAVE
 // header (the length fields are patched on finalize). Same layout as
 // baseband.IQWriter, kept here so a wav dump's body is siglab's cs16 body.
 func writeIQWavHeader(w io.Writer, sampleRate uint32) error {

--- a/internal/siglab/container.go
+++ b/internal/siglab/container.go
@@ -218,6 +218,7 @@ func DecodeContainerFile(path string) ([]complex64, uint32, error) {
 	decodeSW16(body[:len(out)*iqWavBlockAlign], out)
 	return out, rate, nil
 }
+
 // header (the length fields are patched on finalize). Same layout as
 // baseband.IQWriter, kept here so a wav dump's body is siglab's cs16 body.
 func writeIQWavHeader(w io.Writer, sampleRate uint32) error {

--- a/internal/storage/retention.go
+++ b/internal/storage/retention.go
@@ -198,7 +198,7 @@ func (r *Retention) deleteOldFiles() (int, error) {
 
 func isRecordingArtifact(path string) bool {
 	switch strings.ToLower(filepath.Ext(path)) {
-	case ".wav", ".raw":
+	case ".wav", ".flac", ".raw":
 		return true
 	}
 	return false

--- a/internal/trunking/grant.go
+++ b/internal/trunking/grant.go
@@ -354,11 +354,12 @@ type CallEnd struct {
 func (c CallEnd) Duration() time.Duration { return c.EndedAt.Sub(c.StartedAt) }
 
 // CallComplete is the payload of an events.KindCallComplete event. The
-// recorder publishes it once a call's WAV has been flushed and closed,
-// so the outbound-streaming subsystem (internal/broadcast) can read the
-// finished file and upload it to call aggregators. AudioPath is the
-// absolute or working-directory-relative path to the .wav the recorder
-// wrote; SampleRate is its PCM rate in Hz.
+// recorder publishes it once a call's recording has been flushed and
+// closed, so the outbound-streaming subsystem (internal/broadcast) can
+// read the finished file and upload it to call aggregators. AudioPath is
+// the absolute or working-directory-relative path to the recording the
+// recorder wrote (.wav, or .flac under recordings.format: flac);
+// SampleRate is its PCM rate in Hz.
 type CallComplete struct {
 	Grant        Grant
 	Talkgroup    *TalkGroup

--- a/internal/voice/flac.go
+++ b/internal/voice/flac.go
@@ -1,0 +1,235 @@
+package voice
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/mewkiz/flac"
+	"github.com/mewkiz/flac/frame"
+	"github.com/mewkiz/flac/meta"
+)
+
+// flacVoiceBlockSize is the FLAC frame block size for voice recordings —
+// ~half a second at 8 kHz, the upstream encoder's conventional default.
+const flacVoiceBlockSize = 4096
+
+// FlacWriter writes 16-bit mono PCM to a lossless FLAC stream — the FLAC
+// twin of WavWriter with the same surface (WriteSamples / DataBytes / Close),
+// so the recorder can treat the two interchangeably. DataBytes reports the
+// UNCOMPRESSED PCM payload bytes (2 per sample), keeping the recorder's
+// duration math and empty-call checks format-independent; the on-disk file is
+// smaller. Close flushes the last partial block and finalizes the stream
+// (patching the STREAMINFO sample count + MD5 via a seek), so a daemon crash
+// before Close leaves a header with a zero sample count — still parseable by
+// players that stream frames, mirroring WavWriter's crash posture.
+type FlacWriter struct {
+	enc          *flac.Encoder
+	closed       bool
+	sampleRate   uint32
+	bytesWritten uint32 // PCM payload bytes (2 × samples), pre-compression
+	buf          []int32
+	closeFn      func() error
+}
+
+// NewFlacWriter wraps an io.WriteSeeker and starts the FLAC stream.
+func NewFlacWriter(w io.WriteSeeker, sampleRate uint32) (*FlacWriter, error) {
+	if sampleRate == 0 {
+		return nil, errors.New("voice: FLAC sample rate must be > 0")
+	}
+	info := &meta.StreamInfo{
+		SampleRate:    sampleRate,
+		NChannels:     1,
+		BitsPerSample: 16,
+	}
+	enc, err := flac.NewEncoder(voiceWriteSeekerNoCloser{w}, info)
+	if err != nil {
+		return nil, fmt.Errorf("voice: init flac encoder: %w", err)
+	}
+	// Analyse each block for the best fixed/LPC predictor so the stream is
+	// actually compressed rather than stored verbatim.
+	enc.EnablePredictionAnalysis(true)
+	return &FlacWriter{
+		enc:        enc,
+		sampleRate: sampleRate,
+		buf:        make([]int32, 0, flacVoiceBlockSize),
+	}, nil
+}
+
+// NewFlacFile opens path for write (creating or truncating) and returns a
+// FlacWriter that closes the file on Close().
+func NewFlacFile(path string, sampleRate uint32) (*FlacWriter, error) {
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, err
+	}
+	w, err := NewFlacWriter(f, sampleRate)
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+	w.closeFn = f.Close
+	return w, nil
+}
+
+// WriteSamples appends 16-bit PCM samples.
+func (w *FlacWriter) WriteSamples(samples []int16) error {
+	if w.closed {
+		return errors.New("voice: FLAC writer is closed")
+	}
+	for _, s := range samples {
+		w.buf = append(w.buf, int32(s))
+		if len(w.buf) >= flacVoiceBlockSize {
+			if err := w.flushBlock(); err != nil {
+				return err
+			}
+		}
+	}
+	w.bytesWritten += uint32(2 * len(samples))
+	return nil
+}
+
+// DataBytes returns the uncompressed PCM payload bytes written so far —
+// WavWriter-compatible, so callers' duration/empty math is unchanged. Stays
+// readable after Close.
+func (w *FlacWriter) DataBytes() uint32 { return w.bytesWritten }
+
+// Close flushes the pending block, finalizes the FLAC stream, and closes the
+// underlying file (if the writer owns one).
+func (w *FlacWriter) Close() error {
+	// Defensive nil-receiver no-op, mirroring WavWriter.Close.
+	if w == nil {
+		return nil
+	}
+	if w.closed {
+		return nil
+	}
+	w.closed = true
+	err := w.flushBlock()
+	if cerr := w.enc.Close(); err == nil && cerr != nil {
+		err = fmt.Errorf("voice: finalize flac: %w", cerr)
+	}
+	if w.closeFn != nil {
+		if cerr := w.closeFn(); err == nil {
+			err = cerr
+		}
+	}
+	return err
+}
+
+// flushBlock encodes the pending samples as one mono FLAC frame. Subframes
+// start verbatim; the encoder's prediction analysis upgrades them.
+func (w *FlacWriter) flushBlock() error {
+	n := len(w.buf)
+	if n == 0 {
+		return nil
+	}
+	hdr := frame.Header{
+		HasFixedBlockSize: true,
+		BlockSize:         uint16(n),
+		SampleRate:        w.sampleRate,
+		Channels:          frame.ChannelsMono,
+		BitsPerSample:     16,
+	}
+	// Copy the pending samples: WriteFrame mutates in place and the slice is
+	// reused for the next block.
+	samples := make([]int32, n)
+	copy(samples, w.buf)
+	fr := &frame.Frame{
+		Header: hdr,
+		Subframes: []*frame.Subframe{
+			{SubHeader: frame.SubHeader{Pred: frame.PredVerbatim}, Samples: samples, NSamples: n},
+		},
+	}
+	if err := w.enc.WriteFrame(fr); err != nil {
+		return fmt.Errorf("voice: encode flac frame: %w", err)
+	}
+	w.buf = w.buf[:0]
+	return nil
+}
+
+// voiceWriteSeekerNoCloser hides an underlying Close from the FLAC encoder so
+// enc.Close patches the STREAMINFO without closing the caller's file.
+type voiceWriteSeekerNoCloser struct{ ws io.WriteSeeker }
+
+func (w voiceWriteSeekerNoCloser) Write(p []byte) (int, error) { return w.ws.Write(p) }
+func (w voiceWriteSeekerNoCloser) Seek(offset int64, whence int) (int64, error) {
+	return w.ws.Seek(offset, whence)
+}
+
+// ReadFLACSamples reads a 16-bit mono FLAC recording written by FlacWriter
+// (or any mono 16-bit FLAC) and returns its samples and sample rate — the
+// FLAC counterpart of ReadWAVSamples, with the same mono/16-bit contract.
+func ReadFLACSamples(path string) (samples []int16, sampleRate uint32, err error) {
+	stream, err := flac.ParseFile(path)
+	if err != nil {
+		return nil, 0, fmt.Errorf("voice: open flac: %w", err)
+	}
+	defer stream.Close()
+	if stream.Info.NChannels != 1 || stream.Info.BitsPerSample != 16 {
+		return nil, 0, errors.New("voice: expected 16-bit mono FLAC")
+	}
+	sampleRate = stream.Info.SampleRate
+	for {
+		fr, ferr := stream.ParseNext()
+		if ferr != nil {
+			break // io.EOF, or a truncated tail (keep what decoded)
+		}
+		for _, s := range fr.Subframes[0].Samples {
+			samples = append(samples, int16(s))
+		}
+	}
+	return samples, sampleRate, nil
+}
+
+// ReadAudioSamples reads a voice recording (WAV or FLAC, sniffed from the
+// file content rather than the extension) into 16-bit mono samples plus the
+// sample rate — the format-agnostic entry every downstream consumer of a
+// recording (normalization, MP3 transcode) should use.
+func ReadAudioSamples(path string) ([]int16, uint32, error) {
+	if isFLACAudioFile(path) {
+		return ReadFLACSamples(path)
+	}
+	return ReadWAVSamples(path)
+}
+
+// isFLACAudioFile sniffs the 4-byte "fLaC" stream marker.
+func isFLACAudioFile(path string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	var magic [4]byte
+	if _, err := io.ReadFull(f, magic[:]); err != nil {
+		return false
+	}
+	return string(magic[:]) == "fLaC"
+}
+
+// AudioFormatExt returns the recording filename extension (with dot) for a
+// recordings format value ("" and "wav" → ".wav", "flac" → ".flac").
+func AudioFormatExt(format string) string {
+	if format == "flac" {
+		return ".flac"
+	}
+	return ".wav"
+}
+
+// NewAudioFileWriter opens a voice recording at path in the given format —
+// the recorder's single dispatch point between WavWriter and FlacWriter.
+func NewAudioFileWriter(path string, sampleRate uint32, format string) (AudioFileWriter, error) {
+	if format == "flac" {
+		return NewFlacFile(path, sampleRate)
+	}
+	return NewWavFile(path, sampleRate)
+}
+
+// AudioFileWriter is the per-call recording writer contract WavWriter and
+// FlacWriter share.
+type AudioFileWriter interface {
+	WriteSamples(samples []int16) error
+	DataBytes() uint32
+	Close() error
+}

--- a/internal/voice/flac_test.go
+++ b/internal/voice/flac_test.go
@@ -1,0 +1,258 @@
+package voice
+
+import (
+	"context"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// speechLikeSamples builds a deterministic multi-tone signal at the given
+// amplitude — long enough to span multiple FLAC blocks and loud enough for
+// the loudness meter to measure.
+func speechLikeSamples(n int, amp float64) []int16 {
+	out := make([]int16, n)
+	for i := range out {
+		v := amp * (0.6*math.Sin(2*math.Pi*300*float64(i)/8000) +
+			0.4*math.Sin(2*math.Pi*1100*float64(i)/8000))
+		out[i] = int16(math.Round(v * 32767))
+	}
+	return out
+}
+
+// TestFlacWriterRoundTrip pins the mono voice FLAC path: WriteSamples →
+// Close → ReadFLACSamples must return bit-identical PCM at the header rate,
+// with DataBytes reporting the uncompressed payload like WavWriter does.
+func TestFlacWriterRoundTrip(t *testing.T) {
+	samples := speechLikeSamples(10_000, 0.4) // > 2 blocks of 4096
+	path := filepath.Join(t.TempDir(), "call.flac")
+	w, err := NewFlacFile(path, 8000)
+	if err != nil {
+		t.Fatalf("NewFlacFile: %v", err)
+	}
+	// Two writes to exercise the block boundary carry.
+	if err := w.WriteSamples(samples[:3000]); err != nil {
+		t.Fatalf("WriteSamples: %v", err)
+	}
+	if err := w.WriteSamples(samples[3000:]); err != nil {
+		t.Fatalf("WriteSamples: %v", err)
+	}
+	if got, want := w.DataBytes(), uint32(2*len(samples)); got != want {
+		t.Errorf("DataBytes = %d, want %d", got, want)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if got := w.DataBytes(); got != uint32(2*len(samples)) {
+		t.Errorf("DataBytes after Close = %d, want %d", got, 2*len(samples))
+	}
+
+	got, rate, err := ReadFLACSamples(path)
+	if err != nil {
+		t.Fatalf("ReadFLACSamples: %v", err)
+	}
+	if rate != 8000 {
+		t.Errorf("rate = %d, want 8000", rate)
+	}
+	if len(got) != len(samples) {
+		t.Fatalf("decoded %d samples, want %d", len(got), len(samples))
+	}
+	for i := range samples {
+		if got[i] != samples[i] {
+			t.Fatalf("sample %d = %d, want %d", i, got[i], samples[i])
+		}
+	}
+
+	// A speech-band signal must actually compress vs the WAV equivalent.
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Size() >= int64(44+2*len(samples)) {
+		t.Errorf("flac size %d is not smaller than the %d-byte wav equivalent", fi.Size(), 44+2*len(samples))
+	}
+}
+
+// TestReadAudioSamplesSniffsContainer proves the format-agnostic reader picks
+// the decoder from the file content, not the extension.
+func TestReadAudioSamplesSniffsContainer(t *testing.T) {
+	dir := t.TempDir()
+	samples := speechLikeSamples(4000, 0.3)
+
+	// A flac body under a lying .wav name still decodes as flac.
+	lyingPath := filepath.Join(dir, "call.wav")
+	fw, err := NewFlacFile(lyingPath, 8000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := fw.WriteSamples(samples); err != nil {
+		t.Fatal(err)
+	}
+	if err := fw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	got, rate, err := ReadAudioSamples(lyingPath)
+	if err != nil {
+		t.Fatalf("ReadAudioSamples(flac body): %v", err)
+	}
+	if rate != 8000 || len(got) != len(samples) {
+		t.Fatalf("flac body: %d samples @ %d Hz, want %d @ 8000", len(got), rate, len(samples))
+	}
+
+	wavPath := filepath.Join(dir, "call2.wav")
+	ww, err := NewWavFile(wavPath, 8000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ww.WriteSamples(samples); err != nil {
+		t.Fatal(err)
+	}
+	if err := ww.Close(); err != nil {
+		t.Fatal(err)
+	}
+	got, rate, err = ReadAudioSamples(wavPath)
+	if err != nil {
+		t.Fatalf("ReadAudioSamples(wav): %v", err)
+	}
+	if rate != 8000 || len(got) != len(samples) {
+		t.Fatalf("wav: %d samples @ %d Hz, want %d @ 8000", len(got), rate, len(samples))
+	}
+}
+
+// TestNormalizeFLACFileInPlace pins normalization on a flac recording: the
+// quiet call is boosted and rewritten in place AS FLAC (content-sniffed), so
+// recordings.format: flac keeps the whole normalize → web-playback chain
+// intact.
+func TestNormalizeFLACFileInPlace(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "quiet.flac")
+	w, err := NewFlacFile(path, 8000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	orig := speechLikeSamples(3*8000, 0.05) // quiet: needs boost
+	if err := w.WriteSamples(orig); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := NormalizeWAVFile(path, NormalizeConfig{Enabled: true}); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if !isFLACAudioFile(path) {
+		t.Fatal("normalized file is no longer FLAC — the rewrite changed container")
+	}
+	got, rate, err := ReadFLACSamples(path)
+	if err != nil {
+		t.Fatalf("re-read: %v", err)
+	}
+	if rate != 8000 || len(got) != len(orig) {
+		t.Fatalf("normalized: %d samples @ %d Hz, want %d @ 8000", len(got), rate, len(orig))
+	}
+	// The boost must have actually been applied.
+	var origPeak, gotPeak int16
+	for i := range orig {
+		if orig[i] > origPeak {
+			origPeak = orig[i]
+		}
+		if got[i] > gotPeak {
+			gotPeak = got[i]
+		}
+	}
+	if gotPeak <= origPeak {
+		t.Errorf("peak after normalize = %d, want > %d (gain applied)", gotPeak, origPeak)
+	}
+}
+
+// TestRecorderWritesPerCallFLAC is the recorder end-to-end pin for
+// recordings.format: flac — the per-call file lands with a .flac extension,
+// is a real FLAC stream, and decodes to the written PCM.
+func TestRecorderWritesPerCallFLAC(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	dir := t.TempDir()
+	r, err := NewRecorder(RecorderOptions{
+		Bus:        bus,
+		OutDir:     dir,
+		Format:     "flac",
+		SampleRate: 8000,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go r.Run(ctx)
+
+	cs := trunking.CallStart{
+		Grant: trunking.Grant{
+			System:   "TestSystem",
+			Protocol: "p25",
+			GroupID:  1234,
+			SourceID: 56789,
+		},
+		Talkgroup:    &trunking.TalkGroup{ID: 1234, AlphaTag: "FIRE-DISP", Record: true},
+		DeviceSerial: "VOICE-1",
+		StartedAt:    time.Date(2026, 5, 5, 12, 30, 45, 0, time.UTC),
+	}
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: cs})
+
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if r.HasSession("VOICE-1") {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	pcm := speechLikeSamples(1600, 0.3)
+	if err := r.WritePCM("VOICE-1", pcm); err != nil {
+		t.Fatal(err)
+	}
+
+	end := trunking.CallEnd{
+		Grant:        cs.Grant,
+		Talkgroup:    cs.Talkgroup,
+		DeviceSerial: "VOICE-1",
+		StartedAt:    cs.StartedAt,
+		EndedAt:      cs.StartedAt.Add(2 * time.Second),
+		Reason:       trunking.EndReasonNormal,
+	}
+	bus.Publish(events.Event{Kind: events.KindCallEnd, Payload: end})
+
+	deadline = time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if !r.HasSession("VOICE-1") {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	want := filepath.Join(dir, "TestSystem", "FIRE-DISP", "20260505_123045_1234.flac")
+	if _, err := os.Stat(want); err != nil {
+		t.Fatalf("expected flac at %s: %v", want, err)
+	}
+	got, rate, err := ReadFLACSamples(want)
+	if err != nil {
+		t.Fatalf("decode recording: %v", err)
+	}
+	if rate != 8000 {
+		t.Errorf("recording rate = %d, want 8000", rate)
+	}
+	if len(got) != len(pcm) {
+		t.Fatalf("recording holds %d samples, want %d", len(got), len(pcm))
+	}
+	for i := range pcm {
+		if got[i] != pcm[i] {
+			t.Fatalf("sample %d = %d, want %d", i, got[i], pcm[i])
+		}
+	}
+}

--- a/internal/voice/normalize.go
+++ b/internal/voice/normalize.go
@@ -63,7 +63,10 @@ func NormalizeWAVFile(path string, cfg NormalizeConfig) error {
 // quiet to measure (IntegratedLUFS reports !ok) — there is nothing
 // meaningful to normalize. cfg is assumed to already carry defaults.
 func normalizeWAVFile(path string, cfg NormalizeConfig) error {
-	samples, sampleRate, err := ReadWAVSamples(path)
+	// Content-sniffed read + same-container rewrite, so a flac recording is
+	// normalized in place as flac.
+	isFLAC := isFLACAudioFile(path)
+	samples, sampleRate, err := ReadAudioSamples(path)
 	if err != nil {
 		return fmt.Errorf("voice/normalize: read %s: %w", path, err)
 	}
@@ -88,6 +91,9 @@ func normalizeWAVFile(path string, cfg NormalizeConfig) error {
 		samples[i] = clampInt16(v * gain * 32768.0)
 	}
 
+	if isFLAC {
+		return rewriteAudio(path, samples, sampleRate, "flac")
+	}
 	return rewriteWAV(path, samples, sampleRate)
 }
 
@@ -107,8 +113,13 @@ func clampInt16(v float64) int16 {
 // renames it over the original, so a crash mid-write can't truncate the
 // recording.
 func rewriteWAV(path string, samples []int16, sampleRate uint32) error {
+	return rewriteAudio(path, samples, sampleRate, "wav")
+}
+
+// rewriteAudio is rewriteWAV generalized over the recording container.
+func rewriteAudio(path string, samples []int16, sampleRate uint32, format string) error {
 	tmp := path + ".tmp"
-	w, err := NewWavFile(tmp, sampleRate)
+	w, err := NewAudioFileWriter(tmp, sampleRate, format)
 	if err != nil {
 		return fmt.Errorf("voice/normalize: create temp: %w", err)
 	}

--- a/internal/voice/recorder.go
+++ b/internal/voice/recorder.go
@@ -95,6 +95,7 @@ type Recorder struct {
 	bus                *events.Bus
 	log                *slog.Logger
 	outDir             string
+	format             string // recording container: "" / "wav", or "flac"
 	sampleRate         uint32
 	writeRaw           bool
 	writeMBE           bool
@@ -293,7 +294,12 @@ type RecorderOptions struct {
 	Log        *slog.Logger
 	OutDir     string
 	SampleRate uint32 // 8000 typical
-	WriteRaw   bool   // emit a .raw sidecar alongside each .wav
+	// Format selects the recording container: "wav" (default — 16-bit mono
+	// PCM RIFF/WAVE) or "flac" (lossless FLAC, typically half the size of
+	// speech WAV; browsers play it natively). Everything downstream —
+	// normalization, MP3 transcode for uploads, web playback — reads either.
+	Format   string
+	WriteRaw bool // emit a .raw sidecar alongside each recording
 	// WriteMBE emits a dsd-fme-playable MBE sidecar next to each recording
 	// for protocols dsd-fme can play offline: <basename>.imb for P25 Phase 1
 	// IMBE, <basename>.amb for DMR / NXDN / P25 Phase 2 AMBE+2. The file is
@@ -463,6 +469,7 @@ func NewRecorder(opts RecorderOptions) (*Recorder, error) {
 		bus:                opts.Bus,
 		log:                opts.Log,
 		outDir:             opts.OutDir,
+		format:             opts.Format,
 		sampleRate:         opts.SampleRate,
 		writeRaw:           opts.WriteRaw,
 		writeMBE:           opts.WriteMBE,
@@ -1110,7 +1117,7 @@ func (r *Recorder) buildSession(cs trunking.CallStart, startedAt time.Time) *rec
 				"recordings_sample_rate", r.sampleRate)
 		}
 	}
-	s.wavPath = filepath.Join(dir, base+".wav")
+	s.wavPath = filepath.Join(dir, base+r.audioExt())
 	// ProVoice and DMR voice grants always get a sidecar — neither has
 	// an in-process vocoder, so the .raw file is the only capture of
 	// the call.
@@ -1152,9 +1159,9 @@ func (r *Recorder) openSessionFiles(s *recordingSession) error {
 			return err
 		}
 	}
-	wav, err := NewWavFile(s.wavPath, s.sampleRate)
+	wav, err := NewAudioFileWriter(s.wavPath, s.sampleRate, r.format)
 	if err != nil {
-		r.log.Error("recorder: open wav", "path", s.wavPath, "err", err)
+		r.log.Error("recorder: open recording", "path", s.wavPath, "err", err)
 		if s.vocoder != nil {
 			_ = s.vocoder.Close()
 			s.vocoder = nil
@@ -1763,12 +1770,16 @@ func (r *Recorder) basenameFor(cs trunking.CallStart) string {
 func (r *Recorder) ensureUniqueBase(dir, base string) string {
 	candidate := base
 	for n := 2; ; n++ {
-		if !r.wavPathClaimed(filepath.Join(dir, candidate+".wav")) {
+		if !r.wavPathClaimed(filepath.Join(dir, candidate+r.audioExt())) {
 			return candidate
 		}
 		candidate = fmt.Sprintf("%s-%d", base, n)
 	}
 }
+
+// audioExt is the recording filename extension (with dot) for the configured
+// recordings format: ".wav" by default, ".flac" for flac.
+func (r *Recorder) audioExt() string { return AudioFormatExt(r.format) }
 
 // wavPathClaimed reports whether a WAV path already exists on disk or is held by
 // an active recording session.
@@ -1826,7 +1837,10 @@ func sanitize(s string) string {
 }
 
 type recordingSession struct {
-	wav         *WavWriter
+	// wav is the per-call audio writer (a WavWriter, or a FlacWriter when
+	// recordings.format is flac); wavPath keeps its historical name but
+	// carries the format's extension.
+	wav         AudioFileWriter
 	wavPath     string
 	raw         *os.File
 	rawPath     string

--- a/web/src/components/RecordingPlayer.tsx
+++ b/web/src/components/RecordingPlayer.tsx
@@ -21,7 +21,7 @@ export function RecordingPlayer({
   callId: number;
 }) {
   const [objURL, setObjURL] = useState<string | null>(null);
-  const [ext, setExt] = useState<"wav" | "mp3">("wav");
+  const [ext, setExt] = useState<"wav" | "mp3" | "flac">("wav");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   // Track the current object URL so the cleanup revokes exactly what is live,
@@ -65,7 +65,16 @@ export function RecordingPlayer({
         if (cancelled) return;
         const url = URL.createObjectURL(blob);
         urlRef.current = url;
-        setExt(blob.type === "audio/mpeg" ? "mp3" : "wav");
+        // The download name follows the served Content-Type (the daemon sends
+        // audio/flac for recordings.format: flac), so a FLAC recording is not
+        // saved under a lying .wav name.
+        setExt(
+          blob.type === "audio/mpeg"
+            ? "mp3"
+            : blob.type === "audio/flac"
+              ? "flac"
+              : "wav",
+        );
         setObjURL(url);
         setLoading(false);
       })


### PR DESCRIPTION
One shared stereo FLAC encode core (baseband.FLACIQEncoder; siglab.IQContainer
now delegates to it) plus a mono voice twin (voice.FlacWriter), wired through
every recorder that has a container at all:

- `capture -format wav|flac` and the API staged capture now route through
  siglab.IQContainer. Both used to accept the formats and silently write a
  mislabeled body (wav: headerless sw16 under a RIFF label; flac: the
  streaming encoder fell through to u8 with 4 bytes/sample — neither FLAC nor
  decodable). gen and the siglab synth endpoint reject container formats at
  the boundary instead of inheriting the same fallthrough.
- baseband.record[].format: wav|flac covers both taps (wideband recorder and
  the ccdecoder DDC tap), and the replay FileDriver mounts .flac recordings
  back as virtual tuners, sniffing the fLaC marker rather than the extension.
- recordings.format: wav|flac switches per-call voice recordings. The whole
  downstream chain reads either container via content sniffing
  (voice.ReadAudioSamples): loudness normalization rewrites flac-in/flac-out,
  the broadcast MP3 transcode, the /calls/{id}/audio handler (audio/flac +
  .flac allowlisted), the retention sweeper, and the web RecordingPlayer's
  download name. FlacWriter.DataBytes() reports uncompressed PCM bytes so the
  recorder's duration and dead-key math stay container-independent.

Deliberately not converted: diversity_capture stays cs16 (branch-alignment
invariant + offline harness), hunt -survey-capture stays f32.

Pinned by round-trip and failing-first regressions: capture container tests
(fail against the old u8 fallthrough), FLAC FileDriver replay, DDC .flac
roll, voice FLAC round-trip/normalize-in-place/recorder end-to-end, and the
config format validations.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NRL2MUTx9eZfiy2oAGgbXR