### PR TITLE
Fix discovered-talkgroup mode labeling + corroborated capture ppm probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ for tagged releases.
 ## [Unreleased]
 
 ### Fixed
+- **Talkgroups auto-discovered on analog trunking systems are no longer
+  labeled mode "D" (digital)** (#1143 follow-up). Discovered-talkgroup mode
+  now follows the system's protocol: SmartNet/SmartZone, LTR, MPT-1327 and
+  non-ProVoice EDACS talkgroups are stamped "A" (analog), digital protocols
+  stay "D". Display/CSV metadata only — decode and recording are unaffected.
+- **`capture` no longer turns a transient carrier into a confident wrong ppm
+  warning, and now doubles as a ppm-measurement instrument** (#1143's bogus
+  "≈550.3 ppm" warning; #836). The carrier-offset probe used to FFT only the
+  first ~11 ms of the recording — exactly where front-end settling and
+  momentarily-keyed neighbours live. It now spreads eight probe windows
+  across the whole capture and reports an offset only when windows
+  corroborate each other (a real tuner error is constant for the entire
+  file). A corroborated offset is always printed as a `measured carrier
+  offset` line — even below the warning threshold — so capturing any strong
+  known-frequency carrier measures the dongle's ppm error where
+  kalibrate-rtl no longer works (regions without GSM towers). `capture` also
+  honours a backend's actual (quantized) sample rate in the recording,
+  metadata sidecar, and offset math.
 - **Motorola Type II / SmartNet / SmartZone control channels can now actually
   decode off the air** (#1143). The previous framing (24-bit sync, 32-bit OSW,
   BCH(64,16,11)) was spec-guessed, matched no real signal, and only decoded its

--- a/cmd/gophertrunk/capture.go
+++ b/cmd/gophertrunk/capture.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"os/signal"
 	"strings"
@@ -125,6 +126,14 @@ FLAGS:`)
 	if err := dev.SetSampleRate(uint32(*sampleRate)); err != nil {
 		rep.Fatal(1, fmt.Errorf("set sample rate: %w", err))
 	}
+	// Some backends quantize the requested rate to what the hardware can do.
+	// Record (and sidecar-stamp) the ACTUAL delivered rate, mirroring the
+	// daemon's effectiveStreamRate — a capture labeled with the wrong rate
+	// replays with a shifted symbol clock and every offset/ppm figure is off.
+	hwRate, rateNote := captureEffectiveRate(dev, uint32(*sampleRate))
+	if rateNote != "" {
+		fmt.Fprintln(os.Stderr, rateNote)
+	}
 	if err := dev.SetCenterFreq(uint32(*freq)); err != nil {
 		rep.Fatal(1, fmt.Errorf("set centre frequency: %w", err))
 	}
@@ -158,9 +167,9 @@ FLAGS:`)
 	}
 
 	fmt.Printf("capture: %s[%s] @ %d Hz, %g MS/s → %s for %gs…\n",
-		info.Driver, info.Serial, *freq, float64(*sampleRate)/1e6, *out, *seconds)
+		info.Driver, info.Serial, *freq, float64(hwRate)/1e6, *out, *seconds)
 
-	if hint := captureSampleRateHint(uint32(*sampleRate), *protocol); hint != "" {
+	if hint := captureSampleRateHint(hwRate, *protocol); hint != "" {
 		fmt.Fprintln(os.Stderr, hint)
 	}
 
@@ -168,7 +177,7 @@ FLAGS:`)
 	// -center ± -bandwidth without retuning the SDR (the same DDC the daemon and
 	// replay path use). The recorded rate + centre become the channel's.
 	var ddc *ccdecoder.Downconverter
-	recRate := float64(*sampleRate)
+	recRate := float64(hwRate)
 	recCenter := uint32(*freq)
 	if *bandwidthHz > 0 && *decimate > 1 {
 		rep.Fatalf(2, "-bandwidth and -decimate are mutually exclusive (both decimate; pick one)")
@@ -177,7 +186,7 @@ FLAGS:`)
 		// Full-band integer decimation: keep the whole captured span, just at
 		// a lower rate. Same down-converter as the -bandwidth slice, targeted
 		// at sample-rate/decimate with no tuning offset (centre stays -freq).
-		ddc = ccdecoder.NewDownconverter(float64(*sampleRate), float64(*sampleRate)/float64(*decimate))
+		ddc = ccdecoder.NewDownconverter(float64(hwRate), float64(hwRate)/float64(*decimate))
 		recRate = ddc.OutRateHz()
 		fmt.Printf("capture: software decimation ×%d → %.1f kHz effective rate\n",
 			*decimate, recRate/1e3)
@@ -187,26 +196,36 @@ FLAGS:`)
 			center = uint32(*freq)
 		}
 		offsetHz := int64(center) - int64(*freq)
-		half := int64(*sampleRate) / 2
+		half := int64(hwRate) / 2
 		if absInt64(offsetHz)+int64(*bandwidthHz)/2 > half {
 			rep.Fatalf(2, "-center %d + -bandwidth %d falls outside the captured span %d ± %d Hz",
 				center, *bandwidthHz, *freq, half)
 		}
-		ddc = ccdecoder.NewDownconverterWithOffset(float64(*sampleRate), float64(*bandwidthHz), float64(offsetHz))
+		ddc = ccdecoder.NewDownconverterWithOffset(float64(hwRate), float64(*bandwidthHz), float64(offsetHz))
 		recRate = ddc.OutRateHz()
 		recCenter = center
 		fmt.Printf("capture: narrowband slice → centre %.3f MHz, %.1f kHz channel rate\n",
 			float64(recCenter)/1e6, recRate/1e3)
 	}
 
-	written, probe, capErr := captureToFile(ctx, *out, sampleFormat, stream, uint32(*sampleRate), *seconds, ddc)
+	written, probe, capErr := captureToFile(ctx, *out, sampleFormat, stream, hwRate, *seconds, ddc)
 	if capErr != nil && !errors.Is(capErr, context.Canceled) {
 		rep.Fatal(1, fmt.Errorf("capture: %w (wrote %d samples to %s)", capErr, written, *out))
 	}
-	// Warn if a ppm error has pulled the recorded carrier off centre — the
-	// other half of the "capture won't lock" story alongside dropped chunks.
-	if w := carrierOffsetWarning(probe, recRate, recCenter); w != "" {
-		fmt.Fprintln(os.Stderr, w)
+	// Report the measured carrier offset (a ppm-measurement instrument in its
+	// own right — issue #836), and warn if a corroborated offset is large
+	// enough to prevent decode — the other half of the "capture won't lock"
+	// story alongside dropped chunks. A carrier seen in only one probe window
+	// is called out as transient instead of reported as a tuner error (#1143).
+	consensus := carrierOffsetConsensus(probe, recRate)
+	if m := carrierOffsetMeasurement(consensus, recCenter); m != "" {
+		fmt.Println(m)
+	}
+	if note := carrierOffsetInconclusiveNote(consensus); note != "" {
+		fmt.Fprintln(os.Stderr, note)
+	}
+	if consensus.OK && math.Abs(consensus.OffsetHz) >= carrierOffsetWarnHz {
+		fmt.Fprintln(os.Stderr, formatCarrierOffsetWarning(consensus.OffsetHz, offsetPPM(consensus.OffsetHz, recCenter)))
 	}
 	if d := drops.count(); d > 0 {
 		// Loud + actionable: a dropped-chunk capture looks fine on disk but
@@ -277,6 +296,25 @@ FLAGS:`)
 	}
 }
 
+// captureEffectiveRate returns the sample rate the device will actually
+// deliver, via the optional ActualSampleRate() extension (backends that model
+// hardware rate quantization), plus an operator-facing note when it differs
+// from the request. Backends without the extension deliver exactly the
+// configured rate. The capture command never checked this, so a quantizing
+// backend produced a file (and metadata sidecar) labeled with the wrong rate.
+func captureEffectiveRate(dev sdr.Device, requested uint32) (uint32, string) {
+	ar, ok := dev.(interface{ ActualSampleRate() (uint32, error) })
+	if !ok {
+		return requested, ""
+	}
+	actual, err := ar.ActualSampleRate()
+	if err != nil || actual == 0 || actual == requested {
+		return requested, ""
+	}
+	return actual, fmt.Sprintf("capture: note — the SDR quantized the sample rate to %d Hz (requested %d); "+
+		"the recording and its metadata sidecar use the actual hardware rate.", actual, requested)
+}
+
 // openCaptureDevice enumerates the registered drivers and opens the device
 // matching serial (or the sole device when serial is empty). Returns the open
 // handle plus the chosen Info so the caller can report what it grabbed.
@@ -337,10 +375,10 @@ const captureBufWriter = 1 << 20 // 1 MiB
 // INPUT samples, the stream ends, ctx cancels, or a wall-clock safety deadline
 // elapses. Returns the number of IQ samples written (post-decimation when ddc
 // is set).
-// captureToFile returns the samples written plus the first captureProbeSamples
-// of recorded (post-DDC) IQ, which the caller FFTs for the carrier-offset
-// warning.
-func captureToFile(ctx context.Context, path string, format siglab.SampleFormat, src <-chan []complex64, rate uint32, seconds float64, ddc *ccdecoder.Downconverter) (int64, []complex64, error) {
+// captureToFile returns the samples written plus the recorded (post-DDC)
+// carrier-probe windows spread across the capture, which the caller FFTs for
+// the carrier-offset consensus estimate.
+func captureToFile(ctx context.Context, path string, format siglab.SampleFormat, src <-chan []complex64, rate uint32, seconds float64, ddc *ccdecoder.Downconverter) (int64, [][]complex64, error) {
 	// Container formats need a header up front and a finalize step, so they
 	// take the IQContainer path; the headerless formats keep the historical
 	// byte-stream path below.
@@ -369,7 +407,7 @@ func captureToFile(ctx context.Context, path string, format siglab.SampleFormat,
 // and the finalize step (RIFF length patch / FLAC STREAMINFO), so a
 // `capture -format wav|flac` file is a real container rather than a
 // mislabeled headerless body.
-func captureContainerToFile(ctx context.Context, path string, format siglab.SampleFormat, src <-chan []complex64, rate uint32, seconds float64, ddc *ccdecoder.Downconverter) (int64, []complex64, error) {
+func captureContainerToFile(ctx context.Context, path string, format siglab.SampleFormat, src <-chan []complex64, rate uint32, seconds float64, ddc *ccdecoder.Downconverter) (int64, [][]complex64, error) {
 	// The container header carries the ON-DISK rate: the decimated slice rate
 	// when a -bandwidth/-decimate DDC is set, the full input rate otherwise.
 	diskRate := rate
@@ -406,7 +444,7 @@ func captureContainerToFile(ctx context.Context, path string, format siglab.Samp
 // Decoupling keeps the drain running so a transient stall costs latency, not
 // samples. The stateful DDC stays on the drain goroutine (it must run in
 // order); only copied sample chunks cross to the writer, which encodes them.
-func captureStream(ctx context.Context, w io.Writer, format siglab.SampleFormat, src <-chan []complex64, rate uint32, seconds float64, ddc *ccdecoder.Downconverter) (int64, []complex64, error) {
+func captureStream(ctx context.Context, w io.Writer, format siglab.SampleFormat, src <-chan []complex64, rate uint32, seconds float64, ddc *ccdecoder.Downconverter) (int64, [][]complex64, error) {
 	return captureStreamSink(ctx, func(samples []complex64) error {
 		_, err := w.Write(siglab.EncodeCapture(samples, format))
 		return err
@@ -417,12 +455,20 @@ func captureStream(ctx context.Context, w io.Writer, format siglab.SampleFormat,
 // container path: the writer goroutine consumes copied sample chunks and
 // hands them to sink (a byte encoder + io.Writer, or an IQContainer), so a
 // stalled sink costs latency, never samples.
-func captureStreamSink(ctx context.Context, sink func([]complex64) error, src <-chan []complex64, rate uint32, seconds float64, ddc *ccdecoder.Downconverter) (int64, []complex64, error) {
-	probe := make([]complex64, 0, captureProbeSamples)
-
+func captureStreamSink(ctx context.Context, sink func([]complex64) error, src <-chan []complex64, rate uint32, seconds float64, ddc *ccdecoder.Downconverter) (int64, [][]complex64, error) {
 	// Stop once seconds worth of INPUT samples have been read; the written
 	// count may be far smaller when ddc decimates to a narrow channel.
 	target := int64(seconds * float64(rate))
+
+	// Carrier-probe windows are spread across the whole expected recording,
+	// not just its first milliseconds — a real ppm offset persists for the
+	// entire file, and one startup window is where settling transients and
+	// momentarily-keyed neighbours live (#1143's false 550 ppm warning).
+	expected := target
+	if ddc != nil && rate > 0 {
+		expected = int64(float64(target) * ddc.OutRateHz() / float64(rate))
+	}
+	probe := newCarrierProbe(expected)
 	// Safety deadline so a stalled/under-delivering device doesn't hang the
 	// command forever waiting to reach the sample target. The timer is an
 	// explicit select arm (not a post-receive check) so a source that never
@@ -478,16 +524,10 @@ loop:
 			if len(samples) == 0 {
 				continue
 			}
-			// Collect the first window of recorded samples for the caller's
-			// carrier-offset probe (append copies, so it's safe against the
-			// reused ddcBuf / the src-owned chunk).
-			if len(probe) < captureProbeSamples {
-				take := samples
-				if n := captureProbeSamples - len(probe); len(take) > n {
-					take = take[:n]
-				}
-				probe = append(probe, take...)
-			}
+			// Collect recorded samples into the spread probe windows for the
+			// caller's carrier-offset consensus (append copies, so it's safe
+			// against the reused ddcBuf / the src-owned chunk).
+			probe.feed(samples)
 			// Fresh buffer per chunk: it is handed to the writer goroutine, so
 			// it must not alias the reused ddcBuf or the src-owned chunk.
 			// Encoding happens on the writer goroutine (sink), keeping the
@@ -517,7 +557,7 @@ loop:
 		default:
 		}
 	}
-	return written, probe, loopErr
+	return written, probe.Windows(), loopErr
 }
 
 // captureDropCounter counts SDR IQ-chunk drops for one device during a

--- a/cmd/gophertrunk/capture_carrier.go
+++ b/cmd/gophertrunk/capture_carrier.go
@@ -3,15 +3,163 @@ package main
 import (
 	"fmt"
 	"math"
+	"sort"
 
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/fft"
 )
 
-// captureProbeSamples is how many recorded (post-DDC) IQ samples the capture
-// collects for the carrier-offset probe. A power-of-two window keeps the FFT
+// captureProbeSamples is how many recorded (post-DDC) IQ samples each
+// carrier-offset probe window holds. A power-of-two window keeps the FFT
 // cheap; 32768 bins give sub-100 Hz resolution even at multi-MS/s rates and a
 // fraction of a second at a narrowband slice rate.
 const captureProbeSamples = 1 << 15
+
+// captureProbeWindows is how many probe windows the capture spreads across the
+// whole recording. One window at the very start of the stream (the original
+// design) is exactly where front-end settling lives, and 11 ms at 3 MS/s is
+// short enough for a momentarily-keyed carrier elsewhere in the span to win
+// the probe — the #1143 "≈550.3 ppm" false warning. A real tuner ppm error is
+// constant for the whole file, so requiring the same offset across windows
+// spread over the capture separates it from transients.
+const captureProbeWindows = 8
+
+// carrierConsensusToleranceHz is how closely per-window offset estimates must
+// agree to count as the same carrier. Window resolution is sub-100 Hz; the
+// smoothing hump centre wobbles by a fraction of the channel width between
+// windows, so 1 kHz is generous for "same channel" while safely separating
+// 25 kHz-spaced neighbours.
+const carrierConsensusToleranceHz = 1000.0
+
+// carrierProbe collects captureProbeWindows disjoint windows of recorded
+// (post-DDC) IQ, spread evenly across the expected length of the capture, for
+// the carrier-offset consensus estimate. Feed sees the recorded stream in
+// order; expected is the anticipated total recorded sample count (a capture
+// cut short by Ctrl-C simply leaves later windows empty, and a too-short
+// capture degenerates to a single window at the start — the old behaviour).
+type carrierProbe struct {
+	starts  []int64
+	windows [][]complex64
+	pos     int64
+}
+
+func newCarrierProbe(expected int64) *carrierProbe {
+	k := int64(captureProbeWindows)
+	if maxK := expected / captureProbeSamples; maxK < k {
+		k = maxK
+	}
+	if k < 1 {
+		k = 1
+	}
+	stride := int64(captureProbeSamples)
+	if k > 1 {
+		stride = expected / k
+	}
+	p := &carrierProbe{}
+	for i := int64(0); i < k; i++ {
+		p.starts = append(p.starts, i*stride)
+		p.windows = append(p.windows, make([]complex64, 0, captureProbeSamples))
+	}
+	return p
+}
+
+// feed appends the overlap of this (in-order, contiguous) recorded chunk with
+// each still-unfilled probe window.
+func (p *carrierProbe) feed(samples []complex64) {
+	base := p.pos
+	p.pos += int64(len(samples))
+	for i, start := range p.starts {
+		w := p.windows[i]
+		if len(w) >= captureProbeSamples {
+			continue
+		}
+		lo := start + int64(len(w)) // next absolute index this window needs
+		hi := start + captureProbeSamples
+		s, e := lo-base, hi-base
+		if s < 0 {
+			s = 0
+		}
+		if e > int64(len(samples)) {
+			e = int64(len(samples))
+		}
+		if s < e {
+			p.windows[i] = append(w, samples[s:e]...)
+		}
+	}
+}
+
+// Windows returns the collected probe windows, dropping any too short to
+// estimate from (an early-terminated capture leaves trailing windows empty).
+func (p *carrierProbe) Windows() [][]complex64 {
+	if p == nil {
+		return nil
+	}
+	out := make([][]complex64, 0, len(p.windows))
+	for _, w := range p.windows {
+		if len(w) >= 1024 {
+			out = append(out, w)
+		}
+	}
+	return out
+}
+
+// carrierConsensus is the result of the multi-window carrier-offset estimate.
+type carrierConsensus struct {
+	OffsetHz float64
+	MaxAbsHz float64 // largest |estimate| any single window produced
+	Agree    int     // windows agreeing with the median estimate
+	Est      int     // windows that produced any estimate
+	Usable   int     // windows long enough to probe
+	OK       bool    // a consensus offset was reached
+}
+
+// carrierOffsetConsensus runs the single-window estimator over every probe
+// window and accepts an offset only when the estimates corroborate each
+// other: the transient that fooled the old first-11-ms probe (#1143) lights
+// one window; a real ppm error lights every window the signal is up in. With
+// a single usable window (a short capture) the lone estimate stands, as
+// before. With several, at least two must agree within
+// carrierConsensusToleranceHz of their median, and the agreeing set must be a
+// majority of the windows that produced an estimate at all.
+func carrierOffsetConsensus(windows [][]complex64, rate float64) carrierConsensus {
+	var c carrierConsensus
+	var ests []float64
+	for _, w := range windows {
+		if len(w) < 1024 {
+			continue
+		}
+		c.Usable++
+		if off, ok := captureCarrierOffsetHz(w, rate); ok {
+			ests = append(ests, off)
+			if a := math.Abs(off); a > c.MaxAbsHz {
+				c.MaxAbsHz = a
+			}
+		}
+	}
+	c.Est = len(ests)
+	if c.Est == 0 {
+		return c
+	}
+	sorted := append([]float64(nil), ests...)
+	sort.Float64s(sorted)
+	median := sorted[len(sorted)/2]
+	var agreeing []float64
+	for _, e := range ests {
+		if math.Abs(e-median) <= carrierConsensusToleranceHz {
+			agreeing = append(agreeing, e)
+		}
+	}
+	c.Agree = len(agreeing)
+	if c.Usable > 1 && (c.Agree < 2 || 2*c.Agree < c.Est) {
+		return c
+	}
+	var sum float64
+	for _, e := range agreeing {
+		sum += e
+	}
+	c.OffsetHz = sum / float64(len(agreeing))
+	c.OK = true
+	return c
+}
 
 // carrierOffsetWarnHz is the |offset| above which the capture warns. Small
 // offsets are pulled in by every decoder's AFC; a multi-kHz offset (a real
@@ -120,19 +268,59 @@ func captureCarrierOffsetHz(iq []complex64, rate float64) (float64, bool) {
 }
 
 // carrierOffsetWarning returns an operator-facing warning when a recorded
-// capture's carrier sits far enough off centre to matter, or "" when it is
-// close enough (or couldn't be estimated). freqHz is the tuned RF centre, used
-// to translate the offset into an approximate ppm figure.
-func carrierOffsetWarning(iq []complex64, rate float64, freqHz uint32) string {
-	offset, ok := captureCarrierOffsetHz(iq, rate)
-	if !ok || math.Abs(offset) < carrierOffsetWarnHz {
+// capture's carrier sits far enough off centre to matter — corroborated
+// across the probe windows — or "" when it is close enough, transient, or
+// couldn't be estimated. freqHz is the tuned RF centre, used to translate the
+// offset into an approximate ppm figure.
+func carrierOffsetWarning(windows [][]complex64, rate float64, freqHz uint32) string {
+	c := carrierOffsetConsensus(windows, rate)
+	if !c.OK || math.Abs(c.OffsetHz) < carrierOffsetWarnHz {
 		return ""
 	}
-	ppm := 0.0
-	if freqHz > 0 {
-		ppm = offset / float64(freqHz) * 1e6
+	return formatCarrierOffsetWarning(c.OffsetHz, offsetPPM(c.OffsetHz, freqHz))
+}
+
+func offsetPPM(offsetHz float64, freqHz uint32) float64 {
+	if freqHz == 0 {
+		return 0
 	}
-	return formatCarrierOffsetWarning(offset, ppm)
+	return offsetHz / float64(freqHz) * 1e6
+}
+
+// carrierOffsetMeasurement renders the always-on measured-offset line for a
+// consensus estimate — the capture command doubling as a ppm-measurement
+// instrument (issue #836: kalibrate-rtl needs GSM towers, which no longer
+// exist in much of the world; any strong known-frequency carrier plus this
+// line does the same job). Returns "" when no consensus was reached; the
+// companion carrierOffsetInconclusiveNote covers the transient case.
+func carrierOffsetMeasurement(c carrierConsensus, freqHz uint32) string {
+	if !c.OK {
+		return ""
+	}
+	msg := fmt.Sprintf("capture: measured carrier offset %+.0f Hz from centre", c.OffsetHz)
+	if freqHz > 0 {
+		msg += fmt.Sprintf(" (≈%.1f ppm at %.4f MHz)", math.Abs(offsetPPM(c.OffsetHz, freqHz)), float64(freqHz)/1e6)
+	}
+	if c.Usable > 1 {
+		msg += fmt.Sprintf(", consistent across %d of %d probe windows spread over the capture", c.Agree, c.Usable)
+	}
+	msg += ". If the tuned frequency is a known-accurate carrier, this measures the tuner's ppm error for -ppm / sdr.ppm."
+	return msg
+}
+
+// carrierOffsetInconclusiveNote flags the case where the probe saw a strong
+// carrier in some window but the windows do not corroborate one another — a
+// keyed-up transient or front-end settling, not a tuner offset. The old
+// single-window probe turned exactly this into a confident wrong ppm warning
+// (#1143's "≈550.3 ppm"). Returns "" when there was consensus or nothing to
+// see.
+func carrierOffsetInconclusiveNote(c carrierConsensus) string {
+	if c.OK || c.Est == 0 || c.Usable <= 1 || c.MaxAbsHz < carrierOffsetWarnHz {
+		return ""
+	}
+	return fmt.Sprintf("capture: carrier-offset probe inconclusive — a strong off-centre signal appeared in "+
+		"%d of %d probe windows without agreeing across the capture; likely a transient/burst carrier, not a "+
+		"tuner ppm error, so no offset is reported.", c.Est, c.Usable)
 }
 
 // formatCarrierOffsetWarning renders the warning string. Split out so the

--- a/cmd/gophertrunk/capture_carrier_consensus_test.go
+++ b/cmd/gophertrunk/capture_carrier_consensus_test.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"context"
+	"io"
+	"math"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+)
+
+// synthNoise builds n IQ samples of deterministic noise with no carrier, so a
+// probe window over it must yield no offset estimate.
+func synthNoise(n int, amp float64) []complex64 {
+	iq := make([]complex64, n)
+	x := uint32(0x1234ABCD)
+	nz := func() float64 {
+		x = x*1664525 + 1013904223
+		return (float64(x>>8)/float64(1<<24) - 0.5) * amp
+	}
+	for i := 0; i < n; i++ {
+		iq[i] = complex(float32(nz()), float32(nz()))
+	}
+	return iq
+}
+
+// TestCarrierProbeSpreadsWindowsAcrossCapture pins the collection geometry:
+// the probe windows must cover the whole expected recording in order and
+// carry the exact recorded samples for their spans, whatever chunk sizes the
+// stream arrives in.
+func TestCarrierProbeSpreadsWindowsAcrossCapture(t *testing.T) {
+	const total = captureProbeWindows * captureProbeSamples * 2 // stride = 2 windows
+	p := newCarrierProbe(total)
+
+	// Feed index-encoded samples in awkward chunk sizes.
+	stream := make([]complex64, total)
+	for i := range stream {
+		stream[i] = complex(float32(i), -float32(i))
+	}
+	for off, sz := 0, 0; off < total; off += sz {
+		sz = 3000 + (off % 5000)
+		if off+sz > total {
+			sz = total - off
+		}
+		p.feed(stream[off : off+sz])
+	}
+
+	wins := p.Windows()
+	if len(wins) != captureProbeWindows {
+		t.Fatalf("got %d windows, want %d", len(wins), captureProbeWindows)
+	}
+	stride := int64(total / captureProbeWindows)
+	for i, w := range wins {
+		if len(w) != captureProbeSamples {
+			t.Fatalf("window %d has %d samples, want %d", i, len(w), captureProbeSamples)
+		}
+		start := int64(i) * stride
+		for j, s := range []int{0, captureProbeSamples - 1} {
+			want := stream[start+int64(s)]
+			if w[s] != want {
+				t.Fatalf("window %d sample %d = %v, want %v (probe %d)", i, s, w[s], want, j)
+			}
+		}
+	}
+
+	// A capture too short for multiple windows degenerates to one at the
+	// start (the pre-existing behaviour), and a truncated capture drops the
+	// windows it never reached instead of returning unusable stubs.
+	short := newCarrierProbe(captureProbeSamples)
+	short.feed(stream[:captureProbeSamples])
+	if n := len(short.Windows()); n != 1 {
+		t.Errorf("short capture: got %d windows, want 1", n)
+	}
+	cut := newCarrierProbe(total)
+	cut.feed(stream[:total/4])
+	for i, w := range cut.Windows() {
+		if len(w) < 1024 {
+			t.Errorf("truncated capture returned unusable window %d (%d samples)", i, len(w))
+		}
+	}
+}
+
+// TestCarrierOffsetConsensus pins the corroboration rules that separate a
+// real tuner ppm error (the same offset wherever the signal is up) from the
+// transient that produced #1143's false "≈550.3 ppm" capture warning (a
+// strong carrier in a single probe window).
+func TestCarrierOffsetConsensus(t *testing.T) {
+	const rate = 262144.0
+	const freq = 854_562_500
+	tone := func(off float64) []complex64 { return synthTone(captureProbeSamples, off, rate, 0.1) }
+	noise := func() []complex64 { return synthNoise(captureProbeSamples, 0.1) }
+
+	t.Run("transient in one window is rejected", func(t *testing.T) {
+		wins := [][]complex64{tone(-8700), noise(), noise(), noise(), noise(), noise(), noise(), noise()}
+		c := carrierOffsetConsensus(wins, rate)
+		if c.OK {
+			t.Fatalf("single-window transient must not reach consensus: %+v", c)
+		}
+		if c.Est != 1 || c.Usable != 8 {
+			t.Errorf("Est=%d Usable=%d, want 1/8", c.Est, c.Usable)
+		}
+		if w := carrierOffsetWarning(wins, rate, freq); w != "" {
+			t.Errorf("transient carrier must not produce a ppm warning, got: %s", w)
+		}
+		if note := carrierOffsetInconclusiveNote(c); note == "" {
+			t.Error("expected an inconclusive note for a strong single-window transient")
+		}
+	})
+
+	t.Run("intermittent but consistent carrier warns", func(t *testing.T) {
+		// A handheld keyed for part of the capture (issue #836's measurement
+		// use): three windows see the same offset, the rest are noise.
+		wins := [][]complex64{tone(-8700), noise(), tone(-8700), noise(), tone(-8700), noise(), noise(), noise()}
+		c := carrierOffsetConsensus(wins, rate)
+		if !c.OK {
+			t.Fatalf("consistent carrier across 3 windows must reach consensus: %+v", c)
+		}
+		if math.Abs(c.OffsetHz+8700) > 200 {
+			t.Errorf("consensus offset = %.0f Hz, want ≈ -8700", c.OffsetHz)
+		}
+		if w := carrierOffsetWarning(wins, rate, freq); w == "" {
+			t.Error("a corroborated 8.7 kHz offset must warn")
+		}
+		if m := carrierOffsetMeasurement(c, freq); m == "" {
+			t.Error("a consensus offset must produce the measured-offset line")
+		}
+	})
+
+	t.Run("two disagreeing carriers are rejected", func(t *testing.T) {
+		wins := [][]complex64{tone(-8700), tone(5000), noise(), noise(), noise(), noise(), noise(), noise()}
+		if c := carrierOffsetConsensus(wins, rate); c.OK {
+			t.Fatalf("disagreeing windows must not reach consensus: %+v", c)
+		}
+	})
+
+	t.Run("single-window capture keeps the old behaviour", func(t *testing.T) {
+		wins := [][]complex64{tone(-8700)}
+		c := carrierOffsetConsensus(wins, rate)
+		if !c.OK || math.Abs(c.OffsetHz+8700) > 200 {
+			t.Fatalf("short capture (one window) must still estimate: %+v", c)
+		}
+		if note := carrierOffsetInconclusiveNote(c); note != "" {
+			t.Errorf("single-window consensus must not print the inconclusive note: %s", note)
+		}
+	})
+
+	t.Run("small consistent offset measures without warning", func(t *testing.T) {
+		wins := [][]complex64{tone(-500), tone(-500), tone(-500), noise(), noise(), noise(), noise(), noise()}
+		c := carrierOffsetConsensus(wins, rate)
+		if !c.OK {
+			t.Fatalf("expected consensus: %+v", c)
+		}
+		if w := carrierOffsetWarning(wins, rate, freq); w != "" {
+			t.Errorf("500 Hz should not warn, got: %s", w)
+		}
+		if m := carrierOffsetMeasurement(c, freq); m == "" {
+			t.Error("expected a measured-offset line for the ppm-measurement use (issue #836)")
+		}
+	})
+}
+
+// TestCaptureStreamProbeIgnoresStartupTransient is the end-to-end
+// failing-first regression for the #1143 false capture warning: a strong
+// carrier present ONLY in the first ~11 ms of the stream (front-end settling,
+// or a neighbour keying up at stream start) must not be reported as a tuner
+// ppm error, while the same carrier present throughout still is. The old
+// probe collected exactly the first captureProbeSamples, so the transient
+// case warned.
+func TestCaptureStreamProbeIgnoresStartupTransient(t *testing.T) {
+	const rate = uint32(262144)
+	const freq = 854_562_500
+	const seconds = 1.0
+
+	run := func(stream []complex64) string {
+		src := make(chan []complex64)
+		go func() {
+			defer close(src)
+			for off := 0; off < len(stream); off += 4096 {
+				end := off + 4096
+				if end > len(stream) {
+					end = len(stream)
+				}
+				src <- stream[off:end]
+			}
+		}()
+		_, windows, err := captureStream(context.Background(), io.Discard, siglab.FormatF32, src, rate, seconds, nil)
+		if err != nil {
+			t.Fatalf("captureStream: %v", err)
+		}
+		return carrierOffsetWarning(windows, float64(rate), freq)
+	}
+
+	total := int(seconds * float64(rate))
+	transient := append(synthTone(captureProbeSamples, -8700, float64(rate), 0.1),
+		synthNoise(total-captureProbeSamples, 0.1)...)
+	if w := run(transient); w != "" {
+		t.Errorf("a carrier only in the first probe window must not warn, got: %s", w)
+	}
+
+	persistent := synthTone(total, -8700, float64(rate), 0.1)
+	if w := run(persistent); w == "" {
+		t.Error("a persistent 8.7 kHz offset must still warn")
+	}
+}
+
+// TestCaptureEffectiveRate pins the capture command's ActualSampleRate check:
+// a quantizing backend's real rate must flow into the recording metadata (and
+// the operator note fires only on a mismatch).
+func TestCaptureEffectiveRate(t *testing.T) {
+	const requested = 2_048_000
+	for _, c := range []struct {
+		name     string
+		dev      interface{ ActualSampleRate() (uint32, error) }
+		plain    bool
+		want     uint32
+		wantNote bool
+	}{
+		{"quantized", quantizingDevice{actual: 2_048_001}, false, 2_048_001, true},
+		{"exact", quantizingDevice{actual: requested}, false, requested, false},
+		{"error falls back", quantizingDevice{actual: 0, err: io.EOF}, false, requested, false},
+		{"no extension", nil, true, requested, false},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			var got uint32
+			var note string
+			if c.plain {
+				got, note = captureEffectiveRate(rateOnlyDevice{}, requested)
+			} else {
+				got, note = captureEffectiveRate(c.dev.(quantizingDevice), requested)
+			}
+			if got != c.want {
+				t.Errorf("rate = %d, want %d", got, c.want)
+			}
+			if (note != "") != c.wantNote {
+				t.Errorf("note = %q, wantNote %v", note, c.wantNote)
+			}
+		})
+	}
+}

--- a/cmd/gophertrunk/capture_carrier_test.go
+++ b/cmd/gophertrunk/capture_carrier_test.go
@@ -50,12 +50,12 @@ func TestCarrierOffsetWarning(t *testing.T) {
 	const freq = 467_913_000
 
 	// A small offset is pulled in by the decoder's AFC — stay silent.
-	if w := carrierOffsetWarning(synthTone(1<<15, 500, rate, 0.1), rate, freq); w != "" {
+	if w := carrierOffsetWarning([][]complex64{synthTone(1<<15, 500, rate, 0.1)}, rate, freq); w != "" {
 		t.Errorf("500 Hz offset should not warn, got: %s", w)
 	}
 
 	// A multi-kHz offset fires and names the fix.
-	w := carrierOffsetWarning(synthTone(1<<15, -8700, rate, 0.1), rate, freq)
+	w := carrierOffsetWarning([][]complex64{synthTone(1<<15, -8700, rate, 0.1)}, rate, freq)
 	if w == "" {
 		t.Fatal("an 8.7 kHz offset should warn")
 	}

--- a/internal/trunking/engine.go
+++ b/internal/trunking/engine.go
@@ -354,7 +354,7 @@ func (e *Engine) discoverTalkgroup(g Grant) *TalkGroup {
 	tg := &TalkGroup{
 		ID:     g.GroupID,
 		Tag:    discoveredTag,
-		Mode:   "D",
+		Mode:   discoveredMode(g),
 		Scan:   e.ScanMode() != ScanModeList,
 		Stream: true,
 		Record: true,
@@ -363,6 +363,26 @@ func (e *Engine) discoverTalkgroup(g Grant) *TalkGroup {
 	e.log.Info("talkgroup discovered on control channel",
 		"tg", g.GroupID, "system", g.System, "scan", tg.Scan)
 	return tg
+}
+
+// discoveredMode picks the Mode stamped on an auto-discovered talkgroup
+// (D=digital, A=analog — the Trunk Recorder / RadioReference CSV convention)
+// from the grant's protocol. The analog trunking protocols carry analog FM
+// voice and their control channels signal no per-call voice mode, so the old
+// unconditional "D" mislabeled every discovered SmartNet/SmartZone talkgroup
+// as digital (#1143). The protocol set mirrors the composer's analog-trunk
+// routing (classifyVoiceKind): EDACS is analog except ProVoice grants.
+func discoveredMode(g Grant) string {
+	switch g.Protocol {
+	case "motorola", "ltr", "mpt1327":
+		return "A"
+	case "edacs":
+		if g.ProVoice {
+			return "D"
+		}
+		return "A"
+	}
+	return "D"
 }
 
 // knownRadiosCap bounds the learned-radios set so a long-running busy site

--- a/internal/trunking/engine_discover_mode_test.go
+++ b/internal/trunking/engine_discover_mode_test.go
@@ -1,0 +1,45 @@
+package trunking
+
+import "testing"
+
+// TestDiscoveredTalkgroupModeFollowsProtocol pins the #1143 follow-up: a
+// SmartNet/SmartZone system carries analog FM voice, but every auto-discovered
+// talkgroup was stamped Mode "D" (digital) regardless of protocol, so an
+// analog SmartZone talkgroup showed as digital in the Talkgroups UI and CSV
+// export. Discovered mode must follow the grant's protocol: analog trunking
+// protocols (motorola, ltr, mpt1327, non-ProVoice edacs) are "A", digital
+// protocols stay "D", and an EDACS ProVoice grant is "D".
+func TestDiscoveredTalkgroupModeFollowsProtocol(t *testing.T) {
+	cases := []struct {
+		name  string
+		grant Grant
+		want  string
+	}{
+		{"motorola is analog", Grant{System: "msp", Protocol: "motorola", GroupID: 46256, SourceID: 700123, FrequencyHz: 857_237_500}, "A"},
+		{"ltr is analog", Grant{System: "L", Protocol: "ltr", GroupID: 42, SourceID: 7, FrequencyHz: 451_500_000}, "A"},
+		{"mpt1327 is analog", Grant{System: "M", Protocol: "mpt1327", GroupID: 101, SourceID: 8, FrequencyHz: 174_500_000}, "A"},
+		{"edacs is analog", Grant{System: "E", Protocol: "edacs", GroupID: 203, SourceID: 9, FrequencyHz: 856_500_000}, "A"},
+		{"edacs provoice is digital", Grant{System: "E", Protocol: "edacs", GroupID: 204, SourceID: 9, FrequencyHz: 856_512_500, ProVoice: true}, "D"},
+		{"p25 stays digital", Grant{System: "P", Protocol: "p25", GroupID: 305, SourceID: 10, FrequencyHz: 853_450_000}, "D"},
+		{"dmr stays digital", Grant{System: "D", Protocol: "dmr-tier3", GroupID: 406, SourceID: 11, FrequencyHz: 442_387_500, Timeslot: 1}, "D"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e, _, bus, _ := mkEngine(t, 2)
+			defer bus.Close()
+
+			e.HandleGrant(tc.grant)
+			tg := e.talkgroups.Lookup(tc.grant.GroupID)
+			if tg == nil {
+				t.Fatalf("talkgroup %d was not discovered", tc.grant.GroupID)
+			}
+			if tg.Tag != discoveredTag {
+				t.Fatalf("talkgroup %d tag = %q, want %q", tc.grant.GroupID, tg.Tag, discoveredTag)
+			}
+			if tg.Mode != tc.want {
+				t.Errorf("discovered talkgroup %d (protocol %s) Mode = %q, want %q",
+					tc.grant.GroupID, tc.grant.Protocol, tg.Mode, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Two operator-reported fixes from the daily issue review. On #1143 the reporter confirmed the SmartNet rebuild decodes on air, but noted every talkgroup shows mode "D" even when analog. On #836 the reporter can't measure their dongle's ppm because kalibrate-rtl needs GSM towers, which their region no longer has — and the tool GopherTrunk already ships for that job (`capture`'s carrier-offset probe) was untrustworthy: it FFT'd only the first ~11 ms of the stream, which is how #1143 got the bogus "≈550.3 ppm" warning.

## Changes

- **trunking**: `discoverTalkgroup` stamped `Mode: "D"` unconditionally. It now derives the mode from the grant's protocol, mirroring the composer's analog-trunk routing (`classifyVoiceKind`): `motorola`/`ltr`/`mpt1327` and non-ProVoice `edacs` → "A", digital protocols stay "D". Display/CSV metadata only; nothing gates decode on it.
- **capture**: the carrier-offset probe now collects 8 windows spread across the whole recording (`carrierProbe`) instead of the first 32768 samples, and reports an offset only when windows corroborate each other (`carrierOffsetConsensus`): a real tuner ppm error is constant for the whole file, while a settling transient or momentarily-keyed neighbour lights one window — that case now prints an explicit "inconclusive / likely transient" note instead of a confident wrong warning. A short capture degenerates to the old single-window behaviour.
- **capture**: a corroborated offset is always printed as a `measured carrier offset` line, even below the 2 kHz warning threshold — so `capture` against any strong known-frequency carrier doubles as a kalibrate-style ppm measurement (#836's ask).
- **capture**: honours the optional `ActualSampleRate()` backend extension (mirroring the daemon's `effectiveStreamRate`), so a quantizing backend's real rate lands in the recording, metadata sidecar, and ppm math.

## Test plan

- [x] `make vet test` is green locally
- [ ] `make integration` — n/a (no daemon/DSP/replay-path change; `capture`/engine only)
- [x] Added or updated tests where appropriate:
  - `TestDiscoveredTalkgroupModeFollowsProtocol` (failing-first: fails against the old hardcoded "D")
  - `TestCaptureStreamProbeIgnoresStartupTransient` (failing-first: the old first-window probe warned on a carrier present only in the first 11 ms; a persistent offset still warns)
  - `TestCarrierOffsetConsensus`, `TestCarrierProbeSpreadsWindowsAcrossCapture`, `TestCaptureEffectiveRate`
- [ ] Smoke-tested against real hardware — not possible in this environment; the #1143 reporter's on-air setup is the natural verifier (their v1.0.7 run already confirmed the decode; the mode column and capture output are directly observable on their next run)

## Breaking changes

None. New/changed `capture` output lines only (the warning wording is unchanged when it fires); `Mode` affects newly discovered talkgroups' display metadata, not decode, and operator-catalogued CSVs are untouched.

## Docs / CHANGELOG

- [x] Added `## [Unreleased]` bullets to `CHANGELOG.md`
- [ ] README/docs — n/a

## Linked issues

Refs #1143, Refs #836 (both stay open pending reporter verification, per the issue-closing policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018y51YwdjyySp87mPieAL2Y

---
_Generated by [Claude Code](https://claude.ai/code/session_018y51YwdjyySp87mPieAL2Y)_